### PR TITLE
Orders Gitlab issue notes by update date

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-api/gitlab-api.service.ts
@@ -209,7 +209,7 @@ export class GitlabApiService {
     }
     return this._sendPaginatedRequest$(
       {
-        url: `${issue.links.self}/notes`,
+        url: `${issue.links.self}/notes?sort=asc&order_by=updated_at`,
       },
       cfg,
     ).pipe(


### PR DESCRIPTION
Gitlab issue notes are now sorted by update date in ascending order.

This ensures that the last comment displays as the last note.

Fixes #5911