### PR TITLE
fix(tasks): keep done-sound at natural pitch when increase-pitch is off

### DIFF
--- a/src/app/features/tasks/util/play-done-sound.spec.ts
+++ b/src/app/features/tasks/util/play-done-sound.spec.ts
@@ -1,0 +1,95 @@
+import { playDoneSound } from './play-done-sound';
+import { clearAudioBufferCache, closeAudioContext } from '../../../util/audio-context';
+import { SoundConfig } from '../../config/global-config.model';
+
+describe('playDoneSound', () => {
+  let originalAudioContext: typeof AudioContext;
+  let originalFetch: typeof window.fetch;
+  let mockSource: { detune: { value: number }; [key: string]: unknown };
+
+  const BASE_CFG: SoundConfig = {
+    isIncreaseDoneSoundPitch: true,
+    doneSound: 'ding-small-bell.mp3',
+    breakReminderSound: null,
+    volume: 75,
+  };
+
+  /** Plays the sound through mocked Web Audio nodes and returns the applied detune (cents). */
+  const getDetune = async (cfg: SoundConfig, nrOfDoneTasks?: number): Promise<number> => {
+    await playDoneSound(cfg, nrOfDoneTasks);
+    return mockSource.detune.value;
+  };
+
+  beforeEach(() => {
+    originalAudioContext = (window as any).AudioContext;
+    originalFetch = window.fetch;
+
+    mockSource = {
+      detune: { value: 0 },
+      connect: jasmine.createSpy('connect'),
+      disconnect: jasmine.createSpy('disconnect'),
+      start: jasmine.createSpy('start'),
+      buffer: null,
+      onended: null,
+    };
+    const mockContext = {
+      state: 'running',
+      resume: jasmine.createSpy('resume').and.resolveTo(undefined),
+      close: jasmine.createSpy('close'),
+      decodeAudioData: jasmine
+        .createSpy('decodeAudioData')
+        .and.resolveTo({} as AudioBuffer),
+      createBufferSource: jasmine
+        .createSpy('createBufferSource')
+        .and.returnValue(mockSource),
+      createGain: jasmine.createSpy('createGain').and.returnValue({
+        connect: jasmine.createSpy('connect'),
+        disconnect: jasmine.createSpy('disconnect'),
+        gain: { value: 1 },
+      }),
+      destination: {} as AudioDestinationNode,
+    };
+    (window as any).AudioContext = jasmine
+      .createSpy('AudioContext')
+      .and.returnValue(mockContext);
+    (window as any).fetch = jasmine.createSpy('fetch').and.resolveTo({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    } as Response);
+
+    closeAudioContext();
+    clearAudioBufferCache();
+  });
+
+  afterEach(() => {
+    closeAudioContext();
+    (window as any).AudioContext = originalAudioContext;
+    (window as any).fetch = originalFetch;
+  });
+
+  describe('when increase-pitch is disabled (#8265)', () => {
+    const cfg: SoundConfig = { ...BASE_CFG, isIncreaseDoneSoundPitch: false };
+
+    it('never shifts pitch — plays the natural sample regardless of done-task count', async () => {
+      expect(await getDetune(cfg, 0)).toBe(0);
+      expect(await getDetune(cfg, 20)).toBe(0);
+    });
+
+    it('matches the enabled mode’s first-ding pitch', async () => {
+      const disabled = await getDetune(cfg);
+      const enabledFirstTask = await getDetune(BASE_CFG, 0);
+      expect(disabled).toBe(enabledFirstTask);
+    });
+  });
+
+  describe('when increase-pitch is enabled', () => {
+    it('starts at the natural pitch and only ever rises', async () => {
+      expect(await getDetune(BASE_CFG, 0)).toBe(0);
+      expect(await getDetune(BASE_CFG, 1)).toBe(50);
+    });
+
+    it('clamps to the maximum pitch', async () => {
+      expect(await getDetune(BASE_CFG, 1000)).toBe(300);
+    });
+  });
+});

--- a/src/app/features/tasks/util/play-done-sound.ts
+++ b/src/app/features/tasks/util/play-done-sound.ts
@@ -3,7 +3,7 @@ import { TaskLog } from '../../../core/log';
 import { getAudioBuffer, playBuffer } from '../../../util/audio-context';
 
 const BASE = './assets/snd';
-const PITCH_OFFSET = -400;
+const PITCH_PER_TASK = 50;
 const MAX_PITCH = 300;
 
 /**
@@ -19,9 +19,11 @@ export const playDoneSound = async (
   const file = `${BASE}/${soundCfg.doneSound}`;
   TaskLog.log(file);
 
-  const pitchIncrement = nrOfDoneTasks * 50;
+  // detune 0 plays the sample at its natural pitch. When the toggle is off we
+  // never shift it; when on, pitch only ever rises above that baseline (50 cents
+  // per completed task, clamped to MAX_PITCH) and never drops below it (#8265).
   const pitchFactor = soundCfg.isIncreaseDoneSoundPitch
-    ? Math.min(PITCH_OFFSET + pitchIncrement, MAX_PITCH)
+    ? Math.min(nrOfDoneTasks * PITCH_PER_TASK, MAX_PITCH)
     : 0;
 
   try {


### PR DESCRIPTION
Fixes #8265

## Problem
Disabling **"Increase pitch for every task completed"** made the task-completion ding jump *up* in pitch instead of staying low. The reporter heard it as "stuck at the highest pitch."

## Root cause
`play-done-sound.ts` mapped the toggle-off state to `detune = 0` (the sample's natural pitch), but the toggle-*on* state started from a `-400` cent floor for the first task. So "off" (0) sat **above** the on-mode's early dings — turning the feature off raised the pitch.

## Fix
Raise the on-mode floor to the natural pitch so the progression only ever *rises* from baseline:

- **Off** → `detune 0` (natural pitch, never shifted)
- **On**, task 0 → `0` (same as off)
- **On** → `+50` cents per completed task, clamped to `+300`

With the floor at natural pitch, "off" is now both the natural **and** the lowest pitch — matching the toggle label ("*Increase* pitch…") and the reporter's expectation.

## Tests
New `play-done-sound.spec.ts` (4 specs): off stays at `0` for any done-count, off == on-at-task-0, on rises `0 → 50 → … → 300` clamp. Verified the suite fails on the pre-fix code and passes after. `npm run checkFile` clean on both files.