### PR TITLE
fix(android): suspend idle AudioContext in background to stop battery drain (#8243)

### DIFF
--- a/src/app/util/audio-context.spec.ts
+++ b/src/app/util/audio-context.spec.ts
@@ -427,6 +427,20 @@ describe('audio-context', () => {
 
       expect(suspend).toHaveBeenCalled();
     });
+
+    it('should re-allow suspend after closeAudioContext resets keep-awake', () => {
+      mockRunningContext();
+      getAudioContext();
+      setAudioContextKeepAwake(true);
+      closeAudioContext();
+
+      // Fresh running context after teardown; keep-awake must no longer block.
+      const { suspend } = mockRunningContext();
+      getAudioContext();
+      suspendAudioContext();
+
+      expect(suspend).toHaveBeenCalled();
+    });
   });
 
   describe('closeAudioContext', () => {

--- a/src/app/util/audio-context.spec.ts
+++ b/src/app/util/audio-context.spec.ts
@@ -6,6 +6,8 @@ import {
   unlockAudioContext,
   ensureAudioContextRunning,
   playBuffer,
+  suspendAudioContext,
+  setAudioContextKeepAwake,
 } from './audio-context';
 
 describe('audio-context', () => {
@@ -348,6 +350,82 @@ describe('audio-context', () => {
         .allArgs()
         .filter((args: any[]) => args[0] === 'touchend');
       expect(touchendCalls.length).toBe(1);
+    });
+  });
+
+  describe('suspendAudioContext', () => {
+    const mockRunningContext = (): { suspend: jasmine.Spy } => {
+      const suspend = jasmine.createSpy('suspend').and.returnValue(Promise.resolve());
+      const mockContext = {
+        state: 'running',
+        resume: jasmine.createSpy('resume').and.returnValue(Promise.resolve()),
+        suspend,
+        close: jasmine.createSpy('close'),
+      };
+      (window as any).AudioContext = jasmine
+        .createSpy('AudioContext')
+        .and.returnValue(mockContext);
+      return { suspend };
+    };
+
+    it('should suspend a running context', () => {
+      const { suspend } = mockRunningContext();
+      getAudioContext();
+
+      suspendAudioContext();
+
+      expect(suspend).toHaveBeenCalled();
+    });
+
+    it('should be a no-op when no context exists yet', () => {
+      const { suspend } = mockRunningContext();
+
+      // Never call getAudioContext() — nothing should be created or suspended.
+      suspendAudioContext();
+
+      expect((window as any).AudioContext).not.toHaveBeenCalled();
+      expect(suspend).not.toHaveBeenCalled();
+    });
+
+    it('should not suspend a context that is already suspended', () => {
+      const suspend = jasmine.createSpy('suspend').and.returnValue(Promise.resolve());
+      const mockContext = {
+        state: 'suspended',
+        resume: jasmine.createSpy('resume').and.returnValue(Promise.resolve()),
+        suspend,
+        close: jasmine.createSpy('close'),
+      };
+      (window as any).AudioContext = jasmine
+        .createSpy('AudioContext')
+        .and.returnValue(mockContext);
+      getAudioContext();
+
+      suspendAudioContext();
+
+      expect(suspend).not.toHaveBeenCalled();
+    });
+
+    it('should not suspend while keep-awake is set (e.g. white noise playing)', () => {
+      const { suspend } = mockRunningContext();
+      getAudioContext();
+      setAudioContextKeepAwake(true);
+
+      suspendAudioContext();
+
+      expect(suspend).not.toHaveBeenCalled();
+    });
+
+    it('should suspend again after keep-awake is cleared', () => {
+      const { suspend } = mockRunningContext();
+      getAudioContext();
+      setAudioContextKeepAwake(true);
+      suspendAudioContext();
+      expect(suspend).not.toHaveBeenCalled();
+
+      setAudioContextKeepAwake(false);
+      suspendAudioContext();
+
+      expect(suspend).toHaveBeenCalled();
     });
   });
 

--- a/src/app/util/audio-context.ts
+++ b/src/app/util/audio-context.ts
@@ -6,6 +6,10 @@
 let audioContext: AudioContext | null = null;
 const audioBufferCache = new Map<string, AudioBuffer>();
 let unlocked = false;
+// Whether something still needs the context running while the app is backgrounded
+// (e.g. focus-mode white noise). While set, suspendAudioContext() is a no-op so
+// the ongoing sound is not cut off. See setAudioContextKeepAwake().
+let keepAwake = false;
 
 /**
  * Returns the singleton AudioContext instance, creating it if necessary.
@@ -94,6 +98,33 @@ export const playBuffer = async (
 };
 
 /**
+ * Marks (or clears) a need to keep the AudioContext running even while the app is
+ * backgrounded. Used by long-lived background audio such as the focus-mode white
+ * noise so that suspendAudioContext() does not cut it off mid-playback.
+ */
+export const setAudioContextKeepAwake = (value: boolean): void => {
+  keepAwake = value;
+};
+
+/**
+ * Suspends the singleton AudioContext to release the underlying audio output
+ * stream. On Android a `running` AudioContext keeps an AudioTrack open in the
+ * audio HAL even while completely silent — which drains the battery around the
+ * clock and keeps the process alive in the background (issue #8243). Suspending
+ * releases that stream; the next playback resumes it via ensureAudioContextRunning().
+ *
+ * No-op when the context was never created, is already suspended, or something
+ * still needs it running (see setAudioContextKeepAwake).
+ */
+export const suspendAudioContext = (): void => {
+  if (!keepAwake && audioContext && audioContext.state === 'running') {
+    // suspend() returns a promise; the release begins immediately so we don't
+    // await it. Swallow errors — the context may already be closing.
+    void audioContext.suspend().catch(() => {});
+  }
+};
+
+/**
  * Registers one-time touchend/click listeners that create and resume the AudioContext
  * on the first user gesture. This is required on iOS where AudioContext can only be
  * unlocked from within a user gesture event handler.
@@ -137,4 +168,5 @@ export const closeAudioContext = (): void => {
   }
   audioBufferCache.clear();
   unlocked = false;
+  keepAwake = false;
 };

--- a/src/app/util/audio-context.ts
+++ b/src/app/util/audio-context.ts
@@ -101,9 +101,13 @@ export const playBuffer = async (
  * Marks (or clears) a need to keep the AudioContext running even while the app is
  * backgrounded. Used by long-lived background audio such as the focus-mode white
  * noise so that suspendAudioContext() does not cut it off mid-playback.
+ *
+ * Single-owner: white noise is currently the only caller. If a second long-lived
+ * background sound is ever added, replace this boolean with a reference count so
+ * one source clearing the flag cannot release another's.
  */
-export const setAudioContextKeepAwake = (value: boolean): void => {
-  keepAwake = value;
+export const setAudioContextKeepAwake = (keep: boolean): void => {
+  keepAwake = keep;
 };
 
 /**

--- a/src/app/util/white-noise.ts
+++ b/src/app/util/white-noise.ts
@@ -1,4 +1,4 @@
-import { ensureAudioContextRunning } from './audio-context';
+import { ensureAudioContextRunning, setAudioContextKeepAwake } from './audio-context';
 
 let activeSource: AudioBufferSourceNode | null = null;
 let activeGain: GainNode | null = null;
@@ -40,10 +40,13 @@ export const startWhiteNoise = async (volume: number): Promise<void> => {
   source.start(0);
   activeSource = source;
   activeGain = gain;
+  // Keep the context running while backgrounded so the focus sound keeps playing.
+  setAudioContextKeepAwake(true);
 };
 
 export const stopWhiteNoise = (): void => {
   startCancelled = true;
+  setAudioContextKeepAwake(false);
   if (activeSource) {
     try {
       activeSource.stop();

--- a/src/app/util/white-noise.ts
+++ b/src/app/util/white-noise.ts
@@ -1,4 +1,8 @@
-import { ensureAudioContextRunning, setAudioContextKeepAwake } from './audio-context';
+import {
+  ensureAudioContextRunning,
+  setAudioContextKeepAwake,
+  suspendAudioContext,
+} from './audio-context';
 
 let activeSource: AudioBufferSourceNode | null = null;
 let activeGain: GainNode | null = null;
@@ -60,4 +64,10 @@ export const stopWhiteNoise = (): void => {
     activeGain.disconnect();
     activeGain = null;
   }
+  // The only long-lived background sound is gone, so release the audio output
+  // stream right away. We may be backgrounded (focus session ended while the app
+  // was away), where appStateChange won't fire another suspend; the next playback
+  // lazily resumes the context. Without this the silent-but-running context keeps
+  // draining until the next foreground/background cycle (#8243).
+  suspendAudioContext();
 };

--- a/src/app/util/white-noise.ts
+++ b/src/app/util/white-noise.ts
@@ -1,8 +1,4 @@
-import {
-  ensureAudioContextRunning,
-  setAudioContextKeepAwake,
-  suspendAudioContext,
-} from './audio-context';
+import { ensureAudioContextRunning, setAudioContextKeepAwake } from './audio-context';
 
 let activeSource: AudioBufferSourceNode | null = null;
 let activeGain: GainNode | null = null;
@@ -64,10 +60,9 @@ export const stopWhiteNoise = (): void => {
     activeGain.disconnect();
     activeGain = null;
   }
-  // The only long-lived background sound is gone, so release the audio output
-  // stream right away. We may be backgrounded (focus session ended while the app
-  // was away), where appStateChange won't fire another suspend; the next playback
-  // lazily resumes the context. Without this the silent-but-running context keeps
-  // draining until the next foreground/background cycle (#8243).
-  suspendAudioContext();
+  // NOTE: intentionally does NOT suspend the AudioContext here. stopWhiteNoise()
+  // runs (via the whiteNoiseSound$ selector effect) right as a session completes,
+  // racing the session-done chime (playSound) on the shared context — suspending
+  // would cut the chime off. The context is released instead by the appStateChange
+  // background handler in main.ts (#8243).
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,7 +91,7 @@ import { LocaleDatePipe } from './app/ui/pipes/locale-date.pipe';
 import { DateTimeFormatService } from './app/core/date-time-format/date-time-format.service';
 import { CustomDateAdapter } from './app/core/date-time-format/custom-date-adapter';
 import { TranslateMatDatepickerIntl } from './app/core/date-time-format/translate-mat-datepicker-intl';
-import { unlockAudioContext } from './app/util/audio-context';
+import { suspendAudioContext, unlockAudioContext } from './app/util/audio-context';
 import { NetworkRetryInterceptorService } from './app/core/http/network-retry-interceptor.service';
 
 if (environment.production || environment.stage) {
@@ -488,6 +488,9 @@ if (IS_ANDROID_WEB_VIEW) {
     if (isActive) {
       return;
     }
+    // Release the audio output stream so a silent-but-running AudioContext does
+    // not keep the audio hardware (and the process) awake in the background (#8243).
+    suspendAudioContext();
     const taskId = await BackgroundTask.beforeExit(async () => {
       try {
         await flushPendingOperations('Android');
@@ -505,6 +508,9 @@ if (IS_IOS_NATIVE) {
     if (isActive) {
       return;
     }
+    // Release the audio output stream so a silent-but-running AudioContext does
+    // not keep the audio hardware (and the process) awake in the background (#8243).
+    suspendAudioContext();
     const taskId = await BackgroundTask.beforeExit(async () => {
       try {
         // Dispatch any accumulated tracked time so it is enqueued before the


### PR DESCRIPTION
## Problem

Android battery drain (#8243). A reporter's `dumpsys batterystats --charged` showed Super Productivity holding a **continuously-running audio session**:

```
UID u0a262: 1364 ( audio=1364 (18h 11m 18s 685ms) )   ← Super Productivity
...
u0a262:
    Audio: 18h 11m 18s 685ms realtime (0 times) (running)
    Foreground activities: 18h 47m 38s 389ms realtime (0 times) (running)
```

That's **~54% of the phone's entire 2518 mAh discharge**, attributed entirely to `audio`, with **no sound playing, no time tracking, no focus session, and no visible notification**. It is *not* the per-second foreground-service notification tick — the reporter confirmed no notification was even present.

## Root cause

All sound playback goes through a single shared Web Audio `AudioContext` (`src/app/util/audio-context.ts`). `unlockAudioContext()` resumes it on the first user gesture (needed because mobile browsers start it suspended), but **nothing ever suspends or closes it again** — `closeAudioContext()` has no production callers and there was no `.suspend()` anywhere.

On Android, a `running` AudioContext keeps an `AudioTrack` open in the audio HAL **even when completely silent and all nodes are disconnected**. That open stream (a) keeps the audio hardware powered and (b) promotes the process to audio/perceptible importance so the OS never freezes or kills it. So after the first tap the context stays `running` for the lifetime of the WebView and drains the battery around the clock.

It became a regression when sound playback moved from short-lived per-play `new Audio()` elements (created and released each time) to this persistent shared context.

## Fix

Suspend the context when the app is backgrounded, via the existing `appStateChange` listener (Android + iOS). Playback lazily resumes it through `ensureAudioContextRunning()`, which is already called before every sound — so no sound is dropped. A `keepAwake` flag set by the focus-mode white noise prevents cutting off an intentionally-playing background sound when the app is backgrounded.

- `audio-context.ts` — `suspendAudioContext()` (no-op if no context / already suspended / kept-awake) + `setAudioContextKeepAwake()`; `keepAwake` reset in `closeAudioContext()`.
- `white-noise.ts` — sets keep-awake on start, clears on stop.
- `main.ts` — `suspendAudioContext()` on background in the Android and iOS `appStateChange` listeners.
- `audio-context.spec.ts` — 6 new tests (25 pass); focus-mode effects suite (107) unchanged.

## Review

Reviewed by a 6-agent parallel pass (correctness/security/architecture/alternatives/performance/simplicity) plus an independent Fable pass. The Fable pass caught a regression in an interim commit — a `stopWhiteNoise()` suspend that raced the session-done chime on the shared context — which has been **backed out** (`998a66a7c4`). The net diff is intentionally minimal.

## Known residuals (bounded, deliberately deferred)

- The context stays `running` while the app is **foregrounded and idle** (drain there is dwarfed by the screen being on).
- A sound played **while backgrounded** re-arms the context until the next foreground/background cycle (narrow on Android — the focus tick pauses in the background).
- Web/PWA is not covered (Android-specific issue; desktop browsers auto-suspend hidden tabs).

The complete fix for all three would be coordinated suspend-when-idle + resume-aware playback, intentionally kept out of this targeted change.

## ⚠️ Not yet device-verified

Validated by code review, unit tests, and the batterystats analysis — **not** by a real battery measurement. The unit tests assert `suspend()` is *called*, not that the WebView's HAL releases the AudioTrack. The decisive check is a before/after `dumpsys batterystats --charged com.superproductivity.superproductivity` on a patched build, confirming `Audio: …(running)` no longer accumulates while backgrounded. Help testing on-device is welcome.

Fixes #8243
