### PR TITLE
refactor(rxjs): replace remaining service toPromise calls

### DIFF
--- a/src/app/core/share/share.service.ts
+++ b/src/app/core/share/share.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Directory, Filesystem } from '@capacitor/filesystem';
+import { firstValueFrom } from 'rxjs';
 import { IS_NATIVE_PLATFORM } from '../../util/is-native-platform';
 import { IS_IOS } from '../../util/is-ios';
 import { SnackService } from '../snack/snack.service';
@@ -299,7 +300,7 @@ export class ShareService {
         },
       });
 
-      const result = await dialogRef.afterClosed().toPromise();
+      const result = await firstValueFrom(dialogRef.afterClosed());
 
       if (result) {
         return result;

--- a/src/app/features/note/note-startup-banner.service.ts
+++ b/src/app/features/note/note-startup-banner.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { BannerService } from '../../core/banner/banner.service';
 import { BannerId } from '../../core/banner/banner.model';
 import { take } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
 import { getDbDateStr } from '../../util/get-db-date-str';
 import { LS } from '../../core/persistence/storage-keys.const';
 import { devError } from '../../util/dev-error';
@@ -20,10 +21,9 @@ export class NoteStartupBannerService {
 
   async showLastNoteIfNeeded(): Promise<void> {
     const todayStr = getDbDateStr();
-    const metric = await this._metricService
-      .getMetricForDay$(todayStr)
-      .pipe(take(1))
-      .toPromise();
+    const metric = await firstValueFrom(
+      this._metricService.getMetricForDay$(todayStr).pipe(take(1)),
+    );
 
     const reflection = metric?.reflections?.[0];
     if (!reflection?.text?.trim()) {


### PR DESCRIPTION
## Summary
- replace the active `toPromise()` call in the startup note banner service with `firstValueFrom`
- replace the share dialog `afterClosed().toPromise()` call with `firstValueFrom`

Part of #7874.

## Verification
- `npm run checkFile src/app/features/note/note-startup-banner.service.ts`
- `npm run checkFile src/app/core/share/share.service.ts`
- `npm run lint:ts` (passes with existing `src/test.ts` unused eslint-disable warning)
- `git diff --check upstream/master..HEAD`

No direct focused spec exists for these two services; this is a mechanical RxJS modernization with unchanged stream semantics.
