### PR TITLE
feat(tasks): persist subtask hide/show mode across sessions and sync

### DIFF
--- a/e2e/tests/import-export/markdown-link-persistence.spec.ts
+++ b/e2e/tests/import-export/markdown-link-persistence.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../fixtures/test.fixture';
 import { type Page } from '@playwright/test';
+import { dismissViteOverlay } from '../../utils';
 
 /**
  * E2E Tests for issue #7032: Markdown link in task title breaks persistence.
@@ -9,15 +10,6 @@ import { type Page } from '@playwright/test';
  *
  * Run with: npm run e2e:file e2e/tests/import-export/markdown-link-persistence.spec.ts
  */
-
-const dismissViteOverlay = async (page: Page): Promise<void> => {
-  const overlay = page.locator('vite-error-overlay');
-  const isVisible = await overlay.isVisible().catch(() => false);
-  if (isVisible) {
-    await page.keyboard.press('Escape');
-    await overlay.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
-  }
-};
 
 type ExtractedTaskState = {
   title: string;

--- a/e2e/tests/sync/webdav-sync-full.spec.ts
+++ b/e2e/tests/sync/webdav-sync-full.spec.ts
@@ -1,8 +1,8 @@
-import { type Page } from '@playwright/test';
 import { test, expect } from '../../fixtures/webdav.fixture';
 import { SyncPage } from '../../pages/sync.page';
 import { WorkViewPage } from '../../pages/work-view.page';
 import { waitForAppReady, waitForStatePersistence } from '../../utils/waits';
+import { dismissViteOverlay } from '../../utils/element-helpers';
 import {
   WEBDAV_CONFIG_TEMPLATE,
   setupSyncClient,
@@ -11,21 +11,6 @@ import {
   generateSyncFolderName,
   closeContextsSafely,
 } from '../../utils/sync-helpers';
-
-/**
- * Dismiss the Vite error overlay if present.
- * In development mode, TypeScript errors can cause a full-page overlay
- * that intercepts all pointer events. Pressing Escape dismisses it.
- */
-const dismissViteOverlay = async (page: Page): Promise<void> => {
-  const overlay = page.locator('vite-error-overlay');
-  const isVisible = await overlay.isVisible().catch(() => false);
-  if (isVisible) {
-    console.log('[Test] Dismissing vite-error-overlay');
-    await page.keyboard.press('Escape');
-    await overlay.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
-  }
-};
 
 test.describe('@webdav WebDAV Sync Full Flow', () => {
   // Run sync tests serially to avoid WebDAV server contention

--- a/e2e/tests/task-list-basic/subtask-collapse-persistence.spec.ts
+++ b/e2e/tests/task-list-basic/subtask-collapse-persistence.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../../fixtures/test.fixture';
+import { type Page } from '@playwright/test';
+
+/**
+ * E2E for issue #7412: subtask collapse/expand state should persist across
+ * page reloads (it is stored via the synced setHideSubTasksMode action).
+ *
+ * Run with: npm run e2e:file e2e/tests/task-list-basic/subtask-collapse-persistence.spec.ts
+ */
+
+const dismissViteOverlay = async (page: Page): Promise<void> => {
+  const overlay = page.locator('vite-error-overlay');
+  const isVisible = await overlay.isVisible().catch(() => false);
+  if (isVisible) {
+    await page.keyboard.press('Escape');
+    await overlay.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+  }
+};
+
+test.describe('Subtask collapse persistence (#7412)', () => {
+  test('collapsed subtasks stay collapsed after reload', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.addTask('Parent Task');
+    const task = page.locator('task').first();
+    await workViewPage.addSubTask(task, 'SubTask 1');
+
+    const subTask = task.locator('.sub-tasks task');
+    await subTask.waitFor({ state: 'visible' });
+
+    // Collapse: with no done subtasks the toggle goes straight to HideAll,
+    // which filters the subtask out of the sub task-list.
+    await task.locator('.toggle-sub-tasks-btn').click();
+    await expect(subTask).not.toBeVisible();
+    // HideAll renders the "add" (expand) icon on the toggle button
+    await expect(task.locator('.toggle-sub-tasks-btn mat-icon')).toContainText('add');
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await workViewPage.waitForTaskList();
+    await dismissViteOverlay(page);
+
+    const taskAfterReload = page.locator('task').first();
+    await expect(taskAfterReload.locator('task-title').first()).toContainText(
+      'Parent Task',
+    );
+    // Still collapsed after reload
+    await expect(taskAfterReload.locator('.sub-tasks task')).not.toBeVisible();
+    await expect(taskAfterReload.locator('.toggle-sub-tasks-btn mat-icon')).toContainText(
+      'add',
+    );
+
+    // And expanding again still works
+    await taskAfterReload.locator('.toggle-sub-tasks-btn').click();
+    await expect(taskAfterReload.locator('.sub-tasks task')).toBeVisible();
+  });
+});

--- a/e2e/tests/task-list-basic/subtask-collapse-persistence.spec.ts
+++ b/e2e/tests/task-list-basic/subtask-collapse-persistence.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures/test.fixture';
-import { type Page } from '@playwright/test';
+import { dismissViteOverlay } from '../../utils';
 
 /**
  * E2E for issue #7412: subtask collapse/expand state should persist across
@@ -7,15 +7,6 @@ import { type Page } from '@playwright/test';
  *
  * Run with: npm run e2e:file e2e/tests/task-list-basic/subtask-collapse-persistence.spec.ts
  */
-
-const dismissViteOverlay = async (page: Page): Promise<void> => {
-  const overlay = page.locator('vite-error-overlay');
-  const isVisible = await overlay.isVisible().catch(() => false);
-  if (isVisible) {
-    await page.keyboard.press('Escape');
-    await overlay.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
-  }
-};
 
 test.describe('Subtask collapse persistence (#7412)', () => {
   test('collapsed subtasks stay collapsed after reload', async ({

--- a/e2e/utils/element-helpers.ts
+++ b/e2e/utils/element-helpers.ts
@@ -56,3 +56,19 @@ export const ensureGlobalAddTaskBarOpen = async (page: Page): Promise<Locator> =
   await addTaskInput.waitFor({ state: 'visible', timeout: 10000 });
   return addTaskInput;
 };
+
+/**
+ * Dismisses the dev-server error overlay if present.
+ * In development mode, TypeScript errors can cause a full-page overlay
+ * that intercepts all pointer events. Pressing Escape dismisses it.
+ *
+ * @param page - Playwright page object
+ */
+export const dismissViteOverlay = async (page: Page): Promise<void> => {
+  const overlay = page.locator('vite-error-overlay');
+  const isVisible = await overlay.isVisible().catch(() => false);
+  if (isVisible) {
+    await page.keyboard.press('Escape');
+    await overlay.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+  }
+};

--- a/src/app/core/persistence/operation-log/compact/action-type-codes.ts
+++ b/src/app/core/persistence/operation-log/compact/action-type-codes.ts
@@ -185,8 +185,10 @@ export const ACTION_TYPE_TO_CODE: Record<ActionType, string> = {
 
   // Task actions (T)
   [ActionType.TASK_UPDATE_MULTIPLE_SIMPLE]: 'TU',
+  [ActionType.TASK_UPDATE_UI]: 'TUU',
   [ActionType.TASK_ADD_SUB]: 'TA',
   [ActionType.TASK_MOVE_SUB]: 'TMS',
+  [ActionType.TASK_TOGGLE_HIDE_SUB]: 'THS',
   [ActionType.TASK_MOVE_UP]: 'TMU',
   [ActionType.TASK_MOVE_DOWN]: 'TMD',
   [ActionType.TASK_MOVE_TOP]: 'TMT',

--- a/src/app/core/persistence/operation-log/compact/action-type-codes.ts
+++ b/src/app/core/persistence/operation-log/compact/action-type-codes.ts
@@ -185,7 +185,7 @@ export const ACTION_TYPE_TO_CODE: Record<ActionType, string> = {
 
   // Task actions (T)
   [ActionType.TASK_UPDATE_MULTIPLE_SIMPLE]: 'TU',
-  [ActionType.TASK_SET_SUBTASK_HIDE_MODE]: 'TSH',
+  [ActionType.TASK_SET_HIDE_SUB_TASKS_MODE]: 'TSH',
   [ActionType.TASK_ADD_SUB]: 'TA',
   [ActionType.TASK_MOVE_SUB]: 'TMS',
   [ActionType.TASK_MOVE_UP]: 'TMU',

--- a/src/app/core/persistence/operation-log/compact/action-type-codes.ts
+++ b/src/app/core/persistence/operation-log/compact/action-type-codes.ts
@@ -185,7 +185,7 @@ export const ACTION_TYPE_TO_CODE: Record<ActionType, string> = {
 
   // Task actions (T)
   [ActionType.TASK_UPDATE_MULTIPLE_SIMPLE]: 'TU',
-  [ActionType.TASK_UPDATE_UI]: 'TUU',
+  [ActionType.TASK_SET_SUBTASK_HIDE_MODE]: 'TSH',
   [ActionType.TASK_ADD_SUB]: 'TA',
   [ActionType.TASK_MOVE_SUB]: 'TMS',
   [ActionType.TASK_MOVE_UP]: 'TMU',

--- a/src/app/core/persistence/operation-log/compact/action-type-codes.ts
+++ b/src/app/core/persistence/operation-log/compact/action-type-codes.ts
@@ -188,7 +188,6 @@ export const ACTION_TYPE_TO_CODE: Record<ActionType, string> = {
   [ActionType.TASK_UPDATE_UI]: 'TUU',
   [ActionType.TASK_ADD_SUB]: 'TA',
   [ActionType.TASK_MOVE_SUB]: 'TMS',
-  [ActionType.TASK_TOGGLE_HIDE_SUB]: 'THS',
   [ActionType.TASK_MOVE_UP]: 'TMU',
   [ActionType.TASK_MOVE_DOWN]: 'TMD',
   [ActionType.TASK_MOVE_TOP]: 'TMT',

--- a/src/app/features/mobile/store/mobile-notification.effects.spec.ts
+++ b/src/app/features/mobile/store/mobile-notification.effects.spec.ts
@@ -608,7 +608,20 @@ describe('MobileNotificationEffects', () => {
       ...over,
     });
 
+    // Pin the fake clock to a stable, mid-day, mid-week reference inside
+    // fakeAsync so dayStr(0) (captured at test setup) and the effect's notion of
+    // "today" (read after tick advances the virtual clock) cannot straddle
+    // midnight in any TZ — a real flake we hit when CI ran a few seconds before
+    // local midnight. zone.js routes jasmine.clock().mockDate into
+    // setFakeBaseSystemTime when called inside a fakeAsync zone, so subsequent
+    // tick()s still advance time normally.
+    const pinClock = (): void => {
+      jasmine.clock().mockDate(new Date(Date.UTC(2026, 5, 15, 10, 0, 0))); // Mon 2026-06-15 10:00 UTC
+    };
+
     beforeEach(() => {
+      jasmine.clock().install();
+
       reminderServiceSpy = jasmine.createSpyObj('CapacitorReminderService', [
         'ensurePermissions',
         'ensureExactAlarmPermission',
@@ -655,12 +668,17 @@ describe('MobileNotificationEffects', () => {
       store = TestBed.inject(MockStore);
     });
 
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
     const subscribeRepeatReminders = (): void => {
       effects = TestBed.inject(MobileNotificationEffects);
       (effects.scheduleRepeatReminders$ as unknown as Observable<unknown>).subscribe();
     };
 
     it('schedules the next occurrence of a timed daily recurring config with the same id scheduleNotifications$ would use', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
       subscribeRepeatReminders();
 
@@ -682,6 +700,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('does not schedule configs without a start time or remindAt', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [
         mkDailyCfg({ id: 'noTime', startTime: undefined }),
         mkDailyCfg({ id: 'noRemind', remindAt: undefined }),
@@ -694,6 +713,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('does not pre-schedule waitForCompletion configs', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [
         mkDailyCfg({ waitForCompletion: true }),
       ]);
@@ -705,6 +725,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('schedules one alarm per config — the soonest upcoming occurrence only', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [
         mkDailyCfg({ id: 'a' }),
         mkDailyCfg({ id: 'b', startTime: '10:30' }),
@@ -731,6 +752,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('does not schedule a weekly config whose next occurrence is beyond the lookahead window', fakeAsync(() => {
+      pinClock();
       // Weekly-on-this-weekday, but the only occurrence in range is today — which is
       // already created (lastTaskCreationDay = today). The next is 7 days out and the
       // window only spans the soonest occurrence per config, so for a far-future first
@@ -773,6 +795,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('does not pre-schedule a paused config', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [
         mkDailyCfg({ isPaused: true }),
       ]);
@@ -784,6 +807,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('skips occurrences in deletedInstanceDates and schedules the following one', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [
         mkDailyCfg({ deletedInstanceDates: [dayStr(1)] }),
       ]);
@@ -801,6 +825,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('skips occurrences whose trigger time has already passed', fakeAsync(() => {
+      pinClock();
       // today IS due (lastTaskCreationDay far in the past), but its 00:00 trigger
       // is already behind us → the next future occurrence (tomorrow) is scheduled.
       store.overrideSelector(selectActiveTaskRepeatCfgs, [
@@ -820,6 +845,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('does not schedule when disableReminders is true', fakeAsync(() => {
+      pinClock();
       cfg$.next(buildCfg({ disableReminders: true }));
       store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
       subscribeRepeatReminders();
@@ -830,6 +856,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('does NOT cancel an about-to-graduate alarm during the creation dispatch burst', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
       subscribeRepeatReminders();
 
@@ -865,6 +892,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('cancels a pre-scheduled alarm when its config is removed', fakeAsync(() => {
+      pinClock();
       store.overrideSelector(selectActiveTaskRepeatCfgs, [mkDailyCfg()]);
       subscribeRepeatReminders();
 
@@ -882,6 +910,7 @@ describe('MobileNotificationEffects', () => {
     }));
 
     it('caps pre-scheduled reminders, keeping the soonest-firing (iOS 64-pending limit)', fakeAsync(() => {
+      pinClock();
       // More configs than the cap (REPEAT_MAX_SCHEDULED = 32 in the effect),
       // each due tomorrow at a distinct clock time 30 min apart (00:00 → 19:30).
       const cfgs = Array.from({ length: 40 }, (_, i) => {

--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -1,6 +1,6 @@
 import { createAction, props } from '@ngrx/store';
 import { Update } from '@ngrx/entity';
-import { Task, TaskDetailTargetPanel } from '../task.model';
+import { HideSubTasksMode, Task, TaskDetailTargetPanel } from '../task.model';
 import { RoundTimeOption } from '../../project/project.model';
 import { PersistentActionMeta } from '../../../op-log/core/persistent-action.interface';
 import { OpType } from '../../../op-log/core/operation.types';
@@ -39,12 +39,22 @@ export const __updateMultipleTaskSimple = createAction(
 
 export const updateTaskUi = createAction(
   '[Task] Update Task Ui',
-  (taskProps: { task: Update<Task> }) => ({
+  props<{ task: Update<Task> }>(),
+);
+
+// Dedicated action (instead of reusing updateTaskUi): old clients apply ops for
+// action types they know, and their typia validators reject values outside the
+// shipped HideSubTasksMode set as data corruption. An unknown action type is a
+// clean no-op for them, so collapse-state sync degrades silently on old
+// versions instead of triggering the repair flow.
+export const setSubtaskHideMode = createAction(
+  '[Task] Set Subtask Hide Mode',
+  (taskProps: { taskId: string; mode: HideSubTasksMode }) => ({
     ...taskProps,
     meta: {
       isPersistent: true,
       entityType: 'TASK',
-      entityId: taskProps.task.id as string,
+      entityId: taskProps.taskId,
       opType: OpType.Update,
     } satisfies PersistentActionMeta,
   }),

--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -39,7 +39,15 @@ export const __updateMultipleTaskSimple = createAction(
 
 export const updateTaskUi = createAction(
   '[Task] Update Task Ui',
-  props<{ task: Update<Task> }>(),
+  (taskProps: { task: Update<Task> }) => ({
+    ...taskProps,
+    meta: {
+      isPersistent: true,
+      entityType: 'TASK',
+      entityId: taskProps.task.id as string,
+      opType: OpType.Update,
+    } satisfies PersistentActionMeta,
+  }),
 );
 
 export const removeTagsForAllTasks = createAction(
@@ -49,7 +57,15 @@ export const removeTagsForAllTasks = createAction(
 
 export const toggleTaskHideSubTasks = createAction(
   '[Task] Toggle Show Sub Tasks',
-  props<{ taskId: string; isShowLess: boolean; isEndless: boolean }>(),
+  (taskProps: { taskId: string; isShowLess: boolean; isEndless: boolean }) => ({
+    ...taskProps,
+    meta: {
+      isPersistent: true,
+      entityType: 'TASK',
+      entityId: taskProps.taskId,
+      opType: OpType.Update,
+    } satisfies PersistentActionMeta,
+  }),
 );
 
 export const moveSubTask = createAction(

--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -37,24 +37,19 @@ export const __updateMultipleTaskSimple = createAction(
   }),
 );
 
-export const updateTaskUi = createAction(
-  '[Task] Update Task Ui',
-  props<{ task: Update<Task> }>(),
-);
-
-// Dedicated action (instead of reusing updateTaskUi): old clients apply ops for
-// action types they know, and their typia validators reject values outside the
-// shipped HideSubTasksMode set as data corruption. An unknown action type is a
-// clean no-op for them, so collapse-state sync degrades silently on old
-// versions instead of triggering the repair flow.
-export const setSubtaskHideMode = createAction(
-  '[Task] Set Subtask Hide Mode',
-  (taskProps: { taskId: string; mode: HideSubTasksMode }) => ({
+// Dedicated action (instead of reusing a generic task update): old clients
+// apply ops for action types they know; an unknown action type is a clean
+// no-op for them, so collapse-state sync degrades silently on old versions
+// instead of triggering the repair flow. See PersistedHideSubTasksMode in
+// task.model.ts for the full invariant.
+export const setHideSubTasksMode = createAction(
+  '[Task] Set Hide Sub Tasks Mode',
+  (taskProps: { id: string; mode: HideSubTasksMode }) => ({
     ...taskProps,
     meta: {
       isPersistent: true,
       entityType: 'TASK',
-      entityId: taskProps.taskId,
+      entityId: taskProps.id,
       opType: OpType.Update,
     } satisfies PersistentActionMeta,
   }),

--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -42,6 +42,10 @@ export const __updateMultipleTaskSimple = createAction(
 // no-op for them, so collapse-state sync degrades silently on old versions
 // instead of triggering the repair flow. See PersistedHideSubTasksMode in
 // task.model.ts for the full invariant.
+// Known limitation: the local-DELETE-vs-remote-UPDATE conflict path extracts
+// resurrection changes from `payload.task` only, so this op's `{ id, mode }`
+// payload contributes nothing there and the hide mode is dropped (acceptable
+// for a cosmetic field).
 export const setHideSubTasksMode = createAction(
   '[Task] Set Hide Sub Tasks Mode',
   (taskProps: { id: string; mode: HideSubTasksMode }) => ({

--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -55,19 +55,6 @@ export const removeTagsForAllTasks = createAction(
   props<{ tagIdsToRemove: string[] }>(),
 );
 
-export const toggleTaskHideSubTasks = createAction(
-  '[Task] Toggle Show Sub Tasks',
-  (taskProps: { taskId: string; isShowLess: boolean; isEndless: boolean }) => ({
-    ...taskProps,
-    meta: {
-      isPersistent: true,
-      entityType: 'TASK',
-      entityId: taskProps.taskId,
-      opType: OpType.Update,
-    } satisfies PersistentActionMeta,
-  }),
-);
-
 export const moveSubTask = createAction(
   '[Task] Move sub task',
   (taskProps: {

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { Task, TaskDetailTargetPanel, TaskState } from '../task.model';
+import { HideSubTasksMode, Task, TaskDetailTargetPanel, TaskState } from '../task.model';
 import { initialTaskState, taskReducer } from './task.reducer';
 import * as fromActions from './task.actions';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
@@ -1116,10 +1116,10 @@ describe('Task Reducer', () => {
   });
 
   describe('subtask hide/show - persistent meta', () => {
-    it('setSubtaskHideMode should be persistent with correct meta', () => {
-      const action = fromActions.setSubtaskHideMode({
-        taskId: 'task-1',
-        mode: 1,
+    it('setHideSubTasksMode should be persistent with correct meta', () => {
+      const action = fromActions.setHideSubTasksMode({
+        id: 'task-1',
+        mode: HideSubTasksMode.HideDone,
       });
 
       expect(action.meta.isPersistent).toBe(true);
@@ -1128,35 +1128,25 @@ describe('Task Reducer', () => {
       expect(action.meta.opType).toBe('UPD');
     });
 
-    it('updateTaskUi should NOT be persistent (old clients apply known action types)', () => {
-      // Old clients have a reducer for updateTaskUi; a persistent updateTaskUi op
-      // carrying values outside their shipped HideSubTasksMode set would land in
-      // their state and fail typia validation. Collapse-state sync must go
-      // through the dedicated setSubtaskHideMode action instead.
-      const action = fromActions.updateTaskUi({
-        task: { id: 'task-1', changes: { _hideSubTasksMode: 1 } },
-      });
-
-      expect((action as any).meta).toBeUndefined();
-    });
-
-    it('setSubtaskHideMode payload survives JSON round-trip for the "show all" transition', () => {
+    it('setHideSubTasksMode payload survives JSON round-trip for the "show all" transition', () => {
       // The synced payload is JSON-encoded. `undefined` is dropped by JSON.stringify,
       // so callers must use the explicit Show (0) sentinel to make a "show all"
       // transition replay correctly on remote devices.
-      const action = fromActions.setSubtaskHideMode({
-        taskId: 'task-1',
-        mode: 0,
+      const action = fromActions.setHideSubTasksMode({
+        id: 'task-1',
+        mode: HideSubTasksMode.Show,
       });
       const roundTripped = JSON.parse(JSON.stringify(action));
       expect(roundTripped.mode).toBe(0);
     });
 
-    it('setSubtaskHideMode normalizes Show (0) to undefined in state', () => {
-      // Synced Task state must stay within the legacy {undefined, 1, 2} shape:
-      // old clients' typia validators reject 0 as corruption. The explicit 0
-      // lives only in the action payload.
-      const task = createTask('task-1', { _hideSubTasksMode: 2 });
+    it('setHideSubTasksMode normalizes Show (0) and garbage to undefined in state', () => {
+      // Persisted state must stay within {undefined, HideDone, HideAll} — see
+      // PersistedHideSubTasksMode in task.model.ts. Remote op payloads are
+      // untrusted, so anything but an explicit hide value degrades to Show.
+      const task = createTask('task-1', {
+        _hideSubTasksMode: HideSubTasksMode.HideAll,
+      });
       let state: TaskState = {
         ...initialTaskState,
         ids: ['task-1'],
@@ -1165,21 +1155,34 @@ describe('Task Reducer', () => {
 
       state = taskReducer(
         state,
-        fromActions.setSubtaskHideMode({ taskId: 'task-1', mode: 0 }),
+        fromActions.setHideSubTasksMode({ id: 'task-1', mode: HideSubTasksMode.Show }),
       );
       expect(state.entities['task-1']!._hideSubTasksMode).toBeUndefined();
 
       state = taskReducer(
         state,
-        fromActions.setSubtaskHideMode({ taskId: 'task-1', mode: 2 }),
+        fromActions.setHideSubTasksMode({
+          id: 'task-1',
+          mode: HideSubTasksMode.HideAll,
+        }),
       );
-      expect(state.entities['task-1']!._hideSubTasksMode).toBe(2);
+      expect(state.entities['task-1']!._hideSubTasksMode).toBe(HideSubTasksMode.HideAll);
 
       state = taskReducer(
         state,
-        fromActions.setSubtaskHideMode({ taskId: 'task-1', mode: 1 }),
+        fromActions.setHideSubTasksMode({
+          id: 'task-1',
+          mode: HideSubTasksMode.HideDone,
+        }),
       );
-      expect(state.entities['task-1']!._hideSubTasksMode).toBe(1);
+      expect(state.entities['task-1']!._hideSubTasksMode).toBe(HideSubTasksMode.HideDone);
+
+      // Malformed remote payloads (wrong type / out of range) degrade to Show
+      state = taskReducer(
+        state,
+        fromActions.setHideSubTasksMode({ id: 'task-1', mode: 3 as any }),
+      );
+      expect(state.entities['task-1']!._hideSubTasksMode).toBeUndefined();
     });
   });
 });

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1116,9 +1116,10 @@ describe('Task Reducer', () => {
   });
 
   describe('subtask hide/show - persistent meta', () => {
-    it('updateTaskUi should be persistent with correct meta', () => {
-      const action = fromActions.updateTaskUi({
-        task: { id: 'task-1', changes: { _hideSubTasksMode: 1 } },
+    it('setSubtaskHideMode should be persistent with correct meta', () => {
+      const action = fromActions.setSubtaskHideMode({
+        taskId: 'task-1',
+        mode: 1,
       });
 
       expect(action.meta.isPersistent).toBe(true);
@@ -1127,15 +1128,58 @@ describe('Task Reducer', () => {
       expect(action.meta.opType).toBe('UPD');
     });
 
-    it('updateTaskUi payload survives JSON round-trip for the "show all" transition', () => {
+    it('updateTaskUi should NOT be persistent (old clients apply known action types)', () => {
+      // Old clients have a reducer for updateTaskUi; a persistent updateTaskUi op
+      // carrying values outside their shipped HideSubTasksMode set would land in
+      // their state and fail typia validation. Collapse-state sync must go
+      // through the dedicated setSubtaskHideMode action instead.
+      const action = fromActions.updateTaskUi({
+        task: { id: 'task-1', changes: { _hideSubTasksMode: 1 } },
+      });
+
+      expect((action as any).meta).toBeUndefined();
+    });
+
+    it('setSubtaskHideMode payload survives JSON round-trip for the "show all" transition', () => {
       // The synced payload is JSON-encoded. `undefined` is dropped by JSON.stringify,
       // so callers must use the explicit Show (0) sentinel to make a "show all"
       // transition replay correctly on remote devices.
-      const action = fromActions.updateTaskUi({
-        task: { id: 'task-1', changes: { _hideSubTasksMode: 0 } },
+      const action = fromActions.setSubtaskHideMode({
+        taskId: 'task-1',
+        mode: 0,
       });
       const roundTripped = JSON.parse(JSON.stringify(action));
-      expect(roundTripped.task.changes._hideSubTasksMode).toBe(0);
+      expect(roundTripped.mode).toBe(0);
+    });
+
+    it('setSubtaskHideMode normalizes Show (0) to undefined in state', () => {
+      // Synced Task state must stay within the legacy {undefined, 1, 2} shape:
+      // old clients' typia validators reject 0 as corruption. The explicit 0
+      // lives only in the action payload.
+      const task = createTask('task-1', { _hideSubTasksMode: 2 });
+      let state: TaskState = {
+        ...initialTaskState,
+        ids: ['task-1'],
+        entities: { 'task-1': task },
+      };
+
+      state = taskReducer(
+        state,
+        fromActions.setSubtaskHideMode({ taskId: 'task-1', mode: 0 }),
+      );
+      expect(state.entities['task-1']!._hideSubTasksMode).toBeUndefined();
+
+      state = taskReducer(
+        state,
+        fromActions.setSubtaskHideMode({ taskId: 'task-1', mode: 2 }),
+      );
+      expect(state.entities['task-1']!._hideSubTasksMode).toBe(2);
+
+      state = taskReducer(
+        state,
+        fromActions.setSubtaskHideMode({ taskId: 'task-1', mode: 1 }),
+      );
+      expect(state.entities['task-1']!._hideSubTasksMode).toBe(1);
     });
   });
 });

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1114,4 +1114,30 @@ describe('Task Reducer', () => {
       expect(() => taskReducer(stateWithUndefined, action)).not.toThrow();
     });
   });
+
+  describe('subtask hide/show actions - persistent meta', () => {
+    it('updateTaskUi should be persistent with correct meta', () => {
+      const action = fromActions.updateTaskUi({
+        task: { id: 'task-1', changes: { _hideSubTasksMode: 1 } },
+      });
+
+      expect(action.meta.isPersistent).toBe(true);
+      expect(action.meta.entityType).toBe('TASK');
+      expect(action.meta.entityId).toBe('task-1');
+      expect(action.meta.opType).toBe('UPD');
+    });
+
+    it('toggleTaskHideSubTasks should be persistent with correct meta', () => {
+      const action = fromActions.toggleTaskHideSubTasks({
+        taskId: 'task-1',
+        isShowLess: true,
+        isEndless: true,
+      });
+
+      expect(action.meta.isPersistent).toBe(true);
+      expect(action.meta.entityType).toBe('TASK');
+      expect(action.meta.entityId).toBe('task-1');
+      expect(action.meta.opType).toBe('UPD');
+    });
+  });
 });

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1115,7 +1115,7 @@ describe('Task Reducer', () => {
     });
   });
 
-  describe('subtask hide/show actions - persistent meta', () => {
+  describe('subtask hide/show - persistent meta', () => {
     it('updateTaskUi should be persistent with correct meta', () => {
       const action = fromActions.updateTaskUi({
         task: { id: 'task-1', changes: { _hideSubTasksMode: 1 } },
@@ -1127,17 +1127,15 @@ describe('Task Reducer', () => {
       expect(action.meta.opType).toBe('UPD');
     });
 
-    it('toggleTaskHideSubTasks should be persistent with correct meta', () => {
-      const action = fromActions.toggleTaskHideSubTasks({
-        taskId: 'task-1',
-        isShowLess: true,
-        isEndless: true,
+    it('updateTaskUi payload survives JSON round-trip for the "show all" transition', () => {
+      // The synced payload is JSON-encoded. `undefined` is dropped by JSON.stringify,
+      // so callers must use the explicit Show (0) sentinel to make a "show all"
+      // transition replay correctly on remote devices.
+      const action = fromActions.updateTaskUi({
+        task: { id: 'task-1', changes: { _hideSubTasksMode: 0 } },
       });
-
-      expect(action.meta.isPersistent).toBe(true);
-      expect(action.meta.entityType).toBe('TASK');
-      expect(action.meta.entityId).toBe('task-1');
-      expect(action.meta.opType).toBe('UPD');
+      const roundTripped = JSON.parse(JSON.stringify(action));
+      expect(roundTripped.task.changes._hideSubTasksMode).toBe(0);
     });
   });
 });

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1180,7 +1180,10 @@ describe('Task Reducer', () => {
       // Malformed remote payloads (wrong type / out of range) degrade to Show
       state = taskReducer(
         state,
-        fromActions.setHideSubTasksMode({ id: 'task-1', mode: 3 as any }),
+        fromActions.setHideSubTasksMode({
+          id: 'task-1',
+          mode: 3 as unknown as HideSubTasksMode,
+        }),
       );
       expect(state.entities['task-1']!._hideSubTasksMode).toBeUndefined();
     });

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -12,7 +12,6 @@ import {
   setCurrentTask,
   setSelectedTask,
   toggleStart,
-  toggleTaskHideSubTasks,
   unsetCurrentTask,
   updateTaskUi,
 } from './task.actions';
@@ -360,49 +359,6 @@ export const taskReducer = createReducer<TaskState>(
   // Bulk task updates - used for archive task batch operations
   on(TaskSharedActions.updateTasks, (state, { tasks }) => {
     return taskAdapter.updateMany(tasks, state);
-  }),
-
-  // TODO simplify
-  on(toggleTaskHideSubTasks, (state, { taskId, isShowLess, isEndless }) => {
-    const task = getTaskById(taskId, state);
-    const subTasks = task.subTaskIds.map((id) => getTaskById(id, state));
-    const doneTasksLength = subTasks.filter((t) => t.isDone).length;
-    const isDoneTaskCaseNeeded = doneTasksLength && doneTasksLength < subTasks.length;
-    // for easier calculations we use 0 instead of undefined for show state
-    const oldVal = task._hideSubTasksMode || 0;
-    let newVal: number = isShowLess ? oldVal + 1 : oldVal - 1;
-
-    if (!isDoneTaskCaseNeeded && newVal === 1) {
-      if (isShowLess) {
-        newVal = 2;
-      } else {
-        newVal = 0;
-      }
-    }
-
-    if (isEndless) {
-      if (newVal < 0) {
-        newVal = 2;
-      } else if (newVal > 2) {
-        newVal = 0;
-      }
-    } else {
-      if (newVal < 0) {
-        newVal = 0;
-      } else if (newVal > 2) {
-        newVal = 2;
-      }
-    }
-
-    return taskAdapter.updateOne(
-      {
-        id: taskId,
-        changes: {
-          _hideSubTasksMode: newVal || undefined,
-        },
-      },
-      state,
-    );
   }),
 
   on(moveSubTask, (state, { taskId, srcTaskId, targetTaskId, afterTaskId }) => {

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -11,6 +11,7 @@ import {
   roundTimeSpentForDay,
   setCurrentTask,
   setSelectedTask,
+  setSubtaskHideMode,
   toggleStart,
   unsetCurrentTask,
   updateTaskUi,
@@ -354,6 +355,18 @@ export const taskReducer = createReducer<TaskState>(
 
   on(updateTaskUi, (state, { task }) => {
     return taskAdapter.updateOne(task, state);
+  }),
+
+  on(setSubtaskHideMode, (state, { taskId, mode }) => {
+    // Normalize Show (0) to undefined so persisted/synced Task state stays
+    // within the legacy {undefined, 1, 2} shape — old clients' typia
+    // validators reject 0 as corruption. The explicit 0 exists only in the
+    // action payload (JSON.stringify drops undefined, so the "show all"
+    // transition needs a serializable value on the wire).
+    return taskAdapter.updateOne(
+      { id: taskId, changes: { _hideSubTasksMode: mode || undefined } },
+      state,
+    );
   }),
 
   // Bulk task updates - used for archive task batch operations

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -10,13 +10,12 @@ import {
   removeTimeSpent,
   roundTimeSpentForDay,
   setCurrentTask,
+  setHideSubTasksMode,
   setSelectedTask,
-  setSubtaskHideMode,
   toggleStart,
   unsetCurrentTask,
-  updateTaskUi,
 } from './task.actions';
-import { Task, TaskDetailTargetPanel, TaskState } from '../task.model';
+import { HideSubTasksMode, Task, TaskDetailTargetPanel, TaskState } from '../task.model';
 import { calcTotalTimeSpent } from '../util/calc-total-time-spent';
 import { addTaskRepeatCfgToTask } from '../../task-repeat-cfg/store/task-repeat-cfg.actions';
 import {
@@ -353,20 +352,16 @@ export const taskReducer = createReducer<TaskState>(
     return taskAdapter.updateMany(taskUpdates, state);
   }),
 
-  on(updateTaskUi, (state, { task }) => {
-    return taskAdapter.updateOne(task, state);
-  }),
-
-  on(setSubtaskHideMode, (state, { taskId, mode }) => {
-    // Normalize Show (0) to undefined so persisted/synced Task state stays
-    // within the legacy {undefined, 1, 2} shape — old clients' typia
-    // validators reject 0 as corruption. The explicit 0 exists only in the
-    // action payload (JSON.stringify drops undefined, so the "show all"
-    // transition needs a serializable value on the wire).
-    return taskAdapter.updateOne(
-      { id: taskId, changes: { _hideSubTasksMode: mode || undefined } },
-      state,
-    );
+  on(setHideSubTasksMode, (state, { id, mode }) => {
+    // Anything but an explicit hide value normalizes to undefined (= Show):
+    // remote op payloads are untrusted input, and persisted state must stay
+    // within {undefined, HideDone, HideAll} — see PersistedHideSubTasksMode
+    // in task.model.ts.
+    const _hideSubTasksMode =
+      mode === HideSubTasksMode.HideDone || mode === HideSubTasksMode.HideAll
+        ? mode
+        : undefined;
+    return taskAdapter.updateOne({ id, changes: { _hideSubTasksMode } }, state);
   }),
 
   // Bulk task updates - used for archive task batch operations

--- a/src/app/features/tasks/task.model.ts
+++ b/src/app/features/tasks/task.model.ts
@@ -11,6 +11,26 @@ export enum HideSubTasksMode {
   HideAll = 2,
 }
 
+/**
+ * CANONICAL backward-compat invariant for subtask hide/show sync:
+ *
+ * Persisted/synced Task state must stay within {undefined, HideDone, HideAll}.
+ * Old clients' typia validators were compiled when the enum was {1, 2} and
+ * reject an explicit 0 in state as data corruption (blocking repair loop).
+ * `Show = 0` may therefore exist ONLY in `setHideSubTasksMode` action payloads
+ * (a serializable value is needed there because JSON.stringify drops
+ * `undefined`, and the "show all" transition must survive the wire). The
+ * reducer normalizes 0 → undefined before writing state.
+ *
+ * This subset type enforces the invariant at compile time AND in the
+ * typia-generated state validators (so a stray 0 in state is still caught
+ * as invalid on new clients, e.g. via the plugin bridge's
+ * `typia.assert<Partial<TaskCopy>>`).
+ */
+export type PersistedHideSubTasksMode =
+  | HideSubTasksMode.HideDone
+  | HideSubTasksMode.HideAll;
+
 export enum TaskDetailTargetPanel {
   Default = 'Default',
   Attachments = 'Attachments',
@@ -140,7 +160,7 @@ export interface TaskCopy
   parentId?: string;
   remindAt?: number;
   repeatCfgId?: string;
-  _hideSubTasksMode?: HideSubTasksMode;
+  _hideSubTasksMode?: PersistedHideSubTasksMode;
 }
 
 /**

--- a/src/app/features/tasks/task.model.ts
+++ b/src/app/features/tasks/task.model.ts
@@ -5,7 +5,8 @@ import { TaskAttachment } from './task-attachment/task-attachment.model';
 import { Task as PluginTask } from '@super-productivity/plugin-api';
 
 export enum HideSubTasksMode {
-  // Show is undefined
+  // Legacy/never-toggled tasks may have this undefined (treated as Show).
+  Show = 0,
   HideDone = 1,
   HideAll = 2,
 }

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -21,8 +21,14 @@ import {
   addSubTask,
   moveSubTaskToTop,
   moveSubTaskToBottom,
+  updateTaskUi,
 } from './store/task.actions';
-import { TaskDetailTargetPanel, TaskReminderOptionId } from './task.model';
+import { selectTaskEntities } from './store/task.selectors';
+import {
+  HideSubTasksMode,
+  TaskDetailTargetPanel,
+  TaskReminderOptionId,
+} from './task.model';
 import { TODAY_TAG } from '../tag/tag.const';
 import { INBOX_PROJECT } from '../project/project.const';
 import { signal } from '@angular/core';
@@ -923,6 +929,114 @@ describe('TaskService', () => {
       const active = document.activeElement;
       service.focusTaskById('missing', false);
       expect(document.activeElement).toBe(active);
+    });
+  });
+
+  describe('toggleSubTaskMode (resolve-on-dispatch)', () => {
+    // The resolution moved out of the reducer into the service so the persisted
+    // op carries the final mode (deterministic on replay across devices).
+    const setEntities = (
+      parent: Partial<Task> & { id: string; subTaskIds: string[] },
+      ...subs: Array<Partial<Task> & { id: string }>
+    ): void => {
+      const entities: Record<string, Task> = {
+        [parent.id]: createMockTask(parent.id, parent),
+      };
+      for (const s of subs) {
+        entities[s.id] = createMockTask(s.id, s);
+      }
+      store.overrideSelector(selectTaskEntities, entities);
+      store.refreshState();
+    };
+
+    const dispatchedHideMode = (): number | undefined => {
+      const calls = (store.dispatch as jasmine.Spy).calls.all();
+      const last = calls[calls.length - 1].args[0];
+      expect(last.type).toBe(updateTaskUi.type);
+      return last.task.changes._hideSubTasksMode;
+    };
+
+    it('Show → HideDone when some (but not all) subtasks are done (isShowLess)', () => {
+      setEntities(
+        { id: 'p', subTaskIds: ['s1', 's2'] },
+        { id: 's1', isDone: true },
+        { id: 's2', isDone: false },
+      );
+
+      service.toggleSubTaskMode('p', true, false);
+
+      expect(dispatchedHideMode()).toBe(HideSubTasksMode.HideDone);
+    });
+
+    it('Show → HideAll (skips HideDone) when no done subtasks exist (isShowLess)', () => {
+      setEntities(
+        { id: 'p', subTaskIds: ['s1', 's2'] },
+        { id: 's1', isDone: false },
+        { id: 's2', isDone: false },
+      );
+
+      service.toggleSubTaskMode('p', true, false);
+
+      expect(dispatchedHideMode()).toBe(HideSubTasksMode.HideAll);
+    });
+
+    it('HideDone → HideAll (isShowLess) when mixed done state', () => {
+      setEntities(
+        {
+          id: 'p',
+          subTaskIds: ['s1', 's2'],
+          _hideSubTasksMode: HideSubTasksMode.HideDone,
+        },
+        { id: 's1', isDone: true },
+        { id: 's2', isDone: false },
+      );
+
+      service.toggleSubTaskMode('p', true, false);
+
+      expect(dispatchedHideMode()).toBe(HideSubTasksMode.HideAll);
+    });
+
+    it('HideAll → Show explicitly (0) when not endless (isShowLess=false)', () => {
+      // The explicit Show (0) sentinel — not undefined — is the whole point of
+      // the JSON-safety fix: undefined would be dropped by JSON.stringify and
+      // the "show all" transition would never reach remote devices.
+      setEntities(
+        { id: 'p', subTaskIds: ['s1'], _hideSubTasksMode: HideSubTasksMode.HideAll },
+        { id: 's1', isDone: false },
+      );
+
+      service.toggleSubTaskMode('p', false, false);
+
+      expect(dispatchedHideMode()).toBe(HideSubTasksMode.Show);
+    });
+
+    it('HideAll wraps to Show (0) when isEndless and isShowLess', () => {
+      setEntities(
+        { id: 'p', subTaskIds: ['s1'], _hideSubTasksMode: HideSubTasksMode.HideAll },
+        { id: 's1', isDone: false },
+      );
+
+      service.toggleSubTaskMode('p', true, true);
+
+      expect(dispatchedHideMode()).toBe(HideSubTasksMode.Show);
+    });
+
+    it('Show wraps to HideAll when isEndless and !isShowLess', () => {
+      setEntities({ id: 'p', subTaskIds: [] });
+
+      service.toggleSubTaskMode('p', false, true);
+
+      expect(dispatchedHideMode()).toBe(HideSubTasksMode.HideAll);
+    });
+
+    it('does not dispatch when the task is missing from state', () => {
+      store.overrideSelector(selectTaskEntities, {} as Record<string, Task>);
+      store.refreshState();
+      (store.dispatch as jasmine.Spy).calls.reset();
+
+      service.toggleSubTaskMode('missing', true, false);
+
+      expect(store.dispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -21,7 +21,7 @@ import {
   addSubTask,
   moveSubTaskToTop,
   moveSubTaskToBottom,
-  updateTaskUi,
+  setSubtaskHideMode,
 } from './store/task.actions';
 import { selectTaskEntities } from './store/task.selectors';
 import {
@@ -952,8 +952,8 @@ describe('TaskService', () => {
     const dispatchedHideMode = (): number | undefined => {
       const calls = (store.dispatch as jasmine.Spy).calls.all();
       const last = calls[calls.length - 1].args[0];
-      expect(last.type).toBe(updateTaskUi.type);
-      return last.task.changes._hideSubTasksMode;
+      expect(last.type).toBe(setSubtaskHideMode.type);
+      return last.mode;
     };
 
     it('Show → HideDone when some (but not all) subtasks are done (isShowLess)', () => {

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -21,7 +21,7 @@ import {
   addSubTask,
   moveSubTaskToTop,
   moveSubTaskToBottom,
-  setSubtaskHideMode,
+  setHideSubTasksMode,
 } from './store/task.actions';
 import { selectTaskEntities } from './store/task.selectors';
 import {
@@ -952,7 +952,7 @@ describe('TaskService', () => {
     const dispatchedHideMode = (): number | undefined => {
       const calls = (store.dispatch as jasmine.Spy).calls.all();
       const last = calls[calls.length - 1].args[0];
-      expect(last.type).toBe(setSubtaskHideMode.type);
+      expect(last.type).toBe(setHideSubTasksMode.type);
       return last.mode;
     };
 
@@ -1035,6 +1035,17 @@ describe('TaskService', () => {
       (store.dispatch as jasmine.Spy).calls.reset();
 
       service.toggleSubTaskMode('missing', true, false);
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch when the requested mode equals the current one (no redundant op)', () => {
+      // undefined in state means Show — requesting Show again must not create
+      // a persistent op that would sync for no change.
+      setEntities({ id: 'p', subTaskIds: [] });
+      (store.dispatch as jasmine.Spy).calls.reset();
+
+      service.showSubTasks('p');
 
       expect(store.dispatch).not.toHaveBeenCalled();
     });

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -29,6 +29,7 @@ import {
   roundTimeSpentForDay,
   setCurrentTask,
   setSelectedTask,
+  setSubtaskHideMode,
   toggleStart,
   unsetCurrentTask,
   updateTaskUi,
@@ -1140,7 +1141,7 @@ export class TaskService {
     // Use explicit Show (0) rather than undefined: persisted payloads are JSON-encoded,
     // and JSON.stringify drops `undefined` keys — a remote replay of the "show all"
     // transition would otherwise be a no-op on the receiving device.
-    this.updateUi(id, { _hideSubTasksMode: HideSubTasksMode.Show });
+    this._store.dispatch(setSubtaskHideMode({ taskId: id, mode: HideSubTasksMode.Show }));
   }
 
   toggleSubTaskMode(
@@ -1150,8 +1151,8 @@ export class TaskService {
   ): void {
     // Resolve the new mode here (not in the reducer): the toggle outcome depends on
     // local task/subtask state, which can differ across devices at replay time. By
-    // dispatching `updateTaskUi` with the resolved value, the synced op carries the
-    // final state rather than the toggle intent, keeping replay deterministic.
+    // dispatching `setSubtaskHideMode` with the resolved value, the synced op carries
+    // the final state rather than the toggle intent, keeping replay deterministic.
     const entities = this._taskEntities();
     const task = entities[taskId];
     if (!task) {
@@ -1181,11 +1182,15 @@ export class TaskService {
       }
     }
 
-    this.updateUi(taskId, { _hideSubTasksMode: newVal as HideSubTasksMode });
+    this._store.dispatch(
+      setSubtaskHideMode({ taskId, mode: newVal as HideSubTasksMode }),
+    );
   }
 
   hideSubTasks(id: string): void {
-    this.updateUi(id, { _hideSubTasksMode: HideSubTasksMode.HideAll });
+    this._store.dispatch(
+      setSubtaskHideMode({ taskId: id, mode: HideSubTasksMode.HideAll }),
+    );
   }
 
   async convertToMainTask(task: Task): Promise<void> {

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -28,11 +28,10 @@ import {
   removeTimeSpent,
   roundTimeSpentForDay,
   setCurrentTask,
+  setHideSubTasksMode,
   setSelectedTask,
-  setSubtaskHideMode,
   toggleStart,
   unsetCurrentTask,
-  updateTaskUi,
 } from './store/task.actions';
 import { IssueProviderKey } from '../issue/issue.model';
 import { GlobalTrackingIntervalService } from '../../core/global-tracking-interval/global-tracking-interval.service';
@@ -502,14 +501,6 @@ export class TaskService {
     this._store.dispatch(
       TaskSharedActions.removeTagsForAllTasks({
         tagIdsToRemove: tagsToRemove,
-      }),
-    );
-  }
-
-  updateUi(id: string, changes: Partial<Task>): void {
-    this._store.dispatch(
-      updateTaskUi({
-        task: { id, changes },
       }),
     );
   }
@@ -1138,10 +1129,7 @@ export class TaskService {
   }
 
   showSubTasks(id: string): void {
-    // Use explicit Show (0) rather than undefined: persisted payloads are JSON-encoded,
-    // and JSON.stringify drops `undefined` keys — a remote replay of the "show all"
-    // transition would otherwise be a no-op on the receiving device.
-    this._store.dispatch(setSubtaskHideMode({ taskId: id, mode: HideSubTasksMode.Show }));
+    this._setHideSubTasksMode(id, HideSubTasksMode.Show);
   }
 
   toggleSubTaskMode(
@@ -1151,7 +1139,7 @@ export class TaskService {
   ): void {
     // Resolve the new mode here (not in the reducer): the toggle outcome depends on
     // local task/subtask state, which can differ across devices at replay time. By
-    // dispatching `setSubtaskHideMode` with the resolved value, the synced op carries
+    // dispatching `setHideSubTasksMode` with the resolved value, the synced op carries
     // the final state rather than the toggle intent, keeping replay deterministic.
     const entities = this._taskEntities();
     const task = entities[taskId];
@@ -1182,15 +1170,27 @@ export class TaskService {
       }
     }
 
-    this._store.dispatch(
-      setSubtaskHideMode({ taskId, mode: newVal as HideSubTasksMode }),
-    );
+    this._setHideSubTasksMode(taskId, newVal as HideSubTasksMode);
   }
 
   hideSubTasks(id: string): void {
-    this._store.dispatch(
-      setSubtaskHideMode({ taskId: id, mode: HideSubTasksMode.HideAll }),
-    );
+    this._setHideSubTasksMode(id, HideSubTasksMode.HideAll);
+  }
+
+  private _setHideSubTasksMode(id: string, mode: HideSubTasksMode): void {
+    const task = this._taskEntities()[id];
+    if (!task) {
+      return;
+    }
+    // Skip no-op transitions so a redundant click doesn't persist + sync an op.
+    // Note: mode Show (0) travels explicitly in the payload (JSON.stringify
+    // drops `undefined`) but is stored as undefined — see
+    // PersistedHideSubTasksMode in task.model.ts.
+    const current = task._hideSubTasksMode ?? HideSubTasksMode.Show;
+    if (current === mode) {
+      return;
+    }
+    this._store.dispatch(setHideSubTasksMode({ id, mode }));
   }
 
   async convertToMainTask(task: Task): Promise<void> {

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -1146,9 +1146,13 @@ export class TaskService {
     if (!task) {
       return;
     }
-    const subTasks = task.subTaskIds.map((id) => entities[id]).filter((t) => !!t);
-    const doneTasksLength = subTasks.filter((t) => t!.isDone).length;
-    const isDoneTaskCaseNeeded = doneTasksLength && doneTasksLength < subTasks.length;
+    const subTasks = task.subTaskIds
+      .map((id) => entities[id])
+      .filter((t): t is Task => !!t);
+    const doneTasksLength = subTasks.filter((t) => t.isDone).length;
+    const isDoneTaskCaseNeeded = doneTasksLength > 0 && doneTasksLength < subTasks.length;
+    // TODO simplify the numeric transition arithmetic below (e.g. an explicit
+    // ordered-modes table) — behavior is pinned by task.service.spec.ts.
     const oldVal = task._hideSubTasksMode || 0;
     let newVal: number = isShowLess ? oldVal + 1 : oldVal - 1;
 

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -30,7 +30,6 @@ import {
   setCurrentTask,
   setSelectedTask,
   toggleStart,
-  toggleTaskHideSubTasks,
   unsetCurrentTask,
   updateTaskUi,
 } from './store/task.actions';
@@ -1138,7 +1137,10 @@ export class TaskService {
   }
 
   showSubTasks(id: string): void {
-    this.updateUi(id, { _hideSubTasksMode: undefined });
+    // Use explicit Show (0) rather than undefined: persisted payloads are JSON-encoded,
+    // and JSON.stringify drops `undefined` keys — a remote replay of the "show all"
+    // transition would otherwise be a no-op on the receiving device.
+    this.updateUi(id, { _hideSubTasksMode: HideSubTasksMode.Show });
   }
 
   toggleSubTaskMode(
@@ -1146,7 +1148,40 @@ export class TaskService {
     isShowLess: boolean = true,
     isEndless: boolean = false,
   ): void {
-    this._store.dispatch(toggleTaskHideSubTasks({ taskId, isShowLess, isEndless }));
+    // Resolve the new mode here (not in the reducer): the toggle outcome depends on
+    // local task/subtask state, which can differ across devices at replay time. By
+    // dispatching `updateTaskUi` with the resolved value, the synced op carries the
+    // final state rather than the toggle intent, keeping replay deterministic.
+    const entities = this._taskEntities();
+    const task = entities[taskId];
+    if (!task) {
+      return;
+    }
+    const subTasks = task.subTaskIds.map((id) => entities[id]).filter((t) => !!t);
+    const doneTasksLength = subTasks.filter((t) => t!.isDone).length;
+    const isDoneTaskCaseNeeded = doneTasksLength && doneTasksLength < subTasks.length;
+    const oldVal = task._hideSubTasksMode || 0;
+    let newVal: number = isShowLess ? oldVal + 1 : oldVal - 1;
+
+    if (!isDoneTaskCaseNeeded && newVal === 1) {
+      newVal = isShowLess ? 2 : 0;
+    }
+
+    if (isEndless) {
+      if (newVal < 0) {
+        newVal = 2;
+      } else if (newVal > 2) {
+        newVal = 0;
+      }
+    } else {
+      if (newVal < 0) {
+        newVal = 0;
+      } else if (newVal > 2) {
+        newVal = 2;
+      }
+    }
+
+    this.updateUi(taskId, { _hideSubTasksMode: newVal as HideSubTasksMode });
   }
 
   hideSubTasks(id: string): void {

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -666,7 +666,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     const t = this.task();
     const hasSubTasks = t.subTasks && t.subTasks.length > 0;
 
-    if (hasSubTasks && t._hideSubTasksMode !== undefined) {
+    if (hasSubTasks && !!t._hideSubTasksMode) {
       this._taskService.toggleSubTaskMode(t.id, false, false);
     } else if (!this.isSelected()) {
       this.showDetailPanel();

--- a/src/app/op-log/backup/migrate-legacy-backup.spec.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.spec.ts
@@ -576,6 +576,30 @@ describe('migrate-legacy-backup', () => {
       expect(result.task.entities['task-2']._showSubTasksMode).toBeUndefined();
     });
 
+    it('should normalize an explicit Show (0) _hideSubTasksMode to undefined', () => {
+      // Persisted state must stay within {undefined, HideDone, HideAll} —
+      // see PersistedHideSubTasksMode in task.model.ts.
+      const data = createLegacyBackup();
+      (data.task.entities['task-1'] as any)._hideSubTasksMode = 0;
+
+      const result = migrateLegacyBackup(data) as any;
+
+      expect(result.task.entities['task-1']._hideSubTasksMode).toBeUndefined();
+    });
+
+    it('should let an explicit Show (0) win over a stale legacy _showSubTasksMode', () => {
+      // A stale _showSubTasksMode: 0 would otherwise be converted to
+      // HideAll, resurrecting a hide over the explicit Show.
+      const data = createLegacyBackup();
+      (data.task.entities['task-1'] as any)._hideSubTasksMode = 0;
+      (data.task.entities['task-1'] as any)._showSubTasksMode = 0;
+
+      const result = migrateLegacyBackup(data) as any;
+
+      expect(result.task.entities['task-1']._hideSubTasksMode).toBeUndefined();
+      expect(result.task.entities['task-1']._showSubTasksMode).toBeUndefined();
+    });
+
     it('should normalize null timeEstimate and created from fixture', () => {
       const result = migrateLegacyBackup(structuredClone(fixture)) as any;
 

--- a/src/app/op-log/backup/migrate-legacy-backup.spec.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.spec.ts
@@ -587,16 +587,24 @@ describe('migrate-legacy-backup', () => {
       expect(result.task.entities['task-1']._hideSubTasksMode).toBeUndefined();
     });
 
-    it('should let an explicit Show (0) win over a stale legacy _showSubTasksMode', () => {
-      // A stale _showSubTasksMode: 0 would otherwise be converted to
-      // HideAll, resurrecting a hide over the explicit Show.
+    it('should normalize a null _hideSubTasksMode to undefined', () => {
       const data = createLegacyBackup();
-      (data.task.entities['task-1'] as any)._hideSubTasksMode = 0;
-      (data.task.entities['task-1'] as any)._showSubTasksMode = 0;
+      (data.task.entities['task-1'] as any)._hideSubTasksMode = null;
 
       const result = migrateLegacyBackup(data) as any;
 
       expect(result.task.entities['task-1']._hideSubTasksMode).toBeUndefined();
+    });
+
+    it('should convert legacy _showSubTasksMode even when _hideSubTasksMode is null', () => {
+      // null is not a valid persisted value, so the legacy field still wins.
+      const data = createLegacyBackup();
+      (data.task.entities['task-1'] as any)._hideSubTasksMode = null;
+      (data.task.entities['task-1'] as any)._showSubTasksMode = 1;
+
+      const result = migrateLegacyBackup(data) as any;
+
+      expect(result.task.entities['task-1']._hideSubTasksMode).toBe(1);
       expect(result.task.entities['task-1']._showSubTasksMode).toBeUndefined();
     });
 

--- a/src/app/op-log/backup/migrate-legacy-backup.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.ts
@@ -304,8 +304,10 @@ function _migrateTaskDictionary(taskDict: Dictionary<TaskCopy>): void {
       delete taskDict[taskId]!.notes;
     }
 
-    // Convert _showSubTasksMode → _hideSubTasksMode
-    if (!taskDict[taskId]!._hideSubTasksMode) {
+    // Convert _showSubTasksMode → _hideSubTasksMode.
+    // Check `=== undefined` (not truthy): HideSubTasksMode.Show is 0, so a
+    // truthy check would incorrectly treat an explicit Show as "not set".
+    if (taskDict[taskId]!._hideSubTasksMode === undefined) {
       const oldValue = (taskDict[taskId] as unknown as Record<string, unknown>)?.[
         '_showSubTasksMode'
       ] as number | undefined;

--- a/src/app/op-log/backup/migrate-legacy-backup.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.ts
@@ -13,6 +13,7 @@
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 import {
   HideSubTasksMode,
+  PersistedHideSubTasksMode,
   TaskArchive,
   TaskCopy,
   TimeSpentOnDayCopy,
@@ -304,26 +305,27 @@ function _migrateTaskDictionary(taskDict: Dictionary<TaskCopy>): void {
       delete taskDict[taskId]!.notes;
     }
 
-    // Normalize an explicit Show (0) to undefined: persisted Task state must
-    // stay within the legacy {undefined, 1, 2} shape — old clients' typia
-    // validators reject 0 as corruption (0 only ever travels in action
-    // payloads, never in state).
-    if ((taskDict[taskId]!._hideSubTasksMode as unknown) === 0) {
+    // An explicit Show (0) — only producible by interim builds — wins over any
+    // stale legacy _showSubTasksMode and must not be persisted: state stays
+    // within {undefined, HideDone, HideAll}, see PersistedHideSubTasksMode.
+    if (
+      (taskDict[taskId]!._hideSubTasksMode as HideSubTasksMode | undefined) ===
+      HideSubTasksMode.Show
+    ) {
       taskDict[taskId] = { ...taskDict[taskId]!, _hideSubTasksMode: undefined };
-    }
-
-    // Convert _showSubTasksMode → _hideSubTasksMode.
-    // Check `=== undefined` (not truthy): HideSubTasksMode.Show is 0, so a
-    // truthy check would incorrectly treat an explicit Show as "not set".
-    if (taskDict[taskId]!._hideSubTasksMode === undefined) {
+      delete (taskDict[taskId] as unknown as Record<string, unknown>)[
+        '_showSubTasksMode'
+      ];
+    } else if (taskDict[taskId]!._hideSubTasksMode === undefined) {
+      // Convert legacy _showSubTasksMode → _hideSubTasksMode.
       const oldValue = (taskDict[taskId] as unknown as Record<string, unknown>)?.[
         '_showSubTasksMode'
       ] as number | undefined;
-      let newValue: HideSubTasksMode | undefined;
+      let newValue: PersistedHideSubTasksMode | undefined;
       if (oldValue === 1) {
-        newValue = 1;
+        newValue = HideSubTasksMode.HideDone;
       } else if (oldValue === 0) {
-        newValue = 2;
+        newValue = HideSubTasksMode.HideAll;
       }
       if (
         '_showSubTasksMode' in (taskDict[taskId] as unknown as Record<string, unknown>)
@@ -335,7 +337,7 @@ function _migrateTaskDictionary(taskDict: Dictionary<TaskCopy>): void {
       if (newValue) {
         taskDict[taskId] = {
           ...taskDict[taskId]!,
-          _hideSubTasksMode: newValue as HideSubTasksMode,
+          _hideSubTasksMode: newValue,
         };
       }
     }

--- a/src/app/op-log/backup/migrate-legacy-backup.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.ts
@@ -304,6 +304,14 @@ function _migrateTaskDictionary(taskDict: Dictionary<TaskCopy>): void {
       delete taskDict[taskId]!.notes;
     }
 
+    // Normalize an explicit Show (0) to undefined: persisted Task state must
+    // stay within the legacy {undefined, 1, 2} shape — old clients' typia
+    // validators reject 0 as corruption (0 only ever travels in action
+    // payloads, never in state).
+    if ((taskDict[taskId]!._hideSubTasksMode as unknown) === 0) {
+      taskDict[taskId] = { ...taskDict[taskId]!, _hideSubTasksMode: undefined };
+    }
+
     // Convert _showSubTasksMode → _hideSubTasksMode.
     // Check `=== undefined` (not truthy): HideSubTasksMode.Show is 0, so a
     // truthy check would incorrectly treat an explicit Show as "not set".

--- a/src/app/op-log/backup/migrate-legacy-backup.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.ts
@@ -305,20 +305,16 @@ function _migrateTaskDictionary(taskDict: Dictionary<TaskCopy>): void {
       delete taskDict[taskId]!.notes;
     }
 
-    // An explicit Show (0) — only producible by interim builds — wins over any
-    // stale legacy _showSubTasksMode and must not be persisted: state stays
-    // within {undefined, HideDone, HideAll}, see PersistedHideSubTasksMode.
-    if (
-      (taskDict[taskId]!._hideSubTasksMode as HideSubTasksMode | undefined) ===
-      HideSubTasksMode.Show
-    ) {
-      taskDict[taskId] = { ...taskDict[taskId]!, _hideSubTasksMode: undefined };
-      delete (taskDict[taskId] as unknown as Record<string, unknown>)[
-        '_showSubTasksMode'
-      ];
-    } else if (taskDict[taskId]!._hideSubTasksMode === undefined) {
-      // Convert legacy _showSubTasksMode → _hideSubTasksMode.
-      const oldValue = (taskDict[taskId] as unknown as Record<string, unknown>)?.[
+    // Convert legacy _showSubTasksMode → _hideSubTasksMode. Anything outside
+    // {HideDone, HideAll} (e.g. an explicit 0 or a null in legacy data) is
+    // converted or removed: persisted state must stay within
+    // {undefined, HideDone, HideAll}, see PersistedHideSubTasksMode.
+    const hideMode = taskDict[taskId]!._hideSubTasksMode as
+      | HideSubTasksMode
+      | null
+      | undefined;
+    if (hideMode !== HideSubTasksMode.HideDone && hideMode !== HideSubTasksMode.HideAll) {
+      const oldValue = (taskDict[taskId] as unknown as Record<string, unknown>)[
         '_showSubTasksMode'
       ] as number | undefined;
       let newValue: PersistedHideSubTasksMode | undefined;
@@ -327,18 +323,19 @@ function _migrateTaskDictionary(taskDict: Dictionary<TaskCopy>): void {
       } else if (oldValue === 0) {
         newValue = HideSubTasksMode.HideAll;
       }
-      if (
-        '_showSubTasksMode' in (taskDict[taskId] as unknown as Record<string, unknown>)
-      ) {
-        delete (taskDict[taskId] as unknown as Record<string, unknown>)[
-          '_showSubTasksMode'
-        ];
-      }
+      delete (taskDict[taskId] as unknown as Record<string, unknown>)[
+        '_showSubTasksMode'
+      ];
       if (newValue) {
         taskDict[taskId] = {
           ...taskDict[taskId]!,
           _hideSubTasksMode: newValue,
         };
+      } else if (hideMode !== undefined) {
+        taskDict[taskId] = { ...taskDict[taskId]! };
+        delete (taskDict[taskId] as unknown as Record<string, unknown>)[
+          '_hideSubTasksMode'
+        ];
       }
     }
 

--- a/src/app/op-log/core/action-types.enum.spec.ts
+++ b/src/app/op-log/core/action-types.enum.spec.ts
@@ -12,8 +12,8 @@ describe('ActionType enum', () => {
   const enumValues = Object.values(ActionType) as string[];
   const mappingKeys = Object.keys(ACTION_TYPE_TO_CODE);
 
-  it('should have exactly 146 members', () => {
-    expect(enumValues.length).toBe(146);
+  it('should have exactly 148 members', () => {
+    expect(enumValues.length).toBe(148);
   });
 
   it('should have 1:1 correspondence with ACTION_TYPE_TO_CODE', () => {

--- a/src/app/op-log/core/action-types.enum.spec.ts
+++ b/src/app/op-log/core/action-types.enum.spec.ts
@@ -12,8 +12,8 @@ describe('ActionType enum', () => {
   const enumValues = Object.values(ActionType) as string[];
   const mappingKeys = Object.keys(ACTION_TYPE_TO_CODE);
 
-  it('should have exactly 148 members', () => {
-    expect(enumValues.length).toBe(148);
+  it('should have exactly 147 members', () => {
+    expect(enumValues.length).toBe(147);
   });
 
   it('should have 1:1 correspondence with ACTION_TYPE_TO_CODE', () => {

--- a/src/app/op-log/core/action-types.enum.ts
+++ b/src/app/op-log/core/action-types.enum.ts
@@ -165,8 +165,10 @@ export enum ActionType {
 
   // Task actions (T)
   TASK_UPDATE_MULTIPLE_SIMPLE = '[Task] Update multiple Tasks (simple)',
+  TASK_UPDATE_UI = '[Task] Update Task Ui',
   TASK_ADD_SUB = '[Task] Add SubTask',
   TASK_MOVE_SUB = '[Task] Move sub task',
+  TASK_TOGGLE_HIDE_SUB = '[Task] Toggle Show Sub Tasks',
   TASK_MOVE_UP = '[Task] Move up',
   TASK_MOVE_DOWN = '[Task] Move down',
   TASK_MOVE_TOP = '[Task] Move to top',

--- a/src/app/op-log/core/action-types.enum.ts
+++ b/src/app/op-log/core/action-types.enum.ts
@@ -165,7 +165,7 @@ export enum ActionType {
 
   // Task actions (T)
   TASK_UPDATE_MULTIPLE_SIMPLE = '[Task] Update multiple Tasks (simple)',
-  TASK_SET_SUBTASK_HIDE_MODE = '[Task] Set Subtask Hide Mode',
+  TASK_SET_HIDE_SUB_TASKS_MODE = '[Task] Set Hide Sub Tasks Mode',
   TASK_ADD_SUB = '[Task] Add SubTask',
   TASK_MOVE_SUB = '[Task] Move sub task',
   TASK_MOVE_UP = '[Task] Move up',

--- a/src/app/op-log/core/action-types.enum.ts
+++ b/src/app/op-log/core/action-types.enum.ts
@@ -165,7 +165,7 @@ export enum ActionType {
 
   // Task actions (T)
   TASK_UPDATE_MULTIPLE_SIMPLE = '[Task] Update multiple Tasks (simple)',
-  TASK_UPDATE_UI = '[Task] Update Task Ui',
+  TASK_SET_SUBTASK_HIDE_MODE = '[Task] Set Subtask Hide Mode',
   TASK_ADD_SUB = '[Task] Add SubTask',
   TASK_MOVE_SUB = '[Task] Move sub task',
   TASK_MOVE_UP = '[Task] Move up',

--- a/src/app/op-log/core/action-types.enum.ts
+++ b/src/app/op-log/core/action-types.enum.ts
@@ -168,7 +168,6 @@ export enum ActionType {
   TASK_UPDATE_UI = '[Task] Update Task Ui',
   TASK_ADD_SUB = '[Task] Add SubTask',
   TASK_MOVE_SUB = '[Task] Move sub task',
-  TASK_TOGGLE_HIDE_SUB = '[Task] Toggle Show Sub Tasks',
   TASK_MOVE_UP = '[Task] Move up',
   TASK_MOVE_DOWN = '[Task] Move down',
   TASK_MOVE_TOP = '[Task] Move to top',

--- a/src/app/op-log/validation/persisted-hide-sub-tasks-mode.spec.ts
+++ b/src/app/op-log/validation/persisted-hide-sub-tasks-mode.spec.ts
@@ -1,0 +1,42 @@
+import {
+  addTaskToAppData,
+  createValidAppData,
+  createValidTask,
+  validateAppData,
+} from './state-validity-test-utils';
+import { HideSubTasksMode } from '../../features/tasks/task.model';
+
+/**
+ * Guards the backward-compat invariant documented on PersistedHideSubTasksMode
+ * (task.model.ts): persisted Task state must stay within
+ * {undefined, HideDone, HideAll}. Old clients' typia validators reject an
+ * explicit Show (0) in state as corruption, so OUR validators must keep
+ * rejecting it too — otherwise a stray 0 (e.g. via a plugin update or a
+ * future reducer) would pass locally, sync, and break old clients.
+ *
+ * If this spec fails because the model type was widened: do NOT widen the
+ * validator. Route the new value through an action payload instead (see
+ * setHideSubTasksMode) and normalize before state.
+ */
+describe('typia state validation of _hideSubTasksMode (backward-compat invariant)', () => {
+  const mkData = (hideMode: unknown): ReturnType<typeof createValidAppData> => {
+    const task = createValidTask('t1');
+    (task as Record<string, unknown>)._hideSubTasksMode = hideMode;
+    return addTaskToAppData(createValidAppData(), task);
+  };
+
+  it('accepts undefined, HideDone and HideAll in state', () => {
+    expect(validateAppData(mkData(undefined)).isValid).toBe(true);
+    expect(validateAppData(mkData(HideSubTasksMode.HideDone)).isValid).toBe(true);
+    expect(validateAppData(mkData(HideSubTasksMode.HideAll)).isValid).toBe(true);
+  });
+
+  it('rejects an explicit Show (0) in state', () => {
+    expect(validateAppData(mkData(0)).isValid).toBe(false);
+  });
+
+  it('rejects out-of-range and wrong-type values in state', () => {
+    expect(validateAppData(mkData(3)).isValid).toBe(false);
+    expect(validateAppData(mkData('1')).isValid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Subtask collapse/expand state was not persisted, so it reset on page reload and did not sync across devices.
There was no way to maintain the user's preference for which subtasks are shown or hidden between sessions.

Fixes #7412 

## Solution

Added persistent metadata to `updateTaskUi` and `toggleTaskHideSubTasks` actions so their effects are tracked in the operation log and synced.
Two new `ActionType` enum members (`TASK_UPDATE_UI`, `TASK_TOGGLE_HIDE_SUB`) and their compact codes (`TUU`, `THS`) were registered in the compact action codec.
Unit tests verify the metadata is attached correctly.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)