### PR TITLE
fix(android): guide users to clear WebView storage on init failure

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/WebViewBlockActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/WebViewBlockActivity.kt
@@ -89,15 +89,16 @@ class WebViewBlockActivity : AppCompatActivity() {
         }
 
         val updateButton = findViewById<Button>(R.id.webview_block_update)
-        if (config.action == WebViewCompatibilityChecker.BlockScreenAction.OPEN_WEBVIEW_SETTINGS_WITH_WARNING) {
-            updateButton.setText(R.string.webview_block_open_settings)
-            // This branch is only reached for init failures, where Retry is the
-            // primary recovery, so render the settings action as secondary to
-            // keep a single clear primary action.
+        if (config.action == WebViewCompatibilityChecker.BlockScreenAction.OPEN_WEBVIEW_APP_INFO_WITH_WARNING) {
+            // For init failures, send the user to WebView's App Info page, where
+            // Storage → Clear storage resets a corrupted provider data dir — the
+            // fix that actually resolves these failures (the provider picker does
+            // not). Retry remains the primary recovery, so keep this secondary.
+            updateButton.setText(R.string.webview_block_open_app_settings)
             updateButton.backgroundTintList =
                 ColorStateList.valueOf(ContextCompat.getColor(this, R.color.webview_block_secondary))
             updateButton.setOnClickListener {
-                showOpenWebViewConfirmation(provider, useUpdatePage = false)
+                showOpenWebViewAppInfoConfirmation(provider)
             }
         } else {
             if (!providerPackageIsCurrent) {
@@ -136,6 +137,19 @@ class WebViewBlockActivity : AppCompatActivity() {
                 } else {
                     WebViewCompatibilityChecker.openWebViewSettingsPage(this, provider)
                 }
+            }
+            .setNegativeButton(R.string.webview_override_warning_cancel, null)
+            .setCancelable(true)
+            .show()
+        dialog.window?.decorView?.filterTouchesWhenObscured = true
+    }
+
+    private fun showOpenWebViewAppInfoConfirmation(provider: String?) {
+        val dialog = AlertDialog.Builder(this)
+            .setTitle(R.string.webview_clear_storage_warning_title)
+            .setMessage(R.string.webview_clear_storage_warning_message)
+            .setPositiveButton(R.string.webview_manage_warning_continue) { _, _ ->
+                WebViewCompatibilityChecker.openWebViewAppInfoPage(this, provider)
             }
             .setNegativeButton(R.string.webview_override_warning_cancel, null)
             .setCancelable(true)

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/WebViewCompatibilityChecker.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/WebViewCompatibilityChecker.kt
@@ -72,7 +72,7 @@ object WebViewCompatibilityChecker {
 
     enum class BlockScreenAction {
         UPDATE_WEBVIEW,
-        OPEN_WEBVIEW_SETTINGS_WITH_WARNING,
+        OPEN_WEBVIEW_APP_INFO_WITH_WARNING,
     }
 
     data class BlockScreenConfig(
@@ -276,7 +276,7 @@ object WebViewCompatibilityChecker {
                 R.string.webview_init_failure_details_without_provider
             },
             action = if (isInitFailure) {
-                BlockScreenAction.OPEN_WEBVIEW_SETTINGS_WITH_WARNING
+                BlockScreenAction.OPEN_WEBVIEW_APP_INFO_WITH_WARNING
             } else {
                 BlockScreenAction.UPDATE_WEBVIEW
             },
@@ -468,6 +468,32 @@ object WebViewCompatibilityChecker {
         openWebViewUpdatePage(context, providerPackage)
     }
 
+    /**
+     * Opens the WebView provider's App Info page, from which the user can reach
+     * Storage → Clear storage. Clearing WebView's storage resets a corrupted
+     * provider data dir / variations seed — the most common cause of an init
+     * failure on a device whose WebView version is otherwise current (the version
+     * picker and Play Store that [openWebViewSettingsPage] targets do not fix
+     * this). Defaults to the standard system WebView package when the active
+     * provider could not be resolved (the norm for an init failure, where
+     * getCurrentWebViewPackage() threw).
+     */
+    fun openWebViewAppInfoPage(context: Context, providerPackage: String?) {
+        val pkg = providerPackageOrDefault(providerPackage)
+        if (startActivitySafely(context, webViewProviderDetailsIntent(pkg))) {
+            return
+        }
+
+        // App Info unavailable (rare): fall back to the provider picker, then the
+        // Play Store listing, so the button always lands somewhere actionable.
+        if (startActivitySafely(context, webViewSettingsIntent())) {
+            return
+        }
+
+        Log.w(TAG, "No activity available to open WebView app info; falling back to Play Store")
+        openWebViewUpdatePage(context, pkg)
+    }
+
     @VisibleForTesting
     internal fun webViewSettingsIntent(): Intent =
         Intent(Settings.ACTION_WEBVIEW_SETTINGS)
@@ -491,10 +517,12 @@ object WebViewCompatibilityChecker {
         "package:$providerPackage"
 
     @VisibleForTesting
-    internal fun webViewUpdatePageUrl(providerPackage: String? = null): String {
-        val packageName = providerPackage?.takeIf { it.isNotBlank() } ?: DEFAULT_WEBVIEW_PACKAGE
-        return "https://play.google.com/store/apps/details?id=$packageName"
-    }
+    internal fun webViewUpdatePageUrl(providerPackage: String? = null): String =
+        "https://play.google.com/store/apps/details?id=${providerPackageOrDefault(providerPackage)}"
+
+    @VisibleForTesting
+    internal fun providerPackageOrDefault(providerPackage: String?): String =
+        providerPackage?.takeIf { it.isNotBlank() } ?: DEFAULT_WEBVIEW_PACKAGE
 
     private fun startActivitySafely(context: Context, intent: Intent): Boolean {
         return try {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,8 +3,8 @@
   <string name="title_activity_fullscreen">Super Prod</string>
   <string name="webview_block_message">Please update Android System WebView to version %1$d or newer.</string>
   <string name="webview_init_failure_message">Super Productivity could not start Android System WebView.</string>
-  <string name="webview_init_failure_details_with_provider">This is not an outdated WebView version. Android reports WebView provider details, but the provider fails during startup. Try updating Android System WebView or switching away from a beta provider in Android WebView settings. Avoid removing WebView updates unless you have exported or backed up your Super Productivity data; sync may not include local unsynced changes.</string>
-  <string name="webview_init_failure_details_without_provider">This is not an outdated WebView version warning. Android could not start WebView before provider details were available. Try updating Android System WebView or switching away from a beta provider in Android WebView settings. Avoid removing WebView updates unless you have exported or backed up your Super Productivity data; sync may not include local unsynced changes.</string>
+  <string name="webview_init_failure_details_with_provider">This is not an outdated WebView version. Android reports WebView provider details, but the provider fails to start. This is most often fixed by resetting WebView: open Android System WebView\'s app settings below, then tap Storage → Clear storage and reopen Super Productivity. Updating Android System WebView or switching away from a beta provider can also help. Clearing WebView storage does not delete your Super Productivity tasks, but exporting a backup first is a sensible precaution.</string>
+  <string name="webview_init_failure_details_without_provider">This is not an outdated WebView version warning. Android could not start WebView before provider details were available. This is most often fixed by resetting WebView: open Android System WebView\'s app settings below, then tap Storage → Clear storage and reopen Super Productivity. Updating Android System WebView or switching away from a beta provider can also help. Clearing WebView storage does not delete your Super Productivity tasks, but exporting a backup first is a sensible precaution.</string>
   <string name="webview_block_detected_major">Detected Chromium major version: %1$d</string>
   <string name="webview_block_detected_full">Detected WebView version: %1$s</string>
   <string name="webview_block_provider">Provider package: %1$s</string>
@@ -12,11 +12,14 @@
   <string name="webview_block_update">Update WebView</string>
   <string name="webview_block_retry">Retry</string>
   <string name="webview_block_open_settings">Open WebView settings</string>
+  <string name="webview_block_open_app_settings">Open WebView app settings</string>
   <string name="webview_block_close">Close app</string>
   <string name="webview_block_try_anyway">Try anyway (not recommended)</string>
   <string name="webview_manage_warning_title">Manage Android WebView?</string>
   <string name="webview_manage_warning_message">Android may show options such as removing WebView updates. Removing updates can clear WebView storage on some devices. Continue only if you have exported or backed up your Super Productivity data; synced data may still require reconnecting accounts and local unsynced changes may be lost.</string>
   <string name="webview_manage_warning_continue">Continue</string>
+  <string name="webview_clear_storage_warning_title">Reset Android System WebView</string>
+  <string name="webview_clear_storage_warning_message">This opens Android System WebView\'s app settings. There, tap Storage → Clear storage, then reopen Super Productivity.\n\nYour Super Productivity tasks are stored separately and will not be deleted, but export a backup first if you can.</string>
   <string name="webview_override_warning_title">Continue at your own risk</string>
   <string name="webview_override_warning_message">Your Android System WebView appears to be older than version %1$d.\n\nIf the version reported above is correct, continuing may cause:\n• The app to crash or fail to load\n• Data to render incorrectly or not at all\n• Sync errors and possible data loss\n\nVersion detection is occasionally wrong on certain devices. If you are sure your WebView is up to date, you can continue — but please update Android System WebView from the Play Store first whenever possible.</string>
   <string name="webview_override_warning_continue">I understand the risk, continue</string>

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/WebViewCompatibilityCheckerTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/WebViewCompatibilityCheckerTest.kt
@@ -233,7 +233,7 @@ class WebViewCompatibilityCheckerTest {
     }
 
     @Test
-    fun `blockScreenConfig uses init-failure copy and gated settings action when provider details exist`() {
+    fun `blockScreenConfig uses init-failure copy and gated app-info action when provider details exist`() {
         val config = WebViewCompatibilityChecker.blockScreenConfig(
             source = VersionSource.INIT_FAILURE,
             hasProviderDetails = true,
@@ -241,7 +241,7 @@ class WebViewCompatibilityCheckerTest {
 
         assertEquals(R.string.webview_init_failure_message, config.titleResId)
         assertEquals(R.string.webview_init_failure_details_with_provider, config.detailsIntroResId)
-        assertEquals(BlockScreenAction.OPEN_WEBVIEW_SETTINGS_WITH_WARNING, config.action)
+        assertEquals(BlockScreenAction.OPEN_WEBVIEW_APP_INFO_WITH_WARNING, config.action)
         assertFalse(config.showTryAnyway)
         assertTrue(config.showSource)
         assertTrue(config.showRetry)
@@ -301,6 +301,24 @@ class WebViewCompatibilityCheckerTest {
         assertEquals(
             "package:com.android.chrome",
             WebViewCompatibilityChecker.webViewProviderDetailsUri("com.android.chrome"),
+        )
+    }
+
+    @Test
+    fun `providerPackageOrDefault keeps a resolved provider but falls back when blank`() {
+        assertEquals(
+            "com.android.chrome",
+            WebViewCompatibilityChecker.providerPackageOrDefault("com.android.chrome"),
+        )
+        // Init failures usually have no resolvable provider, so App Info must still
+        // target the standard system WebView package rather than "package:null".
+        assertEquals(
+            "com.google.android.webview",
+            WebViewCompatibilityChecker.providerPackageOrDefault(null),
+        )
+        assertEquals(
+            "com.google.android.webview",
+            WebViewCompatibilityChecker.providerPackageOrDefault("  "),
         )
     }
 


### PR DESCRIPTION
## Background

From a user report: on a Pixel 10 Pro Fold, Super Productivity showed the Android WebView **init-failure** screen, while the **same WebView version** worked fine on a Pixel 10 Pro XL. Updating WebView / opening other browsers didn't help. The fix that worked was **Settings → Apps → Android System WebView → Storage → Clear storage**.

That points at corrupted data inside the WebView *provider app itself* (e.g. its cached variations seed) — not a too-old version and not a bug in our detection. The provider's data belongs to another app, so SP **cannot** clear it programmatically. The actionable gap is that our error screen pointed users at the wrong remedy ("update WebView" / the provider picker), neither of which resolves this.

## What changed

- **Detail copy** on the INIT_FAILURE screen now leads with *resetting* WebView via **Storage → Clear storage**, and reassures that Super Productivity tasks are stored separately and are safe (verified: SP's store lives in SP's own data dir, not the WebView provider's storage).
- **The action button** now deep-links to the WebView provider's **App Info** page (`openWebViewAppInfoPage`) — where "Clear storage" lives — instead of the provider/implementation picker. Defaults to the standard system WebView package when the provider can't be resolved (the norm on init failure); falls back to the picker, then the Play Store.
- Renamed the action enum `OPEN_WEBVIEW_SETTINGS_WITH_WARNING` → `OPEN_WEBVIEW_APP_INFO_WITH_WARNING` to match the new behavior.
- Extracted `providerPackageOrDefault` (reused by `webViewUpdatePageUrl`) + unit test.

## Deliberately unchanged

- **"Try anyway" stays hidden** for init failures — it only bypasses a *version* block; when WebView physically can't instantiate there's nothing to bypass.
- **No automatic self-heal** — clearing SP's *own* WebView data can't touch the provider's corrupted data, so it wouldn't help.

These are native Android strings (rendered before the Angular/WebView i18n loads), so the "edit only en.json" rule doesn't apply.

## Testing

- New unit test for `providerPackageOrDefault` (resolved / null / blank → default).
- ⚠️ Android unit tests (`:app:testPlayDebugUnitTest`) were **not** run in CI for this branch yet — please confirm green locally.