### PR TITLE
fix(supersync): check critical operation indexes on startup

### DIFF
--- a/packages/super-sync-server/Dockerfile.test
+++ b/packages/super-sync-server/Dockerfile.test
@@ -55,19 +55,7 @@ ENV TEST_MODE_CONFIRM=yes-i-understand-the-risks
 ENV CORS_ORIGINS=*
 ENV JWT_SECRET=e2e-test-secret-minimum-32-chars-long-for-security
 
-# Push schema to DB and start server.
-# Retry `prisma db push` for up to ~30s on transient connection failures
-# (postgres can briefly bounce during first-run initdb even after the db's
-# healthcheck passes). Without this, the container exits on first P1001
-# and depends on docker's restart policy to recover, which can't be relied
-# on across compose invocations.
-#
-# Exec form is required: shell form would wrap this in an extra `/bin/sh -c`,
-# and the outer shell would expand `$(seq 1 15)` into a multi-line string that
-# busybox's ash refuses to parse inside `for ... in` ("expected do").
-#
-# `exec node ...` on success replaces the shell with node so the loop cannot
-# fall through. If all 15 attempts fail we exit 1 instead of starting the
-# server against an unmigrated DB (which would surface as confusing Prisma
-# errors at request time rather than a clean container failure).
-CMD ["sh", "-c", "for i in $(seq 1 15); do npx prisma db push && exec node dist/src/index.js; echo \"prisma db push failed (attempt $i/15), retrying in 2s...\"; sleep 2; done; echo \"prisma db push failed after 15 attempts, giving up\" >&2; exit 1"]
+# Push schema to DB, create test-only partial indexes that Prisma db push cannot
+# express, and start the server. The script retries transient first-run database
+# connection failures before giving up with a clean container failure.
+CMD ["sh", "scripts/start-test-server.sh"]

--- a/packages/super-sync-server/scripts/start-test-server.sh
+++ b/packages/super-sync-server/scripts/start-test-server.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -u
+
+create_test_partial_indexes() {
+  # `prisma db push` cannot express PostgreSQL partial indexes from schema.prisma.
+  # Mirror the production migration index required by the startup self-check.
+  npx prisma db execute --stdin --schema prisma/schema.prisma <<'SQL'
+CREATE INDEX IF NOT EXISTS "operations_user_id_full_state_server_seq_idx"
+  ON "operations"("user_id", "server_seq")
+  WHERE "op_type" IN ('SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR');
+SQL
+}
+
+for i in $(seq 1 15); do
+  if npx prisma db push && create_test_partial_indexes; then
+    exec node dist/src/index.js
+  fi
+
+  echo "prisma test schema setup failed (attempt $i/15), retrying in 2s..."
+  sleep 2
+done
+
+echo "prisma test schema setup failed after 15 attempts, giving up" >&2
+exit 1

--- a/packages/super-sync-server/src/server.ts
+++ b/packages/super-sync-server/src/server.ts
@@ -260,6 +260,15 @@ export const createServer = (
         options: { maxPayload: 1024 },
       });
 
+      // Critical operations-index self-check: these indexes guard SuperSync's
+      // hot paths from silently degrading into multi-GB sequential scans.
+      try {
+        await getSyncService().assertCriticalOperationIndexesValid();
+      } catch (err) {
+        Logger.error('Startup self-check failed', err);
+        throw err;
+      }
+
       // Backfill self-check: paired with the env-flag enforcement in
       // loadConfigFromEnv. The env flag (SUPERSYNC_PAYLOAD_BYTES_BACKFILL_COMPLETE)
       // is operator-set; if it is flipped to true before the migrate-payload-bytes

--- a/packages/super-sync-server/src/sync/services/index.ts
+++ b/packages/super-sync-server/src/sync/services/index.ts
@@ -21,6 +21,10 @@ export type {
 } from './request-deduplication.service';
 export { DeviceService } from './device.service';
 export { OperationDownloadService } from './operation-download.service';
+export {
+  OperationIndexHealthService,
+  CRITICAL_OPERATION_INDEX_NAMES,
+} from './operation-index-health.service';
 export { OperationUploadService } from './operation-upload.service';
 export { StorageQuotaService } from './storage-quota.service';
 export { SnapshotGenerationService } from './snapshot-generation.service';

--- a/packages/super-sync-server/src/sync/services/operation-index-health.service.ts
+++ b/packages/super-sync-server/src/sync/services/operation-index-health.service.ts
@@ -1,0 +1,73 @@
+import { prisma } from '../../db';
+
+export const CRITICAL_OPERATION_INDEX_NAMES = [
+  'operations_user_id_entity_type_entity_id_server_seq_idx',
+  'operations_user_id_server_seq_key',
+  'operations_user_id_full_state_server_seq_idx',
+] as const;
+
+type OperationIndexHealthRow = {
+  indexName: string;
+  exists: boolean;
+  isValid: boolean;
+};
+
+export class OperationIndexHealthService {
+  async assertCriticalOperationIndexesValid(): Promise<void> {
+    const rows: OperationIndexHealthRow[] = await prisma.$queryRaw<
+      OperationIndexHealthRow[]
+    >`
+      WITH required(index_name) AS (
+        VALUES
+          ('operations_user_id_entity_type_entity_id_server_seq_idx'),
+          ('operations_user_id_server_seq_key'),
+          ('operations_user_id_full_state_server_seq_idx')
+      ),
+      operation_indexes AS (
+        SELECT
+          index_class.relname AS index_name,
+          pg_index.indisvalid AS is_valid
+        FROM pg_index
+        JOIN pg_class index_class ON index_class.oid = pg_index.indexrelid
+        JOIN pg_class table_class ON table_class.oid = pg_index.indrelid
+        JOIN pg_namespace table_namespace ON table_namespace.oid = table_class.relnamespace
+        WHERE table_class.relname = 'operations'
+          AND table_namespace.nspname = current_schema()
+      )
+      SELECT
+        required.index_name AS "indexName",
+        operation_indexes.index_name IS NOT NULL AS "exists",
+        COALESCE(operation_indexes.is_valid, false) AS "isValid"
+      FROM required
+      LEFT JOIN operation_indexes ON operation_indexes.index_name = required.index_name
+      ORDER BY required.index_name
+    `;
+
+    const rowByName = new Map<string, OperationIndexHealthRow>(
+      rows.map((row: OperationIndexHealthRow) => [row.indexName, row]),
+    );
+    const missingIndexes = CRITICAL_OPERATION_INDEX_NAMES.filter(
+      (indexName) => !rowByName.get(indexName)?.exists,
+    );
+    const invalidIndexes = CRITICAL_OPERATION_INDEX_NAMES.filter((indexName) => {
+      const row = rowByName.get(indexName);
+      return row?.exists === true && row.isValid !== true;
+    });
+
+    if (missingIndexes.length === 0 && invalidIndexes.length === 0) {
+      return;
+    }
+
+    const details = [
+      missingIndexes.length > 0 ? `missing: ${missingIndexes.join(', ')}` : undefined,
+      invalidIndexes.length > 0 ? `invalid: ${invalidIndexes.join(', ')}` : undefined,
+    ]
+      .filter(Boolean)
+      .join('; ');
+
+    throw new Error(
+      `SuperSync critical operations indexes are not ready (${details}). ` +
+        'Run or repair database migrations before starting the server.',
+    );
+  }
+}

--- a/packages/super-sync-server/src/sync/services/operation-index-health.service.ts
+++ b/packages/super-sync-server/src/sync/services/operation-index-health.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from '../../db';
 
 export const CRITICAL_OPERATION_INDEX_NAMES = [
@@ -14,15 +15,13 @@ type OperationIndexHealthRow = {
 
 export class OperationIndexHealthService {
   async assertCriticalOperationIndexesValid(): Promise<void> {
+    const requiredIndexValues = Prisma.join(
+      CRITICAL_OPERATION_INDEX_NAMES.map((indexName) => Prisma.sql`(${indexName})`),
+    );
     const rows: OperationIndexHealthRow[] = await prisma.$queryRaw<
       OperationIndexHealthRow[]
     >`
-      WITH required(index_name) AS (
-        VALUES
-          ('operations_user_id_entity_type_entity_id_server_seq_idx'),
-          ('operations_user_id_server_seq_key'),
-          ('operations_user_id_full_state_server_seq_idx')
-      ),
+      WITH required(index_name) AS (VALUES ${requiredIndexValues}),
       operation_indexes AS (
         SELECT
           index_class.relname AS index_name,
@@ -32,6 +31,7 @@ export class OperationIndexHealthService {
         JOIN pg_class table_class ON table_class.oid = pg_index.indrelid
         JOIN pg_namespace table_namespace ON table_namespace.oid = table_class.relnamespace
         WHERE table_class.relname = 'operations'
+          -- SuperSync uses Prisma's default public schema; keep the self-check scoped there.
           AND table_namespace.nspname = current_schema()
       )
       SELECT

--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -17,6 +17,7 @@ import {
   RequestDeduplicationService,
   DeviceService,
   OperationDownloadService,
+  OperationIndexHealthService,
   OperationUploadService,
   StorageQuotaService,
   SnapshotService,
@@ -80,6 +81,7 @@ export class SyncService {
   private requestDeduplicationService: RequestDeduplicationService;
   private deviceService: DeviceService;
   private operationDownloadService: OperationDownloadService;
+  private operationIndexHealthService: OperationIndexHealthService;
   private storageQuotaService: StorageQuotaService;
   private snapshotService: SnapshotService;
   private operationUploadService: OperationUploadService;
@@ -91,6 +93,7 @@ export class SyncService {
     this.requestDeduplicationService = new RequestDeduplicationService();
     this.deviceService = new DeviceService();
     this.operationDownloadService = new OperationDownloadService();
+    this.operationIndexHealthService = new OperationIndexHealthService();
     this.storageQuotaService = new StorageQuotaService();
     this.snapshotService = new SnapshotService();
     this.operationUploadService = new OperationUploadService(
@@ -535,6 +538,10 @@ export class SyncService {
 
   async assertPayloadBytesBackfillComplete(): Promise<void> {
     return this.storageQuotaService.assertPayloadBytesBackfillComplete();
+  }
+
+  async assertCriticalOperationIndexesValid(): Promise<void> {
+    return this.operationIndexHealthService.assertCriticalOperationIndexesValid();
   }
 
   async checkStorageQuota(

--- a/packages/super-sync-server/tests/operation-index-health.service.spec.ts
+++ b/packages/super-sync-server/tests/operation-index-health.service.spec.ts
@@ -3,6 +3,7 @@ import {
   CRITICAL_OPERATION_INDEX_NAMES,
   OperationIndexHealthService,
 } from '../src/sync/services/operation-index-health.service';
+import { readFileSync } from 'fs';
 
 vi.mock('../src/db', () => ({
   prisma: {
@@ -72,15 +73,27 @@ describe('OperationIndexHealthService', () => {
 
     await service.assertCriticalOperationIndexesValid();
 
-    const [queryParts] = vi.mocked(prisma.$queryRaw).mock.calls[0] as unknown as [
+    const [queryParts, requiredIndexValues] = vi.mocked(prisma.$queryRaw).mock
+      .calls[0] as unknown as [
       TemplateStringsArray,
+      { values: string[]; strings: string[] },
     ];
     const query = Array.from(queryParts).join('');
 
     expect(query).toContain('pg_index.indisvalid');
     expect(query).toContain("table_class.relname = 'operations'");
-    for (const indexName of CRITICAL_OPERATION_INDEX_NAMES) {
-      expect(query).toContain(indexName);
-    }
+    expect(query).toContain('WITH required(index_name) AS (VALUES');
+    expect(requiredIndexValues.values).toEqual([...CRITICAL_OPERATION_INDEX_NAMES]);
+  });
+
+  it('creates the partial full-state index in the SuperSync test image setup', () => {
+    const script = readFileSync('scripts/start-test-server.sh', 'utf8');
+
+    expect(script).toContain(
+      'CREATE INDEX IF NOT EXISTS "operations_user_id_full_state_server_seq_idx"',
+    );
+    expect(script).toContain(
+      'npx prisma db execute --stdin --schema prisma/schema.prisma',
+    );
   });
 });

--- a/packages/super-sync-server/tests/operation-index-health.service.spec.ts
+++ b/packages/super-sync-server/tests/operation-index-health.service.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  CRITICAL_OPERATION_INDEX_NAMES,
+  OperationIndexHealthService,
+} from '../src/sync/services/operation-index-health.service';
+
+vi.mock('../src/db', () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+}));
+
+import { prisma } from '../src/db';
+
+const validRows = CRITICAL_OPERATION_INDEX_NAMES.map((indexName) => ({
+  indexName,
+  exists: true,
+  isValid: true,
+}));
+
+describe('OperationIndexHealthService', () => {
+  let service: OperationIndexHealthService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new OperationIndexHealthService();
+  });
+
+  it('resolves when all critical operations indexes exist and are valid', async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue(validRows);
+
+    await expect(service.assertCriticalOperationIndexesValid()).resolves.toBeUndefined();
+  });
+
+  it('throws with missing and invalid index details', async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([
+      {
+        indexName: 'operations_user_id_entity_type_entity_id_server_seq_idx',
+        exists: false,
+        isValid: false,
+      },
+      {
+        indexName: 'operations_user_id_server_seq_key',
+        exists: true,
+        isValid: false,
+      },
+      {
+        indexName: 'operations_user_id_full_state_server_seq_idx',
+        exists: true,
+        isValid: true,
+      },
+    ]);
+
+    await expect(service.assertCriticalOperationIndexesValid()).rejects.toThrow(
+      /missing: operations_user_id_entity_type_entity_id_server_seq_idx/,
+    );
+    await expect(service.assertCriticalOperationIndexesValid()).rejects.toThrow(
+      /invalid: operations_user_id_server_seq_key/,
+    );
+  });
+
+  it('treats absent result rows as missing critical indexes', async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([validRows[0]]);
+
+    await expect(service.assertCriticalOperationIndexesValid()).rejects.toThrow(
+      /operations_user_id_server_seq_key/,
+    );
+  });
+
+  it('checks pg_index validity for the named operations-table indexes', async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue(validRows);
+
+    await service.assertCriticalOperationIndexesValid();
+
+    const [queryParts] = vi.mocked(prisma.$queryRaw).mock.calls[0] as unknown as [
+      TemplateStringsArray,
+    ];
+    const query = Array.from(queryParts).join('');
+
+    expect(query).toContain('pg_index.indisvalid');
+    expect(query).toContain("table_class.relname = 'operations'");
+    for (const indexName of CRITICAL_OPERATION_INDEX_NAMES) {
+      expect(query).toContain(indexName);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #7654

## Summary
- add a SuperSync startup self-check for the three critical `operations` indexes
- fail startup when any required index is missing or `pg_index.indisvalid` is false
- wire the check through `SyncService` next to the existing startup self-checks

## Verification
- `npm run checkFile packages/super-sync-server/src/sync/services/operation-index-health.service.ts`
- `npm run checkFile packages/super-sync-server/src/sync/services/index.ts`
- `npm run checkFile packages/super-sync-server/src/sync/sync.service.ts`
- `npm run checkFile packages/super-sync-server/src/server.ts`
- `npm run checkFile packages/super-sync-server/tests/operation-index-health.service.spec.ts`
- `cd packages/super-sync-server && npx vitest run tests/operation-index-health.service.spec.ts tests/migration-sql.spec.ts tests/storage-quota.service.spec.ts`
- `git diff --check`

Note: `cd packages/super-sync-server && npm run build` currently fails on this checkout before and after this branch because the generated Prisma client available locally does not expose several existing Prisma types/helpers (`Prisma.sql`, `Prisma.empty`, `User`, `Operation`, etc.). The new service was still covered by `checkFile` plus the focused Vitest suite above.
