### PR TITLE
fix(reminder): require action for reminder popup #8051

### DIFF
--- a/docs/wiki/2.05-Manage-Scheduled-Tasks.md
+++ b/docs/wiki/2.05-Manage-Scheduled-Tasks.md
@@ -37,6 +37,8 @@ The task is scheduled immediately and the menu closes. To pick any date or set a
 2. In **Remind at**, choose when you want to be reminded. Options in the app are: **Never**, **when it starts**, **5 minutes before it starts**, **10 minutes before it starts**, **15 minutes before it starts**, **30 minutes before it starts**, **1 hour before it starts**.
 3. Click **Schedule**.
 
+When a task reminder dialog appears, choose an explicit action such as snooze, unschedule, dismiss the reminder, add to today, start, or done. Clicking outside the dialog or pressing Escape does not dismiss the reminder.
+
 ## Remove Scheduling from a Task
 
 **From the context menu (if the task is already scheduled):** Right-click the task. Next to the calendar icon there is an **Unschedule task** button (event_busy icon). Click it to clear the due date and time.

--- a/e2e/tests/reminders/reminders-deadline.spec.ts
+++ b/e2e/tests/reminders/reminders-deadline.spec.ts
@@ -94,7 +94,7 @@ test.describe('Deadline Reminders', () => {
     await expect(page.locator(REMINDER_DIALOG)).not.toBeVisible();
   });
 
-  test('should not reappear after ESC/backdrop dismissal of the deadline reminder dialog', async ({
+  test('should require an explicit action for the deadline reminder dialog', async ({
     page,
     workViewPage,
     testPrefix,
@@ -143,11 +143,18 @@ test.describe('Deadline Reminders', () => {
       state: 'visible',
       timeout: SCHEDULE_MAX_WAIT_TIME,
     });
-    await expect(page.locator(REMINDER_DIALOG)).toBeVisible();
+    const reminderDialog = page.locator(REMINDER_DIALOG);
+    await expect(reminderDialog).toBeVisible();
 
-    // Dismiss via ESC (simulates user closing the dialog without a dedicated action)
+    // ESC and backdrop clicks must not passively dismiss the reminder dialog.
     await page.keyboard.press('Escape');
-    await page.locator(REMINDER_DIALOG).waitFor({ state: 'hidden', timeout: 10000 });
+    await expect(reminderDialog).toBeVisible();
+
+    await page.locator('.cdk-overlay-backdrop').last().click({ force: true });
+    await expect(reminderDialog).toBeVisible();
+
+    await reminderDialog.locator('button:has-text("Done")').click();
+    await reminderDialog.waitFor({ state: 'hidden', timeout: 10000 });
 
     // Poll over a window longer than the 10s reminder worker tick. If the
     // worker re-fires the past-due deadline, the dialog becomes visible and

--- a/src/app/features/reminder/reminder.module.spec.ts
+++ b/src/app/features/reminder/reminder.module.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { Store } from '@ngrx/store';
 import { NEVER, of, Subject } from 'rxjs';
@@ -18,7 +18,91 @@ import {
   NotificationActionEvent,
 } from '../../core/platform/capacitor-notification.service';
 import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
-import { Task } from '../tasks/task.model';
+import { Task, TaskWithReminderData } from '../tasks/task.model';
+import { DialogViewTaskRemindersComponent } from '../tasks/dialog-view-task-reminders/dialog-view-task-reminders.component';
+
+describe('ReminderModule dialog opening', () => {
+  let matDialogSpy: jasmine.SpyObj<MatDialog>;
+  let remindersActive$: Subject<TaskWithReminderData[]>;
+  let syncDone$: Subject<void>;
+
+  const reminder = {
+    id: 'task-1',
+    title: 'Task 1',
+    reminderData: { remindAt: Date.now() - 1000 },
+  } as TaskWithReminderData;
+
+  beforeEach(() => {
+    remindersActive$ = new Subject<TaskWithReminderData[]>();
+    syncDone$ = new Subject<void>();
+    matDialogSpy = jasmine.createSpyObj('MatDialog', ['open'], { openDialogs: [] });
+
+    const taskServiceSpy = jasmine.createSpyObj('TaskService', ['currentTaskId']);
+    taskServiceSpy.currentTaskId.and.returnValue(null);
+
+    const notifyServiceSpy = jasmine.createSpyObj('NotifyService', ['notify']);
+    notifyServiceSpy.notify.and.resolveTo();
+
+    TestBed.configureTestingModule({
+      providers: [
+        ReminderModule,
+        {
+          provide: ReminderService,
+          useValue: jasmine.createSpyObj('ReminderService', ['init'], {
+            onRemindersActive$: remindersActive$,
+          }),
+        },
+        { provide: MatDialog, useValue: matDialogSpy },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', ['open']),
+        },
+        {
+          provide: UiHelperService,
+          useValue: jasmine.createSpyObj('UiHelperService', ['focusApp']),
+        },
+        { provide: NotifyService, useValue: notifyServiceSpy },
+        {
+          provide: LayoutService,
+          useValue: jasmine.createSpyObj('LayoutService', ['isShowAddTaskBar']),
+        },
+        { provide: TaskService, useValue: taskServiceSpy },
+        {
+          provide: SyncTriggerService,
+          useValue: { afterInitialSyncDoneAndDataLoadedInitially$: syncDone$ },
+        },
+        {
+          provide: SyncWrapperService,
+          useValue: jasmine.createSpyObj('SyncWrapperService', ['sync']),
+        },
+        { provide: Store, useValue: jasmine.createSpyObj('Store', ['dispatch']) },
+        { provide: GlobalConfigService, useValue: { cfg: () => ({}) } },
+        {
+          provide: CapacitorReminderService,
+          useValue: jasmine.createSpyObj('CapacitorReminderService', ['initialize'], {
+            action$: NEVER,
+          }),
+        },
+      ],
+    });
+  });
+
+  it('opens task reminder dialog without passive close paths', fakeAsync(() => {
+    TestBed.inject(ReminderModule);
+
+    syncDone$.next();
+    tick(1000);
+    remindersActive$.next([reminder]);
+
+    expect(matDialogSpy.open).toHaveBeenCalledOnceWith(DialogViewTaskRemindersComponent, {
+      restoreFocus: true,
+      disableClose: true,
+      data: {
+        reminders: [reminder],
+      },
+    });
+  }));
+});
 
 describe('ReminderModule iOS notification actions', () => {
   let module: ReminderModule;

--- a/src/app/features/reminder/reminder.module.ts
+++ b/src/app/features/reminder/reminder.module.ts
@@ -188,6 +188,7 @@ export class ReminderModule {
         } else {
           this._matDialog.open(DialogViewTaskRemindersComponent, {
             restoreFocus: true,
+            disableClose: true,
             data: {
               reminders,
             },


### PR DESCRIPTION
Fixes #8051.

## Summary
- Open the task reminder dialog with `disableClose: true` so backdrop clicks and Escape cannot passively close overdue reminders.
- Add ReminderModule regression coverage for the dialog config.
- Update the scheduled-task wiki note to describe the explicit reminder actions.

## Notes
- This intentionally leaves the tooltip cleanup mentioned in the issue comments for a separate PR.

## Validation
- `npm run test:file src/app/features/reminder/reminder.module.spec.ts` (6 tests passed; run twice after formatting)
- `npm run checkFile src/app/features/reminder/reminder.module.ts`
- `npm run checkFile src/app/features/reminder/reminder.module.spec.ts`
- `git diff --check`
- commit hook: changed-file check and `npm run lint` passed

I did not run the full `npm run test` suite locally because the full Karma/Chrome suite has been unstable in this environment; the targeted reminder module spec passed and CI should cover the full suite.