### PR TITLE
refactor(time-tracking): replace toPromise usage

### DIFF
--- a/src/app/features/time-tracking/time-tracking.service.ts
+++ b/src/app/features/time-tracking/time-tracking.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
-import { combineLatest, Observable, Subject } from 'rxjs';
+import { combineLatest, firstValueFrom, Observable, Subject } from 'rxjs';
 import { TimeTrackingState, TTDateMap, TTWorkContextData } from './time-tracking.model';
-import { first, map, shareReplay, startWith, switchMap } from 'rxjs/operators';
+import { map, shareReplay, startWith, switchMap } from 'rxjs/operators';
 import { mergeTimeTrackingStates } from './merge-time-tracking-states';
 import { Store } from '@ngrx/store';
 import { selectTimeTrackingState } from './store/time-tracking.selectors';
@@ -72,7 +72,7 @@ export class TimeTrackingService {
   }
 
   async cleanupDataEverywhereForProject(projectId: string): Promise<void> {
-    const current = await this.current$.pipe(first()).toPromise();
+    const current = await firstValueFrom(this.current$);
     const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
     const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
 
@@ -108,7 +108,7 @@ export class TimeTrackingService {
    * Current state cleanup is now handled atomically in tag-shared.reducer.ts.
    */
   async cleanupDataEverywhereForTag(tagId: string): Promise<void> {
-    const current = await this.current$.pipe(first()).toPromise();
+    const current = await firstValueFrom(this.current$);
     const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
     const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
 
@@ -163,7 +163,7 @@ export class TimeTrackingService {
     id: string;
     type: WorkContextType;
   }): Promise<TTDateMap<TTWorkContextData>> {
-    return this.getWorkStartEndForWorkContext$(ctx).pipe(first()).toPromise();
+    return firstValueFrom(this.getWorkStartEndForWorkContext$(ctx));
   }
 
   async getLegacyWorkStartEndForWorkContext(ctx: {


### PR DESCRIPTION
Part of #7874

## Summary
- replace the remaining `toPromise()` calls in `TimeTrackingService` with `firstValueFrom`
- keep the existing first-emission promise behavior without changing time-tracking cleanup logic

## Verification
- `npm run checkFile src/app/features/time-tracking/time-tracking.service.ts`
- `CHROME_BIN=/snap/bin/chromium npm run test:file -- src/app/features/time-tracking/merge-time-tracking-states.spec.ts` (`16 SUCCESS`)
- `git diff --check upstream/master..HEAD`
