### PR TITLE
fix(date-time): use browser regional locale for default date format

### DIFF
--- a/src/app/core/date-time-format/date-time-format.service.ts
+++ b/src/app/core/date-time-format/date-time-format.service.ts
@@ -61,11 +61,17 @@ export class DateTimeFormatService {
       if (cfgValue) {
         this.setDateAdapterLocale(cfgValue);
       } else {
-        const uiLang =
+        // No explicit date/time override: follow the browser's regional locale
+        // (e.g. 'en-GB' → DD/MM/YYYY) rather than the UI translation language.
+        // The UI language is region-agnostic — 'en' resolves to US MM/DD/YYYY,
+        // which would mis-format dates for en-GB/en-AU/etc. users who never
+        // picked a date locale. Fall back to UI language, then the default.
+        const fallbackLocale =
+          this._translateService.getBrowserCultureLang?.()?.toLowerCase() ||
           this._translateService.currentLang ||
           this._translateService.defaultLang ||
           DEFAULT_LOCALE;
-        this.setDateAdapterLocale(uiLang as DateTimeLocale);
+        this.setDateAdapterLocale(fallbackLocale as DateTimeLocale);
       }
     });
   }


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #8000 ("Fix frequency translations") that turned `master` red and would mis-format dates for many real users.

When **no explicit `dateTimeLocale` override** is set (the default — `DEFAULT_GLOBAL_CONFIG.localization.dateTimeLocale` is `undefined`), #8000 changed the date-adapter locale to follow the **UI translation language** (`currentLang`). That value is region-agnostic: bare `'en'` resolves to US **`MM/DD/YYYY`**, replacing the previous fixed `DEFAULT_LOCALE` (`en-gb`, **`DD/MM/YYYY`**).

Consequences:
- A user in the UK/AU/etc. on `en-GB` who never picked a date locale suddenly sees/parses dates in US `MM/DD` format.
- 5 recurring-task start-date E2E tests fail: the suite pins `navigator.language=en-GB` and types `DD/MM/YYYY`. Under `MM/DD`, a typed date like `04/05/2026` (4 May) is misread as **April 5**, which is before the field's `min` (the fixed "today") → the datepicker rejects it as out-of-range and **clears the input** → Save stays disabled → task lands on the wrong day → projections/instances never render. The failing DOM shows `placeholder="MM/DD/YYYY"`, confirming the flipped format.

## Root cause (bisected)

| Commit | Result |
|---|---|
| `09437a7e7a` (before #8000) | green |
| `25896fd318` — #8000 | first failure (these 5 tests) |
| `ede6b770c8` — #8019 | same 5 (unrelated PR, inherited red master) |

## Fix

When no override is set, fall back to the **browser's regional locale** (`getBrowserCultureLang()`, e.g. `en-GB`) before `currentLang`/`defaultLang`/`DEFAULT_LOCALE`. Date-format conventions (DD/MM vs MM/DD vs DD.MM) are tied to region, not to which UI translation ships — so the browser culture locale is the correct signal. The optional `getBrowserCultureLang?.()` preserves #8000's "reset to UI language when override removed" intent for mocked/edge cases.

```ts
const fallbackLocale =
  this._translateService.getBrowserCultureLang?.()?.toLowerCase() ||
  this._translateService.currentLang ||
  this._translateService.defaultLang ||
  DEFAULT_LOCALE;
this.setDateAdapterLocale(fallbackLocale as DateTimeLocale);
```

## Verification

- Unit: 17/17 in `date-time-format.service.spec.ts`, including #8000's added `fr` fallback test.
- E2E: 6/6 green (the 5 previously-failing tests + 1 sibling), run against `origin/master`'s code with this fix applied:
  - `recurring-move-start-date-earlier-bug-7423`
  - `recurring-move-start-date-earlier-no-instance-bug-7724`
  - `recurring-start-date-epoch-bug-6860`
  - `recurring-startdate-to-today-creates-real-instance-bug-7923`
  - `repeat-edit-strands-today-bug-7951`

## Note

The pre-existing `currentLang`/`defaultLang` deprecation warnings come from #8000's own code and are left unchanged here to keep the fix minimal.
