### PR TITLE
fix: harden archive payload repair and validation

### DIFF
--- a/src/app/features/archive/archive.service.spec.ts
+++ b/src/app/features/archive/archive.service.spec.ts
@@ -368,6 +368,7 @@ describe('ArchiveService', () => {
       const savedData = mockArchiveDbAdapter.saveArchiveYoung.calls.mostRecent().args[0];
       expect(savedData.task.ids).toEqual(['task-1']);
       expect(Object.keys(savedData.task.entities)).toEqual(['task-1']);
+      expect(savedData.task.entities['task-1']!.subTaskIds).toEqual([]);
     });
 
     it('should sync subTaskIds with surviving subtasks when some are dropped', async () => {

--- a/src/app/features/archive/archive.service.spec.ts
+++ b/src/app/features/archive/archive.service.spec.ts
@@ -369,5 +369,28 @@ describe('ArchiveService', () => {
       expect(savedData.task.ids).toEqual(['task-1']);
       expect(Object.keys(savedData.task.entities)).toEqual(['task-1']);
     });
+
+    it('should sync subTaskIds with surviving subtasks when some are dropped', async () => {
+      // If a subtask is dropped because its id is invalid, the parent's subTaskIds
+      // must drop the same reference so the archived parent doesn't carry a
+      // dangling id that would re-surface on restore / remote sync.
+      const validSubTask = createMockTask('sub-ok', { parentId: 'task-1' });
+      const invalidSubTask = {
+        title: 'broken',
+        subTasks: [],
+      } as unknown as TaskWithSubTasks;
+      const parentTask = createMockTask('task-1', {
+        subTaskIds: ['sub-ok', 'sub-broken'],
+        subTasks: [validSubTask, invalidSubTask as any],
+      });
+
+      await service.writeTasksToArchiveForRemoteSync([parentTask]);
+
+      expect(mockArchiveDbAdapter.saveArchiveYoung).toHaveBeenCalled();
+      const savedData = mockArchiveDbAdapter.saveArchiveYoung.calls.mostRecent().args[0];
+      const savedParent = savedData.task.entities['task-1'];
+      expect(savedParent).toBeDefined();
+      expect(savedParent!.subTaskIds).toEqual(['sub-ok']);
+    });
   });
 });

--- a/src/app/features/archive/archive.service.spec.ts
+++ b/src/app/features/archive/archive.service.spec.ts
@@ -342,4 +342,32 @@ describe('ArchiveService', () => {
       });
     });
   });
+
+  describe('writeTasksToArchiveForRemoteSync', () => {
+    it('should ignore malformed tasks without valid ids', async () => {
+      const invalidTask = {
+        title: 'Invalid task',
+        subTasks: [],
+      } as unknown as TaskWithSubTasks;
+
+      await service.writeTasksToArchiveForRemoteSync([invalidTask]);
+
+      expect(mockArchiveDbAdapter.saveArchiveYoung).not.toHaveBeenCalled();
+    });
+
+    it('should drop malformed subtasks before persisting archive data', async () => {
+      const invalidSubTask = { title: 'Invalid subtask' } as unknown as TaskWithSubTasks;
+      const parentTask = createMockTask('task-1', {
+        subTaskIds: ['sub-1'],
+        subTasks: [invalidSubTask as any],
+      });
+
+      await service.writeTasksToArchiveForRemoteSync([parentTask]);
+
+      expect(mockArchiveDbAdapter.saveArchiveYoung).toHaveBeenCalled();
+      const savedData = mockArchiveDbAdapter.saveArchiveYoung.calls.mostRecent().args[0];
+      expect(savedData.task.ids).toEqual(['task-1']);
+      expect(Object.keys(savedData.task.entities)).toEqual(['task-1']);
+    });
+  });
 });

--- a/src/app/features/archive/archive.service.ts
+++ b/src/app/features/archive/archive.service.ts
@@ -18,6 +18,7 @@ import { TimeTrackingState } from '../time-tracking/time-tracking.model';
 import { first } from 'rxjs/operators';
 import { firstValueFrom } from 'rxjs';
 import { selectTimeTrackingState } from '../time-tracking/store/time-tracking.selectors';
+import { isValidEntityId } from '../../op-log/validation/is-valid-entity-id';
 
 /**
  * Maps tasks to archive format by:
@@ -59,13 +60,7 @@ const mapTasksToArchiveFormat = (
   });
 };
 
-const isValidArchiveTaskId = (value: unknown): value is string =>
-  typeof value === 'string' &&
-  value.length > 0 &&
-  value !== 'undefined' &&
-  value !== 'null';
-
-const sanitizeTasksForArchiving = (
+export const sanitizeTasksForArchiving = (
   tasksIn: TaskWithSubTasks[],
   logPrefix: string,
 ): TaskWithSubTasks[] => {
@@ -73,23 +68,31 @@ const sanitizeTasksForArchiving = (
   let droppedSubTasks = 0;
 
   const sanitizedTasks = tasksIn.flatMap((task) => {
-    if (!task || !isValidArchiveTaskId(task.id)) {
+    if (!task || !isValidEntityId(task.id)) {
       droppedRootTasks++;
       return [];
     }
 
     const subTasks = (task.subTasks || []).filter((subTask) => {
-      const isValid = !!subTask && isValidArchiveTaskId(subTask.id);
+      const isValid = !!subTask && isValidEntityId(subTask.id);
       if (!isValid) {
         droppedSubTasks++;
       }
       return isValid;
     });
 
+    // Keep subTaskIds in sync with the surviving subTasks so the archived
+    // parent cannot carry dangling references when subtasks are dropped.
+    const survivingSubTaskIds = new Set(subTasks.map((st) => st.id));
+    const subTaskIds = Array.isArray(task.subTaskIds)
+      ? task.subTaskIds.filter((id) => survivingSubTaskIds.has(id))
+      : [];
+
     return [
       {
         ...task,
         subTasks,
+        subTaskIds,
       },
     ];
   });

--- a/src/app/features/archive/archive.service.ts
+++ b/src/app/features/archive/archive.service.ts
@@ -59,6 +59,53 @@ const mapTasksToArchiveFormat = (
   });
 };
 
+const isValidArchiveTaskId = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  value !== 'undefined' &&
+  value !== 'null';
+
+const sanitizeTasksForArchiving = (
+  tasksIn: TaskWithSubTasks[],
+  logPrefix: string,
+): TaskWithSubTasks[] => {
+  let droppedRootTasks = 0;
+  let droppedSubTasks = 0;
+
+  const sanitizedTasks = tasksIn.flatMap((task) => {
+    if (!task || !isValidArchiveTaskId(task.id)) {
+      droppedRootTasks++;
+      return [];
+    }
+
+    const subTasks = (task.subTasks || []).filter((subTask) => {
+      const isValid = !!subTask && isValidArchiveTaskId(subTask.id);
+      if (!isValid) {
+        droppedSubTasks++;
+      }
+      return isValid;
+    });
+
+    return [
+      {
+        ...task,
+        subTasks,
+      },
+    ];
+  });
+
+  if (droppedRootTasks > 0 || droppedSubTasks > 0) {
+    Log.warn(`[ArchiveService] ${logPrefix}: Dropped malformed archive payload tasks`, {
+      droppedRootTasks,
+      droppedSubTasks,
+      originalTaskCount: tasksIn.length,
+      sanitizedTaskCount: sanitizedTasks.length,
+    });
+  }
+
+  return sanitizedTasks;
+};
+
 /*
 # Considerations for flush architecture:
 ** The main purpose of flushing is mainly to reduce the amount of data that needs to be transferred over the network **
@@ -108,16 +155,18 @@ export class ArchiveService {
   // it is usually triggered every work-day once
   async moveTasksToArchiveAndFlushArchiveIfDue(tasks: TaskWithSubTasks[]): Promise<void> {
     const now = Date.now();
-    const flatTasks = flattenTasks(tasks);
+    const sanitizedTasks = sanitizeTasksForArchiving(tasks, 'moveToArchive');
+    const flatTasks = flattenTasks(sanitizedTasks);
 
     Log.log('[ArchiveService] moveTasksToArchiveAndFlushArchiveIfDue:', {
       inputTasksCount: tasks.length,
+      sanitizedTaskCount: sanitizedTasks.length,
       flatTasksCount: flatTasks.length,
       taskIds: flatTasks.map((t) => t.id),
     });
 
     if (!flatTasks.length) {
-      Log.log('[ArchiveService] No tasks to archive after flattening');
+      Log.log('[ArchiveService] No valid tasks to archive after flattening');
       return;
     }
 
@@ -267,16 +316,18 @@ export class ArchiveService {
    */
   async writeTasksToArchiveForRemoteSync(tasks: TaskWithSubTasks[]): Promise<void> {
     const now = Date.now();
-    const flatTasks = flattenTasks(tasks);
+    const sanitizedTasks = sanitizeTasksForArchiving(tasks, 'Remote sync');
+    const flatTasks = flattenTasks(sanitizedTasks);
 
     Log.log('[ArchiveService] writeTasksToArchiveForRemoteSync:', {
       inputTasksCount: tasks.length,
+      sanitizedTaskCount: sanitizedTasks.length,
       flatTasksCount: flatTasks.length,
       taskIds: flatTasks.map((t) => t.id),
     });
 
     if (!flatTasks.length) {
-      Log.log('[ArchiveService] No tasks to archive for remote sync');
+      Log.log('[ArchiveService] No valid tasks to archive for remote sync');
       return;
     }
 

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -470,6 +470,19 @@ describe('TaskService', () => {
         jasmine.objectContaining({ type: TaskSharedActions.moveToArchive.type }),
       );
     });
+
+    it('should ignore malformed tasks without valid ids', async () => {
+      const invalidTask = { title: 'Broken task', subTasks: [] } as any;
+
+      await service.moveToArchive([invalidTask]);
+
+      expect(store.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ type: TaskSharedActions.moveToArchive.type }),
+      );
+      expect(
+        archiveService.moveTasksToArchiveAndFlushArchiveIfDue,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe('moveToProject', () => {

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -471,17 +471,17 @@ describe('TaskService', () => {
       );
     });
 
-    it('should ignore malformed tasks without valid ids', async () => {
+    it('should delegate malformed-task filtering to archive.service', async () => {
+      // Sanitization lives in archive.service (sanitizeTasksForArchiving) so the
+      // same rules apply to both moveTasksToArchiveAndFlushArchiveIfDue and
+      // writeTasksToArchiveForRemoteSync. task.service is a pass-through here.
       const invalidTask = { title: 'Broken task', subTasks: [] } as any;
 
       await service.moveToArchive([invalidTask]);
 
-      expect(store.dispatch).not.toHaveBeenCalledWith(
-        jasmine.objectContaining({ type: TaskSharedActions.moveToArchive.type }),
-      );
-      expect(
-        archiveService.moveTasksToArchiveAndFlushArchiveIfDue,
-      ).not.toHaveBeenCalled();
+      expect(archiveService.moveTasksToArchiveAndFlushArchiveIfDue).toHaveBeenCalledWith([
+        invalidTask,
+      ]);
     });
   });
 

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -855,7 +855,9 @@ export class TaskService {
     }
 
     if (!Array.isArray(tasks)) {
-      TaskLog.warn('[TaskService] moveToArchive converting single task to array', tasks);
+      TaskLog.warn('[TaskService] moveToArchive converting single task to array', {
+        id: tasks.id,
+      });
       tasks = [tasks];
     }
 

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -849,66 +849,34 @@ export class TaskService {
   }
 
   async moveToArchive(tasks: TaskWithSubTasks | TaskWithSubTasks[]): Promise<void> {
-    // Add comprehensive validation and logging
     if (!tasks) {
-      console.error('[TaskService] moveToArchive called with null/undefined tasks');
+      TaskLog.err('[TaskService] moveToArchive called with null/undefined tasks');
       return;
     }
 
     if (!Array.isArray(tasks)) {
-      console.warn('[TaskService] moveToArchive converting single task to array', tasks);
+      TaskLog.warn('[TaskService] moveToArchive converting single task to array', tasks);
       tasks = [tasks];
     }
 
-    // Double-check it's an array after conversion
-    if (!Array.isArray(tasks)) {
-      console.error('[TaskService] Failed to convert tasks to array:', tasks);
-      throw new Error('moveToArchive: tasks could not be converted to array');
-    }
-
-    const sanitizedTasks = tasks
-      .filter(
-        (task): task is TaskWithSubTasks =>
-          !!task &&
-          typeof task.id === 'string' &&
-          task.id.length > 0 &&
-          task.id !== 'undefined' &&
-          task.id !== 'null',
-      )
-      .map((task) => ({
-        ...task,
-        subTasks: (task.subTasks || []).filter(
-          (subTask): subTask is Task =>
-            !!subTask &&
-            typeof subTask.id === 'string' &&
-            subTask.id.length > 0 &&
-            subTask.id !== 'undefined' &&
-            subTask.id !== 'null',
-        ),
-      }));
-
-    if (sanitizedTasks.length !== tasks.length) {
-      console.warn('[TaskService] moveToArchive dropped malformed tasks', {
-        originalCount: tasks.length,
-        sanitizedCount: sanitizedTasks.length,
-      });
-    }
-
-    if (!sanitizedTasks.length) {
-      TaskLog.log('[TaskService] No valid tasks to archive after sanitization');
+    if (!tasks.length) {
+      TaskLog.log('[TaskService] No tasks to archive');
       return;
     }
 
     TaskLog.log('[TaskService] moveToArchive called with:', {
-      count: sanitizedTasks.length,
-      taskIds: sanitizedTasks.map((t) => t.id),
-      tasksType: typeof sanitizedTasks,
-      isArray: Array.isArray(sanitizedTasks),
+      count: tasks.length,
+      taskIds: tasks.map((t) => t?.id),
+      tasksType: typeof tasks,
+      isArray: Array.isArray(tasks),
     });
 
-    // NOTE: we only update real parents since otherwise we move sub-tasks without their parent into the archive
-    const subTasks = sanitizedTasks.filter((t) => t?.parentId);
-    const parentTasks = sanitizedTasks.filter((t) => t && !t.parentId);
+    // NOTE: malformed tasks (missing/invalid ids) are dropped inside archive.service
+    // via sanitizeTasksForArchiving, which also covers writeTasksToArchiveForRemoteSync.
+    // We only update real parents here since otherwise we'd move sub-tasks without
+    // their parent into the archive.
+    const subTasks = tasks.filter((t) => t?.parentId);
+    const parentTasks = tasks.filter((t) => t && !t.parentId);
 
     TaskLog.log('[TaskService] Filtered tasks:', {
       parentTasks: parentTasks.map((t) => t.id),

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -866,16 +866,49 @@ export class TaskService {
       throw new Error('moveToArchive: tasks could not be converted to array');
     }
 
+    const sanitizedTasks = tasks
+      .filter(
+        (task): task is TaskWithSubTasks =>
+          !!task &&
+          typeof task.id === 'string' &&
+          task.id.length > 0 &&
+          task.id !== 'undefined' &&
+          task.id !== 'null',
+      )
+      .map((task) => ({
+        ...task,
+        subTasks: (task.subTasks || []).filter(
+          (subTask): subTask is Task =>
+            !!subTask &&
+            typeof subTask.id === 'string' &&
+            subTask.id.length > 0 &&
+            subTask.id !== 'undefined' &&
+            subTask.id !== 'null',
+        ),
+      }));
+
+    if (sanitizedTasks.length !== tasks.length) {
+      console.warn('[TaskService] moveToArchive dropped malformed tasks', {
+        originalCount: tasks.length,
+        sanitizedCount: sanitizedTasks.length,
+      });
+    }
+
+    if (!sanitizedTasks.length) {
+      TaskLog.log('[TaskService] No valid tasks to archive after sanitization');
+      return;
+    }
+
     TaskLog.log('[TaskService] moveToArchive called with:', {
-      count: tasks.length,
-      taskIds: tasks.map((t) => t?.id || 'undefined'),
-      tasksType: typeof tasks,
-      isArray: Array.isArray(tasks),
+      count: sanitizedTasks.length,
+      taskIds: sanitizedTasks.map((t) => t.id),
+      tasksType: typeof sanitizedTasks,
+      isArray: Array.isArray(sanitizedTasks),
     });
 
     // NOTE: we only update real parents since otherwise we move sub-tasks without their parent into the archive
-    const subTasks = tasks.filter((t) => t?.parentId);
-    const parentTasks = tasks.filter((t) => t && !t.parentId);
+    const subTasks = sanitizedTasks.filter((t) => t?.parentId);
+    const parentTasks = sanitizedTasks.filter((t) => t && !t.parentId);
 
     TaskLog.log('[TaskService] Filtered tasks:', {
       parentTasks: parentTasks.map((t) => t.id),

--- a/src/app/op-log/validation/data-repair.spec.ts
+++ b/src/app/op-log/validation/data-repair.spec.ts
@@ -593,6 +593,49 @@ describe('dataRepair()', () => {
         },
       });
     });
+
+    it('taskArchive with malformed undefined entity', () => {
+      expect(
+        dataRepair({
+          ...mock,
+          archiveYoung: {
+            lastTimeTrackingFlush: 0,
+            timeTracking: mock.archiveYoung.timeTracking,
+            task: {
+              ids: ['VALID_TASK', null],
+              entities: {
+                VALID_TASK: {
+                  ...DEFAULT_TASK,
+                  id: 'VALID_TASK',
+                  projectId: FAKE_PROJECT_ID,
+                },
+                undefined: {
+                  isDone: true,
+                  doneOn: 1775783824920,
+                  subTasks: [],
+                },
+              },
+            } as any,
+          },
+        }).data,
+      ).toEqual({
+        ...mock,
+        archiveYoung: {
+          lastTimeTrackingFlush: 0,
+          timeTracking: mock.archiveYoung.timeTracking,
+          task: {
+            ids: ['VALID_TASK'],
+            entities: {
+              VALID_TASK: {
+                ...DEFAULT_TASK,
+                id: 'VALID_TASK',
+                projectId: FAKE_PROJECT_ID,
+              },
+            },
+          } as any,
+        },
+      });
+    });
   });
 
   it('should restore missing tasks from taskArchive if available', () => {

--- a/src/app/op-log/validation/data-repair.ts
+++ b/src/app/op-log/validation/data-repair.ts
@@ -19,6 +19,7 @@ import { OpLog } from '../../core/log';
 import { repairMenuTree } from './repair-menu-tree';
 import { initialTimeTrackingState } from '../../features/time-tracking/store/time-tracking.reducer';
 import { RepairSummary } from '../core/operation.types';
+import { isValidEntityId } from './is-valid-entity-id';
 
 export interface DataRepairResult {
   data: AppDataComplete;
@@ -670,12 +671,6 @@ const _removeMissingTasksFromListsOrRestoreFromArchive = (
   return data;
 };
 
-const _isValidEntityId = (value: unknown): value is string =>
-  typeof value === 'string' &&
-  value.length > 0 &&
-  value !== 'undefined' &&
-  value !== 'null';
-
 const _resetEntityIdsFromObjects = <T extends AppBaseDataEntityLikeStates>(
   data: T,
 ): T => {
@@ -694,7 +689,7 @@ const _resetEntityIdsFromObjects = <T extends AppBaseDataEntityLikeStates>(
       }
 
       const entityId = (entity as { id?: unknown }).id;
-      if (!_isValidEntityId(entityId) || !_isValidEntityId(key)) {
+      if (!isValidEntityId(entityId) || !isValidEntityId(key)) {
         return acc;
       }
 

--- a/src/app/op-log/validation/data-repair.ts
+++ b/src/app/op-log/validation/data-repair.ts
@@ -670,6 +670,12 @@ const _removeMissingTasksFromListsOrRestoreFromArchive = (
   return data;
 };
 
+const _isValidEntityId = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  value !== 'undefined' &&
+  value !== 'null';
+
 const _resetEntityIdsFromObjects = <T extends AppBaseDataEntityLikeStates>(
   data: T,
 ): T => {
@@ -681,12 +687,27 @@ const _resetEntityIdsFromObjects = <T extends AppBaseDataEntityLikeStates>(
     } as T;
   }
 
+  const sanitizedEntities = Object.entries(data.entities).reduce(
+    (acc, [key, entity]) => {
+      if (!entity || typeof entity !== 'object') {
+        return acc;
+      }
+
+      const entityId = (entity as { id?: unknown }).id;
+      if (!_isValidEntityId(entityId) || !_isValidEntityId(key)) {
+        return acc;
+      }
+
+      acc[entityId] = entity;
+      return acc;
+    },
+    {} as AppBaseDataEntityLikeStates['entities'],
+  );
+
   return {
     ...data,
-    entities: data.entities || {},
-    ids: data.entities
-      ? Object.keys(data.entities).filter((id) => !!data.entities[id])
-      : [],
+    entities: sanitizedEntities,
+    ids: Object.keys(sanitizedEntities),
   };
 };
 

--- a/src/app/op-log/validation/is-valid-entity-id.ts
+++ b/src/app/op-log/validation/is-valid-entity-id.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared predicate for validating that an entity ID is a usable string.
+ *
+ * Rejects the string literals `'undefined'` and `'null'` because they indicate
+ * an ID was toString'd from a missing value somewhere upstream, not a legitimate
+ * identifier.
+ */
+export const isValidEntityId = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  value !== 'undefined' &&
+  value !== 'null';

--- a/src/app/op-log/validation/validate-operation-payload.spec.ts
+++ b/src/app/op-log/validation/validate-operation-payload.spec.ts
@@ -140,6 +140,30 @@ describe('validateOperationPayload', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should reject UPDATE batch shape when a task is missing a valid id', () => {
+      const op = createTestOperation({
+        opType: OpType.Update,
+        entityType: 'TASK' as EntityType,
+        payload: { tasks: [{ id: 'task1' }, { title: 'Missing id' }] },
+      });
+      const result = validateOperationPayload(op);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('missing valid');
+    });
+
+    it('should reject UPDATE batch shape when a subtask is missing a valid id', () => {
+      const op = createTestOperation({
+        opType: OpType.Update,
+        entityType: 'TASK' as EntityType,
+        payload: {
+          tasks: [{ id: 'task1', subTasks: [{ title: 'Broken subtask' }] }],
+        },
+      });
+      const result = validateOperationPayload(op);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('subTasks[0]');
+    });
+
     it('should validate UPDATE with full entity in nested key', () => {
       const op = createTestOperation({
         opType: OpType.Update,

--- a/src/app/op-log/validation/validate-operation-payload.ts
+++ b/src/app/op-log/validation/validate-operation-payload.ts
@@ -7,6 +7,7 @@ import {
 } from '../core/operation.types';
 import { OpLog } from '../../core/log';
 import { getPayloadKey, getAllPayloadKeys } from '../core/entity-registry';
+import { isValidEntityId } from './is-valid-entity-id';
 
 /**
  * Result of validating an operation payload.
@@ -25,12 +26,6 @@ const getEntityKeyFromType = (entityType: EntityType): string | null => {
   return getPayloadKey(entityType) ?? null;
 };
 
-const isValidTaskPayloadId = (value: unknown): value is string =>
-  typeof value === 'string' &&
-  value.length > 0 &&
-  value !== 'undefined' &&
-  value !== 'null';
-
 const validateTaskBatchPayload = (tasks: unknown[]): PayloadValidationResult => {
   for (let i = 0; i < tasks.length; i++) {
     const task = tasks[i] as Record<string, unknown>;
@@ -41,7 +36,7 @@ const validateTaskBatchPayload = (tasks: unknown[]): PayloadValidationResult => 
       };
     }
 
-    if (!isValidTaskPayloadId(task.id)) {
+    if (!isValidEntityId(task.id)) {
       return {
         success: false,
         error: `UPDATE tasks[${i}] missing valid 'id' field`,
@@ -64,7 +59,7 @@ const validateTaskBatchPayload = (tasks: unknown[]): PayloadValidationResult => 
             error: `UPDATE tasks[${i}].subTasks[${j}] must be an object`,
           };
         }
-        if (!isValidTaskPayloadId(subTask.id)) {
+        if (!isValidEntityId(subTask.id)) {
           return {
             success: false,
             error: `UPDATE tasks[${i}].subTasks[${j}] missing valid 'id' field`,

--- a/src/app/op-log/validation/validate-operation-payload.ts
+++ b/src/app/op-log/validation/validate-operation-payload.ts
@@ -25,6 +25,58 @@ const getEntityKeyFromType = (entityType: EntityType): string | null => {
   return getPayloadKey(entityType) ?? null;
 };
 
+const isValidTaskPayloadId = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  value !== 'undefined' &&
+  value !== 'null';
+
+const validateTaskBatchPayload = (tasks: unknown[]): PayloadValidationResult => {
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i] as Record<string, unknown>;
+    if (!task || typeof task !== 'object' || Array.isArray(task)) {
+      return {
+        success: false,
+        error: `UPDATE tasks[${i}] must be an object`,
+      };
+    }
+
+    if (!isValidTaskPayloadId(task.id)) {
+      return {
+        success: false,
+        error: `UPDATE tasks[${i}] missing valid 'id' field`,
+      };
+    }
+
+    if ('subTasks' in task && task.subTasks !== undefined) {
+      if (!Array.isArray(task.subTasks)) {
+        return {
+          success: false,
+          error: `UPDATE tasks[${i}].subTasks must be an array`,
+        };
+      }
+
+      for (let j = 0; j < task.subTasks.length; j++) {
+        const subTask = task.subTasks[j] as Record<string, unknown>;
+        if (!subTask || typeof subTask !== 'object' || Array.isArray(subTask)) {
+          return {
+            success: false,
+            error: `UPDATE tasks[${i}].subTasks[${j}] must be an object`,
+          };
+        }
+        if (!isValidTaskPayloadId(subTask.id)) {
+          return {
+            success: false,
+            error: `UPDATE tasks[${i}].subTasks[${j}] missing valid 'id' field`,
+          };
+        }
+      }
+    }
+  }
+
+  return { success: true };
+};
+
 /**
  * Attempts to find an entity-like object in the payload.
  * Uses payload keys from the central entity registry.
@@ -147,6 +199,9 @@ const validateUpdatePayload = (
   if (entityKey) {
     const pluralKey = entityKey + 's';
     if (Array.isArray(p[pluralKey])) {
+      if (entityType === 'TASK') {
+        return validateTaskBatchPayload(p[pluralKey] as unknown[]);
+      }
       return { success: true };
     }
   }


### PR DESCRIPTION
## Summary
- sanitize malformed task trees before writing archived task payloads for local archive and remote sync flows
- validate batch TASK payloads more strictly so malformed task and subtask IDs are rejected earlier
- strengthen state repair for broken archive and task relationships and cover the corruption cases with focused tests

## Scope
- this PR contains only the corruption-fix slice cherry-picked onto current origin/master
- changed files are limited to archive, task-service, operation-payload validation, and repair logic plus focused specs

## Related
- fixes #4772
- related to #3205

## Verification
- focused file lint passed locally
- the Angular test runner did not complete in this environment after bundle setup, so no completed ng test result is attached