### PR TITLE
fix(focus-mode): keep manual breaks running when tracking pauses

### DIFF
--- a/src/app/features/focus-mode/focus-mode-break/focus-mode-break.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-break/focus-mode-break.component.spec.ts
@@ -21,7 +21,6 @@ import { of } from 'rxjs';
 import { TaskService } from '../../tasks/task.service';
 import { FocusMainUIState, FocusModeMode } from '../focus-mode.model';
 import { FocusModeConfig } from '../../config/global-config.model';
-import { unsetCurrentTask } from '../../tasks/store/task.actions';
 
 describe('FocusModeBreakComponent', () => {
   let component: FocusModeBreakComponent;
@@ -161,7 +160,7 @@ describe('FocusModeBreakComponent', () => {
       );
     });
 
-    it('should unset current task before starting break offer when pause-during-break is enabled', () => {
+    it('should start break offer without clearing tracking first when pause-during-break is enabled', () => {
       (mockFocusModeService.mainState as any).set(FocusMainUIState.BreakOffer);
       (mockFocusModeService.isSessionRunning as any).set(false);
       (mockFocusModeService.focusModeConfig as any).set({
@@ -170,7 +169,7 @@ describe('FocusModeBreakComponent', () => {
 
       component.resumeBreak();
 
-      expect(mockStore.dispatch).toHaveBeenCalledWith(unsetCurrentTask());
+      expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
       expect(mockStore.dispatch).toHaveBeenCalledWith(
         startBreak({
           duration: 300000,

--- a/src/app/features/focus-mode/focus-mode-break/focus-mode-break.component.ts
+++ b/src/app/features/focus-mode/focus-mode-break/focus-mode-break.component.ts
@@ -22,7 +22,6 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { TaskTrackingInfoComponent } from '../task-tracking-info/task-tracking-info.component';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TaskService } from '../../tasks/task.service';
-import { unsetCurrentTask } from '../../tasks/store/task.actions';
 
 @Component({
   selector: 'focus-mode-break',
@@ -95,10 +94,6 @@ export class FocusModeBreakComponent {
       const currentTaskId = this._taskService.currentTaskId();
       const storePausedTaskId = this._pausedTaskId();
       const pausedTaskId = storePausedTaskId ?? currentTaskId;
-      const config = this.focusModeService.focusModeConfig();
-      if (config?.isPauseTrackingDuringBreak) {
-        this._store.dispatch(unsetCurrentTask());
-      }
 
       this._store.dispatch(
         startBreak({

--- a/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
@@ -413,7 +413,7 @@ describe('FocusModeEffects', () => {
           });
       });
 
-      it('should dispatch both unsetCurrentTask and startBreak with pausedTaskId when isPauseTrackingDuringBreak is true and task is active', (done) => {
+      it('should dispatch startBreak before clearing tracking when isPauseTrackingDuringBreak is true and task is active', (done) => {
         actions$ = of(actions.incrementCycle());
         store.overrideSelector(selectors.selectMode, FocusModeMode.Pomodoro);
         store.overrideSelector(selectors.selectCurrentCycle, 1);
@@ -428,9 +428,8 @@ describe('FocusModeEffects', () => {
         effects.autoStartBreakOnSessionComplete$
           .pipe(toArray())
           .subscribe((actionsArr) => {
-            expect(actionsArr.length).toBe(2);
-            expect(actionsArr[0]).toEqual(unsetCurrentTask());
-            expect(actionsArr[1]).toEqual(
+            expect(actionsArr.length).toBe(1);
+            expect(actionsArr[0]).toEqual(
               actions.startBreak({
                 duration: 5 * 60 * 1000,
                 isLongBreak: false,
@@ -1379,9 +1378,10 @@ describe('FocusModeEffects', () => {
       }, 50);
     });
 
-    it('should dispatch pauseFocusSession during break when tracking stops (Bug #5954)', (done) => {
+    it('should dispatch pauseFocusSession during break when tracking stops and tracking continues during breaks (Bug #5954)', (done) => {
       store.overrideSelector(selectFocusModeConfig, {
         isSkipPreparation: false,
+        isPauseTrackingDuringBreak: false,
       });
       store.overrideSelector(
         selectors.selectTimer,
@@ -1408,6 +1408,35 @@ describe('FocusModeEffects', () => {
         expect(dispatched).toBe(true);
         done();
       }, 100);
+    });
+
+    it('should NOT pause a running break when configured break-start tracking pause clears the task (Bug #4152)', (done) => {
+      store.overrideSelector(selectFocusModeConfig, {
+        isSkipPreparation: false,
+        isPauseTrackingDuringBreak: true,
+      });
+      store.overrideSelector(
+        selectors.selectTimer,
+        createMockTimer({ isRunning: true, purpose: 'break' }),
+      );
+      store.refreshState();
+
+      effects = TestBed.inject(FocusModeEffects);
+
+      const { emitted, subscription } = collectEmissions(
+        effects.syncTrackingStopToSession$,
+      );
+      currentTaskId$.next('task-123');
+
+      setTimeout(() => {
+        currentTaskId$.next(null);
+      }, 10);
+
+      setTimeout(() => {
+        expect(emitted).toEqual([]);
+        subscription.unsubscribe();
+        done();
+      }, 50);
     });
 
     it('should NOT dispatch when switching to different task (not stopping)', (done) => {
@@ -2134,11 +2163,9 @@ describe('FocusModeEffects', () => {
     });
   });
 
-  describe('pauseTrackingDuringBreak (autoStartBreakOnSessionComplete$)', () => {
+  describe('pauseTrackingOnBreakStart$', () => {
     it('should dispatch unsetCurrentTask when break starts and isPauseTrackingDuringBreak is true', (done) => {
-      actions$ = of(actions.incrementCycle());
-      store.overrideSelector(selectors.selectMode, FocusModeMode.Pomodoro);
-      store.overrideSelector(selectors.selectCurrentCycle, 1);
+      actions$ = of(actions.startBreak({ pausedTaskId: 'task-123' }));
       store.overrideSelector(selectFocusModeConfig, {
         isSkipPreparation: false,
         isPauseTrackingDuringBreak: true,
@@ -2146,17 +2173,14 @@ describe('FocusModeEffects', () => {
       currentTaskId$.next('task-123');
       store.refreshState();
 
-      effects.autoStartBreakOnSessionComplete$.pipe(toArray()).subscribe((actionsArr) => {
-        const unsetAction = actionsArr.find((a) => a.type === '[Task] UnsetCurrentTask');
-        expect(unsetAction).toBeDefined();
+      effects.pauseTrackingOnBreakStart$.pipe(take(1)).subscribe((action) => {
+        expect(action).toEqual(unsetCurrentTask());
         done();
       });
     });
 
     it('should NOT dispatch unsetCurrentTask when isPauseTrackingDuringBreak is false', (done) => {
-      actions$ = of(actions.incrementCycle());
-      store.overrideSelector(selectors.selectMode, FocusModeMode.Pomodoro);
-      store.overrideSelector(selectors.selectCurrentCycle, 1);
+      actions$ = of(actions.startBreak({ pausedTaskId: 'task-123' }));
       store.overrideSelector(selectFocusModeConfig, {
         isSkipPreparation: false,
         isPauseTrackingDuringBreak: false,
@@ -2164,9 +2188,8 @@ describe('FocusModeEffects', () => {
       currentTaskId$.next('task-123');
       store.refreshState();
 
-      effects.autoStartBreakOnSessionComplete$.pipe(toArray()).subscribe((actionsArr) => {
-        const unsetAction = actionsArr.find((a) => a.type === '[Task] UnsetCurrentTask');
-        expect(unsetAction).toBeUndefined();
+      effects.pauseTrackingOnBreakStart$.pipe(toArray()).subscribe((actionsArr) => {
+        expect(actionsArr).toEqual([]);
         done();
       });
     });
@@ -2663,6 +2686,7 @@ describe('FocusModeEffects', () => {
       it('should handle Pomodoro mode break correctly', (done) => {
         store.overrideSelector(selectFocusModeConfig, {
           isSkipPreparation: false,
+          isPauseTrackingDuringBreak: false,
         });
         store.overrideSelector(selectors.selectMode, FocusModeMode.Pomodoro);
         store.overrideSelector(

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -136,7 +136,8 @@ export class FocusModeEffects {
     ),
   );
 
-  // Sync: When tracking stops → pause focus session (both work and break)
+  // Sync: When tracking stops → pause focus session (work, plus breaks while
+  // tracking is expected to continue during breaks)
   // Uses pairwise to capture the previous task ID before it's lost
   // Only triggers when focus mode feature is enabled
   // Bug #5954 fix: Also pause breaks when tracking stops
@@ -150,14 +151,18 @@ export class FocusModeEffects {
       withLatestFrom(
         this.store.select(selectors.selectTimer),
         this.store.select(selectIsFocusModeEnabled),
+        this.store.select(selectFocusModeConfig),
       ),
       filter(
-        ([[prevTaskId, currTaskId], timer, isFocusModeEnabled]) =>
+        ([[prevTaskId, currTaskId], timer, isFocusModeEnabled, config]) =>
           isFocusModeEnabled &&
           (timer.purpose === 'work' || timer.purpose === 'break') &&
           timer.isRunning &&
           !!prevTaskId &&
-          !currTaskId, // Was tracking (prevTaskId exists) and now stopped (currTaskId is null)
+          !currTaskId &&
+          // If tracking is intentionally paused for breaks, the app's own
+          // unsetCurrentTask after startBreak must not pause the new break.
+          !(timer.purpose === 'break' && config?.isPauseTrackingDuringBreak),
       ),
       map(([[prevTaskId]]) => actions.pauseFocusSession({ pausedTaskId: prevTaskId })),
     ),
@@ -376,11 +381,6 @@ export class FocusModeEffects {
         const shouldPauseTracking = config?.isPauseTrackingDuringBreak && currentTaskId;
         const actionsArr: Action[] = [];
 
-        // Pause tracking during break if configured
-        if (shouldPauseTracking) {
-          actionsArr.push(unsetCurrentTask());
-        }
-
         // Start break with appropriate duration
         if (breakInfo) {
           actionsArr.push(
@@ -401,6 +401,21 @@ export class FocusModeEffects {
 
         return of(...actionsArr);
       }),
+    ),
+  );
+
+  pauseTrackingOnBreakStart$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(actions.startBreak),
+      withLatestFrom(
+        this.store.select(selectFocusModeConfig),
+        this.taskService.currentTaskId$,
+      ),
+      filter(
+        ([_action, config, currentTaskId]) =>
+          !!config?.isPauseTrackingDuringBreak && !!currentTaskId,
+      ),
+      map(() => unsetCurrentTask()),
     ),
   );
 


### PR DESCRIPTION
Fixes #4152.

## Summary
- start Pomodoro/Flowtime breaks before clearing the active task when break tracking pause is enabled
- move the tracking pause into a `startBreak` effect so break state is already active before `unsetCurrentTask()` fires
- keep tracking-stop sync from immediately pausing a running break when tracking was intentionally paused for that break

## Validation
- npm run checkFile src/app/features/focus-mode/focus-mode-break/focus-mode-break.component.ts
- npm run checkFile src/app/features/focus-mode/focus-mode-break/focus-mode-break.component.spec.ts
- npm run checkFile src/app/features/focus-mode/store/focus-mode.effects.ts
- npm run checkFile src/app/features/focus-mode/store/focus-mode.effects.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/focus-mode/store/focus-mode.effects.spec.ts -- --include='src/app/features/focus-mode/focus-mode-break/focus-mode-break.component.spec.ts'
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/focus-mode/store/focus-mode.bug-5995.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/focus-mode/store/focus-mode.bug-6064.spec.ts
- git diff --check
- push hook: full lint, package tests, release-notes tests, default Angular suite, and LA timezone Angular suite passed