### PR TITLE
fix(sync): measure op payload size limit in UTF-8 bytes, not UTF-16 units

### DIFF
--- a/packages/super-sync-server/src/sync/services/operation-upload.service.ts
+++ b/packages/super-sync-server/src/sync/services/operation-upload.service.ts
@@ -11,6 +11,7 @@ import {
   isFullStateOpType,
   limitVectorClockSize,
   Operation,
+  ProcessOperationResult,
   SyncConfig,
   SYNC_ERROR_CODES,
   UploadResult,
@@ -308,6 +309,7 @@ export class OperationUploadService {
         fullStateVectorClock: isFullStateOpType(op.opType)
           ? { ...op.vectorClock }
           : undefined,
+        payloadBytes: validation.payloadBytes,
       });
     }
     return validatedCandidates;
@@ -475,7 +477,9 @@ export class OperationUploadService {
       }
 
       pruneVectorClockForStorage(op);
-      const sized = computeOpStorageBytes(op);
+      // Reuse the payload byte size measured during validation; the clock is
+      // (re)measured inside computeOpStorageBytes because it was just pruned.
+      const sized = computeOpStorageBytes(op, candidate.payloadBytes);
       acceptedDeltaBytes += sized.bytes;
       if (sized.fallback) unserializableAccepted++;
 
@@ -593,7 +597,15 @@ export class OperationUploadService {
     op: Operation,
     now: number,
     tx: Prisma.TransactionClient,
-  ): Promise<UploadResult> {
+  ): Promise<ProcessOperationResult> {
+    // Rejected ops have no storage cost; the caller only reads storageBytes when
+    // result.accepted is true.
+    const reject = (result: UploadResult): ProcessOperationResult => ({
+      result,
+      storageBytes: 0,
+      fallback: false,
+    });
+
     // Clamp future timestamps instead of rejecting them (prevents silent data
     // loss). Shares the exact clamp + audit with the batch path.
     const originalTimestamp = this.clampFutureTimestamp(userId, clientId, op, now);
@@ -612,12 +624,12 @@ export class OperationUploadService {
         reason: validation.error,
         opType: op.opType,
       });
-      return {
+      return reject({
         opId: op.id,
         accepted: false,
         error: validation.error,
         errorCode: validation.errorCode,
-      };
+      });
     }
     // Capture the *unpruned* vector clock for full-state ops. The op row stores
     // the pruned clock (see `limitVectorClockSize` call below); persisting the
@@ -657,12 +669,12 @@ export class OperationUploadService {
           reason: 'Operation ID already belongs to a different operation',
           opType: op.opType,
         });
-        return {
+        return reject({
           opId: op.id,
           accepted: false,
           error: 'Operation ID already belongs to a different operation',
           errorCode: SYNC_ERROR_CODES.INVALID_OP_ID,
-        };
+        });
       }
 
       Logger.audit({
@@ -676,12 +688,12 @@ export class OperationUploadService {
         reason: 'Duplicate operation ID (pre-check)',
         opType: op.opType,
       });
-      return {
+      return reject({
         opId: op.id,
         accepted: false,
         error: 'Duplicate operation ID',
         errorCode: SYNC_ERROR_CODES.DUPLICATE_OPERATION,
-      };
+      });
     }
 
     // Check for conflicts with existing operations
@@ -703,13 +715,13 @@ export class OperationUploadService {
         reason: conflict.reason,
         opType: op.opType,
       });
-      return {
+      return reject({
         opId: op.id,
         accepted: false,
         error: conflict.reason,
         errorCode,
         existingClock: conflict.existingClock,
-      };
+      });
     }
 
     // Get next sequence number
@@ -746,13 +758,13 @@ export class OperationUploadService {
         reason: `[RACE] ${finalConflict.reason}`,
         opType: op.opType,
       });
-      return {
+      return reject({
         opId: op.id,
         accepted: false,
         error: finalConflict.reason,
         errorCode,
         existingClock: finalConflict.existingClock,
-      };
+      });
     }
 
     // Prune vector clock AFTER conflict detection but BEFORE storage.
@@ -771,6 +783,12 @@ export class OperationUploadService {
       );
     }
 
+    // Size the op once, here, after the clock prune above (so the stored clock is
+    // measured) and reusing the payload byte size from validation (so the
+    // payload isn't re-stringified). Reused for the payloadBytes column and the
+    // caller's acceptedDeltaBytes accumulation.
+    const sized = computeOpStorageBytes(op, validation.payloadBytes);
+
     const createResult = await tx.operation.createMany({
       data: [
         {
@@ -783,7 +801,7 @@ export class OperationUploadService {
           entityType: op.entityType,
           entityId: op.entityId ?? null,
           payload: op.payload as Prisma.InputJsonValue,
-          payloadBytes: BigInt(computeOpStorageBytes(op).bytes),
+          payloadBytes: BigInt(sized.bytes),
           vectorClock: op.vectorClock as Prisma.InputJsonValue,
           schemaVersion: op.schemaVersion,
           clientTimestamp: BigInt(op.timestamp),
@@ -835,12 +853,12 @@ export class OperationUploadService {
           reason: 'Operation ID already belongs to a different operation',
           opType: op.opType,
         });
-        return {
+        return reject({
           opId: op.id,
           accepted: false,
           error: 'Operation ID already belongs to a different operation',
           errorCode: SYNC_ERROR_CODES.INVALID_OP_ID,
-        };
+        });
       }
 
       Logger.audit({
@@ -854,12 +872,12 @@ export class OperationUploadService {
         reason: 'Duplicate operation ID (insert race)',
         opType: op.opType,
       });
-      return {
+      return reject({
         opId: op.id,
         accepted: false,
         error: 'Duplicate operation ID',
         errorCode: SYNC_ERROR_CODES.DUPLICATE_OPERATION,
-      };
+      });
     }
 
     if (fullStateVectorClock) {
@@ -877,9 +895,9 @@ export class OperationUploadService {
     }
 
     return {
-      opId: op.id,
-      accepted: true,
-      serverSeq,
+      result: { opId: op.id, accepted: true, serverSeq },
+      storageBytes: sized.bytes,
+      fallback: sized.fallback,
     };
   }
 }

--- a/packages/super-sync-server/src/sync/services/validation.service.ts
+++ b/packages/super-sync-server/src/sync/services/validation.service.ts
@@ -28,6 +28,12 @@ export interface ValidationResult {
   valid: boolean;
   error?: string;
   errorCode?: SyncErrorCode;
+  /**
+   * UTF-8 byte size of `op.payload`, measured once here to enforce the size
+   * limit and threaded to the persist site so the payload isn't re-stringified.
+   * Set only on the `valid: true` result.
+   */
+  payloadBytes?: number;
 }
 
 export class ValidationService {
@@ -167,8 +173,13 @@ export class ValidationService {
       };
     }
 
-    const payloadSize = JSON.stringify(op.payload).length;
-    if (payloadSize > this.config.maxPayloadSizeBytes) {
+    // Measure UTF-8 bytes, not String#length (UTF-16 code units), so this
+    // per-payload limit agrees with the UTF-8 byte accounting used by the quota
+    // gate, the persisted payloadBytes column, and the storage counter. With
+    // `.length`, a non-ASCII payload undercounts and could pass this check while
+    // exceeding the same byte limit everywhere else.
+    const payloadBytes = Buffer.byteLength(JSON.stringify(op.payload), 'utf8');
+    if (payloadBytes > this.config.maxPayloadSizeBytes) {
       return {
         valid: false,
         error: 'Payload too large',
@@ -196,7 +207,7 @@ export class ValidationService {
       };
     }
 
-    return { valid: true };
+    return { valid: true, payloadBytes };
   }
 
   /**

--- a/packages/super-sync-server/src/sync/sync.const.ts
+++ b/packages/super-sync-server/src/sync/sync.const.ts
@@ -50,16 +50,29 @@ export const APPROX_BYTES_PER_OP = 1024;
  * be bypassed by submitting unserializable ops that still persist as JSONB.
  * `fallback` is `true` in that case so callers can observe the rate of
  * unserializable ops via a single log line (never the op content).
+ *
+ * `cachedPayloadBytes` lets a caller pass the payload's UTF-8 byte size when it
+ * was already measured upstream (validation stringifies the payload to enforce
+ * the size limit; the payload is immutable across the upload pipeline), so a
+ * multi-megabyte payload isn't re-stringified here. The vector clock is always
+ * (re)measured because it is pruned AFTER validation (see
+ * `limitVectorClockSize` / `pruneVectorClockForStorage`) — the stored clock
+ * differs from the validation/gate-time clock, so its size must be computed at
+ * the persist site.
  */
-export const computeOpStorageBytes = (op: {
-  payload: unknown;
-  vectorClock: unknown;
-}): { bytes: number; fallback: boolean } => {
+export const computeOpStorageBytes = (
+  op: {
+    payload: unknown;
+    vectorClock: unknown;
+  },
+  cachedPayloadBytes?: number,
+): { bytes: number; fallback: boolean } => {
   try {
+    const payloadBytes =
+      cachedPayloadBytes ?? Buffer.byteLength(JSON.stringify(op.payload ?? null), 'utf8');
     return {
       bytes:
-        Buffer.byteLength(JSON.stringify(op.payload ?? null), 'utf8') +
-        Buffer.byteLength(JSON.stringify(op.vectorClock ?? {}), 'utf8'),
+        payloadBytes + Buffer.byteLength(JSON.stringify(op.vectorClock ?? {}), 'utf8'),
       fallback: false,
     };
   } catch {

--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -8,7 +8,6 @@ import {
   VectorClock,
   SYNC_ERROR_CODES,
 } from './sync.types';
-import { computeOpStorageBytes } from './sync.const';
 import { Logger } from '../logger';
 import { Prisma } from '@prisma/client';
 import {
@@ -186,18 +185,20 @@ export class SyncService {
             uploadDbRoundtrips++;
 
             for (const op of ops) {
-              const result = await this.operationUploadService.processOperation(
-                userId,
-                clientId,
-                op,
-                now,
-                tx,
-              );
+              const { result, storageBytes, fallback } =
+                await this.operationUploadService.processOperation(
+                  userId,
+                  clientId,
+                  op,
+                  now,
+                  tx,
+                );
               results.push(result);
               if (result.accepted) {
-                const sized = computeOpStorageBytes(op);
-                acceptedDeltaBytes += sized.bytes;
-                if (sized.fallback) unserializableAccepted += 1;
+                // Reuse the size computed in processOperation instead of
+                // re-measuring (the payload can be multi-MB).
+                acceptedDeltaBytes += storageBytes;
+                if (fallback) unserializableAccepted += 1;
               }
             }
           }

--- a/packages/super-sync-server/src/sync/sync.types.ts
+++ b/packages/super-sync-server/src/sync/sync.types.ts
@@ -231,6 +231,12 @@ export interface BatchUploadCandidate {
   resultIndex: number;
   originalTimestamp: number;
   fullStateVectorClock?: VectorClock;
+  /**
+   * UTF-8 byte size of `op.payload` captured during validation, reused when
+   * sizing the stored op so a large payload isn't re-stringified. See
+   * `computeOpStorageBytes`'s `cachedPayloadBytes` parameter.
+   */
+  payloadBytes?: number;
 }
 
 export interface AcceptedBatchOperation extends BatchUploadCandidate {
@@ -268,6 +274,20 @@ export interface UploadResult {
    * Allows clients to create LWW updates that dominate the server's state.
    */
   existingClock?: VectorClock;
+}
+
+/**
+ * Internal return of the serial-path `processOperation`: the client-facing
+ * `UploadResult` plus the op's storage size, computed once at the persist site,
+ * so the caller can accumulate `acceptedDeltaBytes` without re-measuring the
+ * (potentially multi-MB) payload. `storageBytes` / `fallback` are only
+ * meaningful when `result.accepted` is true. Mirrors the batch path, which
+ * returns `acceptedDeltaBytes` from `processOperationBatch`.
+ */
+export interface ProcessOperationResult {
+  result: UploadResult;
+  storageBytes: number;
+  fallback: boolean;
 }
 
 export interface UploadOpsResponse {

--- a/packages/super-sync-server/tests/sync.const.spec.ts
+++ b/packages/super-sync-server/tests/sync.const.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { computeOpStorageBytes, APPROX_BYTES_PER_OP } from '../src/sync/sync.const';
+
+describe('computeOpStorageBytes', () => {
+  const op = {
+    payload: { note: '日本語✓', items: [1, 2, 3] },
+    vectorClock: { 'client-a': 3, 'client-b': 7 },
+  };
+  const payloadBytes = Buffer.byteLength(JSON.stringify(op.payload), 'utf8');
+  const clockBytes = Buffer.byteLength(JSON.stringify(op.vectorClock), 'utf8');
+
+  it('measures payload + vector clock in UTF-8 bytes', () => {
+    const sized = computeOpStorageBytes(op);
+    expect(sized.fallback).toBe(false);
+    expect(sized.bytes).toBe(payloadBytes + clockBytes);
+  });
+
+  it('uses the cached payload byte size instead of re-stringifying the payload', () => {
+    // A cached size that differs from the real one proves the payload is NOT
+    // re-measured: the result must reflect the cached value, not JSON.stringify.
+    const sized = computeOpStorageBytes(op, 12345);
+    expect(sized.bytes).toBe(12345 + clockBytes);
+  });
+
+  it('matches the uncached result when the cached payload size is exact', () => {
+    expect(computeOpStorageBytes(op, payloadBytes).bytes).toBe(
+      computeOpStorageBytes(op).bytes,
+    );
+  });
+
+  it('always re-measures the (mutable, pruned-at-storage) vector clock', () => {
+    // The clock is pruned after validation, so a cached payload size must still
+    // be combined with a freshly-measured clock — not a cached total.
+    const prunedClockOp = { payload: op.payload, vectorClock: { 'client-a': 3 } };
+    const sized = computeOpStorageBytes(prunedClockOp, payloadBytes);
+    expect(sized.bytes).toBe(
+      payloadBytes + Buffer.byteLength(JSON.stringify(prunedClockOp.vectorClock), 'utf8'),
+    );
+    expect(sized.bytes).not.toBe(computeOpStorageBytes(op, payloadBytes).bytes);
+  });
+
+  it('fails closed to APPROX_BYTES_PER_OP for an unserializable payload (no cache)', () => {
+    const badOp = { payload: { big: BigInt(1) }, vectorClock: {} };
+    const sized = computeOpStorageBytes(badOp);
+    expect(sized).toEqual({ bytes: APPROX_BYTES_PER_OP, fallback: true });
+  });
+
+  it('fails closed when the vector clock is unserializable even with a cached payload size', () => {
+    const badClockOp = { payload: op.payload, vectorClock: { big: BigInt(1) } };
+    const sized = computeOpStorageBytes(badClockOp, payloadBytes);
+    expect(sized).toEqual({ bytes: APPROX_BYTES_PER_OP, fallback: true });
+  });
+});

--- a/packages/super-sync-server/tests/validation.service.spec.ts
+++ b/packages/super-sync-server/tests/validation.service.spec.ts
@@ -360,6 +360,43 @@ describe('ValidationService', () => {
       expect(result.errorCode).toBe(SYNC_ERROR_CODES.PAYLOAD_TOO_LARGE);
     });
 
+    it('should measure the size limit in UTF-8 bytes, not UTF-16 code units', () => {
+      // '✓' (U+2713) is one UTF-16 code unit but three UTF-8 bytes.
+      // JSON.stringify({ data: '✓'×100 }) is 111 UTF-16 code units but 311 UTF-8
+      // bytes. With a 200-byte limit the old String#length check (111) wrongly
+      // passed; the UTF-8 byte measure (311) correctly rejects.
+      const service = new ValidationService({
+        ...DEFAULT_SYNC_CONFIG,
+        maxPayloadSizeBytes: 200,
+      });
+      const payload = { data: '✓'.repeat(100) };
+      expect(JSON.stringify(payload).length).toBeLessThanOrEqual(200);
+      expect(Buffer.byteLength(JSON.stringify(payload), 'utf8')).toBeGreaterThan(200);
+      const result = service.validateOp(createValidOp({ payload }), clientId);
+      expect(result.valid).toBe(false);
+      expect(result.errorCode).toBe(SYNC_ERROR_CODES.PAYLOAD_TOO_LARGE);
+    });
+
+    it('returns the UTF-8 payload byte size on the valid result', () => {
+      const asciiOp = createValidOp({ payload: { name: 'Test' } });
+      const asciiResult = validationService.validateOp(asciiOp, clientId);
+      expect(asciiResult.valid).toBe(true);
+      expect(asciiResult.payloadBytes).toBe(
+        Buffer.byteLength(JSON.stringify(asciiOp.payload), 'utf8'),
+      );
+
+      // Non-ASCII: byte size exceeds the UTF-16 code-unit count.
+      const unicodeOp = createValidOp({ payload: { note: '日本語✓' } });
+      const unicodeResult = validationService.validateOp(unicodeOp, clientId);
+      expect(unicodeResult.valid).toBe(true);
+      expect(unicodeResult.payloadBytes).toBe(
+        Buffer.byteLength(JSON.stringify(unicodeOp.payload), 'utf8'),
+      );
+      expect(unicodeResult.payloadBytes).toBeGreaterThan(
+        JSON.stringify(unicodeOp.payload).length,
+      );
+    });
+
     it('should accept timestamps in the future (clamping handled during upload)', () => {
       // Future timestamp validation removed - clamping is handled in OperationUploadService.
       const futureTime = Date.now() + 10 * 60 * 1000; // 10 minutes in future


### PR DESCRIPTION
## Summary

Fixes the UTF-16/UTF-8 measurement mismatch and the redundant payload stringifies in the SuperSync upload path (#8351).

`validateOp` enforced the per-payload size limit with `JSON.stringify(op.payload).length` — **UTF-16 code units** — while the quota gate, the persisted `payloadBytes` column, and the `storage_used_bytes` counter all measure **UTF-8 bytes** via `Buffer.byteLength(...,'utf8')`. Non-ASCII payloads undercount in the check, so a payload could pass validation yet be charged more in every accounting path.

This PR:

- **Standardizes the size check on UTF-8 bytes** (`validation.service.ts`), so the per-payload limit agrees with the byte accounting used everywhere else.
- **Measures the payload size once and reuses it.** `computeOpStorageBytes` gains an optional `cachedPayloadBytes` arg; `validateOp` returns the measured `payloadBytes`. Both upload paths reuse it at the persist site; the (small, mutable) vector clock is still measured there because it is pruned *after* validation. `processOperation` now returns `{ result, storageBytes, fallback }` so the serial loop reuses the size instead of recomputing it — mirroring the batch path's `acceptedDeltaBytes`.

Net payload stringifies per accepted op: **serial 4→2, batch 3→2**. The pre-validation quota gate remains the one unavoidable upfront measure. The persisted `payloadBytes` value is **unchanged** for any accepted op — this is pure dedup, not an accounting change.

## ⚠️ Behavior change

The 20 MB per-payload limit is now enforced in UTF-8 bytes. A heavily non-ASCII (CJK/emoji) full-state import whose true size is >20 MB UTF-8 but <20 M UTF-16 code units was silently accepted before and is now correctly rejected with `PAYLOAD_TOO_LARGE`, matching the documented byte limit.

## Tests

- New `tests/sync.const.spec.ts`: cached-payload contract — cache is used, the clock is always re-measured (drift guard against the post-validation prune), fail-closed `APPROX_BYTES_PER_OP` fallback preserved.
- `tests/validation.service.spec.ts`: UTF-16→UTF-8 boundary case (a payload that passed under `.length` but exceeds the byte limit), plus `payloadBytes` return assertions for ASCII and non-ASCII.
- `checkFile` (prettier + lint) clean on all changed files; `sync.const` + `validation` specs pass (59/59); the serial-loop refactor introduces no new failures in `sync.service.spec.ts` (the `uploadOps` integration assertions require a generated Prisma client and run in CI).

## Review

Vetted with a 6-reviewer parallel pass (correctness, security, architecture, alternatives, performance, simplicity): no correctness or security issues; cached size is byte-exact vs the old uncached measure for accepted ops; clock correctly re-measured post-prune; fail-closed preserved. The serial-path dedup completion in this revision addresses the one finding all reviewers converged on.

Closes #8351
