### PR TITLE
fix(plugins): pass issueNumber into ctx for issue-provider field mappings

### DIFF
--- a/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.spec.ts
+++ b/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.spec.ts
@@ -733,6 +733,56 @@ describe('PluginIssueProviderAdapterService', () => {
         expect(result!.taskChanges['dueWithTime' as keyof Task]).toBeUndefined();
       });
 
+      it('should pass issueNumber from the fresh issue into ctx for toTaskValue', async () => {
+        const freshIssue: PluginIssue = {
+          id: 'ISS-1',
+          title: 'Updated',
+          lastUpdated: 2000,
+          // GitHub-style extended field surfaced via ctx.issueNumber
+          ...({ number: 42 } as Record<string, unknown>),
+        } as PluginIssue;
+        const syncValues = { summary: 'Updated' };
+        const provider = createMockProvider({
+          getById: jasmine.createSpy('getById').and.resolveTo(freshIssue),
+          fieldMappings: [
+            {
+              taskField: 'title',
+              issueField: 'summary',
+              defaultDirection: 'pullOnly',
+              toIssueValue: (v: unknown) => v,
+              toTaskValue: (v: unknown, ctx: { issueId: string; issueNumber?: number }) =>
+                `#${ctx.issueNumber} ${v}`,
+            },
+          ],
+          extractSyncValues: jasmine
+            .createSpy('extractSyncValues')
+            .and.returnValue(syncValues),
+        });
+        registrySpy.getProvider.and.returnValue(provider);
+
+        const cfgWithSync = {
+          ...mockPluginCfg,
+          pluginConfig: {
+            ...mockPluginConfig,
+            twoWaySync: { title: 'pullOnly' },
+          },
+        } as IssueProviderPluginType;
+        storeSpy.select.and.returnValue(of(cfgWithSync));
+
+        const task = {
+          id: 'task-1',
+          issueId: 'ISS-1',
+          issueProviderId: PROVIDER_ID,
+          issueLastUpdated: 1000,
+          issueLastSyncedValues: { summary: 'Original' },
+        } as unknown as Task;
+
+        const result = await service.getFreshDataForIssueTask(task);
+
+        expect(result).not.toBeNull();
+        expect(result!.taskChanges['title' as keyof Task]).toBe('#42 Updated');
+      });
+
       it('should clear mutually exclusive fields when pulling dueWithTime', async () => {
         const freshIssue: PluginIssue = {
           id: 'ISS-1',

--- a/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts
+++ b/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts
@@ -198,6 +198,7 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
           issueLastSyncedValues ?? {},
           task,
           cfg,
+          issue,
         );
 
         return {
@@ -319,6 +320,11 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
     }
   }
 
+  private _getIssueNumber(issue: PluginIssue): number | undefined {
+    const n = (issue as { number?: unknown }).number;
+    return typeof n === 'number' ? n : undefined;
+  }
+
   private _extractTaskFieldsFromIssueWithSyncValues(
     issue: PluginIssue,
     provider: RegisteredPluginIssueProvider,
@@ -326,7 +332,7 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
   ): Record<string, unknown> {
     const issueRecord = issue as Record<string, unknown>;
     const result: Record<string, unknown> = {};
-    const ctx = { issueId: issue.id };
+    const ctx = { issueId: issue.id, issueNumber: this._getIssueNumber(issue) };
 
     const mappings = provider.definition.fieldMappings;
     if (!mappings?.length) {
@@ -421,6 +427,7 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
     freshSyncValues: Record<string, unknown>,
     task: Task,
     cfg: IssueProviderPluginType,
+    issue: PluginIssue,
   ): Partial<Task> {
     const fieldMappings = provider.definition.fieldMappings;
     if (!fieldMappings?.length) {
@@ -429,7 +436,10 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
 
     const twoWaySync = (cfg.pluginConfig?.['twoWaySync'] as Record<string, string>) ?? {};
     const lastSyncedValues = task.issueLastSyncedValues ?? {};
-    const ctx = { issueId: task.issueId! };
+    const ctx = {
+      issueId: task.issueId!,
+      issueNumber: this._getIssueNumber(issue),
+    };
     const changes: Record<string, unknown> = {};
 
     for (const mapping of fieldMappings) {


### PR DESCRIPTION
## Problem

`fieldMapping.toTaskValue` / `toIssueValue` declare ctx as `{ issueId: string; issueNumber?: number }`, but the host adapter only passed `issueId`.
The GitHub plugin's title mapping interpolates `ctx.issueNumber`, so on every poll-triggered update the task title was rewritten to `#undefined <title>`.
The initial add was masked because titles came pre-formatted from `mapSearchResult`.

## Solution

Read `issue.number` (when present) at both ctx construction sites via a small `_getIssueNumber` helper.
Plugins that don't surface `number` are unaffected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki (internal contract, no doc text references it).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes
- [x] Existing tests still pass (54/54 in adapter spec)
- [x] My commit messages follow the Angular format (`type(scope): description`)