### PR TITLE
fix(tasks): keep hover controls visible on Glass theme

### DIFF
--- a/e2e/tests/task-detail/task-time-visibility.spec.ts
+++ b/e2e/tests/task-detail/task-time-visibility.spec.ts
@@ -1,0 +1,33 @@
+import { Locator, Page } from 'playwright/test';
+
+import { expect, test } from '../../fixtures/test.fixture';
+import { WorkViewPage } from '../../pages/work-view.page';
+
+test.describe('Task time visibility', () => {
+
+  const addTaskAndFillEstimatedTime = async (
+    workViewPage: WorkViewPage,
+    page: Page,
+  ): Promise<void> => {
+    await workViewPage.waitForTaskList();
+
+    await workViewPage.addTask('task');
+    await page.getByText(/task/).first().hover();
+    await page.getByRole('button', { name: 'Show/Hide additional info' }).click();
+
+    const durationInput: Locator = page.locator('.mat-ripple.ripple').first();
+    await durationInput.click();
+    const timeSpentInput: Locator = page.getByText('Estimate');
+    await timeSpentInput.fill('45');
+    await page.getByRole('button', { name: 'Save' }).click();
+  };
+
+  test('Task time data should be invisible on hover', async ({ page, workViewPage }) => {
+    await addTaskAndFillEstimatedTime(workViewPage, page);
+
+    const timeWrapper = page.locator('.time-wrapper');
+    await expect(timeWrapper).toBeVisible({ timeout: 3000 });
+    await page.getByText(/task/).first().hover();
+    await expect(timeWrapper).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/e2e/tests/task-detail/task-time-visibility.spec.ts
+++ b/e2e/tests/task-detail/task-time-visibility.spec.ts
@@ -1,33 +1,106 @@
-import { Locator, Page } from 'playwright/test';
+import { Locator, Page } from '@playwright/test';
 
+import { cssSelectors } from '../../constants/selectors';
 import { expect, test } from '../../fixtures/test.fixture';
 import { WorkViewPage } from '../../pages/work-view.page';
+import { TaskPage } from '../../pages';
+
+const { FIRST_TASK, SECOND_TASK, SUB_TASK, MAIN } = cssSelectors;
 
 test.describe('Task time visibility', () => {
-
-  const addTaskAndFillEstimatedTime = async (
-    workViewPage: WorkViewPage,
-    page: Page,
-  ): Promise<void> => {
-    await workViewPage.waitForTaskList();
-
-    await workViewPage.addTask('task');
-    await page.getByText(/task/).first().hover();
-    await page.getByRole('button', { name: 'Show/Hide additional info' }).click();
-
-    const durationInput: Locator = page.locator('.mat-ripple.ripple').first();
+  const fillEstimatedTime = async (page: Page, time: number): Promise<void> => {
+    // time-estimate/Duration position might need adjusting if detail-menu is changed
+    const durationInput: Locator = page.locator(
+      'task-detail-item:nth-child(3) > .input-item > .mat-ripple',
+    );
     await durationInput.click();
-    const timeSpentInput: Locator = page.getByText('Estimate');
+    const timeSpentInput: Locator = page.getByText('Estimate', { exact: true });
     await timeSpentInput.fill('45');
     await page.getByRole('button', { name: 'Save' }).click();
   };
 
-  test('Task time data should be invisible on hover', async ({ page, workViewPage }) => {
-    await addTaskAndFillEstimatedTime(workViewPage, page);
+  const addTaskAndFillEstimatedTime = async (
+    workViewPage: WorkViewPage,
+    page: Page,
+    taskPage: TaskPage,
+    taskName: string,
+  ): Promise<void> => {
+    await workViewPage.waitForTaskList();
+
+    await workViewPage.addTask(taskName);
+    const task = taskPage.getTaskByText(taskName);
+    await taskPage.openTaskDetail(task);
+
+    await fillEstimatedTime(page, 45);
+    //close the detail page
+    await taskPage.toggleTaskDetail(task);
+  };
+
+  const addSubtaskToTaskAndFillEstimatedTime = async (
+    workViewPage: WorkViewPage,
+    page: Page,
+    taskPage: TaskPage,
+    taskName: string,
+    subName: string,
+  ): Promise<void> => {
+    await workViewPage.waitForTaskList();
+
+    const task = taskPage.getTaskByText(taskName);
+    await workViewPage.addSubTask(task, subName);
+    const subTask = taskPage.getSubTasks(task);
+    await taskPage.openTaskDetail(subTask);
+
+    await fillEstimatedTime(page, 30);
+  };
+
+  test('Task time data should be invisible on hover', async ({ page, workViewPage, taskPage, }) => {
+    await addTaskAndFillEstimatedTime(workViewPage, page, taskPage, 'task 1');
+    //hover(MAIN) to reset mouse away from tasks
+    await page.hover(MAIN);
 
     const timeWrapper = page.locator('.time-wrapper');
     await expect(timeWrapper).toBeVisible({ timeout: 3000 });
-    await page.getByText(/task/).first().hover();
+    await page.hover(FIRST_TASK);
     await expect(timeWrapper).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('Task time data should be invisible on hover only for specific task', async ({ page, workViewPage, taskPage, }) => {
+    await addTaskAndFillEstimatedTime(workViewPage, page, taskPage, 'task 1');
+    await addTaskAndFillEstimatedTime(workViewPage, page, taskPage, 'task 2');
+    await page.hover(MAIN);
+
+    const timeWrapper1 = page.locator('.time-wrapper').first();
+    const timeWrapper2 = page.locator('.time-wrapper').last();
+    await expect(timeWrapper1).toBeVisible({ timeout: 3000 });
+    await expect(timeWrapper2).toBeVisible({ timeout: 3000 });
+    await page.hover(FIRST_TASK);
+    await expect(timeWrapper1).not.toBeVisible({ timeout: 3000 });
+    await expect(timeWrapper2).toBeVisible({ timeout: 3000 });
+    await page.hover(SECOND_TASK);
+    await expect(timeWrapper2).not.toBeVisible({ timeout: 3000 });
+    await expect(timeWrapper1).toBeVisible({ timeout: 3000 });
+  });
+
+  test('Task time data should be visible on hover if task has subtask', async ({ page, workViewPage, taskPage, }) => {
+    await addTaskAndFillEstimatedTime(workViewPage, page, taskPage, 'task 1');
+    await addSubtaskToTaskAndFillEstimatedTime(
+      workViewPage,
+      page,
+      taskPage,
+      'task 1',
+      'subtask 1',
+    );
+    await page.hover(MAIN);
+
+    const timeWrapper = page.locator('.time-wrapper').first();
+    const timeWrapperSub = page.locator('.time-wrapper').last();
+    await expect(timeWrapper).toBeVisible({ timeout: 3000 });
+    await expect(timeWrapperSub).toBeVisible({ timeout: 3000 });
+    await page.hover(FIRST_TASK);
+    await expect(timeWrapper).toBeVisible({ timeout: 3000 });
+    await expect(timeWrapperSub).toBeVisible({ timeout: 3000 });
+    await page.hover(SUB_TASK);
+    await expect(timeWrapper).toBeVisible({ timeout: 3000 });
+    await expect(timeWrapperSub).not.toBeVisible({ timeout: 3000 });
   });
 });

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -56,6 +56,10 @@
           (click)="estimateTime()"
           [class.hasNoTimeSpentOrEstimate]="!t.timeSpent && !t.timeEstimate"
           [class.isEditable]="!t.subTasks?.length"
+          [style.visibility]="
+          isFirstLineHover && !IS_TOUCH_PRIMARY && !t.subTasks?.length
+            ? 'hidden'
+            : 'visible'"
           class="time-wrapper"
         >
           @if (!t.subTasks?.length) {

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -57,9 +57,10 @@
           [class.hasNoTimeSpentOrEstimate]="!t.timeSpent && !t.timeEstimate"
           [class.isEditable]="!t.subTasks?.length"
           [style.visibility]="
-          isFirstLineHover && !IS_TOUCH_PRIMARY && !t.subTasks?.length
-            ? 'hidden'
-            : 'visible'"
+            isFirstLineHover && !isTouchActive() && !t.subTasks?.length
+              ? 'hidden'
+              : 'visible'
+          "
           class="time-wrapper"
         >
           @if (!t.subTasks?.length) {


### PR DESCRIPTION
## Problem

With the glass theme, hovering the mouse over a task creates an overlap of the time information and the action buttons (the buttons that appear when hovering the mouse over a task). #5109 

## Solution

The task's time-wrapper visibility is set to hidden when hovering the mouse over a task.
Tasks with sub-tasks are excluded, as they dont have action buttons.

## Test

A new test that verifies if time-wrapper is visible and becomes hidden when hovering was also implemented.
The test creates a simple task with estimated time of 45 minutes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
