### PR TITLE
feat: allow dev override for local REST API

### DIFF
--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -193,10 +193,12 @@ When a plugin uses an iframe UI, the following are **not** available: `registerH
 
 The Local REST API allows external scripts and tools to interact with a running Super Productivity desktop app. It runs on `http://127.0.0.1:3876` and is disabled by default. Enable it in **Settings → Misc → Enable local REST API**.
 
+For development scripts, `SP_FORCE_LOCAL_REST_API=1 npm start` starts the local REST API without changing the persisted user setting. This override only works in `NODE_ENV=DEV`.
+
 ### Prerequisites
 
 - **Electron desktop app only** (not available on web or mobile)
-- Must be enabled in settings
+- Must be enabled in settings, unless using the development override
 - App must be running with renderer ready
 
 ### Authentication
@@ -292,12 +294,12 @@ curl -X POST http://127.0.0.1:3876/tasks/task-id/archive
 
 **POST /tasks body fields:**
 
-| Field                | Notes                                                                                                                                                                                                                                   |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title` (required)   | Non-empty string                                                                                                                                                                                                                        |
+| Field                | Notes                                                                                                                                                                                                                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title` (required)   | Non-empty string                                                                                                                                                                                                                                                                                  |
 | `parentId`           | Create the task as a subtask of this top-level task. Returns 404 if parent missing, 400 if parent is itself a subtask. The new subtask inherits the parent's `projectId` and never has its own tags — supplying `projectId` or `tagIds` together with `parentId` returns 400 `UNSUPPORTED_FIELD`. |
-| `subTaskIds`         | Not supported on create — returns 400 `UNSUPPORTED_FIELD`. Create the parent first, then create each child with `parentId`.                                                                                                             |
-| other allowed fields | `notes`, `isDone`, `timeEstimate`, `timeSpent`, `projectId`, `tagIds`, `dueDay`, `dueWithTime`, `plannedAt`                                                                                                                             |
+| `subTaskIds`         | Not supported on create — returns 400 `UNSUPPORTED_FIELD`. Create the parent first, then create each child with `parentId`.                                                                                                                                                                       |
+| other allowed fields | `notes`, `isDone`, `timeEstimate`, `timeSpent`, `projectId`, `tagIds`, `dueDay`, `dueWithTime`, `plannedAt`                                                                                                                                                                                       |
 
 **PATCH /tasks/:id — restricted fields:**
 

--- a/electron/local-rest-api.ts
+++ b/electron/local-rest-api.ts
@@ -115,6 +115,9 @@ const ALLOWED_HOSTS = new Set([
   'localhost',
 ]);
 
+const isForceEnabledForDev = (): boolean =>
+  process.env.NODE_ENV === 'DEV' && process.env.SP_FORCE_LOCAL_REST_API === '1';
+
 const handleHttpRequest = async (
   req: IncomingMessage,
   res: ServerResponse,
@@ -221,6 +224,12 @@ export const initLocalRestApi = (): void => {
     isListening = false;
     warn('[local-rest-api] Server error', error);
   });
+
+  if (isForceEnabledForDev()) {
+    warn('[local-rest-api] Enabled by SP_FORCE_LOCAL_REST_API=1 for DEV runtime');
+    isEnabled = true;
+    startServer();
+  }
 };
 
 const startServer = (): void => {
@@ -253,7 +262,8 @@ const stopServer = (): void => {
 };
 
 export const updateLocalRestApiConfig = (cfg: GlobalConfigState): void => {
-  const nextEnabled = !!cfg.misc.isLocalRestApiEnabled;
+  const isForcedForDev = isForceEnabledForDev();
+  const nextEnabled = isForcedForDev || !!cfg.misc.isLocalRestApiEnabled;
   if (nextEnabled === isEnabled) {
     if (nextEnabled && !isListening) {
       startServer();


### PR DESCRIPTION
## Summary
- add DEV-only SP_FORCE_LOCAL_REST_API=1 override for starting Local REST API
- keep persisted user setting unchanged
- document development override in API reference

## Verification
- npm run electron:build
- npm run test:electron
- commit/push hooks: npm run lint, npm run test