### PR TITLE
fix(ios): reconcile time tracking and focus mode on app resume

### DIFF
--- a/docs/plans/2026-05-27-ios-background-time-tracking.md
+++ b/docs/plans/2026-05-27-ios-background-time-tracking.md
@@ -14,9 +14,10 @@ no equivalent primitive exists on iOS (silent-audio / location
 
 ## Strategy: wall-clock reconciliation on resume
 
-Trust `Date.now()` deltas. On `pause` flush whatever we have; on `resume`
-compute the wall-clock gap and credit it (capped) to the active task, then
-nudge the focus-mode reducer so its UI snaps to truth.
+Trust `Date.now()` deltas. On `pause` persist whatever we have (handled by the
+existing `main.ts` `appStateChange` listener, inside its `BackgroundTask`
+budget); on `resume` compute the wall-clock gap and credit it (capped) to the
+active task, then nudge the focus-mode reducer so its UI snaps to truth.
 
 The codebase already exposes the three primitives this needs:
 
@@ -30,25 +31,31 @@ The codebase already exposes the three primitives this needs:
 
 ## Multi-review findings folded in
 
-This plan was reviewed by four parallel reviewers (approach / sync /
-iOS-platform / test-strategy) plus a gemini CLI bonus voice. Adjustments
-from that review:
+This plan was reviewed by parallel reviewers across two rounds (plan review,
+then a post-implementation code review). Adjustments:
 
 1. **Cap raised from 30 min → 4 h.** 30 min silently swallowed legitimate
    long sessions; 4 h bounds an overnight-charging scenario (~16 h) but
    keeps an in-flight workday whole. Tunable post-feedback.
-2. **Pause-flush awaits operation persistence.** `flushAccumulatedTimeSpent()`
-   only dispatches actions; the IDB write happens later via
-   `OperationWriteFlushService.flushPendingWrites()`. iOS gives ~5 s after
-   `didEnterBackground` and the existing `main.ts:497`
-   `BackgroundTask.beforeExit` wrapper budgets that window — the effect
-   awaits `flushPendingWrites()` so the queue drains within it (matches
-   Android's `android-foreground-tracking.effects.ts:296`).
-3. **Test seam via `iosInterface.ts`.** Mirror `androidInterface` with
-   `onPause$` / `onResume$` Subjects, fed from a single Capacitor
-   `appStateChange` listener. Handler bodies are exported pure functions
-   so the spec exercises them directly (no `IS_IOS_NATIVE` gate inside
-   the spec).
+2. **Pause persistence stays in `main.ts`, not a new effect.** An earlier
+   draft added a `flushOnPause$` effect that called
+   `OperationWriteFlushService.flushPendingWrites()`. The post-implementation
+   review found this was (a) a duplicate of the drain `main.ts`'s existing iOS
+   `appStateChange` listener already performs, (b) run *outside* the
+   `BackgroundTask.beforeExit` budget (so unprotected against suspension), and
+   (c) racing the `main.ts` listener — if `main.ts` drained first, the
+   accumulated time the effect dispatched afterwards could be lost. `flushPendingWrites()`
+   also has a 30 s `MAX_WAIT_TIME`, so it is not bounded by the iOS budget.
+   Fix: the only new work needed on pause is dispatching accumulated tracked
+   time, so `flushAccumulatedTimeSpent()` is called inside the existing
+   `main.ts` iOS handler, *before* its budgeted drain. The pause effect is
+   removed entirely.
+3. **Test seam via `iosInterface.ts`.** A small `iosInterface` exposes
+   `onResume$`, fed from a single Capacitor `appStateChange` listener. A plain
+   `Subject` (not `ReplaySubject`): unlike `androidInterface`, the producer is
+   a JS listener registered at bootstrap, so a resume cannot arrive before the
+   effect subscribes. The resume handler body is an exported pure function so
+   the spec exercises it directly (no `IS_IOS_NATIVE` gate inside the spec).
 4. **Conditional focus dispatch.** Skip the `focusModeActions.tick()`
    dispatch unless the focus timer is actually running (`timer.purpose !==
    null && timer.isRunning`). The reducer no-ops anyway, but conditioning
@@ -66,28 +73,32 @@ from that review:
 | File | Purpose |
 |---|---|
 | `src/app/app.constants.ts` | Add `MOBILE_BACKGROUND_IDLE_CAP_MS = 4 * 60 * 60 * 1000`. |
-| `src/app/features/ios/ios-interface.ts` (new) | `iosInterface` with `onPause$` / `onResume$` Subjects; one `appStateChange` listener feeds them when `IS_IOS_NATIVE`. |
-| `src/app/features/ios/store/ios-background-tracking.effects.ts` (new) | Two `{ dispatch: false }` effects gated by `IS_IOS_NATIVE`. Exports pure handler functions for spec. |
-| `src/app/features/ios/store/ios-background-tracking.effects.spec.ts` (new) | Karma spec covering the 8 enumerated edge cases. |
+| `src/main.ts` | In the existing iOS `appStateChange` handler, call `flushAccumulatedTimeSpent()` before the budgeted op-log drain. |
+| `src/app/features/ios/ios-interface.ts` (new) | `iosInterface` with an `onResume$` Subject; one `appStateChange` listener feeds it when `IS_IOS_NATIVE`. |
+| `src/app/features/ios/store/ios-background-tracking.effects.ts` (new) | One `{ dispatch: false }` resume effect gated by `IS_IOS_NATIVE`. Exports the pure handler function for spec. |
+| `src/app/features/ios/store/ios-background-tracking.effects.spec.ts` (new) | Karma spec covering the resume edge cases. |
 | `src/app/root-store/feature-stores.module.ts` | Register effect under `IS_IOS_NATIVE`, beside Android. |
 
-### Effects
+### Pause (in `main.ts`)
 
 ```ts
-// On pause: synchronously dispatch any accumulated time, then drain the
-// op-log write queue inside the BackgroundTask budget claimed by main.ts.
-flushOnPause$ = IS_IOS_NATIVE && createEffect(
-  () => iosInterface.onPause$.pipe(
-    exhaustMap(() =>
-      handleIosPause(this._taskService, this._operationWriteFlush)
-    ),
-  ),
-  { dispatch: false },
-);
+const taskId = await BackgroundTask.beforeExit(async () => {
+  try {
+    // Dispatch accumulated tracked time so it is enqueued before the drain.
+    appInjector?.get(TaskService).flushAccumulatedTimeSpent();
+    await flushPendingOperations('iOS');
+  } catch (e) {
+    Log.err('iOS background: operation flush failed', e);
+  }
+  BackgroundTask.finish({ taskId });
+});
+```
 
-// On resume: credit the wall-clock gap to the active task (capped), reset
-// the anchor, drain accumulated time, then nudge the focus reducer if a
-// session is running.
+### Resume effect
+
+```ts
+// Credit the wall-clock gap to the active task (capped), reset the anchor,
+// drain accumulated time, then nudge the focus reducer if a session is running.
 reconcileOnResume$ = IS_IOS_NATIVE && createEffect(
   () => iosInterface.onResume$.pipe(
     withLatestFrom(this._store.select(selectTimer)),
@@ -104,17 +115,9 @@ reconcileOnResume$ = IS_IOS_NATIVE && createEffect(
 );
 ```
 
-### Pure handler functions
+### Pure handler function
 
 ```ts
-export const handleIosPause = async (
-  taskService: TaskService,
-  operationWriteFlush: OperationWriteFlushService,
-): Promise<void> => {
-  taskService.flushAccumulatedTimeSpent();
-  await operationWriteFlush.flushPendingWrites();
-};
-
 export const handleIosResume = (
   globalTracking: GlobalTrackingIntervalService,
   taskService: TaskService,
@@ -132,9 +135,9 @@ export const handleIosResume = (
 
 ## Sync / lint correctness
 
-- Both effects are `{ dispatch: false }` and source from `iosInterface`
-  Subjects, not `Actions` — no `LOCAL_ACTIONS`/`Actions` injection,
-  `no-actions-in-effects` clean. `require-hydration-guard` exempts
+- The resume effect is `{ dispatch: false }` and sources from the
+  `iosInterface` Subject, not `Actions` — no `LOCAL_ACTIONS`/`Actions`
+  injection, `no-actions-in-effects` clean. `require-hydration-guard` exempts
   `{ dispatch: false }`.
 - `addTimeSpent` and `focusModeActions.tick` are non-persistent
   (`time-tracking.actions.ts:70` comment confirms; `tick` has no
@@ -167,8 +170,6 @@ Manual (no Capacitor `appStateChange` simulation precedent in `e2e/`):
 
 Automated (in `ios-background-tracking.effects.spec.ts`):
 
-- `handleIosPause` calls `flushAccumulatedTimeSpent` then awaits
-  `flushPendingWrites`.
 - `handleIosResume` calls `triggerWakeUpTick(4h)` →
   `resetTrackingStart` → `flushAccumulatedTimeSpent` in order.
 - `handleIosResume` dispatches `focusModeActions.tick()` when timer is
@@ -178,5 +179,7 @@ Automated (in `ios-background-tracking.effects.spec.ts`):
   (paused / BreakOffer).
 - Cap exactly at 4 h returns capped duration (delegated to existing
   `global-tracking-interval.service.spec.ts`).
-- `flushPendingWrites` rejection in `handleIosPause` propagates (caller
-  decides — the effect's `exhaustMap` swallows + logs).
+
+The pause path (accumulated-time flush in `main.ts`) has no new unit test —
+it reuses the already-covered `flushAccumulatedTimeSpent` /
+`flushPendingWrites` machinery; verified manually on device.

--- a/docs/plans/2026-05-27-ios-background-time-tracking.md
+++ b/docs/plans/2026-05-27-ios-background-time-tracking.md
@@ -1,0 +1,182 @@
+# iOS background time-tracking — implementation plan
+
+Closes #7824 / tracked in #7826.
+
+## Problem
+
+On iOS, time tracking and the focus-mode timer freeze when the app is
+backgrounded. The WKWebView's WebContent process is suspended within seconds
+of `applicationDidEnterBackground`, halting `interval(1000)` and every other
+JS timer. Android works around this with a native `TrackingForegroundService`;
+no equivalent primitive exists on iOS (silent-audio / location
+`UIBackgroundModes` are App Store violations for a time tracker, and
+`beginBackgroundTask` does not keep the WebView ticking).
+
+## Strategy: wall-clock reconciliation on resume
+
+Trust `Date.now()` deltas. On `pause` flush whatever we have; on `resume`
+compute the wall-clock gap and credit it (capped) to the active task, then
+nudge the focus-mode reducer so its UI snaps to truth.
+
+The codebase already exposes the three primitives this needs:
+
+- `GlobalTrackingIntervalService._currentTrackingStart` — wall-clock anchor;
+  survives JS suspension because nothing mutates it while suspended.
+- `triggerWakeUpTick(maxDurationMs)` — emits a capped delta into `tick$`,
+  consumed by `TaskService` via the existing `addTimeSpent` path.
+- Focus reducer `tick` action — recomputes `elapsed = Date.now() - startedAt`
+  on every dispatch (`focus-mode.reducer.ts:62-63`), so a single dispatch
+  self-corrects regardless of how many ticks were missed.
+
+## Multi-review findings folded in
+
+This plan was reviewed by four parallel reviewers (approach / sync /
+iOS-platform / test-strategy) plus a gemini CLI bonus voice. Adjustments
+from that review:
+
+1. **Cap raised from 30 min → 4 h.** 30 min silently swallowed legitimate
+   long sessions; 4 h bounds an overnight-charging scenario (~16 h) but
+   keeps an in-flight workday whole. Tunable post-feedback.
+2. **Pause-flush awaits operation persistence.** `flushAccumulatedTimeSpent()`
+   only dispatches actions; the IDB write happens later via
+   `OperationWriteFlushService.flushPendingWrites()`. iOS gives ~5 s after
+   `didEnterBackground` and the existing `main.ts:497`
+   `BackgroundTask.beforeExit` wrapper budgets that window — the effect
+   awaits `flushPendingWrites()` so the queue drains within it (matches
+   Android's `android-foreground-tracking.effects.ts:296`).
+3. **Test seam via `iosInterface.ts`.** Mirror `androidInterface` with
+   `onPause$` / `onResume$` Subjects, fed from a single Capacitor
+   `appStateChange` listener. Handler bodies are exported pure functions
+   so the spec exercises them directly (no `IS_IOS_NATIVE` gate inside
+   the spec).
+4. **Conditional focus dispatch.** Skip the `focusModeActions.tick()`
+   dispatch unless the focus timer is actually running (`timer.purpose !==
+   null && timer.isRunning`). The reducer no-ops anyway, but conditioning
+   avoids spurious action noise.
+5. **Reset anchor after wake-up tick.** Android resets
+   `_currentTrackingStart` after a sync (`android-foreground-tracking.effects.ts:548`)
+   to prevent double-counting. The iOS effect calls `resetTrackingStart()`
+   after `triggerWakeUpTick(cap)` so the leftover (uncapped) remainder
+   doesn't bleed into the next 1 s interval tick.
+
+## Implementation
+
+### Files
+
+| File | Purpose |
+|---|---|
+| `src/app/app.constants.ts` | Add `MOBILE_BACKGROUND_IDLE_CAP_MS = 4 * 60 * 60 * 1000`. |
+| `src/app/features/ios/ios-interface.ts` (new) | `iosInterface` with `onPause$` / `onResume$` Subjects; one `appStateChange` listener feeds them when `IS_IOS_NATIVE`. |
+| `src/app/features/ios/store/ios-background-tracking.effects.ts` (new) | Two `{ dispatch: false }` effects gated by `IS_IOS_NATIVE`. Exports pure handler functions for spec. |
+| `src/app/features/ios/store/ios-background-tracking.effects.spec.ts` (new) | Karma spec covering the 8 enumerated edge cases. |
+| `src/app/root-store/feature-stores.module.ts` | Register effect under `IS_IOS_NATIVE`, beside Android. |
+
+### Effects
+
+```ts
+// On pause: synchronously dispatch any accumulated time, then drain the
+// op-log write queue inside the BackgroundTask budget claimed by main.ts.
+flushOnPause$ = IS_IOS_NATIVE && createEffect(
+  () => iosInterface.onPause$.pipe(
+    exhaustMap(() =>
+      handleIosPause(this._taskService, this._operationWriteFlush)
+    ),
+  ),
+  { dispatch: false },
+);
+
+// On resume: credit the wall-clock gap to the active task (capped), reset
+// the anchor, drain accumulated time, then nudge the focus reducer if a
+// session is running.
+reconcileOnResume$ = IS_IOS_NATIVE && createEffect(
+  () => iosInterface.onResume$.pipe(
+    withLatestFrom(this._store.select(selectTimer)),
+    tap(([, timer]) =>
+      handleIosResume(
+        this._globalTrackingIntervalService,
+        this._taskService,
+        this._store,
+        timer,
+      )
+    ),
+  ),
+  { dispatch: false },
+);
+```
+
+### Pure handler functions
+
+```ts
+export const handleIosPause = async (
+  taskService: TaskService,
+  operationWriteFlush: OperationWriteFlushService,
+): Promise<void> => {
+  taskService.flushAccumulatedTimeSpent();
+  await operationWriteFlush.flushPendingWrites();
+};
+
+export const handleIosResume = (
+  globalTracking: GlobalTrackingIntervalService,
+  taskService: TaskService,
+  store: Store,
+  timer: TimerState,
+): void => {
+  globalTracking.triggerWakeUpTick(MOBILE_BACKGROUND_IDLE_CAP_MS);
+  globalTracking.resetTrackingStart();
+  taskService.flushAccumulatedTimeSpent();
+  if (timer.purpose !== null && timer.isRunning) {
+    store.dispatch(focusModeActions.tick());
+  }
+};
+```
+
+## Sync / lint correctness
+
+- Both effects are `{ dispatch: false }` and source from `iosInterface`
+  Subjects, not `Actions` — no `LOCAL_ACTIONS`/`Actions` injection,
+  `no-actions-in-effects` clean. `require-hydration-guard` exempts
+  `{ dispatch: false }`.
+- `addTimeSpent` and `focusModeActions.tick` are non-persistent
+  (`time-tracking.actions.ts:70` comment confirms; `tick` has no
+  `meta.isPersistent`) — no op-log entries replay on other devices.
+- Only the batched `syncTimeSpent` from `flushAccumulatedTimeSpent`
+  produces an op-log entry — one per resume, not per minute.
+- `task.service.ts:226` already gates the `tick$` subscriber on
+  `isDataImportInProgress$`, so resume during a `SYNC_IMPORT` window
+  is silently dropped (correct).
+
+## Out of scope (separate issues)
+
+- "You were away N hours, add it?" confirm dialog when cap is hit.
+- Persisting `_currentTrackingStart` to `Capacitor Preferences` so cold-
+  start after WebView kill can still reconcile.
+- Native iOS Live Activity / Dynamic Island timer.
+- Mac Catalyst tuning (`Capacitor.getPlatform() === 'ios'` also matches
+  Catalyst; behavior is harmless there, just unnecessary).
+
+## Acceptance criteria
+
+Manual (no Capacitor `appStateChange` simulation precedent in `e2e/`):
+
+- Lock phone ~5 min while tracking a task → `task.timeSpent` advances ~5 min.
+- Lock phone 5 h → advances ~4 h (capped at `MOBILE_BACKGROUND_IDLE_CAP_MS`).
+- Focus session backgrounded 2 min → on resume, focus timer shows correct
+  `elapsed`.
+- No regression on Android (effects don't fire — `IS_IOS_NATIVE` is false).
+- No regression on web / desktop (same gate).
+
+Automated (in `ios-background-tracking.effects.spec.ts`):
+
+- `handleIosPause` calls `flushAccumulatedTimeSpent` then awaits
+  `flushPendingWrites`.
+- `handleIosResume` calls `triggerWakeUpTick(4h)` →
+  `resetTrackingStart` → `flushAccumulatedTimeSpent` in order.
+- `handleIosResume` dispatches `focusModeActions.tick()` when timer is
+  running.
+- `handleIosResume` does NOT dispatch when `timer.purpose === null`.
+- `handleIosResume` does NOT dispatch when `timer.isRunning === false`
+  (paused / BreakOffer).
+- Cap exactly at 4 h returns capped duration (delegated to existing
+  `global-tracking-interval.service.spec.ts`).
+- `flushPendingWrites` rejection in `handleIosPause` propagates (caller
+  decides — the effect's `exhaustMap` swallows + logs).

--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -12,6 +12,11 @@ export const TRACKING_INTERVAL = 1000;
 
 export const DRAG_DELAY_FOR_TOUCH = 500;
 
+// Maximum wall-clock gap credited on iOS resume when the WebView was suspended
+// in the background. Larger gaps are capped to this value so an overnight
+// charge can't silently add 8 h to the active task.
+export const MOBILE_BACKGROUND_IDLE_CAP_MS = 4 * 60 * 60 * 1000;
+
 // TODO use
 // const CORS_SKIP_EXTRA_HEADER_PROP = 'sp_cors_skip' as const;
 // export const CORS_SKIP_EXTRA_HEADERS: { [name: string]: string } = IS_ANDROID_WEB_VIEW

--- a/src/app/features/ios/ios-interface.ts
+++ b/src/app/features/ios/ios-interface.ts
@@ -1,25 +1,23 @@
-import { ReplaySubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { App as CapacitorApp } from '@capacitor/app';
 import { IS_IOS_NATIVE } from '../../util/is-native-platform';
 
 export interface IosInterface {
-  onPause$: Subject<void>;
-  // ReplaySubject so a cold-start onResume emission arriving before the JS
-  // subscriber attaches is still delivered. Mirrors androidInterface.
-  onResume$: ReplaySubject<void>;
+  onResume$: Subject<void>;
 }
 
+// Plain Subject (not ReplaySubject): unlike androidInterface, the producer is a
+// JS appStateChange listener registered at app bootstrap, so a resume can never
+// be delivered before the effect has subscribed. Pause persistence is handled
+// in main.ts inside the BackgroundTask.beforeExit budget, not here.
 export const iosInterface: IosInterface = {
-  onPause$: new Subject<void>(),
-  onResume$: new ReplaySubject<void>(1),
+  onResume$: new Subject<void>(),
 };
 
 if (IS_IOS_NATIVE) {
   CapacitorApp.addListener('appStateChange', ({ isActive }) => {
     if (isActive) {
       iosInterface.onResume$.next();
-    } else {
-      iosInterface.onPause$.next();
     }
   });
 }

--- a/src/app/features/ios/ios-interface.ts
+++ b/src/app/features/ios/ios-interface.ts
@@ -1,0 +1,25 @@
+import { ReplaySubject, Subject } from 'rxjs';
+import { App as CapacitorApp } from '@capacitor/app';
+import { IS_IOS_NATIVE } from '../../util/is-native-platform';
+
+export interface IosInterface {
+  onPause$: Subject<void>;
+  // ReplaySubject so a cold-start onResume emission arriving before the JS
+  // subscriber attaches is still delivered. Mirrors androidInterface.
+  onResume$: ReplaySubject<void>;
+}
+
+export const iosInterface: IosInterface = {
+  onPause$: new Subject<void>(),
+  onResume$: new ReplaySubject<void>(1),
+};
+
+if (IS_IOS_NATIVE) {
+  CapacitorApp.addListener('appStateChange', ({ isActive }) => {
+    if (isActive) {
+      iosInterface.onResume$.next();
+    } else {
+      iosInterface.onPause$.next();
+    }
+  });
+}

--- a/src/app/features/ios/store/ios-background-tracking.effects.spec.ts
+++ b/src/app/features/ios/store/ios-background-tracking.effects.spec.ts
@@ -1,10 +1,11 @@
 import { Store } from '@ngrx/store';
+import { of, Subject, Subscription } from 'rxjs';
 import { TimerState } from '../../focus-mode/focus-mode.model';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { TaskService } from '../../tasks/task.service';
 import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
 import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
-import { handleIosResume } from './ios-background-tracking.effects';
+import { handleIosResume, reconcileOnResume } from './ios-background-tracking.effects';
 
 // Effect creation is gated by IS_IOS_NATIVE (false under Karma), so the spec
 // drives the handler body directly. Mirrors the precedent in
@@ -102,6 +103,73 @@ describe('IosBackgroundTrackingEffects', () => {
       handleIosResume(globalTracking, taskService, store, breakOfferTimer);
 
       expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // Covers the effect pipe itself (onResume$ → withLatestFrom(selectTimer) →
+  // handler). The effect field is `false` under Karma (IS_IOS_NATIVE gate), so
+  // we exercise the extracted `reconcileOnResume` factory directly.
+  describe('reconcileOnResume (effect wiring)', () => {
+    let globalTracking: jasmine.SpyObj<GlobalTrackingIntervalService>;
+    let taskService: jasmine.SpyObj<TaskService>;
+    let store: jasmine.SpyObj<Store>;
+    let onResume$: Subject<void>;
+    let sub: Subscription;
+
+    const runningWorkTimer: TimerState = {
+      isRunning: true,
+      startedAt: Date.now() - 60_000,
+      elapsed: 60_000,
+      duration: 25 * 60_000,
+      purpose: 'work',
+    };
+
+    const idleTimer: TimerState = {
+      isRunning: false,
+      startedAt: null,
+      elapsed: 0,
+      duration: 0,
+      purpose: null,
+    };
+
+    beforeEach(() => {
+      globalTracking = jasmine.createSpyObj('GlobalTrackingIntervalService', [
+        'triggerWakeUpTick',
+        'resetTrackingStart',
+      ]);
+      globalTracking.triggerWakeUpTick.and.returnValue({
+        duration: 0,
+        date: '2026-05-27',
+        timestamp: Date.now(),
+      });
+      taskService = jasmine.createSpyObj('TaskService', ['flushAccumulatedTimeSpent']);
+      store = jasmine.createSpyObj('Store', ['select', 'dispatch']);
+      onResume$ = new Subject<void>();
+    });
+
+    afterEach(() => sub?.unsubscribe());
+
+    it('reads the latest timer off the store and reconciles on each resume', () => {
+      store.select.and.returnValue(of(runningWorkTimer));
+      sub = reconcileOnResume(onResume$, store, globalTracking, taskService).subscribe();
+
+      onResume$.next();
+
+      expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledOnceWith(
+        MOBILE_BACKGROUND_IDLE_CAP_MS,
+      );
+      expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(1);
+      expect(store.dispatch).toHaveBeenCalledOnceWith(focusModeActions.tick());
+    });
+
+    it('does not dispatch a focus tick when the store timer is idle', () => {
+      store.select.and.returnValue(of(idleTimer));
+      sub = reconcileOnResume(onResume$, store, globalTracking, taskService).subscribe();
+
+      onResume$.next();
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+      expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/features/ios/store/ios-background-tracking.effects.spec.ts
+++ b/src/app/features/ios/store/ios-background-tracking.effects.spec.ts
@@ -1,75 +1,16 @@
 import { Store } from '@ngrx/store';
 import { TimerState } from '../../focus-mode/focus-mode.model';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
-import { OperationWriteFlushService } from '../../../op-log/sync/operation-write-flush.service';
 import { TaskService } from '../../tasks/task.service';
 import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
 import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
-import { handleIosPause, handleIosResume } from './ios-background-tracking.effects';
+import { handleIosResume } from './ios-background-tracking.effects';
 
 // Effect creation is gated by IS_IOS_NATIVE (false under Karma), so the spec
-// drives the handler bodies directly. Mirrors the precedent in
+// drives the handler body directly. Mirrors the precedent in
 // android-foreground-tracking.effects.spec.ts.
 
 describe('IosBackgroundTrackingEffects', () => {
-  describe('handleIosPause', () => {
-    let taskService: jasmine.SpyObj<TaskService>;
-    let operationWriteFlush: jasmine.SpyObj<OperationWriteFlushService>;
-
-    beforeEach(() => {
-      taskService = jasmine.createSpyObj('TaskService', ['flushAccumulatedTimeSpent']);
-      operationWriteFlush = jasmine.createSpyObj('OperationWriteFlushService', [
-        'flushPendingWrites',
-      ]);
-      operationWriteFlush.flushPendingWrites.and.returnValue(Promise.resolve());
-    });
-
-    it('flushes accumulated time before draining the write queue', async () => {
-      const callOrder: string[] = [];
-      taskService.flushAccumulatedTimeSpent.and.callFake(() =>
-        callOrder.push('flushAccumulated'),
-      );
-      operationWriteFlush.flushPendingWrites.and.callFake(() => {
-        callOrder.push('flushWrites');
-        return Promise.resolve();
-      });
-
-      await handleIosPause(taskService, operationWriteFlush);
-
-      expect(callOrder).toEqual(['flushAccumulated', 'flushWrites']);
-    });
-
-    it('awaits the write-queue drain', async () => {
-      let resolveFlush!: () => void;
-      operationWriteFlush.flushPendingWrites.and.returnValue(
-        new Promise((resolve) => {
-          resolveFlush = resolve;
-        }),
-      );
-
-      let settled = false;
-      const promise = handleIosPause(taskService, operationWriteFlush).then(() => {
-        settled = true;
-      });
-      await Promise.resolve();
-      expect(settled).toBeFalse();
-
-      resolveFlush();
-      await promise;
-      expect(settled).toBeTrue();
-    });
-
-    it('propagates a write-queue rejection so the effect can log it', async () => {
-      const err = new Error('IDB unavailable');
-      operationWriteFlush.flushPendingWrites.and.returnValue(Promise.reject(err));
-
-      await expectAsync(
-        handleIosPause(taskService, operationWriteFlush),
-      ).toBeRejectedWith(err);
-      expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('handleIosResume', () => {
     let globalTracking: jasmine.SpyObj<GlobalTrackingIntervalService>;
     let taskService: jasmine.SpyObj<TaskService>;

--- a/src/app/features/ios/store/ios-background-tracking.effects.spec.ts
+++ b/src/app/features/ios/store/ios-background-tracking.effects.spec.ts
@@ -1,0 +1,166 @@
+import { Store } from '@ngrx/store';
+import { TimerState } from '../../focus-mode/focus-mode.model';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+import { OperationWriteFlushService } from '../../../op-log/sync/operation-write-flush.service';
+import { TaskService } from '../../tasks/task.service';
+import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
+import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
+import { handleIosPause, handleIosResume } from './ios-background-tracking.effects';
+
+// Effect creation is gated by IS_IOS_NATIVE (false under Karma), so the spec
+// drives the handler bodies directly. Mirrors the precedent in
+// android-foreground-tracking.effects.spec.ts.
+
+describe('IosBackgroundTrackingEffects', () => {
+  describe('handleIosPause', () => {
+    let taskService: jasmine.SpyObj<TaskService>;
+    let operationWriteFlush: jasmine.SpyObj<OperationWriteFlushService>;
+
+    beforeEach(() => {
+      taskService = jasmine.createSpyObj('TaskService', ['flushAccumulatedTimeSpent']);
+      operationWriteFlush = jasmine.createSpyObj('OperationWriteFlushService', [
+        'flushPendingWrites',
+      ]);
+      operationWriteFlush.flushPendingWrites.and.returnValue(Promise.resolve());
+    });
+
+    it('flushes accumulated time before draining the write queue', async () => {
+      const callOrder: string[] = [];
+      taskService.flushAccumulatedTimeSpent.and.callFake(() =>
+        callOrder.push('flushAccumulated'),
+      );
+      operationWriteFlush.flushPendingWrites.and.callFake(() => {
+        callOrder.push('flushWrites');
+        return Promise.resolve();
+      });
+
+      await handleIosPause(taskService, operationWriteFlush);
+
+      expect(callOrder).toEqual(['flushAccumulated', 'flushWrites']);
+    });
+
+    it('awaits the write-queue drain', async () => {
+      let resolveFlush!: () => void;
+      operationWriteFlush.flushPendingWrites.and.returnValue(
+        new Promise((resolve) => {
+          resolveFlush = resolve;
+        }),
+      );
+
+      let settled = false;
+      const promise = handleIosPause(taskService, operationWriteFlush).then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBeFalse();
+
+      resolveFlush();
+      await promise;
+      expect(settled).toBeTrue();
+    });
+
+    it('propagates a write-queue rejection so the effect can log it', async () => {
+      const err = new Error('IDB unavailable');
+      operationWriteFlush.flushPendingWrites.and.returnValue(Promise.reject(err));
+
+      await expectAsync(
+        handleIosPause(taskService, operationWriteFlush),
+      ).toBeRejectedWith(err);
+      expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleIosResume', () => {
+    let globalTracking: jasmine.SpyObj<GlobalTrackingIntervalService>;
+    let taskService: jasmine.SpyObj<TaskService>;
+    let store: jasmine.SpyObj<Store>;
+
+    const idleTimer: TimerState = {
+      isRunning: false,
+      startedAt: null,
+      elapsed: 0,
+      duration: 0,
+      purpose: null,
+    };
+
+    const runningWorkTimer: TimerState = {
+      isRunning: true,
+      startedAt: Date.now() - 60_000,
+      elapsed: 60_000,
+      duration: 25 * 60_000,
+      purpose: 'work',
+    };
+
+    const pausedWorkTimer: TimerState = {
+      ...runningWorkTimer,
+      isRunning: false,
+    };
+
+    const breakOfferTimer: TimerState = {
+      isRunning: false,
+      startedAt: null,
+      elapsed: 0,
+      duration: 5 * 60_000,
+      purpose: 'break',
+    };
+
+    beforeEach(() => {
+      globalTracking = jasmine.createSpyObj('GlobalTrackingIntervalService', [
+        'triggerWakeUpTick',
+        'resetTrackingStart',
+      ]);
+      globalTracking.triggerWakeUpTick.and.returnValue({
+        duration: 0,
+        date: '2026-05-27',
+        timestamp: Date.now(),
+      });
+      taskService = jasmine.createSpyObj('TaskService', ['flushAccumulatedTimeSpent']);
+      store = jasmine.createSpyObj('Store', ['dispatch']);
+    });
+
+    it('triggers wake-up tick with the configured cap then resets the anchor', () => {
+      const callOrder: string[] = [];
+      globalTracking.triggerWakeUpTick.and.callFake(() => {
+        callOrder.push('wakeUp');
+        return { duration: 0, date: '2026-05-27', timestamp: Date.now() };
+      });
+      globalTracking.resetTrackingStart.and.callFake(() => callOrder.push('reset'));
+      taskService.flushAccumulatedTimeSpent.and.callFake(() => callOrder.push('flush'));
+
+      handleIosResume(globalTracking, taskService, store, runningWorkTimer);
+
+      expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledOnceWith(
+        MOBILE_BACKGROUND_IDLE_CAP_MS,
+      );
+      expect(callOrder).toEqual(['wakeUp', 'reset', 'flush']);
+    });
+
+    it('dispatches focus tick when a work session is running', () => {
+      handleIosResume(globalTracking, taskService, store, runningWorkTimer);
+
+      expect(store.dispatch).toHaveBeenCalledOnceWith(focusModeActions.tick());
+    });
+
+    it('does not dispatch focus tick when no session is active', () => {
+      handleIosResume(globalTracking, taskService, store, idleTimer);
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+      // But the reconcile work still runs — a backgrounded task without focus
+      // mode still needs its time credited.
+      expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledTimes(1);
+      expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not dispatch focus tick when the session is paused', () => {
+      handleIosResume(globalTracking, taskService, store, pausedWorkTimer);
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch focus tick on the BreakOffer screen', () => {
+      handleIosResume(globalTracking, taskService, store, breakOfferTimer);
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/ios/store/ios-background-tracking.effects.ts
+++ b/src/app/features/ios/store/ios-background-tracking.effects.ts
@@ -1,35 +1,15 @@
 import { inject, Injectable } from '@angular/core';
 import { createEffect } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { exhaustMap, tap, withLatestFrom } from 'rxjs/operators';
+import { tap, withLatestFrom } from 'rxjs/operators';
 import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
 import { IS_IOS_NATIVE } from '../../../util/is-native-platform';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
-import { OperationWriteFlushService } from '../../../op-log/sync/operation-write-flush.service';
 import { TaskService } from '../../tasks/task.service';
 import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
 import { selectTimer } from '../../focus-mode/store/focus-mode.selectors';
 import { TimerState } from '../../focus-mode/focus-mode.model';
-import { Log } from '../../../core/log';
 import { iosInterface } from '../ios-interface';
-
-/**
- * Synchronously dispatch any accumulated tracked time, then drain the op-log
- * write queue. iOS budgets ~5 s after `didEnterBackground` before suspending
- * the WebView; the existing `main.ts` `appStateChange` listener wraps that
- * window in `BackgroundTask.beforeExit`, and this handler completes inside
- * the same budget.
- *
- * Exported as a plain function so the spec can drive it directly without
- * tripping the `IS_IOS_NATIVE` gate on `createEffect`.
- */
-export const handleIosPause = async (
-  taskService: TaskService,
-  operationWriteFlush: OperationWriteFlushService,
-): Promise<void> => {
-  taskService.flushAccumulatedTimeSpent();
-  await operationWriteFlush.flushPendingWrites();
-};
 
 /**
  * Credit the wall-clock gap (capped) to the active task, reset the tracking
@@ -38,9 +18,15 @@ export const handleIosPause = async (
  * session is running (the reducer recomputes elapsed from `Date.now() -
  * startedAt`, so one dispatch self-corrects regardless of missed ticks).
  *
+ * Pause persistence is handled in `main.ts`'s `appStateChange` listener inside
+ * the `BackgroundTask.beforeExit` budget — this effect only handles resume.
+ *
  * Sync-window race: `task.service.ts` already gates the `tick$` subscriber
  * on `isDataImportInProgress$`, so this dispatch is silently dropped during
  * a SYNC_IMPORT — by design.
+ *
+ * Exported as a plain function so the spec can drive it directly without
+ * tripping the `IS_IOS_NATIVE` gate on `createEffect`.
  */
 export const handleIosResume = (
   globalTracking: GlobalTrackingIntervalService,
@@ -61,24 +47,6 @@ export class IosBackgroundTrackingEffects {
   private _store = inject(Store);
   private _taskService = inject(TaskService);
   private _globalTrackingIntervalService = inject(GlobalTrackingIntervalService);
-  private _operationWriteFlush = inject(OperationWriteFlushService);
-
-  flushOnPause$ =
-    IS_IOS_NATIVE &&
-    createEffect(
-      () =>
-        iosInterface.onPause$.pipe(
-          // exhaustMap: rapid pause events (control-center swipe, app switcher)
-          // coalesce onto a single in-flight flush. Safe because the flush is
-          // idempotent — accumulator is cleared in the first pass.
-          exhaustMap(() =>
-            handleIosPause(this._taskService, this._operationWriteFlush).catch((e) => {
-              Log.err('iOS background flush failed', e);
-            }),
-          ),
-        ),
-      { dispatch: false },
-    );
 
   reconcileOnResume$ =
     IS_IOS_NATIVE &&

--- a/src/app/features/ios/store/ios-background-tracking.effects.ts
+++ b/src/app/features/ios/store/ios-background-tracking.effects.ts
@@ -1,0 +1,100 @@
+import { inject, Injectable } from '@angular/core';
+import { createEffect } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { exhaustMap, tap, withLatestFrom } from 'rxjs/operators';
+import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
+import { IS_IOS_NATIVE } from '../../../util/is-native-platform';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+import { OperationWriteFlushService } from '../../../op-log/sync/operation-write-flush.service';
+import { TaskService } from '../../tasks/task.service';
+import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
+import { selectTimer } from '../../focus-mode/store/focus-mode.selectors';
+import { TimerState } from '../../focus-mode/focus-mode.model';
+import { Log } from '../../../core/log';
+import { iosInterface } from '../ios-interface';
+
+/**
+ * Synchronously dispatch any accumulated tracked time, then drain the op-log
+ * write queue. iOS budgets ~5 s after `didEnterBackground` before suspending
+ * the WebView; the existing `main.ts` `appStateChange` listener wraps that
+ * window in `BackgroundTask.beforeExit`, and this handler completes inside
+ * the same budget.
+ *
+ * Exported as a plain function so the spec can drive it directly without
+ * tripping the `IS_IOS_NATIVE` gate on `createEffect`.
+ */
+export const handleIosPause = async (
+  taskService: TaskService,
+  operationWriteFlush: OperationWriteFlushService,
+): Promise<void> => {
+  taskService.flushAccumulatedTimeSpent();
+  await operationWriteFlush.flushPendingWrites();
+};
+
+/**
+ * Credit the wall-clock gap (capped) to the active task, reset the tracking
+ * anchor so the next 1 s interval tick doesn't double-count any uncapped
+ * remainder, flush accumulated time, then nudge the focus-mode reducer if a
+ * session is running (the reducer recomputes elapsed from `Date.now() -
+ * startedAt`, so one dispatch self-corrects regardless of missed ticks).
+ *
+ * Sync-window race: `task.service.ts` already gates the `tick$` subscriber
+ * on `isDataImportInProgress$`, so this dispatch is silently dropped during
+ * a SYNC_IMPORT — by design.
+ */
+export const handleIosResume = (
+  globalTracking: GlobalTrackingIntervalService,
+  taskService: TaskService,
+  store: Store,
+  timer: TimerState,
+): void => {
+  globalTracking.triggerWakeUpTick(MOBILE_BACKGROUND_IDLE_CAP_MS);
+  globalTracking.resetTrackingStart();
+  taskService.flushAccumulatedTimeSpent();
+  if (timer.purpose !== null && timer.isRunning) {
+    store.dispatch(focusModeActions.tick());
+  }
+};
+
+@Injectable()
+export class IosBackgroundTrackingEffects {
+  private _store = inject(Store);
+  private _taskService = inject(TaskService);
+  private _globalTrackingIntervalService = inject(GlobalTrackingIntervalService);
+  private _operationWriteFlush = inject(OperationWriteFlushService);
+
+  flushOnPause$ =
+    IS_IOS_NATIVE &&
+    createEffect(
+      () =>
+        iosInterface.onPause$.pipe(
+          // exhaustMap: rapid pause events (control-center swipe, app switcher)
+          // coalesce onto a single in-flight flush. Safe because the flush is
+          // idempotent — accumulator is cleared in the first pass.
+          exhaustMap(() =>
+            handleIosPause(this._taskService, this._operationWriteFlush).catch((e) => {
+              Log.err('iOS background flush failed', e);
+            }),
+          ),
+        ),
+      { dispatch: false },
+    );
+
+  reconcileOnResume$ =
+    IS_IOS_NATIVE &&
+    createEffect(
+      () =>
+        iosInterface.onResume$.pipe(
+          withLatestFrom(this._store.select(selectTimer)),
+          tap(([, timer]) => {
+            handleIosResume(
+              this._globalTrackingIntervalService,
+              this._taskService,
+              this._store,
+              timer,
+            );
+          }),
+        ),
+      { dispatch: false },
+    );
+}

--- a/src/app/features/ios/store/ios-background-tracking.effects.ts
+++ b/src/app/features/ios/store/ios-background-tracking.effects.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { createEffect } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
 import { tap, withLatestFrom } from 'rxjs/operators';
 import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
 import { IS_IOS_NATIVE } from '../../../util/is-native-platform';
@@ -42,6 +43,23 @@ export const handleIosResume = (
   }
 };
 
+/**
+ * Wire a resume stream to the reconciliation handler, reading the latest focus
+ * timer off the store. Exported (and effect-independent) so the spec can drive
+ * the full pipe — `withLatestFrom(selectTimer)` included — without tripping the
+ * `IS_IOS_NATIVE` gate on `createEffect`.
+ */
+export const reconcileOnResume = (
+  onResume$: Observable<void>,
+  store: Store,
+  globalTracking: GlobalTrackingIntervalService,
+  taskService: TaskService,
+): Observable<unknown> =>
+  onResume$.pipe(
+    withLatestFrom(store.select(selectTimer)),
+    tap(([, timer]) => handleIosResume(globalTracking, taskService, store, timer)),
+  );
+
 @Injectable()
 export class IosBackgroundTrackingEffects {
   private _store = inject(Store);
@@ -52,16 +70,11 @@ export class IosBackgroundTrackingEffects {
     IS_IOS_NATIVE &&
     createEffect(
       () =>
-        iosInterface.onResume$.pipe(
-          withLatestFrom(this._store.select(selectTimer)),
-          tap(([, timer]) => {
-            handleIosResume(
-              this._globalTrackingIntervalService,
-              this._taskService,
-              this._store,
-              timer,
-            );
-          }),
+        reconcileOnResume(
+          iosInterface.onResume$,
+          this._store,
+          this._globalTrackingIntervalService,
+          this._taskService,
         ),
       { dispatch: false },
     );

--- a/src/app/root-store/feature-stores.module.ts
+++ b/src/app/root-store/feature-stores.module.ts
@@ -70,7 +70,8 @@ import { AndroidFocusModeEffects } from '../features/android/store/android-focus
 import { AndroidForegroundTrackingEffects } from '../features/android/store/android-foreground-tracking.effects';
 import { AndroidSyncBridgeEffects } from '../features/android/store/android-sync-bridge.effects';
 import { MobileNotificationEffects } from '../features/mobile/store/mobile-notification.effects';
-import { IS_NATIVE_PLATFORM } from '../util/is-native-platform';
+import { IS_IOS_NATIVE, IS_NATIVE_PLATFORM } from '../util/is-native-platform';
+import { IosBackgroundTrackingEffects } from '../features/ios/store/ios-background-tracking.effects';
 import { NextcloudDeckIssueEffects } from '../features/issue/providers/nextcloud-deck/nextcloud-deck-issue.effects';
 import { CalendarIntegrationEffects } from '../features/calendar-integration/store/calendar-integration.effects';
 import { TimeBlockSyncEffects } from '../features/calendar-integration/time-block/time-block-sync.effects';
@@ -186,6 +187,7 @@ import {
           ]
         : []),
     ]),
+    EffectsModule.forFeature([...(IS_IOS_NATIVE ? [IosBackgroundTrackingEffects] : [])]),
     EffectsModule.forFeature([
       ...(IS_NATIVE_PLATFORM ? [MobileNotificationEffects] : []),
     ]),

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,7 @@ import { initializeMatMenuTouchFix } from './app/features/tasks/task-context-men
 import { Log, SyncLog } from './app/core/log';
 import { setLegacyKdfWarningHandler } from '@sp/sync-core';
 import { OperationWriteFlushService } from './app/op-log/sync/operation-write-flush.service';
+import { TaskService } from './app/features/tasks/task.service';
 import { PluginOAuthRedirectHandler } from './app/plugins/oauth/plugin-oauth-redirect.handler';
 import { OAuthCallbackHandlerService } from './app/imex/sync/oauth-callback-handler.service';
 import { GlobalConfigService } from './app/features/config/global-config.service';
@@ -496,6 +497,10 @@ if (IS_IOS_NATIVE) {
     }
     const taskId = await BackgroundTask.beforeExit(async () => {
       try {
+        // Dispatch any accumulated tracked time so it is enqueued before the
+        // op-log drain below. iOS suspends the WebView seconds after this, so
+        // both the dispatch and the persist must happen inside this budget.
+        appInjector?.get(TaskService).flushAccumulatedTimeSpent();
         await flushPendingOperations('iOS');
       } catch (e) {
         Log.err('iOS background: operation flush failed', e);


### PR DESCRIPTION
## Summary

On iOS, time tracking and the focus-mode countdown froze whenever the app was
backgrounded: WKWebView suspends the WebContent process (and every JS timer)
within seconds of `applicationDidEnterBackground`, and there is no App-Store-legal
way to keep timers running in the background for a time tracker (silent-audio /
location `UIBackgroundModes` would be rejected).

This fixes it with **wall-clock reconciliation on resume** — the only legitimate
iOS pattern:

- **On resume:** credit the elapsed wall-clock gap (capped at
  `MOBILE_BACKGROUND_IDLE_CAP_MS = 4h`) to the active task via the existing
  `GlobalTrackingIntervalService.triggerWakeUpTick()`, reset the tracking anchor
  so the next 1s tick can't double-count, flush accumulated time, and nudge the
  focus reducer (which recomputes `elapsed` from `Date.now() - startedAt`, so one
  dispatch self-corrects any number of missed ticks).
- **On pause:** dispatch accumulated tracked time inside `main.ts`'s existing iOS
  `appStateChange` handler — *before* the op-log drain, *inside* the
  `BackgroundTask.beforeExit` budget — so it is persisted before suspension.

The resume effect is gated by `IS_IOS_NATIVE` and registered only on iOS; the
handler/pipe are exported as pure functions/factories for unit coverage.

## What changed

- `src/app/app.constants.ts` — `MOBILE_BACKGROUND_IDLE_CAP_MS` cap constant.
- `src/main.ts` — flush accumulated tracked time in the budgeted iOS background handler.
- `src/app/features/ios/ios-interface.ts` (new) — Capacitor `appStateChange` → `onResume$`.
- `src/app/features/ios/store/ios-background-tracking.effects.ts` (new) — resume reconciliation effect + pure handler + testable factory.
- `src/app/features/ios/store/ios-background-tracking.effects.spec.ts` (new) — handler + effect-wiring specs.
- `src/app/root-store/feature-stores.module.ts` — `IS_IOS_NATIVE`-gated registration.
- `docs/plans/2026-05-27-ios-background-time-tracking.md` — design notes.

## Sync correctness

The resume effect is `{ dispatch: false }` and sourced from an RxJS subject (not
`Actions`), so `no-actions-in-effects` / `require-hydration-guard` stay clean.
`focusModeActions.tick()` is non-persistent (never enters the op-log); only the
batched `syncTimeSpent` from the flush produces one op per resume. The `tick$`
subscriber is already gated on `isDataImportInProgress$`, so a resume during a
`SYNC_IMPORT` window is correctly dropped.

## Test plan

- [x] Unit: `handleIosResume` credits capped time, resets anchor, flushes, and
      dispatches a focus tick only when a session is running (idle / paused /
      BreakOffer cases covered).
- [x] Unit: resume **effect wiring** (`onResume$ → withLatestFrom(selectTimer) →
      handler`) covered via an extracted factory.
- [x] `tsc --noEmit` clean; surrounding specs (global-tracking-interval,
      focus-mode reducer) green; all touched files lint-clean.
- [ ] **Manual on a real iOS device / simulator** (could not be exercised in CI —
      the native Capacitor `appStateChange` / `BackgroundTask.beforeExit` runtime
      needs hardware):
  - Lock phone ~5 min while tracking → `task.timeSpent` advances ~5 min.
  - Lock phone 5 h → advances ~4 h (capped).
  - Focus session backgrounded ~2 min → on resume the countdown shows correct elapsed.
  - No regression on Android / web / desktop (effects gated by `IS_IOS_NATIVE`).

Closes #7824
Refs #7826