### PR TITLE
chore: limit "resolved" actions to correct categories

### DIFF
--- a/.github/workflows/stale-discussions.yml
+++ b/.github/workflows/stale-discussions.yml
@@ -26,9 +26,10 @@ jobs:
       - name: resolve-answered
         uses: zenoprax/stalesweeper@c9c72ef0504f835bf9bf8ed7319d3bc149539291 # v1.1.2
         env:
-          DAYS_BEFORE_CLOSE: ${{ github.event_name == 'schedule' && '30' || github.event.inputs.days-before-close }}
+          DAYS_BEFORE_CLOSE: ${{ github.event_name == 'schedule' && '90' || github.event.inputs.days-before-close }}
           DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || github.event.inputs.dry-run }}
         with:
+          categories: 'Q&A,General'
           close-reason: 'RESOLVED'
           days-before-close: '${{ env.DAYS_BEFORE_CLOSE}}'
           dry-run: ${{ env.DRY_RUN }}


### PR DESCRIPTION
GH Action will incorrectly mark discussions without the question-answer
format as answered when that is not possible. The action should be fixed
but restricting to the correct categories will also avoid this problem.
