### PR TITLE
feat(tasks): convert tasks to subtasks by drag drop

### DIFF
--- a/docs/wiki/2.04-Manage-Subtasks.md
+++ b/docs/wiki/2.04-Manage-Subtasks.md
@@ -29,6 +29,10 @@ Shortcuts are configurable in [[3.02-Settings-and-Preferences]].
 
 Drag the subtask by its **drag handle** and drop it onto the target parent task, or into that parent’s subtask list. The subtask becomes a child of the new parent and keeps the same project (subtasks inherit the parent’s project).
 
+## Convert a Main Task to a Subtask
+
+Drag the top-level task by its **drag handle** and drop it into another task’s subtask list. The task becomes a subtask at the drop position and inherits the target parent’s project. Repeating tasks and issue-linked tasks cannot be converted to subtasks; see [[4.11-Subtasks]].
+
 ## Convert a Subtask to a Main Task
 
 Right-click the subtask and click **Convert to parent task**. The subtask becomes a top-level task in the same project. Repeating tasks and issue-linked tasks cannot be converted to subtasks; see [[4.11-Subtasks]].

--- a/docs/wiki/4.11-Subtasks.md
+++ b/docs/wiki/4.11-Subtasks.md
@@ -55,7 +55,7 @@ Tag views (see [[4.07-Tag-View]]) show tasks that have a given tag. To avoid sho
 
 ## Movement and Reorganization
 
-You can **move a subtask to another parent** (or make it a top-level task by removing its parent). When you do:
+You can **move a subtask to another parent**, make it a top-level task by removing its parent, or turn a top-level task into a subtask by dragging it into another task’s subtask list. When you do:
 
 - The **old parent’s subtask list** is updated: the moved subtask is removed from it.
 - The **new parent’s subtask list** is updated: the moved subtask is added to it (in the position you chose, if the UI allows).

--- a/src/app/features/tasks/task-list/task-list.component.spec.ts
+++ b/src/app/features/tasks/task-list/task-list.component.spec.ts
@@ -14,6 +14,7 @@ import { TaskWithSubTasks } from '../task.model';
 import { SectionService } from '../../section/section.service';
 import { moveSubTask } from '../store/task.actions';
 import { WorkContextType } from '../../work-context/work-context.model';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 
 describe('TaskListComponent', () => {
   let component: TaskListComponent;
@@ -22,7 +23,12 @@ describe('TaskListComponent', () => {
   let store: MockStore;
 
   // Helper to create mock CdkDrag
-  const createMockDrag = (task: { id: string; parentId: string | null }): CdkDrag =>
+  const createMockDrag = (
+    task: Omit<Partial<TaskWithSubTasks>, 'parentId'> & {
+      id: string;
+      parentId: string | null;
+    },
+  ): CdkDrag =>
     ({
       data: task,
     }) as unknown as CdkDrag;
@@ -194,10 +200,38 @@ describe('TaskListComponent', () => {
         expect(component.enterPredicate(drag, drop)).toBe(true);
       });
 
-      it('should block parent task from dropping to subtask list', () => {
+      it('should allow parent task to drop into another task subtask list', () => {
         const task = { id: 'task1', parentId: null };
         const drag = createMockDrag(task);
         // Task ID listed as a subtask drop-list (listId='SUB').
+        const drop = createMockDrop('some-task-id', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(true);
+      });
+
+      it('should block parent task from dropping into its own subtask list', () => {
+        const task = { id: 'task1', parentId: null };
+        const drag = createMockDrag(task);
+        const drop = createMockDrop('task1', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(false);
+      });
+
+      it('should block parent task from dropping into a direct child subtask list', () => {
+        const task = { id: 'task1', parentId: null, subTaskIds: ['sub1'] };
+        const drag = createMockDrag(task);
+        const drop = createMockDrop('sub1', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(false);
+      });
+
+      it('should block repeating parent task from dropping to a subtask list', () => {
+        const task = { id: 'task1', parentId: null, repeatCfgId: 'repeat1' };
+        const drag = createMockDrag(task);
+        const drop = createMockDrop('some-task-id', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(false);
+      });
+
+      it('should block issue-linked parent task from dropping to a subtask list', () => {
+        const task = { id: 'task1', parentId: null, issueId: 'ISSUE-1' };
+        const drag = createMockDrag(task);
         const drop = createMockDrop('some-task-id', [], 'SUB');
         expect(component.enterPredicate(drag, drop)).toBe(false);
       });
@@ -332,11 +366,12 @@ describe('TaskListComponent', () => {
       srcListId: 'PARENT' | 'SUB',
       targetListId: 'PARENT' | 'SUB',
       newOrderedIds: string[] = [taskId],
+      parentId: string | null = null,
     ): void => {
       (
         component as unknown as {
           _move: (
-            t: string,
+            t: TaskWithSubTasks,
             s: string,
             tg: string,
             sl: 'PARENT' | 'SUB',
@@ -344,12 +379,19 @@ describe('TaskListComponent', () => {
             ids: string[],
           ) => void;
         }
-      )._move(taskId, src, target, srcListId, targetListId, newOrderedIds);
+      )._move(
+        { id: taskId, parentId, subTaskIds: [] } as unknown as TaskWithSubTasks,
+        src,
+        target,
+        srcListId,
+        targetListId,
+        newOrderedIds,
+      );
     };
 
     it('routes a subtask drop into another subtask list to moveSubTask (not addTaskToSection)', () => {
       // Both src and target are subtask lists with parent task ids as listModelId.
-      callMove('sub1', 'parentA', 'parentB', 'SUB', 'SUB');
+      callMove('sub1', 'parentA', 'parentB', 'SUB', 'SUB', ['sub1'], 'parentA');
 
       expect(sectionServiceMock.addTaskToSection).not.toHaveBeenCalled();
       const dispatchedAction = (store.dispatch as jasmine.Spy).calls.mostRecent()
@@ -358,6 +400,19 @@ describe('TaskListComponent', () => {
       expect(dispatchedAction.taskId).toBe('sub1');
       expect(dispatchedAction.srcTaskId).toBe('parentA');
       expect(dispatchedAction.targetTaskId).toBe('parentB');
+    });
+
+    it('routes a parent drop into a subtask list to convertToSubTask', () => {
+      callMove('task1', 'UNDONE', 'parentB', 'PARENT', 'SUB', ['existing-sub', 'task1']);
+
+      expect(sectionServiceMock.addTaskToSection).not.toHaveBeenCalled();
+      expect(sectionServiceMock.removeTaskFromSection).not.toHaveBeenCalled();
+      const dispatchedAction = (store.dispatch as jasmine.Spy).calls.mostRecent()
+        .args[0] as ReturnType<typeof TaskSharedActions.convertToSubTask>;
+      expect(dispatchedAction.type).toBe(TaskSharedActions.convertToSubTask.type);
+      expect(dispatchedAction.taskId).toBe('task1');
+      expect(dispatchedAction.targetTaskId).toBe('parentB');
+      expect(dispatchedAction.afterTaskId).toBe('existing-sub');
     });
 
     it('routes a parent drop into a section drop-list (PARENT + non-reserved id) to addTaskToSection', () => {

--- a/src/app/features/tasks/task-list/task-list.component.ts
+++ b/src/app/features/tasks/task-list/task-list.component.ts
@@ -176,7 +176,7 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
 
   enterPredicate = (drag: CdkDrag, drop: CdkDropList): boolean => {
     // TODO this gets called very often for nested lists. Maybe there are possibilities to optimize
-    const task = drag.data;
+    const task = drag.data as TaskWithSubTasks;
     const targetModelId = drop.data.listModelId;
     const targetListId = drop.data.listId;
     const isSubtask = !!task.parentId;
@@ -211,12 +211,25 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
       return false;
     }
 
-    // Parent tasks: allow drops to PARENT_ALLOWED_LISTS or to sections (parent-level
-    // lists with a non-reserved id). Subtask drop-lists (listId === 'SUB') are
-    // rejected so a top-level task can't be nested into another task's subtree.
+    // Parent tasks: allow drops to PARENT_ALLOWED_LISTS, to sections (parent-level
+    // lists with a non-reserved id), or to a subtask list to convert the task.
     const srcModelId = drag.dropContainer?.data?.listModelId;
     const srcListIdRaw = drag.dropContainer?.data?.listId;
     const isSrcSection = srcListIdRaw === 'PARENT' && !RESERVED_LIST_IDS.has(srcModelId);
+
+    if (targetListId === 'SUB') {
+      if (
+        targetModelId === task.id ||
+        task.subTaskIds?.includes(targetModelId) ||
+        task.repeatCfgId ||
+        task.issueId ||
+        task.issueProviderId ||
+        task.issueType
+      ) {
+        return false;
+      }
+      return true;
+    }
 
     if (PARENT_ALLOWED_LISTS.includes(targetModelId)) {
       // Reject section → BACKLOG: _move() dispatches `removeTaskFromSection`
@@ -318,7 +331,7 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
 
     this.dropListService.blockAniTrigger$.next();
     this._move(
-      draggedTask.id,
+      draggedTask,
       srcListData.listModelId,
       targetListData.listModelId,
       srcListData.listId,
@@ -345,19 +358,43 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
   }
 
   private _move(
-    taskId: string,
+    task: TaskWithSubTasks,
     src: DropListModelSource | string,
     target: DropListModelSource | string,
     srcListId: TaskListId,
     targetListId: TaskListId,
     newOrderedIds: string[],
   ): void {
+    const taskId = task.id;
     const isSrcRegularList = src === 'DONE' || src === 'UNDONE';
     const isTargetRegularList = target === 'DONE' || target === 'UNDONE';
     const workContextId = this._workContextService.activeWorkContextId as string;
 
     // Handle LATER_TODAY - prevent any moves to or from this list
     if (src === 'LATER_TODAY' || target === 'LATER_TODAY') {
+      return;
+    }
+
+    if (targetListId === 'SUB') {
+      const afterTaskId = getAnchorFromDragDrop(taskId, newOrderedIds);
+      if (task.parentId) {
+        this._store.dispatch(
+          moveSubTask({
+            taskId,
+            srcTaskId: task.parentId,
+            targetTaskId: target,
+            afterTaskId,
+          }),
+        );
+      } else {
+        this._store.dispatch(
+          TaskSharedActions.convertToSubTask({
+            taskId,
+            targetTaskId: target,
+            afterTaskId,
+          }),
+        );
+      }
       return;
     }
 

--- a/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts
@@ -112,6 +112,32 @@ describe('sectionSharedMetaReducer', () => {
     expect(updated.entities['s2']?.taskIds).toEqual([]);
   });
 
+  it('removes a task from sections when converting it to a subtask', () => {
+    const state = stateWith({ t1: {}, parent: {} }, [
+      {
+        id: 's1',
+        contextId: 'p1',
+        contextType: WorkContextType.PROJECT,
+        title: 'A',
+        taskIds: ['t1', 'parent'],
+      },
+    ]);
+
+    metaReducer(
+      state,
+      TaskSharedActions.convertToSubTask({
+        taskId: 't1',
+        targetTaskId: 'parent',
+        afterTaskId: null,
+      }),
+    );
+
+    const updated = (mockReducer.calls.mostRecent().args[0] as any)[
+      SECTION_FEATURE_NAME
+    ] as SectionState;
+    expect(updated.entities['s1']?.taskIds).toEqual(['parent']);
+  });
+
   it('strips archived tasks (and their subtasks) from sections on moveToArchive', () => {
     const state = stateWith(
       {

--- a/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts
@@ -361,6 +361,10 @@ const ACTION_HANDLERS: Record<string, Handler> = {
     >;
     return handleMoveToOtherProject(state, task.id, targetProjectId);
   },
+  [TaskSharedActions.convertToSubTask.type]: (state, action) => {
+    const { taskId } = action as ReturnType<typeof TaskSharedActions.convertToSubTask>;
+    return handleTaskRemoval(state, [taskId]);
+  },
   [SectionActions.removeTaskFromSection.type]: (state, action) => {
     const { workContextType, workContextId, taskId, workContextAfterTaskId } =
       action as ReturnType<typeof SectionActions.removeTaskFromSection>;

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
@@ -13,6 +13,7 @@ import { Action, ActionReducer } from '@ngrx/store';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import {
   createBaseState,
+  createMockProject,
   createMockTag,
   createMockTask,
   createStateWithExistingTasks,
@@ -492,6 +493,155 @@ describe('taskSharedCrudMetaReducer', () => {
         mockReducer,
         testState,
       );
+    });
+  });
+
+  describe('convertToSubTask action', () => {
+    const createConvertToSubTaskState = (): RootState => {
+      const taskToConvert = createMockTask({
+        id: 'task1',
+        projectId: 'project1',
+        tagIds: ['tag1'],
+        dueDay: '2030-01-01',
+      });
+      const targetTask = createMockTask({
+        id: 'target-task',
+        projectId: 'project2',
+        tagIds: [],
+        subTaskIds: ['existing-sub'],
+      });
+      const existingSubTask = createMockTask({
+        id: 'existing-sub',
+        parentId: 'target-task',
+        projectId: 'project2',
+        tagIds: [],
+      });
+
+      return {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          ids: ['task1', 'target-task', 'existing-sub'],
+          entities: {
+            task1: taskToConvert,
+            'target-task': targetTask,
+            'existing-sub': existingSubTask,
+          },
+        },
+        [PROJECT_FEATURE_NAME]: {
+          ...baseState[PROJECT_FEATURE_NAME],
+          ids: ['project1', 'project2'],
+          entities: {
+            project1: createMockProject({
+              id: 'project1',
+              taskIds: ['task1'],
+              backlogTaskIds: ['task1'],
+            }),
+            project2: createMockProject({
+              id: 'project2',
+              taskIds: ['target-task'],
+              backlogTaskIds: [],
+            }),
+          },
+        },
+        [TAG_FEATURE_NAME]: {
+          ...baseState[TAG_FEATURE_NAME],
+          entities: {
+            ...baseState[TAG_FEATURE_NAME].entities,
+            tag1: createMockTag({ id: 'tag1', taskIds: ['task1'] }),
+            TODAY: createMockTag({ id: 'TODAY', taskIds: ['task1'] }),
+          },
+        },
+        planner: {
+          ...baseState.planner,
+          days: {
+            '2030-01-01': ['task1', 'other-task'],
+          },
+        },
+      };
+    };
+
+    it('should convert a top-level task into a positioned subtask', () => {
+      const testState = createConvertToSubTaskState();
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetTaskId: 'target-task',
+        afterTaskId: 'existing-sub',
+      });
+
+      metaReducer(testState, action);
+
+      expectStateUpdate(
+        {
+          ...expectTaskUpdate('task1', {
+            parentId: 'target-task',
+            projectId: 'project2',
+            tagIds: [],
+          }),
+          ...expectTaskUpdate('target-task', {
+            subTaskIds: ['existing-sub', 'task1'],
+          }),
+          ...expectProjectUpdate('project1', {
+            taskIds: [],
+            backlogTaskIds: [],
+          }),
+          ...expectTagUpdates({
+            tag1: { taskIds: [] },
+            TODAY: { taskIds: [] },
+          }),
+          planner: jasmine.objectContaining({
+            days: {
+              '2030-01-01': ['other-task'],
+            },
+          }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('should ignore repeating or issue-linked tasks', () => {
+      const testState = createConvertToSubTaskState();
+      testState[TASK_FEATURE_NAME].entities.task1 = createMockTask({
+        id: 'task1',
+        projectId: 'project1',
+        repeatCfgId: 'repeat1',
+      });
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetTaskId: 'target-task',
+        afterTaskId: null,
+      });
+
+      const result = metaReducer(testState, action);
+
+      expect(result).toBe(testState);
+      expect(mockReducer).toHaveBeenCalledWith(testState, action);
+    });
+
+    it('should ignore circular conversions', () => {
+      const testState = createConvertToSubTaskState();
+      testState[TASK_FEATURE_NAME].entities.task1 = createMockTask({
+        id: 'task1',
+        projectId: 'project1',
+        subTaskIds: ['target-task'],
+      });
+      testState[TASK_FEATURE_NAME].entities['target-task'] = createMockTask({
+        id: 'target-task',
+        parentId: 'task1',
+        projectId: 'project1',
+      });
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetTaskId: 'target-task',
+        afterTaskId: null,
+      });
+
+      const result = metaReducer(testState, action);
+
+      expect(result).toBe(testState);
+      expect(mockReducer).toHaveBeenCalledWith(testState, action);
     });
   });
 

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../features/tasks/store/task.reducer';
 import {
   deleteTaskHelper,
+  reCalcTimesForParentIfParent,
   removeTaskFromParentSideEffects,
   updateDoneOnForTask,
   updateTimeEstimateForTask,
@@ -42,6 +43,7 @@ import {
   updateTags,
 } from './task-shared-helpers';
 import { plannerFeatureKey } from '../../../features/planner/store/planner.reducer';
+import { moveItemAfterAnchor } from '../../../features/work-context/store/work-context-meta.helper';
 
 // =============================================================================
 // HELPER FUNCTIONS
@@ -282,6 +284,134 @@ const handleConvertToMainTask = (
   );
 
   return updateTags(updatedState, tagUpdates);
+};
+
+const wouldCreateCircularSubTaskReference = (
+  state: RootState,
+  taskId: string,
+  targetTaskId: string,
+): boolean => {
+  let currentTaskId = targetTaskId;
+  const visited = new Set<string>();
+
+  while (currentTaskId) {
+    if (currentTaskId === taskId) return true;
+    if (visited.has(currentTaskId)) return false;
+    visited.add(currentTaskId);
+    const task = state[TASK_FEATURE_NAME].entities[currentTaskId] as Task | undefined;
+    currentTaskId = task?.parentId || '';
+  }
+
+  return false;
+};
+
+const handleConvertToSubTask = (
+  state: RootState,
+  taskId: string,
+  targetTaskId: string,
+  afterTaskId: string | null,
+): RootState => {
+  const task = state[TASK_FEATURE_NAME].entities[taskId] as Task | undefined;
+  const targetTask = state[TASK_FEATURE_NAME].entities[targetTaskId] as Task | undefined;
+
+  if (
+    !task ||
+    !targetTask ||
+    task.parentId ||
+    task.id === targetTask.id ||
+    task.repeatCfgId ||
+    task.issueId ||
+    task.issueProviderId ||
+    task.issueType ||
+    wouldCreateCircularSubTaskReference(state, task.id, targetTask.id)
+  ) {
+    return state;
+  }
+
+  let updatedTaskState = taskAdapter.updateMany(
+    [
+      {
+        id: targetTask.id,
+        changes: {
+          subTaskIds: moveItemAfterAnchor(
+            task.id,
+            afterTaskId,
+            targetTask.subTaskIds.includes(task.id)
+              ? targetTask.subTaskIds
+              : [...targetTask.subTaskIds, task.id],
+          ),
+        },
+      },
+      {
+        id: task.id,
+        changes: {
+          parentId: targetTask.id,
+          projectId: targetTask.projectId,
+          tagIds: [],
+          modified: Date.now(),
+        },
+      },
+    ],
+    state[TASK_FEATURE_NAME],
+  );
+
+  updatedTaskState = reCalcTimesForParentIfParent(targetTask.id, updatedTaskState);
+
+  let updatedState: RootState = {
+    ...state,
+    [TASK_FEATURE_NAME]: updatedTaskState,
+  };
+
+  const projectUpdates = (updatedState[PROJECT_FEATURE_NAME].ids as string[])
+    .map((projectId): Update<Project> | null => {
+      const project = updatedState[PROJECT_FEATURE_NAME].entities[projectId] as
+        | Project
+        | undefined;
+      if (
+        !project ||
+        (!project.taskIds.includes(task.id) && !project.backlogTaskIds.includes(task.id))
+      ) {
+        return null;
+      }
+
+      return {
+        id: projectId,
+        changes: {
+          taskIds: removeTasksFromList(project.taskIds, [task.id]),
+          backlogTaskIds: removeTasksFromList(project.backlogTaskIds, [task.id]),
+        },
+      };
+    })
+    .filter((update): update is Update<Project> => !!update);
+
+  if (projectUpdates.length) {
+    updatedState = {
+      ...updatedState,
+      [PROJECT_FEATURE_NAME]: projectAdapter.updateMany(
+        projectUpdates,
+        updatedState[PROJECT_FEATURE_NAME],
+      ),
+    };
+  }
+
+  const tagUpdates = (updatedState[TAG_FEATURE_NAME].ids as string[])
+    .map((tagId): Update<Tag> | null => {
+      const tag = updatedState[TAG_FEATURE_NAME].entities[tagId] as Tag | undefined;
+      if (!tag || !tag.taskIds.includes(task.id)) return null;
+      return {
+        id: tagId,
+        changes: {
+          taskIds: removeTasksFromList(tag.taskIds, [task.id]),
+        },
+      };
+    })
+    .filter((update): update is Update<Tag> => !!update);
+
+  if (tagUpdates.length) {
+    updatedState = updateTags(updatedState, tagUpdates);
+  }
+
+  return removeTaskFromPlannerDays(updatedState, task.id);
 };
 
 const handleDeleteTask = (
@@ -759,6 +889,12 @@ const createActionHandlers = (state: RootState, action: Action): ActionHandlerMa
       typeof TaskSharedActions.convertToMainTask
     >;
     return handleConvertToMainTask(state, task, parentTagIds, isPlanForToday);
+  },
+  [TaskSharedActions.convertToSubTask.type]: () => {
+    const { taskId, targetTaskId, afterTaskId } = action as ReturnType<
+      typeof TaskSharedActions.convertToSubTask
+    >;
+    return handleConvertToSubTask(state, taskId, targetTaskId, afterTaskId);
   },
   [TaskSharedActions.deleteTask.type]: () => {
     const { task } = action as ReturnType<typeof TaskSharedActions.deleteTask>;

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -47,6 +47,20 @@ export const TaskSharedActions = createActionGroup({
       } satisfies PersistentActionMeta,
     }),
 
+    convertToSubTask: (taskProps: {
+      taskId: string;
+      targetTaskId: string;
+      afterTaskId: string | null;
+    }) => ({
+      ...taskProps,
+      meta: {
+        isPersistent: true,
+        entityType: 'TASK',
+        entityId: taskProps.taskId,
+        opType: OpType.Update,
+      } satisfies PersistentActionMeta,
+    }),
+
     deleteTask: (taskProps: { task: TaskWithSubTasks }) => ({
       ...taskProps,
       meta: {


### PR DESCRIPTION
## Summary

- allow dragging a top-level task into another task's subtask list to convert it into a subtask
- preserve existing subtask-to-subtask drag behavior while blocking repeating, issue-linked, self, and circular conversions
- clean converted tasks out of project, backlog, tag, Today, planner, and section top-level lists
- update the subtask docs for the new drag conversion flow

Fixes #905

## Verification

- `npm run checkFile src/app/root-store/meta/task-shared.actions.ts`
- `npm run checkFile src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts`
- `npm run checkFile src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts`
- `npm run checkFile src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts`
- `npm run checkFile src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts`
- `npm run checkFile src/app/features/tasks/task-list/task-list.component.ts`
- `npm run checkFile src/app/features/tasks/task-list/task-list.component.spec.ts`
- `npm run test:file src/app/features/tasks/task-list/task-list.component.spec.ts`
- `npm run test:file src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts`
- `npm run test:file src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 git push -u fork apxlbs/drag-task-to-subtask` pre-push hook, including lint, package tests, main Angular suite, and LA timezone suite
