### PR TITLE
Improve wording capitalization

### DIFF
--- a/src/app/core/error-handler/global-error-handler.util.ts
+++ b/src/app/core/error-handler/global-error-handler.util.ts
@@ -315,7 +315,7 @@ const getGithubIssueErrorMarkdown = (
 
 
 
-### Url
+### URL
 ${window.location.href}
 
 ${typeof origErr === 'object' && origErr && 'additionalLog' in origErr ? `### AL\n${origErr.additionalLog}` : ''}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2843,7 +2843,7 @@
     "LATER_TODAY": "Later Today",
     "MOVE_DONE_TO_ARCHIVE": "Move completed tasks to archive",
     "NO_DONE_TASKS": "There are currently no completed tasks",
-    "NO_PLANNED_TASK_ALL_DONE": "all tasks completed",
+    "NO_PLANNED_TASK_ALL_DONE": "All tasks completed",
     "NO_PLANNED_TASKS": "No tasks planned",
     "NO_TASKS_IN_MAIN_LIST": "All tasks are organized into sections",
     "RECURRING_TASKS": "Recurring Tasks",


### PR DESCRIPTION
This updates two small user-facing labels so the empty-task message starts with a capital letter and the error report section uses the standard uppercase URL spelling. It closes #4649.