### PR TITLE
Convert selected text to checklist items

### DIFF
--- a/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
@@ -1300,6 +1300,114 @@ describe('InlineMarkdownComponent', () => {
       // Assert — new item inserted between A and B
       expect(component.modelCopy()).toBe('- [ ] A\n- [ ] \n- [ ] B');
     });
+
+    it('should convert selected text to checklist items', () => {
+      // Arrange
+      const text = 'Folge 1: 17. Dezember\nFolge 2: 24. Dezember\nFolge 3: 31. Dezember';
+      component.model = text;
+      fixture.detectChanges();
+
+      component['isShowEdit'].set(true);
+
+      const mockTextareaEl = {
+        nativeElement: {
+          value: text,
+          selectionStart: 0,
+          selectionEnd: text.length, // all text selected
+          focus: jasmine.createSpy('focus'),
+          setSelectionRange: jasmine.createSpy('setSelectionRange'),
+          style: {},
+          scrollHeight: 100,
+          offsetHeight: 100,
+        },
+      };
+      spyOn(component, 'textareaEl').and.returnValue(mockTextareaEl as any);
+      spyOn(component, 'wrapperEl').and.returnValue({
+        nativeElement: { style: {} },
+      } as any);
+
+      const mockEvent = { preventDefault: () => {}, stopPropagation: () => {} } as any;
+
+      // Act
+      component.toggleChecklistMode(mockEvent);
+
+      // Assert — selected text converted to checklist items
+      expect(component.modelCopy()).toBe(
+        '- [ ] Folge 1: 17. Dezember\n- [ ] Folge 2: 24. Dezember\n- [ ] Folge 3: 31. Dezember',
+      );
+    });
+
+    it('should convert partially selected text to checklist items', () => {
+      // Arrange
+      const text = 'Line 1\nLine 2\nLine 3\nLine 4';
+      component.model = text;
+      fixture.detectChanges();
+
+      component['isShowEdit'].set(true);
+
+      // Select "Line 2\nLine 3"
+      const selectionStart = 7; // after "Line 1\n"
+      const selectionEnd = 20; // before "\nLine 4"
+
+      const mockTextareaEl = {
+        nativeElement: {
+          value: text,
+          selectionStart,
+          selectionEnd,
+          focus: jasmine.createSpy('focus'),
+          setSelectionRange: jasmine.createSpy('setSelectionRange'),
+          style: {},
+          scrollHeight: 100,
+          offsetHeight: 100,
+        },
+      };
+      spyOn(component, 'textareaEl').and.returnValue(mockTextareaEl as any);
+      spyOn(component, 'wrapperEl').and.returnValue({
+        nativeElement: { style: {} },
+      } as any);
+
+      const mockEvent = { preventDefault: () => {}, stopPropagation: () => {} } as any;
+
+      // Act
+      component.toggleChecklistMode(mockEvent);
+
+      // Assert — only selected lines converted
+      expect(component.modelCopy()).toBe('Line 1\n- [ ] Line 2\n- [ ] Line 3\nLine 4');
+    });
+
+    it('should toggle checklist prefix when selected text already has checklist items', () => {
+      // Arrange
+      const text = '- [ ] Item 1\n- [ ] Item 2\n- [ ] Item 3';
+      component.model = text;
+      fixture.detectChanges();
+
+      component['isShowEdit'].set(true);
+
+      const mockTextareaEl = {
+        nativeElement: {
+          value: text,
+          selectionStart: 0,
+          selectionEnd: text.length,
+          focus: jasmine.createSpy('focus'),
+          setSelectionRange: jasmine.createSpy('setSelectionRange'),
+          style: {},
+          scrollHeight: 100,
+          offsetHeight: 100,
+        },
+      };
+      spyOn(component, 'textareaEl').and.returnValue(mockTextareaEl as any);
+      spyOn(component, 'wrapperEl').and.returnValue({
+        nativeElement: { style: {} },
+      } as any);
+
+      const mockEvent = { preventDefault: () => {}, stopPropagation: () => {} } as any;
+
+      // Act
+      component.toggleChecklistMode(mockEvent);
+
+      // Assert — checklist items toggled to plain bullets
+      expect(component.modelCopy()).toBe('- Item 1\n- Item 2\n- Item 3');
+    });
   });
 
   describe('model setter race condition', () => {

--- a/src/app/ui/inline-markdown/inline-markdown.component.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.ts
@@ -30,6 +30,7 @@ import { ClipboardImageService } from '../../core/clipboard-image/clipboard-imag
 import { TaskAttachmentService } from '../../features/tasks/task-attachment/task-attachment.service';
 import { ResolveClipboardImagesDirective } from '../../core/clipboard-image/resolve-clipboard-images.directive';
 import { ClipboardPasteHandlerService } from '../../core/clipboard-image/clipboard-paste-handler.service';
+import { applyTaskList } from './markdown-toolbar.util';
 
 const HIDE_OVERFLOW_TIMEOUT_DURATION = 300;
 
@@ -317,6 +318,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
 
     const textareaEl = this.textareaEl();
     let cursorPos: number | undefined;
+    let selectionEnd: number | undefined;
     let currentText: string;
 
     // Read current content from textarea if available, otherwise from modelCopy.
@@ -325,6 +327,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
     if (textareaEl) {
       currentText = textareaEl.nativeElement.value;
       cursorPos = textareaEl.nativeElement.selectionStart;
+      selectionEnd = textareaEl.nativeElement.selectionEnd;
     } else {
       currentText = this.modelCopy() || '';
     }
@@ -349,7 +352,17 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
     let cleaned: string;
     let adjustedCursorPos: number | undefined;
 
-    if (cursorPos !== undefined) {
+    // Check if there is selected text to convert to checklist items
+    if (
+      cursorPos !== undefined &&
+      selectionEnd !== undefined &&
+      cursorPos !== selectionEnd
+    ) {
+      // Convert selected text to checklist items
+      const result = applyTaskList(currentText, cursorPos, selectionEnd);
+      cleaned = result.text;
+      adjustedCursorPos = result.selectionEnd;
+    } else if (cursorPos !== undefined) {
       // Path A: Textarea visible — insert after cursor's current line
       let lineEnd = cursorPos;
       while (lineEnd < currentText.length && currentText[lineEnd] !== '\n') {


### PR DESCRIPTION
Fixes #6015

## Problem

When a user pastes text into a task's description field, selects it, and clicks "Add checklist item", the selected text was being deleted and replaced with a single empty checklist item. The expected behavior is for the selected text to be converted into multiple checklist items (one per line).

## Solution: What PR does

Modified the `toggleChecklistMode()` method in `inline-markdown.component.ts` to detect when text is selected and convert it to checklist items using the existing `applyTaskList()` utility function:

- Added import for `applyTaskList` from `markdown-toolbar.util.ts`
- Added `selectionEnd` tracking to detect text selection
- When text is selected (`selectionStart !== selectionEnd`), the selected lines are converted to checklist items with the `- [ ] ` prefix
- When no text is selected, the original behavior is preserved (insert a new empty checklist item)
- If selected text already has checklist prefixes, they are toggled off (consistent with the fullscreen editor behavior)

Added unit tests for:
- Converting all selected text to checklist items
- Converting partially selected text (only selected lines)
- Toggling checklist prefix when text already has checklist items

## Changes

- `src/app/ui/inline-markdown/inline-markdown.component.ts`: Added text selection handling to `toggleChecklistMode()`
- `src/app/ui/inline-markdown/inline-markdown.component.spec.ts`: Added 3 new tests for the text-to-checklist conversion

## Testing

Verified by running the new unit tests which cover:
1. Full text selection conversion
2. Partial text selection conversion
3. Toggle behavior for existing checklist items

```
 src/app/ui/inline-markdown/inline-markdown.component.spec.ts | 108 +++++++++++++++++++++
 src/app/ui/inline-markdown/inline-markdown.component.ts      |  15 ++-
 2 files changed, 122 insertions(+), 1 deletion(-)
```