### PR TITLE
fix(jira): paginate auto-import search

### DIFF
--- a/src/app/features/issue/providers/jira/jira-api.service.spec.ts
+++ b/src/app/features/issue/providers/jira/jira-api.service.spec.ts
@@ -7,7 +7,7 @@ import { SnackService } from '../../../../core/snack/snack.service';
 import { GlobalProgressBarService } from '../../../../core-ui/global-progress-bar/global-progress-bar.service';
 import { BannerService } from '../../../../core/banner/banner.service';
 import { MatDialog } from '@angular/material/dialog';
-import { DEFAULT_JIRA_CFG } from './jira.const';
+import { DEFAULT_JIRA_CFG, JIRA_MAX_AUTO_IMPORT_PAGES } from './jira.const';
 import { JiraCfg } from './jira.model';
 import { formatJiraDate } from '../../../../util/format-jira-date';
 import { JiraIssueOriginal } from './jira-api-responses';
@@ -389,6 +389,36 @@ describe('JiraApiService', () => {
       });
     });
 
+    it('caps Jira Cloud auto-import pagination', (done) => {
+      fetchSpy.and.returnValues(
+        ...Array.from({ length: JIRA_MAX_AUTO_IMPORT_PAGES + 1 }, (_, index) =>
+          jsonResponse({
+            issues: [makeJiraIssue(`TEST-${index + 1}`)],
+            maxResults: 100,
+            nextPageToken: `token-${index + 2}`,
+          }),
+        ),
+      );
+
+      service.findAutoImportIssues$(cfg).subscribe({
+        next: (issues) => {
+          expect(issues.map((issue) => issue.key)).toEqual([
+            'TEST-1',
+            'TEST-2',
+            'TEST-3',
+            'TEST-4',
+            'TEST-5',
+          ]);
+          expect(fetchSpy).toHaveBeenCalledTimes(JIRA_MAX_AUTO_IMPORT_PAGES);
+          expect(requestBodyAt(fetchSpy, JIRA_MAX_AUTO_IMPORT_PAGES - 1)).toEqual(
+            jasmine.objectContaining({ nextPageToken: 'token-5' }),
+          );
+          done();
+        },
+        error: done.fail,
+      });
+    });
+
     it('falls back to Jira Server/DC search pages via startAt', (done) => {
       fetchSpy.and.returnValues(
         jsonResponse({ errorMessages: ['not found'] }, 404),
@@ -430,6 +460,40 @@ describe('JiraApiService', () => {
           );
           expect(requestBodyAt(fetchSpy, 3)).toEqual(
             jasmine.objectContaining({ startAt: 200 }),
+          );
+          done();
+        },
+        error: done.fail,
+      });
+    });
+
+    it('caps Jira Server/DC auto-import pagination', (done) => {
+      fetchSpy.and.returnValues(
+        jsonResponse({ errorMessages: ['not found'] }, 404),
+        ...Array.from({ length: JIRA_MAX_AUTO_IMPORT_PAGES + 1 }, (_, index) => {
+          const startAt = index * 100;
+          const issueNumber = startAt + 1;
+          return jsonResponse({
+            issues: [makeJiraIssue(`TEST-${issueNumber}`)],
+            maxResults: 100,
+            startAt,
+            total: 1000,
+          });
+        }),
+      );
+
+      service.findAutoImportIssues$(cfg).subscribe({
+        next: (issues) => {
+          expect(issues.map((issue) => issue.key)).toEqual([
+            'TEST-1',
+            'TEST-101',
+            'TEST-201',
+            'TEST-301',
+            'TEST-401',
+          ]);
+          expect(fetchSpy).toHaveBeenCalledTimes(JIRA_MAX_AUTO_IMPORT_PAGES + 1);
+          expect(requestBodyAt(fetchSpy, JIRA_MAX_AUTO_IMPORT_PAGES)).toEqual(
+            jasmine.objectContaining({ startAt: 400 }),
           );
           done();
         },

--- a/src/app/features/issue/providers/jira/jira-api.service.spec.ts
+++ b/src/app/features/issue/providers/jira/jira-api.service.spec.ts
@@ -10,6 +10,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { DEFAULT_JIRA_CFG } from './jira.const';
 import { JiraCfg } from './jira.model';
 import { formatJiraDate } from '../../../../util/format-jira-date';
+import { JiraIssueOriginal } from './jira-api-responses';
 
 const makeMockExtensionService = (
   onReady$: Subject<boolean> | ReplaySubject<boolean>,
@@ -56,6 +57,44 @@ const baseCfg: JiraCfg = {
   userName: 'user',
   password: 'pass',
 };
+
+const makeJiraIssue = (key: string): JiraIssueOriginal => ({
+  key,
+  id: key.replace(/\D/g, '') || key,
+  expand: '',
+  self: `https://jira.example.com/rest/api/latest/issue/${key}`,
+  fields: {
+    summary: `Summary ${key}`,
+    components: [],
+    attachment: [],
+    timeestimate: 0,
+    timespent: 0,
+    description: null,
+    assignee: null as any,
+    updated: '2026-06-08T00:00:00.000+0000',
+    status: {
+      self: '',
+      id: '1',
+      description: '',
+      iconUrl: '',
+      name: 'Open',
+      statusCategory: {
+        self: '',
+        id: '1',
+        key: 'new',
+        colorName: 'blue-gray',
+        name: 'To Do',
+      },
+    },
+    issuelinks: [],
+  },
+});
+
+const jsonResponse = (body: unknown, status = 200): Promise<Response> =>
+  Promise.resolve(new Response(JSON.stringify(body), { status }));
+
+const requestBodyAt = (fetchSpy: jasmine.Spy, index: number): Record<string, unknown> =>
+  JSON.parse((fetchSpy.calls.argsFor(index)[1] as RequestInit).body as string);
 
 describe('JiraApiService', () => {
   describe('addWorklog$ date formatting', () => {
@@ -288,6 +327,114 @@ describe('JiraApiService', () => {
       );
 
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAutoImportIssues$ pagination', () => {
+    let service: JiraApiService;
+    let fetchSpy: jasmine.Spy;
+    const cfg = {
+      ...baseCfg,
+      allowFetchFallback: true,
+      autoAddBacklogJqlQuery: 'project = TEST ORDER BY updated DESC',
+    };
+
+    beforeEach(() => {
+      service = setupService(new Subject<boolean>());
+      fetchSpy = spyOn(window, 'fetch');
+    });
+
+    it('fetches all Jira Cloud search/jql pages via nextPageToken', (done) => {
+      fetchSpy.and.returnValues(
+        jsonResponse({
+          issues: [makeJiraIssue('TEST-1')],
+          maxResults: 100,
+          nextPageToken: 'token-2',
+        }),
+        jsonResponse({
+          issues: [makeJiraIssue('TEST-2')],
+          maxResults: 100,
+          nextPageToken: 'token-3',
+        }),
+        jsonResponse({
+          issues: [makeJiraIssue('TEST-3')],
+          maxResults: 100,
+        }),
+      );
+
+      service.findAutoImportIssues$(cfg).subscribe({
+        next: (issues) => {
+          expect(issues.map((issue) => issue.key)).toEqual([
+            'TEST-1',
+            'TEST-2',
+            'TEST-3',
+          ]);
+          expect(fetchSpy).toHaveBeenCalledTimes(3);
+          expect(String(fetchSpy.calls.argsFor(0)[0])).toContain('/search/jql');
+          expect(requestBodyAt(fetchSpy, 0)).toEqual(
+            jasmine.objectContaining({
+              jql: cfg.autoAddBacklogJqlQuery,
+              maxResults: 100,
+            }),
+          );
+          expect(requestBodyAt(fetchSpy, 1)).toEqual(
+            jasmine.objectContaining({ nextPageToken: 'token-2' }),
+          );
+          expect(requestBodyAt(fetchSpy, 2)).toEqual(
+            jasmine.objectContaining({ nextPageToken: 'token-3' }),
+          );
+          done();
+        },
+        error: done.fail,
+      });
+    });
+
+    it('falls back to Jira Server/DC search pages via startAt', (done) => {
+      fetchSpy.and.returnValues(
+        jsonResponse({ errorMessages: ['not found'] }, 404),
+        jsonResponse({
+          issues: [makeJiraIssue('TEST-1')],
+          maxResults: 100,
+          startAt: 0,
+          total: 250,
+        }),
+        jsonResponse({
+          issues: [makeJiraIssue('TEST-101')],
+          maxResults: 100,
+          startAt: 100,
+          total: 250,
+        }),
+        jsonResponse({
+          issues: [makeJiraIssue('TEST-201')],
+          maxResults: 100,
+          startAt: 200,
+          total: 250,
+        }),
+      );
+
+      service.findAutoImportIssues$(cfg).subscribe({
+        next: (issues) => {
+          expect(issues.map((issue) => issue.key)).toEqual([
+            'TEST-1',
+            'TEST-101',
+            'TEST-201',
+          ]);
+          expect(fetchSpy).toHaveBeenCalledTimes(4);
+          expect(String(fetchSpy.calls.argsFor(0)[0])).toContain('/search/jql');
+          expect(String(fetchSpy.calls.argsFor(1)[0])).toContain('/search');
+          expect(requestBodyAt(fetchSpy, 1)).not.toEqual(
+            jasmine.objectContaining({ startAt: jasmine.any(Number) }),
+          );
+          expect(requestBodyAt(fetchSpy, 2)).toEqual(
+            jasmine.objectContaining({ startAt: 100 }),
+          );
+          expect(requestBodyAt(fetchSpy, 3)).toEqual(
+            jasmine.objectContaining({ startAt: 200 }),
+          );
+          done();
+        },
+        error: done.fail,
+      });
     });
   });
 });

--- a/src/app/features/issue/providers/jira/jira-api.service.ts
+++ b/src/app/features/issue/providers/jira/jira-api.service.ts
@@ -8,13 +8,14 @@ import {
 } from './jira.const';
 import {
   mapIssueResponse,
-  mapIssuesResponse,
   mapResponse,
   mapToSearchResults,
   mapToSearchResultsForJQL,
   mapTransitionResponse,
 } from './jira-issue-map.util';
 import {
+  JiraApiEnvelope,
+  JiraIssueOriginal,
   JiraOriginalStatus,
   JiraOriginalTransition,
   JiraOriginalUser,
@@ -30,6 +31,7 @@ import {
   concatMap,
   finalize,
   first,
+  map,
   mapTo,
   shareReplay,
   take,
@@ -84,6 +86,15 @@ interface JiraRequestCfg {
   transform?: (res: any, jiraCfg: JiraCfg) => unknown;
   body?: Record<string, unknown>;
 }
+
+type JiraIssueSearchResponse = {
+  issues: JiraIssueOriginal[];
+  maxResults?: number;
+  startAt?: number;
+  total?: number;
+  isLast?: boolean;
+  nextPageToken?: string;
+};
 
 @Injectable({
   providedIn: 'root',
@@ -232,33 +243,27 @@ export class JiraApiService {
       });
     }
 
-    return this._sendRequest$({
-      jiraReqCfg: {
-        transform: mapIssuesResponse,
-        pathname: 'search/jql',
-        method: 'POST',
-        body: {
-          ...options,
-          jql: searchQuery,
-        },
-      },
+    return this._fetchAllJiraSearchPages$({
       cfg,
+      pathname: 'search/jql',
+      body: {
+        ...options,
+        jql: searchQuery,
+      },
+      isCloudJqlSearch: true,
       suppressErrorSnack: true,
     }).pipe(
       catchError((err) => {
         const code = extractHttpStatus(err);
         if (code === 401 || code === 403) return throwError(() => err);
         // Fallback for Server/DC: POST /search with jql in body
-        return this._sendRequest$({
-          jiraReqCfg: {
-            transform: mapIssuesResponse,
-            pathname: 'search',
-            method: 'POST',
-            body: { ...options, jql: searchQuery },
-          },
+        return this._fetchAllJiraSearchPages$({
           cfg,
+          pathname: 'search',
+          body: { ...options, jql: searchQuery },
         });
       }),
+      map((issues) => issues.map((issue) => mapIssueResponse({ response: issue }, cfg))),
     ) as Observable<JiraIssueReduced[]>;
   }
 
@@ -390,6 +395,152 @@ export class JiraApiService {
   // Complex Functions
 
   // --------
+  private _fetchAllJiraSearchPages$({
+    cfg,
+    pathname,
+    body,
+    isCloudJqlSearch = false,
+    suppressErrorSnack = false,
+  }: {
+    cfg: JiraCfg;
+    pathname: string;
+    body: Record<string, unknown>;
+    isCloudJqlSearch?: boolean;
+    suppressErrorSnack?: boolean;
+  }): Observable<JiraIssueOriginal[]> {
+    return this._fetchJiraSearchPage$({
+      cfg,
+      pathname,
+      body,
+      suppressErrorSnack,
+    }).pipe(
+      concatMap((firstPage) => {
+        return this._fetchRemainingJiraSearchPages$({
+          cfg,
+          pathname,
+          baseBody: body,
+          previousPage: firstPage,
+          isCloudJqlSearch,
+          suppressErrorSnack,
+        }).pipe(map((issues) => [...(firstPage.issues || []), ...issues]));
+      }),
+    );
+  }
+
+  private _fetchRemainingJiraSearchPages$({
+    cfg,
+    pathname,
+    baseBody,
+    previousPage,
+    isCloudJqlSearch,
+    suppressErrorSnack,
+  }: {
+    cfg: JiraCfg;
+    pathname: string;
+    baseBody: Record<string, unknown>;
+    previousPage: JiraIssueSearchResponse;
+    isCloudJqlSearch: boolean;
+    suppressErrorSnack: boolean;
+  }): Observable<JiraIssueOriginal[]> {
+    const nextPageBody = this._getNextJiraSearchPageBody({
+      previousPage,
+      baseBody,
+      isCloudJqlSearch,
+    });
+
+    if (!nextPageBody) {
+      return of([]);
+    }
+
+    return this._fetchJiraSearchPage$({
+      cfg,
+      pathname,
+      body: nextPageBody,
+      suppressErrorSnack,
+    }).pipe(
+      concatMap((page) =>
+        this._fetchRemainingJiraSearchPages$({
+          cfg,
+          pathname,
+          baseBody,
+          previousPage: page,
+          isCloudJqlSearch,
+          suppressErrorSnack,
+        }).pipe(map((issues) => [...(page.issues || []), ...issues])),
+      ),
+    );
+  }
+
+  private _fetchJiraSearchPage$({
+    cfg,
+    pathname,
+    body,
+    suppressErrorSnack,
+  }: {
+    cfg: JiraCfg;
+    pathname: string;
+    body: Record<string, unknown>;
+    suppressErrorSnack: boolean;
+  }): Observable<JiraIssueSearchResponse> {
+    return this._sendRequest$({
+      jiraReqCfg: {
+        pathname,
+        method: 'POST',
+        body,
+      },
+      cfg,
+      suppressErrorSnack,
+    }).pipe(
+      map(
+        (res) =>
+          ((res as JiraApiEnvelope<JiraIssueSearchResponse>).response ||
+            {}) as JiraIssueSearchResponse,
+      ),
+    );
+  }
+
+  private _getNextJiraSearchPageBody({
+    previousPage,
+    baseBody,
+    isCloudJqlSearch,
+  }: {
+    previousPage: JiraIssueSearchResponse;
+    baseBody: Record<string, unknown>;
+    isCloudJqlSearch: boolean;
+  }): Record<string, unknown> | null {
+    const maxResults =
+      typeof previousPage.maxResults === 'number'
+        ? previousPage.maxResults
+        : (baseBody.maxResults as number | undefined);
+    const issueCount = previousPage.issues?.length || 0;
+    const pageSize = Math.max(maxResults || issueCount || JIRA_MAX_RESULTS, 1);
+
+    if (isCloudJqlSearch) {
+      return previousPage.nextPageToken
+        ? {
+            ...baseBody,
+            nextPageToken: previousPage.nextPageToken,
+          }
+        : null;
+    }
+
+    if (
+      previousPage.total === undefined ||
+      previousPage.startAt === undefined ||
+      issueCount === 0
+    ) {
+      return null;
+    }
+
+    const startAt = previousPage.startAt + pageSize;
+    return startAt < previousPage.total
+      ? {
+          ...baseBody,
+          startAt,
+        }
+      : null;
+  }
+
   private _isInterfacesReadyIfNeeded$(cfg: JiraCfg): Observable<boolean> {
     if (IS_ELECTRON || IS_ANDROID_WEB_VIEW || cfg.allowFetchFallback) {
       return of(true);

--- a/src/app/features/issue/providers/jira/jira-api.service.ts
+++ b/src/app/features/issue/providers/jira/jira-api.service.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid';
 import { ChromeExtensionInterfaceService } from '../../../../core/chrome-extension-interface/chrome-extension-interface.service';
 import {
   JIRA_ADDITIONAL_ISSUE_FIELDS,
+  JIRA_MAX_AUTO_IMPORT_PAGES,
   JIRA_MAX_RESULTS,
   JIRA_REQUEST_TIMEOUT_DURATION,
 } from './jira.const';
@@ -422,6 +423,7 @@ export class JiraApiService {
           previousPage: firstPage,
           isCloudJqlSearch,
           suppressErrorSnack,
+          fetchedPages: 1,
         }).pipe(map((issues) => [...(firstPage.issues || []), ...issues]));
       }),
     );
@@ -434,6 +436,7 @@ export class JiraApiService {
     previousPage,
     isCloudJqlSearch,
     suppressErrorSnack,
+    fetchedPages,
   }: {
     cfg: JiraCfg;
     pathname: string;
@@ -441,7 +444,12 @@ export class JiraApiService {
     previousPage: JiraIssueSearchResponse;
     isCloudJqlSearch: boolean;
     suppressErrorSnack: boolean;
+    fetchedPages: number;
   }): Observable<JiraIssueOriginal[]> {
+    if (fetchedPages >= JIRA_MAX_AUTO_IMPORT_PAGES) {
+      return of([]);
+    }
+
     const nextPageBody = this._getNextJiraSearchPageBody({
       previousPage,
       baseBody,
@@ -466,6 +474,7 @@ export class JiraApiService {
           previousPage: page,
           isCloudJqlSearch,
           suppressErrorSnack,
+          fetchedPages: fetchedPages + 1,
         }).pipe(map((issues) => [...(page.issues || []), ...issues])),
       ),
     );

--- a/src/app/features/issue/providers/jira/jira.const.ts
+++ b/src/app/features/issue/providers/jira/jira.const.ts
@@ -58,6 +58,7 @@ export const JIRA_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSZZ';
 export const JIRA_ISSUE_TYPE = 'JIRA';
 export const JIRA_REQUEST_TIMEOUT_DURATION = 20000;
 export const JIRA_MAX_RESULTS = 100;
+export const JIRA_MAX_AUTO_IMPORT_PAGES = 5;
 export const JIRA_ADDITIONAL_ISSUE_FIELDS = [
   'assignee',
   'summary',


### PR DESCRIPTION
## Summary
- paginate Jira Cloud auto-import searches with search/jql nextPageToken
- paginate Jira Server/Data Center fallback searches with startAt/total
- keep mapping behavior unchanged after collecting all returned issue pages

Fixes #5578

## Test plan
- npm run checkFile src/app/features/issue/providers/jira/jira-api.service.ts
- npm run checkFile src/app/features/issue/providers/jira/jira-api.service.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/jira/jira-api.service.spec.ts
- git diff --check HEAD~1..HEAD