### PR TITLE
Fixes Gitlab created tasks being marked incorrectly as updated

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -155,19 +155,7 @@ export class GitlabCommonInterfacesService implements IssueServiceInterface {
       const issue = await this._gitlabApiService.getById$(task.issueId, cfg).toPromise();
       if (issue) {
         const issueUpdate: number = new Date(issue.updated_at).getTime();
-        const commentsByOthers =
-          cfg.filterUsername && cfg.filterUsername.length > 1
-            ? issue.comments.filter(
-                (comment) => comment.author.username !== cfg.filterUsername,
-              )
-            : issue.comments;
-
-        const updates: number[] = [
-          ...commentsByOthers.map((comment) => new Date(comment.created_at).getTime()),
-          issueUpdate,
-        ].sort();
-        const lastRemoteUpdate = updates[updates.length - 1];
-        const wasUpdated = lastRemoteUpdate > (task.issueLastUpdated || 0);
+        const wasUpdated = issueUpdate > (task.issueLastUpdated || 0);
         if (wasUpdated) {
           updatedIssues.push({
             task,


### PR DESCRIPTION
Rather than comparing the issues last update timestamp with the last comment timestamp, it now compares the issue last update timestamp with the task `issueLastUpdated` property. This avoids the latency between an update and the update being logged in the comments.

Fixes #5518