### PR TITLE
add deadline to synched fields

### DIFF
--- a/packages/plugin-api/src/issue-provider-types.ts
+++ b/packages/plugin-api/src/issue-provider-types.ts
@@ -19,6 +19,10 @@ export interface PluginSearchResult {
   duration?: number;
   /** True if this is an all-day event */
   isAllDay?: boolean;
+  /** Deadline date as YYYY-MM-DD string. For date-only deadlines (Frist). */
+  deadlineDay?: string;
+  /** Deadline timestamp (ms). For deadlines with a specific time (Frist). */
+  deadlineWithTime?: number;
   /** Event description / body text */
   description?: string;
   /** Provider-specific fields used by issue display and field mappings */
@@ -77,6 +81,8 @@ export interface PluginFieldMapping {
     | 'notes'
     | 'dueDay'
     | 'dueWithTime'
+    | 'deadlineDay'
+    | 'deadlineWithTime'
     | 'timeEstimate'
     | 'tagIds';
   issueField: string;

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -230,6 +230,9 @@ export interface Task {
   remindAt?: number | null;
   dueDay?: string | null;
   dueWithTime?: number | null;
+  deadlineDay?: string | null;
+  deadlineWithTime?: number | null;
+  deadlineRemindAt?: number | null;
   repeatCfgId?: string | null;
 
   // Issue tracking fields (optional)

--- a/src/app/features/issue/two-way-sync/issue-two-way-sync.effects.ts
+++ b/src/app/features/issue/two-way-sync/issue-two-way-sync.effects.ts
@@ -39,6 +39,8 @@ const SYNCABLE_TASK_FIELDS: ReadonlySet<string> = new Set([
   'notes',
   'dueWithTime',
   'dueDay',
+  'deadlineDay',
+  'deadlineWithTime',
   'timeEstimate',
   'tagIds',
 ]);

--- a/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts
+++ b/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts
@@ -430,6 +430,12 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
       typeof raw['dueWithTime'] === 'number' ? (raw['dueWithTime'] as number) : undefined;
     const startMs =
       typeof raw['start'] === 'number' ? (raw['start'] as number) : undefined;
+    const deadlineWithTime =
+      typeof raw['deadlineWithTime'] === 'number'
+        ? (raw['deadlineWithTime'] as number)
+        : undefined;
+    const deadlineDay =
+      typeof raw['deadlineDay'] === 'string' ? (raw['deadlineDay'] as string) : undefined;
 
     return {
       title: data.title,
@@ -444,6 +450,11 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
         ? { dueWithTime }
         : startMs != null
           ? { dueDay: getDbDateStr(startMs) }
+          : {}),
+      ...(deadlineWithTime != null
+        ? { deadlineWithTime, deadlineDay: null }
+        : deadlineDay != null
+          ? { deadlineDay, deadlineWithTime: null }
           : {}),
     };
   }


### PR DESCRIPTION
## Problem

I want to sync deadlines also with plugins

## Solution

Added the deadline fields to the syncable task fields

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
