### PR TITLE
fix(electron): resolve clipboard image file:// paths to blob URLs

### DIFF
--- a/src/app/core/clipboard-image/clipboard-image.service.spec.ts
+++ b/src/app/core/clipboard-image/clipboard-image.service.spec.ts
@@ -1,0 +1,72 @@
+import { TestBed } from '@angular/core/testing';
+import { ClipboardImageService, pathToFileUrl } from './clipboard-image.service';
+import { SnackService } from '../snack/snack.service';
+import { GlobalConfigService } from '../../features/config/global-config.service';
+
+describe('pathToFileUrl', () => {
+  it('prefixes a Unix absolute path correctly', () => {
+    expect(pathToFileUrl('/home/user/img.png')).toBe('file:///home/user/img.png');
+  });
+
+  it('adds the third slash for a Windows drive path (forward slashes)', () => {
+    expect(pathToFileUrl('C:/Users/user/img.png')).toBe('file:///C:/Users/user/img.png');
+  });
+
+  it('normalises Windows backslashes', () => {
+    expect(pathToFileUrl('C:\\Users\\user\\img.png')).toBe(
+      'file:///C:/Users/user/img.png',
+    );
+  });
+
+  it('percent-encodes spaces in a Windows username', () => {
+    expect(pathToFileUrl('C:\\Users\\John Doe\\clipboard-images\\clip.png')).toBe(
+      'file:///C:/Users/John%20Doe/clipboard-images/clip.png',
+    );
+  });
+
+  it('percent-encodes spaces in a Unix path', () => {
+    expect(pathToFileUrl('/home/john doe/img.png')).toBe(
+      'file:///home/john%20doe/img.png',
+    );
+  });
+});
+
+describe('ClipboardImageService', () => {
+  let service: ClipboardImageService;
+
+  beforeEach(() => {
+    const snackServiceSpy = jasmine.createSpyObj('SnackService', ['open']);
+    const globalConfigServiceSpy = jasmine.createSpyObj('GlobalConfigService', [
+      'clipboardImages',
+    ]);
+    globalConfigServiceSpy.clipboardImages.and.returnValue(null);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ClipboardImageService,
+        { provide: SnackService, useValue: snackServiceSpy },
+        { provide: GlobalConfigService, useValue: globalConfigServiceSpy },
+      ],
+    });
+
+    service = TestBed.inject(ClipboardImageService);
+  });
+
+  describe('resolveClipboardImageUrl', () => {
+    it('returns null for an unrelated https URL', async () => {
+      expect(
+        await service.resolveClipboardImageUrl('https://example.com/img.png'),
+      ).toBeNull();
+    });
+
+    it('returns null for a file:// URL outside clipboard-images', async () => {
+      expect(
+        await service.resolveClipboardImageUrl('file:///home/user/img.png'),
+      ).toBeNull();
+    });
+
+    it('returns null for an empty string', async () => {
+      expect(await service.resolveClipboardImageUrl('')).toBeNull();
+    });
+  });
+});

--- a/src/app/core/clipboard-image/clipboard-image.service.ts
+++ b/src/app/core/clipboard-image/clipboard-image.service.ts
@@ -111,18 +111,34 @@ export class ClipboardImageService {
               const filePath = window.ea.getPathForFile(file);
 
               if (filePath) {
-                // Don't copy the file, just use the original path directly
-                const imageUrl = pathToFileUrl(filePath);
-                const fileName = file.name || 'image';
-                const fileNameWithoutExt = fileName.replace(/\.[^.]+$/, '');
-                const markdownText = `![${fileNameWithoutExt}](${imageUrl})`;
+                // Copy to clipboard-images dir so the URL lands in our controlled
+                // directory and can be resolved to a blob: URL before rendering.
+                // Using the original path directly produces a file:/// URL that
+                // Angular's DomSanitizer strips from <img src> bindings.
+                const basePath = await this._getElectronImagePath();
+                const copyResult = await window.ea.copyClipboardImageFile(
+                  basePath,
+                  filePath,
+                );
+                if (copyResult) {
+                  const savedFilePath = await window.ea.getClipboardImagePath(
+                    basePath,
+                    copyResult.id,
+                  );
+                  if (savedFilePath) {
+                    const imageUrl = pathToFileUrl(savedFilePath);
+                    const fileName = file.name || 'image';
+                    const fileNameWithoutExt = fileName.replace(/\.[^.]+$/, '');
+                    const markdownText = `![${fileNameWithoutExt}](${imageUrl})`;
 
-                this._snackService.open({
-                  type: 'SUCCESS',
-                  msg: T.F.CLIPBOARD_IMAGE.PASTE_SUCCESS,
-                });
+                    this._snackService.open({
+                      type: 'SUCCESS',
+                      msg: T.F.CLIPBOARD_IMAGE.PASTE_SUCCESS,
+                    });
 
-                return { success: true, imageUrl, markdownText };
+                    return { success: true, imageUrl, markdownText };
+                  }
+                }
               }
             } catch (error) {
               Log.err('[CLIPBOARD] Error getting file path:', error);
@@ -284,27 +300,82 @@ export class ClipboardImageService {
    * Call this before rendering markdown to ensure images display correctly.
    */
   async resolveMarkdownImages(markdown: string): Promise<string> {
-    const urlPattern = /indexeddb:\/\/clipboard-images\/[^)\s=]+/g;
-    const matches = markdown.match(urlPattern);
-    if (!matches) return markdown;
-
-    const uniqueUrls = [...new Set(matches)];
-    const resolved = new Map<string, string>();
-
-    await Promise.all(
-      uniqueUrls.map(async (url) => {
-        const blobUrl = await this.resolveIndexedDbUrl(url);
-        if (blobUrl) {
-          resolved.set(url, blobUrl);
-        }
-      }),
-    );
-
     let result = markdown;
-    for (const [original, replacement] of resolved) {
-      result = result.split(original).join(replacement);
+
+    // Resolve indexeddb:// URLs (web mode and Electron)
+    const indexedDbMatches = markdown.match(/indexeddb:\/\/clipboard-images\/[^)\s=]+/g);
+    if (indexedDbMatches) {
+      const uniqueUrls = [...new Set(indexedDbMatches)];
+      const resolved = new Map<string, string>();
+      await Promise.all(
+        uniqueUrls.map(async (url) => {
+          const blobUrl = await this.resolveIndexedDbUrl(url);
+          if (blobUrl) resolved.set(url, blobUrl);
+        }),
+      );
+      for (const [original, replacement] of resolved) {
+        result = result.split(original).join(replacement);
+      }
     }
+
+    // Electron: Angular's DomSanitizer strips file: scheme from <img src>, so
+    // file:/// clipboard-image paths must be converted to blob: URLs before rendering.
+    if (IS_ELECTRON) {
+      const fileClipPattern =
+        /file:\/\/\/[^)\s"]*\/clipboard-images\/[^)\s"/]+\.[a-z]{2,5}/g;
+      const fileMatches = new Map<string, string>();
+      let m: RegExpExecArray | null;
+      while ((m = fileClipPattern.exec(result)) !== null) {
+        const url = m[0];
+        const filename = url.split('/').pop() ?? '';
+        const id = filename.replace(/\.[^.]+$/, '');
+        if (id) fileMatches.set(url, id);
+      }
+      if (fileMatches.size > 0) {
+        await Promise.all(
+          [...fileMatches.entries()].map(async ([url, id]) => {
+            const cacheKey = `electron-file:${id}`;
+            const cached = this._blobUrlCache.get(cacheKey);
+            if (cached) {
+              result = result.split(url).join(cached);
+            } else {
+              const blob = await this._getImageElectron(id);
+              if (blob) {
+                const blobUrl = URL.createObjectURL(blob);
+                this._blobUrlCache.set(cacheKey, blobUrl);
+                result = result.split(url).join(blobUrl);
+              }
+            }
+          }),
+        );
+      }
+    }
+
     return result;
+  }
+
+  /**
+   * Resolves any clipboard image URL to a blob: URL safe for use in Angular [src] bindings.
+   * Handles both indexeddb:// (web) and file:/// clipboard-image paths (Electron).
+   */
+  async resolveClipboardImageUrl(url: string): Promise<string | null> {
+    if (this.isIndexedDbUrl(url)) {
+      return this.resolveIndexedDbUrl(url);
+    }
+    if (IS_ELECTRON && url.startsWith('file:///') && url.includes('/clipboard-images/')) {
+      const filename = url.split('/').pop() ?? '';
+      const id = filename.replace(/\.[^.]+$/, '');
+      if (!id) return null;
+      const cacheKey = `electron-file:${id}`;
+      const cached = this._blobUrlCache.get(cacheKey);
+      if (cached) return cached;
+      const blob = await this._getImageElectron(id);
+      if (!blob) return null;
+      const blobUrl = URL.createObjectURL(blob);
+      this._blobUrlCache.set(cacheKey, blobUrl);
+      return blobUrl;
+    }
+    return null;
   }
 
   async resolveIndexedDbUrl(indexedDbUrl: string): Promise<string | null> {

--- a/src/app/core/clipboard-image/clipboard-image.service.ts
+++ b/src/app/core/clipboard-image/clipboard-image.service.ts
@@ -8,10 +8,14 @@ import { MIME_TYPE_EXTENSIONS } from '../../../../electron/shared-with-frontend/
 import { Log } from '../log';
 
 // Windows paths (e.g. C:/...) have no leading slash, so file:// + C:/... yields
-// file://C:/... which fails the canonical file:///  check. Always emit file:///<path>.
-const pathToFileUrl = (filePath: string): string => {
+// file://C:/... which fails the canonical file:/// check. Always emit file:///<path>.
+// encodeURI encodes spaces (common in Windows usernames) so the markdown parser
+// does not split the URL at the first space character.
+export const pathToFileUrl = (filePath: string): string => {
   const normalized = filePath.replace(/\\/g, '/');
-  return normalized.startsWith('/') ? `file://${normalized}` : `file:///${normalized}`;
+  return normalized.startsWith('/')
+    ? `file://${encodeURI(normalized)}`
+    : `file:///${encodeURI(normalized)}`;
 };
 
 const DB_NAME = 'sp-clipboard-images';
@@ -113,8 +117,8 @@ export class ClipboardImageService {
               if (filePath) {
                 // Copy to clipboard-images dir so the URL lands in our controlled
                 // directory and can be resolved to a blob: URL before rendering.
-                // Using the original path directly produces a file:/// URL that
-                // Angular's DomSanitizer strips from <img src> bindings.
+                // Chromium blocks http://localhost → file:// subresource loads
+                // regardless of CSP, so we must convert to a same-origin blob: URL.
                 const basePath = await this._getElectronImagePath();
                 const copyResult = await window.ea.copyClipboardImageFile(
                   basePath,
@@ -318,8 +322,9 @@ export class ClipboardImageService {
       }
     }
 
-    // Electron: Angular's DomSanitizer strips file: scheme from <img src>, so
-    // file:/// clipboard-image paths must be converted to blob: URLs before rendering.
+    // Electron: Chromium blocks http://localhost → file:// cross-origin subresource
+    // loads regardless of CSP, so file:/// clipboard-image paths must be converted
+    // to blob: URLs (same-origin) before the markdown HTML is rendered.
     if (IS_ELECTRON) {
       const fileClipPattern =
         /file:\/\/\/[^)\s"]*\/clipboard-images\/[^)\s"/]+\.[a-z]{2,5}/g;
@@ -624,8 +629,12 @@ export class ClipboardImageService {
   }
 
   private async _deleteImageElectron(id: string): Promise<boolean> {
-    // Clean up cache entry (file:// URLs don't need revocation)
-    this._blobUrlCache.delete(id);
+    const cacheKey = `electron-file:${id}`;
+    const cached = this._blobUrlCache.get(cacheKey);
+    if (cached) {
+      URL.revokeObjectURL(cached);
+      this._blobUrlCache.delete(cacheKey);
+    }
 
     const basePath = await this._getElectronImagePath();
     return window.ea.deleteClipboardImage(basePath, id);

--- a/src/app/core/clipboard-image/clipboard-image.service.ts
+++ b/src/app/core/clipboard-image/clipboard-image.service.ts
@@ -7,6 +7,13 @@ import { getDefaultClipboardImagesPath } from '../../util/get-default-clipboard-
 import { MIME_TYPE_EXTENSIONS } from '../../../../electron/shared-with-frontend/mime-type-mapping.const';
 import { Log } from '../log';
 
+// Windows paths (e.g. C:/...) have no leading slash, so file:// + C:/... yields
+// file://C:/... which fails the canonical file:///  check. Always emit file:///<path>.
+const pathToFileUrl = (filePath: string): string => {
+  const normalized = filePath.replace(/\\/g, '/');
+  return normalized.startsWith('/') ? `file://${normalized}` : `file:///${normalized}`;
+};
+
 const DB_NAME = 'sp-clipboard-images';
 const DB_VERSION = 1;
 const STORE_NAME = 'images';
@@ -105,7 +112,7 @@ export class ClipboardImageService {
 
               if (filePath) {
                 // Don't copy the file, just use the original path directly
-                const imageUrl = `file://${filePath.replace(/\\/g, '/')}`;
+                const imageUrl = pathToFileUrl(filePath);
                 const fileName = file.name || 'image';
                 const fileNameWithoutExt = fileName.replace(/\.[^.]+$/, '');
                 const markdownText = `![${fileNameWithoutExt}](${imageUrl})`;
@@ -132,7 +139,7 @@ export class ClipboardImageService {
         // Get the saved file path and generate file:// URL
         const savedFilePath = await window.ea.getClipboardImagePath(basePath, result.id);
         if (savedFilePath) {
-          const imageUrl = `file://${savedFilePath.replace(/\\/g, '/')}`;
+          const imageUrl = pathToFileUrl(savedFilePath);
           const markdownText = `![pasted image](${imageUrl})`;
 
           this._snackService.open({
@@ -192,7 +199,7 @@ export class ClipboardImageService {
             result.id,
           );
           if (savedFilePath) {
-            const imageUrl = `file://${savedFilePath.replace(/\\/g, '/')}`;
+            const imageUrl = pathToFileUrl(savedFilePath);
             const markdownText = `![pasted image](${imageUrl})`;
 
             this._snackService.open({
@@ -223,7 +230,7 @@ export class ClipboardImageService {
         return null;
       }
 
-      const imageUrl = `file://${savedFilePath.replace(/\\/g, '/')}`;
+      const imageUrl = pathToFileUrl(savedFilePath);
       const fileName = filePath.split(/[\\/]/).pop() || 'image';
       const fileNameWithoutExt = fileName.replace(/\.[^.]+$/, '');
       const markdownText = `![${fileNameWithoutExt}](${imageUrl})`;
@@ -526,8 +533,9 @@ export class ClipboardImageService {
       mimeType,
     );
 
-    // Return file:// URL directly for Electron
-    const fileUrl = `file://${savedPath.replace(/\\/g, '/')}`;
+    // Return file:/// URL for Electron (file:/// is canonical; file:// + Windows path
+    // yields file://C:/... which fails the local-file security check)
+    const fileUrl = pathToFileUrl(savedPath);
     return fileUrl;
   }
 

--- a/src/app/features/tasks/task-attachment/task-attachment-list/task-attachment-list.component.spec.ts
+++ b/src/app/features/tasks/task-attachment/task-attachment-list/task-attachment-list.component.spec.ts
@@ -23,7 +23,8 @@ describe('TaskAttachmentListComponent', () => {
     ]);
     const matDialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
     const clipboardImageServiceSpy = jasmine.createSpyObj('ClipboardImageService', [
-      'resolveUrl',
+      'resolveIndexedDbUrl',
+      'resolveClipboardImageUrl',
     ]);
 
     await TestBed.configureTestingModule({
@@ -73,6 +74,21 @@ describe('TaskAttachmentListComponent', () => {
         fixture.componentRef.setInput('attachments', [imgAttachment(path)]);
         expect(component.resolvedAttachments()[0].resolvedOriginalPath).toBe(path);
       });
+    });
+
+    it('treats clipboard-images file:/// paths as resolvable (returns raw path until async resolved)', () => {
+      const path =
+        'file:///C:/Users/user/AppData/Roaming/superProductivity/clipboard-images/abc123.png';
+      fixture.componentRef.setInput('attachments', [imgAttachment(path)]);
+      // Before async resolution the raw path is returned; isPathSafeToOpen passes it through
+      expect(component.resolvedAttachments()[0].resolvedOriginalPath).toBe(path);
+    });
+
+    it('treats indexeddb:// clipboard-images paths as resolvable (returns raw url until async resolved)', () => {
+      const path = 'indexeddb://clipboard-images/abc123';
+      fixture.componentRef.setInput('attachments', [imgAttachment(path)]);
+      // resolvedOriginalPath is the raw indexeddb url until the effect resolves it
+      expect(component.resolvedAttachments()[0].resolvedOriginalPath).toBe(path);
     });
   });
 

--- a/src/app/features/tasks/task-attachment/task-attachment-list/task-attachment-list.component.ts
+++ b/src/app/features/tasks/task-attachment/task-attachment-list/task-attachment-list.component.ts
@@ -63,14 +63,16 @@ export class TaskAttachmentListComponent {
     if (!attachments) return [];
 
     return attachments.map((att) => {
-      const resolvedPath = att.path?.startsWith('indexeddb://clipboard-images/')
-        ? urlMap.get(att.path) || att.path
-        : att.path;
+      const resolvedPath =
+        att.path && this._isResolvableClipboardUrl(att.path)
+          ? urlMap.get(att.path) || att.path
+          : att.path;
 
       const imgPath = att.originalImgPath || att.path;
-      const rawOriginalPath = imgPath?.startsWith('indexeddb://clipboard-images/')
-        ? urlMap.get(imgPath) || imgPath
-        : imgPath;
+      const rawOriginalPath =
+        imgPath && this._isResolvableClipboardUrl(imgPath)
+          ? urlMap.get(imgPath) || imgPath
+          : imgPath;
       // The <img> src auto-loads on render (no click), so a synced remote
       // file://host / UNC path would silently leak the user's NTLM hash. Drop
       // such srcs so they never reach the binding. See GHSA-hr87-735w-hfq3.
@@ -79,7 +81,8 @@ export class TaskAttachmentListComponent {
         : undefined;
 
       const isLoading =
-        att.path?.startsWith('indexeddb://clipboard-images/') &&
+        !!att.path &&
+        this._isResolvableClipboardUrl(att.path) &&
         !urlMap.has(att.path) &&
         loadingUrls.has(att.path);
 
@@ -105,13 +108,14 @@ export class TaskAttachmentListComponent {
         try {
           const urlsToResolve: string[] = [];
 
-          if (att.path?.startsWith('indexeddb://clipboard-images/')) {
-            urlsToResolve.push(att.path);
+          if (this._isResolvableClipboardUrl(att.path)) {
+            urlsToResolve.push(att.path!);
           }
 
           const imgPath = att.originalImgPath || att.path;
           if (
-            imgPath?.startsWith('indexeddb://clipboard-images/') &&
+            imgPath &&
+            this._isResolvableClipboardUrl(imgPath) &&
             imgPath !== att.path
           ) {
             urlsToResolve.push(imgPath);
@@ -125,7 +129,8 @@ export class TaskAttachmentListComponent {
               return newSet;
             });
 
-            const resolved = await this._clipboardImageService.resolveIndexedDbUrl(url);
+            const resolved =
+              await this._clipboardImageService.resolveClipboardImageUrl(url);
             if (resolved) {
               this._resolvedUrlsMap.update((map) => {
                 const newMap = new Map(map);
@@ -146,6 +151,14 @@ export class TaskAttachmentListComponent {
         }
       });
     });
+  }
+
+  private _isResolvableClipboardUrl(url: string | undefined): boolean {
+    if (!url) return false;
+    return (
+      url.startsWith('indexeddb://clipboard-images/') ||
+      (url.startsWith('file:///') && url.includes('/clipboard-images/'))
+    );
   }
 
   openEditDialog(attachment?: TaskAttachment): void {


### PR DESCRIPTION
## Problem

On Windows, clipboard image paths use a drive-letter prefix (`C:/...`) so the previous `` `file://${path}` `` template produced `file://C:/...` instead of the canonical `file:///C:/...`. This caused images pasted via Ctrl+V or screenshot to appear as broken icons in both Markdown notes and attachment thumbnails.

The same rendering issue affected all platforms: Chromium blocks cross-origin `http://localhost → file://` subresource loads regardless of CSP, so `file:///` paths stored in note content are never loaded by the renderer. Converting them to same-origin `blob:` URLs before rendering is required everywhere.

## Changes

- **`pathToFileUrl()`** — emits `file:///path` on all platforms and `encodeURI`-encodes the path so usernames with spaces (e.g. `C:\Users\John Doe\...`) do not break the markdown URL parser at the first space.
- **`resolveMarkdownImages()`** — extended to convert `file:///clipboard-images/…` paths to `blob:` URLs before markdown HTML reaches the renderer.
- **`resolveClipboardImageUrl()`** — new public method handling both `indexeddb://` (web) and `file:///clipboard-images/` (Electron) URLs; used by the attachment thumbnail list.
- **`_deleteImageElectron()`** — fixed blob URL leak: now revokes and removes the correct `electron-file:<id>` cache entry instead of the wrong bare `id` key.
- **`task-attachment-list`** — updated to call `resolveClipboardImageUrl()` and detect `file:///clipboard-images/` paths for thumbnails.
- **File paste from Explorer** — copied into `clipboard-images/` dir (via `copyClipboardImageFile`) so the resulting URL is always within our controlled directory and resolvable to `blob:`.
- **`clipboard-image.service.spec.ts`** (new) — unit tests for `pathToFileUrl` (Unix / Windows / backslashes / spaces) and `resolveClipboardImageUrl` edge cases.

## Tested on

- Windows 11: Ctrl+V screenshot, Ctrl+V image file from Explorer — both render correctly in Markdown notes and attachment thumbnails.