### PR TITLE
fix(plugins): restore plugin iframe rendering on desktop (#8467)

### DIFF
--- a/src/app/plugins/ui/plugin-index/plugin-index.component.html
+++ b/src/app/plugins/ui/plugin-index/plugin-index.component.html
@@ -66,15 +66,16 @@
     >
       <!-- sandbox must stay a static attribute and mirror PLUGIN_IFRAME_SANDBOX:
            Angular forbids binding security-sensitive iframe attributes (throws NG0910).
-           No allow-same-origin: the iframe runs on an opaque origin so it cannot reach
-           window.parent.ea. Loaded via srcdoc (not a blob: URL) so it still renders on
-           packaged file:// builds, where an opaque-origin blob: fetch would be blocked. -->
+           allow-same-origin is required: an opaque-origin iframe does not paint when the
+           host is served over file:// (packaged desktop) and blanks every plugin UI
+           (#8467). See PLUGIN_IFRAME_SANDBOX for the accepted trade-off and the app://
+           follow-up that restores opaque-origin isolation. -->
       <iframe
         #iframe
         [srcdoc]="iframeSrcdoc()"
         data-plugin-iframe
         [attr.data-plugin-id]="pluginId()"
-        sandbox="allow-scripts allow-forms allow-popups allow-modals"
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
         class="plugin-iframe"
         [class.hidden]="isLoading()"
         (load)="onIframeLoad()"

--- a/src/app/plugins/util/plugin-iframe.util.spec.ts
+++ b/src/app/plugins/util/plugin-iframe.util.spec.ts
@@ -388,9 +388,12 @@ describe('handlePluginMessage()', () => {
     );
   });
 
-  it('keeps iframe plugins on an opaque sandbox origin', () => {
+  // allow-same-origin is required: an opaque-origin iframe does not paint on
+  // packaged file:// desktop builds and blanks every plugin UI (#8467). The
+  // durable fix that restores opaque-origin isolation is an app:// scheme.
+  it('runs iframe plugins with a same-origin sandbox so they render on file://', () => {
     expect(PLUGIN_IFRAME_SANDBOX).toContain('allow-scripts');
-    expect(PLUGIN_IFRAME_SANDBOX).not.toContain('allow-same-origin');
+    expect(PLUGIN_IFRAME_SANDBOX).toContain('allow-same-origin');
   });
 
   describe('buildPluginIframeHtml()', () => {

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -20,10 +20,19 @@ export interface PluginIframeConfig {
   boundMethods?: ReturnType<typeof PluginBridgeService.prototype.createBoundMethods>;
 }
 
-// Keep iframe plugin UIs on an opaque origin. `allow-same-origin` would let blob
-// iframes access `window.parent.ea` and bypass the filtered postMessage bridge.
+// `allow-same-origin` is required: without it the iframe runs on an opaque origin
+// that does NOT paint when the host page is served over file:// (packaged desktop),
+// blanking every plugin UI (#8467) — even though scripts run and the DOM builds.
+//
+// The trade-off is that a same-origin iframe can read `window.parent.ea` directly,
+// bypassing the filtered postMessage bridge. That gap is accepted for now because it
+// only affects explicitly-installed plugins and the same `window.ea` reach already
+// exists via the background `plugin.js` runner (new Function in the host renderer);
+// the most dangerous capability (nodeExecution) stays gated by main-process consent.
+// The durable fix that restores opaque-origin isolation AND rendering is serving the
+// renderer from a registered `app://` scheme instead of file:// (tracked separately).
 export const PLUGIN_IFRAME_SANDBOX =
-  'allow-scripts allow-forms allow-popups allow-modals';
+  'allow-scripts allow-same-origin allow-forms allow-popups allow-modals';
 
 const ALLOWED_IFRAME_API_METHODS = new Set([
   'getTasks',
@@ -546,12 +555,10 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
  * Build the full HTML document for a plugin UI iframe: the plugin's index.html
  * with the host CSS and the postMessage API bridge injected.
  *
- * Returned as a string for `iframe.srcdoc`, NOT a `blob:` URL. srcdoc content is
- * parsed inline, so the iframe loads under its sandbox-assigned opaque origin
- * even on packaged `file://` builds. A `blob:` URL created by the host inherits
- * the host origin, and an opaque-origin iframe (no `allow-same-origin`) cannot
- * fetch it — which blanks the plugin UI on desktop. srcdoc avoids that
- * cross-origin fetch entirely. See PLUGIN_IFRAME_SANDBOX.
+ * Returned as a string for `iframe.srcdoc`, NOT a `blob:` URL: srcdoc is parsed
+ * inline, so there is no blob URL lifecycle to track and revoke. The iframe is
+ * same-origin with the host (see PLUGIN_IFRAME_SANDBOX — `allow-same-origin` is
+ * required so it renders on packaged `file://` builds).
  */
 export const buildPluginIframeHtml = (config: PluginIframeConfig): string => {
   const apiScript = createPluginApiScript(config);


### PR DESCRIPTION
## Fixes #8467 — plugin iframe blank on Windows desktop

### Problem
Since v18.10.0, every plugin UI iframe renders **blank on packaged desktop** (Windows MS Store + native). The plugin's scripts run and its DOM builds — the user's screenshots show `about:srcdoc … Initialization complete` in the console and a fully-populated `srcdoc` document in the Elements panel — but nothing ever paints. Android is unaffected.

### Root cause
The plugin-isolation work in #8205 / #8225 dropped `allow-same-origin` from the iframe sandbox, putting the plugin UI on an **opaque origin**. On the packaged desktop build the host page is served over `file://`, and an opaque-origin sandboxed `srcdoc` document **does not composite/paint under a `file://` parent** in Electron's Chromium. Android works because Capacitor serves the host from a normal `localhost`-scheme origin rather than `file://`.

Last working release (v18.9.1) used `allow-same-origin` + a blob URL; v18.10.0 dropped `allow-same-origin` and switched to `srcdoc`.

### Fix
Re-add `allow-same-origin` to `PLUGIN_IFRAME_SANDBOX` and the static `sandbox=` template attribute. `srcdoc` is kept (no blob URL lifecycle to manage). Restores rendering to match the last-working config.

### Security trade-off (accepted)
This reopens the iframe → `window.parent.ea` reach. It is accepted for now because:
- it only affects **explicitly-installed** plugins (not drive-by);
- the **same `window.ea` reach already exists** via the background `plugin.js` runner (`new Function` in the main renderer), which the sandbox never gated;
- `nodeExecution` — the most dangerous capability — stays gated by main-process consent (#8205).

The durable fix that restores opaque-origin isolation **and** rendering **and** storage is a registered `app://` scheme, tracked in #8209 (Workstream 5). See https://github.com/super-productivity/super-productivity/issues/8209#issuecomment-4740951939.

### Testing
- `plugin-iframe.util.spec.ts` updated to assert the same-origin invariant; 16/16 green.
- `checkFile` clean on all changed files.
- ⚠️ Packaged-Electron GUI render not verifiable in CI — worth a manual smoke-test (open a plugin UI on a Windows build) before release. Config now matches last-working v18.9.1.
