### PR TITLE
fix(redmine): support non-latin issue search

### DIFF
--- a/docs/wiki/3.07-Issue-Integration-Comparison.md
+++ b/docs/wiki/3.07-Issue-Integration-Comparison.md
@@ -111,7 +111,7 @@ Every issue provider supports the same basic operations: checking that the integ
 
 - **Issue import:** Issues from projects.
 - **Status transitions / Worklog / Comments / Subtasks / Attachments:** Not supported.
-- **Filtering:** Project-based; scope support.
+- **Filtering:** Project-based; scope support; task search supports non-Latin subject matches.
 - **Auto-import:** Last 100 issues for the project.
 
 ### 9. Trello

--- a/src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
+++ b/src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
@@ -1,17 +1,19 @@
-import { TestBed } from '@angular/core/testing';
 import {
   HttpClientTestingModule,
   HttpTestingController,
+  TestRequest,
 } from '@angular/common/http/testing';
 import { HttpRequest } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { SnackService } from '../../../../core/snack/snack.service';
+import { SearchResultItem } from '../../issue.model';
 import { RedmineApiService } from './redmine-api.service';
 import { RedmineCfg } from './redmine.model';
-import { SearchResultItem } from '../../issue.model';
-import { SnackService } from '../../../../core/snack/snack.service';
 
 describe('RedmineApiService', () => {
   let service: RedmineApiService;
   let httpMock: HttpTestingController;
+  let snackService: jasmine.SpyObj<SnackService>;
 
   const mockCfg: RedmineCfg = {
     isEnabled: true,
@@ -34,14 +36,15 @@ describe('RedmineApiService', () => {
     limit: 100,
   };
 
-  // by-id lookup is scoped to the configured project (not the global /issues/{id}.json)
+  const searchUrl = (query: string): string =>
+    `${mockCfg.host}/projects/${mockCfg.projectId}/search.json?limit=100&q=${query}&issues=1&open_issues=1`;
+
   const byIdInProjectMatcher =
     (issueId: number) =>
     (req: HttpRequest<unknown>): boolean =>
       req.method === 'GET' &&
       req.url === `${mockCfg.host}/projects/${mockCfg.projectId}/issues.json` &&
       req.params.get('issue_id') === String(issueId) &&
-      // status_id=* so closed issues are found too
       req.params.get('status_id') === '*';
 
   beforeEach(() => {
@@ -57,6 +60,7 @@ describe('RedmineApiService', () => {
     });
     service = TestBed.inject(RedmineApiService);
     httpMock = TestBed.inject(HttpTestingController);
+    snackService = TestBed.inject(SnackService) as jasmine.SpyObj<SnackService>;
   });
 
   afterEach(() => {
@@ -68,10 +72,7 @@ describe('RedmineApiService', () => {
   });
 
   describe('searchIssuesInProject$', () => {
-    const searchUrl = (query: string): string =>
-      `${mockCfg.host}/projects/${mockCfg.projectId}/search.json?limit=100&q=${query}&issues=1&open_issues=1`;
-
-    it('should only send a text search request for non-numeric queries', () => {
+    it('should only send a text search request for non-numeric Latin queries', () => {
       let result: SearchResultItem[] | undefined;
       service.searchIssuesInProject$('some text', mockCfg).subscribe((r) => (result = r));
 
@@ -132,7 +133,6 @@ describe('RedmineApiService', () => {
       service.searchIssuesInProject$('99999', mockCfg).subscribe((r) => (result = r));
 
       const byIdReq = httpMock.expectOne(byIdInProjectMatcher(99999));
-      // Redmine returns an empty list (not a 404) for an id outside the project
       byIdReq.flush({ issues: [], total_count: 0, offset: 0, limit: 1 });
 
       const searchReq = httpMock.expectOne(searchUrl('99999'));
@@ -146,17 +146,89 @@ describe('RedmineApiService', () => {
       let result: SearchResultItem[] | undefined;
       service.searchIssuesInProject$('424242', mockCfg).subscribe((r) => (result = r));
 
-      // The lookup is scoped to the configured project; an id belonging to another
-      // project the API key can see is therefore returned as an empty list by Redmine.
       const byIdReq = httpMock.expectOne(byIdInProjectMatcher(424242));
       byIdReq.flush({ issues: [], total_count: 0, offset: 0, limit: 1 });
 
       const searchReq = httpMock.expectOne(searchUrl('424242'));
       searchReq.flush({ ...mockSearchResponse, results: [] });
 
-      // no global /issues/{id}.json request is ever made
       httpMock.expectNone(`${mockCfg.host}/issues/424242.json`);
       expect(result?.length).toBe(0);
+    });
+
+    it('adds a subject filter fallback for non-Latin queries without full text results', () => {
+      service.searchIssuesInProject$('修正', mockCfg).subscribe((issues) => {
+        expect(issues.length).toBe(1);
+        expect(issues[0].title).toBe('#23 修正ログイン');
+        expect(issues[0].issueData.id).toBe(23);
+      });
+
+      const searchReq = httpMock.expectOne(searchUrl('%E4%BF%AE%E6%AD%A3'));
+      searchReq.flush({
+        results: [],
+        total_count: 0,
+        offset: 0,
+        limit: 100,
+      });
+
+      const fallbackReq = expectSubjectFallbackRequest(httpMock, mockCfg, '修正');
+      expect(fallbackReq.request.method).toBe('GET');
+      fallbackReq.flush({
+        issues: [
+          {
+            id: 23,
+            subject: '修正ログイン',
+            title: '修正ログイン',
+            updated_on: '2026-01-01T00:00:00Z',
+            url: 'https://redmine.example.com/issues/23',
+          },
+        ],
+        total_count: 1,
+        offset: 0,
+        limit: 100,
+      });
+    });
+
+    it('does not request the subject fallback when full text search already returns results', () => {
+      service.searchIssuesInProject$('修正', mockCfg).subscribe((issues) => {
+        expect(issues.map((issue) => issue.issueData.id)).toEqual([23]);
+      });
+
+      const searchReq = httpMock.expectOne(searchUrl('%E4%BF%AE%E6%AD%A3'));
+      searchReq.flush({
+        results: [
+          {
+            id: 23,
+            title: '#23 修正ログイン',
+            url: 'https://redmine.example.com/issues/23',
+          },
+        ],
+        total_count: 1,
+        offset: 0,
+        limit: 100,
+      });
+
+      httpMock.expectNone((req: HttpRequest<unknown>) => {
+        return req.url === `${mockCfg.host}/projects/${mockCfg.projectId}/issues.json`;
+      });
+    });
+
+    it('keeps full text results when subject fallback fails', () => {
+      service.searchIssuesInProject$('修正', mockCfg).subscribe((issues) => {
+        expect(issues).toEqual([]);
+      });
+
+      const searchReq = httpMock.expectOne(searchUrl('%E4%BF%AE%E6%AD%A3'));
+      searchReq.flush({
+        results: [],
+        total_count: 0,
+        offset: 0,
+        limit: 100,
+      });
+
+      const fallbackReq = expectSubjectFallbackRequest(httpMock, mockCfg, '修正');
+      fallbackReq.flush('Forbidden', { status: 403, statusText: 'Forbidden' });
+      expect(snackService.open).not.toHaveBeenCalled();
     });
   });
 
@@ -249,5 +321,57 @@ describe('RedmineApiService', () => {
 
       expect(result?.length).toBe(1);
     });
+
+    it('should run the non-Latin subject fallback against instance-wide /issues.json', () => {
+      service.searchIssuesInProject$('修正', globalCfg).subscribe((issues) => {
+        expect(issues.length).toBe(1);
+        expect(issues[0].title).toBe('#23 修正ログイン');
+      });
+
+      const searchReq = httpMock.expectOne(globalSearchUrl('%E4%BF%AE%E6%AD%A3'));
+      searchReq.flush({
+        results: [],
+        total_count: 0,
+        offset: 0,
+        limit: 100,
+      });
+
+      const fallbackReq = expectSubjectFallbackRequest(httpMock, globalCfg, '修正');
+      expect(fallbackReq.request.method).toBe('GET');
+      fallbackReq.flush({
+        issues: [
+          {
+            id: 23,
+            subject: '修正ログイン',
+            title: '修正ログイン',
+            updated_on: '2026-01-01T00:00:00Z',
+            url: 'https://redmine.example.com/issues/23',
+          },
+        ],
+        total_count: 1,
+        offset: 0,
+        limit: 100,
+      });
+    });
   });
 });
+
+const expectSubjectFallbackRequest = (
+  httpMock: HttpTestingController,
+  cfg: RedmineCfg,
+  query: string,
+): TestRequest =>
+  httpMock.expectOne((req: HttpRequest<unknown>) => {
+    const params = req.params;
+
+    return (
+      req.url ===
+        `${cfg.host}${cfg.projectId ? `/projects/${cfg.projectId}` : ''}/issues.json` &&
+      params.get('limit') === '100' &&
+      params.get('status_id') === 'open' &&
+      params.get('set_filter') === '1' &&
+      params.get('f[]') === 'subject' &&
+      params.get('op[subject]') === '~' &&
+      params.get('v[subject][]') === query
+    );
+  });

--- a/src/app/features/issue/providers/redmine/redmine-api.service.ts
+++ b/src/app/features/issue/providers/redmine/redmine-api.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { SnackService } from '../../../../core/snack/snack.service';
 import { HttpClient, HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
 import { RedmineCfg } from './redmine.model';
-import { catchError, filter, map } from 'rxjs/operators';
+import { catchError, filter, map, switchMap } from 'rxjs/operators';
 import { forkJoin, Observable, of, throwError } from 'rxjs';
 import { throwHandledError } from '../../../../util/throw-handled-error';
 import { T } from '../../../../t.const';
@@ -12,6 +12,7 @@ import {
   RedmineActivityResult,
   RedmineIssue,
   RedmineIssueResult,
+  RedmineIssueStatusOptions,
   RedmineSearchResult,
   RedmineSearchResultItem,
   RedmineTimeEntriesResult,
@@ -36,48 +37,32 @@ export class RedmineApiService {
   private _http = inject(HttpClient);
 
   searchIssuesInProject$(query: string, cfg: RedmineCfg): Observable<SearchResultItem[]> {
-    const textSearch$: Observable<SearchResultItem[]> = this._sendRequest$(
-      {
-        url: `${cfg.host}${this._projectScopePath(cfg)}/search.json`,
-        params: ParamsBuilder.create()
-          .withLimit(100)
-          .withQuery(query)
-          .onlyIssues(true)
-          .openIssues(true)
-          .build(),
-      },
-      cfg,
-    ).pipe(
-      map((res: RedmineSearchResult) => {
-        return res
-          ? res.results.map((item: RedmineSearchResultItem) =>
-              mapRedmineSearchResultItemToSearchResult(item),
-            )
-          : [];
-      }),
-    );
-
-    // Redmine's search API only does full text search and does not match issue ids,
-    // so for numeric queries (e.g. "1234" or "#1234") we additionally try to fetch
-    // the issue by its id and merge it into the results.
+    const searchResults$ = this._searchTextIssuesInProject$(query, cfg);
     const idMatch = query.trim().match(ISSUE_ID_QUERY_RGX);
-    if (!idMatch) {
-      return textSearch$;
+
+    if (!idMatch && !queryHasNonAscii(query)) {
+      return searchResults$;
     }
 
-    const issueId = Number(idMatch[1]);
-    return forkJoin([
-      this._getIssueByIdInProject$(issueId, cfg).pipe(catchError(() => of(null))),
-      textSearch$,
-    ]).pipe(
-      map(([issueById, textResults]) =>
-        issueById
-          ? [
-              mapRedmineIssueToSearchResult(issueById),
-              ...textResults.filter((result) => result.issueData.id !== issueId),
-            ]
-          : textResults,
-      ),
+    const issueById$: Observable<RedmineIssue | null> = idMatch
+      ? this._getIssueByIdInProject$(Number(idMatch[1]), cfg).pipe(
+          catchError(() => of(null)),
+        )
+      : of(null);
+
+    return forkJoin([issueById$, searchResults$]).pipe(
+      switchMap(([issueById, searchResults]) => {
+        const resultsWithId = issueById
+          ? mergeSearchResults([mapRedmineIssueToSearchResult(issueById)], searchResults)
+          : searchResults;
+
+        return queryHasNonAscii(query) && resultsWithId.length === 0
+          ? this._searchIssuesBySubjectInProject$(query, cfg).pipe(
+              map((subjectResults) => mergeSearchResults(resultsWithId, subjectResults)),
+              catchError(() => of(resultsWithId)),
+            )
+          : of(resultsWithId);
+      }),
     );
   }
 
@@ -99,7 +84,7 @@ export class RedmineApiService {
         url: `${cfg.host}${this._projectScopePath(cfg)}/issues.json`,
         params: ParamsBuilder.create()
           .withParam('issue_id', String(issueId))
-          .withState('*')
+          .withState(RedmineIssueStatusOptions.all)
           .withLimit(1)
           .build(),
       },
@@ -189,6 +174,60 @@ export class RedmineApiService {
     );
   }
 
+  private _searchTextIssuesInProject$(
+    query: string,
+    cfg: RedmineCfg,
+  ): Observable<SearchResultItem[]> {
+    return this._sendRequest$(
+      {
+        url: `${cfg.host}${this._projectScopePath(cfg)}/search.json`,
+        params: ParamsBuilder.create()
+          .withLimit(100)
+          .withQuery(query)
+          .onlyIssues(true)
+          .openIssues(true)
+          .build(),
+      },
+      cfg,
+    ).pipe(
+      map((res: RedmineSearchResult) => {
+        return res
+          ? res.results.map((item: RedmineSearchResultItem) =>
+              mapRedmineSearchResultItemToSearchResult(item),
+            )
+          : [];
+      }),
+    );
+  }
+
+  private _searchIssuesBySubjectInProject$(
+    query: string,
+    cfg: RedmineCfg,
+  ): Observable<SearchResultItem[]> {
+    const trimmedQuery = query.trim();
+
+    if (!trimmedQuery) {
+      return of([]);
+    }
+
+    return this._sendRequest$(
+      {
+        url: `${cfg.host}${this._projectScopePath(cfg)}/issues.json`,
+        params: ParamsBuilder.create()
+          .withLimit(100)
+          .withState(RedmineIssueStatusOptions.open)
+          .withSubjectContains(trimmedQuery)
+          .build(),
+      },
+      cfg,
+      { isSkipErrorHandling: true },
+    ).pipe(
+      map((res: RedmineIssueResult) =>
+        (res?.issues ?? []).map((issue) => mapRedmineIssueToSearchResult(issue)),
+      ),
+    );
+  }
+
   // Returns the project URL segment to prefix scoped endpoints with: `/projects/<id>` when a
   // project is configured, or '' when it is not. An empty segment makes requests hit Redmine's
   // instance-wide endpoints (`/search.json`, `/issues.json`), so a single connection can search
@@ -266,6 +305,37 @@ export class RedmineApiService {
   }
 }
 
+const queryHasNonAscii = (query: string): boolean => /[^\u0000-\u007F]/.test(query);
+
+const getIssueId = (item: SearchResultItem): number | string | undefined => {
+  return item.issueData?.id;
+};
+
+const mergeSearchResults = (
+  ...resultGroups: SearchResultItem[][]
+): SearchResultItem[] => {
+  const seenIssueIds = new Set<number | string>();
+  const mergedResults: SearchResultItem[] = [];
+
+  for (const resultGroup of resultGroups) {
+    for (const item of resultGroup) {
+      const issueId = getIssueId(item);
+
+      if (issueId !== undefined && issueId !== null) {
+        if (seenIssueIds.has(issueId)) {
+          continue;
+        }
+
+        seenIssueIds.add(issueId);
+      }
+
+      mergedResults.push(item);
+    }
+  }
+
+  return mergedResults;
+};
+
 class ParamsBuilder {
   params: any = {};
 
@@ -300,6 +370,14 @@ class ParamsBuilder {
 
   withQuery(query: string): ParamsBuilder {
     this.params['q'] = query;
+    return this;
+  }
+
+  withSubjectContains(query: string): ParamsBuilder {
+    this.params['set_filter'] = '1';
+    this.params['f[]'] = 'subject';
+    this.params['op[subject]'] = '~';
+    this.params['v[subject][]'] = query;
     return this;
   }
 


### PR DESCRIPTION
Fixes #4149.

## Summary
- keep the existing Redmine `/search.json` request as the primary search path
- for non-Latin queries, only fall back to a Redmine subject-contains issue filter when `/search.json` returns no results
- return the original search response if the fallback request fails, avoiding an extra snackbar for the fallback path
- document Redmine non-Latin subject search support in the issue integration comparison

## Validation
- npm run checkFile src/app/features/issue/providers/redmine/redmine-api.service.ts
- npm run checkFile src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/redmine/redmine-api.service.spec.ts
- git diff --check
- push hook: full lint, package tests, release-notes tests, default Angular suite, and LA timezone Angular suite passed

Note: PR #8072 also touches Redmine search for numeric issue IDs. This PR keeps its fallback scoped to non-Latin subject queries.