### PR TITLE
fix(logs): avoid logging download file paths

### DIFF
--- a/src/app/util/download.ts
+++ b/src/app/util/download.ts
@@ -48,7 +48,10 @@ export const download = async (
     // Use native dialog for snap to avoid AppArmor permission issues
     const result = await window.ea.saveFileDialog(filename, stringData);
     if (result.success && result.path) {
-      Log.log('File saved to:', result.path);
+      Log.log('File saved via native dialog', {
+        isSnap: true,
+        hasPath: true,
+      });
       return { isSnap: true, path: result.path };
     }
     return { isSnap: true };
@@ -82,7 +85,10 @@ const saveStringAsFile = async (
     encoding: Encoding.UTF8,
     recursive: true,
   });
-  Log.log(r);
+  Log.log('File saved via Capacitor filesystem fallback', {
+    directory: Directory.Documents,
+    hasUri: !!r.uri,
+  });
   return r;
 };
 


### PR DESCRIPTION
## Summary

- replace Snap native-dialog save logging with path-free metadata
- replace Capacitor filesystem fallback result logging with directory/URI-presence metadata
- keep existing return values unchanged so callers can still use the saved path/URI where needed

## Why

Part of #7870. Exported log history should not include local file paths or filesystem URIs from download/save operations.

## Validation

- `npm run checkFile src/app/util/download.ts`
- `git diff --check`
