### PR TITLE
fix(i18n): fix "resume" translation in Spanish

### DIFF
--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -257,7 +257,7 @@
         "PAUSE": "Pausa",
         "POMODORO_BREAK_RUNNING": "El descanso #{{cycleNr}} está en curso",
         "POMODORO_SESSION_RUNNING": "La sesión Pomodoro #{{cycleNr}} está en curso",
-        "RESUME": "Currículum",
+        "RESUME": "Reanudar",
         "SESSION_RUNNING": "La sesión de enfoque está en curso",
         "START": "INICIO",
         "TO_FOCUS_OVERLAY": "A superposición de enfoque",


### PR DESCRIPTION
## Problem
Translation of "Resume" to Spanish was "Currículum", which means CV.
## Solution
Changed the tranlation to the correct one, "Reanudar"
## Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
