### PR TITLE
[codex] Hide global metric charts outside Today

### DIFF
--- a/docs/wiki/4.19-Metrics.md
+++ b/docs/wiki/4.19-Metrics.md
@@ -32,7 +32,7 @@ The app does **not** store these; it calculates them when needed:
 - **Productivity breakdown** — Per-day items with score, impact, focused minutes, total minutes, and energy for a range of days, used for tables and charts.
 - **Chart data** — Line charts of productivity and sustainability scores over time (and other series like focus sessions or simple-counter data). The underlying numbers are computed from the persisted metrics and worklog for the displayed range.
 
-So when you open the **metrics view** or **evaluation sheet**, the app loads the stored daily records and then computes scores, aggregates, and chart series for the range and context you’re looking at.
+So when you open the **metrics view** or **evaluation sheet**, the app loads the stored daily records and then computes scores and aggregates for the range and context you’re looking at. Global chart series are shown in the Today metrics view.
 
 ## Persisted Vs Computed: Why It Matters
 
@@ -43,12 +43,12 @@ That split keeps storage simple (one record per day with a fixed set of fields) 
 
 ## What Parts of the App Use These Metrics?
 
-- **Metrics view** — Shows a **table of aggregate metrics** (time spent, time estimated, tasks done/created, days worked, averages for time per day, time per task, breaks, etc.) for the **current work context**. When your context is **today** (the “all tasks” / today view), the table reflects metrics across all your tasks for the configured range; when your context is a **project**, the table reflects only that project’s tasks and worklog. The same view can show **line charts** of productivity and sustainability scores (and other series) over time.
+- **Metrics view** — Shows a **table of aggregate metrics** (time spent, time estimated, tasks done/created, days worked, averages for time per day, time per task, breaks, etc.) for the **current work context**. When your context is **today** (the “all tasks” / today view), the table reflects metrics across all your tasks for the configured range; when your context is a **project**, the table reflects only that project’s tasks and worklog. The Today metrics view can also show global **line charts** of productivity and sustainability scores, focus sessions, and simple-counter data over time.
 - **Evaluation sheet** — For a **single day**, shows and edits the persisted fields (notes, reflections, impact, energy, remind tomorrow) and **computes** that day’s **productivity score** and **sustainability score** from focus sessions, work minutes, impact, and energy. So the evaluation sheet is where you both **input** daily data and **see** that day’s scores.
 - **Share / summary** — When you use the share or “work summary” feature, the app builds a summary from the **aggregate metrics** (and optionally the current project or today context), so the shared text reflects the same numbers you see in the metrics table for that context and range.
-- **Charts** — Line charts (e.g. productivity and sustainability over the last N days) are drawn from **computed** breakdown and score data; they don’t have a separate stored “chart” object.
+- **Charts** — Line charts (e.g. productivity and sustainability over the last N days) are shown in the Today metrics view and are drawn from **computed** breakdown and score data; they don’t have a separate stored “chart” object.
 
-So: **persisted data** is edited and viewed in the evaluation sheet (and focus sessions are added automatically); **computed** aggregates, scores, trends, and charts are shown in the metrics view, evaluation sheet, and share summary.
+So: **persisted data** is edited and viewed in the evaluation sheet (and focus sessions are added automatically); **computed** aggregates and scores are shown in the metrics view, evaluation sheet, and share summary, while global trends and charts are shown in the Today metrics view.
 
 ## How Context Affects Metrics
 
@@ -57,14 +57,14 @@ The **aggregate metrics table** (time spent, task counts, averages, etc.) is **c
 - **Today / all tasks** — The app uses **all tasks** and the full worklog to compute totals and averages. So you see “everything” for the selected range.
 - **Project** — The app uses only **tasks in the current project** and worklog for that project. So you see project-specific totals and averages.
 
-The **evaluation sheet** and **per-day scores** are always **per day** (one date at a time). Productivity and sustainability **trends** and **charts** are computed over a **date range** (e.g. last 7 or 30 days) from the stored daily records and worklog; they are not restricted by project—they use the global daily metric records and worklog.
+The **evaluation sheet** and **per-day scores** are always **per day** (one date at a time). Productivity and sustainability **trends** and **charts** are computed over a **date range** (e.g. last 7 or 30 days) from the stored daily records and worklog; they are not restricted by project—they use the global daily metric records and worklog and appear in the Today metrics view.
 
 ## Summary
 
 - **Persisted per day:** date, focus sessions, notes, remind tomorrow, reflections, impact (1–4), energy (1–3), total work minutes, completed/planned task counts.
 - **Computed on demand:** aggregate metrics (time spent, breaks, task counts, averages over a range), productivity score, sustainability score, trend indicators, productivity breakdown, and chart data.
 - **Productivity score** emphasizes **impact**; **sustainability score** uses focus time, total work, and **energy check-in**.
-- **Where you see them:** evaluation sheet (per-day inputs and scores), metrics view (aggregate table + charts, by context), share summary (aggregates for current context).
+- **Where you see them:** evaluation sheet (per-day inputs and scores), metrics view (aggregate table by context, global charts in Today), share summary (aggregates for current context).
 
 ## Related
 

--- a/src/app/features/metric/metric.component.html
+++ b/src/app/features/metric/metric.component.html
@@ -71,90 +71,94 @@
     <activity-heatmap></activity-heatmap>
   </section>
 
-  @if (!metricService.hasData()) {
-    <p class="no-data-msg">
-      {{ T.F.METRIC.CMP.NO_ADDITIONAL_DATA_YET | translate }}
-    </p>
-  }
-  @if (metricService.hasData()) {
-    <section class="metric-metrics">
-      <h1>{{ T.F.METRIC.CMP.GLOBAL_METRICS | translate }}</h1>
-      <section class="line-charts">
-        @if (productivityBreakdownChartData(); as breakdownChart) {
-          @if (breakdownChart) {
+  @if (showGlobalMetrics()) {
+    @if (!metricService.hasData()) {
+      <p class="no-data-msg">
+        {{ T.F.METRIC.CMP.NO_ADDITIONAL_DATA_YET | translate }}
+      </p>
+    }
+    @if (metricService.hasData()) {
+      <section class="metric-metrics">
+        <h1>{{ T.F.METRIC.CMP.GLOBAL_METRICS | translate }}</h1>
+        <section class="line-charts">
+          @if (productivityBreakdownChartData(); as breakdownChart) {
+            @if (breakdownChart) {
+              <section>
+                <h3>{{ T.F.METRIC.CMP.PRODUCTIVITY_BREAKDOWN_OVER_TIME | translate }}</h3>
+                <lazy-chart
+                  [type]="lineChartType"
+                  [datasets]="breakdownChart.datasets"
+                  [labels]="breakdownChart.labels"
+                  [legend]="true"
+                  [options]="lineChartOptions"
+                  height="400px"
+                  [shareFileName]="'productivity-sustainability-breakdown.png'"
+                  [enableTimeframeSelector]="true"
+                >
+                </lazy-chart>
+              </section>
+            }
+          }
+          @if (focusSessionData(); as focusSessions) {
+            @if (focusSessions.labels?.length) {
+              <section>
+                <h3>{{ T.F.METRIC.CMP.FOCUS_SESSION_TRENDS | translate }}</h3>
+                <lazy-chart
+                  [type]="lineChartType"
+                  [datasets]="focusSessions.datasets"
+                  [labels]="focusSessions.labels"
+                  [legend]="true"
+                  [options]="lineChartOptions"
+                  height="400px"
+                  [shareFileName]="'focus-session-trends.png'"
+                  [enableTimeframeSelector]="true"
+                ></lazy-chart>
+              </section>
+            }
+          }
+        </section>
+      </section>
+    }
+    @if (metricService.hasData()) {
+      <section class="metric-metrics">
+        <h2>{{ T.F.METRIC.CMP.SIMPLE_COUNTERS | translate }}</h2>
+        <section class="line-charts">
+          @if (simpleClickCounterData(); as simpleCounterClickData) {
             <section>
-              <h3>{{ T.F.METRIC.CMP.PRODUCTIVITY_BREAKDOWN_OVER_TIME | translate }}</h3>
+              <h3>{{ T.F.METRIC.CMP.SIMPLE_CLICK_COUNTERS_OVER_TIME | translate }}</h3>
               <lazy-chart
                 [type]="lineChartType"
-                [datasets]="breakdownChart.datasets"
-                [labels]="breakdownChart.labels"
-                [legend]="true"
+                [datasets]="simpleCounterClickData.datasets"
+                [labels]="simpleCounterClickData.labels"
                 [options]="lineChartOptions"
+                [legend]="true"
                 height="400px"
-                [shareFileName]="'productivity-sustainability-breakdown.png'"
+                [shareFileName]="'simple-click-counters-over-time.png'"
                 [enableTimeframeSelector]="true"
               >
               </lazy-chart>
             </section>
           }
-        }
-        @if (focusSessionData(); as focusSessions) {
-          @if (focusSessions.labels?.length) {
+          @if (simpleCounterStopWatchData(); as simpleCounterStopWatchData) {
             <section>
-              <h3>{{ T.F.METRIC.CMP.FOCUS_SESSION_TRENDS | translate }}</h3>
+              <h3>
+                {{ T.F.METRIC.CMP.SIMPLE_STOPWATCH_COUNTERS_OVER_TIME | translate }}
+              </h3>
               <lazy-chart
                 [type]="lineChartType"
-                [datasets]="focusSessions.datasets"
-                [labels]="focusSessions.labels"
-                [legend]="true"
+                [datasets]="simpleCounterStopWatchData.datasets"
+                [labels]="simpleCounterStopWatchData.labels"
                 [options]="lineChartOptions"
+                [legend]="true"
                 height="400px"
-                [shareFileName]="'focus-session-trends.png'"
+                [shareFileName]="'simple-stopwatch-counters-over-time.png'"
                 [enableTimeframeSelector]="true"
-              ></lazy-chart>
+              >
+              </lazy-chart>
             </section>
           }
-        }
+        </section>
       </section>
-    </section>
-  }
-  @if (metricService.hasData()) {
-    <section class="metric-metrics">
-      <h2>{{ T.F.METRIC.CMP.SIMPLE_COUNTERS | translate }}</h2>
-      <section class="line-charts">
-        @if (simpleClickCounterData(); as simpleCounterClickData) {
-          <section>
-            <h3>{{ T.F.METRIC.CMP.SIMPLE_CLICK_COUNTERS_OVER_TIME | translate }}</h3>
-            <lazy-chart
-              [type]="lineChartType"
-              [datasets]="simpleCounterClickData.datasets"
-              [labels]="simpleCounterClickData.labels"
-              [options]="lineChartOptions"
-              [legend]="true"
-              height="400px"
-              [shareFileName]="'simple-click-counters-over-time.png'"
-              [enableTimeframeSelector]="true"
-            >
-            </lazy-chart>
-          </section>
-        }
-        @if (simpleCounterStopWatchData(); as simpleCounterStopWatchData) {
-          <section>
-            <h3>{{ T.F.METRIC.CMP.SIMPLE_STOPWATCH_COUNTERS_OVER_TIME | translate }}</h3>
-            <lazy-chart
-              [type]="lineChartType"
-              [datasets]="simpleCounterStopWatchData.datasets"
-              [labels]="simpleCounterStopWatchData.labels"
-              [options]="lineChartOptions"
-              [legend]="true"
-              height="400px"
-              [shareFileName]="'simple-stopwatch-counters-over-time.png'"
-              [enableTimeframeSelector]="true"
-            >
-            </lazy-chart>
-          </section>
-        }
-      </section>
-    </section>
+    }
   }
 </div>

--- a/src/app/features/metric/metric.component.html
+++ b/src/app/features/metric/metric.component.html
@@ -71,12 +71,7 @@
     <activity-heatmap></activity-heatmap>
   </section>
 
-  @if (showGlobalMetrics()) {
-    @if (!metricService.hasData()) {
-      <p class="no-data-msg">
-        {{ T.F.METRIC.CMP.NO_ADDITIONAL_DATA_YET | translate }}
-      </p>
-    }
+  @if (isShowingAllTasks()) {
     @if (metricService.hasData()) {
       <section class="metric-metrics">
         <h1>{{ T.F.METRIC.CMP.GLOBAL_METRICS | translate }}</h1>
@@ -118,8 +113,6 @@
           }
         </section>
       </section>
-    }
-    @if (metricService.hasData()) {
       <section class="metric-metrics">
         <h2>{{ T.F.METRIC.CMP.SIMPLE_COUNTERS | translate }}</h2>
         <section class="line-charts">
@@ -159,6 +152,10 @@
           }
         </section>
       </section>
+    } @else {
+      <p class="no-data-msg">
+        {{ T.F.METRIC.CMP.NO_ADDITIONAL_DATA_YET | translate }}
+      </p>
     }
   }
 </div>

--- a/src/app/features/metric/metric.component.spec.ts
+++ b/src/app/features/metric/metric.component.spec.ts
@@ -10,6 +10,7 @@ import { TODAY_TAG } from '../tag/tag.const';
 import { SimpleMetrics } from './metric.model';
 import { signal } from '@angular/core';
 import { T } from '../../t.const';
+import { INBOX_PROJECT } from '../project/project.const';
 
 describe('MetricComponent', () => {
   let component: MetricComponent;
@@ -199,6 +200,32 @@ describe('MetricComponent', () => {
       activeWorkContext$.next(null);
 
       expect(component.metricsTitle()).toBe(T.PM.TITLE);
+    });
+  });
+
+  describe('showGlobalMetrics computed', () => {
+    it('should return true when viewing TODAY_TAG', () => {
+      activeWorkContext$.next(
+        createMockWorkContext(TODAY_TAG.id, WorkContextType.TAG, 'Today'),
+      );
+
+      expect(component.showGlobalMetrics()).toBe(true);
+    });
+
+    it('should return false when viewing a regular project', () => {
+      activeWorkContext$.next(
+        createMockWorkContext('project-1', WorkContextType.PROJECT, 'Project 1'),
+      );
+
+      expect(component.showGlobalMetrics()).toBe(false);
+    });
+
+    it('should return false when viewing the Inbox project', () => {
+      activeWorkContext$.next(
+        createMockWorkContext(INBOX_PROJECT.id, WorkContextType.PROJECT, 'Inbox'),
+      );
+
+      expect(component.showGlobalMetrics()).toBe(false);
     });
   });
 

--- a/src/app/features/metric/metric.component.spec.ts
+++ b/src/app/features/metric/metric.component.spec.ts
@@ -139,13 +139,15 @@ describe('MetricComponent', () => {
     });
   });
 
-  describe('_isShowingAllTasks computed', () => {
+  // Drives the metrics service selection, the view title, and whether the
+  // global charts are shown (global charts are only rendered in the Today view).
+  describe('isShowingAllTasks computed', () => {
     it('should return true when context is TODAY_TAG', () => {
       activeWorkContext$.next(
         createMockWorkContext(TODAY_TAG.id, WorkContextType.TAG, 'Today'),
       );
 
-      expect(component['_isShowingAllTasks']()).toBe(true);
+      expect(component.isShowingAllTasks()).toBe(true);
     });
 
     it('should return false when context is a regular project', () => {
@@ -153,7 +155,15 @@ describe('MetricComponent', () => {
         createMockWorkContext('project-1', WorkContextType.PROJECT, 'Project 1'),
       );
 
-      expect(component['_isShowingAllTasks']()).toBe(false);
+      expect(component.isShowingAllTasks()).toBe(false);
+    });
+
+    it('should return false when context is the Inbox project', () => {
+      activeWorkContext$.next(
+        createMockWorkContext(INBOX_PROJECT.id, WorkContextType.PROJECT, 'Inbox'),
+      );
+
+      expect(component.isShowingAllTasks()).toBe(false);
     });
 
     it('should return false when context is a regular tag', () => {
@@ -161,13 +171,13 @@ describe('MetricComponent', () => {
         createMockWorkContext('tag-1', WorkContextType.TAG, 'Tag 1'),
       );
 
-      expect(component['_isShowingAllTasks']()).toBe(false);
+      expect(component.isShowingAllTasks()).toBe(false);
     });
 
     it('should return false when context is null', () => {
       activeWorkContext$.next(null);
 
-      expect(component['_isShowingAllTasks']()).toBe(false);
+      expect(component.isShowingAllTasks()).toBe(false);
     });
   });
 
@@ -200,32 +210,6 @@ describe('MetricComponent', () => {
       activeWorkContext$.next(null);
 
       expect(component.metricsTitle()).toBe(T.PM.TITLE);
-    });
-  });
-
-  describe('showGlobalMetrics computed', () => {
-    it('should return true when viewing TODAY_TAG', () => {
-      activeWorkContext$.next(
-        createMockWorkContext(TODAY_TAG.id, WorkContextType.TAG, 'Today'),
-      );
-
-      expect(component.showGlobalMetrics()).toBe(true);
-    });
-
-    it('should return false when viewing a regular project', () => {
-      activeWorkContext$.next(
-        createMockWorkContext('project-1', WorkContextType.PROJECT, 'Project 1'),
-      );
-
-      expect(component.showGlobalMetrics()).toBe(false);
-    });
-
-    it('should return false when viewing the Inbox project', () => {
-      activeWorkContext$.next(
-        createMockWorkContext(INBOX_PROJECT.id, WorkContextType.PROJECT, 'Inbox'),
-      );
-
-      expect(component.showGlobalMetrics()).toBe(false);
     });
   });
 

--- a/src/app/features/metric/metric.component.ts
+++ b/src/app/features/metric/metric.component.ts
@@ -57,6 +57,8 @@ export class MetricComponent {
     return context?.type === WorkContextType.TAG && context.id === TODAY_TAG.id;
   });
 
+  showGlobalMetrics = computed(() => this._isShowingAllTasks());
+
   /**
    * Dynamic title that changes based on context
    */

--- a/src/app/features/metric/metric.component.ts
+++ b/src/app/features/metric/metric.component.ts
@@ -48,22 +48,20 @@ export class MetricComponent {
   activeWorkContext = toSignal(this.workContextService.activeWorkContext$);
 
   /**
-   * Determine which metrics service to use based on the active work context.
-   * - For TODAY_TAG: use AllTasksMetricsService (shows all tasks)
-   * - For other contexts: use ProjectMetricsService (project/tag specific)
+   * Whether the active work context is the global "Today / all tasks" view.
+   * Drives the metrics service selection (AllTasks vs Project), the view title,
+   * and whether the global charts are shown (global charts only make sense in Today).
    */
-  private _isShowingAllTasks = computed(() => {
+  isShowingAllTasks = computed(() => {
     const context = this.activeWorkContext();
     return context?.type === WorkContextType.TAG && context.id === TODAY_TAG.id;
   });
-
-  showGlobalMetrics = computed(() => this._isShowingAllTasks());
 
   /**
    * Dynamic title that changes based on context
    */
   metricsTitle = computed(() => {
-    return this._isShowingAllTasks() ? this.T.PM.ALL_TASKS_TITLE : this.T.PM.TITLE;
+    return this.isShowingAllTasks() ? this.T.PM.ALL_TASKS_TITLE : this.T.PM.TITLE;
   });
 
   simpleClickCounterData = toSignal(this.metricService.getSimpleClickCounterMetrics$());
@@ -155,7 +153,7 @@ export class MetricComponent {
    * based on the current context
    */
   simpleMetrics = computed(() => {
-    return this._isShowingAllTasks()
+    return this.isShowingAllTasks()
       ? this.allTasksMetricsService.simpleMetrics()
       : this.projectMetricsService.simpleMetrics();
   });


### PR DESCRIPTION
## Summary

- Hide global metric trend charts and simple-counter charts outside the Today metrics view.
- Keep project and Inbox metrics pages focused on context-specific stats and the activity heatmap.
- Update the metrics wiki note to describe that global charts are shown in Today.

## Why

Issue #8004 points out that global metrics are shown in Inbox and project contexts, where they can be mistaken for context-specific project data.

## Validation

- `npm run checkFile src/app/features/metric/metric.component.ts`
- `npm run checkFile src/app/features/metric/metric.component.spec.ts`
- `npm run lint:file -- src/app/features/metric/metric.component.html`
- `npm run test:file src/app/features/metric/metric.component.spec.ts`