### PR TITLE
fix(planner): don't double-count done recurring tasks in remaining time

### DIFF
--- a/src/app/features/planner/store/planner.bug-8220.spec.ts
+++ b/src/app/features/planner/store/planner.bug-8220.spec.ts
@@ -1,0 +1,177 @@
+import * as fromSelectors from './planner.selectors';
+import { PlannerState } from './planner.reducer';
+import { Task } from '../../tasks/task.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+import {
+  DEFAULT_TASK_REPEAT_CFG,
+  TaskRepeatCfg,
+} from '../../task-repeat-cfg/task-repeat-cfg.model';
+
+// Regression for #8220: a recurring task that already has an instance in a day
+// (created, and possibly marked done) was counted twice in the Planner: once as
+// the real task instance and again as a repeat projection. The "Today" view
+// (work-context.util) only ever counted the real instance, so the two views
+// disagreed on remaining time. The Planner must defer to the real instance and
+// drop the now-redundant projection.
+describe('Planner Selectors - #8220 recurring done task double-count', () => {
+  const today = getDbDateStr();
+  const ONE_HOUR = 60 * 60 * 1000;
+
+  const createMockTask = (overrides: Partial<Task> & { id: string }): Task => {
+    const { id, ...rest } = overrides;
+    return {
+      id,
+      title: `Task ${id}`,
+      created: Date.now(),
+      isDone: false,
+      subTaskIds: [],
+      tagIds: [],
+      projectId: 'project1',
+      timeSpentOnDay: {},
+      timeEstimate: 0,
+      timeSpent: 0,
+      attachments: [],
+      ...rest,
+    };
+  };
+
+  const createTasksMapFromTasksArray = (tasks: Task[]): Map<string, Task> =>
+    new Map(tasks.map((t) => [t.id, t]));
+
+  const emptyPlannerState: PlannerState = {
+    days: {},
+    addPlannedTasksDialogLastShown: undefined,
+  };
+
+  const defaultScheduleConfig = {
+    isWorkStartEndEnabled: false,
+    workStart: '09:00',
+    workEnd: '17:00',
+    isLunchBreakEnabled: false,
+    lunchBreakStart: '12:00',
+    lunchBreakEnd: '13:00',
+  };
+
+  // A daily cfg that still projects for today (startDate in the past,
+  // lastTaskCreationDay not yet advanced to today) and has no startTime, so it
+  // contributes its defaultEstimate via noStartTimeRepeatProjections.
+  const dailyRepeatCfg = (id: string, defaultEstimate: number): TaskRepeatCfg => ({
+    ...DEFAULT_TASK_REPEAT_CFG,
+    id,
+    repeatCycle: 'DAILY',
+    startDate: '2020-01-01',
+    lastTaskCreationDay: '2020-01-01',
+    startTime: undefined,
+    defaultEstimate,
+  });
+
+  it('counts a done recurring instance once (0 remaining), not also as a projection', () => {
+    const cfg = dailyRepeatCfg('R1', ONE_HOUR);
+    const task = createMockTask({
+      id: 't1',
+      repeatCfgId: 'R1',
+      isDone: true,
+      timeEstimate: ONE_HOUR,
+      timeSpent: 0,
+    });
+
+    // Pass t1 as a today-list task id (the reporter sees this in the Today column).
+    const selector = fromSelectors.selectPlannerDays(
+      [today],
+      [cfg],
+      ['t1'],
+      [],
+      [],
+      today,
+    );
+    const result = selector.projector(
+      createTasksMapFromTasksArray([task]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(0);
+    expect(result[0].itemsTotal).toBe(1);
+  });
+
+  it('counts an undone recurring instance once, not doubled', () => {
+    const cfg = dailyRepeatCfg('R1', ONE_HOUR);
+    const task = createMockTask({
+      id: 't1',
+      repeatCfgId: 'R1',
+      isDone: false,
+      timeEstimate: ONE_HOUR,
+      timeSpent: 0,
+    });
+
+    const selector = fromSelectors.selectPlannerDays(
+      [today],
+      [cfg],
+      ['t1'],
+      [],
+      [],
+      today,
+    );
+    const result = selector.projector(
+      createTasksMapFromTasksArray([task]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(ONE_HOUR);
+    expect(result[0].itemsTotal).toBe(1);
+  });
+
+  it('dedupes a timed (startTime) projection too, keeping it out of scheduledIItems', () => {
+    // A cfg WITH a startTime flows through repeatProjectionsForDay (the timed
+    // list) rather than noStartTimeRepeatProjections, so this exercises the other
+    // filtered array and the scheduledIItems dedup.
+    const cfg: TaskRepeatCfg = {
+      ...dailyRepeatCfg('R1', ONE_HOUR),
+      startTime: '09:00',
+    };
+    const task = createMockTask({
+      id: 't1',
+      repeatCfgId: 'R1',
+      isDone: true,
+      timeEstimate: ONE_HOUR,
+      timeSpent: 0,
+    });
+
+    const selector = fromSelectors.selectPlannerDays(
+      [today],
+      [cfg],
+      ['t1'],
+      [],
+      [],
+      today,
+    );
+    const result = selector.projector(
+      createTasksMapFromTasksArray([task]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(0);
+    expect(result[0].itemsTotal).toBe(1);
+    expect(result[0].scheduledIItems.length).toBe(0);
+  });
+
+  it('still projects a recurring cfg that has no task instance in the day', () => {
+    const cfg = dailyRepeatCfg('R2', ONE_HOUR);
+
+    const selector = fromSelectors.selectPlannerDays([today], [cfg], [], [], [], today);
+    const result = selector.projector(
+      createTasksMapFromTasksArray([]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(ONE_HOUR);
+    expect(result[0].itemsTotal).toBe(1);
+  });
+});

--- a/src/app/features/planner/store/planner.selectors.ts
+++ b/src/app/features/planner/store/planner.selectors.ts
@@ -186,8 +186,26 @@ const getPlannerDay = (
     // Filter out tasks with dueDay in future if it is Today's column
     .filter((t) => !isTodayI || !t.dueDay || t.dueDay <= todayStr);
 
-  const { repeatProjectionsForDay, noStartTimeRepeatProjections } =
-    getAllRepeatableTasksForDay(taskRepeatCfgs, currentDayTimestamp);
+  const {
+    repeatProjectionsForDay: allRepeatProjectionsForDay,
+    noStartTimeRepeatProjections: allNoStartTimeRepeatProjections,
+  } = getAllRepeatableTasksForDay(taskRepeatCfgs, currentDayTimestamp);
+
+  // A recurring task can already have a real instance in this day (created, and
+  // possibly marked done). Drop the repeat projection for any config that already
+  // has an instance here, so the same recurring task is not counted twice, once as
+  // the real (done-aware) task and once as a projection. The "Today" view only ever
+  // counts the real task, so without this the two views disagree on remaining time
+  // for done recurring tasks. See #8220.
+  const coveredRepeatCfgIds = new Set(
+    normalTasks.map((t) => t.repeatCfgId).filter((id): id is string => !!id),
+  );
+  const repeatProjectionsForDay = allRepeatProjectionsForDay.filter(
+    (rp) => !coveredRepeatCfgIds.has(rp.repeatCfg.id),
+  );
+  const noStartTimeRepeatProjections = allNoStartTimeRepeatProjections.filter(
+    (rp) => !coveredRepeatCfgIds.has(rp.repeatCfg.id),
+  );
 
   const scheduledTaskItems = getScheduledTaskItems(
     allPlannedTasks,


### PR DESCRIPTION
## Problem

Closes #8220.

When a recurring task is marked done without any time tracked (for example, a recurring meeting that didn't take place), its estimated time still counts toward the remaining time in the **Planner** tab, while the **Today** tab correctly excludes it.

Root cause is a double count in `getPlannerDay` (`planner.selectors.ts`). For a recurring task the Planner sums:

1. the real task instance, which is done-aware and contributes 0 once the task is done, and
2. a separate repeat *projection* built from the `TaskRepeatCfg`, which always uses the full estimate with no done-awareness.

So a done recurring task ends up as `0` (instance) + `fullEstimate` (projection). The Today view never builds projections, so it only ever counts the real task. That is why the two views disagree.

## Solution

In `getPlannerDay`, drop the repeat projection for any config that already has a real instance in that day, deduping by `repeatCfgId`, so the recurring task is counted once through its done-aware instance. This is applied to both the timed (`repeatProjectionsForDay`) and untimed (`noStartTimeRepeatProjections`) projection arrays, so the remaining-time total, the item count, and the scheduled item list all stop double-counting in one place.

This mirrors the dedup the Schedule view already does for the same situation (#7853, see `create-schedule-days.ts`). Per-day dedup by bare `repeatCfgId` is sufficient here because `getPlannerDay` builds a fresh set per day, whereas the Schedule variant keys by `repeatCfgId|day` since it processes many days in one pass.

Added a regression spec (`planner.bug-8220.spec.ts`) covering the done instance, the undone instance, the timed projection, the untimed projection, and the no-instance case (which should still project).

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/wiki
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
