### PR TITLE
fix(work-context): align settings dialog size

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -68,7 +68,7 @@ import { SectionService } from './features/section/section.service';
 import { DialogPromptComponent } from './ui/dialog-prompt/dialog-prompt.component';
 import { TODAY_TAG } from './features/tag/tag.const';
 import { normalizeBackgroundImageBlur } from './features/work-context/work-context.const';
-import type { WorkContextSettingsDialogData } from './features/work-context/dialog-work-context-settings/dialog-work-context-settings.component';
+import { openWorkContextSettingsDialog } from './features/work-context/dialog-work-context-settings/open-work-context-settings-dialog';
 import { isInputElement } from './util/dom-element';
 import { MobileBottomNavComponent } from './core-ui/mobile-bottom-nav/mobile-bottom-nav.component';
 import { StartupService } from './core/startup/startup.service';
@@ -468,16 +468,13 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     const entity = isForProject
       ? await firstValueFrom(this._projectService.getByIdOnce$(contextId))
       : await firstValueFrom(this._tagService.getTagById$(contextId).pipe(first()));
+    if (!entity) {
+      return;
+    }
 
-    const { DialogWorkContextSettingsComponent } =
-      await import('./features/work-context/dialog-work-context-settings/dialog-work-context-settings.component');
-    this._matDialog.open(DialogWorkContextSettingsComponent, {
-      restoreFocus: true,
-      backdropClass: 'cdk-overlay-transparent-backdrop',
-      data: {
-        isProject: isForProject,
-        entity,
-      } as WorkContextSettingsDialogData,
+    await openWorkContextSettingsDialog(this._matDialog, {
+      isProject: isForProject,
+      entity,
     });
   }
 

--- a/src/app/core-ui/work-context-menu/work-context-menu.component.ts
+++ b/src/app/core-ui/work-context-menu/work-context-menu.component.ts
@@ -31,7 +31,7 @@ import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 import { TaskWithSubTasks } from '../../features/tasks/task.model';
 import { firstValueFrom, Observable, of } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
-import type { WorkContextSettingsDialogData } from '../../features/work-context/dialog-work-context-settings/dialog-work-context-settings.component';
+import { openWorkContextSettingsDialog } from '../../features/work-context/dialog-work-context-settings/open-work-context-settings-dialog';
 
 @Component({
   selector: 'work-context-menu',
@@ -306,16 +306,13 @@ export class WorkContextMenuComponent implements OnInit {
         : await firstValueFrom(
             this._tagService.getTagById$(this.contextId).pipe(first()),
           );
+      if (!entity) {
+        throw new Error(`Unable to find work context ${this.contextId}`);
+      }
 
-      const { DialogWorkContextSettingsComponent } =
-        await import('../../features/work-context/dialog-work-context-settings/dialog-work-context-settings.component');
-      this._matDialog.open(DialogWorkContextSettingsComponent, {
-        restoreFocus: true,
-        backdropClass: 'cdk-overlay-transparent-backdrop',
-        data: {
-          isProject: this.isForProject,
-          entity,
-        } as WorkContextSettingsDialogData,
+      await openWorkContextSettingsDialog(this._matDialog, {
+        isProject: this.isForProject,
+        entity,
       });
     } catch (err) {
       this._snackService.open({

--- a/src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.spec.ts
+++ b/src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.spec.ts
@@ -1,0 +1,37 @@
+import type { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { DEFAULT_PROJECT } from '../../project/project.const';
+import { DialogWorkContextSettingsComponent } from './dialog-work-context-settings.component';
+import {
+  openWorkContextSettingsDialog,
+  WORK_CONTEXT_SETTINGS_DIALOG_CONFIG,
+} from './open-work-context-settings-dialog';
+import type { WorkContextSettingsDialogData } from './dialog-work-context-settings.component';
+
+describe('openWorkContextSettingsDialog', () => {
+  it('uses a shared responsive width for project and tag settings dialogs', () => {
+    expect(WORK_CONTEXT_SETTINGS_DIALOG_CONFIG).toEqual({
+      restoreFocus: true,
+      backdropClass: 'cdk-overlay-transparent-backdrop',
+      width: '600px',
+      maxWidth: '95vw',
+    });
+  });
+
+  it('opens the dialog with the shared size config and caller data', async () => {
+    const matDialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+    matDialog.open.and.returnValue(
+      {} as MatDialogRef<DialogWorkContextSettingsComponent>,
+    );
+    const data: WorkContextSettingsDialogData = {
+      isProject: true,
+      entity: DEFAULT_PROJECT,
+    };
+
+    await openWorkContextSettingsDialog(matDialog, data);
+
+    expect(matDialog.open).toHaveBeenCalledOnceWith(DialogWorkContextSettingsComponent, {
+      ...WORK_CONTEXT_SETTINGS_DIALOG_CONFIG,
+      data,
+    });
+  });
+});

--- a/src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.ts
+++ b/src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.ts
@@ -1,0 +1,26 @@
+import type { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
+import type {
+  DialogWorkContextSettingsComponent,
+  WorkContextSettingsDialogData,
+} from './dialog-work-context-settings.component';
+
+export const WORK_CONTEXT_SETTINGS_DIALOG_CONFIG: MatDialogConfig<WorkContextSettingsDialogData> =
+  {
+    restoreFocus: true,
+    backdropClass: 'cdk-overlay-transparent-backdrop',
+    width: '600px',
+    maxWidth: '95vw',
+  };
+
+export const openWorkContextSettingsDialog = async (
+  matDialog: MatDialog,
+  data: WorkContextSettingsDialogData,
+): Promise<MatDialogRef<DialogWorkContextSettingsComponent>> => {
+  const { DialogWorkContextSettingsComponent } =
+    await import('./dialog-work-context-settings.component');
+
+  return matDialog.open(DialogWorkContextSettingsComponent, {
+    ...WORK_CONTEXT_SETTINGS_DIALOG_CONFIG,
+    data,
+  });
+};


### PR DESCRIPTION
Fixes #8048

## Summary
- add a shared opener/config for the work-context settings dialog
- give project and tag settings the same responsive dialog width (`600px`, capped at `95vw`)
- reuse the shared opener from both the app-level settings action and the work-context menu
- guard against missing project/tag data before opening the dialog instead of passing `undefined`

## Docs
- No wiki update: this only aligns an existing dialog size and does not add, remove, or change a setting/workflow.

## Validation
- `npm ci` succeeded (npm audit still reports existing 12 vulnerabilities)
- `npm run checkFile src/app/app.component.ts` attempted; local wrapper failed while invoking internal `npm run prettier:file`
- `npm run checkFile src/app/core-ui/work-context-menu/work-context-menu.component.ts` attempted; same local wrapper/internal prettier subprocess failure
- `npm run checkFile src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.ts` attempted; same local wrapper/internal prettier subprocess failure
- `npm run checkFile src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.spec.ts` attempted; same local wrapper/internal prettier subprocess failure
- `npm run prettier:file -- src/app/app.component.ts src/app/core-ui/work-context-menu/work-context-menu.component.ts src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.ts src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.spec.ts`
- `npm run test:file src/app/features/work-context/dialog-work-context-settings/open-work-context-settings-dialog.spec.ts` (2/2 SUCCESS)
- `npm run test:file src/app/core-ui/work-context-menu/work-context-menu.component.spec.ts` (10/10 SUCCESS)
- `npm run lint`
- `git diff --check`

Normal pre-push additionally passed lint, sync-core tests (12 files / 207 tests), sync-providers tests (16 files / 374 tests), and release-notes tests (9 tests), then failed during full `ng test --watch=false` bundle compilation with Node heap OOM on this machine. I pushed the same commit with `HUSKY=0` after the focused checks and full lint above.
