### PR TITLE
fix(sync): keep own sync settings on hydration replay

### DIFF
--- a/src/app/features/config/store/global-config.reducer.spec.ts
+++ b/src/app/features/config/store/global-config.reducer.spec.ts
@@ -909,6 +909,7 @@ describe('GlobalConfigReducer', () => {
         meta: {
           ...remoteAction.meta,
           isRemote: true,
+          isApplyingFromOtherClient: true,
         },
       };
 
@@ -950,7 +951,11 @@ describe('GlobalConfigReducer', () => {
       });
       const remoteReplayAction = {
         ...remoteAction,
-        meta: { ...remoteAction.meta, isRemote: true },
+        meta: {
+          ...remoteAction.meta,
+          isRemote: true,
+          isApplyingFromOtherClient: true,
+        },
       };
 
       const result = globalConfigReducer(oldState, remoteReplayAction);
@@ -960,6 +965,50 @@ describe('GlobalConfigReducer', () => {
           .withContext(`sync.${key} must survive remote section update`)
           .toBe(localSync[key]);
       }
+    });
+
+    // Regression (scheduled e2e #8077): replaying the device's OWN sync-setup op
+    // during hydration is stamped isRemote (to prevent re-logging) but is NOT a
+    // foreign update. If the crash snapshot predates the setup op, local
+    // state.sync.syncProvider is still null at replay time. Keying the local-only
+    // preservation off isRemote (the #8077 bug) overwrote the op's real provider
+    // with null and silently disabled sync. The bulk meta-reducer sets
+    // isApplyingFromOtherClient ONLY for ops authored by a DIFFERENT client, so
+    // own-op replay (isRemote without that flag) must apply the op faithfully.
+    it('applies own-op replay faithfully when isRemote is set without isApplyingFromOtherClient', () => {
+      const oldState: GlobalConfigState = {
+        ...initialGlobalConfigState,
+        sync: {
+          ...initialGlobalConfigState.sync,
+          // Mid-hydration: snapshot predates the setup op → provider not set yet.
+          syncProvider: null,
+          isEnabled: false,
+          isEncryptionEnabled: false,
+        },
+      };
+      const ownSetupAction = updateGlobalConfigSection({
+        sectionKey: 'sync',
+        sectionCfg: {
+          isEnabled: true,
+          syncProvider: SyncProviderId.WebDAV,
+          isEncryptionEnabled: true,
+          syncInterval: 300000,
+          isManualSyncOnly: true,
+        },
+      });
+      const ownReplayAction = {
+        ...ownSetupAction,
+        meta: { ...ownSetupAction.meta, isRemote: true },
+      };
+
+      const result = globalConfigReducer(oldState, ownReplayAction);
+
+      // The op's own values win — sync is NOT silently disabled.
+      expect(result.sync.syncProvider).toBe(SyncProviderId.WebDAV);
+      expect(result.sync.isEnabled).toBe(true);
+      expect(result.sync.isEncryptionEnabled).toBe(true);
+      expect(result.sync.syncInterval).toBe(300000);
+      expect(result.sync.isManualSyncOnly).toBe(true);
     });
 
     it('should update shared sync settings for remote sync section updates', () => {
@@ -974,6 +1023,7 @@ describe('GlobalConfigReducer', () => {
         meta: {
           ...remoteAction.meta,
           isRemote: true,
+          isApplyingFromOtherClient: true,
         },
       };
 

--- a/src/app/features/config/store/global-config.reducer.ts
+++ b/src/app/features/config/store/global-config.reducer.ts
@@ -238,10 +238,17 @@ export const globalConfigReducer = createReducer<GlobalConfigState>(
       ...normalizedSectionCfg,
     };
 
-    const isRemoteUpdate =
-      (action as { meta?: { isRemote?: boolean } }).meta?.isRemote === true;
+    // Preserve this device's local-only sync settings ONLY when the update came
+    // from ANOTHER client. `isRemote` is also true while replaying the device's
+    // OWN ops during hydration — keying off it there would overwrite the op's
+    // real (own) sync settings with whatever local state happens to be mid-replay
+    // (e.g. a null syncProvider when the crash snapshot predates the setup op),
+    // silently disabling sync. See bulkOperationsMetaReducer.
+    const isFromOtherClient =
+      (action as { meta?: { isApplyingFromOtherClient?: boolean } }).meta
+        ?.isApplyingFromOtherClient === true;
     const nextSection =
-      sectionKey === 'sync' && isRemoteUpdate
+      sectionKey === 'sync' && isFromOtherClient
         ? withLocalOnlySyncSettings(updatedSection as SyncConfig, state.sync)
         : updatedSection;
 

--- a/src/app/op-log/apply/bulk-hydration.action.ts
+++ b/src/app/op-log/apply/bulk-hydration.action.ts
@@ -15,10 +15,17 @@ import { Operation } from '../core/operation.types';
  * - Effects don't see individual actions (they only see this bulk action type)
  * - No need for LOCAL_ACTIONS filtering - effects naturally don't trigger
  * - Single store update = better performance
+ *
+ * `localClientId` is the id of THIS device. The bulk meta-reducer uses it to
+ * tell own-op replay (clientId === localClientId) apart from genuinely remote
+ * ops (another client) so that per-device "local-only" settings are preserved
+ * only when a remote client's op would otherwise overwrite them — never when
+ * replaying the device's own ops during hydration. See `bulkOperationsMetaReducer`
+ * and `withLocalOnlySyncSettings`.
  */
 export const bulkApplyOperations = createAction(
   '[OperationLog] Bulk Apply Operations',
-  props<{ operations: Operation[] }>(),
+  props<{ operations: Operation[]; localClientId?: string }>(),
 );
 
 /**

--- a/src/app/op-log/apply/bulk-hydration.meta-reducer.spec.ts
+++ b/src/app/op-log/apply/bulk-hydration.meta-reducer.spec.ts
@@ -1,6 +1,9 @@
 import { Action } from '@ngrx/store';
 import { bulkHydrationMetaReducer } from './bulk-hydration.meta-reducer';
-import { bulkApplyHydrationOperations } from './bulk-hydration.action';
+import {
+  bulkApplyHydrationOperations,
+  bulkApplyOperations,
+} from './bulk-hydration.action';
 import { ActionType, Operation, OpType } from '../core/operation.types';
 import { RootState } from '../../root-store/root-state';
 import { TASK_FEATURE_NAME } from '../../features/tasks/store/task.reducer';
@@ -300,6 +303,56 @@ describe('bulkHydrationMetaReducer', () => {
 
       const calledAction = reducerCalls[0].action as { meta?: { isRemote?: boolean } };
       expect(calledAction.meta?.isRemote).toBe(true);
+    });
+
+    it('should tag isApplyingFromOtherClient when op.clientId differs from localClientId', () => {
+      const reducer = bulkHydrationMetaReducer(mockReducer);
+      const state = createMockState();
+      const operation = createMockOperation({ clientId: 'otherClient' });
+      const action = bulkApplyOperations({
+        operations: [operation],
+        localClientId: 'thisClient',
+      });
+
+      reducer(state, action);
+
+      const calledAction = reducerCalls[0].action as {
+        meta?: { isApplyingFromOtherClient?: boolean };
+      };
+      expect(calledAction.meta?.isApplyingFromOtherClient).toBe(true);
+    });
+
+    it('should NOT tag isApplyingFromOtherClient for own-op replay (clientId === localClientId)', () => {
+      const reducer = bulkHydrationMetaReducer(mockReducer);
+      const state = createMockState();
+      const operation = createMockOperation({ clientId: 'thisClient' });
+      const action = bulkApplyOperations({
+        operations: [operation],
+        localClientId: 'thisClient',
+      });
+
+      reducer(state, action);
+
+      const calledAction = reducerCalls[0].action as {
+        meta?: { isApplyingFromOtherClient?: boolean };
+      };
+      expect(calledAction.meta?.isApplyingFromOtherClient).toBeUndefined();
+    });
+
+    it('should NOT tag isApplyingFromOtherClient when localClientId is unknown', () => {
+      const reducer = bulkHydrationMetaReducer(mockReducer);
+      const state = createMockState();
+      const operation = createMockOperation({ clientId: 'otherClient' });
+      // No localClientId on the action → cannot tell own from foreign; default to
+      // own-op semantics so we never clobber the device's own settings.
+      const action = bulkApplyOperations({ operations: [operation] });
+
+      reducer(state, action);
+
+      const calledAction = reducerCalls[0].action as {
+        meta?: { isApplyingFromOtherClient?: boolean };
+      };
+      expect(calledAction.meta?.isApplyingFromOtherClient).toBeUndefined();
     });
 
     it('should handle Create operations', () => {

--- a/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
+++ b/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
@@ -46,7 +46,9 @@ export const bulkOperationsMetaReducer = <T>(
 ): ActionReducer<T> => {
   return (state: T | undefined, action: Action): T => {
     if (action.type === bulkApplyOperations.type) {
-      const { operations } = action as ReturnType<typeof bulkApplyOperations>;
+      const { operations, localClientId } = action as ReturnType<
+        typeof bulkApplyOperations
+      >;
 
       // Pre-scan: collect entity IDs being archived or deleted in this batch.
       // LWW Update ops for these entities must be skipped to prevent
@@ -82,7 +84,29 @@ export const bulkOperationsMetaReducer = <T>(
               )
             : op;
           const opAction = convertOpToAction(opForApply);
-          currentState = reducer(currentState, opAction);
+          // Mark ops authored by a DIFFERENT client so reducers can preserve
+          // per-device "local-only" settings against remote overwrites — while
+          // replaying the device's OWN ops faithfully.
+          //
+          // When localClientId is unknown we leave the flag unset (own-op
+          // semantics: apply faithfully, don't preserve). In practice this only
+          // happens before the clientId cache is warm — i.e. a never-synced or
+          // cold-booting device. A device that actually has foreign ops to apply
+          // has already resolved its clientId (download/upload/vector-clock all
+          // require it), so genuine remote applies always carry it and stay
+          // protected. The unset fallback deliberately favours own-op fidelity:
+          // the alternative (blanket-preserve, the old `isRemote` gate) is what
+          // silently nulled the device's own syncProvider on replay. The
+          // residual risk — a foreign op adopting another device's provider/
+          // isEnabled/isEncryptionEnabled — needs a transient IndexedDB failure
+          // on a cold boot and is user-recoverable, strictly narrower than the
+          // own-settings data-loss this replaces.
+          const isApplyingFromOtherClient =
+            !!localClientId && op.clientId !== localClientId;
+          const finalAction = isApplyingFromOtherClient
+            ? { ...opAction, meta: { ...opAction.meta, isApplyingFromOtherClient: true } }
+            : opAction;
+          currentState = reducer(currentState, finalAction);
         }
         return currentState;
       });

--- a/src/app/op-log/apply/operation-applier.service.spec.ts
+++ b/src/app/op-log/apply/operation-applier.service.spec.ts
@@ -11,6 +11,7 @@ import { ArchiveOperationHandler } from './archive-operation-handler.service';
 import { HydrationStateService } from './hydration-state.service';
 import { remoteArchiveDataApplied } from '../../features/archive/store/archive.actions';
 import { bulkApplyOperations } from './bulk-hydration.action';
+import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 import { OperationLogEffects } from '../capture/operation-log.effects';
 
 describe('OperationApplierService', () => {
@@ -19,6 +20,7 @@ describe('OperationApplierService', () => {
   let mockArchiveOperationHandler: jasmine.SpyObj<ArchiveOperationHandler>;
   let mockHydrationState: jasmine.SpyObj<HydrationStateService>;
   let mockOperationLogEffects: jasmine.SpyObj<OperationLogEffects>;
+  let mockClientIdProvider: jasmine.SpyObj<ClientIdProvider>;
 
   const createMockOperation = (
     id: string,
@@ -53,9 +55,15 @@ describe('OperationApplierService', () => {
     mockOperationLogEffects = jasmine.createSpyObj('OperationLogEffects', [
       'processDeferredActions',
     ]);
+    mockClientIdProvider = jasmine.createSpyObj('ClientIdProvider', [
+      'loadClientId',
+      'getOrGenerateClientId',
+      'clearCache',
+    ]);
 
     mockArchiveOperationHandler.handleOperation.and.returnValue(Promise.resolve());
     mockOperationLogEffects.processDeferredActions.and.returnValue(Promise.resolve());
+    mockClientIdProvider.loadClientId.and.resolveTo('testClient');
 
     TestBed.configureTestingModule({
       providers: [
@@ -64,6 +72,7 @@ describe('OperationApplierService', () => {
         { provide: ArchiveOperationHandler, useValue: mockArchiveOperationHandler },
         { provide: HydrationStateService, useValue: mockHydrationState },
         { provide: OperationLogEffects, useValue: mockOperationLogEffects },
+        { provide: CLIENT_ID_PROVIDER, useValue: mockClientIdProvider },
       ],
     });
 
@@ -79,7 +88,7 @@ describe('OperationApplierService', () => {
 
       expect(result.appliedOps).toEqual([op]);
       expect(mockStore.dispatch).toHaveBeenCalledOnceWith(
-        bulkApplyOperations({ operations: [op] }),
+        bulkApplyOperations({ operations: [op], localClientId: 'testClient' }),
       );
     });
 
@@ -475,6 +484,9 @@ describe('OperationApplierService', () => {
       }) as typeof window.setTimeout);
 
       const applyPromise = service.applyOperations([op]);
+      // applyOperations awaits the (cached) clientId load before dispatching, so
+      // flush that one microtask before asserting the synchronous dispatch.
+      await Promise.resolve();
 
       expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
       expect(archiveCalls).toEqual([]);

--- a/src/app/op-log/apply/operation-applier.service.spec.ts
+++ b/src/app/op-log/apply/operation-applier.service.spec.ts
@@ -64,6 +64,7 @@ describe('OperationApplierService', () => {
     mockArchiveOperationHandler.handleOperation.and.returnValue(Promise.resolve());
     mockOperationLogEffects.processDeferredActions.and.returnValue(Promise.resolve());
     mockClientIdProvider.loadClientId.and.resolveTo('testClient');
+    mockClientIdProvider.getOrGenerateClientId.and.resolveTo('testClient');
 
     TestBed.configureTestingModule({
       providers: [

--- a/src/app/op-log/apply/operation-applier.service.spec.ts
+++ b/src/app/op-log/apply/operation-applier.service.spec.ts
@@ -64,7 +64,6 @@ describe('OperationApplierService', () => {
     mockArchiveOperationHandler.handleOperation.and.returnValue(Promise.resolve());
     mockOperationLogEffects.processDeferredActions.and.returnValue(Promise.resolve());
     mockClientIdProvider.loadClientId.and.resolveTo('testClient');
-    mockClientIdProvider.getOrGenerateClientId.and.resolveTo('testClient');
 
     TestBed.configureTestingModule({
       providers: [

--- a/src/app/op-log/apply/operation-applier.service.ts
+++ b/src/app/op-log/apply/operation-applier.service.ts
@@ -98,7 +98,9 @@ export class OperationApplierService implements OperationApplyPort<Operation> {
     // it throws rather than returning null on a transient IndexedDB failure, so
     // a foreign op can never slip through unprotected — the apply aborts and the
     // sync retries instead. It won't mint a fresh id here (this device, having
-    // ops to apply, already has one); both callers wrap this in try/catch.
+    // ops to apply, already has one); every call site tolerates a throw (the two
+    // sync paths wrap applyOperations in try/catch; the boot-time
+    // retryFailedRemoteOps catches per-op and leaves the op for the next launch).
     const localClientId = await this.clientIdProvider.getOrGenerateClientId();
 
     const result = await replayOperationBatch({

--- a/src/app/op-log/apply/operation-applier.service.ts
+++ b/src/app/op-log/apply/operation-applier.service.ts
@@ -16,6 +16,7 @@ import {
 import { HydrationStateService } from './hydration-state.service';
 import { remoteArchiveDataApplied } from '../../features/archive/store/archive.actions';
 import { bulkApplyOperations } from './bulk-hydration.action';
+import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
 import { OperationLogEffects } from '../capture/operation-log.effects';
 import { ApplyOperationsResult, ApplyOperationsOptions } from '../core/types/apply.types';
 
@@ -48,6 +49,7 @@ export class OperationApplierService implements OperationApplyPort<Operation> {
   private store: ActionDispatchPort<SyncActionLike> = inject(Store);
   private archiveOperationHandler = inject(ArchiveOperationHandler);
   private hydrationState = inject(HydrationStateService);
+  private clientIdProvider = inject(CLIENT_ID_PROVIDER);
   // Use Injector to avoid circular dependency: OperationLogEffects depends on services
   // that may depend on this service indirectly through the Store.
   private injector = inject(Injector);
@@ -86,11 +88,17 @@ export class OperationApplierService implements OperationApplyPort<Operation> {
       );
     }
 
+    // Identify THIS device so the bulk meta-reducer can tell own-op replay apart
+    // from genuinely remote ops (preserves per-device local-only sync settings
+    // only against another client's ops, never while replaying our own).
+    const localClientId = (await this.clientIdProvider.loadClientId()) ?? undefined;
+
     const result = await replayOperationBatch({
       ops,
       applyOptions: { isLocalHydration },
       dispatcher: this.store,
-      createBulkApplyAction: (operations) => bulkApplyOperations({ operations }),
+      createBulkApplyAction: (operations) =>
+        bulkApplyOperations({ operations, localClientId }),
       remoteApplyWindow: this.hydrationState,
       deferredLocalActions: {
         processDeferredActions: () =>

--- a/src/app/op-log/apply/operation-applier.service.ts
+++ b/src/app/op-log/apply/operation-applier.service.ts
@@ -91,7 +91,15 @@ export class OperationApplierService implements OperationApplyPort<Operation> {
     // Identify THIS device so the bulk meta-reducer can tell own-op replay apart
     // from genuinely remote ops (preserves per-device local-only sync settings
     // only against another client's ops, never while replaying our own).
-    const localClientId = (await this.clientIdProvider.loadClientId()) ?? undefined;
+    //
+    // This path applies ops during sync, where the clientId has always been
+    // resolved already (download/upload/vector-clocks need it), so the cached
+    // read returns instantly. Use getOrGenerateClientId (not loadClientId):
+    // it throws rather than returning null on a transient IndexedDB failure, so
+    // a foreign op can never slip through unprotected — the apply aborts and the
+    // sync retries instead. It won't mint a fresh id here (this device, having
+    // ops to apply, already has one); both callers wrap this in try/catch.
+    const localClientId = await this.clientIdProvider.getOrGenerateClientId();
 
     const result = await replayOperationBatch({
       ops,

--- a/src/app/op-log/apply/operation-applier.service.ts
+++ b/src/app/op-log/apply/operation-applier.service.ts
@@ -92,16 +92,17 @@ export class OperationApplierService implements OperationApplyPort<Operation> {
     // from genuinely remote ops (preserves per-device local-only sync settings
     // only against another client's ops, never while replaying our own).
     //
-    // This path applies ops during sync, where the clientId has always been
-    // resolved already (download/upload/vector-clocks need it), so the cached
-    // read returns instantly. Use getOrGenerateClientId (not loadClientId):
-    // it throws rather than returning null on a transient IndexedDB failure, so
-    // a foreign op can never slip through unprotected — the apply aborts and the
-    // sync retries instead. It won't mint a fresh id here (this device, having
-    // ops to apply, already has one); every call site tolerates a throw (the two
-    // sync paths wrap applyOperations in try/catch; the boot-time
-    // retryFailedRemoteOps catches per-op and leaves the op for the next launch).
-    const localClientId = await this.clientIdProvider.getOrGenerateClientId();
+    // Use loadClientId (lenient — returns null, never throws). Do NOT switch to
+    // getOrGenerateClientId to "fail safe": applyRemoteOperations appends the
+    // incoming ops as PENDING before calling this applier and only marks them
+    // applied/failed from the returned result, so a throw here would strand those
+    // appended ops — a same-session retry then skips them as duplicates. That is
+    // worse than the unprotected-foreign-op leak it would prevent. The leak is
+    // unreachable on this path anyway: applying remote ops means the clientId was
+    // already resolved (download/vector-clocks need it), so the cached read
+    // returns it. A null only happens off this path (cold-boot hydration), where
+    // the unset flag's own-op default is the safe direction. See meta-reducer.
+    const localClientId = (await this.clientIdProvider.loadClientId()) ?? undefined;
 
     const result = await replayOperationBatch({
       ops,

--- a/src/app/op-log/core/persistent-action.interface.ts
+++ b/src/app/op-log/core/persistent-action.interface.ts
@@ -8,6 +8,13 @@ export interface PersistentActionMeta {
   entityIds?: string[]; // For batch operations
   opType: OpType;
   isRemote?: boolean; // TRUE if from Sync (prevents re-logging)
+  // TRUE only when the op being applied was authored by a DIFFERENT client
+  // (set during bulk apply when op.clientId !== this device's clientId).
+  // Distinct from isRemote, which is also TRUE for replay of the device's OWN
+  // ops during hydration. Reducers that preserve per-device "local-only"
+  // settings (e.g. sync config) must key off THIS flag, not isRemote, so they
+  // don't clobber the device's own settings while replaying its own ops.
+  isApplyingFromOtherClient?: boolean;
   isBulk?: boolean; // TRUE for batch operations
 }
 

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -397,7 +397,10 @@ describe('OperationLogHydratorService', () => {
         expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
         // Tail ops are replayed via bulk dispatch for performance
         expect(mockStore.dispatch).toHaveBeenCalledWith(
-          bulkApplyHydrationOperations({ operations: tailOps.map((e) => e.op) }),
+          bulkApplyHydrationOperations({
+            operations: tailOps.map((e) => e.op),
+            localClientId: 'test-client',
+          }),
         );
         // Hydration state is managed around the dispatch
         expect(mockHydrationStateService.startApplyingRemoteOps).toHaveBeenCalled();
@@ -929,7 +932,10 @@ describe('OperationLogHydratorService', () => {
         expect(mockSchemaMigrationService.migrateOperations).toHaveBeenCalled();
         // Operations should be applied via bulk dispatch
         expect(mockStore.dispatch).toHaveBeenCalledWith(
-          bulkApplyHydrationOperations({ operations: migratedOps }),
+          bulkApplyHydrationOperations({
+            operations: migratedOps,
+            localClientId: 'test-client',
+          }),
         );
       });
 
@@ -1098,7 +1104,10 @@ describe('OperationLogHydratorService', () => {
         // Must replay the whole op-log from seq 0.
         expect(mockOpLogStore.getOpsAfterSeq).toHaveBeenCalledWith(0);
         expect(mockStore.dispatch).toHaveBeenCalledWith(
-          bulkApplyHydrationOperations({ operations: allOps.map((e) => e.op) }),
+          bulkApplyHydrationOperations({
+            operations: allOps.map((e) => e.op),
+            localClientId: 'test-client',
+          }),
         );
       });
 
@@ -1130,7 +1139,10 @@ describe('OperationLogHydratorService', () => {
 
         // Replay all ops via bulk dispatch for performance
         expect(mockStore.dispatch).toHaveBeenCalledWith(
-          bulkApplyHydrationOperations({ operations: allOps.map((e) => e.op) }),
+          bulkApplyHydrationOperations({
+            operations: allOps.map((e) => e.op),
+            localClientId: 'test-client',
+          }),
         );
         // Hydration state is managed around the dispatch
         expect(mockHydrationStateService.startApplyingRemoteOps).toHaveBeenCalled();

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -1416,35 +1416,6 @@ describe('OperationLogHydratorService', () => {
         jasmine.any(Number),
       );
     });
-
-    it('treats a THROWN applyOperations error as still-failed without aborting (boot resilience)', async () => {
-      const failedOp = createMockOperation('throwing-op');
-      const failedEntry: OperationLogEntry = {
-        seq: 7,
-        op: failedOp,
-        appliedAt: Date.now(),
-        source: 'remote',
-        applicationStatus: 'failed',
-        retryCount: 1,
-      };
-
-      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve([failedEntry]));
-      // Simulate getOrGenerateClientId rejecting inside applyOperations (transient
-      // IndexedDB read failure) — a throw, not a result.failedOp.
-      mockOperationApplierService.applyOperations.and.returnValue(
-        Promise.reject(new Error('clientId read failed')),
-      );
-
-      // Must not reject — a clientId hiccup during boot leaves the op for the
-      // next launch rather than aborting hydration.
-      await service.retryFailedRemoteOps();
-
-      expect(mockOpLogStore.markFailed).toHaveBeenCalledWith(
-        ['throwing-op'],
-        jasmine.any(Number),
-      );
-      expect(mockOpLogStore.markApplied).not.toHaveBeenCalled();
-    });
   });
 
   describe('IndexedDB open error handling', () => {

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -1416,6 +1416,35 @@ describe('OperationLogHydratorService', () => {
         jasmine.any(Number),
       );
     });
+
+    it('treats a THROWN applyOperations error as still-failed without aborting (boot resilience)', async () => {
+      const failedOp = createMockOperation('throwing-op');
+      const failedEntry: OperationLogEntry = {
+        seq: 7,
+        op: failedOp,
+        appliedAt: Date.now(),
+        source: 'remote',
+        applicationStatus: 'failed',
+        retryCount: 1,
+      };
+
+      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve([failedEntry]));
+      // Simulate getOrGenerateClientId rejecting inside applyOperations (transient
+      // IndexedDB read failure) — a throw, not a result.failedOp.
+      mockOperationApplierService.applyOperations.and.returnValue(
+        Promise.reject(new Error('clientId read failed')),
+      );
+
+      // Must not reject — a clientId hiccup during boot leaves the op for the
+      // next launch rather than aborting hydration.
+      await service.retryFailedRemoteOps();
+
+      expect(mockOpLogStore.markFailed).toHaveBeenCalledWith(
+        ['throwing-op'],
+        jasmine.any(Number),
+      );
+      expect(mockOpLogStore.markApplied).not.toHaveBeenCalled();
+    });
   });
 
   describe('IndexedDB open error handling', () => {

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -251,8 +251,12 @@ export class OperationLogHydratorService {
             // PERF: Use bulk dispatch to apply all operations in a single NgRx update.
             // This reduces 500 dispatches to 1, dramatically improving startup performance.
             // The bulkHydrationMetaReducer iterates through ops and applies each action.
+            const localClientId =
+              (await this.clientIdProvider.loadClientId()) ?? undefined;
             this.hydrationStateService.startApplyingRemoteOps();
-            this.store.dispatch(bulkApplyOperations({ operations: opsToReplay }));
+            this.store.dispatch(
+              bulkApplyOperations({ operations: opsToReplay, localClientId }),
+            );
             this.hydrationStateService.endApplyingRemoteOps();
 
             // Merge replayed ops' clocks into local clock
@@ -328,8 +332,11 @@ export class OperationLogHydratorService {
           // PERF: Use bulk dispatch to apply all operations in a single NgRx update.
           // This reduces 500 dispatches to 1, dramatically improving startup performance.
           // The bulkHydrationMetaReducer iterates through ops and applies each action.
+          const localClientId = (await this.clientIdProvider.loadClientId()) ?? undefined;
           this.hydrationStateService.startApplyingRemoteOps();
-          this.store.dispatch(bulkApplyOperations({ operations: opsToReplay }));
+          this.store.dispatch(
+            bulkApplyOperations({ operations: opsToReplay, localClientId }),
+          );
           this.hydrationStateService.endApplyingRemoteOps();
 
           // Merge replayed ops' clocks into local clock

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -574,18 +574,7 @@ export class OperationLogHydratorService {
     const stillFailedOpIds: string[] = [];
 
     for (const entry of failedOps) {
-      // applyOperations can THROW here (e.g. getOrGenerateClientId on a transient
-      // IndexedDB read failure), not just return result.failedOp. This runs on
-      // the boot path, so swallow it as "still failed" — a clientId hiccup must
-      // leave the op for the next launch, never abort hydration.
-      let result: Awaited<ReturnType<OperationApplierService['applyOperations']>>;
-      try {
-        result = await this.operationApplierService.applyOperations([entry.op]);
-      } catch (e) {
-        OpLog.warn(`OperationLogHydratorService: Error retrying op ${entry.op.id}`, e);
-        stillFailedOpIds.push(entry.op.id);
-        continue;
-      }
+      const result = await this.operationApplierService.applyOperations([entry.op]);
       if (result.failedOp) {
         // SyncStateCorruptedError or any other error means the op still can't be applied
         OpLog.warn(

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -251,6 +251,11 @@ export class OperationLogHydratorService {
             // PERF: Use bulk dispatch to apply all operations in a single NgRx update.
             // This reduces 500 dispatches to 1, dramatically improving startup performance.
             // The bulkHydrationMetaReducer iterates through ops and applies each action.
+            // Lenient (no throw) so a cold-boot IndexedDB hiccup can't block
+            // startup. A null clientId leaves the bulk-apply flag unset, which
+            // defaults to own-op semantics (apply faithfully) — the safe
+            // direction for the common case (replaying THIS device's own ops).
+            // See bulkOperationsMetaReducer.
             const localClientId =
               (await this.clientIdProvider.loadClientId()) ?? undefined;
             this.hydrationStateService.startApplyingRemoteOps();
@@ -332,6 +337,11 @@ export class OperationLogHydratorService {
           // PERF: Use bulk dispatch to apply all operations in a single NgRx update.
           // This reduces 500 dispatches to 1, dramatically improving startup performance.
           // The bulkHydrationMetaReducer iterates through ops and applies each action.
+          // Lenient (no throw) so a cold-boot IndexedDB hiccup can't block
+          // startup. A null clientId leaves the bulk-apply flag unset, which
+          // defaults to own-op semantics (apply faithfully) — the safe direction
+          // for the common case (replaying THIS device's own ops). See
+          // bulkOperationsMetaReducer.
           const localClientId = (await this.clientIdProvider.loadClientId()) ?? undefined;
           this.hydrationStateService.startApplyingRemoteOps();
           this.store.dispatch(

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -574,7 +574,18 @@ export class OperationLogHydratorService {
     const stillFailedOpIds: string[] = [];
 
     for (const entry of failedOps) {
-      const result = await this.operationApplierService.applyOperations([entry.op]);
+      // applyOperations can THROW here (e.g. getOrGenerateClientId on a transient
+      // IndexedDB read failure), not just return result.failedOp. This runs on
+      // the boot path, so swallow it as "still failed" — a clientId hiccup must
+      // leave the op for the next launch, never abort hydration.
+      let result: Awaited<ReturnType<OperationApplierService['applyOperations']>>;
+      try {
+        result = await this.operationApplierService.applyOperations([entry.op]);
+      } catch (e) {
+        OpLog.warn(`OperationLogHydratorService: Error retrying op ${entry.op.id}`, e);
+        stillFailedOpIds.push(entry.op.id);
+        continue;
+      }
       if (result.failedOp) {
         // SyncStateCorruptedError or any other error means the op still can't be applied
         OpLog.warn(

--- a/src/app/op-log/testing/integration/sync-local-only-hydration.integration.spec.ts
+++ b/src/app/op-log/testing/integration/sync-local-only-hydration.integration.spec.ts
@@ -50,7 +50,9 @@ describe('Sync local-only settings — hydration replay integration (#8077)', ()
     actionType: ActionType.GLOBAL_CONFIG_UPDATE_SECTION,
     opType: OpType.Update,
     entityType: 'GLOBAL_CONFIG' as EntityType,
-    entityId: 'GLOBAL_CONFIG',
+    // Real updateGlobalConfigSection uses the section key as the entity id
+    // (see global-config.actions.ts), so match that here.
+    entityId: 'sync',
     payload: {
       actionPayload: { sectionKey: 'sync', sectionCfg },
       entityChanges: [],

--- a/src/app/op-log/testing/integration/sync-local-only-hydration.integration.spec.ts
+++ b/src/app/op-log/testing/integration/sync-local-only-hydration.integration.spec.ts
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/**
+ * Integration test for the #8077 own-op-replay regression.
+ *
+ * Drives the REAL apply chain — `bulkApplyOperations` (carrying localClientId)
+ * → `bulkOperationsMetaReducer` (which tags `isApplyingFromOtherClient`) →
+ * `globalConfigReducer` — to pin both directions of per-device local-only sync
+ * settings:
+ *
+ *  1. Replaying the device's OWN sync-config op during hydration applies it
+ *     faithfully, even when the crash snapshot predates the op (local
+ *     `syncProvider` is still null mid-replay). Regressing this (keying
+ *     preservation off `isRemote`) silently nulled the provider and disabled
+ *     sync — the scheduled-e2e failures (webdav-encryption-disable,
+ *     supersync-multi-tab) this fixes.
+ *  2. A genuinely FOREIGN client's sync-config op still preserves this device's
+ *     local-only settings while applying truly shared ones.
+ *
+ * Unlike the reducer unit test (which hand-builds the tagged action), this
+ * exercises the actual wiring the fix added: the op→action conversion, the
+ * clientId-based tagging in the meta-reducer, and the reducer gate.
+ */
+import { Action, ActionReducer } from '@ngrx/store';
+import { bulkOperationsMetaReducer } from '../../apply/bulk-hydration.meta-reducer';
+import { bulkApplyOperations } from '../../apply/bulk-hydration.action';
+import { ActionType, EntityType, Operation, OpType } from '../../core/operation.types';
+import {
+  globalConfigReducer,
+  initialGlobalConfigState,
+} from '../../../features/config/store/global-config.reducer';
+import {
+  GlobalConfigState,
+  SyncConfig,
+} from '../../../features/config/global-config.model';
+import { SyncProviderId } from '../../sync-providers/provider.const';
+
+describe('Sync local-only settings — hydration replay integration (#8077)', () => {
+  const composedReducer = bulkOperationsMetaReducer(globalConfigReducer) as ActionReducer<
+    GlobalConfigState,
+    Action
+  >;
+
+  // Build a real GLOBAL_CONFIG_UPDATE_SECTION(sync) op, matching the on-the-wire
+  // shape captured by operation-log.effects (actionPayload + empty entityChanges).
+  const createSyncSectionOp = (
+    clientId: string,
+    sectionCfg: Partial<SyncConfig>,
+  ): Operation => ({
+    id: `op-${clientId}`,
+    actionType: ActionType.GLOBAL_CONFIG_UPDATE_SECTION,
+    opType: OpType.Update,
+    entityType: 'GLOBAL_CONFIG' as EntityType,
+    entityId: 'GLOBAL_CONFIG',
+    payload: {
+      actionPayload: { sectionKey: 'sync', sectionCfg },
+      entityChanges: [],
+    },
+    clientId,
+    vectorClock: { [clientId]: 1 },
+    timestamp: 1_700_000_000_000,
+    schemaVersion: 1,
+  });
+
+  it('applies the device own sync-setup op faithfully during hydration replay', () => {
+    // Mid-hydration: the crash snapshot predates the sync-setup op, so the
+    // provider is not set yet in the state we replay onto.
+    const preSetupState: GlobalConfigState = {
+      ...initialGlobalConfigState,
+      sync: {
+        ...initialGlobalConfigState.sync,
+        syncProvider: null,
+        isEnabled: false,
+        isEncryptionEnabled: false,
+      },
+    };
+
+    const ownClientId = 'device-A';
+    const ownSetupOp = createSyncSectionOp(ownClientId, {
+      isEnabled: true,
+      syncProvider: SyncProviderId.WebDAV,
+      isEncryptionEnabled: true,
+      syncInterval: 300000,
+      isManualSyncOnly: true,
+    });
+
+    const result = composedReducer(
+      preSetupState,
+      bulkApplyOperations({ operations: [ownSetupOp], localClientId: ownClientId }),
+    );
+
+    // The op's own values win — sync is configured, not silently disabled.
+    expect(result.sync.syncProvider).toBe(SyncProviderId.WebDAV);
+    expect(result.sync.isEnabled).toBe(true);
+    expect(result.sync.isEncryptionEnabled).toBe(true);
+    expect(result.sync.syncInterval).toBe(300000);
+    expect(result.sync.isManualSyncOnly).toBe(true);
+  });
+
+  it("preserves this device's local-only settings against a foreign client op", () => {
+    const localState: GlobalConfigState = {
+      ...initialGlobalConfigState,
+      sync: {
+        ...initialGlobalConfigState.sync,
+        syncProvider: SyncProviderId.WebDAV,
+        isEnabled: true,
+        isEncryptionEnabled: true,
+        syncInterval: 300000,
+        isManualSyncOnly: true,
+        isCompressionEnabled: false,
+      },
+    };
+
+    const foreignOp = createSyncSectionOp('device-B', {
+      // local-only keys — must NOT be adopted from another device
+      syncProvider: SyncProviderId.Dropbox,
+      isEnabled: false,
+      isEncryptionEnabled: false,
+      syncInterval: 60000,
+      isManualSyncOnly: false,
+      // genuinely shared key — must sync
+      isCompressionEnabled: true,
+    });
+
+    const result = composedReducer(
+      localState,
+      bulkApplyOperations({ operations: [foreignOp], localClientId: 'device-A' }),
+    );
+
+    // Local-only device/schedule settings are preserved...
+    expect(result.sync.syncProvider).toBe(SyncProviderId.WebDAV);
+    expect(result.sync.isEnabled).toBe(true);
+    expect(result.sync.isEncryptionEnabled).toBe(true);
+    expect(result.sync.syncInterval).toBe(300000);
+    expect(result.sync.isManualSyncOnly).toBe(true);
+    // ...while genuinely shared settings still sync.
+    expect(result.sync.isCompressionEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The scheduled E2E suite has been red on `master` for several consecutive runs, always on the same two sync tests:

- `webdav-encryption-disable.spec.ts:39 › should disable encryption and allow unencrypted sync`
- `supersync-multi-tab.spec.ts:46 › Two tabs sharing IndexedDB converge with external client`

Both fail the same way: after a reload (WebDAV) or after a sync settles (multi-tab), a pending op never clears, so the app never reaches the "fully synced" UI state (`hasNoPendingOps()` stays false / `unsyncedCount` stays ≥1) and the test times out. Last green commit was `cdadc947b4`; first red was `c19365908a` = #8077.

## Root cause

PR **#8077** (`fix(sync): keep schedule settings local`) preserves per-device local-only sync settings whenever an `updateGlobalConfigSection(sync)` op carries `meta.isRemote`:

```ts
const isRemoteUpdate = action.meta?.isRemote === true;
const nextSection = sectionKey === 'sync' && isRemoteUpdate
  ? withLocalOnlySyncSettings(updatedSection, state.sync)  // local values win
  : updatedSection;
```

But `convertOpToAction` stamps `meta.isRemote: true` on **every** replayed op (to prevent re-logging during replay), and op-log hydration replays the device's **own** tail ops through the same reducer path (`bulkOperationsMetaReducer` → `convertOpToAction` → reducer). So replaying the device's own sync-setup op during hydration is misclassified as "remote": `withLocalOnlySyncSettings` overwrites the op's real `syncProvider`/`isEnabled`/`isEncryptionEnabled` with the *current local* state — which is still `null`/default when the crash-safety snapshot predates the setup op (i.e. right after setting up or changing sync, then reloading).

Result in production: `syncProvider` becomes `null`, `OperationLogUploadService.uploadPendingOps` early-returns at the `\!syncProvider` guard, pending ops never upload, and the sync indicator never reaches "synced" — and persists across reloads (the null is re-baked into the next snapshot) until the user manually reconfigures sync.

The #8077/#8235 specs only covered remote ops from a *different* client, never own-op hydration replay, so this slipped through.

## Fix

Discriminate by **op origin**, not `isRemote`:

- `bulkApplyOperations` now carries `localClientId`.
- `bulkOperationsMetaReducer` tags each converted action with `meta.isApplyingFromOtherClient` when `op.clientId \!== localClientId`.
- The sync-config reducer preserves local-only settings only when `isApplyingFromOtherClient` is set — so own-op replay applies faithfully, while genuine remote ops from other clients are still protected.
- `localClientId` is threaded from the hydrator (2 dispatch sites) and the applier (`OperationApplierService` now injects `CLIENT_ID_PROVIDER`).

Confirmed that core dispatches state changes **only** via `createBulkApplyAction` → `bulkOperationsMetaReducer` (`replay-coordinator.ts:115`); `operationToAction` is used solely for archive side-effects, so tagging in the meta-reducer is complete.

When `localClientId` is unknown the flag is left unset (own-op semantics). In practice this only happens before the clientId cache is warm (never-synced / cold boot); any device that actually has foreign ops to apply has already resolved its clientId, so genuine remote applies always carry it and stay protected.

## Tests

- New regression test: own-op replay (`isRemote` without `isApplyingFromOtherClient`) applies the op's sync settings faithfully even when local `syncProvider` is `null` mid-replay.
- New meta-reducer tests: tags `isApplyingFromOtherClient` for foreign ops, not for own-op replay, and not when `localClientId` is unknown.
- Updated the existing #8077/#8235 "remote sync section update" tests to carry both `isRemote` and `isApplyingFromOtherClient` (the real shape of a foreign-client action).
- Green: `global-config.reducer` (72), `bulk-hydration.meta-reducer` (37), `operation-applier.service` (36), `operation-log-hydrator.service` (60), plus bulk-hydration integration (5) and capture effects (36). `checkFile` clean on all changed files.

## Risk / sync-correctness notes

- **Replay-deterministic:** `op.clientId` is immutable and `localClientId` is stable, so classification is consistent per device across replays. Different devices correctly classify the same op as own vs. foreign — which is the intended per-device semantics for local-only settings.
- Scope limited to the `updateGlobalConfigSection` branch (the #8077 regression). The separate `loadAllData`/full-state preservation path is untouched.
- **Not yet verified end-to-end** against the docker-based WebDAV/SuperSync E2E (couldn't run those locally); relies on CI to confirm the two failing specs go green.

Reviewed via a 6-agent parallel review (correctness/security/architecture/alternatives/performance/simplicity): consensus that the origin/`clientId` discriminator is the correct mechanism and the simpler alternatives are incorrect or worse.