### PR TITLE
fix(trello): avoid logging raw picker results

### DIFF
--- a/src/app/features/issue/providers/trello/trello-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/trello/trello-common-interfaces.service.ts
@@ -85,7 +85,7 @@ export class TrelloCommonInterfacesService extends BaseIssueProviderService<Trel
       tap((results) =>
         IssueLog.log('Trello issue picker results fetched', {
           resultCount: results.length,
-          issueKeys: results.map((result) => result.issueData.key),
+          hasIssueKeys: results.some((result) => !!result.issueData.key),
           labelCount: results.reduce(
             (sum, result) => sum + result.issueData.labels.length,
             0,

--- a/src/app/features/issue/providers/trello/trello-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/trello/trello-common-interfaces.service.ts
@@ -81,9 +81,26 @@ export class TrelloCommonInterfacesService extends BaseIssueProviderService<Trel
     searchTerm: string,
     cfg: TrelloCfg,
   ): Observable<SearchResultItem[]> {
-    return this._trelloApiService
-      .issuePicker$(searchTerm, cfg)
-      .pipe(tap((v) => IssueLog.log('trello.issuePicker$', v)));
+    return this._trelloApiService.issuePicker$(searchTerm, cfg).pipe(
+      tap((results) =>
+        IssueLog.log('Trello issue picker results fetched', {
+          resultCount: results.length,
+          issueKeys: results.map((result) => result.issueData.key),
+          labelCount: results.reduce(
+            (sum, result) => sum + result.issueData.labels.length,
+            0,
+          ),
+          memberCount: results.reduce(
+            (sum, result) => sum + result.issueData.members.length,
+            0,
+          ),
+          attachmentCount: results.reduce(
+            (sum, result) => sum + result.issueData.attachments.length,
+            0,
+          ),
+        }),
+      ),
+    );
   }
 
   protected _formatIssueTitleForSnack(issue: IssueData): string {


### PR DESCRIPTION
## Summary
- replace raw Trello picker result logging with safe aggregate diagnostics
- keep result count, Trello issue keys, and label/member/attachment counts
- avoid logging card titles, descriptions, URLs, members, labels, or attachment data

## Why
Part of #7870. Trello picker results can include card summaries, descriptions, URLs, member data, labels, and attachment metadata. The log should keep enough information to debug result shape without recording the raw issue payloads.

## Verification
- `npm run checkFile src/app/features/issue/providers/trello/trello-common-interfaces.service.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/trello/trello-api.service.spec.ts`
- `CHROME_BIN=/snap/bin/chromium git push -u origin fix/trello-picker-safe-log-7870`
