### PR TITLE
fix(config): treat Meta and OS keys as modifier keys during recording

### DIFF
--- a/src/app/features/config/keyboard-input/keyboard-input.component.spec.ts
+++ b/src/app/features/config/keyboard-input/keyboard-input.component.spec.ts
@@ -50,4 +50,34 @@ describe('KeyboardInputComponent', () => {
     component.onKeyDown(createKeydown('Delete', { shiftKey: true }));
     expect(component.formControl.value).toBe('Shift+Delete');
   });
+
+  it('ignores modifier keys pressed alone', () => {
+    const component = createComponent('Meta+N');
+
+    for (const code of [
+      'ShiftLeft',
+      'ShiftRight',
+      'ControlLeft',
+      'ControlRight',
+      'AltLeft',
+      'AltRight',
+      'MetaLeft',
+      'MetaRight',
+      'OSLeft',
+      'OSRight',
+    ]) {
+      component.onKeyDown(createKeydown(code));
+      expect(component.formControl.value).toBe('Meta+N'); // Value is unchanged
+    }
+  });
+
+  it('correctly registers combinations with Meta/OS modifiers', () => {
+    const component = createComponent(null);
+
+    component.onKeyDown(createKeydown('KeyA', { metaKey: true }));
+    expect(component.formControl.value).toBe('Meta+A');
+
+    component.onKeyDown(createKeydown('KeyB', { metaKey: true, shiftKey: true }));
+    expect(component.formControl.value).toBe('Shift+Meta+B');
+  });
 });

--- a/src/app/features/config/keyboard-input/keyboard-input.component.ts
+++ b/src/app/features/config/keyboard-input/keyboard-input.component.ts
@@ -13,6 +13,10 @@ const MODIFIER_KEY_CODES = [
   'ControlRight',
   'AltLeft',
   'AltRight',
+  'MetaLeft',
+  'MetaRight',
+  'OSLeft',
+  'OSRight',
 ];
 
 const hasModifier = (ev: KeyboardEvent): boolean =>


### PR DESCRIPTION
Tackles #8375

## Problem

When setting global shortcuts, pressing the `Command` (Meta) key on macOS or the `Windows` key on Windows immediately registers the modifier key itself as a completed sequence (e.g., `Meta+MetaLeft` or `Shift+Meta+MetaLeft`). Since a shortcut with only modifier keys is invalid, it instantly throws the error: *"Global Shortcut registration failed: [Shortcut]"*. This makes it difficult to register shortcuts naturally.

Fixes #8375.

## Solution

1. Added `MetaLeft`, `MetaRight`, `OSLeft`, and `OSRight` to the `MODIFIER_KEY_CODES` array in `KeyboardInputComponent`. This treats the Command/Windows keys as modifier keys so that keydown events on them return early without prematurely updating the form control value.
2. Added unit tests to `keyboard-input.component.spec.ts` to verify:
   - Modifier keys (`Shift`, `Ctrl`, `Alt`, `Meta`, `OS`) pressed alone are ignored and do not update the form value.
   - Shortcuts containing the `Meta` modifier combined with other keys (e.g., `Meta+A`, `Shift+Meta+B`) are correctly recorded once the non-modifier key is pressed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
