### PR TITLE
fix(calendar): hide archived calendar task events from the schedule

### DIFF
--- a/e2e/tests/calendar/archived-calendar-task-no-regen.spec.ts
+++ b/e2e/tests/calendar/archived-calendar-task-no-regen.spec.ts
@@ -25,6 +25,8 @@ const CONTROL_TITLE = 'E2E-7971 Control Tomorrow';
 
 const PANEL_BTN = '.e2e-toggle-issue-provider-panel';
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
 const icalDate = (d: Date): string =>
   `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(
     d.getDate(),
@@ -35,7 +37,7 @@ const icalDate = (d: Date): string =>
 const buildIcal = (): string => {
   const now = new Date();
   const today = icalDate(now);
-  const tomorrow = icalDate(new Date(now.getTime() + 24 * 60 * 60 * 1000));
+  const tomorrow = icalDate(new Date(now.getTime() + ONE_DAY_MS));
   return [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',

--- a/e2e/tests/calendar/archived-calendar-task-no-regen.spec.ts
+++ b/e2e/tests/calendar/archived-calendar-task-no-regen.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Live repro for https://github.com/super-productivity/super-productivity/issues/7971
+ *
+ * A calendar event auto-imported as a task, completed and archived via "Finish Day",
+ * must NOT re-surface in the Schedule the next time calendar events are rendered.
+ *
+ * The iCal feed is stubbed via page.route so the test is hermetic. We rely on
+ * `isAutoImportForCurrentDay` to turn the event into a task without driving the
+ * (fragile) schedule context-menu.
+ *
+ * With the bug present, the archived calendar task drops out of
+ * `selectAllCalendarTaskEventIds` and the event reappears in the Schedule as a
+ * "not yet added" entry → this test's final assertion fails. With the fix, the
+ * Schedule filter also consults the archive, so the event stays hidden.
+ */
+
+const ICAL_URL = 'https://example.com/sp-7971.ics';
+const EVENT_TITLE = 'E2E-7971 Dentist Appointment';
+// A control event TOMORROW that is never imported/archived. It always renders as a
+// calendar chip, so we can wait for it (a positive signal that the calendar finished
+// rendering) before asserting the archived event is absent — no flaky fixed timeouts.
+const CONTROL_TITLE = 'E2E-7971 Control Tomorrow';
+
+const PANEL_BTN = '.e2e-toggle-issue-provider-panel';
+
+const icalDate = (d: Date): string =>
+  `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(
+    d.getDate(),
+  ).padStart(2, '0')}`;
+
+// iCal feed with (1) a TODAY event that auto-import turns into a task, and (2) a
+// TOMORROW control event that is never imported (auto-import is today-only).
+const buildIcal = (): string => {
+  const now = new Date();
+  const today = icalDate(now);
+  const tomorrow = icalDate(new Date(now.getTime() + 24 * 60 * 60 * 1000));
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//SP E2E//EN',
+    'BEGIN:VEVENT',
+    `DTSTART:${today}T120000Z`,
+    `DTEND:${today}T130000Z`,
+    `SUMMARY:${EVENT_TITLE}`,
+    'UID:e2e-7971-event',
+    'END:VEVENT',
+    'BEGIN:VEVENT',
+    `DTSTART:${tomorrow}T120000Z`,
+    `DTEND:${tomorrow}T130000Z`,
+    `SUMMARY:${CONTROL_TITLE}`,
+    'UID:e2e-7971-control',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+};
+
+test.describe('Calendar #7971', () => {
+  test('archived calendar task does not regenerate in the schedule', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    // Stub the iCal feed for every request to the provider URL.
+    await page.route(ICAL_URL, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/calendar',
+        body: buildIcal(),
+      }),
+    );
+
+    await workViewPage.waitForTaskList();
+
+    // --- Configure a calendar provider with auto-import enabled ---
+    await page.waitForSelector(PANEL_BTN, { state: 'visible' });
+    await page.click(PANEL_BTN);
+    await page.waitForSelector('mat-tab-group', { state: 'visible' });
+    await page.click('mat-tab-group .mat-mdc-tab:last-child');
+    await page.waitForSelector('issue-provider-setup-overview', { state: 'visible' });
+
+    // Open the generic iCal setup dialog ("Other (iCal)" → plain icalUrl, no OAuth).
+    await page.getByRole('button', { name: 'Other (iCal)' }).click();
+    const dialog = page.locator('mat-dialog-container');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // formly renders inputs with id="formly_<n>_input_<key>_<n>", not formcontrolname.
+    await dialog.locator('input[id*="icalUrl"]').fill(ICAL_URL);
+    // "Auto import events as tasks for current day" is a checkbox.
+    await dialog.getByRole('checkbox', { name: /auto import events as tasks/i }).check();
+
+    await dialog.locator('button[type="submit"]').click();
+    await expect(dialog).toBeHidden({ timeout: 5000 });
+
+    // Close the issue-provider panel so it doesn't overlay the task list.
+    await page.keyboard.press('Escape');
+
+    // --- The event should auto-import as a task ---
+    const importedTask = taskPage.getTaskByText(EVENT_TITLE);
+    await expect(importedTask).toBeVisible({ timeout: 15000 });
+
+    // --- Complete it and finish the day to archive it ---
+    await taskPage.markTaskAsDone(importedTask);
+
+    await page.locator('.e2e-finish-day').click();
+    await page.waitForSelector('daily-summary', { state: 'visible', timeout: 10000 });
+    await page
+      .locator('daily-summary button[mat-flat-button][color="primary"]:last-of-type')
+      .click();
+
+    // Simulate "the next day": importing an event skips it for the rest of the current
+    // day (addTaskFromIssue → skipCalendarEvent), which is why the bug only appears the
+    // NEXT day. Clear the per-day skip and reload so the event is eligible to show again.
+    await page.evaluate(() => {
+      localStorage.removeItem('SUP_CALENDER_EVENTS_SKIPPED_TODAY');
+      localStorage.removeItem('SUP_CALENDER_EVENTS_LAST_SKIP_DAY');
+    });
+    await page.reload();
+    await workViewPage.waitForTaskList();
+
+    // The archived calendar event must NOT reappear in the Schedule…
+    await page.goto(page.url().replace(/#.*$/, '') + '#/schedule');
+    await page.waitForSelector('schedule', { state: 'visible', timeout: 10000 });
+    // Anchor: the un-archived control event must render → calendar has finished loading.
+    await expect(page.getByText(CONTROL_TITLE).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(EVENT_TITLE)).toHaveCount(0);
+
+    // …nor in the Planner. (Without the fix it re-surfaces as an un-added calendar entry.)
+    await page.goto(page.url().replace(/#.*$/, '') + '#/planner');
+    await expect(page.getByText(CONTROL_TITLE).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(EVENT_TITLE)).toHaveCount(0);
+  });
+});

--- a/src/app/features/calendar-integration/calendar-integration.service.spec.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.spec.ts
@@ -38,6 +38,7 @@ import { loadIcalModule } from '../schedule/ical/ical-lazy-loader';
 import { CalendarIntegrationEvent } from './calendar-integration.model';
 import { HiddenCalendarEventsService } from './hidden-calendar-events.service';
 import { ScheduleCalendarMapEntry } from '../schedule/schedule.model';
+import { TaskArchiveService } from '../archive/task-archive.service';
 
 describe('CalendarIntegrationService', () => {
   let service: CalendarIntegrationService;
@@ -48,6 +49,14 @@ describe('CalendarIntegrationService', () => {
   const mockSnackService = {
     open: jasmine.createSpy('open'),
   };
+
+  // Default: no calendar tasks in the archive. The #7971 repro overrides `load` to
+  // return an archived calendar task. Reset in beforeEach to avoid cross-test pollution.
+  const mockTaskArchiveService = {
+    load: jasmine.createSpy('load'),
+  };
+  const emptyArchive = (): Promise<{ ids: string[]; entities: object }> =>
+    Promise.resolve({ ids: [], entities: {} });
 
   const createMockProvider = (
     overrides: Partial<IssueProviderCalendar> = {},
@@ -90,6 +99,7 @@ END:VCALENDAR`;
     // Clear localStorage before each test
     localStorage.clear();
     subscriptions = [];
+    mockTaskArchiveService.load.and.callFake(emptyArchive);
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -103,6 +113,7 @@ END:VCALENDAR`;
           ],
         }),
         { provide: SnackService, useValue: mockSnackService },
+        { provide: TaskArchiveService, useValue: mockTaskArchiveService },
       ],
     });
 
@@ -297,6 +308,7 @@ END:VCALENDAR`;
               ],
             }),
             { provide: SnackService, useValue: mockSnackService },
+            { provide: TaskArchiveService, useValue: mockTaskArchiveService },
           ],
         });
 
@@ -378,6 +390,7 @@ END:VCALENDAR`;
               ],
             }),
             { provide: SnackService, useValue: mockSnackService },
+            { provide: TaskArchiveService, useValue: mockTaskArchiveService },
           ],
         });
 
@@ -446,6 +459,7 @@ END:VCALENDAR`;
               ],
             }),
             { provide: SnackService, useValue: mockSnackService },
+            { provide: TaskArchiveService, useValue: mockTaskArchiveService },
           ],
         });
 
@@ -523,6 +537,7 @@ END:VCALENDAR`;
               ],
             }),
             { provide: SnackService, useValue: mockSnackService },
+            { provide: TaskArchiveService, useValue: mockTaskArchiveService },
           ],
         });
 
@@ -795,6 +810,7 @@ END:VCALENDAR`;
               ],
             }),
             { provide: SnackService, useValue: mockSnackService },
+            { provide: TaskArchiveService, useValue: mockTaskArchiveService },
           ],
         });
 
@@ -1264,6 +1280,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1295,6 +1312,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1322,6 +1340,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1346,6 +1365,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1450,6 +1470,160 @@ END:VCALENDAR`;
     }));
   });
 
+  // Repro for https://github.com/super-productivity/super-productivity/issues/7971
+  //
+  // Flow: a calendar event is imported as a task, completed before its due day, then
+  // moved to the archive by "Finish Day". The archived task leaves the live NgRx task
+  // state, so `selectAllCalendarTaskEventIds` (built from `selectAllTasks`, active tasks
+  // only) no longer lists its event id. The schedule/planner view filter relied solely on
+  // that selector, so the event re-surfaced as a "not yet added" entry the next day.
+  //
+  // The fix also feeds archived calendar task event ids (read from the synced archive via
+  // `TaskArchiveService.load()`) into the same view filter, so the event stays hidden.
+  describe('BUG #7971: archived calendar task must stay hidden from the schedule', () => {
+    // Builds a TaskArchiveService.load() result from a list of archived tasks.
+    const archiveOf = (
+      tasks: Array<{ id: string; issueId: string; issueType: string }>,
+    ): Promise<{ ids: string[]; entities: Record<string, unknown> }> =>
+      Promise.resolve({
+        ids: tasks.map((t) => t.id),
+        entities: Object.fromEntries(tasks.map((t) => [t.id, { ...t, isDone: true }])),
+      });
+
+    // Subscribes to calendarEvents$ for one provider, flushes a single iCal fetch and
+    // returns the event ids that survive the view filter. Must run inside fakeAsync.
+    const fetchVisibleEventIds = (activeIds: string[], icalData: string): string[] => {
+      TestBed.resetTestingModule();
+      localStorage.clear();
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [
+          CalendarIntegrationService,
+          provideMockStore({
+            selectors: [
+              { selector: selectCalendarProviders, value: [] },
+              { selector: selectEnabledIssueProviders, value: [] },
+              { selector: selectAllCalendarTaskEventIds, value: activeIds },
+            ],
+          }),
+          { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
+        ],
+      });
+
+      const freshService = TestBed.inject(CalendarIntegrationService);
+      const freshStore = TestBed.inject(MockStore);
+      const freshHttpMock = TestBed.inject(HttpTestingController);
+
+      const mockProvider = createMockProvider();
+      freshStore.overrideSelector(selectCalendarProviders, [mockProvider]);
+      freshStore.refreshState();
+
+      let lastValue: ScheduleCalendarMapEntry[] = [];
+      const sub = freshService.calendarEvents$.subscribe((val) => (lastValue = val));
+
+      tick(0);
+      freshHttpMock.expectOne(mockProvider.icalUrl).flush(icalData);
+      tick(100);
+      flushMicrotasks();
+      freshStore.refreshState();
+      tick(100);
+      flushMicrotasks();
+
+      sub.unsubscribe();
+      discardPeriodicTasks();
+      return lastValue.flatMap((entry) => entry.items.map((item) => item.id));
+    };
+
+    it('hides an event whose only linked task lives in the archive', fakeAsync(() => {
+      // 'test-event-1' is the UID of MOCK_ICAL_DATA's event; the archived calendar task
+      // points back to it. No active task — it was moved to the archive by "Finish Day".
+      mockTaskArchiveService.load.and.returnValue(
+        archiveOf([{ id: 'archivedTask1', issueId: 'test-event-1', issueType: 'ICAL' }]),
+      );
+
+      expect(fetchVisibleEventIds([], MOCK_ICAL_DATA)).not.toContain('test-event-1');
+    }));
+
+    it('still shows an event whose matching archived task is NOT a calendar task', fakeAsync(() => {
+      // A non-calendar archived task (e.g. a GitHub issue) sharing the id must not
+      // suppress the calendar event — isCalendarIssueTask gates the contribution.
+      mockTaskArchiveService.load.and.returnValue(
+        archiveOf([{ id: 'ghTask1', issueId: 'test-event-1', issueType: 'GITHUB' }]),
+      );
+
+      expect(fetchVisibleEventIds([], MOCK_ICAL_DATA)).toContain('test-event-1');
+    }));
+
+    it('still shows an event whose id matches no archived calendar task', fakeAsync(() => {
+      // The archive holds a different event id (e.g. a past occurrence); today's event
+      // must remain visible — guards against over-filtering recurring/independent events.
+      mockTaskArchiveService.load.and.returnValue(
+        archiveOf([{ id: 'archivedTask1', issueId: 'test-event-1', issueType: 'ICAL' }]),
+      );
+
+      expect(fetchVisibleEventIds([], MOCK_ICAL_DATA_2)).toContain('test-event-2');
+    }));
+
+    it('keeps the event hidden across the active → archived transition (no flash)', fakeAsync(() => {
+      TestBed.resetTestingModule();
+      localStorage.clear();
+      // Phase 1: the task is still live (active selector lists its id), archive empty.
+      mockTaskArchiveService.load.and.callFake(emptyArchive);
+
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [
+          CalendarIntegrationService,
+          provideMockStore({
+            selectors: [
+              { selector: selectCalendarProviders, value: [] },
+              { selector: selectEnabledIssueProviders, value: [] },
+              { selector: selectAllCalendarTaskEventIds, value: ['test-event-1'] },
+            ],
+          }),
+          { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
+        ],
+      });
+
+      const freshService = TestBed.inject(CalendarIntegrationService);
+      const freshStore = TestBed.inject(MockStore);
+      const freshHttpMock = TestBed.inject(HttpTestingController);
+
+      const mockProvider = createMockProvider();
+      freshStore.overrideSelector(selectCalendarProviders, [mockProvider]);
+      freshStore.refreshState();
+
+      const emittedIdLists: string[][] = [];
+      const sub = freshService.calendarEvents$.subscribe((val) =>
+        emittedIdLists.push(val.flatMap((e) => e.items.map((i) => i.id))),
+      );
+
+      tick(0);
+      freshHttpMock.expectOne(mockProvider.icalUrl).flush(MOCK_ICAL_DATA);
+      tick(100);
+      flushMicrotasks();
+
+      // Phase 2: "Finish Day" archives the task → it leaves the active set and lands in
+      // the archive in the same beat.
+      mockTaskArchiveService.load.and.returnValue(
+        archiveOf([{ id: 'archivedTask1', issueId: 'test-event-1', issueType: 'ICAL' }]),
+      );
+      freshStore.overrideSelector(selectAllCalendarTaskEventIds, []);
+      freshStore.refreshState();
+      tick(100);
+      flushMicrotasks();
+
+      // The event must never surface in ANY emission across the transition.
+      expect(emittedIdLists.length).toBeGreaterThan(0);
+      emittedIdLists.forEach((ids) => expect(ids).not.toContain('test-event-1'));
+
+      sub.unsubscribe();
+      discardPeriodicTasks();
+    }));
+  });
+
   describe('multiple providers', () => {
     it('should fetch from multiple providers in parallel', fakeAsync(() => {
       const provider1 = createMockProvider({
@@ -1511,6 +1685,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1706,6 +1881,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1729,6 +1905,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1761,6 +1938,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -1917,6 +2095,7 @@ END:VCALENDAR`;
             ],
           }),
           { provide: SnackService, useValue: mockSnackService },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 
@@ -2059,6 +2238,7 @@ END:VCALENDAR`;
           { provide: SnackService, useValue: mockSnackService },
           { provide: PluginIssueProviderRegistryService, useValue: mockRegistry },
           { provide: PluginHttpService, useValue: mockPluginHttp },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
         ],
       });
 

--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -83,19 +83,23 @@ export class CalendarIntegrationService {
   /**
    * Event ids of every calendar task the user has already handled — both live tasks
    * (`selectAllCalendarTaskEventIds`) and ones moved to the archive via "Finish Day",
-   * which leave the live NgRx state. The archive is re-read whenever the active set
-   * changes (archiving a task removes it from the active set → emits here), so a
-   * completed-and-archived calendar event stays hidden from the schedule instead of
-   * re-surfacing as "not yet added" the next day (#7971).
+   * which leave the live NgRx state. The archive is re-read whenever the set of live
+   * calendar-task event ids actually changes (archiving a task removes its id from that
+   * set → emits here), so a completed-and-archived calendar event stays hidden from the
+   * schedule instead of re-surfacing as "not yet added" the next day (#7971).
    */
   private _allLinkedCalendarEventIds$: Observable<string[]> = this._store
     .select(selectAllCalendarTaskEventIds)
     .pipe(
+      // Gate the archive read on a real value change: selectAllCalendarTaskEventIds emits
+      // a new array reference on every task mutation (incl. the per-second time-tracking
+      // tick), and store.select only dedups by reference. Without this guard the
+      // full-archive load() below would run on each of those.
+      distinctUntilChanged(fastArrayCompare),
       switchMap((activeIds) =>
         from(this._taskArchiveService.load()).pipe(
           map((archive) => {
-            const ids = (archive?.ids as string[]) || [];
-            const archivedEventIds = ids
+            const archivedEventIds = archive.ids
               .map((id) => archive.entities[id])
               .filter(isCalendarIssueTask)
               .map((task) => task.issueId as string);
@@ -105,6 +109,9 @@ export class CalendarIntegrationService {
         ),
       ),
       distinctUntilChanged(fastArrayCompare),
+      // Cold field shared by the cache path and every poll/refresh cycle; share so the
+      // archive is loaded once per change instead of once per subscriber.
+      shareReplay({ bufferSize: 1, refCount: true }),
     );
 
   calendarEvents$: Observable<ScheduleCalendarMapEntry[]> = combineLatest([

--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -27,7 +27,10 @@ import { getStartOfDayTimestamp } from '../../util/get-start-of-day-timestamp';
 import { getEndOfDayTimestamp } from '../../util/get-end-of-day-timestamp';
 import { CalendarIntegrationEvent } from './calendar-integration.model';
 import { fastArrayCompare } from '../../util/fast-array-compare';
-import { selectAllCalendarTaskEventIds } from '../tasks/store/task.selectors';
+import {
+  isCalendarIssueTask,
+  selectAllCalendarTaskEventIds,
+} from '../tasks/store/task.selectors';
 import { loadFromRealLs, saveToRealLs } from '../../core/persistence/local-storage';
 import { LS } from '../../core/persistence/storage-keys.const';
 import { Store } from '@ngrx/store';
@@ -56,6 +59,7 @@ import { PluginHttpService } from '../../plugins/issue-provider/plugin-http.serv
 import { selectEnabledIssueProviders } from '../issue/store/issue-provider.selectors';
 import { PluginSearchResult } from '../../plugins/issue-provider/plugin-issue-provider.model';
 import { HiddenCalendarEventsService } from './hidden-calendar-events.service';
+import { TaskArchiveService } from '../archive/task-archive.service';
 import { passesCalendarEventRegexFilter } from './calendar-event-regex-filter';
 import { NotIcalResponseError } from '../schedule/ical/is-likely-ical';
 
@@ -73,7 +77,35 @@ export class CalendarIntegrationService {
   private _pluginRegistry = inject(PluginIssueProviderRegistryService);
   private _pluginHttp = inject(PluginHttpService);
   private _hiddenEventsService = inject(HiddenCalendarEventsService);
+  private _taskArchiveService = inject(TaskArchiveService);
   private _refreshTrigger$ = new Subject<void>();
+
+  /**
+   * Event ids of every calendar task the user has already handled — both live tasks
+   * (`selectAllCalendarTaskEventIds`) and ones moved to the archive via "Finish Day",
+   * which leave the live NgRx state. The archive is re-read whenever the active set
+   * changes (archiving a task removes it from the active set → emits here), so a
+   * completed-and-archived calendar event stays hidden from the schedule instead of
+   * re-surfacing as "not yet added" the next day (#7971).
+   */
+  private _allLinkedCalendarEventIds$: Observable<string[]> = this._store
+    .select(selectAllCalendarTaskEventIds)
+    .pipe(
+      switchMap((activeIds) =>
+        from(this._taskArchiveService.load()).pipe(
+          map((archive) => {
+            const ids = (archive?.ids as string[]) || [];
+            const archivedEventIds = ids
+              .map((id) => archive.entities[id])
+              .filter(isCalendarIssueTask)
+              .map((task) => task.issueId as string);
+            return [...activeIds, ...archivedEventIds];
+          }),
+          catchError(() => of(activeIds)),
+        ),
+      ),
+      distinctUntilChanged(fastArrayCompare),
+    );
 
   calendarEvents$: Observable<ScheduleCalendarMapEntry[]> = combineLatest([
     this._store
@@ -219,9 +251,7 @@ export class CalendarIntegrationService {
     ]);
 
     return combineLatest([
-      this._store
-        .select(selectAllCalendarTaskEventIds)
-        .pipe(distinctUntilChanged(fastArrayCompare)),
+      this._allLinkedCalendarEventIds$,
       this.skippedEventIds$.pipe(distinctUntilChanged(fastArrayCompare)),
       this._hiddenEventsService.hiddenEventIds$.pipe(
         distinctUntilChanged(fastArrayCompare),

--- a/src/app/features/tasks/store/task.selectors.ts
+++ b/src/app/features/tasks/store/task.selectors.ts
@@ -25,7 +25,7 @@ import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { isTodayWithOffset } from '../../../util/is-today.util';
 import { getTimeConflictTaskIds } from '../util/get-time-conflict-task-ids';
 
-const isCalendarIssueTask = (task: Task | undefined): task is Task =>
+export const isCalendarIssueTask = (task: Task | undefined): task is Task =>
   !!task &&
   !!task.issueType &&
   (task.issueType === 'ICAL' || isPluginIssueProvider(task.issueType));


### PR DESCRIPTION
## Problem

Fixes #7971.

A calendar event imported as a task, completed **early**, and archived via **Finish Day** re-surfaces in the **Schedule/Planner** as a "not yet added" calendar entry — "the next day", exactly as reported.

## Root cause

The schedule view filter (`_filterCalendarEntriesForView`) hides an event only if its id is in `selectAllCalendarTaskEventIds`. That selector reads `selectAllTasks` — the **live NgRx state only**, never the IndexedDB task archive. "Finish Day" moves the completed task into the archive, so its event id drops out of the filter and the event reappears.

It only shows up *the next day* because importing an event skips it for the rest of the current day (`addTaskFromIssue → skipCalendarEvent`, a per-day skip). Once that skip resets, the (now archived, no longer filtered) event re-surfaces.

## Fix

Feed archived calendar-task event ids into the same view filter, read from the synced archive via `TaskArchiveService.load()` and merged with the live ids. The archive is re-read whenever the active set changes (archiving a task emits there), with a `catchError` fallback to active-only ids. `TaskArchiveService` is lazy-constructed, so no new eager dependency graph is pulled into the calendar service.

## Testing

- **Unit** (`calendar-integration.service.spec.ts`, 74 pass): archived calendar task → event hidden; active→archived transition (no flash); plus guards that a non-calendar archived task and a non-matching id do **not** over-filter. Verified the fix-dependent tests go red when the fix is reverted.
- **E2E** (`e2e/tests/calendar/archived-calendar-task-no-regen.spec.ts`): live repro — stubbed iCal feed, auto-import, Finish Day, then asserts the event stays out of the Schedule and Planner. Proven to **fail without the fix** (event chip reappears) and pass with it. Race-free via a control event used as a render anchor (no fixed timeouts).