### PR TITLE
style(habits): allow dynamic title width up to screen bounds

### DIFF
--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
@@ -1,16 +1,17 @@
 @use '../../../../styles/_globals.scss' as *;
 
 :host {
-  display: block;
+  display: flex;
+  justify-content: center;
   overflow-x: auto;
   padding: var(--s);
 }
 
 .habit-tracker-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  justify-content: center;
   width: 100%;
+  margin: 0 auto;
 }
 
 .navigation-bar {
@@ -20,7 +21,9 @@
   flex-wrap: wrap;
   gap: 12px var(--s);
   margin-bottom: var(--s2);
+  padding: 0 var(--s-half);
   width: 100%;
+  min-width: 400px;
 
   @include mq(xs, max) {
     margin-bottom: 12px;
@@ -57,6 +60,7 @@
 
 .add-habit-btn {
   font-size: 13px;
+  margin-left: var(--s);
 
   mat-icon {
     margin-right: var(--s-half);
@@ -64,34 +68,35 @@
 }
 
 .habit-grid {
-  display: grid;
-  grid-template-columns: minmax(120px, auto) repeat(7, 44px);
-  width: fit-content;
-  max-width: 100%;
-  margin: 0 auto;
-
-  @include mq(xs, max) {
-    grid-template-columns: 40px repeat(7, 32px);
-  }
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 }
 
 .header-row {
-  display: contents;
+  display: flex;
+  margin-bottom: var(--s-half);
+  align-items: flex-end;
 }
 
 .header-spacer {
+  flex: 1 1 0px;
+  min-width: 120px;
+
   @include mq(xs, max) {
+    flex: 0 0 40px;
     width: 40px;
   }
 }
 
 .day-header {
+  flex: 0 0 44px;
   text-align: center;
   font-size: 11px;
   opacity: 0.7;
-  padding-bottom: var(--s-half);
 
   @include mq(xs, max) {
+    flex: 0 0 32px;
     font-size: 10px;
   }
 
@@ -111,26 +116,27 @@
 }
 
 .habit-row {
-  display: contents;
+  display: flex;
+  align-items: center;
+  padding: var(--s) 0;
+
+  border-bottom: 1px solid var(--c-dark-10);
+
+  @include darkTheme() {
+    border-bottom-color: rgba(255, 255, 255, 0.15);
+  }
+
+  @include lightTheme() {
+    border-bottom-color: rgba(0, 0, 0, 0.15);
+  }
 
   &.cdk-drag-preview {
-    display: flex;
-    align-items: center;
     box-sizing: border-box;
     border-radius: var(--card-border-radius);
-    background: var(--bg-lighter);
     box-shadow:
       0 5px 5px -3px var(--c-dark-20),
       0 8px 10px 1px rgba(0, 0, 0, 0.14),
       0 3px 14px 2px rgba(0, 0, 0, 0.12);
-
-    .habit-title {
-      flex: 0 0 200px;
-    }
-
-    .day-cell {
-      flex: 0 0 44px;
-    }
   }
 
   &.cdk-drag-placeholder {
@@ -143,29 +149,25 @@
 }
 
 .habit-title {
+  flex: 1 1 0px;
+  min-width: 120px;
   display: flex;
   align-items: center;
-  gap: var(--s);
-  cursor: pointer;
-  padding: var(--s) var(--s);
-  border-bottom: 1px solid var(--c-dark-10);
+  justify-content: flex-start;
   overflow: hidden;
-
-  @include darkTheme() {
-    border-bottom-color: rgba(255, 255, 255, 0.15);
-  }
-
-  @include lightTheme() {
-    border-bottom-color: rgba(0, 0, 0, 0.15);
-  }
+  cursor: pointer;
+  gap: var(--s);
+  padding: 0 var(--s);
 
   &:hover {
     opacity: 0.7;
   }
 
   @include mq(xs, max) {
+    flex: 0 0 40px;
+    width: 40px;
     justify-content: center;
-    padding: var(--s) 0;
+    padding: 0;
   }
 
   .habit-icon {
@@ -226,19 +228,91 @@
   }
 }
 
-.day-cell {
+.footer-actions {
   display: flex;
   justify-content: center;
-  align-items: center;
-  cursor: pointer;
-  border-bottom: 1px solid var(--c-dark-10);
+  padding: var(--s4) var(--s2);
 
-  @include darkTheme() {
-    border-bottom-color: rgba(255, 255, 255, 0.15);
+  .add-habit-btn {
+    opacity: 0.6;
+    transition: var(--transition-standard);
+    background-color: transparent !important;
+    border: 1px solid rgba(255, 255, 255, 0.2) !important;
+    padding: var(--s-quarter) var(--s2);
+
+    &:hover {
+      opacity: 1;
+      background-color: var(--c-light-05) !important;
+      border: 1px solid var(--c-light-40) !important;
+    }
+
+    mat-icon {
+      margin-right: var(--s);
+    }
+
+    .mdc-button__label {
+      vertical-align: middle;
+      font-size: 13px;
+    }
   }
+}
 
-  @include lightTheme() {
-    border-bottom-color: rgba(0, 0, 0, 0.15);
+.disabled-section {
+  margin-top: var(--s);
+  padding: 0 var(--s-half);
+  width: 100%;
+}
+
+.disabled-section-header {
+  display: flex;
+  align-items: center;
+  gap: var(--s-half);
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+  opacity: 0.6;
+  padding: var(--s) 0;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.disabled-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.disabled-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--s-half) 0;
+}
+
+.disabled-item-info {
+  display: flex;
+  align-items: center;
+  gap: var(--s);
+  font-size: 13px;
+  opacity: 0.7;
+}
+
+.disabled-item-actions {
+  display: flex;
+  gap: var(--s-half);
+}
+
+.day-cell {
+  flex: 0 0 44px;
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+
+  @include mq(xs, max) {
+    flex: 0 0 32px;
   }
 
   &.is-disabled {

--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
@@ -1,8 +1,7 @@
 @use '../../../../styles/_globals.scss' as *;
 
 :host {
-  display: flex;
-  justify-content: center;
+  display: block;
   overflow-x: auto;
   padding: var(--s);
 }
@@ -10,9 +9,8 @@
 .habit-tracker-container {
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100%;
-  max-width: 800px;
-  margin: 0 auto;
 }
 
 .navigation-bar {
@@ -22,7 +20,7 @@
   flex-wrap: wrap;
   gap: 12px var(--s);
   margin-bottom: var(--s2);
-  padding: 0 var(--s-half);
+  width: 100%;
 
   @include mq(xs, max) {
     margin-bottom: 12px;
@@ -59,7 +57,6 @@
 
 .add-habit-btn {
   font-size: 13px;
-  margin-left: var(--s);
 
   mat-icon {
     margin-right: var(--s-half);
@@ -67,37 +64,34 @@
 }
 
 .habit-grid {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(120px, auto) repeat(7, 44px);
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto;
+
+  @include mq(xs, max) {
+    grid-template-columns: 40px repeat(7, 32px);
+  }
 }
 
 .header-row {
-  display: flex;
-  margin-bottom: var(--s-half);
-  align-items: flex-end;
+  display: contents;
 }
 
 .header-spacer {
-  flex: 0 0 120px;
-  width: 120px;
-
   @include mq(xs, max) {
-    flex: 0 0 40px;
     width: 40px;
   }
 }
 
 .day-header {
-  flex: 1 1 0px;
-  min-width: 30px;
-  max-width: 100px;
   text-align: center;
   font-size: 11px;
   opacity: 0.7;
+  padding-bottom: var(--s-half);
 
   @include mq(xs, max) {
-    min-width: 32px;
     font-size: 10px;
   }
 
@@ -117,27 +111,26 @@
 }
 
 .habit-row {
-  display: flex;
-  align-items: center;
-  padding: var(--s) 0;
-
-  border-bottom: 1px solid var(--c-dark-10);
-
-  @include darkTheme() {
-    border-bottom-color: rgba(255, 255, 255, 0.15);
-  }
-
-  @include lightTheme() {
-    border-bottom-color: rgba(0, 0, 0, 0.15);
-  }
+  display: contents;
 
   &.cdk-drag-preview {
+    display: flex;
+    align-items: center;
     box-sizing: border-box;
     border-radius: var(--card-border-radius);
+    background: var(--bg-lighter);
     box-shadow:
       0 5px 5px -3px var(--c-dark-20),
       0 8px 10px 1px rgba(0, 0, 0, 0.14),
       0 3px 14px 2px rgba(0, 0, 0, 0.12);
+
+    .habit-title {
+      flex: 0 0 200px;
+    }
+
+    .day-cell {
+      flex: 0 0 44px;
+    }
   }
 
   &.cdk-drag-placeholder {
@@ -150,25 +143,29 @@
 }
 
 .habit-title {
-  flex: 0 0 120px;
-  width: 120px;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  overflow: hidden;
-  cursor: pointer;
   gap: var(--s);
-  padding: 0 var(--s);
+  cursor: pointer;
+  padding: var(--s) var(--s);
+  border-bottom: 1px solid var(--c-dark-10);
+  overflow: hidden;
+
+  @include darkTheme() {
+    border-bottom-color: rgba(255, 255, 255, 0.15);
+  }
+
+  @include lightTheme() {
+    border-bottom-color: rgba(0, 0, 0, 0.15);
+  }
 
   &:hover {
     opacity: 0.7;
   }
 
   @include mq(xs, max) {
-    flex: 0 0 40px;
-    width: 40px;
     justify-content: center;
-    padding: 0;
+    padding: var(--s) 0;
   }
 
   .habit-icon {
@@ -229,92 +226,19 @@
   }
 }
 
-.footer-actions {
-  display: flex;
-  justify-content: center;
-  padding: var(--s4) var(--s2);
-
-  .add-habit-btn {
-    opacity: 0.6;
-    transition: var(--transition-standard);
-    background-color: transparent !important;
-    border: 1px solid rgba(255, 255, 255, 0.2) !important;
-    padding: var(--s-quarter) var(--s2);
-
-    &:hover {
-      opacity: 1;
-      background-color: var(--c-light-05) !important;
-      border: 1px solid var(--c-light-40) !important;
-    }
-
-    mat-icon {
-      margin-right: var(--s);
-    }
-
-    .mdc-button__label {
-      vertical-align: middle;
-      font-size: 13px;
-    }
-  }
-}
-
-.disabled-section {
-  margin-top: var(--s);
-  padding: 0 var(--s-half);
-}
-
-.disabled-section-header {
-  display: flex;
-  align-items: center;
-  gap: var(--s-half);
-  background: none;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  font-size: 13px;
-  opacity: 0.6;
-  padding: var(--s) 0;
-
-  &:hover {
-    opacity: 1;
-  }
-}
-
-.disabled-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.disabled-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--s-half) 0;
-}
-
-.disabled-item-info {
-  display: flex;
-  align-items: center;
-  gap: var(--s);
-  font-size: 13px;
-  opacity: 0.7;
-}
-
-.disabled-item-actions {
-  display: flex;
-  gap: var(--s-half);
-}
-
 .day-cell {
-  flex: 1 1 0px;
-  min-width: 30px;
-  max-width: 100px;
   display: flex;
   justify-content: center;
+  align-items: center;
   cursor: pointer;
+  border-bottom: 1px solid var(--c-dark-10);
 
-  @include mq(xs, max) {
-    min-width: 32px;
+  @include darkTheme() {
+    border-bottom-color: rgba(255, 255, 255, 0.15);
+  }
+
+  @include lightTheme() {
+    border-bottom-color: rgba(0, 0, 0, 0.15);
   }
 
   &.is-disabled {

--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
@@ -77,31 +77,43 @@
   min-width: 0; // Critical for flex children truncation
 }
 
-.header-row {
-  display: flex;
-  margin-bottom: var(--s-half);
-  align-items: flex-end;
-  gap: var(--s);
-}
+.header-row,
+.habit-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) repeat(7, 48px);
+  gap: var(--s-half);
+  width: 100%;
+  align-items: center;
 
-.header-spacer {
-  flex: 1 1 0px;
-  min-width: 0;
+  @media screen and (max-width: 1000px) {
+    grid-template-columns: minmax(0, 1fr) repeat(7, 40px);
+  }
+
+  @media screen and (max-width: 800px) {
+    grid-template-columns: minmax(0, 1fr) repeat(7, 32px);
+    gap: 4px;
+  }
 
   @include mq(xs, max) {
-    flex: 0 0 40px;
-    width: 40px;
+    grid-template-columns: 40px repeat(7, 1fr);
+    gap: 0;
   }
 }
 
+.header-row {
+  margin-bottom: var(--s-half);
+  align-items: flex-end;
+}
+
+.header-spacer {
+}
+
 .day-header {
-  flex: 0 0 48px;
   text-align: center;
   font-size: 11px;
   opacity: 0.7;
 
   @include mq(xs, max) {
-    flex: 0 0 32px;
     font-size: 10px;
   }
 
@@ -121,11 +133,7 @@
 }
 
 .habit-row {
-  display: flex;
-  align-items: center;
   padding: var(--s) 0;
-  gap: var(--s);
-
   border-bottom: 1px solid var(--c-dark-10);
 
   @include darkTheme() {
@@ -137,12 +145,24 @@
   }
 
   &.cdk-drag-preview {
+    display: flex; // Maintain flex for floating preview
+    align-items: center;
+    gap: var(--s-half);
     box-sizing: border-box;
     border-radius: var(--card-border-radius);
     box-shadow:
       0 5px 5px -3px var(--c-dark-20),
       0 8px 10px 1px rgba(0, 0, 0, 0.14),
       0 3px 14px 2px rgba(0, 0, 0, 0.12);
+
+    .habit-title {
+      flex: 1 1 0px;
+      min-width: 120px;
+    }
+
+    .day-cell {
+      flex: 0 0 48px;
+    }
   }
 
   &.cdk-drag-placeholder {
@@ -155,8 +175,6 @@
 }
 
 .habit-title {
-  flex: 1 1 0px;
-  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -312,14 +330,9 @@
 }
 
 .day-cell {
-  flex: 0 0 48px;
   display: flex;
   justify-content: center;
   cursor: pointer;
-
-  @include mq(xs, max) {
-    flex: 0 0 32px;
-  }
 
   &.is-disabled {
     cursor: default;

--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.scss
@@ -3,14 +3,16 @@
 :host {
   display: flex;
   justify-content: center;
-  overflow-x: auto;
   padding: var(--s);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .habit-tracker-container {
-  display: grid;
-  justify-content: center;
-  width: 100%;
+  display: flex;
+  flex-direction: column;
+  width: fit-content;
+  max-width: 100%;
   margin: 0 auto;
 }
 
@@ -23,6 +25,7 @@
   margin-bottom: var(--s2);
   padding: 0 var(--s-half);
   width: 100%;
+  box-sizing: border-box;
   min-width: 400px;
 
   @include mq(xs, max) {
@@ -71,17 +74,19 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 0; // Critical for flex children truncation
 }
 
 .header-row {
   display: flex;
   margin-bottom: var(--s-half);
   align-items: flex-end;
+  gap: var(--s);
 }
 
 .header-spacer {
   flex: 1 1 0px;
-  min-width: 120px;
+  min-width: 0;
 
   @include mq(xs, max) {
     flex: 0 0 40px;
@@ -90,7 +95,7 @@
 }
 
 .day-header {
-  flex: 0 0 44px;
+  flex: 0 0 48px;
   text-align: center;
   font-size: 11px;
   opacity: 0.7;
@@ -119,6 +124,7 @@
   display: flex;
   align-items: center;
   padding: var(--s) 0;
+  gap: var(--s);
 
   border-bottom: 1px solid var(--c-dark-10);
 
@@ -150,7 +156,7 @@
 
 .habit-title {
   flex: 1 1 0px;
-  min-width: 120px;
+  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -306,7 +312,7 @@
 }
 
 .day-cell {
-  flex: 0 0 44px;
+  flex: 0 0 48px;
   display: flex;
   justify-content: center;
   cursor: pointer;

--- a/src/app/pages/habit-page/habit-page.component.ts
+++ b/src/app/pages/habit-page/habit-page.component.ts
@@ -20,11 +20,8 @@ import { map } from 'rxjs/operators';
     `
       .page-wrapper {
         padding: 16px;
-        display: flex;
-        justify-content: center;
-      }
-      habit-tracker {
         width: 100%;
+        margin: 0 auto;
       }
     `,
   ],

--- a/src/app/pages/habit-page/habit-page.component.ts
+++ b/src/app/pages/habit-page/habit-page.component.ts
@@ -20,8 +20,11 @@ import { map } from 'rxjs/operators';
     `
       .page-wrapper {
         padding: 16px;
-        max-width: 1000px;
-        margin: 0 auto;
+        display: flex;
+        justify-content: center;
+      }
+      habit-tracker {
+        width: 100%;
       }
     `,
   ],


### PR DESCRIPTION
## Problem
Tackles #8215 

Currently, the habits page is constrained by a fixed maximum width, and the habit tracker columns are also strictly sized. As a result, longer habit names are unnecessarily truncated on wider screens. Conversely, if forced to full width, the layout loses its centered, compact feel for shorter habit names, and long text can overflow onto the habit day circles.

## Solution

This PR refactors the habit tracker to use a flexible CSS Grid layout:

* Removed the arbitrary `max-width: 1000px` from the `.page-wrapper` in `habit-page.component.ts`.
* Migrated `.habit-grid` to `display: grid` with `grid-template-columns: minmax(120px, auto) repeat(7, 44px)`.
* Set the grid's `width: fit-content` with a `max-width: 100%`. This perfectly centers the content and shrink-wraps it when titles are short.
* The habit name column naturally expands to accommodate the longest name, but gracefully falls back to text truncation (`text-overflow: ellipsis`) only when the grid hits the edge of the screen, preventing text from overflowing onto the day circles.

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Refactoring
* [x] Style (UI/UX)
* [ ] Documentation
* [ ] Other (please describe)

## Checklist

* [ ] I have included relevant changes to the documentation/[[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki)](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
* [x] I have run `npm run checkFile` on changed `.ts` / `.scss` files
* [ ] I have added tests for my changes (if applicable)
* [x] Existing tests still pass -> there is one error 
* [x] My commit messages follow the Angular format (`type(scope): description`)

## Additional
During push process, one error occured: 
```
1) should pass today day/month to translate when task has no due date
     DialogEditTaskRepeatCfgComponent quick setting labels use due date (issue #6766)
     Expected '9' to be '10'.
    at <Jasmine>
    at UserContext.<anonymous> (src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts:310:46)
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (node_modules/@babel/runtime/helpers/esm/asyncToGenerator.js:3:1)
```

however, this error. i adressed already in my PR #8227 