### PR TITLE
feat(tasks): add subtask progress bar

### DIFF
--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -278,6 +278,11 @@
       ></progress-bar>
     }
     @if (t.subTasks?.length) {
+      <progress-bar
+        [cssClass]="subTaskProgressCssClass()"
+        [isAlwaysVisible]="true"
+        [progress]="subTaskProgress()"
+      ></progress-bar>
       <div class="sub-tasks">
         <button
           (click)="toggleSubTaskMode()"

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -104,6 +104,7 @@ import { millisecondsDiffToRemindOption } from '../util/remind-option-to-millise
 import { MenuTreeService } from '../../menu-tree/menu-tree.service';
 import { SelectOptionRowComponent } from '../../../ui/select-option-row/select-option-row.component';
 import { SnackService } from '../../../core/snack/snack.service';
+import { calcSubTaskProgress } from '../util/calc-sub-task-progress';
 
 @Component({
   selector: 'task',
@@ -272,6 +273,16 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   // Checklist progress derived from markdown checklist in task notes (null = no checklist)
   checklistProgress = computed<ChecklistProgress | null>(() =>
     getChecklistProgress(this.task().notes),
+  );
+
+  subTaskProgress = computed<number>(() => {
+    return calcSubTaskProgress(this.task().subTasks);
+  });
+
+  subTaskProgressCssClass = computed<string>(() =>
+    this.isCurrent() && this.progress() > 1
+      ? 'bg-success sub-task-progress isStackedBelowProgress'
+      : 'bg-success sub-task-progress',
   );
 
   isShowRemoveFromToday = computed(() => {

--- a/src/app/features/tasks/util/calc-sub-task-progress.spec.ts
+++ b/src/app/features/tasks/util/calc-sub-task-progress.spec.ts
@@ -1,0 +1,30 @@
+import { Task } from '../task.model';
+
+import { calcSubTaskProgress } from './calc-sub-task-progress';
+
+describe('calcSubTaskProgress', () => {
+  const createSubTask = (isDone: boolean): Task => ({ isDone }) as Task;
+
+  it('should return zero for no subtasks', () => {
+    expect(calcSubTaskProgress([])).toBe(0);
+  });
+
+  it('should return zero when no subtasks are done', () => {
+    expect(calcSubTaskProgress([createSubTask(false), createSubTask(false)])).toBe(0);
+  });
+
+  it('should return partial completion percentage', () => {
+    expect(
+      calcSubTaskProgress([
+        createSubTask(true),
+        createSubTask(false),
+        createSubTask(false),
+        createSubTask(true),
+      ]),
+    ).toBe(50);
+  });
+
+  it('should return one hundred when all subtasks are done', () => {
+    expect(calcSubTaskProgress([createSubTask(true), createSubTask(true)])).toBe(100);
+  });
+});

--- a/src/app/features/tasks/util/calc-sub-task-progress.ts
+++ b/src/app/features/tasks/util/calc-sub-task-progress.ts
@@ -1,0 +1,10 @@
+import { Task } from '../task.model';
+
+export const calcSubTaskProgress = (subTasks: readonly Task[]): number => {
+  if (subTasks.length === 0) {
+    return 0;
+  }
+
+  const doneSubTasksCount = subTasks.filter((subTask) => subTask.isDone).length;
+  return (doneSubTasksCount / subTasks.length) * 100;
+};

--- a/src/app/ui/progress-bar/progress-bar.component.scss
+++ b/src/app/ui/progress-bar/progress-bar.component.scss
@@ -21,6 +21,32 @@
     border-radius: var(--card-border-radius);
   }
 
+  &.isAlwaysVisible {
+    &:after {
+      background: var(--separator-color);
+      width: auto;
+    }
+
+    &:before {
+      content: '';
+      background: inherit;
+      position: absolute;
+      width: var(--progress-bar-value, 0%);
+      height: 3px;
+      top: -5px;
+      left: 2px;
+      max-width: calc(100% - 4px);
+      border-radius: var(--card-border-radius);
+    }
+  }
+
+  &.isStackedBelowProgress {
+    &:before,
+    &:after {
+      top: 0;
+    }
+  }
+
   //margin-bottom: -2px;
 
   ////  background-color: #999999;

--- a/src/app/ui/progress-bar/progress-bar.component.spec.ts
+++ b/src/app/ui/progress-bar/progress-bar.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProgressBarComponent } from './progress-bar.component';
+
+describe('ProgressBarComponent', () => {
+  let fixture: ComponentFixture<ProgressBarComponent>;
+  let component: ProgressBarComponent;
+  let hostEl: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProgressBarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProgressBarComponent);
+    component = fixture.componentInstance;
+    hostEl = fixture.nativeElement;
+  });
+
+  it('should hide progress at or below one percent by default', () => {
+    component.progress = 1;
+
+    expect(hostEl.style.visibility).toBe('hidden');
+  });
+
+  it('should show and clamp regular progress above one hundred percent', () => {
+    component.progress = 150;
+
+    expect(hostEl.style.visibility).toBe('visible');
+    expect(hostEl.style.width).toBe('100%');
+  });
+
+  it('should keep the host visible and full-width for always-visible zero progress', () => {
+    component.isAlwaysVisible = true;
+    component.progress = 0;
+
+    expect(hostEl.style.visibility).toBe('visible');
+    expect(hostEl.style.width).toBe('100%');
+    expect(hostEl.style.getPropertyValue('--progress-bar-value')).toBe('0%');
+  });
+
+  it('should store clamped progress in the css variable for always-visible mode', () => {
+    component.isAlwaysVisible = true;
+    component.progress = 150;
+
+    expect(hostEl.style.visibility).toBe('visible');
+    expect(hostEl.style.width).toBe('100%');
+    expect(hostEl.style.getPropertyValue('--progress-bar-value')).toBe('100%');
+  });
+});

--- a/src/app/ui/progress-bar/progress-bar.component.ts
+++ b/src/app/ui/progress-bar/progress-bar.component.ts
@@ -1,4 +1,5 @@
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
@@ -16,27 +17,46 @@ import {
 })
 export class ProgressBarComponent {
   private _elRef = inject(ElementRef);
+  private _progress: number = 0;
+  private _isAlwaysVisible: boolean = false;
 
   // TODO: Skipped for migration because:
   //  This input is used in combination with `@HostBinding` and migrating would
   //  break.
   @HostBinding('class') @Input() cssClass: string = 'bg-primary';
 
+  @HostBinding('class.isAlwaysVisible') get isAlwaysVisibleClass(): boolean {
+    return this._isAlwaysVisible;
+  }
+
+  @Input({ transform: booleanAttribute }) set isAlwaysVisible(value: boolean) {
+    this._isAlwaysVisible = value;
+    this._updateProgress();
+  }
+
   // TODO: Skipped for migration because:
   //  Accessor inputs cannot be migrated as they are too complex.
   @Input() set progress(_value: number) {
-    let val;
-    if (_value > 100) {
-      val = 100;
-    } else {
-      val = _value;
-    }
+    this._progress = _value;
+    this._updateProgress();
+  }
 
+  private _updateProgress(): void {
+    const val = Number.isFinite(this._progress)
+      ? Math.min(Math.max(this._progress, 0), 100)
+      : 0;
+    const style = this._elRef.nativeElement.style;
+    if (this._isAlwaysVisible) {
+      style.visibility = 'visible';
+      style.width = '100%';
+      style.setProperty('--progress-bar-value', `${val}%`);
+      return;
+    }
     if (val > 1) {
-      this._elRef.nativeElement.style.visibility = 'visible';
-      this._elRef.nativeElement.style.width = `${val}%`;
+      style.visibility = 'visible';
+      style.width = `${val}%`;
     } else {
-      this._elRef.nativeElement.style.visibility = 'hidden';
+      style.visibility = 'hidden';
     }
   }
 }


### PR DESCRIPTION
## Problem
Closes #7057.
Parent tasks with many subtasks do not provide an at-a-glance indication of completion progress. Users currently need to manually count completed vs incomplete subtasks to understand how far a task has progressed.
## Solution
This change adds a subtask completion progress bar to parent task rows in the main task list.
- computes progress from completed subtasks vs total subtasks
- renders a thin progress bar for tasks that have subtasks
- keeps the bar visible even when subtasks are hidden/collapsed, so progress remains visible at all times
- uses the existing `progress-bar` component and existing success styling to keep the implementation small and consistent
- adds a small style adjustment so the subtask progress bar can coexist with the current-task time progress bar without overlapping visually
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)
## Checklist
- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)