### PR TITLE
style(ui): globalize task-detail field style to filled form fields

### DIFF
--- a/src/assets/themes/velvet.css
+++ b/src/assets/themes/velvet.css
@@ -183,7 +183,7 @@ body.isDarkTheme {
   --input-bg: var(--velvet-fill-2);
   --input-bg-hover: color-mix(in srgb, var(--c-primary) 6%, transparent);
   --input-border-color: transparent;
-  --input-border-color-focus: color-mix(in srgb, var(--c-primary) 40%, transparent);
+  --input-border-color-focus: var(--c-primary);
   --input-border-radius: 8px;
 
   /* Schedule events read as cards, not list rows — they have borders, a
@@ -323,6 +323,22 @@ body.isDarkTheme add-task-bar.global .add-task-container {
     0 24px 64px rgba(0, 0, 0, 0.65),
     0 6px 16px rgba(0, 0, 0, 0.4),
     inset 0 1px 0 var(--velvet-fill-2);
+}
+
+/* Form fields outline: restore fill for outline inputs in Velvet */
+body.isDarkTheme .mdc-text-field--outlined:not(.mdc-text-field--disabled) {
+  background: var(--velvet-fill-2) !important;
+  border-radius: 8px !important;
+  transition:
+    background 120ms ease-out,
+    border-color 120ms ease-out !important;
+}
+
+body.isDarkTheme .mdc-text-field--outlined:not(.mdc-text-field--disabled):hover,
+body.isDarkTheme
+  .mat-mdc-form-field.mat-focused
+  .mdc-text-field--outlined:not(.mdc-text-field--disabled) {
+  background: color-mix(in srgb, var(--c-primary) 6%, transparent) !important;
 }
 
 /* Primary buttons get a subtle coral gradient — like Raycast's CTAs */

--- a/src/assets/themes/velvet.css
+++ b/src/assets/themes/velvet.css
@@ -183,7 +183,6 @@ body.isDarkTheme {
   --input-bg: var(--velvet-fill-2);
   --input-bg-hover: color-mix(in srgb, var(--c-primary) 6%, transparent);
   --input-border-color: transparent;
-  --input-border-color-focus: var(--c-primary);
   --input-border-radius: 8px;
 
   /* Schedule events read as cards, not list rows — they have borders, a

--- a/src/assets/themes/velvet.css
+++ b/src/assets/themes/velvet.css
@@ -179,6 +179,13 @@ body.isDarkTheme {
   --task-detail-shadow: none;
   --task-detail-value-color: rgba(237, 237, 237, 0.85);
 
+  /* Input fields overrides */
+  --input-bg: var(--velvet-fill-2);
+  --input-bg-hover: color-mix(in srgb, var(--c-primary) 6%, transparent);
+  --input-border-color: transparent;
+  --input-border-color-focus: color-mix(in srgb, var(--c-primary) 40%, transparent);
+  --input-border-radius: 8px;
+
   /* Schedule events read as cards, not list rows — they have borders, a
      project-color left edge, and distinct shapes — so they sit a few stops
      above the task-row default. Side-panel variant stays one stop lower
@@ -316,33 +323,6 @@ body.isDarkTheme add-task-bar.global .add-task-container {
     0 24px 64px rgba(0, 0, 0, 0.65),
     0 6px 16px rgba(0, 0, 0, 0.4),
     inset 0 1px 0 var(--velvet-fill-2);
-}
-
-/* Form fields: dark, rounded, with coral focus glow — Raycast input feel */
-body.isDarkTheme input.mat-mdc-input-element,
-body.isDarkTheme textarea.mat-mdc-input-element,
-body.isDarkTheme .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-  background: var(--velvet-fill-2) !important;
-  border-radius: 8px !important;
-  transition:
-    background 120ms ease-out,
-    box-shadow 120ms ease-out !important;
-}
-
-body.isDarkTheme
-  .mat-mdc-form-field.mat-focused
-  .mdc-text-field--filled:not(.mdc-text-field--disabled),
-body.isDarkTheme .mdc-text-field--focused:not(.mdc-text-field--disabled) {
-  background: color-mix(in srgb, var(--c-primary) 6%, transparent) !important;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--c-primary) 40%, transparent) !important;
-}
-
-/* Hide the underline-style line-ripple — Raycast inputs are bordered, not
-   underlined. */
-body.isDarkTheme .mdc-line-ripple,
-body.isDarkTheme .mdc-text-field--filled .mdc-line-ripple::before,
-body.isDarkTheme .mdc-text-field--filled .mdc-line-ripple::after {
-  display: none !important;
 }
 
 /* Primary buttons get a subtle coral gradient — like Raycast's CTAs */

--- a/src/assets/themes/zen.css
+++ b/src/assets/themes/zen.css
@@ -206,17 +206,17 @@ body.isDarkTheme .mat-mdc-card {
   border-color: rgba(255, 255, 255, 0.1);
 }
 
-/* Material form fields: use main bg with darker underline */
-body .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-  background: var(--bg) !important;
+/* Material form fields: flat border instead of invisible input */
+body {
+  --input-bg: transparent;
+  --input-bg-hover: rgba(0, 0, 0, 0.04);
+  --input-border-color: rgba(0, 0, 0, 0.2);
 }
 
-body .mdc-line-ripple::before {
-  border-bottom-color: rgba(0, 0, 0, 0.3) !important;
-}
-
-body.isDarkTheme .mdc-line-ripple::before {
-  border-bottom-color: rgba(255, 255, 255, 0.3) !important;
+body.isDarkTheme {
+  --input-bg: transparent;
+  --input-bg-hover: rgba(255, 255, 255, 0.04);
+  --input-border-color: rgba(255, 255, 255, 0.2);
 }
 
 /* Side panel edge close handle */

--- a/src/assets/themes/zen.css
+++ b/src/assets/themes/zen.css
@@ -214,7 +214,7 @@ body {
 }
 
 body.isDarkTheme {
-  --input-bg: transparent;
+  /* --input-bg stays transparent (inherited from the body rule above) */
   --input-bg-hover: rgba(255, 255, 255, 0.04);
   --input-border-color: rgba(255, 255, 255, 0.2);
 }

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -376,6 +376,11 @@ body {
   // light-mode contrast issue.
   --brand: var(--palette-primary-600);
   --focus-ring: var(--brand);
+
+  // Input fields
+  --input-bg: rgba(var(--ink-on-channel), 0.04);
+  --input-bg-hover: rgba(var(--ink-on-channel), 0.07);
+  --input-border-color: transparent;
 }
 
 body.isDarkTheme {
@@ -397,6 +402,11 @@ body.isDarkTheme {
 
   --brand: var(--palette-primary-400);
   --focus-ring: var(--brand);
+
+  // Input fields
+  --input-bg: rgba(var(--ink-on-channel), 0.06);
+  --input-bg-hover: rgba(var(--ink-on-channel), 0.1);
+  --input-border-color: transparent;
 }
 
 // -----------------------------
@@ -501,6 +511,10 @@ body.isDarkTheme {
   --state-focus: rgba(var(--ink-on-channel), var(--state-focus-alpha));
   --state-pressed: rgba(var(--ink-on-channel), var(--state-pressed-alpha));
   --state-selected: rgba(var(--ink-on-channel), var(--state-selected-alpha));
+
+  // Input fields semantic aliases
+  --input-border-color-focus: var(--focus-ring-color);
+  --input-border-radius: var(--card-border-radius);
 }
 
 // -----------------------------

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -380,7 +380,7 @@ body {
   // Input fields
   --input-bg: rgba(var(--ink-on-channel), 0.04);
   --input-bg-hover: rgba(var(--ink-on-channel), 0.07);
-  --input-border-color: transparent;
+  --input-border-color: rgba(var(--ink-on-channel), 0.08);
 }
 
 body.isDarkTheme {
@@ -514,6 +514,7 @@ body.isDarkTheme {
 
   // Input fields semantic aliases
   --input-border-color-focus: var(--focus-ring-color);
+  --input-border-color-invalid: var(--palette-warn-500);
   --input-border-radius: var(--card-border-radius);
 }
 

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -208,6 +208,11 @@ body.isNativeMobile .project-complete-fullscreen-dialog {
   // Targets default filled text boxes to transform them into flat, token-driven containers
   .mdc-text-field--filled:not(.mdc-text-field--disabled) {
     border: 1px solid var(--input-border-color) !important;
+    // Material hardcodes the filled field's bottom corner radii to 0 (the
+    // container-shape token above only rounds the top two corners), so a full
+    // border would render rounded-top/square-bottom. Round all four corners to
+    // read as a card, matching the task-detail panel this style is copied from.
+    border-radius: var(--input-border-radius) !important;
     transition:
       background var(--transition-duration-s) ease-out,
       border-color var(--transition-duration-s) ease-out,

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -195,21 +195,23 @@ body.isNativeMobile .project-complete-fullscreen-dialog {
 .mat-mdc-form-field {
   margin-bottom: var(--s2);
 
+  // Feed semantic input tokens to official Material CSS variables
+  --mat-form-field-filled-container-color: var(--input-bg);
+  --mat-form-field-filled-container-shape: var(--input-border-radius);
+
+  // Hide the active indicators (underline ripple) by setting their color to transparent,
+  // but leave the error indicators intact so the red invalid line shows up.
+  --mat-form-field-filled-active-indicator-color: transparent;
+  --mat-form-field-filled-hover-active-indicator-color: transparent;
+  --mat-form-field-filled-focus-active-indicator-color: transparent;
+
   // Targets default filled text boxes to transform them into flat, token-driven containers
   .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-    background: var(--input-bg) !important;
-    border-radius: var(--input-border-radius) !important;
     border: 1px solid var(--input-border-color) !important;
     transition:
       background var(--transition-duration-s) ease-out,
-      border-color var(--transition-duration-s) ease-out !important;
-
-    // Hides the standard material underline active indicator ripple
-    .mdc-line-ripple,
-    &::before,
-    &::after {
-      display: none !important;
-    }
+      border-color var(--transition-duration-s) ease-out,
+      box-shadow var(--transition-duration-s) ease-out !important;
 
     &:hover {
       background: var(--input-bg-hover) !important;
@@ -220,6 +222,12 @@ body.isNativeMobile .project-complete-fullscreen-dialog {
   &.mat-focused .mdc-text-field--filled:not(.mdc-text-field--disabled) {
     background: var(--input-bg-hover) !important;
     border-color: var(--input-border-color-focus) !important;
+    box-shadow: 0 0 0 1px var(--input-border-color-focus) !important;
+  }
+
+  // Error / Invalid state
+  &.mat-form-field-invalid .mdc-text-field--filled:not(.mdc-text-field--disabled) {
+    border-color: var(--input-border-color-invalid) !important;
   }
 }
 

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -128,6 +128,7 @@ body .mat-mdc-dialog-surface {
   // Enable flex layout for proper content scrolling
   display: flex;
   flex-direction: column;
+  border-radius: var(--radius-lg) !important;
 }
 
 .mat-mdc-dialog-panel {
@@ -440,6 +441,13 @@ body .mat-mdc-button-base .mat-icon {
 // MAT MENU
 .mat-mdc-menu-panel {
   overflow-x: hidden !important;
+  border-radius: var(--radius-sm) !important;
+}
+
+// AUTOCOMPLETE & SELECT PANEL
+.cdk-overlay-pane .mat-mdc-autocomplete-panel,
+.mat-mdc-select-panel {
+  border-radius: var(--radius-sm) !important;
 }
 
 .mat-mdc-menu-content {

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -194,6 +194,38 @@ body.isNativeMobile .project-complete-fullscreen-dialog {
 // --------
 .mat-mdc-form-field {
   margin-bottom: var(--s2);
+
+  // Targets default filled text boxes to transform them into hovering containers
+  .mdc-text-field--filled:not(.mdc-text-field--disabled) {
+    background: var(--task-detail-bg) !important;
+    border-radius: var(--card-border-radius) !important;
+    box-shadow: var(--whiteframe-shadow-1dp) !important;
+    border: 1px solid transparent !important;
+    transition:
+      background var(--transition-duration-s) ease-out,
+      border-color var(--transition-duration-s) ease-out,
+      box-shadow var(--transition-duration-s) ease-out !important;
+
+    // Hides the standard material underline active indicator ripple
+    .mdc-line-ripple,
+    &::before,
+    &::after {
+      display: none !important;
+    }
+
+    &:hover {
+      background: var(--task-detail-bg-hover) !important;
+    }
+  }
+
+  // Active / Focus state
+  &.mat-focused .mdc-text-field--filled:not(.mdc-text-field--disabled) {
+    background: var(--task-detail-bg-hover) !important;
+    border-color: var(--focus-ring-color) !important;
+    box-shadow:
+      var(--whiteframe-shadow-1dp),
+      0 0 0 1px var(--focus-ring-color) !important;
+  }
 }
 
 // needs to be global cause of cdk overlay

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -128,7 +128,6 @@ body .mat-mdc-dialog-surface {
   // Enable flex layout for proper content scrolling
   display: flex;
   flex-direction: column;
-  border-radius: var(--radius-lg) !important;
 }
 
 .mat-mdc-dialog-panel {
@@ -441,13 +440,6 @@ body .mat-mdc-button-base .mat-icon {
 // MAT MENU
 .mat-mdc-menu-panel {
   overflow-x: hidden !important;
-  border-radius: var(--radius-sm) !important;
-}
-
-// AUTOCOMPLETE & SELECT PANEL
-.cdk-overlay-pane .mat-mdc-autocomplete-panel,
-.mat-mdc-select-panel {
-  border-radius: var(--radius-sm) !important;
 }
 
 .mat-mdc-menu-content {

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -195,16 +195,14 @@ body.isNativeMobile .project-complete-fullscreen-dialog {
 .mat-mdc-form-field {
   margin-bottom: var(--s2);
 
-  // Targets default filled text boxes to transform them into hovering containers
+  // Targets default filled text boxes to transform them into flat, token-driven containers
   .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-    background: var(--task-detail-bg) !important;
-    border-radius: var(--card-border-radius) !important;
-    box-shadow: var(--whiteframe-shadow-1dp) !important;
-    border: 1px solid transparent !important;
+    background: var(--input-bg) !important;
+    border-radius: var(--input-border-radius) !important;
+    border: 1px solid var(--input-border-color) !important;
     transition:
       background var(--transition-duration-s) ease-out,
-      border-color var(--transition-duration-s) ease-out,
-      box-shadow var(--transition-duration-s) ease-out !important;
+      border-color var(--transition-duration-s) ease-out !important;
 
     // Hides the standard material underline active indicator ripple
     .mdc-line-ripple,
@@ -214,17 +212,14 @@ body.isNativeMobile .project-complete-fullscreen-dialog {
     }
 
     &:hover {
-      background: var(--task-detail-bg-hover) !important;
+      background: var(--input-bg-hover) !important;
     }
   }
 
   // Active / Focus state
   &.mat-focused .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-    background: var(--task-detail-bg-hover) !important;
-    border-color: var(--focus-ring-color) !important;
-    box-shadow:
-      var(--whiteframe-shadow-1dp),
-      0 0 0 1px var(--focus-ring-color) !important;
+    background: var(--input-bg-hover) !important;
+    border-color: var(--input-border-color-focus) !important;
   }
 }
 


### PR DESCRIPTION
## Problem

Tackles the first point of https://github.com/super-productivity/super-productivity/issues/8267#issuecomment-4678414966

The filled form fields in the rest of the application (settings, customizers, dialogs, etc.) were flat, gray, underlined textboxes, which visually clashed with the modern, card-like "hovering container" design used in the task-detail side panel.

## Solution

Overrode the `.mdc-text-field--filled` styles globally inside `src/styles/components/_overwrite-material.scss` to match the side panel's style:
- Set field backgrounds to use `var(--task-detail-bg)` and rounded corners to use `var(--card-border-radius)`.
- Applied a soft elevation shadow using `var(--whiteframe-shadow-1dp)`.
- Hidden default Material underlines (`.mdc-line-ripple`).
- Set hover and focus transitions that shift background to `var(--task-detail-bg-hover)` and border highlights to `var(--focus-ring-color)`.

These overrides are theme-aware, ensuring they adapt correctly to light, dark, Velvet, and Zen (which naturally hides cards/shadows) themes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other: Styling globalization / Visual polish

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Before

<img width="1280" height="502" alt="telegram-cloud-photo-size-2-5290009118980643804-y" src="https://github.com/user-attachments/assets/f39835c9-08af-4020-b309-96754e129f6e" />

## After 

<img width="1280" height="504" alt="telegram-cloud-photo-size-2-5290009118980643803-y" src="https://github.com/user-attachments/assets/0571b233-fb7f-4513-b586-f176b8923efe" />

