### PR TITLE
fix(shortcuts): respect macOS keyboard layout for globals

### DIFF
--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -5,6 +5,7 @@ import {
   TaskWidgetConfig,
 } from '../src/app/features/config/global-config.model';
 import { KeyboardConfig } from '../src/app/features/config/keyboard-config.model';
+import type { KeyboardLayoutSnapshot } from '../src/app/core/keyboard-layout/keyboard-layout.service';
 import { JiraCfg } from '../src/app/features/issue/providers/jira/jira.model';
 import { AppDataCompleteLegacy } from '../src/app/imex/sync/sync.model';
 import { Task } from '../src/app/features/tasks/task.model';
@@ -227,7 +228,10 @@ export interface ElectronAPI {
 
   updateTitleBarDarkMode(isDarkMode: boolean): void;
 
-  registerGlobalShortcuts(keyboardConfig: KeyboardConfig): void;
+  registerGlobalShortcuts(
+    keyboardConfig: KeyboardConfig,
+    keyboardLayout?: KeyboardLayoutSnapshot,
+  ): void;
 
   showFullScreenBlocker(args: { msg?: string; takeABreakCfg: TakeABreakConfig }): void;
 

--- a/electron/global-shortcut-layout.test.cjs
+++ b/electron/global-shortcut-layout.test.cjs
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+require('ts-node/register/transpile-only');
+
+const modulePath = path.resolve(__dirname, 'ipc-handlers/global-shortcut-layout.ts');
+
+const loadModule = () => {
+  delete require.cache[modulePath];
+  return require(modulePath);
+};
+
+test('maps macOS QWERTZ layout Y shortcut to the QWERTY physical accelerator', () => {
+  const { normalizeGlobalShortcutForKeyboardLayout } = loadModule();
+
+  assert.equal(
+    normalizeGlobalShortcutForKeyboardLayout('Meta+Y', [['KeyZ', 'y']], true),
+    'Meta+Z',
+  );
+});
+
+test('maps macOS QWERTZ layout Z shortcut to the QWERTY physical accelerator', () => {
+  const { normalizeGlobalShortcutForKeyboardLayout } = loadModule();
+
+  assert.equal(
+    normalizeGlobalShortcutForKeyboardLayout('Meta+Z', [['KeyY', 'z']], true),
+    'Meta+Y',
+  );
+});
+
+test('keeps shortcuts unchanged without macOS or a keyboard layout snapshot', () => {
+  const { normalizeGlobalShortcutForKeyboardLayout } = loadModule();
+
+  assert.equal(
+    normalizeGlobalShortcutForKeyboardLayout('Meta+Y', [['KeyZ', 'y']], false),
+    'Meta+Y',
+  );
+  assert.equal(normalizeGlobalShortcutForKeyboardLayout('Meta+Y', [], true), 'Meta+Y');
+  assert.equal(
+    normalizeGlobalShortcutForKeyboardLayout('Meta+Y', undefined, true),
+    'Meta+Y',
+  );
+});
+
+test('preserves plus-key accelerator parsing', () => {
+  const { normalizeGlobalShortcutForKeyboardLayout } = loadModule();
+
+  assert.equal(
+    normalizeGlobalShortcutForKeyboardLayout('Ctrl++', [['BracketRight', '+']], true),
+    'Ctrl++',
+  );
+});

--- a/electron/ipc-handlers/global-shortcut-layout.ts
+++ b/electron/ipc-handlers/global-shortcut-layout.ts
@@ -1,0 +1,72 @@
+import type { KeyboardLayoutSnapshot } from '../../src/app/core/keyboard-layout/keyboard-layout.service';
+
+const KEY_CODE_PREFIX = 'Key';
+const PLUS_KEY = '+';
+
+const isLetterKey = (key: string): boolean => /^[A-Z]$/i.test(key);
+
+const parseAccelerator = (
+  accelerator: string,
+): { modifiers: string[]; key: string } | null => {
+  const normalized = accelerator.trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.endsWith(PLUS_KEY + PLUS_KEY)) {
+    return {
+      modifiers: normalized.slice(0, -1).split(PLUS_KEY).filter(Boolean),
+      key: PLUS_KEY,
+    };
+  }
+
+  const parts = normalized.split(PLUS_KEY).filter(Boolean);
+  const key = parts.at(-1);
+
+  return key
+    ? {
+        modifiers: parts.slice(0, -1),
+        key,
+      }
+    : null;
+};
+
+const findQwertyKeyForLayoutKey = (
+  key: string,
+  keyboardLayout: KeyboardLayoutSnapshot,
+): string | null => {
+  const lowerCaseKey = key.toLowerCase();
+  const match = keyboardLayout.find(
+    ([code, value]) =>
+      code.startsWith(KEY_CODE_PREFIX) &&
+      code.length === 4 &&
+      value.toLowerCase() === lowerCaseKey,
+  );
+
+  return match ? match[0].slice(KEY_CODE_PREFIX.length).toUpperCase() : null;
+};
+
+export const normalizeGlobalShortcutForKeyboardLayout = (
+  accelerator: string,
+  keyboardLayout: KeyboardLayoutSnapshot | undefined,
+  isMac = process.platform === 'darwin',
+): string => {
+  if (!isMac || !keyboardLayout?.length) {
+    return accelerator;
+  }
+
+  const parsedAccelerator = parseAccelerator(accelerator);
+
+  if (!parsedAccelerator || !isLetterKey(parsedAccelerator.key)) {
+    return accelerator;
+  }
+
+  const qwertyKey = findQwertyKeyForLayoutKey(parsedAccelerator.key, keyboardLayout);
+
+  if (!qwertyKey) {
+    return accelerator;
+  }
+
+  return [...parsedAccelerator.modifiers, qwertyKey].join(PLUS_KEY);
+};

--- a/electron/ipc-handlers/global-shortcuts.ts
+++ b/electron/ipc-handlers/global-shortcuts.ts
@@ -1,6 +1,7 @@
 import { globalShortcut, ipcMain } from 'electron';
 import { IPC } from '../shared-with-frontend/ipc-events.const';
 import { KeyboardConfig } from '../../src/app/features/config/keyboard-config.model';
+import type { KeyboardLayoutSnapshot } from '../../src/app/core/keyboard-layout/keyboard-layout.service';
 import { getWin, setWasMaximizedBeforeHide } from '../main-window';
 import { toggleTaskWidgetVisibility } from '../task-widget/task-widget';
 import { showOrFocus } from '../various-shared';
@@ -8,14 +9,18 @@ import { ensureIndicator } from '../indicator';
 import { getIsMinimizeToTray } from '../shared-state';
 import { IS_MAC } from '../common.const';
 import { errorHandlerWithFrontendInform } from '../error-handler-with-frontend-inform';
+import { normalizeGlobalShortcutForKeyboardLayout } from './global-shortcut-layout';
 
 export const initGlobalShortcutsIpc = (): void => {
-  ipcMain.on(IPC.REGISTER_GLOBAL_SHORTCUTS_EVENT, (_ev, cfg) => {
-    registerShowAppShortCuts(cfg);
+  ipcMain.on(IPC.REGISTER_GLOBAL_SHORTCUTS_EVENT, (_ev, cfg, keyboardLayout) => {
+    registerShowAppShortCuts(cfg, keyboardLayout);
   });
 };
 
-const registerShowAppShortCuts = (cfg: KeyboardConfig): void => {
+const registerShowAppShortCuts = (
+  cfg: KeyboardConfig,
+  keyboardLayout?: KeyboardLayoutSnapshot,
+): void => {
   // unregister all previous
   globalShortcut.unregisterAll();
   const GLOBAL_KEY_CFG_KEYS: (keyof KeyboardConfig)[] = [
@@ -93,18 +98,23 @@ const registerShowAppShortCuts = (cfg: KeyboardConfig): void => {
         }
 
         if (shortcut && shortcut.length > 0) {
+          const registeredShortcut = normalizeGlobalShortcutForKeyboardLayout(
+            shortcut,
+            keyboardLayout,
+            IS_MAC,
+          );
           try {
-            const ret = globalShortcut.register(shortcut, actionFn) as unknown;
+            const ret = globalShortcut.register(registeredShortcut, actionFn) as unknown;
             if (!ret) {
               errorHandlerWithFrontendInform(
                 'Global Shortcut registration failed: ' + shortcut,
-                shortcut,
+                { shortcut, registeredShortcut },
               );
             }
           } catch (e) {
             errorHandlerWithFrontendInform(
               'Global Shortcut registration failed: ' + shortcut,
-              { e, shortcut },
+              { e, shortcut, registeredShortcut },
             );
           }
         }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -218,8 +218,8 @@ const ea: ElectronAPI = {
   updateTaskWidgetSettings: (cfg) => _send('UPDATE_TASK_WIDGET_SETTINGS', cfg),
   updateTitleBarDarkMode: (isDarkMode: boolean) =>
     _send('UPDATE_TITLE_BAR_DARK_MODE', isDarkMode),
-  registerGlobalShortcuts: (keyboardCfg) =>
-    _send('REGISTER_GLOBAL_SHORTCUTS', keyboardCfg),
+  registerGlobalShortcuts: (keyboardCfg, keyboardLayout) =>
+    _send('REGISTER_GLOBAL_SHORTCUTS', keyboardCfg, keyboardLayout),
   showFullScreenBlocker: (args) => _send('FULL_SCREEN_BLOCKER', args),
 
   makeJiraRequest: (args) => _send('JIRA_MAKE_REQUEST_EVENT', args),

--- a/src/app/core/keyboard-layout/keyboard-layout.service.spec.ts
+++ b/src/app/core/keyboard-layout/keyboard-layout.service.spec.ts
@@ -4,6 +4,7 @@ import {
   KeyboardLayout,
   NavigatorWithKeyboard,
 } from './keyboard-layout.service';
+import { firstValueFrom } from 'rxjs';
 
 describe('KeyboardLayoutService', () => {
   let service: KeyboardLayoutService;
@@ -35,6 +36,22 @@ describe('KeyboardLayoutService', () => {
       expect(service.layout.size).toBe(2);
       expect(service.layout.get('KeyA')).toBe('a');
       expect(service.layout.get('KeyB')).toBe('b');
+    });
+  });
+
+  describe('layoutSnapshot', () => {
+    it('should return a serializable copy of the current layout', () => {
+      service.setLayout(
+        new Map([
+          ['KeyA', 'a'],
+          ['KeyZ', 'y'],
+        ]),
+      );
+
+      expect(service.layoutSnapshot).toEqual([
+        ['KeyA', 'a'],
+        ['KeyZ', 'y'],
+      ]);
     });
   });
 
@@ -192,6 +209,26 @@ describe('KeyboardLayoutService', () => {
       expect(service.layout.size).toBe(1);
       expect(service.layout.get('KeyZ')).toBe('z');
       expect(service.layout.has('KeyX')).toBe(false);
+    });
+
+    it('should emit the updated layout snapshot after saving', async () => {
+      const mockLayoutMap = new Map([['KeyZ', 'y']]);
+
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          keyboard: {
+            getLayoutMap: () => Promise.resolve(mockLayoutMap),
+          },
+        } as NavigatorWithKeyboard,
+        writable: true,
+        configurable: true,
+      });
+
+      const emittedLayout = firstValueFrom(service.layoutChanges$);
+
+      await service.saveUserLayout();
+
+      expect(await emittedLayout).toEqual([['KeyZ', 'y']]);
     });
   });
 });

--- a/src/app/core/keyboard-layout/keyboard-layout.service.ts
+++ b/src/app/core/keyboard-layout/keyboard-layout.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
 
 export interface NavigatorWithKeyboard {
   keyboard?: NavigatorKeyboard;
@@ -15,6 +16,7 @@ export interface NavigatorKeyboard {
  * See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardLayoutMap#browser_compatibility
  */
 export type KeyboardLayout = Map<string, string>;
+export type KeyboardLayoutSnapshot = readonly (readonly [string, string])[];
 
 /**
  * Service that manages the user's keyboard layout mapping.
@@ -29,6 +31,7 @@ export type KeyboardLayout = Map<string, string>;
 })
 export class KeyboardLayoutService {
   private _layout: KeyboardLayout = new Map();
+  private _layoutChanges$ = new Subject<KeyboardLayoutSnapshot>();
 
   /**
    * Gets the current keyboard layout map.
@@ -36,6 +39,14 @@ export class KeyboardLayoutService {
    */
   get layout(): KeyboardLayout {
     return this._layout;
+  }
+
+  get layoutSnapshot(): KeyboardLayoutSnapshot {
+    return Array.from(this._layout.entries());
+  }
+
+  get layoutChanges$(): Observable<KeyboardLayoutSnapshot> {
+    return this._layoutChanges$.asObservable();
   }
 
   /**
@@ -54,6 +65,7 @@ export class KeyboardLayoutService {
     const kbLayout = await keyboard.getLayoutMap();
     this._layout.clear();
     kbLayout.forEach((value, key) => this._layout.set(key, value));
+    this._emitLayoutChange();
   }
 
   /**
@@ -71,5 +83,10 @@ export class KeyboardLayoutService {
   setLayout(layout: KeyboardLayout): void {
     this._layout.clear();
     layout.forEach((value, key) => this._layout.set(key, value));
+    this._emitLayoutChange();
+  }
+
+  private _emitLayoutChange(): void {
+    this._layoutChanges$.next(this.layoutSnapshot);
   }
 }

--- a/src/app/features/config/store/global-config.effects.spec.ts
+++ b/src/app/features/config/store/global-config.effects.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { GlobalConfigEffects } from './global-config.effects';
+import { IS_ELECTRON_TOKEN } from './global-config.effects';
 import { DateService } from 'src/app/core/date/date.service';
 import { LanguageService } from '../../../core/language/language.service';
 import { SnackService } from '../../../core/snack/snack.service';
@@ -15,12 +16,18 @@ import { loadAllData } from '../../../root-store/meta/load-all-data.action';
 import { DEFAULT_GLOBAL_CONFIG } from '../default-global-config.const';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { selectAllTasks } from '../../tasks/store/task.selectors';
+import { KeyboardLayoutService } from '../../../core/keyboard-layout/keyboard-layout.service';
+import { selectKeyboardConfig } from './global-config.reducer';
 
 describe('GlobalConfigEffects', () => {
   let effects: GlobalConfigEffects;
   let actions$: Subject<Action>;
   let dateServiceSpy: jasmine.SpyObj<DateService>;
   let store: MockStore;
+  let keyboardLayoutService: KeyboardLayoutService;
+  let originalElectronApi: typeof window.ea | undefined;
+  let originalNavigator: Navigator;
+  let registerGlobalShortcutsSpy: jasmine.Spy;
 
   beforeEach(() => {
     actions$ = new Subject<Action>();
@@ -31,6 +38,13 @@ describe('GlobalConfigEffects', () => {
     ]);
     dateServiceSpy.todayStr.and.returnValue('2026-02-20');
     dateServiceSpy.getStartOfNextDayDiffMs.and.returnValue(0);
+    originalNavigator = globalThis.navigator;
+    originalElectronApi = window.ea;
+    registerGlobalShortcutsSpy = jasmine.createSpy('registerGlobalShortcuts');
+    window.ea = {
+      ...(window.ea ?? {}),
+      registerGlobalShortcuts: registerGlobalShortcutsSpy,
+    } as unknown as typeof window.ea;
 
     TestBed.configureTestingModule({
       providers: [
@@ -38,6 +52,7 @@ describe('GlobalConfigEffects', () => {
         provideMockActions(() => actions$),
         provideMockStore(),
         { provide: LOCAL_ACTIONS, useValue: actions$ },
+        { provide: IS_ELECTRON_TOKEN, useValue: true },
         { provide: DateService, useValue: dateServiceSpy },
         {
           provide: LanguageService,
@@ -56,12 +71,75 @@ describe('GlobalConfigEffects', () => {
 
     store = TestBed.inject(MockStore);
     store.overrideSelector(selectAllTasks, []);
+    store.overrideSelector(selectKeyboardConfig, DEFAULT_GLOBAL_CONFIG.keyboard);
+    keyboardLayoutService = TestBed.inject(KeyboardLayoutService);
     effects = TestBed.inject(GlobalConfigEffects);
     effects.setStartOfNextDayDiffOnLoad.subscribe();
   });
 
   afterEach(() => {
     store.resetSelectors();
+    window.ea = originalElectronApi as typeof window.ea;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+      configurable: true,
+    });
+    keyboardLayoutService.clear();
+  });
+
+  describe('global shortcut registration', () => {
+    it('should register global shortcuts with the current keyboard layout snapshot on load', () => {
+      keyboardLayoutService.setLayout(new Map([['KeyZ', 'y']]));
+      effects.registerGlobalShortcutInitially$.subscribe();
+
+      actions$.next(
+        loadAllData({
+          appDataComplete: {
+            globalConfig: {
+              ...DEFAULT_GLOBAL_CONFIG,
+              keyboard: {
+                ...DEFAULT_GLOBAL_CONFIG.keyboard,
+                globalShowHide: 'Meta+Y',
+              },
+            },
+          } as any,
+        }),
+      );
+
+      expect(registerGlobalShortcutsSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({ globalShowHide: 'Meta+Y' }),
+        [['KeyZ', 'y']],
+      );
+    });
+
+    it('should re-register global shortcuts when the keyboard layout is saved', async () => {
+      const keyboardCfg = {
+        ...DEFAULT_GLOBAL_CONFIG.keyboard,
+        globalShowHide: 'Meta+Y',
+      };
+      store.overrideSelector(selectKeyboardConfig, keyboardCfg);
+      store.refreshState();
+      const subscription: Subscription =
+        effects.reregisterGlobalShortcutsOnKeyboardLayoutChange$.subscribe();
+
+      Object.defineProperty(globalThis, 'navigator', {
+        value: {
+          keyboard: {
+            getLayoutMap: () => Promise.resolve(new Map([['KeyZ', 'y']])),
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      await keyboardLayoutService.saveUserLayout();
+
+      expect(registerGlobalShortcutsSpy).toHaveBeenCalledWith(keyboardCfg, [
+        ['KeyZ', 'y'],
+      ]);
+      subscription.unsubscribe();
+    });
   });
 
   describe('setStartOfNextDayDiffOnChange', () => {

--- a/src/app/features/config/store/global-config.effects.ts
+++ b/src/app/features/config/store/global-config.effects.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 import { createEffect, ofType } from '@ngrx/effects';
 import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
 import {
@@ -21,6 +21,7 @@ import { KeyboardConfig } from '../keyboard-config.model';
 import { updateGlobalConfigSection } from './global-config.actions';
 import {
   selectConfigFeatureState,
+  selectKeyboardConfig,
   selectLocalizationConfig,
 } from './global-config.reducer';
 import { AppFeaturesConfig, MiscConfig } from '../global-config.model';
@@ -30,6 +31,12 @@ import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions'
 import { selectAllTasks } from '../../tasks/store/task.selectors';
 import { normalizeStartOfNextDayConfig } from '../normalize-start-of-next-day-config';
 import { Log } from '../../../core/log';
+import { KeyboardLayoutService } from '../../../core/keyboard-layout/keyboard-layout.service';
+
+export const IS_ELECTRON_TOKEN = new InjectionToken<boolean>('IS_ELECTRON_TOKEN', {
+  providedIn: 'root',
+  factory: () => IS_ELECTRON,
+});
 
 @Injectable()
 export class GlobalConfigEffects {
@@ -39,6 +46,8 @@ export class GlobalConfigEffects {
   private _snackService = inject(SnackService);
   private _store = inject(Store);
   private _userProfileService = inject(UserProfileService);
+  private _keyboardLayoutService = inject(KeyboardLayoutService);
+  private _isElectron = inject(IS_ELECTRON_TOKEN);
 
   snackUpdate$ = createEffect(
     () =>
@@ -65,11 +74,21 @@ export class GlobalConfigEffects {
     () =>
       this._actions$.pipe(
         ofType(updateGlobalConfigSection),
-        filter(({ sectionKey, sectionCfg }) => IS_ELECTRON && sectionKey === 'keyboard'),
-        tap(({ sectionKey, sectionCfg }) => {
+        filter(({ sectionKey }) => this._isElectron && sectionKey === 'keyboard'),
+        tap(({ sectionCfg }) => {
           const keyboardCfg: KeyboardConfig = sectionCfg as KeyboardConfig;
-          window.ea.registerGlobalShortcuts(keyboardCfg);
+          this._registerGlobalShortcuts(keyboardCfg);
         }),
+      ),
+    { dispatch: false },
+  );
+
+  reregisterGlobalShortcutsOnKeyboardLayoutChange$ = createEffect(
+    () =>
+      this._keyboardLayoutService.layoutChanges$.pipe(
+        filter(() => this._isElectron),
+        withLatestFrom(this._store.select(selectKeyboardConfig)),
+        tap(([, keyboardCfg]) => this._registerGlobalShortcuts(keyboardCfg)),
       ),
     { dispatch: false },
   );
@@ -78,13 +97,13 @@ export class GlobalConfigEffects {
     () =>
       this._actions$.pipe(
         ofType(loadAllData),
-        filter(() => IS_ELECTRON),
+        filter(() => this._isElectron),
         tap((action) => {
           const appDataComplete = action.appDataComplete;
           const keyboardCfg: KeyboardConfig = (
             appDataComplete.globalConfig || DEFAULT_GLOBAL_CONFIG
           ).keyboard;
-          window.ea.registerGlobalShortcuts(keyboardCfg);
+          this._registerGlobalShortcuts(keyboardCfg);
         }),
       ),
     { dispatch: false },
@@ -258,4 +277,11 @@ export class GlobalConfigEffects {
       ),
     { dispatch: false },
   );
+
+  private _registerGlobalShortcuts(keyboardCfg: KeyboardConfig): void {
+    window.ea.registerGlobalShortcuts(
+      keyboardCfg,
+      this._keyboardLayoutService.layoutSnapshot,
+    );
+  }
 }

--- a/src/app/features/config/store/global-config.reducer.ts
+++ b/src/app/features/config/store/global-config.reducer.ts
@@ -96,6 +96,7 @@ export const selectPomodoroConfig = createConfigSectionSelector('pomodoro');
 export const selectFlowtimeConfig = createConfigSectionSelector('flowtime');
 export const selectReminderConfig = createConfigSectionSelector('reminder');
 export const selectAppFeaturesConfig = createConfigSectionSelector('appFeatures');
+export const selectKeyboardConfig = createConfigSectionSelector('keyboard');
 export const selectIsFocusModeEnabled = createSelector(
   selectConfigFeatureState,
   (cfg): boolean =>


### PR DESCRIPTION
## Problem

Fixes #8378.

On macOS, Electron global shortcuts can ignore the active system keyboard layout. This caused layout-aware shortcuts recorded in Super Productivity to behave incorrectly on non-QWERTY layouts, for example German QWERTZ where `Y` and `Z` are swapped.

## Solution

Global shortcut registration now passes the renderer’s saved keyboard layout snapshot to Electron main.

On macOS only, global shortcut accelerators are translated from the displayed layout character to the QWERTY physical key that Electron’s `globalShortcut` listener expects. The stored shortcut value remains unchanged, so the UI still shows the user’s intended layout-aware shortcut.

The fix also re-registers global shortcuts after the keyboard layout is detected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Testing

- [x] `node --test electron/global-shortcut-layout.test.cjs`
- [x] `npm run test:file src/app/core/keyboard-layout/keyboard-layout.service.spec.ts -- --watch=false`
- [x] `npm run test:file src/app/features/config/store/global-config.effects.spec.ts -- --watch=false`
- [x] `npm run electron:build`
- [x] `npm run test:electron`
- [x] Full pre-push `npm test`