### PR TITLE
fix(tag): avoid logging tag state on reorder

### DIFF
--- a/src/app/features/tag/store/tag.reducer.ts
+++ b/src/app/features/tag/store/tag.reducer.ts
@@ -353,7 +353,10 @@ export const tagReducer = createReducer<TagState>(
 
   on(updateTagOrder, (state: TagState, { ids }) => {
     if (ids.length !== state.ids.length) {
-      Log.log({ state, ids });
+      Log.log({
+        currentTagCount: state.ids.length,
+        nextTagCount: ids.length,
+      });
       throw new Error('Tag length should not change on re-order');
     }
 


### PR DESCRIPTION
## Summary
- replace the tag reorder error log's raw tag state with count-only diagnostics
- keep the existing invariant/error behavior unchanged

## Why
Log history is exportable, and `#7870` calls out tag state logging as part of the privacy-sensitive log cleanup. The previous log emitted the full tag reducer state and next id array when tag order lengths differed. Counts preserve the useful mismatch diagnostic without exporting tag names or task associations.

Part of #7870.

## Verification
- `npm run checkFile src/app/features/tag/store/tag.reducer.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/tag/store/tag.reducer.spec.ts`
- `CHROME_BIN=/snap/bin/chromium git push -u origin fix/tag-order-safe-log-7870` (pre-push passed lint, package tests, release-notes tests, Angular/Karma `10359`, and LA timezone Angular/Karma `10345`)
