### PR TITLE
fix(schedule): stop recurring tasks duplicating on future days (#7853)

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
+++ b/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
@@ -154,10 +154,24 @@ export const createScheduleDays = (
       (task) => !isDayAssignedTask(task),
     );
 
+    // Suppress an untimed repeat projection on a day that already has a concrete
+    // instance of the same cfg — otherwise the schedule shows the real task AND
+    // its projection (#7853). This is the untimed counterpart of the guard in
+    // create-sorted-blocker-blocks.ts for timed projections; the projection is a
+    // placeholder for "an instance will exist", so it is redundant once one does.
+    const concreteRepeatCfgIdsForDay = new Set(
+      flowTasksForDay.map((task) => task.repeatCfgId).filter((id): id is string => !!id),
+    );
+    const repeatCfgsToProjectForDay = concreteRepeatCfgIdsForDay.size
+      ? nonScheduledRepeatCfgsDueOnDay.filter(
+          (cfg) => !concreteRepeatCfgIdsForDay.has(cfg.id),
+        )
+      : nonScheduledRepeatCfgsDueOnDay;
+
     viewEntries = createViewEntriesForDay(
       dayDate,
       startTime,
-      nonScheduledRepeatCfgsDueOnDay,
+      repeatCfgsToProjectForDay,
       within,
       blockerBlocksForDay,
       viewEntriesPushedToNextDay,

--- a/src/app/features/schedule/map-schedule-data/create-sorted-blocker-blocks.ts
+++ b/src/app/features/schedule/map-schedule-data/create-sorted-blocker-blocks.ts
@@ -14,6 +14,7 @@ import {
 } from '../schedule.model';
 import { selectTaskRepeatCfgsForExactDay } from '../../task-repeat-cfg/store/task-repeat-cfg.selectors';
 import { isSameDay } from '../../../util/is-same-day';
+import { getDbDateStr } from '../../../util/get-db-date-str';
 const PROJECTION_DAYS: number = 30;
 
 export const createSortedBlockerBlocks = (
@@ -36,6 +37,7 @@ export const createSortedBlockerBlocks = (
       now,
       nrOfDays,
       scheduledTaskRepeatCfgs,
+      scheduledTasks,
       realNow,
     ),
     ...createBlockerBlocksForWorkStartEnd(now, nrOfDays, workStartEndCfg),
@@ -61,9 +63,23 @@ const createBlockerBlocksForScheduledRepeatProjections = (
   now: number,
   nrOfDays: number,
   scheduledTaskRepeatCfgs: TaskRepeatCfg[],
+  scheduledTasks: TaskWithDueTime[],
   realNow?: number,
 ): BlockedBlock[] => {
   const blockedBlocks: BlockedBlock[] = [];
+  // Days that already have a concrete (timed) instance of a repeat cfg, keyed
+  // by `${repeatCfgId}|${dayStr}`. Such days must not also render a projection
+  // for the same cfg, or the schedule shows the real task AND its projection
+  // (#7853). The today-skip below (i starts at 1) only ever covered today;
+  // future-dated instances slipped through whenever the cfg's
+  // lastTaskCreationDay lagged behind the instance's day.
+  const concreteInstanceDays = new Set<string>();
+  scheduledTasks.forEach((task) => {
+    if (task.repeatCfgId) {
+      concreteInstanceDays.add(`${task.repeatCfgId}|${getDbDateStr(task.dueWithTime)}`);
+    }
+  });
+
   const isViewingCurrentDay = realNow === undefined || isSameDay(realNow, now);
   let i: number = isViewingCurrentDay ? 1 : 0;
   while (i < nrOfDays) {
@@ -73,6 +89,7 @@ const createBlockerBlocksForScheduledRepeatProjections = (
     targetDate.setDate(nowDate.getDate() + i);
     targetDate.setHours(0, 0, 0, 0);
     const currentDayTimestamp = targetDate.getTime();
+    const currentDayStr = getDbDateStr(currentDayTimestamp);
 
     const allRepeatableTasksForDay = selectTaskRepeatCfgsForExactDay.projector(
       scheduledTaskRepeatCfgs,
@@ -83,6 +100,9 @@ const createBlockerBlocksForScheduledRepeatProjections = (
     i++;
 
     allRepeatableTasksForDay.forEach((repeatCfg) => {
+      if (concreteInstanceDays.has(`${repeatCfg.id}|${currentDayStr}`)) {
+        return;
+      }
       if (!repeatCfg.startTime || !isValidSplitTime(repeatCfg.startTime)) {
         devError('Timeline: Invalid or missing startTime for repeat projection');
         return;

--- a/src/app/features/schedule/map-schedule-data/scheduled-repeat-projection-dedup.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/scheduled-repeat-projection-dedup.spec.ts
@@ -5,7 +5,6 @@ import { getDbDateStr } from '../../../util/get-db-date-str';
 import { SVEType } from '../schedule.const';
 
 const H = 60 * 60 * 1000;
-const DAY = 24 * H;
 
 const fakeTask = (id: string, add?: Partial<TaskCopy>): TaskCopy =>
   ({
@@ -55,19 +54,17 @@ const fakeCfg = (id: string, add?: Partial<TaskRepeatCfg>): TaskRepeatCfg =>
  * `lastTaskCreationDay` anchor happens to sit.
  */
 describe('scheduled repeat projection dedup (#7853)', () => {
-  const todayMidnight = new Date();
-  todayMidnight.setHours(0, 0, 0, 0);
-  const now = todayMidnight.getTime();
-
-  const addDays = (ts: number, days: number): number => {
-    const offset = days * DAY;
-    return ts + offset;
-  };
-  const futureDayTs = addDays(now, 3);
-  const futureDayStr = getDbDateStr(futureDayTs);
-  const tenHours = 10 * H;
-  const futureAt10 = futureDayTs + tenHours;
-  const dayDates = Array.from({ length: 5 }, (_, i) => getDbDateStr(addDays(now, i)));
+  // Fixed calendar dates (Wed Jun 3 2026 → Sun Jun 7 2026) so day strings are
+  // deterministic regardless of when CI runs. Build days via the (y, m, d+i)
+  // constructor — NOT fixed-millisecond arithmetic — so a DST boundary on the
+  // run day can never collapse or skip a day in the sequence.
+  const dayTs = (offset: number, hour = 0): number =>
+    new Date(2026, 5, 3 + offset, hour, 0, 0, 0).getTime();
+  const now = dayTs(0);
+  const futureOffset = 3;
+  const futureDayStr = getDbDateStr(dayTs(futureOffset));
+  const futureAt10 = dayTs(futureOffset, 10);
+  const dayDates = Array.from({ length: 5 }, (_, i) => getDbDateStr(dayTs(i)));
 
   const entryCountForFutureDay = (lastTaskCreationDay: string): number => {
     const task = fakePlanned('T1', futureAt10, { repeatCfgId: 'R1', timeEstimate: H });
@@ -100,7 +97,7 @@ describe('scheduled repeat projection dedup (#7853)', () => {
   });
 
   it('does not duplicate when the anchor lags behind by one day', () => {
-    expect(entryCountForFutureDay(getDbDateStr(addDays(futureDayTs, -1)))).toBe(1);
+    expect(entryCountForFutureDay(getDbDateStr(dayTs(futureOffset - 1)))).toBe(1);
   });
 
   // Mirrors the exact repro from discussion #7853 (Exhibit 1 video): on a
@@ -156,8 +153,7 @@ describe('scheduled repeat projection dedup (#7853)', () => {
       const day = days.find((d) => d.dayDate === sunStr);
       return (day?.entries ?? []).map((e) => ({
         type: e.type,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        id: (e.data as any)?.id,
+        id: (e.data as TaskCopy)?.id,
       }));
     };
 
@@ -166,6 +162,56 @@ describe('scheduled repeat projection dedup (#7853)', () => {
       expect(entries.length).toBe(1);
       expect(entries[0].type).toBe(SVEType.ScheduledTask);
       expect(entries[0].id).toBe('GYM');
+    });
+  });
+
+  // The untimed projection path (create-schedule-days.ts) is structurally
+  // identical to the timed one and duplicates the same way when the anchor lags.
+  // It is not reachable via the reporter's flow (the Planner workaround keeps the
+  // anchor aligned), but the render-layer guard is symmetric defense-in-depth.
+  describe('untimed (all-day) repeat projection dedup', () => {
+    const wed = new Date(2026, 5, 3, 0, 0, 0, 0).getTime();
+    const futureStr = getDbDateStr(new Date(2026, 5, 6, 0, 0, 0, 0).getTime());
+    const week = Array.from({ length: 5 }, (_, i) =>
+      getDbDateStr(new Date(2026, 5, 3 + i, 0, 0, 0, 0).getTime()),
+    );
+
+    const futureEntries = (): { type: SVEType; id: string }[] => {
+      // Concrete untimed instance carries dueDay (no dueWithTime) + repeatCfgId.
+      const task = fakeTask('U1', { dueDay: futureStr, repeatCfgId: 'UCFG' });
+      // Untimed cfg: no startTime → unScheduledTaskRepeatCfgs; anchor lags to today.
+      const cfg = fakeCfg('UCFG', {
+        startTime: undefined,
+        startDate: futureStr,
+        lastTaskCreationDay: getDbDateStr(wed),
+      });
+
+      const days = mapToScheduleDays(
+        wed,
+        week,
+        [task],
+        [],
+        [],
+        [cfg],
+        [],
+        null,
+        {},
+        undefined,
+        undefined,
+        wed,
+      );
+      const day = days.find((d) => d.dayDate === futureStr);
+      return (day?.entries ?? []).map((e) => ({
+        type: e.type,
+        id: (e.data as TaskCopy)?.id,
+      }));
+    };
+
+    it('shows only the concrete instance, not the projection', () => {
+      const entries = futureEntries();
+      expect(entries.length).toBe(1);
+      expect(entries.some((e) => e.type === SVEType.RepeatProjection)).toBe(false);
+      expect(entries[0].id).toBe('U1');
     });
   });
 });

--- a/src/app/features/schedule/map-schedule-data/scheduled-repeat-projection-dedup.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/scheduled-repeat-projection-dedup.spec.ts
@@ -1,0 +1,104 @@
+import { mapToScheduleDays } from './map-to-schedule-days';
+import { TaskCopy, TaskWithDueTime } from '../../tasks/task.model';
+import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+
+const H = 60 * 60 * 1000;
+const DAY = 24 * H;
+
+const fakeTask = (id: string, add?: Partial<TaskCopy>): TaskCopy =>
+  ({
+    tagIds: [],
+    subTaskIds: [],
+    timeSpent: 0,
+    timeEstimate: H,
+    ...add,
+    id,
+  }) as TaskCopy;
+
+const fakePlanned = (
+  id: string,
+  dueWithTime: number,
+  add?: Partial<TaskWithDueTime>,
+): TaskWithDueTime =>
+  ({
+    ...fakeTask(id, add),
+    dueWithTime,
+    reminderId: 'R_ID',
+  }) as TaskWithDueTime;
+
+const fakeCfg = (id: string, add?: Partial<TaskRepeatCfg>): TaskRepeatCfg =>
+  ({
+    startTime: '10:00',
+    monday: true,
+    tuesday: true,
+    wednesday: true,
+    thursday: true,
+    friday: true,
+    saturday: true,
+    sunday: true,
+    repeatCycle: 'DAILY',
+    repeatEvery: 1,
+    defaultEstimate: H,
+    isPaused: false,
+    ...add,
+    id,
+  }) as Partial<TaskRepeatCfg> as TaskRepeatCfg;
+
+/**
+ * Regression for #7853: a timed recurring task scheduled for a future date
+ * showed up twice in the Schedule — once as the concrete `ScheduledTask`
+ * instance and once as the cfg's `ScheduledRepeatProjection`. The projection
+ * for a day must be suppressed when a concrete instance of the same repeat cfg
+ * is already scheduled on that day, regardless of where the cfg's
+ * `lastTaskCreationDay` anchor happens to sit.
+ */
+describe('scheduled repeat projection dedup (#7853)', () => {
+  const todayMidnight = new Date();
+  todayMidnight.setHours(0, 0, 0, 0);
+  const now = todayMidnight.getTime();
+
+  const addDays = (ts: number, days: number): number => {
+    const offset = days * DAY;
+    return ts + offset;
+  };
+  const futureDayTs = addDays(now, 3);
+  const futureDayStr = getDbDateStr(futureDayTs);
+  const tenHours = 10 * H;
+  const futureAt10 = futureDayTs + tenHours;
+  const dayDates = Array.from({ length: 5 }, (_, i) => getDbDateStr(addDays(now, i)));
+
+  const entryCountForFutureDay = (lastTaskCreationDay: string): number => {
+    const task = fakePlanned('T1', futureAt10, { repeatCfgId: 'R1', timeEstimate: H });
+    const cfg = fakeCfg('R1', { startDate: futureDayStr, lastTaskCreationDay });
+
+    const days = mapToScheduleDays(
+      now,
+      dayDates,
+      [],
+      [task],
+      [cfg],
+      [],
+      [],
+      null,
+      {},
+      undefined,
+      undefined,
+      now,
+    );
+    const day = days.find((d) => d.dayDate === futureDayStr);
+    return (day?.entries ?? []).length;
+  };
+
+  it('renders a single entry when the anchor matches the scheduled day', () => {
+    expect(entryCountForFutureDay(futureDayStr)).toBe(1);
+  });
+
+  it('does not duplicate when the anchor lags behind to today', () => {
+    expect(entryCountForFutureDay(getDbDateStr(now))).toBe(1);
+  });
+
+  it('does not duplicate when the anchor lags behind by one day', () => {
+    expect(entryCountForFutureDay(getDbDateStr(addDays(futureDayTs, -1)))).toBe(1);
+  });
+});

--- a/src/app/features/schedule/map-schedule-data/scheduled-repeat-projection-dedup.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/scheduled-repeat-projection-dedup.spec.ts
@@ -2,6 +2,7 @@ import { mapToScheduleDays } from './map-to-schedule-days';
 import { TaskCopy, TaskWithDueTime } from '../../tasks/task.model';
 import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
 import { getDbDateStr } from '../../../util/get-db-date-str';
+import { SVEType } from '../schedule.const';
 
 const H = 60 * 60 * 1000;
 const DAY = 24 * H;
@@ -100,5 +101,71 @@ describe('scheduled repeat projection dedup (#7853)', () => {
 
   it('does not duplicate when the anchor lags behind by one day', () => {
     expect(entryCountForFutureDay(getDbDateStr(addDays(futureDayTs, -1)))).toBe(1);
+  });
+
+  // Mirrors the exact repro from discussion #7853 (Exhibit 1 video): on a
+  // Wednesday, "Gym (Rest)" is scheduled for the upcoming Sunday at 06:00, then
+  // made into a "Every week on Sunday" recurring task. The Sunday column showed
+  // the 06:00 instance AND a repeat projection. With the cfg's default anchor
+  // (lastTaskCreationDay = creation day = the Wednesday) the projection is not
+  // suppressed by the anchor, so the concrete-instance guard must catch it.
+  describe('weekly-on-Sunday repro from the video', () => {
+    // Fixed dates matching the recording: Wed Jun 3 2026 → Sun Jun 7 2026.
+    const wed = new Date(2026, 5, 3, 0, 0, 0, 0).getTime();
+    const sunTs = new Date(2026, 5, 7, 0, 0, 0, 0).getTime();
+    const sunStr = getDbDateStr(sunTs);
+    const sunAt6 = new Date(2026, 5, 7, 6, 0, 0, 0).getTime();
+    const week = Array.from({ length: 5 }, (_, i) =>
+      getDbDateStr(new Date(2026, 5, 3 + i, 0, 0, 0, 0).getTime()),
+    );
+
+    const sundayEntries = (): { type: SVEType; id: string }[] => {
+      const task = fakePlanned('GYM', sunAt6, {
+        repeatCfgId: 'GYM_CFG',
+        timeEstimate: H,
+      });
+      const cfg = fakeCfg('GYM_CFG', {
+        startTime: '06:00',
+        repeatCycle: 'WEEKLY',
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: true,
+        startDate: sunStr,
+        // cfg keeps its creation-day anchor (the Wednesday), not the Sunday
+        lastTaskCreationDay: getDbDateStr(wed),
+      });
+
+      const days = mapToScheduleDays(
+        wed,
+        week,
+        [],
+        [task],
+        [cfg],
+        [],
+        [],
+        null,
+        {},
+        undefined,
+        undefined,
+        wed,
+      );
+      const day = days.find((d) => d.dayDate === sunStr);
+      return (day?.entries ?? []).map((e) => ({
+        type: e.type,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        id: (e.data as any)?.id,
+      }));
+    };
+
+    it('shows only the concrete instance on the recurring Sunday', () => {
+      const entries = sundayEntries();
+      expect(entries.length).toBe(1);
+      expect(entries[0].type).toBe(SVEType.ScheduledTask);
+      expect(entries[0].id).toBe('GYM');
+    });
   });
 });


### PR DESCRIPTION
## Problem

Discussion #7853: creating a recurring task **from the Schedule** duplicates it. A timed recurring task scheduled for a **future** date renders **twice** in the Schedule timeline — once as the concrete instance (alarm/clock icon) and once as the cfg's repeat projection (↻ icon). "Today" is unaffected; creating from the Planner (untimed) is the reporter's workaround.

Confirmed from the reporter's video: "Gym (Rest)" scheduled Sun Jun 7 06:00, then made *Every week on Sunday* → Sunday shows two "Gym (Rest)".

## Root cause

The Schedule draws a recurring task from two independent sources — the concrete `ScheduledTask`/`TaskPlannedForDay` instance, and the cfg's `RepeatProjection`. The projection is deduped **only** via the cfg's `lastTaskCreationDay` anchor. When that anchor lags behind the concrete instance's scheduled day (which the timed make-repeatable flow does), both render. The existing `i=1` "skip today" hack masked this for today only, never for future days.

## Fix

Suppress a repeat projection on any day that already has a concrete instance of the **same** repeat cfg — the projection is just a placeholder for "an instance will exist", so it's redundant once one does. Robust to whatever the anchor is.

Both structurally-identical projection paths are guarded:
- **Timed** — `create-sorted-blocker-blocks.ts` (keyed `${repeatCfgId}|${dueWithTime-day}`).
- **Untimed / all-day** — `create-schedule-days.ts` (filter `nonScheduledRepeatCfgsDueOnDay` against `flowTasksForDay` repeatCfgIds). Defense-in-depth; not reachable via the Planner flow, but the same class of bug.

## Testing

New regression spec `scheduled-repeat-projection-dedup.spec.ts` — anchor-lag cases, the weekly-on-Sunday video repro, and the untimed case. Each verified to **fail (2 entries) without its guard**. Fixtures use calendar date construction so they're DST-deterministic across the Berlin/LA suite runs.

All affected schedule specs green (121: dedup 5, create-schedule-days 18, create-sorted-blocker-blocks 34, map-to-schedule-days 13+1, map-schedule-days-to-schedule-events 8, schedule.service 42). Lint clean.

## Not in scope (follow-up)

The *upstream* reason `lastTaskCreationDay` lags in the timed make-repeatable flow is unverified and left as a follow-up. The render-layer guards fix the symptom regardless and stay correct even if the anchor is later corrected.

Refs #7853
