### PR TITLE
fix(focus-mode): persist fullscreen notes when a session ends mid-edit

### DIFF
--- a/e2e/tests/focus-mode/focus-mode-notes-fullscreen-save.spec.ts
+++ b/e2e/tests/focus-mode/focus-mode-notes-fullscreen-save.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect } from '../../fixtures/test.fixture';
+import { WorkViewPage } from '../../pages/work-view.page';
+import { cssSelectors } from '../../constants/selectors';
+
+/**
+ * Repro for the Reddit report: notes written in focus mode's fullscreen
+ * markdown editor vanish after clicking "Save".
+ *
+ * The fullscreen markdown dialog is a detached CDK overlay; it routes its
+ * result back through the originating <inline-markdown> component's `changed`
+ * output. When a focus session ends WHILE the dialog is open, the focus-mode
+ * overlay swaps screens (Main → SessionDone) and destroys the <inline-markdown>
+ * that opened the dialog. On Save, `changed` then emits into a dead listener
+ * and the note is silently dropped — the data-loss the user reported.
+ *
+ * Test 1 guards the normal path (session still running). Test 2 reproduces the
+ * actual bug: the session completes mid-edit.
+ */
+test.describe('Focus Mode - fullscreen notes save', () => {
+  const NOTE_TEXT = 'My long plan list from focus mode';
+
+  const startSessionInProgress = async (
+    page: import('@playwright/test').Page,
+    workViewPage: WorkViewPage,
+    mode?: 'Pomodoro',
+  ): Promise<void> => {
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask('Focus note task sd:today');
+
+    const firstTask = page.locator('task').first();
+    await expect(firstTask).toBeVisible();
+
+    // Track the task so the focus-mode play button is enabled.
+    await firstTask.hover();
+    const taskPlayBtn = page.locator('.play-btn.tour-playBtn').first();
+    await taskPlayBtn.waitFor({ state: 'visible' });
+    await taskPlayBtn.click();
+    await expect(firstTask).toHaveClass(/isCurrent/, { timeout: 5000 });
+
+    const mainFocusButton = page
+      .getByRole('button')
+      .filter({ hasText: 'center_focus_strong' });
+    await mainFocusButton.click();
+
+    if (mode) {
+      const modeButton = page.locator('focus-mode-main segmented-button-group button', {
+        hasText: mode,
+      });
+      await modeButton.click();
+    }
+
+    const playButton = page.locator('focus-mode-main button.play-button');
+    await expect(playButton).toBeVisible({ timeout: 5000 });
+    await playButton.click();
+
+    // Countdown animation runs, then the session is InProgress.
+    await expect(page.locator('focus-mode-countdown')).not.toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.locator('focus-mode-main button.complete-session-btn')).toBeVisible(
+      { timeout: 20000 },
+    );
+  };
+
+  test('persists a note saved from the fullscreen editor', async ({
+    page,
+    testPrefix,
+    taskPage,
+  }) => {
+    const workViewPage = new WorkViewPage(page, testPrefix);
+    await startSessionInProgress(page, workViewPage);
+
+    // Open the notes panel.
+    await page.locator('focus-mode-main .show-additional-info-btn').click();
+    const notesPanel = page.locator('focus-mode-main .notes-panel');
+    await expect(notesPanel).toBeVisible();
+
+    // Open the fullscreen markdown editor (the only UI with a Save button).
+    await notesPanel.locator('button', { hasText: 'fullscreen' }).click();
+    const dialog = page.locator('dialog-fullscreen-markdown');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Write the note and Save.
+    const textarea = dialog.locator('textarea');
+    await textarea.click();
+    await textarea.fill(NOTE_TEXT);
+    await page.locator('#T-save-note').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Ground truth: the note must be persisted on the task. Hide the focus
+    // overlay (keeps the session running) and read the task's real notes from
+    // the work-view detail panel.
+    await page.locator('focus-mode-overlay .close-btn').click();
+    await expect(page.locator('focus-mode-overlay')).not.toBeVisible({
+      timeout: 5000,
+    });
+
+    const task = taskPage.getTaskByText('Focus note task');
+    await taskPage.openTaskDetail(task);
+    await expect(page.locator(cssSelectors.DETAIL_PANEL)).toContainText(NOTE_TEXT, {
+      timeout: 5000,
+    });
+  });
+
+  // The real bug: while the fullscreen editor is open the focus session
+  // auto-completes, the focus-mode overlay swaps screens and destroys the
+  // editor, and Save must still persist the note. Shared by the Countdown and
+  // Pomodoro variants (the two modes whose timer auto-completes; Flowtime never
+  // does). Slow (~1min) because there is no sub-minute UI duration: we shrink
+  // the timer to ~1 min and let it elapse with the dialog open.
+  const expectNoteSurvivesMidEditCompletion = async (
+    page: import('@playwright/test').Page,
+    taskPage: import('../../pages/task.page').TaskPage,
+    workViewPage: WorkViewPage,
+    mode?: 'Pomodoro',
+  ): Promise<void> => {
+    await startSessionInProgress(page, workViewPage, mode);
+
+    // Shrink the timer to ~1 min (default is 25 min, the time-adjust button
+    // removes 1 min each) so it completes on its own shortly.
+    const decreaseBtn = page.locator('focus-mode-main .time-adjust-btn--decrease');
+    await expect(decreaseBtn).toBeVisible();
+    for (let i = 0; i < 24; i++) {
+      await decreaseBtn.click();
+    }
+
+    // Open notes → fullscreen → start writing.
+    await page.locator('focus-mode-main .show-additional-info-btn').click();
+    const notesPanel = page.locator('focus-mode-main .notes-panel');
+    await expect(notesPanel).toBeVisible();
+    await notesPanel.locator('button', { hasText: 'fullscreen' }).click();
+    const dialog = page.locator('dialog-fullscreen-markdown');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    const textarea = dialog.locator('textarea');
+    await textarea.click();
+    await textarea.fill(NOTE_TEXT);
+
+    // While we keep the dialog open, the focus session auto-completes: the
+    // in-progress complete-session button detaches once it leaves InProgress.
+    await expect(
+      page.locator('focus-mode-main button.complete-session-btn'),
+    ).not.toBeAttached({ timeout: 90000 });
+
+    // Now save the long note.
+    await page.locator('#T-save-note').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // The note must be persisted on the task even though the session ended
+    // mid-edit. Read the task's real notes from the detail panel.
+    await page.locator('focus-mode-overlay .close-btn').click();
+    await expect(page.locator('focus-mode-overlay')).not.toBeVisible({
+      timeout: 5000,
+    });
+    const task = taskPage.getTaskByText('Focus note task');
+    await taskPage.openTaskDetail(task);
+    await expect(page.locator(cssSelectors.DETAIL_PANEL)).toContainText(NOTE_TEXT, {
+      timeout: 5000,
+    });
+  };
+
+  test('persists a note when a Countdown session completes while the fullscreen editor is open', async ({
+    page,
+    testPrefix,
+    taskPage,
+  }) => {
+    test.setTimeout(120000);
+    const workViewPage = new WorkViewPage(page, testPrefix);
+    await expectNoteSurvivesMidEditCompletion(page, taskPage, workViewPage);
+  });
+
+  test('persists a note when a Pomodoro session completes while the fullscreen editor is open', async ({
+    page,
+    testPrefix,
+    taskPage,
+  }) => {
+    test.setTimeout(120000);
+    const workViewPage = new WorkViewPage(page, testPrefix);
+    await expectNoteSurvivesMidEditCompletion(page, taskPage, workViewPage, 'Pomodoro');
+  });
+});

--- a/e2e/tests/recurring/recurring-start-date-epoch-bug-6860.spec.ts
+++ b/e2e/tests/recurring/recurring-start-date-epoch-bug-6860.spec.ts
@@ -10,6 +10,13 @@ import { saveRecurDialog, setRecurStartDate } from '../../utils/recurring-task-h
  * causing validateDate() to reject all dates via Invalid Date comparison,
  * which the formly parser then converted to '1970-01-01'.
  */
+
+// Pin today so the hardcoded start date below stays in the future: the
+// datepicker disables past days, so without a fixed clock the helper-based
+// test breaks once the wall clock passes the hardcoded date (e.g. a scheduled
+// run on 2026-06-16 could no longer click the disabled 2026-06-15 cell).
+const FIXED_TODAY = new Date('2026-05-01T10:00:00');
+
 test.describe('Recurring Task - Start Date Epoch Bug (#6860)', () => {
   test('should preserve start date when configuring recurring task via calendar', async ({
     page,
@@ -94,6 +101,10 @@ test.describe('Recurring Task - Start Date Epoch Bug (#6860)', () => {
     taskPage,
     testPrefix,
   }) => {
+    // Fix today to May 1, 2026 so the hardcoded 15/06/2026 start date stays a
+    // selectable (enabled) future day in the datepicker.
+    await page.clock.setFixedTime(FIXED_TODAY);
+    await page.reload();
     await workViewPage.waitForTaskList();
 
     // 1. Create a task

--- a/src/app/core/theme/custom-theme.service.ts
+++ b/src/app/core/theme/custom-theme.service.ts
@@ -177,7 +177,8 @@ export const BUILT_IN_THEMES: CustomTheme[] = [
     name: 'Rainbow',
     kind: 'builtin',
     url: 'assets/themes/rainbow.css',
-    requiredMode: 'system',
+    // Neon glow pass needs a dark canvas — picking it auto-applies dark mode.
+    requiredMode: 'dark',
   },
   {
     id: 'velvet',

--- a/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.spec.ts
@@ -5,10 +5,12 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { InlineMarkdownComponent } from './inline-markdown.component';
 import { GlobalConfigService } from '../../features/config/global-config.service';
 import { ClipboardImageService } from '../../core/clipboard-image/clipboard-image.service';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
+import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
+import { Log } from '../../core/log';
 
 describe('InlineMarkdownComponent', () => {
   let component: InlineMarkdownComponent;
@@ -1738,6 +1740,127 @@ describe('InlineMarkdownComponent', () => {
       fixture.detectChanges();
       component.uncheckAllChecklistItems();
       expect(component.changed.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fullscreen editor save after the host is destroyed mid-edit', () => {
+    let afterClosed$: Subject<unknown>;
+    let store: MockStore;
+
+    beforeEach(() => {
+      afterClosed$ = new Subject<unknown>();
+      mockMatDialog.open.and.returnValue({
+        afterClosed: () => afterClosed$.asObservable(),
+      } as any);
+      store = TestBed.inject(MockStore);
+      spyOn(store, 'dispatch');
+      spyOn(component.changed, 'emit');
+      fixture.componentRef.setInput('taskId', 'task-1');
+      fixture.detectChanges();
+    });
+
+    // Regression: the fullscreen dialog is a detached overlay. When the focus
+    // session ends mid-edit it destroys the component that opened the dialog, so
+    // emitting `changed` on save would reach no listener and the note is lost.
+    it('persists the note directly to the task when destroyed while the dialog is open', () => {
+      component.openFullScreen();
+      component.ngOnDestroy();
+
+      afterClosed$.next('saved note');
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.updateTask({
+          task: { id: 'task-1', changes: { notes: 'saved note' } },
+        }),
+      );
+      expect(component.changed.emit).not.toHaveBeenCalled();
+    });
+
+    it('emits via `changed` (no direct dispatch) when still alive', () => {
+      component.openFullScreen();
+
+      afterClosed$.next('saved note');
+
+      expect(component.changed.emit).toHaveBeenCalledWith('saved note');
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('persists a replacement of pre-existing notes when destroyed mid-edit', () => {
+      component.model = 'original notes';
+      fixture.detectChanges();
+      component.openFullScreen();
+      component.ngOnDestroy();
+
+      afterClosed$.next('original notes plus more');
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.updateTask({
+          task: { id: 'task-1', changes: { notes: 'original notes plus more' } },
+        }),
+      );
+    });
+
+    it('clears the note (DELETE) directly when destroyed mid-edit', () => {
+      component.model = 'some real notes';
+      fixture.detectChanges();
+      component.openFullScreen();
+      component.ngOnDestroy();
+
+      afterClosed$.next({ action: 'DELETE' });
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.updateTask({ task: { id: 'task-1', changes: { notes: '' } } }),
+      );
+      expect(component.changed.emit).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the dialog is closed without a result (Close, not Save)', () => {
+      component.openFullScreen();
+      component.ngOnDestroy();
+
+      afterClosed$.next(undefined);
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+      expect(component.changed.emit).not.toHaveBeenCalled();
+    });
+
+    it('does not persist when the content is unchanged (no default-text write-back)', () => {
+      component.model = 'How can I best achieve it now?';
+      fixture.detectChanges();
+      component.openFullScreen();
+      component.ngOnDestroy();
+
+      afterClosed$.next('How can I best achieve it now?');
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+      expect(component.changed.emit).not.toHaveBeenCalled();
+    });
+
+    it('treats a whitespace-only diff of the loaded text as unchanged', () => {
+      component.model = 'How can I best achieve it now?';
+      fixture.detectChanges();
+      component.openFullScreen();
+      component.ngOnDestroy();
+
+      // The editor can re-emit the placeholder with a trailing newline; that is
+      // not a real edit and must not be written back as a note.
+      afterClosed$.next('How can I best achieve it now?\n');
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('warns rather than silently dropping when destroyed without a taskId', () => {
+      const warnSpy = spyOn(Log, 'warn');
+      fixture.componentRef.setInput('taskId', undefined);
+      component.model = 'orig';
+      fixture.detectChanges();
+      component.openFullScreen();
+      component.ngOnDestroy();
+
+      afterClosed$.next('edited content');
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/ui/inline-markdown/inline-markdown.component.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.ts
@@ -38,6 +38,9 @@ import { ClipboardImageService } from '../../core/clipboard-image/clipboard-imag
 import { TaskAttachmentService } from '../../features/tasks/task-attachment/task-attachment.service';
 import { ResolveClipboardImagesDirective } from '../../core/clipboard-image/resolve-clipboard-images.directive';
 import { ClipboardPasteHandlerService } from '../../core/clipboard-image/clipboard-paste-handler.service';
+import { Store } from '@ngrx/store';
+import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
+import { Log } from '../../core/log';
 import { handleListKeydown } from './markdown-toolbar.util';
 
 const HIDE_OVERFLOW_TIMEOUT_DURATION = 300;
@@ -68,8 +71,10 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
   private _clipboardImageService = inject(ClipboardImageService);
   private _taskAttachmentService = inject(TaskAttachmentService);
   private _clipboardPasteHandler = inject(ClipboardPasteHandlerService);
+  private _store = inject(Store);
   private _currentPastePlaceholder: string | null = null;
   private _isFullscreenDialogOpen = false;
+  private _isDestroyed = false;
   private _resolveGeneration = 0;
 
   readonly isLock = input<boolean>(false);
@@ -187,6 +192,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this._isDestroyed = true;
     if (this._hideOverFlowTimeout) {
       window.clearTimeout(this._hideOverFlowTimeout);
     }
@@ -352,6 +358,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
 
   openFullScreen(): void {
     this._isFullscreenDialogOpen = true;
+    const taskId = this.taskId();
     // Read directly from textarea since modelCopy may be stale (one-way ngModel binding)
     const textareaEl = this.textareaEl();
     const currentContent = textareaEl ? textareaEl.nativeElement.value : this.modelCopy();
@@ -362,21 +369,64 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
       autoFocus: 'textarea',
       data: {
         content: currentContent,
-        taskId: this.taskId(),
+        taskId,
       },
     });
 
+    // Intentionally NOT torn down with takeUntilDestroyed: this MUST still fire
+    // after the component is destroyed — see the `_isDestroyed` branch below.
+    // afterClosed emits once then completes, so there is no leak.
     dialogRef.afterClosed().subscribe((res) => {
       this._isFullscreenDialogOpen = false;
-      // This resets the task note to its default text
+      // DELETE resets the note to its default text; a string is the saved note.
+      // A missing result (Close without saving) leaves the note untouched.
+      let newVal: string | null = null;
       if (res?.action === 'DELETE') {
-        this.modelCopy.set('');
-        this.changed.emit('');
-        // This updates the task note on click of the "Save" button only if it contains text.
+        newVal = '';
       } else if (typeof res === 'string') {
-        this.modelCopy.set(res);
-        this.changed.emit(res);
+        newVal = res;
       }
+      if (newVal === null) {
+        return;
+      }
+      this.modelCopy.set(newVal);
+
+      // The fullscreen editor is a detached overlay that outlives this
+      // component: a focus session can end mid-edit and swap the focus-mode
+      // screen, destroying us while the dialog stays open. Our `changed` output
+      // then has no listener, so emitting it would silently drop the user's
+      // note. When we've been destroyed, persist the note directly so the save
+      // survives the teardown.
+      if (this._isDestroyed) {
+        // Skip when the content is effectively unchanged from what we loaded:
+        // avoids a redundant op and stops the unmodified default-text
+        // placeholder being written back as a real note. Trimmed compare to
+        // ignore whitespace-only diffs the editor may introduce. This
+        // approximates (not duplicates) the parent's default-text guard —
+        // comparing against the loaded model is the closest signal we have here.
+        if (newVal.trim() !== (this._model ?? '').trim()) {
+          if (taskId) {
+            // shortcut: a shared ui/ component dispatching a task action is a
+            // layering compromise (TaskService can't be injected here — its
+            // eager effects need a full GlobalConfigService under test). Clean
+            // upgrade: give the surviving focus-mode container ownership of the
+            // fullscreen dialog so the save never depends on this lifetime.
+            this._store.dispatch(
+              TaskSharedActions.updateTask({
+                task: { id: taskId, changes: { notes: newVal } },
+              }),
+            );
+          } else {
+            // No task to persist to and our `changed` listener is gone — the
+            // edit cannot be saved. Surface it rather than dropping it silently.
+            Log.warn(
+              'inline-markdown: fullscreen note edit dropped on destroy (no taskId)',
+            );
+          }
+        }
+        return;
+      }
+      this.changed.emit(newVal);
     });
   }
 

--- a/src/assets/themes/rainbow.css
+++ b/src/assets/themes/rainbow.css
@@ -1,7 +1,18 @@
 /**
  * Rainbow Theme for Super Productivity
- * Colorful and playful theme with vibrant gradients and rainbow backgrounds
- * Designed for enhanced visual appeal and productivity engagement
+ * Colorful, playful theme — now with a full neon glow pass: glowing panel
+ * borders, buttons, active nav, current/selected tasks, chips, focus rings
+ * and scrollbar over a deep-space nebula background.
+ *
+ * Design notes:
+ *   - Neon needs a dark canvas, so this theme is dark-only (requiredMode:'dark'
+ *     in custom-theme.service.ts auto-applies dark mode when picked).
+ *   - All glows are STATIC box-shadows / gradients — no @keyframes on list
+ *     items. The task component is a hot path rendered once per row, so
+ *     continuous repaints are deliberately avoided.
+ *   - Each UI region leans on a different spectrum hue (violet sidenav, cyan
+ *     cards, pink banner, ...) so the whole app reads as a rainbow while any
+ *     single surface stays legible.
  */
 
 /* Smooth transitions */
@@ -16,8 +27,8 @@
 
 body {
   /* ===============================
- * RAINBOW COLOR PALETTE
- * ===============================*/
+   * RAINBOW COLOR PALETTE (playful base — kept for identity)
+   * ===============================*/
 
   --rainbow-primary: #0079bf; /* Trello blue - trust and productivity */
   --rainbow-accent: #ff6b6b; /* Coral - warm and approachable */
@@ -32,87 +43,558 @@ body {
   --rainbow-mint: #2ecc71; /* Mint - progress and balance */
   --rainbow-lavender: #af7ac5; /* Lavender - soft accent */
 
+  --task-border-radius: 16px;
+}
+
+/* ===================================================================
+ * NEON DARK THEME
+ * ===================================================================*/
+body.isDarkTheme {
+  /* ---- Neon spectrum (brighter, higher-saturation siblings of the base
+   * palette — these drive every glow) ---- */
+  --neon-violet: #b66bff;
+  --neon-blue: #5b8bff;
+  --neon-cyan: #2fe0e6;
+  --neon-teal: #2ee6c9;
+  --neon-green: #3ef2a1;
+  --neon-yellow: #ffd93d;
+  --neon-orange: #ff8a4c;
+  --neon-pink: #ff5cc8;
+  --neon-magenta: #e84df0;
+
+  /* Reusable rainbow gradient for borders / accents */
+  --rainbow-gradient: linear-gradient(
+    120deg,
+    var(--neon-violet),
+    var(--neon-blue),
+    var(--neon-cyan),
+    var(--neon-green),
+    var(--neon-yellow),
+    var(--neon-orange),
+    var(--neon-pink)
+  );
+
+  /* Glow presets (outer halos) */
+  --glow-violet: 0 0 20px color-mix(in srgb, var(--neon-violet) 60%, transparent);
+  --glow-cyan: 0 0 20px color-mix(in srgb, var(--neon-cyan) 60%, transparent);
+  --glow-pink: 0 0 20px color-mix(in srgb, var(--neon-pink) 60%, transparent);
+  --glow-green: 0 0 20px color-mix(in srgb, var(--neon-green) 60%, transparent);
+
+  /* ---- Frosted-pane material — translucent indigo + blur so the aurora
+   * shows through every panel as glass, plus a reusable outer glow. ---- */
+  --neon-blur: blur(16px) saturate(150%);
+  --neon-pane: linear-gradient(
+    165deg,
+    color-mix(in srgb, #211a44 78%, transparent) 0%,
+    color-mix(in srgb, #16112c 82%, transparent) 100%
+  );
+  --neon-pane-strong: linear-gradient(
+    165deg,
+    color-mix(in srgb, #251d4e 88%, transparent) 0%,
+    color-mix(in srgb, #181230 90%, transparent) 100%
+  );
+  --pane-glow:
+    0 0 0 1px color-mix(in srgb, var(--neon-violet) 35%, transparent),
+    0 0 28px color-mix(in srgb, var(--neon-violet) 26%, transparent),
+    0 12px 34px rgba(0, 0, 0, 0.55);
+  --pane-glow-cyan:
+    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 35%, transparent),
+    0 0 28px color-mix(in srgb, var(--neon-cyan) 26%, transparent),
+    0 12px 34px rgba(0, 0, 0, 0.55);
+
   /* ===============================
- * ACCENT & THEME COLORS
- * ===============================*/
+   * BACKGROUND COLORS — deep indigo-black "space"
+   * ===============================*/
+  --bg: #0e0b1a;
+  --bg-darker: #070510;
+  --bg-slightly-lighter: #161227;
+  --bg-lighter: #1e1834;
+  --bg-lightest: #271f44;
+  --bg-super-light: #322856;
 
-  /* Primary accent (rainbow coral) */
-  --palette-accent-500: var(--rainbow-accent);
-  --c-accent: var(--rainbow-accent);
-  --palette-accent-100: #ffe3e3;
-  --palette-accent-200: #ffcfcf;
-  --palette-accent-300: #ffbbbb;
-  --palette-accent-400: #ff9393;
-  --palette-accent-600: #ff5757;
-  --palette-accent-700: #ff4343;
-  --palette-accent-800: #ff2f2f;
-  --palette-accent-900: #ff1b1b;
+  --card-bg: #15102a;
+  --sidenav-bg: #0a0716;
+  --selected-task-bg-color: #1c1638;
+  --banner-bg: #15102a;
 
-  /* Semantic colors using rainbow palette */
-  --c-success: var(--rainbow-success);
-  --c-warning: var(--rainbow-warning);
-  --c-error: var(--rainbow-error);
-  --c-info: var(--rainbow-info);
+  /* Task surfaces — translucent indigo so the aurora tints through each row
+   * like frosted glass. No backdrop-filter here on purpose: rows are the hot
+   * path (one per item in long lists) and they sit over a smooth gradient, so
+   * a translucent fill reads as frosted without a per-row blur pass on scroll
+   * (same approach velvet uses; blur is reserved for the few big panels). */
+  --task-c-bg: color-mix(in srgb, #211a44 74%, transparent);
+  --task-c-selected-bg: color-mix(in srgb, #2a2056 88%, transparent);
+  --sub-task-c-bg: color-mix(in srgb, #1a1438 70%, transparent);
+  --sub-task-c-bg-done: color-mix(in srgb, #120e26 70%, transparent);
+  --task-c-bg-done: color-mix(in srgb, #120e26 62%, transparent);
+  --task-c-current-bg: color-mix(in srgb, #2a1f52 86%, transparent);
+  --task-c-drag-drop-bg: color-mix(in srgb, #2a2056 90%, transparent);
+  --sub-task-c-bg-in-selected: color-mix(in srgb, #2f2560 82%, transparent);
+
+  /* Notes */
+  --standard-note-bg: #15102a;
+  --standard-note-bg-hovered: #1c1638;
+
+  /* Planner */
+  --planner-task-bg: #15102a;
+  --planner-days-bg: #0a0716;
+
+  /* ===============================
+   * TEXT COLORS
+   * ===============================*/
+  --text-color: #ece6ff;
+  --text-color-less-intense: color-mix(in srgb, #ece6ff 80%, transparent);
+  --text-color-muted: #9a8fc4;
+  --text-color-more-intense: #ffffff;
+  --text-color-most-intense: #ffffff;
+  --standard-note-fg: #ece6ff;
+  --task-detail-value-color: #c7bdf0;
+
+  /* Task detail panel items (right panel) — were falling back to neutral
+   * --dark8; give them the indigo surface + a glow so they match. */
+  --task-detail-bg: color-mix(in srgb, #1d1640 80%, transparent);
+  --task-detail-bg-hover: color-mix(in srgb, #261d50 88%, transparent);
+  --task-detail-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-violet) 28%, transparent),
+    0 0 16px color-mix(in srgb, var(--neon-violet) 20%, transparent),
+    0 4px 14px rgba(0, 0, 0, 0.45);
+
+  /* ===============================
+   * BORDERS & SEPARATORS
+   * ===============================*/
+  --extra-border-color: color-mix(in srgb, var(--neon-violet) 22%, transparent);
+  --separator-color: color-mix(in srgb, var(--neon-violet) 28%, transparent);
+  --divider-color: color-mix(in srgb, var(--neon-violet) 20%, transparent);
+  --chip-outline-color: color-mix(in srgb, var(--neon-cyan) 55%, transparent);
+  --card-border: color-mix(in srgb, var(--neon-violet) 40%, transparent);
+
+  /* ===============================
+   * ACCENT & THEME COLORS
+   * ===============================*/
+
+  /* Primary = neon violet (buttons, focus, brand) */
+  --palette-primary-500: var(--neon-violet);
+  --c-primary: var(--neon-violet);
+  --brand: var(--neon-violet);
+
+  /* Accent = electric cyan (links, highlights) */
+  --palette-accent-500: var(--neon-cyan);
+  --c-accent: var(--neon-cyan);
+  --palette-accent-100: color-mix(in srgb, var(--neon-cyan) 20%, #ffffff);
+  --palette-accent-200: color-mix(in srgb, var(--neon-cyan) 40%, #ffffff);
+  --palette-accent-300: color-mix(in srgb, var(--neon-cyan) 60%, #ffffff);
+  --palette-accent-400: color-mix(in srgb, var(--neon-cyan) 80%, #ffffff);
+  --palette-accent-600: color-mix(in srgb, var(--neon-cyan) 80%, #000000);
+  --palette-accent-700: color-mix(in srgb, var(--neon-cyan) 60%, #000000);
+  --palette-accent-800: color-mix(in srgb, var(--neon-cyan) 40%, #000000);
+  --palette-accent-900: color-mix(in srgb, var(--neon-cyan) 20%, #000000);
+
+  /* Semantic */
+  --c-success: var(--neon-green);
+  --c-warning: var(--neon-yellow);
+  --c-error: #ff5d73;
+  --c-info: var(--neon-blue);
+  --color-success: var(--neon-green);
+  --color-warning: var(--neon-yellow);
+  --color-danger: #ff5d73;
 
   /* ===============================
    * UI ELEMENTS
    * ===============================*/
 
-  /* Scrollbar - colorful */
-  --scrollbar-thumb: var(--rainbow-primary);
-  --scrollbar-thumb-hover: var(--rainbow-accent);
-  --scrollbar-track: var(--bg);
+  /* Scrollbar */
+  --scrollbar-thumb: color-mix(in srgb, var(--neon-violet) 70%, transparent);
+  --scrollbar-thumb-hover: var(--neon-cyan);
+  --scrollbar-track: transparent;
 
-  --task-border-radius: 16px;
-}
+  /* Sidenav active item */
+  --sidenav-item-active-bg: linear-gradient(
+    100deg,
+    color-mix(in srgb, var(--neon-violet) 32%, transparent),
+    color-mix(in srgb, var(--neon-pink) 24%, transparent)
+  );
+  --sidenav-active-text: #ffffff;
 
-/* Rainbow theme variables */
-body.isDarkTheme {
   /* ===============================
-   * BACKGROUND COLORS
+   * SHADOWS — neon glows
    * ===============================*/
+  --shadow-key-umbra-opacity: 0.45;
+  --shadow-key-penumbra-opacity: 0.35;
+  --shadow-ambient-shadow-opacity: 0.3;
 
-  /* Main backgrounds with subtle colorful tints */
-  --bg: #1a1a1a;
-  --bg-darker: #0f0f0f;
-  --bg-slightly-lighter: #2d2d2d;
-  --bg-lighter: #3a3a3a;
-  --bg-lightest: #474747;
-  --bg-super-light: #545454;
+  --card-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-violet) 30%, transparent),
+    0 0 18px color-mix(in srgb, var(--neon-cyan) 22%, transparent),
+    0 8px 24px rgba(0, 0, 0, 0.5);
 
-  /* Component backgrounds */
-  --card-bg: #2d2d2d;
-  --sidenav-bg: #0f0f0f;
+  --task-current-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-pink) 55%, transparent),
+    0 0 18px color-mix(in srgb, var(--neon-pink) 45%, transparent),
+    0 2px 10px rgba(0, 0, 0, 0.5);
+  --task-selected-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 45%, transparent),
+    0 0 12px color-mix(in srgb, var(--neon-cyan) 30%, transparent);
+
+  /* Hover controls */
+  --hover-controls-border: 1px solid color-mix(in srgb, var(--neon-cyan) 45%, transparent);
+  --hover-controls-border-opacity: 0.6;
+
+  /* Interaction states */
+  --hover-bg-opacity: 0.1;
+  --focus-bg-opacity: 0.14;
+  --pressed-bg-opacity: 0.18;
+  --disabled-opacity: 0.3;
 }
 
-body.isDarkTheme mat-sidenav-content {
-  background:
-    radial-gradient(circle at 20% 80%, rgba(0, 121, 191, 0.18) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(255, 107, 107, 0.18) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(155, 89, 182, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 60% 60%, rgba(26, 188, 156, 0.15) 0%, transparent 50%),
+/* ===================================================================
+ * BACKGROUND — nebula / aurora
+ * Painted on .app-container (which sits above body + any wallpaper layer)
+ * with fixed attachment, so the radial blooms read as one steady aurora
+ * across the whole work area. Everything below .app-container is already
+ * transparent, so the gradient shows through header, route + right panel.
+ * (mat-sidenav-content is NOT the work-area wrapper in this app version.)
+ * ===================================================================*/
+body.isDarkTheme .app-container {
+  background-color: transparent !important;
+  background-image:
+    radial-gradient(
+      ellipse 60% 50% at 88% 2%,
+      color-mix(in srgb, var(--neon-cyan) 32%, transparent) 0%,
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 65% 60% at 4% 98%,
+      color-mix(in srgb, var(--neon-violet) 36%, transparent) 0%,
+      transparent 58%
+    ),
+    radial-gradient(
+      ellipse 55% 48% at 82% 80%,
+      color-mix(in srgb, var(--neon-pink) 24%, transparent) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 48% 42%,
+      color-mix(in srgb, var(--neon-blue) 16%, transparent) 0%,
+      transparent 55%
+    ),
     linear-gradient(
       135deg,
-      rgba(0, 121, 191, 0.06) 0%,
-      rgba(255, 107, 107, 0.06) 25%,
-      rgba(155, 89, 182, 0.06) 50%,
-      rgba(26, 188, 156, 0.06) 75%,
-      rgba(241, 196, 15, 0.06) 100%
+      color-mix(in srgb, var(--neon-violet) 12%, transparent) 0%,
+      color-mix(in srgb, var(--neon-cyan) 9%, transparent) 40%,
+      color-mix(in srgb, var(--neon-pink) 11%, transparent) 100%
     ) !important;
+  background-attachment: fixed !important;
 }
 
-body mat-sidenav-content {
+/* Neutralize SP's flat body:before tint so the nebula is the only wash. */
+body.isDarkTheme::before {
+  display: none !important;
+}
+
+/* ===================================================================
+ * TYPOGRAPHY — subtle glow on headings & links (NOT body / task text,
+ * to keep dense lists crisp and cheap to paint)
+ * ===================================================================*/
+body.isDarkTheme {
+  background-color: var(--bg);
+  color: var(--text-color);
+}
+
+body.isDarkTheme .mat-h1,
+body.isDarkTheme .mat-h2,
+body.isDarkTheme .mat-h3,
+body.isDarkTheme h1,
+body.isDarkTheme h2,
+body.isDarkTheme h3,
+body.isDarkTheme [mat-dialog-title] {
+  text-shadow: 0 0 12px color-mix(in srgb, var(--neon-violet) 45%, transparent);
+}
+
+body.isDarkTheme main-header .current-work-context-title {
+  text-shadow: 0 0 14px color-mix(in srgb, var(--neon-violet) 50%, transparent);
+}
+
+body.isDarkTheme a[href] {
+  color: var(--c-accent);
+  text-decoration: none;
+  transition:
+    color var(--transition-fast),
+    text-shadow var(--transition-fast);
+}
+
+body.isDarkTheme a[href]:hover {
+  color: #ffffff;
+  text-shadow: var(--glow-cyan);
+}
+
+/* ===================================================================
+ * SIDE NAV — frosted glowing pane with a violet bottom-glow
+ * Blur/tint go on the inner .nav-sidenav, never the host (a host backdrop-
+ * filter establishes a containing block that collapses the mobile drawer —
+ * see styling-guide). The host only carries border + box-shadow (safe).
+ * ===================================================================*/
+body.isDarkTheme magic-side-nav {
+  border-right: 1px solid color-mix(in srgb, var(--neon-violet) 40%, transparent);
+  box-shadow: 2px 0 34px color-mix(in srgb, var(--neon-violet) 26%, transparent);
+}
+
+body.isDarkTheme magic-side-nav .nav-sidenav {
   background:
-    radial-gradient(circle at 20% 80%, rgba(0, 121, 191, 0.18) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(255, 107, 107, 0.18) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(155, 89, 182, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 60% 60%, rgba(26, 188, 156, 0.15) 0%, transparent 50%),
-    linear-gradient(
-      135deg,
-      rgba(0, 121, 191, 0.06) 0%,
-      rgba(255, 107, 107, 0.06) 25%,
-      rgba(155, 89, 182, 0.06) 50%,
-      rgba(26, 188, 156, 0.06) 75%,
-      rgba(241, 196, 15, 0.06) 100%
-    ) !important;
+    radial-gradient(
+      ellipse 130% 38% at 50% 112%,
+      color-mix(in srgb, var(--neon-violet) 34%, transparent) 0%,
+      transparent 72%
+    ),
+    radial-gradient(
+      ellipse 120% 30% at 50% -8%,
+      color-mix(in srgb, var(--neon-cyan) 16%, transparent) 0%,
+      transparent 70%
+    ),
+    var(--neon-pane-strong) !important;
+  backdrop-filter: var(--neon-blur);
+  -webkit-backdrop-filter: var(--neon-blur);
+}
+
+body.isDarkTheme .nav-link.active {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-violet) 55%, transparent),
+    0 0 16px color-mix(in srgb, var(--neon-violet) 40%, transparent);
+}
+
+body.isDarkTheme .nav-link.active .nav-icon,
+body.isDarkTheme .nav-link.active mat-icon {
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--neon-pink) 70%, transparent));
+}
+
+/* ===================================================================
+ * CARDS / PANELS — rainbow gradient border + outer glow
+ * The gradient-border trick (padding-box fill + border-box gradient) gives
+ * the ref's lit-edge panels; the box-shadow ring is the safe fallback if a
+ * Material container color wins the background.
+ * ===================================================================*/
+body.isDarkTheme .mat-mdc-card {
+  border: 1px solid transparent;
+  border-radius: 16px;
+  background:
+    var(--neon-pane) padding-box,
+    linear-gradient(135deg, var(--neon-violet), var(--neon-cyan)) border-box;
+  backdrop-filter: var(--neon-blur);
+  -webkit-backdrop-filter: var(--neon-blur);
+  box-shadow:
+    0 0 26px color-mix(in srgb, var(--neon-cyan) 28%, transparent),
+    0 10px 30px rgba(0, 0, 0, 0.55);
+}
+
+/* Menus & dialogs — frosted violet glowing edge */
+body.isDarkTheme .mat-mdc-menu-panel,
+body.isDarkTheme .mat-mdc-dialog-surface {
+  border: 1px solid color-mix(in srgb, var(--neon-violet) 45%, transparent);
+  background: var(--neon-pane-strong) !important;
+  backdrop-filter: var(--neon-blur);
+  -webkit-backdrop-filter: var(--neon-blur);
+  box-shadow: var(--pane-glow);
+}
+
+/* Notes */
+body.isDarkTheme note .note,
+body.isDarkTheme .standard-note {
+  border: 1px solid color-mix(in srgb, var(--neon-teal) 40%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-teal) 24%, transparent),
+    0 0 22px color-mix(in srgb, var(--neon-teal) 24%, transparent);
+}
+
+/* ===================================================================
+ * BANNER — pink/magenta rainbow gradient border (singular, high impact)
+ * ===================================================================*/
+body.isDarkTheme banner .content-wrapper,
+body.isDarkTheme banner {
+  border-radius: 16px;
+}
+
+body.isDarkTheme banner .content-wrapper {
+  border: 1px solid transparent;
+  background:
+    linear-gradient(var(--banner-bg), var(--banner-bg)) padding-box,
+    linear-gradient(120deg, var(--neon-pink), var(--neon-violet), var(--neon-cyan))
+      border-box;
+  box-shadow:
+    0 0 22px color-mix(in srgb, var(--neon-pink) 28%, transparent),
+    0 8px 28px rgba(0, 0, 0, 0.5);
+}
+
+/* ===================================================================
+ * ADD-TASK BAR — cyan glow
+ * ===================================================================*/
+body.isDarkTheme add-task-bar.global .add-task-container {
+  border: 1px solid color-mix(in srgb, var(--neon-cyan) 50%, transparent);
+  background: var(--neon-pane-strong);
+  backdrop-filter: var(--neon-blur);
+  -webkit-backdrop-filter: var(--neon-blur);
+  box-shadow: var(--pane-glow-cyan);
+}
+
+/* ===================================================================
+ * RIGHT PANEL — frosted glass with a violet glow edge
+ * ===================================================================*/
+body.isDarkTheme right-panel .side {
+  background: var(--neon-pane-strong) !important;
+  backdrop-filter: var(--neon-blur);
+  -webkit-backdrop-filter: var(--neon-blur);
+  border-left: 1px solid color-mix(in srgb, var(--neon-violet) 45%, transparent) !important;
+  box-shadow:
+    -16px 0 48px rgba(0, 0, 0, 0.45),
+    -1px 0 30px color-mix(in srgb, var(--neon-violet) 30%, transparent);
+}
+
+/* ===================================================================
+ * TASK DETAIL ITEMS — the per-field rows in the right panel. They get
+ * their surface from --task-detail-bg/-shadow (set above); add a glowing
+ * border so each item reads as a lit panel like the reference.
+ * ===================================================================*/
+body.isDarkTheme task-detail-item .input-item,
+body.isDarkTheme task-detail-item .mat-expansion-panel {
+  border: 1px solid color-mix(in srgb, var(--neon-violet) 32%, transparent) !important;
+}
+
+body.isDarkTheme task-detail-item .mat-expansion-panel.mat-expanded {
+  border-color: color-mix(in srgb, var(--neon-cyan) 45%, transparent) !important;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 40%, transparent),
+    0 0 22px color-mix(in srgb, var(--neon-cyan) 26%, transparent) !important;
+}
+
+/* ===================================================================
+ * MAIN HEADER — translucent bar with a glowing under-edge
+ * ===================================================================*/
+body.isDarkTheme main-header .wrapper {
+  border-bottom: 1px solid color-mix(in srgb, var(--neon-violet) 30%, transparent);
+  box-shadow: 0 6px 24px color-mix(in srgb, var(--neon-violet) 14%, transparent);
+}
+
+/* ===================================================================
+ * TASKS — static per-row glow, intensified on state
+ * (no animation; box-shadow only — cheap to composite on long lists)
+ * ===================================================================*/
+body.isDarkTheme task .box {
+  border: 1px solid color-mix(in srgb, var(--neon-violet) 14%, transparent);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.35);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+body.isDarkTheme task:hover .box,
+body.isDarkTheme task .box:hover {
+  border-color: color-mix(in srgb, var(--neon-cyan) 40%, transparent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--neon-cyan) 25%, transparent);
+}
+
+body.isDarkTheme task.isSelected .box {
+  border-color: color-mix(in srgb, var(--neon-cyan) 55%, transparent);
+  box-shadow: var(--task-selected-shadow);
+}
+
+body.isDarkTheme task.isCurrent .box {
+  border-color: color-mix(in srgb, var(--neon-pink) 60%, transparent);
+  box-shadow: var(--task-current-shadow);
+}
+
+/* Running-task done-toggle halo (the pink "live" tell) */
+body.isDarkTheme task.isCurrent done-toggle .ico-btn {
+  box-shadow: 0 0 12px color-mix(in srgb, var(--neon-pink) 55%, transparent);
+}
+
+/* ===================================================================
+ * CHIPS / TAGS — cyan glowing pills
+ * ===================================================================*/
+body.isDarkTheme .mat-mdc-standard-chip {
+  border: 1px solid color-mix(in srgb, var(--neon-cyan) 45%, transparent);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--neon-cyan) 22%, transparent);
+}
+
+body.isDarkTheme .mat-mdc-chip:hover {
+  box-shadow: var(--glow-cyan);
+}
+
+/* ===================================================================
+ * PRIMARY BUTTONS — violet→pink gradient fill + glow
+ * ===================================================================*/
+body.isDarkTheme button[mat-raised-button][color='primary'],
+body.isDarkTheme button[mat-flat-button][color='primary'],
+body.isDarkTheme .mat-mdc-raised-button.mat-primary,
+body.isDarkTheme .mat-mdc-unelevated-button.mat-primary {
+  background: linear-gradient(120deg, var(--neon-violet), var(--neon-pink)) !important;
+  color: #ffffff !important;
+  border-radius: 10px !important;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.12) inset,
+    0 0 16px color-mix(in srgb, var(--neon-violet) 50%, transparent) !important;
+  transition:
+    box-shadow var(--transition-fast),
+    filter var(--transition-fast) !important;
+}
+
+body.isDarkTheme button[mat-raised-button][color='primary']:hover,
+body.isDarkTheme button[mat-flat-button][color='primary']:hover,
+body.isDarkTheme .mat-mdc-raised-button.mat-primary:hover,
+body.isDarkTheme .mat-mdc-unelevated-button.mat-primary:hover {
+  filter: brightness(1.08);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.18) inset,
+    0 0 26px color-mix(in srgb, var(--neon-pink) 55%, transparent) !important;
+}
+
+/* Mini-fab / fab accent glow */
+body.isDarkTheme .mat-mdc-fab,
+body.isDarkTheme .mat-mdc-mini-fab {
+  box-shadow: 0 0 18px color-mix(in srgb, var(--neon-violet) 45%, transparent) !important;
+}
+
+/* ===================================================================
+ * FOCUS — neon cyan ring with halo
+ * ===================================================================*/
+body.isDarkTheme *:focus-visible {
+  outline: 2px solid var(--neon-cyan);
+  outline-offset: 2px;
+  box-shadow: var(--glow-cyan);
+}
+
+/* ===================================================================
+ * SCROLLBAR — violet→cyan gradient thumb with glow
+ * ===================================================================*/
+body.isDarkTheme ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+body.isDarkTheme ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+body.isDarkTheme ::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--neon-violet), var(--neon-cyan));
+  border-radius: 6px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--neon-violet) 50%, transparent);
+}
+
+body.isDarkTheme ::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, var(--neon-cyan), var(--neon-pink));
+  background-clip: padding-box;
+}
+
+/* ===================================================================
+ * CHECKBOX / SLIDE-TOGGLE — accent glow when checked
+ * ===================================================================*/
+body.isDarkTheme .mat-mdc-checkbox.mat-mdc-checkbox-checked .mdc-checkbox__background {
+  box-shadow: 0 0 8px color-mix(in srgb, var(--neon-cyan) 55%, transparent);
+}
+
+body.isDarkTheme
+  .mat-mdc-slide-toggle.mat-mdc-slide-toggle-checked
+  .mdc-switch__handle::after {
+  box-shadow: 0 0 8px color-mix(in srgb, var(--neon-cyan) 55%, transparent);
 }


### PR DESCRIPTION
## Problem
Notes written in focus mode's fullscreen markdown editor could silently vanish after clicking **Save** (reported on Reddit).

The fullscreen editor is a detached CDK overlay. When a focus session ends *while the editor is open* (a Countdown/Pomodoro timer elapses mid-edit), `focus-mode-overlay` swaps screens (Main → SessionDone/Break) and destroys the `<inline-markdown>` that opened the dialog. Its `changed` output then has no listener, so on Save the note was emitted into the void and never persisted — matching the report ("can't reproduce intentionally", "lost a long plan list", "can't find it anywhere"). The normal path (session still running) was never affected, which is why it was hard to reproduce.

## Fix
In `InlineMarkdownComponent`, when the component has already been destroyed by the time the fullscreen dialog closes, persist the note directly to the store using the `taskId` captured when the dialog opened, instead of emitting `changed`. Guards: skip when content is unchanged (avoids writing the default-text placeholder back as a real note, matching the parent's existing guard); warn when there is no `taskId` to persist to.

## Tests
- inline-markdown unit tests: alive→emit, destroyed→dispatch, pre-existing-note replacement, DELETE-on-destroy, unchanged-skip, no-taskId warn.
- focus-mode e2e: note survives a **Countdown** and a **Pomodoro** session completing mid-edit (both fail without the fix).

---
_Note: this branch also carries two unrelated pre-existing commits (`5b834493c3` recurring test flake fix, `9ce8e3b009` rainbow theme) — drop them if this should be fix-only._