### PR TITLE
feat(plugins): allow TaskRepeatCfg actions via dispatchAction

### DIFF
--- a/src/app/plugins/allowed-plugin-actions.const.ts
+++ b/src/app/plugins/allowed-plugin-actions.const.ts
@@ -4,6 +4,12 @@ import {
   toggleStart,
 } from '../features/tasks/store/task.actions';
 import {
+  addTaskRepeatCfgToTask,
+  deleteTaskRepeatCfg,
+  updateTaskRepeatCfg,
+  upsertTaskRepeatCfg,
+} from '../features/task-repeat-cfg/store/task-repeat-cfg.actions';
+import {
   hideFocusOverlay,
   showFocusOverlay,
 } from '../features/focus-mode/store/focus-mode.actions';
@@ -50,6 +56,16 @@ export const ALLOWED_PLUGIN_ACTIONS = [
   setCurrentTask,
   setSelectedTask,
   // addSubTask,
+
+  // Task Repeat Configuration
+  // Plugins can manage recurring task templates (create/update/delete repeat
+  // configs and attach them to existing tasks). Mirrors the scope of the
+  // existing task-mutation actions; required for MCP-style integrations that
+  // configure recurrences from outside the UI.
+  addTaskRepeatCfgToTask,
+  updateTaskRepeatCfg,
+  upsertTaskRepeatCfg,
+  deleteTaskRepeatCfg,
 
   // Project Management
   // addProject,


### PR DESCRIPTION
## Summary

Adds `addTaskRepeatCfgToTask`, `updateTaskRepeatCfg`, `upsertTaskRepeatCfg`, and `deleteTaskRepeatCfg` to `ALLOWED_PLUGIN_ACTIONS` so plugins can manage recurring task templates through the existing `dispatchAction` surface.

## Motivation

MCP-style integrations (AI assistants driving SP via a plugin bridge) currently can't create, modify, pause, or delete recurrences without manual UI intervention. This is the last remaining gap for fully automating task triage and weekly planning workflows.

## Scope

Mirrors the already-allowed task-mutation actions (`toggleStart`, `setCurrentTask`, `setSelectedTask`): operations that touch user task state but don't bypass project ownership, archival, or permission boundaries.

The two "bulk" variants (`updateTaskRepeatCfgs`, `deleteTaskRepeatCfgs`) and the per-instance skip (`deleteTaskRepeatCfgInstance`) are intentionally left out of this minimal PR. Happy to add them in a follow-up if useful.

## Alternative path

Happy to also expose these as first-class `PluginAPI` methods (mirroring `addTask`/`updateTask`/`deleteTask`) in a follow-up PR if you prefer that pattern over raw `dispatchAction` — just let me know.

## Test plan

- Change is additive config (4 new entries to an existing allowlist + 4 imports from a sibling actions file whose exports were verified manually). No logic changes.
- Will validate end-to-end against a real plugin once the MCP-side wiring lands; CI here will catch typecheck/lint regressions before merge.