### PR TITLE
fix(tracking): split idle time across days when it crosses midnight

### DIFF
--- a/src/app/features/idle/store/idle.effects.spec.ts
+++ b/src/app/features/idle/store/idle.effects.spec.ts
@@ -1,0 +1,197 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Action } from '@ngrx/store';
+import { EMPTY, Subject } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+
+import { IdleEffects } from './idle.effects';
+import { idleDialogResult } from './idle.actions';
+import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
+import { TaskService } from '../../tasks/task.service';
+import { WorkContextService } from '../../work-context/work-context.service';
+import { SimpleCounterService } from '../../simple-counter/simple-counter.service';
+import { UiHelperService } from '../../ui-helper/ui-helper.service';
+import { ChromeExtensionInterfaceService } from '../../../core/chrome-extension-interface/chrome-extension-interface.service';
+import { DateService } from '../../../core/date/date.service';
+import { DataInitStateService } from '../../../core/data-init/data-init-state.service';
+import { DEFAULT_TASK, Task } from '../../tasks/task.model';
+import { IdleTrackItem } from '../dialog-idle/dialog-idle.model';
+
+const H = 60 * 60 * 1000;
+
+describe('IdleEffects handleIdleDialogResult$ (cross-midnight, #3888)', () => {
+  let effects: IdleEffects;
+  let actions$: Subject<Action>;
+  let taskService: jasmine.SpyObj<TaskService>;
+
+  const buildTask = (id: string): Task => ({ ...DEFAULT_TASK, id }) as Task;
+
+  const dispatchIdleResult = (trackItems: IdleTrackItem[], idleTime: number): void => {
+    actions$.next(
+      idleDialogResult({
+        idleTime,
+        isResetBreakTimer: false,
+        wasFocusSessionRunning: false,
+        trackItems,
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    jasmine.clock().install();
+    actions$ = new Subject<Action>();
+
+    taskService = jasmine.createSpyObj('TaskService', [
+      'add',
+      'addTimeSpentForDays',
+      'addTimeSpentAndSync',
+      'setCurrentId',
+      'currentTaskId',
+      'removeTimeSpent',
+    ]);
+    taskService.add.and.returnValue('new-task-id');
+
+    TestBed.configureTestingModule({
+      providers: [
+        IdleEffects,
+        provideMockStore(),
+        { provide: LOCAL_ACTIONS, useValue: actions$ },
+        { provide: TaskService, useValue: taskService },
+        {
+          provide: WorkContextService,
+          useValue: jasmine.createSpyObj('WorkContextService', [
+            'addToBreakTimeForActiveContext',
+          ]),
+        },
+        {
+          provide: SimpleCounterService,
+          useValue: jasmine.createSpyObj(
+            'SimpleCounterService',
+            ['increaseCounterToday', 'toggleCounter', 'decreaseCounterToday'],
+            { enabledSimpleStopWatchCounters$: EMPTY },
+          ),
+        },
+        {
+          provide: UiHelperService,
+          useValue: jasmine.createSpyObj('UiHelperService', [
+            'focusAppAfterNotification',
+          ]),
+        },
+        {
+          provide: ChromeExtensionInterfaceService,
+          useValue: jasmine.createSpyObj(
+            'ChromeExtensionInterfaceService',
+            ['addEventListener'],
+            { onReady$: EMPTY },
+          ),
+        },
+        {
+          provide: DateService,
+          useValue: jasmine.createSpyObj(
+            'DateService',
+            ['getStartOfNextDayDiffMs', 'todayStr'],
+            // no start-of-next-day offset
+            {},
+          ),
+        },
+        { provide: DataInitStateService, useValue: { isAllDataLoadedInitially$: EMPTY } },
+        { provide: MatDialog, useValue: jasmine.createSpyObj('MatDialog', ['open']) },
+      ],
+    });
+
+    (TestBed.inject(DateService).getStartOfNextDayDiffMs as jasmine.Spy).and.returnValue(
+      0,
+    );
+    effects = TestBed.inject(IdleEffects);
+    effects.handleIdleDialogResult$.subscribe();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    TestBed.inject(MockStore).resetSelectors();
+  });
+
+  it('splits idle time across two days for an existing task', () => {
+    // Returned at 02:00 local, 4h of idle => 22:00 prev day -> 02:00 this day.
+    jasmine.clock().mockDate(new Date(2026, 5, 1, 2, 0, 0));
+    const task = buildTask('existing-1');
+
+    dispatchIdleResult(
+      [{ type: 'TASK', time: 'IDLE_TIME', simpleCounterToggleBtns: [], task }],
+      4 * H,
+    );
+
+    expect(taskService.addTimeSpentForDays).toHaveBeenCalledTimes(1);
+    const [taskArg, mapArg] = taskService.addTimeSpentForDays.calls.mostRecent().args;
+    expect(taskArg.id).toBe('existing-1');
+    const expected: { [d: string]: number } = {};
+    expected['2026-05-31'] = 2 * H;
+    expected['2026-06-01'] = 2 * H;
+    expect(mapArg).toEqual(expected);
+    expect(taskService.setCurrentId).toHaveBeenCalledWith('existing-1');
+  });
+
+  it('keeps a same-day idle interval on one day for an existing task', () => {
+    jasmine.clock().mockDate(new Date(2026, 5, 1, 16, 0, 0));
+    const task = buildTask('existing-1');
+
+    dispatchIdleResult(
+      [{ type: 'TASK', time: 'IDLE_TIME', simpleCounterToggleBtns: [], task }],
+      2 * H,
+    );
+
+    const [, mapArg] = taskService.addTimeSpentForDays.calls.mostRecent().args;
+    const expected: { [d: string]: number } = {};
+    expected['2026-06-01'] = 2 * H;
+    expect(mapArg).toEqual(expected);
+  });
+
+  it('creates a new task with a cross-midnight split timeSpentOnDay map', () => {
+    jasmine.clock().mockDate(new Date(2026, 5, 1, 2, 0, 0));
+
+    dispatchIdleResult(
+      [
+        {
+          type: 'TASK',
+          time: 'IDLE_TIME',
+          simpleCounterToggleBtns: [],
+          title: 'Late work',
+        },
+      ],
+      4 * H,
+    );
+
+    expect(taskService.add).toHaveBeenCalledTimes(1);
+    const [title, isAddToBacklog, additionalFields] = taskService.add.calls.mostRecent()
+      .args as [string, boolean, Partial<Task>];
+    expect(title).toBe('Late work');
+    expect(isAddToBacklog).toBe(false);
+    expect(additionalFields.timeSpent).toBe(4 * H);
+    const expected: { [d: string]: number } = {};
+    expected['2026-05-31'] = 2 * H;
+    expected['2026-06-01'] = 2 * H;
+    expect(additionalFields.timeSpentOnDay).toEqual(expected);
+    expect(taskService.setCurrentId).toHaveBeenCalledWith('new-task-id');
+  });
+
+  it('honors the start-of-next-day offset when splitting (existing task)', () => {
+    // 4h offset => logical day starts at 04:00. Returned at 06:00 with 4h idle
+    // (02:00 -> 06:00): 02:00-04:00 is the previous logical day, 04:00-06:00 today.
+    (TestBed.inject(DateService).getStartOfNextDayDiffMs as jasmine.Spy).and.returnValue(
+      4 * H,
+    );
+    jasmine.clock().mockDate(new Date(2026, 5, 1, 6, 0, 0));
+    const task = buildTask('existing-1');
+
+    dispatchIdleResult(
+      [{ type: 'TASK', time: 'IDLE_TIME', simpleCounterToggleBtns: [], task }],
+      4 * H,
+    );
+
+    const [, mapArg] = taskService.addTimeSpentForDays.calls.mostRecent().args;
+    const expected: { [d: string]: number } = {};
+    expected['2026-05-31'] = 2 * H;
+    expected['2026-06-01'] = 2 * H;
+    expect(mapArg).toEqual(expected);
+  });
+});

--- a/src/app/features/idle/store/idle.effects.ts
+++ b/src/app/features/idle/store/idle.effects.ts
@@ -48,6 +48,7 @@ import { isNotNullOrUndefined } from '../../../util/is-not-null-or-undefined';
 import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
 import { T } from '../../../t.const';
 import { DateService } from '../../../core/date/date.service';
+import { splitTimeSpentByDay } from '../../../util/split-time-spent-by-day';
 import { ipcIdleTime$ } from '../../../core/ipc-events';
 import { selectIsSessionRunning } from '../../focus-mode/store/focus-mode.selectors';
 import {
@@ -335,17 +336,23 @@ export class IdleEffects {
             (item: IdleTrackItem) => item.type === 'TASK',
           );
           let taskItemId: string | undefined;
+          const startOfNextDayDiff = this._dateService.getStartOfNextDayDiffMs();
           taskItems.forEach((taskItem) => {
+            // Split across days so an idle interval crossing midnight is logged
+            // for each day it actually covers, not all onto today (issue #3888).
+            const timeSpentOnDay = splitTimeSpentByDay(
+              Date.now(),
+              taskItem.time,
+              startOfNextDayDiff,
+            );
             if (typeof taskItem.title === 'string') {
               taskItemId = this._taskService.add(taskItem.title, false, {
                 timeSpent: taskItem.time,
-                timeSpentOnDay: {
-                  [this._dateService.todayStr()]: taskItem.time,
-                },
+                timeSpentOnDay,
               });
             } else if (taskItem.task) {
               taskItemId = taskItem.task.id;
-              this._taskService.addTimeSpentAndSync(taskItem.task, taskItem.time);
+              this._taskService.addTimeSpentForDays(taskItem.task, timeSpentOnDay);
             }
           });
 

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -820,6 +820,88 @@ describe('Task Reducer', () => {
       expect(state.entities['parent']!.timeSpentOnDay['2024-01-01']).toBe(1500);
       expect(state.entities['parent']!.timeSpent).toBe(1500);
     });
+
+    // Guards the reducer contract that TaskService.addTimeSpentForDays relies on:
+    // addTimeSpent merges onto the action PAYLOAD's timeSpentOnDay, so a
+    // cross-midnight idle split must thread the running map through each per-day
+    // dispatch. These tests replay that exact two-dispatch sequence (#3888).
+    it('preserves both days for a threaded cross-midnight split (flat task, #3888)', () => {
+      const task = createTaskWithTime('t', { '2026-06-01': 1000 });
+      const state0: TaskState = {
+        ...initialTaskState,
+        ids: ['t'],
+        entities: { t: task },
+      };
+
+      // Dispatch 1 (today, +8000) — payload is the original snapshot.
+      const state1 = taskReducer(
+        state0,
+        TimeTrackingActions.addTimeSpent({
+          task,
+          date: '2026-06-01',
+          duration: 8000,
+          isFromTrackingReminder: false,
+        }),
+      );
+      // Dispatch 2 (yesterday, +6000) — payload threads today's addition forward.
+      const threaded: Task = {
+        ...task,
+        timeSpentOnDay: { ...task.timeSpentOnDay, '2026-06-01': 9000 },
+      };
+      const state2 = taskReducer(
+        state1,
+        TimeTrackingActions.addTimeSpent({
+          task: threaded,
+          date: '2026-05-31',
+          duration: 6000,
+          isFromTrackingReminder: false,
+        }),
+      );
+
+      expect(state2.entities['t']!.timeSpentOnDay['2026-06-01']).toBe(9000);
+      expect(state2.entities['t']!.timeSpentOnDay['2026-05-31']).toBe(6000);
+      expect(state2.entities['t']!.timeSpent).toBe(15000);
+    });
+
+    it('aggregates both days on the parent for a threaded cross-midnight subtask split (#3888)', () => {
+      const parent = createTaskWithTime('parent', { '2026-06-01': 1000 });
+      const sub = createTaskWithTime('sub', { '2026-06-01': 1000 }, 'parent');
+      const state0: TaskState = {
+        ...initialTaskState,
+        ids: ['parent', 'sub'],
+        entities: { parent: { ...parent, subTaskIds: ['sub'] }, sub },
+      };
+
+      const state1 = taskReducer(
+        state0,
+        TimeTrackingActions.addTimeSpent({
+          task: sub,
+          date: '2026-06-01',
+          duration: 8000,
+          isFromTrackingReminder: false,
+        }),
+      );
+      const threadedSub: Task = {
+        ...sub,
+        timeSpentOnDay: { ...sub.timeSpentOnDay, '2026-06-01': 9000 },
+      };
+      const state2 = taskReducer(
+        state1,
+        TimeTrackingActions.addTimeSpent({
+          task: threadedSub,
+          date: '2026-05-31',
+          duration: 6000,
+          isFromTrackingReminder: false,
+        }),
+      );
+
+      expect(state2.entities['sub']!.timeSpentOnDay['2026-06-01']).toBe(9000);
+      expect(state2.entities['sub']!.timeSpentOnDay['2026-05-31']).toBe(6000);
+      // Parent picks up both days with no double-count.
+      expect(state2.entities['parent']!.timeSpentOnDay['2026-06-01']).toBe(9000);
+      expect(state2.entities['parent']!.timeSpentOnDay['2026-05-31']).toBe(6000);
+      expect(state2.entities['parent']!.timeSpent).toBe(15000);
+    });
   });
 
   describe('moveToArchive action - orphan subtask handling', () => {

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -843,6 +843,50 @@ describe('TaskService', () => {
     });
   });
 
+  describe('addTimeSpentForDays', () => {
+    const TODAY = '2026-06-01';
+    const YESTERDAY = '2026-05-31';
+
+    it('threads the running map so earlier days are not overwritten (#3888)', () => {
+      const existing: { [d: string]: number } = {};
+      existing[TODAY] = 1000;
+      const task = createMockTask('task-1', { timeSpentOnDay: existing });
+      (store.dispatch as jasmine.Spy).calls.reset();
+
+      const split: { [d: string]: number } = {};
+      split[TODAY] = 8000;
+      split[YESTERDAY] = 6000;
+      service.addTimeSpentForDays(task, split);
+
+      const addCalls: { type: string; date: string; duration: number; task: Task }[] = (
+        store.dispatch as jasmine.Spy
+      ).calls
+        .allArgs()
+        .map(([a]: any) => a)
+        .filter((a: { type: string }) => a.type === '[TimeTracking] Add time spent');
+
+      expect(addCalls.length).toBe(2);
+      // First dispatch (today): payload carries the original map.
+      expect(addCalls[0].date).toBe(TODAY);
+      expect(addCalls[0].duration).toBe(8000);
+      expect(addCalls[0].task.timeSpentOnDay[TODAY]).toBe(1000);
+      // Second dispatch (yesterday): payload MUST carry the first day's addition,
+      // else the reducer (which merges onto the payload map) resets today (#3888).
+      expect(addCalls[1].date).toBe(YESTERDAY);
+      expect(addCalls[1].duration).toBe(6000);
+      expect(addCalls[1].task.timeSpentOnDay[TODAY]).toBe(1000 + 8000);
+    });
+
+    it('does nothing for an empty map', () => {
+      const task = createMockTask('task-1');
+      (store.dispatch as jasmine.Spy).calls.reset();
+
+      service.addTimeSpentForDays(task, {});
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
   describe('removeTimeSpent', () => {
     it('should dispatch removeTimeSpent action', () => {
       service.removeTimeSpent('task-1', 30000);

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -826,13 +826,41 @@ export class TaskService {
    * Use this instead of addTimeSpent when the caller is NOT using BatchedTimeSyncAccumulator
    * (e.g. idle dialog, tracking reminder). The tick path uses the accumulator instead.
    */
-  addTimeSpentAndSync(task: Task, duration: number): void {
+  addTimeSpentAndSync(
+    task: Task,
+    duration: number,
+    date: string = this._dateService.todayStr(),
+  ): void {
     if (duration <= 0) {
       return;
     }
-    const date = this._dateService.todayStr();
     this.addTimeSpent(task, duration, date);
     this._store.dispatch(syncTimeSpent({ taskId: task.id, date, duration }));
+  }
+
+  /**
+   * Adds time spent across multiple days for a single task (e.g. an idle
+   * interval that crossed midnight, see issue #3888).
+   *
+   * Each per-day dispatch must carry forward the previous days' additions: the
+   * addTimeSpent reducer merges onto `task.timeSpentOnDay` from the *action
+   * payload* (not store state), so reusing one stale snapshot would make every
+   * iteration overwrite the prior day's update. We thread an updated snapshot
+   * through the loop so each dispatch sees the accumulated map.
+   */
+  addTimeSpentForDays(task: Task, timeSpentByDay: { [dateStr: string]: number }): void {
+    let runningTask = task;
+    Object.keys(timeSpentByDay).forEach((date) => {
+      const duration = timeSpentByDay[date];
+      this.addTimeSpentAndSync(runningTask, duration, date);
+      runningTask = {
+        ...runningTask,
+        timeSpentOnDay: {
+          ...runningTask.timeSpentOnDay,
+          [date]: (runningTask.timeSpentOnDay?.[date] ?? 0) + duration,
+        },
+      };
+    });
   }
 
   removeTimeSpent(

--- a/src/app/util/split-time-spent-by-day.spec.ts
+++ b/src/app/util/split-time-spent-by-day.spec.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { splitTimeSpentByDay } from './split-time-spent-by-day';
+
+const H = 60 * 60 * 1000;
+const M = 60 * 1000;
+const hm = (h: number, m: number): number => h * H + m * M; // eslint-disable-line no-mixed-operators
+
+// Helper: local-time timestamp for a given Y-M-D hh:mm (so tests are TZ-agnostic).
+const ts = (y: number, mo: number, d: number, h = 0, min = 0): number =>
+  new Date(y, mo - 1, d, h, min, 0, 0).getTime();
+
+describe('splitTimeSpentByDay', () => {
+  it('keeps a same-day interval on a single day', () => {
+    const end = ts(2026, 6, 1, 16, 0); // 16:00
+    const result = splitTimeSpentByDay(end, 2 * H);
+    expect(result).toEqual({ '2026-06-01': 2 * H });
+  });
+
+  it('splits an interval that crosses midnight across both days', () => {
+    // Worked from 22:00 (May 31) until 02:00 (Jun 1) => 4h total.
+    const end = ts(2026, 6, 1, 2, 0); // 02:00 Jun 1
+    const result = splitTimeSpentByDay(end, 4 * H);
+    expect(result).toEqual({
+      '2026-05-31': 2 * H, // 22:00 -> 24:00
+      '2026-06-01': 2 * H, // 00:00 -> 02:00
+    });
+  });
+
+  it('matches the issue #3888 scenario (away overnight, assigned next morning)', () => {
+    // Walked away 18:30 (May 31), returned and logged at 08:00 (Jun 1): 13.5h.
+    const end = ts(2026, 6, 1, 8, 0);
+    const result = splitTimeSpentByDay(end, hm(13, 30));
+    expect(result['2026-05-31']).toBe(hm(5, 30)); // 18:30 -> 24:00
+    expect(result['2026-06-01']).toBe(8 * H); // 00:00 -> 08:00
+  });
+
+  it('spreads across three days for a long interval', () => {
+    const end = ts(2026, 6, 3, 6, 0); // 06:00 Jun 3
+    const result = splitTimeSpentByDay(end, 48 * H); // 06:00 Jun 1 -> 06:00 Jun 3
+    expect(result['2026-06-01']).toBe(18 * H); // 06:00 -> 24:00
+    expect(result['2026-06-02']).toBe(24 * H); // full day
+    expect(result['2026-06-03']).toBe(6 * H); // 00:00 -> 06:00
+  });
+
+  it('respects the start-of-next-day offset (logical day boundary)', () => {
+    // With a 4h offset the logical day starts at 04:00. An interval from
+    // 02:00 to 06:00 on Jun 1 straddles the logical boundary: 02:00-04:00
+    // belongs to the previous logical day (May 31), 04:00-06:00 to Jun 1.
+    const end = ts(2026, 6, 1, 6, 0);
+    const result = splitTimeSpentByDay(end, 4 * H, 4 * H);
+    expect(result['2026-05-31']).toBe(2 * H);
+    expect(result['2026-06-01']).toBe(2 * H);
+  });
+
+  it('attributes the whole interval to today when it does not cross a boundary (offset)', () => {
+    const end = ts(2026, 6, 1, 10, 0);
+    const result = splitTimeSpentByDay(end, 2 * H, 4 * H); // 08:00 -> 10:00, both after 04:00
+    expect(result).toEqual({ '2026-06-01': 2 * H });
+  });
+
+  it('returns an empty map for zero or negative duration', () => {
+    const end = ts(2026, 6, 1, 12, 0);
+    expect(splitTimeSpentByDay(end, 0)).toEqual({});
+    expect(splitTimeSpentByDay(end, -5 * H)).toEqual({});
+  });
+
+  it('ignores non-finite durations', () => {
+    const end = ts(2026, 6, 1, 12, 0);
+    expect(splitTimeSpentByDay(end, NaN)).toEqual({});
+    expect(splitTimeSpentByDay(end, Infinity)).toEqual({});
+  });
+
+  it('attributes an interval ending exactly at midnight to the previous day', () => {
+    const end = ts(2026, 6, 1, 0, 0); // exactly 00:00 Jun 1
+    const result = splitTimeSpentByDay(end, 2 * H);
+    expect(result).toEqual({ '2026-05-31': 2 * H }); // 22:00 -> 24:00 May 31
+  });
+
+  it('sums to the original duration', () => {
+    const end = ts(2026, 6, 2, 3, 17);
+    const duration = hm(11, 42);
+    const result: { [dateStr: string]: number } = splitTimeSpentByDay(end, duration);
+    const total = Object.values(result).reduce((a, b) => a + b, 0);
+    expect(total).toBe(duration);
+  });
+});

--- a/src/app/util/split-time-spent-by-day.ts
+++ b/src/app/util/split-time-spent-by-day.ts
@@ -1,0 +1,55 @@
+import { getDbDateStr } from './get-db-date-str';
+
+// An interval longer than this is almost certainly malformed input; cap the loop
+// so bad data can never spin forever (one iteration per day covered).
+const MAX_DAYS = 1100;
+
+/**
+ * Splits the interval `[endTimeStamp - durationMs, endTimeStamp]` across the
+ * "logical days" it spans, returning a `{ dateStr: ms }` map.
+ *
+ * The logical-day boundary is shifted by `startOfNextDayDiff` (the configurable
+ * start-of-next-day offset), matching how the time tracker attributes ticks to
+ * days (see `DateService.todayStr`).
+ *
+ * Used when a single time interval is logged retroactively (e.g. assigning idle
+ * time to a task) so that an interval crossing midnight is attributed to each
+ * day it actually covers instead of dumping it all onto "today" (issue #3888).
+ */
+export const splitTimeSpentByDay = (
+  endTimeStamp: number,
+  durationMs: number,
+  startOfNextDayDiff: number = 0,
+): { [dateStr: string]: number } => {
+  const result: { [dateStr: string]: number } = {};
+  if (!Number.isFinite(durationMs) || durationMs <= 0) {
+    return result;
+  }
+
+  let remaining = durationMs;
+  let cursorEnd = endTimeStamp;
+  let guard = 0;
+
+  while (remaining > 0 && guard < MAX_DAYS) {
+    guard++;
+    // The day this chunk belongs to is the one containing its last ms. Probing
+    // `cursorEnd - 1` keeps an interval that ends exactly on a boundary on the
+    // previous day (where it was actually worked).
+    const shifted = new Date(cursorEnd - 1 - startOfNextDayDiff);
+    const dateStr = getDbDateStr(shifted);
+
+    // Real-time start of that logical day = local midnight of `shifted` + offset.
+    const localMidnight = new Date(shifted);
+    localMidnight.setHours(0, 0, 0, 0);
+    const startOfLogicalDayMs = localMidnight.getTime() + startOfNextDayDiff;
+
+    const availableInDay = cursorEnd - startOfLogicalDayMs;
+    const take = Math.min(remaining, availableInDay);
+    result[dateStr] = (result[dateStr] || 0) + take;
+
+    remaining -= take;
+    cursorEnd = startOfLogicalDayMs;
+  }
+
+  return result;
+};


### PR DESCRIPTION
## What

When idle time is assigned to a task (or a new task is created from it) via the idle dialog, the whole interval was logged to **today's** `timeSpentOnDay` key — even when the away period crossed midnight. This splits the interval `[now - idleTime, now]` across the logical days it actually covers.

Found while investigating #3888 (a recent comment revived the thread). The issue's original subject — the manual "mark done / estimate" dialog logging to today — remains intended; this PR fixes a *related* idle edge case, so `Refs #3888` rather than closing it.

## Changes

- **`split-time-spent-by-day.ts`** (new pure util): splits a duration ending at a timestamp into a `{ dateStr: ms }` map by logical-day boundary, honoring the start-of-next-day offset (matches `DateService.todayStr`).
- **`TaskService.addTimeSpentForDays`**: applies a per-day map to one task. It **threads an updated task snapshot** through the per-day dispatches — the `addTimeSpent` reducer merges onto the action payload's `timeSpentOnDay` (not store state), so reusing one stale snapshot would make each iteration overwrite the previous day's update (data loss). A regression test pins this.
- **`addTimeSpentAndSync`**: optional `date` param (defaults to today; all existing callers unchanged).
- **`idle.effects.ts`**: the existing-task and new-task assignment branches now split across days.

## Why threaded per-day dispatches (not one combined op)

Time tracking already syncs as one additive `syncTimeSpent` op per `(task, date)` (the `BatchedTimeSyncAccumulator` flushes per day). Emitting one op per covered day is consistent with that model and keeps additive-merge conflict semantics; a single absolute-set op would lose concurrent additions from other devices. Realistic idle intervals are 1–2 days.

## Tests

- `split-time-spent-by-day.spec.ts` — 10 cases (same-day, cross-midnight, 3-day spread, start-of-next-day offset, exact-midnight, edge/invalid inputs, sum invariant).
- `task.service.spec.ts` — regression test for the threaded per-day dispatch (asserts the 2nd day's payload carries the 1st day's addition).
- `idle.effects.spec.ts` (new) — end-to-end wiring through the real effect: existing-task split, same-day, new-task split, and start-of-next-day offset. Passes under both `Europe/Berlin` and `America/Los_Angeles`.
- `task.reducer.spec.ts` — reducer-level end-to-end tests replaying the two-dispatch cross-midnight sequence through the real reducer, proving both days survive for a flat task and a subtask (parent aggregation, no double-count).

## Out of scope (follow-up)

The detection-time `removeTimeSpent` still defaults to "today" — left unchanged because the OS idle clock can't distinguish timer-tracked-while-away from slept time, so day-splitting the *removal* could eat legitimate prior-day work. Tracked separately.
