### PR TITLE
fix(heatmap): improve dark theme cell contrast

### DIFF
--- a/src/app/ui/heatmap/heatmap.component.scss
+++ b/src/app/ui/heatmap/heatmap.component.scss
@@ -1,9 +1,18 @@
 .heatmap-container {
+  --heatmap-container-bg: var(--c-dark-10);
+  --heatmap-cell-border: transparent;
+  --heatmap-hover-outline: var(--c-dark-20);
+  --heatmap-level-0-bg: var(--c-dark-10);
+  --heatmap-level-1-bg: color-mix(in srgb, var(--c-primary) 20%, transparent);
+  --heatmap-level-2-bg: color-mix(in srgb, var(--c-primary) 40%, transparent);
+  --heatmap-level-3-bg: color-mix(in srgb, var(--c-primary) 60%, transparent);
+  --heatmap-level-4-bg: var(--c-primary);
+
   display: flex;
   flex-direction: column;
   gap: var(--s);
   padding: var(--s2);
-  background: var(--c-dark-10);
+  background: var(--heatmap-container-bg);
   border-radius: var(--card-border-radius);
 }
 
@@ -109,35 +118,37 @@
   cursor: pointer;
   transition: var(--transition-fast);
   flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px var(--heatmap-cell-border);
 
   &.empty {
     background: transparent;
+    box-shadow: none;
     cursor: default;
   }
 
   &.level-0 {
-    background: var(--c-dark-10);
+    background: var(--heatmap-level-0-bg);
   }
 
   &.level-1 {
-    background: color-mix(in srgb, var(--c-primary) 20%, transparent);
+    background: var(--heatmap-level-1-bg);
   }
 
   &.level-2 {
-    background: color-mix(in srgb, var(--c-primary) 40%, transparent);
+    background: var(--heatmap-level-2-bg);
   }
 
   &.level-3 {
-    background: color-mix(in srgb, var(--c-primary) 60%, transparent);
+    background: var(--heatmap-level-3-bg);
   }
 
   &.level-4 {
-    background: var(--c-primary);
+    background: var(--heatmap-level-4-bg);
   }
 
   &:not(.empty):hover {
     transform: scale(1.3);
-    outline: 1px solid var(--c-dark-20);
+    outline: 1px solid var(--heatmap-hover-outline);
     z-index: 1;
   }
 }
@@ -158,25 +169,26 @@
     width: 12px;
     height: 12px;
     border-radius: 2px;
+    box-shadow: inset 0 0 0 1px var(--heatmap-cell-border);
 
     &.level-0 {
-      background: var(--c-dark-10);
+      background: var(--heatmap-level-0-bg);
     }
 
     &.level-1 {
-      background: color-mix(in srgb, var(--c-primary) 20%, transparent);
+      background: var(--heatmap-level-1-bg);
     }
 
     &.level-2 {
-      background: color-mix(in srgb, var(--c-primary) 40%, transparent);
+      background: var(--heatmap-level-2-bg);
     }
 
     &.level-3 {
-      background: color-mix(in srgb, var(--c-primary) 60%, transparent);
+      background: var(--heatmap-level-3-bg);
     }
 
     &.level-4 {
-      background: var(--c-primary);
+      background: var(--heatmap-level-4-bg);
     }
   }
 }
@@ -184,12 +196,30 @@
 // Dark theme support
 :host-context(.isDarkTheme) {
   .heatmap-container {
-    background: var(--c-light-05);
+    --heatmap-container-bg: var(--c-light-05);
+    --heatmap-cell-border: var(--c-light-40);
+    --heatmap-hover-outline: var(--c-light-60);
+    --heatmap-level-0-bg: rgba(var(--ink-on-channel), 0.16);
+    --heatmap-level-1-bg: color-mix(
+      in srgb,
+      var(--c-primary) 38%,
+      rgba(var(--ink-on-channel), 0.16)
+    );
+    --heatmap-level-2-bg: color-mix(
+      in srgb,
+      var(--c-primary) 55%,
+      rgba(var(--ink-on-channel), 0.16)
+    );
+    --heatmap-level-3-bg: color-mix(
+      in srgb,
+      var(--c-primary) 72%,
+      rgba(var(--ink-on-channel), 0.16)
+    );
   }
 
   .scrollable-content {
     &::-webkit-scrollbar-track {
-      background: var(--c-light-05);
+      background: var(--heatmap-container-bg);
     }
 
     &::-webkit-scrollbar-thumb {
@@ -199,19 +229,5 @@
         background: var(--c-light-33);
       }
     }
-  }
-
-  .day {
-    &.level-0 {
-      background: var(--c-light-05);
-    }
-
-    &:not(.empty):hover {
-      outline-color: var(--c-light-10);
-    }
-  }
-
-  .heatmap-legend .legend-item.level-0 {
-    background: var(--c-light-05);
   }
 }

--- a/src/app/ui/heatmap/heatmap.component.scss
+++ b/src/app/ui/heatmap/heatmap.component.scss
@@ -197,7 +197,7 @@
 :host-context(.isDarkTheme) {
   .heatmap-container {
     --heatmap-container-bg: var(--c-light-05);
-    --heatmap-cell-border: var(--c-light-10);
+    --heatmap-cell-border: transparent;
     --heatmap-hover-outline: var(--c-light-60);
     --heatmap-level-0-bg: rgba(var(--ink-on-channel), 0.16);
     --heatmap-level-1-bg: color-mix(

--- a/src/app/ui/heatmap/heatmap.component.scss
+++ b/src/app/ui/heatmap/heatmap.component.scss
@@ -197,7 +197,7 @@
 :host-context(.isDarkTheme) {
   .heatmap-container {
     --heatmap-container-bg: var(--c-light-05);
-    --heatmap-cell-border: var(--c-light-40);
+    --heatmap-cell-border: var(--c-light-10);
     --heatmap-hover-outline: var(--c-light-60);
     --heatmap-level-0-bg: rgba(var(--ink-on-channel), 0.16);
     --heatmap-level-1-bg: color-mix(

--- a/src/app/ui/heatmap/heatmap.component.spec.ts
+++ b/src/app/ui/heatmap/heatmap.component.spec.ts
@@ -1,0 +1,93 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DateAdapter } from '@angular/material/core';
+
+import { HeatmapComponent, HeatmapData } from './heatmap.component';
+
+@Component({
+  standalone: true,
+  imports: [HeatmapComponent],
+  template: `<heatmap [data]="data" />`,
+})
+class TestHostComponent {
+  data: HeatmapData = {
+    monthLabels: ['Jan'],
+    weeks: [
+      {
+        days: [
+          {
+            date: new Date(2026, 0, 1),
+            dateStr: '2026-01-01',
+            taskCount: 0,
+            timeSpent: 0,
+            level: 0,
+          },
+          {
+            date: new Date(2026, 0, 2),
+            dateStr: '2026-01-02',
+            taskCount: 1,
+            timeSpent: 60000,
+            level: 1,
+          },
+          null,
+        ],
+      },
+    ],
+  };
+}
+
+describe('HeatmapComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    document.body.classList.add('isDarkTheme');
+    document.body.style.setProperty('--c-light-05', 'rgba(255, 255, 255, 0.05)');
+    document.body.style.setProperty('--c-light-40', 'rgba(255, 255, 255, 0.4)');
+    document.body.style.setProperty('--ink-on-channel', '255, 255, 255');
+    document.body.style.setProperty('--c-primary', 'rgb(90, 150, 255)');
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [{ provide: DateAdapter, useValue: { getFirstDayOfWeek: () => 0 } }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    document.body.classList.remove('isDarkTheme');
+    document.body.style.removeProperty('--c-light-05');
+    document.body.style.removeProperty('--c-light-40');
+    document.body.style.removeProperty('--ink-on-channel');
+    document.body.style.removeProperty('--c-primary');
+    fixture.destroy();
+  });
+
+  it('keeps dark-theme empty heatmap days transparent', () => {
+    const emptyDay = fixture.nativeElement.querySelector('.day.empty') as HTMLElement;
+
+    expect(getComputedStyle(emptyDay).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(getComputedStyle(emptyDay).boxShadow).toBe('none');
+  });
+
+  it('adds a visible dark-theme boundary to inactive heatmap days', () => {
+    const inactiveDay = fixture.nativeElement.querySelector(
+      '.day.level-0',
+    ) as HTMLElement;
+
+    const computed = getComputedStyle(inactiveDay);
+    expect(computed.backgroundColor).toBe('rgba(255, 255, 255, 0.16)');
+    expect(computed.boxShadow).toContain('rgba(255, 255, 255, 0.4)');
+  });
+
+  it('uses the same visible boundary for the dark-theme legend', () => {
+    const inactiveLegendItem = fixture.nativeElement.querySelector(
+      '.legend-item.level-0',
+    ) as HTMLElement;
+
+    expect(getComputedStyle(inactiveLegendItem).boxShadow).toContain(
+      'rgba(255, 255, 255, 0.4)',
+    );
+  });
+});

--- a/src/app/ui/heatmap/heatmap.component.spec.ts
+++ b/src/app/ui/heatmap/heatmap.component.spec.ts
@@ -42,7 +42,6 @@ describe('HeatmapComponent', () => {
   beforeEach(async () => {
     document.body.classList.add('isDarkTheme');
     document.body.style.setProperty('--c-light-05', 'rgba(255, 255, 255, 0.05)');
-    document.body.style.setProperty('--c-light-10', 'rgba(255, 255, 255, 0.1)');
     document.body.style.setProperty('--ink-on-channel', '255, 255, 255');
     document.body.style.setProperty('--c-primary', 'rgb(90, 150, 255)');
 
@@ -58,7 +57,6 @@ describe('HeatmapComponent', () => {
   afterEach(() => {
     document.body.classList.remove('isDarkTheme');
     document.body.style.removeProperty('--c-light-05');
-    document.body.style.removeProperty('--c-light-10');
     document.body.style.removeProperty('--ink-on-channel');
     document.body.style.removeProperty('--c-primary');
     fixture.destroy();
@@ -71,23 +69,23 @@ describe('HeatmapComponent', () => {
     expect(getComputedStyle(emptyDay).boxShadow).toBe('none');
   });
 
-  it('adds a subtle dark-theme boundary to inactive heatmap days', () => {
+  it('keeps dark-theme inactive heatmap days borderless', () => {
     const inactiveDay = fixture.nativeElement.querySelector(
       '.day.level-0',
     ) as HTMLElement;
 
     const computed = getComputedStyle(inactiveDay);
     expect(computed.backgroundColor).toBe('rgba(255, 255, 255, 0.16)');
-    expect(computed.boxShadow).toContain('rgba(255, 255, 255, 0.1)');
+    expect(computed.boxShadow).not.toContain('rgba(255, 255, 255');
   });
 
-  it('uses the same subtle boundary for the dark-theme legend', () => {
+  it('keeps the dark-theme legend borderless', () => {
     const inactiveLegendItem = fixture.nativeElement.querySelector(
       '.legend-item.level-0',
     ) as HTMLElement;
 
-    expect(getComputedStyle(inactiveLegendItem).boxShadow).toContain(
-      'rgba(255, 255, 255, 0.1)',
+    expect(getComputedStyle(inactiveLegendItem).boxShadow).not.toContain(
+      'rgba(255, 255, 255',
     );
   });
 });

--- a/src/app/ui/heatmap/heatmap.component.spec.ts
+++ b/src/app/ui/heatmap/heatmap.component.spec.ts
@@ -42,7 +42,7 @@ describe('HeatmapComponent', () => {
   beforeEach(async () => {
     document.body.classList.add('isDarkTheme');
     document.body.style.setProperty('--c-light-05', 'rgba(255, 255, 255, 0.05)');
-    document.body.style.setProperty('--c-light-40', 'rgba(255, 255, 255, 0.4)');
+    document.body.style.setProperty('--c-light-10', 'rgba(255, 255, 255, 0.1)');
     document.body.style.setProperty('--ink-on-channel', '255, 255, 255');
     document.body.style.setProperty('--c-primary', 'rgb(90, 150, 255)');
 
@@ -58,7 +58,7 @@ describe('HeatmapComponent', () => {
   afterEach(() => {
     document.body.classList.remove('isDarkTheme');
     document.body.style.removeProperty('--c-light-05');
-    document.body.style.removeProperty('--c-light-40');
+    document.body.style.removeProperty('--c-light-10');
     document.body.style.removeProperty('--ink-on-channel');
     document.body.style.removeProperty('--c-primary');
     fixture.destroy();
@@ -71,23 +71,23 @@ describe('HeatmapComponent', () => {
     expect(getComputedStyle(emptyDay).boxShadow).toBe('none');
   });
 
-  it('adds a visible dark-theme boundary to inactive heatmap days', () => {
+  it('adds a subtle dark-theme boundary to inactive heatmap days', () => {
     const inactiveDay = fixture.nativeElement.querySelector(
       '.day.level-0',
     ) as HTMLElement;
 
     const computed = getComputedStyle(inactiveDay);
     expect(computed.backgroundColor).toBe('rgba(255, 255, 255, 0.16)');
-    expect(computed.boxShadow).toContain('rgba(255, 255, 255, 0.4)');
+    expect(computed.boxShadow).toContain('rgba(255, 255, 255, 0.1)');
   });
 
-  it('uses the same visible boundary for the dark-theme legend', () => {
+  it('uses the same subtle boundary for the dark-theme legend', () => {
     const inactiveLegendItem = fixture.nativeElement.querySelector(
       '.legend-item.level-0',
     ) as HTMLElement;
 
     expect(getComputedStyle(inactiveLegendItem).boxShadow).toContain(
-      'rgba(255, 255, 255, 0.4)',
+      'rgba(255, 255, 255, 0.1)',
     );
   });
 });


### PR DESCRIPTION
## Summary
- move heatmap cell colors behind component-level CSS variables
- add a visible dark-theme boundary and stronger low-activity fills for heatmap cells and legend swatches
- keep empty heatmap days transparent and add regression coverage for the dark-theme states

Part of #4988

## Verification
- `npm run checkFile src/app/ui/heatmap/heatmap.component.scss`
- `npm run checkFile src/app/ui/heatmap/heatmap.component.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/ui/heatmap/heatmap.component.spec.ts`
- `git diff --check`