### PR TITLE
fix(simple-counter): reject negative counter values

### DIFF
--- a/src/app/features/simple-counter/dialog-simple-counter-edit/dialog-simple-counter-edit.component.html
+++ b/src/app/features/simple-counter/dialog-simple-counter-edit/dialog-simple-counter-edit.component.html
@@ -73,8 +73,10 @@
           <mat-form-field>
             <mat-label>{{ T.F.SIMPLE_COUNTER.D_EDIT.L_COUNTER | translate }}</mat-label>
             <input
+              #countInput
               matInput
               type="number"
+              min="0"
               name="count"
               [ngModel]="selectedValue()"
               (ngModelChange)="updateValue($event)"

--- a/src/app/features/simple-counter/dialog-simple-counter-edit/dialog-simple-counter-edit.component.ts
+++ b/src/app/features/simple-counter/dialog-simple-counter-edit/dialog-simple-counter-edit.component.ts
@@ -2,8 +2,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  ElementRef,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import {
   MAT_DIALOG_DATA,
@@ -87,6 +89,8 @@ export class DialogSimpleCounterEditComponent {
     'streakWeeklyFrequency',
     'countdownDuration',
   ];
+
+  readonly countInput = viewChild<ElementRef<HTMLInputElement>>('countInput');
 
   // State
   readonly localCounter = signal<SimpleCounterCopy>({
@@ -188,11 +192,21 @@ export class DialogSimpleCounterEditComponent {
 
   updateValue(value: number): void {
     const date = this.selectedDateStr();
+    // counts and durations can never be negative; clamp invalid/empty input to 0
+    const safeValue = Math.max(0, value || 0);
+    // A type="number" field still accepts typed/pasted negatives, and the
+    // one-way [ngModel] binding won't repaint the field when the clamped value
+    // equals the previously bound value (e.g. editing from 0) — so reset the
+    // element directly to reject a negative visibly.
+    const inputEl = this.countInput()?.nativeElement;
+    if (inputEl && value < 0) {
+      inputEl.value = String(safeValue);
+    }
     this.localCounter.update((counter) => ({
       ...counter,
       countOnDay: {
         ...counter.countOnDay,
-        [date]: value,
+        [date]: safeValue,
       },
     }));
   }

--- a/src/app/features/simple-counter/store/simple-counter.reducer.spec.ts
+++ b/src/app/features/simple-counter/store/simple-counter.reducer.spec.ts
@@ -264,6 +264,45 @@ describe('SimpleCounterReducer', () => {
         expect(result.entities['counter1']!.countOnDay['2024-01-14']).toBe(5);
         expect(result.entities['counter1']!.countOnDay['2024-01-15']).toBe(10);
       });
+
+      it('should clamp negative values to 0', () => {
+        const counter = createCounter('counter1', { countOnDay: {} });
+        const existingState = createStateWithCounters([counter]);
+
+        const action = SimpleCounterActions.setSimpleCounterCounterToday({
+          id: 'counter1',
+          newVal: -5,
+          today: '2024-01-15',
+        });
+        const result = simpleCounterReducer(existingState, action);
+
+        expect(result.entities['counter1']!.countOnDay['2024-01-15']).toBe(0);
+      });
+
+      it('should leave 0 and positive values unchanged', () => {
+        const counter = createCounter('counter1', { countOnDay: {} });
+        const existingState = createStateWithCounters([counter]);
+
+        const zeroResult = simpleCounterReducer(
+          existingState,
+          SimpleCounterActions.setSimpleCounterCounterToday({
+            id: 'counter1',
+            newVal: 0,
+            today: '2024-01-15',
+          }),
+        );
+        expect(zeroResult.entities['counter1']!.countOnDay['2024-01-15']).toBe(0);
+
+        const posResult = simpleCounterReducer(
+          existingState,
+          SimpleCounterActions.setSimpleCounterCounterToday({
+            id: 'counter1',
+            newVal: 42,
+            today: '2024-01-15',
+          }),
+        );
+        expect(posResult.entities['counter1']!.countOnDay['2024-01-15']).toBe(42);
+      });
     });
 
     describe('setSimpleCounterCounterForDate', () => {
@@ -279,6 +318,20 @@ describe('SimpleCounterReducer', () => {
         const result = simpleCounterReducer(existingState, action);
 
         expect(result.entities['counter1']!.countOnDay['2024-01-10']).toBe(7);
+      });
+
+      it('should clamp negative values to 0', () => {
+        const counter = createCounter('counter1', { countOnDay: {} });
+        const existingState = createStateWithCounters([counter]);
+
+        const action = SimpleCounterActions.setSimpleCounterCounterForDate({
+          id: 'counter1',
+          date: '2024-01-10',
+          newVal: -7,
+        });
+        const result = simpleCounterReducer(existingState, action);
+
+        expect(result.entities['counter1']!.countOnDay['2024-01-10']).toBe(0);
       });
     });
   });

--- a/src/app/features/simple-counter/store/simple-counter.reducer.ts
+++ b/src/app/features/simple-counter/store/simple-counter.reducer.ts
@@ -154,7 +154,8 @@ const _reducer = createReducer<SimpleCounterState>(
         changes: {
           countOnDay: {
             ...entity.countOnDay,
-            [today]: newVal,
+            // counts and durations can never be negative
+            [today]: Math.max(0, newVal),
           },
         },
       },
@@ -173,7 +174,8 @@ const _reducer = createReducer<SimpleCounterState>(
         changes: {
           countOnDay: {
             ...entity.countOnDay,
-            [date]: newVal,
+            // counts and durations can never be negative
+            [date]: Math.max(0, newVal),
           },
         },
       },


### PR DESCRIPTION
## What

Reject negative values in habit (simple) counters. The counter **edit dialog** accepted negative numbers with no validation.

Resolves discussion #8288.

## Why

Counter values are meant to be non-negative — this is already enforced everywhere else:
- the decrement reducer (`decreaseSimpleCounterCounterToday`) clamps with `Math.max(0, …)`
- the plugin bridge API (`setCounter` / `setCounterForDate`) rejects `value < 0`

The edit dialog was the one entry point missing the guard, so a user could type/paste a negative and persist it.

## How

- **Data layer:** clamp `setSimpleCounterCounterToday` and `setSimpleCounterCounterForDate` to `Math.max(0, newVal)`, so the non-negative invariant holds for every entry point. The clamp is pure and deterministic (same result on local dispatch and remote replay) and a no-op for all valid `>= 0` data, so it is sync-/replay-safe and cannot diverge state between clients.
- **Dialog UX:** clamp the input value and reset the field on a typed/pasted negative so it is visibly rejected. (`min="0"` alone does not block keyboard entry on `type="number"`, and the one-way `[ngModel]` binding won't repaint when the clamp lands on the previously bound value, e.g. editing from 0.)

## Testing

- `simple-counter.reducer.spec.ts`: new tests assert both set-count actions clamp negatives to 0 and leave 0/positive values unchanged — **70/70 pass**.
- `simple-counter.service.spec.ts`: **30/30 pass** (increase/decrease/set flows unaffected).
- `npm run checkFile` clean on changed `.ts`; prettier clean on the template.
