### PR TITLE
chore(electron): remove deprecated Wayland idle stub

### DIFF
--- a/src/app/core/electron/wayland-idle-helper.service.ts
+++ b/src/app/core/electron/wayland-idle-helper.service.ts
@@ -1,3 +1,0 @@
-// This file is deprecated and should be removed
-// Idle detection is now handled entirely in the Electron main process
-// See: electron/idle-time-handler.ts


### PR DESCRIPTION
## Summary

- remove the deprecated Angular-side Wayland idle helper stub
- keep the real Electron idle handling in `electron/idle-time-handler.ts` unchanged

Part of #7874

## Verification

- `rg -n "WaylandIdleHelperService|wayland-idle-helper\\.service" src electron tools package.json`
- `test ! -e src/app/core/electron/wayland-idle-helper.service.ts`
- `npm run electron:build`
- `npm run lint:ts` (passes with the existing `src/test.ts` unused eslint-disable warning)
- `git diff --check`
