### PR TITLE
fix(metric): use worklog totals for activity heatmap

### DIFF
--- a/src/app/features/calendar-integration/calendar-integration.service.spec.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.spec.ts
@@ -3,6 +3,7 @@ import {
   fakeAsync,
   tick,
   discardPeriodicTasks,
+  flush,
   flushMicrotasks,
 } from '@angular/core/testing';
 import {
@@ -1076,7 +1077,10 @@ END:VCALENDAR`;
       const req = httpMock.expectOne(mockProvider.icalUrl);
       req.flush(MOCK_ICAL_DATA);
 
-      tick(0);
+      // flush() (not tick(0)) because requestEvents$ awaits loadIcalModule(),
+      // a dynamic import('ical.js') whose promise chain isn't guaranteed to
+      // resolve in a single microtask drain on first invocation.
+      flush();
       expect(result).toEqual([
         jasmine.objectContaining({
           id: 'test-event-1',
@@ -1096,7 +1100,7 @@ END:VCALENDAR`;
       });
       subscriptions.push(sub);
 
-      tick(0);
+      flush();
 
       // May or may not make request depending on IS_WEB_BROWSER
     }));
@@ -1112,7 +1116,7 @@ END:VCALENDAR`;
       const req = httpMock.expectOne(mockProvider.icalUrl);
       req.flush('INVALID ICAL DATA');
 
-      tick(0);
+      flush();
       // Should not throw, might return empty array or parsed result
     }));
 
@@ -1134,7 +1138,7 @@ END:VCALENDAR`;
           '</body></html>',
       );
 
-      tick(0);
+      flush();
       expect(result).toEqual([]);
       expect(mockSnackService.open).toHaveBeenCalledWith(
         jasmine.objectContaining({
@@ -1162,7 +1166,7 @@ END:VCALENDAR`;
       const req = httpMock.expectOne(mockProvider.icalUrl);
       req.flush('<html>not ical</html>');
 
-      tick(0);
+      flush();
       expect(mockSnackService.open).toHaveBeenCalledWith(
         jasmine.objectContaining({
           msg: 'F.CALENDARS.S.CAL_PROVIDER_NOT_ICAL',

--- a/src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts
+++ b/src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts
@@ -1,0 +1,144 @@
+import { ComponentFixture, TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { DateAdapter } from '@angular/material/core';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { SnackService } from '../../../core/snack/snack.service';
+import { ShareService } from '../../../core/share/share.service';
+import { Task } from '../../tasks/task.model';
+import { WorkContextService } from '../../work-context/work-context.service';
+import { Worklog, WorklogDataForDay } from '../../worklog/worklog.model';
+import { WorklogService } from '../../worklog/worklog.service';
+import { ActivityHeatmapComponent } from './activity-heatmap.component';
+
+describe('ActivityHeatmapComponent', () => {
+  let fixture: ComponentFixture<ActivityHeatmapComponent>;
+  let worklog$: BehaviorSubject<Worklog>;
+
+  const dayStr = '2026-06-03';
+  const year = 2026;
+  const month = 6;
+  const dayOfMonth = 3;
+  const workedMs = 60 * 60 * 1000;
+
+  const createTask = (id: string, overrides: Partial<Task> = {}): Task => ({
+    attachments: [],
+    created: new Date(dayStr).getTime(),
+    id,
+    isDone: false,
+    projectId: 'project',
+    subTaskIds: [],
+    tagIds: [],
+    timeEstimate: 0,
+    timeSpent: 0,
+    timeSpentOnDay: {},
+    title: id,
+    ...overrides,
+  });
+
+  const createWorklogEntry = (
+    task: Task,
+    overrides: Partial<WorklogDataForDay> = {},
+  ): WorklogDataForDay => ({
+    isNoRestore: false,
+    task,
+    timeSpent: workedMs,
+    ...overrides,
+  });
+
+  const createWorklogWithParentAndSubtask = (): Worklog => {
+    const parentTask = createTask('parent', {
+      subTaskIds: ['subtask'],
+      timeSpent: workedMs,
+      timeSpentOnDay: { [dayStr]: workedMs },
+    });
+    const subTask = createTask('subtask', {
+      parentId: parentTask.id,
+      timeSpent: workedMs,
+      timeSpentOnDay: { [dayStr]: workedMs },
+    });
+
+    return {
+      [year]: {
+        daysWorked: 1,
+        monthWorked: 1,
+        timeSpent: workedMs,
+        ent: {
+          [month]: {
+            daysWorked: 1,
+            ent: {
+              [dayOfMonth]: {
+                dateStr: dayStr,
+                dayStr: 'Wed 3.',
+                logEntries: [
+                  createWorklogEntry(parentTask),
+                  createWorklogEntry(subTask, { parentId: parentTask.id }),
+                ],
+                timeSpent: workedMs,
+                workEnd: 0,
+                workStart: 0,
+              },
+            },
+            timeSpent: workedMs,
+            weeks: [],
+          },
+        },
+      },
+    };
+  };
+
+  beforeEach(() => {
+    worklog$ = new BehaviorSubject<Worklog>({});
+
+    const worklogServiceSpy = jasmine.createSpyObj<WorklogService>('WorklogService', [], {
+      worklog$: worklog$.asObservable(),
+    });
+    const workContextServiceSpy = jasmine.createSpyObj<WorkContextService>(
+      'WorkContextService',
+      [],
+      {
+        activeWorkContextTitle$: of('Today'),
+      },
+    );
+    const snackServiceSpy = jasmine.createSpyObj<SnackService>('SnackService', ['open']);
+    const shareServiceSpy = jasmine.createSpyObj<ShareService>('ShareService', [
+      'canOpenDownloadResult',
+      'openDownloadResult',
+      'shareCanvasImage',
+    ]);
+
+    TestBed.configureTestingModule({
+      imports: [ActivityHeatmapComponent],
+      providers: [
+        { provide: DateAdapter, useValue: { getFirstDayOfWeek: () => 0 } },
+        { provide: SnackService, useValue: snackServiceSpy },
+        { provide: ShareService, useValue: shareServiceSpy },
+        { provide: WorkContextService, useValue: workContextServiceSpy },
+        { provide: WorklogService, useValue: worklogServiceSpy },
+      ],
+    }).overrideComponent(ActivityHeatmapComponent, {
+      set: {
+        imports: [],
+        template: '',
+      },
+    });
+
+    fixture = TestBed.createComponent(ActivityHeatmapComponent);
+  });
+
+  it('uses worklog day totals for Today heatmap time', fakeAsync(() => {
+    fixture.detectChanges();
+
+    worklog$.next(createWorklogWithParentAndSubtask());
+    flush();
+    fixture.detectChanges();
+
+    const dayData = fixture.componentInstance
+      .heatmapData()
+      ?.weeks.flatMap((week) => week.days)
+      .find((day) => day?.dateStr === dayStr);
+
+    expect(dayData?.timeSpent).toBe(workedMs);
+    expect(dayData?.taskCount).toBe(2);
+    expect(fixture.componentInstance.availableYears()).toEqual([year]);
+  }));
+});

--- a/src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts
+++ b/src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts
@@ -16,13 +16,15 @@ describe('ActivityHeatmapComponent', () => {
 
   const dayStr = '2026-06-03';
   const year = 2026;
-  const month = 6;
-  const dayOfMonth = 3;
   const workedMs = 60 * 60 * 1000;
 
-  const createTask = (id: string, overrides: Partial<Task> = {}): Task => ({
+  const createTask = (
+    id: string,
+    overrides: Partial<Task> = {},
+    taskDateStr = dayStr,
+  ): Task => ({
     attachments: [],
-    created: new Date(dayStr).getTime(),
+    created: new Date(taskDateStr).getTime(),
     id,
     isDone: false,
     projectId: 'project',
@@ -45,29 +47,40 @@ describe('ActivityHeatmapComponent', () => {
     ...overrides,
   });
 
-  const createWorklogWithParentAndSubtask = (): Worklog => {
-    const parentTask = createTask('parent', {
-      subTaskIds: ['subtask'],
-      timeSpent: workedMs,
-      timeSpentOnDay: { [dayStr]: workedMs },
-    });
-    const subTask = createTask('subtask', {
-      parentId: parentTask.id,
-      timeSpent: workedMs,
-      timeSpentOnDay: { [dayStr]: workedMs },
-    });
+  const createWorklogWithParentAndSubtask = (worklogDayStr = dayStr): Worklog => {
+    const [worklogYear, worklogMonth, worklogDayOfMonth] = worklogDayStr
+      .split('-')
+      .map(Number);
+    const parentTask = createTask(
+      'parent',
+      {
+        subTaskIds: ['subtask'],
+        timeSpent: workedMs,
+        timeSpentOnDay: { [worklogDayStr]: workedMs },
+      },
+      worklogDayStr,
+    );
+    const subTask = createTask(
+      'subtask',
+      {
+        parentId: parentTask.id,
+        timeSpent: workedMs,
+        timeSpentOnDay: { [worklogDayStr]: workedMs },
+      },
+      worklogDayStr,
+    );
 
     return {
-      [year]: {
+      [worklogYear]: {
         daysWorked: 1,
         monthWorked: 1,
         timeSpent: workedMs,
         ent: {
-          [month]: {
+          [worklogMonth]: {
             daysWorked: 1,
             ent: {
-              [dayOfMonth]: {
-                dateStr: dayStr,
+              [worklogDayOfMonth]: {
+                dateStr: worklogDayStr,
                 dayStr: 'Wed 3.',
                 logEntries: [
                   createWorklogEntry(parentTask),
@@ -140,5 +153,25 @@ describe('ActivityHeatmapComponent', () => {
     expect(dayData?.timeSpent).toBe(workedMs);
     expect(dayData?.taskCount).toBe(2);
     expect(fixture.componentInstance.availableYears()).toEqual([year]);
+  }));
+
+  it('uses recalculated selected year for the first worklog emission', fakeAsync(() => {
+    const previousYear = year - 1;
+    const previousYearDayStr = `${previousYear}-06-03`;
+
+    fixture.detectChanges();
+
+    worklog$.next(createWorklogWithParentAndSubtask(previousYearDayStr));
+
+    const dayData = fixture.componentInstance
+      .heatmapData()
+      ?.weeks.flatMap((week) => week.days)
+      .find((day) => day?.dateStr === previousYearDayStr);
+
+    expect(fixture.componentInstance.selectedYear()).toBe(previousYear);
+    expect(dayData?.timeSpent).toBe(workedMs);
+    expect(fixture.componentInstance.availableYears()).toEqual([previousYear]);
+
+    flush();
   }));
 });

--- a/src/app/features/metric/activity-heatmap/activity-heatmap.component.ts
+++ b/src/app/features/metric/activity-heatmap/activity-heatmap.component.ts
@@ -8,14 +8,9 @@ import {
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { WorklogService } from '../../worklog/worklog.service';
 import { WorkContextService } from '../../work-context/work-context.service';
-import { TaskService } from '../../tasks/task.service';
-import { TaskArchiveService } from '../../archive/task-archive.service';
-import { defer, from } from 'rxjs';
-import { combineLatestWith, first, map, switchMap, tap } from 'rxjs/operators';
+import { combineLatestWith, map, tap } from 'rxjs/operators';
 import { TranslatePipe } from '@ngx-translate/core';
 import { T } from '../../../t.const';
-import { TODAY_TAG } from '../../tag/tag.const';
-import { Task } from '../../tasks/task.model';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconButton } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
@@ -31,6 +26,7 @@ import {
   HeatmapComponent,
 } from '../../../ui/heatmap/heatmap.component';
 import { DateAdapter } from '@angular/material/core';
+import { Worklog } from '../../worklog/worklog.model';
 
 interface YearlyActivityData {
   dayMap: Map<string, DayData>;
@@ -56,8 +52,6 @@ interface YearlyActivityData {
 export class ActivityHeatmapComponent {
   private readonly _worklogService = inject(WorklogService);
   private readonly _workContextService = inject(WorkContextService);
-  private readonly _taskService = inject(TaskService);
-  private readonly _taskArchiveService = inject(TaskArchiveService);
   private readonly _snackService = inject(SnackService);
   private readonly _shareService = inject(ShareService);
   private readonly _dateAdapter = inject(DateAdapter);
@@ -94,40 +88,16 @@ export class ActivityHeatmapComponent {
 
   // Raw data signals
   private readonly _rawHeatmapData = toSignal(
-    this._workContextService.activeWorkContext$.pipe(
+    this._worklogService.worklog$.pipe(
       combineLatestWith(toObservable(this.selectedYear)),
-      switchMap(([context, userSelectedYear]) => {
-        // Special case: TODAY tag shows ALL data from all tasks
-        if (context.id === TODAY_TAG.id) {
-          return defer(() => from(this._loadAllTasks())).pipe(
-            tap((tasks) => {
-              // Only side effect: update available years
-              const yearsWithData = this._extractAvailableYears(tasks);
-              this.availableYears.set(yearsWithData);
-              // No selectedYear mutation here!
-            }),
-            map((tasks) => {
-              // Use computed selectedYear value
-              const currentlySelectedYear = this.selectedYear();
-              return this._buildHeatmapDataForGivenYear(tasks, currentlySelectedYear);
-            }),
-          );
-        }
-
-        // Normal case: use context-filtered worklog
-        return this._worklogService.worklog$.pipe(
-          tap((worklog) => {
-            // Only side effect: update available years
-            const yearsWithData = this._extractAvailableYearsFromWorklog(worklog);
-            this.availableYears.set(yearsWithData);
-            // No selectedYear mutation here!
-          }),
-          map((worklog) => {
-            // Use computed selectedYear value
-            const currentlySelectedYear = this.selectedYear();
-            return this._buildHeatmapDataFromWorklog(worklog, currentlySelectedYear);
-          }),
-        );
+      tap(([worklog]) => {
+        // Only side effect: update available years
+        const yearsWithData = this._extractAvailableYearsFromWorklog(worklog);
+        this.availableYears.set(yearsWithData);
+        // No selectedYear mutation here!
+      }),
+      map(([worklog, selectedYear]) => {
+        return this._buildHeatmapDataFromWorklog(worklog, selectedYear);
       }),
     ),
     { initialValue: null },
@@ -151,116 +121,10 @@ export class ActivityHeatmapComponent {
     );
   });
 
-  private async _loadAllTasks(): Promise<Task[]> {
-    // Load both current tasks and archived tasks
-    const [archive, currentTasks] = await Promise.all([
-      this._taskArchiveService.load(),
-      this._taskService.allTasks$.pipe(first()).toPromise(),
-    ]);
-
-    const allTasks: Task[] = [...(currentTasks || [])];
-
-    // Add archived tasks (archive is a single TaskArchive object with all tasks)
-    if (archive && archive.ids) {
-      archive.ids.forEach((taskId) => {
-        const archivedTask = archive.entities[taskId];
-        if (archivedTask) {
-          allTasks.push(archivedTask as Task);
-        }
-      });
-    }
-
-    return allTasks;
-  }
-
-  private _buildHeatmapDataForGivenYear(
-    tasks: Task[],
+  private _buildHeatmapDataFromWorklog(
+    worklog: Worklog,
     year: number,
   ): YearlyActivityData | null {
-    const dayMap = new Map<string, DayData>();
-    const startDate = new Date(year, 0, 1);
-    const endDate = new Date(year, 11, 31);
-
-    // Initialize all days in the specified year
-    const currentDate = new Date(startDate);
-    while (currentDate <= endDate) {
-      const dateStr = getDbDateStr(currentDate);
-      dayMap.set(dateStr, {
-        date: new Date(currentDate),
-        dateStr,
-        taskCount: 0,
-        timeSpent: 0,
-        level: 0,
-      });
-      currentDate.setDate(currentDate.getDate() + 1);
-    }
-
-    // Extract time spent data for the specific year
-    let maxTasks = 0;
-    let maxTime = 0;
-    const taskCountPerDay = new Map<string, Set<string>>();
-    tasks.forEach((task) => {
-      // Skip parent tasks — their timeSpentOnDay aggregates subtask time
-      if (task.subTaskIds && task.subTaskIds.length > 0) return;
-      if (task.timeSpentOnDay) {
-        Object.keys(task.timeSpentOnDay).forEach((dateStr) => {
-          const dateYear = parseInt(dateStr.substring(0, 4), 10);
-          if (dateYear !== year) return;
-          const timeSpent = task.timeSpentOnDay[dateStr];
-          const dayData = dayMap.get(dateStr);
-          if (dayData && timeSpent > 0) {
-            dayData.timeSpent += timeSpent;
-            maxTime = Math.max(maxTime, dayData.timeSpent);
-            // Track unique tasks per day
-            if (!taskCountPerDay.has(dateStr)) {
-              taskCountPerDay.set(dateStr, new Set());
-            }
-            taskCountPerDay.get(dateStr)!.add(task.id);
-          }
-        });
-      }
-    });
-
-    // Update task counts
-    taskCountPerDay.forEach((taskIds, dateStr) => {
-      const dayData = dayMap.get(dateStr);
-      if (dayData) {
-        dayData.taskCount = taskIds.size;
-        maxTasks = Math.max(maxTasks, dayData.taskCount);
-      }
-    });
-
-    // Calculate activity levels
-    dayMap.forEach((day) => {
-      if (day.taskCount === 0 && day.timeSpent === 0) {
-        day.level = 0;
-      } else {
-        const taskRatio = maxTasks > 0 ? day.taskCount / maxTasks : 0;
-        const timeRatio = maxTime > 0 ? day.timeSpent / maxTime : 0;
-        // eslint-disable-next-line no-mixed-operators
-        const combinedRatio = timeRatio * 0.8 + taskRatio * 0.2;
-        if (combinedRatio > 0.75) {
-          day.level = 4;
-        } else if (combinedRatio > 0.5) {
-          day.level = 3;
-        } else if (combinedRatio > 0.25) {
-          day.level = 2;
-        } else {
-          day.level = 1;
-        }
-      }
-    });
-    return { dayMap, startDate, endDate };
-  }
-
-  private _buildHeatmapDataFromWorklog(
-    worklog: any,
-    year: number,
-  ): {
-    dayMap: Map<string, DayData>;
-    startDate: Date;
-    endDate: Date;
-  } | null {
     if (!worklog) {
       return null;
     }
@@ -446,32 +310,7 @@ export class ActivityHeatmapComponent {
     return `${day.dateStr}: ${day.taskCount} tasks, ${msToString(day.timeSpent)}`;
   }
 
-  private _extractAvailableYears(tasks: Task[]): number[] {
-    const yearsSet = new Set<number>();
-    const currentYear = new Date().getFullYear();
-    tasks.forEach((task) => {
-      if (task.timeSpentOnDay) {
-        Object.keys(task.timeSpentOnDay).forEach((dateStr) => {
-          const timeSpent = task.timeSpentOnDay[dateStr];
-          if (timeSpent > 0) {
-            // dateStr is in ISO format YYYY-MM-DD, so extract the
-            // first four characters to get the year
-            const year = parseInt(dateStr.substring(0, 4), 10);
-            // Validate and collect year
-            if (!isNaN(year) && year <= currentYear) {
-              yearsSet.add(year);
-            }
-          }
-        });
-      }
-    });
-    // Sort years in descending order, i.e. latest years
-    // come first so that they will be displayed first in the
-    // select menu
-    return Array.from(yearsSet).sort((a, b) => b - a);
-  }
-
-  private _extractAvailableYearsFromWorklog(worklog: any): number[] {
+  private _extractAvailableYearsFromWorklog(worklog: Worklog): number[] {
     if (!worklog) return [];
     const yearSet = new Set<number>();
     const curYear = new Date().getFullYear();

--- a/src/app/features/metric/activity-heatmap/activity-heatmap.component.ts
+++ b/src/app/features/metric/activity-heatmap/activity-heatmap.component.ts
@@ -96,8 +96,8 @@ export class ActivityHeatmapComponent {
         this.availableYears.set(yearsWithData);
         // No selectedYear mutation here!
       }),
-      map(([worklog, selectedYear]) => {
-        return this._buildHeatmapDataFromWorklog(worklog, selectedYear);
+      map(([worklog]) => {
+        return this._buildHeatmapDataFromWorklog(worklog, this.selectedYear());
       }),
     ),
     { initialValue: null },


### PR DESCRIPTION
## Summary
- use WorklogService as the single source for activity heatmap totals, including the Today metrics view
- remove the Today-only raw task aggregation path that could diverge from Quick History totals
- add a parent/subtask regression spec so heatmap time uses the worklog day total instead of summing log entries

Fixes #7993

## Verification
- npm run checkFile src/app/features/metric/activity-heatmap/activity-heatmap.component.ts
- npm run checkFile src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts
- npm run test:file -- src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts