### PR TITLE
fix(task-repeat): keep yesterday's untracked overdue instance (#7718)

### DIFF
--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
@@ -1,0 +1,225 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { BehaviorSubject, of } from 'rxjs';
+import { TaskRepeatCleanupEffects } from './task-repeat-cleanup.effects';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+import { SyncTriggerService } from '../../../imex/sync/sync-trigger.service';
+import { SyncWrapperService } from '../../../imex/sync/sync-wrapper.service';
+import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
+import { DeletedTaskIssueSidecarService } from '../../issue/two-way-sync/deleted-task-issue-sidecar.service';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { DEFAULT_TASK, Task, TaskWithSubTasks } from '../../tasks/task.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+
+describe('TaskRepeatCleanupEffects', () => {
+  let effects: TaskRepeatCleanupEffects;
+  let store: jasmine.SpyObj<Store>;
+  let repeatableTasks$: BehaviorSubject<TaskWithSubTasks[]>;
+
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const todayMs = new Date().setHours(12, 0, 0, 0);
+  const yesterdayMs = todayMs - DAY_MS;
+
+  const wrapWithSubTasks = (task: Task): TaskWithSubTasks => ({
+    ...task,
+    subTasks: [],
+  });
+
+  const getDispatchedDeleteIds = (): string[] => {
+    const deleteCalls = store.dispatch.calls.allArgs().filter(([action]) => {
+      const a = action as unknown as { type: string };
+      return a.type === TaskSharedActions.deleteTasks.type;
+    });
+    return deleteCalls.flatMap(
+      ([action]) =>
+        (action as unknown as ReturnType<typeof TaskSharedActions.deleteTasks>).taskIds,
+    );
+  };
+
+  beforeEach(() => {
+    repeatableTasks$ = new BehaviorSubject<TaskWithSubTasks[]>([]);
+
+    const storeSpy = jasmine.createSpyObj<Store>('Store', ['select', 'dispatch']);
+    storeSpy.select.and.returnValue(repeatableTasks$.asObservable());
+
+    const syncTriggerSpy = {
+      afterInitialSyncDoneStrict$: of(true),
+    };
+
+    const globalTrackingSpy = {
+      todayDateStr$: new BehaviorSubject(getDbDateStr(todayMs)),
+    };
+
+    const syncWrapperSpy = {
+      afterCurrentSyncDoneOrSyncDisabled$: of(true),
+    };
+
+    const hydrationStateSpy = jasmine.createSpyObj<HydrationStateService>(
+      'HydrationStateService',
+      ['isInSyncWindow'],
+      { isInSyncWindow$: of(false) },
+    );
+    hydrationStateSpy.isInSyncWindow.and.returnValue(false);
+
+    const sidecarSpy = jasmine.createSpyObj<DeletedTaskIssueSidecarService>(
+      'DeletedTaskIssueSidecarService',
+      ['set'],
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        TaskRepeatCleanupEffects,
+        { provide: Store, useValue: storeSpy },
+        { provide: SyncTriggerService, useValue: syncTriggerSpy },
+        { provide: GlobalTrackingIntervalService, useValue: globalTrackingSpy },
+        { provide: SyncWrapperService, useValue: syncWrapperSpy },
+        { provide: HydrationStateService, useValue: hydrationStateSpy },
+        { provide: DeletedTaskIssueSidecarService, useValue: sidecarSpy },
+      ],
+    });
+
+    effects = TestBed.inject(TaskRepeatCleanupEffects);
+    store = TestBed.inject(Store) as jasmine.SpyObj<Store>;
+  });
+
+  describe('cleanupDuplicateRepeatInstances$', () => {
+    it("regression #7718: should NOT delete yesterday's UNTRACKED recurring instance when today's instance exists", fakeAsync(() => {
+      const yesterdayInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'yesterday-untracked',
+        title: 'Untracked recurring task',
+        repeatCfgId: 'cfg-1',
+        created: yesterdayMs,
+        dueDay: getDbDateStr(yesterdayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+      const todayInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'today-fresh',
+        title: 'Untracked recurring task',
+        repeatCfgId: 'cfg-1',
+        created: todayMs,
+        dueDay: getDbDateStr(todayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+
+      repeatableTasks$.next([
+        wrapWithSubTasks(yesterdayInstance),
+        wrapWithSubTasks(todayInstance),
+      ]);
+
+      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
+      tick(3001);
+
+      expect(getDispatchedDeleteIds())
+        .withContext(
+          'Bug #7718: legitimate previous-day overdue instance must remain so it shows in Overdue panel',
+        )
+        .toEqual([]);
+
+      sub.unsubscribe();
+    }));
+
+    it("control: should NOT delete yesterday's TRACKED recurring instance when today's instance exists", fakeAsync(() => {
+      const yesterdayInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'yesterday-tracked',
+        title: 'Tracked recurring task',
+        repeatCfgId: 'cfg-2',
+        created: yesterdayMs,
+        dueDay: getDbDateStr(yesterdayMs),
+        isDone: false,
+        timeSpent: 15 * 60 * 1000,
+      };
+      const todayInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'today-tracked',
+        title: 'Tracked recurring task',
+        repeatCfgId: 'cfg-2',
+        created: todayMs,
+        dueDay: getDbDateStr(todayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+
+      repeatableTasks$.next([
+        wrapWithSubTasks(yesterdayInstance),
+        wrapWithSubTasks(todayInstance),
+      ]);
+
+      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
+      tick(3001);
+
+      expect(getDispatchedDeleteIds())
+        .withContext('Tracked overdue instances must never be cleaned up')
+        .toEqual([]);
+
+      sub.unsubscribe();
+    }));
+
+    it('still deletes genuine same-day duplicates (the original purpose of the cleanup)', fakeAsync(() => {
+      // Simulates the sync-bug scenario this effect was built for: two instances
+      // both created TODAY for the same repeatCfgId. Older one is stale.
+      const olderToday: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'today-stale',
+        title: 'Duplicate',
+        repeatCfgId: 'cfg-3',
+        created: todayMs - 60_000,
+        dueDay: getDbDateStr(todayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+      const newerToday: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'today-newest',
+        title: 'Duplicate',
+        repeatCfgId: 'cfg-3',
+        created: todayMs,
+        dueDay: getDbDateStr(todayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+
+      repeatableTasks$.next([wrapWithSubTasks(olderToday), wrapWithSubTasks(newerToday)]);
+
+      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
+      tick(3001);
+
+      // The older instance is removed; the newer one survives.
+      expect(getDispatchedDeleteIds()).toEqual(['today-stale']);
+
+      sub.unsubscribe();
+    }));
+
+    it('does nothing when only a single instance exists per repeatCfgId', fakeAsync(() => {
+      const onlyInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'sole',
+        repeatCfgId: 'cfg-4',
+        created: yesterdayMs,
+        dueDay: getDbDateStr(yesterdayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+
+      repeatableTasks$.next([wrapWithSubTasks(onlyInstance)]);
+
+      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
+      tick(3001);
+
+      expect(getDispatchedDeleteIds()).toEqual([]);
+
+      sub.unsubscribe();
+    }));
+  });
+});

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
@@ -55,34 +55,38 @@ export class TaskRepeatCleanupEffects {
               this._store.select(selectAllRepeatableTaskWithSubTasks).pipe(first()),
             ),
             switchMap((repeatableTasks: TaskWithSubTasks[]) => {
-              // Group parent tasks by repeatCfgId
-              const tasksByRepeatCfg = new Map<string, TaskWithSubTasks[]>();
+              // Group parent tasks by (repeatCfgId, creation day).
+              // Two instances created on DIFFERENT days are not duplicates —
+              // they represent separate scheduled occurrences (e.g. yesterday's
+              // overdue instance + today's freshly-created instance). Only
+              // same-day collisions are the sync-bug we want to clean up.
+              // (#7718)
+              const tasksByCfgAndDay = new Map<string, TaskWithSubTasks[]>();
               for (const task of repeatableTasks) {
                 if (task.parentId || !task.repeatCfgId) {
                   continue;
                 }
-                const group = tasksByRepeatCfg.get(task.repeatCfgId);
+                const key = `${task.repeatCfgId}|${getDbDateStr(task.created)}`;
+                const group = tasksByCfgAndDay.get(key);
                 if (group) {
                   group.push(task);
                 } else {
-                  tasksByRepeatCfg.set(task.repeatCfgId, [task]);
+                  tasksByCfgAndDay.set(key, [task]);
                 }
               }
 
               const deleteIds: string[] = [];
               const deleteTasks: TaskWithSubTasks[] = [];
-              for (const [, tasks] of tasksByRepeatCfg) {
-                // Only act when there are actual duplicates
+              for (const [, tasks] of tasksByCfgAndDay) {
+                // Only act when there are actual same-day duplicates
                 if (tasks.length <= 1) {
                   continue;
                 }
 
-                // Sort by creation day descending — newest first
-                tasks.sort((a, b) => {
-                  const dayA = getDbDateStr(a.created);
-                  const dayB = getDbDateStr(b.created);
-                  return dayB.localeCompare(dayA);
-                });
+                // Sort by raw creation timestamp descending — true newest first.
+                // (Same-day strings are tied, so sorting by ms picks an
+                // unambiguous survivor.)
+                tasks.sort((a, b) => b.created - a.created);
 
                 // Keep the newest, consider deleting older ones
                 for (let i = 1; i < tasks.length; i++) {


### PR DESCRIPTION
## Summary

Fix #7718: a recurring task that wasn't tracked yesterday silently disappears from Overdue ~3s after each app open / date change.

**Root cause** — `cleanupDuplicateRepeatInstances$` grouped tasks by `repeatCfgId` alone. Once `addAllDueToday` auto-created today's instance, the count for that cfg became 2, and yesterday's untracked instance (`\!isDone`, `timeSpent === 0`, no subtask progress) matched the "stale duplicate" deletion criteria — effectively force-enabling **Skip overdue instances** for any recurring task the user hadn't tracked time on.

**Fix** — Group by `(repeatCfgId, created-day)` so only same-day collisions (the actual sync-bug case this cleanup was built for) trigger deletion. Also sort survivors by raw `created` ms instead of by day string, so the same-day case picks a deterministic newest survivor (latent secondary bug surfaced by the new spec).

**Tests** — adds `task-repeat-cleanup.effects.spec.ts` (4 tests) covering: the #7718 regression, the tracked-instance control case, the same-day-duplicate cleanup path, and the single-instance no-op path.

## Test plan

- [x] `npm run test:file src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts` — 4/4 pass against the fix
- [x] `npm run test:file src/app/features/task-repeat-cfg` — 536/536 pass
- [x] `npm run checkFile` on both modified files
- [ ] Manual repro from the issue (two daily-recurring tasks, track one, advance day): yesterday's untracked instance should now remain in Overdue after the 3s cleanup window