### PR TITLE
fix(sync): replay all entityIds on multi-entity DELETE (#8340)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3431,6 +3431,13 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.2.tgz",
+      "integrity": "sha512-y6ySdFE7FQB7BkVaSNaPINgY7mXCyvi+3GQB5ySX9WGwgrdh31WXMP5RM40oAyYff47lIr7xdcW8UbCW5NHDmw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -27890,6 +27897,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.5.2",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.0.0",

--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -51,6 +51,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.2",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.0.0",

--- a/packages/super-sync-server/src/sync/op-replay.ts
+++ b/packages/super-sync-server/src/sync/op-replay.ts
@@ -93,6 +93,10 @@ export type ReplayOperationRow = {
   opType: string;
   entityType: string;
   entityId: string | null;
+  // Full entity set for multi-entity (batch) ops; empty for single-entity and
+  // pre-migration rows, which fall back to the scalar entityId. Optional so the
+  // many manually-built test rows don't need it (#8340).
+  entityIds?: string[];
   payload: unknown;
   schemaVersion: number;
   isPayloadEncrypted: boolean;
@@ -269,11 +273,26 @@ export const replayOpsToState = (
             };
           }
           break;
-        case 'DEL':
-          if (processEntityId) {
-            delete state[processEntityType][processEntityId];
+        case 'DEL': {
+          // A batch delete (deleteTasks) stores its full set in entityIds and
+          // sets the scalar entityId to entityIds[0]. Delete every member, not
+          // just the scalar — otherwise entities 2..n survive in restore
+          // snapshots and feed back to clients (#8340). Single-entity and
+          // pre-migration ops have an empty/absent array and fall back to the
+          // scalar. (Migration never splits multi-entity ops, so reading the
+          // row's entityIds here is equivalent to the per-op scalar.)
+          const idsToDelete = row.entityIds?.length
+            ? row.entityIds
+            : processEntityId
+              ? [processEntityId]
+              : [];
+          for (const delId of idsToDelete) {
+            // Same prototype-pollution guard as the scalar entityId path.
+            if (isUnsafeEntityKey(delId)) continue;
+            delete state[processEntityType][delId];
           }
           break;
+        }
         case 'MOV':
           if (processEntityId && processPayload) {
             state[processEntityType][processEntityId] = {

--- a/packages/super-sync-server/src/sync/services/snapshot-generation.service.ts
+++ b/packages/super-sync-server/src/sync/services/snapshot-generation.service.ts
@@ -40,6 +40,9 @@ const REPLAY_OPERATION_SELECT = {
   opType: true,
   entityType: true,
   entityId: true,
+  // Multi-entity batch deletes must replay against the full set, not just the
+  // scalar entityId, or entities 2..n survive in restore snapshots (#8340).
+  entityIds: true,
   payload: true,
   schemaVersion: true,
   isPayloadEncrypted: true,

--- a/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
+++ b/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+
+/**
+ * Real-Postgres regression for #8334's multi-entity conflict-detection SQL.
+ *
+ * The mock-based specs (issue-8334-detect-conflict.spec.ts, conflict-detection.spec.ts)
+ * reproduce the Prisma filter semantics by hand and can NOT catch a bug in the raw
+ * `unnest(CASE ...)` SQL that detectConflictForEntities / prefetchLatestEntityOpsForBatch
+ * actually send to Postgres. This spec runs that SQL against an in-process Postgres
+ * (PGlite — no Docker, no DATABASE_URL) so it runs in the normal `npm test` CI job.
+ *
+ * The SQL below is copied verbatim from packages/super-sync-server/src/sync/conflict.ts
+ * (only the Prisma.sql `${}` interpolations are rewritten as `$n` placeholders). If you
+ * change the query shape there, update it here — the two are intentionally kept in sync
+ * by hand (the source keeps the SQL inline so the conflict-detection.spec mock's
+ * positional params stay stable).
+ */
+describe('#8334 multi-entity conflict SQL (PGlite)', () => {
+  let db: PGlite;
+
+  // Mirrors the two migrations: the entity_ids text[] column + the GIN index, plus
+  // the pre-existing btree that the scalar fallback relies on. Building the GIN index
+  // here also proves `USING GIN (entity_ids)` is valid DDL on real Postgres.
+  const createSchema = async (): Promise<void> => {
+    await db.exec(`
+      CREATE TABLE operations (
+        id          text PRIMARY KEY,
+        user_id     integer NOT NULL,
+        client_id   text NOT NULL,
+        server_seq  bigint NOT NULL,
+        entity_type text NOT NULL,
+        entity_id   text,
+        entity_ids  text[] NOT NULL DEFAULT '{}',
+        vector_clock jsonb NOT NULL
+      );
+      CREATE INDEX operations_entity_ids_gin ON operations USING GIN (entity_ids);
+      CREATE INDEX operations_user_entity_seq
+        ON operations (user_id, entity_type, entity_id, server_seq);
+    `);
+  };
+
+  const insertOp = async (op: {
+    id: string;
+    serverSeq: number;
+    clientId: string;
+    entityType?: string;
+    entityId: string | null;
+    entityIds?: string[];
+    vectorClock?: Record<string, number>;
+  }): Promise<void> => {
+    await db.query(
+      `INSERT INTO operations
+         (id, user_id, client_id, server_seq, entity_type, entity_id, entity_ids, vector_clock)
+       VALUES ($1, 1, $2, $3, $4, $5, $6, $7)`,
+      [
+        op.id,
+        op.clientId,
+        op.serverSeq,
+        op.entityType ?? 'TASK',
+        op.entityId,
+        op.entityIds ?? [],
+        JSON.stringify(op.vectorClock ?? { [op.clientId]: op.serverSeq }),
+      ],
+    );
+  };
+
+  type LatestRow = {
+    entityId: string;
+    clientId: string;
+    serverSeq: number;
+    vectorClock: Record<string, number>;
+  };
+
+  // detectConflictForEntities() — single-entity-type batch lookup.
+  const detectForEntities = async (
+    entityType: string,
+    ids: string[],
+  ): Promise<LatestRow[]> => {
+    const res = await db.query<LatestRow>(
+      `SELECT DISTINCT ON (eid)
+          eid AS "entityId",
+          o.client_id AS "clientId",
+          o.server_seq AS "serverSeq",
+          o.vector_clock AS "vectorClock"
+       FROM operations o
+       CROSS JOIN LATERAL unnest(
+         CASE WHEN cardinality(o.entity_ids) > 0 THEN o.entity_ids ELSE ARRAY[o.entity_id] END
+       ) AS eid
+       WHERE o.user_id = 1
+         AND o.entity_type = $1
+         AND (o.entity_ids && $2::text[] OR o.entity_id = ANY($2::text[]))
+         AND eid = ANY($2::text[])
+       ORDER BY eid, o.server_seq DESC`,
+      [entityType, ids],
+    );
+    return res.rows;
+  };
+
+  // detectConflictForEntity() — single entity, Prisma `OR: [{entityId}, {entityIds:{has}}]`
+  // which Prisma renders as `entity_id = $1 OR entity_ids @> ARRAY[$1]`.
+  const detectForEntity = async (
+    entityType: string,
+    id: string,
+  ): Promise<LatestRow | null> => {
+    const res = await db.query<LatestRow>(
+      `SELECT o.entity_id AS "entityId",
+              o.client_id AS "clientId",
+              o.server_seq AS "serverSeq",
+              o.vector_clock AS "vectorClock"
+       FROM operations o
+       WHERE o.user_id = 1
+         AND o.entity_type = $1
+         AND (o.entity_id = $2 OR o.entity_ids @> ARRAY[$2]::text[])
+       ORDER BY o.server_seq DESC
+       LIMIT 1`,
+      [entityType, id],
+    );
+    return res.rows[0] ?? null;
+  };
+
+  // prefetchLatestEntityOpsForBatch() — multi-entity-TYPE batch via a JOIN over
+  // (entity_type, entity_id) pairs.
+  const prefetchForPairs = async (
+    pairs: Array<{ entityType: string; entityId: string }>,
+  ): Promise<Array<LatestRow & { entityType: string }>> => {
+    const valuesSql = pairs.map((_p, i) => `($${i * 2 + 1}, $${i * 2 + 2})`).join(', ');
+    const idArrayParam = `$${pairs.length * 2 + 1}`;
+    const params: unknown[] = [];
+    for (const p of pairs) {
+      params.push(p.entityType, p.entityId);
+    }
+    params.push(pairs.map((p) => p.entityId));
+    const res = await db.query<LatestRow & { entityType: string }>(
+      `SELECT DISTINCT ON (o.entity_type, eid)
+          o.entity_type AS "entityType",
+          eid AS "entityId",
+          o.client_id AS "clientId",
+          o.server_seq AS "serverSeq",
+          o.vector_clock AS "vectorClock"
+       FROM operations o
+       CROSS JOIN LATERAL unnest(
+         CASE WHEN cardinality(o.entity_ids) > 0 THEN o.entity_ids ELSE ARRAY[o.entity_id] END
+       ) AS eid
+       JOIN (VALUES ${valuesSql}) AS touched(entity_type, entity_id)
+         ON touched.entity_type = o.entity_type
+        AND touched.entity_id = eid
+       WHERE o.user_id = 1
+         AND (o.entity_ids && ${idArrayParam}::text[] OR o.entity_id = ANY(${idArrayParam}::text[]))
+       ORDER BY o.entity_type, eid, o.server_seq DESC`,
+      params,
+    );
+    return res.rows;
+  };
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await db.exec('DROP TABLE IF EXISTS operations');
+    await createSchema();
+  });
+
+  describe('detectConflictForEntities (batch unnest SQL)', () => {
+    it('finds a stored multi-entity op via its NON-FIRST entity (the #8334 bug)', async () => {
+      // op A touches task-1 + task-2; scalar entity_id is task-1.
+      await insertOp({
+        id: 'opA',
+        serverSeq: 1,
+        clientId: 'A',
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+      });
+
+      const rows = await detectForEntities('TASK', ['task-2']);
+
+      // Before the fix, task-2 was invisible (only the scalar task-1 was stored), so a
+      // stale write to task-2 found no prior writer and was wrongly accepted.
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ entityId: 'task-2', clientId: 'A', serverSeq: 1 });
+    });
+
+    it('returns the LATEST op per entity (DISTINCT ON ... ORDER BY server_seq DESC)', async () => {
+      await insertOp({
+        id: 'opA',
+        serverSeq: 1,
+        clientId: 'A',
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+      });
+      // A newer single-entity write to task-1.
+      await insertOp({ id: 'opC', serverSeq: 3, clientId: 'A', entityId: 'task-1' });
+
+      const rows = await detectForEntities('TASK', ['task-1']);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].serverSeq).toBe(3);
+    });
+
+    it('falls back to the scalar entity_id for a pre-migration row (entity_ids = {})', async () => {
+      await insertOp({ id: 'opB', serverSeq: 2, clientId: 'A', entityId: 'task-3' });
+
+      const rows = await detectForEntities('TASK', ['task-3']);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ entityId: 'task-3', serverSeq: 2 });
+    });
+
+    it('does not match an unrelated entity', async () => {
+      await insertOp({
+        id: 'opA',
+        serverSeq: 1,
+        clientId: 'A',
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+      });
+
+      expect(await detectForEntities('TASK', ['task-9'])).toHaveLength(0);
+    });
+
+    it('ignores a full-state op (entity_id NULL, entity_ids {}) without erroring', async () => {
+      // SYNC_IMPORT / BACKUP_IMPORT / REPAIR ops have no entity. The unnest hits the
+      // ARRAY[entity_id] branch with a NULL element — it must yield no match, not throw.
+      await insertOp({ id: 'opFull', serverSeq: 1, clientId: 'A', entityId: null });
+
+      expect(await detectForEntities('TASK', ['task-1'])).toHaveLength(0);
+    });
+
+    it('matches an entity stored only in entity_ids when the scalar differs (dedup-off-scalar)', async () => {
+      // getStoredEntityIds persists [task-A] even though length === 1 because it differs
+      // from the scalar entity_id (task-Z). Without entity_ids, task-A would be invisible.
+      await insertOp({
+        id: 'opD',
+        serverSeq: 1,
+        clientId: 'A',
+        entityId: 'task-Z',
+        entityIds: ['task-A'],
+      });
+
+      const rows = await detectForEntities('TASK', ['task-A']);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].entityId).toBe('task-A');
+    });
+
+    it('resolves every requested id to its own latest op in one batch', async () => {
+      await insertOp({
+        id: 'opA',
+        serverSeq: 1,
+        clientId: 'A',
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+      });
+      await insertOp({ id: 'opB', serverSeq: 2, clientId: 'A', entityId: 'task-3' });
+      await insertOp({ id: 'opC', serverSeq: 3, clientId: 'A', entityId: 'task-1' });
+
+      const rows = await detectForEntities('TASK', ['task-1', 'task-2', 'task-3']);
+      const byEntity = Object.fromEntries(rows.map((r) => [r.entityId, r.serverSeq]));
+
+      expect(byEntity).toEqual({ 'task-1': 3, 'task-2': 1, 'task-3': 2 });
+    });
+  });
+
+  describe('detectConflictForEntity (Prisma OR / entity_ids @> ARRAY[id])', () => {
+    it('finds a multi-entity op via its non-first entity', async () => {
+      await insertOp({
+        id: 'opA',
+        serverSeq: 1,
+        clientId: 'A',
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+      });
+
+      const row = await detectForEntity('TASK', 'task-2');
+
+      expect(row).not.toBeNull();
+      expect(row?.clientId).toBe('A');
+    });
+
+    it('returns null for an unrelated entity', async () => {
+      await insertOp({
+        id: 'opA',
+        serverSeq: 1,
+        clientId: 'A',
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+      });
+
+      expect(await detectForEntity('TASK', 'task-9')).toBeNull();
+    });
+  });
+
+  describe('prefetchLatestEntityOpsForBatch (JOIN-over-pairs unnest SQL)', () => {
+    it('matches each (type,id) pair against the op entity set without crossing types', async () => {
+      await insertOp({
+        id: 'opA',
+        serverSeq: 1,
+        clientId: 'A',
+        entityType: 'TASK',
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+      });
+      // Same id string but a different entity type must NOT match the TASK pair.
+      await insertOp({
+        id: 'opP',
+        serverSeq: 2,
+        clientId: 'A',
+        entityType: 'PROJECT',
+        entityId: 'task-2',
+      });
+
+      const rows = await prefetchForPairs([
+        { entityType: 'TASK', entityId: 'task-2' },
+        { entityType: 'PROJECT', entityId: 'task-2' },
+      ]);
+
+      const byKey = Object.fromEntries(
+        rows.map((r) => [`${r.entityType}:${r.entityId}`, r.serverSeq]),
+      );
+      expect(byKey).toEqual({ 'TASK:task-2': 1, 'PROJECT:task-2': 2 });
+    });
+  });
+});

--- a/packages/super-sync-server/tests/op-replay.spec.ts
+++ b/packages/super-sync-server/tests/op-replay.spec.ts
@@ -58,6 +58,69 @@ describe('op replay', () => {
     expect(state).toEqual({ TASK: {} });
   });
 
+  it('deletes EVERY entity of a multi-entity batch DEL, not just the scalar (#8340)', () => {
+    const state = replayOpsToState(
+      [
+        row({
+          id: 'op-2',
+          serverSeq: 2,
+          opType: 'DEL',
+          // deleteTasks stores the full set in entityIds and the scalar = entityIds[0].
+          entityId: 'task-1',
+          entityIds: ['task-1', 'task-2', 'task-3'],
+          payload: {},
+        }),
+      ],
+      {
+        TASK: {
+          'task-1': { title: 'A' },
+          'task-2': { title: 'B' },
+          'task-3': { title: 'C' },
+          'task-4': { title: 'D' },
+        },
+      },
+    );
+
+    // Before the fix only task-1 (the scalar) was deleted; task-2/task-3 survived.
+    expect(state).toEqual({ TASK: { 'task-4': { title: 'D' } } });
+  });
+
+  it('falls back to the scalar entityId when a DEL has an empty entityIds array', () => {
+    const state = replayOpsToState(
+      [
+        row({
+          id: 'op-2',
+          serverSeq: 2,
+          opType: 'DEL',
+          entityId: 'task-1',
+          entityIds: [],
+          payload: {},
+        }),
+      ],
+      { TASK: { 'task-1': { title: 'A' }, 'task-2': { title: 'B' } } },
+    );
+
+    expect(state).toEqual({ TASK: { 'task-2': { title: 'B' } } });
+  });
+
+  it('skips prototype-pollution keys inside a multi-entity DEL set', () => {
+    const state = replayOpsToState(
+      [
+        row({
+          id: 'op-2',
+          serverSeq: 2,
+          opType: 'DEL',
+          entityId: 'task-1',
+          entityIds: ['task-1', '__proto__', 'task-2'],
+          payload: {},
+        }),
+      ],
+      { TASK: { 'task-1': { title: 'A' }, 'task-2': { title: 'B' } } },
+    );
+
+    expect(state).toEqual({ TASK: {} });
+  });
+
   it('throws when the replay state exceeds the size guard', () => {
     vi.spyOn(Buffer, 'byteLength').mockReturnValueOnce(MAX_REPLAY_STATE_SIZE_BYTES + 1);
 

--- a/packages/super-sync-server/tests/snapshot.service.spec.ts
+++ b/packages/super-sync-server/tests/snapshot.service.spec.ts
@@ -35,6 +35,7 @@ const EXPECTED_REPLAY_OPERATION_SELECT = {
   opType: true,
   entityType: true,
   entityId: true,
+  entityIds: true,
   payload: true,
   schemaVersion: true,
   isPayloadEncrypted: true,


### PR DESCRIPTION
## Problem

Fixes #8340 (a follow-up on #8334, which added the persisted `entity_ids` column).

Server-side op-replay (restore points + snapshot generation) handled `DEL` by deleting only the **scalar** `entityId`. But a batch delete (`deleteTasks`) stores its full set in `entityIds` and sets the scalar to `entityIds[0]`, so entities `2..n` survived in the replayed snapshot. That snapshot is cached as `userSyncState.snapshotData` (compounding) and reaches clients via `GET /restore/:serverSeq` → `importCompleteBackup` — so a restore could resurrect deleted tasks.

`entityIds` only became persisted in #8334; before that the replay had nothing to read. Now that the column exists, replay can honour it (the issue's proposed fix option (a)).

## Fix

- Thread `entityIds` through `replayOpsToState`'s `opsToProcess` and, in the `DEL` branch, delete **every** member of the set — falling back to the scalar `entityId` for single-entity and pre-migration ops (empty array).
- Add `entityIds` to `REPLAY_OPERATION_SELECT` (the single projection feeding both the live-snapshot and historical-restore-point replay call sites).
- Per-id `isUnsafeEntityKey` guard mirrors the existing scalar prototype-pollution protection.
- Migrated / old-schema ops carry `entityIds: []` (those schema versions are single-entity, predating the field).

Forward-only by design: pre-migration multi-entity deletes stored `entity_ids = {}`, so they still fall back to the scalar — the same documented residual as #8334.

## Also included — the real-PG test #8377 flagged as missing

A separate `test(sync)` commit adds `packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts`: it runs the actual `unnest(CASE …)` conflict-detection SQL from `conflict.ts` against an **in-process Postgres (PGlite)** — no Docker, no `DATABASE_URL` — so unlike the existing `*.integration.spec.ts` files (excluded from the default config), it runs in the normal `npm test` job. Covers the non-first-entity case, latest-per-entity selection, scalar fallback, dedup-off-scalar, cross-entity-type isolation, and the NULL-`entity_id` full-state op. Adds `@electric-sql/pglite` as a dev-only dependency.

## Validation

- Full `super-sync-server` suite green (813 tests), incl. 4 new replay tests proving multi-entity DEL deletes the whole set, the empty-array scalar fallback, and that an unsafe key in the set is skipped without polluting `Object.prototype`.
- `checkFile` clean on all modified files.

## Not verified locally

- `tsc` — the worktree's Prisma client is an ungenerated stub (pre-existing `Prisma.TransactionIsolationLevel` errors); CI regenerates it. `entityIds: true` is valid against the merged schema.
- Server unit tests aren't a PR check (they run nightly + on push-to-master via `e2e-scheduled.yml`), so this runs there after merge.

## Out of scope

The broader op-replay fidelity gap noted in #8340 — `actionPayload`/`entityChanges` wrappers shallow-merged on `CRT`/`UPD`/`MOV` — is separate and larger; this PR is the bounded DELETE piece the new column enables.
