### PR TITLE
fix(task-repeat): allow selecting today as start date across timezones (#7768)

### DIFF
--- a/src/app/ui/date-picker-input/date-picker-input.component.spec.ts
+++ b/src/app/ui/date-picker-input/date-picker-input.component.spec.ts
@@ -52,6 +52,29 @@ describe('DatePickerInputComponent', () => {
       const date = new Date(2026, 5, 1);
       expect(comp.validateDate(date)).toBe(false);
     });
+
+    // Regression: the MatDatepicker emits selections at LOCAL midnight, while a
+    // string `min` was parsed as UTC midnight. In positive-offset timezones the
+    // selection then compared as "before min", so picking exactly the min day
+    // (e.g. today, once #7799 clamped the start-date floor to today) was
+    // silently rejected — "can't set start date to today" (#7768).
+    it('should accept a value equal to a string min on the same calendar day (#7768)', () => {
+      const fixture = TestBed.createComponent(DatePickerInputComponent);
+      fixture.componentRef.setInput('min', '2026-05-29');
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      const pickedLocalMidnight = new Date(2026, 4, 29);
+      expect(comp.validateDate(pickedLocalMidnight)).toBe(true);
+    });
+
+    it('should accept a value equal to a string max on the same calendar day (#7768)', () => {
+      const fixture = TestBed.createComponent(DatePickerInputComponent);
+      fixture.componentRef.setInput('max', '2026-05-29');
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      const pickedLocalMidnight = new Date(2026, 4, 29);
+      expect(comp.validateDate(pickedLocalMidnight)).toBe(true);
+    });
   });
 
   describe('onValueChange', () => {

--- a/src/app/ui/date-picker-input/date-picker-input.component.ts
+++ b/src/app/ui/date-picker-input/date-picker-input.component.ts
@@ -74,7 +74,13 @@ export class DatePickerInputComponent implements ControlValueAccessor {
   private _cd = inject(ChangeDetectorRef);
 
   toDate(value: Date | string): Date {
-    return value instanceof Date ? value : new Date(value);
+    // Parse YYYY-MM-DD strings to LOCAL midnight (via dateStrToUtcDate),
+    // matching both writeValue's parsing and the MatDatepicker's
+    // local-midnight selections. `new Date('2026-05-29')` would parse as UTC
+    // midnight instead, so in positive-offset timezones a selection equal to a
+    // string `min` (e.g. today) compares as "before min" and gets silently
+    // rejected (#7768 regression: "can't set start date to today").
+    return value instanceof Date ? value : dateStrToUtcDate(value);
   }
 
   formatDate(value: Date | string | undefined): string {


### PR DESCRIPTION
## What

Fixes the v18.8.0 regression reported on #7768: in positive-UTC-offset timezones (most of Europe/Asia/Africa/Oceania) you could no longer set a recurring task's **Start Date to today** — typing showed *"The entered value is not a datetime\!"* and the date picker wouldn't let you Save.

## Why

#7799 clamped the start-date picker's `min` to today (Bug 4). That surfaced a latent off-by-one in `DatePickerInputComponent`: `toDate` parsed string `min`/`max` via `new Date('2026-05-29')` (**UTC** midnight), while the MatDatepicker emits selections at **local** midnight. In a `+` offset, a selection equal to `min` (today) compares as *before* min, so `validateDate` rejected it and `onValueChange` silently nulled the value → the field became `required`-invalid → Save blocked, with the generic `E_DATETIME` error shown.

Before #7799 the field had no `min` (default `1900-01-01`), so the off-by-one never mattered; clamping `min` to today made it bite exactly at the today boundary. The bug is timezone-dependent — fine at `-` offsets, broken at `+`.

## Fix

Parse string bounds with `dateStrToUtcDate` (local midnight), matching both `writeValue`'s own parsing and the picker's selections. One line in `toDate`.

## Tests

Added min/max same-calendar-day boundary regression tests. They fail pre-fix and cover **both** offset directions via the dual-TZ Karma suite (Europe/Berlin fails the `min` case pre-fix; America/Los_Angeles fails the `max` case pre-fix). Verified green in both timezones; the existing repeat-cfg dialog spec is unaffected.

## Scope

- Bugs 1, 2, 4 of #7768 were fixed in #7799; this PR repairs the regression Bug 4's clamp introduced.
- Bug 3 ("deleting a live recurring instance leaves an un-regenerable hole") is intentionally **not** in this PR — split out to #7859, as it needs a deletion-semantics decision.

Closes #7768
