### PR TITLE
test(sections): de-flake intra-section drag reorder e2e

### DIFF
--- a/e2e/tests/work-view/sections.spec.ts
+++ b/e2e/tests/work-view/sections.spec.ts
@@ -129,6 +129,60 @@ test.describe('Sections', () => {
     await page.mouse.up();
   };
 
+  /**
+   * Disable Angular animations for the current session before driving CDK
+   * drag gestures that reorder tasks *already inside* a section. Each drop
+   * re-creates the moved task as a fresh `@for` `:enter`, so it replays the
+   * `expandInOnly` animation (`height: 0 -> *`, expand.ani.ts) and has a
+   * zero-height layout box mid-animation. `boundingBox()` returns `null` for
+   * that, which is the root cause of the "drag source/target has no bounding
+   * box" flake (and why the cross-section tests below are fixme'd).
+   *
+   * Flipping the app's own `isDisableAnimations` config toggles the
+   * `@HostBinding('@.disabled')` on the root component (app.component.ts),
+   * which disables every `@trigger` including `expandInOnly` — so dropped
+   * tasks render at full height instantly and their box never collapses.
+   *
+   * NOTE: only the intra-section reorder test uses this. The "drops a task
+   * into a section" test intentionally keeps animations on: it drags out of
+   * the no-section list into an *empty* section, and with animations off the
+   * source-removal reflow is instant, so the empty drop target can jump out
+   * from under the in-flight pointer and the drop misses.
+   */
+  const disableAnimations = async (
+    page: import('@playwright/test').Page,
+  ): Promise<void> => {
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const store = (
+              window as unknown as {
+                __e2eTestHelpers?: { store?: { dispatch: (a: unknown) => void } };
+              }
+            ).__e2eTestHelpers?.store;
+            if (!store) return false;
+            store.dispatch({
+              // updateGlobalConfigSection
+              // (src/app/features/config/store/global-config.actions.ts)
+              type: '[Global Config] Update Global Config Section',
+              sectionKey: 'misc',
+              sectionCfg: { isDisableAnimations: true },
+              isSkipSnack: true,
+            });
+            return true;
+          }),
+        { timeout: 10000 },
+      )
+      .toBe(true);
+    // `global-theme.service` mirrors the config onto a body class via an
+    // `effect()`. Waiting for it confirms the `@.disabled` binding has flipped
+    // before the first gesture reads layout.
+    await page
+      .locator('body.isDisableAnimations')
+      .waitFor({ state: 'attached', timeout: 5000 });
+  };
+
   test('creates a section via the project context menu', async ({
     page,
     workViewPage,
@@ -286,6 +340,7 @@ test.describe('Sections', () => {
     projectPage,
   }) => {
     await setupTestProject(workViewPage, projectPage);
+    await disableAnimations(page);
 
     await openProjectContextMenu(page);
     await clickAddSection(page);


### PR DESCRIPTION
Fixes the intermittent `reorders tasks within a section via drag and drop` failure (e.g. CI run 26681989260, `drag source/target has no bounding box`).

## Root cause

Each CDK drop re-creates the moved task as a fresh `@for` `:enter`, so it replays the `expandInOnly` animation (`height: 0 -> *`, `expand.ani.ts`). Mid-animation the task's layout box collapses to zero height, so Playwright's `boundingBox()` returns `null` and the gesture throws. With `retries: 0` (set by policy to surface determinism issues) one such race fails the whole job.

## Fix

Disable animations for this test via the app's own `isDisableAnimations` config, which toggles `@HostBinding('@.disabled')` on the root component and removes the `height:0` window entirely. Dispatched through the existing `window.__e2eTestHelpers.store` hook (same pattern as the recurring-task / doc-mode specs); settled by waiting for the reactive `body.isDisableAnimations` class. Verified **5/5** green locally.

## Scope

Reorder test only. The cross-list `drops a task into a section` test deliberately keeps animations on — disabling them makes the empty drop target reflow instantly and miss (observed + reverted, then re-verified 3/3 green). Pure test change; no app code touched.