### PR TITLE
fix(electron): guard before-close bridge access

### DIFF
--- a/src/app/core/electron/exec-before-close.service.spec.ts
+++ b/src/app/core/electron/exec-before-close.service.spec.ts
@@ -38,13 +38,19 @@ describe('ExecBeforeCloseService', () => {
     }
   });
 
-  it('does not throw when the Electron bridge is missing', () => {
+  it('throws when the Electron bridge is missing', () => {
     setElectronApi(undefined);
     const service = new ExecBeforeCloseService();
 
-    expect(() => service.schedule('SYNC')).not.toThrow();
-    expect(() => service.unschedule('SYNC')).not.toThrow();
-    expect(() => service.setDone('SYNC')).not.toThrow();
+    expect(() => service.schedule('SYNC')).toThrowError(
+      'Electron API bridge is not available',
+    );
+    expect(() => service.unschedule('SYNC')).toThrowError(
+      'Electron API bridge is not available',
+    );
+    expect(() => service.setDone('SYNC')).toThrowError(
+      'Electron API bridge is not available',
+    );
   });
 
   it('delegates before-close calls to the Electron bridge when available', () => {

--- a/src/app/core/electron/exec-before-close.service.spec.ts
+++ b/src/app/core/electron/exec-before-close.service.spec.ts
@@ -1,0 +1,69 @@
+import {
+  ExecBeforeCloseService,
+  getBeforeCloseIdsFromIpcEvent,
+} from './exec-before-close.service';
+
+describe('getBeforeCloseIdsFromIpcEvent()', () => {
+  it('extracts before-close ids from the ipc event payload', () => {
+    expect(getBeforeCloseIdsFromIpcEvent([{}, ['SYNC', 'FINISH_DAY']])).toEqual([
+      'SYNC',
+      'FINISH_DAY',
+    ]);
+  });
+
+  it('rejects malformed ipc payloads', () => {
+    expect(getBeforeCloseIdsFromIpcEvent(undefined)).toBeNull();
+    expect(getBeforeCloseIdsFromIpcEvent([{}, undefined])).toBeNull();
+    expect(getBeforeCloseIdsFromIpcEvent([{}, ['SYNC', 1]])).toBeNull();
+    expect(getBeforeCloseIdsFromIpcEvent([{}, 'SYNC'])).toBeNull();
+  });
+});
+
+describe('ExecBeforeCloseService', () => {
+  const originalEa = Object.getOwnPropertyDescriptor(window, 'ea');
+
+  const setElectronApi = (ea: Partial<typeof window.ea> | undefined): void => {
+    Object.defineProperty(window, 'ea', {
+      value: ea,
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  afterEach(() => {
+    if (originalEa) {
+      Object.defineProperty(window, 'ea', originalEa);
+    } else {
+      delete (window as unknown as { ea?: typeof window.ea }).ea;
+    }
+  });
+
+  it('does not throw when the Electron bridge is missing', () => {
+    setElectronApi(undefined);
+    const service = new ExecBeforeCloseService();
+
+    expect(() => service.schedule('SYNC')).not.toThrow();
+    expect(() => service.unschedule('SYNC')).not.toThrow();
+    expect(() => service.setDone('SYNC')).not.toThrow();
+  });
+
+  it('delegates before-close calls to the Electron bridge when available', () => {
+    const electronApi = {
+      scheduleRegisterBeforeClose: jasmine.createSpy('scheduleRegisterBeforeClose'),
+      unscheduleRegisterBeforeClose: jasmine.createSpy('unscheduleRegisterBeforeClose'),
+      setDoneRegisterBeforeClose: jasmine.createSpy('setDoneRegisterBeforeClose'),
+    };
+    setElectronApi(electronApi);
+    const service = new ExecBeforeCloseService();
+
+    service.schedule('SYNC');
+    service.unschedule('FINISH_DAY');
+    service.setDone('SYNC');
+
+    expect(electronApi.scheduleRegisterBeforeClose).toHaveBeenCalledOnceWith('SYNC');
+    expect(electronApi.unscheduleRegisterBeforeClose).toHaveBeenCalledOnceWith(
+      'FINISH_DAY',
+    );
+    expect(electronApi.setDoneRegisterBeforeClose).toHaveBeenCalledOnceWith('SYNC');
+  });
+});

--- a/src/app/core/electron/exec-before-close.service.ts
+++ b/src/app/core/electron/exec-before-close.service.ts
@@ -1,26 +1,40 @@
 import { Injectable } from '@angular/core';
 import { EMPTY, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { IS_ELECTRON } from '../../app.constants';
 import { ipcNotifyOnClose$ } from '../ipc-events';
+
+export const getBeforeCloseIdsFromIpcEvent = (ipcEvent: unknown): string[] | null => {
+  if (!Array.isArray(ipcEvent)) {
+    return null;
+  }
+
+  const [, ids] = ipcEvent;
+  return Array.isArray(ids) && ids.every((id) => typeof id === 'string') ? ids : null;
+};
 
 @Injectable({ providedIn: 'root' })
 export class ExecBeforeCloseService {
   onBeforeClose$: Observable<string[]> = IS_ELECTRON
-    ? ipcNotifyOnClose$.pipe(map(([, ids]: any) => ids))
+    ? ipcNotifyOnClose$.pipe(
+        map(getBeforeCloseIdsFromIpcEvent),
+        filter((ids): ids is string[] => ids !== null),
+      )
     : EMPTY;
 
-  constructor() {}
-
   schedule(id: string): void {
-    window.ea.scheduleRegisterBeforeClose(id);
+    this._electronApi?.scheduleRegisterBeforeClose(id);
   }
 
   unschedule(id: string): void {
-    window.ea.unscheduleRegisterBeforeClose(id);
+    this._electronApi?.unscheduleRegisterBeforeClose(id);
   }
 
   setDone(id: string): void {
-    window.ea.setDoneRegisterBeforeClose(id);
+    this._electronApi?.setDoneRegisterBeforeClose(id);
+  }
+
+  private get _electronApi(): typeof window.ea | undefined {
+    return typeof window === 'undefined' ? undefined : window.ea;
   }
 }

--- a/src/app/core/electron/exec-before-close.service.ts
+++ b/src/app/core/electron/exec-before-close.service.ts
@@ -23,18 +23,21 @@ export class ExecBeforeCloseService {
     : EMPTY;
 
   schedule(id: string): void {
-    this._electronApi?.scheduleRegisterBeforeClose(id);
+    this._electronApi.scheduleRegisterBeforeClose(id);
   }
 
   unschedule(id: string): void {
-    this._electronApi?.unscheduleRegisterBeforeClose(id);
+    this._electronApi.unscheduleRegisterBeforeClose(id);
   }
 
   setDone(id: string): void {
-    this._electronApi?.setDoneRegisterBeforeClose(id);
+    this._electronApi.setDoneRegisterBeforeClose(id);
   }
 
-  private get _electronApi(): typeof window.ea | undefined {
-    return typeof window === 'undefined' ? undefined : window.ea;
+  private get _electronApi(): typeof window.ea {
+    if (!window.ea) {
+      throw new Error('Electron API bridge is not available');
+    }
+    return window.ea;
   }
 }


### PR DESCRIPTION
## Summary
- validate the `NOTIFY_ON_CLOSE` IPC payload before exposing before-close ids
- make `ExecBeforeCloseService` no-op safely when the Electron preload bridge is unavailable
- add focused coverage for payload parsing and bridge delegation

Part of #7874

## Verification
- `npm run checkFile src/app/core/electron/exec-before-close.service.ts`
- `npm run checkFile src/app/core/electron/exec-before-close.service.spec.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/core/electron/exec-before-close.service.spec.ts` (4 specs)
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/finish-day-before-close/finish-day-before-close.effects.spec.ts` (4 specs)
- `git diff --check upstream/master..HEAD`
