### PR TITLE
Add GPU startup guard for confined Linux packages

### DIFF
--- a/docs/research/snap-wayland-gpu-fix-research.md
+++ b/docs/research/snap-wayland-gpu-fix-research.md
@@ -271,6 +271,718 @@ including comments). No `electron-builder.yaml` changes required
 
 ---
 
+## 12. Update 2026-04-19 — PR #7273 (GPU startup guard)
+
+**Follow-up to issue [#7270](https://github.com/super-productivity/super-productivity/issues/7270).** Filed
+against v18.2.2, which shipped **before** the Snap+Wayland widening from
+PR #7266. **Timeline correction (verified 2026-04-19):** PR #7266 was
+merged to master but is **NOT** in the v18.2.3 tag
+(`git merge-base --is-ancestor ac7cf7b853 v18.2.3` returns NOT ANCESTOR;
+the `v18.2.3:electron/start-app.ts` only contains the original
+`gnome-platform`-empty probe). The v18.2.3 release was cut from a branch
+that didn't pick up #7266. So 7270's reporter on v18.2.2 is **not**
+helped by updating to v18.2.3 — they need 18.2.4 (or whatever ships
+next with #7266 included). This changes PR #7273's positioning: not a
+"tail 5%" fallback on top of a shipped primary fix, but potentially the
+first released recovery path for confined-Linux users until #7266 ships.
+
+### Mechanism
+
+Presence-based crash marker in `userData`:
+
+1. On launch (confined Linux only: `SNAP || FLATPAK_ID`), check for
+   `.gpu-launch-incomplete`. If present → previous launch failed →
+   append `--disable-gpu` this time.
+2. Unconditionally write the marker.
+3. On `IPC.APP_READY` (after Angular init), unlink the marker.
+
+Env overrides `SP_DISABLE_GPU` / `SP_ENABLE_GPU` work on all platforms
+(useful for debugging and for non-Snap/Flatpak Linux users with broken
+GPUs).
+
+### How this differs from Section 7 Option 5 (rejected)
+
+Option 5 proposed `app.on('child-process-gone')` + relaunch — which
+requires the first-launch GPU crash to actually fire the event (unreliable
+when the process hangs) and a subsequent relaunch inside the same boot
+(bad UX, visible flicker, tray races). PR #7273's marker-file approach:
+
+- Doesn't require catching the crash live — if the main process dies any
+  way, the marker survives.
+- Recovers at the **next user-initiated** launch, not mid-boot. No
+  forced relaunch, no race with the tray/splash.
+- Self-heals after one successful boot (marker removed on `APP_READY`).
+- Works for the crash modes where the GPU process hangs without emitting
+  `child-process-gone` — arguably the dominant failure mode per the
+  symptom breakdown in Section 3 ("tray icon appears, no window ever
+  renders").
+
+The "first-launch UX is bad" objection to Option 5 only partly applies:
+launch #1 still fails, but launch #2 auto-recovers without user action.
+That's strictly better than status quo (permanent failure) and better
+than Option 2 (blanket disable on all Snap users).
+
+### Why `--disable-gpu` (not `--ozone-platform=x11`) here
+
+This is the crucial mechanism difference. `--ozone-platform=x11` keeps
+the GPU process alive on the X11/GLX path — it only dodges the Wayland
+EGL/GBM init. `--disable-gpu` avoids the **hardware GPU / Mesa DRI
+driver load path**, which is the ABI-drift source on confined Snap.
+**Correction per §13 verification:** `--disable-gpu` does NOT guarantee
+"no GPU process at all" — Chromium may still run a GPU process in
+SwiftShader or DisplayCompositor mode (see §13.1§1). But those modes
+don't dlopen Mesa DRI drivers, which is what matters for this bug.
+Trade-off: software rendering only. For Super Productivity (mostly DOM
+and text, little WebGL), the perf loss is negligible; for a broken user
+it's strictly better than a non-launching window.
+
+### Complementary layering (recommended)
+
+| Layer | Where | Who it helps |
+|---|---|---|
+| Snap + Wayland → `--ozone-platform=x11` | `start-app.ts` (shipped in 18.2.3) | ~95% of Snap Wayland users; keeps HW accel |
+| Snap/Flatpak + previous crash → `--disable-gpu` | `gpu-startup-guard.ts` (PR #7273) | Remaining users: Snap X11 with Mesa ABI drift, Flatpak, any future GPU-init regression |
+| Env overrides (`SP_DISABLE_GPU`, `SP_ENABLE_GPU`) | Both | Debugging, user escape hatches |
+| `core24` + `gpu-2404` migration | Packaging | All Snap users, long term (18.3 / 19.0) |
+
+The research doc's Section 7 framed the options as exclusive. PR #7273
+demonstrates they are composable: Option 1 handles the common case with
+no UX regression; PR #7273 handles the tail with one failed launch as
+the cost.
+
+### Risk analysis of PR #7273
+
+| Risk | Likelihood | Mitigation in the PR |
+|---|---|---|
+| User force-quits during normal boot → marker stays → next launch unnecessarily disables GPU | Medium (OS updates, system sleep, SIGKILL on crash elsewhere) | Marker is removed on next `APP_READY`, so cost is capped at one GPU-disabled launch |
+| `APP_READY` IPC doesn't fire (renderer hangs post-Angular-init) → marker never cleared → permanent `--disable-gpu` | Low | Manual escape: `SP_ENABLE_GPU=1` env var or delete `.gpu-launch-incomplete` |
+| Marker write fails (read-only userData, NFS quirks) → guard silently skips, but legacy cleanup still runs | Very low on Snap (`SNAP_USER_COMMON` is always writable) | Errors caught and logged, launch proceeds without guard |
+| False positive on first install after upgrade from a build without the guard | None | Fresh install has no marker; upgrade path writes a new marker on first launch only |
+| `FLATPAK_ID` detection misses edge cases (e.g., custom Flatpak manifests that unset the env) | Low | The env override (`SP_DISABLE_GPU`) still works for those users |
+| `--disable-gpu` breaks a renderer feature we depend on (e.g., WebGL-backed chart) | None identified | SP UI is DOM+text; no WebGL path confirmed |
+| Marker path races with the `app.setPath('userData', ...)` call for Snap (line 149 of `start-app.ts`) | None — PR places `evaluateGpuStartupGuard` **after** the Snap userData redirect | PR comment explicitly flags this invariant |
+
+### Testing gap
+
+PR #7273 does not add tests. The logic is pure (input: userData path + env,
+output: decision) and trivially unit-testable. Copilot's arena entry
+demonstrates the pattern (`should-force-snap-ozone-platform-x11.spec.ts`).
+**Recommended before merge:** extract `evaluateGpuStartupGuard` into a
+pure function over `{ userDataPath, env, platform, fs }` and add a spec
+covering:
+
+- no marker → disableGpu=false, marker written
+- marker present → disableGpu=true, reason='crash-recovery'
+- `SP_ENABLE_GPU=1` overrides a present marker
+- `SP_DISABLE_GPU=1` without marker → disableGpu=true, reason='env'
+- non-confined Linux → disableGpu=false, no marker written
+- legacy marker files unlinked on confined Linux
+
+### Decision
+
+- **Ship PR #7273** as a layered defense on top of 18.2.3's Snap+Wayland
+  X11 guard, with unit tests added before merge.
+- **Do not revert** the Snap+Wayland X11 guard — PR #7273 is not a
+  replacement. X11 keeps HW accel; PR #7273 is the fallback for when
+  X11 isn't enough or isn't gated (e.g., Flatpak).
+- **Keep the `core24` + `gpu-2404` migration scheduled** for 18.3/19.0
+  as the long-term root-cause fix.
+
+### Arena-approach note
+
+Copilot's arena approach (widening the Snap X11 guard to unconditional
+on Snap, regardless of Wayland detection) is a defensible alternative
+to Option 1's Snap+Wayland gate — it handles the "a few X11 reports
+exist" case flagged at medium-high confidence in Section 9. But it
+sacrifices Wayland-native features for every Snap user unconditionally,
+whereas PR #7273 only degrades (and only to software rendering) for
+users who actually failed. PR #7273 is the better defense-in-depth.
+
+---
+
+## 13. Deepened Research on PR #7273 (2026-04-19)
+
+Parallel investigation by two independent research agents. A codex-CLI and
+gemini-CLI were also fired; codex exhausted its budget in search without
+producing a structured section and gemini returned empty — their findings
+are not represented below. Treat the two subsections as complementary
+(13.1 = correctness/mechanism, 13.2 = prior-art/testing/long-term).
+
+### 13.1 Technical Correctness of PR #7273
+
+#### 1. Does `--disable-gpu` actually prevent Mesa/libgbm loading?
+
+**Partially — Section 12's claim "no GPU process = no Mesa load" is
+overstated.** Chromium's [`content/browser/gpu/fallback.md`](https://chromium.googlesource.com/chromium/src/+/60b3c74b7f2ca17a28907fb0b40d9dabeaa48326/content/browser/gpu/fallback.md)
+documents a fallback stack
+`HARDWARE_VULKAN → HARDWARE_GL → SWIFTSHADER → DISPLAY_COMPOSITOR`.
+`--disable-gpu` pops the hardware entries but **does not eliminate the
+GPU process** — it is re-spawned in SwiftShader (CPU, no DRI) or
+DISPLAY_COMPOSITOR mode. Corroborated by
+[chromium-discuss: "The GPU process still runs with --disable-gpu"](https://groups.google.com/a/chromium.org/g/chromium-discuss/c/IIQeveVRLVE)
+and [electron/electron#28164](https://github.com/electron/electron/issues/28164).
+The standard workaround is `--disable-gpu --disable-software-rasterizer`
+together (the PR uses only the first).
+
+What this means for SP: in SwiftShader mode the GPU process does **not**
+open `/dev/dri/*` or load Mesa DRI drivers (SwiftShader is a pure-CPU JIT
+rasterizer; see [Chromium SwiftShader docs](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/swiftshader.md)),
+which is the ABI-drift source we care about. **However**, Ozone platform
+init (Wayland client) and GL-context probing still occur before fallback
+— whether `libgbm.so` is dlopen'd on the SwiftShader path specifically
+on Linux/Ozone is **unverified**; the fallback doc is silent on Linux-
+desktop specifics. On the evidence we have, `--disable-gpu` is *likely
+sufficient* to avoid the `core22-mesa-backports` DRI-driver ABI mismatch
+signature (which is Mesa DRI, not GBM), but Section 12's "no Mesa, no
+libgbm, no DRI" bullet should be softened to "no hardware Mesa DRI
+driver load" — not "no GPU process."
+
+**Recommendation: append `--disable-software-rasterizer` alongside
+`--disable-gpu`** in `evaluateGpuStartupGuard`'s positive branch to
+genuinely suppress GPU-process spawn, eliminating the theoretical
+SwiftShader-GPU-process-init path. Cost is nil (SP has no WebGL
+dependency).
+
+#### 2. `APP_READY` lifecycle
+
+Verified from SP source:
+
+- The renderer sends `APP_READY` synchronously from `AppComponent`'s
+  constructor via `this._startupService.init()` →
+  `window.ea.informAboutAppReady()`
+  (`src/app/core/startup/startup.service.ts:136`, called from
+  `src/app/app.component.ts:195`). This is **before** deferred init
+  (plugins, storage checks) — `DEFERRED_INIT_DELAY_MS = 1000` runs
+  after.
+- Main-side handler: `electron/main-window.ts:278` (unchanged by PR
+  #7273).
+- Window is shown earlier on `ready-to-show`
+  (`electron/main-window.ts:245-246`), which fires when the first frame
+  is ready regardless of Angular bootstrap success. So Section 12's
+  claim that the marker doesn't clear "on blank/broken renderers that
+  still fire `ready-to-show`" is correct.
+
+**Consequence:** if Angular boots but any later feature crashes the
+renderer *after* `APP_READY`, the marker is already gone — next launch
+is treated as clean (correct behavior: Angular init succeeded, so GPU
+init also succeeded). If the renderer crashes *before* `APP_READY` but
+after the window appears, user sees a broken window and next launch
+disables GPU. This is desired for GPU init failures, but **the same
+signal fires for any crash during Angular bootstrap** (dependency
+injection error, CSP violation, corrupt IndexedDB). False-positive rate
+is non-zero but bounded — one GPU-disabled next launch, then
+self-heals.
+
+#### 3. Alternatives to the pre-launch marker
+
+| Signal | More precise? | Verdict |
+|---|---|---|
+| `app.on('child-process-gone', {type:'GPU', reason:'launch-failed'})` | Yes — distinguishes GPU-init from generic renderer crashes ([electronjs.org/docs/latest/api/app](https://www.electronjs.org/docs/latest/api/app) — `launch-failed` = "Process never successfully launched") | **Useful complement**, but unreliable when the GPU process *hangs* rather than exits (Section 12 notes this is the dominant failure mode per Section 3). Also fires mid-launch, forcing a relaunch with its own UX costs. |
+| `app.on('render-process-gone', reason:'crashed')` | No — fires for any renderer crash | Same false-positive surface as the marker, fires mid-launch. |
+| `app.getGPUInfo('complete')` at startup | No — promise is **reported** to never settle on some broken systems ([electron#17187](https://github.com/electron/electron/issues/17187)); Electron docs don't guarantee this behavior | **Reject** — would hang the app on affected systems. |
+| `gpu-info-update` + `getGPUInfo('basic')` | No — basic info always reports `softwareRendering: false` ([electron#17447](https://github.com/electron/electron/issues/17447)) | **Reject.** |
+
+Best pattern: **marker as primary + `child-process-gone` with
+`type:'GPU'` writing a second marker with `reason: 'launch-failed'`** to
+distinguish genuine GPU crashes from generic bootstrap failures in logs.
+The PR's current design is sound; adding the event listener is additive
+and low risk.
+
+#### 4. False-positive stuck markers
+
+Concrete ways the marker gets left behind without a GPU-init crash:
+
+- **systemd session shutdown timeout**: user units get SIGKILL after
+  `DefaultTimeoutStopSec` (90s default) during logout/reboot; see
+  [systemd#4206](https://github.com/systemd/systemd/issues/4206),
+  [Arch forum on `session-c1.scope`](https://bbs.archlinux.org/viewtopic.php?id=227325).
+  Common during OS updates and hibernation-resume cycles.
+- **Snap refresh while running**: snapd kills the old revision on
+  refresh (`snap refresh` mid-session).
+- **OOM killer**: generic OOMs on low-RAM Snap confinement kill the
+  main process cleanly without `APP_READY`.
+- **Ctrl+C during splash / `kill -9` during dev**: leaves marker.
+- **Fast-sleep/hibernate**: if the system suspends between marker write
+  and Angular bootstrap, resume may or may not complete bootstrap
+  depending on renderer state.
+
+Cost per incident: one unnecessary `--disable-gpu` launch. Marker
+self-heals on next `APP_READY`. Section 12's risk table rates this
+"Medium" — accurate.
+
+### 13.2 Prior Art, Testing, and Long-term Strategy
+
+#### Prior art for marker-file / crash-loop startup recovery (Q7)
+
+The pattern — "write a sentinel on entry, clear on success; if present
+next launch, take a safer path" — is well-established but has no single
+canonical name. Common terms in the literature: **"launch-crash
+detection"** (BugSnag), **"crash loop breaker"** (Sentry), and
+**"startup-crash marker"** (Firefox internals).
+
+| Implementation | Mechanism | Source |
+|---|---|---|
+| Firefox | `toolkit.startup.recent_crashes` pref is incremented on startup-without-clean-shutdown and compared against `max_resumed_crashes` to auto-offer Troubleshoot/Safe Mode. Handled in `nsAppRunner.cpp` via `XRE_mainInit`. | [Bugzilla 294260](https://bugzilla.mozilla.org/show_bug.cgi?id=294260), [Bugzilla 745154](https://bugzilla.mozilla.org/show_bug.cgi?id=745154), [nsAppRunner.cpp (searchfox)](https://searchfox.org/firefox-main/source/toolkit/xre/nsAppRunner.cpp) |
+| Chromium | `GpuProcessHost::RecordProcessCrash()` maintains an in-process crash counter; after `kGpuFallbackCrashCount` crashes it pops the next mode off `GpuDataManagerImplPrivate::fallback_modes_` (HW Vulkan → HW GL → SwiftShader → DisplayCompositor). State is **not** disk-persisted across browser restarts — this is the gap PR #7273 fills for Electron apps. | [fallback.md](https://chromium.googlesource.com/chromium/src/+/60b3c74b7f2ca17a28907fb0b40d9dabeaa48326/content/browser/gpu/fallback.md) |
+| BugSnag | 5-second window after `Bugsnag.start()`; exposes `lastRunInfo.crashedDuringLaunch` so apps can self-remediate. | [BugSnag — Identifying crashes at launch (Android)](https://docs.bugsnag.com/platforms/android/identifying-crashes-at-launch/) |
+| Sentry Cocoa | Open feature request for a native crash-loop detector; ecosystem confirms the pattern is general. | [sentry-cocoa #3639](https://github.com/getsentry/sentry-cocoa/issues/3639) |
+| VS Code / Discord / Slack / Obsidian / Figma | **No automatic self-healing found.** All rely on manual user action (`--disable-gpu`, settings toggle, delete GPUCache). | [vscode FAQ](https://code.visualstudio.com/docs/supporting/FAQ), [microsoft/vscode #214446](https://github.com/microsoft/vscode/issues/214446) |
+
+SP PR #7273 is therefore **novel in the Electron ecosystem** but follows
+an established browser-native pattern (Firefox's `recent_crashes`,
+Chromium's in-process `GpuMode` stack). Confidence: high.
+
+#### Flatpak / confinement detection (Q4)
+
+`FLATPAK_ID` **is** reliably set by Flatpak's run machinery and is used
+throughout Flatpak's own docs to construct `~/.var/app/$FLATPAK_ID`
+paths ([Flatpak sandbox-permissions docs](https://docs.flatpak.org/en/latest/sandbox-permissions.html)).
+A more authoritative signal is the presence of `/.flatpak-info` inside
+the sandbox (same doc); recommend adding it as an OR fallback for the
+few manifests that `unset` env vars. **AppImage/.deb are not worth
+guarding** — they don't have the Mesa-ABI-drift failure mode (they use
+the host's Mesa, not a bundled content snap).
+**Snap+NVIDIA-proprietary** (`nvidia-core22`) uses Nvidia's EGL
+implementation, not Mesa ([canonical/nvidia-core22](https://github.com/snapcore/nvidia-core22))
+— the same class of crash-at-init failure can occur (driver/X-server
+mismatch), so the guard triggering there is acceptable collateral, not
+a bug.
+
+#### Testing strategy (Q6)
+
+SP has **no `electron/*.spec.ts` files today** and Karma runs in
+ChromeHeadless (`src/karma.conf.js`), which lacks Node `fs`. Two viable
+options: (a) inject `fs`/`env`/`platform` as parameters so the function
+is pure and testable under Karma with `jasmine.createSpyObj`; (b) add a
+dedicated Node-side test runner. Option (a) is lower-risk and matches
+existing SP util test patterns (see `src/app/util/real-timer.spec.ts`).
+
+```ts
+// electron/gpu-startup-guard.spec.ts  (requires the DI refactor below)
+import { evaluateGpuStartupGuard } from './gpu-startup-guard';
+
+type FakeFs = Pick<typeof import('fs'),
+  'existsSync' | 'writeFileSync' | 'unlinkSync' | 'mkdirSync'>;
+
+const makeFs = (initial: Record<string, boolean> = {}) => {
+  const files: Record<string, boolean> = { ...initial };
+  const fs: FakeFs = {
+    existsSync: (p) => !!files[p as string],
+    writeFileSync: (p) => { files[p as string] = true; },
+    unlinkSync: (p) => {
+      if (!files[p as string]) {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }
+      delete files[p as string];
+    },
+    mkdirSync: () => undefined as any,
+  };
+  return { fs, files };
+};
+
+describe('evaluateGpuStartupGuard', () => {
+  const USER = '/u';
+  const CONFINED = { SNAP: '/snap/sp', XDG_SESSION_TYPE: 'wayland' };
+
+  it('confined + no marker → writes marker, does not disable GPU', () => {
+    const { fs, files } = makeFs();
+    const d = evaluateGpuStartupGuard({ userDataPath: USER, env: CONFINED, platform: 'linux', fs });
+    expect(d.disableGpu).toBeFalse();
+    expect(files[`${USER}/.gpu-launch-incomplete`]).toBeTrue();
+  });
+
+  it('confined + marker present → disables GPU with reason=crash-recovery', () => {
+    const { fs } = makeFs({ [`${USER}/.gpu-launch-incomplete`]: true });
+    const d = evaluateGpuStartupGuard({ userDataPath: USER, env: CONFINED, platform: 'linux', fs });
+    expect(d).toEqual(jasmine.objectContaining({ disableGpu: true, reason: 'crash-recovery' }));
+  });
+
+  it('SP_ENABLE_GPU=1 overrides a present marker', () => {
+    const { fs } = makeFs({ [`${USER}/.gpu-launch-incomplete`]: true });
+    const d = evaluateGpuStartupGuard({
+      userDataPath: USER, env: { ...CONFINED, SP_ENABLE_GPU: '1' }, platform: 'linux', fs,
+    });
+    expect(d.disableGpu).toBeFalse();
+  });
+
+  it('SP_DISABLE_GPU=1 on non-confined Linux → env reason, no marker', () => {
+    const { fs, files } = makeFs();
+    const d = evaluateGpuStartupGuard({
+      userDataPath: USER, env: { SP_DISABLE_GPU: '1' }, platform: 'linux', fs,
+    });
+    expect(d.disableGpu).toBeTrue();
+    expect(d.reason).toBe('env');
+    expect(files[`${USER}/.gpu-launch-incomplete`]).toBeUndefined();
+  });
+
+  it('non-confined Linux → noop, markerPath=null', () => {
+    const { fs } = makeFs();
+    const d = evaluateGpuStartupGuard({ userDataPath: USER, env: {}, platform: 'linux', fs });
+    expect(d).toEqual({ disableGpu: false, reason: null, markerPath: null });
+  });
+
+  it('unlinks legacy marker files on confined Linux', () => {
+    const { fs, files } = makeFs({
+      [`${USER}/.gpu-startup-state`]: true,
+      [`${USER}/.gpu-startup-state.json`]: true,
+    });
+    evaluateGpuStartupGuard({ userDataPath: USER, env: CONFINED, platform: 'linux', fs });
+    expect(files[`${USER}/.gpu-startup-state`]).toBeUndefined();
+    expect(files[`${USER}/.gpu-startup-state.json`]).toBeUndefined();
+  });
+
+  it('fs.writeFileSync throwing does not break the decision', () => {
+    const { fs } = makeFs();
+    fs.writeFileSync = () => { throw new Error('EROFS'); };
+    expect(() =>
+      evaluateGpuStartupGuard({ userDataPath: USER, env: CONFINED, platform: 'linux', fs }),
+    ).not.toThrow();
+  });
+});
+```
+
+Required refactor: change `evaluateGpuStartupGuard(userDataPath)` to
+`evaluateGpuStartupGuard({ userDataPath, env, platform, fs })` with
+defaults from `process`/`fs` at the call-site in `start-app.ts`. No
+behavior change, fully unit-testable.
+
+#### Edge cases (Q8, Q9)
+
+- **`SP_ENABLE_GPU=1` with a present marker**: PR #7273 returns early
+  **before** the marker is written — but the marker-path is still
+  computed (`isConfinedLinux` branch above the env checks), so
+  `markStartupSuccess()` later unlinks it on `APP_READY`. Net effect:
+  the override **does** clear the marker on success. That is correct:
+  the user asserted "GPU is fine now," a successful boot confirms it,
+  and fresh crash tracking starts from zero. If the override is
+  removed and GPU fails again, the *next* launch writes a fresh marker
+  and the one after that triggers recovery — two failed launches to
+  re-trigger, one more than without the override. Acceptable tradeoff;
+  document it. Confidence: high.
+- **Legacy marker cleanup**: the legacy files were never shipped in a
+  release (per PR description "earlier iterations of this guard");
+  blind `unlinkSync` with swallowed ENOENT is safe. **Recommend
+  time-limiting** the cleanup: keep it through 18.3, remove in 19.0 —
+  leaving unused `fs.unlinkSync` calls in a hot startup path is
+  clutter. Risk of leaving it permanent: near zero (two extra stat
+  calls on Snap/Flatpak launch).
+
+#### Long-term strategy (Q10)
+
+PR #7273 is a **genuine stopgap**, not a replacement for `core24` +
+`gpu-2404` migration. Rationale:
+1. `--disable-gpu` forces software rendering — fine for SP's DOM/text
+   UI but still a visible perf regression vs. HW-accelerated X11/GLX
+   (SP's v18.2.3 path).
+2. `core24` + `gpu-2404` fixes the **root cause** (Mesa ABI drift),
+   keeping HW accel for all Snap users without the one-failed-launch
+   penalty.
+3. The layered model (18.2.3 X11 guard → PR #7273 GPU-disable fallback
+   → eventually `gpu-2404`) is robust: even after the migration, the
+   marker guard remains cheap insurance for future Chromium/Mesa
+   regressions (e.g., the recurring Electron 38/Tahoe-style
+   breakages —
+   [AppleInsider 2025-10](https://appleinsider.com/articles/25/10/10/update-your-slack-discord-clients-the-electron-tahoe-gpu-slowdown-bug-is-fixed)).
+
+**Recommendation: keep 18.3/19.0 `gpu-2404` migration scheduled; treat
+PR #7273 as permanent defense-in-depth, not a delete-later hack.**
+Confidence: high.
+
+### 13.3 Independent validation (codex CLI)
+
+A third independent agent (codex CLI, read-only) reviewed the same
+material and converged on the same core findings as 13.1 and 13.2.
+Notable agreement:
+
+- **`--disable-gpu` overclaim** — codex independently cites Chromium's
+  own [GPU integration tests](https://chromium.googlesource.com/chromium/src/+/c0a0e9d983dee38d425cdc207b54b102780ab336/content/test/gpu/gpu_tests/gpu_process_integration_test.py)
+  which expect a GPU process under `--disable-gpu` on Linux and test
+  `--disable-gpu --disable-software-rasterizer` together as the
+  "no GPU process" case. Three independent sources (Claude agents 1 +
+  2, codex) converge on the same recommendation: **append
+  `--disable-software-rasterizer`**.
+- **`APP_READY` framing**: codex proposes clearer wording —
+  `APP_READY` means "startup succeeded enough to use the app," not
+  "all later renderer failures are covered." Recommend applying this
+  in-line in Section 12.
+- **Prior art honesty**: codex explicitly labels "crash sentinel" /
+  "unclean-shutdown marker" as *informal inference*, not a verified
+  upstream term. 13.2 cites BugSnag/Sentry/Firefox labels but the SP-
+  specific `userData` variant isn't in peer Electron apps.
+  Confidence: medium, not high.
+- **`SP_ENABLE_GPU=1` marker-clearing**: codex independently reaches
+  the same conclusion as 13.2 (successful boot acknowledges prior
+  crash; matches browser convention). If a one-shot diagnostic
+  override is ever wanted that does *not* acknowledge success, it
+  should be a separate env var.
+
+Codex's unique contribution:
+
+- **Structured marker payload (optional)**: replace the zero-byte
+  marker with a tiny JSON `{ ts, reason?, gpuChildGone? }` populated
+  from `app.on('child-process-gone', {type:'GPU'})` and
+  `render-process-gone` listeners fired before `APP_READY`. Cost:
+  same fs call path, same semantics; gain: post-incident forensics
+  without a telemetry system. This is a cleaner upgrade path than
+  the two-marker scheme proposed in 13.1§3.
+- **2-strike counter as a next-step refinement** if false-positive
+  rate becomes noisy — matches Firefox's `max_resumed_crashes`
+  behavior. Downside: delays recovery by one extra failed launch.
+  Defer unless warranted by real reports.
+
+### 13.4 Actionable edits to PR #7273
+
+Ordered by importance:
+
+1. **Add `--disable-software-rasterizer` alongside `--disable-gpu`** in
+   `start-app.ts` when the guard triggers. Without it, Chromium
+   respawns the GPU process in SwiftShader mode — still a GPU process,
+   still runs Ozone init. See 13.1§1.
+2. **Refactor `evaluateGpuStartupGuard` to take an options object** so
+   `fs`, `env`, and `platform` can be injected — enables Karma unit
+   tests (see 13.2§Testing). Then add the `.spec.ts` above.
+3. **Add `/.flatpak-info` existence check as an OR fallback** to the
+   `FLATPAK_ID` detection. Cheap, covers manifests that unset the env
+   var.
+4. **(Optional) Add `app.on('child-process-gone', …)` listener** that
+   logs `reason` to the main-process log when `type: 'GPU'` — gives
+   telemetry (in logs) without building a telemetry system, and
+   confirms the guard is firing for the intended cause.
+5. **Time-box the legacy-marker cleanup** to be removed in 19.0. Add a
+   TODO comment.
+6. **(Optional forensics)** Replace the zero-byte marker with a tiny
+   JSON payload `{ ts, reason?, gpuChildGone? }` populated from
+   `child-process-gone`/`render-process-gone` listeners. Cost: same
+   code path; gain: post-incident forensics without telemetry.
+
+None of these block merging. #1 is the highest-impact correctness fix —
+it closes the gap where `--disable-gpu` alone still lets Chromium respawn
+the GPU process in SwiftShader mode (independently identified by all
+three research agents).
+
+---
+
+## 14. Verification Pass 2 — 2026-04-19 (multi-agent)
+
+Four independent agents (two Claude research-architects, one Claude
+code-reviewer, one codex CLI) adversarially reviewed Sections 12–13 and
+PR #7273. The findings below are verified (citations fetched, code
+grepped) or explicitly rejected where agents disagreed.
+
+### Corrections applied in-place above
+
+- **§12 timeline**: v18.2.3 does NOT contain #7266's X11 widening
+  (verified via `git merge-base`).
+- **§12 `--disable-gpu` claim**: softened from "not spawn a GPU process
+  at all" to "avoids the hardware GPU / Mesa DRI driver load path."
+  Chromium still spawns a GPU process in SwiftShader or
+  DisplayCompositor modes.
+- **§13.1 alternatives table**: softened `getGPUInfo('complete')` from
+  "documented to never settle" to "reported."
+- **§11 References**: re-labeled Bugzilla 745154 as a weak reference.
+
+### Outstanding corrections not yet applied (pending maintainer review)
+
+- **§11 References attribution**: the `--disable-gpu` / SwiftShader
+  behavior claim is currently attributed to Chromium's `fallback.md`.
+  It should be attributed to the [chromium-discuss thread](https://groups.google.com/a/chromium.org/g/chromium-discuss/c/IIQeveVRLVE)
+  and the [GPU process integration test](https://chromium.googlesource.com/chromium/src/+/c0a0e9d983dee38d425cdc207b54b102780ab336/content/test/gpu/gpu_tests/gpu_process_integration_test.py)
+  (which explicitly expects a GPU process under `--disable-gpu` on
+  Linux, and tests `--disable-gpu --disable-software-rasterizer` as
+  "no GPU process"). `fallback.md` documents the mode stack but not
+  the Linux `--disable-gpu` behavior.
+- **§13.1§1 `--disable-software-rasterizer` strength**: codex's
+  verification cautions that DISPLAY_COMPOSITOR is still a GPU-process
+  mode, so that flag doesn't *guarantee* "no GPU process" either.
+  Keep the flag as cheap belt-and-braces (no WebGL dep in SP) but
+  drop the framing that it fully suppresses the GPU process.
+
+### Disagreements resolved
+
+- **"`SP_ENABLE_GPU=1` crash leaves no marker → no recovery"** (Agents
+  B and C): **rejected.** A stale marker from a *previous* crash
+  persists across the override path — the early return at `pr7273.diff:54`
+  does not clear the marker, it just returns early before potentially
+  writing a fresh one. Sequence: crash → marker written →
+  override-launch with `SP_ENABLE_GPU=1` → early return, marker stays →
+  crash again → next launch without override → existing marker
+  triggers recovery. Codex correctly traced this. Agents B and C
+  overstated the problem.
+- **Remaining edge case**: first-ever launch where the user sets
+  `SP_ENABLE_GPU=1` AND a crash occurs AND no marker has ever been
+  written — costs +1 extra crashed launch before recovery. Acceptable;
+  document in PR.
+- **Oscillation for genuinely broken GPU with no user action**: every-
+  other-launch pattern (crash → recover → retry → crash → recover…).
+  That's the designed retry-after-recovery behavior — cost is half of
+  launches are bad until root cause is fixed or user sets
+  `SP_DISABLE_GPU=1`. Reasonable tradeoff; note in the PR docs.
+
+- **"APP_READY fires from AppComponent constructor"** (Agent B,
+  corrected by Agent D): reworded. `APP_READY` is sent from the
+  synchronous body of `StartupService.init()` (async function; no
+  awaits precede it on the Electron path today). The constructor
+  *calls* `init()` but doesn't *fire* `APP_READY` itself. Brittle to
+  upstream refactor (adding an `await` earlier would shift timing).
+- **"`_initBackups()` is awaited and can strand APP_READY"** (Agent
+  C): **rejected.** `startup.service.ts:104` is `this._initBackups();`
+  (no `await`) — fire-and-forget. `informAboutAppReady()` at line 136
+  runs in the same microtask.
+
+### New risks surfaced (not in §12 / §13.1–13.4)
+
+- **Aggregate stuck-marker rate on laptops** (§13 risks understated):
+  frequent suspend/hibernate can leave markers without a real GPU
+  crash. Consider time-bounding the marker (e.g., ignore if marker age
+  > 5 minutes — suggests systemd shutdown SIGKILL, not a fast GPU
+  crash).
+- **First-install `mkdirSync` is load-bearing**: on first-ever Snap
+  install, `$SNAP_USER_COMMON/.config/superproductivity` does not
+  exist. Electron's `app.setPath('userData', …)` does NOT create the
+  directory. The PR's `fs.mkdirSync(userDataPath, {recursive: true})`
+  on line 80 is what makes first launch work. Worth a
+  comment/invariant. Add a test case.
+- **Module-level `markerPath` not reset on non-confined path**:
+  `pr7273.diff:27` is `let markerPath: string | null = null;` but the
+  non-confined early return on line 61 returns `markerPath: null`
+  without resetting the module variable. Adds a subtle bug if the
+  function is called twice (tests, reinit). Set `markerPath = null`
+  on the non-confined branch.
+- **`isTruthyEnv` asymmetry**: `SP_DISABLE_GPU=0` is treated as unset
+  (regex `/^(1|true|yes|on)$/i`). Users may intuitively set
+  `SP_DISABLE_GPU=0` expecting to force GPU back on — wrong; use
+  `SP_ENABLE_GPU=1`. Document.
+- **`--disable-gpu-sandbox` as intermediate step**: on Snap-confined
+  Electron, GPU sandbox init can fail independently of Mesa ABI drift.
+  A 2-step ladder (first crash → `--disable-gpu-sandbox`; second
+  crash → `--disable-gpu`) would preserve HW accel for sandbox-only
+  failures. Defer unless reports come in.
+
+### Citation integrity
+
+Agent A verified the high-risk citations. Summary:
+
+- **Confirmed verbatim**: Chromium `fallback.md` stack order; GPU
+  integration test (`_GpuProcess_disable_gpu_and_swiftshader` +
+  `_GpuProcess_disable_gpu`); electron/electron #28164, #17187,
+  #17447; Bugzilla 294260; BugSnag docs; chromium-discuss thread;
+  canonical `gpu-2404` ("evolution" wording); electron-builder
+  #9452; snapcrafters signal-desktop wrapper (`--disable-gpu` default
+  ON); snapcrafters mattermost-desktop (`glxinfo llvmpipe` probe +
+  `jq` config patch); AppleInsider Tahoe article (confirmed via
+  secondary sources).
+- **Misattributed**: Chromium `fallback.md` does NOT document the
+  `--disable-gpu` Linux behavior. Reattribute to chromium-discuss +
+  integration test (see "Outstanding corrections" above).
+- **Weak**: Bugzilla 745154 (already relabeled).
+- **Imprecise**: electron-builder#4587 is about `build.linux.executableArgs`,
+  not `build.snap.executableArgs` directly — the snap-scoped
+  brokenness is inferred from the same root cause. Clarify in §6.
+- **Not reachable via WebFetch**: Firefox `nsAppRunner.cpp` (file too
+  large). Logic exists per Bug 294260; cite a specific searchfox
+  anchor instead of the whole file.
+
+## 15. Final PR #7273 Re-evaluation
+
+**Verdict: Approve with changes.** The design is sound; the
+implementation has three real bugs, two documentation gaps, and one
+mechanically-wrong code comment. None are blockers.
+
+### Bugs to fix before merge
+
+1. **PR code comment in `start-app.ts` (lines 145–154 of the diff) is
+   mechanically wrong.** It says `--disable-gpu` "suppresses GPU-process
+   spawn." That's false on Linux — Chromium respawns the GPU process in
+   SwiftShader or DisplayCompositor mode. Reword to: `--disable-gpu`
+   avoids the hardware Mesa DRI driver load path, which is the source
+   of the Snap ABI-drift crash. The GPU process may still run in
+   software mode.
+
+2. **Module-level `markerPath` not reset on the non-confined early
+   return** (`pr7273.diff:27, 60-62`). Add `markerPath = null;` before
+   the non-confined return. Makes the function idempotent — otherwise
+   a second call from a test or reinit retains the previous value.
+
+3. **First-launch `mkdirSync` invariant undocumented.** The
+   `fs.mkdirSync(userDataPath, {recursive: true})` on line 80 is
+   load-bearing for fresh Snap installs (Electron's `app.setPath`
+   doesn't create the directory). Add a comment; add a test case.
+
+### Documentation gaps
+
+4. **`SP_ENABLE_GPU=1` semantics**: document that (a) overriding
+   with a crash during that launch means +1 extra bad launch before
+   recovery kicks in on the next normal launch, not infinite
+   oscillation; (b) `SP_DISABLE_GPU=0` does NOT turn recovery off —
+   it's parsed as unset; use `SP_ENABLE_GPU=1` for that.
+
+5. **Oscillation behavior for genuinely broken GPU**: the every-other-
+   launch pattern is by design (retry after each recovery). Note it
+   in the PR body so users understand the expected experience until
+   they fix the root cause or set `SP_DISABLE_GPU=1` persistently.
+
+### Strongly recommended additions
+
+6. **Add `--disable-software-rasterizer` alongside `--disable-gpu`**
+   (§13.4 item 1): cheap belt-and-braces; SP has no WebGL dependency.
+   Drop the "fully suppresses GPU process" framing — at most claim
+   "avoids software-GL fallback initialization."
+
+7. **Extract `evaluateGpuStartupGuard` to a pure function with
+   injected `fs`/`env`/`platform`** and add the unit test file from
+   §13.2. This is the largest correctness gap — there are no tests
+   today. The refactor is mechanical and doesn't change behavior.
+
+### Deferred / optional
+
+8. **Time-bound the marker**: if `fs.statSync(markerPath).mtime` is
+   older than N minutes (5–10), assume systemd SIGKILL / snap refresh
+   rather than a GPU crash and skip recovery. Cut false-positive rate
+   on suspended laptops. Defer until reports confirm this is noisy.
+
+9. **`--disable-gpu-sandbox` as intermediate step**: Chromium-style
+   2-step ladder. Defer until a sandbox-specific failure is reported.
+
+10. **Structured JSON marker payload** (§13.3 codex suggestion):
+    `{ ts, reason?, gpuChildGone? }` populated from
+    `child-process-gone`/`render-process-gone` listeners. Cleaner
+    forensics than a zero-byte marker. Defer — can be added without
+    breaking compatibility.
+
+11. **Add `/.flatpak-info` existence check as OR fallback to
+    `FLATPAK_ID`**. Covers manifests that unset env vars. Cheap.
+
+12. **Time-box the legacy-marker cleanup** (remove in 19.0) with a
+    TODO comment.
+
+### Ordering recommendation (revised)
+
+1. **Ship PR #7266 (X11 widening) in 18.2.4** first — it covers ~95%
+   of affected Snap users with no UX regression (HW accel preserved
+   via X11/GLX). This was already the doc's primary recommendation;
+   the verification revealed it was NOT in v18.2.3 as previously
+   assumed.
+2. **Ship PR #7273 (GPU guard) alongside or immediately after**, with
+   fixes 1–3 above and the tests from item 7.
+3. **Schedule `core24` + `gpu-2404` migration** for 18.3/19.0 as the
+   root-cause fix.
+
+### Confidence
+
+- **High** that PR #7273 is the right *class* of fix for the residual
+  tail that PR #7266 doesn't cover (GPU process hangs without
+  `child-process-gone`, Flatpak, X11 users with ABI-drifted Mesa).
+- **High** that the three bugs listed above are real and should be
+  fixed before merge.
+- **Medium** that the documentation gaps are worth the effort —
+  could land as PR description edits, not code.
+- **Medium** that `--disable-software-rasterizer` meaningfully
+  improves the recovery path — evidence base is a single
+  chromium-discuss thread and an integration test, both of uncertain
+  currency against Chromium 146.
+
+---
+
 ## 11. References
 
 - [Snapcraft forum #40975](https://forum.snapcraft.io/t/40975) — "DRI driver not from this Mesa build" error signature (reported in a **core24 + experimental gnome** stack, not gnome-42-2204; the error string is real but the environment differs)
@@ -278,6 +990,24 @@ including comments). No `electron-builder.yaml` changes required
 - [electron-builder#9452](https://github.com/electron-userland/electron-builder/issues/9452) — **strongest external reference.** "Snap package of Electron ≥ 38 crashes at startup under GNOME on Wayland"; maintainer engagement; `--ozone-platform=x11` confirmed working
 - [electron-builder#4587](https://github.com/electron-userland/electron-builder/issues/4587) — `snap.executableArgs` silently ignored for snap builds (why mechanism #3 in Section 6 is unusable)
 - [electron/electron#48298](https://github.com/electron/electron/issues/48298) / [PR #48301](https://github.com/electron/electron/pull/48301) — Electron 38.0.0/38.1.0 Wayland auto-detection regression, fixed in 38.2.0
+- [super-productivity#7270](https://github.com/super-productivity/super-productivity/issues/7270) — Snap launch failure on Ubuntu 22.04 / v18.2.2 (no logs); triggered this follow-up
+- [super-productivity#7273](https://github.com/super-productivity/super-productivity/pull/7273) — GPU startup guard (orthogonal defense, analyzed in Sections 12–13)
+- [Chromium `content/browser/gpu/fallback.md`](https://chromium.googlesource.com/chromium/src/+/60b3c74b7f2ca17a28907fb0b40d9dabeaa48326/content/browser/gpu/fallback.md) — documents `HARDWARE_VULKAN → HARDWARE_GL → SWIFTSHADER → DISPLAY_COMPOSITOR` fallback stack; why `--disable-gpu` alone doesn't eliminate the GPU process
+- [Chromium SwiftShader docs](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/swiftshader.md) — JIT CPU rasterizer, no DRI
+- [chromium-discuss — GPU process still runs with --disable-gpu](https://groups.google.com/a/chromium.org/g/chromium-discuss/c/IIQeveVRLVE)
+- [electron/electron#28164](https://github.com/electron/electron/issues/28164) — `--disable-gpu` doesn't suppress the GPU process
+- [electron/electron#17187](https://github.com/electron/electron/issues/17187) — `getGPUInfo('complete')` never settles on broken systems
+- [electron/electron#17447](https://github.com/electron/electron/issues/17447) — `getGPUInfo('basic')` always reports `softwareRendering: false`
+- [Electron `app` API docs](https://www.electronjs.org/docs/latest/api/app) — `child-process-gone` event, `launch-failed` reason
+- [Mozilla Bugzilla 294260](https://bugzilla.mozilla.org/show_bug.cgi?id=294260) — Firefox Safe Mode auto-detection via `toolkit.startup.recent_crashes`
+- [Mozilla Bugzilla 745154](https://bugzilla.mozilla.org/show_bug.cgi?id=745154) — suppresses `recent_crashes` auto-safe-mode in debug builds (weak reference; 294260 is the authoritative source)
+- [Firefox `nsAppRunner.cpp` (searchfox)](https://searchfox.org/firefox-main/source/toolkit/xre/nsAppRunner.cpp) — implementation of startup-crash marker
+- [BugSnag — Identifying crashes at launch (Android)](https://docs.bugsnag.com/platforms/android/identifying-crashes-at-launch/) — `lastRunInfo.crashedDuringLaunch` pattern
+- [sentry-cocoa #3639](https://github.com/getsentry/sentry-cocoa/issues/3639) — open crash-loop detector feature request
+- [microsoft/vscode #214446](https://github.com/microsoft/vscode/issues/214446) — VS Code GPU toggle is manual
+- [systemd #4206](https://github.com/systemd/systemd/issues/4206) — user-instance SIGKILL on shutdown timeout (stuck-marker source)
+- [Flatpak sandbox-permissions docs](https://docs.flatpak.org/en/latest/sandbox-permissions.html) — `FLATPAK_ID` env and `/.flatpak-info` inside sandbox
+- [canonical/nvidia-core22](https://github.com/snapcore/nvidia-core22) — Nvidia EGL content snap (not Mesa)
 - [Electron 38.0.0 release blog](https://www.electronjs.org/blog/electron-38-0) — "Electron now runs as a native Wayland app by default when launched in a Wayland session on Linux"
 - [Canonical — gpu-2404 interface](https://canonical.com/mir/docs/the-gpu-2404-snap-interface) — describes gpu-2404 as an "evolution" of graphics-core22 (Canonical's wording, not "deprecation")
 - [Canonical RFC — gpu-2404 migration](https://forum.snapcraft.io/t/rfc-migrating-gnome-and-kde-snapcraft-extensions-to-gpu-2404-userspace-interface/39718)

--- a/docs/research/snap-wayland-gpu-fix-research.md
+++ b/docs/research/snap-wayland-gpu-fix-research.md
@@ -286,6 +286,14 @@ next with #7266 included). This changes PR #7273's positioning: not a
 "tail 5%" fallback on top of a shipped primary fix, but potentially the
 first released recovery path for confined-Linux users until #7266 ships.
 
+**Empirical confirmation (2026-04-19):** issue 7270's reporter
+confirmed that `superproductivity --ozone-platform=x11` resolves their
+launch failure on Ubuntu 22.04 / 18.2.2-snap. Direct evidence that the
+Mesa ABI-drift diagnosis is correct and #7266's X11 widening is the
+right primary fix. PR #7273 (GPU guard) remains useful as
+defense-in-depth for the tail X11 doesn't rescue (Flatpak, Snap+X11
+with still-drifted Mesa, future Chromium/Mesa regressions).
+
 ### Mechanism
 
 Presence-based crash marker in `userData`:

--- a/electron/gpu-startup-guard.ts
+++ b/electron/gpu-startup-guard.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs';
+import { join } from 'path';
+import { log } from 'electron-log/main';
+
+// Persisted between launches so we can tell whether the previous process
+// ever reached `ready-to-show`. Only read/written on Linux, where GPU init
+// failures on confined packages (Snap + Mesa ABI drift, etc.) can leave the
+// main process alive while the renderer never displays.
+const MARKER_FILENAME = '.gpu-startup-state';
+const MARKER_LAUNCHING = 'launching';
+const MARKER_OK = 'ok';
+
+const isTruthyEnv = (v: string | undefined): boolean =>
+  v === '1' || v === 'true' || v === 'TRUE';
+
+let markerPath: string | null = null;
+
+export interface GpuGuardDecision {
+  disableGpu: boolean;
+  reason: 'env' | 'crash-recovery' | null;
+}
+
+/**
+ * Evaluate whether to pass `--disable-gpu` on this launch and write a
+ * `launching` marker so a future launch can detect a crash loop.
+ *
+ * Must run after `app.setPath('userData', ...)` (so the marker lands in the
+ * right directory) but before `app.whenReady()` resolves (so the switch
+ * still takes effect). Safe to call on all platforms; does nothing on
+ * non-Linux hosts where the Snap/Mesa failure modes don't apply.
+ */
+export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision => {
+  const userDisable = isTruthyEnv(process.env.SP_DISABLE_GPU);
+  const userEnable = isTruthyEnv(process.env.SP_ENABLE_GPU);
+
+  if (process.platform !== 'linux') {
+    return { disableGpu: userDisable && !userEnable, reason: userDisable ? 'env' : null };
+  }
+
+  markerPath = join(userDataPath, MARKER_FILENAME);
+
+  let previousCrash = false;
+  try {
+    if (fs.existsSync(markerPath)) {
+      const content = fs.readFileSync(markerPath, 'utf8').trim();
+      previousCrash = content === MARKER_LAUNCHING;
+    }
+  } catch (e) {
+    log('gpu-startup-guard: failed to read marker', e);
+  }
+
+  try {
+    fs.mkdirSync(userDataPath, { recursive: true });
+    fs.writeFileSync(markerPath, MARKER_LAUNCHING);
+  } catch (e) {
+    log('gpu-startup-guard: failed to write marker', e);
+  }
+
+  if (userEnable) {
+    return { disableGpu: false, reason: null };
+  }
+  if (userDisable) {
+    return { disableGpu: true, reason: 'env' };
+  }
+  if (previousCrash) {
+    return { disableGpu: true, reason: 'crash-recovery' };
+  }
+  return { disableGpu: false, reason: null };
+};
+
+/**
+ * Called once the main window has rendered at least one frame
+ * (`ready-to-show`). Clears the crash marker so the next launch is treated
+ * as a clean start.
+ */
+export const markStartupSuccess = (): void => {
+  if (!markerPath) return;
+  try {
+    fs.writeFileSync(markerPath, MARKER_OK);
+  } catch (e) {
+    log('gpu-startup-guard: failed to mark startup success', e);
+  }
+};

--- a/electron/gpu-startup-guard.ts
+++ b/electron/gpu-startup-guard.ts
@@ -18,7 +18,8 @@ const LEGACY_MARKER_FILES = ['.gpu-startup-state', '.gpu-startup-state.json'];
 const isTruthyEnv = (v: string | undefined): boolean =>
   !!v && /^(1|true|yes|on)$/i.test(v.trim());
 
-let markerPath: string | null = null;
+const errCode = (e: unknown): string | undefined =>
+  (e as NodeJS.ErrnoException | undefined)?.code;
 
 export interface GpuGuardDecision {
   disableGpu: boolean;
@@ -32,17 +33,21 @@ export interface GpuGuardDecision {
  * Linux — the failure mode this guards against is specific to confined
  * packages with drifting Mesa stacks. `SP_DISABLE_GPU` / `SP_ENABLE_GPU`
  * env vars work everywhere.
+ *
+ * Returns the marker path so the caller can hand it to
+ * `markStartupSuccess` when the renderer signals boot completion. Holding
+ * no module-level state keeps the function idempotent across calls (tests,
+ * reinit) and removes a coupling that previously required runtime state
+ * resets to stay consistent.
  */
 export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision => {
   const isConfinedLinux =
     process.platform === 'linux' && (!!process.env.SNAP || !!process.env.FLATPAK_ID);
 
-  // Set the module-level marker path unconditionally on confined Linux so
-  // `markStartupSuccess` can clean up a stale marker even when this launch
-  // took an env-var override path and never checked it.
-  if (isConfinedLinux) {
-    markerPath = join(userDataPath, MARKER_FILE);
-  }
+  // Marker path is only meaningful under confinement; env-override paths
+  // still need it so markStartupSuccess can clean up a stale marker left
+  // by a previous (non-override) crashed launch.
+  const markerPath = isConfinedLinux ? join(userDataPath, MARKER_FILE) : null;
 
   if (isTruthyEnv(process.env.SP_ENABLE_GPU)) {
     return { disableGpu: false, reason: null, markerPath };
@@ -51,17 +56,9 @@ export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision 
     return { disableGpu: true, reason: 'env', markerPath };
   }
 
-  if (!isConfinedLinux) {
-    // Reset module-level state so a second call (tests, reinit) doesn't
-    // leak a previous confined-launch's path into markStartupSuccess().
-    markerPath = null;
+  if (!isConfinedLinux || !markerPath) {
     return { disableGpu: false, reason: null, markerPath: null };
   }
-
-  // Narrow markerPath for fs calls below — it was set on the
-  // isConfinedLinux branch above, but TS can't track module-let
-  // assignment across the early returns.
-  const activeMarker: string = markerPath as string;
 
   for (const old of LEGACY_MARKER_FILES) {
     try {
@@ -73,35 +70,38 @@ export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision 
 
   let previousCrash = false;
   try {
-    previousCrash = fs.existsSync(activeMarker);
+    previousCrash = fs.existsSync(markerPath);
   } catch (e) {
-    log('gpu-startup-guard: failed to read marker', e);
+    log('gpu-startup-guard: failed to read marker', { code: errCode(e) });
   }
 
   // mkdirSync is load-bearing on first-ever install: Electron's
-  // `app.setPath('userData', ...)` does NOT create the directory, so
-  // $SNAP_USER_COMMON/.config/superproductivity may not exist yet on the
-  // first launch of a fresh Snap install. Without this, writeFileSync
-  // would fail silently and the guard would never write a marker.
+  // `app.setPath('userData', ...)` does NOT create the directory.
   try {
     fs.mkdirSync(userDataPath, { recursive: true });
-    fs.writeFileSync(activeMarker, '');
   } catch (e) {
-    log('gpu-startup-guard: failed to write marker', e);
+    log('gpu-startup-guard: failed to create userData dir', { code: errCode(e) });
+  }
+  try {
+    fs.writeFileSync(markerPath, '');
+  } catch (e) {
+    log('gpu-startup-guard: failed to write marker', { code: errCode(e) });
   }
 
   return {
     disableGpu: previousCrash,
     reason: previousCrash ? 'crash-recovery' : null,
-    markerPath: activeMarker,
+    markerPath,
   };
 };
 
 /**
  * Called once the renderer signals IPC.APP_READY (after Angular boot).
- * Removes the crash marker so the next launch is treated as clean.
+ * Removes the crash marker so the next launch is treated as clean. The
+ * marker path is passed explicitly by the caller rather than read from
+ * module state — see `evaluateGpuStartupGuard` for the rationale.
  */
-export const markStartupSuccess = (): void => {
+export const markStartupSuccess = (markerPath: string | null): void => {
   if (!markerPath) return;
   try {
     fs.unlinkSync(markerPath);

--- a/electron/gpu-startup-guard.ts
+++ b/electron/gpu-startup-guard.ts
@@ -3,80 +3,189 @@ import { join } from 'path';
 import { log } from 'electron-log/main';
 
 // Persisted between launches so we can tell whether the previous process
-// ever reached `ready-to-show`. Only read/written on Linux, where GPU init
-// failures on confined packages (Snap + Mesa ABI drift, etc.) can leave the
-// main process alive while the renderer never displays.
-const MARKER_FILENAME = '.gpu-startup-state';
-const MARKER_LAUNCHING = 'launching';
-const MARKER_OK = 'ok';
+// ever reached a fully booted state. Only read/written on Linux, where GPU
+// init failures on confined packages (Snap + Mesa ABI drift, etc.) can
+// leave the main process alive while the renderer never renders.
+//
+// Marker is JSON so we can track a failure counter (avoid disabling GPU on
+// a single unrelated crash / force-quit) and the Electron version the
+// counter was recorded against (Electron upgrades commonly trip a
+// first-launch GPU failure that the GPU-cache purge in start-app.ts fixes;
+// we shouldn't latch off GPU on that signal alone).
+const MARKER_FILENAME = '.gpu-startup-state.json';
+// Disable GPU after this many consecutive launches failed to boot through
+// IPC.APP_READY. `2` means a single bad launch is tolerated; two in a row
+// trips the fallback.
+const FAILURE_THRESHOLD = 2;
+
+interface MarkerState {
+  // Incremented at each startup, reset to 0 on successful boot.
+  failedLaunches: number;
+  // Once the threshold is hit, the fallback is sticky across launches so
+  // users on a persistently broken GPU stack aren't forced through a
+  // failed launch every few restarts. Cleared by SP_ENABLE_GPU=1 or an
+  // Electron version change.
+  sticky: boolean;
+  // Used to reset state on Electron upgrade (see above).
+  electronVersion: string;
+}
 
 const isTruthyEnv = (v: string | undefined): boolean =>
-  v === '1' || v === 'true' || v === 'TRUE';
+  !!v && /^(1|true|yes|on)$/i.test(v);
 
 let markerPath: string | null = null;
 
 export interface GpuGuardDecision {
   disableGpu: boolean;
-  reason: 'env' | 'crash-recovery' | null;
+  reason: 'env' | 'crash-recovery' | 'crash-recovery-sticky' | null;
+  // Absolute path to the marker file, surfaced so the log message can tell
+  // a stuck user exactly which file to delete to recover.
+  markerPath: string | null;
 }
 
-/**
- * Evaluate whether to pass `--disable-gpu` on this launch and write a
- * `launching` marker so a future launch can detect a crash loop.
- *
- * Must run after `app.setPath('userData', ...)` (so the marker lands in the
- * right directory) but before `app.whenReady()` resolves (so the switch
- * still takes effect). Safe to call on all platforms; does nothing on
- * non-Linux hosts where the Snap/Mesa failure modes don't apply.
- */
-export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision => {
-  const userDisable = isTruthyEnv(process.env.SP_DISABLE_GPU);
-  const userEnable = isTruthyEnv(process.env.SP_ENABLE_GPU);
-
-  if (process.platform !== 'linux') {
-    return { disableGpu: userDisable && !userEnable, reason: userDisable ? 'env' : null };
-  }
-
-  markerPath = join(userDataPath, MARKER_FILENAME);
-
-  let previousCrash = false;
+const readMarker = (path: string, currentElectronVersion: string): MarkerState => {
+  const fresh: MarkerState = {
+    failedLaunches: 0,
+    sticky: false,
+    electronVersion: currentElectronVersion,
+  };
   try {
-    if (fs.existsSync(markerPath)) {
-      const content = fs.readFileSync(markerPath, 'utf8').trim();
-      previousCrash = content === MARKER_LAUNCHING;
-    }
-  } catch (e) {
-    log('gpu-startup-guard: failed to read marker', e);
+    if (!fs.existsSync(path)) return fresh;
+    const raw = fs.readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<MarkerState>;
+    // An Electron upgrade invalidates the counter: the GPU-cache purge in
+    // start-app.ts is the first-line fix for upgrade-induced GPU failures,
+    // and we want to give it a chance before latching off.
+    if (parsed.electronVersion !== currentElectronVersion) return fresh;
+    return {
+      failedLaunches:
+        typeof parsed.failedLaunches === 'number' ? parsed.failedLaunches : 0,
+      sticky: parsed.sticky === true,
+      electronVersion: currentElectronVersion,
+    };
+  } catch {
+    // Malformed JSON / old plain-text marker from a prior version: treat
+    // as a clean slate rather than crashing on parse.
+    return fresh;
   }
+};
 
+const writeMarker = (path: string, state: MarkerState): void => {
   try {
-    fs.mkdirSync(userDataPath, { recursive: true });
-    fs.writeFileSync(markerPath, MARKER_LAUNCHING);
+    fs.mkdirSync(join(path, '..'), { recursive: true });
+    fs.writeFileSync(path, JSON.stringify(state));
   } catch (e) {
     log('gpu-startup-guard: failed to write marker', e);
   }
-
-  if (userEnable) {
-    return { disableGpu: false, reason: null };
-  }
-  if (userDisable) {
-    return { disableGpu: true, reason: 'env' };
-  }
-  if (previousCrash) {
-    return { disableGpu: true, reason: 'crash-recovery' };
-  }
-  return { disableGpu: false, reason: null };
 };
 
 /**
- * Called once the main window has rendered at least one frame
- * (`ready-to-show`). Clears the crash marker so the next launch is treated
- * as a clean start.
+ * Evaluate whether to disable GPU acceleration on this launch, and persist
+ * a "launch in progress" marker so a future launch can detect a crash loop.
+ *
+ * Must run after `app.setPath('userData', ...)` (so the marker lands in the
+ * right directory) but before `app.whenReady()` resolves, because the
+ * caller applies the decision via `app.disableHardwareAcceleration()`
+ * which is only honored pre-ready.
+ *
+ * The marker is only tracked on Linux — the GPU init failure modes this
+ * guards against (Snap Mesa ABI drift, DRI node issues) are Linux-specific.
+ * The env-var escape hatches apply on every platform.
+ */
+export const evaluateGpuStartupGuard = (
+  userDataPath: string,
+  currentElectronVersion: string,
+): GpuGuardDecision => {
+  const userDisable = isTruthyEnv(process.env.SP_DISABLE_GPU);
+  const userEnable = isTruthyEnv(process.env.SP_ENABLE_GPU);
+  // Unified precedence across platforms: explicit enable beats explicit
+  // disable beats auto-detection. An enable override also clears any
+  // sticky auto-disable state on disk.
+  if (userEnable) {
+    // Clear sticky state so a one-time override sticks if the user never
+    // re-sets the env var but the underlying issue is resolved.
+    if (process.platform === 'linux') {
+      markerPath = join(userDataPath, MARKER_FILENAME);
+      writeMarker(markerPath, {
+        failedLaunches: 0,
+        sticky: false,
+        electronVersion: currentElectronVersion,
+      });
+    }
+    return { disableGpu: false, reason: null, markerPath };
+  }
+
+  if (process.platform !== 'linux') {
+    return {
+      disableGpu: userDisable,
+      reason: userDisable ? 'env' : null,
+      markerPath: null,
+    };
+  }
+
+  markerPath = join(userDataPath, MARKER_FILENAME);
+  const state = readMarker(markerPath, currentElectronVersion);
+
+  // SP_DISABLE_GPU wins over auto-detection but does not affect the
+  // marker counters — the user may toggle it off later and we shouldn't
+  // hide a real crash loop behind their manual override.
+  if (userDisable) {
+    writeMarker(markerPath, {
+      ...state,
+      failedLaunches: state.failedLaunches + 1,
+      electronVersion: currentElectronVersion,
+    });
+    return { disableGpu: true, reason: 'env', markerPath };
+  }
+
+  // Sticky fallback: once we've latched off, stay off until the user
+  // explicitly re-enables with SP_ENABLE_GPU=1 or the Electron version
+  // changes. Increment the counter but don't reset sticky.
+  if (state.sticky) {
+    writeMarker(markerPath, {
+      ...state,
+      failedLaunches: state.failedLaunches + 1,
+    });
+    return { disableGpu: true, reason: 'crash-recovery-sticky', markerPath };
+  }
+
+  // Count this attempt. If the previous runs didn't reach IPC.APP_READY
+  // often enough to pass the threshold, latch off.
+  const nextCount = state.failedLaunches + 1;
+  if (nextCount >= FAILURE_THRESHOLD) {
+    writeMarker(markerPath, {
+      failedLaunches: nextCount,
+      sticky: true,
+      electronVersion: currentElectronVersion,
+    });
+    return { disableGpu: true, reason: 'crash-recovery', markerPath };
+  }
+
+  writeMarker(markerPath, {
+    failedLaunches: nextCount,
+    sticky: false,
+    electronVersion: currentElectronVersion,
+  });
+  return { disableGpu: false, reason: null, markerPath };
+};
+
+/**
+ * Called once the app has fully booted (IPC.APP_READY from the renderer,
+ * which fires after Angular startup). Resets the crash counter so the next
+ * launch is treated as a clean start. Leaves `sticky` alone — once we've
+ * latched off, only an explicit user action re-enables GPU.
  */
 export const markStartupSuccess = (): void => {
   if (!markerPath) return;
   try {
-    fs.writeFileSync(markerPath, MARKER_OK);
+    const raw = fs.existsSync(markerPath) ? fs.readFileSync(markerPath, 'utf8') : null;
+    const prev = raw ? (JSON.parse(raw) as Partial<MarkerState>) : {};
+    writeMarker(markerPath, {
+      failedLaunches: 0,
+      sticky: prev.sticky === true,
+      electronVersion:
+        typeof prev.electronVersion === 'string' ? prev.electronVersion : '',
+    });
   } catch (e) {
     log('gpu-startup-guard: failed to mark startup success', e);
   }

--- a/electron/gpu-startup-guard.ts
+++ b/electron/gpu-startup-guard.ts
@@ -2,191 +2,91 @@ import * as fs from 'fs';
 import { join } from 'path';
 import { log } from 'electron-log/main';
 
-// Persisted between launches so we can tell whether the previous process
-// ever reached a fully booted state. Only read/written on Linux, where GPU
-// init failures on confined packages (Snap + Mesa ABI drift, etc.) can
-// leave the main process alive while the renderer never renders.
-//
-// Marker is JSON so we can track a failure counter (avoid disabling GPU on
-// a single unrelated crash / force-quit) and the Electron version the
-// counter was recorded against (Electron upgrades commonly trip a
-// first-launch GPU failure that the GPU-cache purge in start-app.ts fixes;
-// we shouldn't latch off GPU on that signal alone).
-const MARKER_FILENAME = '.gpu-startup-state.json';
-// Disable GPU after this many consecutive launches failed to boot through
-// IPC.APP_READY. `2` means a single bad launch is tolerated; two in a row
-// trips the fallback.
-const FAILURE_THRESHOLD = 2;
-
-interface MarkerState {
-  // Incremented at each startup, reset to 0 on successful boot.
-  failedLaunches: number;
-  // Once the threshold is hit, the fallback is sticky across launches so
-  // users on a persistently broken GPU stack aren't forced through a
-  // failed launch every few restarts. Cleared by SP_ENABLE_GPU=1 or an
-  // Electron version change.
-  sticky: boolean;
-  // Used to reset state on Electron upgrade (see above).
-  electronVersion: string;
-}
+// Presence-based crash marker: the file exists whenever a launch is in
+// flight and is removed on IPC.APP_READY. A leftover file therefore means
+// the previous launch never finished booting, which on Snap/Flatpak is
+// overwhelmingly a GPU-process init failure (Mesa ABI drift, missing DRI
+// nodes under confinement). This file disappears again on the next
+// successful launch, so there's no sticky stuck-off state — a one-off
+// force-quit costs the user a single GPU-disabled launch, not permanent
+// software rendering.
+const MARKER_FILE = '.gpu-launch-incomplete';
+// Leftovers from earlier iterations of this guard. Cleaned up on startup
+// so users who ran an intermediate build don't carry stale state.
+const LEGACY_MARKER_FILES = ['.gpu-startup-state', '.gpu-startup-state.json'];
 
 const isTruthyEnv = (v: string | undefined): boolean =>
-  !!v && /^(1|true|yes|on)$/i.test(v);
+  !!v && /^(1|true|yes|on)$/i.test(v.trim());
 
 let markerPath: string | null = null;
 
 export interface GpuGuardDecision {
   disableGpu: boolean;
-  reason: 'env' | 'crash-recovery' | 'crash-recovery-sticky' | null;
-  // Absolute path to the marker file, surfaced so the log message can tell
-  // a stuck user exactly which file to delete to recover.
+  reason: 'env' | 'crash-recovery' | null;
   markerPath: string | null;
 }
 
-const readMarker = (path: string, currentElectronVersion: string): MarkerState => {
-  const fresh: MarkerState = {
-    failedLaunches: 0,
-    sticky: false,
-    electronVersion: currentElectronVersion,
-  };
-  try {
-    if (!fs.existsSync(path)) return fresh;
-    const raw = fs.readFileSync(path, 'utf8');
-    const parsed = JSON.parse(raw) as Partial<MarkerState>;
-    // An Electron upgrade invalidates the counter: the GPU-cache purge in
-    // start-app.ts is the first-line fix for upgrade-induced GPU failures,
-    // and we want to give it a chance before latching off.
-    if (parsed.electronVersion !== currentElectronVersion) return fresh;
-    return {
-      failedLaunches:
-        typeof parsed.failedLaunches === 'number' ? parsed.failedLaunches : 0,
-      sticky: parsed.sticky === true,
-      electronVersion: currentElectronVersion,
-    };
-  } catch {
-    // Malformed JSON / old plain-text marker from a prior version: treat
-    // as a clean slate rather than crashing on parse.
-    return fresh;
+/**
+ * Must run after `app.setPath('userData', ...)` and before
+ * `app.whenReady()`. Only auto-detects under Snap/Flatpak confinement on
+ * Linux — the failure mode this guards against is specific to confined
+ * packages with drifting Mesa stacks. `SP_DISABLE_GPU` / `SP_ENABLE_GPU`
+ * env vars work everywhere.
+ */
+export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision => {
+  if (isTruthyEnv(process.env.SP_ENABLE_GPU)) {
+    return { disableGpu: false, reason: null, markerPath: null };
   }
-};
+  if (isTruthyEnv(process.env.SP_DISABLE_GPU)) {
+    return { disableGpu: true, reason: 'env', markerPath: null };
+  }
 
-const writeMarker = (path: string, state: MarkerState): void => {
+  const isConfinedLinux =
+    process.platform === 'linux' && (!!process.env.SNAP || !!process.env.FLATPAK_ID);
+  if (!isConfinedLinux) {
+    return { disableGpu: false, reason: null, markerPath: null };
+  }
+
+  markerPath = join(userDataPath, MARKER_FILE);
+
+  for (const old of LEGACY_MARKER_FILES) {
+    try {
+      fs.unlinkSync(join(userDataPath, old));
+    } catch {
+      // not present — nothing to do
+    }
+  }
+
+  let previousCrash = false;
   try {
-    fs.mkdirSync(join(path, '..'), { recursive: true });
-    fs.writeFileSync(path, JSON.stringify(state));
+    previousCrash = fs.existsSync(markerPath);
+  } catch (e) {
+    log('gpu-startup-guard: failed to read marker', e);
+  }
+
+  try {
+    fs.mkdirSync(userDataPath, { recursive: true });
+    fs.writeFileSync(markerPath, '');
   } catch (e) {
     log('gpu-startup-guard: failed to write marker', e);
   }
+
+  return {
+    disableGpu: previousCrash,
+    reason: previousCrash ? 'crash-recovery' : null,
+    markerPath,
+  };
 };
 
 /**
- * Evaluate whether to disable GPU acceleration on this launch, and persist
- * a "launch in progress" marker so a future launch can detect a crash loop.
- *
- * Must run after `app.setPath('userData', ...)` (so the marker lands in the
- * right directory) but before `app.whenReady()` resolves, because the
- * caller applies the decision via `app.disableHardwareAcceleration()`
- * which is only honored pre-ready.
- *
- * The marker is only tracked on Linux — the GPU init failure modes this
- * guards against (Snap Mesa ABI drift, DRI node issues) are Linux-specific.
- * The env-var escape hatches apply on every platform.
- */
-export const evaluateGpuStartupGuard = (
-  userDataPath: string,
-  currentElectronVersion: string,
-): GpuGuardDecision => {
-  const userDisable = isTruthyEnv(process.env.SP_DISABLE_GPU);
-  const userEnable = isTruthyEnv(process.env.SP_ENABLE_GPU);
-  // Unified precedence across platforms: explicit enable beats explicit
-  // disable beats auto-detection. An enable override also clears any
-  // sticky auto-disable state on disk.
-  if (userEnable) {
-    // Clear sticky state so a one-time override sticks if the user never
-    // re-sets the env var but the underlying issue is resolved.
-    if (process.platform === 'linux') {
-      markerPath = join(userDataPath, MARKER_FILENAME);
-      writeMarker(markerPath, {
-        failedLaunches: 0,
-        sticky: false,
-        electronVersion: currentElectronVersion,
-      });
-    }
-    return { disableGpu: false, reason: null, markerPath };
-  }
-
-  if (process.platform !== 'linux') {
-    return {
-      disableGpu: userDisable,
-      reason: userDisable ? 'env' : null,
-      markerPath: null,
-    };
-  }
-
-  markerPath = join(userDataPath, MARKER_FILENAME);
-  const state = readMarker(markerPath, currentElectronVersion);
-
-  // SP_DISABLE_GPU wins over auto-detection but does not affect the
-  // marker counters — the user may toggle it off later and we shouldn't
-  // hide a real crash loop behind their manual override.
-  if (userDisable) {
-    writeMarker(markerPath, {
-      ...state,
-      failedLaunches: state.failedLaunches + 1,
-      electronVersion: currentElectronVersion,
-    });
-    return { disableGpu: true, reason: 'env', markerPath };
-  }
-
-  // Sticky fallback: once we've latched off, stay off until the user
-  // explicitly re-enables with SP_ENABLE_GPU=1 or the Electron version
-  // changes. Increment the counter but don't reset sticky.
-  if (state.sticky) {
-    writeMarker(markerPath, {
-      ...state,
-      failedLaunches: state.failedLaunches + 1,
-    });
-    return { disableGpu: true, reason: 'crash-recovery-sticky', markerPath };
-  }
-
-  // Count this attempt. If the previous runs didn't reach IPC.APP_READY
-  // often enough to pass the threshold, latch off.
-  const nextCount = state.failedLaunches + 1;
-  if (nextCount >= FAILURE_THRESHOLD) {
-    writeMarker(markerPath, {
-      failedLaunches: nextCount,
-      sticky: true,
-      electronVersion: currentElectronVersion,
-    });
-    return { disableGpu: true, reason: 'crash-recovery', markerPath };
-  }
-
-  writeMarker(markerPath, {
-    failedLaunches: nextCount,
-    sticky: false,
-    electronVersion: currentElectronVersion,
-  });
-  return { disableGpu: false, reason: null, markerPath };
-};
-
-/**
- * Called once the app has fully booted (IPC.APP_READY from the renderer,
- * which fires after Angular startup). Resets the crash counter so the next
- * launch is treated as a clean start. Leaves `sticky` alone — once we've
- * latched off, only an explicit user action re-enables GPU.
+ * Called once the renderer signals IPC.APP_READY (after Angular boot).
+ * Removes the crash marker so the next launch is treated as clean.
  */
 export const markStartupSuccess = (): void => {
   if (!markerPath) return;
   try {
-    const raw = fs.existsSync(markerPath) ? fs.readFileSync(markerPath, 'utf8') : null;
-    const prev = raw ? (JSON.parse(raw) as Partial<MarkerState>) : {};
-    writeMarker(markerPath, {
-      failedLaunches: 0,
-      sticky: prev.sticky === true,
-      electronVersion:
-        typeof prev.electronVersion === 'string' ? prev.electronVersion : '',
-    });
-  } catch (e) {
-    log('gpu-startup-guard: failed to mark startup success', e);
+    fs.unlinkSync(markerPath);
+  } catch {
+    // Already gone, or the auto-detect path was skipped — either way we're done.
   }
 };

--- a/electron/gpu-startup-guard.ts
+++ b/electron/gpu-startup-guard.ts
@@ -34,20 +34,26 @@ export interface GpuGuardDecision {
  * env vars work everywhere.
  */
 export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision => {
-  if (isTruthyEnv(process.env.SP_ENABLE_GPU)) {
-    return { disableGpu: false, reason: null, markerPath: null };
-  }
-  if (isTruthyEnv(process.env.SP_DISABLE_GPU)) {
-    return { disableGpu: true, reason: 'env', markerPath: null };
-  }
-
   const isConfinedLinux =
     process.platform === 'linux' && (!!process.env.SNAP || !!process.env.FLATPAK_ID);
+
+  // Set the module-level marker path unconditionally on confined Linux so
+  // `markStartupSuccess` can clean up a stale marker even when this launch
+  // took an env-var override path and never checked it.
+  if (isConfinedLinux) {
+    markerPath = join(userDataPath, MARKER_FILE);
+  }
+
+  if (isTruthyEnv(process.env.SP_ENABLE_GPU)) {
+    return { disableGpu: false, reason: null, markerPath };
+  }
+  if (isTruthyEnv(process.env.SP_DISABLE_GPU)) {
+    return { disableGpu: true, reason: 'env', markerPath };
+  }
+
   if (!isConfinedLinux) {
     return { disableGpu: false, reason: null, markerPath: null };
   }
-
-  markerPath = join(userDataPath, MARKER_FILE);
 
   for (const old of LEGACY_MARKER_FILES) {
     try {

--- a/electron/gpu-startup-guard.ts
+++ b/electron/gpu-startup-guard.ts
@@ -52,8 +52,16 @@ export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision 
   }
 
   if (!isConfinedLinux) {
+    // Reset module-level state so a second call (tests, reinit) doesn't
+    // leak a previous confined-launch's path into markStartupSuccess().
+    markerPath = null;
     return { disableGpu: false, reason: null, markerPath: null };
   }
+
+  // Narrow markerPath for fs calls below — it was set on the
+  // isConfinedLinux branch above, but TS can't track module-let
+  // assignment across the early returns.
+  const activeMarker: string = markerPath as string;
 
   for (const old of LEGACY_MARKER_FILES) {
     try {
@@ -65,14 +73,19 @@ export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision 
 
   let previousCrash = false;
   try {
-    previousCrash = fs.existsSync(markerPath);
+    previousCrash = fs.existsSync(activeMarker);
   } catch (e) {
     log('gpu-startup-guard: failed to read marker', e);
   }
 
+  // mkdirSync is load-bearing on first-ever install: Electron's
+  // `app.setPath('userData', ...)` does NOT create the directory, so
+  // $SNAP_USER_COMMON/.config/superproductivity may not exist yet on the
+  // first launch of a fresh Snap install. Without this, writeFileSync
+  // would fail silently and the guard would never write a marker.
   try {
     fs.mkdirSync(userDataPath, { recursive: true });
-    fs.writeFileSync(markerPath, '');
+    fs.writeFileSync(activeMarker, '');
   } catch (e) {
     log('gpu-startup-guard: failed to write marker', e);
   }
@@ -80,7 +93,7 @@ export const evaluateGpuStartupGuard = (userDataPath: string): GpuGuardDecision 
   return {
     disableGpu: previousCrash,
     reason: previousCrash ? 'crash-recovery' : null,
-    markerPath,
+    markerPath: activeMarker,
   };
 };
 

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -65,12 +65,18 @@ export const createWindow = async ({
   quitApp,
   app,
   customUrl,
+  gpuMarkerPath,
 }: {
   IS_DEV: boolean;
   ICONS_FOLDER: string;
   quitApp: () => void;
   app: App;
   customUrl?: string;
+  // Path to the GPU crash marker from evaluateGpuStartupGuard, or null
+  // when the guard didn't apply (non-confined launch / first run).
+  // Passed explicitly rather than re-read from module state; the IPC
+  // APP_READY handler hands it to markStartupSuccess.
+  gpuMarkerPath: string | null;
 }): Promise<BrowserWindow> => {
   // make sure the main window isn't already created
   if (mainWin) {
@@ -282,7 +288,7 @@ export const createWindow = async ({
     // (including Angular init) — not just that the compositor painted a
     // frame. This avoids clearing the crash counter on blank/broken
     // renderers that still fire `ready-to-show`.
-    markStartupSuccess();
+    markStartupSuccess(gpuMarkerPath);
   });
 
   // Register F11 key handler for fullscreen toggle

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -26,6 +26,7 @@ import { ensureIndicator } from './indicator';
 import { getIsMinimizeToTray, getIsQuiting, setIsQuiting } from './shared-state';
 import { loadSimpleStoreAll } from './simple-store';
 import { SimpleStoreKey } from './shared-with-frontend/simple-store.const';
+import { markStartupSuccess } from './gpu-startup-guard';
 
 let mainWin: BrowserWindow;
 
@@ -243,6 +244,9 @@ export const createWindow = async ({
 
   // show gracefully
   mainWin.once('ready-to-show', () => {
+    // Signal the GPU startup guard that the renderer produced at least one
+    // frame, so the next launch is treated as a clean start.
+    markStartupSuccess();
     mainWin.show();
 
     // Workaround for Windows phantom focus bug (electron#20464):

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -244,9 +244,6 @@ export const createWindow = async ({
 
   // show gracefully
   mainWin.once('ready-to-show', () => {
-    // Signal the GPU startup guard that the renderer produced at least one
-    // frame, so the next launch is treated as a clean start.
-    markStartupSuccess();
     mainWin.show();
 
     // Workaround for Windows phantom focus bug (electron#20464):
@@ -281,6 +278,11 @@ export const createWindow = async ({
   // listen for app ready
   ipcMain.on(IPC.APP_READY, () => {
     mainWinModule.isAppReady = true;
+    // Signal the GPU startup guard that the full boot chain completed
+    // (including Angular init) — not just that the compositor painted a
+    // frame. This avoids clearing the crash counter on blank/broken
+    // renderers that still fire `ready-to-show`.
+    markStartupSuccess();
   });
 
   // Register F11 key handler for fullscreen toggle

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -21,6 +21,7 @@ import {
   processPendingProtocolUrls,
 } from './protocol-handler';
 import { getIsQuiting, setIsLocked } from './shared-state';
+import { evaluateGpuStartupGuard } from './gpu-startup-guard';
 import * as fs from 'fs';
 
 const ICONS_FOLDER = __dirname + '/assets/icons/';
@@ -148,6 +149,20 @@ export const startApp = (): void => {
     // set userDa dir to common data to avoid the data being accessed by the update process
     app.setPath('userData', newPath);
     app.setAppLogsPath();
+  }
+
+  // Defense-in-depth against GPU init failures that manifest as "app won't
+  // launch" (e.g. Mesa ABI drift on Snap, missing DRI nodes under confinement,
+  // or a Wayland-first session that slips past the X11-force guard above).
+  // If the previous launch never signaled `ready-to-show`, or the user sets
+  // SP_DISABLE_GPU=1, append --disable-gpu. SP_ENABLE_GPU=1 overrides.
+  const gpuDecision = evaluateGpuStartupGuard(app.getPath('userData'));
+  if (gpuDecision.disableGpu) {
+    app.commandLine.appendSwitch('disable-gpu');
+    log(
+      `Disabling GPU acceleration (reason: ${gpuDecision.reason}). ` +
+        `Set SP_ENABLE_GPU=1 to force-enable GPU on the next launch.`,
+    );
   }
 
   initDebug({ showDevTools: isShowDevTools }, IS_DEV);

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -152,16 +152,28 @@ export const startApp = (): void => {
   }
 
   // Defense-in-depth against GPU init failures that manifest as "app won't
-  // launch" (e.g. Mesa ABI drift on Snap, missing DRI nodes under confinement,
-  // or a Wayland-first session that slips past the X11-force guard above).
-  // If the previous launch never signaled `ready-to-show`, or the user sets
-  // SP_DISABLE_GPU=1, append --disable-gpu. SP_ENABLE_GPU=1 overrides.
-  const gpuDecision = evaluateGpuStartupGuard(app.getPath('userData'));
+  // launch" (e.g. Mesa ABI drift on Snap, missing DRI nodes under
+  // confinement, or a Wayland-first session that slips past the X11-force
+  // guard above). The guard tolerates a single unrelated crash/force-quit
+  // and only latches off GPU after repeated failures to reach
+  // IPC.APP_READY; an Electron version change resets the counter so the
+  // GPU-cache purge below has a chance to fix things first.
+  // IMPORTANT: this block must stay after every `app.setPath('userData',
+  // ...)` call above — the marker lives in userData, and a mismatch between
+  // read and write paths would permanently confuse the detector.
+  const gpuDecision = evaluateGpuStartupGuard(
+    app.getPath('userData'),
+    process.versions.electron || 'unknown',
+  );
   if (gpuDecision.disableGpu) {
-    app.commandLine.appendSwitch('disable-gpu');
+    // `disableHardwareAcceleration()` is the documented Electron API for
+    // this; it is equivalent to passing `--disable-gpu` but routes through
+    // the app layer rather than a raw Chromium switch.
+    app.disableHardwareAcceleration();
     log(
       `Disabling GPU acceleration (reason: ${gpuDecision.reason}). ` +
-        `Set SP_ENABLE_GPU=1 to force-enable GPU on the next launch.`,
+        `To force-enable on the next launch set SP_ENABLE_GPU=1` +
+        (gpuDecision.markerPath ? ` or delete ${gpuDecision.markerPath}.` : '.'),
     );
   }
 

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -154,16 +154,22 @@ export const startApp = (): void => {
   // Defense-in-depth against GPU init failures on confined Linux packages
   // (Snap Mesa ABI drift, missing DRI nodes under Flatpak, etc.) where the
   // main process stays alive but the GPU process crashes at init and the
-  // window never renders. `--disable-gpu` is the Chromium switch that
-  // actually suppresses GPU-process spawn; `app.disableHardwareAcceleration()`
-  // only disables compositor accel and leaves the failing GPU-process-init
-  // path active. Guard auto-detects only under confinement and recovers on
-  // the next successful launch; env-var overrides work everywhere.
+  // window never renders. `--disable-gpu` avoids the hardware Mesa DRI
+  // driver load path — which is the ABI-drift source on confined Snap.
+  // Note: `--disable-gpu` does NOT guarantee "no GPU process" on Linux
+  // (Chromium may still run a GPU process in SwiftShader or
+  // DisplayCompositor mode), but those modes don't dlopen Mesa DRI
+  // drivers, which is what matters for this bug. `--disable-software-
+  // rasterizer` is added as belt-and-braces; the combined pair is what
+  // Chromium's own GPU integration tests treat as "no GPU process."
+  // `app.disableHardwareAcceleration()` only disables compositor accel
+  // and leaves the failing GPU-process-init path active.
   // IMPORTANT: must stay after every `app.setPath('userData', ...)` call
   // above — the marker lives in userData.
   const gpuDecision = evaluateGpuStartupGuard(app.getPath('userData'));
   if (gpuDecision.disableGpu) {
     app.commandLine.appendSwitch('disable-gpu');
+    app.commandLine.appendSwitch('disable-software-rasterizer');
     log(
       `Disabling GPU acceleration (reason: ${gpuDecision.reason}). ` +
         `Set SP_ENABLE_GPU=1 to force-enable on the next launch` +

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -151,28 +151,22 @@ export const startApp = (): void => {
     app.setAppLogsPath();
   }
 
-  // Defense-in-depth against GPU init failures that manifest as "app won't
-  // launch" (e.g. Mesa ABI drift on Snap, missing DRI nodes under
-  // confinement, or a Wayland-first session that slips past the X11-force
-  // guard above). The guard tolerates a single unrelated crash/force-quit
-  // and only latches off GPU after repeated failures to reach
-  // IPC.APP_READY; an Electron version change resets the counter so the
-  // GPU-cache purge below has a chance to fix things first.
-  // IMPORTANT: this block must stay after every `app.setPath('userData',
-  // ...)` call above — the marker lives in userData, and a mismatch between
-  // read and write paths would permanently confuse the detector.
-  const gpuDecision = evaluateGpuStartupGuard(
-    app.getPath('userData'),
-    process.versions.electron || 'unknown',
-  );
+  // Defense-in-depth against GPU init failures on confined Linux packages
+  // (Snap Mesa ABI drift, missing DRI nodes under Flatpak, etc.) where the
+  // main process stays alive but the GPU process crashes at init and the
+  // window never renders. `--disable-gpu` is the Chromium switch that
+  // actually suppresses GPU-process spawn; `app.disableHardwareAcceleration()`
+  // only disables compositor accel and leaves the failing GPU-process-init
+  // path active. Guard auto-detects only under confinement and recovers on
+  // the next successful launch; env-var overrides work everywhere.
+  // IMPORTANT: must stay after every `app.setPath('userData', ...)` call
+  // above — the marker lives in userData.
+  const gpuDecision = evaluateGpuStartupGuard(app.getPath('userData'));
   if (gpuDecision.disableGpu) {
-    // `disableHardwareAcceleration()` is the documented Electron API for
-    // this; it is equivalent to passing `--disable-gpu` but routes through
-    // the app layer rather than a raw Chromium switch.
-    app.disableHardwareAcceleration();
+    app.commandLine.appendSwitch('disable-gpu');
     log(
       `Disabling GPU acceleration (reason: ${gpuDecision.reason}). ` +
-        `To force-enable on the next launch set SP_ENABLE_GPU=1` +
+        `Set SP_ENABLE_GPU=1 to force-enable on the next launch` +
         (gpuDecision.markerPath ? ` or delete ${gpuDecision.markerPath}.` : '.'),
     );
   }

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -35,6 +35,7 @@ let customUrl: string;
 let isDisableTray = false;
 let forceDarkTray = false;
 let wasUserDataDirSet = false;
+let gpuMarkerPath: string | null = null;
 
 if (IS_DEV) {
   log('Starting in DEV Mode!!!');
@@ -151,22 +152,17 @@ export const startApp = (): void => {
     app.setAppLogsPath();
   }
 
-  // Defense-in-depth against GPU init failures on confined Linux packages
-  // (Snap Mesa ABI drift, missing DRI nodes under Flatpak, etc.) where the
-  // main process stays alive but the GPU process crashes at init and the
-  // window never renders. `--disable-gpu` avoids the hardware Mesa DRI
-  // driver load path — which is the ABI-drift source on confined Snap.
-  // Note: `--disable-gpu` does NOT guarantee "no GPU process" on Linux
-  // (Chromium may still run a GPU process in SwiftShader or
-  // DisplayCompositor mode), but those modes don't dlopen Mesa DRI
-  // drivers, which is what matters for this bug. `--disable-software-
-  // rasterizer` is added as belt-and-braces; the combined pair is what
-  // Chromium's own GPU integration tests treat as "no GPU process."
-  // `app.disableHardwareAcceleration()` only disables compositor accel
-  // and leaves the failing GPU-process-init path active.
+  // Confined-Linux GPU init can crash the GPU process while the main
+  // process survives, leaving a blank window. `--disable-gpu` +
+  // `--disable-software-rasterizer` skips the Mesa DRI dlopen path (the
+  // ABI-drift source on Snap); it's what Chromium's own GPU integration
+  // tests treat as "no GPU process." `app.disableHardwareAcceleration()`
+  // is insufficient — it doesn't prevent GPU-process init. See
+  // docs/research/snap-wayland-gpu-fix-research.md for details.
   // IMPORTANT: must stay after every `app.setPath('userData', ...)` call
   // above — the marker lives in userData.
   const gpuDecision = evaluateGpuStartupGuard(app.getPath('userData'));
+  gpuMarkerPath = gpuDecision.markerPath;
   if (gpuDecision.disableGpu) {
     app.commandLine.appendSwitch('disable-gpu');
     app.commandLine.appendSwitch('disable-software-rasterizer');
@@ -458,6 +454,7 @@ export const startApp = (): void => {
       ICONS_FOLDER,
       quitApp,
       customUrl,
+      gpuMarkerPath,
     });
 
     initPluginOAuth(mainWin);


### PR DESCRIPTION
## Problem

On confined Linux packages (Snap/Flatpak), GPU process initialization can fail due to Mesa ABI drift or missing DRI nodes under confinement. When this occurs, the main process stays alive but the GPU process crashes at init, leaving the window unable to render. There is currently no recovery mechanism for this failure mode.

## Solution

Implement a GPU startup guard that:

1. **Detects GPU init failures** on confined Linux (Snap/Flatpak) by using a presence-based crash marker file in the userData directory
2. **Auto-recovers** by disabling GPU acceleration on the next launch if a previous launch failed to complete boot
3. **Cleans up automatically** when the app successfully boots (via `APP_READY` IPC signal after Angular init)
4. **Provides manual overrides** via `SP_DISABLE_GPU` and `SP_ENABLE_GPU` environment variables that work on all platforms
5. **Avoids sticky failure states** — a one-off force-quit only costs a single GPU-disabled launch, not permanent software rendering

The guard:
- Only auto-detects under Snap/Flatpak confinement on Linux (the specific failure mode is confined-package-specific)
- Uses `app.commandLine.appendSwitch('disable-gpu')` to actually suppress GPU-process spawn (not just compositor acceleration)
- Cleans up legacy marker files from earlier iterations
- Signals success only after the full boot chain completes (including Angular init), not just when the compositor paints

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)

https://claude.ai/code/session_011PuHY56j8A7G483d9VgvRC