### PR TITLE
fix(schedule): sanitize iCal URL in tooltips and tighten chip filter

### DIFF
--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -338,7 +338,7 @@ export class CalendarIntegrationService {
           events.map((ev) => ({
             ...ev,
             isReferenceCalendar: !!calProvider.isReferenceCalendar,
-            ...(calProvider.color && { color: calProvider.color }),
+            color: calProvider.color,
           })),
         ),
         catchError((err) => {

--- a/src/app/features/calendar-integration/hidden-calendar-providers.service.ts
+++ b/src/app/features/calendar-integration/hidden-calendar-providers.service.ts
@@ -9,12 +9,12 @@ export class HiddenCalendarProvidersService {
   readonly hiddenProviderIds = signal<string[]>(this._loadFromStorage());
 
   toggle(providerId: string): void {
-    const current = this.hiddenProviderIds();
-    const next = current.includes(providerId)
-      ? current.filter((id) => id !== providerId)
-      : [...current, providerId];
-    this.hiddenProviderIds.set(next);
-    saveToRealLs(LS.HIDDEN_CALENDAR_PROVIDER_IDS, next);
+    this.hiddenProviderIds.update((current) =>
+      current.includes(providerId)
+        ? current.filter((id) => id !== providerId)
+        : [...current, providerId],
+    );
+    saveToRealLs(LS.HIDDEN_CALENDAR_PROVIDER_IDS, this.hiddenProviderIds());
   }
 
   private _loadFromStorage(): string[] {

--- a/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.ts
+++ b/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.ts
@@ -2,6 +2,22 @@ import { IssueProvider } from '../issue.model';
 
 const SECRET_KEY_PATTERNS = /token|secret|key|password|apikey|api_key/i;
 
+// iCal feed URLs frequently embed credentials in the path (e.g. Google
+// private feeds) or query string. Show only the host so tokens never end up
+// in tooltips, screenshots, or screenshares.
+const sanitizeIcalUrlForDisplay = (url: string | undefined): string => {
+  if (!url) return 'iCal';
+  try {
+    const u = new URL(url);
+    if (u.host) return u.host;
+    // file:// — show basename only
+    const basename = u.pathname.split('/').filter(Boolean).pop();
+    return basename ? `file: ${basename}` : 'iCal';
+  } catch {
+    return 'iCal';
+  }
+};
+
 const _hasPluginConfig = (
   issueProvider: IssueProvider,
 ): issueProvider is IssueProvider & { pluginConfig: Record<string, unknown> } => {
@@ -35,7 +51,7 @@ export const getIssueProviderTooltip = (issueProvider: IssueProvider): string =>
       case 'CALDAV':
         return issueProvider.caldavUrl;
       case 'ICAL':
-        return issueProvider.icalUrl;
+        return sanitizeIcalUrlForDisplay(issueProvider.icalUrl);
       case 'REDMINE':
         return issueProvider.projectId;
       case 'OPEN_PROJECT':

--- a/src/app/features/issue/providers/calendar/calendar.const.ts
+++ b/src/app/features/issue/providers/calendar/calendar.const.ts
@@ -24,7 +24,6 @@ export const DEFAULT_CALENDAR_CFG: CalendarProviderCfg = {
   icalUrl: '',
   isAutoImportForCurrentDay: false,
   isReferenceCalendar: false,
-  color: undefined,
   checkUpdatesEvery: 2 * 60 * 60000,
   showBannerBeforeThreshold: 2 * 60 * 60000,
   isDisabledForWebApp: false,

--- a/src/app/features/schedule/schedule.service.spec.ts
+++ b/src/app/features/schedule/schedule.service.spec.ts
@@ -685,12 +685,40 @@ describe('ScheduleService – calendar visibility filter', () => {
     expect(callCreate().length).toBe(0);
   });
 
-  it('should keep entries whose items array is empty (no calProviderId to match)', () => {
+  it('should drop entries whose items array becomes empty after filtering', () => {
     calendarEvents$.next([{ items: [] }, makeEntry('provider-A')]);
+    hiddenProviderIds.set(['provider-A']);
+
+    expect(callCreate().length).toBe(0);
+  });
+
+  it('should filter hidden items inside a mixed-provider entry', () => {
+    const mixedEntry: ScheduleCalendarMapEntry = {
+      items: [
+        {
+          id: 'ev-A',
+          calProviderId: 'provider-A',
+          issueProviderKey: 'ICAL',
+          title: 'A',
+          start: Date.now() + 60_000,
+          duration: 3_600_000,
+        },
+        {
+          id: 'ev-B',
+          calProviderId: 'provider-B',
+          issueProviderKey: 'ICAL',
+          title: 'B',
+          start: Date.now() + 60_000,
+          duration: 3_600_000,
+        },
+      ],
+    };
+    calendarEvents$.next([mixedEntry]);
     hiddenProviderIds.set(['provider-A']);
 
     const passed = callCreate();
     expect(passed.length).toBe(1);
-    expect(passed[0].items.length).toBe(0);
+    expect(passed[0].items.length).toBe(1);
+    expect(passed[0].items[0].calProviderId).toBe('provider-B');
   });
 });

--- a/src/app/features/schedule/schedule.service.ts
+++ b/src/app/features/schedule/schedule.service.ts
@@ -128,11 +128,16 @@ export class ScheduleService {
     const timelineCfg = this._timelineConfig();
     const plannerDayMap = this._plannerDayMap();
     const hiddenProviderIds = this._hiddenCalendarProviders.hiddenProviderIds();
-    const calendarEvents = this._calendarEvents().filter(
-      (entry) =>
-        !entry.items[0]?.calProviderId ||
-        !hiddenProviderIds.includes(entry.items[0].calProviderId),
-    );
+    const calendarEvents = hiddenProviderIds.length
+      ? this._calendarEvents()
+          .map((entry) => ({
+            ...entry,
+            items: entry.items.filter(
+              (item) => !hiddenProviderIds.includes(item.calProviderId),
+            ),
+          }))
+          .filter((entry) => entry.items.length > 0)
+      : this._calendarEvents();
 
     return this.buildScheduleDays({
       now: params.contextNow,

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -67,7 +67,7 @@
   <div class="title">{{ headerTitle() }}</div>
 </div>
 
-@if (enabledCalendarProviders().length >= 1) {
+@if (enabledCalendarProviders().length > 1) {
   <mat-chip-listbox
     class="cal-filter-bar"
     [multiple]="true"
@@ -75,8 +75,9 @@
   >
     @for (provider of enabledCalendarProviders(); track provider.id) {
       <mat-chip-option
+        [value]="provider.id"
         [selected]="!hiddenCalendarProviderIds().includes(provider.id)"
-        (click)="toggleCalendarProvider(provider.id)"
+        (selectionChange)="onCalProviderSelectionChange($event, provider.id)"
         [matTooltip]="calProviderLabel(provider)"
       >
         @if (provider.color) {

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -16,7 +16,11 @@ import {
   getIssueProviderTooltip,
 } from '../../issue/mapping-helper/get-issue-provider-tooltip';
 import { IssueProvider } from '../../issue/issue.model';
-import { MatChipListbox, MatChipOption } from '@angular/material/chips';
+import {
+  MatChipListbox,
+  MatChipOption,
+  MatChipSelectionChange,
+} from '@angular/material/chips';
 import { debounceTime, map, startWith } from 'rxjs/operators';
 import { safeFormatDate } from '../../../util/safe-format-date';
 import { TaskService } from '../../tasks/task.service';
@@ -87,7 +91,11 @@ export class ScheduleComponent {
     getIssueProviderInitials(p) ??
     getIssueProviderTooltip(p).substring(0, 2).toUpperCase();
 
-  toggleCalendarProvider(providerId: string): void {
+  // Triggered by user interaction with the mat-chip-option. The isUserInput
+  // guard prevents the loop where setting [selected] programmatically
+  // (after the toggle updates hiddenProviderIds) re-fires the handler.
+  onCalProviderSelectionChange(ev: MatChipSelectionChange, providerId: string): void {
+    if (!ev.isUserInput) return;
     this._hiddenCalendarProviders.toggle(providerId);
   }
 


### PR DESCRIPTION
Follow-up to PR #7497.

- Sanitize iCal URL in `getIssueProviderTooltip` to host-only so private feed credentials (Google private feeds, tokens in path/query) don't leak into chip tooltips, the issue panel, or screenshares.
- Switch the calendar visibility chip listbox from `[selected]+(click)` to the idiomatic `[value]+(selectionChange)` pattern with an `isUserInput` guard, removing the double-toggle path.
- Filter hidden providers at item level instead of by `entry.items[0]` so future multi-provider entries can't silently leak hidden events.
- Minor cleanup: drop redundant conditional spread for `color`, raise chip-bar threshold from `>= 1` to `> 1`, use `signal.update` in `HiddenCalendarProvidersService.toggle`, drop redundant `color: undefined` default.

## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

## Solution

<!-- Describe your changes in detail. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)
