### PR TITLE
fix(trello): include workspace boards in picker

### DIFF
--- a/src/app/features/issue/providers/trello/trello-api.service.spec.ts
+++ b/src/app/features/issue/providers/trello/trello-api.service.spec.ts
@@ -112,6 +112,103 @@ describe('TrelloApiService', () => {
     });
   });
 
+  describe('getBoards$', () => {
+    it('should include open boards from Trello organizations', (done) => {
+      service.getBoards$(mockCfg).subscribe((boards) => {
+        expect(boards).toEqual([
+          { id: 'member-board', name: 'Member Board' },
+          { id: 'shared-board', name: 'Shared Board from Member List' },
+          { id: 'org-board', name: 'Organization Board' },
+        ]);
+        done();
+      });
+
+      const memberBoardsReq = httpMock.expectOne(
+        (request) => request.url === 'https://api.trello.com/1/members/me/boards',
+      );
+      expect(memberBoardsReq.request.params.get('filter')).toBe('open');
+      expect(memberBoardsReq.request.params.get('fields')).toBe('name,id');
+      memberBoardsReq.flush([
+        { id: 'member-board', name: 'Member Board' },
+        { id: 'shared-board', name: 'Shared Board from Member List' },
+      ]);
+
+      const organizationsReq = httpMock.expectOne(
+        (request) => request.url === 'https://api.trello.com/1/members/me/organizations',
+      );
+      expect(organizationsReq.request.params.get('fields')).toBe('id');
+      organizationsReq.flush([{ id: 'org-1' }]);
+
+      const organizationBoardsReq = httpMock.expectOne(
+        (request) =>
+          request.url === 'https://api.trello.com/1/organizations/org-1/boards',
+      );
+      expect(organizationBoardsReq.request.params.get('filter')).toBe('open');
+      expect(organizationBoardsReq.request.params.get('fields')).toBe('name,id');
+      organizationBoardsReq.flush([
+        { id: 'shared-board', name: 'Duplicate Organization Board' },
+        { id: 'org-board', name: 'Organization Board' },
+      ]);
+    });
+
+    it('should keep member boards if organization lookup fails', (done) => {
+      service.getBoards$(mockCfg).subscribe((boards) => {
+        expect(boards).toEqual([{ id: 'member-board', name: 'Member Board' }]);
+        expect(snackService.open).not.toHaveBeenCalled();
+        done();
+      });
+
+      const memberBoardsReq = httpMock.expectOne(
+        (request) => request.url === 'https://api.trello.com/1/members/me/boards',
+      );
+      memberBoardsReq.flush([{ id: 'member-board', name: 'Member Board' }]);
+
+      const organizationsReq = httpMock.expectOne(
+        (request) => request.url === 'https://api.trello.com/1/members/me/organizations',
+      );
+      organizationsReq.flush(
+        { error: 'Unauthorized' },
+        { status: 401, statusText: 'Unauthorized' },
+      );
+    });
+
+    it('should keep other boards if one organization boards request fails', (done) => {
+      service.getBoards$(mockCfg).subscribe((boards) => {
+        expect(boards).toEqual([
+          { id: 'member-board', name: 'Member Board' },
+          { id: 'org-board', name: 'Organization Board' },
+        ]);
+        expect(snackService.open).not.toHaveBeenCalled();
+        done();
+      });
+
+      const memberBoardsReq = httpMock.expectOne(
+        (request) => request.url === 'https://api.trello.com/1/members/me/boards',
+      );
+      memberBoardsReq.flush([{ id: 'member-board', name: 'Member Board' }]);
+
+      const organizationsReq = httpMock.expectOne(
+        (request) => request.url === 'https://api.trello.com/1/members/me/organizations',
+      );
+      organizationsReq.flush([{ id: 'org-1' }, { id: 'org-2' }]);
+
+      const org1BoardsReq = httpMock.expectOne(
+        (request) =>
+          request.url === 'https://api.trello.com/1/organizations/org-1/boards',
+      );
+      org1BoardsReq.flush([{ id: 'org-board', name: 'Organization Board' }]);
+
+      const org2BoardsReq = httpMock.expectOne(
+        (request) =>
+          request.url === 'https://api.trello.com/1/organizations/org-2/boards',
+      );
+      org2BoardsReq.flush(
+        { error: 'Forbidden' },
+        { status: 403, statusText: 'Forbidden' },
+      );
+    });
+  });
+
   describe('configuration validation', () => {
     it('should throw error when apiKey is missing', () => {
       const invalidCfg = { ...mockCfg, apiKey: null };

--- a/src/app/features/issue/providers/trello/trello-api.service.ts
+++ b/src/app/features/issue/providers/trello/trello-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
-import { Observable, throwError, of } from 'rxjs';
+import { forkJoin, Observable, throwError, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { TrelloCfg } from './trello.model';
 import { SnackService } from '../../../../core/snack/snack.service';
@@ -47,6 +47,20 @@ const DEFAULT_ATTACHMENT_FIELDS = [
   'idMember',
 ].join(',');
 const DEFAULT_MEMBER_FIELDS = ['fullName', 'username', 'avatarUrl'].join(',');
+const BOARD_LIST_FIELDS = 'name,id';
+const BOARD_LIST_PARAMS = {
+  filter: 'open',
+  fields: BOARD_LIST_FIELDS,
+} as const;
+
+interface TrelloBoardResponse {
+  id: string;
+  name: string;
+}
+
+interface TrelloOrganizationResponse {
+  id: string;
+}
 
 @Injectable({
   providedIn: 'root',
@@ -125,12 +139,47 @@ export class TrelloApiService {
     );
   }
 
-  // list all projects from user
-  getBoards$(cfg: TrelloCfg): Observable<any> {
-    return this._request$('/members/me/boards', cfg, {
-      filter: 'open',
-      fields: 'name,id',
-    });
+  getBoards$(cfg: TrelloCfg): Observable<TrelloBoardResponse[]> {
+    return this._request$<TrelloBoardResponse[]>(
+      '/members/me/boards',
+      cfg,
+      BOARD_LIST_PARAMS,
+    ).pipe(
+      switchMap((memberBoards) =>
+        this._requestRaw$<TrelloOrganizationResponse[]>(
+          '/members/me/organizations',
+          cfg,
+          {
+            fields: 'id',
+          },
+        ).pipe(
+          catchError(() => of<TrelloOrganizationResponse[]>([])),
+          switchMap((organizations) => {
+            const organizationIds = Array.from(
+              new Set((organizations || []).map((organization) => organization.id)),
+            ).filter(Boolean);
+
+            if (organizationIds.length === 0) {
+              return of(this._mergeUniqueBoards(memberBoards));
+            }
+
+            return forkJoin(
+              organizationIds.map((organizationId) =>
+                this._requestRaw$<TrelloBoardResponse[]>(
+                  `/organizations/${organizationId}/boards`,
+                  cfg,
+                  BOARD_LIST_PARAMS,
+                ).pipe(catchError(() => of<TrelloBoardResponse[]>([]))),
+              ),
+            ).pipe(
+              map((organizationBoards) =>
+                this._mergeUniqueBoards([...memberBoards, ...organizationBoards.flat()]),
+              ),
+            );
+          }),
+        ),
+      ),
+    );
   }
 
   getCurrentMemberId$(username: string, cfg: TrelloCfg): Observable<string> {
@@ -215,13 +264,34 @@ export class TrelloApiService {
     cfg: TrelloCfg,
     params?: Record<string, unknown>,
   ): Observable<T> {
+    return this._requestRaw$<T>(path, cfg, params).pipe(
+      catchError((err) => this._handleError$(err)),
+    );
+  }
+
+  private _requestRaw$<T>(
+    path: string,
+    cfg: TrelloCfg,
+    params?: Record<string, unknown>,
+  ): Observable<T> {
     this._checkSettings(cfg);
     const httpParams = this._createParams(cfg, params);
-    return this._http
-      .get<T>(`${BASE_URL}${path}`, {
-        params: httpParams,
-      })
-      .pipe(catchError((err) => this._handleError$(err)));
+    return this._http.get<T>(`${BASE_URL}${path}`, {
+      params: httpParams,
+    });
+  }
+
+  private _mergeUniqueBoards(boards: TrelloBoardResponse[] = []): TrelloBoardResponse[] {
+    const boardsById = new Map<string, TrelloBoardResponse>();
+
+    boards.forEach((board) => {
+      if (!board?.id || boardsById.has(board.id)) {
+        return;
+      }
+      boardsById.set(board.id, board);
+    });
+
+    return Array.from(boardsById.values());
   }
 
   private _createParams(cfg: TrelloCfg, params?: Record<string, unknown>): HttpParams {


### PR DESCRIPTION
Fixes #7317.

## Summary
- keep loading direct member boards, then best-effort load the user's Trello organizations
- include open boards from each organization in the board picker
- dedupe boards by id and keep direct member boards if organization lookup or a single organization board request fails
- add focused coverage for organization boards, deduplication, and graceful fallback paths

## Validation
- npm run checkFile src/app/features/issue/providers/trello/trello-api.service.ts
- npm run checkFile src/app/features/issue/providers/trello/trello-api.service.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/trello/trello-api.service.spec.ts
- git diff --check