### PR TITLE
fix(github-plugin): enable github advanced search to make queries including "OR" or "AND" logic operators work

### DIFF
--- a/packages/plugin-dev/github-issue-provider/src/plugin.ts
+++ b/packages/plugin-dev/github-issue-provider/src/plugin.ts
@@ -170,7 +170,7 @@ PluginAPI.registerIssueProvider({
       searchTerm.includes('is:issue') || searchTerm.includes('is:pull-request');
     const typeFilter = hasTypeFilter ? '' : ' is:issue';
     const q = encodeGithubQuery(`repo:${owner}/${repo}${typeFilter} ${searchTerm}`);
-    const url = `${API_BASE}/search/issues?q=${q}&per_page=50`;
+    const url = `${API_BASE}/search/issues?q=${q}&per_page=50&advanced_search=true`;
     const response = await http.get<GithubSearchResponse>(url);
     return (response.items || []).map(mapSearchResult);
   },
@@ -270,7 +270,7 @@ PluginAPI.registerIssueProvider({
     const { owner, repo } = parseRepo(cfg);
     const query = cfg.backlogQuery || 'sort:updated state:open assignee:@me';
     const q = encodeGithubQuery(`repo:${owner}/${repo} is:issue ${query}`);
-    const url = `${API_BASE}/search/issues?q=${q}&per_page=50`;
+    const url = `${API_BASE}/search/issues?q=${q}&per_page=50&advanced_search=true`;
     const response = await http.get<GithubSearchResponse>(url);
     return (response.items || []).map(mapSearchResult);
   },


### PR DESCRIPTION
## Problem

Using advanced search queries with logic operators like "OR" are supported by Github, but dont currently work in Super Productivity's Github Issue Search
This fixes #4913

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

## Solution

Enabling advanced_search fixes this, with no side effects from what i could gather.

<!-- Describe your changes in detail. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
