### PR TITLE
fix(core): avoid logging crash user data

### DIFF
--- a/src/app/core/error-handler/global-error-handler.util.ts
+++ b/src/app/core/error-handler/global-error-handler.util.ts
@@ -78,7 +78,6 @@ export const logAdvancedStacktrace = (
       }
 
       const githubIssueLinks = document.getElementsByClassName('github-issue-urlX');
-      Log.log(githubIssueLinks);
 
       if (githubIssueLinks) {
         const errEscaped = _cleanHtml(getErrorTxt(origErr));
@@ -165,8 +164,6 @@ export const createErrorAlert = (
     }
   });
   innerWrapper.append(btnReload);
-
-  Log.log(userData);
 
   if (userData) {
     const btnExport = document.createElement('BUTTON');


### PR DESCRIPTION
## Summary
- stop logging the crash alert user-data backup object
- remove a debug log of the GitHub issue link DOM collection
- keep the explicit crash export and anonymized export buttons unchanged

## Why
Part of #7870. The crash alert can receive a complete backup object so users can explicitly export it for debugging. That object should not also be written into exported logs automatically.

## Verification
- `npm run checkFile src/app/core/error-handler/global-error-handler.util.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/core/error-handler/global-error-handler.util.spec.ts`
- `CHROME_BIN=/snap/bin/chromium git push -u origin fix/global-error-safe-log-7870`
