### PR TITLE
chore(debug): add opt-in search navigation traces

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,7 @@ import { ActivatedRoute, RouterOutlet } from '@angular/router';
 import { concatMap, first, take } from 'rxjs/operators';
 
 import { IS_MOBILE } from './util/is-mobile';
+import { recordSearchNavDebug } from './util/search-nav-debug';
 import { warpAnimation, warpInAnimation } from './ui/animations/warp.ani';
 import { AddTaskBarComponent } from './features/tasks/add-task-bar/add-task-bar.component';
 import { Dir } from '@angular/cdk/bidi';
@@ -226,6 +227,10 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     this._subs.add(
       this._activatedRoute.queryParams.subscribe((params) => {
         if (!!params.focusItem) {
+          recordSearchNavDebug('appComponent:focusQueryParam', {
+            focusItem: params.focusItem,
+            url: window.location.pathname + window.location.search,
+          });
           this._focusElement(params.focusItem);
         }
       }),
@@ -440,7 +445,16 @@ export class AppComponent implements OnDestroy, AfterViewInit {
    * retrying until the rendered task row is available avoids missing focus targets
    */
   private _focusElement(id: string): void {
+    recordSearchNavDebug('appComponent:focusElement', {
+      taskId: id,
+      url: window.location.pathname + window.location.search,
+    });
     this.layoutService.focusTaskInViewWhenReady(id, (el) => {
+      recordSearchNavDebug('appComponent:focusElement:success', {
+        taskId: id,
+        url: window.location.pathname + window.location.search,
+        matchedElementId: el.id,
+      });
       if (el && IS_MOBILE) {
         el.classList.add('mobile-highlight-searched-item');
         el.addEventListener('blur', () =>

--- a/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
+++ b/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
@@ -13,6 +13,7 @@ import { SnackService } from '../../core/snack/snack.service';
 import { T } from '../../t.const';
 import { Log } from '../../core/log';
 import { LayoutService } from '../layout/layout.service';
+import { recordSearchNavDebug } from '../../util/search-nav-debug';
 
 @Injectable({
   providedIn: 'root',
@@ -32,8 +33,22 @@ export class NavigateToTaskService {
         throw new Error(`Task with id ${taskId} not found`);
       }
       const location = await this._getLocation(task, isArchiveTask);
+      recordSearchNavDebug('navigateToTask:start', {
+        taskId,
+        isArchiveTask,
+        currentUrl: this._router.url,
+        location,
+        parentId: task.parentId || null,
+        projectId: task.projectId || null,
+        firstTagId: task.tagIds?.[0] || null,
+      });
 
       if (this._router.url.startsWith(location)) {
+        recordSearchNavDebug('navigateToTask:sameContext', {
+          taskId,
+          currentUrl: this._router.url,
+          location,
+        });
         this._focusTaskElement(taskId);
         return;
       }
@@ -44,8 +59,18 @@ export class NavigateToTaskService {
       } else {
         queryParams.isInBacklog = await this._isInBacklog(task);
       }
+      recordSearchNavDebug('navigateToTask:routeChange', {
+        taskId,
+        location,
+        queryParams,
+      });
       await this._router.navigate([location], { queryParams });
     } catch (err) {
+      recordSearchNavDebug('navigateToTask:error', {
+        taskId,
+        isArchiveTask,
+        error: err instanceof Error ? err.message : String(err),
+      });
       Log.err(err);
       this._snackService.open({
         type: 'ERROR',

--- a/src/app/features/work-view/work-view.component.ts
+++ b/src/app/features/work-view/work-view.component.ts
@@ -67,6 +67,7 @@ import {
 } from '../task-repeat-cfg/store/task-repeat-cfg.selectors';
 import { TaskRepeatCfg } from '../task-repeat-cfg/task-repeat-cfg.model';
 import { RepeatCfgPreviewComponent } from '../task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component';
+import { recordSearchNavDebug } from '../../util/search-nav-debug';
 
 @Component({
   selector: 'work-view',
@@ -209,6 +210,11 @@ export class WorkViewComponent implements OnInit, OnDestroy {
   @ViewChild('splitTopEl', { read: ElementRef }) set splitTopElRef(ref: ElementRef) {
     if (ref) {
       this._splitTopElement = ref.nativeElement;
+      recordSearchNavDebug('workView:splitTopElReady', {
+        selectedTaskId: this.selectedTaskId(),
+        clientHeight: ref.nativeElement.clientHeight,
+        scrollHeight: ref.nativeElement.scrollHeight,
+      });
       this.splitTopEl$.next(ref.nativeElement);
       if (this._pendingFocusItemTaskId) {
         this._focusItemInWorkViewWhenReady(this._pendingFocusItemTaskId);
@@ -291,6 +297,11 @@ export class WorkViewComponent implements OnInit, OnDestroy {
           this.splitInputPos = 50;
         }
         if (params?.focusItem) {
+          recordSearchNavDebug('workView:focusQueryParam', {
+            focusItem: params.focusItem,
+            selectedTaskId: this.selectedTaskId(),
+            splitInputPos: this.splitInputPos,
+          });
           this._pendingFocusItemTaskId = params.focusItem;
           this._focusItemInWorkViewWhenReady(params.focusItem);
         } else {
@@ -374,6 +385,18 @@ export class WorkViewComponent implements OnInit, OnDestroy {
     const matchedElement = directMatch ?? selectedMatch;
     const el =
       matchedElement && this._isTaskElementReady(matchedElement) ? matchedElement : null;
+    recordSearchNavDebug('workView:focusAttempt', {
+      taskId,
+      retriesLeft,
+      selectedTaskId: this.selectedTaskId(),
+      hasContainer: !!container,
+      hasDirectMatch: !!directMatch,
+      hasSelectedMatch: !!selectedMatch,
+      matchedElementHeight: matchedElement?.getBoundingClientRect().height ?? null,
+      containerScrollTop: container?.scrollTop ?? null,
+      containerClientHeight: container?.clientHeight ?? null,
+      containerScrollHeight: container?.scrollHeight ?? null,
+    });
     if (container && el) {
       const relativeTop = this._getRelativeTopWithinContainer(el, container);
       const containerCenterOffset = container.clientHeight / 2;
@@ -381,6 +404,25 @@ export class WorkViewComponent implements OnInit, OnDestroy {
       const centeredTop = relativeTop - containerCenterOffset + elementCenterOffset;
       container.scrollTop = Math.max(centeredTop, 0);
       el.focus({ preventScroll: true });
+      recordSearchNavDebug('workView:focusSuccess', {
+        taskId,
+        selectedTaskId: this.selectedTaskId(),
+        matchedElementId: el.id,
+        relativeTop,
+        elementOffsetHeight: el.offsetHeight,
+        centeredTop,
+        appliedScrollTop: container.scrollTop,
+      });
+      window.setTimeout(() => {
+        recordSearchNavDebug('workView:focusPostTick', {
+          taskId,
+          selectedTaskId: this.selectedTaskId(),
+          matchedElementId: el.id,
+          containerScrollTop: container.scrollTop,
+          containerClientHeight: container.clientHeight,
+          containerScrollHeight: container.scrollHeight,
+        });
+      }, 0);
       this._pendingFocusItemTaskId = null;
       return;
     }

--- a/src/app/util/search-nav-debug.ts
+++ b/src/app/util/search-nav-debug.ts
@@ -1,0 +1,43 @@
+import { Log } from '../core/log';
+
+type SearchNavDebugPayload = Record<string, unknown>;
+
+interface SearchNavDebugEntry extends SearchNavDebugPayload {
+  at: string;
+  event: string;
+}
+
+const DEBUG_FLAG = 'SP_SEARCH_NAV_DEBUG';
+const MAX_ENTRIES = 100;
+const DEBUG_CONTEXT = 'search-nav-debug';
+
+let _entries: SearchNavDebugEntry[] = [];
+
+const _isEnabled = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof localStorage !== 'undefined' &&
+  localStorage.getItem(DEBUG_FLAG) === '1';
+
+export const recordSearchNavDebug = (
+  event: string,
+  payload: SearchNavDebugPayload = {},
+): void => {
+  if (!_isEnabled()) {
+    return;
+  }
+
+  const entry: SearchNavDebugEntry = {
+    at: new Date().toISOString(),
+    event,
+    ...payload,
+  };
+
+  _entries = [..._entries.slice(-(MAX_ENTRIES - 1)), entry];
+  (
+    window as Window & {
+      __spSearchNavDebug?: SearchNavDebugEntry[];
+    }
+  ).__spSearchNavDebug = _entries;
+
+  Log.log(`[${DEBUG_CONTEXT}]`, entry);
+};


### PR DESCRIPTION
## Summary
- add an opt-in search navigation trace helper behind localStorage flag SP_SEARCH_NAV_DEBUG
- keep trace history in memory on window.__spSearchNavDebug instead of writing debug files
- instrument the navigation, route-change, and work-view focus path for future diagnosis of rendering and scroll timing issues

## Notes
- disabled by default
- no disk writes
- intended only for debugging search-navigation issues
