### PR TITLE
fix(nav-item): prevent project counters from overlapping menu icon

### DIFF
--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -75,16 +75,6 @@
   }
 }
 
-@media (hover: none) {
-  .additional-btn {
-    opacity: 1;
-    visibility: visible;
-  }
-  .task-count {
-    display: flex !important;
-  }
-}
-
 .task-count {
   position: absolute;
   top: 50%;
@@ -92,13 +82,28 @@
   line-height: 1;
   text-align: center;
   font-size: 10px;
-  // Position to the left of the additional button (40px) with some padding (8px)
-  right: 48px;
+  right: 16px;
   display: flex;
   align-items: center;
   color: var(--text-color-muted);
   // avoid affecting drag handle
   pointer-events: none;
+}
+
+// On touch devices the .additional-btn is always visible, so let the counter
+// flow inline beside it instead of overlapping.
+:host-context(.isTouchPrimary) {
+  .task-count {
+    position: static;
+    transform: none;
+    padding: 0 var(--s);
+    flex-shrink: 0;
+    pointer-events: auto;
+  }
+
+  button:first-of-type.has-tasks {
+    padding-right: var(--s);
+  }
 }
 
 // Active state visuals - ensure they override Angular Material styles

--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -81,7 +81,6 @@
     visibility: visible;
   }
   .task-count {
-    right: 48px !important;
     display: flex !important;
   }
 }
@@ -93,7 +92,8 @@
   line-height: 1;
   text-align: center;
   font-size: 10px;
-  right: 16px;
+  // Position to the left of the additional button (40px) with some padding (8px)
+  right: 48px;
   display: flex;
   align-items: center;
   color: var(--text-color-muted);


### PR DESCRIPTION
## Description

This PR fixes the UI issue where project counters (task-count badges) overlap with the menu icon (three-dot menu button) in the sidebar navigation.

### Problem

When the sidebar was narrow, the task-count badge positioned at `right: 16px` would overlap with the additional-btn (three-dot menu button, 40px wide), making both elements difficult to read and interact with.

### Solution

Changed the default position of `.task-count` from `right: 16px` to `right: 48px` (40px button width + 8px padding) to ensure the counter is always positioned to the left of the menu button.

### Changes

- Updated `src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss`
- Changed `right: 16px` to `right: 48px` in the `.task-count` class
- Removed redundant `right: 48px !important` from the `@media (hover: none)` query since it's now the default

Fixes #7132