### PR TITLE
fix(electron): recreate tray indicator before minimize to tray

### DIFF
--- a/electron/indicator.ts
+++ b/electron/indicator.ts
@@ -92,7 +92,7 @@ export const initIndicator = ({
   app: App;
   ICONS_FOLDER: string;
   forceDarkTray: boolean;
-}): Tray => {
+}): Tray | undefined => {
   indicatorConfig = {
     showApp,
     quitApp,
@@ -116,16 +116,9 @@ export const initIndicator = ({
   return ensureIndicator();
 };
 
-export const ensureIndicator = ({
-  refresh = false,
-}: { refresh?: boolean } = {}): Tray => {
+export const ensureIndicator = (): Tray | undefined => {
   if (!indicatorConfig) {
-    throw new Error('Indicator not initialized');
-  }
-
-  if (refresh && tray) {
-    tray.destroy();
-    tray = undefined;
+    return undefined;
   }
 
   if (tray) {
@@ -170,8 +163,7 @@ function initAppListeners(app: App): void {
   _isAppListenersInitialized = true;
   app.on('before-quit', () => {
     if (tray) {
-      tray.destroy();
-      tray = undefined;
+      destroyTray();
     }
   });
 }
@@ -451,6 +443,12 @@ const syncTray = (tr: Tray): void => {
   }
 };
 
+const destroyTray = (): void => {
+  tray?.destroy();
+  tray = undefined;
+  curIco = undefined;
+};
+
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function createIndicatorMessage(
   task: TaskCopy,
@@ -555,7 +553,7 @@ function getRunningIconPath(progress?: number): string {
   return DIR + `running${suf}.png`;
 }
 
-let curIco: string;
+let curIco: string | undefined;
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function setTrayIcon(tr: Tray, icoPath: string): void {

--- a/electron/indicator.ts
+++ b/electron/indicator.ts
@@ -13,7 +13,16 @@ import {
 } from './task-widget/task-widget';
 import { getWin } from './main-window';
 
-let tray: Tray;
+type IndicatorConfig = {
+  showApp: () => void;
+  quitApp: () => void;
+  app: App;
+  ICONS_FOLDER: string;
+  forceDarkTray: boolean;
+};
+
+let tray: Tray | undefined;
+let indicatorConfig: IndicatorConfig | undefined;
 let _showApp: () => void;
 let _quitApp: () => void;
 let _todayTasks: {
@@ -40,6 +49,8 @@ let _lastCurrentPomodoroSessionTime: number;
 let _lastIsFocusModeEnabled: boolean;
 let _lastCurrentFocusSessionTime: number;
 let _lastFocusModeMode: string;
+let _isAppListenersInitialized = false;
+let _isListenersInitialized = false;
 
 const IS_MAC = process.platform === 'darwin';
 const IS_LINUX = process.platform === 'linux';
@@ -82,6 +93,13 @@ export const initIndicator = ({
   ICONS_FOLDER: string;
   forceDarkTray: boolean;
 }): Tray => {
+  indicatorConfig = {
+    showApp,
+    quitApp,
+    app,
+    ICONS_FOLDER,
+    forceDarkTray,
+  };
   DIR = ICONS_FOLDER + 'indicator/';
   shouldUseDarkColors =
     forceDarkTray ||
@@ -95,40 +113,76 @@ export const initIndicator = ({
   initAppListeners(app);
   initListeners();
 
-  const suf = shouldUseDarkColors ? '-d.png' : '-l.png';
-  const trayIconPath = DIR + `stopped${suf}`;
-  if (IS_WINDOWS) {
-    try {
-      tray = new Tray(trayIconPath, getWindowsTrayGuid());
-    } catch (e) {
-      log('Tray creation with GUID failed, retrying without GUID:', e);
-      tray = new Tray(trayIconPath);
-    }
-  } else {
-    tray = new Tray(trayIconPath);
-  }
-  tray.setContextMenu(createContextMenu());
+  return ensureIndicator();
+};
 
-  tray.on('click', () => {
-    showApp();
-  });
+export const ensureIndicator = ({
+  refresh = false,
+}: { refresh?: boolean } = {}): Tray => {
+  if (!indicatorConfig) {
+    throw new Error('Indicator not initialized');
+  }
+
+  if (refresh && tray) {
+    tray.destroy();
+    tray = undefined;
+  }
+
+  if (tray) {
+    return tray;
+  }
+
+  tray = createTray();
+  syncTray(tray);
 
   return tray;
 };
 
+const createTray = (): Tray => {
+  const suf = shouldUseDarkColors ? '-d.png' : '-l.png';
+  const trayIconPath = DIR + `stopped${suf}`;
+  let nextTray: Tray;
+  if (IS_WINDOWS) {
+    try {
+      nextTray = new Tray(trayIconPath, getWindowsTrayGuid());
+    } catch (e) {
+      log('Tray creation with GUID failed, retrying without GUID:', e);
+      nextTray = new Tray(trayIconPath);
+    }
+  } else {
+    nextTray = new Tray(trayIconPath);
+  }
+  nextTray.setContextMenu(createContextMenu());
+
+  nextTray.on('click', () => {
+    indicatorConfig?.showApp();
+  });
+
+  return nextTray;
+};
+
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function initAppListeners(app: App): void {
-  if (tray) {
-    app.on('before-quit', () => {
-      if (tray) {
-        tray.destroy();
-      }
-    });
+  if (_isAppListenersInitialized) {
+    return;
   }
+
+  _isAppListenersInitialized = true;
+  app.on('before-quit', () => {
+    if (tray) {
+      tray.destroy();
+      tray = undefined;
+    }
+  });
 }
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function initListeners(): void {
+  if (_isListenersInitialized) {
+    return;
+  }
+  _isListenersInitialized = true;
+
   let isTaskWidgetEnabled = false;
   // Listen for settings updates to handle task widget enable/disable
   ipcMain.on(IPC.UPDATE_SETTINGS, (ev, settings: GlobalConfigState) => {
@@ -149,7 +203,7 @@ function initListeners(): void {
   });
 
   ipcMain.on(IPC.SET_PROGRESS_BAR, (ev: IpcMainEvent, { progress }) => {
-    if (_isRunning) {
+    if (_isRunning && tray) {
       setTrayIcon(tray, getRunningIconPath(progress));
     }
 
@@ -344,6 +398,58 @@ function initListeners(): void {
   // }
   // });
 }
+
+const syncTray = (tr: Tray): void => {
+  const menuMsg = _lastCurrentTask
+    ? createIndicatorMessage(
+        _lastCurrentTask,
+        _lastIsPomodoroEnabled || false,
+        _lastCurrentPomodoroSessionTime || 0,
+        true,
+        _lastIsFocusModeEnabled || false,
+        _lastCurrentFocusSessionTime || 0,
+        _lastFocusModeMode,
+      )
+    : _lastMsg;
+
+  tr.setContextMenu(createContextMenu(menuMsg));
+
+  const isTrayShowCurrentTask = getIsTrayShowCurrentTask();
+  const isTrayShowCurrentCountdown = getIsTrayShowCurrentCountdown();
+  const trayMsg = _lastCurrentTask
+    ? createIndicatorMessage(
+        _lastCurrentTask,
+        _lastIsPomodoroEnabled || false,
+        _lastCurrentPomodoroSessionTime || 0,
+        isTrayShowCurrentCountdown,
+        _lastIsFocusModeEnabled || false,
+        _lastCurrentFocusSessionTime || 0,
+        _lastFocusModeMode,
+      )
+    : '';
+
+  if (_lastCurrentTask?.title && isTrayShowCurrentTask) {
+    tr.setTitle(trayMsg);
+    if (!IS_MAC) {
+      tr.setToolTip(trayMsg);
+    }
+  } else {
+    tr.setTitle('');
+    if (!IS_MAC) {
+      tr.setToolTip('');
+    }
+  }
+
+  if (_lastCurrentTask?.title && !_lastIsFocusModeEnabled) {
+    const progress = _lastCurrentTask.timeEstimate
+      ? _lastCurrentTask.timeSpent / _lastCurrentTask.timeEstimate
+      : undefined;
+    setTrayIcon(tr, getRunningIconPath(progress));
+  } else {
+    const suf = shouldUseDarkColors ? '-d.png' : '-l.png';
+    setTrayIcon(tr, DIR + `stopped${suf}`);
+  }
+};
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function createIndicatorMessage(

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -458,14 +458,18 @@ const appCloseHandler = (app: App): void => {
     // NOTE: this might not work if we run a second instance of the app
     log('close, isQuiting:', getIsQuiting());
     if (!getIsQuiting()) {
-      event.preventDefault();
       if (getIsMinimizeToTray()) {
-        ensureIndicator();
-        setWasMaximizedBeforeHide(mainWin.isMaximized());
-        mainWin.hide();
-        showTaskWidget();
-        return;
+        const indicator = ensureIndicator();
+        if (indicator) {
+          event.preventDefault();
+          setWasMaximizedBeforeHide(mainWin.isMaximized());
+          mainWin.hide();
+          showTaskWidget();
+          return;
+        }
       }
+
+      event.preventDefault();
 
       if (ids.length > 0) {
         log('Actions to wait for ', ids);
@@ -499,8 +503,11 @@ const appMinimizeHandler = (app: App): void => {
     // @ts-ignore
     mainWin.on('minimize', (event: Event) => {
       if (getIsMinimizeToTray()) {
+        const indicator = ensureIndicator();
+        if (!indicator) {
+          return;
+        }
         event.preventDefault();
-        ensureIndicator();
         setWasMaximizedBeforeHide(mainWin.isMaximized());
         mainWin.hide();
         showTaskWidget();

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -23,6 +23,7 @@ import {
   hideTaskWidget,
   showTaskWidget,
 } from './task-widget/task-widget';
+import { ensureIndicator } from './indicator';
 import { getIsMinimizeToTray, getIsQuiting, setIsQuiting } from './shared-state';
 import { loadSimpleStoreAll } from './simple-store';
 import { SimpleStoreKey } from './shared-with-frontend/simple-store.const';
@@ -459,6 +460,7 @@ const appCloseHandler = (app: App): void => {
     if (!getIsQuiting()) {
       event.preventDefault();
       if (getIsMinimizeToTray()) {
+        ensureIndicator();
         setWasMaximizedBeforeHide(mainWin.isMaximized());
         mainWin.hide();
         showTaskWidget();
@@ -498,6 +500,7 @@ const appMinimizeHandler = (app: App): void => {
     mainWin.on('minimize', (event: Event) => {
       if (getIsMinimizeToTray()) {
         event.preventDefault();
+        ensureIndicator();
         setWasMaximizedBeforeHide(mainWin.isMaximized());
         mainWin.hide();
         showTaskWidget();


### PR DESCRIPTION
Closes #7070
On Windows, minimizing Super Productivity to tray can leave users without a visible tray icon. The app already creates the tray indicator on startup, but if the tray instance is missing or becomes invalid later, minimizing to tray hides the main window without ensuring that the indicator still exists.
## Solution
This change makes tray initialization reusable and restores the tray state before the window is hidden to tray.
- add `ensureIndicator()` to make tray creation idempotent
- reuse the saved tray config instead of reinitializing listeners multiple times
- restore tray menu, title/tooltip, and icon when the tray is recreated
- call `ensureIndicator()` before `hide()` in the minimize-to-tray close/minimize handlers
This makes the Windows tray behavior more robust and avoids ending up with a hidden window and no tray entry.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)
## Checklist
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)