### PR TITLE
POC for Android widgets (for architectural review)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -149,5 +149,24 @@
       </intent-filter>
     </receiver>
 
+    <receiver
+      android:name=".widget.TaskListWidgetProvider"
+      android:exported="true"
+      android:label="@string/widget_title">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+        <action android:name="com.superproductivity.superproductivity.WIDGET_MARK_DONE" />
+        <action android:name="com.superproductivity.superproductivity.WIDGET_OPEN_APP" />
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/appwidget_info" />
+    </receiver>
+
+    <service
+      android:name=".widget.TaskListWidgetService"
+      android:exported="false"
+      android:permission="android.permission.BIND_REMOTEVIEWS" />
+
   </application>
 </manifest>

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -29,6 +29,7 @@ import com.superproductivity.superproductivity.webview.WebViewBlockActivity
 import com.superproductivity.superproductivity.webview.WebViewCompatibilityChecker
 import com.superproductivity.superproductivity.widget.ShareIntentQueue
 import com.superproductivity.superproductivity.widget.StartupOverlayManager
+import com.superproductivity.superproductivity.widget.TaskListWidgetProvider
 import com.superproductivity.plugins.webdavhttp.WebDavHttpPlugin
 import org.json.JSONObject
 
@@ -52,6 +53,17 @@ class CapacitorMainActivity : BridgeActivity() {
                 val isBreak = intent.getBooleanExtra(FocusModeForegroundService.EXTRA_IS_BREAK, false)
                 Log.d("SP_FOCUS", "Timer complete broadcast received, isBreak=$isBreak")
                 callJSInterfaceFunctionIfExists("next", "onFocusModeTimerComplete$", isBreak.toString())
+            }
+        }
+    }
+
+    private val widgetDoneReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == TaskListWidgetProvider.ACTION_WIDGET_DONE_LOCAL) {
+                val taskId = intent.getStringExtra(TaskListWidgetProvider.EXTRA_TASK_ID) ?: return
+                val sanitizedId = taskId.replace(Regex("[^a-zA-Z0-9_-]"), "")
+                Log.d("SP_WIDGET", "Widget done broadcast received: taskId=$sanitizedId")
+                callJSInterfaceFunctionIfExists("next", "onWidgetDone$", "'$sanitizedId'")
             }
         }
     }
@@ -169,6 +181,12 @@ class CapacitorMainActivity : BridgeActivity() {
         LocalBroadcastManager.getInstance(this).registerReceiver(
             timerCompleteReceiver,
             IntentFilter(FocusModeForegroundService.ACTION_TIMER_COMPLETE)
+        )
+
+        // Register broadcast receiver for widget done actions
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+            widgetDoneReceiver,
+            IntentFilter(TaskListWidgetProvider.ACTION_WIDGET_DONE_LOCAL)
         )
 
         // Show startup overlay for quick task entry while Angular loads.
@@ -354,6 +372,7 @@ class CapacitorMainActivity : BridgeActivity() {
         startupOverlayManager = null
         super.onDestroy()
         LocalBroadcastManager.getInstance(this).unregisterReceiver(timerCompleteReceiver)
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(widgetDoneReceiver)
     }
 
     companion object {

--- a/android/app/src/main/java/com/superproductivity/superproductivity/app/KeyValStore.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/app/KeyValStore.kt
@@ -45,7 +45,6 @@ class KeyValStore(private val context: Context) :
             values.put(KEY_CREATED_AT, "time('now')")
             row = db.replace(DATABASE_TABLE, null, values)
             Log.v(TAG, "save db value size: " + value?.length)
-            db.close()
         }
         return row
     }
@@ -64,14 +63,12 @@ class KeyValStore(private val context: Context) :
         dbHelper.readableDatabase?.let { database ->
             database.query(
                 DATABASE_TABLE, arrayOf(VALUE), "$KEY=?", arrayOf(newKey), null, null, null
-            )?.let { cursor ->
+            )?.use { cursor ->
                 if (cursor.moveToNext()) {
                     value = cursor.getString(cursor.getColumnIndexOrThrow(VALUE))
                 }
                 Log.v(TAG, "get db value size:" + value.length)
-                cursor.close()
             }
-            database.close()
         }
         return value
     }
@@ -82,7 +79,6 @@ class KeyValStore(private val context: Context) :
         if (db != null) {
             db.delete(DATABASE_TABLE, null, null)
             Log.v(TAG, "cleared db ")
-            db.close()
         }
     }
 

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
@@ -22,6 +22,8 @@ import com.superproductivity.superproductivity.widget.ReminderDoneQueue
 import com.superproductivity.superproductivity.widget.ReminderSnoozeQueue
 import com.superproductivity.superproductivity.widget.ReminderTapQueue
 import com.superproductivity.superproductivity.widget.ShareIntentQueue
+import com.superproductivity.superproductivity.widget.TaskListWidgetProvider
+import com.superproductivity.superproductivity.widget.WidgetDoneQueue
 import com.superproductivity.superproductivity.widget.WidgetTaskQueue
 
 
@@ -237,6 +239,18 @@ class JavaScriptInterface(
     @JavascriptInterface
     fun getWidgetTaskQueue(): String? {
         return WidgetTaskQueue.getAndClearQueue(activity)
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun getWidgetDoneQueue(): String? {
+        return WidgetDoneQueue.getAndClear(activity)
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun updateWidget() {
+        TaskListWidgetProvider.notifyDataChanged(activity)
     }
 
     /**

--- a/android/app/src/main/java/com/superproductivity/superproductivity/widget/TaskListWidgetProvider.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/widget/TaskListWidgetProvider.kt
@@ -1,0 +1,136 @@
+package com.superproductivity.superproductivity.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import android.widget.RemoteViews
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.superproductivity.superproductivity.App
+import com.superproductivity.superproductivity.CapacitorMainActivity
+import com.superproductivity.superproductivity.R
+import org.json.JSONObject
+
+class TaskListWidgetProvider : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            updateWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+
+        when (intent.action) {
+            ACTION_MARK_DONE -> {
+                val taskId = intent.getStringExtra(EXTRA_TASK_ID) ?: return
+                Log.d(TAG, "Mark done from widget: taskId=$taskId")
+
+                WidgetDoneQueue.addTaskId(context, taskId)
+                markDoneInWidgetData(context, taskId)
+
+                // Refresh widget to show updated state
+                val appWidgetManager = AppWidgetManager.getInstance(context)
+                val widgetIds = appWidgetManager.getAppWidgetIds(
+                    ComponentName(context, TaskListWidgetProvider::class.java)
+                )
+                appWidgetManager.notifyAppWidgetViewDataChanged(widgetIds, R.id.widget_task_list)
+
+                // Notify app if alive via LocalBroadcast
+                val localIntent = Intent(ACTION_WIDGET_DONE_LOCAL).apply {
+                    putExtra(EXTRA_TASK_ID, taskId)
+                }
+                LocalBroadcastManager.getInstance(context).sendBroadcast(localIntent)
+            }
+            ACTION_OPEN_APP -> {
+                val openIntent = Intent(context, CapacitorMainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                }
+                context.startActivity(openIntent)
+            }
+        }
+    }
+
+    private fun markDoneInWidgetData(context: Context, taskId: String) {
+        try {
+            val store = (context.applicationContext as App).keyValStore
+            val json = store.get("widget_data", "{}")
+            val root = JSONObject(json)
+            val tasks = root.optJSONArray("tasks") ?: return
+            for (i in 0 until tasks.length()) {
+                val task = tasks.getJSONObject(i)
+                if (task.getString("id") == taskId) {
+                    task.put("isDone", true)
+                    break
+                }
+            }
+            store.set("widget_data", root.toString())
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update widget_data for done task", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "TaskListWidget"
+        const val ACTION_MARK_DONE = "com.superproductivity.superproductivity.WIDGET_MARK_DONE"
+        const val ACTION_OPEN_APP = "com.superproductivity.superproductivity.WIDGET_OPEN_APP"
+        const val ACTION_WIDGET_DONE_LOCAL = "com.superproductivity.superproductivity.WIDGET_DONE_LOCAL"
+        const val EXTRA_TASK_ID = "WIDGET_TASK_ID"
+        const val EXTRA_OPEN_APP = "WIDGET_OPEN_APP"
+
+        fun notifyDataChanged(context: Context) {
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val widgetIds = appWidgetManager.getAppWidgetIds(
+                ComponentName(context, TaskListWidgetProvider::class.java)
+            )
+            appWidgetManager.notifyAppWidgetViewDataChanged(widgetIds, R.id.widget_task_list)
+        }
+
+        private fun updateWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val views = RemoteViews(context.packageName, R.layout.widget_task_list)
+
+            // Set up the RemoteViews adapter for the ListView
+            val serviceIntent = Intent(context, TaskListWidgetService::class.java).apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
+            }
+            views.setRemoteAdapter(R.id.widget_task_list, serviceIntent)
+            views.setEmptyView(R.id.widget_task_list, R.id.widget_empty)
+
+            // PendingIntent template for done checkbox clicks
+            val doneIntent = Intent(context, TaskListWidgetProvider::class.java).apply {
+                action = ACTION_MARK_DONE
+            }
+            val donePendingIntent = PendingIntent.getBroadcast(
+                context, 0, doneIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            )
+            views.setPendingIntentTemplate(R.id.widget_task_list, donePendingIntent)
+
+            // Header tap → open app
+            val openAppIntent = Intent(context, CapacitorMainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+            val openAppPendingIntent = PendingIntent.getActivity(
+                context, 0, openAppIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            views.setOnClickPendingIntent(R.id.widget_header, openAppPendingIntent)
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/widget/TaskListWidgetService.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/widget/TaskListWidgetService.kt
@@ -1,0 +1,119 @@
+package com.superproductivity.superproductivity.widget
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.util.Log
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import com.superproductivity.superproductivity.App
+import com.superproductivity.superproductivity.R
+import org.json.JSONObject
+
+class TaskListWidgetService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+        return TaskListRemoteViewsFactory(applicationContext)
+    }
+}
+
+private data class WidgetTask(
+    val id: String,
+    val title: String,
+    val isDone: Boolean,
+    val projectId: String?,
+    val projectColor: String?
+)
+
+private class TaskListRemoteViewsFactory(
+    private val context: Context
+) : RemoteViewsService.RemoteViewsFactory {
+
+    private var tasks: List<WidgetTask> = emptyList()
+
+    override fun onCreate() {}
+
+    override fun onDataSetChanged() {
+        try {
+            val json = (context.applicationContext as App).keyValStore.get("widget_data", "{}")
+            val root = JSONObject(json)
+            val tasksArray = root.optJSONArray("tasks") ?: return
+            val projects = root.optJSONObject("projects")
+
+            val loaded = mutableListOf<WidgetTask>()
+            val limit = minOf(tasksArray.length(), 20)
+            for (i in 0 until limit) {
+                val task = tasksArray.getJSONObject(i)
+                val projectId = task.optString("projectId", null)
+                val projectColor = if (projectId != null && projects != null) {
+                    projects.optJSONObject(projectId)?.optString("color", null)
+                } else null
+
+                loaded.add(
+                    WidgetTask(
+                        id = task.getString("id"),
+                        title = task.getString("title"),
+                        isDone = task.optBoolean("isDone", false),
+                        projectId = projectId,
+                        projectColor = projectColor
+                    )
+                )
+            }
+            tasks = loaded
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse widget data", e)
+            tasks = emptyList()
+        }
+    }
+
+    override fun onDestroy() {
+        tasks = emptyList()
+    }
+
+    override fun getCount(): Int = tasks.size
+
+    override fun getViewAt(position: Int): RemoteViews {
+        val rv = RemoteViews(context.packageName, R.layout.widget_task_row)
+
+        if (position >= tasks.size) {
+            return rv
+        }
+
+        val task = tasks[position]
+        rv.setTextViewText(R.id.widget_task_title, task.title)
+
+        if (task.isDone) {
+            rv.setImageViewResource(R.id.widget_done_checkbox, android.R.drawable.checkbox_on_background)
+        } else {
+            rv.setImageViewResource(R.id.widget_done_checkbox, android.R.drawable.checkbox_off_background)
+        }
+
+        val color = try {
+            if (task.projectColor != null) Color.parseColor(task.projectColor) else DEFAULT_DOT_COLOR
+        } catch (e: Exception) {
+            DEFAULT_DOT_COLOR
+        }
+        rv.setInt(R.id.widget_project_dot, "setBackgroundColor", color)
+
+        val fillInIntent = Intent().apply {
+            putExtra(TaskListWidgetProvider.EXTRA_TASK_ID, task.id)
+        }
+        rv.setOnClickFillInIntent(R.id.widget_done_checkbox, fillInIntent)
+
+        val openIntent = Intent().apply {
+            putExtra(TaskListWidgetProvider.EXTRA_OPEN_APP, true)
+        }
+        rv.setOnClickFillInIntent(R.id.widget_task_title, openIntent)
+
+        return rv
+    }
+
+    override fun getLoadingView(): RemoteViews? = null
+    override fun getViewTypeCount(): Int = 1
+    override fun getItemId(position: Int): Long = position.toLong()
+    override fun hasStableIds(): Boolean = false
+
+    companion object {
+        private const val TAG = "TaskListWidget"
+        private const val DEFAULT_DOT_COLOR = 0xFF2196F3.toInt()
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/widget/WidgetDoneQueue.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/widget/WidgetDoneQueue.kt
@@ -1,0 +1,37 @@
+package com.superproductivity.superproductivity.widget
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.json.JSONArray
+
+/**
+ * SharedPreferences-backed queue for persisting "Done" task IDs from widget checkbox actions.
+ * Accumulates task IDs (multiple done presses before app opens) as a JSON array.
+ */
+object WidgetDoneQueue {
+    private const val PREFS_NAME = "SuperProductivityWidgetDone"
+    private const val KEY_DONE_TASKS = "WIDGET_DONE_TASK_IDS"
+
+    private fun getPrefs(context: Context): SharedPreferences {
+        return context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    @Synchronized
+    fun addTaskId(context: Context, taskId: String) {
+        val prefs = getPrefs(context)
+        val existing = prefs.getString(KEY_DONE_TASKS, null)
+        val array = if (existing != null) JSONArray(existing) else JSONArray()
+        array.put(taskId)
+        prefs.edit().putString(KEY_DONE_TASKS, array.toString()).commit()
+    }
+
+    @Synchronized
+    fun getAndClear(context: Context): String? {
+        val prefs = getPrefs(context)
+        val data = prefs.getString(KEY_DONE_TASKS, null)
+        if (data != null) {
+            prefs.edit().remove(KEY_DONE_TASKS).commit()
+        }
+        return data
+    }
+}

--- a/android/app/src/main/res/layout/widget_task_list.xml
+++ b/android/app/src/main/res/layout/widget_task_list.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#DD1E1E2E"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/widget_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/widget_title"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="8dp" />
+
+    <ListView
+        android:id="@+id/widget_task_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:divider="@null"
+        android:dividerHeight="0dp"
+        android:scrollbars="vertical" />
+
+    <TextView
+        android:id="@+id/widget_empty"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/widget_empty"
+        android:textColor="#80FFFFFF"
+        android:textSize="14sp"
+        android:gravity="center"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_task_row.xml
+++ b/android/app/src/main/res/layout/widget_task_row.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingStart="4dp"
+    android:paddingEnd="8dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp"
+    android:minHeight="40dp">
+
+    <ImageView
+        android:id="@+id/widget_project_dot"
+        android:layout_width="6dp"
+        android:layout_height="6dp"
+        android:layout_marginEnd="8dp"
+        android:background="#2196F3"
+        android:contentDescription="" />
+
+    <ImageView
+        android:id="@+id/widget_done_checkbox"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginEnd="8dp"
+        android:src="@android:drawable/checkbox_off_background"
+        android:scaleType="fitCenter"
+        android:contentDescription="@string/widget_task_done" />
+
+    <TextView
+        android:id="@+id/widget_task_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textColor="#FFFFFF"
+        android:textSize="14sp"
+        android:maxLines="2"
+        android:ellipsize="end" />
+
+</LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,6 +11,12 @@
   <!-- Share intent -->
   <string name="share_received">Content received, creating task\u2026</string>
 
+  <!-- Widget -->
+  <string name="widget_title">Today\'s Tasks</string>
+  <string name="widget_description">Shows today\'s tasks with quick done action</string>
+  <string name="widget_empty">No tasks for today</string>
+  <string name="widget_task_done">Mark task done</string>
+
   <!-- Startup overlay -->
   <string name="startup_overlay_add_task">Add task</string>
   <string name="startup_overlay_hint">Add a task while loading\u2026</string>

--- a/android/app/src/main/res/xml/appwidget_info.xml
+++ b/android/app/src/main/res/xml/appwidget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_task_list"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_description" />

--- a/src/app/features/android/android-interface.ts
+++ b/src/app/features/android/android-interface.ts
@@ -85,6 +85,12 @@ export interface AndroidInterface {
   // Widget task queue - get queued tasks from home screen widget
   getWidgetTaskQueue?(): string | null;
 
+  // Widget done queue - get task IDs marked done from widget
+  getWidgetDoneQueue?(): string | null;
+
+  // Widget update - trigger native widget refresh
+  updateWidget?(): void;
+
   // Startup overlay
   getStartupOverlayPartialText?(): string | null;
   hideStartupOverlay?(): void;
@@ -121,6 +127,9 @@ export interface AndroidInterface {
   onReminderSnooze$: ReplaySubject<{ taskId: string; newRemindAt: number }>; // emits snooze events
   getReminderSnoozeQueue?(): string | null;
 
+  // Widget done action callbacks
+  onWidgetDone$: ReplaySubject<string>; // emits taskId
+
   // Background sync credential bridge (for WorkManager-based reminder cancellation)
   setSuperSyncCredentials?(baseUrl: string, accessToken: string): void;
   clearSuperSyncCredentials?(): void;
@@ -149,6 +158,7 @@ if (IS_ANDROID_WEB_VIEW) {
   androidInterface.onReminderTap$ = new ReplaySubject(5);
   androidInterface.onReminderDone$ = new ReplaySubject(20);
   androidInterface.onReminderSnooze$ = new ReplaySubject(20);
+  androidInterface.onWidgetDone$ = new ReplaySubject(20);
   androidInterface.onShareWithAttachment$ = new ReplaySubject(1);
   androidInterface.isKeyboardShown$ = new BehaviorSubject(false);
 
@@ -262,6 +272,20 @@ if (IS_ANDROID_WEB_VIEW) {
     }
   } catch (e) {
     DroidLog.err('Failed to parse reminder snooze queue', e);
+  }
+
+  // Pull-based: retrieve queued "Done" task IDs from widget actions
+  try {
+    const widgetDoneQueue = androidInterface.getWidgetDoneQueue?.();
+    if (widgetDoneQueue) {
+      const taskIds: string[] = JSON.parse(widgetDoneQueue);
+      DroidLog.log('Pulled widget done queue from SharedPreferences', taskIds);
+      for (const id of taskIds) {
+        androidInterface.onWidgetDone$.next(id);
+      }
+    }
+  } catch (e) {
+    DroidLog.err('Failed to parse widget done queue', e);
   }
 
   // Push-based: sets isFrontendReady=true on native side for warm-start shares

--- a/src/app/features/android/store/android-widget.effects.ts
+++ b/src/app/features/android/store/android-widget.effects.ts
@@ -1,0 +1,102 @@
+import { inject, Injectable } from '@angular/core';
+import { createEffect } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { combineLatest } from 'rxjs';
+import { debounceTime, distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
+import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
+import { androidInterface } from '../android-interface';
+import { WidgetDataService } from '../widget-data.service';
+import { TaskService } from '../../tasks/task.service';
+import { SnackService } from '../../../core/snack/snack.service';
+import { DroidLog } from '../../../core/log';
+import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
+import { selectTodayTaskIds } from '../../work-context/store/work-context.selectors';
+import { selectTaskEntities } from '../../tasks/store/task.selectors';
+import { selectAllProjectColorsAndTitles } from '../../project/store/project.selectors';
+
+@Injectable()
+export class AndroidWidgetEffects {
+  private _store = inject(Store);
+  private _widgetDataService = inject(WidgetDataService);
+  private _taskService = inject(TaskService);
+  private _snackService = inject(SnackService);
+  private _hydrationState = inject(HydrationStateService);
+
+  pushOnStateChange$ =
+    IS_ANDROID_WEB_VIEW &&
+    createEffect(
+      () =>
+        combineLatest([
+          this._store.select(selectTodayTaskIds),
+          this._store.select(selectTaskEntities),
+          this._store.select(selectAllProjectColorsAndTitles),
+        ]).pipe(
+          filter(() => !this._hydrationState.isApplyingRemoteOps()),
+          map(([todayIds, entities, _projects]) => {
+            const relevant = todayIds.map((id) => {
+              const t = entities[id];
+              return t ? `${t.id}:${t.isDone}:${t.title}` : '';
+            });
+            return relevant.join('|');
+          }),
+          distinctUntilChanged(),
+          debounceTime(500),
+          tap(() => {
+            this._widgetDataService.serialize();
+          }),
+        ),
+      { dispatch: false },
+    );
+
+  pushOnPause$ =
+    IS_ANDROID_WEB_VIEW &&
+    createEffect(
+      () =>
+        androidInterface.onPause$.pipe(
+          tap(() => {
+            this._widgetDataService.serialize();
+          }),
+        ),
+      { dispatch: false },
+    );
+
+  drainWidgetDoneQueueOnResume$ =
+    IS_ANDROID_WEB_VIEW &&
+    createEffect(
+      () =>
+        androidInterface.onResume$.pipe(
+          tap(() => {
+            try {
+              const doneQueue = androidInterface.getWidgetDoneQueue?.();
+              if (doneQueue) {
+                const taskIds: string[] = JSON.parse(doneQueue);
+                DroidLog.log('Resume: found widget done queue', taskIds);
+                for (const id of taskIds) {
+                  androidInterface.onWidgetDone$.next(id);
+                }
+              }
+            } catch (e) {
+              DroidLog.err('Failed to process widget done queue on resume', e);
+            }
+          }),
+        ),
+      { dispatch: false },
+    );
+
+  handleWidgetDone$ =
+    IS_ANDROID_WEB_VIEW &&
+    createEffect(
+      () =>
+        androidInterface.onWidgetDone$.pipe(
+          tap((taskId: string) => {
+            DroidLog.log('Widget done action for task', { id: taskId });
+            this._taskService.setDone(taskId);
+            this._snackService.open({
+              type: 'SUCCESS',
+              msg: 'Task marked done from widget',
+            });
+          }),
+        ),
+      { dispatch: false },
+    );
+}

--- a/src/app/features/android/widget-data.service.ts
+++ b/src/app/features/android/widget-data.service.ts
@@ -1,0 +1,85 @@
+import { inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { first } from 'rxjs/operators';
+import { selectTodayTaskIds } from '../work-context/store/work-context.selectors';
+import { selectTaskFeatureState } from '../tasks/store/task.selectors';
+import { selectProjectFeatureState } from '../project/store/project.selectors';
+import { androidInterface } from './android-interface';
+import { DroidLog } from '../../core/log';
+import { HydrationStateService } from '../../op-log/apply/hydration-state.service';
+
+@Injectable({ providedIn: 'root' })
+export class WidgetDataService {
+  private _store = inject(Store);
+  private _hydrationState = inject(HydrationStateService);
+
+  async serialize(): Promise<void> {
+    if (this._hydrationState.isApplyingRemoteOps()) {
+      return;
+    }
+
+    const todayTaskIds = await this._store
+      .select(selectTodayTaskIds)
+      .pipe(first())
+      .toPromise();
+    const taskState = await this._store
+      .select(selectTaskFeatureState)
+      .pipe(first())
+      .toPromise();
+    const projectState = await this._store
+      .select(selectProjectFeatureState)
+      .pipe(first())
+      .toPromise();
+
+    if (!todayTaskIds || !taskState || !projectState) {
+      return;
+    }
+
+    const tasks: {
+      id: string;
+      title: string;
+      isDone: boolean;
+      projectId: string | null;
+    }[] = [];
+    const projectIds = new Set<string>();
+
+    for (const taskId of todayTaskIds) {
+      const task = taskState.entities[taskId];
+      if (!task) continue;
+      tasks.push({
+        id: task.id,
+        title: task.title,
+        isDone: task.isDone,
+        projectId: task.projectId || null,
+      });
+      if (task.projectId) {
+        projectIds.add(task.projectId);
+      }
+    }
+
+    const projects: Record<string, { title: string; color: string | null }> = {};
+    for (const pId of projectIds) {
+      const project = projectState.entities[pId];
+      if (project) {
+        projects[pId] = {
+          title: project.title,
+          color: project.theme?.primary || null,
+        };
+      }
+    }
+
+    const blob = JSON.stringify({
+      v: 1,
+      ts: Date.now(),
+      tasks,
+      projects,
+    });
+
+    try {
+      await androidInterface.saveToDbWrapped('widget_data', blob);
+      androidInterface.updateWidget?.();
+    } catch (e) {
+      DroidLog.err('Failed to push widget data', e);
+    }
+  }
+}

--- a/src/app/root-store/feature-stores.module.ts
+++ b/src/app/root-store/feature-stores.module.ts
@@ -65,6 +65,7 @@ import { AndroidEffects } from '../features/android/store/android.effects';
 import { AndroidFocusModeEffects } from '../features/android/store/android-focus-mode.effects';
 import { AndroidForegroundTrackingEffects } from '../features/android/store/android-foreground-tracking.effects';
 import { AndroidSyncBridgeEffects } from '../features/android/store/android-sync-bridge.effects';
+import { AndroidWidgetEffects } from '../features/android/store/android-widget.effects';
 import { MobileNotificationEffects } from '../features/mobile/store/mobile-notification.effects';
 import { IS_NATIVE_PLATFORM } from '../util/is-native-platform';
 import { NextcloudDeckIssueEffects } from '../features/issue/providers/nextcloud-deck/nextcloud-deck-issue.effects';
@@ -177,6 +178,7 @@ import {
             AndroidFocusModeEffects,
             AndroidForegroundTrackingEffects,
             AndroidSyncBridgeEffects,
+            AndroidWidgetEffects,
           ]
         : []),
     ]),


### PR DESCRIPTION
## Problem

Implements an Android home screen widget for interacting with tasks without opening the app (#3818).

## Solution

**This is a proof of concept — not intended to be merged as-is.** We'd like feedback on the architectural approach and whether this direction makes sense before investing further.

### What it does (enough to verify the approach works)

- Shows today's tasks on a native Android home screen widget
- Project color indicator per task
- "Mark done" checkbox with immediate visual feedback
- Tap header to open app
- Widget refreshes on app state change, on pause, and every 30 min (Android minimum)

### Technical approach

The core problem is that the app state lives in IndexedDB inside a Capacitor WebView, which native widget code cannot access — there's no viable way to read IndexedDB from native Android without a live WebView.

**Chosen solution:** Use the existing `KeyValStore` (SQLite) as a shared data layer between Angular and the native widget. Angular pushes a compact JSON snapshot of today's tasks to KeyValStore via the existing `saveToDb` bridge. The native `RemoteViewsFactory` reads it directly. This avoids introducing new storage mechanisms — KeyValStore is already the established persistence bridge between the WebView and native code.

**Done actions flow back** via a `SharedPreferences`-backed queue (`WidgetDoneQueue`), following the existing `ReminderDoneQueue` pattern. Two delivery paths cover all states:
- **App alive:** `LocalBroadcast` → `CapacitorMainActivity` → pushes to WebView instantly
- **App dead:** Queue accumulates, drained on next resume or cold start via `ReplaySubject`

**Why not other approaches:**
- **ContentProvider:** Unnecessary complexity for same-process communication. Both widget and app share the same process, so `@Synchronized` on KeyValStore is sufficient.
- **Direct IndexedDB access from native:** Not feasible without a live WebView instance.
- **WorkManager for periodic sync:** The widget data is a UI snapshot, not persistent state. Eager refresh on state change + onPause covers active use; the 30-min periodic update is just a fallback.

### Known drawbacks

- Widget data reflects the app's last known state — changes from other sync clients appear after the app is next opened (which triggers sync and widget refresh). The existing `SyncReminderWorker` only manages native alarms, it does not apply full state changes or update KeyValStore.
- No undo for "mark done" from widget
- Hardcoded dark styling, no Material You / dynamic color theming
- `RemoteViews` has severe layout limitations (no custom views, limited styling options)
- No task creation from widget (only mark done)
- If user marks done while app is alive, both push (broadcast) and pull (resume queue) paths could fire — relies on `setDone()` being idempotent on already-done tasks

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
