### PR TITLE
fix(sync): prevent never-synced clients from wiping server state

### DIFF
--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -1602,6 +1602,51 @@ describe('OperationLogSyncService', () => {
         isCleanSlate: true,
       });
     });
+
+    it('should refuse to force-upload from a never-synced client with no meaningful data', async () => {
+      // Defense-in-depth: a never-synced client (lastServerSeq === 0) whose store holds
+      // only defaults/example data must not replace the entire server with empty state.
+      stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
+        task: { ids: [] },
+        project: { ids: [INBOX_PROJECT.id] },
+        tag: { ids: [TODAY_TAG.id] },
+        note: { ids: [] },
+      } as any);
+
+      const mockProvider = {
+        supportsOperationSync: true,
+        getLastServerSeq: jasmine.createSpy('getLastServerSeq').and.resolveTo(0),
+        setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+      } as any;
+
+      await expectAsync(
+        service.forceUploadLocalState(mockProvider),
+      ).toBeRejectedWithError(/never-synced|empty local state/i);
+      expect(serverMigrationServiceSpy.handleServerMigration).not.toHaveBeenCalled();
+    });
+
+    it('should allow force-upload from a never-synced client that has meaningful data', async () => {
+      // Genuine first-sync upload (e.g. legacy migration / real offline work) is allowed.
+      stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
+        task: { ids: ['real-task-1'] },
+        project: { ids: [INBOX_PROJECT.id] },
+        tag: { ids: [TODAY_TAG.id] },
+        note: { ids: [] },
+      } as any);
+
+      const mockProvider = {
+        supportsOperationSync: true,
+        getLastServerSeq: jasmine.createSpy('getLastServerSeq').and.resolveTo(0),
+        setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+      } as any;
+
+      await service.forceUploadLocalState(mockProvider);
+
+      expect(serverMigrationServiceSpy.handleServerMigration).toHaveBeenCalledWith(
+        mockProvider,
+        { skipServerEmptyCheck: true, syncImportReason: 'FORCE_UPLOAD' },
+      );
+    });
   });
 
   describe('forceDownloadRemoteState', () => {
@@ -2432,6 +2477,9 @@ describe('OperationLogSyncService', () => {
 
       const mockProvider = {
         supportsOperationSync: true,
+        // Established client (has synced before) — pending ops are real user work,
+        // so the conflict dialog must be shown.
+        getLastServerSeq: jasmine.createSpy('getLastServerSeq').and.resolveTo(7),
         setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
       } as any;
 
@@ -2446,6 +2494,60 @@ describe('OperationLogSyncService', () => {
       expect(remoteOpsProcessingServiceSpy.processRemoteOps).not.toHaveBeenCalled();
       expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
       expect(result.kind).toBe('cancelled');
+    });
+
+    it('should auto-accept remote (no dialog) for a never-synced client with bootstrap ops', async () => {
+      const incomingSyncImport = createIncomingSyncImport();
+
+      downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+        newOps: [incomingSyncImport],
+        success: true,
+        providerMode: 'superSyncOps',
+        failedFileCount: 0,
+        latestServerSeq: 42,
+      });
+
+      // Brand-new client: its only pending op is an auto-generated example/onboarding
+      // task created before the first sync landed (ExampleTasksService). This makes
+      // hasMeaningfulPendingOps misfire, but the client has never downloaded anything.
+      opLogStoreSpy.getUnsynced.and.resolveTo([
+        {
+          seq: 1,
+          op: {
+            id: 'example-task-1',
+            clientId: 'client-A',
+            actionType: 'test' as ActionType,
+            opType: OpType.Create,
+            entityType: 'TASK',
+            entityId: 'task-1',
+            payload: { title: 'Set Up Sync' },
+            vectorClock: { clientA: 1 },
+            timestamp: Date.now(),
+            schemaVersion: 1,
+          },
+          appliedAt: Date.now(),
+          source: 'local',
+        },
+      ]);
+
+      const forceDownloadSpy = spyOn(service, 'forceDownloadRemoteState').and.resolveTo();
+
+      const mockProvider = {
+        supportsOperationSync: true,
+        // Never synced from this remote.
+        getLastServerSeq: jasmine.createSpy('getLastServerSeq').and.resolveTo(0),
+        setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+      } as any;
+
+      const result = await service.downloadRemoteOps(mockProvider);
+
+      // No conflict dialog, no force-upload — just take remote.
+      expect(
+        syncImportConflictDialogServiceSpy.showConflictDialog,
+      ).not.toHaveBeenCalled();
+      expect(forceDownloadSpy).toHaveBeenCalledWith(mockProvider);
+      expect(remoteOpsProcessingServiceSpy.processRemoteOps).not.toHaveBeenCalled();
+      expect(result.kind).toBe('no_new_ops');
     });
 
     it('should flush pending writes before checking incoming SYNC_IMPORT conflicts', async () => {

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -224,6 +224,28 @@ export class OperationLogSyncService {
         // to silent acceptance via this gate — the data is identical, only the
         // encryption changed.)
         if (dialogData) {
+          // Mirror the download gate: a never-synced client (lastServerSeq === 0)
+          // has only auto-generated bootstrap ops to "defend", so auto-accept remote
+          // instead of prompting or risking a server-wiping USE_LOCAL. See the
+          // download path for the full rationale.
+          if (await this._hasNeverSyncedFromRemote(syncProvider)) {
+            OpLog.warn(
+              `OperationLogSyncService: Piggybacked ${fullStateOp.opType} from client ` +
+                `${fullStateOp.clientId} on a never-synced client with ${pendingOps.length} ` +
+                `bootstrap op(s). Auto-accepting remote (no conflict dialog).`,
+            );
+            await this.forceDownloadRemoteState(syncProvider);
+            return {
+              kind: 'completed',
+              uploadedCount: result.uploadedCount,
+              piggybackedOpsCount: result.piggybackedOps.length,
+              localWinOpsCreated: 0,
+              permanentRejectionCount: 0,
+              hasMorePiggyback: false,
+              rejectedOps: [],
+            };
+          }
+
           OpLog.warn(
             `OperationLogSyncService: Piggybacked ${fullStateOp.opType} from client ${fullStateOp.clientId} ` +
               `with ${pendingOps.length} pending local ops. Showing conflict dialog.`,
@@ -661,6 +683,28 @@ export class OperationLogSyncService {
       // to silent acceptance via this gate — the data is identical, only the
       // encryption changed.)
       if (dialogData) {
+        // A client that has never completed a download from this remote
+        // (lastServerSeq === 0) cannot have meaningful divergent work to defend
+        // against an incoming full-state op. Its only "pending" ops are
+        // auto-generated bootstrap ops (e.g. default/onboarding tasks,
+        // addAllDueToday, default config writes) created before the first sync
+        // landed. Those ops make checkIncomingFullStateConflict misfire and would
+        // otherwise (a) show a confusing conflict dialog on a brand-new install and
+        // (b) offer a USE_LOCAL escape that force-uploads near-empty bootstrap state
+        // as a clean-slate SYNC_IMPORT, wiping the rest of the fleet's history.
+        // Auto-accept remote instead. (Genuine pre-op-log/offline data is handled
+        // earlier via the isWhollyFreshClient checks and never reaches this gate;
+        // and a normal populated server has no full-state op here at all.)
+        if (await this._hasNeverSyncedFromRemote(syncProvider)) {
+          OpLog.warn(
+            `OperationLogSyncService: Incoming ${fullStateOp.opType} from client ` +
+              `${fullStateOp.clientId} on a never-synced client with ${pendingOps.length} ` +
+              `bootstrap op(s). Auto-accepting remote (no conflict dialog).`,
+          );
+          await this.forceDownloadRemoteState(syncProvider);
+          return { kind: 'no_new_ops' };
+        }
+
         OpLog.warn(
           `OperationLogSyncService: Incoming ${fullStateOp.opType} from client ${fullStateOp.clientId} ` +
             `with ${pendingOps.length} pending local ops. Showing conflict dialog.`,
@@ -767,6 +811,26 @@ export class OperationLogSyncService {
   }
 
   /**
+   * True when this client has never completed a download from the remote
+   * (lastServerSeq === 0). Such a client cannot have meaningful divergent work to
+   * defend against an incoming full-state op — its only local ops are auto-generated
+   * bootstrap ops (example/onboarding tasks, default config writes) created before the
+   * first sync landed.
+   *
+   * Providers always implement getLastServerSeq(); if a provider omits it we
+   * conservatively treat the client as already-synced, so we never auto-discard local
+   * state or skip the conflict dialog based on a missing signal.
+   */
+  private async _hasNeverSyncedFromRemote(
+    syncProvider: OperationSyncCapable,
+  ): Promise<boolean> {
+    if (typeof syncProvider.getLastServerSeq !== 'function') {
+      return false;
+    }
+    return (await syncProvider.getLastServerSeq()) === 0;
+  }
+
+  /**
    * Shows the SYNC_IMPORT conflict dialog and executes the user's chosen action.
    *
    * This consolidates the repeated dialog + switch pattern used when a SYNC_IMPORT
@@ -803,6 +867,23 @@ export class OperationLogSyncService {
    * @param syncProvider - The sync provider to upload to
    */
   async forceUploadLocalState(syncProvider: OperationSyncCapable): Promise<void> {
+    // SAFETY (defense-in-depth): never let a client that has never downloaded from
+    // this remote (lastServerSeq === 0) AND has no meaningful local data force-upload
+    // its state. Doing so would replace the entire server with near-empty
+    // bootstrap/default state via a clean-slate SYNC_IMPORT and invalidate every other
+    // device's history. Genuine first-sync uploads of real local data have meaningful
+    // store data and are unaffected; the incoming-SYNC_IMPORT gate already auto-accepts
+    // remote for never-synced clients, so this should never trigger in practice.
+    const hasNeverSynced = await this._hasNeverSyncedFromRemote(syncProvider);
+    if (hasNeverSynced && !this.syncLocalStateService.hasMeaningfulStoreData()) {
+      OpLog.warn(
+        'OperationLogSyncService: Refusing forceUploadLocalState - never-synced client ' +
+          'with no meaningful local data would overwrite remote with empty state.',
+      );
+      throw new Error(
+        'Cannot force-upload empty local state before the first sync has downloaded remote data.',
+      );
+    }
     await this.syncImportConflictCoordinator.forceUploadLocalState(syncProvider);
   }
 


### PR DESCRIPTION
## Problem

A never-synced client (one that has never completed a download from the remote, indicated by `lastServerSeq === 0`) could accidentally wipe the entire server state by force-uploading its near-empty bootstrap data as a clean-slate `SYNC_IMPORT`. This could happen in two scenarios:

1. When a user manually triggers `forceUploadLocalState()` on a brand-new client with only auto-generated example/onboarding tasks
2. When a never-synced client receives an incoming full-state operation and the conflict dialog offers a "use local" escape hatch

Additionally, the conflict dialog would confusingly appear on brand-new installs when receiving a full-state operation, even though the client has no meaningful divergent work to defend.

## Solution

Implemented defense-in-depth checks to prevent never-synced clients from overwriting remote state:

1. **`forceUploadLocalState()` safety gate:** Added a check that refuses to force-upload if the client has never synced (`lastServerSeq === 0`) AND has no meaningful local data. This prevents accidental server wipes while still allowing genuine first-sync uploads of real user data.

2. **Incoming full-state operation auto-accept:** When a never-synced client receives an incoming full-state operation, it now auto-accepts the remote state instead of showing a conflict dialog. This is safe because:
   - The client's only pending ops are auto-generated bootstrap ops (example tasks, default config writes) created before the first sync
   - The incoming operation represents the authoritative server state
   - Genuine pre-op-log/offline data is handled earlier via `isWhollyFreshClient` checks

3. **Piggybacked full-state operation auto-accept:** Applied the same logic to piggybacked full-state operations received during upload operations.

4. **Helper method:** Added `_hasNeverSyncedFromRemote()` to safely check if a client has never synced, with conservative fallback (treats missing `getLastServerSeq` as already-synced).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I have included relevant changes to the documentation/wiki
- [x] I have run `npm run checkFile` on changed `.ts` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format

## Test Coverage

Added three new test cases:

1. `should refuse to force-upload from a never-synced client with no meaningful data` — Verifies the safety gate rejects empty uploads
2. `should allow force-upload from a never-synced client that has meaningful data` — Verifies genuine first-sync uploads still work
3. `should auto-accept remote (no dialog) for a never-synced client with bootstrap ops` — Verifies incoming full-state operations skip the conflict dialog on never-synced clients

All existing tests pass; the changes are backward-compatible with established clients (those with `lastServerSeq > 0`).

https://claude.ai/code/session_01CoSKihfWHFN2c1B3Twfa5m