### PR TITLE
feat(supersync): configure server bind host

### DIFF
--- a/packages/super-sync-server/.env.example
+++ b/packages/super-sync-server/.env.example
@@ -4,6 +4,10 @@
 # Server port (default: 1900)
 PORT=1900
 
+# Server bind address (default: 0.0.0.0)
+# Use :: for IPv6-only deployments.
+HOST=0.0.0.0
+
 # Data directory for storing sync files and database (default: ./data)
 DATA_DIR=./data
 

--- a/packages/super-sync-server/README.md
+++ b/packages/super-sync-server/README.md
@@ -156,6 +156,7 @@ All configuration is done via environment variables.
 | Variable       | Default                              | Description                                                                     |
 | :------------- | :----------------------------------- | :------------------------------------------------------------------------------ |
 | `PORT`         | `1900`                               | Server port                                                                     |
+| `HOST`         | `0.0.0.0`                            | Server bind address. Use `::` for IPv6-only deployments.                        |
 | `DATABASE_URL` | -                                    | PostgreSQL connection string (e.g. `postgresql://user:pass@localhost:5432/db`)  |
 | `JWT_SECRET`   | -                                    | **Required.** Secret for signing JWTs (min 32 chars)                            |
 | `PUBLIC_URL`   | -                                    | **Required.** Public URL used for email links (e.g. `https://sync.example.com`) |

--- a/packages/super-sync-server/docker-compose.yml
+++ b/packages/super-sync-server/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - NODE_ENV=${NODE_ENV:-production}
       - PORT=1900
+      - HOST=${HOST:-0.0.0.0}
       - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-supersync}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-supersync}}
       - RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}
       - JWT_SECRET=${JWT_SECRET}

--- a/packages/super-sync-server/env.example
+++ b/packages/super-sync-server/env.example
@@ -18,6 +18,14 @@ JWT_SECRET=your-secure-jwt-secret-minimum-32-characters
 POSTGRES_PASSWORD=your-secure-postgres-password
 
 # =============================================================================
+# SERVER SETTINGS (optional - defaults provided)
+# =============================================================================
+
+# Server bind address (default: 0.0.0.0)
+# Use :: for IPv6-only deployments.
+HOST=0.0.0.0
+
+# =============================================================================
 # DATABASE SETTINGS (optional - defaults provided)
 # =============================================================================
 

--- a/packages/super-sync-server/helm/supersync/templates/configmap.yaml
+++ b/packages/super-sync-server/helm/supersync/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "supersync.labels" . | nindent 4 }}
 data:
   PORT: {{ .Values.supersync.port | quote }}
+  HOST: {{ .Values.supersync.host | quote }}
   NODE_ENV: {{ .Values.supersync.nodeEnv | quote }}
   {{- if .Values.supersync.publicUrl }}
   PUBLIC_URL: {{ .Values.supersync.publicUrl | quote }}

--- a/packages/super-sync-server/helm/supersync/values.yaml
+++ b/packages/super-sync-server/helm/supersync/values.yaml
@@ -31,6 +31,8 @@ serviceAccount:
 supersync:
   # -- Application listening port
   port: 1900
+  # -- Application bind address. Use "::" for IPv6-only deployments.
+  host: "0.0.0.0"
   # -- Node.js environment
   nodeEnv: production
   # -- REQUIRED: Public URL of the sync server (e.g. https://sync.example.com)

--- a/packages/super-sync-server/src/config.ts
+++ b/packages/super-sync-server/src/config.ts
@@ -69,6 +69,7 @@ export interface PrivacyConfig {
 
 export interface ServerConfig {
   port: number;
+  host: string;
   dataDir: string;
   /**
    * Enables the batched upload implementation in SyncService.
@@ -123,6 +124,7 @@ const DEFAULT_CORS_ORIGINS: CorsOrigin[] = [
 
 const DEFAULT_CONFIG: ServerConfig = {
   port: 1900,
+  host: '0.0.0.0',
   dataDir: './data',
   batchUpload: false,
   publicUrl: 'http://localhost:1900',
@@ -156,6 +158,22 @@ export const loadConfigFromEnv = (
     } else {
       throw new Error(`Invalid PORT: ${process.env.PORT}. Must be a positive integer.`);
     }
+  }
+
+  if (process.env.HOST !== undefined) {
+    const trimmedHost = process.env.HOST.trim();
+    if (!trimmedHost) {
+      throw new Error('Invalid HOST: must not be empty.');
+    }
+    if (/\s/.test(trimmedHost)) {
+      throw new Error(`Invalid HOST: ${process.env.HOST}. Must not contain whitespace.`);
+    }
+    if (/^https?:\/\//i.test(trimmedHost) || trimmedHost.includes('/')) {
+      throw new Error(
+        `Invalid HOST: ${process.env.HOST}. Use a hostname or IP address without protocol or path.`,
+      );
+    }
+    config.host = trimmedHost;
   }
 
   if (process.env.DATA_DIR) {
@@ -294,6 +312,10 @@ export const loadConfigFromEnv = (
   // Validation
   if (!Number.isInteger(config.port) || config.port <= 0) {
     throw new Error(`Invalid port configuration: ${config.port}`);
+  }
+
+  if (!config.host) {
+    throw new Error('Host configuration is missing');
   }
 
   if (!config.dataDir) {

--- a/packages/super-sync-server/src/server.ts
+++ b/packages/super-sync-server/src/server.ts
@@ -103,6 +103,13 @@ export const sanitizeRequestUrlForLog = (rawUrl: string): string => {
   }
 };
 
+export const createListenOptions = (
+  config: Pick<ServerConfig, 'port' | 'host'>,
+): { port: number; host: string } => ({
+  port: config.port,
+  host: config.host,
+});
+
 const generatePrivacyHtml = (privacy?: PrivacyConfig): void => {
   const publicDir = path.join(__dirname, '../../public');
   const templatePath = path.join(publicDir, 'privacy.template.html');
@@ -312,10 +319,7 @@ export const createServer = (
       getWsConnectionService().startHeartbeat();
 
       try {
-        const address = await fastifyServer.listen({
-          port: fullConfig.port,
-          host: '0.0.0.0',
-        });
+        const address = await fastifyServer.listen(createListenOptions(fullConfig));
         Logger.info(`Server started on ${address}`);
         return address;
       } catch (err) {

--- a/packages/super-sync-server/tests/config.spec.ts
+++ b/packages/super-sync-server/tests/config.spec.ts
@@ -265,6 +265,65 @@ describe('loadConfigFromEnv - SuperSync rollout flags', () => {
   });
 });
 
+describe('loadConfigFromEnv - server bind address', () => {
+  beforeEach(() => {
+    resetEnv();
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  it('should bind to all IPv4 interfaces by default', async () => {
+    const { loadConfigFromEnv } = await importConfig();
+    const config = loadConfigFromEnv();
+
+    expect(config.host).toBe('0.0.0.0');
+  });
+
+  it('should load HOST from environment', async () => {
+    process.env.HOST = '::';
+
+    const { loadConfigFromEnv } = await importConfig();
+    const config = loadConfigFromEnv();
+
+    expect(config.host).toBe('::');
+  });
+
+  it('should trim HOST from environment', async () => {
+    process.env.HOST = '  127.0.0.1  ';
+
+    const { loadConfigFromEnv } = await importConfig();
+    const config = loadConfigFromEnv();
+
+    expect(config.host).toBe('127.0.0.1');
+  });
+
+  it('should reject an empty HOST', async () => {
+    process.env.HOST = '';
+
+    const { loadConfigFromEnv } = await importConfig();
+
+    expect(() => loadConfigFromEnv()).toThrow('Invalid HOST: must not be empty');
+  });
+
+  it('should reject a whitespace-only HOST', async () => {
+    process.env.HOST = '   ';
+
+    const { loadConfigFromEnv } = await importConfig();
+
+    expect(() => loadConfigFromEnv()).toThrow('Invalid HOST: must not be empty');
+  });
+
+  it('should reject HOST values with protocol or path', async () => {
+    process.env.HOST = 'http://0.0.0.0';
+
+    const { loadConfigFromEnv } = await importConfig();
+
+    expect(() => loadConfigFromEnv()).toThrow('without protocol or path');
+  });
+});
+
 describe('DEFAULT_CORS_ORIGINS', () => {
   beforeEach(() => {
     resetEnv();

--- a/packages/super-sync-server/tests/server.error-log-level.spec.ts
+++ b/packages/super-sync-server/tests/server.error-log-level.spec.ts
@@ -13,7 +13,16 @@ vi.mock('../src/logger', () => ({
   },
 }));
 
-const { pickErrorLogLevel } = await import('../src/server');
+const { createListenOptions, pickErrorLogLevel } = await import('../src/server');
+
+describe('createListenOptions', () => {
+  it('passes the configured host and port to Fastify listen', () => {
+    expect(createListenOptions({ port: 1900, host: '::' })).toEqual({
+      port: 1900,
+      host: '::',
+    });
+  });
+});
 
 describe('pickErrorLogLevel', () => {
   describe('5xx', () => {


### PR DESCRIPTION
## Summary
- add a `HOST` environment option for the SuperSync server bind address, defaulting to `0.0.0.0`
- pass the configured host into Fastify `listen()` and cover the listen options in tests
- document the new option in README, env examples, docker-compose, and Helm values/configmap

Closes #7301

## Validation
- `npm ci`
- `npm run checkFile packages/super-sync-server/src/config.ts` (fails at known absolute-path prettier wrapper issue)
- `npm run checkFile packages/super-sync-server/src/server.ts` (fails at known absolute-path prettier wrapper issue)
- `npm run checkFile packages/super-sync-server/tests/config.spec.ts` (fails at known absolute-path prettier wrapper issue)
- `npm run checkFile packages/super-sync-server/tests/server.error-log-level.spec.ts` (fails at known absolute-path prettier wrapper issue)
- `npm run prettier:file -- packages/super-sync-server/src/config.ts packages/super-sync-server/src/server.ts packages/super-sync-server/tests/config.spec.ts packages/super-sync-server/tests/server.error-log-level.spec.ts packages/super-sync-server/README.md packages/super-sync-server/docker-compose.yml packages/super-sync-server/helm/supersync/values.yaml packages/super-sync-server/helm/supersync/templates/configmap.yaml`
- `cd packages/super-sync-server && npm test -- --run tests/config.spec.ts tests/server.error-log-level.spec.ts`
- `git diff --check`
- normal pre-push passed lint, sync-core tests, sync-providers tests, and release-notes tests, then `ng test --watch=false` OOMed during bundle generation

## Note
`cd packages/super-sync-server && npm run build` currently fails on existing Prisma type-generation errors unrelated to this change (for example missing `Prisma.sql`/`Prisma.empty`/model exports).
