### PR TITLE
fix(projects): apply primary color to project icons in visibility menu

### DIFF
--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
@@ -143,8 +143,10 @@
   font-size: 18px;
   line-height: 1;
   margin-right: var(--s-half);
+  color: var(--c-primary);
 
   &.nav-icon-emoji {
+    color: inherit;
     font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif;
     font-size: 16px;
     font-feature-settings: normal;


### PR DESCRIPTION
## Summary

Fixes #8029 (follow-up to #7926 / #7894).

The `.nav-icon` class added in #7926 had sizing and layout but no `color` rule. Inside a `mat-menu` there is no ambient primary-color context, so Material icons were rendering in the neutral text color.

## Changes

- `color: var(--c-primary)` on `.nav-icon` so Material icons use the primary color, matching their appearance in the sidebar nav items.
- `color: inherit` inside `.nav-icon-emoji` so emoji icons retain their natural colors and are not overridden.

## Testing

- Opened the Show/Hide Projects visibility menu — project icons (Material) now show in the primary color.
- Emoji project icons retain their natural color.
- No other styles affected (`.nav-icon` is only used in the visibility menu in this component).