### PR TITLE
Allow dragging tasks into subtask lists

### DIFF
--- a/src/app/features/tasks/task-list/task-list.component.spec.ts
+++ b/src/app/features/tasks/task-list/task-list.component.spec.ts
@@ -14,6 +14,7 @@ import { TaskWithSubTasks } from '../task.model';
 import { SectionService } from '../../section/section.service';
 import { moveSubTask } from '../store/task.actions';
 import { WorkContextType } from '../../work-context/work-context.model';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 
 describe('TaskListComponent', () => {
   let component: TaskListComponent;
@@ -22,7 +23,11 @@ describe('TaskListComponent', () => {
   let store: MockStore;
 
   // Helper to create mock CdkDrag
-  const createMockDrag = (task: { id: string; parentId: string | null }): CdkDrag =>
+  const createMockDrag = (task: {
+    id: string;
+    parentId: string | null;
+    subTaskIds?: string[];
+  }): CdkDrag =>
     ({
       data: task,
     }) as unknown as CdkDrag;
@@ -194,10 +199,17 @@ describe('TaskListComponent', () => {
         expect(component.enterPredicate(drag, drop)).toBe(true);
       });
 
-      it('should block parent task from dropping to subtask list', () => {
-        const task = { id: 'task1', parentId: null };
+      it('should allow parent task without subtasks to drop to subtask list', () => {
+        const task = { id: 'task1', parentId: null, subTaskIds: [] };
         const drag = createMockDrag(task);
         // Task ID listed as a subtask drop-list (listId='SUB').
+        const drop = createMockDrop('some-task-id', [], 'SUB');
+        expect(component.enterPredicate(drag, drop)).toBe(true);
+      });
+
+      it('should block parent task with subtasks from dropping to subtask list', () => {
+        const task = { id: 'task1', parentId: null, subTaskIds: ['sub1'] };
+        const drag = createMockDrag(task);
         const drop = createMockDrop('some-task-id', [], 'SUB');
         expect(component.enterPredicate(drag, drop)).toBe(false);
       });
@@ -358,6 +370,18 @@ describe('TaskListComponent', () => {
       expect(dispatchedAction.taskId).toBe('sub1');
       expect(dispatchedAction.srcTaskId).toBe('parentA');
       expect(dispatchedAction.targetTaskId).toBe('parentB');
+    });
+
+    it('routes a parent drop into a subtask list to convertToSubTask', () => {
+      callMove('task1', 'UNDONE', 'parentB', 'PARENT', 'SUB', ['before', 'task1']);
+
+      expect(sectionServiceMock.addTaskToSection).not.toHaveBeenCalled();
+      const dispatchedAction = (store.dispatch as jasmine.Spy).calls.mostRecent()
+        .args[0] as ReturnType<typeof TaskSharedActions.convertToSubTask>;
+      expect(dispatchedAction.type).toBe(TaskSharedActions.convertToSubTask.type);
+      expect(dispatchedAction.taskId).toBe('task1');
+      expect(dispatchedAction.targetParentId).toBe('parentB');
+      expect(dispatchedAction.afterTaskId).toBe('before');
     });
 
     it('routes a parent drop into a section drop-list (PARENT + non-reserved id) to addTaskToSection', () => {

--- a/src/app/features/tasks/task-list/task-list.component.ts
+++ b/src/app/features/tasks/task-list/task-list.component.ts
@@ -213,12 +213,16 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
       return false;
     }
 
-    // Parent tasks: allow drops to PARENT_ALLOWED_LISTS or to sections (parent-level
-    // lists with a non-reserved id). Subtask drop-lists (listId === 'SUB') are
-    // rejected so a top-level task can't be nested into another task's subtree.
+    // Parent tasks: allow drops to PARENT_ALLOWED_LISTS, to sections (parent-level
+    // lists with a non-reserved id), or to a task's subtask list if the dragged
+    // task is not itself already a parent.
     const srcModelId = drag.dropContainer?.data?.listModelId;
     const srcListIdRaw = drag.dropContainer?.data?.listId;
     const isSrcSection = srcListIdRaw === 'PARENT' && !RESERVED_LIST_IDS.has(srcModelId);
+
+    if (targetListId === 'SUB') {
+      return targetModelId !== task.id && !task.subTaskIds?.length;
+    }
 
     if (PARENT_ALLOWED_LISTS.includes(targetModelId)) {
       // Reject section → BACKLOG: _move() dispatches `removeTaskFromSection`
@@ -360,6 +364,18 @@ export class TaskListComponent implements OnDestroy, AfterViewInit {
 
     // Handle LATER_TODAY - prevent any moves to or from this list
     if (src === 'LATER_TODAY' || target === 'LATER_TODAY') {
+      return;
+    }
+
+    if (srcListId === 'PARENT' && targetListId === 'SUB') {
+      const afterTaskId = getAnchorFromDragDrop(taskId, newOrderedIds);
+      this._store.dispatch(
+        TaskSharedActions.convertToSubTask({
+          taskId,
+          targetParentId: target as string,
+          afterTaskId,
+        }),
+      );
       return;
     }
 

--- a/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts
@@ -178,6 +178,32 @@ describe('sectionSharedMetaReducer', () => {
     expect(updated.entities['s2']?.taskIds).toEqual(['t4']);
   });
 
+  it('removes a task from sections when it is converted to a subtask', () => {
+    const state = stateWith({ parent: {}, t1: {}, t2: {} }, [
+      {
+        id: 's1',
+        contextId: 'p1',
+        contextType: WorkContextType.PROJECT,
+        title: 'A',
+        taskIds: ['t1', 't2'],
+      },
+    ]);
+
+    metaReducer(
+      state,
+      TaskSharedActions.convertToSubTask({
+        taskId: 't1',
+        targetParentId: 'parent',
+        afterTaskId: null,
+      }),
+    );
+
+    const updated = (mockReducer.calls.mostRecent().args[0] as any)[
+      SECTION_FEATURE_NAME
+    ] as SectionState;
+    expect(updated.entities['s1']?.taskIds).toEqual(['t2']);
+  });
+
   it('passes through unrelated actions unchanged', () => {
     const state = stateWith({ t1: {} }, [
       {

--- a/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts
@@ -361,6 +361,10 @@ const ACTION_HANDLERS: Record<string, Handler> = {
     >;
     return handleMoveToOtherProject(state, task.id, targetProjectId);
   },
+  [TaskSharedActions.convertToSubTask.type]: (state, action) => {
+    const { taskId } = action as ReturnType<typeof TaskSharedActions.convertToSubTask>;
+    return handleTaskRemoval(state, [taskId]);
+  },
   [SectionActions.removeTaskFromSection.type]: (state, action) => {
     const { workContextType, workContextId, taskId, workContextAfterTaskId } =
       action as ReturnType<typeof SectionActions.removeTaskFromSection>;

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
@@ -495,6 +495,151 @@ describe('taskSharedCrudMetaReducer', () => {
     });
   });
 
+  describe('convertToSubTask action', () => {
+    const createConvertToSubTaskState = (
+      taskOverrides: Partial<Task> = {},
+      parentOverrides: Partial<Task> = {},
+    ): RootState => {
+      const task = createMockTask({
+        id: 'task1',
+        projectId: 'project1',
+        tagIds: ['tag1'],
+        subTaskIds: [],
+        ...taskOverrides,
+      });
+      const parentTask = createMockTask({
+        id: 'parent-task',
+        projectId: 'project1',
+        tagIds: ['tag1'],
+        subTaskIds: [],
+        ...parentOverrides,
+      });
+
+      return {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          ids: ['parent-task', 'task1'],
+          entities: {
+            'parent-task': parentTask,
+            task1: task,
+          },
+        },
+        [PROJECT_FEATURE_NAME]: {
+          ...baseState[PROJECT_FEATURE_NAME],
+          entities: {
+            ...baseState[PROJECT_FEATURE_NAME].entities,
+            project1: {
+              ...baseState[PROJECT_FEATURE_NAME].entities.project1,
+              taskIds: ['parent-task', 'task1'],
+              backlogTaskIds: ['task1'],
+            } as Project,
+          },
+        },
+        [TAG_FEATURE_NAME]: {
+          ...baseState[TAG_FEATURE_NAME],
+          entities: {
+            ...baseState[TAG_FEATURE_NAME].entities,
+            tag1: {
+              ...baseState[TAG_FEATURE_NAME].entities.tag1,
+              taskIds: ['parent-task', 'task1'],
+            } as Tag,
+            TODAY: {
+              ...baseState[TAG_FEATURE_NAME].entities.TODAY,
+              taskIds: ['task1'],
+            } as Tag,
+          },
+        },
+      };
+    };
+
+    const createConvertToSubTaskAction = (afterTaskId: string | null = null) =>
+      TaskSharedActions.convertToSubTask({
+        taskId: 'task1',
+        targetParentId: 'parent-task',
+        afterTaskId,
+      });
+
+    it('should move a main task under the target parent', () => {
+      const testState = createConvertToSubTaskState();
+      const action = createConvertToSubTaskAction();
+
+      metaReducer(testState, action);
+      expectStateUpdate(
+        {
+          ...expectTaskUpdate('task1', {
+            parentId: 'parent-task',
+            projectId: 'project1',
+            tagIds: [],
+          }),
+          ...expectTaskUpdate('parent-task', { subTaskIds: ['task1'] }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('should remove converted task from project and tag top-level lists', () => {
+      const testState = createConvertToSubTaskState();
+      const action = createConvertToSubTaskAction();
+
+      metaReducer(testState, action);
+      expectStateUpdate(
+        {
+          ...expectProjectUpdate('project1', {
+            taskIds: ['parent-task'],
+            backlogTaskIds: [],
+          }),
+          ...expectTagUpdates({
+            tag1: { taskIds: ['parent-task'] },
+            TODAY: { taskIds: [] },
+          }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('should place the converted task after the target anchor', () => {
+      const existingSubTask = createMockTask({
+        id: 'existing-sub',
+        parentId: 'parent-task',
+        tagIds: [],
+      });
+      const base = createConvertToSubTaskState({}, { subTaskIds: ['existing-sub'] });
+      const testState = {
+        ...base,
+        [TASK_FEATURE_NAME]: {
+          ...base[TASK_FEATURE_NAME],
+          ids: ['parent-task', 'existing-sub', 'task1'],
+          entities: {
+            ...base[TASK_FEATURE_NAME].entities,
+            'existing-sub': existingSubTask,
+          },
+        },
+      };
+      const action = createConvertToSubTaskAction('existing-sub');
+
+      metaReducer(testState, action);
+      expectStateUpdate(
+        expectTaskUpdate('parent-task', { subTaskIds: ['existing-sub', 'task1'] }),
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('should not convert a task that already has subtasks', () => {
+      const testState = createConvertToSubTaskState({ subTaskIds: ['child-task'] });
+      const action = createConvertToSubTaskAction();
+
+      metaReducer(testState, action);
+      expect(mockReducer).toHaveBeenCalledWith(testState, action);
+    });
+  });
+
   describe('deleteTask action', () => {
     const createDeleteAction = (taskOverrides: Partial<TaskWithSubTasks> = {}) =>
       TaskSharedActions.deleteTask({

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -14,6 +14,7 @@ import {
 import {
   deleteTaskHelper,
   removeTaskFromParentSideEffects,
+  reCalcTimesForParentIfParent,
   updateDoneOnForTask,
   updateTimeEstimateForTask,
   updateTimeSpentForTask,
@@ -26,6 +27,7 @@ import { TODAY_TAG } from '../../../features/tag/tag.const';
 import { unique } from '../../../util/unique';
 import { appStateFeatureKey } from '../../app-state/app-state.reducer';
 import { getDbDateStr } from '../../../util/get-db-date-str';
+import { moveItemAfterAnchor } from '../../../features/work-context/store/work-context-meta.helper';
 import {
   ActionHandlerMap,
   addTaskToList,
@@ -206,6 +208,80 @@ const handleConvertToMainTask = (
   );
 
   return updateTags(updatedState, tagUpdates);
+};
+
+const handleConvertToSubTask = (
+  state: RootState,
+  taskId: string,
+  targetParentId: string,
+  afterTaskId: string | null,
+): RootState => {
+  const task = state[TASK_FEATURE_NAME].entities[taskId] as Task | undefined;
+  const targetParent = state[TASK_FEATURE_NAME].entities[targetParentId] as
+    | Task
+    | undefined;
+
+  if (
+    !task ||
+    !targetParent ||
+    task.parentId ||
+    task.id === targetParent.id ||
+    !!task.subTaskIds?.length
+  ) {
+    return state;
+  }
+
+  let updatedState = state;
+
+  if (task.projectId && state[PROJECT_FEATURE_NAME].entities[task.projectId]) {
+    const project = getProject(state, task.projectId);
+    updatedState = updateProject(updatedState, task.projectId, {
+      taskIds: removeTasksFromList(project.taskIds, [task.id]),
+      backlogTaskIds: removeTasksFromList(project.backlogTaskIds, [task.id]),
+    });
+  }
+
+  const taskIdSet = new Set([task.id]);
+  const tagUpdates = (state[TAG_FEATURE_NAME].ids as string[])
+    .map((tagId) => state[TAG_FEATURE_NAME].entities[tagId])
+    .filter((tag): tag is Tag => !!tag && tag.taskIds.some((id) => taskIdSet.has(id)))
+    .map(
+      (tag): Update<Tag> => ({
+        id: tag.id,
+        changes: {
+          taskIds: removeTasksFromList(tag.taskIds, [task.id]),
+        },
+      }),
+    );
+  updatedState = updateTags(updatedState, tagUpdates);
+
+  let taskState = updatedState[TASK_FEATURE_NAME];
+  taskState = taskAdapter.updateMany(
+    [
+      {
+        id: targetParent.id,
+        changes: {
+          subTaskIds: moveItemAfterAnchor(task.id, afterTaskId, targetParent.subTaskIds),
+        },
+      },
+      {
+        id: task.id,
+        changes: {
+          parentId: targetParent.id,
+          projectId: targetParent.projectId,
+          tagIds: [],
+          modified: Date.now(),
+        },
+      },
+    ],
+    taskState,
+  );
+  taskState = reCalcTimesForParentIfParent(targetParent.id, taskState);
+
+  return {
+    ...updatedState,
+    [TASK_FEATURE_NAME]: taskState,
+  };
 };
 
 const handleDeleteTask = (
@@ -723,6 +799,12 @@ const createActionHandlers = (state: RootState, action: Action): ActionHandlerMa
       typeof TaskSharedActions.convertToMainTask
     >;
     return handleConvertToMainTask(state, task, parentTagIds, isPlanForToday);
+  },
+  [TaskSharedActions.convertToSubTask.type]: () => {
+    const { taskId, targetParentId, afterTaskId } = action as ReturnType<
+      typeof TaskSharedActions.convertToSubTask
+    >;
+    return handleConvertToSubTask(state, taskId, targetParentId, afterTaskId);
   },
   [TaskSharedActions.deleteTask.type]: () => {
     const { task } = action as ReturnType<typeof TaskSharedActions.deleteTask>;

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -49,6 +49,20 @@ export const TaskSharedActions = createActionGroup({
       } satisfies PersistentActionMeta,
     }),
 
+    convertToSubTask: (taskProps: {
+      taskId: string;
+      targetParentId: string;
+      afterTaskId: string | null;
+    }) => ({
+      ...taskProps,
+      meta: {
+        isPersistent: true,
+        entityType: 'TASK',
+        entityId: taskProps.taskId,
+        opType: OpType.Update,
+      } satisfies PersistentActionMeta,
+    }),
+
     deleteTask: (taskProps: { task: TaskWithSubTasks }) => ({
       ...taskProps,
       meta: {


### PR DESCRIPTION
## Summary

- Allow dragging a top-level task without subtasks into another task's subtask list.
- Add a shared `convertToSubTask` action that updates the task/parent relationship and removes the converted task from top-level project, backlog, tag, and section lists.
- Keep the existing guard against nested subtask trees by blocking parent tasks that already have subtasks.

Addresses #905.

## Testing

- `npx ng test --watch=false --include=src/app/features/tasks/task-list/task-list.component.spec.ts --include=src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts --include=src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts`
- `npx ng lint --lint-file-patterns=src/app/features/tasks/task-list/task-list.component.ts --lint-file-patterns=src/app/features/tasks/task-list/task-list.component.spec.ts --lint-file-patterns=src/app/root-store/meta/task-shared.actions.ts --lint-file-patterns=src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts --lint-file-patterns=src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts --lint-file-patterns=src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.ts --lint-file-patterns=src/app/root-store/meta/task-shared-meta-reducers/section-shared.reducer.spec.ts`
- pre-push hook: `packages:test`, `release-notes:test`, full `ng test --watch=false`, and `test:tz:ci` passed