### PR TITLE
fix(schedule): disable unsupported month event dragging

### DIFF
--- a/src/app/features/schedule/schedule-month/schedule-month.component.html
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.html
@@ -24,6 +24,7 @@
               <schedule-event
                 [event]="ev"
                 [isMonthView]="true"
+                [cdkDragDisabled]="true"
                 class="month-schedule-event"
               ></schedule-event>
             </div>

--- a/src/app/features/schedule/schedule-month/schedule-month.component.spec.ts
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.spec.ts
@@ -1,8 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, Input } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { ScheduleMonthComponent } from './schedule-month.component';
 import { ScheduleService } from '../schedule.service';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
+import { ScheduleEventComponent } from '../schedule-event/schedule-event.component';
+import { ScheduleEvent } from '../schedule.model';
+import { SVEType } from '../schedule.const';
 
 describe('ScheduleMonthComponent', () => {
   let component: ScheduleMonthComponent;
@@ -30,7 +35,12 @@ describe('ScheduleMonthComponent', () => {
         { provide: ScheduleService, useValue: mockScheduleService },
         { provide: DateTimeFormatService, useValue: mockDateTimeFormatService },
       ],
-    }).compileComponents();
+    })
+      .overrideComponent(ScheduleMonthComponent, {
+        remove: { imports: [ScheduleEventComponent] },
+        add: { imports: [ScheduleEventStubComponent] },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(ScheduleMonthComponent);
     component = fixture.componentInstance;
@@ -141,6 +151,28 @@ describe('ScheduleMonthComponent', () => {
       const middleDay = parseDbDateStr(days[21]);
       expect(result.getFullYear()).toBe(middleDay.getFullYear());
       expect(result.getMonth()).toBe(middleDay.getMonth());
+    });
+  });
+
+  describe('month event drag behavior', () => {
+    it('should render month events with drag disabled', () => {
+      // Arrange
+      const scheduleEvent = createTaskScheduleEvent('task-1', '2026-01-15');
+      fixture.componentRef.setInput('daysToShow', ['2026-01-15']);
+      mockScheduleService.getEventsForDay.and.returnValue([scheduleEvent]);
+
+      // Act
+      fixture.detectChanges();
+
+      // Assert
+      const eventDebugEl = fixture.debugElement.query(
+        By.directive(ScheduleEventStubComponent),
+      );
+      const scheduleEventCmp =
+        eventDebugEl.componentInstance as ScheduleEventStubComponent;
+      expect(scheduleEventCmp.event).toBe(scheduleEvent);
+      expect(scheduleEventCmp.isMonthView).toBe(true);
+      expect(scheduleEventCmp.cdkDragDisabled).toBe(true);
     });
   });
 
@@ -389,4 +421,27 @@ describe('ScheduleMonthComponent', () => {
       expect(component.firstDayOfWeek()).toBe(1);
     });
   });
+});
+
+@Component({
+  selector: 'schedule-event',
+  standalone: true,
+  template: '',
+})
+class ScheduleEventStubComponent {
+  @Input() event?: ScheduleEvent;
+  @Input() isMonthView?: boolean;
+  @Input() cdkDragDisabled?: boolean;
+}
+
+const createTaskScheduleEvent = (id: string, plannedForDay: string): ScheduleEvent => ({
+  id,
+  type: SVEType.TaskPlannedForDay,
+  style: '',
+  startHours: 10,
+  timeLeftInHours: 1,
+  data: {
+    id,
+  } as ScheduleEvent['data'],
+  plannedForDay,
 });


### PR DESCRIPTION
## Summary

- disable CDK drag for events rendered in the Schedule month view
- add focused coverage that month events render as month-view events with dragging disabled

## Why

Month-view drag/drop is not implemented for Schedule events yet. Without disabling the inherited `schedule-event` drag directive, month events look draggable and can be dragged away even though no month drop handler updates the task date.

Part of #5926.

## Validation

- `npm run checkFile src/app/features/schedule/schedule-month/schedule-month.component.spec.ts`
- `npm run checkFile src/app/features/schedule/schedule-month/schedule-month.component.html`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/schedule/schedule-month/schedule-month.component.spec.ts` (24 success)
- `git diff --check`
