### PR TITLE
fix(plugins): avoid logging extracted ZIP data

### DIFF
--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -1076,7 +1076,10 @@ export class PluginService implements OnDestroy {
   }
 
   async loadPluginFromZip(file: File): Promise<PluginInstance> {
-    PluginLog.log(`Starting plugin load from ZIP: ${file.name}`);
+    PluginLog.log('Starting plugin load from ZIP', {
+      size: file.size,
+      type: file.type,
+    });
 
     // Import fflate dynamically for better bundle size
     const { unzip } = await import('fflate');
@@ -1114,7 +1117,14 @@ export class PluginService implements OnDestroy {
           });
         },
       );
-      PluginLog.log({ extractedFiles });
+      const extractedFileEntries = Object.entries(extractedFiles);
+      PluginLog.log('Plugin ZIP extracted', {
+        fileCount: extractedFileEntries.length,
+        totalBytes: extractedFileEntries.reduce((sum, [, data]) => sum + data.length, 0),
+        hasManifest: !!extractedFiles['manifest.json'],
+        hasPluginJs: !!extractedFiles['plugin.js'],
+        hasIndexHtml: !!extractedFiles['index.html'],
+      });
 
       // Find and extract manifest.json
       if (!extractedFiles['manifest.json']) {


### PR DESCRIPTION
## Summary
- avoid logging the raw extracted ZIP file map when loading uploaded plugins
- keep safe diagnostics for ZIP size/type, entry count, total extracted bytes, and whether expected entries are present

This keeps plugin ZIP diagnostics useful without putting archive entry data or file contents into exportable log history.

Part of #7870.

## Verification
- `npm run checkFile src/app/plugins/plugin.service.ts`
- `CHROME_BIN=/snap/bin/chromium npx ng test --watch=false --include='**/plugin.service.load-from-zip.spec.ts'` (`3` success)
- `CHROME_BIN=/snap/bin/chromium git push -u origin fix/plugin-zip-safe-log-7870` pre-push hook:
  - `npm run lint`
  - package tests for `sync-core` and `sync-providers`
  - release-notes tests
  - Angular/Karma tests: `10359` success
  - LA timezone Angular/Karma tests: `10345` success