### PR TITLE
fix(docs): Add documentation for time estimate short syntax

### DIFF
--- a/docs/wiki/2.03-Add-Tasks.md
+++ b/docs/wiki/2.03-Add-Tasks.md
@@ -10,7 +10,7 @@ This how-to covers adding new tasks to your list. For subtasks, scheduling, repe
 
 ## Create a Task
 
-1. With the add task bar open, type the task title in the input. The placeholder shows an example: **A task title #tag @16:00** (you can use **#tag** and **@time** or **@date** in the title; see below).
+1. With the add task bar open, type the task title in the input. The placeholder shows an example: **A task title #tag @16:00 t25m** (you can use **#tag**, **@time**, **@date**, and **[t]time** in the title; see below).
 2. Press **Enter** or click the **Add task** button (plus icon next to the input). The task is added to the current project or context (Today / tag).
 
 The new task appears at the **top** or **bottom** of the list depending on the add bar setting (see “Add to top or bottom” below).
@@ -22,6 +22,9 @@ While typing the title you can use:
 - **#tagName** — Add the task to a tag (e.g. `#work`). If the tag does not exist, you can create it when adding the task.
 - **@16:00** or **@09:30** — Set a due time for the task (today by default when only time is given).
 - **@tomorrow**, **@next week**, or a date — Set the due date. You can combine with a time (e.g. **@tomorrow @14:00**).
+- **[t]25m** — Set an estimated time for the task. You can also add time previously spent on a task by adding a `/` at the end (e.g. `t30m/`). The `t` tag is optional and the short syntax will work even if it is ommitted.
+
+See [[3.04-Short-Syntax]] for more information on available short syntax tags.
 
 The add task bar also has **Tags**, **Schedule**, and **Estimate** buttons to set these without typing. On the Schedule/Planner view, the add bar may show different options (e.g. “Plan for today”).
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1480,7 +1480,7 @@
         "CREATE_NEW_TAGS": "Create new tags",
         "DUE_BUTTON": "Schedule",
         "ESTIMATE_BUTTON": "Estimate",
-        "PLACEHOLDER_CREATE": "A task title #tag @16:00",
+        "PLACEHOLDER_CREATE": "A task title #tag @16:00 t25m ",
         "PLACEHOLDER_SEARCH": "Add existing task or issues...",
         "REPEAT_BUTTON": "Repeat",
         "SEARCH_INFO_TEXT": "Search and add issues and tasks from archive and other projects",


### PR DESCRIPTION
>Note: This is a _very_ low priority change
## Problem

There is currently no in-app documentation informing users that short syntax can be used to add time estimates when creating tasks (see #7394).

## Solution

1. Update the placeholder text in the `Add Task` bar to include `[t]25m` as an example of the short syntax for time.
2. Add section to Add Task wiki page to describe short syntax time estimate options.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [N/A] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [N/A] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
