### PR TITLE
Prevents task creation during IME conversion.

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -600,33 +600,43 @@ describe('AddTaskBarComponent', () => {
   });
 
   describe('IME handling (Integration)', () => {
-    it('should not add a task when Enter is pressed during IME composition', () => {
+    let inputEl: HTMLInputElement;
+
+    beforeEach(() => {
       component.stateService.updateInputTxt('New Task');
       fixture.detectChanges();
+      inputEl = fixture.debugElement.nativeElement.querySelector('input');
+    });
 
-      const inputEl = fixture.debugElement.nativeElement.querySelector('input');
+    const dispatchEnterKeydown = (options: {
+      isComposing: boolean;
+      keyCode?: number;
+    }): void => {
       const event = new KeyboardEvent('keydown', {
         key: 'Enter',
-        isComposing: true,
+        isComposing: options.isComposing,
       });
+
+      if (options.keyCode) {
+        Object.defineProperty(event, 'keyCode', { value: options.keyCode });
+      }
+
       inputEl.dispatchEvent(event);
       fixture.detectChanges();
+    };
 
+    it('should not add a task when Enter is pressed during IME composition', () => {
+      dispatchEnterKeydown({ isComposing: true });
+      expect(mockTaskService.add).not.toHaveBeenCalled();
+    });
+
+    it('should not add a task when Enter is pressed with keyCode 229 even if isComposing is false', () => {
+      dispatchEnterKeydown({ isComposing: false, keyCode: 229 });
       expect(mockTaskService.add).not.toHaveBeenCalled();
     });
 
     it('should add a task when Enter is pressed and NOT in IME composition', () => {
-      component.stateService.updateInputTxt('New Task');
-      fixture.detectChanges();
-
-      const inputEl = fixture.debugElement.nativeElement.querySelector('input');
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        isComposing: false,
-      });
-      inputEl.dispatchEvent(event);
-      fixture.detectChanges();
-
+      dispatchEnterKeydown({ isComposing: false });
       expect(mockTaskService.add).toHaveBeenCalled();
     });
   });

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -598,4 +598,36 @@ describe('AddTaskBarComponent', () => {
       expect(doneSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('IME handling (Integration)', () => {
+    it('should not add a task when Enter is pressed during IME composition', () => {
+      component.stateService.updateInputTxt('New Task');
+      fixture.detectChanges();
+
+      const inputEl = fixture.debugElement.nativeElement.querySelector('input');
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        isComposing: true,
+      });
+      inputEl.dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(mockTaskService.add).not.toHaveBeenCalled();
+    });
+
+    it('should add a task when Enter is pressed and NOT in IME composition', () => {
+      component.stateService.updateInputTxt('New Task');
+      fixture.detectChanges();
+
+      const inputEl = fixture.debugElement.nativeElement.querySelector('input');
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        isComposing: false,
+      });
+      inputEl.dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(mockTaskService.add).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -685,7 +685,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     }
 
     // Handle Enter key
-    if (event.key === 'Enter' && !event.isComposing) {
+    if (event.key === 'Enter' && !event.isComposing && event.keyCode !== 229) {
       event.preventDefault();
       if (!this.isSearchMode() && !event.repeat) {
         void this.addTask();

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -685,7 +685,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     }
 
     // Handle Enter key
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && !event.isComposing) {
       event.preventDefault();
       if (!this.isSearchMode() && !event.repeat) {
         void this.addTask();


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

The Input Method Editor (IME) enter key was not functioning correctly while a user was inputting a new task in the application interface, leading to poor usability for users with non-Latin or complex IME environments.

## Solution

<!-- Describe your changes in detail. -->

The code has been modified to check if the IME input event is `isComposing` when the Enter key is pressed, and to call `addTask()` only if it is not.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
