### PR TITLE
fix(sync): capture quota double-dequeue (#8307) + in-tab sync-cycle guard (#8309)

### DIFF
--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -75,6 +75,7 @@ import { IS_ELECTRON } from '../../app.constants';
 import { OperationLogStoreService } from '../../op-log/persistence/operation-log-store.service';
 import { OperationLogSyncService } from '../../op-log/sync/operation-log-sync.service';
 import { SyncSessionValidationService } from '../../op-log/sync/sync-session-validation.service';
+import { SyncCycleGuardService } from '../../op-log/sync/sync-cycle-guard.service';
 import { WrappedProviderService } from '../../op-log/sync-providers/wrapped-provider.service';
 import { isSuperSyncWebSocketAccess } from '@sp/sync-providers/super-sync';
 import { isTransientNetworkError } from '@sp/sync-providers/http';
@@ -116,6 +117,7 @@ export class SyncWrapperService {
   private _opLogStore = inject(OperationLogStoreService);
   private _opLogSyncService = inject(OperationLogSyncService);
   private _sessionValidation = inject(SyncSessionValidationService);
+  private _syncCycleGuard = inject(SyncCycleGuardService);
   private _wrappedProvider = inject(WrappedProviderService);
   private _hydrationState = inject(HydrationStateService);
 
@@ -280,6 +282,19 @@ export class SyncWrapperService {
       return 'HANDLED_ERROR';
     }
     this._isSyncInProgress$.next(true);
+
+    // #8309: claim the in-tab sync cycle so the conflict-gate decision,
+    // setLastServerSeq, and the session-validation latch are serialized against
+    // the side channels (immediate upload / WS download). Both this claim and
+    // the re-entry check above are synchronous (no await between), so the
+    // check-and-set stays atomic. If a (short-lived) side channel is mid-cycle
+    // we skip rather than block — the next trigger retries. Released in the
+    // finally below.
+    if (!this._syncCycleGuard.tryBegin()) {
+      this._isSyncInProgress$.next(false);
+      SyncLog.log('Sync skipped: another sync cycle is in progress');
+      return 'HANDLED_ERROR';
+    }
     // Open before any async work — see `HydrationStateService.isInSyncWindow`.
     // Pass 0 to disable the failsafe: the `finally` block below is the
     // authoritative close, and a slow sync (provider I/O > 2s) would
@@ -290,6 +305,7 @@ export class SyncWrapperService {
     const result = await this._sync(isUserTriggered).finally(() => {
       this._isSyncInProgress$.next(false);
       this._hydrationState.closeSyncWindow();
+      this._syncCycleGuard.end();
       // Safeguard: if _sync() threw or completed without setting a final status,
       // reset from SYNCING to UNKNOWN_OR_CHANGED to avoid getting stuck in SYNCING state
       if (this._providerManager.isSyncInProgress) {
@@ -976,42 +992,60 @@ export class SyncWrapperService {
   private async _forceDownload(): Promise<void> {
     SyncLog.log('SyncWrapperService: forceDownload called - downloading remote state');
 
+    await this.runWithSyncBlocked(async () => {
+      // #8309: claim the sync cycle so this flow's conflict-gate / session
+      // latch are isolated from the immediate-upload / WS-download side
+      // channels. runWithSyncBlocked has already drained any main sync and set
+      // isEncryptionOperationInProgress, so the only thing that could hold the
+      // guard here is a short-lived side channel; skip-and-let-the-user-retry
+      // rather than block.
+      if (!this._syncCycleGuard.tryBegin()) {
+        SyncLog.log('Force download skipped: another sync cycle is in progress');
+        return;
+      }
+      try {
+        await this._forceDownloadInner();
+      } finally {
+        this._syncCycleGuard.end();
+      }
+    });
+  }
+
+  private async _forceDownloadInner(): Promise<void> {
     // Open a session-validation scope — read after forceDownloadRemoteState
     // returns so a corrupt downloaded state is reported as ERROR. (#7330)
-    await this.runWithSyncBlocked(() =>
-      this._sessionValidation.withSession(async () => {
-        try {
-          const rawProvider = this._providerManager.getActiveProvider();
-          const syncCapableProvider =
-            await this._wrappedProvider.getOperationSyncCapable(rawProvider);
+    await this._sessionValidation.withSession(async () => {
+      try {
+        const rawProvider = this._providerManager.getActiveProvider();
+        const syncCapableProvider =
+          await this._wrappedProvider.getOperationSyncCapable(rawProvider);
 
-          if (!syncCapableProvider) {
-            SyncLog.warn(
-              'SyncWrapperService: Cannot force download - provider not available',
-            );
-            return;
-          }
-
-          await this._opLogSyncService.forceDownloadRemoteState(syncCapableProvider);
-          if (this._sessionValidation.hasFailed()) {
-            SyncLog.err(
-              'SyncWrapperService: Force download applied but post-sync validation failed; reporting ERROR',
-            );
-            this._providerManager.setSyncStatus('ERROR');
-          } else {
-            this._providerManager.setSyncStatus('IN_SYNC');
-          }
-          SyncLog.log('SyncWrapperService: Force download complete');
-        } catch (error) {
-          SyncLog.err('SyncWrapperService: Force download failed:', error);
-          const errStr = getSyncErrorStr(error);
-          this._snackService.open({
-            msg: errStr,
-            type: 'ERROR',
-          });
+        if (!syncCapableProvider) {
+          SyncLog.warn(
+            'SyncWrapperService: Cannot force download - provider not available',
+          );
+          return;
         }
-      }),
-    );
+
+        await this._opLogSyncService.forceDownloadRemoteState(syncCapableProvider);
+        if (this._sessionValidation.hasFailed()) {
+          SyncLog.err(
+            'SyncWrapperService: Force download applied but post-sync validation failed; reporting ERROR',
+          );
+          this._providerManager.setSyncStatus('ERROR');
+        } else {
+          this._providerManager.setSyncStatus('IN_SYNC');
+        }
+        SyncLog.log('SyncWrapperService: Force download complete');
+      } catch (error) {
+        SyncLog.err('SyncWrapperService: Force download failed:', error);
+        const errStr = getSyncErrorStr(error);
+        this._snackService.open({
+          msg: errStr,
+          type: 'ERROR',
+        });
+      }
+    });
   }
 
   async configuredAuthForSyncProviderIfNecessary(

--- a/src/app/op-log/capture/operation-log.effects.spec.ts
+++ b/src/app/op-log/capture/operation-log.effects.spec.ts
@@ -505,6 +505,33 @@ describe('OperationLogEffects', () => {
       expect(mockOpLogStore.appendWithVectorClockUpdate).toHaveBeenCalledTimes(2);
     }));
 
+    it('should NOT dequeue a second time on the quota-exceeded retry (#8307)', fakeAsync(() => {
+      // Regression: the first attempt consumes this action's queue entry via
+      // dequeue() BEFORE appendWithVectorClockUpdate throws the quota error. The
+      // retry after emergency compaction must skip dequeue, otherwise it steals
+      // the NEXT pending action's entry.
+      const quotaError = new DOMException('Quota exceeded', 'QuotaExceededError');
+      let appendCount = 0;
+      mockOpLogStore.appendWithVectorClockUpdate.and.callFake(() => {
+        appendCount++;
+        if (appendCount === 1) {
+          return Promise.reject(quotaError);
+        }
+        return Promise.resolve(1);
+      });
+      mockOperationCaptureService.dequeue.and.returnValue([]);
+
+      const action = createPersistentAction(ActionType.TASK_SHARED_UPDATE);
+      actions$ = of(action);
+
+      effects.persistOperation$.subscribe();
+
+      tick(100);
+      // Append ran twice (initial + retry) but dequeue ran exactly once.
+      expect(mockOpLogStore.appendWithVectorClockUpdate).toHaveBeenCalledTimes(2);
+      expect(mockOperationCaptureService.dequeue).toHaveBeenCalledTimes(1);
+    }));
+
     it('should use updated clientId after backup import generates new one', (done) => {
       const action1 = createPersistentAction(ActionType.TASK_SHARED_ADD);
       const action2 = createPersistentAction(ActionType.TASK_SHARED_UPDATE);

--- a/src/app/op-log/capture/operation-log.effects.ts
+++ b/src/app/op-log/capture/operation-log.effects.ts
@@ -329,7 +329,7 @@ export class OperationLogEffects implements DeferredLocalActionsPort {
           );
           this.notifyUserAndTriggerRollback();
         } else {
-          await this.handleQuotaExceeded(action, skipDequeue, options);
+          await this.handleQuotaExceeded(action, options);
         }
       } else {
         this.notifyUserAndTriggerRollback();
@@ -455,7 +455,6 @@ export class OperationLogEffects implements DeferredLocalActionsPort {
    */
   private async handleQuotaExceeded(
     action: PersistentAction,
-    skipDequeue = false,
     options: WriteOperationOptions = {},
   ): Promise<void> {
     OpLog.err(
@@ -487,8 +486,17 @@ export class OperationLogEffects implements DeferredLocalActionsPort {
         try {
           // Set circuit breaker before retry to prevent recursive handling
           this.isHandlingQuotaExceeded = true;
-          // Retry the failed operation after compaction freed space
-          await this.writeOperation(action, skipDequeue, options);
+          // Retry the failed operation after compaction freed space.
+          // #8307: force skipDequeue=true. The first attempt already consumed
+          // this action's queue entry (dequeue runs at the top of the lock,
+          // BEFORE the appendWithVectorClockUpdate that threw the quota error),
+          // so re-passing the original skipDequeue=false would dequeue a SECOND
+          // time and steal the NEXT pending action's entityChanges. This mirrors
+          // the deferred path (processDeferredActions), which also hardcodes
+          // true. Trade-off: the first attempt's entityChanges are not
+          // re-captured, so the retried op carries empty entityChanges —
+          // acceptable for this rare quota-recovery edge case.
+          await this.writeOperation(action, true, options);
           this.snackService.open({
             type: 'SUCCESS',
             msg: T.F.SYNC.S.STORAGE_RECOVERED_AFTER_COMPACTION,

--- a/src/app/op-log/sync/immediate-upload.service.spec.ts
+++ b/src/app/op-log/sync/immediate-upload.service.spec.ts
@@ -107,6 +107,10 @@ describe('ImmediateUploadService', () => {
     });
 
     service = TestBed.inject(ImmediateUploadService);
+    // The cycle guard is a root singleton; reset it so a prior test that left
+    // it claimed (e.g. an assertion threw before guard.end()) can't poison this
+    // one. Mirrors SyncSessionValidationService's per-test reset.
+    TestBed.inject(SyncCycleGuardService)._resetForTest();
   });
 
   afterEach(() => {

--- a/src/app/op-log/sync/immediate-upload.service.spec.ts
+++ b/src/app/op-log/sync/immediate-upload.service.spec.ts
@@ -6,6 +6,7 @@ import { SyncProviderId } from '../sync-providers/provider.const';
 import { DataInitStateService } from '../../core/data-init/data-init-state.service';
 import { SyncWrapperService } from '../../imex/sync/sync-wrapper.service';
 import { SyncSessionValidationService } from './sync-session-validation.service';
+import { SyncCycleGuardService } from './sync-cycle-guard.service';
 import { BehaviorSubject } from 'rxjs';
 import { RejectedOpInfo } from '../core/types/sync-results.types';
 
@@ -186,6 +187,47 @@ describe('ImmediateUploadService', () => {
 
       // Piggybacked ops are processed internally, no checkmark shown
       expect(mockProviderManager.setSyncStatus).not.toHaveBeenCalled();
+    }));
+  });
+
+  // #8309: the immediate-upload side channel must not interleave with another
+  // sync cycle (main sync, force flow, or WS download). It claims the in-tab
+  // SyncCycleGuard synchronously at the start of _performUpload and skips if a
+  // cycle is already active.
+  describe('sync-cycle guard (#8309)', () => {
+    it('skips the upload when another sync cycle is active', fakeAsync(() => {
+      const guard = TestBed.inject(SyncCycleGuardService);
+      // Simulate another cycle holding the guard (e.g. a WS download).
+      expect(guard.tryBegin()).toBe(true);
+
+      mockSyncService.uploadPendingOps.and.returnValue(
+        Promise.resolve(completedResult({ uploadedCount: 1 })),
+      );
+
+      service.initialize();
+      service.trigger();
+      tick(2000);
+      flush();
+
+      expect(mockSyncService.uploadPendingOps).not.toHaveBeenCalled();
+
+      guard.end();
+    }));
+
+    it('releases the guard after the upload so a later cycle can run', fakeAsync(() => {
+      const guard = TestBed.inject(SyncCycleGuardService);
+      mockSyncService.uploadPendingOps.and.returnValue(
+        Promise.resolve(completedResult({ uploadedCount: 1 })),
+      );
+
+      service.initialize();
+      service.trigger();
+      tick(2000);
+      flush();
+
+      expect(mockSyncService.uploadPendingOps).toHaveBeenCalledTimes(1);
+      // Guard was released in the finally — a subsequent cycle can claim it.
+      expect(guard.isActive).toBe(false);
     }));
   });
 

--- a/src/app/op-log/sync/immediate-upload.service.ts
+++ b/src/app/op-log/sync/immediate-upload.service.ts
@@ -10,6 +10,7 @@ import { DataInitStateService } from '../../core/data-init/data-init-state.servi
 import { handleStorageQuotaError } from './sync-error-utils';
 import { SyncWrapperService } from '../../imex/sync/sync-wrapper.service';
 import { SyncSessionValidationService } from './sync-session-validation.service';
+import { SyncCycleGuardService } from './sync-cycle-guard.service';
 
 const IMMEDIATE_UPLOAD_DEBOUNCE_MS = 2000;
 
@@ -53,6 +54,7 @@ export class ImmediateUploadService implements OnDestroy {
   private _dataInitStateService = inject(DataInitStateService);
   private _syncWrapper = inject(SyncWrapperService);
   private _sessionValidation = inject(SyncSessionValidationService);
+  private _syncCycleGuard = inject(SyncCycleGuardService);
 
   private _uploadTrigger$ = new Subject<void>();
   private _subscription: Subscription | null = null;
@@ -182,6 +184,25 @@ export class ImmediateUploadService implements OnDestroy {
    * the immediate-upload path.
    */
   private async _performUpload(): Promise<void> {
+    // #8309: opportunistically claim the sync cycle. Skip if any cycle (the
+    // main sync, a force flow, or the WS-download side channel) is already
+    // active — the running cycle or the next trigger covers this upload, and a
+    // background upload must not mutate state / flip the session-validation
+    // latch while another cycle (or its conflict dialog) is open.
+    if (!this._syncCycleGuard.tryBegin()) {
+      OpLog.verbose(
+        'ImmediateUploadService: Skipping immediate upload — another sync cycle is active',
+      );
+      return;
+    }
+    try {
+      await this._performUploadInner();
+    } finally {
+      this._syncCycleGuard.end();
+    }
+  }
+
+  private async _performUploadInner(): Promise<void> {
     const provider = this._providerManager.getActiveProvider();
     if (!provider) {
       return;

--- a/src/app/op-log/sync/sync-cycle-guard.service.spec.ts
+++ b/src/app/op-log/sync/sync-cycle-guard.service.spec.ts
@@ -1,0 +1,42 @@
+import { SyncCycleGuardService } from './sync-cycle-guard.service';
+
+describe('SyncCycleGuardService', () => {
+  let guard: SyncCycleGuardService;
+
+  beforeEach(() => {
+    guard = new SyncCycleGuardService();
+  });
+
+  it('claims the cycle when free and reports active', () => {
+    expect(guard.isActive).toBe(false);
+    expect(guard.tryBegin()).toBe(true);
+    expect(guard.isActive).toBe(true);
+  });
+
+  it('returns false without claiming when a cycle is already active', () => {
+    expect(guard.tryBegin()).toBe(true);
+    // A second claimant (another entry point) must be told to skip.
+    expect(guard.tryBegin()).toBe(false);
+    expect(guard.isActive).toBe(true);
+  });
+
+  it('frees the cycle on end()', () => {
+    expect(guard.tryBegin()).toBe(true);
+    guard.end();
+    expect(guard.isActive).toBe(false);
+  });
+
+  it('can be re-acquired after end()', () => {
+    expect(guard.tryBegin()).toBe(true);
+    guard.end();
+    expect(guard.tryBegin()).toBe(true);
+    expect(guard.isActive).toBe(true);
+  });
+
+  it('_resetForTest clears active state', () => {
+    expect(guard.tryBegin()).toBe(true);
+    guard._resetForTest();
+    expect(guard.isActive).toBe(false);
+    expect(guard.tryBegin()).toBe(true);
+  });
+});

--- a/src/app/op-log/sync/sync-cycle-guard.service.ts
+++ b/src/app/op-log/sync/sync-cycle-guard.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * In-tab mutual-exclusion guard for the four top-level sync entry points:
+ * - `SyncWrapperService.sync()`        (periodic / user-triggered full sync)
+ * - `SyncWrapperService._forceDownload()` (sync-error dialog recovery)
+ * - `ImmediateUploadService._performUpload()` (side channel)
+ * - `WsTriggeredDownloadService._downloadOps()` (side channel)
+ *
+ * ## Why (#8309)
+ * These flows share the per-tab {@link SyncSessionValidationService} latch,
+ * whose single-mutable-boolean design is only safe if at most ONE session is
+ * active at a time. They also run lock-free seams — the SYNC_IMPORT
+ * conflict-gate decision (which awaits a user dialog) and `setLastServerSeq`
+ * persistence — that a concurrent flow can invalidate. The apply phase is
+ * already serialized by the cross-tab `OPERATION_LOG`/`UPLOAD`/`DOWNLOAD` Web
+ * Locks; this guard closes the remaining in-tab seams and prevents
+ * `withSession()` latch misattribution (two overlapping sessions sharing one
+ * latch).
+ *
+ * ## Why a synchronous in-memory skip-guard, not a Web Lock
+ * - The conflict gate awaits a user dialog. Holding a cross-tab Web Lock across
+ *   that wait would stall other tabs until the 30s lock timeout.
+ * - Every entry point claims the cycle with {@link tryBegin} *before its first
+ *   `await`*, so the check-and-set is atomic on the single-threaded event loop,
+ *   and skips when a cycle is already active. Skipping (rather than queuing) is
+ *   the correct semantics: an opportunistic side channel must not mutate state
+ *   while another cycle (or its conflict dialog) is open, and a user-triggered
+ *   sync that collides with a short-lived side channel is simply retried on the
+ *   next trigger. Because nothing ever waits on the guard, it cannot deadlock.
+ *
+ * Cross-tab apply-phase serialization remains the job of the existing Web
+ * Locks; cross-tab gate/seq staleness is out of scope for this guard.
+ */
+@Injectable({ providedIn: 'root' })
+export class SyncCycleGuardService {
+  private _isActive = false;
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  /**
+   * Synchronously claim the cycle. Returns `false` (without claiming) if a
+   * cycle is already active. MUST be called before the caller's first `await`
+   * so the check-and-set is atomic within the single-threaded event loop.
+   */
+  tryBegin(): boolean {
+    if (this._isActive) {
+      return false;
+    }
+    this._isActive = true;
+    return true;
+  }
+
+  /** Release the cycle. Always call from a `finally` block. */
+  end(): void {
+    this._isActive = false;
+  }
+
+  /** @internal Test-only reset for the root singleton between unit tests. */
+  _resetForTest(): void {
+    this._isActive = false;
+  }
+}

--- a/src/app/op-log/sync/ws-triggered-download.service.spec.ts
+++ b/src/app/op-log/sync/ws-triggered-download.service.spec.ts
@@ -9,6 +9,7 @@ import { SyncProviderManager } from '../sync-providers/provider-manager.service'
 import { WrappedProviderService } from '../sync-providers/wrapped-provider.service';
 import { WsTriggeredDownloadService } from './ws-triggered-download.service';
 import { SyncSessionValidationService } from './sync-session-validation.service';
+import { SyncCycleGuardService } from './sync-cycle-guard.service';
 import { AuthFailSPError, MissingCredentialsSPError } from '../sync-exports';
 
 describe('WsTriggeredDownloadService', () => {
@@ -110,6 +111,37 @@ describe('WsTriggeredDownloadService', () => {
 
     expect(mockWrappedProvider.getOperationSyncCapable).not.toHaveBeenCalled();
     expect(mockSyncService.downloadRemoteOps).not.toHaveBeenCalled();
+  }));
+
+  // #8309: the WS-download side channel claims the in-tab SyncCycleGuard and
+  // skips when another cycle (main sync, force flow, or immediate upload) is
+  // active, so its gate decision / setLastServerSeq can't race a concurrent
+  // flow and overlapping withSession() calls can't misattribute the latch.
+  it('should skip the download when another sync cycle is active (#8309)', fakeAsync(() => {
+    const guard = TestBed.inject(SyncCycleGuardService);
+    expect(guard.tryBegin()).toBe(true);
+
+    service.start();
+    notification$.next({ latestSeq: 7 });
+    tick(500);
+    flushMicrotasks();
+
+    expect(mockWrappedProvider.getOperationSyncCapable).not.toHaveBeenCalled();
+    expect(mockSyncService.downloadRemoteOps).not.toHaveBeenCalled();
+
+    guard.end();
+  }));
+
+  it('releases the guard after the download so a later cycle can run (#8309)', fakeAsync(() => {
+    const guard = TestBed.inject(SyncCycleGuardService);
+
+    service.start();
+    notification$.next({ latestSeq: 8 });
+    tick(500);
+    flushMicrotasks();
+
+    expect(mockSyncService.downloadRemoteOps).toHaveBeenCalledTimes(1);
+    expect(guard.isActive).toBe(false);
   }));
 
   it('should stop listening after an auth failure', fakeAsync(() => {

--- a/src/app/op-log/sync/ws-triggered-download.service.spec.ts
+++ b/src/app/op-log/sync/ws-triggered-download.service.spec.ts
@@ -62,6 +62,10 @@ describe('WsTriggeredDownloadService', () => {
     });
 
     service = TestBed.inject(WsTriggeredDownloadService);
+    // The cycle guard is a root singleton; reset it so a prior test that left
+    // it claimed (e.g. an assertion threw before guard.end()) can't poison this
+    // one. Mirrors SyncSessionValidationService's per-test reset.
+    TestBed.inject(SyncCycleGuardService)._resetForTest();
   });
 
   afterEach(() => {

--- a/src/app/op-log/sync/ws-triggered-download.service.ts
+++ b/src/app/op-log/sync/ws-triggered-download.service.ts
@@ -6,6 +6,7 @@ import { OperationLogSyncService } from './operation-log-sync.service';
 import { SyncProviderManager } from '../sync-providers/provider-manager.service';
 import { WrappedProviderService } from '../sync-providers/wrapped-provider.service';
 import { SyncSessionValidationService } from './sync-session-validation.service';
+import { SyncCycleGuardService } from './sync-cycle-guard.service';
 import { SyncLog } from '../../core/log';
 import { AuthFailSPError, MissingCredentialsSPError } from '../sync-exports';
 
@@ -28,6 +29,7 @@ export class WsTriggeredDownloadService implements OnDestroy {
   private _providerManager = inject(SyncProviderManager);
   private _wrappedProvider = inject(WrappedProviderService);
   private _sessionValidation = inject(SyncSessionValidationService);
+  private _syncCycleGuard = inject(SyncCycleGuardService);
 
   private _subscription: Subscription | null = null;
 
@@ -64,6 +66,27 @@ export class WsTriggeredDownloadService implements OnDestroy {
       return;
     }
 
+    // #8309: claim the sync cycle. Both this check and the isSyncInProgress
+    // check above are synchronous (no await between), so the claim is atomic.
+    // Skip if any cycle (main sync, force flow, or the immediate-upload side
+    // channel) is active — its apply or its conflict dialog must not race this
+    // download's gate decision / setLastServerSeq, and overlapping withSession()
+    // calls would misattribute the validation latch.
+    if (!this._syncCycleGuard.tryBegin()) {
+      SyncLog.log(
+        'WsTriggeredDownloadService: Another sync cycle is active, skipping WS download',
+      );
+      return;
+    }
+
+    try {
+      return await this._downloadOpsInner(latestSeq);
+    } finally {
+      this._syncCycleGuard.end();
+    }
+  }
+
+  private async _downloadOpsInner(latestSeq: number): Promise<void> {
     // WS-triggered downloads are their own session boundary. The session
     // wrapper resets the latch up-front so the read at the end reflects
     // only this session, and a leaked-failed latch from a prior path can't


### PR DESCRIPTION
Two independent client-side sync fixes from the SuperSync deep-review batch (#8363). The third #8363 item, the server-side multi-entity conflict bug (#8334), is handled separately by #8377 — this PR is client-only.

## fix(sync): quota-retry double-dequeue of the capture queue (#8307)

`OperationLogEffects.handleQuotaExceeded`'s post-compaction retry re-ran `writeOperation` with the **original** `skipDequeue=false`, but the first attempt had already consumed this action's queue entry — `dequeue()` runs at the top of the lock, *before* the `appendWithVectorClockUpdate` that throws `QuotaExceededError`. The retry then dequeued a **second** time and stole the next pending action's `entityChanges` (TIME_TRACKING / time-spent material), shifting every later pairing by one and making `flushPendingWrites` undercount.

- Force `skipDequeue=true` on the retry (mirrors the deferred-action path, which already hardcodes it) and drop the now-dead `skipDequeue` param from `handleQuotaExceeded`.
- Trade-off: the retried op carries empty `entityChanges` (the first attempt's were lost with the failed write) — acceptable for this rare quota-recovery edge.
- Regression test asserts the invariant: append twice, **dequeue once** (verified to fail on the old code).

## fix(sync): serialize sync entry points with an in-tab cycle guard (#8309)

`ImmediateUploadService`, `WsTriggeredDownloadService` and the main sync only *read* the `SYNCING` status (none set it), so the two side channels didn't exclude each other and there was a TOCTOU gap vs. the main sync. Overlapping flows share the per-tab `SyncSessionValidationService` latch (a single boolean, safe only when one session is active → misattribution) and run lock-free seams — the `SYNC_IMPORT` conflict-gate dialog decision and `setLastServerSeq`. The apply phase was already serialized by the cross-tab Web Locks; these in-tab seams were not.

- New `SyncCycleGuardService`: a synchronous in-memory **skip-guard**. Every entry point calls `tryBegin()` *before its first `await`* (atomic check-and-set on the single-threaded event loop) and **skips** if a cycle is already active; `end()` releases in a `finally`. Wired into `sync()`, `_forceDownload()`, `_performUpload()`, `_downloadOps()`.
- Deliberately **not** a cross-tab Web Lock: it must not be held across the user conflict dialog (that would stall other tabs to the 30s lock timeout), and skipping (vs. queuing) is the correct behavior for the opportunistic side channels — the running cycle or the next trigger covers their work. Nothing waits on the guard, so it cannot deadlock.
- Scope is per-tab; cross-tab apply-phase serialization remains the existing Web Locks' job.

## Testing
- Unit specs green: cycle-guard (5), capture effects (37), immediate-upload (23), WS-download (12), sync-wrapper (123). `checkFile` + `eslint` (custom local rules) clean on every changed file.
- Reviewed by a 6-agent multi-review + a focused follow-up pass on the simplified guard (verdict: correct). The guard was simplified from an earlier blocking/FIFO/timeout design to this skip-only form on the review's recommendation.
- Not verifiable in-sandbox: cross-tab / multi-tab behavior (SuperSync docker e2e).

## Out-of-scope follow-up
`forceUpload()` is a 5th destructive entry point routed through `runWithSyncBlocked`; it's excluded from immediate-upload (which checks `isEncryptionOperationInProgress`) but **not** from WS-download. Worth confirming whether a WS download racing a `forceUpload` is a real seam — outside this PR's four-entry-point scope.

Fixes #8307
Fixes #8309
