### PR TITLE
perf(tasks): reduce per-task store subscriptions and selector overhead

### DIFF
--- a/src/app/features/tasks/store/short-syntax.effects.ts
+++ b/src/app/features/tasks/store/short-syntax.effects.ts
@@ -205,7 +205,9 @@ export class ShortSyntaxEffects {
 
             // Build task changes including tagIds update
             const tagIds: string[] = [...(r.taskChanges.tagIds || task.tagIds)];
-            const isEqualTags = JSON.stringify(tagIds) === JSON.stringify(task.tagIds);
+            const isEqualTags =
+              tagIds.length === task.tagIds.length &&
+              tagIds.every((id, i) => id === task.tagIds[i]);
             const finalTaskChanges = { ...taskChanges };
             if (tagIds && tagIds.length && !isEqualTags) {
               finalTaskChanges.tagIds = unique(tagIds);

--- a/src/app/features/tasks/store/task.selectors.spec.ts
+++ b/src/app/features/tasks/store/task.selectors.spec.ts
@@ -545,6 +545,62 @@ describe('Task Selectors', () => {
       expect(result[0].id).toBe('olderOverdue');
       expect(result[1].id).toBe('task6');
     });
+
+    it('selectOverdueTasksWithSubTasks should keep a stable order for calendar-invalid dueDay values', () => {
+      const twoDaysMs = 2 * 86400000;
+      const twoDaysAgo = getDbDateStr(new Date(Date.now() - twoDaysMs));
+
+      // Passes the lexical isDBDateStr guard but parses to Invalid Date (NaN)
+      const invalidDueDay: Task = {
+        id: 'invalidDueDay',
+        title: 'Invalid Due Day',
+        created: Date.now(),
+        isDone: false,
+        subTaskIds: [],
+        tagIds: [],
+        projectId: 'project1',
+        timeSpentOnDay: {},
+        dueDay: '2024-02-30',
+        timeEstimate: 0,
+        timeSpent: 0,
+        attachments: [],
+      };
+      const olderOverdue: Task = {
+        ...invalidDueDay,
+        id: 'olderOverdue',
+        title: 'Older Overdue',
+        dueDay: twoDaysAgo,
+      };
+
+      const stateWithInvalidDueDay = {
+        ...mockState,
+        [TASK_FEATURE_NAME]: {
+          ...mockTaskState,
+          ids: [...mockTaskState.ids, 'invalidDueDay', 'olderOverdue'],
+          entities: {
+            ...mockTaskState.entities,
+            invalidDueDay,
+            olderOverdue,
+          },
+        },
+      };
+
+      // the invalid date string triggers devError, which throws when the globally
+      // mocked confirm() returns true (see src/test.ts) — opt out for this test
+      const confirmSpy = window.confirm as unknown as jasmine.Spy;
+      confirmSpy.and.returnValue(false);
+      try {
+        const result =
+          fromSelectors.selectOverdueTasksWithSubTasks(stateWithInvalidDueDay);
+        expect(result.length).toBe(3);
+        // NaN-parsing dueDay is pinned to the front; valid tasks stay chronological
+        expect(result[0].id).toBe('invalidDueDay');
+        expect(result[1].id).toBe('olderOverdue');
+        expect(result[2].id).toBe('task6');
+      } finally {
+        confirmSpy.and.returnValue(true);
+      }
+    });
     describe('selectOverdueTasks with startOfNextDayDiffMs offset', () => {
       const FOUR_HOURS = 4 * 3600 * 1000;
 

--- a/src/app/features/tasks/store/task.selectors.ts
+++ b/src/app/features/tasks/store/task.selectors.ts
@@ -298,29 +298,29 @@ export const selectOverdueTasksWithSubTasks = createSelector(
           (!task.parentId || !overdueIdSet.has(task.parentId)) && !task.isDone,
       )
       .map((task) => {
-        return mapSubTasksToTask(task as Task, taskState) as TaskWithSubTasks;
-      })
-      .sort((a, b) => {
-        // sort all chronologically
-        if (a.dueWithTime && b.dueWithTime) {
-          return a.dueWithTime - b.dueWithTime;
-        } else if (a.dueWithTime && b.dueDay) {
-          // Use dateStrToUtcDate to avoid timezone issues
-          const bStartOfDueDay = dateStrToUtcDate(b.dueDay);
-          bStartOfDueDay.setHours(0, 0, 0, 0);
-          return a.dueWithTime - bStartOfDueDay.getTime();
-        } else if (a.dueDay && b.dueWithTime) {
-          // Use dateStrToUtcDate to avoid timezone issues
-          const aStartOfDueDay = dateStrToUtcDate(a.dueDay);
-          aStartOfDueDay.setHours(0, 0, 0, 0);
-          return aStartOfDueDay.getTime() - b.dueWithTime;
-        } else if (a.dueDay && b.dueDay) {
-          // Note: String comparison works correctly here because dueDay is in YYYY-MM-DD format
-          // which is lexicographically sortable. This avoids timezone conversion issues.
-          return a.dueDay.localeCompare(b.dueDay);
+        // Pre-compute a chronological sort key so the comparator stays allocation-free
+        // (parsing dueDay inside .sort() costs O(n log n) Date objects).
+        // dueWithTime takes priority over dueDay; dueDay counts as start of that day.
+        // Use dateStrToUtcDate to avoid timezone issues.
+        let sortKey = 0;
+        if (task.dueWithTime) {
+          sortKey = task.dueWithTime;
+        } else if (task.dueDay) {
+          const startOfDueDay = dateStrToUtcDate(task.dueDay);
+          startOfDueDay.setHours(0, 0, 0, 0);
+          const startOfDueDayMs = startOfDueDay.getTime();
+          // A calendar-invalid dueDay (e.g. 2024-02-30 passes the lexical isDBDateStr
+          // guard in selectOverdueTasks) parses to NaN, which would poison the sort
+          // comparator; pin such tasks to the front instead.
+          sortKey = Number.isNaN(startOfDueDayMs) ? 0 : startOfDueDayMs;
         }
-        return 0;
-      });
+        return {
+          task: mapSubTasksToTask(task as Task, taskState) as TaskWithSubTasks,
+          sortKey,
+        };
+      })
+      .sort((a, b) => a.sortKey - b.sortKey)
+      .map((t) => t.task);
   },
 );
 

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -56,6 +56,7 @@ import {
   selectTasksByRepeatConfigId,
   selectTasksByTag,
   selectTaskWithSubTasksByRepeatConfigId,
+  selectTimeConflictTaskIds,
 } from './store/task.selectors';
 import { selectTodayTaskIds } from '../work-context/store/work-context.selectors';
 import { RoundTimeOption } from '../project/project.model';
@@ -152,6 +153,11 @@ export class TaskService {
 
   // Set version for O(1) lookup - used by task components to check membership
   todayListSet = computed(() => new Set(this.todayList()));
+
+  // Shared signal to avoid one store subscription per rendered task component
+  timeConflictTaskIds = toSignal(this._store.pipe(select(selectTimeConflictTaskIds)), {
+    initialValue: new Set<string>(),
+  });
 
   selectedTask$: Observable<TaskWithSubTasks | null> = this._store.pipe(
     select(selectSelectedTask),

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -77,6 +77,7 @@ describe('TaskComponent shortcut handling', () => {
         currentTaskId: signal<string | null>(null),
         selectedTaskId: signal<string | null>(null),
         todayListSet: signal<Set<string>>(new Set<string>()),
+        timeConflictTaskIds: signal<Set<string>>(new Set<string>()),
       },
     );
     // Default: any parent lookup returns an empty-subTasks shell.

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -74,7 +74,7 @@ import { DialogDeadlineComponent } from '../dialog-deadline/dialog-deadline.comp
 import { isDeadlineOverdue as isDeadlineOverdueFn } from '../util/is-deadline-overdue';
 import { isDeadlineApproaching as isDeadlineApproachingFn } from '../util/is-deadline-approaching';
 import { TaskContextMenuComponent } from '../task-context-menu/task-context-menu.component';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ICAL_TYPE } from '../../issue/issue.const';
 import { TaskTitleComponent } from '../../../ui/task-title/task-title.component';
 import { MatIcon } from '@angular/material/icon';
@@ -98,7 +98,6 @@ import { GlobalTrackingIntervalService } from '../../../core/global-tracking-int
 import { TaskLog } from '../../../core/log';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
 import { TaskFocusService } from '../task-focus.service';
-import { selectTimeConflictTaskIds } from '../store/task.selectors';
 import { MatTooltip } from '@angular/material/tooltip';
 import { millisecondsDiffToRemindOption } from '../util/remind-option-to-milliseconds';
 import { MenuTreeService } from '../../menu-tree/menu-tree.service';
@@ -172,10 +171,6 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   readonly workContextService = inject(WorkContextService);
   readonly layoutService = inject(LayoutService);
   readonly globalTrackingIntervalService = inject(GlobalTrackingIntervalService);
-  private readonly _timeConflictTaskIds = toSignal(
-    this._store.select(selectTimeConflictTaskIds),
-    { initialValue: new Set<string>() },
-  );
 
   task = input.required<TaskWithSubTasks>();
   isBacklog = input<boolean>(false);
@@ -251,7 +246,8 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
   hasTimeConflict = computed(() => {
     const task = this.task();
     return (
-      typeof task.dueWithTime === 'number' && this._timeConflictTaskIds().has(task.id)
+      typeof task.dueWithTime === 'number' &&
+      this._taskService.timeConflictTaskIds().has(task.id)
     );
   });
 


### PR DESCRIPTION
## Summary

Three targeted performance improvements in the tasks feature, found via a codebase-wide perf audit and verified with adversarial review:

- **Share a single `timeConflictTaskIds` signal via `TaskService`** instead of creating one `toSignal(store.select(selectTimeConflictTaskIds))` per rendered task component. In long lists this removes hundreds of store subscriptions; follows the existing `todayListSet` shared-signal pattern (and its "avoid creating 200+ subscriptions" rationale).
- **`selectOverdueTasksWithSubTasks`: precompute numeric sort keys** instead of parsing `dueDay` via `dateStrToUtcDate` inside the sort comparator (O(n) Date allocations instead of O(n log n)). Ordering is unchanged for all reachable inputs: every task passing `selectOverdueTasks` has `dueDay` or `dueWithTime`, and `dueWithTime` keeps priority for legacy both-set data. Calendar-invalid `dueDay` values (e.g. `2024-02-30`, which passes the lexical `isDBDateStr` guard but parses to `NaN`) are guarded so they can no longer poison the comparator — this also hardens a pre-existing NaN exposure in the old mixed-branch comparison.
- **`short-syntax.effects.ts`: replace `JSON.stringify` array comparison** with length + element-wise equality (allocation-free, exactly equivalent for `string[]`).

No sync-relevant surface is touched: selectors, one in-effect comparison, and component/service wiring only — no state shape, reducer, or effect-trigger changes; selectors remain pure and replay-deterministic.

## Test plan

- [x] New regression test: calendar-invalid `dueDay` keeps a stable, deterministic overdue order
- [x] `task.selectors.spec.ts` 57/57, `short-syntax.effects.spec.ts` 7/7, `task.service.spec.ts` 60/60, `task-shortcuts.spec.ts` 17/17 (spy extended with the new signal)
- [x] Adjacent suites rendering tasks: board-panel 23, select-task 6, focus-panel-sync 13, focus-mode-task-selector 14
- [x] `npm run checkFile` clean on all modified files
- [x] Reviewed by two independent agents (general code review + adversarial equivalence verification); the one refuted edge case (NaN sort key) is fixed and covered by the new test