### PR TITLE
fix(focus-mode): make duration-slider blur-on-Enter opt-in so dialogs still submit

### DIFF
--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html
@@ -154,6 +154,7 @@
               [bareRing]="true"
               [hideHandle]="isPomodoro()"
               [useFlexibleIncrement]="!isPomodoro()"
+              [blurOnEnter]="true"
               (modelChange)="onDurationChange($event)"
             ></input-duration-slider>
           </div>

--- a/src/app/ui/duration/input-duration-slider/input-duration-slider.component.html
+++ b/src/app/ui/duration/input-duration-slider/input-duration-slider.component.html
@@ -24,7 +24,7 @@
     <input
       #durationInput
       (ngModelChange)="onInputChange($event)"
-      (keydown.enter)="$event.preventDefault(); durationInput.blur()"
+      (keydown.enter)="onEnterKey($event, durationInput)"
       [id]="uid"
       [ngModel]="_model()"
       [placeholder]="T.G.EXAMPLE_VAL | translate"

--- a/src/app/ui/duration/input-duration-slider/input-duration-slider.component.spec.ts
+++ b/src/app/ui/duration/input-duration-slider/input-duration-slider.component.spec.ts
@@ -85,6 +85,35 @@ describe('InputDurationSliderComponent', () => {
     sub.unsubscribe();
   });
 
+  describe('Enter handling (blurOnEnter)', () => {
+    // Guards the #7586 regression: blurring on Enter cancels a host form's
+    // implicit submit, so it must stay opt-in or the time-estimate dialogs
+    // can no longer be saved with Enter.
+    const pressEnter = (): { preventDefault: jasmine.Spy; blur: jasmine.Spy } => {
+      const ev = { preventDefault: jasmine.createSpy('preventDefault') };
+      const inputEl = { blur: jasmine.createSpy('blur') };
+      component.onEnterKey(
+        ev as unknown as KeyboardEvent,
+        inputEl as unknown as HTMLInputElement,
+      );
+      return { preventDefault: ev.preventDefault, blur: inputEl.blur };
+    };
+
+    it('does nothing by default so the host form can submit on Enter', () => {
+      const { preventDefault, blur } = pressEnter();
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(blur).not.toHaveBeenCalled();
+    });
+
+    it('commits and blurs on Enter when opted in', () => {
+      fixture.componentRef.setInput('blurOnEnter', true);
+      fixture.detectChanges();
+      const { preventDefault, blur } = pressEnter();
+      expect(preventDefault).toHaveBeenCalled();
+      expect(blur).toHaveBeenCalled();
+    });
+  });
+
   describe('flexible increment (hybrid drag)', () => {
     // Apply a single drag tick at the given raw pointer angle and return the
     // value emitted by modelChange.

--- a/src/app/ui/duration/input-duration-slider/input-duration-slider.component.ts
+++ b/src/app/ui/duration/input-duration-slider/input-duration-slider.component.ts
@@ -61,6 +61,12 @@ export class InputDurationSliderComponent implements OnInit, OnDestroy {
   // for Pomodoro preparation, where the duration is typed rather than dragged.
   readonly hideHandle = input(false);
 
+  // On Enter, commit the typed value and drop focus. Opt-in (focus-mode) only:
+  // blurring on Enter cancels the browser's implicit form submission, so the
+  // default must stay off or the time-estimate dialogs (slider inside a <form>
+  // with a submit button) can no longer be saved by pressing Enter.
+  readonly blurOnEnter = input(false);
+
   // Output remains the same
   readonly modelChange = output<number>();
 
@@ -338,6 +344,15 @@ export class InputDurationSliderComponent implements OnInit, OnDestroy {
     this._model.set($event);
     this.modelChange.emit($event);
     this.setRotationFromValue();
+  }
+
+  onEnterKey(ev: KeyboardEvent, inputEl: HTMLInputElement): void {
+    // Only the focus-mode consumer opts into blur-on-Enter; doing it for form
+    // consumers would cancel the implicit submit (see blurOnEnter docs above).
+    if (this.blurOnEnter()) {
+      ev.preventDefault();
+      inputEl.blur();
+    }
   }
 
   setRotationFromValue(val?: number): void {


### PR DESCRIPTION
## What

Make blur-on-Enter **opt-in** on the shared `input-duration-slider`, restoring Enter-to-save in the time-estimate dialogs.

## Why

PR #7586 (focus-mode overhaul) added to the shared slider's input:

```html
(keydown.enter)="$event.preventDefault(); durationInput.blur()"
```

Both `preventDefault()` and `blur()` independently cancel the browser's **implicit form submission**. The slider is embedded inside a `<form>` with a `type="submit"` button in two dialogs — `dialog-time-estimate` and `dialog-add-time-estimate-for-other-day` — so pressing **Enter no longer saved/closed those dialogs**.

This surfaced as a deterministic failure in the scheduled SuperSync E2E run ([27454954345](https://github.com/super-productivity/super-productivity/actions/runs/27454954345)): `supersync-daily-summary.spec.ts:38` — the time-estimate dialog never closed on Enter. The last green scheduled run preceded #7586; it failed identically the moment #7586 landed (6/12) and again on the 6/13 nightly.

## Fix

- New opt-in `blurOnEnter` input (default `false`), matching the component's existing `bareRing` / `hideHandle` convention.
- Enter routes through `onEnterKey()`, which only `preventDefault()` + `blur()`s when opted in.
- Focus-mode (the only consumer that wants blur-on-Enter, and has no `<form>`) sets `[blurOnEnter]="true"` — behavior preserved exactly.
- The two dialogs revert to their working pre-#7586 implicit-submit behavior.

## Verification

- Chromium experiment: default path → form submits (dialog closes); opt-in → blur/no-submit (focus-mode unchanged).
- Unit: slider spec 11/11 (added 2 guard tests so the default can't silently flip back), focus-mode-main 56/56.
- Independent code review (adversarial): confirmed value still commits on `input` (not blur) so nothing is dropped, exactly 3 consumers all correctly classified — verdict safe to merge.
- The failing E2E needs no change.
