### PR TITLE
fix(planner): don't double-count timed recurring tasks on Today

### DIFF
--- a/src/app/features/planner/store/planner.bug-8232.spec.ts
+++ b/src/app/features/planner/store/planner.bug-8232.spec.ts
@@ -1,0 +1,191 @@
+import * as fromSelectors from './planner.selectors';
+import { PlannerState } from './planner.reducer';
+import { Task, TaskWithDueTime } from '../../tasks/task.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
+import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
+import {
+  DEFAULT_TASK_REPEAT_CFG,
+  TaskRepeatCfg,
+} from '../../task-repeat-cfg/task-repeat-cfg.model';
+
+// Regression for #8232: the dedup added in #8220/#8229 keyed only off
+// `normalTasks`, but a recurring task with `startTime` is created with
+// `dueWithTime` and therefore lives in `allPlannedTasks` -> `scheduledTaskItems`,
+// never in `normalTasks` on the Today column. The projection was not dropped,
+// and `getScheduledTaskItems` ignored `isDone`, so a done timed recurring
+// instance contributed roughly 2x its estimate (full from scheduledTaskItems +
+// full from the projection). Today only ever counts the real (done-aware) task,
+// so the two views disagreed again — the original #8220 symptom for the timed
+// subset.
+describe('Planner Selectors - #8232 timed recurring done task double-count', () => {
+  const today = getDbDateStr();
+  const ONE_HOUR = 60 * 60 * 1000;
+
+  const createMockTask = (overrides: Partial<Task> & { id: string }): Task => {
+    const { id, ...rest } = overrides;
+    return {
+      id,
+      title: `Task ${id}`,
+      created: Date.now(),
+      isDone: false,
+      subTaskIds: [],
+      tagIds: [],
+      projectId: 'project1',
+      timeSpentOnDay: {},
+      timeEstimate: 0,
+      timeSpent: 0,
+      attachments: [],
+      ...rest,
+    };
+  };
+
+  const createTasksMapFromTasksArray = (tasks: Task[]): Map<string, Task> =>
+    new Map(tasks.map((t) => [t.id, t]));
+
+  const emptyPlannerState: PlannerState = {
+    days: {},
+    addPlannedTasksDialogLastShown: undefined,
+  };
+
+  const defaultScheduleConfig = {
+    isWorkStartEndEnabled: false,
+    workStart: '09:00',
+    workEnd: '17:00',
+    isLunchBreakEnabled: false,
+    lunchBreakStart: '12:00',
+    lunchBreakEnd: '13:00',
+  };
+
+  // A daily cfg with a fixed startTime — projects via `repeatProjectionsForDay`
+  // (the timed list) and, when an instance exists, that instance has
+  // `dueWithTime` set so it flows through `allPlannedTasks` /
+  // `scheduledTaskItems`.
+  const dailyTimedRepeatCfg = (
+    id: string,
+    defaultEstimate: number,
+    startTime = '09:00',
+  ): TaskRepeatCfg => ({
+    ...DEFAULT_TASK_REPEAT_CFG,
+    id,
+    repeatCycle: 'DAILY',
+    startDate: '2020-01-01',
+    lastTaskCreationDay: '2020-01-01',
+    startTime,
+    defaultEstimate,
+  });
+
+  const todayAt = (clock: string): number =>
+    getDateTimeFromClockString(clock, dateStrToUtcDate(today).getTime());
+
+  it('done timed recurring instance contributes 0 remaining, not estimate x 2', () => {
+    const cfg = dailyTimedRepeatCfg('R1', ONE_HOUR);
+    const task = createMockTask({
+      id: 't1',
+      repeatCfgId: 'R1',
+      isDone: true,
+      timeEstimate: ONE_HOUR,
+      timeSpent: 0,
+      dueWithTime: todayAt('09:00'),
+    }) as TaskWithDueTime;
+
+    // The reporter's setup: instance is in today's list AND in allPlannedTasks
+    // (because dueWithTime is set on the recurring instance).
+    const selector = fromSelectors.selectPlannerDays(
+      [today],
+      [cfg],
+      ['t1'],
+      [],
+      [task],
+      today,
+    );
+    const result = selector.projector(
+      createTasksMapFromTasksArray([task]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(0);
+    // One real (done) instance, projection dropped.
+    expect(result[0].itemsTotal).toBe(1);
+    // Scheduled list still shows the instance (visible in the day), but as a
+    // zero-length item — no double-booked projection alongside it.
+    expect(result[0].scheduledIItems.length).toBe(1);
+  });
+
+  it('undone timed recurring instance contributes one estimate, not two', () => {
+    const cfg = dailyTimedRepeatCfg('R1', ONE_HOUR);
+    const task = createMockTask({
+      id: 't1',
+      repeatCfgId: 'R1',
+      isDone: false,
+      timeEstimate: ONE_HOUR,
+      timeSpent: 0,
+      dueWithTime: todayAt('09:00'),
+    }) as TaskWithDueTime;
+
+    const selector = fromSelectors.selectPlannerDays(
+      [today],
+      [cfg],
+      ['t1'],
+      [],
+      [task],
+      today,
+    );
+    const result = selector.projector(
+      createTasksMapFromTasksArray([task]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(ONE_HOUR);
+    expect(result[0].itemsTotal).toBe(1);
+    expect(result[0].scheduledIItems.length).toBe(1);
+  });
+
+  it('done timed task with no recurring cfg also contributes 0 (getScheduledTaskItems is done-aware)', () => {
+    // Independent of the dedup fix: a one-off done timed task used to contribute
+    // its full estimate via scheduledTaskItems.
+    const task = createMockTask({
+      id: 't1',
+      isDone: true,
+      timeEstimate: ONE_HOUR,
+      timeSpent: 0,
+      dueWithTime: todayAt('10:00'),
+    }) as TaskWithDueTime;
+
+    const selector = fromSelectors.selectPlannerDays(
+      [today],
+      [],
+      ['t1'],
+      [],
+      [task],
+      today,
+    );
+    const result = selector.projector(
+      createTasksMapFromTasksArray([task]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(0);
+  });
+
+  it('still projects a timed recurring cfg that has no instance in the day', () => {
+    const cfg = dailyTimedRepeatCfg('R2', ONE_HOUR);
+
+    const selector = fromSelectors.selectPlannerDays([today], [cfg], [], [], [], today);
+    const result = selector.projector(
+      createTasksMapFromTasksArray([]),
+      emptyPlannerState,
+      defaultScheduleConfig,
+      0,
+    );
+
+    expect(result[0].timeEstimate).toBe(ONE_HOUR);
+    expect(result[0].itemsTotal).toBe(1);
+  });
+});

--- a/src/app/features/planner/store/planner.selectors.ts
+++ b/src/app/features/planner/store/planner.selectors.ts
@@ -191,26 +191,33 @@ const getPlannerDay = (
     noStartTimeRepeatProjections: allNoStartTimeRepeatProjections,
   } = getAllRepeatableTasksForDay(taskRepeatCfgs, currentDayTimestamp);
 
-  // A recurring task can already have a real instance in this day (created, and
-  // possibly marked done). Drop the repeat projection for any config that already
-  // has an instance here, so the same recurring task is not counted twice, once as
-  // the real (done-aware) task and once as a projection. The "Today" view only ever
-  // counts the real task, so without this the two views disagree on remaining time
-  // for done recurring tasks. See #8220.
-  const coveredRepeatCfgIds = new Set(
-    normalTasks.map((t) => t.repeatCfgId).filter((id): id is string => !!id),
+  const scheduledTaskItems = getScheduledTaskItems(
+    allPlannedTasks,
+    dayDate,
+    startOfNextDayDiffMs,
   );
+
+  // A recurring task can already have a real instance in this day, either in
+  // normalTasks (untimed instance, or any non-Today column) or in
+  // scheduledTaskItems (timed `dueWithTime` instance on Today — excluded from
+  // normalTasks because allPlannedTasks owns it). Drop the projection for any
+  // config that already has an instance here so the same recurring task is not
+  // counted twice — once as the real (done-aware) task and once as a full-
+  // estimate projection. The "Today" view only ever counts the real task, so
+  // without this the two views disagree on remaining time for done recurring
+  // tasks. See #8220, #8232.
+  const coveredRepeatCfgIds = new Set<string>();
+  for (const t of normalTasks) {
+    if (t.repeatCfgId) coveredRepeatCfgIds.add(t.repeatCfgId);
+  }
+  for (const si of scheduledTaskItems) {
+    if (si.task.repeatCfgId) coveredRepeatCfgIds.add(si.task.repeatCfgId);
+  }
   const repeatProjectionsForDay = allRepeatProjectionsForDay.filter(
     (rp) => !coveredRepeatCfgIds.has(rp.repeatCfg.id),
   );
   const noStartTimeRepeatProjections = allNoStartTimeRepeatProjections.filter(
     (rp) => !coveredRepeatCfgIds.has(rp.repeatCfg.id),
-  );
-
-  const scheduledTaskItems = getScheduledTaskItems(
-    allPlannedTasks,
-    dayDate,
-    startOfNextDayDiffMs,
   );
   const { timedEvents, allDayEvents } = getIcalEventsForDay(
     calendarEvents,
@@ -344,7 +351,11 @@ const getScheduledTaskItems = (
     )
     .map((task) => {
       const start = task.dueWithTime;
-      const end = start + Math.max(task.timeEstimate - task.timeSpent, 0);
+      // Mirror normalTasks: a done task contributes 0 remaining time. Without
+      // this, a done timed task still adds its full estimate to the day total
+      // (and a done timed recurring task double-counted with its projection
+      // before the dedup above). See #8232.
+      const end = start + (task.isDone ? 0 : getTimeLeftForTask(task));
       return {
         id: task.id,
         type: ScheduleItemType.Task,


### PR DESCRIPTION
## Problem

Closes #8232. Narrow follow-up to #8220 / #8229.

#8229 fixes the Planner's double-count for recurring tasks marked done without time tracked by deduping repeat projections against `normalTasks` in `getPlannerDay`. That covers untimed recurring tasks and recurring tasks on non-Today columns.

There's still a gap for **timed** recurring tasks (`TaskRepeatCfg.startTime` set) on the **Today** column:

- For today, `tIds = unplannedTaskIdsToday = todayListTaskIds.filter(id => !allPlannedIdSet.has(id))`. A recurring task with `dueWithTime` is in `allPlannedTasks`, so it's filtered out of `normalTasks` and into `scheduledTaskItems`.
- `coveredRepeatCfgIds` in #8229 is built from `normalTasks.map(t => t.repeatCfgId)`, so it never sees this task's `repeatCfgId` — the projection survives.
- `getScheduledTaskItems` ignored `isDone`, so a done timed recurring meeting with zero `timeSpent` still contributed its full estimate via `scheduledTaskItems` **and** another full estimate via the un-deduped projection — Planner ended ~`2 × estimate` higher than Today.

## Solution

Two independent changes in `src/app/features/planner/store/planner.selectors.ts`:

1. **Extend the dedup** to also include `repeatCfgId`s from `scheduledTaskItems`, so a timed recurring instance on Today suppresses its own projection. Mirrors the dedup pattern in `create-schedule-days.ts:162-169`.
2. **Make `getScheduledTaskItems` done-aware** — `end = start + (task.isDone ? 0 : getTimeLeftForTask(task))`. Mirrors the `normalTasks` rule in `getAllTimeSpent`. Also independently fixes any one-off done timed task that previously kept adding its full estimate to the day total. Side benefit: now consistent with the schedule view (which already uses `getTimeLeftForTask` for the same `dueWithTime` tasks).

Added `planner.bug-8232.spec.ts` with four cases:
- Done timed recurring instance -> `timeEstimate === 0`, no doubled projection.
- Undone timed recurring instance -> counted once at full estimate.
- Done one-off timed task (no recurring cfg) -> `timeEstimate === 0` (guards the `isDone` change independently).
- Timed recurring cfg with no instance -> still projects normally.

## Notes

- This branch is stacked on #8229's commit so the diff is self-contained. Once #8229 merges to master, rebasing this branch will drop the duplicate commit automatically.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/wiki
- [x] I have run \`npm run checkFile\` on changed \`.ts\`/\`.scss\` files
- [x] I have added tests for my changes
- [x] Existing tests still pass (planner.selectors.spec.ts 37/37, planner.bug-8220.spec.ts 4/4, planner.bug-8232.spec.ts 4/4)
- [x] My commit messages follow the Angular format