### PR TITLE
Fix/markdown follow ups

### DIFF
--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts
@@ -351,43 +351,4 @@ describe('DialogFullscreenMarkdownComponent', () => {
       expect(shortcutLabels.bullet.keys).toEqual([MOD, 'Shift', '8']);
     });
   });
-
-  describe('caret placement after transform', () => {
-    let mockTextarea: HTMLTextAreaElement;
-
-    beforeEach(() => {
-      mockTextarea = document.createElement('textarea');
-      mockTextarea.value = 'item one';
-      mockTextarea.selectionStart = 0;
-      mockTextarea.selectionEnd = 8;
-
-      spyOn(component, 'textareaEl').and.returnValue({
-        nativeElement: mockTextarea,
-      } as any);
-    });
-
-    it('toolbar call (isKeyboard=false) preserves a selection range', fakeAsync(() => {
-      spyOn(mockTextarea, 'setSelectionRange').and.callThrough();
-
-      component.onApplyBulletList(false);
-      tick();
-
-      const [start, end] = (
-        mockTextarea.setSelectionRange as jasmine.Spy
-      ).calls.mostRecent().args;
-      expect(start).toBeLessThan(end);
-    }));
-
-    it('keyboard call (isKeyboard=true) collapses caret to end', fakeAsync(() => {
-      spyOn(mockTextarea, 'setSelectionRange').and.callThrough();
-
-      component.onApplyBulletList(true);
-      tick();
-
-      const [start, end] = (
-        mockTextarea.setSelectionRange as jasmine.Spy
-      ).calls.mostRecent().args;
-      expect(start).toEqual(end);
-    }));
-  });
 });

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
@@ -54,7 +54,9 @@ import { IS_IOS } from 'src/app/util/is-ios';
 import { Keyboard } from '@capacitor/keyboard';
 import { DialogMarkdownShortcutsComponent } from './dialog-markdown-shortcuts.component';
 import {
+  isShortcutWithKey,
   MARKDOWN_SHORTCUTS,
+  MarkdownShortcut,
   shortcutLabels,
   ShortcutNames,
 } from './markdown-shortcuts.const';
@@ -221,6 +223,10 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
       case 'quote':
         this.onApplyQuote();
         break;
+      default: {
+        const _exhaustive: never = name;
+        return _exhaustive;
+      }
     }
   }
 
@@ -239,10 +245,17 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
     }
 
     if (hasModifier) {
-      const shortcut = MARKDOWN_SHORTCUTS.find((s) => {
-        const keyMatch = s.code ? ev.code === s.code : ev.key.toLowerCase() === s.key;
-        return keyMatch && ev.shiftKey === s.shiftKey;
-      });
+      const shortcutIndex = (MARKDOWN_SHORTCUTS as readonly MarkdownShortcut[]).findIndex(
+        (s) => {
+          const keyMatch = isShortcutWithKey(s)
+            ? ev.key.toLowerCase() === s.key
+            : ev.code === s.code;
+          return keyMatch && ev.shiftKey === s.shiftKey;
+        },
+      );
+
+      const shortcut =
+        shortcutIndex !== -1 ? MARKDOWN_SHORTCUTS[shortcutIndex] : undefined;
 
       if (shortcut) {
         ev.preventDefault();

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
@@ -210,16 +210,16 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
         this.onApplyStrikethrough();
         break;
       case 'bullet':
-        this.onApplyBulletList(true);
+        this.onApplyBulletList();
         break;
       case 'numbered':
-        this.onApplyNumberedList(true);
+        this.onApplyNumberedList();
         break;
       case 'code':
         this.onApplyInlineCode();
         break;
       case 'quote':
-        this.onApplyQuote(true);
+        this.onApplyQuote();
         break;
     }
   }
@@ -361,16 +361,16 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
     );
   }
 
-  onApplyQuote(isKeyboard = false): void {
-    this._applyTransformWithArgs(applyQuote, isKeyboard);
+  onApplyQuote(): void {
+    this._applyTransformWithArgs(applyQuote);
   }
 
-  onApplyBulletList(isKeyboard = false): void {
-    this._applyTransformWithArgs(applyBulletList, isKeyboard);
+  onApplyBulletList(): void {
+    this._applyTransformWithArgs(applyBulletList);
   }
 
-  onApplyNumberedList(isKeyboard = false): void {
-    this._applyTransformWithArgs(applyNumberedList, isKeyboard);
+  onApplyNumberedList(): void {
+    this._applyTransformWithArgs(applyNumberedList);
   }
 
   onApplyTaskList(): void {
@@ -399,7 +399,6 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
 
   private _applyTransformWithArgs(
     transformFn: (text: string, start: number, end: number) => TextTransformResult,
-    isKeyboard = false,
   ): void {
     const textarea = this.textareaEl()?.nativeElement;
     if (!textarea) {
@@ -415,11 +414,7 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
     // Wait for Angular to update the DOM after ngModel change before restoring selection
     setTimeout(() => {
       textarea.focus();
-      if (!isKeyboard) {
-        textarea.setSelectionRange(result.selectionStart, result.selectionEnd);
-      } else {
-        textarea.setSelectionRange(result.selectionEnd, result.selectionEnd);
-      }
+      textarea.setSelectionRange(result.selectionStart, result.selectionEnd);
     });
   }
 }

--- a/src/app/ui/dialog-fullscreen-markdown/markdown-shortcuts.const.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/markdown-shortcuts.const.ts
@@ -1,17 +1,7 @@
 import { IS_MAC } from 'src/app/util/is-mac';
 
-export type ShortcutNames =
-  | 'bold'
-  | 'italic'
-  | 'link'
-  | 'strikethrough'
-  | 'bullet'
-  | 'numbered'
-  | 'code'
-  | 'quote';
-
 type BaseShortcut = {
-  name: ShortcutNames;
+  name: string;
   translationKey: string;
   shiftKey: boolean;
 };
@@ -28,10 +18,9 @@ type ShortcutWithCode = BaseShortcut & {
 
 export type MarkdownShortcut = ShortcutWithKey | ShortcutWithCode;
 
-export type ShortcutLabel = Record<ShortcutNames, { keys: string[]; tooltip: string }>;
 export const MOD = IS_MAC ? 'Cmd' : 'Ctrl';
 
-export const MARKDOWN_SHORTCUTS: MarkdownShortcut[] = [
+export const MARKDOWN_SHORTCUTS = [
   {
     name: 'bold',
     translationKey: 'BOLD',
@@ -80,9 +69,14 @@ export const MARKDOWN_SHORTCUTS: MarkdownShortcut[] = [
     key: 'e',
     shiftKey: false,
   },
-];
+] as const satisfies readonly MarkdownShortcut[];
 
-const isShortcutWithKey = (shortcut: MarkdownShortcut): shortcut is ShortcutWithKey => {
+export type ShortcutNames = (typeof MARKDOWN_SHORTCUTS)[number]['name'];
+
+export type ShortcutLabel = Record<ShortcutNames, { keys: string[]; tooltip: string }>;
+export const isShortcutWithKey = (
+  shortcut: MarkdownShortcut,
+): shortcut is ShortcutWithKey => {
   return shortcut.key !== undefined;
 };
 
@@ -95,9 +89,11 @@ const formatKeyDisplay = (shortcut: MarkdownShortcut): string => {
 
 export const shortcutLabels = MARKDOWN_SHORTCUTS.reduce((acc, s) => {
   const keys = [MOD, ...(s.shiftKey ? ['Shift'] : []), formatKeyDisplay(s)];
+
   acc[s.name] = {
     keys,
     tooltip: ` (${keys.join('+')})`,
   };
+
   return acc;
 }, {} as ShortcutLabel);

--- a/src/app/ui/inline-markdown/markdown-toolbar.util.spec.ts
+++ b/src/app/ui/inline-markdown/markdown-toolbar.util.spec.ts
@@ -138,6 +138,22 @@ describe('markdown-toolbar.util', () => {
       const result = applyQuote('line one\nline two', 0, 17);
       expect(result.text).toBe('> line one\n> line two');
     });
+
+    it('collapses caret when input selection is collapsed', () => {
+      const result = applyQuote('some text', 4, 4);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+    });
+
+    it('preserves transformed block selection when input has a range', () => {
+      const result = applyQuote('some text', 0, 9);
+      expect(result.selectionStart).toBeLessThan(result.selectionEnd);
+    });
+
+    it('moves caret back when removing prefix with collapsed selection', () => {
+      const result = applyQuote('> some text', 5, 5);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+      expect(result.selectionStart).toBeLessThan(5);
+    });
   });
 
   describe('applyBulletList', () => {
@@ -159,6 +175,28 @@ describe('markdown-toolbar.util', () => {
     it('should convert task list to bullet list', () => {
       const result = applyBulletList('- [ ] hello world', 0, 17);
       expect(result.text).toBe('- hello world');
+    });
+
+    it('collapses caret when input selection is collapsed', () => {
+      const result = applyBulletList('item one', 4, 4);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+    });
+
+    it('preserves transformed block selection when input has a range', () => {
+      const result = applyBulletList('item one', 0, 8);
+      expect(result.selectionStart).toBeLessThan(result.selectionEnd);
+    });
+
+    it('moves caret back when removing prefix with collapsed selection', () => {
+      const result = applyBulletList('- item one', 4, 4);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+      expect(result.selectionStart).toBeLessThan(4);
+    });
+
+    it('does not produce a negative caret position when removing prefix at position 0', () => {
+      const result = applyBulletList('- item', 0, 0);
+      expect(result.selectionStart).toBe(0);
+      expect(result.selectionEnd).toBe(0);
     });
   });
 
@@ -182,6 +220,21 @@ describe('markdown-toolbar.util', () => {
       const result = applyNumberedList('- hello', 0, 7);
       expect(result.text).toBe('1. hello');
     });
+    it('collapses caret when input selection is collapsed', () => {
+      const result = applyNumberedList('item one', 4, 4);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+    });
+
+    it('preserves transformed block selection when input has a range', () => {
+      const result = applyNumberedList('item one', 0, 8);
+      expect(result.selectionStart).toBeLessThan(result.selectionEnd);
+    });
+
+    it('moves caret back when removing prefix with collapsed selection', () => {
+      const result = applyNumberedList('1. item one', 5, 5);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+      expect(result.selectionStart).toBeLessThan(5);
+    });
   });
 
   describe('applyTaskList', () => {
@@ -203,6 +256,28 @@ describe('markdown-toolbar.util', () => {
     it('should convert numbered list to task list', () => {
       const result = applyTaskList('1. hello world', 0, 14);
       expect(result.text).toBe('- [ ] hello world');
+    });
+
+    it('collapses caret when input selection is collapsed', () => {
+      const result = applyTaskList('item one', 4, 4);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+    });
+
+    it('preserves transformed block selection when input has a range', () => {
+      const result = applyTaskList('item one', 0, 8);
+      expect(result.selectionStart).toBeLessThan(result.selectionEnd);
+    });
+
+    it('moves caret back when removing prefix with collapsed selection', () => {
+      const result = applyTaskList('- [ ] item', 5, 5);
+      expect(result.selectionStart).toEqual(result.selectionEnd);
+      expect(result.selectionStart).toBeLessThan(5);
+    });
+
+    it('does not produce a negative caret position when removing prefix at position 0', () => {
+      const result = applyTaskList('- [ ] item', 0, 0);
+      expect(result.selectionStart).toBe(0);
+      expect(result.selectionEnd).toBe(0);
     });
   });
 

--- a/src/app/ui/inline-markdown/markdown-toolbar.util.ts
+++ b/src/app/ui/inline-markdown/markdown-toolbar.util.ts
@@ -210,6 +210,15 @@ const toggleLinePrefix = (
 
   // Adjust selection
   const lengthDiff = newContent.length - (lineEnd - lineStart);
+  if (selectionStart === selectionEnd) {
+    const newPos = Math.max(0, selectionStart + lengthDiff);
+    return {
+      text: newText,
+      selectionStart: newPos,
+      selectionEnd: newPos,
+    };
+  }
+
   return {
     text: newText,
     selectionStart: lineStart,
@@ -344,6 +353,15 @@ export const applyNumberedList = (
   const newText = text.substring(0, lineStart) + newContent + text.substring(lineEnd);
 
   const lengthDiff = newContent.length - (lineEnd - lineStart);
+
+  if (selectionStart === selectionEnd) {
+    const newPos = Math.max(0, selectionStart + lengthDiff);
+    return {
+      text: newText,
+      selectionStart: newPos,
+      selectionEnd: newPos,
+    };
+  }
   return {
     text: newText,
     selectionStart: lineStart,
@@ -391,6 +409,14 @@ export const applyTaskList = (
   const newText = text.substring(0, lineStart) + newContent + text.substring(lineEnd);
 
   const lengthDiff = newContent.length - (lineEnd - lineStart);
+  if (selectionStart === selectionEnd) {
+    const newPos = Math.max(0, selectionStart + lengthDiff);
+    return {
+      text: newText,
+      selectionStart: newPos,
+      selectionEnd: newPos,
+    };
+  }
   return {
     text: newText,
     selectionStart: lineStart,


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->
Addresses #8268
## Solution

### 1. Move the collapsed-caret fix into the transforms (drop the `isKeyboard` flag)
added a check in `toggleLinePrefix`, `applyNumberedList` to preserve collapsed caret position after transformation.
```ts
  if (selectionStart === selectionEnd) {
    const newPos = Math.max(0, selectionStart + lengthDiff);
    return {
      text: newText,
      selectionStart: newPos,
      selectionEnd: newPos,
    };
  }

```

same check was added to `applyTaskList` 

### 2. `shortcutLabels` exhaustiveness not enforced
addressed using approach discussed in https://github.com/super-productivity/super-productivity/issues/8268#issuecomment-4692581563
<!-- Describe your changes in detail. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
