### PR TITLE
feat(tasks): costumizable reminder 

### DIFF
--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -265,7 +265,7 @@ export interface Task {
   doneOn?: number | null;
   attachments?: any[];
   remindAt?: number | null;
-  remindAtTime?: number | null;
+  remindAtTime?: string | null;
   remindAtDay?: string | null;
   dueDay?: string | null;
   dueWithTime?: number | null;

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -265,6 +265,8 @@ export interface Task {
   doneOn?: number | null;
   attachments?: any[];
   remindAt?: number | null;
+  remindAtTime?: number | null;
+  remindAtDay?: string | null;
   dueDay?: string | null;
   dueWithTime?: number | null;
   repeatCfgId?: string | null;

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task-select-due-only.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task-select-due-only.spec.ts
@@ -129,6 +129,8 @@ describe('DialogScheduleTaskComponent - Select Due Only Mode', () => {
         date: testDate,
         time: testTime,
         remindOption: TaskReminderOptionId.AtStart,
+        reminderTime: null,
+        reminderDate: null,
       });
       expect(taskServiceSpy.scheduleTask).not.toHaveBeenCalled();
     });
@@ -145,6 +147,8 @@ describe('DialogScheduleTaskComponent - Select Due Only Mode', () => {
         date: testDate,
         time: null,
         remindOption: TaskReminderOptionId.AtStart,
+        reminderTime: null,
+        reminderDate: null,
       });
     });
 

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
@@ -73,21 +73,37 @@
     </mat-form-field>
 
     @if (selectedTime) {
-      <mat-form-field [@expandFade]>
-        <mat-icon matPrefix>alarm</mat-icon>
-        <mat-label>{{ T.F.TASK.D_SCHEDULE_TASK.REMIND_AT | translate }}</mat-label>
-        <mat-select
-          [(ngModel)]="selectedReminderCfgId"
-          name="type"
-          required="true"
-        >
-          @for (remindOption of remindAvailableOptions; track remindOption.value) {
-            <mat-option [value]="remindOption.value">
-              {{ remindOption.label | translate }}
-            </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+      <div
+        [@expandFade]
+        class="reminder-datetime-wrapper"
+      >
+        <mat-form-field class="example-full-width">
+          <mat-label
+            >{{ T.F.TASK.D_SCHEDULE_TASK.REMIND_AT | translate }}
+            {{ T.F.TASK.D_SELECT_DATE_AND_TIME.TIME | translate }}</mat-label
+          >
+          <mat-icon matPrefix>alarm</mat-icon>
+          <input
+            type="time"
+            [(ngModel)]="selectedReminderTime"
+            step="60"
+            matInput
+          />
+        </mat-form-field>
+
+        <mat-form-field class="example-full-width">
+          <mat-label
+            >{{ T.F.TASK.D_SCHEDULE_TASK.REMIND_AT | translate }}
+            {{ T.F.TASK.D_SELECT_DATE_AND_TIME.DATE | translate }}</mat-label
+          >
+          <mat-icon matPrefix>alarm</mat-icon>
+          <input
+            type="date"
+            [(ngModel)]="selectedReminderDate"
+            matInput
+          />
+        </mat-form-field>
+      </div>
     }
 
     @if (

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
@@ -73,6 +73,24 @@
     </mat-form-field>
 
     @if (selectedTime) {
+      <mat-form-field [@expandFade]>
+        <mat-icon matPrefix>alarm</mat-icon>
+        <mat-label>{{ T.F.TASK.D_SCHEDULE_TASK.REMIND_AT | translate }}</mat-label>
+        <mat-select
+          [(ngModel)]="selectedReminderCfgId"
+          name="type"
+          required="true"
+        >
+          @for (remindOption of remindAvailableOptions; track remindOption.value) {
+            <mat-option [value]="remindOption.value">
+              {{ remindOption.label | translate }}
+            </mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+
+    @if (selectedTime) {
       <div
         [@expandFade]
         class="reminder-datetime-wrapper"
@@ -88,7 +106,17 @@
             [(ngModel)]="selectedReminderTime"
             step="60"
             matInput
+            (keydown)="onReminderTimeKeyDown($event)"
           />
+          @if (selectedReminderTime) {
+            <mat-icon
+              class="time-clear-btn"
+              matSuffix
+              (click)="onReminderTimeClear($event)"
+            >
+              close
+            </mat-icon>
+          }
         </mat-form-field>
 
         <mat-form-field class="example-full-width">
@@ -101,7 +129,17 @@
             type="date"
             [(ngModel)]="selectedReminderDate"
             matInput
+            (keydown)="onReminderDateKeyDown($event)"
           />
+          @if (selectedReminderDate) {
+            <mat-icon
+              class="time-clear-btn"
+              matSuffix
+              (click)="onReminderDateClear($event)"
+            >
+              close
+            </mat-icon>
+          }
         </mat-form-field>
       </div>
     }

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
@@ -272,6 +272,7 @@ describe('DialogScheduleTaskComponent', () => {
         expectedDate.getTime(),
         TaskReminderOptionId.AtStart,
         false,
+        false,
       );
     });
 

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
@@ -270,7 +270,9 @@ describe('DialogScheduleTaskComponent', () => {
           subTaskIds: [],
         }),
         expectedDate.getTime(),
-        TaskReminderOptionId.AtStart,
+        jasmine.any(String),
+        null,
+        null,
         false,
         false,
       );
@@ -497,6 +499,66 @@ describe('DialogScheduleTaskComponent', () => {
       expect(selectedDate.getMonth()).toBe(originalDate.getMonth());
       expect(selectedDate.getDate()).toBe(originalDate.getDate());
       expect(component.selectedTime).toBe('14:45');
+    });
+  });
+
+  describe('ngAfterViewInit - reminder initialization', () => {
+    it('should initialize selectedReminderTime and selectedReminderDate from remindAtTime and remindAtDay', async () => {
+      const mockTask = {
+        id: 'taskWithReminder',
+        title: 'Task With Reminder',
+        tagIds: [] as string[],
+        projectId: 'DEFAULT',
+        timeSpentOnDay: {},
+        attachments: [],
+        timeEstimate: 0,
+        timeSpent: 0,
+        isDone: false,
+        created: Date.now(),
+        subTaskIds: [],
+        dueWithTime: new Date(2025, 5, 15, 17, 0, 0).getTime(),
+        remindAtTime: '14:30',
+        remindAtDay: '2025-06-15',
+      } as unknown as TaskCopy;
+
+      component.data = { task: mockTask };
+      component.task = mockTask;
+      fixture.detectChanges();
+
+      await component.ngAfterViewInit();
+
+      expect(component.selectedReminderTime).toBe('14:30');
+      expect(component.selectedReminderDate).toBe('2025-06-15');
+    });
+
+    it('should call scheduleTask with selectedReminderCfgId when no specific reminder is set', async () => {
+      component.task = {
+        id: 'task123',
+        title: 'Test Task',
+        tagIds: [] as string[],
+        projectId: 'DEFAULT',
+        timeSpentOnDay: {},
+        attachments: [],
+        timeEstimate: 0,
+        timeSpent: 0,
+        isDone: false,
+        created: 1640995200000,
+        subTaskIds: [],
+      } as TaskCopy;
+      component.selectedDate = new Date(2025, 5, 15);
+      component.selectedTime = '17:00';
+
+      await component.submit();
+
+      expect(taskServiceSpy.scheduleTask).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        jasmine.any(Number),
+        jasmine.any(String),
+        null,
+        null,
+        false,
+        false,
+      );
     });
   });
 });

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -141,9 +141,7 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
 
   async ngAfterViewInit(): Promise<void> {
     // Handle case when task is provided
-    Log.log(this.data);
     if (this.data.task) {
-      Log.log('hi');
       if (this.data.task.remindAt) {
         if (this.data.task.dueWithTime) {
           this.selectedReminderCfgId = millisecondsDiffToRemindOption(
@@ -157,6 +155,7 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
         this.selectedReminderCfgId = TaskReminderOptionId.DoNotRemind;
       }
 
+      Log.log('BYE', this.data.task.dueWithTime, this.selectedTime);
       if (this.data.task.dueWithTime) {
         // dueWithTime is a UTC timestamp - Date constructor handles timezone conversion automatically
         // Do NOT add timezone offset here as it would double-apply the conversion (fixes #5515)
@@ -176,15 +175,11 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
           ? dateStrToUtcDate(this.plannedDayForTask)
           : null;
       }
-      Log.log('hi2');
+      Log.log('HIIII', this.data.task.remindAtTime, this.selectedReminderTime);
+      Log.log('HIIII2', this.data.task.remindAtDay, this.selectedReminderDate);
       if (this.data.task.remindAtTime) {
-        this.selectedReminderTime = new Date(
-          this.data.task.remindAtTime,
-        ).toLocaleTimeString('en-GB', {
-          hour: '2-digit',
-          minute: '2-digit',
-          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        });
+        this.selectedReminderTime = this.data.task.remindAtTime;
+        Log.log('HIIII3', this.selectedReminderTime);
       } else {
         this.selectedReminderTime = this.selectedTime;
       }
@@ -327,7 +322,11 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
       return;
     }
 
-    if (this.data.task.remindAt) {
+    if (
+      this.data.task.remindAt ||
+      this.data.task.remindAtTime ||
+      this.data.task.remindAtDay
+    ) {
       this._store.dispatch(
         TaskSharedActions.unscheduleTask({
           id: this.data.task.id,
@@ -394,7 +393,6 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
       Log.err('no selected date');
       return;
     }
-
     // If in select-due-only mode, return the selected values instead of dispatching actions
     if (this.data.isSelectDueOnly) {
       this.close({
@@ -435,6 +433,7 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     }
 
     this.close(true);
+    Log.log(this.data.task);
   }
 
   private _handleReminderRemoval(): void {
@@ -488,6 +487,8 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
       task,
       newDate.getTime(),
       remindAt,
+      this.selectedReminderTime,
+      this.selectedReminderDate,
       specificReminder,
       false,
     );

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -5,7 +5,6 @@ import {
   Component,
   computed,
   inject,
-  signal,
   viewChild,
 } from '@angular/core';
 import {
@@ -53,14 +52,9 @@ import {
 import { MatSelect } from '@angular/material/select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { MatInput } from '@angular/material/input';
-import { TimeStepDirective } from '../../../ui/time-step/time-step.directive';
 import { Log } from '../../../core/log';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
-import { selectAllTasksWithDueTimeSorted } from '../../tasks/store/task.selectors';
-import { selectTimelineConfig } from '../../config/store/global-config.reducer';
-import { getTimeConflictTaskIds } from '../../tasks/util/get-time-conflict-task-ids';
-import { isTaskOutsideWorkHours } from '../../tasks/util/is-task-outside-work-hours';
 
 const DEFAULT_TIME = '09:00';
 
@@ -83,7 +77,6 @@ const DEFAULT_TIME = '09:00';
     MatLabel,
     MatSuffix,
     MatPrefix,
-    TimeStepDirective,
   ],
   templateUrl: './dialog-schedule-task.component.html',
   styleUrl: './dialog-schedule-task.component.scss',
@@ -108,10 +101,6 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
   private _globalConfigService = inject(GlobalConfigService);
   private _dateService = inject(DateService);
   private readonly _dateAdapter = inject(DateAdapter);
-  private readonly _tasksWithDueTimeSorted = this._store.selectSignal(
-    selectAllTasksWithDueTimeSorted,
-  );
-  private readonly _timelineConfig = this._store.selectSignal(selectTimelineConfig);
 
   // Wait for localization config to be loaded before rendering calendar
   // This ensures DateAdapter.getFirstDayOfWeek() returns the correct value
@@ -126,11 +115,9 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
   remindAvailableOptions: TaskReminderOption[] = TASK_REMINDER_OPTIONS;
   task: TaskCopy | undefined = this.data.task;
 
-  private _selectedDate = signal<Date | string | null>(null);
-  private _selectedTime = signal<string | null>(null);
   selectedDate: Date | string | null = null;
   selectedTime: string | null = null;
-  selectedReminderDate: Date | string | null = null;
+  selectedReminderDate: string | null = null;
   selectedReminderTime: string | null = null;
   selectedReminderCfgId!: TaskReminderOptionId;
 
@@ -142,7 +129,8 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
   // private _prevSelectedQuickAccessDate: Date | null = null;
   // private _prevQuickAccessAction: number | null = null;
   private _timeCheckVal: string | null = null;
-  private _previewTaskId = '__schedule-preview__';
+  private _reminderTimeCheckVal: string | null = null;
+  private _reminderDateCheckVal: string | null = null;
 
   private _defaultTaskRemindCfgId = computed(
     () =>
@@ -150,66 +138,12 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
         ?.defaultTaskRemindOption as TaskReminderOptionId) ??
       DEFAULT_GLOBAL_CONFIG.reminder.defaultTaskRemindOption!,
   );
-  get selectedDate(): Date | string | null {
-    return this._selectedDate();
-  }
-  set selectedDate(value: Date | string | null) {
-    this._selectedDate.set(value);
-  }
-
-  get selectedTime(): string | null {
-    return this._selectedTime();
-  }
-  set selectedTime(value: string | null) {
-    this._selectedTime.set(value);
-  }
-
-  plannedTimestamp = computed<number | null>(() => {
-    const selectedDate = this._selectedDate();
-    const selectedTime = this._selectedTime();
-    if (!selectedDate || !selectedTime) {
-      return null;
-    }
-
-    return getDateTimeFromClockString(selectedTime, selectedDate as Date);
-  });
-  scheduleWarnings = computed(() => {
-    const plannedTimestamp = this.plannedTimestamp();
-    if (!plannedTimestamp) {
-      return {
-        hasOverlap: false,
-        isOutsideWorkHours: false,
-      };
-    }
-
-    const candidateTask = {
-      id: this._previewTaskId,
-      dueWithTime: plannedTimestamp,
-      timeEstimate: this.task?.timeEstimate || 0,
-      timeSpent: this.task?.timeSpent || 0,
-      subTaskIds: this.task?.subTaskIds || [],
-      isDone: false,
-      projectId: this.task?.projectId || '',
-      timeSpentOnDay: this.task?.timeSpentOnDay || {},
-      attachments: this.task?.attachments || [],
-      title: this.task?.title || '',
-      tagIds: this.task?.tagIds || [],
-      created: this.task?.created || 0,
-    };
-    const conflictIds = getTimeConflictTaskIds([
-      ...this._tasksWithDueTimeSorted().filter((task) => task.id !== this.task?.id),
-      candidateTask,
-    ]);
-
-    return {
-      hasOverlap: conflictIds.has(this._previewTaskId),
-      isOutsideWorkHours: isTaskOutsideWorkHours(candidateTask, this._timelineConfig()),
-    };
-  });
 
   async ngAfterViewInit(): Promise<void> {
     // Handle case when task is provided
+    Log.log(this.data);
     if (this.data.task) {
+      Log.log('hi');
       if (this.data.task.remindAt) {
         if (this.data.task.dueWithTime) {
           this.selectedReminderCfgId = millisecondsDiffToRemindOption(
@@ -217,7 +151,7 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
             this.data.task.remindAt,
           );
         }
-      } else if (!this.data.task.dueWithTime) {
+      } else if (this.data.task.dueWithTime) {
         this.selectedReminderCfgId = this._defaultTaskRemindCfgId();
       } else {
         this.selectedReminderCfgId = TaskReminderOptionId.DoNotRemind;
@@ -235,14 +169,30 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
             timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           },
         );
-        this.selectedReminderDate = new Date();
-        this.selectedReminderTime = this.selectedTime;
       } else {
         this.plannedDayForTask = this.data.task.dueDay || null;
 
         this.selectedDate = this.plannedDayForTask
           ? dateStrToUtcDate(this.plannedDayForTask)
           : null;
+      }
+      Log.log('hi2');
+      if (this.data.task.remindAtTime) {
+        this.selectedReminderTime = new Date(
+          this.data.task.remindAtTime,
+        ).toLocaleTimeString('en-GB', {
+          hour: '2-digit',
+          minute: '2-digit',
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        });
+      } else {
+        this.selectedReminderTime = this.selectedTime;
+      }
+
+      if (this.data.task.remindAtDay) {
+        this.selectedReminderDate = this.data.task.remindAtDay;
+      } else {
+        this.selectedReminderDate = new Date().toISOString().split('T')[0];
       }
     } else {
       this.selectedReminderCfgId = this._defaultTaskRemindCfgId();
@@ -323,6 +273,30 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     }
   }
 
+  onReminderTimeKeyDown(ev: KeyboardEvent): void {
+    if (ev.key === 'Enter') {
+      this.isShowEnterMsg = true;
+      if (this._reminderTimeCheckVal === this.selectedReminderTime) {
+        this.submit();
+      }
+      this._reminderTimeCheckVal = this.selectedReminderTime;
+    } else {
+      this.isShowEnterMsg = false;
+    }
+  }
+
+  onReminderDateKeyDown(ev: KeyboardEvent): void {
+    if (ev.key === 'Enter') {
+      this.isShowEnterMsg = true;
+      if (this._reminderDateCheckVal === this.selectedReminderDate) {
+        this.submit();
+      }
+      this._reminderDateCheckVal = this.selectedReminderDate;
+    } else {
+      this.isShowEnterMsg = false;
+    }
+  }
+
   close(
     result:
       | boolean
@@ -330,6 +304,8 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
           date: Date | null;
           time: string | null;
           remindOption: TaskReminderOptionId | null;
+          reminderTime: string | null;
+          reminderDate: string | null;
         } = false,
   ): void {
     this._matDialogRef.close(result);
@@ -425,6 +401,8 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
         date: this.selectedDate as Date,
         time: this.selectedTime,
         remindOption: this.selectedReminderCfgId,
+        reminderTime: this.selectedReminderTime,
+        reminderDate: this.selectedReminderDate,
       });
       return;
     }
@@ -488,10 +466,29 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     const newDate = new Date(
       getDateTimeFromClockString(this.selectedTime as string, this.selectedDate as Date),
     );
+
+    let remindAt: TaskReminderOptionId | number | null = null;
+    let specificReminder: boolean = false;
+    if (this.selectedReminderDate && this.selectedReminderTime) {
+      remindAt = new Date(
+        `${this.selectedReminderDate}T${this.selectedReminderTime}`,
+      ).getTime();
+      specificReminder = true;
+    } else if (this.selectedReminderTime && !this.selectedReminderDate) {
+      remindAt = getDateTimeFromClockString(
+        this.selectedReminderTime,
+        this.selectedDate as Date,
+      );
+      specificReminder = true;
+    } else {
+      remindAt = this.selectedReminderCfgId;
+    }
+
     this._taskService.scheduleTask(
       task,
       newDate.getTime(),
-      this.selectedReminderCfgId,
+      remindAt,
+      specificReminder,
       false,
     );
     // TODO if we want this, we should add it as an effect

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -128,6 +128,10 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
 
   private _selectedDate = signal<Date | string | null>(null);
   private _selectedTime = signal<string | null>(null);
+  selectedDate: Date | string | null = null;
+  selectedTime: string | null = null;
+  selectedReminderDate: Date | string | null = null;
+  selectedReminderTime: string | null = null;
   selectedReminderCfgId!: TaskReminderOptionId;
 
   plannedDayForTask: string | null = null;
@@ -231,6 +235,8 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
             timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           },
         );
+        this.selectedReminderDate = new Date();
+        this.selectedReminderTime = this.selectedTime;
       } else {
         this.plannedDayForTask = this.data.task.dueDay || null;
 

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -403,6 +403,10 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
         reminderDate: this.selectedReminderDate,
       });
       return;
+    } else {
+      this.selectedReminderCfgId = this._defaultTaskRemindCfgId();
+      this.selectedReminderTime = this.selectedTime;
+      this.selectedReminderDate = new Date().toISOString().split('T')[0];
     }
 
     const newDayDate = new Date(this.selectedDate);

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -155,7 +155,6 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
         this.selectedReminderCfgId = TaskReminderOptionId.DoNotRemind;
       }
 
-      Log.log('BYE', this.data.task.dueWithTime, this.selectedTime);
       if (this.data.task.dueWithTime) {
         // dueWithTime is a UTC timestamp - Date constructor handles timezone conversion automatically
         // Do NOT add timezone offset here as it would double-apply the conversion (fixes #5515)
@@ -175,19 +174,16 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
           ? dateStrToUtcDate(this.plannedDayForTask)
           : null;
       }
-      Log.log('HIIII', this.data.task.remindAtTime, this.selectedReminderTime);
-      Log.log('HIIII2', this.data.task.remindAtDay, this.selectedReminderDate);
       if (this.data.task.remindAtTime) {
         this.selectedReminderTime = this.data.task.remindAtTime;
-        Log.log('HIIII3', this.selectedReminderTime);
       } else {
-        this.selectedReminderTime = this.selectedTime;
+        this.selectedReminderTime = null;
       }
 
       if (this.data.task.remindAtDay) {
         this.selectedReminderDate = this.data.task.remindAtDay;
       } else {
-        this.selectedReminderDate = new Date().toISOString().split('T')[0];
+        this.selectedReminderDate = null;
       }
     } else {
       this.selectedReminderCfgId = this._defaultTaskRemindCfgId();
@@ -368,6 +364,15 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     this.selectedTime = null;
     this.isInitValOnTimeFocus = true;
   }
+  onReminderTimeClear(ev: MouseEvent): void {
+    ev.stopPropagation();
+    this.selectedReminderTime = null;
+  }
+
+  onReminderDateClear(ev: MouseEvent): void {
+    ev.stopPropagation();
+    this.selectedReminderDate = null;
+  }
 
   onTimeFocus(): void {
     Log.log('onTimeFocus');
@@ -393,6 +398,7 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
       Log.err('no selected date');
       return;
     }
+    this._validateAndFixReminderTime();
     // If in select-due-only mode, return the selected values instead of dispatching actions
     if (this.data.isSelectDueOnly) {
       this.close({
@@ -403,10 +409,6 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
         reminderDate: this.selectedReminderDate,
       });
       return;
-    } else {
-      this.selectedReminderCfgId = this._defaultTaskRemindCfgId();
-      this.selectedReminderTime = this.selectedTime;
-      this.selectedReminderDate = new Date().toISOString().split('T')[0];
     }
 
     const newDayDate = new Date(this.selectedDate);
@@ -437,7 +439,6 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     }
 
     this.close(true);
-    Log.log(this.data.task);
   }
 
   private _handleReminderRemoval(): void {
@@ -459,11 +460,36 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
     }
   }
 
+  private _validateAndFixReminderTime(): void {
+    if (
+      !this.selectedReminderDate ||
+      !this.selectedReminderTime ||
+      !this.selectedDate ||
+      !this.selectedTime
+    ) {
+      return;
+    }
+
+    const dueWithTime = new Date(
+      getDateTimeFromClockString(this.selectedTime, this.selectedDate as Date),
+    ).getTime();
+
+    const remindAt = new Date(
+      `${this.selectedReminderDate}T${this.selectedReminderTime}`,
+    ).getTime();
+
+    if (remindAt >= dueWithTime) {
+      this.selectedReminderTime = this.selectedTime;
+      this.selectedReminderDate = getDbDateStr(new Date(this.selectedDate as Date));
+    }
+  }
+
   private _scheduleWithTime(): void {
     // Only schedule if task is provided
     if (!this.data.task) {
       return;
     }
+    this._validateAndFixReminderTime();
 
     const task = this.data.task;
     const newDate = new Date(

--- a/src/app/features/planner/planner-day/planner-day.component.ts
+++ b/src/app/features/planner/planner-day/planner-day.component.ts
@@ -165,6 +165,14 @@ export class PlannerDayComponent {
       task.dueWithTime as number,
       task.remindAt,
     );
-    this._taskService.scheduleTask(task, newDate.getTime(), selectedReminderCfgId, false);
+    this._taskService.scheduleTask(
+      task,
+      newDate.getTime(),
+      selectedReminderCfgId,
+      null,
+      null,
+      false,
+      false,
+    );
   }
 }

--- a/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.ts
+++ b/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.ts
@@ -27,7 +27,6 @@ import { devError } from '../../../util/dev-error';
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
-import { Log } from '../../../core/log';
 
 type Timeout = NodeJS.Timeout | number | undefined;
 
@@ -235,7 +234,6 @@ export class CreateTaskPlaceholderComponent implements OnDestroy {
   }
 
   private async createNewTask(title: string): Promise<void> {
-    Log.log('waza');
     try {
       if (this.isForDayMode()) {
         // Plan task for day (no specific time)

--- a/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.ts
+++ b/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.ts
@@ -27,6 +27,7 @@ import { devError } from '../../../util/dev-error';
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
+import { Log } from '../../../core/log';
 
 type Timeout = NodeJS.Timeout | number | undefined;
 
@@ -234,6 +235,7 @@ export class CreateTaskPlaceholderComponent implements OnDestroy {
   }
 
   private async createNewTask(title: string): Promise<void> {
+    Log.log('waza');
     try {
       if (this.isForDayMode()) {
         // Plan task for day (no specific time)

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
@@ -753,11 +753,12 @@ export class TaskRepeatCfgEffects {
         this._taskService.reScheduleTask({
           task,
           due: dateTime,
-          remindCfg: completeCfg.remindAt,
+          remindTime: completeCfg.remindAt,
+          specificReminder: false,
           isMoveToBacklog: false,
         });
       } else {
-        this._taskService.scheduleTask(task, dateTime, completeCfg.remindAt);
+        this._taskService.scheduleTask(task, dateTime, completeCfg.remindAt, false);
       }
     }
     if (changes.tagIds) {

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
@@ -756,9 +756,19 @@ export class TaskRepeatCfgEffects {
           remindTime: completeCfg.remindAt,
           specificReminder: false,
           isMoveToBacklog: false,
+          remindAtTime: null,
+          remindAtDay: null,
         });
       } else {
-        this._taskService.scheduleTask(task, dateTime, completeCfg.remindAt, false);
+        this._taskService.scheduleTask(
+          task,
+          dateTime,
+          completeCfg.remindAt,
+          null,
+          null,
+          false,
+          false,
+        );
       }
     }
     if (changes.tagIds) {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
@@ -96,6 +96,7 @@ describe('AddTaskBarActionsComponent', () => {
       'updateDate',
       'updateEstimate',
       'updateRemindOption',
+      'updateRemindAt',
       'clearDate',
       'clearTags',
       'clearEstimate',

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
@@ -97,6 +97,8 @@ describe('AddTaskBarActionsComponent', () => {
       'updateEstimate',
       'updateRemindOption',
       'updateRemindAt',
+      'updateRemindAtTime',
+      'updateRemindAtDay',
       'clearDate',
       'clearTags',
       'clearEstimate',
@@ -1001,6 +1003,73 @@ describe('AddTaskBarActionsComponent', () => {
       component.openScheduleDialog();
 
       expect(mockStateService.updateDate).toHaveBeenCalledWith('2025-01-01', '00:00');
+    });
+  });
+
+  describe('openScheduleDialog - reminder handling', () => {
+    it('should get correct remindAt from reminderDate and reminderTime', () => {
+      const reminderDate = '2026-05-27';
+      const reminderTime = '16:45';
+      const expectedRemindAt = new Date(`${reminderDate}T${reminderTime}`).getTime();
+
+      const mockResult = {
+        date: new Date('2026-05-27'),
+        time: '17:00',
+        remindOption: null,
+        reminderDate,
+        reminderTime,
+      };
+      mockDialogRef.afterClosed.and.returnValue(of(mockResult));
+
+      component.openScheduleDialog();
+
+      expect(mockStateService.updateRemindAt).toHaveBeenCalledWith(expectedRemindAt);
+      expect(mockStateService.updateRemindAtTime).toHaveBeenCalledWith(reminderTime);
+      expect(mockStateService.updateRemindAtDay).toHaveBeenCalledWith(reminderDate);
+    });
+
+    it('Should store null in remindAt when no reminderDate', () => {
+      const mockResult = {
+        date: new Date('2026-05-27'),
+        time: '17:00',
+        remindOption: null,
+        reminderDate: null,
+        reminderTime: '16:45',
+      };
+      mockDialogRef.afterClosed.and.returnValue(of(mockResult));
+
+      component.openScheduleDialog();
+
+      expect(mockStateService.updateRemindAt).toHaveBeenCalledWith(null);
+      expect(mockStateService.updateRemindAtTime).toHaveBeenCalledWith(null);
+      expect(mockStateService.updateRemindAtDay).toHaveBeenCalledWith(null);
+    });
+
+    it('Should store null in remindAt when no reminderTime', () => {
+      const mockResult = {
+        date: new Date('2026-05-27'),
+        time: '17:00',
+        remindOption: null,
+        reminderDate: '2026-05-27',
+        reminderTime: null,
+      };
+      mockDialogRef.afterClosed.and.returnValue(of(mockResult));
+
+      component.openScheduleDialog();
+
+      expect(mockStateService.updateRemindAt).toHaveBeenCalledWith(null);
+      expect(mockStateService.updateRemindAtTime).toHaveBeenCalledWith(null);
+      expect(mockStateService.updateRemindAtDay).toHaveBeenCalledWith(null);
+    });
+
+    it('should not call updateRemindAt if dialog is canceled', () => {
+      mockDialogRef.afterClosed.and.returnValue(of(false));
+
+      component.openScheduleDialog();
+
+      expect(mockStateService.updateRemindAt).not.toHaveBeenCalled();
+      expect(mockStateService.updateRemindAtTime).not.toHaveBeenCalled();
+      expect(mockStateService.updateRemindAtDay).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
@@ -201,7 +201,7 @@ export class AddTaskBarActionsComponent {
           this.stateService.updateRemindAtTime(result.reminderTime);
           this.stateService.updateRemindAtDay(result.reminderDate);
         } else if (result.remindOption) {
-          this.stateService.updateRemindAt(result.remindOption);
+          this.stateService.updateRemindAt(null);
           this.stateService.updateRemindAtTime(null);
           this.stateService.updateRemindAtDay(null);
         } else {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
@@ -198,8 +198,16 @@ export class AddTaskBarActionsComponent {
             `${result.reminderDate}T${result.reminderTime}`,
           ).getTime();
           this.stateService.updateRemindAt(remindAt);
+          this.stateService.updateRemindAtTime(result.reminderTime);
+          this.stateService.updateRemindAtDay(result.reminderDate);
+        } else if (result.remindOption) {
+          this.stateService.updateRemindAt(result.remindOption);
+          this.stateService.updateRemindAtTime(null);
+          this.stateService.updateRemindAtDay(null);
         } else {
           this.stateService.updateRemindAt(null);
+          this.stateService.updateRemindAtTime(null);
+          this.stateService.updateRemindAtDay(null);
         }
       }
       this.refocus.emit();

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
@@ -193,6 +193,14 @@ export class AddTaskBarActionsComponent {
         this.stateService.updateDate(getDbDateStr(result.date), result.time);
         // No UI access to reminder without a time being set
         this.stateService.updateRemindOption(result.remindOption);
+        if (result.reminderDate && result.reminderTime) {
+          const remindAt = new Date(
+            `${result.reminderDate}T${result.reminderTime}`,
+          ).getTime();
+          this.stateService.updateRemindAt(remindAt);
+        } else {
+          this.stateService.updateRemindAt(null);
+        }
       }
       this.refocus.emit();
       window.setTimeout(() => {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -137,6 +137,8 @@ describe('AddTaskBarParserService', () => {
           cleanText: null,
           remindOption: null,
           remindAt: null,
+          remindAtTime: null,
+          remindAtDay: null,
           attachments: [],
           repeatQuickSetting: null,
         };
@@ -176,6 +178,8 @@ describe('AddTaskBarParserService', () => {
           cleanText: null,
           remindOption: null,
           remindAt: null,
+          remindAtTime: null,
+          remindAtDay: null,
           attachments: [],
           repeatQuickSetting: null,
         };
@@ -212,6 +216,8 @@ describe('AddTaskBarParserService', () => {
           cleanText: null,
           remindOption: null,
           remindAt: null,
+          remindAtTime: null,
+          remindAtDay: null,
           attachments: [],
           repeatQuickSetting: null,
         };
@@ -634,6 +640,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -670,6 +678,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -708,6 +718,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -744,6 +756,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -779,6 +793,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -898,6 +914,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -933,6 +951,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -968,6 +988,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1001,6 +1023,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1035,6 +1059,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1079,6 +1105,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1108,6 +1136,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1157,6 +1187,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1200,6 +1232,8 @@ describe('AddTaskBarParserService', () => {
         cleanText: null,
         remindOption: null,
         remindAt: null,
+        remindAtTime: null,
+        remindAtDay: null,
         attachments: [],
         repeatQuickSetting: null,
       };

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -35,6 +35,7 @@ describe('AddTaskBarParserService', () => {
       time: null,
       estimate: null,
       cleanText: null,
+      remindAt: null,
     };
     mockStateServiceSpy.state.and.returnValue(defaultMockState);
 
@@ -135,6 +136,7 @@ describe('AddTaskBarParserService', () => {
           estimate: null,
           cleanText: null,
           remindOption: null,
+          remindAt: null,
           attachments: [],
           repeatQuickSetting: null,
         };
@@ -173,6 +175,7 @@ describe('AddTaskBarParserService', () => {
           estimate: null,
           cleanText: null,
           remindOption: null,
+          remindAt: null,
           attachments: [],
           repeatQuickSetting: null,
         };
@@ -208,6 +211,7 @@ describe('AddTaskBarParserService', () => {
           estimate: null,
           cleanText: null,
           remindOption: null,
+          remindAt: null,
           attachments: [],
           repeatQuickSetting: null,
         };
@@ -629,6 +633,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -664,6 +669,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -701,6 +707,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -736,6 +743,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -770,6 +778,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -888,6 +897,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -922,6 +932,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -956,6 +967,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -988,6 +1000,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1021,6 +1034,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1064,6 +1078,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1092,6 +1107,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1140,6 +1156,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };
@@ -1182,6 +1199,7 @@ describe('AddTaskBarParserService', () => {
         estimate: null,
         cleanText: null,
         remindOption: null,
+        remindAt: null,
         attachments: [],
         repeatQuickSetting: null,
       };

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.spec.ts
@@ -624,5 +624,101 @@ describe('AddTaskBarStateService', () => {
       expect(service.state().date).toBe('2024-01-15');
       expect(service.state().estimate).toBe(3600000);
     });
+
+    it('should clear remindAt after reset', () => {
+      const remindAt = new Date(2026, 4, 27, 16, 45).getTime();
+      service.updateRemindAt(remindAt);
+
+      service.resetAfterAdd();
+
+      expect(service.state().remindAt).toBe(null);
+    });
+
+    it('should clear remindAtTime and remindAtDay after reset', () => {
+      service.updateRemindAtTime('16:45');
+      service.updateRemindAtDay('2026-05-27');
+
+      service.resetAfterAdd();
+
+      expect(service.state().remindAtTime).toBe(null);
+      expect(service.state().remindAtDay).toBe(null);
+    });
+  });
+
+  describe('updateRemindAt', () => {
+    it('should update remindAt in state', () => {
+      const remindAt = new Date(2026, 4, 27, 16, 45).getTime();
+
+      service.updateRemindAt(remindAt);
+
+      expect(service.state().remindAt).toBe(remindAt);
+    });
+
+    it('should clear remindAt', () => {
+      const remindAt = new Date(2026, 4, 27, 16, 45).getTime();
+      service.updateRemindAt(remindAt);
+
+      service.updateRemindAt(null);
+
+      expect(service.state().remindAt).toBe(null);
+    });
+
+    it('should preserve other fields in state', () => {
+      const remindAt = new Date(2026, 4, 27, 16, 45).getTime();
+      service.updateProjectId('project-1');
+      service.updateDate('2026-05-27', '17:00');
+      service.updateEstimate(1800000);
+
+      service.updateRemindAt(remindAt);
+
+      expect(service.state().projectId).toBe('project-1');
+      expect(service.state().date).toBe('2026-05-27');
+      expect(service.state().time).toBe('17:00');
+      expect(service.state().estimate).toBe(1800000);
+    });
+
+    it('remindAt should start as null in initial state', () => {
+      expect(service.state().remindAt).toBe(null);
+    });
+  });
+
+  describe('updateRemindAtTime', () => {
+    it('should update remindAtTime in state', () => {
+      service.updateRemindAtTime('16:45');
+
+      expect(service.state().remindAtTime).toBe('16:45');
+    });
+
+    it('should clear remindAtTime when null passed', () => {
+      service.updateRemindAtTime('16:45');
+
+      service.updateRemindAtTime(null);
+
+      expect(service.state().remindAtTime).toBe(null);
+    });
+
+    it('should start as null in initial state', () => {
+      expect(service.state().remindAtTime).toBe(null);
+    });
+  });
+
+  describe('updateRemindAtDay', () => {
+    it('should update remindAtDay in state', () => {
+      service.updateRemindAtDay('2026-05-27');
+
+      expect(service.state().remindAtDay).toBe('2026-05-27');
+    });
+
+    it('should clear remindAtDay when null passed', () => {
+      service.updateRemindAtDay('2026-05-27');
+
+      service.updateRemindAtDay(null);
+
+      expect(service.state().remindAtDay).toBe(null);
+    });
+
+    it('should start as null in initial state', () => {
+      expect(service.state().remindAtDay).toBe(null);
+    });
   });
 });

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -54,6 +54,14 @@ export class AddTaskBarStateService {
     this._taskInputState.update((state) => ({ ...state, remindAt }));
   }
 
+  updateRemindAtTime(remindAtTime: string | null): void {
+    this._taskInputState.update((state) => ({ ...state, remindAtTime }));
+  }
+
+  updateRemindAtDay(remindAtDay: string | null): void {
+    this._taskInputState.update((state) => ({ ...state, remindAtDay }));
+  }
+
   updateEstimate(estimate: number | null): void {
     this._taskInputState.update((state) => ({ ...state, estimate }));
   }

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -50,6 +50,10 @@ export class AddTaskBarStateService {
     this._taskInputState.update((state) => ({ ...state, remindOption }));
   }
 
+  updateRemindAt(remindAt: number | null): void {
+    this._taskInputState.update((state) => ({ ...state, remindAt }));
+  }
+
   updateEstimate(estimate: number | null): void {
     this._taskInputState.update((state) => ({ ...state, estimate }));
   }

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -156,6 +156,9 @@ export class AddTaskBarStateService {
       cleanText: null,
       attachments: [],
       repeatQuickSetting: null,
+      remindAt: null,
+      remindAtTime: null,
+      remindAtDay: null,
     }));
     this.inputTxt.set('');
     // Keep isAutoDetected as is to preserve project selection

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -20,7 +20,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { signal, Signal } from '@angular/core';
 import { AddTaskSuggestion } from './add-task-suggestions.model';
 import { PlannerActions } from '../../planner/store/planner.actions';
-import { TaskCopy, TaskReminderOptionId } from '../task.model';
+import { TaskCopy } from '../task.model';
 import { DateTimeFormatService } from 'src/app/core/date-time-format/date-time-format.service';
 import { DEFAULT_LOCALE } from 'src/app/core/locale.constants';
 
@@ -181,14 +181,16 @@ describe('AddTaskBarComponent', () => {
       ]),
     );
     mockGlobalConfigService = jasmine.createSpyObj('GlobalConfigService', [], {
-      cfg: signal({
-        reminder: { defaultTaskRemindOption: TaskReminderOptionId.AtStart },
-      }),
       lang$: new BehaviorSubject<LocalizationConfig>(mockLocalizationConfig),
       misc$: new BehaviorSubject<MiscConfig>(mockMiscConfig),
       tasks$: new BehaviorSubject({ defaultProjectId: null }),
       shortSyntax$: of({}),
       localization: () => ({ timeLocale: DEFAULT_LOCALE }),
+      cfg: () => ({
+        reminder: { defaultTaskRemindOption: 'AtStart' },
+        tasks: { defaultProjectId: null },
+        appFeatures: { isTimeTrackingEnabled: true },
+      }),
     });
     mockStore = jasmine.createSpyObj('Store', ['select', 'dispatch', 'pipe']);
     mockStore.pipe.and.returnValue(of([]));
@@ -273,45 +275,6 @@ describe('AddTaskBarComponent', () => {
         }),
       );
       expect(mockTaskService.moveToCurrentWorkContext).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('addTask', () => {
-    it('should not add a task when the visible input is empty', async () => {
-      component.stateService.updateCleanText('Stale task');
-      component.stateService.updateInputTxt('   ');
-
-      await component.addTask();
-
-      expect(mockTaskService.add).not.toHaveBeenCalled();
-    });
-
-    it('should keep the active tag selected for subsequent tasks in tag context', async () => {
-      const tagWorkContext: WorkContext = {
-        id: 'tag-1',
-        title: 'Test Tag',
-        type: WorkContextType.TAG,
-      } as WorkContext;
-      (
-        mockWorkContextService.activeWorkContext$ as BehaviorSubject<WorkContext | null>
-      ).next(tagWorkContext);
-      mockTaskService.add.and.returnValues('task-1', 'task-2');
-
-      fixture.detectChanges();
-
-      component.stateService.updateInputTxt('First task');
-      component.stateService.updateCleanText('First task');
-      await component.addTask();
-
-      expect(component.stateService.state().tagIds).toEqual(['tag-1']);
-
-      component.stateService.updateInputTxt('Second task');
-      component.stateService.updateCleanText('Second task');
-      await component.addTask();
-
-      const secondCall = mockTaskService.add.calls.mostRecent();
-      const secondTaskData = secondCall.args[2] as Partial<TaskCopy>;
-      expect(secondTaskData.tagIds).toEqual(['tag-1']);
     });
   });
 
@@ -576,31 +539,6 @@ describe('AddTaskBarComponent', () => {
     });
   });
 
-  describe('_setProjectInitially', () => {
-    it('should use projectId from additionalFields instead of defaultProject$', () => {
-      // Set tag work context (would normally fall back to INBOX_PROJECT)
-      (
-        mockWorkContextService.activeWorkContext$ as BehaviorSubject<WorkContext | null>
-      ).next(mockTagWorkContext);
-
-      fixture.componentRef.setInput('additionalFields', { projectId: 'project-2' });
-      fixture.detectChanges();
-
-      expect(component.stateService.state().projectId).toBe('project-2');
-    });
-
-    it('should fall back to defaultProject$ when additionalFields has no projectId', () => {
-      (
-        mockWorkContextService.activeWorkContext$ as BehaviorSubject<WorkContext | null>
-      ).next(mockTagWorkContext);
-
-      fixture.componentRef.setInput('additionalFields', { isDone: false });
-      fixture.detectChanges();
-
-      expect(component.stateService.state().projectId).toBe('INBOX_PROJECT');
-    });
-  });
-
   describe('document click handling', () => {
     beforeEach(() => {
       fixture.detectChanges();
@@ -630,45 +568,65 @@ describe('AddTaskBarComponent', () => {
     });
   });
 
-  describe('IME handling (Integration)', () => {
-    let inputEl: HTMLInputElement;
-
+  describe('addTask() - reminder scheduling', () => {
     beforeEach(() => {
-      component.stateService.updateInputTxt('New Task');
       fixture.detectChanges();
-      inputEl = fixture.debugElement.nativeElement.querySelector('input');
+      mockTaskService.add.and.returnValue('new-task-id');
+      mockTaskService.getByIdOnce$.and.returnValue(
+        of({ id: 'new-task-id', title: 'Test' } as TaskCopy),
+      );
     });
 
-    const dispatchEnterKeydown = (options: {
-      isComposing: boolean;
-      keyCode?: number;
-    }): void => {
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        isComposing: options.isComposing,
-      });
+    it('should call scheduleTask with specificReminder=true when remindAt is set in state', async () => {
+      const remindAt = new Date(2026, 4, 27, 16, 45).getTime();
 
-      if (options.keyCode) {
-        Object.defineProperty(event, 'keyCode', { value: options.keyCode });
-      }
+      component.stateService.updateDate('2026-05-27', '17:00');
+      component.stateService.updateRemindAt(remindAt);
+      component.stateService.updateRemindAtTime('16:45');
+      component.stateService.updateRemindAtDay('2026-05-27');
+      component.stateService.updateInputTxt('Test task');
 
-      inputEl.dispatchEvent(event);
-      fixture.detectChanges();
-    };
+      await component.addTask();
 
-    it('should not add a task when Enter is pressed during IME composition', () => {
-      dispatchEnterKeydown({ isComposing: true });
-      expect(mockTaskService.add).not.toHaveBeenCalled();
+      expect(mockTaskService.scheduleTask).toHaveBeenCalledWith(
+        jasmine.objectContaining({ id: 'new-task-id' }),
+        jasmine.any(Number),
+        remindAt,
+        '16:45',
+        '2026-05-27',
+        true,
+        false,
+      );
     });
 
-    it('should not add a task when Enter is pressed with keyCode 229 even if isComposing is false', () => {
-      dispatchEnterKeydown({ isComposing: false, keyCode: 229 });
-      expect(mockTaskService.add).not.toHaveBeenCalled();
+    it('should call scheduleTask with specificReminder=false when remindAt is null', async () => {
+      component.stateService.updateDate('2026-05-27', '17:00');
+      component.stateService.updateRemindAt(null);
+      component.stateService.updateRemindAtTime(null);
+      component.stateService.updateRemindAtDay(null);
+      component.stateService.updateInputTxt('Test task');
+
+      await component.addTask();
+
+      expect(mockTaskService.scheduleTask).toHaveBeenCalledWith(
+        jasmine.objectContaining({ id: 'new-task-id' }),
+        jasmine.any(Number),
+        jasmine.any(String),
+        null,
+        null,
+        false,
+        false,
+      );
     });
 
-    it('should add a task when Enter is pressed and NOT in IME composition', () => {
-      dispatchEnterKeydown({ isComposing: false });
-      expect(mockTaskService.add).toHaveBeenCalled();
+    it('should not call scheduleTask when no time is set', async () => {
+      component.stateService.updateDate('2026-05-27', null);
+      component.stateService.updateRemindAt(null);
+      component.stateService.updateInputTxt('Test task');
+
+      await component.addTask();
+
+      expect(mockTaskService.scheduleTask).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -488,12 +488,23 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
           .getByIdOnce$(taskId)
           .pipe(timeout(1000))
           .subscribe((task) => {
-            this._taskService.scheduleTask(
-              task,
-              taskData.dueWithTime!,
-              resolvedRemindOption,
-              this.isAddToBacklog(),
-            );
+            if (state.remindAt) {
+              this._taskService.scheduleTask(
+                task,
+                taskData.dueWithTime!,
+                state.remindAt,
+                true,
+                this.isAddToBacklog(),
+              );
+            } else {
+              this._taskService.scheduleTask(
+                task,
+                taskData.dueWithTime!,
+                resolvedRemindOption,
+                false,
+                this.isAddToBacklog(),
+              );
+            }
           });
       }
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -493,7 +493,9 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
                 task,
                 taskData.dueWithTime!,
                 state.remindAt,
-                true,
+                null,
+                null,
+                false,
                 this.isAddToBacklog(),
               );
             } else {
@@ -501,6 +503,8 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
                 task,
                 taskData.dueWithTime!,
                 resolvedRemindOption,
+                null,
+                null,
                 false,
                 this.isAddToBacklog(),
               );

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -488,14 +488,18 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
           .getByIdOnce$(taskId)
           .pipe(timeout(1000))
           .subscribe((task) => {
+            const hasSpecificReminder = !!(
+              state.remindAt ||
+              (state.remindAtTime && state.remindAtDay)
+            );
             if (state.remindAt) {
               this._taskService.scheduleTask(
                 task,
                 taskData.dueWithTime!,
                 state.remindAt,
-                null,
-                null,
-                false,
+                state.remindAtTime ?? null,
+                state.remindAtDay ?? null,
+                hasSpecificReminder,
                 this.isAddToBacklog(),
               );
             } else {

--- a/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
@@ -15,6 +15,8 @@ export interface AddTaskBarState {
   cleanText: string | null;
   remindOption: TaskReminderOptionId | null;
   remindAt: number | null;
+  remindAtTime: string | null;
+  remindAtDay: string | null;
   attachments: TaskAttachment[];
   repeatQuickSetting: RepeatQuickSetting | null;
 }
@@ -44,6 +46,8 @@ export const INITIAL_ADD_TASK_BAR_STATE: AddTaskBarState = {
   cleanText: null,
   remindOption: null,
   remindAt: null,
+  remindAtTime: null,
+  remindAtDay: null,
   attachments: [],
   repeatQuickSetting: null,
 };

--- a/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
@@ -14,6 +14,7 @@ export interface AddTaskBarState {
   newTagTitles: string[];
   cleanText: string | null;
   remindOption: TaskReminderOptionId | null;
+  remindAt: number | null;
   attachments: TaskAttachment[];
   repeatQuickSetting: RepeatQuickSetting | null;
 }
@@ -42,6 +43,7 @@ export const INITIAL_ADD_TASK_BAR_STATE: AddTaskBarState = {
   newTagTitles: [],
   cleanText: null,
   remindOption: null,
+  remindAt: null,
   attachments: [],
   repeatQuickSetting: null,
 };

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
@@ -778,6 +778,8 @@ export class TaskContextMenuInnerComponent implements AfterViewInit, OnDestroy {
         newDate.getTime(),
         this._globalConfigService.cfg()?.reminder.defaultTaskRemindOption ??
           DEFAULT_GLOBAL_CONFIG.reminder.defaultTaskRemindOption!,
+        null,
+        null,
         false,
       );
     } else {

--- a/src/app/features/tasks/task.model.ts
+++ b/src/app/features/tasks/task.model.ts
@@ -138,6 +138,8 @@ export interface TaskCopy
   doneOn?: number;
   parentId?: string;
   remindAt?: number;
+  remindAtTime?: number;
+  remindAtDay?: string;
   repeatCfgId?: string;
   _hideSubTasksMode?: HideSubTasksMode;
 }
@@ -153,13 +155,23 @@ export type ArchiveTask = Readonly<TaskCopy>;
 export type Task = Readonly<TaskCopy>;
 
 export interface TaskWithReminderData extends Task {
-  readonly reminderData: { remindAt: number };
+  readonly reminderData: {
+    remindAt: number;
+    remindAtTime?: number | null;
+    remindAtDay?: string | null;
+  };
   readonly parentData?: Task;
   readonly isDeadlineReminder?: boolean;
 }
 
 export interface TaskWithReminder extends Task {
   remindAt: number;
+}
+
+export interface TaskWithSetReminder extends Task {
+  remindAt: undefined;
+  remindAtTime?: number;
+  remindAtDay?: string;
 }
 
 export interface TaskWithDueTime extends Task {

--- a/src/app/features/tasks/task.model.ts
+++ b/src/app/features/tasks/task.model.ts
@@ -138,7 +138,7 @@ export interface TaskCopy
   doneOn?: number;
   parentId?: string;
   remindAt?: number;
-  remindAtTime?: number;
+  remindAtTime?: string;
   remindAtDay?: string;
   repeatCfgId?: string;
   _hideSubTasksMode?: HideSubTasksMode;
@@ -170,7 +170,7 @@ export interface TaskWithReminder extends Task {
 
 export interface TaskWithSetReminder extends Task {
   remindAt: undefined;
-  remindAtTime?: number;
+  remindAtTime?: string;
   remindAtDay?: string;
 }
 

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -565,6 +565,8 @@ describe('TaskService', () => {
         task,
         due,
         remindTime: TaskReminderOptionId.AtStart,
+        remindAtTime: null,
+        remindAtDay: null,
         specificReminder: false,
         isMoveToBacklog: false,
       });
@@ -868,6 +870,87 @@ describe('TaskService', () => {
     });
   });
 
+  describe('scheduleTask - specificReminder', () => {
+    it('should pass remindAt directly when specificReminder is true', () => {
+      const task = createMockTask('task-1');
+      const due = Date.now() + 3600000;
+      const remindAt = due - 900000;
+
+      service.scheduleTask(task, due, remindAt, null, null, true);
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: TaskSharedActions.scheduleTaskWithTime.type,
+          dueWithTime: due,
+          remindAt: remindAt,
+        }),
+      );
+    });
+
+    it('should calculate remindAt with remindOptionToMilliseconds when specificReminder is false', () => {
+      const task = createMockTask('task-1');
+      const due = Date.now() + 3600000;
+
+      service.scheduleTask(task, due, TaskReminderOptionId.AtStart, null, null, false);
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: TaskSharedActions.scheduleTaskWithTime.type,
+          dueWithTime: due,
+          remindAt: due,
+        }),
+      );
+    });
+  });
+
+  describe('reScheduleTask - specificReminder', () => {
+    it('should pass remindAt directly when specificReminder is true', () => {
+      const task = createMockTask('task-1');
+      const due = Date.now() + 3600000;
+      const remindAt = due - 900000;
+
+      service.reScheduleTask({
+        task,
+        due,
+        remindTime: remindAt,
+        remindAtTime: null,
+        remindAtDay: null,
+        specificReminder: true,
+        isMoveToBacklog: false,
+      });
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: TaskSharedActions.reScheduleTaskWithTime.type,
+          dueWithTime: due,
+          remindAt: remindAt,
+        }),
+      );
+    });
+
+    it('should calculate remindAt with remindOptionToMilliseconds when specificReminder is false', () => {
+      const task = createMockTask('task-1');
+      const due = Date.now() + 3600000;
+
+      service.reScheduleTask({
+        task,
+        due,
+        remindTime: TaskReminderOptionId.AtStart,
+        remindAtTime: null,
+        remindAtDay: null,
+        specificReminder: false,
+        isMoveToBacklog: false,
+      });
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: TaskSharedActions.reScheduleTaskWithTime.type,
+          dueWithTime: due,
+          remindAt: due,
+        }),
+      );
+    });
+  });
   // Note: convertToMainTask requires complex selector mocking that doesn't work well
   // with the current test setup. It's better tested via integration tests.
 });

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -564,7 +564,8 @@ describe('TaskService', () => {
       service.reScheduleTask({
         task,
         due,
-        remindCfg: TaskReminderOptionId.AtStart,
+        remindTime: TaskReminderOptionId.AtStart,
+        specificReminder: false,
         isMoveToBacklog: false,
       });
 

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -1034,7 +1034,7 @@ export class TaskService {
       TaskSharedActions.scheduleTaskWithTime({
         task,
         dueWithTime: due,
-        remindAt: specificReminder
+        remindAt: !specificReminder
           ? remindOptionToMilliseconds(due, remindTime as TaskReminderOptionId)
           : (remindTime as number),
         isMoveToBacklog,
@@ -1059,7 +1059,7 @@ export class TaskService {
       TaskSharedActions.reScheduleTaskWithTime({
         task,
         dueWithTime: due,
-        remindAt: specificReminder
+        remindAt: !specificReminder
           ? remindOptionToMilliseconds(due, remindTime as TaskReminderOptionId)
           : (remindTime as number),
         isMoveToBacklog,

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -1026,14 +1026,17 @@ export class TaskService {
   scheduleTask(
     task: Task | TaskWithSubTasks,
     due: number,
-    remindCfg: TaskReminderOptionId,
+    remindTime: TaskReminderOptionId | number,
+    specificReminder: boolean = false,
     isMoveToBacklog: boolean = false,
   ): void {
     this._store.dispatch(
       TaskSharedActions.scheduleTaskWithTime({
         task,
         dueWithTime: due,
-        remindAt: remindOptionToMilliseconds(due, remindCfg),
+        remindAt: specificReminder
+          ? remindOptionToMilliseconds(due, remindTime as TaskReminderOptionId)
+          : (remindTime as number),
         isMoveToBacklog,
       }),
     );
@@ -1042,19 +1045,23 @@ export class TaskService {
   reScheduleTask({
     task,
     due,
-    remindCfg,
+    remindTime,
+    specificReminder,
     isMoveToBacklog = false,
   }: {
     task: Task;
     due: number;
-    remindCfg: TaskReminderOptionId;
+    remindTime: TaskReminderOptionId | number;
+    specificReminder: boolean;
     isMoveToBacklog: boolean;
   }): void {
     this._store.dispatch(
       TaskSharedActions.reScheduleTaskWithTime({
         task,
         dueWithTime: due,
-        remindAt: remindOptionToMilliseconds(due, remindCfg),
+        remindAt: specificReminder
+          ? remindOptionToMilliseconds(due, remindTime as TaskReminderOptionId)
+          : (remindTime as number),
         isMoveToBacklog,
       }),
     );

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -1027,6 +1027,8 @@ export class TaskService {
     task: Task | TaskWithSubTasks,
     due: number,
     remindTime: TaskReminderOptionId | number,
+    remindAtTime: string | null = null,
+    remindAtDay: string | null = null,
     specificReminder: boolean = false,
     isMoveToBacklog: boolean = false,
   ): void {
@@ -1037,6 +1039,8 @@ export class TaskService {
         remindAt: !specificReminder
           ? remindOptionToMilliseconds(due, remindTime as TaskReminderOptionId)
           : (remindTime as number),
+        remindAtTime: specificReminder ? remindAtTime : null,
+        remindAtDay: specificReminder ? remindAtDay : null,
         isMoveToBacklog,
       }),
     );
@@ -1046,12 +1050,16 @@ export class TaskService {
     task,
     due,
     remindTime,
+    remindAtTime,
+    remindAtDay,
     specificReminder,
     isMoveToBacklog = false,
   }: {
     task: Task;
     due: number;
     remindTime: TaskReminderOptionId | number;
+    remindAtTime: string | null;
+    remindAtDay: string | null;
     specificReminder: boolean;
     isMoveToBacklog: boolean;
   }): void {
@@ -1062,6 +1070,8 @@ export class TaskService {
         remindAt: !specificReminder
           ? remindOptionToMilliseconds(due, remindTime as TaskReminderOptionId)
           : (remindTime as number),
+        remindAtTime: specificReminder ? remindAtTime : null,
+        remindAtDay: specificReminder ? remindAtDay : null,
         isMoveToBacklog,
       }),
     );

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.ts
@@ -39,6 +39,8 @@ const handleScheduleTaskWithTime = (
   task: { id: string; projectId?: string | null },
   dueWithTime: number,
   remindAt?: number,
+  remindAtTime?: string | null,
+  remindAtDay?: string | null,
   isMoveToBacklog?: boolean,
 ): RootState => {
   // Check if task already has the same dueWithTime
@@ -61,6 +63,8 @@ const handleScheduleTaskWithTime = (
   if (
     currentTask.dueWithTime === dueWithTime &&
     currentTask.remindAt === remindAt &&
+    currentTask.remindAtTime === remindAtTime &&
+    currentTask.remindAtDay === remindAtDay &&
     isScheduledForToday === isCurrentlyInToday &&
     !isMoveToBacklog
   ) {
@@ -80,6 +84,8 @@ const handleScheduleTaskWithTime = (
           // See: docs/ai/dueDay-dueWithTime-mutual-exclusivity.md
           dueDay: undefined,
           remindAt,
+          remindAtTime: remindAtTime ?? undefined,
+          remindAtDay: remindAtDay ?? undefined,
         },
       },
       state[TASK_FEATURE_NAME],
@@ -308,26 +314,28 @@ const handleMoveTaskInTodayTagList = (
 
 const createActionHandlers = (state: RootState, action: Action): ActionHandlerMap => ({
   [TaskSharedActions.scheduleTaskWithTime.type]: () => {
-    const { task, dueWithTime, remindAt, isMoveToBacklog } = action as ReturnType<
-      typeof TaskSharedActions.scheduleTaskWithTime
-    >;
+    const { task, dueWithTime, remindAt, isMoveToBacklog, remindAtTime, remindAtDay } =
+      (action = action as ReturnType<typeof TaskSharedActions.scheduleTaskWithTime>);
     return handleScheduleTaskWithTime(
       state,
       task,
       dueWithTime,
       remindAt,
+      remindAtTime,
+      remindAtDay,
       isMoveToBacklog,
     );
   },
   [TaskSharedActions.reScheduleTaskWithTime.type]: () => {
-    const { task, dueWithTime, remindAt, isMoveToBacklog } = action as ReturnType<
-      typeof TaskSharedActions.reScheduleTaskWithTime
-    >;
+    const { task, dueWithTime, remindAt, isMoveToBacklog, remindAtTime, remindAtDay } =
+      action as ReturnType<typeof TaskSharedActions.reScheduleTaskWithTime>;
     return handleScheduleTaskWithTime(
       state,
       task,
       dueWithTime,
       remindAt,
+      remindAtTime,
+      remindAtDay,
       isMoveToBacklog,
     );
   },

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -127,6 +127,8 @@ export const TaskSharedActions = createActionGroup({
       task: Task;
       dueWithTime: number;
       remindAt?: number;
+      remindAtTime?: string | null;
+      remindAtDay?: string | null;
       isMoveToBacklog: boolean;
       isSkipAutoRemoveFromToday?: boolean;
     }) => ({
@@ -143,6 +145,8 @@ export const TaskSharedActions = createActionGroup({
       task: Task;
       dueWithTime: number;
       remindAt?: number;
+      remindAtTime?: string | null;
+      remindAtDay?: string | null;
       isMoveToBacklog: boolean;
       isSkipAutoRemoveFromToday?: boolean;
     }) => ({


### PR DESCRIPTION
## Problem

An issue was emitted to implement a feature to bring the desired flexibility for task reminders, while maintaining the simplicity of the interface (Issue #6531).
Based on the original and associated issue (#4667), we developed the following changes to the task reminder scheduling.

## Solution

Tasks will have the possibility to receive a costume task reminder time.
- The reminder time and date (seconds, minutes, hours, day, month, year) can be set manually in the scheduling dialogue.

## Type of Change

- [ ] Bug fix
- [x ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
