### PR TITLE
fix(tasks): translate default inbox add-task chip

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.html
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.html
@@ -21,7 +21,11 @@
         {{ selectedProject()?.icon || DEFAULT_PROJECT_ICON }}
       </mat-icon>
     }
-    <span>{{ selectedProject()?.title }}</span>
+    @if (isDefaultInboxProject(selectedProject())) {
+      <span>{{ T.G.INBOX_PROJECT_TITLE | translate }}</span>
+    } @else {
+      <span>{{ selectedProject()?.title }}</span>
+    }
   </button>
 
   @if (!isHideDueBtn()) {
@@ -193,7 +197,11 @@
       (click)="stateService.updateProjectId(project.id)"
     >
       <select-option-row
-        [title]="project.title"
+        [title]="
+          isDefaultInboxProject(project)
+            ? (T.G.INBOX_PROJECT_TITLE | translate)
+            : project.title
+        "
         [icon]="project.icon"
         [defaultIcon]="DEFAULT_PROJECT_ICON"
         [color]="project.theme?.primary"

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
@@ -12,7 +12,7 @@ import { TagService } from '../../../tag/tag.service';
 import { DialogScheduleTaskComponent } from '../../../planner/dialog-schedule-task/dialog-schedule-task.component';
 import { Project } from '../../../project/project.model';
 import { Tag } from '../../../tag/tag.model';
-import { signal } from '@angular/core';
+import { signal, WritableSignal } from '@angular/core';
 import { getDbDateStr } from '../../../../util/get-db-date-str';
 import { DateTimeFormatService } from 'src/app/core/date-time-format/date-time-format.service';
 import { Store } from '@ngrx/store';
@@ -20,6 +20,7 @@ import { GlobalConfigService } from 'src/app/features/config/global-config.servi
 import { DateTimeLocale, DateTimeLocales } from 'src/app/core/locale.constants';
 import { DateService } from '../../../../core/date/date.service';
 import { TaskReminderOptionId } from '../../task.model';
+import { INBOX_PROJECT } from '../../../project/project.const';
 
 const expectedLocaleTime = (timeStr: string, locale: string): string => {
   const [hours, minutes] = timeStr.split(':').map(Number);
@@ -38,6 +39,7 @@ describe('AddTaskBarActionsComponent', () => {
   let mockMatDialog: jasmine.SpyObj<MatDialog>;
   let mockDialogRef: jasmine.SpyObj<MatDialogRef<DialogScheduleTaskComponent>>;
   let mockDateService: jasmine.SpyObj<DateService>;
+  let mockProjectsSignal: WritableSignal<Project[]>;
 
   const mockProject: Project = {
     id: '1',
@@ -132,10 +134,11 @@ describe('AddTaskBarActionsComponent', () => {
       'removeShortSyntaxFromInput',
     ]);
 
+    mockProjectsSignal = signal([mockProject]);
     mockProjectService = jasmine.createSpyObj('ProjectService', [], {
       list$: of([mockProject]),
-      listSortedForUI: signal([mockProject]),
-      listSorted: signal([mockProject]),
+      listSortedForUI: mockProjectsSignal,
+      listSorted: mockProjectsSignal,
     });
 
     mockTagService = jasmine.createSpyObj('TagService', [], {
@@ -193,6 +196,9 @@ describe('AddTaskBarActionsComponent', () => {
           },
         },
       },
+      G: {
+        INBOX_PROJECT_TITLE: 'Posteingang',
+      },
     });
     translateService.use('en');
 
@@ -225,6 +231,39 @@ describe('AddTaskBarActionsComponent', () => {
   });
 
   describe('Computed Properties', () => {
+    it('should translate the default inbox project title in the action button', () => {
+      mockProjectsSignal.set([INBOX_PROJECT]);
+      (mockStateService as any)._mockStateSignal.set({
+        ...mockState,
+        projectId: INBOX_PROJECT.id,
+      });
+
+      fixture.detectChanges();
+
+      const projectButton: HTMLElement =
+        fixture.nativeElement.querySelector('.action-btn');
+      expect(projectButton.textContent).toContain('Posteingang');
+      expect(projectButton.textContent).not.toContain('Inbox');
+    });
+
+    it('should preserve a renamed inbox project title in the action button', () => {
+      const renamedInboxProject = {
+        ...INBOX_PROJECT,
+        title: 'Personal Inbox',
+      };
+      mockProjectsSignal.set([renamedInboxProject]);
+      (mockStateService as any)._mockStateSignal.set({
+        ...mockState,
+        projectId: INBOX_PROJECT.id,
+      });
+
+      fixture.detectChanges();
+
+      const projectButton: HTMLElement =
+        fixture.nativeElement.querySelector('.action-btn');
+      expect(projectButton.textContent).toContain('Personal Inbox');
+    });
+
     it('should compute hasNewTags correctly', () => {
       const stateWithNewTags = {
         ...mockState,

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -245,6 +245,21 @@ describe('AddTaskBarActionsComponent', () => {
       expect(projectButton.textContent).toContain('Posteingang');
       expect(projectButton.textContent).not.toContain('Inbox');
     });
+
+    it('should translate the default inbox project title in the project menu', fakeAsync(() => {
+      mockProjectsSignal.set([INBOX_PROJECT]);
+      fixture.detectChanges();
+
+      const projectButton: HTMLElement =
+        fixture.nativeElement.querySelector('.action-btn');
+      projectButton.click();
+      fixture.detectChanges();
+      tick();
+
+      const menuPanel = document.querySelector('.cdk-overlay-container');
+      expect(menuPanel?.textContent).toContain('Posteingang');
+      expect(menuPanel?.textContent).not.toContain('Inbox');
+    }));
 
     it('should preserve a renamed inbox project title in the action button', () => {
       const renamedInboxProject = {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
@@ -32,7 +32,8 @@ import { isValidSplitTime } from '../../../../util/is-valid-split-time';
 import { normalizeClockStr } from '../../../../util/normalize-clock-str';
 import { getDbDateStr } from '../../../../util/get-db-date-str';
 import { isSingleEmoji } from '../../../../util/extract-first-emoji';
-import { DEFAULT_PROJECT_ICON } from '../../../project/project.const';
+import { DEFAULT_PROJECT_ICON, INBOX_PROJECT } from '../../../project/project.const';
+import { Project } from '../../../project/project.model';
 import { DateTimeFormatService } from 'src/app/core/date-time-format/date-time-format.service';
 import { RepeatQuickSetting } from '../../../task-repeat-cfg/task-repeat-cfg.model';
 import { buildRepeatQuickSettingOptions } from '../../../task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options';
@@ -205,6 +206,10 @@ export class AddTaskBarActionsComponent {
     const icon = project?.icon || 'folder';
     return isSingleEmoji(icon);
   });
+
+  isDefaultInboxProject(project: Project | null | undefined): boolean {
+    return project?.id === INBOX_PROJECT.id && project.title === INBOX_PROJECT.title;
+  }
 
   openScheduleDialog(): void {
     const state = this.state();


### PR DESCRIPTION
## Summary
- Translate the default Inbox project label in the add-task bar project chip and project menu.
- Keep manually renamed Inbox projects unchanged.
- Add regression coverage for the translated default Inbox label in both the action button and project menu, plus renamed Inbox behavior.

## Root cause
The add-task bar rendered `project.title` directly for the selected project and project menu entries. The built-in Inbox project stores the English default title (`Inbox`) so that label stayed untranslated in otherwise localized UI.

Fixes #5585

## Validation
- `npm run checkFile src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts`
- `npm run checkFile src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts` (61 success)
- `git diff --check`