### PR TITLE
fix(nextcloud-deck): load cards when stacks omit them

### DIFF
--- a/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.spec.ts
+++ b/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.spec.ts
@@ -1,0 +1,196 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { NextcloudDeckApiService } from './nextcloud-deck-api.service';
+import { SnackService } from '../../../../core/snack/snack.service';
+import { NextcloudDeckCfg } from './nextcloud-deck.model';
+
+describe('NextcloudDeckApiService', () => {
+  let service: NextcloudDeckApiService;
+  let httpMock: HttpTestingController;
+
+  const baseUrl = 'https://cloud.example.com/index.php/apps/deck/api/v1.0';
+  const mockCfg: NextcloudDeckCfg = {
+    isEnabled: true,
+    nextcloudBaseUrl: 'https://cloud.example.com',
+    username: 'user',
+    password: 'pass',
+    selectedBoardId: 10,
+    selectedBoardTitle: 'Board',
+    importStackIds: null,
+    doneStackId: 30,
+    isTransitionIssuesEnabled: true,
+    filterByAssignee: false,
+    titleTemplate: null,
+    pollIntervalMinutes: 5,
+  };
+
+  const card = {
+    id: 7,
+    title: 'Important Card',
+    description: 'Details',
+    duedate: null,
+    lastModified: 1710000000,
+    archived: false,
+    done: false,
+    order: 1,
+    labels: [{ id: 1, title: 'Bug', color: 'ff0000' }],
+    assignedUsers: [{ participant: { uid: 'user', displayname: 'User' } }],
+  };
+
+  beforeEach(() => {
+    const snackServiceSpy = jasmine.createSpyObj('SnackService', ['open']);
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        NextcloudDeckApiService,
+        {
+          provide: SnackService,
+          useValue: snackServiceSpy,
+        },
+      ],
+    });
+
+    service = TestBed.inject(NextcloudDeckApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('searchOpenCards$', () => {
+    it('fetches stack details when the stacks response omits cards', (done) => {
+      service.searchOpenCards$('important', mockCfg).subscribe((results) => {
+        expect(results.length).toBe(1);
+        expect(results[0].title).toBe('Important Card');
+        expect(results[0].issueData).toEqual(
+          jasmine.objectContaining({
+            id: 7,
+            title: 'Important Card',
+            stackId: 20,
+            stackTitle: 'To do',
+          }),
+        );
+        done();
+      });
+
+      const stacksReq = httpMock.expectOne(`${baseUrl}/boards/10/stacks`);
+      expect(stacksReq.request.method).toBe('GET');
+      stacksReq.flush([
+        {
+          id: 20,
+          title: 'To do',
+          boardId: 10,
+        },
+        {
+          id: 30,
+          title: 'Done',
+          boardId: 10,
+        },
+      ]);
+
+      const stackReq = httpMock.expectOne(`${baseUrl}/boards/10/stacks/20`);
+      expect(stackReq.request.method).toBe('GET');
+      stackReq.flush({
+        id: 20,
+        title: 'To do',
+        boardId: 10,
+        cards: [card],
+      });
+    });
+
+    it('does not refetch stacks that already contain cards', (done) => {
+      service.searchOpenCards$('important', mockCfg).subscribe((results) => {
+        expect(results.length).toBe(1);
+        done();
+      });
+
+      const stacksReq = httpMock.expectOne(`${baseUrl}/boards/10/stacks`);
+      stacksReq.flush([
+        {
+          id: 20,
+          title: 'To do',
+          boardId: 10,
+          cards: [card],
+        },
+      ]);
+
+      httpMock.expectNone(`${baseUrl}/boards/10/stacks/20`);
+    });
+
+    it('only fetches configured import stacks when cards are missing', (done) => {
+      service
+        .searchOpenCards$('important', {
+          ...mockCfg,
+          importStackIds: [20],
+          doneStackId: null,
+        })
+        .subscribe((results) => {
+          expect(results.length).toBe(1);
+          done();
+        });
+
+      const stacksReq = httpMock.expectOne(`${baseUrl}/boards/10/stacks`);
+      stacksReq.flush([
+        {
+          id: 20,
+          title: 'To do',
+          boardId: 10,
+        },
+        {
+          id: 40,
+          title: 'Later',
+          boardId: 10,
+        },
+      ]);
+
+      const stackReq = httpMock.expectOne(`${baseUrl}/boards/10/stacks/20`);
+      stackReq.flush({
+        id: 20,
+        title: 'To do',
+        boardId: 10,
+        cards: [card],
+      });
+      httpMock.expectNone(`${baseUrl}/boards/10/stacks/40`);
+    });
+  });
+
+  describe('getById$', () => {
+    it('fetches stack details before looking up a card by id', (done) => {
+      service.getById$(7, mockCfg).subscribe((issue) => {
+        expect(issue).toEqual(
+          jasmine.objectContaining({
+            id: 7,
+            title: 'Important Card',
+            description: 'Details',
+            stackId: 20,
+            stackTitle: 'To do',
+            boardId: 10,
+          }),
+        );
+        done();
+      });
+
+      const stacksReq = httpMock.expectOne(`${baseUrl}/boards/10/stacks`);
+      stacksReq.flush([
+        {
+          id: 20,
+          title: 'To do',
+          boardId: 10,
+        },
+      ]);
+
+      const stackReq = httpMock.expectOne(`${baseUrl}/boards/10/stacks/20`);
+      stackReq.flush({
+        id: 20,
+        title: 'To do',
+        boardId: 10,
+        cards: [card],
+      });
+    });
+  });
+});

--- a/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.ts
+++ b/src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable, from, throwError } from 'rxjs';
-import { catchError, map, first } from 'rxjs/operators';
+import { Observable, forkJoin, from, of, throwError } from 'rxjs';
+import { catchError, first, map, switchMap } from 'rxjs/operators';
 import { NextcloudDeckCfg } from './nextcloud-deck.model';
 import {
   NextcloudDeckIssue,
@@ -39,7 +39,7 @@ interface DeckStackResponse {
   id: number;
   title: string;
   boardId: number;
-  cards: DeckCardResponse[];
+  cards?: DeckCardResponse[] | null;
 }
 
 @Injectable({
@@ -65,6 +65,18 @@ export class NextcloudDeckApiService {
     const url = `${this._getBaseUrl(cfg)}/boards/${boardId}/stacks`;
     return this._http
       .get<DeckStackResponse[]>(url, { headers: this._getHeaders(cfg) })
+      .pipe(catchError((err) => this._handleError(err)));
+  }
+
+  getStack$(
+    cfg: NextcloudDeckCfg,
+    boardId: number,
+    stackId: number,
+  ): Observable<DeckStackResponse> {
+    this._checkSettings(cfg);
+    const url = `${this._getBaseUrl(cfg)}/boards/${boardId}/stacks/${stackId}`;
+    return this._http
+      .get<DeckStackResponse>(url, { headers: this._getHeaders(cfg) })
       .pipe(catchError((err) => this._handleError(err)));
   }
 
@@ -123,6 +135,7 @@ export class NextcloudDeckApiService {
       }));
     }
     return this.getStacks$(cfg, boardId).pipe(
+      switchMap((stacks) => this._getStacksWithCards$(cfg, boardId, stacks, true)),
       map((stacks) => this._mapStacksToCards(stacks, cfg)),
     );
   }
@@ -187,14 +200,7 @@ export class NextcloudDeckApiService {
   ): NextcloudDeckIssueReduced[] {
     const results: NextcloudDeckIssueReduced[] = [];
     for (const stack of stacks) {
-      if (
-        cfg.importStackIds &&
-        cfg.importStackIds.length > 0 &&
-        !cfg.importStackIds.includes(stack.id)
-      ) {
-        continue;
-      }
-      if (cfg.doneStackId && stack.id === cfg.doneStackId) {
+      if (!this._isImportStack(stack, cfg)) {
         continue;
       }
       if (!stack.cards) {
@@ -253,9 +259,8 @@ export class NextcloudDeckApiService {
     boardId: number,
     cardId: number,
   ): Promise<NextcloudDeckIssue | null> {
-    const url = `${this._getBaseUrl(cfg)}/boards/${boardId}/stacks`;
-    const stacks = await this._http
-      .get<DeckStackResponse[]>(url, { headers: this._getHeaders(cfg) })
+    const stacks = await this.getStacks$(cfg, boardId)
+      .pipe(switchMap((res) => this._getStacksWithCards$(cfg, boardId, res)))
       .pipe(first())
       .toPromise();
     if (!stacks) {
@@ -272,6 +277,50 @@ export class NextcloudDeckApiService {
       }
     }
     return null;
+  }
+
+  private _getStacksWithCards$(
+    cfg: NextcloudDeckCfg,
+    boardId: number,
+    stacks: DeckStackResponse[],
+    onlyImportStacks = false,
+  ): Observable<DeckStackResponse[]> {
+    const stacksWithoutCards = stacks.filter(
+      (stack) =>
+        (!onlyImportStacks || this._isImportStack(stack, cfg)) &&
+        !Array.isArray(stack.cards),
+    );
+
+    if (stacksWithoutCards.length === 0) {
+      return of(stacks);
+    }
+
+    return forkJoin(
+      stacksWithoutCards.map((stack) => this.getStack$(cfg, boardId, stack.id)),
+    ).pipe(
+      map((stackDetails) => {
+        const stackDetailsById = new Map(stackDetails.map((stack) => [stack.id, stack]));
+        return stacks.map((stack) =>
+          Array.isArray(stack.cards)
+            ? stack
+            : {
+                ...stack,
+                cards: stackDetailsById.get(stack.id)?.cards || [],
+              },
+        );
+      }),
+    );
+  }
+
+  private _isImportStack(stack: DeckStackResponse, cfg: NextcloudDeckCfg): boolean {
+    if (
+      cfg.importStackIds &&
+      cfg.importStackIds.length > 0 &&
+      !cfg.importStackIds.includes(stack.id)
+    ) {
+      return false;
+    }
+    return !(cfg.doneStackId && stack.id === cfg.doneStackId);
   }
 
   private _checkSettings(cfg: NextcloudDeckCfg): void {


### PR DESCRIPTION
Fixes #7299.

## Summary
- keep loading Nextcloud Deck stacks as before, but fetch stack details when the stack list omits `cards`
- limit search/auto-import fallback requests to configured import stacks and skip done stacks
- let `getById$` fetch missing stack details across the board so already-linked cards can refresh even outside import stacks
- add focused coverage for missing-card stack responses, existing embedded-card fast path, import-stack filtering, and card lookup by id

## Validation
- npm run checkFile src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.ts
- npm run checkFile src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/nextcloud-deck/nextcloud-deck-api.service.spec.ts
- git diff --check