### PR TITLE
fix(caldav): handle missing DAV response header

### DIFF
--- a/src/app/features/issue/providers/caldav/caldav-client.service.spec.ts
+++ b/src/app/features/issue/providers/caldav/caldav-client.service.spec.ts
@@ -158,6 +158,20 @@ describe('CaldavClientService._getXhrProvider – web platform', () => {
     expect(headers['Authorization']).toBe(EXPECTED_AUTH);
     expect(headers['X-Requested-With']).toBe('SuperProductivity');
   });
+
+  it('returns an empty DAV response header when the server does not expose it', () => {
+    spyOn(XMLHttpRequest.prototype, 'getResponseHeader').and.returnValue(null);
+    const factory: () => XMLHttpRequest = (svc as any)._getXhrProvider(MOCK_CFG);
+    const xhr = factory();
+    expect(xhr.getResponseHeader('DAV')).toBe('');
+  });
+
+  it('preserves non-DAV missing response headers as null', () => {
+    spyOn(XMLHttpRequest.prototype, 'getResponseHeader').and.returnValue(null);
+    const factory: () => XMLHttpRequest = (svc as any)._getXhrProvider(MOCK_CFG);
+    const xhr = factory();
+    expect(xhr.getResponseHeader('content-type')).toBeNull();
+  });
 });
 
 describe('CaldavClientService.getByIds$', () => {
@@ -356,6 +370,20 @@ describe('CaldavClientService._getNativeXhrProvider – native platform', () => 
     xhr.send(null);
     await Promise.resolve();
     expect(xhr.getResponseHeader('content-type')).toBe('application/xml; charset=utf-8');
+  });
+
+  it('returns an empty DAV response header when native HTTP omits it', async () => {
+    svc.webDavRequestSpy.and.resolveTo({
+      status: 207,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      headers: { 'content-type': 'application/xml' },
+      data: '',
+    });
+    const xhr = getFakeXhr();
+    xhr.open('REPORT', 'https://cal.example.com/');
+    xhr.send(null);
+    await Promise.resolve();
+    expect(xhr.getResponseHeader('DAV')).toBe('');
   });
 
   it('getAllResponseHeaders returns formatted header string after send()', async () => {

--- a/src/app/features/issue/providers/caldav/caldav-client.service.ts
+++ b/src/app/features/issue/providers/caldav/caldav-client.service.ts
@@ -214,6 +214,13 @@ export class CaldavClientService {
     return hash;
   }
 
+  private static _getResponseHeaderWithDavFallback(
+    name: string,
+    value: string | null,
+  ): string | null {
+    return value === null && name.toLowerCase() === 'dav' ? '' : value;
+  }
+
   async _get_client(cfg: CaldavCfg): Promise<ClientCache> {
     this._checkSettings(cfg);
 
@@ -352,6 +359,7 @@ export class CaldavClientService {
     function xhrProvider(): XMLHttpRequest {
       const xhr = new XMLHttpRequest();
       const oldOpen = xhr.open;
+      const oldGetResponseHeader = xhr.getResponseHeader;
 
       // override open() method to add headers
 
@@ -366,6 +374,15 @@ export class CaldavClientService {
           'Basic ' + btoa(cfg.username + ':' + cfg.password),
         );
         return result;
+      };
+      xhr.getResponseHeader = function (
+        this: XMLHttpRequest,
+        name: string,
+      ): string | null {
+        return CaldavClientService._getResponseHeaderWithDavFallback(
+          name,
+          oldGetResponseHeader.call(this, name),
+        );
       };
       return xhr;
     }
@@ -449,7 +466,10 @@ export class CaldavClientService {
         },
 
         getResponseHeader: (name: string): string | null => {
-          return responseHeaders[name.toLowerCase()] ?? null;
+          return CaldavClientService._getResponseHeaderWithDavFallback(
+            name,
+            responseHeaders[name.toLowerCase()] ?? null,
+          );
         },
 
         getAllResponseHeaders: (): string => {


### PR DESCRIPTION
## Summary
- avoid crashing CalDAV connection setup when a server does not expose the `DAV` response header
- return an empty `DAV` header from both browser XHR and native fake-XHR paths so `@nextcloud/cdav-library` does not call `.split()` on `null`
- add regression coverage for missing `DAV` header handling while preserving `null` for other missing response headers

Fixes #5503

## Validation
- `npm run checkFile src/app/features/issue/providers/caldav/caldav-client.service.ts`
- `npm run checkFile src/app/features/issue/providers/caldav/caldav-client.service.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npx ng test --watch=false --karma-config=src/karma-caldav-fastmail-01.conf.js --include src/app/features/issue/providers/caldav/caldav-client.service.spec.ts` (`33` specs; temporary Karma config used only to avoid concurrent worker port collisions and removed afterward)
