### PR TITLE
test(schedule): mock CalendarEventActionsService in locale spec

### DIFF
--- a/src/app/features/schedule/schedule/schedule-locale-ng0701.spec.ts
+++ b/src/app/features/schedule/schedule/schedule-locale-ng0701.spec.ts
@@ -8,6 +8,7 @@ import { DateAdapter } from '@angular/material/core';
 import { MatDialog } from '@angular/material/dialog';
 
 import { ScheduleComponent } from './schedule.component';
+import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
 import { TaskService } from '../../tasks/task.service';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
 import { ScheduleService } from '../schedule.service';
@@ -109,6 +110,22 @@ describe('issue #7383 — NG0701 race on /schedule', () => {
           { provide: LayoutService, useValue: mockLayoutService },
           { provide: ScheduleService, useValue: mockScheduleService },
           { provide: MatDialog, useValue: jasmine.createSpyObj('MatDialog', ['open']) },
+          // schedule-week/schedule-event eagerly inject this service; without a mock
+          // the deferred CD pass after the test hits NG0201 (missing ScannedActionsSubject)
+          // and the async error kills the whole Karma session.
+          {
+            provide: CalendarEventActionsService,
+            useValue: jasmine.createSpyObj('CalendarEventActionsService', [
+              'hasEventUrl',
+              'isPluginEvent',
+              'canMoveEvent',
+              'openEventLink',
+              'reschedule',
+              'createAsTask',
+              'hideForever',
+              'deleteEvent',
+            ]),
+          },
           {
             provide: GlobalTrackingIntervalService,
             useValue: mockGlobalTrackingIntervalService,


### PR DESCRIPTION
## Problem

Since #7965, `schedule-week`/`schedule-event` eagerly inject `CalendarEventActionsService`. The NG0701 locale regression spec (`schedule-locale-ng0701.spec.ts`) creates a `ScheduleComponent` fixture without providing that service. The deferred change-detection pass after the test renders the template, hits the unresolvable provider chain (`CalendarEventActionsService → IssueService → … → Actions → ScannedActionsSubject`), and throws NG0201 as an async **afterAll** error — which disconnects Chrome and kills the entire Karma session.

**This currently fails the Tests job on every PR** (reproduced on #8225 and the `calendar_adjust_outline` style-only PR; master itself never runs the full Tests workflow on push, so it went unnoticed at merge time).

## Fix

Provide the same `CalendarEventActionsService` spy that #7965 added to the sibling `schedule.component.spec.ts` (it updated that spec but missed this one).

## Verification

- Before: `npm run test:file src/app/features/schedule/schedule/schedule-locale-ng0701.spec.ts` → `An error was thrown in afterAll … NG0201` → Chrome disconnect (1 of 48 executed).
- After: 48/48 SUCCESS, no afterAll error.
- checkFile clean.