### PR TITLE
Improve typography system and add design tokens

### DIFF
--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -28,10 +28,44 @@
   // -----------------------------
   // Fonts
   // -----------------------------
+  // Lead with the native platform UI font (SF Pro on Apple, Segoe UI Variable
+  // on Win 11, Roboto on Android). Inter/Open Sans are graceful fallbacks.
   --font-primary-stack:
-    'Open Sans', 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji', 'Android Emoji', 'EmojiSymbols', -apple-system,
-    BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI Variable Text', 'Segoe UI', Roboto,
+    'Inter', 'Open Sans', 'Helvetica Neue', Arial, 'Noto Sans', 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', 'Android Emoji',
+    'EmojiSymbols', sans-serif;
+  --font-mono-stack:
+    ui-monospace, 'SF Mono', 'JetBrains Mono', 'Fira Code', Menlo, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+
+  // Type scale
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-md: 14px; // base
+  --font-size-lg: 16px;
+  --font-size-xl: 18px;
+  --font-size-2xl: 22px;
+  --font-size-3xl: 28px;
+  --font-size-4xl: 34px;
+
+  // Font weights
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  // Line heights (unitless so they scale with font-size)
+  --line-height-tight: 1.2;
+  --line-height-snug: 1.35;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.65;
+
+  // Letter spacing — modern UI tracking
+  --letter-spacing-tighter: -0.02em;
+  --letter-spacing-tight: -0.01em;
+  --letter-spacing-normal: 0;
+  --letter-spacing-wide: 0.02em;
 
   --s2: 16px; // 2 * 8px
   --s3: 24px; // 3 * 8px

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -100,7 +100,15 @@
   --bar-height-small: 40px;
   --mat-mini-fab-size: 48px;
   --mac-title-bar-padding: 20px;
-  --card-border-radius: 4px;
+
+  // Radius scale — use tokens below; legacy aliases kept for existing rules.
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 9999px;
+  --card-border-radius: var(--radius-md);
   --window-controls-width: 140px; // Fallback for non-WCO contexts; main-header uses env() directly
 
   // Z-index layers
@@ -228,7 +236,7 @@
   --task-icon-default-opacity: 0.7;
   --task-inner-padding-top-bottom: 4px;
   --task-is-done-dim-opacity: 0.3;
-  --task-border-radius: 4px;
+  --task-border-radius: var(--radius-sm);
 
   // Task z-indexes
   --z-drag-handle: 1;
@@ -257,6 +265,14 @@
   --separator-alpha: 0.3;
   --muted-alpha: 0.6;
   --intense-alpha: 0.9;
+
+  // -----------------------------
+  // Focus Ring (keyboard accessibility)
+  // -----------------------------
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
+  --focus-ring-color: var(--palette-primary-500);
+  --focus-ring: 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
 }
 
 // ===============================

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -14,6 +14,81 @@ app-root,
   box-sizing: border-box;
   font-optical-sizing: auto;
   font-family: var(--font-primary-stack);
+  // Crisper rendering on macOS/iOS and Windows/Linux
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  // Common kerning + contextual ligatures; tabular numerals keep digits aligned
+  // in tables (time spent, progress %, etc.)
+  font-feature-settings:
+    'kern' 1,
+    'liga' 1,
+    'clig' 1,
+    'calt' 1;
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+  letter-spacing: var(--letter-spacing-normal);
+}
+
+// Tabular figures for any numeric display (durations, counts, time)
+.tabular-nums,
+time,
+.time-display {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1;
+}
+
+// Headings: tighter tracking + snug leading for a more modern feel.
+// These are non-Material heading tags; Material components keep their own scale.
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: inherit;
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-snug);
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--text-color-most-intense);
+}
+
+h1 {
+  font-size: var(--font-size-3xl);
+  letter-spacing: var(--letter-spacing-tighter);
+  line-height: var(--line-height-tight);
+}
+
+h2 {
+  font-size: var(--font-size-2xl);
+  letter-spacing: var(--letter-spacing-tighter);
+}
+
+h3 {
+  font-size: var(--font-size-xl);
+}
+
+h4 {
+  font-size: var(--font-size-lg);
+}
+
+h5 {
+  font-size: var(--font-size-md);
+}
+
+h6 {
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wide);
+  color: var(--text-color-muted);
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--font-mono-stack);
+  font-feature-settings: 'liga' 0;
 }
 
 html {

--- a/src/styles/themes.scss
+++ b/src/styles/themes.scss
@@ -1,8 +1,11 @@
 @use '@angular/material' as mat;
 @use 'angular-material-css-vars' as mat-css-vars;
 
+// Mirror --font-primary-stack. The Material mixin only accepts a string here,
+// so CSS vars can't be used — keep this list in sync with `_css-variables.scss`.
 $custom-typography: mat.m2-define-typography-config(
-  $font-family: 'Open Sans, sans-serif',
+  $font-family:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI Variable Text", "Segoe UI", Roboto, Inter, "Open Sans", "Helvetica Neue", Arial, sans-serif',
 );
 @include mat-css-vars.init-material-css-vars($typography-config: $custom-typography);
 


### PR DESCRIPTION
## Problem

The application lacked a comprehensive typography system and design tokens for consistent styling across the codebase. Font rendering was not optimized, heading styles were not standardized, and spacing/sizing values were hardcoded rather than using reusable tokens.

## Solution

Implemented a complete typography and design token system:

**Typography Improvements:**
- Added font rendering optimizations (`-webkit-font-smoothing`, `-moz-osx-font-smoothing`, `text-rendering`) for crisper text on all platforms
- Configured OpenType features (kerning, ligatures, contextual alternates) for better text quality
- Reordered font stack to prioritize native platform fonts (SF Pro, Segoe UI Variable, Roboto) with Inter/Open Sans as fallbacks
- Added monospace font stack for code/kbd/pre/samp elements
- Standardized heading styles (h1-h6) with consistent font weights, line heights, and letter spacing
- Added tabular numerals support for numeric displays (time, counts, durations)

**Design Tokens:**
- Created comprehensive type scale (--font-size-xs through --font-size-4xl)
- Added font weight tokens (regular, medium, semibold, bold)
- Added line height tokens (tight, snug, normal, relaxed)
- Added letter spacing tokens (tighter, tight, normal, wide)
- Created radius scale (--radius-xs through --radius-pill) to replace hardcoded values
- Added focus ring tokens for keyboard accessibility
- Updated existing variables to use new tokens (e.g., --card-border-radius, --task-border-radius)

**Material Theme:**
- Updated Material typography config to match the new primary font stack

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)

## Test Plan

Visual verification of typography rendering across the application. No automated tests needed as these are styling changes that don't affect functionality.

https://claude.ai/code/session_01LgoStG2beb6dUsmHrx3EQr