### PR TITLE
feat(focus-mode): show flowtime and countdown timer in browser tab ti…

### DIFF
--- a/src/app/core/browser-title/browser-title.service.spec.ts
+++ b/src/app/core/browser-title/browser-title.service.spec.ts
@@ -56,7 +56,7 @@ describe('BrowserTitleService', () => {
   });
 
   describe('_getTitle', () => {
-    it('should return base title when not in Pomodoro mode', () => {
+    it('should show elapsed time for Flowtime mode when running', () => {
       const result = (service as any)._getTitle(
         FocusModeMode.Flowtime,
         1500000,
@@ -64,10 +64,38 @@ describe('BrowserTitleService', () => {
         true,
         false,
         false,
+        30000,
+      );
+
+      expect(result).toBe('00:30');
+    });
+
+    it('should show "Paused" for Flowtime mode when paused', () => {
+      const result = (service as any)._getTitle(
+        FocusModeMode.Flowtime,
+        0,
+        false,
+        false,
+        true,
+        false,
+        120000,
+      );
+
+      expect(result).toBe('Paused 02:00');
+    });
+
+    it('should show remaining time for Countdown mode when running', () => {
+      const result = (service as any)._getTitle(
+        FocusModeMode.Countdown,
+        600000,
+        false,
+        true,
+        false,
+        false,
         0,
       );
 
-      expect(result).toBe('Super Productivity');
+      expect(result).toBe('10:00');
     });
 
     it('should return base title when in Pomodoro but not running or paused', () => {
@@ -95,7 +123,7 @@ describe('BrowserTitleService', () => {
         0,
       );
 
-      expect(result).toBe('(25:00) Super Productivity');
+      expect(result).toBe('25:00');
     });
 
     it('should show "Paused" when paused', () => {
@@ -109,7 +137,7 @@ describe('BrowserTitleService', () => {
         0,
       );
 
-      expect(result).toBe('(Paused 25:00) Super Productivity');
+      expect(result).toBe('Paused 25:00');
     });
 
     it('should show "Break" when break is active', () => {
@@ -123,7 +151,7 @@ describe('BrowserTitleService', () => {
         0,
       );
 
-      expect(result).toBe('(05:00 Break) Super Productivity');
+      expect(result).toBe('05:00 (Break)');
     });
 
     it('should show both "Paused" and "Break" when both are active', () => {
@@ -137,7 +165,7 @@ describe('BrowserTitleService', () => {
         0,
       );
 
-      expect(result).toBe('(Paused 05:00 Break) Super Productivity');
+      expect(result).toBe('Paused 05:00 (Break)');
     });
 
     it('should show elapsed time during overtime', () => {
@@ -151,7 +179,7 @@ describe('BrowserTitleService', () => {
         1560000,
       );
 
-      expect(result).toBe('(26:00) Super Productivity');
+      expect(result).toBe('26:00');
     });
 
     it('should show elapsed break time during overtime', () => {
@@ -165,7 +193,7 @@ describe('BrowserTitleService', () => {
         360000,
       );
 
-      expect(result).toBe('(06:00 Break) Super Productivity');
+      expect(result).toBe('06:00 (Break)');
     });
 
     it('should pad single digit minutes correctly', () => {
@@ -179,7 +207,7 @@ describe('BrowserTitleService', () => {
         0,
       );
 
-      expect(result).toBe('(05:00) Super Productivity');
+      expect(result).toBe('05:00');
     });
   });
 
@@ -190,25 +218,21 @@ describe('BrowserTitleService', () => {
 
       TestBed.flushEffects();
 
-      expect(titleService.setTitle).toHaveBeenCalledWith('(24:59) Super Productivity');
+      expect(titleService.setTitle).toHaveBeenCalledWith('24:59');
 
       focusModeServiceMock.isBreakActive.set(true);
       focusModeServiceMock.timeRemaining.set(299000);
 
       TestBed.flushEffects();
 
-      expect(titleService.setTitle).toHaveBeenCalledWith(
-        '(04:59 Break) Super Productivity',
-      );
+      expect(titleService.setTitle).toHaveBeenCalledWith('04:59 (Break)');
 
       focusModeServiceMock.isRunning.set(false);
       focusModeServiceMock.isSessionPaused.set(true);
 
       TestBed.flushEffects();
 
-      expect(titleService.setTitle).toHaveBeenCalledWith(
-        '(Paused 04:59 Break) Super Productivity',
-      );
+      expect(titleService.setTitle).toHaveBeenCalledWith('Paused 04:59 (Break)');
 
       focusModeServiceMock.isSessionPaused.set(false);
       focusModeServiceMock.isRunning.set(true);
@@ -217,11 +241,17 @@ describe('BrowserTitleService', () => {
 
       TestBed.flushEffects();
 
-      expect(titleService.setTitle).toHaveBeenCalledWith(
-        '(26:00 Break) Super Productivity',
-      );
+      expect(titleService.setTitle).toHaveBeenCalledWith('26:00 (Break)');
 
       focusModeServiceMock.mode.set(FocusModeMode.Flowtime);
+      focusModeServiceMock.timeElapsed.set(60000);
+
+      TestBed.flushEffects();
+
+      expect(titleService.setTitle).toHaveBeenCalledWith('01:00 (Break)');
+
+      focusModeServiceMock.isRunning.set(false);
+      focusModeServiceMock.isSessionPaused.set(false);
 
       TestBed.flushEffects();
 

--- a/src/app/core/browser-title/browser-title.service.spec.ts
+++ b/src/app/core/browser-title/browser-title.service.spec.ts
@@ -70,7 +70,7 @@ describe('BrowserTitleService', () => {
       expect(result).toBe('00:30');
     });
 
-    it('should show "Paused" for Flowtime mode when paused', () => {
+    it('should show "Paused" for Flowtime mode when paused and time has elapsed', () => {
       const result = (service as any)._getTitle(
         FocusModeMode.Flowtime,
         0,
@@ -82,6 +82,48 @@ describe('BrowserTitleService', () => {
       );
 
       expect(result).toBe('Paused 02:00');
+    });
+
+    it('should show remaining time for Flowtime break offer (not running, zero elapsed)', () => {
+      const result = (service as any)._getTitle(
+        FocusModeMode.Flowtime,
+        300000,
+        true,
+        false,
+        true,
+        false,
+        0,
+      );
+
+      expect(result).toBe('05:00 (Break)');
+    });
+
+    it('should show remaining time for active Flowtime break', () => {
+      const result = (service as any)._getTitle(
+        FocusModeMode.Flowtime,
+        270000,
+        true,
+        true,
+        false,
+        false,
+        30000,
+      );
+
+      expect(result).toBe('04:30 (Break)');
+    });
+
+    it('should show "Paused" and remaining time for paused Flowtime break', () => {
+      const result = (service as any)._getTitle(
+        FocusModeMode.Flowtime,
+        270000,
+        true,
+        false,
+        true,
+        false,
+        30000,
+      );
+
+      expect(result).toBe('Paused 04:30 (Break)');
     });
 
     it('should show remaining time for Countdown mode when running', () => {
@@ -154,7 +196,7 @@ describe('BrowserTitleService', () => {
       expect(result).toBe('05:00 (Break)');
     });
 
-    it('should show both "Paused" and "Break" when both are active', () => {
+    it('should show both "Paused" and "Break" when both are active and time elapsed', () => {
       const result = (service as any)._getTitle(
         FocusModeMode.Pomodoro,
         300000,
@@ -162,7 +204,7 @@ describe('BrowserTitleService', () => {
         false,
         true,
         false,
-        0,
+        1000,
       );
 
       expect(result).toBe('Paused 05:00 (Break)');
@@ -229,6 +271,7 @@ describe('BrowserTitleService', () => {
 
       focusModeServiceMock.isRunning.set(false);
       focusModeServiceMock.isSessionPaused.set(true);
+      focusModeServiceMock.timeElapsed.set(1000);
 
       TestBed.flushEffects();
 

--- a/src/app/core/browser-title/browser-title.service.ts
+++ b/src/app/core/browser-title/browser-title.service.ts
@@ -41,8 +41,9 @@ export class BrowserTitleService {
     isInOvertime: boolean,
     timeElapsed: number,
   ): string {
-    if (mode === FocusModeMode.Pomodoro && (isRunning || isSessionPaused)) {
-      const displayTime = isInOvertime ? timeElapsed : timeRemaining;
+    if (isRunning || isSessionPaused) {
+      const isCountTimeDown = mode !== FocusModeMode.Flowtime;
+      const displayTime = isCountTimeDown && !isInOvertime ? timeRemaining : timeElapsed;
 
       const timeStr = msToMinuteClockString(displayTime);
 
@@ -50,14 +51,16 @@ export class BrowserTitleService {
       const formattedTime = `${minutes.padStart(2, '0')}:${seconds}`;
 
       const breakStr = isBreakActive
-        ? ` ${this._translateService.instant(T.F.FOCUS_MODE.BROWSER_TITLE_BREAK)}`
+        ? ` (${this._translateService.instant(T.F.FOCUS_MODE.BROWSER_TITLE_BREAK)})`
         : '';
 
-      const pausedStr = isSessionPaused
-        ? `${this._translateService.instant(T.F.FOCUS_MODE.BROWSER_TITLE_PAUSED)} `
-        : '';
+      if (isSessionPaused) {
+        return `${this._translateService.instant(
+          T.F.FOCUS_MODE.BROWSER_TITLE_PAUSED,
+        )} ${formattedTime}${breakStr}`;
+      }
 
-      return `(${pausedStr}${formattedTime}${breakStr}) ${this._baseTitle}`;
+      return `${formattedTime}${breakStr}`;
     }
 
     return this._baseTitle;

--- a/src/app/core/browser-title/browser-title.service.ts
+++ b/src/app/core/browser-title/browser-title.service.ts
@@ -42,7 +42,7 @@ export class BrowserTitleService {
     timeElapsed: number,
   ): string {
     if (isRunning || isSessionPaused) {
-      const isCountTimeDown = mode !== FocusModeMode.Flowtime;
+      const isCountTimeDown = mode !== FocusModeMode.Flowtime || isBreakActive;
       const displayTime = isCountTimeDown && !isInOvertime ? timeRemaining : timeElapsed;
 
       const timeStr = msToMinuteClockString(displayTime);
@@ -54,7 +54,9 @@ export class BrowserTitleService {
         ? ` (${this._translateService.instant(T.F.FOCUS_MODE.BROWSER_TITLE_BREAK)})`
         : '';
 
-      if (isSessionPaused) {
+      const isActuallyPaused = isSessionPaused && !(isBreakActive && timeElapsed === 0);
+
+      if (isActuallyPaused) {
         return `${this._translateService.instant(
           T.F.FOCUS_MODE.BROWSER_TITLE_PAUSED,
         )} ${formattedTime}${breakStr}`;


### PR DESCRIPTION
…tle and removes app name during timer

## Problem

Currently, the browser tab title countdown is only shown for Pomodoro sessions.

Flowtime and Countdown sessions do not update the browser tab title, which makes it harder to monitor active sessions while working in other tabs or applications.

Additionally, the current tab title format includes the app name suffix:

(24:15) Super Productivity

This makes the most important information (remaining time) less prominent and can get truncated in narrower tabs.

Fixes: #7612

## Solution

Display the active Flowtime timer and countdown timer countdown directly in the browser tab title.
Removes App name from title when focus mode is on.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
