### PR TITLE
fix(header): show focus mode entry on mobile

### DIFF
--- a/docs/wiki/4.15-Timers-and-Focus-Mode.md
+++ b/docs/wiki/4.15-Timers-and-Focus-Mode.md
@@ -2,6 +2,8 @@
 
 Focus Mode in Super Productivity addresses a central challenge of task-based work: **maintaining sustained attention and structured work sessions** in the face of distractions and context switching. The app is designed to help you stay organized and focused through timeboxing, time tracking, break reminders, anti-procrastination features, and a Pomodoro-style timer—all working together to support healthy, productive habits. Timers and focus are treated as a **first-class feature**: they have dedicated configuration, distinct modes with clear behavior, and deep integration with task tracking and metrics. Understanding what problem Focus Mode solves, how it relates to time-boxing and deep work, what the app assumes about focus when using timers, and how timers influence your behavior helps you use it effectively.
 
+You can enter Focus Mode from the focus button in the main header on both desktop and mobile layouts. The keyboard shortcut is listed in [[3.03-Keyboard-Shortcuts]].
+
 For how time is logged when you track a task, see [[4.14-How-Time-Is-Logged]]. Focus Mode settings (sync with task tracking, tick sound, preparation screen, breaks, etc.) are in [[3.02-Settings-and-Preferences]].
 
 ## What Problem Does Focus Mode Solve?

--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -13,8 +13,7 @@
           ></play-button>
         }
 
-        <!-- Focus button: always inline on desktop; on mobile only while a
-             session/break is active, so the running countdown stays reachable. -->
+        <!-- Focus button: keep the entry point discoverable on desktop and mobile. -->
         @if (isFocusButtonVisible()) {
           <focus-button></focus-button>
         }

--- a/src/app/core-ui/main-header/main-header.component.spec.ts
+++ b/src/app/core-ui/main-header/main-header.component.spec.ts
@@ -1,5 +1,31 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EnvironmentInjector,
+  runInInjectionContext,
+  signal,
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { EMPTY, of } from 'rxjs';
+
+import { MainHeaderComponent } from './main-header.component';
+import { ProjectService } from '../../features/project/project.service';
+import { LayoutService } from '../layout/layout.service';
+import { TaskService } from '../../features/tasks/task.service';
+import { WorkContextService } from '../../features/work-context/work-context.service';
+import { SimpleCounterService } from '../../features/simple-counter/simple-counter.service';
+import { SyncWrapperService } from '../../imex/sync/sync-wrapper.service';
+import { SnackService } from '../../core/snack/snack.service';
+import { Router } from '@angular/router';
+import { GlobalConfigService } from '../../features/config/global-config.service';
+import { MatDialog } from '@angular/material/dialog';
+import { Store } from '@ngrx/store';
+import { DataInitStateService } from '../../core/data-init/data-init-state.service';
+import { MetricService } from '../../features/metric/metric.service';
+import { DateService } from '../../core/date/date.service';
+import { UserProfileService } from '../../features/user-profile/user-profile.service';
+import { FocusModeService } from '../../features/focus-mode/focus-mode.service';
+import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 
 // Regression test for #7477: in a project view a long title pushed the
 // right-side header actions (simple-counter / habit buttons) off screen.
@@ -86,5 +112,137 @@ describe('MainHeaderComponent layout', () => {
     } finally {
       document.body.removeChild(fixture.nativeElement);
     }
+  });
+});
+
+describe('MainHeaderComponent focus button visibility', () => {
+  let component: MainHeaderComponent;
+  let isXs = signal(false);
+  let isXxxs = signal(false);
+  let appFeatures = signal(DEFAULT_GLOBAL_CONFIG.appFeatures);
+  let isSessionRunning = signal(false);
+  let isSessionPaused = signal(false);
+  let isBreakActive = signal(false);
+
+  const createComponent = (): MainHeaderComponent => {
+    const cfg = {
+      ...DEFAULT_GLOBAL_CONFIG,
+      appFeatures: appFeatures(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ElementRef,
+          useValue: {
+            nativeElement: {
+              querySelector: () => null,
+            },
+          },
+        },
+        { provide: ProjectService, useValue: { getByIdOnce$: () => of(null) } },
+        {
+          provide: LayoutService,
+          useValue: {
+            isXs,
+            isXxxs,
+            isShowIssuePanel: signal(false),
+            isShowNotes: signal(false),
+            isShowScheduleDayPanel: signal(false),
+          },
+        },
+        {
+          provide: TaskService,
+          useValue: {
+            currentTaskParentOrCurrent$: of(null),
+            currentTask$: of(null),
+            currentTaskId: signal(null),
+          },
+        },
+        {
+          provide: WorkContextService,
+          useValue: {
+            activeWorkContextId$: of(null),
+            undoneTasks$: of([]),
+          },
+        },
+        { provide: SimpleCounterService, useValue: { enabledSimpleCounters$: of([]) } },
+        {
+          provide: SyncWrapperService,
+          useValue: {
+            isEnabledAndReady$: of(false),
+            syncState$: of('IN_SYNC'),
+            isSyncInProgress$: of(false),
+            hasNoPendingOps$: of(true),
+            superSyncIsConfirmedInSync$: of(false),
+          },
+        },
+        { provide: SnackService, useValue: { open: jasmine.createSpy('open') } },
+        { provide: Router, useValue: { events: EMPTY } },
+        {
+          provide: GlobalConfigService,
+          useValue: {
+            cfg$: of(cfg),
+            cfg: signal(cfg),
+            appFeatures,
+            misc: signal({ isVerticalActionBar: false }),
+          },
+        },
+        { provide: MatDialog, useValue: { open: jasmine.createSpy('open') } },
+        { provide: Store, useValue: { dispatch: jasmine.createSpy('dispatch') } },
+        {
+          provide: DataInitStateService,
+          useValue: { isAllDataLoadedInitially$: of(true) },
+        },
+        { provide: MetricService, useValue: { getFocusSummaryForDay: () => null } },
+        { provide: DateService, useValue: { todayStr: () => '2026-06-09' } },
+        { provide: UserProfileService, useValue: { isInitialized: () => false } },
+        {
+          provide: FocusModeService,
+          useValue: {
+            isSessionRunning,
+            isSessionPaused,
+            isBreakActive,
+          },
+        },
+      ],
+    });
+
+    return runInInjectionContext(TestBed.inject(EnvironmentInjector), () => {
+      return new MainHeaderComponent();
+    });
+  };
+
+  afterEach(() => {
+    component?.ngOnDestroy();
+  });
+
+  it('keeps the focus mode entry visible on narrow mobile screens (#8157)', () => {
+    isXs = signal(true);
+    isXxxs = signal(true);
+    appFeatures = signal({
+      ...DEFAULT_GLOBAL_CONFIG.appFeatures,
+      isFocusModeEnabled: true,
+    });
+    isSessionRunning = signal(false);
+    isSessionPaused = signal(false);
+    isBreakActive = signal(false);
+
+    component = createComponent();
+
+    expect(component.showDesktopButtons()).toBe(false);
+    expect(component.isFocusSessionActive()).toBe(false);
+    expect(component.isFocusButtonVisible()).toBe(true);
+  });
+
+  it('hides the focus button when the app feature is disabled', () => {
+    appFeatures = signal({
+      ...DEFAULT_GLOBAL_CONFIG.appFeatures,
+      isFocusModeEnabled: false,
+    });
+
+    component = createComponent();
+
+    expect(component.isFocusButtonVisible()).toBe(false);
   });
 });

--- a/src/app/core-ui/main-header/main-header.component.spec.ts
+++ b/src/app/core-ui/main-header/main-header.component.spec.ts
@@ -24,7 +24,6 @@ import { DataInitStateService } from '../../core/data-init/data-init-state.servi
 import { MetricService } from '../../features/metric/metric.service';
 import { DateService } from '../../core/date/date.service';
 import { UserProfileService } from '../../features/user-profile/user-profile.service';
-import { FocusModeService } from '../../features/focus-mode/focus-mode.service';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 
 // Regression test for #7477: in a project view a long title pushed the
@@ -120,9 +119,6 @@ describe('MainHeaderComponent focus button visibility', () => {
   let isXs = signal(false);
   let isXxxs = signal(false);
   let appFeatures = signal(DEFAULT_GLOBAL_CONFIG.appFeatures);
-  let isSessionRunning = signal(false);
-  let isSessionPaused = signal(false);
-  let isBreakActive = signal(false);
 
   const createComponent = (): MainHeaderComponent => {
     const cfg = {
@@ -197,14 +193,6 @@ describe('MainHeaderComponent focus button visibility', () => {
         { provide: MetricService, useValue: { getFocusSummaryForDay: () => null } },
         { provide: DateService, useValue: { todayStr: () => '2026-06-09' } },
         { provide: UserProfileService, useValue: { isInitialized: () => false } },
-        {
-          provide: FocusModeService,
-          useValue: {
-            isSessionRunning,
-            isSessionPaused,
-            isBreakActive,
-          },
-        },
       ],
     });
 
@@ -224,14 +212,10 @@ describe('MainHeaderComponent focus button visibility', () => {
       ...DEFAULT_GLOBAL_CONFIG.appFeatures,
       isFocusModeEnabled: true,
     });
-    isSessionRunning = signal(false);
-    isSessionPaused = signal(false);
-    isBreakActive = signal(false);
 
     component = createComponent();
 
     expect(component.showDesktopButtons()).toBe(false);
-    expect(component.isFocusSessionActive()).toBe(false);
     expect(component.isFocusButtonVisible()).toBe(true);
   });
 

--- a/src/app/core-ui/main-header/main-header.component.ts
+++ b/src/app/core-ui/main-header/main-header.component.ts
@@ -48,7 +48,6 @@ import { DateService } from '../../core/date/date.service';
 import { UserProfileButtonComponent } from '../../features/user-profile/user-profile-button/user-profile-button.component';
 import { FocusButtonComponent } from './focus-button/focus-button.component';
 import { UserProfileService } from '../../features/user-profile/user-profile.service';
-import { FocusModeService } from '../../features/focus-mode/focus-mode.service';
 
 @Component({
   selector: 'main-header',
@@ -92,7 +91,6 @@ export class MainHeaderComponent implements OnDestroy {
   private readonly _metricService = inject(MetricService);
   private readonly _dateService = inject(DateService);
   private readonly _dataInitStateService = inject(DataInitStateService);
-  private readonly _focusModeService = inject(FocusModeService);
 
   readonly isDataLoaded = toSignal(this._dataInitStateService.isAllDataLoadedInitially$, {
     initialValue: false,
@@ -193,14 +191,8 @@ export class MainHeaderComponent implements OnDestroy {
   readonly isFocusModeEnabled = computed(() => {
     return this.globalConfigService.appFeatures().isFocusModeEnabled;
   });
-  // Keep the focus entry point visible on mobile too. Otherwise Android users
-  // can only discover focus mode by rotating to a wider layout (#8157).
-  readonly isFocusSessionActive = computed(
-    () =>
-      this._focusModeService.isSessionRunning() ||
-      this._focusModeService.isSessionPaused() ||
-      this._focusModeService.isBreakActive(),
-  );
+  // Keep the focus entry point visible on mobile too when the feature is enabled.
+  // Otherwise Android users can only discover focus mode by rotating to a wider layout (#8157).
   readonly isFocusButtonVisible = computed(() => this.isFocusModeEnabled());
   readonly isSyncIconEnabled = computed(() => {
     return this.globalConfigService.appFeatures().isSyncIconEnabled;

--- a/src/app/core-ui/main-header/main-header.component.ts
+++ b/src/app/core-ui/main-header/main-header.component.ts
@@ -193,22 +193,15 @@ export class MainHeaderComponent implements OnDestroy {
   readonly isFocusModeEnabled = computed(() => {
     return this.globalConfigService.appFeatures().isFocusModeEnabled;
   });
-  // On mobile the focus-button is normally hidden to save space. When a focus
-  // session/break is in flight (including paused) the running countdown lives
-  // on this button, so surface it on mobile too — otherwise the user has no
-  // way to see or resume the session after the overlay is closed.
+  // Keep the focus entry point visible on mobile too. Otherwise Android users
+  // can only discover focus mode by rotating to a wider layout (#8157).
   readonly isFocusSessionActive = computed(
     () =>
       this._focusModeService.isSessionRunning() ||
       this._focusModeService.isSessionPaused() ||
       this._focusModeService.isBreakActive(),
   );
-  readonly isFocusButtonVisible = computed(
-    () =>
-      this.isFocusModeEnabled() &&
-      !this.isXxxs() &&
-      (this.showDesktopButtons() || this.isFocusSessionActive()),
-  );
+  readonly isFocusButtonVisible = computed(() => this.isFocusModeEnabled());
   readonly isSyncIconEnabled = computed(() => {
     return this.globalConfigService.appFeatures().isSyncIconEnabled;
   });


### PR DESCRIPTION
## Summary
- keep the header focus button visible on mobile when Focus Mode is enabled
- add a regression test for the narrow/mobile header visibility case
- mention the header focus entry point in the Focus Mode wiki page

Fixes #8157

## Test plan
- `npm run checkFile src/app/core-ui/main-header/main-header.component.ts`
- `npm run checkFile src/app/core-ui/main-header/main-header.component.spec.ts`
- `npx prettier --check src/app/core-ui/main-header/main-header.component.html docs/wiki/4.15-Timers-and-Focus-Mode.md`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/core-ui/main-header/main-header.component.spec.ts`
- `npm run int:test`
- `git diff --check`
