### PR TITLE
fix(plugins): Change AutoPlan plugin URLs to Codeberg

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -26,9 +26,9 @@
   {
     "name": "AutoPlan",
     "shortDescription": "Smart non-AI plugin for the automatic scheduling of tasks using priorities assigned automatically based on tags, projects, and time estimation.",
-    "url": "https://github.com/00sapo/sp-autoplan",
+    "url": "https://codeberg.org/00sapo/sp-autoplan",
     "author": "00sapo",
-    "authorUrl": "https://github.com/00sapo",
+    "authorUrl": "https://codeberg.org/00sapo",
     "stars": 28
   },
   {


### PR DESCRIPTION
## Problem
<img width="967" height="291" alt="Screenshot 2026-04-24 at 11 21 43" src="https://github.com/user-attachments/assets/69573ebb-0b14-4b37-9710-b7c7fe7f5a35" />

Github repo https://github.com/00sapo/sp-autoplan was archived on the 22nd Feb 2026.

## Solution

Updated URLs for AutoPlan plugin to point to Codeberg

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)
