### PR TITLE
test(e2e): flush op-log persistence before reload in #7344 spec

### DIFF
--- a/e2e/tests/recurring/recurring-preserve-past-due-day-bug-7344.spec.ts
+++ b/e2e/tests/recurring/recurring-preserve-past-due-day-bug-7344.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../fixtures/test.fixture';
+import { waitForStatePersistence } from '../../utils/waits';
 
 /**
  * Bug: https://github.com/super-productivity/super-productivity/issues/7344
@@ -85,6 +86,10 @@ test.describe('Recurring Task - preserve past dueDay (#7344)', () => {
     //    Before the fix: task.dueDay was auto-shifted to 2027-04-01 and the
     //    task disappeared from Today. After the fix: task.dueDay is preserved
     //    at 2026-04-01 (past, still overdue) and the task stays visible.
+    //    Flush the op-log IndexedDB writes from the Save above before reload —
+    //    otherwise the in-flight transaction races the next bootstrap and can
+    //    stall the navigation `domcontentloaded` event past 30s.
+    await waitForStatePersistence(page);
     await page.reload({ waitUntil: 'domcontentloaded' });
     await workViewPage.waitForTaskList();
     await expect(taskPage.getTaskByText(taskTitle).first()).toBeVisible({


### PR DESCRIPTION
## Summary

- Fix the flake in `recurring-preserve-past-due-day-bug-7344.spec.ts` that broke the scheduled E2E run [26430212931](https://github.com/super-productivity/super-productivity/actions/runs/26430212931).
- The final `page.reload({ waitUntil: 'domcontentloaded' })` raced the IndexedDB write triggered by the repeat-dialog Save click; the in-flight transaction occasionally stalled the next bootstrap, so the navigation `domcontentloaded` event timed out past 30s — even though the post-failure screenshot showed the app had loaded with the expected state (task preserved in Today under Overdue).
- Call the existing `waitForStatePersistence(page)` helper (built for exactly this race) before the reload.

## Test plan

- [x] `npm run e2e:file -- e2e/tests/recurring/recurring-preserve-past-due-day-bug-7344.spec.ts --retries=0 --repeat-each=3` — 3/3 pass locally (~18 s each)
- [x] `npm run checkFile e2e/tests/recurring/recurring-preserve-past-due-day-bug-7344.spec.ts`
- [ ] Scheduled E2E run on master green after merge