### PR TITLE
fix: preserve #<n> prefix on imported issue tasks

### DIFF
--- a/packages/plugin-dev/github-issue-provider/src/plugin.ts
+++ b/packages/plugin-dev/github-issue-provider/src/plugin.ts
@@ -322,14 +322,20 @@ PluginAPI.registerIssueProvider({
         taskValue: unknown,
         ctx: { issueId: string; issueNumber?: number },
       ): string => {
+        const num = ctx.issueNumber ?? ctx.issueId;
         const str = taskValue as string;
-        const prefix = `#${ctx.issueNumber} `;
+        const prefix = `#${num} `;
         return str.startsWith(prefix) ? str.slice(prefix.length) : str;
       },
       toTaskValue: (
         issueValue: unknown,
         ctx: { issueId: string; issueNumber?: number },
-      ): string => `#${ctx.issueNumber} ${issueValue}`,
+      ): string => {
+        const num = ctx.issueNumber ?? ctx.issueId;
+        const str = issueValue as string;
+        const prefix = `#${num} `;
+        return str.startsWith(prefix) ? str : `${prefix}${str}`;
+      },
     },
     {
       taskField: 'notes',

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -413,6 +413,37 @@ describe('shortSyntax', () => {
       expect(r).toEqual(undefined);
     });
 
+    it('should not parse issue references (e.g. "fixes #1234") as tags for issue tasks', async () => {
+      const t = {
+        ...TASK,
+        issueId: '42',
+        title: '#42 Fix regression from #1234',
+      };
+      const r = await shortSyntax(t, CONFIG, ALL_TAGS);
+
+      expect(r).toEqual(undefined);
+    });
+
+    it('should still parse non-numeric existing #tags in issue task titles', async () => {
+      const t = {
+        ...TASK,
+        issueId: '42',
+        title: '#42 Some title #blu',
+      };
+      const r = await shortSyntax(t, CONFIG, ALL_TAGS);
+
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        projectId: undefined,
+        attachments: [],
+        taskChanges: {
+          title: '#42 Some title',
+          tagIds: ['blu_id'],
+        },
+      });
+    });
+
     it('should not trigger for tasks with starting # (e.g. github issues) when adding tags', async () => {
       const t = {
         ...TASK,

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -320,8 +320,8 @@ const parseTagChanges = (
           return (
             newTagTitle.length >= 1 &&
             tagStartIndex !== -1 &&
-            // NOTE: only block tags at the beginning if they are numeric (e.g. "#123 task")
-            (!isNumericOnly || tagStartIndex > 0)
+            // NOTE: block numeric tags at the start, and any numeric tag on issue tasks
+            (!isNumericOnly || (tagStartIndex > 0 && !task.issueId))
           );
         });
 


### PR DESCRIPTION
## Problem

Two related bugs hit when syncing/importing GitHub issues:

1. Imported task titles came out as `#undefined Some title` instead of `#1337 Some title`.
2. When the title rendered correctly as `#1337 Some title`, short syntax detected the `#1337` as a hashtag, prompted "create tag 1337?", and stripped the `#1337` from the title — so the user lost the issue number either way.

While investigating, a related cross-provider bug surfaced: any issue task on any provider (GitHub, Gitea/Forgejo, GitLab, Redmine, ...) whose title references another issue (`fixes #1234`) had that reference parsed as a tag and stripped from the title.

## Solution

Two narrowly-scoped, complementary changes.

### 1. GitHub plugin (`packages/plugin-dev/github-issue-provider/src/plugin.ts`)

The `title` field mapping mishandled the **import path** (backlog auto-import + search-then-add):

- Search results carry no `number` field, so `ctx.issueNumber` was `undefined` → `#undefined <title>`. Fall back to `ctx.issueId`, which equals `String(issue.number)` for GitHub.
- `mapSearchResult` already display-prefixes the title with `#<n> `, and `toTaskValue` re-applied the prefix → `#<n> #<n> <title>`. The double-prefix is what made short syntax detect a non-leading `#<n>`. `toTaskValue` is now idempotent: it skips the prefix when the title already starts with it.

This complements **PR #7360** (merged), which fixed the same `ctx.issueNumber`-undefined problem on the **update/poll** path. #7360's commit message claimed the import path was unaffected "because titles came pre-formatted from `mapSearchResult`" — that turned out to be incomplete: the pre-formatted title then got re-prefixed and the missing `number` still yielded `#undefined`. This PR closes that gap.

### 2. Short syntax (`src/app/features/tasks/short-syntax.ts`)

The existing numeric-at-start guard only spared a numeric `#<n>` at position 0 (the issue-number prefix). Extended for issue tasks: also spare numeric `#<n>` *anywhere* in the title, so cross-issue references like "fixes #1234" stop being treated as tags.

Deliberately **narrow** — only numeric `#tags` are blocked on issue tasks. Non-numeric `#mytag` still parses, so manually tagging an issue task via its title keeps working.

Behavior on issue tasks (`issueId: '42'`):

| Title                                              | Before                                    | After                                  |
| -------------------------------------------------- | ----------------------------------------- | -------------------------------------- |
| `#42 Some title`                                   | unchanged                                 | unchanged                              |
| `#42 Fix regression from #1234`                    | strips `#1234`, prompts "create tag 1234" | unchanged ✓                            |
| `#42 Some title #blu` (`blu` is an existing tag)   | adds `blu` tag, strips `#blu`             | adds `blu` tag, strips `#blu` (same)   |
| `#42 Some title #mynewtag`                         | prompts "create tag mynewtag", strips     | prompts "create tag mynewtag", strips  |

Non-issue tasks are unchanged.

Two regression tests lock down both halves: numeric refs blocked, non-numeric tags still parsed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki) (internal mechanics, no user-facing doc change).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (short-syntax guard, 2 new cases — 159/159 pass)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
