### PR TITLE
feat:Add a keyboard shortcut to collapse/expand groups

### DIFF
--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -68,6 +68,18 @@ The following shortcuts apply for the currently selected task (selected via tab 
 - `Arrow keys`: Navigate around task list
 - `ArrowRight`: Open additional info panel for currently focused task
 
+## Collapsible Groups
+
+The following shortcuts apply when focus is on a collapsible group header (e.g., task groupings in Work View like Overdue, Today, Done, Recurring, etc.).
+
+- `ArrowLeft`: Collapse the focused group
+- `ArrowRight`: Expand the focused group
+- `Shift`+`ArrowLeft`: Collapse all groups
+- `Shift`+`ArrowRight`: Expand all groups
+- `Enter` or `Space`: Toggle the focused group
+
+These shortcuts are **unconfigurable** and always available on group headers.
+
 ## Platform-Specific Differences
 
 **Electron/desktop only:**

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -207,7 +207,7 @@ export class TaskShortcutService {
         checkKeyCombo(ev, keys.selectPreviousTask))
     ) {
       ev.preventDefault();
-      this._handleTaskShortcut(focusedTaskId, 'focusPrevious');
+      this._handleTaskShortcut(focusedTaskId, 'handleArrowUp');
       return true;
     }
 
@@ -217,7 +217,7 @@ export class TaskShortcutService {
         checkKeyCombo(ev, keys.selectNextTask))
     ) {
       ev.preventDefault();
-      this._handleTaskShortcut(focusedTaskId, 'focusNext');
+      this._handleTaskShortcut(focusedTaskId, 'handleArrowDown');
       return true;
     }
 

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -544,6 +544,42 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     setTimeout(() => this.focusSelf(), 10);
   }
 
+  handleArrowUp(): void {
+    if (this._focusGroupHeaderIfAtBoundary('prev')) {
+      return;
+    }
+    this.focusPrevious();
+  }
+
+  handleArrowDown(): void {
+    if (this._focusGroupHeaderIfAtBoundary('next')) {
+      return;
+    }
+    this.focusNext();
+  }
+
+  private _focusGroupHeaderIfAtBoundary(direction: 'prev' | 'next'): boolean {
+    const myEl = this._elementRef.nativeElement as HTMLElement;
+    const myGroup = myEl.closest('collapsible.is-group') as HTMLElement | null;
+    if (!myGroup) {
+      return false;
+    }
+    const allTasks = Array.from(document.querySelectorAll('task')) as HTMLElement[];
+    const myIdx = allTasks.indexOf(myEl);
+    const adjacent = direction === 'prev' ? allTasks[myIdx - 1] : allTasks[myIdx + 1];
+    const adjacentGroup = adjacent?.closest('collapsible.is-group') ?? null;
+    if (adjacentGroup === myGroup) {
+      return false;
+    }
+    const targetGroup = direction === 'prev' ? myGroup : adjacentGroup;
+    const header = targetGroup?.querySelector('.collapsible-header');
+    if (header instanceof HTMLElement) {
+      header.focus();
+      return true;
+    }
+    return false;
+  }
+
   handleArrowLeft(): void {
     const t = this.task();
     const hasSubTasks = t.subTasks && t.subTasks.length > 0;

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -33,6 +33,7 @@ import { concatMap, first, tap } from 'rxjs/operators';
 import { fadeAnimation } from '../../../ui/animations/fade.ani';
 import { DoneToggleComponent } from '../../../ui/done-toggle/done-toggle.component';
 import { SwipeBlockComponent } from '../../../ui/swipe-block/swipe-block.component';
+import { CollapsibleComponent } from '../../../ui/collapsible/collapsible.component';
 import { TaskAttachmentService } from '../task-attachment/task-attachment.service';
 import { DialogEditTaskAttachmentComponent } from '../task-attachment/dialog-edit-attachment/dialog-edit-task-attachment.component';
 import { ProjectService } from '../../project/project.service';
@@ -549,11 +550,21 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
 
     if (this.isSelected()) {
       this.hideDetailPanel();
-    } else if (hasSubTasks && t._hideSubTasksMode !== HideSubTasksMode.HideAll) {
-      this._taskService.toggleSubTaskMode(t.id, true, false);
-    } else {
-      this.focusPrevious();
+      return;
     }
+    if (hasSubTasks && t._hideSubTasksMode !== HideSubTasksMode.HideAll) {
+      this._taskService.toggleSubTaskMode(t.id, true, false);
+      return;
+    }
+    if (!t.parentId) {
+      const group = CollapsibleComponent.findClosestGroup(this._elementRef.nativeElement);
+      if (group?.isExpanded) {
+        group.focusHeader();
+        group.collapseIfExpanded();
+        return;
+      }
+    }
+    this.focusPrevious();
   }
 
   handleArrowRight(): void {

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -33,7 +33,11 @@ import { concatMap, first, tap } from 'rxjs/operators';
 import { fadeAnimation } from '../../../ui/animations/fade.ani';
 import { DoneToggleComponent } from '../../../ui/done-toggle/done-toggle.component';
 import { SwipeBlockComponent } from '../../../ui/swipe-block/swipe-block.component';
-import { CollapsibleComponent } from '../../../ui/collapsible/collapsible.component';
+import {
+  CollapsibleComponent,
+  GROUP_NAV_SELECTOR,
+} from '../../../ui/collapsible/collapsible.component';
+import { findAdjacentFocusable } from '../../../util/find-adjacent-focusable';
 import { TaskAttachmentService } from '../task-attachment/task-attachment.service';
 import { DialogEditTaskAttachmentComponent } from '../task-attachment/dialog-edit-attachment/dialog-edit-task-attachment.component';
 import { ProjectService } from '../../project/project.service';
@@ -559,22 +563,13 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   }
 
   private _focusGroupHeaderIfAtBoundary(direction: 'prev' | 'next'): boolean {
-    const myEl = this._elementRef.nativeElement as HTMLElement;
-    const myGroup = myEl.closest('collapsible.is-group') as HTMLElement | null;
-    if (!myGroup) {
-      return false;
-    }
-    const allTasks = Array.from(document.querySelectorAll('task')) as HTMLElement[];
-    const myIdx = allTasks.indexOf(myEl);
-    const adjacent = direction === 'prev' ? allTasks[myIdx - 1] : allTasks[myIdx + 1];
-    const adjacentGroup = adjacent?.closest('collapsible.is-group') ?? null;
-    if (adjacentGroup === myGroup) {
-      return false;
-    }
-    const targetGroup = direction === 'prev' ? myGroup : adjacentGroup;
-    const header = targetGroup?.querySelector('.collapsible-header');
-    if (header instanceof HTMLElement) {
-      header.focus();
+    const adjacent = findAdjacentFocusable(
+      this._elementRef.nativeElement,
+      direction,
+      GROUP_NAV_SELECTOR,
+    );
+    if (adjacent?.matches('.collapsible-header')) {
+      adjacent.focus();
       return true;
     }
     return false;

--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -156,6 +156,7 @@
               [isExpanded]="!isOverdueHidden()"
               (isExpandedChange)="isOverdueHidden.set(!$event)"
               [isIconBefore]="true"
+              [isGroup]="true"
             >
               <div class="overdue-btn-wrapper">
                 <button
@@ -204,6 +205,7 @@
               [isExpanded]="!isLaterTodayHidden()"
               (isExpandedChange)="isLaterTodayHidden.set(!$event)"
               [isIconBefore]="true"
+              [isGroup]="true"
             >
               <task-list
                 [tasks]="laterTodayTasks()"
@@ -235,6 +237,7 @@
               [isExpanded]="!isDoneHidden()"
               (isExpandedChange)="isDoneHidden.set(!$event)"
               [isIconBefore]="true"
+              [isGroup]="true"
             >
               <task-list
                 class="tour-doneList"
@@ -278,6 +281,7 @@
               [isExpanded]="!isRepeatCfgsHidden()"
               (isExpandedChange)="isRepeatCfgsHidden.set(!$event)"
               [isIconBefore]="true"
+              [isGroup]="true"
             >
               <div class="repeat-cfg-list">
                 @for (repeatCfg of repeatCfgsForContext(); track repeatCfg.id) {

--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -126,6 +126,7 @@
                 [title]="group.key | scheduledDateGroup"
                 [isIconBefore]="true"
                 [isExpanded]="true"
+                [isGroup]="true"
               >
                 <task-list
                   [tasks]="group.value"

--- a/src/app/ui/collapsible/collapsible.component.html
+++ b/src/app/ui/collapsible/collapsible.component.html
@@ -5,6 +5,7 @@
   [attr.tabindex]="isGroup ? 0 : null"
   [attr.role]="isGroup ? 'button' : null"
   [attr.aria-expanded]="isGroup ? isExpanded : null"
+  [attr.aria-controls]="isGroup ? panelId : null"
 >
   @if (isIconBefore()) {
     <mat-icon class="collapsible-expand-icon">expand_more</mat-icon>
@@ -24,6 +25,7 @@
   <div
     [@expand]
     class="collapsible-panel ani-expand-collapse"
+    [attr.id]="panelId"
   >
     <ng-content></ng-content>
   </div>

--- a/src/app/ui/collapsible/collapsible.component.html
+++ b/src/app/ui/collapsible/collapsible.component.html
@@ -2,9 +2,9 @@
   (click)="toggleExpand()"
   (keydown)="onHeaderKeydown($event)"
   class="collapsible-header"
-  role="button"
-  tabindex="0"
-  [attr.aria-expanded]="isExpanded"
+  [attr.tabindex]="isGroup ? 0 : null"
+  [attr.role]="isGroup ? 'button' : null"
+  [attr.aria-expanded]="isGroup ? isExpanded : null"
 >
   @if (isIconBefore()) {
     <mat-icon class="collapsible-expand-icon">expand_more</mat-icon>

--- a/src/app/ui/collapsible/collapsible.component.html
+++ b/src/app/ui/collapsible/collapsible.component.html
@@ -1,6 +1,10 @@
 <div
   (click)="toggleExpand()"
+  (keydown)="onHeaderKeydown($event)"
   class="collapsible-header"
+  role="button"
+  tabindex="0"
+  [attr.aria-expanded]="isExpanded"
 >
   @if (isIconBefore()) {
     <mat-icon class="collapsible-expand-icon">expand_more</mat-icon>

--- a/src/app/ui/collapsible/collapsible.component.scss
+++ b/src/app/ui/collapsible/collapsible.component.scss
@@ -1,15 +1,21 @@
+// :host(.is-group) {
+//   border: 1px solid transparent;
+//   border-radius: var(--border-radius);
+//   transition:
+//     border-color 0.2s ease,
+//     background-color 0.2s ease;
+
+//   &:focus-within {
+//     background-color: rgba(var(--text-color-rgb, 0, 0, 0), 0.04);
+//   }
+// }
+
 :host {
   display: block;
-  border: 1px solid transparent;
-  border-radius: var(--border-radius);
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease;
+}
 
-  &:focus-within {
-    border-color: var(--c-accent);
-    background-color: rgba(var(--text-color-rgb, 0, 0, 0), 0.04);
-  }
+:host(.is-group) .collapsible-header {
+  padding: calc(var(--s) / 2) var(--s);
 }
 
 .collapsible-header {
@@ -18,7 +24,6 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: calc(var(--s) / 2) var(--s);
 
   &:focus-visible {
     outline: none;

--- a/src/app/ui/collapsible/collapsible.component.scss
+++ b/src/app/ui/collapsible/collapsible.component.scss
@@ -1,5 +1,15 @@
 :host {
   display: block;
+  border: 1px solid transparent;
+  border-radius: var(--border-radius);
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+
+  &:focus-within {
+    border-color: var(--c-accent);
+    background-color: rgba(var(--text-color-rgb, 0, 0, 0), 0.04);
+  }
 }
 
 .collapsible-header {
@@ -8,8 +18,9 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  padding: calc(var(--s) / 2) var(--s);
 
-  &:focus {
+  &:focus-visible {
     outline: none;
   }
 

--- a/src/app/ui/collapsible/collapsible.component.scss
+++ b/src/app/ui/collapsible/collapsible.component.scss
@@ -1,15 +1,3 @@
-// :host(.is-group) {
-//   border: 1px solid transparent;
-//   border-radius: var(--border-radius);
-//   transition:
-//     border-color 0.2s ease,
-//     background-color 0.2s ease;
-
-//   &:focus-within {
-//     background-color: rgba(var(--text-color-rgb, 0, 0, 0), 0.04);
-//   }
-// }
-
 :host {
   display: block;
 }
@@ -26,7 +14,8 @@
   align-items: center;
 
   &:focus-visible {
-    outline: none;
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
   }
 
   :host.isInline & {

--- a/src/app/ui/collapsible/collapsible.component.spec.ts
+++ b/src/app/ui/collapsible/collapsible.component.spec.ts
@@ -16,6 +16,10 @@ import { CollapsibleComponent } from './collapsible.component';
       [title]="'Group Two'"
       [isGroup]="true"
     ></collapsible>
+    <collapsible
+      [title]="'Non-Group'"
+      [isGroup]="false"
+    ></collapsible>
   `,
   imports: [CollapsibleComponent],
 })
@@ -27,6 +31,7 @@ describe('CollapsibleComponent', () => {
   let collapsibleInstances: CollapsibleComponent[];
 
   beforeEach(async () => {
+    CollapsibleComponent['_groupCollapsibles'].clear();
     await TestBed.configureTestingModule({
       imports: [TestHostComponent, MatIconModule, NoopAnimationsModule],
     }).compileComponents();
@@ -68,6 +73,7 @@ describe('CollapsibleComponent', () => {
 
   it('should expand and collapse all groups with Shift+ArrowRight / Shift+ArrowLeft', () => {
     const header = headerElements[0];
+    const groupCollapsibles = collapsibleInstances.slice(0, 2);
 
     header.dispatchEvent(
       new KeyboardEvent('keydown', {
@@ -78,7 +84,7 @@ describe('CollapsibleComponent', () => {
     );
     fixture.detectChanges();
 
-    expect(collapsibleInstances.every((c) => c.isExpanded)).toBe(true);
+    expect(groupCollapsibles.every((c) => c.isExpanded)).toBe(true);
 
     header.dispatchEvent(
       new KeyboardEvent('keydown', {
@@ -89,6 +95,66 @@ describe('CollapsibleComponent', () => {
     );
     fixture.detectChanges();
 
-    expect(collapsibleInstances.every((c) => c.isExpanded)).toBe(false);
+    expect(groupCollapsibles.every((c) => c.isExpanded)).toBe(false);
+  });
+
+  it('should toggle the group with Enter and Space', () => {
+    const header = headerElements[0];
+    const collapsible = collapsibleInstances[0];
+
+    expect(collapsible.isExpanded).toBe(false);
+
+    header.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(collapsible.isExpanded).toBe(true);
+
+    header.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    fixture.detectChanges();
+
+    expect(collapsible.isExpanded).toBe(false);
+  });
+
+  it('should not toggle a non-group collapsible with Arrow keys', () => {
+    const nonGroupHeader = headerElements[2];
+    const nonGroupCollapsible = collapsibleInstances[2];
+
+    expect(nonGroupCollapsible.isExpanded).toBe(false);
+
+    nonGroupHeader.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(nonGroupCollapsible.isExpanded).toBe(false);
+  });
+
+  it('should not affect group collapsibles when Shift+Arrow on a non-group', () => {
+    const nonGroupHeader = headerElements[2];
+    const groupCollapsibles = collapsibleInstances.slice(0, 2);
+
+    // First expand all groups
+    headerElements[0].dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    fixture.detectChanges();
+
+    expect(groupCollapsibles.every((c) => c.isExpanded)).toBe(true);
+
+    // Now Shift+Arrow on non-group should not affect groups
+    nonGroupHeader.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    fixture.detectChanges();
+
+    expect(groupCollapsibles.every((c) => c.isExpanded)).toBe(true);
   });
 });

--- a/src/app/ui/collapsible/collapsible.component.spec.ts
+++ b/src/app/ui/collapsible/collapsible.component.spec.ts
@@ -1,0 +1,94 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconModule } from '@angular/material/icon';
+import { CollapsibleComponent } from './collapsible.component';
+
+@Component({
+  standalone: true,
+  template: `
+    <collapsible
+      [title]="'Group One'"
+      [isGroup]="true"
+    ></collapsible>
+    <collapsible
+      [title]="'Group Two'"
+      [isGroup]="true"
+    ></collapsible>
+  `,
+  imports: [CollapsibleComponent],
+})
+class TestHostComponent {}
+
+describe('CollapsibleComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let headerElements: HTMLElement[];
+  let collapsibleInstances: CollapsibleComponent[];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, MatIconModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    headerElements = Array.from(
+      fixture.nativeElement.querySelectorAll('.collapsible-header'),
+    );
+    collapsibleInstances = fixture.debugElement
+      .queryAll(By.directive(CollapsibleComponent))
+      .map((de) => de.componentInstance as CollapsibleComponent);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('should toggle the current group with ArrowLeft and ArrowRight', () => {
+    const header = headerElements[0];
+
+    expect(collapsibleInstances[0].isExpanded).toBe(false);
+
+    header.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(collapsibleInstances[0].isExpanded).toBe(true);
+
+    header.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(collapsibleInstances[0].isExpanded).toBe(false);
+  });
+
+  it('should expand and collapse all groups with Shift+ArrowRight / Shift+ArrowLeft', () => {
+    const header = headerElements[0];
+
+    header.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    fixture.detectChanges();
+
+    expect(collapsibleInstances.every((c) => c.isExpanded)).toBe(true);
+
+    header.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    fixture.detectChanges();
+
+    expect(collapsibleInstances.every((c) => c.isExpanded)).toBe(false);
+  });
+});

--- a/src/app/ui/collapsible/collapsible.component.ts
+++ b/src/app/ui/collapsible/collapsible.component.ts
@@ -30,7 +30,7 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
   @Input() icon?: string;
 
   readonly isIconBefore = input<boolean>(false);
-  @Input() isGroup = false;
+  @HostBinding('class.is-group') @Input() isGroup = false;
 
   // TODO: Skipped for migration because:
   //  Your application code writes to the input. This prevents migration.
@@ -57,8 +57,12 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
   }
 
   onHeaderKeydown(ev: KeyboardEvent): void {
+    if (!this.isGroup) {
+      return;
+    }
+
     if (ev.key === 'ArrowLeft') {
-      if (ev.shiftKey && this.isGroup) {
+      if (ev.shiftKey) {
         CollapsibleComponent.setAllGroupExpanded(false);
       } else {
         this.collapseIfExpanded();
@@ -69,11 +73,18 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
     }
 
     if (ev.key === 'ArrowRight') {
-      if (ev.shiftKey && this.isGroup) {
+      if (ev.shiftKey) {
         CollapsibleComponent.setAllGroupExpanded(true);
       } else {
         this.expandIfCollapsed();
       }
+      ev.preventDefault();
+      ev.stopPropagation();
+      return;
+    }
+
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      this.toggleExpand();
       ev.preventDefault();
       ev.stopPropagation();
       return;

--- a/src/app/ui/collapsible/collapsible.component.ts
+++ b/src/app/ui/collapsible/collapsible.component.ts
@@ -22,7 +22,12 @@ import { MatIcon } from '@angular/material/icon';
   imports: [MatIcon],
 })
 export class CollapsibleComponent implements OnInit, OnDestroy {
+  // TODO: _groupCollapsibles is a global registry. If a second consumer uses [isGroup]="true",
+  // all instances will silently be linked via Shift+Arrow behavior. Consider scoping this to
+  // a parent context or separating by logical group if that becomes a future requirement.
   private static _groupCollapsibles = new Set<CollapsibleComponent>();
+  private static _idCounter = 0;
+  readonly panelId = this.createPanelId();
   readonly title = input<string>();
   // TODO: Skipped for migration because:
   //  This input is used in a control flow expression (e.g. `@if` or `*ngIf`)
@@ -43,6 +48,14 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
   readonly isExpandedChange = output<boolean>();
 
   private _cd = inject(ChangeDetectorRef);
+
+  private createPanelId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+
+    return `collapsible-panel-${++CollapsibleComponent._idCounter}`;
+  }
 
   ngOnInit(): void {
     if (this.isGroup) {

--- a/src/app/ui/collapsible/collapsible.component.ts
+++ b/src/app/ui/collapsible/collapsible.component.ts
@@ -98,12 +98,44 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
       return;
     }
 
+    if (ev.key === 'ArrowDown') {
+      if (this._focusAdjacentTask('next')) {
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+      return;
+    }
+
+    if (ev.key === 'ArrowUp') {
+      if (this._focusAdjacentTask('prev')) {
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+      return;
+    }
+
     if (ev.key === 'Enter' || ev.key === ' ') {
       this.toggleExpand();
       ev.preventDefault();
       ev.stopPropagation();
       return;
     }
+  }
+
+  private _focusAdjacentTask(direction: 'next' | 'prev'): boolean {
+    const host = this._elementRef.nativeElement as HTMLElement;
+    const tasks = Array.from(document.querySelectorAll('task')) as HTMLElement[];
+    const wantedBit =
+      direction === 'next'
+        ? Node.DOCUMENT_POSITION_FOLLOWING
+        : Node.DOCUMENT_POSITION_PRECEDING;
+    const ordered = direction === 'next' ? tasks : tasks.reverse();
+    const target = ordered.find((t) => host.compareDocumentPosition(t) & wantedBit);
+    if (target) {
+      target.focus();
+      return true;
+    }
+    return false;
   }
 
   toggleExpand(): void {

--- a/src/app/ui/collapsible/collapsible.component.ts
+++ b/src/app/ui/collapsible/collapsible.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   HostBinding,
   Input,
   OnDestroy,
@@ -48,6 +49,7 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
   readonly isExpandedChange = output<boolean>();
 
   private _cd = inject(ChangeDetectorRef);
+  private _elementRef = inject(ElementRef);
 
   private createPanelId(): string {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -110,19 +112,39 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
     this._cd.markForCheck();
   }
 
-  private collapseIfExpanded(): void {
+  collapseIfExpanded(): void {
     if (this.isExpanded) {
       this.toggleExpand();
     }
   }
 
-  private expandIfCollapsed(): void {
+  expandIfCollapsed(): void {
     if (!this.isExpanded) {
       this.toggleExpand();
     }
   }
 
-  private static setAllGroupExpanded(isExpanded: boolean): void {
+  focusHeader(): void {
+    const header = this._elementRef.nativeElement.querySelector('.collapsible-header');
+    if (header instanceof HTMLElement) {
+      header.focus();
+    }
+  }
+
+  static findClosestGroup(element: HTMLElement | null): CollapsibleComponent | null {
+    const host = element?.closest('collapsible.is-group') ?? null;
+    if (!host) {
+      return null;
+    }
+    for (const c of CollapsibleComponent._groupCollapsibles) {
+      if (c._elementRef.nativeElement === host) {
+        return c;
+      }
+    }
+    return null;
+  }
+
+  static setAllGroupExpanded(isExpanded: boolean): void {
     for (const collapsible of CollapsibleComponent._groupCollapsibles) {
       if (collapsible.isExpanded !== isExpanded) {
         collapsible.isExpanded = isExpanded;

--- a/src/app/ui/collapsible/collapsible.component.ts
+++ b/src/app/ui/collapsible/collapsible.component.ts
@@ -13,6 +13,13 @@ import {
 } from '@angular/core';
 import { expandAnimation } from '../animations/expand.ani';
 import { MatIcon } from '@angular/material/icon';
+import { findAdjacentFocusable } from '../../util/find-adjacent-focusable';
+
+/**
+ * CSS selector matching every element that participates in keyboard
+ * arrow-navigation across the work view: task rows and group headers.
+ */
+export const GROUP_NAV_SELECTOR = 'task, collapsible.is-group > .collapsible-header';
 
 @Component({
   selector: 'collapsible',
@@ -98,16 +105,8 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (ev.key === 'ArrowDown') {
-      if (this._focusAdjacentTask('next')) {
-        ev.preventDefault();
-        ev.stopPropagation();
-      }
-      return;
-    }
-
-    if (ev.key === 'ArrowUp') {
-      if (this._focusAdjacentTask('prev')) {
+    if (ev.key === 'ArrowDown' || ev.key === 'ArrowUp') {
+      if (this._focusAdjacent(ev, ev.key === 'ArrowDown' ? 'next' : 'prev')) {
         ev.preventDefault();
         ev.stopPropagation();
       }
@@ -122,15 +121,9 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
     }
   }
 
-  private _focusAdjacentTask(direction: 'next' | 'prev'): boolean {
-    const host = this._elementRef.nativeElement as HTMLElement;
-    const tasks = Array.from(document.querySelectorAll('task')) as HTMLElement[];
-    const wantedBit =
-      direction === 'next'
-        ? Node.DOCUMENT_POSITION_FOLLOWING
-        : Node.DOCUMENT_POSITION_PRECEDING;
-    const ordered = direction === 'next' ? tasks : tasks.reverse();
-    const target = ordered.find((t) => host.compareDocumentPosition(t) & wantedBit);
+  private _focusAdjacent(ev: KeyboardEvent, direction: 'prev' | 'next'): boolean {
+    const from = ev.currentTarget as HTMLElement;
+    const target = findAdjacentFocusable(from, direction, GROUP_NAV_SELECTOR);
     if (target) {
       target.focus();
       return true;

--- a/src/app/ui/collapsible/collapsible.component.ts
+++ b/src/app/ui/collapsible/collapsible.component.ts
@@ -143,14 +143,16 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
     }
   }
 
-  expandIfCollapsed(): void {
+  private expandIfCollapsed(): void {
     if (!this.isExpanded) {
       this.toggleExpand();
     }
   }
 
   focusHeader(): void {
-    const header = this._elementRef.nativeElement.querySelector('.collapsible-header');
+    const header = this._elementRef.nativeElement.querySelector(
+      ':scope > .collapsible-header',
+    );
     if (header instanceof HTMLElement) {
       header.focus();
     }
@@ -169,7 +171,7 @@ export class CollapsibleComponent implements OnInit, OnDestroy {
     return null;
   }
 
-  static setAllGroupExpanded(isExpanded: boolean): void {
+  private static setAllGroupExpanded(isExpanded: boolean): void {
     for (const collapsible of CollapsibleComponent._groupCollapsibles) {
       if (collapsible.isExpanded !== isExpanded) {
         collapsible.isExpanded = isExpanded;

--- a/src/app/ui/collapsible/collapsible.component.ts
+++ b/src/app/ui/collapsible/collapsible.component.ts
@@ -1,8 +1,12 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   HostBinding,
   Input,
+  OnDestroy,
+  OnInit,
+  inject,
   input,
   output,
 } from '@angular/core';
@@ -17,7 +21,8 @@ import { MatIcon } from '@angular/material/icon';
   animations: [expandAnimation],
   imports: [MatIcon],
 })
-export class CollapsibleComponent {
+export class CollapsibleComponent implements OnInit, OnDestroy {
+  private static _groupCollapsibles = new Set<CollapsibleComponent>();
   readonly title = input<string>();
   // TODO: Skipped for migration because:
   //  This input is used in a control flow expression (e.g. `@if` or `*ngIf`)
@@ -25,6 +30,7 @@ export class CollapsibleComponent {
   @Input() icon?: string;
 
   readonly isIconBefore = input<boolean>(false);
+  @Input() isGroup = false;
 
   // TODO: Skipped for migration because:
   //  Your application code writes to the input. This prevents migration.
@@ -36,10 +42,69 @@ export class CollapsibleComponent {
 
   readonly isExpandedChange = output<boolean>();
 
-  constructor() {}
+  private _cd = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    if (this.isGroup) {
+      CollapsibleComponent._groupCollapsibles.add(this);
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.isGroup) {
+      CollapsibleComponent._groupCollapsibles.delete(this);
+    }
+  }
+
+  onHeaderKeydown(ev: KeyboardEvent): void {
+    if (ev.key === 'ArrowLeft') {
+      if (ev.shiftKey && this.isGroup) {
+        CollapsibleComponent.setAllGroupExpanded(false);
+      } else {
+        this.collapseIfExpanded();
+      }
+      ev.preventDefault();
+      ev.stopPropagation();
+      return;
+    }
+
+    if (ev.key === 'ArrowRight') {
+      if (ev.shiftKey && this.isGroup) {
+        CollapsibleComponent.setAllGroupExpanded(true);
+      } else {
+        this.expandIfCollapsed();
+      }
+      ev.preventDefault();
+      ev.stopPropagation();
+      return;
+    }
+  }
 
   toggleExpand(): void {
     this.isExpanded = !this.isExpanded;
     this.isExpandedChange.emit(this.isExpanded);
+    this._cd.markForCheck();
+  }
+
+  private collapseIfExpanded(): void {
+    if (this.isExpanded) {
+      this.toggleExpand();
+    }
+  }
+
+  private expandIfCollapsed(): void {
+    if (!this.isExpanded) {
+      this.toggleExpand();
+    }
+  }
+
+  private static setAllGroupExpanded(isExpanded: boolean): void {
+    for (const collapsible of CollapsibleComponent._groupCollapsibles) {
+      if (collapsible.isExpanded !== isExpanded) {
+        collapsible.isExpanded = isExpanded;
+        collapsible.isExpandedChange.emit(isExpanded);
+        collapsible._cd.markForCheck();
+      }
+    }
   }
 }

--- a/src/app/util/find-adjacent-focusable.spec.ts
+++ b/src/app/util/find-adjacent-focusable.spec.ts
@@ -1,0 +1,98 @@
+import { findAdjacentFocusable } from './find-adjacent-focusable';
+
+describe('findAdjacentFocusable', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    root.remove();
+  });
+
+  const setupTree = (): {
+    headerA: HTMLElement;
+    taskA1: HTMLElement;
+    taskA2: HTMLElement;
+    subA2: HTMLElement;
+    headerB: HTMLElement;
+    taskB1: HTMLElement;
+  } => {
+    root.innerHTML = `
+      <collapsible class="is-group">
+        <div class="collapsible-header" id="hA"></div>
+        <task id="tA1"></task>
+        <task id="tA2">
+          <task id="sA2"></task>
+        </task>
+      </collapsible>
+      <collapsible class="is-group">
+        <div class="collapsible-header" id="hB"></div>
+        <task id="tB1"></task>
+      </collapsible>
+    `;
+    return {
+      headerA: root.querySelector('#hA')!,
+      taskA1: root.querySelector('#tA1')!,
+      taskA2: root.querySelector('#tA2')!,
+      subA2: root.querySelector('#sA2')!,
+      headerB: root.querySelector('#hB')!,
+      taskB1: root.querySelector('#tB1')!,
+    };
+  };
+
+  const SELECTOR = 'task, collapsible.is-group > .collapsible-header';
+
+  it('returns next match when from is in the list', () => {
+    const { taskA1, taskA2 } = setupTree();
+    expect(findAdjacentFocusable(taskA1, 'next', SELECTOR)).toBe(taskA2);
+  });
+
+  it('returns prev match when from is in the list', () => {
+    const { headerA, taskA1 } = setupTree();
+    expect(findAdjacentFocusable(taskA1, 'prev', SELECTOR)).toBe(headerA);
+  });
+
+  it('crosses group boundary forward (last sub-task → next group header)', () => {
+    const { subA2, headerB } = setupTree();
+    expect(findAdjacentFocusable(subA2, 'next', SELECTOR)).toBe(headerB);
+  });
+
+  it('crosses group boundary backward (first task → current group header)', () => {
+    const { taskB1, headerB } = setupTree();
+    expect(findAdjacentFocusable(taskB1, 'prev', SELECTOR)).toBe(headerB);
+  });
+
+  it('walks past sub-tasks in document order', () => {
+    const { taskA2, subA2 } = setupTree();
+    // taskA2 is the parent; subA2 is its child and immediately follows in DOM
+    expect(findAdjacentFocusable(taskA2, 'next', SELECTOR)).toBe(subA2);
+  });
+
+  it('returns null at the start of the list', () => {
+    const { headerA } = setupTree();
+    expect(findAdjacentFocusable(headerA, 'prev', SELECTOR)).toBeNull();
+  });
+
+  it('returns null at the end of the list', () => {
+    const { taskB1 } = setupTree();
+    expect(findAdjacentFocusable(taskB1, 'next', SELECTOR)).toBeNull();
+  });
+
+  it('falls back to compareDocumentPosition when from does not match selector', () => {
+    setupTree();
+    const outsider = document.createElement('div');
+    root.insertBefore(outsider, root.firstChild);
+    // outsider is before everything; next focusable is the first header
+    const result = findAdjacentFocusable(outsider, 'next', SELECTOR);
+    expect(result?.id).toBe('hA');
+  });
+
+  it('returns null when no elements match the selector', () => {
+    const lonely = document.createElement('div');
+    root.appendChild(lonely);
+    expect(findAdjacentFocusable(lonely, 'next', '.does-not-exist')).toBeNull();
+  });
+});

--- a/src/app/util/find-adjacent-focusable.spec.ts
+++ b/src/app/util/find-adjacent-focusable.spec.ts
@@ -81,18 +81,10 @@ describe('findAdjacentFocusable', () => {
     expect(findAdjacentFocusable(taskB1, 'next', SELECTOR)).toBeNull();
   });
 
-  it('falls back to compareDocumentPosition when from does not match selector', () => {
+  it('returns null when from does not match the selector', () => {
     setupTree();
     const outsider = document.createElement('div');
     root.insertBefore(outsider, root.firstChild);
-    // outsider is before everything; next focusable is the first header
-    const result = findAdjacentFocusable(outsider, 'next', SELECTOR);
-    expect(result?.id).toBe('hA');
-  });
-
-  it('returns null when no elements match the selector', () => {
-    const lonely = document.createElement('div');
-    root.appendChild(lonely);
-    expect(findAdjacentFocusable(lonely, 'next', '.does-not-exist')).toBeNull();
+    expect(findAdjacentFocusable(outsider, 'next', SELECTOR)).toBeNull();
   });
 });

--- a/src/app/util/find-adjacent-focusable.ts
+++ b/src/app/util/find-adjacent-focusable.ts
@@ -5,13 +5,9 @@ export type FocusDirection = 'prev' | 'next';
  * relative to `from`. Used for keyboard arrow-navigation across a mixed list
  * of focusable elements (e.g. group headers and task rows in the work view).
  *
- * If `from` itself matches the selector, walks one step in `direction`.
- * Otherwise (e.g. the caller passes its host element) finds the closest match
- * before/after `from` via `compareDocumentPosition`.
- *
- * Visibility is determined by DOM presence — Angular structural directives
- * (`@if`, `@for` filters) keep hidden elements out of the document, so this
- * will only return currently-rendered targets.
+ * `from` must itself match `selector`. Visibility is determined by DOM
+ * presence — Angular structural directives (`@if`, `@for` filters) keep
+ * hidden elements out of the document, so this only returns rendered targets.
  */
 export const findAdjacentFocusable = (
   from: HTMLElement,
@@ -20,13 +16,9 @@ export const findAdjacentFocusable = (
 ): HTMLElement | null => {
   const all = Array.from(document.querySelectorAll<HTMLElement>(selector));
   const idx = all.indexOf(from);
-  if (idx >= 0) {
-    return direction === 'next' ? (all[idx + 1] ?? null) : (all[idx - 1] ?? null);
+  if (idx < 0) {
+    return null;
   }
-  const wantedBit =
-    direction === 'next'
-      ? Node.DOCUMENT_POSITION_FOLLOWING
-      : Node.DOCUMENT_POSITION_PRECEDING;
-  const ordered = direction === 'next' ? all : all.slice().reverse();
-  return ordered.find((el) => from.compareDocumentPosition(el) & wantedBit) ?? null;
+  const step = direction === 'next' ? 1 : -1;
+  return all[idx + step] ?? null;
 };

--- a/src/app/util/find-adjacent-focusable.ts
+++ b/src/app/util/find-adjacent-focusable.ts
@@ -1,0 +1,32 @@
+export type FocusDirection = 'prev' | 'next';
+
+/**
+ * Returns the previous or next element matching `selector` in document order,
+ * relative to `from`. Used for keyboard arrow-navigation across a mixed list
+ * of focusable elements (e.g. group headers and task rows in the work view).
+ *
+ * If `from` itself matches the selector, walks one step in `direction`.
+ * Otherwise (e.g. the caller passes its host element) finds the closest match
+ * before/after `from` via `compareDocumentPosition`.
+ *
+ * Visibility is determined by DOM presence — Angular structural directives
+ * (`@if`, `@for` filters) keep hidden elements out of the document, so this
+ * will only return currently-rendered targets.
+ */
+export const findAdjacentFocusable = (
+  from: HTMLElement,
+  direction: FocusDirection,
+  selector: string,
+): HTMLElement | null => {
+  const all = Array.from(document.querySelectorAll<HTMLElement>(selector));
+  const idx = all.indexOf(from);
+  if (idx >= 0) {
+    return direction === 'next' ? (all[idx + 1] ?? null) : (all[idx - 1] ?? null);
+  }
+  const wantedBit =
+    direction === 'next'
+      ? Node.DOCUMENT_POSITION_FOLLOWING
+      : Node.DOCUMENT_POSITION_PRECEDING;
+  const ordered = direction === 'next' ? all : all.slice().reverse();
+  return ordered.find((el) => from.compareDocumentPosition(el) & wantedBit) ?? null;
+};


### PR DESCRIPTION
## Problem

There is no efficient way to expand or collapse all task groups at once. Users must manually toggle each group, which is inefficient when working with many groups.

Fixes: #7313 
## Solution

Added keyboard shortcuts to expand and collapse all task groups simultaneously. Also added support for toggling individual groups using arrow keys, improving navigation and usability.

(Border color is not getting recorded correctly in the video)
Video:
[Screencast from 2026-04-26 13-52-14.webm](https://github.com/user-attachments/assets/a0a4ce9e-e357-440e-93d9-44ed6a64a5a7)

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)