### PR TITLE
feat(github): add "Include pull requests" option to issue provider

### DIFF
--- a/packages/plugin-dev/github-issue-provider/i18n/en.json
+++ b/packages/plugin-dev/github-issue-provider/i18n/en.json
@@ -4,6 +4,7 @@
     "TOKEN": "Personal Access Token (required for private repos/optional for public repos)",
     "FILTER_USERNAME": "Filter username (ignore own comments for update detection)",
     "BACKLOG_QUERY": "Backlog query (default: \"sort:updated state:open assignee:@me\")",
+    "INCLUDE_PULL_REQUESTS": "Include pull requests (search and backlog return PRs alongside issues)",
     "HOW_TO_GET_TOKEN": "How to get a token"
   },
   "DISPLAY": {

--- a/packages/plugin-dev/github-issue-provider/src/plugin.ts
+++ b/packages/plugin-dev/github-issue-provider/src/plugin.ts
@@ -18,6 +18,7 @@ interface GithubConfig {
   token?: string;
   filterUsername?: string;
   backlogQuery?: string;
+  includePullRequests?: boolean;
 }
 
 interface GithubUser {
@@ -145,6 +146,12 @@ PluginAPI.registerIssueProvider({
       required: false,
       advanced: true,
     },
+    {
+      key: 'includePullRequests',
+      type: 'checkbox' as const,
+      label: t('CFG.INCLUDE_PULL_REQUESTS'),
+      advanced: true,
+    },
   ],
 
   getHeaders(config: Record<string, unknown>): Record<string, string> {
@@ -165,10 +172,11 @@ PluginAPI.registerIssueProvider({
   ): Promise<PluginSearchResult[]> {
     const cfg = config as unknown as GithubConfig;
     const { owner, repo } = parseRepo(cfg);
-    // Ensure we only search issues (not PRs) unless user explicitly specifies
+    // Ensure we only search issues (not PRs) unless the user opted in via
+    // config or explicitly typed an is: filter in their search term.
     const hasTypeFilter =
       searchTerm.includes('is:issue') || searchTerm.includes('is:pull-request');
-    const typeFilter = hasTypeFilter ? '' : ' is:issue';
+    const typeFilter = hasTypeFilter || cfg.includePullRequests ? '' : ' is:issue';
     const q = encodeGithubQuery(`repo:${owner}/${repo}${typeFilter} ${searchTerm}`);
     const url = `${API_BASE}/search/issues?q=${q}&per_page=50&advanced_search=true`;
     const response = await http.get<GithubSearchResponse>(url);
@@ -269,7 +277,8 @@ PluginAPI.registerIssueProvider({
     const cfg = config as unknown as GithubConfig;
     const { owner, repo } = parseRepo(cfg);
     const query = cfg.backlogQuery || 'sort:updated state:open assignee:@me';
-    const q = encodeGithubQuery(`repo:${owner}/${repo} is:issue ${query}`);
+    const typeFilter = cfg.includePullRequests ? '' : ' is:issue';
+    const q = encodeGithubQuery(`repo:${owner}/${repo}${typeFilter} ${query}`);
     const url = `${API_BASE}/search/issues?q=${q}&per_page=50&advanced_search=true`;
     const response = await http.get<GithubSearchResponse>(url);
     return (response.items || []).map(mapSearchResult);


### PR DESCRIPTION
## Problem

The bundled GitHub issue provider plugin hardcodes `is:issue` into both the backlog auto-import (`getNewIssuesForBacklog`) and the in-provider search (`searchIssues`).
This means PRs cannot be synced into the backlog at all, even by users who explicitly write `is:pull-request` into their `backlogQuery`, because the resulting `repo:x/y is:issue is:pull-request …` query gets resolved by GitHub as issues only.
There is no escape hatch for the backlog path.

## Solution

Adds an advanced checkbox `Include pull requests` to the GitHub provider config.
When enabled, the plugin omits the hardcoded `is:issue` filter in both the backlog and search code paths, so the user's own query controls the type filter.

A typical query then becomes:

```
sort:updated state:open is:pull-request (assignee:@me OR author:@me OR review-requested:@me)
```

Behavior:

- Checkbox unchecked (default) → identical query to today (`repo:owner/repo is:issue …`); existing users see no change.
- Checkbox checked → `is:issue` is omitted; the user's `backlogQuery` / search term controls type filtering.
- The pre-existing manual-search escape hatch (typing `is:pull-request` in the search box) keeps working regardless of the checkbox.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki) (existing wiki text is generic enough to remain accurate).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (the GitHub plugin has no existing test scaffolding; adding the first spec for it is out of scope)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)