### PR TITLE
fix: new task screen doesn't render/show when new note screen is visible

### DIFF
--- a/src/app/core-ui/shortcut/shortcut.service.ts
+++ b/src/app/core-ui/shortcut/shortcut.service.ts
@@ -7,19 +7,21 @@ import { GlobalConfigService } from '../../features/config/global-config.service
 import { ActivatedRoute, Router } from '@angular/router';
 import { LayoutService } from '../layout/layout.service';
 import { TaskService } from '../../features/tasks/task.service';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { DialogAddNoteComponent } from '../../features/note/dialog-add-note/dialog-add-note.component';
 import { IPC } from '../../../../electron/shared-with-frontend/ipc-events.const';
 import { UiHelperService } from '../../features/ui-helper/ui-helper.service';
 import { WorkContextService } from '../../features/work-context/work-context.service';
 import { WorkContextType } from '../../features/work-context/work-context.model';
+import { T } from '../../t.const';
 import { Store } from '@ngrx/store';
 import { showFocusOverlay } from '../../features/focus-mode/store/focus-mode.actions';
 import { SyncWrapperService } from '../../imex/sync/sync-wrapper.service';
 import { first, mapTo, switchMap } from 'rxjs/operators';
-import { fromEvent, merge, Observable, of } from 'rxjs';
+import { firstValueFrom, fromEvent, merge, Observable, of } from 'rxjs';
 import { PluginBridgeService } from '../../plugins/plugin-bridge.service';
 import { TaskShortcutService } from '../../features/tasks/task-shortcut.service';
+import { DialogConfirmComponent } from '../../ui/dialog-confirm/dialog-confirm.component';
 
 // NOTE: Relying on Angular CDK overlay CSS class names keeps shortcut suppression simple.
 // If CDK changes these class names we only need to adjust the helpers below.
@@ -73,7 +75,7 @@ export class ShortcutService {
         this._taskService.toggleStartTask();
       });
       window.ea.on(IPC.SHOW_ADD_TASK_BAR, () => {
-        this._layoutService.showAddTaskBar();
+        void this._showAddTaskBarFromDesktopCommand();
       });
       window.ea.on(IPC.ADD_NOTE, () => {
         if (this._matDialog.openDialogs.length === 0) {
@@ -86,6 +88,51 @@ export class ShortcutService {
         }
       });
     }
+  }
+
+  private async _showAddTaskBarFromDesktopCommand(): Promise<void> {
+    const addNoteDialogRef = this._getAddNoteDialogRef();
+    if (!addNoteDialogRef) {
+      this._layoutService.showAddTaskBar();
+      return;
+    }
+
+    const addNoteDialog =
+      addNoteDialogRef.componentInstance as DialogAddNoteComponent | null;
+    const noteContent = addNoteDialog?.data?.content?.trim() || '';
+
+    if (noteContent.length > 0) {
+      const shouldSave = await firstValueFrom(
+        this._matDialog
+          .open(DialogConfirmComponent, {
+            data: {
+              message: T.F.NOTE.C.CONFIRM_SAVE_BEFORE_OPENING_NEW_TASK,
+              okTxt: T.G.SAVE,
+              cancelTxt: T.G.DISCARD,
+            },
+          })
+          .afterClosed(),
+      );
+
+      if (typeof shouldSave !== 'boolean') {
+        return;
+      }
+
+      addNoteDialog?.close(!shouldSave);
+    } else {
+      addNoteDialog?.close(true);
+    }
+
+    await firstValueFrom(addNoteDialogRef.afterClosed());
+    this._layoutService.showAddTaskBar();
+  }
+
+  private _getAddNoteDialogRef(): MatDialogRef<DialogAddNoteComponent> | null {
+    return (
+      (this._matDialog.openDialogs.find(
+        (dialogRef) => dialogRef.componentInstance instanceof DialogAddNoteComponent,
+      ) as MatDialogRef<DialogAddNoteComponent> | undefined) || null
+    );
   }
 
   async handleKeyDown(ev: KeyboardEvent): Promise<void> {

--- a/src/app/t.const.ts
+++ b/src/app/t.const.ts
@@ -703,6 +703,10 @@ const T = {
       },
     },
     NOTE: {
+      C: {
+        CONFIRM_SAVE_BEFORE_OPENING_NEW_TASK:
+          'F.NOTE.C.CONFIRM_SAVE_BEFORE_OPENING_NEW_TASK',
+      },
       D_FULLSCREEN: {
         TOOLBAR: {
           BOLD: 'F.NOTE.D_FULLSCREEN.TOOLBAR.BOLD',
@@ -1995,6 +1999,7 @@ const T = {
     CONFIRM: 'G.CONFIRM',
     CONTINUE: 'G.CONTINUE',
     DELETE: 'G.DELETE',
+    DISCARD: 'G.DISCARD',
     DISMISS: 'G.DISMISS',
     DO_IT: 'G.DO_IT',
     DONT_SHOW_AGAIN: 'G.DONT_SHOW_AGAIN',

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -692,6 +692,9 @@
       }
     },
     "NOTE": {
+      "C": {
+        "CONFIRM_SAVE_BEFORE_OPENING_NEW_TASK": "Save the current note before opening a new task?"
+      },
       "D_FULLSCREEN": {
         "TOOLBAR": {
           "BOLD": "Bold",
@@ -1948,6 +1951,7 @@
     "CONFIRM": "Confirm",
     "CONTINUE": "Continue",
     "DELETE": "Delete",
+    "DISCARD": "Discard",
     "DISMISS": "Dismiss",
     "DO_IT": "Do it!",
     "DONT_SHOW_AGAIN": "Do not show again",


### PR DESCRIPTION
## Problem

If the desktop command to create a new task is triggered while the fullscreen note dialog is open, the task UI can open underneath the note dialog instead of replacing it cleanly.

Related issue here: https://github.com/super-productivity/super-productivity/issues/7114

## Solution

When the add-task desktop command is received while the add-note dialog is open:
- if the note is empty, close the note dialog first and then show the add-task UI
- if the note has unsaved content, ask whether to save before switching
- if the user cancels the confirmation, keep the note dialog open and do not switch

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki.
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Validation notes:
- `npm run lint` passed locally
- `npm run checkFile ...` failed in this environment with `spawnSync npm EPERM`
