### PR TITLE
fix(focus-mode): constrain long task titles #8012

### DIFF
--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.scss
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.scss
@@ -62,7 +62,10 @@
   justify-content: center;
   position: relative;
   flex-direction: column;
-  margin: var(--s);
+  width: calc(100% - var(--s2));
+  max-width: var(--component-max-width);
+  min-width: 0;
+  margin: var(--s) auto;
 
   &:hover button {
     opacity: 1;
@@ -125,6 +128,12 @@
 }
 
 .task-title {
+  width: 100%;
+  max-width: 100%;
+  max-height: min(24vh, 8em);
+  overflow-x: hidden;
+  overflow-y: auto;
+
   ::ng-deep textarea {
     text-align: center;
   }

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
@@ -178,6 +178,37 @@ describe('FocusModeMainComponent', () => {
     it('should initialize isDragOver to false', () => {
       expect(component.isDragOver()).toBe(false);
     });
+
+    it('should constrain long task titles in focus mode layout (issue #8012)', () => {
+      currentTaskSubject.next({
+        ...mockTask,
+        title: 'A'.repeat(1000),
+      });
+      fixture.detectChanges();
+
+      const taskSection = fixture.nativeElement.querySelector(
+        '.task-section',
+      ) as HTMLElement | null;
+      const taskTitle = fixture.nativeElement.querySelector(
+        'task-title.task-title',
+      ) as HTMLElement | null;
+
+      expect(taskSection).not.toBeNull();
+      expect(taskTitle).not.toBeNull();
+
+      if (!taskSection || !taskTitle) {
+        return;
+      }
+
+      const sectionStyles = window.getComputedStyle(taskSection);
+      const titleStyles = window.getComputedStyle(taskTitle);
+
+      expect(sectionStyles.maxWidth).not.toBe('none');
+      expect(titleStyles.maxWidth).not.toBe('none');
+      expect(titleStyles.maxHeight).not.toBe('none');
+      expect(titleStyles.overflowX).toBe('hidden');
+      expect(titleStyles.overflowY).toBe('auto');
+    });
   });
 
   describe('issue URL observable', () => {


### PR DESCRIPTION
## Summary
- constrain the Focus Mode task title area to the main content width
- cap very long titles with vertical scrolling so pasted text cannot cover the timer and controls
- add a focused regression check for the long-title layout constraints

Fixes #8012

## Validation
- npm run test:file src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
- npm run checkFile src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.scss
- npm run checkFile src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts