### PR TITLE
fix(search): scroll to selected task after search navigation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -189,7 +189,6 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   );
 
   private _subs: Subscription = new Subscription();
-  private _intervalTimer?: NodeJS.Timeout;
 
   constructor() {
     this._startupService.init();
@@ -434,31 +433,20 @@ export class AppComponent implements OnDestroy, AfterViewInit {
 
   ngOnDestroy(): void {
     this._subs.unsubscribe();
-    if (this._intervalTimer) clearInterval(this._intervalTimer);
   }
 
   /**
    * since page load and animation time are not always equal
-   * an interval seemed to feel the most responsive
+   * retrying until the rendered task row is available avoids missing focus targets
    */
   private _focusElement(id: string): void {
-    let counter = 0;
-    this._intervalTimer = setInterval(() => {
-      counter += 1;
-
-      const el = document.getElementById(`t-${id}`);
-      el?.focus();
-
+    this.layoutService.focusTaskInViewWhenReady(id, (el) => {
       if (el && IS_MOBILE) {
         el.classList.add('mobile-highlight-searched-item');
         el.addEventListener('blur', () =>
           el.classList.remove('mobile-highlight-searched-item'),
         );
       }
-
-      if ((el || counter === 4) && this._intervalTimer) {
-        clearInterval(this._intervalTimer);
-      }
-    }, 400);
+    });
   }
 }

--- a/src/app/core-ui/layout/layout.service.spec.ts
+++ b/src/app/core-ui/layout/layout.service.spec.ts
@@ -11,6 +11,23 @@ describe('LayoutService', () => {
   let service: LayoutService;
   let mockStore: jasmine.SpyObj<Store>;
 
+  const mockRenderedTaskElement = (
+    el: HTMLElement,
+    top: number = 0,
+    height: number = 40,
+  ): void => {
+    Object.defineProperty(el, 'offsetHeight', { value: height, configurable: true });
+    spyOn(el, 'getBoundingClientRect').and.returnValue({
+      top,
+      height,
+    } as DOMRect);
+    spyOn(el, 'getClientRects').and.returnValue([
+      {
+        height,
+      },
+    ] as unknown as DOMRectList);
+  };
+
   beforeEach(() => {
     const storeSpy = jasmine.createSpyObj('Store', ['dispatch', 'pipe', 'select']);
     const breakpointObserverSpy = jasmine.createSpyObj('BreakpointObserver', ['observe']);
@@ -80,6 +97,7 @@ describe('LayoutService', () => {
       const newTaskElement = document.createElement('div');
       newTaskElement.id = `t-${newTaskId}`;
       newTaskElement.tabIndex = 0;
+      mockRenderedTaskElement(newTaskElement);
       document.body.appendChild(newTaskElement);
 
       spyOn(newTaskElement, 'focus');
@@ -100,6 +118,7 @@ describe('LayoutService', () => {
       const pendingTaskElement = document.createElement('div');
       pendingTaskElement.id = `t-${pendingTaskId}`;
       pendingTaskElement.tabIndex = 0;
+      mockRenderedTaskElement(pendingTaskElement);
       document.body.appendChild(pendingTaskElement);
 
       spyOn(pendingTaskElement, 'focus');
@@ -230,10 +249,7 @@ describe('LayoutService', () => {
         }
         return { overflowY: 'visible' } as CSSStyleDeclaration;
       });
-      spyOn(taskElement, 'getBoundingClientRect').and.returnValue({
-        top: 250,
-        height: 40,
-      } as DOMRect);
+      mockRenderedTaskElement(taskElement, 250);
 
       scrollContainer.appendChild(taskElement);
       document.body.appendChild(scrollContainer);
@@ -276,10 +292,7 @@ describe('LayoutService', () => {
         }
         return { overflowY: 'visible' } as CSSStyleDeclaration;
       });
-      spyOn(taskElement, 'getBoundingClientRect').and.returnValue({
-        top: 200,
-        height: 40,
-      } as DOMRect);
+      mockRenderedTaskElement(taskElement, 200);
 
       scrollContainer.appendChild(taskElement);
       document.body.appendChild(scrollContainer);
@@ -316,10 +329,7 @@ describe('LayoutService', () => {
         }
         return { overflowY: 'visible' } as CSSStyleDeclaration;
       });
-      spyOn(taskElement, 'getBoundingClientRect').and.returnValue({
-        top: 180,
-        height: 40,
-      } as DOMRect);
+      mockRenderedTaskElement(taskElement, 180);
 
       service.focusTaskInViewWhenReady(taskId);
 

--- a/src/app/core-ui/layout/layout.service.spec.ts
+++ b/src/app/core-ui/layout/layout.service.spec.ts
@@ -215,22 +215,35 @@ describe('LayoutService', () => {
 
   describe('scrollToNewTask', () => {
     it('should scroll an existing task into view after a short delay', (done) => {
+      const scrollContainer = document.createElement('div');
       const taskId = 'scroll-task';
       const taskElement = document.createElement('div');
       taskElement.id = `t-${taskId}`;
-      spyOn(taskElement, 'scrollIntoView');
-      document.body.appendChild(taskElement);
+      Object.defineProperty(scrollContainer, 'clientHeight', { value: 400 });
+      Object.defineProperty(scrollContainer, 'scrollHeight', { value: 1000 });
+      Object.defineProperty(scrollContainer, 'scrollTop', { value: 50, writable: true });
+      Object.defineProperty(taskElement, 'offsetTop', { value: 250 });
+      Object.defineProperty(scrollContainer, 'offsetTop', { value: 0 });
+      spyOn(window, 'getComputedStyle').and.callFake((target: Element) => {
+        if (target === scrollContainer) {
+          return { overflowY: 'auto' } as CSSStyleDeclaration;
+        }
+        return { overflowY: 'visible' } as CSSStyleDeclaration;
+      });
+      spyOn(taskElement, 'getBoundingClientRect').and.returnValue({
+        top: 250,
+        height: 40,
+      } as DOMRect);
+
+      scrollContainer.appendChild(taskElement);
+      document.body.appendChild(scrollContainer);
 
       service.scrollToNewTask(taskId);
 
       setTimeout(() => {
-        expect(taskElement.scrollIntoView).toHaveBeenCalledWith({
-          behavior: 'instant',
-          block: 'center',
-          inline: 'nearest',
-        });
+        expect(scrollContainer.scrollTop).toBe(70);
 
-        document.body.removeChild(taskElement);
+        document.body.removeChild(scrollContainer);
         done();
       }, 100);
     });
@@ -242,6 +255,85 @@ describe('LayoutService', () => {
         expect().nothing();
         done();
       }, 100);
+    });
+  });
+
+  describe('focusTaskInViewIfPossible', () => {
+    it('should center and focus an existing task inside a scrollable container', () => {
+      const scrollContainer = document.createElement('div');
+      const taskId = 'focus-task';
+      const taskElement = document.createElement('div');
+      taskElement.id = `t-${taskId}`;
+      spyOn(taskElement, 'focus');
+      Object.defineProperty(scrollContainer, 'clientHeight', { value: 300 });
+      Object.defineProperty(scrollContainer, 'scrollHeight', { value: 1000 });
+      Object.defineProperty(scrollContainer, 'scrollTop', { value: 0, writable: true });
+      Object.defineProperty(taskElement, 'offsetTop', { value: 200 });
+      Object.defineProperty(scrollContainer, 'offsetTop', { value: 0 });
+      spyOn(window, 'getComputedStyle').and.callFake((target: Element) => {
+        if (target === scrollContainer) {
+          return { overflowY: 'auto' } as CSSStyleDeclaration;
+        }
+        return { overflowY: 'visible' } as CSSStyleDeclaration;
+      });
+      spyOn(taskElement, 'getBoundingClientRect').and.returnValue({
+        top: 200,
+        height: 40,
+      } as DOMRect);
+
+      scrollContainer.appendChild(taskElement);
+      document.body.appendChild(scrollContainer);
+
+      const result = service.focusTaskInViewIfPossible(taskId);
+
+      expect(result).toBe(taskElement);
+      expect(scrollContainer.scrollTop).toBe(70);
+      expect(taskElement.focus).toHaveBeenCalledWith({ preventScroll: true });
+
+      document.body.removeChild(scrollContainer);
+    });
+
+    it('should return null when the task element is missing', () => {
+      expect(service.focusTaskInViewIfPossible('missing-task')).toBeNull();
+    });
+  });
+
+  describe('focusTaskInViewWhenReady', () => {
+    it('should retry until the task element is rendered', (done) => {
+      const scrollContainer = document.createElement('div');
+      const taskId = 'delayed-focus-task';
+      const taskElement = document.createElement('div');
+      taskElement.id = `t-${taskId}`;
+      spyOn(taskElement, 'focus');
+      Object.defineProperty(scrollContainer, 'clientHeight', { value: 300 });
+      Object.defineProperty(scrollContainer, 'scrollHeight', { value: 1000 });
+      Object.defineProperty(scrollContainer, 'scrollTop', { value: 20, writable: true });
+      Object.defineProperty(taskElement, 'offsetTop', { value: 150 });
+      Object.defineProperty(scrollContainer, 'offsetTop', { value: 0 });
+      spyOn(window, 'getComputedStyle').and.callFake((target: Element) => {
+        if (target === scrollContainer) {
+          return { overflowY: 'auto' } as CSSStyleDeclaration;
+        }
+        return { overflowY: 'visible' } as CSSStyleDeclaration;
+      });
+      spyOn(taskElement, 'getBoundingClientRect').and.returnValue({
+        top: 180,
+        height: 40,
+      } as DOMRect);
+
+      service.focusTaskInViewWhenReady(taskId);
+
+      setTimeout(() => {
+        scrollContainer.appendChild(taskElement);
+        document.body.appendChild(scrollContainer);
+      }, 100);
+
+      setTimeout(() => {
+        expect(scrollContainer.scrollTop).toBe(20);
+        expect(taskElement.focus).toHaveBeenCalledWith({ preventScroll: true });
+        document.body.removeChild(scrollContainer);
+        done();
+      }, 400);
     });
   });
 });

--- a/src/app/core-ui/layout/layout.service.ts
+++ b/src/app/core-ui/layout/layout.service.ts
@@ -36,11 +36,14 @@ const initialXsMatch =
 })
 export class LayoutService {
   private static readonly _TASK_ACTION_DELAY = 50;
+  private static readonly _TASK_FOCUS_RETRY_DELAY = 250;
+  private static readonly _TASK_FOCUS_MAX_RETRIES = 16;
 
   private _store$ = inject<Store<LayoutState>>(Store);
   private _breakPointObserver = inject(BreakpointObserver);
   private _previouslyFocusedElement: HTMLElement | null = null;
   private _pendingFocusTaskId: string | null = null; // store new task id until user closes the bar
+  private _pendingTaskRevealTimeout?: number;
 
   // Signal to trigger sidebar focus
   private _focusSideNavTrigger = signal(0);
@@ -143,12 +146,45 @@ export class LayoutService {
 
   scrollToNewTask(taskId: string): void {
     this._runForTaskElement(taskId, (el) => {
-      el.scrollIntoView({
-        behavior: 'instant',
-        block: 'center',
-        inline: 'nearest',
-      });
+      this._scrollTaskElementIntoView(el);
     });
+  }
+
+  focusTaskInViewIfPossible(taskId: string): HTMLElement | null {
+    const el = document.getElementById(`t-${taskId}`);
+    if (!el || !this._isTaskElementReady(el)) {
+      return null;
+    }
+
+    this._scrollTaskElementIntoView(el);
+    el.focus({ preventScroll: true });
+    return el;
+  }
+
+  focusTaskInViewWhenReady(
+    taskId: string,
+    onSuccess?: (el: HTMLElement) => void,
+    retriesLeft: number = LayoutService._TASK_FOCUS_MAX_RETRIES,
+  ): void {
+    if (this._pendingTaskRevealTimeout) {
+      window.clearTimeout(this._pendingTaskRevealTimeout);
+      this._pendingTaskRevealTimeout = undefined;
+    }
+
+    const el = this.focusTaskInViewIfPossible(taskId);
+    if (el) {
+      onSuccess?.(el);
+      return;
+    }
+
+    if (retriesLeft <= 0) {
+      return;
+    }
+
+    this._pendingTaskRevealTimeout = window.setTimeout(() => {
+      this._pendingTaskRevealTimeout = undefined;
+      this.focusTaskInViewWhenReady(taskId, onSuccess, retriesLeft - 1);
+    }, LayoutService._TASK_FOCUS_RETRY_DELAY);
   }
 
   private _runForTaskElement(
@@ -158,12 +194,57 @@ export class LayoutService {
   ): void {
     window.setTimeout(() => {
       const el = document.getElementById(`t-${taskId}`);
-      if (el) {
+      if (el && this._isTaskElementReady(el)) {
         cb(el);
       } else {
         onNotFound?.();
       }
     }, LayoutService._TASK_ACTION_DELAY);
+  }
+
+  private _isTaskElementReady(el: HTMLElement): boolean {
+    return (
+      document.body.contains(el) &&
+      el.getClientRects().length > 0 &&
+      el.getBoundingClientRect().height > 0
+    );
+  }
+
+  private _scrollTaskElementIntoView(el: HTMLElement): void {
+    const scrollContainer = this._getNearestScrollableAncestor(el);
+    if (!scrollContainer) {
+      el.scrollIntoView({
+        behavior: 'auto',
+        block: 'center',
+        inline: 'nearest',
+      });
+      return;
+    }
+
+    const elementRect = el.getBoundingClientRect();
+    const relativeTop = el.offsetTop - scrollContainer.offsetTop;
+    const containerCenterOffset = scrollContainer.clientHeight / 2;
+    const elementCenterOffset = elementRect.height / 2;
+    const centeredTop = relativeTop - containerCenterOffset + elementCenterOffset;
+    scrollContainer.scrollTop = Math.max(centeredTop, 0);
+  }
+
+  private _getNearestScrollableAncestor(el: HTMLElement): HTMLElement | null {
+    let current: HTMLElement | null = el.parentElement;
+
+    while (current) {
+      const style = window.getComputedStyle(current);
+      const overflowY = style.overflowY;
+      if (
+        (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') &&
+        current.scrollHeight > current.clientHeight
+      ) {
+        return current;
+      }
+      current = current.parentElement;
+    }
+
+    return null;
   }
 
   private _focusPreviousTaskOrFallback(): void {

--- a/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
+++ b/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
@@ -12,6 +12,7 @@ import { TODAY_TAG } from '../../features/tag/tag.const';
 import { SnackService } from '../../core/snack/snack.service';
 import { T } from '../../t.const';
 import { Log } from '../../core/log';
+import { LayoutService } from '../layout/layout.service';
 
 @Injectable({
   providedIn: 'root',
@@ -22,6 +23,7 @@ export class NavigateToTaskService {
   private _router = inject(Router);
   private _snackService = inject(SnackService);
   private _dateService = inject(DateService);
+  private _layoutService = inject(LayoutService);
 
   async navigate(taskId: string, isArchiveTask: boolean = false): Promise<void> {
     try {
@@ -88,10 +90,7 @@ export class NavigateToTaskService {
   }
 
   private _focusTaskElement(taskId: string): void {
-    const el = document.getElementById(`t-${taskId}`);
-    if (el) {
-      el.focus();
-    }
+    this._layoutService.focusTaskInViewWhenReady(taskId);
   }
 
   private async _isInBacklog(task: Task): Promise<boolean> {

--- a/src/app/features/work-view/work-view.component.ts
+++ b/src/app/features/work-view/work-view.component.ts
@@ -100,6 +100,9 @@ import { RepeatCfgPreviewComponent } from '../task-repeat-cfg/repeat-cfg-preview
   ],
 })
 export class WorkViewComponent implements OnInit, OnDestroy {
+  private static readonly _FOCUS_ITEM_RETRY_DELAY = 250;
+  private static readonly _FOCUS_ITEM_MAX_RETRIES = 20;
+
   taskService = inject(TaskService);
   takeABreakService = inject(TakeABreakService);
   layoutService = inject(LayoutService);
@@ -196,13 +199,20 @@ export class WorkViewComponent implements OnInit, OnDestroy {
     );
 
   private _subs: Subscription = new Subscription();
+  private _pendingFocusItemTaskId: string | null = null;
+  private _pendingFocusItemTimeout?: number;
+  private _splitTopElement?: HTMLElement;
   private _switchListAnimationTimeout?: number;
 
   // TODO: Skipped for migration because:
   //  Accessor queries cannot be migrated as they are too complex.
   @ViewChild('splitTopEl', { read: ElementRef }) set splitTopElRef(ref: ElementRef) {
     if (ref) {
+      this._splitTopElement = ref.nativeElement;
       this.splitTopEl$.next(ref.nativeElement);
+      if (this._pendingFocusItemTaskId) {
+        this._focusItemInWorkViewWhenReady(this._pendingFocusItemTaskId);
+      }
     }
   }
 
@@ -280,6 +290,12 @@ export class WorkViewComponent implements OnInit, OnDestroy {
         } else if (params.isInBacklog === 'true') {
           this.splitInputPos = 50;
         }
+        if (params?.focusItem) {
+          this._pendingFocusItemTaskId = params.focusItem;
+          this._focusItemInWorkViewWhenReady(params.focusItem);
+        } else {
+          this._pendingFocusItemTaskId = null;
+        }
         // NOTE: otherwise this is not triggered right away
         this._cd.detectChanges();
       }),
@@ -287,6 +303,9 @@ export class WorkViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (this._pendingFocusItemTimeout) {
+      window.clearTimeout(this._pendingFocusItemTimeout);
+    }
     if (this._switchListAnimationTimeout) {
       window.clearTimeout(this._switchListAnimationTimeout);
     }
@@ -334,6 +353,68 @@ export class WorkViewComponent implements OnInit, OnDestroy {
           this.layoutService.isWorkViewScrolled.set(false);
         }
       }),
+    );
+  }
+
+  private _focusItemInWorkViewWhenReady(
+    taskId: string,
+    retriesLeft: number = WorkViewComponent._FOCUS_ITEM_MAX_RETRIES,
+  ): void {
+    if (this._pendingFocusItemTimeout) {
+      window.clearTimeout(this._pendingFocusItemTimeout);
+      this._pendingFocusItemTimeout = undefined;
+    }
+
+    const container = this._splitTopElement;
+    const directMatch = container?.querySelector(`#t-${taskId}`) as HTMLElement | null;
+    const selectedMatch =
+      this.selectedTaskId() === taskId
+        ? ((container?.querySelector('task.isSelected') as HTMLElement | null) ?? null)
+        : null;
+    const matchedElement = directMatch ?? selectedMatch;
+    const el =
+      matchedElement && this._isTaskElementReady(matchedElement) ? matchedElement : null;
+    if (container && el) {
+      const relativeTop = this._getRelativeTopWithinContainer(el, container);
+      const containerCenterOffset = container.clientHeight / 2;
+      const elementCenterOffset = el.offsetHeight / 2;
+      const centeredTop = relativeTop - containerCenterOffset + elementCenterOffset;
+      container.scrollTop = Math.max(centeredTop, 0);
+      el.focus({ preventScroll: true });
+      this._pendingFocusItemTaskId = null;
+      return;
+    }
+
+    if (retriesLeft <= 0) {
+      return;
+    }
+
+    this._pendingFocusItemTimeout = window.setTimeout(() => {
+      this._pendingFocusItemTimeout = undefined;
+      this._focusItemInWorkViewWhenReady(taskId, retriesLeft - 1);
+    }, WorkViewComponent._FOCUS_ITEM_RETRY_DELAY);
+  }
+
+  private _getRelativeTopWithinContainer(
+    el: HTMLElement,
+    container: HTMLElement,
+  ): number {
+    let relativeTop = 0;
+    let current: HTMLElement | null = el;
+
+    while (current && current !== container) {
+      relativeTop += current.offsetTop;
+      current = current.offsetParent as HTMLElement | null;
+    }
+
+    return relativeTop;
+  }
+
+  private _isTaskElementReady(el: HTMLElement): boolean {
+    return (
+      document.body.contains(el) &&
+      el.getClientRects().length > 0 &&
+      el.getBoundingClientRect().height > 0
     );
   }
 


### PR DESCRIPTION
## Summary
- wait for the target task row to have real layout before treating search navigation as successful
- center the selected task inside the nearest scrollable task container
- add coverage for delayed task rendering in the layout service tests

## Root cause
Search-driven navigation could resolve the target task before the row had a real rendered height. That zero-height element made the scroll calculation collapse to the top of the list, so the task became selected without being brought into view.

## Validation
- reproduced with search navigation into KB Must Act
- validated the patched Windows build locally after rebuilding on aa-desktop
