### PR TITLE
fix(calendar): use actual time spent for calendar event duration on completion

### DIFF
--- a/src/app/features/calendar-integration/time-block/time-block-sync.effects.spec.ts
+++ b/src/app/features/calendar-integration/time-block/time-block-sync.effects.spec.ts
@@ -447,4 +447,76 @@ describe('TimeBlockSyncEffects', () => {
     bulkSub.unsubscribe();
     flush();
   }));
+
+  it('uses timeSpent as duration when a done task has time tracked', fakeAsync(() => {
+    getByIdOnce$Spy.and.callFake((id: string) =>
+      of(
+        createTask(id, {
+          isDone: true,
+          timeEstimate: 60 * 60 * 1000, // 60 min
+          timeSpent: 51 * 60 * 1000, // 51 min
+        }),
+      ),
+    );
+
+    actions$.next(
+      TaskSharedActions.updateTask({
+        task: { id: 'task-1', changes: { isDone: true } },
+      }),
+    );
+
+    tick(COALESCE_MS);
+
+    expect(upsertEventSpy).toHaveBeenCalledTimes(1);
+    expect(upsertEventSpy.calls.mostRecent().args[1].durationMs).toBe(51 * 60 * 1000);
+    flush();
+  }));
+
+  it('falls back to timeEstimate when a done task has no time tracked', fakeAsync(() => {
+    getByIdOnce$Spy.and.callFake((id: string) =>
+      of(
+        createTask(id, {
+          isDone: true,
+          timeEstimate: 60 * 60 * 1000,
+          timeSpent: 0,
+        }),
+      ),
+    );
+
+    actions$.next(
+      TaskSharedActions.updateTask({
+        task: { id: 'task-1', changes: { isDone: true } },
+      }),
+    );
+
+    tick(COALESCE_MS);
+
+    expect(upsertEventSpy).toHaveBeenCalledTimes(1);
+    expect(upsertEventSpy.calls.mostRecent().args[1].durationMs).toBe(60 * 60 * 1000);
+    flush();
+  }));
+
+  it('uses the larger of estimate and time spent as duration for a non-done task', fakeAsync(() => {
+    getByIdOnce$Spy.and.callFake((id: string) =>
+      of(
+        createTask(id, {
+          isDone: false,
+          timeEstimate: 60 * 60 * 1000, // 60 min
+          timeSpent: 20 * 60 * 1000, // 20 min
+        }),
+      ),
+    );
+
+    actions$.next(
+      TaskSharedActions.updateTask({
+        task: { id: 'task-1', changes: { timeEstimate: 60 * 60 * 1000 } },
+      }),
+    );
+
+    tick(COALESCE_MS);
+
+    expect(upsertEventSpy).toHaveBeenCalledTimes(1);
+    expect(upsertEventSpy.calls.mostRecent().args[1].durationMs).toBe(60 * 60 * 1000);
+    flush();
+  }));
 });

--- a/src/app/features/calendar-integration/time-block/time-block-sync.effects.ts
+++ b/src/app/features/calendar-integration/time-block/time-block-sync.effects.ts
@@ -435,7 +435,9 @@ export class TimeBlockSyncEffects {
     task: Task,
     dueWithTime: number,
   ): Promise<void> {
-    const durationMs = Math.max(task.timeEstimate - task.timeSpent, 0) || 30 * 60 * 1000;
+    const durationMs = task.isDone
+      ? task.timeSpent || task.timeEstimate || 30 * 60 * 1000
+      : Math.max(task.timeEstimate, task.timeSpent) || 30 * 60 * 1000;
     await ctx.definition.timeBlock!.upsertEvent(
       task.id,
       {


### PR DESCRIPTION
## Problem

#7949 

When a task was synchronized to a Google Calendar time-block, the calendar event duration was calculated incorrectly:
1. **Task is not done**: The duration was calculated using the remaining time (`Math.max(task.timeEstimate - task.timeSpent, 0)`). This caused the calendar block to shrink as time was tracked, and default to 30 minutes if actual time spent exceeded the estimate.
2. **Task is done**: The event did not scale to the actual completed duration (`timeSpent`).

## Solution

Modified the duration calculation in [time-block-sync.effects.ts](file:///Users/Finbridge/Desktop/msc/Github/super-productivity/src/app/features/calendar-integration/time-block/time-block-sync.effects.ts):
- For **completed/done** tasks: Use actual time spent if tracked, fallback to estimate, and fallback to 30 minutes if neither is present.
- For **uncompleted** tasks: Use the larger of estimate or spent time (`Math.max(timeEstimate, timeSpent)`), fallback to 30 minutes.

Added new unit tests in [time-block-sync.effects.spec.ts](file:///Users/Finbridge/Desktop/msc/Github/super-productivity/src/app/features/calendar-integration/time-block/time-block-sync.effects.spec.ts) covering the new duration calculation rules.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] NO CHANGES NEEDED: I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)