### PR TITLE
feat(plugins): allow multiple hook handlers per (hook, pluginId)

### DIFF
--- a/src/app/plugins/plugin-hooks.spec.ts
+++ b/src/app/plugins/plugin-hooks.spec.ts
@@ -108,4 +108,79 @@ describe('PluginHooksService.dispatchHookToPlugin', () => {
       ),
     ).toThrowError(/must not contain ':'/);
   });
+
+  it('fires every handler when a plugin registers more than once for the same hook', async () => {
+    // document-mode registers from both its background script and its iframe
+    // editor under the same pluginId — pre-fix the second registration
+    // silently overwrote the first, so iframe registration permanently
+    // shadowed background's enabledIds-reconcile handler.
+    const bgHandler = jasmine.createSpy('bgHandler');
+    const iframeHandler = jasmine.createSpy('iframeHandler');
+    service.registerHookHandler(
+      'document-mode',
+      PluginHooks.PERSISTED_DATA_CHANGED,
+      bgHandler,
+    );
+    service.registerHookHandler(
+      'document-mode',
+      PluginHooks.PERSISTED_DATA_CHANGED,
+      iframeHandler,
+    );
+
+    await service.dispatchHookToPlugin(
+      'document-mode',
+      PluginHooks.PERSISTED_DATA_CHANGED,
+    );
+
+    expect(bgHandler).toHaveBeenCalledTimes(1);
+    expect(iframeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregisterPluginHooks drops every handler for that plugin across all hooks', () => {
+    const dataChanged = jasmine.createSpy('dataChanged');
+    const dataChanged2 = jasmine.createSpy('dataChanged2');
+    const taskComplete = jasmine.createSpy('taskComplete');
+    const otherPlugin = jasmine.createSpy('otherPlugin');
+
+    service.registerHookHandler(
+      'document-mode',
+      PluginHooks.PERSISTED_DATA_CHANGED,
+      dataChanged,
+    );
+    service.registerHookHandler(
+      'document-mode',
+      PluginHooks.PERSISTED_DATA_CHANGED,
+      dataChanged2,
+    );
+    service.registerHookHandler('document-mode', PluginHooks.TASK_COMPLETE, taskComplete);
+    // Sibling plugin's handler must survive a teardown targeting document-mode.
+    service.registerHookHandler('other', PluginHooks.TASK_COMPLETE, otherPlugin);
+
+    service.unregisterPluginHooks('document-mode');
+
+    return Promise.all([
+      service.dispatchHookToPlugin('document-mode', PluginHooks.PERSISTED_DATA_CHANGED),
+      service.dispatchHook(PluginHooks.TASK_COMPLETE),
+    ]).then(() => {
+      expect(dataChanged).not.toHaveBeenCalled();
+      expect(dataChanged2).not.toHaveBeenCalled();
+      expect(taskComplete).not.toHaveBeenCalled();
+      expect(otherPlugin).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('dispatchHook fan-out fires every handler from every plugin', async () => {
+    const aH1 = jasmine.createSpy('aH1');
+    const aH2 = jasmine.createSpy('aH2');
+    const bH = jasmine.createSpy('bH');
+    service.registerHookHandler('plugin-a', PluginHooks.TASK_COMPLETE, aH1);
+    service.registerHookHandler('plugin-a', PluginHooks.TASK_COMPLETE, aH2);
+    service.registerHookHandler('plugin-b', PluginHooks.TASK_COMPLETE, bH);
+
+    await service.dispatchHook(PluginHooks.TASK_COMPLETE);
+
+    expect(aH1).toHaveBeenCalledTimes(1);
+    expect(aH2).toHaveBeenCalledTimes(1);
+    expect(bH).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/plugins/plugin-hooks.ts
+++ b/src/app/plugins/plugin-hooks.ts
@@ -5,13 +5,18 @@ import { PluginLog } from '../core/log';
 /**
  * Simplified plugin hooks service following KISS principles.
  * Each handler has a 5s timeout to prevent hung handlers from blocking others.
+ *
+ * A plugin may register multiple handlers for the same hook under one
+ * pluginId — for example, document-mode registers from both its background
+ * script (host page) and its iframe editor. All registered handlers fire on
+ * dispatch.
  */
 @Injectable({
   providedIn: 'root',
 })
 export class PluginHooksService {
   private static readonly HOOK_TIMEOUT_MS = 5000;
-  private _handlers = new Map<Hooks, Map<string, PluginHookHandler<any>>>();
+  private _handlers = new Map<Hooks, Map<string, Set<PluginHookHandler<any>>>>();
 
   /**
    * Register a hook handler.
@@ -33,7 +38,11 @@ export class PluginHooksService {
     if (!this._handlers.has(hook)) {
       this._handlers.set(hook, new Map());
     }
-    this._handlers.get(hook)!.set(pluginId, handler);
+    const perPlugin = this._handlers.get(hook)!;
+    if (!perPlugin.has(pluginId)) {
+      perPlugin.set(pluginId, new Set());
+    }
+    perPlugin.get(pluginId)!.add(handler);
     PluginLog.log(`Plugin ${pluginId} registered for ${hook}`);
   }
 
@@ -44,23 +53,27 @@ export class PluginHooksService {
    * {@link dispatchHookToPlugin} so only the owner's handler runs.
    */
   async dispatchHook(hook: Hooks, payload?: unknown): Promise<void> {
-    const handlers = this._handlers.get(hook);
-    if (!handlers || handlers.size === 0) {
+    const perPlugin = this._handlers.get(hook);
+    if (!perPlugin || perPlugin.size === 0) {
       return;
     }
-    for (const [pluginId, handler] of handlers) {
-      await this._invokeWithTimeout(pluginId, hook, handler, payload);
+    for (const [pluginId, handlers] of perPlugin) {
+      for (const handler of handlers) {
+        await this._invokeWithTimeout(pluginId, hook, handler, payload);
+      }
     }
   }
 
   /**
-   * Dispatch a hook to a single plugin's handler (scoped).
+   * Dispatch a hook to a single plugin's handler(s) (scoped).
    * Counterpart to {@link dispatchHook} — use for per-owner events such as
    * `PERSISTED_DATA_CHANGED` where only the affected plugin should be notified.
-   * No-op if `pluginId` has no handler registered for `hook`.
+   * Fires every handler the plugin registered for `hook` (a plugin with both
+   * a background-script and an iframe handler runs both). No-op if `pluginId`
+   * has no handler registered for `hook`.
    *
    * Callers are expected to invoke without awaiting (fire-and-forget). Each
-   * call allocates one `Promise.race([handler, 5s timeout])` (see
+   * call allocates one `Promise.race([handler, 5s timeout])` per handler (see
    * `HOOK_TIMEOUT_MS` above) — the closure is released within the timeout
    * window, so concurrent dispatches stay bounded by the number of in-flight
    * plugins.
@@ -70,11 +83,13 @@ export class PluginHooksService {
     hook: T,
     payload?: unknown,
   ): Promise<void> {
-    const handler = this._handlers.get(hook)?.get(pluginId);
-    if (!handler) {
+    const handlers = this._handlers.get(hook)?.get(pluginId);
+    if (!handlers || handlers.size === 0) {
       return;
     }
-    await this._invokeWithTimeout(pluginId, hook, handler, payload);
+    for (const handler of handlers) {
+      await this._invokeWithTimeout(pluginId, hook, handler, payload);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #7805. `PluginHooksService._handlers` was `Map<Hooks, Map<pluginId, handler>>` — a single-handler slot per `(hook, pluginId)`. A plugin that registers the same hook from two JS contexts under one pluginId (document-mode registers from both its background script and its iframe editor) loses one handler to whichever runs second.

Widen the inner slot to `Set<handler>`:
- `registerHookHandler` adds to the set
- `dispatchHook` / `dispatchHookToPlugin` iterate the set
- `unregisterPluginHooks` still drops the whole set for that pluginId
- Per-handler 5s timeout race is unchanged

No new public unregister API. `unregisterPluginHooks` already clears all handlers for a plugin and is the existing teardown path called by `PluginService.deactivatePlugin`; a surgical `unregisterHookHandler` was considered for iframe-teardown handler cleanup but cut as unused public surface — the host accepts a stale postMessage proxy as a 5s timeout slot today, and if that cost ever becomes real, add the method then.

Unblocks #7752 (document-mode adoption of `PERSISTED_DATA_CHANGED`).

## Test plan

- [x] `npm run test:file src/app/plugins/plugin-hooks.spec.ts` — 8/8 pass (3 existing + 5 new)
- [x] `npm run checkFile` clean on both modified files
- [ ] CI green on the full suite