### PR TITLE
Fix #7485: Can't right click certain area

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -91,7 +91,21 @@
   <context-menu
     [contextMenu]="backgroundContextMenu"
     [rightClickTriggerEl]="routeWrapper.nativeElement"
-    [allowedSelectors]="'.route-wrapper, .today, .task-list-wrapper, .page-wrapper, .route-wrapper > *, .search-results'"
+    [allowedSelectors]="'
+      .route-wrapper,
+      .today,
+      .task-list-wrapper,
+      .task-list-wrapper > *,
+      .task-list-inner,
+      .work-view-header,
+      .page-wrapper,
+      .route-wrapper > *,
+      .search-results,
+      .add-more-or-finish,
+      .add-more-or-finish > *,
+      .no-tasks-illu-wrapper,
+      .no-tasks-illu-wrapper *,
+      .finish-day-button-wrapper'"
   ></context-menu>
 }
 


### PR DESCRIPTION
## Problem

Fix #7485

## Solution

Added several css classes to context-menu component's allowed selectors property. Those classes now can be right clickable to open the context-menu.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
