### PR TITLE
fix(plugins): translate yesterday tasks plugin

### DIFF
--- a/packages/plugin-dev/scripts/build-all.js
+++ b/packages/plugin-dev/scripts/build-all.js
@@ -175,6 +175,10 @@ const plugins = [
           fs.copyFileSync(src, dest);
         }
       }
+      const i18nSrc = path.join(pluginPath, 'i18n');
+      if (fs.existsSync(i18nSrc)) {
+        copyRecursive(i18nSrc, path.join(targetDir, 'i18n'));
+      }
       return 'Copied to assets';
     },
   },

--- a/packages/plugin-dev/yesterday-tasks-plugin/i18n/de.json
+++ b/packages/plugin-dev/yesterday-tasks-plugin/i18n/de.json
@@ -1,0 +1,19 @@
+{
+  "PLUGIN": {
+    "NAME": "Aufgaben von gestern",
+    "DESCRIPTION": "Zeigt alle Aufgaben an, an denen du gestern gearbeitet hast, inklusive der jeweils erfassten Zeit."
+  },
+  "SHORTCUT": {
+    "SHOW_YESTERDAY_TASKS": "Aufgaben von gestern anzeigen"
+  },
+  "DATE": {
+    "YESTERDAY": "Gestern",
+    "DAYS_AGO": "vor {{count}} Tagen"
+  },
+  "MESSAGES": {
+    "LOADING_TASKS": "Aufgaben werden geladen...",
+    "NO_RECENT_TASKS_FOUND": "Keine aktuellen Aufgaben gefunden",
+    "NO_TASKS_LAST_30_DAYS": "In den letzten 30 Tagen wurden keine Aufgaben erfasst.",
+    "ERROR_LOADING_TASKS": "Fehler beim Laden der Aufgaben. Bitte versuche es erneut."
+  }
+}

--- a/packages/plugin-dev/yesterday-tasks-plugin/i18n/en.json
+++ b/packages/plugin-dev/yesterday-tasks-plugin/i18n/en.json
@@ -1,0 +1,19 @@
+{
+  "PLUGIN": {
+    "NAME": "Yesterday's Tasks",
+    "DESCRIPTION": "Shows all tasks you worked on yesterday with time spent on each."
+  },
+  "SHORTCUT": {
+    "SHOW_YESTERDAY_TASKS": "Show Yesterday's Tasks"
+  },
+  "DATE": {
+    "YESTERDAY": "Yesterday",
+    "DAYS_AGO": "{{count}} days ago"
+  },
+  "MESSAGES": {
+    "LOADING_TASKS": "Loading tasks...",
+    "NO_RECENT_TASKS_FOUND": "No recent tasks found",
+    "NO_TASKS_LAST_30_DAYS": "No tasks tracked in the last 30 days.",
+    "ERROR_LOADING_TASKS": "Error loading tasks. Please try again."
+  }
+}

--- a/packages/plugin-dev/yesterday-tasks-plugin/index.html
+++ b/packages/plugin-dev/yesterday-tasks-plugin/index.html
@@ -73,7 +73,12 @@
       ></div>
 
       <div id="content">
-        <div class="loading">Loading tasks...</div>
+        <div
+          class="loading"
+          data-i18n="MESSAGES.LOADING_TASKS"
+        >
+          Loading tasks...
+        </div>
       </div>
     </div>
 
@@ -128,12 +133,56 @@
         return minutes + 'm';
       }
 
-      // Wait for plugin API to be available
-      function waitForPlugin() {
-        if (typeof PluginAPI !== 'undefined') {
-          init();
+      async function translate(key, params) {
+        if (
+          typeof PluginAPI !== 'undefined' &&
+          typeof PluginAPI.translate === 'function'
+        ) {
+          return await PluginAPI.translate(key, params);
+        }
+        return key;
+      }
+
+      async function formatPluginDate(date, format) {
+        if (
+          typeof PluginAPI !== 'undefined' &&
+          typeof PluginAPI.formatDate === 'function'
+        ) {
+          return await PluginAPI.formatDate(date, format);
+        }
+        return date.toLocaleDateString('en-US', {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        });
+      }
+
+      async function applyStaticTranslations() {
+        await Promise.all(
+          Array.from(document.querySelectorAll('[data-i18n]')).map(async (el) => {
+            el.textContent = await translate(el.dataset.i18n);
+          }),
+        );
+      }
+
+      async function updateDateDisplay(result) {
+        const dateEl = document.getElementById('yesterday-date');
+        if (result.tasks.length > 0) {
+          const dateText = await formatPluginDate(result.date, 'long');
+
+          if (result.daysBack === 1) {
+            dateEl.textContent =
+              dateText + ' (' + (await translate('DATE.YESTERDAY')) + ')';
+          } else {
+            dateEl.textContent =
+              dateText +
+              ' (' +
+              (await translate('DATE.DAYS_AGO', { count: result.daysBack })) +
+              ')';
+          }
         } else {
-          setTimeout(waitForPlugin, 100);
+          dateEl.textContent = await translate('MESSAGES.NO_RECENT_TASKS_FOUND');
         }
       }
 
@@ -257,42 +306,27 @@
 
       async function init() {
         try {
+          await applyStaticTranslations();
           const result = await getLastAvailableTasks();
           const projects = await PluginAPI.getAllProjects();
 
-          // Update the date display based on what was found
-          const dateEl = document.getElementById('yesterday-date');
-          if (result.tasks.length > 0) {
-            const dateText = result.date.toLocaleDateString('en-US', {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            });
+          await updateDateDisplay(result);
 
-            if (result.daysBack === 1) {
-              dateEl.textContent = dateText + ' (Yesterday)';
-            } else {
-              dateEl.textContent = dateText + ` (${result.daysBack} days ago)`;
-            }
-          } else {
-            dateEl.textContent = 'No recent tasks found';
-          }
-
-          displayTasks(result.tasks, projects);
+          await displayTasks(result.tasks, projects);
         } catch (error) {
           console.error('Error loading tasks:', error);
+          const errorMsg = await translate('MESSAGES.ERROR_LOADING_TASKS');
           document.getElementById('content').innerHTML =
-            '<div class="no-tasks">Error loading tasks. Please try again.</div>';
+            `<div class="no-tasks">${escapeHtml(errorMsg)}</div>`;
         }
       }
 
-      function displayTasks(tasks, projects = []) {
+      async function displayTasks(tasks, projects = []) {
         const contentEl = document.getElementById('content');
 
         if (tasks.length === 0) {
-          contentEl.innerHTML =
-            '<div class="no-tasks">No tasks tracked in the last 30 days.</div>';
+          const noTasksMsg = await translate('MESSAGES.NO_TASKS_LAST_30_DAYS');
+          contentEl.innerHTML = `<div class="no-tasks">${escapeHtml(noTasksMsg)}</div>`;
           return;
         }
 
@@ -339,26 +373,9 @@
         const result = await getLastAvailableTasks();
         const projects = await PluginAPI.getAllProjects();
 
-        // Update the date display
-        const dateEl = document.getElementById('yesterday-date');
-        if (result.tasks.length > 0) {
-          const dateText = result.date.toLocaleDateString('en-US', {
-            weekday: 'long',
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          });
+        await updateDateDisplay(result);
 
-          if (result.daysBack === 1) {
-            dateEl.textContent = dateText + ' (Yesterday)';
-          } else {
-            dateEl.textContent = dateText + ` (${result.daysBack} days ago)`;
-          }
-        } else {
-          dateEl.textContent = 'No recent tasks found';
-        }
-
-        displayTasks(result.tasks, projects);
+        await displayTasks(result.tasks, projects);
       }
 
       // Register hooks to refresh on task changes
@@ -371,6 +388,10 @@
         });
         PluginAPI.registerHook(PluginAPI.Hooks.TASK_DELETE, (taskData) => {
           refreshTasks();
+        });
+        PluginAPI.registerHook(PluginAPI.Hooks.LANGUAGE_CHANGE, async () => {
+          await applyStaticTranslations();
+          await refreshTasks();
         });
       }
 

--- a/packages/plugin-dev/yesterday-tasks-plugin/manifest.json
+++ b/packages/plugin-dev/yesterday-tasks-plugin/manifest.json
@@ -7,6 +7,9 @@
   "description": "Shows all tasks you worked on yesterday with time spent on each.",
   "hooks": [],
   "permissions": ["getTasks", "getArchivedTasks", "showIndexHtmlAsView", "openDialog"],
+  "i18n": {
+    "languages": ["en", "de"]
+  },
   "iFrame": true,
   "sidePanel": true,
   "type": "standard",

--- a/packages/plugin-dev/yesterday-tasks-plugin/plugin.js
+++ b/packages/plugin-dev/yesterday-tasks-plugin/plugin.js
@@ -3,7 +3,7 @@ console.log("Yesterday's Tasks Plugin loaded");
 // Register a keyboard shortcut
 PluginAPI.registerShortcut({
   id: 'show_yesterday',
-  label: "Show Yesterday's Tasks",
+  label: PluginAPI.translate('SHORTCUT.SHOW_YESTERDAY_TASKS'),
   onExec: function () {
     PluginAPI.showIndexHtmlAsView();
   },

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -85,6 +85,8 @@ import { createPluginSyncAdapter } from './issue-provider/plugin-sync-adapter.se
 import { PluginOAuthBridgeService } from './oauth/plugin-oauth-bridge.service';
 import { ISSUE_PROVIDER_TYPES } from '../features/issue/issue.const';
 import { PluginService } from './plugin.service';
+import { PluginI18nService } from './plugin-i18n.service';
+import { formatDateForPlugin } from './plugin-i18n-date.util';
 
 // New imports for simple counters
 import { selectAllSimpleCounters } from '../features/simple-counter/store/simple-counter.reducer';
@@ -102,6 +104,8 @@ import {
 } from '../features/simple-counter/store/simple-counter.actions';
 import { getDbDateStr } from '../util/get-db-date-str';
 import { DataInitService } from '../core/data-init/data-init.service';
+
+type PluginDateFormat = 'short' | 'medium' | 'long' | 'time' | 'datetime';
 
 /**
  * PluginBridge acts as an intermediary layer between plugins and the main application services.
@@ -247,6 +251,9 @@ export class PluginBridgeService implements OnDestroy {
     startOAuthFlow: (config: OAuthFlowConfig) => Promise<OAuthTokenResult>;
     getOAuthToken: () => Promise<string | null>;
     clearOAuthToken: () => Promise<void>;
+    translate: (key: string, params?: Record<string, string | number>) => string;
+    formatDate: (date: Date | string | number, format: PluginDateFormat) => string;
+    getCurrentLanguage: () => string;
     log: ReturnType<typeof Log.withContext>;
   } {
     return {
@@ -335,6 +342,18 @@ export class PluginBridgeService implements OnDestroy {
         ),
       clearOAuthToken: (): Promise<void> =>
         this._pluginOAuthBridge.clearOAuthTokens(pluginId),
+
+      // i18n
+      translate: (key: string, params?: Record<string, string | number>): string =>
+        this._injector.get(PluginI18nService).translate(pluginId, key, params),
+      formatDate: (date: Date | string | number, format: PluginDateFormat): string =>
+        formatDateForPlugin(
+          date,
+          format,
+          this._injector.get(PluginI18nService).getCurrentLanguage(),
+        ),
+      getCurrentLanguage: (): string =>
+        this._injector.get(PluginI18nService).getCurrentLanguage(),
 
       // Logging
       log: Log.withContext(`${pluginId}`),

--- a/src/app/plugins/plugin-runner.spec.ts
+++ b/src/app/plugins/plugin-runner.spec.ts
@@ -14,6 +14,7 @@ describe('PluginRunner', () => {
   let mockSnackService: jasmine.SpyObj<SnackService>;
   let mockCleanupService: jasmine.SpyObj<PluginCleanupService>;
   let mockI18nService: jasmine.SpyObj<PluginI18nService>;
+  let registerSidePanelButtonSpy: jasmine.Spy;
 
   const mockManifest: PluginManifest = {
     id: 'test-plugin',
@@ -39,7 +40,10 @@ describe('PluginRunner', () => {
       'pingNodeBridge',
     ]);
     // createBoundMethods should return an empty object (no additional bound methods)
-    mockPluginBridge.createBoundMethods.and.returnValue({} as any);
+    registerSidePanelButtonSpy = jasmine.createSpy('registerSidePanelButton');
+    mockPluginBridge.createBoundMethods.and.returnValue({
+      registerSidePanelButton: registerSidePanelButtonSpy,
+    } as any);
     mockPluginBridge.pingNodeBridge.and.resolveTo(false);
 
     mockSecurityService = jasmine.createSpyObj('PluginSecurityService', [
@@ -57,6 +61,7 @@ describe('PluginRunner', () => {
       'unloadPluginTranslations',
     ]);
     mockI18nService.getCurrentLanguage.and.returnValue('en');
+    mockI18nService.translate.and.callFake((_pluginId, key) => key);
 
     TestBed.configureTestingModule({
       providers: [
@@ -153,6 +158,42 @@ describe('PluginRunner', () => {
       expect(mockSecurityService.analyzePluginCode).toHaveBeenCalledWith(
         pluginCode,
         mockManifest,
+      );
+    });
+
+    it('uses plugin i18n for auto-registered side panel labels', async () => {
+      mockI18nService.translate
+        .withArgs('test-plugin', 'PLUGIN.NAME')
+        .and.returnValue('Aufgaben von gestern');
+
+      await service.loadPlugin(
+        {
+          ...mockManifest,
+          sidePanel: true,
+          i18n: { languages: ['en', 'de'] },
+        },
+        `/* no-op */`,
+        mockBaseCfg,
+      );
+
+      expect(registerSidePanelButtonSpy).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({ label: 'Aufgaben von gestern' }),
+      );
+    });
+
+    it('falls back to manifest name when plugin name i18n is missing', async () => {
+      await service.loadPlugin(
+        {
+          ...mockManifest,
+          sidePanel: true,
+          i18n: { languages: ['en', 'de'] },
+        },
+        `/* no-op */`,
+        mockBaseCfg,
+      );
+
+      expect(registerSidePanelButtonSpy).toHaveBeenCalledOnceWith(
+        jasmine.objectContaining({ label: 'Test Plugin' }),
       );
     });
   });

--- a/src/app/plugins/plugin-runner.ts
+++ b/src/app/plugins/plugin-runner.ts
@@ -84,9 +84,14 @@ export class PluginRunner {
 
         // Register UI components for iframe plugins
         // Skip menu entry if this is a side panel plugin
+        const pluginDisplayName = this._translatePluginText(
+          manifest,
+          'PLUGIN.NAME',
+          manifest.name,
+        );
         if (manifest.iFrame && !manifest.isSkipMenuEntry && !manifest.sidePanel) {
           pluginAPI.registerMenuEntry({
-            label: manifest.name,
+            label: pluginDisplayName,
             icon: manifest.icon || 'extension',
             onClick: () => pluginAPI.showIndexHtmlAsView(),
           });
@@ -95,7 +100,7 @@ export class PluginRunner {
         // Auto-register side panel if configured
         if (manifest.sidePanel) {
           pluginAPI.registerSidePanelButton({
-            label: manifest.name,
+            label: pluginDisplayName,
             icon: manifest.icon || 'extension',
             onClick: () => {
               // No-op: the side panel toggle is handled by PluginSidePanelBtnsComponent
@@ -115,6 +120,18 @@ export class PluginRunner {
       PluginLog.err(`Failed to load plugin ${manifest.id}:`, error);
       throw error;
     }
+  }
+
+  private _translatePluginText(
+    manifest: PluginManifest,
+    key: string,
+    fallback: string,
+  ): string {
+    if (!manifest.i18n?.languages?.length) {
+      return fallback;
+    }
+    const translated = this._pluginI18nService.translate(manifest.id, key);
+    return translated === key ? fallback : translated;
   }
 
   /**

--- a/src/app/plugins/util/plugin-iframe.util.spec.ts
+++ b/src/app/plugins/util/plugin-iframe.util.spec.ts
@@ -11,7 +11,10 @@ import {
 } from './plugin-iframe.util';
 
 describe('handlePluginMessage()', () => {
-  const createConfig = (pluginBridge: PluginBridgeService): PluginIframeConfig => ({
+  const createConfig = (
+    pluginBridge: PluginBridgeService,
+    boundMethods?: PluginIframeConfig['boundMethods'],
+  ): PluginIframeConfig => ({
     pluginId: 'test-plugin',
     manifest: {
       id: 'test-plugin',
@@ -30,9 +33,7 @@ describe('handlePluginMessage()', () => {
       isDev: false,
     } as PluginBaseCfg,
     pluginBridge,
-    boundMethods: {} as ReturnType<
-      typeof PluginBridgeService.prototype.createBoundMethods
-    >,
+    boundMethods,
   });
 
   it('rebuilds iframe dialog button handlers and returns the selected result', async () => {
@@ -164,6 +165,45 @@ describe('handlePluginMessage()', () => {
         type: PluginIframeMessageType.API_ERROR,
         callId: 8,
         error: 'Button failed',
+      },
+      '*',
+    );
+  });
+
+  it('routes iframe i18n API calls through plugin-bound methods', async () => {
+    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
+      'sourceWindow',
+      ['postMessage'],
+    );
+    const translate = jasmine
+      .createSpy('translate')
+      .withArgs('DATE.YESTERDAY', { days: 1 })
+      .and.returnValue('Gestern');
+    const pluginBridge = {
+      createBoundMethods: () => ({
+        translate,
+      }),
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.API_CALL,
+          method: 'translate',
+          callId: 11,
+          args: ['DATE.YESTERDAY', { days: 1 }],
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(translate).toHaveBeenCalledOnceWith('DATE.YESTERDAY', { days: 1 });
+    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PluginIframeMessageType.API_RESPONSE,
+        callId: 11,
+        result: 'Gestern',
       },
       '*',
     );

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -404,6 +404,11 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
           deleteCounter: (id) => callApi('deleteCounter', [id]),
           getAllCounters: () => callApi('getAllCounters'),
 
+          // i18n
+          translate: (key, params) => callApi('translate', [key, params]),
+          formatDate: (date, format) => callApi('formatDate', [date, format]),
+          getCurrentLanguage: () => callApi('getCurrentLanguage'),
+
           // Readiness signal for iframe plugins.
           //
           // NOTE — semantic difference from host-side onReady:


### PR DESCRIPTION
## Summary
- add plugin-local English and German i18n files for Yesterday's Tasks
- translate the Yesterday Tasks iframe UI, shortcut label, and auto-registered plugin entry label
- expose plugin i18n methods through the iframe PluginAPI and copy Yesterday plugin i18n files into bundled assets

Fixes #5103

## Verification
- `npm run checkFile src/app/plugins/plugin-bridge.service.ts`
- `npm run checkFile src/app/plugins/plugin-runner.ts`
- `npm run checkFile src/app/plugins/plugin-runner.spec.ts`
- `npm run checkFile src/app/plugins/util/plugin-iframe.util.ts`
- `npm run checkFile src/app/plugins/util/plugin-iframe.util.spec.ts`
- `npm run checkFile packages/plugin-api/src/types.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/plugins/plugin-runner.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/plugins/util/plugin-iframe.util.spec.ts`
- `node -c packages/plugin-dev/scripts/build-all.js`
- `node -c packages/plugin-dev/yesterday-tasks-plugin/plugin.js`
- JSON parse check for Yesterday plugin manifest and i18n files
- Yesterday plugin inline HTML script syntax check
- `git diff --check`
