### PR TITLE
fix(schedule): show overlapping same-time tasks

### DIFF
--- a/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts
@@ -180,7 +180,8 @@ describe('mapScheduleDaysToScheduleEvents()', () => {
       ],
       FH,
     );
-    expect(res.eventsFlat[1].overlap).toEqual({ count: 1, offset: 1 });
+    expect(res.eventsFlat[0].overlap).toEqual({ count: 2, offset: 0 });
+    expect(res.eventsFlat[1].overlap).toEqual({ count: 2, offset: 1 });
   });
 
   it('should detect overlap for three zero-duration events at the same time', () => {
@@ -197,8 +198,9 @@ describe('mapScheduleDaysToScheduleEvents()', () => {
       ],
       FH,
     );
-    expect(res.eventsFlat[1].overlap).toEqual({ count: 1, offset: 1 });
-    expect(res.eventsFlat[2].overlap).toEqual({ count: 2, offset: 2 });
+    expect(res.eventsFlat[0].overlap).toEqual({ count: 3, offset: 0 });
+    expect(res.eventsFlat[1].overlap).toEqual({ count: 3, offset: 1 });
+    expect(res.eventsFlat[2].overlap).toEqual({ count: 3, offset: 2 });
   });
 
   it('should detect overlap for two events with normal duration at the same time', () => {
@@ -214,7 +216,8 @@ describe('mapScheduleDaysToScheduleEvents()', () => {
       ],
       FH,
     );
-    expect(res.eventsFlat[1].overlap).toEqual({ count: 1, offset: 1 });
+    expect(res.eventsFlat[0].overlap).toEqual({ count: 2, offset: 0 });
+    expect(res.eventsFlat[1].overlap).toEqual({ count: 2, offset: 1 });
   });
 
   it('should NOT detect overlap for two zero-duration events at different times', () => {

--- a/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.ts
+++ b/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.ts
@@ -35,7 +35,10 @@ export const mapScheduleDaysToScheduleEvents = (
       };
     });
 
-    const activeEntries: typeof day.entries = [];
+    const activeEntries: (
+      | { entry: (typeof day.entries)[number]; eventIndex: number }
+      | undefined
+    )[] = [];
 
     day.entries.forEach((entry) => {
       if (entry.type !== SVEType.WorkdayEnd && entry.type !== SVEType.WorkdayStart) {
@@ -53,6 +56,7 @@ export const mapScheduleDaysToScheduleEvents = (
         const timeLeftInHours = Math.floor(timeLeft / 1000 / 60) / 60;
         const rowSpan = Math.max(1, Math.round(timeLeftInHours * FH));
 
+        const eventIndex = eventsFlat.length;
         eventsFlat.push({
           dayOfMonth: getDayOfMonth(
             (entry.data as TaskWithPlannedForDayIndication)?.plannedForDay,
@@ -69,13 +73,14 @@ export const mapScheduleDaysToScheduleEvents = (
 
         let overlapCount = 0;
         for (let i = 0; i < activeEntries.length; i++) {
-          if (!activeEntries[i]) {
+          const activeEntry = activeEntries[i];
+          if (!activeEntry) {
             continue;
           }
           const entryEnd = entry.start + Math.max(entry.duration, 1);
           const activeEnd =
-            activeEntries[i].start + Math.max(activeEntries[i].duration, 1);
-          if (entryEnd <= activeEntries[i].start || activeEnd <= entry.start) {
+            activeEntry.entry.start + Math.max(activeEntry.entry.duration, 1);
+          if (entryEnd <= activeEntry.entry.start || activeEnd <= entry.start) {
             delete activeEntries[i];
           } else {
             overlapCount += 1;
@@ -87,13 +92,34 @@ export const mapScheduleDaysToScheduleEvents = (
           nextInactiveSlot = activeEntries.length === 0 ? 0 : activeEntries.length;
         }
 
-        activeEntries[nextInactiveSlot] = entry;
+        activeEntries[nextInactiveSlot] = { entry, eventIndex };
 
         if (overlapCount > 0 || nextInactiveSlot > 0) {
-          eventsFlat[eventsFlat.length - 1].overlap = {
-            count: overlapCount,
-            offset: nextInactiveSlot,
-          };
+          const activeEventSlots = activeEntries
+            .map((activeEntry, offset) => ({ activeEntry, offset }))
+            .filter(
+              (
+                activeEventSlot,
+              ): activeEventSlot is {
+                activeEntry: { entry: (typeof day.entries)[number]; eventIndex: number };
+                offset: number;
+              } => !!activeEventSlot.activeEntry,
+            );
+          const laneCount = Math.max(
+            ...activeEventSlots.map(({ activeEntry, offset }) =>
+              Math.max(
+                offset + 1,
+                eventsFlat[activeEntry.eventIndex].overlap?.count ?? 1,
+              ),
+            ),
+          );
+
+          activeEventSlots.forEach(({ activeEntry, offset }) => {
+            eventsFlat[activeEntry.eventIndex].overlap = {
+              count: laneCount,
+              offset,
+            };
+          });
         }
       }
     });

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -28,12 +28,13 @@ const makeCalendarScheduleEvent = (isReferenceCalendar: boolean): ScheduleEvent 
   } as any,
 });
 
-const makeTaskScheduleEvent = (): ScheduleEvent => ({
+const makeTaskScheduleEvent = (overlap?: ScheduleEvent['overlap']): ScheduleEvent => ({
   id: 'task-1',
   type: SVEType.Task,
-  style: '',
+  style: 'grid-column: 2;  grid-row: 121 / span 12',
   startHours: 10,
   timeLeftInHours: 1,
+  overlap,
   data: { id: 'task-1', title: 'Task', timeEstimate: 3600000 } as any,
 });
 
@@ -144,6 +145,34 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
       fixture.detectChanges();
 
       expect(component.isResizable()).toBe(false);
+    });
+  });
+
+  describe('style', () => {
+    it('should render overlapping events in equal-width lanes', () => {
+      fixture.componentRef.setInput(
+        'event',
+        makeTaskScheduleEvent({ count: 2, offset: 1 }),
+      );
+      fixture.detectChanges();
+
+      expect(component.style()).toBe(
+        'margin-left: calc(50% + var(--margin-left)); ' +
+          'width: calc(50% - var(--margin-left) - var(--margin-right)); ' +
+          'overflow: hidden !important; ' +
+          'grid-column: 2;  grid-row: 121 / span 12',
+      );
+    });
+
+    it('should not lane events in month view', () => {
+      fixture.componentRef.setInput(
+        'event',
+        makeTaskScheduleEvent({ count: 2, offset: 1 }),
+      );
+      fixture.componentRef.setInput('isMonthView', true);
+      fixture.detectChanges();
+
+      expect(component.style()).toBe('grid-column: 2;  grid-row: 121 / span 12');
     });
   });
 });

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -242,14 +242,10 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
 
   readonly style = computed(() => {
     const { overlap, style } = this.se();
-    // Arbitrarily chosen value that controls width reduction of this component
-    // whenever the underlying event duration overlaps with others
-    const overlapReductionFactor = 0.75;
     return (
       (!this.isMonthView() && !this.isDragPreview() && overlap
-        ? // eslint-disable-next-line no-mixed-operators -- conflicts with prettier formatting
-          `margin-left: ${100 - 100 * Math.pow(overlapReductionFactor, overlap.offset)}%; ` +
-          `width: calc(${Math.pow(overlapReductionFactor, overlap.count) * 100}% - var(--margin-right)); ` +
+        ? `margin-left: calc(${overlap.offset * (100 / overlap.count)}% + var(--margin-left)); ` +
+          `width: calc(${100 / overlap.count}% - var(--margin-left) - var(--margin-right)); ` +
           // Content inside the event element can spill out when the width is limited enough
           'overflow: hidden !important; '
         : '') + style


### PR DESCRIPTION
Fixes #5887.

## Summary
- assign all overlapping same-time schedule events to equal-width lanes
- backfill overlap metadata to earlier events in the active overlap group so the first item also shrinks instead of being covered
- keep month view and drag preview rendering unchanged

## Validation
- `npm run checkFile src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.ts`
- `npm run checkFile src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts`
- `npm run checkFile src/app/features/schedule/schedule-event/schedule-event.component.ts`
- `npm run checkFile src/app/features/schedule/schedule-event/schedule-event.component.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts` (8 passed)
- `CHROME_BIN=/snap/bin/chromium npm run test:file src/app/features/schedule/schedule-event/schedule-event.component.spec.ts` (9 passed)
- `git diff --check upstream/master..HEAD`
