### PR TITLE
feat(task): add Ctrl+Enter and escape shortcuts

### DIFF
--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -167,6 +167,13 @@ export class TaskShortcutService {
       ev.preventDefault();
       return true;
     }
+    // Ctrl/Cmd + Enter on a focused task: smart subtask creation
+    // (focuses an existing empty subtask, else spawns a new one).
+    if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') {
+      this._handleTaskShortcut(focusedTaskId, 'addSubTaskOrFocusEmpty');
+      ev.preventDefault();
+      return true;
+    }
     if (checkKeyCombo(ev, keys.taskAddAttachment)) {
       this._handleTaskShortcut(focusedTaskId, 'addAttachment');
       ev.preventDefault();

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -125,7 +125,9 @@ export class TaskShortcutService {
 
     // Ctrl/Cmd+Enter on a focused (but not editing) task: same as the `a`
     // shortcut — create a new subtask. Must run before the plain-Enter
-    // "edit title" handler below.
+    // "edit title" handler below. A user-bound `togglePlay` is checked
+    // earlier (line ~74), so remapping `togglePlay` to Mod+Enter takes
+    // precedence over this hardcoded combo.
     if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') {
       this._handleTaskShortcut(focusedTaskId, 'addSubTask');
       ev.preventDefault();

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -123,6 +123,15 @@ export class TaskShortcutService {
     // Check if the focused task's context menu is open - if so, skip arrow navigation shortcuts
     const isContextMenuOpen = this._isTaskContextMenuOpen(focusedTaskId);
 
+    // Ctrl/Cmd+Enter on a focused (but not editing) task: same as the `a`
+    // shortcut — create a new subtask. Must run before the plain-Enter
+    // "edit title" handler below.
+    if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') {
+      this._handleTaskShortcut(focusedTaskId, 'addSubTask');
+      ev.preventDefault();
+      return true;
+    }
+
     // Basic task actions that work through component delegation
     if (
       !isContextMenuOpen &&
@@ -164,13 +173,6 @@ export class TaskShortcutService {
     }
     if (checkKeyCombo(ev, keys.taskAddSubTask)) {
       this._handleTaskShortcut(focusedTaskId, 'addSubTask');
-      ev.preventDefault();
-      return true;
-    }
-    // Ctrl/Cmd + Enter on a focused task: smart subtask creation
-    // (focuses an existing empty subtask, else spawns a new one).
-    if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') {
-      this._handleTaskShortcut(focusedTaskId, 'addSubTaskOrFocusEmpty');
       ev.preventDefault();
       return true;
     }

--- a/src/app/features/tasks/task.model.ts
+++ b/src/app/features/tasks/task.model.ts
@@ -228,3 +228,5 @@ export interface TaskState extends EntityState<Task> {
 export interface WorklogTask extends Task {
   dateStr: string;
 }
+
+export type SubmitTrigger = 'blur' | 'escape' | 'enter' | 'modEnter';

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -757,14 +757,19 @@ export class TaskService {
       }),
     );
 
-    this._focusNewlyCreatedTask(task.id, !task.title?.trim().length);
+    this.focusTaskById(task.id, !task.title?.trim().length);
 
     return task.id;
   }
 
-  private _focusNewlyCreatedTask(taskId: string, shouldStartEditing: boolean): void {
-    // Use double-RAF to ensure Angular has completed rendering after change detection.
-    // First RAF queues after the current frame, second RAF runs after the render.
+  /**
+   * Focus a task element by id, deferred via double-RAF so it runs after
+   * Angular renders the next frame. When `shouldStartEditing` is true and
+   * the task's title is empty at the time of focus, also enter title edit
+   * mode. Used both by newly-created tasks and by callers that want to
+   * focus an existing task (e.g. an empty sibling on Mod+Enter).
+   */
+  focusTaskById(taskId: string, shouldStartEditing: boolean): void {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         const taskElement = document.getElementById(`t-${taskId}`);

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -2,6 +2,7 @@ import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { Store } from '@ngrx/store';
+import { of } from 'rxjs';
 import { DateService } from '../../../core/date/date.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
@@ -53,6 +54,7 @@ describe('TaskComponent shortcut handling', () => {
         'addSubTaskTo',
         'setSelectedId',
         'toggleSubTaskMode',
+        'showSubTasks',
         'toggleDoneWithAnimation',
         'moveUp',
         'moveDown',
@@ -60,12 +62,22 @@ describe('TaskComponent shortcut handling', () => {
         'moveToBottom',
         'setCurrentId',
         'pauseCurrent',
+        'getByIdWithSubTaskData$',
       ],
       {
         currentTaskId: signal<string | null>(null),
         selectedTaskId: signal<string | null>(null),
         todayListSet: signal<Set<string>>(new Set<string>()),
       },
+    );
+    taskServiceSpy.getByIdWithSubTaskData$.and.returnValue(
+      of({
+        ...DEFAULT_TASK,
+        id: 'parent-1',
+        title: 'Parent',
+        subTasks: [],
+        subTaskIds: [],
+      } as unknown as TaskWithSubTasks),
     );
 
     await TestBed.configureTestingModule({
@@ -213,7 +225,24 @@ describe('TaskComponent shortcut handling', () => {
     expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('parent-1');
   });
 
-  it('expands hidden subtasks before adding when the parent has them collapsed', () => {
+  it('expands hidden subtasks before adding when the parent has HideAll set', () => {
+    const parent = {
+      ...createTopLevelTask('Parent'),
+      _hideSubTasksMode: 2,
+    } as TaskWithSubTasks;
+    fixture.componentRef.setInput('task', parent);
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'Parent',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.showSubTasks).toHaveBeenCalledWith('top-1');
+    expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
+  });
+
+  it('does not expand subtasks when only HideDone is set (new task is not done)', () => {
     const parent = {
       ...createTopLevelTask('Parent'),
       _hideSubTasksMode: 1,
@@ -226,11 +255,11 @@ describe('TaskComponent shortcut handling', () => {
       submitTrigger: 'modEnter',
     });
 
-    expect(taskServiceSpy.toggleSubTaskMode).toHaveBeenCalledWith('top-1', false, false);
+    expect(taskServiceSpy.showSubTasks).not.toHaveBeenCalled();
     expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
   });
 
-  it('does not toggle subtask mode when subtasks are already visible', () => {
+  it('does not expand subtasks when subtasks are already visible', () => {
     fixture.componentRef.setInput('task', createTopLevelTask('Parent'));
 
     component.updateTaskTitleIfChanged({
@@ -239,7 +268,62 @@ describe('TaskComponent shortcut handling', () => {
       submitTrigger: 'modEnter',
     });
 
-    expect(taskServiceSpy.toggleSubTaskMode).not.toHaveBeenCalled();
+    expect(taskServiceSpy.showSubTasks).not.toHaveBeenCalled();
     expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
+  });
+
+  it('focuses an existing empty child instead of spawning a new one (parent)', () => {
+    const parent = {
+      ...createTopLevelTask('Parent'),
+      subTasks: [
+        { ...DEFAULT_TASK, id: 'child-1', title: 'Filled', parentId: 'top-1' },
+        { ...DEFAULT_TASK, id: 'child-2', title: '', parentId: 'top-1' },
+      ],
+    } as TaskWithSubTasks;
+    fixture.componentRef.setInput('task', parent);
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'Parent',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.addSubTaskTo).not.toHaveBeenCalled();
+  });
+
+  it('focuses an existing empty sibling instead of spawning a new one (subtask)', () => {
+    taskServiceSpy.getByIdWithSubTaskData$.and.returnValue(
+      of({
+        ...DEFAULT_TASK,
+        id: 'parent-1',
+        title: 'Parent',
+        subTasks: [
+          { ...DEFAULT_TASK, id: 'sub-1', title: 'Existing', parentId: 'parent-1' },
+          { ...DEFAULT_TASK, id: 'sub-2', title: '', parentId: 'parent-1' },
+        ],
+        subTaskIds: ['sub-1', 'sub-2'],
+      } as unknown as TaskWithSubTasks),
+    );
+    fixture.componentRef.setInput('task', createSubTask('Existing'));
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'Existing',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.addSubTaskTo).not.toHaveBeenCalled();
+  });
+
+  it('no-ops on Mod+Enter when current subtask is the only empty one', () => {
+    fixture.componentRef.setInput('task', createSubTask(''));
+
+    component.updateTaskTitleIfChanged({
+      newVal: '',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.addSubTaskTo).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -11,7 +11,7 @@ import { ProjectService } from '../../project/project.service';
 import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { TaskAttachmentService } from '../task-attachment/task-attachment.service';
 import { TaskFocusService } from '../task-focus.service';
-import { DEFAULT_TASK, TaskWithSubTasks } from '../task.model';
+import { DEFAULT_TASK, HideSubTasksMode, TaskWithSubTasks } from '../task.model';
 import { TaskService } from '../task.service';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { TaskComponent } from './task.component';
@@ -230,7 +230,7 @@ describe('TaskComponent shortcut handling', () => {
   it('expands hidden subtasks before adding when the parent has HideAll set', () => {
     const parent = {
       ...createTopLevelTask('Parent'),
-      _hideSubTasksMode: 2,
+      _hideSubTasksMode: HideSubTasksMode.HideAll,
     } as TaskWithSubTasks;
     fixture.componentRef.setInput('task', parent);
 
@@ -247,7 +247,7 @@ describe('TaskComponent shortcut handling', () => {
   it('does not expand subtasks when only HideDone is set (new task is not done)', () => {
     const parent = {
       ...createTopLevelTask('Parent'),
-      _hideSubTasksMode: 1,
+      _hideSubTasksMode: HideSubTasksMode.HideDone,
     } as TaskWithSubTasks;
     fixture.componentRef.setInput('task', parent);
 

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -63,6 +63,7 @@ describe('TaskComponent shortcut handling', () => {
         'setCurrentId',
         'pauseCurrent',
         'getByIdWithSubTaskData$',
+        'focusTaskById',
       ],
       {
         currentTaskId: signal<string | null>(null),

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -70,10 +70,12 @@ describe('TaskComponent shortcut handling', () => {
         todayListSet: signal<Set<string>>(new Set<string>()),
       },
     );
-    taskServiceSpy.getByIdWithSubTaskData$.and.returnValue(
+    // Default: any parent lookup returns an empty-subTasks shell.
+    // Individual specs may override via .and.returnValue(of({...})).
+    taskServiceSpy.getByIdWithSubTaskData$.and.callFake((id: string) =>
       of({
         ...DEFAULT_TASK,
-        id: 'parent-1',
+        id,
         title: 'Parent',
         subTasks: [],
         subTaskIds: [],
@@ -273,14 +275,19 @@ describe('TaskComponent shortcut handling', () => {
   });
 
   it('focuses an existing empty child instead of spawning a new one (parent)', () => {
-    const parent = {
-      ...createTopLevelTask('Parent'),
-      subTasks: [
-        { ...DEFAULT_TASK, id: 'child-1', title: 'Filled', parentId: 'top-1' },
-        { ...DEFAULT_TASK, id: 'child-2', title: '', parentId: 'top-1' },
-      ],
-    } as TaskWithSubTasks;
-    fixture.componentRef.setInput('task', parent);
+    taskServiceSpy.getByIdWithSubTaskData$.and.returnValue(
+      of({
+        ...DEFAULT_TASK,
+        id: 'top-1',
+        title: 'Parent',
+        subTasks: [
+          { ...DEFAULT_TASK, id: 'child-1', title: 'Filled', parentId: 'top-1' },
+          { ...DEFAULT_TASK, id: 'child-2', title: '', parentId: 'top-1' },
+        ],
+        subTaskIds: ['child-1', 'child-2'],
+      } as unknown as TaskWithSubTasks),
+    );
+    fixture.componentRef.setInput('task', createTopLevelTask('Parent'));
 
     component.updateTaskTitleIfChanged({
       newVal: 'Parent',

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -212,4 +212,34 @@ describe('TaskComponent shortcut handling', () => {
     });
     expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('parent-1');
   });
+
+  it('expands hidden subtasks before adding when the parent has them collapsed', () => {
+    const parent = {
+      ...createTopLevelTask('Parent'),
+      _hideSubTasksMode: 1,
+    } as TaskWithSubTasks;
+    fixture.componentRef.setInput('task', parent);
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'Parent',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.toggleSubTaskMode).toHaveBeenCalledWith('top-1', false, false);
+    expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
+  });
+
+  it('does not toggle subtask mode when subtasks are already visible', () => {
+    fixture.componentRef.setInput('task', createTopLevelTask('Parent'));
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'Parent',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.toggleSubTaskMode).not.toHaveBeenCalled();
+    expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
+  });
 });

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -197,4 +197,19 @@ describe('TaskComponent shortcut handling', () => {
 
     expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
   });
+
+  it('persists the typed title before spawning a sibling on Mod+Enter', () => {
+    fixture.componentRef.setInput('task', createSubTask(''));
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'New subtask',
+      wasChanged: true,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.update).toHaveBeenCalledWith('sub-1', {
+      title: 'New subtask',
+    });
+    expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('parent-1');
+  });
 });

--- a/src/app/features/tasks/task/task-title-escape-subtask.spec.ts
+++ b/src/app/features/tasks/task/task-title-escape-subtask.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression tests for Escape behavior in `TaskComponent.updateTaskTitleIfChanged()`.
+ *
+ * Desired behavior:
+ * - Escape on a freshly created empty subtask should remove it.
+ * - Escape on an existing subtask whose title was cleared should NOT remove it.
+ */
+describe('Task subtask Escape delete guard', () => {
+  const shouldDeleteOnEscape = ({
+    submitTrigger,
+    parentId,
+    wasChanged,
+    newVal,
+  }: {
+    submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter';
+    parentId?: string | null;
+    wasChanged: boolean;
+    newVal: string;
+  }): boolean => {
+    return submitTrigger === 'escape' && !!parentId && !wasChanged && !newVal;
+  };
+
+  it('deletes on Escape for freshly created empty subtask', () => {
+    const shouldDelete = shouldDeleteOnEscape({
+      submitTrigger: 'escape',
+      parentId: 'parent-1',
+      wasChanged: false,
+      newVal: '',
+    });
+
+    expect(shouldDelete).toBeTrue();
+  });
+
+  it('does NOT delete on Escape for existing subtask with cleared title', () => {
+    const shouldDelete = shouldDeleteOnEscape({
+      submitTrigger: 'escape',
+      parentId: 'parent-1',
+      wasChanged: true,
+      newVal: '',
+    });
+
+    expect(shouldDelete).toBeFalse();
+  });
+});

--- a/src/app/features/tasks/task/task-title-escape-subtask.spec.ts
+++ b/src/app/features/tasks/task/task-title-escape-subtask.spec.ts
@@ -15,7 +15,7 @@ import { TaskService } from '../task.service';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { TaskComponent } from './task.component';
 
-describe('Task subtask Escape delete guard', () => {
+describe('TaskComponent shortcut handling', () => {
   let fixture: import('@angular/core/testing').ComponentFixture<TaskComponent>;
   let component: TaskComponent;
   let taskServiceSpy: jasmine.SpyObj<TaskService>;
@@ -26,6 +26,18 @@ describe('Task subtask Escape delete guard', () => {
       id: 'sub-1',
       title,
       parentId: 'parent-1',
+      projectId: 'project-1',
+      subTasks: [],
+      subTaskIds: [],
+      tagIds: [],
+    }) as TaskWithSubTasks;
+
+  const createTopLevelTask = (title: string): TaskWithSubTasks =>
+    ({
+      ...DEFAULT_TASK,
+      id: 'top-1',
+      title,
+      parentId: undefined,
       projectId: 'project-1',
       subTasks: [],
       subTaskIds: [],
@@ -160,5 +172,29 @@ describe('Task subtask Escape delete guard', () => {
 
     expect(taskServiceSpy.update).toHaveBeenCalledWith('sub-1', { title: '' });
     expect(taskServiceSpy.remove).not.toHaveBeenCalled();
+  });
+
+  it('adds a sibling subtask on Mod+Enter when editing a subtask', () => {
+    fixture.componentRef.setInput('task', createSubTask('Existing subtask'));
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'Existing subtask',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('parent-1');
+  });
+
+  it('adds a child subtask on Mod+Enter when editing a top-level task', () => {
+    fixture.componentRef.setInput('task', createTopLevelTask('Top-level task'));
+
+    component.updateTaskTitleIfChanged({
+      newVal: 'Top-level task',
+      wasChanged: false,
+      submitTrigger: 'modEnter',
+    });
+
+    expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
   });
 });

--- a/src/app/features/tasks/task/task-title-escape-subtask.spec.ts
+++ b/src/app/features/tasks/task/task-title-escape-subtask.spec.ts
@@ -1,44 +1,164 @@
-/**
- * Regression tests for Escape behavior in `TaskComponent.updateTaskTitleIfChanged()`.
- *
- * Desired behavior:
- * - Escape on a freshly created empty subtask should remove it.
- * - Escape on an existing subtask whose title was cleared should NOT remove it.
- */
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { Store } from '@ngrx/store';
+import { DateService } from '../../../core/date/date.service';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+import { LayoutService } from '../../../core-ui/layout/layout.service';
+import { GlobalConfigService } from '../../config/global-config.service';
+import { ProjectService } from '../../project/project.service';
+import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
+import { TaskAttachmentService } from '../task-attachment/task-attachment.service';
+import { TaskFocusService } from '../task-focus.service';
+import { DEFAULT_TASK, TaskWithSubTasks } from '../task.model';
+import { TaskService } from '../task.service';
+import { WorkContextService } from '../../work-context/work-context.service';
+import { TaskComponent } from './task.component';
+
 describe('Task subtask Escape delete guard', () => {
-  const shouldDeleteOnEscape = ({
-    submitTrigger,
-    parentId,
-    wasChanged,
-    newVal,
-  }: {
-    submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter';
-    parentId?: string | null;
-    wasChanged: boolean;
-    newVal: string;
-  }): boolean => {
-    return submitTrigger === 'escape' && !!parentId && !wasChanged && !newVal;
-  };
+  let fixture: import('@angular/core/testing').ComponentFixture<TaskComponent>;
+  let component: TaskComponent;
+  let taskServiceSpy: jasmine.SpyObj<TaskService>;
+
+  const createSubTask = (title: string): TaskWithSubTasks =>
+    ({
+      ...DEFAULT_TASK,
+      id: 'sub-1',
+      title,
+      parentId: 'parent-1',
+      projectId: 'project-1',
+      subTasks: [],
+      subTaskIds: [],
+      tagIds: [],
+    }) as TaskWithSubTasks;
+
+  beforeEach(async () => {
+    taskServiceSpy = jasmine.createSpyObj<TaskService>(
+      'TaskService',
+      [
+        'update',
+        'remove',
+        'addSubTaskTo',
+        'setSelectedId',
+        'toggleSubTaskMode',
+        'toggleDoneWithAnimation',
+        'moveUp',
+        'moveDown',
+        'moveToTop',
+        'moveToBottom',
+        'setCurrentId',
+        'pauseCurrent',
+      ],
+      {
+        currentTaskId: signal<string | null>(null),
+        selectedTaskId: signal<string | null>(null),
+        todayListSet: signal<Set<string>>(new Set<string>()),
+      },
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [TaskComponent],
+      providers: [
+        { provide: TaskService, useValue: taskServiceSpy },
+        {
+          provide: TaskRepeatCfgService,
+          useValue: jasmine.createSpyObj('TaskRepeatCfgService', [
+            'getTaskRepeatCfgById$',
+            'updateTaskRepeatCfg',
+          ]),
+        },
+        { provide: MatDialog, useValue: jasmine.createSpyObj('MatDialog', ['open']) },
+        {
+          provide: GlobalConfigService,
+          useValue: jasmine.createSpyObj('GlobalConfigService', ['cfg'], {
+            cfg: () => ({ keyboard: {}, tasks: {} }),
+          }),
+        },
+        {
+          provide: TaskAttachmentService,
+          useValue: jasmine.createSpyObj('TaskAttachmentService', [
+            'createFromDrop',
+            'addAttachment',
+          ]),
+        },
+        { provide: Store, useValue: jasmine.createSpyObj('Store', ['dispatch']) },
+        {
+          provide: ProjectService,
+          useValue: jasmine.createSpyObj('ProjectService', [
+            'getProjectsWithoutId$',
+            'moveTaskToBacklog',
+            'moveTaskToTodayList',
+            'getByIdOnce$',
+          ]),
+        },
+        {
+          provide: TaskFocusService,
+          useValue: {
+            focusedTaskId: signal<string | null>(null),
+            lastFocusedTaskComponent: signal<unknown | null>(null),
+          },
+        },
+        {
+          provide: DateService,
+          useValue: jasmine.createSpyObj('DateService', ['isToday'], {
+            isToday: () => false,
+          }),
+        },
+        {
+          provide: GlobalTrackingIntervalService,
+          useValue: jasmine.createSpyObj('GlobalTrackingIntervalService', [], {
+            todayDateStr: signal('2026-05-05'),
+          }),
+        },
+        {
+          provide: LayoutService,
+          useValue: jasmine.createSpyObj('LayoutService', [], {
+            isXs: signal(false),
+          }),
+        },
+        {
+          provide: WorkContextService,
+          useValue: {
+            isTodayList: signal(false),
+          },
+        },
+      ],
+    })
+      .overrideComponent(TaskComponent, {
+        set: { template: '' },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(TaskComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('task', createSubTask(''));
+    fixture.componentRef.setInput('isInSubTaskList', true);
+    fixture.componentRef.setInput('isBacklog', false);
+
+    spyOn<any>(component, '_getPreviousTaskEl').and.returnValue(undefined);
+    spyOn<any>(component, '_focusTaskHost').and.stub();
+  });
 
   it('deletes on Escape for freshly created empty subtask', () => {
-    const shouldDelete = shouldDeleteOnEscape({
-      submitTrigger: 'escape',
-      parentId: 'parent-1',
-      wasChanged: false,
+    component.updateTaskTitleIfChanged({
       newVal: '',
+      wasChanged: false,
+      submitTrigger: 'escape',
     });
 
-    expect(shouldDelete).toBeTrue();
+    expect(taskServiceSpy.remove).toHaveBeenCalledWith(component.task());
   });
 
   it('does NOT delete on Escape for existing subtask with cleared title', () => {
-    const shouldDelete = shouldDeleteOnEscape({
-      submitTrigger: 'escape',
-      parentId: 'parent-1',
-      wasChanged: true,
+    fixture.componentRef.setInput('task', createSubTask('Existing subtask'));
+
+    component.updateTaskTitleIfChanged({
       newVal: '',
+      wasChanged: true,
+      submitTrigger: 'escape',
     });
 
-    expect(shouldDelete).toBeFalse();
+    expect(taskServiceSpy.update).toHaveBeenCalledWith('sub-1', { title: '' });
+    expect(taskServiceSpy.remove).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -701,7 +701,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
 
     if (submitTrigger === 'modEnter') {
-      this._addSubTaskOrFocusEmpty(newVal);
+      this.addSubTaskOrFocusEmpty(newVal);
       return;
     }
 
@@ -789,10 +789,11 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   /**
    * Mod+Enter handler: focus an existing empty sibling subtask if one exists,
    * otherwise create a new one. For top-level tasks, "siblings" means children.
-   * `effectiveSelfTitle` is the just-submitted title — use it instead of
-   * `task().title`, which still reflects the pre-update value within this turn.
+   * `effectiveSelfTitle` is the just-submitted title (used when called from
+   * the title editor); falls back to `task().title` when invoked from the
+   * focused-task shortcut path.
    */
-  private _addSubTaskOrFocusEmpty(effectiveSelfTitle: string): void {
+  addSubTaskOrFocusEmpty(effectiveSelfTitle: string = this.task().title): void {
     const t = this.task();
     const targetParentId = t.parentId || t.id;
     const isOnParent = !t.parentId;

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -688,13 +688,31 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     newVal,
     wasChanged,
     blurEvent,
+    submitTrigger,
   }: {
     newVal: string;
     wasChanged: boolean;
     blurEvent?: FocusEvent;
+    submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter';
   }): void {
     if (wasChanged) {
       this._taskService.update(this.task().id, { title: newVal });
+    }
+
+    if (submitTrigger === 'modEnter') {
+      this.addSubTask();
+      return;
+    }
+
+    // Escape in subtask editor should return focus to previous sibling;
+    // for empty titles we remove the subtask entirely.
+    if (submitTrigger === 'escape' && this.task().parentId) {
+      const previousTaskEl = this._getPreviousTaskEl();
+      if (!newVal) {
+        this._taskService.remove(this.task());
+      }
+      this._focusTaskHost(previousTaskEl);
+      return;
     }
 
     // Only focus self if no input/textarea is receiving focus next
@@ -1163,6 +1181,22 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
         })()
       : (taskEls[currentIndex + 1] as HTMLElement);
     return nextEl;
+  }
+
+  private _getPreviousTaskEl(): HTMLElement | undefined {
+    const taskEls = Array.from(document.querySelectorAll('task'));
+    const currentIndex = taskEls.findIndex((el) => el === this._elementRef.nativeElement);
+    return taskEls[currentIndex - 1] as HTMLElement | undefined;
+  }
+
+  private _focusTaskHost(taskEl?: HTMLElement): void {
+    if (!taskEl || isTouchActive()) {
+      return;
+    }
+    // Defer to next tick so focus survives blur/delete related DOM updates.
+    window.setTimeout(() => {
+      taskEl.focus();
+    });
   }
 
   get kb(): KeyboardConfig {

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -806,7 +806,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     this._taskService.getByIdWithSubTaskData$(targetParentId).subscribe((parent) => {
       const emptyChild = parent.subTasks.find((s) => s.id !== t.id && isEmpty(s.title));
       if (emptyChild) {
-        this._focusExistingTask(emptyChild.id);
+        this._taskService.focusTaskById(emptyChild.id, true);
         return;
       }
       // Already on the only empty subtask — leave focus where it is.
@@ -814,20 +814,6 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
         return;
       }
       this._taskService.addSubTaskTo(targetParentId);
-    });
-  }
-
-  private _focusExistingTask(taskId: string): void {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const taskElement = document.getElementById(`t-${taskId}`);
-        if (!taskElement) return;
-        taskElement.focus();
-        const taskComponent = this._taskFocusService.lastFocusedTaskComponent();
-        if (taskComponent && taskComponent.task().id === taskId) {
-          taskComponent.focusTitleForEdit();
-        }
-      });
     });
   }
 

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -701,7 +701,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
 
     if (submitTrigger === 'modEnter') {
-      this.addSubTask();
+      this._addSubTaskOrFocusEmpty(newVal);
       return;
     }
 
@@ -783,14 +783,63 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   }
 
   addSubTask(): void {
+    this._taskService.addSubTaskTo(this.task().parentId || this.task().id);
+  }
+
+  /**
+   * Mod+Enter handler: focus an existing empty sibling subtask if one exists,
+   * otherwise create a new one. For top-level tasks, "siblings" means children.
+   * `effectiveSelfTitle` is the just-submitted title — use it instead of
+   * `task().title`, which still reflects the pre-update value within this turn.
+   */
+  private _addSubTaskOrFocusEmpty(effectiveSelfTitle: string): void {
     const t = this.task();
     const targetParentId = t.parentId || t.id;
-    // When adding to self (top-level case), make sure the subtask list is visible
-    // so the newly created task gets focused and doesn't appear hidden.
-    if (targetParentId === t.id && t._hideSubTasksMode !== undefined) {
-      this._taskService.toggleSubTaskMode(t.id, false, false);
+    const isOnParent = !t.parentId;
+    const isEmptyTitle = (title?: string): boolean => !title?.trim();
+
+    if (isOnParent) {
+      const emptyChild = t.subTasks.find((s) => isEmptyTitle(s.title));
+      if (t._hideSubTasksMode === HideSubTasksMode.HideAll) {
+        this._taskService.showSubTasks(t.id);
+      }
+      if (emptyChild) {
+        this._focusExistingTask(emptyChild.id);
+        return;
+      }
+      this._taskService.addSubTaskTo(targetParentId);
+      return;
     }
-    this._taskService.addSubTaskTo(targetParentId);
+
+    // Subtask: look up the parent's children synchronously via the store
+    this._taskService.getByIdWithSubTaskData$(targetParentId).subscribe((parent) => {
+      const emptySibling = parent.subTasks.find(
+        (s) => s.id !== t.id && isEmptyTitle(s.title),
+      );
+      if (emptySibling) {
+        this._focusExistingTask(emptySibling.id);
+        return;
+      }
+      // We're already on the only empty subtask — leave focus where it is.
+      if (isEmptyTitle(effectiveSelfTitle)) {
+        return;
+      }
+      this._taskService.addSubTaskTo(targetParentId);
+    });
+  }
+
+  private _focusExistingTask(taskId: string): void {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const taskElement = document.getElementById(`t-${taskId}`);
+        if (!taskElement) return;
+        taskElement.focus();
+        const taskComponent = this._taskFocusService.lastFocusedTaskComponent();
+        if (taskComponent && taskComponent.task().id === taskId) {
+          taskComponent.focusTitleForEdit();
+        }
+      });
+    });
   }
 
   @throttle(200, { leading: true, trailing: false })

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -783,7 +783,14 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   }
 
   addSubTask(): void {
-    this._taskService.addSubTaskTo(this.task().parentId || this.task().id);
+    const t = this.task();
+    const targetParentId = t.parentId || t.id;
+    // When adding to self (top-level case), make sure the subtask list is visible
+    // so the newly created task gets focused and doesn't appear hidden.
+    if (targetParentId === t.id && t._hideSubTasksMode !== undefined) {
+      this._taskService.toggleSubTaskMode(t.id, false, false);
+    }
+    this._taskService.addSubTaskTo(targetParentId);
   }
 
   @throttle(200, { leading: true, trailing: false })

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -797,32 +797,20 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     const t = this.task();
     const targetParentId = t.parentId || t.id;
     const isOnParent = !t.parentId;
-    const isEmptyTitle = (title?: string): boolean => !title?.trim();
+    const isEmpty = (title?: string): boolean => !title?.trim();
 
-    if (isOnParent) {
-      const emptyChild = t.subTasks.find((s) => isEmptyTitle(s.title));
-      if (t._hideSubTasksMode === HideSubTasksMode.HideAll) {
-        this._taskService.showSubTasks(t.id);
-      }
+    if (isOnParent && t._hideSubTasksMode === HideSubTasksMode.HideAll) {
+      this._taskService.showSubTasks(t.id);
+    }
+
+    this._taskService.getByIdWithSubTaskData$(targetParentId).subscribe((parent) => {
+      const emptyChild = parent.subTasks.find((s) => s.id !== t.id && isEmpty(s.title));
       if (emptyChild) {
         this._focusExistingTask(emptyChild.id);
         return;
       }
-      this._taskService.addSubTaskTo(targetParentId);
-      return;
-    }
-
-    // Subtask: look up the parent's children synchronously via the store
-    this._taskService.getByIdWithSubTaskData$(targetParentId).subscribe((parent) => {
-      const emptySibling = parent.subTasks.find(
-        (s) => s.id !== t.id && isEmptyTitle(s.title),
-      );
-      if (emptySibling) {
-        this._focusExistingTask(emptySibling.id);
-        return;
-      }
-      // We're already on the only empty subtask — leave focus where it is.
-      if (isEmptyTitle(effectiveSelfTitle)) {
+      // Already on the only empty subtask — leave focus where it is.
+      if (!isOnParent && isEmpty(effectiveSelfTitle)) {
         return;
       }
       this._taskService.addSubTaskTo(targetParentId);

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -701,7 +701,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
 
     if (submitTrigger === 'modEnter') {
-      this.addSubTaskOrFocusEmpty(newVal);
+      this._addSubTaskOrFocusEmpty(newVal);
       return;
     }
 
@@ -787,13 +787,13 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   }
 
   /**
-   * Mod+Enter handler: focus an existing empty sibling subtask if one exists,
-   * otherwise create a new one. For top-level tasks, "siblings" means children.
-   * `effectiveSelfTitle` is the just-submitted title (used when called from
-   * the title editor); falls back to `task().title` when invoked from the
-   * focused-task shortcut path.
+   * Mod+Enter (in title editor): focus an existing empty sibling subtask if
+   * one exists, otherwise create a new one. For top-level tasks, "siblings"
+   * means children. `effectiveSelfTitle` is the just-submitted title — use it
+   * instead of `task().title`, which still reflects the pre-update value
+   * within this turn.
    */
-  addSubTaskOrFocusEmpty(effectiveSelfTitle: string = this.task().title): void {
+  private _addSubTaskOrFocusEmpty(effectiveSelfTitle: string): void {
     const t = this.task();
     const targetParentId = t.parentId || t.id;
     const isOnParent = !t.parentId;

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -701,7 +701,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
 
     if (submitTrigger === 'modEnter') {
-      this.addSiblingSubTask();
+      this.addSubTask();
       return;
     }
 
@@ -784,16 +784,6 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
 
   addSubTask(): void {
     this._taskService.addSubTaskTo(this.task().parentId || this.task().id);
-  }
-
-  addSiblingSubTask(): void {
-    const parentId = this.task().parentId;
-
-    if (!parentId) {
-      return; // no-op for top-level
-    }
-
-    this._taskService.addSubTaskTo(parentId);
   }
 
   @throttle(200, { leading: true, trailing: false })

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -18,6 +18,7 @@ import { TaskService } from '../task.service';
 import { EMPTY, forkJoin, Subscription } from 'rxjs';
 import {
   HideSubTasksMode,
+  SubmitTrigger,
   TaskCopy,
   TaskDetailTargetPanel,
   TaskWithSubTasks,
@@ -693,7 +694,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     newVal: string;
     wasChanged: boolean;
     blurEvent?: FocusEvent;
-    submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter';
+    submitTrigger: SubmitTrigger;
   }): void {
     if (wasChanged) {
       this._taskService.update(this.task().id, { title: newVal });
@@ -708,7 +709,9 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     // for empty titles we remove the subtask entirely.
     if (submitTrigger === 'escape' && this.task().parentId) {
       const previousTaskEl = this._getPreviousTaskEl();
-      if (!newVal) {
+      // Only auto-delete for freshly spawned empty subtasks.
+      // If user cleared an existing title, Escape should save and keep the task.
+      if (!wasChanged && !newVal) {
         this._taskService.remove(this.task());
       }
       this._focusTaskHost(previousTaskEl);

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -701,7 +701,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
 
     if (submitTrigger === 'modEnter') {
-      this.addSubTask();
+      this.addSiblingSubTask();
       return;
     }
 
@@ -784,6 +784,16 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
 
   addSubTask(): void {
     this._taskService.addSubTaskTo(this.task().parentId || this.task().id);
+  }
+
+  addSiblingSubTask(): void {
+    const parentId = this.task().parentId;
+
+    if (!parentId) {
+      return; // no-op for top-level
+    }
+
+    this._taskService.addSubTaskTo(parentId);
   }
 
   @throttle(200, { leading: true, trailing: false })
@@ -1187,9 +1197,13 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   }
 
   private _getPreviousTaskEl(): HTMLElement | undefined {
-    const taskEls = Array.from(document.querySelectorAll('task'));
-    const currentIndex = taskEls.findIndex((el) => el === this._elementRef.nativeElement);
-    return taskEls[currentIndex - 1] as HTMLElement | undefined;
+    const currentTaskEl = this._elementRef.nativeElement as HTMLElement;
+    const enclosingListEl = currentTaskEl.closest('task-list');
+    const taskEls = Array.from(
+      (enclosingListEl ?? document).querySelectorAll('task'),
+    ) as HTMLElement[];
+    const currentIndex = taskEls.findIndex((el) => el === currentTaskEl);
+    return currentIndex > 0 ? taskEls[currentIndex - 1] : undefined;
   }
 
   private _focusTaskHost(taskEl?: HTMLElement): void {

--- a/src/app/ui/task-title/task-title.component.spec.ts
+++ b/src/app/ui/task-title/task-title.component.spec.ts
@@ -194,4 +194,42 @@ describe('TaskTitleComponent', () => {
       expect(component.isEditing()).toBe(true);
     });
   });
+
+  describe('handleKeyDown trigger routing', () => {
+    const buildKey = (key: string, opts: KeyboardEventInit = {}): KeyboardEvent =>
+      new KeyboardEvent('keydown', { key, ...opts });
+
+    it('routes Escape to a blur with submitTrigger=escape', () => {
+      const blurSpy = spyOn<any>(component, '_forceBlur');
+      component.handleKeyDown(buildKey('Escape'));
+      expect(blurSpy).toHaveBeenCalledTimes(1);
+      expect((component as any)._submitTrigger).toBe('escape');
+    });
+
+    it('routes plain Enter to a blur with submitTrigger=enter', () => {
+      const blurSpy = spyOn<any>(component, '_forceBlur');
+      component.handleKeyDown(buildKey('Enter'));
+      expect(blurSpy).toHaveBeenCalledTimes(1);
+      expect((component as any)._submitTrigger).toBe('enter');
+    });
+
+    it('routes Ctrl+Enter to a blur with submitTrigger=modEnter', () => {
+      const blurSpy = spyOn<any>(component, '_forceBlur');
+      component.handleKeyDown(buildKey('Enter', { ctrlKey: true }));
+      expect(blurSpy).toHaveBeenCalledTimes(1);
+      expect((component as any)._submitTrigger).toBe('modEnter');
+    });
+
+    it('swallows Enter/Escape (no blur) while the mention list is shown', () => {
+      const blurSpy = spyOn<any>(component, '_forceBlur');
+      // Set the gating signal directly to bypass the setTimeout in updateMentionListShown.
+      (component as any)._isMentionListShown.set(true);
+
+      component.handleKeyDown(buildKey('Enter'));
+      component.handleKeyDown(buildKey('Escape'));
+      component.handleKeyDown(buildKey('Enter', { metaKey: true }));
+
+      expect(blurSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/ui/task-title/task-title.component.spec.ts
+++ b/src/app/ui/task-title/task-title.component.spec.ts
@@ -194,4 +194,34 @@ describe('TaskTitleComponent', () => {
       expect(component.isEditing()).toBe(true);
     });
   });
+
+  describe('Mod+Enter dedupe', () => {
+    const buildModEnter = (): KeyboardEvent =>
+      new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true });
+
+    it('skips blur (and emits nothing) when current and previous values are both empty', () => {
+      const blurSpy = spyOn<any>(component, '_forceBlur');
+      component.tmpValue.set('');
+      component.lastExternalValue = '';
+
+      const ev = buildModEnter();
+      const preventDefaultSpy = spyOn(ev, 'preventDefault');
+      component.handleKeyDown(ev);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(blurSpy).not.toHaveBeenCalled();
+    });
+
+    it('triggers blur with modEnter when the title has content', () => {
+      const blurSpy = spyOn<any>(component, '_forceBlur');
+      component.tmpValue.set('Some title');
+      component.lastExternalValue = 'Some title';
+
+      component.handleKeyDown(buildModEnter());
+
+      expect(blurSpy).toHaveBeenCalledTimes(1);
+      // _submitTrigger is captured by _submit on blur; verify it was set
+      expect((component as any)._submitTrigger).toBe('modEnter');
+    });
+  });
 });

--- a/src/app/ui/task-title/task-title.component.spec.ts
+++ b/src/app/ui/task-title/task-title.component.spec.ts
@@ -194,34 +194,4 @@ describe('TaskTitleComponent', () => {
       expect(component.isEditing()).toBe(true);
     });
   });
-
-  describe('Mod+Enter dedupe', () => {
-    const buildModEnter = (): KeyboardEvent =>
-      new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true });
-
-    it('skips blur (and emits nothing) when current and previous values are both empty', () => {
-      const blurSpy = spyOn<any>(component, '_forceBlur');
-      component.tmpValue.set('');
-      component.lastExternalValue = '';
-
-      const ev = buildModEnter();
-      const preventDefaultSpy = spyOn(ev, 'preventDefault');
-      component.handleKeyDown(ev);
-
-      expect(preventDefaultSpy).toHaveBeenCalled();
-      expect(blurSpy).not.toHaveBeenCalled();
-    });
-
-    it('triggers blur with modEnter when the title has content', () => {
-      const blurSpy = spyOn<any>(component, '_forceBlur');
-      component.tmpValue.set('Some title');
-      component.lastExternalValue = 'Some title';
-
-      component.handleKeyDown(buildModEnter());
-
-      expect(blurSpy).toHaveBeenCalledTimes(1);
-      // _submitTrigger is captured by _submit on blur; verify it was set
-      expect((component as any)._submitTrigger).toBe('modEnter');
-    });
-  });
 });

--- a/src/app/ui/task-title/task-title.component.ts
+++ b/src/app/ui/task-title/task-title.component.ts
@@ -40,6 +40,7 @@ import { hasLinkHints, RenderLinksPipe } from '../pipes/render-links.pipe';
   },
 })
 export class TaskTitleComponent implements OnDestroy {
+  private static readonly _DEFAULT_SUBMIT_TRIGGER = 'blur' as const;
   T: typeof T = T;
 
   // short-syntax autocomplete config shared across all editor instances
@@ -90,11 +91,14 @@ export class TaskTitleComponent implements OnDestroy {
     newVal: string;
     wasChanged: boolean;
     blurEvent?: FocusEvent;
+    submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter';
   }>();
 
   private readonly _isFocused = signal(false);
   private readonly _isEditing = signal(false);
   private _focusTimeoutId: number | undefined;
+  private _submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter' =
+    TaskTitleComponent._DEFAULT_SUBMIT_TRIGGER;
 
   updateMentionListShown(isShown: boolean): void {
     // use setTimeout to ensure blur event order doesn't interfere with mention selection
@@ -187,11 +191,20 @@ export class TaskTitleComponent implements OnDestroy {
     if (ev.key === 'Escape') {
       // if mention list is open, Escape is handled by MentionDirective - don't blur
       if (!this._isMentionListShown()) {
+        this._submitTrigger = 'escape';
         this._forceBlur();
+        ev.preventDefault();
+      }
+    } else if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) {
+      if (!this._isMentionListShown()) {
+        this._submitTrigger = 'modEnter';
+        this._forceBlur();
+        ev.preventDefault();
       }
     } else if (ev.key === 'Enter') {
       // if mention list is open, Enter selects from list - don't blur
       if (!this._isMentionListShown()) {
+        this._submitTrigger = 'enter';
         this._forceBlur();
         ev.preventDefault();
       }
@@ -265,12 +278,15 @@ export class TaskTitleComponent implements OnDestroy {
   private _submit(blurEvent?: FocusEvent): void {
     const previousValue = this.lastExternalValue;
     const cleanVal = this._cleanValue(this.tmpValue());
+    const submitTrigger = this._submitTrigger;
     this.tmpValue.set(cleanVal);
     this.lastExternalValue = cleanVal;
+    this._submitTrigger = TaskTitleComponent._DEFAULT_SUBMIT_TRIGGER;
     this.valueEdited.emit({
       newVal: cleanVal,
       wasChanged: cleanVal !== previousValue,
       blurEvent,
+      submitTrigger,
     });
   }
 

--- a/src/app/ui/task-title/task-title.component.ts
+++ b/src/app/ui/task-title/task-title.component.ts
@@ -197,9 +197,14 @@ export class TaskTitleComponent implements OnDestroy {
       }
     } else if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) {
       if (!this._isMentionListShown()) {
+        ev.preventDefault();
+        // No-op when editing a fresh empty title — keeps the textarea focused
+        // instead of spawning a duplicate empty subtask on rapid Mod+Enter.
+        if (!this.tmpValue().trim() && !this.lastExternalValue?.trim()) {
+          return;
+        }
         this._submitTrigger = 'modEnter';
         this._forceBlur();
-        ev.preventDefault();
       }
     } else if (ev.key === 'Enter') {
       // if mention list is open, Enter selects from list - don't blur

--- a/src/app/ui/task-title/task-title.component.ts
+++ b/src/app/ui/task-title/task-title.component.ts
@@ -197,14 +197,9 @@ export class TaskTitleComponent implements OnDestroy {
       }
     } else if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) {
       if (!this._isMentionListShown()) {
-        ev.preventDefault();
-        // No-op when editing a fresh empty title — keeps the textarea focused
-        // instead of spawning a duplicate empty subtask on rapid Mod+Enter.
-        if (!this.tmpValue().trim() && !this.lastExternalValue?.trim()) {
-          return;
-        }
         this._submitTrigger = 'modEnter';
         this._forceBlur();
+        ev.preventDefault();
       }
     } else if (ev.key === 'Enter') {
       // if mention list is open, Enter selects from list - don't blur

--- a/src/app/ui/task-title/task-title.component.ts
+++ b/src/app/ui/task-title/task-title.component.ts
@@ -188,27 +188,22 @@ export class TaskTitleComponent implements OnDestroy {
   // Enter/Escape to submit and blur
   handleKeyDown(ev: KeyboardEvent): void {
     ev.stopPropagation();
+
+    let trigger: SubmitTrigger | null = null;
     if (ev.key === 'Escape') {
-      // if mention list is open, Escape is handled by MentionDirective - don't blur
-      if (!this._isMentionListShown()) {
-        this._submitTrigger = 'escape';
-        this._forceBlur();
-        ev.preventDefault();
-      }
-    } else if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) {
-      if (!this._isMentionListShown()) {
-        this._submitTrigger = 'modEnter';
-        this._forceBlur();
-        ev.preventDefault();
-      }
+      trigger = 'escape';
     } else if (ev.key === 'Enter') {
-      // if mention list is open, Enter selects from list - don't blur
-      if (!this._isMentionListShown()) {
-        this._submitTrigger = 'enter';
-        this._forceBlur();
-        ev.preventDefault();
-      }
+      trigger = ev.ctrlKey || ev.metaKey ? 'modEnter' : 'enter';
     }
+    if (!trigger) return;
+
+    // While the mention list is open, MentionDirective owns Enter (selects)
+    // and Escape (closes) — leave the textarea focused for either path.
+    if (this._isMentionListShown()) return;
+
+    this._submitTrigger = trigger;
+    this._forceBlur();
+    ev.preventDefault();
   }
 
   // Android WebView: Enter key comes through as textInput

--- a/src/app/ui/task-title/task-title.component.ts
+++ b/src/app/ui/task-title/task-title.component.ts
@@ -21,6 +21,7 @@ import { AsyncPipe } from '@angular/common';
 import { Observable } from 'rxjs';
 import { MentionConfigService } from '../../features/tasks/mention-config.service';
 import { hasLinkHints, RenderLinksPipe } from '../pipes/render-links.pipe';
+import { SubmitTrigger } from 'src/app/features/tasks/task.model';
 
 /**
  * Inline-editable text field for task titles.
@@ -91,14 +92,13 @@ export class TaskTitleComponent implements OnDestroy {
     newVal: string;
     wasChanged: boolean;
     blurEvent?: FocusEvent;
-    submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter';
+    submitTrigger: SubmitTrigger;
   }>();
 
   private readonly _isFocused = signal(false);
   private readonly _isEditing = signal(false);
   private _focusTimeoutId: number | undefined;
-  private _submitTrigger: 'blur' | 'escape' | 'enter' | 'modEnter' =
-    TaskTitleComponent._DEFAULT_SUBMIT_TRIGGER;
+  private _submitTrigger: SubmitTrigger = TaskTitleComponent._DEFAULT_SUBMIT_TRIGGER;
 
   updateMentionListShown(isShown: boolean): void {
     // use setTimeout to ensure blur event order doesn't interfere with mention selection


### PR DESCRIPTION
## Problem

Currently, creating subtasks via keyboard requires pressing `a`, and there is no smooth way to chain subtask creation while editing a task. Additionally, cancelling a newly created subtask requires manual deletion.

Fixes: #7420 

## Solution
This PR introduces a keyboard-first workflow for subtasks:

- **Ctrl+Enter (Mod+Enter)** while editing:
  - Saves the current task (exits edit mode)
  - Creates a new subtask
  - Focuses the new subtask in edit mode

- **Escape on a newly created subtask**:
  - Cancels the subtask if it is still empty
  - Restores focus to the previous task (not in edit mode)
<!-- Describe your changes in detail. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
