### PR TITLE
test(focus-mode): fix flaky auto-start test with hash navigation

### DIFF
--- a/e2e/tests/focus-mode/auto-start-focus-on-play.spec.ts
+++ b/e2e/tests/focus-mode/auto-start-focus-on-play.spec.ts
@@ -60,8 +60,17 @@ test.describe('autoStartFocusOnPlay', () => {
     // Step 1: enable the new setting via Settings UI.
     await enableAutoStartOnPlay(page);
 
-    // Step 2: navigate back to work view and add a task.
-    await page.goto('/');
+    // Step 2: navigate back to the work view and add a task.
+    // Use a same-document hash navigation rather than `page.goto('/')`. A hard
+    // reload re-bootstraps the app and re-reads the config from IndexedDB,
+    // which races the debounced persistence of the toggle we just flipped: if
+    // the write hasn't flushed yet, the reloaded app boots with
+    // autoStartFocusOnPlay=false and the session never spawns — a flake no
+    // timeout can fix. Hash nav keeps the in-memory NgRx config that the toggle
+    // already updated synchronously, so we test the auto-start behavior without
+    // depending on persistence timing.
+    await page.goto('/#/tag/TODAY/tasks');
+    await page.waitForURL(/tag\/TODAY/);
     await workViewPage.waitForTaskList();
     await workViewPage.addTask('AutoStartTask');
 


### PR DESCRIPTION
## Problem

The `autoStartFocusOnPlay` E2E test is flaky due to a race condition between IndexedDB persistence and app re-bootstrap. When `page.goto('/')` performs a hard reload, the app re-reads config from IndexedDB before the debounced toggle write has flushed, causing the test to boot with `autoStartFocusOnPlay=false` and the auto-start session never spawns.

## Solution

Replace the hard reload (`page.goto('/')`) with a same-document hash navigation (`page.goto('/#/tag/TODAY/tasks')`). Hash navigation keeps the in-memory NgRx config that was already updated synchronously by the toggle, eliminating the dependency on persistence timing. Add a `waitForURL` to ensure navigation completes before proceeding.

This approach tests the actual auto-start behavior without being vulnerable to IndexedDB write delays.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

https://claude.ai/code/session_01AQ6pppAS5fmZ5QaXx7bPJL