### PR TITLE
fix(tasks): use attachment title as task name when pasting a bare URL

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1657,6 +1657,16 @@ describe('shortSyntax', () => {
       expect(r?.taskChanges.title).toBe('my-cool-page');
     });
 
+    it('should use domain basename as task name when pasting a root URL with urlBehavior "extract"', async () => {
+      const t = {
+        ...TASK,
+        title: 'https://example.com',
+      };
+      const r = await shortSyntax(t, { ...CONFIG, urlBehavior: 'extract' });
+      expect(r).toBeDefined();
+      expect(r?.taskChanges.title).toBe('example');
+    });
+
     it('should keep URL in title and add attachment when urlBehavior is "keep-and-attach"', async () => {
       const t = {
         ...TASK,

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1645,6 +1645,18 @@ describe('shortSyntax', () => {
       expect(r?.taskChanges.title).toBe('Check for details');
     });
 
+    it('should use attachment title as task name when pasting a bare URL with urlBehavior "extract"', async () => {
+      const t = {
+        ...TASK,
+        title: 'https://example.com/my-cool-page',
+      };
+      const r = await shortSyntax(t, { ...CONFIG, urlBehavior: 'extract' });
+      expect(r).toBeDefined();
+      expect(r?.attachments.length).toBe(1);
+      expect(r?.attachments[0].path).toBe('https://example.com/my-cool-page');
+      expect(r?.taskChanges.title).toBe('my-cool-page');
+    });
+
     it('should keep URL in title and add attachment when urlBehavior is "keep-and-attach"', async () => {
       const t = {
         ...TASK,

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -556,10 +556,12 @@ const parseUrlAttachments = (
     cleanedTitle = markdownUrls.length > 0 ? titleWithoutMarkdown : task.title;
     cleanedTitle = removeUrlsFromTitle(cleanedTitle, plainUrlMatches);
 
-    // If the title is empty after extracting URLs, use the first attachment's title
-    // so pasting a bare URL results in a meaningful task name instead of a blank one
-    if (!cleanedTitle.trim() && newAttachments.length > 0 && newAttachments[0].title) {
-      cleanedTitle = newAttachments[0].title;
+    // If the title is empty after extracting URLs, use a URL basename as
+    // the task name so pasting a bare URL results in a meaningful title.
+    // Use allUrls (not newAttachments) because the pasted URL may already
+    // exist as an attachment, in which case newAttachments would be empty.
+    if (!cleanedTitle && allUrls.length > 0) {
+      cleanedTitle = _baseNameForUrl(allUrls[0]) || cleanedTitle;
     }
   }
 

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -555,6 +555,12 @@ const parseUrlAttachments = (
     // In extract mode: replace markdown links with display text, remove plain URLs
     cleanedTitle = markdownUrls.length > 0 ? titleWithoutMarkdown : task.title;
     cleanedTitle = removeUrlsFromTitle(cleanedTitle, plainUrlMatches);
+
+    // If the title is empty after extracting URLs, use the first attachment's title
+    // so pasting a bare URL results in a meaningful task name instead of a blank one
+    if (!cleanedTitle.trim() && newAttachments.length > 0 && newAttachments[0].title) {
+      cleanedTitle = newAttachments[0].title;
+    }
   }
 
   // Return undefined if nothing changed


### PR DESCRIPTION
## Summary
When pasting a bare URL (e.g. `https://github.com/super-productivity/super-productivity`) into the add-task bar with `urlBehavior: 'extract'`, the URL gets extracted into an attachment but the task title is left blank.

This fix uses the attachment's title (derived from the URL basename via `_baseNameForUrl`) as the task name when the title would otherwise be empty after URL extraction.

**Before:** Pasting `https://example.com/my-cool-page` → task title: `` (empty), attachment: `my-cool-page`
**After:** Pasting `https://example.com/my-cool-page` → task title: `my-cool-page`, attachment: `my-cool-page`

The change is a 4-line addition in `parseUrlAttachments()` inside `short-syntax.ts`.

Fixes #6444

## Test plan
- [ ] Set URL behavior to "extract" in settings
- [ ] Paste a bare URL into the add-task bar
- [ ] Verify the task is created with the URL basename as the title
- [ ] Verify the URL is still added as an attachment
- [ ] Paste a URL with surrounding text → verify only the text remains as title (existing behavior)
- [ ] Paste a markdown link `[title](url)` → verify title is used (existing behavior)