### PR TITLE
fix(tasks): focus context submenus for typeahead

### DIFF
--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
@@ -267,9 +267,11 @@
   }
 
   <button
+    #tagMenuTrigger="matMenuTrigger"
     [matMenuTriggerFor]="tagMenu"
     mat-menu-item
-    menuTouchFix
+    [menuTouchFix]="tagMenuTrigger"
+    (menuOpened)="focusFirstSubmenuItem(tagMenu)"
     class="e2e-edit-tags-btn"
   >
     <span class="menuItemLeft">
@@ -281,9 +283,11 @@
 
   @if (!task.parentId && ((moveToProjectList$ | async)?.length || 0) > 0) {
     <button
+      #projectMenuTrigger="matMenuTrigger"
       [matMenuTriggerFor]="projectMenu"
       mat-menu-item
-      menuTouchFix
+      [menuTouchFix]="projectMenuTrigger"
+      (menuOpened)="focusFirstSubmenuItem(projectMenu)"
     >
       <span class="menuItemLeft">
         <mat-icon>forward</mat-icon>

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts
@@ -213,4 +213,21 @@ describe('TaskContextMenuInnerComponent', () => {
       expect(getByIdSpy).toHaveBeenCalledWith('t-task-with-{special}-chars');
     }));
   });
+
+  describe('focusFirstSubmenuItem()', () => {
+    it('should focus the submenu so Material typeahead owns keyboard input', () => {
+      const menu = jasmine.createSpyObj('MatMenu', ['focusFirstItem']);
+      component.task = {
+        id: 'T1',
+        title: 'Test',
+        projectId: 'P1',
+        tagIds: [],
+        subTaskIds: [],
+      } as any;
+
+      component.focusFirstSubmenuItem(menu);
+
+      expect(menu.focusFirstItem).toHaveBeenCalledWith('program');
+    });
+  });
 });

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
@@ -341,6 +341,10 @@ export class TaskContextMenuInnerComponent implements AfterViewInit, OnDestroy {
     t?.parentElement?.querySelector('button')?.focus();
   }
 
+  focusFirstSubmenuItem(menu: MatMenu): void {
+    menu.focusFirstItem('program');
+  }
+
   goToFocusMode(): void {
     this._taskService.setCurrentId(this.task.id);
     this._store.dispatch(showFocusOverlay());


### PR DESCRIPTION
## Summary
- focus the tag/project context submenus when they open so Material menu typeahead owns keyboard input
- keep the existing touch submenu fix wired through the concrete submenu triggers
- add a small regression test for the focus handoff helper

Fixes #7987

## Notes
This intentionally keeps the scope to the focus bug discussed in the issue. It does not add a new text-filter UI or substring search for the project/tag menus.

## Validation
- `npm run checkFile src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts` (known wrapper failure: `Command failed: npm run prettier:file -- /abs/path`)
- `npm run checkFile src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html` (known wrapper failure: `Command failed: npm run prettier:file -- /abs/path`)
- `npm run checkFile src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts` (known wrapper failure: `Command failed: npm run prettier:file -- /abs/path`)
- `npm run prettier:file -- src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts`
- `git diff --check`
- `npm run test:file src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts`
- `npm run lint`
- pre-push ran `npm run lint`, sync-core tests (207), sync-providers tests (374), and `release-notes:test` (9), then hit the known local full Angular `ng test --watch=false` heap OOM during bundle generation
