### PR TITLE
fix(config): preserve hidden flowtime settings

### DIFF
--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.html
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.html
@@ -5,7 +5,7 @@
       [fields]="fields()"
       [form]="form"
       [model]="model()"
-      (modelChange)="model.set($event)"
+      (modelChange)="updateModel($event)"
     ></formly-form>
   </form>
   <div class="dialog-actions">

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -270,6 +270,49 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(component.model().breakRules).toEqual(initialRules);
   });
 
+  it('should ignore partial hidden rule rows emitted while Ratio-based is visible', () => {
+    fixture.destroy();
+    globalConfigServiceMock.cfg.and.returnValue({
+      flowtime: {
+        isBreakEnabled: false,
+        breakMode: 'ratio',
+        breakPercentage: 20,
+        breakRules: [],
+      },
+    });
+    fixture = TestBed.createComponent(DialogFlowtimeSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const initialRules = component.model().breakRules;
+    const enabledRatioModel = component.model();
+    enabledRatioModel.isBreakEnabled = true;
+    enabledRatioModel.breakRules = [
+      {
+        minDuration: '' as unknown as number,
+        maxDuration: '' as unknown as number,
+        breakDuration: 5,
+      },
+    ];
+    component.updateModel(enabledRatioModel);
+
+    const restoredRuleModel = component.model();
+    restoredRuleModel.breakMode = 'rule';
+    restoredRuleModel.breakRules = [
+      {
+        minDuration: '' as unknown as number,
+        maxDuration: '' as unknown as number,
+        breakDuration: 5,
+      },
+    ];
+    component.updateModel(restoredRuleModel);
+    fixture.detectChanges();
+
+    expect(component.model().breakRules).toEqual(initialRules);
+    const firstRule = (component.form.get('breakRules') as any).at(0);
+    expect(firstRule.value).toEqual(initialRules![0]);
+  });
+
   describe('save()', () => {
     it('should convert minutes back to ms and save the config', () => {
       component.save();

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -313,6 +313,32 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(firstRule.value).toEqual(initialRules![0]);
   });
 
+  it('should allow deleting restored rule rows after switching back to Rule-based', () => {
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'ratio',
+      breakRules: [],
+    });
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: [
+        {
+          minDuration: '' as unknown as number,
+          maxDuration: '' as unknown as number,
+          breakDuration: 5,
+        },
+      ],
+    });
+
+    component.updateModel({
+      ...component.model(),
+      breakRules: [],
+    });
+
+    expect(component.model().breakRules).toEqual([]);
+  });
+
   describe('save()', () => {
     it('should convert minutes back to ms and save the config', () => {
       component.save();
@@ -384,6 +410,24 @@ describe('DialogFlowtimeSettingsComponent', () => {
         breakPercentage: 20,
         breakRules: [{ minDuration: 0, maxDuration: 1500000, breakDuration: 300000 }],
       });
+    });
+
+    it('should persist rule edits made before disabling breaks', () => {
+      component.updateModel({
+        ...component.model(),
+        breakRules: [{ minDuration: 0, maxDuration: 30, breakDuration: 10 }],
+      });
+      component.updateModel({
+        ...component.model(),
+        isBreakEnabled: false,
+      });
+
+      component.save();
+      const savedConfig =
+        globalConfigServiceMock.updateSection.calls.mostRecent().args[1];
+      expect(savedConfig.breakRules).toEqual([
+        { minDuration: 0, maxDuration: 30 * 60000, breakDuration: 10 * 60000 },
+      ]);
     });
   });
 

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -125,6 +125,48 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(component.model().breakRules).toEqual(initialRules);
   });
 
+  it('should keep rule fields when Formly mutates the model object while switching modes', () => {
+    fixture.destroy();
+    globalConfigServiceMock.cfg.and.returnValue({
+      flowtime: {
+        isBreakEnabled: false,
+        breakMode: 'ratio',
+        breakPercentage: 20,
+        breakRules: [],
+      },
+    });
+    fixture = TestBed.createComponent(DialogFlowtimeSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const initialRules = component.model().breakRules;
+    const enabledModel = component.model();
+    enabledModel.isBreakEnabled = true;
+    component.updateModel(enabledModel);
+
+    const ruleModel = component.model();
+    ruleModel.breakMode = 'rule';
+    component.updateModel(ruleModel);
+
+    const ratioModel = component.model();
+    ratioModel.breakMode = 'ratio';
+    ratioModel.breakRules = [];
+    component.updateModel(ratioModel);
+
+    const restoredRuleModel = component.model();
+    restoredRuleModel.breakMode = 'rule';
+    restoredRuleModel.breakRules = [
+      {
+        minDuration: '' as unknown as number,
+        maxDuration: '' as unknown as number,
+        breakDuration: '' as unknown as number,
+      },
+    ];
+    component.updateModel(restoredRuleModel);
+
+    expect(component.model().breakRules).toEqual(initialRules);
+  });
+
   describe('save()', () => {
     it('should convert minutes back to ms and save the config', () => {
       component.save();

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -101,6 +101,30 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(component.model().breakRules).toEqual(initialRules);
   });
 
+  it('should keep rule fields when Formly emits blank strings while restoring the rule section', () => {
+    const initialRules = component.model().breakRules;
+
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'ratio',
+      breakRules: [],
+    });
+
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: [
+        {
+          minDuration: '' as unknown as number,
+          maxDuration: '' as unknown as number,
+          breakDuration: '' as unknown as number,
+        },
+      ],
+    });
+
+    expect(component.model().breakRules).toEqual(initialRules);
+  });
+
   describe('save()', () => {
     it('should convert minutes back to ms and save the config', () => {
       component.save();

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -75,6 +75,32 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(fields.find((field) => field.key === 'breakRules')?.resetOnHide).toBe(false);
   });
 
+  it('should keep rule fields while switching Rule-based -> Ratio-based -> Rule-based', () => {
+    const initialRules = component.model().breakRules;
+
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'ratio',
+      breakRules: [],
+    });
+
+    expect(component.model().breakRules).toEqual(initialRules);
+
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: [
+        {
+          minDuration: null as unknown as number,
+          maxDuration: null,
+          breakDuration: null as unknown as number,
+        },
+      ],
+    });
+
+    expect(component.model().breakRules).toEqual(initialRules);
+  });
+
   describe('save()', () => {
     it('should convert minutes back to ms and save the config', () => {
       component.save();

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -65,6 +65,16 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(model.breakRules![0].breakDuration).toBe(5); // 300000 / 60000
   });
 
+  it('should keep mode-specific settings when fields are hidden', () => {
+    const fields = component.fields();
+
+    expect(fields.find((field) => field.key === 'breakMode')?.resetOnHide).toBe(false);
+    expect(fields.find((field) => field.key === 'breakPercentage')?.resetOnHide).toBe(
+      false,
+    );
+    expect(fields.find((field) => field.key === 'breakRules')?.resetOnHide).toBe(false);
+  });
+
   describe('save()', () => {
     it('should convert minutes back to ms and save the config', () => {
       component.save();

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -202,6 +202,32 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(component.model().breakRules).toEqual(initialRules);
   });
 
+  it('should patch restored partially blank rule values back to the form controls', () => {
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'ratio',
+      breakRules: [],
+    });
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: [
+        {
+          minDuration: '' as unknown as number,
+          maxDuration: '' as unknown as number,
+          breakDuration: 5,
+        },
+      ],
+    });
+
+    const firstRule = (component.form.get('breakRules') as any).at(0);
+    expect(firstRule.value).toEqual({
+      minDuration: 0,
+      maxDuration: 25,
+      breakDuration: 5,
+    });
+  });
+
   it('should keep rule fields when Formly mutates the model object while switching modes', () => {
     fixture.destroy();
     globalConfigServiceMock.cfg.and.returnValue({

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -121,6 +121,22 @@ describe('DialogFlowtimeSettingsComponent', () => {
         breakDuration: 15 * 60000,
       });
     });
+
+    it('should preserve hidden break settings when Flowtime breaks are disabled', () => {
+      component.model.set({
+        isBreakEnabled: false,
+      });
+
+      component.save();
+      const savedConfig =
+        globalConfigServiceMock.updateSection.calls.mostRecent().args[1];
+      expect(savedConfig).toEqual({
+        isBreakEnabled: false,
+        breakMode: 'rule',
+        breakPercentage: 20,
+        breakRules: [{ minDuration: 0, maxDuration: 1500000, breakDuration: 300000 }],
+      });
+    });
   });
 
   describe('validator', () => {

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -125,6 +125,83 @@ describe('DialogFlowtimeSettingsComponent', () => {
     expect(component.model().breakRules).toEqual(initialRules);
   });
 
+  it('should restore partially blank rule rows while switching back to Rule-based', () => {
+    const initialRules = [
+      { minDuration: 0, maxDuration: 25, breakDuration: 5 },
+      { minDuration: 25, maxDuration: null, breakDuration: 10 },
+    ];
+
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: initialRules,
+    });
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'ratio',
+      breakRules: [],
+    });
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: [
+        {
+          minDuration: '' as unknown as number,
+          maxDuration: '' as unknown as number,
+          breakDuration: '' as unknown as number,
+        },
+        {
+          minDuration: '' as unknown as number,
+          maxDuration: '' as unknown as number,
+          breakDuration: 10,
+        },
+      ],
+    });
+
+    expect(component.model().breakRules).toEqual(initialRules);
+  });
+
+  it('should keep restoring if Formly emits a delayed partially blank rule payload', () => {
+    const initialRules = [
+      { minDuration: 0, maxDuration: 25, breakDuration: 5 },
+      { minDuration: 25, maxDuration: null, breakDuration: 10 },
+    ];
+
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: initialRules,
+    });
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'ratio',
+      breakRules: [],
+    });
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: [],
+    });
+    component.updateModel({
+      ...component.model(),
+      breakMode: 'rule',
+      breakRules: [
+        {
+          minDuration: '' as unknown as number,
+          maxDuration: '' as unknown as number,
+          breakDuration: '' as unknown as number,
+        },
+        {
+          minDuration: '' as unknown as number,
+          maxDuration: '' as unknown as number,
+          breakDuration: 10,
+        },
+      ],
+    });
+
+    expect(component.model().breakRules).toEqual(initialRules);
+  });
+
   it('should keep rule fields when Formly mutates the model object while switching modes', () => {
     fixture.destroy();
     globalConfigServiceMock.cfg.and.returnValue({

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -71,6 +71,10 @@ export class DialogFlowtimeSettingsComponent {
     breakDuration: 5,
   };
   private readonly _initialFlowtimeConfig: FlowtimeConfig;
+  private _lastIsBreakEnabled: FlowtimeFormModel['isBreakEnabled'];
+  private _lastBreakMode: FlowtimeFormModel['breakMode'];
+  private _lastBreakPercentage: FlowtimeFormModel['breakPercentage'];
+  private _lastNonEmptyBreakRules: FlowtimeBreakRuleInMinutes[];
 
   T = T;
   form = new FormGroup({});
@@ -203,27 +207,37 @@ export class DialogFlowtimeSettingsComponent {
       ...DEFAULT_GLOBAL_CONFIG.flowtime,
       ...(cfg?.flowtime ?? {}),
     };
+    const breakRules = this._toBreakRulesInMinutes(flowtime);
     this._initialFlowtimeConfig = flowtime;
+    this._lastIsBreakEnabled = flowtime.isBreakEnabled;
+    this._lastBreakMode = flowtime.breakMode;
+    this._lastBreakPercentage = flowtime.breakPercentage;
+    this._lastNonEmptyBreakRules = this._copyBreakRules(breakRules);
 
     this.model.set({
       ...flowtime,
-      breakRules: this._toBreakRulesInMinutes(flowtime),
+      breakRules,
     });
   }
 
   updateModel(nextModel: FlowtimeFormModel): void {
-    const previousModel = this.model();
-    const breakMode = this._getNextBreakMode(previousModel, nextModel);
-
-    this.model.set({
+    const previousIsBreakEnabled = this._lastIsBreakEnabled;
+    const previousBreakMode = this._lastBreakMode;
+    const breakMode = this._getNextBreakMode(nextModel);
+    const nextModelToSet = {
       ...nextModel,
       breakMode,
-      breakPercentage: this._getNextBreakPercentage(previousModel, nextModel, breakMode),
-      breakRules: this._getNextBreakRules(previousModel, {
-        ...nextModel,
+      breakPercentage: this._getNextBreakPercentage(nextModel, breakMode),
+      breakRules: this._getNextBreakRules(
+        nextModel,
+        previousIsBreakEnabled,
+        previousBreakMode,
         breakMode,
-      }),
-    });
+      ),
+    };
+
+    this.model.set(nextModelToSet);
+    this._rememberModelState(nextModelToSet);
   }
 
   save(): void {
@@ -253,46 +267,45 @@ export class DialogFlowtimeSettingsComponent {
   }
 
   private _getNextBreakMode(
-    previousModel: FlowtimeFormModel,
     nextModel: FlowtimeFormModel,
   ): FlowtimeFormModel['breakMode'] {
     const isBreakModeHidden = !nextModel.isBreakEnabled;
 
     return nextModel.breakMode == null && isBreakModeHidden
-      ? (previousModel.breakMode ?? this._initialFlowtimeConfig.breakMode)
+      ? (this._lastBreakMode ?? this._initialFlowtimeConfig.breakMode)
       : nextModel.breakMode;
   }
 
   private _getNextBreakPercentage(
-    previousModel: FlowtimeFormModel,
     nextModel: FlowtimeFormModel,
     breakMode: FlowtimeFormModel['breakMode'],
   ): FlowtimeFormModel['breakPercentage'] {
     const isBreakPercentageHidden = !nextModel.isBreakEnabled || breakMode !== 'ratio';
 
     return nextModel.breakPercentage == null && isBreakPercentageHidden
-      ? (previousModel.breakPercentage ?? this._initialFlowtimeConfig.breakPercentage)
+      ? (this._lastBreakPercentage ?? this._initialFlowtimeConfig.breakPercentage)
       : nextModel.breakPercentage;
   }
 
   private _getNextBreakRules(
-    previousModel: FlowtimeFormModel,
     nextModel: FlowtimeFormModel,
+    previousIsBreakEnabled: FlowtimeFormModel['isBreakEnabled'],
+    previousBreakMode: FlowtimeFormModel['breakMode'],
+    breakMode: FlowtimeFormModel['breakMode'],
   ): FlowtimeBreakRuleInMinutes[] {
-    const previousRules =
-      previousModel.breakRules ??
-      this._toBreakRulesInMinutes(this._initialFlowtimeConfig);
     const nextRules = nextModel.breakRules;
 
     if (!this._isEmptyBreakRules(nextRules)) {
-      return nextRules!;
+      return this._copyBreakRules(nextRules!);
     }
 
     const didRuleFieldsVisibilityChange =
-      previousModel.isBreakEnabled !== nextModel.isBreakEnabled ||
-      previousModel.breakMode !== nextModel.breakMode;
+      previousIsBreakEnabled !== nextModel.isBreakEnabled ||
+      previousBreakMode !== breakMode;
 
-    return didRuleFieldsVisibilityChange ? previousRules : (nextRules ?? []);
+    return didRuleFieldsVisibilityChange
+      ? this._copyBreakRules(this._lastNonEmptyBreakRules)
+      : (nextRules ?? []);
   }
 
   private _isEmptyBreakRules(
@@ -312,6 +325,25 @@ export class DialogFlowtimeSettingsComponent {
 
   private _isBlankFormValue(value: unknown): boolean {
     return value == null || value === '';
+  }
+
+  private _rememberModelState(model: FlowtimeFormModel): void {
+    this._lastIsBreakEnabled = model.isBreakEnabled;
+    this._lastBreakMode = model.breakMode;
+
+    if (!this._isBlankFormValue(model.breakPercentage)) {
+      this._lastBreakPercentage = model.breakPercentage;
+    }
+
+    if (!this._isEmptyBreakRules(model.breakRules)) {
+      this._lastNonEmptyBreakRules = this._copyBreakRules(model.breakRules!);
+    }
+  }
+
+  private _copyBreakRules(
+    breakRules: FlowtimeBreakRuleInMinutes[],
+  ): FlowtimeBreakRuleInMinutes[] {
+    return breakRules.map((rule: FlowtimeBreakRuleInMinutes) => ({ ...rule }));
   }
 
   private _toBreakRulesInMinutes(

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -75,6 +75,7 @@ export class DialogFlowtimeSettingsComponent {
   private _lastBreakMode: FlowtimeFormModel['breakMode'];
   private _lastBreakPercentage: FlowtimeFormModel['breakPercentage'];
   private _lastNonEmptyBreakRules: FlowtimeBreakRuleInMinutes[];
+  private _isRestoringBreakRules = false;
 
   T = T;
   form = new FormGroup({});
@@ -294,17 +295,24 @@ export class DialogFlowtimeSettingsComponent {
     breakMode: FlowtimeFormModel['breakMode'],
   ): FlowtimeBreakRuleInMinutes[] {
     const nextRules = nextModel.breakRules;
-
-    if (!this._isEmptyBreakRules(nextRules)) {
-      return this._copyBreakRules(nextRules!);
-    }
-
     const didRuleFieldsVisibilityChange =
       previousIsBreakEnabled !== nextModel.isBreakEnabled ||
       previousBreakMode !== breakMode;
+    const isRuleModeVisible = nextModel.isBreakEnabled === true && breakMode === 'rule';
+    const shouldRestoreBreakRules =
+      didRuleFieldsVisibilityChange || this._isRestoringBreakRules;
+    const hasRestorableBlankBreakRuleFields =
+      this._hasRestorableBlankBreakRuleFields(nextRules);
 
-    return didRuleFieldsVisibilityChange
-      ? this._copyBreakRules(this._lastNonEmptyBreakRules)
+    this._isRestoringBreakRules =
+      isRuleModeVisible && shouldRestoreBreakRules && hasRestorableBlankBreakRuleFields;
+
+    if (shouldRestoreBreakRules && hasRestorableBlankBreakRuleFields) {
+      return this._restoreBreakRulesFromLastNonEmpty(nextRules);
+    }
+
+    return !this._isEmptyBreakRules(nextRules)
+      ? this._copyBreakRules(nextRules!)
       : (nextRules ?? []);
   }
 
@@ -325,6 +333,52 @@ export class DialogFlowtimeSettingsComponent {
 
   private _isBlankFormValue(value: unknown): boolean {
     return value == null || value === '';
+  }
+
+  private _hasRestorableBlankBreakRuleFields(
+    breakRules: FlowtimeBreakRuleInMinutes[] | undefined,
+  ): boolean {
+    const fallbackRules = this._lastNonEmptyBreakRules.length
+      ? this._lastNonEmptyBreakRules
+      : [this._defaultRuleInMinutes];
+
+    return fallbackRules.some((fallbackRule, index) => {
+      const rule = breakRules?.[index];
+
+      return (
+        !rule ||
+        this._isBlankFormValue(rule.minDuration) ||
+        this._isBlankFormValue(rule.breakDuration) ||
+        (fallbackRule.maxDuration !== null && this._isBlankFormValue(rule.maxDuration))
+      );
+    });
+  }
+
+  private _restoreBreakRulesFromLastNonEmpty(
+    nextRules: FlowtimeBreakRuleInMinutes[] | undefined,
+  ): FlowtimeBreakRuleInMinutes[] {
+    const fallbackRules = this._lastNonEmptyBreakRules.length
+      ? this._lastNonEmptyBreakRules
+      : [this._defaultRuleInMinutes];
+    const rowCount = Math.max(nextRules?.length ?? 0, fallbackRules.length);
+
+    return Array.from({ length: rowCount }, (_, index) => {
+      const nextRule = nextRules?.[index];
+      const fallbackRule =
+        fallbackRules[index] ?? fallbackRules[fallbackRules.length - 1];
+
+      return {
+        minDuration: this._isBlankFormValue(nextRule?.minDuration)
+          ? fallbackRule.minDuration
+          : nextRule!.minDuration,
+        maxDuration: this._isBlankFormValue(nextRule?.maxDuration)
+          ? fallbackRule.maxDuration
+          : nextRule!.maxDuration,
+        breakDuration: this._isBlankFormValue(nextRule?.breakDuration)
+          ? fallbackRule.breakDuration
+          : nextRule!.breakDuration,
+      };
+    });
   }
 
   private _rememberModelState(model: FlowtimeFormModel): void {

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -260,7 +260,7 @@ export class DialogFlowtimeSettingsComponent {
       breakRules:
         currentModel.isBreakEnabled && breakMode === 'rule' && currentModel.breakRules
           ? this._toBreakRulesInMs(currentModel.breakRules)
-          : (this._initialFlowtimeConfig.breakRules ?? []),
+          : this._toBreakRulesInMs(this._lastNonEmptyBreakRules),
     };
 
     this._globalConfigService.updateSection('flowtime', flowtimeConfig, true);
@@ -305,6 +305,17 @@ export class DialogFlowtimeSettingsComponent {
     const isRuleModeVisible = nextModel.isBreakEnabled === true && breakMode === 'rule';
     const shouldRestoreBreakRules =
       didRuleFieldsVisibilityChange || this._isRestoringBreakRules;
+
+    if (
+      this._isRestoringBreakRules &&
+      !didRuleFieldsVisibilityChange &&
+      isRuleModeVisible &&
+      (nextRules?.length ?? 0) < this._lastNonEmptyBreakRules.length
+    ) {
+      this._isRestoringBreakRules = false;
+      return nextRules ? this._copyBreakRules(nextRules) : [];
+    }
+
     const hasRestorableBlankBreakRuleFields =
       this._hasRestorableBlankBreakRuleFields(nextRules);
 

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -421,9 +421,29 @@ export class DialogFlowtimeSettingsComponent {
       this._lastBreakPercentage = model.breakPercentage;
     }
 
-    if (!this._isEmptyBreakRules(model.breakRules)) {
+    if (
+      this._isRuleModeVisible(model) &&
+      this._hasCacheableBreakRules(model.breakRules)
+    ) {
       this._lastNonEmptyBreakRules = this._copyBreakRules(model.breakRules!);
     }
+  }
+
+  private _isRuleModeVisible(model: FlowtimeFormModel): boolean {
+    return model.isBreakEnabled === true && model.breakMode === 'rule';
+  }
+
+  private _hasCacheableBreakRules(
+    breakRules: FlowtimeBreakRuleInMinutes[] | undefined,
+  ): breakRules is FlowtimeBreakRuleInMinutes[] {
+    return (
+      !!breakRules?.length &&
+      breakRules.every(
+        (rule: FlowtimeBreakRuleInMinutes) =>
+          !this._isBlankFormValue(rule.minDuration) &&
+          !this._isBlankFormValue(rule.breakDuration),
+      )
+    );
   }
 
   private _copyBreakRules(

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -205,21 +205,24 @@ export class DialogFlowtimeSettingsComponent {
     };
     this._initialFlowtimeConfig = flowtime;
 
-    const breakRulesInMinutes = (flowtime.breakRules ?? []).map(
-      (rule: FlowtimeBreakRule) => ({
-        minDuration: Math.round(rule.minDuration / 60000),
-        maxDuration:
-          rule.maxDuration === null ? null : Math.round(rule.maxDuration / 60000),
-        breakDuration: Math.round(rule.breakDuration / 60000),
-      }),
-    );
-
     this.model.set({
       ...flowtime,
-      breakRules:
-        breakRulesInMinutes.length > 0
-          ? breakRulesInMinutes
-          : [{ ...this._defaultRuleInMinutes }],
+      breakRules: this._toBreakRulesInMinutes(flowtime),
+    });
+  }
+
+  updateModel(nextModel: FlowtimeFormModel): void {
+    const previousModel = this.model();
+    const breakMode = this._getNextBreakMode(previousModel, nextModel);
+
+    this.model.set({
+      ...nextModel,
+      breakMode,
+      breakPercentage: this._getNextBreakPercentage(previousModel, nextModel, breakMode),
+      breakRules: this._getNextBreakRules(previousModel, {
+        ...nextModel,
+        breakMode,
+      }),
     });
   }
 
@@ -247,6 +250,81 @@ export class DialogFlowtimeSettingsComponent {
 
   close(): void {
     this._dialogRef.close();
+  }
+
+  private _getNextBreakMode(
+    previousModel: FlowtimeFormModel,
+    nextModel: FlowtimeFormModel,
+  ): FlowtimeFormModel['breakMode'] {
+    const isBreakModeHidden = !nextModel.isBreakEnabled;
+
+    return nextModel.breakMode == null && isBreakModeHidden
+      ? (previousModel.breakMode ?? this._initialFlowtimeConfig.breakMode)
+      : nextModel.breakMode;
+  }
+
+  private _getNextBreakPercentage(
+    previousModel: FlowtimeFormModel,
+    nextModel: FlowtimeFormModel,
+    breakMode: FlowtimeFormModel['breakMode'],
+  ): FlowtimeFormModel['breakPercentage'] {
+    const isBreakPercentageHidden = !nextModel.isBreakEnabled || breakMode !== 'ratio';
+
+    return nextModel.breakPercentage == null && isBreakPercentageHidden
+      ? (previousModel.breakPercentage ?? this._initialFlowtimeConfig.breakPercentage)
+      : nextModel.breakPercentage;
+  }
+
+  private _getNextBreakRules(
+    previousModel: FlowtimeFormModel,
+    nextModel: FlowtimeFormModel,
+  ): FlowtimeBreakRuleInMinutes[] {
+    const previousRules =
+      previousModel.breakRules ??
+      this._toBreakRulesInMinutes(this._initialFlowtimeConfig);
+    const nextRules = nextModel.breakRules;
+
+    if (!this._isEmptyBreakRules(nextRules)) {
+      return nextRules!;
+    }
+
+    const didRuleFieldsVisibilityChange =
+      previousModel.isBreakEnabled !== nextModel.isBreakEnabled ||
+      previousModel.breakMode !== nextModel.breakMode;
+
+    return didRuleFieldsVisibilityChange ? previousRules : (nextRules ?? []);
+  }
+
+  private _isEmptyBreakRules(
+    breakRules: FlowtimeBreakRuleInMinutes[] | undefined,
+  ): boolean {
+    return (
+      !breakRules ||
+      breakRules.length === 0 ||
+      breakRules.every(
+        (rule: FlowtimeBreakRuleInMinutes) =>
+          rule.minDuration == null &&
+          rule.maxDuration == null &&
+          rule.breakDuration == null,
+      )
+    );
+  }
+
+  private _toBreakRulesInMinutes(
+    flowtime: Pick<FlowtimeConfig, 'breakRules'>,
+  ): FlowtimeBreakRuleInMinutes[] {
+    const breakRulesInMinutes = (flowtime.breakRules ?? []).map(
+      (rule: FlowtimeBreakRule) => ({
+        minDuration: Math.round(rule.minDuration / 60000),
+        maxDuration:
+          rule.maxDuration === null ? null : Math.round(rule.maxDuration / 60000),
+        breakDuration: Math.round(rule.breakDuration / 60000),
+      }),
+    );
+
+    return breakRulesInMinutes.length > 0
+      ? breakRulesInMinutes
+      : [{ ...this._defaultRuleInMinutes }];
   }
 
   private _toBreakRulesInMs(

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -11,6 +11,7 @@ import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { T } from '../../../t.const';
 import { FlowtimeBreakRule, FlowtimeConfig } from '../../config/global-config.model';
+import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { MatButton } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -69,6 +70,7 @@ export class DialogFlowtimeSettingsComponent {
     maxDuration: 25,
     breakDuration: 5,
   };
+  private readonly _initialFlowtimeConfig: FlowtimeConfig;
 
   T = T;
   form = new FormGroup({});
@@ -194,12 +196,11 @@ export class DialogFlowtimeSettingsComponent {
 
   constructor() {
     const cfg = this._globalConfigService.cfg();
-    const flowtime = cfg?.flowtime ?? {
-      isBreakEnabled: false,
-      breakMode: 'ratio',
-      breakPercentage: 20,
-      breakRules: [],
+    const flowtime = {
+      ...DEFAULT_GLOBAL_CONFIG.flowtime,
+      ...(cfg?.flowtime ?? {}),
     };
+    this._initialFlowtimeConfig = flowtime;
 
     const breakRulesInMinutes = (flowtime.breakRules ?? []).map(
       (rule: FlowtimeBreakRule) => ({
@@ -225,27 +226,16 @@ export class DialogFlowtimeSettingsComponent {
       return;
     }
     const currentModel = this.model();
+    const breakMode = currentModel.breakMode ?? this._initialFlowtimeConfig.breakMode;
     const flowtimeConfig: FlowtimeConfig = {
       isBreakEnabled: currentModel.isBreakEnabled,
-      breakMode: currentModel.breakMode,
-      breakPercentage: currentModel.breakPercentage,
-      breakRules: [...(currentModel.breakRules ?? [])]
-        .sort((a, b) => (a.minDuration ?? 0) - (b.minDuration ?? 0))
-        .map((rule: FlowtimeBreakRuleInMinutes) => {
-          const min = rule.minDuration ?? 0;
-
-          let max = rule.maxDuration == null ? null : rule.maxDuration;
-
-          if (max !== null && max < min) {
-            max = min;
-          }
-
-          return {
-            minDuration: Math.round(min * 60000),
-            maxDuration: max === null ? null : Math.round(max * 60000),
-            breakDuration: Math.round((rule.breakDuration ?? 0) * 60000),
-          };
-        }),
+      breakMode,
+      breakPercentage:
+        currentModel.breakPercentage ?? this._initialFlowtimeConfig.breakPercentage,
+      breakRules:
+        currentModel.isBreakEnabled && breakMode === 'rule' && currentModel.breakRules
+          ? this._toBreakRulesInMs(currentModel.breakRules)
+          : (this._initialFlowtimeConfig.breakRules ?? []),
     };
 
     this._globalConfigService.updateSection('flowtime', flowtimeConfig, true);
@@ -254,5 +244,27 @@ export class DialogFlowtimeSettingsComponent {
 
   close(): void {
     this._dialogRef.close();
+  }
+
+  private _toBreakRulesInMs(
+    breakRules: FlowtimeBreakRuleInMinutes[],
+  ): FlowtimeBreakRule[] {
+    return [...breakRules]
+      .sort((a, b) => (a.minDuration ?? 0) - (b.minDuration ?? 0))
+      .map((rule: FlowtimeBreakRuleInMinutes) => {
+        const min = rule.minDuration ?? 0;
+
+        let max = rule.maxDuration == null ? null : rule.maxDuration;
+
+        if (max !== null && max < min) {
+          max = min;
+        }
+
+        return {
+          minDuration: Math.round(min * 60000),
+          maxDuration: max === null ? null : Math.round(max * 60000),
+          breakDuration: Math.round((rule.breakDuration ?? 0) * 60000),
+        };
+      });
   }
 }

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -225,19 +225,23 @@ export class DialogFlowtimeSettingsComponent {
     const previousIsBreakEnabled = this._lastIsBreakEnabled;
     const previousBreakMode = this._lastBreakMode;
     const breakMode = this._getNextBreakMode(nextModel);
+    const breakRules = this._getNextBreakRules(
+      nextModel,
+      previousIsBreakEnabled,
+      previousBreakMode,
+      breakMode,
+    );
     const nextModelToSet = {
       ...nextModel,
       breakMode,
       breakPercentage: this._getNextBreakPercentage(nextModel, breakMode),
-      breakRules: this._getNextBreakRules(
-        nextModel,
-        previousIsBreakEnabled,
-        previousBreakMode,
-        breakMode,
-      ),
+      breakRules,
     };
 
     this.model.set(nextModelToSet);
+    if (this._hasBreakRuleValueDiff(nextModel.breakRules, breakRules)) {
+      this._patchBreakRulesFormValue(breakRules);
+    }
     this._rememberModelState(nextModelToSet);
   }
 
@@ -378,6 +382,34 @@ export class DialogFlowtimeSettingsComponent {
           ? fallbackRule.breakDuration
           : nextRule!.breakDuration,
       };
+    });
+  }
+
+  private _hasBreakRuleValueDiff(
+    nextRules: FlowtimeBreakRuleInMinutes[] | undefined,
+    restoredRules: FlowtimeBreakRuleInMinutes[],
+  ): boolean {
+    if ((nextRules?.length ?? 0) !== restoredRules.length) {
+      return true;
+    }
+
+    return restoredRules.some((restoredRule, index) => {
+      const nextRule = nextRules?.[index];
+
+      return (
+        !nextRule ||
+        nextRule.minDuration !== restoredRule.minDuration ||
+        nextRule.maxDuration !== restoredRule.maxDuration ||
+        nextRule.breakDuration !== restoredRule.breakDuration
+      );
+    });
+  }
+
+  private _patchBreakRulesFormValue(breakRules: FlowtimeBreakRuleInMinutes[]): void {
+    const breakRulesControl = this.form.get('breakRules') as AbstractControl | null;
+
+    breakRulesControl?.patchValue(this._copyBreakRules(breakRules), {
+      emitEvent: false,
     });
   }
 

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -303,11 +303,15 @@ export class DialogFlowtimeSettingsComponent {
       breakRules.length === 0 ||
       breakRules.every(
         (rule: FlowtimeBreakRuleInMinutes) =>
-          rule.minDuration == null &&
-          rule.maxDuration == null &&
-          rule.breakDuration == null,
+          this._isBlankFormValue(rule.minDuration) &&
+          this._isBlankFormValue(rule.maxDuration) &&
+          this._isBlankFormValue(rule.breakDuration),
       )
     );
+  }
+
+  private _isBlankFormValue(value: unknown): boolean {
+    return value == null || value === '';
   }
 
   private _toBreakRulesInMinutes(

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -91,6 +91,7 @@ export class DialogFlowtimeSettingsComponent {
     {
       key: 'breakMode',
       type: 'select',
+      resetOnHide: false,
       expressions: {
         hide: (field: FormlyFieldConfig) => !field.parent?.model?.isBreakEnabled,
       },
@@ -111,6 +112,7 @@ export class DialogFlowtimeSettingsComponent {
     {
       key: 'breakPercentage',
       type: 'input',
+      resetOnHide: false,
       expressions: {
         hide: (field: FormlyFieldConfig) =>
           !field.parent?.model?.isBreakEnabled ||
@@ -129,6 +131,7 @@ export class DialogFlowtimeSettingsComponent {
       key: 'breakRules',
       description: T.F.FOCUS_MODE.FLOWTIME_BREAK_RULES_DESC,
       type: 'repeat',
+      resetOnHide: false,
       expressions: {
         hide: (field: FormlyFieldConfig) =>
           !field.parent?.model?.isBreakEnabled ||


### PR DESCRIPTION
Part of #7581

## Summary
- preserve hidden Flowtime break settings when breaks are disabled
- restore the saved break mode, percentage, and rules when Flowtime break settings are shown again
- add a regression spec for saving disabled Flowtime breaks without dropping hidden values

## Tests
- npm run checkFile src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
- npm run checkFile src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
- git diff --check HEAD~1..HEAD

## Context
#7581 also includes broader Flowtime defaults/product behavior requests. This PR only covers the narrow config-preservation bug for existing hidden settings.