### PR TITLE
fix(electron): use template tray icons on macOS

### DIFF
--- a/electron/indicator.ts
+++ b/electron/indicator.ts
@@ -106,11 +106,15 @@ export const initIndicator = ({
     forceDarkTray,
   };
   DIR = ICONS_FOLDER + 'indicator/';
+  // On macOS we always load the black (`-l`) icons and mark them as template
+  // images in getTrayImage(); the system auto-inverts them for the current
+  // menu bar appearance, so the static dark/light choice doesn't apply.
   shouldUseDarkColors =
-    forceDarkTray ||
-    IS_LINUX ||
-    (IS_WINDOWS && !isWindows11()) ||
-    nativeTheme.shouldUseDarkColors;
+    !IS_MAC &&
+    (forceDarkTray ||
+      IS_LINUX ||
+      (IS_WINDOWS && !isWindows11()) ||
+      nativeTheme.shouldUseDarkColors);
 
   _showApp = showApp;
   _quitApp = quitApp;
@@ -552,8 +556,11 @@ let curIco: string | undefined;
 // GNOME AppIndicator can fall back to a generic "three dots" icon for
 // sandboxed Electron apps when given only a file path. Passing a NativeImage
 // keeps the actual pixel data attached to the tray item.
+// On macOS we also need a NativeImage so we can mark it as a template image —
+// the system then inverts it for the current menu bar appearance (light/dark,
+// highlight state, accessibility), so it stays visible on any background.
 const getTrayImage = (icoPath: string): string | Electron.NativeImage => {
-  if (!IS_LINUX) {
+  if (!IS_LINUX && !IS_MAC) {
     return icoPath;
   }
 
@@ -561,6 +568,10 @@ const getTrayImage = (icoPath: string): string | Electron.NativeImage => {
   if (image.isEmpty()) {
     log('Tray icon NativeImage is empty, falling back to icon path:', icoPath);
     return icoPath;
+  }
+
+  if (IS_MAC) {
+    image.setTemplateImage(true);
   }
 
   return image;


### PR DESCRIPTION
## Problem

On macOS, the menu-bar tray icon is loaded as a static black-on-transparent or white-on-transparent PNG, chosen once at startup from `nativeTheme.shouldUseDarkColors`. When the menu bar appearance later differs from that initial choice (system theme change, wallpaper-driven menu bar darkness, etc.) the icon stays black on a dark menu bar (or white on a light one) and is effectively invisible.

## Solution

Use the existing `-l` (black-on-transparent) icons on macOS unconditionally and mark them as template images via `nativeImage.setTemplateImage(true)`. macOS auto-inverts template images for the current menu bar appearance, including the highlight state when the menu is open and accessibility inverted-colors, so the icon stays visible on any background without manual theme tracking.

Linux and Windows behavior is unchanged. `--force-dark-tray` is now a no-op on macOS because template images make manual forcing unnecessary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/wiki (N/A, internal Electron fix with no user-facing docs)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (N/A, existing `electron/indicator.test.cjs` still passes; the macOS template-image path is platform-specific and not covered by the Node-based mock suite)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)