### PR TITLE
feat(take-a-break): add Start break action to break reminder

### DIFF
--- a/src/app/features/take-a-break/take-a-break.service.ts
+++ b/src/app/features/take-a-break/take-a-break.service.ts
@@ -26,7 +26,6 @@ import { GlobalConfigState, TakeABreakConfig } from '../config/global-config.mod
 import { T } from '../../t.const';
 import { NotifyService } from '../../core/notify/notify.service';
 import { UiHelperService } from '../ui-helper/ui-helper.service';
-import { WorkContextService } from '../work-context/work-context.service';
 import { Tick } from '../../core/global-tracking-interval/tick.model';
 import { ofType } from '@ngrx/effects';
 import { idleDialogResult, triggerResetBreakTimer } from '../idle/store/idle.actions';
@@ -57,7 +56,6 @@ export class TakeABreakService {
   private _idleService = inject(IdleService);
   private _actions$ = inject(LOCAL_ACTIONS);
   private _configService = inject(GlobalConfigService);
-  private _workContextService = inject(WorkContextService);
   private _notifyService = inject(NotifyService);
   private _bannerService = inject(BannerService);
   private _chromeExtensionInterfaceService = inject(ChromeExtensionInterfaceService);
@@ -296,8 +294,8 @@ export class TakeABreakService {
           time: msToString(cfg.takeABreak.takeABreakSnoozeTime),
         },
         action: {
-          label: T.F.TIME_TRACKING.B.ALREADY_DID,
-          fn: () => this.resetTimerAndCountAsBreak(),
+          label: T.F.FOCUS_MODE.START_BREAK,
+          fn: () => this.startBreak(),
         },
         action2: {
           label: T.F.TIME_TRACKING.B.SNOOZE,
@@ -324,13 +322,9 @@ export class TakeABreakService {
     this._triggerManualReset$.next(0);
   }
 
-  resetTimerAndCountAsBreak(): void {
-    const min5 = 1000 * 60 * 5;
-    this._workContextService.addToBreakTimeForActiveContext(undefined, min5);
+  startBreak(): void {
+    this._taskService.pauseCurrent();
     this.resetTimer();
-
-    this._triggerLockScreenCounter$.next(false);
-    this._triggerFullscreenBlocker$.next(false);
   }
 
   private _createMessage(duration: number, cfg: TakeABreakConfig): string | undefined {

--- a/src/app/t.const.ts
+++ b/src/app/t.const.ts
@@ -1964,7 +1964,6 @@ const T = {
     },
     TIME_TRACKING: {
       B: {
-        ALREADY_DID: 'F.TIME_TRACKING.B.ALREADY_DID',
         SNOOZE: 'F.TIME_TRACKING.B.SNOOZE'
       },
       B_TTR: {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1964,7 +1964,6 @@
     },
     "TIME_TRACKING": {
       "B": {
-        "ALREADY_DID": "I already did",
         "SNOOZE": "Snooze {{time}}"
       },
       "B_TTR": {


### PR DESCRIPTION
## Summary

Replaces the break reminder's **"I already did"** button with **"Start break"**, which:

1. dismisses the reminder,
2. pauses the active task (`unsetCurrentTask`), and
3. resets the "time without a break" counter.

This is the minimal, honest-break path proposed by @zenoprax in #4068: the break becomes an untracked gap instead of forcing a fabricated 5-minute break entry or leaving the task stopwatch running while you're away. Intentionally scoped down — no break countdown/progress UI, since that overlaps with the existing Focus Mode feature.

## Behavior notes

- **No more flat 5-minute break log.** The old button wrote an arbitrary 5 min to the break-time metrics/daily-summary; "Start break" doesn't (those fields stay manually editable, and real break time still comes from the idle dialog's "Break" option). This is deliberate, per the accuracy motivation in the issue.
- **Pauses an active Focus/Pomodoro session** (the task going set→null triggers `pauseFocusSession`); `pausedTaskId` allows resuming. The task stays selected, so the top-bar ▶ button resumes it.
- The label reuses the existing, already-translated `T.F.FOCUS_MODE.START_BREAK` string.

## Test plan

- [ ] In break-reminder settings, lower `takeABreakMinWorkingTime` to a small value
- [ ] Track a task until the break reminder banner appears
- [ ] Click **Start break** → banner closes, the active task pauses (top-bar button flips to ▶), and the timer resets
- [ ] Confirm the banner does not reappear while paused, and reappears only after resuming and working another full interval
- [ ] Confirm **Snooze** still suppresses the banner for the snooze duration as before

Refs #4068