### PR TITLE
fix(android): keep header below status bar on Android <15 (#8283)

### DIFF
--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -751,13 +751,31 @@ export class GlobalThemeService {
     // system-bar insets regardless, so applying them as CSS padding on top of
     // the native margin double-counts the inset (visible as excessive padding
     // above the top bar). The WebView interior is fully safe there, so keep the
-    // safe-area CSS vars at 0; only iOS (contentInset: 'never') needs the
-    // WebView to pad itself. A few styles read env(safe-area-inset-bottom)
-    // directly (e.g. mobile-bottom-nav) rather than these vars; inside the
-    // natively-inset WebView that env value is expected to be ~0, keeping them
-    // consistent with the pinned vars here.
+    // bottom/side safe-area CSS vars at 0; only iOS (contentInset: 'never')
+    // needs the WebView to pad itself. A few styles read env(safe-area-inset-
+    // bottom) directly (e.g. mobile-bottom-nav) rather than these vars; inside
+    // the natively-inset WebView that env value is expected to be ~0, keeping
+    // them consistent with the pinned vars here.
+    //
+    // The TOP is the exception. On Android < 15 the WebView is forced
+    // edge-to-edge by @capacitor/status-bar's legacy `overlaysWebView`
+    // fullscreen flag (a no-op on Android 15+), and the plugin's native top
+    // margin is not reliably applied on every OS/ROM — the header then draws
+    // behind the status bar (#8283, seen on Android 14). Pinning the top var to
+    // 0 leaves no fallback. Instead defer the top to the WebView's own
+    // env(safe-area-inset-top): with viewport-fit=cover it equals the status-bar
+    // height exactly when the WebView extends under it, and resolves to 0 once
+    // the WebView is already inset (Android 15+ / native margin applied) — so it
+    // self-corrects across OS versions without ever double-counting.
     if (this._platformService.isAndroid()) {
       applyInsets({ top: 0, right: 0, bottom: 0, left: 0 });
+      // Override only the top with the env() fallback (see above). getComputedStyle
+      // resolves env() to a pixel value, so the readers in
+      // _patchCdkViewportForSafeArea also pick up the real top inset.
+      this.document.documentElement.style.setProperty(
+        CSS_VAR_SAFE_AREA_TOP,
+        'env(safe-area-inset-top, 0px)',
+      );
     } else {
       SafeArea.getSafeAreaInsets().then(({ insets }) => applyInsets(insets));
       SafeArea.addListener('safeAreaChanged', ({ insets }) => applyInsets(insets));


### PR DESCRIPTION
## What & why

On Android < 15 the WebView is forced edge-to-edge by `@capacitor/status-bar`'s legacy `overlaysWebView` fullscreen flag (a no-op on Android 15+, where edge-to-edge is OS-enforced). The theme service pinned every Android safe-area CSS var to `0`, trusting the `@capawesome` edge-to-edge plugin's native margins to inset the WebView — but on Android < 15 that top margin isn't reliably applied, so the header drew **behind the status bar** and its buttons became unreachable. Reported on Pixel 7a / Android 14 / LineageOS (#8283).

## Fix

Defer the top inset to the WebView's own `env(safe-area-inset-top)` (the page already sets `viewport-fit=cover`):

- equals the status-bar height exactly when the WebView extends under the bar (Android < 15), and
- resolves to `0` once the WebView is natively inset (Android 15+) — so it self-corrects across OS versions **without double-counting**.

Bottom/side vars stay pinned at `0` (the native plugin owns them). Reuses the existing `applyInsets` helper for those.

## Scope

One file (`src/app/core/theme/global-theme.service.ts`), Android-only branch. iOS / web / Electron paths unchanged. No new dependencies, no native-code changes.

## Verification

- `npm run checkFile` passes; multi-agent review clean.
- One reviewer flagged a "CRITICAL" (that `parseInt` readers of the var would break) — **empirically disproven**: `getComputedStyle()` resolves `env()` to a pixel value, so the CDK-overlay / context-menu readers correctly pick up the top inset too (a small incidental improvement over the prior pinned `0`).
- ⚠️ **Still needs on-device verification across Android 14 / 15 / 16**: confirm the header clears the status bar and the bottom/IME inset is not doubled. Fails safe if `env()` is unreliable on a given WebView (no worse than current behavior).

Addresses #8283 (pending on-device verification)
