### PR TITLE
fix(network): retry GETs once on transient client-side network errors

### DIFF
--- a/src/app/core/http/network-retry-interceptor.service.spec.ts
+++ b/src/app/core/http/network-retry-interceptor.service.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import {
+  HttpClient,
+  HTTP_INTERCEPTORS,
+  HttpErrorResponse,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { NetworkRetryInterceptorService } from './network-retry-interceptor.service';
+
+describe('NetworkRetryInterceptorService', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: NetworkRetryInterceptorService,
+          multi: true,
+        },
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('retries a GET once on status 0 then succeeds', fakeAsync(() => {
+    let result: unknown = null;
+    http.get('/x').subscribe((r) => (result = r));
+
+    const first = httpMock.expectOne('/x');
+    first.error(new ProgressEvent('error'), { status: 0, statusText: '' });
+    tick(500);
+
+    const second = httpMock.expectOne('/x');
+    second.flush({ ok: true });
+
+    expect(result).toEqual({ ok: true });
+  }));
+
+  it('surfaces the error if the retry also fails', fakeAsync(() => {
+    let err: HttpErrorResponse | null = null;
+    http.get('/x').subscribe({ error: (e) => (err = e) });
+
+    httpMock.expectOne('/x').error(new ProgressEvent('error'), { status: 0 });
+    tick(500);
+    httpMock.expectOne('/x').error(new ProgressEvent('error'), { status: 0 });
+
+    expect(err).toBeTruthy();
+    expect(err!.status).toBe(0);
+  }));
+
+  it('does not retry on non-zero status (e.g. 500)', () => {
+    let err: HttpErrorResponse | null = null;
+    http.get('/x').subscribe({ error: (e) => (err = e) });
+
+    httpMock.expectOne('/x').flush('oops', { status: 500, statusText: 'Server' });
+
+    httpMock.expectNone('/x');
+    expect(err!.status).toBe(500);
+  });
+
+  it('does not retry non-GET requests on status 0', () => {
+    let err: HttpErrorResponse | null = null;
+    http.post('/x', { a: 1 }).subscribe({ error: (e) => (err = e) });
+
+    httpMock.expectOne('/x').error(new ProgressEvent('error'), { status: 0 });
+
+    httpMock.expectNone('/x');
+    expect(err!.status).toBe(0);
+  });
+});

--- a/src/app/core/http/network-retry-interceptor.service.ts
+++ b/src/app/core/http/network-retry-interceptor.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable, throwError, timer } from 'rxjs';
+import { retry } from 'rxjs/operators';
+
+/** Short backoff — long enough for the WebView's socket reconnect, short enough to feel instant. */
+const RETRY_DELAY_MS = 500;
+
+/**
+ * Retries GETs once on transient client-side network errors
+ * (`HttpErrorResponse` with `status === 0`), which is how Angular surfaces
+ * fetch failures from the browser network stack (ERR_NETWORK_CHANGED /
+ * ERR_INTERNET_DISCONNECTED / ERR_NAME_NOT_RESOLVED). Catches the common
+ * case of the WebView's sockets not being ready in the first few hundred ms
+ * after Android/Electron resume. Non-GET requests are never retried — we do
+ * not silently re-issue writes.
+ */
+@Injectable({ providedIn: 'root' })
+export class NetworkRetryInterceptorService implements HttpInterceptor {
+  intercept(
+    req: HttpRequest<unknown>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<unknown>> {
+    if (req.method !== 'GET') {
+      return next.handle(req);
+    }
+    return next.handle(req).pipe(
+      retry({
+        count: 1,
+        delay: (error: unknown) => {
+          if (error instanceof HttpErrorResponse && error.status === 0) {
+            return timer(RETRY_DELAY_MS);
+          }
+          return throwError(() => error);
+        },
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,11 @@ import { DataInitStateService } from './app/core/data-init/data-init-state.servi
 import { App as CapacitorApp } from '@capacitor/app';
 import { GlobalErrorHandler } from './app/core/error-handler/global-error-handler.class';
 import { bootstrapApplication, BrowserModule } from '@angular/platform-browser';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  HTTP_INTERCEPTORS,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { MarkdownModule, MARKED_OPTIONS, SANITIZE } from 'ngx-markdown';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
@@ -86,6 +90,7 @@ import { LocaleDatePipe } from './app/ui/pipes/locale-date.pipe';
 import { DateTimeFormatService } from './app/core/date-time-format/date-time-format.service';
 import { CustomDateAdapter } from './app/core/date-time-format/custom-date-adapter';
 import { unlockAudioContext } from './app/util/audio-context';
+import { NetworkRetryInterceptorService } from './app/core/http/network-retry-interceptor.service';
 
 if (environment.production || environment.stage) {
   enableProdMode();
@@ -188,6 +193,11 @@ bootstrapApplication(AppComponent, {
     ),
     { provide: ErrorHandler, useClass: GlobalErrorHandler },
     provideHttpClient(withInterceptorsFromDi()),
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: NetworkRetryInterceptorService,
+      multi: true,
+    },
     LocaleDatePipe,
     ShortTimeHtmlPipe,
     ShortTimePipe,


### PR DESCRIPTION
## Summary

- Adds an Angular `HttpInterceptor` that retries `GET` requests **once** on `HttpErrorResponse` with `status === 0` after a 500 ms backoff. This is Angular's marker for transient client-side network failures (`ERR_NETWORK_CHANGED` / `ERR_INTERNET_DISCONNECTED` / `ERR_NAME_NOT_RESOLVED`).
- Targets the root cause of the spurious network-error snackbars users hit when bringing the app to foreground on Android: the WebView's Chromium socket layer needs a few hundred ms after `onResume` to re-establish keepalive connections, and `navigator.onLine` flips back to `true` before sockets are actually usable. This also helps on Electron and PWAs after sleep / network handover.
- Covers everything that goes through Angular `HttpClient` — issue providers (Jira, GitHub, Gitea, Linear, Redmine, OpenProject, GitLab), file imex, plugin HTTP.
- **Non-GETs are never retried** — we do not silently re-issue writes.
- Sync providers go through CapacitorHttp via `packages/sync-providers/src/http/native-http-retry.ts` which already has its own ~4.5 s retry budget for this exact problem (058f92e972), so the two layers complement each other without overlap.

## Why only the interceptor

A previous iteration of this branch also added a 2 s post-resume "snack suppression window" as belt-and-suspenders. It was dropped because the interceptor alone catches the common case at the source, `native-http-retry` already handles the sync path, and the snack window introduced module-level state that caused cross-spec test contamination. If we observe remaining snacks on resume after this lands, that gives a real signal pointing to a specific path that needs more hardening — better than pre-emptively suppressing both.

## Test plan

- [x] Unit specs: retry-then-succeed on status 0, retry-then-fail (error surfaces correctly), no retry on non-zero status (500), no retry on POST with status 0.
- [x] `npm run checkFile` clean on all touched files.
- [ ] Manual smoke on Android: background the app for ~30 s with the device's screen off, bring it back to foreground. Confirm the network-error snackbar that used to appear immediately on resume is gone or significantly reduced.
- [ ] Manual smoke on Android: turn on airplane mode, then attempt a sync. Confirm the `NETWORK_ERROR` warning still surfaces (the interceptor retries once, then propagates — persistent offline still notifies the user).
- [ ] Manual smoke on Electron after sleep / wake.