### PR TITLE
feat(take-a-break): clearer break-reminder action with feedback

### DIFF
--- a/src/app/features/take-a-break/take-a-break.service.spec.ts
+++ b/src/app/features/take-a-break/take-a-break.service.spec.ts
@@ -1,0 +1,92 @@
+import { TestBed } from '@angular/core/testing';
+import { EMPTY, of } from 'rxjs';
+import { TakeABreakService } from './take-a-break.service';
+import { TaskService } from '../tasks/task.service';
+import { GlobalTrackingIntervalService } from '../../core/global-tracking-interval/global-tracking-interval.service';
+import { IdleService } from '../idle/idle.service';
+import { GlobalConfigService } from '../config/global-config.service';
+import { NotifyService } from '../../core/notify/notify.service';
+import { BannerService } from '../../core/banner/banner.service';
+import { ChromeExtensionInterfaceService } from '../../core/chrome-extension-interface/chrome-extension-interface.service';
+import { UiHelperService } from '../ui-helper/ui-helper.service';
+import { SnackService } from '../../core/snack/snack.service';
+import { LOCAL_ACTIONS } from '../../util/local-actions.token';
+import { BannerId } from '../../core/banner/banner.model';
+import { T } from '../../t.const';
+
+describe('TakeABreakService', () => {
+  let service: TakeABreakService;
+  let taskService: jasmine.SpyObj<TaskService>;
+  let snackService: jasmine.SpyObj<SnackService>;
+  let bannerService: jasmine.SpyObj<BannerService>;
+
+  beforeEach(() => {
+    taskService = jasmine.createSpyObj<TaskService>('TaskService', [
+      'pauseCurrent',
+      'currentTaskId',
+    ]);
+    // `currentTaskId$` is read as a property during construction.
+    (taskService as unknown as { currentTaskId$: unknown }).currentTaskId$ = of(null);
+    taskService.currentTaskId.and.returnValue(null);
+
+    snackService = jasmine.createSpyObj<SnackService>('SnackService', ['open']);
+    bannerService = jasmine.createSpyObj<BannerService>('BannerService', [
+      'open',
+      'dismiss',
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        TakeABreakService,
+        { provide: TaskService, useValue: taskService },
+        { provide: SnackService, useValue: snackService },
+        { provide: BannerService, useValue: bannerService },
+        { provide: LOCAL_ACTIONS, useValue: EMPTY },
+        { provide: GlobalTrackingIntervalService, useValue: { tick$: EMPTY } },
+        { provide: IdleService, useValue: { isIdle$: of(false) } },
+        {
+          provide: GlobalConfigService,
+          useValue: {
+            cfg$: of({ takeABreak: { isTakeABreakEnabled: true } }),
+            takeABreak$: of({ isTakeABreakEnabled: true }),
+            idle$: of({ isEnableIdleTimeTracking: false }),
+            sound$: of({ breakReminderSound: null, volume: 0 }),
+          },
+        },
+        { provide: NotifyService, useValue: { notifyDesktop: () => undefined } },
+        { provide: ChromeExtensionInterfaceService, useValue: { isReady$: of(false) } },
+        {
+          provide: UiHelperService,
+          useValue: { focusAppAfterNotification: () => undefined },
+        },
+      ],
+    });
+
+    service = TestBed.inject(TakeABreakService);
+  });
+
+  describe('startBreak()', () => {
+    it('pauses tracking', () => {
+      service.startBreak();
+      expect(taskService.pauseCurrent).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows an encouraging snack so the click clearly does something', () => {
+      service.startBreak();
+
+      expect(snackService.open).toHaveBeenCalledTimes(1);
+      expect(snackService.open).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: 'SUCCESS',
+          msg: T.F.TIME_TRACKING.B.BREAK_SNACK,
+        }),
+      );
+    });
+
+    it('dismisses the reminder banner', () => {
+      service.startBreak();
+      expect(bannerService.dismiss).toHaveBeenCalledTimes(1);
+      expect(bannerService.dismiss).toHaveBeenCalledWith(BannerId.TakeABreak);
+    });
+  });
+});

--- a/src/app/features/take-a-break/take-a-break.service.ts
+++ b/src/app/features/take-a-break/take-a-break.service.ts
@@ -31,6 +31,7 @@ import { ofType } from '@ngrx/effects';
 import { idleDialogResult, triggerResetBreakTimer } from '../idle/store/idle.actions';
 import { playSound } from '../../util/play-sound';
 import { LOCAL_ACTIONS } from '../../util/local-actions.token';
+import { SnackService } from '../../core/snack/snack.service';
 
 const BREAK_TRIGGER_DURATION = 10 * 60 * 1000;
 const PING_UPDATE_BANNER_INTERVAL = 60 * 1000;
@@ -60,6 +61,7 @@ export class TakeABreakService {
   private _bannerService = inject(BannerService);
   private _chromeExtensionInterfaceService = inject(ChromeExtensionInterfaceService);
   private _uiHelperService = inject(UiHelperService);
+  private _snackService = inject(SnackService);
 
   otherNoBreakTIme$ = new Subject<number>();
 
@@ -289,7 +291,9 @@ export class TakeABreakService {
           time: msToString(cfg.takeABreak.takeABreakSnoozeTime),
         },
         action: {
-          label: T.F.FOCUS_MODE.START_BREAK,
+          // Not "Start break": this reminder has no break timer/screen, the
+          // button just pauses tracking — so label it for what it does.
+          label: T.F.TIME_TRACKING.B.PAUSE_AND_BREAK,
           fn: () => this.startBreak(),
         },
         action2: {
@@ -318,7 +322,15 @@ export class TakeABreakService {
   }
 
   startBreak(): void {
+    // This reminder isn't a timed-break feature: it just pauses tracking so the
+    // rest counts as a break, then resets the reminder. Show an encouraging
+    // snack so the click clearly does something instead of nothing.
     this._taskService.pauseCurrent();
+    this._snackService.open({
+      type: 'SUCCESS',
+      ico: 'free_breakfast',
+      msg: T.F.TIME_TRACKING.B.BREAK_SNACK,
+    });
     this.resetTimer();
   }
 

--- a/src/app/t.const.ts
+++ b/src/app/t.const.ts
@@ -2017,6 +2017,8 @@ const T = {
     },
     TIME_TRACKING: {
       B: {
+        BREAK_SNACK: 'F.TIME_TRACKING.B.BREAK_SNACK',
+        PAUSE_AND_BREAK: 'F.TIME_TRACKING.B.PAUSE_AND_BREAK',
         SNOOZE: 'F.TIME_TRACKING.B.SNOOZE',
       },
       B_TTR: {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1967,6 +1967,8 @@
     },
     "TIME_TRACKING": {
       "B": {
+        "BREAK_SNACK": "Enjoy your break!",
+        "PAUSE_AND_BREAK": "Pause & take a break",
         "SNOOZE": "Snooze {{time}}"
       },
       "B_TTR": {


### PR DESCRIPTION
## Problem

The "Take a Break" reminder banner reused the focus-mode label **"Start break"** for its primary action, but outside a focus session that button only calls `pauseCurrent()` + `resetTimer()` — there's no break timer or break screen. So the label over-promised, and clicking it appeared to do nothing.

## Change

- Relabel the banner action to **"Pause & take a break"** (new `T.F.TIME_TRACKING.B.PAUSE_AND_BREAK`) so it describes what it actually does.
- Show an encouraging SUCCESS snack on click (`"Enjoy your break\!"`) so the action gives visible feedback instead of silently closing the banner.

## Why not start a "real" break screen?

An earlier iteration made the button open the focus-mode break screen when a session was running. It was dropped because it didn't hold up across modes:

- **Pomodoro** never triggers this banner mid-session — each cycle's break resets the reminder timer, so it can't reach the threshold.
- **Countdown** has no break concept, and **Flowtime** breaks default to off.
- In the cases the branch *was* reachable (Countdown / long Flowtime), it would force an unwanted 5-min break and **clobber the running session** (overwriting the work timer, dropping back to the start screen afterward).

So the behavior is now mode-agnostic and non-destructive: pause tracking + reset the reminder + encouraging snack.

## Test plan

- New `take-a-break.service.spec.ts`: `startBreak()` pauses tracking, opens the SUCCESS snack, and dismisses the reminder banner (3 tests).
- `npm run test:file` green; `checkFile` clean on all `.ts`; `en.json` Prettier-clean.
- Translations: English-only edit per project rule.
