### PR TITLE
Add AI Assistant community plugin

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -63,7 +63,7 @@
   },
   {
     "name": "Dashboard",
-    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user\u2011defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
+    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
     "url": "https://github.com/dougcooper/sp-dashboard",
     "author": "dougcooper",
     "authorUrl": "https://github.com/dougcooper",
@@ -92,5 +92,13 @@
     "author": "sinenomine",
     "authorUrl": "https://codeberg.org/sinenomine/",
     "stars": 1
+  },
+  {
+    "name": "AI Assistant",
+    "shortDescription": "OpenAI-powered AI assistant chat panel. Manage tasks, projects, and tags via natural language with function calling support. Configurable API key, model, and base URL.",
+    "url": "https://github.com/ai-eifying/ai-assistant-plugin",
+    "author": "ai-eifying",
+    "authorUrl": "https://github.com/ai-eifying",
+    "stars": 0
   }
 ]


### PR DESCRIPTION
## AI Assistant Plugin

Adds a new community plugin entry for **AI Assistant** — an OpenAI-powered chat panel for Super Productivity.

**Features:**
- Chat with AI to manage tasks, projects, and tags via natural language
- OpenAI function calling for automatic tool execution
- Configurable: API key, base URL, model, temperature
- Sidebar panel with markdown rendering
- Supports any OpenAI-compatible API

**Plugin repo:** https://github.com/ai-eifying/ai-assistant-plugin