### PR TITLE
fix(backup): guard iOS backup against overwrite on transient read failure (#8414)

### DIFF
--- a/src/app/imex/local-backup/local-backup.service.spec.ts
+++ b/src/app/imex/local-backup/local-backup.service.spec.ts
@@ -298,6 +298,8 @@ describe('LocalBackupService', () => {
     type LocalBackupServiceWithIosRing = {
       _readIOSExistingSlotOrThrow: (path: string) => Promise<string | null>;
       _readIOSFileOrNull: (path: string) => Promise<string | null>;
+      _readIOSFileRaw: (path: string) => Promise<string>;
+      _iosFileExists: (path: string) => Promise<boolean>;
       _writeIOSFile: (path: string, data: string) => Promise<void>;
     };
 
@@ -360,6 +362,32 @@ describe('LocalBackupService', () => {
       await (service as unknown as LocalBackupServiceWithPrivate)._backup();
 
       expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('still writes the primary on the first-ever backup when the raw read throws (#8414)', async () => {
+      // Capacitor signals a missing file by THROWING (same as a transient
+      // failure), so the absent re-probe must let the write proceed end-to-end —
+      // the overwrite guard must not over-correct and block a legitimate first
+      // backup. Exercises _readIOSExistingSlotOrThrow's raw-throw + confirmed-absent
+      // branch through _backup().
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosRing,
+        '_readIOSFileRaw',
+      ).and.rejectWith(new Error('File does not exist'));
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosRing,
+        '_iosFileExists',
+      ).and.resolveTo(false);
+      const writeSpy = spyOn(
+        service as unknown as LocalBackupServiceWithIosRing,
+        '_writeIOSFile',
+      ).and.resolveTo();
+
+      await (service as unknown as LocalBackupServiceWithPrivate)._backup();
+
+      // No prev promotion (nothing to promote) — just the single primary write.
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      expect(writeSpy.calls.mostRecent().args[0]).toBe(PRIMARY);
     });
 
     it('loadBackupIOS resolves to "" (never throws) when no usable backup exists', async () => {

--- a/src/app/imex/local-backup/local-backup.service.spec.ts
+++ b/src/app/imex/local-backup/local-backup.service.spec.ts
@@ -296,6 +296,7 @@ describe('LocalBackupService', () => {
     const PREV = 'super-productivity-backup.prev.json';
 
     type LocalBackupServiceWithIosRing = {
+      _readIOSExistingSlotOrThrow: (path: string) => Promise<string | null>;
       _readIOSFileOrNull: (path: string) => Promise<string | null>;
       _writeIOSFile: (path: string, data: string) => Promise<void>;
     };
@@ -312,7 +313,7 @@ describe('LocalBackupService', () => {
       const existing = JSON.stringify({ task: { ids: ['existing'] } });
       spyOn(
         service as unknown as LocalBackupServiceWithIosRing,
-        '_readIOSFileOrNull',
+        '_readIOSExistingSlotOrThrow',
       ).and.resolveTo(existing);
       const writeSpy = spyOn(
         service as unknown as LocalBackupServiceWithIosRing,
@@ -330,7 +331,7 @@ describe('LocalBackupService', () => {
     it('skips promotion when there is no existing backup yet', async () => {
       spyOn(
         service as unknown as LocalBackupServiceWithIosRing,
-        '_readIOSFileOrNull',
+        '_readIOSExistingSlotOrThrow',
       ).and.resolveTo(null);
       const writeSpy = spyOn(
         service as unknown as LocalBackupServiceWithIosRing,
@@ -343,6 +344,24 @@ describe('LocalBackupService', () => {
       expect(writeSpy.calls.mostRecent().args[0]).toBe(PRIMARY);
     });
 
+    it('bails without writing when the existing slot read fails transiently (#8414)', async () => {
+      // A transient read failure must NOT be mistaken for "no backup yet": the
+      // primary stays untouched (no prev promotion, no overwrite), preserving both
+      // ring slots so the next cycle can retry. Mirrors the Android guard.
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosRing,
+        '_readIOSExistingSlotOrThrow',
+      ).and.rejectWith(new Error('transient read failure'));
+      const writeSpy = spyOn(
+        service as unknown as LocalBackupServiceWithIosRing,
+        '_writeIOSFile',
+      ).and.resolveTo();
+
+      await (service as unknown as LocalBackupServiceWithPrivate)._backup();
+
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
     it('loadBackupIOS resolves to "" (never throws) when no usable backup exists', async () => {
       // Guards the fire-and-forget startup path from an unhandled rejection.
       spyOn(
@@ -351,6 +370,65 @@ describe('LocalBackupService', () => {
       ).and.resolveTo(null);
 
       await expectAsync(service.loadBackupIOS()).toBeResolvedTo('');
+    });
+  });
+
+  describe('_readIOSExistingSlotOrThrow (write-path read, #8414)', () => {
+    type LocalBackupServiceWithIosSlotRead = {
+      _readIOSExistingSlotOrThrow: (path: string) => Promise<string | null>;
+      _readIOSFileRaw: (path: string) => Promise<string>;
+      _iosFileExists: (path: string) => Promise<boolean>;
+    };
+
+    it('returns the file contents when the read succeeds', async () => {
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosSlotRead,
+        '_readIOSFileRaw',
+      ).and.resolveTo('the-backup');
+
+      const result = await (
+        service as unknown as LocalBackupServiceWithIosSlotRead
+      )._readIOSExistingSlotOrThrow('some-path');
+
+      expect(result).toBe('the-backup');
+    });
+
+    it('returns null when the read fails AND the file is confirmed absent', async () => {
+      // First-ever backup: no file exists. The write must be allowed to proceed.
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosSlotRead,
+        '_readIOSFileRaw',
+      ).and.rejectWith(new Error('File does not exist'));
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosSlotRead,
+        '_iosFileExists',
+      ).and.resolveTo(false);
+
+      const result = await (
+        service as unknown as LocalBackupServiceWithIosSlotRead
+      )._readIOSExistingSlotOrThrow('some-path');
+
+      expect(result).toBeNull();
+    });
+
+    it('rethrows when the read fails but the file still exists (transient failure)', async () => {
+      // The slot is there but momentarily unreadable: we must NOT treat this as
+      // "no backup" — rethrow so the caller bails without overwriting.
+      const readErr = new Error('transient read failure');
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosSlotRead,
+        '_readIOSFileRaw',
+      ).and.rejectWith(readErr);
+      spyOn(
+        service as unknown as LocalBackupServiceWithIosSlotRead,
+        '_iosFileExists',
+      ).and.resolveTo(true);
+
+      await expectAsync(
+        (
+          service as unknown as LocalBackupServiceWithIosSlotRead
+        )._readIOSExistingSlotOrThrow('some-path'),
+      ).toBeRejectedWith(readErr);
     });
   });
 
@@ -407,7 +485,7 @@ describe('LocalBackupService', () => {
     };
 
     type LocalBackupServiceWithIosRing = {
-      _readIOSFileOrNull: (path: string) => Promise<string | null>;
+      _readIOSExistingSlotOrThrow: (path: string) => Promise<string | null>;
       _writeIOSFile: (path: string, data: string) => Promise<void>;
     };
 
@@ -493,7 +571,7 @@ describe('LocalBackupService', () => {
         );
         spyOn(
           service as unknown as LocalBackupServiceWithIosRing,
-          '_readIOSFileOrNull',
+          '_readIOSExistingSlotOrThrow',
         ).and.resolveTo(makeStoredBackup(20));
         const writeSpy = spyOn(
           service as unknown as LocalBackupServiceWithIosRing,
@@ -513,7 +591,7 @@ describe('LocalBackupService', () => {
         );
         spyOn(
           service as unknown as LocalBackupServiceWithIosRing,
-          '_readIOSFileOrNull',
+          '_readIOSExistingSlotOrThrow',
         ).and.resolveTo(makeStoredBackup(20));
         const writeSpy = spyOn(
           service as unknown as LocalBackupServiceWithIosRing,

--- a/src/app/imex/local-backup/local-backup.service.ts
+++ b/src/app/imex/local-backup/local-backup.service.ts
@@ -442,11 +442,25 @@ export class LocalBackupService {
   // Returns true when a backup was actually written, false when the A3 guard
   // skipped it or the write failed.
   private async _backupIOS(data: AppDataComplete): Promise<boolean> {
+    // Read the existing primary slot in a way that distinguishes "no backup yet"
+    // from "unreadable" (#8414): on the write path a read failure is ambiguous —
+    // we can't tell "no backup" from "couldn't read it" — so we must not overwrite
+    // the primary on uncertainty. Bail instead, preserving both ring slots; the
+    // next cycle retries. Mirrors _backupAndroid.
+    let existing: string | null;
     try {
-      const existing = await this._readIOSFileOrNull(IOS_BACKUP_FILENAME);
-      if (this._guardNearEmptyOverwrite(data, existing, 'iOS')) {
-        return false;
-      }
+      existing = await this._readIOSExistingSlotOrThrow(IOS_BACKUP_FILENAME);
+    } catch (e) {
+      Log.err(
+        'LocalBackupService: skipping iOS backup — could not read existing slot',
+        e,
+      );
+      return false;
+    }
+    if (this._guardNearEmptyOverwrite(data, existing, 'iOS')) {
+      return false;
+    }
+    try {
       if (existing) {
         await this._writeIOSFile(IOS_BACKUP_PREV_FILENAME, existing);
       }
@@ -468,17 +482,49 @@ export class LocalBackupService {
     });
   }
 
+  private async _readIOSFileRaw(path: string): Promise<string> {
+    const result = await Filesystem.readFile({
+      path,
+      directory: Directory.Data,
+      encoding: Encoding.UTF8,
+    });
+    return result.data as string;
+  }
+
+  /**
+   * Read-path helper: swallows ALL errors and returns null. Safe for
+   * loadBackupIOS (fire-and-forget startup restore), where a missing-vs-unreadable
+   * distinction can't cause data loss and a throw would surface as an unhandled
+   * rejection. NOT for the write path — see _readIOSExistingSlotOrThrow.
+   */
   private async _readIOSFileOrNull(path: string): Promise<string | null> {
     try {
-      const result = await Filesystem.readFile({
-        path,
-        directory: Directory.Data,
-        encoding: Encoding.UTF8,
-      });
-      return result.data as string;
+      return await this._readIOSFileRaw(path);
     } catch {
-      // File doesn't exist
+      // File doesn't exist (or is unreadable — irrelevant on the read path).
       return null;
+    }
+  }
+
+  /**
+   * Write-path helper (#8414): returns null only when the slot is *confirmed
+   * absent* (a legitimate first backup, where the write should proceed), and
+   * rethrows on a transient read failure so the caller bails WITHOUT overwriting,
+   * preserving both ring slots. Capacitor signals a missing file with a thrown
+   * error — the same way it signals a transient failure — so on error we re-probe
+   * with stat(): only a still-absent file reads as "no backup"; anything else is
+   * treated as uncertain and rethrown. Mirrors _backupAndroid's guard.
+   */
+  private async _readIOSExistingSlotOrThrow(path: string): Promise<string | null> {
+    try {
+      return await this._readIOSFileRaw(path);
+    } catch (e) {
+      if (!(await this._iosFileExists(path))) {
+        // Confirmed absent → no existing backup, let the write proceed.
+        return null;
+      }
+      // File is present but unreadable → transient. Don't overwrite on uncertainty.
+      throw e;
     }
   }
 


### PR DESCRIPTION
The iOS write path read the existing primary slot via _readIOSFileOrNull,
which swallows all errors and returns null. On a transient read failure that
made `existing` look like "no backup yet": the near-empty guard and prev-slot
promotion were skipped and the primary was overwritten with no prev copy
preserved — defeating the two-generation ring exactly when it is needed.

Add a write-path reader (_readIOSExistingSlotOrThrow) that distinguishes a
confirmed-absent slot (legitimate first backup → null, write proceeds) from a
transient read failure (re-probed via stat → rethrow), and make _backupIOS
bail without overwriting on uncertainty, mirroring _backupAndroid's guard.
The read/restore path keeps _readIOSFileOrNull's swallow-all behavior, which
is correct there.