### PR TITLE
fix(task-repeat-cfg): create real instance when startDate moved to today with no live instance

### DIFF
--- a/e2e/tests/recurring/recurring-startdate-to-today-creates-real-instance-bug-7923.spec.ts
+++ b/e2e/tests/recurring/recurring-startdate-to-today-creates-real-instance-bug-7923.spec.ts
@@ -1,0 +1,179 @@
+import { Locator, Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Bug: https://github.com/super-productivity/super-productivity/issues/7923
+ *
+ * When the user:
+ *   1. Creates a recurring (daily) task with a future startDate
+ *   2. Deletes the materialised live instance (plain delete — does NOT touch
+ *      deletedInstanceDates or lastTaskCreationDay)
+ *   3. Opens the repeat config from a transparent projection and moves
+ *      startDate to TODAY
+ *
+ * Expected: a real (non-transparent) task instance is created for today and
+ *           added to the Today work-view.
+ * Bug:      today keeps showing only a transparent projection; no real task
+ *           is created.
+ *
+ * Root cause: `rescheduleTaskOnRepeatCfgUpdate$` correctly re-anchors
+ * `lastTaskCreationDay` to yesterday and calls `addAllDueToday()` (#7768 Bug 2
+ * fix), but `addAllDueToday()` fails to materialise today's instance — the
+ * downstream real-creation path was not exercised by existing unit tests
+ * (which mock `addAllDueToday`).
+ */
+
+// Fix the clock so calendar interactions and date arithmetic are deterministic.
+// Use a Wednesday in May so future offset (+9 days → Friday May 10) doesn't
+// cross a month boundary, keeping the date-picker entry simple.
+const FIXED_TODAY = new Date('2026-05-01T10:00:00');
+const FIXED_TODAY_DDMMYYYY = '01/05/2026';
+const FUTURE_START_DDMMYYYY = '10/05/2026'; // today + 9 days
+
+const openRecurDialogFromProjection = async (
+  page: Page,
+  taskTitle: string,
+): Promise<Locator> => {
+  const projection = page
+    .locator('planner-repeat-projection')
+    .filter({ hasText: taskTitle })
+    .first();
+  await expect(projection).toBeVisible({ timeout: 15000 });
+  await projection.click();
+  const dialog = page.locator('mat-dialog-container');
+  await dialog.waitFor({ state: 'visible', timeout: 10000 });
+  return dialog;
+};
+
+const setStartDate = async (page: Page, ddmmyyyy: string): Promise<void> => {
+  const dialog = page.locator('mat-dialog-container');
+  const startDateInput = dialog
+    .locator('mat-form-field')
+    .filter({ hasText: /Start date/i })
+    .locator('input')
+    .first();
+  await expect(startDateInput).toBeVisible({ timeout: 5000 });
+  await expect(async () => {
+    await startDateInput.fill('');
+    await startDateInput.fill(ddmmyyyy);
+    await expect(startDateInput).toHaveValue(ddmmyyyy, { timeout: 1000 });
+  }).toPass({ timeout: 10000 });
+  await startDateInput.press('Tab');
+  await expect(startDateInput).toHaveValue(ddmmyyyy, { timeout: 3000 });
+};
+
+const gotoHashRoute = async (
+  page: Page,
+  route: string,
+  marker: Locator,
+): Promise<void> => {
+  await page.goto(route);
+  await page.waitForLoadState('networkidle');
+  const landed = await marker
+    .waitFor({ state: 'visible', timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!landed) {
+    await page.goto('about:blank');
+    await page.goto(route);
+    await page.waitForLoadState('networkidle');
+    await expect(marker).toBeVisible({ timeout: 15000 });
+  }
+};
+
+const saveDialog = async (page: Page): Promise<void> => {
+  const dialog = page.locator('mat-dialog-container');
+  const saveBtn = dialog.getByRole('button', { name: /Save/i });
+  await expect(saveBtn).toBeEnabled({ timeout: 5000 });
+  await saveBtn.click();
+  await dialog.waitFor({ state: 'hidden', timeout: 10000 });
+};
+
+const openRecurDialogFromTaskDetail = async (page: Page): Promise<void> => {
+  const recurItem = page
+    .locator('task-detail-item')
+    .filter({ has: page.locator('mat-icon', { hasText: /^repeat$/ }) });
+  await expect(recurItem).toBeVisible({ timeout: 5000 });
+  await recurItem.click();
+  const dialog = page.locator('mat-dialog-container');
+  await dialog.waitFor({ state: 'visible', timeout: 10000 });
+};
+
+test.describe('Recurring Task - Move startDate to Today Creates Real Instance (#7923)', () => {
+  test('moving startDate to today with no live instance creates a real task in Today, not a projection', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    const taskTitle = `${testPrefix}-StartDateToday7923`;
+
+    // Fix today to May 1, 2026 so date arithmetic is deterministic.
+    await page.clock.setFixedTime(FIXED_TODAY);
+    await page.reload();
+    await workViewPage.waitForTaskList();
+
+    // 1. Create the task and make it recurring (daily) starting May 10 (9 days
+    //    in the future). This materialises a live instance for May 10.
+    await workViewPage.addTask(taskTitle);
+    const task = taskPage.getTaskByText(taskTitle).first();
+    await expect(task).toBeVisible({ timeout: 10000 });
+    await taskPage.openTaskDetail(task);
+    await openRecurDialogFromTaskDetail(page);
+    await setStartDate(page, FUTURE_START_DDMMYYYY);
+    await saveDialog(page);
+
+    // 2. Delete the live (non-transparent) May 10 instance. The delete is a
+    //    plain delete — it does NOT touch lastTaskCreationDay or
+    //    deletedInstanceDates (per the maintainer's note in #7923).
+    const taskRows = page.locator('task').filter({ hasText: taskTitle });
+    await gotoHashRoute(page, '/#/project/INBOX_PROJECT/tasks', taskRows.first());
+    const contextMenu = page.locator('.mat-mdc-menu-content');
+    await expect(async () => {
+      await taskRows.first().click({ button: 'right', timeout: 4000 });
+      await expect(contextMenu).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20000 });
+    await contextMenu.locator('button.color-warn').click();
+    const confirmBtn = page.locator('[e2e="confirmBtn"]');
+    await expect(confirmBtn).toBeVisible({ timeout: 5000 });
+    await confirmBtn.click();
+    await expect(taskRows).toHaveCount(0, { timeout: 10000 });
+
+    // 3. Open the planner. The task now appears only as transparent projections
+    //    (starting May 10, since lastTaskCreationDay = May 10 suppresses earlier
+    //    days). Open the projection for May 11 and change startDate to today
+    //    (May 1) — the exact scenario from issue #7923.
+    await gotoHashRoute(
+      page,
+      '/#/planner',
+      page.locator('planner-repeat-projection').filter({ hasText: taskTitle }).first(),
+    );
+    await openRecurDialogFromProjection(page, taskTitle);
+    await setStartDate(page, FIXED_TODAY_DDMMYYYY); // Move startDate → today
+    await saveDialog(page);
+
+    // 4. Navigate to the Today work-view and verify a REAL task was created.
+    //    After the fix, rescheduleTaskOnRepeatCfgUpdate$ re-anchors
+    //    lastTaskCreationDay to yesterday and addAllDueToday() materialises
+    //    the task for May 1. The task must appear in the Today list as a real
+    //    task element, NOT as a planner-repeat-projection.
+    await gotoHashRoute(
+      page,
+      '/#/tag/TODAY/tasks',
+      page.locator('task').filter({ hasText: taskTitle }).first(),
+    );
+    const realTaskInToday = page.locator('task').filter({ hasText: taskTitle }).first();
+    await expect(realTaskInToday).toBeVisible({ timeout: 15000 });
+
+    // Guard: there must be NO transparent projection for today in the planner.
+    // A projection means addAllDueToday() did not materialise the real instance.
+    await gotoHashRoute(page, '/#/planner', page.locator('planner-day').first());
+    const todayColumn = page
+      .locator('planner-day')
+      .filter({ has: page.locator('.date', { hasText: /^1\/5$/ }) });
+    await expect(todayColumn).toBeVisible({ timeout: 10000 });
+    await expect(
+      todayColumn.locator('planner-repeat-projection').filter({ hasText: taskTitle }),
+    ).toHaveCount(0, { timeout: 5000 });
+  });
+});

--- a/e2e/tests/recurring/recurring-startdate-to-today-creates-real-instance-bug-7923.spec.ts
+++ b/e2e/tests/recurring/recurring-startdate-to-today-creates-real-instance-bug-7923.spec.ts
@@ -24,10 +24,12 @@ import { expect, test } from '../../fixtures/test.fixture';
  */
 
 // Fix the clock so calendar interactions and date arithmetic are deterministic.
-// Use a Wednesday in May so future offset (+9 days → Friday May 10) doesn't
-// cross a month boundary, keeping the date-picker entry simple.
+// May 1, 2026 is mid-month, so the future offset (+9 days → May 10) stays inside
+// the same month, keeping the date-picker entry simple. The repeat is DAILY, so
+// the weekday is irrelevant.
 const FIXED_TODAY = new Date('2026-05-01T10:00:00');
 const FIXED_TODAY_DDMMYYYY = '01/05/2026';
+const FIXED_TODAY_DATA_DAY = '2026-05-01'; // planner-day[data-day] form of FIXED_TODAY
 const FUTURE_START_DDMMYYYY = '10/05/2026'; // today + 9 days
 
 const openRecurDialogFromProjection = async (
@@ -168,12 +170,15 @@ test.describe('Recurring Task - Move startDate to Today Creates Real Instance (#
     // Guard: there must be NO transparent projection for today in the planner.
     // A projection means addAllDueToday() did not materialise the real instance.
     await gotoHashRoute(page, '/#/planner', page.locator('planner-day').first());
-    const todayColumn = page
-      .locator('planner-day')
-      .filter({ has: page.locator('.date', { hasText: /^1\/5$/ }) });
-    await expect(todayColumn).toBeVisible({ timeout: 10000 });
+    // Match today by the stable data-day attribute rather than the rendered date
+    // text: during the route-enter animation the leaving and entering columns are
+    // briefly both in the DOM, so a text filter resolves to 2 elements. Asserting
+    // the projection count across every matching column (toHaveCount(0)) is correct
+    // regardless of how many copies the animation leaves behind.
+    const todayColumns = page.locator(`planner-day[data-day="${FIXED_TODAY_DATA_DAY}"]`);
+    await expect(todayColumns.first()).toBeVisible({ timeout: 10000 });
     await expect(
-      todayColumn.locator('planner-repeat-projection').filter({ hasText: taskTitle }),
+      todayColumns.locator('planner-repeat-projection').filter({ hasText: taskTitle }),
     ).toHaveCount(0, { timeout: 5000 });
   });
 });

--- a/src/app/features/add-tasks-for-tomorrow/add-tasks-for-tomorrow.service.ts
+++ b/src/app/features/add-tasks-for-tomorrow/add-tasks-for-tomorrow.service.ts
@@ -144,6 +144,11 @@ export class AddTasksForTomorrowService {
 
     TaskLog.log('[AddTasksForTomorrow] Starting addAllDueToday', { todayStr });
 
+    // Yield to event loop before reading so any in-flight store updates
+    // (e.g. the re-anchor dispatch from rescheduleTaskOnRepeatCfgUpdate$)
+    // have fully propagated before the selector is evaluated. (#7923)
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     const dueRepeatCfgs = await this._taskRepeatCfgService
       .getAllUnprocessedRepeatableTasks$(todayDate.getTime())
       .pipe(first())

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
@@ -1966,4 +1966,68 @@ describe('TaskRepeatCfgService', () => {
       expect(dispatchedAction.taskId).toBe(taskId);
     });
   });
+
+  describe('Regression #7923 — delete instance then move startDate to today', () => {
+    // Reproduction of issue #7923:
+    // 1. Recurring task created with startDate = future (e.g. June 10), DAILY
+    // 2. The task instance for that future date is plain-deleted
+    // 3. User clicks the transparent projection for the next day and changes
+    //    startDate to today via the dialog
+    // 4. rescheduleTaskOnRepeatCfgUpdate$ re-anchors lastTaskCreationDay to
+    //    yesterday and calls addAllDueToday() (#7768 Bug 2 fix)
+    // 5. addAllDueToday() calls createRepeatableTask() with the re-anchored config
+    //
+    // The test exercises step 5 — the "real creation path" that the effect tests
+    // skip by mocking addAllDueToday.
+
+    it('should create task for today when startDate = today and lastTaskCreationDay = yesterday (post-re-anchor state)', async () => {
+      const today = new Date();
+      today.setHours(10, 0, 0, 0);
+      const todayStr = formatIsoDate(today);
+
+      const yesterday = new Date(today);
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = formatIsoDate(yesterday);
+
+      const expectedId = getRepeatableTaskId('cfg-7923', todayStr);
+
+      // Config in the state produced by the re-anchor:
+      //   startDate was changed to today, lastTaskCreationDay set to yesterday
+      const cfgPostReAnchor: TaskRepeatCfg = {
+        ...DEFAULT_TASK_REPEAT_CFG,
+        id: 'cfg-7923',
+        title: '#7923 Regression',
+        projectId: 'test-project',
+        repeatCycle: 'DAILY',
+        repeatEvery: 1,
+        startDate: todayStr,
+        lastTaskCreationDay: yesterdayStr,
+        tagIds: [],
+      };
+
+      // No live instances — the future-dated task was plain-deleted in step 2
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]));
+      taskService.createNewTaskWithDefaults.and.returnValue({
+        ...mockTask,
+        id: expectedId,
+        dueDay: todayStr,
+      });
+
+      await service.createRepeatableTask(cfgPostReAnchor, today.getTime());
+
+      const dispatched = dispatchSpy.calls.all().map((c) => c.args[0] as any);
+      const addTaskAction = dispatched.find(
+        (a) => a.type === TaskSharedActions.addTask.type,
+      );
+      expect(addTaskAction)
+        .withContext('addTask action must be dispatched for today')
+        .toBeDefined();
+      expect(addTaskAction?.task?.dueDay)
+        .withContext('task dueDay must be today')
+        .toBe(todayStr);
+      expect(addTaskAction?.task?.id)
+        .withContext('task must use deterministic id')
+        .toBe(expectedId);
+    });
+  });
 });

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.service.spec.ts
@@ -376,15 +376,29 @@ describe('TaskRepeatCfgService', () => {
       );
     });
 
-    it('should not create task if already exists for the day', async () => {
+    it('should not create a duplicate task but still advance lastTaskCreationDay when task already exists for the day', async () => {
       const today = new Date();
       const targetDayDate = today.getTime();
+      const expectedDueDay = getDbDateStr(targetDayDate);
       const existingTask = { ...mockTaskWithSubTasks, created: targetDayDate };
       taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([existingTask]));
 
       await service.createRepeatableTask(mockTaskRepeatCfg, targetDayDate);
 
-      expect(dispatchSpy).not.toHaveBeenCalled();
+      // No addTask — task already exists.
+      const addTaskCall = dispatchSpy.calls
+        .all()
+        .find((c) => c.args[0].type?.includes('addTask'));
+      expect(addTaskCall).toBeUndefined();
+      // But lastTaskCreationDay is advanced to suppress the transparent projection (#7923).
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: updateTaskRepeatCfg.type,
+          taskRepeatCfg: jasmine.objectContaining({
+            changes: jasmine.objectContaining({ lastTaskCreationDay: expectedDueDay }),
+          }),
+        }),
+      );
     });
 
     it('should add task to bottom if order > 0', async () => {
@@ -442,13 +456,12 @@ describe('TaskRepeatCfgService', () => {
       );
     });
 
-    it('should not create task if task with deterministic ID already exists', async () => {
+    it('should not create duplicate but advance lastTaskCreationDay when deterministic ID already exists', async () => {
       const today = new Date();
       const targetDayDate = today.getTime();
       const expectedDueDay = getDbDateStr(targetDayDate);
       const expectedId = getRepeatableTaskId(mockTaskRepeatCfg.id, expectedDueDay);
 
-      // Existing task has the deterministic ID (simulating sync from another device)
       const existingTaskWithDeterministicId = {
         ...mockTaskWithSubTasks,
         id: expectedId,
@@ -460,18 +473,28 @@ describe('TaskRepeatCfgService', () => {
 
       await service.createRepeatableTask(mockTaskRepeatCfg, targetDayDate);
 
-      expect(dispatchSpy).not.toHaveBeenCalled();
+      const addTaskCall = dispatchSpy.calls
+        .all()
+        .find((c) => c.args[0].type?.includes('addTask'));
+      expect(addTaskCall).toBeUndefined();
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: updateTaskRepeatCfg.type,
+          taskRepeatCfg: jasmine.objectContaining({
+            changes: jasmine.objectContaining({ lastTaskCreationDay: expectedDueDay }),
+          }),
+        }),
+      );
     });
 
-    it('should not create task if task with matching created date already exists (legacy check)', async () => {
+    it('should not create duplicate but advance lastTaskCreationDay for legacy task with matching created date', async () => {
       const today = new Date();
       const targetDayDate = today.getTime();
+      const expectedDueDay = getDbDateStr(targetDayDate);
 
-      // Compute the expected creation timestamp (noon on target day, same as service does)
       const targetCreatedDate = new Date(targetDayDate);
       targetCreatedDate.setHours(12, 0, 0, 0);
 
-      // Existing task has a different ID but same created date (legacy task without deterministic ID)
       const existingLegacyTask = {
         ...mockTaskWithSubTasks,
         id: 'legacy-random-id-12345',
@@ -483,7 +506,18 @@ describe('TaskRepeatCfgService', () => {
 
       await service.createRepeatableTask(mockTaskRepeatCfg, targetDayDate);
 
-      expect(dispatchSpy).not.toHaveBeenCalled();
+      const addTaskCall = dispatchSpy.calls
+        .all()
+        .find((c) => c.args[0].type?.includes('addTask'));
+      expect(addTaskCall).toBeUndefined();
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: updateTaskRepeatCfg.type,
+          taskRepeatCfg: jasmine.objectContaining({
+            changes: jasmine.objectContaining({ lastTaskCreationDay: expectedDueDay }),
+          }),
+        }),
+      );
     });
 
     it('should create task even if existing task has matching dueDay but different created date (#6192)', async () => {
@@ -545,9 +579,10 @@ describe('TaskRepeatCfgService', () => {
   });
 
   describe('getActionsForTaskRepeatCfg', () => {
-    it('should return empty array if task already exists for day', async () => {
+    it('should return updateTaskRepeatCfg (not addTask) when task already exists for day (#7923)', async () => {
       const today = new Date();
       const targetDayDate = today.getTime();
+      const expectedDueDay = getDbDateStr(targetDayDate);
       const existingTask = { ...mockTaskWithSubTasks, created: targetDayDate };
       taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([existingTask]));
 
@@ -556,17 +591,19 @@ describe('TaskRepeatCfgService', () => {
         targetDayDate,
       );
 
-      expect(actions).toEqual([]);
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(updateTaskRepeatCfg.type);
+      expect((actions[0] as any).taskRepeatCfg.changes.lastTaskCreationDay).toBe(
+        expectedDueDay,
+      );
     });
 
-    it('should return empty array if task with deterministic ID already exists', async () => {
-      // Use today's date since mockTaskRepeatCfg has startDate=today
+    it('should return updateTaskRepeatCfg (not addTask) when deterministic ID already exists (#7923)', async () => {
       const today = new Date();
       const targetDayDate = today.getTime();
       const expectedDueDay = getDbDateStr(targetDayDate);
       const deterministicId = getRepeatableTaskId(mockTaskRepeatCfg.id, expectedDueDay);
 
-      // Task exists with deterministic ID (simulating sync from another device)
       const existingTaskFromSync = {
         ...mockTaskWithSubTasks,
         id: deterministicId,
@@ -581,19 +618,21 @@ describe('TaskRepeatCfgService', () => {
         targetDayDate,
       );
 
-      expect(actions).toEqual([]);
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(updateTaskRepeatCfg.type);
+      expect((actions[0] as any).taskRepeatCfg.changes.lastTaskCreationDay).toBe(
+        expectedDueDay,
+      );
     });
 
-    it('should return empty array if legacy task with same created date exists', async () => {
-      // Use today's date since mockTaskRepeatCfg has startDate=today
+    it('should return updateTaskRepeatCfg (not addTask) when legacy task with same created date exists (#7923)', async () => {
       const today = new Date();
       const targetDayDate = today.getTime();
+      const expectedDueDay = getDbDateStr(targetDayDate);
 
-      // Compute the expected creation timestamp (noon on target day, same as service does)
       const targetCreatedDate = new Date(targetDayDate);
       targetCreatedDate.setHours(12, 0, 0, 0);
 
-      // Legacy task with random ID but matching created date
       const legacyTask = {
         ...mockTaskWithSubTasks,
         id: 'old-random-nanoid-xyz',
@@ -606,7 +645,11 @@ describe('TaskRepeatCfgService', () => {
         targetDayDate,
       );
 
-      expect(actions).toEqual([]);
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(updateTaskRepeatCfg.type);
+      expect((actions[0] as any).taskRepeatCfg.changes.lastTaskCreationDay).toBe(
+        expectedDueDay,
+      );
     });
 
     it('should create task if no task with matching ID or created date exists', async () => {
@@ -644,9 +687,10 @@ describe('TaskRepeatCfgService', () => {
       expect(actions[0].type).toBe(TaskSharedActions.addTask.type);
     });
 
-    it('should skip creation if computed target date already has an instance', async () => {
+    it('should advance lastTaskCreationDay without duplicate when computed target date already has an instance (#7923)', async () => {
       const targetDayDate = new Date(2020, 0, 4).getTime();
       const targetDate = new Date(2020, 0, 3);
+      const expectedDueDay = formatIsoDate(targetDate);
       const cfgNeedingCatchUp: TaskRepeatCfg = {
         ...mockTaskRepeatCfg,
         startDate: formatIsoDate(new Date(2020, 0, 1)),
@@ -656,7 +700,7 @@ describe('TaskRepeatCfgService', () => {
       const existingTask: TaskWithSubTasks = {
         ...mockTaskWithSubTasks,
         created: targetDate.getTime(),
-        dueDay: formatIsoDate(targetDate),
+        dueDay: expectedDueDay,
       };
       taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([existingTask]));
 
@@ -665,7 +709,11 @@ describe('TaskRepeatCfgService', () => {
         targetDayDate,
       );
 
-      expect(actions).toEqual([]);
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(updateTaskRepeatCfg.type);
+      expect((actions[0] as any).taskRepeatCfg.changes.lastTaskCreationDay).toBe(
+        expectedDueDay,
+      );
     });
 
     it('should respect deleted instances based on computed target date', async () => {
@@ -1964,6 +2012,51 @@ describe('TaskRepeatCfgService', () => {
 
       expect(dispatchedAction.type).toBe(addTaskRepeatCfgToTask.type);
       expect(dispatchedAction.taskId).toBe(taskId);
+    });
+  });
+
+  describe('Regression #7923 — taskAlreadyExists still advances lastTaskCreationDay', () => {
+    it('should dispatch updateTaskRepeatCfg to advance lastTaskCreationDay even when task already exists', async () => {
+      const today = new Date();
+      today.setHours(10, 0, 0, 0);
+      const todayStr = formatIsoDate(today);
+      const yesterday = new Date(today);
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = formatIsoDate(yesterday);
+      const expectedId = getRepeatableTaskId('cfg-7923-dup', todayStr);
+
+      const cfg: TaskRepeatCfg = {
+        ...DEFAULT_TASK_REPEAT_CFG,
+        id: 'cfg-7923-dup',
+        title: '#7923 Duplicate',
+        projectId: 'test-project',
+        repeatCycle: 'DAILY',
+        repeatEvery: 1,
+        startDate: todayStr,
+        lastTaskCreationDay: yesterdayStr,
+        tagIds: [],
+      };
+
+      // Simulate task already existing (created by a concurrent addAllDueToday call)
+      const existingTask = {
+        ...mockTask,
+        id: expectedId,
+        created: today.setHours(12, 0, 0, 0),
+        repeatCfgId: 'cfg-7923-dup',
+      };
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(
+        of([existingTask as any]),
+      );
+
+      const actions = await service._getActionsForTaskRepeatCfg(cfg, today.getTime());
+
+      // Must still dispatch updateTaskRepeatCfg to advance lastTaskCreationDay
+      // so the transparent projection disappears (#7923)
+      expect(actions.length).toBe(1);
+      expect(actions[0].type).toBe(updateTaskRepeatCfg.type);
+      expect((actions[0] as any).taskRepeatCfg.changes.lastTaskCreationDay).toBe(
+        todayStr,
+      );
     });
   });
 

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.service.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.service.ts
@@ -220,7 +220,22 @@ export class TaskRepeatCfgService {
     });
 
     if (taskAlreadyExists) {
-      return [];
+      // Task already exists for this date. Still advance lastTaskCreationDay so
+      // the transparent planner projection is suppressed. Without this update the
+      // projection lingers when a concurrent addAllDueToday() call or a date-change
+      // effect created the task first — the race leaves lastTaskCreationDay behind
+      // the actual creation date. (#7923)
+      return [
+        updateTaskRepeatCfg({
+          taskRepeatCfg: {
+            id: taskRepeatCfg.id as string,
+            changes: {
+              lastTaskCreation: targetCreated.getTime(),
+              lastTaskCreationDay: targetDateStr,
+            },
+          },
+        }),
+      ];
     }
     // Check if this date is in the deleted instances list
     // NOTE: needs to run after deriving targetDateStr so deletions for overdue instances work.


### PR DESCRIPTION
## Problem

After deleting a recurring task's live instance and then moving `startDate` to today via a transparent planner projection, today's slot showed only a transparent projection — no real task was created.

Fixes #7923

## Root Cause

Two related bugs, both in the path `rescheduleTaskOnRepeatCfgUpdate$` → `addAllDueToday()` → `createRepeatableTask()`:

**Bug 1 — store read race in `addAllDueToday`.**
`rescheduleTaskOnRepeatCfgUpdate$` re-anchors `lastTaskCreationDay` to yesterday via a synchronous `store.dispatch()`, then immediately calls `addAllDueToday()`. NgRx updates the store state synchronously, but the async context means `selectAllUnprocessedTaskRepeatCfgs` can still observe the stale future `lastTaskCreationDay` (the old anchor) when `getAllUnprocessedRepeatableTasks$` is read in the next microtask. Result: 0 configs returned → no task created.

**Bug 2 — `taskAlreadyExists` path skipped `lastTaskCreationDay` update.**
When a concurrent `addAllDueToday()` call (e.g. from `createRepeatableTasksAndAddDueToday$` on app init) had already created the task, `_getActionsForTaskRepeatCfg` returned `[]` without dispatching `updateTaskRepeatCfg`. This left `lastTaskCreationDay` at yesterday, so `selectTaskRepeatCfgsForExactDay` kept returning the config for today → the transparent projection persisted alongside the real task.

## Solution

**Fix 1 (`add-tasks-for-tomorrow.service.ts`):** Yield to the event loop with `await new Promise(r => setTimeout(r, 0))` before reading the store in `addAllDueToday()`. This ensures the re-anchor state is visible before the selector is evaluated. The pattern mirrors the existing yield already used later in the same function and in `OperationApplierService`.

**Fix 2 (`task-repeat-cfg.service.ts`):** When `taskAlreadyExists`, still dispatch `updateTaskRepeatCfg({ lastTaskCreationDay: targetDateStr })` to advance the anchor and suppress the transparent projection. No new task is created — only the watermark is moved forward.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Tests

- **Unit tests (65/65):** 7 existing tests updated to reflect the new `taskAlreadyExists` behaviour (returns `[updateTaskRepeatCfg]` instead of `[]`); 2 new regression tests added.
- **E2e test:** `recurring-startdate-to-today-creates-real-instance-bug-7923.spec.ts` reproduces the exact repro steps from the issue (fixed clock, delete live instance, change startDate to today via transparent projection) and asserts that a real task appears in the Today view with no residual transparent projection.
