### PR TITLE
refactor(core): share markdown task parsing setup

### DIFF
--- a/src/app/util/parse-markdown-tasks.ts
+++ b/src/app/util/parse-markdown-tasks.ts
@@ -44,6 +44,16 @@ interface ParsedLine {
   originalLine: string;
 }
 
+interface CollectedNestedItems {
+  items: ParsedLine[];
+  nextIndex: number;
+}
+
+interface TopLevelWalkResult<T> {
+  item: T;
+  nextIndex: number;
+}
+
 const parseLineStructure = (line: string): ParsedLine | null => {
   // Calculate indentation level (count leading spaces/tabs)
   const indentMatch = line.match(/^(\s*)/);
@@ -125,6 +135,15 @@ const normalizeIndentation = (parsedLines: ParsedLine[]): void => {
   }
 };
 
+const parseNormalizedLines = (text: string): ParsedLine[] | null => {
+  const parsedLines = parseLines(text);
+  if (!parsedLines) {
+    return null;
+  }
+  normalizeIndentation(parsedLines);
+  return parsedLines;
+};
+
 // Normalize a parsed item to `<indent>- [ ] content` (or `[x]`), preserving the
 // original leading whitespace so nested depth survives the round-trip.
 const formatAsCheckboxLine = (item: ParsedLine): string => {
@@ -135,6 +154,58 @@ const formatAsCheckboxLine = (item: ParsedLine): string => {
 
 const buildNotesFromNestedItems = (nestedItems: ParsedLine[]): string =>
   nestedItems.map(formatAsCheckboxLine).join('\n');
+
+const createParsedTask = (line: ParsedLine): ParsedMarkdownTask => ({
+  title: line.content,
+  isCompleted: line.isCompleted,
+});
+
+const createParsedSubTask = (line: ParsedLine): ParsedMarkdownSubTask => ({
+  title: line.content,
+  isCompleted: line.isCompleted,
+});
+
+const collectNestedItems = (
+  parsedLines: ParsedLine[],
+  startIndex: number,
+  parentIndentLevel: number = 0,
+): CollectedNestedItems => {
+  const items: ParsedLine[] = [];
+  let nextIndex = startIndex;
+
+  while (
+    nextIndex < parsedLines.length &&
+    parsedLines[nextIndex].indentLevel > parentIndentLevel
+  ) {
+    items.push(parsedLines[nextIndex]);
+    nextIndex++;
+  }
+
+  return { items, nextIndex };
+};
+
+const walkTopLevelTasks = <T>(
+  parsedLines: ParsedLine[],
+  buildTask: (line: ParsedLine, index: number) => TopLevelWalkResult<T>,
+): T[] => {
+  const tasks: T[] = [];
+  let i = 0;
+
+  while (i < parsedLines.length) {
+    const currentLine = parsedLines[i];
+
+    if (currentLine.indentLevel === 0) {
+      const result = buildTask(currentLine, i);
+      tasks.push(result.item);
+      i = result.nextIndex;
+    } else {
+      // This preserves the previous behavior for leading orphan nested items.
+      i++;
+    }
+  }
+
+  return tasks;
+};
 
 export const convertToMarkdownNotes = (text: string): string | null => {
   const parsedLines = parseLines(text);
@@ -147,149 +218,90 @@ export const convertToMarkdownNotes = (text: string): string | null => {
 export const parseMarkdownTasksWithStructure = (
   text: string,
 ): MarkdownTaskStructure | null => {
-  const parsedLines = parseLines(text);
+  const parsedLines = parseNormalizedLines(text);
   if (!parsedLines) {
     return null;
   }
-  normalizeIndentation(parsedLines);
 
-  const tasks: ParsedMarkdownTask[] = [];
   let totalSubTasks = 0;
-  let i = 0;
+  const tasks = walkTopLevelTasks(parsedLines, (currentLine, i) => {
+    const subTasks: ParsedMarkdownSubTask[] = [];
+    const task: ParsedMarkdownTask = {
+      ...createParsedTask(currentLine),
+      subTasks,
+    };
 
-  while (i < parsedLines.length) {
-    const currentLine = parsedLines[i];
+    // Look ahead for nested items and determine the first sub-task level.
+    let j = i + 1;
+    let firstSubTaskLevel: number | null = null;
 
-    // Only process top-level items (indentLevel 0) as main tasks
-    if (currentLine.indentLevel === 0) {
-      const task: ParsedMarkdownTask = {
-        title: currentLine.content,
-        isCompleted: currentLine.isCompleted,
-        subTasks: [],
-      };
-
-      // Look ahead for nested items and determine the first sub-task level
-      let j = i + 1;
-      let firstSubTaskLevel: number | null = null;
-
-      // Find the first level of sub-tasks for this main task
-      while (j < parsedLines.length && parsedLines[j].indentLevel > 0) {
-        if (firstSubTaskLevel === null) {
-          firstSubTaskLevel = parsedLines[j].indentLevel;
-        }
-
-        const subLine = parsedLines[j];
-
-        if (subLine.indentLevel === firstSubTaskLevel) {
-          // This is a direct sub-task
-          const subTask: ParsedMarkdownSubTask = {
-            title: subLine.content,
-            isCompleted: subLine.isCompleted,
-          };
-
-          // Look ahead for deeper nested items (indentLevel > firstSubTaskLevel) to add as notes
-          const deepNestedItems: ParsedLine[] = [];
-          let k = j + 1;
-
-          while (
-            k < parsedLines.length &&
-            parsedLines[k].indentLevel > firstSubTaskLevel
-          ) {
-            deepNestedItems.push(parsedLines[k]);
-            k++;
-          }
-
-          // If there are deeper nested items, add them as notes
-          if (deepNestedItems.length > 0) {
-            subTask.notes = buildNotesFromNestedItems(deepNestedItems);
-          }
-
-          task.subTasks!.push(subTask);
-          totalSubTasks++;
-          j = k; // Skip the processed nested items
-        } else if (subLine.indentLevel > firstSubTaskLevel) {
-          // This is a deeper nested item, should be handled by the sub-task above
-          j++;
-        } else {
-          // This is a new main task, break out
-          break;
-        }
+    while (j < parsedLines.length && parsedLines[j].indentLevel > 0) {
+      if (firstSubTaskLevel === null) {
+        firstSubTaskLevel = parsedLines[j].indentLevel;
       }
 
-      // If no sub-tasks were found but there were nested items, add them as notes to the main task
-      if (task.subTasks!.length === 0) {
-        const nestedItems: ParsedLine[] = [];
-        let k = i + 1;
+      const subLine = parsedLines[j];
 
-        while (k < parsedLines.length && parsedLines[k].indentLevel > 0) {
-          nestedItems.push(parsedLines[k]);
-          k++;
+      if (subLine.indentLevel === firstSubTaskLevel) {
+        const subTask = createParsedSubTask(subLine);
+        const { items: deepNestedItems, nextIndex } = collectNestedItems(
+          parsedLines,
+          j + 1,
+          firstSubTaskLevel,
+        );
+
+        if (deepNestedItems.length > 0) {
+          subTask.notes = buildNotesFromNestedItems(deepNestedItems);
         }
 
-        if (nestedItems.length > 0) {
-          task.notes = buildNotesFromNestedItems(nestedItems);
-        }
-        j = k;
+        subTasks.push(subTask);
+        totalSubTasks++;
+        j = nextIndex;
+      } else if (subLine.indentLevel > firstSubTaskLevel) {
+        // This is a deeper nested item, should be handled by the sub-task above.
+        j++;
+      } else {
+        // Preserve the existing dip-below behavior documented in the specs.
+        break;
       }
-
-      // Remove empty subTasks array if no sub-tasks
-      if (task.subTasks!.length === 0) {
-        delete task.subTasks;
-      }
-
-      tasks.push(task);
-      i = j; // Skip the nested items we just processed
-    } else {
-      // This shouldn't happen if we process correctly, but skip just in case
-      i++;
     }
-  }
+
+    if (subTasks.length === 0) {
+      const { items: nestedItems, nextIndex } = collectNestedItems(parsedLines, i + 1);
+
+      if (nestedItems.length > 0) {
+        task.notes = buildNotesFromNestedItems(nestedItems);
+      }
+      j = nextIndex;
+    }
+
+    if (subTasks.length === 0) {
+      delete task.subTasks;
+    }
+
+    return { item: task, nextIndex: j };
+  });
 
   // Return structure only if we found at least one main task
   return tasks.length > 0 ? { mainTasks: tasks, totalSubTasks } : null;
 };
 
 export const parseMarkdownTasks = (text: string): ParsedMarkdownTask[] | null => {
-  const parsedLines = parseLines(text);
+  const parsedLines = parseNormalizedLines(text);
   if (!parsedLines) {
     return null;
   }
-  normalizeIndentation(parsedLines);
 
-  const tasks: ParsedMarkdownTask[] = [];
-  let i = 0;
+  const tasks = walkTopLevelTasks(parsedLines, (currentLine, i) => {
+    const task = createParsedTask(currentLine);
+    const { items: nestedItems, nextIndex } = collectNestedItems(parsedLines, i + 1);
 
-  while (i < parsedLines.length) {
-    const currentLine = parsedLines[i];
-
-    // Only process top-level items (indentLevel 0) as main tasks
-    if (currentLine.indentLevel === 0) {
-      const task: ParsedMarkdownTask = {
-        title: currentLine.content,
-        isCompleted: currentLine.isCompleted,
-      };
-
-      // Look ahead for nested items (indentLevel > 0)
-      const nestedItems: ParsedLine[] = [];
-      let j = i + 1;
-
-      while (j < parsedLines.length && parsedLines[j].indentLevel > 0) {
-        nestedItems.push(parsedLines[j]);
-        j++;
-      }
-
-      // If there are nested items, add them as notes
-      if (nestedItems.length > 0) {
-        task.notes = buildNotesFromNestedItems(nestedItems);
-      }
-
-      tasks.push(task);
-      i = j; // Skip the nested items we just processed
-    } else {
-      // This shouldn't happen if we process correctly, but skip just in case
-      i++;
+    if (nestedItems.length > 0) {
+      task.notes = buildNotesFromNestedItems(nestedItems);
     }
-  }
+
+    return { item: task, nextIndex };
+  });
 
   // Return tasks only if we found at least one
   return tasks.length > 0 ? tasks : null;


### PR DESCRIPTION
## Summary
- extract shared parse-and-normalize setup for markdown task parsing
- reuse a top-level task walker and nested-item collector across both parsing modes
- keep `parseMarkdownTasks()` and `parseMarkdownTasksWithStructure()` behavior unchanged, including the currently documented nested indentation edge case

Fixes #7918

## Verification
- npm run prettier:file -- src/app/util/parse-markdown-tasks.ts
- npm run lint:file -- src/app/util/parse-markdown-tasks.ts
- npm run test:file src/app/util/parse-markdown-tasks.spec.ts
- git diff --check

`npm run checkFile src/app/util/parse-markdown-tasks.ts` was attempted as required, but this local environment still fails in the known absolute-path prettier wrapper step (`npm run prettier:file -- /home/coco/桌面/.../src/app/util/parse-markdown-tasks.ts`). The same prettier and lint steps pass when run with the repository-relative path above.
