### PR TITLE
fix(caldav): discover calendars via principal/calendar-home-set #8259

### DIFF
--- a/packages/plugin-dev/caldav-calendar-provider/src/plugin.spec.ts
+++ b/packages/plugin-dev/caldav-calendar-provider/src/plugin.spec.ts
@@ -1142,4 +1142,257 @@ END:VCALENDAR</cal:calendar-data>
       expect(mockHttp.delete).toHaveBeenCalledTimes(1);
     });
   });
+
+  // Regression coverage for issue #8259 — CalDAV servers advertise a root or
+  // principal URL, not the calendar-home, so a plain Depth:1 PROPFIND there
+  // lists no <calendar> resources and the config dropdowns stayed empty.
+  describe('calendar discovery / loadOptions (issue #8259)', () => {
+    const getLoadOptions = (): NonNullable<
+      (typeof definition.configFields)[number]['loadOptions']
+    > => {
+      const field = definition.configFields.find((f) => f.key === 'readCalendarIds');
+      if (!field?.loadOptions) throw new Error('readCalendarIds.loadOptions missing');
+      return field.loadOptions;
+    };
+
+    /** Multistatus listing the user's calendars (one VEVENT, one VTODO-only). */
+    const CALENDAR_LIST_XML = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/calendars/admin/</d:href>
+    <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/calendars/admin/personal/</d:href>
+    <d:propstat><d:prop>
+      <d:displayname>Personal</d:displayname>
+      <d:resourcetype><d:collection/><cal:calendar/></d:resourcetype>
+      <cal:supported-calendar-component-set><cal:comp name="VEVENT"/></cal:supported-calendar-component-set>
+    </d:prop></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/calendars/admin/tasks/</d:href>
+    <d:propstat><d:prop>
+      <d:displayname>Tasks</d:displayname>
+      <d:resourcetype><d:collection/><cal:calendar/></d:resourcetype>
+      <cal:supported-calendar-component-set><cal:comp name="VTODO"/></cal:supported-calendar-component-set>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+    /** Depth:1 on a root/principal collection — no <calendar> resources. */
+    const NON_CALENDAR_COLLECTION_XML = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/</d:href>
+    <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/calendars/</d:href>
+    <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+    const PRINCIPAL_XML = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/</d:href>
+    <d:propstat><d:prop>
+      <d:current-user-principal><d:href>/remote.php/dav/principals/users/admin/</d:href></d:current-user-principal>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+    const HOME_SET_XML = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/principals/users/admin/</d:href>
+    <d:propstat><d:prop>
+      <cal:calendar-home-set><d:href>/remote.php/dav/calendars/admin/</d:href></cal:calendar-home-set>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+    /** Route PROPFIND responses by URL + Depth; 404 anything unmapped. */
+    const makeHttp = (
+      routes: Record<string, string>,
+    ): { request: any } & Record<string, any> => ({
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+      request: vi.fn(
+        async (
+          _method: string,
+          url: string,
+          _body: unknown,
+          opts: any,
+        ): Promise<string> => {
+          const depth = opts?.headers?.Depth;
+          const res = routes[`${url}|${depth}`];
+          if (res === undefined) {
+            throw Object.assign(new Error(`no route for ${url} depth=${depth}`), {
+              status: 404,
+            });
+          }
+          return res;
+        },
+      ),
+    });
+
+    it('returns [] without any request when credentials are incomplete', async () => {
+      const http = makeHttp({});
+      const result = await getLoadOptions()(
+        { serverUrl: 'https://nc.example.com/remote.php/dav' } as any,
+        http as any,
+      );
+      expect(result).toEqual([]);
+      expect(http.request).not.toHaveBeenCalled();
+    });
+
+    it('uses the entered URL directly when it is already a calendar-home (back-compat)', async () => {
+      const http = makeHttp({
+        'https://nc.example.com/remote.php/dav/calendars/admin/|1': CALENDAR_LIST_XML,
+      });
+      const result = await getLoadOptions()(
+        {
+          serverUrl: 'https://nc.example.com/remote.php/dav/calendars/admin/',
+          username: 'admin',
+          password: 'pass',
+        } as any,
+        http as any,
+      );
+      expect(result).toEqual([
+        { label: 'Personal', value: '/remote.php/dav/calendars/admin/personal/' },
+      ]);
+      // No discovery bootstrap needed — a single Depth:1 PROPFIND.
+      expect(http.request).toHaveBeenCalledTimes(1);
+    });
+
+    it('discovers calendars from a Nextcloud root URL via principal + calendar-home-set', async () => {
+      const http = makeHttp({
+        // Step 1: Depth:1 on the root lists only non-calendar collections.
+        'https://nc.example.com/remote.php/dav/|1': NON_CALENDAR_COLLECTION_XML,
+        // Step 2: Depth:0 on the root yields the current-user-principal.
+        'https://nc.example.com/remote.php/dav/|0': PRINCIPAL_XML,
+        // Step 3: Depth:0 on the principal yields the calendar-home-set.
+        'https://nc.example.com/remote.php/dav/principals/users/admin/|0': HOME_SET_XML,
+        // Step 4: Depth:1 on the calendar-home enumerates the calendars.
+        'https://nc.example.com/remote.php/dav/calendars/admin/|1': CALENDAR_LIST_XML,
+      });
+      const result = await getLoadOptions()(
+        {
+          serverUrl: 'https://nc.example.com/remote.php/dav',
+          username: 'admin',
+          password: 'pass',
+        } as any,
+        http as any,
+      );
+      expect(result).toEqual([
+        { label: 'Personal', value: '/remote.php/dav/calendars/admin/personal/' },
+      ]);
+    });
+
+    it('discovers calendars when calendar-home-set is advertised at the entered URL', async () => {
+      const HOME_AT_ROOT_XML = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/dav/</d:href>
+    <d:propstat><d:prop>
+      <cal:calendar-home-set><d:href>/remote.php/dav/calendars/admin/</d:href></cal:calendar-home-set>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+      const http = makeHttp({
+        'https://nc.example.com/dav/|1': NON_CALENDAR_COLLECTION_XML,
+        'https://nc.example.com/dav/|0': HOME_AT_ROOT_XML,
+        'https://nc.example.com/remote.php/dav/calendars/admin/|1': CALENDAR_LIST_XML,
+      });
+      const result = await getLoadOptions()(
+        {
+          serverUrl: 'https://nc.example.com/dav',
+          username: 'admin',
+          password: 'pass',
+        } as any,
+        http as any,
+      );
+      expect(result).toEqual([
+        { label: 'Personal', value: '/remote.php/dav/calendars/admin/personal/' },
+      ]);
+    });
+
+    it('returns [] when neither calendars nor a principal can be resolved', async () => {
+      const EMPTY_PROPS_XML = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/</d:href>
+    <d:propstat><d:prop/></d:propstat>
+  </d:response>
+</d:multistatus>`;
+      const http = makeHttp({
+        'https://nc.example.com/remote.php/dav/|1': NON_CALENDAR_COLLECTION_XML,
+        'https://nc.example.com/remote.php/dav/|0': EMPTY_PROPS_XML,
+      });
+      const result = await getLoadOptions()(
+        {
+          serverUrl: 'https://nc.example.com/remote.php/dav',
+          username: 'admin',
+          password: 'pass',
+        } as any,
+        http as any,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('falls back to discovery when the entered URL rejects a Depth:1 PROPFIND', async () => {
+      const http = makeHttp({
+        // No '|1' route for the root → Depth:1 throws (e.g. 403/405); bootstrap runs.
+        'https://nc.example.com/remote.php/dav/|0': PRINCIPAL_XML,
+        'https://nc.example.com/remote.php/dav/principals/users/admin/|0': HOME_SET_XML,
+        'https://nc.example.com/remote.php/dav/calendars/admin/|1': CALENDAR_LIST_XML,
+      });
+      const result = await getLoadOptions()(
+        {
+          serverUrl: 'https://nc.example.com/remote.php/dav',
+          username: 'admin',
+          password: 'pass',
+        } as any,
+        http as any,
+      );
+      expect(result).toEqual([
+        { label: 'Personal', value: '/remote.php/dav/calendars/admin/personal/' },
+      ]);
+    });
+
+    it('refuses a cross-origin calendar-home-set href without sending a credentialed request to it (SSRF guard)', async () => {
+      const CROSS_ORIGIN_HOME_XML = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/</d:href>
+    <d:propstat><d:prop>
+      <cal:calendar-home-set><d:href>https://evil.example.com/dav/calendars/admin/</d:href></cal:calendar-home-set>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+      const http = makeHttp({
+        'https://nc.example.com/remote.php/dav/|1': NON_CALENDAR_COLLECTION_XML,
+        'https://nc.example.com/remote.php/dav/|0': CROSS_ORIGIN_HOME_XML,
+      });
+      // resolveHref rejects the off-origin href → discovery throws rather than
+      // issuing a credentialed PROPFIND to the attacker-controlled host.
+      await expect(
+        getLoadOptions()(
+          {
+            serverUrl: 'https://nc.example.com/remote.php/dav',
+            username: 'admin',
+            password: 'pass',
+          } as any,
+          http as any,
+        ),
+      ).rejects.toThrow();
+      const calledUrls = http.request.mock.calls.map((c: unknown[]) => c[1]);
+      expect(calledUrls.some((u: string) => u.includes('evil.example.com'))).toBe(false);
+    });
+  });
 });

--- a/packages/plugin-dev/caldav-calendar-provider/src/plugin.spec.ts
+++ b/packages/plugin-dev/caldav-calendar-provider/src/plugin.spec.ts
@@ -1391,8 +1391,14 @@ END:VCALENDAR</cal:calendar-data>
           http as any,
         ),
       ).rejects.toThrow();
-      const calledUrls = http.request.mock.calls.map((c: unknown[]) => c[1]);
-      expect(calledUrls.some((u: string) => u.includes('evil.example.com'))).toBe(false);
+      // Every request must have stayed on the entered server origin — no
+      // credentialed PROPFIND escaped to the attacker-named host.
+      const calledOrigins = http.request.mock.calls.map(
+        (c: unknown[]) => new URL(c[1] as string).origin,
+      );
+      expect(calledOrigins.every((o: string) => o === 'https://nc.example.com')).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/plugin-dev/caldav-calendar-provider/src/plugin.ts
+++ b/packages/plugin-dev/caldav-calendar-provider/src/plugin.ts
@@ -462,6 +462,22 @@ const DAV_NS = 'DAV:';
 const CALDAV_NS = 'urn:ietf:params:xml:ns:caldav';
 const CS_NS = 'http://calendarserver.org/ns/';
 
+/**
+ * Parse an XML string into a Document, throwing on parser errors.
+ * The error message intentionally omits the parser output / response body —
+ * it is untrusted server content and the log is exportable (never log it).
+ * DOMParser (browser + jsdom) does not resolve external entities, so this is
+ * safe against XXE; do not swap it for a server-side XML lib without disabling
+ * entity resolution.
+ */
+const parseXmlDoc = (xml: string): Document => {
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
+  if (doc.querySelector('parsererror')) {
+    throw new Error('[CalDAV] Failed to parse XML response');
+  }
+  return doc;
+};
+
 /** Build PROPFIND body for calendar discovery */
 const buildPropfindBody = (): string =>
   `<?xml version="1.0" encoding="UTF-8"?>
@@ -525,12 +541,7 @@ interface CalendarInfo {
 
 /** Parse PROPFIND multistatus response for calendar discovery */
 const parseCalendarList = (xml: string): CalendarInfo[] => {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(xml, 'application/xml');
-  const parseErr = doc.querySelector('parsererror');
-  if (parseErr) {
-    throw new Error('[CalDAV] Failed to parse XML response: ' + parseErr.textContent);
-  }
+  const doc = parseXmlDoc(xml);
   const responses = doc.getElementsByTagNameNS(DAV_NS, 'response');
   const calendars: CalendarInfo[] = [];
 
@@ -581,12 +592,7 @@ interface CalendarEventResponse {
 
 /** Parse REPORT multistatus response for calendar events */
 const parseEventResponses = (xml: string): CalendarEventResponse[] => {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(xml, 'application/xml');
-  const parseErr = doc.querySelector('parsererror');
-  if (parseErr) {
-    throw new Error('[CalDAV] Failed to parse XML response: ' + parseErr.textContent);
-  }
+  const doc = parseXmlDoc(xml);
   const responses = doc.getElementsByTagNameNS(DAV_NS, 'response');
   const events: CalendarEventResponse[] = [];
 
@@ -619,34 +625,124 @@ const caldavHeaders = (extra?: Record<string, string>): Record<string, string> =
   ...extra,
 });
 
-/** Resolve a relative href to a full URL using the server origin */
+/**
+ * Resolve a server-supplied href against the configured server origin and
+ * refuse anything that escapes it. Discovery follows hrefs that the (untrusted)
+ * server controls — principal, calendar-home-set — so this is the SSRF
+ * boundary: credentials are attached to every request and must never be sent
+ * off-origin. Resolving via the URL constructor handles relative, absolute, and
+ * protocol-relative (`//host`) forms uniformly; a prefix sniff + string concat
+ * would mis-handle `//host` and uppercase schemes. The href is omitted from the
+ * error (untrusted content; the log is exportable).
+ */
 const resolveHref = (cfg: CaldavCalendarConfig, href: string): string => {
   const serverOrigin = new URL(getServerUrl(cfg)).origin;
-  if (href.startsWith('http://') || href.startsWith('https://')) {
-    if (new URL(href).origin !== serverOrigin) {
-      throw new Error(`[CalDAV] Refusing cross-origin href: ${href}`);
-    }
-    return href;
+  const resolved = new URL(href, serverOrigin + '/');
+  if (resolved.origin !== serverOrigin) {
+    throw new Error('[CalDAV] Refusing cross-origin href');
   }
-  return serverOrigin + href;
+  return resolved.toString();
 };
 
-/** Discover calendars supporting VEVENT via PROPFIND */
+/** Build PROPFIND body to bootstrap discovery: principal + calendar-home-set */
+const buildDiscoveryPropfindBody = (): string =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:c="${CALDAV_NS}">
+  <d:prop>
+    <d:current-user-principal/>
+    <c:calendar-home-set/>
+  </d:prop>
+</d:propfind>`;
+
+/**
+ * Extract the first `<d:href>` nested inside the named property element
+ * (e.g. DAV `current-user-principal` or CalDAV `calendar-home-set`).
+ */
+const getHrefInProp = (doc: Document, ns: string, localName: string): string => {
+  const els = doc.getElementsByTagNameNS(ns, localName);
+  for (let i = 0; i < els.length; i++) {
+    const href = els[i].getElementsByTagNameNS(DAV_NS, 'href')[0];
+    const text = href?.textContent?.trim();
+    if (text) return text;
+  }
+  return '';
+};
+
+const propfind = (
+  http: PluginHttp,
+  url: string,
+  body: string,
+  depth: '0' | '1',
+): Promise<string> =>
+  http.request<string>('PROPFIND', url, body, {
+    headers: { ...caldavHeaders(), Depth: depth },
+    responseType: 'text',
+  });
+
+/** PROPFIND Depth:1 a collection and return its VEVENT-capable calendars */
+const enumerateCalendars = async (
+  http: PluginHttp,
+  url: string,
+): Promise<{ label: string; value: string }[]> => {
+  const xml = await propfind(http, url, buildPropfindBody(), '1');
+  return parseCalendarList(xml)
+    .filter((c) => c.supportsVevent)
+    .map((c) => ({ label: c.displayName, value: c.href }));
+};
+
+/**
+ * Resolve the calendar-home-set collection that actually holds the user's
+ * calendars. CalDAV servers advertise a root or principal URL — e.g. Nextcloud's
+ * `https://host/remote.php/dav`, Fastmail's `https://caldav.fastmail.com/dav/` —
+ * not the calendar-home itself, so a plain Depth:1 PROPFIND there lists no
+ * `<calendar>` resources (they sit one or two levels deeper). Follow the RFC 4791
+ * bootstrap: read `calendar-home-set` directly, else find the
+ * `current-user-principal` and read `calendar-home-set` from it. Returns '' when
+ * neither can be resolved.
+ */
+const resolveCalendarHome = async (
+  http: PluginHttp,
+  cfg: CaldavCalendarConfig,
+  enteredUrl: string,
+): Promise<string> => {
+  const doc = parseXmlDoc(
+    await propfind(http, enteredUrl, buildDiscoveryPropfindBody(), '0'),
+  );
+  const directHome = getHrefInProp(doc, CALDAV_NS, 'calendar-home-set');
+  if (directHome) return ensureTrailingSlash(resolveHref(cfg, directHome));
+
+  const principal = getHrefInProp(doc, DAV_NS, 'current-user-principal');
+  if (!principal) return '';
+  const principalDoc = parseXmlDoc(
+    await propfind(http, resolveHref(cfg, principal), buildDiscoveryPropfindBody(), '0'),
+  );
+  const home = getHrefInProp(principalDoc, CALDAV_NS, 'calendar-home-set');
+  return home ? ensureTrailingSlash(resolveHref(cfg, home)) : '';
+};
+
+/**
+ * Discover calendars supporting VEVENT.
+ * First try the entered URL directly (handles users who pasted the calendar-home
+ * collection). If that lists no calendars, fall back to RFC 4791 service
+ * discovery via the principal / calendar-home-set. See issue #8259.
+ */
 const discoverCalendars = async (
   http: PluginHttp,
   cfg: CaldavCalendarConfig,
 ): Promise<{ label: string; value: string }[]> => {
-  const url = ensureTrailingSlash(getServerUrl(cfg));
-  const xml = await http.request<string>('PROPFIND', url, buildPropfindBody(), {
-    headers: { ...caldavHeaders(), Depth: '1' },
-    responseType: 'text',
-  });
-  return parseCalendarList(xml)
-    .filter((c) => c.supportsVevent)
-    .map((c) => ({
-      label: c.displayName,
-      value: c.href,
-    }));
+  const enteredUrl = ensureTrailingSlash(getServerUrl(cfg));
+
+  try {
+    const direct = await enumerateCalendars(http, enteredUrl);
+    if (direct.length) return direct;
+  } catch {
+    // The entered URL may be a principal/root collection that rejects Depth:1.
+    // Fall through to the discovery bootstrap below.
+  }
+
+  const home = await resolveCalendarHome(http, cfg, enteredUrl);
+  if (!home) return [];
+  return enumerateCalendars(http, home);
 };
 
 // --- ical.js-based RRULE expansion ---
@@ -1044,7 +1140,7 @@ PluginAPI.registerIssueProvider({
       type: 'input' as const,
       label: 'CalDAV server URL',
       description:
-        'The CalDAV endpoint URL (e.g. https://cloud.example.com/remote.php/dav/calendars/username/)',
+        'The CalDAV server URL — the root works (e.g. https://cloud.example.com/remote.php/dav for Nextcloud, https://caldav.fastmail.com/dav/ for Fastmail). A specific calendar-home URL also works.',
       required: true,
     },
     {


### PR DESCRIPTION
Fixes #8259

## Problem

"CalDAV Events" (the bundled `caldav-calendar-provider` plugin) connects to a CalDAV server, but the **Calendars to display** and **Default calendar for new events** dropdowns stay empty, and the Schedule shows no events. Reproduces on **any** CalDAV server (reporter confirmed Nextcloud and Fastmail).

## Root cause

`discoverCalendars` populated the dropdowns with a **single `Depth:1` PROPFIND on the exact URL the user entered**, keeping only responses whose `resourcetype` is `<calendar>`.

Users paste the advertised CalDAV **root** — Nextcloud `https://host/remote.php/dav`, Fastmail `https://caldav.fastmail.com/dav/` — where the actual calendars live one or two collection levels deeper. So the PROPFIND **succeeds** (HTTP 207) but lists only non-calendar collections → discovery returns `[]`.

Because `loadOptions` *resolved* (with an empty array) rather than throwing, the dialog showed a green **"Options loaded"** tick with empty dropdowns, and the Schedule stayed empty because no calendar could be selected. **Test Connection** still passed — it's only a `Depth:0` PROPFIND.

## Fix

Rewrite `discoverCalendars` to do RFC 4791 service discovery:

1. Try the entered URL directly (back-compat for users who pasted the deep calendar-home URL).
2. If that lists no calendars: `Depth:0` PROPFIND for `current-user-principal` → `Depth:0` PROPFIND for `calendar-home-set` → `Depth:1` enumerate the calendars at the home collection.

The `serverUrl` field description now states the root URL works (with Nextcloud/Fastmail examples).

## Security hardening (from a multi-agent review of this change)

Discovery now **follows server-controlled hrefs** (principal, calendar-home-set), so:

- `resolveHref` is hardened to resolve via the `URL` constructor and refuse any off-origin target. This is the SSRF boundary — credentials are attached to every request, so they must never be sent off-origin. The URL constructor robustly rejects `//host` / uppercase-scheme forms that the old prefix-sniff only pinned by accident.
- Thrown error messages no longer interpolate untrusted server data (hrefs / response bodies), per the "logs are exportable, never log user content" rule.
- The duplicated `DOMParser` + `parsererror` guard is deduplicated into a shared `parseXmlDoc`.

## Testing

- **65 unit tests pass** (the discovery path previously had **zero** coverage; this adds 7 specs covering the Nextcloud-root bootstrap, the calendar-home-advertised-at-root case, direct back-compat, `Depth:1`-rejection fallback, unresolvable → `[]`, and **cross-origin href refusal**).
- `tsc --noEmit` clean, esbuild build OK, `checkFile` (prettier + eslint) clean.

## Limitations / follow-ups (not in this PR)

- No `.well-known/caldav` fallback for users who enter a **bare domain** (the documented inputs are DAV roots, which resolve via the principal).
- **iCloud** redirects calendars to a per-user host; the same-origin guard refuses that by design.
- The host-side `PluginHttp` attaches plugin Basic-auth to every request with no origin binding — the systemic SSRF amplifier behind the hardening above. Worth a separate issue.
- Discovery runs once per dynamic field (3×) on dialog open; memoization is a possible follow-up but interacts with the explicit "Reload Options" button.

## Note for the maintainer

Heads-up per the contribution norms — happy to adjust scope (e.g. drop the `resolveHref`/`parseXmlDoc` cleanups to keep the diff to pure discovery) if preferred.
