### PR TITLE
fix(ios): prevent tag picker from auto-opening on portrait task open

### DIFF
--- a/src/app/features/right-panel/right-panel.component.ts
+++ b/src/app/features/right-panel/right-panel.component.ts
@@ -235,6 +235,11 @@ export class RightPanelComponent implements AfterViewInit, OnDestroy {
                 hasBackdrop: true,
                 closeOnNavigation: false,
                 panelClass: 'bottom-panel-sheet',
+                // Default 'first-tabbable' otherwise focuses the tag-edit
+                // input (the bottom-panel close-btn is display:none and gets
+                // skipped), which on touch makes mat-autocomplete pop open
+                // immediately on every task open in portrait.
+                autoFocus: false,
               },
             );
 


### PR DESCRIPTION
Fixes #7769.

## Problem

On iPhone in portrait, opening any task immediately opens the tag selection
autocomplete, covering the rest of the task detail. Landscape (right panel)
is unaffected.

## Root cause

The mobile bottom sheet is opened in `RightPanelComponent` without an
explicit `autoFocus`, so CDK's FocusTrap falls back to the default
`'first-tabbable'`. The intended close button in the sheet header is
`display: none` (`bottom-panel-container.component.scss`), so it is skipped
and focus lands on the tag-edit `<input>` inside the task detail panel.
On touch, the bound `mat-autocomplete` opens immediately on focus, hence
the dropdown every time.

The right-panel path (non-xs breakpoint) doesn't use `MatBottomSheet`, so
no FocusTrap — that's why landscape is fine.

## Fix

One line: pass `autoFocus: false` to the bottom-sheet open call. This
matches what `task-detail-panel.component.ts` already does for its own
dialog opens (`scheduleTask`, `openDeadlineDialog`).

## Verified

- Reproduced on the App Store build (SP v18.7.0 / iOS app v9.12).
- Verified the fix on a local self-build of this branch installed on an
  iPhone — tag picker no longer auto-opens, neither in portrait nor
  landscape, and tapping the tag field explicitly still opens it as
  expected.