### PR TITLE
fix(tasks): normalize HH:MM:SS time input (#7802)

### DIFF
--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.invalid-time.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.invalid-time.spec.ts
@@ -135,12 +135,40 @@ describe('DialogScheduleTaskComponent — malformed selectedTime', () => {
     expect(component.plannedTimestamp()).toBeNull();
   });
 
-  // --- repro for #7802 (currently FAILING) ---
+  // --- repro for #7802 ---
 
-  // After the fix, reading plannedTimestamp() with a malformed time must not
-  // throw "Invalid clock string". Returning null is the natural fallback —
-  // scheduleWarnings already treats null as "no warnings".
-  ['13:30:00', '25:00', '13:60', 'abc', '12'].forEach((badTime) => {
+  // A stray seconds component (`13:30:00`, which macOS Chrome produces from
+  // <input type="time"> even with step="60") is recoverable: it must normalize
+  // to `13:30` and schedule, not be dropped. See the dedicated tests below.
+  it('plannedTimestamp normalizes a "13:30:00" time and returns a number', () => {
+    const component = createComponent();
+    component.selectedDate = new Date(2026, 4, 26);
+    component.selectedTime = '13:30:00';
+
+    const ts = component.plannedTimestamp();
+    expect(typeof ts).toBe('number');
+    const d = new Date(ts as number);
+    expect(d.getHours()).toBe(13);
+    expect(d.getMinutes()).toBe(30);
+  });
+
+  it('submit() schedules with the normalized time for "13:30:00"', async () => {
+    const component = createComponent();
+    component.selectedDate = new Date(2026, 4, 26);
+    component.selectedTime = '13:30:00';
+
+    await component.submit();
+
+    expect(taskServiceSpy.scheduleTask).toHaveBeenCalled();
+    const scheduledTs = taskServiceSpy.scheduleTask.calls.mostRecent().args[1] as number;
+    const d = new Date(scheduledTs);
+    expect(d.getHours()).toBe(13);
+    expect(d.getMinutes()).toBe(30);
+  });
+
+  // Genuinely malformed values still fail validation after normalization and
+  // must not throw "Invalid clock string" — they fall back to null / day-only.
+  ['25:00', '13:60', 'abc', '12'].forEach((badTime) => {
     it(`plannedTimestamp does NOT throw for malformed selectedTime "${badTime}"`, () => {
       const component = createComponent();
       component.selectedDate = new Date(2026, 4, 26);

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -39,6 +39,7 @@ import { TaskService } from '../../tasks/task.service';
 import { ReminderService } from '../../reminder/reminder.service';
 import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
 import { isValidSplitTime } from '../../../util/is-valid-split-time';
+import { normalizeClockStr } from '../../../util/normalize-clock-str';
 import { fadeAnimation } from '../../../ui/animations/fade.ani';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { DateAdapter, MatOption } from '@angular/material/core';
@@ -161,17 +162,25 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     this._selectedTime.set(value);
   }
 
+  // A `<input type="time">` can yield `HH:MM:SS` (macOS Chrome renders a seconds
+  // segment even with step="60"); recover it to `HH:MM` so the time the user set
+  // survives validation instead of being dropped or crashing the guard (#7802).
+  private _normalizedTime = computed<string | null>(() => {
+    const t = this._selectedTime();
+    return t ? normalizeClockStr(t) : null;
+  });
+
   plannedTimestamp = computed<number | null>(() => {
     const selectedDate = this._selectedDate();
-    const selectedTime = this._selectedTime();
-    // Malformed values (e.g. `HH:MM:SS` pasted into <input type="time">, out-of-range
-    // `25:00`, garbage) would otherwise crash getDateTimeFromClockString and bubble
-    // "Invalid clock string" to the global error handler via scheduleWarnings (#7802).
-    if (!selectedDate || !selectedTime || !isValidSplitTime(selectedTime)) {
+    const normalizedTime = this._normalizedTime();
+    // Out-of-range (`25:00`) or garbage values still fail validation here and
+    // would otherwise crash getDateTimeFromClockString and bubble "Invalid clock
+    // string" to the global error handler via scheduleWarnings (#7802).
+    if (!selectedDate || !normalizedTime || !isValidSplitTime(normalizedTime)) {
       return null;
     }
 
-    return getDateTimeFromClockString(selectedTime, selectedDate as Date);
+    return getDateTimeFromClockString(normalizedTime, selectedDate as Date);
   });
   scheduleWarnings = computed(() => {
     const plannedTimestamp = this.plannedTimestamp();
@@ -421,7 +430,7 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     if (this.data.isSelectDueOnly) {
       this.close({
         date: this.selectedDate as Date,
-        time: this.selectedTime,
+        time: this._normalizedTime(),
         remindOption: this.selectedReminderCfgId,
       });
       return;
@@ -432,9 +441,10 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
 
     this._handleReminderRemoval();
 
-    // Treat malformed time the same as "no time": fall through to day-only planning
-    // rather than crashing in _scheduleWithTime (#7802).
-    const hasValidTime = !!this.selectedTime && isValidSplitTime(this.selectedTime);
+    // Treat genuinely malformed time the same as "no time": fall through to
+    // day-only planning rather than crashing in _scheduleWithTime (#7802).
+    const normalizedTime = this._normalizedTime();
+    const hasValidTime = !!normalizedTime && isValidSplitTime(normalizedTime);
 
     if (hasValidTime) {
       this._scheduleWithTime();
@@ -483,13 +493,14 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
   private _scheduleWithTime(): void {
     // Only schedule if task is provided and time is valid (submit() pre-validates;
     // belt-and-braces guard against direct callers / malformed paste — see #7802).
-    if (!this.data.task || !isValidSplitTime(this.selectedTime ?? undefined)) {
+    const normalizedTime = this._normalizedTime();
+    if (!this.data.task || !normalizedTime || !isValidSplitTime(normalizedTime)) {
       return;
     }
 
     const task = this.data.task;
     const newDate = new Date(
-      getDateTimeFromClockString(this.selectedTime as string, this.selectedDate as Date),
+      getDateTimeFromClockString(normalizedTime, this.selectedDate as Date),
     );
     this._taskService.scheduleTask(
       task,

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
@@ -360,6 +360,44 @@ describe('AddTaskBarActionsComponent', () => {
       expect(result).toContain(expectedLocaleTime('10:00', 'en-US'));
     });
 
+    // Repro for #7802 — a malformed time string in state crashed change
+    // detection via the "Invalid clock string" guard in _formatTimeForDisplay.
+    it('does NOT throw and shows the normalized time for a "13:30:00" state.time', () => {
+      const today = mockDateService.todayStr();
+      (mockStateService as any)._mockStateSignal.set({
+        ...mockState,
+        date: today,
+        time: '13:30:00',
+      });
+
+      expect(() => component.dateDisplay()).not.toThrow();
+      expect(component.dateDisplay()).toBe(expectedLocaleTime('13:30', 'en-US'));
+    });
+
+    it('does NOT throw for genuinely invalid state.time', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 4);
+      (mockStateService as any)._mockStateSignal.set({
+        ...mockState,
+        date: getDbDateStr(futureDate),
+        time: 'abc',
+      });
+
+      expect(() => component.dateDisplay()).not.toThrow();
+    });
+
+    it('does NOT throw and shows the normalized time for a "13:30:00" deadlineTime', () => {
+      const today = mockDateService.todayStr();
+      (mockStateService as any)._mockStateSignal.set({
+        ...mockState,
+        deadlineDate: today,
+        deadlineTime: '13:30:00',
+      });
+
+      expect(() => component.deadlineDateDisplay()).not.toThrow();
+      expect(component.deadlineDateDisplay()).toBe(expectedLocaleTime('13:30', 'en-US'));
+    });
+
     it('should handle auto-detected state correctly', () => {
       (mockStateService as any)._mockAutoDetectedSignal.set(true);
       const stateWithProject = {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
@@ -28,6 +28,8 @@ import { T } from '../../../../t.const';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { dateStrToUtcDate } from '../../../../util/date-str-to-utc-date';
 import { getDateTimeFromClockString } from '../../../../util/get-date-time-from-clock-string';
+import { isValidSplitTime } from '../../../../util/is-valid-split-time';
+import { normalizeClockStr } from '../../../../util/normalize-clock-str';
 import { getDbDateStr } from '../../../../util/get-db-date-str';
 import { isSingleEmoji } from '../../../../util/extract-first-emoji';
 import { DEFAULT_PROJECT_ICON } from '../../../project/project.const';
@@ -158,8 +160,15 @@ export class AddTaskBarActionsComponent {
   });
 
   private _formatTimeForDisplay(timeStr: string): string {
+    // Never let a malformed time crash change detection via the "Invalid clock
+    // string" guard (#7802). Recover a stray seconds component, then fall back
+    // to the raw string for genuinely invalid values rather than throwing.
+    const normalized = normalizeClockStr(timeStr);
+    if (!isValidSplitTime(normalized)) {
+      return timeStr;
+    }
     return this._dateTimeFormatService.formatTime(
-      getDateTimeFromClockString(timeStr, new Date()),
+      getDateTimeFromClockString(normalized, new Date()),
     );
   }
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts
@@ -82,6 +82,16 @@ describe('AddTaskBarStateService', () => {
       expect(service.state().time).toBe('09:00');
     });
 
+    // #7802 — a stray seconds component must be normalized on entry so the time
+    // survives validation at task creation instead of being dropped.
+    it('should normalize a "13:30:00" time to "13:30"', () => {
+      const testDate = new Date('2024-01-15');
+
+      service.updateDate(getDbDateStr(testDate), '13:30:00');
+
+      expect(service.state().time).toBe('13:30');
+    });
+
     it('should clear time when explicitly set to null', () => {
       service.updateTime('09:00');
       const testDate = new Date('2024-01-15');
@@ -117,6 +127,27 @@ describe('AddTaskBarStateService', () => {
       service.updateTime(null);
 
       expect(service.state().time).toBe(null);
+    });
+
+    it('should normalize a "13:30:00" time to "13:30" (#7802)', () => {
+      service.updateTime('13:30:00');
+
+      expect(service.state().time).toBe('13:30');
+    });
+  });
+
+  describe('updateDeadline', () => {
+    it('should update deadline date and time when both provided', () => {
+      service.updateDeadline('2024-01-15', '10:30');
+
+      expect(service.state().deadlineDate).toBe('2024-01-15');
+      expect(service.state().deadlineTime).toBe('10:30');
+    });
+
+    it('should normalize a "13:30:00" deadline time to "13:30" (#7802)', () => {
+      service.updateDeadline('2024-01-15', '13:30:00');
+
+      expect(service.state().deadlineTime).toBe('13:30');
     });
   });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -6,6 +6,7 @@ import { SS } from '../../../core/persistence/storage-keys.const';
 import { TimeSpentOnDay, TaskReminderOptionId } from '../task.model';
 import { TaskAttachment } from '../task-attachment/task-attachment.model';
 import { RepeatQuickSetting } from '../../task-repeat-cfg/task-repeat-cfg.model';
+import { normalizeClockStr } from '../../../util/normalize-clock-str';
 
 @Injectable()
 export class AddTaskBarStateService {
@@ -34,12 +35,12 @@ export class AddTaskBarStateService {
     this._taskInputState.update((state) => ({
       ...state,
       date,
-      time: time !== undefined ? time : state.time,
+      time: time !== undefined ? this._normTime(time) : state.time,
     }));
   }
 
   updateTime(time: string | null): void {
-    this._taskInputState.update((state) => ({ ...state, time }));
+    this._taskInputState.update((state) => ({ ...state, time: this._normTime(time) }));
   }
 
   updateSpent(spent: TimeSpentOnDay | null): void {
@@ -138,8 +139,16 @@ export class AddTaskBarStateService {
     this._taskInputState.update((state) => ({
       ...state,
       deadlineDate,
-      deadlineTime: deadlineTime !== undefined ? deadlineTime : state.deadlineTime,
+      deadlineTime:
+        deadlineTime !== undefined ? this._normTime(deadlineTime) : state.deadlineTime,
     }));
+  }
+
+  // Recover a stray seconds component (e.g. a pasted `13:30:00`) so a time the
+  // user intended survives validation at task creation instead of being dropped
+  // to a date-only due/deadline (#7802). Empty/null values pass through.
+  private _normTime(time: string | null): string | null {
+    return time ? normalizeClockStr(time) : time;
   }
 
   updateDeadlineRemindOption(deadlineRemindOption: TaskReminderOptionId | null): void {

--- a/src/app/features/tasks/dialog-deadline/dialog-deadline.component.spec.ts
+++ b/src/app/features/tasks/dialog-deadline/dialog-deadline.component.spec.ts
@@ -119,12 +119,14 @@ describe('DialogDeadlineComponent.submit() input validation', () => {
     expect(calls[0].autoPlanToday).toBe('2026-05-06');
   });
 
-  // Currently FAILS — proves issue #7490. After the fix, submit() must not
-  // throw on a malformed selectedTime and must fall back to a date-only deadline.
+  // Proves issue #7490. submit() must not throw on a malformed selectedTime and
+  // must fall back to a date-only deadline for genuinely invalid values.
   // Note: '1:' is intentionally NOT in this list — isValidSplitTime parses it
   // as 1:00 (split[1] is '', +'' === 0), so it never throws. That's arguably a
   // separate UX issue but not the crash this test pins.
-  ['13:30:00', 'abc', '13:60', '25:00'].forEach((badTime) => {
+  // '13:30:00' is also NOT here — a stray seconds component is recoverable and
+  // must persist (see the test below); only true garbage drops the time.
+  ['abc', '13:60', '25:00'].forEach((badTime) => {
     it(`does NOT throw and falls back to deadlineDay for malformed selectedTime "${badTime}"`, () => {
       const component = createComponent();
       component.selectedDate = new Date(2026, 4, 6);
@@ -137,6 +139,25 @@ describe('DialogDeadlineComponent.submit() input validation', () => {
       expect(calls[0].deadlineDay).toBe('2026-05-06');
       expect(calls[0].deadlineWithTime).toBeUndefined();
     });
+  });
+
+  // Repro for #7802 — a user-set time was silently dropped instead of saved.
+  // A stray seconds component (e.g. `13:30:00` pasted into the time input) must
+  // be normalized to `13:30` and persisted as deadlineWithTime, not discarded.
+  it('persists a normalized deadlineWithTime for a "13:30:00" selectedTime', () => {
+    const component = createComponent();
+    component.selectedDate = new Date(2026, 4, 6);
+    component.selectedTime = '13:30:00';
+
+    expect(() => component.submit()).not.toThrow();
+
+    const calls = setDeadlineCalls();
+    expect(calls.length).toBe(1);
+    expect(calls[0].deadlineDay).toBeUndefined();
+    expect(calls[0].deadlineWithTime).toBeDefined();
+    const d = new Date(calls[0].deadlineWithTime as number);
+    expect(d.getHours()).toBe(13);
+    expect(d.getMinutes()).toBe(30);
   });
 
   it('does nothing (no dispatch) when no date is selected', () => {

--- a/src/app/features/tasks/dialog-deadline/dialog-deadline.component.ts
+++ b/src/app/features/tasks/dialog-deadline/dialog-deadline.component.ts
@@ -28,6 +28,7 @@ import { fadeAnimation } from '../../../ui/animations/fade.ani';
 import { getClockStringFromHours } from '../../../util/get-clock-string-from-hours';
 import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
 import { isValidSplitTime } from '../../../util/is-valid-split-time';
+import { normalizeClockStr } from '../../../util/normalize-clock-str';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { DateService } from '../../../core/date/date.service';
@@ -257,21 +258,23 @@ export class DialogDeadlineComponent implements AfterViewInit {
       return;
     }
 
+    // Recover a stray seconds component (e.g. a pasted `13:30:00`) so the time
+    // the user set actually persists instead of silently dropping to a
+    // date-only deadline (#7802). Genuine garbage still fails the guard below.
+    const time = this.selectedTime ? normalizeClockStr(this.selectedTime) : null;
+
     if (this.data.isSelectDeadlineOnly) {
       this._matDialogRef.close({
         date: this.selectedDate,
-        time: this.selectedTime,
+        time,
         remindOption: this.selectedReminderCfgId,
       });
       return;
     }
 
     if (this.task) {
-      if (this.selectedTime && isValidSplitTime(this.selectedTime)) {
-        const deadlineTimestamp = getDateTimeFromClockString(
-          this.selectedTime,
-          this.selectedDate!,
-        );
+      if (time && isValidSplitTime(time)) {
+        const deadlineTimestamp = getDateTimeFromClockString(time, this.selectedDate!);
         const deadlineRemindAt =
           this.selectedReminderCfgId !== TaskReminderOptionId.DoNotRemind
             ? remindOptionToMilliseconds(deadlineTimestamp, this.selectedReminderCfgId)

--- a/src/app/util/normalize-clock-str.spec.ts
+++ b/src/app/util/normalize-clock-str.spec.ts
@@ -1,0 +1,32 @@
+import { normalizeClockStr } from './normalize-clock-str';
+import { isValidSplitTime } from './is-valid-split-time';
+
+describe('normalizeClockStr', () => {
+  it('leaves a canonical HH:MM untouched', () => {
+    expect(normalizeClockStr('14:30')).toBe('14:30');
+    expect(normalizeClockStr('09:00')).toBe('09:00');
+  });
+
+  it('drops a trailing seconds component (the #7802 recovery case)', () => {
+    expect(normalizeClockStr('13:30:00')).toBe('13:30');
+    expect(normalizeClockStr('13:30:45')).toBe('13:30');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeClockStr('  14:30  ')).toBe('14:30');
+    expect(normalizeClockStr('14:30:00 ')).toBe('14:30');
+  });
+
+  it('makes a recovered seconds value pass isValidSplitTime', () => {
+    expect(isValidSplitTime('13:30:00')).toBe(false);
+    expect(isValidSplitTime(normalizeClockStr('13:30:00'))).toBe(true);
+  });
+
+  it('does NOT invent a valid time from genuine garbage', () => {
+    // out-of-range / non-numeric / incomplete values stay invalid after
+    // normalization — recovery only strips a stray seconds component
+    ['abc', '25:00', '13:60', '12'].forEach((bad) => {
+      expect(isValidSplitTime(normalizeClockStr(bad))).toBe(false);
+    });
+  });
+});

--- a/src/app/util/normalize-clock-str.ts
+++ b/src/app/util/normalize-clock-str.ts
@@ -1,0 +1,15 @@
+/**
+ * Best-effort normalization of a clock string toward the canonical `HH:MM`
+ * that isValidSplitTime / getDateTimeFromClockString expect.
+ *
+ * Trims surrounding whitespace and drops a trailing seconds segment, so a value
+ * like `13:30:00` (e.g. pasted into an `<input type="time">`) becomes `13:30`
+ * and survives validation instead of being silently dropped or crashing the
+ * "Invalid clock string" guard (#7802).
+ *
+ * Genuinely malformed input (`abc`, `25:00`, `13:60`, `12`) is returned trimmed
+ * and still fails isValidSplitTime — normalization only recovers a stray
+ * seconds component, it never invents a valid time.
+ */
+export const normalizeClockStr = (v: string): string =>
+  v.trim().split(':').slice(0, 2).join(':');


### PR DESCRIPTION
## Problem

Reported in #7802: on macOS Chrome, setting a task **due/deadline time** either crashed with `Invalid clock string` or silently dropped the time — the *default* time persisted, but a *user-set* time did not.

## Root cause

macOS Chrome renders a **seconds segment** for `<input type="time">` even with `step="60"`, so the value the user enters is `HH:MM:SS`. Verified against Chromium 148: a `HH:MM:SS` value is kept verbatim — `step="60"` does **not** strip it. That value fails `isValidSplitTime` (length 8 > 5), which:

- crashes the add-task-bar due/deadline display via the "Invalid clock string" guard in `_formatTimeForDisplay` (matches the reporter's stack trace), and
- is silently saved as a **date-only** due/deadline, losing the time.

The default time persists only because it is set programmatically (`"09:00"`) and never re-read from the input; an edited time flows back through `ngModel` and carries the seconds.

## Fix

Add `normalizeClockStr` (trim + drop a stray seconds component) and apply it at every boundary where a raw input value crosses into app logic:

- add-task-bar display guard + state setters (`updateDate` / `updateTime` / `updateDeadline`)
- deadline dialog `submit()` (+ select-deadline-only return)
- schedule dialog (`plannedTimestamp` / `submit` / `_scheduleWithTime` / select-due return)

Genuinely invalid values (`25:00`, `13:60`, `abc`, `12`) still fail validation and fall back to date-only, unchanged.

## Tests

- new `normalize-clock-str.spec.ts`
- add-task-bar-actions: display no longer throws and shows the normalized time
- add-task-bar-state.service: normalization on entry (incl. `updateDeadline`)
- deadline + schedule specs: `13:30:00` now persists the normalized time (moved out of the "drops to day-only" sets)

200 affected unit tests pass; `checkFile` clean on all 10 files.

## Known limitation

The seconds *segment* still renders visually on macOS (browser-native control; not controllable from JS reliably). The stored value is now correct.