### PR TITLE
fix(i18n): boot with bundled English when translation fetch fails offline (#7854)

### DIFF
--- a/e2e/tests/app-features/offline-i18n-load-failure.spec.ts
+++ b/e2e/tests/app-features/offline-i18n-load-failure.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { skipOnboardingForE2E } from '../../utils/waits';
+import { cssSelectors } from '../../constants/selectors';
+
+const { GLOBAL_ERROR_ALERT, ROUTE_WRAPPER } = cssSelectors;
+
+/**
+ * Bug: https://github.com/super-productivity/super-productivity/issues/7854
+ *
+ * The app fetches its translation file at runtime via ngx-translate's
+ * TranslateHttpLoader (`GET ./assets/i18n/<lang>.json`). When that request
+ * fails with a status-0 network error — e.g. the app is opened offline via
+ * Safari's Reading List, which serves the HTML snapshot but bypasses the
+ * service worker that would otherwise serve the cached `en.json` — the loader
+ * has no fallback. The rejected request propagates to `GlobalErrorHandler`,
+ * which treats it as a critical error and renders the `.global-error-alert`
+ * crash card on top of the app instead of letting it boot.
+ *
+ * `route.abort('failed')` reproduces the exact failure mode: Angular's
+ * HttpClient surfaces an aborted fetch as `HttpErrorResponse { status: 0 }`,
+ * which is the `0 Unknown Error` in the report. (The app's
+ * NetworkRetryInterceptorService retries the GET once, so the request is
+ * aborted twice before the error surfaces — that's expected.)
+ *
+ * Expected (post-fix): the translation loader degrades gracefully by falling
+ * back to the English translations bundled at build time, so the app shell
+ * boots, NO crash card appears, AND real translated text renders (not raw keys).
+ *
+ * This test deliberately uses the base Playwright `test` rather than the shared
+ * fixture: the shared `page` fixture auto-navigates and fails the test on any
+ * runtime page error, both of which would abort here during setup. We must
+ * install the route interception *before* the first navigation, and we expect
+ * runtime errors while the bug is present.
+ */
+test.describe('Offline i18n load failure (#7854)', () => {
+  test('should boot with bundled English when the translation file fails to load (status 0)', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      // Auto-dismiss any blocking dialog so the test asserts on the crash card
+      // rather than hanging on a window.confirm/alert.
+      page.on('dialog', (dialog) => {
+        dialog.dismiss().catch(() => {});
+      });
+
+      // Skip onboarding before any app JS runs.
+      await page.addInitScript(skipOnboardingForE2E);
+
+      // Simulate the offline / Reading-List case: the app's own translation
+      // JSON never loads. Aborting yields the HttpErrorResponse status 0 from
+      // the report. Scoped to assets/i18n so plugin i18n files are unaffected.
+      await page.route('**/assets/i18n/*.json', (route) => route.abort('failed'));
+
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+      const crashCard = page.locator(GLOBAL_ERROR_ALERT);
+      const appShell = page.locator(ROUTE_WRAPPER).first();
+
+      // The crash card appears only after the failed GET + the interceptor's
+      // single retry + an async user-data read + a 1.5s reveal timer. We must
+      // wait out that whole window: a plain `not.toBeVisible()` would pass
+      // instantly (before the card has a chance to render) and miss the bug.
+      // While the bug is present this resolves quickly (card appears) and the
+      // assertion below fails; once fixed, the card never appears and the
+      // waitFor times out, yielding `false`.
+      const crashAppeared = await crashCard
+        .waitFor({ state: 'visible', timeout: 15000 })
+        .then(() => true)
+        .catch(() => false);
+
+      // Correct behavior: no crash card, and the app shell booted.
+      expect(crashAppeared).toBe(false);
+      await expect(appShell).toBeVisible();
+
+      // And the bundled English fallback is actually in effect: the side-nav
+      // renders translated labels (the `MH.*` keys), not raw keys. Without the
+      // fix these would read e.g. "MH.PLANNER". This proves the fix serves real
+      // text offline rather than only suppressing the crash card.
+      const sideNav = page.locator(cssSelectors.SIDENAV);
+      await expect(sideNav).toContainText('Planner', { timeout: 15000 });
+      await expect(sideNav).toContainText('Projects');
+      await expect(sideNav).not.toContainText('MH.');
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/src/app/core/http/translate-http-loader-with-fallback.class.spec.ts
+++ b/src/app/core/http/translate-http-loader-with-fallback.class.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
+import {
+  TRANSLATE_HTTP_LOADER_CONFIG,
+  TranslateHttpLoaderConfig,
+} from '@ngx-translate/http-loader';
+import { TranslateHttpLoaderWithFallback } from './translate-http-loader-with-fallback.class';
+import EN_TRANSLATIONS from '../../../assets/i18n/en.json';
+
+describe('TranslateHttpLoaderWithFallback', () => {
+  let loader: TranslateHttpLoaderWithFallback;
+  let httpMock: HttpTestingController;
+
+  const CONFIG: TranslateHttpLoaderConfig = {
+    prefix: './assets/i18n/',
+    suffix: '.json',
+    enforceLoading: false,
+    useHttpBackend: false,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: TRANSLATE_HTTP_LOADER_CONFIG, useValue: CONFIG },
+        TranslateHttpLoaderWithFallback,
+      ],
+    });
+    loader = TestBed.inject(TranslateHttpLoaderWithFallback);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('returns the parsed translations on success', (done) => {
+    // `unknown` avoids the deep recursive `TranslationObject` type blowing up inference.
+    loader.getTranslation('en').subscribe((res: unknown) => {
+      expect(res).toEqual({ HELLO: 'Hello' });
+      done();
+    });
+
+    httpMock.expectOne('./assets/i18n/en.json').flush({ HELLO: 'Hello' });
+  });
+
+  it('falls back to bundled English on a status-0 (offline) error', (done) => {
+    loader.getTranslation('en').subscribe({
+      next: (res: unknown) => {
+        // The whole bundled en.json is returned so the app boots with readable
+        // text rather than raw keys.
+        expect(res).toBe(EN_TRANSLATIONS as unknown as object);
+        done();
+      },
+      error: () => done.fail('should not error on a status-0 failure'),
+    });
+
+    httpMock
+      .expectOne('./assets/i18n/en.json')
+      .error(new ProgressEvent('error'), { status: 0, statusText: '' });
+  });
+
+  it('falls back to bundled English even for a non-English language on a status-0 error', (done) => {
+    loader.getTranslation('de').subscribe({
+      next: (res: unknown) => {
+        expect(res).toBe(EN_TRANSLATIONS as unknown as object);
+        done();
+      },
+      error: () => done.fail('should not error on a status-0 failure'),
+    });
+
+    httpMock
+      .expectOne('./assets/i18n/de.json')
+      .error(new ProgressEvent('error'), { status: 0, statusText: '' });
+  });
+
+  it('rethrows non-status-0 errors (e.g. 404) so real deploy issues stay visible', (done) => {
+    loader.getTranslation('en').subscribe({
+      next: () => done.fail('should not emit a value on a 404'),
+      error: (err: unknown) => {
+        expect(err).toBeInstanceOf(HttpErrorResponse);
+        expect((err as HttpErrorResponse).status).toBe(404);
+        done();
+      },
+    });
+
+    httpMock
+      .expectOne('./assets/i18n/en.json')
+      .flush('Not found', { status: 404, statusText: 'Not Found' });
+  });
+});

--- a/src/app/core/http/translate-http-loader-with-fallback.class.ts
+++ b/src/app/core/http/translate-http-loader-with-fallback.class.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslateLoader, TranslationObject } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { Log } from '../log';
+import { DEFAULT_LANGUAGE } from '../locale.constants';
+import EN_TRANSLATIONS from '../../../assets/i18n/en.json';
+
+/**
+ * TranslateLoader that degrades gracefully when the translation JSON cannot be
+ * fetched because of a transient network failure (`HttpErrorResponse` with
+ * `status === 0`).
+ *
+ * This is the offline / Safari-Reading-List case from issue #7854: the HTML is
+ * served from a cache that bypasses the service worker, so the relative
+ * `GET ./assets/i18n/<lang>.json` never completes and Angular surfaces it as a
+ * status-0 error. The stock {@link TranslateHttpLoader} has no fallback, so the
+ * rejection reaches the GlobalErrorHandler and the app shows a crash card
+ * instead of booting.
+ *
+ * On a status-0 failure we fall back to the English translations bundled at
+ * build time so the app boots with readable text rather than a crash card or
+ * raw translation keys, and self-heals once a cached or online copy is
+ * available. Any other failure (e.g. a 404 or a JSON parse error, which
+ * indicate a genuine deployment problem rather than being offline) is rethrown
+ * so it stays visible.
+ *
+ * The inner {@link TranslateHttpLoader} is created in this provider's injection
+ * context, so its constructor `inject(TRANSLATE_HTTP_LOADER_CONFIG)` resolves
+ * the same prefix/suffix config the app already provides.
+ */
+@Injectable({ providedIn: 'root' })
+export class TranslateHttpLoaderWithFallback implements TranslateLoader {
+  private _httpLoader = new TranslateHttpLoader();
+
+  getTranslation(lang: string): Observable<TranslationObject> {
+    return this._httpLoader.getTranslation(lang).pipe(
+      catchError((err: unknown) => {
+        if (err instanceof HttpErrorResponse && err.status === 0) {
+          // Expected, recoverable offline degrade — warn, don't err.
+          Log.warn(
+            `Translation file for "${lang}" could not be loaded (offline?). ` +
+              `Falling back to bundled English translations so the app can still boot.`,
+          );
+          return of(this._getFallbackTranslations(lang));
+        }
+        throw err;
+      }),
+    );
+  }
+
+  /**
+   * Bundled English baseline for the offline fallback. For non-English
+   * languages we still return English (the only language bundled): English is
+   * the source language with complete key coverage, so it is the best readable
+   * fallback. An empty map for `en` itself would only ever yield raw keys.
+   */
+  private _getFallbackTranslations(lang: string): TranslationObject {
+    if (lang !== DEFAULT_LANGUAGE) {
+      Log.warn(
+        `No bundled translations for "${lang}"; using bundled "${DEFAULT_LANGUAGE}" as fallback.`,
+      );
+    }
+    return EN_TRANSLATIONS as TranslationObject;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,10 +69,8 @@ import { EffectsModule } from '@ngrx/effects';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import {
-  TRANSLATE_HTTP_LOADER_CONFIG,
-  TranslateHttpLoader,
-} from '@ngx-translate/http-loader';
+import { TRANSLATE_HTTP_LOADER_CONFIG } from '@ngx-translate/http-loader';
+import { TranslateHttpLoaderWithFallback } from './app/core/http/translate-http-loader-with-fallback.class';
 import { CdkDropListGroup } from '@angular/cdk/drag-drop';
 import { AppComponent } from './app/app.component';
 import { ShortTimeHtmlPipe } from './app/ui/pipes/short-time-html.pipe';
@@ -187,7 +185,7 @@ bootstrapApplication(AppComponent, {
         fallbackLang: DEFAULT_LANGUAGE,
         loader: {
           provide: TranslateLoader,
-          useClass: TranslateHttpLoader,
+          useClass: TranslateHttpLoaderWithFallback,
         },
       }),
       CdkDropListGroup,


### PR DESCRIPTION
Fixes #7854.

## Problem
The app loads UI translations at runtime via ngx-translate's `TranslateHttpLoader` (`GET ./assets/i18n/<lang>.json`). When that request fails with a status-0 network error — e.g. opened **offline via Safari's Reading List**, which serves the cached HTML but bypasses the service worker that would otherwise serve the cached `en.json` — the stock loader has no fallback. The rejection reaches `GlobalErrorHandler`, which treats it as critical and shows a crash card instead of letting the app boot.

(The reporter's issue body was itself generated by that crash card — the `META:` string and `💥` title come from `getSimpleMeta()` / `getGithubErrorUrl()`.)

## Fix
Wrap `TranslateHttpLoader` in `TranslateHttpLoaderWithFallback`:
- On a `status === 0` failure, fall back to the English translations **bundled at build time** so the app boots with readable text, self-healing once a cached/online copy loads.
- Any other failure (404, JSON parse error = a real deploy problem) is rethrown so it stays visible.

Placed in `core/http/` beside `NetworkRetryInterceptorService`, which already handles the same status-0 transient-network class with the identical guard.

## Trade-off
Bundles ~163 KB (`en.json`) into the main JS for all users — redundant with the SW prefetch for the ~99% with a working service worker, but it guarantees readable English in the offline-bypass case (raw translation keys otherwise). Prod build verified: **initial bundle 4.95 MB raw / 1.09 MB transfer, under the 5.5 MB budget**.

## Tests
- **Unit** (`translate-http-loader-with-fallback.class.spec.ts`): success / status-0 fallback (`en` + non-`en`) / 404 rethrow.
- **E2E** (`offline-i18n-load-failure.spec.ts`): aborts the i18n fetch (yields `HttpErrorResponse status 0`, the reported error), asserts no crash card **and** that the side-nav renders real English (not raw `MH.*` keys). Red before the fix, green after.
- Happy-path e2e (`all-basic-routes-without-error`) unaffected.