### PR TITLE
fix(daily-summary): avoid logging archived task data

### DIFF
--- a/src/app/pages/daily-summary/daily-summary.component.ts
+++ b/src/app/pages/daily-summary/daily-summary.component.ts
@@ -465,7 +465,6 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
     Log.log('[DailySummary] Moving done tasks to archive:', {
       count: doneTasks.length,
       taskIds: doneTasks.map((t) => t.id),
-      tasks: doneTasks,
     });
 
     if (doneTasks.length === 0) {


### PR DESCRIPTION
## Summary
- remove the raw done task array from the Daily Summary archive log
- keep the existing done-task count and task ids for diagnostics without exporting task content

## Issue
Part of #7870.

## Verification
- npm run checkFile src/app/pages/daily-summary/daily-summary.component.ts
- git diff --check