### PR TITLE
fix(android): pause web-layer 1s tick while app is backgrounded (#8243)

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -17,6 +17,15 @@ export const DRAG_DELAY_FOR_TOUCH = 500;
 // charge can't silently add 8 h to the active task.
 export const MOBILE_BACKGROUND_IDLE_CAP_MS = 4 * 60 * 60 * 1000;
 
+// Maximum wall-clock gap credited to generic tick$ consumers (running
+// stopwatch counters, break tracking) when the Android tick interval — paused
+// while backgrounded (#8243) — restarts on resume. Deliberately more generous
+// than the iOS cap above (a stopwatch left running through a workday away
+// from the app keeps counting): unlike iOS, the active task is unaffected by
+// this cap either way, since it reconciles from the native foreground-service
+// counter.
+export const ANDROID_BACKGROUND_TICK_CAP_MS = 8 * 60 * 60 * 1000;
+
 // TODO use
 // const CORS_SKIP_EXTRA_HEADER_PROP = 'sp_cors_skip' as const;
 // export const CORS_SKIP_EXTRA_HEADERS: { [name: string]: string } = IS_ANDROID_WEB_VIEW

--- a/src/app/core/global-tracking-interval/global-tracking-interval.service.spec.ts
+++ b/src/app/core/global-tracking-interval/global-tracking-interval.service.spec.ts
@@ -1,8 +1,61 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import { GlobalTrackingIntervalService } from './global-tracking-interval.service';
+import { Subject } from 'rxjs';
+import {
+  createGlobalInterval$,
+  GlobalTrackingIntervalService,
+} from './global-tracking-interval.service';
 import { TRACKING_INTERVAL } from '../../app.constants';
 import { DateService } from '../date/date.service';
+
+describe('createGlobalInterval$', () => {
+  it('should emit a plain interval when no background stream is provided', fakeAsync(() => {
+    const emissions: number[] = [];
+    const sub = createGlobalInterval$().subscribe((v) => emissions.push(v));
+
+    tick(TRACKING_INTERVAL * 2);
+    sub.unsubscribe();
+
+    expect(emissions.length).toBe(2);
+  }));
+
+  it('should pause emissions while backgrounded and resume afterwards', fakeAsync(() => {
+    const isInBackground$ = new Subject<boolean>();
+    const emissions: number[] = [];
+    const sub = createGlobalInterval$(isInBackground$).subscribe((v) =>
+      emissions.push(v),
+    );
+
+    tick(TRACKING_INTERVAL * 2);
+    expect(emissions.length).toBe(2);
+
+    isInBackground$.next(true);
+    tick(TRACKING_INTERVAL * 60);
+    expect(emissions.length).toBe(2);
+
+    isInBackground$.next(false);
+    tick(TRACKING_INTERVAL);
+    expect(emissions.length).toBe(3);
+
+    sub.unsubscribe();
+  }));
+
+  it('should not restart the interval on duplicate foreground emissions', fakeAsync(() => {
+    const isInBackground$ = new Subject<boolean>();
+    const emissions: number[] = [];
+    const sub = createGlobalInterval$(isInBackground$).subscribe((v) =>
+      emissions.push(v),
+    );
+
+    // a duplicate "foreground" half-way through the interval must not reset it
+    tick(TRACKING_INTERVAL / 2);
+    isInBackground$.next(false);
+    tick(TRACKING_INTERVAL / 2);
+
+    expect(emissions.length).toBe(1);
+    sub.unsubscribe();
+  }));
+});
 
 describe('GlobalTrackingIntervalService', () => {
   beforeEach(() => {

--- a/src/app/core/global-tracking-interval/global-tracking-interval.service.ts
+++ b/src/app/core/global-tracking-interval/global-tracking-interval.service.ts
@@ -11,11 +11,44 @@ import {
   share,
   shareReplay,
   startWith,
+  switchMap,
   tap,
 } from 'rxjs/operators';
 import { Tick } from './tick.model';
 import { DateService } from 'src/app/core/date/date.service';
 import { Log } from '../log';
+import { IS_ANDROID_WEB_VIEW } from '../../util/is-android-web-view';
+import { androidInterface } from '../../features/android/android-interface';
+
+/**
+ * Builds the shared 1s tick source. When a background-state stream is given
+ * (Android WebView), the interval is unsubscribed while the app is
+ * backgrounded: the tracking/focus foreground services keep the process alive
+ * there, so a free-running interval would run store dispatches + change
+ * detection once per second around the clock — the web-layer half of the
+ * #8243 battery drain. Consumers lose no time: ticks are wall-clock deltas,
+ * and on resume AndroidForegroundTrackingEffects emits one capped wake-up
+ * tick covering the gap (mirroring the iOS resume path), while current-task
+ * time is reconciled from the native counter anyway.
+ *
+ * Desktop/Electron intentionally keeps the free-running interval — tracking
+ * while the window is hidden/minimized is a feature there.
+ *
+ * Exported so unit tests can drive the background gating without the
+ * IS_ANDROID_WEB_VIEW const.
+ */
+export const createGlobalInterval$ = (
+  isInBackground$?: Observable<boolean>,
+): Observable<number> =>
+  isInBackground$
+    ? isInBackground$.pipe(
+        startWith(false),
+        distinctUntilChanged(),
+        switchMap((isInBackground) =>
+          isInBackground ? EMPTY : interval(TRACKING_INTERVAL),
+        ),
+      )
+    : interval(TRACKING_INTERVAL);
 
 @Injectable({
   providedIn: 'root',
@@ -23,7 +56,9 @@ import { Log } from '../log';
 export class GlobalTrackingIntervalService {
   private _dateService = inject(DateService);
 
-  globalInterval$: Observable<number> = interval(TRACKING_INTERVAL).pipe(share());
+  globalInterval$: Observable<number> = createGlobalInterval$(
+    IS_ANDROID_WEB_VIEW ? androidInterface.isInBackground$ : undefined,
+  ).pipe(share());
   private _currentTrackingStart: number;
   private _wakeUpTick$ = new Subject<Tick>();
 

--- a/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { TaskService } from '../../tasks/task.service';
 import { DateService } from '../../../core/date/date.service';
 import { Task } from '../../tasks/task.model';
 import {
-  createReconcileTicksOnResume$,
+  creditBackgroundTickGap,
   isTimeSpentJumpForNotification,
   parseNativeTrackingData,
   TIME_SPENT_JUMP_THRESHOLD_MS,
@@ -1779,13 +1779,11 @@ describe('AndroidForegroundTrackingEffects - enhanced error handling (issue #584
   });
 });
 
-describe('createReconcileTicksOnResume$ - background tick gap (#8243)', () => {
-  let onResume$: Subject<void>;
+describe('creditBackgroundTickGap - background tick gap (#8243)', () => {
   let globalTracking: jasmine.SpyObj<GlobalTrackingIntervalService>;
   let taskService: jasmine.SpyObj<TaskService>;
 
   beforeEach(() => {
-    onResume$ = new Subject<void>();
     globalTracking = jasmine.createSpyObj<GlobalTrackingIntervalService>(
       'GlobalTrackingIntervalService',
       ['triggerWakeUpTick', 'resetTrackingStart'],
@@ -1795,48 +1793,27 @@ describe('createReconcileTicksOnResume$ - background tick gap (#8243)', () => {
     ]);
   });
 
-  it('should do nothing before a resume arrives', () => {
-    const sub = createReconcileTicksOnResume$(
-      onResume$,
-      globalTracking,
-      taskService,
-    ).subscribe();
-
-    expect(globalTracking.triggerWakeUpTick).not.toHaveBeenCalled();
-    expect(globalTracking.resetTrackingStart).not.toHaveBeenCalled();
-    expect(taskService.flushAccumulatedTimeSpent).not.toHaveBeenCalled();
-    sub.unsubscribe();
-  });
-
-  it('should credit a capped wake-up tick, reset the anchor and flush on resume', () => {
-    const sub = createReconcileTicksOnResume$(
-      onResume$,
-      globalTracking,
-      taskService,
-    ).subscribe();
-
-    onResume$.next();
+  it('should credit a capped wake-up tick, reset the anchor and flush', () => {
+    creditBackgroundTickGap(globalTracking, taskService);
 
     expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledWith(
       ANDROID_BACKGROUND_TICK_CAP_MS,
     );
     expect(globalTracking.resetTrackingStart).toHaveBeenCalledTimes(1);
     expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(1);
-    sub.unsubscribe();
   });
 
-  it('should reconcile once per resume', () => {
-    const sub = createReconcileTicksOnResume$(
-      onResume$,
-      globalTracking,
-      taskService,
-    ).subscribe();
+  it('should credit the gap before flushing it into a syncTimeSpent op', () => {
+    const callOrder: string[] = [];
+    globalTracking.triggerWakeUpTick.and.callFake(() => {
+      callOrder.push('wakeUpTick');
+      return { duration: 0, date: '2026-06-11', timestamp: 0 };
+    });
+    globalTracking.resetTrackingStart.and.callFake(() => callOrder.push('reset'));
+    taskService.flushAccumulatedTimeSpent.and.callFake(() => callOrder.push('flush'));
 
-    onResume$.next();
-    onResume$.next();
+    creditBackgroundTickGap(globalTracking, taskService);
 
-    expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledTimes(2);
-    expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(2);
-    sub.unsubscribe();
+    expect(callOrder).toEqual(['wakeUpTick', 'reset', 'flush']);
   });
 });

--- a/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
@@ -11,7 +11,7 @@ import {
   TIME_SPENT_JUMP_THRESHOLD_MS,
 } from './android-foreground-tracking.effects';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
-import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
+import { ANDROID_BACKGROUND_TICK_CAP_MS } from '../../../app.constants';
 
 // We need to test the effect logic by reimplementing it in tests since
 // the actual effects are conditionally created based on IS_ANDROID_WEB_VIEW
@@ -1818,7 +1818,7 @@ describe('createReconcileTicksOnResume$ - background tick gap (#8243)', () => {
     onResume$.next();
 
     expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledWith(
-      MOBILE_BACKGROUND_IDLE_CAP_MS,
+      ANDROID_BACKGROUND_TICK_CAP_MS,
     );
     expect(globalTracking.resetTrackingStart).toHaveBeenCalledTimes(1);
     expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(1);

--- a/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
@@ -1,14 +1,17 @@
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { TaskService } from '../../tasks/task.service';
 import { DateService } from '../../../core/date/date.service';
 import { Task } from '../../tasks/task.model';
 import {
+  createReconcileTicksOnResume$,
   isTimeSpentJumpForNotification,
   parseNativeTrackingData,
   TIME_SPENT_JUMP_THRESHOLD_MS,
 } from './android-foreground-tracking.effects';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
 
 // We need to test the effect logic by reimplementing it in tests since
 // the actual effects are conditionally created based on IS_ANDROID_WEB_VIEW
@@ -1773,5 +1776,67 @@ describe('AndroidForegroundTrackingEffects - enhanced error handling (issue #584
     expect(addTimeSpentSpy).not.toHaveBeenCalled();
     expect(resetTrackingStartSpy).toHaveBeenCalled();
     expect(snackOpenSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('createReconcileTicksOnResume$ - background tick gap (#8243)', () => {
+  let onResume$: Subject<void>;
+  let globalTracking: jasmine.SpyObj<GlobalTrackingIntervalService>;
+  let taskService: jasmine.SpyObj<TaskService>;
+
+  beforeEach(() => {
+    onResume$ = new Subject<void>();
+    globalTracking = jasmine.createSpyObj<GlobalTrackingIntervalService>(
+      'GlobalTrackingIntervalService',
+      ['triggerWakeUpTick', 'resetTrackingStart'],
+    );
+    taskService = jasmine.createSpyObj<TaskService>('TaskService', [
+      'flushAccumulatedTimeSpent',
+    ]);
+  });
+
+  it('should do nothing before a resume arrives', () => {
+    const sub = createReconcileTicksOnResume$(
+      onResume$,
+      globalTracking,
+      taskService,
+    ).subscribe();
+
+    expect(globalTracking.triggerWakeUpTick).not.toHaveBeenCalled();
+    expect(globalTracking.resetTrackingStart).not.toHaveBeenCalled();
+    expect(taskService.flushAccumulatedTimeSpent).not.toHaveBeenCalled();
+    sub.unsubscribe();
+  });
+
+  it('should credit a capped wake-up tick, reset the anchor and flush on resume', () => {
+    const sub = createReconcileTicksOnResume$(
+      onResume$,
+      globalTracking,
+      taskService,
+    ).subscribe();
+
+    onResume$.next();
+
+    expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledWith(
+      MOBILE_BACKGROUND_IDLE_CAP_MS,
+    );
+    expect(globalTracking.resetTrackingStart).toHaveBeenCalledTimes(1);
+    expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(1);
+    sub.unsubscribe();
+  });
+
+  it('should reconcile once per resume', () => {
+    const sub = createReconcileTicksOnResume$(
+      onResume$,
+      globalTracking,
+      taskService,
+    ).subscribe();
+
+    onResume$.next();
+    onResume$.next();
+
+    expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledTimes(2);
+    expect(taskService.flushAccumulatedTimeSpent).toHaveBeenCalledTimes(2);
+    sub.unsubscribe();
   });
 });

--- a/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.spec.ts
@@ -6,6 +6,7 @@ import { DateService } from '../../../core/date/date.service';
 import { Task } from '../../tasks/task.model';
 import {
   creditBackgroundTickGap,
+  handleAndroidResume,
   isTimeSpentJumpForNotification,
   parseNativeTrackingData,
   TIME_SPENT_JUMP_THRESHOLD_MS,
@@ -1815,5 +1816,113 @@ describe('creditBackgroundTickGap - background tick gap (#8243)', () => {
     creditBackgroundTickGap(globalTracking, taskService);
 
     expect(callOrder).toEqual(['wakeUpTick', 'reset', 'flush']);
+  });
+});
+
+describe('handleAndroidResume - credit-before-reconcile ordering (#8243)', () => {
+  const GAP_MS = 10 * 60 * 1000;
+  const PRE_GAP_TIME_SPENT = 60000;
+  const NATIVE_ELAPSED = PRE_GAP_TIME_SPENT + GAP_MS;
+
+  let globalTracking: jasmine.SpyObj<GlobalTrackingIntervalService>;
+  let taskService: jasmine.SpyObj<TaskService>;
+
+  beforeEach(() => {
+    globalTracking = jasmine.createSpyObj<GlobalTrackingIntervalService>(
+      'GlobalTrackingIntervalService',
+      ['triggerWakeUpTick', 'resetTrackingStart'],
+    );
+    globalTracking.triggerWakeUpTick.and.returnValue({
+      duration: GAP_MS,
+      date: '2026-06-11',
+      timestamp: 0,
+    });
+    taskService = jasmine.createSpyObj<TaskService>('TaskService', [
+      'flushAccumulatedTimeSpent',
+    ]);
+  });
+
+  it('should credit the gap BEFORE the native reconcile samples the task', async () => {
+    const order: string[] = [];
+    globalTracking.triggerWakeUpTick.and.callFake(() => {
+      order.push('credit');
+      return { duration: GAP_MS, date: '2026-06-11', timestamp: 0 };
+    });
+
+    await handleAndroidResume(
+      {
+        globalTracking,
+        taskService,
+        syncElapsedTimeForTask: (taskId) => {
+          order.push('reconcile:' + taskId);
+          return Promise.resolve(true);
+        },
+        getNativeTrackingData: () => null,
+        requestRecovery: () => order.push('recovery'),
+      },
+      { id: 'task-1' } as Task,
+    );
+
+    expect(order).toEqual(['credit', 'reconcile:task-1']);
+  });
+
+  it('should produce exactly ONE syncTimeSpent op for the gap (reconcile sees post-credit state)', async () => {
+    // Models the real wiring: the wake tick credits the gap into the task's
+    // timeSpent synchronously (tick$ subscriber + reducer), the flush emits
+    // one op, and the native reconcile then computes its delta from the
+    // POST-credit timeSpent. With the original two-effect race the reconcile
+    // sampled the pre-credit value and ops would be [GAP_MS, GAP_MS] - the
+    // cross-device double-count this guards against.
+    let timeSpent = PRE_GAP_TIME_SPENT;
+    const emittedOps: number[] = [];
+
+    globalTracking.triggerWakeUpTick.and.callFake(() => {
+      timeSpent += GAP_MS;
+      return { duration: GAP_MS, date: '2026-06-11', timestamp: 0 };
+    });
+    taskService.flushAccumulatedTimeSpent.and.callFake(() => {
+      emittedOps.push(GAP_MS);
+    });
+
+    await handleAndroidResume(
+      {
+        globalTracking,
+        taskService,
+        // mirrors _syncElapsedTimeForTask's delta logic against live state
+        syncElapsedTimeForTask: () => {
+          const duration = NATIVE_ELAPSED - timeSpent;
+          if (duration > 0) {
+            emittedOps.push(duration);
+          }
+          return Promise.resolve(true);
+        },
+        getNativeTrackingData: () => null,
+        requestRecovery: () => {},
+      },
+      { id: 'task-1' } as Task,
+    );
+
+    expect(emittedOps).toEqual([GAP_MS]);
+  });
+
+  it('should route a no-current-task resume to recovery without a reconcile call', async () => {
+    const nativeData = { taskId: 'task-native', elapsedMs: NATIVE_ELAPSED };
+    const recovered: unknown[] = [];
+    const reconcileSpy = jasmine.createSpy('syncElapsedTimeForTask').and.resolveTo(true);
+
+    await handleAndroidResume(
+      {
+        globalTracking,
+        taskService,
+        syncElapsedTimeForTask: reconcileSpy,
+        getNativeTrackingData: () => nativeData,
+        requestRecovery: (data) => recovered.push(data),
+      },
+      null,
+    );
+
+    expect(globalTracking.triggerWakeUpTick).toHaveBeenCalledTimes(1);
+    expect(reconcileSpy).not.toHaveBeenCalled();
+    expect(recovered).toEqual([nativeData]);
   });
 });

--- a/src/app/features/android/store/android-foreground-tracking.effects.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.ts
@@ -22,7 +22,7 @@ import { DroidLog } from '../../../core/log';
 import { DateService } from '../../../core/date/date.service';
 import { Task } from '../../tasks/task.model';
 import { selectTimer } from '../../focus-mode/store/focus-mode.selectors';
-import { combineLatest, firstValueFrom, Observable, Subject } from 'rxjs';
+import { combineLatest, firstValueFrom, Subject } from 'rxjs';
 import { ANDROID_BACKGROUND_TICK_CAP_MS } from '../../../app.constants';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { SnackService } from '../../../core/snack/snack.service';
@@ -115,32 +115,30 @@ export const isTimeSpentJumpForNotification = (
   currTimeSpent - prevTimeSpent > TIME_SPENT_JUMP_THRESHOLD_MS;
 
 /**
- * The shared 1s interval is paused while the app is backgrounded (see
- * createGlobalInterval$ — the web-layer half of the #8243 battery drain). On
- * resume, credit the backgrounded wall-clock gap to tick$ consumers (running
- * stopwatch counters, break tracking) with a single capped wake-up tick,
- * mirroring the iOS resume path (handleIosResume). Current-task time does NOT
- * depend on this: syncOnResume$ reconciles it from the native counter
- * (authoritative) and computes a ~0 delta when this tick ran first; if the
- * gap exceeded the cap, the native reconcile adds the uncapped remainder.
- * resetTrackingStart() drops that remainder from the tick anchor so the next
- * interval tick can't deliver it a second time.
+ * Credit the backgrounded wall-clock gap (capped at 8h) to tick$ consumers
+ * (running stopwatch counters, break tracking) with one wake-up tick, and
+ * flush it into a syncTimeSpent op. The 1s interval is paused while the app
+ * is backgrounded (see createGlobalInterval$ — the web-layer half of the
+ * #8243 battery drain), so without this the gap would never reach them.
+ * resetTrackingStart() drops any over-cap remainder from the tick anchor so
+ * the restarted interval can't deliver it again; for the current task the
+ * native reconcile adds that remainder from the authoritative counter.
  *
- * Exported (effect-independent) so the spec can drive it without tripping
- * the IS_ANDROID_WEB_VIEW gate on createEffect.
+ * MUST be called from syncOnResume$ BEFORE _syncElapsedTimeForTask (see the
+ * effect comment) — as a separate onResume$ effect it would race the native
+ * reconcile and double-count the gap in the op-log.
+ *
+ * Exported so the spec can exercise it without tripping the
+ * IS_ANDROID_WEB_VIEW gate on createEffect.
  */
-export const createReconcileTicksOnResume$ = (
-  onResume$: Observable<void>,
+export const creditBackgroundTickGap = (
   globalTracking: GlobalTrackingIntervalService,
   taskService: TaskService,
-): Observable<unknown> =>
-  onResume$.pipe(
-    tap(() => {
-      globalTracking.triggerWakeUpTick(ANDROID_BACKGROUND_TICK_CAP_MS);
-      globalTracking.resetTrackingStart();
-      taskService.flushAccumulatedTimeSpent();
-    }),
-  );
+): void => {
+  globalTracking.triggerWakeUpTick(ANDROID_BACKGROUND_TICK_CAP_MS);
+  globalTracking.resetTrackingStart();
+  taskService.flushAccumulatedTimeSpent();
+};
 
 @Injectable()
 export class AndroidForegroundTrackingEffects {
@@ -297,7 +295,18 @@ export class AndroidForegroundTrackingEffects {
     );
 
   /**
-   * When the app resumes from background, sync the elapsed time from the native service.
+   * When the app resumes from background, first credit the backgrounded gap
+   * to generic tick$ consumers (the 1s interval was paused, #8243), then sync
+   * the current task's elapsed time from the native service.
+   *
+   * ORDER IS LOAD-BEARING: creditBackgroundTickGap must run synchronously
+   * BEFORE _syncElapsedTimeForTask subscribes its task snapshot. That way the
+   * native reconcile sees the already-credited timeSpent and computes only
+   * the uncredited remainder (cap overflow / sub-second jitter). If the
+   * reconcile sampled first — e.g. were the credit a separate onResume$
+   * effect — both paths would emit a syncTimeSpent op for the SAME gap, and
+   * remote devices would double-count it on op-log replay (ops apply
+   * state-relative there, unlike the snapshot-based local reducer).
    */
   syncOnResume$ =
     IS_ANDROID_WEB_VIEW &&
@@ -310,6 +319,10 @@ export class AndroidForegroundTrackingEffects {
           ),
           filter(([, , isTaskDataLoaded]) => isTaskDataLoaded),
           tap(async ([, currentTask]) => {
+            creditBackgroundTickGap(
+              this._globalTrackingIntervalService,
+              this._taskService,
+            );
             if (currentTask) {
               await this._syncElapsedTimeForTask(currentTask.id);
             } else {
@@ -319,22 +332,6 @@ export class AndroidForegroundTrackingEffects {
               }
             }
           }),
-        ),
-      { dispatch: false },
-    );
-
-  /**
-   * See createReconcileTicksOnResume$ — credits the backgrounded gap to
-   * generic tick$ consumers after the paused 1s interval restarts.
-   */
-  reconcileTicksOnResume$ =
-    IS_ANDROID_WEB_VIEW &&
-    createEffect(
-      () =>
-        createReconcileTicksOnResume$(
-          androidInterface.onResume$,
-          this._globalTrackingIntervalService,
-          this._taskService,
         ),
       { dispatch: false },
     );

--- a/src/app/features/android/store/android-foreground-tracking.effects.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.ts
@@ -23,7 +23,7 @@ import { DateService } from '../../../core/date/date.service';
 import { Task } from '../../tasks/task.model';
 import { selectTimer } from '../../focus-mode/store/focus-mode.selectors';
 import { combineLatest, firstValueFrom, Observable, Subject } from 'rxjs';
-import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
+import { ANDROID_BACKGROUND_TICK_CAP_MS } from '../../../app.constants';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
@@ -136,7 +136,7 @@ export const createReconcileTicksOnResume$ = (
 ): Observable<unknown> =>
   onResume$.pipe(
     tap(() => {
-      globalTracking.triggerWakeUpTick(MOBILE_BACKGROUND_IDLE_CAP_MS);
+      globalTracking.triggerWakeUpTick(ANDROID_BACKGROUND_TICK_CAP_MS);
       globalTracking.resetTrackingStart();
       taskService.flushAccumulatedTimeSpent();
     }),

--- a/src/app/features/android/store/android-foreground-tracking.effects.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.ts
@@ -140,6 +140,36 @@ export const creditBackgroundTickGap = (
   taskService.flushAccumulatedTimeSpent();
 };
 
+export type AndroidResumeDeps = {
+  globalTracking: GlobalTrackingIntervalService;
+  taskService: TaskService;
+  syncElapsedTimeForTask: (taskId: string) => Promise<boolean>;
+  getNativeTrackingData: () => NativeTrackingData | null;
+  requestRecovery: (data: NativeTrackingData) => void;
+};
+
+/**
+ * Body of syncOnResume$, effect-independent so the spec can pin the
+ * load-bearing ordering (see the effect comment): the gap credit must run
+ * synchronously BEFORE syncElapsedTimeForTask samples the task, else the
+ * native reconcile re-emits the same gap as a second syncTimeSpent op and
+ * remote devices double-count it on op-log replay.
+ */
+export const handleAndroidResume = async (
+  deps: AndroidResumeDeps,
+  currentTask: Task | null,
+): Promise<void> => {
+  creditBackgroundTickGap(deps.globalTracking, deps.taskService);
+  if (currentTask) {
+    await deps.syncElapsedTimeForTask(currentTask.id);
+  } else {
+    const nativeData = deps.getNativeTrackingData();
+    if (nativeData) {
+      deps.requestRecovery(nativeData);
+    }
+  }
+};
+
 @Injectable()
 export class AndroidForegroundTrackingEffects {
   private _store = inject(Store);
@@ -318,20 +348,19 @@ export class AndroidForegroundTrackingEffects {
             this._store.select(selectIsTaskDataLoaded),
           ),
           filter(([, , isTaskDataLoaded]) => isTaskDataLoaded),
-          tap(async ([, currentTask]) => {
-            creditBackgroundTickGap(
-              this._globalTrackingIntervalService,
-              this._taskService,
-            );
-            if (currentTask) {
-              await this._syncElapsedTimeForTask(currentTask.id);
-            } else {
-              const nativeData = this._getNativeTrackingData();
-              if (nativeData) {
-                this._recoveryRequest$.next({ data: nativeData, source: 'resume' });
-              }
-            }
-          }),
+          tap(([, currentTask]) =>
+            handleAndroidResume(
+              {
+                globalTracking: this._globalTrackingIntervalService,
+                taskService: this._taskService,
+                syncElapsedTimeForTask: (taskId) => this._syncElapsedTimeForTask(taskId),
+                getNativeTrackingData: () => this._getNativeTrackingData(),
+                requestRecovery: (data) =>
+                  this._recoveryRequest$.next({ data, source: 'resume' }),
+              },
+              currentTask,
+            ),
+          ),
         ),
       { dispatch: false },
     );

--- a/src/app/features/android/store/android-foreground-tracking.effects.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.ts
@@ -22,7 +22,8 @@ import { DroidLog } from '../../../core/log';
 import { DateService } from '../../../core/date/date.service';
 import { Task } from '../../tasks/task.model';
 import { selectTimer } from '../../focus-mode/store/focus-mode.selectors';
-import { combineLatest, firstValueFrom, Subject } from 'rxjs';
+import { combineLatest, firstValueFrom, Observable, Subject } from 'rxjs';
+import { MOBILE_BACKGROUND_IDLE_CAP_MS } from '../../../app.constants';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
@@ -112,6 +113,34 @@ export const isTimeSpentJumpForNotification = (
 ): boolean =>
   currTimeSpent < prevTimeSpent ||
   currTimeSpent - prevTimeSpent > TIME_SPENT_JUMP_THRESHOLD_MS;
+
+/**
+ * The shared 1s interval is paused while the app is backgrounded (see
+ * createGlobalInterval$ — the web-layer half of the #8243 battery drain). On
+ * resume, credit the backgrounded wall-clock gap to tick$ consumers (running
+ * stopwatch counters, break tracking) with a single capped wake-up tick,
+ * mirroring the iOS resume path (handleIosResume). Current-task time does NOT
+ * depend on this: syncOnResume$ reconciles it from the native counter
+ * (authoritative) and computes a ~0 delta when this tick ran first; if the
+ * gap exceeded the cap, the native reconcile adds the uncapped remainder.
+ * resetTrackingStart() drops that remainder from the tick anchor so the next
+ * interval tick can't deliver it a second time.
+ *
+ * Exported (effect-independent) so the spec can drive it without tripping
+ * the IS_ANDROID_WEB_VIEW gate on createEffect.
+ */
+export const createReconcileTicksOnResume$ = (
+  onResume$: Observable<void>,
+  globalTracking: GlobalTrackingIntervalService,
+  taskService: TaskService,
+): Observable<unknown> =>
+  onResume$.pipe(
+    tap(() => {
+      globalTracking.triggerWakeUpTick(MOBILE_BACKGROUND_IDLE_CAP_MS);
+      globalTracking.resetTrackingStart();
+      taskService.flushAccumulatedTimeSpent();
+    }),
+  );
 
 @Injectable()
 export class AndroidForegroundTrackingEffects {
@@ -290,6 +319,22 @@ export class AndroidForegroundTrackingEffects {
               }
             }
           }),
+        ),
+      { dispatch: false },
+    );
+
+  /**
+   * See createReconcileTicksOnResume$ — credits the backgrounded gap to
+   * generic tick$ consumers after the paused 1s interval restarts.
+   */
+  reconcileTicksOnResume$ =
+    IS_ANDROID_WEB_VIEW &&
+    createEffect(
+      () =>
+        createReconcileTicksOnResume$(
+          androidInterface.onResume$,
+          this._globalTrackingIntervalService,
+          this._taskService,
         ),
       { dispatch: false },
     );


### PR DESCRIPTION
## Summary

Web-layer half of #8243 (Android battery drain). The Kotlin half (chronometer notifications, `e428e402ce`) stopped the native 1Hz loops, but the WebView kept running the shared `interval(1000)` while the tracking/focus foreground service holds the process alive — NgRx dispatches + full change detection once per second, around the clock.

- **`GlobalTrackingIntervalService`** gates its tick source on `androidInterface.isInBackground$` (fed natively by Activity `onPause`/`onResume`): the interval is unsubscribed entirely while backgrounded. Android WebView only — on desktop/Electron tracking-while-hidden is a feature, and iOS OS-suspends JS anyway.
- **On resume**, `syncOnResume$` first credits the backgrounded wall-clock gap to generic `tick$` consumers (stopwatch counters, break tracking) with one wake-up tick capped at the new `ANDROID_BACKGROUND_TICK_CAP_MS` (8h), then reconciles the current task from the native counter (authoritative, unchanged). Mirrors the iOS resume path; the iOS 4h cap is intentionally untouched (there it bounds *active-task* credit).

## Why totals stay correct

Ticks are wall-clock deltas, so pausing loses nothing — the gap arrives as one capped tick. **Order is load-bearing** (documented on the effect): the gap credit runs synchronously before `_syncElapsedTimeForTask` samples the task, so the native reconcile computes only the uncredited remainder. An earlier iteration used a separate `onResume$` effect; a multi-agent review caught that this races the reconcile's snapshot and emits a **second `syncTimeSpent` op for the same gap** — locally invisible (snapshot-based reducer), but op-log replay applies durations state-relative, inflating tracked time on remote devices by up to 8h per resume. Fixed by folding the credit into `syncOnResume$`, and the ordering is now pinned by tests (`handleAndroidResume` spec: a 10-min gap must yield exactly ONE op).

## Behavior changes (intentional)

- Stopwatch counters: background accrual capped at 8h per stint (was unbounded).
- Countdown counters / break threshold crossings: detected on resume instead of mid-background (invisible while backgrounded anyway); totals unchanged.
- Midnight rollover while backgrounded: day-change work runs on resume via the existing #5464 visibility/focus resampling — same as desktop sleep today.

## Review trail

- 6-agent review (correctness/security/architecture/alternatives/performance/simplicity) → 1 CRITICAL (the double-count above), fixed.
- Adversarial re-review of the fix → all 5 functional attack surfaces refuted; remaining test gap closed in `72909ca49c`.
- 81/81 + 10/10 unit tests green; `checkFile` clean on all touched files.

## Remaining verification (before merge)

- [ ] On-device: track a task → background ~10 min → resume → in-app time matches the notification chronometer
- [ ] Cross-device: sync after the above → tracked time NOT inflated on the second device
- [ ] Stopwatch counter running across a background stint keeps its time (≤8h)

## Known residuals (out of scope, follow-ups)

- 10s reminder web-worker + 2–10min polls still run while backgrounded (smaller drain contributors).
- `isInBackground$` could be a seeded `BehaviorSubject` (hardening; touches sync-trigger semantics, deliberately separate).

Related: #8243