### PR TITLE
fix: native WebDAV error surfacing

### DIFF
--- a/packages/sync-providers/src/errors.ts
+++ b/packages/sync-providers/src/errors.ts
@@ -15,4 +15,5 @@ export {
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
   UploadRevToMatchMismatchAPIError,
+  WebDavNativeRequestError,
 } from './errors/index';

--- a/packages/sync-providers/src/errors/index.ts
+++ b/packages/sync-providers/src/errors/index.ts
@@ -222,6 +222,16 @@ export class NetworkUnavailableSPError extends Error {
   }
 }
 
+export class WebDavNativeRequestError extends Error {
+  override name = 'WebDavNativeRequestError';
+  readonly code?: string | number;
+
+  constructor(message: string, code?: string | number) {
+    super(message);
+    this.code = code;
+  }
+}
+
 export class AuthFailSPError extends AdditionalLogErrorBase {
   override name = 'AuthFailSPError';
 }

--- a/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
@@ -8,6 +8,7 @@ import {
   PotentialCorsError,
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
+  WebDavNativeRequestError,
 } from '../../errors';
 import { errorMeta } from '../../log/error-meta';
 import { WebDavHttpHeader, WebDavHttpStatus } from './webdav.const';
@@ -168,10 +169,23 @@ export class WebDavHttpAdapter {
         throw e;
       }
 
+      const nativeErrorCode = WebDavHttpAdapter._readErrorCode(e);
       this._deps.logger.critical(
         `${WebDavHttpAdapter.L}.request() error`,
-        errorMeta(e, { url: scrubbedUrl, method: options.method }),
+        errorMeta(e, {
+          ...(nativeErrorCode !== undefined ? { errorCode: nativeErrorCode } : {}),
+          url: scrubbedUrl,
+          method: options.method,
+        }),
       );
+
+      if (this._deps.platformInfo.isNativePlatform) {
+        throw new WebDavNativeRequestError(
+          this._formatNativeErrorMessage(e),
+          nativeErrorCode,
+        );
+      }
+
       // Create a fake Response object for the error
       const errorResponse = new Response(`HTTP error for ${scrubbedUrl}`, {
         status: WebDavHttpStatus.INTERNAL_SERVER_ERROR,
@@ -218,6 +232,34 @@ export class WebDavHttpAdapter {
     }
   }
 
+  private _formatNativeErrorMessage(error: unknown): string {
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : typeof error === 'string' && error
+          ? error
+          : 'Native WebDAV request failed';
+    return WebDavHttpAdapter._redactUrlParts(message);
+  }
+
+  private static _readErrorCode(error: unknown): string | number | undefined {
+    const rawCode = (error as { code?: unknown } | null)?.code;
+    return typeof rawCode === 'string' || typeof rawCode === 'number'
+      ? rawCode
+      : undefined;
+  }
+
+  private static _redactUrlParts(message: string): string {
+    return message.replace(/https?:\/\/[^\s"'<>]+/gi, (rawUrl) => {
+      try {
+        const url = new URL(rawUrl);
+        return `${url.protocol}//${url.host}`;
+      } catch {
+        return '[redacted-url]';
+      }
+    });
+  }
+
   /**
    * Serialize the allowlisted cache-relevant headers (case-insensitive) into a
    * compact, log-safe string like `etag=W/"a1"; age=3; x-cache=HIT`. Returns
@@ -258,7 +300,7 @@ export class WebDavHttpAdapter {
     }
 
     if (status === WebDavHttpStatus.UNAUTHORIZED) {
-      throw new AuthFailSPError();
+      throw new AuthFailSPError('Authentication failed (HTTP 401)');
     }
 
     if (status === WebDavHttpStatus.NOT_FOUND) {

--- a/packages/sync-providers/src/http/native-http-retry.ts
+++ b/packages/sync-providers/src/http/native-http-retry.ts
@@ -1,4 +1,5 @@
 import { NOOP_SYNC_LOGGER, toSyncLogError, type SyncLogger } from '@sp/sync-core';
+import { urlHostOnly } from '../log/error-meta';
 
 /**
  * Max retries for transient network errors (e.g., iOS NSURLErrorNetworkConnectionLost).
@@ -100,7 +101,7 @@ export const executeNativeRequestWithRetry = async (
           `${label} transient network error, retrying in ${delayMs}ms ` +
             `(attempt ${attempt + 1}/${maxRetries})`,
           {
-            url: config.url,
+            url: urlHostOnly(config.url),
             attempt: attempt + 1,
             maxRetries,
             delayMs,
@@ -148,7 +149,9 @@ export const isTransientNetworkError = (e: unknown): boolean => {
     if (
       errorCode === 'SocketTimeoutException' ||
       errorCode === 'UnknownHostException' ||
-      errorCode === 'ConnectException'
+      errorCode === 'ConnectException' ||
+      errorCode === 'NETWORK_ERROR' ||
+      errorCode === 'TIMEOUT_ERROR'
     ) {
       return true;
     }

--- a/packages/sync-providers/src/log.ts
+++ b/packages/sync-providers/src/log.ts
@@ -1,1 +1,1 @@
-export { errorMeta, urlPathOnly } from './log/error-meta';
+export { errorMeta, urlHostOnly, urlPathOnly } from './log/error-meta';

--- a/packages/sync-providers/src/log/error-meta.ts
+++ b/packages/sync-providers/src/log/error-meta.ts
@@ -18,6 +18,20 @@ export const urlPathOnly = (url: string): string => {
 };
 
 /**
+ * Keep only the URL host for exportable log metadata.
+ *
+ * Unlike `urlPathOnly`, invalid inputs are not returned unchanged because this
+ * helper is intended for potentially user-configured sync endpoints.
+ */
+export const urlHostOnly = (url: string): string => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return '[invalid-url]';
+  }
+};
+
+/**
  * Build privacy-aware `SyncLogMeta` from an unknown error plus an
  * optional bag of extra fields.
  *

--- a/packages/sync-providers/tests/errors.spec.ts
+++ b/packages/sync-providers/tests/errors.spec.ts
@@ -16,6 +16,7 @@ import {
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
   UploadRevToMatchMismatchAPIError,
+  WebDavNativeRequestError,
 } from '../src/errors';
 
 describe('AdditionalLogErrorBase', () => {
@@ -173,6 +174,7 @@ describe('Error class identity (single definition per class)', () => {
       ['PotentialCorsError', PotentialCorsError],
       ['RemoteFileChangedUnexpectedly', RemoteFileChangedUnexpectedly],
       ['NetworkUnavailableSPError', NetworkUnavailableSPError],
+      ['WebDavNativeRequestError', WebDavNativeRequestError],
     ];
 
   it.each(ERROR_CLASSES)('%s is an Error subclass', (_name, ErrCtor) => {
@@ -201,6 +203,8 @@ describe('Error class identity (single definition per class)', () => {
       instance = new TooManyRequestsAPIError({ status: 429 });
     } else if (ErrCtor === PotentialCorsError) {
       instance = new PotentialCorsError('https://example.test');
+    } else if (ErrCtor === WebDavNativeRequestError) {
+      instance = new WebDavNativeRequestError('Native request failed');
     } else {
       instance = new (ErrCtor as new (...a: never[]) => Error)();
     }
@@ -211,5 +215,10 @@ describe('Error class identity (single definition per class)', () => {
     const err = new EmptyRemoteBodySPError('empty body');
     expect(err).toBeInstanceOf(InvalidDataSPError);
     expect(err).toBeInstanceOf(Error);
+  });
+
+  it('WebDavNativeRequestError preserves native error code for catch-site classification', () => {
+    const err = new WebDavNativeRequestError('Network error', 'NETWORK_ERROR');
+    expect(err.code).toBe('NETWORK_ERROR');
   });
 });

--- a/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
@@ -15,6 +15,7 @@ import {
   MissingCredentialsSPError,
   RemoteFileChangedUnexpectedly,
   RemoteFileNotFoundAPIError,
+  WebDavNativeRequestError,
 } from '../../../src/errors';
 
 const cfg: WebdavPrivateCfg = {
@@ -289,6 +290,28 @@ describe('WebdavApi', () => {
       const r = await makeApi(adapter).testConnection(cfg);
       expect(r.success).toBe(false);
       expect(r.error).toBe('Network unreachable');
+      expect(r.fullUrl).toContain('dav.example.com');
+    });
+
+    // Issue #8053: on native platforms the adapter wraps a thrown native
+    // request error (SSL/timeout/DNS) into WebDavNativeRequestError carrying a
+    // readable, already-redacted message. testConnection must surface that
+    // message verbatim as `result.error` so the "Test connection" snackbar
+    // shows something actionable instead of "Unknown error". This guards the
+    // seam between the adapter (proven to redact in webdav-http-adapter.spec)
+    // and the user-facing return value.
+    it('surfaces a native WebDavNativeRequestError message to the user', async () => {
+      const adapter = makeAdapter();
+      adapter.request.mockRejectedValue(
+        new WebDavNativeRequestError(
+          'SSL error: Trust anchor for certification path not found',
+          'SSL_ERROR',
+        ),
+      );
+      const r = await makeApi(adapter).testConnection(cfg);
+      expect(r.success).toBe(false);
+      expect(r.error).toBe('SSL error: Trust anchor for certification path not found');
+      expect(r.error).not.toBe('Unknown error');
       expect(r.fullUrl).toContain('dav.example.com');
     });
 

--- a/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
@@ -7,6 +7,7 @@ import {
   PotentialCorsError,
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
+  WebDavNativeRequestError,
 } from '../../../src/errors';
 import type { NativeHttpExecutor } from '../../../src/http';
 import type { ProviderPlatformInfo, WebFetchFactory } from '../../../src/platform';
@@ -121,9 +122,14 @@ describe('WebDavHttpAdapter', () => {
       const adapter = new WebDavHttpAdapter(
         makeDeps({ fetchImpl: fetchImpl as unknown as typeof fetch }),
       );
-      await expect(
-        adapter.request({ url: 'https://dav.example.com/x', method: 'GET' }),
-      ).rejects.toBeInstanceOf(AuthFailSPError);
+      const promise = adapter.request({
+        url: 'https://dav.example.com/x',
+        method: 'GET',
+      });
+      await expect(promise).rejects.toBeInstanceOf(AuthFailSPError);
+      await expect(promise).rejects.toMatchObject({
+        message: 'Authentication failed (HTTP 401)',
+      });
     });
 
     it('throws RemoteFileNotFoundAPIError on 404', async () => {
@@ -343,6 +349,67 @@ describe('WebDavHttpAdapter', () => {
           url: 'dav.example.com',
         }),
       );
+    });
+
+    it('surfaces native network errors with code and readable message', async () => {
+      const nativeHttp = vi.fn().mockRejectedValue(
+        Object.assign(new Error('Network error: Unable to resolve host'), {
+          code: 'NETWORK_ERROR',
+        }),
+      );
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isNativePlatform: true, nativeHttp, logger }),
+      );
+
+      const promise = adapter.request({
+        url: 'https://dav.example.com/sync/file',
+        method: 'PROPFIND',
+      });
+      await expect(promise).rejects.toBeInstanceOf(WebDavNativeRequestError);
+      await expect(promise).rejects.toMatchObject({
+        message: 'Network error: Unable to resolve host',
+        code: 'NETWORK_ERROR',
+      });
+
+      const errorLog = loggedMessages.find((l) => l.msg.includes('error'));
+      expect(errorLog?.meta).toEqual(
+        expect.objectContaining({
+          errorName: 'Error',
+          errorCode: 'NETWORK_ERROR',
+          url: 'dav.example.com',
+        }),
+      );
+    });
+
+    it('redacts URL secrets and paths from re-thrown native error messages', async () => {
+      const nativeHttp = vi
+        .fn()
+        .mockRejectedValue(
+          Object.assign(
+            new Error(
+              'Network error: Failed for https://user:pass@dav.example.com/remote.php/dav/files/alice/sp?token=secret#frag',
+            ),
+            { code: 'NETWORK_ERROR' },
+          ),
+        );
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isNativePlatform: true, nativeHttp, logger }),
+      );
+
+      try {
+        await adapter.request({
+          url: 'https://dav.example.com/sync/file',
+          method: 'PROPFIND',
+        });
+        expect.fail('expected throw');
+      } catch (e) {
+        const message = (e as Error).message;
+        expect(message).toContain('https://dav.example.com');
+        expect(message).not.toContain('user:pass');
+        expect(message).not.toContain('token=secret');
+        expect(message).not.toContain('/remote.php');
+        expect(message).not.toContain('alice');
+      }
     });
   });
 });

--- a/packages/sync-providers/tests/log/error-meta.spec.ts
+++ b/packages/sync-providers/tests/log/error-meta.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { errorMeta, urlPathOnly } from '../../src/log';
+import { errorMeta, urlHostOnly, urlPathOnly } from '../../src/log';
 
 describe('urlPathOnly', () => {
   it('strips query string', () => {
@@ -70,6 +70,33 @@ describe('urlPathOnly', () => {
     expect(stripped).not.toContain('access_token');
     expect(stripped).not.toContain('SECRETTOKENVALUE');
     expect(stripped).not.toContain('refresh_token');
+  });
+});
+
+describe('urlHostOnly', () => {
+  it('keeps only the host', () => {
+    expect(urlHostOnly('https://api.dropbox.com/2/files/upload?token=abc123')).toBe(
+      'api.dropbox.com',
+    );
+  });
+
+  it('strips userinfo, path, query, and fragment', () => {
+    const host = urlHostOnly(
+      'https://user:secret@host.example.com:8443/path/to/file?token=abc#anchor',
+    );
+
+    expect(host).toBe('host.example.com:8443');
+    expect(host).not.toContain('user');
+    expect(host).not.toContain('secret');
+    expect(host).not.toContain('/path');
+    expect(host).not.toContain('token');
+    expect(host).not.toContain('anchor');
+  });
+
+  it('returns a fixed placeholder for invalid URLs', () => {
+    expect(urlHostOnly('/relative/path?token=x')).toBe('[invalid-url]');
+    expect(urlHostOnly('not a url')).toBe('[invalid-url]');
+    expect(urlHostOnly('')).toBe('[invalid-url]');
   });
 });
 

--- a/packages/sync-providers/tests/native-http-retry.spec.ts
+++ b/packages/sync-providers/tests/native-http-retry.spec.ts
@@ -68,6 +68,27 @@ describe('isTransientNetworkError', () => {
       });
       expect(isTransientNetworkError(error)).toBe(true);
     });
+
+    it('returns true for custom WebDavHttp NETWORK_ERROR', () => {
+      const error = Object.assign(new Error('connection reset'), {
+        code: 'NETWORK_ERROR',
+      });
+      expect(isTransientNetworkError(error)).toBe(true);
+    });
+
+    it('returns true for custom WebDavHttp TIMEOUT_ERROR', () => {
+      const error = Object.assign(new Error('request took too long'), {
+        code: 'TIMEOUT_ERROR',
+      });
+      expect(isTransientNetworkError(error)).toBe(true);
+    });
+
+    it('returns false for custom WebDavHttp SSL_ERROR', () => {
+      const error = Object.assign(new Error('certificate rejected'), {
+        code: 'SSL_ERROR',
+      });
+      expect(isTransientNetworkError(error)).toBe(false);
+    });
   });
 
   describe('Fallback string matching', () => {
@@ -329,10 +350,14 @@ describe('executeNativeRequestWithRetry', () => {
       .fn<NativeHttpExecutor>()
       .mockRejectedValueOnce(transientError)
       .mockResolvedValueOnce(successResponse);
+    const config: NativeHttpRequestConfig = {
+      ...baseConfig,
+      url: 'https://user:secret@example.com:8443/private/sync.json?token=abc#frag',
+    };
     const { delay } = collectDelays();
     const logger = noopLogger();
 
-    await executeNativeRequestWithRetry(baseConfig, {
+    await executeNativeRequestWithRetry(config, {
       executor,
       label: 'Test',
       logger,
@@ -343,13 +368,18 @@ describe('executeNativeRequestWithRetry', () => {
     const [message, meta] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(message).toContain('Test transient network error');
     expect(meta).toMatchObject({
-      url: baseConfig.url,
+      url: 'example.com:8443',
       attempt: 1,
       maxRetries: 2,
       delayMs: 1500,
       errorName: 'Error',
       errorCode: 'NSURLErrorDomain',
     });
+    expect(JSON.stringify(meta)).not.toContain('user');
+    expect(JSON.stringify(meta)).not.toContain('secret');
+    expect(JSON.stringify(meta)).not.toContain('private');
+    expect(JSON.stringify(meta)).not.toContain('token');
+    expect(JSON.stringify(meta)).not.toContain('frag');
   });
 
   it('does not retry when maxRetries is 0', async () => {

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -34,6 +34,7 @@ import {
   JsonParseError,
   SyncDataCorruptedError,
   UploadRevToMatchMismatchAPIError,
+  WebDavNativeRequestError,
 } from '../../op-log/core/errors/sync-errors';
 import { MAX_LWW_REUPLOAD_RETRIES } from '../../op-log/core/operation-log.const';
 
@@ -1081,6 +1082,32 @@ describe('SyncWrapperService', () => {
         jasmine.objectContaining({
           msg: T.F.SYNC.S.NETWORK_ERROR,
           type: 'WARNING',
+        }),
+      );
+    });
+
+    it('should treat native WebDAV timeout codes as transient network errors', async () => {
+      mockSyncService.downloadRemoteOps.and.returnValue(
+        Promise.reject(
+          new WebDavNativeRequestError('Network error: Request timeout', 'TIMEOUT_ERROR'),
+        ),
+      );
+
+      const result = await service.sync(true);
+
+      expect(result).toBe('HANDLED_ERROR');
+      expect(mockProviderManager.setSyncStatus).toHaveBeenCalledWith(
+        'UNKNOWN_OR_CHANGED',
+      );
+      expect(mockSnackService.open).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          msg: T.F.SYNC.S.NETWORK_ERROR,
+          type: 'WARNING',
+        }),
+      );
+      expect(mockSnackService.open).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          msg: T.F.SYNC.S.TIMEOUT_ERROR,
         }),
       );
     });

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -827,26 +827,6 @@ export class SyncWrapperService {
           config: { duration: 15000 },
         });
         return 'HANDLED_ERROR';
-      } else if (this._isTimeoutError(error)) {
-        // Like the transient-network branch below, a sync timeout is
-        // self-healing (the next cycle retries) and its "Please try again"
-        // message only makes sense for someone actively waiting — so only
-        // surface it for user-triggered syncs. This also closes the gap where a
-        // connectivity error phrased "timeout" (one word, caught here) would
-        // otherwise still flash on automatic resume syncs while "timed out"
-        // (caught by the transient-network branch) stayed silent.
-        if (isUserTriggered) {
-          this._snackService.open({
-            msg: T.F.SYNC.S.TIMEOUT_ERROR,
-            type: 'ERROR',
-            config: { duration: 12000 },
-            translateParams: {
-              suggestion:
-                'Large sync operations may take up to 90 seconds. Please try again.',
-            },
-          });
-        }
-        return 'HANDLED_ERROR';
       } else if (
         error instanceof NetworkUnavailableSPError ||
         isTransientNetworkError(error)
@@ -866,6 +846,24 @@ export class SyncWrapperService {
           this._snackService.open({
             msg: T.F.SYNC.S.NETWORK_ERROR,
             type: 'WARNING',
+          });
+        }
+        return 'HANDLED_ERROR';
+      } else if (this._isTimeoutError(error)) {
+        // Like transient network failures, a sync timeout is self-healing (the
+        // next cycle retries) and its "Please try again" message only makes
+        // sense for someone actively waiting. Structured native transport
+        // timeouts are handled by the network branch above so status is marked
+        // UNKNOWN_OR_CHANGED consistently.
+        if (isUserTriggered) {
+          this._snackService.open({
+            msg: T.F.SYNC.S.TIMEOUT_ERROR,
+            type: 'ERROR',
+            config: { duration: 12000 },
+            translateParams: {
+              suggestion:
+                'Large sync operations may take up to 90 seconds. Please try again.',
+            },
           });
         }
         return 'HANDLED_ERROR';

--- a/src/app/op-log/core/errors/sync-errors.identity.spec.ts
+++ b/src/app/op-log/core/errors/sync-errors.identity.spec.ts
@@ -13,6 +13,7 @@ import {
   RemoteFileNotFoundAPIError as PackageRemoteFileNotFoundAPIError,
   TooManyRequestsAPIError as PackageTooManyRequestsAPIError,
   UploadRevToMatchMismatchAPIError as PackageUploadRevToMatchMismatchAPIError,
+  WebDavNativeRequestError as PackageWebDavNativeRequestError,
 } from '@sp/sync-providers/errors';
 import { WebCryptoNotAvailableError as PackageWebCryptoNotAvailableError } from '@sp/sync-core';
 import {
@@ -30,6 +31,7 @@ import {
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
   UploadRevToMatchMismatchAPIError,
+  WebDavNativeRequestError,
   WebCryptoNotAvailableError,
 } from './sync-errors';
 
@@ -83,6 +85,11 @@ describe('sync-errors identity (single class definition across import paths)', (
       'RemoteFileChangedUnexpectedly',
       RemoteFileChangedUnexpectedly,
       PackageRemoteFileChangedUnexpectedly,
+    ],
+    [
+      'WebDavNativeRequestError',
+      WebDavNativeRequestError,
+      PackageWebDavNativeRequestError,
     ],
     // Re-exported from @sp/sync-core (not @sp/sync-providers/errors), but the
     // identity rule is the same: a single class definition must back every

--- a/src/app/op-log/core/errors/sync-errors.ts
+++ b/src/app/op-log/core/errors/sync-errors.ts
@@ -27,6 +27,7 @@ export {
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
   UploadRevToMatchMismatchAPIError,
+  WebDavNativeRequestError,
 } from '@sp/sync-providers/errors';
 
 export const extractErrorMessage = packageExtractErrorMessage;


### PR DESCRIPTION
## Summary

Fixes #8053.

This preserves native WebDAV transport failures instead of flattening them into a synthetic HTTP 500 error. Android/iOS WebDAV failures now surface as `WebDavNativeRequestError` with the native code preserved, so connection tests can show useful diagnostics such as DNS, timeout, or SSL failures.

## Root Cause

The native WebDAV adapter caught non-HTTP native plugin rejections and rewrapped them as `HttpNotOkAPIError` with a fake response. That erased the useful native failure code/message, so the WebDAV connection test could only report an unknown/generic error.

## Changes

- Add exported `WebDavNativeRequestError` in `@sp/sync-providers/errors` and re-export it through the app error shim.
- Preserve and sanitize native WebDAV errors in the adapter instead of converting them to fake HTTP errors.
- Keep WebDAV 401 failures as `AuthFailSPError` with a clearer `Authentication failed (HTTP 401)` message.
- Treat native WebDAV `NETWORK_ERROR` and `TIMEOUT_ERROR` codes as transient network failures.
- Ensure retry logs record host-only URL metadata, not paths, query strings, fragments, or userinfo.
- Route structured native timeout codes through the transient-network sync wrapper branch before generic timeout handling.
- Add regression coverage for error identity, redaction, connection-test surfacing, retry classification, safe log metadata, and wrapper classification.

## Validation

- `npm run checkFile ...` for each modified TypeScript file
- `npm --workspace @sp/sync-providers test` passed: 374 tests
- `npm run test:file src/app/imex/sync/sync-wrapper.service.spec.ts` passed: 123 tests
- `npm run test:file src/app/op-log/core/errors/sync-errors.identity.spec.ts` passed: 16 tests
- `npm run build` passed
- Push hook passed full lint and tests:
  - sync-core: 207 tests
  - sync-providers: 374 tests
  - release notes: 9 tests
  - default Angular/Karma suite: 10347 passed, 2 skipped
  - Los Angeles timezone Angular/Karma suite: 10333 passed, 16 skipped
