### PR TITLE
fix(localization): resolve "System default" to navigator.language

### DIFF
--- a/src/app/core/date-time-format/date-time-format.service.spec.ts
+++ b/src/app/core/date-time-format/date-time-format.service.spec.ts
@@ -76,6 +76,22 @@ describe('DateTimeFormatService', () => {
       });
     };
 
+    // Re-construct the service after stubbing so the computed picks up the
+    // stubbed navigator.language.
+    const createServiceForSystemLocale = (lang: string): DateTimeFormatService => {
+      stubNavigatorLanguage(lang);
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MatNativeDateModule],
+        providers: [
+          DateTimeFormatService,
+          { provide: DateAdapter, useClass: CustomDateAdapter },
+          provideMockStore({ initialState: { globalConfig: DEFAULT_GLOBAL_CONFIG } }),
+        ],
+      });
+      return TestBed.inject(DateTimeFormatService);
+    };
+
     afterEach(() => {
       // Remove the own property so navigator.language resolves back to the
       // inherited prototype getter — restoring the platform default for any
@@ -83,38 +99,22 @@ describe('DateTimeFormatService', () => {
       delete (navigator as { language?: string }).language;
     });
 
-    it('uses 12-hour format on en-AU systems', () => {
-      stubNavigatorLanguage('en-AU');
-      // Re-construct the service after stubbing so the computed picks up
-      // the new navigator.language.
-      TestBed.resetTestingModule();
-      TestBed.configureTestingModule({
-        imports: [MatNativeDateModule],
-        providers: [
-          DateTimeFormatService,
-          { provide: DateAdapter, useClass: CustomDateAdapter },
-          provideMockStore({ initialState: { globalConfig: DEFAULT_GLOBAL_CONFIG } }),
-        ],
+    (
+      [
+        { lang: 'en-AU', locale: 'en-au', is24Hour: false },
+        { lang: 'de-DE', locale: 'de-de', is24Hour: true },
+        // Region-less 'en' is pinned to the en-GB default so the Intl- and
+        // DatePipe-based formatting paths stay consistent.
+        { lang: 'en', locale: 'en-gb', is24Hour: true },
+        // Malformed tags fall back to the default locale instead of throwing.
+        { lang: 'C', locale: 'en-gb', is24Hour: true },
+      ] as const
+    ).forEach(({ lang, locale, is24Hour }) => {
+      it(`resolves "${lang}" to ${locale} (24h=${is24Hour})`, () => {
+        const svc = createServiceForSystemLocale(lang);
+        expect(svc.currentLocale()).toBe(locale);
+        expect(svc.is24HourFormat()).toBe(is24Hour);
       });
-      const svc = TestBed.inject(DateTimeFormatService);
-      expect(svc.is24HourFormat()).toBe(false);
-      expect(svc.currentLocale()).toBe('en-au');
-    });
-
-    it('uses 24-hour format on de-DE systems', () => {
-      stubNavigatorLanguage('de-DE');
-      TestBed.resetTestingModule();
-      TestBed.configureTestingModule({
-        imports: [MatNativeDateModule],
-        providers: [
-          DateTimeFormatService,
-          { provide: DateAdapter, useClass: CustomDateAdapter },
-          provideMockStore({ initialState: { globalConfig: DEFAULT_GLOBAL_CONFIG } }),
-        ],
-      });
-      const svc = TestBed.inject(DateTimeFormatService);
-      expect(svc.is24HourFormat()).toBe(true);
-      expect(svc.currentLocale()).toBe('de-de');
     });
   });
 

--- a/src/app/core/date-time-format/date-time-format.service.spec.ts
+++ b/src/app/core/date-time-format/date-time-format.service.spec.ts
@@ -68,6 +68,56 @@ describe('DateTimeFormatService', () => {
     expect(formatted.length).toBeGreaterThan(0);
   });
 
+  describe('System default locale follows navigator.language', () => {
+    const stubNavigatorLanguage = (lang: string): void => {
+      Object.defineProperty(navigator, 'language', {
+        configurable: true,
+        get: () => lang,
+      });
+    };
+
+    afterEach(() => {
+      // Remove the own property so navigator.language resolves back to the
+      // inherited prototype getter — restoring the platform default for any
+      // spec scheduled later in the (randomized) Karma run.
+      delete (navigator as { language?: string }).language;
+    });
+
+    it('uses 12-hour format on en-AU systems', () => {
+      stubNavigatorLanguage('en-AU');
+      // Re-construct the service after stubbing so the computed picks up
+      // the new navigator.language.
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MatNativeDateModule],
+        providers: [
+          DateTimeFormatService,
+          { provide: DateAdapter, useClass: CustomDateAdapter },
+          provideMockStore({ initialState: { globalConfig: DEFAULT_GLOBAL_CONFIG } }),
+        ],
+      });
+      const svc = TestBed.inject(DateTimeFormatService);
+      expect(svc.is24HourFormat()).toBe(false);
+      expect(svc.currentLocale()).toBe('en-au');
+    });
+
+    it('uses 24-hour format on de-DE systems', () => {
+      stubNavigatorLanguage('de-DE');
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MatNativeDateModule],
+        providers: [
+          DateTimeFormatService,
+          { provide: DateAdapter, useClass: CustomDateAdapter },
+          provideMockStore({ initialState: { globalConfig: DEFAULT_GLOBAL_CONFIG } }),
+        ],
+      });
+      const svc = TestBed.inject(DateTimeFormatService);
+      expect(svc.is24HourFormat()).toBe(true);
+      expect(svc.currentLocale()).toBe('de-de');
+    });
+  });
+
   it('should detect 24-hour format for appropriate locales', () => {
     const is24Hour = service.is24HourFormat();
     expect(typeof is24Hour).toBe('boolean');

--- a/src/app/core/date-time-format/date-time-format.service.ts
+++ b/src/app/core/date-time-format/date-time-format.service.ts
@@ -1,7 +1,7 @@
 import { computed, effect, inject, Injectable } from '@angular/core';
 import { GlobalConfigService } from '../../features/config/global-config.service';
 import { DateAdapter } from '@angular/material/core';
-import { DEFAULT_LOCALE, DateTimeLocale } from 'src/app/core/locale.constants';
+import { getSystemDefaultLocale } from 'src/app/core/locale.constants';
 
 @Injectable({
   providedIn: 'root',
@@ -10,9 +10,15 @@ export class DateTimeFormatService {
   private readonly _globalConfigService = inject(GlobalConfigService);
   private _dateAdapter = inject(DateAdapter);
 
-  // Signal for the locale to use
-  readonly currentLocale = computed<DateTimeLocale>(() => {
-    return this._globalConfigService.localization()?.dateTimeLocale || DEFAULT_LOCALE;
+  // Signal for the locale to use. When the config value is unset
+  // ("System default"), resolve to navigator.language so date/time formatting
+  // follows the OS / browser locale instead of the hardcoded en-GB fallback.
+  // Typed as `string` because the resolved value can be any BCP-47 tag,
+  // not just a member of the curated DateTimeLocale union.
+  readonly currentLocale = computed<string>(() => {
+    return (
+      this._globalConfigService.localization()?.dateTimeLocale || getSystemDefaultLocale()
+    );
   });
 
   /** Test formats to detect locale-specific time and date formats (e.g., 24h vs 12h, DD/MM vs MM/DD) */
@@ -52,15 +58,16 @@ export class DateTimeFormatService {
   });
 
   constructor() {
-    // Use effect to reactively update date adapter locale when config changes
+    // Use effect to reactively update date adapter locale when config changes.
+    // Read from currentLocale() so "System default" also propagates to the
+    // adapter (via navigator.language) rather than leaving it at en-GB.
     effect(() => {
-      const cfgValue = this._globalConfigService.localization()?.dateTimeLocale;
-      if (cfgValue) this.setDateAdapterLocale(cfgValue);
+      this.setDateAdapterLocale(this.currentLocale());
     });
   }
 
   /** Set the locale for the date adapter formatting */
-  setDateAdapterLocale(locale: DateTimeLocale): void {
+  setDateAdapterLocale(locale: string): void {
     this._dateAdapter.setLocale(locale);
   }
 
@@ -74,7 +81,7 @@ export class DateTimeFormatService {
    * // For en-GB locale
    * formatTime(new Date(2000, 11, 31, 13, 0, 0).getTime()); // 13:00
    */
-  formatTime(timestamp: number, locale: DateTimeLocale = this.currentLocale()): string {
+  formatTime(timestamp: number, locale: string = this.currentLocale()): string {
     return new Date(timestamp).toLocaleTimeString(locale, {
       hour: 'numeric',
       minute: 'numeric',
@@ -91,7 +98,7 @@ export class DateTimeFormatService {
    * // For en-GB locale
    * formatDate(new Date(2000, 11, 31), 'en-GB'); // 31/12/2000
    */
-  formatDate(date: Date, locale: DateTimeLocale = this.currentLocale()): string {
+  formatDate(date: Date, locale: string = this.currentLocale()): string {
     const formatter = new Intl.DateTimeFormat(locale, {
       year: 'numeric',
       month: '2-digit',

--- a/src/app/core/date-time-format/date-time-format.service.ts
+++ b/src/app/core/date-time-format/date-time-format.service.ts
@@ -10,11 +10,8 @@ export class DateTimeFormatService {
   private readonly _globalConfigService = inject(GlobalConfigService);
   private _dateAdapter = inject(DateAdapter);
 
-  // Signal for the locale to use. When the config value is unset
-  // ("System default"), resolve to navigator.language so date/time formatting
-  // follows the OS / browser locale instead of the hardcoded en-GB fallback.
-  // Typed as `string` because the resolved value can be any BCP-47 tag,
-  // not just a member of the curated DateTimeLocale union.
+  // Locale for date/time formatting. "System default" (unset config) follows
+  // the OS / browser locale — see getSystemDefaultLocale().
   readonly currentLocale = computed<string>(() => {
     return (
       this._globalConfigService.localization()?.dateTimeLocale || getSystemDefaultLocale()
@@ -58,9 +55,8 @@ export class DateTimeFormatService {
   });
 
   constructor() {
-    // Use effect to reactively update date adapter locale when config changes.
-    // Read from currentLocale() so "System default" also propagates to the
-    // adapter (via navigator.language) rather than leaving it at en-GB.
+    // Keep the Material DateAdapter's locale in sync with currentLocale() so
+    // "System default" reaches date pickers too, not just Intl formatting.
     effect(() => {
       this.setDateAdapterLocale(this.currentLocale());
     });

--- a/src/app/core/locale.constants.ts
+++ b/src/app/core/locale.constants.ts
@@ -75,6 +75,21 @@ export const DateTimeLocales = {
   ro_ro: `${LanguageCode.ro}-ro`,
   ro_md: `${LanguageCode.ro}-md`,
   pl_pl: `${LanguageCode.pl}-pl`,
+  // English region variants below are NOT exposed in the dropdown —
+  // they exist so `LocaleImportFns` registers Angular locale data for
+  // common navigator.language values when the user picks "System
+  // default". Without these, Angular's DatePipe falls back through 'en'
+  // (bound to en-GB data) and shows 24h for en-AU/en-CA/en-NZ users.
+  // Scope: English variants only; other languages (es-MX, fr-CA, …)
+  // already fall back to their language code which is locale-correct.
+  en_au: `${LanguageCode.en}-au`,
+  en_ca: `${LanguageCode.en}-ca`,
+  en_ie: `${LanguageCode.en}-ie`,
+  en_in: `${LanguageCode.en}-in`,
+  en_nz: `${LanguageCode.en}-nz`,
+  en_ph: `${LanguageCode.en}-ph`,
+  en_sg: `${LanguageCode.en}-sg`,
+  en_za: `${LanguageCode.en}-za`,
 } as const;
 
 export type DateTimeLocale = (typeof DateTimeLocales)[keyof typeof DateTimeLocales];
@@ -132,6 +147,16 @@ export const LocaleImportFns: Record<
   ro_ro: () => import('@angular/common/locales/ro'),
   ro_md: () => import('@angular/common/locales/ro-MD'),
   vi: () => import('@angular/common/locales/vi'),
+  // English region variants for navigator.language fallback (not in
+  // the UI dropdown — see DateTimeLocales comment).
+  en_au: () => import('@angular/common/locales/en-AU'),
+  en_ca: () => import('@angular/common/locales/en-CA'),
+  en_ie: () => import('@angular/common/locales/en-IE'),
+  en_in: () => import('@angular/common/locales/en-IN'),
+  en_nz: () => import('@angular/common/locales/en-NZ'),
+  en_ph: () => import('@angular/common/locales/en-PH'),
+  en_sg: () => import('@angular/common/locales/en-SG'),
+  en_za: () => import('@angular/common/locales/en-ZA'),
 };
 
 /** Default locale data, statically imported for instant availability */
@@ -140,3 +165,23 @@ export const DEFAULT_LOCALE_DATA = localeEnGB;
 export const DEFAULT_LANGUAGE = LanguageCode.en;
 export const DEFAULT_LOCALE = DateTimeLocales.en_gb;
 export const DEFAULT_FIRST_DAY_OF_WEEK = 1; // monday
+
+/**
+ * Returns the system-reported locale as a lowercase BCP-47 string
+ * (e.g. `en-au`, `de-de`), suitable for `Intl.DateTimeFormat` and the
+ * Material `DateAdapter`. Falls back to {@link DEFAULT_LOCALE} when
+ * `navigator.language` is unavailable (e.g. SSR or unit tests).
+ *
+ * In Electron, `navigator.language` reflects `app.getLocale()` which is
+ * resolved from the OS. In browsers, it reflects the browser's UI
+ * language. In Capacitor WebViews, it reflects the device locale.
+ *
+ * Return type is `string` rather than `DateTimeLocale` because the value
+ * is an arbitrary BCP-47 tag — only a subset matches the curated union.
+ */
+export const getSystemDefaultLocale = (): string => {
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    return navigator.language.toLowerCase();
+  }
+  return DEFAULT_LOCALE;
+};

--- a/src/app/core/locale.constants.ts
+++ b/src/app/core/locale.constants.ts
@@ -75,21 +75,6 @@ export const DateTimeLocales = {
   ro_ro: `${LanguageCode.ro}-ro`,
   ro_md: `${LanguageCode.ro}-md`,
   pl_pl: `${LanguageCode.pl}-pl`,
-  // English region variants below are NOT exposed in the dropdown —
-  // they exist so `LocaleImportFns` registers Angular locale data for
-  // common navigator.language values when the user picks "System
-  // default". Without these, Angular's DatePipe falls back through 'en'
-  // (bound to en-GB data) and shows 24h for en-AU/en-CA/en-NZ users.
-  // Scope: English variants only; other languages (es-MX, fr-CA, …)
-  // already fall back to their language code which is locale-correct.
-  en_au: `${LanguageCode.en}-au`,
-  en_ca: `${LanguageCode.en}-ca`,
-  en_ie: `${LanguageCode.en}-ie`,
-  en_in: `${LanguageCode.en}-in`,
-  en_nz: `${LanguageCode.en}-nz`,
-  en_ph: `${LanguageCode.en}-ph`,
-  en_sg: `${LanguageCode.en}-sg`,
-  en_za: `${LanguageCode.en}-za`,
 } as const;
 
 export type DateTimeLocale = (typeof DateTimeLocales)[keyof typeof DateTimeLocales];
@@ -147,8 +132,29 @@ export const LocaleImportFns: Record<
   ro_ro: () => import('@angular/common/locales/ro'),
   ro_md: () => import('@angular/common/locales/ro-MD'),
   vi: () => import('@angular/common/locales/vi'),
-  // English region variants for navigator.language fallback (not in
-  // the UI dropdown — see DateTimeLocales comment).
+};
+
+/**
+ * Angular locale data for common `navigator.language` region variants that
+ * are NOT user-selectable in the dropdown — they back the "System default"
+ * option (see {@link getSystemDefaultLocale}). English regions need their own
+ * data because Angular's `DatePipe` would otherwise fall back through `en`
+ * (registered as en-GB) and render 24h for en-AU/en-CA/en-NZ users.
+ *
+ * Kept separate from {@link DateTimeLocales} so the `DateTimeLocale` union
+ * stays limited to genuinely selectable locales. Scope is English regions
+ * only: English is the most common navigator.language and the one language
+ * whose bare code is mis-pinned to en-GB. Other regional variants (es-MX,
+ * fr-CA, …) still fall back to their bare language code — not always
+ * region-correct, but out of scope for this fix.
+ *
+ * Keys are snake_case; `registerLocaleData` normalises them to BCP-47
+ * (`en_au` -> `en-au`), matching `navigator.language.toLowerCase()`.
+ */
+export const NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS: Record<
+  string,
+  () => Promise<{ default: unknown }>
+> = {
   en_au: () => import('@angular/common/locales/en-AU'),
   en_ca: () => import('@angular/common/locales/en-CA'),
   en_ie: () => import('@angular/common/locales/en-IE'),
@@ -167,21 +173,28 @@ export const DEFAULT_LOCALE = DateTimeLocales.en_gb;
 export const DEFAULT_FIRST_DAY_OF_WEEK = 1; // monday
 
 /**
- * Returns the system-reported locale as a lowercase BCP-47 string
- * (e.g. `en-au`, `de-de`), suitable for `Intl.DateTimeFormat` and the
- * Material `DateAdapter`. Falls back to {@link DEFAULT_LOCALE} when
- * `navigator.language` is unavailable (e.g. SSR or unit tests).
+ * Resolves the OS / browser locale for the "System default" option, as a
+ * lowercase BCP-47 tag suitable for `Intl` and the Material `DateAdapter`.
+ * Falls back to {@link DEFAULT_LOCALE} when `navigator.language` is
+ * unavailable (SSR / unit tests) or not a valid locale tag.
  *
- * In Electron, `navigator.language` reflects `app.getLocale()` which is
- * resolved from the OS. In browsers, it reflects the browser's UI
- * language. In Capacitor WebViews, it reflects the device locale.
- *
- * Return type is `string` rather than `DateTimeLocale` because the value
- * is an arbitrary BCP-47 tag — only a subset matches the curated union.
+ * The return type is `string` (not `DateTimeLocale`) because the value is an
+ * arbitrary BCP-47 tag — only a subset matches the curated union.
  */
 export const getSystemDefaultLocale = (): string => {
-  if (typeof navigator !== 'undefined' && navigator.language) {
-    return navigator.language.toLowerCase();
+  if (typeof navigator === 'undefined' || !navigator.language) {
+    return DEFAULT_LOCALE;
   }
-  return DEFAULT_LOCALE;
+  const lang = navigator.language.toLowerCase();
+  try {
+    // Reject structurally invalid tags (e.g. the POSIX 'C' locale) before
+    // they reach Intl / DatePipe / the Material DateAdapter.
+    Intl.getCanonicalLocales(lang);
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+  // A region-less 'en' is ambiguous: Intl formats it with 12h conventions
+  // while the app registers Angular's 'en' data as en-GB (24h). Pin it to
+  // the explicit default so the Intl- and DatePipe-based paths agree.
+  return lang === LanguageCode.en ? DEFAULT_LOCALE : lang;
 };

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -112,7 +112,10 @@ describe('ScheduleComponent', () => {
           useValue: mockGlobalTrackingIntervalService,
         },
         { provide: GlobalConfigService, useValue: mockGlobalConfigService },
-        { provide: DateAdapter, useValue: { getFirstDayOfWeek: () => 1 } },
+        {
+          provide: DateAdapter,
+          useValue: { getFirstDayOfWeek: () => 1, setLocale: () => undefined },
+        },
       ],
     }).compileComponents();
 

--- a/src/app/features/worklog/util/map-archive-to-worklog-weeks.ts
+++ b/src/app/features/worklog/util/map-archive-to-worklog-weeks.ts
@@ -5,7 +5,6 @@ import { WorklogYearsWithWeeks } from '../worklog.model';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { WorkStartEnd } from '../../work-context/work-context.model';
 import { formatDayMonthStr } from '../../../util/format-day-month-str';
-import { DateTimeLocale } from 'src/app/core/locale.constants';
 import { sortWorklogEntriesAlphabetically } from './sort-worklog-entries';
 
 // Provides defaults to display tasks without time spent on them
@@ -30,7 +29,7 @@ export const mapArchiveToWorklogWeeks = (
   noRestoreIds: string[] = [],
   startEnd: { workStart: WorkStartEnd; workEnd: WorkStartEnd },
   firstDayOfWeek: number = 1,
-  locale: DateTimeLocale,
+  locale: string,
 ): WorklogYearsWithWeeks => {
   const entities = taskState.entities;
   const worklogYearsWithSimpleWeeks: WorklogYearsWithWeeks = {};

--- a/src/app/ui/pipes/locale-date.pipe.ts
+++ b/src/app/ui/pipes/locale-date.pipe.ts
@@ -16,6 +16,13 @@ export class LocaleDatePipe implements PipeTransform {
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _datePipe: DatePipe | null = null;
   private _lastLocale: string | undefined;
+  // Fallback pipe, reused instead of re-allocated on every failed transform.
+  // DEFAULT_LOCALE ('en-gb') resolves to the 'en' data registered statically
+  // at bootstrap, so this path never depends on lazy locale registration.
+  private readonly _fallbackDatePipe = new DatePipe(DEFAULT_LOCALE);
+  // This pipe is impure (runs every change-detection cycle); warn at most
+  // once per unregistered locale instead of flooding the console.
+  private readonly _warnedLocales = new Set<string>();
 
   transform(
     value: Date | string | number | null | undefined,
@@ -39,18 +46,20 @@ export class LocaleDatePipe implements PipeTransform {
     try {
       return this._datePipe.transform(value, format, timezone, effectiveLocale);
     } catch (e) {
-      // Angular throws RuntimeError(701) when locale data isn't registered
-      // (any locale whose language subtag isn't 'en' and isn't in the app's
-      // 24 registered languages). Retry with the default locale so the date
-      // renders instead of going blank in UI. Mirrors safeFormatDate.
-      console.warn('LocaleDatePipe: failed to format value', value, e);
-      try {
-        return new DatePipe(DEFAULT_LOCALE).transform(
-          value,
-          format,
-          timezone,
-          DEFAULT_LOCALE,
+      // Angular throws NG0701 when locale data for `effectiveLocale` isn't
+      // registered — reachable now that "System default" follows
+      // navigator.language. Fall back to the always-registered default
+      // locale so the date still renders. Mirrors safeFormatDate.
+      if (!this._warnedLocales.has(effectiveLocale)) {
+        this._warnedLocales.add(effectiveLocale);
+        console.warn(
+          `LocaleDatePipe: cannot format with locale "${effectiveLocale}", ` +
+            `using "${DEFAULT_LOCALE}"`,
+          e,
         );
+      }
+      try {
+        return this._fallbackDatePipe.transform(value, format, timezone, DEFAULT_LOCALE);
       } catch {
         return null;
       }

--- a/src/app/ui/pipes/locale-date.pipe.ts
+++ b/src/app/ui/pipes/locale-date.pipe.ts
@@ -1,6 +1,7 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { DateTimeFormatService } from '../../core/date-time-format/date-time-format.service';
+import { DEFAULT_LOCALE } from '../../core/locale.constants';
 
 /**
  * Custom date pipe that respects the user's configured locale
@@ -38,8 +39,21 @@ export class LocaleDatePipe implements PipeTransform {
     try {
       return this._datePipe.transform(value, format, timezone, effectiveLocale);
     } catch (e) {
+      // Angular throws RuntimeError(701) when locale data isn't registered
+      // (any locale whose language subtag isn't 'en' and isn't in the app's
+      // 24 registered languages). Retry with the default locale so the date
+      // renders instead of going blank in UI. Mirrors safeFormatDate.
       console.warn('LocaleDatePipe: failed to format value', value, e);
-      return null;
+      try {
+        return new DatePipe(DEFAULT_LOCALE).transform(
+          value,
+          format,
+          timezone,
+          DEFAULT_LOCALE,
+        );
+      } catch {
+        return null;
+      }
     }
   }
 }

--- a/src/app/util/datetime-formatter.ts
+++ b/src/app/util/datetime-formatter.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE, DateTimeLocale } from '../core/locale.constants';
+import { DEFAULT_LOCALE } from '../core/locale.constants';
 
 /**
  * Core datetime formatter
@@ -9,7 +9,7 @@ import { DEFAULT_LOCALE, DateTimeLocale } from '../core/locale.constants';
  * If we go further, perhaps we could improve this func to remove the current DatePipe (imported from @angular/common) in LocaleDatePipe.
  */
 export const dateTimeFormatter = (
-  locale: DateTimeLocale,
+  locale: string,
   overrides?: Intl.DateTimeFormatOptions,
 ): Intl.DateTimeFormat => {
   return new Intl.DateTimeFormat([locale, DEFAULT_LOCALE], {

--- a/src/app/util/format-day-month-str.ts
+++ b/src/app/util/format-day-month-str.ts
@@ -1,4 +1,3 @@
-import { DateTimeLocale } from '../core/locale.constants';
 import { dateTimeFormatter } from './datetime-formatter';
 
 /**
@@ -7,7 +6,7 @@ import { dateTimeFormatter } from './datetime-formatter';
  * @param locale - The locale string (e.g., 'en-US', 'de-DE')
  * @returns The formatted day and date string in the specified locale
  */
-export const formatDayMonthStr = (dateStr: string, locale: DateTimeLocale): string => {
+export const formatDayMonthStr = (dateStr: string, locale: string): string => {
   // Parse the date string as local date parts to avoid timezone issues
   const [year, month, day] = dateStr.split('-').map(Number);
   const date = new Date(year, month - 1, day);

--- a/src/app/util/format-month-day.util.ts
+++ b/src/app/util/format-month-day.util.ts
@@ -1,6 +1,5 @@
 import { LocaleDatePipe } from 'src/app/ui/pipes/locale-date.pipe';
 import { Log } from '../core/log';
-import { DateTimeLocale } from '../core/locale.constants';
 import { dateTimeFormatter } from './datetime-formatter';
 
 /**
@@ -17,7 +16,7 @@ import { dateTimeFormatter } from './datetime-formatter';
  * @param locale The locale string (e.g., 'en-US', 'de-DE')
  * @returns Formatted month/day string, or empty string if formatting fails
  */
-export const formatMonthDay = (date: Date, locale: DateTimeLocale): string => {
+export const formatMonthDay = (date: Date, locale: string): string => {
   try {
     // Validate the date first
     if (!date || isNaN(date.getTime())) return '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -328,7 +328,11 @@ bootstrapApplication(AppComponent, {
   // Register default locale immediately (statically imported, no network fetch)
   registerLocaleData(DEFAULT_LOCALE_DATA, DEFAULT_LANGUAGE);
 
-  // Lazily load and register remaining locales during idle time
+  // Lazily load and register remaining locales during idle time.
+  // The set includes English region variants (en-au, en-ca, en-nz, etc)
+  // not exposed in the UI dropdown — they back the navigator.language
+  // fallback so "System default" gets the right 12/24h + date format on
+  // those systems. See locale.constants.ts for the full list.
   const registerRemainingLocales = (): void => {
     Object.keys(LocaleImportFns).forEach((locale) => {
       if (locale !== DEFAULT_LANGUAGE) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_LOCALE_DATA,
   LocaleImportFns,
+  NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS,
 } from './app/core/locale.constants';
 import { IS_ANDROID_WEB_VIEW } from './app/util/is-android-web-view';
 import { androidInterface } from './app/features/android/android-interface';
@@ -329,10 +330,6 @@ bootstrapApplication(AppComponent, {
   registerLocaleData(DEFAULT_LOCALE_DATA, DEFAULT_LANGUAGE);
 
   // Lazily load and register remaining locales during idle time.
-  // The set includes English region variants (en-au, en-ca, en-nz, etc)
-  // not exposed in the UI dropdown — they back the navigator.language
-  // fallback so "System default" gets the right 12/24h + date format on
-  // those systems. See locale.constants.ts for the full list.
   const registerRemainingLocales = (): void => {
     Object.keys(LocaleImportFns).forEach((locale) => {
       if (locale !== DEFAULT_LANGUAGE) {
@@ -340,6 +337,11 @@ bootstrapApplication(AppComponent, {
           registerLocaleData(m.default, locale);
         });
       }
+    });
+    // Region variants backing the "System default" navigator.language
+    // fallback — not user-selectable (see locale.constants.ts).
+    Object.entries(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).forEach(([locale, load]) => {
+      load().then((m) => registerLocaleData(m.default, locale));
     });
   };
 


### PR DESCRIPTION
## Summary

- "System default" in **Settings → Language and Date/Time Format → Date and Time Locale** now follows the OS / browser locale instead of falling back to a hardcoded en-GB. Users on en-AU, en-CA, en-NZ, etc. see 12-hour times and dd/MM/yyyy dates without having to manually pick a locale.
- Register Angular locale data for eight English region variants (en-AU, en-CA, en-IE, en-IN, en-NZ, en-PH, en-SG, en-ZA) so `LocaleDatePipe` (used by snack/toast messages) also honours the system locale.
- Harden `LocaleDatePipe` to retry with `DEFAULT_LOCALE` on missing locale data so users on locales outside the registered set (es-MX, fr-CA, th-TH, …) keep getting en-GB-formatted dates instead of blank UI.

## Problem

`DateTimeFormatService.currentLocale` resolved the unset config value with:

```ts
this._globalConfigService.localization()?.dateTimeLocale || DEFAULT_LOCALE
```

…where `DEFAULT_LOCALE = DateTimeLocales.en_gb`. So **"System default"** always meant en-GB regardless of the user's actual OS locale. On an en-AU system, times rendered as `13:00` instead of `1:00 PM`.

Closed issue #5246 ("make the app follow the date and time format of the device") was marked resolved by the localization refactor, but that refactor only expanded the explicit locale dropdown — it didn't make the `Auto / System default` option follow the system.

Two related symptoms downstream:

1. The Material `DateAdapter` was only updated when `dateTimeLocale` was truthy, so System default never reached date pickers either.
2. Angular's `DatePipe` (via `LocaleDatePipe`, used by reminder/schedule toast messages) needs locale data registered. For unregistered regions like `en-au`, it falls back through the language code `'en'` — which `main.ts` registers with **en-GB** data — so toasts still showed 24-hour time even after `Intl`-based formatting was fixed.

## Changes

| File | Change |
| --- | --- |
| `src/app/core/locale.constants.ts` | Add `getSystemDefaultLocale()` returning `navigator.language.toLowerCase()` (typed `string` — the value is an arbitrary BCP-47 tag, not the curated union). Add 8 English region variants to `DateTimeLocales` + `LocaleImportFns` for the navigator.language fallback (not exposed in the dropdown). |
| `src/app/core/date-time-format/date-time-format.service.ts` | Use `getSystemDefaultLocale()` for the null fallback in `currentLocale`. Always propagate `currentLocale()` to `DateAdapter` (was guarded by truthy config). Relax locale parameter types to `string`. |
| `src/app/ui/pipes/locale-date.pipe.ts` | On `DatePipe.transform` failure (Angular `RuntimeError(701)` for unregistered locales), retry with `DEFAULT_LOCALE` before returning null. Mirrors `safeFormatDate`. |
| `src/app/util/{datetime-formatter,format-day-month-str,format-month-day.util}.ts`, `src/app/features/worklog/util/map-archive-to-worklog-weeks.ts` | Relax `locale` parameter from `DateTimeLocale` to `string`. |
| `src/app/core/date-time-format/date-time-format.service.spec.ts` | Add behavior specs: stub `navigator.language` to `en-AU` (asserts `is24HourFormat() === false`) and `de-DE` (asserts `=== true`). |
| `src/app/features/schedule/schedule/schedule.component.spec.ts` | Add missing `setLocale` to the `DateAdapter` stub. |

`Intl.DateTimeFormat` (used by `DateTimeFormatService.formatTime/formatDate` and `MatNativeDateAdapter`) accepts any BCP-47 string directly, so no additional registration is needed for those code paths.

## Test plan

- [x] `npm run test:file src/app/core/date-time-format/date-time-format.service.spec.ts` — 18/18 pass, including the new behavior specs.
- [x] `npm run test:file src/app/ui/pipes/short-time.pipe.spec.ts` / `locale-date.pipe.spec.ts` / `schedule-week.component.spec.ts` — pass.
- [x] Full `npm test` matches master baseline (same 8 pre-existing TZ-env failures, none new — Karma's Chrome subprocess doesn't inherit `TZ=Europe/Berlin` from the Node parent process, so date specs that depend on TZ shift across UTC+10 systems).
- [x] Prettier check passes on modified files.
- [x] `ng lint` passes on modified files.
- [x] Manual smoke test on Windows 11 with `Get-Culture` = `en-AU` (12-hour, dd/MM/yyyy):
  - Schedule view times display as `1:00 PM` instead of `13:00`.
  - Date display remains `dd/MM/yyyy`.
  - Reminder/scheduling toast shows `22/05/2026, 1:00 pm` instead of `22/05/2026, 13:00`.
  - Material date picker week starts on Monday (locale default preserved).

## Out of scope

Audit of the codebase surfaced several pre-existing locale bugs unrelated to the null fallback. Keeping this PR focused; happy to file separate issues:

- `is24HourFormat` signal called without `()` in `schedule-event.component.ts:150,162` — schedule event labels permanently 24-hour.
- Four templates using Angular's `| date:` instead of `| localeDate:` (restore-point, clipboard-images, reflection-history, user-profile dialogs).
- Hardcoded `momentFormat: 'HH:mm'` for display (not `<input type="time">`) in worklog-week, quick-history, schedule-day-panel drag preview, create-task-placeholder.
- `Date.toLocaleString()` with no locale argument in `dialog-restore-point.component.ts` and `local-backup.service.ts`.
- The `PLACEHOLDER_CREATE` example text `@16:00` is a literal translation string, not a formatted timestamp; the parser accepts both `@16:00` and `@4pm` regardless.

## References

- Closes #5246 properly (system locale was not actually being followed despite the issue being closed)
- Related: #5867, #7590, #5803, #4805 — all asking for variations of the same outcome