### PR TITLE
fix(sync): force no-cache on native WebDAV reads (iOS data loss) (#7144)

### DIFF
--- a/ios/App/App/WebDavHttpPlugin.swift
+++ b/ios/App/App/WebDavHttpPlugin.swift
@@ -13,6 +13,15 @@ public class WebDavHttpPlugin: CAPPlugin, CAPBridgedPlugin {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 30
         config.timeoutIntervalForResource = 30
+        // Sync correctness (#7144): never serve WebDAV responses from the HTTP
+        // cache. A cached GET of sync-data.json hides remote changes AND defeats
+        // the content-hash conflict check (the pre-upload GET returns the same
+        // stale body), so the client silently overwrites newer remote data and
+        // loses it. URLSessionConfiguration.default ships a shared URLCache and
+        // the default .useProtocolCachePolicy, so iOS caches these GETs while
+        // Android (OkHttp, no cache) and web (fetch `cache: 'no-store'`) do not.
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.urlCache = nil
         return URLSession(configuration: config)
     }()
 

--- a/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
@@ -10,7 +10,7 @@ import {
   TooManyRequestsAPIError,
 } from '../../errors';
 import { errorMeta } from '../../log/error-meta';
-import { WebDavHttpStatus } from './webdav.const';
+import { WebDavHttpHeader, WebDavHttpStatus } from './webdav.const';
 
 export interface WebDavHttpRequest {
   url: string;
@@ -42,6 +42,44 @@ export interface WebDavHttpAdapterDeps {
 export class WebDavHttpAdapter {
   private static readonly L = 'WebDavHttpAdapter';
 
+  /**
+   * Sync correctness (#7144): force revalidation on the NATIVE HTTP path. iOS
+   * `URLSession` caches GETs by default and an upstream reverse proxy / CDN may
+   * cache too — a stale `sync-data.json` both hides remote changes and defeats
+   * the content-hash conflict check, silently overwriting newer remote data.
+   *
+   * Native-only, intentionally: the web/fetch path uses the CORS-safe fetch
+   * `cache: 'no-store'` option instead. `Cache-Control` is not a CORS-safelisted
+   * request header, so adding it to a cross-origin browser request would require
+   * the WebDAV server to allow it in preflight and could break web sync. Native
+   * HTTP is not subject to CORS, so the headers are safe here and additionally
+   * instruct upstream proxies to revalidate.
+   */
+  private static readonly NO_CACHE_HEADERS: Record<string, string> = {
+    [WebDavHttpHeader.CACHE_CONTROL]: 'no-cache, no-store',
+    Pragma: 'no-cache',
+  };
+
+  /**
+   * Non-sensitive, cache-relevant response headers worth surfacing in a shared
+   * log capture so we can tell whether a stale read came from a client cache or
+   * an upstream proxy. Deliberately excludes anything that can carry user data
+   * or secrets (set-cookie, www-authenticate, content-location, location).
+   */
+  private static readonly _CACHE_HEADER_ALLOWLIST = [
+    'etag',
+    'age',
+    'cache-control',
+    'date',
+    'last-modified',
+    'expires',
+    'x-cache',
+    'cf-cache-status',
+    'x-served-by',
+    'via',
+    'x-proxy-cache',
+  ] as const;
+
   constructor(private readonly _deps: WebDavHttpAdapterDeps) {}
 
   async request(options: WebDavHttpRequest): Promise<WebDavHttpResponse> {
@@ -63,7 +101,10 @@ export class WebDavHttpAdapter {
         const nativeResp = await this._deps.nativeHttp({
           url: options.url,
           method: options.method,
-          headers: options.headers ?? {},
+          headers: {
+            ...(options.headers ?? {}),
+            ...WebDavHttpAdapter.NO_CACHE_HEADERS,
+          },
           data: options.body ?? undefined,
           responseType: 'text',
         });
@@ -100,6 +141,17 @@ export class WebDavHttpAdapter {
           throw fetchError;
         }
       }
+
+      // Diagnostic (#7144): surface cache-relevant response headers so a shared
+      // log capture reveals whether a stale read originated from the client
+      // cache or an upstream proxy. Allowlisted, non-sensitive metadata only.
+      this._deps.logger.normal(`${WebDavHttpAdapter.L}.response()`, {
+        method: options.method,
+        url: scrubbedUrl,
+        status: response.status,
+        bodyChars: response.data.length,
+        cacheHeaders: WebDavHttpAdapter._pickCacheHeaders(response.headers),
+      });
 
       // Check for common HTTP errors
       this._checkHttpStatus(response.status, scrubbedUrl, response.data);
@@ -164,6 +216,26 @@ export class WebDavHttpAdapter {
     } catch {
       return '[invalid-webdav-url]';
     }
+  }
+
+  /**
+   * Serialize the allowlisted cache-relevant headers (case-insensitive) into a
+   * compact, log-safe string like `etag=W/"a1"; age=3; x-cache=HIT`. Returns
+   * `'none'` when the response carries no such headers (already a useful
+   * signal). `SyncLogMeta` only holds primitives, hence a string not an object.
+   */
+  private static _pickCacheHeaders(headers: Record<string, string>): string {
+    const lower: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+      lower[key.toLowerCase()] = value;
+    }
+    const parts: string[] = [];
+    for (const key of WebDavHttpAdapter._CACHE_HEADER_ALLOWLIST) {
+      if (lower[key] !== undefined) {
+        parts.push(`${key}=${lower[key]}`);
+      }
+    }
+    return parts.length > 0 ? parts.join('; ') : 'none';
   }
 
   private async _convertFetchResponse(response: Response): Promise<WebDavHttpResponse> {

--- a/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
@@ -63,6 +63,34 @@ describe('WebDavHttpAdapter', () => {
       );
     });
 
+    it('sends no-cache request headers on the native path (#7144)', async () => {
+      // Regression guard: iOS URLSession / upstream proxies otherwise serve a
+      // stale sync-data.json, which hides remote changes and defeats the
+      // content-hash conflict check, causing silent overwrite/data loss.
+      const nativeHttp = vi.fn().mockResolvedValue({
+        status: 200,
+        headers: {},
+        data: 'native-body',
+      });
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isNativePlatform: true, nativeHttp }),
+      );
+
+      await adapter.request({
+        url: 'https://dav.example.com/sync/file',
+        method: 'GET',
+        headers: { Authorization: 'Basic abc' },
+      });
+
+      const sentHeaders = (
+        nativeHttp.mock.calls[0][0] as { headers: Record<string, string> }
+      ).headers;
+      expect(sentHeaders['Cache-Control']).toBe('no-cache, no-store');
+      expect(sentHeaders['Pragma']).toBe('no-cache');
+      // Caller headers are preserved.
+      expect(sentHeaders['Authorization']).toBe('Basic abc');
+    });
+
     it('uses fetch when not native', async () => {
       const fetchImpl = vi.fn().mockResolvedValue(okFetchResponse(200, 'web-body'));
       const adapter = new WebDavHttpAdapter(
@@ -235,6 +263,61 @@ describe('WebDavHttpAdapter', () => {
       expect(JSON.stringify(loggedMessages)).not.toContain('user:pass');
       expect(JSON.stringify(loggedMessages)).not.toContain('alice');
       expect(JSON.stringify(loggedMessages)).not.toContain('sync/file');
+    });
+
+    it('logs allowlisted cache headers but never sensitive ones (#7144 diagnostic)', async () => {
+      /* eslint-disable @typescript-eslint/naming-convention */
+      const nativeHttp = vi.fn().mockResolvedValue({
+        status: 200,
+        headers: {
+          ETag: 'W/"v15"',
+          Age: '7',
+          'X-Cache': 'HIT',
+          'Set-Cookie': 'session=topsecret',
+          'WWW-Authenticate': 'Basic realm="x"',
+        },
+        data: 'body',
+      });
+      /* eslint-enable @typescript-eslint/naming-convention */
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isNativePlatform: true, nativeHttp, logger }),
+      );
+
+      await adapter.request({
+        url: 'https://dav.example.com/sync/file',
+        method: 'GET',
+      });
+
+      const responseLog = loggedMessages.find((l) => l.msg.includes('.response()'));
+      expect(responseLog).toBeTruthy();
+      const cacheHeaders = (responseLog?.meta as { cacheHeaders?: string }).cacheHeaders;
+      // Allowlisted, case-insensitive.
+      expect(cacheHeaders).toContain('etag=W/"v15"');
+      expect(cacheHeaders).toContain('age=7');
+      expect(cacheHeaders).toContain('x-cache=HIT');
+      // Sensitive headers never surface in the log.
+      expect(JSON.stringify(loggedMessages)).not.toContain('topsecret');
+      expect(JSON.stringify(loggedMessages)).not.toContain('set-cookie');
+      expect(JSON.stringify(loggedMessages)).not.toContain('Set-Cookie');
+    });
+
+    it('logs cacheHeaders=none when the response has no cache headers', async () => {
+      const nativeHttp = vi.fn().mockResolvedValue({
+        status: 200,
+        headers: {},
+        data: 'body',
+      });
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isNativePlatform: true, nativeHttp, logger }),
+      );
+
+      await adapter.request({
+        url: 'https://dav.example.com/sync/file',
+        method: 'GET',
+      });
+
+      const responseLog = loggedMessages.find((l) => l.msg.includes('.response()'));
+      expect((responseLog?.meta as { cacheHeaders?: string }).cacheHeaders).toBe('none');
     });
 
     it('logs structured errorMeta on unexpected error (no raw Error)', async () => {


### PR DESCRIPTION
Fixes #7144

## Problem

iOS/iPadOS file-based sync (WebDAV / Nextcloud / generic WebDAV) **silently loses data**. Reproduced by a user on 18.8.0 (Mac ↔ iPad, Nextcloud):

1. Create a task on the Mac → sync (upload confirmed on the server).
2. Hit sync on the iPad → it reports "in sync" instantly, but the task never appears.
3. Edit on the iPad → sync.
4. Sync the Mac → the Mac's task **disappears**, replaced by the iPad's edit.

## Root cause

The user's logs show the iPad reads a **permanently stale copy** of `sync-data.json` — `syncVersion=15` on *every* download for the whole session — while the Mac always reads fresh (16, 17). The iPad never sees the Mac's newer versions, and can't even read back its own uploads.

The only client-side difference is HTTP caching:

- **iOS** `WebDavHttpPlugin` uses `URLSessionConfiguration.default`, which ships a shared `URLCache`, with the default `.useProtocolCachePolicy` → **GET responses are cached**.
- **Android** (OkHttp, no cache by default) and **web/desktop** (fetch `cache: 'no-store'`) are unaffected — which is why this is iOS-only.

One stale cache defeats *two* safeguards:

1. **Download** never surfaces remote changes → the iPad shows stale state.
2. The pre-upload conflict check (`webdav-api.ts`) re-`GET`s the file and compares a content hash; the cached GET returns the same stale body, so `hash === expectedRev`, the optimistic-concurrency guard passes falsely, and the client **blindly overwrites newer remote data**.

## Fix

- **`ios/.../WebDavHttpPlugin.swift`** — disable the HTTP cache on the WebDAV `URLSession` (`urlCache = nil` + `requestCachePolicy = .reloadIgnoringLocalCacheData`) so sync reads always hit the network.
- **`webdav-http-adapter.ts`** — send `Cache-Control: no-cache, no-store` + `Pragma: no-cache` on the **native** request path (covers an upstream reverse-proxy / CDN cache for iOS *and* Android). Intentionally native-only: the web/fetch path keeps the CORS-safe `cache: 'no-store'` option, because `Cache-Control` is not a CORS-safelisted request header and adding it to cross-origin browser requests could break web sync.
- Added a diagnostic `.response()` log emitting an **allowlisted, non-sensitive** set of cache-relevant response headers (`etag`, `age`, `x-cache`, `cf-cache-status`, `via`, …) so a future log capture can localise a stale read (client cache vs upstream proxy).

**Scope:** Dropbox on iOS uses `fetch` with POST-based downloads (not GET-cacheable), so it isn't affected by this bug; the fix is scoped to the WebDAV path that was reproduced.

## Tests

- New regression guard: native requests carry the no-cache headers and preserve caller headers.
- New privacy guards: allowlisted cache headers are logged; `Set-Cookie` / `WWW-Authenticate` never are; `cacheHeaders=none` when absent.
- `webdav-http-adapter.spec.ts` 21/21 · full webdav suite 87/87 · package typecheck + `checkFile` clean.

## Verification caveat

The Swift change can't be built/run in CI here — it needs a Mac/Xcode build and an on-device run of the 4-step repro to confirm end-to-end. The TypeScript layer is fully unit-tested.

This change was reviewed by a 6-perspective multi-agent pass (correctness, security, architecture, alternatives, performance, simplicity) before opening.