### PR TITLE
fix(focus-mode): re-sync timer on Android resume (#7856)

### DIFF
--- a/src/app/features/android/store/android-focus-mode.effects.spec.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.spec.ts
@@ -21,8 +21,22 @@
 
 import { Subject } from 'rxjs';
 import { Action } from '@ngrx/store';
-import { createFocusResumeTick$ } from './android-focus-mode.effects';
+import {
+  createFocusResumeTick$,
+  hasFocusNotificationStateChanged,
+} from './android-focus-mode.effects';
 import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
+import { TimerState } from '../../focus-mode/focus-mode.model';
+
+const MIN = 60_000;
+const workTimer = (elapsed: number, over: Partial<TimerState> = {}): TimerState => ({
+  isRunning: true,
+  startedAt: 0,
+  elapsed,
+  duration: 25 * MIN,
+  purpose: 'work',
+  ...over,
+});
 
 describe('AndroidFocusModeEffects: focus timer resume re-sync (#7856)', () => {
   let onResume$: Subject<void>;
@@ -51,5 +65,44 @@ describe('AndroidFocusModeEffects: focus timer resume re-sync (#7856)', () => {
 
     expect(emitted.length).toBe(3);
     emitted.forEach((a) => expect(a).toEqual(focusModeActions.tick()));
+  });
+});
+
+// The notification reconciles with the in-app countdown only when
+// syncFocusModeToNotification$ decides state changed. Elapsed-only updates are
+// throttled to 5s, but the large elapsed jump produced by a resume tick (#7856)
+// must cross that threshold so the corrected value is pushed to native — closing
+// the loop so BOTH the app and the notification end up correct.
+describe('hasFocusNotificationStateChanged (notification reconciliation, #7856)', () => {
+  it('pushes a native update after a resume tick (elapsed jumps well past 5s)', () => {
+    // Backgrounded at 5 min elapsed; resume tick recomputes elapsed to 15 min.
+    const beforeResume = workTimer(5 * MIN);
+    const afterResume = workTimer(15 * MIN);
+
+    expect(hasFocusNotificationStateChanged(beforeResume, afterResume)).toBe(true);
+  });
+
+  it('throttles a normal 1-second tick (elapsed diff < 5s)', () => {
+    expect(hasFocusNotificationStateChanged(workTimer(60_000), workTimer(61_000))).toBe(
+      false,
+    );
+  });
+
+  it('pushes immediately when the timer is paused/resumed (isRunning flips)', () => {
+    const running = workTimer(5 * MIN);
+    const paused = workTimer(5 * MIN, { isRunning: false });
+
+    expect(hasFocusNotificationStateChanged(running, paused)).toBe(true);
+  });
+
+  it('pushes immediately when purpose changes (work -> break)', () => {
+    const work = workTimer(5 * MIN);
+    const brk = workTimer(5 * MIN, { purpose: 'break' });
+
+    expect(hasFocusNotificationStateChanged(work, brk)).toBe(true);
+  });
+
+  it('always pushes the first emission (no previous state)', () => {
+    expect(hasFocusNotificationStateChanged(undefined, workTimer(0))).toBe(true);
   });
 });

--- a/src/app/features/android/store/android-focus-mode.effects.spec.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Effect test for GitHub issue #7856
+ * https://github.com/super-productivity/super-productivity/issues/7856
+ *
+ * The in-app Focus/Pomodoro countdown is driven by an RxJS `interval(1000)`
+ * (FocusModeService) that Android/Chromium freezes for a backgrounded WebView,
+ * so no `tick` fires while away and the display drifts from the still-accurate
+ * native notification. Time tracking avoids this by re-syncing from native on
+ * `androidInterface.onResume$` (see android-foreground-tracking.effects
+ * `syncOnResume$`); focus mode had no equivalent.
+ *
+ * Fix: on app resume, dispatch a `tick()` so the wall-clock-based reducer
+ * (`elapsed = Date.now() - startedAt`) snaps the countdown back to the truth.
+ * The reducer no-ops `tick` for idle/paused timers, so the effect dispatches
+ * unconditionally (see focus-mode.bug-7856.spec for that guarantee).
+ *
+ * The gated effect wiring (`IS_ANDROID_WEB_VIEW && createEffect(...)`) cannot be
+ * instantiated under Karma, so the stream logic lives in the exported
+ * `createFocusResumeTick$` factory and is exercised directly here.
+ */
+
+import { Subject } from 'rxjs';
+import { Action } from '@ngrx/store';
+import { createFocusResumeTick$ } from './android-focus-mode.effects';
+import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
+
+describe('AndroidFocusModeEffects: focus timer resume re-sync (#7856)', () => {
+  let onResume$: Subject<void>;
+  let emitted: Action[];
+
+  beforeEach(() => {
+    onResume$ = new Subject<void>();
+    emitted = [];
+    createFocusResumeTick$(onResume$).subscribe((a) => emitted.push(a));
+  });
+
+  it('does not emit before the app resumes', () => {
+    expect(emitted).toEqual([]);
+  });
+
+  it('dispatches tick() when the app resumes', () => {
+    onResume$.next();
+
+    expect(emitted).toEqual([focusModeActions.tick()]);
+  });
+
+  it('dispatches one tick() for every resume event', () => {
+    onResume$.next();
+    onResume$.next();
+    onResume$.next();
+
+    expect(emitted.length).toBe(3);
+    emitted.forEach((a) => expect(a).toEqual(focusModeActions.tick()));
+  });
+});

--- a/src/app/features/android/store/android-focus-mode.effects.spec.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.spec.ts
@@ -24,6 +24,7 @@ import { Action } from '@ngrx/store';
 import {
   createFocusResumeTick$,
   hasFocusNotificationStateChanged,
+  shouldHandleNativeTimerComplete,
 } from './android-focus-mode.effects';
 import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
 import { TimerState } from '../../focus-mode/focus-mode.model';
@@ -104,5 +105,40 @@ describe('hasFocusNotificationStateChanged (notification reconciliation, #7856)'
 
   it('always pushes the first emission (no previous state)', () => {
     expect(hasFocusNotificationStateChanged(undefined, workTimer(0))).toBe(true);
+  });
+});
+
+// handleNativeTimerComplete$ acts on a native completion only while the matching
+// session is still active. The work-session guard is what prevents a double
+// completion when a resume tick (#7856) already finished the session before the
+// buffered native event is delivered.
+describe('shouldHandleNativeTimerComplete (native completion guard, #7856)', () => {
+  it('handles a work completion while the work timer is still running', () => {
+    expect(shouldHandleNativeTimerComplete(false, workTimer(25 * MIN))).toBe(true);
+  });
+
+  it('ignores a work completion once the timer has stopped (resume tick already completed it)', () => {
+    expect(
+      shouldHandleNativeTimerComplete(false, workTimer(34 * MIN, { isRunning: false })),
+    ).toBe(false);
+  });
+
+  it('ignores a work completion when the session is already idle (purpose null)', () => {
+    expect(
+      shouldHandleNativeTimerComplete(
+        false,
+        workTimer(0, { isRunning: false, purpose: null }),
+      ),
+    ).toBe(false);
+  });
+
+  it('handles a break completion while a break is active', () => {
+    expect(
+      shouldHandleNativeTimerComplete(true, workTimer(5 * MIN, { purpose: 'break' })),
+    ).toBe(true);
+  });
+
+  it('ignores a break completion when the active session is work, not break', () => {
+    expect(shouldHandleNativeTimerComplete(true, workTimer(5 * MIN))).toBe(false);
   });
 });

--- a/src/app/features/android/store/android-focus-mode.effects.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.ts
@@ -30,6 +30,26 @@ import { GlobalTrackingIntervalService } from '../../../core/global-tracking-int
 export const createFocusResumeTick$ = (onResume$: Observable<void>): Observable<Action> =>
   onResume$.pipe(map(() => focusModeActions.tick()));
 
+/**
+ * Whether the focus-mode notification needs a fresh push to the native service.
+ * Elapsed-only changes are throttled to 5s (the native handler already ticks
+ * every second), but pause/purpose changes — and the large elapsed jump a resume
+ * `tick()` produces (#7856) — must propagate immediately so the notification
+ * reconciles with the corrected in-app countdown.
+ */
+export const hasFocusNotificationStateChanged = (
+  prevTimer: TimerState | undefined,
+  currTimer: TimerState,
+): boolean => {
+  if (!prevTimer) return true;
+  // Pause state changed
+  if (prevTimer.isRunning !== currTimer.isRunning) return true;
+  // Purpose changed (work -> break or vice versa)
+  if (prevTimer.purpose !== currTimer.purpose) return true;
+  // Otherwise throttle elapsed-only updates to every 5 seconds
+  return Math.abs(currTimer.elapsed - prevTimer.elapsed) >= 5000;
+};
+
 @Injectable()
 export class AndroidFocusModeEffects {
   private _store = inject(Store);
@@ -107,7 +127,7 @@ export class AndroidFocusModeEffects {
                   'Failed to start focus mode notification',
                   true,
                 );
-              } else if (this._hasStateChanged(prev?.timer, timer, taskTitle, curr)) {
+              } else if (hasFocusNotificationStateChanged(prev?.timer, timer)) {
                 // Only update if something significant changed
                 DroidLog.log('AndroidFocusModeEffects: Updating focus mode service', {
                   title,
@@ -181,7 +201,15 @@ export class AndroidFocusModeEffects {
   // time tracking re-syncs from native on resume (syncOnResume$).
   resyncFocusTimerOnResume$ =
     IS_ANDROID_WEB_VIEW &&
-    createEffect(() => createFocusResumeTick$(androidInterface.onResume$));
+    createEffect(() =>
+      createFocusResumeTick$(
+        androidInterface.onResume$.pipe(
+          tap(() =>
+            DroidLog.log('AndroidFocusModeEffects: App resumed, re-syncing focus timer'),
+          ),
+        ),
+      ),
+    );
 
   handleFocusSkip$ =
     IS_ANDROID_WEB_VIEW &&
@@ -284,34 +312,5 @@ export class AndroidFocusModeEffects {
       default:
         return 'Focus';
     }
-  }
-
-  private _hasStateChanged(
-    prevTimer: TimerState | undefined,
-    currTimer: TimerState,
-    taskTitle: string | null,
-    curr: {
-      timer: TimerState;
-      mode: FocusModeMode;
-      currentTask: { title: string } | null;
-      isBreakActive: boolean;
-      isLongBreak: boolean;
-      timeRemaining: number;
-    },
-  ): boolean {
-    if (!prevTimer) return true;
-
-    // Check if pause state changed
-    if (prevTimer.isRunning !== currTimer.isRunning) return true;
-
-    // Check if purpose changed (work -> break or vice versa)
-    if (prevTimer.purpose !== currTimer.purpose) return true;
-
-    // Only update notification every 5 seconds to reduce overhead
-    // (native service already updates every second)
-    const elapsedDiff = Math.abs(currTimer.elapsed - prevTimer.elapsed);
-    if (elapsedDiff >= 5000) return true;
-
-    return false;
   }
 }

--- a/src/app/features/android/store/android-focus-mode.effects.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.ts
@@ -50,6 +50,22 @@ export const hasFocusNotificationStateChanged = (
   return Math.abs(currTimer.elapsed - prevTimer.elapsed) >= 5000;
 };
 
+/**
+ * Whether a native timer-complete event should drive a state change. The native
+ * foreground service fires this when its countdown reaches 0; we act on it only
+ * while the matching session is still active in app state — a break event needs an
+ * active break, a work event needs a still-running work session. The work guard is
+ * what makes the native completion a no-op once a resume `tick()` has already
+ * completed the session on return from the background (#7856), so the two never
+ * double-complete. Pure + exported so the `IS_ANDROID_WEB_VIEW`-gated effect's guard
+ * is unit-testable.
+ */
+export const shouldHandleNativeTimerComplete = (
+  isBreak: boolean,
+  timer: TimerState,
+): boolean =>
+  isBreak ? timer.purpose === 'break' : timer.purpose === 'work' && timer.isRunning;
+
 @Injectable()
 export class AndroidFocusModeEffects {
   private _store = inject(Store);
@@ -254,11 +270,7 @@ export class AndroidFocusModeEffects {
           this._store.select(selectTimer),
           this._store.select(selectPausedTaskId),
         ),
-        filter(([isBreak, timer]) =>
-          isBreak
-            ? timer.purpose === 'break'
-            : timer.purpose === 'work' && timer.isRunning,
-        ),
+        filter(([isBreak, timer]) => shouldHandleNativeTimerComplete(isBreak, timer)),
         map(([isBreak, timer, pausedTaskId]) => {
           if (isBreak) {
             return focusModeActions.skipBreak({ pausedTaskId });

--- a/src/app/features/android/store/android-focus-mode.effects.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { createEffect } from '@ngrx/effects';
-import { Store } from '@ngrx/store';
+import { Action, Store } from '@ngrx/store';
 import { filter, map, pairwise, startWith, tap, withLatestFrom } from 'rxjs/operators';
 import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
 import { androidInterface } from '../android-interface';
@@ -14,12 +14,21 @@ import {
 } from '../../focus-mode/store/focus-mode.selectors';
 import * as focusModeActions from '../../focus-mode/store/focus-mode.actions';
 import { selectCurrentTask, selectCurrentTaskId } from '../../tasks/store/task.selectors';
-import { combineLatest } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { FocusModeMode, TimerState } from '../../focus-mode/focus-mode.model';
 import { DroidLog } from '../../../core/log';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+
+/**
+ * On app resume, fire a single `tick()` so the wall-clock-based focus reducer
+ * snaps the in-app countdown back to the truth after the WebView interval was
+ * frozen in the background (#7856). The `tick` reducer is a no-op when the timer
+ * is idle or paused, so no extra guard is needed here.
+ */
+export const createFocusResumeTick$ = (onResume$: Observable<void>): Observable<Action> =>
+  onResume$.pipe(map(() => focusModeActions.tick()));
 
 @Injectable()
 export class AndroidFocusModeEffects {
@@ -164,6 +173,15 @@ export class AndroidFocusModeEffects {
         map(() => focusModeActions.unPauseFocusSession()),
       ),
     );
+
+  // When the app returns to the foreground, the WebView's interval(1000) may have
+  // been frozen while backgrounded, leaving the in-app focus countdown stale and
+  // adrift from the still-accurate native notification (#7856). Fire one tick so
+  // the wall-clock reducer snaps the countdown back to the truth — mirroring how
+  // time tracking re-syncs from native on resume (syncOnResume$).
+  resyncFocusTimerOnResume$ =
+    IS_ANDROID_WEB_VIEW &&
+    createEffect(() => createFocusResumeTick$(androidInterface.onResume$));
 
   handleFocusSkip$ =
     IS_ANDROID_WEB_VIEW &&

--- a/src/app/features/focus-mode/store/focus-mode.bug-7856-completion-race.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.bug-7856-completion-race.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Completion-race test for GitHub issue #7856 (companion to focus-mode.bug-7856.spec).
+ * https://github.com/super-productivity/super-productivity/issues/7856
+ *
+ * The resume-tick fix (AndroidFocusModeEffects.resyncFocusTimerOnResume$) dispatches a
+ * `tick()` on app resume. When a Pomodoro/Countdown session ran PAST its duration while
+ * the app was backgrounded, the native foreground service ALSO completes: it decrements
+ * `remainingMs` to 0 on its main-looper handler and fires ACTION_TIMER_COMPLETE
+ * (FocusModeForegroundService.onTimerComplete). CapacitorMainActivity registers that
+ * broadcast receiver onCreate..onDestroy — NOT onResume/onPause — so the native
+ * completion is delivered (not dropped) even while backgrounded, and is bridged into
+ * `onFocusModeTimerComplete$` -> handleNativeTimerComplete$ -> completeFocusSession.
+ *
+ * On resume, therefore, BOTH a `tick()` and a native completeFocusSession are in play.
+ * Whether the bridged native call executes while still backgrounded (native wins, before
+ * the resume tick) or is deferred until the WebView unfreezes (it races the tick) is
+ * platform-dependent WebView behaviour and can only be confirmed on-device.
+ *
+ * This spec pins the JS-side invariant that must hold in EITHER ordering: exactly one
+ * clean completion — never a double-dispatch, never a dropped completion. It walks the
+ * REAL reducer through both orderings, and ties the two effect guards to their real code
+ * (no re-encoded predicates):
+ *   - handleNativeTimerComplete$'s guard is the exported `shouldHandleNativeTimerComplete`
+ *     used here directly (unit-covered in android-focus-mode.effects.spec.ts). The native
+ *     event dispatches `completeFocusSession({ isManual: false, completedDuration })` only
+ *     while that guard holds, with completedDuration capped at `timer.duration`.
+ *   - detectSessionCompletion$ dispatches `completeFocusSession({ isManual: false })` with
+ *     NO completedDuration on the running->stopped transition, and stays silent once idle.
+ *     Both are covered by the real effect in focus-mode.effects.spec.ts (describe
+ *     'detectSessionCompletion$'); here we apply the action it is proven to emit and assert
+ *     the resulting reducer state.
+ *
+ * The one observable difference between the two orderings — the logged session length —
+ * is asserted explicitly and is benign (see the final test).
+ */
+
+import { focusModeReducer, initialState } from './focus-mode.reducer';
+import * as a from './focus-mode.actions';
+import { FocusModeMode, FocusModeState } from '../focus-mode.model';
+import { shouldHandleNativeTimerComplete } from '../../android/store/android-focus-mode.effects';
+
+const MIN = 60_000;
+const DURATION = 25 * MIN;
+
+/** A running 25-min Pomodoro work session whose last in-app tick was `lastTickAgoMs` ago. */
+const runningWorkSession = (lastTickAgoMs: number): FocusModeState => ({
+  ...initialState,
+  mode: FocusModeMode.Pomodoro,
+  timer: {
+    isRunning: true,
+    startedAt: Date.now() - lastTickAgoMs,
+    elapsed: lastTickAgoMs,
+    duration: DURATION,
+    purpose: 'work',
+  },
+});
+
+/** What detectSessionCompletion$ dispatches once the tick stops an over-run work timer. */
+const completionFromTickPath = (): ReturnType<typeof a.completeFocusSession> =>
+  a.completeFocusSession({ isManual: false });
+
+/** What handleNativeTimerComplete$ dispatches; completedDuration is capped at duration. */
+const completionFromNativePath = (
+  cappedDuration: number,
+): ReturnType<typeof a.completeFocusSession> =>
+  a.completeFocusSession({ isManual: false, completedDuration: cappedDuration });
+
+describe('FocusMode Bug #7856: completion-while-backgrounded race (resume tick vs native complete)', () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(2023, 0, 1, 10, 0, 0));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('tick-wins ordering: the resume tick completes the session and the later native event is filtered out (one completion)', () => {
+    // 25-min Pomodoro last ticked at 24 min, then backgrounded for 10 min -> 34 min of
+    // real time elapsed (9 min past its end) by the time the app resumes.
+    let state = runningWorkSession(24 * MIN);
+    jasmine.clock().tick(10 * MIN);
+
+    // The resume tick fires first.
+    state = focusModeReducer(state, a.tick());
+
+    // The reducer stops the work timer at its true over-run elapsed and marks the duration,
+    // but does NOT clear `purpose` until completeFocusSession runs.
+    expect(state.timer.isRunning).toBe(false);
+    expect(state.timer.purpose).toBe('work');
+    expect(state.lastCompletedDuration).toBe(34 * MIN);
+
+    // The native completion event, arriving in this window, is rejected by the REAL
+    // handleNativeTimerComplete$ guard because the tick already stopped the timer.
+    expect(shouldHandleNativeTimerComplete(false, state.timer)).toBe(false);
+
+    // detectSessionCompletion$ observes the running->stopped transition and dispatches
+    // completeFocusSession (no completedDuration) -> the session ends idle. That emission
+    // is covered by the real effect in focus-mode.effects.spec.ts ('detectSessionCompletion$
+    // should dispatch completeFocusSession when timer completes'); here we apply it and
+    // assert the resulting state.
+    state = focusModeReducer(state, completionFromTickPath());
+    expect(state.timer.purpose).toBeNull();
+    expect(state.lastCompletedDuration).toBe(34 * MIN);
+
+    // A native event delivered even later is still filtered (idle), and a late resume
+    // tick is a no-op on the idle timer -> no double completion.
+    expect(shouldHandleNativeTimerComplete(false, state.timer)).toBe(false);
+    expect(focusModeReducer(state, a.tick())).toBe(state);
+  });
+
+  it('native-wins ordering: the native completion ends the session and the later resume tick is a no-op (one completion)', () => {
+    let state = runningWorkSession(24 * MIN);
+    jasmine.clock().tick(10 * MIN);
+
+    // The native completion fires first, capped at the session duration.
+    state = focusModeReducer(state, completionFromNativePath(DURATION));
+    expect(state.timer.purpose).toBeNull();
+    expect(state.lastCompletedDuration).toBe(DURATION);
+
+    // detectSessionCompletion$ does NOT fire a second completion on the now-idle timer
+    // (purpose null) -> verified against the real effect in focus-mode.effects.spec.ts
+    // ('detectSessionCompletion$ should NOT dispatch when the session is already idle').
+
+    // The resume tick, arriving after, is a no-op on the idle timer -> no double completion.
+    expect(focusModeReducer(state, a.tick())).toBe(state);
+  });
+
+  it('documents the benign duration nondeterminism: tick-wins logs the over-run elapsed, native-wins logs the capped duration', () => {
+    // Same physical scenario, two valid single-completion outcomes that differ ONLY in the
+    // logged session length. Which one occurs depends on platform event ordering (see file
+    // header). 34 min matches desktop/web behaviour (its interval is throttled the same way);
+    // 25 min is the native cap. Neither double-completes nor drops the completion.
+    const base = runningWorkSession(24 * MIN);
+    jasmine.clock().tick(10 * MIN);
+
+    const tickWins = focusModeReducer(
+      focusModeReducer(base, a.tick()),
+      completionFromTickPath(),
+    );
+    const nativeWins = focusModeReducer(base, completionFromNativePath(DURATION));
+
+    expect(tickWins.lastCompletedDuration).toBe(34 * MIN);
+    expect(nativeWins.lastCompletedDuration).toBe(DURATION);
+    expect(tickWins.lastCompletedDuration).not.toBe(nativeWins.lastCompletedDuration);
+
+    // Both orderings end in a single, clean, idle completion.
+    expect(tickWins.timer.purpose).toBeNull();
+    expect(nativeWins.timer.purpose).toBeNull();
+  });
+});

--- a/src/app/features/focus-mode/store/focus-mode.bug-7856.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.bug-7856.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Reducer test for GitHub issue #7856
+ * https://github.com/super-productivity/super-productivity/issues/7856
+ *
+ * Bug (Android): after the app sits in the background for several minutes, the
+ * in-app Pomodoro/Focus countdown differs from the Android notification timer.
+ * The difference is roughly the time spent away (2 min, 10 min, ...). There is
+ * no drift while the app stays in the foreground.
+ *
+ * These tests are a DIAGNOSIS aid, not the fix. They pin down the JS half of the
+ * mechanism so we can be confident about the root cause and about what the fix
+ * must do:
+ *
+ *   1. The in-app remaining time lives in `state.timer.elapsed` and only changes
+ *      when a `tick` action is dispatched. The tick is driven solely by
+ *      `GlobalTrackingIntervalService.globalInterval$` (see
+ *      focus-mode.service.ts), an RxJS `interval(1000)` that Chromium/Android
+ *      freezes for a backgrounded WebView. While frozen, no tick fires, so the
+ *      displayed value is STALE — it drifts from wall-clock truth by exactly the
+ *      background duration. (Test A.)
+ *
+ *   2. The reducer itself is wall-clock based (`elapsed = Date.now() - startedAt`),
+ *      so a SINGLE tick after resume snaps the countdown back to the truth. The
+ *      fix therefore only needs to *fire a tick on resume* (mirroring how time
+ *      tracking re-syncs via `androidInterface.onResume$`); it does not need to
+ *      pull a value from native. (Test B.)
+ *
+ *   3. If the session would have elapsed past its duration while backgrounded,
+ *      the resume tick must still complete it cleanly. (Test C — guards the one
+ *      behavioural risk of a resume-tick fix.)
+ *
+ * The native notification half (it keeps counting accurately on the
+ * foreground-service main-looper handler) is Kotlin and is not exercised here.
+ */
+
+import { focusModeReducer, initialState } from './focus-mode.reducer';
+import * as a from './focus-mode.actions';
+import { selectTimeRemaining } from './focus-mode.selectors';
+import { FocusModeMode, FocusModeState } from '../focus-mode.model';
+
+const MIN = 60_000;
+
+/** Build a running 25-min Pomodoro work session that started `agoMs` ago. */
+const runningSession = (agoMs: number): FocusModeState => ({
+  ...initialState,
+  mode: FocusModeMode.Pomodoro,
+  timer: {
+    isRunning: true,
+    startedAt: Date.now() - agoMs,
+    elapsed: agoMs,
+    duration: 25 * MIN,
+    purpose: 'work' as const,
+  },
+});
+
+/** The value the in-app countdown actually displays. */
+const displayedRemaining = (state: FocusModeState): number =>
+  selectTimeRemaining.projector(state.timer.elapsed, state.timer.duration);
+
+describe('FocusMode Bug #7856: in-app timer drifts from notification after backgrounding', () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(2023, 0, 1, 10, 0, 0));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('A: freezes the in-app countdown while backgrounded (no ticks fire) → drift = background duration', () => {
+    // Session has been running for 5 min and was just ticked, so the display is correct.
+    let state = runningSession(5 * MIN);
+    state = focusModeReducer(state, a.tick());
+    expect(displayedRemaining(state)).toBe(20 * MIN);
+
+    // App goes to background: the WebView interval is frozen, so NO tick fires
+    // for the next 10 minutes of real time.
+    jasmine.clock().tick(10 * MIN);
+
+    // The notification (native handler, wall-clock) would now show 10 min
+    // remaining. But the in-app value is still the stale pre-background value.
+    const trueRemaining = state.timer.duration - (Date.now() - state.timer.startedAt!);
+    expect(trueRemaining).toBe(10 * MIN);
+    expect(displayedRemaining(state)).toBe(20 * MIN); // <-- 10 min adrift = the bug
+  });
+
+  it('B: a single tick on resume reconciles the in-app countdown to wall-clock truth (the fix mechanism)', () => {
+    let state = runningSession(5 * MIN);
+    state = focusModeReducer(state, a.tick());
+    expect(displayedRemaining(state)).toBe(20 * MIN);
+
+    // 10 min in the background, no ticks...
+    jasmine.clock().tick(10 * MIN);
+    expect(displayedRemaining(state)).toBe(20 * MIN); // still stale
+
+    // ...then resume fires exactly ONE tick (what the fix would dispatch).
+    state = focusModeReducer(state, a.tick());
+
+    expect(displayedRemaining(state)).toBe(10 * MIN); // snapped to truth
+    expect(state.timer.isRunning).toBe(true);
+  });
+
+  it('C: resume tick completes the session cleanly if it elapsed past its duration while backgrounded', () => {
+    // 24 min elapsed, 1 min remaining, last ticked at that point.
+    let state = runningSession(24 * MIN);
+    state = focusModeReducer(state, a.tick());
+    expect(displayedRemaining(state)).toBe(1 * MIN);
+
+    // Backgrounded for 10 min — the 25-min session ran out 9 min ago.
+    jasmine.clock().tick(10 * MIN);
+
+    // Resume tick: must stop the timer and report the true completed duration,
+    // not keep ticking and not under-report.
+    state = focusModeReducer(state, a.tick());
+
+    expect(state.timer.isRunning).toBe(false);
+    expect(state.timer.elapsed).toBe(34 * MIN);
+    expect(state.lastCompletedDuration).toBe(34 * MIN);
+  });
+
+  // The resume re-sync effect (AndroidFocusModeEffects.resyncFocusTimerOnResume$)
+  // dispatches `tick()` unconditionally. These two guarantee that is safe — the
+  // reducer must NOT advance a paused or idle timer.
+  it('D: a resume tick must NOT advance a PAUSED session (paused time is not lost)', () => {
+    let state = runningSession(5 * MIN);
+    state = focusModeReducer(state, a.tick());
+    state = focusModeReducer(state, a.pauseFocusSession({ pausedTaskId: null }));
+    expect(state.timer.isRunning).toBe(false);
+    const remainingWhilePaused = displayedRemaining(state);
+
+    // 10 min pass while paused-and-backgrounded, then resume fires a tick.
+    jasmine.clock().tick(10 * MIN);
+    const afterTick = focusModeReducer(state, a.tick());
+
+    expect(afterTick).toBe(state); // untouched
+    expect(displayedRemaining(afterTick)).toBe(remainingWhilePaused);
+  });
+
+  it('E: a resume tick is a no-op when no session is active (idle)', () => {
+    jasmine.clock().tick(10 * MIN);
+    expect(focusModeReducer(initialState, a.tick())).toBe(initialState);
+  });
+});

--- a/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
@@ -2300,6 +2300,35 @@ describe('FocusModeEffects', () => {
       }, 50);
     });
 
+    // #7856: after a native timer-complete ends the session (createIdleTimer ->
+    // purpose null), a following resume tick must NOT make this effect dispatch a
+    // SECOND completeFocusSession. Guards the no-double-completion race invariant.
+    it('should NOT dispatch when the session is already idle (purpose null)', (done) => {
+      store.overrideSelector(
+        selectors.selectTimer,
+        createMockTimer({
+          isRunning: false,
+          purpose: null,
+          duration: 0,
+          elapsed: 0,
+        }),
+      );
+      store.overrideSelector(selectors.selectMode, FocusModeMode.Pomodoro);
+      store.refreshState();
+
+      effects = TestBed.inject(FocusModeEffects);
+
+      const { emitted, subscription } = collectEmissions(
+        effects.detectSessionCompletion$,
+      );
+
+      setTimeout(() => {
+        expect(emitted).toEqual([]);
+        subscription.unsubscribe();
+        done();
+      }, 50);
+    });
+
     // Overtime: when _isOvertimeEnabled is true, the tick reducer keeps the timer running,
     // so detectSessionCompletion$ should never fire. This guard handles the edge case
     // where the user pauses during overtime (isRunning becomes false).


### PR DESCRIPTION
## Summary

Re #7856 — on Android, the in-app Focus/Pomodoro countdown drifts away from the notification timer after the app sits in the background for a while (by roughly the time spent away). No drift while the app stays in the foreground.

> **Not auto-closing #7856:** the fix is Android-only and couldn't be verified on-device here, so this uses `Re` rather than `Fixes`. Confirm on a real Android build before closing (see _Verification_ below).

## Root cause

Focus mode runs two independent timers:

- **In-app display** — an RxJS `interval(1000)` (`FocusModeService`) dispatching `tick`, which Android/Chromium **freezes for a backgrounded WebView**, so no tick fires while away.
- **Notification** — a native `Handler.postDelayed(1000)` on the foreground-service main looper, which keeps running and stays accurate.

Both sides are individually wall-clock based (`elapsed = now - startedAt`), but nothing reconciles them when the app returns to the foreground. Time tracking avoids this by re-syncing from native on `androidInterface.onResume$` (`syncOnResume$`); focus mode had no equivalent. The codebase already documents that `interval()` is unreliable in the background (`global-tracking-interval.service.ts`), which is why `todayDateStr$` merges in resume/visibility events — the focus tick was never given the same treatment.

## Fix

On app resume, dispatch a `tick()` so the wall-clock reducer snaps the in-app countdown back to the truth. The `tick` reducer is a no-op for idle/paused timers, so it dispatches unconditionally — mirroring the sibling `handleFocusResume$`.

Bonus: the resume tick's large `elapsed` jump crosses the 5 s throttle in the notification-sync effect, so the corrected value is also pushed to native — **both** the app and the notification end up correct.

## Tests

- `focus-mode.bug-7856.spec.ts` — characterises the drift, the snap-back on a single tick, clean completion if the session elapsed past its duration while backgrounded, and that `tick` is a no-op for paused/idle timers (makes the unconditional dispatch safe).
- `android-focus-mode.effects.spec.ts` — the resume effect emits `tick()` per resume; and `hasFocusNotificationStateChanged` (extracted from the private `_hasStateChanged`) pushes a native update after a resume tick while still throttling normal 1 s ticks.

All focus-mode + android store suites pass (389), lint clean.

## Verification still recommended (on-device)

Couldn't run the Android build in CI here. A debug-APK A/B closes the platform half: start a Pomodoro → background ~10 min → return; before the fix the app lags the notification, after it snaps within a second. A `DroidLog` was added on resume so logcat shows the full chain (`App resumed, re-syncing focus timer` → tick → `Updating focus mode service`).

The change is Android-gated and rides the same `onResume$` stream time tracking already uses in production, so the merge risk is low (worst case: the fix is inert, not that anything regresses). It can therefore merge before device confirmation — but **verify on the next Android nightly/release before closing #7856.** The reporter says they reproduce it reliably, so they're a good confirmation path once a build ships.

## Scope / not covered

This addresses the WebView-throttle/freeze case (process survives). A separate, distinct failure mode — Android **killing the process** while backgrounded — would reset the (non-persisted) focus state to idle and orphan the notification; that needs focus-timer persistence and is out of scope here.

