### PR TITLE
fix(backup): chunk Android backup reads to survive 2MB CursorWindow

### DIFF
--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/app/KeyValStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/app/KeyValStoreInstrumentedTest.kt
@@ -1,0 +1,70 @@
+package com.superproductivity.superproductivity.app
+
+import androidx.test.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import com.superproductivity.superproductivity.App
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented test for [KeyValStore].
+ *
+ * MUST run on an emulator/device, not Robolectric: the ~2 MB CursorWindow limit
+ * that this is guarding against only manifests against real Android SQLite.
+ *
+ * Regression for the on-device backup data-loss bug: a backup blob larger than
+ * Android's ~2 MB CursorWindow could be written via [KeyValStore.set] but not
+ * read back via [KeyValStore.get] — `cursor.getString()` threw
+ * SQLiteBlobTooBigException ("Row too big to fit into CursorWindow"). That surfaced
+ * to the WebView as "Error invoking loadFromDb: Java exception …", so the
+ * eviction-recovery path (#7901) silently failed and the user lost everything.
+ *
+ * Run: ./gradlew :app:connectedPlayDebugAndroidTest (emulator/device required).
+ */
+@RunWith(AndroidJUnit4::class)
+class KeyValStoreInstrumentedTest {
+
+    private val store by lazy {
+        (InstrumentationRegistry.getTargetContext().applicationContext as App).keyValStore
+    }
+
+    private val testKey = "instr_test_keyvalstore"
+
+    @After
+    fun cleanUp() {
+        store.set(testKey, null)
+    }
+
+    @Test
+    fun smallValueRoundTrips() {
+        val value = "hello / with 'apostrophes' and \"quotes\" and \n newlines"
+        store.set(testKey, value)
+        assertEquals(value, store.get(testKey, "DEFAULT"))
+    }
+
+    @Test
+    fun missingKeyReturnsDefault() {
+        assertEquals("DEFAULT", store.get("instr_test_definitely_absent_key", "DEFAULT"))
+    }
+
+    /**
+     * Core regression: a value well past the ~2 MB CursorWindow limit.
+     * Pre-fix this throws inside get(); post-fix the chunked read returns it whole.
+     */
+    @Test
+    fun largeValueOverCursorWindowRoundTrips() {
+        val big = buildString {
+            // ~3 MB of varied content (not one repeated char) to mimic a real JSON backup.
+            val unit = "{\"id\":\"abc123def456\",\"title\":\"do the thing\",\"t\":600000},"
+            while (length < 3 * 1024 * 1024) append(unit)
+        }
+        store.set(testKey, big)
+
+        val read = store.get(testKey, "DEFAULT")
+
+        assertEquals(big.length, read.length)
+        assertEquals(big, read)
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/app/KeyValStore.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/app/KeyValStore.kt
@@ -69,20 +69,34 @@ class KeyValStore(private val context: Context) :
         val newKey = DatabaseUtils.sqlEscapeString(key)
         Log.v(TAG, "getting db value: $newKey")
         val dbHelper = (context.applicationContext as App).keyValStore
-        var value = defaultValue
-        dbHelper.readableDatabase?.let { database ->
-            database.query(
-                DATABASE_TABLE, arrayOf(VALUE), "$KEY=?", arrayOf(newKey), null, null, null
-            )?.let { cursor ->
-                if (cursor.moveToNext()) {
-                    value = cursor.getString(cursor.getColumnIndexOrThrow(VALUE))
-                }
-                Log.v(TAG, "get db value size:" + value.length)
-                cursor.close()
+        val database = dbHelper.readableDatabase ?: return defaultValue
+        return try {
+            // Read in <2 MB chunks: a single cursor.getString() on a row past Android's
+            // ~2 MB CursorWindow throws SQLiteBlobTooBigException. substr() is 1-indexed
+            // and counts code points, so the reassembled chunks are byte-exact.
+            val sb = StringBuilder()
+            var offset = 1
+            while (true) {
+                val chunk = database.rawQuery(
+                    "SELECT substr($VALUE, ?, ?) FROM $DATABASE_TABLE WHERE $KEY=? LIMIT 1",
+                    arrayOf(offset.toString(), GET_CHUNK_CHARS.toString(), newKey)
+                ).use { if (it.moveToFirst()) it.getString(0) else null }
+                if (chunk.isNullOrEmpty()) break // no row, NULL column, or past end-of-string
+                sb.append(chunk)
+                if (chunk.length < GET_CHUNK_CHARS) break // short chunk = finished
+                offset += GET_CHUNK_CHARS
             }
+            Log.v(TAG, "get db value size:" + sb.length)
+            // The only caller passes "" as default, so empty-value and absent collapse.
+            sb.toString().ifEmpty { defaultValue }
+        } catch (e: Exception) {
+            // Never let a read failure crash the JS bridge — degrade to default so
+            // callers can surface "no backup" instead of an opaque invocation error.
+            Log.e(TAG, "get failed for key $newKey", e)
+            defaultValue
+        } finally {
             database.close()
         }
-        return value
     }
 
     fun clearAll(context: Context) {
@@ -103,6 +117,10 @@ class KeyValStore(private val context: Context) :
         private const val VALUE: String = "VALUE"
         private const val KEY_CREATED_AT: String = "KEY_CREATED_AT"
         private const val TAG: String = "SupKeyValStore"
+
+        // Read large rows in chunks of this many CHARACTERS. Even at 4 bytes/char
+        // (256K * 4 = 1 MB) this stays well under the ~2 MB CursorWindow limit.
+        private const val GET_CHUNK_CHARS: Int = 256 * 1024
         // IF NOT EXISTS so the additive onUpgrade() (which calls onCreate) is safe
         // to run against an already-populated DB without throwing (#7901).
         private const val CREATE_TABLE =

--- a/src/app/imex/local-backup/local-backup.service.spec.ts
+++ b/src/app/imex/local-backup/local-backup.service.spec.ts
@@ -952,4 +952,80 @@ describe('LocalBackupService', () => {
       expect(service.getLastBackupTime()).toBeNull();
     });
   });
+
+  // PR #8402: Android native-KV read/write resilience. These spy the `_nativeDb*`
+  // seams (thin wrappers over the window.SUPAndroid singleton, which is undefined
+  // off-device) so the read-degradation + write-path bail logic runs in CI without
+  // an emulator. The real CursorWindow limit is covered by KeyValStoreInstrumentedTest.
+  describe('Android native KV read/write resilience (#8402)', () => {
+    type NativeSeams = {
+      _backupAndroid: (data: AppDataComplete) => Promise<boolean>;
+      _loadAndroidDbValueSafe: (key: string) => Promise<string | null>;
+      _nativeDbLoad: (key: string) => Promise<string | null>;
+      _nativeDbSave: (key: string, value: string) => Promise<void>;
+    };
+    // Ring-slot keys — module-private constants in the service under test.
+    const PRIMARY = 'backup';
+    const PREV = 'backup_prev';
+    // >= 3 tasks so the A3 near-empty guard (#7925) never fires here.
+    const dataWith3Tasks = {
+      task: {
+        ids: ['t1', 't2', 't3'],
+        entities: {
+          t1: { id: 't1', title: 'a' },
+          t2: { id: 't2', title: 'b' },
+          t3: { id: 't3', title: 'c' },
+        },
+      },
+      archiveYoung: DEFAULT_ARCHIVE,
+      archiveOld: DEFAULT_ARCHIVE,
+      project: { ids: [], entities: {} },
+      tag: { ids: [], entities: {} },
+    } as unknown as AppDataComplete;
+    const seams = (): NativeSeams => service as unknown as NativeSeams;
+
+    it('read degrades to null (never throws) when the native read fails', async () => {
+      spyOn(seams(), '_nativeDbLoad').and.rejectWith(new Error('Java exception'));
+
+      expect(await seams()._loadAndroidDbValueSafe(PRIMARY)).toBeNull();
+    });
+
+    it('read passes the value through on success', async () => {
+      spyOn(seams(), '_nativeDbLoad').and.resolveTo('the-backup-blob');
+
+      expect(await seams()._loadAndroidDbValueSafe(PRIMARY)).toBe('the-backup-blob');
+    });
+
+    it('write BAILS (no overwrite) when the existing-slot read fails — preserves both ring slots (#7901)', async () => {
+      spyOn(seams(), '_nativeDbLoad').and.rejectWith(new Error('read failed'));
+      const saveSpy = spyOn(seams(), '_nativeDbSave').and.resolveTo();
+
+      const didWrite = await seams()._backupAndroid(dataWith3Tasks);
+
+      expect(didWrite).toBe(false);
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it('write rotates prev then writes primary when an existing backup is present', async () => {
+      spyOn(seams(), '_nativeDbLoad').and.resolveTo('EXISTING_BLOB');
+      const saveSpy = spyOn(seams(), '_nativeDbSave').and.resolveTo();
+
+      const didWrite = await seams()._backupAndroid(dataWith3Tasks);
+
+      expect(didWrite).toBe(true);
+      expect(saveSpy).toHaveBeenCalledWith(PREV, 'EXISTING_BLOB');
+      expect(saveSpy).toHaveBeenCalledWith(PRIMARY, JSON.stringify(dataWith3Tasks));
+    });
+
+    it('write skips rotation and writes primary when there is no existing backup', async () => {
+      spyOn(seams(), '_nativeDbLoad').and.resolveTo(null);
+      const saveSpy = spyOn(seams(), '_nativeDbSave').and.resolveTo();
+
+      const didWrite = await seams()._backupAndroid(dataWith3Tasks);
+
+      expect(didWrite).toBe(true);
+      expect(saveSpy).toHaveBeenCalledOnceWith(PRIMARY, JSON.stringify(dataWith3Tasks));
+      expect(saveSpy).not.toHaveBeenCalledWith(PREV, jasmine.anything());
+    });
+  });
 });

--- a/src/app/imex/local-backup/local-backup.service.ts
+++ b/src/app/imex/local-backup/local-backup.service.ts
@@ -86,13 +86,12 @@ export class LocalBackupService {
   checkBackupAvailable(): Promise<boolean | LocalBackupMeta> {
     if (this._isAndroidWebView) {
       // Available if either ring slot holds a backup (#7901).
-      return androidInterface.loadFromDbWrapped(ANDROID_DB_KEY).then(async (primary) => {
-        if (primary) {
+      return (async () => {
+        if (await this._loadAndroidDbValueSafe(ANDROID_DB_KEY)) {
           return true;
         }
-        const prev = await androidInterface.loadFromDbWrapped(ANDROID_DB_KEY_PREV);
-        return !!prev;
-      });
+        return !!(await this._loadAndroidDbValueSafe(ANDROID_DB_KEY_PREV));
+      })();
     }
     if (this._platformService.isIOS()) {
       return this._checkBackupAvailableIOS();
@@ -112,10 +111,33 @@ export class LocalBackupService {
     // usable exists (degrades to the existing import-error snack rather than
     // throwing on the startup path).
     const [primary, prev] = await Promise.all([
-      androidInterface.loadFromDbWrapped(ANDROID_DB_KEY),
-      androidInterface.loadFromDbWrapped(ANDROID_DB_KEY_PREV),
+      this._loadAndroidDbValueSafe(ANDROID_DB_KEY),
+      this._loadAndroidDbValueSafe(ANDROID_DB_KEY_PREV),
     ]);
     return selectBestBackupStr(primary, prev) ?? '';
+  }
+
+  /**
+   * Android-only native-KV read with diagnostics + graceful failure.
+   *
+   * - Logs the blob SIZE (never content — see core/log rule 9) so a shared log
+   *   export shows whether a backup has grown into the ~2 MB CursorWindow danger
+   *   zone that used to make `loadFromDb` throw.
+   * - Returns null instead of throwing, so a read failure degrades to "no backup"
+   *   (the existing snack) rather than an opaque "Error invoking loadFromDb" that
+   *   aborts the whole restore action.
+   */
+  private async _loadAndroidDbValueSafe(key: string): Promise<string | null> {
+    try {
+      const val = await androidInterface.loadFromDbWrapped(key);
+      Log.log(
+        `LocalBackupService: read Android backup '${key}' (${val ? val.length : 0} chars)`,
+      );
+      return val;
+    } catch (e) {
+      Log.err(`LocalBackupService: failed to read Android backup '${key}'`, e);
+      return null;
+    }
   }
 
   async loadBackupIOS(): Promise<string> {
@@ -379,14 +401,30 @@ export class LocalBackupService {
   // Returns true when a backup was actually written, false when the A3 guard
   // skipped it (so the caller knows whether to advance the last-backup time).
   private async _backupAndroid(data: AppDataComplete): Promise<boolean> {
-    const existing = await androidInterface.loadFromDbWrapped(ANDROID_DB_KEY);
+    // Read the existing primary slot directly (NOT via _loadAndroidDbValueSafe): on the
+    // write path a read failure is ambiguous — we can't tell "no backup yet" from
+    // "unreadable" — so we must not overwrite the primary on uncertainty. Bail instead,
+    // preserving both ring slots; the next cycle retries (#7901).
+    let existing: string | null;
+    try {
+      existing = await androidInterface.loadFromDbWrapped(ANDROID_DB_KEY);
+    } catch (e) {
+      Log.err(
+        'LocalBackupService: skipping Android backup — could not read existing slot',
+        e,
+      );
+      return false;
+    }
     if (this._guardNearEmptyOverwrite(data, existing, 'Android')) {
       return false;
     }
     if (existing) {
       await androidInterface.saveToDbWrapped(ANDROID_DB_KEY_PREV, existing);
     }
-    await androidInterface.saveToDbWrapped(ANDROID_DB_KEY, JSON.stringify(data));
+    const json = JSON.stringify(data);
+    // Size only, never content (core/log rule 9) — lands in shared log exports.
+    Log.log(`LocalBackupService: writing Android backup (${json.length} chars)`);
+    await androidInterface.saveToDbWrapped(ANDROID_DB_KEY, json);
     return true;
   }
 

--- a/src/app/imex/local-backup/local-backup.service.ts
+++ b/src/app/imex/local-backup/local-backup.service.ts
@@ -129,7 +129,7 @@ export class LocalBackupService {
    */
   private async _loadAndroidDbValueSafe(key: string): Promise<string | null> {
     try {
-      const val = await androidInterface.loadFromDbWrapped(key);
+      const val = await this._nativeDbLoad(key);
       Log.log(
         `LocalBackupService: read Android backup '${key}' (${val ? val.length : 0} chars)`,
       );
@@ -138,6 +138,17 @@ export class LocalBackupService {
       Log.err(`LocalBackupService: failed to read Android backup '${key}'`, e);
       return null;
     }
+  }
+
+  // Thin seams over the `androidInterface` (window.SUPAndroid) singleton — which
+  // is undefined off-device and has no DI seam — so the read/write logic above is
+  // unit-testable (spec spies these instead of the global).
+  private _nativeDbLoad(key: string): Promise<string | null> {
+    return androidInterface.loadFromDbWrapped(key);
+  }
+
+  private _nativeDbSave(key: string, value: string): Promise<void> {
+    return androidInterface.saveToDbWrapped(key, value);
   }
 
   async loadBackupIOS(): Promise<string> {
@@ -407,7 +418,7 @@ export class LocalBackupService {
     // preserving both ring slots; the next cycle retries (#7901).
     let existing: string | null;
     try {
-      existing = await androidInterface.loadFromDbWrapped(ANDROID_DB_KEY);
+      existing = await this._nativeDbLoad(ANDROID_DB_KEY);
     } catch (e) {
       Log.err(
         'LocalBackupService: skipping Android backup — could not read existing slot',
@@ -419,12 +430,12 @@ export class LocalBackupService {
       return false;
     }
     if (existing) {
-      await androidInterface.saveToDbWrapped(ANDROID_DB_KEY_PREV, existing);
+      await this._nativeDbSave(ANDROID_DB_KEY_PREV, existing);
     }
     const json = JSON.stringify(data);
     // Size only, never content (core/log rule 9) — lands in shared log exports.
     Log.log(`LocalBackupService: writing Android backup (${json.length} chars)`);
-    await androidInterface.saveToDbWrapped(ANDROID_DB_KEY, json);
+    await this._nativeDbSave(ANDROID_DB_KEY, json);
     return true;
   }
 


### PR DESCRIPTION
Closes #8401.

`KeyValStore.get()` read the backup blob via a single `cursor.getString()`, which throws `SQLiteBlobTooBigException` once a row exceeds Android's ~2 MB CursorWindow. The on-device backup crosses 2 MB after roughly a year of normal use, so it was written but never readable. It surfaced as "Error invoking loadFromDb: Java exception" and silently broke the #7901 eviction-recovery path, causing total data loss on Android. (Electron/iOS use file-based backups and are unaffected.)

### Changes
- `KeyValStore.get()`: read in 256K-char `substr()` chunks, wrapped in try/catch returning the default. This also recovers already-written oversized backups.
- `KeyValStoreInstrumentedTest`: emulator regression test (Robolectric does not reproduce the CursorWindow limit).
- `local-backup.service`: logs backup size (never content) to the exportable log, and degrades a read failure to "no backup" instead of an opaque crash.

### Verification
Needs a run on an emulator/device: `./gradlew :app:connectedPlayDebugAndroidTest` (CI will not run connectedAndroidTest).
