### PR TITLE
fix(tasks): defer schedule overdue warning until deadline passes

### DIFF
--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -60,6 +60,7 @@ import { KeyboardConfig } from '../../config/keyboard-config.model';
 import { DialogScheduleTaskComponent } from '../../planner/dialog-schedule-task/dialog-schedule-task.component';
 import { DialogDeadlineComponent } from '../dialog-deadline/dialog-deadline.component';
 import { isDeadlineOverdue as isDeadlineOverdueFn } from '../util/is-deadline-overdue';
+import { isScheduleOverdue } from '../util/is-schedule-overdue';
 import { TaskContextMenuComponent } from '../task-context-menu/task-context-menu.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ICAL_TYPE } from '../../issue/issue.const';
@@ -182,22 +183,10 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     () => !!(this.task().repeatCfgId && this._dateService.isToday(this.task().created)),
   );
   isOverdue = computed(() => {
-    const t = this.task();
-    const todayStr = this.globalTrackingIntervalService.todayDateStr();
-    return (
-      !t.isDone &&
-      ((t.dueWithTime &&
-        !this._dateService.isToday(t.dueWithTime) &&
-        t.dueWithTime < Date.now()) ||
-        // Note: String comparison works correctly here because dueDay is in YYYY-MM-DD format
-        // which is lexicographically sortable. This avoids timezone conversion issues that occur
-        // when creating Date objects from date strings.
-        // Guard: only compare if dueDay is a valid YYYY-MM-DD string to avoid corrupted data
-        // producing false overdue results (see #6908)
-        (t.dueDay &&
-          isDBDateStr(t.dueDay) &&
-          t.dueDay !== todayStr &&
-          t.dueDay < todayStr))
+    return isScheduleOverdue(
+      this.task(),
+      this.globalTrackingIntervalService.todayDateStr(),
+      (timestamp) => this._dateService.isToday(timestamp),
     );
   });
   isScheduledToday = computed(() => {

--- a/src/app/features/tasks/util/is-schedule-overdue.spec.ts
+++ b/src/app/features/tasks/util/is-schedule-overdue.spec.ts
@@ -1,0 +1,81 @@
+import { Task } from '../task.model';
+import { isScheduleOverdue } from './is-schedule-overdue';
+
+const createTask = (overrides: Partial<Task> = {}): Task =>
+  ({
+    id: 'task1',
+    isDone: false,
+    dueDay: undefined,
+    dueWithTime: undefined,
+    deadlineDay: undefined,
+    deadlineWithTime: undefined,
+    ...overrides,
+  }) as Task;
+
+describe('isScheduleOverdue', () => {
+  const TODAY_STR = '2026-03-15';
+  const isNeverToday = (): boolean => false;
+
+  it('should return true when dueDay is before today and there is no deadline', () => {
+    const task = createTask({ dueDay: '2026-03-14' });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(true);
+  });
+
+  it('should return false when dueDay is before today and deadlineDay is in the future', () => {
+    const task = createTask({
+      dueDay: '2026-03-14',
+      deadlineDay: '2026-03-16',
+    });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(false);
+  });
+
+  it('should return true when dueDay is before today and deadlineDay is overdue', () => {
+    const task = createTask({
+      dueDay: '2026-03-14',
+      deadlineDay: '2026-03-14',
+    });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(true);
+  });
+
+  it('should return false when dueWithTime is in the past and deadlineWithTime is in the future', () => {
+    const task = createTask({
+      dueWithTime: Date.now() - 60_000,
+      deadlineWithTime: Date.now() + 60_000,
+    });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(false);
+  });
+
+  it('should return true when dueWithTime is in the past and deadlineWithTime is overdue', () => {
+    const task = createTask({
+      dueWithTime: Date.now() - 120_000,
+      deadlineWithTime: Date.now() - 60_000,
+    });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(true);
+  });
+
+  it('should return false when dueDay equals today', () => {
+    const task = createTask({ dueDay: TODAY_STR });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(false);
+  });
+
+  it('should return false for done tasks', () => {
+    const task = createTask({ isDone: true, dueDay: '2026-03-14' });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(false);
+  });
+
+  it('should not suppress overdue when deadlineDay is malformed', () => {
+    const task = createTask({
+      dueDay: '2026-03-14',
+      deadlineDay: '-/-/2026',
+    });
+
+    expect(isScheduleOverdue(task, TODAY_STR, isNeverToday)).toBe(true);
+  });
+});

--- a/src/app/features/tasks/util/is-schedule-overdue.ts
+++ b/src/app/features/tasks/util/is-schedule-overdue.ts
@@ -1,0 +1,35 @@
+import { isDBDateStr } from '../../../util/get-db-date-str';
+import { Task } from '../task.model';
+import { isDeadlineOverdue } from './is-deadline-overdue';
+
+export const isScheduleOverdue = (
+  task: Task,
+  todayStr: string,
+  isTodayFn: (timestamp: number) => boolean,
+): boolean => {
+  if (task.isDone) {
+    return false;
+  }
+
+  const isDueWithTimeOverdue = !!(
+    task.dueWithTime &&
+    !isTodayFn(task.dueWithTime) &&
+    task.dueWithTime < Date.now()
+  );
+  const isDueDayOverdue = !!(
+    task.dueDay &&
+    isDBDateStr(task.dueDay) &&
+    task.dueDay !== todayStr &&
+    task.dueDay < todayStr
+  );
+
+  if (!isDueWithTimeOverdue && !isDueDayOverdue) {
+    return false;
+  }
+
+  const hasDeadline =
+    typeof task.deadlineWithTime === 'number' ||
+    !!(task.deadlineDay && isDBDateStr(task.deadlineDay));
+
+  return !hasDeadline || isDeadlineOverdue(task, todayStr);
+};


### PR DESCRIPTION
## Problem
Closes #7069.
Tasks planned for a previous day were visually marked as overdue even when their deadline had not passed yet. This made the schedule indicator look incorrect for tasks that were still within their actual deadline window.
## Solution
This change separates the visual overdue warning for a task's schedule from the task's deadline state.
- added a new `isScheduleOverdue` utility to decide when the schedule icon should be shown as overdue
- updated `TaskComponent` to use the new utility instead of the previous inline overdue logic
- suppressed the red schedule overdue warning when a task is planned in the past but still has a future deadline
- kept existing overdue list behavior unchanged, so tasks can still appear in Overdue based on their planned date
- added unit tests for the new schedule overdue behavior
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)
## Checklist
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)