### PR TITLE
feat(jira): show issue priority

### DIFF
--- a/src/app/features/issue/providers/jira/jira-api-responses.d.ts
+++ b/src/app/features/issue/providers/jira/jira-api-responses.d.ts
@@ -106,6 +106,13 @@ export type JiraOriginalStatus = Readonly<{
   statusCategory: JiraOriginalCategory;
 }>;
 
+export type JiraOriginalPriority = Readonly<{
+  self: string;
+  id: string;
+  iconUrl: string;
+  name: string;
+}>;
+
 export type JiraOriginalFields = Readonly<{
   summary: string;
   components: JiraOriginalComponent[];
@@ -123,6 +130,7 @@ export type JiraOriginalFields = Readonly<{
   assignee: JiraOriginalAuthor;
   updated: string;
   status: JiraOriginalStatus;
+  priority?: JiraOriginalPriority | null;
   issuelinks: JiraOriginalIssueLink[];
 }>;
 

--- a/src/app/features/issue/providers/jira/jira-issue-content.const.spec.ts
+++ b/src/app/features/issue/providers/jira/jira-issue-content.const.spec.ts
@@ -1,0 +1,44 @@
+import { T } from '../../../../t.const';
+import { IssueFieldType } from '../../issue-content/issue-content.model';
+import { JIRA_ISSUE_CONTENT_CONFIG } from './jira-issue-content.const';
+import { JiraIssue } from './jira-issue.model';
+
+const makeIssue = (priority?: JiraIssue['priority']): JiraIssue =>
+  ({
+    key: 'SP-42',
+    summary: 'Fix the thing',
+    status: { name: 'In Progress' },
+    priority,
+  }) as unknown as JiraIssue;
+
+describe('JIRA_ISSUE_CONTENT_CONFIG', () => {
+  it('shows priority after status when Jira provides one', () => {
+    const statusIndex = JIRA_ISSUE_CONTENT_CONFIG.fields.findIndex(
+      (field) => field.label === T.F.ISSUE.ISSUE_CONTENT.STATUS,
+    );
+    const priorityIndex = JIRA_ISSUE_CONTENT_CONFIG.fields.findIndex(
+      (field) => field.label === T.F.ISSUE.ISSUE_CONTENT.PRIORITY,
+    );
+    const priorityField = JIRA_ISSUE_CONTENT_CONFIG.fields[priorityIndex];
+    const issue = makeIssue({
+      self: '',
+      id: '2',
+      iconUrl: '',
+      name: 'High',
+    });
+
+    expect(priorityIndex).toBe(statusIndex + 1);
+    expect(priorityField.type).toBe(IssueFieldType.TEXT);
+    expect(priorityField.isVisible?.(issue)).toBe(true);
+    expect(typeof priorityField.value).toBe('function');
+    expect((priorityField.value as (issue: JiraIssue) => unknown)(issue)).toBe('High');
+  });
+
+  it('hides priority when Jira does not provide one', () => {
+    const priorityField = JIRA_ISSUE_CONTENT_CONFIG.fields.find(
+      (field) => field.label === T.F.ISSUE.ISSUE_CONTENT.PRIORITY,
+    );
+
+    expect(priorityField?.isVisible?.(makeIssue(null))).toBe(false);
+  });
+});

--- a/src/app/features/issue/providers/jira/jira-issue-content.const.ts
+++ b/src/app/features/issue/providers/jira/jira-issue-content.const.ts
@@ -21,6 +21,12 @@ export const JIRA_ISSUE_CONTENT_CONFIG: IssueContentConfig<JiraIssue> = {
       value: (issue: JiraIssue) => issue.status?.name,
     },
     {
+      label: T.F.ISSUE.ISSUE_CONTENT.PRIORITY,
+      type: IssueFieldType.TEXT,
+      value: (issue: JiraIssue) => issue.priority?.name,
+      isVisible: (issue: JiraIssue) => !!issue.priority?.name,
+    },
+    {
       label: T.F.ISSUE.ISSUE_CONTENT.STORY_POINTS,
       value: 'storyPoints',
       type: IssueFieldType.TEXT,

--- a/src/app/features/issue/providers/jira/jira-issue-map.util.spec.ts
+++ b/src/app/features/issue/providers/jira/jira-issue-map.util.spec.ts
@@ -1,0 +1,55 @@
+import { DEFAULT_JIRA_CFG } from './jira.const';
+import { JiraIssueOriginal } from './jira-api-responses';
+import { mapIssue } from './jira-issue-map.util';
+
+const makeIssue = (fields: Partial<JiraIssueOriginal['fields']>): JiraIssueOriginal =>
+  ({
+    key: 'SP-42',
+    id: '10042',
+    expand: '',
+    self: 'https://jira.example.com/rest/api/2/issue/10042',
+    fields: {
+      summary: 'Fix the thing',
+      components: [],
+      attachment: [],
+      timeestimate: 0,
+      timespent: 0,
+      description: null,
+      assignee: null,
+      updated: '2026-06-09T00:00:00.000+0000',
+      status: {
+        self: '',
+        id: '3',
+        description: '',
+        iconUrl: '',
+        name: 'In Progress',
+        statusCategory: {
+          self: '',
+          id: '',
+          key: 'indeterminate',
+          colorName: 'yellow',
+          name: 'In Progress',
+        },
+      },
+      priority: null,
+      issuelinks: [],
+      ...fields,
+    },
+  }) as unknown as JiraIssueOriginal;
+
+describe('jira-issue-map.util', () => {
+  describe('mapIssue', () => {
+    it('maps Jira priority metadata', () => {
+      const priority = {
+        self: 'https://jira.example.com/rest/api/2/priority/2',
+        id: '2',
+        iconUrl: 'https://jira.example.com/images/icons/priorities/high.svg',
+        name: 'High',
+      };
+
+      const mapped = mapIssue(makeIssue({ priority }), DEFAULT_JIRA_CFG);
+
+      expect(mapped.priority).toEqual(priority);
+    });
+  });
+});

--- a/src/app/features/issue/providers/jira/jira-issue-map.util.ts
+++ b/src/app/features/issue/providers/jira/jira-issue-map.util.ts
@@ -126,6 +126,7 @@ export const mapIssue = (issue: JiraIssueOriginal, cfg: JiraCfg): JiraIssue => {
     summary: fields.summary,
     updated: fields.updated,
     status: fields.status,
+    priority: fields.priority,
     storyPoints:
       !!cfg.storyPointFieldId &&
       !!(fields as Record<string, unknown>)[cfg.storyPointFieldId]

--- a/src/app/features/issue/providers/jira/jira-issue.model.ts
+++ b/src/app/features/issue/providers/jira/jira-issue.model.ts
@@ -1,6 +1,10 @@
 // Mapped Data Types
 // -----------------
-import { JiraOriginalComponent, JiraOriginalStatus } from './jira-api-responses';
+import {
+  JiraOriginalComponent,
+  JiraOriginalPriority,
+  JiraOriginalStatus,
+} from './jira-api-responses';
 
 export type JiraAuthor = Readonly<{
   id: string;
@@ -56,6 +60,7 @@ export type JiraIssueReduced = Readonly<{
 
   updated: string;
   status: JiraOriginalStatus;
+  priority?: JiraOriginalPriority | null;
 
   // mapped data
   attachments: JiraAttachment[];

--- a/src/app/features/issue/providers/jira/jira.const.ts
+++ b/src/app/features/issue/providers/jira/jira.const.ts
@@ -65,6 +65,7 @@ export const JIRA_ADDITIONAL_ISSUE_FIELDS = [
   'timeestimate',
   'timespent',
   'status',
+  'priority',
   'attachment',
   'comment',
   'updated',


### PR DESCRIPTION
## Summary
- request Jira priority in issue fetches and keep it on mapped issue data
- show Jira priority directly after status when the API returns one
- add focused mapper/content config coverage for the priority field

Fixes #4245

## Test plan
- `npm run checkFile src/app/features/issue/providers/jira/jira-api-responses.d.ts`
- `npm run checkFile src/app/features/issue/providers/jira/jira-issue.model.ts`
- `npm run checkFile src/app/features/issue/providers/jira/jira-issue-map.util.ts`
- `npm run checkFile src/app/features/issue/providers/jira/jira-issue-content.const.ts`
- `npm run checkFile src/app/features/issue/providers/jira/jira.const.ts`
- `npm run checkFile src/app/features/issue/providers/jira/jira-issue-map.util.spec.ts`
- `npm run checkFile src/app/features/issue/providers/jira/jira-issue-content.const.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/issue/providers/jira/jira-issue-map.util.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/issue/providers/jira/jira-issue-content.const.spec.ts`
- `npm run int:test`
- `git diff --check`

## Conflict checks
- no conflict markers from `merge-tree` against `#8160`, `#8161`, and `#8177`
- `#7808` currently has broad unrelated conflicts against current master; this PR does not touch its Jira worklog/dialog picker files
