### PR TITLE
fix(config): custom-title-bar default + drop no-op "None" project (#7891)

### DIFF
--- a/src/app/features/config/default-global-config.const.ts
+++ b/src/app/features/config/default-global-config.const.ts
@@ -6,6 +6,7 @@ import {
 
 import { TaskReminderOptionId } from '../tasks/task.model';
 import { GlobalConfigState } from './global-config.model';
+import { INBOX_PROJECT } from '../project/project.const';
 
 const minute = 60 * 1000;
 const defaultTaskNotesTemplate = `**How can I best achieve it now?**
@@ -43,7 +44,7 @@ export const DEFAULT_GLOBAL_CONFIG: GlobalConfigState = {
     isAutoAddWorkedOnToToday: true,
     isAutoMarkParentAsDone: false,
     isTrayShowCurrent: true,
-    defaultProjectId: null,
+    defaultProjectId: INBOX_PROJECT.id,
     isMarkdownFormattingInNotesEnabled: true,
     notesTemplate: defaultTaskNotesTemplate,
   },
@@ -58,6 +59,11 @@ export const DEFAULT_GLOBAL_CONFIG: GlobalConfigState = {
     isDisableAnimations: false,
     isVerticalActionBar: false,
     isDisableCelebration: false,
+    // NOTE: isUseCustomWindowTitleBar is intentionally NOT defaulted here. A
+    // persisted default would be pushed to Electron on every launch and override
+    // a legacy `isUseObsidianStyleHeader` choice. Its effective default is resolved
+    // at read time (main-window.ts / global-theme.service.ts: `?? !IS_GNOME_DESKTOP`)
+    // and the settings checkbox is seeded display-only in misc-settings-form (#7891).
     isShowProductivityTipLonger: false,
     customTheme: 'default',
     defaultStartPage: 0,

--- a/src/app/features/config/form-cfgs/misc-settings-form.const.ts
+++ b/src/app/features/config/form-cfgs/misc-settings-form.const.ts
@@ -104,6 +104,18 @@ export const MISC_SETTINGS_FORM_CFG: ConfigFormSection<MiscConfig> = {
           {
             key: 'isUseCustomWindowTitleBar',
             type: 'checkbox',
+            // Display-only default: seed the checkbox so it reflects the actual
+            // window state on a fresh install (the custom title bar is on by
+            // default here -- this field is only shown on non-GNOME Electron, see
+            // the enclosing guard). formly seeds the control without an initial
+            // modelChange, so nothing is persisted on load.
+            // KNOWN RESIDUAL (#7891): saving any *other* Misc setting emits the
+            // whole model and persists this seeded value too. We accept that over a
+            // persisted DEFAULT_GLOBAL_CONFIG default, which would be pushed to
+            // Electron on *every* launch and override a legacy `isUseObsidianStyleHeader`
+            // choice. So a pre-2025-12 non-GNOME user who had disabled the old
+            // header may see it re-enabled after editing Misc settings (reversible here).
+            defaultValue: true,
             templateOptions: {
               label: T.GCF.MISC.IS_USE_CUSTOM_WINDOW_TITLE_BAR,
               description: T.GCF.MISC.IS_USE_CUSTOM_WINDOW_TITLE_BAR_HINT,

--- a/src/app/features/config/form-cfgs/tasks-settings-form.const.ts
+++ b/src/app/features/config/form-cfgs/tasks-settings-form.const.ts
@@ -45,6 +45,10 @@ export const TASKS_SETTINGS_FORM_CFG: ConfigFormSection<TasksConfig> = {
       type: 'project-select',
       templateOptions: {
         label: T.GCF.TASKS.DEFAULT_PROJECT,
+        // "None" is meaningless here: an unset default still routes new tasks to
+        // the Inbox, so the option only confused users (#7891). Inbox is itself a
+        // selectable project, so hiding "None" leaves no functionality behind.
+        hideNoneOption: true,
       },
     },
     {

--- a/src/app/features/config/select-project/select-project.component.html
+++ b/src/app/features/config/select-project/select-project.component.html
@@ -17,9 +17,11 @@
   [formlyAttributes]="field"
   [id]="id"
 >
-  <mat-option [value]="''">{{
-    field.props?.nullLabel || T.G.NONE | translate
-  }}</mat-option>
+  @if (!field.props?.hideNoneOption) {
+    <mat-option [value]="''">{{
+      field.props?.nullLabel || T.G.NONE | translate
+    }}</mat-option>
+  }
   @for (opt of projectService.list$ | async; track trackById($index, opt)) {
     <mat-option [value]="opt.id">{{ opt.title }}</mat-option>
   }

--- a/src/app/features/config/select-project/select-project.component.ts
+++ b/src/app/features/config/select-project/select-project.component.ts
@@ -3,11 +3,19 @@ import { FieldType } from '@ngx-formly/material';
 import { ProjectService } from '../../project/project.service';
 import { Project } from '../../project/project.model';
 import { T } from 'src/app/t.const';
-import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
+import { FormlyFieldConfig, FormlyFieldProps, FormlyModule } from '@ngx-formly/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AsyncPipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatOption, MatSelect } from '@angular/material/select';
+
+/** Custom props for the shared `project-select` formly field. */
+export interface SelectProjectProps extends FormlyFieldProps {
+  /** Label for the empty (`''`) option; defaults to the translated "None". */
+  nullLabel?: string;
+  /** Hide the empty option entirely (e.g. the tasks default-project field, #7891). */
+  hideNoneOption?: boolean;
+}
 
 @Component({
   selector: 'select-project',
@@ -24,7 +32,9 @@ import { MatOption, MatSelect } from '@angular/material/select';
     MatOption,
   ],
 })
-export class SelectProjectComponent extends FieldType<FormlyFieldConfig> {
+export class SelectProjectComponent extends FieldType<
+  FormlyFieldConfig<SelectProjectProps>
+> {
   projectService = inject(ProjectService);
 
   T: typeof T = T;

--- a/src/app/features/config/store/global-config.reducer.spec.ts
+++ b/src/app/features/config/store/global-config.reducer.spec.ts
@@ -22,6 +22,7 @@ import { GlobalConfigState } from '../global-config.model';
 import { SyncProviderId } from '../../../op-log/sync-providers/provider.const';
 import { AppDataComplete } from '../../../op-log/model/model-config';
 import { DEFAULT_GLOBAL_CONFIG } from '../default-global-config.const';
+import { INBOX_PROJECT } from '../../project/project.const';
 
 describe('GlobalConfigReducer', () => {
   describe('loadAllData action', () => {
@@ -88,6 +89,62 @@ describe('GlobalConfigReducer', () => {
         DEFAULT_GLOBAL_CONFIG.tasks.isMarkdownFormattingInNotesEnabled,
       );
       expect(result.tasks.notesTemplate).toBe(DEFAULT_GLOBAL_CONFIG.tasks.notesTemplate);
+    });
+
+    it('should coerce a legacy null defaultProjectId to the Inbox default (#7891)', () => {
+      // Older configs stored `null` (the removed "None" default). With the "None"
+      // option gone, that value no longer matches a dropdown option, so it must be
+      // normalized to the Inbox project on load.
+      const incomingConfig = {
+        ...initialGlobalConfigState,
+        tasks: { ...initialGlobalConfigState.tasks, defaultProjectId: null } as any,
+      };
+
+      const result = globalConfigReducer(
+        initialGlobalConfigState,
+        loadAllData({
+          appDataComplete: { globalConfig: incomingConfig } as AppDataComplete,
+        }),
+      );
+
+      expect(result.tasks.defaultProjectId).toBe(INBOX_PROJECT.id);
+    });
+
+    it('should coerce a legacy empty-string defaultProjectId to the Inbox default (#7891)', () => {
+      // The removed "None" mat-option used value `''`, so users who explicitly
+      // selected it persisted an empty string (not null). It must coerce to Inbox too.
+      const incomingConfig = {
+        ...initialGlobalConfigState,
+        tasks: { ...initialGlobalConfigState.tasks, defaultProjectId: '' } as any,
+      };
+
+      const result = globalConfigReducer(
+        initialGlobalConfigState,
+        loadAllData({
+          appDataComplete: { globalConfig: incomingConfig } as AppDataComplete,
+        }),
+      );
+
+      expect(result.tasks.defaultProjectId).toBe(INBOX_PROJECT.id);
+    });
+
+    it('should preserve an explicitly configured defaultProjectId on load', () => {
+      const incomingConfig = {
+        ...initialGlobalConfigState,
+        tasks: {
+          ...initialGlobalConfigState.tasks,
+          defaultProjectId: 'my-project',
+        } as any,
+      };
+
+      const result = globalConfigReducer(
+        initialGlobalConfigState,
+        loadAllData({
+          appDataComplete: { globalConfig: incomingConfig } as AppDataComplete,
+        }),
+      );
+
+      expect(result.tasks.defaultProjectId).toBe('my-project');
     });
 
     describe('keyboard migration', () => {
@@ -650,6 +707,16 @@ describe('GlobalConfigReducer', () => {
         // Migration must NOT have backfilled — the prototype key is not "owned".
         expect(result.focusMode.autoStartFocusOnPlay).toBe(false);
       });
+    });
+  });
+
+  describe('default misc config (#7891)', () => {
+    it('should NOT persist a default isUseCustomWindowTitleBar', () => {
+      // Guard: a concrete default here would be pushed to Electron on every launch
+      // and override a legacy `isUseObsidianStyleHeader` choice. The checkbox
+      // default is seeded display-only in misc-settings-form.const.ts. Do not
+      // "fix" the checkbox by adding a value here (see #7891).
+      expect(DEFAULT_GLOBAL_CONFIG.misc.isUseCustomWindowTitleBar).toBeUndefined();
     });
   });
 

--- a/src/app/features/config/store/global-config.reducer.ts
+++ b/src/app/features/config/store/global-config.reducer.ts
@@ -220,6 +220,13 @@ export const globalConfigReducer = createReducer<GlobalConfigState>(
       tasks: {
         ...DEFAULT_GLOBAL_CONFIG.tasks,
         ...appDataComplete.globalConfig.tasks,
+        // Legacy configs stored `null`/`''` (the old "None" default) which no longer
+        // has a matching dropdown option; coerce to the Inbox default so the select
+        // shows a value. Behavior is unchanged — an unset default already routed new
+        // tasks to the Inbox (#7891).
+        defaultProjectId:
+          appDataComplete.globalConfig.tasks?.defaultProjectId ||
+          DEFAULT_GLOBAL_CONFIG.tasks.defaultProjectId,
       },
       shortSyntax: {
         ...DEFAULT_GLOBAL_CONFIG.shortSyntax,

--- a/src/app/features/project/store/project.effects.spec.ts
+++ b/src/app/features/project/store/project.effects.spec.ts
@@ -13,6 +13,7 @@ import { GlobalConfigService } from '../../config/global-config.service';
 import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
 import { GlobalConfigState } from '../../config/global-config.model';
 import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
+import { INBOX_PROJECT } from '../project.const';
 
 describe('ProjectEffects', () => {
   let effects: ProjectEffects;
@@ -61,7 +62,7 @@ describe('ProjectEffects', () => {
   });
 
   describe('deleteProjectRelatedData', () => {
-    it('should clear defaultProjectId when deleted project was the default', (done) => {
+    it('should reset defaultProjectId to the Inbox when deleted project was the default', (done) => {
       // Set up config where project-1 is the default
       globalConfigServiceMock.cfg.and.returnValue({
         ...DEFAULT_GLOBAL_CONFIG,
@@ -73,7 +74,7 @@ describe('ProjectEffects', () => {
 
       effects.deleteProjectRelatedData.subscribe(() => {
         expect(globalConfigServiceMock.updateSection).toHaveBeenCalledWith('tasks', {
-          defaultProjectId: null,
+          defaultProjectId: INBOX_PROJECT.id,
         });
         done();
       });

--- a/src/app/features/project/store/project.effects.ts
+++ b/src/app/features/project/store/project.effects.ts
@@ -12,6 +12,7 @@ import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { T } from '../../../t.const';
 import { Project } from '../project.model';
+import { INBOX_PROJECT } from '../project.const';
 import { Observable } from 'rxjs';
 
 @Injectable()
@@ -37,9 +38,13 @@ export class ProjectEffects {
           if (!cfg) {
             return;
           }
-          // Clear defaultProjectId if the deleted project was the default
+          // Reset defaultProjectId to the Inbox if the deleted project was the
+          // default. (Inbox is the canonical "unset" target — see #7891; writing
+          // null would leave the settings dropdown blank now that "None" is hidden.)
           if (projectId === cfg.tasks.defaultProjectId) {
-            this._globalConfigService.updateSection('tasks', { defaultProjectId: null });
+            this._globalConfigService.updateSection('tasks', {
+              defaultProjectId: INBOX_PROJECT.id,
+            });
           }
           // Clear misc.defaultStartPage if it pointed at the deleted project,
           // otherwise users land on a dead route next app launch.


### PR DESCRIPTION
Fixes two Settings bugs from #7891 (Bug 1 + Bug 2). The other items in that issue (Bug 3 background, the "NONE"/"Off" → "None" renames) are not addressed here.

## Bug 1 — "Use custom title bar" checkbox showed unchecked on a fresh install

The Electron window enables the custom title bar by default on non-GNOME desktops (`main-window.ts`: `persisted ?? legacy ?? !IS_GNOME_DESKTOP`), but the Misc-Settings checkbox read the raw config value (`undefined`) and rendered unchecked.

**Fix:** seed the checkbox with a **display-only** formly `defaultValue` so it reflects the real window state. It is deliberately **not** added to `DEFAULT_GLOBAL_CONFIG` — a persisted default would be pushed to Electron's simpleStore on every launch and override a legacy `isUseObsidianStyleHeader` choice.

**Accepted, documented residual:** formly's `modelChange` emits the whole model, so saving any *other* Misc setting persists the seeded value too. A pre-2025-12 non-GNOME user who had disabled the old obsidian-style header may then see the custom title bar re-enabled (reversible via the checkbox). This was a deliberate KISS call over a heavier custom field-type / one-time IPC migration; the trade-off is documented inline in `misc-settings-form.const.ts`.

## Bug 2 — "Default project … if none is specified" had a no-op "None" option

Selecting "None" still routed new tasks to the Inbox (`task.service.ts`: `defaultProjectId || INBOX_PROJECT.id`), and Inbox is itself a selectable project, so "None" was indistinguishable from "Inbox".

**Fix (4 parts):**
- Add an opt-in `hideNoneOption` prop to the **shared** `select-project` component, set only on this field — the Boards ("All Projects") and Issue-provider forms legitimately keep the null option.
- Default `tasks.defaultProjectId` to `INBOX_PROJECT.id`.
- Normalize legacy `null`/`''` → Inbox in the `loadAllData` reducer (so existing users don't see a blank select).
- Reset to Inbox (not `null`) when the chosen default project is deleted.
- Also typed the shared component's custom props (`SelectProjectProps extends FormlyFieldProps`).

## Verification
- `npm run checkFile` clean on every changed file.
- Full `ng build` (development, strictTemplates): 0 errors.
- Unit tests: `global-config.reducer` 62/62 (incl. legacy `null`/`''` coercion + a guard that the title-bar default stays unpersisted), `project.effects` 8/8.
- Reviewed across three multi-agent review rounds; Bug 2 confirmed correct, Bug 1's legacy residual identified and explicitly accepted/documented.

⚠️ Not yet smoke-tested in a real Electron build (couldn't run Electron in the dev sandbox) — worth a manual check of the title-bar checkbox on a non-GNOME desktop **and** GNOME before merge.

Refs #7891
