### PR TITLE
style(calendar): use dashed outline for hover on focused cells

### DIFF
--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -16,14 +16,21 @@
       // Keyboard nav hides the cursor, so suppress the stale mouse :hover
       // outline/background — only the keyboard-focused cell should be marked.
       // The .mat-calendar ancestor is included purely to outweigh the global
-      // dashed-hover rule in _overwrite-material.scss.
-      .mat-calendar:not(.no-hover-effects)
-        .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover:not(:focus)
-        > .mat-calendar-body-cell-content {
-        outline: none !important;
+      // hover rules in _overwrite-material.scss.
+      .mat-calendar:not(.no-hover-effects) {
+        .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
+          > .mat-calendar-body-cell-content {
+          outline: none !important;
 
-        &:not(.mat-calendar-body-selected) {
-          background-color: transparent !important;
+          &:not(.mat-calendar-body-selected) {
+            background-color: transparent !important;
+          }
+        }
+
+        // Ensure the focused cell is always marked with a solid outline.
+        .mat-calendar-body-cell:not(.mat-calendar-body-disabled):focus
+          > .mat-calendar-body-cell-content {
+          outline: 2px solid color-mix(in srgb, var(--c-accent) 80%, transparent) !important;
         }
       }
     }

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -493,7 +493,7 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
     outline: 2px solid color-mix(in srgb, var(--c-accent) 80%, transparent) !important;
   }
 
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover:not(:focus)
+  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover
     > .mat-calendar-body-cell-content {
     outline: 2px dashed color-mix(in srgb, var(--c-accent) 80%, transparent) !important;
   }


### PR DESCRIPTION
@beerkumquatpome https://github.com/super-productivity/super-productivity/pull/8227#issuecomment-4670211209

Updates calendar cell hover behavior to use a dashed outline even if the cell is already focused. This provides clearer visual feedback for intentional mouse hovers over the active selection.

Ensures keyboard navigation remains solid by explicitly suppressing hover outlines in DateTimePickerComponent when sp-hide-cursor is active, preventing a stale mouse position from causing a dashed outline during keyboard use.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
