### PR TITLE
docs(caldav): mark VEVENT two-way as shipped via the bundled plugin

### DIFF
--- a/docs/long-term-plans/caldav-vevent-expansion-design.md
+++ b/docs/long-term-plans/caldav-vevent-expansion-design.md
@@ -1,6 +1,17 @@
 # CalDAV VEVENT Expansion — Design Document
 
-> **Status: Planned**
+> **Status: Implemented — via a separate bundled plugin, not by extending the core provider.**
+>
+> Two-way **VEVENT** sync and task→event **time-blocking** shipped in the bundled **"CalDAV Events"**
+> plugin (`packages/plugin-dev/caldav-calendar-provider`), a `type: 'issueProvider'` plugin with
+> `searchIssues`/`getById`/`createIssue`/`updateIssue`/`deleteIssue`, an iCal VEVENT builder plus an
+> RRULE/EXDATE/RECURRENCE-ID-aware reader, PROPFIND calendar discovery, and a working
+> `timeBlock.upsertEvent`/`deleteEvent` (default `pollIntervalMs: 60000`; `allowPrivateNetwork: true`
+> for self-hosters). The **core** CalDAV provider (`src/app/features/issue/providers/caldav/`) remains
+> **VTODO-only**, so a self-hosted household configures the same server twice — the core provider for
+> shared tasks and the bundled plugin for shared events. The original "extend the existing CalDAV
+> provider" approach described below was therefore **not** the path taken; this document is retained for
+> design history.
 
 ## Overview
 


### PR DESCRIPTION
Refreshes the stale status of the CalDAV VEVENT design doc.

Two-way VEVENT + task→event time-blocking shipped via the bundled `caldav-calendar-provider` ("CalDAV Events") plugin, not by extending the core CalDAV provider as this doc originally planned. The core provider remains VTODO-only, so a self-hosted setup configures the same server twice (core = tasks, plugin = events). Adds an accurate status banner + as-built note; retains the historical design below.

Docs-only; no code changes.

Closes #7878

🤖 Generated with [Claude Code](https://claude.com/claude-code)