### PR TITLE
fix(task-repeat): handle startDate moved to today (#7768)

### DIFF
--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -426,6 +426,56 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
     });
   });
 
+  describe('startDate min floor (#7768 Bug 4)', () => {
+    const getStartDateMin = (
+      fixture: ComponentFixture<DialogEditTaskRepeatCfgComponent>,
+    ): unknown => {
+      const fields = fixture.componentInstance.essentialFormFields();
+      const startDateField = fields.find((f) => f.key === 'startDate');
+      return (startDateField?.templateOptions as Record<string, unknown> | undefined)?.[
+        'min'
+      ];
+    };
+
+    const todayStr = (): string => {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      const yyyy = d.getFullYear();
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      return `${yyyy}-${mm}-${dd}`;
+    };
+
+    it('floors startDate to today for a new repeat cfg created from a task', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      expect(getStartDateMin(fixture)).toBe(todayStr());
+    });
+
+    it('keeps the past startDate as the floor when editing an existing past cfg', async () => {
+      const pastCfg: TaskRepeatCfg = {
+        ...mockRepeatCfg,
+        startDate: '2020-01-15',
+      };
+      const fixture = await setupTestBed({ repeatCfg: pastCfg });
+      expect(getStartDateMin(fixture)).toBe('2020-01-15');
+    });
+
+    it('floors to today when editing a cfg whose startDate is in the future', async () => {
+      const future = new Date();
+      future.setFullYear(future.getFullYear() + 1);
+      const yyyy = future.getFullYear();
+      const mm = String(future.getMonth() + 1).padStart(2, '0');
+      const dd = String(future.getDate()).padStart(2, '0');
+      const futureStr = `${yyyy}-${mm}-${dd}`;
+      const futureCfg: TaskRepeatCfg = {
+        ...mockRepeatCfg,
+        startDate: futureStr,
+      };
+      const fixture = await setupTestBed({ repeatCfg: futureCfg });
+      expect(getStartDateMin(fixture)).toBe(todayStr());
+    });
+  });
+
   describe('save button disabled state (issue #5828)', () => {
     it('should not allow save while isLoading is true', fakeAsync(async () => {
       const taskWithRepeatCfg = {

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -214,6 +214,31 @@ export class DialogEditTaskRepeatCfgComponent {
       ...field,
     }));
 
+    // Clamp startDate to today as a floor for NEW configs and recent ones
+    // (#7768 Bug 4). For configs whose startDate is already in the past, the
+    // existing value is the floor — users can still keep or adjust it.
+    const startDateIdx = formConfig.findIndex((f) => f.key === 'startDate');
+    if (startDateIdx !== -1) {
+      const startDateField: FormlyFieldConfig = {
+        ...formConfig[startDateIdx],
+        templateOptions: { ...formConfig[startDateIdx].templateOptions },
+      };
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const initialStartDate = this._data.repeatCfg?.startDate
+        ? dateStrToUtcDate(this._data.repeatCfg.startDate)
+        : this._data.task?.dueDay
+          ? dateStrToUtcDate(this._data.task.dueDay)
+          : today;
+      // Formly types templateOptions.min as number, but the formly-date-picker
+      // passes it through to date-picker-input which accepts Date | string.
+      // Use the YYYY-MM-DD string form so the cast is just a type concern.
+      const minFloor = initialStartDate < today ? initialStartDate : today;
+      (startDateField.templateOptions as Record<string, unknown>).min =
+        getDbDateStr(minFloor);
+      formConfig[startDateIdx] = startDateField;
+    }
+
     // Deep-clone the quickSetting field to avoid mutating the shared constant
     const quickSettingIdx = formConfig.findIndex((f) => f.key === 'quickSetting');
     if (quickSettingIdx === -1) {

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.spec.ts
@@ -7,6 +7,7 @@ import { TaskService } from '../../tasks/task.service';
 import { TaskRepeatCfgService } from '../task-repeat-cfg.service';
 import { MatDialog } from '@angular/material/dialog';
 import { TaskArchiveService } from '../../archive/task-archive.service';
+import { AddTasksForTomorrowService } from '../../add-tasks-for-tomorrow/add-tasks-for-tomorrow.service';
 import { addTaskRepeatCfgToTask, updateTaskRepeatCfg } from './task-repeat-cfg.actions';
 import {
   DEFAULT_TASK,
@@ -33,6 +34,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
   let taskService: jasmine.SpyObj<TaskService>;
   let taskRepeatCfgService: jasmine.SpyObj<TaskRepeatCfgService>;
   let taskArchiveService: jasmine.SpyObj<TaskArchiveService>;
+  let addTasksForTomorrowService: jasmine.SpyObj<AddTasksForTomorrowService>;
   let testScheduler: TestScheduler;
 
   const mockTask: Task = {
@@ -97,6 +99,11 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
 
     const matDialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
     const taskArchiveServiceSpy = jasmine.createSpyObj('TaskArchiveService', ['load']);
+    const addTasksForTomorrowServiceSpy = jasmine.createSpyObj(
+      'AddTasksForTomorrowService',
+      ['addAllDueToday'],
+    );
+    addTasksForTomorrowServiceSpy.addAllDueToday.and.returnValue(Promise.resolve());
     TestBed.configureTestingModule({
       providers: [
         TaskRepeatCfgEffects,
@@ -105,6 +112,10 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         { provide: TaskRepeatCfgService, useValue: taskRepeatCfgServiceSpy },
         { provide: MatDialog, useValue: matDialogSpy },
         { provide: TaskArchiveService, useValue: taskArchiveServiceSpy },
+        {
+          provide: AddTasksForTomorrowService,
+          useValue: addTasksForTomorrowServiceSpy,
+        },
       ],
     });
 
@@ -116,6 +127,9 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
     taskArchiveService = TestBed.inject(
       TaskArchiveService,
     ) as jasmine.SpyObj<TaskArchiveService>;
+    addTasksForTomorrowService = TestBed.inject(
+      AddTasksForTomorrowService,
+    ) as jasmine.SpyObj<AddTasksForTomorrowService>;
 
     testScheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
@@ -2647,6 +2661,105 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         done();
       }, 0);
     });
+
+    // Issue #7768 Bug 1: moving startDate to today must move the existing
+    // live instance to today, not leave it stranded on its previous due day.
+    // The pre-fix effect skipped planTaskForDay when first occurrence was
+    // today (the `!isFirstOccurrenceToday_` guard), so the task's dueDay
+    // stayed on the old startDate.
+    it('should plan task for today when startDate is moved to today and a live instance exists (#7768)', (done) => {
+      const today = new Date();
+      const todayStr = getDbDateStr(today);
+      const oldStartDateStr = getDbDateStr(addDays(today, 5));
+
+      const liveTask: Task = {
+        ...mockTask,
+        isDone: false,
+        dueDay: oldStartDateStr,
+        created: today.getTime(),
+      };
+
+      const updatedCfg: TaskRepeatCfgCopy = {
+        ...mockRepeatCfg,
+        repeatCycle: 'DAILY',
+        repeatEvery: 1,
+        startDate: todayStr,
+        lastTaskCreationDay: oldStartDateStr,
+      };
+
+      const action = updateTaskRepeatCfg({
+        taskRepeatCfg: {
+          id: 'repeat-cfg-id',
+          changes: { startDate: todayStr },
+        },
+      });
+
+      actions$ = of(action);
+      taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(of(updatedCfg));
+      taskService.getTasksByRepeatCfgId$.and.returnValue(of([liveTask]));
+
+      effects.rescheduleTaskOnRepeatCfgUpdate$.subscribe((result) => {
+        expect(result).toEqual(
+          PlannerActions.planTaskForDay({
+            task: liveTask as any,
+            day: todayStr,
+          }),
+        );
+        done();
+      });
+    });
+
+    // Issue #7768 Bug 2: moving startDate to today when no live instance
+    // exists must create one for today. The re-anchor alone is not enough —
+    // addAllDueToday() is only triggered on date change, so without an
+    // explicit call here the live instance won't appear until app restart
+    // or the next midnight.
+    it('should trigger addAllDueToday when startDate is moved to today and no live instance exists (#7768)', (done) => {
+      const today = new Date();
+      const todayStr = getDbDateStr(today);
+      const oldStartDateStr = getDbDateStr(addDays(today, 5));
+      const expectedAnchorStr = getDbDateStr(addDays(today, -1));
+
+      const updatedCfg: TaskRepeatCfgCopy = {
+        ...mockRepeatCfg,
+        repeatCycle: 'DAILY',
+        repeatEvery: 1,
+        startDate: todayStr,
+        lastTaskCreationDay: oldStartDateStr,
+      };
+
+      const action = updateTaskRepeatCfg({
+        taskRepeatCfg: {
+          id: 'repeat-cfg-id',
+          changes: { startDate: todayStr },
+        },
+      });
+
+      actions$ = of(action);
+      taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(of(updatedCfg));
+      taskService.getTasksByRepeatCfgId$.and.returnValue(of([]));
+
+      let emitted = false;
+      effects.rescheduleTaskOnRepeatCfgUpdate$.subscribe(() => {
+        emitted = true;
+      });
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        // Anchor is re-set to the day before today so addAllDueToday picks
+        // today up.
+        expect(taskRepeatCfgService.updateTaskRepeatCfg).toHaveBeenCalledWith(
+          'repeat-cfg-id',
+          jasmine.objectContaining({
+            lastTaskCreationDay: expectedAnchorStr,
+          }),
+        );
+        // The live instance for today must actually be created — not only
+        // unblocked for the next date change.
+        expect(addTasksForTomorrowService.addAllDueToday).toHaveBeenCalled();
+        done();
+      }, 0);
+    });
   });
 });
 
@@ -2708,6 +2821,11 @@ describe('TaskRepeatCfgEffects - Deterministic Date Scenarios', () => {
 
     const matDialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
     const taskArchiveServiceSpy = jasmine.createSpyObj('TaskArchiveService', ['load']);
+    const addTasksForTomorrowServiceSpy = jasmine.createSpyObj(
+      'AddTasksForTomorrowService',
+      ['addAllDueToday'],
+    );
+    addTasksForTomorrowServiceSpy.addAllDueToday.and.returnValue(Promise.resolve());
     TestBed.configureTestingModule({
       providers: [
         TaskRepeatCfgEffects,
@@ -2716,6 +2834,10 @@ describe('TaskRepeatCfgEffects - Deterministic Date Scenarios', () => {
         { provide: TaskRepeatCfgService, useValue: taskRepeatCfgServiceSpy },
         { provide: MatDialog, useValue: matDialogSpy },
         { provide: TaskArchiveService, useValue: taskArchiveServiceSpy },
+        {
+          provide: AddTasksForTomorrowService,
+          useValue: addTasksForTomorrowServiceSpy,
+        },
       ],
     });
 

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
@@ -28,6 +28,7 @@ import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clo
 import { isValidSplitTime } from '../../../util/is-valid-split-time';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { TaskArchiveService } from '../../archive/task-archive.service';
+import { AddTasksForTomorrowService } from '../../add-tasks-for-tomorrow/add-tasks-for-tomorrow.service';
 import { DateService } from '../../../core/date/date.service';
 import { Log } from '../../../core/log';
 import {
@@ -67,6 +68,7 @@ export class TaskRepeatCfgEffects {
   private _taskRepeatCfgService = inject(TaskRepeatCfgService);
   private _matDialog = inject(MatDialog);
   private _taskArchiveService = inject(TaskArchiveService);
+  private _addTasksForTomorrowService = inject(AddTasksForTomorrowService);
   private _dateService = inject(DateService);
 
   addRepeatCfgToTaskUpdateTask$ = createEffect(() =>
@@ -315,6 +317,14 @@ export class TaskRepeatCfgEffects {
                       ),
                       lastTaskCreation: dayBeforeFirstOccurrence.getTime(),
                     });
+                    // When the new first occurrence is today, addAllDueToday()
+                    // is the only path that creates the live instance — and it
+                    // only runs on date change (#6230, see task-due.effects.ts).
+                    // Trigger it explicitly so the user sees today's instance
+                    // immediately instead of after the next midnight (#7768 Bug 2).
+                    if (this._dateService.isToday(firstOccurrence)) {
+                      this._addTasksForTomorrowService.addAllDueToday();
+                    }
                   }
                   return EMPTY;
                 }
@@ -338,9 +348,6 @@ export class TaskRepeatCfgEffects {
                   fullCfg.remindAt &&
                   isValidSplitTime(fullCfg.startTime)
                 );
-                const isFirstOccurrenceToday_ = firstOccurrence
-                  ? this._dateService.isToday(firstOccurrence)
-                  : true;
 
                 if (isTimedTask) {
                   const targetDayTimestamp = firstOccurrence
@@ -366,7 +373,12 @@ export class TaskRepeatCfgEffects {
                   );
                 }
 
-                if (!isFirstOccurrenceToday_ && firstOccurrence) {
+                // When first occurrence is today, planTaskForDay also moves
+                // the existing instance's dueDay to today via the task reducer
+                // and adds it to TODAY_TAG ordering via the planner meta
+                // reducer. Skipping today here left the instance stranded on
+                // its old dueDay (#7768 Bug 1).
+                if (firstOccurrence) {
                   return rxOf(
                     PlannerActions.planTaskForDay({
                       task: task as TaskCopy,


### PR DESCRIPTION
## Summary

Fixes three of the four bugs reported in #7768. All revolve around editing a recurring task config and moving its `startDate` to today.

- **Bug 1** — `rescheduleTaskOnRepeatCfgUpdate$` skipped `planTaskForDay` when the new first occurrence was today, leaving the live instance stranded on its previous due day. The today guard is removed; reducers already handle the today case (sets `dueDay = todayStr`, updates `TODAY_TAG` ordering).
- **Bug 2** — When no live instance exists and `startDate` moves to today, the existing re-anchor (#7724) updates `lastTaskCreationDay` but the live task isn't created until the next midnight, because `createRepeatableTasksAndAddDueToday$` only fires on date change (known gap #6230). The effect now explicitly calls `addAllDueToday()` in that branch.
- **Bug 4** — `startDate` had no min-date validator. The dialog now clamps the picker's `min` to `min(today, initialStartDate)` — blocks setting NEW past dates while keeping existing past-startDate configs editable.

**Not in this PR:** Bug 3 (saving an unchanged edit after deleting a live instance doesn't restore it). It needs a UX decision — auto-restore on save vs. explicit "Restore" button. Worth a separate issue/PR.

## Test plan

- [x] New unit tests for Bug 1 & Bug 2 in `task-repeat-cfg.effects.spec.ts` (red → green)
- [x] New unit tests for Bug 4 in `dialog-edit-task-repeat-cfg.component.spec.ts` (3 scenarios: new cfg / past cfg / future cfg)
- [x] Full effect spec (84 tests) green
- [x] Dialog spec (22 tests) green
- [x] TZ spec + form-const spec green
- [x] `npm run checkFile` clean on all four modified files
- [x] `tsc --noEmit` clean for both app and spec configs
- [ ] Manual reproduction in the running app for each bug
- [ ] Full `npm test` run

Fixes #7768 (Bugs 1, 2, 4)