### PR TITLE
fix(schedule): guard schedule dialog against malformed time input

### DIFF
--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.invalid-time.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.invalid-time.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideMockStore } from '@ngrx/store/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
+import { DateAdapter } from '@angular/material/core';
+import { DialogScheduleTaskComponent } from './dialog-schedule-task.component';
+import { TaskCopy } from '../../tasks/task.model';
+import { SnackService } from '../../../core/snack/snack.service';
+import { LocaleDatePipe } from 'src/app/ui/pipes/locale-date.pipe';
+import { TaskService } from '../../tasks/task.service';
+import { ReminderService } from '../../reminder/reminder.service';
+import { DateService } from '../../../core/date/date.service';
+import { GlobalConfigService } from '../../config/global-config.service';
+import {
+  selectAllTasksWithDueTimeSorted,
+  selectTaskById,
+} from '../../tasks/store/task.selectors';
+import { selectTimelineConfig } from '../../config/store/global-config.reducer';
+
+/**
+ * Repro for issue #7802 — "Invalid clock string" on Schedule Task dialog.
+ *
+ * `plannedTimestamp` (a computed signal added in #7559) calls
+ * getDateTimeFromClockString eagerly whenever selectedTime changes. Any value
+ * that is non-empty but fails isValidSplitTime (e.g. an HH:MM:SS value pasted
+ * into <input type="time">, an out-of-range "25:00", or garbage) makes the
+ * computed throw, the throw escapes through the template's
+ * scheduleWarnings() call, and "Invalid clock string" bubbles to the global
+ * error handler.
+ *
+ * Mirrors the pattern already established by:
+ *  - dialog-deadline.component.spec.ts (#7490)
+ *  - invalid-clock-string-bug-7067.spec.ts (#7067)
+ */
+describe('DialogScheduleTaskComponent — malformed selectedTime', () => {
+  let matDialogRefSpy: jasmine.SpyObj<MatDialogRef<DialogScheduleTaskComponent>>;
+  let taskServiceSpy: jasmine.SpyObj<TaskService>;
+
+  const task: TaskCopy = {
+    id: 'task-1',
+    title: 'Test',
+    tagIds: [],
+    projectId: 'DEFAULT',
+    timeSpentOnDay: {},
+    attachments: [],
+    timeEstimate: 0,
+    timeSpent: 0,
+    isDone: false,
+    created: 1640995200000,
+    subTaskIds: [],
+  } as TaskCopy;
+
+  const createComponent = (): DialogScheduleTaskComponent => {
+    const fixture = TestBed.createComponent(DialogScheduleTaskComponent);
+    const component = fixture.componentInstance;
+    component.data = { task };
+    component.task = task;
+    return component;
+  };
+
+  beforeEach(async () => {
+    matDialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+    taskServiceSpy = jasmine.createSpyObj('TaskService', ['scheduleTask']);
+    // ngAfterViewInit reads viewChild.required(MatCalendar). With the template
+    // stubbed there is no calendar — skip the hook and test in isolation.
+    spyOn(DialogScheduleTaskComponent.prototype, 'ngAfterViewInit').and.stub();
+
+    await TestBed.configureTestingModule({
+      imports: [
+        DialogScheduleTaskComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        provideMockStore({
+          initialState: {},
+          selectors: [
+            { selector: selectAllTasksWithDueTimeSorted, value: [] },
+            { selector: selectTimelineConfig, value: null },
+            { selector: selectTaskById, value: task },
+          ],
+        }),
+        { provide: MatDialogRef, useValue: matDialogRefSpy },
+        { provide: MAT_DIALOG_DATA, useValue: { task } },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', ['open']),
+        },
+        { provide: TaskService, useValue: taskServiceSpy },
+        {
+          provide: ReminderService,
+          useValue: jasmine.createSpyObj('ReminderService', ['getById']),
+        },
+        {
+          provide: DateService,
+          useValue: {
+            isToday: () => false,
+            todayStr: () => '2026-05-26',
+            getStartOfNextDayDiffMs: () => 0,
+          },
+        },
+        {
+          provide: GlobalConfigService,
+          useValue: { localization: () => undefined, cfg: () => undefined },
+        },
+        {
+          provide: DateAdapter,
+          useValue: { getFirstDayOfWeek: () => 1, getDayOfWeek: () => 1 },
+        },
+        TranslateService,
+        TranslateStore,
+        LocaleDatePipe,
+      ],
+    })
+      .overrideComponent(DialogScheduleTaskComponent, { set: { template: '' } })
+      .compileComponents();
+  });
+
+  // --- pinning tests (must keep passing through the fix) ---
+
+  it('plannedTimestamp returns a number for a valid HH:MM time', () => {
+    const component = createComponent();
+    component.selectedDate = new Date(2026, 4, 26);
+    component.selectedTime = '14:30';
+
+    expect(typeof component.plannedTimestamp()).toBe('number');
+  });
+
+  it('plannedTimestamp returns null when no time is set', () => {
+    const component = createComponent();
+    component.selectedDate = new Date(2026, 4, 26);
+    component.selectedTime = null;
+
+    expect(component.plannedTimestamp()).toBeNull();
+  });
+
+  // --- repro for #7802 (currently FAILING) ---
+
+  // After the fix, reading plannedTimestamp() with a malformed time must not
+  // throw "Invalid clock string". Returning null is the natural fallback —
+  // scheduleWarnings already treats null as "no warnings".
+  ['13:30:00', '25:00', '13:60', 'abc', '12'].forEach((badTime) => {
+    it(`plannedTimestamp does NOT throw for malformed selectedTime "${badTime}"`, () => {
+      const component = createComponent();
+      component.selectedDate = new Date(2026, 4, 26);
+      component.selectedTime = badTime;
+
+      expect(() => component.plannedTimestamp()).not.toThrow();
+      expect(component.plannedTimestamp()).toBeNull();
+    });
+
+    it(`scheduleWarnings does NOT throw for malformed selectedTime "${badTime}"`, () => {
+      const component = createComponent();
+      component.selectedDate = new Date(2026, 4, 26);
+      component.selectedTime = badTime;
+
+      expect(() => component.scheduleWarnings()).not.toThrow();
+      expect(component.scheduleWarnings()).toEqual({
+        hasOverlap: false,
+        isOutsideWorkHours: false,
+      });
+    });
+
+    it(`submit() falls back to day-only planning for malformed selectedTime "${badTime}"`, async () => {
+      const component = createComponent();
+      component.selectedDate = new Date(2026, 4, 26);
+      component.selectedTime = badTime;
+
+      let err: unknown;
+      try {
+        await component.submit();
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeUndefined();
+      // Invalid time must not reach scheduleTask — it would crash there too.
+      expect(taskServiceSpy.scheduleTask).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -38,6 +38,7 @@ import { DateService } from '../../../core/date/date.service';
 import { TaskService } from '../../tasks/task.service';
 import { ReminderService } from '../../reminder/reminder.service';
 import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
+import { isValidSplitTime } from '../../../util/is-valid-split-time';
 import { fadeAnimation } from '../../../ui/animations/fade.ani';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { DateAdapter, MatOption } from '@angular/material/core';
@@ -163,7 +164,10 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
   plannedTimestamp = computed<number | null>(() => {
     const selectedDate = this._selectedDate();
     const selectedTime = this._selectedTime();
-    if (!selectedDate || !selectedTime) {
+    // Malformed values (e.g. `HH:MM:SS` pasted into <input type="time">, out-of-range
+    // `25:00`, garbage) would otherwise crash getDateTimeFromClockString and bubble
+    // "Invalid clock string" to the global error handler via scheduleWarnings (#7802).
+    if (!selectedDate || !selectedTime || !isValidSplitTime(selectedTime)) {
       return null;
     }
 
@@ -428,7 +432,11 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
 
     this._handleReminderRemoval();
 
-    if (this.selectedTime) {
+    // Treat malformed time the same as "no time": fall through to day-only planning
+    // rather than crashing in _scheduleWithTime (#7802).
+    const hasValidTime = !!this.selectedTime && isValidSplitTime(this.selectedTime);
+
+    if (hasValidTime) {
       this._scheduleWithTime();
     } else if (
       this.data.task &&
@@ -473,8 +481,9 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
   }
 
   private _scheduleWithTime(): void {
-    // Only schedule if task is provided
-    if (!this.data.task) {
+    // Only schedule if task is provided and time is valid (submit() pre-validates;
+    // belt-and-braces guard against direct callers / malformed paste — see #7802).
+    if (!this.data.task || !isValidSplitTime(this.selectedTime ?? undefined)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #7802 — "Invalid clock string" thrown from the Schedule Task dialog while the user is editing the time.

`plannedTimestamp` (a `computed()` added in #7559) calls `getDateTimeFromClockString` reactively on every `selectedTime` change. Any non-empty value that isn't strict `HH:MM` (`HH:MM:SS` paste, out-of-range `25:00`, garbage) crashes the computed, the throw escapes through the template's `scheduleWarnings()` call, and "Invalid clock string" bubbles to the global error handler.

Same class of bug already fixed in #7067 (`task-repeat-cfg`) and #7490 (`dialog-deadline`); same defensive `isValidSplitTime` guard applied here.

- `plannedTimestamp`: returns `null` for invalid time (warnings stay clean)
- `submit()`: falls through to day-only planning instead of crashing
- `_scheduleWithTime()`: belt-and-braces guard for direct callers

## Test plan

- [x] New spec `dialog-schedule-task.component.invalid-time.spec.ts`: 2 pinning tests + 15 repro tests (5 malformed inputs × `plannedTimestamp` / `scheduleWarnings` / `submit`). Fails 15/17 before the fix, all 17 pass after.
- [x] Sibling specs unchanged: `dialog-schedule-task.component.spec.ts` (13/13), `-select-due-only.spec.ts` (13/13), `.component.tz.spec.ts` (10/10).
- [x] `npm run checkFile` clean on both modified files.
- [ ] Manual smoke: open Schedule Task from boards, paste `13:30:00` into time — no console error, submit falls back to day-only planning.