### PR TITLE
Prevent multiple empty subtask drafts per parent task

### DIFF
--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -326,6 +326,39 @@ describe('TaskService', () => {
         }),
       );
     });
+
+    it('should delete an abandoned empty subtask draft instead of updating it', () => {
+      const emptySubTask = createMockTask('subtask-1', {
+        title: '',
+        parentId: 'parent-1',
+      });
+      store.setState({
+        tasks: {
+          ids: ['task-1', 'task-2', 'subtask-1'],
+          entities: {
+            ['task-1']: createMockTask('task-1'),
+            ['task-2']: createMockTask('task-2'),
+            ['subtask-1']: emptySubTask,
+          },
+          currentTaskId: null,
+          selectedTaskId: null,
+          taskDetailTargetPanel: null,
+          isDataLoaded: true,
+        },
+      });
+      store.refreshState();
+
+      service.update('subtask-1', { title: '   ' });
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.deleteTask({
+          task: {
+            ...emptySubTask,
+            subTasks: [],
+          },
+        }),
+      );
+    });
   });
 
   describe('updateTags', () => {
@@ -419,6 +452,70 @@ describe('TaskService', () => {
         }),
       );
       expect(id).toBeTruthy();
+    });
+
+    it('should not create another empty subtask draft for the same parent', () => {
+      const emptySubTask = createMockTask('subtask-1', {
+        title: '',
+        parentId: 'parent-1',
+      });
+      store.setState({
+        tasks: {
+          ids: ['task-1', 'task-2', 'subtask-1'],
+          entities: {
+            ['task-1']: createMockTask('task-1'),
+            ['task-2']: createMockTask('task-2'),
+            ['subtask-1']: emptySubTask,
+          },
+          currentTaskId: null,
+          selectedTaskId: null,
+          taskDetailTargetPanel: null,
+          isDataLoaded: true,
+        },
+      });
+      store.refreshState();
+
+      const id = service.addSubTaskTo('parent-1');
+
+      expect(store.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: addSubTask.type,
+        }),
+      );
+      expect(id).toBe('subtask-1');
+    });
+
+    it('should allow creating an empty subtask draft for a different parent', () => {
+      const emptySubTask = createMockTask('subtask-1', {
+        title: '',
+        parentId: 'parent-1',
+      });
+      store.setState({
+        tasks: {
+          ids: ['task-1', 'task-2', 'subtask-1'],
+          entities: {
+            ['task-1']: createMockTask('task-1'),
+            ['task-2']: createMockTask('task-2'),
+            ['subtask-1']: emptySubTask,
+          },
+          currentTaskId: null,
+          selectedTaskId: null,
+          taskDetailTargetPanel: null,
+          isDataLoaded: true,
+        },
+      });
+      store.refreshState();
+
+      const id = service.addSubTaskTo('parent-2');
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: addSubTask.type,
+          parentId: 'parent-2',
+        }),
+      );
+      expect(id).toBeTruthy();
+      expect(id).not.toBe('subtask-1');
     });
   });
 

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -468,6 +468,25 @@ export class TaskService {
   }
 
   update(id: string, changedFields: Partial<Task>): void {
+    const task = this._taskEntities()[id];
+    if (
+      task &&
+      task.parentId &&
+      typeof changedFields.title === 'string' &&
+      !task.title.trim().length &&
+      !changedFields.title.trim().length
+    ) {
+      this._store.dispatch(
+        TaskSharedActions.deleteTask({
+          task: {
+            ...task,
+            subTasks: [],
+          },
+        }),
+      );
+      return;
+    }
+
     this._store.dispatch(
       TaskSharedActions.updateTask({
         task: { id, changes: changedFields },
@@ -746,6 +765,13 @@ export class TaskService {
   }
 
   addSubTaskTo(parentId: string, additional: Partial<Task> = {}): string {
+    if (!additional.title?.trim().length) {
+      const existingDraftId = this._findEmptySubTaskDraftId(parentId);
+      if (existingDraftId) {
+        return existingDraftId;
+      }
+    }
+
     const task = this.createNewTaskWithDefaults({
       title: additional.title || '',
       additional: { dueDay: additional.dueDay || undefined, ...additional },
@@ -762,6 +788,15 @@ export class TaskService {
     this._focusNewlyCreatedTask(task.id, !task.title?.trim().length);
 
     return task.id;
+  }
+
+  private _findEmptySubTaskDraftId(parentId: string): string | null {
+    for (const task of Object.values(this._taskEntities())) {
+      if (task?.parentId === parentId && !task.title.trim().length) {
+        return task.id;
+      }
+    }
+    return null;
   }
 
   private _focusNewlyCreatedTask(taskId: string, shouldStartEditing: boolean): void {


### PR DESCRIPTION
## Summary

This fixes #6956 by preventing multiple empty subtask drafts from being created for the same parent task.

## Changes

- Prevent creating a second empty subtask draft if the same parent task already has one
- Delete an abandoned empty subtask draft instead of persisting it
- Add focused service-level tests for the new behavior

## Notes

This change is intentionally minimal and limited to the behavior described in the issue.

It does not redesign the subtask creation flow or change unrelated programmatic subtask creation paths.

Local pre-push ran into unrelated timezone test failures on my machine, but the targeted task service test for this change passed.