### PR TITLE
ci: auto-submit iOS and macOS App Store builds for review

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -213,7 +213,7 @@ jobs:
         # .ruby-version file in the repo the action errors out rather than
         # using system Ruby. bundler-cache runs `bundle install` and caches the
         # ~210-gem fastlane tree so it isn't reinstalled each run.
-        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # latest
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -208,22 +208,23 @@ jobs:
           name: sup-ios-release
           path: ${{ runner.temp }}/ipa-output/*.ipa
 
-      - name: Validate App
-        run: |
-          xcrun altool --type ios --validate-app \
-            -f "$RUNNER_TEMP/ipa-output/"*.ipa \
-            -u "${{ secrets.APPLE_ID }}" \
-            -p "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      - name: Install fastlane
+        run: bundle install
 
-      - name: Upload to App Store Connect
-        run: |
-          xcrun altool --type ios --upload-app \
-            -f "$RUNNER_TEMP/ipa-output/"*.ipa \
-            -u "${{ secrets.APPLE_ID }}" \
-            -p "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
+      - name: Prepare App Store release notes
+        run: node tools/prepare-appstore-release-notes.js
+
+      # Upload the IPA to App Store Connect and (for final release tags) submit
+      # it for review with automatic release on approval. Pre-release tags
+      # (RC/beta/alpha) and manual runs only upload the build (TestFlight).
+      - name: Upload to App Store Connect and submit for review
         env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
+          ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
+          ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
+          SUBMIT_FOR_REVIEW: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'RC') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha') }}
+        run: |
+          IPA_PATH="$(ls "$RUNNER_TEMP"/ipa-output/*.ipa | head -n1)"
+          export IPA_PATH
+          echo "Submitting $IPA_PATH (submit_for_review=$SUBMIT_FOR_REVIEW)"
+          bundle exec fastlane ios release

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -209,10 +209,13 @@ jobs:
           path: ${{ runner.temp }}/ipa-output/*.ipa
 
       - name: Set up Ruby and fastlane
-        # Pinned by SHA per repo policy; installs the locked Bundler/gems and
-        # caches them so the ~210-gem fastlane tree isn't reinstalled each run.
+        # Pinned by SHA per repo policy. ruby-version is required: with no
+        # .ruby-version file in the repo the action errors out rather than
+        # using system Ruby. bundler-cache runs `bundle install` and caches the
+        # ~210-gem fastlane tree so it isn't reinstalled each run.
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # latest
         with:
+          ruby-version: '3.3'
           bundler-cache: true
 
       - name: Prepare App Store release notes

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -208,23 +208,35 @@ jobs:
           name: sup-ios-release
           path: ${{ runner.temp }}/ipa-output/*.ipa
 
-      - name: Install fastlane
-        run: bundle install
+      - name: Set up Ruby and fastlane
+        # Pinned by SHA per repo policy; installs the locked Bundler/gems and
+        # caches them so the ~210-gem fastlane tree isn't reinstalled each run.
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # latest
+        with:
+          bundler-cache: true
 
       - name: Prepare App Store release notes
         run: node tools/prepare-appstore-release-notes.js
 
       # Upload the IPA to App Store Connect and (for final release tags) submit
-      # it for review with automatic release on approval. Pre-release tags
-      # (RC/beta/alpha) and manual runs only upload the build (TestFlight).
+      # it for review with automatic release on approval. Pre-release tags (any
+      # tag containing "-", e.g. -rc.0/-beta.1) and manual runs only upload the
+      # build (TestFlight). The "-" check is case-insensitive by construction,
+      # unlike contains(...,'RC'); the repo's RC tags are mostly lowercase.
       - name: Upload to App Store Connect and submit for review
         env:
           ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
           ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
           ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
-          SUBMIT_FOR_REVIEW: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'RC') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha') }}
+          SUBMIT_FOR_REVIEW: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
         run: |
-          IPA_PATH="$(ls "$RUNNER_TEMP"/ipa-output/*.ipa | head -n1)"
-          export IPA_PATH
+          set -euo pipefail
+          shopt -s nullglob
+          ipas=("$RUNNER_TEMP"/ipa-output/*.ipa)
+          if [ ${#ipas[@]} -ne 1 ]; then
+            echo "Expected exactly 1 .ipa, found ${#ipas[@]}: ${ipas[*]:-none}"
+            exit 1
+          fi
+          export IPA_PATH="${ipas[0]}"
           echo "Submitting $IPA_PATH (submit_for_review=$SUBMIT_FOR_REVIEW)"
           bundle exec fastlane ios release

--- a/.github/workflows/build-publish-to-mac-store-on-release.yml
+++ b/.github/workflows/build-publish-to-mac-store-on-release.yml
@@ -178,10 +178,13 @@ jobs:
         shell: bash
 
       - name: Set up Ruby and fastlane
-        # Pinned by SHA per repo policy; installs the locked Bundler/gems and
-        # caches them so the ~210-gem fastlane tree isn't reinstalled each run.
+        # Pinned by SHA per repo policy. ruby-version is required: with no
+        # .ruby-version file in the repo the action errors out rather than
+        # using system Ruby. bundler-cache runs `bundle install` and caches the
+        # ~210-gem fastlane tree so it isn't reinstalled each run.
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # latest
         with:
+          ruby-version: '3.3'
           bundler-cache: true
 
       - name: Prepare App Store release notes

--- a/.github/workflows/build-publish-to-mac-store-on-release.yml
+++ b/.github/workflows/build-publish-to-mac-store-on-release.yml
@@ -182,7 +182,7 @@ jobs:
         # .ruby-version file in the repo the action errors out rather than
         # using system Ruby. bundler-cache runs `bundle install` and caches the
         # ~210-gem fastlane tree so it isn't reinstalled each run.
-        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # latest
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/build-publish-to-mac-store-on-release.yml
+++ b/.github/workflows/build-publish-to-mac-store-on-release.yml
@@ -23,8 +23,13 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
+            rubygems.org:443
+            index.rubygems.org:443
             www.apple.com:443
             appstoreconnect.apple.com:443
+            api.appstoreconnect.apple.com:443
+            contentdelivery.itunes.apple.com:443
+            idmsa.apple.com:443
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -172,14 +177,23 @@ jobs:
       - run: ls .tmp/app-builds
         shell: bash
 
-      - name: Validate App
-        run: ls .tmp/app-builds; ls .tmp/app-builds/mas-universal; xcrun altool --type macos --validate-app -f .tmp/app-builds/mas-universal/super*.pkg -u ${{secrets.APPLE_ID}} -p ${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}
-        env:
-          APPLE_ID: ${{secrets.APPLE_ID}}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}
+      - name: Install fastlane
+        run: bundle install
 
-      - name: Push to Store
-        run: xcrun altool --type macos --upload-app -f .tmp/app-builds/mas-universal/super*.pkg -u ${{secrets.APPLE_ID}} -p ${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}
+      - name: Prepare App Store release notes
+        run: node tools/prepare-appstore-release-notes.js
+
+      # Upload the MAS .pkg to App Store Connect and (for final release tags)
+      # submit it for review with automatic release on approval. Pre-release
+      # tags (RC/beta/alpha) and manual runs only upload the build.
+      - name: Upload to App Store Connect and submit for review
         env:
-          APPLE_ID: ${{secrets.APPLE_ID}}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}
+          ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
+          ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
+          ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
+          SUBMIT_FOR_REVIEW: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'RC') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha') }}
+        run: |
+          PKG_PATH="$(ls .tmp/app-builds/mas-universal/super*.pkg | head -n1)"
+          export PKG_PATH
+          echo "Submitting $PKG_PATH (submit_for_review=$SUBMIT_FOR_REVIEW)"
+          bundle exec fastlane mac release

--- a/.github/workflows/build-publish-to-mac-store-on-release.yml
+++ b/.github/workflows/build-publish-to-mac-store-on-release.yml
@@ -177,23 +177,35 @@ jobs:
       - run: ls .tmp/app-builds
         shell: bash
 
-      - name: Install fastlane
-        run: bundle install
+      - name: Set up Ruby and fastlane
+        # Pinned by SHA per repo policy; installs the locked Bundler/gems and
+        # caches them so the ~210-gem fastlane tree isn't reinstalled each run.
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # latest
+        with:
+          bundler-cache: true
 
       - name: Prepare App Store release notes
         run: node tools/prepare-appstore-release-notes.js
 
       # Upload the MAS .pkg to App Store Connect and (for final release tags)
       # submit it for review with automatic release on approval. Pre-release
-      # tags (RC/beta/alpha) and manual runs only upload the build.
+      # tags (any tag containing "-", e.g. -rc.0/-beta.1) and manual runs only
+      # upload the build. The "-" check is case-insensitive by construction,
+      # unlike contains(...,'RC'); the repo's RC tags are mostly lowercase.
       - name: Upload to App Store Connect and submit for review
         env:
           ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
           ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
           ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
-          SUBMIT_FOR_REVIEW: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'RC') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha') }}
+          SUBMIT_FOR_REVIEW: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
         run: |
-          PKG_PATH="$(ls .tmp/app-builds/mas-universal/super*.pkg | head -n1)"
-          export PKG_PATH
+          set -euo pipefail
+          shopt -s nullglob
+          pkgs=(.tmp/app-builds/mas-universal/super*.pkg)
+          if [ ${#pkgs[@]} -ne 1 ]; then
+            echo "Expected exactly 1 .pkg, found ${#pkgs[@]}: ${pkgs[*]:-none}"
+            exit 1
+          fi
+          export PKG_PATH="${pkgs[0]}"
           echo "Submitting $PKG_PATH (submit_for_review=$SUBMIT_FOR_REVIEW)"
           bundle exec fastlane mac release

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ data/
 /.secrets.example
 
 .worktrees/
+
+# Generated App Store Connect "What's New" notes (see tools/prepare-appstore-release-notes.js)
+/fastlane/appstore_metadata

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,9 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  arm64-darwin
   ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -1,0 +1,64 @@
+# Apple (iOS & macOS) release automation
+
+Pushing a final version tag (`vX.Y.Z`) builds, signs, uploads **and submits**
+the iOS and macOS App Store builds for review, set to release automatically once
+Apple approves them. The only step that is not automated is Apple's human
+review.
+
+## Pipeline
+
+| Target | Workflow | Output |
+| --- | --- | --- |
+| iOS App Store | `.github/workflows/build-ios.yml` | `.ipa` → App Store Connect |
+| Mac App Store | `.github/workflows/build-publish-to-mac-store-on-release.yml` | MAS `.pkg` → App Store Connect |
+| Mac direct download (notarized DMG/zip, auto-update) | `.github/workflows/build.yml` (`mac-bin`) | GitHub release asset |
+
+On a tag push each workflow builds and signs the artifact, then runs a fastlane
+lane (`fastlane/Fastfile`, `ios release` / `mac release`) that:
+
+1. Uploads the artifact to App Store Connect.
+2. Pushes the "What's New" release notes (derived from `build/release-notes.md`
+   by `tools/prepare-appstore-release-notes.js`). Other listing metadata and
+   screenshots are managed by hand in App Store Connect and are **not** touched.
+3. Waits for App Store Connect to finish processing the build.
+4. Submits the version for review with **automatic release on approval**.
+
+### Submit vs. upload-only
+
+`SUBMIT_FOR_REVIEW` is computed per run:
+
+- **Final tag** (`vX.Y.Z`) → upload **and** submit for review.
+- **Pre-release tag** (`v…-RC…` / `beta` / `alpha`) or **manual
+  `workflow_dispatch`** → upload only (build lands in App Store Connect /
+  TestFlight, no store submission).
+
+## Required secrets
+
+Authentication uses an **App Store Connect API key** (reused from the
+notarization secrets), which is more robust in CI than an Apple ID +
+app-specific password:
+
+| Secret | Used as | Purpose |
+| --- | --- | --- |
+| `mac_api_key` | `ASC_KEY_CONTENT` | Contents of the `.p8` key file |
+| `mac_api_key_id` | `ASC_KEY_ID` | API key id |
+| `mac_api_key_issuer_id` | `ASC_ISSUER_ID` | API issuer id |
+
+> **Important:** the API key must belong to a user with the **App Manager** role
+> (or higher). A key with only the **Developer** role can upload/notarize but
+> **cannot create a version or submit it for review**. If submission fails with
+> a permissions error, mint a new key with the App Manager role and update the
+> three secrets above.
+
+## Caveats
+
+- **Apple review is the only manual gate** — it is performed by humans (~1–2
+  days) and can be rejected. Everything up to and including submission is
+  automated.
+- **"What's New" locales:** only `en-US` notes are generated. If the App Store
+  listing has additional active locales, Apple may require "What's New" text for
+  them on submission. Add more `release_notes.txt` files (or extend
+  `tools/prepare-appstore-release-notes.js`) as needed.
+- **Export compliance:** if `ios/App/App/Info.plist` does not set
+  `ITSAppUsesNonExemptEncryption`, App Store Connect will pause the submission
+  to ask the encryption question. Set it once to keep submission fully hands-off.

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -21,9 +21,11 @@ lane (`fastlane/Fastfile`, `ios release` / `mac release`) that:
    `altool --validate-app` step).
 2. Pushes only the "What's New" release notes (derived from
    `build/release-notes.md` by `tools/prepare-appstore-release-notes.js`). The
-   lane sets `skip_metadata`/`skip_screenshots`, so all other listing fields
-   (description, keywords, screenshots, …) curated by hand in App Store Connect
-   are **not** read back or overwritten.
+   lane points `metadata_path` at a dir containing **only**
+   `<locale>/release_notes.txt`; deliver reads just that file and skips every
+   other field (no remote read-back), so the description, keywords, screenshots,
+   … curated by hand in App Store Connect are left untouched. (`skip_metadata`
+   is intentionally **not** set — it would make deliver upload no notes at all.)
 3. Waits for App Store Connect to finish processing the build.
 4. Submits the version for review with **automatic release on approval**.
 

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -7,30 +7,46 @@ review.
 
 ## Pipeline
 
-| Target | Workflow | Output |
-| --- | --- | --- |
-| iOS App Store | `.github/workflows/build-ios.yml` | `.ipa` → App Store Connect |
-| Mac App Store | `.github/workflows/build-publish-to-mac-store-on-release.yml` | MAS `.pkg` → App Store Connect |
-| Mac direct download (notarized DMG/zip, auto-update) | `.github/workflows/build.yml` (`mac-bin`) | GitHub release asset |
+| Target                                               | Workflow                                                      | Output                         |
+| ---------------------------------------------------- | ------------------------------------------------------------- | ------------------------------ |
+| iOS App Store                                        | `.github/workflows/build-ios.yml`                             | `.ipa` → App Store Connect     |
+| Mac App Store                                        | `.github/workflows/build-publish-to-mac-store-on-release.yml` | MAS `.pkg` → App Store Connect |
+| Mac direct download (notarized DMG/zip, auto-update) | `.github/workflows/build.yml` (`mac-bin`)                     | GitHub release asset           |
 
 On a tag push each workflow builds and signs the artifact, then runs a fastlane
 lane (`fastlane/Fastfile`, `ios release` / `mac release`) that:
 
-1. Uploads the artifact to App Store Connect.
-2. Pushes the "What's New" release notes (derived from `build/release-notes.md`
-   by `tools/prepare-appstore-release-notes.js`). Other listing metadata and
-   screenshots are managed by hand in App Store Connect and are **not** touched.
+1. Uploads the artifact to App Store Connect. Apple's binary validation runs
+   inline during the upload (this replaces the previous standalone
+   `altool --validate-app` step).
+2. Pushes only the "What's New" release notes (derived from
+   `build/release-notes.md` by `tools/prepare-appstore-release-notes.js`). The
+   lane sets `skip_metadata`/`skip_screenshots`, so all other listing fields
+   (description, keywords, screenshots, …) curated by hand in App Store Connect
+   are **not** read back or overwritten.
 3. Waits for App Store Connect to finish processing the build.
 4. Submits the version for review with **automatic release on approval**.
 
+`build/release-notes.md` is a committed snapshot regenerated at release time
+(see `tools/release-notes.js`). If a tag is pushed without that file refreshed
+for the new version, stale notes upload silently — make sure the release-notes
+commit lands before tagging.
+
 ### Submit vs. upload-only
 
-`SUBMIT_FOR_REVIEW` is computed per run:
+`SUBMIT_FOR_REVIEW` is computed per run as
+`startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')`:
 
-- **Final tag** (`vX.Y.Z`) → upload **and** submit for review.
-- **Pre-release tag** (`v…-RC…` / `beta` / `alpha`) or **manual
-  `workflow_dispatch`** → upload only (build lands in App Store Connect /
-  TestFlight, no store submission).
+- **Final tag** (`vX.Y.Z`, no hyphen) → upload **and** submit for review.
+- **Pre-release tag** (any tag containing `-`, e.g. `v18.0.0-rc.0`,
+  `v17.0.0-RC.13`, `-beta.1`, `-alpha.0`) or **manual `workflow_dispatch`** →
+  upload only (build lands in App Store Connect / TestFlight, no store
+  submission).
+
+> The gate keys on the presence of `-` rather than denylisting `RC`/`beta`/
+> `alpha`, because GitHub Actions `contains()` is case-sensitive and this repo's
+> RC tags are predominantly **lowercase** `-rc.N`. Every pre-release tag in the
+> repo's history contains `-`; no final tag does.
 
 ## Required secrets
 
@@ -38,11 +54,11 @@ Authentication uses an **App Store Connect API key** (reused from the
 notarization secrets), which is more robust in CI than an Apple ID +
 app-specific password:
 
-| Secret | Used as | Purpose |
-| --- | --- | --- |
-| `mac_api_key` | `ASC_KEY_CONTENT` | Contents of the `.p8` key file |
-| `mac_api_key_id` | `ASC_KEY_ID` | API key id |
-| `mac_api_key_issuer_id` | `ASC_ISSUER_ID` | API issuer id |
+| Secret                  | Used as           | Purpose                                                                                         |
+| ----------------------- | ----------------- | ----------------------------------------------------------------------------------------------- |
+| `mac_api_key`           | `ASC_KEY_CONTENT` | Contents of the `.p8` key file (raw PEM, including the `-----BEGIN/END PRIVATE KEY-----` lines) |
+| `mac_api_key_id`        | `ASC_KEY_ID`      | API key id                                                                                      |
+| `mac_api_key_issuer_id` | `ASC_ISSUER_ID`   | API issuer id                                                                                   |
 
 > **Important:** the API key must belong to a user with the **App Manager** role
 > (or higher). A key with only the **Developer** role can upload/notarize but
@@ -55,6 +71,17 @@ app-specific password:
 - **Apple review is the only manual gate** — it is performed by humans (~1–2
   days) and can be rejected. Everything up to and including submission is
   automated.
+- **`automatic_release: true`** ships the version to 100% of users the moment
+  Apple approves it (no manual "Release this version" click, no staged
+  rollout). If you'd prefer a human go-live or phased rollout, set
+  `automatic_release: false` (and/or `phased_release: true` for iOS) in
+  `fastlane/Fastfile`.
+- **Build numbers are single-use.** If the lane fails _after_ the binary
+  uploads but _before_ the submission completes (network drop, App-Manager-role
+  error, export-compliance pause), simply re-running won't work — App Store
+  Connect rejects a duplicate build number. Recovery means finishing the
+  submission by hand in App Store Connect, or bumping the build number and
+  re-tagging.
 - **"What's New" locales:** only `en-US` notes are generated. If the App Store
   listing has additional active locales, Apple may require "What's New" text for
   them on submission. Add more `release_notes.txt` files (or extend
@@ -62,3 +89,6 @@ app-specific password:
 - **Export compliance:** if `ios/App/App/Info.plist` does not set
   `ITSAppUsesNonExemptEncryption`, App Store Connect will pause the submission
   to ask the encryption question. Set it once to keep submission fully hands-off.
+- **Never enable fastlane verbose mode** (`--verbose` / `FASTLANE_VERBOSE`) in
+  these lanes — verbose output can dump the deliver options hash, which carries
+  the API key material.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,9 +64,6 @@ def deliver_options(extra)
     # skip_metadata; see the header comment.)
     metadata_path: ENV.fetch('METADATA_PATH', 'fastlane/appstore_metadata'),
     skip_screenshots: true,
-    # Wait for App Store Connect to finish processing the upload before the
-    # version can be submitted.
-    wait_for_uploaded_build: true,
     submit_for_review: submit_for_review?,
     automatic_release: true,
     # Precheck inspects listing metadata we don't manage from here.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,10 +21,13 @@
 # contains the App Store Connect API key material.
 #
 # Listing metadata (description, keywords, screenshots, ...) is managed manually
-# in App Store Connect and is intentionally NOT overwritten here: `skip_metadata`
-# / `skip_screenshots` keep deliver from reading back and re-uploading those
-# fields. The ONLY field pushed is the "What's New" release notes, and only when
-# a release_notes.txt file is present in METADATA_PATH/<locale>/.
+# in App Store Connect and is intentionally NOT overwritten here. METADATA_PATH
+# is a dedicated dir that contains ONLY <locale>/release_notes.txt, so deliver's
+# load_from_filesystem reads just the release notes (it skips fields with no
+# local file: `next unless File.exist?`, and upload skips nil fields). There is
+# no remote read-back, so other listing fields are left untouched. Do NOT set
+# `skip_metadata` here: it makes deliver return early and upload no release notes
+# at all. `skip_screenshots` is safe — screenshots live elsewhere.
 #
 # Required env vars (wired from GitHub secrets in the workflows):
 #   ASC_KEY_ID       App Store Connect API key id      (secrets.mac_api_key_id)
@@ -34,7 +37,6 @@
 #   PKG_PATH         Path to the built MAS .pkg        (mac lane)
 # Optional:
 #   METADATA_PATH      release-notes dir (default: fastlane/appstore_metadata)
-#   RELEASE_NOTES_LOCALE  locale subdir to read (default: en-US)
 #   SUBMIT_FOR_REVIEW  "false" to only upload the build without submitting
 
 APP_IDENTIFIER = 'com.super-productivity.app'
@@ -52,29 +54,15 @@ def submit_for_review?
   ENV.fetch('SUBMIT_FOR_REVIEW', 'true') != 'false'
 end
 
-# "What's New" text, read from METADATA_PATH/<locale>/release_notes.txt and
-# returned as the per-locale hash deliver expects. Returns nil when the file is
-# absent so that deliver leaves the existing release notes untouched.
-def release_notes
-  locale = ENV.fetch('RELEASE_NOTES_LOCALE', 'en-US')
-  metadata_path = ENV.fetch('METADATA_PATH', 'fastlane/appstore_metadata')
-  notes_file = File.join(metadata_path, locale, 'release_notes.txt')
-  return nil unless File.exist?(notes_file)
-
-  text = File.read(notes_file).strip
-  return nil if text.empty?
-
-  { locale => text }
-end
-
 # Shared deliver options. `extra` carries the platform-specific binary path.
 def deliver_options(extra)
-  options = {
+  {
     api_key: asc_api_key,
     app_identifier: APP_IDENTIFIER,
-    # Listing metadata/screenshots are curated by hand in App Store Connect;
-    # skip them so deliver only touches the build + release notes below.
-    skip_metadata: true,
+    # Dir holding only <locale>/release_notes.txt -> deliver uploads just the
+    # "What's New" text and leaves every other listing field as-is. (Do not add
+    # skip_metadata; see the header comment.)
+    metadata_path: ENV.fetch('METADATA_PATH', 'fastlane/appstore_metadata'),
     skip_screenshots: true,
     # Wait for App Store Connect to finish processing the upload before the
     # version can be submitted.
@@ -88,13 +76,7 @@ def deliver_options(extra)
     },
     # Non-interactive: skip the HTML report confirmation prompt.
     force: true,
-  }
-
-  # Push "What's New" only; skip_metadata above keeps every other field as-is.
-  notes = release_notes
-  options[:release_notes] = notes if notes
-
-  options.merge(extra)
+  }.merge(extra)
 end
 
 platform :ios do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,84 @@
+# iOS and macOS App Store submission lanes.
+#
+# The signed release binaries are produced in CI:
+#   - iOS:   .github/workflows/build-ios.yml                       -> .ipa
+#   - macOS: .github/workflows/build-publish-to-mac-store-on-release.yml -> MAS .pkg
+#
+# These lanes take the finished artifact, upload it to App Store Connect, set
+# the "What's New" text, submit the version for review and flag it to be
+# released automatically once Apple approves it. The only step that cannot be
+# automated is Apple's human review itself.
+#
+# Authentication uses an App Store Connect API key (not an Apple ID +
+# app-specific password), which is far more robust in CI.
+#
+# IMPORTANT: the API key must belong to a user with the "App Manager" role (or
+# higher). A key with only the "Developer" role can upload/notarize but cannot
+# create a version or submit it for review.
+#
+# Listing metadata (description, keywords, screenshots, ...) is managed manually
+# in App Store Connect and is intentionally NOT overwritten here. Only the
+# "What's New" release notes are pushed, and only when a release_notes.txt file
+# is present in METADATA_PATH.
+#
+# Required env vars (wired from GitHub secrets in the workflows):
+#   ASC_KEY_ID       App Store Connect API key id      (secrets.mac_api_key_id)
+#   ASC_ISSUER_ID    App Store Connect API issuer id   (secrets.mac_api_key_issuer_id)
+#   ASC_KEY_CONTENT  Contents of the .p8 key file      (secrets.mac_api_key)
+#   IPA_PATH         Path to the built .ipa            (ios lane)
+#   PKG_PATH         Path to the built MAS .pkg        (mac lane)
+# Optional:
+#   METADATA_PATH      deliver metadata dir (default: fastlane/appstore_metadata)
+#   SUBMIT_FOR_REVIEW  "false" to only upload the build without submitting
+
+APP_IDENTIFIER = 'com.super-productivity.app'
+
+def asc_api_key
+  app_store_connect_api_key(
+    key_id: ENV.fetch('ASC_KEY_ID'),
+    issuer_id: ENV.fetch('ASC_ISSUER_ID'),
+    key_content: ENV.fetch('ASC_KEY_CONTENT'),
+    is_key_content_base64: false,
+  )
+end
+
+def submit_for_review?
+  ENV.fetch('SUBMIT_FOR_REVIEW', 'true') != 'false'
+end
+
+# Shared deliver options. `extra` carries the platform-specific binary path.
+def deliver_options(extra)
+  {
+    api_key: asc_api_key,
+    app_identifier: APP_IDENTIFIER,
+    metadata_path: ENV.fetch('METADATA_PATH', 'fastlane/appstore_metadata'),
+    # Listing metadata/screenshots are curated by hand in App Store Connect.
+    skip_screenshots: true,
+    # Wait for App Store Connect to finish processing the upload before the
+    # version can be submitted.
+    wait_for_uploaded_build: true,
+    submit_for_review: submit_for_review?,
+    automatic_release: true,
+    # Precheck inspects listing metadata we don't manage from here.
+    run_precheck_before_submit: false,
+    submission_information: {
+      add_id_info_uses_idfa: false,
+    },
+    # Non-interactive: skip the HTML report confirmation prompt.
+    force: true,
+  }.merge(extra)
+end
+
+platform :ios do
+  desc 'Upload the prebuilt iOS .ipa to App Store Connect and submit for review'
+  lane :release do
+    upload_to_app_store(deliver_options(platform: 'ios', ipa: ENV.fetch('IPA_PATH')))
+  end
+end
+
+platform :mac do
+  desc 'Upload the prebuilt macOS .pkg to App Store Connect and submit for review'
+  lane :release do
+    upload_to_app_store(deliver_options(platform: 'osx', pkg: ENV.fetch('PKG_PATH')))
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,10 +16,15 @@
 # higher). A key with only the "Developer" role can upload/notarize but cannot
 # create a version or submit it for review.
 #
+# SECURITY: never enable verbose mode (--verbose / FASTLANE_VERBOSE / verbose:
+# true) in these lanes. Verbose output can dump the deliver options hash, which
+# contains the App Store Connect API key material.
+#
 # Listing metadata (description, keywords, screenshots, ...) is managed manually
-# in App Store Connect and is intentionally NOT overwritten here. Only the
-# "What's New" release notes are pushed, and only when a release_notes.txt file
-# is present in METADATA_PATH.
+# in App Store Connect and is intentionally NOT overwritten here: `skip_metadata`
+# / `skip_screenshots` keep deliver from reading back and re-uploading those
+# fields. The ONLY field pushed is the "What's New" release notes, and only when
+# a release_notes.txt file is present in METADATA_PATH/<locale>/.
 #
 # Required env vars (wired from GitHub secrets in the workflows):
 #   ASC_KEY_ID       App Store Connect API key id      (secrets.mac_api_key_id)
@@ -28,7 +33,8 @@
 #   IPA_PATH         Path to the built .ipa            (ios lane)
 #   PKG_PATH         Path to the built MAS .pkg        (mac lane)
 # Optional:
-#   METADATA_PATH      deliver metadata dir (default: fastlane/appstore_metadata)
+#   METADATA_PATH      release-notes dir (default: fastlane/appstore_metadata)
+#   RELEASE_NOTES_LOCALE  locale subdir to read (default: en-US)
 #   SUBMIT_FOR_REVIEW  "false" to only upload the build without submitting
 
 APP_IDENTIFIER = 'com.super-productivity.app'
@@ -46,13 +52,29 @@ def submit_for_review?
   ENV.fetch('SUBMIT_FOR_REVIEW', 'true') != 'false'
 end
 
+# "What's New" text, read from METADATA_PATH/<locale>/release_notes.txt and
+# returned as the per-locale hash deliver expects. Returns nil when the file is
+# absent so that deliver leaves the existing release notes untouched.
+def release_notes
+  locale = ENV.fetch('RELEASE_NOTES_LOCALE', 'en-US')
+  metadata_path = ENV.fetch('METADATA_PATH', 'fastlane/appstore_metadata')
+  notes_file = File.join(metadata_path, locale, 'release_notes.txt')
+  return nil unless File.exist?(notes_file)
+
+  text = File.read(notes_file).strip
+  return nil if text.empty?
+
+  { locale => text }
+end
+
 # Shared deliver options. `extra` carries the platform-specific binary path.
 def deliver_options(extra)
-  {
+  options = {
     api_key: asc_api_key,
     app_identifier: APP_IDENTIFIER,
-    metadata_path: ENV.fetch('METADATA_PATH', 'fastlane/appstore_metadata'),
-    # Listing metadata/screenshots are curated by hand in App Store Connect.
+    # Listing metadata/screenshots are curated by hand in App Store Connect;
+    # skip them so deliver only touches the build + release notes below.
+    skip_metadata: true,
     skip_screenshots: true,
     # Wait for App Store Connect to finish processing the upload before the
     # version can be submitted.
@@ -66,7 +88,13 @@ def deliver_options(extra)
     },
     # Non-interactive: skip the HTML report confirmation prompt.
     force: true,
-  }.merge(extra)
+  }
+
+  # Push "What's New" only; skip_metadata above keeps every other field as-is.
+  notes = release_notes
+  options[:release_notes] = notes if notes
+
+  options.merge(extra)
 end
 
 platform :ios do

--- a/tools/prepare-appstore-release-notes.js
+++ b/tools/prepare-appstore-release-notes.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Derive a plain-text "What's New" file for App Store Connect from the
+// generated GitHub release notes (build/release-notes.md).
+//
+// App Store Connect release notes are plain text (no markdown), so this strips
+// headings, emphasis and links and drops the GitHub-only downloads footer. The
+// result is written for the App Store deliver lanes (fastlane/Fastfile).
+//
+// Usage: node tools/prepare-appstore-release-notes.js [outFile] [locale]
+//   outFile  defaults to fastlane/appstore_metadata/<locale>/release_notes.txt
+//   locale   defaults to en-US
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.join(__dirname, '..');
+const SOURCE_FILE = path.join(ROOT_DIR, 'build', 'release-notes.md');
+// App Store Connect caps "What's New" at 4000 characters.
+const MAX_CHARS = 4000;
+
+const locale = process.argv[3] || 'en-US';
+const outFile =
+  process.argv[2] ||
+  path.join(ROOT_DIR, 'fastlane', 'appstore_metadata', locale, 'release_notes.txt');
+
+// GitHub-only footer lines that don't belong in an App Store "What's New".
+const FOOTER_PATTERNS = [
+  /check the wiki/i,
+  /current downloads/i,
+  /download (links|options)/i,
+  /releases\/latest/i,
+  /^\s*for the latest version/i,
+  /^\s*visit:?\s*$/i,
+  /^\s*https?:\/\/\S+\s*$/i,
+];
+
+const toPlainText = (markdown) =>
+  markdown
+    .split('\n')
+    .filter((line) => !FOOTER_PATTERNS.some((re) => re.test(line)))
+    .map((line) =>
+      line
+        // headings: "## Features" -> "Features"
+        .replace(/^#{1,6}\s*/, '')
+        // bold/italic markers
+        .replace(/\*\*(.*?)\*\*/g, '$1')
+        .replace(/(^|\s)[*_](\S.*?\S)[*_]/g, '$1$2')
+        // links: "[text](url)" -> "text"
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        // list bullets: "- item" / "* item" -> "• item"
+        .replace(/^\s*[-*]\s+/, '• '),
+    )
+    .join('\n')
+    // collapse 3+ blank lines down to a single blank line
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+// Always ensure the deliver metadata dir exists so the App Store lanes never
+// fail on a missing metadata_path; an empty dir simply leaves "What's New"
+// untouched in App Store Connect.
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+
+if (!fs.existsSync(SOURCE_FILE)) {
+  console.error(`No release notes source found at ${SOURCE_FILE}; skipping.`);
+  process.exit(0);
+}
+
+let text = toPlainText(fs.readFileSync(SOURCE_FILE, 'utf8'));
+
+if (!text) {
+  console.error('Release notes are empty after processing; skipping.');
+  process.exit(0);
+}
+
+if (text.length > MAX_CHARS) {
+  text = `${text.slice(0, MAX_CHARS - 1).trimEnd()}…`;
+}
+
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+fs.writeFileSync(outFile, `${text}\n`, 'utf8');
+console.log(`Wrote App Store release notes (${text.length} chars) to ${outFile}`);

--- a/tools/prepare-appstore-release-notes.js
+++ b/tools/prepare-appstore-release-notes.js
@@ -79,8 +79,11 @@ if (!text) {
   process.exit(0);
 }
 
-if (text.length > MAX_CHARS) {
-  text = `${text.slice(0, MAX_CHARS - 1).trimEnd()}…`;
+const chars = [...text];
+if (chars.length > MAX_CHARS) {
+  // Slice by code points (not UTF-16 units) so a multi-byte character (e.g. an
+  // emoji surrogate pair) is never cut in half. Keeps us within ASC's cap.
+  text = `${chars.slice(0, MAX_CHARS - 1).join('').trimEnd()}…`;
 }
 
 fs.writeFileSync(outFile, `${text}\n`, 'utf8');

--- a/tools/prepare-appstore-release-notes.js
+++ b/tools/prepare-appstore-release-notes.js
@@ -24,12 +24,14 @@ const outFile =
   path.join(ROOT_DIR, 'fastlane', 'appstore_metadata', locale, 'release_notes.txt');
 
 // GitHub-only footer lines that don't belong in an App Store "What's New".
+// Anchored to the start of the line so they can't swallow a legitimate content
+// line that merely mentions "download" (e.g. a fix about a download dialog).
 const FOOTER_PATTERNS = [
   /check the wiki/i,
-  /current downloads/i,
-  /download (links|options)/i,
-  /releases\/latest/i,
+  /^\s*for all current downloads/i,
   /^\s*for the latest version/i,
+  /^\s*(see|view|read) the (full )?changelog/i,
+  /releases\/latest\b/i,
   /^\s*visit:?\s*$/i,
   /^\s*https?:\/\/\S+\s*$/i,
 ];
@@ -42,9 +44,14 @@ const toPlainText = (markdown) =>
       line
         // headings: "## Features" -> "Features"
         .replace(/^#{1,6}\s*/, '')
-        // bold/italic markers
-        .replace(/\*\*(.*?)\*\*/g, '$1')
-        .replace(/(^|\s)[*_](\S.*?\S)[*_]/g, '$1$2')
+        // bold: "**text**" -> "text"
+        .replace(/\*\*(?=\S)([^*\n]+?)\*\*/g, '$1')
+        // italic "*text*" -> "text" (markers must hug non-space and be bounded
+        // by whitespace/edges, so stray asterisks like "*.md" or "a * b" survive)
+        .replace(/(^|\s)\*(?=\S)([^*\n]+?)\*(?=\s|$)/g, '$1$2')
+        // italic "_text_" -> "text" (intra-word underscores like snake_case
+        // are left untouched by the boundary requirements)
+        .replace(/(^|\s)_(?=\S)([^_\n]+?)_(?=\s|$)/g, '$1$2')
         // links: "[text](url)" -> "text"
         .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
         // list bullets: "- item" / "* item" -> "• item"
@@ -76,6 +83,5 @@ if (text.length > MAX_CHARS) {
   text = `${text.slice(0, MAX_CHARS - 1).trimEnd()}…`;
 }
 
-fs.mkdirSync(path.dirname(outFile), { recursive: true });
 fs.writeFileSync(outFile, `${text}\n`, 'utf8');
 console.log(`Wrote App Store release notes (${text.length} chars) to ${outFile}`);


### PR DESCRIPTION
The iOS and Mac App Store workflows previously stopped after uploading the
build to App Store Connect via altool, leaving version creation, "What's New"
and submission as manual steps.

Add fastlane lanes (ios/mac release) that upload the prebuilt .ipa / MAS .pkg
using App Store Connect API key auth (reusing the existing notarization key
secrets), push release notes derived from build/release-notes.md, wait for
processing, submit for review and flag automatic release on approval.

Final version tags submit for review; pre-release tags (RC/beta/alpha) and
manual runs only upload the build. Listing metadata and screenshots remain
curated by hand in App Store Connect.

https://claude.ai/code/session_014c1W1mX7tfvFzpZ6wyWzsJ