### PR TITLE
test(schedule): flush dateSelected setTimeout with fakeAsync/tick

### DIFF
--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task-select-due-only.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task-select-due-only.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { DialogScheduleTaskComponent } from './dialog-schedule-task.component';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -226,16 +226,15 @@ describe('DialogScheduleTaskComponent - Select Due Only Mode', () => {
       fixture.detectChanges();
     });
 
-    it('should update selectedDate when dateSelected is called', () => {
+    it('should update selectedDate when dateSelected is called', fakeAsync(() => {
       const testDate = new Date('2024-01-20');
 
       component.dateSelected(testDate);
+      // dateSelected defers the assignment via setTimeout — flush it before asserting
+      tick();
 
-      // Wait for setTimeout to complete
-      setTimeout(() => {
-        expect(component.selectedDate).toEqual(testDate);
-      }, 1);
-    });
+      expect(component.selectedDate).toEqual(testDate);
+    }));
 
     it('should handle quick access buttons correctly', () => {
       const initialDate = new Date();


### PR DESCRIPTION
## Summary
- Fixes a latent flake in `dialog-schedule-task-select-due-only.spec.ts` that bit master CI on run [26468898831](https://github.com/super-productivity/super-productivity/actions/runs/26468898831) (LA-TZ Karma pass).
- The `should update selectedDate when dateSelected is called` test wrapped its `expect` in `setTimeout(..., 1)` with no `done` / `fakeAsync`, so the assertion fired **after** the `it` block returned. When it eventually ran, it asserted against a sibling test's mutated `component.selectedDate` — Jasmine reported it as an `afterAll` error, the Karma browser then disconnected after 30 s and the job failed.
- Rewrap the test in `fakeAsync` and flush the component's deferred `setTimeout` via `tick()` so the assertion is owned by the test that scheduled it.

## Why LA-only / not flagged before
Pure timing — in Berlin TZ runs the leaked `setTimeout` happened to fire while `selectedDate` was still `testDate`. The dead-expect pattern has been in the file since 2025-08-23 (`50b496e5b6`).

## Test plan
- [x] `TZ='America/Los_Angeles' npx ng test --include='src/app/features/planner/dialog-schedule-task/dialog-schedule-task-select-due-only.spec.ts' --watch=false` → 13/13 SUCCESS
- [x] `npm run checkFile <spec>` clean
- [ ] CI green on this PR