### PR TITLE
chore(deps): add cooldown for NPM and GH Actions to reduce supply chain attack risk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,8 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'Europe/Berlin'
-
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
 
     reviewers:
@@ -38,7 +39,8 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'Europe/Berlin'
-
+    cooldown:
+      default-days: 3
     # Limit concurrent PRs to avoid overwhelming maintainers
     open-pull-requests-limit: 5
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org/
+min-release-age=3


### PR DESCRIPTION
- Monthly/weekly update frequency reduces the window of exposure but the addition of a cooldown should help narrow it further.
- Implemented as suggested in this gist: https://gist.github.com/mcollina/b294a6c39ee700d24073c0e5a4e93104
- I've opted to use the more conservative 3-day cooldown as this is the default in some tools.
- Dependabot needs to be adjusted in combination with .npmrc to avoid creating PRs that can't succeed.

Ref.
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
