### PR TITLE
refactor(shepherd): replace toPromise usage

### DIFF
--- a/src/app/features/shepherd/shepherd.service.ts
+++ b/src/app/features/shepherd/shepherd.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { SHEPHERD_STEPS, TourId } from './shepherd-steps.const';
 import { LayoutService } from '../../core-ui/layout/layout.service';
@@ -32,7 +33,7 @@ export class ShepherdService {
     }
     this._initialize();
 
-    const cfg = await this.globalConfigService.cfg$.pipe(first()).toPromise();
+    const cfg = await firstValueFrom(this.globalConfigService.cfg$.pipe(first()));
     this.addSteps(
       SHEPHERD_STEPS(
         this,


### PR DESCRIPTION
Part of #7874.

## Summary
- replace the Shepherd tour config lookup `.toPromise()` call with `firstValueFrom`
- keep the existing `first()` behavior and initialization flow unchanged

## Verification
- `npm run checkFile src/app/features/shepherd/shepherd.service.ts`
- `git diff --check upstream/master..HEAD`
