### PR TITLE
fix(util): support technical symbol emojis

### DIFF
--- a/src/app/util/extract-first-emoji.spec.ts
+++ b/src/app/util/extract-first-emoji.spec.ts
@@ -58,6 +58,17 @@ describe('extractFirstEmoji', () => {
     expect(extractFirstEmoji('0️⃣ zero')).toBe('0️⃣');
   });
 
+  it('should handle misc technical symbol emojis', () => {
+    expect(extractFirstEmoji('⏩ fast forward')).toBe('⏩');
+    expect(extractFirstEmoji('⏪ rewind')).toBe('⏪');
+    expect(extractFirstEmoji('⏫ up')).toBe('⏫');
+    expect(extractFirstEmoji('⏬ down')).toBe('⏬');
+    expect(extractFirstEmoji('⏰ alarm')).toBe('⏰');
+    expect(extractFirstEmoji('⌚ watch')).toBe('⌚');
+    expect(extractFirstEmoji('⏳ hourglass')).toBe('⏳');
+    expect(extractFirstEmoji('⌛ done')).toBe('⌛');
+  });
+
   it('should handle ZWJ emojis with skin tone', () => {
     expect(extractFirstEmoji('👩🏽‍💻 developer')).toBe('👩🏽‍💻');
   });
@@ -128,6 +139,17 @@ describe('isSingleEmoji', () => {
     expect(isSingleEmoji('0️⃣')).toBe(true);
   });
 
+  it('should return true for misc technical symbol emojis', () => {
+    expect(isSingleEmoji('⏩')).toBe(true);
+    expect(isSingleEmoji('⏪')).toBe(true);
+    expect(isSingleEmoji('⏫')).toBe(true);
+    expect(isSingleEmoji('⏬')).toBe(true);
+    expect(isSingleEmoji('⏰')).toBe(true);
+    expect(isSingleEmoji('⌚')).toBe(true);
+    expect(isSingleEmoji('⏳')).toBe(true);
+    expect(isSingleEmoji('⌛')).toBe(true);
+  });
+
   it('should return true for ZWJ emojis with skin tone', () => {
     expect(isSingleEmoji('👩🏽‍💻')).toBe(true);
   });
@@ -179,6 +201,12 @@ describe('containsEmoji', () => {
 
   it('should detect keycap emojis in mixed text', () => {
     expect(containsEmoji('Press #️⃣ to continue')).toBe(true);
+  });
+
+  it('should detect misc technical symbol emojis in mixed text', () => {
+    expect(containsEmoji('Use ⏩ to skip')).toBe(true);
+    expect(containsEmoji('Alarm ⏰')).toBe(true);
+    expect(containsEmoji('Waiting ⏳')).toBe(true);
   });
 
   it('should handle null/undefined gracefully', () => {

--- a/src/app/util/extract-first-emoji.ts
+++ b/src/app/util/extract-first-emoji.ts
@@ -21,6 +21,11 @@ const isEmojiCodePoint = (codePoint: number): boolean => {
     (codePoint >= 0x1f300 && codePoint <= 0x1f5ff) || // Misc Symbols and Pictographs
     (codePoint >= 0x1f680 && codePoint <= 0x1f6ff) || // Transport and Map Symbols
     (codePoint >= 0x1f1e0 && codePoint <= 0x1f1ff) || // Regional Indicator Symbols
+    codePoint === 0x231a || // Watch
+    codePoint === 0x231b || // Hourglass
+    (codePoint >= 0x23e9 && codePoint <= 0x23ec) || // Fast arrows
+    codePoint === 0x23f0 || // Alarm clock
+    codePoint === 0x23f3 || // Hourglass with flowing sand
     (codePoint >= 0x2600 && codePoint <= 0x26ff) || // Misc symbols
     (codePoint >= 0x2700 && codePoint <= 0x27bf) || // Dingbats
     (codePoint >= 0x2b00 && codePoint <= 0x2bff) || // Misc Symbols and Arrows (includes ⭐)


### PR DESCRIPTION
## Summary

Fixes #7896

Adds minimal support for the reported Misc Technical emoji symbols in the shared emoji detection utility, without adding an emoji picker, dependency, or generated emoji list.

## Changes

- Recognize the reported technical-symbol emoji code points: `⌚`, `⌛`, `⏩`-`⏬`, `⏰`, and `⏳`.
- Add regression coverage for `extractFirstEmoji`, `isSingleEmoji`, and `containsEmoji`.
- Keep the check scoped to the exact emoji code points instead of treating the full U+2300 block as emoji.

## Validation

- `npm ci`
- `npm run prettier:file -- src/app/util/extract-first-emoji.ts src/app/util/extract-first-emoji.spec.ts`
- `npm run test:file src/app/util/extract-first-emoji.spec.ts` (36 passed)
- `npm run lint`
- `git diff --check`

## Local Environment Notes

- `npm run checkFile <ts-file>` fails locally inside `tools/check-file.js` when it invokes `npm run prettier:file` through the Snap `npm` subprocess, but the underlying direct prettier/lint commands pass.
- A normal local pre-push reached the full Karma suite but failed in this non-ASCII worktree path while proxying `sql-wasm.wasm` (`ERR_UNESCAPED_CHARACTERS`). The earlier lint/package/release-note phases passed; this PR relies on GitHub CI for the full project suite.
