### PR TITLE
fix(schedule): replace circle icon with wb_sunny for today button

### DIFF
--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -87,7 +87,7 @@
       [attr.aria-label]="T.G.TODAY_TAG_TITLE | translate"
       [matTooltip]="T.G.TODAY_TAG_TITLE | translate"
     >
-      <mat-icon>radio_button_unchecked</mat-icon>
+      <mat-icon>wb_sunny</mat-icon>
     </button>
 
     <button


### PR DESCRIPTION
closes #7537 and makes #7538 obsolete
