### PR TITLE
fix(tasks): open task menu with native menu key

### DIFF
--- a/src/app/features/tasks/task-shortcut.service.spec.ts
+++ b/src/app/features/tasks/task-shortcut.service.spec.ts
@@ -312,6 +312,63 @@ describe('TaskShortcutService', () => {
       expect(mockTaskComponent.openDeadlineDialog).toHaveBeenCalled();
     });
 
+    it('should open the task context menu when the native Menu key is pressed', () => {
+      const mockTaskComponent = {
+        task: () => ({ id: 'focused-task-1' }),
+        openContextMenu: jasmine.createSpy('openContextMenu'),
+        taskContextMenu: () => undefined,
+      };
+      mockTaskFocusService.focusedTaskId.set('focused-task-1');
+      mockTaskFocusService.lastFocusedTaskComponent.set(mockTaskComponent);
+
+      const event = createKeyboardEvent('ContextMenu', 'ContextMenu');
+      spyOn(event, 'preventDefault');
+
+      const result = service.handleTaskShortcuts(event);
+
+      expect(result).toBe(true);
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(mockTaskComponent.openContextMenu).toHaveBeenCalledWith(event);
+    });
+
+    it('should recognize Linux Menu key events by physical ContextMenu code', () => {
+      const mockTaskComponent = {
+        task: () => ({ id: 'focused-task-1' }),
+        openContextMenu: jasmine.createSpy('openContextMenu'),
+        taskContextMenu: () => undefined,
+      };
+      mockTaskFocusService.focusedTaskId.set('focused-task-1');
+      mockTaskFocusService.lastFocusedTaskComponent.set(mockTaskComponent);
+
+      const event = createKeyboardEvent('Unidentified', 'ContextMenu');
+      spyOn(event, 'preventDefault');
+
+      const result = service.handleTaskShortcuts(event);
+
+      expect(result).toBe(true);
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(mockTaskComponent.openContextMenu).toHaveBeenCalledWith(event);
+    });
+
+    it('should not treat modified Menu key presses as the native context menu key', () => {
+      const mockTaskComponent = {
+        task: () => ({ id: 'focused-task-1' }),
+        openContextMenu: jasmine.createSpy('openContextMenu'),
+        taskContextMenu: () => undefined,
+      };
+      mockTaskFocusService.focusedTaskId.set('focused-task-1');
+      mockTaskFocusService.lastFocusedTaskComponent.set(mockTaskComponent);
+
+      const event = createKeyboardEvent('ContextMenu', 'ContextMenu', {
+        ctrlKey: true,
+      });
+
+      const result = service.handleTaskShortcuts(event);
+
+      expect(result).toBe(false);
+      expect(mockTaskComponent.openContextMenu).not.toHaveBeenCalled();
+    });
+
     it('should return false for non-togglePlay shortcuts when no focused task', () => {
       // Arrange
       mockTaskFocusService.focusedTaskId.set(null);

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -11,6 +11,13 @@ import { isInputElement } from '../../util/dom-element';
 
 type TaskId = string;
 
+const isNativeContextMenuKey = (ev: KeyboardEvent): boolean =>
+  !ev.ctrlKey &&
+  !ev.altKey &&
+  !ev.metaKey &&
+  !ev.shiftKey &&
+  (ev.key === 'ContextMenu' || ev.key === 'Menu' || ev.code === 'ContextMenu');
+
 /**
  * Available methods on the task component for keyboard shortcut delegation.
  * These correspond to actual methods implemented in the TaskComponent.
@@ -208,7 +215,7 @@ export class TaskShortcutService {
     }
 
     // Toggle context menu
-    if (checkKeyCombo(ev, keys.taskOpenContextMenu)) {
+    if (checkKeyCombo(ev, keys.taskOpenContextMenu) || isNativeContextMenuKey(ev)) {
       this._handleTaskShortcut(focusedTaskId, 'openContextMenu', ev);
       ev.preventDefault();
       return true;


### PR DESCRIPTION
## Summary
- handle the keyboard Menu/ContextMenu key as a task action-menu shortcut
- support browser and Linux-style ContextMenu key event shapes
- ignore modified Menu key presses so configured shortcuts keep their normal behavior

Fixes #6670

## Test plan
- npm run checkFile src/app/features/tasks/task-shortcut.service.ts
- npm run checkFile src/app/features/tasks/task-shortcut.service.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/tasks/task-shortcut.service.spec.ts
- git diff --check HEAD~1..HEAD