### PR TITLE
docs(backup): document Android automatic restore

### DIFF
--- a/docs/wiki/2.02-Restore-Data-From-Backup.md
+++ b/docs/wiki/2.02-Restore-Data-From-Backup.md
@@ -11,6 +11,17 @@ To understand what a backup contains and how import replaces your data, see [[4.
 
 If the app finds no data but detects backups (e.g. on startup), it may prompt you to restore the latest backup; you can accept that instead of using Import from File.
 
+## Android: Restore Latest Automatic Backup
+
+On Android, automatic backups are stored inside the app data instead of as visible backup files. To restore the latest usable slot:
+
+1. Open **Settings**.
+2. Open the **Sync & Backup** tab.
+3. In the **Automatic Backups** section, click **Restore latest automatic backup**.
+4. Confirm the warning. This replaces the current local data with the selected automatic backup.
+
+Use this only as a recovery action. If sync is configured, the restored data is treated like a backup import and can overwrite other synced devices on the next sync.
+
 ## Alternative Method: Clear App Data First, then Import
 
 If the app does not start properly (e.g. [inconsistent task state](https://github.com/super-productivity/super-productivity/issues/3052)), clear local data and then import a backup:


### PR DESCRIPTION
## Summary
- add the Android-only "Restore latest automatic backup" path to the restore how-to
- explain that Android automatic backups live inside app data rather than visible backup files
- repeat the local-data replacement and sync propagation warning from the user-data reference

## Validation
- `npx prettier --check docs/wiki/2.02-Restore-Data-From-Backup.md`
- `git diff --check -- docs/wiki/2.02-Restore-Data-From-Backup.md`

Follow-up to #8066 / #8158.
