### PR TITLE
Fix #6123: mention list row unreadable with light primary

### DIFF
--- a/src/app/ui/mentions/mention-list.component.contrast.spec.ts
+++ b/src/app/ui/mentions/mention-list.component.contrast.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+
+import { MentionListComponent } from './mention-list.component';
+import { Log } from '../../core/log';
+
+/**
+ * Regression #6123: active mention row must use --c-contrast on --c-primary.
+ * Kept in a separate spec so the first detectChanges() runs after items are set
+ * (avoids ExpressionChangedAfterItHasBeenCheckedError from the shared component spec).
+ * Global mentions.scss is loaded via src/styles.scss in Karma.
+ */
+describe('MentionListComponent contrast (regression #6123)', () => {
+  let component: MentionListComponent;
+  let fixture: ComponentFixture<MentionListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MentionListComponent, CommonModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MentionListComponent);
+    component = fixture.componentInstance;
+    spyOn(Log, 'warn');
+
+    const host = fixture.nativeElement as HTMLElement;
+    host.style.setProperty('--c-primary', 'rgb(255, 255, 255)');
+    host.style.setProperty('--c-contrast', 'rgb(10, 10, 10)');
+    host.style.setProperty('--text-color-most-intense', 'rgb(255, 255, 255)');
+    host.style.setProperty('--text-color', 'rgb(200, 200, 200)');
+    host.style.setProperty('--bg-lightest', 'rgb(40, 40, 40)');
+
+    component.hidden = false;
+    component.styleOff = false;
+    component.labelKey = 'title';
+    component.items = [{ title: 'Noite' }, { title: 'Dia' }] as any;
+    component.activeIndex = 0;
+
+    fixture.detectChanges();
+    fixture.detectChanges();
+  });
+
+  it('should use --c-contrast for active row text when primary is light', () => {
+    const activeLink = fixture.nativeElement.querySelector(
+      '.mention-active > a',
+    ) as HTMLElement | null;
+
+    expect(activeLink).not.toBeNull();
+
+    const computed = getComputedStyle(activeLink!);
+    expect(computed.color).toBe('rgb(10, 10, 10)');
+    expect(computed.backgroundColor).toBe('rgb(255, 255, 255)');
+  });
+
+  it('should not use --text-color-most-intense for active row (would match light primary)', () => {
+    const activeLink = fixture.nativeElement.querySelector(
+      '.mention-active > a',
+    ) as HTMLElement | null;
+
+    expect(activeLink).not.toBeNull();
+
+    const computed = getComputedStyle(activeLink!);
+    expect(computed.color).not.toBe('rgb(255, 255, 255)');
+  });
+
+  it('should keep inactive rows on --text-color', () => {
+    const inactiveLink = fixture.nativeElement.querySelector(
+      'li:not(.mention-active) a.mention-item',
+    ) as HTMLElement | null;
+
+    expect(inactiveLink).not.toBeNull();
+
+    expect(getComputedStyle(inactiveLink!).color).toBe('rgb(200, 200, 200)');
+  });
+});

--- a/src/app/ui/mentions/mention-list.component.scss
+++ b/src/app/ui/mentions/mention-list.component.scss
@@ -19,13 +19,13 @@
   padding: 0.5em 0;
   margin: 0.125em 0 0;
   font-size: 1em;
-  color: #212529;
+  color: var(--text-color);
   text-align: left;
   list-style: none;
-  background-color: #fff;
+  background-color: var(--bg-lightest);
   background-clip: padding-box;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 0.25em;
+  border: 1px solid var(--extra-border-color);
+  border-radius: var(--card-border-radius);
 }
 .mention-item {
   display: block;
@@ -33,16 +33,16 @@
   line-height: 1.5em;
   clear: both;
   font-weight: 400;
-  color: #212529;
+  color: var(--text-color);
   text-align: inherit;
   white-space: nowrap;
   background-color: transparent;
   border: 0;
 }
 .mention-active > a {
-  color: #fff;
+  color: var(--c-contrast);
   text-decoration: none;
-  background-color: #337ab7;
+  background-color: var(--c-primary);
   outline: 0;
 }
 .scrollable-menu {

--- a/src/styles/components/mentions.scss
+++ b/src/styles/components/mentions.scss
@@ -8,7 +8,8 @@
   color: var(--text-color) !important;
 }
 
+// Text must contrast with --c-primary (project themes can use very light primaries).
 .mention-active > a {
   background: var(--c-primary) !important;
-  color: var(--text-color-most-intense) !important;
+  color: var(--c-contrast) !important;
 }


### PR DESCRIPTION
## Fixes #6123 — Mention list: unreadable highlighted row with light project primary

### Problem

When adding a task (e.g. **Shift+A**) and typing **`#`** to pick a tag, the mention dropdown highlights the active row with **`background: var(--c-primary)`** (the **project** primary colour).

That row used **`color: var(--text-color-most-intense)`**, which is tuned for general UI surfaces (e.g. strong body text in a dark app theme). It is **not** the colour meant for text **on top of the primary** swatch.

If the project primary is **very light** (and/or the app theme uses light “intense” text), the highlighted row can end up with **light text on a light background**, so the tag label is effectively invisible. Project contrast/threshold settings apply to the primary palette (via **`--c-contrast`** / `--palette-primary-contrast-*`), but they were not used for this row.

### Fix

- **`src/styles/components/mentions.scss`** — For `.mention-active > a`, set **`color: var(--c-contrast)`** instead of **`var(--text-color-most-intense)`**, so label colour tracks **contrast against `--c-primary`** (including light primaries).
- **`src/app/ui/mentions/mention-list.component.scss`** — Replace hardcoded Bootstrap-like colours with **design tokens** (`--text-color`, `--bg-lightest`, `--c-primary`, `--c-contrast`, borders, radius) so defaults stay consistent with the global theme.

### Tests

- **`src/app/ui/mentions/mention-list.component.contrast.spec.ts`** — Sets CSS variables on the component host (light primary, dark contrast, etc.) and asserts **`getComputedStyle`** on the active vs inactive rows so this regression does not come back.

### How to verify manually

1. Set a **light primary** on a project and select that project.
2. **Shift+A**, type **`#`**.
3. The **highlighted** suggestion row should show **readable** text on the primary background across themes.