### PR TITLE
fix(security): restrict renderer-supplied filesystem IPC paths

### DIFF
--- a/electron/clipboard-image-handler.test.cjs
+++ b/electron/clipboard-image-handler.test.cjs
@@ -1,0 +1,84 @@
+/**
+ * Security test for CLIPBOARD_COPY_IMAGE_FILE source validation.
+ * The copy source is renderer-supplied; only actual image files may be copied
+ * (so a plugin/XSS can't copy a secret into the images dir and read it back).
+ * Run with: npm run test:electron
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+const Module = require('node:module');
+
+require('ts-node/register/transpile-only');
+
+const modPath = path.resolve(__dirname, 'clipboard-image-handler.ts');
+const originalModuleLoad = Module._load;
+
+let handlers = {};
+let userDataDir;
+let externalDir;
+
+const installMocks = () => {
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        ipcMain: { handle: (channel, fn) => (handlers[channel] = fn) },
+        app: { getPath: () => userDataDir },
+        clipboard: { readImage: () => ({ isEmpty: () => true }) },
+      };
+    }
+    return originalModuleLoad.call(this, request, parent, isMain);
+  };
+};
+
+const load = () => {
+  delete require.cache[modPath];
+  handlers = {};
+  require(modPath).initClipboardImageHandlers();
+};
+
+test.beforeEach(() => {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-cb-ud-'));
+  externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-cb-src-'));
+  installMocks();
+  load();
+});
+
+test.afterEach(() => {
+  Module._load = originalModuleLoad;
+  delete require.cache[modPath];
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+  fs.rmSync(externalDir, { recursive: true, force: true });
+});
+
+const imagesDir = () => path.join(userDataDir, 'clipboard-images');
+
+test('CLIPBOARD_COPY_IMAGE_FILE refuses a non-image source file', async () => {
+  const secret = path.join(externalDir, 'secret.txt');
+  fs.writeFileSync(secret, 'topsecret');
+
+  const result = await handlers['CLIPBOARD_COPY_IMAGE_FILE'](
+    {},
+    { basePath: imagesDir(), filePath: secret },
+  );
+
+  assert.equal(result, null, 'returns the error value');
+  // Nothing copied into the images dir.
+  const copied = fs.existsSync(imagesDir()) ? fs.readdirSync(imagesDir()) : [];
+  assert.equal(copied.length, 0);
+});
+
+test('CLIPBOARD_COPY_IMAGE_FILE copies an actual image file', async () => {
+  const src = path.join(externalDir, 'pic.png');
+  fs.writeFileSync(src, 'pngbytes');
+
+  const result = await handlers['CLIPBOARD_COPY_IMAGE_FILE'](
+    {},
+    { basePath: imagesDir(), filePath: src },
+  );
+
+  assert.ok(result && typeof result.id === 'string');
+  assert.equal(fs.readdirSync(imagesDir()).length, 1);
+});

--- a/electron/clipboard-image-handler.ts
+++ b/electron/clipboard-image-handler.ts
@@ -4,7 +4,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 import { createValidatedHandler } from './ipc-handler-wrapper';
-import { EXTENSION_MIME_TYPES } from './shared-with-frontend/mime-type-mapping.const';
+import {
+  EXTENSION_MIME_TYPES,
+  SUPPORTED_IMAGE_EXTENSIONS,
+} from './shared-with-frontend/mime-type-mapping.const';
 
 interface ClipboardImageMeta {
   id: string;
@@ -12,16 +15,6 @@ interface ClipboardImageMeta {
   createdAt: number;
   size: number;
 }
-
-const SUPPORTED_IMAGE_EXTENSIONS = [
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-  '.svg',
-  '.bmp',
-];
 
 /**
  * Ensures the clipboard-images directory exists.
@@ -184,6 +177,12 @@ export const initClipboardImageHandlers = (): void => {
         // Generate unique ID
         const id = Date.now().toString(36) + Math.random().toString(36).substring(2);
         const ext = path.extname(filePath).toLowerCase();
+        // SECURITY: only copy actual image files. `filePath` is renderer-supplied;
+        // without this a plugin/XSS could copy an arbitrary file (e.g. a secret)
+        // into the images dir and read it back via CLIPBOARD_IMAGE_LOAD.
+        if (!SUPPORTED_IMAGE_EXTENSIONS.includes(ext)) {
+          throw new Error('Invalid source image');
+        }
         const destFileName = `${id}${ext}`;
         const destPath = path.join(basePath, destFileName);
 

--- a/electron/file-path-guard.test.cjs
+++ b/electron/file-path-guard.test.cjs
@@ -1,6 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
 
 require('ts-node/register/transpile-only');
 
@@ -10,7 +12,9 @@ require('ts-node/register/transpile-only');
 // requires that cannot resolve in the package (it scans raw text). A computed
 // require is skipped by that static check and matches the pattern the other
 // electron *.test.cjs files use. The test still runs from source via ts-node.
-const { isPathInsideDir } = require(path.resolve(__dirname, 'file-path-guard.ts'));
+const { isPathInsideDir, assertPathOutside } = require(
+  path.resolve(__dirname, 'file-path-guard.ts'),
+);
 
 const DIR = path.resolve('/home/user/.config/superProductivity/backups');
 
@@ -47,4 +51,48 @@ test('rejects empty / non-string input', () => {
 
 test('accepts a path that needs normalization but stays inside', () => {
   assert.equal(isPathInsideDir(DIR, path.join(DIR, 'sub', '..', 'a.json')), true);
+});
+
+test('assertPathOutside: throws for the dir itself and for a path inside it', () => {
+  assert.throws(
+    () => assertPathOutside(DIR, path.join(DIR, 'simpleSettings')),
+    /protected directory/,
+  );
+  assert.throws(() => assertPathOutside(DIR, DIR), /protected directory/);
+});
+
+test('assertPathOutside: allows a path outside the protected dir', () => {
+  assert.doesNotThrow(() => assertPathOutside(DIR, path.resolve('/data/sync/main.json')));
+});
+
+test('assertPathOutside: rejects a non-string candidate (fail-closed deny)', () => {
+  assert.throws(() => assertPathOutside(DIR, undefined), /protected directory/);
+  assert.throws(() => assertPathOutside(DIR, ['/etc/passwd']), /protected directory/);
+});
+
+test('canonicalizes: a symlink resolving INTO the protected dir is rejected', () => {
+  // Deterministic stand-in for the macOS case-insensitivity bypass — both rely on
+  // the same realpath canonicalization. Lexically `<outside>/sneaky/x` looks
+  // outside, but the symlink resolves into the protected dir.
+  const protectedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-prot-'));
+  const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-out-'));
+  try {
+    const link = path.join(outsideDir, 'sneaky');
+    fs.symlinkSync(protectedDir, link);
+    assert.throws(
+      () => assertPathOutside(protectedDir, path.join(link, 'simpleSettings')),
+      /protected directory/,
+    );
+    // isPathInsideDir agrees: the symlinked path is "inside" once canonicalized.
+    assert.equal(isPathInsideDir(protectedDir, path.join(link, 'simpleSettings')), true);
+    // A symlink resolving OUTSIDE is still allowed.
+    const linkOut = path.join(protectedDir, 'out');
+    fs.symlinkSync(outsideDir, linkOut);
+    assert.doesNotThrow(() =>
+      assertPathOutside(protectedDir, path.join(linkOut, 'main.json')),
+    );
+  } finally {
+    fs.rmSync(protectedDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
 });

--- a/electron/file-path-guard.ts
+++ b/electron/file-path-guard.ts
@@ -1,7 +1,44 @@
+import * as fs from 'fs';
 import * as path from 'path';
 
 /**
- * Returns true if `targetPath` resolves to a location strictly inside `dir`.
+ * Canonicalize a path for containment checks: resolve the deepest existing
+ * ancestor with `fs.realpathSync.native` and re-append the (possibly
+ * not-yet-existing) tail. This collapses symlinks AND filesystem-level aliases
+ * — case-insensitive names on macOS APFS / NTFS and Windows 8.3 short names —
+ * so a renderer cannot slip a check with e.g. a case-variant of the protected
+ * dir (`…/SUPERPRODUCTIVITY/simpleSettings`), which a purely lexical compare
+ * treats as a different, "outside" path.
+ *
+ * The leaf often does not exist yet (a `FILE_SYNC_SAVE` target), hence the
+ * deepest-existing-ancestor walk; with no existing ancestor we fall back to a
+ * lexical resolve (`path.dirname` of a root is a fixed point, ending the loop).
+ * The catch intentionally swallows ANY realpath error (ENOENT, but also EACCES /
+ * ELOOP / ENOTDIR) and keeps walking up, so an unresolvable component is treated
+ * lexically — keeping the deny direction (`assertPathOutside`) fail-closed.
+ */
+const canonicalize = (p: string): string => {
+  const resolved = path.resolve(p);
+  let current = resolved;
+  const tail: string[] = [];
+  while (true) {
+    try {
+      const real = fs.realpathSync.native(current);
+      return tail.length ? path.join(real, ...tail.reverse()) : real;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return resolved;
+      }
+      tail.push(path.basename(current));
+      current = parent;
+    }
+  }
+};
+
+/**
+ * Returns true if `targetPath` resolves to a location strictly inside `dir`
+ * (`dir` itself is NOT "inside").
  *
  * Security boundary: several IPC handlers receive file paths from the renderer,
  * which executes untrusted plugin code (plugin scripts run via `new Function`
@@ -9,19 +46,41 @@ import * as path from 'path';
  * plugin could read/write arbitrary files via the exposed `window.ea` bridge.
  * See GHSA-x937-wf3j-88q3.
  *
- * `path.relative` is used instead of a `startsWith` string compare so that
- * `..` traversal is collapsed and a sibling directory sharing a name prefix
- * (e.g. `backups` vs `backups-evil`) is not mistaken for a child.
- *
- * Containment is purely lexical (no `fs.realpath`): a symlink planted *inside*
- * `dir` pointing outside would pass. That requires pre-existing local
- * filesystem write access, which is outside the threat model here (untrusted
- * renderer/plugin-supplied path strings), so symlink resolution is omitted.
+ * `path.relative` (over canonical paths) is used instead of a `startsWith`
+ * string compare so that `..` traversal is collapsed and a sibling directory
+ * sharing a name prefix (e.g. `backups` vs `backups-evil`) is not mistaken for
+ * a child. Paths are canonicalized first (see `canonicalize`) so symlinks and
+ * case-insensitive / 8.3 short-name aliases cannot bypass the check.
  */
 export const isPathInsideDir = (dir: string, targetPath: string): boolean => {
   if (typeof targetPath !== 'string' || targetPath.length === 0) {
     return false;
   }
-  const rel = path.relative(path.resolve(dir), path.resolve(targetPath));
+  const rel = path.relative(canonicalize(dir), canonicalize(targetPath));
   return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+};
+
+// Generic, path-free error so the offending path never leaks back to the
+// untrusted renderer (handlers further sanitize via createSafeIpcError).
+const pathNotAllowed = (message: string): Error => {
+  const e = new Error(message);
+  e.name = 'PathNotAllowedError';
+  delete (e as { stack?: string }).stack;
+  return e;
+};
+
+/**
+ * Throw if `candidate` is `dir` itself or resolves inside it. The deny direction
+ * for IPCs that must never touch the app's private dir (userData) — which holds
+ * settings/grants/db, so writing there is a privilege-escalation primitive (e.g.
+ * forging the nodeExecution grant file). Fails closed on a non-string candidate.
+ */
+export const assertPathOutside = (dir: string, candidate: string): void => {
+  if (
+    typeof candidate !== 'string' ||
+    canonicalize(candidate) === canonicalize(dir) ||
+    isPathInsideDir(dir, candidate)
+  ) {
+    throw pathNotAllowed('Path is inside a protected directory');
+  }
 };

--- a/electron/ipc-handler-wrapper.test.cjs
+++ b/electron/ipc-handler-wrapper.test.cjs
@@ -1,0 +1,104 @@
+/**
+ * Security tests for createValidatedHandler path/name validation.
+ * Closes the grant-file forgery via clipboard image save (fileName='simpleSettings'),
+ * the `<userData>-evil` sibling-prefix bypass (containment vs bare startsWith), and
+ * `..` traversal out of the images dir. Run with: npm run test:electron
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+require('ts-node/register/transpile-only');
+
+const modPath = path.resolve(__dirname, 'ipc-handler-wrapper.ts');
+const originalModuleLoad = Module._load;
+const USERDATA = path.resolve('/home/u/.config/sp');
+
+Module._load = function (request, parent, isMain) {
+  if (request === 'electron') {
+    return { app: { getPath: () => USERDATA } };
+  }
+  return originalModuleLoad.call(this, request, parent, isMain);
+};
+
+const { createValidatedHandler, validatePathInUserData } = require(modPath);
+
+// A SAVE-like handler (no errorValue): validation failures must reject.
+const saveLike = createValidatedHandler(async () => 'WROTE', { validatePath: true });
+const call = (args) => saveLike({}, args);
+
+test('validatePathInUserData: containment, not bare startsWith', () => {
+  assert.equal(validatePathInUserData(path.join(USERDATA, 'clipboard-images')), true);
+  // The userData root itself is not a valid write target (strict containment).
+  assert.equal(validatePathInUserData(USERDATA), false);
+  assert.equal(validatePathInUserData(USERDATA + '-evil'), false); // sibling prefix
+  assert.equal(validatePathInUserData(path.resolve('/etc')), false);
+});
+
+test('allows a normal clipboard image write', async () => {
+  const r = await call({
+    basePath: path.join(USERDATA, 'clipboard-images'),
+    fileName: 'abc123.png',
+    base64Data: 'x',
+  });
+  assert.equal(r, 'WROTE');
+});
+
+test('rejects fileName="simpleSettings" (grant-file forgery)', async () => {
+  await assert.rejects(
+    () =>
+      call({
+        basePath: path.join(USERDATA, 'clipboard-images'),
+        fileName: 'simpleSettings',
+        base64Data: 'x',
+      }),
+    /Invalid file name/,
+  );
+});
+
+test('rejects a `..`/separator traversal in fileName', async () => {
+  await assert.rejects(
+    () =>
+      call({
+        basePath: path.join(USERDATA, 'clipboard-images'),
+        fileName: '../simpleSettings.png',
+        base64Data: 'x',
+      }),
+    /Invalid file name/,
+  );
+});
+
+test('rejects a non-image fileName even with a safe basename', async () => {
+  await assert.rejects(
+    () =>
+      call({
+        basePath: path.join(USERDATA, 'clipboard-images'),
+        fileName: 'evil.sh',
+        base64Data: 'x',
+      }),
+    /Invalid file name/,
+  );
+});
+
+test('rejects basePath outside userData', async () => {
+  await assert.rejects(
+    () => call({ basePath: path.resolve('/etc'), fileName: 'a.png', base64Data: 'x' }),
+    /Invalid base path/,
+  );
+});
+
+test('rejects an imageId containing a traversal', async () => {
+  const loadLike = createValidatedHandler(async () => 'READ', { validatePath: true });
+  await assert.rejects(
+    () =>
+      loadLike(
+        {},
+        {
+          basePath: path.join(USERDATA, 'clipboard-images'),
+          imageId: '../../etc/passwd',
+        },
+      ),
+    /Invalid image id/,
+  );
+});

--- a/electron/ipc-handler-wrapper.ts
+++ b/electron/ipc-handler-wrapper.ts
@@ -1,18 +1,38 @@
 import { app } from 'electron';
-import * as path from 'path';
+import { isPathInsideDir } from './file-path-guard';
+import { SUPPORTED_IMAGE_EXTENSIONS } from './shared-with-frontend/mime-type-mapping.const';
 
 /**
- * Validates if the given path is within the userData directory.
+ * Validates that `basePath` is within the userData directory. Uses proper
+ * containment (not a bare startsWith, which would accept a sibling like
+ * `<userData>-evil`).
  */
-export const validatePathInUserData = (basePath: string): boolean => {
-  const userDataPath = app.getPath('userData');
-  const resolvedBasePath = path.resolve(basePath);
-  const resolvedUserDataPath = path.resolve(userDataPath);
-  return resolvedBasePath.startsWith(resolvedUserDataPath);
-};
+export const validatePathInUserData = (basePath: string): boolean =>
+  typeof basePath === 'string' && isPathInsideDir(app.getPath('userData'), basePath);
+
+// A safe filename/id: a single path segment — no separators, no `..`, no NUL.
+const isSafeName = (name: unknown): name is string =>
+  typeof name === 'string' &&
+  name.length > 0 &&
+  !name.includes('/') &&
+  !name.includes('\\') &&
+  !name.includes('..') &&
+  !name.includes('\0');
+
+const isSafeImageFileName = (name: unknown): name is string =>
+  isSafeName(name) &&
+  SUPPORTED_IMAGE_EXTENSIONS.some((ext) => name.toLowerCase().endsWith(ext));
 
 /**
- * Creates a validated IPC handler with consistent error handling and optional path validation.
+ * Creates a validated IPC handler with consistent error handling and optional
+ * path validation.
+ *
+ * SECURITY: the renderer is untrusted (a plugin or XSS payload can call any
+ * window.ea IPC). With `validatePath`, the handler refuses any `basePath`
+ * outside userData, any `fileName` that is not a plain image basename, and any
+ * `imageId` containing path separators/`..`. Without this a renderer could
+ * write e.g. `<userData>/simpleSettings` (forging the nodeExecution grant file)
+ * or traverse out of the images dir.
  */
 export const createValidatedHandler = <TArgs extends object, TResult>(
   handler: (args: TArgs) => Promise<TResult>,
@@ -23,11 +43,16 @@ export const createValidatedHandler = <TArgs extends object, TResult>(
 ): ((event: Electron.IpcMainInvokeEvent, args: TArgs) => Promise<TResult>) => {
   return async (_, args: TArgs) => {
     try {
-      // Add path validation if requested
-      if (options?.validatePath && 'basePath' in args) {
-        const basePath = (args as any).basePath;
-        if (!validatePathInUserData(basePath)) {
+      if (options?.validatePath && args && 'basePath' in args) {
+        const a = args as Record<string, unknown>;
+        if (!validatePathInUserData(a.basePath as string)) {
           throw new Error('Invalid base path');
+        }
+        if ('fileName' in a && !isSafeImageFileName(a.fileName)) {
+          throw new Error('Invalid file name');
+        }
+        if ('imageId' in a && !isSafeName(a.imageId)) {
+          throw new Error('Invalid image id');
         }
       }
 

--- a/electron/local-file-sync.test.cjs
+++ b/electron/local-file-sync.test.cjs
@@ -1,0 +1,150 @@
+/**
+ * Security tests for the local file-sync IPC path guards.
+ * The handlers must refuse paths inside the app's private dir (userData) — which
+ * holds settings/grants/db — while still serving user-chosen sync folders.
+ * Run with: npm run test:electron
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+const Module = require('node:module');
+
+require('ts-node/register/transpile-only');
+
+const modPath = path.resolve(__dirname, 'local-file-sync.ts');
+const originalModuleLoad = Module._load;
+
+let handlers = {};
+let userDataDir;
+let externalDir;
+
+const installMocks = () => {
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        ipcMain: { handle: (channel, fn) => (handlers[channel] = fn) },
+        app: { getPath: () => userDataDir },
+        dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+      };
+    }
+    if (request === 'electron-log/main') {
+      return { log: () => {}, error: () => {} };
+    }
+    if (/[/\\]main-window$/.test(request)) {
+      return { getWin: () => ({}) };
+    }
+    return originalModuleLoad.call(this, request, parent, isMain);
+  };
+};
+
+const load = () => {
+  delete require.cache[modPath];
+  handlers = {};
+  require(modPath).initLocalFileSyncAdapter();
+};
+
+test.beforeEach(() => {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-ud-'));
+  externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-ext-'));
+  installMocks();
+  load();
+});
+
+test.afterEach(() => {
+  Module._load = originalModuleLoad;
+  delete require.cache[modPath];
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+  fs.rmSync(externalDir, { recursive: true, force: true });
+});
+
+test('FILE_SYNC_SAVE refuses to write inside userData (grant-file forgery guard)', () => {
+  const target = path.join(userDataDir, 'simpleSettings');
+  const result = handlers['FILE_SYNC_SAVE'](
+    {},
+    { filePath: target, dataStr: '{"pwn":true}', localRev: null },
+  );
+  assert.ok(result instanceof Error, 'returns a safe error');
+  assert.equal(fs.existsSync(target), false, 'nothing written into userData');
+});
+
+test('FILE_SYNC_SAVE still writes to a user-chosen folder outside userData', () => {
+  const target = path.join(externalDir, 'main.json');
+  const result = handlers['FILE_SYNC_SAVE'](
+    {},
+    { filePath: target, dataStr: '{"ok":1}', localRev: null },
+  );
+  assert.ok(!(result instanceof Error), 'no error');
+  assert.equal(typeof result, 'string', 'returns a revision string');
+  assert.equal(fs.readFileSync(target, 'utf8'), '{"ok":1}');
+});
+
+test('FILE_SYNC_SAVE rejects a `..` traversal back into userData', () => {
+  const target = path.join(
+    externalDir,
+    '..',
+    path.basename(userDataDir),
+    'simpleSettings',
+  );
+  const result = handlers['FILE_SYNC_SAVE'](
+    {},
+    { filePath: target, dataStr: 'x', localRev: null },
+  );
+  assert.ok(result instanceof Error);
+  assert.equal(fs.existsSync(path.join(userDataDir, 'simpleSettings')), false);
+});
+
+test('FILE_SYNC_LOAD refuses to read inside userData', () => {
+  fs.writeFileSync(path.join(userDataDir, 'secret'), 'topsecret');
+  const result = handlers['FILE_SYNC_LOAD'](
+    {},
+    { filePath: path.join(userDataDir, 'secret'), localRev: null },
+  );
+  assert.ok(result instanceof Error);
+});
+
+test('FILE_SYNC_LOAD reads a user-chosen folder outside userData', () => {
+  fs.writeFileSync(path.join(externalDir, 'main.json'), 'hello');
+  const result = handlers['FILE_SYNC_LOAD'](
+    {},
+    { filePath: path.join(externalDir, 'main.json'), localRev: null },
+  );
+  assert.equal(result.dataStr, 'hello');
+});
+
+test('FILE_SYNC_REMOVE refuses to delete inside userData', () => {
+  const target = path.join(userDataDir, 'simpleSettings');
+  fs.writeFileSync(target, 'keep me');
+  const result = handlers['FILE_SYNC_REMOVE']({}, { filePath: target });
+  assert.ok(result instanceof Error);
+  assert.equal(fs.existsSync(target), true, 'file inside userData not deleted');
+});
+
+test('CHECK_DIR_EXISTS refuses a userData path', () => {
+  const result = handlers['CHECK_DIR_EXISTS']({}, { dirPath: userDataDir });
+  assert.ok(result instanceof Error);
+});
+
+test('FILE_SYNC_LIST_FILES refuses a userData path', () => {
+  const result = handlers['FILE_SYNC_LIST_FILES']({}, { dirPath: userDataDir });
+  assert.ok(result instanceof Error);
+});
+
+test('READ_LOCAL_IMAGE_AS_DATA_URL refuses an image inside userData', async () => {
+  fs.writeFileSync(path.join(userDataDir, 'secret.png'), 'not-really-png');
+  const result = await handlers['READ_LOCAL_IMAGE_AS_DATA_URL'](
+    {},
+    path.join(userDataDir, 'secret.png'),
+  );
+  assert.equal(result, null);
+});
+
+test('READ_LOCAL_IMAGE_AS_DATA_URL inlines a user image outside userData', async () => {
+  fs.writeFileSync(path.join(externalDir, 'bg.png'), 'pngbytes');
+  const result = await handlers['READ_LOCAL_IMAGE_AS_DATA_URL'](
+    {},
+    path.join(externalDir, 'bg.png'),
+  );
+  assert.match(result, /^data:image\/png;base64,/);
+});

--- a/electron/local-file-sync.ts
+++ b/electron/local-file-sync.ts
@@ -8,9 +8,17 @@ import {
   unlinkSync,
 } from 'fs';
 import { error, log } from 'electron-log/main';
-import { dialog, ipcMain } from 'electron';
+import { app, dialog, ipcMain } from 'electron';
 import { getWin } from './main-window';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { assertPathOutside } from './file-path-guard';
+
+// SECURITY: file-sync must never read/write/list inside the app's private dir,
+// which holds settings/grants/db — touching it is a privilege-escalation
+// primitive (e.g. forging the nodeExecution grant file). The path is
+// renderer-supplied (untrusted plugin/XSS). Lazy getter — userData can be
+// changed at startup (--user-data-dir, Snap). See file-path-guard.ts.
+const getAppPrivateDir = (): string => app.getPath('userData');
 
 export const initLocalFileSyncAdapter = (): void => {
   ipcMain.handle(
@@ -20,6 +28,10 @@ export const initLocalFileSyncAdapter = (): void => {
         const normalized = filePathOrUrl.startsWith('file://')
           ? fileURLToPath(filePathOrUrl)
           : filePathOrUrl;
+
+        // SECURITY: never inline a file from the app's private dir (the path is
+        // renderer-supplied background-image config).
+        assertPathOutside(getAppPrivateDir(), normalized);
 
         const ext = normalized.toLowerCase().split('.').pop() || '';
 
@@ -79,6 +91,7 @@ export const initLocalFileSyncAdapter = (): void => {
       },
     ): string | Error => {
       try {
+        assertPathOutside(getAppPrivateDir(), filePath);
         log(IPC.FILE_SYNC_SAVE, {
           dataLength: dataStr.length,
           hasData: dataStr.length > 0,
@@ -112,6 +125,7 @@ export const initLocalFileSyncAdapter = (): void => {
       },
     ): { rev: string; dataStr: string | undefined } | Error => {
       try {
+        assertPathOutside(getAppPrivateDir(), filePath);
         log(IPC.FILE_SYNC_LOAD, {
           hasLocalRev: !!localRev,
         });
@@ -141,6 +155,7 @@ export const initLocalFileSyncAdapter = (): void => {
       },
     ): void | Error => {
       try {
+        assertPathOutside(getAppPrivateDir(), filePath);
         log(IPC.FILE_SYNC_REMOVE);
         unlinkSync(filePath);
         return;
@@ -162,6 +177,7 @@ export const initLocalFileSyncAdapter = (): void => {
       },
     ): true | Error => {
       try {
+        assertPathOutside(getAppPrivateDir(), dirPath);
         const dirEntries = readdirSync(dirPath);
         log(IPC.CHECK_DIR_EXISTS, {
           dirEntryCount: dirEntries.length,
@@ -190,6 +206,7 @@ export const initLocalFileSyncAdapter = (): void => {
       },
     ): string[] | Error => {
       try {
+        assertPathOutside(getAppPrivateDir(), dirPath);
         return readdirSync(dirPath);
       } catch (e) {
         error('Local file sync list files failed', getSafeErrorMeta(e));

--- a/electron/shared-with-frontend/mime-type-mapping.const.ts
+++ b/electron/shared-with-frontend/mime-type-mapping.const.ts
@@ -18,3 +18,13 @@ export const EXTENSION_MIME_TYPES = {
   '.bmp': 'image/bmp',
 } as const;
 /* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * Canonical list of supported image extensions (lowercase, dot-prefixed). Single
+ * source of truth for the image-file security allowlists in the filesystem IPC
+ * handlers (clipboard copy/save, ipc-handler-wrapper). Keep those checks derived
+ * from this — drift between an "allowed to write" set and an "allowed to copy"
+ * set reopens holes.
+ */
+export const SUPPORTED_IMAGE_EXTENSIONS: readonly string[] =
+  Object.keys(EXTENSION_MIME_TYPES);


### PR DESCRIPTION
Extends file-path-guard with realpath canonicalization (closes a macOS case-alias  bypass in the existing backup fix) and applies path containment to the FILE_SYNC_* family, clipboard copy, and ipc-handler-wrapper. electron-only; 59 electron tests.