### PR TITLE
docs(caldav): clarify bidirectional VTODO sync

### DIFF
--- a/docs/wiki/4.24-Integrations.md
+++ b/docs/wiki/4.24-Integrations.md
@@ -47,7 +47,7 @@ The app supports **11 issue-style integrations** (the exact list may vary by ver
 **CalDAV** — Connects to a **CalDAV server** (e.g. Nextcloud calendars) with **username and password**.
 
 - The app requests **VTODO** components only (tasks/todos). It does **not** use VEVENTs.
-- You get task import and **completion status can sync back** to the server.
+- You get task import and **completion status can sync back** to the server. The “bidirectional” settings apply to already-imported CalDAV tasks; tasks created inside Super Productivity are **not** uploaded as new CalDAV VTODOs.
 - In **Nextcloud**, use the **“Copy private link”** (or the CalDAV URL for your user/calendar), e.g. `https://<NC-URL>/remote.php/dav/calendars/<USER>/<CALENDAR_NAME>/`. Do **not** use the subscription/export link here—that is for the iCal integration.
 
 **Google Calendar OAuth is per-device.** The "Connect Google Account" authorization is stored locally and is not included in Super Productivity sync. Run the Google Calendar connection flow separately on each device (desktop, Android, or iOS). This is intentional, so calendar access stays isolated between devices.


### PR DESCRIPTION
## Summary
- clarify that CalDAV bidirectional settings apply to already-imported VTODO tasks
- note that tasks created inside Super Productivity are not uploaded as new CalDAV VTODOs

Part of #7641

## Verification
- npx prettier --check docs/wiki/4.24-Integrations.md
- git diff --check