### PR TITLE
fix(android): close popups with back button

### DIFF
--- a/src/app/features/android/android-back-button.service.integration.spec.ts
+++ b/src/app/features/android/android-back-button.service.integration.spec.ts
@@ -11,6 +11,7 @@ import { DefaultStartPage } from '../config/default-start-page.const';
 import { selectIsOverlayShown } from '../focus-mode/store/focus-mode.selectors';
 import { selectAllProjects } from '../project/store/project.selectors';
 import { TODAY_TAG } from '../tag/tag.const';
+import { LayoutService } from '../../core-ui/layout/layout.service';
 
 /**
  * Integration test that exercises the decision logic against the REAL Angular
@@ -66,6 +67,15 @@ describe('AndroidBackButtonService integration with real Router (#7972)', () => 
           },
         },
         { provide: MatDialog, useValue: { openDialogs: [] } },
+        {
+          provide: LayoutService,
+          useValue: {
+            isShowAddTaskBar: () => false,
+            isShowIssuePanel: () => false,
+            hideAddTaskBar: jasmine.createSpy('hideAddTaskBar'),
+            hideAddTaskPanel: jasmine.createSpy('hideAddTaskPanel'),
+          },
+        },
       ],
     });
 

--- a/src/app/features/android/android-back-button.service.spec.ts
+++ b/src/app/features/android/android-back-button.service.spec.ts
@@ -14,6 +14,7 @@ import { selectAllProjects } from '../project/store/project.selectors';
 import { AppFeaturesConfig } from '../config/global-config.model';
 import { getStartPageUrlPath } from '../config/default-start-page.util';
 import { hideFocusOverlay } from '../focus-mode/store/focus-mode.actions';
+import { LayoutService } from '../../core-ui/layout/layout.service';
 
 const TODAY_URL = `/tag/${TODAY_TAG.id}/tasks`;
 
@@ -31,6 +32,10 @@ describe('AndroidBackButtonService (#7972)', () => {
   let misc: { defaultStartPage?: number | string } | undefined;
   let appFeatures: Record<string, boolean>;
   let openDialogs: MatDialogRef<unknown>[];
+  let isShowAddTaskBar: jasmine.Spy<() => boolean>;
+  let isShowIssuePanel: jasmine.Spy<() => boolean>;
+  let hideAddTaskBar: jasmine.Spy;
+  let hideAddTaskPanel: jasmine.Spy;
 
   const setProjects = (projects: Project[]): void => {
     store.overrideSelector(selectAllProjects, projects);
@@ -56,6 +61,10 @@ describe('AndroidBackButtonService (#7972)', () => {
       isSchedulerEnabled: true,
       isBoardsEnabled: true,
     };
+    isShowAddTaskBar = jasmine.createSpy('isShowAddTaskBar').and.returnValue(false);
+    isShowIssuePanel = jasmine.createSpy('isShowIssuePanel').and.returnValue(false);
+    hideAddTaskBar = jasmine.createSpy('hideAddTaskBar');
+    hideAddTaskPanel = jasmine.createSpy('hideAddTaskPanel');
 
     TestBed.configureTestingModule({
       providers: [
@@ -83,6 +92,15 @@ describe('AndroidBackButtonService (#7972)', () => {
             get openDialogs(): MatDialogRef<unknown>[] {
               return openDialogs;
             },
+          },
+        },
+        {
+          provide: LayoutService,
+          useValue: {
+            isShowAddTaskBar,
+            isShowIssuePanel,
+            hideAddTaskBar,
+            hideAddTaskPanel,
           },
         },
       ],
@@ -198,6 +216,55 @@ describe('AndroidBackButtonService (#7972)', () => {
 
       expect(historyBack).toHaveBeenCalled();
       expect(dialog.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('store-backed layout popups', () => {
+    it('hides the add-task bar before exiting from the start page', () => {
+      isShowAddTaskBar.and.returnValue(true);
+
+      service.handleBackButton();
+
+      expect(hideAddTaskBar).toHaveBeenCalled();
+      expect(hideAddTaskPanel).not.toHaveBeenCalled();
+      expect(minimizeApp).not.toHaveBeenCalled();
+      expect(navigateByUrl).not.toHaveBeenCalled();
+      expect(historyBack).not.toHaveBeenCalled();
+    });
+
+    it('hides the issue panel before exiting from the start page', () => {
+      isShowIssuePanel.and.returnValue(true);
+
+      service.handleBackButton();
+
+      expect(hideAddTaskPanel).toHaveBeenCalled();
+      expect(hideAddTaskBar).not.toHaveBeenCalled();
+      expect(minimizeApp).not.toHaveBeenCalled();
+      expect(navigateByUrl).not.toHaveBeenCalled();
+      expect(historyBack).not.toHaveBeenCalled();
+    });
+
+    it('lets history-backed overlays take precedence over store-backed popups', () => {
+      (
+        service as unknown as { _isHistoryOverlayOpen: jasmine.Spy }
+      )._isHistoryOverlayOpen.and.returnValue(true);
+      isShowAddTaskBar.and.returnValue(true);
+
+      service.handleBackButton();
+
+      expect(historyBack).toHaveBeenCalled();
+      expect(hideAddTaskBar).not.toHaveBeenCalled();
+    });
+
+    it('closes a modal dialog before store-backed popups', () => {
+      const dialog = fakeDialog();
+      openDialogs = [dialog];
+      isShowAddTaskBar.and.returnValue(true);
+
+      service.handleBackButton();
+
+      expect(dialog.close).toHaveBeenCalled();
+      expect(hideAddTaskBar).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/features/android/android-back-button.service.ts
+++ b/src/app/features/android/android-back-button.service.ts
@@ -10,6 +10,7 @@ import { getStartPageUrlPath } from '../config/default-start-page.util';
 import { selectIsOverlayShown } from '../focus-mode/store/focus-mode.selectors';
 import { selectAllProjects } from '../project/store/project.selectors';
 import { hideFocusOverlay } from '../focus-mode/store/focus-mode.actions';
+import { LayoutService } from '../../core-ui/layout/layout.service';
 
 /**
  * Implements Android back-button behavior for top-level (bottom-nav) destinations
@@ -24,9 +25,9 @@ import { hideFocusOverlay } from '../focus-mode/store/focus-mode.actions';
  * History-backed overlays (side-nav, task-detail, notes, fullscreen-markdown)
  * and non-top-level pages (context sub-pages, settings, search, …) keep their
  * existing `window.history.back()` behavior so back still closes overlays and
- * navigates up. Focus mode is store-backed and is closed directly. A plain
- * modal dialog (no history state) is dismissed directly so back closes it
- * rather than minimizing the app underneath it.
+ * navigates up. Focus mode and layout popups are store-backed and are closed
+ * directly. A plain modal dialog (no history state) is dismissed directly so
+ * back closes it rather than minimizing the app underneath it.
  */
 @Injectable({ providedIn: 'root' })
 export class AndroidBackButtonService {
@@ -34,6 +35,7 @@ export class AndroidBackButtonService {
   private readonly _globalConfigService = inject(GlobalConfigService);
   private readonly _store = inject(Store);
   private readonly _matDialog = inject(MatDialog);
+  private readonly _layoutService = inject(LayoutService);
 
   private readonly _isFocusOverlayShown = this._store.selectSignal(selectIsOverlayShown);
   private readonly _allProjects = this._store.selectSignal(selectAllProjects);
@@ -65,7 +67,13 @@ export class AndroidBackButtonService {
       return;
     }
 
-    // 4. Not a top-level destination (context sub-page, settings, search, …)
+    // 4. Store-backed layout popups do not push history state or open a
+    //    MatDialog, so close them before falling through to navigation/exit.
+    if (this._closeStoreBackedPopup()) {
+      return;
+    }
+
+    // 5. Not a top-level destination (context sub-page, settings, search, …)
     //    → navigate up via the history stack as before.
     const currentUrl = this._router.url;
     if (!this._isTopLevelDestination(currentUrl)) {
@@ -77,7 +85,7 @@ export class AndroidBackButtonService {
       return;
     }
 
-    // 5. A top-level destination → pop to the start destination, or exit if
+    // 6. A top-level destination → pop to the start destination, or exit if
     //    already there.
     const startUrl = this._getStartPageUrl();
     if (this._pathOf(currentUrl) === this._pathOf(startUrl)) {
@@ -85,6 +93,20 @@ export class AndroidBackButtonService {
     } else {
       this._router.navigateByUrl(startUrl, { replaceUrl: true });
     }
+  }
+
+  private _closeStoreBackedPopup(): boolean {
+    if (this._layoutService.isShowAddTaskBar()) {
+      this._layoutService.hideAddTaskBar();
+      return true;
+    }
+
+    if (this._layoutService.isShowIssuePanel()) {
+      this._layoutService.hideAddTaskPanel();
+      return true;
+    }
+
+    return false;
   }
 
   private _isHistoryOverlayOpen(): boolean {


### PR DESCRIPTION
## Summary
- close the add-task bar when Android back is pressed before falling through to navigation or app minimize
- close the issue provider panel through the same back-button path
- keep existing priority for focus overlay, history-backed overlays, and Material dialogs

Fixes #6638

## Verification
- npm run checkFile src/app/features/android/android-back-button.service.ts
- npm run checkFile src/app/features/android/android-back-button.service.spec.ts
- npm run checkFile src/app/features/android/android-back-button.service.integration.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/android/android-back-button.service.spec.ts
- CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/android/android-back-button.service.integration.spec.ts
- npm run int:test
- git diff --check