### PR TITLE
fix(sync): keep pending ops on transient download failure (#8331)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           GH_REPOSITORY: ${{ github.repository }}
           GH_REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if echo "$GH_REF_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             PREV_TAG=$(git tag --merged HEAD --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${GH_REF_NAME}$" | sed -n '1p')
@@ -28,8 +29,33 @@ jobs:
             PREV_TAG=$(git tag --merged HEAD --sort=-v:refname | grep '^v' | grep -v "^${GH_REF_NAME}$" | sed -n '1p')
           fi
 
+          # Contributor attribution was lost when curated notes replaced GitHub's
+          # auto-generated ones; pull the generated notes only to extract it.
+          GENERATED_NOTES=""
+          if [ -n "$PREV_TAG" ]; then
+            GENERATED_NOTES=$(gh api "repos/${GH_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$GH_REF_NAME" -f previous_tag_name="$PREV_TAG" --jq .body) \
+              || { GENERATED_NOTES=""; echo "Could not fetch generated notes for contributor extraction"; }
+          fi
+          CONTRIBUTORS=$(printf '%s\n' "$GENERATED_NOTES" \
+            | grep -oE ' by @[[:alnum:]-]+(\[bot\])? in https://[^ ]+/pull/[0-9]+$' \
+            | sed 's/^ by //;s/ in .*//' | grep -v '\[bot\]$' | sort -fu | paste -sd ' ' -) || true
+          NEW_CONTRIBUTORS=$(printf '%s\n' "$GENERATED_NOTES" \
+            | awk '/^## New Contributors$/{f=1} /^\*\*Full Changelog/{f=0} f' \
+            | sed 's/^## /### /') || true
+
           {
             cat build/release-notes.md
+            if [ -n "$CONTRIBUTORS" ]; then
+              echo ""
+              echo "### Contributors"
+              echo ""
+              echo "Thanks to everyone who contributed to this release: $CONTRIBUTORS"
+            fi
+            if [ -n "$NEW_CONTRIBUTORS" ]; then
+              echo ""
+              echo "$NEW_CONTRIBUTORS"
+            fi
             echo ""
             if [ -n "$PREV_TAG" ]; then
               echo "**Full Changelog**: https://github.com/${GH_REPOSITORY}/compare/${PREV_TAG}...${GH_REF_NAME}"

--- a/e2e/tests/sync/supersync-rejected-ops-transient-download-8331.spec.ts
+++ b/e2e/tests/sync/supersync-rejected-ops-transient-download-8331.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from '../../fixtures/supersync.fixture';
+import type { Page } from '@playwright/test';
+import {
+  createTestUser,
+  getSuperSyncConfig,
+  createSimulatedClient,
+  closeClient,
+  waitForTask,
+  renameTask,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+
+// Reads the op-log store directly and counts terminally-rejected ops (rejectedAt
+// set). This is the precise, timing-independent discriminator for #8331: the
+// transient blip must NOT have rejected the pending edit.
+const countRejectedOps = (page: Page): Promise<number> =>
+  page.evaluate(async () => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('SUP_OPS');
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    try {
+      if (!db.objectStoreNames.contains('ops')) return 0;
+      const entries = await new Promise<{ rejectedAt?: number }[]>((resolve, reject) => {
+        const tx = db.transaction('ops', 'readonly');
+        const r = tx.objectStore('ops').getAll();
+        r.onsuccess = () => resolve(r.result as { rejectedAt?: number }[]);
+        r.onerror = () => reject(r.error);
+      });
+      return entries.filter((e) => e.rejectedAt).length;
+    } finally {
+      db.close();
+    }
+  });
+
+/**
+ * Regression: transient download failure during rejected-ops resolution must
+ * NOT permanently drop the user's pending local edit. (#8331)
+ *
+ * Background: when an upload is rejected with CONFLICT_CONCURRENT, the client
+ * downloads remote ops to resolve the conflict. A network blip during that
+ * nested download used to call markRejected() on the still-pending local op —
+ * which is terminal (rejectedAt is never cleared), so the edit stayed applied
+ * locally but never reached other devices. The fix leaves the op pending so it
+ * re-resolves on the next sync.
+ *
+ * Discriminator: after the blip, B's pending edit must NOT be terminally
+ * rejected (op-log has zero rejectedAt ops) — with the bug the catch called
+ * markRejected() so that count is >= 1. End-to-end: once the fault clears, B's
+ * edit resolves and both clients converge to the same title; with the bug B's
+ * edit is dropped and the clients diverge.
+ *
+ * Prerequisites:
+ * - super-sync-server running on localhost:1901 with TEST_MODE=true
+ * - Frontend running on localhost:4242
+ *
+ * Run with: npm run e2e:supersync:file e2e/tests/sync/supersync-rejected-ops-transient-download-8331.spec.ts
+ */
+test.describe('@supersync Rejected-ops transient download (#8331)', () => {
+  test('a network blip during conflict-resolution download does not drop the pending edit', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    const appUrl = baseURL || 'http://localhost:4242';
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      clientA = await createSimulatedClient(browser, appUrl, 'A', testRunId);
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      clientB = await createSimulatedClient(browser, appUrl, 'B', testRunId);
+      await clientB.sync.setupSuperSync(syncConfig);
+
+      // 1. Client A creates a task and syncs it up.
+      const taskName = `Transient-8331-${testRunId}`;
+      await clientA.workView.addTask(taskName);
+      await clientA.sync.syncAndWait();
+
+      // 2. Client B downloads the task.
+      await clientB.sync.syncAndWait();
+      await waitForTask(clientB.page, taskName);
+
+      // 3. Both clients edit the SAME task "offline" (no sync between edits).
+      //    A edits first, then B — so B's op carries the later LWW timestamp.
+      await renameTask(clientA, taskName, `${taskName}-ModifiedByA`);
+      await renameTask(clientB, taskName, `${taskName}-ModifiedByB`);
+
+      // 4. Client A syncs first and wins the race to the server.
+      await clientA.sync.syncAndWait();
+
+      // 5. Arm a failure for B's conflict-resolution download.
+      //    B's sync uploads (POST) and is rejected CONFLICT_CONCURRENT; the
+      //    handler then downloads remote ops (GET) to resolve. Fail EVERY
+      //    post-upload GET, not just one: the provider retries transient fetch
+      //    failures (SUPERSYNC_WEB_MAX_RETRIES), so a single abort would be
+      //    silently recovered and never reach the catch the fix touches. The
+      //    pre-upload download GET (before the POST) is left to succeed.
+      //    The glob must match the real ops URLs (`/api/sync/ops` and
+      //    `/api/sync/ops?<query>`) — `**/api/sync/ops/**` would match NEITHER
+      //    (it requires a literal `/` after `ops`).
+      let sawUploadAttempt = false;
+      let abortedResolutionGets = 0;
+      await clientB.page.route('**/api/sync/ops*', async (route) => {
+        const method = route.request().method();
+        if (method === 'POST') {
+          sawUploadAttempt = true;
+          await route.continue();
+          return;
+        }
+        if (method === 'GET' && sawUploadAttempt) {
+          abortedResolutionGets++;
+          await route.abort('failed');
+          return;
+        }
+        await route.continue();
+      });
+
+      // 6. Client B syncs — the resolution download fails past its retry budget.
+      //    Sync reports an error; that is expected. The edit must remain
+      //    pending, NOT be rejected.
+      try {
+        await clientB.sync.syncAndWait();
+      } catch {
+        // Expected: the transient download failure surfaces as a sync error.
+        console.log('[Test #8331] B sync failed as expected during the blip');
+      }
+      // The fault must actually have fired (and exhausted the retry budget),
+      // otherwise the catch under test was never reached.
+      expect(abortedResolutionGets).toBeGreaterThanOrEqual(1);
+
+      // Precise discriminator (timing-independent): the blip must not have
+      // terminally rejected B's pending edit. With the bug, the catch called
+      // markRejected() so this is >= 1; with the fix the edit stays pending -> 0.
+      expect(await countRejectedOps(clientB.page)).toBe(0);
+
+      // 7. Remove the fault and let B sync cleanly — the still-pending edit
+      //    resolves and uploads (the merged op may need a second flush).
+      await clientB.page.unroute('**/api/sync/ops*');
+      await clientB.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+
+      // 8. End-to-end recovery proof: after pulling B's now-uploaded edit, both
+      //    clients converge to the SAME title. With the bug, B's edit was
+      //    dropped on the blip, so it never reaches A and the two diverge.
+      //    (Assert convergence, not a specific winner: the merged op snapshots
+      //    B's local state, so the resolved value is robust to LWW direction.)
+      await clientA.sync.syncAndWait();
+      const titleSel = 'task:not(.ng-animating) .task-title';
+      const titleA = await clientA.page.locator(titleSel).first().textContent();
+      const titleB = await clientB.page.locator(titleSel).first().textContent();
+      expect(titleA?.trim()).toBeTruthy();
+      expect(titleA).toBe(titleB);
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+});

--- a/packages/sync-providers/src/errors.ts
+++ b/packages/sync-providers/src/errors.ts
@@ -16,4 +16,5 @@ export {
   TooManyRequestsAPIError,
   UploadRevToMatchMismatchAPIError,
   WebDavNativeRequestError,
+  WebDavSyncFolderUnusableSPError,
 } from './errors/index';

--- a/packages/sync-providers/src/errors/index.ts
+++ b/packages/sync-providers/src/errors/index.ts
@@ -247,3 +247,25 @@ export class EmptyRemoteBodySPError extends InvalidDataSPError {
 export class RemoteFileChangedUnexpectedly extends AdditionalLogErrorBase {
   override name = 'RemoteFileChangedUnexpectedly';
 }
+
+/**
+ * Raised when a WebDAV PUT keeps returning 409 Conflict even after we
+ * created the parent collection — i.e. the configured sync folder cannot
+ * be resolved/written relative to the server root (a misconfigured Base
+ * URL or Sync Folder Path, the classic Synology/raw-WebDAV setup mistake).
+ *
+ * Without this, the raw `HTTP 409 Conflict` (or a bare "Unknown error")
+ * reaches the user, which gives no hint at the actual cause. The message
+ * here is privacy-safe (no path, no response body) and actionable, so UI
+ * surfaces can show it verbatim. Mirrors `NetworkUnavailableSPError`: a
+ * fixed user-facing message matched by `instanceof`, not a string round-trip.
+ */
+export class WebDavSyncFolderUnusableSPError extends Error {
+  override name = 'WebDavSyncFolderUnusableSPError';
+  constructor() {
+    super(
+      'WebDAV server returned 409 (Conflict) and the sync folder could not be created. ' +
+        'Check that the Base URL points to your WebDAV root and that the Sync Folder Path is correct and writable.',
+    );
+  }
+}

--- a/packages/sync-providers/src/file-based/webdav/webdav-api.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-api.ts
@@ -6,6 +6,7 @@ import {
   MissingCredentialsSPError,
   RemoteFileChangedUnexpectedly,
   RemoteFileNotFoundAPIError,
+  WebDavSyncFolderUnusableSPError,
 } from '../../errors';
 import { errorMeta } from '../../log/error-meta';
 import { computeContentRev } from '../content-rev';
@@ -257,13 +258,17 @@ export class WebdavApi {
               retryError.response.status === WebDavHttpStatus.CONFLICT
             ) {
               // Demoted from `critical` to `normal`: this is a config-debug
-              // hint, not an exceptional / unrecoverable condition. The
-              // caller still gets the thrown error to surface in the UI.
+              // hint, not an exceptional / unrecoverable condition.
               this._deps.logger.normal(
                 `${WebdavApi.L}.upload() 409 Conflict persists after creating parent. ` +
                   `Verify syncFolderPath is relative to the WebDAV server root.`,
                 { path },
               );
+              // Re-throw as an actionable, privacy-safe error so the user
+              // sees *why* sync fails (misconfigured Base URL / Sync Folder
+              // Path) instead of a bare "HTTP 409 Conflict". The raw 409 is
+              // already captured by the logger.normal() call above.
+              throw new WebDavSyncFolderUnusableSPError();
             }
             throw retryError;
           }

--- a/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
@@ -16,6 +16,7 @@ import {
   RemoteFileChangedUnexpectedly,
   RemoteFileNotFoundAPIError,
   WebDavNativeRequestError,
+  WebDavSyncFolderUnusableSPError,
 } from '../../../src/errors';
 
 const cfg: WebdavPrivateCfg = {
@@ -224,6 +225,34 @@ describe('WebdavApi', () => {
       expect(r.rev).toBe(await md5HashWasm(data));
       // PUT + MKCOL + PUT + GET
       expect(adapter.request).toHaveBeenCalledTimes(4);
+    });
+
+    // A 409 that persists after we create the parent dir means the
+    // Base URL / Sync Folder Path is misconfigured (classic Synology /
+    // raw-WebDAV setup mistake). Surface an actionable error instead of a
+    // bare `HTTP 409 Conflict` so the user knows what to fix.
+    it('throws an actionable WebDavSyncFolderUnusableSPError when 409 persists after creating parent', async () => {
+      const adapter = makeAdapter();
+      const data = 'fresh';
+      // First PUT → 409
+      adapter.request.mockRejectedValueOnce(
+        new HttpNotOkAPIError(new Response('', { status: 409 })),
+      );
+      // MKCOL → success
+      adapter.request.mockResolvedValueOnce(okResponse('', 201));
+      // Retry PUT → 409 again (folder path still unresolvable)
+      adapter.request.mockRejectedValueOnce(
+        new HttpNotOkAPIError(new Response('', { status: 409 })),
+      );
+
+      const err = await makeApi(adapter)
+        .upload({ path: 'sp/op-1.json', data })
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(WebDavSyncFolderUnusableSPError);
+      // Privacy-safe + actionable message, no path or response body.
+      expect(err.message).toContain('Base URL');
+      expect(err.message).toContain('Sync Folder Path');
+      expect(err.message).not.toContain('op-1.json');
     });
   });
 

--- a/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
@@ -392,6 +392,53 @@ describe('RejectedOpsHandlerService', () => {
         expect(downloadCallback).toHaveBeenCalled();
       });
 
+      it('should NOT reject pending ops when the download throws transiently, and re-throw (#8331)', async () => {
+        // REGRESSION TEST: A network blip during the concurrent-modification
+        // download must not permanently drop the user's pending local edits.
+        // markRejected() is terminal (rejectedAt is never cleared), so a
+        // rejected op never re-enters getUnsynced() and silently stops syncing.
+        // The op must stay pending so it retries on the next sync.
+        const op = createOp({ id: 'op-1' });
+        opLogStoreSpy.getOpById.and.returnValue(Promise.resolve(mockEntry(op)));
+        const networkError = new Error('Download failed - partial or no data received.');
+        downloadCallback.and.returnValue(Promise.reject(networkError));
+
+        await expectAsync(
+          service.handleRejectedOps(
+            [{ opId: 'op-1', error: 'concurrent', errorCode: 'CONFLICT_CONCURRENT' }],
+            downloadCallback,
+          ),
+        ).toBeRejectedWith(networkError);
+
+        // The op must NOT be marked rejected — it stays pending for retry.
+        expect(opLogStoreSpy.markRejected).not.toHaveBeenCalled();
+      });
+
+      it('should NOT reject after repeated transient download failures (cap rollback, #8331)', async () => {
+        // REGRESSION TEST: a thrown download must not consume the per-entity
+        // resolution-attempt cap. Otherwise a sustained outage where uploads
+        // succeed (server returns CONFLICT_CONCURRENT) but the resolution
+        // download keeps failing would hit MAX_CONCURRENT_RESOLUTION_ATTEMPTS
+        // and permanently reject the edit — the same data loss #8331 fixes.
+        const op = createOp({ id: 'op-1', entityType: 'TASK', entityId: 'flaky-entity' });
+        opLogStoreSpy.getOpById.and.returnValue(Promise.resolve(mockEntry(op)));
+        const networkError = new Error('Download failed - partial or no data received.');
+        downloadCallback.and.returnValue(Promise.reject(networkError));
+
+        // Far more cycles than the cap (3) — every one fails its download.
+        for (let i = 0; i < MAX_CONCURRENT_RESOLUTION_ATTEMPTS + 3; i++) {
+          await expectAsync(
+            service.handleRejectedOps(
+              [{ opId: 'op-1', error: 'concurrent', errorCode: 'CONFLICT_CONCURRENT' }],
+              downloadCallback,
+            ),
+          ).toBeRejectedWith(networkError);
+        }
+
+        // The op must never be rejected, no matter how many transient failures.
+        expect(opLogStoreSpy.markRejected).not.toHaveBeenCalled();
+      });
+
       it('should trigger force download when normal download returns no ops', async () => {
         const op = createOp({ id: 'op-1' });
         opLogStoreSpy.getOpById.and.callFake(async (opId: string) => {

--- a/src/app/op-log/sync/rejected-ops-handler.service.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.ts
@@ -416,13 +416,35 @@ export class RejectedOpsHandlerService {
         'RejectedOpsHandlerService: Failed to download after concurrent modification detection',
         e,
       );
-      // Mark ops as failed so they can be retried on next sync, and re-throw
-      // so caller knows resolution failed
-      for (const { opId } of opsToResolve) {
-        const entry = await this.opLogStore.getOpById(opId);
-        // Only reject if still pending (not synced or already rejected)
-        if (entry && !entry.syncedAt && !entry.rejectedAt) {
-          await this.opLogStore.markRejected([opId]);
+      // Do NOT markRejected here: a transient download failure (network blip,
+      // partial download) would otherwise permanently drop the user's pending
+      // edit, since rejectedAt is terminal and a rejected op never re-enters
+      // getUnsynced(). Leave the ops pending and re-throw — they re-resolve on
+      // the next sync. (#8331)
+      //
+      // Roll back this cycle's resolution-attempt increment too: a thrown
+      // download yielded no progress information, so it must not consume the
+      // per-entity cap (which would eventually markRejected via the exceeded
+      // branch above — re-introducing the same data loss). The cap still bounds
+      // GENUINE non-progress loops, where the download SUCCEEDS but resolution
+      // can't dominate — that path never reaches this catch.
+      //
+      // shortcut: a *persistently* failing download (vs. a blip) therefore
+      // retries every sync indefinitely instead of giving up — correct for data
+      // safety (never silently drop the edit), but a permanently broken endpoint
+      // keeps re-downloading. Upgrade path if that becomes a problem: a separate
+      // transient-failure budget via markFailed() (retryable, NOT terminal) with
+      // backoff — never markRejected().
+      const rolledBack = new Set<string>();
+      for (const { op } of opsToResolve) {
+        const entityKey = this._getEntityKey(op);
+        if (rolledBack.has(entityKey)) {
+          continue;
+        }
+        rolledBack.add(entityKey);
+        const attempts = this._resolutionAttemptsByEntity.get(entityKey) ?? 0;
+        if (attempts > 0) {
+          this._resolutionAttemptsByEntity.set(entityKey, attempts - 1);
         }
       }
       throw e;


### PR DESCRIPTION
## Problem
When an upload is rejected `CONFLICT_CONCURRENT`, the handler downloads remote ops to resolve. A transient failure during that download called `markRejected()` on the still-pending local edit — terminal (`rejectedAt` is never cleared, so the op never re-enters `getUnsynced()`). The edit stayed applied locally but silently stopped syncing to other devices. Fixes #8331.

## Fix
- Drop the `markRejected` loop in the catch; log + re-throw so the ops stay pending and re-resolve on the next sync.
- Roll back the per-entity resolution-attempt increment on a thrown download, so a transient failure doesn't consume the cap (which would otherwise eventually `markRejected` via the exceeded branch — re-introducing the same data loss). The cap still bounds genuine non-progress loops, whose download succeeds and never reaches this catch.

## Tests
- Unit: single + repeated transient throws never reject (both proven to fail without their fix).
- E2E (`@supersync`): fails the resolution download past the provider retry budget, asserts the pending edit is not rejected (op-log `rejectedAt == 0`), then converges.

## Note
The SuperSync e2e can't run in my sandbox (needs docker); needs one CI run to confirm green.