### PR TITLE
fix(plugins): stop leaked timers on plugin disable via onUnload hook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           GH_REPOSITORY: ${{ github.repository }}
           GH_REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if echo "$GH_REF_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             PREV_TAG=$(git tag --merged HEAD --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${GH_REF_NAME}$" | sed -n '1p')
@@ -28,8 +29,33 @@ jobs:
             PREV_TAG=$(git tag --merged HEAD --sort=-v:refname | grep '^v' | grep -v "^${GH_REF_NAME}$" | sed -n '1p')
           fi
 
+          # Contributor attribution was lost when curated notes replaced GitHub's
+          # auto-generated ones; pull the generated notes only to extract it.
+          GENERATED_NOTES=""
+          if [ -n "$PREV_TAG" ]; then
+            GENERATED_NOTES=$(gh api "repos/${GH_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$GH_REF_NAME" -f previous_tag_name="$PREV_TAG" --jq .body) \
+              || { GENERATED_NOTES=""; echo "Could not fetch generated notes for contributor extraction"; }
+          fi
+          CONTRIBUTORS=$(printf '%s\n' "$GENERATED_NOTES" \
+            | grep -oE ' by @[[:alnum:]-]+(\[bot\])? in https://[^ ]+/pull/[0-9]+$' \
+            | sed 's/^ by //;s/ in .*//' | grep -v '\[bot\]$' | sort -fu | paste -sd ' ' -) || true
+          NEW_CONTRIBUTORS=$(printf '%s\n' "$GENERATED_NOTES" \
+            | awk '/^## New Contributors$/{f=1} /^\*\*Full Changelog/{f=0} f' \
+            | sed 's/^## /### /') || true
+
           {
             cat build/release-notes.md
+            if [ -n "$CONTRIBUTORS" ]; then
+              echo ""
+              echo "### Contributors"
+              echo ""
+              echo "Thanks to everyone who contributed to this release: $CONTRIBUTORS"
+            fi
+            if [ -n "$NEW_CONTRIBUTORS" ]; then
+              echo ""
+              echo "$NEW_CONTRIBUTORS"
+            fi
             echo ""
             if [ -n "$PREV_TAG" ]; then
               echo "**Full Changelog**: https://github.com/${GH_REPOSITORY}/compare/${PREV_TAG}...${GH_REF_NAME}"

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -616,11 +616,17 @@ plugin.onUnload(() => {
 ```
 
 The host invokes the callback at the start of plugin teardown, while the Plugin API is
-still usable. Registering again replaces the previous callback, so register once and do
-all cleanup there. Errors thrown by the callback are logged and do not block teardown.
+still usable. The returned promise is **not awaited** — do synchronous cleanup
+(`clearInterval` etc.) before any `await`, since teardown continues immediately.
+Registering again replaces the previous callback, so register once and do all cleanup
+there. Errors thrown by the callback are logged and do not block teardown.
 
-**Iframe plugins:** `onUnload` exists but is a no-op — the host destroys the iframe on
-unload, which takes its timers and listeners with it.
+Plugins distributed independently of the app should feature-detect it
+(`if (plugin.onUnload) { ... }`) — hosts predating the hook don't provide it.
+
+**Iframe plugins:** `onUnload` exists but is a no-op — the host unmounts the iframe on
+unload, which takes its timers and listeners with it. Don't rely on it for unload-time
+persistence in iframes; persist when the data changes instead.
 
 ### 4. Don't spam the logs
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -599,6 +599,29 @@ fine in practice because iframe plugins are rendered on user navigation (well af
 startup). Iframe API calls still go through the host bridge when they are made;
 cold-boot bridge pings are only performed for host-side plugin code.
 
+**Clean up with `plugin.onUnload()`:**
+
+Code-based plugins (`plugin.js`) run directly in the app's renderer, so timers and
+listeners they create are **not** cleaned up automatically when the plugin is disabled,
+reloaded, or uninstalled — a `setInterval` started by your plugin keeps firing until the
+app is fully reloaded. Register a teardown callback to clear them yourself:
+
+```javascript
+const intervalId = setInterval(doWork, 60000);
+
+plugin.onUnload(() => {
+  clearInterval(intervalId);
+  // also: removeEventListener, speechSynthesis.cancel(), close connections, …
+});
+```
+
+The host invokes the callback at the start of plugin teardown, while the Plugin API is
+still usable. Registering again replaces the previous callback, so register once and do
+all cleanup there. Errors thrown by the callback are logged and do not block teardown.
+
+**Iframe plugins:** `onUnload` exists but is a no-op — the host destroys the iframe on
+unload, which takes its timers and listeners with it.
+
 ### 4. Don't spam the logs
 
 `console.logs` should be kept to a minimum.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -616,10 +616,12 @@ plugin.onUnload(() => {
 ```
 
 The host invokes the callback at the start of plugin teardown, while the Plugin API is
-still usable. The returned promise is **not awaited** — do synchronous cleanup
-(`clearInterval` etc.) before any `await`, since teardown continues immediately.
-Registering again replaces the previous callback, so register once and do all cleanup
-there. Errors thrown by the callback are logged and do not block teardown.
+still usable for calls like persisting data — but don't register new hooks or listeners
+from inside it (the plugin is going away; re-registering `onUnload` there is ignored).
+The returned promise is **not awaited** — do synchronous cleanup (`clearInterval` etc.)
+before any `await`, since teardown continues immediately. Registering again replaces the
+previous callback, so register once and do all cleanup there. Errors thrown by the
+callback are logged and do not block teardown.
 
 Plugins distributed independently of the app should feature-detect it
 (`if (plugin.onUnload) { ... }`) — hosts predating the hook don't provide it.

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -545,10 +545,11 @@ export interface PluginAPI {
   // disabled, reloaded, or uninstalled. Code-based plugins run directly in the
   // renderer, so timers/listeners they create survive unload unless cleared
   // here (clearInterval, removeEventListener, speechSynthesis.cancel, …).
-  // In iframe plugins this is a no-op: the iframe is destroyed on unload and
-  // takes its timers with it. Registering again replaces the previous callback.
-  // Optional so older plugin API typings remain assignable; the host always
-  // provides it.
+  // The returned promise is NOT awaited — do synchronous cleanup before any
+  // await. In iframe plugins this is a no-op: the iframe is unmounted on
+  // unload and takes its timers with it. Registering again replaces the
+  // previous callback. Optional so older plugin API typings remain assignable;
+  // the host always provides it.
   onUnload?(fn: () => void | Promise<void>): void;
 
   // cross-process communication

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -541,6 +541,16 @@ export interface PluginAPI {
   // plugin API typings remain assignable; the host always provides it.
   onReady?(fn: () => void | Promise<void>): void;
 
+  // teardown signal — register a callback the host invokes when the plugin is
+  // disabled, reloaded, or uninstalled. Code-based plugins run directly in the
+  // renderer, so timers/listeners they create survive unload unless cleared
+  // here (clearInterval, removeEventListener, speechSynthesis.cancel, …).
+  // In iframe plugins this is a no-op: the iframe is destroyed on unload and
+  // takes its timers with it. Registering again replaces the previous callback.
+  // Optional so older plugin API typings remain assignable; the host always
+  // provides it.
+  onUnload?(fn: () => void | Promise<void>): void;
+
   // cross-process communication
   onMessage?(handler: (message: unknown) => Promise<unknown> | unknown): void;
 

--- a/packages/plugin-dev/voice-reminder/plugin.js
+++ b/packages/plugin-dev/voice-reminder/plugin.js
@@ -37,6 +37,8 @@ if (!window.speechSynthesis) {
   }
 
   function _vrSpeak(text, volume, voiceName) {
+    // the settings dialog can outlive the plugin (Test button) — stay silent
+    if (_vrUnloaded) return;
     var synth = window.speechSynthesis;
     if (!synth) {
       console.error('[voice-reminder] No window.speechSynthesis available.');
@@ -76,6 +78,10 @@ if (!window.speechSynthesis) {
     // re-check after the await: the plugin may have been unloaded while the
     // config was loading — arming the interval then would leak it (#8281)
     if (!cfg.isEnabled || _vrUnloaded) return;
+
+    // stop again: an interleaved _vrStartTimer call may have armed its own
+    // interval during the await — without this that handle is orphaned
+    _vrStopTimer();
 
     var intervalMs = Math.max(cfg.interval || 300000, 5000);
     _vrInterval = setInterval(function () {

--- a/packages/plugin-dev/voice-reminder/plugin.js
+++ b/packages/plugin-dev/voice-reminder/plugin.js
@@ -8,6 +8,7 @@ if (!window.speechSynthesis) {
   var _vrInterval = null;
   var _vrCurrentTask = null;
   var _vrDefaultTtsRate = 0.7;
+  var _vrUnloaded = false;
 
   var _vrDefaults = {
     isEnabled: false,
@@ -72,7 +73,9 @@ if (!window.speechSynthesis) {
   async function _vrStartTimer() {
     _vrStopTimer();
     var cfg = await _vrLoadConfig();
-    if (!cfg.isEnabled) return;
+    // re-check after the await: the plugin may have been unloaded while the
+    // config was loading — arming the interval then would leak it (#8281)
+    if (!cfg.isEnabled || _vrUnloaded) return;
 
     var intervalMs = Math.max(cfg.interval || 300000, 5000);
     _vrInterval = setInterval(function () {
@@ -88,6 +91,16 @@ if (!window.speechSynthesis) {
   // Track current task via hook. The host emits { current, previous }.
   PluginAPI.registerHook('currentTaskChange', function (payload) {
     _vrCurrentTask = payload && payload.current ? payload.current : null;
+  });
+
+  // Stop the reminder timer and any in-flight speech when the plugin is
+  // disabled/reloaded — without this the interval survives unload (#8281).
+  // shortcut: cancel() clears ALL renderer TTS, not just ours — fine while
+  // this is the only plugin using speechSynthesis
+  PluginAPI.onUnload(function () {
+    _vrUnloaded = true;
+    _vrStopTimer();
+    window.speechSynthesis.cancel();
   });
 
   // Initial load and start

--- a/packages/plugin-dev/voice-reminder/plugin.js
+++ b/packages/plugin-dev/voice-reminder/plugin.js
@@ -9,6 +9,7 @@ if (!window.speechSynthesis) {
   var _vrCurrentTask = null;
   var _vrDefaultTtsRate = 0.7;
   var _vrUnloaded = false;
+  var _vrStartGen = 0;
 
   var _vrDefaults = {
     isEnabled: false,
@@ -73,15 +74,15 @@ if (!window.speechSynthesis) {
   }
 
   async function _vrStartTimer() {
+    var myGen = ++_vrStartGen;
     _vrStopTimer();
     var cfg = await _vrLoadConfig();
-    // re-check after the await: the plugin may have been unloaded while the
-    // config was loading — arming the interval then would leak it (#8281)
-    if (!cfg.isEnabled || _vrUnloaded) return;
-
-    // stop again: an interleaved _vrStartTimer call may have armed its own
-    // interval during the await — without this that handle is orphaned
+    // overlapping calls (e.g. Save racing the initial load) resume with stale
+    // config — only the latest call may touch the timer, and only while the
+    // plugin is still loaded (#8281)
+    if (myGen !== _vrStartGen) return;
     _vrStopTimer();
+    if (!cfg.isEnabled || _vrUnloaded) return;
 
     var intervalMs = Math.max(cfg.interval || 300000, 5000);
     _vrInterval = setInterval(function () {

--- a/packages/sync-providers/src/errors.ts
+++ b/packages/sync-providers/src/errors.ts
@@ -16,4 +16,5 @@ export {
   TooManyRequestsAPIError,
   UploadRevToMatchMismatchAPIError,
   WebDavNativeRequestError,
+  WebDavSyncFolderUnusableSPError,
 } from './errors/index';

--- a/packages/sync-providers/src/errors/index.ts
+++ b/packages/sync-providers/src/errors/index.ts
@@ -247,3 +247,25 @@ export class EmptyRemoteBodySPError extends InvalidDataSPError {
 export class RemoteFileChangedUnexpectedly extends AdditionalLogErrorBase {
   override name = 'RemoteFileChangedUnexpectedly';
 }
+
+/**
+ * Raised when a WebDAV PUT keeps returning 409 Conflict even after we
+ * created the parent collection — i.e. the configured sync folder cannot
+ * be resolved/written relative to the server root (a misconfigured Base
+ * URL or Sync Folder Path, the classic Synology/raw-WebDAV setup mistake).
+ *
+ * Without this, the raw `HTTP 409 Conflict` (or a bare "Unknown error")
+ * reaches the user, which gives no hint at the actual cause. The message
+ * here is privacy-safe (no path, no response body) and actionable, so UI
+ * surfaces can show it verbatim. Mirrors `NetworkUnavailableSPError`: a
+ * fixed user-facing message matched by `instanceof`, not a string round-trip.
+ */
+export class WebDavSyncFolderUnusableSPError extends Error {
+  override name = 'WebDavSyncFolderUnusableSPError';
+  constructor() {
+    super(
+      'WebDAV server returned 409 (Conflict) and the sync folder could not be created. ' +
+        'Check that the Base URL points to your WebDAV root and that the Sync Folder Path is correct and writable.',
+    );
+  }
+}

--- a/packages/sync-providers/src/file-based/webdav/webdav-api.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-api.ts
@@ -6,6 +6,7 @@ import {
   MissingCredentialsSPError,
   RemoteFileChangedUnexpectedly,
   RemoteFileNotFoundAPIError,
+  WebDavSyncFolderUnusableSPError,
 } from '../../errors';
 import { errorMeta } from '../../log/error-meta';
 import { computeContentRev } from '../content-rev';
@@ -257,13 +258,17 @@ export class WebdavApi {
               retryError.response.status === WebDavHttpStatus.CONFLICT
             ) {
               // Demoted from `critical` to `normal`: this is a config-debug
-              // hint, not an exceptional / unrecoverable condition. The
-              // caller still gets the thrown error to surface in the UI.
+              // hint, not an exceptional / unrecoverable condition.
               this._deps.logger.normal(
                 `${WebdavApi.L}.upload() 409 Conflict persists after creating parent. ` +
                   `Verify syncFolderPath is relative to the WebDAV server root.`,
                 { path },
               );
+              // Re-throw as an actionable, privacy-safe error so the user
+              // sees *why* sync fails (misconfigured Base URL / Sync Folder
+              // Path) instead of a bare "HTTP 409 Conflict". The raw 409 is
+              // already captured by the logger.normal() call above.
+              throw new WebDavSyncFolderUnusableSPError();
             }
             throw retryError;
           }

--- a/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
@@ -16,6 +16,7 @@ import {
   RemoteFileChangedUnexpectedly,
   RemoteFileNotFoundAPIError,
   WebDavNativeRequestError,
+  WebDavSyncFolderUnusableSPError,
 } from '../../../src/errors';
 
 const cfg: WebdavPrivateCfg = {
@@ -224,6 +225,34 @@ describe('WebdavApi', () => {
       expect(r.rev).toBe(await md5HashWasm(data));
       // PUT + MKCOL + PUT + GET
       expect(adapter.request).toHaveBeenCalledTimes(4);
+    });
+
+    // A 409 that persists after we create the parent dir means the
+    // Base URL / Sync Folder Path is misconfigured (classic Synology /
+    // raw-WebDAV setup mistake). Surface an actionable error instead of a
+    // bare `HTTP 409 Conflict` so the user knows what to fix.
+    it('throws an actionable WebDavSyncFolderUnusableSPError when 409 persists after creating parent', async () => {
+      const adapter = makeAdapter();
+      const data = 'fresh';
+      // First PUT → 409
+      adapter.request.mockRejectedValueOnce(
+        new HttpNotOkAPIError(new Response('', { status: 409 })),
+      );
+      // MKCOL → success
+      adapter.request.mockResolvedValueOnce(okResponse('', 201));
+      // Retry PUT → 409 again (folder path still unresolvable)
+      adapter.request.mockRejectedValueOnce(
+        new HttpNotOkAPIError(new Response('', { status: 409 })),
+      );
+
+      const err = await makeApi(adapter)
+        .upload({ path: 'sp/op-1.json', data })
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(WebDavSyncFolderUnusableSPError);
+      // Privacy-safe + actionable message, no path or response body.
+      expect(err.message).toContain('Base URL');
+      expect(err.message).toContain('Sync Folder Path');
+      expect(err.message).not.toContain('op-1.json');
     });
   });
 

--- a/src/app/plugins/plugin-api.spec.ts
+++ b/src/app/plugins/plugin-api.spec.ts
@@ -217,29 +217,24 @@ describe('PluginAPI', () => {
     });
   });
 
-  describe('onReady()', () => {
-    it('should register a callback via the onReadyRegister function', async () => {
-      let registeredFn: (() => void | Promise<void>) | undefined;
-      const mockBridge2 = jasmine.createSpyObj('PluginBridgeService', [
-        'createBoundMethods',
-      ]);
-      mockBridge2.createBoundMethods.and.returnValue({
+  describe('lifecycle registration', () => {
+    type LifecycleRegisters = NonNullable<ConstructorParameters<typeof PluginAPI>[5]>;
+
+    const buildApiWithLifecycle = (lifecycle: LifecycleRegisters): PluginAPI => {
+      const bridge = jasmine.createSpyObj('PluginBridgeService', ['createBoundMethods']);
+      bridge.createBoundMethods.and.returnValue({
         log: jasmine.createSpyObj('log', ['log', 'err', 'info', 'warn', 'debug']),
       });
-      const mockI18n2 = jasmine.createSpyObj('PluginI18nService', [
+      const i18n = jasmine.createSpyObj('PluginI18nService', [
         'translate',
         'getCurrentLanguage',
       ]);
-      const api = new PluginAPI(
-        baseCfg,
-        'test-plugin-2',
-        mockBridge2,
-        mockI18n2,
-        undefined,
-        (fn) => {
-          registeredFn = fn;
-        },
-      );
+      return new PluginAPI(baseCfg, 'test-plugin-2', bridge, i18n, undefined, lifecycle);
+    };
+
+    it('should register an onReady callback via the lifecycle register', async () => {
+      let registeredFn: (() => void | Promise<void>) | undefined;
+      const api = buildApiWithLifecycle({ onReady: (fn) => (registeredFn = fn) });
 
       const readySpy = jasmine.createSpy('readyFn').and.resolveTo();
       api.onReady(readySpy);
@@ -249,36 +244,9 @@ describe('PluginAPI', () => {
       expect(readySpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should be a no-op when no onReadyRegister is provided', () => {
-      // pluginAPI was constructed without onReadyRegister — should not throw
-      expect(() => pluginAPI.onReady(() => {})).not.toThrow();
-    });
-  });
-
-  describe('onUnload()', () => {
-    it('should register a callback via the onUnloadRegister function', async () => {
+    it('should register an onUnload callback via the lifecycle register', async () => {
       let registeredFn: (() => void | Promise<void>) | undefined;
-      const mockBridge2 = jasmine.createSpyObj('PluginBridgeService', [
-        'createBoundMethods',
-      ]);
-      mockBridge2.createBoundMethods.and.returnValue({
-        log: jasmine.createSpyObj('log', ['log', 'err', 'info', 'warn', 'debug']),
-      });
-      const mockI18n2 = jasmine.createSpyObj('PluginI18nService', [
-        'translate',
-        'getCurrentLanguage',
-      ]);
-      const api = new PluginAPI(
-        baseCfg,
-        'test-plugin-2',
-        mockBridge2,
-        mockI18n2,
-        undefined,
-        undefined,
-        (fn) => {
-          registeredFn = fn;
-        },
-      );
+      const api = buildApiWithLifecycle({ onUnload: (fn) => (registeredFn = fn) });
 
       const unloadSpy = jasmine.createSpy('unloadFn').and.resolveTo();
       api.onUnload(unloadSpy);
@@ -288,8 +256,9 @@ describe('PluginAPI', () => {
       expect(unloadSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should be a no-op when no onUnloadRegister is provided', () => {
-      // pluginAPI was constructed without onUnloadRegister — should not throw
+    it('should be a no-op when no lifecycle registers are provided', () => {
+      // pluginAPI was constructed without lifecycle registers — should not throw
+      expect(() => pluginAPI.onReady(() => {})).not.toThrow();
       expect(() => pluginAPI.onUnload(() => {})).not.toThrow();
     });
   });

--- a/src/app/plugins/plugin-api.spec.ts
+++ b/src/app/plugins/plugin-api.spec.ts
@@ -254,4 +254,43 @@ describe('PluginAPI', () => {
       expect(() => pluginAPI.onReady(() => {})).not.toThrow();
     });
   });
+
+  describe('onUnload()', () => {
+    it('should register a callback via the onUnloadRegister function', async () => {
+      let registeredFn: (() => void | Promise<void>) | undefined;
+      const mockBridge2 = jasmine.createSpyObj('PluginBridgeService', [
+        'createBoundMethods',
+      ]);
+      mockBridge2.createBoundMethods.and.returnValue({
+        log: jasmine.createSpyObj('log', ['log', 'err', 'info', 'warn', 'debug']),
+      });
+      const mockI18n2 = jasmine.createSpyObj('PluginI18nService', [
+        'translate',
+        'getCurrentLanguage',
+      ]);
+      const api = new PluginAPI(
+        baseCfg,
+        'test-plugin-2',
+        mockBridge2,
+        mockI18n2,
+        undefined,
+        undefined,
+        (fn) => {
+          registeredFn = fn;
+        },
+      );
+
+      const unloadSpy = jasmine.createSpy('unloadFn').and.resolveTo();
+      api.onUnload(unloadSpy);
+      expect(registeredFn).toBeDefined();
+
+      await registeredFn!();
+      expect(unloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be a no-op when no onUnloadRegister is provided', () => {
+      // pluginAPI was constructed without onUnloadRegister — should not throw
+      expect(() => pluginAPI.onUnload(() => {})).not.toThrow();
+    });
+  });
 });

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -350,7 +350,8 @@ export class PluginAPI implements PluginAPIInterface {
    * Register a callback the host invokes when the plugin is disabled, reloaded,
    * or uninstalled. Code-based plugins must clear timers/listeners they created
    * here, since they run directly in the renderer and outlive their unload
-   * otherwise. Registering again replaces the previous callback.
+   * otherwise. The returned promise is not awaited — do synchronous cleanup
+   * before any await. Registering again replaces the previous callback.
    */
   onUnload(fn: () => void | Promise<void>): void {
     this.#onUnloadRegister?.(fn);

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -73,15 +73,17 @@ export class PluginAPI implements PluginAPIInterface {
     pluginBridge: PluginBridgeService,
     pluginI18nService: PluginI18nService,
     manifest?: PluginManifest,
-    onReadyRegister?: (fn: () => void | Promise<void>) => void,
-    onUnloadRegister?: (fn: () => void | Promise<void>) => void,
+    lifecycleRegisters?: {
+      onReady?: (fn: () => void | Promise<void>) => void;
+      onUnload?: (fn: () => void | Promise<void>) => void;
+    },
   ) {
     this.#pluginId = pluginId;
     this.#pluginBridge = pluginBridge;
     this.#pluginI18nService = pluginI18nService;
     this.#manifest = manifest;
-    this.#onReadyRegister = onReadyRegister;
-    this.#onUnloadRegister = onUnloadRegister;
+    this.#onReadyRegister = lifecycleRegisters?.onReady;
+    this.#onUnloadRegister = lifecycleRegisters?.onUnload;
 
     // Get bound methods for this plugin
     this.#boundMethods = this.#pluginBridge.createBoundMethods(

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -52,6 +52,7 @@ export class PluginAPI implements PluginAPIInterface {
   #pluginI18nService: PluginI18nService;
   #manifest?: PluginManifest;
   #onReadyRegister?: (fn: () => void | Promise<void>) => void;
+  #onUnloadRegister?: (fn: () => void | Promise<void>) => void;
   #hookHandlers = new Map<string, Map<Hooks, Array<PluginHookHandler<Hooks>>>>();
   #messageHandler?: (message: unknown) => Promise<unknown>;
   #boundMethods: ReturnType<typeof PluginBridgeService.prototype.createBoundMethods>;
@@ -73,12 +74,14 @@ export class PluginAPI implements PluginAPIInterface {
     pluginI18nService: PluginI18nService,
     manifest?: PluginManifest,
     onReadyRegister?: (fn: () => void | Promise<void>) => void,
+    onUnloadRegister?: (fn: () => void | Promise<void>) => void,
   ) {
     this.#pluginId = pluginId;
     this.#pluginBridge = pluginBridge;
     this.#pluginI18nService = pluginI18nService;
     this.#manifest = manifest;
     this.#onReadyRegister = onReadyRegister;
+    this.#onUnloadRegister = onUnloadRegister;
 
     // Get bound methods for this plugin
     this.#boundMethods = this.#pluginBridge.createBoundMethods(
@@ -341,6 +344,16 @@ export class PluginAPI implements PluginAPIInterface {
    */
   onReady(fn: () => void | Promise<void>): void {
     this.#onReadyRegister?.(fn);
+  }
+
+  /**
+   * Register a callback the host invokes when the plugin is disabled, reloaded,
+   * or uninstalled. Code-based plugins must clear timers/listeners they created
+   * here, since they run directly in the renderer and outlive their unload
+   * otherwise. Registering again replaces the previous callback.
+   */
+  onUnload(fn: () => void | Promise<void>): void {
+    this.#onUnloadRegister?.(fn);
   }
 
   /**

--- a/src/app/plugins/plugin-runner.spec.ts
+++ b/src/app/plugins/plugin-runner.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { PluginRunner } from './plugin-runner';
+import { PluginAPI } from './plugin-api';
 import { PluginBridgeService } from './plugin-bridge.service';
 import { PluginSecurityService } from './plugin-security';
 import { SnackService } from '../core/snack/snack.service';
@@ -358,6 +359,39 @@ describe('PluginRunner', () => {
       expect(mockCleanupService.cleanupPlugin).toHaveBeenCalledWith(mockManifest.id);
       // let the rejected promise settle so it doesn't leak into other specs
       await new Promise((r) => setTimeout(r, 0));
+    });
+
+    it('should fire the callback at most once across triggerUnload and unloadPlugin', async () => {
+      const unloadSpy = jasmine.createSpy('unload');
+      getGlobal()[mockManifest.id] = unloadSpy;
+
+      const code = `plugin.onUnload(() => globalThis['${UNLOAD_GLOBAL}']['${mockManifest.id}']());`;
+      await service.loadPlugin(mockManifest, code, mockBaseCfg);
+
+      // plugin.service fires triggerUnload at the start of teardown, then
+      // unloadPlugin runs as part of the same teardown — must not double-fire
+      service.triggerUnload(mockManifest.id);
+      expect(unloadSpy).toHaveBeenCalledTimes(1);
+
+      const result = service.unloadPlugin(mockManifest.id);
+      expect(result).toBe(true);
+      expect(unloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore onUnload registrations from a stale API instance', async () => {
+      const staleSpy = jasmine.createSpy('staleUnload');
+      // plugin leaks its API object so the test can register after unload
+      const code = `globalThis['${UNLOAD_GLOBAL}']['leakedApi'] = plugin;`;
+      await service.loadPlugin(mockManifest, code, mockBaseCfg);
+      service.unloadPlugin(mockManifest.id);
+
+      const leakedApi = getGlobal()['leakedApi'] as unknown as PluginAPI;
+      leakedApi.onUnload(staleSpy);
+
+      // reload the plugin: the stale registration must not fire on its unload
+      await service.loadPlugin(mockManifest, `/* no-op */`, mockBaseCfg);
+      service.unloadPlugin(mockManifest.id);
+      expect(staleSpy).not.toHaveBeenCalled();
     });
 
     it('should only fire the callback of the unloaded plugin', async () => {

--- a/src/app/plugins/plugin-runner.spec.ts
+++ b/src/app/plugins/plugin-runner.spec.ts
@@ -280,6 +280,22 @@ describe('PluginRunner', () => {
     it('should resolve silently for unknown plugin id', async () => {
       await expectAsync(service.triggerReady('does-not-exist')).toBeResolved();
     });
+
+    it('should ignore onReady registrations from a stale API instance', async () => {
+      const staleSpy = jasmine.createSpy('staleReady');
+      // plugin leaks its API object so the test can register after unload
+      const code = `globalThis['${READY_GLOBAL}']['leakedApi'] = plugin;`;
+      await service.loadPlugin(mockManifest, code, mockBaseCfg);
+      service.unloadPlugin(mockManifest.id);
+
+      const leakedApi = getGlobal()['leakedApi'] as unknown as PluginAPI;
+      leakedApi.onReady(staleSpy);
+
+      // reload the plugin: the stale registration must not run in its activation
+      await service.loadPlugin(mockManifest, `/* no-op */`, mockBaseCfg);
+      await service.triggerReady(mockManifest.id);
+      expect(staleSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('onUnload', () => {

--- a/src/app/plugins/plugin-runner.spec.ts
+++ b/src/app/plugins/plugin-runner.spec.ts
@@ -281,6 +281,109 @@ describe('PluginRunner', () => {
     });
   });
 
+  describe('onUnload', () => {
+    // Same globalThis-spy pattern as the triggerReady() tests above.
+    const UNLOAD_GLOBAL = '__pluginRunnerSpec_onUnload__';
+    const getGlobal = (): Record<string, jasmine.Spy> =>
+      (globalThis as unknown as Record<string, Record<string, jasmine.Spy>>)[
+        UNLOAD_GLOBAL
+      ];
+
+    beforeEach(() => {
+      (globalThis as unknown as Record<string, Record<string, jasmine.Spy>>)[
+        UNLOAD_GLOBAL
+      ] = {};
+    });
+
+    afterEach(() => {
+      delete (globalThis as unknown as Record<string, unknown>)[UNLOAD_GLOBAL];
+    });
+
+    it('should call the registered onUnload callback when unloading', async () => {
+      const unloadSpy = jasmine.createSpy('unload');
+      getGlobal()[mockManifest.id] = unloadSpy;
+
+      const code = `plugin.onUnload(() => globalThis['${UNLOAD_GLOBAL}']['${mockManifest.id}']());`;
+      await service.loadPlugin(mockManifest, code, mockBaseCfg);
+
+      expect(unloadSpy).not.toHaveBeenCalled();
+      const result = service.unloadPlugin(mockManifest.id);
+
+      expect(result).toBe(true);
+      expect(unloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should invoke the callback before hooks are unregistered', async () => {
+      const callOrder: string[] = [];
+      getGlobal()[mockManifest.id] = jasmine
+        .createSpy('unload')
+        .and.callFake(() => callOrder.push('onUnload'));
+      mockPluginBridge.unregisterPluginHooks.and.callFake(() => {
+        callOrder.push('unregisterPluginHooks');
+      });
+
+      const code = `plugin.onUnload(() => globalThis['${UNLOAD_GLOBAL}']['${mockManifest.id}']());`;
+      await service.loadPlugin(mockManifest, code, mockBaseCfg);
+      service.unloadPlugin(mockManifest.id);
+
+      expect(callOrder).toEqual(['onUnload', 'unregisterPluginHooks']);
+    });
+
+    it('should not block teardown when the callback throws', async () => {
+      getGlobal()[mockManifest.id] = jasmine.createSpy('unload').and.throwError('boom');
+
+      const code = `plugin.onUnload(() => globalThis['${UNLOAD_GLOBAL}']['${mockManifest.id}']());`;
+      await service.loadPlugin(mockManifest, code, mockBaseCfg);
+
+      const result = service.unloadPlugin(mockManifest.id);
+
+      expect(result).toBe(true);
+      expect(mockCleanupService.cleanupPlugin).toHaveBeenCalledWith(mockManifest.id);
+      expect(mockPluginBridge.unregisterPluginHooks).toHaveBeenCalledWith(
+        mockManifest.id,
+      );
+    });
+
+    it('should not block teardown when the callback rejects asynchronously', async () => {
+      getGlobal()[mockManifest.id] = jasmine
+        .createSpy('unload')
+        .and.rejectWith(new Error('async boom'));
+
+      const code = `plugin.onUnload(() => globalThis['${UNLOAD_GLOBAL}']['${mockManifest.id}']());`;
+      await service.loadPlugin(mockManifest, code, mockBaseCfg);
+
+      const result = service.unloadPlugin(mockManifest.id);
+
+      expect(result).toBe(true);
+      expect(mockCleanupService.cleanupPlugin).toHaveBeenCalledWith(mockManifest.id);
+      // let the rejected promise settle so it doesn't leak into other specs
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    it('should only fire the callback of the unloaded plugin', async () => {
+      const manifestB = { ...mockManifest, id: 'plugin-b', name: 'Plugin B' };
+      const aSpy = jasmine.createSpy('aUnload');
+      const bSpy = jasmine.createSpy('bUnload');
+      getGlobal()[mockManifest.id] = aSpy;
+      getGlobal()[manifestB.id] = bSpy;
+
+      await service.loadPlugin(
+        mockManifest,
+        `plugin.onUnload(() => globalThis['${UNLOAD_GLOBAL}']['${mockManifest.id}']());`,
+        mockBaseCfg,
+      );
+      await service.loadPlugin(
+        manifestB,
+        `plugin.onUnload(() => globalThis['${UNLOAD_GLOBAL}']['${manifestB.id}']());`,
+        mockBaseCfg,
+      );
+
+      service.unloadPlugin(mockManifest.id);
+      expect(aSpy).toHaveBeenCalledTimes(1);
+      expect(bSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('pingNodeBridge()', () => {
     it('should return false for unknown plugin', async () => {
       const result = await service.pingNodeBridge('unknown-plugin');

--- a/src/app/plugins/plugin-runner.ts
+++ b/src/app/plugins/plugin-runner.ts
@@ -45,7 +45,14 @@ export class PluginRunner {
         this._pluginI18nService,
         manifest,
         (fn) => this._readyCallbacks.set(manifest.id, fn),
-        (fn) => this._unloadCallbacks.set(manifest.id, fn),
+        (fn) => {
+          // ignore registrations from a stale API instance — leaked plugin code
+          // can run after its own unload (the failure class this hook fixes)
+          // and must not clobber a reloaded instance's callback
+          if (this._pluginApis.get(manifest.id) === pluginAPI) {
+            this._unloadCallbacks.set(manifest.id, fn);
+          }
+        },
       );
 
       // executeNodeScript is now automatically bound if permitted via createBoundMethods
@@ -186,21 +193,10 @@ export class PluginRunner {
   unloadPlugin(pluginId: string): boolean {
     const plugin = this._loadedPlugins.get(pluginId);
     if (plugin) {
-      // Give the plugin a chance to clear timers/listeners it created in the
-      // renderer (code-based plugins outlive their unload otherwise — see #8281).
-      // Fire-and-forget: unloadPlugin is sync and a buggy callback must not
-      // block teardown.
-      const unloadFn = this._unloadCallbacks.get(pluginId);
-      this._unloadCallbacks.delete(pluginId);
-      if (unloadFn) {
-        try {
-          Promise.resolve(unloadFn()).catch((e) =>
-            PluginLog.err(`Plugin ${pluginId} onUnload callback failed:`, e),
-          );
-        } catch (e) {
-          PluginLog.err(`Plugin ${pluginId} onUnload callback failed:`, e);
-        }
-      }
+      // Fallback for teardown routes that bypass PluginService's
+      // _teardownPluginRuntime (activation-error cleanup) — no-op when the
+      // service already fired it.
+      this.triggerUnload(pluginId);
 
       // Clean up API reference
       this._pluginApis.delete(pluginId);
@@ -226,6 +222,28 @@ export class PluginRunner {
    */
   getLoadedPlugin(pluginId: string): PluginInstance | undefined {
     return this._loadedPlugins.get(pluginId);
+  }
+
+  /**
+   * Fire the plugin's registered onUnload callback so it can clear timers and
+   * listeners it created in the renderer — code-based plugins outlive their
+   * unload otherwise (see #8281). Idempotent: the callback fires at most once.
+   * Fire-and-forget: teardown is sync and a buggy callback must not block it;
+   * the returned promise of an async callback is not awaited.
+   * Called by plugin.service.ts at the start of teardown (while hooks and
+   * translations are still registered) and from unloadPlugin() as a fallback.
+   */
+  triggerUnload(pluginId: string): void {
+    const unloadFn = this._unloadCallbacks.get(pluginId);
+    this._unloadCallbacks.delete(pluginId);
+    // drop the API reference first so re-registration from inside the callback
+    // (or any later stale call) is ignored by the registration guard
+    this._pluginApis.delete(pluginId);
+    if (unloadFn) {
+      void (async () => unloadFn())().catch((e) =>
+        PluginLog.err(`Plugin ${pluginId} onUnload callback failed:`, e),
+      );
+    }
   }
 
   /**

--- a/src/app/plugins/plugin-runner.ts
+++ b/src/app/plugins/plugin-runner.ts
@@ -44,14 +44,16 @@ export class PluginRunner {
         this._pluginBridge,
         this._pluginI18nService,
         manifest,
-        (fn) => this._readyCallbacks.set(manifest.id, fn),
-        (fn) => {
-          // ignore registrations from a stale API instance — leaked plugin code
-          // can run after its own unload (the failure class this hook fixes)
-          // and must not clobber a reloaded instance's callback
-          if (this._pluginApis.get(manifest.id) === pluginAPI) {
-            this._unloadCallbacks.set(manifest.id, fn);
-          }
+        {
+          onReady: (fn) => this._readyCallbacks.set(manifest.id, fn),
+          onUnload: (fn) => {
+            // ignore registrations from a stale API instance — leaked plugin
+            // code can run after its own unload (the failure class this hook
+            // fixes) and must not clobber a reloaded instance's callback
+            if (this._pluginApis.get(manifest.id) === pluginAPI) {
+              this._unloadCallbacks.set(manifest.id, fn);
+            }
+          },
         },
       );
 

--- a/src/app/plugins/plugin-runner.ts
+++ b/src/app/plugins/plugin-runner.ts
@@ -25,6 +25,7 @@ export class PluginRunner {
   private _loadedPlugins = new Map<string, PluginInstance>();
   private _pluginApis = new Map<string, PluginAPI>();
   private _readyCallbacks = new Map<string, () => void | Promise<void>>();
+  private _unloadCallbacks = new Map<string, () => void | Promise<void>>();
 
   /**
    * Load and execute a plugin
@@ -44,6 +45,7 @@ export class PluginRunner {
         this._pluginI18nService,
         manifest,
         (fn) => this._readyCallbacks.set(manifest.id, fn),
+        (fn) => this._unloadCallbacks.set(manifest.id, fn),
       );
 
       // executeNodeScript is now automatically bound if permitted via createBoundMethods
@@ -184,6 +186,22 @@ export class PluginRunner {
   unloadPlugin(pluginId: string): boolean {
     const plugin = this._loadedPlugins.get(pluginId);
     if (plugin) {
+      // Give the plugin a chance to clear timers/listeners it created in the
+      // renderer (code-based plugins outlive their unload otherwise — see #8281).
+      // Fire-and-forget: unloadPlugin is sync and a buggy callback must not
+      // block teardown.
+      const unloadFn = this._unloadCallbacks.get(pluginId);
+      this._unloadCallbacks.delete(pluginId);
+      if (unloadFn) {
+        try {
+          Promise.resolve(unloadFn()).catch((e) =>
+            PluginLog.err(`Plugin ${pluginId} onUnload callback failed:`, e),
+          );
+        } catch (e) {
+          PluginLog.err(`Plugin ${pluginId} onUnload callback failed:`, e);
+        }
+      }
+
       // Clean up API reference
       this._pluginApis.delete(pluginId);
       this._readyCallbacks.delete(pluginId);

--- a/src/app/plugins/plugin-runner.ts
+++ b/src/app/plugins/plugin-runner.ts
@@ -45,11 +45,16 @@ export class PluginRunner {
         this._pluginI18nService,
         manifest,
         {
-          onReady: (fn) => this._readyCallbacks.set(manifest.id, fn),
+          // both registers ignore calls from a stale API instance — leaked
+          // plugin code can run after its own unload (the failure class the
+          // onUnload hook fixes) and must not clobber a reloaded instance's
+          // callbacks
+          onReady: (fn) => {
+            if (this._pluginApis.get(manifest.id) === pluginAPI) {
+              this._readyCallbacks.set(manifest.id, fn);
+            }
+          },
           onUnload: (fn) => {
-            // ignore registrations from a stale API instance — leaked plugin
-            // code can run after its own unload (the failure class this hook
-            // fixes) and must not clobber a reloaded instance's callback
             if (this._pluginApis.get(manifest.id) === pluginAPI) {
               this._unloadCallbacks.set(manifest.id, fn);
             }
@@ -193,15 +198,14 @@ export class PluginRunner {
    * Unload a plugin and clean up resources
    */
   unloadPlugin(pluginId: string): boolean {
+    // Fallback for teardown routes that bypass PluginService's
+    // _teardownPluginRuntime (activation-error cleanup) — no-op when the
+    // service already fired it. Outside the loaded-check so a plugin whose
+    // loadPlugin threw after API creation still gets cleaned up.
+    this.triggerUnload(pluginId);
+
     const plugin = this._loadedPlugins.get(pluginId);
     if (plugin) {
-      // Fallback for teardown routes that bypass PluginService's
-      // _teardownPluginRuntime (activation-error cleanup) — no-op when the
-      // service already fired it.
-      this.triggerUnload(pluginId);
-
-      // Clean up API reference
-      this._pluginApis.delete(pluginId);
       this._readyCallbacks.delete(pluginId);
 
       // Clean up all resources
@@ -231,9 +235,14 @@ export class PluginRunner {
    * listeners it created in the renderer — code-based plugins outlive their
    * unload otherwise (see #8281). Idempotent: the callback fires at most once.
    * Fire-and-forget: teardown is sync and a buggy callback must not block it;
-   * the returned promise of an async callback is not awaited.
-   * Called by plugin.service.ts at the start of teardown (while hooks and
-   * translations are still registered) and from unloadPlugin() as a fallback.
+   * the returned promise of an async callback is not awaited (unlike
+   * triggerReady, which is awaited and may throw).
+   *
+   * Side effect: also drops the plugin's API reference, which disables
+   * sendMessageToPlugin and further lifecycle registrations for this instance.
+   * Callers must follow up with unloadPlugin() — it is only called separately
+   * by plugin.service.ts at the start of teardown, while hooks and
+   * translations are still registered.
    */
   triggerUnload(pluginId: string): void {
     const unloadFn = this._unloadCallbacks.get(pluginId);

--- a/src/app/plugins/plugin.service.load-from-zip.spec.ts
+++ b/src/app/plugins/plugin.service.load-from-zip.spec.ts
@@ -60,6 +60,7 @@ describe('PluginService loadPluginFromZip iframe-only plugins', () => {
       'loadPlugin',
       'triggerReady',
       'unloadPlugin',
+      'triggerUnload',
       'pingNodeBridge',
     ]);
     pluginRunner.loadPlugin.and.callFake(

--- a/src/app/plugins/plugin.service.spec.ts
+++ b/src/app/plugins/plugin.service.spec.ts
@@ -78,6 +78,7 @@ describe('PluginService', () => {
     pluginRunner = jasmine.createSpyObj<PluginRunner>('PluginRunner', [
       'loadPlugin',
       'unloadPlugin',
+      'triggerUnload',
       'getLoadedPlugin',
       'triggerReady',
       'pingNodeBridge',

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -1599,6 +1599,10 @@ export class PluginService implements OnDestroy {
    * without changing isEnabled or _pluginStates. Used for re-upload and reload.
    */
   private _teardownPluginRuntime(pluginId: string): void {
+    // Let the plugin clear its renderer-side timers/listeners first, while its
+    // hooks and translations are still registered (#8281)
+    this._pluginRunner.triggerUnload(pluginId);
+
     this._bumpPluginIframeGeneration(pluginId);
 
     // Close the side panel if this plugin is active

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -1632,6 +1632,9 @@ export class PluginService implements OnDestroy {
     // SECURITY: revoke the main-process nodeExecution token on teardown, so a
     // disabled/uninstalled plugin cannot run Node for the rest of the session.
     // Best-effort and fire-and-forget because teardown is synchronous.
+    // Deliberately AFTER triggerUnload above: the onUnload callback may make
+    // one final node call for cleanup — same capability the plugin held while
+    // enabled, just at a guaranteed point.
     void this._revokeNodeExecutionGrant(pluginId).catch((e) =>
       PluginLog.err(`Failed to revoke nodeExecution grant for ${pluginId}`, e),
     );

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -493,7 +493,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
             });
           },
 
-          // Teardown signal — no-op in iframes: the host destroys the iframe on
+          // Teardown signal — no-op in iframes: the host unmounts the iframe on
           // unload, which takes its timers/listeners with it. Provided so plugin
           // code can call onUnload unconditionally on both execution paths.
           onUnload: (fn) => {},

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -493,6 +493,11 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
             });
           },
 
+          // Teardown signal — no-op in iframes: the host destroys the iframe on
+          // unload, which takes its timers/listeners with it. Provided so plugin
+          // code can call onUnload unconditionally on both execution paths.
+          onUnload: (fn) => {},
+
           // Message handling
           onMessage: (handler) => {
             // Store the handler and set up message listener


### PR DESCRIPTION
Fixes #8281

## Problem

Disabling a code-based (bundled) plugin did not stop timers/listeners the plugin started. The host unregisters hooks and drops references, but `new Function` plugins run directly in the renderer — their `setInterval` handles live in their own closures, and there was no plugin-side teardown hook to clear them. Concretely: **Voice Reminder kept speaking after being disabled**, frozen on a stale task title (its `currentTaskChange` hook was unregistered, so `_vrCurrentTask` never updated), until a full app reload. Reported via #8243.

## Fix

**Platform — new `onUnload` lifecycle hook (mirror of `onReady`):**

- `PluginAPI.onUnload(fn)` registers a teardown callback; optional in the public typings so older plugin typings stay assignable. Iframe plugins get a documented no-op (the iframe is unmounted on unload and takes its timers with it).
- `PluginRunner.triggerUnload()` fires it idempotently (at most once, delete-before-invoke) and fire-and-forget (sync teardown; a buggy callback is logged, never blocks). Called at the start of `PluginService._teardownPluginRuntime` — while hooks/translations are still registered — with a fallback inside `runner.unloadPlugin()` for the direct error-cleanup paths. All disable/uninstall/reload/re-upload/error routes funnel through it.
- Stale-instance guard on both lifecycle registers: leaked plugin code running after its own unload (the exact failure class this fixes) cannot clobber a reloaded instance's `onReady`/`onUnload` callbacks.
- `onReadyRegister`/`onUnloadRegister` grouped into a `lifecycleRegisters` options object (two adjacent identically-typed positional params were a silent-transposition hazard).

**Voice Reminder:**

- Registers `onUnload`: stops the interval, cancels in-flight speech.
- Generation token in `_vrStartTimer` so overlapping calls (Save racing initial load) can't orphan an interval or arm a stale config; `_vrUnloaded` guards re-arming after the async config load and the settings dialog's Test button (the dialog can outlive the plugin).

**Docs:** new "Clean up with `plugin.onUnload()`" section in `docs/plugin-development.md` (sync-cleanup-before-await contract, replace semantics, feature-detection for independently distributed plugins, iframe caveat).

## Review process

Two rounds of multi-agent review (6 + 4 independent reviewers: correctness, security, architecture, alternatives, performance, simplicity). All verified findings fixed across the four commits; notable: callback now fires before hook unregistration on the real teardown path (not just at the runner's unit boundary), `onReady` got the same stale-guard as `onUnload` (a stale `onReady` is *awaited* during reload activation — worse than the unload case), and the nodeExecution-revoke-after-callback ordering is recorded as deliberate.

Consciously declined: AbortSignal-style API (different idiom from the existing `onReady`/`onMessage` callback registration), multi-callback support (documented replace semantics, YAGNI), bridge-level rejection of registrations from unloaded plugin ids (pre-existing plugin-isolation class, tracked separately).

## Tests

- 7 new `plugin-runner` specs: fires on unload, ordering before hook unregistration, sync-throw + async-reject containment, at-most-once across `triggerUnload`/`unloadPlugin`, stale-instance rejection for both `onReady` and `onUnload`, per-plugin isolation.
- `plugin-api` lifecycle registration specs (refactored with a shared builder).
- All touched suites green: 24 + 15 + 9 + 5; `checkFile` clean on every modified file.

## Notes

- The app loads Voice Reminder from gitignored `src/assets/bundled-plugins/` — manual verification needs `npm run plugins:build` first or the fix appears absent.
- This branch was cut from local master and currently shows two unrelated commits (`d4c4a389ae` WebDAV 409, `382bb7ed98` release-notes CI) that are not yet on `origin/master`; they drop out of the diff once master is pushed.
- Separate from #8243's main fix (#8280, AudioContext suspend) — independent leak found while investigating that report.
