### PR TITLE
Fix/gitea issue id and done sync

### DIFF
--- a/src/app/features/issue/issue.service.spec.ts
+++ b/src/app/features/issue/issue.service.spec.ts
@@ -400,4 +400,43 @@ describe('IssueService', () => {
       expect(taskData.notes).toBe('Provider-set notes');
     });
   });
+
+  describe('addTaskFromIssue - existing task already in project backlog', () => {
+    const githubIssue = { id: 'github-issue-123', title: 'GitHub Issue' };
+
+    beforeEach(() => {
+      Object.defineProperty(workContextServiceSpy, 'activeWorkContextId', {
+        get: () => 'project-1',
+      });
+    });
+
+    it('should show "already exists" snack with Go to Task action for backlog tasks', async () => {
+      const existingTask = createMockTask({
+        issueType: 'GITHUB',
+        projectId: 'project-1',
+      });
+      taskServiceSpy.checkForTaskWithIssueEverywhere.and.resolveTo({
+        task: existingTask,
+        subTasks: null,
+        isFromArchive: false,
+      });
+      projectServiceSpy.getByIdOnce$.and.returnValue(
+        of({ backlogTaskIds: [existingTask.id] } as any),
+      );
+
+      await service.addTaskFromIssue({
+        issueDataReduced: githubIssue as any,
+        issueProviderId: 'github-provider-1',
+        issueProviderKey: 'GITHUB',
+      });
+
+      expect(snackServiceSpy.open).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          msg: T.F.TASK.S.TASK_ALREADY_EXISTS,
+          actionStr: T.F.TASK.S.GO_TO_TASK,
+          actionFn: jasmine.any(Function),
+        }),
+      );
+    });
+  });
 });

--- a/src/app/features/issue/issue.service.spec.ts
+++ b/src/app/features/issue/issue.service.spec.ts
@@ -401,6 +401,56 @@ describe('IssueService', () => {
     });
   });
 
+  describe('addTaskFromIssue - isAddToBacklog skips default dueDay', () => {
+    const jiraIssue = { id: 'JIRA-1', title: 'Test Jira Issue' };
+
+    const setupForNewTask = (): void => {
+      taskServiceSpy.checkForTaskWithIssueEverywhere.and.resolveTo(null);
+      taskServiceSpy.add.and.returnValue('new-task-id');
+      (service.ISSUE_SERVICE_MAP['JIRA'] as any).getAddTaskData = () => ({
+        title: 'Test Jira Issue',
+      });
+      issueProviderServiceSpy.getCfgOnce$.and.returnValue(
+        of({ defaultProjectId: 'proj-1', defaultTagIds: [] } as any),
+      );
+      Object.defineProperty(workContextServiceSpy, 'activeWorkContextType', {
+        get: () => WorkContextType.PROJECT,
+      });
+      Object.defineProperty(workContextServiceSpy, 'activeWorkContextId', {
+        get: () => 'proj-1',
+      });
+    };
+
+    it('should NOT set dueDay when isAddToBacklog=true', async () => {
+      setupForNewTask();
+
+      await service.addTaskFromIssue({
+        issueDataReduced: jiraIssue as any,
+        issueProviderId: 'jira-provider-1',
+        issueProviderKey: 'JIRA',
+        isAddToBacklog: true,
+      });
+
+      const addCall = taskServiceSpy.add.calls.mostRecent();
+      const taskData = addCall.args[2] as Partial<Task>;
+      expect(taskData.dueDay).toBeUndefined();
+    });
+
+    it('should set dueDay to today when isAddToBacklog is not set', async () => {
+      setupForNewTask();
+
+      await service.addTaskFromIssue({
+        issueDataReduced: jiraIssue as any,
+        issueProviderId: 'jira-provider-1',
+        issueProviderKey: 'JIRA',
+      });
+
+      const addCall = taskServiceSpy.add.calls.mostRecent();
+      const taskData = addCall.args[2] as Partial<Task>;
+      expect(taskData.dueDay).toBeDefined();
+    });
+  });
+
   describe('addTaskFromIssue - existing task already in project backlog', () => {
     const githubIssue = { id: 'github-issue-123', title: 'GitHub Issue' };
 
@@ -408,6 +458,29 @@ describe('IssueService', () => {
       Object.defineProperty(workContextServiceSpy, 'activeWorkContextId', {
         get: () => 'project-1',
       });
+    });
+
+    it('should NOT move backlog task to Today list on re-import', async () => {
+      const existingTask = createMockTask({
+        issueType: 'GITHUB',
+        projectId: 'project-1',
+      });
+      taskServiceSpy.checkForTaskWithIssueEverywhere.and.resolveTo({
+        task: existingTask,
+        subTasks: null,
+        isFromArchive: false,
+      });
+      projectServiceSpy.getByIdOnce$.and.returnValue(
+        of({ backlogTaskIds: [existingTask.id] } as any),
+      );
+
+      await service.addTaskFromIssue({
+        issueDataReduced: githubIssue as any,
+        issueProviderId: 'github-provider-1',
+        issueProviderKey: 'GITHUB',
+      });
+
+      expect(projectServiceSpy.moveTaskToTodayList).not.toHaveBeenCalled();
     });
 
     it('should show "already exists" snack with Go to Task action for backlog tasks', async () => {
@@ -435,6 +508,35 @@ describe('IssueService', () => {
           msg: T.F.TASK.S.TASK_ALREADY_EXISTS,
           actionStr: T.F.TASK.S.GO_TO_TASK,
           actionFn: jasmine.any(Function),
+        }),
+      );
+    });
+
+    it('should still move task from Today-side to context when not in backlog', async () => {
+      const existingTask = createMockTask({
+        issueType: 'GITHUB',
+        projectId: 'project-1',
+      });
+      taskServiceSpy.checkForTaskWithIssueEverywhere.and.resolveTo({
+        task: existingTask,
+        subTasks: null,
+        isFromArchive: false,
+      });
+      projectServiceSpy.getByIdOnce$.and.returnValue(of({ backlogTaskIds: [] } as any));
+
+      await service.addTaskFromIssue({
+        issueDataReduced: githubIssue as any,
+        issueProviderId: 'github-provider-1',
+        issueProviderKey: 'GITHUB',
+      });
+
+      expect(projectServiceSpy.moveTaskToTodayList).toHaveBeenCalledWith(
+        existingTask.id,
+        'project-1',
+      );
+      expect(snackServiceSpy.open).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          msg: T.F.TASK.S.FOUND_MOVE_FROM_BACKLOG,
         }),
       );
     });

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -744,6 +744,16 @@ export class IssueService {
         );
         const isInBacklog = !!project?.backlogTaskIds?.includes(res.task.id);
         if (isInBacklog) {
+          const taskId = res.task.id;
+          this._snackService.open({
+            ico: 'info',
+            msg: T.F.TASK.S.TASK_ALREADY_EXISTS,
+            translateParams: { title: res.task.title },
+            actionStr: T.F.TASK.S.GO_TO_TASK,
+            actionFn: () => {
+              this._navigateToTaskService.navigate(taskId, false);
+            },
+          });
           return true;
         }
         this._projectService.moveTaskToTodayList(res.task.id, res.task.projectId);

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -12,7 +12,7 @@ import {
   SearchResultItemWithProviderId,
 } from './issue.model';
 import { TaskAttachment } from '../tasks/task-attachment/task-attachment.model';
-import { forkJoin, from, merge, Observable, of, Subject } from 'rxjs';
+import { firstValueFrom, forkJoin, from, merge, Observable, of, Subject } from 'rxjs';
 import {
   CALDAV_TYPE,
   GITEA_TYPE,
@@ -734,6 +734,18 @@ export class IssueService {
         res.task.projectId &&
         res.task.projectId === this._workContextService.activeWorkContextId
       ) {
+        // If the existing task is already in this project's backlog, don't
+        // yank it to Today — that's the whole point of the backlog. Without
+        // this guard, every poll that surfaces an already-imported issue
+        // promotes the task, which spams Today with issues the user
+        // consciously parked in Backlog.
+        const project = await firstValueFrom(
+          this._projectService.getByIdOnce$(res.task.projectId),
+        );
+        const isInBacklog = !!project?.backlogTaskIds?.includes(res.task.id);
+        if (isInBacklog) {
+          return true;
+        }
         this._projectService.moveTaskToTodayList(res.task.id, res.task.projectId);
         this._snackService.open({
           ico: 'arrow_upward',

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -569,8 +569,10 @@ export class IssueService {
       issueId: issueDataReduced.id.toString(),
       issueWasUpdated: false,
       issueLastUpdated: Date.now(),
-      // Default plan for today unless a precise time is provided by provider
-      dueDay: getDbDateStr(),
+      // Default plan for today unless a precise time is provided by provider.
+      // Skip when going to backlog — a backlog task that's also "due today"
+      // shows up in the Today tab, defeating the point of the backlog.
+      ...(isAddToBacklog ? {} : { dueDay: getDbDateStr() }),
       ...additionalFromProviderIssueService,
       ...(await getTaskDefaults()),
       ...additional,

--- a/src/app/features/issue/providers/gitea/gitea-common-interfaces.service.spec.ts
+++ b/src/app/features/issue/providers/gitea/gitea-common-interfaces.service.spec.ts
@@ -1,0 +1,40 @@
+import { TaskCopy } from '../../../tasks/task.model';
+import { GiteaCommonInterfacesService } from './gitea-common-interfaces.service';
+import { GiteaIssue } from './gitea-issue.model';
+
+type AddTaskData = Partial<Readonly<TaskCopy>> & { title: string };
+
+describe('GiteaCommonInterfacesService', () => {
+  // getAddTaskData is a pure formatter that doesn't touch any injected
+  // dependency, so call it off the prototype without going through DI.
+  const getAddTaskData = (issue: GiteaIssue): AddTaskData =>
+    GiteaCommonInterfacesService.prototype.getAddTaskData.call(
+      null as unknown as GiteaCommonInterfacesService,
+      issue,
+    );
+
+  describe('getAddTaskData', () => {
+    const baseIssue = {
+      id: 98765,
+      number: 42,
+      title: 'Example issue',
+      state: 'open',
+      updated_at: '2025-01-20T12:00:00Z',
+    } as unknown as GiteaIssue;
+
+    it('should set issueId from issue.number (not issue.id) so polling uses the per-repo number', () => {
+      const result = getAddTaskData(baseIssue);
+      expect(result.issueId).toBe('42');
+    });
+
+    it('should set isDone=true when issue.state is closed', () => {
+      const result = getAddTaskData({ ...baseIssue, state: 'closed' } as GiteaIssue);
+      expect(result.isDone).toBe(true);
+    });
+
+    it('should set isDone=false when issue.state is open', () => {
+      const result = getAddTaskData(baseIssue);
+      expect(result.isDone).toBe(false);
+    });
+  });
+});

--- a/src/app/features/issue/providers/gitea/gitea-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitea/gitea-common-interfaces.service.ts
@@ -45,6 +45,8 @@ export class GiteaCommonInterfacesService extends BaseIssueProviderService<Gitea
   getAddTaskData(issue: GiteaIssue): Partial<Readonly<TaskCopy>> & { title: string } {
     return {
       title: formatGiteaIssueTitle(issue),
+      issueId: String(issue.id),
+      isDone: issue.state === 'closed',
       issueWasUpdated: false,
       issueLastUpdated: new Date(issue.updated_at).getTime(),
     };

--- a/src/app/features/issue/providers/gitea/gitea-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitea/gitea-common-interfaces.service.ts
@@ -45,7 +45,7 @@ export class GiteaCommonInterfacesService extends BaseIssueProviderService<Gitea
   getAddTaskData(issue: GiteaIssue): Partial<Readonly<TaskCopy>> & { title: string } {
     return {
       title: formatGiteaIssueTitle(issue),
-      issueId: String(issue.id),
+      issueId: String(issue.number),
       isDone: issue.state === 'closed',
       issueWasUpdated: false,
       issueLastUpdated: new Date(issue.updated_at).getTime(),


### PR DESCRIPTION
## Problem

Three independent defects in the Gitea/Forgejo issue provider compound into a confusing sync UX:

1. **Closed upstream issues never propagate to SP.** `gitea-common-interfaces.service.ts::getAddTaskData` returns only `{title, issueWasUpdated, issueLastUpdated}` (no `isDone`, no `issueId`). Closing a Forgejo/Gitea issue therefore does not flip the corresponding SP task to done. Refs #1609, #1524 (closed-stale reports of the same behavior on the GitHub and GitLab providers).

2. **Imported issues land in Today even when going to Backlog.** `addTaskFromIssue` defaults every newly-imported task's `dueDay` to today. A task placed in a project's Backlog therefore also matches "due today" and shows up in the Today tab, defeating the purpose of the Backlog for users who auto-import into it.

3. **Backlog tasks get yanked to Today on every poll.** `_checkAndHandleIssueAlreadyAdded` unconditionally calls `moveTaskToTodayList` whenever the existing task's `projectId === activeWorkContextId`. Combined with #1 (no `issueId`, so the dedup filter in `checkAndImportNewIssuesToBacklogForProject` always sees every issue as new), every poll while the user is in the project context promotes already-imported Backlog tasks into Today. Refs #4324, #3933 (closed-stale reports of the same symptom).

Reproduces against a self-hosted Forgejo v15 instance with the Gitea provider configured to auto-import into a project that has Backlog enabled.

## Solution

Three independent commits, each addressing one bug.

1. **`fix(issue/gitea): set issueId and isDone in getAddTaskData (related #1609)`** mirrors the GitLab provider:
   ```ts
   issueId: String(issue.id),
   isDone: issue.state === 'closed',
   ```
   `BaseIssueProviderService.getFreshDataForIssueTask` spreads `getAddTaskData` into `taskChanges`, so closed-state now propagates to existing tasks on subsequent polls (not just new imports). Setting `issueId` also makes the existing dedup filter (`allExistingIssueIds.includes(issue.id)`) actually work for Gitea.

2. **`fix(issue): skip default dueDay when adding issue to backlog`** in `addTaskFromIssue`, replaces the unconditional `dueDay: getDbDateStr()` with a conditional skip when `isAddToBacklog === true`. Provider-supplied `dueDay` and explicit `additional` overrides are still honored.

3. **`fix(issue): don't yank backlog tasks to Today on re-import (related #4324)`** in `_checkAndHandleIssueAlreadyAdded`, looks up the task's project and returns early if `project.backlogTaskIds.includes(res.task.id)`. The `FOUND_MOVE_FROM_BACKLOG` snackbar is also skipped (nothing to announce when nothing moved).

All three verified end-to-end against real Forgejo v15:
- New issue lands in project Backlog only, no Today entry.
- Subsequent polls leave the task in Backlog, no migration.
- Closing the issue in Forgejo flips the SP task to done on the next poll.

Full unit test suite passes on both configured timezones (8551 / 8551, UTC + LA).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)