### PR TITLE
fix(metric): avoid Today heatmap subtask double count

### DIFF
--- a/src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts
+++ b/src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import { DateAdapter } from '@angular/material/core';
+import { NEVER, of } from 'rxjs';
+import { ActivityHeatmapComponent } from './activity-heatmap.component';
+import { WorklogService } from '../../worklog/worklog.service';
+import { WorkContextService } from '../../work-context/work-context.service';
+import { TaskService } from '../../tasks/task.service';
+import { TaskArchiveService } from '../../archive/task-archive.service';
+import { SnackService } from '../../../core/snack/snack.service';
+import { ShareService } from '../../../core/share/share.service';
+import { createTask } from '../../tasks/task.test-helper';
+import { Task } from '../../tasks/task.model';
+
+interface ActivityHeatmapTestApi {
+  _buildHeatmapDataForGivenYear: (
+    tasks: Task[],
+    year: number,
+  ) => { dayMap: Map<string, { timeSpent: number; taskCount: number }> };
+}
+
+describe('ActivityHeatmapComponent', () => {
+  const DAY = '2026-06-03';
+
+  const setup = (): ActivityHeatmapComponent => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: WorklogService,
+          useValue: { worklog$: NEVER },
+        },
+        {
+          provide: WorkContextService,
+          useValue: {
+            activeWorkContext$: NEVER,
+            activeWorkContextTitle$: of('Today'),
+          },
+        },
+        {
+          provide: TaskService,
+          useValue: { allTasks$: of([]) },
+        },
+        {
+          provide: TaskArchiveService,
+          useValue: { load: () => Promise.resolve(null) },
+        },
+        {
+          provide: SnackService,
+          useValue: { open: jasmine.createSpy('open') },
+        },
+        {
+          provide: ShareService,
+          useValue: {
+            shareCanvasImage: jasmine.createSpy('shareCanvasImage'),
+            canOpenDownloadResult: jasmine
+              .createSpy('canOpenDownloadResult')
+              .and.returnValue(false),
+          },
+        },
+        {
+          provide: DateAdapter,
+          useValue: { getFirstDayOfWeek: () => 1 },
+        },
+      ],
+    });
+
+    return TestBed.runInInjectionContext(() => new ActivityHeatmapComponent());
+  };
+
+  it('does not double-count parent task time when subTaskIds are incomplete', () => {
+    const component = setup();
+    const result = (
+      component as unknown as ActivityHeatmapTestApi
+    )._buildHeatmapDataForGivenYear(
+      [
+        createTask({
+          id: 'parent',
+          subTaskIds: [],
+          timeSpentOnDay: { [DAY]: 60 * 60 * 1000 },
+        }),
+        createTask({
+          id: 'sub-1',
+          parentId: 'parent',
+          timeSpentOnDay: { [DAY]: 60 * 60 * 1000 },
+        }),
+      ],
+      2026,
+    );
+    const dayData = result.dayMap.get(DAY);
+
+    expect(dayData).toBeDefined();
+    expect(dayData!.timeSpent).toBe(60 * 60 * 1000);
+    expect(dayData!.taskCount).toBe(1);
+  });
+});

--- a/src/app/features/metric/activity-heatmap/activity-heatmap.component.ts
+++ b/src/app/features/metric/activity-heatmap/activity-heatmap.component.ts
@@ -199,9 +199,14 @@ export class ActivityHeatmapComponent {
     let maxTasks = 0;
     let maxTime = 0;
     const taskCountPerDay = new Map<string, Set<string>>();
+    const parentTaskIds = new Set<string>(
+      tasks.flatMap((task) => (task.parentId ? [task.parentId] : [])),
+    );
     tasks.forEach((task) => {
       // Skip parent tasks — their timeSpentOnDay aggregates subtask time
-      if (task.subTaskIds && task.subTaskIds.length > 0) return;
+      if ((task.subTaskIds && task.subTaskIds.length > 0) || parentTaskIds.has(task.id)) {
+        return;
+      }
       if (task.timeSpentOnDay) {
         Object.keys(task.timeSpentOnDay).forEach((dateStr) => {
           const dateYear = parseInt(dateStr.substring(0, 4), 10);


### PR DESCRIPTION
Fixes #7993

## Summary
- treat tasks referenced by a child `parentId` as parent tasks in the Today heatmap, even when their `subTaskIds` list is incomplete
- keep aggregating only leaf/subtask time so parent aggregate `timeSpentOnDay` is not added on top of subtask time
- add focused coverage for the incomplete `subTaskIds` case reported by Today Metrics

## Validation
- `npm run prettier:file -- src/app/features/metric/activity-heatmap/activity-heatmap.component.ts src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts`
- `npm run lint:file -- src/app/features/metric/activity-heatmap/activity-heatmap.component.ts`
- `npm run lint:file -- src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts`
- `npm run test:file src/app/features/metric/activity-heatmap/activity-heatmap.component.spec.ts`
- `git diff --check`

Note: I also tried `npm run checkFile` for both changed TS/spec files. In this workspace it still fails in the known absolute-path prettier wrapper step, while the equivalent relative-path prettier + per-file lint commands above pass.