### PR TITLE
fix(open-project): search closed work packages

### DIFF
--- a/src/app/features/issue/providers/open-project/open-project-api.service.spec.ts
+++ b/src/app/features/issue/providers/open-project/open-project-api.service.spec.ts
@@ -1,0 +1,124 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { SnackService } from '../../../../core/snack/snack.service';
+import { DEFAULT_OPEN_PROJECT_CFG } from './open-project.const';
+import { OpenProjectApiService } from './open-project-api.service';
+import { OpenProjectCfg } from './open-project.model';
+
+describe('OpenProjectApiService', () => {
+  let service: OpenProjectApiService;
+  let httpMock: HttpTestingController;
+  const workPackagesUrl =
+    'https://openproject.example.com/api/v3/projects/software/work_packages';
+
+  const cfg: OpenProjectCfg = {
+    ...DEFAULT_OPEN_PROJECT_CFG,
+    host: 'https://openproject.example.com',
+    projectId: 'software',
+    token: 'test-token',
+    scope: null,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        OpenProjectApiService,
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj<SnackService>('SnackService', ['open']),
+        },
+      ],
+    });
+
+    service = TestBed.inject(OpenProjectApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('searchIssueForRepo$', () => {
+    it('searches explicit terms across all statuses so closed work packages can match', (done) => {
+      service.searchIssueForRepo$(' 1451 ', cfg).subscribe((results) => {
+        expect(results).toEqual([]);
+        done();
+      });
+
+      const req = httpMock.expectOne((request) => request.url === workPackagesUrl);
+      const filters = JSON.parse(req.request.params.get('filters') || '[]');
+
+      expect(filters).toEqual([
+        {
+          subjectOrId: {
+            operator: '**',
+            values: ['1451'],
+          },
+        },
+      ]);
+      expect(req.request.params.get('pageSize')).toBe('100');
+      expect(req.request.params.get('sortBy')).toBe('[["updatedAt","desc"]]');
+
+      req.flush({ _embedded: { elements: [] } });
+    });
+
+    it('keeps empty searches limited to open work packages', (done) => {
+      service.searchIssueForRepo$('', cfg).subscribe((results) => {
+        expect(results).toEqual([]);
+        done();
+      });
+
+      const req = httpMock.expectOne((request) => request.url === workPackagesUrl);
+      const filters = JSON.parse(req.request.params.get('filters') || '[]');
+
+      expect(filters).toEqual([
+        {
+          status: {
+            operator: 'o',
+            values: [],
+          },
+        },
+      ]);
+
+      req.flush({ _embedded: { elements: [] } });
+    });
+
+    it('preserves configured scope filters when searching closed work packages', (done) => {
+      service
+        .searchIssueForRepo$('bug', {
+          ...cfg,
+          scope: 'assigned-to-me',
+        })
+        .subscribe((results) => {
+          expect(results).toEqual([]);
+          done();
+        });
+
+      const req = httpMock.expectOne((request) => request.url === workPackagesUrl);
+      const filters = JSON.parse(req.request.params.get('filters') || '[]');
+
+      expect(filters).toEqual([
+        {
+          subjectOrId: {
+            operator: '**',
+            values: ['bug'],
+          },
+        },
+        {
+          assignee: {
+            operator: '=',
+            values: ['me'],
+          },
+        },
+      ]);
+
+      req.flush({ _embedded: { elements: [] } });
+    });
+  });
+});

--- a/src/app/features/issue/providers/open-project/open-project-api.service.ts
+++ b/src/app/features/issue/providers/open-project/open-project-api.service.ts
@@ -70,11 +70,12 @@ export class OpenProjectApiService {
     searchText: string,
     cfg: OpenProjectCfg,
   ): Observable<SearchResultItem[]> {
-    // OpenProject does not allow empty filter for subjectOrId, only send when searchText is present
-    const filters: OpenProjectFilterItem[] = [{ status: { operator: 'o', values: [] } }];
-    if (searchText?.trim()) {
-      filters.push({ subjectOrId: { operator: '**', values: [searchText] } });
-    }
+    const trimmedSearchText = searchText?.trim();
+    // OpenProject does not allow empty filter for subjectOrId. Keep empty searches
+    // bounded to open work packages, but search explicit terms across all statuses.
+    const filters: OpenProjectFilterItem[] = trimmedSearchText
+      ? [{ subjectOrId: { operator: '**', values: [trimmedSearchText] } }]
+      : [{ status: { operator: 'o', values: [] } }];
     return this._sendRequest$(
       {
         // see https://www.openproject.org/docs/api/endpoints/work-packages/


### PR DESCRIPTION
Fixes #6055.

## Summary
- search explicit OpenProject terms across all statuses so closed work packages can match
- keep empty OpenProject searches limited to open work packages, preserving the existing bounded/default behavior
- add request-level coverage for explicit searches, empty searches, and configured scope filters

## Data-size note
This does not broaden the default empty search/background result set. It only removes the open-only status filter when the user has entered a concrete search term, while keeping `pageSize=100` and existing scope filters.

## Validation
- `npm run checkFile src/app/features/issue/providers/open-project/open-project-api.service.ts`
- `npm run checkFile src/app/features/issue/providers/open-project/open-project-api.service.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/issue/providers/open-project/open-project-api.service.spec.ts` (3 passed)
- `git diff --check upstream/master..HEAD`
