### PR TITLE
feat(plugins): add reInitData API

### DIFF
--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -395,6 +395,7 @@ export interface PluginAPI {
 
   getCurrentContextTasks(): Promise<Task[]>;
 
+  reInitData(): Promise<void>;
   updateTask(taskId: string, updates: Partial<Task>): Promise<void>;
 
   addTask(taskData: PluginCreateTaskData): Promise<string>;

--- a/src/app/plugins/plugin-api.spec.ts
+++ b/src/app/plugins/plugin-api.spec.ts
@@ -4,6 +4,7 @@ import { PluginBaseCfg } from './plugin-api.model';
 describe('PluginAPI', () => {
   let pluginAPI: PluginAPI;
   let showIndexHtmlAsViewSpy: jasmine.Spy;
+  let reInitDataSpy: jasmine.Spy;
 
   const baseCfg: PluginBaseCfg = {
     theme: 'light',
@@ -14,10 +15,13 @@ describe('PluginAPI', () => {
 
   beforeEach(() => {
     showIndexHtmlAsViewSpy = jasmine.createSpy('showIndexHtmlAsView');
+    reInitDataSpy = jasmine.createSpy('reInitData').and.resolveTo();
 
     const mockBridge = jasmine.createSpyObj('PluginBridgeService', [
       'createBoundMethods',
+      'reInitData',
     ]);
+    mockBridge.reInitData.and.callFake(reInitDataSpy);
     mockBridge.createBoundMethods.and.returnValue({
       showIndexHtmlAsView: showIndexHtmlAsViewSpy,
       log: {
@@ -45,6 +49,13 @@ describe('PluginAPI', () => {
     it('should delegate to the bridge method', () => {
       pluginAPI.showIndexHtmlAsView();
       expect(showIndexHtmlAsViewSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reInitData()', () => {
+    it('should delegate to the bridge method', async () => {
+      await pluginAPI.reInitData();
+      expect(reInitDataSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -179,6 +179,10 @@ export class PluginAPI implements PluginAPIInterface {
     return tasks.map(taskCopyToTaskData);
   }
 
+  async reInitData(): Promise<void> {
+    PluginLog.log(`Plugin ${this._pluginId} requested data re-init`);
+    return this._pluginBridge.reInitData();
+  }
   async updateTask(taskId: string, updates: Partial<Task>): Promise<void> {
     PluginLog.log(`Plugin ${this._pluginId} requested to update task ${taskId}`);
     const taskCopyUpdates = taskDataToPartialTaskCopy(updates);

--- a/src/app/plugins/plugin-bridge-counter.service.spec.ts
+++ b/src/app/plugins/plugin-bridge-counter.service.spec.ts
@@ -27,6 +27,7 @@ import { PluginIssueProviderRegistryService } from './issue-provider/plugin-issu
 import { IssueSyncAdapterRegistryService } from '../features/issue/two-way-sync/issue-sync-adapter-registry.service';
 import { PluginHttpService } from './issue-provider/plugin-http.service';
 import { getDbDateStr } from '../util/get-db-date-str';
+import { DataInitService } from '../core/data-init/data-init.service';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 describe('PluginBridgeService.setCounter()', () => {
@@ -55,6 +56,8 @@ describe('PluginBridgeService.setCounter()', () => {
     const workContextServiceSpy = jasmine.createSpyObj('WorkContextService', [
       'activeWorkContext$',
     ]);
+    const dataInitServiceSpy = jasmine.createSpyObj('DataInitService', ['reInit']);
+    dataInitServiceSpy.reInit.and.resolveTo();
 
     TestBed.configureTestingModule({
       providers: [
@@ -103,6 +106,7 @@ describe('PluginBridgeService.setCounter()', () => {
         { provide: PluginIssueProviderRegistryService, useValue: {} },
         { provide: IssueSyncAdapterRegistryService, useValue: {} },
         { provide: PluginHttpService, useValue: {} },
+        { provide: DataInitService, useValue: dataInitServiceSpy },
       ],
     });
 

--- a/src/app/plugins/plugin-bridge.service.spec.ts
+++ b/src/app/plugins/plugin-bridge.service.spec.ts
@@ -597,11 +597,13 @@ import { PluginIssueProviderRegistryService } from './issue-provider/plugin-issu
 import { IssueSyncAdapterRegistryService } from '../features/issue/two-way-sync/issue-sync-adapter-registry.service';
 import { PluginHttpService } from './issue-provider/plugin-http.service';
 import { getDbDateStr } from '../util/get-db-date-str';
+import { DataInitService } from '../core/data-init/data-init.service';
 
 describe('PluginBridgeService - Counter Methods', () => {
   let service: PluginBridgeService;
   let store: MockStore;
   let dispatchSpy: jasmine.Spy;
+  let dataInitService: jasmine.SpyObj<DataInitService>;
 
   const mockExistingCounter: SimpleCounter = {
     ...EMPTY_SIMPLE_COUNTER,
@@ -613,6 +615,9 @@ describe('PluginBridgeService - Counter Methods', () => {
   };
 
   beforeEach(() => {
+    const dataInitServiceSpy = jasmine.createSpyObj('DataInitService', ['reInit']);
+    dataInitServiceSpy.reInit.and.resolveTo();
+
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
@@ -639,16 +644,18 @@ describe('PluginBridgeService - Counter Methods', () => {
         { provide: PluginIssueProviderRegistryService, useValue: {} },
         { provide: IssueSyncAdapterRegistryService, useValue: {} },
         { provide: PluginHttpService, useValue: {} },
+        { provide: DataInitService, useValue: dataInitServiceSpy },
       ],
     });
 
     service = TestBed.inject(PluginBridgeService);
     store = TestBed.inject(MockStore);
+    dataInitService = TestBed.inject(DataInitService) as jasmine.SpyObj<DataInitService>;
     dispatchSpy = spyOn(store, 'dispatch').and.callThrough();
   });
 
   afterEach(() => {
-    store.resetSelectors();
+    store?.resetSelectors();
   });
 
   describe('setCounter', () => {
@@ -808,6 +815,14 @@ describe('PluginBridgeService - Counter Methods', () => {
 
       (service as any)._configHandlers.delete('test-plugin');
       expect(service.hasConfigHandler('test-plugin')).toBe(false);
+    });
+  });
+
+  describe('reInitData', () => {
+    it('should delegate to DataInitService.reInit', async () => {
+      await service.reInitData();
+
+      expect(dataInitService.reInit).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -79,6 +79,7 @@ import {
   upsertSimpleCounter,
 } from '../features/simple-counter/store/simple-counter.actions';
 import { getDbDateStr } from '../util/get-db-date-str';
+import { DataInitService } from '../core/data-init/data-init.service';
 
 /**
  * PluginBridge acts as an intermediary layer between plugins and the main application services.
@@ -113,6 +114,7 @@ export class PluginBridgeService implements OnDestroy {
   private _syncAdapterRegistry = inject(IssueSyncAdapterRegistryService);
   private _pluginHttpService = inject(PluginHttpService);
   private _pluginOAuthBridge = inject(PluginOAuthBridgeService);
+  private _dataInitService = inject(DataInitService);
 
   // Track header buttons registered by plugins
   private readonly _headerButtons = signal<PluginHeaderBtnCfg[]>([]);
@@ -487,6 +489,10 @@ export class PluginBridgeService implements OnDestroy {
     return contextTasks || [];
   }
 
+  async reInitData(): Promise<void> {
+    PluginLog.log('PluginBridge: Re-initializing app data');
+    await this._dataInitService.reInit();
+  }
   /**
    * Update a task
    */

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -294,6 +294,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
           getTasks: () => callApi('getTasks'),
           getArchivedTasks: () => callApi('getArchivedTasks'),
           getCurrentContextTasks: () => callApi('getCurrentContextTasks'),
+          reInitData: () => callApi('reInitData'),
           updateTask: (taskId, updates) => callApi('updateTask', [taskId, updates]),
           addTask: (taskData) => callApi('addTask', [taskData]),
           deleteTask: (taskId) => callApi('deleteTask', [taskId]),


### PR DESCRIPTION
## Summary
- add a `reInitData()` method to the public plugin API surface
- wire the call through the iframe bridge into `DataInitService.reInit()`
- add a focused `PluginAPI` delegation spec for the new method

## Testing
- `bash -lc 'export CHROME_BIN="$HOME/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome"; npm run test:file -- src/app/plugins/plugin-api.spec.ts --browsers ChromeHeadless'`
  - `TOTAL: 2 SUCCESS`
