### PR TITLE
fix(tasks): plan started tasks for today

### DIFF
--- a/src/app/features/tasks/store/task-internal.effects.spec.ts
+++ b/src/app/features/tasks/store/task-internal.effects.spec.ts
@@ -16,12 +16,15 @@ import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
 import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
 import { GlobalConfigState, TasksConfig } from '../../config/global-config.model';
 import { WorkContextType } from '../../work-context/work-context.model';
+import { selectTodayTaskIds } from '../../work-context/store/work-context.selectors';
+import { DateService } from '../../../core/date/date.service';
 
 describe('TaskInternalEffects', () => {
   let effects: TaskInternalEffects;
   let actions$: Subject<any>;
   let store: MockStore;
   let mainListTaskIds$: BehaviorSubject<string[]>;
+  let dateService: jasmine.SpyObj<DateService>;
 
   const createTask = (id: string, partial: Partial<Task> = {}): Task => ({
     ...DEFAULT_TASK,
@@ -79,6 +82,12 @@ describe('TaskInternalEffects', () => {
   beforeEach(() => {
     actions$ = new Subject<any>();
     mainListTaskIds$ = new BehaviorSubject<string[]>([]);
+    dateService = jasmine.createSpyObj<DateService>('DateService', [
+      'todayStr',
+      'getStartOfNextDayDiffMs',
+    ]);
+    dateService.todayStr.and.returnValue('2026-01-05');
+    dateService.getStartOfNextDayDiffMs.and.returnValue(0);
 
     const workContextServiceMock = {
       mainListTaskIds$,
@@ -96,10 +105,12 @@ describe('TaskInternalEffects', () => {
             },
             { selector: selectTaskFeatureState, value: createTaskState([]) },
             { selector: selectConfigFeatureState, value: createConfigState() },
+            { selector: selectTodayTaskIds, value: [] },
           ],
         }),
         { provide: WorkContextService, useValue: workContextServiceMock },
         { provide: LOCAL_ACTIONS, useValue: actions$ },
+        { provide: DateService, useValue: dateService },
       ],
     });
 
@@ -331,6 +342,82 @@ describe('TaskInternalEffects', () => {
         expect(emitted).toBe(false);
         done();
       }, 50);
+    });
+  });
+
+  describe('planStartedTaskForToday$', () => {
+    it('should plan the started task for today when it is not in today', (done) => {
+      const task = createTask('task1', { isDone: false });
+
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], 'task1'));
+      store.overrideSelector(selectTodayTaskIds, []);
+      store.refreshState();
+
+      effects.planStartedTaskForToday$.subscribe((action) => {
+        expect(action).toEqual(
+          TaskSharedActions.planTasksForToday({
+            taskIds: ['task1'],
+            today: '2026-01-05',
+            startOfNextDayDiffMs: 0,
+            parentTaskMap: { task1: undefined },
+          }),
+        );
+        done();
+      });
+
+      actions$.next(setCurrentTask({ id: 'task1' }));
+    });
+
+    it('should not plan the started task again when it is already in today', (done) => {
+      const task = createTask('task1', { isDone: false, dueDay: '2026-01-05' });
+
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], 'task1'));
+      store.overrideSelector(selectTodayTaskIds, ['task1']);
+      store.refreshState();
+
+      let emitted = false;
+      effects.planStartedTaskForToday$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(setCurrentTask({ id: 'task1' }));
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 50);
+    });
+
+    it('should plan the actual started subtask when a parent task start selects it', (done) => {
+      const parent = createTask('parent', {
+        subTaskIds: ['sub1'],
+        isDone: false,
+      });
+      const subTask = createTask('sub1', {
+        parentId: 'parent',
+        isDone: false,
+      });
+
+      store.overrideSelector(
+        selectTaskFeatureState,
+        createTaskState([parent, subTask], 'sub1'),
+      );
+      store.overrideSelector(selectTodayTaskIds, []);
+      store.refreshState();
+
+      effects.planStartedTaskForToday$.subscribe((action) => {
+        expect(action).toEqual(
+          TaskSharedActions.planTasksForToday({
+            taskIds: ['sub1'],
+            today: '2026-01-05',
+            startOfNextDayDiffMs: 0,
+            parentTaskMap: { sub1: 'parent' },
+          }),
+        );
+        done();
+      });
+
+      actions$.next(setCurrentTask({ id: 'parent' }));
     });
   });
 

--- a/src/app/features/tasks/store/task-internal.effects.ts
+++ b/src/app/features/tasks/store/task-internal.effects.ts
@@ -18,16 +18,19 @@ import {
 import { Task, TaskState } from '../task.model';
 import { EMPTY, of } from 'rxjs';
 import { WorkContextService } from '../../work-context/work-context.service';
+import { selectTodayTaskIds } from '../../work-context/store/work-context.selectors';
 import {
   moveProjectTaskToBacklogList,
   moveProjectTaskToBacklogListAuto,
 } from '../../project/store/project.actions';
+import { DateService } from '../../../core/date/date.service';
 
 @Injectable()
 export class TaskInternalEffects {
   private _actions$ = inject(LOCAL_ACTIONS);
   private _store$ = inject(Store);
   private _workContextSession = inject(WorkContextService);
+  private _dateService = inject(DateService);
 
   onAllSubTasksDone$ = createEffect(() =>
     this._actions$.pipe(
@@ -88,6 +91,40 @@ export class TaskInternalEffects {
           },
         }),
       ),
+    ),
+  );
+
+  planStartedTaskForToday$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(setCurrentTask),
+      withLatestFrom(
+        this._store$.pipe(select(selectTaskFeatureState)),
+        this._store$.pipe(select(selectTodayTaskIds)),
+      ),
+      mergeMap(([, state, todayTaskIds]) => {
+        const currentTaskId = state.currentTaskId;
+        if (!currentTaskId) {
+          return EMPTY;
+        }
+
+        const currentTask = state.entities[currentTaskId] as Task | undefined;
+        if (
+          !currentTask ||
+          todayTaskIds.includes(currentTaskId) ||
+          (!!currentTask.parentId && todayTaskIds.includes(currentTask.parentId))
+        ) {
+          return EMPTY;
+        }
+
+        return of(
+          TaskSharedActions.planTasksForToday({
+            taskIds: [currentTaskId],
+            today: this._dateService.todayStr(),
+            startOfNextDayDiffMs: this._dateService.getStartOfNextDayDiffMs(),
+            parentTaskMap: { [currentTaskId]: currentTask.parentId },
+          }),
+        );
+      }),
     ),
   );
 


### PR DESCRIPTION
## Summary

Fixes #8031.

Starting a task can set it as the current task without making it part of the Today work context. The desktop tray context menu is built from the Today task ids, so a running task that was not already scheduled for today could be missing from the tray task switcher.

This adds a small internal effect that reacts after setCurrentTask and plans the actual current task for today when it is not already in the Today list. It uses the resolved currentTaskId from state, so starting a parent task that actually begins an unfinished subtask plans the subtask. Existing Today tasks are ignored to avoid duplicate persistent operations.

## Validation

- npm run checkFile src/app/features/tasks/store/task-internal.effects.ts
- npm run checkFile src/app/features/tasks/store/task-internal.effects.spec.ts
- npm run test:file src/app/features/tasks/store/task-internal.effects.spec.ts
- npm run test:file src/app/features/tasks/store/task-electron.effects.spec.ts
- npm run test:file src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.spec.ts
- git diff --check