### PR TITLE
fix(nav): keep tree drag labels visible

### DIFF
--- a/src/app/ui/tree-dnd/tree.component.html
+++ b/src/app/ui/tree-dnd/tree.component.html
@@ -52,6 +52,7 @@
     cdkDrag
     [cdkDragData]="node.id"
     [cdkDragStartDelay]="dragDelayForTouch()"
+    cdkDragPreviewClass="tree-dnd-drag-preview"
     cdkDragLockAxis="y"
     [ngClass]="{
       'is-folder': folder,

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -341,6 +341,32 @@ body .mat-mdc-button-base .mat-icon {
   background: var(--bg-lightest) !important;
 }
 
+.cdk-drag-preview.tree-dnd-drag-preview {
+  box-sizing: border-box;
+  max-width: calc(100vw - var(--s2));
+  border-radius: var(--card-border-radius);
+  color: var(--sidenav-text);
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  .nav-child-item,
+  nav-item,
+  .nav-link {
+    min-width: 0;
+  }
+
+  .nav-link,
+  .nav-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 .drag-preview-time-badge {
   position: absolute;
   right: 6px;


### PR DESCRIPTION
Fixes #5135.

## Summary
- add a scoped CDK drag preview class to the reusable tree DnD rows
- keep the side-nav project/tag drag preview text visible and clipped inside the preview box
- leave other drag previews untouched

## Validation
- `npm run checkFile src/styles/components/_overwrite-material.scss`
- `npm run checkFile src/app/ui/tree-dnd/tree.component.html`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/ui/tree-dnd/tree.utils.spec.ts` (6 passed)
- `git diff --check upstream/master..HEAD`

Note: I verified this through the shared tree DnD preview styling and focused unit tests; I did not have an Android runtime available for a visual drag reproduction.
