### PR TITLE
chore(log): suppress per-op action log lines during bulk replay

### DIFF
--- a/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
+++ b/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
@@ -7,6 +7,7 @@ import {
   stripBatchArchivedTaskIdsFromLwwPayload,
 } from './bulk-archive-filter.util';
 import { OpLog } from '../../core/log';
+import { runWithBulkReplayLoggingSuppressed } from '../../util/bulk-replay-log-guard';
 
 /**
  * Meta-reducer that applies multiple operations in a single reducer pass.
@@ -55,30 +56,37 @@ export const bulkOperationsMetaReducer = <T>(
         state,
       );
 
-      let currentState = state;
       const hasArchives = archivingOrDeletingEntityIds.size > 0;
-      for (const op of operations) {
-        const isLww = hasArchives && isLwwUpdateActionType(op.actionType);
-        // Skip LWW Updates whose entityId itself is archived/deleted in this batch
-        // (covers TASK; for TAG/PROJECT entityId is the tag/project id, not a task).
-        if (isLww && op.entityId && archivingOrDeletingEntityIds.has(op.entityId)) {
-          OpLog.normal(
-            `bulkOperationsMetaReducer: Skipping LWW Update for ` +
-              `${op.entityType}:${op.entityId} — entity archived/deleted in same batch`,
-          );
-          continue;
+      // Apply every op in one synchronous reducer pass. Suppress the action
+      // logger's per-op console line for the duration (see bulk-replay-log-guard):
+      // this is a single dispatch, and the caller (hydrator / applier) already
+      // logs an "applying N ops" summary, so per-op `[a]` lines are just noise.
+      const finalState = runWithBulkReplayLoggingSuppressed(() => {
+        let currentState = state;
+        for (const op of operations) {
+          const isLww = hasArchives && isLwwUpdateActionType(op.actionType);
+          // Skip LWW Updates whose entityId itself is archived/deleted in this batch
+          // (covers TASK; for TAG/PROJECT entityId is the tag/project id, not a task).
+          if (isLww && op.entityId && archivingOrDeletingEntityIds.has(op.entityId)) {
+            OpLog.normal(
+              `bulkOperationsMetaReducer: Skipping LWW Update for ` +
+                `${op.entityType}:${op.entityId} — entity archived/deleted in same batch`,
+            );
+            continue;
+          }
+          const opForApply = hasArchives
+            ? stripBatchArchivedTaskIdsFromLwwPayload(
+                op,
+                isLww,
+                archivingOrDeletingEntityIds,
+              )
+            : op;
+          const opAction = convertOpToAction(opForApply);
+          currentState = reducer(currentState, opAction);
         }
-        const opForApply = hasArchives
-          ? stripBatchArchivedTaskIdsFromLwwPayload(
-              op,
-              isLww,
-              archivingOrDeletingEntityIds,
-            )
-          : op;
-        const opAction = convertOpToAction(opForApply);
-        currentState = reducer(currentState, opAction);
-      }
-      return currentState as T;
+        return currentState;
+      });
+      return finalState as T;
     }
     return reducer(state, action);
   };

--- a/src/app/root-store/meta/action-logger.reducer.spec.ts
+++ b/src/app/root-store/meta/action-logger.reducer.spec.ts
@@ -1,6 +1,7 @@
 import { actionLoggerReducer } from './action-logger.reducer';
 import { Log } from '../../core/log';
 import { ActionReducer, Action } from '@ngrx/store';
+import { runWithBulkReplayLoggingSuppressed } from '../../util/bulk-replay-log-guard';
 
 describe('actionLoggerReducer', () => {
   const passThrough: ActionReducer<unknown, Action> = (state) => state;
@@ -54,5 +55,25 @@ describe('actionLoggerReducer', () => {
     const wrapped = actionLoggerReducer(reducer);
 
     expect(wrapped({ n: 1 }, { type: 'inc' } as Action)).toEqual({ n: 2 });
+  });
+
+  it('skips the per-op type line during a bulk-replay pass', () => {
+    const reducer: ActionReducer<{ n: number }, Action> = (state, action) =>
+      action.type === 'inc' ? { n: (state?.n ?? 0) + 1 } : (state ?? { n: 0 });
+    const wrapped = actionLoggerReducer(reducer);
+
+    // Inside a bulk-replay pass the per-op `[a]<type>` console line is suppressed
+    // (one bulk dispatch would otherwise print one line per op)...
+    const result = runWithBulkReplayLoggingSuppressed(() =>
+      wrapped({ n: 0 }, { type: '[TimeTracking] Sync sessions' } as Action),
+    );
+
+    expect(Log.exportLogHistory()).not.toContain('[TimeTracking] Sync sessions');
+    // ...but state is still reduced normally.
+    expect(result).toEqual({ n: 0 });
+
+    // ...and once the pass ends, logging resumes.
+    wrapped({ n: 0 }, { type: '[Task] Update Task' } as Action);
+    expect(Log.exportLogHistory()).toContain('[Task] Update Task');
   });
 });

--- a/src/app/root-store/meta/action-logger.reducer.ts
+++ b/src/app/root-store/meta/action-logger.reducer.ts
@@ -1,6 +1,7 @@
 import { actionLogger } from '../../util/action-logger';
 import { ActionReducer, Action } from '@ngrx/store';
 import { Log } from '../../core/log';
+import { isBulkReplayLoggingSuppressed } from '../../util/bulk-replay-log-guard';
 
 export const actionLoggerReducer = <S, A extends Action = Action>(
   reducer: ActionReducer<S, A>,
@@ -8,7 +9,15 @@ export const actionLoggerReducer = <S, A extends Action = Action>(
   return (state: S | undefined, action: A) => {
     // Log the action TYPE only — payloads/full actions carry user content
     // and the log history is user-exportable. See core/log.ts header / rule #9.
-    Log.verbose('[a]' + action.type);
+    //
+    // Skip the per-op console line during a bulk-replay pass: one
+    // `bulkApplyOperations` dispatch runs this reducer once per op, which would
+    // otherwise print one `[a]<type>` line per op (hundreds for a hydration
+    // replay). The caller already logs a single "applying N ops" summary. The
+    // in-memory ring buffer below is still fed (it dedupes) for error reports.
+    if (!isBulkReplayLoggingSuppressed()) {
+      Log.verbose('[a]' + action.type);
+    }
     actionLogger(action as unknown as { type: string; [key: string]: unknown });
     return reducer(state, action);
   };

--- a/src/app/util/bulk-replay-log-guard.ts
+++ b/src/app/util/bulk-replay-log-guard.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared flag indicating that a `bulkApplyOperations` pass is mid-flight, i.e. a
+ * batch of ops is being applied in a single synchronous reducer pass (startup
+ * hydration replay or remote-sync apply).
+ *
+ * While the flag is set, the action logger skips its per-op console line.
+ * Without this, one bulk dispatch prints one `[a]<type>` line per op — e.g. 344
+ * lines for a single hydration replay — which reads as "hundreds of dispatches"
+ * when it is really one reducer pass. The callers (hydrator / applier) already
+ * log a single "applying N ops" summary, so nothing is lost.
+ *
+ * The flag is set synchronously around the bulk loop, so it is always accurate
+ * by the time the inner reducer chain (including the action logger) runs.
+ *
+ * Intentionally separate from HydrationStateService.isApplyingRemoteOps: that flag
+ * stays set across the whole (async) remote-apply window, so reusing it here would
+ * also suppress logging for unrelated actions dispatched in that wider window. This
+ * flag is scoped to the synchronous bulk reducer loop only, so it suppresses exactly
+ * the per-op replay lines and nothing else.
+ */
+let isSuppressed = false;
+
+/**
+ * Runs `fn` with bulk-replay log suppression active. Restores the previous value
+ * afterwards (reentrancy-safe), so nested bulk passes behave correctly.
+ */
+export const runWithBulkReplayLoggingSuppressed = <T>(fn: () => T): T => {
+  const prev = isSuppressed;
+  isSuppressed = true;
+  try {
+    return fn();
+  } finally {
+    isSuppressed = prev;
+  }
+};
+
+export const isBulkReplayLoggingSuppressed = (): boolean => isSuppressed;


### PR DESCRIPTION
## What

During startup hydration replay (and remote-sync apply), a single `bulkApplyOperations` dispatch runs the reducer chain once per op. The innermost `actionLoggerReducer` logged `[a]<type>` per op, so **one** dispatch printed hundreds of `[a]` lines (e.g. 344 for a hydration replay) — which reads in the console as hundreds of separate dispatches when it is really one reducer pass.

This gates that per-op verbose console line behind a bulk-replay flag. The caller already logs a single "applying N ops" summary, so nothing useful is lost.

## Details

- New `src/app/util/bulk-replay-log-guard.ts`: `runWithBulkReplayLoggingSuppressed(fn)` / `isBulkReplayLoggingSuppressed()`. A module-level flag, set synchronously around the bulk loop and restored in `finally` (reentrancy-safe). Intentionally **distinct** from `HydrationStateService.isApplyingRemoteOps`, which spans the broader async apply window and would over-suppress.
- `bulk-hydration.meta-reducer.ts`: wraps the apply loop in the guard — loop logic byte-for-byte unchanged.
- `action-logger.reducer.ts`: skips `Log.verbose('[a]' + action.type)` while suppressed; **still** feeds the in-memory action ring buffer used for error reports.

## What this does NOT change

- No NgRx state / reducer behavior — only a verbose-level console line is skipped.
- Privacy (rule #9) is unaffected: only action *types* were ever logged, and suppression strictly *reduces* output.

## Testing

- Unit: `action-logger.reducer.spec` 5/5, `bulk-hydration.meta-reducer.spec` 34/36 (2 pre-skipped).
- App + spec `tsc --noEmit` clean.

## Note

This is the low-risk half of a two-part investigation into a noisy/heavy startup. It is split off so it can land independently. The companion change (op-log *table* growth → a startup compaction trigger) lives on a separate branch and is held back for a runtime pass before review.
