### PR TITLE
fix(boards): show tasks from sidebar-hidden projects

### DIFF
--- a/docs/wiki/3.02-Settings-and-Preferences.md
+++ b/docs/wiki/3.02-Settings-and-Preferences.md
@@ -61,6 +61,8 @@ See [[3.03-Keyboard-Shortcuts]] for full list.
 - **Enable Project Backlog** — Adds a separate backlog list to the project.
 - **Hide project from sidebar** — Removes the project from the sidebar project list. The project stays active: its tasks can still appear in cross-project task views such as Today, Planner, Schedule, Boards, and Search. The sidebar visibility menu remains the place to show the project again; project short syntax does not match hidden projects.
 
+#### project-settings.Theme
+
 Theme settings can include background images for light mode, dark mode, or both.
 When at least one background image is set, the background contrast and blur
 sliders are shown. The blur slider defaults to `0px`. When at least one mode has

--- a/docs/wiki/3.02-Settings-and-Preferences.md
+++ b/docs/wiki/3.02-Settings-and-Preferences.md
@@ -54,6 +54,13 @@ See [[3.03-Keyboard-Shortcuts]] for full list.
 
 ## Project, Tag, Today, And Inbox Settings
 
+### Project Settings
+
+#### project-settings.Basic-Settings
+
+- **Enable Project Backlog** — Adds a separate backlog list to the project.
+- **Hide project from sidebar** — Removes the project from the sidebar project list. The project stays active: its tasks can still appear in cross-project task views such as Today, Planner, Schedule, Boards, and Search. The sidebar visibility menu remains the place to show the project again; project short syntax does not match hidden projects.
+
 Theme settings can include background images for light mode, dark mode, or both.
 When at least one background image is set, the background contrast and blur
 sliders are shown. The blur slider defaults to `0px`. When at least one mode has

--- a/docs/wiki/4.05-Board-View.md
+++ b/docs/wiki/4.05-Board-View.md
@@ -31,11 +31,13 @@ This means moving a task to a "Done" panel marks it complete, and moving it to a
 
 Tasks can appear on **multiple boards simultaneously**. This works because:
 
-- Each board panel independently filters all tasks based on its criteria
+- Each board panel independently filters tasks from active projects based on its criteria
 - Tasks don't store which boards they belong to—membership is calculated dynamically
 - Each panel maintains its own ordering, so a task can be in different positions on different boards
 
 For example, a task might appear in the "Urgent" column of an Eisenhower Matrix board and also in the "In Progress" column of a Kanban board, with different positions in each.
+
+Boards include tasks from projects that are hidden from the sidebar. Hidden projects are still active; only archived projects are removed from board task membership.
 
 ## Boards Vs Projects Vs Tags
 

--- a/docs/wiki/4.06-Project-View.md
+++ b/docs/wiki/4.06-Project-View.md
@@ -66,7 +66,7 @@ To archive a project, right-click it in the sidebar (or click the `⋮` button) 
 
 Archiving a project makes it fully **dormant**: the project and all its data are preserved, but it stops generating noise across the app. Specifically, an archived project:
 
-- Is removed from the sidebar and the visibility menu
+- Is removed from the sidebar project list and the main visibility checklist
 - Has its tasks hidden from Today, Tags, Boards, Overdue, Deadline, and Scheduled views
 - Has its repeating tasks suspended — no new instances are generated
 - Has its reminders suppressed — no notifications fire for its tasks

--- a/docs/wiki/4.06-Project-View.md
+++ b/docs/wiki/4.06-Project-View.md
@@ -43,6 +43,12 @@ However, you can **organize projects into folders** in the navigation menu. Fold
 
 You can move projects between folders without affecting the tasks or any other project data.
 
+## Hiding Projects
+
+When a project is active but you do not want it in the sidebar project list, enable **Hide project from sidebar** in the project settings or use the Projects visibility menu in the sidebar.
+
+Hiding a project changes navigation only. The project stays active, and its tasks can still appear in cross-project task views such as Today, Planner, Schedule, Boards, and Search. Project navigation helpers, including project short syntax, do not match hidden projects.
+
 ## How Tasks Belong to Projects
 
 Every task has a project assignment. When you create a task, it's assigned to the current project (or the Inbox if you're in a tag context without a default project). You can change a task's project by:
@@ -67,7 +73,7 @@ Archiving a project makes it fully **dormant**: the project and all its data are
 
 All data is kept intact. Archiving is safe to use even if the project still has active tasks, open deadlines, or configured repeating tasks — everything is simply invisible until you unarchive.
 
-To **restore** a project, click the eye icon in the Projects section header to open the visibility menu, then navigate to **Archived projects**. From there you can either click the project title to open it (an archived banner appears at the top with a one-click restore) or click the **Restore project** icon directly in the row — all tasks, repeating configs, and reminders become active again immediately. If the project was hidden from the menu when archived, the snack message offers a **Show in menu** action so it reappears in the sidebar.
+To **restore** a project, click the eye icon in the Projects section header to open the visibility menu, then navigate to **Archived projects**. From there you can either click the project title to open it (an archived banner appears at the top with a one-click restore) or click the **Restore project** icon directly in the row — all tasks, repeating configs, and reminders become active again immediately. If the project was hidden from the sidebar when archived, the snack message offers a **Show in sidebar** action so it reappears in the sidebar.
 
 ## Related
 

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
@@ -166,9 +166,9 @@
       (click)="toggleProjectVisibility(project.id)"
     >
       @if (!project.isHiddenFromMenu) {
-        <mat-icon>check_box</mat-icon>
+        <mat-icon>visibility</mat-icon>
       } @else {
-        <mat-icon>check_box_outline_blank</mat-icon>
+        <mat-icon>visibility_off</mat-icon>
       }
       <mat-icon
         class="nav-icon"

--- a/src/app/features/boards/board-panel/board-panel.component.spec.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.spec.ts
@@ -16,7 +16,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { PlannerTaskComponent } from '../../planner/planner-task/planner-task.component';
 import { AddTaskInlineComponent } from '../../planner/add-task-inline/add-task-inline.component';
 import { selectUnarchivedProjects } from '../../project/store/project.selectors';
-import { selectAllTasksWithoutHiddenProjects } from '../../tasks/store/task.selectors';
+import { selectAllTasksInActiveProjects } from '../../tasks/store/task.selectors';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { ProjectService } from '../../project/project.service';
 import { signal } from '@angular/core';
@@ -81,7 +81,7 @@ describe('BoardPanelComponent - Backlog Feature', () => {
       select: (selectorFn: any) => {
         if (selectorFn === selectUnarchivedProjects) {
           return of(mockProjects);
-        } else if (selectorFn === selectAllTasksWithoutHiddenProjects) {
+        } else if (selectorFn === selectAllTasksInActiveProjects) {
           return of(mockTasks);
         }
         return of([]);
@@ -173,6 +173,7 @@ describe('BoardPanelComponent - Hidden Project Backlog', () => {
   let actions$: ReplaySubject<any>;
 
   const hiddenProjectBacklogTaskId = 'hidden-backlog-task';
+  const hiddenProjectRegularTaskId = 'hidden-regular-task';
   const regularTaskId = 'regular-task';
 
   const mockPanelCfg: Partial<BoardPanelCfg> = {
@@ -190,6 +191,19 @@ describe('BoardPanelComponent - Hidden Project Backlog', () => {
     {
       id: hiddenProjectBacklogTaskId,
       title: 'Task from hidden project backlog',
+      projectId: 'hidden-project',
+      timeSpentOnDay: {},
+      attachments: [],
+      timeEstimate: 0,
+      timeSpent: 0,
+      isDone: false,
+      tagIds: ['important-tag'],
+      created: Date.now(),
+      subTaskIds: [],
+    } as TaskCopy,
+    {
+      id: hiddenProjectRegularTaskId,
+      title: 'Regular task from hidden project',
       projectId: 'hidden-project',
       timeSpentOnDay: {},
       attachments: [],
@@ -232,7 +246,7 @@ describe('BoardPanelComponent - Hidden Project Backlog', () => {
       select: (selectorFn: any) => {
         if (selectorFn === selectUnarchivedProjects) {
           return of(mockProjects);
-        } else if (selectorFn === selectAllTasksWithoutHiddenProjects) {
+        } else if (selectorFn === selectAllTasksInActiveProjects) {
           return of(mockTasks);
         }
         return of([]);
@@ -271,7 +285,7 @@ describe('BoardPanelComponent - Hidden Project Backlog', () => {
     fixture.detectChanges();
   });
 
-  it('should exclude backlog tasks from hidden projects when backlogState is NoBacklog', () => {
+  it('should include regular tasks from hidden projects when backlogState is NoBacklog', () => {
     fixture.componentRef.setInput('panelCfg', {
       ...mockPanelCfg,
       backlogState: BoardPanelCfgTaskTypeFilter.NoBacklog,
@@ -279,8 +293,10 @@ describe('BoardPanelComponent - Hidden Project Backlog', () => {
     fixture.detectChanges();
 
     const tasks = component.tasks();
-    expect(tasks.length).toBe(1);
-    expect(tasks[0].id).toBe(regularTaskId);
+    expect(tasks.map((task) => task.id)).toEqual([
+      hiddenProjectRegularTaskId,
+      regularTaskId,
+    ]);
     expect(tasks.find((t) => t.id === hiddenProjectBacklogTaskId)).toBeFalsy();
   });
 
@@ -324,7 +340,7 @@ describe('BoardPanelComponent - Tag match mode, sort, inline-create computeds', 
       select: (selectorFn: any) => {
         if (selectorFn === selectUnarchivedProjects)
           return of([{ id: 'p1', backlogTaskIds: [] }]);
-        if (selectorFn === selectAllTasksWithoutHiddenProjects) return of(tasks);
+        if (selectorFn === selectAllTasksInActiveProjects) return of(tasks);
         return of([]);
       },
       dispatch: jasmine.createSpy('dispatch'),
@@ -661,7 +677,7 @@ describe('BoardPanelComponent - drop()', () => {
       select: (selectorFn: any) => {
         if (selectorFn === selectUnarchivedProjects)
           return of([{ id: 'p1', backlogTaskIds: [] }]);
-        if (selectorFn === selectAllTasksWithoutHiddenProjects) return of(tasks);
+        if (selectorFn === selectAllTasksInActiveProjects) return of(tasks);
         return of([]);
       },
       pipe: () => ({ toPromise: () => Promise.resolve(undefined) }),

--- a/src/app/features/boards/board-panel/board-panel.component.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.ts
@@ -17,7 +17,7 @@ import {
 import { buildComparator, rewriteTagIdsForPanel } from '../boards.util';
 import { select, Store } from '@ngrx/store';
 import {
-  selectAllTasksWithoutHiddenProjects,
+  selectAllTasksInActiveProjects,
   selectTaskById,
   selectTaskByIdWithSubTaskData,
 } from '../../tasks/store/task.selectors';
@@ -77,7 +77,7 @@ export class BoardPanelComponent {
   taskService = inject(TaskService);
   _matDialog = inject(MatDialog);
 
-  allTasks$ = this.store.select(selectAllTasksWithoutHiddenProjects);
+  allTasks$ = this.store.select(selectAllTasksInActiveProjects);
   allTasks = toSignal(this.allTasks$, {
     initialValue: [],
   });

--- a/src/app/features/project/store/project.selectors.ts
+++ b/src/app/features/project/store/project.selectors.ts
@@ -23,11 +23,6 @@ export const selectUnarchivedVisibleProjects = createSelector(
       (p) => !p.isArchived && !p.isHiddenFromMenu && p.id !== INBOX_PROJECT.id,
     ),
 );
-export const selectUnarchivedHiddenProjectIds = createSelector(
-  selectAllProjects,
-  (projects) =>
-    projects.filter((p) => !p.isArchived && p.isHiddenFromMenu).map((p) => p.id),
-);
 
 export const selectArchivedProjects = createSelector(selectAllProjects, (projects) =>
   projects.filter((p) => p.isArchived),
@@ -42,18 +37,6 @@ export const selectArrayOfArchivedProjectIds = createSelector(
 );
 export const selectArchivedProjectIds = createSelector(
   selectArrayOfArchivedProjectIds,
-  (ids): Set<string> => new Set(ids),
-);
-export const selectArrayOfHiddenProjectIds = createSelector(
-  selectAllProjects,
-  (projects) =>
-    projects
-      .filter((p) => p.isHiddenFromMenu)
-      .map((p) => p.id)
-      .sort(),
-);
-export const selectHiddenProjectIds = createSelector(
-  selectArrayOfHiddenProjectIds,
   (ids): Set<string> => new Set(ids),
 );
 export const selectAllProjectColors = createSelector(selectAllProjects, (projects) =>

--- a/src/app/features/tasks/store/task.selectors.spec.ts
+++ b/src/app/features/tasks/store/task.selectors.spec.ts
@@ -842,15 +842,6 @@ describe('Task Selectors', () => {
     });
   });
 
-  // Project-related selectors
-  describe('Project-related selectors', () => {
-    it('should select all tasks without hidden projects', () => {
-      const result = fromSelectors.selectAllTasksWithoutHiddenProjects(mockState);
-      // All tasks should still be returned since none belong to hidden project3
-      expect(result.length).toBe(11);
-    });
-  });
-
   // Performance-optimized selectors (Set-based lookups)
   describe('Set-based lookup optimizations', () => {
     it('selectOverdueTasksOnToday should correctly filter with Set lookup', () => {

--- a/src/app/features/tasks/store/task.selectors.ts
+++ b/src/app/features/tasks/store/task.selectors.ts
@@ -12,10 +12,7 @@ import { taskAdapter } from './task.adapter';
 import { devError } from '../../../util/dev-error';
 import { isDBDateStr } from '../../../util/get-db-date-str';
 import { IssueProvider, isPluginIssueProvider } from '../../issue/issue.model';
-import {
-  selectArchivedProjectIds,
-  selectHiddenProjectIds,
-} from '../../project/store/project.selectors';
+import { selectArchivedProjectIds } from '../../project/store/project.selectors';
 import { selectTodayTagTaskIds } from '../../tag/store/tag.reducer';
 import {
   selectStartOfNextDayDiffMs,
@@ -719,13 +716,6 @@ export const selectAllTaskIssueIdsForIssueProvider = (issueProvider: IssueProvid
       .map((t) => t.issueId as string);
   });
 };
-
-export const selectAllTasksWithoutHiddenProjects = createSelector(
-  selectAllTasksInActiveProjects,
-  selectHiddenProjectIds,
-  (tasks: Task[], hiddenIds: Set<string>): Task[] =>
-    tasks.filter((t) => !t.projectId || !hiddenIds.has(t.projectId)),
-);
 
 export const selectAllUndoneTasksWithDueDay = createSelector(
   selectAllTasksInActiveProjects,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -924,7 +924,7 @@
       },
       "FORM_BASIC": {
         "L_ENABLE_BACKLOG": "Enable Project Backlog",
-        "L_IS_HIDDEN_FROM_MENU": "Hide project from menu",
+        "L_IS_HIDDEN_FROM_MENU": "Hide project from sidebar",
         "L_TITLE": "Project Name",
         "TITLE": "Basic Settings"
       },
@@ -954,9 +954,9 @@
         "ARCHIVED": "Archived Project",
         "CREATED": "Created project <strong>{{title}}</strong>. You can select it from the menu on the top left.",
         "DELETED": "Deleted Project",
-        "SHOW_IN_MENU": "Show in menu",
+        "SHOW_IN_MENU": "Show in sidebar",
         "UNARCHIVED": "Project restored",
-        "UNARCHIVED_HIDDEN_FROM_MENU": "Project restored, but still hidden from the menu",
+        "UNARCHIVED_HIDDEN_FROM_MENU": "Project restored, but still hidden from the sidebar",
         "UPDATED": "Updated project settings"
       },
       "ARCHIVED_NOTICE": "This project is archived.",
@@ -984,7 +984,7 @@
         "PLACEHOLDER": "Select folder"
       },
       "TOOLTIP_CREATE": "Create project folder",
-      "TOOLTIP_VISIBILITY": "Show/hide projects"
+      "TOOLTIP_VISIBILITY": "Show/hide sidebar projects"
     },
     "QUICK_HISTORY": {
       "NO_DATA": "No work tracked yet this year. Complete tasks to see your history here.",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -952,7 +952,7 @@
       },
       "S": {
         "ARCHIVED": "Archived Project",
-        "CREATED": "Created project <strong>{{title}}</strong>. You can select it from the menu on the top left.",
+        "CREATED": "Created project <strong>{{title}}</strong>. You can select it from the sidebar.",
         "DELETED": "Deleted Project",
         "SHOW_IN_MENU": "Show in sidebar",
         "UNARCHIVED": "Project restored",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -984,7 +984,7 @@
         "PLACEHOLDER": "Select folder"
       },
       "TOOLTIP_CREATE": "Create project folder",
-      "TOOLTIP_VISIBILITY": "Show/hide sidebar projects"
+      "TOOLTIP_VISIBILITY": "Show/hide projects"
     },
     "QUICK_HISTORY": {
       "NO_DATA": "No work tracked yet this year. Complete tasks to see your history here.",


### PR DESCRIPTION
## Problem

Fixes #7893.

Hidden projects were treated inconsistently across cross-project task views. Planner, Schedule, Today, and Search kept showing tasks from projects hidden from the sidebar, but Boards filtered them out via `selectAllTasksWithoutHiddenProjects`.

## Solution

- Make board panels use active-project tasks, so hidden-from-sidebar projects remain visible on Boards while archived projects remain excluded.
- Remove the now-unused hidden-project task selector path.
- Update board panel regression coverage for hidden project backlog and regular tasks.
- Clarify English copy and wiki docs so project hiding is described as sidebar/navigation-only and distinct from archiving.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Verification:

- `npm run checkFile src/app/features/boards/board-panel/board-panel.component.ts`
- `npm run checkFile src/app/features/boards/board-panel/board-panel.component.spec.ts`
- `npm run checkFile src/app/features/tasks/store/task.selectors.ts`
- `npm run checkFile src/app/features/tasks/store/task.selectors.spec.ts`
- `npm run checkFile src/app/features/project/store/project.selectors.ts`
- `npm run test:file src/app/features/boards/board-panel/board-panel.component.spec.ts -- --watch=false`
- `npm run test:file src/app/features/tasks/store/task.selectors.spec.ts -- --watch=false`
- `npx prettier --check docs/wiki/3.02-Settings-and-Preferences.md docs/wiki/4.05-Board-View.md docs/wiki/4.06-Project-View.md src/assets/i18n/en.json`
- `git diff --check`

Review:

- Reviewed via three read-only sub-agents for board behavior, selector/API cleanup, and docs/copy consistency.
- Addressed docs/copy review findings in follow-up commit `822006c9c0`.
