### PR TITLE
fix(calendar): disable iCal polling on Android

### DIFF
--- a/docs/wiki/3.05-Web-App-vs-Desktop.md
+++ b/docs/wiki/3.05-Web-App-vs-Desktop.md
@@ -10,7 +10,7 @@ Plugins that require Node.js execution (elevated permissions) are disabled in th
 
 ### Calendar Integration
 
-Calendar providers can be disabled for the web app via an `isDisabledForWebApp` flag to avoid CORS failures. When this flag is set and the app runs in a browser, calendar event requests return empty results instead of performing the HTTP request. The UI shows a prominent warning that calendar integration will likely not work in the browser and recommends downloading the desktop version.
+Calendar providers can be disabled for the web app or Android app via an `isDisabledForWebApp` flag to avoid CORS and WebView failures. When this flag is set and the app runs in a browser or Android WebView, calendar event requests return empty results instead of performing the HTTP request. The UI shows a prominent warning that calendar integration will likely not work in the browser or Android app and recommends downloading the desktop version.
 
 ### Local File System
 

--- a/docs/wiki/3.07-Issue-Integration-Comparison.md
+++ b/docs/wiki/3.07-Issue-Integration-Comparison.md
@@ -104,6 +104,7 @@ Every issue provider supports the same basic operations: checking that the integ
 - **Due dates:** Event start time (all-day or timed).
 - **Descriptions:** Event description as task notes.
 - **URL format (example Nextcloud):** Use the **“Copy subscription link”** so the URL is in the correct form, e.g. `https://<NC-URL>/remote.php/dav/public-calendars/<CALENDAR-ID>?export`. Paste this in the app under **“URL of the iCal source.”** Do **not** use the “Copy private link”—that format is for CalDAV, not iCal.
+- **Platform note:** The **Disable in web or Android app** setting suppresses iCal requests in the browser and on Android, where WebView network restrictions can produce similar failures.
 
 ### 8. Redmine
 

--- a/src/app/features/calendar-integration/calendar-integration.service.spec.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.spec.ts
@@ -944,7 +944,7 @@ END:VCALENDAR`;
 
   describe('testConnection', () => {
     it('should return true when connection succeeds', async () => {
-      const cfg = { icalUrl: 'https://example.com/calendar.ics' } as any;
+      const cfg = createMockProvider();
 
       const promise = service.testConnection(cfg);
 
@@ -956,7 +956,7 @@ END:VCALENDAR`;
     });
 
     it('should return false when connection fails', async () => {
-      const cfg = { icalUrl: 'https://example.com/calendar.ics' } as any;
+      const cfg = createMockProvider();
 
       const promise = service.testConnection(cfg);
 
@@ -968,7 +968,7 @@ END:VCALENDAR`;
     });
 
     it('should return false for empty response', async () => {
-      const cfg = { icalUrl: 'https://example.com/calendar.ics' } as any;
+      const cfg = createMockProvider();
 
       const promise = service.testConnection(cfg);
 
@@ -1094,15 +1094,16 @@ END:VCALENDAR`;
         isDisabledForWebApp: true,
       });
 
-      // Note: IS_WEB_BROWSER might be false in tests, so this test might not fully work
-      const sub = service.requestEvents$(mockProvider).subscribe(() => {
-        // Subscribe to trigger the request
+      let result: CalendarIntegrationEvent[] | undefined;
+      const sub = service.requestEvents$(mockProvider).subscribe((events) => {
+        result = events;
       });
       subscriptions.push(sub);
 
       flush();
 
-      // May or may not make request depending on IS_WEB_BROWSER
+      expect(result).toEqual([]);
+      httpMock.expectNone(mockProvider.icalUrl);
     }));
 
     it('should handle parse errors gracefully', fakeAsync(() => {

--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -62,6 +62,7 @@ import { HiddenCalendarEventsService } from './hidden-calendar-events.service';
 import { TaskArchiveService } from '../archive/task-archive.service';
 import { passesCalendarEventRegexFilter } from './calendar-event-regex-filter';
 import { NotIcalResponseError } from '../schedule/ical/is-likely-ical';
+import { isCalendarProviderDisabledOnCurrentPlatform } from '../issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util';
 
 const ONE_MONTHS = 60 * 60 * 1000 * 24 * 31;
 const ONE_WEEK = 60 * 60 * 1000 * 24 * 7;
@@ -416,8 +417,9 @@ export class CalendarIntegrationService {
     end = getEndOfDayTimestamp(),
     isForwardError = false,
   ): Observable<CalendarIntegrationEvent[]> {
-    // allow calendars to be disabled for web apps if CORS will fail to prevent errors
-    if (calProvider.isDisabledForWebApp && IS_WEB_BROWSER) {
+    // Allow calendars to be disabled where the app uses browser/WebView requests
+    // that often fail due to remote calendar CORS or redirect behavior.
+    if (isCalendarProviderDisabledOnCurrentPlatform(calProvider, IS_WEB_BROWSER)) {
       return of([]);
     }
     return this._http

--- a/src/app/features/issue/providers/calendar/calendar-common-interfaces.service.spec.ts
+++ b/src/app/features/issue/providers/calendar/calendar-common-interfaces.service.spec.ts
@@ -8,11 +8,26 @@ import { getDbDateStr } from '../../../../util/get-db-date-str';
 import { of } from 'rxjs';
 import { Task } from '../../../tasks/task.model';
 import { CalendarIntegrationEvent } from '../../../calendar-integration/calendar-integration.model';
+import { IssueProviderCalendar } from '../../issue.model';
+import { DEFAULT_CALENDAR_CFG } from './calendar.const';
 
 describe('CalendarCommonInterfacesService', () => {
   let service: CalendarCommonInterfacesService;
   let calendarIntegrationServiceSpy: jasmine.SpyObj<CalendarIntegrationService>;
   let issueProviderServiceSpy: jasmine.SpyObj<IssueProviderService>;
+  const createCalendarProvider = (
+    overrides: Partial<IssueProviderCalendar> = {},
+  ): IssueProviderCalendar => ({
+    id: 'provider-1',
+    issueProviderKey: 'ICAL',
+    isEnabled: true,
+    icalUrl: 'https://example.com/calendar.ics',
+    checkUpdatesEvery: DEFAULT_CALENDAR_CFG.checkUpdatesEvery,
+    showBannerBeforeThreshold: DEFAULT_CALENDAR_CFG.showBannerBeforeThreshold,
+    isAutoImportForCurrentDay: DEFAULT_CALENDAR_CFG.isAutoImportForCurrentDay,
+    isDisabledForWebApp: false,
+    ...overrides,
+  });
 
   beforeEach(() => {
     calendarIntegrationServiceSpy = jasmine.createSpyObj('CalendarIntegrationService', [
@@ -37,6 +52,22 @@ describe('CalendarCommonInterfacesService', () => {
       ],
     });
     service = TestBed.inject(CalendarCommonInterfacesService);
+  });
+
+  describe('isEnabled', () => {
+    it('should disable iCal providers marked as disabled for web app in browser tests', () => {
+      expect(
+        service.isEnabled(
+          createCalendarProvider({
+            isDisabledForWebApp: true,
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('should keep enabled iCal providers active when the platform disable flag is off', () => {
+      expect(service.isEnabled(createCalendarProvider())).toBe(true);
+    });
   });
 
   describe('getAddTaskData', () => {

--- a/src/app/features/issue/providers/calendar/calendar-common-interfaces.service.ts
+++ b/src/app/features/issue/providers/calendar/calendar-common-interfaces.service.ts
@@ -16,6 +16,7 @@ import { ICAL_TYPE } from '../../issue.const';
 import { getDbDateStr } from '../../../../util/get-db-date-str';
 import { CALENDAR_POLL_INTERVAL } from './calendar.const';
 import { passesCalendarEventRegexFilter } from '../../../calendar-integration/calendar-event-regex-filter';
+import { isCalendarProviderDisabledOnCurrentPlatform } from './is-calendar-provider-disabled-on-current-platform.util';
 
 @Injectable({
   providedIn: 'root',
@@ -27,7 +28,11 @@ export class CalendarCommonInterfacesService extends BaseIssueProviderService<Is
   readonly pollInterval: number = CALENDAR_POLL_INTERVAL;
 
   isEnabled(cfg: IssueProviderCalendar): boolean {
-    return cfg.isEnabled && cfg.icalUrl?.length > 0;
+    return (
+      cfg.isEnabled &&
+      cfg.icalUrl?.length > 0 &&
+      !isCalendarProviderDisabledOnCurrentPlatform(cfg)
+    );
   }
 
   // Uses CalendarIntegrationService for connection testing

--- a/src/app/features/issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util.spec.ts
+++ b/src/app/features/issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util.spec.ts
@@ -1,0 +1,37 @@
+import { isCalendarProviderDisabledOnCurrentPlatform } from './is-calendar-provider-disabled-on-current-platform.util';
+import { IssueProviderCalendar } from '../../issue.model';
+
+const createCalendarProvider = (
+  overrides: Partial<IssueProviderCalendar> = {},
+): Pick<IssueProviderCalendar, 'isDisabledForWebApp'> => ({
+  isDisabledForWebApp: false,
+  ...overrides,
+});
+
+describe('isCalendarProviderDisabledOnCurrentPlatform', () => {
+  it('returns false when the provider disable flag is off', () => {
+    const provider = createCalendarProvider({ isDisabledForWebApp: false });
+
+    expect(isCalendarProviderDisabledOnCurrentPlatform(provider, true, true)).toBe(false);
+  });
+
+  it('returns true for browsers when the provider disable flag is on', () => {
+    const provider = createCalendarProvider({ isDisabledForWebApp: true });
+
+    expect(isCalendarProviderDisabledOnCurrentPlatform(provider, true, false)).toBe(true);
+  });
+
+  it('returns true for Android when the provider disable flag is on', () => {
+    const provider = createCalendarProvider({ isDisabledForWebApp: true });
+
+    expect(isCalendarProviderDisabledOnCurrentPlatform(provider, false, true)).toBe(true);
+  });
+
+  it('returns false for desktop when the provider disable flag is on', () => {
+    const provider = createCalendarProvider({ isDisabledForWebApp: true });
+
+    expect(isCalendarProviderDisabledOnCurrentPlatform(provider, false, false)).toBe(
+      false,
+    );
+  });
+});

--- a/src/app/features/issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util.ts
+++ b/src/app/features/issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util.ts
@@ -1,0 +1,9 @@
+import { IS_WEB_BROWSER } from '../../../../app.constants';
+import { IS_ANDROID_NATIVE } from '../../../../util/is-native-platform';
+import { IssueProviderCalendar } from '../../issue.model';
+
+export const isCalendarProviderDisabledOnCurrentPlatform = (
+  calProvider: Pick<IssueProviderCalendar, 'isDisabledForWebApp'>,
+  isWebBrowser = IS_WEB_BROWSER,
+  isAndroidNative = IS_ANDROID_NATIVE,
+): boolean => !!calProvider.isDisabledForWebApp && (isWebBrowser || isAndroidNative);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2243,11 +2243,11 @@
     },
     "CALENDARS": {
       "AUTO_IMPORT_FOR_CURRENT_DAY": "Auto import events as tasks for current day",
-      "BROWSER_WARNING": "Due to cross-origin restrictions <b>this will likely NOT work with the web browser version of Super Productivity.<br /> Please <a href=\"https://super-productivity.com/download/\">download the desktop version</a> to use this feature!</b>",
+      "BROWSER_WARNING": "Due to cross-origin and WebView restrictions <b>this will likely NOT work with the web browser or Android app versions of Super Productivity.<br /> Please <a href=\"https://super-productivity.com/download/\">download the desktop version</a> to use this feature!</b>",
       "CAL_COLOR": "Calendar color",
       "CAL_PATH": "URL of the iCal source",
       "CHECK_UPDATES": "Check for remote updates every X",
-      "DISABLE_FOR_WEB_APP": "Disable when using web application",
+      "DISABLE_FOR_WEB_APP": "Disable in web or Android app",
       "FILTER_EXCLUDE_REGEX": "Exclude events matching regex (optional)",
       "FILTER_EXCLUDE_REGEX_DESCRIPTION": "Events whose title matches this regular expression will be hidden. Applied after the include filter. Example: Lunch|Daily|Blocker",
       "FILTER_INCLUDE_REGEX": "Include events matching regex (optional)",


### PR DESCRIPTION
Fixes #7406

## Summary
- extend the existing iCal "disable in web app" setting so it also disables provider polling/requesting on Android WebView
- keep manual connection testing behavior unchanged while suppressing automatic event requests for disabled providers
- update the English setting copy and wiki docs to mention Android/WebView behavior

## Verification
- `npm run checkFile src/app/features/calendar-integration/calendar-integration.service.ts`
- `npm run checkFile src/app/features/calendar-integration/calendar-integration.service.spec.ts`
- `npm run checkFile src/app/features/issue/providers/calendar/calendar-common-interfaces.service.ts`
- `npm run checkFile src/app/features/issue/providers/calendar/calendar-common-interfaces.service.spec.ts`
- `npm run checkFile src/app/features/issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util.ts`
- `npm run checkFile src/app/features/issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/issue/providers/calendar/is-calendar-provider-disabled-on-current-platform.util.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/calendar-integration/calendar-integration.service.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/issue/providers/calendar/calendar-common-interfaces.service.spec.ts`
- `npm run int:test`
- `git diff --check`
- `git diff HEAD~1..HEAD --check`