### PR TITLE
fix(tasks): avoid logging short syntax result

### DIFF
--- a/src/app/features/tasks/store/short-syntax.effects.ts
+++ b/src/app/features/tasks/store/short-syntax.effects.ts
@@ -124,7 +124,13 @@ export class ShortSyntaxEffects {
             isReplaceTagIds ? 'replace' : 'combine',
           ).then((r) => {
             if (environment.production) {
-              TaskLog.log('shortSyntax', r);
+              TaskLog.log('shortSyntax', {
+                taskId: task.id,
+                hasResult: !!r,
+                changedFields: r ? Object.keys(r.taskChanges) : [],
+                attachmentCount: r?.attachments.length ?? 0,
+                projectId: r?.projectId,
+              });
             }
             const isAddDefaultProjectIfNecessary: boolean =
               !!defaultProjectId &&


### PR DESCRIPTION
## Summary
- avoid writing the raw short-syntax parser result to production task logs
- keep a safe diagnostic summary with `taskId`, result status, changed field names, attachment count, and target `projectId`

This keeps the log useful while avoiding parsed task title/URL/path content in exportable log history.

Part of #7870.

## Verification
- `npm run checkFile src/app/features/tasks/store/short-syntax.effects.ts`
- `CHROME_BIN=/snap/bin/chromium npx ng test --watch=false --include='**/short-syntax.effects.spec.ts'` (`7` success)
- `CHROME_BIN=/snap/bin/chromium git push -u origin fix/short-syntax-safe-log-7870` pre-push hook:
  - `npm run lint`
  - package tests for `sync-core` and `sync-providers`
  - release-notes tests
  - Angular/Karma tests: `10359` success
  - LA timezone Angular/Karma tests: `10345` success