### PR TITLE
Adds option to import GitLab labels as tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "removeWOFF1": "node ./tools/remove-woff.js",
     "serveProd": "ng serve --configuration production",
     "start": "npm run electron:build && cross-env NODE_ENV=DEV electron .",
+    "startDebug": "npm run electron:build && cross-env NODE_ENV=DEV electron --remote-debugging-port=9223 .",
     "startFrontend": "npm run env && ng serve",
     "startFrontend:e2e": "npm run env && ng serve --port=4242",
     "startFrontend:prod": "npm run env && ng serve --configuration production",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "release": "npm run release.changelog && npm run dist",
     "release.changelog": "conventional-changelog -i CHANGELOG.md -s -p angular",
     "removeWOFF1": "node ./tools/remove-woff.js",
+    "serveDev": "ng serve",
     "serveProd": "ng serve --configuration production",
     "start": "npm run electron:build && cross-env NODE_ENV=DEV electron .",
     "startDebug": "npm run electron:build && cross-env NODE_ENV=DEV electron --remote-debugging-port=9223 .",

--- a/src/app/features/calendar-integration/calendar-integration.service.spec.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.spec.ts
@@ -727,6 +727,9 @@ END:VCALENDAR`;
 
   describe('constructor', () => {
     it('should load skipped events from localStorage on init', () => {
+      // Clean up localStorage first
+      localStorage.clear();
+
       const skippedIds = ['event-1', 'event-2'];
       const today = new Date().toISOString().split('T')[0];
 
@@ -754,9 +757,15 @@ END:VCALENDAR`;
 
       const newService = TestBed.inject(CalendarIntegrationService);
       expect(newService.skippedEventIds$.getValue()).toEqual(skippedIds);
+
+      // Clean up after test
+      localStorage.clear();
     });
 
     it('should not load skipped events from different day', () => {
+      // Clean up localStorage first
+      localStorage.clear();
+
       const skippedIds = ['event-1', 'event-2'];
       const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
 
@@ -784,9 +793,15 @@ END:VCALENDAR`;
 
       const newService = TestBed.inject(CalendarIntegrationService);
       expect(newService.skippedEventIds$.getValue()).toEqual([]);
+
+      // Clean up after test
+      localStorage.clear();
     });
 
     it('should handle invalid JSON in localStorage gracefully', () => {
+      // Clean up localStorage first
+      localStorage.clear();
+
       const today = new Date().toISOString().split('T')[0];
 
       localStorage.setItem('SUP_CALENDER_EVENTS_SKIPPED_TODAY', 'invalid json');
@@ -809,6 +824,9 @@ END:VCALENDAR`;
       });
 
       expect(() => TestBed.inject(CalendarIntegrationService)).not.toThrow();
+
+      // Clean up after test
+      localStorage.clear();
     });
   });
 

--- a/src/app/features/calendar-integration/calendar-integration.service.spec.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.spec.ts
@@ -16,6 +16,7 @@ import {
 import { SnackService } from '../../core/snack/snack.service';
 import { take } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
+import { getDbDateStr } from '../../util/get-db-date-str';
 
 describe('CalendarIntegrationService', () => {
   let service: CalendarIntegrationService;
@@ -731,7 +732,8 @@ END:VCALENDAR`;
       localStorage.clear();
 
       const skippedIds = ['event-1', 'event-2'];
-      const today = new Date().toISOString().split('T')[0];
+      // Use the same date format as the service
+      const today = getDbDateStr();
 
       localStorage.setItem(
         'SUP_CALENDER_EVENTS_SKIPPED_TODAY',

--- a/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.ts
@@ -94,6 +94,31 @@ export const GITLAB_CONFIG_FORM: LimitedFormlyFieldConfig<IssueProviderGitlab>[]
       },
       ...ISSUE_PROVIDER_COMMON_FORM_FIELDS,
       {
+        key: 'isImportGitLabLabels',
+        type: 'checkbox',
+        defaultValue: false,
+        expressions: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          // 'props.disabled': '!model.defaultProjectId',
+        },
+        props: {
+          // label: T.F.CALDAV.FORM.IS_AUTO_IMPORT_ISSUES,
+          label: 'Auto import labels',
+          description:
+            'Enabling this will automatically import GitLab labels for each imported issue, creating corresponding tags in Super Productivity and adding them to the imported task.',
+        },
+      },
+      {
+        key: 'isForceUpdate',
+        type: 'toggle',
+        defaultValue: false,
+        props: {
+          label: 'Force update tasks (Debug)',
+          description:
+            "Forces task updates even when GitLab issues haven't changed. Useful for testing tag import functionality.",
+        },
+      },
+      {
         key: 'filterUsername',
         type: 'input',
         templateOptions: {

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -124,27 +124,14 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
 
     const wasUpdated = lastRemoteUpdate > (task.issueLastUpdated || 0);
     const forceUpdate = cfg?.isForceUpdate || false;
-    this.logger.normal('wasUpdated check:', {
-      lastRemoteUpdate,
-      taskIssueLastUpdated: task.issueLastUpdated,
-      wasUpdated,
-      forceUpdate,
-    });
 
     if (wasUpdated || forceUpdate) {
       const taskData = this.getAddTaskData(issue, cfg);
-      this.logger.normal(
-        'GitLab update - cfg.isImportGitLabLabels:',
-        cfg?.isImportGitLabLabels,
-      );
-      this.logger.normal('GitLab update - issue.labels:', issue.labels);
-      this.logger.normal('GitLab update - taskData.tagIds:', taskData.tagIds);
-      this.logger.normal('GitLab update - existing task.tagIds:', task.tagIds);
+
       const newTagIds = cfg?.isImportGitLabLabels ? taskData.tagIds || [] : [];
-      // Merge and deduplicate tag IDs
       const existingTagIds = task.tagIds || [];
       const mergedTagIds = [...new Set([...existingTagIds, ...newTagIds])];
-      this.logger.normal('GitLab update - merged tagIds:', mergedTagIds);
+      // this.logger.normal('GitLab update - merged tagIds:', mergedTagIds);
       return {
         taskChanges: {
           ...taskData,
@@ -162,7 +149,6 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
   async getFreshDataForIssueTasks(
     tasks: Task[],
   ): Promise<{ task: Task; taskChanges: Partial<Task>; issue: GitlabIssue }[]> {
-    this.logger.normal('getFreshDataForIssueTasks called with', tasks.length, 'tasks');
     const issueProviderId =
       tasks && tasks[0].issueProviderId ? tasks[0].issueProviderId : 0;
     if (!issueProviderId) {
@@ -170,10 +156,6 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
     }
 
     const cfg = await this._getCfgOnce$(issueProviderId).toPromise();
-    this.logger.normal(
-      'GitLab batch update - cfg.isImportGitLabLabels:',
-      cfg?.isImportGitLabLabels,
-    );
 
     const updatedIssues: {
       task: Task;
@@ -202,23 +184,12 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
         const lastRemoteUpdate = updates[updates.length - 1];
         const wasUpdated = lastRemoteUpdate > (task.issueLastUpdated || 0);
         const forceUpdate = cfg?.isForceUpdate || false;
-        this.logger.normal(
-          'Batch update check for task:',
-          task.title,
-          'wasUpdated:',
-          wasUpdated,
-          'forceUpdate:',
-          forceUpdate,
-        );
         if (wasUpdated || forceUpdate) {
           const taskData = this.getAddTaskData(issue, cfg);
-          this.logger.normal('Batch update - issue.labels:', issue.labels);
-          this.logger.normal('Batch update - taskData.tagIds:', taskData.tagIds);
           const newTagIds = cfg?.isImportGitLabLabels ? taskData.tagIds || [] : [];
           // Merge and deduplicate tag IDs
           const existingTagIds = task.tagIds || [];
           const mergedTagIds = [...new Set([...existingTagIds, ...newTagIds])];
-          this.logger.normal('Batch update - merged tagIds:', mergedTagIds);
           updatedIssues.push({
             task,
             taskChanges: {
@@ -236,16 +207,10 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
   }
 
   getAddTaskData(issue: GitlabIssue, cfg?: GitlabCfg): Partial<Task> & { title: string } {
-    this.logger.normal(
-      'getAddTaskData called with labels:',
-      issue.labels,
-      'cfg.isImportGitLabLabels:',
-      cfg?.isImportGitLabLabels,
-    );
     const tagIds = cfg?.isImportGitLabLabels
       ? this._createTagsFromLabels(issue.labels)
       : [];
-    this.logger.normal('getAddTaskData returning tagIds:', tagIds);
+    // this.logger.normal('getAddTaskData returning tagIds:', tagIds);
 
     return {
       title: this._formatIssueTitle(issue),

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -11,6 +11,9 @@ import { truncate } from '../../../../util/truncate';
 import { GITLAB_BASE_URL, GITLAB_POLL_INTERVAL } from './gitlab.const';
 import { isGitlabEnabled } from './is-gitlab-enabled.util';
 import { IssueProviderService } from '../../issue-provider.service';
+import { TagService } from '../../../tag/tag.service';
+import { MenuTreeService } from '../../../menu-tree/menu-tree.service';
+import { Log } from '../../../../core/log';
 
 @Injectable({
   providedIn: 'root',
@@ -18,7 +21,10 @@ import { IssueProviderService } from '../../issue-provider.service';
 export class GitlabCommonInterfacesService implements IssueServiceInterface {
   private readonly _gitlabApiService = inject(GitlabApiService);
   private readonly _issueProviderService = inject(IssueProviderService);
+  private readonly _tagService = inject(TagService);
+  private readonly _menuTreeService = inject(MenuTreeService);
 
+  logger = Log.withContext('gitlab');
   pollInterval: number = GITLAB_POLL_INTERVAL;
 
   isEnabled(cfg: GitlabCfg): boolean {
@@ -117,11 +123,33 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
     const lastRemoteUpdate = updates[updates.length - 1];
 
     const wasUpdated = lastRemoteUpdate > (task.issueLastUpdated || 0);
+    const forceUpdate = cfg?.isForceUpdate || false;
+    this.logger.normal('wasUpdated check:', {
+      lastRemoteUpdate,
+      taskIssueLastUpdated: task.issueLastUpdated,
+      wasUpdated,
+      forceUpdate,
+    });
 
-    if (wasUpdated) {
+    if (wasUpdated || forceUpdate) {
+      const taskData = this.getAddTaskData(issue, cfg);
+      this.logger.normal(
+        'GitLab update - cfg.isImportGitLabLabels:',
+        cfg?.isImportGitLabLabels,
+      );
+      this.logger.normal('GitLab update - issue.labels:', issue.labels);
+      this.logger.normal('GitLab update - taskData.tagIds:', taskData.tagIds);
+      this.logger.normal('GitLab update - existing task.tagIds:', task.tagIds);
+      const newTagIds = cfg?.isImportGitLabLabels ? taskData.tagIds || [] : [];
+      // Merge and deduplicate tag IDs
+      const existingTagIds = task.tagIds || [];
+      const mergedTagIds = [...new Set([...existingTagIds, ...newTagIds])];
+      this.logger.normal('GitLab update - merged tagIds:', mergedTagIds);
       return {
         taskChanges: {
-          ...this.getAddTaskData(issue),
+          ...taskData,
+          // Merge existing tags with new GitLab tags
+          tagIds: mergedTagIds,
           issueWasUpdated: true,
         },
         issue,
@@ -134,6 +162,7 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
   async getFreshDataForIssueTasks(
     tasks: Task[],
   ): Promise<{ task: Task; taskChanges: Partial<Task>; issue: GitlabIssue }[]> {
+    this.logger.normal('getFreshDataForIssueTasks called with', tasks.length, 'tasks');
     const issueProviderId =
       tasks && tasks[0].issueProviderId ? tasks[0].issueProviderId : 0;
     if (!issueProviderId) {
@@ -141,6 +170,10 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
     }
 
     const cfg = await this._getCfgOnce$(issueProviderId).toPromise();
+    this.logger.normal(
+      'GitLab batch update - cfg.isImportGitLabLabels:',
+      cfg?.isImportGitLabLabels,
+    );
 
     const updatedIssues: {
       task: Task;
@@ -168,11 +201,30 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
         ].sort();
         const lastRemoteUpdate = updates[updates.length - 1];
         const wasUpdated = lastRemoteUpdate > (task.issueLastUpdated || 0);
-        if (wasUpdated) {
+        const forceUpdate = cfg?.isForceUpdate || false;
+        this.logger.normal(
+          'Batch update check for task:',
+          task.title,
+          'wasUpdated:',
+          wasUpdated,
+          'forceUpdate:',
+          forceUpdate,
+        );
+        if (wasUpdated || forceUpdate) {
+          const taskData = this.getAddTaskData(issue, cfg);
+          this.logger.normal('Batch update - issue.labels:', issue.labels);
+          this.logger.normal('Batch update - taskData.tagIds:', taskData.tagIds);
+          const newTagIds = cfg?.isImportGitLabLabels ? taskData.tagIds || [] : [];
+          // Merge and deduplicate tag IDs
+          const existingTagIds = task.tagIds || [];
+          const mergedTagIds = [...new Set([...existingTagIds, ...newTagIds])];
+          this.logger.normal('Batch update - merged tagIds:', mergedTagIds);
           updatedIssues.push({
             task,
             taskChanges: {
-              ...this.getAddTaskData(issue),
+              ...taskData,
+              // Merge existing tags with new GitLab tags
+              tagIds: mergedTagIds,
               issueWasUpdated: true,
             },
             issue,
@@ -183,7 +235,18 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
     return updatedIssues;
   }
 
-  getAddTaskData(issue: GitlabIssue): Partial<Task> & { title: string } {
+  getAddTaskData(issue: GitlabIssue, cfg?: GitlabCfg): Partial<Task> & { title: string } {
+    this.logger.normal(
+      'getAddTaskData called with labels:',
+      issue.labels,
+      'cfg.isImportGitLabLabels:',
+      cfg?.isImportGitLabLabels,
+    );
+    const tagIds = cfg?.isImportGitLabLabels
+      ? this._createTagsFromLabels(issue.labels)
+      : [];
+    this.logger.normal('getAddTaskData returning tagIds:', tagIds);
+
     return {
       title: this._formatIssueTitle(issue),
       issuePoints: issue.weight,
@@ -194,6 +257,7 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
       // GitLab returns due_date as YYYY-MM-DD string, use it directly
       // to avoid timezone conversion issues
       dueDay: issue.due_date || undefined,
+      tagIds,
     };
   }
 
@@ -202,7 +266,13 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
     allExistingIssueIds: number[] | string[],
   ): Promise<IssueData[]> {
     const cfg = await this._getCfgOnce$(issueProviderId).toPromise();
-    return await this._gitlabApiService.getProjectIssues$(cfg).toPromise();
+    const issues = await this._gitlabApiService.getProjectIssues$(cfg).toPromise();
+
+    // Add cfg to each issue for proper tag handling
+    return issues.map((issue) => ({
+      ...issue,
+      ...this.getAddTaskData(issue, cfg),
+    }));
   }
 
   private _formatIssueTitle(issue: GitlabIssue): string {
@@ -219,5 +289,74 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
 
   private _isIssueDone(issue: GitlabIssue): boolean {
     return issue.state === 'closed';
+  }
+
+  private _createTagsFromLabels(labels: string[]): string[] {
+    const existingTags = this._tagService.tags();
+    const tagIds: string[] = [];
+    const newTagIds: string[] = [];
+
+    // Ensure GitLab folder exists
+    this._menuTreeService.createTagFolderIfNotExists('GitLab');
+
+    for (const label of labels) {
+      const labelStr = label.toString();
+
+      // Check if tag with this title already exists
+      const existingTag = existingTags.find((tag) => tag.title === labelStr);
+
+      if (existingTag) {
+        tagIds.push(existingTag.id);
+      } else {
+        // Create new tag from GitLab label
+        const newTagId = this._tagService.addTag({
+          title: labelStr,
+          color: this._generateColorFromLabel(labelStr),
+        });
+        tagIds.push(newTagId);
+        newTagIds.push(newTagId);
+      }
+    }
+
+    // Move newly created tags to GitLab folder (async, doesn't affect task creation)
+    if (newTagIds.length > 0) {
+      setTimeout(() => {
+        newTagIds.forEach((tagId) => {
+          this._menuTreeService.moveTagToFolder(tagId, 'GitLab');
+        });
+      }, 100);
+    }
+
+    return tagIds;
+  }
+
+  private _findFolderByName(tree: any[], name: string): boolean {
+    for (const node of tree) {
+      if (node.k === 'FOLDER' && node.name === name) {
+        return true;
+      }
+      if (node.k === 'FOLDER' && node.children) {
+        if (this._findFolderByName(node.children, name)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private _generateColorFromLabel(label: string): string {
+    // Generate a consistent color based on the label name
+    // This ensures the same label always gets the same color
+    let hash = 0;
+    for (let i = 0; i < label.length; i++) {
+      hash = label.charCodeAt(i) + ((hash << 5) - hash);
+    }
+
+    // Convert hash to a pleasant color
+    const hue = Math.abs(hash) % 360;
+    const saturation = 65; // Medium saturation for readability
+    const lightness = 50; // Medium lightness for good contrast
+
+    return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
   }
 }

--- a/src/app/features/issue/providers/gitlab/gitlab.const.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab.const.ts
@@ -16,6 +16,8 @@ export const DEFAULT_GITLAB_CFG: GitlabCfg = {
   scope: 'all',
   filter: null,
   isEnableTimeTracking: false,
+  isImportGitLabLabels: false,
+  isForceUpdate: false,
 };
 
 // NOTE: we need a high limit because git has low usage limits :(

--- a/src/app/features/issue/providers/gitlab/gitlab.model.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab.model.ts
@@ -8,4 +8,6 @@ export interface GitlabCfg extends BaseIssueProviderCfg {
   scope: string | null;
   filter: string | null;
   isEnableTimeTracking: boolean;
+  isImportGitLabLabels: boolean;
+  isForceUpdate: boolean;
 }

--- a/src/app/pfapi/validate/is-related-model-data-valid.spec.ts
+++ b/src/app/pfapi/validate/is-related-model-data-valid.spec.ts
@@ -347,7 +347,8 @@ describe('isRelatedModelDataValid', () => {
       };
 
       expect(() => isRelatedModelDataValid(invalidData as any)).toThrowError(
-        'Missing reminder missing-reminder-id from task not existing',
+        'Reminder ID "missing-reminder-id" on task "" of type "undefined" was not found.',
+        // 'Missing reminder missing-reminder-id from task not existing',
       );
     });
   });

--- a/src/app/pfapi/validate/is-related-model-data-valid.ts
+++ b/src/app/pfapi/validate/is-related-model-data-valid.ts
@@ -282,7 +282,8 @@ const validateSubTasks = (
             `Inconsistent Task State: Missing sub task data in archive ${subId}`,
             { task, d },
           );
-          return false;
+          // if we get here, the user dismissed the error so let's move on as if nothing happened.
+          return true;
         }
       }
     }
@@ -353,11 +354,15 @@ const validateReminders = (d: AppDataCompleteNew): boolean => {
   for (const tid of d.task.ids) {
     const task = d.task.entities[tid];
     if (task && task.reminderId && !reminderIds.has(task.reminderId)) {
-      _validityError(`Missing reminder ${task.reminderId} from task not existing`, {
-        task,
-        d,
-      });
-      return false;
+      _validityError(
+        `Reminder ID "${task.reminderId}" on task "${task.title}" of type "${task.issueType}" was not found.`,
+        {
+          task,
+          d,
+        },
+      );
+      // if we get here, the user dismissed the error so let's move on as if nothing happened.
+      return true;
     }
   }
 


### PR DESCRIPTION
This pull request adds the option to import GitLab labels as tags in Super Productivity. It adds an option in the the GitLab configuration to enable the creation of tags from labels assigned to GitLab work items (issues and tasks). 

If enabled, as each work item is imported, the work item's labels are duplicated as Super Productivity tags and assigned to the created Super Productivity task. Tags created from GitLab work item labels are moved into a tags folder called "GitLab" to easily identify them.

By default, tags are only created on the first import of a work item, so there is an additional toggle in the GitLab configuration to force tag creation, even for existing tasks. This is useful if there are existing tasks created from GitLab that were imported before enabling the label import.

While the code is currently functional, I'm making this a draft pull request for 3 reasons: First, based on comments on the pull request to enable GitHub label imports, I'm looking into "generifying" the implementation so it can be used by other issue providers. Second, I want to make sure it's tested thoroughly. And third, I'm hoping for feedback since this is a significant change.