### PR TITLE
docs(calendar): note per-device credentials

### DIFF
--- a/docs/wiki/4.24-Integrations.md
+++ b/docs/wiki/4.24-Integrations.md
@@ -50,6 +50,8 @@ The app supports **11 issue-style integrations** (the exact list may vary by ver
 - You get task import and **completion status can sync back** to the server.
 - In **Nextcloud**, use the **“Copy private link”** (or the CalDAV URL for your user/calendar), e.g. `https://<NC-URL>/remote.php/dav/calendars/<USER>/<CALENDAR_NAME>/`. Do **not** use the subscription/export link here—that is for the iCal integration.
 
+**Google Calendar OAuth is per-device.** The "Connect Google Account" authorization is stored locally and is not included in Super Productivity sync. Run the Google Calendar connection flow separately on each device (desktop, Android, or iOS). This is intentional, so calendar access stays isolated between devices.
+
 For more detail see [[3.07-Issue-Integration-Comparison]].
 
 ## How You Use Integrations in Practice


### PR DESCRIPTION
## Summary
- document that Google Calendar OAuth authorization is stored locally per device
- clarify that desktop, Android, and iOS devices need to run the Google Calendar connection flow separately

Fixes #7742

## Verification
- `npx --yes prettier@3.8.3 --check docs/wiki/4.24-Integrations.md`
- `git diff --check upstream/master`