### PR TITLE
fix(issue): avoid logging raw http errors

### DIFF
--- a/src/app/features/issue/handle-issue-provider-http-error.ts
+++ b/src/app/features/issue/handle-issue-provider-http-error.ts
@@ -13,7 +13,17 @@ export const handleIssueProviderHttpError$ = <T>(
   snackService: SnackService,
   error: HttpErrorResponse,
 ): ObservableInput<T> => {
-  IssueLog.log(error);
+  const errorBody: unknown = error.error;
+  IssueLog.log('Issue provider HTTP error', {
+    issueProviderKey,
+    status: error.status,
+    errorBodyName: _getErrorBodyName(errorBody),
+    isClientError: errorBody instanceof ErrorEvent,
+    hasErrorBody: !!errorBody,
+    hasMessage: !!error.message,
+    hasStatusText: !!error.statusText,
+    hasUrl: !!error.url,
+  });
   if (error.error instanceof ErrorEvent) {
     // A client-side or network error occurred. Handle it accordingly.
     snackService.open({
@@ -48,3 +58,11 @@ export const handleIssueProviderHttpError$ = <T>(
 
   return throwError({ [HANDLED_ERROR_PROP_STR]: `${ipLabel}: ${getErrorTxt(error)}` });
 };
+
+const _getErrorBodyName = (errorBody: unknown): string | undefined =>
+  typeof errorBody === 'object' &&
+  errorBody !== null &&
+  'name' in errorBody &&
+  typeof errorBody.name === 'string'
+    ? errorBody.name
+    : undefined;


### PR DESCRIPTION
## Summary
- Replace raw issue-provider `HttpErrorResponse` logging with a safe diagnostic summary.
- Keep provider key, status, coarse error-body metadata, and boolean flags while avoiding response body, URL, and message contents in exportable logs.
- Preserve existing snackbar and handled-error behavior.

Part of #7870.

## Verification
- npm run checkFile src/app/features/issue/handle-issue-provider-http-error.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/linear/linear-api.service.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/gitea/gitea-common-interfaces.service.spec.ts
- CHROME_BIN=/snap/bin/chromium git push -u origin fix/issue-http-error-safe-log-7870 (pre-push: lint, package tests, release-notes tests, full Karma, LA timezone Karma)