### PR TITLE
feat(calendar): add Google Calendar past sync window

### DIFF
--- a/docs/wiki/2.07-Manage-Task-Integrations.md
+++ b/docs/wiki/2.07-Manage-Task-Integrations.md
@@ -17,6 +17,10 @@ The **issue provider panel** (Integrations & Calendars) is a side panel that lis
 3. **For a calendar:** Under **Connect Calendar**, click **Google Calendar**, **Outlook 365**, or **iCal Other**. A configuration dialog opens (e.g. URL for iCal, or OAuth for Google/Outlook). Fill in the details and save.
 4. **For an issue provider:** Under **Setup Issue Provider**, click the provider you want: **Jira**, **Trello**, **GitHub**, **Redmine**, **GitLab**, **CalDAV**, **Open Project**, **Gitea**, **Linear**, or **ClickUp**. A configuration dialog opens. Enter the required fields (host URL, token or password, project/repo ID, etc. — the exact fields depend on the provider). Save to create the integration.
 
+Google Calendar normally syncs upcoming events only. In advanced configuration
+you can set **Past events range (weeks)** to keep a limited rolling history in
+the Schedule view.
+
 ### Calendar Integrations: iCal Vs CalDAV (e.g. Nextcloud)
 
 **iCal** and **CalDAV** are two different integrations and need **different link types**:

--- a/packages/plugin-dev/google-calendar-provider/src/plugin.spec.ts
+++ b/packages/plugin-dev/google-calendar-provider/src/plugin.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
-import type { IssueProviderPluginDefinition } from '@super-productivity/plugin-api';
+import type {
+  IssueProviderPluginDefinition,
+  PluginHttp,
+} from '@super-productivity/plugin-api';
 
 let definition: IssueProviderPluginDefinition;
 
@@ -39,6 +42,65 @@ describe('Google Calendar Plugin', () => {
       expect(oauthConfig?.scopes).not.toContain(
         'https://www.googleapis.com/auth/calendar.readonly',
       );
+    });
+  });
+
+  describe('calendar sync range', () => {
+    const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+    let mockHttp: PluginHttp;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'));
+      mockHttp = {
+        get: vi.fn().mockResolvedValue({ items: [] }),
+        post: vi.fn(),
+        put: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+        request: vi.fn(),
+      };
+    });
+
+    it('exposes an advanced past events range config field', () => {
+      const field = definition.configFields.find(
+        (configField) => configField.key === 'syncRangePastWeeks',
+      );
+
+      expect(field).toMatchObject({
+        type: 'input',
+        label: 'Past events range (weeks)',
+        required: false,
+        pattern: '^[0-9]*$',
+        advanced: true,
+      });
+    });
+
+    it('keeps the default Google Calendar query window forward-only', async () => {
+      await definition.getNewIssuesForBacklog!({}, mockHttp);
+
+      const [, options] = vi.mocked(mockHttp.get).mock.calls[0];
+      expect(options?.params?.timeMin).toBe('2026-06-01T12:00:00.000Z');
+      expect(options?.params?.timeMax).toBe(
+        new Date(Date.now() + 2 * MS_PER_WEEK).toISOString(),
+      );
+      expect(options?.params?.maxResults).toBe('100');
+    });
+
+    it('moves timeMin back by the configured past range and caps it at 12 weeks', async () => {
+      await definition.getNewIssuesForBacklog!(
+        { syncRangeWeeks: '3', syncRangePastWeeks: '20' },
+        mockHttp,
+      );
+
+      const [, options] = vi.mocked(mockHttp.get).mock.calls[0];
+      expect(options?.params?.timeMin).toBe(
+        new Date(Date.now() - 12 * MS_PER_WEEK).toISOString(),
+      );
+      expect(options?.params?.timeMax).toBe(
+        new Date(Date.now() + 3 * MS_PER_WEEK).toISOString(),
+      );
+      expect(options?.params?.maxResults).toBe('500');
     });
   });
 

--- a/packages/plugin-dev/google-calendar-provider/src/plugin.ts
+++ b/packages/plugin-dev/google-calendar-provider/src/plugin.ts
@@ -45,6 +45,7 @@ interface GoogleCalendarConfig {
   readCalendarIds?: string[];
   writeCalendarId?: string;
   syncRangeWeeks?: string;
+  syncRangePastWeeks?: string;
   showDeclinedEvents?: boolean;
   isAutoTimeBlock?: boolean;
   timeBlockCalendarId?: string;
@@ -190,6 +191,11 @@ const isHttpStatus = (err: unknown, status: number): boolean =>
 
 const RATE_LIMIT_REASONS = new Set(['rateLimitExceeded', 'userRateLimitExceeded']);
 const RATE_LIMIT_MAX_ATTEMPTS = 4;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+const MAX_SYNC_RANGE_PAST_WEEKS = 12;
+const DEFAULT_SYNC_MAX_RESULTS = 100;
+const MAX_SYNC_MAX_RESULTS = 500;
+const SYNC_MAX_RESULTS_PER_WEEK = 50;
 
 /**
  * Read `error.errors[0].reason` from a Google Calendar API error response.
@@ -252,6 +258,29 @@ const isDeclined = (event: GoogleCalendarEvent): boolean =>
 const isSpManagedEvent = (event: GoogleCalendarEvent): boolean =>
   typeof event.extendedProperties?.private?.spTaskId === 'string';
 
+const parsePositiveInt = (value: string | undefined, fallback: number): number => {
+  const parsed = parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const parsePastWeeks = (value: string | undefined): number => {
+  const parsed = parseInt(value || '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.min(parsed, MAX_SYNC_RANGE_PAST_WEEKS);
+};
+
+const getSyncMaxResults = (cfg: GoogleCalendarConfig): string => {
+  const syncRangePastWeeks = parsePastWeeks(cfg.syncRangePastWeeks);
+  if (syncRangePastWeeks === 0) return String(DEFAULT_SYNC_MAX_RESULTS);
+
+  const syncRangeWeeks = parsePositiveInt(cfg.syncRangeWeeks, 2);
+  const rangeMaxResults =
+    (syncRangeWeeks + syncRangePastWeeks) * SYNC_MAX_RESULTS_PER_WEEK;
+  return String(
+    Math.min(MAX_SYNC_MAX_RESULTS, Math.max(DEFAULT_SYNC_MAX_RESULTS, rangeMaxResults)),
+  );
+};
+
 /** Fetch events from a single calendar. */
 const fetchEventsForCalendar = async (
   http: PluginHttp,
@@ -259,12 +288,13 @@ const fetchEventsForCalendar = async (
   cfg: GoogleCalendarConfig,
   opts?: { query?: string; maxResults?: string },
 ): Promise<PluginSearchResult[]> => {
-  const syncRangeWeeks = parseInt(cfg.syncRangeWeeks || '', 10) || 2;
+  const syncRangeWeeks = parsePositiveInt(cfg.syncRangeWeeks, 2);
+  const syncRangePastWeeks = parsePastWeeks(cfg.syncRangePastWeeks);
   const now = new Date();
-  const timeMin = now.toISOString();
-  const timeMax = new Date(
-    now.getTime() + syncRangeWeeks * 7 * 24 * 60 * 60 * 1000,
+  const timeMin = new Date(
+    now.getTime() - syncRangePastWeeks * MS_PER_WEEK,
   ).toISOString();
+  const timeMax = new Date(now.getTime() + syncRangeWeeks * MS_PER_WEEK).toISOString();
 
   const response = await http.get<GoogleCalendarListResponse>(eventUrl(calendarId), {
     params: {
@@ -369,6 +399,17 @@ PluginAPI.registerIssueProvider({
       label: 'Sync range (weeks)',
       description: 'How many weeks ahead to sync events. Defaults to 2.',
       required: false,
+      pattern: '^[0-9]*$',
+    },
+    {
+      key: 'syncRangePastWeeks',
+      type: 'input' as const,
+      label: 'Past events range (weeks)',
+      description:
+        'How many past weeks to keep visible in the Schedule view. Defaults to 0 and is capped at 12.',
+      required: false,
+      pattern: '^[0-9]*$',
+      advanced: true,
     },
     {
       key: 'showDeclinedEvents',
@@ -466,7 +507,8 @@ PluginAPI.registerIssueProvider({
     config: Record<string, unknown>,
     http: PluginHttp,
   ): Promise<PluginSearchResult[]> {
-    return fetchEvents(http, migrateConfig(config), { maxResults: '100' });
+    const cfg = migrateConfig(config);
+    return fetchEvents(http, cfg, { maxResults: getSyncMaxResults(cfg) });
   },
 
   issueDisplay: [

--- a/src/app/features/calendar-integration/calendar-integration.service.spec.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.spec.ts
@@ -196,18 +196,31 @@ END:VCALENDAR`;
         discardPeriodicTasks();
       }));
 
-      it('should filter out events older than one week from cache', fakeAsync(() => {
+      it('should keep cached past events within the rolling history window', fakeAsync(() => {
         const ONE_WEEK = 60 * 60 * 1000 * 24 * 7;
+        const now = Date.now();
+        const twelveWeeks = 12 * ONE_WEEK;
+        const twoWeeks = 2 * ONE_WEEK;
+        const tooOldStart = now - twelveWeeks - 7_200_000;
+        const rollingHistoryStart = now - twoWeeks;
         const cachedProvider = createMockProvider({ id: 'provider-1' });
         const cachedData = [
           {
             items: [
               {
-                id: 'old-event',
+                id: 'too-old-event',
                 calProviderId: 'provider-1',
                 issueProviderKey: 'ICAL',
-                title: 'Old Event',
-                start: Date.now() - ONE_WEEK - 7200000, // more than 1 week ago
+                title: 'Too Old Event',
+                start: tooOldStart,
+                duration: 3600000,
+              },
+              {
+                id: 'rolling-history-event',
+                calProviderId: 'provider-1',
+                issueProviderKey: 'ICAL',
+                title: 'Rolling History Event',
+                start: rollingHistoryStart,
                 duration: 3600000,
               },
               {
@@ -242,10 +255,12 @@ END:VCALENDAR`;
         subscriptions.push(sub);
 
         tick(0);
-        // Old event (> 1 week) is filtered; recent past and future events are kept
-        expect((emittedValue as any[])[0].items.length).toBe(2);
-        expect((emittedValue as any[])[0].items[0].id).toBe('recent-past-event');
-        expect((emittedValue as any[])[0].items[1].id).toBe('future-event');
+        // Events inside the 12-week rolling history are kept; older cache is dropped.
+        expect((emittedValue as any[])[0].items.map((item: any) => item.id)).toEqual([
+          'rolling-history-event',
+          'recent-past-event',
+          'future-event',
+        ]);
         discardPeriodicTasks();
       }));
     });

--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -66,6 +66,7 @@ import { isCalendarProviderDisabledOnCurrentPlatform } from '../issue/providers/
 
 const ONE_MONTHS = 60 * 60 * 1000 * 24 * 31;
 const ONE_WEEK = 60 * 60 * 1000 * 24 * 7;
+const PAST_EVENTS_RETENTION = 12 * ONE_WEEK;
 const PLUGIN_CALENDAR_POLL_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
 @Injectable({
@@ -493,11 +494,12 @@ export class CalendarIntegrationService {
 
     return (
       cached
-        // filter out cached entries older than one week
+        // Keep this aligned with the Google Calendar provider's capped past sync window
+        // so cached plugin events remain visible after a reload.
         .map((provider) => ({
           ...provider,
           items: provider.items
-            .filter((item) => item.start + item.duration >= now - ONE_WEEK)
+            .filter((item) => item.start + item.duration >= now - PAST_EVENTS_RETENTION)
             // Backfill issueProviderKey for events cached before it became required
             .map((item) =>
               item.issueProviderKey ? item : { ...item, issueProviderKey: 'ICAL' },

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -66,7 +66,7 @@
     <button
       mat-icon-button
       (click)="goToPreviousPeriod()"
-      [disabled]="isViewingToday()"
+      [disabled]="isAtPastNavLimit()"
       [attr.aria-label]="
         (isMonthView() ? T.F.SCHEDULE.PREVIOUS_MONTH : T.F.SCHEDULE.PREVIOUS_WEEK)
           | translate

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -299,15 +299,30 @@ describe('ScheduleComponent', () => {
       expect(newDate?.getHours()).toBe(0); // Normalized to midnight
     });
 
-    it('should not navigate backward when already viewing today', () => {
+    it('should navigate backward from today into the past window', () => {
       // Arrange - viewing today (null selected date)
       component['_selectedDate'].set(null);
 
       // Act
       component.goToPreviousPeriod();
 
-      // Assert - prev nav is disabled when today is in view
-      expect(component['_selectedDate']()).toBeNull();
+      // Assert - past calendar events can be inspected in the Schedule view
+      expect(component['_selectedDate']()).not.toBeNull();
+      expect(component['_selectedDate']()?.getTime()).toBeLessThan(Date.now());
+    });
+
+    it('should clamp backward navigation to the 12-week past window', () => {
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2025-10-01',
+        '2025-10-02',
+        '2025-10-03',
+      ]);
+      component['_selectedDate'].set(new Date(2025, 9, 1));
+
+      component.goToPreviousPeriod();
+
+      const limit = new Date(component['_pastNavLimitTime']());
+      expect(component['_selectedDate']()?.getTime()).toBe(limit.getTime());
     });
 
     it('should go to previous month in month view', () => {

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -44,6 +44,8 @@ import { DateTimeFormatService } from '../../../core/date-time-format/date-time-
 import { getWeekNumber } from '../../../util/get-week-number';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
 
+const PAST_SCHEDULE_NAV_LIMIT_WEEKS = 12;
+
 @Component({
   selector: 'schedule',
   imports: [
@@ -113,6 +115,12 @@ export class ScheduleComponent {
     if (this._selectedDate() === null) return true;
     const todayStr = this._todayDateStr();
     return todayStr ? this.daysToShow().includes(todayStr) : false;
+  });
+
+  isAtPastNavLimit = computed(() => {
+    const days = this.daysToShow();
+    if (!days.length) return true;
+    return parseDbDateStr(days[0]).getTime() <= this._pastNavLimitTime();
   });
 
   protected _todayDateStr = toSignal(this._globalTrackingIntervalService.todayDateStr$);
@@ -286,9 +294,6 @@ export class ScheduleComponent {
   });
 
   goToPreviousPeriod(): void {
-    // Never navigate into the past — the displayed range must include today or later
-    if (this.isViewingToday()) return;
-
     const currentDate = this._selectedDate() || new Date();
     const selectedView = this._currentTimeViewMode();
 
@@ -298,21 +303,13 @@ export class ScheduleComponent {
         currentDate.getMonth() - 1,
         1,
       );
-      this._selectedDate.set(previousMonth);
+      this._selectedDate.set(this._clampToPastNavLimit(previousMonth));
     } else {
       const daysToSkip = this.daysToShow().length;
       const previousPeriod = new Date(currentDate);
       previousPeriod.setDate(currentDate.getDate() - daysToSkip);
       previousPeriod.setHours(0, 0, 0, 0);
-
-      // If going back would land on or before today, snap to "today view" (null)
-      const todayMidnight = new Date();
-      todayMidnight.setHours(0, 0, 0, 0);
-      if (previousPeriod.getTime() <= todayMidnight.getTime()) {
-        this._selectedDate.set(null);
-      } else {
-        this._selectedDate.set(previousPeriod);
-      }
+      this._selectedDate.set(this._clampToPastNavLimit(previousPeriod));
     }
   }
 
@@ -394,6 +391,19 @@ export class ScheduleComponent {
   private getTimeView(): 'week' | 'month' {
     const preservedView = localStorage.getItem(LS.SELECTED_TIME_VIEW);
     return preservedView === 'month' ? 'month' : 'week';
+  }
+
+  private _pastNavLimitTime(): number {
+    const todayStr = this._todayDateStr();
+    const today = todayStr ? parseDbDateStr(todayStr) : new Date();
+    today.setHours(0, 0, 0, 0);
+    today.setDate(today.getDate() - PAST_SCHEDULE_NAV_LIMIT_WEEKS * 7);
+    return today.getTime();
+  }
+
+  private _clampToPastNavLimit(date: Date): Date {
+    const limit = new Date(this._pastNavLimitTime());
+    return date.getTime() < limit.getTime() ? limit : date;
   }
 
   constructor() {


### PR DESCRIPTION
Fixes #7743.

## Summary
- add an advanced Google Calendar `syncRangePastWeeks` config field, defaulting to the existing forward-only behavior
- cap the past-history window at 12 weeks and increase auto-sync `maxResults` only when past history is enabled
- document the advanced option in the task integrations wiki page

## Validation
- `npm run checkFile packages/plugin-dev/google-calendar-provider/src/plugin.ts`
- `npm run checkFile packages/plugin-dev/google-calendar-provider/src/plugin.spec.ts`
- `cd packages/plugin-dev/google-calendar-provider && npm run typecheck`
- `cd packages/plugin-dev/google-calendar-provider && CHROME_BIN=/snap/bin/chromium npm test -- src/plugin.spec.ts` (38 passed)
- `cd packages/plugin-dev/google-calendar-provider && npm run build`
- `git diff --check upstream/master..HEAD`
