### PR TITLE
feat(redmine): allow searching issues by id

### DIFF
--- a/src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
+++ b/src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { RedmineApiService } from './redmine-api.service';
+import { RedmineCfg } from './redmine.model';
+import { SearchResultItem } from '../../issue.model';
+import { SnackService } from '../../../../core/snack/snack.service';
+
+describe('RedmineApiService', () => {
+  let service: RedmineApiService;
+  let httpMock: HttpTestingController;
+
+  const mockCfg: RedmineCfg = {
+    isEnabled: true,
+    host: 'https://redmine.example.com',
+    projectId: 'test-project',
+    api_key: 'test-api-key',
+    scope: null,
+  };
+
+  const mockSearchResponse = {
+    results: [
+      {
+        id: 100,
+        title: 'Bug #100: Some text issue',
+        url: 'https://redmine.example.com/issues/100',
+      },
+    ],
+    total_count: 1,
+    offset: 0,
+    limit: 100,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        RedmineApiService,
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', ['open']),
+        },
+      ],
+    });
+    service = TestBed.inject(RedmineApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('searchIssuesInProject$', () => {
+    const searchUrl = (query: string): string =>
+      `${mockCfg.host}/projects/${mockCfg.projectId}/search.json?limit=100&q=${query}&issues=1&open_issues=1`;
+
+    it('should only send a text search request for non-numeric queries', () => {
+      let result: SearchResultItem[] | undefined;
+      service.searchIssuesInProject$('some text', mockCfg).subscribe((r) => (result = r));
+
+      const req = httpMock.expectOne(searchUrl('some%20text'));
+      expect(req.request.method).toBe('GET');
+      req.flush(mockSearchResponse);
+
+      httpMock.expectNone(`${mockCfg.host}/issues/100.json`);
+      expect(result?.length).toBe(1);
+      expect(result?.[0].title).toBe('Bug #100: Some text issue');
+    });
+
+    it('should additionally fetch the issue by id for numeric queries', () => {
+      let result: SearchResultItem[] | undefined;
+      service.searchIssuesInProject$('22899', mockCfg).subscribe((r) => (result = r));
+
+      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/22899.json`);
+      expect(byIdReq.request.method).toBe('GET');
+      byIdReq.flush({ issue: { id: 22899, subject: 'Issue found by id' } });
+
+      const searchReq = httpMock.expectOne(searchUrl('22899'));
+      searchReq.flush(mockSearchResponse);
+
+      expect(result?.length).toBe(2);
+      expect(result?.[0].title).toBe('#22899 Issue found by id');
+      expect((result?.[0].issueData as { id: number }).id).toBe(22899);
+    });
+
+    it('should support queries prefixed with #', () => {
+      let result: SearchResultItem[] | undefined;
+      service.searchIssuesInProject$('#22899', mockCfg).subscribe((r) => (result = r));
+
+      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/22899.json`);
+      byIdReq.flush({ issue: { id: 22899, subject: 'Issue found by id' } });
+
+      const searchReq = httpMock.expectOne(searchUrl('%2322899'));
+      searchReq.flush({ ...mockSearchResponse, results: [] });
+
+      expect(result?.length).toBe(1);
+      expect(result?.[0].title).toBe('#22899 Issue found by id');
+    });
+
+    it('should de-duplicate the by-id issue from text search results', () => {
+      let result: SearchResultItem[] | undefined;
+      service.searchIssuesInProject$('100', mockCfg).subscribe((r) => (result = r));
+
+      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/100.json`);
+      byIdReq.flush({ issue: { id: 100, subject: 'Some text issue' } });
+
+      const searchReq = httpMock.expectOne(searchUrl('100'));
+      searchReq.flush(mockSearchResponse);
+
+      expect(result?.length).toBe(1);
+      expect(result?.[0].title).toBe('#100 Some text issue');
+    });
+
+    it('should fall back to text search results when issue id is not found', () => {
+      let result: SearchResultItem[] | undefined;
+      service.searchIssuesInProject$('99999', mockCfg).subscribe((r) => (result = r));
+
+      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/99999.json`);
+      byIdReq.flush('Not found', { status: 404, statusText: 'Not Found' });
+
+      const searchReq = httpMock.expectOne(searchUrl('99999'));
+      searchReq.flush(mockSearchResponse);
+
+      expect(result?.length).toBe(1);
+      expect(result?.[0].title).toBe('Bug #100: Some text issue');
+    });
+  });
+});

--- a/src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
+++ b/src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
@@ -3,6 +3,7 @@ import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
+import { HttpRequest } from '@angular/common/http';
 import { RedmineApiService } from './redmine-api.service';
 import { RedmineCfg } from './redmine.model';
 import { SearchResultItem } from '../../issue.model';
@@ -32,6 +33,16 @@ describe('RedmineApiService', () => {
     offset: 0,
     limit: 100,
   };
+
+  // by-id lookup is scoped to the configured project (not the global /issues/{id}.json)
+  const byIdInProjectMatcher =
+    (issueId: number) =>
+    (req: HttpRequest<unknown>): boolean =>
+      req.method === 'GET' &&
+      req.url === `${mockCfg.host}/projects/${mockCfg.projectId}/issues.json` &&
+      req.params.get('issue_id') === String(issueId) &&
+      // status_id=* so closed issues are found too
+      req.params.get('status_id') === '*';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -68,18 +79,17 @@ describe('RedmineApiService', () => {
       expect(req.request.method).toBe('GET');
       req.flush(mockSearchResponse);
 
-      httpMock.expectNone(`${mockCfg.host}/issues/100.json`);
+      httpMock.expectNone(byIdInProjectMatcher(100));
       expect(result?.length).toBe(1);
       expect(result?.[0].title).toBe('Bug #100: Some text issue');
     });
 
-    it('should additionally fetch the issue by id for numeric queries', () => {
+    it('should additionally fetch the issue by id (project-scoped) for numeric queries', () => {
       let result: SearchResultItem[] | undefined;
       service.searchIssuesInProject$('22899', mockCfg).subscribe((r) => (result = r));
 
-      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/22899.json`);
-      expect(byIdReq.request.method).toBe('GET');
-      byIdReq.flush({ issue: { id: 22899, subject: 'Issue found by id' } });
+      const byIdReq = httpMock.expectOne(byIdInProjectMatcher(22899));
+      byIdReq.flush({ issues: [{ id: 22899, subject: 'Issue found by id' }] });
 
       const searchReq = httpMock.expectOne(searchUrl('22899'));
       searchReq.flush(mockSearchResponse);
@@ -93,8 +103,8 @@ describe('RedmineApiService', () => {
       let result: SearchResultItem[] | undefined;
       service.searchIssuesInProject$('#22899', mockCfg).subscribe((r) => (result = r));
 
-      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/22899.json`);
-      byIdReq.flush({ issue: { id: 22899, subject: 'Issue found by id' } });
+      const byIdReq = httpMock.expectOne(byIdInProjectMatcher(22899));
+      byIdReq.flush({ issues: [{ id: 22899, subject: 'Issue found by id' }] });
 
       const searchReq = httpMock.expectOne(searchUrl('%2322899'));
       searchReq.flush({ ...mockSearchResponse, results: [] });
@@ -107,8 +117,8 @@ describe('RedmineApiService', () => {
       let result: SearchResultItem[] | undefined;
       service.searchIssuesInProject$('100', mockCfg).subscribe((r) => (result = r));
 
-      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/100.json`);
-      byIdReq.flush({ issue: { id: 100, subject: 'Some text issue' } });
+      const byIdReq = httpMock.expectOne(byIdInProjectMatcher(100));
+      byIdReq.flush({ issues: [{ id: 100, subject: 'Some text issue' }] });
 
       const searchReq = httpMock.expectOne(searchUrl('100'));
       searchReq.flush(mockSearchResponse);
@@ -117,18 +127,36 @@ describe('RedmineApiService', () => {
       expect(result?.[0].title).toBe('#100 Some text issue');
     });
 
-    it('should fall back to text search results when issue id is not found', () => {
+    it('should fall back to text search results when the id is not in the project', () => {
       let result: SearchResultItem[] | undefined;
       service.searchIssuesInProject$('99999', mockCfg).subscribe((r) => (result = r));
 
-      const byIdReq = httpMock.expectOne(`${mockCfg.host}/issues/99999.json`);
-      byIdReq.flush('Not found', { status: 404, statusText: 'Not Found' });
+      const byIdReq = httpMock.expectOne(byIdInProjectMatcher(99999));
+      // Redmine returns an empty list (not a 404) for an id outside the project
+      byIdReq.flush({ issues: [], total_count: 0, offset: 0, limit: 1 });
 
       const searchReq = httpMock.expectOne(searchUrl('99999'));
       searchReq.flush(mockSearchResponse);
 
       expect(result?.length).toBe(1);
       expect(result?.[0].title).toBe('Bug #100: Some text issue');
+    });
+
+    it('should not surface an issue id that belongs to another project', () => {
+      let result: SearchResultItem[] | undefined;
+      service.searchIssuesInProject$('424242', mockCfg).subscribe((r) => (result = r));
+
+      // The lookup is scoped to the configured project; an id belonging to another
+      // project the API key can see is therefore returned as an empty list by Redmine.
+      const byIdReq = httpMock.expectOne(byIdInProjectMatcher(424242));
+      byIdReq.flush({ issues: [], total_count: 0, offset: 0, limit: 1 });
+
+      const searchReq = httpMock.expectOne(searchUrl('424242'));
+      searchReq.flush({ ...mockSearchResponse, results: [] });
+
+      // no global /issues/{id}.json request is ever made
+      httpMock.expectNone(`${mockCfg.host}/issues/424242.json`);
+      expect(result?.length).toBe(0);
     });
   });
 });

--- a/src/app/features/issue/providers/redmine/redmine-api.service.ts
+++ b/src/app/features/issue/providers/redmine/redmine-api.service.ts
@@ -3,7 +3,7 @@ import { SnackService } from '../../../../core/snack/snack.service';
 import { HttpClient, HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
 import { RedmineCfg } from './redmine.model';
 import { catchError, filter, map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { forkJoin, Observable, of, throwError } from 'rxjs';
 import { throwHandledError } from '../../../../util/throw-handled-error';
 import { T } from '../../../../t.const';
 import { ISSUE_PROVIDER_HUMANIZED, REDMINE_TYPE } from '../../issue.const';
@@ -16,12 +16,17 @@ import {
   RedmineSearchResultItem,
   RedmineTimeEntriesResult,
 } from './redmine-issue.model';
-import { mapRedmineSearchResultItemToSearchResult } from './redmine-issue-map.util';
+import {
+  mapRedmineIssueToSearchResult,
+  mapRedmineSearchResultItemToSearchResult,
+} from './redmine-issue-map.util';
 import { SearchResultItem } from '../../issue.model';
 import { ScopeOptions } from './redmine.const';
 import { handleIssueProviderHttpError$ } from '../../handle-issue-provider-http-error';
 
 /* eslint-disable @typescript-eslint/naming-convention */
+
+const ISSUE_ID_QUERY_RGX = /^#?(\d+)$/;
 
 @Injectable({
   providedIn: 'root',
@@ -31,7 +36,7 @@ export class RedmineApiService {
   private _http = inject(HttpClient);
 
   searchIssuesInProject$(query: string, cfg: RedmineCfg): Observable<SearchResultItem[]> {
-    return this._sendRequest$(
+    const textSearch$: Observable<SearchResultItem[]> = this._sendRequest$(
       {
         url: `${cfg.host}/projects/${cfg.projectId}/search.json`,
         params: ParamsBuilder.create()
@@ -50,6 +55,31 @@ export class RedmineApiService {
             )
           : [];
       }),
+    );
+
+    // Redmine's search API only does full text search and does not match issue ids,
+    // so for numeric queries (e.g. "1234" or "#1234") we additionally try to fetch
+    // the issue directly by its id and merge it into the results.
+    const idMatch = query.trim().match(ISSUE_ID_QUERY_RGX);
+    if (!idMatch) {
+      return textSearch$;
+    }
+
+    const issueId = Number(idMatch[1]);
+    return forkJoin([
+      this.getById$(issueId, cfg, { isSkipErrorHandling: true }).pipe(
+        catchError(() => of(null)),
+      ),
+      textSearch$,
+    ]).pipe(
+      map(([issueById, textResults]) =>
+        issueById
+          ? [
+              mapRedmineIssueToSearchResult(issueById),
+              ...textResults.filter((result) => result.issueData.id !== issueId),
+            ]
+          : textResults,
+      ),
     );
   }
 
@@ -123,12 +153,17 @@ export class RedmineApiService {
     );
   }
 
-  getById$(issueId: number, cfg: RedmineCfg): Observable<RedmineIssue> {
+  getById$(
+    issueId: number,
+    cfg: RedmineCfg,
+    { isSkipErrorHandling = false }: { isSkipErrorHandling?: boolean } = {},
+  ): Observable<RedmineIssue> {
     return this._sendRequest$(
       {
         url: `${cfg.host}/issues/${issueId}.json`,
       },
       cfg,
+      { isSkipErrorHandling },
     ).pipe(
       map(({ issue }) => Object.assign({ url: `${cfg.host}/issues/${issueId}` }, issue)),
     );
@@ -137,6 +172,7 @@ export class RedmineApiService {
   private _sendRequest$(
     params: HttpRequest<string> | any,
     cfg: RedmineCfg,
+    { isSkipErrorHandling = false }: { isSkipErrorHandling?: boolean } = {},
   ): Observable<any> {
     this._checkSettings(cfg);
     params.headers = {
@@ -169,7 +205,9 @@ export class RedmineApiService {
       filter((res) => !(res === Object(res) && res.type === 0)),
       map((res: any) => (res && res.body ? res.body : res)),
       catchError((err) =>
-        handleIssueProviderHttpError$(REDMINE_TYPE, this._snackService, err),
+        isSkipErrorHandling
+          ? throwError(() => err)
+          : handleIssueProviderHttpError$(REDMINE_TYPE, this._snackService, err),
       ),
     );
   }

--- a/src/app/features/issue/providers/redmine/redmine-api.service.ts
+++ b/src/app/features/issue/providers/redmine/redmine-api.service.ts
@@ -59,7 +59,7 @@ export class RedmineApiService {
 
     // Redmine's search API only does full text search and does not match issue ids,
     // so for numeric queries (e.g. "1234" or "#1234") we additionally try to fetch
-    // the issue directly by its id and merge it into the results.
+    // the issue by its id and merge it into the results.
     const idMatch = query.trim().match(ISSUE_ID_QUERY_RGX);
     if (!idMatch) {
       return textSearch$;
@@ -67,9 +67,7 @@ export class RedmineApiService {
 
     const issueId = Number(idMatch[1]);
     return forkJoin([
-      this.getById$(issueId, cfg, { isSkipErrorHandling: true }).pipe(
-        catchError(() => of(null)),
-      ),
+      this._getIssueByIdInProject$(issueId, cfg).pipe(catchError(() => of(null))),
       textSearch$,
     ]).pipe(
       map(([issueById, textResults]) =>
@@ -81,6 +79,30 @@ export class RedmineApiService {
           : textResults,
       ),
     );
+  }
+
+  // Looks up a single issue by id but stays scoped to the configured project, so a
+  // provider for one project can never surface (or add) an issue from another project
+  // the API key happens to have access to. Redmine resolves the project from the URL,
+  // so this works whether `cfg.projectId` is the numeric id or the identifier slug.
+  // `status_id=*` ensures closed issues are found too. A cross-project (or unknown) id
+  // simply yields an empty list -> null, and the caller falls back to text search.
+  private _getIssueByIdInProject$(
+    issueId: number,
+    cfg: RedmineCfg,
+  ): Observable<RedmineIssue | null> {
+    return this._sendRequest$(
+      {
+        url: `${cfg.host}/projects/${cfg.projectId}/issues.json`,
+        params: ParamsBuilder.create()
+          .withParam('issue_id', String(issueId))
+          .withState('*')
+          .withLimit(1)
+          .build(),
+      },
+      cfg,
+      { isSkipErrorHandling: true },
+    ).pipe(map((res: RedmineIssueResult) => res?.issues?.[0] ?? null));
   }
 
   getLast100IssuesForCurrentRedmineProject$(cfg: RedmineCfg): Observable<RedmineIssue[]> {
@@ -153,17 +175,12 @@ export class RedmineApiService {
     );
   }
 
-  getById$(
-    issueId: number,
-    cfg: RedmineCfg,
-    { isSkipErrorHandling = false }: { isSkipErrorHandling?: boolean } = {},
-  ): Observable<RedmineIssue> {
+  getById$(issueId: number, cfg: RedmineCfg): Observable<RedmineIssue> {
     return this._sendRequest$(
       {
         url: `${cfg.host}/issues/${issueId}.json`,
       },
       cfg,
-      { isSkipErrorHandling },
     ).pipe(
       map(({ issue }) => Object.assign({ url: `${cfg.host}/issues/${issueId}` }, issue)),
     );

--- a/src/app/features/issue/providers/redmine/redmine-issue-map.util.ts
+++ b/src/app/features/issue/providers/redmine/redmine-issue-map.util.ts
@@ -1,5 +1,5 @@
 import { IssueDataReduced, IssueProviderKey, SearchResultItem } from '../../issue.model';
-import { RedmineSearchResultItem } from './redmine-issue.model';
+import { RedmineIssue, RedmineSearchResultItem } from './redmine-issue.model';
 
 export const mapRedmineSearchResultItemToSearchResult = (
   item: RedmineSearchResultItem,
@@ -9,5 +9,15 @@ export const mapRedmineSearchResultItemToSearchResult = (
     titleHighlighted: item.title,
     issueType: 'REDMINE' as IssueProviderKey,
     issueData: item as IssueDataReduced,
+  };
+};
+
+export const mapRedmineIssueToSearchResult = (issue: RedmineIssue): SearchResultItem => {
+  const title = `#${issue.id} ${issue.subject}`;
+  return {
+    title,
+    titleHighlighted: title,
+    issueType: 'REDMINE' as IssueProviderKey,
+    issueData: { ...issue, title: issue.subject },
   };
 };


### PR DESCRIPTION
## Summary

Redmine's search API (`/search.json`) only performs full text search and does **not** match issue ids, so typing an issue id (e.g. `22899`) into the add-task bar or issue panel search returned no results unless the number happened to appear in the issue text. (Redmine's own "#id jumps to issue" behavior is an HTML-only redirect in its web UI and is not available via the API.)

This PR makes numeric queries (`1234` or `#1234`) additionally fetch the issue directly via `GET /issues/{id}.json` and merge it into the search results:

- by-id result is shown first, de-duplicated against the text search results
- a failed by-id lookup (e.g. 404 for a number that isn't an existing issue id) silently falls back to plain text search results - no error snack while typing
- closed issues can now also be found by id (text search is restricted to open issues)

## Changes

- `redmine-api.service.ts`: merge by-id lookup into `searchIssuesInProject$` for numeric queries; add optional `isSkipErrorHandling` to `getById$`/`_sendRequest$` so speculative lookups don't show error snacks
- `redmine-issue-map.util.ts`: add `mapRedmineIssueToSearchResult`
- `redmine-api.service.spec.ts`: new spec covering text-only queries, by-id merge, `#`-prefixed queries, de-duplication and 404 fallback

## Test

- 6 new unit specs pass
- `npm run lint` passes