### PR TITLE
fix(nav): avoid logging dragged task objects

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -695,7 +695,7 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
       }
 
       const projectId = navItemElement.getAttribute('data-project-id');
-      Log.debug('Task dropped on Project', { draggedTask, projectId });
+      Log.debug('Task dropped on Project', { taskId: draggedTask.id, projectId });
 
       // We do not want to change the order of the task list if we drop
       // to a project or a tag in the main nav
@@ -713,7 +713,7 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
     } else if (navItemElement.hasAttribute('data-tag-id')) {
       // Task is dropped on a tag
       const tagId = navItemElement.getAttribute('data-tag-id');
-      Log.debug('Task dropped on Tag', { draggedTask, tagId });
+      Log.debug('Task dropped on Tag', { taskId: draggedTask.id, tagId });
 
       this._externalDragService.setCancelNextDrop(true);
 


### PR DESCRIPTION
## Summary
- avoid writing the full dragged task object to nav drop debug logs
- keep useful identifiers (`taskId`, `projectId`, `tagId`) for diagnosing project/tag drops

This avoids exporting task user content such as titles or notes through debug log history while keeping the log useful.

Part of #7870.

## Verification
- `npm run checkFile src/app/core-ui/magic-side-nav/magic-side-nav.component.ts`
- `CHROME_BIN=/snap/bin/chromium git push -u origin fix/safe-nav-drop-logs-7870` pre-push hook:
  - `npm run lint`
  - package tests for `sync-core`, `sync-providers`, and release notes
  - Angular/Karma tests: `10359` success
  - LA timezone Angular/Karma tests: `10345` success