### PR TITLE
fix(android): restore IME inset handling via edge-to-edge plugin

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -17,12 +17,21 @@ const config: CapacitorConfig = {
       // and uses JavaScriptInterface for keyboard visibility instead.
       // 'native' resizes the WKWebView so 100vh fits above the keyboard.
       resize: 'native',
-      resizeOnFullScreen: true,
+      // false is required when paired with @capawesome/capacitor-android-edge-
+      // to-edge-support; ignored on iOS where this key has no effect.
+      resizeOnFullScreen: false,
     },
     StatusBar: {
       // iOS: overlay the status bar so content can sit beneath it.
       // No-op on Android 15+ (targetSdk 36).
       overlaysWebView: true,
+    },
+    SystemBars: {
+      // Disable Capacitor's built-in inset handling so the edge-to-edge plugin
+      // can own it. With targetSdk 36 (Android 16) edge-to-edge is mandatory,
+      // and the two layers both applying insets fight each other — visible
+      // as fixed-position elements scrolling with content when the IME is up.
+      insetsHandling: 'disable',
     },
   },
   android: {
@@ -38,6 +47,7 @@ const config: CapacitorConfig = {
       '@capacitor/local-notifications',
       '@capacitor/share',
       '@capawesome/capacitor-android-dark-mode-support',
+      '@capawesome/capacitor-android-edge-to-edge-support',
       '@capawesome/capacitor-background-task',
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@capacitor/ios": "^8.3.4",
         "@capacitor/keyboard": "8.0.1",
         "@capacitor/status-bar": "^8.0.2",
+        "@capawesome/capacitor-android-edge-to-edge-support": "^8.0.8",
         "@material-symbols/font-400": "^0.44.4",
         "@noble/ciphers": "^2.2.0",
         "capacitor-plugin-safe-area": "^5.0.0",
@@ -3024,6 +3025,25 @@
       "resolved": "https://registry.npmjs.org/@capawesome/capacitor-android-dark-mode-support/-/capacitor-android-dark-mode-support-8.0.1.tgz",
       "integrity": "sha512-6n+Q72XrxlurKY6u73EcJKQhz6RFSXWVGgnADA7ap4ab2LQqrzio33wZC/UBB/mtpD98erW2LFfx5291P/Iv6Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capawesome/capacitor-android-edge-to-edge-support": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/@capawesome/capacitor-android-edge-to-edge-support/-/capacitor-android-edge-to-edge-support-8.0.8.tgz",
+      "integrity": "sha512-+eKz15uhfOwft5IRZFL1QQZT/FHeeE5scNnlP9CIMrhW0Ctc9cJM13Ec2vOTd9oYGz3mCF3kf39C2spDDuSUVw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "@capacitor/ios": "^8.3.4",
     "@capacitor/keyboard": "8.0.1",
     "@capacitor/status-bar": "^8.0.2",
+    "@capawesome/capacitor-android-edge-to-edge-support": "^8.0.8",
     "@material-symbols/font-400": "^0.44.4",
     "@noble/ciphers": "^2.2.0",
     "capacitor-plugin-safe-area": "^5.0.0",


### PR DESCRIPTION
## Summary

- Adds `@capawesome/capacitor-android-edge-to-edge-support` as the structural replacement for `adjustMarginsForEdgeToEdge: 'auto'`, which was dropped from `capacitor.config.ts` in the Capacitor 8 migration (334b14aa2).
- On targetSdk 36 (Android 16) edge-to-edge is mandatory, so without explicit inset wiring the WebView no longer applies IME insets. `position: fixed` elements (the global add-task-bar) end up anchored to a layout viewport that doesn't shrink when the keyboard opens — so they appear to scroll with the page on swipe and jump inconsistently as the IME animates.
- Plugin registers a single `ViewCompat.setOnApplyWindowInsetsListener` that applies system-bar + display-cutout insets to the WebView and defers IME to `windowSoftInputMode="adjustResize"` (skipping its own bottom margin while the keyboard is visible to avoid double-counting). Verified by reading `node_modules/@capawesome/.../EdgeToEdge.java`.

### Required companion config (per the plugin's README)

- `SystemBars: { insetsHandling: 'disable' }` — turns off Capacitor core's insets handler so the two layers don't fight.
- `Keyboard.resizeOnFullScreen: false` — Android-only key; no-op on iOS, and `@capacitor/keyboard` is excluded from Android via `includePlugins` anyway, but matches the plugin's documented recommendation.

### iOS impact

None. The plugin is gated to `android.includePlugins`; both `SystemBars.insetsHandling` and `Keyboard.resizeOnFullScreen` are Android-only config keys per their respective Capacitor docs.

### Confidence

Moderate. The fix is the structural replacement for what the Capacitor 8 migration removed; if the symptoms are a regression from that migration (their first appearance lines up with it timing-wise), this should restore correct behaviour. If symptoms predate the migration, additional fixes around `body { position: absolute; inset: 0; height: 100% }` in `src/styles/page.scss` and/or anchoring the bar to `visualViewport` may be needed in a follow-up.

## Test plan

- [ ] `npm run build && npx cap sync android` — wires plugin into the Android project
- [ ] Build and install on a physical Android 15+ device
- [ ] Open the global add-task-bar (FAB / shortcut); confirm it sits cleanly above the IME with no overlap or gap
- [ ] With keyboard open, swipe the underlying page content; bar should stay pinned (not scroll with content)
- [ ] Open/close keyboard repeatedly; bar should not jump through intermediate positions
- [ ] Verify status bar and navigation bar inset behaviour still looks correct (no overlap, no gray gap)
- [ ] Smoke-check that the inline add-task-bar (planner / plan-tasks-tomorrow) is unaffected
- [ ] iOS smoke test — no regressions in keyboard behaviour or safe-area handling