### PR TITLE
fix(readme): correct anchor and strong tag nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@
 </p>
 
 <p align="center">
-  <strong>For all current downloads, package links, and platform-specific notes:
+  <strong>
+    For all current downloads, package links, and platform-specific notes:
+    <a href="https://github.com/super-productivity/super-productivity/wiki/2.01-Downloads-and-Install" target="_blank">
+      check the wiki
+    </a>.
+  </strong>
+  <br/>
   <a href="https://github.com/super-productivity/super-productivity/wiki/2.01-Downloads-and-Install" target="_blank">
-    check the wiki</strong>.<br/>
     <img
       src="docs/screens/get-it-on-github.webp"
       alt="Get it on GitHub"

--- a/README.md
+++ b/README.md
@@ -49,13 +49,11 @@
 </p>
 
 <p align="center">
-  <strong>
-    For all current downloads, package links, and platform-specific notes:
+  <strong>For all current downloads, package links, and platform-specific notes:
     <a href="https://github.com/super-productivity/super-productivity/wiki/2.01-Downloads-and-Install" target="_blank">
       check the wiki
-    </a>.
-  </strong>
-  <br/>
+    </a>
+  </strong><br/>
   <a href="https://github.com/super-productivity/super-productivity/wiki/2.01-Downloads-and-Install" target="_blank">
     <img
       src="docs/screens/get-it-on-github.webp"


### PR DESCRIPTION
Corrected <strong> and <a> tag nesting.

## Problem

The “Get it on GitHub” image was redirecting to the image source instead of the intended wiki page due to incorrect HTML nesting and anchor placement in the README section.

## Solution

This change fixes the markup so both the text and image correctly link to the downloads wiki page.
Wrapped the “Get it on GitHub” image inside a dedicated anchor element pointing to the downloads wiki page.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
