### PR TITLE
fix(android): keep timer & tracking running after app swipe (#7818)

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/FocusModeForegroundService.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/FocusModeForegroundService.kt
@@ -305,9 +305,5 @@ class FocusModeForegroundService : Service() {
         handler.removeCallbacks(updateRunnable)
     }
 
-    override fun onTaskRemoved(rootIntent: Intent?) {
-        super.onTaskRemoved(rootIntent)
-        Log.d(TAG, "Task removed, stopping service")
-        stopFocusMode()
-    }
+    // Do not override onTaskRemoved — foreground service must survive app swipe (#7818).
 }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/TrackingForegroundService.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/TrackingForegroundService.kt
@@ -263,9 +263,5 @@ class TrackingForegroundService : Service() {
         handler.removeCallbacks(updateRunnable)
     }
 
-    override fun onTaskRemoved(rootIntent: Intent?) {
-        super.onTaskRemoved(rootIntent)
-        Log.d(TAG, "Task removed, stopping service")
-        stopTracking()
-    }
+    // Do not override onTaskRemoved — foreground service must survive app swipe (#7818).
 }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/service/ForegroundServiceTaskRemovalTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/service/ForegroundServiceTaskRemovalTest.kt
@@ -1,0 +1,42 @@
+package com.superproductivity.superproductivity.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Regression guard for #7818 ("app cannot run in the background").
+ *
+ * Both foreground services used to override `onTaskRemoved` to stop themselves
+ * when the app was swiped from recents, which killed the native countdown and
+ * the ongoing notification — defeating the purpose of a foreground service.
+ * Re-introducing such an override would re-break background timing/tracking, so
+ * we assert the override stays absent. The default [android.app.Service]
+ * implementation is a no-op, which is exactly what keeps the service alive.
+ *
+ * This is a structural (reflection-only) check on purpose: it loads the class
+ * but never instantiates the service or calls any framework method, so it runs
+ * as a plain JVM unit test with no Robolectric/device dependency.
+ */
+class ForegroundServiceTaskRemovalTest {
+
+    private fun declaresOnTaskRemoved(serviceClass: Class<*>): Boolean =
+        serviceClass.declaredMethods.any { it.name == "onTaskRemoved" }
+
+    @Test
+    fun `FocusModeForegroundService does not override onTaskRemoved (must survive app swipe)`() {
+        assertFalse(
+            "FocusModeForegroundService must NOT override onTaskRemoved — a self-stopping " +
+                "override re-breaks #7818 (focus timer dies when app is swiped from recents).",
+            declaresOnTaskRemoved(FocusModeForegroundService::class.java),
+        )
+    }
+
+    @Test
+    fun `TrackingForegroundService does not override onTaskRemoved (must survive app swipe)`() {
+        assertFalse(
+            "TrackingForegroundService must NOT override onTaskRemoved — a self-stopping " +
+                "override re-breaks #7818 (time tracking dies when app is swiped from recents).",
+            declaresOnTaskRemoved(TrackingForegroundService::class.java),
+        )
+    }
+}

--- a/e2e/pages/supersync.page.ts
+++ b/e2e/pages/supersync.page.ts
@@ -777,8 +777,10 @@ export class SuperSyncPage extends BasePage {
           // Continue loop to re-check for dialogs
         }
 
-        // Final check for check icon
-        await this.syncCheckIcon.waitFor({ state: 'visible', timeout: 10000 });
+        // Final check for check icon — generous timeout because the inner
+        // race above already used the 30s budget, and on saturated CI runners
+        // the sync state icon can take noticeably longer to render.
+        await this.syncCheckIcon.waitFor({ state: 'visible', timeout: 30000 });
       }
     } else if (waitForInitialSync) {
       // Encryption is mandatory for SuperSync, so even when the caller doesn't

--- a/e2e/tests/recurring/repeat-task-day-change-bug-6230.spec.ts
+++ b/e2e/tests/recurring/repeat-task-day-change-bug-6230.spec.ts
@@ -80,10 +80,11 @@ test.describe('Repeat Task - Day Change (#6230)', () => {
 
     // 8. Assert: a new undone task with the same title should appear
     //    The app's date-change mechanism should detect the new day and create
-    //    a fresh repeat task instance. 30s timeout accounts for debounce + sync.
+    //    a fresh repeat task instance. 60s timeout accounts for debounce + sync
+    //    on saturated CI runners where the 1s tick can lag substantially.
     await expect(
       taskPage.getUndoneTasks().filter({ hasText: taskTitle }).first(),
-    ).toBeVisible({ timeout: 30000 });
+    ).toBeVisible({ timeout: 60000 });
 
     console.log('[Bug #6230] New repeat task instance appeared after day change');
   });

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -645,20 +645,52 @@ export class GlobalThemeService {
     const vv = window.visualViewport;
     if (!vv) return;
     const root = this.document.documentElement;
-    // Filter out small differences that come from URL bar / overlay UI
-    // rather than the IME — keeps us from setting a phantom keyboard offset.
+    // Filter out small differences from URL bar / overlay UI rather than the
+    // IME — keeps us from setting a phantom keyboard offset.
     const KEYBOARD_THRESHOLD_PX = 100;
+    // IME open/close on Android resizes the layout viewport (adjustResize)
+    // and the visual viewport at slightly different times, so per-event
+    // commits park fixed-position UI (e.g. the global add-task bar) at
+    // intermediate partial-keyboard amounts. Debounce the OPEN path so only
+    // the final value lands (200ms, just past `--transition-duration-m`:
+    // 225ms). Commit the CLOSE path synchronously so the bar drops the moment
+    // the IME is gone rather than parking at the old height for the debounce
+    // window — that would just invert the original symptom.
+    const KEYBOARD_RESIZE_DEBOUNCE_MS = 200;
+    let resizeTimer: number | null = null;
 
-    const update = (): void => {
+    const commit = (): void => {
       const obscured = window.innerHeight - vv.height;
       const keyboardHeight = obscured > KEYBOARD_THRESHOLD_PX ? obscured : 0;
       root.style.setProperty(CSS_VAR_KEYBOARD_HEIGHT, `${keyboardHeight}px`);
     };
 
-    update();
-    vv.addEventListener('resize', update, { passive: true });
+    const onViewportResize = (): void => {
+      const obscured = window.innerHeight - vv.height;
+      if (obscured <= KEYBOARD_THRESHOLD_PX) {
+        if (resizeTimer !== null) {
+          window.clearTimeout(resizeTimer);
+          resizeTimer = null;
+        }
+        commit();
+        return;
+      }
+      if (resizeTimer !== null) {
+        window.clearTimeout(resizeTimer);
+      }
+      resizeTimer = window.setTimeout(() => {
+        resizeTimer = null;
+        commit();
+      }, KEYBOARD_RESIZE_DEBOUNCE_MS);
+    };
+
+    commit();
+    vv.addEventListener('resize', onViewportResize, { passive: true });
     this._destroyRef.onDestroy(() => {
-      vv.removeEventListener('resize', update);
+      vv.removeEventListener('resize', onViewportResize);
+      if (resizeTimer !== null) {
+        window.clearTimeout(resizeTimer);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Android background-execution and related UX/CI fixes for #7818.

- **Background execution (#7818, #4513):** `FocusModeForegroundService` and `TrackingForegroundService` overrode `onTaskRemoved` to stop themselves when the app was swiped from recents — defeating the point of a foreground service. Removing the overrides lets the native countdown keep ticking and the notification persist after task removal. Added a JVM unit test that guards against re-introducing a self-stopping override.
- **Android keyboard tracking:** debounce the IME-open height sampling (200ms) so the global add-task bar lands at its final position instead of parking mid-page from a partial `innerHeight - visualViewport.height` reading; commit synchronously on fall-back-to-zero so the bar drops the instant the IME closes.
- **E2E flake:** raise two timeouts that hit their limit on saturated runners without indicating a real regression (SuperSync final-icon `waitFor` 10s→30s; repeat-task #6230 post-midnight visibility 30s→60s).

## Known follow-up (not in scope here)

After swipe + reopen mid-focus-session, the native countdown/notification persist correctly, but the **in-app** focus UI starts fresh — focus state is in-memory only and there's no native→JS readback on resume (unlike time-tracking, which reconciles via `getTrackingElapsed()`). Self-healing (native timer completes; next session resets the service). Worth a separate PR mirroring the tracking resume pattern if desired.

## Test plan

- [x] `cd android && ./gradlew :app:testPlayDebugUnitTest --tests "*ForegroundServiceTaskRemovalTest"` — passes
- [ ] Manual (device): start a timer / pomodoro, swipe the app from recents → notification persists and keeps counting down; completion notification still fires
- [ ] Manual (device): open the keyboard → add-task bar settles at the final position (not mid-page) and drops immediately when the IME closes
- [ ] CI: the two adjusted e2e specs pass