### PR TITLE
fix(schedule): clamp schedule event titles

### DIFF
--- a/src/app/features/schedule/schedule-event/schedule-event.component.html
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.html
@@ -62,27 +62,32 @@
 </div>
 <!-- -->
 
-<div class="title">
-  <!--  {{ se().data['plannedForDay'] }}-->
-  <!--  {{ scheduledClockStr }}-->
-  <!--  {{se().id}} __ {{se().data?.id}} __-->
-  <!-- -->
-
-  @if (
-    se().type === SVEType.SplitTaskContinuedLast ||
-    se().type === SVEType.SplitTaskContinued ||
-    se().type === SVEType.RepeatProjectionSplitContinued ||
-    se().type === SVEType.RepeatProjectionSplitContinuedLast
-  ) {
-    ...
+<div
+  #titleEl
+  class="title"
+>
+  <span class="title-text">
+    <!--  {{ se().data['plannedForDay'] }}-->
+    <!--  {{ scheduledClockStr }}-->
+    <!--  {{se().id}} __ {{se().data?.id}} __-->
     <!-- -->
-  } @else {
-    @if (titleHasLinks()) {
-      <span [innerHTML]="title() | renderLinks"></span>
+
+    @if (
+      se().type === SVEType.SplitTaskContinuedLast ||
+      se().type === SVEType.SplitTaskContinued ||
+      se().type === SVEType.RepeatProjectionSplitContinued ||
+      se().type === SVEType.RepeatProjectionSplitContinuedLast
+    ) {
+      ...
+      <!-- -->
     } @else {
-      {{ title() }}
+      @if (titleHasLinks()) {
+        <span [innerHTML]="title() | renderLinks"></span>
+      } @else {
+        {{ title() }}
+      }
     }
-  }
+  </span>
 </div>
 
 @if (task()) {

--- a/src/app/features/schedule/schedule-event/schedule-event.component.scss
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.scss
@@ -281,21 +281,27 @@
 }
 
 .title {
+  --title-padding-y: 6px;
+  --title-line-height: 1.4em;
+
   font-size: 14px;
-  @include truncateText();
   flex: 1 1 auto;
-  padding: 6px;
+  min-width: 0;
+  padding: var(--title-padding-y) 6px;
+  box-sizing: border-box;
   font-weight: 400;
   line-height: 1.4;
   max-height: 100%;
+  overflow: hidden;
   text-align: left;
-  column-width: 250px;
 
   @include mq(xs, max) {
-    column-width: 120px;
+    --title-padding-y: var(--s-half);
+    --title-line-height: 1.3em;
+
     font-size: 11px;
     line-height: 1.3;
-    padding: var(--s-half);
+    padding: var(--title-padding-y);
   }
 
   @include mq(xxs, max) {
@@ -303,14 +309,36 @@
   }
 
   :host.very-short-event & {
+    max-height: 100%;
     padding: 1px 6px var(--s-quarter);
+  }
+
+  // Keep padding off the clamped element. Padding on a line-clamped box can
+  // reveal a sliver of the next hidden line in Chromium.
+  .title-text {
+    display: -webkit-box;
+    max-height: calc(var(--title-line-clamp, 1) * var(--title-line-height));
+    overflow: hidden;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--title-line-clamp, 1);
+    line-clamp: var(--title-line-clamp, 1);
+  }
+
+  :host.very-short-event & .title-text {
+    display: block;
+    @include truncateText();
   }
 
   :host.SplitTaskContinued &,
   :host.RepeatProjectionSplitContinued &,
   :host.SplitTaskContinuedLast &,
   :host.RepeatProjectionSplitContinuedLast & {
-    line-clamp: 1;
+    .title-text {
+      -webkit-line-clamp: 1;
+      line-clamp: 1;
+    }
   }
 
   // Override inherited pointer-events: none from :host > * so links are clickable.

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -1,10 +1,13 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  AfterViewInit,
   computed,
   ElementRef,
   inject,
   input,
+  NgZone,
+  OnDestroy,
   signal,
   viewChild,
 } from '@angular/core';
@@ -60,6 +63,7 @@ const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;
     '[title]': 'hoverTitle()',
     '[class]': 'cssClass()',
     '[style]': 'style()',
+    '[style.--title-line-clamp]': '_titleLineClamp()',
     '[style.--project-color]': 'projectColor()',
     '[style.height]': '_resizeHeight()',
     '(click)': 'clickHandler($event)',
@@ -74,13 +78,14 @@ const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;
     },
   ],
 })
-export class ScheduleEventComponent {
+export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
   private _store = inject(Store);
   private _elRef = inject(ElementRef);
   private _matDialog = inject(MatDialog);
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _taskService = inject(TaskService);
   private _calEventActions = inject(CalendarEventActionsService);
+  private _ngZone = inject(NgZone);
   readonly titleHasLinks = computed(() => {
     const t = this.title();
     return !!t && hasLinkHints(t);
@@ -102,9 +107,13 @@ export class ScheduleEventComponent {
   });
 
   readonly calMenuTrigger = viewChild('calMenuTrigger', { read: MatMenuTrigger });
+  private readonly _titleEl = viewChild<ElementRef<HTMLElement>>('titleEl');
 
   protected readonly SVEType = SVEType;
   private _isBeingSubmitted = false;
+  private _resizeObserver?: ResizeObserver;
+  private _measureRafId?: number;
+  readonly _titleLineClamp = signal(1);
 
   // Computed signals for derived state
   readonly se = computed(() => this.event());
@@ -225,6 +234,59 @@ export class ScheduleEventComponent {
         : '') + style
     );
   });
+
+  ngAfterViewInit(): void {
+    const hostEl = this._elRef.nativeElement as HTMLElement;
+    const titleEl = this._titleEl()?.nativeElement;
+    if (!titleEl) {
+      return;
+    }
+
+    this._ngZone.runOutsideAngular(() => {
+      this._resizeObserver = new ResizeObserver(() =>
+        this._scheduleTitleLineClampUpdate(),
+      );
+      this._resizeObserver.observe(hostEl);
+      this._scheduleTitleLineClampUpdate();
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this._measureRafId !== undefined) {
+      cancelAnimationFrame(this._measureRafId);
+    }
+    this._resizeObserver?.disconnect();
+  }
+
+  private _scheduleTitleLineClampUpdate(): void {
+    if (this._measureRafId !== undefined) {
+      return;
+    }
+
+    this._measureRafId = requestAnimationFrame(() => {
+      this._measureRafId = undefined;
+      this._updateTitleLineClamp();
+    });
+  }
+
+  private _updateTitleLineClamp(): void {
+    const hostEl = this._elRef.nativeElement as HTMLElement;
+    const titleEl = this._titleEl()?.nativeElement;
+    if (!titleEl) {
+      return;
+    }
+
+    const styles = getComputedStyle(titleEl);
+    const lineHeight = parseFloat(styles.lineHeight);
+    const paddingTop = parseFloat(styles.paddingTop);
+    const paddingBottom = parseFloat(styles.paddingBottom);
+    const availableTitleHeight = hostEl.clientHeight - paddingTop - paddingBottom;
+    const lineClamp = Math.max(1, Math.floor(availableTitleHeight / lineHeight));
+
+    if (Number.isFinite(lineClamp) && lineClamp !== this._titleLineClamp()) {
+      this._ngZone.run(() => this._titleLineClamp.set(lineClamp));
+    }
+  }
 
   private readonly _projectId = computed(() => this.task()?.projectId || null);
 


### PR DESCRIPTION
## What changed

This updates schedule event titles so they use the available event height instead of always truncating to a single line. Longer titles can now wrap across the space they have, while very short and continued split events still stay compact.

The title text is measured after render and on resize, then exposed as a CSS line clamp. The resize observer and animation frame are cleaned up when the component is destroyed.

## Why

Schedule events with enough vertical room could still hide useful title text. This makes dense schedule views friendlier without letting text spill out of small or overlapping events.

## Validation

- npm run checkFile src/app/features/schedule/schedule-event/schedule-event.component.ts
- npm run checkFile src/app/features/schedule/schedule-event/schedule-event.component.scss
- npm run test:file src/app/features/schedule/schedule/schedule.component.spec.ts
- pre-push hook: npm run lint
- pre-push hook: npm test