### PR TITLE
[codex] Fix daily summary exit after sync failure

### DIFF
--- a/src/app/pages/daily-summary/daily-summary.component.spec.ts
+++ b/src/app/pages/daily-summary/daily-summary.component.spec.ts
@@ -1,6 +1,60 @@
+import { fakeAsync, flushMicrotasks, tick } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { T } from '../../t.const';
-import { DailySummaryComponent } from './daily-summary.component';
+import {
+  DailySummaryComponent,
+  FINISH_DAY_FINAL_SYNC_TIMEOUT_MS,
+} from './daily-summary.component';
+
+const callFinishDayForGood = (
+  receiver: DailySummaryComponent,
+  cb?: () => void,
+): Promise<void> =>
+  (
+    DailySummaryComponent.prototype as unknown as {
+      _finishDayForGood: (cb?: () => void) => Promise<void>;
+    }
+  )._finishDayForGood.call(receiver, cb);
+
+const buildFinishDayForGoodReceiver = (
+  sync: () => Promise<unknown>,
+): {
+  receiver: DailySummaryComponent;
+  sync: jasmine.Spy;
+  flushPendingWrites: jasmine.Spy;
+  snackOpen: jasmine.Spy;
+} => {
+  const syncSpy = jasmine.createSpy('sync').and.callFake(sync);
+  const flushPendingWrites = jasmine
+    .createSpy('flushPendingWrites')
+    .and.resolveTo(undefined);
+  const snackOpen = jasmine.createSpy('snackOpen');
+  const receiver = Object.assign(Object.create(DailySummaryComponent.prototype), {
+    configService: {
+      cfg: () => ({
+        sync: {
+          isEnabled: true,
+        },
+      }),
+    },
+    _operationWriteFlushService: {
+      flushPendingWrites,
+    },
+    _syncWrapperService: {
+      sync: syncSpy,
+    },
+    _snackService: {
+      open: snackOpen,
+    },
+  }) as DailySummaryComponent;
+
+  return {
+    receiver,
+    sync: syncSpy,
+    flushPendingWrites,
+    snackOpen,
+  };
+};
 
 describe('DailySummaryComponent', () => {
   describe('finishDay()', () => {
@@ -79,6 +133,74 @@ describe('DailySummaryComponent', () => {
         type: 'ERROR',
       });
     });
+  });
+
+  describe('_finishDayForGood()', () => {
+    it('should still execute the callback when the final sync fails', async () => {
+      const cb = jasmine.createSpy('cb');
+      const { receiver, sync, flushPendingWrites, snackOpen } =
+        buildFinishDayForGoodReceiver(() => Promise.reject(new Error('sync failed')));
+
+      await callFinishDayForGood(receiver, cb);
+
+      expect(flushPendingWrites).toHaveBeenCalled();
+      expect(sync).toHaveBeenCalled();
+      expect(cb).toHaveBeenCalled();
+      expect(snackOpen).toHaveBeenCalledWith({
+        msg: T.F.SYNC.S.FINISH_DAY_SYNC_ERROR,
+        type: 'ERROR',
+      });
+    });
+
+    it('should not execute the callback when pending operation writes cannot be flushed', async () => {
+      const cb = jasmine.createSpy('cb');
+      const { receiver, sync, flushPendingWrites, snackOpen } =
+        buildFinishDayForGoodReceiver(() => Promise.resolve());
+      flushPendingWrites.and.rejectWith(new Error('flush failed'));
+
+      await callFinishDayForGood(receiver, cb);
+
+      expect(flushPendingWrites).toHaveBeenCalled();
+      expect(sync).not.toHaveBeenCalled();
+      expect(cb).not.toHaveBeenCalled();
+      expect(snackOpen).toHaveBeenCalledWith({
+        msg: T.F.SYNC.S.FINISH_DAY_SYNC_ERROR,
+        type: 'ERROR',
+      });
+    });
+
+    it('should still execute the callback when the final sync times out', fakeAsync(() => {
+      const cb = jasmine.createSpy('cb');
+      let isResolved = false;
+      const { receiver, sync, flushPendingWrites, snackOpen } =
+        buildFinishDayForGoodReceiver(() => new Promise(() => undefined));
+
+      callFinishDayForGood(receiver, cb).then(() => {
+        isResolved = true;
+      });
+      flushMicrotasks();
+
+      expect(flushPendingWrites).toHaveBeenCalled();
+      expect(sync).toHaveBeenCalled();
+      expect(cb).not.toHaveBeenCalled();
+      expect(isResolved).toBeFalse();
+
+      tick(FINISH_DAY_FINAL_SYNC_TIMEOUT_MS - 1);
+      flushMicrotasks();
+
+      expect(cb).not.toHaveBeenCalled();
+      expect(isResolved).toBeFalse();
+
+      tick(1);
+      flushMicrotasks();
+
+      expect(cb).toHaveBeenCalled();
+      expect(isResolved).toBeTrue();
+      expect(snackOpen).toHaveBeenCalledWith({
+        msg: T.F.SYNC.S.FINISH_DAY_SYNC_ERROR,
+        type: 'ERROR',
+      });
+    }));
   });
 });
 

--- a/src/app/pages/daily-summary/daily-summary.component.ts
+++ b/src/app/pages/daily-summary/daily-summary.component.ts
@@ -59,7 +59,9 @@ import { WorkContextType } from '../../features/work-context/work-context.model'
 import { WorkContextService } from '../../features/work-context/work-context.service';
 import { WorklogWeekComponent } from '../../features/worklog/worklog-week/worklog-week.component';
 import { WorklogService } from '../../features/worklog/worklog.service';
+import { SYNC_WAIT_TIMEOUT_MS } from '../../imex/sync/sync.const';
 import { SyncWrapperService } from '../../imex/sync/sync-wrapper.service';
+import { OperationWriteFlushService } from '../../op-log/sync/operation-write-flush.service';
 import { T } from '../../t.const';
 import { expandAnimation } from '../../ui/animations/expand.ani';
 import { DialogConfirmComponent } from '../../ui/dialog-confirm/dialog-confirm.component';
@@ -77,6 +79,9 @@ import {
 } from './simple-counter-summary-item/simple-counter-summary-item.component';
 import { MetricService } from '../../features/metric/metric.service';
 import { isWithinYesterdayMargin } from './is-include-yesterday.util';
+
+const FINISH_DAY_SYNC_WAIT_TIMEOUT_MS = 30000;
+export const FINISH_DAY_FINAL_SYNC_TIMEOUT_MS = SYNC_WAIT_TIMEOUT_MS;
 
 @Component({
   selector: 'daily-summary',
@@ -119,6 +124,7 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
   private readonly _worklogService = inject(WorklogService);
   private readonly _activatedRoute = inject(ActivatedRoute);
   private readonly _syncWrapperService = inject(SyncWrapperService);
+  private readonly _operationWriteFlushService = inject(OperationWriteFlushService);
   private readonly _beforeFinishDayService = inject(BeforeFinishDayService);
   private readonly _simpleCounterService = inject(SimpleCounterService);
   private readonly _dateService = inject(DateService);
@@ -340,7 +346,7 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
       // Wait for any ongoing sync to complete before archiving to avoid DB lock errors.
       // Use a 30-second timeout to prevent hanging indefinitely if sync is stuck.
       await this._syncWrapperService.afterCurrentSyncDoneOrSyncDisabled$
-        .pipe(first(), timeout(30000))
+        .pipe(first(), timeout(FINISH_DAY_SYNC_WAIT_TIMEOUT_MS))
         .toPromise()
         .catch((err) => {
           // Log timeout but continue - better to proceed than to block the user
@@ -491,11 +497,45 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
   private async _finishDayForGood(cb?: () => void): Promise<void> {
     const cfg = this.configService.cfg();
     const syncCfg = cfg?.sync;
-    if (syncCfg?.isEnabled) {
-      await this._syncWrapperService.sync();
+    let isLocalStateFlushed = false;
+    try {
+      await this._operationWriteFlushService.flushPendingWrites();
+      isLocalStateFlushed = true;
+      if (syncCfg?.isEnabled) {
+        await this._runFinalSyncBeforeFinishDay();
+      }
+    } catch (err) {
+      Log.warn(
+        '[DailySummary] Final persistence or sync before finishing day failed:',
+        err,
+      );
+      this._snackService.open({
+        msg: T.F.SYNC.S.FINISH_DAY_SYNC_ERROR,
+        type: 'ERROR',
+      });
+    } finally {
+      if (isLocalStateFlushed && cb) {
+        cb();
+      }
     }
-    if (cb) {
-      cb();
+  }
+
+  private async _runFinalSyncBeforeFinishDay(): Promise<void> {
+    let syncTimeoutId: number | undefined;
+    try {
+      await Promise.race([
+        this._syncWrapperService.sync(),
+        new Promise<never>((_, reject) => {
+          syncTimeoutId = window.setTimeout(
+            () => reject(new Error('Finish day final sync timed out')),
+            FINISH_DAY_FINAL_SYNC_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (syncTimeoutId !== undefined) {
+        window.clearTimeout(syncTimeoutId);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #6423.

- Ensure the daily summary finish callback still runs when the optional final sync fails or times out.
- Flush pending operation-log writes before allowing the finish callback to close or navigate away.
- Add focused tests for final sync failure, final sync timeout, and pending-write flush failure.

## Root Cause

The daily summary `Exit` path archived done tasks and then awaited a final sync before calling `window.ea.shutdownNow()`. If that final sync failed or did not resolve, the shutdown callback was skipped, so the app stayed open after the first click.

## Validation

- `npm run checkFile src/app/pages/daily-summary/daily-summary.component.ts`
- `npm run checkFile src/app/pages/daily-summary/daily-summary.component.spec.ts`
- `npm run test:file src/app/pages/daily-summary/daily-summary.component.spec.ts`
- `git diff --check`