### PR TITLE
fix(projects): color visibility menu project icons

### DIFF
--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html
@@ -159,6 +159,8 @@
 <!-- Project Visibility Menu -->
 <mat-menu #visibilityMenu="matMenu">
   @for (project of allUnarchivedProjects(); track project.id) {
+    @let projectIcon = project.icon || DEFAULT_PROJECT_ICON;
+    @let isProjectIconEmoji = isSingleEmoji(projectIcon);
     <button
       mat-menu-item
       role="menuitemcheckbox"
@@ -172,8 +174,9 @@
       }
       <mat-icon
         class="nav-icon"
-        [class.nav-icon-emoji]="isSingleEmoji(project.icon || DEFAULT_PROJECT_ICON)"
-        >{{ project.icon || DEFAULT_PROJECT_ICON }}</mat-icon
+        [class.nav-icon-emoji]="isProjectIconEmoji"
+        [style.color]="getProjectVisibilityIconColor(project)"
+        >{{ projectIcon }}</mat-icon
       >
       {{ project.title }}
     </button>

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts
@@ -1,0 +1,47 @@
+import { DEFAULT_PROJECT } from '../../../features/project/project.const';
+import { Project } from '../../../features/project/project.model';
+import { getProjectVisibilityIconColor } from './nav-list-tree.component';
+
+const createProject = (
+  overrides: Omit<Partial<Project>, 'theme'> & {
+    theme?: Partial<Project['theme']>;
+  },
+): Project => ({
+  ...DEFAULT_PROJECT,
+  id: 'project-id',
+  title: 'Project',
+  ...overrides,
+  theme: {
+    ...DEFAULT_PROJECT.theme,
+    ...overrides.theme,
+  },
+});
+
+describe('getProjectVisibilityIconColor', () => {
+  it('returns the project primary color for material icons', () => {
+    const project = createProject({
+      icon: 'work',
+      theme: { primary: '#123456' },
+    });
+
+    expect(getProjectVisibilityIconColor(project)).toBe('#123456');
+  });
+
+  it('does not color emoji project icons', () => {
+    const project = createProject({
+      icon: '\u{1F680}',
+      theme: { primary: '#123456' },
+    });
+
+    expect(getProjectVisibilityIconColor(project)).toBeNull();
+  });
+
+  it('uses the default material icon when a project has no icon', () => {
+    const project = createProject({
+      icon: undefined,
+      theme: { primary: '#abcdef' },
+    });
+
+    expect(getProjectVisibilityIconColor(project)).toBe('#abcdef');
+  });
+});

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.ts
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.ts
@@ -33,11 +33,17 @@ import {
 import { MenuTreeService } from '../../../features/menu-tree/menu-tree.service';
 import { WorkContextType } from '../../../features/work-context/work-context.model';
 import { DEFAULT_PROJECT_ICON } from '../../../features/project/project.const';
+import { Project } from '../../../features/project/project.model';
 import { isSingleEmoji } from '../../../util/extract-first-emoji';
 import { expandCollapseAni } from '../../../ui/tree-dnd/tree.animations';
 import { Router } from '@angular/router';
 
 const EXPAND_ANIMATION_RESET_DELAY_MS = 250;
+
+export const getProjectVisibilityIconColor = (project: Project): string | null =>
+  isSingleEmoji(project.icon || DEFAULT_PROJECT_ICON)
+    ? null
+    : (project.theme.primary ?? null);
 
 @Component({
   selector: 'nav-list-tree',
@@ -76,6 +82,7 @@ export class NavListTreeComponent implements OnDestroy {
   readonly WorkContextType = WorkContextType;
   readonly DEFAULT_PROJECT_ICON = DEFAULT_PROJECT_ICON;
   readonly isSingleEmoji = isSingleEmoji;
+  readonly getProjectVisibilityIconColor = getProjectVisibilityIconColor;
   readonly MenuTreeKind = MenuTreeKind;
 
   // Access to service methods and data for visibility menu (includes Inbox for unhiding)


### PR DESCRIPTION
## Problem

Fixes #8029. The project visibility menu should show each project icon with that project's own primary color. Material icons were not getting the correct project color in this menu, while emoji project icons should stay uncolored.

## Solution

- Add a small helper for visibility-menu project icon color selection.
- Apply each project's `theme.primary` to non-emoji project icons in the visibility menu.
- Keep emoji project icons uncolored.
- Add focused unit coverage for material icons, emoji icons, and the default project icon fallback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Validation run locally:

- `npm run checkFile src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.ts`
- `npm run checkFile src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts`
- `npm run prettier:file -- src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html`
- `npm run lint:file -- src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.html`
- `npm run test:file src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts`
- `git diff --check`
- pre-push hook from an ASCII-path worktree: `npm run lint && npm run test`
  - Angular/Karma: `10362 SUCCESS`
  - LA timezone run: `10348 SUCCESS`

Documentation/wiki changes are not included because this is a narrow UI bug fix.