### PR TITLE
test(task selectors): clear and release new task selectors

### DIFF
--- a/src/app/features/tasks/store/task.selectors.spec.ts
+++ b/src/app/features/tasks/store/task.selectors.spec.ts
@@ -204,9 +204,13 @@ describe('Task Selectors', () => {
     fromSelectors.selectAllTasksWithSubTasks.clearResult();
     fromSelectors.selectAllRepeatableTaskWithSubTasks.clearResult();
     fromSelectors.selectTaskByIdWithSubTaskData.clearResult();
+    fromSelectors.selectOverdueTasksWithSubTasks.clearResult();
+    fromSelectors.selectLaterTodayTasksWithSubTasks.clearResult();
     fromSelectors.selectAllTasksWithSubTasks.release();
     fromSelectors.selectAllRepeatableTaskWithSubTasks.release();
     fromSelectors.selectTaskByIdWithSubTaskData.release();
+    fromSelectors.selectOverdueTasksWithSubTasks.release();
+    fromSelectors.selectLaterTodayTasksWithSubTasks.release();
   });
 
   // Basic selectors


### PR DESCRIPTION
## Problem

The test setup for task selectors was incomplete. Two new selectors (`selectOverdueTasksWithSubTasks` and `selectLaterTodayTasksWithSubTasks`) were not being properly cleared and released in the test teardown, which could cause test pollution and inconsistent test results.

## Solution

Added `clearResult()` and `release()` calls for the two new selectors in the test's `afterEach` hook, ensuring they are properly cleaned up alongside the existing selectors.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

https://claude.ai/code/session_019ZDiMb5diiSBBRogoP9bUE