### PR TITLE
Fix minor cal design

### DIFF
--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -37,6 +37,11 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
   let mockDateTimeFormatService: jasmine.SpyObj<DateTimeFormatService>;
   let mockDateService: jasmine.SpyObj<DateService>;
 
+  // DateService is mocked to this fixed day; assertions about "today" must
+  // derive from these consts, never from the real clock (see #8017 CI breakage).
+  const MOCK_TODAY = new Date(2026, 5, 9, 0, 0, 0, 0);
+  const MOCK_TODAY_STR = '2026-06-09';
+
   const mockRepeatCfg: TaskRepeatCfg = {
     ...DEFAULT_TASK_REPEAT_CFG,
     id: 'repeat-cfg-123',
@@ -83,8 +88,8 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       'todayStr',
       'getLogicalTodayDate',
     ]);
-    mockDateService.todayStr.and.returnValue('2026-06-09');
-    mockDateService.getLogicalTodayDate.and.returnValue(new Date(2026, 5, 9, 0, 0, 0, 0));
+    mockDateService.todayStr.and.returnValue(MOCK_TODAY_STR);
+    mockDateService.getLogicalTodayDate.and.returnValue(new Date(MOCK_TODAY));
 
     // Set up the return value for getTaskRepeatCfgById$ before creating the component
     if (getTaskRepeatCfgById$ReturnValue) {
@@ -303,8 +308,9 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
         (c) => c.key === T.F.TASK_REPEAT.F.Q_MONTHLY_CURRENT_DATE,
       );
 
-      const today = mockDateService.getLogicalTodayDate();
-      const todayDayStr = today.toLocaleDateString('en-US', { day: 'numeric' });
+      // "today" comes from the mocked DateService.getLogicalTodayDate (2026-06-09),
+      // not the wall clock — asserting against new Date() breaks on any other day
+      const todayDayStr = MOCK_TODAY.toLocaleDateString('en-US', { day: 'numeric' });
 
       expect(monthlyCall).toBeDefined();
       expect(monthlyCall!.params.dateDayStr).toBe(todayDayStr);
@@ -379,11 +385,8 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
     });
 
     it('should preserve WEEKLY_CURRENT_WEEKDAY when startDate weekday differs from today', async () => {
-      // Pick a date whose weekday definitely differs from today
-      const today = mockDateService.getLogicalTodayDate();
-      const differentDay = new Date(today);
-      differentDay.setDate(today.getDate() + 3); // 3 days from now is a different weekday
-      const dateStr = differentDay.toISOString().slice(0, 10);
+      // Pick a date whose weekday definitely differs from the mocked today
+      const dateStr = '2026-06-12'; // Friday; MOCK_TODAY is a Tuesday
 
       const cfgWeekly: TaskRepeatCfg = {
         ...DEFAULT_TASK_REPEAT_CFG,
@@ -453,7 +456,7 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       const component = fixture.componentInstance;
       component.openScheduleDialog();
 
-      const expectedToday = new Date(2026, 5, 9, 0, 0, 0, 0);
+      const expectedToday = new Date(MOCK_TODAY);
       expect(mockMatDialog.open).toHaveBeenCalledWith(
         jasmine.any(Function),
         jasmine.objectContaining({

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -303,7 +303,7 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
         (c) => c.key === T.F.TASK_REPEAT.F.Q_MONTHLY_CURRENT_DATE,
       );
 
-      const today = new Date();
+      const today = mockDateService.getLogicalTodayDate();
       const todayDayStr = today.toLocaleDateString('en-US', { day: 'numeric' });
 
       expect(monthlyCall).toBeDefined();
@@ -380,7 +380,7 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
 
     it('should preserve WEEKLY_CURRENT_WEEKDAY when startDate weekday differs from today', async () => {
       // Pick a date whose weekday definitely differs from today
-      const today = new Date();
+      const today = mockDateService.getLogicalTodayDate();
       const differentDay = new Date(today);
       differentDay.setDate(today.getDate() + 3); // 3 days from now is a different weekday
       const dateStr = differentDay.toISOString().slice(0, 10);

--- a/src/app/ui/datetime-picker/datetime-picker.component.html
+++ b/src/app/ui/datetime-picker/datetime-picker.component.html
@@ -39,7 +39,7 @@
 @if (isConfigReady()) {
   <mat-calendar
     (keydown)="onKeyDownOnCalendar($event)"
-    [selected]="calendarSelectedDate"
+    [selected]="selectedDate()"
     [minDate]="minDate()"
     (selectedChange)="dateSelected.emit($event)"
   ></mat-calendar>

--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -18,16 +18,13 @@
   // Focus outline suppression
   &:not(.sp-hide-cursor):not(.sp-initial-focus) {
     ::ng-deep {
-      .mat-calendar-body-cell:focus:not(:hover)
-        > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
+      .mat-calendar-body-cell:focus:not(:hover) > .mat-calendar-body-cell-content {
         outline: none !important;
-        background-color: transparent !important;
       }
 
-      // If selected, we still want to keep the selected color, so only hide outline
       .mat-calendar-body-cell:focus:not(:hover)
-        > .mat-calendar-body-cell-content.mat-calendar-body-selected {
-        outline: none !important;
+        > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
+        background-color: transparent !important;
       }
     }
   }

--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -12,6 +12,20 @@
       .mat-calendar-body-cell-content {
         cursor: none !important;
       }
+
+      // Keyboard nav hides the cursor, so suppress the stale mouse :hover
+      // outline/background — only the keyboard-focused cell should be marked.
+      // The .mat-calendar ancestor is included purely to outweigh the global
+      // dashed-hover rule in _overwrite-material.scss.
+      .mat-calendar:not(.no-hover-effects)
+        .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover:not(:focus)
+        > .mat-calendar-body-cell-content {
+        outline: none !important;
+
+        &:not(.mat-calendar-body-selected) {
+          background-color: transparent !important;
+        }
+      }
     }
   }
 

--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -12,14 +12,22 @@
       .mat-calendar-body-cell-content {
         cursor: none !important;
       }
-      // Suppress hover-only styling (when not focused) when cursor is hidden
-      .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover:not(:focus-visible)
-        > .mat-calendar-body-cell-content {
-        outline: none !important;
+    }
+  }
 
-        &:not(.mat-calendar-body-selected) {
-          background-color: transparent !important;
-        }
+  // Focus outline suppression
+  &:not(.sp-hide-cursor):not(.sp-initial-focus) {
+    ::ng-deep {
+      .mat-calendar-body-cell:focus:not(:hover)
+        > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
+        outline: none !important;
+        background-color: transparent !important;
+      }
+
+      // If selected, we still want to keep the selected color, so only hide outline
+      .mat-calendar-body-cell:focus:not(:hover)
+        > .mat-calendar-body-cell-content.mat-calendar-body-selected {
+        outline: none !important;
       }
     }
   }

--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -13,7 +13,7 @@
         cursor: none !important;
       }
       // Suppress hover-only styling (when not focused) when cursor is hidden
-      .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover:not(:focus)
+      .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover:not(:focus-visible)
         > .mat-calendar-body-cell-content {
         outline: none !important;
 

--- a/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
@@ -151,6 +151,27 @@ describe('DateTimePickerComponent', () => {
     expect(fixture.nativeElement.classList.contains('sp-initial-focus')).toBeFalse();
   });
 
+  it('should reset isInitialFocus to true when calendar view changes', () => {
+    fixture.detectChanges();
+    const calendar = component.calendar()!;
+
+    // Initial state
+    expect(component.isInitialFocus).toBeTrue();
+
+    // Reset it to false first
+    component.isInitialFocus = false;
+    fixture.detectChanges();
+    expect(component.isInitialFocus).toBeFalse();
+
+    // Change view
+    calendar.currentView = 'year';
+    calendar.stateChanges.next();
+    fixture.detectChanges();
+
+    expect(component.isInitialFocus).toBeTrue();
+    expect(fixture.nativeElement.classList.contains('sp-initial-focus')).toBeTrue();
+  });
+
   it('should only update calendar activeDate when selectedDate changes', () => {
     const calendar = component.calendar()!;
     const initialDate = new Date(2026, 4, 6);

--- a/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
@@ -120,6 +120,23 @@ describe('DateTimePickerComponent', () => {
     expect(component.isKeyboardNavigating).toBeFalse();
   });
 
+  it('should reset isInitialFocus on keyboard navigation or mouse move', () => {
+    expect(component.isInitialFocus).toBeTrue();
+
+    // Trigger keyboard navigation key down on calendar
+    const arrowDownEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+    component.onKeyDownOnCalendar(arrowDownEvent);
+    expect(component.isInitialFocus).toBeFalse();
+
+    // Reset for next test
+    component.isInitialFocus = true;
+
+    // Trigger mousemove
+    const mouseMoveEvent = new MouseEvent('mousemove', { clientX: 30, clientY: 40 });
+    component.onHostMouseMove(mouseMoveEvent);
+    expect(component.isInitialFocus).toBeFalse();
+  });
+
   it('should only update calendar activeDate when selectedDate changes', () => {
     const calendar = component.calendar()!;
     const initialDate = new Date(2026, 4, 6);
@@ -143,6 +160,27 @@ describe('DateTimePickerComponent', () => {
     fixture.componentRef.setInput('selectedDate', differentDate);
     fixture.detectChanges();
     expect(calendar.activeDate).toEqual(differentDate);
+  });
+
+  it('should not update activeDate when calendar is focused', () => {
+    const calendar = component.calendar()!;
+    const initialDate = new Date(2026, 4, 6);
+    const differentDate = new Date(2026, 4, 7);
+
+    fixture.componentRef.setInput('selectedDate', initialDate);
+    fixture.detectChanges();
+    expect(calendar.activeDate).toEqual(initialDate);
+
+    // Mock calendar focus
+    const calendarEl = fixture.nativeElement.querySelector('mat-calendar');
+    spyOnProperty(document, 'activeElement', 'get').and.returnValue(calendarEl);
+    spyOn(calendarEl, 'contains').and.returnValue(true);
+
+    fixture.componentRef.setInput('selectedDate', differentDate);
+    fixture.detectChanges();
+
+    // Should NOT have updated activeDate because it was focused
+    expect(calendar.activeDate).toEqual(initialDate);
   });
 
   it('should emit enterSubmit when Enter is pressed on the calendar and date matches', () => {

--- a/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
@@ -102,39 +102,53 @@ describe('DateTimePickerComponent', () => {
   });
 
   it('should toggle isKeyboardNavigating based on keyboard navigation and mouse move', () => {
+    fixture.detectChanges();
     expect(component.isKeyboardNavigating).toBeFalse();
+    expect(fixture.nativeElement.classList.contains('sp-hide-cursor')).toBeFalse();
 
     // Trigger keyboard navigation key down on calendar
-    const arrowDownEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-    component.onKeyDownOnCalendar(arrowDownEvent);
+    fixture.nativeElement
+      .querySelector('mat-calendar')
+      ?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    fixture.detectChanges();
     expect(component.isKeyboardNavigating).toBeTrue();
-
-    // Trigger non-navigation key down on calendar - should not reset it
-    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
-    component.onKeyDownOnCalendar(enterEvent);
-    expect(component.isKeyboardNavigating).toBeTrue();
+    expect(fixture.nativeElement.classList.contains('sp-hide-cursor')).toBeTrue();
 
     // Trigger mousemove with changed coordinates - should reset it to false
-    const mouseMoveEvent = new MouseEvent('mousemove', { clientX: 30, clientY: 40 });
-    component.onHostMouseMove(mouseMoveEvent);
+    fixture.nativeElement.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 30, clientY: 40, bubbles: true }),
+    );
+    fixture.detectChanges();
     expect(component.isKeyboardNavigating).toBeFalse();
+    expect(fixture.nativeElement.classList.contains('sp-hide-cursor')).toBeFalse();
   });
 
-  it('should reset isInitialFocus on keyboard navigation or mouse move', () => {
+  it('should reset isInitialFocus on keyboard navigation', () => {
+    fixture.detectChanges();
     expect(component.isInitialFocus).toBeTrue();
+    expect(fixture.nativeElement.classList.contains('sp-initial-focus')).toBeTrue();
 
     // Trigger keyboard navigation key down on calendar
-    const arrowDownEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
-    component.onKeyDownOnCalendar(arrowDownEvent);
+    fixture.nativeElement
+      .querySelector('mat-calendar')
+      ?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    fixture.detectChanges();
     expect(component.isInitialFocus).toBeFalse();
+    expect(fixture.nativeElement.classList.contains('sp-initial-focus')).toBeFalse();
+  });
 
-    // Reset for next test
-    component.isInitialFocus = true;
+  it('should reset isInitialFocus on mouse move', () => {
+    fixture.detectChanges();
+    expect(component.isInitialFocus).toBeTrue();
+    expect(fixture.nativeElement.classList.contains('sp-initial-focus')).toBeTrue();
 
     // Trigger mousemove
-    const mouseMoveEvent = new MouseEvent('mousemove', { clientX: 30, clientY: 40 });
-    component.onHostMouseMove(mouseMoveEvent);
+    fixture.nativeElement.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 30, clientY: 40, bubbles: true }),
+    );
+    fixture.detectChanges();
     expect(component.isInitialFocus).toBeFalse();
+    expect(fixture.nativeElement.classList.contains('sp-initial-focus')).toBeFalse();
   });
 
   it('should only update calendar activeDate when selectedDate changes', () => {

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -14,7 +14,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatCalendar } from '@angular/material/datepicker';
+import { MatCalendar, MatCalendarView } from '@angular/material/datepicker';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import {
@@ -105,7 +105,7 @@ export class DateTimePickerComponent implements AfterViewInit {
     () => this._globalConfigService.localization() !== undefined,
   );
 
-  private _lastView: 'month' | 'year' | 'multi-year' | null = null;
+  private _lastView: MatCalendarView | null = null;
   private _viewChangeEffect = effect((onCleanup) => {
     const cal = this.calendar();
     if (cal) {

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -71,7 +71,7 @@ const DEFAULT_TIME = '09:00';
 export class DateTimePickerComponent implements AfterViewInit {
   private _dateService = inject(DateService);
   private _globalConfigService = inject(GlobalConfigService);
-  private _cdr = inject(ChangeDetectorRef);
+  private readonly _cdr = inject(ChangeDetectorRef);
   private _el = inject(ElementRef);
 
   // Inputs

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -117,7 +117,17 @@ export class DateTimePickerComponent implements AfterViewInit {
 
     const cal = this.calendar();
     if (cal) {
-      cal.activeDate = new Date(date || new Date());
+      const activeEl = document.activeElement;
+      const isCalendarFocused =
+        activeEl &&
+        this._el.nativeElement.querySelector('mat-calendar')?.contains(activeEl);
+
+      if (!isCalendarFocused) {
+        const newActiveDate = new Date(date || new Date());
+        if (cal.activeDate.getTime() !== newActiveDate.getTime()) {
+          cal.activeDate = newActiveDate;
+        }
+      }
     }
   });
 

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -125,10 +125,6 @@ export class DateTimePickerComponent implements AfterViewInit {
   private _syncActiveDateEffect = effect(() => {
     const date = this.selectedDate();
     const dateMs = date ? new Date(date).getTime() : null;
-    if (dateMs === this._lastSyncedDate) {
-      return;
-    }
-    this._lastSyncedDate = dateMs;
 
     const cal = this.calendar();
     if (cal) {
@@ -138,6 +134,11 @@ export class DateTimePickerComponent implements AfterViewInit {
         this._el.nativeElement.querySelector('mat-calendar')?.contains(activeEl);
 
       if (!isCalendarFocused) {
+        if (dateMs === this._lastSyncedDate) {
+          return;
+        }
+        this._lastSyncedDate = dateMs;
+
         const newActiveDate = new Date(date || new Date());
         if (cal.activeDate.getTime() !== newActiveDate.getTime()) {
           cal.activeDate = newActiveDate;

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -74,27 +74,7 @@ export class DateTimePickerComponent implements AfterViewInit {
   private readonly _cdr = inject(ChangeDetectorRef);
   private _el = inject(ElementRef);
 
-  pickerSelectedDate: Date | null = null;
-
-  constructor() {
-    effect((onCleanup) => {
-      const cal = this.calendar();
-      if (cal) {
-        // Set initial view and date
-        if (cal.currentView !== 'month') {
-          this.pickerSelectedDate = cal.activeDate;
-        }
-
-        const sub = cal.stateChanges.subscribe(() => {
-          if (cal.currentView !== 'month') {
-            this.pickerSelectedDate = cal.activeDate;
-          }
-          this._cdr.markForCheck();
-        });
-        onCleanup(() => sub.unsubscribe());
-      }
-    });
-  }
+  constructor() {}
 
   // Inputs
   selectedDate = input<Date | null>(null);
@@ -125,17 +105,6 @@ export class DateTimePickerComponent implements AfterViewInit {
   readonly isConfigReady = computed(
     () => this._globalConfigService.localization() !== undefined,
   );
-
-  get calendarSelectedDate(): Date | null {
-    const cal = this.calendar();
-    if (!cal) {
-      return this.selectedDate();
-    }
-    if (cal.currentView === 'month') {
-      return this.selectedDate();
-    }
-    return this.pickerSelectedDate || cal.activeDate;
-  }
 
   private _lastSyncedDate: number | null = null;
   private _syncActiveDateEffect = effect(() => {

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -71,10 +71,8 @@ const DEFAULT_TIME = '09:00';
 export class DateTimePickerComponent implements AfterViewInit {
   private _dateService = inject(DateService);
   private _globalConfigService = inject(GlobalConfigService);
-  private readonly _cdr = inject(ChangeDetectorRef);
+  private _cdr = inject(ChangeDetectorRef);
   private _el = inject(ElementRef);
-
-  constructor() {}
 
   // Inputs
   selectedDate = input<Date | null>(null);
@@ -106,6 +104,22 @@ export class DateTimePickerComponent implements AfterViewInit {
   readonly isConfigReady = computed(
     () => this._globalConfigService.localization() !== undefined,
   );
+
+  private _lastView: 'month' | 'year' | 'multi-year' | null = null;
+  private _viewChangeEffect = effect((onCleanup) => {
+    const cal = this.calendar();
+    if (cal) {
+      this._lastView = cal.currentView;
+      const sub = cal.stateChanges.subscribe(() => {
+        if (cal.currentView !== this._lastView) {
+          this._lastView = cal.currentView;
+          this.isInitialFocus = true;
+          this._cdr.markForCheck();
+        }
+      });
+      onCleanup(() => sub.unsubscribe());
+    }
+  });
 
   private _lastSyncedDate: number | null = null;
   private _syncActiveDateEffect = effect(() => {

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -99,6 +99,7 @@ export class DateTimePickerComponent implements AfterViewInit {
   isInitValOnTimeFocus = true;
   isShowEnterMsg = false;
   @HostBinding('class.sp-hide-cursor') isKeyboardNavigating = false;
+  @HostBinding('class.sp-initial-focus') isInitialFocus = true;
 
   readonly calendar = viewChild(MatCalendar);
 
@@ -135,6 +136,7 @@ export class DateTimePickerComponent implements AfterViewInit {
 
   onKeyDownOnCalendar(ev: KeyboardEvent): void {
     this._timeCheckVal = null;
+    this.isInitialFocus = false;
     if (ev.code === 'Enter' || ev.code === 'Space') {
       this.isShowEnterMsg = true;
       const cal = this.calendar();
@@ -246,6 +248,7 @@ export class DateTimePickerComponent implements AfterViewInit {
 
   @HostListener('mousemove', ['$event'])
   onHostMouseMove(ev: MouseEvent): void {
+    this.isInitialFocus = false;
     this._resetKeyboardNav(ev);
   }
 

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -493,6 +493,11 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
     outline: 2px solid color-mix(in srgb, var(--c-accent) 80%, transparent) !important;
   }
 
+  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover:not(:focus)
+    > .mat-calendar-body-cell-content {
+    outline: 2px dashed color-mix(in srgb, var(--c-accent) 80%, transparent) !important;
+  }
+
   .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
     > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected),
   .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -490,14 +490,14 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
 .mat-calendar:not(.no-hover-effects) {
   .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
     > .mat-calendar-body-cell-content,
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus-visible
-    .mat-calendar-body-cell-content {
+  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus
+    > .mat-calendar-body-cell-content {
     outline: 2px solid color-mix(in srgb, var(--c-accent) 80%, transparent) !important;
   }
 
   .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
     > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected),
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus-visible
+  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus
     > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
     background-color: var(--calendar-hover-bg) !important;
   }

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -488,8 +488,6 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
 
 // Shared calendar hover and focus overrides
 .mat-calendar:not(.no-hover-effects) {
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
-    > .mat-calendar-body-cell-content,
   .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus
     > .mat-calendar-body-cell-content {
     outline: 2px solid color-mix(in srgb, var(--c-accent) 80%, transparent) !important;

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -490,14 +490,14 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
 .mat-calendar:not(.no-hover-effects) {
   .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
     > .mat-calendar-body-cell-content,
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus
+  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus-visible
     .mat-calendar-body-cell-content {
     outline: 2px solid color-mix(in srgb, var(--c-accent) 80%, transparent) !important;
   }
 
   .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
     > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected),
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus
+  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus-visible
     > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
     background-color: var(--calendar-hover-bg) !important;
   }


### PR DESCRIPTION
## Problem

Adressing the [comment of a recent PR](https://github.com/super-productivity/super-productivity/pull/8017#issuecomment-4661441890)

The date picker (based on Angular Material's mat-calendar) had several minor but noticeable design and UX inconsistencies:
   1. Selection Highlight Loss: Navigating years or months would cause the actual selected date to lose its primary color highlight, as the
      selected property was being incorrectly tied to the "active" (focused) date in those views.
   2. Sticky Focus Outline: Clicking a date with the mouse would leave a persistent focus outline (circle) that wouldn't disappear until focus
      was explicitly moved, creating a "sticky" visual feeling.
   3. Missing Initial Focus: The focus outline was not visible when the calendar first opened or when switching views, making it unclear which
      field was active for keyboard users.
   4. Keyboard Navigation Skipping: Quickly moving focus after a selection would sometimes "skip" fields because a background state sync was
      force-resetting the calendar's activeDate while the user was interacting.

## Solution

I performed a surgical refactoring of the DateTimePickerComponent and refined the global Material overwrites:
   1. Selection Logic: Removed custom pickerSelectedDate logic and bound mat-calendar directly to the selectedDate signal. This ensures the
      selected date remains highlighted regardless of view navigation.
   2. Focus Management:
      - Introduced an isInitialFocus state to show the focus outline on open/view-switch.
      - Implemented a hybrid suppression logic: focus outlines are suppressed when the mouse is used (preventing "stickiness") but remain fully
        visible for keyboard navigation and initial states.
      - Reverted global :focus-visible to :focus but scoped its suppression within the component to allow for programmatic focus visibility.
   3. Navigation Fix: Updated the activeDate sync effect to skip updates if the calendar currently has focus. This prevents background
      synchronization from "fighting" with active keyboard navigation.

## Type of Change

   - [x] Bug fix
   - [ ] New feature
   - [ ] Breaking change
   - [ ] Refactoring
   - [ ] Documentation
   - [x] Style/UX Improvement

## Checklist

   - [ ] I have included relevant changes to the documentation/wiki.
   - [x] I have run npm run checkFile on changed .ts/.scss files.
   - [x] I have added tests for my changes.
   - [x] Existing tests still pass.
   - [x] My commit messages follow the Angular format (type(scope): description).