### PR TITLE
fix(sync): guard against caching empty state over good data (#7892)

### DIFF
--- a/src/app/op-log/persistence/operation-log-compaction.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.spec.ts
@@ -25,8 +25,10 @@ describe('OperationLogCompactionService', () => {
   let mockVectorClockService: jasmine.SpyObj<VectorClockService>;
   let mockClientIdProvider: jasmine.SpyObj<ClientIdProvider>;
 
+  // Meaningful by default (contains a task) so compaction proceeds. The
+  // empty-state guard (#7892) is exercised by dedicated tests below.
   const mockState = {
-    task: { entities: {}, ids: [] },
+    task: { entities: { t1: { id: 't1' } }, ids: ['t1'] },
     project: { entities: {}, ids: [] },
     tag: { entities: {}, ids: [] },
   } as any;
@@ -296,14 +298,17 @@ describe('OperationLogCompactionService', () => {
       expect(capturedFilter!(futureSeqEntry)).toBeFalse();
     });
 
-    it('should handle empty state', async () => {
+    it('should skip compaction entirely when state has no meaningful data (#7892)', async () => {
+      // A transient empty/initial NgRx state must never be cached over good data,
+      // and the op-deletion must not run against it (it would prune the very ops
+      // needed to recover).
       mockStateSnapshot.getStateSnapshot.and.returnValue({} as any);
 
       await service.compact();
 
-      expect(mockOpLogStore.saveStateCache).toHaveBeenCalledWith(
-        jasmine.objectContaining({ state: {} }),
-      );
+      expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
+      expect(mockOpLogStore.deleteOpsWhere).not.toHaveBeenCalled();
+      expect(mockOpLogStore.resetCompactionCounter).not.toHaveBeenCalled();
     });
 
     it('should handle empty vector clock', async () => {
@@ -580,6 +585,9 @@ describe('OperationLogCompactionService', () => {
 
     it('should extract REMINDER entity keys from reminders array', async () => {
       const stateWithReminders = {
+        // Include a task so the empty-state guard (#7892) lets compaction run;
+        // the assertions below target the REMINDER keys specifically.
+        task: { ids: ['t1'], entities: {} },
         reminders: [{ id: 'rem-1' }, { id: 'rem-2' }],
       } as any;
 
@@ -594,6 +602,9 @@ describe('OperationLogCompactionService', () => {
 
     it('should extract singleton entity keys (GLOBAL_CONFIG, PLANNER, etc)', async () => {
       const stateWithSingletons = {
+        // Include a task so the empty-state guard (#7892) lets compaction run;
+        // the assertions below target the singleton keys.
+        task: { ids: ['t1'], entities: {} },
         globalConfig: { someConfig: true },
         planner: { days: [] },
         menuTree: { items: [] },
@@ -613,6 +624,9 @@ describe('OperationLogCompactionService', () => {
 
     it('should extract archived task entity keys', async () => {
       const stateWithArchive = {
+        // Include a live task so the empty-state guard (#7892) lets compaction
+        // run; the assertions below target the archived TASK keys.
+        task: { ids: ['t1'], entities: {} },
         archiveYoung: { task: { ids: ['archived-task-1'], entities: {} } },
         archiveOld: { task: { ids: ['old-archived-task'], entities: {} } },
       } as any;
@@ -627,17 +641,18 @@ describe('OperationLogCompactionService', () => {
       expect(savedCache.snapshotEntityKeys).toContain('TASK:old-archived-task');
     });
 
-    it('should handle empty state gracefully', async () => {
+    it('should skip empty state instead of caching empty keys (#7892)', async () => {
+      // Previously this saved a snapshot with empty snapshotEntityKeys. The
+      // empty-overwrite guard now skips entirely so a transient empty state can
+      // never replace good cached data.
       mockStateSnapshot.getStateSnapshot.and.returnValue({} as any);
 
       await service.compact();
 
-      const savedCache = mockOpLogStore.saveStateCache.calls.mostRecent().args[0];
-      expect(savedCache.snapshotEntityKeys).toBeDefined();
-      expect(savedCache.snapshotEntityKeys!.length).toBe(0);
+      expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
     });
 
-    it('should handle state with empty ids arrays', async () => {
+    it('should skip a state whose collections are all empty (#7892)', async () => {
       const stateWithEmptyIds = {
         task: { ids: [], entities: {} },
         project: { ids: [], entities: {} },
@@ -648,13 +663,7 @@ describe('OperationLogCompactionService', () => {
 
       await service.compact();
 
-      const savedCache = mockOpLogStore.saveStateCache.calls.mostRecent().args[0];
-      // Should have no entity keys (but should not throw)
-      expect(savedCache.snapshotEntityKeys).toBeDefined();
-      const taskKeys = savedCache.snapshotEntityKeys!.filter((k: string) =>
-        k.startsWith('TASK:'),
-      );
-      expect(taskKeys.length).toBe(0);
+      expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
     });
 
     it('should extract entity keys for ALL models defined in MODEL_CONFIGS', async () => {

--- a/src/app/op-log/persistence/operation-log-compaction.service.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.ts
@@ -69,9 +69,14 @@ export class OperationLogCompactionService {
       // GUARD (#7892): never compact against an empty/degraded state. Compaction
       // both writes the state cache AND deletes old synced ops — if the live
       // state were a transient empty/initial state, we would cache emptiness and
-      // then prune the very ops needed to recover. Skip the whole cycle; the next
-      // compaction (with real state) handles it. Replaying the un-pruned op-log
-      // still reconstructs the correct state, including legitimate full wipes.
+      // then prune the very ops needed to recover. Skipping is always safe for
+      // correctness: the op-log stays the source of truth and replaying the
+      // un-pruned log reconstructs the correct state, including legitimate full
+      // wipes. Trade-off: a store that is *genuinely* empty-but-active (e.g. the
+      // user deleted everything yet keeps generating synced ops) will never get
+      // its old synced ops pruned while it stays empty, so the log can grow. That
+      // is an accepted cost — preventing empty-over-good is worth more than GC for
+      // this rare case, and pruning resumes as soon as real data exists again.
       if (!hasMeaningfulStateData(currentState)) {
         OpLog.warn(
           'OperationLogCompactionService: Skipping compaction — current state has no ' +

--- a/src/app/op-log/persistence/operation-log-compaction.service.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.ts
@@ -15,6 +15,7 @@ import { OpLog } from '../../core/log';
 import { extractEntityKeysFromState } from './extract-entity-keys';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 import { limitVectorClockSize } from '../../core/util/vector-clock';
+import { hasMeaningfulStateData } from '../validation/has-meaningful-state-data.util';
 
 /**
  * Manages the compaction (garbage collection) of the operation log.
@@ -64,6 +65,20 @@ export class OperationLogCompactionService {
       // 1. Get current state from NgRx store
       const currentState = this.stateSnapshot.getStateSnapshot();
       this.checkCompactionTimeout(startTime, `${label}state snapshot`);
+
+      // GUARD (#7892): never compact against an empty/degraded state. Compaction
+      // both writes the state cache AND deletes old synced ops — if the live
+      // state were a transient empty/initial state, we would cache emptiness and
+      // then prune the very ops needed to recover. Skip the whole cycle; the next
+      // compaction (with real state) handles it. Replaying the un-pruned op-log
+      // still reconstructs the correct state, including legitimate full wipes.
+      if (!hasMeaningfulStateData(currentState)) {
+        OpLog.warn(
+          'OperationLogCompactionService: Skipping compaction — current state has no ' +
+            'meaningful data (refusing to overwrite cache and prune ops against empty state)',
+        );
+        return;
+      }
 
       // 2. Get current vector clock (max of all ops)
       const currentVectorClock = await this.vectorClockService.getCurrentVectorClock();

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -1017,24 +1017,67 @@ describe('OperationLogHydratorService', () => {
     });
 
     describe('invalid snapshot handling', () => {
-      it('should attempt recovery if snapshot is invalid', async () => {
+      it('should attempt recovery if snapshot is invalid and there are no ops', async () => {
         const invalidSnapshot = createMockSnapshot();
         mockOpLogStore.loadStateCache.and.returnValue(Promise.resolve(invalidSnapshot));
         mockSnapshotService.isValidSnapshot.and.returnValue(false);
+        // #7892: recovery-to-empty is only taken when the op-log is also empty.
+        mockOpLogStore.getLastSeq.and.returnValue(Promise.resolve(0));
 
         await service.hydrateStore();
 
         expect(mockRecoveryService.attemptRecovery).toHaveBeenCalled();
       });
 
-      it('should not dispatch loadAllData if snapshot is invalid', async () => {
+      it('should not dispatch loadAllData if snapshot is invalid and there are no ops', async () => {
         const invalidSnapshot = createMockSnapshot();
         mockOpLogStore.loadStateCache.and.returnValue(Promise.resolve(invalidSnapshot));
         mockSnapshotService.isValidSnapshot.and.returnValue(false);
+        mockOpLogStore.getLastSeq.and.returnValue(Promise.resolve(0));
 
         await service.hydrateStore();
 
         // Only dispatch should NOT happen because recovery takes over
+        expect(mockRecoveryService.attemptRecovery).toHaveBeenCalled();
+      });
+
+      // #7892: when the snapshot/state-cache is corrupt but the op-log is intact
+      // (lastSeq > 0), the hydrator must DISCARD the corrupt snapshot and replay
+      // the op-log instead of dropping to recovery-to-empty. This is the core
+      // data-saving fix; the recovery-to-empty path is reserved for lastSeq === 0.
+      it('should discard a corrupt snapshot and replay the op-log when lastSeq > 0 (#7892)', async () => {
+        const invalidSnapshot = createMockSnapshot();
+        mockOpLogStore.loadStateCache.and.returnValue(Promise.resolve(invalidSnapshot));
+        mockSnapshotService.isValidSnapshot.and.returnValue(false);
+
+        // Op-log is intact: lastSeq > 0 and getOpsAfterSeq(0) returns the ops.
+        const allOps = [
+          createMockEntry(1, createMockOperation('op-1')),
+          createMockEntry(2, createMockOperation('op-2')),
+        ];
+        mockOpLogStore.getLastSeq.and.returnValue(Promise.resolve(2));
+        mockOpLogStore.getOpsAfterSeq.and.returnValue(Promise.resolve(allOps));
+
+        await service.hydrateStore();
+
+        // Must NOT drop to recovery-to-empty.
+        expect(mockRecoveryService.attemptRecovery).not.toHaveBeenCalled();
+        // Must replay the whole op-log from seq 0.
+        expect(mockOpLogStore.getOpsAfterSeq).toHaveBeenCalledWith(0);
+        expect(mockStore.dispatch).toHaveBeenCalledWith(
+          bulkApplyHydrationOperations({ operations: allOps.map((e) => e.op) }),
+        );
+      });
+
+      it('should attempt recovery for an invalid snapshot only when no ops exist (lastSeq === 0) (#7892)', async () => {
+        const invalidSnapshot = createMockSnapshot();
+        mockOpLogStore.loadStateCache.and.returnValue(Promise.resolve(invalidSnapshot));
+        mockSnapshotService.isValidSnapshot.and.returnValue(false);
+        // No op-log to replay.
+        mockOpLogStore.getLastSeq.and.returnValue(Promise.resolve(0));
+
+        await service.hydrateStore();
+
         expect(mockRecoveryService.attemptRecovery).toHaveBeenCalled();
       });
     });

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -117,12 +117,33 @@ export class OperationLogHydratorService {
 
       // 3. Validate snapshot if it exists
       if (snapshot && !this.snapshotService.isValidSnapshot(snapshot)) {
-        OpLog.warn(
-          'OperationLogHydratorService: Snapshot is invalid/corrupted. Attempting recovery...',
-        );
-        await this.recoveryService.attemptRecovery();
-        sessionStorage.removeItem(IDB_OPEN_ERROR_RELOAD_KEY);
-        return;
+        OpLog.warn('OperationLogHydratorService: Snapshot is invalid/corrupted.');
+        // The snapshot is only a load-time cache — the op-log is the source of
+        // truth. Before surrendering to recovery (which, with no legacy data and
+        // no sync, drops to an EMPTY store), check whether the op-log itself is
+        // intact and rebuild from it (#7892).
+        //
+        // Correctness: compaction only ever prunes *synced* ops, so for a
+        // no-sync client the entire log survives and replay-from-0 fully
+        // reconstructs state; for a synced client any pruned ops still live on
+        // the remote and a subsequent sync restores them. Either way, replaying
+        // the surviving log is strictly better than discarding it for empty.
+        const lastSeq = await this.opLogStore.getLastSeq();
+        if (lastSeq > 0) {
+          OpLog.warn(
+            `OperationLogHydratorService: Discarding corrupt snapshot and replaying ` +
+              `the op-log from the start (lastSeq=${lastSeq}).`,
+          );
+          // Fall through to the "no snapshot → replay all operations" branch.
+          snapshot = null;
+        } else {
+          OpLog.warn(
+            'OperationLogHydratorService: No op-log to replay. Attempting recovery...',
+          );
+          await this.recoveryService.attemptRecovery();
+          sessionStorage.removeItem(IDB_OPEN_ERROR_RELOAD_KEY);
+          return;
+        }
       }
 
       if (snapshot) {

--- a/src/app/op-log/persistence/operation-log-snapshot.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-snapshot.service.spec.ts
@@ -12,6 +12,14 @@ import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider
 import { MAX_VECTOR_CLOCK_SIZE } from '@sp/shared-schema';
 import { ValidateStateService } from '../validation/validate-state.service';
 
+// Meaningful state (contains a task) so saveCurrentStateAsSnapshot proceeds past
+// the empty-state guard (#7892). Tests that care only about clock pruning /
+// compactedAt / entity keys use this so the save actually fires; the guard
+// itself has a dedicated test.
+const MEANINGFUL_SNAPSHOT_STATE = {
+  task: { ids: ['t1'], entities: { t1: { id: 't1' } } },
+} as unknown;
+
 describe('OperationLogSnapshotService', () => {
   let service: OperationLogSnapshotService;
   let mockOpLogStore: jasmine.SpyObj<OperationLogStoreService>;
@@ -195,13 +203,27 @@ describe('OperationLogSnapshotService', () => {
     });
 
     it('should not throw when save fails', async () => {
-      mockStateSnapshotService.getStateSnapshot.and.returnValue({} as any);
+      mockStateSnapshotService.getStateSnapshot.and.returnValue(
+        MEANINGFUL_SNAPSHOT_STATE as any,
+      );
       mockVectorClockService.getCurrentVectorClock.and.resolveTo({});
       mockOpLogStore.getLastSeq.and.resolveTo(1);
       mockOpLogStore.saveStateCache.and.rejectWith(new Error('Save failed'));
 
       // Should not throw - errors are caught internally
       await expectAsync(service.saveCurrentStateAsSnapshot()).toBeResolved();
+    });
+
+    it('should skip saving when state has no meaningful data (#7892)', async () => {
+      // A transient empty/initial NgRx state must never be cached over good data.
+      mockStateSnapshotService.getStateSnapshot.and.returnValue({} as any);
+      mockVectorClockService.getCurrentVectorClock.and.resolveTo({ client1: 1 });
+      mockOpLogStore.getLastSeq.and.resolveTo(10);
+      mockOpLogStore.saveStateCache.and.resolveTo(undefined);
+
+      await service.saveCurrentStateAsSnapshot();
+
+      expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
     });
 
     it('should prune vector clock before saving when it exceeds MAX_VECTOR_CLOCK_SIZE', async () => {
@@ -213,7 +235,9 @@ describe('OperationLogSnapshotService', () => {
       // Ensure the local client is in the clock
       bloatedClock['test-client'] = 999;
 
-      mockStateSnapshotService.getStateSnapshot.and.returnValue({} as any);
+      mockStateSnapshotService.getStateSnapshot.and.returnValue(
+        MEANINGFUL_SNAPSHOT_STATE as any,
+      );
       mockVectorClockService.getCurrentVectorClock.and.resolveTo(bloatedClock);
       mockOpLogStore.getLastSeq.and.resolveTo(1);
       mockOpLogStore.saveStateCache.and.resolveTo(undefined);
@@ -229,7 +253,9 @@ describe('OperationLogSnapshotService', () => {
 
     it('should not prune vector clock when it is within MAX_VECTOR_CLOCK_SIZE', async () => {
       const smallClock = { client1: 5, client2: 3 };
-      mockStateSnapshotService.getStateSnapshot.and.returnValue({} as any);
+      mockStateSnapshotService.getStateSnapshot.and.returnValue(
+        MEANINGFUL_SNAPSHOT_STATE as any,
+      );
       mockVectorClockService.getCurrentVectorClock.and.resolveTo(smallClock);
       mockOpLogStore.getLastSeq.and.resolveTo(1);
       mockOpLogStore.saveStateCache.and.resolveTo(undefined);
@@ -245,7 +271,9 @@ describe('OperationLogSnapshotService', () => {
       for (let i = 0; i < MAX_VECTOR_CLOCK_SIZE; i++) {
         exactClock[`client-${i}`] = i + 1;
       }
-      mockStateSnapshotService.getStateSnapshot.and.returnValue({} as any);
+      mockStateSnapshotService.getStateSnapshot.and.returnValue(
+        MEANINGFUL_SNAPSHOT_STATE as any,
+      );
       mockVectorClockService.getCurrentVectorClock.and.resolveTo(exactClock);
       mockOpLogStore.getLastSeq.and.resolveTo(1);
       mockOpLogStore.saveStateCache.and.resolveTo(undefined);
@@ -259,7 +287,9 @@ describe('OperationLogSnapshotService', () => {
     it('should save unpruned clock if clientId is null', async () => {
       mockClientIdProvider.loadClientId.and.resolveTo(null);
       const clock = { client1: 5 };
-      mockStateSnapshotService.getStateSnapshot.and.returnValue({} as any);
+      mockStateSnapshotService.getStateSnapshot.and.returnValue(
+        MEANINGFUL_SNAPSHOT_STATE as any,
+      );
       mockVectorClockService.getCurrentVectorClock.and.resolveTo(clock);
       mockOpLogStore.getLastSeq.and.resolveTo(1);
       mockOpLogStore.saveStateCache.and.resolveTo(undefined);
@@ -272,7 +302,9 @@ describe('OperationLogSnapshotService', () => {
 
     it('should include compactedAt timestamp', async () => {
       const beforeTime = Date.now();
-      mockStateSnapshotService.getStateSnapshot.and.returnValue({} as any);
+      mockStateSnapshotService.getStateSnapshot.and.returnValue(
+        MEANINGFUL_SNAPSHOT_STATE as any,
+      );
       mockVectorClockService.getCurrentVectorClock.and.resolveTo({});
       mockOpLogStore.getLastSeq.and.resolveTo(1);
       mockOpLogStore.saveStateCache.and.resolveTo(undefined);

--- a/src/app/op-log/persistence/operation-log-snapshot.service.ts
+++ b/src/app/op-log/persistence/operation-log-snapshot.service.ts
@@ -12,6 +12,7 @@ import { extractEntityKeysFromState } from './extract-entity-keys';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 import { limitVectorClockSize } from '../../core/util/vector-clock';
 import { ValidateStateService } from '../validation/validate-state.service';
+import { hasMeaningfulStateData } from '../validation/has-meaningful-state-data.util';
 
 type StateCache = MigratableStateCache;
 
@@ -82,6 +83,21 @@ export class OperationLogSnapshotService {
     try {
       // Get current state from NgRx
       const currentState = this.stateSnapshotService.getStateSnapshot();
+
+      // GUARD (#7892): never cache an empty/degraded state over a good one.
+      // The snapshot is only a load-time cache — the op-log is the source of
+      // truth. If the live NgRx state has no user data (e.g. a transient
+      // hydration glitch left the store in its initial empty state), caching it
+      // would make the next boot trust empty data. Skipping the save is always
+      // safe for correctness: replaying the op-log reconstructs the true state
+      // (including legitimate full-wipe deletes), at most costing a slower boot.
+      if (!hasMeaningfulStateData(currentState)) {
+        OpLog.warn(
+          'OperationLogSnapshotService: Skipping snapshot save — current state has no ' +
+            'meaningful data (refusing to overwrite cache with empty state)',
+        );
+        return;
+      }
 
       // Get current vector clock and last seq
       const vectorClock = await this.vectorClockService.getCurrentVectorClock();

--- a/src/app/op-log/sync/sync-local-state.service.ts
+++ b/src/app/op-log/sync/sync-local-state.service.ts
@@ -3,16 +3,9 @@ import { TranslateService } from '@ngx-translate/core';
 import { OperationLogStoreService } from '../persistence/operation-log-store.service';
 import { StateSnapshotService } from '../backup/state-snapshot.service';
 import { OpLog } from '../../core/log';
-import { INBOX_PROJECT } from '../../features/project/project.const';
-import { SYSTEM_TAG_IDS } from '../../features/tag/tag.const';
 import { T } from '../../t.const';
 import { confirmDialog } from '../../util/native-dialogs';
-
-const isEntityState = (obj: unknown): obj is { ids: string[] } =>
-  typeof obj === 'object' &&
-  obj !== null &&
-  'ids' in obj &&
-  Array.isArray((obj as { ids: unknown }).ids);
+import { hasMeaningfulStateData } from '../validation/has-meaningful-state-data.util';
 
 @Injectable({
   providedIn: 'root',
@@ -39,29 +32,7 @@ export class SyncLocalStateService {
       return false;
     }
 
-    if (isEntityState(snapshot.task) && snapshot.task.ids.length > 0) {
-      return true;
-    }
-
-    if (
-      isEntityState(snapshot.project) &&
-      snapshot.project.ids.some((id) => id !== INBOX_PROJECT.id)
-    ) {
-      return true;
-    }
-
-    if (
-      isEntityState(snapshot.tag) &&
-      snapshot.tag.ids.some((id) => !SYSTEM_TAG_IDS.has(id))
-    ) {
-      return true;
-    }
-
-    if (isEntityState(snapshot.note) && snapshot.note.ids.length > 0) {
-      return true;
-    }
-
-    return false;
+    return hasMeaningfulStateData(snapshot);
   }
 
   confirmFreshClientSync(opCount: number): boolean {

--- a/src/app/op-log/testing/integration/compaction.integration.spec.ts
+++ b/src/app/op-log/testing/integration/compaction.integration.spec.ts
@@ -590,4 +590,94 @@ describe('Compaction Integration', () => {
       expect(await storeService.hasStateCacheBackup()).toBe(false);
     });
   });
+
+  // Real-IndexedDB proof of the #7892 fix: a transient empty live state must not
+  // clobber a good on-disk state cache, and must not prune ops. The unit specs
+  // assert this against spies; here we assert it against the REAL store so a bug
+  // in saveStateCache/compact's persistence interaction would also be caught.
+  // Discriminator: the guard's early `return` happens BEFORE resetCompactionCounter(),
+  // so an unchanged counter proves the guard path was taken (without it, compact()
+  // would have overwritten the cache and reset the counter).
+  describe('Empty-state guard (#7892)', () => {
+    it('keeps a good state cache and the op-log intact when live state is empty', async () => {
+      const client = new TestClient('client-guard');
+
+      // Seed synced ops (deletion-eligible if the guard were absent).
+      for (let i = 1; i <= 5; i++) {
+        await storeService.append(
+          createTaskOperation(client, `task-${i}`, OpType.Create, { title: `Task ${i}` }),
+          'local',
+        );
+      }
+      const seeded = await storeService.getOpsAfterSeq(0);
+      await storeService.markSynced(seeded.map((e) => e.seq));
+
+      // A good snapshot already exists on disk — this is what must NOT be lost.
+      const goodState = {
+        task: {
+          ids: ['task-1'],
+          entities: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'task-1': createMinimalTaskPayload('task-1', { title: 'Task 1' }),
+          },
+        },
+      };
+      await storeService.saveStateCache({
+        state: goodState,
+        lastAppliedOpSeq: seeded[seeded.length - 1].seq,
+        vectorClock: client.getCurrentClock(),
+        compactedAt: Date.now(),
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      });
+      await storeService.incrementCompactionCounter();
+
+      // Live NgRx state is the transient empty/initial state.
+      mockStateSnapshot.getStateSnapshot.and.returnValue({
+        task: { ids: [], entities: {} },
+        project: { ids: [], entities: {} },
+        tag: { ids: [], entities: {} },
+        note: { ids: [], entities: {} },
+      } as any);
+
+      await compactionService.compact();
+
+      // Good cache survives untouched (NOT overwritten with empty).
+      const cacheAfter = await storeService.loadStateCache();
+      expect(cacheAfter!.state).toEqual(goodState);
+      // No ops pruned.
+      expect((await storeService.getOpsAfterSeq(0)).length).toBe(5);
+      // Counter NOT reset -> the guard's early return ran.
+      expect(await storeService.getCompactionCounter()).toBe(1);
+    });
+
+    it('resumes compaction (writes cache, resets counter) once real data exists', async () => {
+      const client = new TestClient('client-guard2');
+      await storeService.append(
+        createTaskOperation(client, 'task-1', OpType.Create, { title: 'Task 1' }),
+        'local',
+      );
+      await storeService.incrementCompactionCounter();
+      await storeService.incrementCompactionCounter();
+
+      const liveState = {
+        task: {
+          ids: ['task-1'],
+          entities: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'task-1': createMinimalTaskPayload('task-1', { title: 'Task 1' }),
+          },
+        },
+      };
+      mockStateSnapshot.getStateSnapshot.and.returnValue(liveState as any);
+
+      await compactionService.compact();
+
+      const cacheAfter = await storeService.loadStateCache();
+      expect(cacheAfter).not.toBeNull();
+      expect(cacheAfter!.state).toEqual(liveState);
+      expect(cacheAfter!.snapshotEntityKeys).toContain('TASK:task-1');
+      // Counter reset -> the normal (non-guard) path ran.
+      expect(await storeService.getCompactionCounter()).toBe(0);
+    });
+  });
 });

--- a/src/app/op-log/testing/integration/performance.integration.spec.ts
+++ b/src/app/op-log/testing/integration/performance.integration.spec.ts
@@ -317,6 +317,12 @@ describe('Performance Integration', () => {
       mockStateSnapshot.getAllSyncModelDataFromStore.and.returnValue({
         task: { ids: taskIds, entities: taskEntities },
       } as any);
+      // Compaction reads live state via getStateSnapshot(); give it the same
+      // task-bearing data so the empty-state guard (#7892) doesn't skip the
+      // cycle (the shared default returns an empty store).
+      mockStateSnapshot.getStateSnapshot.and.returnValue({
+        task: { ids: taskIds, entities: taskEntities },
+      } as any);
 
       // Measure compaction
       const compactStart = Date.now();

--- a/src/app/op-log/validation/has-meaningful-state-data.util.spec.ts
+++ b/src/app/op-log/validation/has-meaningful-state-data.util.spec.ts
@@ -1,0 +1,61 @@
+import { hasMeaningfulStateData } from './has-meaningful-state-data.util';
+import { INBOX_PROJECT } from '../../features/project/project.const';
+
+const initialState = (): Record<string, unknown> => ({
+  task: { ids: [], entities: {} },
+  // The default app ships with only the INBOX project and the system tags.
+  project: { ids: [INBOX_PROJECT.id], entities: {} },
+  tag: { ids: ['TODAY', 'NO_LIST'], entities: {} },
+  note: { ids: [], entities: {} },
+});
+
+describe('hasMeaningfulStateData', () => {
+  it('returns false for null/undefined/non-object', () => {
+    expect(hasMeaningfulStateData(null)).toBe(false);
+    expect(hasMeaningfulStateData(undefined)).toBe(false);
+    expect(hasMeaningfulStateData('nope')).toBe(false);
+    expect(hasMeaningfulStateData(42)).toBe(false);
+  });
+
+  it('returns false for an empty object', () => {
+    expect(hasMeaningfulStateData({})).toBe(false);
+  });
+
+  it('returns false for the default/initial app state', () => {
+    expect(hasMeaningfulStateData(initialState())).toBe(false);
+  });
+
+  it('returns true when there is at least one task', () => {
+    const s = initialState();
+    s.task = { ids: ['t1'], entities: {} };
+    expect(hasMeaningfulStateData(s)).toBe(true);
+  });
+
+  it('returns true for a non-INBOX project', () => {
+    const s = initialState();
+    s.project = { ids: [INBOX_PROJECT.id, 'p1'], entities: {} };
+    expect(hasMeaningfulStateData(s)).toBe(true);
+  });
+
+  it('returns true for a non-system tag', () => {
+    const s = initialState();
+    s.tag = { ids: ['TODAY', 'NO_LIST', 'tag1'], entities: {} };
+    expect(hasMeaningfulStateData(s)).toBe(true);
+  });
+
+  it('returns false when only system tags exist', () => {
+    expect(hasMeaningfulStateData(initialState())).toBe(false);
+  });
+
+  it('returns true when there is at least one note', () => {
+    const s = initialState();
+    s.note = { ids: ['n1'], entities: {} };
+    expect(hasMeaningfulStateData(s)).toBe(true);
+  });
+
+  it('ignores malformed (non-entity) collections without throwing', () => {
+    expect(hasMeaningfulStateData({ task: 'broken', project: null, tag: 123 })).toBe(
+      false,
+    );
+  });
+});

--- a/src/app/op-log/validation/has-meaningful-state-data.util.spec.ts
+++ b/src/app/op-log/validation/has-meaningful-state-data.util.spec.ts
@@ -1,11 +1,19 @@
 import { hasMeaningfulStateData } from './has-meaningful-state-data.util';
 import { INBOX_PROJECT } from '../../features/project/project.const';
 
+// The default app ships with only the INBOX project and the built-in system
+// tags (TODAY, EM_URGENT, EM_IMPORTANT, KANBAN_IN_PROGRESS — see SYSTEM_TAG_IDS).
+const SYSTEM_TAG_IDS_FIXTURE = [
+  'TODAY',
+  'EM_URGENT',
+  'EM_IMPORTANT',
+  'KANBAN_IN_PROGRESS',
+];
+
 const initialState = (): Record<string, unknown> => ({
   task: { ids: [], entities: {} },
-  // The default app ships with only the INBOX project and the system tags.
   project: { ids: [INBOX_PROJECT.id], entities: {} },
-  tag: { ids: ['TODAY', 'NO_LIST'], entities: {} },
+  tag: { ids: [...SYSTEM_TAG_IDS_FIXTURE], entities: {} },
   note: { ids: [], entities: {} },
 });
 
@@ -39,7 +47,7 @@ describe('hasMeaningfulStateData', () => {
 
   it('returns true for a non-system tag', () => {
     const s = initialState();
-    s.tag = { ids: ['TODAY', 'NO_LIST', 'tag1'], entities: {} };
+    s.tag = { ids: [...SYSTEM_TAG_IDS_FIXTURE, 'tag1'], entities: {} };
     expect(hasMeaningfulStateData(s)).toBe(true);
   });
 

--- a/src/app/op-log/validation/has-meaningful-state-data.util.ts
+++ b/src/app/op-log/validation/has-meaningful-state-data.util.ts
@@ -1,0 +1,47 @@
+import { INBOX_PROJECT } from '../../features/project/project.const';
+import { SYSTEM_TAG_IDS } from '../../features/tag/tag.const';
+
+const isEntityState = (obj: unknown): obj is { ids: string[] } =>
+  typeof obj === 'object' &&
+  obj !== null &&
+  'ids' in obj &&
+  Array.isArray((obj as { ids: unknown }).ids);
+
+/**
+ * Returns true if the given (partial) app state contains user-created data worth
+ * protecting: at least one task, a non-INBOX project, a non-system tag, or a note.
+ *
+ * The default/initial app state (empty task list, only the INBOX project and the
+ * built-in system tags) returns false. This is the single source of truth for the
+ * "does this state actually have user data?" question, reused by:
+ * - SyncLocalStateService (first-time-sync conflict detection)
+ * - the snapshot/compaction empty-overwrite guard (prevents a transient degraded
+ *   NgRx state from being cached over a good snapshot — see issue #7892).
+ *
+ * Accepts an arbitrary object so callers can pass an NgRx snapshot, a loaded
+ * state cache, or a remote payload without type juggling.
+ */
+export const hasMeaningfulStateData = (state: unknown): boolean => {
+  if (!state || typeof state !== 'object') {
+    return false;
+  }
+  const s = state as Record<string, unknown>;
+
+  if (isEntityState(s.task) && s.task.ids.length > 0) {
+    return true;
+  }
+
+  if (isEntityState(s.project) && s.project.ids.some((id) => id !== INBOX_PROJECT.id)) {
+    return true;
+  }
+
+  if (isEntityState(s.tag) && s.tag.ids.some((id) => !SYSTEM_TAG_IDS.has(id))) {
+    return true;
+  }
+
+  if (isEntityState(s.note) && s.note.ids.length > 0) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/app/op-log/validation/has-meaningful-state-data.util.ts
+++ b/src/app/op-log/validation/has-meaningful-state-data.util.ts
@@ -18,6 +18,13 @@ const isEntityState = (obj: unknown): obj is { ids: string[] } =>
  * - the snapshot/compaction empty-overwrite guard (prevents a transient degraded
  *   NgRx state from being cached over a good snapshot — see issue #7892).
  *
+ * Scope is intentionally narrow (these four collections only) and is always consumed
+ * in the "safe" direction: a false negative merely SKIPS work (a snapshot save, a
+ * compaction, or a fresh-client sync prompt) — it can never cache empty-over-good or
+ * delete data. Omitting models like simpleCounter / taskRepeatCfg / timeTracking
+ * therefore cannot lose data; it would only forgo the snapshot/compaction optimization
+ * for a data-less-but-active store, so it is left out of this safety fix by design.
+ *
  * Accepts an arbitrary object so callers can pass an NgRx snapshot, a loaded
  * state cache, or a remote payload without type juggling.
  */


### PR DESCRIPTION
A local data-loss report (blank app after an overnight gap, no sync, on
Android) surfaced a robustness hole: a transient hydration/IndexedDB
glitch could leave NgRx in its initial empty state, which would then be
written back over the good state cache and, on the next compaction, prune
the very ops needed to recover — turning a recoverable hiccup into
permanent loss.

- Add `hasMeaningfulStateData()` as the single source of truth for "does
  this state contain user data?" (task / non-INBOX project / non-system
  tag / note). Reused by `SyncLocalStateService.hasMeaningfulStoreData()`
  which previously duplicated the predicate.
- Snapshot save (`saveCurrentStateAsSnapshot`) and compaction
  (`_doCompact`) now skip when the live state has no meaningful data,
  refusing to overwrite the cache (and, in compaction, refusing to prune
  ops) against empty state. Skipping is always safe: the op-log is the
  source of truth and replay reconstructs the true state, including
  legitimate full wipes.
- Hydrator: when the state cache is invalid/corrupt but the op-log is
  intact (lastSeq > 0), replay the log from the start instead of dropping
  straight to recovery-to-empty.

Adds unit tests for the new predicate; existing snapshot/compaction/
hydrator/sync-local-state specs still pass.