### PR TITLE
fix(markdown): toggle fullscreen checklist labels

### DIFF
--- a/docs/wiki/4.10-Task-Notes.md
+++ b/docs/wiki/4.10-Task-Notes.md
@@ -26,7 +26,7 @@ The note system balances structure and flexibility so notes can serve as both pl
 
 1. **Template-guided structure** — The default note template gives new tasks a consistent starting shape (for example planning questions). The template is editable per task, so you keep structure where it helps and drop it where it does not.
 
-2. **Markdown flexibility** — Notes support standard markdown: headings, lists, bold, links, and so on. You can write free-form text or use list syntax that the app can treat as a checklist. You are not locked into a fixed form.
+2. **Markdown flexibility** — Notes support standard markdown: headings, lists, bold, links, and so on. You can write free-form text or use list syntax that the app can treat as a checklist. Rendered checklist items can be toggled from the checkbox or item text, while links keep their normal link behavior. You are not locked into a fixed form.
 
 3. **Context-aware storage** — Notes are stored as simple text attached to a specific task (or, for project notes, to a project). That keeps them easy to find and keeps the data model simple—no heavy schema, just content tied to the right context.
 

--- a/src/app/features/markdown-checklist/is-markdown-checklist.spec.ts
+++ b/src/app/features/markdown-checklist/is-markdown-checklist.spec.ts
@@ -12,7 +12,7 @@ and not:
 Some text yeah
  */
 
-import { isMarkdownChecklist } from './is-markdown-checklist';
+import { isMarkdownChecklist, isMarkdownChecklistLine } from './is-markdown-checklist';
 
 describe('isMarkdownChecklist()', () => {
   [
@@ -38,5 +38,17 @@ describe('isMarkdownChecklist()', () => {
     it(`should return false for a non valid checklist #${i}`, () => {
       expect(isMarkdownChecklist(text)).toBe(false);
     });
+  });
+});
+
+describe('isMarkdownChecklistLine()', () => {
+  it('should identify markdown checklist lines', () => {
+    expect(isMarkdownChecklistLine('- [ ] task')).toBe(true);
+    expect(isMarkdownChecklistLine('  - [x] task')).toBe(true);
+  });
+
+  it('should ignore regular text with task-like brackets', () => {
+    expect(isMarkdownChecklistLine('Note: use - [flags] here')).toBe(false);
+    expect(isMarkdownChecklistLine('- [flags] here')).toBe(false);
   });
 });

--- a/src/app/features/markdown-checklist/is-markdown-checklist.ts
+++ b/src/app/features/markdown-checklist/is-markdown-checklist.ts
@@ -15,6 +15,9 @@ and not:
 Some text yeah
  */
 
+export const isMarkdownChecklistLine = (line: string): boolean =>
+  isChecklistItemLine(line);
+
 export const isMarkdownChecklist = (text: string): boolean => {
   try {
     const lines = text.split('\n').filter((it) => it.trim() !== '');
@@ -23,7 +26,7 @@ export const isMarkdownChecklist = (text: string): boolean => {
       return false;
     }
 
-    const items = lines.filter((it) => isChecklistItemLine(it));
+    const items = lines.filter(isMarkdownChecklistLine);
     return items.length === lines.length || items.length >= 2;
   } catch (e) {
     Log.err('Checklist parsing failed');

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts
@@ -1,0 +1,114 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { MarkdownModule } from 'ngx-markdown';
+import { EMPTY } from 'rxjs';
+import { ClipboardImageService } from '../../core/clipboard-image/clipboard-image.service';
+import { ClipboardPasteHandlerService } from '../../core/clipboard-image/clipboard-paste-handler.service';
+import { TaskAttachmentService } from '../../features/tasks/task-attachment/task-attachment.service';
+import { DialogFullscreenMarkdownComponent } from './dialog-fullscreen-markdown.component';
+
+describe('DialogFullscreenMarkdownComponent', () => {
+  let component: DialogFullscreenMarkdownComponent;
+  let fixture: ComponentFixture<DialogFullscreenMarkdownComponent>;
+  let dialogData: { content: string; taskId?: string };
+  let mockClipboardImageService: jasmine.SpyObj<ClipboardImageService>;
+
+  beforeEach(async () => {
+    dialogData = {
+      content: '- [ ] Task 1\n\n- [ ] Task 2',
+    };
+    mockClipboardImageService = jasmine.createSpyObj('ClipboardImageService', [
+      'resolveMarkdownImages',
+    ]);
+    mockClipboardImageService.resolveMarkdownImages.and.callFake((content: string) =>
+      Promise.resolve(content),
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [
+        DialogFullscreenMarkdownComponent,
+        MarkdownModule.forRoot(),
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {
+            close: jasmine.createSpy('close'),
+            disableClose: false,
+            keydownEvents: () => EMPTY,
+          },
+        },
+        { provide: MAT_DIALOG_DATA, useValue: dialogData },
+        { provide: ClipboardImageService, useValue: mockClipboardImageService },
+        { provide: TaskAttachmentService, useValue: {} },
+        { provide: ClipboardPasteHandlerService, useValue: {} },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DialogFullscreenMarkdownComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('clickPreview', () => {
+    let mockPreviewEl: { element: { nativeElement: HTMLElement } };
+
+    beforeEach(() => {
+      mockPreviewEl = {
+        element: {
+          nativeElement: document.createElement('div'),
+        },
+      };
+      spyOn(component, 'previewEl').and.returnValue(mockPreviewEl as any);
+      spyOn(component.contentChanged, 'emit');
+    });
+
+    it('should toggle a gapped checklist item when clicking its label text', fakeAsync(() => {
+      const wrapper1 = document.createElement('li');
+      wrapper1.className = 'checkbox-wrapper undone';
+      wrapper1.appendChild(document.createElement('span')).className =
+        'checkbox material-icons';
+      wrapper1.appendChild(document.createTextNode('Task 1'));
+
+      const wrapper2 = document.createElement('li');
+      wrapper2.className = 'checkbox-wrapper undone';
+      const checkbox2 = document.createElement('span');
+      checkbox2.className = 'checkbox material-icons';
+      const label2 = document.createElement('span');
+      label2.textContent = 'Task 2';
+      wrapper2.appendChild(checkbox2);
+      wrapper2.appendChild(label2);
+
+      mockPreviewEl.element.nativeElement.appendChild(wrapper1);
+      mockPreviewEl.element.nativeElement.appendChild(wrapper2);
+
+      component.clickPreview({ target: label2 } as unknown as MouseEvent);
+      tick(500);
+
+      expect(component.data.content).toBe('- [ ] Task 1\n\n- [x] Task 2');
+      expect(component.contentChanged.emit).toHaveBeenCalledWith(
+        '- [ ] Task 1\n\n- [x] Task 2',
+      );
+    }));
+
+    it('should keep link clicks from toggling the parent checklist item', () => {
+      const wrapper = document.createElement('li');
+      wrapper.className = 'checkbox-wrapper undone';
+      const link = document.createElement('a');
+      link.href = 'https://example.com';
+      link.textContent = 'link';
+      wrapper.appendChild(document.createElement('span')).className =
+        'checkbox material-icons';
+      wrapper.appendChild(link);
+      mockPreviewEl.element.nativeElement.appendChild(wrapper);
+
+      component.clickPreview({ target: link } as unknown as MouseEvent);
+
+      expect(component.data.content).toBe('- [ ] Task 1\n\n- [ ] Task 2');
+      expect(component.contentChanged.emit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
@@ -247,15 +247,15 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
   }
 
   clickPreview($event: MouseEvent): void {
-    if (($event.target as HTMLElement).tagName === 'A') {
+    const target = $event.target as HTMLElement;
+    if (target.closest('a')) {
       // links are already handled by the markdown component
-    } else if (
-      $event?.target &&
-      ($event.target as HTMLElement).classList.contains('checkbox')
-    ) {
-      this._handleCheckboxClick(
-        ($event.target as HTMLElement).parentElement as HTMLElement,
-      );
+      return;
+    }
+
+    const wrapper = target.closest('.checkbox-wrapper') as HTMLElement | null;
+    if (wrapper) {
+      this._handleCheckboxClick(wrapper);
     }
   }
 

--- a/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
@@ -1550,6 +1550,28 @@ describe('InlineMarkdownComponent', () => {
       );
     });
 
+    it('should ignore regular text containing task-like brackets', () => {
+      // Arrange
+      component.model = '- [ ] Task 1\n\nNote: use - [flags] here\n\n- [ ] Task 2';
+      fixture.detectChanges();
+
+      const wrapper1 = document.createElement('li');
+      wrapper1.className = 'checkbox-wrapper';
+      const wrapper2 = document.createElement('li');
+      wrapper2.className = 'checkbox-wrapper';
+
+      mockPreviewEl.element.nativeElement.appendChild(wrapper1);
+      mockPreviewEl.element.nativeElement.appendChild(wrapper2);
+
+      // Act - toggle Task 2
+      component['_handleCheckboxClick'](wrapper2);
+
+      // Assert - regular text with "- [" should not offset the checkbox mapping
+      expect(component.changed.emit).toHaveBeenCalledWith(
+        '- [ ] Task 1\n\nNote: use - [flags] here\n\n- [x] Task 2',
+      );
+    });
+
     it('should handle mixed checked and unchecked items', () => {
       // Arrange
       component.model = '- [x] Done\n- [ ] Todo\n- [x] Also Done';


### PR DESCRIPTION
## Summary

- allow fullscreen markdown checklist items to toggle when clicking the item text, matching inline markdown preview behavior
- keep link clicks inside checklist items from toggling the checkbox
- reuse a checklist-line helper so checkbox DOM indexes only map to real `- [ ]` / `- [x]` markdown rows
- document rendered checklist click behavior in the task notes wiki page

## Notes

Current `master` already has regression coverage for blank-line-separated checklists in the inline markdown preview. This keeps the PR scoped to the remaining fullscreen preview inconsistency and a related mapping edge case where regular text containing `- [` could offset checkbox-to-markdown-line mapping.

The fullscreen-preview label toggle is intentional: it keeps rendered checklist interaction consistent between the inline preview and fullscreen preview while still preserving normal link-click behavior inside checklist items.

Part of #5950.

## Verification

- `npm run prettier:file -- src/app/features/markdown-checklist/is-markdown-checklist.ts src/app/features/markdown-checklist/is-markdown-checklist.spec.ts src/app/ui/inline-markdown/inline-markdown.component.ts src/app/ui/inline-markdown/inline-markdown.component.spec.ts src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts docs/wiki/4.10-Task-Notes.md`
- `npm run lint:file -- src/app/features/markdown-checklist/is-markdown-checklist.ts`
- `npm run lint:file -- src/app/features/markdown-checklist/is-markdown-checklist.spec.ts`
- `npm run lint:file -- src/app/ui/inline-markdown/inline-markdown.component.ts`
- `npm run lint:file -- src/app/ui/inline-markdown/inline-markdown.component.spec.ts`
- `npm run lint:file -- src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts`
- `npm run lint:file -- src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts`
- `npm run test:file src/app/features/markdown-checklist/is-markdown-checklist.spec.ts -- --include src/app/ui/inline-markdown/inline-markdown.component.spec.ts --include src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts` (`66/66 SUCCESS`)
- `git diff --check`
- normal pre-push passed full `npm run lint`, sync-core tests (`207`), sync-providers tests (`374`), and release-notes tests (`9`); full Angular `ng test --watch=false` still OOMed during bundle generation, so the same commit was pushed with `HUSKY=0`
