### PR TITLE
test(e2e): strengthen assertions across reviewed specs

### DIFF
--- a/e2e/tests/import-export/markdown-link-persistence.spec.ts
+++ b/e2e/tests/import-export/markdown-link-persistence.spec.ts
@@ -71,17 +71,16 @@ const waitForLocalOpsToPersist = async (page: Page, minCount: number): Promise<v
     .poll(
       () =>
         page.evaluate(async (expectedMinCount) => {
-          type CompactOperation = {
-            e?: string;
-            o?: string;
-          };
-          type Operation = {
-            entityType?: string;
-            opType?: string;
-          };
+          // Ops are persisted in either compact ({e, o}) or full ({entityType, opType})
+          // form depending on writer version — accept both.
           type StoredOperation = {
             source?: string;
-            op?: CompactOperation | Operation;
+            op?: {
+              e?: string;
+              o?: string;
+              entityType?: string;
+              opType?: string;
+            };
           };
 
           const db = await new Promise<IDBDatabase>((resolve, reject) => {
@@ -97,9 +96,8 @@ const waitForLocalOpsToPersist = async (page: Page, minCount: number): Promise<v
               const request = store.getAll();
               request.onsuccess = (): void => {
                 const ops = (request.result as StoredOperation[]).filter((entry) => {
-                  const op = entry.op;
-                  const entityType = op && ('e' in op ? op.e : op.entityType);
-                  const opType = op && ('o' in op ? op.o : op.opType);
+                  const entityType = entry.op?.e ?? entry.op?.entityType;
+                  const opType = entry.op?.o ?? entry.op?.opType;
                   return (
                     entry.source === 'local' &&
                     ((entityType === 'GLOBAL_CONFIG' && opType === 'UPD') ||
@@ -188,7 +186,7 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
       '[Website](https://example.com/)',
     );
     expect(persistedTaskState).not.toBeNull();
-    expect(persistedTaskState.title).toContain('[Website](https://example.com/)');
+    expect(persistedTaskState!.title).toContain('[Website](https://example.com/)');
 
     await page.reload();
     await page.waitForLoadState('networkidle');
@@ -204,7 +202,7 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
       '[Website](https://example.com/)',
     );
     expect(persistedTaskStateAfterReload).not.toBeNull();
-    expect(persistedTaskStateAfterReload.title).toContain(
+    expect(persistedTaskStateAfterReload!.title).toContain(
       '[Website](https://example.com/)',
     );
   });
@@ -288,9 +286,9 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
 
     const extractedTaskState = await getExtractedWebsiteTaskState(page);
     expect(extractedTaskState).not.toBeNull();
-    expect(extractedTaskState.title).toContain('Website');
-    expect(extractedTaskState.title).not.toContain('https://example.com/');
-    expect(extractedTaskState.title).not.toContain('[Website]');
+    expect(extractedTaskState!.title).toContain('Website');
+    expect(extractedTaskState!.title).not.toContain('https://example.com/');
+    expect(extractedTaskState!.title).not.toContain('[Website]');
 
     // Reload and verify the app still works
     await page.reload();
@@ -305,9 +303,9 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
 
     const extractedTaskStateAfterReload = await getExtractedWebsiteTaskState(page);
     expect(extractedTaskStateAfterReload).not.toBeNull();
-    expect(extractedTaskStateAfterReload.title).toContain('Website');
-    expect(extractedTaskStateAfterReload.title).not.toContain('https://example.com/');
-    expect(extractedTaskStateAfterReload.title).not.toContain('[Website]');
+    expect(extractedTaskStateAfterReload!.title).toContain('Website');
+    expect(extractedTaskStateAfterReload!.title).not.toContain('https://example.com/');
+    expect(extractedTaskStateAfterReload!.title).not.toContain('[Website]');
   });
 
   test('malformed title from extract mode should survive reload', async ({
@@ -330,7 +328,7 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
 
     const persistedTaskState = await getTaskStateByTitle(page, malformedTitle);
     expect(persistedTaskState).not.toBeNull();
-    expect(persistedTaskState.title).toContain(malformedTitle);
+    expect(persistedTaskState!.title).toContain(malformedTitle);
 
     await page.reload();
     await page.waitForLoadState('networkidle');
@@ -342,6 +340,6 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
 
     const persistedTaskStateAfterReload = await getTaskStateByTitle(page, malformedTitle);
     expect(persistedTaskStateAfterReload).not.toBeNull();
-    expect(persistedTaskStateAfterReload.title).toContain(malformedTitle);
+    expect(persistedTaskStateAfterReload!.title).toContain(malformedTitle);
   });
 });

--- a/e2e/tests/import-export/markdown-link-persistence.spec.ts
+++ b/e2e/tests/import-export/markdown-link-persistence.spec.ts
@@ -19,6 +19,153 @@ const dismissViteOverlay = async (page: Page): Promise<void> => {
   }
 };
 
+type ExtractedTaskState = {
+  title: string;
+};
+
+const getTaskStateByTitle = async (
+  page: Page,
+  titleIncludes: string,
+): Promise<ExtractedTaskState | null> =>
+  page.evaluate((title) => {
+    type TaskLike = {
+      title?: string;
+    };
+    type StoreState = {
+      tasks?: {
+        entities?: Record<string, TaskLike | undefined>;
+      };
+    };
+    type StoreSubscription = {
+      unsubscribe: () => void;
+    };
+    type StoreLike = {
+      subscribe: (next: (state: StoreState) => void) => StoreSubscription;
+    };
+    type E2ETestHelpers = {
+      store?: StoreLike;
+    };
+
+    const helpers = (window as unknown as { __e2eTestHelpers?: E2ETestHelpers })
+      .__e2eTestHelpers;
+    const store = helpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+
+    let latestState: StoreState | undefined;
+    const subscription = store.subscribe((state) => {
+      latestState = state;
+    });
+    subscription.unsubscribe();
+
+    const task = Object.values(latestState?.tasks?.entities ?? {}).find((candidate) =>
+      candidate?.title?.includes(title),
+    );
+
+    return task ? { title: task.title ?? '' } : null;
+  }, titleIncludes);
+
+const waitForLocalOpsToPersist = async (page: Page, minCount: number): Promise<void> => {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(async (expectedMinCount) => {
+          type CompactOperation = {
+            e?: string;
+            o?: string;
+          };
+          type Operation = {
+            entityType?: string;
+            opType?: string;
+          };
+          type StoredOperation = {
+            source?: string;
+            op?: CompactOperation | Operation;
+          };
+
+          const db = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('SUP_OPS');
+            request.onsuccess = (): void => resolve(request.result);
+            request.onerror = (): void => reject(request.error);
+          });
+
+          try {
+            const tx = db.transaction('ops', 'readonly');
+            const store = tx.objectStore('ops');
+            const persistedCount = await new Promise<number>((resolve, reject) => {
+              const request = store.getAll();
+              request.onsuccess = (): void => {
+                const ops = (request.result as StoredOperation[]).filter((entry) => {
+                  const op = entry.op;
+                  const entityType = op && ('e' in op ? op.e : op.entityType);
+                  const opType = op && ('o' in op ? op.o : op.opType);
+                  return (
+                    entry.source === 'local' &&
+                    ((entityType === 'GLOBAL_CONFIG' && opType === 'UPD') ||
+                      entityType === 'TASK')
+                  );
+                });
+                resolve(ops.length);
+              };
+              request.onerror = (): void => reject(request.error);
+            });
+
+            return persistedCount >= expectedMinCount;
+          } finally {
+            db.close();
+          }
+        }, minCount),
+      { timeout: 10000 },
+    )
+    .toBe(true);
+};
+
+const getExtractedWebsiteTaskState = async (
+  page: Page,
+): Promise<ExtractedTaskState | null> =>
+  page.evaluate(() => {
+    type TaskLike = {
+      title?: string;
+    };
+    type StoreState = {
+      tasks?: {
+        entities?: Record<string, TaskLike | undefined>;
+      };
+    };
+    type StoreSubscription = {
+      unsubscribe: () => void;
+    };
+    type StoreLike = {
+      subscribe: (next: (state: StoreState) => void) => StoreSubscription;
+    };
+    type E2ETestHelpers = {
+      store?: StoreLike;
+    };
+
+    const helpers = (window as unknown as { __e2eTestHelpers?: E2ETestHelpers })
+      .__e2eTestHelpers;
+    const store = helpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+
+    let latestState: StoreState | undefined;
+    const subscription = store.subscribe((state) => {
+      latestState = state;
+    });
+    subscription.unsubscribe();
+
+    const task = Object.values(latestState?.tasks?.entities ?? {}).find(
+      (candidate) =>
+        candidate?.title?.includes('Website') &&
+        !candidate.title.includes('https://example.com/') &&
+        !candidate.title.includes('[Website]'),
+    );
+
+    return task ? { title: task.title ?? '' } : null;
+  });
+
 test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
   test('task with markdown link should survive reload', async ({
     page,
@@ -30,9 +177,18 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
     await workViewPage.waitForTaskList();
     await dismissViteOverlay(page);
     await workViewPage.addTask('[Website](https://example.com/)');
+    await waitForLocalOpsToPersist(page, 1);
 
     const task = taskPage.getTaskByText('Website');
     await expect(task).toBeVisible();
+    await expect(task.locator('a[href="https://example.com/"]')).toBeVisible();
+
+    const persistedTaskState = await getTaskStateByTitle(
+      page,
+      '[Website](https://example.com/)',
+    );
+    expect(persistedTaskState).not.toBeNull();
+    expect(persistedTaskState.title).toContain('[Website](https://example.com/)');
 
     await page.reload();
     await page.waitForLoadState('networkidle');
@@ -41,6 +197,16 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
 
     const taskAfterReload = taskPage.getTaskByText('Website');
     await expect(taskAfterReload).toBeVisible();
+    await expect(taskAfterReload.locator('a[href="https://example.com/"]')).toBeVisible();
+
+    const persistedTaskStateAfterReload = await getTaskStateByTitle(
+      page,
+      '[Website](https://example.com/)',
+    );
+    expect(persistedTaskStateAfterReload).not.toBeNull();
+    expect(persistedTaskStateAfterReload.title).toContain(
+      '[Website](https://example.com/)',
+    );
   });
 
   test('task with markdown link should survive reload with urlBehavior extract', async ({
@@ -53,47 +219,78 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
     await workViewPage.waitForTaskList();
     await dismissViteOverlay(page);
 
-    // Set urlBehavior to 'extract' via IndexedDB state_cache
-    await page.evaluate(async () => {
-      const DB_NAME = 'SUP_OPS';
-      const db = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open(DB_NAME);
-        request.onsuccess = (): void => resolve(request.result);
-        request.onerror = (): void => reject(request.error);
-      });
+    // Set urlBehavior to 'extract' through the same NgRx action the settings UI uses.
+    const didUpdateShortSyntaxConfig = await page.evaluate(async () => {
+      type StoreState = {
+        globalConfig?: {
+          shortSyntax?: {
+            urlBehavior?: string;
+          };
+        };
+      };
+      type StoreSubscription = {
+        unsubscribe: () => void;
+      };
+      type StoreLike = {
+        dispatch: (action: unknown) => void;
+        subscribe: (next: (state: StoreState) => void) => StoreSubscription;
+      };
+      type E2ETestHelpers = {
+        store?: StoreLike;
+      };
 
-      const tx = db.transaction('state_cache', 'readwrite');
-      const store = tx.objectStore('state_cache');
-
-      const entry = await new Promise<any>((resolve, reject) => {
-        const request = store.get('current');
-        request.onsuccess = (): void => resolve(request.result);
-        request.onerror = (): void => reject(request.error);
-      });
-
-      if (entry?.state?.globalConfig?.shortSyntax) {
-        entry.state.globalConfig.shortSyntax.urlBehavior = 'extract';
-        await new Promise<void>((resolve, reject) => {
-          const putReq = store.put(entry, 'current');
-          putReq.onsuccess = (): void => resolve();
-          putReq.onerror = (): void => reject(putReq.error);
-        });
+      const helpers = (window as unknown as { __e2eTestHelpers?: E2ETestHelpers })
+        .__e2eTestHelpers;
+      const store = helpers?.store;
+      if (!store) {
+        throw new Error('__e2eTestHelpers.store missing');
       }
 
-      db.close();
+      return new Promise<boolean>((resolve, reject) => {
+        const subscriptionRef: { current?: StoreSubscription } = {};
+        const timeoutId = window.setTimeout(() => {
+          subscriptionRef.current?.unsubscribe();
+          reject(new Error('Timed out waiting for urlBehavior extract'));
+        }, 5000);
+        subscriptionRef.current = store.subscribe((state) => {
+          if (state.globalConfig?.shortSyntax?.urlBehavior === 'extract') {
+            window.clearTimeout(timeoutId);
+            subscriptionRef.current?.unsubscribe();
+            resolve(true);
+          }
+        });
+
+        store.dispatch({
+          type: '[Global Config] Update Global Config Section',
+          sectionKey: 'shortSyntax',
+          sectionCfg: { urlBehavior: 'extract' },
+          isSkipSnack: true,
+          meta: {
+            isPersistent: true,
+            entityType: 'GLOBAL_CONFIG',
+            entityId: 'shortSyntax',
+            opType: 'UPD',
+          },
+        });
+      });
     });
+    expect(didUpdateShortSyntaxConfig).toBe(true);
+    await waitForLocalOpsToPersist(page, 1);
 
-    // Reload to pick up the config change
-    await page.reload();
-    await page.waitForLoadState('networkidle');
-    await workViewPage.waitForTaskList();
-    await dismissViteOverlay(page);
-
-    // Add task — extract mode will remove the URL and mangle the title
+    // Add task - extract mode removes the URL while keeping the markdown label text.
     await workViewPage.addTask('[Website](https://example.com/)');
+    await waitForLocalOpsToPersist(page, 2);
 
-    const allTasks = await taskPage.getAllTasks().allTextContents();
-    expect(allTasks.length).toBeGreaterThan(0);
+    const task = taskPage.getTaskByText('Website');
+    await expect(task).toBeVisible();
+    await expect(task).not.toContainText('https://example.com/');
+    await expect(task.locator('a[href*="example.com"]')).toHaveCount(0);
+
+    const extractedTaskState = await getExtractedWebsiteTaskState(page);
+    expect(extractedTaskState).not.toBeNull();
+    expect(extractedTaskState.title).toContain('Website');
+    expect(extractedTaskState.title).not.toContain('https://example.com/');
+    expect(extractedTaskState.title).not.toContain('[Website]');
 
     // Reload and verify the app still works
     await page.reload();
@@ -101,8 +298,16 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
     await workViewPage.waitForTaskList();
     await dismissViteOverlay(page);
 
-    const tasksAfterReload = await taskPage.getAllTasks().allTextContents();
-    expect(tasksAfterReload.length).toBeGreaterThan(0);
+    const taskAfterReload = taskPage.getTaskByText('Website');
+    await expect(taskAfterReload).toBeVisible();
+    await expect(taskAfterReload).not.toContainText('https://example.com/');
+    await expect(taskAfterReload.locator('a[href*="example.com"]')).toHaveCount(0);
+
+    const extractedTaskStateAfterReload = await getExtractedWebsiteTaskState(page);
+    expect(extractedTaskStateAfterReload).not.toBeNull();
+    expect(extractedTaskStateAfterReload.title).toContain('Website');
+    expect(extractedTaskStateAfterReload.title).not.toContain('https://example.com/');
+    expect(extractedTaskStateAfterReload.title).not.toContain('[Website]');
   });
 
   test('malformed title from extract mode should survive reload', async ({
@@ -116,17 +321,27 @@ test.describe('@markdown-link Markdown link persistence (issue #7032)', () => {
     await dismissViteOverlay(page);
 
     // Directly create a task with the mangled title that extract mode produces
-    await workViewPage.addTask('Add [Website](');
+    const malformedTitle = 'Add [Website](';
+    await workViewPage.addTask(malformedTitle);
+    await waitForLocalOpsToPersist(page, 1);
 
-    const task = taskPage.getTaskByText('[Website]');
+    const task = taskPage.getTaskByText(malformedTitle);
     await expect(task).toBeVisible();
+
+    const persistedTaskState = await getTaskStateByTitle(page, malformedTitle);
+    expect(persistedTaskState).not.toBeNull();
+    expect(persistedTaskState.title).toContain(malformedTitle);
 
     await page.reload();
     await page.waitForLoadState('networkidle');
     await workViewPage.waitForTaskList();
     await dismissViteOverlay(page);
 
-    const taskAfterReload = taskPage.getTaskByText('[Website]');
+    const taskAfterReload = taskPage.getTaskByText(malformedTitle);
     await expect(taskAfterReload).toBeVisible();
+
+    const persistedTaskStateAfterReload = await getTaskStateByTitle(page, malformedTitle);
+    expect(persistedTaskStateAfterReload).not.toBeNull();
+    expect(persistedTaskStateAfterReload.title).toContain(malformedTitle);
   });
 });

--- a/e2e/tests/issue-provider-panel/issue-provider-panel.spec.ts
+++ b/e2e/tests/issue-provider-panel/issue-provider-panel.spec.ts
@@ -5,11 +5,6 @@ const PANEL_BTN = '.e2e-toggle-issue-provider-panel';
 
 test.describe('Issue Provider Panel', () => {
   test('should open all dialogs without error', async ({ page, workViewPage }) => {
-    const pageErrors: string[] = [];
-    page.on('pageerror', (error) => {
-      pageErrors.push(error.message);
-    });
-
     // Wait for work view to be ready
     await workViewPage.waitForTaskList();
 
@@ -25,6 +20,15 @@ test.describe('Issue Provider Panel', () => {
       .locator('issue-provider-setup-overview button')
       .first()
       .waitFor({ state: 'visible', timeout: 5000 });
+
+    // Start capturing page errors only after the panel is settled so we don't
+    // pick up unrelated startup noise (vite overlay, lazy-chunk warnings, etc.)
+    // that the surrounding suite tolerates.
+    const pageErrors: string[] = [];
+    const onPageError = (error: Error): void => {
+      pageErrors.push(error.message);
+    };
+    page.on('pageerror', onPageError);
 
     // Get all buttons in the issue provider setup overview
     const setupButtons = page.locator('issue-provider-setup-overview button');
@@ -60,6 +64,7 @@ test.describe('Issue Provider Panel', () => {
     }
 
     expect(openedDialogCount).toBe(buttonCount);
+    page.off('pageerror', onPageError);
     await expectNoGlobalError(page);
     expect(pageErrors).toEqual([]);
   });

--- a/e2e/tests/issue-provider-panel/issue-provider-panel.spec.ts
+++ b/e2e/tests/issue-provider-panel/issue-provider-panel.spec.ts
@@ -1,10 +1,15 @@
-import { test } from '../../fixtures/test.fixture';
+import { expect, test } from '../../fixtures/test.fixture';
+import { expectNoGlobalError } from '../../utils/assertions';
 
 const PANEL_BTN = '.e2e-toggle-issue-provider-panel';
-const CANCEL_BTN = 'mat-dialog-actions button:first-child';
 
 test.describe('Issue Provider Panel', () => {
   test('should open all dialogs without error', async ({ page, workViewPage }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message);
+    });
+
     // Wait for work view to be ready
     await workViewPage.waitForTaskList();
 
@@ -24,51 +29,38 @@ test.describe('Issue Provider Panel', () => {
     // Get all buttons in the issue provider setup overview
     const setupButtons = page.locator('issue-provider-setup-overview button');
     const buttonCount = await setupButtons.count();
+    expect(buttonCount).toBeGreaterThan(0);
 
     // Click each button and close the dialog
+    let openedDialogCount = 0;
     for (let i = 0; i < buttonCount; i++) {
       const button = setupButtons.nth(i);
 
-      // Skip if button is not visible or enabled
-      const isVisible = await button.isVisible().catch(() => false);
-      const isEnabled = await button.isEnabled().catch(() => false);
+      await expect(button).toBeVisible();
+      await expect(button).toBeEnabled();
+      await button.click();
 
-      if (isVisible && isEnabled) {
-        await button.click();
+      // Wait for dialog to open
+      const dialogContainer = page.locator('mat-dialog-container');
+      await expect(dialogContainer).toBeVisible({ timeout: 5000 });
+      openedDialogCount++;
 
-        // Wait for dialog to open
-        const dialogOpened = await page
-          .waitForSelector(CANCEL_BTN, {
-            state: 'visible',
-            timeout: 5000,
-          })
-          .catch(() => null);
+      // Close the dialog from within the dialog container.
+      const cancelBtn = dialogContainer.locator('mat-dialog-actions button').first();
+      await expect(cancelBtn).toBeVisible({ timeout: 5000 });
+      await cancelBtn.click();
 
-        if (dialogOpened) {
-          // Wait for dialog container to be stable
-          const dialogContainer = page.locator('mat-dialog-container');
-          await dialogContainer.waitFor({ state: 'visible', timeout: 5000 });
+      // Wait for dialog to close
+      await expect(dialogContainer).toBeHidden({ timeout: 5000 });
 
-          // Try to click cancel within the dialog container
-          const cancelBtn = dialogContainer.locator('mat-dialog-actions button').first();
-          const cancelClicked = await cancelBtn
-            .click({ timeout: 5000 })
-            .catch(() => false);
-
-          if (cancelClicked !== false) {
-            // Wait for dialog to close
-            await dialogContainer.waitFor({ state: 'detached', timeout: 5000 });
-          }
-
-          // Ensure we're back on the issue provider panel
-          await page.waitForSelector('issue-provider-setup-overview', {
-            state: 'visible',
-            timeout: 3000,
-          });
-        }
-      }
+      // Ensure we're back on the issue provider panel
+      await expect(page.locator('issue-provider-setup-overview')).toBeVisible({
+        timeout: 3000,
+      });
     }
 
-    // No error check is implicit - test will fail if any error occurs
+    expect(openedDialogCount).toBe(buttonCount);
+    await expectNoGlobalError(page);
+    expect(pageErrors).toEqual([]);
   });
 });

--- a/e2e/tests/plugins/plugin-feature-check.spec.ts
+++ b/e2e/tests/plugins/plugin-feature-check.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../../fixtures/test.fixture';
 
-test.describe.serial('Plugin Feature Check', () => {
-  test('check if PluginService exists', async ({ page, workViewPage }) => {
+test.describe.serial('Plugin Management Feature Check', () => {
+  test('renders plugin management install controls', async ({ page, workViewPage }) => {
     // Wait for Angular app to be fully loaded
     await workViewPage.waitForTaskList();
 
@@ -12,58 +12,35 @@ test.describe.serial('Plugin Feature Check', () => {
     const pluginsTab = page.getByRole('tab', { name: 'Plugins' });
     await pluginsTab.click();
 
-    // Verify plugin management component exists (proves PluginService is loaded)
-    // The plugin-management component requires PluginService to be injected and functional
     const pluginMgmt = page.locator('plugin-management');
-    await expect(pluginMgmt).toBeAttached({ timeout: 10000 });
-
-    // Additional verification: check that plugin management has rendered content
-    // This confirms the service is not only loaded but also working correctly
-    const pluginCards = pluginMgmt.locator('mat-card');
-    await expect(pluginCards.first()).toBeVisible({ timeout: 10000 });
+    await expect(pluginMgmt).toBeVisible({ timeout: 10000 });
+    await expect(
+      pluginMgmt.getByRole('button', { name: /Choose Plugin File/i }),
+    ).toBeVisible();
+    await expect(
+      pluginMgmt.getByRole('button', { name: /Clear Plugin Cache/i }),
+    ).toBeVisible();
   });
 
-  test('check plugin UI elements in DOM', async ({ page, workViewPage }) => {
+  test('renders community plugin catalog', async ({ page, workViewPage }) => {
     // Wait for work view to be ready
     await workViewPage.waitForTaskList();
 
     // Navigate to config page
     await page.goto('/#/config');
+    await expect(page.locator('.page-settings')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('tab', { name: 'Plugins' }).click();
 
-    await page.evaluate(() => {
-      const uiResults: {
-        hasPluginManagementTag: boolean;
-        hasPluginSection: boolean;
-        hasMagicSideNav: boolean;
-        hasPluginHeaderBtns: boolean;
-        hasPluginTextInBody: boolean;
-        hasPluginTextInConfig?: boolean;
-      } = {
-        hasPluginManagementTag: false,
-        hasPluginSection: false,
-        hasMagicSideNav: false,
-        hasPluginHeaderBtns: false,
-        hasPluginTextInBody: false,
-      };
-
-      // Check various plugin-related elements
-      uiResults.hasPluginManagementTag = !!document.querySelector('plugin-management');
-      uiResults.hasPluginSection = !!document.querySelector('.plugin-section');
-      uiResults.hasMagicSideNav = !!document.querySelector('magic-side-nav');
-      uiResults.hasPluginHeaderBtns = !!document.querySelector('plugin-header-btns');
-
-      // Check if plugin text appears anywhere
-      const bodyText = (document.body as HTMLElement).innerText || '';
-      uiResults.hasPluginTextInBody = bodyText.toLowerCase().includes('plugin');
-
-      // Check config page
-      const configPage = document.querySelector('.page-settings');
-      if (configPage) {
-        const configText = (configPage as HTMLElement).innerText || '';
-        uiResults.hasPluginTextInConfig = configText.toLowerCase().includes('plugin');
-      }
-
-      return uiResults;
-    });
+    const pluginManagement = page.locator('plugin-management');
+    await expect(pluginManagement).toBeVisible({ timeout: 10000 });
+    await expect(
+      pluginManagement.locator('.community-plugins-card mat-card-title'),
+    ).toContainText('Community Plugins');
+    await expect(
+      pluginManagement.locator('.community-plugin-item').first(),
+    ).toBeVisible();
+    await expect(
+      pluginManagement.getByRole('link', { name: /Get your plugin to show up here/i }),
+    ).toHaveAttribute('href', /community-plugins\.json/);
   });
 });

--- a/e2e/tests/plugins/plugin-structure-test.spec.ts
+++ b/e2e/tests/plugins/plugin-structure-test.spec.ts
@@ -1,12 +1,9 @@
 import { test, expect } from '../../fixtures/test.fixture';
-import { cssSelectors } from '../../constants/selectors';
 import {
   waitForPluginAssets,
   waitForPluginManagementInit,
   getCITimeoutMultiplier,
 } from '../../helpers/plugin-test.helpers';
-
-const { SETTINGS_BTN } = cssSelectors;
 
 test.describe.serial('Plugin Structure Test', () => {
   test('check plugin card structure', async ({ page, workViewPage }) => {
@@ -32,97 +29,18 @@ test.describe.serial('Plugin Structure Test', () => {
       );
     }
 
-    // Navigate to plugin settings (implementing navigateToPluginSettings inline)
-    await page.click(SETTINGS_BTN);
-    await page
-      .locator('.page-settings')
-      .first()
-      .waitFor({ state: 'visible', timeout: 10000 });
+    const pluginManagement = page.locator('plugin-management');
+    const apiTestCard = pluginManagement
+      .locator('mat-card')
+      .filter({ hasText: 'API Test Plugin' })
+      .first();
+    const enableSwitch = apiTestCard.locator('mat-slide-toggle [role="switch"]').first();
 
-    // Execute script to navigate to plugin section
-    await page.evaluate(() => {
-      // First ensure we're on the config page
-      const configPage = document.querySelector('.page-settings');
-      if (!configPage) {
-        console.error('Not on config page');
-        return;
-      }
-
-      // Scroll to plugins section
-      const pluginSection = document.querySelector('.plugin-section');
-      if (pluginSection) {
-        pluginSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      } else {
-        console.error('Plugin section not found');
-        return;
-      }
-
-      // Make sure collapsible is expanded - click the header to toggle
-      const collapsible = document.querySelector('.plugin-section collapsible');
-      if (collapsible) {
-        const isExpanded = collapsible.classList.contains('isExpanded');
-        if (!isExpanded) {
-          // Click the collapsible header to expand it
-          const header = collapsible.querySelector('.collapsible-header');
-          if (header) {
-            (header as HTMLElement).click();
-            // console.log('Clicked to expand plugin collapsible');
-          } else {
-            console.error('Could not find collapsible header');
-          }
-        } else {
-          // console.log('Plugin collapsible already expanded');
-        }
-      } else {
-        console.error('Plugin collapsible not found');
-      }
-    });
-
-    await expect(page.locator('plugin-management')).toBeVisible({ timeout: 10000 });
-
-    // Check plugin card structure
-    await page.evaluate(() => {
-      const cards = Array.from(document.querySelectorAll('plugin-management mat-card'));
-      const apiTestCard = cards.find((card) => {
-        const title = card.querySelector('mat-card-title')?.textContent || '';
-        return title.includes('API Test Plugin');
-      });
-
-      if (!apiTestCard) {
-        return { found: false };
-      }
-
-      // Look for all possible toggle selectors
-      const toggleSelectors = [
-        'mat-slide-toggle input',
-        'mat-slide-toggle button',
-        '.mat-mdc-slide-toggle input',
-        '.mat-mdc-slide-toggle button',
-        '[role="switch"]',
-        'input[type="checkbox"]',
-      ];
-
-      const toggleResults = toggleSelectors.map((selector) => ({
-        selector,
-        found: !!apiTestCard.querySelector(selector),
-        element: apiTestCard.querySelector(selector)?.tagName,
-      }));
-
-      // Get the card's inner HTML structure
-      const cardStructure = apiTestCard.innerHTML.substring(0, 500);
-
-      return {
-        found: true,
-        cardTitle: apiTestCard.querySelector('mat-card-title')?.textContent,
-        toggleResults,
-        cardStructure,
-        hasMatSlideToggle: !!apiTestCard.querySelector('mat-slide-toggle'),
-        allInputs: Array.from(apiTestCard.querySelectorAll('input')).map((input) => ({
-          type: input.type,
-          id: input.id,
-          class: input.className,
-        })),
-      };
-    });
+    await expect(pluginManagement).toBeVisible({ timeout: 10000 });
+    await expect(apiTestCard).toBeVisible({ timeout: 10000 });
+    await expect(apiTestCard.locator('mat-card-title')).toContainText('API Test Plugin');
+    await expect(apiTestCard.locator('mat-card-subtitle')).toContainText(/v\d/);
+    await expect(enableSwitch).toBeVisible();
+    await expect(enableSwitch).toHaveAttribute('aria-checked', /^(true|false)$/);
   });
 });

--- a/e2e/tests/plugins/test-plugin-visibility.spec.ts
+++ b/e2e/tests/plugins/test-plugin-visibility.spec.ts
@@ -21,77 +21,35 @@ test.describe.serial('Plugin Visibility', () => {
     // Navigate to settings
     await page.click(SETTINGS_BTN);
     await page.waitForSelector(ROUTER_WRAPPER, { state: 'visible' });
+    await page.getByRole('tab', { name: 'Plugins' }).click();
 
-    const results = await page.evaluate(() => {
-      const pageResults: {
-        hasPluginSection: boolean;
-        hasPluginManagement: boolean;
-        hasCollapsible: boolean;
-        pluginHeading?: Element;
-        headingText: string;
-        sectionCount: number;
-        sectionClasses: string[];
-        hasConfigPage: boolean;
-      } = {
-        hasPluginSection: false,
-        hasPluginManagement: false,
-        hasCollapsible: false,
-        headingText: '',
-        sectionCount: 0,
-        sectionClasses: [],
-        hasConfigPage: false,
-      };
-
-      // Check for plugin section
-      pageResults.hasPluginSection = !!document.querySelector('.plugin-section');
-      pageResults.hasPluginManagement = !!document.querySelector('plugin-management');
-      pageResults.hasCollapsible = !!document.querySelector(
-        '.plugin-section collapsible',
-      );
-
-      // Check for plugin heading
-      const headings = Array.from(document.querySelectorAll('h2'));
-      pageResults.pluginHeading = headings.find((h) => h.textContent?.includes('Plugin'));
-      pageResults.headingText = pageResults.pluginHeading?.textContent || 'Not found';
-
-      // Get all section classes
-      const sections = Array.from(document.querySelectorAll('.config-section'));
-      pageResults.sectionCount = sections.length;
-      pageResults.sectionClasses = sections.map((s) => s.className);
-
-      // Check entire page HTML for debugging
-      const configPage = document.querySelector('.page-settings');
-      pageResults.hasConfigPage = !!configPage;
-
-      return pageResults;
-    });
-
-    // console.log('Page structure results:', results);
-    expect(results).toBeTruthy();
+    const settingsPage = page.locator('.page-settings');
+    const pluginManagement = page.locator('plugin-management');
+    await expect(settingsPage).toBeVisible();
+    await expect(page.locator('.plugin-section')).toBeVisible({ timeout: 10000 });
+    await expect(pluginManagement).toBeVisible({ timeout: 10000 });
   });
 
-  test('log page content for debugging', async ({ page, workViewPage }) => {
+  test('settings page includes plugin content', async ({ page, workViewPage }) => {
     // Wait for work view to be ready
     await workViewPage.waitForTaskList();
 
     // Navigate to settings
     await page.click(SETTINGS_BTN);
     await page.waitForSelector(ROUTER_WRAPPER, { state: 'visible' });
+    await page.getByRole('tab', { name: 'Plugins' }).click();
 
-    await page.evaluate(() => {
-      const configContent =
-        document.querySelector('.page-settings')?.innerHTML || 'No config page found';
-      // console.log('Config page content length:', configContent.length);
+    const settingsPage = page.locator('.page-settings');
+    const pluginManagement = page.locator('plugin-management');
+    const apiTestPluginCard = pluginManagement
+      .locator('mat-card')
+      .filter({ hasText: 'API Test Plugin' })
+      .first();
 
-      // Look for any mentions of plugin
-      const pluginMentions = configContent.match(/plugin/gi) || [];
-      // console.log('Plugin mentions found:', pluginMentions.length);
-
-      return {
-        contentLength: configContent.length,
-        pluginMentions: pluginMentions.length,
-        hasPluginText: configContent.toLowerCase().includes('plugin'),
-      };
-    });
+    await expect(settingsPage).toBeVisible();
+    await expect(pluginManagement).toBeVisible({ timeout: 10000 });
+    await expect(apiTestPluginCard.locator('mat-card-title')).toHaveText(
+      'API Test Plugin',
+    );
   });
 });

--- a/e2e/tests/recurring/recurring-task.spec.ts
+++ b/e2e/tests/recurring/recurring-task.spec.ts
@@ -71,9 +71,13 @@ const getTaskStateByTitle = async (
       : null;
   }, taskTitle);
 
+// Mirrors BasePage.addTask but skips the "wait for the task in the today list"
+// step that would time out for tasks scheduled for a future day. Caller is
+// expected to pre-bake the testPrefix into `rawTaskInput` since BasePage's
+// internal prefix logic is not reused here.
 const addTaskWithoutWaitingForTodayList = async (
   page: Page,
-  taskTitle: string,
+  rawTaskInput: string,
 ): Promise<void> => {
   const inputEl = page.locator('add-task-bar.global input');
   const isInputVisible = await inputEl
@@ -88,7 +92,7 @@ const addTaskWithoutWaitingForTodayList = async (
   await input.waitFor({ state: 'visible', timeout: 10000 });
   await input.click();
   await input.clear();
-  await input.fill(taskTitle);
+  await input.fill(rawTaskInput);
   await page.locator('.e2e-add-task-submit').click();
 };
 
@@ -221,7 +225,9 @@ test.describe('Scheduled Task Operations', () => {
   }) => {
     await workViewPage.waitForTaskList();
 
-    // Create task with @tomorrow short syntax
+    // Create task with @tomorrow short syntax. workViewPage.addTask cannot be
+    // used because it waits for the new task in the today list and tomorrow's
+    // task does not show up there.
     const taskTitle = `${testPrefix}-Tomorrow Task`;
     await addTaskWithoutWaitingForTodayList(page, `${taskTitle} @tomorrow`);
 

--- a/e2e/tests/recurring/recurring-task.spec.ts
+++ b/e2e/tests/recurring/recurring-task.spec.ts
@@ -1,4 +1,112 @@
 import { test, expect } from '../../fixtures/test.fixture';
+import { type Page } from '@playwright/test';
+
+const DB_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ONE_HOUR = 60 * 60 * 1000;
+const THIRTY_MINUTES = 30 * 60 * 1000;
+
+type TaskStateSnapshot = {
+  title: string;
+  dueDay?: string | null;
+  timeEstimate?: number | null;
+};
+
+const getDbDateStr = async (page: Page, offsetDays = 0): Promise<string> =>
+  page.evaluate((offset) => {
+    const date = new Date();
+    date.setDate(date.getDate() + offset);
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+  }, offsetDays);
+
+const getTaskStateByTitle = async (
+  page: Page,
+  taskTitle: string,
+): Promise<TaskStateSnapshot | null> =>
+  page.evaluate((title) => {
+    type TaskLike = {
+      title?: string;
+      dueDay?: string | null;
+      timeEstimate?: number | null;
+    };
+    type StoreState = {
+      tasks?: {
+        entities?: Record<string, TaskLike | undefined>;
+      };
+    };
+    type StoreSubscription = {
+      unsubscribe: () => void;
+    };
+    type StoreLike = {
+      subscribe: (next: (state: StoreState) => void) => StoreSubscription;
+    };
+    type E2ETestHelpers = {
+      store?: StoreLike;
+    };
+
+    const helpers = (window as unknown as { __e2eTestHelpers?: E2ETestHelpers })
+      .__e2eTestHelpers;
+    const store = helpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+
+    let latestState: StoreState | undefined;
+    const subscription = store.subscribe((state) => {
+      latestState = state;
+    });
+    subscription.unsubscribe();
+
+    const task = Object.values(latestState?.tasks?.entities ?? {}).find((candidate) =>
+      candidate?.title?.includes(title),
+    );
+
+    return task
+      ? {
+          title: task.title ?? '',
+          dueDay: task.dueDay ?? null,
+          timeEstimate: task.timeEstimate ?? null,
+        }
+      : null;
+  }, taskTitle);
+
+const addTaskWithoutWaitingForTodayList = async (
+  page: Page,
+  taskTitle: string,
+): Promise<void> => {
+  const inputEl = page.locator('add-task-bar.global input');
+  const isInputVisible = await inputEl
+    .first()
+    .isVisible()
+    .catch(() => false);
+  if (!isInputVisible) {
+    await page.locator('.tour-addBtn').click();
+  }
+
+  const input = inputEl.first();
+  await input.waitFor({ state: 'visible', timeout: 10000 });
+  await input.click();
+  await input.clear();
+  await input.fill(taskTitle);
+  await page.locator('.e2e-add-task-submit').click();
+};
+
+const expectTaskTitleWithoutShortSyntax = async (
+  page: Page,
+  taskTitle: string,
+  token: string,
+): Promise<TaskStateSnapshot> => {
+  await expect
+    .poll(async () => (await getTaskStateByTitle(page, taskTitle))?.title ?? null)
+    .not.toBeNull();
+
+  const taskState = await getTaskStateByTitle(page, taskTitle);
+  expect(taskState).not.toBeNull();
+  expect(taskState!.title).toContain(taskTitle);
+  expect(taskState!.title).not.toContain(token);
+  return taskState!;
+};
 
 /**
  * Recurring/Scheduled Task E2E Tests
@@ -20,18 +128,18 @@ test.describe('Scheduled Task Operations', () => {
   }) => {
     await workViewPage.waitForTaskList();
 
-    // Create task with sd:today short syntax
+    // Create task with @today short syntax
     const taskTitle = `${testPrefix}-Scheduled Task`;
-    await workViewPage.addTask(`${taskTitle} sd:today`);
+    await workViewPage.addTask(`${taskTitle} @today`);
 
     // Verify task is visible
     const task = page.locator('task').filter({ hasText: taskTitle });
     await expect(task).toBeVisible({ timeout: 10000 });
+    await expect(task.locator('task-title')).not.toContainText('@today');
 
-    // Task should have scheduling indicator (sun icon for today)
-    // Check that task was created successfully
-    const taskCount = await page.locator('task').count();
-    expect(taskCount).toBeGreaterThanOrEqual(1);
+    const expectedDueDay = await getDbDateStr(page);
+    const taskState = await expectTaskTitleWithoutShortSyntax(page, taskTitle, '@today');
+    expect(taskState.dueDay).toBe(expectedDueDay);
   });
 
   test('should create task with time estimate using short syntax', async ({
@@ -41,16 +149,17 @@ test.describe('Scheduled Task Operations', () => {
   }) => {
     await workViewPage.waitForTaskList();
 
-    // Create task with t:1h short syntax for 1 hour estimate
+    // Create task with 1h short syntax for 1 hour estimate
     const taskTitle = `${testPrefix}-Estimated Task`;
-    await workViewPage.addTask(`${taskTitle} t:1h`);
+    await workViewPage.addTask(`${taskTitle} 1h`);
 
     // Verify task is visible
     const task = page.locator('task').filter({ hasText: taskTitle });
     await expect(task).toBeVisible({ timeout: 10000 });
+    await expect(task.locator('task-title')).not.toContainText('1h');
 
-    // Task should be created with estimate
-    // The estimate may be visible in the task UI or detail panel
+    const taskState = await expectTaskTitleWithoutShortSyntax(page, taskTitle, '1h');
+    expect(taskState.timeEstimate).toBe(ONE_HOUR);
   });
 
   test('should open context menu on task', async ({ page, workViewPage, testPrefix }) => {
@@ -66,28 +175,23 @@ test.describe('Scheduled Task Operations', () => {
 
     // Right-click to open context menu
     await task.click({ button: 'right' });
-    await page.waitForTimeout(300);
 
-    // Check if context menu appeared (look for quick-access or menu overlay)
-    const contextMenu = page.locator('.quick-access, .cdk-overlay-pane');
-    const menuVisible = await contextMenu
-      .first()
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
+    // Check if the task context menu appeared.
+    const contextMenu = page
+      .locator('.mat-mdc-menu-panel')
+      .filter({ has: page.locator('.quick-access') })
+      .first();
+    await expect(contextMenu).toBeVisible({ timeout: 3000 });
+    await expect(contextMenu.getByRole('menuitem', { name: /Delete/ })).toBeVisible();
 
     // Close the menu with Escape
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(200);
 
     // Task should still exist after closing menu
     await expect(task).toBeVisible();
-
-    // Verify menu interaction was possible (test passes if menu appeared or not)
-    expect(menuVisible || true).toBe(true);
   });
 
   test('should complete scheduled task', async ({
-    page,
     workViewPage,
     taskPage,
     testPrefix,
@@ -96,21 +200,18 @@ test.describe('Scheduled Task Operations', () => {
 
     // Create scheduled task
     const taskTitle = `${testPrefix}-Complete Scheduled`;
-    await workViewPage.addTask(`${taskTitle} sd:today`);
+    await workViewPage.addTask(`${taskTitle} @today`);
 
     // Wait for task - use first() to avoid strict mode violation during animations
     const task = taskPage.getTaskByText(taskTitle).first();
     await expect(task).toBeVisible({ timeout: 10000 });
+    await expect(task.locator('task-title')).not.toContainText('@today');
 
     // Mark as done
     await taskPage.markTaskAsDone(task);
 
-    // Wait for animation to complete
-    await page.waitForTimeout(500);
-
-    // Verify at least one done task exists
-    const doneCount = await taskPage.getDoneTaskCount();
-    expect(doneCount).toBeGreaterThanOrEqual(1);
+    // Verify this scheduled task was completed.
+    await expect(task).toHaveClass(/isDone/, { timeout: 5000 });
   });
 
   test('should create task scheduled for tomorrow', async ({
@@ -120,13 +221,20 @@ test.describe('Scheduled Task Operations', () => {
   }) => {
     await workViewPage.waitForTaskList();
 
-    // Create task with sd:tomorrow short syntax
+    // Create task with @tomorrow short syntax
     const taskTitle = `${testPrefix}-Tomorrow Task`;
-    await workViewPage.addTask(`${taskTitle} sd:tomorrow`);
+    await addTaskWithoutWaitingForTodayList(page, `${taskTitle} @tomorrow`);
 
-    // The task might not be visible in today's view since it's scheduled for tomorrow
-    // The app may navigate to planner view automatically
-    await page.waitForTimeout(1000);
+    const expectedDueDay = await getDbDateStr(page, 1);
+    await expect
+      .poll(async () => (await getTaskStateByTitle(page, taskTitle))?.dueDay ?? '')
+      .toBe(expectedDueDay);
+    const taskState = await expectTaskTitleWithoutShortSyntax(
+      page,
+      taskTitle,
+      '@tomorrow',
+    );
+    expect(taskState.dueDay).toMatch(DB_DATE_RE);
 
     // Navigate back to work view to verify app is responsive
     await page.goto('/#/tag/TODAY/tasks');
@@ -144,8 +252,8 @@ test.describe('Scheduled Task Operations', () => {
     await workViewPage.waitForTaskList();
 
     // Create multiple tasks with different schedules/estimates
-    await workViewPage.addTask(`${testPrefix}-Task1 sd:today t:30m`);
-    await workViewPage.addTask(`${testPrefix}-Task2 sd:today t:1h`);
+    await workViewPage.addTask(`${testPrefix}-Task1 @today 30m`);
+    await workViewPage.addTask(`${testPrefix}-Task2 @today 1h`);
 
     // Wait for both tasks
     const task1 = page.locator('task').filter({ hasText: `${testPrefix}-Task1` });
@@ -153,9 +261,26 @@ test.describe('Scheduled Task Operations', () => {
 
     await expect(task1).toBeVisible({ timeout: 10000 });
     await expect(task2).toBeVisible({ timeout: 10000 });
+    await expect(task1.locator('task-title')).not.toContainText(/@today|30m/);
+    await expect(task2.locator('task-title')).not.toContainText(/@today|1h/);
 
-    // Verify we have at least 2 tasks
-    const taskCount = await page.locator('task').count();
-    expect(taskCount).toBeGreaterThanOrEqual(2);
+    const expectedDueDay = await getDbDateStr(page);
+    const task1State = await expectTaskTitleWithoutShortSyntax(
+      page,
+      `${testPrefix}-Task1`,
+      '@today',
+    );
+    expect(task1State.title).not.toContain('30m');
+    expect(task1State.dueDay).toBe(expectedDueDay);
+    expect(task1State.timeEstimate).toBe(THIRTY_MINUTES);
+
+    const task2State = await expectTaskTitleWithoutShortSyntax(
+      page,
+      `${testPrefix}-Task2`,
+      '@today',
+    );
+    expect(task2State.title).not.toContain('1h');
+    expect(task2State.dueDay).toBe(expectedDueDay);
+    expect(task2State.timeEstimate).toBe(ONE_HOUR);
   });
 });

--- a/e2e/tests/schedule/schedule-overlap.spec.ts
+++ b/e2e/tests/schedule/schedule-overlap.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '../../fixtures/test.fixture';
+import { expect, test } from '../../fixtures/test.fixture';
 
 test.describe('Schedule overlap', () => {
   test('should display multiple tasks starting the same time', async ({
@@ -41,10 +41,9 @@ test.describe('Schedule overlap', () => {
         // left corner should always be visible to click on
         .click({ position: { x: 0, y: 0 } });
       // Clicking on the task should bring up its details panel
-      await page
-        .locator('task-detail-panel')
-        .filter({ hasText: taskDescription })
-        .isVisible();
+      await expect(
+        page.locator('task-detail-panel').filter({ hasText: taskDescription }),
+      ).toBeVisible();
     };
 
     await checkTaskAccessible('task1');

--- a/e2e/tests/settings/settings-basic.spec.ts
+++ b/e2e/tests/settings/settings-basic.spec.ts
@@ -59,20 +59,19 @@ test.describe('Settings', () => {
     await page.goto('/#/config');
     await page.waitForLoadState('networkidle');
 
-    // Find first expansion panel and click to expand
-    const firstSection = page.locator('mat-expansion-panel').first();
-    const isFirstSectionVisible = await firstSection
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
+    // Find first config section and click its collapsible header.
+    const firstSection = page.locator('config-section').first();
+    await expect(firstSection).toBeVisible({ timeout: 5000 });
+    const header = firstSection.locator('collapsible > .collapsible-header').first();
+    const expandedContent = firstSection.locator('.collapsible-panel').first();
 
-    if (isFirstSectionVisible) {
-      await firstSection.click();
-      await page.waitForTimeout(300);
-
-      // Section should be expanded
-      const expandedContent = firstSection.locator('.mat-expansion-panel-content');
-      await expect(expandedContent).toBeVisible();
+    if (await expandedContent.isVisible().catch(() => false)) {
+      await header.click();
+      await expect(expandedContent).toBeHidden();
     }
+
+    await header.click();
+    await expect(expandedContent).toBeVisible();
   });
 
   test('should have multiple config sections', async ({ page, workViewPage }) => {
@@ -101,21 +100,15 @@ test.describe('Settings', () => {
 
     // Expand first config section to reveal form elements
     const firstSection = page.locator('config-section').first();
-    const isSectionVisible = await firstSection
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
+    await expect(firstSection).toBeVisible({ timeout: 5000 });
+    await firstSection.click();
 
-    if (isSectionVisible) {
-      await firstSection.click();
-      await page.waitForTimeout(300);
-
-      // Look for form elements like inputs, checkboxes, or toggles
-      const formElements = page.locator(
-        'config-section input, config-section mat-checkbox, config-section mat-slide-toggle, config-section mat-select',
-      );
-      const formCount = await formElements.count();
-      expect(formCount).toBeGreaterThanOrEqual(0);
-    }
+    // Look for visible form elements in the section we opened.
+    const formElements = firstSection.locator(
+      'input:visible, mat-checkbox:visible, mat-slide-toggle:visible, mat-select:visible',
+    );
+    await expect(formElements.first()).toBeVisible({ timeout: 5000 });
+    await expect.poll(() => formElements.count()).toBeGreaterThan(0);
   });
 
   test('should return to work view from settings', async ({ page, workViewPage }) => {


### PR DESCRIPTION
## Summary
- Replaces brittle DOM-snapshot and `length > 0` checks with concrete behavioral assertions in 8 e2e specs (markdown links, issue providers, plugins, recurring tasks, schedule overlap, settings).
- Fixes a real broken assertion in `schedule-overlap.spec.ts` (`await locator.isVisible()` did not actually assert; now uses `expect().toBeVisible()`).
- Switches recurring-task tests to the actual short-syntax tokens (`@today`, `@tomorrow`, `1h`, `30m`) and asserts parsed `dueDay` / `timeEstimate` in the store rather than just task presence.
- Drops `waitForTimeout()` and `isVisible().catch(...)` no-op patterns in favor of Playwright auto-waiting matchers.
- TS strictness pass on the markdown-link spec: unifies compact/full op shapes into one optional-field type and uses `\!` non-null assertions after `expect(...).not.toBeNull()` so `e2e/tsconfig.json` `strict: true` passes for the touched files.
- Scopes the `pageerror` capture in the issue-provider-panel test to just the dialog loop so unrelated startup noise can't fail the test.

## Test plan
- [ ] `npx tsc --project e2e/tsconfig.json --noEmit` clean for touched files
- [ ] `npm run checkFile` passes on each modified spec
- [ ] `npm run e2e:file e2e/tests/import-export/markdown-link-persistence.spec.ts -- --retries=0`
- [ ] `npm run e2e:file e2e/tests/recurring/recurring-task.spec.ts -- --retries=0`
- [ ] `npm run e2e:file e2e/tests/issue-provider-panel/issue-provider-panel.spec.ts -- --retries=0`
- [ ] `npm run e2e:file e2e/tests/plugins/plugin-feature-check.spec.ts -- --retries=0`
- [ ] `npm run e2e:file e2e/tests/plugins/plugin-structure-test.spec.ts -- --retries=0`
- [ ] `npm run e2e:file e2e/tests/plugins/test-plugin-visibility.spec.ts -- --retries=0`
- [ ] `npm run e2e:file e2e/tests/schedule/schedule-overlap.spec.ts -- --retries=0`
- [ ] `npm run e2e:file e2e/tests/settings/settings-basic.spec.ts -- --retries=0`