### PR TITLE
feat(tasks): convert tasks to subtasks by drag drop

### DIFF
--- a/docs/wiki/2.04-Manage-Subtasks.md
+++ b/docs/wiki/2.04-Manage-Subtasks.md
@@ -33,7 +33,7 @@ Drag the subtask by its **drag handle** and drop it onto the target parent task,
 
 Drag a top-level task by its **drag handle** and drop it into another task, or into that task’s subtask list. The task becomes a subtask of the target parent and moves into that parent’s project.
 
-Tasks that already have subtasks cannot be converted this way, because that would create a deeper hierarchy. Repeating tasks and issue-linked tasks also stay as top-level tasks.
+Tasks that already have subtasks cannot be converted this way, because that would create a deeper hierarchy. Repeating, scheduled, reminder, and issue-linked tasks also stay as top-level tasks.
 
 ## Convert a Subtask to a Main Task
 

--- a/docs/wiki/2.04-Manage-Subtasks.md
+++ b/docs/wiki/2.04-Manage-Subtasks.md
@@ -29,6 +29,12 @@ Shortcuts are configurable in [[3.02-Settings-and-Preferences]].
 
 Drag the subtask by its **drag handle** and drop it onto the target parent task, or into that parent’s subtask list. The subtask becomes a child of the new parent and keeps the same project (subtasks inherit the parent’s project).
 
+## Convert a Main Task to a Subtask
+
+Drag a top-level task by its **drag handle** and drop it into another task, or into that task’s subtask list. The task becomes a subtask of the target parent and moves into that parent’s project.
+
+Tasks that already have subtasks cannot be converted this way, because that would create a deeper hierarchy. Repeating tasks and issue-linked tasks also stay as top-level tasks.
+
 ## Convert a Subtask to a Main Task
 
 Right-click the subtask and click **Convert to parent task**. The subtask becomes a top-level task in the same project. Repeating tasks and issue-linked tasks cannot be converted to subtasks; see [[4.11-Subtasks]].

--- a/docs/wiki/4.11-Subtasks.md
+++ b/docs/wiki/4.11-Subtasks.md
@@ -21,8 +21,9 @@ Not every task can be turned into a subtask, and some behaviors are constrained 
 
 ### Tasks That Cannot Be Converted to Subtasks
 
-Two kinds of tasks **cannot** be converted into subtasks:
+Three kinds of tasks **cannot** be converted into subtasks:
 
+- **Tasks that already have subtasks**: Converting these would create a deeper hierarchy than the main drag-and-drop workflow supports. Move or convert the existing subtasks first, then convert the parent task.
 - **Repeating tasks** — Tasks that recur on a schedule (for example daily or weekly) cannot be made subtasks of another task. See [[4.13-Repeating-Tasks]]. The repeat rule applies to a single task; nesting would conflict with that.
 - **Issue-linked tasks** — Tasks that are linked to an external issue (for example Jira or GitHub) cannot be made subtasks. The issue link is a one-to-one relationship between a task and an issue; the app does not support issue-linked subtasks in the same way.
 

--- a/docs/wiki/4.11-Subtasks.md
+++ b/docs/wiki/4.11-Subtasks.md
@@ -21,10 +21,11 @@ Not every task can be turned into a subtask, and some behaviors are constrained 
 
 ### Tasks That Cannot Be Converted to Subtasks
 
-Three kinds of tasks **cannot** be converted into subtasks:
+Four kinds of tasks **cannot** be converted into subtasks:
 
 - **Tasks that already have subtasks**: Converting these would create a deeper hierarchy than the main drag-and-drop workflow supports. Move or convert the existing subtasks first, then convert the parent task.
 - **Repeating tasks** — Tasks that recur on a schedule (for example daily or weekly) cannot be made subtasks of another task. See [[4.13-Repeating-Tasks]]. The repeat rule applies to a single task; nesting would conflict with that.
+- **Scheduled tasks or tasks with reminders** — Tasks with a due date, due time, or reminder stay as top-level tasks so their schedule and reminder state cannot become orphaned.
 - **Issue-linked tasks** — Tasks that are linked to an external issue (for example Jira or GitHub) cannot be made subtasks. The issue link is a one-to-one relationship between a task and an issue; the app does not support issue-linked subtasks in the same way.
 
 If you try to convert such a task to a subtask (for example by indenting it in a markdown-based workflow), the app will warn you and leave the task as a top-level task. You can still create normal subtasks under a parent and use repeating or issue-linked tasks alongside them as separate tasks.

--- a/src/app/features/schedule/schedule-week/schedule-external-drag.service.ts
+++ b/src/app/features/schedule/schedule-week/schedule-external-drag.service.ts
@@ -5,7 +5,7 @@ import { DragRef } from '@angular/cdk/drag-drop';
 @Injectable({ providedIn: 'root' })
 export class ScheduleExternalDragService {
   private readonly _activeTask = signal<TaskWithSubTasks | null>(null);
-  private _activeDragRef: DragRef | null = null;
+  private readonly _activeDragRef = signal<DragRef | null>(null);
   private _cancelNextDrop: boolean = false;
 
   setCancelNextDrop(val: boolean): void {
@@ -21,11 +21,11 @@ export class ScheduleExternalDragService {
   }
 
   activeDragRef(): DragRef | null {
-    return this._activeDragRef;
+    return this._activeDragRef();
   }
 
   setActiveTask(task: TaskWithSubTasks | null, dragRef: DragRef | null = null): void {
     this._activeTask.set(task);
-    this._activeDragRef = dragRef;
+    this._activeDragRef.set(dragRef);
   }
 }

--- a/src/app/features/tasks/task-list/task-list.component.html
+++ b/src/app/features/tasks/task-list/task-list.component.html
@@ -45,6 +45,7 @@
       [cdkDragLockAxis]="isXs() ? 'y' : ''"
       [cdkDragDisabled]="listModelId() === 'LATER_TODAY'"
       [cdkDragData]="task"
+      (pointerdown)="onDragPrepared(task)"
       (cdkDragStarted)="onDragStarted(task, $event)"
       (cdkDragEnded)="onDragEnded()"
     >

--- a/src/app/features/tasks/task-list/task-list.component.html
+++ b/src/app/features/tasks/task-list/task-list.component.html
@@ -45,7 +45,6 @@
       [cdkDragLockAxis]="isXs() ? 'y' : ''"
       [cdkDragDisabled]="listModelId() === 'LATER_TODAY'"
       [cdkDragData]="task"
-      (pointerdown)="onDragPrepared(task)"
       (cdkDragStarted)="onDragStarted(task, $event)"
       (cdkDragEnded)="onDragEnded()"
     >

--- a/src/app/features/tasks/task-list/task-list.component.spec.ts
+++ b/src/app/features/tasks/task-list/task-list.component.spec.ts
@@ -14,6 +14,7 @@ import { TaskWithSubTasks } from '../task.model';
 import { SectionService } from '../../section/section.service';
 import { moveSubTask } from '../store/task.actions';
 import { WorkContextType } from '../../work-context/work-context.model';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 
 describe('TaskListComponent', () => {
   let component: TaskListComponent;
@@ -21,10 +22,15 @@ describe('TaskListComponent', () => {
   let sectionServiceMock: jasmine.SpyObj<SectionService>;
   let store: MockStore;
 
+  type MockTaskWithNullableParent = Partial<Omit<TaskWithSubTasks, 'parentId'>> & {
+    id: string;
+    parentId?: string | null;
+  };
+
   // Helper to create mock CdkDrag
-  const createMockDrag = (task: { id: string; parentId: string | null }): CdkDrag =>
+  const createMockDrag = (task: MockTaskWithNullableParent): CdkDrag =>
     ({
-      data: task,
+      data: { subTaskIds: [], ...task },
     }) as unknown as CdkDrag;
 
   // Helper to create mock CdkDropList with allTasks. listId defaults to
@@ -64,6 +70,7 @@ describe('TaskListComponent', () => {
         {
           provide: ScheduleExternalDragService,
           useValue: {
+            activeTask: () => null,
             setActiveTask: () => {},
             isCancelNextDrop: () => false,
             setCancelNextDrop: () => {},
@@ -194,10 +201,38 @@ describe('TaskListComponent', () => {
         expect(component.enterPredicate(drag, drop)).toBe(true);
       });
 
-      it('should block parent task from dropping to subtask list', () => {
+      it('should allow parent task without subtasks to drop to subtask list', () => {
         const task = { id: 'task1', parentId: null };
         const drag = createMockDrag(task);
         // Task ID listed as a subtask drop-list (listId='SUB').
+        const drop = createMockDrop('some-task-id', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(true);
+      });
+
+      it('should block parent task with subtasks from dropping to subtask list', () => {
+        const task = { id: 'task1', parentId: null, subTaskIds: ['child1'] };
+        const drag = createMockDrag(task);
+        const drop = createMockDrop('some-task-id', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(false);
+      });
+
+      it('should block repeating parent task from dropping to subtask list', () => {
+        const task = { id: 'task1', parentId: null, repeatCfgId: 'repeat1' };
+        const drag = createMockDrag(task);
+        const drop = createMockDrop('some-task-id', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(false);
+      });
+
+      it('should block issue-linked parent task from dropping to subtask list', () => {
+        const task = { id: 'task1', parentId: null, issueId: 'issue1' };
+        const drag = createMockDrag(task);
+        const drop = createMockDrop('some-task-id', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(false);
+      });
+
+      it('should block parent task with issue provider from dropping to subtask list', () => {
+        const task = { id: 'task1', parentId: null, issueProviderId: 'github' };
+        const drag = createMockDrag(task);
         const drop = createMockDrop('some-task-id', [], 'SUB');
         expect(component.enterPredicate(drag, drop)).toBe(false);
       });
@@ -358,6 +393,18 @@ describe('TaskListComponent', () => {
       expect(dispatchedAction.taskId).toBe('sub1');
       expect(dispatchedAction.srcTaskId).toBe('parentA');
       expect(dispatchedAction.targetTaskId).toBe('parentB');
+    });
+
+    it('routes a parent drop into a subtask list to convertToSubTask', () => {
+      callMove('task1', 'UNDONE', 'parentA', 'PARENT', 'SUB', ['sub1', 'task1']);
+
+      expect(sectionServiceMock.addTaskToSection).not.toHaveBeenCalled();
+      const dispatchedAction = (store.dispatch as jasmine.Spy).calls.mostRecent()
+        .args[0] as ReturnType<typeof TaskSharedActions.convertToSubTask>;
+      expect(dispatchedAction.type).toBe(TaskSharedActions.convertToSubTask.type);
+      expect(dispatchedAction.taskId).toBe('task1');
+      expect(dispatchedAction.targetParentId).toBe('parentA');
+      expect(dispatchedAction.afterTaskId).toBe('sub1');
     });
 
     it('routes a parent drop into a section drop-list (PARENT + non-reserved id) to addTaskToSection', () => {

--- a/src/app/features/tasks/task-list/task-list.component.spec.ts
+++ b/src/app/features/tasks/task-list/task-list.component.spec.ts
@@ -43,6 +43,7 @@ describe('TaskListComponent', () => {
     ({
       data: { listId, listModelId, allTasks },
     }) as unknown as CdkDropList;
+  const scheduledAt = 1779144000000;
 
   beforeEach(async () => {
     sectionServiceMock = jasmine.createSpyObj<SectionService>('SectionService', [
@@ -228,6 +229,19 @@ describe('TaskListComponent', () => {
         const drag = createMockDrag(task);
         const drop = createMockDrop('some-task-id', [], 'SUB');
         expect(component.enterPredicate(drag, drop)).toBe(false);
+      });
+
+      [
+        { label: 'dueWithTime', task: { dueWithTime: scheduledAt } },
+        { label: 'dueDay', task: { dueDay: '2026-05-19' } },
+        { label: 'remindAt', task: { remindAt: scheduledAt } },
+        { label: 'reminderId', task: { reminderId: 'reminder1' } },
+      ].forEach(({ label, task }) => {
+        it(`should block scheduled parent task with ${label} from dropping to subtask list`, () => {
+          const drag = createMockDrag({ id: 'task1', parentId: null, ...task });
+          const drop = createMockDrop('some-task-id', [], 'SUB');
+          expect(component.enterPredicate(drag, drop)).toBe(false);
+        });
       });
 
       it('should block parent task with issue provider from dropping to subtask list', () => {

--- a/src/app/features/tasks/task-list/task-list.component.spec.ts
+++ b/src/app/features/tasks/task-list/task-list.component.spec.ts
@@ -382,19 +382,37 @@ describe('TaskListComponent', () => {
       srcListId: 'PARENT' | 'SUB',
       targetListId: 'PARENT' | 'SUB',
       newOrderedIds: string[] = [taskId],
+      taskOverrides: Partial<TaskWithSubTasks> = {},
+      targetAllTaskIds: string[] = [],
     ): void => {
+      const task = {
+        id: taskId,
+        parentId: srcListId === 'SUB' ? src : undefined,
+        subTaskIds: [],
+        ...taskOverrides,
+      } as TaskWithSubTasks;
+
       (
         component as unknown as {
           _move: (
-            t: string,
+            t: TaskWithSubTasks,
             s: string,
             tg: string,
             sl: 'PARENT' | 'SUB',
             tl: 'PARENT' | 'SUB',
             ids: string[],
+            allIds?: string[],
           ) => void;
         }
-      )._move(taskId, src, target, srcListId, targetListId, newOrderedIds);
+      )._move(
+        task,
+        src,
+        target,
+        srcListId,
+        targetListId,
+        newOrderedIds,
+        targetAllTaskIds,
+      );
     };
 
     it('routes a subtask drop into another subtask list to moveSubTask (not addTaskToSection)', () => {
@@ -420,6 +438,27 @@ describe('TaskListComponent', () => {
       expect(dispatchedAction.taskId).toBe('task1');
       expect(dispatchedAction.targetParentId).toBe('parentA');
       expect(dispatchedAction.afterTaskId).toBe('sub1');
+    });
+
+    it('does not dispatch convertToSubTask when the parent task is not convertible', () => {
+      callMove('task1', 'UNDONE', 'parentA', 'PARENT', 'SUB', ['task1'], {
+        subTaskIds: ['child1'],
+      });
+
+      expect(sectionServiceMock.addTaskToSection).not.toHaveBeenCalled();
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('appends to existing subtasks when the target subtask list is hidden', () => {
+      callMove('task1', 'UNDONE', 'parentA', 'PARENT', 'SUB', ['task1'], {}, [
+        'existing-sub',
+        'last-sub',
+      ]);
+
+      const dispatchedAction = (store.dispatch as jasmine.Spy).calls.mostRecent()
+        .args[0] as ReturnType<typeof TaskSharedActions.convertToSubTask>;
+      expect(dispatchedAction.type).toBe(TaskSharedActions.convertToSubTask.type);
+      expect(dispatchedAction.afterTaskId).toBe('last-sub');
     });
 
     it('routes a parent drop into a section drop-list (PARENT + non-reserved id) to addTaskToSection', () => {

--- a/src/app/features/tasks/task-list/task-list.component.spec.ts
+++ b/src/app/features/tasks/task-list/task-list.component.spec.ts
@@ -72,6 +72,7 @@ describe('TaskListComponent', () => {
           provide: ScheduleExternalDragService,
           useValue: {
             activeTask: () => null,
+            activeDragRef: () => null,
             setActiveTask: () => {},
             isCancelNextDrop: () => false,
             setCancelNextDrop: () => {},

--- a/src/app/features/tasks/task-list/task-list.component.ts
+++ b/src/app/features/tasks/task-list/task-list.component.ts
@@ -73,6 +73,20 @@ const RESERVED_LIST_IDS = new Set<string>([
 ] satisfies DropListModelSource[]);
 const PARENT_ALLOWED_LISTS = ['DONE', 'UNDONE', 'OVERDUE', 'BACKLOG', 'ADD_TASK_PANEL'];
 
+const canConvertParentDropToSubTask = (
+  task: TaskWithSubTasks,
+  targetModelId: ListModelId,
+  targetListId: TaskListId,
+): boolean =>
+  targetListId === 'SUB' &&
+  !RESERVED_LIST_IDS.has(targetModelId) &&
+  targetModelId !== task.id &&
+  (task.subTaskIds?.length ?? 0) === 0 &&
+  !task.repeatCfgId &&
+  !task.issueId &&
+  !task.issueProviderId &&
+  !task.issueType;
+
 export interface DropModelDataForList {
   listId: TaskListId;
   listModelId: ListModelId;
@@ -213,12 +227,16 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
       return false;
     }
 
-    // Parent tasks: allow drops to PARENT_ALLOWED_LISTS or to sections (parent-level
-    // lists with a non-reserved id). Subtask drop-lists (listId === 'SUB') are
-    // rejected so a top-level task can't be nested into another task's subtree.
+    // Parent tasks: allow drops to PARENT_ALLOWED_LISTS, to sections (parent-level
+    // lists with a non-reserved id), or into another task's subtask list when
+    // the move does not create nested subtasks or unsupported linked subtasks.
     const srcModelId = drag.dropContainer?.data?.listModelId;
     const srcListIdRaw = drag.dropContainer?.data?.listId;
     const isSrcSection = srcListIdRaw === 'PARENT' && !RESERVED_LIST_IDS.has(srcModelId);
+
+    if (canConvertParentDropToSubTask(task, targetModelId, targetListId)) {
+      return true;
+    }
 
     if (PARENT_ALLOWED_LISTS.includes(targetModelId)) {
       // Reject section → BACKLOG: _move() dispatches `removeTaskFromSection`
@@ -360,6 +378,22 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
 
     // Handle LATER_TODAY - prevent any moves to or from this list
     if (src === 'LATER_TODAY' || target === 'LATER_TODAY') {
+      return;
+    }
+
+    if (
+      srcListId === 'PARENT' &&
+      targetListId === 'SUB' &&
+      !RESERVED_LIST_IDS.has(target)
+    ) {
+      const afterTaskId = getAnchorFromDragDrop(taskId, newOrderedIds);
+      this._store.dispatch(
+        TaskSharedActions.convertToSubTask({
+          taskId,
+          targetParentId: target as string,
+          afterTaskId,
+        }),
+      );
       return;
     }
 

--- a/src/app/features/tasks/task-list/task-list.component.ts
+++ b/src/app/features/tasks/task-list/task-list.component.ts
@@ -195,37 +195,6 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
     this._scheduleExternalDragService.setActiveTask(task, event.source._dragRef);
   }
 
-  onDragPrepared(task: TaskWithSubTasks): void {
-    if (this.listModelId() === 'LATER_TODAY') {
-      return;
-    }
-
-    this._scheduleExternalDragService.setActiveTask(task);
-
-    const abortController = new AbortController();
-    const cleanup = (): void => {
-      abortController.abort();
-      window.setTimeout(() => {
-        const activeTask = this._scheduleExternalDragService.activeTask();
-        if (
-          activeTask?.id === task.id &&
-          !this._scheduleExternalDragService.activeDragRef()
-        ) {
-          this._scheduleExternalDragService.setActiveTask(null);
-        }
-      });
-    };
-
-    document.addEventListener('pointerup', cleanup, {
-      once: true,
-      signal: abortController.signal,
-    });
-    document.addEventListener('pointercancel', cleanup, {
-      once: true,
-      signal: abortController.signal,
-    });
-  }
-
   onDragEnded(): void {
     this._scheduleExternalDragService.setActiveTask(null);
   }

--- a/src/app/features/tasks/task-list/task-list.component.ts
+++ b/src/app/features/tasks/task-list/task-list.component.ts
@@ -84,6 +84,18 @@ const canConvertParentDropToSubTask = (
   targetModelId !== task.id &&
   canConvertTaskToSubTask(task);
 
+const getConvertToSubTaskAfterTaskId = (
+  taskId: string,
+  newOrderedIds: string[],
+  targetAllTaskIds: string[],
+): string | null => {
+  const visibleIdsWithoutDraggedTask = newOrderedIds.filter((id) => id !== taskId);
+
+  return visibleIdsWithoutDraggedTask.length === 0 && targetAllTaskIds.length > 0
+    ? targetAllTaskIds[targetAllTaskIds.length - 1]
+    : getAnchorFromDragDrop(taskId, newOrderedIds);
+};
+
 export interface DropModelDataForList {
   listId: TaskListId;
   listModelId: ListModelId;
@@ -366,12 +378,13 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
 
     this.dropListService.blockAniTrigger$.next();
     this._move(
-      draggedTask.id,
+      draggedTask,
       srcListData.listModelId,
       targetListData.listModelId,
       srcListData.listId,
       targetListData.listId,
       newIds.map((p) => p.id),
+      targetListData.allTasks.map((p) => p.id),
     );
 
     this._taskViewCustomizerService.setSort(DEFAULT_OPTIONS.sort);
@@ -393,13 +406,15 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
   }
 
   private _move(
-    taskId: string,
+    task: TaskWithSubTasks,
     src: DropListModelSource | string,
     target: DropListModelSource | string,
     srcListId: TaskListId,
     targetListId: TaskListId,
     newOrderedIds: string[],
+    targetAllTaskIds: string[] = [],
   ): void {
+    const taskId = task.id;
     const isSrcRegularList = src === 'DONE' || src === 'UNDONE';
     const isTargetRegularList = target === 'DONE' || target === 'UNDONE';
     const workContextId = this._workContextService.activeWorkContextId as string;
@@ -414,7 +429,15 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
       targetListId === 'SUB' &&
       !RESERVED_LIST_IDS.has(target)
     ) {
-      const afterTaskId = getAnchorFromDragDrop(taskId, newOrderedIds);
+      if (!canConvertParentDropToSubTask(task, target, targetListId)) {
+        return;
+      }
+
+      const afterTaskId = getConvertToSubTaskAfterTaskId(
+        taskId,
+        newOrderedIds,
+        targetAllTaskIds,
+      );
       this._store.dispatch(
         TaskSharedActions.convertToSubTask({
           taskId,

--- a/src/app/features/tasks/task-list/task-list.component.ts
+++ b/src/app/features/tasks/task-list/task-list.component.ts
@@ -46,6 +46,7 @@ import { ScheduleExternalDragService } from '../../schedule/schedule-week/schedu
 import { DEFAULT_OPTIONS } from '../../task-view-customizer/types';
 import { dragDelayForTouch } from '../../../util/input-intent';
 import { DateService } from '../../../core/date/date.service';
+import { canConvertTaskToSubTask } from '../util/can-convert-to-sub-task';
 
 export type TaskListId = 'PARENT' | 'SUB';
 export type ListModelId = DropListModelSource | string;
@@ -81,11 +82,7 @@ const canConvertParentDropToSubTask = (
   targetListId === 'SUB' &&
   !RESERVED_LIST_IDS.has(targetModelId) &&
   targetModelId !== task.id &&
-  (task.subTaskIds?.length ?? 0) === 0 &&
-  !task.repeatCfgId &&
-  !task.issueId &&
-  !task.issueProviderId &&
-  !task.issueType;
+  canConvertTaskToSubTask(task);
 
 export interface DropModelDataForList {
   listId: TaskListId;
@@ -184,6 +181,37 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
 
   onDragStarted(task: TaskWithSubTasks, event: CdkDragStart): void {
     this._scheduleExternalDragService.setActiveTask(task, event.source._dragRef);
+  }
+
+  onDragPrepared(task: TaskWithSubTasks): void {
+    if (this.listModelId() === 'LATER_TODAY') {
+      return;
+    }
+
+    this._scheduleExternalDragService.setActiveTask(task);
+
+    const abortController = new AbortController();
+    const cleanup = (): void => {
+      abortController.abort();
+      window.setTimeout(() => {
+        const activeTask = this._scheduleExternalDragService.activeTask();
+        if (
+          activeTask?.id === task.id &&
+          !this._scheduleExternalDragService.activeDragRef()
+        ) {
+          this._scheduleExternalDragService.setActiveTask(null);
+        }
+      });
+    };
+
+    document.addEventListener('pointerup', cleanup, {
+      once: true,
+      signal: abortController.signal,
+    });
+    document.addEventListener('pointercancel', cleanup, {
+      once: true,
+      signal: abortController.signal,
+    });
   }
 
   onDragEnded(): void {

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -216,6 +216,31 @@ describe('TaskComponent shortcut handling', () => {
     expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledWith('top-1');
   });
 
+  it('keeps the empty subtask drop target mounted for childless top-level tasks', () => {
+    fixture.componentRef.setInput('task', createTopLevelTask('Top-level task'));
+    fixture.componentRef.setInput('isInSubTaskList', false);
+
+    expect(component.isEmptySubTaskDropTargetMountable()).toBeTrue();
+    expect(component.isEmptySubTaskDropTargetVisible()).toBeFalse();
+  });
+
+  it('does not mount the empty subtask drop target for tasks with subtasks', () => {
+    fixture.componentRef.setInput('task', {
+      ...createTopLevelTask('Top-level task'),
+      subTaskIds: ['sub-1'],
+    });
+    fixture.componentRef.setInput('isInSubTaskList', false);
+
+    expect(component.isEmptySubTaskDropTargetMountable()).toBeFalse();
+  });
+
+  it('does not mount the empty subtask drop target inside subtask lists', () => {
+    fixture.componentRef.setInput('task', createTopLevelTask('Top-level task'));
+    fixture.componentRef.setInput('isInSubTaskList', true);
+
+    expect(component.isEmptySubTaskDropTargetMountable()).toBeFalse();
+  });
+
   it('persists the typed title before spawning a sibling on Mod+Enter', () => {
     fixture.componentRef.setInput('task', createSubTask(''));
 

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -252,28 +252,37 @@
         [progress]="progress()"
       ></progress-bar>
     }
-    @if (t.subTasks?.length) {
-      <div class="sub-tasks">
-        <button
-          (click)="toggleSubTaskMode()"
-          [title]="T.F.TASK.CMP.TOGGLE_SUB_TASK_VISIBILITY | translate"
-          class="toggle-sub-tasks-btn ico-btn mat-elevation-z2"
-          color=""
-          mat-mini-fab
-        >
-          @if (t._hideSubTasksMode === ShowSubTasksMode.HideAll) {
-            <mat-icon>add</mat-icon>
-          } @else {
-            <mat-icon
-              [class.isHideDoneTasks]="t._hideSubTasksMode === ShowSubTasksMode.HideDone"
-              >remove
-            </mat-icon>
-          }
-        </button>
+    @if (t.subTasks?.length || isEmptySubTaskDropTargetVisible()) {
+      <div
+        [class.is-empty-drop-target]="!t.subTasks?.length"
+        class="sub-tasks"
+      >
+        @if (t.subTasks?.length) {
+          <button
+            (click)="toggleSubTaskMode()"
+            [title]="T.F.TASK.CMP.TOGGLE_SUB_TASK_VISIBILITY | translate"
+            class="toggle-sub-tasks-btn ico-btn mat-elevation-z2"
+            color=""
+            mat-mini-fab
+          >
+            @if (t._hideSubTasksMode === ShowSubTasksMode.HideAll) {
+              <mat-icon>add</mat-icon>
+            } @else {
+              <mat-icon
+                [class.isHideDoneTasks]="
+                  t._hideSubTasksMode === ShowSubTasksMode.HideDone
+                "
+                >remove
+              </mat-icon>
+            }
+          </button>
+        }
         <task-list
           [@expandInOnly]
-          [isHideAll]="!!t._hideSubTasksMode"
-          [isHideDone]="t._hideSubTasksMode === ShowSubTasksMode.HideDone"
+          [isHideAll]="!!t.subTasks?.length && !!t._hideSubTasksMode"
+          [isHideDone]="
+            !!t.subTasks?.length && t._hideSubTasksMode === ShowSubTasksMode.HideDone
+          "
           [isSubTaskList]="true"
           [listModelId]="t.id"
           [parentId]="t.id"

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -252,11 +252,9 @@
         [progress]="progress()"
       ></progress-bar>
     }
-    @if (t.subTasks?.length || isEmptySubTaskDropTargetVisible()) {
+    @if (t.subTasks?.length || isEmptySubTaskDropTargetMountable()) {
       <div
-        [class.is-empty-drop-target]="
-          !t.subTasks?.length && isEmptySubTaskDropTargetActive()
-        "
+        [class.is-empty-drop-target]="isEmptySubTaskDropTargetActive()"
         [class.is-empty-drop-target-prepared]="
           !t.subTasks?.length && !isEmptySubTaskDropTargetActive()
         "

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -254,7 +254,12 @@
     }
     @if (t.subTasks?.length || isEmptySubTaskDropTargetVisible()) {
       <div
-        [class.is-empty-drop-target]="!t.subTasks?.length"
+        [class.is-empty-drop-target]="
+          !t.subTasks?.length && isEmptySubTaskDropTargetActive()
+        "
+        [class.is-empty-drop-target-prepared]="
+          !t.subTasks?.length && !isEmptySubTaskDropTargetActive()
+        "
         class="sub-tasks"
       >
         @if (t.subTasks?.length) {

--- a/src/app/features/tasks/task/task.component.scss
+++ b/src/app/features/tasks/task/task.component.scss
@@ -21,18 +21,24 @@
   height: 0;
   margin: 0;
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
   pointer-events: none;
+  position: relative;
 
   ::ng-deep task-list {
+    display: block;
     height: 0;
     margin: 0;
     padding: 0;
   }
 
   ::ng-deep .task-list-inner {
-    height: 0;
-    min-height: 0;
+    height: 12px;
+    min-height: 12px;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
   }
 }
 

--- a/src/app/features/tasks/task/task.component.scss
+++ b/src/app/features/tasks/task/task.component.scss
@@ -17,6 +17,25 @@
   }
 }
 
+.sub-tasks.is-empty-drop-target-prepared {
+  height: 0;
+  margin: 0;
+  min-height: 0;
+  overflow: hidden;
+  pointer-events: none;
+
+  ::ng-deep task-list {
+    height: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  ::ng-deep .task-list-inner {
+    height: 0;
+    min-height: 0;
+  }
+}
+
 :host.isDragReady:not(.cdk-drag-placeholder) {
   background: var(--bg-lighter);
   box-shadow: var(--whiteframe-shadow-8dp);

--- a/src/app/features/tasks/task/task.component.scss
+++ b/src/app/features/tasks/task/task.component.scss
@@ -3,6 +3,20 @@
 @use './task-base';
 @use './task-controls';
 
+.sub-tasks.is-empty-drop-target {
+  margin-top: var(--s-half);
+  margin-bottom: var(--s-half);
+  min-height: 12px;
+
+  ::ng-deep task-list {
+    padding: 0;
+  }
+
+  ::ng-deep .task-list-inner {
+    min-height: 12px;
+  }
+}
+
 :host.isDragReady:not(.cdk-drag-placeholder) {
   background: var(--bg-lighter);
   box-shadow: var(--whiteframe-shadow-8dp);

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -282,6 +282,11 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
 
     return canShowEmptySubTaskDropTarget(t, activeTask, this.isInSubTaskList());
   });
+  isEmptySubTaskDropTargetMountable = computed(() => {
+    const t = this.task();
+
+    return !this.isInSubTaskList() && !t.parentId && (t.subTaskIds?.length ?? 0) === 0;
+  });
   isEmptySubTaskDropTargetActive = computed(
     () =>
       this.isEmptySubTaskDropTargetVisible() &&

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -282,6 +282,11 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
 
     return canShowEmptySubTaskDropTarget(t, activeTask, this.isInSubTaskList());
   });
+  isEmptySubTaskDropTargetActive = computed(
+    () =>
+      this.isEmptySubTaskDropTargetVisible() &&
+      !!this._scheduleExternalDragService.activeDragRef(),
+  );
 
   hasDeadline = computed(() => {
     const t = this.task();

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -89,6 +89,7 @@ import { LayoutService } from '../../../core-ui/layout/layout.service';
 import { TaskFocusService } from '../task-focus.service';
 import { selectTimeConflictTaskIds } from '../store/task.selectors';
 import { MatTooltip } from '@angular/material/tooltip';
+import { ScheduleExternalDragService } from '../../schedule/schedule-week/schedule-external-drag.service';
 
 @Component({
   selector: 'task',
@@ -146,6 +147,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   private readonly _taskFocusService = inject(TaskFocusService);
   private readonly _dateService = inject(DateService);
   private readonly _destroyRef = inject(DestroyRef);
+  private readonly _scheduleExternalDragService = inject(ScheduleExternalDragService);
 
   readonly workContextService = inject(WorkContextService);
   readonly layoutService = inject(LayoutService);
@@ -272,6 +274,25 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
       this.globalTrackingIntervalService.todayDateStr(),
     ),
   );
+
+  isEmptySubTaskDropTargetVisible = computed(() => {
+    const t = this.task();
+    const activeTask = this._scheduleExternalDragService.activeTask();
+
+    return (
+      !this.isInSubTaskList() &&
+      !t.parentId &&
+      t.id !== activeTask?.id &&
+      (t.subTaskIds?.length ?? 0) === 0 &&
+      !!activeTask &&
+      !activeTask.parentId &&
+      (activeTask.subTaskIds?.length ?? 0) === 0 &&
+      !activeTask.repeatCfgId &&
+      !activeTask.issueId &&
+      !activeTask.issueProviderId &&
+      !activeTask.issueType
+    );
+  });
 
   hasDeadline = computed(() => {
     const t = this.task();

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -90,6 +90,7 @@ import { TaskFocusService } from '../task-focus.service';
 import { selectTimeConflictTaskIds } from '../store/task.selectors';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ScheduleExternalDragService } from '../../schedule/schedule-week/schedule-external-drag.service';
+import { canShowEmptySubTaskDropTarget } from '../util/can-convert-to-sub-task';
 
 @Component({
   selector: 'task',
@@ -279,19 +280,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     const t = this.task();
     const activeTask = this._scheduleExternalDragService.activeTask();
 
-    return (
-      !this.isInSubTaskList() &&
-      !t.parentId &&
-      t.id !== activeTask?.id &&
-      (t.subTaskIds?.length ?? 0) === 0 &&
-      !!activeTask &&
-      !activeTask.parentId &&
-      (activeTask.subTaskIds?.length ?? 0) === 0 &&
-      !activeTask.repeatCfgId &&
-      !activeTask.issueId &&
-      !activeTask.issueProviderId &&
-      !activeTask.issueType
-    );
+    return canShowEmptySubTaskDropTarget(t, activeTask, this.isInSubTaskList());
   });
 
   hasDeadline = computed(() => {

--- a/src/app/features/tasks/util/can-convert-to-sub-task.spec.ts
+++ b/src/app/features/tasks/util/can-convert-to-sub-task.spec.ts
@@ -1,0 +1,68 @@
+import {
+  canConvertTaskToSubTask,
+  canShowEmptySubTaskDropTarget,
+} from './can-convert-to-sub-task';
+import { DEFAULT_TASK, Task } from '../task.model';
+
+const task = (overrides: Partial<Task> = {}): Task => ({
+  ...DEFAULT_TASK,
+  ...overrides,
+  id: overrides.id ?? 'task1',
+  projectId: overrides.projectId ?? '',
+  subTaskIds: overrides.subTaskIds ?? [],
+  tagIds: overrides.tagIds ?? [],
+});
+const SCHEDULED_AT = 1779144000000;
+const blockedTaskCases: { label: string; overrides: Partial<Task> }[] = [
+  { label: 'subtasks', overrides: { subTaskIds: ['child1'] } },
+  { label: 'repeat config', overrides: { repeatCfgId: 'repeat1' } },
+  { label: 'issue id', overrides: { issueId: 'issue1' } },
+  { label: 'issue provider', overrides: { issueProviderId: 'github' } },
+  { label: 'issue type', overrides: { issueType: 'GITHUB' } },
+  { label: 'dueWithTime', overrides: { dueWithTime: SCHEDULED_AT } },
+  { label: 'dueDay', overrides: { dueDay: '2026-05-19' } },
+  { label: 'remindAt', overrides: { remindAt: SCHEDULED_AT } },
+  { label: 'reminderId', overrides: { reminderId: 'reminder1' } },
+];
+
+describe('canConvertTaskToSubTask', () => {
+  it('allows plain top-level tasks without children or external links', () => {
+    expect(canConvertTaskToSubTask(task())).toBe(true);
+  });
+
+  blockedTaskCases.forEach(({ label, overrides }) => {
+    it(`blocks tasks with ${label}`, () => {
+      expect(canConvertTaskToSubTask(task(overrides))).toBe(false);
+    });
+  });
+});
+
+describe('canShowEmptySubTaskDropTarget', () => {
+  it('shows the empty drop target when converting a plain top-level task', () => {
+    const targetParent = task({ id: 'parent1' });
+    const activeTask = task({ id: 'task1' });
+
+    expect(canShowEmptySubTaskDropTarget(targetParent, activeTask, false)).toBe(true);
+  });
+
+  it('shows the empty drop target when reparenting a subtask to a childless parent', () => {
+    const targetParent = task({ id: 'parent2' });
+    const activeTask = task({ id: 'sub1', parentId: 'parent1' });
+
+    expect(canShowEmptySubTaskDropTarget(targetParent, activeTask, false)).toBe(true);
+  });
+
+  it('does not show the empty drop target for the current parent', () => {
+    const targetParent = task({ id: 'parent1' });
+    const activeTask = task({ id: 'sub1', parentId: 'parent1' });
+
+    expect(canShowEmptySubTaskDropTarget(targetParent, activeTask, false)).toBe(false);
+  });
+
+  it('does not show the empty drop target for scheduled top-level tasks', () => {
+    const targetParent = task({ id: 'parent1' });
+    const activeTask = task({ id: 'task1', dueDay: '2026-05-19' });
+
+    expect(canShowEmptySubTaskDropTarget(targetParent, activeTask, false)).toBe(false);
+  });
+});

--- a/src/app/features/tasks/util/can-convert-to-sub-task.ts
+++ b/src/app/features/tasks/util/can-convert-to-sub-task.ts
@@ -1,0 +1,34 @@
+import { Task } from '../task.model';
+
+export const isScheduledTask = (task: Task): boolean =>
+  task.dueWithTime != null || !!task.dueDay || task.remindAt != null || !!task.reminderId;
+
+export const canConvertTaskToSubTask = (task: Task): boolean =>
+  !task.parentId &&
+  (task.subTaskIds?.length ?? 0) === 0 &&
+  !task.repeatCfgId &&
+  !task.issueId &&
+  !task.issueProviderId &&
+  !task.issueType &&
+  !isScheduledTask(task);
+
+export const canShowEmptySubTaskDropTarget = (
+  targetParent: Task,
+  activeTask: Task | null,
+  isInSubTaskList: boolean,
+): boolean => {
+  if (
+    isInSubTaskList ||
+    !activeTask ||
+    !!targetParent.parentId ||
+    targetParent.id === activeTask.id ||
+    (targetParent.subTaskIds?.length ?? 0) > 0
+  ) {
+    return false;
+  }
+
+  return (
+    canConvertTaskToSubTask(activeTask) ||
+    (!!activeTask.parentId && activeTask.parentId !== targetParent.id)
+  );
+};

--- a/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts
@@ -112,6 +112,32 @@ describe('sectionSharedMetaReducer', () => {
     expect(updated.entities['s2']?.taskIds).toEqual([]);
   });
 
+  it('removes a task from sections when converting it to a subtask', () => {
+    const state = stateWith({ task1: {}, parent: {}, other: {} }, [
+      {
+        id: 's1',
+        contextId: 'project1',
+        contextType: WorkContextType.PROJECT,
+        title: 'A',
+        taskIds: ['task1', 'other'],
+      },
+    ]);
+
+    metaReducer(
+      state,
+      TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent',
+        afterTaskId: null,
+      }),
+    );
+
+    const updated = (mockReducer.calls.mostRecent().args[0] as any)[
+      SECTION_FEATURE_NAME
+    ] as SectionState;
+    expect(updated.entities['s1']?.taskIds).toEqual(['other']);
+  });
+
   it('strips archived tasks (and their subtasks) from sections on moveToArchive', () => {
     const state = stateWith(
       {

--- a/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts
@@ -335,6 +335,10 @@ const ACTION_HANDLERS: Record<string, Handler> = {
       cleanupSectionTaskIds(state[SECTION_FEATURE_NAME], Array.from(idSet)),
     );
   },
+  [TaskSharedActions.convertToSubTask.type]: (state, action) => {
+    const { taskId } = action as ReturnType<typeof TaskSharedActions.convertToSubTask>;
+    return handleTaskRemoval(state, [taskId]);
+  },
   [TaskSharedActions.deleteProject.type]: (state, action) => {
     const { projectId, allTaskIds } = action as ReturnType<
       typeof TaskSharedActions.deleteProject

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
@@ -1794,6 +1794,257 @@ describe('taskSharedCrudMetaReducer', () => {
     });
   });
 
+  describe('convertToSubTask action', () => {
+    const createConvertToSubTaskState = (
+      taskOverrides: Partial<Task> = {},
+      parentOverrides: Partial<Task> = {},
+    ): RootState => {
+      const parentTask = createMockTask({
+        id: 'parent-task',
+        projectId: 'project1',
+        tagIds: ['tag1'],
+        subTaskIds: ['existing-sub'],
+        ...parentOverrides,
+      });
+      const task = createMockTask({
+        id: 'task1',
+        projectId: 'project1',
+        tagIds: ['tag1'],
+        subTaskIds: [],
+        timeSpentOnDay: { '2026-05-19': 60000 },
+        timeSpent: 60000,
+        timeEstimate: 120000,
+        ...taskOverrides,
+      });
+      const existingSub = createMockTask({
+        id: 'existing-sub',
+        parentId: 'parent-task',
+        projectId: 'project1',
+        tagIds: [],
+        timeSpentOnDay: { '2026-05-19': 30000 },
+        timeSpent: 30000,
+        timeEstimate: 60000,
+      });
+
+      return {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          ids: ['parent-task', 'task1', 'existing-sub'],
+          entities: {
+            'parent-task': parentTask,
+            task1: task,
+            'existing-sub': existingSub,
+          },
+        },
+        [PROJECT_FEATURE_NAME]: {
+          ...baseState[PROJECT_FEATURE_NAME],
+          entities: {
+            ...baseState[PROJECT_FEATURE_NAME].entities,
+            project1: {
+              ...baseState[PROJECT_FEATURE_NAME].entities.project1,
+              taskIds: ['parent-task', 'task1'],
+              backlogTaskIds: [],
+            } as Project,
+          },
+        },
+        [TAG_FEATURE_NAME]: {
+          ...baseState[TAG_FEATURE_NAME],
+          entities: {
+            ...baseState[TAG_FEATURE_NAME].entities,
+            tag1: {
+              ...baseState[TAG_FEATURE_NAME].entities.tag1,
+              taskIds: ['parent-task', 'task1'],
+            } as Tag,
+            TODAY: {
+              ...baseState[TAG_FEATURE_NAME].entities.TODAY,
+              taskIds: ['task1'],
+            } as Tag,
+          },
+        },
+      };
+    };
+
+    it('moves a top-level task under the target parent and removes top-level references', () => {
+      const testState = createConvertToSubTaskState();
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId: 'existing-sub',
+      });
+
+      metaReducer(testState, action);
+
+      expectStateUpdate(
+        {
+          ...expectTaskUpdate('task1', {
+            parentId: 'parent-task',
+            projectId: 'project1',
+            tagIds: [],
+          }),
+          ...expectTaskUpdate('parent-task', {
+            subTaskIds: ['existing-sub', 'task1'],
+            timeSpentOnDay: { '2026-05-19': 90000 },
+            timeSpent: 90000,
+            timeEstimate: 90000,
+          }),
+          ...expectProjectUpdate('project1', { taskIds: ['parent-task'] }),
+          ...expectTagUpdates({
+            tag1: { taskIds: ['parent-task'] },
+            TODAY: { taskIds: [] },
+          }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('inserts at the start of the target subtask list when afterTaskId is null', () => {
+      const testState = createConvertToSubTaskState();
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId: null,
+      });
+
+      metaReducer(testState, action);
+
+      expectStateUpdate(
+        expectTaskUpdate('parent-task', {
+          subTaskIds: ['task1', 'existing-sub'],
+        }),
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('removes the task from project backlog when it was a backlog task', () => {
+      const baseTestState = createConvertToSubTaskState();
+      const project = baseTestState[PROJECT_FEATURE_NAME].entities.project1 as Project;
+      const testState: RootState = {
+        ...baseTestState,
+        [PROJECT_FEATURE_NAME]: {
+          ...baseTestState[PROJECT_FEATURE_NAME],
+          entities: {
+            ...baseTestState[PROJECT_FEATURE_NAME].entities,
+            project1: {
+              ...project,
+              taskIds: ['parent-task'],
+              backlogTaskIds: ['task1'],
+            } as Project,
+          },
+        },
+      };
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId: null,
+      });
+
+      metaReducer(testState, action);
+
+      expectStateUpdate(
+        expectProjectUpdate('project1', {
+          taskIds: ['parent-task'],
+          backlogTaskIds: [],
+        }),
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('removes the task from planner days', () => {
+      const testState: RootState = {
+        ...createConvertToSubTaskState(),
+        planner: {
+          ...baseState.planner,
+          days: {
+            '2026-05-20': ['other-task', 'task1'],
+            '2026-05-21': ['task1'],
+          },
+        },
+      };
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId: null,
+      });
+
+      metaReducer(testState, action);
+
+      expectStateUpdate(
+        {
+          planner: {
+            ...testState.planner,
+            days: {
+              '2026-05-20': ['other-task'],
+              '2026-05-21': [],
+            },
+          },
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('ignores tasks that already have subtasks', () => {
+      const testState = createConvertToSubTaskState({ subTaskIds: ['child-task'] });
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId: null,
+      });
+
+      const result = metaReducer(testState, action);
+
+      expect(result[TASK_FEATURE_NAME].entities.task1?.parentId).toBeUndefined();
+      expect(result[TASK_FEATURE_NAME].entities['parent-task']?.subTaskIds).toEqual([
+        'existing-sub',
+      ]);
+      expect(result[PROJECT_FEATURE_NAME].entities.project1?.taskIds).toEqual([
+        'parent-task',
+        'task1',
+      ]);
+    });
+
+    it('ignores target parents that are already subtasks', () => {
+      const testState = createConvertToSubTaskState({}, { parentId: 'root-task' });
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId: null,
+      });
+
+      const result = metaReducer(testState, action);
+
+      expect(result[TASK_FEATURE_NAME].entities.task1?.parentId).toBeUndefined();
+      expect(result[TASK_FEATURE_NAME].entities['parent-task']?.subTaskIds).toEqual([
+        'existing-sub',
+      ]);
+    });
+
+    it('ignores issue-linked tasks', () => {
+      const testState = createConvertToSubTaskState({ issueProviderId: 'github' });
+      const action = TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId: null,
+      });
+
+      const result = metaReducer(testState, action);
+
+      expect(result[TASK_FEATURE_NAME].entities.task1?.parentId).toBeUndefined();
+      expect(result[PROJECT_FEATURE_NAME].entities.project1?.taskIds).toEqual([
+        'parent-task',
+        'task1',
+      ]);
+    });
+  });
+
   describe('restoreDeletedTask action', () => {
     const createRestoreAction = (
       overrides: {

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
@@ -29,6 +29,7 @@ describe('taskSharedCrudMetaReducer', () => {
   let mockReducer: jasmine.Spy;
   let metaReducer: ActionReducer<any, Action>;
   let baseState: RootState;
+  const scheduledAt = 1779144000000;
 
   beforeEach(() => {
     mockReducer = jasmine.createSpy('reducer').and.callFake((state, action) => state);
@@ -2042,6 +2043,33 @@ describe('taskSharedCrudMetaReducer', () => {
         'parent-task',
         'task1',
       ]);
+    });
+
+    [
+      { label: 'dueWithTime', task: { dueWithTime: scheduledAt } },
+      { label: 'dueDay', task: { dueDay: '2026-05-19' } },
+      { label: 'remindAt', task: { remindAt: scheduledAt } },
+      { label: 'reminderId', task: { reminderId: 'reminder1' } },
+    ].forEach(({ label, task }) => {
+      it(`ignores scheduled tasks with ${label}`, () => {
+        const testState = createConvertToSubTaskState(task);
+        const action = TaskSharedActions.convertToSubTask({
+          taskId: 'task1',
+          targetParentId: 'parent-task',
+          afterTaskId: null,
+        });
+
+        const result = metaReducer(testState, action);
+
+        expect(result[TASK_FEATURE_NAME].entities.task1?.parentId).toBeUndefined();
+        expect(result[TASK_FEATURE_NAME].entities['parent-task']?.subTaskIds).toEqual([
+          'existing-sub',
+        ]);
+        expect(result[PROJECT_FEATURE_NAME].entities.project1?.taskIds).toEqual([
+          'parent-task',
+          'task1',
+        ]);
+      });
     });
   });
 

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -14,6 +14,7 @@ import {
 import {
   deleteTaskHelper,
   removeTaskFromParentSideEffects,
+  reCalcTimesForParentIfParent,
   updateDoneOnForTask,
   updateTimeEstimateForTask,
   updateTimeSpentForTask,
@@ -42,6 +43,7 @@ import {
   updateTags,
 } from './task-shared-helpers';
 import { plannerFeatureKey } from '../../../features/planner/store/planner.reducer';
+import { moveItemAfterAnchor } from '../../../features/work-context/store/work-context-meta.helper';
 
 // =============================================================================
 // HELPER FUNCTIONS
@@ -282,6 +284,105 @@ const handleConvertToMainTask = (
   );
 
   return updateTags(updatedState, tagUpdates);
+};
+
+const handleConvertToSubTask = (
+  state: RootState,
+  taskId: string,
+  targetParentId: string,
+  afterTaskId: string | null,
+): RootState => {
+  const task = state[TASK_FEATURE_NAME].entities[taskId] as Task | undefined;
+  const targetParent = state[TASK_FEATURE_NAME].entities[targetParentId] as
+    | Task
+    | undefined;
+
+  if (
+    !task ||
+    !targetParent ||
+    task.parentId ||
+    targetParent.parentId ||
+    taskId === targetParentId
+  ) {
+    return state;
+  }
+
+  if (
+    task.subTaskIds.length > 0 ||
+    task.repeatCfgId ||
+    task.issueId ||
+    task.issueProviderId ||
+    task.issueType
+  ) {
+    return state;
+  }
+
+  let updatedState = state;
+
+  if (task.projectId && state[PROJECT_FEATURE_NAME].entities[task.projectId]) {
+    const project = getProject(state, task.projectId);
+    updatedState = updateProject(updatedState, task.projectId, {
+      taskIds: removeTasksFromList(project.taskIds, [taskId]),
+      backlogTaskIds: removeTasksFromList(project.backlogTaskIds, [taskId]),
+    });
+  }
+
+  updatedState = removeTaskFromPlannerDays(updatedState, taskId);
+
+  const tagUpdates: Update<Tag>[] = task.tagIds
+    .filter((tagId) => tagId !== TODAY_TAG.id)
+    .filter((tagId) => updatedState[TAG_FEATURE_NAME].entities[tagId])
+    .map((tagId): Update<Tag> => {
+      const tag = getTag(updatedState, tagId);
+      return {
+        id: tagId,
+        changes: {
+          taskIds: removeTasksFromList(tag.taskIds, [taskId]),
+        },
+      };
+    });
+
+  const todayTag = updatedState[TAG_FEATURE_NAME].entities[TODAY_TAG.id] as
+    | Tag
+    | undefined;
+  if (todayTag?.taskIds.includes(taskId)) {
+    tagUpdates.push({
+      id: TODAY_TAG.id,
+      changes: {
+        taskIds: removeTasksFromList(todayTag.taskIds, [taskId]),
+      },
+    });
+  }
+
+  if (tagUpdates.length > 0) {
+    updatedState = updateTags(updatedState, tagUpdates);
+  }
+
+  let taskState = taskAdapter.updateMany(
+    [
+      {
+        id: targetParentId,
+        changes: {
+          subTaskIds: moveItemAfterAnchor(taskId, afterTaskId, targetParent.subTaskIds),
+        },
+      },
+      {
+        id: taskId,
+        changes: {
+          parentId: targetParentId,
+          projectId: targetParent.projectId,
+          tagIds: [],
+        },
+      },
+    ],
+    updatedState[TASK_FEATURE_NAME],
+  );
+  taskState = reCalcTimesForParentIfParent(targetParentId, taskState);
+
+  return {
+    ...updatedState,
+    [TASK_FEATURE_NAME]: taskState,
+  };
 };
 
 const handleDeleteTask = (
@@ -806,6 +907,12 @@ const createActionHandlers = (state: RootState, action: Action): ActionHandlerMa
       typeof TaskSharedActions.convertToMainTask
     >;
     return handleConvertToMainTask(state, task, parentTagIds, isPlanForToday);
+  },
+  [TaskSharedActions.convertToSubTask.type]: () => {
+    const { taskId, targetParentId, afterTaskId } = action as ReturnType<
+      typeof TaskSharedActions.convertToSubTask
+    >;
+    return handleConvertToSubTask(state, taskId, targetParentId, afterTaskId);
   },
   [TaskSharedActions.deleteTask.type]: () => {
     const { task } = action as ReturnType<typeof TaskSharedActions.deleteTask>;

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -44,6 +44,7 @@ import {
 } from './task-shared-helpers';
 import { plannerFeatureKey } from '../../../features/planner/store/planner.reducer';
 import { moveItemAfterAnchor } from '../../../features/work-context/store/work-context-meta.helper';
+import { canConvertTaskToSubTask } from '../../../features/tasks/util/can-convert-to-sub-task';
 
 // =============================================================================
 // HELPER FUNCTIONS
@@ -307,13 +308,7 @@ const handleConvertToSubTask = (
     return state;
   }
 
-  if (
-    task.subTaskIds.length > 0 ||
-    task.repeatCfgId ||
-    task.issueId ||
-    task.issueProviderId ||
-    task.issueType
-  ) {
+  if (!canConvertTaskToSubTask(task)) {
     return state;
   }
 

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -49,6 +49,20 @@ export const TaskSharedActions = createActionGroup({
       } satisfies PersistentActionMeta,
     }),
 
+    convertToSubTask: (taskProps: {
+      taskId: string;
+      targetParentId: string;
+      afterTaskId: string | null;
+    }) => ({
+      ...taskProps,
+      meta: {
+        isPersistent: true,
+        entityType: 'TASK',
+        entityId: taskProps.taskId,
+        opType: OpType.Move,
+      } satisfies PersistentActionMeta,
+    }),
+
     deleteTask: (taskProps: { task: TaskWithSubTasks }) => ({
       ...taskProps,
       meta: {


### PR DESCRIPTION
Fixes #905

Gitpay task: https://gitpay.me/#/task/1146/adding-a-sub-task-via-drag-drop

## Summary

- Adds a persistent shared action for converting a top-level task into a subtask by drag and drop.
- Allows valid top-level tasks to be dropped into another task or its subtask list, including parents that do not already have subtasks.
- Keeps unsupported conversions blocked for tasks with subtasks, repeating tasks, issue-linked tasks, scheduled/due/reminder data, and subtask targets.
- Applies the same conversion guard in the shared reducer so programmatic moves cannot bypass the drag predicate.
- Removes converted tasks from top-level project, backlog, tag, today, planner, and section lists while recalculating parent time totals.
- Updates subtask docs for the new conversion flow and limits.

## Validation

- `git diff --check`
- `npm run checkFile` on the touched TypeScript, HTML, and SCSS files from the first pass
- `npx prettier --check` on the touched follow-up files
- `npx ng lint --lint-file-patterns ...` on the touched follow-up files
- Focused Angular test commands for the touched task-list, reducer, and helper specs compiled the browser bundles successfully, then stopped at browser launch because this Android Termux environment has no Chrome binary and `CHROME_BIN` is not set.
