### PR TITLE
fix(notes): preserve visible default template when toggling checklist

### DIFF
--- a/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
@@ -639,6 +639,30 @@ describe('InlineMarkdownComponent', () => {
       expect(component.changed.emit).toHaveBeenCalledOnceWith('- [ ] ');
     });
 
+    it('should preserve default template content when toggling checklist (issue #7786)', () => {
+      // Arrange — task has no saved notes but a default template is visible
+      spyOn(component.changed, 'emit');
+      const defaultTemplate = '**How can I best achieve it now?**';
+      component.model = defaultTemplate;
+      fixture.detectChanges();
+
+      component['isShowEdit'].set(false);
+      spyOn(component, 'textareaEl').and.returnValue(undefined);
+      spyOn(component, 'isDefaultText').and.returnValue(true);
+      spyOn<any>(component, '_toggleShowEdit');
+
+      const mockEvent = { preventDefault: () => {}, stopPropagation: () => {} } as any;
+
+      // Act
+      component.toggleChecklistMode(mockEvent);
+
+      // Assert — visible template preserved, checkbox appended below
+      const finalText = component.modelCopy();
+      expect(finalText).toContain(defaultTemplate);
+      expect(finalText).toContain('- [ ] ');
+      expect(component.changed.emit).toHaveBeenCalledTimes(1);
+    });
+
     it('should insert checklist item after cursor line, not at end', () => {
       // Arrange
       const text = '- [ ] First\n- [ ] Second\n- [ ] Third';

--- a/src/app/ui/inline-markdown/inline-markdown.component.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.ts
@@ -376,7 +376,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
 
     const INSERT_TEXT = '\n- [ ] ';
 
-    if (this.isDefaultText()) {
+    if (this.isDefaultText() && !currentText) {
       const newValue = '- [ ] ';
       this.model = newValue;
       this.isChecklistMode.set(true);


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

Closes #7786.

When a user has a default note template configured under Settings → Tasks (the `notesTemplate` shipping default is "**How can I best achieve it now?**"), the template content is rendered in the task notes editor for any task whose own `notes` field is still empty. Clicking the checklist toggle button in that editor silently replaces the visible template content with just `'- [ ] '`, losing whatever the user could see.

The original reporter notes their reproducible behavior in board view (open a new task whose note shows the template, click checklist, content vanishes), but the same surface is reachable from the task detail panel and focus mode anywhere `inline-markdown` is mounted with `[isShowChecklistToggle]="true"`.

Root cause is in `src/app/ui/inline-markdown/inline-markdown.component.ts:379`:

```ts
if (this.isDefaultText()) {
  const newValue = '- [ ] ';
  this.model = newValue;          // replaces the visible content
  ...
  return;
}
```

The `isDefaultText` input is wired from `!task().notes` in both `task-detail-panel.component.html:236` and `focus-mode-main.component.html:355`, so it reflects only the saved value. But the visible model is `task().notes || defaultTaskNotes()`. When notes are empty AND a template is configured, `isDefaultText` is true but the visible content is non-empty, and the early-return branch nukes it.

## Solution

<!-- Describe your changes in detail. -->

Narrow the early-return guard to require `currentText` to be empty as well:

```ts
if (this.isDefaultText() && !currentText) {
```

When there's truly nothing visible (no template configured, no typed text), the existing convenience still kicks in and starts the editor with a single fresh `'- [ ] '` checkbox. When the template IS visible, execution falls through to the regular append path (Path B for preview mode, Path A for active textarea), which produces `template + '\n- [ ] '` after the existing newline-cleanup regex. The user's visible content is preserved and a checkbox is added after it.

Also adds a regression test in `inline-markdown.component.spec.ts` that simulates the default-template scenario and asserts both the template content and the new checkbox end up in the final value.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).

  Not applicable, internal editor behavior with no user-facing documentation impact.

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)

  Added one regression test in `inline-markdown.component.spec.ts`. All 145 inline-markdown specs pass, including the new test and the two existing `isDefaultText` cases.

- [x] Existing tests still pass

  Also re-ran the upstream callers: all 506 task-detail-panel + focus-mode specs pass.

- [x] My commit messages follow the Angular format (`type(scope): description`)
