### PR TITLE
feat(bottom-panel): smooth swipe-to-close with momentum on mobile

### DIFF
--- a/src/app/features/bottom-panel/bottom-panel-container.component.scss
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.scss
@@ -5,6 +5,9 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  // Constrain native gestures to vertical pan so swipe-to-close from the
+  // content area doesn't race horizontal scroll/pull-to-refresh.
+  touch-action: pan-y;
 }
 
 .bottom-panel-header {

--- a/src/app/features/bottom-panel/bottom-panel-container.component.scss
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.scss
@@ -5,9 +5,6 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  // Constrain native gestures to vertical pan so swipe-to-close from the
-  // content area doesn't race horizontal scroll/pull-to-refresh.
-  touch-action: pan-y;
 }
 
 .bottom-panel-header {

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -103,11 +103,10 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _activePointerId: number | null = null;
   private _activeTouchId: number | null = null;
   private _captureTarget: HTMLElement | null = null;
-  private _pendingClientY: number | null = null;
-  private _rafId: number | null = null;
   private _startY = 0;
   private _startHeight = 0;
   private _currentTranslateY = 0;
+  private _currentRawOffset = 0;
   private _lastY = 0;
   private _lastTime = 0;
   private _velocity = 0;
@@ -129,7 +128,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private readonly _boundOnPointerMove = this._onPointerMove.bind(this);
   private readonly _boundOnPointerUp = this._onPointerUp.bind(this);
   private readonly _boundOnViewportResize = this._onViewportResize.bind(this);
-  private readonly _boundFlushDrag = this._flushDrag.bind(this);
 
   ngAfterViewInit(): void {
     // Mark bottom panel as open for mutual exclusion with right panel
@@ -193,10 +191,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     document.removeEventListener('pointermove', this._boundOnPointerMove);
     document.removeEventListener('pointerup', this._boundOnPointerUp);
     document.removeEventListener('pointercancel', this._boundOnPointerUp);
-    if (this._rafId !== null) {
-      cancelAnimationFrame(this._rafId);
-      this._rafId = null;
-    }
   }
 
   // ── Touch-event path (mobile) ─────────────────────────────────────────
@@ -225,7 +219,8 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
       // Active drag — block native scroll/rubber-banding so the panel can
       // track the finger 1:1.
       if (event.cancelable) event.preventDefault();
-      this._scheduleDragUpdate(touch.clientY);
+      this._trackVelocity(touch.clientY);
+      this._applyDragPosition(touch.clientY);
       return;
     }
 
@@ -234,7 +229,8 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     if (this._evaluatePotentialDrag(touch.clientX, touch.clientY)) {
       if (event.cancelable) event.preventDefault();
       this._beginDrag(this._potentialStartY);
-      this._scheduleDragUpdate(touch.clientY);
+      this._trackVelocity(touch.clientY);
+      this._applyDragPosition(touch.clientY);
     }
   }
 
@@ -297,7 +293,8 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     }
 
     if (this._isDragging) {
-      this._scheduleDragUpdate(event.clientY);
+      this._trackVelocity(event.clientY);
+      this._applyDragPosition(event.clientY);
       return;
     }
 
@@ -305,7 +302,8 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
 
     if (this._evaluatePotentialDrag(event.clientX, event.clientY)) {
       this._beginDrag(this._potentialStartY);
-      this._scheduleDragUpdate(event.clientY);
+      this._trackVelocity(event.clientY);
+      this._applyDragPosition(event.clientY);
     }
   }
 
@@ -362,6 +360,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     this._lastTime = Date.now();
     this._velocity = 0;
     this._currentTranslateY = 0;
+    this._currentRawOffset = 0;
     const container = this._getSheetContainer();
     if (container) {
       this._startHeight = container.offsetHeight;
@@ -373,9 +372,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     document.body.style.userSelect = 'none';
   }
 
-  private _scheduleDragUpdate(clientY: number): void {
-    // Track velocity on the input thread so we have an up-to-date sample
-    // even if multiple moves coalesce into one rAF.
+  private _trackVelocity(clientY: number): void {
     const currentTime = Date.now();
     const timeDiff = currentTime - this._lastTime;
     if (timeDiff > 0) {
@@ -384,46 +381,22 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     }
     this._lastY = clientY;
     this._lastTime = currentTime;
-
-    this._pendingClientY = clientY;
-    if (this._rafId === null) {
-      this._rafId = requestAnimationFrame(this._boundFlushDrag);
-    }
-  }
-
-  private _flushDrag(): void {
-    this._rafId = null;
-    if (!this._isDragging || this._pendingClientY === null) return;
-    this._applyDragPosition(this._pendingClientY);
   }
 
   private _applyDragPosition(clientY: number): void {
     const container = this._getSheetContainer();
     if (!container) return;
 
-    const offset = clientY - this._startY; // +down, -up
-    const viewportHeight = window.innerHeight;
+    const rawOffset = clientY - this._startY; // +down, -up
+    // Apply rubber-band resistance to upward over-drag so we never need to
+    // touch `height` (which would force a layout) on the input thread —
+    // transform-only updates stay on the compositor and feel instant.
+    const offset =
+      rawOffset >= 0 ? rawOffset : -Math.sqrt(-rawOffset * 12);
 
-    if (offset <= 0) {
-      // Drag up: grow height, no translate
-      const minHeight = viewportHeight * PANEL_HEIGHTS.MIN_HEIGHT;
-      const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
-      const newHeight = Math.min(
-        Math.max(this._startHeight - offset, minHeight),
-        maxHeight,
-      );
-      container.style.height = `${newHeight}px`;
-      container.style.maxHeight = `${newHeight}px`;
-      // translate3d keeps the layer on the GPU compositor for smooth motion
-      container.style.transform = 'translate3d(0, 0, 0)';
-      this._currentTranslateY = 0;
-    } else {
-      // Drag down: translate the panel with the finger so it visibly moves
-      container.style.height = `${this._startHeight}px`;
-      container.style.maxHeight = `${this._startHeight}px`;
-      container.style.transform = `translate3d(0, ${offset}px, 0)`;
-      this._currentTranslateY = offset;
-    }
+    container.style.transform = `translate3d(0, ${offset}px, 0)`;
+    this._currentTranslateY = Math.max(rawOffset, 0);
+    this._currentRawOffset = rawOffset;
   }
 
   private _endDragOrPotential(): void {
@@ -438,11 +411,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     this._captureTarget = null;
     this._activePointerId = null;
     this._activeTouchId = null;
-    this._pendingClientY = null;
-    if (this._rafId !== null) {
-      cancelAnimationFrame(this._rafId);
-      this._rafId = null;
-    }
 
     if (this._isPotentialDrag) {
       this._isPotentialDrag = false;
@@ -463,6 +431,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
       this._currentTranslateY > viewportHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
     const flingDown = this._velocity > PANEL_HEIGHTS.VELOCITY_THRESHOLD;
     const flingUp = this._velocity < -PANEL_HEIGHTS.VELOCITY_THRESHOLD;
+    const draggedUp = this._currentRawOffset < 0;
 
     if (flingDown || closeByDistance) {
       this._animateClose(container, viewportHeight);
@@ -472,14 +441,16 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     // Not closing — release dragging state so transitions re-enable.
     container.classList.remove('dragging');
 
-    if (this._currentTranslateY > 0) {
-      // Snap back to the start height/position
-      this._animateSnapBack(container);
-    } else if (flingUp) {
-      // Fling up → expand to max height
+    if (flingUp || draggedUp) {
+      // Fling-up or any upward drag → expand toward max height. We commit
+      // the height change here (not on every move) so dragging stays purely
+      // transform-based and the input thread never triggers a layout.
       this._animateExpand(container, viewportHeight);
+    } else if (this._currentRawOffset > 0) {
+      // Released a downward drag below the close threshold — snap back.
+      this._animateSnapBack(container);
     }
-    // else: user released at a height they chose; leave it.
+    // else: user released without moving — leave the panel as-is.
   }
 
   private _animateClose(container: HTMLElement, viewportHeight: number): void {
@@ -505,12 +476,11 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _animateSnapBack(container: HTMLElement): void {
-    container.style.transition = `transform ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}, height ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}, max-height ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}`;
+    container.style.transition = `transform ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}`;
     void container.offsetHeight;
     container.style.transform = 'translate3d(0, 0, 0)';
-    container.style.height = `${this._startHeight}px`;
-    container.style.maxHeight = `${this._startHeight}px`;
     this._currentTranslateY = 0;
+    this._currentRawOffset = 0;
 
     window.setTimeout(() => {
       container.style.transition = '';
@@ -519,13 +489,23 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _animateExpand(container: HTMLElement, viewportHeight: number): void {
-    const targetHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT;
-    container.style.transition = `height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}, max-height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}`;
+    // Animate both: zero out any rubber-band translate from upward drag, and
+    // grow the height to the expanded target.
+    const targetHeight = Math.min(
+      viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT,
+      viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE,
+    );
+    container.style.transition = `transform ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}, height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}, max-height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}`;
+    void container.offsetHeight;
+    container.style.transform = 'translate3d(0, 0, 0)';
     container.style.height = `${targetHeight}px`;
     container.style.maxHeight = `${targetHeight}px`;
+    this._currentTranslateY = 0;
+    this._currentRawOffset = 0;
 
     window.setTimeout(() => {
       container.style.transition = '';
+      container.style.transform = '';
     }, PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION);
   }
 

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -31,29 +31,24 @@ export interface BottomPanelData {
   panelContent: PanelContentType;
 }
 
-// Panel height constants
 const PANEL_HEIGHTS = {
   MAX_HEIGHT: 0.8,
   MIN_HEIGHT: 0.2,
   MAX_HEIGHT_ABSOLUTE: 0.98,
   TASK_PANEL_HEIGHT: 0.6,
   OTHER_PANEL_HEIGHT: 0.9,
-  VELOCITY_THRESHOLD: 0.5, // px/ms — fling-to-close
-  CLOSE_DISTANCE_RATIO: 0.25, // fraction of viewport — slow drag close
-  DRAG_INTENT_THRESHOLD: 6, // px before content drag commits
-  CLOSE_ANIMATION_MIN_DURATION: 120, // ms
-  CLOSE_ANIMATION_MAX_DURATION: 320, // ms
-  SNAP_BACK_DURATION: 260, // ms
-  EXPAND_ANIMATION_DURATION: 280, // ms
-  INITIAL_ANIMATION_BLOCK_DURATION: 300, // ms
+  VELOCITY_THRESHOLD: 0.5, // px/ms
+  CLOSE_DISTANCE_RATIO: 0.4, // close if dragged below this fraction of original height
+  CLOSE_ANIMATION_MIN_DURATION: 140,
+  CLOSE_ANIMATION_MAX_DURATION: 320,
+  EXPAND_ANIMATION_DURATION: 280,
+  INITIAL_ANIMATION_BLOCK_DURATION: 300,
 } as const;
 
-const DRAG_EASING = 'cubic-bezier(0.22, 0.61, 0.36, 1)';
-
-const KEYBOARD_DETECT_THRESHOLD = 100; // px - minimum height change to detect keyboard
-const KEYBOARD_SAFE_HEIGHT_MIN = 200; // px - minimal safe panel height while keyboard visible
-const KEYBOARD_SAFE_HEIGHT_RATIO = 0.85; // fraction of visual viewport height
-const KEYBOARD_RESIZE_DEBOUNCE_MS = 100; // ms - debounce viewport resize events
+const KEYBOARD_DETECT_THRESHOLD = 100;
+const KEYBOARD_SAFE_HEIGHT_MIN = 200;
+const KEYBOARD_SAFE_HEIGHT_RATIO = 0.85;
+const KEYBOARD_RESIZE_DEBOUNCE_MS = 100;
 
 @Component({
   selector: 'bottom-panel-container',
@@ -92,21 +87,12 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   readonly selectedTask = toSignal(this._taskService.selectedTask$, {
     initialValue: null,
   });
-  readonly isDisableTaskPanelAni = signal(true); // Always start with animation disabled
+  readonly isDisableTaskPanelAni = signal(true);
 
   private _isDragging = false;
-  private _isPotentialDrag = false;
-  private _potentialStartX = 0;
-  private _potentialStartY = 0;
-  private _scrollableEl: HTMLElement | null = null;
-  private _scrollableStartTop = 0;
-  private _activePointerId: number | null = null;
-  private _activeTouchId: number | null = null;
-  private _captureTarget: HTMLElement | null = null;
   private _startY = 0;
   private _startHeight = 0;
-  private _currentTranslateY = 0;
-  private _currentRawOffset = 0;
+  private _currentHeight = 0;
   private _lastY = 0;
   private _lastTime = 0;
   private _velocity = 0;
@@ -114,29 +100,21 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _closeAniTimeout?: number;
   private _cachedContainer: HTMLElement | null = null;
 
-  // Mobile keyboard handling
   private _isKeyboardWatcherInitialized = false;
   private _originalHeight: string = '';
   private _vvResizeTimer: number | null = null;
 
-  // Store bound functions to prevent memory leaks
-  private readonly _boundOnTouchStart = this._onTouchStart.bind(this);
-  private readonly _boundOnTouchMove = this._onTouchMove.bind(this);
-  private readonly _boundOnTouchEnd = this._onTouchEnd.bind(this);
-  private readonly _boundOnTouchCancel = this._onTouchCancel.bind(this);
   private readonly _boundOnPointerDown = this._onPointerDown.bind(this);
   private readonly _boundOnPointerMove = this._onPointerMove.bind(this);
   private readonly _boundOnPointerUp = this._onPointerUp.bind(this);
   private readonly _boundOnViewportResize = this._onViewportResize.bind(this);
 
   ngAfterViewInit(): void {
-    // Mark bottom panel as open for mutual exclusion with right panel
     this._bottomPanelState.isOpen.set(true);
     this._setupDragListeners();
     this._setupKeyboardWatcher();
     this._setInitialHeight();
 
-    // Re-enable animations after initial render is complete
     this._disableAniTimeout = window.setTimeout(() => {
       this.isDisableTaskPanelAni.set(false);
     }, PANEL_HEIGHTS.INITIAL_ANIMATION_BLOCK_DURATION);
@@ -147,8 +125,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     this._removeKeyboardWatcher();
     window.clearTimeout(this._disableAniTimeout);
     window.clearTimeout(this._closeAniTimeout);
-    this._cachedContainer = null; // Clear cached reference
-    // Mark bottom panel as closed
+    this._cachedContainer = null;
     this._bottomPanelState.isOpen.set(false);
   }
 
@@ -157,265 +134,84 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _setupDragListeners(): void {
-    const containerEl = this._elementRef.nativeElement as HTMLElement;
-    if (!containerEl) return;
+    const panelHeader = this.panelHeader()?.nativeElement;
+    if (!panelHeader) return;
 
-    // Touch events first — they're the most reliable on mobile and don't
-    // race the browser's pointer-event coalescing or gesture-recognizer.
-    containerEl.addEventListener('touchstart', this._boundOnTouchStart, {
-      passive: true,
-    });
-    containerEl.addEventListener('touchmove', this._boundOnTouchMove, {
+    panelHeader.addEventListener('pointerdown', this._boundOnPointerDown);
+    document.addEventListener('pointermove', this._boundOnPointerMove, {
       passive: false,
     });
-    containerEl.addEventListener('touchend', this._boundOnTouchEnd);
-    containerEl.addEventListener('touchcancel', this._boundOnTouchCancel);
-
-    // Pointer events for mouse / pen on desktop. We deliberately skip touch
-    // pointers (handled above) to avoid double-handling.
-    containerEl.addEventListener('pointerdown', this._boundOnPointerDown);
-    document.addEventListener('pointermove', this._boundOnPointerMove);
     document.addEventListener('pointerup', this._boundOnPointerUp);
     document.addEventListener('pointercancel', this._boundOnPointerUp);
   }
 
   private _removeDragListeners(): void {
-    const containerEl = this._elementRef.nativeElement as HTMLElement;
-    if (containerEl) {
-      containerEl.removeEventListener('touchstart', this._boundOnTouchStart);
-      containerEl.removeEventListener('touchmove', this._boundOnTouchMove);
-      containerEl.removeEventListener('touchend', this._boundOnTouchEnd);
-      containerEl.removeEventListener('touchcancel', this._boundOnTouchCancel);
-      containerEl.removeEventListener('pointerdown', this._boundOnPointerDown);
+    const panelHeader = this.panelHeader()?.nativeElement;
+    if (panelHeader) {
+      panelHeader.removeEventListener('pointerdown', this._boundOnPointerDown);
     }
     document.removeEventListener('pointermove', this._boundOnPointerMove);
     document.removeEventListener('pointerup', this._boundOnPointerUp);
     document.removeEventListener('pointercancel', this._boundOnPointerUp);
   }
 
-  // ── Touch-event path (mobile) ─────────────────────────────────────────
-
-  private _onTouchStart(event: TouchEvent): void {
-    if (this._isDragging || this._isPotentialDrag) return;
-    if (event.touches.length !== 1) return;
-    const touch = event.touches[0];
-    const target = touch.target as HTMLElement;
-    if (!target || this._isInteractiveTarget(target)) return;
-
-    this._activeTouchId = touch.identifier;
-    const isFromHeader = !!target.closest('.bottom-panel-header');
-    if (isFromHeader) {
-      this._beginDrag(touch.clientY);
-    } else {
-      this._armPotentialDrag(touch.clientX, touch.clientY, target);
-    }
-  }
-
-  private _onTouchMove(event: TouchEvent): void {
-    const touch = this._findActiveTouch(event.touches);
-    if (!touch) return;
-
-    if (this._isDragging) {
-      // Active drag — block native scroll/rubber-banding so the panel can
-      // track the finger 1:1.
-      if (event.cancelable) event.preventDefault();
-      this._trackVelocity(touch.clientY);
-      this._applyDragPosition(touch.clientY);
-      return;
-    }
-
-    if (!this._isPotentialDrag) return;
-
-    if (this._evaluatePotentialDrag(touch.clientX, touch.clientY)) {
-      if (event.cancelable) event.preventDefault();
-      this._beginDrag(this._potentialStartY);
-      this._trackVelocity(touch.clientY);
-      this._applyDragPosition(touch.clientY);
-    }
-  }
-
-  private _onTouchEnd(event: TouchEvent): void {
-    if (
-      this._activeTouchId !== null &&
-      !this._findActiveTouch(event.changedTouches)
-    ) {
-      return;
-    }
-    this._endDragOrPotential();
-  }
-
-  private _onTouchCancel(): void {
-    this._endDragOrPotential();
-  }
-
-  private _findActiveTouch(list: TouchList): Touch | null {
-    if (this._activeTouchId === null) return null;
-    for (let i = 0; i < list.length; i++) {
-      if (list[i].identifier === this._activeTouchId) return list[i];
-    }
-    return null;
-  }
-
-  // ── Pointer-event path (desktop / pen) ────────────────────────────────
-
   private _onPointerDown(event: PointerEvent): void {
-    // Touch pointers are handled by the touch listeners above.
-    if (event.pointerType === 'touch') return;
     if (event.pointerType === 'mouse' && event.button !== 0) return;
-    if (this._isDragging || this._isPotentialDrag) return;
-
-    const target = event.target as HTMLElement;
-    if (this._isInteractiveTarget(target)) return;
-
-    const isFromHeader = !!target.closest('.bottom-panel-header');
-    if (isFromHeader) {
-      this._activePointerId = event.pointerId;
-      this._captureTarget = target;
-      try {
-        target.setPointerCapture(event.pointerId);
-      } catch {
-        /* setPointerCapture can throw on some browsers — safe to ignore */
-      }
-      this._beginDrag(event.clientY);
-    } else {
-      this._activePointerId = event.pointerId;
-      this._armPotentialDrag(event.clientX, event.clientY, target);
-    }
+    event.preventDefault();
+    this._startDrag(event.clientY);
   }
 
-  private _onPointerMove(event: PointerEvent): void {
-    if (event.pointerType === 'touch') return;
-    if (
-      this._activePointerId !== null &&
-      event.pointerId !== this._activePointerId
-    ) {
-      return;
-    }
-
-    if (this._isDragging) {
-      this._trackVelocity(event.clientY);
-      this._applyDragPosition(event.clientY);
-      return;
-    }
-
-    if (!this._isPotentialDrag) return;
-
-    if (this._evaluatePotentialDrag(event.clientX, event.clientY)) {
-      this._beginDrag(this._potentialStartY);
-      this._trackVelocity(event.clientY);
-      this._applyDragPosition(event.clientY);
-    }
-  }
-
-  private _onPointerUp(event: PointerEvent): void {
-    if (event.pointerType === 'touch') return;
-    if (
-      this._activePointerId !== null &&
-      event.pointerId !== this._activePointerId
-    ) {
-      return;
-    }
-    this._endDragOrPotential();
-  }
-
-  // ── Shared logic ──────────────────────────────────────────────────────
-
-  private _armPotentialDrag(
-    clientX: number,
-    clientY: number,
-    target: HTMLElement,
-  ): void {
-    this._isPotentialDrag = true;
-    this._potentialStartX = clientX;
-    this._potentialStartY = clientY;
-    this._scrollableEl = this._findScrollableUnder(target);
-    this._scrollableStartTop = this._scrollableEl?.scrollTop ?? 0;
-    this._lastY = clientY;
-    this._lastTime = Date.now();
-  }
-
-  private _evaluatePotentialDrag(clientX: number, clientY: number): boolean {
-    const dy = clientY - this._potentialStartY;
-    const dx = clientX - this._potentialStartX;
-    if (Math.abs(dy) < PANEL_HEIGHTS.DRAG_INTENT_THRESHOLD) return false;
-
-    const isDownward = dy > 0;
-    const isMostlyVertical = Math.abs(dy) > Math.abs(dx);
-    const contentWasAtTop = !this._scrollableEl || this._scrollableStartTop <= 0;
-
-    if (isDownward && isMostlyVertical && contentWasAtTop) {
-      return true;
-    }
-    // Hand the gesture back to the browser
-    this._isPotentialDrag = false;
-    this._scrollableEl = null;
-    return false;
-  }
-
-  private _beginDrag(clientY: number): void {
+  private _startDrag(clientY: number): void {
     this._isDragging = true;
-    this._isPotentialDrag = false;
     this._startY = clientY;
     this._lastY = clientY;
     this._lastTime = Date.now();
     this._velocity = 0;
-    this._currentTranslateY = 0;
-    this._currentRawOffset = 0;
     const container = this._getSheetContainer();
     if (container) {
       this._startHeight = container.offsetHeight;
-      // Inline `transition: none` has highest specificity, so it overrides
-      // any leftover Material/Angular animation transitions.
-      container.style.transition = 'none';
+      this._currentHeight = this._startHeight;
       container.classList.add('dragging');
     }
     document.body.style.userSelect = 'none';
   }
 
-  private _trackVelocity(clientY: number): void {
+  private _onPointerMove(event: PointerEvent): void {
+    if (!this._isDragging) return;
+    event.preventDefault();
+    this._updateHeight(event.clientY);
+  }
+
+  private _updateHeight(clientY: number): void {
+    const container = this._getSheetContainer();
+    if (!container) return;
+
+    const deltaY = this._startY - clientY;
+    const newHeight = this._startHeight + deltaY;
+    const viewportHeight = window.innerHeight;
+
+    // Allow heights all the way down to zero so the panel can be dragged
+    // off the bottom — closing happens on release based on threshold/velocity.
+    const minHeight = 0;
+    const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
+    const constrainedHeight = Math.min(Math.max(newHeight, minHeight), maxHeight);
+
+    container.style.height = `${constrainedHeight}px`;
+    container.style.maxHeight = `${constrainedHeight}px`;
+    this._currentHeight = constrainedHeight;
+
     const currentTime = Date.now();
     const timeDiff = currentTime - this._lastTime;
     if (timeDiff > 0) {
       const instant = (clientY - this._lastY) / timeDiff;
+      // Light low-pass on the velocity sample
       this._velocity = this._velocity * 0.5 + instant * 0.5;
     }
     this._lastY = clientY;
     this._lastTime = currentTime;
   }
 
-  private _applyDragPosition(clientY: number): void {
-    const container = this._getSheetContainer();
-    if (!container) return;
-
-    const rawOffset = clientY - this._startY; // +down, -up
-    // Apply rubber-band resistance to upward over-drag so we never need to
-    // touch `height` (which would force a layout) on the input thread —
-    // transform-only updates stay on the compositor and feel instant.
-    const offset =
-      rawOffset >= 0 ? rawOffset : -Math.sqrt(-rawOffset * 12);
-
-    container.style.transform = `translate3d(0, ${offset}px, 0)`;
-    this._currentTranslateY = Math.max(rawOffset, 0);
-    this._currentRawOffset = rawOffset;
-  }
-
-  private _endDragOrPotential(): void {
-    // Release pointer capture if we had it
-    if (this._captureTarget && this._activePointerId !== null) {
-      try {
-        this._captureTarget.releasePointerCapture(this._activePointerId);
-      } catch {
-        /* may already be released */
-      }
-    }
-    this._captureTarget = null;
-    this._activePointerId = null;
-    this._activeTouchId = null;
-
-    if (this._isPotentialDrag) {
-      this._isPotentialDrag = false;
-      this._scrollableEl = null;
-    }
+  private _onPointerUp(): void {
     if (!this._isDragging) return;
     this._handleDragEnd();
   }
@@ -426,48 +222,39 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const container = this._getSheetContainer();
     if (!container) return;
 
+    container.classList.remove('dragging');
+
     const viewportHeight = window.innerHeight;
-    const closeByDistance =
-      this._currentTranslateY > viewportHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
     const flingDown = this._velocity > PANEL_HEIGHTS.VELOCITY_THRESHOLD;
     const flingUp = this._velocity < -PANEL_HEIGHTS.VELOCITY_THRESHOLD;
-    const draggedUp = this._currentRawOffset < 0;
+    const closeByDistance =
+      this._currentHeight < this._startHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
 
     if (flingDown || closeByDistance) {
       this._animateClose(container, viewportHeight);
       return;
     }
 
-    // Not closing — release dragging state so transitions re-enable.
-    container.classList.remove('dragging');
-
-    if (flingUp || draggedUp) {
-      // Fling-up or any upward drag → expand toward max height. We commit
-      // the height change here (not on every move) so dragging stays purely
-      // transform-based and the input thread never triggers a layout.
+    if (flingUp) {
       this._animateExpand(container, viewportHeight);
-    } else if (this._currentRawOffset > 0) {
-      // Released a downward drag below the close threshold — snap back.
-      this._animateSnapBack(container);
     }
-    // else: user released without moving — leave the panel as-is.
+    // Otherwise: leave the panel at whatever height the user released at —
+    // they intentionally dragged to that size.
   }
 
   private _animateClose(container: HTMLElement, viewportHeight: number): void {
-    const remaining = Math.max(viewportHeight - this._currentTranslateY, 1);
-    const speed = Math.max(Math.abs(this._velocity), 0.6); // px/ms floor for nice feel
+    // Use translateY (not height) for the close animation so the panel
+    // visibly slides off the bottom with momentum-derived speed.
+    const remaining = Math.max(viewportHeight - (viewportHeight - this._currentHeight), 1);
+    const speed = Math.max(Math.abs(this._velocity), 0.6);
     const duration = Math.min(
       Math.max(remaining / speed, PANEL_HEIGHTS.CLOSE_ANIMATION_MIN_DURATION),
       PANEL_HEIGHTS.CLOSE_ANIMATION_MAX_DURATION,
     );
 
-    // Drop the dragging class so its `transition: none !important` no longer
-    // wins over the close transition we're about to apply.
-    container.classList.remove('dragging');
-    container.style.transition = `transform ${duration}ms ${DRAG_EASING}`;
-    // Force a layout flush so the transition takes effect from the current value
+    container.style.transition = `transform ${duration}ms cubic-bezier(0.22, 0.61, 0.36, 1)`;
     void container.offsetHeight;
-    container.style.transform = `translate3d(0, ${viewportHeight}px, 0)`;
+    container.style.transform = `translateY(${this._currentHeight}px)`;
 
     window.clearTimeout(this._closeAniTimeout);
     this._closeAniTimeout = window.setTimeout(() => {
@@ -475,62 +262,15 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     }, duration);
   }
 
-  private _animateSnapBack(container: HTMLElement): void {
-    container.style.transition = `transform ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}`;
-    void container.offsetHeight;
-    container.style.transform = 'translate3d(0, 0, 0)';
-    this._currentTranslateY = 0;
-    this._currentRawOffset = 0;
-
-    window.setTimeout(() => {
-      container.style.transition = '';
-      container.style.transform = '';
-    }, PANEL_HEIGHTS.SNAP_BACK_DURATION);
-  }
-
   private _animateExpand(container: HTMLElement, viewportHeight: number): void {
-    // Animate both: zero out any rubber-band translate from upward drag, and
-    // grow the height to the expanded target.
-    const targetHeight = Math.min(
-      viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT,
-      viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE,
-    );
-    container.style.transition = `transform ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}, height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}, max-height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}`;
-    void container.offsetHeight;
-    container.style.transform = 'translate3d(0, 0, 0)';
+    const targetHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT;
+    container.style.transition = `height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms cubic-bezier(0.22, 0.61, 0.36, 1), max-height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms cubic-bezier(0.22, 0.61, 0.36, 1)`;
     container.style.height = `${targetHeight}px`;
     container.style.maxHeight = `${targetHeight}px`;
-    this._currentTranslateY = 0;
-    this._currentRawOffset = 0;
 
     window.setTimeout(() => {
       container.style.transition = '';
-      container.style.transform = '';
     }, PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION);
-  }
-
-  private _findScrollableUnder(target: HTMLElement | null): HTMLElement | null {
-    let el: HTMLElement | null = target;
-    const root = this._elementRef.nativeElement as HTMLElement;
-    while (el && el !== root && root.contains(el)) {
-      const style = window.getComputedStyle(el);
-      const overflowY = style.overflowY;
-      if (
-        (overflowY === 'auto' || overflowY === 'scroll') &&
-        el.scrollHeight > el.clientHeight
-      ) {
-        return el;
-      }
-      el = el.parentElement;
-    }
-    return null;
-  }
-
-  private _isInteractiveTarget(target: HTMLElement | null): boolean {
-    if (!target) return false;
-    return !!target.closest(
-      'input, textarea, select, button, [contenteditable="true"], [contenteditable=""]',
-    );
   }
 
   private _setInitialHeight(): void {
@@ -570,7 +310,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     }
     this._isKeyboardWatcherInitialized = true;
 
-    // Use Visual Viewport API if available (modern browsers)
     if ('visualViewport' in window && window.visualViewport) {
       window.visualViewport.addEventListener('resize', this._boundOnViewportResize);
     }
@@ -580,7 +319,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     if (typeof window !== 'undefined' && window.visualViewport) {
       window.visualViewport.removeEventListener('resize', this._boundOnViewportResize);
     }
-    // Restore original height if it was stored
     if (this._originalHeight) {
       const container = this._getSheetContainer();
       if (container) {
@@ -591,7 +329,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _onViewportResize(): void {
-    // Debounce rapid viewport resize events while the keyboard animates
     if (this._vvResizeTimer) {
       window.clearTimeout(this._vvResizeTimer);
       this._vvResizeTimer = null;
@@ -614,38 +351,29 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const viewportHeight = visualViewport.height;
     const keyboardHeight = windowHeight - viewportHeight;
 
-    // Check if keyboard is visible
     const isKeyboardVisible = keyboardHeight > KEYBOARD_DETECT_THRESHOLD;
 
     const container = this._getSheetContainer();
     if (!container) return;
 
     if (isKeyboardVisible) {
-      // Store original height if not already stored
       if (!this._originalHeight) {
         this._originalHeight = container.style.maxHeight || '';
       }
 
-      // Calculate safe height - be more conservative
       const safeHeight = Math.max(
         KEYBOARD_SAFE_HEIGHT_MIN,
         viewportHeight * KEYBOARD_SAFE_HEIGHT_RATIO,
       );
 
-      // Use !important to override CSS max-height
       container.style.setProperty('max-height', `${safeHeight}px`, 'important');
 
-      // Force current height if it exceeds the new max
       if (container.offsetHeight > safeHeight) {
         container.style.setProperty('height', `${safeHeight}px`, 'important');
       }
     } else {
-      // Restore original height constraints when keyboard is hidden
-      // Remove our forced styles
       container.style.removeProperty('max-height');
       container.style.removeProperty('height');
-
-      // Clean up stored height
       this._originalHeight = '';
     }
   }

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -92,6 +92,12 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _isDragging = false;
   private _startY = 0;
   private _startHeight = 0;
+  // Drag-down uses transform so the close animation can continue the exact
+  // same property — no discontinuity at release. Drag-up keeps using
+  // height (panel grows) and never sets transform.
+  private _currentTranslateY = 0;
+  // Tracks the larger of (start height, last expanded height) so a partial
+  // drag-down after expanding still has a known starting point.
   private _currentHeight = 0;
   // Rolling window of recent move samples for robust velocity at release.
   // A naive low-pass filter dilutes the peak fling speed because users
@@ -168,10 +174,13 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     this._startY = clientY;
     this._velocity = 0;
     this._velocitySamples = [{ y: clientY, t: Date.now() }];
+    this._currentTranslateY = 0;
     const container = this._getSheetContainer();
     if (container) {
       this._startHeight = container.offsetHeight;
       this._currentHeight = this._startHeight;
+      // Clear any leftover transition so the drag tracks 1:1.
+      container.style.transition = '';
       container.classList.add('dragging');
     }
     document.body.style.userSelect = 'none';
@@ -180,26 +189,34 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _onPointerMove(event: PointerEvent): void {
     if (!this._isDragging) return;
     event.preventDefault();
-    this._updateHeight(event.clientY);
+    this._updatePosition(event.clientY);
   }
 
-  private _updateHeight(clientY: number): void {
+  private _updatePosition(clientY: number): void {
     const container = this._getSheetContainer();
     if (!container) return;
 
-    const deltaY = this._startY - clientY;
-    const newHeight = this._startHeight + deltaY;
+    const offset = clientY - this._startY; // +down, -up
     const viewportHeight = window.innerHeight;
 
-    // Allow heights all the way down to zero so the panel can be dragged
-    // off the bottom — closing happens on release based on threshold/velocity.
-    const minHeight = 0;
-    const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
-    const constrainedHeight = Math.min(Math.max(newHeight, minHeight), maxHeight);
-
-    container.style.height = `${constrainedHeight}px`;
-    container.style.maxHeight = `${constrainedHeight}px`;
-    this._currentHeight = constrainedHeight;
+    if (offset > 0) {
+      // Drag down: translate the whole panel with the finger. The close
+      // animation continues this exact transform — no jump at release.
+      // Translate is clamped to the current rendered height so it can move
+      // exactly off-screen even if the panel was expanded earlier.
+      const translateY = Math.min(offset, this._currentHeight);
+      container.style.transform = `translateY(${translateY}px)`;
+      this._currentTranslateY = translateY;
+    } else {
+      // Drag up: grow height (the original, proven-responsive behavior).
+      const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
+      const newHeight = Math.min(this._startHeight - offset, maxHeight);
+      container.style.transform = '';
+      container.style.height = `${newHeight}px`;
+      container.style.maxHeight = `${newHeight}px`;
+      this._currentTranslateY = 0;
+      this._currentHeight = newHeight;
+    }
 
     // Push a sample and trim to the last 80ms of motion. Velocity at
     // release is then computed from the oldest-still-fresh sample to the
@@ -233,35 +250,38 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const container = this._getSheetContainer();
     if (!container) return;
 
-    container.classList.remove('dragging');
-
     const viewportHeight = window.innerHeight;
     const flingDown = this._velocity > PANEL_HEIGHTS.VELOCITY_THRESHOLD;
     const flingUp = this._velocity < -PANEL_HEIGHTS.VELOCITY_THRESHOLD;
     const closeByDistance =
-      this._currentHeight < this._startHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
+      this._currentTranslateY > this._currentHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
 
     if (flingDown || closeByDistance) {
-      this._animateClose(container, viewportHeight);
+      this._animateClose(container);
       return;
     }
 
-    if (flingUp) {
+    container.classList.remove('dragging');
+
+    if (this._currentTranslateY > 0) {
+      // Released a partial drag-down without enough velocity/distance to
+      // close — snap the translate back to 0.
+      this._animateSnapBack(container);
+    } else if (flingUp) {
       this._animateExpand(container, viewportHeight);
     }
     // Otherwise: leave the panel at whatever height the user released at —
     // they intentionally dragged to that size.
   }
 
-  private _animateClose(container: HTMLElement, viewportHeight: number): void {
-    // Slide the panel off the bottom via translateY. The panel sits at
-    // `bottom: 0`, so translating by its current height moves it exactly
-    // off-screen.
-    const distance = Math.max(this._currentHeight, 1);
+  private _animateClose(container: HTMLElement): void {
+    // We were already updating `transform` during the drag, so this just
+    // continues that motion to fully off-screen — the browser interpolates
+    // from the current transform value, no jump.
+    const distance = Math.max(this._currentHeight - this._currentTranslateY, 1);
 
-    // For slow / distance-only closes, keep a friendly minimum speed so
-    // the duration doesn't balloon. For real flings we use the measured
-    // velocity directly — a 4 px/ms swing closes a 600px panel in 150ms.
+    // Use the measured fling velocity directly when present. The min
+    // floor only applies for slow / distance-triggered closes.
     const flingSpeed = Math.abs(this._velocity);
     const speed = Math.max(flingSpeed, 0.6);
 
@@ -271,22 +291,44 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
       PANEL_HEIGHTS.CLOSE_ANIMATION_MAX_DURATION,
     );
 
-    // Easing: slower releases get a soft ease-out (looks natural). Fast
-    // flings use a near-linear curve so the panel actually moves at the
-    // velocity the user gave it instead of decelerating immediately.
+    // Curve choice: a CSS transition always interpolates from the current
+    // value at velocity 0 along the timing function, so the *initial slope*
+    // of the curve is what determines whether the motion looks continuous
+    // with the drag.
+    //   - For a fast fling we want a curve that starts at near-fling speed
+    //     and decelerates — `(0.2, 0.8, 0.4, 1)` has a tall initial slope
+    //     (~4) so it actually launches into the motion instead of easing in.
+    //   - For slow / distance-only closes a softer ease-out feels natural.
     const easing =
-      flingSpeed > 1.8
-        ? 'cubic-bezier(0.33, 0.0, 0.67, 1)'
+      flingSpeed > 0.8
+        ? 'cubic-bezier(0.2, 0.8, 0.4, 1)'
         : 'cubic-bezier(0.22, 0.61, 0.36, 1)';
 
+    // Keeping the dragging class through the close keeps the parent's
+    // `transition: none !important` from racing the inline transition we
+    // set below — we resolve this by setting transition inline AFTER
+    // removing the class.
+    container.classList.remove('dragging');
     container.style.transition = `transform ${duration}ms ${easing}`;
     void container.offsetHeight;
-    container.style.transform = `translateY(${distance}px)`;
+    container.style.transform = `translateY(${this._currentHeight}px)`;
 
     window.clearTimeout(this._closeAniTimeout);
     this._closeAniTimeout = window.setTimeout(() => {
       this.close();
     }, duration);
+  }
+
+  private _animateSnapBack(container: HTMLElement): void {
+    container.style.transition = `transform 220ms cubic-bezier(0.22, 0.61, 0.36, 1)`;
+    void container.offsetHeight;
+    container.style.transform = 'translateY(0)';
+    this._currentTranslateY = 0;
+
+    window.setTimeout(() => {
+      container.style.transition = '';
+      container.style.transform = '';
+    }, 220);
   }
 
   private _animateExpand(container: HTMLElement, viewportHeight: number): void {

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -92,12 +92,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _isDragging = false;
   private _startY = 0;
   private _startHeight = 0;
-  // Drag-down uses transform so the close animation can continue the exact
-  // same property — no discontinuity at release. Drag-up keeps using
-  // height (panel grows) and never sets transform.
-  private _currentTranslateY = 0;
-  // Tracks the larger of (start height, last expanded height) so a partial
-  // drag-down after expanding still has a known starting point.
   private _currentHeight = 0;
   // Rolling window of recent move samples for robust velocity at release.
   // A naive low-pass filter dilutes the peak fling speed because users
@@ -174,13 +168,10 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     this._startY = clientY;
     this._velocity = 0;
     this._velocitySamples = [{ y: clientY, t: Date.now() }];
-    this._currentTranslateY = 0;
     const container = this._getSheetContainer();
     if (container) {
       this._startHeight = container.offsetHeight;
       this._currentHeight = this._startHeight;
-      // Clear any leftover transition so the drag tracks 1:1.
-      container.style.transition = '';
       container.classList.add('dragging');
     }
     document.body.style.userSelect = 'none';
@@ -189,34 +180,26 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _onPointerMove(event: PointerEvent): void {
     if (!this._isDragging) return;
     event.preventDefault();
-    this._updatePosition(event.clientY);
+    this._updateHeight(event.clientY);
   }
 
-  private _updatePosition(clientY: number): void {
+  private _updateHeight(clientY: number): void {
     const container = this._getSheetContainer();
     if (!container) return;
 
-    const offset = clientY - this._startY; // +down, -up
+    const deltaY = this._startY - clientY;
+    const newHeight = this._startHeight + deltaY;
     const viewportHeight = window.innerHeight;
 
-    if (offset > 0) {
-      // Drag down: translate the whole panel with the finger. The close
-      // animation continues this exact transform — no jump at release.
-      // Translate is clamped to the current rendered height so it can move
-      // exactly off-screen even if the panel was expanded earlier.
-      const translateY = Math.min(offset, this._currentHeight);
-      container.style.transform = `translateY(${translateY}px)`;
-      this._currentTranslateY = translateY;
-    } else {
-      // Drag up: grow height (the original, proven-responsive behavior).
-      const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
-      const newHeight = Math.min(this._startHeight - offset, maxHeight);
-      container.style.transform = '';
-      container.style.height = `${newHeight}px`;
-      container.style.maxHeight = `${newHeight}px`;
-      this._currentTranslateY = 0;
-      this._currentHeight = newHeight;
-    }
+    // Allow heights all the way down to zero so the panel can be dragged
+    // off the bottom — closing happens on release based on threshold/velocity.
+    const minHeight = 0;
+    const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
+    const constrainedHeight = Math.min(Math.max(newHeight, minHeight), maxHeight);
+
+    container.style.height = `${constrainedHeight}px`;
+    container.style.maxHeight = `${constrainedHeight}px`;
+    this._currentHeight = constrainedHeight;
 
     // Push a sample and trim to the last 80ms of motion. Velocity at
     // release is then computed from the oldest-still-fresh sample to the
@@ -250,38 +233,35 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const container = this._getSheetContainer();
     if (!container) return;
 
+    container.classList.remove('dragging');
+
     const viewportHeight = window.innerHeight;
     const flingDown = this._velocity > PANEL_HEIGHTS.VELOCITY_THRESHOLD;
     const flingUp = this._velocity < -PANEL_HEIGHTS.VELOCITY_THRESHOLD;
     const closeByDistance =
-      this._currentTranslateY > this._currentHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
+      this._currentHeight < this._startHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
 
     if (flingDown || closeByDistance) {
-      this._animateClose(container);
+      this._animateClose(container, viewportHeight);
       return;
     }
 
-    container.classList.remove('dragging');
-
-    if (this._currentTranslateY > 0) {
-      // Released a partial drag-down without enough velocity/distance to
-      // close — snap the translate back to 0.
-      this._animateSnapBack(container);
-    } else if (flingUp) {
+    if (flingUp) {
       this._animateExpand(container, viewportHeight);
     }
     // Otherwise: leave the panel at whatever height the user released at —
     // they intentionally dragged to that size.
   }
 
-  private _animateClose(container: HTMLElement): void {
-    // We were already updating `transform` during the drag, so this just
-    // continues that motion to fully off-screen — the browser interpolates
-    // from the current transform value, no jump.
-    const distance = Math.max(this._currentHeight - this._currentTranslateY, 1);
+  private _animateClose(container: HTMLElement, viewportHeight: number): void {
+    // Slide the panel off the bottom via translateY. The panel sits at
+    // `bottom: 0`, so translating by its current height moves it exactly
+    // off-screen.
+    const distance = Math.max(this._currentHeight, 1);
 
-    // Use the measured fling velocity directly when present. The min
-    // floor only applies for slow / distance-triggered closes.
+    // For slow / distance-only closes, keep a friendly minimum speed so
+    // the duration doesn't balloon. For real flings we use the measured
+    // velocity directly — a 4 px/ms swing closes a 600px panel in 150ms.
     const flingSpeed = Math.abs(this._velocity);
     const speed = Math.max(flingSpeed, 0.6);
 
@@ -291,44 +271,22 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
       PANEL_HEIGHTS.CLOSE_ANIMATION_MAX_DURATION,
     );
 
-    // Curve choice: a CSS transition always interpolates from the current
-    // value at velocity 0 along the timing function, so the *initial slope*
-    // of the curve is what determines whether the motion looks continuous
-    // with the drag.
-    //   - For a fast fling we want a curve that starts at near-fling speed
-    //     and decelerates — `(0.2, 0.8, 0.4, 1)` has a tall initial slope
-    //     (~4) so it actually launches into the motion instead of easing in.
-    //   - For slow / distance-only closes a softer ease-out feels natural.
+    // Easing: slower releases get a soft ease-out (looks natural). Fast
+    // flings use a near-linear curve so the panel actually moves at the
+    // velocity the user gave it instead of decelerating immediately.
     const easing =
-      flingSpeed > 0.8
-        ? 'cubic-bezier(0.2, 0.8, 0.4, 1)'
+      flingSpeed > 1.8
+        ? 'cubic-bezier(0.33, 0.0, 0.67, 1)'
         : 'cubic-bezier(0.22, 0.61, 0.36, 1)';
 
-    // Keeping the dragging class through the close keeps the parent's
-    // `transition: none !important` from racing the inline transition we
-    // set below — we resolve this by setting transition inline AFTER
-    // removing the class.
-    container.classList.remove('dragging');
     container.style.transition = `transform ${duration}ms ${easing}`;
     void container.offsetHeight;
-    container.style.transform = `translateY(${this._currentHeight}px)`;
+    container.style.transform = `translateY(${distance}px)`;
 
     window.clearTimeout(this._closeAniTimeout);
     this._closeAniTimeout = window.setTimeout(() => {
       this.close();
     }, duration);
-  }
-
-  private _animateSnapBack(container: HTMLElement): void {
-    container.style.transition = `transform 220ms cubic-bezier(0.22, 0.61, 0.36, 1)`;
-    void container.offsetHeight;
-    container.style.transform = 'translateY(0)';
-    this._currentTranslateY = 0;
-
-    window.setTimeout(() => {
-      container.style.transition = '';
-      container.style.transform = '';
-    }, 220);
   }
 
   private _animateExpand(container: HTMLElement, viewportHeight: number): void {

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -38,9 +38,17 @@ const PANEL_HEIGHTS = {
   MAX_HEIGHT_ABSOLUTE: 0.98,
   TASK_PANEL_HEIGHT: 0.6,
   OTHER_PANEL_HEIGHT: 0.9,
-  VELOCITY_THRESHOLD: 0.5,
+  VELOCITY_THRESHOLD: 0.5, // px/ms — fling-to-close
+  CLOSE_DISTANCE_RATIO: 0.25, // fraction of viewport — slow drag close
+  DRAG_INTENT_THRESHOLD: 6, // px before content drag commits
+  CLOSE_ANIMATION_MIN_DURATION: 120, // ms
+  CLOSE_ANIMATION_MAX_DURATION: 320, // ms
+  SNAP_BACK_DURATION: 260, // ms
+  EXPAND_ANIMATION_DURATION: 280, // ms
   INITIAL_ANIMATION_BLOCK_DURATION: 300, // ms
 } as const;
+
+const DRAG_EASING = 'cubic-bezier(0.22, 0.61, 0.36, 1)';
 
 const KEYBOARD_DETECT_THRESHOLD = 100; // px - minimum height change to detect keyboard
 const KEYBOARD_SAFE_HEIGHT_MIN = 200; // px - minimal safe panel height while keyboard visible
@@ -87,12 +95,19 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   readonly isDisableTaskPanelAni = signal(true); // Always start with animation disabled
 
   private _isDragging = false;
+  private _isPotentialDrag = false;
+  private _potentialStartX = 0;
+  private _potentialStartY = 0;
+  private _scrollableEl: HTMLElement | null = null;
+  private _scrollableStartTop = 0;
   private _startY = 0;
   private _startHeight = 0;
+  private _currentTranslateY = 0;
   private _lastY = 0;
   private _lastTime = 0;
   private _velocity = 0;
   private _disableAniTimeout?: number;
+  private _closeAniTimeout?: number;
   private _cachedContainer: HTMLElement | null = null;
 
   // Mobile keyboard handling
@@ -123,6 +138,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     this._removeDragListeners();
     this._removeKeyboardWatcher();
     window.clearTimeout(this._disableAniTimeout);
+    window.clearTimeout(this._closeAniTimeout);
     this._cachedContainer = null; // Clear cached reference
     // Mark bottom panel as closed
     this._bottomPanelState.isOpen.set(false);
@@ -133,11 +149,12 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _setupDragListeners(): void {
-    const panelHeader = this.panelHeader()?.nativeElement;
-    if (!panelHeader) return;
+    const containerEl = this._elementRef.nativeElement as HTMLElement;
+    if (!containerEl) return;
 
-    // Unified pointer events (mouse, touch, pen)
-    panelHeader.addEventListener('pointerdown', this._boundOnPointerDown);
+    // Listen anywhere on the panel — content-area drags only commit when the
+    // inner scroller is at the top, so normal scrolling still works.
+    containerEl.addEventListener('pointerdown', this._boundOnPointerDown);
     document.addEventListener('pointermove', this._boundOnPointerMove, {
       passive: false,
     });
@@ -146,9 +163,9 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _removeDragListeners(): void {
-    const panelHeader = this.panelHeader()?.nativeElement;
-    if (panelHeader) {
-      panelHeader.removeEventListener('pointerdown', this._boundOnPointerDown);
+    const containerEl = this._elementRef.nativeElement as HTMLElement;
+    if (containerEl) {
+      containerEl.removeEventListener('pointerdown', this._boundOnPointerDown);
     }
     document.removeEventListener('pointermove', this._boundOnPointerMove);
     document.removeEventListener('pointerup', this._boundOnPointerUp);
@@ -160,57 +177,122 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     if (event.pointerType === 'mouse' && event.button !== 0) {
       return;
     }
-    event.preventDefault();
-    this._startDrag(event.clientY);
+    if (this._isDragging || this._isPotentialDrag) return;
+
+    const target = event.target as HTMLElement;
+    if (this._isInteractiveTarget(target)) return;
+
+    const isFromHeader = !!target.closest('.bottom-panel-header');
+    if (isFromHeader) {
+      event.preventDefault();
+      this._beginDrag(event.clientY);
+      return;
+    }
+
+    // Content-area: defer until movement direction is known
+    this._isPotentialDrag = true;
+    this._potentialStartX = event.clientX;
+    this._potentialStartY = event.clientY;
+    this._scrollableEl = this._findScrollableUnder(target);
+    this._scrollableStartTop = this._scrollableEl?.scrollTop ?? 0;
+    this._lastY = event.clientY;
+    this._lastTime = Date.now();
   }
 
-  private _startDrag(clientY: number): void {
+  private _beginDrag(clientY: number): void {
     this._isDragging = true;
+    this._isPotentialDrag = false;
     this._startY = clientY;
     this._lastY = clientY;
     this._lastTime = Date.now();
     this._velocity = 0;
+    this._currentTranslateY = 0;
     const container = this._getSheetContainer();
     if (container) {
       this._startHeight = container.offsetHeight;
+      container.style.transition = '';
       container.classList.add('dragging');
     }
     document.body.style.userSelect = 'none';
   }
 
   private _onPointerMove(event: PointerEvent): void {
-    if (!this._isDragging) return;
-    event.preventDefault();
-    this._updateHeight(event.clientY);
+    if (this._isDragging) {
+      event.preventDefault();
+      this._updateDrag(event.clientY);
+      return;
+    }
+
+    if (!this._isPotentialDrag) return;
+
+    const dy = event.clientY - this._potentialStartY;
+    const dx = event.clientX - this._potentialStartX;
+    if (Math.abs(dy) < PANEL_HEIGHTS.DRAG_INTENT_THRESHOLD) return;
+
+    // Mostly vertical, downward, and the content was at the top when the
+    // gesture began → take over. Using the start position avoids racing the
+    // browser's native scroll handler.
+    const isDownward = dy > 0;
+    const isMostlyVertical = Math.abs(dy) > Math.abs(dx);
+    const contentWasAtTop = !this._scrollableEl || this._scrollableStartTop <= 0;
+
+    if (isDownward && isMostlyVertical && contentWasAtTop) {
+      event.preventDefault();
+      // Use the original touch position so the drag feels continuous
+      this._beginDrag(this._potentialStartY);
+      this._updateDrag(event.clientY);
+    } else {
+      // Let the browser handle scroll/other gestures
+      this._isPotentialDrag = false;
+      this._scrollableEl = null;
+    }
   }
 
-  private _updateHeight(clientY: number): void {
+  private _updateDrag(clientY: number): void {
     const container = this._getSheetContainer();
     if (!container) return;
 
-    const deltaY = this._startY - clientY;
-    const newHeight = this._startHeight + deltaY;
+    const offset = clientY - this._startY; // +down, -up
     const viewportHeight = window.innerHeight;
 
-    // Constrain height between min and max bounds
-    const minHeight = viewportHeight * PANEL_HEIGHTS.MIN_HEIGHT;
-    const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
-    const constrainedHeight = Math.min(Math.max(newHeight, minHeight), maxHeight);
+    if (offset <= 0) {
+      // Drag up: grow height, no translate
+      const minHeight = viewportHeight * PANEL_HEIGHTS.MIN_HEIGHT;
+      const maxHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT_ABSOLUTE;
+      const newHeight = Math.min(
+        Math.max(this._startHeight - offset, minHeight),
+        maxHeight,
+      );
+      container.style.height = `${newHeight}px`;
+      container.style.maxHeight = `${newHeight}px`;
+      container.style.transform = '';
+      this._currentTranslateY = 0;
+    } else {
+      // Drag down: translate the panel with the finger so it visibly moves
+      container.style.height = `${this._startHeight}px`;
+      container.style.maxHeight = `${this._startHeight}px`;
+      container.style.transform = `translateY(${offset}px)`;
+      this._currentTranslateY = offset;
+    }
 
-    container.style.height = `${constrainedHeight}px`;
-    container.style.maxHeight = `${constrainedHeight}px`;
-
-    // Calculate velocity for momentum detection
+    // Velocity (px/ms; positive = downward)
     const currentTime = Date.now();
     const timeDiff = currentTime - this._lastTime;
     if (timeDiff > 0) {
-      this._velocity = (clientY - this._lastY) / timeDiff;
+      // Light low-pass filter to avoid spikes from a single jittery sample
+      const instant = (clientY - this._lastY) / timeDiff;
+      this._velocity = this._velocity * 0.5 + instant * 0.5;
     }
     this._lastY = clientY;
     this._lastTime = currentTime;
   }
 
   private _onPointerUp(): void {
+    if (this._isPotentialDrag) {
+      this._isPotentialDrag = false;
+      this._scrollableEl = null;
+    }
+    if (!this._isDragging) return;
     this._handleDragEnd();
   }
 
@@ -218,34 +300,99 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     this._isDragging = false;
     document.body.style.userSelect = '';
     const container = this._getSheetContainer();
-    if (container) {
-      container.classList.remove('dragging');
+    if (!container) return;
 
-      // Check for momentum and handle snap behavior
-      const viewportHeight = window.innerHeight;
+    const viewportHeight = window.innerHeight;
+    const closeByDistance =
+      this._currentTranslateY > viewportHeight * PANEL_HEIGHTS.CLOSE_DISTANCE_RATIO;
+    const flingDown = this._velocity > PANEL_HEIGHTS.VELOCITY_THRESHOLD;
+    const flingUp = this._velocity < -PANEL_HEIGHTS.VELOCITY_THRESHOLD;
 
-      if (Math.abs(this._velocity) > PANEL_HEIGHTS.VELOCITY_THRESHOLD) {
-        if (this._velocity > 0) {
-          // Swiping down with momentum - close the panel
-          this.close();
-          return;
-        } else {
-          // Swiping up with momentum - expand to max height
-          const targetHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT;
-          container.style.height = `${targetHeight}px`;
-          container.style.maxHeight = `${targetHeight}px`;
-          container.style.transition = 'height 0.3s ease-out, max-height 0.3s ease-out';
-
-          // Remove transition after animation
-          setTimeout(() => {
-            container.style.transition = '';
-          }, PANEL_HEIGHTS.INITIAL_ANIMATION_BLOCK_DURATION);
-          return;
-        }
-      }
-
-      // No momentum - no action needed
+    if (flingDown || closeByDistance) {
+      this._animateClose(container, viewportHeight);
+      return;
     }
+
+    // Not closing — release dragging state so transitions re-enable.
+    container.classList.remove('dragging');
+
+    if (this._currentTranslateY > 0) {
+      // Snap back to the start height/position
+      this._animateSnapBack(container);
+    } else if (flingUp) {
+      // Fling up → expand to max height
+      this._animateExpand(container, viewportHeight);
+    }
+    // else: user released at a height they chose; leave it.
+  }
+
+  private _animateClose(container: HTMLElement, viewportHeight: number): void {
+    const remaining = Math.max(viewportHeight - this._currentTranslateY, 1);
+    const speed = Math.max(Math.abs(this._velocity), 0.6); // px/ms floor for nice feel
+    const duration = Math.min(
+      Math.max(remaining / speed, PANEL_HEIGHTS.CLOSE_ANIMATION_MIN_DURATION),
+      PANEL_HEIGHTS.CLOSE_ANIMATION_MAX_DURATION,
+    );
+
+    // Keep the dragging class so inner transitions stay disabled while we slide.
+    container.style.transition = `transform ${duration}ms ${DRAG_EASING}`;
+    // Force a layout flush so the transition takes effect from the current value
+    void container.offsetHeight;
+    container.style.transform = `translateY(${viewportHeight}px)`;
+
+    window.clearTimeout(this._closeAniTimeout);
+    this._closeAniTimeout = window.setTimeout(() => {
+      this.close();
+    }, duration);
+  }
+
+  private _animateSnapBack(container: HTMLElement): void {
+    container.style.transition = `transform ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}, height ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}, max-height ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}`;
+    void container.offsetHeight;
+    container.style.transform = 'translateY(0)';
+    container.style.height = `${this._startHeight}px`;
+    container.style.maxHeight = `${this._startHeight}px`;
+    this._currentTranslateY = 0;
+
+    window.setTimeout(() => {
+      container.style.transition = '';
+      container.style.transform = '';
+    }, PANEL_HEIGHTS.SNAP_BACK_DURATION);
+  }
+
+  private _animateExpand(container: HTMLElement, viewportHeight: number): void {
+    const targetHeight = viewportHeight * PANEL_HEIGHTS.MAX_HEIGHT;
+    container.style.transition = `height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}, max-height ${PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION}ms ${DRAG_EASING}`;
+    container.style.height = `${targetHeight}px`;
+    container.style.maxHeight = `${targetHeight}px`;
+
+    window.setTimeout(() => {
+      container.style.transition = '';
+    }, PANEL_HEIGHTS.EXPAND_ANIMATION_DURATION);
+  }
+
+  private _findScrollableUnder(target: HTMLElement | null): HTMLElement | null {
+    let el: HTMLElement | null = target;
+    const root = this._elementRef.nativeElement as HTMLElement;
+    while (el && el !== root && root.contains(el)) {
+      const style = window.getComputedStyle(el);
+      const overflowY = style.overflowY;
+      if (
+        (overflowY === 'auto' || overflowY === 'scroll') &&
+        el.scrollHeight > el.clientHeight
+      ) {
+        return el;
+      }
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  private _isInteractiveTarget(target: HTMLElement | null): boolean {
+    if (!target) return false;
+    return !!target.closest(
+      'input, textarea, select, button, [contenteditable="true"], [contenteditable=""]',
+    );
   }
 
   private _setInitialHeight(): void {

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -100,6 +100,11 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _potentialStartY = 0;
   private _scrollableEl: HTMLElement | null = null;
   private _scrollableStartTop = 0;
+  private _activePointerId: number | null = null;
+  private _activeTouchId: number | null = null;
+  private _captureTarget: HTMLElement | null = null;
+  private _pendingClientY: number | null = null;
+  private _rafId: number | null = null;
   private _startY = 0;
   private _startHeight = 0;
   private _currentTranslateY = 0;
@@ -116,10 +121,15 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _vvResizeTimer: number | null = null;
 
   // Store bound functions to prevent memory leaks
+  private readonly _boundOnTouchStart = this._onTouchStart.bind(this);
+  private readonly _boundOnTouchMove = this._onTouchMove.bind(this);
+  private readonly _boundOnTouchEnd = this._onTouchEnd.bind(this);
+  private readonly _boundOnTouchCancel = this._onTouchCancel.bind(this);
   private readonly _boundOnPointerDown = this._onPointerDown.bind(this);
   private readonly _boundOnPointerMove = this._onPointerMove.bind(this);
   private readonly _boundOnPointerUp = this._onPointerUp.bind(this);
   private readonly _boundOnViewportResize = this._onViewportResize.bind(this);
+  private readonly _boundFlushDrag = this._flushDrag.bind(this);
 
   ngAfterViewInit(): void {
     // Mark bottom panel as open for mutual exclusion with right panel
@@ -152,12 +162,21 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const containerEl = this._elementRef.nativeElement as HTMLElement;
     if (!containerEl) return;
 
-    // Listen anywhere on the panel — content-area drags only commit when the
-    // inner scroller is at the top, so normal scrolling still works.
-    containerEl.addEventListener('pointerdown', this._boundOnPointerDown);
-    document.addEventListener('pointermove', this._boundOnPointerMove, {
+    // Touch events first — they're the most reliable on mobile and don't
+    // race the browser's pointer-event coalescing or gesture-recognizer.
+    containerEl.addEventListener('touchstart', this._boundOnTouchStart, {
+      passive: true,
+    });
+    containerEl.addEventListener('touchmove', this._boundOnTouchMove, {
       passive: false,
     });
+    containerEl.addEventListener('touchend', this._boundOnTouchEnd);
+    containerEl.addEventListener('touchcancel', this._boundOnTouchCancel);
+
+    // Pointer events for mouse / pen on desktop. We deliberately skip touch
+    // pointers (handled above) to avoid double-handling.
+    containerEl.addEventListener('pointerdown', this._boundOnPointerDown);
+    document.addEventListener('pointermove', this._boundOnPointerMove);
     document.addEventListener('pointerup', this._boundOnPointerUp);
     document.addEventListener('pointercancel', this._boundOnPointerUp);
   }
@@ -165,18 +184,88 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _removeDragListeners(): void {
     const containerEl = this._elementRef.nativeElement as HTMLElement;
     if (containerEl) {
+      containerEl.removeEventListener('touchstart', this._boundOnTouchStart);
+      containerEl.removeEventListener('touchmove', this._boundOnTouchMove);
+      containerEl.removeEventListener('touchend', this._boundOnTouchEnd);
+      containerEl.removeEventListener('touchcancel', this._boundOnTouchCancel);
       containerEl.removeEventListener('pointerdown', this._boundOnPointerDown);
     }
     document.removeEventListener('pointermove', this._boundOnPointerMove);
     document.removeEventListener('pointerup', this._boundOnPointerUp);
     document.removeEventListener('pointercancel', this._boundOnPointerUp);
+    if (this._rafId !== null) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
   }
 
-  private _onPointerDown(event: PointerEvent): void {
-    // Only react to primary button for mouse
-    if (event.pointerType === 'mouse' && event.button !== 0) {
+  // ── Touch-event path (mobile) ─────────────────────────────────────────
+
+  private _onTouchStart(event: TouchEvent): void {
+    if (this._isDragging || this._isPotentialDrag) return;
+    if (event.touches.length !== 1) return;
+    const touch = event.touches[0];
+    const target = touch.target as HTMLElement;
+    if (!target || this._isInteractiveTarget(target)) return;
+
+    this._activeTouchId = touch.identifier;
+    const isFromHeader = !!target.closest('.bottom-panel-header');
+    if (isFromHeader) {
+      this._beginDrag(touch.clientY);
+    } else {
+      this._armPotentialDrag(touch.clientX, touch.clientY, target);
+    }
+  }
+
+  private _onTouchMove(event: TouchEvent): void {
+    const touch = this._findActiveTouch(event.touches);
+    if (!touch) return;
+
+    if (this._isDragging) {
+      // Active drag — block native scroll/rubber-banding so the panel can
+      // track the finger 1:1.
+      if (event.cancelable) event.preventDefault();
+      this._scheduleDragUpdate(touch.clientY);
       return;
     }
+
+    if (!this._isPotentialDrag) return;
+
+    if (this._evaluatePotentialDrag(touch.clientX, touch.clientY)) {
+      if (event.cancelable) event.preventDefault();
+      this._beginDrag(this._potentialStartY);
+      this._scheduleDragUpdate(touch.clientY);
+    }
+  }
+
+  private _onTouchEnd(event: TouchEvent): void {
+    if (
+      this._activeTouchId !== null &&
+      !this._findActiveTouch(event.changedTouches)
+    ) {
+      return;
+    }
+    this._endDragOrPotential();
+  }
+
+  private _onTouchCancel(): void {
+    this._endDragOrPotential();
+  }
+
+  private _findActiveTouch(list: TouchList): Touch | null {
+    if (this._activeTouchId === null) return null;
+    for (let i = 0; i < list.length; i++) {
+      if (list[i].identifier === this._activeTouchId) return list[i];
+    }
+    return null;
+  }
+
+  // ── Pointer-event path (desktop / pen) ────────────────────────────────
+
+  private _onPointerDown(event: PointerEvent): void {
+    // Touch pointers are handled by the touch listeners above.
+    if (event.pointerType === 'touch') return;
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
     if (this._isDragging || this._isPotentialDrag) return;
 
     const target = event.target as HTMLElement;
@@ -184,19 +273,85 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
 
     const isFromHeader = !!target.closest('.bottom-panel-header');
     if (isFromHeader) {
-      event.preventDefault();
+      this._activePointerId = event.pointerId;
+      this._captureTarget = target;
+      try {
+        target.setPointerCapture(event.pointerId);
+      } catch {
+        /* setPointerCapture can throw on some browsers — safe to ignore */
+      }
       this._beginDrag(event.clientY);
+    } else {
+      this._activePointerId = event.pointerId;
+      this._armPotentialDrag(event.clientX, event.clientY, target);
+    }
+  }
+
+  private _onPointerMove(event: PointerEvent): void {
+    if (event.pointerType === 'touch') return;
+    if (
+      this._activePointerId !== null &&
+      event.pointerId !== this._activePointerId
+    ) {
       return;
     }
 
-    // Content-area: defer until movement direction is known
+    if (this._isDragging) {
+      this._scheduleDragUpdate(event.clientY);
+      return;
+    }
+
+    if (!this._isPotentialDrag) return;
+
+    if (this._evaluatePotentialDrag(event.clientX, event.clientY)) {
+      this._beginDrag(this._potentialStartY);
+      this._scheduleDragUpdate(event.clientY);
+    }
+  }
+
+  private _onPointerUp(event: PointerEvent): void {
+    if (event.pointerType === 'touch') return;
+    if (
+      this._activePointerId !== null &&
+      event.pointerId !== this._activePointerId
+    ) {
+      return;
+    }
+    this._endDragOrPotential();
+  }
+
+  // ── Shared logic ──────────────────────────────────────────────────────
+
+  private _armPotentialDrag(
+    clientX: number,
+    clientY: number,
+    target: HTMLElement,
+  ): void {
     this._isPotentialDrag = true;
-    this._potentialStartX = event.clientX;
-    this._potentialStartY = event.clientY;
+    this._potentialStartX = clientX;
+    this._potentialStartY = clientY;
     this._scrollableEl = this._findScrollableUnder(target);
     this._scrollableStartTop = this._scrollableEl?.scrollTop ?? 0;
-    this._lastY = event.clientY;
+    this._lastY = clientY;
     this._lastTime = Date.now();
+  }
+
+  private _evaluatePotentialDrag(clientX: number, clientY: number): boolean {
+    const dy = clientY - this._potentialStartY;
+    const dx = clientX - this._potentialStartX;
+    if (Math.abs(dy) < PANEL_HEIGHTS.DRAG_INTENT_THRESHOLD) return false;
+
+    const isDownward = dy > 0;
+    const isMostlyVertical = Math.abs(dy) > Math.abs(dx);
+    const contentWasAtTop = !this._scrollableEl || this._scrollableStartTop <= 0;
+
+    if (isDownward && isMostlyVertical && contentWasAtTop) {
+      return true;
+    }
+    // Hand the gesture back to the browser
+    this._isPotentialDrag = false;
+    this._scrollableEl = null;
+    return false;
   }
 
   private _beginDrag(clientY: number): void {
@@ -210,45 +365,39 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const container = this._getSheetContainer();
     if (container) {
       this._startHeight = container.offsetHeight;
-      container.style.transition = '';
+      // Inline `transition: none` has highest specificity, so it overrides
+      // any leftover Material/Angular animation transitions.
+      container.style.transition = 'none';
       container.classList.add('dragging');
     }
     document.body.style.userSelect = 'none';
   }
 
-  private _onPointerMove(event: PointerEvent): void {
-    if (this._isDragging) {
-      event.preventDefault();
-      this._updateDrag(event.clientY);
-      return;
+  private _scheduleDragUpdate(clientY: number): void {
+    // Track velocity on the input thread so we have an up-to-date sample
+    // even if multiple moves coalesce into one rAF.
+    const currentTime = Date.now();
+    const timeDiff = currentTime - this._lastTime;
+    if (timeDiff > 0) {
+      const instant = (clientY - this._lastY) / timeDiff;
+      this._velocity = this._velocity * 0.5 + instant * 0.5;
     }
+    this._lastY = clientY;
+    this._lastTime = currentTime;
 
-    if (!this._isPotentialDrag) return;
-
-    const dy = event.clientY - this._potentialStartY;
-    const dx = event.clientX - this._potentialStartX;
-    if (Math.abs(dy) < PANEL_HEIGHTS.DRAG_INTENT_THRESHOLD) return;
-
-    // Mostly vertical, downward, and the content was at the top when the
-    // gesture began → take over. Using the start position avoids racing the
-    // browser's native scroll handler.
-    const isDownward = dy > 0;
-    const isMostlyVertical = Math.abs(dy) > Math.abs(dx);
-    const contentWasAtTop = !this._scrollableEl || this._scrollableStartTop <= 0;
-
-    if (isDownward && isMostlyVertical && contentWasAtTop) {
-      event.preventDefault();
-      // Use the original touch position so the drag feels continuous
-      this._beginDrag(this._potentialStartY);
-      this._updateDrag(event.clientY);
-    } else {
-      // Let the browser handle scroll/other gestures
-      this._isPotentialDrag = false;
-      this._scrollableEl = null;
+    this._pendingClientY = clientY;
+    if (this._rafId === null) {
+      this._rafId = requestAnimationFrame(this._boundFlushDrag);
     }
   }
 
-  private _updateDrag(clientY: number): void {
+  private _flushDrag(): void {
+    this._rafId = null;
+    if (!this._isDragging || this._pendingClientY === null) return;
+    this._applyDragPosition(this._pendingClientY);
+  }
+
+  private _applyDragPosition(clientY: number): void {
     const container = this._getSheetContainer();
     if (!container) return;
 
@@ -265,29 +414,36 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
       );
       container.style.height = `${newHeight}px`;
       container.style.maxHeight = `${newHeight}px`;
-      container.style.transform = '';
+      // translate3d keeps the layer on the GPU compositor for smooth motion
+      container.style.transform = 'translate3d(0, 0, 0)';
       this._currentTranslateY = 0;
     } else {
       // Drag down: translate the panel with the finger so it visibly moves
       container.style.height = `${this._startHeight}px`;
       container.style.maxHeight = `${this._startHeight}px`;
-      container.style.transform = `translateY(${offset}px)`;
+      container.style.transform = `translate3d(0, ${offset}px, 0)`;
       this._currentTranslateY = offset;
     }
-
-    // Velocity (px/ms; positive = downward)
-    const currentTime = Date.now();
-    const timeDiff = currentTime - this._lastTime;
-    if (timeDiff > 0) {
-      // Light low-pass filter to avoid spikes from a single jittery sample
-      const instant = (clientY - this._lastY) / timeDiff;
-      this._velocity = this._velocity * 0.5 + instant * 0.5;
-    }
-    this._lastY = clientY;
-    this._lastTime = currentTime;
   }
 
-  private _onPointerUp(): void {
+  private _endDragOrPotential(): void {
+    // Release pointer capture if we had it
+    if (this._captureTarget && this._activePointerId !== null) {
+      try {
+        this._captureTarget.releasePointerCapture(this._activePointerId);
+      } catch {
+        /* may already be released */
+      }
+    }
+    this._captureTarget = null;
+    this._activePointerId = null;
+    this._activeTouchId = null;
+    this._pendingClientY = null;
+    if (this._rafId !== null) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+
     if (this._isPotentialDrag) {
       this._isPotentialDrag = false;
       this._scrollableEl = null;
@@ -334,11 +490,13 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
       PANEL_HEIGHTS.CLOSE_ANIMATION_MAX_DURATION,
     );
 
-    // Keep the dragging class so inner transitions stay disabled while we slide.
+    // Drop the dragging class so its `transition: none !important` no longer
+    // wins over the close transition we're about to apply.
+    container.classList.remove('dragging');
     container.style.transition = `transform ${duration}ms ${DRAG_EASING}`;
     // Force a layout flush so the transition takes effect from the current value
     void container.offsetHeight;
-    container.style.transform = `translateY(${viewportHeight}px)`;
+    container.style.transform = `translate3d(0, ${viewportHeight}px, 0)`;
 
     window.clearTimeout(this._closeAniTimeout);
     this._closeAniTimeout = window.setTimeout(() => {
@@ -349,7 +507,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _animateSnapBack(container: HTMLElement): void {
     container.style.transition = `transform ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}, height ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}, max-height ${PANEL_HEIGHTS.SNAP_BACK_DURATION}ms ${DRAG_EASING}`;
     void container.offsetHeight;
-    container.style.transform = 'translateY(0)';
+    container.style.transform = 'translate3d(0, 0, 0)';
     container.style.height = `${this._startHeight}px`;
     container.style.maxHeight = `${this._startHeight}px`;
     this._currentTranslateY = 0;

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -39,8 +39,8 @@ const PANEL_HEIGHTS = {
   OTHER_PANEL_HEIGHT: 0.9,
   VELOCITY_THRESHOLD: 0.5, // px/ms
   CLOSE_DISTANCE_RATIO: 0.4, // close if dragged below this fraction of original height
-  CLOSE_ANIMATION_MIN_DURATION: 140,
-  CLOSE_ANIMATION_MAX_DURATION: 320,
+  CLOSE_ANIMATION_MIN_DURATION: 70, // ms — fast flings get near-instant dismissal
+  CLOSE_ANIMATION_MAX_DURATION: 280, // ms — slow drags still close briskly
   EXPAND_ANIMATION_DURATION: 280,
   INITIAL_ANIMATION_BLOCK_DURATION: 300,
 } as const;
@@ -93,8 +93,10 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _startY = 0;
   private _startHeight = 0;
   private _currentHeight = 0;
-  private _lastY = 0;
-  private _lastTime = 0;
+  // Rolling window of recent move samples for robust velocity at release.
+  // A naive low-pass filter dilutes the peak fling speed because users
+  // decelerate slightly as they lift their finger.
+  private _velocitySamples: { y: number; t: number }[] = [];
   private _velocity = 0;
   private _disableAniTimeout?: number;
   private _closeAniTimeout?: number;
@@ -164,9 +166,8 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _startDrag(clientY: number): void {
     this._isDragging = true;
     this._startY = clientY;
-    this._lastY = clientY;
-    this._lastTime = Date.now();
     this._velocity = 0;
+    this._velocitySamples = [{ y: clientY, t: Date.now() }];
     const container = this._getSheetContainer();
     if (container) {
       this._startHeight = container.offsetHeight;
@@ -200,15 +201,25 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     container.style.maxHeight = `${constrainedHeight}px`;
     this._currentHeight = constrainedHeight;
 
-    const currentTime = Date.now();
-    const timeDiff = currentTime - this._lastTime;
-    if (timeDiff > 0) {
-      const instant = (clientY - this._lastY) / timeDiff;
-      // Light low-pass on the velocity sample
-      this._velocity = this._velocity * 0.5 + instant * 0.5;
+    // Push a sample and trim to the last 80ms of motion. Velocity at
+    // release is then computed from the oldest-still-fresh sample to the
+    // newest, which keeps the peak fling speed even if the user decelerates
+    // their finger in the last frame or two before lift-off.
+    const now = Date.now();
+    this._velocitySamples.push({ y: clientY, t: now });
+    const cutoff = now - 80;
+    while (
+      this._velocitySamples.length > 2 &&
+      this._velocitySamples[0].t < cutoff
+    ) {
+      this._velocitySamples.shift();
     }
-    this._lastY = clientY;
-    this._lastTime = currentTime;
+    const first = this._velocitySamples[0];
+    const last = this._velocitySamples[this._velocitySamples.length - 1];
+    const dt = last.t - first.t;
+    if (dt > 0) {
+      this._velocity = (last.y - first.y) / dt;
+    }
   }
 
   private _onPointerUp(): void {
@@ -243,18 +254,34 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _animateClose(container: HTMLElement, viewportHeight: number): void {
-    // Use translateY (not height) for the close animation so the panel
-    // visibly slides off the bottom with momentum-derived speed.
-    const remaining = Math.max(viewportHeight - (viewportHeight - this._currentHeight), 1);
-    const speed = Math.max(Math.abs(this._velocity), 0.6);
-    const duration = Math.min(
-      Math.max(remaining / speed, PANEL_HEIGHTS.CLOSE_ANIMATION_MIN_DURATION),
+    // Slide the panel off the bottom via translateY. The panel sits at
+    // `bottom: 0`, so translating by its current height moves it exactly
+    // off-screen.
+    const distance = Math.max(this._currentHeight, 1);
+
+    // For slow / distance-only closes, keep a friendly minimum speed so
+    // the duration doesn't balloon. For real flings we use the measured
+    // velocity directly — a 4 px/ms swing closes a 600px panel in 150ms.
+    const flingSpeed = Math.abs(this._velocity);
+    const speed = Math.max(flingSpeed, 0.6);
+
+    let duration = distance / speed;
+    duration = Math.min(
+      Math.max(duration, PANEL_HEIGHTS.CLOSE_ANIMATION_MIN_DURATION),
       PANEL_HEIGHTS.CLOSE_ANIMATION_MAX_DURATION,
     );
 
-    container.style.transition = `transform ${duration}ms cubic-bezier(0.22, 0.61, 0.36, 1)`;
+    // Easing: slower releases get a soft ease-out (looks natural). Fast
+    // flings use a near-linear curve so the panel actually moves at the
+    // velocity the user gave it instead of decelerating immediately.
+    const easing =
+      flingSpeed > 1.8
+        ? 'cubic-bezier(0.33, 0.0, 0.67, 1)'
+        : 'cubic-bezier(0.22, 0.61, 0.36, 1)';
+
+    container.style.transition = `transform ${duration}ms ${easing}`;
     void container.offsetHeight;
-    container.style.transform = `translateY(${this._currentHeight}px)`;
+    container.style.transform = `translateY(${distance}px)`;
 
     window.clearTimeout(this._closeAniTimeout);
     this._closeAniTimeout = window.setTimeout(() => {

--- a/src/styles/components/_bottom-panel.scss
+++ b/src/styles/components/_bottom-panel.scss
@@ -11,8 +11,12 @@
     left: 0 !important;
     right: 0 !important;
     width: 100vw !important;
-    // Enable smooth resizing - but disable during custom dragging
+    // Enable smooth resizing — close/snap transitions are set inline to use
+    // velocity-derived durations, so we keep the default light height ease
+    // for any non-drag-driven height changes.
     transition: height 0.25s cubic-bezier(0.25, 0.8, 0.25, 1);
+    // Hint the compositor for smooth transform-based dragging
+    will-change: transform, height;
     // Allow the sheet to be draggable
     resize: vertical;
     overflow: hidden;
@@ -21,7 +25,10 @@
     border-top-left-radius: 20px;
     box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
 
-    // Disable transitions during custom drag
+    // While the user is actively dragging, kill all transitions so the panel
+    // tracks the finger 1:1. Inline transitions (snap-back / close) override
+    // this rule because they are set after the dragging class is removed
+    // (or, in the close case, take precedence as inline styles).
     &.dragging {
       transition: none;
       // Prevent any inner animation/transition jank while dragging

--- a/src/styles/components/_bottom-panel.scss
+++ b/src/styles/components/_bottom-panel.scss
@@ -26,11 +26,11 @@
     box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
 
     // While the user is actively dragging, kill all transitions so the panel
-    // tracks the finger 1:1. Inline transitions (snap-back / close) override
-    // this rule because they are set after the dragging class is removed
-    // (or, in the close case, take precedence as inline styles).
+    // tracks the finger 1:1. The component also sets inline `transition: none`
+    // on dragstart so this is a belt-and-braces guard against Material's
+    // animation framework leaving residual transitions on the element.
     &.dragging {
-      transition: none;
+      transition: none !important;
       // Prevent any inner animation/transition jank while dragging
       * {
         transition: none !important;

--- a/src/styles/components/_bottom-panel.scss
+++ b/src/styles/components/_bottom-panel.scss
@@ -11,13 +11,9 @@
     left: 0 !important;
     right: 0 !important;
     width: 100vw !important;
-    // Enable smooth resizing — close/snap transitions are set inline to use
-    // velocity-derived durations, so we keep the default light height ease
-    // for any non-drag-driven height changes.
+    // Smooth height transitions for non-drag changes (set-initial / keyboard).
+    // The release-time animations (close, expand) set transitions inline.
     transition: height 0.25s cubic-bezier(0.25, 0.8, 0.25, 1);
-    // Hint the compositor for smooth transform-based dragging
-    will-change: transform, height;
-    // Allow the sheet to be draggable
     resize: vertical;
     overflow: hidden;
     background: var(--bottom-panel-bg);
@@ -25,12 +21,9 @@
     border-top-left-radius: 20px;
     box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
 
-    // While the user is actively dragging, kill the parent transition so the
-    // panel tracks the finger 1:1. We deliberately avoid a `*` rule here —
-    // it forces a style recalc on every descendant on dragstart, which on
-    // a busy panel (task detail + notes + plugins) can stall the first
-    // few frames of the gesture badly enough that the panel only appears
-    // to move once the user releases.
+    // While dragging: kill the height transition so the panel tracks the
+    // finger 1:1. Only the parent rule — no descendant selectors — so we
+    // don't trigger a style recalc on every child on dragstart.
     &.dragging {
       transition: none !important;
     }

--- a/src/styles/components/_bottom-panel.scss
+++ b/src/styles/components/_bottom-panel.scss
@@ -25,17 +25,14 @@
     border-top-left-radius: 20px;
     box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
 
-    // While the user is actively dragging, kill all transitions so the panel
-    // tracks the finger 1:1. The component also sets inline `transition: none`
-    // on dragstart so this is a belt-and-braces guard against Material's
-    // animation framework leaving residual transitions on the element.
+    // While the user is actively dragging, kill the parent transition so the
+    // panel tracks the finger 1:1. We deliberately avoid a `*` rule here —
+    // it forces a style recalc on every descendant on dragstart, which on
+    // a busy panel (task detail + notes + plugins) can stall the first
+    // few frames of the gesture badly enough that the panel only appears
+    // to move once the user releases.
     &.dragging {
       transition: none !important;
-      // Prevent any inner animation/transition jank while dragging
-      * {
-        transition: none !important;
-        animation: none !important;
-      }
     }
   }
 


### PR DESCRIPTION
The mobile bottom sheet only resized in place during a drag, so closing
felt like the panel was shrinking rather than being swiped away, and there
was no momentum on release.

- Drag down now translates the panel with the finger (transform: translateY)
  instead of just shrinking its height, so it visibly moves with the gesture.
- Velocity-derived close animation: the slide-out duration scales with the
  release velocity (clamped 120–320ms) for a momentum feel.
- Distance threshold (25% of viewport) closes the panel even on a slow drag.
- Snap-back animation springs the panel back to its start size when the
  user releases without enough distance or velocity.
- Pull-to-close from the content area: when the inner scroller is already
  at the top, a downward drag from anywhere on the panel becomes a close
  gesture (existing scrolling/horizontal gestures are untouched).
- Light low-pass filter on velocity smooths out jittery samples.