### PR TITLE
fix(open-project): avoid logging backlog work packages

### DIFF
--- a/src/app/features/issue/providers/open-project/open-project-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/open-project/open-project-common-interfaces.service.ts
@@ -78,7 +78,11 @@ export class OpenProjectCommonInterfacesService extends BaseIssueProviderService
         cfg,
       ),
     );
-    IssueLog.log(workPackages);
+    IssueLog.log('OpenProject backlog work packages fetched', {
+      issueProviderId,
+      workPackageCount: workPackages.length,
+      workPackageIds: workPackages.map((workPackage) => workPackage.id),
+    });
     return workPackages;
   }
 

--- a/src/app/features/issue/providers/open-project/open-project-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/open-project/open-project-common-interfaces.service.ts
@@ -81,7 +81,7 @@ export class OpenProjectCommonInterfacesService extends BaseIssueProviderService
     IssueLog.log('OpenProject backlog work packages fetched', {
       issueProviderId,
       workPackageCount: workPackages.length,
-      workPackageIds: workPackages.map((workPackage) => workPackage.id),
+      hasWorkPackageIds: workPackages.some((workPackage) => !!workPackage.id),
     });
     return workPackages;
   }


### PR DESCRIPTION
## Summary
- Replace raw OpenProject backlog work package logging with a safe summary.
- Keep provider id, work package count, and work package ids while avoiding subject/description payloads in exportable logs.
- Preserve existing backlog import behavior.

Part of #7870.

## Verification
- npm run checkFile src/app/features/issue/providers/open-project/open-project-common-interfaces.service.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/open-project/open-project-common-interfaces.service.tz.spec.ts
- CHROME_BIN=/snap/bin/chromium git push -u origin fix/open-project-backlog-safe-log-7870 (pre-push: lint, package tests, release-notes tests, full Karma, LA timezone Karma)