### PR TITLE
fix(sync): deep-clone in dataRepair() to stop mutating live NgRx store (#8333)

### DIFF
--- a/src/app/op-log/backup/state-snapshot.service.ts
+++ b/src/app/op-log/backup/state-snapshot.service.ts
@@ -42,6 +42,16 @@ const DEFAULT_ARCHIVE: ArchiveModel = {
  * Most models are persisted via OperationLogEffects to SUP_OPS IndexedDB, so we read from NgRx.
  * Archives (archiveYoung, archiveOld) are read from SUP_OPS via ArchiveDbAdapter.
  *
+ * ## ⚠️ Returned objects share references with live NgRx state — DO NOT MUTATE
+ * Only the top-level `task` slice is shallow-copied; `project`, `tag`,
+ * `taskRepeatCfg`, every `entities` map, and all entity objects are the same
+ * references held by the store. NgRx runtime freezing is OFF in production
+ * (`src/main.ts`), so mutating a returned object silently corrupts the store
+ * (memoized selectors won't recompute; a throw before the next `loadAllData`
+ * leaves the damage in place with no op-log capture). Any consumer that needs
+ * to modify the snapshot must `structuredClone()` it first — see the #8333
+ * regression in `dataRepair()` (`op-log/validation/data-repair.ts`).
+ *
  * ## Usage
  * ```typescript
  * const snapshot = inject(StateSnapshotService);
@@ -63,6 +73,8 @@ export class StateSnapshotService {
   /**
    * Gets all sync model data from NgRx store.
    * Archives are returned with default empty values - use async version for actual archives.
+   *
+   * ⚠️ Returns live store references — never mutate (clone first). See class doc.
    */
   getStateSnapshot(): AppStateSnapshot {
     const ngRxData = this._getNgRxDataSync();
@@ -84,6 +96,8 @@ export class StateSnapshotService {
 
   /**
    * Async version that also loads archives from IndexedDB
+   *
+   * ⚠️ Returns live store references — never mutate (clone first). See class doc.
    */
   async getStateSnapshotAsync(): Promise<AppStateSnapshot> {
     const [archiveYoung, archiveOld] = await Promise.all([

--- a/src/app/op-log/validation/data-repair.spec.ts
+++ b/src/app/op-log/validation/data-repair.spec.ts
@@ -47,6 +47,54 @@ describe('dataRepair()', () => {
     mock = dirtyDeepCopy(mock);
   });
 
+  // Regression for #8333: production builds disable NgRx runtime freezing, so
+  // the input passed to dataRepair() is a live, writable store reference. The
+  // fixers mutate nested entities in place (projectId, quickSetting, weekday
+  // flags, …), so dataRepair() must deep-clone its input — the caller's object
+  // graph must come back untouched even when repair changes the returned copy.
+  it('should not mutate its (non-frozen) input data', () => {
+    const taskBadProject = {
+      ...DEFAULT_TASK,
+      id: 'TASK_BAD_PROJECT',
+      title: 'TASK_BAD_PROJECT',
+      projectId: 'NON_EXISTENT_PROJECT',
+    };
+    const cfgNoStartDate = {
+      ...DEFAULT_TASK_REPEAT_CFG,
+      id: 'CFG_NO_START',
+      title: 'CFG_NO_START',
+      projectId: INBOX_PROJECT.id,
+      // date-dependent quickSetting with no startDate -> repair rewrites to CUSTOM
+      quickSetting: 'MONTHLY_CURRENT_DATE' as const,
+      startDate: undefined,
+    };
+    const input: AppDataComplete = {
+      ...mock,
+      task: {
+        ...mock.task,
+        ...fakeEntityStateFromArray<Task>([taskBadProject]),
+      } as any,
+      taskRepeatCfg: {
+        ...fakeEntityStateFromArray<TaskRepeatCfg>([cfgNoStartDate]),
+      } as any,
+    };
+    // structuredClone (not dirtyDeepCopy) so undefined-valued keys are preserved
+    // and don't produce false mismatches against the post-repair input.
+    const inputSnapshot = structuredClone(input);
+
+    const result = dataRepair(input);
+
+    // Repair really did fix things on the returned copy...
+    expect(result.data.task.entities['TASK_BAD_PROJECT']!.projectId).toBe(
+      INBOX_PROJECT.id,
+    );
+    expect(result.data.taskRepeatCfg.entities['CFG_NO_START']!.quickSetting).toBe(
+      'CUSTOM',
+    );
+    // ...while the caller's input object graph is left byte-for-byte unchanged.
+    expect(input).toEqual(inputSnapshot);
+  });
+
   it('should delete tasks with same id in "task" and "taskArchive" from taskArchive', () => {
     const taskState = {
       ...mock.task,
@@ -79,7 +127,9 @@ describe('dataRepair()', () => {
 
     expect(result.data.task).toEqual(taskState);
     expect(result.data.archiveYoung.lastTimeTrackingFlush).toBe(0);
-    expect(result.data.archiveYoung.timeTracking).toBe(mock.archiveYoung.timeTracking);
+    // dataRepair() deep-clones its input (#8333), so this is an equal clone,
+    // no longer the same reference.
+    expect(result.data.archiveYoung.timeTracking).toEqual(mock.archiveYoung.timeTracking);
     expect(result.data.archiveYoung.task.ids).toEqual([]);
     expect(Object.keys(result.data.archiveYoung.task.entities)).toEqual([]);
   });
@@ -115,7 +165,25 @@ describe('dataRepair()', () => {
       }).data,
     ).toEqual({
       ...mock,
-      task: taskState as any,
+      // repair back-references the tag onto the task (tagIds) and adds the
+      // orphaned task to its project's list
+      task: {
+        ...taskState,
+        entities: {
+          ...taskState.entities,
+          TEST: { ...taskState.entities.TEST, tagIds: ['TEST_ID_TAG'] },
+        },
+      } as any,
+      project: {
+        ...mock.project,
+        entities: {
+          ...mock.project.entities,
+          [FAKE_PROJECT_ID]: {
+            ...(mock.project.entities[FAKE_PROJECT_ID] as any),
+            taskIds: ['TEST'],
+          },
+        },
+      } as any,
       tag: {
         ...tagState,
         entities: {
@@ -362,7 +430,14 @@ describe('dataRepair()', () => {
       archiveYoung: {
         lastTimeTrackingFlush: 0,
         timeTracking: mock.archiveYoung.timeTracking,
-        task: taskArchiveState,
+        // repair re-attaches the orphaned archived sub task to its parent
+        task: {
+          ...taskArchiveState,
+          entities: {
+            ...taskArchiveState.entities,
+            PAR_ID: { ...taskArchiveState.entities.PAR_ID, subTaskIds: ['SUB_ID'] },
+          },
+        },
       },
       project: {
         ...projectState,
@@ -413,7 +488,14 @@ describe('dataRepair()', () => {
       }).data,
     ).toEqual({
       ...mock,
-      task: taskState as any,
+      // repair assigns the backlog task's projectId from the project that lists it
+      task: {
+        ...taskState,
+        entities: {
+          ...taskState.entities,
+          TEST: { ...taskState.entities.TEST, projectId: 'TEST_ID_PROJECT' },
+        },
+      } as any,
       project: {
         ...projectState,
         entities: {
@@ -477,6 +559,17 @@ describe('dataRepair()', () => {
               projectId: FAKE_PROJECT_ID,
             },
           ]),
+        } as any,
+        // repair adds the de-duplicated tasks to their project's list
+        project: {
+          ...mock.project,
+          entities: {
+            ...mock.project.entities,
+            [FAKE_PROJECT_ID]: {
+              ...(mock.project.entities[FAKE_PROJECT_ID] as any),
+              taskIds: ['DUPE', 'NO_DUPE'],
+            },
+          },
         } as any,
       });
     });
@@ -561,6 +654,17 @@ describe('dataRepair()', () => {
           entities: {
             AAA: { ...DEFAULT_TASK, id: 'AAA', projectId: FAKE_PROJECT_ID },
             CCC: { ...DEFAULT_TASK, id: 'CCC', projectId: FAKE_PROJECT_ID },
+          },
+        } as any,
+        // repair adds the surviving tasks to their project's list
+        project: {
+          ...mock.project,
+          entities: {
+            ...mock.project.entities,
+            [FAKE_PROJECT_ID]: {
+              ...(mock.project.entities[FAKE_PROJECT_ID] as any),
+              taskIds: ['AAA', 'CCC'],
+            },
           },
         } as any,
       });
@@ -926,6 +1030,17 @@ describe('dataRepair()', () => {
           ...fakeEntityStateFromArray<Task>([]),
         } as any,
       },
+      // repair adds the top-level parent task to its project's list
+      project: {
+        ...mock.project,
+        entities: {
+          ...mock.project.entities,
+          [FAKE_PROJECT_ID]: {
+            ...(mock.project.entities[FAKE_PROJECT_ID] as any),
+            taskIds: ['parent'],
+          },
+        },
+      } as any,
     });
   });
 
@@ -1060,7 +1175,14 @@ describe('dataRepair()', () => {
       }).data,
     ).toEqual({
       ...mock,
-      project,
+      // repair adds the top-level parent task to its project's list
+      project: {
+        ...project,
+        entities: {
+          ...project.entities,
+          p1: { ...project.entities.p1, taskIds: ['parent'] },
+        },
+      } as any,
       task: {
         ...mock.task,
         ...fakeEntityStateFromArray<Task>([
@@ -1116,6 +1238,8 @@ describe('dataRepair()', () => {
         entities: {
           TEST: {
             ...taskState.entities.TEST,
+            // dangling projectId is reassigned to the inbox project
+            projectId: INBOX_PROJECT.id,
           },
         },
       },
@@ -1215,6 +1339,8 @@ describe('dataRepair()', () => {
         entities: {
           TEST: {
             ...taskRepeatCfgState.entities.TEST,
+            // dangling projectId is cleared to null on repeat configs
+            projectId: null,
           },
         },
       },
@@ -1580,6 +1706,17 @@ describe('dataRepair()', () => {
           },
         ]),
       } as any,
+      // both tasks got the inbox projectId, so repair adds them to its list
+      project: {
+        ...mock.project,
+        entities: {
+          ...mock.project.entities,
+          [INBOX_PROJECT.id]: {
+            ...(mock.project.entities[INBOX_PROJECT.id] as any),
+            taskIds: ['task1', 'task2'],
+          },
+        },
+      } as any,
     });
   });
 
@@ -1671,6 +1808,17 @@ describe('dataRepair()', () => {
           ]),
         } as any,
       },
+      // repair adds the top-level task1 to its project's list
+      project: {
+        ...mock.project,
+        entities: {
+          ...mock.project.entities,
+          [FAKE_PROJECT_ID]: {
+            ...(mock.project.entities[FAKE_PROJECT_ID] as any),
+            taskIds: ['task1'],
+          },
+        },
+      } as any,
     });
   });
 
@@ -1737,6 +1885,17 @@ describe('dataRepair()', () => {
           ]),
         } as any,
       },
+      // repair adds the top-level task1 to its project's list
+      project: {
+        ...mock.project,
+        entities: {
+          ...mock.project.entities,
+          [FAKE_PROJECT_ID]: {
+            ...(mock.project.entities[FAKE_PROJECT_ID] as any),
+            taskIds: ['task1'],
+          },
+        },
+      } as any,
     });
   });
 
@@ -1820,6 +1979,21 @@ describe('dataRepair()', () => {
           ]),
         } as any,
       },
+      // repair fills each project's list from the (re)assigned task projectIds
+      project: {
+        ...mock.project,
+        entities: {
+          ...mock.project.entities,
+          [INBOX_PROJECT.id]: {
+            ...(mock.project.entities[INBOX_PROJECT.id] as any),
+            taskIds: ['task1', 'sub_task'],
+          },
+          [FAKE_PROJECT_ID]: {
+            ...(mock.project.entities[FAKE_PROJECT_ID] as any),
+            taskIds: ['task2'],
+          },
+        },
+      } as any,
     });
   });
 

--- a/src/app/op-log/validation/data-repair.ts
+++ b/src/app/op-log/validation/data-repair.ts
@@ -28,6 +28,20 @@ export interface DataRepairResult {
 }
 
 /**
+ * Deeply-immutable view of a type. `dataRepair`'s input is typed with this so
+ * the compiler rejects any in-place mutation of the caller's state (which, on
+ * the live-state path, is a direct NgRx store reference — #8333). It also
+ * forces the deep clone below: a shallow `{ ...data }` keeps the nested
+ * `readonly` types and fails to assign to the mutable `dataOut`, so detaching
+ * via `structuredClone` becomes the only way to get a writable working copy.
+ */
+type DeepReadonly<T> = T extends (infer R)[]
+  ? readonly DeepReadonly<R>[]
+  : T extends object
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T;
+
+/**
  * Entity state keys that have ids/entities structure.
  * Used for fixing entity state consistency during repair.
  */
@@ -44,10 +58,10 @@ const ENTITY_STATE_KEYS: (keyof AppDataCompleteLegacy)[] = [
 ];
 
 export const dataRepair = (
-  data: AppDataComplete,
+  data: DeepReadonly<AppDataComplete>,
   errors: IValidation.IError[] = [],
 ): DataRepairResult => {
-  if (!isDataRepairPossible(data)) {
+  if (!isDataRepairPossible(data as AppDataComplete)) {
     throw new Error('Data repair attempted but not possible');
   }
 
@@ -67,7 +81,9 @@ export const dataRepair = (
   // shallow `{ ...data }` shares every nested object, letting repair corrupt
   // store-owned state before `loadAllData` is dispatched (#8333). Repair only
   // runs after a (rare) validation failure, so the unconditional clone is cheap.
-  let dataOut: AppDataComplete = structuredClone(data);
+  // The cast launders DeepReadonly -> mutable: structuredClone returns a fresh,
+  // fully-detached object, so writing to it can never reach the caller's state.
+  let dataOut: AppDataComplete = structuredClone(data) as AppDataComplete;
 
   // Ensure archive structures exist
   if (!dataOut.archiveYoung) {

--- a/src/app/op-log/validation/data-repair.ts
+++ b/src/app/op-log/validation/data-repair.ts
@@ -28,21 +28,6 @@ export interface DataRepairResult {
 }
 
 /**
- * Deeply-immutable view of a type. `dataRepair`'s input is typed with this to
- * force the deep clone below and block in-place mutation of `data` inside this
- * function: a shallow `{ ...data }` keeps the nested `readonly` types and won't
- * assign to the mutable `dataOut`, so `structuredClone` is the only way to get
- * a writable working copy (#8333). Note this guards the function body, not the
- * call sites — callers still pass live store references (a mutable type widens
- * to readonly), which is exactly why the unconditional clone is what matters.
- */
-type DeepReadonly<T> = T extends (infer R)[]
-  ? readonly DeepReadonly<R>[]
-  : T extends object
-    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
-    : T;
-
-/**
  * Entity state keys that have ids/entities structure.
  * Used for fixing entity state consistency during repair.
  */
@@ -59,11 +44,10 @@ const ENTITY_STATE_KEYS: (keyof AppDataCompleteLegacy)[] = [
 ];
 
 export const dataRepair = (
-  data: DeepReadonly<AppDataComplete>,
+  data: AppDataComplete,
   errors: IValidation.IError[] = [],
 ): DataRepairResult => {
-  // cast only to satisfy the signature — isDataRepairPossible is a read-only check
-  if (!isDataRepairPossible(data as AppDataComplete)) {
+  if (!isDataRepairPossible(data)) {
     throw new Error('Data repair attempted but not possible');
   }
 
@@ -76,16 +60,13 @@ export const dataRepair = (
     typeErrorsFixed: 0,
   };
 
-  // Deep clone before any repair runs. The fixers below mutate nested entities
-  // in place (e.g. `t.tagIds = []`, `cfg[day] = false`, `Object.assign` onto
-  // feature states), and production builds disable NgRx runtime freezing (see
-  // `src/main.ts`) — so the input here is a live, writable store reference. A
-  // shallow `{ ...data }` shares every nested object, letting repair corrupt
-  // store-owned state before `loadAllData` is dispatched (#8333). Repair only
-  // runs after a (rare) validation failure, so the unconditional clone is cheap.
-  // The cast launders DeepReadonly -> mutable: structuredClone returns a fresh,
-  // fully-detached object, so writing to it can never reach the caller's state.
-  let dataOut: AppDataComplete = structuredClone(data) as AppDataComplete;
+  // Deep clone before any repair runs: the fixers below mutate nested entities
+  // in place, and prod builds disable NgRx runtime freezing (src/main.ts) so
+  // `data` is a live, writable store reference. A shallow `{ ...data }` shares
+  // every nested object, letting repair corrupt store-owned state before
+  // `loadAllData` is dispatched (#8333). Only runs after a rare validation
+  // failure, so the unconditional clone is cheap.
+  let dataOut: AppDataComplete = structuredClone(data);
 
   // Ensure archive structures exist
   if (!dataOut.archiveYoung) {

--- a/src/app/op-log/validation/data-repair.ts
+++ b/src/app/op-log/validation/data-repair.ts
@@ -28,12 +28,13 @@ export interface DataRepairResult {
 }
 
 /**
- * Deeply-immutable view of a type. `dataRepair`'s input is typed with this so
- * the compiler rejects any in-place mutation of the caller's state (which, on
- * the live-state path, is a direct NgRx store reference — #8333). It also
- * forces the deep clone below: a shallow `{ ...data }` keeps the nested
- * `readonly` types and fails to assign to the mutable `dataOut`, so detaching
- * via `structuredClone` becomes the only way to get a writable working copy.
+ * Deeply-immutable view of a type. `dataRepair`'s input is typed with this to
+ * force the deep clone below and block in-place mutation of `data` inside this
+ * function: a shallow `{ ...data }` keeps the nested `readonly` types and won't
+ * assign to the mutable `dataOut`, so `structuredClone` is the only way to get
+ * a writable working copy (#8333). Note this guards the function body, not the
+ * call sites — callers still pass live store references (a mutable type widens
+ * to readonly), which is exactly why the unconditional clone is what matters.
  */
 type DeepReadonly<T> = T extends (infer R)[]
   ? readonly DeepReadonly<R>[]
@@ -61,6 +62,7 @@ export const dataRepair = (
   data: DeepReadonly<AppDataComplete>,
   errors: IValidation.IError[] = [],
 ): DataRepairResult => {
+  // cast only to satisfy the signature — isDataRepairPossible is a read-only check
   if (!isDataRepairPossible(data as AppDataComplete)) {
     throw new Error('Data repair attempted but not possible');
   }

--- a/src/app/op-log/validation/data-repair.ts
+++ b/src/app/op-log/validation/data-repair.ts
@@ -60,13 +60,14 @@ export const dataRepair = (
     typeErrorsFixed: 0,
   };
 
-  // NOTE deep copy is important to prevent readonly errors from frozen NgRx state
-  // We detect if the state is frozen and only deep clone in that case for performance
-  const isFrozen =
-    Object.isFrozen(data) ||
-    (data.task && Object.isFrozen(data.task)) ||
-    (data.project && Object.isFrozen(data.project));
-  let dataOut: AppDataComplete = isFrozen ? structuredClone(data) : { ...data };
+  // Deep clone before any repair runs. The fixers below mutate nested entities
+  // in place (e.g. `t.tagIds = []`, `cfg[day] = false`, `Object.assign` onto
+  // feature states), and production builds disable NgRx runtime freezing (see
+  // `src/main.ts`) — so the input here is a live, writable store reference. A
+  // shallow `{ ...data }` shares every nested object, letting repair corrupt
+  // store-owned state before `loadAllData` is dispatched (#8333). Repair only
+  // runs after a (rare) validation failure, so the unconditional clone is cheap.
+  let dataOut: AppDataComplete = structuredClone(data);
 
   // Ensure archive structures exist
   if (!dataOut.archiveYoung) {


### PR DESCRIPTION
## Summary

Fixes #8333. `dataRepair()` deep-cloned its input only when it detected a *frozen* state, otherwise taking a shallow `{ ...data }`. NgRx runtime freezing is **off in production** (`src/main.ts`), and the repair entry path passes **live store references** (`project`/`tag`/`taskRepeatCfg` directly; the `task` slice shares its `entities`). The repair fixers mutate nested entities in place (`t.tagIds = []`, `cfg[day] = false`, `Object.assign` onto feature states, …), so in production repair corrupted store-owned objects **before** `loadAllData` was dispatched — memoized selectors didn't recompute (same refs) and any throw between mutation and dispatch left the store silently corrupted with no op-log capture.

## Fix

- **Unconditional `structuredClone(data)`** in `dataRepair()`. Repair only runs after a (rare) validation failure, and dev mode already always paid this cost — so the frozen-detection micro-optimization wasn't worth the hazard.
- Doc warning on `StateSnapshotService.getStateSnapshot[Async]()` that it returns **live store references** (the root footgun) and must be cloned before mutation.

## Tests

- New regression test `should not mutate its (non-frozen) input data` — fails on the old shallow-copy code, passes now.
- **14 existing data-repair tests were passing tautologically**: they built their `expected` by spreading the same input-entity references the buggy shallow clone mutated in place, so they couldn't detect the bug. Decoupled them to assert the genuine repaired output.
- This fix does **not** change `dataRepair`'s output — only stops it mutating the input (verified: reverting to the shallow copy leaves 55/56 tests passing).

## Verification

- All 18 repair-path specs green (~580 tests), incl. all three production live-state callers (`conflict-resolution` 132, `remote-ops-processing` 43, `server-migration` 25).
- `tsc` clean on app + spec projects; `checkFile` + `eslint` clean.

## Risk

Low. The repaired output is byte-for-byte unchanged; `structuredClone` was already exercised on this exact data by the prior dev-mode frozen path, so cloneability is proven, and a throw on hypothetical non-cloneable corrupted state is caught gracefully by `validateAndRepair`.
