### PR TITLE
fix(notes): keep long mobile note panel dismissible

### DIFF
--- a/src/app/features/bottom-panel/bottom-panel-container.component.html
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.html
@@ -10,8 +10,8 @@
         mat-icon-button
         class="close-btn"
         [attr.aria-label]="T.G.CLOSE | translate"
-        (pointerdown)="$event.stopPropagation()"
-        (click)="close(); $event.stopPropagation()"
+        (pointerdown)="stopHeaderEventPropagation($event)"
+        (click)="close(); stopHeaderEventPropagation($event)"
       >
         <mat-icon>close</mat-icon>
       </button>

--- a/src/app/features/bottom-panel/bottom-panel-container.component.html
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.html
@@ -1,16 +1,21 @@
 <div class="bottom-panel-container">
   <div
     class="bottom-panel-header"
+    [class.has-close-btn]="isShowCloseButton()"
     #panelHeader
   >
     <div class="drag-handle"></div>
-    <button
-      mat-icon-button
-      class="close-btn"
-      (click)="close()"
-    >
-      <mat-icon>close</mat-icon>
-    </button>
+    @if (isShowCloseButton()) {
+      <button
+        mat-icon-button
+        class="close-btn"
+        [attr.aria-label]="T.G.CLOSE | translate"
+        (pointerdown)="$event.stopPropagation()"
+        (click)="close(); $event.stopPropagation()"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    }
   </div>
 
   <div class="bottom-panel-content">

--- a/src/app/features/bottom-panel/bottom-panel-container.component.scss
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.scss
@@ -38,7 +38,20 @@
   }
 
   .close-btn {
-    display: none; // Hidden for now
+    display: none; // Hidden by default to keep task panel autofocus behavior unchanged.
+  }
+
+  &.has-close-btn {
+    justify-content: center;
+
+    .close-btn {
+      display: inline-flex;
+      position: absolute;
+      right: 4px;
+      top: 50%;
+      transform: translateY(-50%);
+      pointer-events: auto;
+    }
   }
 }
 

--- a/src/app/features/bottom-panel/bottom-panel-container.component.spec.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.spec.ts
@@ -1,4 +1,8 @@
-import { getInitialBottomPanelHeightRatio } from './bottom-panel-container.component';
+import {
+  getInitialBottomPanelHeightRatio,
+  isBottomPanelCloseButtonVisible,
+  stopBottomPanelHeaderEventPropagation,
+} from './bottom-panel-container.component';
 
 describe('getInitialBottomPanelHeightRatio', () => {
   it('uses the compact height for task panels', () => {
@@ -12,5 +16,24 @@ describe('getInitialBottomPanelHeightRatio', () => {
   it('uses the expanded height for other panels', () => {
     expect(getInitialBottomPanelHeightRatio('ISSUE_PANEL')).toBe(0.9);
     expect(getInitialBottomPanelHeightRatio(null)).toBe(0.9);
+  });
+});
+
+describe('isBottomPanelCloseButtonVisible', () => {
+  it('only shows the close button for notes panels', () => {
+    expect(isBottomPanelCloseButtonVisible('NOTES')).toBeTrue();
+    expect(isBottomPanelCloseButtonVisible('TASK')).toBeFalse();
+    expect(isBottomPanelCloseButtonVisible('ISSUE_PANEL')).toBeFalse();
+    expect(isBottomPanelCloseButtonVisible(null)).toBeFalse();
+  });
+});
+
+describe('stopBottomPanelHeaderEventPropagation', () => {
+  it('stops close-button pointer and click events from starting a header drag', () => {
+    const event = jasmine.createSpyObj<Event>('event', ['stopPropagation']);
+
+    stopBottomPanelHeaderEventPropagation(event);
+
+    expect(event.stopPropagation).toHaveBeenCalledOnceWith();
   });
 });

--- a/src/app/features/bottom-panel/bottom-panel-container.component.spec.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.spec.ts
@@ -1,0 +1,16 @@
+import { getInitialBottomPanelHeightRatio } from './bottom-panel-container.component';
+
+describe('getInitialBottomPanelHeightRatio', () => {
+  it('uses the compact height for task panels', () => {
+    expect(getInitialBottomPanelHeightRatio('TASK')).toBe(0.6);
+  });
+
+  it('uses the compact height for notes panels', () => {
+    expect(getInitialBottomPanelHeightRatio('NOTES')).toBe(0.6);
+  });
+
+  it('uses the expanded height for other panels', () => {
+    expect(getInitialBottomPanelHeightRatio('ISSUE_PANEL')).toBe(0.9);
+    expect(getInitialBottomPanelHeightRatio(null)).toBe(0.9);
+  });
+});

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -27,6 +27,8 @@ import { PanelContentService, PanelContentType } from '../panels/panel-content.s
 import { BottomPanelStateService } from '../../core-ui/bottom-panel-state.service';
 import { IS_TOUCH_ONLY } from '../../util/is-touch-only';
 import { BodyClass } from '../../app.constants';
+import { T } from '../../t.const';
+import { TranslatePipe } from '@ngx-translate/core';
 
 export interface BottomPanelData {
   panelContent: PanelContentType;
@@ -36,6 +38,7 @@ const PANEL_HEIGHTS = {
   MAX_HEIGHT: 0.8,
   MAX_HEIGHT_ABSOLUTE: 0.98,
   TASK_PANEL_HEIGHT: 0.6,
+  NOTES_PANEL_HEIGHT: 0.6,
   OTHER_PANEL_HEIGHT: 0.9,
   // Upward fling → expand to MAX_HEIGHT.
   VELOCITY_THRESHOLD: 0.5, // px/ms
@@ -63,6 +66,19 @@ const PANEL_HEIGHTS = {
   INITIAL_ANIMATION_BLOCK_DURATION: 300,
 } as const;
 
+export const getInitialBottomPanelHeightRatio = (
+  panelContent: PanelContentType | null,
+): number => {
+  switch (panelContent) {
+    case 'TASK':
+      return PANEL_HEIGHTS.TASK_PANEL_HEIGHT;
+    case 'NOTES':
+      return PANEL_HEIGHTS.NOTES_PANEL_HEIGHT;
+    default:
+      return PANEL_HEIGHTS.OTHER_PANEL_HEIGHT;
+  }
+};
+
 const KEYBOARD_DETECT_THRESHOLD = 100;
 const KEYBOARD_SAFE_HEIGHT_MIN = 200;
 const KEYBOARD_SAFE_HEIGHT_RATIO = 0.85;
@@ -85,10 +101,12 @@ const CSS_VAR_VISUAL_VIEWPORT_HEIGHT = '--visual-viewport-height';
     IssuePanelComponent,
     TaskViewCustomizerPanelComponent,
     PluginPanelContainerComponent,
+    TranslatePipe,
   ],
   standalone: true,
 })
 export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
+  readonly T = T;
   private _bottomSheetRef = inject(MatBottomSheetRef<BottomPanelContainerComponent>);
   private _elementRef = inject(ElementRef);
   private _taskService = inject(TaskService);
@@ -105,6 +123,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const dataContent = this.data?.panelContent ?? null;
     return dataContent ?? this._panelContentService.getCurrentPanelType();
   });
+  readonly isShowCloseButton = computed<boolean>(() => this.panelContent() === 'NOTES');
   readonly selectedTask = toSignal(this._taskService.selectedTask$, {
     initialValue: null,
   });
@@ -408,10 +427,7 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   private _setInitialHeight(): void {
     const container = this._getSheetContainer();
     if (container) {
-      const heightRatio =
-        this.panelContent() === 'TASK'
-          ? PANEL_HEIGHTS.TASK_PANEL_HEIGHT
-          : PANEL_HEIGHTS.OTHER_PANEL_HEIGHT;
+      const heightRatio = getInitialBottomPanelHeightRatio(this.panelContent());
       const initialHeight = window.innerHeight * heightRatio;
       container.style.height = `${initialHeight}px`;
       container.style.maxHeight = `${initialHeight}px`;

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -79,6 +79,14 @@ export const getInitialBottomPanelHeightRatio = (
   }
 };
 
+export const isBottomPanelCloseButtonVisible = (
+  panelContent: PanelContentType | null,
+): boolean => panelContent === 'NOTES';
+
+export const stopBottomPanelHeaderEventPropagation = (event: Event): void => {
+  event.stopPropagation();
+};
+
 const KEYBOARD_DETECT_THRESHOLD = 100;
 const KEYBOARD_SAFE_HEIGHT_MIN = 200;
 const KEYBOARD_SAFE_HEIGHT_RATIO = 0.85;
@@ -123,7 +131,9 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const dataContent = this.data?.panelContent ?? null;
     return dataContent ?? this._panelContentService.getCurrentPanelType();
   });
-  readonly isShowCloseButton = computed<boolean>(() => this.panelContent() === 'NOTES');
+  readonly isShowCloseButton = computed<boolean>(() =>
+    isBottomPanelCloseButtonVisible(this.panelContent()),
+  );
   readonly selectedTask = toSignal(this._taskService.selectedTask$, {
     initialValue: null,
   });
@@ -184,6 +194,10 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
 
   close(): void {
     this._bottomSheetRef.dismiss();
+  }
+
+  stopHeaderEventPropagation(event: Event): void {
+    stopBottomPanelHeaderEventPropagation(event);
   }
 
   private _setupDragListeners(): void {


### PR DESCRIPTION
Fixes #5849

## Summary
- start the notes bottom sheet at the same compact height as task panels instead of the expanded generic panel height
- show the bottom-sheet close button for notes panels only, with translated aria text
- keep the close button clickable inside the draggable header without changing the task panel header/autofocus behavior

## Validation
- `npm run checkFile src/app/features/bottom-panel/bottom-panel-container.component.ts`
- `npm run checkFile src/app/features/bottom-panel/bottom-panel-container.component.scss`
- `npm run checkFile src/app/features/bottom-panel/bottom-panel-container.component.spec.ts`
- `npx prettier --check src/app/features/bottom-panel/bottom-panel-container.component.html`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/bottom-panel/bottom-panel-container.component.spec.ts`
- `npm run int:test`
- `git diff --check`

## Conflict/duplication checks
- issue #5849 is open and unassigned
- no exact open PR for #5849 found
- checked nearby note/task UX PRs #8044, #8100, and #8156; this patch only touches bottom-panel container files and `merge-tree` showed no conflict markers
