### PR TITLE
feat(schedule): include plugin calendar providers in filter and event color

### DIFF
--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -43,6 +43,7 @@ import {
   isPluginIssueProvider,
 } from '../issue/issue.model';
 import { CalendarProviderCfg } from '../issue/providers/calendar/calendar.model';
+import { getCalendarProviderColor } from '../issue/mapping-helper/get-issue-provider-color';
 import { CORS_SKIP_EXTRA_HEADERS, IS_WEB_BROWSER } from '../../app.constants';
 import { Log } from '../../core/log';
 import { getErrorTxt } from '../../util/get-error-text';
@@ -284,6 +285,7 @@ export class CalendarIntegrationService {
     const results: PluginSearchResult[] =
       await provider.definition.getNewIssuesForBacklog(pluginProvider.pluginConfig, http);
 
+    const color = getCalendarProviderColor(pluginProvider);
     return results
       .filter((r) => r.start != null)
       .map((r) => ({
@@ -296,6 +298,7 @@ export class CalendarIntegrationService {
         isAllDay: r.isAllDay,
         issueProviderKey: pluginProvider.issueProviderKey,
         dueWithTime: r.dueWithTime,
+        color,
       }));
   }
 

--- a/src/app/features/issue/mapping-helper/get-issue-provider-color.spec.ts
+++ b/src/app/features/issue/mapping-helper/get-issue-provider-color.spec.ts
@@ -1,0 +1,65 @@
+import { getCalendarProviderColor } from './get-issue-provider-color';
+import {
+  IssueProvider,
+  IssueProviderCalendar,
+  IssueProviderPluginType,
+} from '../issue.model';
+
+const icalProvider = (over: Partial<IssueProviderCalendar> = {}): IssueProvider =>
+  ({
+    id: 'ical-1',
+    isEnabled: true,
+    issueProviderKey: 'ICAL',
+    icalUrl: 'https://example.com/cal.ics',
+    ...over,
+  }) as IssueProvider;
+
+const pluginProvider = (over: Partial<IssueProviderPluginType> = {}): IssueProvider =>
+  ({
+    id: 'plugin-1',
+    isEnabled: true,
+    issueProviderKey: 'plugin:caldav-calendar-provider',
+    pluginId: 'caldav-calendar-provider',
+    pluginConfig: {},
+    ...over,
+  }) as IssueProvider;
+
+describe('getCalendarProviderColor', () => {
+  it('returns the explicit color of an iCal provider', () => {
+    expect(getCalendarProviderColor(icalProvider({ color: '#4caf50' }))).toBe('#4caf50');
+  });
+
+  it('returns the color from a plugin provider pluginConfig', () => {
+    expect(
+      getCalendarProviderColor(pluginProvider({ pluginConfig: { color: '#abcdef' } })),
+    ).toBe('#abcdef');
+  });
+
+  it('falls back to a HSL color when an iCal provider has no color', () => {
+    expect(getCalendarProviderColor(icalProvider())).toMatch(
+      /^hsl\(\d{1,3}, 60%, 55%\)$/,
+    );
+  });
+
+  it('falls back to a HSL color when a plugin provider has no color', () => {
+    expect(getCalendarProviderColor(pluginProvider())).toMatch(
+      /^hsl\(\d{1,3}, 60%, 55%\)$/,
+    );
+  });
+
+  it('derives the fallback deterministically from the provider id', () => {
+    const a = getCalendarProviderColor(pluginProvider({ id: 'same-id' }));
+    const b = getCalendarProviderColor(pluginProvider({ id: 'same-id' }));
+    expect(a).toBe(b);
+  });
+
+  it('gives different ids different fallback hues', () => {
+    const a = getCalendarProviderColor(pluginProvider({ id: 'provider-aaa' }));
+    const b = getCalendarProviderColor(pluginProvider({ id: 'provider-bbb' }));
+    expect(a).not.toBe(b);
+  });
+
+  it('ignores an empty-string color and falls back', () => {
+    expect(getCalendarProviderColor(icalProvider({ color: '' }))).toMatch(/^hsl\(/);
+  });
+});

--- a/src/app/features/issue/mapping-helper/get-issue-provider-color.ts
+++ b/src/app/features/issue/mapping-helper/get-issue-provider-color.ts
@@ -1,0 +1,23 @@
+import {
+  IssueProvider,
+  IssueProviderPluginType,
+  isPluginIssueProvider,
+} from '../issue.model';
+
+const _hueFromId = (id: string): number => {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    const shifted = h * 31;
+    h = (shifted + id.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % 360;
+};
+
+export const getCalendarProviderColor = (p: IssueProvider): string => {
+  if ('color' in p && typeof p.color === 'string' && p.color) return p.color;
+  if (isPluginIssueProvider(p.issueProviderKey)) {
+    const c = (p as IssueProviderPluginType).pluginConfig?.['color'];
+    if (typeof c === 'string' && c) return c;
+  }
+  return `hsl(${_hueFromId(p.id)}, 60%, 55%)`;
+};

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -48,13 +48,13 @@
               } @else {
                 <mat-icon>check_box</mat-icon>
               }
-              @if (provider.color) {
+              <span class="cal-provider-row">
                 <span
                   class="cal-color-dot"
-                  [style.background]="provider.color"
+                  [style.background]="calProviderColor(provider)"
                 ></span>
-              }
-              {{ calProviderLabel(provider) }}
+                <span class="cal-provider-label">{{ calProviderLabel(provider) }}</span>
+              </span>
             </button>
           }
         </div>

--- a/src/app/features/schedule/schedule/schedule.component.scss
+++ b/src/app/features/schedule/schedule/schedule.component.scss
@@ -117,13 +117,17 @@
   }
 }
 
+.cal-provider-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .cal-color-dot {
   display: inline-block;
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  margin-right: 4px;
-  vertical-align: middle;
   flex-shrink: 0;
 }
 

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -9,8 +9,12 @@ import { DateAdapter } from '@angular/material/core';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { selectCalendarProviders } from '../../issue/store/issue-provider.selectors';
+import {
+  selectCalendarProviders,
+  selectEnabledIssueProviders,
+} from '../../issue/store/issue-provider.selectors';
 import { HiddenCalendarProvidersService } from '../../calendar-integration/hidden-calendar-providers.service';
+import { PluginIssueProviderRegistryService } from '../../../plugins/issue-provider/plugin-issue-provider-registry.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SCHEDULE_CONSTANTS } from '../schedule.constants';
 import { GlobalConfigService } from '../../config/global-config.service';
@@ -804,6 +808,98 @@ describe('ScheduleComponent', () => {
       store.refreshState();
       fixture.detectChanges();
       expect(component.showCalFilterBtn()).toBe(true);
+    });
+  });
+
+  describe('plugin calendar providers', () => {
+    const icalProvider = (id: string): any => ({
+      id,
+      isEnabled: true,
+      issueProviderKey: 'ICAL',
+      icalUrl: `https://example.com/${id}.ics`,
+    });
+    const pluginProvider = (id: string, key = 'plugin:cal'): any => ({
+      id,
+      isEnabled: true,
+      issueProviderKey: key,
+      pluginId: 'cal',
+      pluginConfig: {},
+    });
+
+    beforeEach(() => {
+      localStorage.removeItem('SUP_HIDDEN_CALENDAR_PROVIDER_IDS');
+      TestBed.inject(HiddenCalendarProvidersService).setHidden([]);
+    });
+
+    afterEach(() => {
+      TestBed.inject(MockStore).resetSelectors();
+    });
+
+    it('includes plugin issue providers that opt into the agenda view', () => {
+      const store = TestBed.inject(MockStore);
+      spyOn(
+        TestBed.inject(PluginIssueProviderRegistryService),
+        'getUseAgendaView',
+      ).and.returnValue(true);
+      store.overrideSelector(selectCalendarProviders, []);
+      store.overrideSelector(selectEnabledIssueProviders, [pluginProvider('p1')]);
+      store.refreshState();
+      fixture.detectChanges();
+      expect(component.enabledCalendarProviders().map((p) => p.id)).toEqual(['p1']);
+    });
+
+    it('excludes plugin providers that do not use the agenda view', () => {
+      const store = TestBed.inject(MockStore);
+      spyOn(
+        TestBed.inject(PluginIssueProviderRegistryService),
+        'getUseAgendaView',
+      ).and.returnValue(false);
+      store.overrideSelector(selectCalendarProviders, []);
+      store.overrideSelector(selectEnabledIssueProviders, [pluginProvider('p1')]);
+      store.refreshState();
+      fixture.detectChanges();
+      expect(component.enabledCalendarProviders()).toEqual([]);
+    });
+
+    it('shows the filter button for one iCal plus one plugin calendar provider', () => {
+      const store = TestBed.inject(MockStore);
+      spyOn(
+        TestBed.inject(PluginIssueProviderRegistryService),
+        'getUseAgendaView',
+      ).and.returnValue(true);
+      store.overrideSelector(selectCalendarProviders, [icalProvider('ical')]);
+      store.overrideSelector(selectEnabledIssueProviders, [
+        icalProvider('ical'),
+        pluginProvider('plug'),
+      ]);
+      store.refreshState();
+      fixture.detectChanges();
+      expect(component.showCalFilterBtn()).toBe(true);
+    });
+  });
+
+  describe('calProviderLabel', () => {
+    it('normalizes a URL-shaped label to host-only', () => {
+      expect(
+        component.calProviderLabel({
+          id: 'p',
+          isEnabled: true,
+          issueProviderKey: 'plugin:cal',
+          pluginId: 'cal',
+          pluginConfig: { serverUrl: 'https://calendar.example.com/dav/' },
+        } as any),
+      ).toBe('calendar.example.com');
+    });
+
+    it('leaves an already host-only iCal label untouched', () => {
+      expect(
+        component.calProviderLabel({
+          id: 'p',
+          isEnabled: true,
+          issueProviderKey: 'ICAL',
+          icalUrl: 'https://feeds.example.com/cal.ics',
+        } as any),
+      ).toBe('feeds.example.com');
     });
   });
 

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -7,12 +7,21 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { fromEvent } from 'rxjs';
+import { combineLatest, fromEvent } from 'rxjs';
 import { select, Store } from '@ngrx/store';
-import { selectCalendarProviders } from '../../issue/store/issue-provider.selectors';
+import {
+  selectCalendarProviders,
+  selectEnabledIssueProviders,
+} from '../../issue/store/issue-provider.selectors';
 import { HiddenCalendarProvidersService } from '../../calendar-integration/hidden-calendar-providers.service';
 import { getIssueProviderTooltip } from '../../issue/mapping-helper/get-issue-provider-tooltip';
-import { IssueProvider } from '../../issue/issue.model';
+import { getCalendarProviderColor } from '../../issue/mapping-helper/get-issue-provider-color';
+import {
+  IssueProvider,
+  IssueProviderPluginType,
+  isPluginIssueProvider,
+} from '../../issue/issue.model';
+import { PluginIssueProviderRegistryService } from '../../../plugins/issue-provider/plugin-issue-provider-registry.service';
 import {
   MatMenu,
   MatMenuContent,
@@ -78,13 +87,25 @@ export class ScheduleComponent {
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _translate = inject(TranslateService);
   private _hiddenCalendarProviders = inject(HiddenCalendarProvidersService);
+  private _pluginIssueProviderRegistry = inject(PluginIssueProviderRegistryService);
 
   readonly hiddenCalendarProviderIds = this._hiddenCalendarProviders.hiddenProviderIds;
   readonly enabledCalendarProviders = toSignal(
-    this._store
-      .select(selectCalendarProviders)
-      .pipe(map((ps) => ps.filter((p) => p.isEnabled))),
-    { initialValue: [] },
+    combineLatest([
+      this._store.select(selectCalendarProviders),
+      this._store
+        .select(selectEnabledIssueProviders)
+        .pipe(
+          map((providers) =>
+            providers.filter(
+              (p): p is IssueProviderPluginType =>
+                isPluginIssueProvider(p.issueProviderKey) &&
+                this._pluginIssueProviderRegistry.getUseAgendaView(p.issueProviderKey),
+            ),
+          ),
+        ),
+    ]).pipe(map(([ical, plugin]): IssueProvider[] => [...ical, ...plugin])),
+    { initialValue: [] as IssueProvider[] },
   );
   // Show the button with multiple providers, OR with a single provider that
   // is currently hidden — otherwise the user has no UI to re-enable the only
@@ -95,7 +116,17 @@ export class ScheduleComponent {
     const hidden = this.hiddenCalendarProviderIds();
     return providers.some((p) => hidden.includes(p.id));
   });
-  readonly calProviderLabel = (p: IssueProvider): string => getIssueProviderTooltip(p);
+  readonly calProviderLabel = (p: IssueProvider): string => {
+    const raw = getIssueProviderTooltip(p);
+    if (!/^(https?|webcals?|file):\/\//i.test(raw)) return raw;
+    try {
+      const u = new URL(raw.replace(/^webcals?:\/\//i, 'https://'));
+      return u.hostname || raw;
+    } catch {
+      return raw;
+    }
+  };
+  readonly calProviderColor = getCalendarProviderColor;
 
   toggleCalProvider(providerId: string): void {
     this._hiddenCalendarProviders.toggle(providerId);


### PR DESCRIPTION
## Problem

`CalendarIntegrationService.calendarEvents$` already reads schedule events from both iCal providers and plugin issue providers that opt into the agenda view (`useAgendaView: true`), but two pieces of the UI still only know about iCal:

1. The visibility-filter button (`showCalFilterBtn` in `schedule.component.ts`) reads `selectCalendarProviders`, which is filtered strictly to `ICAL_TYPE`.
   A user with one iCal feed plus one plugin calendar (e.g. the `caldav-calendar-provider` plugin against Exchange) sees a count of 1, so the filter button stays hidden and there's no way to toggle either source on the schedule.

2. Plugin calendar events go through `_fetchPluginCalendarEvents` without a `color` field, so they render with the default neutral border on the grid while iCal events from the same logical calendar are tinted with the iCal provider's configured `color`.

A side-effect of (1) is that the labels in the filter menu also don't match: iCal goes through `sanitizeIcalUrlForDisplay` (hostname-only) but `getIssueProviderTooltip` returns the raw first config string for plugins, so a plugin row would read `https://calendar.example.com/dav/...` next to an iCal row reading `outlook.office365.com`.

## Solution

- `enabledCalendarProviders` in the schedule component now combines `selectCalendarProviders` with `selectEnabledIssueProviders` filtered to plugin providers with `useAgendaView`, mirroring `calendarEvents$`'s own source set, including its `registrationChanges$` trigger so a plugin that registers after the store hydrates still shows up in the menu. Both branches are gated with `distinctUntilChanged(fastArrayCompare)` like the sibling stream.
- Menu rows (id, color, label) are precomputed in a `computed()` so the template no longer calls methods inside `@for`.
- `calProviderLabel` builds on `sanitizeIcalUrlForDisplay`: any scheme-prefixed plugin label is reduced to its hostname, and opaque schemes (`javascript:`, `data:`, ...) fall back to the provider key, so plugin rows format like iCal rows and never render a config string verbatim.
- New helper `getCalendarProviderColor` returns the provider's explicit `color`, then `pluginConfig.color`, then a deterministic HSL derived from the provider id. Only plain color literals (hex, `rgb()`/`hsl()`, named) are accepted, since `pluginConfig.color` is untrusted and lands in a `[style.background]` binding; anything else, e.g. `url(...)`, takes the fallback.
- The menu dot, `_fetchPluginCalendarEvents`, and `requestEvents$` all go through the helper, so the filter dot and the grid event always agree on a color. **Behavior change:** iCal feeds without a configured color, which previously rendered with the neutral border, now get the deterministic per-provider tint.
- Wrap the menu's dot + label in an inline-flex container with an explicit gap (and drop the now-redundant `margin-right` / `vertical-align` from `.cal-color-dot`) so spacing is identical whether the dot is the explicit user color or the HSL fallback.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

