### PR TITLE
fix(gitlab): avoid stale comment update alerts

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts
@@ -1,0 +1,166 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { GitlabCommonInterfacesService } from './gitlab-common-interfaces.service';
+import { GitlabApiService } from './gitlab-api/gitlab-api.service';
+import { IssueProviderService } from '../../issue-provider.service';
+import { DEFAULT_GITLAB_CFG } from './gitlab.const';
+import { GitlabIssue } from './gitlab-issue.model';
+import {
+  GitlabOriginalComment,
+  GitlabOriginalUser,
+} from './gitlab-api/gitlab-api-responses';
+import { createTask } from '../../../tasks/task.test-helper';
+import { Task } from '../../../tasks/task.model';
+import { IssueProviderGitlab } from '../../issue.model';
+
+const ISSUE_PROVIDER_ID = 'gitlab-provider-1';
+const ISSUE_ID = 'project/repo#42';
+const BASE_UPDATED_AT = '2026-01-08T03:29:14.653Z';
+const LATER_COMMENT_AT = '2026-01-08T03:29:14.717Z';
+const NEWER_UPDATED_AT = '2026-01-08T03:30:00.000Z';
+
+const BASE_CFG: IssueProviderGitlab = {
+  ...DEFAULT_GITLAB_CFG,
+  id: ISSUE_PROVIDER_ID,
+  issueProviderKey: 'GITLAB',
+  isEnabled: true,
+  project: 'project/repo',
+  token: 'token',
+  filterUsername: 'current-user',
+};
+
+const USER: GitlabOriginalUser = {
+  id: 1,
+  username: 'another-user',
+  name: 'Another User',
+  state: 'active',
+  avatar_url: '',
+  web_url: '',
+};
+
+const makeComment = (createdAt: string): GitlabOriginalComment => ({
+  id: 1,
+  body: 'comment',
+  attachment: '',
+  author: USER,
+  created_at: createdAt,
+  updated_at: createdAt,
+  system: false,
+  noteable_id: 42,
+  noteable_type: 'Issue',
+  noteable_iid: 42,
+  resolvable: false,
+});
+
+const makeIssue = (
+  updatedAt: string,
+  comments: GitlabOriginalComment[] = [],
+): GitlabIssue => ({
+  html_url: 'https://gitlab.example.com/project/repo/-/issues/42',
+  number: 42,
+  state: 'open',
+  title: 'GitLab issue',
+  body: 'body',
+  user: USER,
+  labels: [],
+  assignee: USER,
+  milestone: {
+    id: 1,
+    iid: 1,
+    project_id: 1,
+    title: 'milestone',
+    description: '',
+    start_date: '',
+    due_date: '',
+    state: 'active',
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  },
+  closed_at: '',
+  created_at: '2026-01-08T03:00:00.000Z',
+  updated_at: updatedAt,
+  wasUpdated: false,
+  commentsNr: comments.length,
+  comments,
+  url: 'https://gitlab.example.com/project/repo/-/issues/42',
+  id: ISSUE_ID,
+  links: {
+    self: 'https://gitlab.example.com/api/v4/projects/1/issues/42',
+    notes: 'https://gitlab.example.com/api/v4/projects/1/issues/42/notes',
+    award_emoji: 'https://gitlab.example.com/api/v4/projects/1/issues/42/award_emoji',
+    project: 'https://gitlab.example.com/api/v4/projects/1',
+  },
+});
+
+const makeTask = (issueLastUpdated: number): Task =>
+  createTask({
+    id: 'task-1',
+    title: '#42 GitLab issue',
+    issueId: ISSUE_ID,
+    issueProviderId: ISSUE_PROVIDER_ID,
+    issueType: 'GITLAB',
+    issueLastUpdated,
+    issueWasUpdated: false,
+  });
+
+describe('GitlabCommonInterfacesService', () => {
+  let service: GitlabCommonInterfacesService;
+  let gitlabApiService: jasmine.SpyObj<GitlabApiService>;
+  let issueProviderService: jasmine.SpyObj<IssueProviderService>;
+
+  beforeEach(() => {
+    gitlabApiService = jasmine.createSpyObj('GitlabApiService', [
+      'getById$',
+      'searchIssueInProject$',
+      'getProjectIssues$',
+    ]);
+    issueProviderService = jasmine.createSpyObj('IssueProviderService', ['getCfgOnce$']);
+    issueProviderService.getCfgOnce$.and.returnValue(of(BASE_CFG));
+
+    TestBed.configureTestingModule({
+      providers: [
+        GitlabCommonInterfacesService,
+        { provide: GitlabApiService, useValue: gitlabApiService },
+        { provide: IssueProviderService, useValue: issueProviderService },
+      ],
+    });
+    service = TestBed.inject(GitlabCommonInterfacesService);
+  });
+
+  describe('getFreshDataForIssueTask', () => {
+    it('does not flag an update when only a GitLab comment timestamp is later than issue.updated_at', async () => {
+      const issueLastUpdated = new Date(BASE_UPDATED_AT).getTime();
+      gitlabApiService.getById$.and.returnValue(
+        of(makeIssue(BASE_UPDATED_AT, [makeComment(LATER_COMMENT_AT)])),
+      );
+
+      const result = await service.getFreshDataForIssueTask(makeTask(issueLastUpdated));
+
+      expect(result).toBeNull();
+    });
+
+    it('does not flag an update from a later comment after the user marked updates as read', async () => {
+      const issueLastUpdated = new Date(LATER_COMMENT_AT).getTime();
+      gitlabApiService.getById$.and.returnValue(
+        of(makeIssue(BASE_UPDATED_AT, [makeComment(LATER_COMMENT_AT)])),
+      );
+
+      const result = await service.getFreshDataForIssueTask(makeTask(issueLastUpdated));
+
+      expect(result).toBeNull();
+    });
+
+    it('flags an update when issue.updated_at is newer than the task baseline', async () => {
+      const issueLastUpdated = new Date(BASE_UPDATED_AT).getTime();
+      gitlabApiService.getById$.and.returnValue(of(makeIssue(NEWER_UPDATED_AT)));
+
+      const result = await service.getFreshDataForIssueTask(makeTask(issueLastUpdated));
+
+      expect(result?.taskChanges.issueWasUpdated).toBe(true);
+      expect(result?.taskChanges.issueLastUpdated).toBe(
+        new Date(NEWER_UPDATED_AT).getTime(),
+      );
+      expect(result?.issueTitle).toBe('#42 GitLab issue');
+    });
+  });
+});

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts
@@ -15,6 +15,7 @@ import { IssueProviderGitlab } from '../../issue.model';
 
 const ISSUE_PROVIDER_ID = 'gitlab-provider-1';
 const ISSUE_ID = 'project/repo#42';
+const ISSUE_BODY = 'body';
 const BASE_UPDATED_AT = '2026-01-08T03:29:14.653Z';
 const LATER_COMMENT_AT = '2026-01-08T03:29:14.717Z';
 const NEWER_UPDATED_AT = '2026-01-08T03:30:00.000Z';
@@ -38,9 +39,9 @@ const USER: GitlabOriginalUser = {
   web_url: '',
 };
 
-const makeComment = (createdAt: string): GitlabOriginalComment => ({
+const makeComment = (createdAt: string, body = 'comment'): GitlabOriginalComment => ({
   id: 1,
-  body: 'comment',
+  body,
   attachment: '',
   author: USER,
   created_at: createdAt,
@@ -55,12 +56,13 @@ const makeComment = (createdAt: string): GitlabOriginalComment => ({
 const makeIssue = (
   updatedAt: string,
   comments: GitlabOriginalComment[] = [],
+  body = ISSUE_BODY,
 ): GitlabIssue => ({
   html_url: 'https://gitlab.example.com/project/repo/-/issues/42',
   number: 42,
   state: 'open',
   title: 'GitLab issue',
-  body: 'body',
+  body,
   user: USER,
   labels: [],
   assignee: USER,
@@ -150,9 +152,11 @@ describe('GitlabCommonInterfacesService', () => {
       expect(result).toBeNull();
     });
 
-    it('flags an update when issue.updated_at is newer than the task baseline', async () => {
+    it('flags a new GitLab comment as an update when issue.updated_at is bumped', async () => {
       const issueLastUpdated = new Date(BASE_UPDATED_AT).getTime();
-      gitlabApiService.getById$.and.returnValue(of(makeIssue(NEWER_UPDATED_AT)));
+      gitlabApiService.getById$.and.returnValue(
+        of(makeIssue(NEWER_UPDATED_AT, [makeComment(NEWER_UPDATED_AT, 'new comment')])),
+      );
 
       const result = await service.getFreshDataForIssueTask(makeTask(issueLastUpdated));
 
@@ -160,6 +164,9 @@ describe('GitlabCommonInterfacesService', () => {
       expect(result?.taskChanges.issueLastUpdated).toBe(
         new Date(NEWER_UPDATED_AT).getTime(),
       );
+      const issue = result?.issue as GitlabIssue;
+      expect(issue.body).toBe(ISSUE_BODY);
+      expect(issue.commentsNr).toBe(1);
       expect(result?.issueTitle).toBe('#42 GitLab issue');
     });
   });

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { firstValueFrom, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Task, TaskCopy } from 'src/app/features/tasks/task.model';
+import { Task } from 'src/app/features/tasks/task.model';
 import { BaseIssueProviderService } from '../../base/base-issue-provider.service';
 import { IssueData, SearchResultItem } from '../../issue.model';
 import { GitlabApiService } from './gitlab-api/gitlab-api.service';
@@ -75,60 +75,6 @@ export class GitlabCommonInterfacesService extends BaseIssueProviderService<Gitl
   ): Promise<IssueData[]> {
     const cfg = await firstValueFrom(this._getCfgOnce$(issueProviderId));
     return await firstValueFrom(this._gitlabApiService.getProjectIssues$(cfg));
-  }
-
-  // Uses comment filtering for update detection
-  override async getFreshDataForIssueTask(task: Task): Promise<{
-    taskChanges: Partial<Task>;
-    issue: GitlabIssue;
-    issueTitle: string;
-  } | null> {
-    if (!task.issueProviderId) {
-      throw new Error('No issueProviderId');
-    }
-    if (!task.issueId) {
-      throw new Error('No issueId');
-    }
-
-    const cfg = await firstValueFrom(this._getCfgOnce$(task.issueProviderId));
-    const issue = await firstValueFrom(
-      this._gitlabApiService.getById$(task.issueId, cfg),
-    );
-
-    const issueUpdate: number = new Date(issue.updated_at).getTime();
-    const commentsByOthers =
-      cfg.filterUsername && cfg.filterUsername.length > 1
-        ? issue.comments.filter(
-            (comment) => comment.author.username !== cfg.filterUsername,
-          )
-        : issue.comments;
-
-    const commentUpdates: number[] = commentsByOthers
-      .map((comment) => new Date(comment.created_at).getTime())
-      .sort();
-    const newestCommentUpdate = commentUpdates[commentUpdates.length - 1];
-
-    const wasUpdated =
-      (newestCommentUpdate && newestCommentUpdate > (task.issueLastUpdated || 0)) ||
-      issueUpdate > (task.issueLastUpdated || 0);
-
-    if (wasUpdated) {
-      // Exclude dueDay from polling updates to prevent overwriting
-      // user-set schedules (see issue #6792)
-      const taskData: Partial<TaskCopy> & { title: string } = {
-        ...this.getAddTaskData(issue),
-      };
-      delete taskData.dueDay;
-      return {
-        taskChanges: {
-          ...taskData,
-          issueWasUpdated: true,
-        },
-        issue,
-        issueTitle: truncate(this._formatIssueTitle(issue)),
-      };
-    }
-    return null;
   }
 
   protected _apiGetById$(


### PR DESCRIPTION
## Summary

Fixes #5518.

- reuse the base issue-provider freshness check for GitLab polling updates
- stop treating comment timestamps newer than `issue.updated_at` as a separate update baseline
- add regression coverage for comment-driven GitLab updates via `issue.updated_at`

## GitLab behavior note

GitLab upstream touches the noteable issue/MR when a note is saved, so the base `updated_at` freshness path preserves comment-driven update detection for GitLab/self-managed instances following upstream behavior.

References:
- `Note` has `after_save :touch_noteable`: https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/note.rb#L211
- `touch_noteable` calls `touch` on the noteable: https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/note.rb#L595-611
- GitLab spec coverage for issue notes touching the noteable: https://gitlab.com/gitlab-org/gitlab/-/blob/master/spec/models/note_spec.rb#L275-284

## Validation

- `CHROME_BIN=/usr/bin/chromium-browser npm run test:file -- src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts` (`3` success)
- `ng lint sp2 --lint-file-patterns src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts`
- `prettier --check src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.ts src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts`
- `git diff --check`