### PR TITLE
fix(reminder): dismiss reminder dialog when reminders vanish after sync

### DIFF
--- a/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.spec.ts
+++ b/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.spec.ts
@@ -922,6 +922,8 @@ describe('DialogViewTaskRemindersComponent reconciles vanished reminders (sync)'
         deadlineRemindAt: undefined,
       }),
     ]);
+    // Prove the reconcile path (not some other path) handled the disappearance.
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
     dispatchSpy.calls.reset();
 
     component.ngOnDestroy();
@@ -931,5 +933,107 @@ describe('DialogViewTaskRemindersComponent reconciles vanished reminders (sync)'
       .map(([action]) => action)
       .filter((a) => a.type === TaskSharedActions.clearDeadlineReminder.type);
     expect(clearedIds).toEqual([]);
+  });
+
+  it('keeps a reminder that is rescheduled to the future (still a valid reminder, not gone)', () => {
+    const component = createComponent([buildReminder('task-1')], [buildTask('task-1')]);
+
+    // Rescheduled (e.g. snoozed on another device): remindAt is still a number,
+    // just in the future. The reminder still exists, so it must NOT be dropped.
+    const ONE_HOUR_MS = 60 * 60 * 1000;
+    storeTasks$.next([buildTask('task-1', { remindAt: Date.now() + ONE_HOUR_MS })]);
+
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+    expect(component.taskIds$.getValue()).toEqual(['task-1']);
+  });
+
+  it('closes once when ALL reminders vanish in a single store emission', () => {
+    createComponent(
+      [buildReminder('task-1'), buildReminder('task-2')],
+      [buildTask('task-1'), buildTask('task-2')],
+    );
+
+    storeTasks$.next([
+      buildTask('task-1', { remindAt: undefined }),
+      buildTask('task-2', { remindAt: undefined }),
+    ]);
+
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes isAllDeadline when a schedule reminder is dropped leaving only a deadline one', () => {
+    const component = createComponent(
+      [
+        buildReminder('task-1'),
+        buildReminder('task-2', { isDeadline: true, deadlineDay: '2026-04-25' }),
+      ],
+      [
+        buildTask('task-1'),
+        buildTask('task-2', {
+          remindAt: undefined,
+          deadlineDay: '2026-04-25',
+          deadlineRemindAt: Date.now() - 1000,
+        }),
+      ],
+    );
+    expect(component.isAllDeadline).toBe(false);
+
+    // Schedule reminder for task-1 is cleared; only the deadline reminder remains.
+    storeTasks$.next([
+      buildTask('task-1', { remindAt: undefined }),
+      buildTask('task-2', {
+        remindAt: undefined,
+        deadlineDay: '2026-04-25',
+        deadlineRemindAt: Date.now() - 1000,
+      }),
+    ]);
+
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+    expect(component.taskIds$.getValue()).toEqual(['task-2']);
+    expect(component.isAllDeadline).toBe(true);
+  });
+
+  it('does not re-process or re-close on a redundant store emission after a partial drop', () => {
+    const component = createComponent(
+      [buildReminder('task-1'), buildReminder('task-2')],
+      [buildTask('task-1'), buildTask('task-2')],
+    );
+
+    storeTasks$.next([buildTask('task-1', { remindAt: undefined }), buildTask('task-2')]);
+    expect(component.taskIds$.getValue()).toEqual(['task-2']);
+
+    // The same surviving state arrives again (e.g. another unrelated sync tick).
+    storeTasks$.next([buildTask('task-2')]);
+
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+    expect(component.taskIds$.getValue()).toEqual(['task-2']);
+  });
+
+  it('does not re-add a dropped reminder if the store re-adds it (flap)', () => {
+    const component = createComponent(
+      [buildReminder('task-1'), buildReminder('task-2')],
+      [buildTask('task-1'), buildTask('task-2')],
+    );
+
+    // task-1 vanishes -> dropped
+    storeTasks$.next([buildTask('task-1', { remindAt: undefined }), buildTask('task-2')]);
+    expect(component.taskIds$.getValue()).toEqual(['task-2']);
+
+    // task-1 reappears in the store -> must NOT come back into the dialog
+    storeTasks$.next([buildTask('task-1'), buildTask('task-2')]);
+    expect(component.taskIds$.getValue()).toEqual(['task-2']);
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+  });
+
+  it('stops reconciling after close: a later store emission does not call close again', () => {
+    createComponent([buildReminder('task-1')], [buildTask('task-1')]);
+
+    storeTasks$.next([buildTask('task-1', { remindAt: undefined })]);
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
+
+    // getState now reports a non-open dialog; further emissions must be inert.
+    matDialogRefSpy.getState.and.returnValue(MatDialogState.CLOSED);
+    storeTasks$.next([buildTask('task-1', { remindAt: undefined })]);
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.spec.ts
+++ b/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.spec.ts
@@ -1,7 +1,12 @@
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { first, map, switchMap } from 'rxjs/operators';
 import { TestBed } from '@angular/core/testing';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogRef,
+  MatDialogState,
+} from '@angular/material/dialog';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
@@ -722,5 +727,209 @@ describe('DialogViewTaskRemindersComponent destroy clears unhandled deadline rem
     component.ngOnDestroy();
 
     expect(dispatchedClearIds()).toEqual([]);
+  });
+});
+
+/**
+ * Tests for dismissing the dialog when reminders disappear from the store while it
+ * is open — e.g. the reminder was dismissed, the task completed, or the task deleted
+ * on another device and then synced in.
+ *
+ * The reminder worker only ever signals reminders that ARE active, never that one is
+ * gone, so the dialog reconciles the displayed list against the live store and closes
+ * once the reminders it was showing no longer exist. A reminder that is already absent
+ * on the first store read (worker snapshot briefly ahead of the store) is never
+ * confirmed and therefore never auto-dismissed, preserving the open-time race fix.
+ */
+describe('DialogViewTaskRemindersComponent reconciles vanished reminders (sync)', () => {
+  let dispatchSpy: jasmine.Spy;
+  let taskServiceSpy: jasmine.SpyObj<TaskService>;
+  let projectServiceSpy: jasmine.SpyObj<ProjectService>;
+  let matDialogSpy: jasmine.SpyObj<MatDialog>;
+  let matDialogRefSpy: jasmine.SpyObj<MatDialogRef<DialogViewTaskRemindersComponent>>;
+  let reminderServiceStub: { onRemindersActive$: Subject<TaskWithReminderData[]> };
+  let storeTasks$: BehaviorSubject<Task[]>;
+
+  const buildTask = (id: string, overrides: Partial<Task> = {}): Task =>
+    ({
+      ...DEFAULT_TASK,
+      id,
+      title: `Task ${id}`,
+      remindAt: Date.now() - 1000,
+      ...overrides,
+    }) as Task;
+
+  const buildReminder = (
+    id: string,
+    opts: { isDeadline?: boolean; deadlineDay?: string } = {},
+  ): TaskWithReminderData =>
+    ({
+      ...DEFAULT_TASK,
+      id,
+      title: `Task ${id}`,
+      deadlineDay: opts.deadlineDay,
+      deadlineRemindAt: opts.isDeadline ? Date.now() - 1000 : undefined,
+      remindAt: opts.isDeadline ? undefined : Date.now() - 1000,
+      isDeadlineReminder: !!opts.isDeadline,
+      reminderData: { remindAt: Date.now() - 1000 },
+    }) as TaskWithReminderData;
+
+  const createComponent = (
+    reminders: TaskWithReminderData[],
+    initialStoreTasks: Task[],
+  ): DialogViewTaskRemindersComponent => {
+    TestBed.overrideProvider(MAT_DIALOG_DATA, { useValue: { reminders } });
+    storeTasks$ = new BehaviorSubject<Task[]>(initialStoreTasks);
+    taskServiceSpy.getByIdsLive$.and.returnValue(storeTasks$);
+    const store = TestBed.inject(MockStore);
+    dispatchSpy = spyOn(store, 'dispatch').and.callThrough();
+    const fixture = TestBed.createComponent(DialogViewTaskRemindersComponent);
+    return fixture.componentInstance;
+  };
+
+  beforeEach(async () => {
+    matDialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close', 'getState']);
+    matDialogRefSpy.getState.and.returnValue(MatDialogState.OPEN);
+    taskServiceSpy = jasmine.createSpyObj('TaskService', [
+      'getByIdsLive$',
+      'setDone',
+      'setCurrentId',
+    ]);
+    projectServiceSpy = jasmine.createSpyObj('ProjectService', ['moveTaskToTodayList']);
+    matDialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    reminderServiceStub = {
+      onRemindersActive$: new Subject<TaskWithReminderData[]>(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        DialogViewTaskRemindersComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        provideMockStore({ initialState: {} }),
+        { provide: MatDialogRef, useValue: matDialogRefSpy },
+        { provide: MAT_DIALOG_DATA, useValue: { reminders: [] } },
+        { provide: TaskService, useValue: taskServiceSpy },
+        { provide: ProjectService, useValue: projectServiceSpy },
+        { provide: MatDialog, useValue: matDialogSpy },
+        { provide: ReminderService, useValue: reminderServiceStub },
+        TranslateService,
+        TranslateStore,
+      ],
+    })
+      .overrideComponent(DialogViewTaskRemindersComponent, {
+        set: { template: '' },
+      })
+      .compileComponents();
+  });
+
+  it('closes the dialog when the only reminder is cleared in the store', () => {
+    createComponent([buildReminder('task-1')], [buildTask('task-1')]);
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+
+    // Sync clears the reminder (e.g. dismissed on another device)
+    storeTasks$.next([buildTask('task-1', { remindAt: undefined })]);
+
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the dialog when the only reminder task is completed in the store', () => {
+    const component = createComponent([buildReminder('task-1')], [buildTask('task-1')]);
+
+    storeTasks$.next([buildTask('task-1', { isDone: true })]);
+
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
+    expect(component).toBeTruthy();
+  });
+
+  it('closes the dialog when the only reminder task is deleted from the store', () => {
+    createComponent([buildReminder('task-1')], [buildTask('task-1')]);
+
+    // Task removed entirely (deleted on another device)
+    storeTasks$.next([]);
+
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the dialog when a deadline reminder is cleared in the store', () => {
+    createComponent(
+      [buildReminder('task-1', { isDeadline: true, deadlineDay: '2026-04-25' })],
+      [
+        buildTask('task-1', {
+          remindAt: undefined,
+          deadlineDay: '2026-04-25',
+          deadlineRemindAt: Date.now() - 1000,
+        }),
+      ],
+    );
+
+    storeTasks$.next([
+      buildTask('task-1', {
+        remindAt: undefined,
+        deadlineDay: '2026-04-25',
+        deadlineRemindAt: undefined,
+      }),
+    ]);
+
+    expect(matDialogRefSpy.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops only the vanished reminder and keeps the dialog open for the rest', () => {
+    const component = createComponent(
+      [buildReminder('task-1'), buildReminder('task-2')],
+      [buildTask('task-1'), buildTask('task-2')],
+    );
+
+    storeTasks$.next([buildTask('task-1', { remindAt: undefined }), buildTask('task-2')]);
+
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+    expect(component.taskIds$.getValue()).toEqual(['task-2']);
+  });
+
+  it('does NOT dismiss a reminder that is already absent on first store read (preserves open-time race fix)', () => {
+    createComponent(
+      [buildReminder('task-1')],
+      // remindAt already gone the moment the dialog reads the store
+      [buildTask('task-1', { remindAt: undefined })],
+    );
+
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+
+    // A subsequent unrelated store emission still must not close it
+    storeTasks$.next([buildTask('task-1', { remindAt: undefined })]);
+    expect(matDialogRefSpy.close).not.toHaveBeenCalled();
+  });
+
+  it('does not re-clear a vanished deadline reminder on destroy', () => {
+    const component = createComponent(
+      [buildReminder('task-1', { isDeadline: true, deadlineDay: '2026-04-25' })],
+      [
+        buildTask('task-1', {
+          remindAt: undefined,
+          deadlineDay: '2026-04-25',
+          deadlineRemindAt: Date.now() - 1000,
+        }),
+      ],
+    );
+
+    // Deadline reminder cleared via sync -> dialog reconciles & closes
+    storeTasks$.next([
+      buildTask('task-1', {
+        remindAt: undefined,
+        deadlineDay: '2026-04-25',
+        deadlineRemindAt: undefined,
+      }),
+    ]);
+    dispatchSpy.calls.reset();
+
+    component.ngOnDestroy();
+
+    const clearedIds = dispatchSpy.calls
+      .allArgs()
+      .map(([action]) => action)
+      .filter((a) => a.type === TaskSharedActions.clearDeadlineReminder.type);
+    expect(clearedIds).toEqual([]);
   });
 });

--- a/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.ts
+++ b/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.ts
@@ -16,7 +16,7 @@ import {
 } from '@angular/material/dialog';
 import { Task, TaskWithReminderData } from '../task.model';
 import { TaskService } from '../task.service';
-import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
 import { ReminderService } from '../../reminder/reminder.service';
 import { first, map, switchMap, takeWhile } from 'rxjs/operators';
 import { T } from '../../../t.const';
@@ -130,9 +130,18 @@ export class DialogViewTaskRemindersComponent implements OnDestroy {
   private _subs: Subscription = new Subscription();
   // Track dismissed reminder IDs to prevent stale data from worker re-triggering them
   private _dismissedReminderIds = new Set<string>();
+  // Reminders we have observed as still-valid in the store at least once. We only
+  // auto-dismiss a reminder that was confirmed present and then disappeared (e.g.
+  // cleared/completed/deleted on another device and synced in). A reminder that is
+  // already absent at open time is never confirmed, so it is never dropped — this
+  // preserves the open-time relaxation that fixed the worker/store snapshot race.
+  private _confirmedPresentIds = new Set<string>();
   // Stored separately so it can be cancelled eagerly when the dialog begins closing,
   // preventing race conditions where a worker tick updates a mid-animation dialog.
   private _onRemindersActiveSub: Subscription = Subscription.EMPTY;
+  // Cancelled eagerly on close for the same reason as _onRemindersActiveSub: a store
+  // emission mid-animation must not reconcile a dialog that is being torn down.
+  private _storeReconcileSub: Subscription = Subscription.EMPTY;
 
   constructor() {
     this._onRemindersActiveSub = this._reminderService.onRemindersActive$.subscribe(
@@ -153,6 +162,21 @@ export class DialogViewTaskRemindersComponent implements OnDestroy {
       },
     );
     this._subs.add(this._onRemindersActiveSub);
+
+    // Watch the live store so reminders that disappear while the dialog is open —
+    // e.g. dismissed, completed or deleted on another device and then synced in —
+    // are removed from the list and the dialog is closed once nothing is left.
+    // The worker only ever signals reminders that ARE active, never that one is
+    // gone, so without this a synced-away reminder would keep the dialog open.
+    this._storeReconcileSub = this.taskIds$
+      .pipe(
+        switchMap((taskIds) =>
+          taskIds.length ? this._taskService.getByIdsLive$(taskIds) : of([] as Task[]),
+        ),
+      )
+      .subscribe((tasks) => this._reconcileWithStore(tasks));
+    this._subs.add(this._storeReconcileSub);
+
     this._subs.add(
       this.isMultiple$.subscribe((isMultiple) => (this.isMultiple = isMultiple)),
     );
@@ -426,6 +450,57 @@ export class DialogViewTaskRemindersComponent implements OnDestroy {
     this._finalizeBulkAction();
   }
 
+  private _reconcileWithStore(tasks: Task[]): void {
+    const taskById = new Map(
+      tasks.filter((task): task is Task => !!task).map((task) => [task.id, task]),
+    );
+    const currentIds = this.taskIds$.getValue();
+
+    const isReminderStillValid = (id: string): boolean => {
+      const task = taskById.get(id);
+      if (!task || task.isDone) {
+        return false;
+      }
+      // A reminder is still "present" as long as its timestamp exists; clearing it
+      // (unschedule / dismiss / remove deadline) is what marks it as gone. We do not
+      // treat a future-rescheduled timestamp as gone — that reminder still exists and
+      // the worker will fire it again later.
+      const remindAt = this._deadlineReminderTaskIds.has(id)
+        ? task.deadlineRemindAt
+        : task.remindAt;
+      return typeof remindAt === 'number';
+    };
+
+    // Confirm presence first so a later disappearance can be detected. A reminder
+    // that is absent on the very first pass (worker snapshot briefly ahead of the
+    // store) is never confirmed here and therefore never auto-dismissed.
+    currentIds.forEach((id) => {
+      if (isReminderStillValid(id)) {
+        this._confirmedPresentIds.add(id);
+      }
+    });
+
+    const goneIds = currentIds.filter(
+      (id) => this._confirmedPresentIds.has(id) && !isReminderStillValid(id),
+    );
+    if (goneIds.length === 0) {
+      return;
+    }
+
+    // Mark as dismissed so a worker tick cannot re-add them and ngOnDestroy does not
+    // re-clear an already-cleared deadline reminder.
+    goneIds.forEach((id) => this._dismissedReminderIds.add(id));
+    const remainingIds = currentIds.filter((id) => !goneIds.includes(id));
+    if (remainingIds.length === 0) {
+      this._close();
+    } else {
+      this.isAllDeadline = remainingIds.every((id) =>
+        this._deadlineReminderTaskIds.has(id),
+      );
+      this.taskIds$.next(remainingIds);
+    }
+  }
+
   private _clearDeadlineReminder(task: TaskWithReminderData): void {
     this._store.dispatch(
       TaskSharedActions.clearDeadlineReminder({
@@ -438,9 +513,11 @@ export class DialogViewTaskRemindersComponent implements OnDestroy {
     if (this._matDialogRef.getState() !== MatDialogState.OPEN) {
       return;
     }
-    // Stop listening for new reminders immediately so a worker tick during the
-    // close animation cannot update the view while it is being torn down.
+    // Stop listening for new reminders and store changes immediately so a worker
+    // tick or store emission during the close animation cannot update the view
+    // while it is being torn down.
     this._onRemindersActiveSub.unsubscribe();
+    this._storeReconcileSub.unsubscribe();
     this._menuTriggers().forEach((trigger) => {
       trigger.closeMenu();
     });

--- a/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.ts
+++ b/src/app/features/tasks/dialog-view-task-reminders/dialog-view-task-reminders.component.ts
@@ -18,7 +18,7 @@ import { Task, TaskWithReminderData } from '../task.model';
 import { TaskService } from '../task.service';
 import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
 import { ReminderService } from '../../reminder/reminder.service';
-import { first, map, switchMap, takeWhile } from 'rxjs/operators';
+import { distinctUntilChanged, first, map, switchMap, takeWhile } from 'rxjs/operators';
 import { T } from '../../../t.const';
 import { standardListAnimation } from '../../../ui/animations/standard-list.ani';
 import { getTomorrow } from '../../../util/get-tomorrow';
@@ -173,6 +173,25 @@ export class DialogViewTaskRemindersComponent implements OnDestroy {
         switchMap((taskIds) =>
           taskIds.length ? this._taskService.getByIdsLive$(taskIds) : of([] as Task[]),
         ),
+        // getByIdsLive$ emits a fresh array on every task mutation app-wide; only
+        // reconcile when something we care about on the watched tasks changes.
+        distinctUntilChanged((prev, curr) => {
+          if (prev.length !== curr.length) {
+            return false;
+          }
+          return prev.every((p, i) => {
+            const c = curr[i];
+            if (!p || !c) {
+              return p === c;
+            }
+            return (
+              p.id === c.id &&
+              p.isDone === c.isDone &&
+              p.remindAt === c.remindAt &&
+              p.deadlineRemindAt === c.deadlineRemindAt
+            );
+          });
+        }),
       )
       .subscribe((tasks) => this._reconcileWithStore(tasks));
     this._subs.add(this._storeReconcileSub);


### PR DESCRIPTION
The reminder dialog's displayed list was only updated by explicit user
actions or by the worker emitting active reminders. The worker only ever
signals reminders that ARE due, never that one has disappeared, so when a
reminder was dismissed, completed or deleted on another device and synced
in, the open dialog kept showing the now-stale entry indefinitely.

Reconcile the displayed reminders against the live store: drop a reminder
once its task loses the relevant remindAt/deadlineRemindAt, is completed,
or is deleted, and close the dialog when nothing is left.

To avoid re-introducing the open-time race (worker snapshot briefly ahead
of the store) that an earlier fix relaxed, a reminder is only auto-dismissed
if it was confirmed present in the store at least once and then vanished.
The reconcile subscription is cancelled eagerly on close, mirroring the
existing onRemindersActive$ handling.