### PR TITLE
fix(plugins): harden iframe bridge boundaries

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -511,7 +511,11 @@ PluginAPI.registerHook(PluginAPI.Hooks.ACTION, (action) => {
 
 ### Data Persistence
 
-You can persist data that will also be synced vai the `persistDataSynced` and `loadSyncedData` APIs. For local storage I recommend using `localStorage`.
+You can persist data that will also be synced via the `persistDataSynced` and
+`loadSyncedData` APIs. Host-side `plugin.js` code can use `localStorage` for
+data that should stay local. Iframe plugins should prefer the synced
+persistence APIs because sandboxed iframe origins may not have reliable access
+to browser storage.
 
 ```javascript
 // Save plugin data
@@ -634,9 +638,12 @@ cold-boot bridge pings are only performed for host-side plugin code.
 
 Iframe plugins receive a filtered `window.PluginAPI` object injected into `index.html`.
 The iframe can use the injected task/project/tag APIs, dialog and notification APIs,
-navigation helpers, persistence helpers, registration helpers, counters, and action
-dispatch. APIs not injected into the iframe are unavailable, even if they exist on the
-host-side plugin bridge.
+navigation helpers, persistence helpers, counters, action dispatch, `registerHook()`,
+and `registerWorkContextHeaderButton()`. Callback-heavy registration methods such as
+`registerHeaderButton()`, `registerMenuEntry()`, `registerSidePanelButton()`,
+`registerShortcut()`, and `registerConfigHandler()` must be registered from
+host-side `plugin.js` code. APIs not injected into the iframe are unavailable, even if
+they exist on the host-side plugin bridge.
 
 `executeNodeScript()` is proxied through the host bridge for iframe plugins when
 the desktop app grants the plugin `nodeExecution` permission.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -171,7 +171,11 @@ Iframe-only plugins do not need a `plugin.js` file if all plugin behavior lives 
 `index.html`. Super Productivity automatically adds the default menu or side-panel entry
 from the manifest when the plugin is loaded.
 
-**Important:** When using iframes, you must inline all CSS and JavaScript directly in the HTML file. External stylesheets and scripts are blocked for security reasons.
+**Important:** Iframe plugins are served from a sandboxed blob document and talk to
+the host only through the filtered Plugin API message bridge. Inline CSS, JavaScript,
+and small assets directly in `index.html`; arbitrary extra files from the ZIP are not
+served to the iframe. External URLs can work when the app/runtime CSP allows them, but
+they are not part of the portable plugin contract.
 
 **Example index.html:**
 
@@ -585,23 +589,23 @@ not fire.
 You can also use `onReady` for any other startup work that should run after the plugin
 script has finished setting up its hooks and registrations — not just for `nodeExecution`.
 
-**Iframe plugins:** `plugin.onReady()` is also available inside iframe plugins, but it
-fires on the next microtask after `plugin.js` finishes evaluating — without an IPC bridge
-ping. This is fine in practice because iframe plugins are rendered on user navigation
-(well after host startup, when the bridge is already up). If your iframe plugin needs the
-bridge from `onReady`, it will be available; cold-boot races affect host-side plugin code
-only.
+**Iframe plugins:** `PluginAPI.onReady()` is available inside `index.html`. It fires on
+the next microtask after the callback is registered — without an IPC bridge ping. This is
+fine in practice because iframe plugins are rendered on user navigation (well after host
+startup). Iframe API calls still go through the host bridge when they are made;
+cold-boot bridge pings are only performed for host-side plugin code.
 
 ### 4. Don't spam the logs
 
 `console.logs` should be kept to a minimum.
 
-### 5. Iframe plugins: inline everything
+### 5. Iframe plugins: keep assets self-contained
 
-1. **Inline everything**: CSS and JavaScript must be in the HTML file
+1. **Prefer self-contained HTML**: inline CSS, JavaScript, and small assets are the
+   most portable option for iframe plugins
 
 ```html
-<!-- Good: Everything inlined -->
+<!-- Portable: Everything needed by the iframe is in index.html -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -626,22 +630,22 @@ only.
 - Iframe plugins run in sandboxed iframes with restricted permissions
 - No access to file system unless through API
 
-### API Restrictions
+### Iframe API Surface
 
-In iframe context, these methods are NOT available:
+Iframe plugins receive a filtered `window.PluginAPI` object injected into `index.html`.
+The iframe can use the injected task/project/tag APIs, dialog and notification APIs,
+navigation helpers, persistence helpers, registration helpers, counters, and action
+dispatch. APIs not injected into the iframe are unavailable, even if they exist on the
+host-side plugin bridge.
 
-- `registerHeaderButton()`
-- `registerMenuEntry()`
-- `registerSidePanelButton()`
-- `registerShortcut()`
-- `registerHook()`
-- `execNodeScript()`
+`executeNodeScript()` is proxied through the host bridge for iframe plugins when
+the desktop app grants the plugin `nodeExecution` permission.
 
-### Content Security Policy
+### Iframe Boundary
 
-- External scripts/styles are blocked in iframes
-- Only same-origin resources are allowed
-- Inline scripts must be within the HTML file
+- Iframe plugins run without `allow-same-origin`, so they have an opaque origin
+- Host access is limited to the filtered Plugin API `postMessage` bridge
+- Remote assets depend on the app/runtime CSP and should not be relied on
 
 ## Testing Your Plugin
 

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -191,7 +191,7 @@ Plugin packages normally include `plugin.js` for host-side behavior. Iframe-only
 
 ### Iframe Restrictions
 
-When a plugin uses an iframe UI, the following are **not** available: `registerHeaderButton`, `registerMenuEntry`, `registerSidePanelButton`, `registerShortcut`, `registerHook`, `execNodeScript`. Iframe content is subject to CSP (e.g. no external scripts; same-origin or inlined only).
+Iframe plugins receive a filtered `window.PluginAPI` object injected into `index.html`. The iframe can use the injected task/project/tag APIs, dialog and notification APIs, navigation helpers, persistence helpers, registration helpers, counters, and action dispatch. APIs not injected into the iframe are unavailable, even if they exist on the host-side plugin bridge. `executeNodeScript` is proxied through the host bridge when the desktop app grants the plugin `nodeExecution` permission. Iframe content runs in a sandboxed blob document without `allow-same-origin` and communicates with the host through the filtered `postMessage` bridge.
 
 ---
 

--- a/docs/wiki/3.05-Web-App-vs-Desktop.md
+++ b/docs/wiki/3.05-Web-App-vs-Desktop.md
@@ -79,22 +79,24 @@ The web app uses a Service Worker (production builds) to cache assets for limite
 
 ### Plugin API in Iframes
 
-When plugins use iframe-based UIs, the following API methods are not available for security reasons:
+Iframe plugins receive a filtered `window.PluginAPI` object injected into `index.html`.
+The iframe can use the injected task/project/tag APIs, dialog and notification APIs,
+navigation helpers, persistence helpers, registration helpers, counters, and action
+dispatch. APIs not injected into the iframe are unavailable, even if they exist on the
+host-side plugin bridge.
 
-- `registerHeaderButton()`
-- `registerMenuEntry()`
-- `registerSidePanelButton()`
-- `registerShortcut()`
-- `registerHook()`
-- `execNodeScript()`
+`executeNodeScript()` is proxied through the host bridge for iframe plugins when
+the desktop app grants the plugin `nodeExecution` permission. The desktop app
+currently grants this only to packaged built-in plugins whose manifest can be
+verified by the main process.
 
-### Content Security Policy (Iframe Plugins)
+### Iframe Boundary
 
-Iframe plugins are subject to strict CSP:
+Iframe plugins are isolated from the host page:
 
-- External scripts and stylesheets are blocked.
-- Only same-origin resources are allowed.
-- Scripts must be inlined within the plugin HTML file.
+- The iframe sandbox does not include `allow-same-origin`, so iframe content has an opaque origin.
+- Host access goes through the filtered Plugin API `postMessage` bridge.
+- Inline CSS, JavaScript, and small assets in `index.html` for portable iframe plugins. Arbitrary extra files from uploaded plugin ZIPs are not served to the iframe; external URLs depend on the app/runtime CSP.
 
 ### Chrome Extension for Integrations
 

--- a/src/app/plugins/plugin.service.spec.ts
+++ b/src/app/plugins/plugin.service.spec.ts
@@ -22,6 +22,7 @@ import { PluginInstance, PluginManifest } from './plugin-api.model';
 import { PluginService } from './plugin.service';
 import { PluginState } from './plugin-state.model';
 import { PluginBridgeService } from './plugin-bridge.service';
+import { T } from '../t.const';
 
 describe('PluginService', () => {
   let service: PluginService;
@@ -329,6 +330,35 @@ describe('PluginService', () => {
         error: 'broken',
       }),
     );
+  });
+
+  it('does not serve iframe HTML for plugins that are not loaded and enabled', () => {
+    const manifest: PluginManifest = {
+      ...mockManifest,
+      id: 'blocked-iframe',
+      name: 'Blocked Iframe',
+      iFrame: true,
+    };
+    (
+      service as unknown as {
+        _setPluginState: (pluginId: string, state: PluginState) => void;
+        _pluginIndexHtml: Map<string, string>;
+      }
+    )._setPluginState(manifest.id, {
+      manifest,
+      status: 'error',
+      path: 'uploaded://blocked-iframe',
+      type: 'uploaded',
+      isEnabled: false,
+      error: T.PLUGINS.NODE_EXECUTION_PERMISSION_DENIED,
+    });
+    (
+      service as unknown as {
+        _pluginIndexHtml: Map<string, string>;
+      }
+    )._pluginIndexHtml.set(manifest.id, '<html>blocked</html>');
+
+    expect(service.getPluginIndexHtml(manifest.id)).toBeNull();
   });
 
   it('clears stale instances when ready handling fails', () => {

--- a/src/app/plugins/plugin.service.spec.ts
+++ b/src/app/plugins/plugin.service.spec.ts
@@ -361,6 +361,40 @@ describe('PluginService', () => {
     expect(service.getPluginIndexHtml(manifest.id)).toBeNull();
   });
 
+  it('bumps iframe generation when unloading a plugin runtime', () => {
+    const instance: PluginInstance = {
+      manifest: mockManifest,
+      loaded: true,
+      isEnabled: true,
+    };
+    (
+      service as unknown as {
+        _loadedPlugins: PluginInstance[];
+        _setPluginState: (pluginId: string, state: PluginState) => void;
+      }
+    )._loadedPlugins = [instance];
+    (
+      service as unknown as {
+        _setPluginState: (pluginId: string, state: PluginState) => void;
+      }
+    )._setPluginState(mockManifest.id, {
+      manifest: mockManifest,
+      status: 'loaded',
+      path: 'uploaded://test-plugin',
+      type: 'uploaded',
+      isEnabled: true,
+      instance,
+    });
+
+    const generationBeforeUnload = service.getPluginIframeGeneration(mockManifest.id);
+
+    service.unloadPlugin(mockManifest.id);
+
+    expect(service.getPluginIframeGeneration(mockManifest.id)).toBe(
+      generationBeforeUnload + 1,
+    );
+  });
+
   it('clears stale instances when ready handling fails', () => {
     const instance: PluginInstance = {
       manifest: mockManifest,

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -103,6 +103,7 @@ export class PluginService implements OnDestroy {
   private _pluginPaths: Map<string, string> = new Map(); // Store plugin ID -> path mapping
   private _pluginIndexHtml: Map<string, string> = new Map(); // Store plugin ID -> index.html content
   private _pluginIcons: Map<string, string> = new Map(); // Store plugin ID -> SVG icon content
+  private _pluginIframeGenerations: Map<string, number> = new Map();
   private _pluginIconsSignal = signal<Map<string, string>>(new Map());
 
   // Lazy loading state management
@@ -679,6 +680,7 @@ export class PluginService implements OnDestroy {
     const pluginId = instance.manifest.id;
     const errorMsg = error instanceof Error ? error.message : String(error);
     PluginLog.err(`onReady failed for plugin ${pluginId}:`, error);
+    this._bumpPluginIframeGeneration(pluginId);
 
     try {
       this._pluginRunner.unloadPlugin(pluginId);
@@ -996,6 +998,10 @@ export class PluginService implements OnDestroy {
 
   getPluginPath(pluginId: string): string | undefined {
     return this._pluginPaths.get(pluginId);
+  }
+
+  getPluginIframeGeneration(pluginId: string): number {
+    return this._pluginIframeGenerations.get(pluginId) ?? 0;
   }
 
   isInitialized(): boolean {
@@ -1591,6 +1597,8 @@ export class PluginService implements OnDestroy {
    * without changing isEnabled or _pluginStates. Used for re-upload and reload.
    */
   private _teardownPluginRuntime(pluginId: string): void {
+    this._bumpPluginIframeGeneration(pluginId);
+
     // Close the side panel if this plugin is active
     const activePluginId = this.getActiveSidePanelPluginId();
     if (activePluginId === pluginId) {
@@ -1620,6 +1628,13 @@ export class PluginService implements OnDestroy {
     // Best-effort and fire-and-forget because teardown is synchronous.
     void this._revokeNodeExecutionGrant(pluginId).catch((e) =>
       PluginLog.err(`Failed to revoke nodeExecution grant for ${pluginId}`, e),
+    );
+  }
+
+  private _bumpPluginIframeGeneration(pluginId: string): void {
+    this._pluginIframeGenerations.set(
+      pluginId,
+      this.getPluginIframeGeneration(pluginId) + 1,
     );
   }
 

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -1006,6 +1006,9 @@ export class PluginService implements OnDestroy {
    * Get index.html content for a plugin
    */
   getPluginIndexHtml(pluginId: string): string | null {
+    if (!this._canServePluginIndexHtml(pluginId)) {
+      return null;
+    }
     return this._pluginIndexHtml.get(pluginId) || null;
   }
 
@@ -1080,6 +1083,10 @@ export class PluginService implements OnDestroy {
    * Load plugin index.html content
    */
   async loadPluginIndexHtml(pluginId: string): Promise<string | null> {
+    if (!this._canServePluginIndexHtml(pluginId)) {
+      return null;
+    }
+
     // First check if we already have it cached
     const cached = this._pluginIndexHtml.get(pluginId);
     if (cached) {
@@ -1091,12 +1098,26 @@ export class PluginService implements OnDestroy {
     if (pluginPath?.startsWith('uploaded://')) {
       const cachedPlugin = await this._pluginCacheService.getPlugin(pluginId);
       if (cachedPlugin?.indexHtml) {
+        if (!this._canServePluginIndexHtml(pluginId)) {
+          return null;
+        }
         this._pluginIndexHtml.set(pluginId, cachedPlugin.indexHtml);
         return cachedPlugin.indexHtml;
       }
     }
 
     return null;
+  }
+
+  private _canServePluginIndexHtml(pluginId: string): boolean {
+    const state = this._getPluginState(pluginId);
+    return (
+      !!state &&
+      state.status === 'loaded' &&
+      state.isEnabled &&
+      state.instance?.loaded === true &&
+      !state.error
+    );
   }
 
   async dispatchHook(hookName: Hooks, payload?: unknown): Promise<void> {

--- a/src/app/plugins/ui/plugin-index/plugin-index.component.html
+++ b/src/app/plugins/ui/plugin-index/plugin-index.component.html
@@ -69,7 +69,7 @@
         [src]="iframeSrc()"
         data-plugin-iframe
         [attr.data-plugin-id]="pluginId()"
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+        [attr.sandbox]="iframeSandbox"
         class="plugin-iframe"
         [class.hidden]="isLoading()"
         (load)="onIframeLoad()"

--- a/src/app/plugins/ui/plugin-index/plugin-index.component.ts
+++ b/src/app/plugins/ui/plugin-index/plugin-index.component.ts
@@ -233,6 +233,7 @@ export class PluginIndexComponent implements OnInit, OnDestroy {
       baseCfg,
       pluginBridge: this._pluginBridge,
       bridgeToken: this._createBridgeToken(),
+      bridgeGeneration: this._pluginService.getPluginIframeGeneration(pluginId),
       boundMethods: this._pluginBridge.createBoundMethods(pluginId, plugin.manifest),
     };
 
@@ -249,6 +250,12 @@ export class PluginIndexComponent implements OnInit, OnDestroy {
       const msgEvent = event as MessageEvent;
       const iframeWin = this.iframeRef?.nativeElement?.contentWindow;
       if (!iframeWin || msgEvent.source !== iframeWin) {
+        return;
+      }
+      if (
+        this._pluginService.getPluginIframeGeneration(config.pluginId) !==
+        config.bridgeGeneration
+      ) {
         return;
       }
       if (!this._pluginService.getPluginIndexHtml(config.pluginId)) {

--- a/src/app/plugins/ui/plugin-index/plugin-index.component.ts
+++ b/src/app/plugins/ui/plugin-index/plugin-index.component.ts
@@ -21,6 +21,7 @@ import {
   createPluginIframeUrl,
   handlePluginMessage,
   cleanupPluginIframeUrl,
+  PLUGIN_IFRAME_SANDBOX,
 } from '../../util/plugin-iframe.util';
 import {
   MatCard,
@@ -89,6 +90,7 @@ export class PluginIndexComponent implements OnInit, OnDestroy {
   private readonly _layoutService = inject(LayoutService);
 
   T = T;
+  readonly iframeSandbox = PLUGIN_IFRAME_SANDBOX;
 
   readonly pluginId = signal<string>('');
   readonly isLoading = signal<boolean>(true);
@@ -207,6 +209,10 @@ export class PluginIndexComponent implements OnInit, OnDestroy {
         throw new Error('Plugin does not support iframes');
       }
 
+      if (plugin.error) {
+        throw new Error(plugin.error);
+      }
+
       throw new Error('Plugin index.html not loaded');
     }
 
@@ -226,6 +232,7 @@ export class PluginIndexComponent implements OnInit, OnDestroy {
       indexHtml: indexContent,
       baseCfg,
       pluginBridge: this._pluginBridge,
+      bridgeToken: this._createBridgeToken(),
       boundMethods: this._pluginBridge.createBoundMethods(pluginId, plugin.manifest),
     };
 
@@ -242,6 +249,9 @@ export class PluginIndexComponent implements OnInit, OnDestroy {
       const msgEvent = event as MessageEvent;
       const iframeWin = this.iframeRef?.nativeElement?.contentWindow;
       if (!iframeWin || msgEvent.source !== iframeWin) {
+        return;
+      }
+      if (!this._pluginService.getPluginIndexHtml(config.pluginId)) {
         return;
       }
       await handlePluginMessage(msgEvent, config);
@@ -261,6 +271,12 @@ export class PluginIndexComponent implements OnInit, OnDestroy {
     this.iframeSrc.set(safeUrl);
     this.isLoading.set(false);
     PluginLog.log(`Plugin ${pluginId} iframe src set, loading complete`);
+  }
+
+  private _createBridgeToken(): string {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
   }
 
   private _cleanupIframeCommunication(): void {

--- a/src/app/plugins/util/plugin-iframe.util.spec.ts
+++ b/src/app/plugins/util/plugin-iframe.util.spec.ts
@@ -32,6 +32,7 @@ describe('handlePluginMessage()', () => {
     } as PluginBaseCfg,
     pluginBridge,
     bridgeToken: 'test-bridge-token',
+    bridgeGeneration: 4,
     boundMethods: {} as ReturnType<
       typeof PluginBridgeService.prototype.createBoundMethods
     >,
@@ -59,6 +60,7 @@ describe('handlePluginMessage()', () => {
             data: {
               type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
               bridgeToken: 'test-bridge-token',
+              bridgeGeneration: 4,
               dialogCallId: 7,
               buttonIndex: 0,
               result: undefined,
@@ -76,6 +78,7 @@ describe('handlePluginMessage()', () => {
         data: {
           type: PluginIframeMessageType.API_CALL,
           bridgeToken: 'test-bridge-token',
+          bridgeGeneration: 4,
           method: 'openDialog',
           callId: 7,
           args: [
@@ -130,6 +133,7 @@ describe('handlePluginMessage()', () => {
             data: {
               type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
               bridgeToken: 'test-bridge-token',
+              bridgeGeneration: 4,
               dialogCallId: 8,
               buttonIndex: 0,
               error: 'Button failed',
@@ -145,6 +149,7 @@ describe('handlePluginMessage()', () => {
         data: {
           type: PluginIframeMessageType.API_CALL,
           bridgeToken: 'test-bridge-token',
+          bridgeGeneration: 4,
           method: 'openDialog',
           callId: 8,
           args: [
@@ -191,6 +196,7 @@ describe('handlePluginMessage()', () => {
             data: {
               type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
               bridgeToken: 'test-bridge-token',
+              bridgeGeneration: 3,
               dialogCallId: 10,
               buttonIndex: 0,
               result: 'spoofed',
@@ -203,6 +209,7 @@ describe('handlePluginMessage()', () => {
             data: {
               type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
               bridgeToken: 'test-bridge-token',
+              bridgeGeneration: 4,
               dialogCallId: 10,
               buttonIndex: 0,
               result: 'trusted',
@@ -219,6 +226,7 @@ describe('handlePluginMessage()', () => {
         data: {
           type: PluginIframeMessageType.API_CALL,
           bridgeToken: 'test-bridge-token',
+          bridgeGeneration: 4,
           method: 'openDialog',
           callId: 10,
           args: [
@@ -249,6 +257,10 @@ describe('handlePluginMessage()', () => {
     expect(script).toContain('.then(() => handler())');
     expect(script).toContain('Unknown dialog button error');
     expect(script).toContain('const bridgeToken = "test-bridge-token"');
+    expect(script).toContain('const bridgeGeneration = 4');
+    expect(script).toContain(
+      "registerHeaderButton: unsupportedIframeRegistration('registerHeaderButton')",
+    );
   });
 
   it('keeps iframe plugins on an opaque sandbox origin', () => {
@@ -271,6 +283,7 @@ describe('handlePluginMessage()', () => {
         data: {
           type: PluginIframeMessageType.API_CALL,
           bridgeToken: 'test-bridge-token',
+          bridgeGeneration: 4,
           method: 'requestNodeExecutionGrant',
           callId: 9,
           args: ['sync-md'],
@@ -329,6 +342,82 @@ describe('handlePluginMessage()', () => {
     expect(sourceWindow.postMessage).not.toHaveBeenCalled();
   });
 
+  it('ignores iframe API calls from a stale bridge generation', async () => {
+    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
+      'sourceWindow',
+      ['postMessage'],
+    );
+    const pluginBridge = {
+      createBoundMethods: () => ({}),
+      getTasks: jasmine.createSpy('getTasks'),
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.API_CALL,
+          bridgeToken: 'test-bridge-token',
+          bridgeGeneration: 3,
+          method: 'getTasks',
+          callId: 13,
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(
+      (
+        pluginBridge as unknown as {
+          getTasks: jasmine.Spy;
+        }
+      ).getTasks,
+    ).not.toHaveBeenCalled();
+    expect(sourceWindow.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects raw iframe registration APIs that need callback proxying', async () => {
+    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
+      'sourceWindow',
+      ['postMessage'],
+    );
+    const pluginBridge = {
+      createBoundMethods: () => ({}),
+      registerHeaderButton: jasmine.createSpy('registerHeaderButton'),
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.API_CALL,
+          bridgeToken: 'test-bridge-token',
+          bridgeGeneration: 4,
+          method: 'registerHeaderButton',
+          callId: 14,
+          args: [{ label: 'Run' }],
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(
+      (
+        pluginBridge as unknown as {
+          registerHeaderButton: jasmine.Spy;
+        }
+      ).registerHeaderButton,
+    ).not.toHaveBeenCalled();
+    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PluginIframeMessageType.API_ERROR,
+        callId: 14,
+        error: 'Unknown API method: registerHeaderButton',
+      },
+      '*',
+    );
+  });
+
   it('rejects raw iframe registerHook calls with legacy string handlers', async () => {
     const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
       'sourceWindow',
@@ -344,6 +433,7 @@ describe('handlePluginMessage()', () => {
         data: {
           type: PluginIframeMessageType.API_CALL,
           bridgeToken: 'test-bridge-token',
+          bridgeGeneration: 4,
           method: 'registerHook',
           callId: 11,
           args: ['TASK_UPDATE', '() => window.__unexpectedParentHandler = true'],
@@ -365,6 +455,47 @@ describe('handlePluginMessage()', () => {
         type: PluginIframeMessageType.API_ERROR,
         callId: 11,
         error: 'Iframe registerHook calls must use IFRAME_HANDLER',
+      },
+      '*',
+    );
+  });
+
+  it('forwards legacy iframe plugin messages without requiring a bridge token', async () => {
+    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
+      'sourceWindow',
+      ['postMessage'],
+    );
+    const pluginBridge = {
+      createBoundMethods: () => ({}),
+      sendMessageToPlugin: jasmine
+        .createSpy('sendMessageToPlugin')
+        .and.resolveTo({ ok: true }),
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.MESSAGE,
+          messageId: 'msg-1',
+          message: { type: 'getConfig' },
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(
+      (
+        pluginBridge as unknown as {
+          sendMessageToPlugin: jasmine.Spy;
+        }
+      ).sendMessageToPlugin,
+    ).toHaveBeenCalledOnceWith('test-plugin', { type: 'getConfig' });
+    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PluginIframeMessageType.MESSAGE_RESPONSE,
+        messageId: 'msg-1',
+        result: { ok: true },
       },
       '*',
     );

--- a/src/app/plugins/util/plugin-iframe.util.spec.ts
+++ b/src/app/plugins/util/plugin-iframe.util.spec.ts
@@ -8,6 +8,7 @@ import {
   createPluginApiScript,
   handlePluginMessage,
   PluginIframeConfig,
+  PLUGIN_IFRAME_SANDBOX,
 } from './plugin-iframe.util';
 
 describe('handlePluginMessage()', () => {
@@ -30,6 +31,7 @@ describe('handlePluginMessage()', () => {
       isDev: false,
     } as PluginBaseCfg,
     pluginBridge,
+    bridgeToken: 'test-bridge-token',
     boundMethods: {} as ReturnType<
       typeof PluginBridgeService.prototype.createBoundMethods
     >,
@@ -41,10 +43,8 @@ describe('handlePluginMessage()', () => {
           buttons?: Array<Record<string, unknown>>;
         }
       | undefined;
-    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
-      'sourceWindow',
-      ['postMessage'],
-    );
+    const sourceWindow = window;
+    const postMessageSpy = spyOn(sourceWindow, 'postMessage') as jasmine.Spy;
     const pluginBridge = {
       createBoundMethods: () => ({}),
       openDialog: async (dialogCfg: { buttons?: Array<Record<string, unknown>> }) => {
@@ -55,8 +55,10 @@ describe('handlePluginMessage()', () => {
         const clickPromise = onClick?.();
         window.dispatchEvent(
           new MessageEvent('message', {
+            source: sourceWindow as unknown as MessageEventSource,
             data: {
               type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
+              bridgeToken: 'test-bridge-token',
               dialogCallId: 7,
               buttonIndex: 0,
               result: undefined,
@@ -73,6 +75,7 @@ describe('handlePluginMessage()', () => {
       {
         data: {
           type: PluginIframeMessageType.API_CALL,
+          bridgeToken: 'test-bridge-token',
           method: 'openDialog',
           callId: 7,
           args: [
@@ -93,7 +96,7 @@ describe('handlePluginMessage()', () => {
 
     expect(bridgedDialogCfg?.buttons?.[0].onClick).toEqual(jasmine.any(Function));
     expect(bridgedDialogCfg?.buttons?.[0].__hasDialogButtonHandler).toBeUndefined();
-    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+    expect(postMessageSpy).toHaveBeenCalledWith(
       {
         type: PluginIframeMessageType.DIALOG_BUTTON_CLICK,
         buttonIndex: 0,
@@ -101,7 +104,7 @@ describe('handlePluginMessage()', () => {
       },
       { targetOrigin: '*' },
     );
-    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+    expect(postMessageSpy).toHaveBeenCalledWith(
       {
         type: PluginIframeMessageType.API_RESPONSE,
         callId: 7,
@@ -112,10 +115,8 @@ describe('handlePluginMessage()', () => {
   });
 
   it('reports iframe dialog button handler errors as API errors', async () => {
-    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
-      'sourceWindow',
-      ['postMessage'],
-    );
+    const sourceWindow = window;
+    const postMessageSpy = spyOn(sourceWindow, 'postMessage') as jasmine.Spy;
     const pluginBridge = {
       createBoundMethods: () => ({}),
       openDialog: async (dialogCfg: { buttons?: Array<Record<string, unknown>> }) => {
@@ -125,8 +126,10 @@ describe('handlePluginMessage()', () => {
         const clickPromise = onClick?.();
         window.dispatchEvent(
           new MessageEvent('message', {
+            source: sourceWindow as unknown as MessageEventSource,
             data: {
               type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
+              bridgeToken: 'test-bridge-token',
               dialogCallId: 8,
               buttonIndex: 0,
               error: 'Button failed',
@@ -141,6 +144,7 @@ describe('handlePluginMessage()', () => {
       {
         data: {
           type: PluginIframeMessageType.API_CALL,
+          bridgeToken: 'test-bridge-token',
           method: 'openDialog',
           callId: 8,
           args: [
@@ -159,7 +163,7 @@ describe('handlePluginMessage()', () => {
       createConfig(pluginBridge),
     );
 
-    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+    expect(postMessageSpy).toHaveBeenCalledWith(
       {
         type: PluginIframeMessageType.API_ERROR,
         callId: 8,
@@ -167,6 +171,73 @@ describe('handlePluginMessage()', () => {
       },
       '*',
     );
+  });
+
+  it('ignores dialog button responses from a different iframe source', async () => {
+    let dialogButtonResult: unknown;
+    const sourceWindow = window;
+    spyOn(sourceWindow, 'postMessage');
+    const otherWindow = new MessageChannel().port1;
+    const pluginBridge = {
+      createBoundMethods: () => ({}),
+      openDialog: async (dialogCfg: { buttons?: Array<Record<string, unknown>> }) => {
+        const onClick = dialogCfg.buttons?.[0].onClick as
+          | (() => Promise<unknown>)
+          | undefined;
+        const clickPromise = onClick?.();
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            source: otherWindow as unknown as MessageEventSource,
+            data: {
+              type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
+              bridgeToken: 'test-bridge-token',
+              dialogCallId: 10,
+              buttonIndex: 0,
+              result: 'spoofed',
+            },
+          }),
+        );
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            source: sourceWindow as unknown as MessageEventSource,
+            data: {
+              type: PluginIframeMessageType.DIALOG_BUTTON_RESPONSE,
+              bridgeToken: 'test-bridge-token',
+              dialogCallId: 10,
+              buttonIndex: 0,
+              result: 'trusted',
+            },
+          }),
+        );
+        dialogButtonResult = await clickPromise;
+        return 'Confirm';
+      },
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.API_CALL,
+          bridgeToken: 'test-bridge-token',
+          method: 'openDialog',
+          callId: 10,
+          args: [
+            {
+              buttons: [
+                {
+                  label: 'Confirm',
+                  __hasDialogButtonHandler: true,
+                },
+              ],
+            },
+          ],
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(dialogButtonResult).toBe('trusted');
   });
 
   it('generates iframe code that waits for async dialog button handlers', () => {
@@ -177,5 +248,125 @@ describe('handlePluginMessage()', () => {
     expect(script).toContain('Promise.resolve()');
     expect(script).toContain('.then(() => handler())');
     expect(script).toContain('Unknown dialog button error');
+    expect(script).toContain('const bridgeToken = "test-bridge-token"');
+  });
+
+  it('keeps iframe plugins on an opaque sandbox origin', () => {
+    expect(PLUGIN_IFRAME_SANDBOX).toContain('allow-scripts');
+    expect(PLUGIN_IFRAME_SANDBOX).not.toContain('allow-same-origin');
+  });
+
+  it('rejects raw iframe calls to bridge methods outside the iframe API allowlist', async () => {
+    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
+      'sourceWindow',
+      ['postMessage'],
+    );
+    const pluginBridge = {
+      createBoundMethods: () => ({}),
+      requestNodeExecutionGrant: jasmine.createSpy('requestNodeExecutionGrant'),
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.API_CALL,
+          bridgeToken: 'test-bridge-token',
+          method: 'requestNodeExecutionGrant',
+          callId: 9,
+          args: ['sync-md'],
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(
+      (
+        pluginBridge as unknown as {
+          requestNodeExecutionGrant: jasmine.Spy;
+        }
+      ).requestNodeExecutionGrant,
+    ).not.toHaveBeenCalled();
+    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PluginIframeMessageType.API_ERROR,
+        callId: 9,
+        error: 'Unknown API method: requestNodeExecutionGrant',
+      },
+      '*',
+    );
+  });
+
+  it('ignores iframe API calls without the bridge token', async () => {
+    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
+      'sourceWindow',
+      ['postMessage'],
+    );
+    const pluginBridge = {
+      createBoundMethods: () => ({}),
+      getTasks: jasmine.createSpy('getTasks'),
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.API_CALL,
+          method: 'getTasks',
+          callId: 12,
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(
+      (
+        pluginBridge as unknown as {
+          getTasks: jasmine.Spy;
+        }
+      ).getTasks,
+    ).not.toHaveBeenCalled();
+    expect(sourceWindow.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects raw iframe registerHook calls with legacy string handlers', async () => {
+    const sourceWindow = jasmine.createSpyObj<{ postMessage: jasmine.Spy }>(
+      'sourceWindow',
+      ['postMessage'],
+    );
+    const pluginBridge = {
+      createBoundMethods: () => ({}),
+      registerHook: jasmine.createSpy('registerHook'),
+    } as unknown as PluginBridgeService;
+
+    await handlePluginMessage(
+      {
+        data: {
+          type: PluginIframeMessageType.API_CALL,
+          bridgeToken: 'test-bridge-token',
+          method: 'registerHook',
+          callId: 11,
+          args: ['TASK_UPDATE', '() => window.__unexpectedParentHandler = true'],
+        },
+        source: sourceWindow,
+      } as unknown as MessageEvent,
+      createConfig(pluginBridge),
+    );
+
+    expect(
+      (
+        pluginBridge as unknown as {
+          registerHook: jasmine.Spy;
+        }
+      ).registerHook,
+    ).not.toHaveBeenCalled();
+    expect(sourceWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: PluginIframeMessageType.API_ERROR,
+        callId: 11,
+        error: 'Iframe registerHook calls must use IFRAME_HANDLER',
+      },
+      '*',
+    );
   });
 });

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -15,12 +15,59 @@ export interface PluginIframeConfig {
   indexHtml: string;
   baseCfg: PluginBaseCfg;
   pluginBridge: PluginBridgeService;
+  bridgeToken: string;
   boundMethods?: ReturnType<typeof PluginBridgeService.prototype.createBoundMethods>;
 }
 
-// Simple sandbox - allow what plugins need
+// Keep iframe plugin UIs on an opaque origin. `allow-same-origin` would let blob
+// iframes access `window.parent.ea` and bypass the filtered postMessage bridge.
 export const PLUGIN_IFRAME_SANDBOX =
-  'allow-scripts allow-same-origin allow-forms allow-popups allow-modals';
+  'allow-scripts allow-forms allow-popups allow-modals';
+
+const ALLOWED_IFRAME_API_METHODS = new Set([
+  'getTasks',
+  'getArchivedTasks',
+  'getCurrentContextTasks',
+  'selectTask',
+  'reInitData',
+  'updateTask',
+  'addTask',
+  'deleteTask',
+  'batchUpdateForProject',
+  'reorderTasks',
+  'getAllProjects',
+  'addProject',
+  'updateProject',
+  'getAllTags',
+  'addTag',
+  'updateTag',
+  'showSnack',
+  'notify',
+  'openDialog',
+  'showIndexHtmlAsView',
+  'showIndexHtmlInSidePanel',
+  'showInWorkContext',
+  'closeWorkContextView',
+  'getActiveWorkContext',
+  'getAppState',
+  'persistDataSynced',
+  'loadPersistedData',
+  'registerHook',
+  'registerHeaderButton',
+  'registerMenuEntry',
+  'registerConfigHandler',
+  'registerShortcut',
+  'registerSidePanelButton',
+  'registerWorkContextHeaderButton',
+  'executeNodeScript',
+  'dispatchAction',
+  'setCounter',
+  'getCounter',
+  'incrementCounter',
+  'decrementCounter',
+  'deleteCounter',
+  'getAllCounters',
+]);
 
 const isTransparentCssValue = (value: string): boolean => {
   const normalized = value.trim().replace(/\s+/g, '').toLowerCase();
@@ -189,6 +236,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
     <script>
       (function() {
         let callId = 0;
+        const bridgeToken = ${JSON.stringify(config.bridgeToken)};
         const pendingCalls = new Map();
         const dialogButtonHandlers = new Map();
         const hookHandlers = new Map(); // Store hook handlers by hook type
@@ -225,6 +273,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
                 .then((result) => {
                   window.parent.postMessage({
                     type: '${PluginIframeMessageType.DIALOG_BUTTON_RESPONSE}',
+                    bridgeToken: bridgeToken,
                     dialogCallId: data.dialogCallId,
                     buttonIndex: data.buttonIndex,
                     result: result
@@ -233,6 +282,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
                 .catch((error) => {
                   window.parent.postMessage({
                     type: '${PluginIframeMessageType.DIALOG_BUTTON_RESPONSE}',
+                    bridgeToken: bridgeToken,
                     dialogCallId: data.dialogCallId,
                     buttonIndex: data.buttonIndex,
                     error: error instanceof Error ? error.message : 'Unknown dialog button error'
@@ -308,6 +358,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
 
             window.parent.postMessage({
               type: '${PluginIframeMessageType.API_CALL}',
+              bridgeToken: bridgeToken,
               method: method,
               args: processedArgs || [],
               callId: id
@@ -459,6 +510,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
         // Notify parent that plugin is ready
         window.parent.postMessage({
           type: '${PluginIframeMessageType.READY}',
+          bridgeToken: bridgeToken,
           pluginId: '${config.pluginId}'
         }, '*');
       })();
@@ -539,6 +591,7 @@ export const handlePluginMessage = async (
   const { data } = event;
 
   if (!data || typeof data !== 'object') return;
+  if (!isValidBridgeMessage(data, config)) return;
 
   // Ensure we have bound methods
   if (!config.boundMethods) {
@@ -550,9 +603,13 @@ export const handlePluginMessage = async (
 
   // Handle API calls
   if (data.type === PluginIframeMessageType.API_CALL && data.callId) {
-    const { method, args, callId } = data;
+    const { method, args = [], callId } = data;
 
     try {
+      if (!ALLOWED_IFRAME_API_METHODS.has(method)) {
+        throw new Error(`Unknown API method: ${method}`);
+      }
+
       // For iframe plugins, we need to handle API calls differently
       // Some methods need special handling because the bridge methods have different signatures
 
@@ -626,9 +683,7 @@ export const handlePluginMessage = async (
             };
             result = await bridge.registerHook(config.pluginId, hook, handler);
           } else {
-            // Legacy string handler support
-            const handler = new Function('return ' + handlerPlaceholder)();
-            result = await bridge.registerHook(config.pluginId, hook, handler);
+            throw new Error('Iframe registerHook calls must use IFRAME_HANDLER');
           }
           event.source?.postMessage(
             {
@@ -696,6 +751,8 @@ export const handlePluginMessage = async (
                     return new Promise((resolve, reject) => {
                       const handleResponse = (e: MessageEvent): void => {
                         if (
+                          e.source === event.source &&
+                          e.data?.bridgeToken === config.bridgeToken &&
                           e.data?.type ===
                             PluginIframeMessageType.DIALOG_BUTTON_RESPONSE &&
                           e.data?.dialogCallId === callId &&
@@ -785,4 +842,19 @@ export const handlePluginMessage = async (
   if (data.type === PluginIframeMessageType.READY && data.pluginId === config.pluginId) {
     PluginLog.log(`Plugin ${config.pluginId} is ready`);
   }
+};
+
+const isValidBridgeMessage = (
+  data: Record<string, unknown>,
+  config: PluginIframeConfig,
+): boolean => {
+  const hostHandledTypes = new Set<unknown>([
+    PluginIframeMessageType.API_CALL,
+    PluginIframeMessageType.MESSAGE,
+    PluginIframeMessageType.READY,
+  ]);
+  if (!hostHandledTypes.has(data.type)) {
+    return true;
+  }
+  return data.bridgeToken === config.bridgeToken;
 };

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -16,6 +16,7 @@ export interface PluginIframeConfig {
   baseCfg: PluginBaseCfg;
   pluginBridge: PluginBridgeService;
   bridgeToken: string;
+  bridgeGeneration: number;
   boundMethods?: ReturnType<typeof PluginBridgeService.prototype.createBoundMethods>;
 }
 
@@ -53,11 +54,6 @@ const ALLOWED_IFRAME_API_METHODS = new Set([
   'persistDataSynced',
   'loadPersistedData',
   'registerHook',
-  'registerHeaderButton',
-  'registerMenuEntry',
-  'registerConfigHandler',
-  'registerShortcut',
-  'registerSidePanelButton',
   'registerWorkContextHeaderButton',
   'executeNodeScript',
   'dispatchAction',
@@ -237,6 +233,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
       (function() {
         let callId = 0;
         const bridgeToken = ${JSON.stringify(config.bridgeToken)};
+        const bridgeGeneration = ${JSON.stringify(config.bridgeGeneration)};
         const pendingCalls = new Map();
         const dialogButtonHandlers = new Map();
         const hookHandlers = new Map(); // Store hook handlers by hook type
@@ -274,6 +271,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
                   window.parent.postMessage({
                     type: '${PluginIframeMessageType.DIALOG_BUTTON_RESPONSE}',
                     bridgeToken: bridgeToken,
+                    bridgeGeneration: bridgeGeneration,
                     dialogCallId: data.dialogCallId,
                     buttonIndex: data.buttonIndex,
                     result: result
@@ -283,6 +281,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
                   window.parent.postMessage({
                     type: '${PluginIframeMessageType.DIALOG_BUTTON_RESPONSE}',
                     bridgeToken: bridgeToken,
+                    bridgeGeneration: bridgeGeneration,
                     dialogCallId: data.dialogCallId,
                     buttonIndex: data.buttonIndex,
                     error: error instanceof Error ? error.message : 'Unknown dialog button error'
@@ -359,6 +358,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
             window.parent.postMessage({
               type: '${PluginIframeMessageType.API_CALL}',
               bridgeToken: bridgeToken,
+              bridgeGeneration: bridgeGeneration,
               method: method,
               args: processedArgs || [],
               callId: id
@@ -372,6 +372,12 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
               }
             }, 30000);
           });
+        }
+
+        function unsupportedIframeRegistration(method) {
+          return () => Promise.reject(
+            new Error(method + ' is only supported in plugin.js, not iframe index.html')
+          );
         }
 
         // Create the PluginAPI object with all methods
@@ -424,11 +430,11 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
 
           // Registration methods
           registerHook: (hook, handler) => callApi('registerHook', [hook, handler]),
-          registerHeaderButton: (cfg) => callApi('registerHeaderButton', [cfg]),
-          registerMenuEntry: (cfg) => callApi('registerMenuEntry', [cfg]),
-          registerConfigHandler: (handler) => callApi('registerConfigHandler', [handler]),
-          registerShortcut: (cfg) => callApi('registerShortcut', [cfg]),
-          registerSidePanelButton: (cfg) => callApi('registerSidePanelButton', [cfg]),
+          registerHeaderButton: unsupportedIframeRegistration('registerHeaderButton'),
+          registerMenuEntry: unsupportedIframeRegistration('registerMenuEntry'),
+          registerConfigHandler: unsupportedIframeRegistration('registerConfigHandler'),
+          registerShortcut: unsupportedIframeRegistration('registerShortcut'),
+          registerSidePanelButton: unsupportedIframeRegistration('registerSidePanelButton'),
           registerWorkContextHeaderButton: (cfg) => {
             // onClick is not structured-cloneable across postMessage; keep it
             // locally, keyed by the button's label, and send the rest of the
@@ -511,6 +517,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
         window.parent.postMessage({
           type: '${PluginIframeMessageType.READY}',
           bridgeToken: bridgeToken,
+          bridgeGeneration: bridgeGeneration,
           pluginId: '${config.pluginId}'
         }, '*');
       })();
@@ -753,6 +760,7 @@ export const handlePluginMessage = async (
                         if (
                           e.source === event.source &&
                           e.data?.bridgeToken === config.bridgeToken &&
+                          e.data?.bridgeGeneration === config.bridgeGeneration &&
                           e.data?.type ===
                             PluginIframeMessageType.DIALOG_BUTTON_RESPONSE &&
                           e.data?.dialogCallId === callId &&
@@ -856,5 +864,14 @@ const isValidBridgeMessage = (
   if (!hostHandledTypes.has(data.type)) {
     return true;
   }
-  return data.bridgeToken === config.bridgeToken;
+  if (data.type === PluginIframeMessageType.MESSAGE) {
+    // Legacy iframe UIs post raw plugin-to-plugin messages. PluginIndexComponent
+    // source-checks the mounted iframe and verifies the current bridge generation
+    // before calling into this handler.
+    return true;
+  }
+  return (
+    data.bridgeToken === config.bridgeToken &&
+    data.bridgeGeneration === config.bridgeGeneration
+  );
 };


### PR DESCRIPTION
## Summary

Stacked on #8205. This follow-up is intentionally limited to iframe plugin boundaries:

- keep iframe plugin documents on an opaque sandbox origin by removing `allow-same-origin`
- require the current bridge token/generation for iframe API RPC, ready, and dialog callback messages
- keep legacy iframe `PLUGIN_MESSAGE` forwarding working through the mounted iframe `event.source` check plus the current bridge generation check
- invalidate mounted same-id iframes when plugin runtime teardown/reload/replacement advances the plugin iframe generation
- allowlist iframe PluginAPI RPC methods, reject raw legacy `registerHook` string handlers, and reject callback-heavy iframe registration APIs that are only supported from `plugin.js`
- revalidate live plugin state before serving iframe HTML or handling mounted iframe messages
- update iframe plugin docs to match the sandboxed blob/document bridge behavior, callback registration limits, and storage constraints

Out of scope here: uploaded plugin replacement lifecycle cleanup and issue-provider setup filtering. Those broader ideas are preserved on the saved follow-up branch, but are not included in this PR.

## Validation

- `npm run checkFile src/app/plugins/plugin.service.ts`
- `npm run checkFile src/app/plugins/plugin.service.spec.ts`
- `npm run checkFile src/app/plugins/ui/plugin-index/plugin-index.component.ts`
- `npm run checkFile src/app/plugins/util/plugin-iframe.util.ts`
- `npm run checkFile src/app/plugins/util/plugin-iframe.util.spec.ts`
- `npm run test:file src/app/plugins/plugin.service.spec.ts -- --watch=false` (9/9)
- `npm run test:file src/app/plugins/plugin.service.load-from-zip.spec.ts -- --watch=false` (5/5)
- `npm run test:file src/app/plugins/util/plugin-iframe.util.spec.ts -- --watch=false` (11/11)
- `npm run build`
- pre-push hook: lint, package tests, release-notes tests, full Angular suite (10,613 success / 2 skipped), LA timezone Angular suite (10,599 success / 16 skipped)

Known existing warnings: Angular browserslist warning for chrome 107; lint warning in `src/test.ts` for an unused eslint-disable; Node `util._extend` deprecation warning during Karma.
