### PR TITLE
feat(schedule): Add new Today button to Schedule view

### DIFF
--- a/src/app/core/date-time-format/date-time-format.service.ts
+++ b/src/app/core/date-time-format/date-time-format.service.ts
@@ -91,12 +91,28 @@ export class DateTimeFormatService {
    * // For en-GB locale
    * formatDate(new Date(2000, 11, 31), 'en-GB'); // 31/12/2000
    */
-  formatDate(date: Date, locale: DateTimeLocale = this.currentLocale()): string {
-    const formatter = new Intl.DateTimeFormat(locale, {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    });
+  formatDate(
+    date: Date,
+    locale: DateTimeLocale = this.currentLocale(),
+    formatOptions?: 'long',
+  ): string {
+    let format: Intl.DateTimeFormatOptions = {};
+
+    if (formatOptions === 'long') {
+      format = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: '2-digit',
+      };
+    } else {
+      format = {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      };
+    }
+    const formatter = new Intl.DateTimeFormat(locale, format);
 
     return formatter.format(date);
   }

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -80,14 +80,13 @@
     </button>
 
     <button
-      mat-icon-button
       class="today-btn"
       (click)="goToToday()"
       [disabled]="isViewingToday()"
       [attr.aria-label]="T.G.TODAY_TAG_TITLE | translate"
-      [matTooltip]="T.G.TODAY_TAG_TITLE | translate"
     >
-      <mat-icon>radio_button_unchecked</mat-icon>
+      <mat-icon>wb_sunny</mat-icon>
+      {{ 'Today' | translate }}
     </button>
 
     <button

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -72,7 +72,9 @@
       [matTooltipDisabled]="isViewingToday()"
     >
       <mat-icon>wb_sunny</mat-icon>
-      {{ T.G.TODAY_TAG_TITLE | translate }}
+      @if (!this.layoutService.isXxxs()) {
+        {{ T.G.TODAY_TAG_TITLE | translate }}
+      }
     </button>
 
     <button

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -64,6 +64,18 @@
 
   <div class="date-nav-group">
     <button
+      class="today-btn"
+      (click)="goToToday()"
+      [disabled]="isViewingToday()"
+      [attr.aria-label]="T.G.TODAY_TAG_TITLE | translate"
+      [matTooltip]="displayTodayDate()"
+      [matTooltipDisabled]="isViewingToday()"
+    >
+      <mat-icon>wb_sunny</mat-icon>
+      {{ T.G.TODAY_TAG_TITLE | translate }}
+    </button>
+
+    <button
       mat-icon-button
       (click)="goToPreviousPeriod()"
       [disabled]="isViewingToday()"
@@ -77,18 +89,6 @@
       "
     >
       <mat-icon>chevron_left</mat-icon>
-    </button>
-
-    <button
-      class="today-btn"
-      (click)="goToToday()"
-      [disabled]="isViewingToday()"
-      [attr.aria-label]="T.G.TODAY_TAG_TITLE | translate"
-      [matTooltip]="displayTodayDate()"
-      [matTooltipDisabled]="isViewingToday()"
-    >
-      <mat-icon>wb_sunny</mat-icon>
-      {{ T.G.TODAY_TAG_TITLE | translate }}
     </button>
 
     <button

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -84,6 +84,8 @@
       (click)="goToToday()"
       [disabled]="isViewingToday()"
       [attr.aria-label]="T.G.TODAY_TAG_TITLE | translate"
+      [matTooltip]="_todayDateStr()"
+      [matTooltipDisabled]="isViewingToday()"
     >
       <mat-icon>wb_sunny</mat-icon>
       {{ 'Today' | translate }}

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -84,11 +84,11 @@
       (click)="goToToday()"
       [disabled]="isViewingToday()"
       [attr.aria-label]="T.G.TODAY_TAG_TITLE | translate"
-      [matTooltip]="_todayDateStr()"
+      [matTooltip]="displayTodayDate()"
       [matTooltipDisabled]="isViewingToday()"
     >
       <mat-icon>wb_sunny</mat-icon>
-      {{ 'Today' | translate }}
+      {{ T.G.TODAY_TAG_TITLE | translate }}
     </button>
 
     <button

--- a/src/app/features/schedule/schedule/schedule.component.scss
+++ b/src/app/features/schedule/schedule/schedule.component.scss
@@ -76,6 +76,30 @@
     flex-shrink: 0;
   }
 
+  .today-btn {
+    color: var(--text-color);
+    background: var(--separator-color);
+    border-style: solid;
+    border-color: var(--extra-border-color);
+    border-radius: var(--card-border-radius);
+    padding: 5%;
+    margin-left: 5%;
+    margin-right: 5%;
+    font-weight: 500;
+    font-size: 14px;
+
+    &:disabled {
+      opacity: 50%;
+      background: transparent;
+    }
+
+    &:hover:not(:disabled) {
+      background: var(--c-primary);
+      cursor: pointer;
+      color: white;
+    }
+  }
+
   mat-icon {
     flex-shrink: 0;
   }

--- a/src/app/features/schedule/schedule/schedule.component.scss
+++ b/src/app/features/schedule/schedule/schedule.component.scss
@@ -78,7 +78,7 @@
 
   .today-btn {
     color: var(--text-color);
-    background: var(--separator-color);
+    background: transparent;
     border-style: solid;
     border-color: var(--extra-border-color);
     border-radius: var(--card-border-radius);

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -72,6 +72,7 @@ describe('ScheduleComponent', () => {
       [],
       {
         todayDateStr$: of('2026-01-20'),
+        todayDateStr: signal('2026-01-20'),
       },
     );
 

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -342,6 +342,12 @@ export class ScheduleComponent {
     this._selectedDate.set(null); // Resets to "today" mode
   }
 
+  displayTodayDate = computed(() => {
+    const todayDateStr = this._globalTrackingIntervalService.todayDateStr();
+    const locale = this._dateTimeFormatService.currentLocale();
+    return safeFormatDate(todayDateStr, 'EEEE, MMM dd, yyyy', locale);
+  });
+
   // Tracks whether the scroll-wrapper has been scrolled horizontally. Used
   // by schedule-week so the sticky time column gets a background only once
   // day-content is actually sliding under it.

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -345,7 +345,11 @@ export class ScheduleComponent {
   displayTodayDate = computed(() => {
     const todayDateStr = this._globalTrackingIntervalService.todayDateStr();
     const locale = this._dateTimeFormatService.currentLocale();
-    return safeFormatDate(todayDateStr, 'EEEE, MMM dd, yyyy', locale);
+    return this._dateTimeFormatService.formatDate(
+      parseDbDateStr(todayDateStr),
+      locale,
+      'long',
+    );
   });
 
   // Tracks whether the scroll-wrapper has been scrolled horizontally. Used


### PR DESCRIPTION
## Problem

The previous Today button only had an unchecked box icon which did not explain its function.

<img width="1011" height="629" alt="sp-592026-1519" src="https://github.com/user-attachments/assets/dedf2d0f-22e9-4f24-9249-95d9a5674868" />


## Solution

Replace the icon with text reading "Today" and the universal SP Today icon `wb_sunny`. Change tooltip from `Today` to the current date, similar to the Google Calendar implementation.

Fixes #7537

## Examples

### Normal (Light mode)
<img width="937" height="628" alt="sp-592026-1535" src="https://github.com/user-attachments/assets/b150fec5-9ecb-4114-98e2-a6c8740f43db" />

### Hovered (Light mode)
<img width="957" height="483" alt="sp-592026-1730" src="https://github.com/user-attachments/assets/c08de3ce-0c73-480b-9b12-e39ce46a5cb2" />

### Normal (Dark mode)
<img width="959" height="635" alt="sp-592026-1532" src="https://github.com/user-attachments/assets/be23a0e0-563f-43c3-8330-c80f8b086ca9" />

### Hovered (Light mode)
<img width="954" height="633" alt="sp-592026-1533" src="https://github.com/user-attachments/assets/39ff4f4e-460f-48df-be3c-79b68be4c072" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (please describe)

Purely a UI change. No functionality altered.

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files [N/A]
- [ ] I have added tests for my changes (if applicable) [N/A]
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
