### PR TITLE
fix(work-view): keep task selected when group/filter shows cross-context tasks

### DIFF
--- a/src/app/features/work-view/work-view.component.spec.ts
+++ b/src/app/features/work-view/work-view.component.spec.ts
@@ -1,0 +1,245 @@
+import { TaskWithSubTasks } from '../tasks/task.model';
+import { TODAY_TAG } from '../tag/tag.const';
+
+/**
+ * Tests for Issue #7269: Detail panel closes immediately when opened for a task
+ * that only appears in the customized/filtered list.
+ *
+ * The WorkViewComponent has a constructor `effect()` that deselects the currently
+ * selected task whenever it is no longer present in any of the visible task lists.
+ * Previously it only consulted the primary context lists (undone / done / later /
+ * overdue / backlog). When the task-view customizer pulls tasks in from other work
+ * contexts, the selected task would not be found in any of those lists and would
+ * be deselected immediately, closing the detail panel.
+ *
+ * The fix additionally checks `customizedUndoneTasks().list` before resetting the
+ * selection. These tests mirror the effect body exactly so that changes to the
+ * logic in `work-view.component.ts` are caught here.
+ *
+ * Note: WorkViewComponent has a large dependency surface (NgRx store,
+ * WorkContextService, TaskService, TaskViewCustomizerService, ProjectService,
+ * GlobalConfigService, SnackService, LayoutService, TakeABreakService,
+ * ActivatedRoute, ...) and its constructor eagerly instantiates several signals
+ * from observables. Instantiating the real component for a unit test therefore
+ * requires mocking a large graph of services. The effect body we care about is
+ * pure given its signal inputs, so we mirror its body in an equivalent helper
+ * and exercise that directly — this keeps the test fast, deterministic and
+ * focused on the regression being fixed.
+ */
+describe('WorkViewComponent - selected task retention effect (#7269)', () => {
+  const buildTask = (overrides: Partial<TaskWithSubTasks> = {}): TaskWithSubTasks =>
+    ({
+      id: 'MOCK_ID',
+      title: 'Mock',
+      isDone: false,
+      tagIds: [],
+      parentId: null,
+      subTaskIds: [],
+      subTasks: [],
+      timeSpentOnDay: {},
+      timeSpent: 0,
+      timeEstimate: 0,
+      reminderId: null,
+      dueWithTime: undefined,
+      dueDay: null,
+      hasPlannedTime: false,
+      repeatCfgId: null,
+      notes: '',
+      issueId: null,
+      issueType: null,
+      issueWasUpdated: null,
+      issueLastUpdated: null,
+      issueTimeTracked: null,
+      attachments: [],
+      projectId: null,
+      _showSubTasksMode: 0,
+      _currentTab: 0,
+      _isTaskPlaceHolder: false,
+      ...overrides,
+    }) as TaskWithSubTasks;
+
+  // Inline copy of WorkViewComponent's private _hasTaskInList helper so the
+  // simulator stays in sync with the real traversal (including subtasks).
+  const hasTaskInList = (
+    taskList: TaskWithSubTasks[] | null | undefined,
+    taskId: string,
+  ): boolean => {
+    if (!taskList || !taskList.length) return false;
+    for (const task of taskList) {
+      if (!task) continue;
+      if (task.id === taskId) return true;
+      const subTasks = task.subTasks;
+      if (Array.isArray(subTasks) && subTasks.length) {
+        for (const subTask of subTasks) {
+          if (subTask && subTask.id === taskId) return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  interface EffectInputs {
+    selectedTaskId: string | null;
+    undoneTasks: TaskWithSubTasks[];
+    doneTasks: TaskWithSubTasks[];
+    laterTodayTasks: TaskWithSubTasks[];
+    overdueTasks: TaskWithSubTasks[];
+    backlogTasks: TaskWithSubTasks[];
+    customizedUndoneTasks: { list: TaskWithSubTasks[] } | undefined;
+    activeWorkContextId: string;
+  }
+
+  /**
+   * Mirrors the constructor effect body in `work-view.component.ts`.
+   * Returns true if `setSelectedId(null)` would be dispatched.
+   */
+  const wouldDeselect = (inputs: EffectInputs): boolean => {
+    const currentSelectedId = inputs.selectedTaskId;
+    if (!currentSelectedId) return false;
+
+    if (hasTaskInList(inputs.undoneTasks, currentSelectedId)) return false;
+    if (hasTaskInList(inputs.doneTasks, currentSelectedId)) return false;
+    if (hasTaskInList(inputs.laterTodayTasks, currentSelectedId)) return false;
+
+    if (
+      inputs.activeWorkContextId === TODAY_TAG.id &&
+      hasTaskInList(inputs.overdueTasks, currentSelectedId)
+    ) {
+      return false;
+    }
+
+    if (hasTaskInList(inputs.backlogTasks, currentSelectedId)) return false;
+
+    // The fix: also consult the customizer's list.
+    if (hasTaskInList(inputs.customizedUndoneTasks?.list, currentSelectedId)) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const baseInputs = (): EffectInputs => ({
+    selectedTaskId: null,
+    undoneTasks: [],
+    doneTasks: [],
+    laterTodayTasks: [],
+    overdueTasks: [],
+    backlogTasks: [],
+    customizedUndoneTasks: { list: [] },
+    activeWorkContextId: 'some-project-id',
+  });
+
+  describe('fix for #7269 - customizer list retention', () => {
+    it('should NOT deselect when the selected task only appears in customizedUndoneTasks.list', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'cross-context-task';
+      inputs.customizedUndoneTasks = {
+        list: [buildTask({ id: 'cross-context-task' })],
+      };
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+
+    it('should NOT deselect when the selected task is a subtask inside customizedUndoneTasks.list', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'nested-sub';
+      inputs.customizedUndoneTasks = {
+        list: [
+          buildTask({
+            id: 'parent',
+            subTasks: [buildTask({ id: 'nested-sub' })],
+          }),
+        ],
+      };
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+  });
+
+  describe('regression - deselect still fires when task is truly gone', () => {
+    it('should deselect when the task is not present in ANY list (including customizedUndoneTasks)', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'ghost-task';
+      inputs.undoneTasks = [buildTask({ id: 'other-1' })];
+      inputs.doneTasks = [buildTask({ id: 'other-2' })];
+      inputs.customizedUndoneTasks = { list: [buildTask({ id: 'other-3' })] };
+
+      expect(wouldDeselect(inputs)).toBe(true);
+    });
+
+    it('should deselect when customizedUndoneTasks is undefined and task is not elsewhere', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'ghost-task';
+      inputs.customizedUndoneTasks = undefined;
+
+      expect(wouldDeselect(inputs)).toBe(true);
+    });
+
+    it('should deselect when customizedUndoneTasks.list is empty and task is not elsewhere', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'ghost-task';
+      inputs.customizedUndoneTasks = { list: [] };
+
+      expect(wouldDeselect(inputs)).toBe(true);
+    });
+  });
+
+  describe('existing behaviour preserved', () => {
+    it('should NOT deselect when selectedTaskId is null', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = null;
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+
+    it('should NOT deselect when the task is in undoneTasks', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'undone-task';
+      inputs.undoneTasks = [buildTask({ id: 'undone-task' })];
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+
+    it('should NOT deselect when the task is in doneTasks', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'done-task';
+      inputs.doneTasks = [buildTask({ id: 'done-task', isDone: true })];
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+
+    it('should NOT deselect when the task is in laterTodayTasks', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'later-task';
+      inputs.laterTodayTasks = [buildTask({ id: 'later-task' })];
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+
+    it('should NOT deselect when the task is in backlogTasks', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'backlog-task';
+      inputs.backlogTasks = [buildTask({ id: 'backlog-task' })];
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+
+    it('should NOT deselect when on TODAY_TAG and task is in overdueTasks', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'overdue-task';
+      inputs.activeWorkContextId = TODAY_TAG.id;
+      inputs.overdueTasks = [buildTask({ id: 'overdue-task' })];
+
+      expect(wouldDeselect(inputs)).toBe(false);
+    });
+
+    it('SHOULD deselect when NOT on TODAY_TAG even if task is in overdueTasks (and nowhere else)', () => {
+      const inputs = baseInputs();
+      inputs.selectedTaskId = 'overdue-task';
+      inputs.activeWorkContextId = 'some-project-id';
+      inputs.overdueTasks = [buildTask({ id: 'overdue-task' })];
+
+      expect(wouldDeselect(inputs)).toBe(true);
+    });
+  });
+});

--- a/src/app/features/work-view/work-view.component.spec.ts
+++ b/src/app/features/work-view/work-view.component.spec.ts
@@ -1,245 +1,237 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { WorkViewComponent } from './work-view.component';
+import { TaskService } from '../tasks/task.service';
+import { TakeABreakService } from '../take-a-break/take-a-break.service';
+import { LayoutService } from '../../core-ui/layout/layout.service';
+import { TaskViewCustomizerService } from '../task-view-customizer/task-view-customizer.service';
+import { WorkContextService } from '../work-context/work-context.service';
+import { ProjectService } from '../project/project.service';
+import { SnackService } from '../../core/snack/snack.service';
+import { GlobalConfigService } from '../config/global-config.service';
 import { TaskWithSubTasks } from '../tasks/task.model';
+import {
+  selectLaterTodayTasksWithSubTasks,
+  selectOverdueTasksWithSubTasks,
+} from '../tasks/store/task.selectors';
+import {
+  selectTaskRepeatCfgsByProjectId,
+  selectTaskRepeatCfgsByTagId,
+} from '../task-repeat-cfg/store/task-repeat-cfg.selectors';
 import { TODAY_TAG } from '../tag/tag.const';
 
 /**
- * Tests for Issue #7269: Detail panel closes immediately when opened for a task
- * that only appears in the customized/filtered list.
+ * Tests for issue #7269: Detail panel closes immediately when opened for a task
+ * that only appears in the task-view customizer's list.
  *
  * The WorkViewComponent has a constructor `effect()` that deselects the currently
  * selected task whenever it is no longer present in any of the visible task lists.
  * Previously it only consulted the primary context lists (undone / done / later /
- * overdue / backlog). When the task-view customizer pulls tasks in from other work
+ * overdue / backlog). When the customizer pulls tasks in from other work
  * contexts, the selected task would not be found in any of those lists and would
  * be deselected immediately, closing the detail panel.
  *
- * The fix additionally checks `customizedUndoneTasks().list` before resetting the
- * selection. These tests mirror the effect body exactly so that changes to the
- * logic in `work-view.component.ts` are caught here.
- *
- * Note: WorkViewComponent has a large dependency surface (NgRx store,
- * WorkContextService, TaskService, TaskViewCustomizerService, ProjectService,
- * GlobalConfigService, SnackService, LayoutService, TakeABreakService,
- * ActivatedRoute, ...) and its constructor eagerly instantiates several signals
- * from observables. Instantiating the real component for a unit test therefore
- * requires mocking a large graph of services. The effect body we care about is
- * pure given its signal inputs, so we mirror its body in an equivalent helper
- * and exercise that directly — this keeps the test fast, deterministic and
- * focused on the regression being fixed.
+ * The fix additionally checks `customizedUndoneTasks().list` before resetting
+ * the selection. These tests exercise the real component; the template is
+ * overridden to a no-op so we don't have to stand up every child component.
  */
-describe('WorkViewComponent - selected task retention effect (#7269)', () => {
-  const buildTask = (overrides: Partial<TaskWithSubTasks> = {}): TaskWithSubTasks =>
-    ({
-      id: 'MOCK_ID',
-      title: 'Mock',
-      isDone: false,
-      tagIds: [],
-      parentId: null,
-      subTaskIds: [],
-      subTasks: [],
-      timeSpentOnDay: {},
-      timeSpent: 0,
-      timeEstimate: 0,
-      reminderId: null,
-      dueWithTime: undefined,
-      dueDay: null,
-      hasPlannedTime: false,
-      repeatCfgId: null,
-      notes: '',
-      issueId: null,
-      issueType: null,
-      issueWasUpdated: null,
-      issueLastUpdated: null,
-      issueTimeTracked: null,
-      attachments: [],
-      projectId: null,
-      _showSubTasksMode: 0,
-      _currentTab: 0,
-      _isTaskPlaceHolder: false,
-      ...overrides,
-    }) as TaskWithSubTasks;
 
-  // Inline copy of WorkViewComponent's private _hasTaskInList helper so the
-  // simulator stays in sync with the real traversal (including subtasks).
-  const hasTaskInList = (
-    taskList: TaskWithSubTasks[] | null | undefined,
-    taskId: string,
-  ): boolean => {
-    if (!taskList || !taskList.length) return false;
-    for (const task of taskList) {
-      if (!task) continue;
-      if (task.id === taskId) return true;
-      const subTasks = task.subTasks;
-      if (Array.isArray(subTasks) && subTasks.length) {
-        for (const subTask of subTasks) {
-          if (subTask && subTask.id === taskId) return true;
-        }
-      }
-    }
-    return false;
-  };
+const buildTask = (id: string, subTasks: TaskWithSubTasks[] = []): TaskWithSubTasks =>
+  ({ id, subTasks }) as unknown as TaskWithSubTasks;
 
-  interface EffectInputs {
-    selectedTaskId: string | null;
-    undoneTasks: TaskWithSubTasks[];
-    doneTasks: TaskWithSubTasks[];
-    laterTodayTasks: TaskWithSubTasks[];
-    overdueTasks: TaskWithSubTasks[];
-    backlogTasks: TaskWithSubTasks[];
-    customizedUndoneTasks: { list: TaskWithSubTasks[] } | undefined;
-    activeWorkContextId: string;
-  }
+describe('WorkViewComponent', () => {
+  describe('selected task retention effect (#7269)', () => {
+    let selectedTaskId: ReturnType<typeof signal<string | null>>;
+    let setSelectedId: jasmine.Spy;
+    let customized$: BehaviorSubject<{ list: TaskWithSubTasks[] }>;
+    let activeWorkContextId: string;
+    let store: MockStore;
 
-  /**
-   * Mirrors the constructor effect body in `work-view.component.ts`.
-   * Returns true if `setSelectedId(null)` would be dispatched.
-   */
-  const wouldDeselect = (inputs: EffectInputs): boolean => {
-    const currentSelectedId = inputs.selectedTaskId;
-    if (!currentSelectedId) return false;
+    const createComponent = async (
+      inputs: {
+        undone?: TaskWithSubTasks[];
+        done?: TaskWithSubTasks[];
+        backlog?: TaskWithSubTasks[];
+      } = {},
+    ): Promise<WorkViewComponent> => {
+      await TestBed.compileComponents();
+      const fixture = TestBed.createComponent(WorkViewComponent);
+      fixture.componentRef.setInput('undoneTasks', inputs.undone ?? []);
+      fixture.componentRef.setInput('doneTasks', inputs.done ?? []);
+      fixture.componentRef.setInput('backlogTasks', inputs.backlog ?? []);
+      fixture.detectChanges();
+      return fixture.componentInstance;
+    };
 
-    if (hasTaskInList(inputs.undoneTasks, currentSelectedId)) return false;
-    if (hasTaskInList(inputs.doneTasks, currentSelectedId)) return false;
-    if (hasTaskInList(inputs.laterTodayTasks, currentSelectedId)) return false;
+    beforeEach(() => {
+      selectedTaskId = signal<string | null>(null);
+      setSelectedId = jasmine.createSpy('setSelectedId');
+      customized$ = new BehaviorSubject<{ list: TaskWithSubTasks[] }>({ list: [] });
+      activeWorkContextId = 'some-project-id';
 
-    if (
-      inputs.activeWorkContextId === TODAY_TAG.id &&
-      hasTaskInList(inputs.overdueTasks, currentSelectedId)
-    ) {
-      return false;
-    }
-
-    if (hasTaskInList(inputs.backlogTasks, currentSelectedId)) return false;
-
-    // The fix: also consult the customizer's list.
-    if (hasTaskInList(inputs.customizedUndoneTasks?.list, currentSelectedId)) {
-      return false;
-    }
-
-    return true;
-  };
-
-  const baseInputs = (): EffectInputs => ({
-    selectedTaskId: null,
-    undoneTasks: [],
-    doneTasks: [],
-    laterTodayTasks: [],
-    overdueTasks: [],
-    backlogTasks: [],
-    customizedUndoneTasks: { list: [] },
-    activeWorkContextId: 'some-project-id',
-  });
-
-  describe('fix for #7269 - customizer list retention', () => {
-    it('should NOT deselect when the selected task only appears in customizedUndoneTasks.list', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'cross-context-task';
-      inputs.customizedUndoneTasks = {
-        list: [buildTask({ id: 'cross-context-task' })],
-      };
-
-      expect(wouldDeselect(inputs)).toBe(false);
-    });
-
-    it('should NOT deselect when the selected task is a subtask inside customizedUndoneTasks.list', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'nested-sub';
-      inputs.customizedUndoneTasks = {
-        list: [
-          buildTask({
-            id: 'parent',
-            subTasks: [buildTask({ id: 'nested-sub' })],
-          }),
+      TestBed.configureTestingModule({
+        imports: [WorkViewComponent, TranslateModule.forRoot()],
+        providers: [
+          provideNoopAnimations(),
+          provideMockStore({ initialState: {} }),
+          {
+            provide: TaskService,
+            useValue: {
+              selectedTaskId,
+              setSelectedId,
+              moveToArchive: () => Promise.resolve(),
+            },
+          },
+          { provide: TakeABreakService, useValue: { resetTimer: () => {} } },
+          {
+            provide: LayoutService,
+            useValue: {
+              isXs: signal(false),
+              isWorkViewScrolled: { set: () => {} },
+              showAddTaskBar: () => {},
+            },
+          },
+          {
+            provide: TaskViewCustomizerService,
+            useValue: {
+              customizeUndoneTasks: () => customized$.asObservable(),
+              isCustomized: signal(false),
+            },
+          },
+          {
+            provide: WorkContextService,
+            useValue: {
+              get activeWorkContextId() {
+                return activeWorkContextId;
+              },
+              undoneTasks$: of([]),
+              todayRemainingInProject$: of(0),
+              estimateRemainingToday$: of(0),
+              workingToday$: of(0),
+              isTodayList$: of(false),
+              activeWorkContextTypeAndId$: of({
+                activeType: 'TAG',
+                activeId: 'TODAY',
+              }),
+              isContextChanging$: of(false),
+            },
+          },
+          { provide: ProjectService, useValue: { onMoveToBacklog$: of() } },
+          { provide: SnackService, useValue: { open: () => {} } },
+          {
+            provide: GlobalConfigService,
+            useValue: {
+              appFeatures: signal({ isFinishDayEnabled: false }),
+              cfg: () => ({}),
+            },
+          },
+          { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
         ],
-      };
+      });
 
-      expect(wouldDeselect(inputs)).toBe(false);
-    });
-  });
+      // Stub the template and imports so children (task-list, backlog, etc.)
+      // don't need to be instantiated. The constructor effect runs without
+      // rendering and this keeps the dependency surface small.
+      TestBed.overrideComponent(WorkViewComponent, {
+        set: { template: '', imports: [], styles: [''] },
+      });
 
-  describe('regression - deselect still fires when task is truly gone', () => {
-    it('should deselect when the task is not present in ANY list (including customizedUndoneTasks)', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'ghost-task';
-      inputs.undoneTasks = [buildTask({ id: 'other-1' })];
-      inputs.doneTasks = [buildTask({ id: 'other-2' })];
-      inputs.customizedUndoneTasks = { list: [buildTask({ id: 'other-3' })] };
-
-      expect(wouldDeselect(inputs)).toBe(true);
-    });
-
-    it('should deselect when customizedUndoneTasks is undefined and task is not elsewhere', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'ghost-task';
-      inputs.customizedUndoneTasks = undefined;
-
-      expect(wouldDeselect(inputs)).toBe(true);
+      store = TestBed.inject(MockStore);
+      store.overrideSelector(selectOverdueTasksWithSubTasks, []);
+      store.overrideSelector(selectLaterTodayTasksWithSubTasks, []);
+      store.overrideSelector(selectTaskRepeatCfgsByProjectId, []);
+      store.overrideSelector(selectTaskRepeatCfgsByTagId, []);
     });
 
-    it('should deselect when customizedUndoneTasks.list is empty and task is not elsewhere', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'ghost-task';
-      inputs.customizedUndoneTasks = { list: [] };
+    it('keeps the selection when the task is only in customizedUndoneTasks.list (bug #7269)', async () => {
+      await createComponent();
+      customized$.next({ list: [buildTask('cross-ctx-1')] });
+      selectedTaskId.set('cross-ctx-1');
+      TestBed.flushEffects();
 
-      expect(wouldDeselect(inputs)).toBe(true);
-    });
-  });
-
-  describe('existing behaviour preserved', () => {
-    it('should NOT deselect when selectedTaskId is null', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = null;
-
-      expect(wouldDeselect(inputs)).toBe(false);
+      expect(setSelectedId).not.toHaveBeenCalled();
     });
 
-    it('should NOT deselect when the task is in undoneTasks', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'undone-task';
-      inputs.undoneTasks = [buildTask({ id: 'undone-task' })];
+    it('keeps the selection when the task is a subtask inside customizedUndoneTasks.list', async () => {
+      await createComponent();
+      customized$.next({
+        list: [buildTask('parent', [buildTask('nested-sub')])],
+      });
+      selectedTaskId.set('nested-sub');
+      TestBed.flushEffects();
 
-      expect(wouldDeselect(inputs)).toBe(false);
+      expect(setSelectedId).not.toHaveBeenCalled();
     });
 
-    it('should NOT deselect when the task is in doneTasks', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'done-task';
-      inputs.doneTasks = [buildTask({ id: 'done-task', isDone: true })];
+    it('deselects when the task is absent from every list (including customizedUndoneTasks)', async () => {
+      await createComponent();
+      customized$.next({ list: [buildTask('other')] });
+      selectedTaskId.set('ghost');
+      TestBed.flushEffects();
 
-      expect(wouldDeselect(inputs)).toBe(false);
+      expect(setSelectedId).toHaveBeenCalledOnceWith(null);
     });
 
-    it('should NOT deselect when the task is in laterTodayTasks', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'later-task';
-      inputs.laterTodayTasks = [buildTask({ id: 'later-task' })];
+    it('keeps the selection when the task is in undoneTasks (existing behaviour)', async () => {
+      await createComponent({ undone: [buildTask('undone-1')] });
+      selectedTaskId.set('undone-1');
+      TestBed.flushEffects();
 
-      expect(wouldDeselect(inputs)).toBe(false);
+      expect(setSelectedId).not.toHaveBeenCalled();
     });
 
-    it('should NOT deselect when the task is in backlogTasks', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'backlog-task';
-      inputs.backlogTasks = [buildTask({ id: 'backlog-task' })];
+    it('keeps the selection when the task is in doneTasks (existing behaviour)', async () => {
+      await createComponent({ done: [buildTask('done-1')] });
+      selectedTaskId.set('done-1');
+      TestBed.flushEffects();
 
-      expect(wouldDeselect(inputs)).toBe(false);
+      expect(setSelectedId).not.toHaveBeenCalled();
     });
 
-    it('should NOT deselect when on TODAY_TAG and task is in overdueTasks', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'overdue-task';
-      inputs.activeWorkContextId = TODAY_TAG.id;
-      inputs.overdueTasks = [buildTask({ id: 'overdue-task' })];
+    it('keeps the selection when the task is in backlogTasks (existing behaviour)', async () => {
+      await createComponent({ backlog: [buildTask('backlog-1')] });
+      selectedTaskId.set('backlog-1');
+      TestBed.flushEffects();
 
-      expect(wouldDeselect(inputs)).toBe(false);
+      expect(setSelectedId).not.toHaveBeenCalled();
     });
 
-    it('SHOULD deselect when NOT on TODAY_TAG even if task is in overdueTasks (and nowhere else)', () => {
-      const inputs = baseInputs();
-      inputs.selectedTaskId = 'overdue-task';
-      inputs.activeWorkContextId = 'some-project-id';
-      inputs.overdueTasks = [buildTask({ id: 'overdue-task' })];
+    it('keeps the selection when on TODAY_TAG and task is in overdueTasks', async () => {
+      activeWorkContextId = TODAY_TAG.id;
+      store.overrideSelector(selectOverdueTasksWithSubTasks, [buildTask('overdue-1')]);
+      store.refreshState();
 
-      expect(wouldDeselect(inputs)).toBe(true);
+      await createComponent();
+      selectedTaskId.set('overdue-1');
+      TestBed.flushEffects();
+
+      expect(setSelectedId).not.toHaveBeenCalled();
+    });
+
+    it('deselects when NOT on TODAY_TAG even if task is in overdueTasks', async () => {
+      activeWorkContextId = 'some-project-id';
+      store.overrideSelector(selectOverdueTasksWithSubTasks, [buildTask('overdue-1')]);
+      store.refreshState();
+
+      await createComponent();
+      selectedTaskId.set('overdue-1');
+      TestBed.flushEffects();
+
+      expect(setSelectedId).toHaveBeenCalledOnceWith(null);
+    });
+
+    it('does nothing when selectedTaskId is null', async () => {
+      await createComponent();
+      selectedTaskId.set(null);
+      TestBed.flushEffects();
+
+      expect(setSelectedId).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/features/work-view/work-view.component.ts
+++ b/src/app/features/work-view/work-view.component.ts
@@ -225,6 +225,11 @@ export class WorkViewComponent implements OnInit, OnDestroy {
       // Check if task is in backlog
       if (this._hasTaskInList(this.backlogTasks(), currentSelectedId)) return;
 
+      // Group/filter may pull tasks from other work contexts into the view;
+      // keep those selected so the detail panel can open for them.
+      if (this._hasTaskInList(this.customizedUndoneTasks()?.list, currentSelectedId))
+        return;
+
       // if task really is gone
       this.taskService.setSelectedId(null);
     });


### PR DESCRIPTION
When Group by project/tag or cross-context filters pulled tasks from other work
contexts into the view, tapping one of those tasks dispatched setSelectedId(id)
but an effect in WorkViewComponent immediately reset it to null because the
task was not in the current context's undone/done/later/overdue/backlog lists.
On mobile this opened the bottom sheet with no task-detail-panel content,
appearing as a blank screen.

Also consult customizedUndoneTasks().list so tasks surfaced via the customizer
keep the selection alive and the detail panel can render.

Fixes #7269

https://claude.ai/code/session_019AwFGKFEEEcBqjp7HdhU17