### PR TITLE
fix(sync): Caddy WS-token log redaction (#8343) + batched failed-op retry (#8305)

### DIFF
--- a/packages/super-sync-server/Caddyfile
+++ b/packages/super-sync-server/Caddyfile
@@ -27,8 +27,21 @@
     encode gzip zstd
 
     # Logging
+    #
+    # Redact the WebSocket auth token from the logged URI. The WS endpoint
+    # authenticates via `?token=<JWT>` (browsers can't set headers on a
+    # WebSocket), and that JWT is valid for 365 days with no rotation. Without
+    # this filter every WS upgrade writes a year-valid, full-sync credential to
+    # stdout / `docker logs`. `token` is only ever a query param on the WS URL
+    # (the HTTP API authenticates via the Authorization header), so redacting it
+    # here is targeted and safe. See #8343.
     log {
         output stdout
-        format console
+        format filter {
+            wrap console
+            request>uri query {
+                replace token REDACTED
+            }
+        }
     }
 }

--- a/packages/super-sync-server/Caddyfile
+++ b/packages/super-sync-server/Caddyfile
@@ -28,13 +28,14 @@
 
     # Logging
     #
-    # Redact the WebSocket auth token from the logged URI. The WS endpoint
+    # Redact the `token` query param from the logged URI. The WebSocket endpoint
     # authenticates via `?token=<JWT>` (browsers can't set headers on a
-    # WebSocket), and that JWT is valid for 365 days with no rotation. Without
-    # this filter every WS upgrade writes a year-valid, full-sync credential to
-    # stdout / `docker logs`. `token` is only ever a query param on the WS URL
-    # (the HTTP API authenticates via the Authorization header), so redacting it
-    # here is targeted and safe. See #8343.
+    # WebSocket), and that JWT is valid for 365 days with no rotation — so
+    # without this filter every WS upgrade writes a year-valid, full-sync
+    # credential to stdout / `docker logs`. `token` is only ever a query param
+    # carrying an auth secret (the WS JWT, plus the email-verification,
+    # passkey-recovery and magic-login links), never a benign field, so
+    # redacting it across this site block is targeted and safe. See #8343.
     log {
         output stdout
         format filter {

--- a/src/app/op-log/apply/failed-op-ids.util.spec.ts
+++ b/src/app/op-log/apply/failed-op-ids.util.spec.ts
@@ -1,0 +1,27 @@
+import { getFailedOpIdsFromBatch } from './failed-op-ids.util';
+import { Operation } from '../core/operation.types';
+
+const op = (id: string): Operation => ({ id }) as Operation;
+
+describe('getFailedOpIdsFromBatch', () => {
+  it('returns the failed op and every op after it (slice-from-failure)', () => {
+    const ops = [op('a'), op('b'), op('c'), op('d')];
+    expect(getFailedOpIdsFromBatch(ops, op('b'))).toEqual(['b', 'c', 'd']);
+  });
+
+  it('returns just the last op when it is the one that failed', () => {
+    const ops = [op('a'), op('b'), op('c')];
+    expect(getFailedOpIdsFromBatch(ops, op('c'))).toEqual(['c']);
+  });
+
+  it('returns all ops when the first one failed', () => {
+    const ops = [op('a'), op('b'), op('c')];
+    expect(getFailedOpIdsFromBatch(ops, op('a'))).toEqual(['a', 'b', 'c']);
+  });
+
+  it('falls back to only the failed op when it is not in the batch (defensive -1 guard)', () => {
+    // Guards against slice(-1) wrongly selecting just the last op.
+    const ops = [op('a'), op('b'), op('c')];
+    expect(getFailedOpIdsFromBatch(ops, op('x'))).toEqual(['x']);
+  });
+});

--- a/src/app/op-log/apply/failed-op-ids.util.ts
+++ b/src/app/op-log/apply/failed-op-ids.util.ts
@@ -1,0 +1,25 @@
+import { Operation } from '../core/operation.types';
+
+/**
+ * Given the ops handed to a single `applyOperations()` batch in causal (seq)
+ * order and the op whose archive side effect threw, return the ids of every op
+ * that stays unapplied: the failed op plus everything after it.
+ *
+ * The batch applier (`replayOperationBatch`) stops at the first failing archive
+ * side effect, so ops after `failedOp` were never processed and must be retried
+ * together with it. This is the slice-from-failure handling shared by every
+ * caller that applies a batch and then marks the remainder failed (the remote
+ * apply path, conflict resolution, and the failed-op retry on hydration).
+ *
+ * The `-1` guard is defensive: `failedOp` always originates from `opsToApply`,
+ * but if it somehow isn't found we mark only the failed op rather than letting
+ * `slice(-1)` wrongly select just the last op.
+ */
+export const getFailedOpIdsFromBatch = (
+  opsToApply: Operation[],
+  failedOp: Operation,
+): string[] => {
+  const failedIndex = opsToApply.findIndex((op) => op.id === failedOp.id);
+  const stillFailed = failedIndex === -1 ? [failedOp] : opsToApply.slice(failedIndex);
+  return stillFailed.map((op) => op.id);
+};

--- a/src/app/op-log/persistence/operation-log-hydrator.retry.integration.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.retry.integration.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { OperationLogHydratorService } from './operation-log-hydrator.service';
+import { OperationLogStoreService } from './operation-log-store.service';
+import { OperationLogMigrationService } from './operation-log-migration.service';
+import { SchemaMigrationService } from './schema-migration.service';
+import { OperationLogSnapshotService } from './operation-log-snapshot.service';
+import { OperationLogRecoveryService } from './operation-log-recovery.service';
+import { SyncHydrationService } from './sync-hydration.service';
+import { ArchiveMigrationService } from './archive-migration.service';
+import { StateSnapshotService } from '../backup/state-snapshot.service';
+import { SnackService } from '../../core/snack/snack.service';
+import { ValidateStateService } from '../validation/validate-state.service';
+import { OperationApplierService } from '../apply/operation-applier.service';
+import { HydrationStateService } from '../apply/hydration-state.service';
+import { VectorClockService } from '../sync/vector-clock.service';
+import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
+import { MAX_CONFLICT_RETRY_ATTEMPTS } from '../core/operation-log.const';
+import { ActionType, EntityType, Operation, OpType } from '../core/operation.types';
+import { ApplyOperationsResult } from '../core/types/apply.types';
+import { uuidv7 } from '../../util/uuid-v7';
+
+/**
+ * Integration coverage for retryFailedRemoteOps (#8305 fix (b)) against the REAL
+ * OperationLogStoreService (real IndexedDB), with only the applier controlled.
+ *
+ * The co-located unit spec mocks the store, so it can't prove the actual status
+ * transitions the retry depends on: failed -> applied on success, the
+ * slice-from-failure re-mark, and the retry-count -> reject lifecycle that ends
+ * with getFailedRemoteOps filtering the op out. These tests exercise exactly
+ * that, end to end, across simulated reboots.
+ */
+describe('OperationLogHydratorService retryFailedRemoteOps (integration, real store)', () => {
+  let hydrator: OperationLogHydratorService;
+  let store: OperationLogStoreService;
+  let applier: jasmine.SpyObj<OperationApplierService>;
+
+  const mockClientIdProvider: ClientIdProvider = {
+    loadClientId: () => Promise.resolve('testClient'),
+    getOrGenerateClientId: () => Promise.resolve('testClient'),
+    clearCache: () => {},
+  };
+
+  const createOp = (overrides: Partial<Operation> = {}): Operation => ({
+    id: uuidv7(),
+    actionType: '[Task] Update' as ActionType,
+    opType: OpType.Update,
+    entityType: 'TASK' as EntityType,
+    entityId: 'task1',
+    payload: { title: 'Test Task' },
+    clientId: 'remoteClient',
+    vectorClock: { remoteClient: 1 },
+    timestamp: Date.now(),
+    schemaVersion: 1,
+    ...overrides,
+  });
+
+  /**
+   * Seeds remote ops in the store in 'failed' state (source=remote,
+   * applicationStatus=failed) — the shape getFailedRemoteOps selects — by
+   * appending them as pending remote ops and then marking them failed.
+   */
+  const seedFailedRemoteOps = async (
+    ops: Operation[],
+  ): Promise<{ id: string; seq: number }[]> => {
+    const { seqs } = await store.appendBatchSkipDuplicates(ops, 'remote', {
+      pendingApply: true,
+    });
+    await store.markFailed(ops.map((o) => o.id));
+    return ops.map((o, i) => ({ id: o.id, seq: seqs[i] }));
+  };
+
+  beforeEach(async () => {
+    applier = jasmine.createSpyObj<OperationApplierService>('OperationApplierService', [
+      'applyOperations',
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        OperationLogHydratorService,
+        OperationLogStoreService,
+        VectorClockService,
+        { provide: CLIENT_ID_PROVIDER, useValue: mockClientIdProvider },
+        { provide: OperationApplierService, useValue: applier },
+        // retryFailedRemoteOps touches only the store + applier; the remaining
+        // hydrator deps must exist for DI but are never called on this path.
+        { provide: Store, useValue: jasmine.createSpyObj('Store', ['dispatch']) },
+        { provide: OperationLogMigrationService, useValue: {} },
+        { provide: SchemaMigrationService, useValue: {} },
+        { provide: OperationLogSnapshotService, useValue: {} },
+        { provide: OperationLogRecoveryService, useValue: {} },
+        { provide: SyncHydrationService, useValue: {} },
+        { provide: ArchiveMigrationService, useValue: {} },
+        { provide: StateSnapshotService, useValue: {} },
+        { provide: SnackService, useValue: {} },
+        { provide: ValidateStateService, useValue: {} },
+        { provide: HydrationStateService, useValue: {} },
+      ],
+    });
+
+    hydrator = TestBed.inject(OperationLogHydratorService);
+    store = TestBed.inject(OperationLogStoreService);
+    await store.init();
+    await store._clearAllDataForTesting();
+  });
+
+  it('clears all failed ops to applied when the whole batch succeeds', async () => {
+    const ops = [createOp(), createOp(), createOp()];
+    const seeded = await seedFailedRemoteOps(ops);
+    // Real applier returns appliedOps === input ops on full success.
+    applier.applyOperations.and.callFake((toApply: Operation[]) =>
+      Promise.resolve({ appliedOps: toApply } as ApplyOperationsResult),
+    );
+
+    await hydrator.retryFailedRemoteOps();
+
+    expect(await store.getFailedRemoteOps()).toEqual([]);
+    for (const { id } of seeded) {
+      expect((await store.getOpById(id))?.applicationStatus).toBe('applied');
+    }
+  });
+
+  it('applies in one batch: the applier is called once with every failed op', async () => {
+    const ops = [createOp(), createOp(), createOp()];
+    await seedFailedRemoteOps(ops);
+    applier.applyOperations.and.callFake((toApply: Operation[]) =>
+      Promise.resolve({ appliedOps: toApply } as ApplyOperationsResult),
+    );
+
+    await hydrator.retryFailedRemoteOps();
+
+    expect(applier.applyOperations).toHaveBeenCalledTimes(1);
+    const passed = applier.applyOperations.calls.argsFor(0)[0] as Operation[];
+    expect(passed.length).toBe(3);
+  });
+
+  it('on partial failure marks the failed op and every op after it as still-failing', async () => {
+    const ops = [createOp(), createOp(), createOp()];
+    const seeded = await seedFailedRemoteOps(ops);
+    const [a, b, c] = seeded;
+    // Applier stops at op b: a applied, b failed, c dropped.
+    applier.applyOperations.and.callFake((toApply: Operation[]) =>
+      Promise.resolve({
+        appliedOps: toApply.slice(0, 1),
+        failedOp: { op: toApply[1], error: new Error('archive side-effect failed') },
+      } as ApplyOperationsResult),
+    );
+
+    await hydrator.retryFailedRemoteOps();
+
+    expect((await store.getOpById(a.id))?.applicationStatus).toBe('applied');
+    const stillFailed = (await store.getFailedRemoteOps()).map((e) => e.op.id).sort();
+    expect(stillFailed).toEqual([b.id, c.id].sort());
+  });
+
+  it('eventually rejects a permanently-failing op across reboots, then stops returning it', async () => {
+    const op = createOp();
+    await seedFailedRemoteOps([op]); // retryCount starts at 1 after the seed markFailed
+    applier.applyOperations.and.callFake((toApply: Operation[]) =>
+      Promise.resolve({
+        appliedOps: [],
+        failedOp: { op: toApply[0], error: new Error('still failing') },
+      } as ApplyOperationsResult),
+    );
+
+    // Each call simulates one boot's retry. The seed left retryCount at 1, so
+    // it takes MAX_CONFLICT_RETRY_ATTEMPTS - 1 more failed retries to hit the cap.
+    let guard = 0;
+    while ((await store.getFailedRemoteOps()).length > 0 && guard < 10) {
+      await hydrator.retryFailedRemoteOps();
+      guard++;
+    }
+
+    // Op is gone from the retry set and persisted as rejected, not failed.
+    expect(await store.getFailedRemoteOps()).toEqual([]);
+    expect(guard).toBe(MAX_CONFLICT_RETRY_ATTEMPTS - 1);
+    const rejected = await store.getOpById(op.id);
+    expect(rejected?.rejectedAt).toBeTruthy();
+    expect(rejected?.applicationStatus).toBeUndefined();
+  });
+});

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -27,6 +27,7 @@ import {
 import { loadAllData } from '../../root-store/meta/load-all-data.action';
 import { bulkApplyHydrationOperations } from '../apply/bulk-hydration.action';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
+import { MAX_CONFLICT_RETRY_ATTEMPTS } from '../core/operation-log.const';
 import { MAX_VECTOR_CLOCK_SIZE } from '@sp/shared-schema';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 import { IDB_OPEN_ERROR_RELOAD_KEY } from './operation-log-hydrator.service';
@@ -1332,89 +1333,92 @@ describe('OperationLogHydratorService', () => {
   // ===========================================================================
   // These tests verify the retry mechanism for failed remote operations.
   describe('retryFailedRemoteOps', () => {
-    it('should call markApplied for successfully retried failed ops', async () => {
-      const failedOp = createMockOperation('failed-op-1');
-      const failedEntry: OperationLogEntry = {
-        seq: 42,
-        op: failedOp,
-        appliedAt: Date.now(),
-        source: 'remote',
-        applicationStatus: 'failed',
-        retryCount: 1,
-      };
+    const failedEntry = (seq: number, opId: string): OperationLogEntry => ({
+      seq,
+      op: createMockOperation(opId),
+      appliedAt: Date.now(),
+      source: 'remote',
+      applicationStatus: 'failed',
+      retryCount: 1,
+    });
 
-      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve([failedEntry]));
-      mockOperationApplierService.applyOperations.and.returnValue(
-        Promise.resolve({ appliedOps: [] }),
+    it('should retry all failed ops as a single batch (not one at a time) — #8305', async () => {
+      const entries = [
+        failedEntry(40, 'op-a'),
+        failedEntry(41, 'op-b'),
+        failedEntry(42, 'op-c'),
+      ];
+      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve(entries));
+      mockOperationApplierService.applyOperations.and.callFake((ops: Operation[]) =>
+        Promise.resolve({ appliedOps: ops }),
       );
 
       await service.retryFailedRemoteOps();
 
-      // Verify markApplied was called with the sequence number
-      expect(mockOpLogStore.markApplied).toHaveBeenCalledWith([42]);
+      // One batch call carrying every failed op — the per-op retry that
+      // defeated the same-batch archive pre-scan is gone.
+      expect(mockOperationApplierService.applyOperations).toHaveBeenCalledTimes(1);
+      const passedOps = mockOperationApplierService.applyOperations.calls.argsFor(0)[0];
+      expect(passedOps.map((o: Operation) => o.id)).toEqual(['op-a', 'op-b', 'op-c']);
+      expect(mockOpLogStore.markApplied).toHaveBeenCalledWith([40, 41, 42]);
+      expect(mockOpLogStore.markFailed).not.toHaveBeenCalled();
     });
 
-    it('should clear failed status after successful retry (markApplied handles failed status)', async () => {
-      // Verify that markApplied is called with the correct sequence number
-      // after a successful retry. The actual status transition is tested
-      // in operation-log-store.service.spec.ts.
-
-      const failedOp = createMockOperation('failed-op-1');
-      const failedEntry: OperationLogEntry = {
-        seq: 42,
-        op: failedOp,
-        appliedAt: Date.now(),
-        source: 'remote',
-        applicationStatus: 'failed',
-        retryCount: 1,
-      };
-
-      let markAppliedCalledWithSeqs: number[] = [];
-      mockOpLogStore.markApplied.and.callFake((seqs: number[]) => {
-        markAppliedCalledWithSeqs = seqs;
-        return Promise.resolve();
-      });
-
-      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve([failedEntry]));
-      mockOperationApplierService.applyOperations.and.returnValue(
-        Promise.resolve({ appliedOps: [] }),
+    it('should apply failed ops in ascending seq order regardless of store order', async () => {
+      // getFailedRemoteOps reads from an index whose result order is not part of
+      // its contract; the batch must still be applied in causal (seq) order.
+      const entries = [
+        failedEntry(42, 'op-c'),
+        failedEntry(40, 'op-a'),
+        failedEntry(41, 'op-b'),
+      ];
+      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve(entries));
+      mockOperationApplierService.applyOperations.and.callFake((ops: Operation[]) =>
+        Promise.resolve({ appliedOps: ops }),
       );
 
       await service.retryFailedRemoteOps();
 
-      // markApplied should be called with the failed op's sequence number
-      expect(markAppliedCalledWithSeqs).toEqual([42]);
+      const passedOps = mockOperationApplierService.applyOperations.calls.argsFor(0)[0];
+      expect(passedOps.map((o: Operation) => o.id)).toEqual(['op-a', 'op-b', 'op-c']);
+      expect(mockOpLogStore.markApplied).toHaveBeenCalledWith([40, 41, 42]);
     });
 
-    it('should call markFailed for ops that still fail after retry', async () => {
-      const failedOp = createMockOperation('still-failing-op');
-      const failedEntry: OperationLogEntry = {
-        seq: 99,
-        op: failedOp,
-        appliedAt: Date.now(),
-        source: 'remote',
-        applicationStatus: 'failed',
-        retryCount: 1,
-      };
-
-      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve([failedEntry]));
+    it('should mark the failed op and every op after it (in seq order) as still-failing', async () => {
+      const entries = [
+        failedEntry(40, 'op-a'),
+        failedEntry(41, 'op-b'),
+        failedEntry(42, 'op-c'),
+      ];
+      const opB = entries[1].op;
+      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve(entries));
+      // Batch applier stops at op-b: op-a applied, op-b failed, op-c dropped.
       mockOperationApplierService.applyOperations.and.returnValue(
         Promise.resolve({
-          appliedOps: [],
-          failedOp: {
-            op: failedOp,
-            error: new Error('Still failing'),
-          },
+          appliedOps: [entries[0].op],
+          failedOp: { op: opB, error: new Error('Still failing') },
         }),
       );
 
       await service.retryFailedRemoteOps();
 
-      // markFailed should be called with the op ID
+      expect(mockOpLogStore.markApplied).toHaveBeenCalledWith([40]);
+      // op-b (failed) and op-c (after it) are both marked failed, with the
+      // retry-cap so a permanently-failing op is eventually rejected.
       expect(mockOpLogStore.markFailed).toHaveBeenCalledWith(
-        ['still-failing-op'],
-        jasmine.any(Number),
+        ['op-b', 'op-c'],
+        MAX_CONFLICT_RETRY_ATTEMPTS,
       );
+    });
+
+    it('should do nothing when there are no failed ops', async () => {
+      mockOpLogStore.getFailedRemoteOps.and.returnValue(Promise.resolve([]));
+
+      await service.retryFailedRemoteOps();
+
+      expect(mockOperationApplierService.applyOperations).not.toHaveBeenCalled();
+      expect(mockOpLogStore.markApplied).not.toHaveBeenCalled();
+      expect(mockOpLogStore.markFailed).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -570,36 +570,48 @@ export class OperationLogHydratorService {
       `OperationLogHydratorService: Retrying ${failedOps.length} previously failed remote ops...`,
     );
 
-    const appliedOpIds: string[] = [];
-    const stillFailedOpIds: string[] = [];
+    // Retry as ONE seq-ordered batch, not one op at a time. A per-op retry turns
+    // every applyOperations() call into a single-op batch, and the same-batch
+    // archive pre-scan (collectArchivingOrDeletingEntityIdsFromBatch) returns an
+    // empty set for single-op batches — silently weakening the #7330
+    // orphan-resurrection guard. Batching restores that protection and matches
+    // how the primary remote-apply path (applyRemoteOperations) applies ops.
+    // getFailedRemoteOps() reads from an index whose result order isn't part of
+    // its contract, so sort by seq explicitly to keep causal order. See #8305.
+    const orderedFailedOps = [...failedOps].sort((a, b) => a.seq - b.seq);
+    const opsToApply = orderedFailedOps.map((e) => e.op);
+    const opIdToSeq = new Map(orderedFailedOps.map((e) => [e.op.id, e.seq]));
 
-    for (const entry of failedOps) {
-      const result = await this.operationApplierService.applyOperations([entry.op]);
-      if (result.failedOp) {
-        OpLog.warn(
-          `OperationLogHydratorService: Failed to retry op ${entry.op.id}`,
-          result.failedOp.error,
-        );
-        stillFailedOpIds.push(entry.op.id);
-      } else {
-        // Operation succeeded
-        appliedOpIds.push(entry.op.id);
-      }
-    }
+    const result = await this.operationApplierService.applyOperations(opsToApply);
 
-    // Mark successfully applied ops
-    if (appliedOpIds.length > 0) {
-      const appliedSeqs = failedOps
-        .filter((e) => appliedOpIds.includes(e.op.id))
-        .map((e) => e.seq);
+    // Mark successfully applied ops.
+    const appliedSeqs = result.appliedOps
+      .map((op) => opIdToSeq.get(op.id))
+      .filter((seq): seq is number => seq !== undefined);
+    if (appliedSeqs.length > 0) {
       await this.opLogStore.markApplied(appliedSeqs);
       OpLog.normal(
-        `OperationLogHydratorService: Successfully retried ${appliedOpIds.length} failed ops`,
+        `OperationLogHydratorService: Successfully retried ${appliedSeqs.length} failed ops`,
       );
     }
 
-    // Update retry count for still-failed ops (may reject them if max retries reached)
-    if (stillFailedOpIds.length > 0) {
+    // On a partial failure the batch applier stops at the first op whose archive
+    // side effect throws and returns it; that op and every op after it in seq
+    // order stay unapplied. Mirror the primary path's slice-from-failure
+    // handling. markFailed bumps the retry count (rejecting ops past
+    // MAX_CONFLICT_RETRY_ATTEMPTS), so a permanently-failing op can't be retried
+    // forever.
+    if (result.failedOp) {
+      const failedOpId = result.failedOp.op.id;
+      const failedIndex = opsToApply.findIndex((op) => op.id === failedOpId);
+      const stillFailedOpIds = (
+        failedIndex === -1 ? [result.failedOp.op] : opsToApply.slice(failedIndex)
+      ).map((op) => op.id);
+
+      OpLog.warn(
+        `OperationLogHydratorService: Failed to retry op ${failedOpId}`,
+        result.failedOp.error,
+      );
       await this.opLogStore.markFailed(stillFailedOpIds, MAX_CONFLICT_RETRY_ATTEMPTS);
       OpLog.warn(
         `OperationLogHydratorService: ${stillFailedOpIds.length} ops still failing after retry`,

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -22,6 +22,7 @@ import { ValidateStateService } from '../validation/validate-state.service';
 import { OperationApplierService } from '../apply/operation-applier.service';
 import { HydrationStateService } from '../apply/hydration-state.service';
 import { bulkApplyOperations } from '../apply/bulk-hydration.action';
+import { getFailedOpIdsFromBatch } from '../apply/failed-op-ids.util';
 import { VectorClockService } from '../sync/vector-clock.service';
 import { MAX_CONFLICT_RETRY_ATTEMPTS } from '../core/operation-log.const';
 import { AppDataComplete } from '../model/model-config';
@@ -597,19 +598,15 @@ export class OperationLogHydratorService {
 
     // On a partial failure the batch applier stops at the first op whose archive
     // side effect throws and returns it; that op and every op after it in seq
-    // order stay unapplied. Mirror the primary path's slice-from-failure
-    // handling. markFailed bumps the retry count (rejecting ops past
+    // order stay unapplied (slice-from-failure, shared with the primary path).
+    // markFailed bumps the retry count (rejecting ops past
     // MAX_CONFLICT_RETRY_ATTEMPTS), so a permanently-failing op can't be retried
     // forever.
     if (result.failedOp) {
-      const failedOpId = result.failedOp.op.id;
-      const failedIndex = opsToApply.findIndex((op) => op.id === failedOpId);
-      const stillFailedOpIds = (
-        failedIndex === -1 ? [result.failedOp.op] : opsToApply.slice(failedIndex)
-      ).map((op) => op.id);
+      const stillFailedOpIds = getFailedOpIdsFromBatch(opsToApply, result.failedOp.op);
 
       OpLog.warn(
-        `OperationLogHydratorService: Failed to retry op ${failedOpId}`,
+        `OperationLogHydratorService: Failed to retry op ${result.failedOp.op.id}`,
         result.failedOp.error,
       );
       await this.opLogStore.markFailed(stillFailedOpIds, MAX_CONFLICT_RETRY_ATTEMPTS);

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -31,6 +31,7 @@ import {
 } from '../core/operation.types';
 import { toLwwUpdateActionType } from '../core/lww-update-action-types';
 import { OperationApplierService } from '../apply/operation-applier.service';
+import { getFailedOpIdsFromBatch } from '../apply/failed-op-ids.util';
 import { OperationLogStoreService } from '../persistence/operation-log-store.service';
 import { OpLog } from '../../core/log';
 import { toEntityKey } from '../util/entity-key.util';
@@ -438,11 +439,10 @@ export class ConflictResolutionService {
         }
 
         if (applyResult.failedOp) {
-          const failedOpIndex = allOpsToApply.findIndex(
-            (op) => op.id === applyResult.failedOp!.op.id,
+          const failedOpIds = getFailedOpIdsFromBatch(
+            allOpsToApply,
+            applyResult.failedOp.op,
           );
-          const failedOps = allOpsToApply.slice(failedOpIndex);
-          const failedOpIds = failedOps.map((op) => op.id);
 
           OpLog.err(
             `ConflictResolutionService: ${applyResult.appliedOps.length} ops applied before failure. ` +


### PR DESCRIPTION
## Summary

Two SuperSync hardening fixes from the #8363 tracker, plus a small shared-helper refactor and integration coverage. **Neither issue is fully closed** — both are scoped, see below.

### #8343 — redact the WebSocket auth token from Caddy access logs (interim mitigation)
The WS endpoint authenticates via `?token=<JWT>` in the URL (browsers can't set headers on a WebSocket). That JWT is valid **365 days** with no rotation, and the shipped `Caddyfile` enabled access logging — so every WS upgrade wrote a year-valid, full-sync credential to stdout / `docker logs`. This switches the access log to a `filter` encoder that redacts the `token` query param while keeping the request line for observability (`...?token=REDACTED&clientId=...`). The same filter also covers the email-verification / passkey-recovery / magic-login token links (all auth secrets), since the filter is global to the site block.

> This is the **interim** mitigation the issue scoped; the preferred `ws-ticket` / `Sec-WebSocket-Protocol` redesign remains open under #8343.

### #8305 — retry failed remote ops as one seq-ordered batch (fix (b) only)
`retryFailedRemoteOps()` applied each failed op in its own single-op `applyOperations([op])` call. A single-op batch makes the same-batch archive pre-scan (`collectArchivingOrDeletingEntityIdsFromBatch`) return empty, silently weakening the #7330 orphan-resurrection guard. This retries all failed ops as one batch, ordered by seq, mirroring the primary `applyRemoteOperations` result handling (applied-from-`appliedOps`, slice-from-failure for the remainder, `MAX_CONFLICT_RETRY_ATTEMPTS` reject cap).

> Scope: **fix (b) only.** The deeper (a) phase-tracking and (c) replay-dedup remedies remain open under #8305.

### refactor — share the slice-from-failure logic
Extracts `getFailedOpIdsFromBatch()` (the "failed op + every op after it" slice) used by the retry path, `ConflictResolutionService`, and the sync-core remote-apply path. Removes the app-side duplication **and** fixes a latent bug: `ConflictResolutionService` sliced from the `findIndex` result with no `-1` guard, so an unfound failed op would `slice(-1)` and mark only the last op failed. Behavior is otherwise unchanged.

## Test evidence
- Full op-log suite green: **2723/2725** (2 pre-existing skips).
- New **real-IndexedDB integration spec** for `retryFailedRemoteOps`: full-batch success → applied; one batch call; partial failure re-marks the failed op + everything after it; permanently-failing op rejected at the cap across reboots, then no longer returned.
- Caddyfile **runtime-validated** by Caddy v2: `caddy validate` → "Valid configuration".
- Reviewed by 6 independent agents (correctness, security, architecture, alternatives, performance, simplicity); findings addressed.

## Reviewer checklist / pre-merge gates
- [ ] CI + CodeQL green
- [ ] **SuperSync docker e2e run** — #8363 asks for e2e integration; couldn't run it in the authoring sandbox. This is the gold-standard check for a sync change.
- [ ] *(optional)* confirm redaction fires at runtime: `docker compose up` + a real WS sync + `grep docker logs token=REDACTED` (validate proves parse, not runtime behavior).
- [ ] Squash-merge (or autosquash locally) to fold the `fixup!` commit.

## Risk notes (sync-correctness)
This touches the sync path. The one behavioral change — ops after a failing op are swept into slice-from-failure and accrue retry count — matches the existing primary-path semantics, and the integration test confirms **no data loss** (rejected ops remain in the durable op-log and replay on boot). No corruption path found in review; the docker e2e is the remaining empirical confirmation.
