### PR TITLE
feat(plugins): Stage A keyed persistence with LWW (#7749)

### DIFF
--- a/docs/plans/2026-05-23-stage-a-keyed-plugin-persistence.md
+++ b/docs/plans/2026-05-23-stage-a-keyed-plugin-persistence.md
@@ -1,18 +1,39 @@
 # Stage A — keyed plugin-persistence API for per-context sync entities
 
-**Status:** **scheduled when cross-context conflicts become observable**
+**Status:** **Phases 1, 3, 4 implemented 2026-05-23** (Phase 2 still deferred)
 **Date:** 2026-05-23
 **Issue:** [super-productivity#7749](https://github.com/super-productivity/super-productivity/issues/7749)
 **Predecessor:** [`2026-05-22-document-mode-sync-data-model.md`](./2026-05-22-document-mode-sync-data-model.md) (Stage 0 — gzip + throttle, shipped)
+
+## Implementation status
+
+| Phase                                                      | Status                      | Commits                 |
+| ---------------------------------------------------------- | --------------------------- | ----------------------- |
+| Phase 1 — keyed API end-to-end                             | Implemented                 | `b628ec5eec`            |
+| Phase 2 — `EntityAdapter` conversion                       | Deferred (not load-bearing) | —                       |
+| Phase 3 — host-side cleanup (Option A)                     | Implemented                 | `b628ec5eec`            |
+| Phase 4 — document-mode migration                          | Implemented                 | `4cd60ca852`            |
+| Boundary tightening (review fixes)                         | Implemented                 | `79d7558ae8`            |
+| Per-write cap reduced 1 MB → 256 KB                        | Implemented                 | `0aac34f581`            |
+| E2E migration coverage                                     | Implemented                 | `103f6d582e`            |
+| Migration `attemptedAt` + `detectStaleLegacyWrite` cleanup | Implemented                 | _(follows this commit)_ |
+
+Behavior change worth noting on release: `removePluginUserData` now
+no-ops when no matching entries exist in local state, instead of
+emitting a phantom Delete op for the bare pluginId. Pre-Stage-A that
+phantom propagated to peers via sync; post-Stage-A, per-device
+uninstall is a local decision. Users who expect uninstall on Device A
+to also clear data on Device B should uninstall on each device.
 
 ## TL;DR
 
 Document-mode was unregistered from bundled plugins
 (`b0cae69ffe`) and is being re-bundled **without** Stage A: opt-in usage
-+ Stage 0 (~75× wire-payload reduction) + the existing in-plugin
-migration runway are judged enough for the initial bundled rollout. The
-remaining cross-context concurrent-edit conflict at the LWW layer is the
-gap this plan closes, and it's picked up when real users hit it.
+
+- Stage 0 (~75× wire-payload reduction) + the existing in-plugin
+  migration runway are judged enough for the initial bundled rollout. The
+  remaining cross-context concurrent-edit conflict at the LWW layer is the
+  gap this plan closes, and it's picked up when real users hit it.
 
 The shipping unit, when picked up, is Phase 1 + Phase 3 + Phase 4 in
 one release window. Phase 2 (`EntityAdapter`) stays deferred unless a
@@ -54,6 +75,7 @@ agnostic — a pre-Stage-A client replicates and stores `pluginId:key`
 entries inertly without code to read them. (Verified.)
 
 ### 1.1 Public API surface
+
 - `packages/plugin-api/src/types.ts:555-557`:
   ```ts
   persistDataSynced(dataStr: string, key?: string): Promise<void>;
@@ -61,6 +83,7 @@ entries inertly without code to read them. (Verified.)
   ```
 
 ### 1.2 iframe wrapper — pass the key
+
 - `src/app/plugins/util/plugin-iframe.util.ts:365-367`: wrappers declare
   `(data) =>` and never read a second arg. `callApi(name, args)` already
   forwards the array transparently:
@@ -71,11 +94,13 @@ entries inertly without code to read them. (Verified.)
   ```
 
 ### 1.3 Host bridge — thread + validate
+
 - `src/app/plugins/plugin-bridge.service.ts:239-240, :1034-1065`: bound
   methods accept `(data, key?)`. `composeId` is called here (transport
   layer) so the same validation covers iframe and direct callers.
 
 ### 1.4 Persistence service — composite id, same Maps
+
 - `src/app/plugins/plugin-user-persistence.service.ts`: all internal
   `Map<string, …>` are already keyed by what we currently call `pluginId`.
   Re-key by `composeId(pluginId, key)`. No structural change.
@@ -86,6 +111,7 @@ entries inertly without code to read them. (Verified.)
   landed yet. That's why Phase 1 and Phase 3 ship together.
 
 ### 1.5 Rate-limit & size-cap
+
 - Keep `MIN_PLUGIN_PERSIST_INTERVAL_MS` and `MAX_PLUGIN_DATA_SIZE` enforced
   per **composite id** (mechanical re-key of the current Map).
 - **No per-plugin aggregate cap.** Originally proposed; multi-review
@@ -98,6 +124,7 @@ entries inertly without code to read them. (Verified.)
   unserialized running total.
 
 ### 1.6 Tests
+
 - Composite-id round-trip; throws on `pluginId` containing `:`.
 - Two distinct keys → two distinct ops with distinct `entityId`s.
 - Keyless `loadPluginUserData(pluginId)` still hits the legacy entry.
@@ -113,7 +140,7 @@ Current reducer is a 28-LOC array with `findIndex`/`filter`. The issue
 flagged O(N) regression at scale. **Verdict from multi-review:** still
 not the bottleneck.
 
-- `findIndex` runs on every reducer match, *including* sync replay via
+- `findIndex` runs on every reducer match, _including_ sync replay via
   `bulkApplyOperations`, SYNC_IMPORT, validateAndFix sweeps. With 500
   entries this is still sub-millisecond per op; a 1000-op replay touches
   it ≤ 1000× → < 1 s of accumulated cost. Not load-bearing.
@@ -129,7 +156,7 @@ keyed entries on remote devices.
 ### Why a reducer-only "prefix match" doesn't work
 
 Verified against `operation-capture.service.ts:135-158`: the op-log
-captures one op per *dispatched action*, not per state mutation. A
+captures one op per _dispatched action_, not per state mutation. A
 reducer that sweeps multiple ids in response to a single
 `deletePluginUserData({ pluginId })` emits one Delete op for `pluginId`
 only — remote replicas keep the keyed entries. Reviewer 1 caught this
@@ -142,8 +169,7 @@ to a "smart reducer" shortcut. Don't take it.
 The service reads current state, filters by
 `item.id === pluginId || item.id.startsWith(pluginId + ':')`, and
 dispatches one `deletePluginUserData({ pluginId: item.id })` per match,
-then `await new Promise(r => setTimeout(r, 0))` per CLAUDE.md sync rule
-6. Each dispatch produces one Delete op; remote replay reconstructs the
+then `await new Promise(r => setTimeout(r, 0))` per CLAUDE.md sync rule 6. Each dispatch produces one Delete op; remote replay reconstructs the
 full sweep. Pattern already exists at
 `plugin-user-persistence.service.ts:268-277`.
 
@@ -160,6 +186,7 @@ Option B is structurally cleaner but adds a new action + entity-registry
 consideration; defer until profiling or correctness pushes for it.
 
 ### Tests
+
 - 3 keyed + 1 legacy entry for `pluginA`; cleanup removes all 4;
   `pluginB`'s entries untouched.
 - Mock op-log capture verifies 4 Delete ops emitted (Option A) or 1
@@ -212,7 +239,7 @@ async function migrateToKeyedPersistence(): Promise<void> {
   // Step 3: delete legacy entry + stamp success.
   // A keyless persist of an empty payload is interpreted as
   // "tombstone the legacy entry" — see below.
-  await PluginAPI.persistDataSynced('', undefined);  // legacy = tombstone
+  await PluginAPI.persistDataSynced('', undefined); // legacy = tombstone
   await PluginAPI.persistDataSynced(JSON.stringify({ migrated: 1 }), '__meta__');
 }
 ```
@@ -229,7 +256,7 @@ prefer one over the other.
 
 Tombstoning the legacy entry (an empty payload, which the plugin's read
 path treats as "ignore") gives LWW a winning side: Device B's offline
-edit to the legacy blob is *guaranteed* to lose against the tombstone if
+edit to the legacy blob is _guaranteed_ to lose against the tombstone if
 the tombstone's timestamp is later. If B's edit is later, the user keeps
 that edit (which is the same data the migration was about to split) —
 acceptable.
@@ -286,16 +313,16 @@ host work. Same shape as any plugin-format migration.
 
 ## Risks
 
-| Risk | Mitigation |
-| --- | --- |
-| Keyed entries leak on uninstall if Phase 1 ships alone | Don't ship alone. Phase 1 + Phase 3 land together. A reducer-level prefix-match looks tempting but is wrong (local sweep without matching ops → remote replicas leak; see Phase 3). |
-| Cross-device version skew during Stage A rollout | Plugin-side "older device detected" banner; documented limitation. Worse than v3's framing assumed — without bundling-gated-on-Stage-A, the skew window is "user updates the app whenever they update" plus the lag of users still on a pre-Stage-A release. |
+| Risk                                                                               | Mitigation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keyed entries leak on uninstall if Phase 1 ships alone                             | Don't ship alone. Phase 1 + Phase 3 land together. A reducer-level prefix-match looks tempting but is wrong (local sweep without matching ops → remote replicas leak; see Phase 3).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Cross-device version skew during Stage A rollout                                   | Plugin-side "older device detected" banner; documented limitation. Worse than v3's framing assumed — without bundling-gated-on-Stage-A, the skew window is "user updates the app whenever they update" plus the lag of users still on a pre-Stage-A release.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Stale editor view when a remote `PLUGIN_USER_DATA` op lands during an open session | Document-mode subscribes only to `WORK_CONTEXT_CHANGE`; the editor's in-memory `storedState` does not refresh on remote upserts to the plugin entity. The user keeps typing against stale data until they switch contexts or reload. **Stage A does not fix this** — it splits the entity but the editor would still need an upstream-change hook to refresh. Independent follow-up: `PluginHooks.PERSISTED_DATA_UPDATE = 'persistedDataUpdate'` already exists in `packages/plugin-api/src/types.ts:24` but is **never dispatched on the host side** (grep `src/app/`); wiring requires a store-subscription in `plugin-bridge.service.ts` (selector-based, since CLAUDE.md sync rule 1 forbids the `ALL_ACTIONS` effect that would otherwise see remote upserts). Comment in `background.ts` marks the spot. |
-| User-installed third-party plugin with `:` in its id | `composeId` throws synchronously; existing keyless data path still works (it calls neither `composeId` nor the keyed API). The plugin's read of its own data is unaffected unless it tries to call the keyed API, in which case it sees a synchronous throw with a clear message. |
-| Cross-device plugin version skew (Phase 4) | Plugin-side banner; documented limitation. Same as any plugin-format migration. |
-| Op-log compaction storm during heavy multi-context editing | Real risk Phase 1 needs to handle: 50 keyed entries × ~1 op/sec each × `COMPACTION_THRESHOLD = 500` → compaction every ~10 s. Per-pluginId commit chain (deferred above) is the eventual fix. Until then, document-mode's SAVE_THROTTLE_MS (~2 s) holds the per-context rate well below 1/sec, so the projected storm is theoretical. **Monitor first.** |
-| Stage-A writer downgrades to pre-Stage-A client | Keyed entries become silently invisible to the plugin (storage intact, read path returns nothing for keys). Acceptable for an opt-in plugin; document. |
-| Phase 4 partial-failure | `migrated: 0, attemptedAt` stamp + content-idempotent upserts + cross-device "newer keyed entry exists" check. |
+| User-installed third-party plugin with `:` in its id                               | `composeId` throws synchronously; existing keyless data path still works (it calls neither `composeId` nor the keyed API). The plugin's read of its own data is unaffected unless it tries to call the keyed API, in which case it sees a synchronous throw with a clear message.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Cross-device plugin version skew (Phase 4)                                         | Plugin-side banner; documented limitation. Same as any plugin-format migration.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Op-log compaction storm during heavy multi-context editing                         | Real risk Phase 1 needs to handle: 50 keyed entries × ~1 op/sec each × `COMPACTION_THRESHOLD = 500` → compaction every ~10 s. Per-pluginId commit chain (deferred above) is the eventual fix. Until then, document-mode's SAVE_THROTTLE_MS (~2 s) holds the per-context rate well below 1/sec, so the projected storm is theoretical. **Monitor first.**                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Stage-A writer downgrades to pre-Stage-A client                                    | Keyed entries become silently invisible to the plugin (storage intact, read path returns nothing for keys). Acceptable for an opt-in plugin; document.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Phase 4 partial-failure                                                            | `migrated: 0, attemptedAt` stamp + content-idempotent upserts + cross-device "newer keyed entry exists" check.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 ## Testing
 

--- a/e2e/tests/plugins/document-mode-migration.spec.ts
+++ b/e2e/tests/plugins/document-mode-migration.spec.ts
@@ -1,0 +1,217 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import {
+  enablePluginWithVerification,
+  waitForPluginAssets,
+  waitForPluginManagementInit,
+} from '../../helpers/plugin-test.helpers';
+
+/**
+ * End-to-end coverage of the Stage A keyed persistence migration in the
+ * bundled document-mode plugin. The migration logic is unit-tested against
+ * a mock PluginAPI (`packages/plugin-dev/document-mode/src/persistence.spec.ts`),
+ * but those tests can't catch real-iframe quirks: postMessage handling of
+ * `undefined` second args, commit-chain timing across the host's rate
+ * limiter, hydration ordering against the op-log.
+ *
+ * Two scenarios:
+ *  - fresh install: enable the plugin, verify the `__meta__` stamp lands
+ *    with `migrated: 1`.
+ *  - legacy blob: seed a pre-Stage-A single-blob entry into NgRx via the
+ *    e2e helper store, enable the plugin, verify it splits into `meta` +
+ *    `doc:${ctxId}` keyed entries and tombstones the legacy id.
+ */
+
+const PLUGIN_ID = 'document-mode';
+// Underscore-cased so the @typescript-eslint/naming-convention rule on
+// object literal keys is happy. The keys are opaque context ids; their
+// shape doesn't matter to the host.
+const CTX_ALPHA = 'p_alpha';
+const CTX_BETA = 'p_beta';
+const LEGACY_DOCS: Record<string, unknown> = {
+  [CTX_ALPHA]: { type: 'doc', content: [{ type: 'paragraph' }] },
+  [CTX_BETA]: {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'seed' }] }],
+  },
+};
+const LEGACY_BLOB = JSON.stringify({
+  version: 1,
+  docs: LEGACY_DOCS,
+  enabledCtxIds: [CTX_ALPHA],
+});
+
+type PluginUserDataEntry = { id: string; data: string };
+
+/**
+ * Read the current `pluginUserData` feature state from the live store
+ * exposed at `window.__e2eTestHelpers.store` (only present in dev/stage
+ * builds, see main.ts).
+ */
+const readPluginState = async (
+  page: import('@playwright/test').Page,
+): Promise<PluginUserDataEntry[] | null> =>
+  page.evaluate<PluginUserDataEntry[] | null>(async () => {
+    const helpers = (window as unknown as { __e2eTestHelpers?: { store?: unknown } })
+      .__e2eTestHelpers;
+    const store = helpers?.store as
+      | {
+          select: (fn: (s: Record<string, unknown>) => unknown) => {
+            subscribe: (cb: (v: unknown) => void) => { unsubscribe: () => void };
+          };
+        }
+      | undefined;
+    if (!store) return null;
+    return new Promise<PluginUserDataEntry[] | null>((resolve) => {
+      const subRef: { current?: { unsubscribe: () => void } } = {};
+      subRef.current = store
+        .select((s) => s.pluginUserData)
+        .subscribe((value) => {
+          // Defer unsubscribe so the initial sync emit isn't cancelled before
+          // we receive it.
+          window.setTimeout(() => subRef.current?.unsubscribe());
+          resolve(Array.isArray(value) ? (value as PluginUserDataEntry[]) : null);
+        });
+    });
+  });
+
+const findEntry = (
+  entries: PluginUserDataEntry[] | null,
+  id: string,
+): PluginUserDataEntry | undefined => entries?.find((e) => e.id === id);
+
+test.describe('Document Mode Stage A migration', () => {
+  test('stamps migration success on a fresh install', async ({ page, workViewPage }) => {
+    test.setTimeout(60000);
+
+    const assetsAvailable = await waitForPluginAssets(page);
+    if (!assetsAvailable) {
+      if (process.env.CI) {
+        test.skip(true, 'Plugin assets not available in CI');
+        return;
+      }
+      throw new Error('Plugin assets not available — run `npm run prebuild`');
+    }
+
+    await workViewPage.waitForTaskList();
+    const pluginReady = await waitForPluginManagementInit(page);
+    expect(pluginReady).toBeTruthy();
+
+    const enabled = await enablePluginWithVerification(page, 'Document Mode');
+    expect(enabled).toBeTruthy();
+
+    // The migration runs once the plugin's background.js executes init().
+    // Poll until the keyed stamp lands.
+    await expect
+      .poll(
+        async () => {
+          const entries = await readPluginState(page);
+          const stamp = findEntry(entries, `${PLUGIN_ID}:__meta__`);
+          if (!stamp?.data) return null;
+          try {
+            return JSON.parse(stamp.data) as { migrated?: number };
+          } catch {
+            return null;
+          }
+        },
+        { timeout: 15000, message: 'migration stamp never reached migrated:1' },
+      )
+      .toMatchObject({ migrated: 1 });
+  });
+
+  test('migrates a legacy single-blob entry into keyed entries', async ({
+    page,
+    workViewPage,
+  }) => {
+    test.setTimeout(60000);
+
+    const assetsAvailable = await waitForPluginAssets(page);
+    if (!assetsAvailable) {
+      if (process.env.CI) {
+        test.skip(true, 'Plugin assets not available in CI');
+        return;
+      }
+      throw new Error('Plugin assets not available — run `npm run prebuild`');
+    }
+
+    await workViewPage.waitForTaskList();
+
+    // Seed pre-Stage-A storage: a single keyless entry under the bare
+    // plugin id. Dispatched via the same action the host would emit, so
+    // the op-log + state both see a "legacy upsert" from this client.
+    await page.evaluate(
+      async ({ pluginId, blob }) => {
+        const helpers = (window as unknown as { __e2eTestHelpers?: { store?: unknown } })
+          .__e2eTestHelpers;
+        const store = helpers?.store as
+          | { dispatch: (action: unknown) => void }
+          | undefined;
+        if (!store) {
+          throw new Error('__e2eTestHelpers.store not exposed — non-dev build?');
+        }
+        store.dispatch({
+          type: '[Plugin] Upsert User Data',
+          pluginUserData: { id: pluginId, data: blob },
+          meta: {
+            isPersistent: true,
+            entityType: 'PLUGIN_USER_DATA',
+            entityId: pluginId,
+            opType: 'UPDATE',
+          },
+        });
+      },
+      { pluginId: PLUGIN_ID, blob: LEGACY_BLOB },
+    );
+
+    // Sanity-check the seed landed before enabling the plugin.
+    const seeded = findEntry(await readPluginState(page), PLUGIN_ID);
+    expect(seeded?.data).toBe(LEGACY_BLOB);
+
+    const pluginReady = await waitForPluginManagementInit(page);
+    expect(pluginReady).toBeTruthy();
+
+    const enabled = await enablePluginWithVerification(page, 'Document Mode');
+    expect(enabled).toBeTruthy();
+
+    // Wait for the migration to stamp success. The full sequence is:
+    // attempted stamp → write each doc → write meta → tombstone legacy →
+    // success stamp. The final stamp is the last write, so observing it
+    // means everything else has landed.
+    await expect
+      .poll(
+        async () => {
+          const entries = await readPluginState(page);
+          const stamp = findEntry(entries, `${PLUGIN_ID}:__meta__`);
+          if (!stamp?.data) return null;
+          try {
+            return JSON.parse(stamp.data) as { migrated?: number };
+          } catch {
+            return null;
+          }
+        },
+        { timeout: 15000, message: 'migration never stamped migrated:1' },
+      )
+      .toMatchObject({ migrated: 1 });
+
+    // Now inspect the rest of the keyspace.
+    const entries = await readPluginState(page);
+
+    // The legacy entry is tombstoned (empty payload) — present but empty.
+    const legacy = findEntry(entries, PLUGIN_ID);
+    expect(legacy?.data).toBe('');
+
+    // The meta entry holds the migrated enabledCtxIds.
+    const meta = findEntry(entries, `${PLUGIN_ID}:meta`);
+    expect(meta).toBeDefined();
+    const metaParsed = JSON.parse(meta!.data) as { enabledCtxIds: string[] };
+    expect(metaParsed.enabledCtxIds).toEqual([CTX_ALPHA]);
+
+    // Each legacy doc became its own keyed entry. Compare the parsed
+    // shape rather than the exact serialized string — the host may have
+    // re-encoded (e.g. via the gzip codec for large payloads).
+    for (const [ctxId, expectedDoc] of Object.entries(LEGACY_DOCS)) {
+      const entry = findEntry(entries, `${PLUGIN_ID}:doc:${ctxId}`);
+      expect(entry, `expected entry for doc:${ctxId}`).toBeDefined();
+      expect(JSON.parse(entry!.data)).toEqual(expectedDoc);
+    }
+  });
+});

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -552,9 +552,16 @@ export interface PluginAPI {
   };
 
   // persistence
-  persistDataSynced(dataStr: string): Promise<void>;
+  //
+  // The optional `key` splits a plugin's synced data into multiple
+  // independently-LWW-resolved entries. Calls without a key target the
+  // legacy single-blob entry. `key` must not contain ':' beyond what the
+  // plugin chooses (the host reserves ':' only as the pluginId/key
+  // delimiter and only enforces that the pluginId itself is clean).
+  // Empty-string keys are equivalent to omitting the argument.
+  persistDataSynced(dataStr: string, key?: string): Promise<void>;
 
-  loadSyncedData(): Promise<string | null>;
+  loadSyncedData(key?: string): Promise<string | null>;
 
   getConfig<T = Record<string, unknown>>(): Promise<T | null>;
 

--- a/packages/plugin-dev/document-mode/src/background.ts
+++ b/packages/plugin-dev/document-mode/src/background.ts
@@ -1,14 +1,19 @@
 /**
  * Document-Mode background script. Runs once per plugin load in the host
  * page context. Responsible for:
+ *  - Running the legacy → keyed persistence migration on first load
  *  - Registering the work-context header button
  *  - Tracking which contexts have document mode enabled
  *  - Auto-showing / -closing the work-view embed on context navigation
  *
- * The TipTap editor itself lives in the iframe (src/ui/editor.ts). Both
- * scripts share a single persisted blob; this script owns the
- * `enabledCtxIds` field, the editor owns `docs`. Each one read-modify-writes
- * only its own slice so updates don't clobber each other.
+ * The TipTap editor itself lives in the iframe (src/ui/editor.ts). Each
+ * persisted entity is now keyed independently (Stage A):
+ *  - `meta`         — enabledCtxIds (owned by this script)
+ *  - `doc:${ctxId}` — one entry per context (owned by the editor iframe)
+ *  - `__meta__`     — migration stamp
+ *
+ * Splitting by entity means a concurrent toggle on one device and an edit
+ * on another no longer LWW-collide at the blob level.
  */
 
 import {
@@ -17,57 +22,43 @@ import {
   type PluginAPI,
   type WorkContextChangePayload,
 } from '@super-productivity/plugin-api';
+import {
+  loadEnabledCtxIds,
+  migrateToKeyedPersistence,
+  saveEnabledCtxIds,
+} from './persistence';
 
 declare const PluginAPI: PluginAPI;
 
-interface StoredState {
-  version: number;
-  docs: Record<string, unknown>;
-  enabledCtxIds: string[];
-}
-
-const STORAGE_VERSION = 1;
-const emptyState = (): StoredState => ({
-  version: STORAGE_VERSION,
-  docs: {},
-  enabledCtxIds: [],
-});
-
-const loadState = async (): Promise<StoredState> => {
-  try {
-    const raw = await PluginAPI.loadSyncedData();
-    if (!raw) return emptyState();
-    const parsed = JSON.parse(raw) as Partial<StoredState>;
-    return {
-      version: parsed.version ?? STORAGE_VERSION,
-      docs: parsed.docs ?? {},
-      enabledCtxIds: Array.isArray(parsed.enabledCtxIds) ? parsed.enabledCtxIds : [],
-    };
-  } catch (err) {
-    PluginAPI.log.err('document-mode: failed to parse stored state', err);
-    return emptyState();
-  }
-};
-
 /**
- * Read-modify-write helper. Re-reads the blob from storage before mutating
- * so we don't overwrite changes made by the editor (which writes the `docs`
- * field on its own debounce schedule).
+ * Read-modify-write helper. Re-reads the meta entry before mutating so we
+ * don't overwrite a concurrent toggle that landed since our last read. The
+ * editor iframe owns `doc:${ctxId}` entries; this script touches only `meta`.
  */
 const updateEnabledCtxIds = async (
   mutate: (ids: string[]) => string[],
 ): Promise<string[]> => {
-  const current = await loadState();
-  const next = mutate(current.enabledCtxIds);
-  await PluginAPI.persistDataSynced(JSON.stringify({ ...current, enabledCtxIds: next }));
+  const current = await loadEnabledCtxIds(PluginAPI);
+  const next = mutate(current);
+  await saveEnabledCtxIds(PluginAPI, next);
   return next;
 };
 
 let enabledIds = new Set<string>();
 
 const init = async (): Promise<void> => {
-  const state = await loadState();
-  enabledIds = new Set(state.enabledCtxIds);
+  // Migration is idempotent and guarded by a stamp — safe to call on every
+  // load. Must run before the first keyed read or we'd see "no data" for
+  // every existing user.
+  try {
+    await migrateToKeyedPersistence(PluginAPI);
+  } catch (err) {
+    PluginAPI.log.err('document-mode: migration failed', err);
+    // Continue anyway: a partial migration leaves the data in place
+    // (corruption guard in persistence.ts) and the next session will retry.
+  }
+
+  enabledIds = new Set(await loadEnabledCtxIds(PluginAPI));
 
   // If the active context is already enabled, mount the embed immediately
   // so the user sees doc mode on app start without an extra click.
@@ -117,7 +108,7 @@ PluginAPI.registerWorkContextHeaderButton({
 
 // Known gap: no hook for remote PLUGIN_USER_DATA updates. An edit on
 // another device arriving mid-session leaves this script's in-memory
-// `enabledIds` and the iframe editor's `storedState` stale until a
+// `enabledIds` and the iframe editor's per-context doc stale until a
 // context switch or page reload. Acceptable while document-mode is
 // alpha + opt-in per context; revisit if conflicts are reported.
 // Tracked alongside Stage A in docs/plans/2026-05-23-stage-a-keyed-plugin-persistence.md.

--- a/packages/plugin-dev/document-mode/src/persistence.spec.ts
+++ b/packages/plugin-dev/document-mode/src/persistence.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for the keyed-persistence helpers and the legacy → keyed migration.
+ * Run with `npm test` (see scripts/test.js) — esbuild transpiles + bundles
+ * each spec, and `node --test` executes it.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { PluginAPI } from '@super-productivity/plugin-api';
+import {
+  docKey,
+  detectStaleLegacyWrite,
+  loadContextDoc,
+  loadEnabledCtxIds,
+  migrateToKeyedPersistence,
+  saveContextDoc,
+  saveEnabledCtxIds,
+} from './persistence';
+
+/**
+ * In-memory mock of the host's plugin storage. Mirrors the keyed semantics:
+ * each (pluginId, key?) tuple is a distinct entry, an empty payload
+ * tombstones an entry (treated as missing on read).
+ */
+const createMockApi = (): {
+  api: PluginAPI;
+  store: Map<string, string>;
+  writes: { key: string | undefined; data: string }[];
+} => {
+  // Single entityId space (pluginId-scoped — the test plugin id is implied).
+  // Key "" means the legacy keyless entry.
+  const store = new Map<string, string>();
+  const writes: { key: string | undefined; data: string }[] = [];
+  const api = {
+    persistDataSynced: async (data: string, key?: string): Promise<void> => {
+      writes.push({ key, data });
+      const k = key ?? '';
+      // Plugin-side tombstone convention: an empty payload means "ignore".
+      // We model this on the host by storing the empty string; the read
+      // side returns null for empty entries so callers see "no data".
+      store.set(k, data);
+    },
+    loadSyncedData: async (key?: string): Promise<string | null> => {
+      const k = key ?? '';
+      const v = store.get(k);
+      if (v === undefined) return null;
+      if (v === '') return ''; // explicit tombstone — still readable as empty
+      return v;
+    },
+  } as unknown as PluginAPI;
+  return { api, store, writes };
+};
+
+/* -------------------------------------------------------------------------- */
+/* Read/write helpers                                                          */
+/* -------------------------------------------------------------------------- */
+
+test('docKey: composes "doc:<ctxId>"', () => {
+  assert.equal(docKey('project-1'), 'doc:project-1');
+  assert.equal(docKey('TODAY'), 'doc:TODAY');
+});
+
+test('loadEnabledCtxIds: returns [] when meta is missing', async () => {
+  const { api } = createMockApi();
+  assert.deepEqual(await loadEnabledCtxIds(api), []);
+});
+
+test('loadEnabledCtxIds: returns the saved ids', async () => {
+  const { api } = createMockApi();
+  await saveEnabledCtxIds(api, ['p1', 'p2']);
+  assert.deepEqual(await loadEnabledCtxIds(api), ['p1', 'p2']);
+});
+
+test('loadEnabledCtxIds: tolerates corrupt meta (returns [])', async () => {
+  const { api, store } = createMockApi();
+  store.set('meta', '{not json');
+  assert.deepEqual(await loadEnabledCtxIds(api), []);
+});
+
+test('loadContextDoc: returns null when the entry is missing', async () => {
+  const { api } = createMockApi();
+  assert.equal(await loadContextDoc(api, 'p1'), null);
+});
+
+test('loadContextDoc: round-trips the doc value', async () => {
+  const { api } = createMockApi();
+  const doc = { type: 'doc', content: [{ type: 'paragraph' }] };
+  await saveContextDoc(api, 'p1', doc);
+  assert.deepEqual(await loadContextDoc(api, 'p1'), doc);
+});
+
+test('saveContextDoc: writes under doc:<ctxId>', async () => {
+  const { api, store } = createMockApi();
+  await saveContextDoc(api, 'TODAY', { type: 'doc' });
+  assert.equal(store.get('doc:TODAY'), JSON.stringify({ type: 'doc' }));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Migration                                                                   */
+/* -------------------------------------------------------------------------- */
+
+test('migration: no-op when already stamped', async () => {
+  const { api, store, writes } = createMockApi();
+  store.set('__meta__', JSON.stringify({ migrated: 1 }));
+  // Even if a legacy blob exists, we don't touch it once the stamp says we're
+  // done — a re-migration could overwrite later edits to the keyed entries.
+  store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } } }));
+
+  await migrateToKeyedPersistence(api);
+
+  assert.deepEqual(writes, []);
+  assert.equal(store.has('doc:p1'), false);
+});
+
+test('migration: stamps success on a fresh install (no legacy data)', async () => {
+  const { api, store } = createMockApi();
+  await migrateToKeyedPersistence(api);
+  assert.equal(store.get('__meta__'), JSON.stringify({ migrated: 1 }));
+  assert.equal(store.has('meta'), false);
+  assert.equal(store.has(''), false);
+});
+
+test('migration: splits legacy blob into keyed entries + meta', async () => {
+  const { api, store } = createMockApi();
+  const legacy = {
+    version: 1,
+    docs: {
+      p1: { type: 'doc', content: [{ type: 'paragraph' }] },
+      TODAY: { type: 'doc', content: [{ type: 'heading' }] },
+    },
+    enabledCtxIds: ['p1'],
+  };
+  store.set('', JSON.stringify(legacy));
+
+  await migrateToKeyedPersistence(api);
+
+  assert.equal(store.get('doc:p1'), JSON.stringify(legacy.docs.p1));
+  assert.equal(store.get('doc:TODAY'), JSON.stringify(legacy.docs.TODAY));
+  assert.equal(store.get('meta'), JSON.stringify({ enabledCtxIds: ['p1'] }));
+  // Legacy entry tombstoned (empty payload).
+  assert.equal(store.get(''), '');
+  // Final stamp.
+  assert.equal(store.get('__meta__'), JSON.stringify({ migrated: 1 }));
+});
+
+test('migration: handles a legacy blob with no enabledCtxIds', async () => {
+  const { api, store } = createMockApi();
+  store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } } }));
+
+  await migrateToKeyedPersistence(api);
+
+  assert.equal(store.get('meta'), JSON.stringify({ enabledCtxIds: [] }));
+  assert.equal(store.get('doc:p1'), JSON.stringify({ type: 'doc' }));
+});
+
+test('migration: refuses to tombstone a corrupt legacy blob (preserves data for recovery)', async () => {
+  const { api, store, writes } = createMockApi();
+  store.set('', '{not json');
+
+  await migrateToKeyedPersistence(api);
+
+  // Corrupt legacy stays in place; no keyed entries; no success stamp.
+  assert.equal(store.get(''), '{not json');
+  assert.equal(store.has('__meta__'), false);
+  assert.equal(store.has('meta'), false);
+  // We attempted (intent stamp) but bailed before tombstoning.
+  const sawAttemptedStamp = writes.some(
+    (w) =>
+      w.key === '__meta__' &&
+      typeof w.data === 'string' &&
+      w.data.includes('"migrated":0'),
+  );
+  // The attempt stamp wasn't written either — we bailed BEFORE stamping
+  // attempt, because parsing failed.
+  assert.equal(sawAttemptedStamp, false);
+});
+
+test('migration: idempotent re-run after crash mid-loop', async () => {
+  const { api, store } = createMockApi();
+  store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } }, enabledCtxIds: ['p1'] }));
+  // Simulate a previous attempt that stamped attemptedAt but never reached
+  // success — e.g. the iframe was torn down mid-loop.
+  store.set('__meta__', JSON.stringify({ migrated: 0, attemptedAt: 100 }));
+
+  await migrateToKeyedPersistence(api);
+
+  assert.equal(store.get('doc:p1'), JSON.stringify({ type: 'doc' }));
+  assert.equal(store.get('meta'), JSON.stringify({ enabledCtxIds: ['p1'] }));
+  assert.equal(store.get(''), '');
+  assert.equal(store.get('__meta__'), JSON.stringify({ migrated: 1 }));
+});
+
+test('migration: re-running after success is a no-op even with replayed legacy data', async () => {
+  // Simulate: A migrates, B (offline, old build) replays a legacy edit on top
+  // of A's tombstone, A's local stamp still says migrated:1. A must NOT
+  // re-migrate (it would overwrite its keyed entries with B's older shape).
+  const { api, store, writes } = createMockApi();
+  store.set('__meta__', JSON.stringify({ migrated: 1 }));
+  store.set('', JSON.stringify({ docs: { p1: { type: 'paragraph' } } }));
+  store.set('doc:p1', JSON.stringify({ type: 'doc', content: [{ type: 'heading' }] }));
+
+  await migrateToKeyedPersistence(api);
+
+  assert.deepEqual(writes, []);
+  assert.equal(
+    store.get('doc:p1'),
+    JSON.stringify({ type: 'doc', content: [{ type: 'heading' }] }),
+  );
+});
+
+test('migration: stamps attempted FIRST, then splits, then tombstones, then stamps success', async () => {
+  // Order matters for crash recovery: the attempted stamp must be the first
+  // write so that a crash between "stamp" and "split" still leaves the
+  // marker that says "we tried; retry on resume."
+  const { api, store, writes } = createMockApi();
+  store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } }, enabledCtxIds: [] }));
+
+  await migrateToKeyedPersistence(api);
+
+  const order = writes.map((w) => w.key ?? '<legacy>');
+  // First write: attempted stamp.
+  assert.equal(order[0], '__meta__');
+  assert.match(writes[0].data, /"migrated":0/);
+  // Last write: success stamp.
+  assert.equal(order[order.length - 1], '__meta__');
+  assert.match(writes[writes.length - 1].data, /"migrated":1/);
+  // Tombstone happens before the success stamp.
+  const tombstoneIdx = writes.findIndex((w) => w.key === undefined && w.data === '');
+  const successIdx = writes.findIndex(
+    (w, i) => w.key === '__meta__' && i > 0 && w.data.includes('"migrated":1'),
+  );
+  assert.ok(tombstoneIdx > 0, 'expected a tombstone write');
+  assert.ok(successIdx > tombstoneIdx, 'success stamp must come after tombstone');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Stale-legacy detection                                                      */
+/* -------------------------------------------------------------------------- */
+
+test('detectStaleLegacyWrite: false when migration not stamped', async () => {
+  const { api } = createMockApi();
+  assert.equal(await detectStaleLegacyWrite(api), false);
+});
+
+test('detectStaleLegacyWrite: false after a fresh tombstone (empty legacy)', async () => {
+  const { api, store } = createMockApi();
+  store.set('__meta__', JSON.stringify({ migrated: 1 }));
+  store.set('', '');
+  assert.equal(await detectStaleLegacyWrite(api), false);
+});
+
+test('detectStaleLegacyWrite: true when a stale device writes legacy after migration', async () => {
+  const { api, store } = createMockApi();
+  store.set('__meta__', JSON.stringify({ migrated: 1 }));
+  store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } } }));
+  assert.equal(await detectStaleLegacyWrite(api), true);
+});

--- a/packages/plugin-dev/document-mode/src/persistence.spec.ts
+++ b/packages/plugin-dev/document-mode/src/persistence.spec.ts
@@ -9,7 +9,6 @@ import assert from 'node:assert/strict';
 import type { PluginAPI } from '@super-productivity/plugin-api';
 import {
   docKey,
-  detectStaleLegacyWrite,
   loadContextDoc,
   loadEnabledCtxIds,
   migrateToKeyedPersistence,
@@ -229,9 +228,9 @@ test('migration: skips an oversized legacy doc and leaves legacy intact for reco
 test('migration: idempotent re-run after crash mid-loop', async () => {
   const { api, store } = createMockApi();
   store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } }, enabledCtxIds: ['p1'] }));
-  // Simulate a previous attempt that stamped attemptedAt but never reached
+  // Simulate a previous attempt that stamped intent but never reached
   // success — e.g. the iframe was torn down mid-loop.
-  store.set('__meta__', JSON.stringify({ migrated: 0, attemptedAt: 100 }));
+  store.set('__meta__', JSON.stringify({ migrated: 0 }));
 
   await migrateToKeyedPersistence(api);
 
@@ -259,8 +258,8 @@ test('migration: re-running after success is a no-op even with replayed legacy d
   );
 });
 
-test('migration: stamps attempted FIRST, then splits, then tombstones, then stamps success', async () => {
-  // Order matters for crash recovery: the attempted stamp must be the first
+test('migration: stamps intent FIRST, then splits, then tombstones, then stamps success', async () => {
+  // Order matters for crash recovery: the intent stamp must be the first
   // write so that a crash between "stamp" and "split" still leaves the
   // marker that says "we tried; retry on resume."
   const { api, store, writes } = createMockApi();
@@ -269,7 +268,7 @@ test('migration: stamps attempted FIRST, then splits, then tombstones, then stam
   await migrateToKeyedPersistence(api);
 
   const order = writes.map((w) => w.key ?? '<legacy>');
-  // First write: attempted stamp.
+  // First write: intent stamp.
   assert.equal(order[0], '__meta__');
   assert.match(writes[0].data, /"migrated":0/);
   // Last write: success stamp.
@@ -282,27 +281,4 @@ test('migration: stamps attempted FIRST, then splits, then tombstones, then stam
   );
   assert.ok(tombstoneIdx > 0, 'expected a tombstone write');
   assert.ok(successIdx > tombstoneIdx, 'success stamp must come after tombstone');
-});
-
-/* -------------------------------------------------------------------------- */
-/* Stale-legacy detection                                                      */
-/* -------------------------------------------------------------------------- */
-
-test('detectStaleLegacyWrite: false when migration not stamped', async () => {
-  const { api } = createMockApi();
-  assert.equal(await detectStaleLegacyWrite(api), false);
-});
-
-test('detectStaleLegacyWrite: false after a fresh tombstone (empty legacy)', async () => {
-  const { api, store } = createMockApi();
-  store.set('__meta__', JSON.stringify({ migrated: 1 }));
-  store.set('', '');
-  assert.equal(await detectStaleLegacyWrite(api), false);
-});
-
-test('detectStaleLegacyWrite: true when a stale device writes legacy after migration', async () => {
-  const { api, store } = createMockApi();
-  store.set('__meta__', JSON.stringify({ migrated: 1 }));
-  store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } } }));
-  assert.equal(await detectStaleLegacyWrite(api), true);
 });

--- a/packages/plugin-dev/document-mode/src/persistence.spec.ts
+++ b/packages/plugin-dev/document-mode/src/persistence.spec.ts
@@ -175,6 +175,57 @@ test('migration: refuses to tombstone a corrupt legacy blob (preserves data for 
   assert.equal(sawAttemptedStamp, false);
 });
 
+test('migration: skips an oversized legacy doc and leaves legacy intact for recovery', async () => {
+  // One context's stored doc is so big that the keyed write throws (mock
+  // simulates the host's MAX_PLUGIN_DATA_SIZE check). The migration must
+  // not abort the whole run — the other docs must still land — and must
+  // NOT tombstone or stamp success, so a future build with a larger cap
+  // (or after the user prunes the doc) can recover.
+  const { store, writes } = createMockApi();
+  const api = {
+    persistDataSynced: async (data: string, key?: string): Promise<void> => {
+      // Simulate host-side cap: throw for the oversized doc.
+      if (data.length > 10_000) {
+        throw new Error('Plugin data exceeds maximum size');
+      }
+      writes.push({ key, data });
+      store.set(key ?? '', data);
+    },
+    loadSyncedData: async (key?: string): Promise<string | null> => {
+      const v = store.get(key ?? '');
+      return v === undefined ? null : v;
+    },
+  } as unknown as PluginAPI;
+  const big = 'x'.repeat(20_000);
+  store.set(
+    '',
+    JSON.stringify({
+      docs: { small: { type: 'doc' }, big: { type: 'doc', text: big } },
+      enabledCtxIds: ['small'],
+    }),
+  );
+
+  await migrateToKeyedPersistence(api);
+
+  // Small doc migrated; big doc absent.
+  assert.equal(store.get('doc:small'), JSON.stringify({ type: 'doc' }));
+  assert.equal(store.has('doc:big'), false);
+  // Meta lands (it's small).
+  assert.equal(store.get('meta'), JSON.stringify({ enabledCtxIds: ['small'] }));
+  // Legacy NOT tombstoned — original bytes preserved.
+  assert.equal(
+    store.get(''),
+    JSON.stringify({
+      docs: { small: { type: 'doc' }, big: { type: 'doc', text: big } },
+      enabledCtxIds: ['small'],
+    }),
+  );
+  // Migration NOT stamped successful — next session retries.
+  const stampRaw = store.get('__meta__');
+  const stamp = stampRaw ? (JSON.parse(stampRaw) as { migrated: number }) : null;
+  assert.notEqual(stamp?.migrated, 1);
+});
+
 test('migration: idempotent re-run after crash mid-loop', async () => {
   const { api, store } = createMockApi();
   store.set('', JSON.stringify({ docs: { p1: { type: 'doc' } }, enabledCtxIds: ['p1'] }));

--- a/packages/plugin-dev/document-mode/src/persistence.ts
+++ b/packages/plugin-dev/document-mode/src/persistence.ts
@@ -140,19 +140,35 @@ export const migrateToKeyedPersistence = async (api: PluginAPI): Promise<void> =
   );
 
   const docs = parsed.docs ?? {};
+  // One oversized legacy doc must not block migration of every other context.
+  // The host throws a synchronous Error from persistDataSynced when a payload
+  // exceeds MAX_PLUGIN_DATA_SIZE; catch per-doc and skip — the original bytes
+  // stay in the legacy blob (we suppress the tombstone below) so a future
+  // build with a larger cap (or the user pruning the doc) can recover them.
+  let anyDocSkipped = false;
   for (const [ctxId, doc] of Object.entries(docs)) {
-    await api.persistDataSynced(JSON.stringify(doc), docKey(ctxId));
+    try {
+      await api.persistDataSynced(JSON.stringify(doc), docKey(ctxId));
+    } catch {
+      anyDocSkipped = true;
+    }
   }
 
   const enabledCtxIds = Array.isArray(parsed.enabledCtxIds) ? parsed.enabledCtxIds : [];
   await api.persistDataSynced(JSON.stringify({ enabledCtxIds }), META_KEY);
 
-  // Tombstone the legacy entry: an empty payload is a plugin-side
-  // convention for "ignore". This gives LWW a winning side against any
-  // offline device that still writes the old shape.
-  await api.persistDataSynced('');
-
-  await api.persistDataSynced(JSON.stringify({ migrated: 1 }), MIGRATION_STAMP_KEY);
+  if (!anyDocSkipped) {
+    // Tombstone the legacy entry: an empty payload is a plugin-side
+    // convention for "ignore". This gives LWW a winning side against any
+    // offline device that still writes the old shape. Skipped when any
+    // doc was too big to migrate — preserving the legacy bytes for recovery.
+    await api.persistDataSynced('');
+    await api.persistDataSynced(JSON.stringify({ migrated: 1 }), MIGRATION_STAMP_KEY);
+  }
+  // If anyDocSkipped: leave the stamp at {migrated: 0}. The next session
+  // will retry, which is a no-op for already-written docs (content-idempotent)
+  // and another skip for the oversized one. Stable failure mode without
+  // data loss.
 };
 
 /**

--- a/packages/plugin-dev/document-mode/src/persistence.ts
+++ b/packages/plugin-dev/document-mode/src/persistence.ts
@@ -35,7 +35,6 @@ interface MetaEntry {
 
 interface MigrationStamp {
   migrated: 0 | 1;
-  attemptedAt?: number;
 }
 
 interface LegacyBlob {
@@ -97,16 +96,13 @@ export const saveContextDoc = async (
  * One-shot migration from the legacy single-blob shape to keyed entries.
  *
  * Idempotent and crash-safe: a `__meta__` stamp guards re-runs after the
- * full sweep completes. If a previous run set `attemptedAt` but never
- * reached `migrated: 1` (process killed mid-way), the next call re-runs the
- * loop — each upsert is content-idempotent (same context → same doc), so
- * re-running costs op-log budget but doesn't corrupt state.
+ * full sweep completes. If a previous run wrote `migrated: 0` but never
+ * reached `migrated: 1` (process killed mid-way), the next call re-runs
+ * the loop — each upsert is content-idempotent (same context → same doc),
+ * so re-running costs op-log budget but doesn't corrupt state.
  *
  * Two devices migrating the same legacy data concurrently both write
- * identical keyed entries; LWW resolves deterministically per entity. A
- * stale device that writes to the legacy blob after migration is detected
- * downstream by the plugin (a non-empty legacy read after `migrated: 1`
- * means "older app on another device").
+ * identical keyed entries; LWW resolves deterministically per entity.
  */
 export const migrateToKeyedPersistence = async (api: PluginAPI): Promise<void> => {
   const stampRaw = await api.loadSyncedData(MIGRATION_STAMP_KEY);
@@ -131,13 +127,9 @@ export const migrateToKeyedPersistence = async (api: PluginAPI): Promise<void> =
   }
 
   // Stamp the attempt FIRST so a crash before the split is detectable on
-  // resume. attemptedAt is informational; the practical recovery is "if
-  // stamp.migrated !== 1, re-run the loop" — re-writes are content-
-  // idempotent.
-  await api.persistDataSynced(
-    JSON.stringify({ migrated: 0, attemptedAt: Date.now() }),
-    MIGRATION_STAMP_KEY,
-  );
+  // resume — `migrated: 0` means "we tried, retry the loop." Recovery is
+  // simply re-running the loop; each upsert below is content-idempotent.
+  await api.persistDataSynced(JSON.stringify({ migrated: 0 }), MIGRATION_STAMP_KEY);
 
   const docs = parsed.docs ?? {};
   // One oversized legacy doc must not block migration of every other context.
@@ -169,17 +161,4 @@ export const migrateToKeyedPersistence = async (api: PluginAPI): Promise<void> =
   // will retry, which is a no-op for already-written docs (content-idempotent)
   // and another skip for the oversized one. Stable failure mode without
   // data loss.
-};
-
-/**
- * Detect a post-migration write to the legacy entry — symptomatic of an
- * older device still running a pre-Stage-A build. Caller (background.ts)
- * can surface a "update all devices" notice; the data itself isn't lost
- * but won't be visible until the older device upgrades.
- */
-export const detectStaleLegacyWrite = async (api: PluginAPI): Promise<boolean> => {
-  const stamp = safeParse<MigrationStamp>(await api.loadSyncedData(MIGRATION_STAMP_KEY));
-  if (stamp?.migrated !== 1) return false;
-  const legacy = await api.loadSyncedData();
-  return Boolean(legacy);
 };

--- a/packages/plugin-dev/document-mode/src/persistence.ts
+++ b/packages/plugin-dev/document-mode/src/persistence.ts
@@ -1,0 +1,169 @@
+/**
+ * Document-mode keyed persistence (Stage A Phase 4).
+ *
+ * Before Stage A, every context's editor doc + the enabled-context set were
+ * stuffed into one synced blob under the bare plugin id. Concurrent edits
+ * across contexts on different devices LWW-collided at the blob level — one
+ * side's whole-blob write wiped the other side's per-context changes.
+ *
+ * The keyed layout splits that into:
+ *  - `meta`             — `{ enabledCtxIds: string[] }`, owned by background.ts
+ *  - `doc:${ctxId}`     — the editor doc for one context, owned by editor.ts
+ *  - `__meta__`         — internal migration stamp `{ migrated: 1 }`
+ *
+ * Each entry has its own LWW timestamp on the host, so a concurrent edit in
+ * project A doesn't lose a concurrent edit in project B.
+ *
+ * The legacy single-blob entry is tombstoned (empty payload) after migration
+ * so an offline device that still writes the old shape loses cleanly on
+ * reconnect — see docs/plans/2026-05-23-stage-a-keyed-plugin-persistence.md
+ * Phase 4 for the LWW rationale.
+ */
+
+import type { PluginAPI } from '@super-productivity/plugin-api';
+
+const META_KEY = 'meta';
+const MIGRATION_STAMP_KEY = '__meta__';
+const DOC_KEY_PREFIX = 'doc:';
+
+/** Key for a single context's editor doc. Pure so tests can verify. */
+export const docKey = (ctxId: string): string => `${DOC_KEY_PREFIX}${ctxId}`;
+
+interface MetaEntry {
+  enabledCtxIds: string[];
+}
+
+interface MigrationStamp {
+  migrated: 0 | 1;
+  attemptedAt?: number;
+}
+
+interface LegacyBlob {
+  docs?: Record<string, unknown>;
+  enabledCtxIds?: string[];
+  [extra: string]: unknown;
+}
+
+const safeParse = <T>(raw: string | null): T | null => {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Read the enabled-context set from the keyed meta entry. Returns an empty
+ * array for a fresh install or a corrupt meta entry (the user can re-toggle).
+ */
+export const loadEnabledCtxIds = async (api: PluginAPI): Promise<string[]> => {
+  const raw = await api.loadSyncedData(META_KEY);
+  const parsed = safeParse<MetaEntry>(raw);
+  return Array.isArray(parsed?.enabledCtxIds) ? parsed!.enabledCtxIds : [];
+};
+
+export const saveEnabledCtxIds = async (
+  api: PluginAPI,
+  enabledCtxIds: string[],
+): Promise<void> => {
+  await api.persistDataSynced(JSON.stringify({ enabledCtxIds }), META_KEY);
+};
+
+/**
+ * Read one context's editor doc. Returns null when the entry is missing or
+ * unparseable — caller falls back to a seed doc and (in editor.ts) gates
+ * saves so the fallback can't overwrite a recoverable original.
+ */
+export const loadContextDoc = async (api: PluginAPI, ctxId: string): Promise<unknown> => {
+  const raw = await api.loadSyncedData(docKey(ctxId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+export const saveContextDoc = async (
+  api: PluginAPI,
+  ctxId: string,
+  doc: unknown,
+): Promise<void> => {
+  await api.persistDataSynced(JSON.stringify(doc), docKey(ctxId));
+};
+
+/**
+ * One-shot migration from the legacy single-blob shape to keyed entries.
+ *
+ * Idempotent and crash-safe: a `__meta__` stamp guards re-runs after the
+ * full sweep completes. If a previous run set `attemptedAt` but never
+ * reached `migrated: 1` (process killed mid-way), the next call re-runs the
+ * loop — each upsert is content-idempotent (same context → same doc), so
+ * re-running costs op-log budget but doesn't corrupt state.
+ *
+ * Two devices migrating the same legacy data concurrently both write
+ * identical keyed entries; LWW resolves deterministically per entity. A
+ * stale device that writes to the legacy blob after migration is detected
+ * downstream by the plugin (a non-empty legacy read after `migrated: 1`
+ * means "older app on another device").
+ */
+export const migrateToKeyedPersistence = async (api: PluginAPI): Promise<void> => {
+  const stampRaw = await api.loadSyncedData(MIGRATION_STAMP_KEY);
+  const stamp = safeParse<MigrationStamp>(stampRaw);
+  if (stamp?.migrated === 1) return;
+
+  const legacyRaw = await api.loadSyncedData();
+  if (!legacyRaw) {
+    // No legacy data — either a fresh install or someone already tombstoned
+    // the legacy entry. Either way, stamp success and exit.
+    await api.persistDataSynced(JSON.stringify({ migrated: 1 }), MIGRATION_STAMP_KEY);
+    return;
+  }
+
+  const parsed = safeParse<LegacyBlob>(legacyRaw);
+  if (!parsed) {
+    // Legacy blob is corrupt. Don't tombstone — that would destroy whatever
+    // bytes are there, and we'd rather a future build with a fix have
+    // something to recover from. Bail without stamping success so the
+    // migration retries next session.
+    return;
+  }
+
+  // Stamp the attempt FIRST so a crash before the split is detectable on
+  // resume. attemptedAt is informational; the practical recovery is "if
+  // stamp.migrated !== 1, re-run the loop" — re-writes are content-
+  // idempotent.
+  await api.persistDataSynced(
+    JSON.stringify({ migrated: 0, attemptedAt: Date.now() }),
+    MIGRATION_STAMP_KEY,
+  );
+
+  const docs = parsed.docs ?? {};
+  for (const [ctxId, doc] of Object.entries(docs)) {
+    await api.persistDataSynced(JSON.stringify(doc), docKey(ctxId));
+  }
+
+  const enabledCtxIds = Array.isArray(parsed.enabledCtxIds) ? parsed.enabledCtxIds : [];
+  await api.persistDataSynced(JSON.stringify({ enabledCtxIds }), META_KEY);
+
+  // Tombstone the legacy entry: an empty payload is a plugin-side
+  // convention for "ignore". This gives LWW a winning side against any
+  // offline device that still writes the old shape.
+  await api.persistDataSynced('');
+
+  await api.persistDataSynced(JSON.stringify({ migrated: 1 }), MIGRATION_STAMP_KEY);
+};
+
+/**
+ * Detect a post-migration write to the legacy entry — symptomatic of an
+ * older device still running a pre-Stage-A build. Caller (background.ts)
+ * can surface a "update all devices" notice; the data itself isn't lost
+ * but won't be visible until the older device upgrades.
+ */
+export const detectStaleLegacyWrite = async (api: PluginAPI): Promise<boolean> => {
+  const stamp = safeParse<MigrationStamp>(await api.loadSyncedData(MIGRATION_STAMP_KEY));
+  if (stamp?.migrated !== 1) return false;
+  const legacy = await api.loadSyncedData();
+  return Boolean(legacy);
+};

--- a/packages/plugin-dev/document-mode/src/ui/editor.ts
+++ b/packages/plugin-dev/document-mode/src/ui/editor.ts
@@ -28,6 +28,11 @@ import {
   taskRefWithSubtasksJSON,
   type TaskLookup,
 } from '../doc-transform';
+import {
+  loadContextDoc,
+  migrateToKeyedPersistence,
+  saveContextDoc,
+} from '../persistence';
 import { iconSvg } from './icons';
 import * as docNav from './doc-nav';
 import { createTaskRefNode, type TaskRefNodeDeps } from './task-ref-node';
@@ -45,7 +50,6 @@ declare const PluginAPI: PluginAPI;
 // firing. Kept above the host's 1 s persist rate limit
 // (MIN_PLUGIN_PERSIST_INTERVAL_MS) so saves aren't rejected.
 const SAVE_THROTTLE_MS = 30_000;
-const STORAGE_VERSION = 1;
 
 // Action type the host emits for an in-place single-task update (NgRx
 // `createActionGroup`, source 'Task Shared'). `onAnyTaskUpdate` uses it to
@@ -54,14 +58,7 @@ const STORAGE_VERSION = 1;
 // always-correct full refresh runs instead.
 const UPDATE_TASK_ACTION = '[Task Shared] Update Task';
 
-interface StoredState {
-  version: number;
-  docs: Record<string, unknown>;
-  [key: string]: unknown; // preserve fields owned by background script
-}
-
 let currentCtx: ActiveWorkContext | null = null;
-let storedState: StoredState = { version: STORAGE_VERSION, docs: {} };
 let taskCache = new Map<string, Task>();
 /**
  * Stable task lookup handed to the pure `doc-transform` helpers. Defined as
@@ -82,10 +79,6 @@ let isLoadingDoc = false;
 // back to an empty seed. Gates scheduleSave so the empty seed is not
 // auto-persisted on top of the original (possibly corrupt) blob.
 let isDocCorrupt = false;
-// True when the *whole* stored blob is in a schema version we don't
-// understand (a user synced from a newer build). Gates scheduleSave so
-// we never downgrade-overwrite the original blob with our empty fallback.
-let isStorageUnreadable = false;
 // Monotonic guard for setActiveContext: concurrent calls (rapid context
 // switches) read this to drop after their awaits if a newer call has
 // superseded them.
@@ -235,46 +228,6 @@ const createSubTaskAfter = async (
 /* Persistence                                                                 */
 /* -------------------------------------------------------------------------- */
 
-const readBlob = async (): Promise<StoredState> => {
-  try {
-    const raw = await PluginAPI.loadSyncedData();
-    if (!raw) return { version: STORAGE_VERSION, docs: {} };
-    const parsed = JSON.parse(raw) as StoredState;
-    if (parsed && typeof parsed === 'object') {
-      // Future-version guard: if we encounter a blob whose schema is
-      // ahead of what this build understands (e.g. user synced from a
-      // newer release), don't pretend we can read it — return an empty
-      // shell. flushSave is gated by isDocCorrupt (see setActiveContext)
-      // so we won't clobber the original on disk.
-      const parsedVersion = Number(parsed.version) || STORAGE_VERSION;
-      if (parsedVersion > STORAGE_VERSION) {
-        // Refuse to load AND gate saves so we don't overwrite the
-        // user's newer blob with our empty fallback. Recovery happens
-        // when the user updates to a build that understands the
-        // newer schema.
-        isStorageUnreadable = true;
-        logErr(
-          `Stored doc-mode blob is version ${parsedVersion}; this build understands ${STORAGE_VERSION}. Refusing to load.`,
-        );
-        return { version: STORAGE_VERSION, docs: {} };
-      }
-      isStorageUnreadable = false;
-      return {
-        ...parsed,
-        version: parsedVersion,
-        docs: parsed.docs || {},
-      };
-    }
-  } catch (err) {
-    logErr('Failed to parse stored doc state', err);
-  }
-  return { version: STORAGE_VERSION, docs: {} };
-};
-
-const loadStoredState = async (): Promise<void> => {
-  storedState = await readBlob();
-};
-
 const flushSave = async (): Promise<void> => {
   if (saveTimer !== null) {
     clearTimeout(saveTimer);
@@ -283,13 +236,11 @@ const flushSave = async (): Promise<void> => {
   if (!currentCtx || !editor) return;
   saveInFlight = true;
   try {
-    const latest = await readBlob();
-    const merged: StoredState = {
-      ...latest,
-      docs: { ...latest.docs, [currentCtx.id]: stripChipContent(editor.getJSON()) },
-    };
-    storedState = merged;
-    await PluginAPI.persistDataSynced(JSON.stringify(merged));
+    // Keyed storage (Stage A): write only this context's doc. No need to
+    // read+merge any sibling state — the meta entry (enabledCtxIds) lives
+    // in its own LWW-resolved entity owned by background.ts, and sibling
+    // contexts each have their own `doc:${ctxId}` entry.
+    await saveContextDoc(PluginAPI, currentCtx.id, stripChipContent(editor.getJSON()));
   } catch (err) {
     logErr('persistDataSynced failed', err);
   } finally {
@@ -300,45 +251,33 @@ const flushSave = async (): Promise<void> => {
 /**
  * Teardown-safe save. The work-context embed iframe is destroyed
  * *synchronously* whenever the active context changes (the host's work-view
- * drops `<plugin-index>` from the DOM while the context is switching), so the
- * async `flushSave` is unusable on the way out: its `await readBlob()` never
- * receives a reply — the iframe is gone before the host responds — and the
- * `persistDataSynced` call after it never runs. The doc blob is then lost, and
- * because top-level chips are rebuilt from the host's task list on reload, the
- * loss only shows as vanished *text* blocks (paragraphs, headings, dividers).
+ * drops `<plugin-index>` from the DOM while the context is switching), so an
+ * awaited save is unusable on the way out: its `persistDataSynced` call may
+ * never leave the iframe before it dies. The doc blob is then lost, and
+ * because top-level chips are rebuilt from the host's task list on reload,
+ * the loss only shows as vanished *text* blocks (paragraphs, headings,
+ * dividers).
  *
- * This variant skips the round-trip: it builds the blob from the in-memory
- * `storedState` and dispatches `persistDataSynced` synchronously, so the
- * postMessage leaves the iframe before it dies. The host transparently
- * compresses the payload on its end (see `plugin-data-codec.ts`), so this
- * path still benefits from the size win.
- *
- * Trade-off: an `enabledCtxIds` change made by background.ts since our last
- * `readBlob` would be written back stale. That field only changes on an
- * explicit doc-mode toggle — which itself tears this iframe down — so the
- * window is effectively nil, and losing the whole doc is the worse outcome.
+ * Keyed storage (Stage A) means we no longer need to read+merge before
+ * writing — each `doc:${ctxId}` entry stands alone, so the sync path is just
+ * "stringify the doc and dispatch". The host transparently compresses the
+ * payload on its end (see `plugin-data-codec.ts`).
  */
 const flushSaveSync = (): void => {
   // Dirty signal: a timer is pending (edits queued for the throttle window)
-  // OR an async flushSave is mid-flight (its readBlob round-trip is awaiting
-  // a response that may never arrive if teardown is now). Skipping when
-  // neither is true avoids a full stringify + gzip on every blur (which
-  // fires on any focus shift inside the page).
+  // OR an async flushSave is mid-flight (its dispatch may not have left
+  // the iframe yet). Skipping when neither is true avoids a full stringify
+  // + gzip on every blur (which fires on any focus shift inside the page).
   if (saveTimer === null && !saveInFlight) return;
   if (saveTimer !== null) {
     clearTimeout(saveTimer);
     saveTimer = null;
   }
   if (!currentCtx || !editor) return;
-  // Same guard as scheduleSave — never overwrite a blob we couldn't read.
-  if (isDocCorrupt || isStorageUnreadable) return;
+  // Same guard as scheduleSave — never overwrite a doc we couldn't read.
+  if (isDocCorrupt) return;
   try {
-    const merged: StoredState = {
-      ...storedState,
-      docs: { ...storedState.docs, [currentCtx.id]: stripChipContent(editor.getJSON()) },
-    };
-    storedState = merged;
-    void PluginAPI.persistDataSynced(JSON.stringify(merged));
+    void saveContextDoc(PluginAPI, currentCtx.id, stripChipContent(editor.getJSON()));
   } catch (err) {
     logErr('persistDataSynced (sync flush) failed', err);
   }
@@ -346,10 +285,10 @@ const flushSaveSync = (): void => {
 
 const scheduleSave = (): void => {
   if (isLoadingDoc) return;
-  // Refuse to persist while the doc is a fallback (loaded from a blob we
-  // couldn't parse, or a future-version blob we don't understand). Saving
-  // here would overwrite the original blob with our empty seed.
-  if (isDocCorrupt || isStorageUnreadable) return;
+  // Refuse to persist while the doc is a fallback (loaded from an entry we
+  // couldn't parse). Saving here would overwrite the original entry with
+  // our empty seed.
+  if (isDocCorrupt) return;
   // Throttle: if a save is already pending, leave it — do NOT reschedule.
   // A debounce (reset-on-every-keystroke) would never fire for a continuous
   // typist, and the iframe can be torn down at any moment. This guarantees
@@ -384,14 +323,10 @@ const refreshTaskCache = async (): Promise<void> => {
 let bannerEl: HTMLDivElement | null = null;
 
 const updateDocStatusBanner = (): void => {
-  const message = isStorageUnreadable
-    ? 'This document was saved by a newer version of Super Productivity. ' +
-      'It is shown read-only and your data is left untouched — update the ' +
-      'app to edit it here.'
-    : isDocCorrupt
-      ? 'This document could not be loaded, so a blank one is shown. Your ' +
-        'saved data is untouched; editing is disabled here to protect it.'
-      : null;
+  const message = isDocCorrupt
+    ? 'This document could not be loaded, so a blank one is shown. Your ' +
+      'saved data is untouched; editing is disabled here to protect it.'
+    : null;
   if (!message) {
     bannerEl?.remove();
     bannerEl = null;
@@ -442,7 +377,11 @@ const setActiveContext = async (ctx: ActiveWorkContext | null): Promise<void> =>
   // (a task gaining the TODAY tag, a dueDay being set, etc.).
   lastSeenTaskIds = snapshotInContextTaskIds(taskCache.values(), ctx);
 
-  const stored = storedState.docs[ctx.id];
+  const stored = await loadContextDoc(PluginAPI, ctx.id);
+  if (seq !== activeContextSeq) {
+    isLoadingDoc = false;
+    return;
+  }
   const docJson = stored
     ? prepareStoredDoc(stored, ctx, lookupTask)
     : buildSeedDoc(ctx, lookupTask);
@@ -1829,7 +1768,14 @@ let isMounted = false;
 const mount = async (): Promise<void> => {
   if (isMounted) return;
   isMounted = true;
-  await loadStoredState();
+  // Run the legacy → keyed migration in case background.ts hasn't finished
+  // it before the user opened the editor for the first time. The migration
+  // is idempotent and stamp-guarded, so a duplicate call here is free.
+  try {
+    await migrateToKeyedPersistence(PluginAPI);
+  } catch (err) {
+    logErr('document-mode: migration failed', err);
+  }
   updateDocStatusBanner();
   const initialCtx = await PluginAPI.getActiveWorkContext();
 

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -290,13 +290,18 @@ export class PluginAPI implements PluginAPIInterface {
   }
 
   persistDataSynced(dataStr: string, key?: string): Promise<void> {
-    PluginLog.log(`Plugin ${this._pluginId} requested to persist data`, { key });
+    // Log keyLen, not key — plugins may use user-supplied content as keys
+    // (search queries, document titles), and the log history is exportable.
+    // CLAUDE.md rule 9: only ids, never user content.
+    PluginLog.log(`Plugin ${this._pluginId} requested to persist data`, {
+      keyLen: key?.length ?? 0,
+    });
     return this._boundMethods.persistDataSynced(dataStr, key);
   }
 
   loadSyncedData(key?: string): Promise<string | null> {
     PluginLog.log(`Plugin ${this._pluginId} requested to load persisted data`, {
-      key,
+      keyLen: key?.length ?? 0,
     });
     return this._boundMethods.loadPersistedData(key);
   }

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -289,14 +289,16 @@ export class PluginAPI implements PluginAPIInterface {
     return this._pluginBridge.notify(notifyCfg);
   }
 
-  persistDataSynced(dataStr: string): Promise<void> {
-    PluginLog.log(`Plugin ${this._pluginId} requested to persist data`);
-    return this._boundMethods.persistDataSynced(dataStr);
+  persistDataSynced(dataStr: string, key?: string): Promise<void> {
+    PluginLog.log(`Plugin ${this._pluginId} requested to persist data`, { key });
+    return this._boundMethods.persistDataSynced(dataStr, key);
   }
 
-  loadSyncedData(): Promise<string | null> {
-    PluginLog.log(`Plugin ${this._pluginId} requested to load persisted data:`);
-    return this._boundMethods.loadPersistedData();
+  loadSyncedData(key?: string): Promise<string | null> {
+    PluginLog.log(`Plugin ${this._pluginId} requested to load persisted data`, {
+      key,
+    });
+    return this._boundMethods.loadPersistedData(key);
   }
 
   async getConfig(): Promise<any> {

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -21,7 +21,10 @@ import {
   Task,
 } from './plugin-api.model';
 import { toActiveWorkContext } from './util/active-work-context.util';
-import { composeId } from './util/plugin-persistence-key.util';
+import {
+  assertPluginPersistenceKey,
+  composeId,
+} from './util/plugin-persistence-key.util';
 
 import {
   BatchTaskCreate,
@@ -1041,6 +1044,7 @@ export class PluginBridgeService implements OnDestroy {
     key?: string,
   ): Promise<void> {
     typia.assert<string>(dataStr);
+    assertPluginPersistenceKey(key);
 
     try {
       // Validates the pluginId synchronously; bubbles through the try/catch
@@ -1049,7 +1053,7 @@ export class PluginBridgeService implements OnDestroy {
       this._pluginUserPersistenceService.persistPluginUserData(entityId, dataStr);
       console.log('PluginBridge: Plugin data persisted successfully', {
         pluginId,
-        key,
+        keyLen: key?.length ?? 0,
         dataSize: new Blob([dataStr]).size,
       });
     } catch (error) {
@@ -1066,13 +1070,19 @@ export class PluginBridgeService implements OnDestroy {
 
   /**
    * Internal method to load persisted plugin data.
+   *
+   * `composeId` runs outside the try/catch so a bad pluginId throws to the
+   * caller symmetrically with the persist path — silently returning `null`
+   * for "your pluginId is malformed" would look indistinguishable from "no
+   * data yet" and could mask a misconfiguration.
    */
   private async _loadPersistedData(
     pluginId: string,
     key?: string,
   ): Promise<string | null> {
+    assertPluginPersistenceKey(key);
+    const entityId = composeId(pluginId, key);
     try {
-      const entityId = composeId(pluginId, key);
       return await this._pluginUserPersistenceService.loadPluginUserData(entityId);
     } catch (error) {
       PluginLog.err('PluginBridge: Failed to get persisted plugin data:', error);

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -21,6 +21,7 @@ import {
   Task,
 } from './plugin-api.model';
 import { toActiveWorkContext } from './util/active-work-context.util';
+import { composeId } from './util/plugin-persistence-key.util';
 
 import {
   BatchTaskCreate,
@@ -192,8 +193,8 @@ export class PluginBridgeService implements OnDestroy {
     pluginId: string,
     manifest?: PluginManifest,
   ): {
-    persistDataSynced: (dataStr: string) => Promise<void>;
-    loadPersistedData: () => Promise<string | null>;
+    persistDataSynced: (dataStr: string, key?: string) => Promise<void>;
+    loadPersistedData: (key?: string) => Promise<string | null>;
     getConfig: () => Promise<unknown>;
     downloadFile: (filename: string, data: string) => Promise<void>;
     registerHeaderButton: (cfg: PluginHeaderBtnCfg) => void;
@@ -236,8 +237,9 @@ export class PluginBridgeService implements OnDestroy {
   } {
     return {
       // Data persistence
-      persistDataSynced: (dataStr: string) => this._persistDataSynced(pluginId, dataStr),
-      loadPersistedData: () => this._loadPersistedData(pluginId),
+      persistDataSynced: (dataStr: string, key?: string) =>
+        this._persistDataSynced(pluginId, dataStr, key),
+      loadPersistedData: (key?: string) => this._loadPersistedData(pluginId, key),
       getConfig: () => this._getConfig(pluginId),
       downloadFile: (filename: string, data: string) =>
         this._downloadFile(filename, data),
@@ -1028,20 +1030,30 @@ export class PluginBridgeService implements OnDestroy {
   }
 
   /**
-   * Internal method to persist plugin data
-   * Includes size and rate limit validation
+   * Internal method to persist plugin data.
+   * Includes size and rate limit validation; composeId enforces the
+   * `pluginId` keyspace contract at this transport boundary so the throw
+   * covers both iframe and direct API callers.
    */
-  private async _persistDataSynced(pluginId: string, dataStr: string): Promise<void> {
+  private async _persistDataSynced(
+    pluginId: string,
+    dataStr: string,
+    key?: string,
+  ): Promise<void> {
     typia.assert<string>(dataStr);
 
     try {
-      this._pluginUserPersistenceService.persistPluginUserData(pluginId, dataStr);
+      // Validates the pluginId synchronously; bubbles through the try/catch
+      // below as a normal Error.
+      const entityId = composeId(pluginId, key);
+      this._pluginUserPersistenceService.persistPluginUserData(entityId, dataStr);
       console.log('PluginBridge: Plugin data persisted successfully', {
         pluginId,
+        key,
         dataSize: new Blob([dataStr]).size,
       });
     } catch (error) {
-      // Log the specific error (rate limit or size exceeded)
+      // Log the specific error (rate limit, size, or composeId)
       PluginLog.err('PluginBridge: Failed to persist plugin data:', error);
 
       // Rethrow with the original error message for better debugging
@@ -1053,11 +1065,15 @@ export class PluginBridgeService implements OnDestroy {
   }
 
   /**
-   * Internal method to load persisted plugin data
+   * Internal method to load persisted plugin data.
    */
-  private async _loadPersistedData(pluginId: string): Promise<string | null> {
+  private async _loadPersistedData(
+    pluginId: string,
+    key?: string,
+  ): Promise<string | null> {
     try {
-      return await this._pluginUserPersistenceService.loadPluginUserData(pluginId);
+      const entityId = composeId(pluginId, key);
+      return await this._pluginUserPersistenceService.loadPluginUserData(entityId);
     } catch (error) {
       PluginLog.err('PluginBridge: Failed to get persisted plugin data:', error);
       return null;

--- a/src/app/plugins/plugin-persistence.model.ts
+++ b/src/app/plugins/plugin-persistence.model.ts
@@ -1,8 +1,19 @@
 /**
- * Maximum size of plugin data in bytes (1 MB).
- * This prevents malicious or broken plugins from flooding storage with large data.
+ * Maximum size of a single plugin-persistence write, in bytes (256 KB).
+ *
+ * Sized for the realistic upper bound of plugin payloads — a heavy
+ * document-mode TipTap doc is ~30–100 KB, plugin configs are KB-scale,
+ * automation rules / AI prompts are KB-scale. 256 KB gives several×
+ * headroom while keeping the per-plugin storage growth bounded:
+ * a misbehaving plugin with N keyed entries can still hold N × 256 KB,
+ * but the per-write surprise is much smaller than the original 1 MB.
+ *
+ * The pre-Stage-A cap was 1 MB because one blob held every context's
+ * data; with the keyed split each context gets its own entry, so the
+ * per-write budget can shrink. Legacy migrations skip individual docs
+ * that exceed this (see `document-mode/src/persistence.ts`).
  */
-export const MAX_PLUGIN_DATA_SIZE = 1024 * 1024; // 1 MB
+export const MAX_PLUGIN_DATA_SIZE = 256 * 1024; // 256 KB
 
 /**
  * Minimum interval between plugin data persist calls in milliseconds.

--- a/src/app/plugins/plugin-user-persistence.service.spec.ts
+++ b/src/app/plugins/plugin-user-persistence.service.spec.ts
@@ -10,7 +10,7 @@ import { selectPluginUserDataFeatureState } from './store/plugin-user-data.reduc
 import { COMPRESS_THRESHOLD, SENTINEL, encodeForPersist } from './util/plugin-data-codec';
 
 /**
- * Drain enough microtasks for the per-plugin commit chain to settle. The
+ * Drain enough microtasks for the per-entity commit chain to settle. The
  * chain is `Promise.resolve().catch().then(() => _encodeAndDispatch())` plus
  * one `await` inside _encodeAndDispatch — three turns max — but a few extra
  * yields are free and survive any future chain tweak.
@@ -161,6 +161,58 @@ describe('PluginUserPersistenceService', () => {
       // races with test teardown but is harmless.
       expect(() => service.persistPluginUserData(pluginId, exactLimitData)).not.toThrow();
     });
+
+    it('should dispatch distinct ops for distinct composite ids of one plugin', async () => {
+      const baseTime = Date.now();
+      jasmine.clock().install();
+      jasmine.clock().mockDate(new Date(baseTime));
+      try {
+        // Two keys for the same plugin compose into distinct entity ids, so
+        // they bypass each other's rate-limit window and emit two separate
+        // upsert ops — the per-entity LWW guarantee Stage A is built on.
+        await Promise.all([
+          service.persistPluginUserData('plugin-a:doc-1', 'one'),
+          service.persistPluginUserData('plugin-a:doc-2', 'two'),
+        ]);
+
+        expect(dispatchSpy).toHaveBeenCalledTimes(2);
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          upsertPluginUserData({
+            pluginUserData: { id: 'plugin-a:doc-1', data: 'one' },
+          }),
+        );
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          upsertPluginUserData({
+            pluginUserData: { id: 'plugin-a:doc-2', data: 'two' },
+          }),
+        );
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
+
+    it('should rate-limit each composite id independently', async () => {
+      const baseTime = Date.now();
+      jasmine.clock().install();
+      jasmine.clock().mockDate(new Date(baseTime));
+      try {
+        // First persist on each key dispatches immediately; second on each
+        // is coalesced. After ticking the window, the coalesced writes
+        // flush, giving 4 dispatches total — proving keys are not
+        // serialized against one another.
+        await service.persistPluginUserData('plugin-a:doc-1', 'a1');
+        await service.persistPluginUserData('plugin-a:doc-2', 'b1');
+        service.persistPluginUserData('plugin-a:doc-1', 'a2'); // coalesced
+        service.persistPluginUserData('plugin-a:doc-2', 'b2'); // coalesced
+        expect(dispatchSpy).toHaveBeenCalledTimes(2);
+
+        jasmine.clock().tick(MIN_PLUGIN_PERSIST_INTERVAL_MS);
+        await drainAsync();
+        expect(dispatchSpy).toHaveBeenCalledTimes(4);
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
   });
 
   describe('loadPluginUserData', () => {
@@ -222,32 +274,118 @@ describe('PluginUserPersistenceService', () => {
         jasmine.clock().uninstall();
       }
     });
+
+    it('should return only the matching composite id, not a sibling key', async () => {
+      // Verifies that a keyed load resolves by exact entityId — no prefix
+      // fallback to the legacy entry.
+      store.overrideSelector(selectPluginUserDataFeatureState, [
+        { id: 'plugin-a', data: 'legacy' },
+        { id: 'plugin-a:doc-1', data: 'one' },
+        { id: 'plugin-a:doc-2', data: 'two' },
+      ]);
+
+      expect(await service.loadPluginUserData('plugin-a')).toBe('legacy');
+      expect(await service.loadPluginUserData('plugin-a:doc-1')).toBe('one');
+      expect(await service.loadPluginUserData('plugin-a:doc-2')).toBe('two');
+      expect(await service.loadPluginUserData('plugin-a:doc-missing')).toBeNull();
+    });
   });
 
   describe('removePluginUserData', () => {
-    it('should dispatch deletePluginUserData action', () => {
-      const pluginId = 'test-plugin';
+    it('should dispatch one delete per matching entry (legacy + keyed)', async () => {
+      // Stage A Phase 3: a single uninstall of `plugin-a` must emit one
+      // delete op per existing entry under that plugin's prefix, so remote
+      // replicas don't keep the keyed entries after the legacy delete
+      // replays. `plugin-b`'s entries must be untouched.
+      store.overrideSelector(selectPluginUserDataFeatureState, [
+        { id: 'plugin-a', data: 'legacy-a' },
+        { id: 'plugin-a:doc-1', data: 'one' },
+        { id: 'plugin-a:doc-2', data: 'two' },
+        { id: 'plugin-b', data: 'legacy-b' },
+        { id: 'plugin-b:doc-1', data: 'b1' },
+      ]);
 
-      service.removePluginUserData(pluginId);
+      await service.removePluginUserData('plugin-a');
 
-      expect(dispatchSpy).toHaveBeenCalledWith(deletePluginUserData({ pluginId }));
+      const deleteCalls = dispatchSpy.calls
+        .allArgs()
+        .filter(([action]) => action.type === deletePluginUserData.type)
+        .map(([action]) => (action as ReturnType<typeof deletePluginUserData>).pluginId);
+
+      expect(deleteCalls.sort()).toEqual(
+        ['plugin-a', 'plugin-a:doc-1', 'plugin-a:doc-2'].sort(),
+      );
     });
 
-    it('should cancel a pending coalesced write', async () => {
+    it('should not match plugin ids that merely share a prefix', async () => {
+      // 'plugin-abc' shares the literal 'plugin-a' prefix but isn't part of
+      // 'plugin-a's keyspace. The `:` delimiter is what disambiguates.
+      store.overrideSelector(selectPluginUserDataFeatureState, [
+        { id: 'plugin-a', data: 'a' },
+        { id: 'plugin-abc', data: 'abc' },
+        { id: 'plugin-abc:doc', data: 'abc-doc' },
+      ]);
+
+      await service.removePluginUserData('plugin-a');
+
+      const deleteCalls = dispatchSpy.calls
+        .allArgs()
+        .filter(([action]) => action.type === deletePluginUserData.type)
+        .map(([action]) => (action as ReturnType<typeof deletePluginUserData>).pluginId);
+
+      expect(deleteCalls).toEqual(['plugin-a']);
+    });
+
+    it('should be a no-op when the plugin has no entries in state', async () => {
+      // No matching state means there is nothing for remote replicas to
+      // resolve, so we suppress the phantom delete op the pre-Stage-A
+      // implementation used to emit.
+      await service.removePluginUserData('absent-plugin');
+
+      const deleteCalls = dispatchSpy.calls
+        .allArgs()
+        .filter(([action]) => action.type === deletePluginUserData.type);
+      expect(deleteCalls).toEqual([]);
+    });
+
+    it('should cancel a pending coalesced write across all matching keys', async () => {
       const baseTime = Date.now();
       jasmine.clock().install();
       jasmine.clock().mockDate(new Date(baseTime));
       try {
-        const pluginId = 'test-plugin';
-        await service.persistPluginUserData(pluginId, 'first');
-        service.persistPluginUserData(pluginId, 'pending'); // coalesced
+        // Two keys both have committed entries (so they appear in state)
+        // *and* a follow-up coalesced write. The cancel must drop both
+        // coalesced writes; the deletes must still fire.
+        store.overrideSelector(selectPluginUserDataFeatureState, [
+          { id: 'plugin-a:doc-1', data: 'committed-1' },
+          { id: 'plugin-a:doc-2', data: 'committed-2' },
+        ]);
+        await service.persistPluginUserData('plugin-a:doc-1', 'committed-1');
+        await service.persistPluginUserData('plugin-a:doc-2', 'committed-2');
+        service.persistPluginUserData('plugin-a:doc-1', 'pending-1'); // coalesced
+        service.persistPluginUserData('plugin-a:doc-2', 'pending-2'); // coalesced
 
-        service.removePluginUserData(pluginId);
-        dispatchSpy.calls.reset();
-
+        // remove's sync portion cancels the pendings immediately. Its async
+        // portion does: await firstValueFrom -> dispatch loop -> await
+        // setTimeout(0). Drain microtasks first so the trailing setTimeout
+        // is *scheduled*, then tick so it fires, then drain again so the
+        // await resolves.
+        const removePromise = service.removePluginUserData('plugin-a');
+        await drainAsync();
         jasmine.clock().tick(MIN_PLUGIN_PERSIST_INTERVAL_MS * 2);
         await drainAsync();
-        expect(dispatchSpy).not.toHaveBeenCalled();
+        await removePromise;
+
+        // The pending 'pending-1' / 'pending-2' coalesced writes must not
+        // have resurfaced as upserts after the cancellation.
+        const upsertedValues = dispatchSpy.calls
+          .allArgs()
+          .filter(([a]) => a.type === upsertPluginUserData.type)
+          .map(
+            ([a]) => (a as ReturnType<typeof upsertPluginUserData>).pluginUserData.data,
+          );
+        expect(upsertedValues).not.toContain('pending-1');
+        expect(upsertedValues).not.toContain('pending-2');
       } finally {
         jasmine.clock().uninstall();
       }
@@ -255,6 +393,12 @@ describe('PluginUserPersistenceService', () => {
 
     it('should not resurrect data when removed during an in-flight commit', async () => {
       const pluginId = 'test-plugin';
+      // The entry must be in state for `remove` to dispatch a delete — but
+      // the resurrection guard is independent of state membership: it relies
+      // on the generation counter inside _encodeAndDispatch.
+      store.overrideSelector(selectPluginUserDataFeatureState, [
+        { id: pluginId, data: 'previously-committed' },
+      ]);
       // A payload above the codec threshold forces async compression, so
       // the commit's dispatch happens after at least one microtask turn —
       // wide enough for a synchronous remove to land in between.
@@ -262,10 +406,13 @@ describe('PluginUserPersistenceService', () => {
 
       const persistPromise = service.persistPluginUserData(pluginId, data);
 
-      // remove() runs synchronously while compression is still pending.
-      service.removePluginUserData(pluginId);
+      // remove() runs while compression is still pending. Its synchronous
+      // _cancelPendingForPlugin bumps the generation; its async portion
+      // resolves after the commit's await.
+      const removePromise = service.removePluginUserData(pluginId);
 
       await persistPromise;
+      await removePromise;
       await drainAsync();
 
       const upsertCalls = dispatchSpy.calls

--- a/src/app/plugins/plugin-user-persistence.service.ts
+++ b/src/app/plugins/plugin-user-persistence.service.ts
@@ -9,12 +9,20 @@ import {
 import { upsertPluginUserData, deletePluginUserData } from './store/plugin.actions';
 import { selectPluginUserDataFeatureState } from './store/plugin-user-data.reducer';
 import { decodeFromPersist, encodeForPersist } from './util/plugin-data-codec';
+import { isPluginIdMatch } from './util/plugin-persistence-key.util';
 import { PluginLog } from '../core/log';
 
 /**
  * Service for persisting plugin user data using NgRx actions.
  * Handles data that plugins store and retrieve via persistDataSynced/loadSyncedData.
  * Includes rate limiting and size validation to prevent abuse.
+ *
+ * The `entityId` argument is the composed storage key: it equals the bare
+ * `pluginId` for legacy single-blob entries, and `pluginId:key` for keyed
+ * entries (composed at the bridge transport boundary, see
+ * `util/plugin-persistence-key.util.ts`). All internal Maps and dispatched
+ * ops key by `entityId`, so distinct keys are independently rate-limited,
+ * coalesced, and LWW-resolved.
  *
  * Data is transparently gzip-compressed at the persistence boundary (see
  * `plugin-data-codec.ts`). Plugins only see their own raw strings; the
@@ -28,24 +36,24 @@ export class PluginUserPersistenceService {
   private _store = inject(Store);
 
   /**
-   * Track the last *committed* persist time per plugin, for rate limiting.
+   * Track the last *committed* persist time per entity id, for rate limiting.
    */
   private _lastPersistTime = new Map<string, number>();
 
   /**
    * Data that arrived inside the rate-limit window and is waiting to be
-   * committed. Coalesced — only the most recent value per plugin is kept.
+   * committed. Coalesced — only the most recent value per entity id is kept.
    * Holds *uncompressed* input (compression happens at commit time).
    */
   private _pendingData = new Map<string, string>();
 
   /**
-   * Active flush timers for coalesced writes, keyed by plugin id.
+   * Active flush timers for coalesced writes, keyed by entity id.
    */
   private _flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   /**
-   * The latest uncompressed input for a plugin whose `_commit` has started
+   * The latest uncompressed input for an entity whose `_commit` has started
    * but whose async compression has not yet dispatched. A read in this
    * window must see the latest write (read-your-writes), so we hold the
    * raw input here until the dispatch lands.
@@ -53,16 +61,16 @@ export class PluginUserPersistenceService {
   private _committing = new Map<string, string>();
 
   /**
-   * Per-plugin commit chain. Compression is async (`CompressionStream`),
+   * Per-entity commit chain. Compression is async (`CompressionStream`),
    * so two `_commit` calls in quick succession could finish out of order
    * and dispatch a stale write last. Chaining serializes
-   * compress-then-dispatch per plugin while leaving different plugins
+   * compress-then-dispatch per entity while leaving different entities
    * concurrent.
    */
   private _commitChain = new Map<string, Promise<void>>();
 
   /**
-   * Per-plugin generation counter. Bumped by `_cancelPending` so any
+   * Per-entity generation counter. Bumped by `_cancelPending` so any
    * in-flight `_commit` whose compression started under an older
    * generation aborts before dispatching. Without this, a
    * `removePluginUserData` issued during an async compress would be
@@ -71,14 +79,17 @@ export class PluginUserPersistenceService {
   private _commitGeneration = new Map<string, number>();
 
   /**
-   * Persist user data for a specific plugin (called by plugin via persistDataSynced).
+   * Persist user data for a specific entity (called by plugin via
+   * persistDataSynced(data, key?), with the bridge composing pluginId+key
+   * into `entityId` before reaching here).
    *
    * Rate limiting *coalesces* rather than rejects: a call that arrives inside
    * the MIN_PLUGIN_PERSIST_INTERVAL_MS window is not dropped — its data is
    * held and committed when the window opens (latest write wins). This still
-   * caps the op-log/sync rate at one write per interval, but never discards
-   * the caller's most recent data. Dropping it silently lost edits — e.g. a
-   * plugin's final save on teardown landing just after a periodic save.
+   * caps the op-log/sync rate at one write per interval *per entity id*,
+   * but never discards the caller's most recent data. Dropping it silently
+   * lost edits — e.g. a plugin's final save on teardown landing just after a
+   * periodic save.
    *
    * Returns a Promise that resolves once the data has been compressed and
    * dispatched (or queued for a future commit). The size-cap check is
@@ -97,10 +108,12 @@ export class PluginUserPersistenceService {
    *
    * @throws Error if data exceeds MAX_PLUGIN_DATA_SIZE
    */
-  persistPluginUserData(pluginId: string, data: string): Promise<void> {
+  persistPluginUserData(entityId: string, data: string): Promise<void> {
     // Validate data size — applies whether the write commits now or later.
     // Cap is on the uncompressed user input, so a plugin can't bypass by
-    // sending pre-compressed bytes.
+    // sending pre-compressed bytes. The cap is per-entity (i.e. per
+    // composite id); aggregate caps across a plugin's keys are out of
+    // scope — see docs/plans/2026-05-23-stage-a-keyed-plugin-persistence.md.
     const dataSize = new Blob([data]).size;
     if (dataSize > MAX_PLUGIN_DATA_SIZE) {
       throw new Error(
@@ -111,68 +124,68 @@ export class PluginUserPersistenceService {
 
     // Rate limiting: check if enough time has passed since the last commit.
     const now = Date.now();
-    const lastPersist = this._lastPersistTime.get(pluginId) || 0;
+    const lastPersist = this._lastPersistTime.get(entityId) || 0;
     const timeSinceLastPersist = now - lastPersist;
 
     if (timeSinceLastPersist < MIN_PLUGIN_PERSIST_INTERVAL_MS) {
       // Inside the window: coalesce. Hold the latest data and flush it once
       // the window opens, so no write is discarded.
-      this._pendingData.set(pluginId, data);
-      if (!this._flushTimers.has(pluginId)) {
+      this._pendingData.set(entityId, data);
+      if (!this._flushTimers.has(entityId)) {
         const delay = MIN_PLUGIN_PERSIST_INTERVAL_MS - timeSinceLastPersist;
         this._flushTimers.set(
-          pluginId,
+          entityId,
           setTimeout(() => {
-            void this._flushPendingData(pluginId);
+            void this._flushPendingData(entityId);
           }, delay),
         );
       }
       return Promise.resolve();
     }
 
-    return this._commit(pluginId, data, now);
+    return this._commit(entityId, data, now);
   }
 
   /**
    * Commit a coalesced write once its rate-limit window has elapsed.
    */
-  private async _flushPendingData(pluginId: string): Promise<void> {
-    this._flushTimers.delete(pluginId);
-    const data = this._pendingData.get(pluginId);
+  private async _flushPendingData(entityId: string): Promise<void> {
+    this._flushTimers.delete(entityId);
+    const data = this._pendingData.get(entityId);
     if (data === undefined) {
       return;
     }
-    this._pendingData.delete(pluginId);
-    await this._commit(pluginId, data, Date.now());
+    this._pendingData.delete(entityId);
+    await this._commit(entityId, data, Date.now());
   }
 
   /**
-   * Compress and dispatch. Serialized per plugin via `_commitChain` to
+   * Compress and dispatch. Serialized per entity via `_commitChain` to
    * preserve write order even if compression times vary across calls.
    */
-  private _commit(pluginId: string, data: string, at: number): Promise<void> {
-    this._lastPersistTime.set(pluginId, at);
-    this._committing.set(pluginId, data);
+  private _commit(entityId: string, data: string, at: number): Promise<void> {
+    this._lastPersistTime.set(entityId, at);
+    this._committing.set(entityId, data);
     // Capture the generation at the moment we schedule. If a remove bumps
     // it before this commit's compression finishes, _encodeAndDispatch
     // bails and the upsert is suppressed — preventing post-delete
     // resurrection.
-    const myGeneration = this._commitGeneration.get(pluginId) ?? 0;
+    const myGeneration = this._commitGeneration.get(entityId) ?? 0;
 
-    const prev = this._commitChain.get(pluginId) ?? Promise.resolve();
+    const prev = this._commitChain.get(entityId) ?? Promise.resolve();
     // Swallow prior errors so the chain doesn't poison subsequent writes.
     // The original failed call has already seen and surfaced its own error.
     const next: Promise<void> = prev
       .catch(() => undefined)
-      .then(() => this._encodeAndDispatch(pluginId, data, myGeneration));
-    this._commitChain.set(pluginId, next);
+      .then(() => this._encodeAndDispatch(entityId, data, myGeneration));
+    this._commitChain.set(entityId, next);
 
     next.finally(() => {
-      if (this._committing.get(pluginId) === data) {
-        this._committing.delete(pluginId);
+      if (this._committing.get(entityId) === data) {
+        this._committing.delete(entityId);
       }
-      if (this._commitChain.get(pluginId) === next) {
-        this._commitChain.delete(pluginId);
+      if (this._commitChain.get(entityId) === next) {
+        this._commitChain.delete(entityId);
       }
     });
 
@@ -180,22 +193,24 @@ export class PluginUserPersistenceService {
   }
 
   private async _encodeAndDispatch(
-    pluginId: string,
+    entityId: string,
     data: string,
     generation: number,
   ): Promise<void> {
     const encoded = await encodeForPersist(data);
-    if ((this._commitGeneration.get(pluginId) ?? 0) !== generation) {
+    if ((this._commitGeneration.get(entityId) ?? 0) !== generation) {
       // A removePluginUserData / clearAllPluginUserData ran between
       // schedule and dispatch. Dropping the upsert preserves the delete.
       return;
     }
-    const pluginUserData: PluginUserData = { id: pluginId, data: encoded };
+    const pluginUserData: PluginUserData = { id: entityId, data: encoded };
     this._store.dispatch(upsertPluginUserData({ pluginUserData }));
   }
 
   /**
-   * Load user data for a specific plugin (called by plugin via loadSyncedData).
+   * Load user data for a specific entity (called by plugin via
+   * loadSyncedData(key?), with the bridge composing pluginId+key into
+   * `entityId` before reaching here).
    *
    * Returns a coalesced-but-not-yet-committed write if one is pending, so a
    * plugin's read-modify-write cycle always sees its own latest data. Same
@@ -203,19 +218,19 @@ export class PluginUserPersistenceService {
    *
    * Otherwise reads from NgRx state and decompresses transparently.
    */
-  async loadPluginUserData(pluginId: string): Promise<string | null> {
-    const pending = this._pendingData.get(pluginId);
+  async loadPluginUserData(entityId: string): Promise<string | null> {
+    const pending = this._pendingData.get(entityId);
     if (pending !== undefined) {
       return pending;
     }
-    const committing = this._committing.get(pluginId);
+    const committing = this._committing.get(entityId);
     if (committing !== undefined) {
       return committing;
     }
     const currentState = await firstValueFrom(
       this._store.select(selectPluginUserDataFeatureState),
     );
-    const pluginData = currentState.find((item) => item.id === pluginId);
+    const pluginData = currentState.find((item) => item.id === entityId);
     if (!pluginData?.data) {
       return null;
     }
@@ -225,7 +240,7 @@ export class PluginUserPersistenceService {
       // Don't log `err` directly — gzip/atob messages can contain partial
       // payload bytes from user content. Surface only the error class.
       PluginLog.err('PluginUserPersistenceService: failed to decode stored data', {
-        pluginId,
+        entityId,
         errName: (err as Error)?.name,
       });
       return null;
@@ -233,29 +248,74 @@ export class PluginUserPersistenceService {
   }
 
   /**
-   * Remove user data for a specific plugin.
+   * Remove all user data belonging to a plugin (legacy entry + every keyed
+   * entry `pluginId:*`). The pluginId is treated as a prefix here — distinct
+   * from `persist`/`load`, which key on a single composite entity id.
+   *
+   * Mechanism (Stage A Phase 3, Option A): the service reads current state,
+   * filters by `isPluginIdMatch`, and dispatches one `deletePluginUserData`
+   * per match. Each dispatch produces one Delete op in the op-log; remote
+   * replicas replay the full sweep. A reducer-only prefix match would emit
+   * only one op (for `pluginId` alone) and leak keyed entries on remote
+   * devices — see the Phase 3 plan.
+   *
+   * Yields the event loop after the dispatch loop — CLAUDE.md sync rule 6:
+   * rapid in-loop dispatches against an `array`-pattern entity can lose
+   * state without a microtask break.
    */
-  removePluginUserData(pluginId: string): void {
-    this._cancelPending(pluginId);
-    this._store.dispatch(deletePluginUserData({ pluginId }));
+  async removePluginUserData(pluginId: string): Promise<void> {
+    // Cancel any in-flight commits whose entity id matches the plugin.
+    // These may not yet exist in NgRx state (they're mid-compress), so we
+    // walk the internal Maps as well, not just the state.
+    this._cancelPendingForPlugin(pluginId);
+
+    const currentState = await firstValueFrom(
+      this._store.select(selectPluginUserDataFeatureState),
+    );
+    const matches = currentState.filter((item) => isPluginIdMatch(item.id, pluginId));
+    for (const item of matches) {
+      this._store.dispatch(deletePluginUserData({ pluginId: item.id }));
+    }
+    await new Promise((r) => setTimeout(r, 0));
   }
 
   /**
-   * Drop any pending coalesced write (and its timer) for a plugin, so it
-   * cannot resurrect data that is being removed. Also bumps the commit
-   * generation so an *in-flight* `_commit` (already past its rate-limit
-   * check, currently awaiting compression) detects the cancel and skips
-   * its dispatch — the upsert would otherwise undo this delete.
+   * Drop any pending coalesced write (and its timer) for a single entity
+   * id, so it cannot resurrect data that is being removed. Also bumps the
+   * commit generation so an *in-flight* `_commit` (already past its
+   * rate-limit check, currently awaiting compression) detects the cancel
+   * and skips its dispatch — the upsert would otherwise undo this delete.
    */
-  private _cancelPending(pluginId: string): void {
-    const timer = this._flushTimers.get(pluginId);
+  private _cancelPending(entityId: string): void {
+    const timer = this._flushTimers.get(entityId);
     if (timer !== undefined) {
       clearTimeout(timer);
-      this._flushTimers.delete(pluginId);
+      this._flushTimers.delete(entityId);
     }
-    this._pendingData.delete(pluginId);
-    this._committing.delete(pluginId);
-    this._commitGeneration.set(pluginId, (this._commitGeneration.get(pluginId) ?? 0) + 1);
+    this._pendingData.delete(entityId);
+    this._committing.delete(entityId);
+    this._commitGeneration.set(entityId, (this._commitGeneration.get(entityId) ?? 0) + 1);
+  }
+
+  /**
+   * Cancel pendings for every entity id currently tracked under the given
+   * plugin (legacy + any keyed entries). We have to walk the in-flight
+   * Maps directly because an entity whose first persist is mid-compress
+   * is not yet in NgRx state.
+   */
+  private _cancelPendingForPlugin(pluginId: string): void {
+    const candidateIds = new Set<string>();
+    for (const id of this._lastPersistTime.keys()) candidateIds.add(id);
+    for (const id of this._pendingData.keys()) candidateIds.add(id);
+    for (const id of this._flushTimers.keys()) candidateIds.add(id);
+    for (const id of this._committing.keys()) candidateIds.add(id);
+    for (const id of this._commitChain.keys()) candidateIds.add(id);
+    for (const id of this._commitGeneration.keys()) candidateIds.add(id);
+    for (const id of candidateIds) {
+      if (isPluginIdMatch(id, pluginId)) {
+        this._cancelPending(id);
+      }
+    }
   }
 
   /**

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -361,10 +361,10 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
           closeWorkContextView: () => callApi('closeWorkContextView'),
           getActiveWorkContext: () => callApi('getActiveWorkContext'),
 
-          // Persistence methods
-          persistDataSynced: (data) => callApi('persistDataSynced', [data]),
-          loadPersistedData: () => callApi('loadPersistedData'),
-          loadSyncedData: () => callApi('loadPersistedData'), // Alias
+          // Persistence methods (optional second arg = key, forwarded by callApi)
+          persistDataSynced: (data, key) => callApi('persistDataSynced', [data, key]),
+          loadPersistedData: (key) => callApi('loadPersistedData', [key]),
+          loadSyncedData: (key) => callApi('loadPersistedData', [key]), // Alias
 
           // Registration methods
           registerHook: (hook, handler) => callApi('registerHook', [hook, handler]),

--- a/src/app/plugins/util/plugin-persistence-key.util.spec.ts
+++ b/src/app/plugins/util/plugin-persistence-key.util.spec.ts
@@ -1,4 +1,9 @@
-import { composeId, isPluginIdMatch } from './plugin-persistence-key.util';
+import {
+  assertPluginPersistenceKey,
+  composeId,
+  isPluginIdMatch,
+  MAX_PLUGIN_PERSISTENCE_KEY_LENGTH,
+} from './plugin-persistence-key.util';
 
 describe('composeId', () => {
   it('returns pluginId unchanged when no key is provided', () => {
@@ -24,6 +29,42 @@ describe('composeId', () => {
   it('throws synchronously when pluginId contains ":"', () => {
     expect(() => composeId('bad:plugin')).toThrowError(/must not contain ':'/);
     expect(() => composeId('bad:plugin', 'k')).toThrowError(/must not contain ':'/);
+  });
+});
+
+describe('assertPluginPersistenceKey', () => {
+  it('accepts undefined (legacy keyless form)', () => {
+    expect(() => assertPluginPersistenceKey(undefined)).not.toThrow();
+  });
+
+  it('accepts ordinary strings', () => {
+    expect(() => assertPluginPersistenceKey('')).not.toThrow();
+    expect(() => assertPluginPersistenceKey('doc-1')).not.toThrow();
+    expect(() => assertPluginPersistenceKey('a'.repeat(100))).not.toThrow();
+  });
+
+  it('accepts a key at exactly the length cap', () => {
+    expect(() =>
+      assertPluginPersistenceKey('a'.repeat(MAX_PLUGIN_PERSISTENCE_KEY_LENGTH)),
+    ).not.toThrow();
+  });
+
+  it('throws on a key over the length cap', () => {
+    expect(() =>
+      assertPluginPersistenceKey('a'.repeat(MAX_PLUGIN_PERSISTENCE_KEY_LENGTH + 1)),
+    ).toThrowError(/exceeds maximum length/);
+  });
+
+  it('throws on non-string input', () => {
+    expect(() => assertPluginPersistenceKey(null)).toThrowError(
+      /must be a string or undefined/,
+    );
+    expect(() => assertPluginPersistenceKey(42)).toThrowError(
+      /must be a string or undefined/,
+    );
+    expect(() => assertPluginPersistenceKey({ toString: () => 'x' })).toThrowError(
+      /must be a string or undefined/,
+    );
   });
 });
 

--- a/src/app/plugins/util/plugin-persistence-key.util.spec.ts
+++ b/src/app/plugins/util/plugin-persistence-key.util.spec.ts
@@ -1,0 +1,50 @@
+import { composeId, isPluginIdMatch } from './plugin-persistence-key.util';
+
+describe('composeId', () => {
+  it('returns pluginId unchanged when no key is provided', () => {
+    expect(composeId('plugin-a')).toBe('plugin-a');
+  });
+
+  it('returns pluginId unchanged when key is undefined', () => {
+    expect(composeId('plugin-a', undefined)).toBe('plugin-a');
+  });
+
+  it('treats empty key as undefined (no colon appended)', () => {
+    expect(composeId('plugin-a', '')).toBe('plugin-a');
+  });
+
+  it('joins pluginId and key with ":"', () => {
+    expect(composeId('plugin-a', 'doc-1')).toBe('plugin-a:doc-1');
+  });
+
+  it('allows keys that themselves contain colons (delimiter only applies to pluginId)', () => {
+    expect(composeId('plugin-a', 'doc:nested:1')).toBe('plugin-a:doc:nested:1');
+  });
+
+  it('throws synchronously when pluginId contains ":"', () => {
+    expect(() => composeId('bad:plugin')).toThrowError(/must not contain ':'/);
+    expect(() => composeId('bad:plugin', 'k')).toThrowError(/must not contain ':'/);
+  });
+});
+
+describe('isPluginIdMatch', () => {
+  it('matches the legacy entry', () => {
+    expect(isPluginIdMatch('plugin-a', 'plugin-a')).toBe(true);
+  });
+
+  it('matches keyed entries by prefix', () => {
+    expect(isPluginIdMatch('plugin-a:doc-1', 'plugin-a')).toBe(true);
+    expect(isPluginIdMatch('plugin-a:doc:nested', 'plugin-a')).toBe(true);
+  });
+
+  it('rejects unrelated plugin entries', () => {
+    expect(isPluginIdMatch('plugin-b', 'plugin-a')).toBe(false);
+    expect(isPluginIdMatch('plugin-b:doc', 'plugin-a')).toBe(false);
+  });
+
+  it('rejects plugin ids that share a prefix without the delimiter', () => {
+    // 'plugin-abc' should NOT match cleanup for 'plugin-a'.
+    expect(isPluginIdMatch('plugin-abc', 'plugin-a')).toBe(false);
+    expect(isPluginIdMatch('plugin-abc:doc', 'plugin-a')).toBe(false);
+  });
+});

--- a/src/app/plugins/util/plugin-persistence-key.util.ts
+++ b/src/app/plugins/util/plugin-persistence-key.util.ts
@@ -31,3 +31,30 @@ export const composeId = (pluginId: string, key?: string): string => {
  */
 export const isPluginIdMatch = (entityId: string, pluginId: string): boolean =>
   entityId === pluginId || entityId.startsWith(pluginId + ':');
+
+/**
+ * Bound on a single plugin's persistence key length. Generous for any
+ * realistic per-plugin keyspace (e.g. document-mode uses `doc:<uuid>`,
+ * well under 100 chars). Prevents a compromised iframe from passing a
+ * multi-megabyte `key` that would be stored verbatim in NgRx state,
+ * IndexedDB, the op-log, and on the sync wire — bypassing the
+ * MAX_PLUGIN_DATA_SIZE cap which only constrains the `data` arg.
+ */
+export const MAX_PLUGIN_PERSISTENCE_KEY_LENGTH = 256;
+
+/**
+ * Type + length guard for the plugin-supplied `key` arg at the bridge
+ * boundary. Throws on non-string or oversized input. `undefined` is the
+ * legacy form (no key) and is allowed.
+ */
+export const assertPluginPersistenceKey = (key: unknown): void => {
+  if (key === undefined) return;
+  if (typeof key !== 'string') {
+    throw new Error('Plugin persistence key must be a string or undefined');
+  }
+  if (key.length > MAX_PLUGIN_PERSISTENCE_KEY_LENGTH) {
+    throw new Error(
+      `Plugin persistence key exceeds maximum length of ${MAX_PLUGIN_PERSISTENCE_KEY_LENGTH} characters`,
+    );
+  }
+};

--- a/src/app/plugins/util/plugin-persistence-key.util.ts
+++ b/src/app/plugins/util/plugin-persistence-key.util.ts
@@ -1,0 +1,33 @@
+/**
+ * Compose the storage entity id for a plugin's persisted data.
+ *
+ * Without a key this returns the bare `pluginId` (the legacy single-blob
+ * form). With a key it returns `pluginId + ':' + key`, allowing one plugin
+ * to maintain multiple independently-synced entries that LWW-resolve
+ * per-entity rather than overwriting each other.
+ *
+ * - Empty `key` (`''`) is treated as `undefined`; this is intentional
+ *   so plugins don't accidentally split their storage by passing falsy
+ *   strings.
+ * - Throws synchronously if `pluginId` itself contains `:`. Registration-
+ *   time validation alone misses user-installed plugins, so the only
+ *   reliable guard is at the call site.
+ */
+export const composeId = (pluginId: string, key?: string): string => {
+  if (pluginId.includes(':')) {
+    throw new Error(
+      `Plugin id "${pluginId}" must not contain ':' — the colon is reserved as the key delimiter for plugin-persistence entries.`,
+    );
+  }
+  if (key === undefined || key === '') {
+    return pluginId;
+  }
+  return `${pluginId}:${key}`;
+};
+
+/**
+ * Match an entity id against a plugin's full keyspace (legacy entry +
+ * any keyed entries). Used by host-side cleanup when uninstalling.
+ */
+export const isPluginIdMatch = (entityId: string, pluginId: string): boolean =>
+  entityId === pluginId || entityId.startsWith(pluginId + ':');

--- a/src/app/plugins/util/validate-manifest.util.spec.ts
+++ b/src/app/plugins/util/validate-manifest.util.spec.ts
@@ -1,0 +1,36 @@
+import { PluginManifest } from '../plugin-api.model';
+import { validatePluginManifest } from './validate-manifest.util';
+
+const baseManifest: PluginManifest = {
+  id: 'my-plugin',
+  name: 'My Plugin',
+  version: '1.0.0',
+} as PluginManifest;
+
+describe('validatePluginManifest', () => {
+  it('accepts a valid manifest', () => {
+    const result = validatePluginManifest(baseManifest);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects a plugin id containing ':'", () => {
+    // ':' is reserved as the persistence key delimiter (composeId). A
+    // plugin with this id would collide with another plugin's keyed
+    // namespace and over-match in removePluginUserData's prefix sweep.
+    const result = validatePluginManifest({ ...baseManifest, id: 'evil:plugin' });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(
+      "Plugin ID must not contain ':' (reserved as the persistence key delimiter)",
+    );
+  });
+
+  it('rejects a missing plugin id', () => {
+    const result = validatePluginManifest({
+      ...baseManifest,
+      id: undefined as unknown as string,
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Plugin ID is required');
+  });
+});

--- a/src/app/plugins/util/validate-manifest.util.ts
+++ b/src/app/plugins/util/validate-manifest.util.ts
@@ -18,6 +18,15 @@ export const validatePluginManifest = (
   // Only validate critical fields
   if (!manifest?.id) {
     errors.push('Plugin ID is required');
+  } else if (manifest.id.includes(':')) {
+    // ':' is reserved as the persistence key delimiter (composeId). An id
+    // containing it would collide with another plugin's keyed namespace —
+    // and removePluginUserData's prefix sweep would over-match. The bridge
+    // also throws at the persist/load boundary, but rejecting at install
+    // fails fast with a clear message instead of a runtime surprise.
+    errors.push(
+      "Plugin ID must not contain ':' (reserved as the persistence key delimiter)",
+    );
   }
 
   if (!manifest?.name) {


### PR DESCRIPTION
## Summary

Implements Stage A of #7749: per-key plugin persistence with LWW
resolution. Plugins can now pass an optional `key` to `persistDataSynced` /
`loadSyncedData`; each `pluginId:key` resolves independently against
remote replicas, eliminating whole-blob conflicts during concurrent
cross-context edits.

- Host: keyed API, `composeId` enforcement at the bridge + at install
  via `validatePluginManifest`, `key` type/length guard, 256 KB
  per-write cap (down from 1 MB).
- Document-mode: migrated from single-blob storage to `meta` +
  `doc:${ctxId}` keyed entries with a stamp-guarded, idempotent
  legacy → keyed migration that tombstones the old blob.
- Coverage: 396 host specs + 77 document-mode specs + 2 e2e migration
  tests against a real iframe.

Plan: `docs/plans/2026-05-23-stage-a-keyed-plugin-persistence.md` —
implementation-status table references the shipping commits.

Followups (independent): #7754 (host-side `PERSISTED_DATA_CHANGED` hook)
and #7752 (doc-mode adopts that hook, blocked on #7754).

## Behavior change worth noting

`removePluginUserData` no longer emits a phantom Delete op when local
state has no matching entries. Pre-Stage-A that phantom propagated to
peers via sync; post-Stage-A, per-device uninstall is a local decision.
Users who expect uninstall on Device A to also clear data on Device B
should uninstall on each device.

## Test plan

- [ ] CI Karma matrix (Europe/Berlin + America/Los_Angeles)
- [ ] CI runs `e2e/tests/plugins/document-mode-migration.spec.ts`
- [ ] Smoke: enable doc-mode on a project, type, switch contexts, switch back
- [ ] Smoke: legacy local IDB (if available) migrates cleanly on first load