### PR TITLE
feat(community-plugins): add Memos Sync

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -102,5 +102,13 @@
     "author": "ai-eifying",
     "authorUrl": "https://github.com/ai-eifying",
     "stars": 4
+  },
+  {
+    "name": "Memos Sync",
+    "shortDescription": "Syncs plugin-owned notes between Super Productivity and Memos with attachments, auto-sync, and conflict handling.",
+    "url": "https://github.com/giba0/memos-sync",
+    "author": "giba0",
+    "authorUrl": "https://github.com/giba0",
+    "stars": 2
   }
 ]


### PR DESCRIPTION
## Problem

Adds **Memos Sync** to the community plugins list in `src/assets/community-plugins.json`.

## Solution

Memos Sync gives Super Productivity users a note-centric workflow that stays separate from task management while syncing with Memos.

Current feature set includes:
- plugin-owned local notes
- two-way sync with Memos
- configurable sync tag
- manual conflict resolution
- attachment import/upload support
- optional auto-sync
- Memos-inspired card/timeline UI


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
