### PR TITLE
fix(sync): keep schedule settings local

### DIFF
--- a/src/app/features/config/local-only-sync-settings.util.spec.ts
+++ b/src/app/features/config/local-only-sync-settings.util.spec.ts
@@ -1,0 +1,50 @@
+import {
+  stripLocalOnlySyncScheduleSettings,
+  stripLocalOnlySyncSettingsFromAppData,
+} from './local-only-sync-settings.util';
+import { SyncProviderId } from '../../op-log/sync-providers/provider.const';
+
+describe('local-only sync settings utils', () => {
+  it('should strip sync schedule settings from a sync config object', () => {
+    const result = stripLocalOnlySyncScheduleSettings({
+      syncInterval: 300000,
+      isManualSyncOnly: true,
+      isCompressionEnabled: true,
+    }) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      isCompressionEnabled: true,
+    });
+  });
+
+  it('should strip local-only sync settings from app data', () => {
+    const result = stripLocalOnlySyncSettingsFromAppData({
+      globalConfig: {
+        sync: {
+          syncProvider: SyncProviderId.WebDAV,
+          syncInterval: 300000,
+          isManualSyncOnly: true,
+          isCompressionEnabled: true,
+        },
+        misc: { isDisableAnimations: true },
+      },
+      task: { ids: [] },
+    }) as Record<string, unknown>;
+
+    const globalConfig = result['globalConfig'] as Record<string, unknown>;
+    const sync = globalConfig['sync'] as Record<string, unknown>;
+
+    expect(sync['syncProvider']).toBeNull();
+    expect(sync['syncInterval']).toBeUndefined();
+    expect(sync['isManualSyncOnly']).toBeUndefined();
+    expect(sync['isCompressionEnabled']).toBe(true);
+    expect(globalConfig['misc']).toEqual({ isDisableAnimations: true });
+    expect(result['task']).toEqual({ ids: [] });
+  });
+
+  it('should leave data without globalConfig.sync unchanged by reference', () => {
+    const data = { task: { ids: [] } };
+
+    expect(stripLocalOnlySyncSettingsFromAppData(data)).toBe(data);
+  });
+});

--- a/src/app/features/config/local-only-sync-settings.util.spec.ts
+++ b/src/app/features/config/local-only-sync-settings.util.spec.ts
@@ -1,4 +1,5 @@
 import {
+  applyLocalOnlySyncSettingsToAppData,
   stripLocalOnlySyncScheduleSettings,
   stripLocalOnlySyncSettingsFromAppData,
 } from './local-only-sync-settings.util';
@@ -46,5 +47,36 @@ describe('local-only sync settings utils', () => {
     const data = { task: { ids: [] } };
 
     expect(stripLocalOnlySyncSettingsFromAppData(data)).toBe(data);
+  });
+
+  it('should apply local-only sync settings to app data', () => {
+    const result = applyLocalOnlySyncSettingsToAppData(
+      {
+        globalConfig: {
+          sync: {
+            syncProvider: SyncProviderId.Dropbox,
+            syncInterval: 600000,
+            isManualSyncOnly: false,
+            isCompressionEnabled: true,
+          },
+        },
+      },
+      {
+        isEnabled: true,
+        isEncryptionEnabled: false,
+        syncProvider: SyncProviderId.WebDAV,
+        syncInterval: 300000,
+        isManualSyncOnly: true,
+      },
+    ) as Record<string, unknown>;
+
+    const globalConfig = result['globalConfig'] as Record<string, unknown>;
+    const sync = globalConfig['sync'] as Record<string, unknown>;
+
+    expect(sync['isEnabled']).toBe(true);
+    expect(sync['syncProvider']).toBe(SyncProviderId.WebDAV);
+    expect(sync['syncInterval']).toBe(300000);
+    expect(sync['isManualSyncOnly']).toBe(true);
+    expect(sync['isCompressionEnabled']).toBe(true);
   });
 });

--- a/src/app/features/config/local-only-sync-settings.util.ts
+++ b/src/app/features/config/local-only-sync-settings.util.ts
@@ -1,5 +1,14 @@
 import { SyncConfig } from './global-config.model';
 
+export type LocalOnlySyncSettings = Pick<
+  SyncConfig,
+  | 'isEnabled'
+  | 'isEncryptionEnabled'
+  | 'syncProvider'
+  | 'syncInterval'
+  | 'isManualSyncOnly'
+>;
+
 export const LOCAL_ONLY_SYNC_SCHEDULE_KEYS = [
   'syncInterval',
   'isManualSyncOnly',
@@ -7,12 +16,42 @@ export const LOCAL_ONLY_SYNC_SCHEDULE_KEYS = [
 
 export const stripLocalOnlySyncScheduleSettings = <T extends Record<string, unknown>>(
   syncConfig: T,
-): T => {
+): Omit<T, (typeof LOCAL_ONLY_SYNC_SCHEDULE_KEYS)[number]> => {
   const stripped = { ...syncConfig };
   for (const key of LOCAL_ONLY_SYNC_SCHEDULE_KEYS) {
     delete stripped[key];
   }
   return stripped;
+};
+
+export const applyLocalOnlySyncSettingsToAppData = <T>(
+  data: T,
+  localOnlySettings: LocalOnlySyncSettings,
+): T => {
+  if (!data || typeof data !== 'object') {
+    return data;
+  }
+
+  const typedData = data as Record<string, unknown>;
+  if (!typedData['globalConfig'] || typeof typedData['globalConfig'] !== 'object') {
+    return data;
+  }
+
+  const globalConfig = typedData['globalConfig'] as Record<string, unknown>;
+  if (!globalConfig['sync'] || typeof globalConfig['sync'] !== 'object') {
+    return data;
+  }
+
+  return {
+    ...typedData,
+    globalConfig: {
+      ...globalConfig,
+      sync: {
+        ...(globalConfig['sync'] as Record<string, unknown>),
+        ...localOnlySettings,
+      },
+    },
+  } as T;
 };
 
 export const stripLocalOnlySyncSettingsFromAppData = (data: unknown): unknown => {

--- a/src/app/features/config/local-only-sync-settings.util.ts
+++ b/src/app/features/config/local-only-sync-settings.util.ts
@@ -24,9 +24,9 @@ export const stripLocalOnlySyncScheduleSettings = <T extends Record<string, unkn
   return stripped;
 };
 
-export const applyLocalOnlySyncSettingsToAppData = <T>(
+const _updateSyncConfigInAppData = <T>(
   data: T,
-  localOnlySettings: LocalOnlySyncSettings,
+  updateSyncConfig: (syncConfig: Record<string, unknown>) => Record<string, unknown>,
 ): T => {
   if (!data || typeof data !== 'object') {
     return data;
@@ -46,39 +46,24 @@ export const applyLocalOnlySyncSettingsToAppData = <T>(
     ...typedData,
     globalConfig: {
       ...globalConfig,
-      sync: {
-        ...(globalConfig['sync'] as Record<string, unknown>),
-        ...localOnlySettings,
-      },
+      sync: updateSyncConfig(globalConfig['sync'] as Record<string, unknown>),
     },
   } as T;
 };
 
+export const applyLocalOnlySyncSettingsToAppData = <T>(
+  data: T,
+  localOnlySettings: LocalOnlySyncSettings,
+): T => {
+  return _updateSyncConfigInAppData(data, (syncConfig) => ({
+    ...syncConfig,
+    ...localOnlySettings,
+  }));
+};
+
 export const stripLocalOnlySyncSettingsFromAppData = (data: unknown): unknown => {
-  if (!data || typeof data !== 'object') {
-    return data;
-  }
-
-  const typedData = data as Record<string, unknown>;
-  if (!typedData['globalConfig'] || typeof typedData['globalConfig'] !== 'object') {
-    return data;
-  }
-
-  const globalConfig = typedData['globalConfig'] as Record<string, unknown>;
-  if (!globalConfig['sync'] || typeof globalConfig['sync'] !== 'object') {
-    return data;
-  }
-
-  const sync = globalConfig['sync'] as Record<string, unknown>;
-
-  return {
-    ...typedData,
-    globalConfig: {
-      ...globalConfig,
-      sync: {
-        ...stripLocalOnlySyncScheduleSettings(sync),
-        syncProvider: null,
-      },
-    },
-  };
+  return _updateSyncConfigInAppData(data, (syncConfig) => ({
+    ...stripLocalOnlySyncScheduleSettings(syncConfig),
+    syncProvider: null,
+  }));
 };

--- a/src/app/features/config/local-only-sync-settings.util.ts
+++ b/src/app/features/config/local-only-sync-settings.util.ts
@@ -1,0 +1,45 @@
+import { SyncConfig } from './global-config.model';
+
+export const LOCAL_ONLY_SYNC_SCHEDULE_KEYS = [
+  'syncInterval',
+  'isManualSyncOnly',
+] as const satisfies readonly (keyof SyncConfig)[];
+
+export const stripLocalOnlySyncScheduleSettings = <T extends Record<string, unknown>>(
+  syncConfig: T,
+): T => {
+  const stripped = { ...syncConfig };
+  for (const key of LOCAL_ONLY_SYNC_SCHEDULE_KEYS) {
+    delete stripped[key];
+  }
+  return stripped;
+};
+
+export const stripLocalOnlySyncSettingsFromAppData = (data: unknown): unknown => {
+  if (!data || typeof data !== 'object') {
+    return data;
+  }
+
+  const typedData = data as Record<string, unknown>;
+  if (!typedData['globalConfig'] || typeof typedData['globalConfig'] !== 'object') {
+    return data;
+  }
+
+  const globalConfig = typedData['globalConfig'] as Record<string, unknown>;
+  if (!globalConfig['sync'] || typeof globalConfig['sync'] !== 'object') {
+    return data;
+  }
+
+  const sync = globalConfig['sync'] as Record<string, unknown>;
+
+  return {
+    ...typedData,
+    globalConfig: {
+      ...globalConfig,
+      sync: {
+        ...stripLocalOnlySyncScheduleSettings(sync),
+        syncProvider: null,
+      },
+    },
+  };
+};

--- a/src/app/features/config/store/global-config.reducer.spec.ts
+++ b/src/app/features/config/store/global-config.reducer.spec.ts
@@ -17,6 +17,7 @@ import {
   selectIsFocusModeEnabled,
   selectTimelineWorkStartEndHours,
 } from './global-config.reducer';
+import { updateGlobalConfigSection } from './global-config.actions';
 import { loadAllData } from '../../../root-store/meta/load-all-data.action';
 import { GlobalConfigState } from '../global-config.model';
 import { SyncProviderId } from '../../../op-log/sync-providers/provider.const';
@@ -444,13 +445,14 @@ describe('GlobalConfigReducer', () => {
       expect(result.misc.startOfNextDayTime).toBe('00:00');
     });
 
-    it('should update other sync config properties while preserving syncProvider', () => {
+    it('should update shared sync config properties while preserving local-only ones', () => {
       const oldState: GlobalConfigState = {
         ...initialGlobalConfigState,
         sync: {
           ...initialGlobalConfigState.sync,
           syncProvider: SyncProviderId.SuperSync,
           syncInterval: 300000,
+          isManualSyncOnly: true,
         },
       };
 
@@ -460,6 +462,7 @@ describe('GlobalConfigReducer', () => {
           ...initialGlobalConfigState.sync,
           syncProvider: null,
           syncInterval: 600000,
+          isManualSyncOnly: false,
           isCompressionEnabled: true,
         },
       };
@@ -471,10 +474,11 @@ describe('GlobalConfigReducer', () => {
         }),
       );
 
-      // syncProvider preserved
+      // Local-only settings preserved
       expect(result.sync.syncProvider).toBe(SyncProviderId.SuperSync);
-      // Other sync settings updated
-      expect(result.sync.syncInterval).toBe(600000);
+      expect(result.sync.syncInterval).toBe(300000);
+      expect(result.sync.isManualSyncOnly).toBe(true);
+      // Shared sync settings updated
       expect(result.sync.isCompressionEnabled).toBe(true);
     });
 
@@ -593,6 +597,62 @@ describe('GlobalConfigReducer', () => {
       });
     });
 
+    describe('local-only sync schedule settings preservation', () => {
+      it('should use sync schedule settings from snapshot on initial load', () => {
+        const snapshotConfig: GlobalConfigState = {
+          ...initialGlobalConfigState,
+          sync: {
+            ...initialGlobalConfigState.sync,
+            syncProvider: SyncProviderId.WebDAV,
+            syncInterval: 600000,
+            isManualSyncOnly: true,
+          },
+        };
+
+        const result = globalConfigReducer(
+          initialGlobalConfigState,
+          loadAllData({
+            appDataComplete: { globalConfig: snapshotConfig } as AppDataComplete,
+          }),
+        );
+
+        expect(result.sync.syncInterval).toBe(600000);
+        expect(result.sync.isManualSyncOnly).toBe(true);
+      });
+
+      it('should preserve local sync schedule settings during sync hydration', () => {
+        const oldState: GlobalConfigState = {
+          ...initialGlobalConfigState,
+          sync: {
+            ...initialGlobalConfigState.sync,
+            syncProvider: SyncProviderId.WebDAV,
+            syncInterval: 300000,
+            isManualSyncOnly: true,
+          },
+        };
+
+        const syncedConfig: GlobalConfigState = {
+          ...initialGlobalConfigState,
+          sync: {
+            ...initialGlobalConfigState.sync,
+            syncProvider: null,
+            syncInterval: 600000,
+            isManualSyncOnly: false,
+          },
+        };
+
+        const result = globalConfigReducer(
+          oldState,
+          loadAllData({
+            appDataComplete: { globalConfig: syncedConfig } as AppDataComplete,
+          }),
+        );
+
+        expect(result.sync.syncInterval).toBe(300000);
+        expect(result.sync.isManualSyncOnly).toBe(true);
+      });
+    });
+
     describe('focusMode migration: isSyncSessionWithTracking → autoStartFocusOnPlay', () => {
       // Real persisted JSON never carries `autoStartFocusOnPlay` (it didn't
       // exist pre-rework). Constructing the fixture as an Object.assign so the
@@ -707,6 +767,95 @@ describe('GlobalConfigReducer', () => {
         // Migration must NOT have backfilled — the prototype key is not "owned".
         expect(result.focusMode.autoStartFocusOnPlay).toBe(false);
       });
+    });
+  });
+
+  describe('updateGlobalConfigSection action', () => {
+    it('should update sync schedule settings for local actions', () => {
+      const result = globalConfigReducer(
+        initialGlobalConfigState,
+        updateGlobalConfigSection({
+          sectionKey: 'sync',
+          sectionCfg: {
+            syncInterval: 600000,
+            isManualSyncOnly: true,
+          },
+        }),
+      );
+
+      expect(result.sync.syncInterval).toBe(600000);
+      expect(result.sync.isManualSyncOnly).toBe(true);
+    });
+
+    it('should preserve local-only sync settings for remote sync section updates', () => {
+      const oldState: GlobalConfigState = {
+        ...initialGlobalConfigState,
+        sync: {
+          ...initialGlobalConfigState.sync,
+          isEnabled: true,
+          syncProvider: SyncProviderId.WebDAV,
+          isEncryptionEnabled: true,
+          syncInterval: 300000,
+          isManualSyncOnly: true,
+          isCompressionEnabled: false,
+        },
+      };
+      const remoteAction = updateGlobalConfigSection({
+        sectionKey: 'sync',
+        sectionCfg: {
+          isEnabled: false,
+          syncProvider: SyncProviderId.LocalFile,
+          isEncryptionEnabled: false,
+          syncInterval: 600000,
+          isManualSyncOnly: false,
+          isCompressionEnabled: true,
+        },
+      });
+      const remoteReplayAction = {
+        ...remoteAction,
+        meta: {
+          ...remoteAction.meta,
+          isRemote: true,
+        },
+      };
+
+      const result = globalConfigReducer(oldState, remoteReplayAction);
+
+      expect(result.sync.isEnabled).toBe(true);
+      expect(result.sync.syncProvider).toBe(SyncProviderId.WebDAV);
+      expect(result.sync.isEncryptionEnabled).toBe(true);
+      expect(result.sync.syncInterval).toBe(300000);
+      expect(result.sync.isManualSyncOnly).toBe(true);
+      expect(result.sync.isCompressionEnabled).toBe(true);
+    });
+
+    it('should update shared sync settings for remote sync section updates', () => {
+      const remoteAction = updateGlobalConfigSection({
+        sectionKey: 'sync',
+        sectionCfg: {
+          isCompressionEnabled: true,
+        },
+      });
+      const remoteReplayAction = {
+        ...remoteAction,
+        meta: {
+          ...remoteAction.meta,
+          isRemote: true,
+        },
+      };
+
+      const result = globalConfigReducer(
+        {
+          ...initialGlobalConfigState,
+          sync: {
+            ...initialGlobalConfigState.sync,
+            syncProvider: SyncProviderId.WebDAV,
+          },
+        },
+        remoteReplayAction,
+      );
+
+      expect(result.sync.isCompressionEnabled).toBe(true);
     });
   });
 

--- a/src/app/features/config/store/global-config.reducer.ts
+++ b/src/app/features/config/store/global-config.reducer.ts
@@ -11,6 +11,7 @@ import {
   FocusModeConfig,
   GlobalConfigState,
   MiscConfig,
+  SyncConfig,
 } from '../global-config.model';
 import type { KeyboardConfig } from '../keyboard-config.model';
 import { DEFAULT_GLOBAL_CONFIG } from '../default-global-config.const';
@@ -125,6 +126,18 @@ const migrateKeyboardConfig = (cfg: KeyboardConfig | undefined): KeyboardConfig 
   return keyboard;
 };
 
+const withLocalOnlySyncSettings = (
+  incomingSyncConfig: SyncConfig,
+  localSyncConfig: SyncConfig,
+): SyncConfig => ({
+  ...incomingSyncConfig,
+  syncProvider: localSyncConfig.syncProvider,
+  isEnabled: localSyncConfig.isEnabled,
+  isEncryptionEnabled: localSyncConfig.isEncryptionEnabled,
+  syncInterval: localSyncConfig.syncInterval,
+  isManualSyncOnly: localSyncConfig.isManualSyncOnly,
+});
+
 export const globalConfigReducer = createReducer<GlobalConfigState>(
   initialGlobalConfigState,
 
@@ -133,29 +146,26 @@ export const globalConfigReducer = createReducer<GlobalConfigState>(
       return oldState;
     }
 
-    const incomingSyncConfig = appDataComplete.globalConfig.sync;
+    const incomingSyncConfig = {
+      ...DEFAULT_GLOBAL_CONFIG.sync,
+      ...appDataComplete.globalConfig.sync,
+    };
 
     // Preserve local-only sync settings if they're already set.
     // These settings should remain local to each client:
     // - syncProvider: Each client can use different providers (Dropbox, WebDAV, etc.)
     // - isEnabled: Each client independently controls whether sync is enabled
     // - isEncryptionEnabled: Encryption state must not be overwritten by imports
+    // - syncInterval: Each client chooses its own automatic sync frequency
+    // - isManualSyncOnly: Each client chooses automatic vs manual sync
     //
     // If oldState.sync.syncProvider is null, we're on first load (using initialGlobalConfigState)
     // and should use the incoming values (from snapshot). Otherwise, preserve local values.
     const hasLocalSettings = oldState.sync.syncProvider !== null;
 
-    const syncProvider = hasLocalSettings
-      ? oldState.sync.syncProvider
-      : incomingSyncConfig.syncProvider;
-
-    const isEnabled = hasLocalSettings
-      ? oldState.sync.isEnabled
-      : incomingSyncConfig.isEnabled;
-
-    const isEncryptionEnabled = hasLocalSettings
-      ? oldState.sync.isEncryptionEnabled
-      : incomingSyncConfig.isEncryptionEnabled;
+    const syncConfig = hasLocalSettings
+      ? withLocalOnlySyncSettings(incomingSyncConfig, oldState.sync)
+      : incomingSyncConfig;
 
     const incomingGlobalConfig = {
       ...DEFAULT_GLOBAL_CONFIG,
@@ -196,27 +206,31 @@ export const globalConfigReducer = createReducer<GlobalConfigState>(
         ...migrateFocusModeConfig(appDataComplete.globalConfig.focusMode),
       },
       keyboard: migrateKeyboardConfig(appDataComplete.globalConfig.keyboard),
-      sync: {
-        ...incomingSyncConfig,
-        syncProvider,
-        isEnabled,
-        isEncryptionEnabled,
-      },
+      sync: syncConfig,
     };
   }),
 
-  on(updateGlobalConfigSection, (state, { sectionKey, sectionCfg }) => {
+  on(updateGlobalConfigSection, (state, action) => {
+    const { sectionKey, sectionCfg } = action;
     const normalizedSectionCfg =
       sectionKey === 'misc'
         ? normalizeStartOfNextDayConfig(sectionCfg as Partial<MiscConfig>)
         : sectionCfg;
+    const updatedSection = {
+      ...state[sectionKey],
+      ...normalizedSectionCfg,
+    };
+
+    const isRemoteUpdate =
+      (action as { meta?: { isRemote?: boolean } }).meta?.isRemote === true;
+    const nextSection =
+      sectionKey === 'sync' && isRemoteUpdate
+        ? withLocalOnlySyncSettings(updatedSection as SyncConfig, state.sync)
+        : updatedSection;
 
     return {
       ...state,
-      [sectionKey]: {
-        ...state[sectionKey],
-        ...normalizedSectionCfg,
-      },
+      [sectionKey]: nextSection,
     };
   }),
 );

--- a/src/app/imex/sync/snapshot-upload.service.spec.ts
+++ b/src/app/imex/sync/snapshot-upload.service.spec.ts
@@ -12,6 +12,7 @@ import {
 import { OperationEncryptionService } from '../../op-log/sync/operation-encryption.service';
 import type { SuperSyncPrivateCfg } from '@sp/sync-providers/super-sync';
 import { WebCryptoNotAvailableError } from '../../op-log/core/errors/sync-errors';
+import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 
 describe('SnapshotUploadService', () => {
   let service: SnapshotUploadService;
@@ -180,6 +181,31 @@ describe('SnapshotUploadService', () => {
       expect(result.vectorClock).toBe(mockVectorClock);
       expect(result.clientId).toBe('test-client-id');
       expect(result.existingCfg).toEqual({ encryptKey: 'test' } as any);
+    });
+
+    it('should strip local-only sync settings from gathered snapshot state', async () => {
+      const mockState = {
+        globalConfig: {
+          ...DEFAULT_GLOBAL_CONFIG,
+          sync: {
+            ...DEFAULT_GLOBAL_CONFIG.sync,
+            syncProvider: SyncProviderId.WebDAV,
+            syncInterval: 300000,
+            isManualSyncOnly: true,
+            isCompressionEnabled: true,
+          },
+        },
+      };
+      mockStateSnapshotService.getStateSnapshotAsync.and.resolveTo(mockState as any);
+
+      const result = await service.gatherSnapshotData();
+      const globalConfig = result.state.globalConfig as Record<string, unknown>;
+      const sync = globalConfig['sync'] as Record<string, unknown>;
+
+      expect(sync['syncProvider']).toBeNull();
+      expect(sync['syncInterval']).toBeUndefined();
+      expect(sync['isManualSyncOnly']).toBeUndefined();
+      expect(sync['isCompressionEnabled']).toBe(true);
     });
 
     it('should regenerate client ID when getOrGenerateClientId is used', async () => {

--- a/src/app/imex/sync/snapshot-upload.service.ts
+++ b/src/app/imex/sync/snapshot-upload.service.ts
@@ -23,6 +23,7 @@ import { VectorClock } from '../../core/util/vector-clock';
 import { OperationEncryptionService } from '../../op-log/sync/operation-encryption.service';
 import { isCryptoSubtleAvailable } from '@sp/sync-core';
 import { WebCryptoNotAvailableError } from '../../op-log/core/errors/sync-errors';
+import { stripLocalOnlySyncSettingsFromAppData } from '../../features/config/local-only-sync-settings.util';
 
 /**
  * Data gathered for a snapshot upload operation.
@@ -118,7 +119,9 @@ export class SnapshotUploadService {
     // IMPORTANT: Must use async version to load real archives from IndexedDB
     // The sync getStateSnapshot() returns DEFAULT_ARCHIVE (empty) which causes data loss
     SyncLog.normal(`${prefix}Getting current state...`);
-    const state = await this._stateSnapshotService.getStateSnapshotAsync();
+    const state = stripLocalOnlySyncSettingsFromAppData(
+      await this._stateSnapshotService.getStateSnapshotAsync(),
+    ) as AppStateSnapshot;
     const vectorClock = await this._vectorClockService.getCurrentVectorClock();
     const clientId = await this._clientIdProvider.getOrGenerateClientId();
 

--- a/src/app/op-log/capture/operation-log.effects.spec.ts
+++ b/src/app/op-log/capture/operation-log.effects.spec.ts
@@ -328,7 +328,7 @@ describe('OperationLogEffects', () => {
       });
     });
 
-    it('should not persist sync updates that only change local schedule settings', (done) => {
+    it('should persist sync updates that only change local schedule settings for local replay', (done) => {
       const action = updateGlobalConfigSection({
         sectionKey: 'sync',
         sectionCfg: {
@@ -341,14 +341,29 @@ describe('OperationLogEffects', () => {
       effects.persistOperation$.subscribe({
         complete: () => {
           expect(mockOperationCaptureService.dequeue).toHaveBeenCalled();
-          expect(mockOpLogStore.appendWithVectorClockUpdate).not.toHaveBeenCalled();
-          expect(mockImmediateUploadService.trigger).not.toHaveBeenCalled();
+          expect(mockOpLogStore.appendWithVectorClockUpdate).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              actionType: ActionType.GLOBAL_CONFIG_UPDATE_SECTION,
+              payload: {
+                actionPayload: {
+                  sectionKey: 'sync',
+                  sectionCfg: {
+                    syncInterval: 300000,
+                    isManualSyncOnly: true,
+                  },
+                },
+                entityChanges: [],
+              },
+            }),
+            'local',
+          );
+          expect(mockImmediateUploadService.trigger).toHaveBeenCalled();
           done();
         },
       });
     });
 
-    it('should strip local schedule settings from persisted sync updates', (done) => {
+    it('should keep local schedule settings in persisted sync updates', (done) => {
       const action = updateGlobalConfigSection({
         sectionKey: 'sync',
         sectionCfg: {
@@ -369,6 +384,8 @@ describe('OperationLogEffects', () => {
             actionPayload: {
               sectionKey: 'sync',
               sectionCfg: {
+                syncInterval: 300000,
+                isManualSyncOnly: true,
                 isCompressionEnabled: true,
               },
             },

--- a/src/app/op-log/capture/operation-log.effects.spec.ts
+++ b/src/app/op-log/capture/operation-log.effects.spec.ts
@@ -21,6 +21,7 @@ import { ClientIdService } from '../../core/util/client-id.service';
 import { OperationCaptureService } from './operation-capture.service';
 import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 import { T } from '../../t.const';
+import { updateGlobalConfigSection } from '../../features/config/store/global-config.actions';
 
 describe('OperationLogEffects', () => {
   let effects: OperationLogEffects;
@@ -321,6 +322,57 @@ describe('OperationLogEffects', () => {
           expect(operation.payload).toEqual({
             actionPayload: { title: 'Updated Title', done: true },
             entityChanges: jasmine.any(Array),
+          });
+          done();
+        },
+      });
+    });
+
+    it('should not persist sync updates that only change local schedule settings', (done) => {
+      const action = updateGlobalConfigSection({
+        sectionKey: 'sync',
+        sectionCfg: {
+          syncInterval: 300000,
+          isManualSyncOnly: true,
+        },
+      });
+      actions$ = of(action);
+
+      effects.persistOperation$.subscribe({
+        complete: () => {
+          expect(mockOperationCaptureService.dequeue).toHaveBeenCalled();
+          expect(mockOpLogStore.appendWithVectorClockUpdate).not.toHaveBeenCalled();
+          expect(mockImmediateUploadService.trigger).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should strip local schedule settings from persisted sync updates', (done) => {
+      const action = updateGlobalConfigSection({
+        sectionKey: 'sync',
+        sectionCfg: {
+          syncInterval: 300000,
+          isManualSyncOnly: true,
+          isCompressionEnabled: true,
+        },
+      });
+      actions$ = of(action);
+
+      effects.persistOperation$.subscribe({
+        complete: () => {
+          const operation =
+            mockOpLogStore.appendWithVectorClockUpdate.calls.mostRecent().args[0];
+
+          expect(operation.actionType).toBe(ActionType.GLOBAL_CONFIG_UPDATE_SECTION);
+          expect(operation.payload).toEqual({
+            actionPayload: {
+              sectionKey: 'sync',
+              sectionCfg: {
+                isCompressionEnabled: true,
+              },
+            },
+            entityChanges: [],
           });
           done();
         },

--- a/src/app/op-log/capture/operation-log.effects.ts
+++ b/src/app/op-log/capture/operation-log.effects.ts
@@ -31,38 +31,10 @@ import { ImmediateUploadService } from '../sync/immediate-upload.service';
 import { getDeferredActions, isDeferredAction } from './operation-capture.meta-reducer';
 import { ClientIdService } from '../../core/util/client-id.service';
 import { SuperSyncStatusService } from '../sync/super-sync-status.service';
-import { stripLocalOnlySyncScheduleSettings } from '../../features/config/local-only-sync-settings.util';
 
 interface WriteOperationOptions {
   callerHoldsOperationLogLock?: boolean;
 }
-
-const sanitizeLocalOnlySyncSettings = (
-  action: PersistentAction,
-  actionPayload: Record<string, unknown>,
-): Record<string, unknown> | null => {
-  if (
-    action.type !== ActionType.GLOBAL_CONFIG_UPDATE_SECTION ||
-    actionPayload['sectionKey'] !== 'sync' ||
-    typeof actionPayload['sectionCfg'] !== 'object' ||
-    actionPayload['sectionCfg'] === null
-  ) {
-    return actionPayload;
-  }
-
-  const sanitizedSectionCfg = stripLocalOnlySyncScheduleSettings(
-    actionPayload['sectionCfg'] as Record<string, unknown>,
-  );
-
-  if (Object.keys(sanitizedSectionCfg).length === 0) {
-    return null;
-  }
-
-  return {
-    ...actionPayload,
-    sectionCfg: sanitizedSectionCfg,
-  };
-};
 
 /**
  * NgRx Effects for persisting application state changes as operations to the
@@ -210,18 +182,11 @@ export class OperationLogEffects implements DeferredLocalActionsPort {
         // enqueueing — there's no matching queue entry to dequeue.
         const entityChanges = skipDequeue ? [] : this.operationCaptureService.dequeue();
 
-        const actionPayload = sanitizeLocalOnlySyncSettings(
+        const actionPayload = this.addReplayDateFieldsToActionPayload(
           action,
-          this.addReplayDateFieldsToActionPayload(
-            action,
-            rawActionPayload,
-            operationTimestamp,
-          ),
+          rawActionPayload,
+          operationTimestamp,
         );
-
-        if (!actionPayload) {
-          return;
-        }
 
         // Create multi-entity payload with action payload and computed changes
         const multiEntityPayload: MultiEntityPayload = {

--- a/src/app/op-log/capture/operation-log.effects.ts
+++ b/src/app/op-log/capture/operation-log.effects.ts
@@ -31,10 +31,38 @@ import { ImmediateUploadService } from '../sync/immediate-upload.service';
 import { getDeferredActions, isDeferredAction } from './operation-capture.meta-reducer';
 import { ClientIdService } from '../../core/util/client-id.service';
 import { SuperSyncStatusService } from '../sync/super-sync-status.service';
+import { stripLocalOnlySyncScheduleSettings } from '../../features/config/local-only-sync-settings.util';
 
 interface WriteOperationOptions {
   callerHoldsOperationLogLock?: boolean;
 }
+
+const sanitizeLocalOnlySyncSettings = (
+  action: PersistentAction,
+  actionPayload: Record<string, unknown>,
+): Record<string, unknown> | null => {
+  if (
+    action.type !== ActionType.GLOBAL_CONFIG_UPDATE_SECTION ||
+    actionPayload['sectionKey'] !== 'sync' ||
+    typeof actionPayload['sectionCfg'] !== 'object' ||
+    actionPayload['sectionCfg'] === null
+  ) {
+    return actionPayload;
+  }
+
+  const sanitizedSectionCfg = stripLocalOnlySyncScheduleSettings(
+    actionPayload['sectionCfg'] as Record<string, unknown>,
+  );
+
+  if (Object.keys(sanitizedSectionCfg).length === 0) {
+    return null;
+  }
+
+  return {
+    ...actionPayload,
+    sectionCfg: sanitizedSectionCfg,
+  };
+};
 
 /**
  * NgRx Effects for persisting application state changes as operations to the
@@ -182,11 +210,18 @@ export class OperationLogEffects implements DeferredLocalActionsPort {
         // enqueueing — there's no matching queue entry to dequeue.
         const entityChanges = skipDequeue ? [] : this.operationCaptureService.dequeue();
 
-        const actionPayload = this.addReplayDateFieldsToActionPayload(
+        const actionPayload = sanitizeLocalOnlySyncSettings(
           action,
-          rawActionPayload,
-          operationTimestamp,
+          this.addReplayDateFieldsToActionPayload(
+            action,
+            rawActionPayload,
+            operationTimestamp,
+          ),
         );
+
+        if (!actionPayload) {
+          return;
+        }
 
         // Create multi-entity payload with action payload and computed changes
         const multiEntityPayload: MultiEntityPayload = {

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -30,6 +30,7 @@ import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider
 import { MAX_VECTOR_CLOCK_SIZE } from '@sp/shared-schema';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 import { IDB_OPEN_ERROR_RELOAD_KEY } from './operation-log-hydrator.service';
+import { SyncProviderId } from '../sync-providers/provider.const';
 
 describe('OperationLogHydratorService', () => {
   let service: OperationLogHydratorService;
@@ -696,6 +697,38 @@ describe('OperationLogHydratorService', () => {
           loadAllDataSequence,
           `mergeRemoteOpClocks (seq ${mergeClockSequence}) should be called BEFORE ` +
             `loadAllData (seq ${loadAllDataSequence}) in no-snapshot branch`,
+        );
+      });
+
+      it('should preserve local sync settings when replaying SYNC_IMPORT without state cache', async () => {
+        const syncImportPayload = {
+          task: {},
+          project: {},
+          globalConfig: {
+            sync: {
+              syncProvider: SyncProviderId.WebDAV,
+              isEnabled: true,
+              isEncryptionEnabled: true,
+              syncInterval: 300000,
+              isManualSyncOnly: true,
+              isCompressionEnabled: true,
+            },
+          },
+        };
+        const syncImportOp = createMockOperation('sync-op', OpType.SyncImport, {
+          payload: syncImportPayload,
+          entityType: 'ALL',
+        });
+
+        mockOpLogStore.loadStateCache.and.returnValue(Promise.resolve(null));
+        mockOpLogStore.getOpsAfterSeq.and.returnValue(
+          Promise.resolve([createMockEntry(1, syncImportOp)]),
+        );
+
+        await service.hydrateStore();
+
+        expect(mockStore.dispatch).toHaveBeenCalledWith(
+          loadAllData({ appDataComplete: syncImportPayload as any }),
         );
       });
 

--- a/src/app/op-log/persistence/sync-hydration.service.spec.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.spec.ts
@@ -28,6 +28,8 @@ describe('SyncHydrationService', () => {
     ...DEFAULT_GLOBAL_CONFIG.sync,
     isEnabled: true,
     syncProvider: SyncProviderId.WebDAV,
+    syncInterval: 300000,
+    isManualSyncOnly: false,
   };
 
   beforeEach(() => {
@@ -223,11 +225,16 @@ describe('SyncHydrationService', () => {
       expect(vectorClock['remoteClient']).toBe(100);
     });
 
-    it('should strip syncProvider from globalConfig.sync', async () => {
+    it('should strip local-only settings from globalConfig.sync', async () => {
       const downloadedData = {
         task: {},
         globalConfig: {
-          sync: { syncProvider: 'dropbox', someOther: 'setting' },
+          sync: {
+            syncProvider: 'dropbox',
+            syncInterval: 600000,
+            isManualSyncOnly: true,
+            someOther: 'setting',
+          },
           otherSetting: 'value',
         },
       };
@@ -239,6 +246,8 @@ describe('SyncHydrationService', () => {
       const globalConfig = payload['globalConfig'] as Record<string, unknown>;
       const sync = globalConfig['sync'] as Record<string, unknown>;
       expect(sync['syncProvider']).toBeNull();
+      expect(sync['syncInterval']).toBeUndefined();
+      expect(sync['isManualSyncOnly']).toBeUndefined();
       expect(sync['someOther']).toBe('setting');
       expect(globalConfig['otherSetting']).toBe('value');
     });
@@ -526,7 +535,7 @@ describe('SyncHydrationService', () => {
       expect(mockOpLogStore.append).toHaveBeenCalled();
     });
 
-    it('should preserve all other globalConfig properties', async () => {
+    it('should preserve synced globalConfig properties while stripping local-only sync settings', async () => {
       const downloadedData = {
         globalConfig: {
           lang: 'de',
@@ -547,7 +556,7 @@ describe('SyncHydrationService', () => {
       expect(globalConfig['lang']).toBe('de');
       expect(globalConfig['theme']).toBe('dark');
       const sync = globalConfig['sync'] as Record<string, unknown>;
-      expect(sync['syncInterval']).toBe(300);
+      expect(sync['syncInterval']).toBeUndefined();
       expect(sync['isEnabled']).toBe(true);
       expect(sync['syncProvider']).toBeNull();
     });
@@ -576,6 +585,8 @@ describe('SyncHydrationService', () => {
         ...DEFAULT_GLOBAL_CONFIG.sync,
         isEnabled: true,
         syncProvider: SyncProviderId.WebDAV,
+        syncInterval: 300000,
+        isManualSyncOnly: false,
       };
       mockStore.select.and.returnValue(of(localSyncConfig));
 
@@ -607,6 +618,8 @@ describe('SyncHydrationService', () => {
       // Step 4: Verify the snapshot has PRESERVED local settings (not remote's false)
       expect(snapshotSync['isEnabled']).toBe(true); // Local value preserved!
       expect(snapshotSync['syncProvider']).toBe(SyncProviderId.WebDAV); // Local provider preserved!
+      expect(snapshotSync['syncInterval']).toBe(300000);
+      expect(snapshotSync['isManualSyncOnly']).toBe(false);
 
       // Step 5: Simulate what happens on reload
       // The hydrator will call store.dispatch(loadAllData({ appDataComplete: snapshotState }))
@@ -620,15 +633,19 @@ describe('SyncHydrationService', () => {
       // Final verification: The data dispatched to NgRx has correct local settings
       expect(dispatchedSync['isEnabled']).toBe(true);
       expect(dispatchedSync['syncProvider']).toBe(SyncProviderId.WebDAV);
+      expect(dispatchedSync['syncInterval']).toBe(300000);
+      expect(dispatchedSync['isManualSyncOnly']).toBe(false);
     });
 
-    it('should preserve local isEnabled when remote has it disabled', async () => {
+    it('should preserve local-only sync settings when remote has sync disabled', async () => {
       // Local has sync enabled
       mockStore.select.and.returnValue(
         of({
           ...DEFAULT_GLOBAL_CONFIG.sync,
           isEnabled: true,
           syncProvider: SyncProviderId.WebDAV,
+          syncInterval: 300000,
+          isManualSyncOnly: true,
         }),
       );
 
@@ -638,6 +655,8 @@ describe('SyncHydrationService', () => {
           sync: {
             isEnabled: false, // Remote has sync disabled
             syncProvider: 'dropbox',
+            syncInterval: 600000,
+            isManualSyncOnly: false,
           },
         },
       };
@@ -651,6 +670,42 @@ describe('SyncHydrationService', () => {
       const sync = globalConfig['sync'] as Record<string, unknown>;
       expect(sync['isEnabled']).toBe(true);
       expect(sync['syncProvider']).toBe(SyncProviderId.WebDAV);
+      expect(sync['syncInterval']).toBe(300000);
+      expect(sync['isManualSyncOnly']).toBe(true);
+    });
+
+    it('should keep local sync schedule settings out of the SYNC_IMPORT payload', async () => {
+      mockStore.select.and.returnValue(
+        of({
+          ...DEFAULT_GLOBAL_CONFIG.sync,
+          isEnabled: true,
+          syncProvider: SyncProviderId.WebDAV,
+          syncInterval: 300000,
+          isManualSyncOnly: true,
+        }),
+      );
+
+      const downloadedData = {
+        globalConfig: {
+          sync: {
+            isEnabled: false,
+            syncProvider: SyncProviderId.Dropbox,
+            syncInterval: 600000,
+            isManualSyncOnly: false,
+          },
+        },
+      };
+
+      await service.hydrateFromRemoteSync(downloadedData);
+
+      const appendCall = mockOpLogStore.append.calls.mostRecent();
+      const payload = appendCall.args[0].payload as Record<string, unknown>;
+      const globalConfig = payload['globalConfig'] as Record<string, unknown>;
+      const sync = globalConfig['sync'] as Record<string, unknown>;
+
+      expect(sync['syncProvider']).toBeNull();
+      expect(sync['syncInterval']).toBeUndefined();
+      expect(sync['isManualSyncOnly']).toBeUndefined();
     });
 
     it('should preserve local isEnabled when remote has it enabled', async () => {
@@ -725,6 +780,8 @@ describe('SyncHydrationService', () => {
           ...DEFAULT_GLOBAL_CONFIG.sync,
           isEnabled: true,
           syncProvider: SyncProviderId.SuperSync,
+          syncInterval: 300000,
+          isManualSyncOnly: true,
         }),
       );
 
@@ -733,6 +790,8 @@ describe('SyncHydrationService', () => {
           sync: {
             isEnabled: false,
             syncProvider: SyncProviderId.LocalFile,
+            syncInterval: 600000,
+            isManualSyncOnly: false,
           },
         },
       };
@@ -746,6 +805,8 @@ describe('SyncHydrationService', () => {
       const savedSync = savedGlobalConfig['sync'] as Record<string, unknown>;
       expect(savedSync['isEnabled']).toBe(true);
       expect(savedSync['syncProvider']).toBe(SyncProviderId.SuperSync);
+      expect(savedSync['syncInterval']).toBe(300000);
+      expect(savedSync['isManualSyncOnly']).toBe(true);
 
       // Check dispatch
       const dispatchCall = mockStore.dispatch.calls.mostRecent();
@@ -757,6 +818,8 @@ describe('SyncHydrationService', () => {
       const dispatchedSync = dispatchedGlobalConfig['sync'] as Record<string, unknown>;
       expect(dispatchedSync['isEnabled']).toBe(true);
       expect(dispatchedSync['syncProvider']).toBe(SyncProviderId.SuperSync);
+      expect(dispatchedSync['syncInterval']).toBe(300000);
+      expect(dispatchedSync['isManualSyncOnly']).toBe(true);
     });
   });
 });

--- a/src/app/op-log/persistence/sync-hydration.service.spec.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.spec.ts
@@ -225,7 +225,7 @@ describe('SyncHydrationService', () => {
       expect(vectorClock['remoteClient']).toBe(100);
     });
 
-    it('should strip local-only settings from globalConfig.sync', async () => {
+    it('should persist local-only settings in local SYNC_IMPORT payload for replay', async () => {
       const downloadedData = {
         task: {},
         globalConfig: {
@@ -245,9 +245,13 @@ describe('SyncHydrationService', () => {
       const payload = appendCall.args[0].payload as Record<string, unknown>;
       const globalConfig = payload['globalConfig'] as Record<string, unknown>;
       const sync = globalConfig['sync'] as Record<string, unknown>;
-      expect(sync['syncProvider']).toBeNull();
-      expect(sync['syncInterval']).toBeUndefined();
-      expect(sync['isManualSyncOnly']).toBeUndefined();
+      expect(sync['isEnabled']).toBe(defaultLocalSyncConfig.isEnabled);
+      expect(sync['isEncryptionEnabled']).toBe(
+        defaultLocalSyncConfig.isEncryptionEnabled,
+      );
+      expect(sync['syncProvider']).toBe(defaultLocalSyncConfig.syncProvider);
+      expect(sync['syncInterval']).toBe(defaultLocalSyncConfig.syncInterval);
+      expect(sync['isManualSyncOnly']).toBe(defaultLocalSyncConfig.isManualSyncOnly);
       expect(sync['someOther']).toBe('setting');
       expect(globalConfig['otherSetting']).toBe('value');
     });
@@ -535,7 +539,7 @@ describe('SyncHydrationService', () => {
       expect(mockOpLogStore.append).toHaveBeenCalled();
     });
 
-    it('should preserve synced globalConfig properties while stripping local-only sync settings', async () => {
+    it('should preserve synced globalConfig properties while overlaying local-only sync settings', async () => {
       const downloadedData = {
         globalConfig: {
           lang: 'de',
@@ -556,9 +560,10 @@ describe('SyncHydrationService', () => {
       expect(globalConfig['lang']).toBe('de');
       expect(globalConfig['theme']).toBe('dark');
       const sync = globalConfig['sync'] as Record<string, unknown>;
-      expect(sync['syncInterval']).toBeUndefined();
-      expect(sync['isEnabled']).toBe(true);
-      expect(sync['syncProvider']).toBeNull();
+      expect(sync['isEnabled']).toBe(defaultLocalSyncConfig.isEnabled);
+      expect(sync['syncProvider']).toBe(defaultLocalSyncConfig.syncProvider);
+      expect(sync['syncInterval']).toBe(defaultLocalSyncConfig.syncInterval);
+      expect(sync['isManualSyncOnly']).toBe(defaultLocalSyncConfig.isManualSyncOnly);
     });
   });
 
@@ -674,7 +679,7 @@ describe('SyncHydrationService', () => {
       expect(sync['isManualSyncOnly']).toBe(true);
     });
 
-    it('should keep local sync schedule settings out of the SYNC_IMPORT payload', async () => {
+    it('should keep local sync schedule settings in the local SYNC_IMPORT payload', async () => {
       mockStore.select.and.returnValue(
         of({
           ...DEFAULT_GLOBAL_CONFIG.sync,
@@ -703,9 +708,9 @@ describe('SyncHydrationService', () => {
       const globalConfig = payload['globalConfig'] as Record<string, unknown>;
       const sync = globalConfig['sync'] as Record<string, unknown>;
 
-      expect(sync['syncProvider']).toBeNull();
-      expect(sync['syncInterval']).toBeUndefined();
-      expect(sync['isManualSyncOnly']).toBeUndefined();
+      expect(sync['syncProvider']).toBe(SyncProviderId.WebDAV);
+      expect(sync['syncInterval']).toBe(300000);
+      expect(sync['isManualSyncOnly']).toBe(true);
     });
 
     it('should preserve local isEnabled when remote has it enabled', async () => {

--- a/src/app/op-log/persistence/sync-hydration.service.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.ts
@@ -24,7 +24,10 @@ import { T } from '../../t.const';
 import { ArchiveDbAdapter } from '../../core/persistence/archive-db-adapter.service';
 import { ArchiveModel } from '../../features/time-tracking/time-tracking.model';
 import { normalizeGlobalConfigStartOfNextDay } from '../../features/config/normalize-start-of-next-day-config';
-import { stripLocalOnlySyncSettingsFromAppData } from '../../features/config/local-only-sync-settings.util';
+import {
+  applyLocalOnlySyncSettingsToAppData,
+  stripLocalOnlySyncSettingsFromAppData,
+} from '../../features/config/local-only-sync-settings.util';
 
 /**
  * Handles hydration after remote sync downloads.
@@ -122,6 +125,10 @@ export class SyncHydrationService {
         : dbData;
 
       const syncedData = stripLocalOnlySyncSettingsFromAppData(mergedData);
+      const locallyReplayableSyncedData = applyLocalOnlySyncSettingsToAppData(
+        syncedData,
+        localOnlySettings,
+      );
       OpLog.normal(
         'SyncHydrationService: Loaded synced data',
         downloadedMainModelData
@@ -175,7 +182,7 @@ export class SyncHydrationService {
           actionType: ActionType.LOAD_ALL_DATA,
           opType: OpType.SyncImport,
           entityType: 'ALL',
-          payload: syncedData,
+          payload: locallyReplayableSyncedData,
           clientId: clientId,
           vectorClock: newClock,
           timestamp: Date.now(),
@@ -228,7 +235,7 @@ export class SyncHydrationService {
       // can refuse IN_SYNC. Without this, snapshot hydration would silently
       // accept corrupt remote data — a gap not covered by validateAfterSync
       // since this path bypasses processRemoteOps entirely. (#7330)
-      const downloadedAppData = syncedData as AppDataComplete;
+      const downloadedAppData = locallyReplayableSyncedData as AppDataComplete;
       const normalizedGlobalConfig = normalizeGlobalConfigStartOfNextDay(
         downloadedAppData.globalConfig,
       );
@@ -251,23 +258,6 @@ export class SyncHydrationService {
           { error: validationResult.error },
         );
         this.sessionValidation.setFailed();
-      }
-
-      // 7b. Restore local-only sync settings into dataToLoad
-      // This ensures the snapshot and NgRx state have the correct local settings,
-      // not the ones from remote data. Without this, isEnabled could be set to false
-      // if another client had sync disabled, causing sync to appear disabled on reload.
-      if (dataToLoad.globalConfig?.sync) {
-        dataToLoad = {
-          ...dataToLoad,
-          globalConfig: {
-            ...dataToLoad.globalConfig,
-            sync: {
-              ...dataToLoad.globalConfig.sync,
-              ...localOnlySettings,
-            },
-          },
-        };
       }
 
       // 8. Determine the working clock to use.

--- a/src/app/op-log/persistence/sync-hydration.service.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.ts
@@ -24,6 +24,7 @@ import { T } from '../../t.const';
 import { ArchiveDbAdapter } from '../../core/persistence/archive-db-adapter.service';
 import { ArchiveModel } from '../../features/time-tracking/time-tracking.model';
 import { normalizeGlobalConfigStartOfNextDay } from '../../features/config/normalize-start-of-next-day-config';
+import { stripLocalOnlySyncSettingsFromAppData } from '../../features/config/local-only-sync-settings.util';
 
 /**
  * Handles hydration after remote sync downloads.
@@ -84,7 +85,10 @@ export class SyncHydrationService {
       const currentSyncConfig = await firstValueFrom(this.store.select(selectSyncConfig));
       const localOnlySettings = {
         isEnabled: currentSyncConfig.isEnabled,
+        isEncryptionEnabled: currentSyncConfig.isEncryptionEnabled,
         syncProvider: currentSyncConfig.syncProvider,
+        syncInterval: currentSyncConfig.syncInterval,
+        isManualSyncOnly: currentSyncConfig.isManualSyncOnly,
       };
 
       // 1. Write archives to IndexedDB if they were included in the downloaded data.
@@ -117,7 +121,7 @@ export class SyncHydrationService {
         ? { ...dbData, ...downloadedMainModelData }
         : dbData;
 
-      const syncedData = this._stripLocalOnlySettings(mergedData);
+      const syncedData = stripLocalOnlySyncSettingsFromAppData(mergedData);
       OpLog.normal(
         'SyncHydrationService: Loaded synced data',
         downloadedMainModelData
@@ -310,42 +314,5 @@ export class SyncHydrationService {
       OpLog.err('SyncHydrationService: Error during hydrateFromRemoteSync', e);
       throw e;
     }
-  }
-
-  /**
-   * Strips local-only settings from synced data to prevent them from being
-   * overwritten by remote data. These settings should remain local to each client.
-   *
-   * Currently strips:
-   * - globalConfig.sync.syncProvider: Each client chooses its own sync provider
-   */
-  private _stripLocalOnlySettings(data: unknown): unknown {
-    if (!data || typeof data !== 'object') {
-      return data;
-    }
-
-    const typedData = data as Record<string, unknown>;
-    if (!typedData['globalConfig']) {
-      return data;
-    }
-
-    const globalConfig = typedData['globalConfig'] as Record<string, unknown>;
-    if (!globalConfig['sync']) {
-      return data;
-    }
-
-    const sync = globalConfig['sync'] as Record<string, unknown>;
-
-    // Return data with syncProvider nulled out
-    return {
-      ...typedData,
-      globalConfig: {
-        ...globalConfig,
-        sync: {
-          ...sync,
-          syncProvider: null, // Local-only setting, don't overwrite from remote
-        },
-      },
-    };
   }
 }

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -18,6 +18,7 @@ import { getSyncFilePrefix } from '../../util/sync-file-prefix';
 import { ArchiveDbAdapter } from '../../../core/persistence/archive-db-adapter.service';
 import { ArchiveModel } from '../../../features/time-tracking/time-tracking.model';
 import { StateSnapshotService } from '../../backup/state-snapshot.service';
+import { DEFAULT_GLOBAL_CONFIG } from '../../../features/config/default-global-config.const';
 
 describe('FileBasedSyncAdapterService', () => {
   let service: FileBasedSyncAdapterService;
@@ -137,6 +138,16 @@ describe('FileBasedSyncAdapterService', () => {
     mockStateSnapshotService.getStateSnapshot.and.returnValue({
       tasks: [],
       projects: [],
+      globalConfig: {
+        ...DEFAULT_GLOBAL_CONFIG,
+        sync: {
+          ...DEFAULT_GLOBAL_CONFIG.sync,
+          syncProvider: SyncProviderId.WebDAV,
+          syncInterval: 300000,
+          isManualSyncOnly: true,
+          isCompressionEnabled: true,
+        },
+      },
     } as any);
 
     TestBed.configureTestingModule({
@@ -684,7 +695,16 @@ describe('FileBasedSyncAdapterService', () => {
       expect(result.accepted).toBe(true);
       const uploadedData = parseWithPrefix(uploadedDataStr);
       // State should come from getStateSnapshot(), not the passed parameter
-      expect(uploadedData.state).toEqual({ tasks: [], projects: [] } as any);
+      expect(uploadedData.state).toEqual(
+        jasmine.objectContaining({ tasks: [], projects: [] }) as any,
+      );
+      const uploadedState = uploadedData.state as Record<string, unknown>;
+      const globalConfig = uploadedState['globalConfig'] as Record<string, unknown>;
+      const sync = globalConfig['sync'] as Record<string, unknown>;
+      expect(sync['syncProvider']).toBeNull();
+      expect(sync['syncInterval']).toBeUndefined();
+      expect(sync['isManualSyncOnly']).toBeUndefined();
+      expect(sync['isCompressionEnabled']).toBe(true);
       expect(uploadedData.vectorClock).toEqual(vectorClock);
       expect(uploadedData.schemaVersion).toBe(2);
       expect(uploadedData.syncVersion).toBe(1);
@@ -1019,6 +1039,12 @@ describe('FileBasedSyncAdapterService', () => {
         const uploadedData = parseWithPrefix(uploadedDataStr);
         expect(uploadedData.archiveYoung).toBeUndefined();
         expect(uploadedData.archiveOld).toBeUndefined();
+        const uploadedState = uploadedData.state as Record<string, unknown>;
+        const globalConfig = uploadedState['globalConfig'] as Record<string, unknown>;
+        const sync = globalConfig['sync'] as Record<string, unknown>;
+        expect(sync['syncProvider']).toBeNull();
+        expect(sync['syncInterval']).toBeUndefined();
+        expect(sync['isManualSyncOnly']).toBeUndefined();
       });
     });
 

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -41,6 +41,7 @@ import {
 import { mergeVectorClocks } from '../../../core/util/vector-clock';
 import { ArchiveDbAdapter } from '../../../core/persistence/archive-db-adapter.service';
 import { StateSnapshotService } from '../../backup/state-snapshot.service';
+import { stripLocalOnlySyncSettingsFromAppData } from '../../../features/config/local-only-sync-settings.util';
 
 /**
  * Adapter that enables file-based sync providers (WebDAV, Dropbox, LocalFile)
@@ -406,7 +407,9 @@ export class FileBasedSyncAdapterService {
     const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
 
     // Get current state from NgRx store - this keeps the snapshot up-to-date
-    const currentState = await this._stateSnapshotService.getStateSnapshot();
+    const currentState = stripLocalOnlySyncSettingsFromAppData(
+      await this._stateSnapshotService.getStateSnapshot(),
+    );
 
     // Compute oldestOpSyncVersion from the first (oldest) op in mergedOps.
     // Ops without sv (from old sync files) are ignored — gap detection stays
@@ -783,7 +786,9 @@ export class FileBasedSyncAdapterService {
     //    sync cycle, so fetching directly ensures we capture the latest store state.
     // Note: double-encryption is not a concern here — file-based providers don't expose
     // getEncryptKey, so the upload service never applies payload-level encryption for them.
-    const currentState = await this._stateSnapshotService.getStateSnapshot();
+    const currentState = stripLocalOnlySyncSettingsFromAppData(
+      await this._stateSnapshotService.getStateSnapshot(),
+    );
 
     // Load archive data from IndexedDB to include in snapshot
     const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -177,6 +177,65 @@ describe('OperationLogUploadService', () => {
         expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([1, 2]);
       });
 
+      it('should strip local sync schedule settings from regular config ops before upload', async () => {
+        const entry = createMockEntry(1, 'op-1', 'client-1');
+        entry.op.actionType = ActionType.GLOBAL_CONFIG_UPDATE_SECTION;
+        entry.op.entityType = 'GLOBAL_CONFIG';
+        entry.op.payload = {
+          actionPayload: {
+            sectionKey: 'sync',
+            sectionCfg: {
+              syncInterval: 300000,
+              isManualSyncOnly: true,
+              isCompressionEnabled: true,
+            },
+          },
+          entityChanges: [],
+        };
+        mockOpLogStore.getUnsynced.and.returnValue(Promise.resolve([entry]));
+        mockApiProvider.uploadOps.and.returnValue(
+          Promise.resolve({
+            results: [{ opId: 'op-1', accepted: true }],
+            latestSeq: 1,
+            newOps: [],
+          }),
+        );
+
+        await service.uploadPendingOps(mockApiProvider);
+
+        const uploadedOps = mockApiProvider.uploadOps.calls.mostRecent().args[0];
+        const payload = uploadedOps[0].payload as {
+          actionPayload: { sectionCfg: Record<string, unknown> };
+        };
+
+        expect(payload.actionPayload.sectionCfg).toEqual({
+          isCompressionEnabled: true,
+        });
+      });
+
+      it('should not upload regular config ops that only contain local sync schedule settings', async () => {
+        const entry = createMockEntry(1, 'op-1', 'client-1');
+        entry.op.actionType = ActionType.GLOBAL_CONFIG_UPDATE_SECTION;
+        entry.op.entityType = 'GLOBAL_CONFIG';
+        entry.op.payload = {
+          actionPayload: {
+            sectionKey: 'sync',
+            sectionCfg: {
+              syncInterval: 300000,
+              isManualSyncOnly: true,
+            },
+          },
+          entityChanges: [],
+        };
+        mockOpLogStore.getUnsynced.and.returnValue(Promise.resolve([entry]));
+
+        const result = await service.uploadPendingOps(mockApiProvider);
+
+        expect(mockApiProvider.uploadOps).not.toHaveBeenCalled();
+        expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([1]);
+        expect(result.uploadedCount).toBe(1);
+      });
+
       it('should update last server seq after upload', async () => {
         mockOpLogStore.getUnsynced.and.returnValue(
           Promise.resolve([createMockEntry(1, 'op-1', 'client-1')]),
@@ -984,6 +1043,38 @@ describe('OperationLogUploadService', () => {
           'BACKUP_IMPORT', // snapshotOpType
           undefined, // syncImportReason
         );
+      });
+
+      it('should strip local-only sync settings from full-state snapshot uploads', async () => {
+        const entry = createFullStateEntry(1, 'op-1', 'client-1', OpType.SyncImport);
+        entry.op.payload = {
+          task: { ids: [], entities: {} },
+          globalConfig: {
+            sync: {
+              isEnabled: true,
+              isEncryptionEnabled: true,
+              syncProvider: SyncProviderId.WebDAV,
+              syncInterval: 300000,
+              isManualSyncOnly: true,
+              isCompressionEnabled: true,
+            },
+          },
+        };
+        mockOpLogStore.getUnsynced.and.returnValue(Promise.resolve([entry]));
+
+        await service.uploadPendingOps(mockApiProvider);
+
+        const uploadedState = mockApiProvider.uploadSnapshot.calls.mostRecent()
+          .args[0] as Record<string, unknown>;
+        const globalConfig = uploadedState['globalConfig'] as Record<string, unknown>;
+        const sync = globalConfig['sync'] as Record<string, unknown>;
+
+        expect(sync['syncProvider']).toBeNull();
+        expect(sync['syncInterval']).toBeUndefined();
+        expect(sync['isManualSyncOnly']).toBeUndefined();
+        expect(sync['isEnabled']).toBe(true);
+        expect(sync['isEncryptionEnabled']).toBe(true);
+        expect(sync['isCompressionEnabled']).toBe(true);
       });
 
       /**

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -455,6 +455,7 @@ export class OperationLogUploadService {
       actionPayload['sectionCfg'] as Record<string, unknown>,
     );
     if (Object.keys(sectionCfg).length === 0) {
+      // GLOBAL_CONFIG_UPDATE_SECTION replays from actionPayload; entityChanges are empty.
       return null;
     }
 

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -12,6 +12,7 @@ import {
   FULL_STATE_OP_TYPES,
   extractFullStateFromPayload,
   assertValidFullStatePayload,
+  ActionType,
 } from '../core/operation.types';
 import { OpLog } from '../../core/log';
 import { LOCK_NAMES, MAX_OPS_PER_UPLOAD_REQUEST } from '../core/operation-log.const';
@@ -31,6 +32,10 @@ import {
 import { isRetryableUploadError } from '@sp/sync-providers/http';
 import { handleStorageQuotaError } from './sync-error-utils';
 import { DecryptNoPasswordError } from '../core/errors/sync-errors';
+import {
+  stripLocalOnlySyncScheduleSettings,
+  stripLocalOnlySyncSettingsFromAppData,
+} from '../../features/config/local-only-sync-settings.util';
 
 // Re-export for consumers that import from this service
 export type {
@@ -214,10 +219,30 @@ export class OperationLogUploadService {
         regularOps = opsAfterSnapshot;
       }
 
-      // Convert to SyncOperation format
-      let syncOps: SyncOperation[] = regularOps.map((entry) =>
-        this._entryToSyncOp(entry),
-      );
+      // Convert to SyncOperation format. Local-only operations remain in the
+      // local op-log for replay, but are acknowledged locally instead of uploaded.
+      const syncOpPairs = regularOps
+        .map((entry) => ({ entry, syncOp: this._entryToSyncOp(entry) }))
+        .filter(
+          (pair): pair is { entry: OperationLogEntry; syncOp: SyncOperation } =>
+            pair.syncOp !== null,
+        );
+      const localOnlySeqs = regularOps
+        .filter((entry) => !syncOpPairs.some((pair) => pair.entry.seq === entry.seq))
+        .map((entry) => entry.seq);
+      if (localOnlySeqs.length > 0) {
+        await this.opLogStore.markSynced(localOnlySeqs);
+        uploadedCount += localOnlySeqs.length;
+        OpLog.normal(
+          `OperationLogUploadService: Marked ${localOnlySeqs.length} local-only op(s) as synced without upload`,
+        );
+      }
+      if (syncOpPairs.length === 0) {
+        return;
+      }
+
+      let syncOps: SyncOperation[] = syncOpPairs.map((pair) => pair.syncOp);
+      const uploadEntries = syncOpPairs.map((pair) => pair.entry);
 
       // Encrypt payloads if E2E encryption is enabled
       if (isEncryptionEnabled && encryptKey) {
@@ -227,7 +252,7 @@ export class OperationLogUploadService {
 
       // Upload in batches to avoid 413 Payload Too Large errors
       const chunks = chunkArray(syncOps, MAX_OPS_PER_UPLOAD_REQUEST);
-      const correspondingEntries = chunkArray(regularOps, MAX_OPS_PER_UPLOAD_REQUEST);
+      const correspondingEntries = chunkArray(uploadEntries, MAX_OPS_PER_UPLOAD_REQUEST);
 
       for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
@@ -378,7 +403,12 @@ export class OperationLogUploadService {
     };
   }
 
-  private _entryToSyncOp(entry: OperationLogEntry): SyncOperation {
+  private _entryToSyncOp(entry: OperationLogEntry): SyncOperation | null {
+    const payload = this._sanitizeRegularOpPayloadForUpload(entry.op);
+    if (payload === null) {
+      return null;
+    }
+
     return {
       id: entry.op.id,
       clientId: entry.op.clientId,
@@ -387,13 +417,53 @@ export class OperationLogUploadService {
       entityType: entry.op.entityType,
       entityId: entry.op.entityId,
       entityIds: entry.op.entityIds,
-      payload: entry.op.payload,
+      payload,
       vectorClock: entry.op.vectorClock,
       timestamp: entry.op.timestamp,
       schemaVersion: entry.op.schemaVersion,
       ...(entry.op.syncImportReason
         ? { syncImportReason: entry.op.syncImportReason }
         : {}),
+    };
+  }
+
+  private _sanitizeRegularOpPayloadForUpload(op: Operation): unknown | null {
+    if (
+      op.actionType !== ActionType.GLOBAL_CONFIG_UPDATE_SECTION ||
+      typeof op.payload !== 'object' ||
+      op.payload === null ||
+      !('actionPayload' in op.payload)
+    ) {
+      return op.payload;
+    }
+
+    const multiEntityPayload = op.payload as {
+      actionPayload?: Record<string, unknown>;
+      entityChanges?: unknown;
+    };
+    const actionPayload = multiEntityPayload.actionPayload;
+    if (
+      !actionPayload ||
+      actionPayload['sectionKey'] !== 'sync' ||
+      typeof actionPayload['sectionCfg'] !== 'object' ||
+      actionPayload['sectionCfg'] === null
+    ) {
+      return op.payload;
+    }
+
+    const sectionCfg = stripLocalOnlySyncScheduleSettings(
+      actionPayload['sectionCfg'] as Record<string, unknown>,
+    );
+    if (Object.keys(sectionCfg).length === 0) {
+      return null;
+    }
+
+    return {
+      ...multiEntityPayload,
+      actionPayload: {
+        ...actionPayload,
+        sectionCfg,
+      },
     };
   }
 
@@ -425,7 +495,9 @@ export class OperationLogUploadService {
 
     // Extract state from payload, handling both wrapped and unwrapped formats.
     // Uses shared utility to ensure consistent handling across the codebase.
-    let state: unknown = extractFullStateFromPayload(op.payload);
+    let state: unknown = stripLocalOnlySyncSettingsFromAppData(
+      extractFullStateFromPayload(op.payload),
+    );
 
     // Validate the payload structure before uploading to catch bugs early.
     // This throws if the payload is malformed (e.g., missing expected keys).

--- a/src/app/op-log/sync/remote-ops-processing.service.spec.ts
+++ b/src/app/op-log/sync/remote-ops-processing.service.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { of } from 'rxjs';
 import { RemoteOpsProcessingService } from './remote-ops-processing.service';
 import {
   SchemaMigrationService,
@@ -32,8 +34,11 @@ import {
 import { toEntityKey } from '../util/entity-key.util';
 import { T } from '../../t.const';
 import { OpLog } from '../../core/log';
+import { SyncProviderId } from '../sync-providers/provider.const';
+
 describe('RemoteOpsProcessingService', () => {
   let service: RemoteOpsProcessingService;
+  let storeSpy: jasmine.SpyObj<Store>;
   let schemaMigrationServiceSpy: jasmine.SpyObj<SchemaMigrationService>;
   let snackServiceSpy: jasmine.SpyObj<SnackService>;
   let opLogStoreSpy: jasmine.SpyObj<OperationLogStoreService>;
@@ -47,6 +52,16 @@ describe('RemoteOpsProcessingService', () => {
   let operationLogEffectsSpy: jasmine.SpyObj<OperationLogEffects>;
 
   beforeEach(() => {
+    storeSpy = jasmine.createSpyObj('Store', ['select']);
+    storeSpy.select.and.returnValue(
+      of({
+        isEnabled: true,
+        isEncryptionEnabled: true,
+        syncProvider: SyncProviderId.WebDAV,
+        syncInterval: 300000,
+        isManualSyncOnly: true,
+      }),
+    );
     schemaMigrationServiceSpy = jasmine.createSpyObj('SchemaMigrationService', [
       'getCurrentVersion',
       'migrateOperation',
@@ -223,6 +238,7 @@ describe('RemoteOpsProcessingService', () => {
     TestBed.configureTestingModule({
       providers: [
         RemoteOpsProcessingService,
+        { provide: Store, useValue: storeSpy },
         { provide: SchemaMigrationService, useValue: schemaMigrationServiceSpy },
         { provide: SnackService, useValue: snackServiceSpy },
         { provide: OperationLogStoreService, useValue: opLogStoreSpy },
@@ -699,6 +715,59 @@ describe('RemoteOpsProcessingService', () => {
           priorUnsyncedByOpType: { [OpType.Update]: 1 },
         }),
       );
+    });
+
+    it('should persist current local sync settings into incoming SYNC_IMPORT ops for replay', async () => {
+      const syncImportOp: Operation = {
+        id: 'sync-import-localized',
+        opType: OpType.SyncImport,
+        actionType: '[All] Load All Data' as ActionType,
+        entityType: 'ALL',
+        payload: {
+          task: {},
+          project: {},
+          globalConfig: {
+            sync: {
+              isEnabled: false,
+              isEncryptionEnabled: false,
+              syncProvider: null,
+              syncInterval: 600000,
+              isManualSyncOnly: false,
+              isCompressionEnabled: true,
+            },
+          },
+        },
+        clientId: 'client-1',
+        vectorClock: { client1: 1 },
+        timestamp: Date.now(),
+        schemaVersion: 1,
+      };
+      let appliedOps: Operation[] = [];
+
+      opLogStoreSpy.hasOp.and.returnValue(Promise.resolve(false));
+      operationApplierServiceSpy.applyOperations.and.callFake(async (ops) => {
+        appliedOps = ops;
+        return { appliedOps: ops };
+      });
+
+      await service.processRemoteOps([syncImportOp]);
+
+      const writtenOp =
+        opLogStoreSpy.appendBatchSkipDuplicates.calls.mostRecent().args[0][0];
+      const writtenPayload = writtenOp.payload as Record<string, unknown>;
+      const writtenGlobalConfig = writtenPayload['globalConfig'] as Record<
+        string,
+        unknown
+      >;
+      const writtenSync = writtenGlobalConfig['sync'] as Record<string, unknown>;
+
+      expect(writtenSync['isEnabled']).toBe(true);
+      expect(writtenSync['isEncryptionEnabled']).toBe(true);
+      expect(writtenSync['syncProvider']).toBe(SyncProviderId.WebDAV);
+      expect(writtenSync['syncInterval']).toBe(300000);
+      expect(writtenSync['isManualSyncOnly']).toBe(true);
+      expect(writtenSync['isCompressionEnabled']).toBe(true);
+      expect(appliedOps[0]).toBe(writtenOp);
     });
 
     it('should skip conflict detection when BACKUP_IMPORT is in remote ops', async () => {

--- a/src/app/op-log/sync/remote-ops-processing.service.ts
+++ b/src/app/op-log/sync/remote-ops-processing.service.ts
@@ -1,9 +1,13 @@
 import { inject, Injectable, Injector } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { firstValueFrom } from 'rxjs';
 import { applyRemoteOperations } from '@sp/sync-core';
 import { OperationLogStoreService } from '../persistence/operation-log-store.service';
 import {
   ConflictResult,
   EntityConflict,
+  extractFullStateFromPayload,
+  isWrappedFullStatePayload,
   Operation,
   OpType,
   VectorClock,
@@ -27,6 +31,11 @@ import { OperationLogCompactionService } from '../persistence/operation-log-comp
 import { SyncImportFilterService } from './sync-import-filter.service';
 import { OperationWriteFlushService } from './operation-write-flush.service';
 import { processDeferredActionsAfterRemoteApply } from './process-deferred-actions-flush.util';
+import { selectSyncConfig } from '../../features/config/store/global-config.reducer';
+import {
+  applyLocalOnlySyncSettingsToAppData,
+  LocalOnlySyncSettings,
+} from '../../features/config/local-only-sync-settings.util';
 
 /**
  * Handles the core pipeline for processing remote operations.
@@ -45,6 +54,7 @@ import { processDeferredActionsAfterRemoteApply } from './process-deferred-actio
   providedIn: 'root',
 })
 export class RemoteOpsProcessingService {
+  private store = inject(Store);
   private opLogStore = inject(OperationLogStoreService);
   private operationApplier = inject(OperationApplierService);
   private conflictResolutionService = inject(ConflictResolutionService);
@@ -389,7 +399,10 @@ export class RemoteOpsProcessingService {
     ops: Operation[],
     callerHoldsLock: boolean = false,
   ): Promise<void> {
-    await this._logFullStateApplyDiagnostics(ops);
+    const locallyReplayableOps =
+      await this._withLocalOnlySyncSettingsForFullStateOps(ops);
+
+    await this._logFullStateApplyDiagnostics(locallyReplayableOps);
 
     // Mirror autoResolveConflictsLWW: wrap apply in try/finally so deferred
     // local actions are flushed whether the apply succeeded or threw.
@@ -401,7 +414,7 @@ export class RemoteOpsProcessingService {
       // Core owns the generic crash-safety ordering. Angular diagnostics,
       // validation, and user notifications stay in this service.
       const result = await applyRemoteOperations({
-        ops,
+        ops: locallyReplayableOps,
         store: this.opLogStore,
         applier: {
           applyOperations: (opsToApply) =>
@@ -461,6 +474,46 @@ export class RemoteOpsProcessingService {
         await processDeferredActionsAfterRemoteApply(this.injector, callerHoldsLock);
       }
     }
+  }
+
+  private async _withLocalOnlySyncSettingsForFullStateOps(
+    ops: Operation[],
+  ): Promise<Operation[]> {
+    const hasFullStateOp = ops.some((op) => this._isFullStateOperation(op));
+    if (!hasFullStateOp) {
+      return ops;
+    }
+
+    const currentSyncConfig = await firstValueFrom(this.store.select(selectSyncConfig));
+    const localOnlySettings: LocalOnlySyncSettings = {
+      isEnabled: currentSyncConfig.isEnabled,
+      isEncryptionEnabled: currentSyncConfig.isEncryptionEnabled,
+      syncProvider: currentSyncConfig.syncProvider,
+      syncInterval: currentSyncConfig.syncInterval,
+      isManualSyncOnly: currentSyncConfig.isManualSyncOnly,
+    };
+
+    return ops.map((op) => {
+      if (!this._isFullStateOperation(op)) {
+        return op;
+      }
+
+      const fullState = extractFullStateFromPayload(op.payload);
+      const localReplayPayload = applyLocalOnlySyncSettingsToAppData(
+        fullState,
+        localOnlySettings,
+      );
+      if (localReplayPayload === fullState) {
+        return op;
+      }
+
+      return {
+        ...op,
+        payload: isWrappedFullStatePayload(op.payload)
+          ? { ...op.payload, appDataComplete: localReplayPayload }
+          : localReplayPayload,
+      };
+    });
   }
 
   private _isFullStateOperation(op: Operation): boolean {


### PR DESCRIPTION
## Summary

Fixes #7661.

- keep sync interval and manual-only mode durable as local-only settings in the local op-log/replay path
- strip those fields only at remote upload/export boundaries for SuperSync/file providers and mark schedule-only updates synced locally without remote upload
- preserve local sync settings when hydrating local full-state imports and when persisting/applying incoming remote full-state ops
- tighten `stripLocalOnlySyncScheduleSettings<T>()` so the return type matches the sanitized runtime shape

## Validation

- `npm run checkFile src/app/features/config/local-only-sync-settings.util.ts`
- `npm run checkFile src/app/features/config/local-only-sync-settings.util.spec.ts`
- `npm run checkFile src/app/features/config/store/global-config.reducer.ts`
- `npm run checkFile src/app/features/config/store/global-config.reducer.spec.ts`
- `npm run checkFile src/app/imex/sync/snapshot-upload.service.ts`
- `npm run checkFile src/app/imex/sync/snapshot-upload.service.spec.ts`
- `npm run checkFile src/app/op-log/capture/operation-log.effects.ts`
- `npm run checkFile src/app/op-log/capture/operation-log.effects.spec.ts`
- `npm run checkFile src/app/op-log/persistence/sync-hydration.service.ts`
- `npm run checkFile src/app/op-log/persistence/sync-hydration.service.spec.ts`
- `npm run checkFile src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts`
- `npm run checkFile src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts`
- `npm run checkFile src/app/op-log/sync/operation-log-upload.service.ts`
- `npm run checkFile src/app/op-log/sync/operation-log-upload.service.spec.ts`
- `npm run checkFile src/app/op-log/sync/remote-ops-processing.service.ts`
- `npm run checkFile src/app/op-log/sync/remote-ops-processing.service.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/config/local-only-sync-settings.util.spec.ts` (`4` success)
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/op-log/capture/operation-log.effects.spec.ts` (`36` success)
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/op-log/persistence/sync-hydration.service.spec.ts` (`37` success)
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/op-log/sync/operation-log-upload.service.spec.ts` (`60` success)
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/op-log/persistence/operation-log-hydrator.service.spec.ts` (`60` success)
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/op-log/sync/remote-ops-processing.service.spec.ts` (`42` success)
- `git diff --check`

## Notes

Local-only schedule settings are intentionally kept in the local persistence/replay path, but removed before remote upload/export payloads are written.