### PR TITLE
feat(op-log): validate SQLite backend + IDB→SQLite migration + backend-aware init (#7931)

### DIFF
--- a/docs/sync-and-op-log/sqlite-migration-followup.md
+++ b/docs/sync-and-op-log/sqlite-migration-followup.md
@@ -12,9 +12,22 @@ ordered so each item is independently shippable and reviewable.
 - ✅ `OperationLogStoreService` + `ArchiveStoreService` fully routed through the
   port (no direct `this.db`), behind a DI factory token
   (`OP_LOG_DB_ADAPTER_FACTORY`), IndexedDB-backed on every platform today.
-- ✅ `SqliteOpLogAdapter` fully implemented against a minimal `SqliteDb` port,
-  unit-tested against an in-memory SQLite stand-in. **Not wired to any
-  platform; no native plugin dependency.**
+- ✅ `SqliteOpLogAdapter` fully implemented against a minimal `SqliteDb` port.
+  **Not wired to any platform; no native plugin dependency.**
+- ✅ **Validated against a real SQLite engine (sql.js).** `sql.js` is served into
+  Karma (dev-only; never in the app bundle) and the adapter's behavioral
+  contract runs against both the in-memory fake and real SQLite
+  (`sqlite-op-log-adapter.spec.ts`), plus a store-level second pass through
+  `OperationLogStoreService` (`remote-apply-store-port.integration.spec.ts`).
+  Confirms the real `UNIQUE constraint failed` → `ConstraintError` mapping,
+  `AUTOINCREMENT`-after-`clear()`, compound-index + NULL ranges, and real
+  `BEGIN IMMEDIATE` rollback. **(B2 translation-layer + store-port passes; the
+  on-device real-engine run still remains.)**
+- ✅ **C1 backend migration implemented + tested** (`op-log-backend-migration.ts`):
+  whole-DB copy from any source adapter to any dest adapter in one dest
+  transaction with verify-before-commit (op count + last `seq` + vector clock;
+  mismatch → rollback). Validated real-Chrome-IDB → sql.js. **Not wired into
+  startup** — B3/C2 decide when to run it.
 - ✅ App-private local backup shipped (#7924): `LocalBackupService` writes a
   JSON snapshot every 5 min on Android (`KeyValStore` rows `backup` /
   `backup_prev`) and iOS (`Directory.Data` `super-productivity-backup.json` /
@@ -86,45 +99,79 @@ captured on the next tick.
   IndexedDB — i.e. it reintroduces the eviction risk. Bind SQLite **only** when
   `IS_NATIVE_PLATFORM`; web/PWA/Electron stay on IndexedDB.
 - **Size:** small. **Risk:** native build/CI surface.
+- **⚡ Perf — bake two mitigations into the wrapper from the start.** On native
+  the dominant cost is the Capacitor JS↔native bridge round-trip, not SQLite
+  itself. Reads (`getAll`/`count`) are already one query = one crossing.
+  Single-op append is negligible. The one cliff is **bulk write**:
+  `OperationLogStoreService.appendBatch()` loops `await tx.add()` once per op, so
+  N ops = N crossings. Mitigations (only matter on the bridge; can't be measured
+  with in-process sql.js, so validate on-device):
+  1. **Return `lastId` from the plugin's own `run` response** (it provides it) —
+     never issue a separate `SELECT last_insert_rowid()`, which would double
+     every insert to two crossings.
+  2. **Add an optional bulk path to the port** (e.g. `runBatch(statements)` on
+     `SqliteDb` + an `addBatch` on `OpLogTx`) so `appendBatch` collapses to one
+     crossing via the plugin's `executeSet`. Per-op `seq` recovery from a batched
+     insert needs `RETURNING seq` (SQLite ≥ 3.35) or `last_insert_rowid()`
+     arithmetic over the consecutive AUTOINCREMENT range — pick after confirming
+     the plugin's SQLite version on-device.
 
-### B2. Validate `SqliteOpLogAdapter` against a real engine
+### B2. Validate `SqliteOpLogAdapter` against a real engine — ✅ done (CI), on-device remains
 
-The current 23 specs use an in-memory stand-in that validates the _translation
-layer_, not SQLite itself.
-
-- **Do:** run the adapter once against a real engine. Two options:
-  1. **On-device** integration check (most faithful), or
-  2. wire **sql.js with a served `.wasm`** into a dedicated Karma run (the
-     universal sql.js build statically imports `node:` modules webpack can't
-     bundle, so this needs an asset/proxy entry, not the default builder).
-- **Do also:** parameterize the existing op-log integration harness to run a
-  second pass against `SqliteOpLogAdapter` (the plan's "run the suite against
-  both adapters" gate) — catches autoincrement/unique/range/atomicity gaps the
-  stand-in can't.
-- **Size:** medium. **Risk:** medium — this is where real-SQLite surprises
-  surface (collation/ordering of TEXT keys, NULL handling in compound ranges).
+- ✅ **sql.js in Karma.** `sql.js` is a devDependency, served into Karma as a
+  global script + a proxied `.wasm` (`src/karma.conf.js`), so the webpack `node:`
+  import problem is sidestepped (loaded as a script, not bundled). A ~25-line
+  `SqlJsDb` wrapper (`sql-js-db.test-helper.ts`) satisfies the `SqliteDb` port.
+- ✅ **Adapter contract dual-run.** `sqlite-op-log-adapter.spec.ts` runs the
+  behavioral contract against both the fake and real sql.js; SQL-emission specs
+  stay fake-only. Confirmed the real `UNIQUE constraint failed` → `ConstraintError`
+  mapping, `AUTOINCREMENT`-after-`clear()`, compound-index + NULL ranges, real
+  `BEGIN IMMEDIATE` rollback. No surprises surfaced.
+- ✅ **Store-port second pass.** `remote-apply-store-port.integration.spec.ts`
+  runs the store's composed flows (apply/mark/merge-clock, partial failures,
+  full-state clearing) through `OperationLogStoreService` on both backends.
+- ⏳ **Remains: the on-device real-engine run.** sql.js validates the engine, not
+  the Capacitor bridge or the native plugin's specific SQLite build/flags. The
+  `operation-log-stress.benchmark.ts` harness is the lever for the on-device
+  perf + behavior pass (see B1 perf note).
 
 ### B3. Flip the DI token on native
 
 - **Do:** override `OP_LOG_DB_ADAPTER_FACTORY` to return `SqliteOpLogAdapter`
   when `IS_NATIVE_PLATFORM`, behind a feature flag defaulting **off**.
-- **Size:** tiny. **Risk:** gated by the flag.
+- **⚠️ Must also fix the store init flow (found during B2 stage 2).**
+  `OperationLogStoreService.init()` (and `ArchiveStoreService`) is IDB-shaped: it
+  unconditionally `_openDbWithRetry()`s an IndexedDB connection and hands it to
+  `adapter.adoptConnection?.(db)` — a **no-op for SQLite**, which self-manages.
+  Two consequences on the SQLite path: (a) the adapter's tables are never created
+  (`adapter.init()` is the DDL and is never called → "no such table"), and (b) it
+  still opens the evictable WebView IndexedDB we're trying to escape. So `init()`
+  must, when the backend self-manages (no `adoptConnection`), call
+  `await this._adapter.init()` and **skip the IDB open**. The B2 store-port spec
+  papers over (a) by pre-creating the tables; B3 is where the real fix lands.
+- **Size:** tiny token flip; small-but-careful init change. **Risk:** gated by
+  the flag.
 
 ---
 
 ## Track C — Data migration (native, one-time)
 
-### C1. IDB → SQLite copy on first launch after enabling B3
+### C1. IDB → SQLite copy on first launch after enabling B3 — ✅ algorithm done + tested, wiring remains
 
-- **Do:** when the SQLite DB is empty/absent **and** a legacy `SUP_OPS`
-  IndexedDB exists, copy OPS / STATE*CACHE / VECTOR_CLOCK / CLIENT_ID /
-  ARCHIVE*\* across in one SQLite transaction (reuse the IndexedDB adapter's read
-  side + the SQLite adapter's write side — both already exist).
-- **Verify before commit:** op count, last `seq`, and vector clock match.
-- **Keep the IDB copy** untouched for ≥1 release as a fallback; add cleanup
-  later. Mirror the proven legacy `pf` → `SUP_OPS` migration pattern.
-- **Size:** medium. **Risk:** high (data movement) — mitigated by verify +
-  retain-source.
+- ✅ **Algorithm:** `migrateOpLogBackend(source, dest)` in
+  `op-log-backend-migration.ts` copies **all** stores in one `dest` transaction
+  with verify-before-commit (op count + last `seq` + vector clock; mismatch →
+  rollback, source untouched). Generic `iterate`→`put`: preserves ops `seq`
+  (incl. gaps) via put-honors-seq, writes singletons at their out-of-line key,
+  no per-store special-casing. Adapter-agnostic, so validated real-Chrome-IDB →
+  sql.js in CI; the native plugin dest behaves identically through the port.
+- ⏳ **Remains (wiring, with B3):** detect "SQLite empty/absent **and** legacy
+  `SUP_OPS` present" on first launch and call `migrateOpLogBackend`. Set a
+  migration-complete marker. **Keep the IDB copy** untouched for ≥1 release as a
+  fallback. Note: the copy uses the adapter port's read side, independent of the
+  store-init IDB-open fix in B3.
+- **Risk:** high (data movement) — mitigated by the verify-before-commit safety
+  net (now tested to actually roll back) + retain-source.
 
 ### C2. Staged rollout
 

--- a/docs/sync-and-op-log/sqlite-migration-followup.md
+++ b/docs/sync-and-op-log/sqlite-migration-followup.md
@@ -28,6 +28,11 @@ ordered so each item is independently shippable and reviewable.
   transaction with verify-before-commit (op count + last `seq` + vector clock;
   mismatch → rollback). Validated real-Chrome-IDB → sql.js. **Not wired into
   startup** — B3/C2 decide when to run it.
+- ✅ **Backend-aware store init (B3, partial).** `OperationLogStoreService.init()`
+  / `ArchiveStoreService._init()` now call `adapter.init()` and skip the IDB open
+  for self-managing backends (no `adoptConnection`); the IndexedDB path is
+  unchanged. Dead in production until the native token flip. Only the device-gated
+  token override + native `SqliteDb` wrapper remain.
 - ✅ App-private local backup shipped (#7924): `LocalBackupService` writes a
   JSON snapshot every 5 min on Android (`KeyValStore` rows `backup` /
   `backup_prev`) and iOS (`Directory.Data` `super-productivity-backup.json` /
@@ -135,22 +140,24 @@ captured on the next tick.
   `operation-log-stress.benchmark.ts` harness is the lever for the on-device
   perf + behavior pass (see B1 perf note).
 
-### B3. Flip the DI token on native
+### B3. Flip the DI token on native — init fix ✅ landed; token flip device-gated
 
-- **Do:** override `OP_LOG_DB_ADAPTER_FACTORY` to return `SqliteOpLogAdapter`
-  when `IS_NATIVE_PLATFORM`, behind a feature flag defaulting **off**.
-- **⚠️ Must also fix the store init flow (found during B2 stage 2).**
-  `OperationLogStoreService.init()` (and `ArchiveStoreService`) is IDB-shaped: it
-  unconditionally `_openDbWithRetry()`s an IndexedDB connection and hands it to
-  `adapter.adoptConnection?.(db)` — a **no-op for SQLite**, which self-manages.
-  Two consequences on the SQLite path: (a) the adapter's tables are never created
-  (`adapter.init()` is the DDL and is never called → "no such table"), and (b) it
-  still opens the evictable WebView IndexedDB we're trying to escape. So `init()`
-  must, when the backend self-manages (no `adoptConnection`), call
-  `await this._adapter.init()` and **skip the IDB open**. The B2 store-port spec
-  papers over (a) by pre-creating the tables; B3 is where the real fix lands.
-- **Size:** tiny token flip; small-but-careful init change. **Risk:** gated by
-  the flag.
+- ✅ **Backend-aware store init (the half found during B2 stage 2, now done).**
+  `OperationLogStoreService.init()` and `ArchiveStoreService._init()` were
+  IDB-shaped — they unconditionally opened+adopted a WebView IndexedDB connection
+  and never called `adapter.init()`, so on SQLite the tables were never created
+  _and_ the evictable store was still touched. Now: when the adapter exposes no
+  `adoptConnection` (self-managing, e.g. SQLite), `init()` calls
+  `await this._adapter.init()` and **skips the IDB open**; the IndexedDB path is
+  unchanged. Two unit tests cover both branches; the store-port integration spec
+  now drives the store fully on SQLite (no pre-init workaround). The new branch is
+  **dead in production** until the token flip below, so it shipped risk-free.
+- ⏳ **Remains (device-gated):** override `OP_LOG_DB_ADAPTER_FACTORY` to return
+  `SqliteOpLogAdapter` when `IS_NATIVE_PLATFORM`, behind a feature flag defaulting
+  **off**. The factory must hand **both** services' adapters the **same**
+  `SqliteDb` (one SQLite file, all tables) — mirroring how they share one IDB
+  connection today. Needs B1 (the native `SqliteDb` wrapper) first.
+- **Size:** tiny token flip (init change done). **Risk:** gated by the flag.
 
 ---
 

--- a/docs/sync-and-op-log/sqlite-migration.md
+++ b/docs/sync-and-op-log/sqlite-migration.md
@@ -29,13 +29,22 @@
 >   minimal `SqliteDb` port, so no native dependency. 23 specs validate the
 >   translation layer + transaction semantics against an in-memory SQLite
 >   stand-in.
-> - ⏳ Remaining for Phase B: add `@capacitor-community/sqlite` + a thin
->   `SqliteDb` wrapper over its `SQLiteDBConnection`, override
->   `OP_LOG_DB_ADAPTER_FACTORY` to return `SqliteOpLogAdapter` when native, and
->   run this adapter once against a REAL SQLite engine on-device (the in-memory
->   fake validates translation, not SQLite itself). The other small IDB
->   consumers (theme, credential, oauth, client-id) are out of the data-loss
->   scope (Phase D).
+> - ✅ **Phase B step 3 — real-engine validation (CI):** `sql.js` served into
+>   Karma drives the adapter's behavioral contract (`sqlite-op-log-adapter.spec.ts`)
+>   and a store-level pass (`remote-apply-store-port.integration.spec.ts`) against
+>   actual SQLite. Confirms the `UNIQUE`→`ConstraintError` mapping,
+>   `AUTOINCREMENT`-after-`clear()`, compound-index/NULL ranges, real
+>   `BEGIN IMMEDIATE` rollback. No surprises.
+> - ✅ **Phase C step (algorithm) — backend migration:** `migrateOpLogBackend`
+>   (`op-log-backend-migration.ts`) copies the whole DB source→dest with
+>   verify-before-commit; tested real-IDB → sql.js. Not yet wired into startup.
+> - ⏳ Remaining (device-gated): add `@capacitor-community/sqlite` + a thin
+>   `SqliteDb` wrapper over its `SQLiteDBConnection` (with the bridge-perf
+>   mitigations — see followup B1), override `OP_LOG_DB_ADAPTER_FACTORY` for
+>   native behind a flag, fix the store `init()` to call `adapter.init()` / skip
+>   the IDB open on SQLite (see followup B3), wire the C1 migration trigger, and
+>   run on-device. The other small IDB consumers (theme, credential, oauth,
+>   client-id) are out of the data-loss scope (Phase D).
 >
 > **Open decisions (need on-device validation):**
 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
         "query-string": "^7.1.3",
         "rxjs": "^7.8.2",
         "shepherd.js": "^11.2.0",
+        "sql.js": "^1.14.1",
         "stacktrace-js": "^2.0.2",
         "start-server-and-test": "^2.1.3",
         "stylelint": "^17.9.1",
@@ -24279,6 +24280,13 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ssri": {
       "version": "13.0.1",

--- a/package.json
+++ b/package.json
@@ -304,6 +304,7 @@
     "query-string": "^7.1.3",
     "rxjs": "^7.8.2",
     "shepherd.js": "^11.2.0",
+    "sql.js": "^1.14.1",
     "stacktrace-js": "^2.0.2",
     "start-server-and-test": "^2.1.3",
     "stylelint": "^17.9.1",

--- a/src/app/op-log/persistence/archive-store.service.ts
+++ b/src/app/op-log/persistence/archive-store.service.ts
@@ -81,6 +81,14 @@ export class ArchiveStoreService {
    * all stores.
    */
   private async _init(): Promise<void> {
+    // Self-managing backends (e.g. SQLite) own their handle and create their own
+    // schema via the adapter — no WebView IndexedDB connection needed. Mirrors
+    // OperationLogStoreService.init(); only the adopt-connection (IndexedDB)
+    // backend opens/owns a connection here.
+    if (!this._adapter.adoptConnection) {
+      await this._adapter.init();
+      return;
+    }
     const db = await this._openDbWithRetry();
     db.addEventListener('close', () => {
       Log.warn(

--- a/src/app/op-log/persistence/op-log-backend-migration.spec.ts
+++ b/src/app/op-log/persistence/op-log-backend-migration.spec.ts
@@ -1,0 +1,173 @@
+import { IndexedDbOpLogAdapter } from './indexed-db-op-log-adapter';
+import { SqliteOpLogAdapter } from './sqlite-op-log-adapter';
+import { createSqlJsDb } from './sql-js-db.test-helper';
+import {
+  migrateOpLogBackend,
+  OpLogBackendMigrationError,
+} from './op-log-backend-migration';
+import { OPS_INDEXES, SINGLETON_KEY, STORE_NAMES } from './db-keys.const';
+import { DbTxMode, OpLogDbAdapter, OpLogTx } from './op-log-db-adapter';
+
+const ALL_STORES = Object.values(STORE_NAMES);
+
+const makeOpEntry = (
+  id: string,
+  source: 'local' | 'remote' = 'local',
+): Record<string, unknown> => ({
+  op: { id },
+  appliedAt: 1,
+  source,
+  syncedAt: undefined,
+  applicationStatus: undefined,
+});
+
+/**
+ * Wrap a dest adapter so its migration transaction silently drops the first OPS
+ * write — simulating a partial copy, to prove verify-before-commit rolls back.
+ */
+const makeLossyDest = (dest: OpLogDbAdapter): OpLogDbAdapter => {
+  let dropped = false;
+  const wrapTx = (tx: OpLogTx): OpLogTx => ({
+    add: (s, v) => tx.add(s, v),
+    put: (s, v, k) => {
+      if (s === STORE_NAMES.OPS && !dropped) {
+        dropped = true;
+        return Promise.resolve();
+      }
+      return tx.put(s, v, k);
+    },
+    get: (s, k) => tx.get(s, k),
+    getAll: (s, r) => tx.getAll(s, r),
+    delete: (s, k) => tx.delete(s, k),
+    clear: (s) => tx.clear(s),
+    getFromIndex: (s, i, k) => tx.getFromIndex(s, i, k),
+    getKeyFromIndex: (s, i, k) => tx.getKeyFromIndex(s, i, k),
+    getAllFromIndex: (s, i, r) => tx.getAllFromIndex(s, i, r),
+    iterate: (s, o, vis) => tx.iterate(s, o, vis),
+  });
+  return new Proxy(dest, {
+    get: (target, prop, recv) => {
+      if (prop === 'transaction') {
+        return <T>(stores: string[], mode: DbTxMode, fn: (tx: OpLogTx) => Promise<T>) =>
+          target.transaction(stores, mode, (tx) => fn(wrapTx(tx)));
+      }
+      const v = Reflect.get(target, prop, recv);
+      return typeof v === 'function' ? v.bind(target) : v;
+    },
+  }) as OpLogDbAdapter;
+};
+
+describe('migrateOpLogBackend (IndexedDB -> SQLite, C1)', () => {
+  let src: IndexedDbOpLogAdapter;
+  let dest: SqliteOpLogAdapter;
+
+  beforeEach(async () => {
+    // Real Chrome IndexedDB (shared SUP_OPS) — isolate from other specs/runs.
+    src = new IndexedDbOpLogAdapter();
+    await src.init();
+    for (const store of ALL_STORES) {
+      await src.clear(store);
+    }
+    dest = new SqliteOpLogAdapter(await createSqlJsDb());
+    await dest.init();
+  });
+
+  afterEach(async () => {
+    for (const store of ALL_STORES) {
+      await src.clear(store);
+    }
+    src.close();
+  });
+
+  it('copies every store with op-seq, singleton and vector-clock fidelity', async () => {
+    const s1 = await src.add(STORE_NAMES.OPS, makeOpEntry('a'));
+    const s2 = await src.add(STORE_NAMES.OPS, makeOpEntry('b'));
+    const s3 = await src.add(STORE_NAMES.OPS, makeOpEntry('c'));
+    await src.delete(STORE_NAMES.OPS, s2); // leave a gap: seqs are s1, s3
+    await src.put(STORE_NAMES.VECTOR_CLOCK, { clientA: 3, clientB: 7 }, SINGLETON_KEY);
+    await src.put(STORE_NAMES.CLIENT_ID, { id: 'device-xyz' }, SINGLETON_KEY);
+    await src.put(STORE_NAMES.STATE_CACHE, { id: SINGLETON_KEY, state: { tasks: 2 } });
+    // archive_young uses an in-line key (keyPath `id`) — no out-of-line key.
+    await src.put(STORE_NAMES.ARCHIVE_YOUNG, {
+      id: SINGLETON_KEY,
+      data: { foo: 1 },
+      lastModified: 5,
+    });
+
+    const result = await migrateOpLogBackend(src, dest);
+
+    expect(result.copiedCounts[STORE_NAMES.OPS]).toBe(2);
+    expect(result.lastSeq).toBe(s3);
+
+    // ops: both the seq values AND the gap are preserved (put, not add).
+    const destOps = await dest.getAll<{ op: { id: string }; seq: number }>(
+      STORE_NAMES.OPS,
+    );
+    expect(destOps.map((o) => o.seq).sort((a, b) => a - b)).toEqual([s1, s3]);
+    expect(destOps.map((o) => o.op.id).sort()).toEqual(['a', 'c']);
+    // the unique byId index is rebuilt on dest and resolves to the right seq.
+    expect(
+      (await dest.getFromIndex<{ seq: number }>(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'c'))
+        ?.seq,
+    ).toBe(s3);
+
+    expect(await dest.get(STORE_NAMES.VECTOR_CLOCK, SINGLETON_KEY)).toEqual({
+      clientA: 3,
+      clientB: 7,
+    });
+    expect(await dest.get(STORE_NAMES.CLIENT_ID, SINGLETON_KEY)).toEqual({
+      id: 'device-xyz',
+    });
+    expect(
+      (
+        await dest.get<{ state: { tasks: number } }>(
+          STORE_NAMES.STATE_CACHE,
+          SINGLETON_KEY,
+        )
+      )?.state.tasks,
+    ).toBe(2);
+    expect(await dest.get(STORE_NAMES.ARCHIVE_YOUNG, SINGLETON_KEY)).toEqual({
+      id: SINGLETON_KEY,
+      data: { foo: 1 },
+      lastModified: 5,
+    });
+  });
+
+  it('a new local op after migration continues past the copied high-water seq', async () => {
+    await src.add(STORE_NAMES.OPS, makeOpEntry('a'));
+    const s2 = await src.add(STORE_NAMES.OPS, makeOpEntry('b'));
+
+    await migrateOpLogBackend(src, dest);
+
+    // AUTOINCREMENT must resume above the migrated seqs, never colliding.
+    const next = await dest.add(STORE_NAMES.OPS, makeOpEntry('c'));
+    expect(next).toBeGreaterThan(s2);
+  });
+
+  it('handles an empty source', async () => {
+    const result = await migrateOpLogBackend(src, dest);
+    expect(result.copiedCounts[STORE_NAMES.OPS]).toBe(0);
+    expect(result.lastSeq).toBe(0);
+    expect(await dest.count(STORE_NAMES.OPS)).toBe(0);
+  });
+
+  it('refuses to migrate into a non-empty destination', async () => {
+    await src.add(STORE_NAMES.OPS, makeOpEntry('a'));
+    await dest.add(STORE_NAMES.OPS, makeOpEntry('pre-existing'));
+    await expectAsync(migrateOpLogBackend(src, dest)).toBeRejectedWith(
+      jasmine.any(OpLogBackendMigrationError),
+    );
+  });
+
+  it('rolls the destination back when verify-before-commit fails', async () => {
+    await src.add(STORE_NAMES.OPS, makeOpEntry('a'));
+    await src.add(STORE_NAMES.OPS, makeOpEntry('b'));
+    await src.add(STORE_NAMES.OPS, makeOpEntry('c'));
+
+    await expectAsync(migrateOpLogBackend(src, makeLossyDest(dest))).toBeRejectedWith(
+      jasmine.any(OpLogBackendMigrationError),
+    );
+    // The whole copy rolled back — the real dest is left empty.
+    expect(await dest.count(STORE_NAMES.OPS)).toBe(0);
+  });
+});

--- a/src/app/op-log/persistence/op-log-backend-migration.ts
+++ b/src/app/op-log/persistence/op-log-backend-migration.ts
@@ -1,0 +1,120 @@
+/**
+ * C1 — one-time op-log backend migration (see
+ * docs/sync-and-op-log/sqlite-migration.md). Copies the ENTIRE op-log database
+ * from `source` (the legacy IndexedDB backend) to `dest` (SQLite) in a single
+ * `dest` transaction with **verify-before-commit**: if the copied op count,
+ * last `seq`, or vector clock do not match the source, the transaction throws
+ * and rolls back, leaving `dest` empty and the `source` untouched.
+ *
+ * Adapter-agnostic by design — it talks only to the {@link OpLogDbAdapter} port,
+ * so it is validated in CI with a real IndexedDB source + a sql.js SQLite dest;
+ * the native `@capacitor-community/sqlite` dest behaves identically through the
+ * same port. The CALLER (Phase B3/C2) decides WHEN to run it — only when the
+ * SQLite DB is empty and a legacy `SUP_OPS` IndexedDB exists — and keeps the IDB
+ * copy as a fallback for >= 1 release. Mirrors the proven legacy `pf` -> SUP_OPS
+ * migration pattern.
+ */
+import { OpLogDbAdapter } from './op-log-db-adapter';
+import { SINGLETON_KEY, STORE_NAMES } from './db-keys.const';
+
+/** Every store is copied — fully evacuating the source, not just the hot ones. */
+const ALL_STORES: readonly string[] = Object.values(STORE_NAMES);
+
+export interface OpLogBackendMigrationResult {
+  /** Rows copied per store. */
+  readonly copiedCounts: Readonly<Record<string, number>>;
+  /** Highest ops `seq` carried across (0 when there are no ops). */
+  readonly lastSeq: number;
+}
+
+export class OpLogBackendMigrationError extends Error {
+  constructor(message: string) {
+    super(`OpLogBackendMigration: ${message}`);
+    this.name = 'OpLogBackendMigrationError';
+  }
+}
+
+interface StoredRow {
+  readonly value: unknown;
+  readonly key: number | string;
+}
+
+const maxSeq = (rows: ReadonlyArray<{ seq?: number }>): number =>
+  rows.reduce((m, r) => (typeof r.seq === 'number' && r.seq > m ? r.seq : m), 0);
+
+/**
+ * Copy the whole op-log from `source` to `dest`. Both adapters are `init()`-ed
+ * here. Throws {@link OpLogBackendMigrationError} (and rolls `dest` back) on a
+ * non-empty destination or any verification mismatch.
+ */
+export const migrateOpLogBackend = async (
+  source: OpLogDbAdapter,
+  dest: OpLogDbAdapter,
+): Promise<OpLogBackendMigrationResult> => {
+  await source.init();
+  await dest.init();
+
+  // Refuse a non-empty destination — C1 runs only when SQLite is empty.
+  // Merging into existing data would risk seq/clock corruption.
+  if ((await dest.count(STORE_NAMES.OPS)) > 0) {
+    throw new OpLogBackendMigrationError(
+      'destination already has ops; refusing to merge',
+    );
+  }
+
+  // Snapshot every store from the source (value + primary key) via a readonly
+  // cursor. The visitor key is the `seq` for ops, the out-of-line key for
+  // singletons (vector clock, client id), and the keyPath key for keyed stores.
+  const snapshot = new Map<string, StoredRow[]>();
+  for (const store of ALL_STORES) {
+    const rows: StoredRow[] = [];
+    await source.iterate<unknown>(store, { mode: 'readonly' }, (value, key) => {
+      rows.push({ value, key: key as number | string });
+      return 'continue';
+    });
+    snapshot.set(store, rows);
+  }
+
+  // Source invariants the copy must reproduce exactly.
+  const srcOps = snapshot.get(STORE_NAMES.OPS) ?? [];
+  const srcOpCount = srcOps.length;
+  const srcLastSeq = maxSeq(srcOps.map((r) => r.value as { seq?: number }));
+  const srcClock = await source.get(STORE_NAMES.VECTOR_CLOCK, SINGLETON_KEY);
+
+  await dest.transaction([...ALL_STORES], 'readwrite', async (tx) => {
+    for (const store of ALL_STORES) {
+      for (const { value, key } of snapshot.get(store) ?? []) {
+        // `put` preserves the ops `seq` (the value carries it via ON CONFLICT)
+        // and writes singletons at their out-of-line key — uniform across all
+        // store kinds, so no per-store special-casing is needed.
+        await tx.put(store, value, key);
+      }
+    }
+
+    // Verify-before-commit: any mismatch throws -> the whole copy rolls back.
+    const destOps = await tx.getAll<{ seq?: number }>(STORE_NAMES.OPS);
+    if (destOps.length !== srcOpCount) {
+      throw new OpLogBackendMigrationError(
+        `op count mismatch: source ${srcOpCount}, dest ${destOps.length}`,
+      );
+    }
+    const destLastSeq = maxSeq(destOps);
+    if (destLastSeq !== srcLastSeq) {
+      throw new OpLogBackendMigrationError(
+        `last seq mismatch: source ${srcLastSeq}, dest ${destLastSeq}`,
+      );
+    }
+    const destClock = await tx.get(STORE_NAMES.VECTOR_CLOCK, SINGLETON_KEY);
+    // Both values come from the same source object through a JSON round-trip,
+    // so key order is preserved and a string compare is sufficient.
+    if (JSON.stringify(srcClock ?? null) !== JSON.stringify(destClock ?? null)) {
+      throw new OpLogBackendMigrationError('vector clock mismatch');
+    }
+  });
+
+  const copiedCounts: Record<string, number> = {};
+  for (const store of ALL_STORES) {
+    copiedCounts[store] = (snapshot.get(store) ?? []).length;
+  }
+  return { copiedCounts, lastSeq: srcLastSeq };
+};

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -18,6 +18,8 @@ import {
 } from '../../core/util/vector-clock';
 import { limitVectorClockSize, MAX_VECTOR_CLOCK_SIZE } from '@sp/shared-schema';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
+import { OP_LOG_DB_ADAPTER_FACTORY } from './op-log-db-adapter.token';
+import { OpLogDbAdapter } from './op-log-db-adapter';
 import {
   IDB_OPEN_RETRIES,
   IDB_OPEN_RETRIES_NON_LOCK,
@@ -91,6 +93,63 @@ describe('OperationLogStoreService', () => {
 
       // All should resolve without error
       await expectAsync(Promise.all(initPromises)).toBeResolved();
+    });
+  });
+
+  describe('init backend selection (Phase B3)', () => {
+    // Build a fresh service whose adapter comes from the given factory.
+    const freshServiceWith = (adapter: OpLogDbAdapter): OperationLogStoreService => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          OperationLogStoreService,
+          { provide: CLIENT_ID_PROVIDER, useValue: mockClientIdProvider },
+          { provide: OP_LOG_DB_ADAPTER_FACTORY, useValue: () => adapter },
+        ],
+      });
+      return TestBed.inject(OperationLogStoreService);
+    };
+
+    it('init()s a self-managing adapter (no adoptConnection) and opens NO IndexedDB', async () => {
+      // SQLite-style backend: self-manages its handle, creates its schema via
+      // init(), and never adopts a connection.
+      const initSpy = jasmine.createSpy('init').and.resolveTo(undefined);
+      const adapter = { init: initSpy } as unknown as OpLogDbAdapter;
+      const svc = freshServiceWith(adapter);
+      const openSpy = spyOn(
+        svc as unknown as { _openDbOnce: () => Promise<unknown> },
+        '_openDbOnce',
+      );
+
+      await svc.init();
+
+      expect(initSpy).toHaveBeenCalledTimes(1);
+      expect(openSpy).not.toHaveBeenCalled();
+      // No WebView IndexedDB connection is opened or cached on this path.
+      expect((svc as unknown as { _db: unknown })._db).toBeUndefined();
+    });
+
+    it('opens + adopts a connection for an adopt-connection (IndexedDB) adapter', async () => {
+      const initSpy = jasmine.createSpy('init').and.resolveTo(undefined);
+      const adoptSpy = jasmine.createSpy('adoptConnection');
+      const adapter = {
+        init: initSpy,
+        adoptConnection: adoptSpy,
+      } as unknown as OpLogDbAdapter;
+      const svc = freshServiceWith(adapter);
+      const fakeDb = { addEventListener: (): void => {} };
+      spyOn(
+        svc as unknown as { _openDbOnce: () => Promise<unknown> },
+        '_openDbOnce',
+      ).and.resolveTo(fakeDb);
+
+      await svc.init();
+
+      expect(adoptSpy).toHaveBeenCalledWith(fakeDb);
+      // The IndexedDB backend does NOT use the adapter's own init() (its schema
+      // comes from the IDB upgrade on the adopted connection).
+      expect(initSpy).not.toHaveBeenCalled();
+      expect((svc as unknown as { _db: unknown })._db).toBe(fakeDb);
     });
   });
 

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -225,6 +225,15 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
   private _vectorClockCache: VectorClock | null = null;
 
   async init(): Promise<void> {
+    // Self-managing backends (e.g. SQLite) own their handle and create their own
+    // schema via the adapter — they need no WebView IndexedDB connection. Opening
+    // one would both leave the adapter's tables uncreated AND still touch the
+    // evictable WebView store this migration exists to escape. Only the
+    // adopt-connection (IndexedDB) backend opens/owns a connection here.
+    if (!this._adapter.adoptConnection) {
+      await this._adapter.init();
+      return;
+    }
     const db = await this._openDbWithRetry();
     db.addEventListener('close', () => {
       Log.warn(

--- a/src/app/op-log/persistence/sql-js-db.test-helper.ts
+++ b/src/app/op-log/persistence/sql-js-db.test-helper.ts
@@ -1,0 +1,93 @@
+/**
+ * Test helper: a REAL SQLite engine (sql.js / WASM) behind the {@link SqliteDb}
+ * port, so the {@link SqliteOpLogAdapter} contract can be validated against
+ * actual SQLite — not just the in-memory translation-layer fake in
+ * `sqlite-op-log-adapter.spec.ts`. This is the B2 "run against a real engine"
+ * gate from docs/sync-and-op-log/sqlite-migration.md.
+ *
+ * sql.js is loaded as a Karma global (see src/karma.conf.js `files`), not
+ * imported, because its universal build statically references `node:` builtins
+ * the webpack Karma builder cannot bundle. The wasm is fetched from the proxied
+ * `/sql-wasm.wasm`. Dev/test only — never imported by app code, so it never
+ * reaches the app bundle (preserving the native-only SQLite rule).
+ */
+import { SqliteDb } from './sqlite-op-log-adapter';
+
+// ── minimal slice of the sql.js API this helper drives (sql.js ships no types) ─
+interface SqlJsStatement {
+  bind(params: unknown[]): boolean;
+  step(): boolean;
+  getAsObject(): Record<string, unknown>;
+  free(): boolean;
+}
+interface SqlJsDatabase {
+  run(sql: string, params?: unknown[]): unknown;
+  exec(sql: string): { columns: string[]; values: unknown[][] }[];
+  prepare(sql: string): SqlJsStatement;
+  getRowsModified(): number;
+}
+interface SqlJsStatic {
+  Database: new () => SqlJsDatabase;
+}
+type InitSqlJs = (config?: {
+  locateFile?: (file: string) => string;
+}) => Promise<SqlJsStatic>;
+
+declare const initSqlJs: InitSqlJs;
+
+let _sqlJs: Promise<SqlJsStatic> | undefined;
+
+const loadSqlJs = (): Promise<SqlJsStatic> => {
+  if (typeof initSqlJs !== 'function') {
+    throw new Error(
+      'sql.js global not found — is the karma.conf.js `files` entry for sql-wasm.js present?',
+    );
+  }
+  return (_sqlJs ??= initSqlJs({ locateFile: () => '/sql-wasm.wasm' }));
+};
+
+/**
+ * A {@link SqliteDb} backed by sql.js. sql.js is synchronous once loaded; the
+ * async port methods just wrap that. Mirrors what a thin native wrapper over
+ * `@capacitor-community/sqlite`'s `SQLiteDBConnection` will do.
+ */
+class SqlJsDb implements SqliteDb {
+  constructor(private readonly _db: SqlJsDatabase) {}
+
+  async run(
+    sql: string,
+    params: unknown[] = [],
+  ): Promise<{ changes: number; lastId?: number }> {
+    this._db.run(sql, params);
+    const changes = this._db.getRowsModified();
+    // `lastId` is only consumed right after an INSERT (sqlAdd); reading it
+    // otherwise would be a wasted round-trip on a real (bridged) engine.
+    let lastId: number | undefined;
+    if (/^\s*INSERT/i.test(sql)) {
+      const res = this._db.exec('SELECT last_insert_rowid() AS id');
+      const v = res[0]?.values[0]?.[0];
+      lastId = typeof v === 'number' ? v : Number(v);
+    }
+    return { changes, lastId };
+  }
+
+  async query(sql: string, params: unknown[] = []): Promise<Record<string, unknown>[]> {
+    const stmt = this._db.prepare(sql);
+    try {
+      stmt.bind(params);
+      const rows: Record<string, unknown>[] = [];
+      while (stmt.step()) {
+        rows.push(stmt.getAsObject());
+      }
+      return rows;
+    } finally {
+      stmt.free();
+    }
+  }
+}
+
+/** Create a fresh in-memory real-SQLite db satisfying the {@link SqliteDb} port. */
+export const createSqlJsDb = async (): Promise<SqliteDb> => {
+  const SQL = await loadSqlJs();
+  return new SqlJsDb(new SQL.Database());
+};

--- a/src/app/op-log/persistence/sqlite-op-log-adapter.spec.ts
+++ b/src/app/op-log/persistence/sqlite-op-log-adapter.spec.ts
@@ -6,18 +6,29 @@ import {
 } from './sqlite-op-log-adapter';
 import { OpLogDbAdapter } from './op-log-db-adapter';
 import { STORE_NAMES, OPS_INDEXES } from './db-keys.const';
+import { createSqlJsDb } from './sql-js-db.test-helper';
 
 /**
- * A small in-memory SQLite stand-in. It is NOT a real SQL engine — it models
- * just enough table semantics (autoinc PK, unique op_id, value + extracted
- * columns, BEGIN/COMMIT/ROLLBACK, WHERE/ORDER for the exact shapes this adapter
- * emits) to validate the adapter's behavior in Karma without a native build.
+ * Two engines validate this adapter:
  *
- * A REAL SQLite engine (the @capacitor-community/sqlite path, or sql.js with a
- * served .wasm) should additionally exercise this adapter on-device — see the
- * note in docs/sync-and-op-log/sqlite-migration.md. This fake verifies the
- * translation layer (SQL/params/value-extraction/decode/tx ordering); it does
- * not re-verify SQLite itself.
+ * 1. A small in-memory SQLite stand-in (`FakeSqliteDb`). It is NOT a real SQL
+ *    engine — it models just enough table semantics (autoinc PK, unique op_id,
+ *    value + extracted columns, BEGIN/COMMIT/ROLLBACK, WHERE/ORDER for the
+ *    exact shapes this adapter emits) to validate the *translation layer*
+ *    (SQL/params/value-extraction/decode/tx ordering) and let us introspect the
+ *    emitted SQL via `db.log`.
+ *
+ * 2. **Real SQLite via sql.js** (`createSqlJsDb`). The behavioral contract below
+ *    runs against BOTH, so genuine-engine behavior — TEXT collation/ordering,
+ *    NULL handling in compound ranges, AUTOINCREMENT-after-clear, the real
+ *    `UNIQUE constraint failed` message → ConstraintError mapping, real
+ *    BEGIN IMMEDIATE rollback — is exercised, not just the stand-in's model.
+ *    This is the B2 "run against a real engine" gate in
+ *    docs/sync-and-op-log/sqlite-migration.md.
+ *
+ * SQL-emission assertions (which SQL/params the adapter produces) stay
+ * fake-only — they introspect `FakeSqliteDb.log`, and what SQL is emitted is
+ * engine-independent.
  */
 interface Row {
   [col: string]: string | number | null;
@@ -228,22 +239,368 @@ class FakeSqliteDb implements SqliteDb {
   }
 }
 
-describe('SqliteOpLogAdapter', () => {
+const makeOpEntry = (
+  id: string,
+  source: 'local' | 'remote',
+  applicationStatus?: 'pending' | 'applied' | 'failed',
+  syncedAt?: number,
+): Record<string, unknown> => ({
+  op: { id },
+  appliedAt: Date.now(),
+  source,
+  syncedAt,
+  applicationStatus,
+});
+
+/**
+ * The engine-behavioral contract, run against both the in-memory fake and real
+ * sql.js. Everything here goes through the adapter's public API only (no
+ * `db.log` introspection), so it is a genuine same-behavior assertion across
+ * engines.
+ */
+const defineBehavioralContract = (
+  label: string,
+  makeDb: () => SqliteDb | Promise<SqliteDb>,
+): void => {
+  describe(`SqliteOpLogAdapter — behavior (${label})`, () => {
+    let adapter: SqliteOpLogAdapter;
+
+    beforeEach(async () => {
+      adapter = new SqliteOpLogAdapter(await makeDb());
+      await adapter.init();
+    });
+
+    // ── CRUD ─────────────────────────────────────────────────────────────────
+
+    it('add() auto-increments seq and get() round-trips the JSON value', async () => {
+      const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
+      const s2 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
+      expect(s2).toBe(s1 + 1);
+      const got = await adapter.get<{ op: { id: string } }>(STORE_NAMES.OPS, s1);
+      expect(got?.op.id).toBe('a');
+    });
+
+    it('seq keeps climbing after clear() (AUTOINCREMENT, never reused)', async () => {
+      const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
+      await adapter.clear(STORE_NAMES.OPS);
+      const s2 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
+      expect(s2).toBeGreaterThan(s1);
+    });
+
+    it('put()/get() works for a keyPath store (state_cache, key from $.id)', async () => {
+      await adapter.put(STORE_NAMES.STATE_CACHE, { id: 'current', state: { x: 1 } });
+      const got = await adapter.get<{ state: { x: number } }>(
+        STORE_NAMES.STATE_CACHE,
+        'current',
+      );
+      expect(got?.state.x).toBe(1);
+    });
+
+    it('put() upserts a keyless singleton under an explicit key', async () => {
+      await adapter.put(STORE_NAMES.VECTOR_CLOCK, { clock: { a: 1 } }, 'current');
+      await adapter.put(STORE_NAMES.VECTOR_CLOCK, { clock: { a: 2 } }, 'current');
+      const vc = await adapter.get<{ clock: Record<string, number> }>(
+        STORE_NAMES.VECTOR_CLOCK,
+        'current',
+      );
+      expect(vc?.clock['a']).toBe(2);
+      expect(await adapter.count(STORE_NAMES.VECTOR_CLOCK)).toBe(1);
+    });
+
+    it('enforces the unique byId index, surfacing a ConstraintError', async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local'));
+      await expectAsync(
+        adapter.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local')),
+      ).toBeRejectedWith(jasmine.objectContaining({ name: 'ConstraintError' }));
+    });
+
+    it('get() / getFromIndex() return undefined on a miss', async () => {
+      expect(await adapter.get(STORE_NAMES.OPS, 999)).toBeUndefined();
+      expect(
+        await adapter.getFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'absent'),
+      ).toBeUndefined();
+    });
+
+    // ── indexes & ranges ───────────────────────────────────────────────────────
+
+    it('getFromIndex(byId) / getKeyFromIndex resolve to the row and its seq', async () => {
+      const seq = await adapter.add(STORE_NAMES.OPS, makeOpEntry('probe', 'local'));
+      const row = await adapter.getFromIndex<{ op: { id: string } }>(
+        STORE_NAMES.OPS,
+        OPS_INDEXES.BY_ID,
+        'probe',
+      );
+      expect(row?.op.id).toBe('probe');
+      expect(
+        await adapter.getKeyFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'probe'),
+      ).toBe(seq);
+      expect(
+        await adapter.getKeyFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'nope'),
+      ).toBeUndefined();
+    });
+
+    it('getAll with a primary-key range filters by seq (getOpsAfterSeq pattern)', async () => {
+      const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('c', 'local'));
+      const after = await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS, {
+        lower: s1,
+        lowerOpen: true,
+      });
+      expect(after.map((r) => r.op.id)).toEqual(['b', 'c']);
+    });
+
+    it('getAllFromIndex matches a compound-index exact key (bySourceAndStatus)', async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('p1', 'remote', 'pending'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('a1', 'remote', 'applied'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('p2', 'remote', 'pending'));
+      const pending = await adapter.getAllFromIndex<{ op: { id: string } }>(
+        STORE_NAMES.OPS,
+        OPS_INDEXES.BY_SOURCE_AND_STATUS,
+        { lower: ['remote', 'pending'], upper: ['remote', 'pending'] },
+      );
+      expect(pending.map((r) => r.op.id).sort()).toEqual(['p1', 'p2']);
+    });
+
+    it('count reflects a primary-key range; countFromIndex an index match', async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'remote', 'pending'));
+      const s2 = await adapter.add(
+        STORE_NAMES.OPS,
+        makeOpEntry('b', 'remote', 'applied'),
+      );
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('c', 'remote', 'pending'));
+      expect(await adapter.count(STORE_NAMES.OPS)).toBe(3);
+      expect(await adapter.count(STORE_NAMES.OPS, { lower: s2 })).toBe(2);
+      expect(
+        await adapter.countFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_SOURCE_AND_STATUS, {
+          lower: ['remote', 'pending'],
+          upper: ['remote', 'pending'],
+        }),
+      ).toBe(2);
+    });
+
+    // ── cursor iteration ───────────────────────────────────────────────────────
+
+    it('iterate(prev) walks descending and exposes the primary key', async () => {
+      const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
+      const s3 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('c', 'local'));
+      const seen: Array<{ id: string; key: number }> = [];
+      await adapter.iterate<{ op: { id: string } }>(
+        STORE_NAMES.OPS,
+        { direction: 'prev', mode: 'readonly' },
+        (v, key) => {
+          seen.push({ id: v.op.id, key: key as number });
+          return 'continue';
+        },
+      );
+      expect(seen.map((x) => x.id)).toEqual(['c', 'b', 'a']);
+      expect(seen[0].key).toBe(s3);
+      expect(seen[2].key).toBe(s1);
+    });
+
+    it("iterate 'delete' prunes matching rows in a transaction", async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('keep1', 'local'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('drop', 'remote'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('keep2', 'local'));
+      await adapter.iterate<{ op: { id: string }; source: string }>(
+        STORE_NAMES.OPS,
+        {},
+        (v) => (v.source === 'remote' ? 'delete' : 'continue'),
+      );
+      expect(
+        (await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS))
+          .map((r) => r.op.id)
+          .sort(),
+      ).toEqual(['keep1', 'keep2']);
+    });
+
+    it("iterate 'delete-stop' over an index at an exact key removes one entry", async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('alpha', 'local'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('beta', 'local'));
+      const seen: string[] = [];
+      await adapter.iterate<{ op: { id: string } }>(
+        STORE_NAMES.OPS,
+        { index: OPS_INDEXES.BY_ID, query: 'beta' },
+        (v) => {
+          seen.push(v.op.id);
+          return 'delete-stop';
+        },
+      );
+      expect(seen).toEqual(['beta']);
+      expect(
+        (await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS)).map(
+          (r) => r.op.id,
+        ),
+      ).toEqual(['alpha']);
+    });
+
+    // ── transactions: commit / rollback ────────────────────────────────────────
+
+    it('transaction commits a multi-store write atomically', async () => {
+      await adapter.transaction(
+        [STORE_NAMES.OPS, STORE_NAMES.VECTOR_CLOCK],
+        'readwrite',
+        async (tx) => {
+          await tx.add(STORE_NAMES.OPS, makeOpEntry('tx', 'local'));
+          await tx.put(STORE_NAMES.VECTOR_CLOCK, { clock: { c: 1 } }, 'current');
+        },
+      );
+      expect(
+        (
+          await adapter.getFromIndex<{ op: { id: string } }>(
+            STORE_NAMES.OPS,
+            OPS_INDEXES.BY_ID,
+            'tx',
+          )
+        )?.op.id,
+      ).toBe('tx');
+      expect(
+        (
+          await adapter.get<{ clock: Record<string, number> }>(
+            STORE_NAMES.VECTOR_CLOCK,
+            'current',
+          )
+        )?.clock['c'],
+      ).toBe(1);
+    });
+
+    it('transaction rolls back a destructive clear()+delete() on throw', async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('survivor1', 'local'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('survivor2', 'local'));
+      await adapter.put(STORE_NAMES.VECTOR_CLOCK, { clock: { keep: 7 } }, 'current');
+
+      await expectAsync(
+        adapter.transaction(
+          [STORE_NAMES.OPS, STORE_NAMES.VECTOR_CLOCK],
+          'readwrite',
+          async (tx) => {
+            await tx.clear(STORE_NAMES.OPS);
+            await tx.delete(STORE_NAMES.VECTOR_CLOCK, 'current');
+            await tx.add(STORE_NAMES.OPS, makeOpEntry('newBaseline', 'local'));
+            throw new Error('interrupted');
+          },
+        ),
+      ).toBeRejectedWithError('interrupted');
+
+      expect(
+        (await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS))
+          .map((o) => o.op.id)
+          .sort(),
+      ).toEqual(['survivor1', 'survivor2']);
+      expect(
+        (
+          await adapter.get<{ clock: Record<string, number> }>(
+            STORE_NAMES.VECTOR_CLOCK,
+            'current',
+          )
+        )?.clock['keep'],
+      ).toBe(7);
+    });
+
+    it('transaction aborts on an inner UNIQUE violation, mapping to ConstraintError', async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local'));
+      await expectAsync(
+        adapter.transaction([STORE_NAMES.OPS], 'readwrite', async (tx) => {
+          await tx.add(STORE_NAMES.OPS, makeOpEntry('fresh', 'local'));
+          await tx.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local'));
+        }),
+      ).toBeRejectedWith(jasmine.objectContaining({ name: 'ConstraintError' }));
+      expect(
+        await adapter.getFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'fresh'),
+      ).toBeUndefined();
+    });
+
+    it('exposes transactional reads, index reads and cursor iteration', async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('r1', 'remote', 'pending'));
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('r2', 'remote', 'pending'));
+      const out = await adapter.transaction(
+        [STORE_NAMES.OPS],
+        'readwrite',
+        async (tx) => {
+          const byId = await tx.getFromIndex<{ op: { id: string } }>(
+            STORE_NAMES.OPS,
+            OPS_INDEXES.BY_ID,
+            'r1',
+          );
+          const all = await tx.getAll<{ op: { id: string } }>(STORE_NAMES.OPS);
+          const ids: string[] = [];
+          await tx.iterate<{ op: { id: string } }>(STORE_NAMES.OPS, {}, (v) => {
+            ids.push(v.op.id);
+            return 'continue';
+          });
+          return { byId: byId?.op.id, count: all.length, ids: ids.sort() };
+        },
+      );
+      expect(out).toEqual({ byId: 'r1', count: 2, ids: ['r1', 'r2'] });
+    });
+
+    // ── autoinc seq round-trip + in-place update (the mark*/clearUnsynced path) ─
+
+    it('reads of the ops table carry their seq (the autoinc PK), like IDB', async () => {
+      const seq = await adapter.add(STORE_NAMES.OPS, makeOpEntry('s', 'local'));
+      const got = await adapter.get<{ seq: number }>(STORE_NAMES.OPS, seq);
+      expect(got?.seq).toBe(seq);
+      const fromIndex = await adapter.getFromIndex<{ seq: number }>(
+        STORE_NAMES.OPS,
+        OPS_INDEXES.BY_ID,
+        's',
+      );
+      expect(fromIndex?.seq).toBe(seq);
+    });
+
+    it('put() on the ops table updates in place by seq, not inserting a duplicate', async () => {
+      const seq = await adapter.add(
+        STORE_NAMES.OPS,
+        makeOpEntry('m', 'remote', 'pending'),
+      );
+      // The mark*/clearUnsynced flow: read the entry, mutate it, put it back.
+      const entry = await adapter.get<Record<string, unknown>>(STORE_NAMES.OPS, seq);
+      entry!['applicationStatus'] = 'applied';
+      await adapter.put(STORE_NAMES.OPS, entry);
+      expect(await adapter.count(STORE_NAMES.OPS)).toBe(1);
+      const after = await adapter.get<{ applicationStatus: string }>(
+        STORE_NAMES.OPS,
+        seq,
+      );
+      expect(after?.applicationStatus).toBe('applied');
+    });
+
+    // ── port-contract hardening ─────────────────────────────────────────────────
+
+    it('iterate under mode:readonly rejects a delete action and does not mutate', async () => {
+      await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
+      await expectAsync(
+        adapter.iterate<{ op: { id: string } }>(
+          STORE_NAMES.OPS,
+          { mode: 'readonly' },
+          () => 'delete',
+        ),
+      ).toBeRejectedWith(jasmine.objectContaining({ name: 'ReadOnlyError' }));
+      expect(await adapter.count(STORE_NAMES.OPS)).toBe(1);
+    });
+
+    it('transaction rejects touching a store outside its declared scope', async () => {
+      await expectAsync(
+        adapter.transaction([STORE_NAMES.OPS], 'readwrite', async (tx) => {
+          await tx.put(STORE_NAMES.VECTOR_CLOCK, { clock: { a: 1 } }, 'current');
+        }),
+      ).toBeRejectedWithError(/outside this transaction's declared scope/);
+    });
+  });
+};
+
+defineBehavioralContract('in-memory fake', () => new FakeSqliteDb());
+defineBehavioralContract('sql.js (real SQLite)', createSqlJsDb);
+
+/**
+ * Translation-layer assertions: schema→DDL planning and the exact SQL the
+ * adapter emits. These introspect `FakeSqliteDb.log`; what SQL is produced is
+ * engine-independent, so they run against the fake only.
+ */
+describe('SqliteOpLogAdapter — translation layer (fake)', () => {
   let db: FakeSqliteDb;
   let adapter: SqliteOpLogAdapter;
-
-  const makeOpEntry = (
-    id: string,
-    source: 'local' | 'remote',
-    applicationStatus?: 'pending' | 'applied' | 'failed',
-    syncedAt?: number,
-  ): Record<string, unknown> => ({
-    op: { id },
-    appliedAt: Date.now(),
-    source,
-    syncedAt,
-    applicationStatus,
-  });
 
   beforeEach(async () => {
     db = new FakeSqliteDb();
@@ -292,131 +649,7 @@ describe('SqliteOpLogAdapter', () => {
     expect(insert.params).toContain(1234); // synced_at
   });
 
-  // ── CRUD against the in-memory model ───────────────────────────────────────
-
-  it('add() auto-increments seq and get() round-trips the JSON value', async () => {
-    const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
-    const s2 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
-    expect(s2).toBe(s1 + 1);
-    const got = await adapter.get<{ op: { id: string } }>(STORE_NAMES.OPS, s1);
-    expect(got?.op.id).toBe('a');
-  });
-
-  it('seq keeps climbing after clear() (AUTOINCREMENT, never reused)', async () => {
-    const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
-    await adapter.clear(STORE_NAMES.OPS);
-    const s2 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
-    expect(s2).toBeGreaterThan(s1);
-  });
-
-  it('put()/get() works for a keyPath store (state_cache, key from $.id)', async () => {
-    await adapter.put(STORE_NAMES.STATE_CACHE, { id: 'current', state: { x: 1 } });
-    const got = await adapter.get<{ state: { x: number } }>(
-      STORE_NAMES.STATE_CACHE,
-      'current',
-    );
-    expect(got?.state.x).toBe(1);
-  });
-
-  it('put() upserts a keyless singleton under an explicit key', async () => {
-    await adapter.put(STORE_NAMES.VECTOR_CLOCK, { clock: { a: 1 } }, 'current');
-    await adapter.put(STORE_NAMES.VECTOR_CLOCK, { clock: { a: 2 } }, 'current');
-    const vc = await adapter.get<{ clock: Record<string, number> }>(
-      STORE_NAMES.VECTOR_CLOCK,
-      'current',
-    );
-    expect(vc?.clock['a']).toBe(2);
-    expect(await adapter.count(STORE_NAMES.VECTOR_CLOCK)).toBe(1);
-  });
-
-  it('enforces the unique byId index, surfacing a ConstraintError', async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local'));
-    await expectAsync(
-      adapter.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local')),
-    ).toBeRejectedWith(jasmine.objectContaining({ name: 'ConstraintError' }));
-  });
-
-  it('get() / getFromIndex() return undefined on a miss', async () => {
-    expect(await adapter.get(STORE_NAMES.OPS, 999)).toBeUndefined();
-    expect(
-      await adapter.getFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'absent'),
-    ).toBeUndefined();
-  });
-
-  // ── indexes & ranges ───────────────────────────────────────────────────────
-
-  it('getFromIndex(byId) / getKeyFromIndex resolve to the row and its seq', async () => {
-    const seq = await adapter.add(STORE_NAMES.OPS, makeOpEntry('probe', 'local'));
-    const row = await adapter.getFromIndex<{ op: { id: string } }>(
-      STORE_NAMES.OPS,
-      OPS_INDEXES.BY_ID,
-      'probe',
-    );
-    expect(row?.op.id).toBe('probe');
-    expect(
-      await adapter.getKeyFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'probe'),
-    ).toBe(seq);
-    expect(
-      await adapter.getKeyFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'nope'),
-    ).toBeUndefined();
-  });
-
-  it('getAll with a primary-key range filters by seq (getOpsAfterSeq pattern)', async () => {
-    const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('c', 'local'));
-    const after = await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS, {
-      lower: s1,
-      lowerOpen: true,
-    });
-    expect(after.map((r) => r.op.id)).toEqual(['b', 'c']);
-  });
-
-  it('getAllFromIndex matches a compound-index exact key (bySourceAndStatus)', async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('p1', 'remote', 'pending'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('a1', 'remote', 'applied'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('p2', 'remote', 'pending'));
-    const pending = await adapter.getAllFromIndex<{ op: { id: string } }>(
-      STORE_NAMES.OPS,
-      OPS_INDEXES.BY_SOURCE_AND_STATUS,
-      { lower: ['remote', 'pending'], upper: ['remote', 'pending'] },
-    );
-    expect(pending.map((r) => r.op.id).sort()).toEqual(['p1', 'p2']);
-  });
-
-  it('count reflects a primary-key range; countFromIndex an index match', async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'remote', 'pending'));
-    const s2 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'remote', 'applied'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('c', 'remote', 'pending'));
-    expect(await adapter.count(STORE_NAMES.OPS)).toBe(3);
-    expect(await adapter.count(STORE_NAMES.OPS, { lower: s2 })).toBe(2);
-    expect(
-      await adapter.countFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_SOURCE_AND_STATUS, {
-        lower: ['remote', 'pending'],
-        upper: ['remote', 'pending'],
-      }),
-    ).toBe(2);
-  });
-
-  // ── cursor iteration ───────────────────────────────────────────────────────
-
-  it('iterate(prev) walks descending and exposes the primary key', async () => {
-    const s1 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('b', 'local'));
-    const s3 = await adapter.add(STORE_NAMES.OPS, makeOpEntry('c', 'local'));
-    const seen: Array<{ id: string; key: number }> = [];
-    await adapter.iterate<{ op: { id: string } }>(
-      STORE_NAMES.OPS,
-      { direction: 'prev', mode: 'readonly' },
-      (v, key) => {
-        seen.push({ id: v.op.id, key: key as number });
-        return 'continue';
-      },
-    );
-    expect(seen.map((x) => x.id)).toEqual(['c', 'b', 'a']);
-    expect(seen[0].key).toBe(s3);
-    expect(seen[2].key).toBe(s1);
-  });
+  // ── transaction SQL emission (BEGIN/COMMIT/ROLLBACK) ───────────────────────
 
   it('readonly iterate does not open a transaction', async () => {
     await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
@@ -429,43 +662,7 @@ describe('SqliteOpLogAdapter', () => {
     expect(db.log.some((e) => /^BEGIN/i.test(e.sql))).toBeFalse();
   });
 
-  it("iterate 'delete' prunes matching rows in a transaction", async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('keep1', 'local'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('drop', 'remote'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('keep2', 'local'));
-    await adapter.iterate<{ op: { id: string }; source: string }>(
-      STORE_NAMES.OPS,
-      {},
-      (v) => (v.source === 'remote' ? 'delete' : 'continue'),
-    );
-    expect(
-      (await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS))
-        .map((r) => r.op.id)
-        .sort(),
-    ).toEqual(['keep1', 'keep2']);
-  });
-
-  it("iterate 'delete-stop' over an index at an exact key removes one entry", async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('alpha', 'local'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('beta', 'local'));
-    const seen: string[] = [];
-    await adapter.iterate<{ op: { id: string } }>(
-      STORE_NAMES.OPS,
-      { index: OPS_INDEXES.BY_ID, query: 'beta' },
-      (v) => {
-        seen.push(v.op.id);
-        return 'delete-stop';
-      },
-    );
-    expect(seen).toEqual(['beta']);
-    expect(
-      (await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS)).map((r) => r.op.id),
-    ).toEqual(['alpha']);
-  });
-
-  // ── transactions: commit / rollback ────────────────────────────────────────
-
-  it('transaction commits a multi-store write atomically (BEGIN…COMMIT)', async () => {
+  it('a committed readwrite transaction emits BEGIN IMMEDIATE and COMMIT', async () => {
     await adapter.transaction(
       [STORE_NAMES.OPS, STORE_NAMES.VECTOR_CLOCK],
       'readwrite',
@@ -476,124 +673,19 @@ describe('SqliteOpLogAdapter', () => {
     );
     expect(db.log.some((e) => e.sql === 'BEGIN IMMEDIATE')).toBeTrue();
     expect(db.log.some((e) => e.sql === 'COMMIT')).toBeTrue();
-    expect(
-      (
-        await adapter.getFromIndex<{ op: { id: string } }>(
-          STORE_NAMES.OPS,
-          OPS_INDEXES.BY_ID,
-          'tx',
-        )
-      )?.op.id,
-    ).toBe('tx');
   });
 
-  it('transaction rolls back a destructive clear()+delete() on throw', async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('survivor1', 'local'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('survivor2', 'local'));
-    await adapter.put(STORE_NAMES.VECTOR_CLOCK, { clock: { keep: 7 } }, 'current');
-
-    await expectAsync(
-      adapter.transaction(
-        [STORE_NAMES.OPS, STORE_NAMES.VECTOR_CLOCK],
-        'readwrite',
-        async (tx) => {
-          await tx.clear(STORE_NAMES.OPS);
-          await tx.delete(STORE_NAMES.VECTOR_CLOCK, 'current');
-          await tx.add(STORE_NAMES.OPS, makeOpEntry('newBaseline', 'local'));
-          throw new Error('interrupted');
-        },
-      ),
-    ).toBeRejectedWithError('interrupted');
-
-    expect(db.log.some((e) => e.sql === 'ROLLBACK')).toBeTrue();
-    expect(
-      (await adapter.getAll<{ op: { id: string } }>(STORE_NAMES.OPS))
-        .map((o) => o.op.id)
-        .sort(),
-    ).toEqual(['survivor1', 'survivor2']);
-    expect(
-      (
-        await adapter.get<{ clock: Record<string, number> }>(
-          STORE_NAMES.VECTOR_CLOCK,
-          'current',
-        )
-      )?.clock['keep'],
-    ).toBe(7);
-  });
-
-  it('transaction aborts on an inner UNIQUE violation, mapping to ConstraintError', async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local'));
+  it('a throwing transaction body emits ROLLBACK', async () => {
     await expectAsync(
       adapter.transaction([STORE_NAMES.OPS], 'readwrite', async (tx) => {
-        await tx.add(STORE_NAMES.OPS, makeOpEntry('fresh', 'local'));
-        await tx.add(STORE_NAMES.OPS, makeOpEntry('dup', 'local'));
+        await tx.add(STORE_NAMES.OPS, makeOpEntry('x', 'local'));
+        throw new Error('interrupted');
       }),
-    ).toBeRejectedWith(jasmine.objectContaining({ name: 'ConstraintError' }));
-    expect(
-      await adapter.getFromIndex(STORE_NAMES.OPS, OPS_INDEXES.BY_ID, 'fresh'),
-    ).toBeUndefined();
+    ).toBeRejectedWithError('interrupted');
+    expect(db.log.some((e) => e.sql === 'ROLLBACK')).toBeTrue();
   });
 
-  it('exposes transactional reads, index reads and cursor iteration', async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('r1', 'remote', 'pending'));
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('r2', 'remote', 'pending'));
-    const out = await adapter.transaction([STORE_NAMES.OPS], 'readwrite', async (tx) => {
-      const byId = await tx.getFromIndex<{ op: { id: string } }>(
-        STORE_NAMES.OPS,
-        OPS_INDEXES.BY_ID,
-        'r1',
-      );
-      const all = await tx.getAll<{ op: { id: string } }>(STORE_NAMES.OPS);
-      const ids: string[] = [];
-      await tx.iterate<{ op: { id: string } }>(STORE_NAMES.OPS, {}, (v) => {
-        ids.push(v.op.id);
-        return 'continue';
-      });
-      return { byId: byId?.op.id, count: all.length, ids: ids.sort() };
-    });
-    expect(out).toEqual({ byId: 'r1', count: 2, ids: ['r1', 'r2'] });
-  });
-
-  // ── autoinc seq round-trip + in-place update (the mark*/clearUnsynced path) ─
-
-  it('reads of the ops table carry their seq (the autoinc PK), like IDB', async () => {
-    const seq = await adapter.add(STORE_NAMES.OPS, makeOpEntry('s', 'local'));
-    const got = await adapter.get<{ seq: number }>(STORE_NAMES.OPS, seq);
-    expect(got?.seq).toBe(seq);
-    const fromIndex = await adapter.getFromIndex<{ seq: number }>(
-      STORE_NAMES.OPS,
-      OPS_INDEXES.BY_ID,
-      's',
-    );
-    expect(fromIndex?.seq).toBe(seq);
-  });
-
-  it('put() on the ops table updates in place by seq, not inserting a duplicate', async () => {
-    const seq = await adapter.add(STORE_NAMES.OPS, makeOpEntry('m', 'remote', 'pending'));
-    // The mark*/clearUnsynced flow: read the entry, mutate it, put it back.
-    const entry = await adapter.get<Record<string, unknown>>(STORE_NAMES.OPS, seq);
-    entry!['applicationStatus'] = 'applied';
-    await adapter.put(STORE_NAMES.OPS, entry);
-    expect(await adapter.count(STORE_NAMES.OPS)).toBe(1);
-    const after = await adapter.get<{ applicationStatus: string }>(STORE_NAMES.OPS, seq);
-    expect(after?.applicationStatus).toBe('applied');
-  });
-
-  // ── port-contract hardening: readonly-delete + transaction store scope ──────
-
-  it('iterate under mode:readonly rejects a delete action and does not mutate', async () => {
-    await adapter.add(STORE_NAMES.OPS, makeOpEntry('a', 'local'));
-    await expectAsync(
-      adapter.iterate<{ op: { id: string } }>(
-        STORE_NAMES.OPS,
-        { mode: 'readonly' },
-        () => 'delete',
-      ),
-    ).toBeRejectedWith(jasmine.objectContaining({ name: 'ReadOnlyError' }));
-    expect(await adapter.count(STORE_NAMES.OPS)).toBe(1);
-  });
-
-  it('transaction rejects touching a store outside its declared scope', async () => {
+  it('a scope violation rolls back (emits ROLLBACK)', async () => {
     await expectAsync(
       adapter.transaction([STORE_NAMES.OPS], 'readwrite', async (tx) => {
         await tx.put(STORE_NAMES.VECTOR_CLOCK, { clock: { a: 1 } }, 'current');

--- a/src/app/op-log/testing/integration/remote-apply-store-port.integration.spec.ts
+++ b/src/app/op-log/testing/integration/remote-apply-store-port.integration.spec.ts
@@ -202,15 +202,11 @@ defineStorePortContract('IndexedDB', async () => []);
 
 defineStorePortContract('sql.js (real SQLite)', async () => {
   // One shared sql.js database; the store's single adapter reads/writes it.
-  // The store's init() is IDB-shaped — it opens+adopts an IndexedDB connection
-  // and never calls the adapter's own init(), so for a self-managing backend
-  // like SQLite the tables would not exist ("no such table"). Create them once
-  // on the shared db here; this mirrors the store-init change Phase B3 must make
-  // on native (call adapter.init() / skip the IDB open when the backend is
-  // SQLite). CREATE TABLE IF NOT EXISTS is idempotent, so the store's per-call
-  // adapters reuse these tables.
+  // OperationLogStoreService.init() now calls adapter.init() for self-managing
+  // backends (no adoptConnection) and skips the IndexedDB open (Phase B3), so the
+  // store itself creates the SQLite tables — no pre-init needed. This spec thus
+  // exercises the store running fully on SQLite with `_db` undefined.
   const db = await createSqlJsDb();
-  await new SqliteOpLogAdapter(db).init();
   return [
     { provide: OP_LOG_DB_ADAPTER_FACTORY, useValue: () => new SqliteOpLogAdapter(db) },
   ];

--- a/src/app/op-log/testing/integration/remote-apply-store-port.integration.spec.ts
+++ b/src/app/op-log/testing/integration/remote-apply-store-port.integration.spec.ts
@@ -1,178 +1,217 @@
 import { TestBed } from '@angular/core/testing';
+import { Provider } from '@angular/core';
 import { applyRemoteOperations } from '@sp/sync-core';
 import type { OperationApplyPort } from '@sp/sync-core';
 import { ActionType, EntityType, Operation, OpType } from '../../core/operation.types';
 import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../../util/client-id.provider';
+import { OP_LOG_DB_ADAPTER_FACTORY } from '../../persistence/op-log-db-adapter.token';
+import { SqliteOpLogAdapter } from '../../persistence/sqlite-op-log-adapter';
+import { createSqlJsDb } from '../../persistence/sql-js-db.test-helper';
 
-describe('RemoteOperationApplyStorePort Integration', () => {
-  let store: OperationLogStoreService;
+/**
+ * The store-port composed flows run against BOTH backends: the default
+ * IndexedDB adapter and a sql.js-backed `SqliteOpLogAdapter` (B2 Stage 2 — the
+ * "second pass against SqliteOpLogAdapter" gate from
+ * docs/sync-and-op-log/sqlite-migration.md). This exercises the store's
+ * COMPOSED transactions (the apply/mark/merge-clock path, full-state clearing,
+ * vector-clock persistence) on a real SQL engine — not just the adapter in
+ * isolation.
+ */
+const defineStorePortContract = (
+  label: string,
+  backendProviders: () => Promise<Provider[]>,
+): void => {
+  describe(`RemoteOperationApplyStorePort Integration (${label})`, () => {
+    let store: OperationLogStoreService;
 
-  const mockClientIdProvider: ClientIdProvider = {
-    loadClientId: () => Promise.resolve('testClient'),
-    getOrGenerateClientId: () => Promise.resolve('testClient'),
-    clearCache: () => {},
-  };
-
-  const createOperation = (
-    id: string,
-    overrides: Partial<Operation> = {},
-  ): Operation => ({
-    id,
-    actionType: '[Task] Update' as ActionType,
-    opType: OpType.Update,
-    entityType: 'TASK' as EntityType,
-    entityId: id,
-    payload: {},
-    clientId: 'remoteClient',
-    vectorClock: { remoteClient: 1 },
-    timestamp: 1,
-    schemaVersion: 1,
-    ...overrides,
-  });
-
-  const createApplier = (
-    result: Awaited<ReturnType<OperationApplyPort<Operation>['applyOperations']>>,
-  ): {
-    applier: OperationApplyPort<Operation>;
-    applyOperationsSpy: jasmine.Spy;
-  } => {
-    const applyOperationsSpy = jasmine.createSpy('applyOperations').and.resolveTo(result);
-
-    return {
-      applier: { applyOperations: applyOperationsSpy },
-      applyOperationsSpy,
+    const mockClientIdProvider: ClientIdProvider = {
+      loadClientId: () => Promise.resolve('testClient'),
+      getOrGenerateClientId: () => Promise.resolve('testClient'),
+      clearCache: () => {},
     };
-  };
 
-  beforeEach(async () => {
-    TestBed.configureTestingModule({
-      providers: [
-        OperationLogStoreService,
-        { provide: CLIENT_ID_PROVIDER, useValue: mockClientIdProvider },
-      ],
+    const createOperation = (
+      id: string,
+      overrides: Partial<Operation> = {},
+    ): Operation => ({
+      id,
+      actionType: '[Task] Update' as ActionType,
+      opType: OpType.Update,
+      entityType: 'TASK' as EntityType,
+      entityId: id,
+      payload: {},
+      clientId: 'remoteClient',
+      vectorClock: { remoteClient: 1 },
+      timestamp: 1,
+      schemaVersion: 1,
+      ...overrides,
     });
 
-    store = TestBed.inject(OperationLogStoreService);
-    await store.init();
-    await store._clearAllDataForTesting();
+    const createApplier = (
+      result: Awaited<ReturnType<OperationApplyPort<Operation>['applyOperations']>>,
+    ): {
+      applier: OperationApplyPort<Operation>;
+      applyOperationsSpy: jasmine.Spy;
+    } => {
+      const applyOperationsSpy = jasmine
+        .createSpy('applyOperations')
+        .and.resolveTo(result);
+
+      return {
+        applier: { applyOperations: applyOperationsSpy },
+        applyOperationsSpy,
+      };
+    };
+
+    beforeEach(async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          OperationLogStoreService,
+          { provide: CLIENT_ID_PROVIDER, useValue: mockClientIdProvider },
+          ...(await backendProviders()),
+        ],
+      });
+
+      store = TestBed.inject(OperationLogStoreService);
+      await store.init();
+      await store._clearAllDataForTesting();
+    });
+
+    it('should append, apply, mark, merge clocks, and skip duplicates through the real store port', async () => {
+      const duplicateOp = createOperation('remote-duplicate', {
+        clientId: 'clientA',
+        vectorClock: { clientA: 1 },
+      });
+      const newOp = createOperation('remote-new', {
+        clientId: 'clientB',
+        vectorClock: { clientB: 3 },
+      });
+      await store.append(duplicateOp, 'remote');
+
+      const { applier, applyOperationsSpy } = createApplier({ appliedOps: [newOp] });
+
+      const result = await applyRemoteOperations({
+        ops: [duplicateOp, newOp],
+        store,
+        applier,
+      });
+
+      expect(applyOperationsSpy).toHaveBeenCalledOnceWith([newOp]);
+      expect(result.appendedOps).toEqual([newOp]);
+      expect(result.skippedCount).toBe(1);
+      expect(result.appliedOps).toEqual([newOp]);
+      expect(result.failedOpIds).toEqual([]);
+
+      const duplicateEntry = await store.getOpById(duplicateOp.id);
+      const newEntry = await store.getOpById(newOp.id);
+      expect(duplicateEntry?.applicationStatus).toBe('applied');
+      expect(newEntry?.source).toBe('remote');
+      expect(newEntry?.syncedAt).toBeDefined();
+      expect(newEntry?.applicationStatus).toBe('applied');
+      expect(result.appliedSeqs).toEqual(newEntry ? [newEntry.seq] : []);
+      expect(await store.getPendingRemoteOps()).toEqual([]);
+      expect(await store.getFailedRemoteOps()).toEqual([]);
+      expect(await store.getVectorClock()).toEqual({ clientB: 3 });
+    });
+
+    it('should persist partial apply failures against the real store entries', async () => {
+      const appliedOp = createOperation('remote-applied', {
+        clientId: 'clientA',
+        vectorClock: { clientA: 2 },
+      });
+      const failedOp = createOperation('remote-failed', {
+        clientId: 'clientB',
+        vectorClock: { clientB: 4 },
+      });
+      const remainingOp = createOperation('remote-remaining', {
+        clientId: 'clientC',
+        vectorClock: { clientC: 6 },
+      });
+      const error = new Error('archive write failed');
+      const { applier } = createApplier({
+        appliedOps: [appliedOp],
+        failedOp: { op: failedOp, error },
+      });
+
+      const result = await applyRemoteOperations({
+        ops: [appliedOp, failedOp, remainingOp],
+        store,
+        applier,
+      });
+
+      expect(result.failedOp).toEqual({ op: failedOp, error });
+      expect(result.failedOpIds).toEqual([failedOp.id, remainingOp.id]);
+
+      const appliedEntry = await store.getOpById(appliedOp.id);
+      const failedEntry = await store.getOpById(failedOp.id);
+      const remainingEntry = await store.getOpById(remainingOp.id);
+      expect(appliedEntry?.applicationStatus).toBe('applied');
+      expect(failedEntry?.applicationStatus).toBe('failed');
+      expect(failedEntry?.retryCount).toBe(1);
+      expect(remainingEntry?.applicationStatus).toBe('failed');
+      expect(remainingEntry?.retryCount).toBe(1);
+      expect(
+        (await store.getFailedRemoteOps()).map((entry) => entry.op.id).sort(),
+      ).toEqual([failedOp.id, remainingOp.id].sort());
+      expect(await store.getVectorClock()).toEqual({ clientA: 2 });
+    });
+
+    it('should clear older full-state ops and reset the vector clock after an applied remote import', async () => {
+      const oldImportOp = createOperation('old-import', {
+        opType: OpType.SyncImport,
+        clientId: 'oldImportClient',
+        vectorClock: { oldImportClient: 1 },
+      });
+      const newImportOp = createOperation('new-import', {
+        opType: OpType.SyncImport,
+        clientId: 'importClient',
+        vectorClock: { importClient: 9, deadClient: 4 },
+      });
+      const postImportOp = createOperation('post-import-op', {
+        clientId: 'importClient',
+        vectorClock: { importClient: 10 },
+      });
+      await store.append(oldImportOp, 'remote');
+      await store.setVectorClock({ staleClient: 5, testClient: 7 });
+
+      const { applier } = createApplier({
+        appliedOps: [newImportOp, postImportOp],
+      });
+
+      const result = await applyRemoteOperations({
+        ops: [newImportOp, postImportOp],
+        store,
+        applier,
+        isFullStateOperation: (op) => op.opType === OpType.SyncImport,
+      });
+
+      expect(result.clearedFullStateOpCount).toBe(1);
+      expect(await store.getOpById(oldImportOp.id)).toBeUndefined();
+      expect((await store.getOpById(newImportOp.id))?.applicationStatus).toBe('applied');
+      expect((await store.getOpById(postImportOp.id))?.applicationStatus).toBe('applied');
+      expect(await store.getVectorClock()).toEqual({
+        importClient: 10,
+        testClient: 7,
+      });
+    });
   });
+};
 
-  it('should append, apply, mark, merge clocks, and skip duplicates through the real store port', async () => {
-    const duplicateOp = createOperation('remote-duplicate', {
-      clientId: 'clientA',
-      vectorClock: { clientA: 1 },
-    });
-    const newOp = createOperation('remote-new', {
-      clientId: 'clientB',
-      vectorClock: { clientB: 3 },
-    });
-    await store.append(duplicateOp, 'remote');
+defineStorePortContract('IndexedDB', async () => []);
 
-    const { applier, applyOperationsSpy } = createApplier({ appliedOps: [newOp] });
-
-    const result = await applyRemoteOperations({
-      ops: [duplicateOp, newOp],
-      store,
-      applier,
-    });
-
-    expect(applyOperationsSpy).toHaveBeenCalledOnceWith([newOp]);
-    expect(result.appendedOps).toEqual([newOp]);
-    expect(result.skippedCount).toBe(1);
-    expect(result.appliedOps).toEqual([newOp]);
-    expect(result.failedOpIds).toEqual([]);
-
-    const duplicateEntry = await store.getOpById(duplicateOp.id);
-    const newEntry = await store.getOpById(newOp.id);
-    expect(duplicateEntry?.applicationStatus).toBe('applied');
-    expect(newEntry?.source).toBe('remote');
-    expect(newEntry?.syncedAt).toBeDefined();
-    expect(newEntry?.applicationStatus).toBe('applied');
-    expect(result.appliedSeqs).toEqual(newEntry ? [newEntry.seq] : []);
-    expect(await store.getPendingRemoteOps()).toEqual([]);
-    expect(await store.getFailedRemoteOps()).toEqual([]);
-    expect(await store.getVectorClock()).toEqual({ clientB: 3 });
-  });
-
-  it('should persist partial apply failures against the real IndexedDB entries', async () => {
-    const appliedOp = createOperation('remote-applied', {
-      clientId: 'clientA',
-      vectorClock: { clientA: 2 },
-    });
-    const failedOp = createOperation('remote-failed', {
-      clientId: 'clientB',
-      vectorClock: { clientB: 4 },
-    });
-    const remainingOp = createOperation('remote-remaining', {
-      clientId: 'clientC',
-      vectorClock: { clientC: 6 },
-    });
-    const error = new Error('archive write failed');
-    const { applier } = createApplier({
-      appliedOps: [appliedOp],
-      failedOp: { op: failedOp, error },
-    });
-
-    const result = await applyRemoteOperations({
-      ops: [appliedOp, failedOp, remainingOp],
-      store,
-      applier,
-    });
-
-    expect(result.failedOp).toEqual({ op: failedOp, error });
-    expect(result.failedOpIds).toEqual([failedOp.id, remainingOp.id]);
-
-    const appliedEntry = await store.getOpById(appliedOp.id);
-    const failedEntry = await store.getOpById(failedOp.id);
-    const remainingEntry = await store.getOpById(remainingOp.id);
-    expect(appliedEntry?.applicationStatus).toBe('applied');
-    expect(failedEntry?.applicationStatus).toBe('failed');
-    expect(failedEntry?.retryCount).toBe(1);
-    expect(remainingEntry?.applicationStatus).toBe('failed');
-    expect(remainingEntry?.retryCount).toBe(1);
-    expect((await store.getFailedRemoteOps()).map((entry) => entry.op.id).sort()).toEqual(
-      [failedOp.id, remainingOp.id].sort(),
-    );
-    expect(await store.getVectorClock()).toEqual({ clientA: 2 });
-  });
-
-  it('should clear older full-state ops and reset the vector clock after an applied remote import', async () => {
-    const oldImportOp = createOperation('old-import', {
-      opType: OpType.SyncImport,
-      clientId: 'oldImportClient',
-      vectorClock: { oldImportClient: 1 },
-    });
-    const newImportOp = createOperation('new-import', {
-      opType: OpType.SyncImport,
-      clientId: 'importClient',
-      vectorClock: { importClient: 9, deadClient: 4 },
-    });
-    const postImportOp = createOperation('post-import-op', {
-      clientId: 'importClient',
-      vectorClock: { importClient: 10 },
-    });
-    await store.append(oldImportOp, 'remote');
-    await store.setVectorClock({ staleClient: 5, testClient: 7 });
-
-    const { applier } = createApplier({
-      appliedOps: [newImportOp, postImportOp],
-    });
-
-    const result = await applyRemoteOperations({
-      ops: [newImportOp, postImportOp],
-      store,
-      applier,
-      isFullStateOperation: (op) => op.opType === OpType.SyncImport,
-    });
-
-    expect(result.clearedFullStateOpCount).toBe(1);
-    expect(await store.getOpById(oldImportOp.id)).toBeUndefined();
-    expect((await store.getOpById(newImportOp.id))?.applicationStatus).toBe('applied');
-    expect((await store.getOpById(postImportOp.id))?.applicationStatus).toBe('applied');
-    expect(await store.getVectorClock()).toEqual({
-      importClient: 10,
-      testClient: 7,
-    });
-  });
+defineStorePortContract('sql.js (real SQLite)', async () => {
+  // One shared sql.js database; the store's single adapter reads/writes it.
+  // The store's init() is IDB-shaped — it opens+adopts an IndexedDB connection
+  // and never calls the adapter's own init(), so for a self-managing backend
+  // like SQLite the tables would not exist ("no such table"). Create them once
+  // on the shared db here; this mirrors the store-init change Phase B3 must make
+  // on native (call adapter.init() / skip the IDB open when the backend is
+  // SQLite). CREATE TABLE IF NOT EXISTS is idempotent, so the store's per-call
+  // adapters reuse these tables.
+  const db = await createSqlJsDb();
+  await new SqliteOpLogAdapter(db).init();
+  return [
+    { provide: OP_LOG_DB_ADAPTER_FACTORY, useValue: () => new SqliteOpLogAdapter(db) },
+  ];
 });

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -3,6 +3,15 @@
 
 const path = require('node:path');
 
+// sql.js (WASM SQLite) is served into the Karma run so the SqliteOpLogAdapter
+// can be validated against a REAL SQLite engine, not just the in-memory
+// translation-layer fake (see docs/sync-and-op-log/sqlite-migration.md, B2).
+// It is loaded as a plain global <script> rather than imported, because the
+// universal sql.js build statically references node: builtins that the webpack
+// Karma builder cannot bundle. Dev/test only — never reaches the app bundle.
+const SQL_JS_DIST = path.join(__dirname, '..', 'node_modules', 'sql.js', 'dist');
+const SQL_JS_WASM_ABS = '/absolute' + path.join(SQL_JS_DIST, 'sql-wasm.wasm');
+
 module.exports = function (config) {
   // NOTE: necessary to fix some of the unit tests with a timezone in them
   // NOTE2: won't work for wallaby, but that's maybe ok for now
@@ -25,6 +34,19 @@ module.exports = function (config) {
       require('karma-coverage-istanbul-reporter'),
       require('karma-spec-reporter'),
     ],
+    files: [
+      // Global initSqlJs; the wasm is served (not auto-included) and fetched on demand.
+      { pattern: path.join(SQL_JS_DIST, 'sql-wasm.js'), included: true, watched: false },
+      {
+        pattern: path.join(SQL_JS_DIST, 'sql-wasm.wasm'),
+        included: false,
+        watched: false,
+      },
+    ],
+    proxies: {
+      // initSqlJs({ locateFile: () => '/sql-wasm.wasm' }) resolves here.
+      '/sql-wasm.wasm': SQL_JS_WASM_ABS,
+    },
     client: {
       clearContext: false, // leave Jasmine Spec Runner output visible in browser
       captureConsole: false,


### PR DESCRIPTION
Advances **#7931** (SQLite primary store for native) by landing every piece that can be **built and verified in CI**, and hands off the device-gated remainder with precise design notes. Nothing here changes runtime behavior for existing users — the SQLite path stays dead in production until the native token flip (still gated, not in this PR).

## What's in this PR

### B2 — validate `SqliteOpLogAdapter` against a *real* SQLite engine
The adapter's 23 specs previously ran only against an in-memory regex stand-in (validates the translation layer, not SQLite itself). This adds **sql.js** (devDependency, never in the app bundle) served into Karma, and runs:
- the adapter's behavioral contract against **both** the fake and real SQLite (`sqlite-op-log-adapter.spec.ts`), and
- a **store-level** second pass through `OperationLogStoreService` (`remote-apply-store-port.integration.spec.ts`).

This exercises genuine-engine behavior the stand-in could only model: the real `UNIQUE constraint failed` → `ConstraintError` mapping, `AUTOINCREMENT` never reusing `seq` after `clear()`, compound-index + NULL ranges, and real `BEGIN IMMEDIATE` rollback. **No surprises surfaced** — the translation layer is faithful.

### C1 — verified IDB→SQLite backend migration
`op-log-backend-migration.ts`: a one-time, adapter-agnostic copy of the whole op-log from a source adapter to a dest adapter in a single dest transaction with **verify-before-commit** (op count + last `seq` + vector clock; any mismatch throws and rolls back, leaving dest empty and source untouched). Generic `iterate`→`put` preserves ops `seq` (incl. gaps) and writes singletons at their out-of-line key with no per-store special-casing. Validated real-Chrome-IDB → sql.js, including the rollback path. **Not wired into startup** — B3/C2 decide when to run it.

### B3 (partial) — backend-aware store init
`OperationLogStoreService.init()` / `ArchiveStoreService._init()` were IDB-shaped: they always opened+adopted a WebView IndexedDB connection and never called `adapter.init()`. On a self-managing backend (SQLite) that meant the tables were never created **and** the evictable WebView store was still touched. Now: when the adapter exposes no `adoptConnection`, `init()` calls `adapter.init()` and **skips the IDB open**; the IndexedDB path is unchanged. Surfaced while wiring the B2 store-port pass.

## Test status

- `sqlite-op-log-adapter.spec.ts` — **51** (contract × {fake, sql.js} + fake-only SQL-emission)
- `remote-apply-store-port.integration.spec.ts` — **6** (store flows × {IndexedDB, sql.js})
- `op-log-backend-migration.spec.ts` — **5** (fidelity, AUTOINCREMENT-continues, empty, guard, verify-rollback)
- full `op-log/persistence` regression — **521** green
- two new unit tests cover both init branches (self-managing → `adapter.init`, no IDB open; IDB → open+adopt, no `adapter.init`)

## Honest ceiling — what this does NOT prove

sql.js validates the SQLite **engine**, not the Capacitor **bridge** or the native plugin's specific SQLite build. The durability claim (SQLite survives WebView eviction where IDB doesn't), native perf (bridge round-trips), and the migration on real device data all remain **device-gated**.

## Remaining (device-gated, see `docs/sync-and-op-log/sqlite-migration-followup.md`)

- **B1** — add `@capacitor-community/sqlite` + the native `SqliteDb` wrapper, with the two bridge-perf mitigations baked in (return `lastId` from the plugin's `run`; add a `runBatch`/`executeSet` bulk path with `RETURNING seq`).
- **B3 (token flip)** — override `OP_LOG_DB_ADAPTER_FACTORY` for native behind a flag defaulting off (the init half is done here).
- **C1 wiring + C2** — trigger the migration on first launch, staged rollout, retain the IDB copy ≥ 1 release.
- On-device validation: eviction survival, the engine behaving like sql.js, and the perf benchmark.

Refs #7931. Root cause #7892.
