### PR TITLE
feat(config): respect locale time format in time-of-day settings

### DIFF
--- a/src/app/features/config/form-cfgs/misc-settings-form.const.ts
+++ b/src/app/features/config/form-cfgs/misc-settings-form.const.ts
@@ -5,6 +5,7 @@ import {
 } from '../global-config.model';
 import { T } from '../../../t.const';
 import { IS_ELECTRON, IS_GNOME_DESKTOP } from '../../../app.constants';
+import { isValidSplitTime } from '../../../util/is-valid-split-time';
 
 export const MISC_SETTINGS_FORM_CFG: ConfigFormSection<MiscConfig> = {
   title: T.GCF.MISC.TITLE,
@@ -51,16 +52,18 @@ export const MISC_SETTINGS_FORM_CFG: ConfigFormSection<MiscConfig> = {
       : []) as LimitedFormlyFieldConfig<MiscConfig>[]),
     {
       key: 'startOfNextDayTime',
-      type: 'input',
+      type: 'time',
       defaultValue: '00:00',
       templateOptions: {
         required: true,
         label: T.GCF.MISC.START_OF_NEXT_DAY,
         description: T.GCF.MISC.START_OF_NEXT_DAY_HINT,
-        type: 'text',
-        pattern: '^([01]\\d|2[0-3]):([0-5]\\d)$',
-        maxLength: 5,
-        minLength: 5,
+      },
+      // Guard against a corrupt/legacy stored value (e.g. from an import): a
+      // truthy-but-invalid time would otherwise display blank yet pass silently.
+      // Mirrors the work-time fields in schedule-form.const.ts.
+      validators: {
+        validTimeString: (c: { value: string | undefined }) => isValidSplitTime(c.value),
       },
     },
     {

--- a/src/app/features/config/form-cfgs/schedule-form.const.ts
+++ b/src/app/features/config/form-cfgs/schedule-form.const.ts
@@ -17,7 +17,7 @@ export const SCHEDULE_FORM_CFG: ConfigFormSection<ScheduleConfig> = {
     {
       hideExpression: (m, v, field) => !field?.model.isWorkStartEndEnabled,
       key: 'workStart',
-      type: 'input',
+      type: 'time',
       templateOptions: {
         required: true,
         label: T.GCF.SCHEDULE.L_WORK_START,
@@ -32,7 +32,7 @@ export const SCHEDULE_FORM_CFG: ConfigFormSection<ScheduleConfig> = {
     {
       hideExpression: (m, v, field) => !field?.model.isWorkStartEndEnabled,
       key: 'workEnd',
-      type: 'input',
+      type: 'time',
       templateOptions: {
         required: true,
         label: T.GCF.SCHEDULE.L_WORK_END,
@@ -54,7 +54,7 @@ export const SCHEDULE_FORM_CFG: ConfigFormSection<ScheduleConfig> = {
     {
       hideExpression: (m, v, field) => !field?.model.isLunchBreakEnabled,
       key: 'lunchBreakStart',
-      type: 'input',
+      type: 'time',
       templateOptions: {
         required: true,
         label: T.GCF.SCHEDULE.L_LUNCH_BREAK_START,
@@ -69,7 +69,7 @@ export const SCHEDULE_FORM_CFG: ConfigFormSection<ScheduleConfig> = {
     {
       hideExpression: (m, v, field) => !field?.model.isLunchBreakEnabled,
       key: 'lunchBreakEnd',
-      type: 'input',
+      type: 'time',
       templateOptions: {
         required: true,
         label: T.GCF.SCHEDULE.L_LUNCH_BREAK_END,

--- a/src/app/ui/formly-config.module.ts
+++ b/src/app/ui/formly-config.module.ts
@@ -4,6 +4,7 @@ import { MarkdownModule } from 'ngx-markdown';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FORMLY_CONFIG, FormlyModule } from '@ngx-formly/core';
 import { InputDurationFormlyComponent } from './duration/input-duration-formly/input-duration-formly.component';
+import { InputTimeFormlyComponent } from './input-time/input-time-formly/input-time-formly.component';
 import { ValidationModule } from './validation/validation.module';
 import { TranslateService } from '@ngx-translate/core';
 import { FormlyMaterialModule } from '@ngx-formly/material';
@@ -53,6 +54,12 @@ import { FormlyDatePickerComponent } from './formly-date-picker/formly-date-pick
         {
           name: 'duration',
           component: InputDurationFormlyComponent,
+          extends: 'input',
+          wrappers: ['form-field'],
+        },
+        {
+          name: 'time',
+          component: InputTimeFormlyComponent,
           extends: 'input',
           wrappers: ['form-field'],
         },

--- a/src/app/ui/input-time/input-time-formly/input-time-formly.component.html
+++ b/src/app/ui/input-time/input-time-formly/input-time-formly.component.html
@@ -1,0 +1,11 @@
+<input
+  type="time"
+  inputTime
+  step="60"
+  [name]="props.name"
+  [required]="!!props.required"
+  [readonly]="props.readonly"
+  [formControl]="formControl"
+  [formlyAttributes]="field"
+  matInput
+/>

--- a/src/app/ui/input-time/input-time-formly/input-time-formly.component.spec.ts
+++ b/src/app/ui/input-time/input-time-formly/input-time-formly.component.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InputTimeFormlyComponent } from './input-time-formly.component';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatInputModule } from '@angular/material/input';
+
+describe('InputTimeFormlyComponent', () => {
+  let component: InputTimeFormlyComponent;
+  let fixture: ComponentFixture<InputTimeFormlyComponent>;
+  let formControl: FormControl;
+
+  const getInput = (): HTMLInputElement =>
+    fixture.nativeElement.querySelector('input[type=time]');
+
+  const setup = async (initialValue: string | null): Promise<void> => {
+    await TestBed.configureTestingModule({
+      imports: [
+        InputTimeFormlyComponent,
+        ReactiveFormsModule,
+        FormlyModule.forRoot(),
+        BrowserAnimationsModule,
+        MatInputModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InputTimeFormlyComponent);
+    component = fixture.componentInstance;
+
+    formControl = new FormControl(initialValue);
+    Object.defineProperty(component, 'formControl', {
+      get: () => formControl,
+      configurable: true,
+    });
+    component.field = {
+      key: 'workStart',
+      type: 'time',
+      props: {},
+      templateOptions: {},
+    } as FormlyFieldConfig;
+
+    fixture.detectChanges();
+  };
+
+  it('renders a native time input', async () => {
+    await setup('09:00');
+    expect(getInput()).toBeTruthy();
+  });
+
+  it('displays a legacy unpadded model value zero-padded', async () => {
+    await setup('9:00');
+    expect(getInput().value).toBe('09:00');
+  });
+
+  it('writes the canonical HH:mm back to the model on input', async () => {
+    await setup('09:00');
+    const input = getInput();
+    input.value = '17:30';
+    input.dispatchEvent(new Event('input'));
+    expect(formControl.value).toBe('17:30');
+  });
+
+  it('clears the model when the field is emptied', async () => {
+    await setup('09:00');
+    const input = getInput();
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    expect(formControl.value).toBe('');
+  });
+});

--- a/src/app/ui/input-time/input-time-formly/input-time-formly.component.ts
+++ b/src/app/ui/input-time/input-time-formly/input-time-formly.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/material';
+import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
+import { MatInput } from '@angular/material/input';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { InputTimeDirective } from '../input-time.directive';
+
+/**
+ * Formly `time` field type: a native `<input type="time">` that respects the
+ * browser/OS locale's 12h/24h preference while storing a canonical `HH:mm`
+ * string (see {@link InputTimeDirective}).
+ */
+@Component({
+  selector: 'input-time-formly',
+  templateUrl: './input-time-formly.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [InputTimeDirective, MatInput, FormsModule, FormlyModule, ReactiveFormsModule],
+})
+export class InputTimeFormlyComponent extends FieldType<FormlyFieldConfig> {}

--- a/src/app/ui/input-time/input-time.directive.spec.ts
+++ b/src/app/ui/input-time/input-time.directive.spec.ts
@@ -1,0 +1,86 @@
+import { ElementRef, Renderer2 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { InputTimeDirective } from './input-time.directive';
+
+describe('InputTimeDirective', () => {
+  let directive: InputTimeDirective;
+  let nativeElement: { value: string; disabled: boolean };
+  let renderer: jasmine.SpyObj<Renderer2>;
+
+  beforeEach(() => {
+    nativeElement = { value: '', disabled: false };
+    renderer = jasmine.createSpyObj<Renderer2>('Renderer2', ['setProperty']);
+    renderer.setProperty.and.callFake((_el: unknown, prop: string, val: unknown) => {
+      (nativeElement as Record<string, unknown>)[prop] = val;
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ElementRef, useValue: new ElementRef(nativeElement) },
+        { provide: Renderer2, useValue: renderer },
+      ],
+    });
+
+    directive = TestBed.runInInjectionContext(() => new InputTimeDirective());
+  });
+
+  describe('writeValue (model → display)', () => {
+    it('zero-pads a legacy unpadded value for display', () => {
+      directive.writeValue('9:00');
+      expect(nativeElement.value).toBe('09:00');
+    });
+
+    it('passes through an already-padded value', () => {
+      directive.writeValue('17:00');
+      expect(nativeElement.value).toBe('17:00');
+    });
+
+    it('clears the display for an empty/invalid value', () => {
+      directive.writeValue(null);
+      expect(nativeElement.value).toBe('');
+    });
+
+    it('does NOT re-emit when only displaying a legacy value (no spurious change)', () => {
+      const onChange = jasmine.createSpy('onChange');
+      directive.registerOnChange(onChange);
+
+      directive.writeValue('9:00');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onInput (display → model)', () => {
+    it('emits the canonical HH:mm the native control provides', () => {
+      const onChange = jasmine.createSpy('onChange');
+      directive.registerOnChange(onChange);
+
+      directive.onInput('13:45');
+
+      expect(onChange).toHaveBeenCalledWith('13:45');
+    });
+
+    it('strips a stray seconds segment before emitting', () => {
+      const onChange = jasmine.createSpy('onChange');
+      directive.registerOnChange(onChange);
+
+      directive.onInput('13:45:30');
+
+      expect(onChange).toHaveBeenCalledWith('13:45');
+    });
+
+    it('emits an empty string when the field is cleared', () => {
+      const onChange = jasmine.createSpy('onChange');
+      directive.registerOnChange(onChange);
+
+      directive.onInput('');
+
+      expect(onChange).toHaveBeenCalledWith('');
+    });
+  });
+
+  it('reflects the disabled state onto the element', () => {
+    directive.setDisabledState(true);
+    expect(nativeElement.disabled).toBe(true);
+  });
+});

--- a/src/app/ui/input-time/input-time.directive.ts
+++ b/src/app/ui/input-time/input-time.directive.ts
@@ -1,0 +1,74 @@
+import {
+  Directive,
+  ElementRef,
+  forwardRef,
+  HostListener,
+  inject,
+  Renderer2,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { toPaddedClockStr } from '../../util/to-padded-clock-str';
+
+/**
+ * Value accessor for a native `<input type="time">` that keeps the bound model
+ * value as a canonical zero-padded `HH:mm` string.
+ *
+ * The native control renders 12h/24h based on the browser/OS locale, but it
+ * only *displays* zero-padded values — so a legacy config holding `9:00` would
+ * show blank without this. On write we pad for display; on input we normalize
+ * back to `HH:mm` (dropping any stray seconds), so the model never drifts from
+ * canonical `HH:mm` regardless of how the value was entered.
+ *
+ * We intentionally do NOT re-emit the padded value on write: a legacy `9:00`
+ * displays as `09:00` but stays `9:00` in the model until the user actually
+ * edits it, so merely opening a settings page never dirties the form or writes
+ * a spurious sync op.
+ */
+@Directive({
+  selector: 'input[type=time][inputTime]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => InputTimeDirective),
+      multi: true,
+    },
+  ],
+})
+export class InputTimeDirective implements ControlValueAccessor {
+  private _elementRef = inject(ElementRef);
+  private _renderer = inject(Renderer2);
+
+  private _onChange: (value: string) => void = () => {};
+  private _onTouched: () => void = () => {};
+
+  @HostListener('input', ['$event.target.value'])
+  onInput(value: string): void {
+    this._onChange(toPaddedClockStr(value));
+  }
+
+  @HostListener('blur')
+  onBlur(): void {
+    this._onTouched();
+  }
+
+  writeValue(value: string | null): void {
+    this._renderer.setProperty(
+      this._elementRef.nativeElement,
+      'value',
+      toPaddedClockStr(value),
+    );
+  }
+
+  registerOnChange(fn: (value: string) => void): void {
+    this._onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
+}

--- a/src/app/util/to-padded-clock-str.spec.ts
+++ b/src/app/util/to-padded-clock-str.spec.ts
@@ -1,0 +1,51 @@
+import { toPaddedClockStr } from './to-padded-clock-str';
+
+describe('toPaddedClockStr', () => {
+  it('zero-pads a single-digit hour', () => {
+    expect(toPaddedClockStr('9:00')).toBe('09:00');
+  });
+
+  it('leaves an already-padded value unchanged', () => {
+    expect(toPaddedClockStr('17:05')).toBe('17:05');
+  });
+
+  it('zero-pads a single-digit minute', () => {
+    expect(toPaddedClockStr('9:5')).toBe('09:05');
+  });
+
+  it('drops a stray seconds segment', () => {
+    expect(toPaddedClockStr('13:30:00')).toBe('13:30');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(toPaddedClockStr('  8:30 ')).toBe('08:30');
+  });
+
+  it('handles midnight', () => {
+    expect(toPaddedClockStr('0:00')).toBe('00:00');
+  });
+
+  it('handles the last minute of the day', () => {
+    expect(toPaddedClockStr('23:59')).toBe('23:59');
+  });
+
+  describe('invalid input → empty string', () => {
+    [
+      undefined,
+      null,
+      '',
+      'abc',
+      '25:00',
+      '24:00',
+      '13:60',
+      '12',
+      ':30',
+      '9:',
+      '9.5:00',
+    ].forEach((v) => {
+      it(`returns '' for ${JSON.stringify(v)}`, () => {
+        expect(toPaddedClockStr(v)).toBe('');
+      });
+    });
+  });
+});

--- a/src/app/util/to-padded-clock-str.ts
+++ b/src/app/util/to-padded-clock-str.ts
@@ -1,0 +1,44 @@
+import { normalizeClockStr } from './normalize-clock-str';
+
+/**
+ * Convert a stored clock string to the zero-padded `HH:mm` that a native
+ * `<input type="time">` requires in order to display it.
+ *
+ * Legacy configs store unpadded values like `9:00` (the app's own
+ * `DEFAULT_DAY_START`), which the native control silently renders blank. Stray
+ * seconds (`13:30:00`) are dropped via {@link normalizeClockStr} so the value
+ * stays canonical `HH:mm`.
+ *
+ * Returns '' for empty or genuinely invalid input (`25:00`, `13:60`, `abc`), so
+ * the field shows empty rather than a stale or browser-rejected value.
+ *
+ * @example
+ * toPaddedClockStr('9:00');     // '09:00'
+ * toPaddedClockStr('13:30:00'); // '13:30'
+ * toPaddedClockStr('25:00');    // ''
+ */
+export const toPaddedClockStr = (value: string | null | undefined): string => {
+  if (!value) {
+    return '';
+  }
+  const [hStr, mStr] = normalizeClockStr(value).split(':');
+  if (!hStr?.trim() || !mStr?.trim()) {
+    return '';
+  }
+  const h = Number(hStr);
+  const m = Number(mStr);
+  // Deliberately stricter than isValidSplitTime (which accepts hour 24): a
+  // native <input type="time"> caps at 23:59, so a stored `24:00` can only ever
+  // render blank — returning '' here keeps display and validation in agreement.
+  if (
+    !Number.isInteger(h) ||
+    !Number.isInteger(m) ||
+    h < 0 ||
+    h > 23 ||
+    m < 0 ||
+    m > 59
+  ) {
+    return '';
+  }
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+};


### PR DESCRIPTION
## Summary

The "Start time of the next day" (Misc Settings) and "Work Day Start/End" + lunch break (Schedule) settings were plain text inputs hard-wired to 24h `HH:mm`, ignoring the user's time-format preference (#8264). A US user couldn't enter times in 12h AM/PM.

They're now a shared, reusable formly `time` field type backed by a native `<input type="time">` — locale-aware 12h/24h with a real picker — while the **stored value stays canonical 24h `HH:mm`** (feeds the logical day-boundary clock + scheduling, unchanged → sync-safe).

## Changes

- **`toPaddedClockStr` util** — zero-pads to `HH:mm`, strips stray seconds, returns `''` for invalid. Native inputs only render zero-padded values, and `DEFAULT_DAY_START` is the unpadded `'9:00'`.
- **`inputTime` ControlValueAccessor directive** (mirrors `InputDurationDirective`) — pads legacy values for display, normalizes input back to canonical `HH:mm`. Deliberately does **not** re-emit on write, so opening a settings page never dirties the form or writes a spurious sync op; a legacy `9:00` displays as `09:00` but stays `9:00` in the model until the user edits it.
- **`InputTimeFormlyComponent`** + registered `time` formly type (mirrors the existing `duration` type).
- Converted the 5 config fields from text `input` to `time`; kept the `validTimeString` validator on all of them for parity.

## Why it's sync-safe

The stored string format is unchanged 24h `HH:mm`. All downstream consumers parse numerically (`getStartOfNextDayHourFromTimeString`, `getHoursFromClockString`, `getDateTimeFromClockString`, `isValidSplitTime`) and tolerate both padded and unpadded values. No reducer/effect/vector-clock surface is touched.

## Tradeoff

Native time inputs follow the **browser/OS locale**, not the in-app `dateTimeLocale` setting; they diverge only when those differ. This is consistent with the schedule dialog, which already uses a native `<input type="time">`.

## Testing

- 30 new unit tests: `to-padded-clock-str` (18), `input-time.directive` (8), and a `input-time-formly` integration test (4) that renders the real native input and asserts `9:00`→`09:00` display + canonical round-trip.
- `checkFile` clean on all changed files.
- Not yet verified visually in packaged Electron / iOS / Android (renders in headless Chromium = same engine).

Closes #8264