### PR TITLE
Fix/global show hide shortcut

### DIFF
--- a/electron/desktop-command-executor.ts
+++ b/electron/desktop-command-executor.ts
@@ -1,0 +1,104 @@
+import { log } from 'electron-log/main';
+import { DesktopCommand } from './desktop-command';
+import { IPC } from './shared-with-frontend/ipc-events.const';
+
+export interface DesktopCommandWindow {
+  blur(): void;
+  hide(): void;
+  isFocused(): boolean;
+  webContents: {
+    send(channel: IPC, ...args: unknown[]): void;
+  };
+}
+
+export interface DesktopCommandDeps {
+  showOrFocus: (mainWin: DesktopCommandWindow) => void;
+}
+
+const pendingDesktopCommands: DesktopCommand[] = [];
+
+export const executeDesktopCommand = (
+  command: DesktopCommand,
+  mainWin: DesktopCommandWindow,
+  { showOrFocus }: DesktopCommandDeps,
+): void => {
+  switch (command.type) {
+    case 'toggle-visibility':
+      if (mainWin.isFocused()) {
+        mainWin.blur();
+        mainWin.hide();
+      } else {
+        showOrFocus(mainWin);
+      }
+      return;
+
+    case 'toggle-time-tracking':
+      mainWin.webContents.send(IPC.TASK_TOGGLE_START);
+      return;
+
+    case 'new-note':
+      showOrFocus(mainWin);
+      mainWin.webContents.send(IPC.ADD_NOTE);
+      return;
+
+    case 'new-task':
+      showOrFocus(mainWin);
+      mainWin.webContents.send(IPC.SHOW_ADD_TASK_BAR);
+      return;
+
+    case 'create-task':
+      showOrFocus(mainWin);
+      mainWin.webContents.send(IPC.ADD_TASK_FROM_APP_URI, { title: command.title });
+      return;
+  }
+};
+
+export const queueDesktopCommand = (command: DesktopCommand): void => {
+  pendingDesktopCommands.push(command);
+};
+
+export const flushPendingDesktopCommands = ({
+  getMainWindow,
+  isAppReady,
+  showOrFocus,
+}: {
+  getMainWindow: () => DesktopCommandWindow | null | undefined;
+  isAppReady: () => boolean;
+  showOrFocus: (mainWin: DesktopCommandWindow) => void;
+}): void => {
+  const mainWin = getMainWindow();
+  if (!mainWin || !isAppReady() || pendingDesktopCommands.length === 0) {
+    return;
+  }
+
+  log(`Processing ${pendingDesktopCommands.length} pending desktop command(s)`);
+  const commands = [...pendingDesktopCommands];
+  pendingDesktopCommands.length = 0;
+  commands.forEach((command) => executeDesktopCommand(command, mainWin, { showOrFocus }));
+};
+
+export const queueOrExecuteDesktopCommand = ({
+  command,
+  getMainWindow,
+  isAppReady,
+  showOrFocus,
+}: {
+  command: DesktopCommand;
+  getMainWindow: () => DesktopCommandWindow | null | undefined;
+  isAppReady: () => boolean;
+  showOrFocus: (mainWin: DesktopCommandWindow) => void;
+}): void => {
+  const mainWin = getMainWindow();
+  if (!mainWin || !isAppReady()) {
+    queueDesktopCommand(command);
+    return;
+  }
+
+  executeDesktopCommand(command, mainWin, { showOrFocus });
+};
+
+export const getPendingDesktopCommandCount = (): number => pendingDesktopCommands.length;
+
+export const resetPendingDesktopCommands = (): void => {
+  pendingDesktopCommands.length = 0;
+};

--- a/electron/desktop-command-executor.ts
+++ b/electron/desktop-command-executor.ts
@@ -1,11 +1,11 @@
-import { log } from 'electron-log/main';
 import { DesktopCommand } from './desktop-command';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 
 export interface DesktopCommandWindow {
-  blur(): void;
   hide(): void;
   isFocused(): boolean;
+  isMinimized(): boolean;
+  isVisible(): boolean;
   webContents: {
     send(channel: IPC, ...args: unknown[]): void;
   };
@@ -24,8 +24,7 @@ export const executeDesktopCommand = (
 ): void => {
   switch (command.type) {
     case 'toggle-visibility':
-      if (mainWin.isFocused()) {
-        mainWin.blur();
+      if (mainWin.isVisible() && !mainWin.isMinimized()) {
         mainWin.hide();
       } else {
         showOrFocus(mainWin);
@@ -71,7 +70,6 @@ export const flushPendingDesktopCommands = ({
     return;
   }
 
-  log(`Processing ${pendingDesktopCommands.length} pending desktop command(s)`);
   const commands = [...pendingDesktopCommands];
   pendingDesktopCommands.length = 0;
   commands.forEach((command) => executeDesktopCommand(command, mainWin, { showOrFocus }));

--- a/electron/desktop-command-parser.ts
+++ b/electron/desktop-command-parser.ts
@@ -1,0 +1,84 @@
+import { DesktopCommand, DesktopCommandParseResult } from './desktop-command';
+
+const ACTION_FLAG_COMMAND_PAIRS: ReadonlyArray<
+  readonly [string, DesktopCommand['type']]
+> = [
+  ['--toggle-visibility', 'toggle-visibility'],
+  ['--toggle-time-tracking', 'toggle-time-tracking'],
+  ['--new-note', 'new-note'],
+  ['--new-task', 'new-task'],
+];
+
+const PROTOCOL_PREFIX = 'superproductivity://';
+
+export const parseDesktopCommandFromArgv = (
+  argv: string[],
+): DesktopCommandParseResult => {
+  const matchingFlags = argv.filter((arg) =>
+    ACTION_FLAG_COMMAND_PAIRS.some(([flag]) => flag === arg),
+  );
+
+  if (matchingFlags.length === 0) {
+    return { kind: 'none' };
+  }
+
+  if (matchingFlags.length > 1) {
+    return {
+      kind: 'error',
+      error: `Multiple desktop command flags are not supported: ${matchingFlags.join(', ')}`,
+    };
+  }
+
+  const matchedFlag = matchingFlags[0];
+  const commandType = ACTION_FLAG_COMMAND_PAIRS.find(
+    ([flag]) => flag === matchedFlag,
+  )?.[1];
+
+  if (!commandType) {
+    return { kind: 'none' };
+  }
+
+  return { kind: 'command', command: { type: commandType } as DesktopCommand };
+};
+
+export const parseDesktopCommandFromProtocolUrl = (
+  url: string,
+): DesktopCommandParseResult => {
+  if (!url.startsWith(PROTOCOL_PREFIX)) {
+    return { kind: 'none' };
+  }
+
+  try {
+    const urlObj = new URL(url);
+    const action = urlObj.hostname;
+    const pathParts = urlObj.pathname.split('/').filter(Boolean);
+
+    switch (action) {
+      case 'create-task': {
+        if (pathParts.length === 0) {
+          return {
+            kind: 'error',
+            error: 'Protocol action "create-task" requires a task title',
+          };
+        }
+        return {
+          kind: 'command',
+          command: { type: 'create-task', title: decodeURIComponent(pathParts[0]) },
+        };
+      }
+      case 'task-toggle-start':
+        return { kind: 'command', command: { type: 'toggle-time-tracking' } };
+      default:
+        return { kind: 'error', error: `Unknown protocol action: ${action}` };
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      kind: 'error',
+      error: `Failed to parse desktop command URL: ${errorMessage}`,
+    };
+  }
+};
+
+export const getProtocolUrlFromArgv = (argv: string[]): string | undefined =>
+  argv.find((arg) => arg.startsWith(PROTOCOL_PREFIX));

--- a/electron/desktop-command-parser.ts
+++ b/electron/desktop-command-parser.ts
@@ -8,12 +8,27 @@ const ACTION_FLAG_COMMAND_PAIRS: ReadonlyArray<
   ['--new-note', 'new-note'],
   ['--new-task', 'new-task'],
 ];
+const COMMAND_FLAG_PREFIXES = ['--toggle-', '--new-'] as const;
 
 const PROTOCOL_PREFIX = 'superproductivity://';
 
 export const parseDesktopCommandFromArgv = (
   argv: string[],
 ): DesktopCommandParseResult => {
+  const unknownCommandFlag = argv.find(
+    (arg) =>
+      arg.startsWith('--') &&
+      COMMAND_FLAG_PREFIXES.some((prefix) => arg.startsWith(prefix)) &&
+      !ACTION_FLAG_COMMAND_PAIRS.some(([flag]) => flag === arg),
+  );
+
+  if (unknownCommandFlag) {
+    return {
+      kind: 'error',
+      error: `Unknown desktop command flag: ${unknownCommandFlag}`,
+    };
+  }
+
   const matchingFlags = argv.filter((arg) =>
     ACTION_FLAG_COMMAND_PAIRS.some(([flag]) => flag === arg),
   );

--- a/electron/desktop-command.spec.ts
+++ b/electron/desktop-command.spec.ts
@@ -35,6 +35,13 @@ describe('desktop command parser', () => {
     });
   });
 
+  it('should reject unknown desktop command-like flags', () => {
+    expect(parseDesktopCommandFromArgv(['app', '--toggle-'])).toEqual({
+      kind: 'error',
+      error: 'Unknown desktop command flag: --toggle-',
+    });
+  });
+
   it('should parse existing create-task protocol URLs', () => {
     expect(
       parseDesktopCommandFromProtocolUrl('superproductivity://create-task/Foo%20Bar'),

--- a/electron/desktop-command.spec.ts
+++ b/electron/desktop-command.spec.ts
@@ -1,0 +1,162 @@
+import {
+  executeDesktopCommand,
+  flushPendingDesktopCommands,
+  getPendingDesktopCommandCount,
+  queueOrExecuteDesktopCommand,
+  resetPendingDesktopCommands,
+  type DesktopCommandWindow,
+} from './desktop-command-executor';
+import {
+  getProtocolUrlFromArgv,
+  parseDesktopCommandFromArgv,
+  parseDesktopCommandFromProtocolUrl,
+} from './desktop-command-parser';
+import { IPC } from './shared-with-frontend/ipc-events.const';
+
+describe('desktop command parser', () => {
+  it('should parse toggle visibility argv flag', () => {
+    expect(parseDesktopCommandFromArgv(['app', '--toggle-visibility'])).toEqual({
+      kind: 'command',
+      command: { type: 'toggle-visibility' },
+    });
+  });
+
+  it('should ignore existing non-command flags', () => {
+    expect(parseDesktopCommandFromArgv(['app', '--disable-tray', '--new-task'])).toEqual({
+      kind: 'command',
+      command: { type: 'new-task' },
+    });
+  });
+
+  it('should reject multiple command flags', () => {
+    expect(parseDesktopCommandFromArgv(['app', '--new-note', '--new-task'])).toEqual({
+      kind: 'error',
+      error: 'Multiple desktop command flags are not supported: --new-note, --new-task',
+    });
+  });
+
+  it('should parse existing create-task protocol URLs', () => {
+    expect(
+      parseDesktopCommandFromProtocolUrl('superproductivity://create-task/Foo%20Bar'),
+    ).toEqual({
+      kind: 'command',
+      command: { type: 'create-task', title: 'Foo Bar' },
+    });
+  });
+
+  it('should parse existing toggle tracking protocol URLs', () => {
+    expect(
+      parseDesktopCommandFromProtocolUrl('superproductivity://task-toggle-start'),
+    ).toEqual({
+      kind: 'command',
+      command: { type: 'toggle-time-tracking' },
+    });
+  });
+
+  it('should return matching protocol URL from argv', () => {
+    expect(
+      getProtocolUrlFromArgv([
+        'app',
+        '--dev-tools',
+        'superproductivity://task-toggle-start',
+      ]),
+    ).toBe('superproductivity://task-toggle-start');
+  });
+});
+
+describe('desktop command executor', () => {
+  let mainWin: DesktopCommandWindow;
+  let showOrFocusSpy: jasmine.Spy;
+  let sendSpy: jasmine.Spy;
+  let hideSpy: jasmine.Spy;
+  let blurSpy: jasmine.Spy;
+  let isFocusedSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    sendSpy = jasmine.createSpy('send');
+    hideSpy = jasmine.createSpy('hide');
+    blurSpy = jasmine.createSpy('blur');
+    isFocusedSpy = jasmine.createSpy('isFocused').and.returnValue(false);
+    showOrFocusSpy = jasmine.createSpy('showOrFocus');
+    mainWin = {
+      blur: blurSpy,
+      hide: hideSpy,
+      isFocused: isFocusedSpy,
+      webContents: {
+        send: sendSpy,
+      },
+    };
+    resetPendingDesktopCommands();
+  });
+
+  afterEach(() => {
+    resetPendingDesktopCommands();
+  });
+
+  it('should hide focused window for toggle visibility', () => {
+    isFocusedSpy.and.returnValue(true);
+
+    executeDesktopCommand({ type: 'toggle-visibility' }, mainWin, {
+      showOrFocus: showOrFocusSpy,
+    });
+
+    expect(blurSpy).toHaveBeenCalled();
+    expect(hideSpy).toHaveBeenCalled();
+    expect(showOrFocusSpy).not.toHaveBeenCalled();
+  });
+
+  it('should show or focus hidden window for toggle visibility', () => {
+    executeDesktopCommand({ type: 'toggle-visibility' }, mainWin, {
+      showOrFocus: showOrFocusSpy,
+    });
+
+    expect(showOrFocusSpy).toHaveBeenCalledWith(mainWin);
+    expect(hideSpy).not.toHaveBeenCalled();
+  });
+
+  it('should send the expected ipc messages for commands', () => {
+    executeDesktopCommand({ type: 'toggle-time-tracking' }, mainWin, {
+      showOrFocus: showOrFocusSpy,
+    });
+    executeDesktopCommand({ type: 'new-note' }, mainWin, {
+      showOrFocus: showOrFocusSpy,
+    });
+    executeDesktopCommand({ type: 'new-task' }, mainWin, {
+      showOrFocus: showOrFocusSpy,
+    });
+    executeDesktopCommand({ type: 'create-task', title: 'Protocol Task' }, mainWin, {
+      showOrFocus: showOrFocusSpy,
+    });
+
+    expect(sendSpy.calls.argsFor(0)).toEqual([IPC.TASK_TOGGLE_START]);
+    expect(sendSpy.calls.argsFor(1)).toEqual([IPC.ADD_NOTE]);
+    expect(sendSpy.calls.argsFor(2)).toEqual([IPC.SHOW_ADD_TASK_BAR]);
+    expect(sendSpy.calls.argsFor(3)).toEqual([
+      IPC.ADD_TASK_FROM_APP_URI,
+      { title: 'Protocol Task' },
+    ]);
+    expect(showOrFocusSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should queue until app readiness and flush pending commands', () => {
+    queueOrExecuteDesktopCommand({
+      command: { type: 'new-note' },
+      getMainWindow: () => mainWin,
+      isAppReady: () => false,
+      showOrFocus: showOrFocusSpy,
+    });
+
+    expect(getPendingDesktopCommandCount()).toBe(1);
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    flushPendingDesktopCommands({
+      getMainWindow: () => mainWin,
+      isAppReady: () => true,
+      showOrFocus: showOrFocusSpy,
+    });
+
+    expect(getPendingDesktopCommandCount()).toBe(0);
+    expect(sendSpy).toHaveBeenCalledWith(IPC.ADD_NOTE);
+    expect(showOrFocusSpy).toHaveBeenCalledWith(mainWin);
+  });
+});

--- a/electron/desktop-command.spec.ts
+++ b/electron/desktop-command.spec.ts
@@ -76,19 +76,22 @@ describe('desktop command executor', () => {
   let showOrFocusSpy: jasmine.Spy;
   let sendSpy: jasmine.Spy;
   let hideSpy: jasmine.Spy;
-  let blurSpy: jasmine.Spy;
   let isFocusedSpy: jasmine.Spy;
+  let isMinimizedSpy: jasmine.Spy;
+  let isVisibleSpy: jasmine.Spy;
 
   beforeEach(() => {
     sendSpy = jasmine.createSpy('send');
     hideSpy = jasmine.createSpy('hide');
-    blurSpy = jasmine.createSpy('blur');
     isFocusedSpy = jasmine.createSpy('isFocused').and.returnValue(false);
+    isMinimizedSpy = jasmine.createSpy('isMinimized').and.returnValue(false);
+    isVisibleSpy = jasmine.createSpy('isVisible').and.returnValue(true);
     showOrFocusSpy = jasmine.createSpy('showOrFocus');
     mainWin = {
-      blur: blurSpy,
       hide: hideSpy,
       isFocused: isFocusedSpy,
+      isMinimized: isMinimizedSpy,
+      isVisible: isVisibleSpy,
       webContents: {
         send: sendSpy,
       },
@@ -100,19 +103,33 @@ describe('desktop command executor', () => {
     resetPendingDesktopCommands();
   });
 
-  it('should hide focused window for toggle visibility', () => {
-    isFocusedSpy.and.returnValue(true);
+  it('should hide visible non-minimized window for toggle visibility', () => {
+    isVisibleSpy.and.returnValue(true);
+    isMinimizedSpy.and.returnValue(false);
 
     executeDesktopCommand({ type: 'toggle-visibility' }, mainWin, {
       showOrFocus: showOrFocusSpy,
     });
 
-    expect(blurSpy).toHaveBeenCalled();
     expect(hideSpy).toHaveBeenCalled();
     expect(showOrFocusSpy).not.toHaveBeenCalled();
   });
 
   it('should show or focus hidden window for toggle visibility', () => {
+    isVisibleSpy.and.returnValue(false);
+
+    executeDesktopCommand({ type: 'toggle-visibility' }, mainWin, {
+      showOrFocus: showOrFocusSpy,
+    });
+
+    expect(showOrFocusSpy).toHaveBeenCalledWith(mainWin);
+    expect(hideSpy).not.toHaveBeenCalled();
+  });
+
+  it('should show or focus minimized window for toggle visibility', () => {
+    isVisibleSpy.and.returnValue(true);
+    isMinimizedSpy.and.returnValue(true);
+
     executeDesktopCommand({ type: 'toggle-visibility' }, mainWin, {
       showOrFocus: showOrFocusSpy,
     });

--- a/electron/desktop-command.ts
+++ b/electron/desktop-command.ts
@@ -1,0 +1,11 @@
+export type DesktopCommand =
+  | { type: 'toggle-visibility' }
+  | { type: 'toggle-time-tracking' }
+  | { type: 'new-note' }
+  | { type: 'new-task' }
+  | { type: 'create-task'; title: string };
+
+export type DesktopCommandParseResult =
+  | { kind: 'none' }
+  | { kind: 'command'; command: DesktopCommand }
+  | { kind: 'error'; error: string };

--- a/electron/ipc-handlers/global-shortcuts.ts
+++ b/electron/ipc-handlers/global-shortcuts.ts
@@ -6,6 +6,9 @@ import { errorHandlerWithFrontendInform } from '../error-handler-with-frontend-i
 import { executeDesktopCommand } from '../desktop-command-executor';
 import { showOrFocus } from '../various-shared';
 
+const TOGGLE_VISIBILITY_REPEAT_GAP_MS = 1000;
+let lastToggleVisibilityEvent = 0;
+
 export const initGlobalShortcutsIpc = (): void => {
   ipcMain.on(IPC.REGISTER_GLOBAL_SHORTCUTS_EVENT, (ev, cfg) => {
     registerShowAppShortCuts(cfg);
@@ -33,6 +36,21 @@ const registerShowAppShortCuts = (cfg: KeyboardConfig): void => {
         switch (key) {
           case 'globalShowHide':
             actionFn = () => {
+              const now = Date.now();
+              const sinceLastMs = now - lastToggleVisibilityEvent;
+              lastToggleVisibilityEvent = now;
+
+              // On some Linux/Wayland setups Electron's globalShortcut repeats while the
+              // key combo is held. Treat hidden-window repeats with a short required quiet
+              // gap as the same physical press, and only allow re-show after a real pause.
+              if (
+                !mainWin.isVisible() &&
+                !mainWin.isMinimized() &&
+                sinceLastMs < TOGGLE_VISIBILITY_REPEAT_GAP_MS
+              ) {
+                return;
+              }
+
               executeDesktopCommand({ type: 'toggle-visibility' }, mainWin, {
                 showOrFocus,
               });

--- a/electron/ipc-handlers/global-shortcuts.ts
+++ b/electron/ipc-handlers/global-shortcuts.ts
@@ -2,8 +2,9 @@ import { globalShortcut, ipcMain } from 'electron';
 import { IPC } from '../shared-with-frontend/ipc-events.const';
 import { KeyboardConfig } from '../../src/app/features/config/keyboard-config.model';
 import { getWin } from '../main-window';
-import { showOrFocus } from '../various-shared';
 import { errorHandlerWithFrontendInform } from '../error-handler-with-frontend-inform';
+import { executeDesktopCommand } from '../desktop-command-executor';
+import { showOrFocus } from '../various-shared';
 
 export const initGlobalShortcutsIpc = (): void => {
   ipcMain.on(IPC.REGISTER_GLOBAL_SHORTCUTS_EVENT, (ev, cfg) => {
@@ -32,34 +33,29 @@ const registerShowAppShortCuts = (cfg: KeyboardConfig): void => {
         switch (key) {
           case 'globalShowHide':
             actionFn = () => {
-              if (mainWin.isFocused()) {
-                // we need to blur the window for windows
-                mainWin.blur();
-                mainWin.hide();
-              } else {
-                showOrFocus(mainWin);
-              }
+              executeDesktopCommand({ type: 'toggle-visibility' }, mainWin, {
+                showOrFocus,
+              });
             };
             break;
 
           case 'globalToggleTaskStart':
             actionFn = () => {
-              mainWin.webContents.send(IPC.TASK_TOGGLE_START);
+              executeDesktopCommand({ type: 'toggle-time-tracking' }, mainWin, {
+                showOrFocus,
+              });
             };
             break;
 
           case 'globalAddNote':
             actionFn = () => {
-              showOrFocus(mainWin);
-              mainWin.webContents.send(IPC.ADD_NOTE);
+              executeDesktopCommand({ type: 'new-note' }, mainWin, { showOrFocus });
             };
             break;
 
           case 'globalAddTask':
             actionFn = () => {
-              showOrFocus(mainWin);
-              // NOTE: delay slightly to make sure app is ready
-              mainWin.webContents.send(IPC.SHOW_ADD_TASK_BAR);
+              executeDesktopCommand({ type: 'new-task' }, mainWin, { showOrFocus });
             };
             break;
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,10 +1,28 @@
+import { spawn } from 'child_process';
 import { app } from 'electron';
 import { parseDesktopCommandFromArgv } from './desktop-command-parser';
 import { PROTOCOL_PREFIX } from './protocol-handler';
 import { startApp } from './start-app';
 
+const BACKGROUND_CLI_ENV_FLAG = 'SP_BACKGROUND_CLI_LAUNCH';
 const parsedDesktopCommand = parseDesktopCommandFromArgv(process.argv);
 const hasProtocolUrl = process.argv.some((arg) => arg.startsWith(PROTOCOL_PREFIX));
+const shouldLaunchDetachedInBackground =
+  !process.env[BACKGROUND_CLI_ENV_FLAG] &&
+  (parsedDesktopCommand.kind === 'command' || hasProtocolUrl);
+
+if (shouldLaunchDetachedInBackground) {
+  const child = spawn(process.execPath, process.argv.slice(1), {
+    detached: true,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      [BACKGROUND_CLI_ENV_FLAG]: '1',
+    },
+  });
+  child.unref();
+  process.exit(0);
+}
 
 // Enforce single-instance behavior on all desktop platforms.
 // macOS Finder launches are already single-instance, but CLI invocations still need this.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,17 +1,24 @@
 import { app } from 'electron';
+import { parseDesktopCommandFromArgv } from './desktop-command-parser';
 import { PROTOCOL_PREFIX } from './protocol-handler';
 import { startApp } from './start-app';
+
+const parsedDesktopCommand = parseDesktopCommandFromArgv(process.argv);
+const hasProtocolUrl = process.argv.some((arg) => arg.startsWith(PROTOCOL_PREFIX));
 
 // Enforce single-instance behavior on all desktop platforms.
 // macOS Finder launches are already single-instance, but CLI invocations still need this.
 const isLockObtained = app.requestSingleInstanceLock();
 if (!isLockObtained) {
-  const hasProtocolUrl = process.argv.some((arg) => arg.startsWith(PROTOCOL_PREFIX));
-  if (!hasProtocolUrl) {
-    console.log('Another instance is already running. Exiting.');
+  if (parsedDesktopCommand.kind === 'error') {
+    console.error(parsedDesktopCommand.error);
+    process.exit(1);
   }
   process.exit(0);
 } else {
-  console.log('Start app...');
+  if (parsedDesktopCommand.kind === 'error' && !hasProtocolUrl) {
+    console.error(parsedDesktopCommand.error);
+    process.exit(1);
+  }
   startApp();
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,23 +2,16 @@ import { app } from 'electron';
 import { PROTOCOL_PREFIX } from './protocol-handler';
 import { startApp } from './start-app';
 
-const IS_MAC = process.platform === 'darwin';
-
-if (!IS_MAC) {
-  // make it a single instance by closing other instances but allow for dev mode
-  // because of https://github.com/electron/electron/issues/14094
-  const isLockObtained = app.requestSingleInstanceLock();
-  if (!isLockObtained) {
-    const hasProtocolUrl = process.argv.some((arg) => arg.startsWith(PROTOCOL_PREFIX));
-    if (!hasProtocolUrl) {
-      console.log('Another instance is already running. Exiting.');
-    }
-    // Force immediate exit without waiting for graceful shutdown
-    process.exit(0);
-  } else {
-    console.log('Start app...');
-    startApp();
+// Enforce single-instance behavior on all desktop platforms.
+// macOS Finder launches are already single-instance, but CLI invocations still need this.
+const isLockObtained = app.requestSingleInstanceLock();
+if (!isLockObtained) {
+  const hasProtocolUrl = process.argv.some((arg) => arg.startsWith(PROTOCOL_PREFIX));
+  if (!hasProtocolUrl) {
+    console.log('Another instance is already running. Exiting.');
   }
+  process.exit(0);
 } else {
+  console.log('Start app...');
   startApp();
 }

--- a/electron/protocol-handler.ts
+++ b/electron/protocol-handler.ts
@@ -1,70 +1,77 @@
 import { App, BrowserWindow } from 'electron';
 import { log } from 'electron-log/main';
 import * as path from 'path';
-import { IPC } from './shared-with-frontend/ipc-events.const';
+import {
+  flushPendingDesktopCommands,
+  queueOrExecuteDesktopCommand,
+} from './desktop-command-executor';
+import {
+  getProtocolUrlFromArgv,
+  parseDesktopCommandFromArgv,
+  parseDesktopCommandFromProtocolUrl,
+} from './desktop-command-parser';
 import { showOrFocus } from './various-shared';
+import { getIsAppReady } from './main-window';
 
 export const PROTOCOL_NAME = 'superproductivity';
 export const PROTOCOL_PREFIX = `${PROTOCOL_NAME}://`;
 
-// Store pending URLs to process after window is ready
-let pendingUrls: string[] = [];
-
 export const processProtocolUrl = (url: string, mainWin: BrowserWindow | null): void => {
   log('Processing protocol URL:', url);
-
-  // Only process after window is ready
-  if (!mainWin || !mainWin.webContents) {
-    log('Window not ready, deferring protocol URL processing');
-    pendingUrls.push(url);
-
-    // Process any pending protocol URLs after window is created
-    setTimeout(() => {
-      processPendingProtocolUrls(mainWin);
-    }, 10000);
+  const parsedResult = parseDesktopCommandFromProtocolUrl(url);
+  if (parsedResult.kind === 'error') {
+    log(parsedResult.error);
+    return;
+  }
+  if (parsedResult.kind === 'none') {
     return;
   }
 
-  try {
-    const urlObj = new URL(url);
-    const action = urlObj.hostname;
-    const pathParts = urlObj.pathname.split('/').filter(Boolean);
-
-    log('Protocol action:', action);
-    log('Protocol path parts:', pathParts);
-
-    switch (action) {
-      case 'create-task':
-        if (pathParts.length > 0) {
-          const taskTitle = decodeURIComponent(pathParts[0]);
-          log('Creating task with title:', taskTitle);
-
-          // Send IPC message to create task
-          if (mainWin && mainWin.webContents) {
-            mainWin.webContents.send(IPC.ADD_TASK_FROM_APP_URI, { title: taskTitle });
-          }
-        }
-        break;
-      case 'task-toggle-start':
-        // Send IPC message to toggle task start
-        if (mainWin && mainWin.webContents) {
-          mainWin.webContents.send(IPC.TASK_TOGGLE_START);
-        }
-        break;
-      default:
-        log('Unknown protocol action:', action);
-    }
-  } catch (error) {
-    log('Error processing protocol URL:', error);
-  }
+  queueOrExecuteDesktopCommand({
+    command: parsedResult.command,
+    getMainWindow: () => mainWin,
+    isAppReady: getIsAppReady,
+    showOrFocus,
+  });
 };
 
 export const processPendingProtocolUrls = (mainWin: BrowserWindow): void => {
-  if (pendingUrls.length > 0) {
-    log(`Processing ${pendingUrls.length} pending protocol URLs`);
-    const urls = [...pendingUrls];
-    pendingUrls = [];
-    urls.forEach((url) => processProtocolUrl(url, mainWin));
+  flushPendingDesktopCommands({
+    getMainWindow: () => mainWin,
+    isAppReady: getIsAppReady,
+    showOrFocus,
+  });
+};
+
+const handleSecondInstanceInvocation = (
+  commandLine: string[],
+  getMainWindow: () => BrowserWindow | null,
+): void => {
+  const mainWin = getMainWindow();
+
+  const parsedCliResult = parseDesktopCommandFromArgv(commandLine);
+  if (parsedCliResult.kind === 'error') {
+    log(parsedCliResult.error);
+    return;
+  }
+  if (parsedCliResult.kind === 'command') {
+    queueOrExecuteDesktopCommand({
+      command: parsedCliResult.command,
+      getMainWindow,
+      isAppReady: getIsAppReady,
+      showOrFocus,
+    });
+    return;
+  }
+
+  const url = getProtocolUrlFromArgv(commandLine);
+  if (url) {
+    processProtocolUrl(url, mainWin);
+    return;
+  }
+
+  if (mainWin) {
+    showOrFocus(mainWin);
   }
 };
 
@@ -86,18 +93,7 @@ export const initializeProtocolHandling = (
 
   // Handle protocol on Windows/Linux via second instance
   appInstance.on('second-instance', (event, commandLine) => {
-    const mainWin = getMainWindow();
-
-    // Someone tried to run a second instance, we should focus our window instead.
-    if (mainWin) {
-      showOrFocus(mainWin);
-    }
-
-    // Handle protocol url from second instance
-    const url = commandLine.find((arg) => arg.startsWith(PROTOCOL_PREFIX));
-    if (url) {
-      processProtocolUrl(url, mainWin);
-    }
+    handleSecondInstanceInvocation(commandLine, getMainWindow);
   });
 
   // Handle protocol on macOS

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -21,9 +21,14 @@ import { CONFIG } from './CONFIG';
 import { lazySetInterval } from './shared-with-frontend/lazy-set-interval';
 import { initIndicator } from './indicator';
 import { quitApp, showOrFocus } from './various-shared';
-import { createWindow } from './main-window';
+import { createWindow, getIsAppReady } from './main-window';
 import { IdleTimeHandler } from './idle-time-handler';
 import { destroyTaskWidget } from './task-widget/task-widget';
+import {
+  flushPendingDesktopCommands,
+  queueOrExecuteDesktopCommand,
+} from './desktop-command-executor';
+import { parseDesktopCommandFromArgv } from './desktop-command-parser';
 import {
   initializeProtocolHandling,
   processPendingProtocolUrls,
@@ -57,6 +62,16 @@ export const startApp = (): void => {
 
   // LOAD IPC STUFF
   initIpcInterfaces();
+
+  ipcMain.on(IPC.APP_READY, () => {
+    setTimeout(() => {
+      flushPendingDesktopCommands({
+        getMainWindow: () => mainWin,
+        isAppReady: getIsAppReady,
+        showOrFocus,
+      });
+    });
+  });
 
   electronLog.initialize();
 
@@ -98,6 +113,18 @@ export const startApp = (): void => {
       isShowDevTools = true;
     }
   });
+
+  const parsedDesktopCommand = parseDesktopCommandFromArgv(process.argv);
+  if (parsedDesktopCommand.kind === 'error') {
+    log(parsedDesktopCommand.error);
+  } else if (parsedDesktopCommand.kind === 'command') {
+    queueOrExecuteDesktopCommand({
+      command: parsedDesktopCommand.command,
+      getMainWindow: () => mainWin,
+      isAppReady: getIsAppReady,
+      showOrFocus,
+    });
+  }
 
   // TODO remove at one point in the future and only leave the directory setting part
   // Special handling for snaps, since default user folder will cause problems when updating
@@ -382,6 +409,12 @@ export const startApp = (): void => {
     setTimeout(() => {
       processPendingProtocolUrls(mainWin);
     }, 1000);
+
+    flushPendingDesktopCommands({
+      getMainWindow: () => mainWin,
+      isAppReady: getIsAppReady,
+      showOrFocus,
+    });
   }
 
   // eslint-disable-next-line prefer-arrow/prefer-arrow-functions

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -72,7 +72,6 @@ export const startApp = (): void => {
       });
     });
   });
-
   electronLog.initialize();
 
   app.commandLine.appendSwitch('enable-speech-dispatcher');

--- a/electron/various-shared.ts
+++ b/electron/various-shared.ts
@@ -23,13 +23,19 @@ export function showOrFocus(passedWin: BrowserWindow): void {
     return;
   }
 
-  if (win.isVisible()) {
-    win.focus();
-  } else {
-    // restore explicitly
-    if (win.isMinimized()) win.restore();
+  // Restore first so the focus/raise path can operate on a normal window.
+  if (win.isMinimized()) {
+    win.restore();
+  }
+
+  if (!win.isVisible()) {
     win.show();
     if (getWasMaximizedBeforeHide()) win.maximize();
+  } else {
+    // Re-show and raise already-visible windows because focus() alone can fail to
+    // bring the existing instance to the foreground on some Linux window managers.
+    win.show();
+    win.moveTop();
   }
 
   // Hide task widget when main window is shown

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -10,5 +10,5 @@
     }
   },
   "files": ["test.ts", "polyfills.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts", "**/*.d.ts", "../electron/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Problem

On Linux/Wayland, invoking the global "Show/hide Super Productivity" shortcut while the SP window was visible/in focus would hide the main window but then automatically reopen it the window ~0.5 seconds after (i.e., window was not remaining hidden, as intended).

Root cause: Electron's `globalShortcut` repeated while the key combo was still held, which caused an unintended second toggle after the window had already been hidden.

Related issue here: https://github.com/super-productivity/super-productivity/issues/7114

## Solution

This change stabilizes the global show/hide shortcut by:

- using window visible/minimized state instead of focus state to decide whether to hide or show
- ignoring repeated hidden-window shortcut firings within a short window so one physical key press only hides once

Observed and validated on Linux/Wayland (`niri`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Validation Notes

- `npm run lint` passed locally
- `npm run electron:build` passed locally
- `npm run checkFile ...` failed in this environment with `spawnSync npm EPERM`
- `.deb` packaging also passed locally during validation
