### PR TITLE
feat: add local REST project endpoints

### DIFF
--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -45,6 +45,22 @@ describe('LocalRestApiHandlerService', () => {
     subTasks,
   });
 
+  const createMockProject = (id: string, overrides: Record<string, unknown> = {}): any =>
+    ({
+      id,
+      title: `Project ${id}`,
+      icon: 'list_alt',
+      isArchived: false,
+      isHiddenFromMenu: false,
+      isEnableBacklog: false,
+      taskIds: [],
+      backlogTaskIds: [],
+      noteIds: [],
+      advancedCfg: {},
+      theme: {},
+      ...overrides,
+    }) as any;
+
   const mockElectronApi = (): void => {
     (window as any).ea = {
       onLocalRestApiRequest: (handler: (payload: LocalRestApiRequestPayload) => void) => {
@@ -126,8 +142,10 @@ describe('LocalRestApiHandlerService', () => {
       ['add', 'update', 'remove', 'archive'],
       {
         list$: of([]),
+        getByIdOnce$: (_id: string) => of(undefined),
       },
     );
+    (projectServiceMock as any).add.and.returnValue('new-project-id');
 
     tagServiceMock = jasmine.createSpyObj(
       'TagService',
@@ -843,6 +861,135 @@ describe('LocalRestApiHandlerService', () => {
         );
 
         expect(response.body.ok).toBe(true);
+      });
+    });
+
+    describe('POST /projects', () => {
+      it('should reject unsafe list fields', async () => {
+        const createdProject = createMockProject('new-project-id', {
+          title: 'Symphony',
+          icon: 'hub',
+        });
+        Object.defineProperty(projectServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(createdProject),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/projects', {
+            body: {
+              title: '  Symphony  ',
+              icon: 'hub',
+              taskIds: ['unsafe'],
+              id: 'injected-id',
+            },
+          }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('UNSUPPORTED_FIELD');
+        expect(projectServiceMock.add).not.toHaveBeenCalled();
+      });
+
+      it('should create a project and strip unknown fields', async () => {
+        const createdProject = createMockProject('new-project-id', {
+          title: 'Symphony',
+          icon: 'hub',
+        });
+        Object.defineProperty(projectServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(createdProject),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/projects', {
+            body: {
+              title: '  Symphony  ',
+              icon: 'hub',
+              unknownField: 'ignored',
+            },
+          }),
+        );
+
+        expect(response.body.ok).toBe(true);
+        expect(response.status).toBe(201);
+        expect(projectServiceMock.add).toHaveBeenCalledWith({
+          title: 'Symphony',
+          icon: 'hub',
+        });
+        expect((response.body as any).data).toEqual(createdProject);
+      });
+
+      it('should return 400 for missing title', async () => {
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/projects', { body: { icon: 'hub' } }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('INVALID_INPUT');
+      });
+
+      it('should return 400 for empty title', async () => {
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/projects', { body: { title: '   ' } }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+      });
+    });
+
+    describe('PATCH /projects/:id', () => {
+      it('should update an existing project', async () => {
+        const existingProject = createMockProject('project-1', { title: 'Old' });
+        Object.defineProperty(projectServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(existingProject),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('PATCH', '/projects/project-1', {
+            body: { title: '  New  ', icon: 'hub', unknownField: 'ignored' },
+          }),
+        );
+
+        expect(response.body.ok).toBe(true);
+        expect(response.status).toBe(200);
+        expect(projectServiceMock.update).toHaveBeenCalledWith('project-1', {
+          title: 'New',
+          icon: 'hub',
+        });
+      });
+
+      it('should return 404 for non-existent project', async () => {
+        Object.defineProperty(projectServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(undefined),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('PATCH', '/projects/missing', { body: { title: 'New' } }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(404);
+        expect((response.body as any).error.code).toBe('PROJECT_NOT_FOUND');
+      });
+
+      it('should reject unsafe list fields', async () => {
+        const existingProject = createMockProject('project-1');
+        Object.defineProperty(projectServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(existingProject),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('PATCH', '/projects/project-1', {
+            body: { taskIds: ['unsafe'] },
+          }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('UNSUPPORTED_FIELD');
+        expect(projectServiceMock.update).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -4,6 +4,7 @@ import { TaskService } from '../../features/tasks/task.service';
 import { Task, TaskWithSubTasks } from '../../features/tasks/task.model';
 import { TaskArchiveService } from '../../features/archive/task-archive.service';
 import { ProjectService } from '../../features/project/project.service';
+import { Project } from '../../features/project/project.model';
 import { TagService } from '../../features/tag/tag.service';
 import {
   LocalRestApiRequestPayload,
@@ -43,6 +44,17 @@ const REJECTED_TASK_FIELDS = ['parentId', 'subTaskIds'] as const;
  */
 const SUBTASK_INHERITED_FIELDS = ['projectId', 'tagIds'] as const;
 
+/** Keep project REST writes to scalar/basic fields. Task and note lists are reducer-owned. */
+const ALLOWED_PROJECT_FIELDS = new Set<string>([
+  'title',
+  'icon',
+  'isArchived',
+  'isHiddenFromMenu',
+  'isEnableBacklog',
+]);
+
+const REJECTED_PROJECT_FIELDS = ['taskIds', 'backlogTaskIds', 'noteIds'] as const;
+
 const pickAllowedFields = (body: Record<string, unknown>): Partial<Task> => {
   const result: Record<string, unknown> = {};
   for (const key of Object.keys(body)) {
@@ -55,6 +67,20 @@ const pickAllowedFields = (body: Record<string, unknown>): Partial<Task> => {
 
 const firstRejectedField = (body: Record<string, unknown>): string | undefined =>
   REJECTED_TASK_FIELDS.find((field) => field in body);
+
+const pickAllowedProjectFields = (body: Record<string, unknown>): Partial<Project> => {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(body)) {
+    if (ALLOWED_PROJECT_FIELDS.has(key)) {
+      result[key] =
+        key === 'title' && typeof body[key] === 'string' ? body[key].trim() : body[key];
+    }
+  }
+  return result as Partial<Project>;
+};
+
+const firstRejectedProjectField = (body: Record<string, unknown>): string | undefined =>
+  REJECTED_PROJECT_FIELDS.find((field) => field in body);
 
 const getQueryParam = (
   query: Record<string, string | string[]>,
@@ -183,6 +209,14 @@ export class LocalRestApiHandlerService {
 
     if (method === 'GET' && path === '/projects') {
       return this._handleListProjects(requestId, query);
+    }
+
+    if (method === 'POST' && path === '/projects') {
+      return this._handleCreateProject(requestId, body);
+    }
+
+    if (segments[0] === 'projects' && segments[1] && segments.length >= 2) {
+      return this._handleProjectRoutes(method, segments, requestId, body);
     }
 
     if (method === 'GET' && path === '/tags') {
@@ -520,6 +554,109 @@ export class LocalRestApiHandlerService {
     return createSuccessResponse(requestId, 200, projects);
   }
 
+  private async _handleCreateProject(
+    requestId: string,
+    body: unknown,
+  ): Promise<LocalRestApiResponsePayload> {
+    if (!isRecord(body) || typeof body.title !== 'string' || !body.title.trim()) {
+      return createErrorResponse(
+        requestId,
+        400,
+        'INVALID_INPUT',
+        'Project title must be a non-empty string',
+      );
+    }
+
+    const rejected = firstRejectedProjectField(body);
+    if (rejected) {
+      return createErrorResponse(
+        requestId,
+        400,
+        'UNSUPPORTED_FIELD',
+        `${rejected} cannot be set via project REST API`,
+      );
+    }
+
+    const projectFields = pickAllowedProjectFields(body);
+    const projectId = this._projectService.add(projectFields);
+    const createdProject = await this._getProjectById(projectId);
+    return createSuccessResponse(
+      requestId,
+      201,
+      createdProject || { id: projectId, ...projectFields },
+    );
+  }
+
+  private async _handleProjectRoutes(
+    method: string,
+    segments: string[],
+    requestId: string,
+    body: unknown,
+  ): Promise<LocalRestApiResponsePayload> {
+    const projectId = segments[1];
+
+    if (segments.length === 2) {
+      if (method === 'GET') {
+        const project = await this._getProjectById(projectId);
+        if (!project) {
+          return createErrorResponse(
+            requestId,
+            404,
+            'PROJECT_NOT_FOUND',
+            'Project not found',
+          );
+        }
+        return createSuccessResponse(requestId, 200, project);
+      }
+
+      if (method === 'PATCH') {
+        if (!isRecord(body)) {
+          return createErrorResponse(
+            requestId,
+            400,
+            'INVALID_INPUT',
+            'PATCH body must be a JSON object',
+          );
+        }
+
+        if ('title' in body && (typeof body.title !== 'string' || !body.title.trim())) {
+          return createErrorResponse(
+            requestId,
+            400,
+            'INVALID_INPUT',
+            'Project title must be a non-empty string',
+          );
+        }
+
+        const rejected = firstRejectedProjectField(body);
+        if (rejected) {
+          return createErrorResponse(
+            requestId,
+            400,
+            'UNSUPPORTED_FIELD',
+            `${rejected} cannot be set via project REST API`,
+          );
+        }
+
+        const project = await this._getProjectById(projectId);
+        if (!project) {
+          return createErrorResponse(
+            requestId,
+            404,
+            'PROJECT_NOT_FOUND',
+            'Project not found',
+          );
+        }
+
+        this._projectService.update(projectId, pickAllowedProjectFields(body));
+        const updatedProject = await this._getProjectById(projectId);
+        return createSuccessResponse(requestId, 200, updatedProject || project);
+      }
+    }
+
+    return createErrorResponse(requestId, 404, 'NOT_FOUND', 'Route not found');
+  }
+
   private async _handleListTags(
     requestId: string,
     query: Record<string, string | string[]>,
@@ -546,6 +683,12 @@ export class LocalRestApiHandlerService {
     return (
       (await firstValueFrom(this._taskService.getByIdWithSubTaskData$(taskId))) ||
       undefined
+    );
+  }
+
+  private async _getProjectById(projectId: string): Promise<Project | undefined> {
+    return (
+      (await firstValueFrom(this._projectService.getByIdOnce$(projectId))) || undefined
     );
   }
 }


### PR DESCRIPTION
## Summary
- add Local REST endpoints to create, fetch, and update projects
- keep project list/note relation fields reducer-owned by rejecting taskIds, backlogTaskIds, and noteIds
- add focused LocalRestApiHandlerService coverage for project create/update validation

## Verification
- npx ng test --watch=false --include='src/app/core/electron/local-rest-api-handler.service.spec.ts' --browsers=ChromeHeadless
- pre-push hook: npm run lint
- pre-push hook: npm run test