### PR TITLE
feat(plugins): emit taskUpdate hook for project moves

### DIFF
--- a/src/app/plugins/plugin-hooks.effects.spec.ts
+++ b/src/app/plugins/plugin-hooks.effects.spec.ts
@@ -6,7 +6,7 @@ import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { PluginService } from './plugin.service';
 import { TaskSharedActions } from '../root-store/meta/task-shared.actions';
 import { PlannerActions } from '../features/planner/store/planner.actions';
-import { Task, TaskCopy } from '../features/tasks/task.model';
+import { TaskWithSubTasks } from '../features/tasks/task.model';
 import { PluginHooks } from './plugin-api.model';
 import {
   selectCurrentTask,
@@ -20,13 +20,14 @@ describe('PluginHooksEffects', () => {
   let pluginServiceMock: jasmine.SpyObj<PluginService>;
   let store: MockStore;
 
-  const createMockTask = (overrides: Partial<Task> = {}): Task =>
+  const createMockTask = (overrides: Partial<TaskWithSubTasks> = {}): TaskWithSubTasks =>
     ({
       id: 'task-123',
       title: 'Test Task',
       projectId: null,
       tagIds: [],
       subTaskIds: [],
+      subTasks: [],
       parentId: null,
       timeSpentOnDay: {},
       timeSpent: 0,
@@ -48,9 +49,9 @@ describe('PluginHooksEffects', () => {
       created: Date.now(),
       _showSubTasksMode: 2,
       ...overrides,
-    }) as Task;
+    }) as TaskWithSubTasks;
 
-  let mockTask: Task;
+  let mockTask: TaskWithSubTasks;
 
   beforeEach(() => {
     mockTask = createMockTask();
@@ -174,7 +175,7 @@ describe('PluginHooksEffects', () => {
       const targetProjectId = 'project-456';
       actions$ = of(
         TaskSharedActions.moveToOtherProject({
-          task: mockTask as TaskCopy,
+          task: mockTask,
           targetProjectId,
         }),
       );
@@ -195,7 +196,7 @@ describe('PluginHooksEffects', () => {
       const day = '2024-01-15';
       actions$ = of(
         PlannerActions.planTaskForDay({
-          task: mockTask as TaskCopy,
+          task: mockTask,
           day,
         }),
       );
@@ -216,7 +217,7 @@ describe('PluginHooksEffects', () => {
       const newDay = '2024-01-16';
       actions$ = of(
         PlannerActions.transferTask({
-          task: mockTask as TaskCopy,
+          task: mockTask,
           prevDay: '2024-01-15',
           newDay,
           targetIndex: 0,

--- a/src/app/plugins/plugin-hooks.effects.spec.ts
+++ b/src/app/plugins/plugin-hooks.effects.spec.ts
@@ -170,6 +170,27 @@ describe('PluginHooksEffects', () => {
       });
     });
 
+    it('should dispatch TASK_UPDATE hook on moveToOtherProject action', (done) => {
+      const targetProjectId = 'project-456';
+      actions$ = of(
+        TaskSharedActions.moveToOtherProject({
+          task: mockTask as TaskCopy,
+          targetProjectId,
+        }),
+      );
+
+      effects.taskUpdate$.subscribe(() => {
+        expect(pluginServiceMock.dispatchHook).toHaveBeenCalledWith(
+          PluginHooks.TASK_UPDATE,
+          jasmine.objectContaining({
+            taskId: mockTask.id,
+            changes: { projectId: targetProjectId },
+          }),
+        );
+        done();
+      });
+    });
+
     it('should dispatch TASK_UPDATE hook on planTaskForDay action', (done) => {
       const day = '2024-01-15';
       actions$ = of(

--- a/src/app/plugins/plugin-hooks.effects.ts
+++ b/src/app/plugins/plugin-hooks.effects.ts
@@ -98,6 +98,7 @@ export class PluginHooksEffects {
           TaskSharedActions.scheduleTaskWithTime,
           TaskSharedActions.reScheduleTaskWithTime,
           TaskSharedActions.unscheduleTask,
+          TaskSharedActions.moveToOtherProject,
           PlannerActions.planTaskForDay,
           PlannerActions.transferTask,
         ),
@@ -118,6 +119,9 @@ export class PluginHooksEffects {
           } else if (action.type === TaskSharedActions.unscheduleTask.type) {
             taskId = action.id;
             changes = { dueWithTime: undefined, reminderId: undefined };
+          } else if (action.type === TaskSharedActions.moveToOtherProject.type) {
+            taskId = action.task.id;
+            changes = { projectId: action.targetProjectId };
           } else if (action.type === PlannerActions.planTaskForDay.type) {
             taskId = action.task.id;
             changes = { dueDay: action.day, dueWithTime: undefined };


### PR DESCRIPTION
## Summary
- dispatch the TASK_UPDATE plugin hook when a task is moved to another project
- include the new projectId in the emitted change payload
- update the plugin hook fixture/spec coverage for the current task hook action set

## Local verification
- export CHROME_BIN="/home/aakhter/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome"
- npm run test:file -- src/app/plugins/plugin-hooks.effects.spec.ts --browsers ChromeHeadless
- result: 9 SUCCESS
