### PR TITLE
fix(core): refresh day stream after next-day start changes

### DIFF
--- a/src/app/core/date/date.service.ts
+++ b/src/app/core/date/date.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
 import { getDbDateStr } from '../../util/get-db-date-str';
 import { getStartOfNextDayDiffMs } from '../../util/start-of-next-day.util';
 
 @Injectable({ providedIn: 'root' })
 export class DateService {
   private startOfNextDayDiff: number = 0;
+  private _startOfNextDayDiffChange$ = new Subject<void>();
+
+  readonly startOfNextDayDiffChange$ = this._startOfNextDayDiffChange$.asObservable();
 
   setStartOfNextDayDiff(
     startOfNextDayTimeOrHour: string | number | undefined,
@@ -17,7 +21,16 @@ export class DateService {
         ? startOfNextDayTimeOrHour
         : legacyStartOfNextDay;
 
-    this.startOfNextDayDiff = getStartOfNextDayDiffMs(startOfNextDayTime, startOfNextDay);
+    const nextStartOfNextDayDiff = getStartOfNextDayDiffMs(
+      startOfNextDayTime,
+      startOfNextDay,
+    );
+    if (this.startOfNextDayDiff === nextStartOfNextDayDiff) {
+      return;
+    }
+
+    this.startOfNextDayDiff = nextStartOfNextDayDiff;
+    this._startOfNextDayDiffChange$.next();
   }
 
   /**

--- a/src/app/core/global-tracking-interval/global-tracking-interval.service.spec.ts
+++ b/src/app/core/global-tracking-interval/global-tracking-interval.service.spec.ts
@@ -2,6 +2,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { GlobalTrackingIntervalService } from './global-tracking-interval.service';
 import { TRACKING_INTERVAL } from '../../app.constants';
+import { DateService } from '../date/date.service';
 
 describe('GlobalTrackingIntervalService', () => {
   beforeEach(() => {
@@ -79,5 +80,22 @@ describe('GlobalTrackingIntervalService', () => {
     sub.unsubscribe();
 
     expect(observed).toContain(100);
+  }));
+
+  it('should refresh todayDateStr$ when the start-of-next-day offset changes', fakeAsync(() => {
+    spyOn(Date, 'now').and.returnValue(new Date(2026, 4, 22, 10, 5).getTime());
+    const service = TestBed.inject(GlobalTrackingIntervalService);
+    const dateService = TestBed.inject(DateService);
+    const observed: string[] = [];
+
+    const sub = service.todayDateStr$.subscribe((dateStr) => observed.push(dateStr));
+
+    expect(observed).toEqual(['2026-05-22']);
+
+    dateService.setStartOfNextDayDiff('10:10');
+    tick(0);
+
+    expect(observed).toEqual(['2026-05-22', '2026-05-21']);
+    sub.unsubscribe();
   }));
 });

--- a/src/app/core/global-tracking-interval/global-tracking-interval.service.ts
+++ b/src/app/core/global-tracking-interval/global-tracking-interval.service.ts
@@ -112,7 +112,22 @@ export class GlobalTrackingIntervalService {
     // so consumers never receive the day change (see #5464). We therefore merge in visibility/focus/resume
     // events – all of which fire as soon as the app becomes interactive again – to force an immediate
     // re-sampling of todayStr() even if the regular 1s interval is still suspended.
-    return merge(timerBased$, focusBased$, visibilityBased$, systemResumeBased$).pipe(
+    const startOfNextDayDiffChange$ = (
+      this._dateService as {
+        startOfNextDayDiffChange$?: Observable<unknown>;
+      }
+    ).startOfNextDayDiffChange$;
+    const startOfNextDayChangeBased$ = (startOfNextDayDiffChange$ ?? EMPTY).pipe(
+      map(() => this._dateService.todayStr()),
+    );
+
+    return merge(
+      timerBased$,
+      focusBased$,
+      visibilityBased$,
+      systemResumeBased$,
+      startOfNextDayChangeBased$,
+    ).pipe(
       startWith(this._dateService.todayStr()),
       distinctUntilChanged(),
       tap((v) => Log.log('DAY_CHANGE ' + v)),


### PR DESCRIPTION
Fixes #7720.

### Summary

- emit a DateService notification when the start-of-next-day offset changes
- have GlobalTrackingIntervalService resample todayStr() from that notification
- cover the restart/config-load case where 10:05 should still be the previous logical day when the next day starts at 10:10

### Root cause

todayDateStr$ is shareReplay(1) and can cache the calendar-day value created before the stored start-of-next-day config is applied during app startup. If the app restarts before the configured day boundary, date-change consumers can see the stale calendar day until the next timer/focus/visibility emission.

### Validation

- npm run checkFile src/app/core/date/date.service.ts
- npm run checkFile src/app/core/global-tracking-interval/global-tracking-interval.service.ts
- npm run checkFile src/app/core/global-tracking-interval/global-tracking-interval.service.spec.ts
- npm run test:file src/app/core/global-tracking-interval/global-tracking-interval.service.spec.ts
- npm run test:file src/app/core/date/date.service.spec.ts
- npm run test:file src/app/core/date/date.service.tz.spec.ts
- npm run test:file src/app/features/tasks/store/task-due.effects.spec.ts
- npm run test:file src/app/features/simple-counter/simple-counter.service.spec.ts
- npm run lint
- npm run packages:test
- npm run release-notes:test
- git diff --check

Local note: full npm test did not complete in this checkout because the real path contains non-ASCII characters (/home/coco/桌面/...), which makes the sql.js wasm fixture request fail with ERR_UNESCAPED_CHARACTERS. The related focused specs above pass.
