### PR TITLE
refactor(plugin): change GitHub Issues access token description

### DIFF
--- a/packages/plugin-dev/github-issue-provider/i18n/en.json
+++ b/packages/plugin-dev/github-issue-provider/i18n/en.json
@@ -1,7 +1,7 @@
 {
   "CFG": {
     "REPO": "Repository (owner/repo)",
-    "TOKEN": "Personal Access Token (optional, for private repos)",
+    "TOKEN": "Personal Access Token (required for private repos/optional for public repos)",
     "FILTER_USERNAME": "Filter username (ignore own comments for update detection)",
     "BACKLOG_QUERY": "Backlog query (default: \"sort:updated state:open assignee:@me\")",
     "HOW_TO_GET_TOKEN": "How to get a token"


### PR DESCRIPTION
## Problem

When setting up GitHub Issues as an issue provider, the message describing the Personal Access Token field read `optional, for private repos`. This message was confusing and seemed to indicate that tokens were optional for private repos, which is not the case.

## Solution

The new message, `required for private repos/optional for public repos`, makes it clear to users that a token is required to access a private repo, but is not required to access a public repo.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). [N/A]
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files [N/A]
- [ ] I have added tests for my changes (if applicable) [N/A]
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
