### PR TITLE
test(e2e): de-flake three scheduled-run E2E failures

### DIFF
--- a/e2e/pages/supersync.page.ts
+++ b/e2e/pages/supersync.page.ts
@@ -2032,27 +2032,29 @@ export class SuperSyncPage extends BasePage {
       'input[name="confirmPassword"]',
     );
 
-    // fill() can resolve before the OnPush dialog's [(ngModel)] two-way
-    // binding commits the value, intermittently leaving a field empty (and
-    // the confirm button permanently disabled) even though the fill itself
-    // succeeded. Re-fill each field until its value is committed in the DOM
-    // before relying on the confirm button's enabled state.
-    for (const input of [newPasswordInput, confirmPasswordInput]) {
-      await expect(async () => {
-        if ((await input.inputValue()) !== newPassword) {
-          await input.fill(newPassword);
-          await input.blur(); // Trigger ngModel update
-        }
-        await expect(input).toHaveValue(newPassword, { timeout: 1000 });
-      }).toPass({ timeout: 5000 });
-    }
-
     // Click the "Change Password" confirm button (mat-flat-button, not the "Disable Encryption" button which is mat-stroked-button)
     const confirmBtn = changePasswordDialog.locator(
       'button[mat-flat-button][color="warn"]',
     );
     await confirmBtn.waitFor({ state: 'visible', timeout: 5000 });
-    await expect(confirmBtn).toBeEnabled({ timeout: 5000 });
+
+    // fill() can resolve before the OnPush dialog's [(ngModel)] two-way
+    // binding commits the value, intermittently leaving a field empty — or
+    // committed-but-with-the-form-validity-still-lagging — which leaves the
+    // confirm button disabled even though the fill itself succeeded. Re-fill
+    // both fields until the confirm button is actually enabled, folding the
+    // value-commit and validity waits together so a lagging button re-triggers
+    // a re-fill instead of failing the assertion.
+    await expect(async () => {
+      for (const input of [newPasswordInput, confirmPasswordInput]) {
+        if ((await input.inputValue()) !== newPassword) {
+          await input.fill(newPassword);
+          await input.blur(); // Trigger ngModel update
+        }
+      }
+      await expect(confirmBtn).toBeEnabled({ timeout: 1000 });
+    }).toPass({ timeout: 10000 });
+
     await confirmBtn.click();
 
     // Wait for the dialog to close (password change complete)

--- a/e2e/tests/focus-mode/auto-start-focus-on-play.spec.ts
+++ b/e2e/tests/focus-mode/auto-start-focus-on-play.spec.ts
@@ -80,7 +80,11 @@ test.describe('autoStartFocusOnPlay', () => {
 
     // Expected: focus session spawns and the header countdown becomes the
     // surface (per the rework, the overlay must NOT auto-open here).
-    await expect(focusRunningLabel).toBeVisible({ timeout: 5000 });
+    // The indicator appears only after an async effect chain
+    // (syncTrackingStartToSession$ → startFocusSession → reducer → selector →
+    // OnPush render), so use the suite's default expect timeout (20s, set for
+    // slow rendering) rather than a tight 5s that flakes under CI parallel load.
+    await expect(focusRunningLabel).toBeVisible();
     await expect(focusOverlay).not.toBeVisible();
   });
 

--- a/e2e/tests/work-view/sections.spec.ts
+++ b/e2e/tests/work-view/sections.spec.ts
@@ -80,22 +80,29 @@ test.describe('Sections', () => {
    * so the read can't race the re-render. This is the failure the two
    * `test.fixme`s below hit; keeping the guard here lets the active tests
    * stay reliable instead of throwing "no bounding box".
+   *
+   * The box captured *inside* the poll is the one returned — re-reading
+   * after the poll reopens the very race the poll closes (the list can
+   * re-render in the gap, making the second read return `null`).
    */
   const stableBoundingBox = async (
     locator: import('@playwright/test').Locator,
   ): Promise<{ x: number; y: number; width: number; height: number }> => {
     await locator.waitFor({ state: 'visible', timeout: 10000 });
+    let box: { x: number; y: number; width: number; height: number } | null = null;
     await expect
       .poll(
         async () => {
           const b = await locator.boundingBox();
-          return !!b && b.width > 0 && b.height > 0;
+          if (b && b.width > 0 && b.height > 0) {
+            box = b;
+            return true;
+          }
+          return false;
         },
         { timeout: 10000 },
       )
       .toBe(true);
-    // The poll guarantees a real box exists; re-read it for the gesture.
-    const box = await locator.boundingBox();
     if (!box) throw new Error('drag source/target has no bounding box');
     return box;
   };


### PR DESCRIPTION
Fixes the flaky failures observed in scheduled master E2E run [26672979319](https://github.com/super-productivity/super-productivity/actions/runs/26672979319) — all single-attempt (`retries: 0` by design).

## Failures addressed
| Test | Symptom | Fix |
|------|---------|-----|
| `work-view/sections.spec.ts` reorders via DnD | `drag source/target has no bounding box` | `stableBoundingBox` polled until a box existed then **re-read** it, reopening the TOCTOU race the poll closes (the CDK list re-renders in the gap). Now the validated box is captured inside the poll and returned directly. |
| `focus-mode/auto-start-focus-on-play.spec.ts` indicator-only | `focus-running-label` not visible after 5s | The indicator is gated behind an async effect chain (`syncTrackingStartToSession$` → `startFocusSession` → reducer → selector → OnPush render). The assertion used a hardcoded `{ timeout: 5000 }`, tighter than the suite's 20s default (set for slow rendering). Inherit the default. |
| `sync/supersync-wrong-password-error.spec.ts` overwrite remote | `changeEncryptionPassword` warn button stayed `disabled` | The helper committed input *values* in one loop, then separately asserted the button enabled, with no recovery when form validity lagged. Fold the re-fill and `toBeEnabled` into one `toPass` so a still-disabled button re-triggers a re-fill. |

## Not included
`supersync-server-migration.spec.ts:266` (180s timeout) is a deliberately heavy test (3 migrations + sync) hitting its self-imposed budget under parallel CI load — an infra/load issue, not a test-mechanics bug, so left for separate triage.

## Verification
- sections + focus files: ran locally, all pass (incl. the previously-failing DnD reorder test).
- wrong-password: lint + typecheck clean; the docker `@supersync` suite isn't runnable in the dev sandbox (network-namespace isolation), so this one is reasoning/static-verified only.