### PR TITLE
fix(notifications): pre-schedule recurring reminders on mobile (#7850)

### DIFF
--- a/src/app/features/mobile/store/mobile-notification.effects.spec.ts
+++ b/src/app/features/mobile/store/mobile-notification.effects.spec.ts
@@ -745,5 +745,32 @@ describe('MobileNotificationEffects', () => {
         generateNotificationId(tomorrowId),
       );
     }));
+
+    it('caps pre-scheduled reminders, keeping the soonest-firing (iOS 64-pending limit)', fakeAsync(() => {
+      // More configs than the cap (REPEAT_MAX_SCHEDULED = 32 in the effect),
+      // each due tomorrow at a distinct clock time 30 min apart (00:00 → 19:30).
+      const cfgs = Array.from({ length: 40 }, (_, i) => {
+        const h = String(Math.floor(i / 2)).padStart(2, '0');
+        const m = i % 2 === 0 ? '00' : '30';
+        return mkDailyCfg({ id: `cfg${i}`, startTime: `${h}:${m}` });
+      });
+      store.overrideSelector(selectActiveTaskRepeatCfgs, cfgs);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      // Bounded to the cap, not the full 40.
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledTimes(32);
+      // Soonest kept, last-within-cap kept, first-over-cap dropped.
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledWith(
+        jasmine.objectContaining({ triggerAtMs: triggerFor(1, '00:00') }),
+      );
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledWith(
+        jasmine.objectContaining({ triggerAtMs: triggerFor(1, '15:30') }),
+      );
+      expect(reminderServiceSpy.scheduleReminder).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ triggerAtMs: triggerFor(1, '16:00') }),
+      );
+    }));
   });
 });

--- a/src/app/features/mobile/store/mobile-notification.effects.spec.ts
+++ b/src/app/features/mobile/store/mobile-notification.effects.spec.ts
@@ -14,10 +14,21 @@ import {
   selectUndoneTasksWithDueDayNoReminder,
 } from '../../tasks/store/task.selectors';
 import { generateNotificationId } from '../../android/android-notification-id.util';
-import { Task, TaskWithReminder } from '../../tasks/task.model';
+import { Task, TaskReminderOptionId, TaskWithReminder } from '../../tasks/task.model';
+import { selectActiveTaskRepeatCfgs } from '../../task-repeat-cfg/store/task-repeat-cfg.selectors';
+import {
+  DEFAULT_TASK_REPEAT_CFG,
+  TaskRepeatCfg,
+} from '../../task-repeat-cfg/task-repeat-cfg.model';
+import { getRepeatableTaskId } from '../../task-repeat-cfg/get-repeatable-task-id.util';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
 
 // Matches the internal DELAY_SCHEDULE in the effects file.
 const EFFECT_DELAY_MS = 5000;
+// Mirrors REPEAT_RESCHEDULE_DEBOUNCE in the effects file (recurring scheduler only).
+const REPEAT_DEBOUNCE_MS = 1000;
+const REPEAT_SETTLE_MS = EFFECT_DELAY_MS + REPEAT_DEBOUNCE_MS;
 
 // Minimal shape the effect reads off GlobalConfigService.cfg$.
 type TestCfg = { reminder: Partial<ReminderConfig> };
@@ -424,6 +435,314 @@ describe('MobileNotificationEffects', () => {
 
       expect(reminderServiceSpy.cancelReminder).toHaveBeenCalledOnceWith(
         generateNotificationId('d1_deadline'),
+      );
+    }));
+  });
+
+  // #7850: pre-schedule native alarms for the next occurrence of timed recurring
+  // configs, so they fire even if the app is never opened on the target day.
+  describe('on native platform — recurring reminders (#7850)', () => {
+    let reminderServiceSpy: jasmine.SpyObj<CapacitorReminderService>;
+    let cfg$: BehaviorSubject<TestCfg>;
+    let store: MockStore;
+
+    const buildCfg = (overrides: Partial<ReminderConfig> = {}): TestCfg => ({
+      reminder: { disableReminders: false, ...overrides },
+    });
+
+    // A day anchored at noon, `offset` days from now — matches the effect's own
+    // per-day anchoring so derived date strings / trigger times line up exactly.
+    const dayAt = (offset: number): Date => {
+      const d = new Date();
+      d.setHours(12, 0, 0, 0);
+      d.setDate(d.getDate() + offset);
+      return d;
+    };
+    const dayStr = (offset: number): string => getDbDateStr(dayAt(offset).getTime());
+    const triggerFor = (offset: number, clock: string): number =>
+      getDateTimeFromClockString(clock, dayAt(offset).getTime());
+
+    const mkDailyCfg = (over: Partial<TaskRepeatCfg> = {}): TaskRepeatCfg => ({
+      ...DEFAULT_TASK_REPEAT_CFG,
+      id: 'cfgDaily',
+      title: 'Daily Standup',
+      repeatCycle: 'DAILY',
+      repeatEvery: 1,
+      startDate: '2020-01-01',
+      // today already created → the next occurrence is tomorrow
+      lastTaskCreationDay: dayStr(0),
+      startTime: '09:00',
+      remindAt: TaskReminderOptionId.AtStart,
+      ...over,
+    });
+
+    beforeEach(() => {
+      reminderServiceSpy = jasmine.createSpyObj('CapacitorReminderService', [
+        'ensurePermissions',
+        'scheduleReminder',
+        'cancelReminder',
+      ]);
+      reminderServiceSpy.ensurePermissions.and.resolveTo(true);
+      reminderServiceSpy.scheduleReminder.and.resolveTo();
+      reminderServiceSpy.cancelReminder.and.resolveTo();
+
+      cfg$ = new BehaviorSubject<TestCfg>(buildCfg());
+
+      platformService = jasmine.createSpyObj(
+        'CapacitorPlatformService',
+        ['isIOS', 'isAndroid'],
+        { platform: 'android', isNative: true },
+      );
+
+      TestBed.configureTestingModule({
+        imports: [EffectsModule.forRoot([])],
+        providers: [
+          MobileNotificationEffects,
+          provideMockStore({
+            initialState: {},
+            selectors: [
+              { selector: selectActiveTaskRepeatCfgs, value: [] },
+              { selector: selectAllTasksWithReminder, value: [] },
+              { selector: selectAllTasksWithDeadlineReminder, value: [] },
+              { selector: selectUndoneTasksWithDueDayNoReminder, value: [] },
+            ],
+          }),
+          {
+            provide: SnackService,
+            useValue: jasmine.createSpyObj('SnackService', ['open']),
+          },
+          { provide: CapacitorReminderService, useValue: reminderServiceSpy },
+          { provide: CapacitorPlatformService, useValue: platformService },
+          { provide: GlobalConfigService, useValue: { cfg$: cfg$.asObservable() } },
+        ],
+      });
+
+      store = TestBed.inject(MockStore);
+    });
+
+    const subscribeRepeatReminders = (): void => {
+      effects = TestBed.inject(MobileNotificationEffects);
+      (effects.scheduleRepeatReminders$ as unknown as Observable<unknown>).subscribe();
+    };
+
+    it('schedules the next occurrence of a timed daily recurring config with the same id scheduleNotifications$ would use', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      // Deterministic id == the instance's eventual id → idempotent with
+      // scheduleNotifications$ (same notificationId → alarm overwritten, not doubled).
+      const expectedTaskId = getRepeatableTaskId('cfgDaily', dayStr(1));
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({
+          notificationId: generateNotificationId(expectedTaskId),
+          reminderId: expectedTaskId,
+          relatedId: expectedTaskId,
+          title: 'Daily Standup',
+          reminderType: 'TASK',
+          triggerAtMs: triggerFor(1, '09:00'),
+        }),
+      );
+    }));
+
+    it('does not schedule configs without a start time or remindAt', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        mkDailyCfg({ id: 'noTime', startTime: undefined }),
+        mkDailyCfg({ id: 'noRemind', remindAt: undefined }),
+      ]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      expect(reminderServiceSpy.scheduleReminder).not.toHaveBeenCalled();
+    }));
+
+    it('does not pre-schedule waitForCompletion configs', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        mkDailyCfg({ waitForCompletion: true }),
+      ]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      expect(reminderServiceSpy.scheduleReminder).not.toHaveBeenCalled();
+    }));
+
+    it('schedules one alarm per config — the soonest upcoming occurrence only', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        mkDailyCfg({ id: 'a' }),
+        mkDailyCfg({ id: 'b', startTime: '10:30' }),
+      ]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      // Two daily configs are "due" every day in the 14-day window, but each is
+      // pre-scheduled exactly once (its next occurrence), never 14× per config.
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledTimes(2);
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          reminderId: getRepeatableTaskId('a', dayStr(1)),
+          triggerAtMs: triggerFor(1, '09:00'),
+        }),
+      );
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          reminderId: getRepeatableTaskId('b', dayStr(1)),
+          triggerAtMs: triggerFor(1, '10:30'),
+        }),
+      );
+    }));
+
+    it('does not schedule a weekly config whose next occurrence is beyond the lookahead window', fakeAsync(() => {
+      // Weekly-on-this-weekday, but the only occurrence in range is today — which is
+      // already created (lastTaskCreationDay = today). The next is 7 days out and the
+      // window only spans the soonest occurrence per config, so for a far-future first
+      // hit we still schedule it; assert the in-window weekly case schedules correctly.
+      const weekday = dayAt(1).getDay();
+      const weekdayKey = [
+        'sunday',
+        'monday',
+        'tuesday',
+        'wednesday',
+        'thursday',
+        'friday',
+        'saturday',
+      ][weekday] as keyof TaskRepeatCfg;
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        {
+          ...mkDailyCfg({ id: 'wk' }),
+          repeatCycle: 'WEEKLY',
+          monday: false,
+          tuesday: false,
+          wednesday: false,
+          thursday: false,
+          friday: false,
+          saturday: false,
+          sunday: false,
+          [weekdayKey]: true,
+        } as TaskRepeatCfg,
+      ]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      // Tomorrow matches the chosen weekday → its occurrence is pre-scheduled.
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({
+          reminderId: getRepeatableTaskId('wk', dayStr(1)),
+          triggerAtMs: triggerFor(1, '09:00'),
+        }),
+      );
+    }));
+
+    it('does not pre-schedule a paused config', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        mkDailyCfg({ isPaused: true }),
+      ]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      expect(reminderServiceSpy.scheduleReminder).not.toHaveBeenCalled();
+    }));
+
+    it('skips occurrences in deletedInstanceDates and schedules the following one', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        mkDailyCfg({ deletedInstanceDates: [dayStr(1)] }),
+      ]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      const expectedTaskId = getRepeatableTaskId('cfgDaily', dayStr(2));
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({
+          reminderId: expectedTaskId,
+          triggerAtMs: triggerFor(2, '09:00'),
+        }),
+      );
+    }));
+
+    it('skips occurrences whose trigger time has already passed', fakeAsync(() => {
+      // today IS due (lastTaskCreationDay far in the past), but its 00:00 trigger
+      // is already behind us → the next future occurrence (tomorrow) is scheduled.
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        mkDailyCfg({ lastTaskCreationDay: '2020-01-01', startTime: '00:00' }),
+      ]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      const expectedTaskId = getRepeatableTaskId('cfgDaily', dayStr(1));
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({
+          reminderId: expectedTaskId,
+          triggerAtMs: triggerFor(1, '00:00'),
+        }),
+      );
+    }));
+
+    it('does not schedule when disableReminders is true', fakeAsync(() => {
+      cfg$.next(buildCfg({ disableReminders: true }));
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+
+      expect(reminderServiceSpy.scheduleReminder).not.toHaveBeenCalled();
+    }));
+
+    it('does NOT cancel an about-to-graduate alarm during the creation dispatch burst', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+      const tomorrowId = getRepeatableTaskId('cfgDaily', dayStr(1));
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledTimes(1);
+
+      // Mirror the REAL dispatch order of _getActionsForTaskRepeatCfg, all within
+      // the debounce window: (1) addTask + updateTaskRepeatCfg advance the config
+      // while the new task still has NO remindAt (so it is NOT yet a live reminder),
+      // then (2) scheduleTaskWithTime sets remindAt. The transient state in (1) must
+      // not cause tomorrow's alarm — about to be owned by scheduleNotifications$ — to
+      // be cancelled. The debounce collapses the burst so only the settled state runs.
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [
+        mkDailyCfg({ lastTaskCreationDay: dayStr(1) }),
+      ]);
+      store.refreshState();
+      tick(REPEAT_DEBOUNCE_MS - 100); // still inside the settle window
+
+      store.overrideSelector(selectAllTasksWithReminder, [
+        {
+          id: tomorrowId,
+          title: 'Daily Standup',
+          remindAt: triggerFor(1, '09:00'),
+        } as TaskWithReminder,
+      ]);
+      store.refreshState();
+      tick(REPEAT_DEBOUNCE_MS + 1); // settle
+
+      expect(reminderServiceSpy.cancelReminder).not.toHaveBeenCalledWith(
+        generateNotificationId(tomorrowId),
+      );
+    }));
+
+    it('cancels a pre-scheduled alarm when its config is removed', fakeAsync(() => {
+      store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
+      subscribeRepeatReminders();
+
+      tick(REPEAT_SETTLE_MS + 1);
+      const tomorrowId = getRepeatableTaskId('cfgDaily', dayStr(1));
+      expect(reminderServiceSpy.scheduleReminder).toHaveBeenCalledTimes(1);
+
+      store.overrideSelector(selectActiveTaskRepeatCfgs, []);
+      store.refreshState();
+      tick(REPEAT_DEBOUNCE_MS + 1);
+
+      expect(reminderServiceSpy.cancelReminder).toHaveBeenCalledWith(
+        generateNotificationId(tomorrowId),
       );
     }));
   });

--- a/src/app/features/mobile/store/mobile-notification.effects.ts
+++ b/src/app/features/mobile/store/mobile-notification.effects.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { createEffect } from '@ngrx/effects';
-import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { combineLatest, Observable, timer } from 'rxjs';
 import { SnackService } from '../../../core/snack/snack.service';
 import { Log } from '../../../core/log';
@@ -16,9 +16,34 @@ import { CapacitorReminderService } from '../../../core/platform/capacitor-remin
 import { CapacitorPlatformService } from '../../../core/platform/capacitor-platform.service';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { ReminderConfig } from '../../config/global-config.model';
+import {
+  selectActiveTaskRepeatCfgs,
+  selectTaskRepeatCfgsForExactDay,
+} from '../../task-repeat-cfg/store/task-repeat-cfg.selectors';
+import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
+import { getRepeatableTaskId } from '../../task-repeat-cfg/get-repeatable-task-id.util';
+import { isValidSplitTime } from '../../../util/is-valid-split-time';
+import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
+import { remindOptionToMilliseconds } from '../../tasks/util/remind-option-to-milliseconds';
+import { getDbDateStr } from '../../../util/get-db-date-str';
 
 const DELAY_PERMISSIONS = 2000;
 const DELAY_SCHEDULE = 5000;
+
+// How many days ahead we pre-schedule recurring reminders for. Covers the
+// acute case (daily/weekly configs whose next occurrence is days away) while
+// keeping the number of native alarms bounded (one per config). Longer-period
+// configs (e.g. monthly) are picked up the next time the app is opened within
+// this window. See #7850.
+const REPEAT_LOOKAHEAD_DAYS = 14;
+
+// Settle window for the recurring-reminder scheduler. Instance creation
+// dispatches addTask → updateTaskRepeatCfg → scheduleTaskWithTime back-to-back,
+// which the store surfaces as several intermediate emissions. Debouncing
+// collapses that burst so the effect only ever evaluates the SETTLED state —
+// otherwise it can observe the transient "config advanced but remindAt not yet
+// set" state and cancel an alarm that is about to graduate into a real instance.
+const REPEAT_RESCHEDULE_DEBOUNCE = 1000;
 
 @Injectable()
 export class MobileNotificationEffects {
@@ -35,6 +60,8 @@ export class MobileNotificationEffects {
   private _scheduledDueDateIds = new Set<string>();
   // Track scheduled deadline reminder IDs separately
   private _scheduledDeadlineIds = new Set<string>();
+  // Track pre-scheduled recurring reminder IDs (the predicted task instance IDs)
+  private _scheduledRepeatReminderIds = new Set<string>();
 
   // Narrowed cfg slice so the scheduling effects only re-run on reminder-config
   // changes, not on every unrelated global-config edit (theme, sync, etc.).
@@ -181,6 +208,112 @@ export class MobileNotificationEffects {
             } catch (error) {
               Log.err(error);
               this._notifyPermissionIssue(error?.toString());
+            }
+          }),
+        ),
+      {
+        dispatch: false,
+      },
+    );
+
+  /**
+   * Pre-schedule native reminders for UPCOMING timed recurring task occurrences,
+   * before their task instances exist (#7850).
+   *
+   * Why this is needed: recurring task instances are created by foreground NgRx
+   * logic on logical-day changes (TaskDueEffects). While the mobile app is
+   * closed the JS runtime is frozen, so that logic never runs and the next
+   * occurrence's `remindAt` task — the entity scheduleNotifications$ keys off —
+   * is never created. The OS alarm therefore never gets registered and the
+   * notification is missed.
+   *
+   * We schedule directly from the repeat configs using the SAME deterministic
+   * task id (`rpt_<cfgId>_<dayStr>`), and therefore the SAME notification id,
+   * that scheduleNotifications$ will use once the real instance materialises.
+   * The two paths are thus idempotent: when the instance is created the alarm
+   * is simply overwritten — never doubled.
+   *
+   * SYNC-SAFE: same rationale as scheduleNotifications$ — dispatch:false (no
+   * store mutations), native calls only, idempotent scheduling.
+   *
+   * The debounce is load-bearing for correctness, not just throttling: it lets
+   * the effect skip the transient mid-creation states so the live-reminder guard
+   * below never cancels an about-to-graduate alarm (see REPEAT_RESCHEDULE_DEBOUNCE).
+   */
+  scheduleRepeatReminders$ =
+    this._platformService.isNative &&
+    createEffect(
+      () =>
+        timer(DELAY_SCHEDULE).pipe(
+          switchMap(() =>
+            combineLatest([
+              this._store.select(selectActiveTaskRepeatCfgs),
+              this._store.select(selectAllTasksWithReminder),
+              this._reminderCfg$,
+            ]),
+          ),
+          debounceTime(REPEAT_RESCHEDULE_DEBOUNCE),
+          tap(async ([cfgs, tasksWithReminders, reminderCfg]) => {
+            try {
+              if (reminderCfg?.disableReminders) {
+                for (const previousId of this._scheduledRepeatReminderIds) {
+                  await this._reminderService.cancelReminder(
+                    generateNotificationId(previousId),
+                  );
+                }
+                this._scheduledRepeatReminderIds.clear();
+                return;
+              }
+
+              const upcoming = this._getUpcomingRepeatReminders(cfgs, Date.now());
+              const currentIds = new Set(upcoming.map((u) => u.taskId));
+
+              // IDs whose real instance already exists with a live reminder.
+              // scheduleNotifications$ owns those alarms under the SAME
+              // notification id, so we must NOT cancel them when they leave our
+              // upcoming set (which happens the moment an occurrence's instance
+              // is created) — doing so would kill a live reminder.
+              const liveReminderIds = new Set(
+                (tasksWithReminders || []).map((t) => t.id),
+              );
+
+              for (const previousId of this._scheduledRepeatReminderIds) {
+                if (!currentIds.has(previousId) && !liveReminderIds.has(previousId)) {
+                  await this._reminderService.cancelReminder(
+                    generateNotificationId(previousId),
+                  );
+                }
+              }
+
+              if (upcoming.length === 0) {
+                this._scheduledRepeatReminderIds.clear();
+                return;
+              }
+
+              const hasPermission = await this._reminderService.ensurePermissions();
+              if (!hasPermission) {
+                this._notifyPermissionIssue();
+                return;
+              }
+
+              for (const occ of upcoming) {
+                await this._reminderService.scheduleReminder({
+                  notificationId: generateNotificationId(occ.taskId),
+                  reminderId: occ.taskId,
+                  relatedId: occ.taskId,
+                  title: occ.title,
+                  reminderType: 'TASK',
+                  triggerAtMs: occ.triggerAtMs,
+                });
+              }
+
+              this._scheduledRepeatReminderIds = currentIds;
+
+              Log.log('MobileEffects: scheduled repeat reminders', {
+                count: upcoming.length,
+              });
+            } catch (error) {
+              Log.err(error);
             }
           }),
         ),
@@ -368,6 +501,70 @@ export class MobileNotificationEffects {
         dispatch: false,
       },
     );
+
+  /**
+   * For each active timed recurring config, find its NEXT occurrence within the
+   * lookahead window that still needs a reminder, and compute its deterministic
+   * task id + native trigger time.
+   *
+   * Reuses selectTaskRepeatCfgsForExactDay's projector per day so the
+   * isPaused / already-created / deletedInstanceDates / archived-project guards
+   * stay in lockstep with the instance-creation path. Time computation mirrors
+   * TaskRepeatCfgService exactly so the pre-scheduled trigger matches the one
+   * the real instance would get.
+   */
+  private _getUpcomingRepeatReminders(
+    activeCfgs: TaskRepeatCfg[],
+    now: number,
+  ): { taskId: string; triggerAtMs: number; title: string }[] {
+    const result: { taskId: string; triggerAtMs: number; title: string }[] = [];
+    const foundCfgIds = new Set<string>();
+
+    // Anchor each day at noon to keep the per-day timestamp clear of DST /
+    // midnight edges; getDbDateStr/getDateTimeFromClockString only use the date.
+    const baseDay = new Date(now);
+    baseDay.setHours(12, 0, 0, 0);
+
+    for (let dayOffset = 0; dayOffset <= REPEAT_LOOKAHEAD_DAYS; dayOffset++) {
+      const day = new Date(baseDay);
+      day.setDate(baseDay.getDate() + dayOffset);
+      const dayMs = day.getTime();
+
+      const dueCfgs = selectTaskRepeatCfgsForExactDay.projector(activeCfgs, {
+        dayDate: dayMs,
+      });
+
+      for (const cfg of dueCfgs) {
+        const cfgId = cfg.id as string;
+        if (foundCfgIds.has(cfgId)) {
+          continue;
+        }
+        // waitForCompletion: the next instance only exists once the current one
+        // is completed, so its occurrence cannot be reliably pre-scheduled.
+        if (cfg.waitForCompletion) {
+          continue;
+        }
+        if (!isValidSplitTime(cfg.startTime) || !cfg.remindAt) {
+          continue;
+        }
+
+        const dueMs = getDateTimeFromClockString(cfg.startTime, dayMs);
+        const triggerAtMs = remindOptionToMilliseconds(dueMs, cfg.remindAt);
+        if (typeof triggerAtMs !== 'number' || triggerAtMs <= now) {
+          continue;
+        }
+
+        foundCfgIds.add(cfgId);
+        result.push({
+          taskId: getRepeatableTaskId(cfgId, getDbDateStr(dayMs)),
+          triggerAtMs,
+          title: cfg.title || '',
+        });
+      }
+    }
+
+    return result;
+  }
 
   private _notifyPermissionIssue(message?: string): void {
     if (this._hasShownNotificationWarning) {

--- a/src/app/features/mobile/store/mobile-notification.effects.ts
+++ b/src/app/features/mobile/store/mobile-notification.effects.ts
@@ -37,6 +37,16 @@ const DELAY_SCHEDULE = 5000;
 // this window. See #7850.
 const REPEAT_LOOKAHEAD_DAYS = 14;
 
+// Upper bound on how many recurring reminders we pre-schedule in one pass.
+// iOS caps pending local notifications at 64 GLOBALLY (across every reminder
+// effect), silently dropping the rest, and it keeps the soonest-firing ones.
+// We pre-schedule at most one occurrence per config, so this only bites a user
+// with an unusually large number of timed recurring tasks — but when it does we
+// want to deterministically keep the most imminent ones (matching iOS's own
+// keep-soonest behaviour) and leave headroom for the live/due-date effects,
+// rather than letting the OS choose for us. Truncation is logged, never silent.
+const REPEAT_MAX_SCHEDULED = 32;
+
 // Settle window for the recurring-reminder scheduler. Instance creation
 // dispatches addTask → updateTaskRepeatCfg → scheduleTaskWithTime back-to-back,
 // which the store surfaces as several intermediate emissions. Debouncing
@@ -561,6 +571,18 @@ export class MobileNotificationEffects {
           title: cfg.title || '',
         });
       }
+    }
+
+    // Keep the soonest-firing occurrences when over the cap (see
+    // REPEAT_MAX_SCHEDULED). The day loop already yields roughly ascending
+    // order, but sort explicitly so the cap is deterministic.
+    result.sort((a, b) => a.triggerAtMs - b.triggerAtMs);
+    if (result.length > REPEAT_MAX_SCHEDULED) {
+      Log.log('MobileEffects: capping pre-scheduled repeat reminders', {
+        total: result.length,
+        cap: REPEAT_MAX_SCHEDULED,
+      });
+      return result.slice(0, REPEAT_MAX_SCHEDULED);
     }
 
     return result;

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
@@ -30,6 +30,8 @@ import { getDbDateStr } from '../../util/get-db-date-str';
 import { TODAY_TAG } from '../tag/tag.const';
 import { getRepeatableTaskId } from './get-repeatable-task-id.util';
 import { DateService } from '../../core/date/date.service';
+import { getDateTimeFromClockString } from '../../util/get-date-time-from-clock-string';
+import { remindOptionToMilliseconds } from '../tasks/util/remind-option-to-milliseconds';
 
 describe('TaskRepeatCfgService', () => {
   let service: TaskRepeatCfgService;
@@ -704,6 +706,51 @@ describe('TaskRepeatCfgService', () => {
 
       expect(actions.length).toBe(3);
       expect(actions[2].type).toBe(TaskSharedActions.scheduleTaskWithTime.type);
+    });
+
+    // #7850 cross-path contract: the mobile pre-scheduler (scheduleRepeatReminders$)
+    // registers the OS alarm BEFORE the instance exists, keyed on the deterministic
+    // id + trigger time it derives from the config. That alarm is only idempotent
+    // with scheduleNotifications$ (same notificationId → overwrite, never doubled) if
+    // it lands on EXACTLY the id, dueWithTime and remindAt the instance path produces.
+    // This locks that equality against the REAL instance-creation path.
+    it('matches the mobile pre-scheduler (#7850) on id, dueWithTime and remindAt', async () => {
+      const tomorrowNoon = new Date();
+      tomorrowNoon.setHours(12, 0, 0, 0);
+      tomorrowNoon.setDate(tomorrowNoon.getDate() + 1);
+      const targetDayDate = tomorrowNoon.getTime();
+
+      const cfg = {
+        ...mockTaskRepeatCfg,
+        startTime: '09:00',
+        remindAt: TaskReminderOptionId.AtStart,
+      } as TaskRepeatCfg;
+
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]));
+      // Honour the deterministic id the service passes in (the real impl does too).
+      taskService.createNewTaskWithDefaults.and.callFake(
+        (args: { id?: string }) => ({ ...mockTask, id: args.id }) as Task,
+      );
+
+      const actions = await service._getActionsForTaskRepeatCfg(cfg, targetDayDate);
+      const scheduleAction = actions.find(
+        (a) => a.type === TaskSharedActions.scheduleTaskWithTime.type,
+      ) as ReturnType<typeof TaskSharedActions.scheduleTaskWithTime>;
+      expect(scheduleAction).toBeDefined();
+
+      // What scheduleRepeatReminders$ computes for the same (cfg, day) — see
+      // _getUpcomingRepeatReminders in mobile-notification.effects.ts.
+      const dueDayStr = getDbDateStr(targetDayDate);
+      const expectedId = getRepeatableTaskId(cfg.id, dueDayStr);
+      const expectedDueWithTime = getDateTimeFromClockString('09:00', targetDayDate);
+      const expectedRemindAt = remindOptionToMilliseconds(
+        expectedDueWithTime,
+        TaskReminderOptionId.AtStart,
+      );
+
+      expect(scheduleAction.task.id).toBe(expectedId);
+      expect(scheduleAction.dueWithTime).toBe(expectedDueWithTime);
+      expect(scheduleAction.remindAt).toBe(expectedRemindAt);
     });
 
     it('should throw error if no id', async () => {


### PR DESCRIPTION
Closes #7850

## Problem

On mobile, a timed recurring task (e.g. a daily reminder at 00:05) does **not** fire if the app is closed before the next instance is created. Native scheduling was bound to already-created task instances, but while the app is suspended the JS runtime is frozen — so the logical-day rollover that creates the next due instance never ticks, and its OS alarm is never registered. The notification is silently missed.

## Root cause

The next recurring instance (the entity `scheduleNotifications$` keys its alarm off) is only created when the app is running. Closed app → no instance → no alarm.

## Fix

A new `scheduleRepeatReminders$` effect pre-schedules OS alarms **directly from the active task-repeat configs** (14-day look-ahead), independent of whether the instance exists yet:

- Uses the **same deterministic notification id** the real instance will eventually get (`generateNotificationId(getRepeatableTaskId(cfgId, dayStr))`). Verified against the native layer: `FLAG_UPDATE_CURRENT` + `ReminderAlarmStore` dedup by `notificationId` means same id ⇒ **overwrite, never a duplicate**. When the real instance materialises, the alarm is simply replaced.
- Reuses `selectTaskRepeatCfgsForExactDay`'s projector per day, so the `isPaused` / already-created / `deletedInstanceDates` / archived-project / `waitForCompletion` guards stay in lockstep with the instance-creation path.
- Time computation mirrors `TaskRepeatCfgService` exactly (`getDateTimeFromClockString` + `remindOptionToMilliseconds`), proven by a cross-check test against the real producer.

### Sync-safe
`dispatch: false`, no store mutations — native scheduling only, same model as the existing `scheduleNotifications$`.

### Settle-window guard (load-bearing)
Instance creation dispatches `addTask → updateTaskRepeatCfg → scheduleTaskWithTime` back-to-back. A `debounceTime` ensures the effect only ever evaluates the **settled** store state, so it can't observe the transient "config advanced but `remindAt` not yet set" window and cancel an about-to-graduate alarm.

### iOS 64-pending cap
iOS caps pending local notifications at 64 globally and silently drops the overflow. The pre-scheduler is bounded to the soonest-firing `REPEAT_MAX_SCHEDULED` occurrences (matching iOS's own keep-soonest eviction) with truncation logged. Android (AlarmManager) is unaffected.

## Testing

- New effect coverage + a burst-regression test (asserts no cancel of an about-to-graduate alarm) + cap test.
- Cross-check test: pre-scheduler and the real instance path agree on `id`, `dueWithTime` and `remindAt`.
- Related-suite sweep green: `mobile-notification.effects` 25/25, full `task-repeat-cfg/**` 542/542, `core/platform` + `reminder` + `android` + `tasks/store` 426/426.

## Not covered here (device-only)
On-device repro of the literal 00:05 scenario (force-close before midnight, reboot-before-fire) — the JS logic and the native persistence/overwrite/reboot chain (`BootReceiver` re-registers on `BOOT_COMPLETED` + `MY_PACKAGE_REPLACED`) are verified in code/tests, but an end-to-end device check is still worthwhile before release.