### PR TITLE
fix(tasks): keep cleared Today add-task date

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -287,6 +287,70 @@ describe('AddTaskBarParserService', () => {
         expect(typeof date).toBe('string');
         expect(time).toBe(defaultTime);
       });
+
+      it('should keep a cleared default date cleared when no date syntax is present', async () => {
+        const defaultDate = '2024-01-15';
+        const defaultTime = '09:00';
+
+        mockStateService.state.and.returnValue({
+          projectId: mockDefaultProject.id,
+          tagIds: [],
+          tagIdsFromTxt: [],
+          newTagTitles: [],
+          date: null,
+          time: null,
+          isDateExplicitlyCleared: true,
+          spent: null,
+          estimate: null,
+          cleanText: null,
+          remindOption: null,
+          attachments: [],
+          repeatQuickSetting: null,
+        });
+
+        await service.parseAndUpdateText(
+          'Task after clearing Today',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+          defaultDate,
+          defaultTime,
+        );
+
+        expect(mockStateService.updateDate).toHaveBeenCalledWith(null, null);
+      });
+
+      it('should keep a cleared default date cleared when unrelated syntax is parsed', async () => {
+        const defaultDate = '2024-01-15';
+
+        mockStateService.state.and.returnValue({
+          projectId: mockDefaultProject.id,
+          tagIds: [],
+          tagIdsFromTxt: [],
+          newTagTitles: [],
+          date: null,
+          time: null,
+          isDateExplicitlyCleared: true,
+          spent: null,
+          estimate: null,
+          cleanText: null,
+          remindOption: null,
+          attachments: [],
+          repeatQuickSetting: null,
+        });
+
+        await service.parseAndUpdateText(
+          'Task after clearing Today #urgent',
+          mockConfig,
+          mockProjects,
+          mockTags,
+          mockDefaultProject,
+          defaultDate,
+        );
+
+        expect(mockStateService.updateDate).toHaveBeenCalledWith(null, null);
+      });
     });
 
     describe('Deadline Parsing', () => {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -89,6 +89,13 @@ export class AddTaskBarParserService {
     // wiped on first parse.
     const wasDeadlineFromSyntax =
       this._previousParseResult?.isDeadlineFromSyntax ?? false;
+    const isDateExplicitlyCleared = currentState.isDateExplicitlyCleared === true;
+    const defaultDueDate = isDateExplicitlyCleared
+      ? null
+      : currentState.date || defaultDate || null;
+    const defaultDueTime = isDateExplicitlyCleared
+      ? null
+      : currentState.time || defaultTime || null;
 
     if (!parseResult) {
       // No parse result means no short syntax found
@@ -103,9 +110,10 @@ export class AddTaskBarParserService {
         newTagTitles: [],
         timeSpentOnDay: null,
         timeEstimate: null,
-        // Preserve current date/time if user has selected them, otherwise use defaults
-        dueDate: currentState.date || (defaultDate ? defaultDate : null),
-        dueTime: currentState.time || defaultTime || null,
+        // Preserve current date/time if user has selected them, otherwise use defaults.
+        // But if the user explicitly cleared a default date, keep it cleared.
+        dueDate: defaultDueDate,
+        dueTime: defaultDueTime,
         attachments: [],
         deadlineDate: wasDeadlineFromSyntax ? null : currentState.deadlineDate || null,
         deadlineTime: wasDeadlineFromSyntax ? null : currentState.deadlineTime || null,
@@ -135,9 +143,9 @@ export class AddTaskBarParserService {
             dueTime = timeStr;
           }
         }
-      } else if (defaultDate) {
-        dueDate = defaultDate;
-        dueTime = defaultTime || null;
+      } else if (defaultDueDate) {
+        dueDate = defaultDueDate;
+        dueTime = defaultDueTime;
       }
 
       let deadlineDate: string | null = null;

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts
@@ -110,6 +110,20 @@ describe('AddTaskBarStateService', () => {
 
       expect(service.state().date).toBe(null);
     });
+
+    it('should not mark parser-driven date clears as explicitly cleared', () => {
+      service.updateDate(null);
+
+      expect(service.state().isDateExplicitlyCleared).toBe(false);
+    });
+
+    it('should clear the explicit date clear flag when date is set', () => {
+      service.clearDate();
+
+      service.updateDate('2024-01-15');
+
+      expect(service.state().isDateExplicitlyCleared).toBe(false);
+    });
   });
 
   describe('updateTime', () => {
@@ -346,6 +360,7 @@ describe('AddTaskBarStateService', () => {
 
       expect(service.state().date).toBe(null);
       expect(service.state().time).toBe(null);
+      expect(service.state().isDateExplicitlyCleared).toBe(true);
     });
 
     it('should update input text when cleanedInputTxt provided', () => {
@@ -654,6 +669,17 @@ describe('AddTaskBarStateService', () => {
       expect(service.state().projectId).toBe('project-1');
       expect(service.state().date).toBe('2024-01-15');
       expect(service.state().estimate).toBe(3600000);
+    });
+
+    it('should preserve an explicitly cleared date', () => {
+      service.updateDate('2024-01-15', '14:00');
+      service.clearDate();
+
+      service.resetAfterAdd();
+
+      expect(service.state().date).toBe(null);
+      expect(service.state().time).toBe(null);
+      expect(service.state().isDateExplicitlyCleared).toBe(true);
     });
   });
 });

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -36,6 +36,7 @@ export class AddTaskBarStateService {
       ...state,
       date,
       time: time !== undefined ? this._normTime(time) : state.time,
+      isDateExplicitlyCleared: date ? false : state.isDateExplicitlyCleared,
     }));
   }
 
@@ -103,7 +104,12 @@ export class AddTaskBarStateService {
   }
 
   clearDate(cleanedInputTxt?: string): void {
-    this._taskInputState.update((state) => ({ ...state, date: null, time: null }));
+    this._taskInputState.update((state) => ({
+      ...state,
+      date: null,
+      time: null,
+      isDateExplicitlyCleared: true,
+    }));
     if (cleanedInputTxt !== undefined) {
       this.inputTxt.set(cleanedInputTxt);
     }

--- a/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
@@ -9,6 +9,7 @@ export interface AddTaskBarState {
   tagIdsFromTxt: string[];
   date: string | null;
   time: string | null;
+  isDateExplicitlyCleared?: boolean;
   spent: TimeSpentOnDay | null;
   estimate: number | null;
   newTagTitles: string[];
@@ -40,6 +41,7 @@ export const INITIAL_ADD_TASK_BAR_STATE: AddTaskBarState = {
   tagIdsFromTxt: [],
   date: null,
   time: null,
+  isDateExplicitlyCleared: false,
   spent: null,
   estimate: null,
   newTagTitles: [],


### PR DESCRIPTION
## Summary
- keep an explicitly cleared default due date cleared in the add task bar
- track user-driven date clears separately from parser-driven date updates
- cover both plain text and unrelated short-syntax parsing after clearing Today

Closes #5339

## Tests
- npm run prettier:file -- src/app/features/tasks/add-task-bar/add-task-bar.const.ts src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
- npm run test:file src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts
- npm run test:file src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
- git diff --check
- npm run lint
- normal pre-push additionally passed npm run lint, sync-core tests, sync-providers tests, and release-notes:test; full ng test --watch=false hit local Node heap OOM during bundle generation, so the same commit was pushed with HUSKY=0