### PR TITLE
fix(sync): guard convertToMainTask against non-array parentTagIds

### DIFF
--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -113,6 +113,40 @@ const addReplaySafeDoneFields = (
 };
 
 /**
+ * `[Task Shared] convertToMainTask` carries `parentTagIds?: string[]`.
+ * A SuperSync fresh-client replay crashed at `task-shared-crud.reducer.ts`
+ * with `TypeError: r is not iterable` because a captured op's
+ * `parentTagIds` was truthy but not an array — bypassing the reducer's
+ * `parentTagIds ?? parentTask.tagIds` fallback and crashing the spread.
+ *
+ * The producing code path is unknown (current dispatch sites all pass an
+ * array or omit the field); strip the field on the read boundary so a
+ * single bad op cannot poison the bulk-replay loop, and warn with the op
+ * id/clientId so we can chase the producer next time it appears.
+ */
+const stripMalformedConvertToMainTaskParentTagIds = (
+  actionType: string,
+  actionPayload: Record<string, unknown>,
+  op: Operation,
+): Record<string, unknown> => {
+  if (actionType !== ActionType.TASK_SHARED_CONVERT_TO_MAIN) return actionPayload;
+  const ptt = actionPayload['parentTagIds'];
+  if (ptt === undefined || Array.isArray(ptt)) return actionPayload;
+  SyncLog.warn(
+    `[convertOpToAction] convertToMainTask: parentTagIds is not an array — stripping so the reducer falls back to parent.tagIds`,
+    {
+      opId: op.id,
+      clientId: op.clientId,
+      vectorClock: op.vectorClock,
+      parentTagIdsType: ptt === null ? 'null' : typeof ptt,
+    },
+  );
+  const rest = { ...actionPayload };
+  delete rest['parentTagIds'];
+  return rest;
+};
+
+/**
  * Converts an Operation from the operation log back into a PersistentAction.
  * Used during sync replay and recovery to re-dispatch operations.
  *
@@ -136,6 +170,11 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
 
   actionPayload = addLegacyPlanForTodayDate(actionType, actionPayload, op);
   actionPayload = addReplaySafeDoneFields(actionType, actionPayload, op);
+  actionPayload = stripMalformedConvertToMainTaskParentTagIds(
+    actionType,
+    actionPayload,
+    op,
+  );
 
   // Force `payload.id = op.entityId` for non-singleton LWW Update ops. The
   // op's `entityId` is the canonical identifier — producers also enforce

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
@@ -599,6 +599,69 @@ describe('taskSharedCrudMetaReducer', () => {
         testState,
       );
     });
+
+    // Regression: a fresh client bulk-replaying SuperSync ops hit
+    // "TypeError: r is not iterable" inside handleConvertToMainTask when the
+    // captured op carried a malformed parentTagIds. Two shapes can produce
+    // this — both must survive the reducer:
+    //   (a) parentTagIds is missing AND parent.tagIds is missing
+    //       — the original `??` chain handled this but only by accident.
+    //   (b) parentTagIds is truthy but not an array (e.g. carried through
+    //       as a number/object from a producer bug or legacy op payload)
+    //       — `??` does NOT catch this, only Array.isArray does. This is
+    //       the case the user actually hit during SuperSync replay.
+    it('should not throw when parentTagIds is omitted and parent.tagIds is missing', () => {
+      const parentTask = {
+        ...createMockTask({ id: 'parent-task', projectId: 'project1' }),
+        tagIds: undefined as unknown as string[],
+      };
+      const testState: RootState = {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          entities: {
+            ...baseState[TASK_FEATURE_NAME].entities,
+            'parent-task': parentTask,
+          },
+          ids: [...baseState[TASK_FEATURE_NAME].ids, 'parent-task'],
+        },
+      };
+
+      const action = TaskSharedActions.convertToMainTask({
+        task: createMockTask({ id: 'task1', parentId: 'parent-task' }),
+        isPlanForToday: false,
+      });
+
+      expect(() => metaReducer(testState, action)).not.toThrow();
+    });
+
+    it('should not throw when parentTagIds is truthy-but-non-array (legacy/corrupt op)', () => {
+      const parentTask = createMockTask({
+        id: 'parent-task',
+        projectId: 'project1',
+        tagIds: ['tag1'],
+      });
+      const testState: RootState = {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          entities: {
+            ...baseState[TASK_FEATURE_NAME].entities,
+            'parent-task': parentTask,
+          },
+          ids: [...baseState[TASK_FEATURE_NAME].ids, 'parent-task'],
+        },
+      };
+
+      const action = TaskSharedActions.convertToMainTask({
+        task: createMockTask({ id: 'task1', parentId: 'parent-task' }),
+        // Truthy non-array bypasses `??` — only Array.isArray catches it.
+        parentTagIds: 0 as unknown as string[],
+        isPlanForToday: false,
+      });
+
+      expect(() => metaReducer(testState, action)).not.toThrow();
+    });
   });
 
   describe('convertToSubTask action', () => {

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -177,7 +177,14 @@ const handleConvertToMainTask = (
   }
 
   const todayStr = state[appStateFeatureKey]?.todayStr ?? getDbDateStr();
-  const resolvedParentTagIds = parentTagIds ?? parentTask.tagIds;
+  // `Array.isArray` guard (not `??`): a truthy non-array `parentTagIds`
+  // from a captured op (seen on long-running SuperSync clients) bypasses
+  // `??` and crashes the spread below. Same for `parentTask.tagIds`.
+  const resolvedParentTagIds = Array.isArray(parentTagIds)
+    ? parentTagIds
+    : Array.isArray(parentTask.tagIds)
+      ? parentTask.tagIds
+      : [];
   const positionConvertedTask = (taskIds: string[]): string[] => {
     // Dropped at the start of DONE → append to the bottom of the done list.
     if (afterTaskId == null && isDone) {
@@ -201,7 +208,9 @@ const handleConvertToMainTask = (
         parentId: undefined,
         // Filter out TODAY_TAG.id - it's a virtual tag where membership is
         // determined by task.dueDay, not by being in tagIds
-        tagIds: parentTask.tagIds.filter((id) => id !== TODAY_TAG.id),
+        tagIds: (Array.isArray(parentTask.tagIds) ? parentTask.tagIds : []).filter(
+          (id) => id !== TODAY_TAG.id,
+        ),
         modified: Date.now(),
         ...(isPlanForToday && !task.dueWithTime
           ? {


### PR DESCRIPTION
## Summary

A SuperSync fresh-client bulk-replay crashed with `TypeError: r is not iterable` inside `handleConvertToMainTask`. The crashing value was the captured op's `parentTagIds` — truthy but non-iterable, which bypassed the reducer's `parentTagIds ?? parentTask.tagIds` fallback (`??` only catches `null`/`undefined`) and blew up the spread.

- **Reducer**: replace `??` with `Array.isArray` on both `parentTagIds` and `parentTask.tagIds` so any non-array shape falls back cleanly.
- **`convertOpToAction`**: when a `[Task Shared] convertToMainTask` op carries a non-array `parentTagIds`, strip the field on the read boundary so a single malformed op cannot poison the bulk-replay loop. Warn with `opId` / `clientId` / `vectorClock` / `typeof` so the historical producer can be identified next time it fires.
- **Spec**: covers both the missing-tagIds path and the truthy-non-array path (the original `??` chain only handled the former).

Current dispatch sites all pass arrays or omit the field; the producer is presumed to be a past code version whose ops still live in a long-running user's server-side op-log. The warn telemetry is the mechanism to identify the producer when it next fires.

## Test plan

- [x] `npm run checkFile` on all three modified files
- [ ] `npm run test:file src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts` — confirm both new specs pass
- [ ] Manual: SuperSync from long-running client → fresh client, confirm bulk replay completes
- [ ] Manual: confirm \`[convertOpToAction] convertToMainTask: parentTagIds is not an array — stripping\` warn fires when the malformed op is encountered