### PR TITLE
docs(sync): document Proton Drive via rclone + WebDAV

### DIFF
--- a/docs/wiki/2.08-Choose-Sync-Backend.md
+++ b/docs/wiki/2.08-Choose-Sync-Backend.md
@@ -18,6 +18,8 @@ In the **Sync provider** dropdown you will see:
 - **WebDAV (experimental)** — Sync via any other WebDAV-compatible server (e.g. ownCloud or a NAS). Labeled **experimental** because WebDAV implementations differ a lot between providers and may not work smoothly with every server. The option is not being removed.
 - **Local file (experimental)** — Saves the sync file to a folder on your machine (desktop or Android). Labeled **experimental** because behavior can depend on how you use that folder (e.g. multiple app instances at once). For many users it works fine. It is **not** being removed.
 
+Advanced users can also expose some other storage providers as WebDAV themselves. For example, Proton Drive can be used through a local rclone WebDAV bridge; see [[2.19-Sync-Proton-Drive-via-rclone]]. This is not a built-in Proton Drive provider.
+
 ## When to Use Which
 
 - **You want the newest sync stack and can accept beta** → **SuperSync** (self-hosted or hosted). Good if you want real-time sync and optional E2E encryption on the server.
@@ -25,6 +27,7 @@ In the **Sync provider** dropdown you will see:
 - **You already use Nextcloud** → **Nextcloud**. Use this instead of generic WebDAV unless you specifically need to enter the full WebDAV base URL yourself.
 - **You already use another WebDAV server** → **WebDAV**. Try it; if it works with your server, you’re set. If not, the experimental label reflects that WebDAV compatibility varies.
 - **You want backup or sync to a local/network folder (desktop or Android only)** → **Local file**. No account, no internet. Use for one device or backup to an external drive/NAS. **Do not** use tools like Syncthing or Resilio to sync that same folder between devices—they can cause conflicts. For multi-device sync, use WebDAV, Dropbox, or SuperSync instead.
+- **You use Proton Drive and accept an advanced setup** → Use **WebDAV** with a local rclone bridge. See [[2.19-Sync-Proton-Drive-via-rclone]]. This is not an officially supported built-in provider.
 
 ## Important: Local File and Syncthing/Resilio
 
@@ -34,5 +37,6 @@ Local file sync stores data in **one folder** on your device. The app warns: do 
 
 - [[1.02-Configure-Data-Synchronization]] — Quickstart: set up and configure sync from start to finish
 - [[2.09-Configure-Sync-Backend]] — Configure your chosen provider
+- [[2.19-Sync-Proton-Drive-via-rclone]] — Advanced Proton Drive setup through rclone and WebDAV
 - [[3.08-Sync-Integration-Comparison]] — Comparison table and details
 - [[4.23-Managing-Your-Data]] and [[3.06-User-Data]] — Where data and backups live, and how sync behaves

--- a/docs/wiki/3.08-Sync-Integration-Comparison.md
+++ b/docs/wiki/3.08-Sync-Integration-Comparison.md
@@ -35,6 +35,7 @@ Sync providers **synchronize your full Super Productivity data** (tasks, project
 - **Configuration:** Base URL, username, password, and an optional sync folder path on the server.
 - **Encryption:** Optional client-side encryption; you set an encryption key that is not sent to the server.
 - **Platform:** Available on desktop (Electron), web, and mobile. In the browser, CORS can block WebDAV requests; the app may recommend the desktop version for reliable sync.
+- **Advanced recipes:** Some storage providers can be exposed as local WebDAV with external tools. For Proton Drive via rclone, see [[2.19-Sync-Proton-Drive-via-rclone]]. This is not a built-in Proton Drive provider.
 
 ### Dropbox
 
@@ -70,6 +71,7 @@ Conflict resolution (e.g. when two devices change the same data) is the same for
 ## Related
 
 - [[4.24-Integrations]] — How issue and sync providers work
+- [[2.19-Sync-Proton-Drive-via-rclone]] — Advanced Proton Drive setup through rclone and WebDAV
 - [[3.07-Issue-Integration-Comparison]] — Issue provider comparison
 - [[4.23-Managing-Your-Data]] — Backups, import/export, and sync from a user perspective
 - [[3.06-User-Data]] — Where data and backups are stored, sync behavior by platform

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,4 +1,5 @@
 <!-- pyml disable md041 -->
+
 ## [[1.00-Quickstarts]]
 
 - [[1.01-First-Steps]]
@@ -17,6 +18,7 @@
 - [[2.07-Manage-Task-Integrations]]
 - [[2.08-Choose-Sync-Backend]]
 - [[2.09-Configure-Sync-Backend]]
+- [[2.19-Sync-Proton-Drive-via-rclone]]
 - [[2.13-Run-with-Docker]]
 
 ### Contributing to Super-Productivity


### PR DESCRIPTION
Document how to sync Super Productivity to **Proton Drive** on desktop using the existing **WebDAV** provider pointed at a local `rclone serve webdav` bridge, rather than a dedicated built-in provider.

This wires cross-references to the rclone + WebDAV guide ([`2.19-Sync-Proton-Drive-via-rclone`](docs/wiki/2.19-Sync-Proton-Drive-via-rclone.md)) into the sync docs and the wiki sidebar. Marked experimental and no-support, in line with how generic WebDAV is treated, since it relies on rclone's reverse-engineered Proton backend.

## Problem

#8008 asks for Proton Drive sync. Proton Drive has no official third-party API, and rclone's Proton backend is community-maintained and reverse-engineered — so a bundled built-in provider would add ongoing maintenance and security surface (spawning/managing a local `rclone` process). Documenting the supported WebDAV + rclone path avoids that while giving users a working setup.

## Solution

- `2.08-Choose-Sync-Backend.md` — note the advanced rclone + WebDAV Proton Drive recipe in the overview and "When to Use Which".
- `3.08-Sync-Integration-Comparison.md` — mention it under WebDAV "Advanced recipes" and in Related.
- `_Sidebar.md` — add the guide to the navigation.

Each reference clarifies this is **not** an officially supported built-in Proton Drive provider.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Closes: #8008
