### PR TITLE
fix(tasks): persist collapsed section state across project switches

### DIFF
--- a/src/app/features/section/section.model.ts
+++ b/src/app/features/section/section.model.ts
@@ -6,6 +6,7 @@ export interface Section {
   contextId: string;
   contextType: WorkContextType;
   title: string;
+  isExpanded?: boolean;
   taskIds: string[];
 }
 

--- a/src/app/features/section/section.service.ts
+++ b/src/app/features/section/section.service.ts
@@ -50,6 +50,7 @@ export class SectionService {
           contextId,
           contextType,
           title: sanitizeSectionTitle(title),
+          isExpanded: true,
           taskIds: [],
         },
       }),

--- a/src/app/features/section/store/section.reducer.spec.ts
+++ b/src/app/features/section/store/section.reducer.spec.ts
@@ -16,6 +16,7 @@ const makeSection = (overrides: Partial<Section> = {}): Section => ({
   contextId: 'project1',
   contextType: WorkContextType.PROJECT,
   title: 'Section 1',
+  isExpanded: true,
   taskIds: [],
   ...overrides,
 });
@@ -36,6 +37,7 @@ describe('sectionReducer', () => {
           contextId: 'p1',
           contextType: WorkContextType.PROJECT,
           title: 'New',
+          isExpanded: true,
         } as Section,
       });
       const next = sectionReducer(initialSectionState, action);
@@ -112,6 +114,15 @@ describe('sectionReducer', () => {
         }),
       );
       expect(nextNull.entities['s1']?.title).toBe('');
+    });
+
+    it('updates isExpanded property', () => {
+      const start = stateWithSections([makeSection({ id: 's1', isExpanded: true })]);
+      const next = sectionReducer(
+        start,
+        updateSection({ section: { id: 's1', changes: { isExpanded: false } } }),
+      );
+      expect(next.entities['s1']?.isExpanded).toBe(false);
     });
   });
 

--- a/src/app/features/section/store/section.selectors.ts
+++ b/src/app/features/section/store/section.selectors.ts
@@ -9,8 +9,10 @@ export const selectAllSections = createSelector(selectSectionFeatureState, selec
 
 export const selectSectionById = createSelector(
   selectSectionFeatureState,
-  (state: SectionState, props: { id: string }): Section | undefined =>
-    state.entities[props.id],
+  (state: SectionState, props: { id: string }): Section | undefined => {
+    const s = state.entities[props.id];
+    return s && s.isExpanded === undefined ? { ...s, isExpanded: true } : s;
+  },
 );
 
 /**
@@ -23,11 +25,12 @@ export const selectSectionsByContextIdMap = createSelector(
   (sections): Map<string, Section[]> => {
     const map = new Map<string, Section[]>();
     for (const s of sections) {
-      const arr = map.get(s.contextId);
+      const section = s.isExpanded === undefined ? { ...s, isExpanded: true } : s;
+      const arr = map.get(section.contextId);
       if (arr) {
-        arr.push(s);
+        arr.push(section);
       } else {
-        map.set(s.contextId, [s]);
+        map.set(section.contextId, [section]);
       }
     }
     return map;

--- a/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
@@ -1289,4 +1289,26 @@ describe('TaskViewCustomizerService', () => {
       });
     });
   });
+
+  describe('collapsedGroupIds', () => {
+    it('should toggle group expansion', () => {
+      service.toggleGroupExpansion('group1');
+      expect(service.collapsedGroupIds()).toContain('group1');
+      service.toggleGroupExpansion('group1');
+      expect(service.collapsedGroupIds()).not.toContain('group1');
+    });
+
+    it('should persist collapsedGroupIds to localStorage', (done) => {
+      service.toggleGroupExpansion('group2');
+
+      // The effect is async, so we wait a bit
+      setTimeout(() => {
+        const stored = JSON.parse(
+          localStorage.getItem(LS.TASK_VIEW_CUSTOMIZER_BY_CONTEXT) || '{}',
+        );
+        expect(stored['TAG:TODAY'].collapsedGroupIds).toContain('group2');
+        done();
+      }, 50);
+    });
+  });
 });

--- a/src/app/features/task-view-customizer/task-view-customizer.service.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.ts
@@ -55,6 +55,7 @@ export class TaskViewCustomizerService {
   public selectedSort = signal<SortOption>(DEFAULT_OPTIONS.sort);
   public selectedGroup = signal<GroupOption>(DEFAULT_OPTIONS.group);
   public selectedFilter = signal<FilterOption>(DEFAULT_OPTIONS.filter);
+  public collapsedGroupIds = signal<string[]>([]);
 
   isCustomized = computed(() => {
     return [
@@ -93,19 +94,30 @@ export class TaskViewCustomizerService {
         this.selectedSort.set(stored?.sort ?? DEFAULT_OPTIONS.sort);
         this.selectedGroup.set(this._sanitizeGroupForContext(stored?.group, activeType));
         this.selectedFilter.set(stored?.filter ?? DEFAULT_OPTIONS.filter);
+        this.collapsedGroupIds.set(stored?.collapsedGroupIds ?? []);
       });
 
     effect(() => {
       const sort = this.selectedSort();
       const group = this.selectedGroup();
       const filter = this.selectedFilter();
+      const collapsedGroupIds = this.collapsedGroupIds();
       if (!this._currentContextKey) return;
       this._stateByContext = {
         ...this._stateByContext,
-        [this._currentContextKey]: { sort, group, filter },
+        [this._currentContextKey]: { sort, group, filter, collapsedGroupIds },
       };
       lsSetJSON(LS.TASK_VIEW_CUSTOMIZER_BY_CONTEXT, this._stateByContext);
     });
+  }
+
+  toggleGroupExpansion(groupId: string): void {
+    const current = this.collapsedGroupIds();
+    if (current.includes(groupId)) {
+      this.collapsedGroupIds.set(current.filter((id) => id !== groupId));
+    } else {
+      this.collapsedGroupIds.set([...current, groupId]);
+    }
   }
 
   private _allProjects: Project[] = [];

--- a/src/app/features/task-view-customizer/types.ts
+++ b/src/app/features/task-view-customizer/types.ts
@@ -78,6 +78,7 @@ export interface CustomizerContextState {
   sort: SortOption;
   group: GroupOption;
   filter: FilterOption;
+  collapsedGroupIds: string[];
 }
 
 export const DEFAULT_OPTIONS = {

--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -125,7 +125,8 @@
               <collapsible
                 [title]="group.key | scheduledDateGroup"
                 [isIconBefore]="true"
-                [isExpanded]="true"
+                [isExpanded]="!customizerService.collapsedGroupIds().includes(group.key)"
+                (isExpandedChange)="customizerService.toggleGroupExpansion(group.key)"
                 [isGroup]="true"
               >
                 <task-list
@@ -166,7 +167,10 @@
                   <collapsible
                     [title]="section.title"
                     [isIconBefore]="true"
-                    [isExpanded]="true"
+                    [isExpanded]="section.isExpanded"
+                    (isExpandedChange)="
+                      sectionService.updateSection(section.id, { isExpanded: $event })
+                    "
                     [isTitleDragHandle]="true"
                   >
                     <ng-container actions>


### PR DESCRIPTION
## Problem

Collapsed sections lose their state when switching between projects/work contexts.
This causes previously minimized sections to expand again after navigating away and returning.

fixes: #7462

## Solution

Persist the collapsed section state instead of keeping it only in temporary UI state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
