### PR TITLE
fix(side-panel): Focus side-panel title field for sub-tasks

### DIFF
--- a/e2e/pages/work-view.page.ts
+++ b/e2e/pages/work-view.page.ts
@@ -63,8 +63,13 @@ export class WorkViewPage extends BasePage {
 
     await task.press('a');
 
-    // Wait for textarea to appear
-    const textarea = this.page.locator('textarea:focus, input[type="text"]:focus');
+    // Sub-task creation focuses the side-panel title field (mobile fix #7120);
+    // when no panel is mounted we fall back to whatever input has focus.
+    const textarea = this.page
+      .locator(
+        'task-detail-panel task-title textarea, textarea:focus, input[type="text"]:focus',
+      )
+      .first();
     await textarea.waitFor({ state: 'visible', timeout: 3000 });
 
     // Ensure the field is properly focused and cleared before filling

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.html
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.html
@@ -5,6 +5,7 @@
       (valueEdited)="updateTaskTitleIfChanged($event.wasChanged, $event.newVal)"
       [value]="task().title || ''"
       class="task-title"
+      #taskTitleField
     ></task-title>
     <!--    <button mat-icon-button>-->
     <!--      <mat-icon>more_vert</mat-icon>-->

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -152,8 +152,6 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
     isExpandedAttachmentPanel: signal(!IS_MOBILE),
   };
 
-  setTaskDetailPanel = this._taskFocusService.taskDetailPanel.set(this);
-
   // Observable conversions
   private _task$ = toObservable(this.task);
 
@@ -444,6 +442,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
 
   ngOnInit(): void {
     window.history.pushState({ [HISTORY_STATE.TASK_DETAIL_PANEL]: true }, '');
+    this._taskFocusService.taskDetailPanel.set(this);
   }
 
   ngAfterViewInit(): void {
@@ -472,6 +471,11 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
       window.history.back();
     }
     window.clearTimeout(this._focusTimeout);
+    // Only clear the singleton if we still own it — another panel may have
+    // taken over (right-panel ↔ dialog ↔ bottom-panel can overlap briefly).
+    if (this._taskFocusService.taskDetailPanel() === this) {
+      this._taskFocusService.taskDetailPanel.set(null);
+    }
   }
 
   changeTaskNotes($event: string): void {

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -82,6 +82,7 @@ import { isMarkdownChecklist } from '../../markdown-checklist/is-markdown-checkl
 import { Log } from '../../../core/log';
 import { isInputElement } from '../../../util/dom-element';
 import { checkKeyCombo } from '../../../util/check-key-combo';
+import { TaskFocusService } from '../task-focus.service';
 
 @Component({
   selector: 'task-detail-panel',
@@ -125,6 +126,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
   private _translateService = inject(TranslateService);
   private _destroyRef = inject(DestroyRef);
   private _dateTimeFormatService = inject(DateTimeFormatService);
+  private _taskFocusService = inject(TaskFocusService);
 
   // Inputs
   task = input.required<TaskWithSubTasks>();
@@ -134,6 +136,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
   // View children
   itemEls = viewChildren(TaskDetailItemComponent);
   attachmentPanelElRef = viewChild<TaskDetailItemComponent>('attachmentPanelElRef');
+  taskTitleField = viewChild<TaskTitleComponent>('taskTitleField');
 
   // Constants
   IS_TOUCH_PRIMARY = IS_TOUCH_PRIMARY;
@@ -148,6 +151,9 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
     isDragOver: signal(false),
     isExpandedAttachmentPanel: signal(!IS_MOBILE),
   };
+
+  //Set panel as last focused panel
+  setTaskDetailPanel = this._taskFocusService.setTaskDetailPanel(this);
 
   // Observable conversions
   private _task$ = toObservable(this.task);
@@ -608,6 +614,15 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
         cmpInstance.elementRef.nativeElement.focus();
       }
     }, timeoutDuration);
+  }
+
+  focusTitleField(): void {
+    const taskTitleField = this.taskTitleField();
+    if (!taskTitleField) {
+      Log.log(taskTitleField);
+      throw new Error('No el');
+    }
+    taskTitleField.focusInput();
   }
 
   updateTaskTitleIfChanged(isChanged: boolean, newTitle: string): void {

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -152,7 +152,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
     isExpandedAttachmentPanel: signal(!IS_MOBILE),
   };
 
-  setTaskDetailPanel = this._taskFocusService.setTaskDetailPanel(this);
+  setTaskDetailPanel = this._taskFocusService.taskDetailPanel.set(this);
 
   // Observable conversions
   private _task$ = toObservable(this.task);

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -152,7 +152,6 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
     isExpandedAttachmentPanel: signal(!IS_MOBILE),
   };
 
-  //Set panel as last focused panel
   setTaskDetailPanel = this._taskFocusService.setTaskDetailPanel(this);
 
   // Observable conversions
@@ -619,8 +618,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
   focusTitleField(): void {
     const taskTitleField = this.taskTitleField();
     if (!taskTitleField) {
-      Log.log(taskTitleField);
-      throw new Error('No el');
+      throw new Error('TaskDetailPanel: title field missing');
     }
     taskTitleField.focusInput();
   }

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -4,8 +4,10 @@ import {
   Component,
   computed,
   DestroyRef,
+  effect,
   HostListener,
   inject,
+  Injector,
   input,
   OnDestroy,
   OnInit,
@@ -127,6 +129,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
   private _destroyRef = inject(DestroyRef);
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _taskFocusService = inject(TaskFocusService);
+  private _injector = inject(Injector);
 
   // Inputs
   task = input.required<TaskWithSubTasks>();
@@ -443,6 +446,21 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
   ngOnInit(): void {
     window.history.pushState({ [HISTORY_STATE.TASK_DETAIL_PANEL]: true }, '');
     this._taskFocusService.taskDetailPanel.set(this);
+
+    // Reactive title-focus: consume focusTitleRequest only once `task` input
+    // has caught up to the requested id. This avoids the synchronous race
+    // where a caller fires focus before NgRx CD propagates the new selection.
+    effect(
+      () => {
+        const reqId = this._taskFocusService.focusTitleRequest();
+        if (reqId === null || this.task().id !== reqId) return;
+        const field = this.taskTitleField();
+        if (!field) return;
+        this._taskFocusService.focusTitleRequest.set(null);
+        field.focusInput();
+      },
+      { injector: this._injector },
+    );
   }
 
   ngAfterViewInit(): void {
@@ -617,14 +635,6 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
         cmpInstance.elementRef.nativeElement.focus();
       }
     }, timeoutDuration);
-  }
-
-  focusTitleField(): void {
-    const taskTitleField = this.taskTitleField();
-    if (!taskTitleField) {
-      throw new Error('TaskDetailPanel: title field missing');
-    }
-    taskTitleField.focusInput();
   }
 
   updateTaskTitleIfChanged(isChanged: boolean, newTitle: string): void {

--- a/src/app/features/tasks/task-focus.service.ts
+++ b/src/app/features/tasks/task-focus.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { TaskComponent } from './task/task.component';
+import { TaskDetailPanelComponent } from './task-detail-panel/task-detail-panel.component';
 
 @Injectable({
   providedIn: 'root',
@@ -8,6 +9,7 @@ export class TaskFocusService {
   readonly focusedTaskId = signal<string | null>(null);
   readonly lastFocusedTaskComponent = signal<TaskComponent | null>(null);
   readonly isTaskContextMenuOpen = signal(false);
+  readonly taskDetailPanel = signal<TaskDetailPanelComponent | null>(null);
 
   // Registry of all task components for efficient focus navigation
   private _taskComponentsRegistry = new Map<string, TaskComponent>();
@@ -53,5 +55,9 @@ export class TaskFocusService {
     const taskEls = this.getTaskElements();
     const currentIndex = taskEls.findIndex((el) => el === currentEl);
     return taskEls[currentIndex - 1] as HTMLElement;
+  }
+
+  setTaskDetailPanel(panel: TaskDetailPanelComponent): void {
+    this.taskDetailPanel.set(panel);
   }
 }

--- a/src/app/features/tasks/task-focus.service.ts
+++ b/src/app/features/tasks/task-focus.service.ts
@@ -10,6 +10,12 @@ export class TaskFocusService {
   readonly lastFocusedTaskComponent = signal<TaskComponent | null>(null);
   readonly isTaskContextMenuOpen = signal(false);
   readonly taskDetailPanel = signal<TaskDetailPanelComponent | null>(null);
+  /**
+   * Set to a task id to request that the side-panel title field for that task
+   * receive focus. The panel reacts via an effect once its `task` input has
+   * caught up, then clears the request. Race-free without imperative timing.
+   */
+  readonly focusTitleRequest = signal<string | null>(null);
 
   // Registry of all task components for efficient focus navigation
   private _taskComponentsRegistry = new Map<string, TaskComponent>();

--- a/src/app/features/tasks/task-focus.service.ts
+++ b/src/app/features/tasks/task-focus.service.ts
@@ -56,8 +56,4 @@ export class TaskFocusService {
     const currentIndex = taskEls.findIndex((el) => el === currentEl);
     return taskEls[currentIndex - 1] as HTMLElement;
   }
-
-  setTaskDetailPanel(panel: TaskDetailPanelComponent): void {
-    this.taskDetailPanel.set(panel);
-  }
 }

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -774,14 +774,17 @@ export class TaskService {
 
         if (shouldStartEditing) {
           const taskComponent = this._taskFocusService.lastFocusedTaskComponent();
-          const taskDetailPanel = this._taskFocusService.taskDetailPanel();
           if (
             taskComponent &&
             taskComponent.task().id === taskId &&
-            !taskComponent.task().title?.trim().length &&
-            taskDetailPanel
+            !taskComponent.task().title?.trim().length
           ) {
-            taskDetailPanel.focusTitleField();
+            const taskDetailPanel = this._taskFocusService.taskDetailPanel();
+            if (taskDetailPanel) {
+              taskDetailPanel.focusTitleField();
+            } else {
+              taskComponent.focusTitleForEdit();
+            }
           }
         }
       });

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -779,9 +779,8 @@ export class TaskService {
             taskComponent.task().id === taskId &&
             !taskComponent.task().title?.trim().length
           ) {
-            const taskDetailPanel = this._taskFocusService.taskDetailPanel();
-            if (taskDetailPanel) {
-              taskDetailPanel.focusTitleField();
+            if (this._taskFocusService.taskDetailPanel()) {
+              this._taskFocusService.focusTitleRequest.set(taskId);
             } else {
               taskComponent.focusTitleForEdit();
             }

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -774,12 +774,14 @@ export class TaskService {
 
         if (shouldStartEditing) {
           const taskComponent = this._taskFocusService.lastFocusedTaskComponent();
+          const taskDetailPanel = this._taskFocusService.taskDetailPanel();
           if (
             taskComponent &&
             taskComponent.task().id === taskId &&
-            !taskComponent.task().title?.trim().length
+            !taskComponent.task().title?.trim().length &&
+            taskDetailPanel
           ) {
-            taskComponent.focusTitleForEdit();
+            taskDetailPanel.focusTitleField();
           }
         }
       });

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -431,6 +431,9 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
           const taskDetailPanel = this._taskFocusService.taskDetailPanel();
           if (taskDetailPanel) {
             taskDetailPanel.focusTitleField();
+          } else {
+            // No detail panel mounted — fall back to inline-list edit.
+            this.focusTitleForEdit();
           }
         }
       });

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -428,7 +428,10 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
           ) ===
             otherTaskEl.length - 1
         ) {
-          this.focusTitleForEdit();
+          const taskDetailPanel = this._taskFocusService.taskDetailPanel();
+          if (taskDetailPanel) {
+            taskDetailPanel?.focusTitleField();
+          }
         }
       });
     }

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -430,7 +430,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
         ) {
           const taskDetailPanel = this._taskFocusService.taskDetailPanel();
           if (taskDetailPanel) {
-            taskDetailPanel?.focusTitleField();
+            taskDetailPanel.focusTitleField();
           }
         }
       });

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -428,9 +428,8 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
           ) ===
             otherTaskEl.length - 1
         ) {
-          const taskDetailPanel = this._taskFocusService.taskDetailPanel();
-          if (taskDetailPanel) {
-            taskDetailPanel.focusTitleField();
+          if (this._taskFocusService.taskDetailPanel()) {
+            this._taskFocusService.focusTitleRequest.set(t.id);
           } else {
             // No detail panel mounted — fall back to inline-list edit.
             this.focusTitleForEdit();


### PR DESCRIPTION
When a new sub-task is created, the title field in the side details panel is highlighted for editing instead of the title field in the main task list.

Fixes #7120 

## Problem

Previously, when creating a new sub-task, the title field in the main task list view was focused for editing instead of the title field in the side details panel. This caused issues for mobile users because the side panel view overlays the task list on mobile and prevents interaction with the focused input.

## Solution
When a subtask is added, the side panel title field is focused.
### Details

- Added `focusTitleField()` function to focus side panel title field
- Added `taskDetailPanel` Signal to reference the detail panel component
- Added `setTaskDetailPanel` to set `taskDetailPanel` to active side panel
- Called `focusTitleField()` when subtask is added instead of `focusTitleForEdit()`

## Testing

This is my first code-changing PR and I'm not very familiar with Angular testing, so my apologies in advance if there are missing tests that are necessary. I'll be happy to figure them out and update this PR if needs be.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
