### PR TITLE
feat(projects): add project icons to show/hide projects visibility menu

### DIFF
--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
@@ -161,6 +161,8 @@
   @for (project of allUnarchivedProjects(); track project.id) {
     <button
       mat-menu-item
+      role="menuitemcheckbox"
+      [attr.aria-checked]="!project.isHiddenFromMenu"
       (click)="toggleProjectVisibility(project.id)"
     >
       @if (!project.isHiddenFromMenu) {
@@ -168,7 +170,11 @@
       } @else {
         <mat-icon>check_box_outline_blank</mat-icon>
       }
-      <mat-icon>{{ project.icon || DEFAULT_PROJECT_ICON }}</mat-icon>
+      <mat-icon
+        class="nav-icon"
+        [class.nav-icon-emoji]="isSingleEmoji(project.icon || DEFAULT_PROJECT_ICON)"
+        >{{ project.icon || DEFAULT_PROJECT_ICON }}</mat-icon
+      >
       {{ project.title }}
     </button>
   }

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
@@ -157,16 +157,19 @@
 }
 
 <!-- Project Visibility Menu -->
-<!-- Hidden-project opacity style in src/styles/components/_overwrite-material.scss -->
 <mat-menu #visibilityMenu="matMenu">
   @for (project of allUnarchivedProjects(); track project.id) {
     <button
       mat-menu-item
-      [class.is-hidden-from-menu]="project.isHiddenFromMenu"
       (click)="toggleProjectVisibility(project.id)"
     >
+      @if (!project.isHiddenFromMenu) {
+        <mat-icon>check_box</mat-icon>
+      } @else {
+        <mat-icon>check_box_outline_blank</mat-icon>
+      }
       <mat-icon>{{ project.icon || DEFAULT_PROJECT_ICON }}</mat-icon>
-      <span>{{ project.title }}</span>
+      {{ project.title }}
     </button>
   }
   @if (archivedProjectsCount() > 0) {

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
@@ -157,17 +157,15 @@
 }
 
 <!-- Project Visibility Menu -->
+<!-- Hidden-project opacity style in src/styles/components/_overwrite-material.scss -->
 <mat-menu #visibilityMenu="matMenu">
   @for (project of allUnarchivedProjects(); track project.id) {
     <button
       mat-menu-item
+      [class.is-hidden-from-menu]="project.isHiddenFromMenu"
       (click)="toggleProjectVisibility(project.id)"
     >
-      @if (!project.isHiddenFromMenu) {
-        <mat-icon>visibility</mat-icon>
-      } @else {
-        <mat-icon>visibility_off</mat-icon>
-      }
+      <mat-icon>{{ project.icon || DEFAULT_PROJECT_ICON }}</mat-icon>
       <span>{{ project.title }}</span>
     </button>
   }

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
@@ -133,6 +133,33 @@
   }
 }
 
+.nav-icon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  line-height: 1;
+  margin-right: var(--s-half);
+
+  &.nav-icon-emoji {
+    font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif;
+    font-size: 16px;
+    font-feature-settings: normal;
+    font-variation-settings: normal;
+    text-transform: none;
+    letter-spacing: normal;
+    overflow-wrap: normal;
+    white-space: nowrap;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+}
+
 .nav-child-item {
   position: relative;
 

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.ts
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.ts
@@ -33,6 +33,7 @@ import {
 import { MenuTreeService } from '../../../features/menu-tree/menu-tree.service';
 import { WorkContextType } from '../../../features/work-context/work-context.model';
 import { DEFAULT_PROJECT_ICON } from '../../../features/project/project.const';
+import { isSingleEmoji } from '../../../util/extract-first-emoji';
 import { expandCollapseAni } from '../../../ui/tree-dnd/tree.animations';
 import { Router } from '@angular/router';
 
@@ -74,6 +75,7 @@ export class NavListTreeComponent implements OnDestroy {
   readonly T = T;
   readonly WorkContextType = WorkContextType;
   readonly DEFAULT_PROJECT_ICON = DEFAULT_PROJECT_ICON;
+  readonly isSingleEmoji = isSingleEmoji;
   readonly MenuTreeKind = MenuTreeKind;
 
   // Access to service methods and data for visibility menu (includes Inbox for unhiding)

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -411,8 +411,3 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
 .mat-expansion-panel-header {
   --mat-expansion-header-expanded-state-height: 48px;
 }
-
-// Dimmed state for hidden projects in the show/hide projects visibility menu (nav-list-tree component)
-.is-hidden-from-menu {
-  opacity: 0.4;
-}

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -411,3 +411,8 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
 .mat-expansion-panel-header {
   --mat-expansion-header-expanded-state-height: 48px;
 }
+
+// Dimmed state for hidden projects in the show/hide projects visibility menu (nav-list-tree component)
+.is-hidden-from-menu {
+  opacity: 0.4;
+}


### PR DESCRIPTION
## Problem

The "Show/Hide Projects" visibility menu (the eye icon beside the Projects section in the sidebar) displayed only project names — no project icons. Users who rely on the visual icon to identify projects had no icon reference in this menu, making it inconsistent with the main sidebar where projects are listed as `[icon] name`.

Fixes #7894

## Solution

- Replace the `visibility`/`visibility_off` icon with each project's own configured icon as the leading icon in the menu item — consistent with how every other nav menu in the sidebar renders items (`[single icon] label`, see `nav-mat-menu.component.html`).
- Hidden projects are visually distinguished by dimming the entire menu row to `opacity: 0.4`, which is a standard "off/inactive" convention and avoids a double-icon layout that has no precedent in the codebase.

**Design note:** An earlier iteration used `[eye icon] [project icon] title` to make the toggle state explicit, but that pattern doesn't exist anywhere else in the nav menus. The opacity approach conveys the same information with a single-icon layout that matches the rest of the UI. Happy to discuss if a different treatment is preferred.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) — no unit-testable logic changed; this is a template binding and a CSS rule
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
