### PR TITLE
refactor(sync): single source of truth for local-only sync settings + round-trip tests #8233

### DIFF
--- a/src/app/features/config/local-only-sync-settings.util.spec.ts
+++ b/src/app/features/config/local-only-sync-settings.util.spec.ts
@@ -1,11 +1,25 @@
 import {
   applyLocalOnlySyncSettingsToAppData,
+  LOCAL_ONLY_SYNC_DEVICE_KEYS,
+  LOCAL_ONLY_SYNC_KEYS,
+  LOCAL_ONLY_SYNC_SCHEDULE_KEYS,
   stripLocalOnlySyncScheduleSettings,
   stripLocalOnlySyncSettingsFromAppData,
 } from './local-only-sync-settings.util';
 import { SyncProviderId } from '../../op-log/sync-providers/provider.const';
 
 describe('local-only sync settings utils', () => {
+  it('schedule and device key sets are disjoint and exhaust LOCAL_ONLY_SYNC_KEYS', () => {
+    const union = new Set<string>([
+      ...LOCAL_ONLY_SYNC_SCHEDULE_KEYS,
+      ...LOCAL_ONLY_SYNC_DEVICE_KEYS,
+    ]);
+    expect(union.size).toBe(
+      LOCAL_ONLY_SYNC_SCHEDULE_KEYS.length + LOCAL_ONLY_SYNC_DEVICE_KEYS.length,
+    );
+    expect(union.size).toBe(LOCAL_ONLY_SYNC_KEYS.length);
+  });
+
   it('should strip sync schedule settings from a sync config object', () => {
     const result = stripLocalOnlySyncScheduleSettings({
       syncInterval: 300000,

--- a/src/app/features/config/local-only-sync-settings.util.ts
+++ b/src/app/features/config/local-only-sync-settings.util.ts
@@ -1,18 +1,42 @@
 import { SyncConfig } from './global-config.model';
 
-export type LocalOnlySyncSettings = Pick<
-  SyncConfig,
-  | 'isEnabled'
-  | 'isEncryptionEnabled'
-  | 'syncProvider'
-  | 'syncInterval'
-  | 'isManualSyncOnly'
->;
-
+/**
+ * Local-only sync settings — two tiers, both per-device:
+ *
+ * - SCHEDULE keys (`syncInterval`, `isManualSyncOnly`): must NEVER leave the
+ *   device. Stripped (`Omit`-style) at every upload boundary.
+ * - DEVICE-IDENTITY keys (`syncProvider`, `isEnabled`, `isEncryptionEnabled`):
+ *   exist on every device but the local value must win on hydration. On upload
+ *   `syncProvider` is nulled (so a remote import never picks a provider for
+ *   you); on hydration the local values are re-applied via
+ *   {@link applyLocalOnlySyncSettingsToAppData}.
+ *
+ * The key arrays below are the single source of truth — both the
+ * `LocalOnlySyncSettings` type and the reducer-side preservation helper
+ * (`withLocalOnlySyncSettings` in `global-config.reducer.ts`) derive from them.
+ * Add a new local-only key here and the type + reducer + strip helpers pick it
+ * up automatically.
+ */
 export const LOCAL_ONLY_SYNC_SCHEDULE_KEYS = [
   'syncInterval',
   'isManualSyncOnly',
 ] as const satisfies readonly (keyof SyncConfig)[];
+
+export const LOCAL_ONLY_SYNC_DEVICE_KEYS = [
+  'syncProvider',
+  'isEnabled',
+  'isEncryptionEnabled',
+] as const satisfies readonly (keyof SyncConfig)[];
+
+export const LOCAL_ONLY_SYNC_KEYS = [
+  ...LOCAL_ONLY_SYNC_SCHEDULE_KEYS,
+  ...LOCAL_ONLY_SYNC_DEVICE_KEYS,
+] as const;
+
+export type LocalOnlySyncSettings = Pick<
+  SyncConfig,
+  (typeof LOCAL_ONLY_SYNC_KEYS)[number]
+>;
 
 export const stripLocalOnlySyncScheduleSettings = <T extends Record<string, unknown>>(
   syncConfig: T,

--- a/src/app/features/config/store/global-config.reducer.spec.ts
+++ b/src/app/features/config/store/global-config.reducer.spec.ts
@@ -23,6 +23,7 @@ import { GlobalConfigState } from '../global-config.model';
 import { SyncProviderId } from '../../../op-log/sync-providers/provider.const';
 import { AppDataComplete } from '../../../op-log/model/model-config';
 import { DEFAULT_GLOBAL_CONFIG } from '../default-global-config.const';
+import { LOCAL_ONLY_SYNC_KEYS } from '../local-only-sync-settings.util';
 import { INBOX_PROJECT } from '../../project/project.const';
 
 describe('GlobalConfigReducer', () => {
@@ -919,6 +920,46 @@ describe('GlobalConfigReducer', () => {
       expect(result.sync.syncInterval).toBe(300000);
       expect(result.sync.isManualSyncOnly).toBe(true);
       expect(result.sync.isCompressionEnabled).toBe(true);
+    });
+
+    // Round-trip pin (issue #8233): iterates LOCAL_ONLY_SYNC_KEYS so adding a
+    // new local-only key grows coverage here automatically.
+    it('preserves every LOCAL_ONLY_SYNC_KEYS value on remote section updates (round-trip)', () => {
+      const localSync = {
+        ...initialGlobalConfigState.sync,
+        isEnabled: true,
+        isEncryptionEnabled: true,
+        syncProvider: SyncProviderId.WebDAV,
+        syncInterval: 300000,
+        isManualSyncOnly: true,
+      };
+      const remoteSync = {
+        isEnabled: false,
+        isEncryptionEnabled: false,
+        syncProvider: SyncProviderId.Dropbox,
+        syncInterval: 60000,
+        isManualSyncOnly: false,
+      };
+      const oldState: GlobalConfigState = {
+        ...initialGlobalConfigState,
+        sync: localSync,
+      };
+      const remoteAction = updateGlobalConfigSection({
+        sectionKey: 'sync',
+        sectionCfg: remoteSync,
+      });
+      const remoteReplayAction = {
+        ...remoteAction,
+        meta: { ...remoteAction.meta, isRemote: true },
+      };
+
+      const result = globalConfigReducer(oldState, remoteReplayAction);
+
+      for (const key of LOCAL_ONLY_SYNC_KEYS) {
+        expect(result.sync[key])
+          .withContext(`sync.${key} must survive remote section update`)
+          .toBe(localSync[key]);
+      }
     });
 
     it('should update shared sync settings for remote sync section updates', () => {

--- a/src/app/features/config/store/global-config.reducer.ts
+++ b/src/app/features/config/store/global-config.reducer.ts
@@ -18,6 +18,7 @@ import { DEFAULT_GLOBAL_CONFIG } from '../default-global-config.const';
 import { loadAllData } from '../../../root-store/meta/load-all-data.action';
 import { getHoursFromClockString } from '../../../util/get-hours-from-clock-string';
 import { normalizeStartOfNextDayConfig } from '../normalize-start-of-next-day-config';
+import { LOCAL_ONLY_SYNC_KEYS } from '../local-only-sync-settings.util';
 
 /**
  * Migrate the legacy `isSyncSessionWithTracking` flag (removed in the focus-mode
@@ -136,17 +137,19 @@ const migrateKeyboardConfig = (cfg: KeyboardConfig | undefined): KeyboardConfig 
   return keyboard;
 };
 
+// Overwrite every local-only key on the incoming config with the local value.
+// Keys are sourced from LOCAL_ONLY_SYNC_KEYS so adding a new local-only key in
+// local-only-sync-settings.util.ts automatically preserves it here too.
 const withLocalOnlySyncSettings = (
   incomingSyncConfig: SyncConfig,
   localSyncConfig: SyncConfig,
-): SyncConfig => ({
-  ...incomingSyncConfig,
-  syncProvider: localSyncConfig.syncProvider,
-  isEnabled: localSyncConfig.isEnabled,
-  isEncryptionEnabled: localSyncConfig.isEncryptionEnabled,
-  syncInterval: localSyncConfig.syncInterval,
-  isManualSyncOnly: localSyncConfig.isManualSyncOnly,
-});
+): SyncConfig => {
+  const merged = { ...incomingSyncConfig } as Record<string, unknown>;
+  for (const key of LOCAL_ONLY_SYNC_KEYS) {
+    merged[key] = localSyncConfig[key];
+  }
+  return merged as SyncConfig;
+};
 
 export const globalConfigReducer = createReducer<GlobalConfigState>(
   initialGlobalConfigState,

--- a/src/app/op-log/persistence/sync-hydration.service.spec.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.spec.ts
@@ -11,6 +11,7 @@ import { loadAllData } from '../../root-store/meta/load-all-data.action';
 import { ActionType, OpType } from '../core/operation.types';
 import { SyncProviderId } from '../sync-providers/provider.const';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
+import { LOCAL_ONLY_SYNC_KEYS } from '../../features/config/local-only-sync-settings.util';
 import { SnackService } from '../../core/snack/snack.service';
 
 describe('SyncHydrationService', () => {
@@ -777,6 +778,56 @@ describe('SyncHydrationService', () => {
       const sync = globalConfig['sync'] as Record<string, unknown>;
       expect(sync['syncProvider']).toBe(SyncProviderId.WebDAV);
       expect(sync['isEnabled']).toBe(true);
+    });
+
+    // Round-trip pin (issue #8233): iterates LOCAL_ONLY_SYNC_KEYS so adding a
+    // new local-only key in the util grows coverage here automatically without
+    // touching this spec.
+    it('preserves every LOCAL_ONLY_SYNC_KEYS value through hydration (round-trip)', async () => {
+      const localSync = {
+        ...DEFAULT_GLOBAL_CONFIG.sync,
+        isEnabled: true,
+        isEncryptionEnabled: false,
+        syncProvider: SyncProviderId.WebDAV,
+        syncInterval: 300000,
+        isManualSyncOnly: true,
+      };
+      const remoteSync = {
+        ...DEFAULT_GLOBAL_CONFIG.sync,
+        isEnabled: false,
+        isEncryptionEnabled: true,
+        syncProvider: SyncProviderId.Dropbox,
+        syncInterval: 60000,
+        isManualSyncOnly: false,
+      };
+      mockStore.select.and.returnValue(of(localSync));
+
+      await service.hydrateFromRemoteSync({
+        task: {},
+        globalConfig: { sync: remoteSync },
+      });
+
+      const dispatchedAction = mockStore.dispatch.calls.mostRecent()
+        .args[0] as unknown as ReturnType<typeof loadAllData>;
+      const dispatchedSync = (
+        dispatchedAction.appDataComplete.globalConfig as Record<string, unknown>
+      )['sync'] as Record<string, unknown>;
+      for (const key of LOCAL_ONLY_SYNC_KEYS) {
+        expect(dispatchedSync[key])
+          .withContext(`dispatched sync.${key} must match local`)
+          .toBe(localSync[key]);
+      }
+
+      const savedState = mockOpLogStore.saveStateCache.calls.mostRecent().args[0]
+        .state as Record<string, unknown>;
+      const savedSync = (savedState['globalConfig'] as Record<string, unknown>)[
+        'sync'
+      ] as Record<string, unknown>;
+      for (const key of LOCAL_ONLY_SYNC_KEYS) {
+        expect(savedSync[key])
+          .withContext(`saved snapshot sync.${key} must match local`)
+          .toBe(localSync[key]);
+      }
     });
 
     it('should preserve local settings in both snapshot and dispatch', async () => {

--- a/src/app/op-log/sync/remote-ops-processing.service.spec.ts
+++ b/src/app/op-log/sync/remote-ops-processing.service.spec.ts
@@ -35,6 +35,7 @@ import { toEntityKey } from '../util/entity-key.util';
 import { T } from '../../t.const';
 import { OpLog } from '../../core/log';
 import { SyncProviderId } from '../sync-providers/provider.const';
+import { LOCAL_ONLY_SYNC_KEYS } from '../../features/config/local-only-sync-settings.util';
 
 describe('RemoteOpsProcessingService', () => {
   let service: RemoteOpsProcessingService;
@@ -768,6 +769,63 @@ describe('RemoteOpsProcessingService', () => {
       expect(writtenSync['isManualSyncOnly']).toBe(true);
       expect(writtenSync['isCompressionEnabled']).toBe(true);
       expect(appliedOps[0]).toBe(writtenOp);
+    });
+
+    // Round-trip pin (issue #8233): iterates LOCAL_ONLY_SYNC_KEYS so adding a
+    // new local-only key in the util grows coverage here automatically.
+    it('preserves every LOCAL_ONLY_SYNC_KEYS value on incoming full-state ops (round-trip)', async () => {
+      const localSync = {
+        isEnabled: true,
+        isEncryptionEnabled: true,
+        syncProvider: SyncProviderId.WebDAV,
+        syncInterval: 300000,
+        isManualSyncOnly: true,
+      };
+      storeSpy.select.and.returnValue(of(localSync));
+
+      const syncImportOp: Operation = {
+        id: 'sync-import-roundtrip',
+        opType: OpType.SyncImport,
+        actionType: '[All] Load All Data' as ActionType,
+        entityType: 'ALL',
+        payload: {
+          globalConfig: {
+            sync: {
+              isEnabled: false,
+              isEncryptionEnabled: false,
+              syncProvider: SyncProviderId.Dropbox,
+              syncInterval: 60000,
+              isManualSyncOnly: false,
+            },
+          },
+        },
+        clientId: 'client-1',
+        vectorClock: { client1: 1 },
+        timestamp: Date.now(),
+        schemaVersion: 1,
+      };
+
+      opLogStoreSpy.hasOp.and.returnValue(Promise.resolve(false));
+      operationApplierServiceSpy.applyOperations.and.callFake(async (ops) => ({
+        appliedOps: ops,
+      }));
+
+      await service.processRemoteOps([syncImportOp]);
+
+      const writtenOp =
+        opLogStoreSpy.appendBatchSkipDuplicates.calls.mostRecent().args[0][0];
+      const writtenSync = (
+        (writtenOp.payload as Record<string, unknown>)['globalConfig'] as Record<
+          string,
+          unknown
+        >
+      )['sync'] as Record<string, unknown>;
+
+      for (const key of LOCAL_ONLY_SYNC_KEYS) {
+        expect(writtenSync[key])
+          .withContext(`replay payload sync.${key} must match local`)
+          .toBe(localSync[key]);
+      }
     });
 
     it('should skip conflict detection when BACKUP_IMPORT is in remote ops', async () => {


### PR DESCRIPTION
## Summary

Phases 1 + 2 of #8233. Pure refactor + test additions, no behavior change. Phase 3 (replacing the `syncProvider === null` "first load" heuristic with an explicit hydration flag) is deferred per the issue — it's a state-shape change that should land separately once a reproducer pins the bug it would fix.

### What changes

- `local-only-sync-settings.util.ts`: declare `LOCAL_ONLY_SYNC_SCHEDULE_KEYS` (schedule, stripped on the wire) and `LOCAL_ONLY_SYNC_DEVICE_KEYS` (device-identity, nulled on the wire and re-applied on hydration) as the source of truth. Derive `LOCAL_ONLY_SYNC_KEYS`, `LocalOnlySyncSettings`, and the reducer's `withLocalOnlySyncSettings` from those arrays. Document the two-tier model in a header comment.
- `global-config.reducer.ts`: rewrite `withLocalOnlySyncSettings` as a loop over `LOCAL_ONLY_SYNC_KEYS` instead of a hand-rolled list of 5 keys.
- Unit test pins that the schedule/device key sets are disjoint and that their union exhausts `LOCAL_ONLY_SYNC_KEYS`.
- Round-trip integration pins at the three boundaries where the invariant lives — hydration, full-state remote ops, and remote `updateGlobalConfigSection`. Each iterates `LOCAL_ONLY_SYNC_KEYS` so a future local-only key automatically grows coverage without touching the specs.

### Why

The set of local-only sync keys was previously encoded in three places (type, schedule array, reducer helper) that could silently drift. The existing strip helper is pinned by `local-only-sync-settings.util.spec.ts` and the apply side by `global-config.reducer.spec.ts`, but nothing iterated the key list itself — adding a 6th local-only key wouldn't have automatically been caught at the test layer.

## Test plan

- [ ] `npm run checkFile` on the four files where it didn't run pre-commit: `global-config.reducer.ts`, `global-config.reducer.spec.ts`, `sync-hydration.service.spec.ts`, `remote-ops-processing.service.spec.ts`
- [ ] `npm run test:file src/app/features/config/local-only-sync-settings.util.spec.ts`
- [ ] `npm run test:file src/app/features/config/store/global-config.reducer.spec.ts`
- [ ] `npm run test:file src/app/op-log/persistence/sync-hydration.service.spec.ts`
- [ ] `npm run test:file src/app/op-log/sync/remote-ops-processing.service.spec.ts`
- [ ] Manual sanity check: a fresh client whose local sync config differs from a remote snapshot keeps local values for all 5 keys after a full sync round trip

## Refs

- Issue #8233 (this issue)
- PR #8077 / #7661 (the original local-only fix this hardens)
- `docs/sync-and-op-log/contributor-sync-model.md`