### PR TITLE
fix(focusMode): notify on zero-duration break completion

### DIFF
--- a/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
@@ -2421,6 +2421,30 @@ describe('FocusModeEffects', () => {
         done();
       }, 50);
     });
+
+    // Regression: reducer drops the `duration > 0` completion guard, so a
+    // break with duration=0 stops immediately. The effect must match — without
+    // this, the break ends silently with no notification.
+    it('should notify when a duration=0 break stops', (done) => {
+      store.overrideSelector(
+        selectors.selectTimer,
+        createMockTimer({
+          isRunning: false,
+          purpose: 'break',
+          duration: 0,
+          elapsed: 0,
+        }),
+      );
+      store.refreshState();
+
+      effects = TestBed.inject(FocusModeEffects);
+      const notifyUserSpy = spyOn(effects as any, '_notifyUser');
+
+      effects.detectBreakTimeUp$.pipe(take(1)).subscribe(() => {
+        expect(notifyUserSpy).toHaveBeenCalled();
+        done();
+      });
+    });
   });
 
   describe('Bug #5954 Additional Edge Cases', () => {

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -286,7 +286,6 @@ export class FocusModeEffects {
           (timer) =>
             timer.purpose === 'break' &&
             !timer.isRunning &&
-            timer.duration > 0 &&
             timer.elapsed >= timer.duration,
         ),
         distinctUntilChanged(


### PR DESCRIPTION
The tick reducer's recent #7707 fix dropped the duration > 0 guard so non-Flowtime sessions with duration adjusted to 0 still auto-complete. detectBreakTimeUp$ kept the duration > 0 filter, so a break that lands at duration === 0 silently flips isRunning to false with no user-facing notification. Drop the effect's guard to keep reducer and effect symmetric; add a regression test.

## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

## Solution

<!-- Describe your changes in detail. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)
