### PR TITLE
refactor(op-log): reduce duplication in persistence paths

### DIFF
--- a/src/app/op-log/apply/archive-operation-handler.service.ts
+++ b/src/app/op-log/apply/archive-operation-handler.service.ts
@@ -468,86 +468,30 @@ export class ArchiveOperationHandler implements ArchiveSideEffectPort<Persistent
     const originalArchiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
     const originalArchiveOld = await this._archiveDbAdapter.loadArchiveOld();
 
-    // Safety guard: Check if we're about to overwrite non-empty archives with empty ones
-    // This can happen if a full-state op (SYNC_IMPORT/REPAIR) was created with the sync
-    // getStateSnapshot() instead of getStateSnapshotAsync(), which returns
-    // DEFAULT_ARCHIVE (empty)
-    const hasExistingYoung = (originalArchiveYoung?.task?.ids?.length ?? 0) > 0;
-    const hasExistingOld = (originalArchiveOld?.task?.ids?.length ?? 0) > 0;
-    const isIncomingYoungEmpty = !archiveYoung?.task?.ids?.length;
-    const isIncomingOldEmpty = !archiveOld?.task?.ids?.length;
-
     // Write archiveYoung if present in the import data
     if (archiveYoung !== undefined) {
-      if (hasExistingYoung && isIncomingYoungEmpty) {
-        const existingCount = originalArchiveYoung?.task?.ids?.length ?? 0;
-        if (
-          action.meta.opType === OpType.SyncImport ||
-          action.meta.opType === OpType.Repair
-        ) {
-          // SYNC_IMPORT/REPAIR with empty archives is most often a bug (full-state
-          // op built with the sync getStateSnapshot() instead of
-          // getStateSnapshotAsync()). Preserve local archives: discarding non-empty
-          // local data for an empty payload is never the safe choice.
-          OpLog.warn(
-            `[ArchiveOperationHandler] ${action.meta.opType} has empty archiveYoung but local has ${existingCount} tasks. ` +
-              'Preserving local archives (this is likely a bug in the full-state op source).',
-          );
-          // Skip writing empty archive - preserve local
-        } else if (action.meta.opType === OpType.BackupImport) {
-          // BACKUP_IMPORT is an explicit user action - ask for confirmation
-          const confirmed = confirmDialog(
-            `This backup has empty archives, but you have ${existingCount} archived tasks locally. ` +
-              'Restoring will delete your archived data. Continue?',
-          );
-          if (!confirmed) {
-            throw new Error(
-              '[ArchiveOperationHandler] User cancelled backup import to preserve archives',
-            );
-          }
-          await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
-        } else {
-          await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
-        }
-      } else {
+      if (
+        await this._guardArchiveOverwrite({
+          label: 'archiveYoung',
+          existing: originalArchiveYoung,
+          incoming: archiveYoung,
+          opType: action.meta.opType,
+        })
+      ) {
         await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
       }
     }
 
     // Write archiveOld if present in the import data
     if (archiveOld !== undefined) {
-      let shouldWriteArchiveOld = true;
-
-      if (hasExistingOld && isIncomingOldEmpty) {
-        const existingCount = originalArchiveOld?.task?.ids?.length ?? 0;
-        if (
-          action.meta.opType === OpType.SyncImport ||
-          action.meta.opType === OpType.Repair
-        ) {
-          // SYNC_IMPORT/REPAIR with empty archives is most often a bug (full-state
-          // op built with the sync getStateSnapshot() instead of
-          // getStateSnapshotAsync()). Preserve local archives: discarding non-empty
-          // local data for an empty payload is never the safe choice.
-          OpLog.warn(
-            `[ArchiveOperationHandler] ${action.meta.opType} has empty archiveOld but local has ${existingCount} tasks. ` +
-              'Preserving local archives (this is likely a bug in the full-state op source).',
-          );
-          shouldWriteArchiveOld = false;
-        } else if (action.meta.opType === OpType.BackupImport) {
-          // BACKUP_IMPORT is an explicit user action - ask for confirmation
-          const confirmed = confirmDialog(
-            `This backup has empty old archives, but you have ${existingCount} old archived tasks locally. ` +
-              'Restoring will delete your old archived data. Continue?',
-          );
-          if (!confirmed) {
-            throw new Error(
-              '[ArchiveOperationHandler] User cancelled backup import to preserve archives',
-            );
-          }
-        }
-      }
-
-      if (shouldWriteArchiveOld) {
+      if (
+        await this._guardArchiveOverwrite({
+          label: 'archiveOld',
+          existing: originalArchiveOld,
+          incoming: archiveOld,
+          opType: action.meta.opType,
+        })
+      ) {
         try {
           await this._archiveDbAdapter.saveArchiveOld(archiveOld);
         } catch (e) {
@@ -575,5 +519,52 @@ export class ArchiveOperationHandler implements ArchiveSideEffectPort<Persistent
     OpLog.log(
       '[ArchiveOperationHandler] Wrote archive data from SYNC_IMPORT/BACKUP_IMPORT',
     );
+  }
+
+  /**
+   * Safety guard: prevents overwriting a non-empty local archive with an empty
+   * incoming one. Returns true if the caller should proceed with the write.
+   *
+   * Handles three opType paths:
+   * - SYNC_IMPORT / REPAIR: silently preserves local (empty incoming is likely a bug)
+   * - BACKUP_IMPORT: asks user for confirmation (explicit restore action)
+   * - default: allows the write
+   */
+  private async _guardArchiveOverwrite(opts: {
+    label: 'archiveYoung' | 'archiveOld';
+    existing: ArchiveModel | undefined;
+    incoming: ArchiveModel | undefined;
+    opType: OpType;
+  }): Promise<boolean> {
+    const hasExisting = (opts.existing?.task?.ids?.length ?? 0) > 0;
+    const isIncomingEmpty = !opts.incoming?.task?.ids?.length;
+
+    if (!hasExisting || !isIncomingEmpty) {
+      return true;
+    }
+
+    const existingCount = opts.existing?.task?.ids?.length ?? 0;
+
+    if (opts.opType === OpType.SyncImport || opts.opType === OpType.Repair) {
+      OpLog.warn(
+        `[ArchiveOperationHandler] ${opts.opType} has empty ${opts.label} but local has ${existingCount} tasks. ` +
+          'Preserving local archives (this is likely a bug in the full-state op source).',
+      );
+      return false;
+    }
+
+    if (opts.opType === OpType.BackupImport) {
+      const confirmed = confirmDialog(
+        `This backup has empty ${opts.label === 'archiveYoung' ? '' : 'old '}archives, but you have ${existingCount} ${opts.label === 'archiveYoung' ? '' : 'old '}archived tasks locally. ` +
+          `Restoring will delete your ${opts.label === 'archiveYoung' ? '' : 'old '}archived data. Continue?`,
+      );
+      if (!confirmed) {
+        throw new Error(
+          '[ArchiveOperationHandler] User cancelled backup import to preserve archives',
+        );
+      }
+    }
+
+    return true;
   }
 }

--- a/src/app/op-log/backup/state-snapshot.service.ts
+++ b/src/app/op-log/backup/state-snapshot.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Selector, Store } from '@ngrx/store';
 import { combineLatest, firstValueFrom } from 'rxjs';
 import { first } from 'rxjs/operators';
 
@@ -35,6 +35,41 @@ const DEFAULT_ARCHIVE: ArchiveModel = {
   timeTracking: initialTimeTrackingState,
   lastTimeTrackingFlush: 0,
 };
+
+/**
+ * Single source of truth for the NgRx selectors that make up the snapshot.
+ * Both _getNgRxDataSync() and getStateSnapshotAsync() iterate this list,
+ * so adding a new synced model requires updating it in exactly one place.
+ *
+ * The order is load-bearing for _getNgRxDataSync — each entry's key
+ * determines where the value lands in the returned AppStateSnapshot.
+ * The first entry must be `task` because it receives special treatment
+ * (selectedTaskId / currentTaskId clearing).
+ */
+type NgRxModelKey = keyof Omit<AppStateSnapshot, 'archiveYoung' | 'archiveOld'>;
+
+const SNAPSHOT_SELECTORS: readonly {
+  key: NgRxModelKey;
+  selector: Selector<object, unknown>;
+}[] = [
+  { key: 'task', selector: selectTaskFeatureState },
+  { key: 'project', selector: selectProjectFeatureState },
+  { key: 'tag', selector: selectTagFeatureState },
+  { key: 'globalConfig', selector: selectConfigFeatureState },
+  { key: 'note', selector: selectNoteFeatureState },
+  { key: 'issueProvider', selector: selectIssueProviderState },
+  { key: 'planner', selector: selectPlannerState },
+  { key: 'boards', selector: selectBoardsState },
+  { key: 'metric', selector: selectMetricFeatureState },
+  { key: 'simpleCounter', selector: selectSimpleCounterFeatureState },
+  { key: 'taskRepeatCfg', selector: selectTaskRepeatCfgFeatureState },
+  { key: 'menuTree', selector: selectMenuTreeState },
+  { key: 'timeTracking', selector: selectTimeTrackingState },
+  { key: 'pluginUserData', selector: selectPluginUserDataFeatureState },
+  { key: 'pluginMetadata', selector: selectPluginMetadataFeatureState },
+  { key: 'reminders', selector: selectReminderFeatureState },
+  { key: 'section', selector: selectSectionFeatureState },
+] as const;
 
 /**
  * Service that reads complete application state from NgRx store and IndexedDB.
@@ -105,72 +140,19 @@ export class StateSnapshotService {
       this._loadArchive('archiveOld'),
     ]);
 
-    const ngRxData = await firstValueFrom(
-      combineLatest([
-        this._store.select(selectTaskFeatureState),
-        this._store.select(selectProjectFeatureState),
-        this._store.select(selectTagFeatureState),
-        this._store.select(selectConfigFeatureState),
-        this._store.select(selectNoteFeatureState),
-        this._store.select(selectIssueProviderState),
-        this._store.select(selectPlannerState),
-        this._store.select(selectBoardsState),
-        this._store.select(selectMetricFeatureState),
-        this._store.select(selectSimpleCounterFeatureState),
-        this._store.select(selectTaskRepeatCfgFeatureState),
-        this._store.select(selectMenuTreeState),
-        this._store.select(selectTimeTrackingState),
-        this._store.select(selectPluginUserDataFeatureState),
-        this._store.select(selectPluginMetadataFeatureState),
-        this._store.select(selectReminderFeatureState),
-        this._store.select(selectSectionFeatureState),
-      ]).pipe(first()),
+    const ngRxValues = await firstValueFrom(
+      combineLatest(SNAPSHOT_SELECTORS.map((s) => this._store.select(s.selector))).pipe(
+        first(),
+      ),
     );
 
-    const [
-      task,
-      project,
-      tag,
-      globalConfig,
-      note,
-      issueProvider,
-      planner,
-      boards,
-      metric,
-      simpleCounter,
-      taskRepeatCfg,
-      menuTree,
-      timeTracking,
-      pluginUserData,
-      pluginMetadata,
-      reminders,
-      section,
-    ] = ngRxData;
+    const result: Partial<Record<NgRxModelKey, unknown>> = {};
+    for (let i = 0; i < SNAPSHOT_SELECTORS.length; i++) {
+      result[SNAPSHOT_SELECTORS[i].key] = ngRxValues[i];
+    }
 
     return {
-      task: {
-        ...(task as object),
-        selectedTaskId: environment.production
-          ? null
-          : ((task as { selectedTaskId?: string | null })?.selectedTaskId ?? null),
-        currentTaskId: null,
-      },
-      project,
-      tag,
-      globalConfig,
-      note,
-      issueProvider,
-      planner,
-      boards,
-      metric,
-      simpleCounter,
-      taskRepeatCfg,
-      menuTree,
-      timeTracking,
-      pluginUserData,
-      pluginMetadata,
-      reminders,
-      section,
+      ...this._normalizeNgRxData(result),
       archiveYoung,
       archiveOld,
     };
@@ -185,114 +167,38 @@ export class StateSnapshotService {
   }
 
   private _getNgRxDataSync(): Omit<AppStateSnapshot, 'archiveYoung' | 'archiveOld'> {
-    let task: unknown,
-      project: unknown,
-      tag: unknown,
-      globalConfig: unknown,
-      note: unknown;
-    let issueProvider: unknown, planner: unknown, boards: unknown, metric: unknown;
-    let simpleCounter: unknown,
-      taskRepeatCfg: unknown,
-      menuTree: unknown,
-      timeTracking: unknown,
-      section: unknown;
-    let pluginUserData: unknown, pluginMetadata: unknown, reminders: unknown;
+    const result: Partial<Record<NgRxModelKey, unknown>> = {};
 
     // Subscribe synchronously to get current values
-    this._store
-      .select(selectTaskFeatureState)
-      .pipe(first())
-      .subscribe((v) => (task = v));
-    this._store
-      .select(selectProjectFeatureState)
-      .pipe(first())
-      .subscribe((v) => (project = v));
-    this._store
-      .select(selectTagFeatureState)
-      .pipe(first())
-      .subscribe((v) => (tag = v));
-    this._store
-      .select(selectConfigFeatureState)
-      .pipe(first())
-      .subscribe((v) => (globalConfig = v));
-    this._store
-      .select(selectNoteFeatureState)
-      .pipe(first())
-      .subscribe((v) => (note = v));
-    this._store
-      .select(selectIssueProviderState)
-      .pipe(first())
-      .subscribe((v) => (issueProvider = v));
-    this._store
-      .select(selectPlannerState)
-      .pipe(first())
-      .subscribe((v) => (planner = v));
-    this._store
-      .select(selectBoardsState)
-      .pipe(first())
-      .subscribe((v) => (boards = v));
-    this._store
-      .select(selectMetricFeatureState)
-      .pipe(first())
-      .subscribe((v) => (metric = v));
-    this._store
-      .select(selectSimpleCounterFeatureState)
-      .pipe(first())
-      .subscribe((v) => (simpleCounter = v));
-    this._store
-      .select(selectTaskRepeatCfgFeatureState)
-      .pipe(first())
-      .subscribe((v) => (taskRepeatCfg = v));
-    this._store
-      .select(selectMenuTreeState)
-      .pipe(first())
-      .subscribe((v) => (menuTree = v));
-    this._store
-      .select(selectTimeTrackingState)
-      .pipe(first())
-      .subscribe((v) => (timeTracking = v));
-    this._store
-      .select(selectPluginUserDataFeatureState)
-      .pipe(first())
-      .subscribe((v) => (pluginUserData = v));
-    this._store
-      .select(selectPluginMetadataFeatureState)
-      .pipe(first())
-      .subscribe((v) => (pluginMetadata = v));
-    this._store
-      .select(selectReminderFeatureState)
-      .pipe(first())
-      .subscribe((v) => (reminders = v));
-    this._store
-      .select(selectSectionFeatureState)
-      .pipe(first())
-      .subscribe((v) => (section = v));
+    for (const { key, selector } of SNAPSHOT_SELECTORS) {
+      this._store
+        .select(selector)
+        .pipe(first())
+        .subscribe((v) => (result[key] = v));
+    }
 
+    return this._normalizeNgRxData(result);
+  }
+
+  /**
+   * Applies the task-specific normalization (clear selectedTaskId/currentTaskId
+   * in production) and returns the result typed as AppStateSnapshot minus archives.
+   * Shared by both the sync and async snapshot paths.
+   */
+  private _normalizeNgRxData(
+    data: Partial<Record<NgRxModelKey, unknown>>,
+  ): Omit<AppStateSnapshot, 'archiveYoung' | 'archiveOld'> {
+    const task = data['task'] as object;
     return {
+      ...data,
       task: {
-        ...(task as object),
+        ...task,
         selectedTaskId: environment.production
           ? null
           : ((task as { selectedTaskId?: string | null })?.selectedTaskId ?? null),
         currentTaskId: null,
       },
-      project,
-      tag,
-      globalConfig,
-      note,
-      issueProvider,
-      planner,
-      boards,
-      metric,
-      simpleCounter,
-      taskRepeatCfg,
-      menuTree,
-      timeTracking,
-      pluginUserData,
-      pluginMetadata,
-      reminders,
-      section,
-    };
+    } as Omit<AppStateSnapshot, 'archiveYoung' | 'archiveOld'>;
   }
 
   private async _loadArchive(key: 'archiveYoung' | 'archiveOld'): Promise<ArchiveModel> {

--- a/src/app/op-log/persistence/archive-store.service.ts
+++ b/src/app/op-log/persistence/archive-store.service.ts
@@ -193,87 +193,65 @@ export class ArchiveStoreService {
   // ============================================================
 
   /**
-   * Loads archiveYoung data from IndexedDB.
-   * @returns The archive data, or undefined if not found.
+   * Shared store name type for archive_young and archive_old.
+   * Used by the private helpers below to parameterize the store.
    */
+  private _loadFromStore(
+    storeName: typeof STORE_NAMES.ARCHIVE_YOUNG | typeof STORE_NAMES.ARCHIVE_OLD,
+  ): Promise<ArchiveModel | undefined> {
+    return this._withRetryOnClose(async () => {
+      await this._ensureInit();
+      const entry = await this._adapter.get<ArchiveStoreEntry>(storeName, SINGLETON_KEY);
+      return entry?.data;
+    });
+  }
+
+  private _saveToStore(
+    storeName: typeof STORE_NAMES.ARCHIVE_YOUNG | typeof STORE_NAMES.ARCHIVE_OLD,
+    data: ArchiveModel,
+  ): Promise<void> {
+    return this._withRetryOnClose(async () => {
+      await this._ensureInit();
+      await this._adapter.put(storeName, {
+        id: SINGLETON_KEY,
+        data,
+        lastModified: Date.now(),
+      });
+    });
+  }
+
+  private _hasEntry(
+    storeName: typeof STORE_NAMES.ARCHIVE_YOUNG | typeof STORE_NAMES.ARCHIVE_OLD,
+  ): Promise<boolean> {
+    return this._withRetryOnClose(async () => {
+      await this._ensureInit();
+      const entry = await this._adapter.get(storeName, SINGLETON_KEY);
+      return !!entry;
+    });
+  }
+
   async loadArchiveYoung(): Promise<ArchiveModel | undefined> {
-    return this._withRetryOnClose(async () => {
-      await this._ensureInit();
-      const entry = await this._adapter.get<ArchiveStoreEntry>(
-        STORE_NAMES.ARCHIVE_YOUNG,
-        SINGLETON_KEY,
-      );
-      return entry?.data;
-    });
+    return this._loadFromStore(STORE_NAMES.ARCHIVE_YOUNG);
   }
 
-  /**
-   * Saves archiveYoung data to IndexedDB.
-   * @param data The archive data to save.
-   */
   async saveArchiveYoung(data: ArchiveModel): Promise<void> {
-    return this._withRetryOnClose(async () => {
-      await this._ensureInit();
-      await this._adapter.put(STORE_NAMES.ARCHIVE_YOUNG, {
-        id: SINGLETON_KEY,
-        data,
-        lastModified: Date.now(),
-      });
-    });
+    return this._saveToStore(STORE_NAMES.ARCHIVE_YOUNG, data);
   }
 
-  /**
-   * Loads archiveOld data from IndexedDB.
-   * @returns The archive data, or undefined if not found.
-   */
   async loadArchiveOld(): Promise<ArchiveModel | undefined> {
-    return this._withRetryOnClose(async () => {
-      await this._ensureInit();
-      const entry = await this._adapter.get<ArchiveStoreEntry>(
-        STORE_NAMES.ARCHIVE_OLD,
-        SINGLETON_KEY,
-      );
-      return entry?.data;
-    });
+    return this._loadFromStore(STORE_NAMES.ARCHIVE_OLD);
   }
 
-  /**
-   * Saves archiveOld data to IndexedDB.
-   * @param data The archive data to save.
-   */
   async saveArchiveOld(data: ArchiveModel): Promise<void> {
-    return this._withRetryOnClose(async () => {
-      await this._ensureInit();
-      await this._adapter.put(STORE_NAMES.ARCHIVE_OLD, {
-        id: SINGLETON_KEY,
-        data,
-        lastModified: Date.now(),
-      });
-    });
+    return this._saveToStore(STORE_NAMES.ARCHIVE_OLD, data);
   }
 
-  /**
-   * Checks if archiveYoung exists in the database.
-   * Used to determine if migration from legacy 'pf' database is needed.
-   */
   async hasArchiveYoung(): Promise<boolean> {
-    return this._withRetryOnClose(async () => {
-      await this._ensureInit();
-      const entry = await this._adapter.get(STORE_NAMES.ARCHIVE_YOUNG, SINGLETON_KEY);
-      return !!entry;
-    });
+    return this._hasEntry(STORE_NAMES.ARCHIVE_YOUNG);
   }
 
-  /**
-   * Checks if archiveOld exists in the database.
-   * Used to determine if migration from legacy 'pf' database is needed.
-   */
   async hasArchiveOld(): Promise<boolean> {
-    return this._withRetryOnClose(async () => {
-      await this._ensureInit();
-      const entry = await this._adapter.get(STORE_NAMES.ARCHIVE_OLD, SINGLETON_KEY);
-      return !!entry;
-    });
+    return this._hasEntry(STORE_NAMES.ARCHIVE_OLD);
   }
 
   /**

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -364,36 +364,68 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     }
   }
 
+  /**
+   * Builds a StoredOperationLogEntry (minus auto-incremented seq) from an
+   * Operation, encoding it to compact format. Shared by append/appendBatch/
+   * appendBatchSkipDuplicates/appendWithVectorClockUpdate.
+   */
+  private _buildStoredEntry(
+    op: Operation,
+    source: 'local' | 'remote',
+    options?: { pendingApply?: boolean },
+  ): Omit<StoredOperationLogEntry, 'seq'> {
+    return {
+      op: encodeOperation(op),
+      appliedAt: Date.now(),
+      source,
+      syncedAt: source === 'remote' ? Date.now() : undefined,
+      applicationStatus:
+        source === 'remote' ? (options?.pendingApply ? 'pending' : 'applied') : undefined,
+    };
+  }
+
+  /**
+   * Shared error handler for append operations.
+   * Translates IndexedDB DOMExceptions into typed application errors.
+   * ConstraintError also invalidates the applied-op-ids cache (issue #6213).
+   */
+  private _handleAppendError(e: unknown): never {
+    if (e instanceof DOMException && e.name === 'ConstraintError') {
+      this._appliedOpIdsCache = null;
+      this._cacheLastSeq = 0;
+      throw new Error(DUPLICATE_OPERATION_ERROR_MSG);
+    }
+    if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+      throw new StorageQuotaExceededError();
+    }
+    throw e;
+  }
+
+  /**
+   * Invalidates all caches (applied op IDs, unsynced, vector clock cache
+   * is NOT touched here). Called after bulk mutations that affect the
+   * entire ops store (clearAllOperations, runDestructiveStateReplacement,
+   * deleteOpsWhere).
+   */
+  private _invalidateAppliedAndUnsyncedCaches(): void {
+    this._appliedOpIdsCache = null;
+    this._cacheLastSeq = 0;
+    this._invalidateUnsyncedCache();
+  }
+
   async append(
     op: Operation,
     source: 'local' | 'remote' = 'local',
     options?: { pendingApply?: boolean },
   ): Promise<number> {
     await this._ensureInit();
-    // Encode operation to compact format for storage efficiency
-    const compactOp = encodeOperation(op);
-    const entry: Omit<StoredOperationLogEntry, 'seq'> = {
-      op: compactOp,
-      appliedAt: Date.now(),
-      source,
-      syncedAt: source === 'remote' ? Date.now() : undefined,
-      // For remote ops, track application status for crash recovery
-      applicationStatus:
-        source === 'remote' ? (options?.pendingApply ? 'pending' : 'applied') : undefined,
-    };
-    // seq is auto-incremented, returned for later reference
     try {
-      return await this._adapter.add(STORE_NAMES.OPS, entry);
+      return await this._adapter.add(
+        STORE_NAMES.OPS,
+        this._buildStoredEntry(op, source, options),
+      );
     } catch (e) {
-      if (e instanceof DOMException && e.name === 'ConstraintError') {
-        this._appliedOpIdsCache = null;
-        this._cacheLastSeq = 0;
-        throw new Error(DUPLICATE_OPERATION_ERROR_MSG);
-      }
-      if (e instanceof DOMException && e.name === 'QuotaExceededError') {
-        throw new StorageQuotaExceededError();
-      }
-      throw e;
+      this._handleAppendError(e);
     }
   }
 
@@ -410,39 +442,17 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         async (tx) => {
           const seqs: number[] = [];
           for (const op of ops) {
-            // Encode operation to compact format for storage efficiency
-            const compactOp = encodeOperation(op);
-            const entry: Omit<StoredOperationLogEntry, 'seq'> = {
-              op: compactOp,
-              appliedAt: Date.now(),
-              source,
-              syncedAt: source === 'remote' ? Date.now() : undefined,
-              applicationStatus:
-                source === 'remote'
-                  ? options?.pendingApply
-                    ? 'pending'
-                    : 'applied'
-                  : undefined,
-            };
-            const seq = await tx.add(STORE_NAMES.OPS, entry);
+            const seq = await tx.add(
+              STORE_NAMES.OPS,
+              this._buildStoredEntry(op, source, options),
+            );
             seqs.push(seq);
           }
           return seqs;
         },
       );
     } catch (e) {
-      // Cache is stale if we hit a constraint error - invalidate to force refresh
-      // This handles the case where a previous sync partially wrote ops before failing,
-      // leaving the cache out of sync with IndexedDB. See issue #6213.
-      if (e instanceof DOMException && e.name === 'ConstraintError') {
-        this._appliedOpIdsCache = null;
-        this._cacheLastSeq = 0;
-        throw new Error(DUPLICATE_OPERATION_ERROR_MSG);
-      }
-      if (e instanceof DOMException && e.name === 'QuotaExceededError') {
-        throw new StorageQuotaExceededError();
-      }
-      throw e;
+      this._handleAppendError(e);
     }
   }
 
@@ -488,20 +498,10 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
             continue;
           }
 
-          const compactOp = encodeOperation(op);
-          const entry: Omit<StoredOperationLogEntry, 'seq'> = {
-            op: compactOp,
-            appliedAt: Date.now(),
-            source,
-            syncedAt: source === 'remote' ? Date.now() : undefined,
-            applicationStatus:
-              source === 'remote'
-                ? options?.pendingApply
-                  ? 'pending'
-                  : 'applied'
-                : undefined,
-          };
-          const seq = await tx.add(STORE_NAMES.OPS, entry);
+          const seq = await tx.add(
+            STORE_NAMES.OPS,
+            this._buildStoredEntry(op, source, options),
+          );
           seqs.push(seq);
           writtenOps.push(op);
         }
@@ -654,32 +654,45 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
    * @returns The latest full-state operation entry, or undefined if none exists
    */
   async getLatestFullStateOpEntry(): Promise<OperationLogEntry | undefined> {
-    await this._ensureInit();
-
     let latestEntry: OperationLogEntry | undefined;
 
+    await this._forEachFullStateOp((entry) => {
+      // Track the latest by UUIDv7 (lexicographic comparison works for UUIDv7).
+      // We never stop early: UUIDv7 order can differ from seq order when remote
+      // ops with earlier timestamps arrive later, so we must scan all full-state
+      // ops to find the one with the latest UUIDv7 id.
+      if (!latestEntry || entry.op.id > latestEntry.op.id) {
+        latestEntry = entry;
+      }
+      return 'continue';
+    });
+
+    return latestEntry;
+  }
+
+  /**
+   * Iterates all ops, decodes each entry, and invokes `cb` for every
+   * full-state op (SYNC_IMPORT, BACKUP_IMPORT, REPAIR). Return `'stop'`
+   * from `cb` to end the scan early.
+   *
+   * Shared by `getLatestFullStateOpEntry` and `clearFullStateOpsExcept`
+   * to avoid duplicating the decode + isFullStateOpType check.
+   */
+  private async _forEachFullStateOp(
+    cb: (entry: OperationLogEntry) => 'continue' | 'stop',
+  ): Promise<void> {
+    await this._ensureInit();
     await this._adapter.iterate<StoredOperationLogEntry>(
       STORE_NAMES.OPS,
-      // Pure read: readonly avoids a write lock on the hot ops store.
-      { direction: 'prev', mode: 'readonly' },
+      { mode: 'readonly' },
       (value) => {
         const entry = decodeStoredEntry(value);
-        const isFullStateOp = isFullStateOpType(entry.op.opType);
-
-        if (isFullStateOp) {
-          // Track the latest by UUIDv7 (lexicographic comparison works for UUIDv7)
-          if (!latestEntry || entry.op.id > latestEntry.op.id) {
-            latestEntry = entry;
-          }
+        if (isFullStateOpType(entry.op.opType)) {
+          return cb(entry);
         }
-        // We never stop early: UUIDv7 order can differ from seq order when remote
-        // ops with earlier timestamps arrive later, so we must scan all full-state
-        // ops to find the one with the latest UUIDv7 id.
         return 'continue';
       },
     );
-
-    return latestEntry;
   }
 
   /**
@@ -736,26 +749,15 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
    * @returns Number of operations deleted
    */
   async clearFullStateOpsExcept(excludeIds: string[]): Promise<number> {
-    await this._ensureInit();
-
     const excludeIdSet = new Set(excludeIds);
     const opsToDelete: string[] = [];
 
-    // Find all full-state ops except the excluded ones. Pure read scan — the
-    // delete happens in a separate transaction below — so readonly to avoid
-    // taking a write lock on the hot ops store (parity with the pre-adapter
-    // cursor, which was readonly).
-    await this._adapter.iterate<StoredOperationLogEntry>(
-      STORE_NAMES.OPS,
-      { mode: 'readonly' },
-      (value) => {
-        const entry = decodeStoredEntry(value);
-        if (isFullStateOpType(entry.op.opType) && !excludeIdSet.has(entry.op.id)) {
-          opsToDelete.push(entry.op.id);
-        }
-        return 'continue';
-      },
-    );
+    await this._forEachFullStateOp((entry) => {
+      if (!excludeIdSet.has(entry.op.id)) {
+        opsToDelete.push(entry.op.id);
+      }
+      return 'continue';
+    });
 
     await this._deleteOpsByIds(opsToDelete);
     return opsToDelete.length;
@@ -986,9 +988,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
 
     // Invalidate caches if any ops were deleted to prevent stale data
     if (deletedCount > 0) {
-      this._appliedOpIdsCache = null;
-      this._cacheLastSeq = 0;
-      this._invalidateUnsyncedCache();
+      this._invalidateAppliedAndUnsyncedCaches();
     }
   }
 
@@ -1246,11 +1246,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         await tx.clear(store);
       }
     });
-    // Invalidate all caches
-    this._appliedOpIdsCache = null;
-    this._cacheLastSeq = 0;
-    this._unsyncedCache = null;
-    this._unsyncedCacheLastSeq = 0;
+    this._invalidateAppliedAndUnsyncedCaches();
     this._vectorClockCache = null;
   }
 
@@ -1315,10 +1311,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
   async clearAllOperations(): Promise<void> {
     await this._ensureInit();
     await this._adapter.clear(STORE_NAMES.OPS);
-    // Invalidate caches since we cleared all ops
-    this._appliedOpIdsCache = null;
-    this._cacheLastSeq = 0;
-    this._invalidateUnsyncedCache();
+    this._invalidateAppliedAndUnsyncedCaches();
   }
 
   // ============================================================
@@ -1558,20 +1551,10 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         'readwrite',
         async (tx) => {
           // 1. Append operation to ops store (encoded to compact format)
-          const compactOp = encodeOperation(op);
-          const entry: Omit<StoredOperationLogEntry, 'seq'> = {
-            op: compactOp,
-            appliedAt: Date.now(),
-            source,
-            syncedAt: source === 'remote' ? Date.now() : undefined,
-            applicationStatus:
-              source === 'remote'
-                ? options?.pendingApply
-                  ? 'pending'
-                  : 'applied'
-                : undefined,
-          };
-          const seq = await tx.add(STORE_NAMES.OPS, entry);
+          const seq = await tx.add(
+            STORE_NAMES.OPS,
+            this._buildStoredEntry(op, source, options),
+          );
 
           // 2. Update vector clock to match the operation's clock (only for
           // local ops). The op.vectorClock already contains the incremented
@@ -1590,15 +1573,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         },
       );
     } catch (e) {
-      if (e instanceof DOMException && e.name === 'ConstraintError') {
-        this._appliedOpIdsCache = null;
-        this._cacheLastSeq = 0;
-        throw new Error(DUPLICATE_OPERATION_ERROR_MSG);
-      }
-      if (e instanceof DOMException && e.name === 'QuotaExceededError') {
-        throw new StorageQuotaExceededError();
-      }
-      throw e;
+      this._handleAppendError(e);
     }
   }
 
@@ -1635,7 +1610,6 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     const newState = syncImportOp.payload;
     const newVectorClock = syncImportOp.vectorClock;
     const compactedAt = Date.now();
-    const compactOp = encodeOperation(syncImportOp);
     const storeNames: OpLogStoreName[] = [
       STORE_NAMES.OPS,
       STORE_NAMES.STATE_CACHE,
@@ -1667,14 +1641,10 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
 
         await tx.clear(STORE_NAMES.OPS);
 
-        const entry: Omit<StoredOperationLogEntry, 'seq'> = {
-          op: compactOp,
-          appliedAt: Date.now(),
-          source: 'local',
-          syncedAt: undefined,
-          applicationStatus: undefined,
-        };
-        const seq = await tx.add(STORE_NAMES.OPS, entry);
+        const seq = await tx.add(
+          STORE_NAMES.OPS,
+          this._buildStoredEntry(syncImportOp, 'local'),
+        );
 
         await tx.put(
           STORE_NAMES.VECTOR_CLOCK,
@@ -1710,9 +1680,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       });
 
       // Reached only on a committed transaction.
-      this._appliedOpIdsCache = null;
-      this._cacheLastSeq = 0;
-      this._invalidateUnsyncedCache();
+      this._invalidateAppliedAndUnsyncedCaches();
       this._vectorClockCache = newVectorClock;
       // The clientId rotated atomically with the stores above. Invalidate the
       // ClientIdService cache so the next read sees the rotated value. On


### PR DESCRIPTION
## What

Extract helpers that preserve public behavior and storage formats exactly, across 4 files identified in #7920.

### archive-store.service.ts
- `_loadFromStore` / `_saveToStore` / `_hasEntry` helpers parameterized by store name
- 6 public methods (`loadArchiveYoung/Old`, `saveArchiveYoung/Old`, `hasArchiveYoung/Old`) become one-liner delegations

### operation-log-store.service.ts
- `_buildStoredEntry`: shared entry construction for `append` / `appendBatch` / `appendBatchSkipDuplicates` / `appendWithVectorClockUpdate` / `runDestructiveStateReplacement`
- `_handleAppendError`: shared `ConstraintError` / `QuotaExceededError` handling across 3 append methods
- `_invalidateAppliedAndUnsyncedCaches`: shared cache invalidation for `deleteOpsWhere` / `clearAllOperations` / `runDestructiveStateReplacement` / `_clearAllDataForTesting`

### state-snapshot.service.ts
- `SNAPSHOT_SELECTORS` constant array — single source of truth for the 17 NgRx selectors
- `_normalizeNgRxData`: shared task field normalization (`selectedTaskId` / `currentTaskId` clearing)
- Eliminates the dual 17-selector listing and dual destructuring in `_getNgRxDataSync` and `getStateSnapshotAsync`

### archive-operation-handler.service.ts
- `_guardArchiveOverwrite`: consolidates empty-archive overwrite protection for `SyncImport` / `Repair` / `BackupImport` across `archiveYoung` and `archiveOld`

## Why

Adding a new synced model or changing error handling currently requires updating multiple independent copies of the same logic. These extractions make each concern single-sourced.

## Risk

Medium-low. All public APIs and storage formats unchanged. Behavioral equivalence verified by existing tests (11027 passed).

## Verification
- `npm run test` — all unit tests pass
- `npm run lint` — no new lint issues

Fixes #7920