### PR TITLE
fix(caldav): support Vikunja project discovery

### DIFF
--- a/docs/wiki/3.07-Issue-Integration-Comparison.md
+++ b/docs/wiki/3.07-Issue-Integration-Comparison.md
@@ -91,7 +91,7 @@ Every issue provider supports the same basic operations: checking that the integ
 - **Notes:** Task notes/description support.
 - **Due dates:** Start date with time support.
 - **Related tasks:** Task relationship tracking.
-- **URL format (example Nextcloud):** `https://<NC-URL>/remote.php/dav/calendars/<USER>/<CALENDAR_NAME>/`. Use the **“Copy private link”** (or CalDAV URL) from your calendar—**not** the subscription/export link (that is for the iCal integration). Items without a valid VTODO are skipped.
+- **URL format:** For Nextcloud, use `https://<NC-URL>/remote.php/dav/calendars/<USER>/<CALENDAR_NAME>/` from **“Copy private link”** (or the CalDAV URL), not the subscription/export link. For Vikunja, use the principal URL shown in Vikunja's CalDAV settings, e.g. `https://<VIKUNJA-URL>/dav/principals/<USER>/`, and set the CalDAV resource to the project name or project ID. Items without a valid VTODO are skipped.
 
 ### 7. Calendar (iCal)
 

--- a/src/app/features/issue/providers/caldav/caldav-client.service.spec.ts
+++ b/src/app/features/issue/providers/caldav/caldav-client.service.spec.ts
@@ -93,6 +93,61 @@ const makeIssue = (id: string): CaldavIssue => ({
   etag_hash: 1,
 });
 
+interface TestCalendarLike {
+  displayname?: string;
+  url: string;
+  calendarQuery: jasmine.Spy;
+}
+
+interface TestCalendarHomeLike {
+  displayname?: string;
+  url: string;
+  findAllCalendars: jasmine.Spy<() => Promise<TestCalendarLike[]>>;
+}
+
+interface TestClientCacheLike {
+  client: { calendarHomes: TestCalendarHomeLike[] };
+  calendars: Map<string, TestCalendarLike>;
+}
+
+interface TestGetClientTarget {
+  _get_client: (cfg: CaldavCfg) => Promise<TestClientCacheLike>;
+}
+
+interface TestGetCalendarTarget {
+  _getCalendar: (cfg: CaldavCfg) => Promise<TestCalendarLike>;
+}
+
+const makeCalendar = (
+  url: string,
+  displayname?: string,
+  canQuery = true,
+): TestCalendarLike => ({
+  url,
+  displayname,
+  calendarQuery: jasmine.createSpy('calendarQuery').and.resolveTo(canQuery ? [] : null),
+});
+
+const makeCalendarHome = (
+  url: string,
+  calendars: TestCalendarLike[],
+  displayname?: string,
+): TestCalendarHomeLike => ({
+  url,
+  displayname,
+  findAllCalendars: jasmine.createSpy('findAllCalendars').and.resolveTo(calendars),
+});
+
+const makeFailingCalendarHome = (
+  url: string,
+  error: Error,
+  displayname?: string,
+): TestCalendarHomeLike => ({
+  url,
+  displayname,
+  findAllCalendars: jasmine.createSpy('findAllCalendars').and.rejectWith(error),
+});
+
 /** Subclass that makes platform detection and native HTTP injectable for tests. */
 class TestableCaldavClientService extends CaldavClientService {
   private _isNativePlatformValue = false;
@@ -202,6 +257,184 @@ describe('CaldavClientService.getByIds$', () => {
     const result = await firstValueFrom(svc.getByIds$(['task-10', 'other'], MOCK_CFG));
 
     expect(result.map((issue) => issue.id)).toEqual(['task-10', 'other']);
+  });
+});
+
+describe('CaldavClientService._getCalendar', () => {
+  let svc: TestableCaldavClientService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: CaldavClientService, useClass: TestableCaldavClientService },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', ['open']),
+        },
+      ],
+    });
+    svc = TestBed.inject(CaldavClientService) as TestableCaldavClientService;
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('finds a calendar from later calendar homes when the first home has no match', async () => {
+    const laterCalendar = makeCalendar('/dav/projects/12/', 'Inbox');
+    const firstHome = makeCalendarHome('/dav/calendars/', [
+      makeCalendar('/dav/calendars/archive/', 'Archive'),
+    ]);
+    const secondHome = makeCalendarHome('/dav/projects/', [laterCalendar]);
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [firstHome, secondHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    const calendar = await (svc as unknown as TestGetCalendarTarget)._getCalendar({
+      ...MOCK_CFG,
+      resourceName: 'Inbox',
+    });
+
+    expect(calendar).toBe(laterCalendar);
+    expect(firstHome.findAllCalendars).toHaveBeenCalledTimes(1);
+    expect(secondHome.findAllCalendars).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves displayname precedence over matching URL segments', async () => {
+    const urlSegmentMatch = makeCalendar('/dav/projects/Personal/', 'Work');
+    const displayNameMatch = makeCalendar('/dav/projects/b123/', 'Personal');
+    const projectsHome = makeCalendarHome('/dav/projects/', [
+      urlSegmentMatch,
+      displayNameMatch,
+    ]);
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [projectsHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    const calendar = await (svc as unknown as TestGetCalendarTarget)._getCalendar({
+      ...MOCK_CFG,
+      resourceName: 'Personal',
+    });
+
+    expect(calendar).toBe(displayNameMatch);
+  });
+
+  it('does not select the Vikunja projects home when resourceName matches the home', async () => {
+    const projectsHomeCollection = makeCalendar('/dav/projects/', 'projects', false);
+    const projectsHome = makeCalendarHome('/dav/projects/', [projectsHomeCollection]);
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [projectsHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    await expectAsync(
+      (svc as unknown as TestGetCalendarTarget)._getCalendar({
+        ...MOCK_CFG,
+        caldavUrl: 'http://192.168.0.5:3456/dav/principals/loki/',
+        resourceName: 'projects',
+        username: 'loki',
+      }),
+    ).toBeRejectedWithError('CALENDAR NOT FOUND: projects');
+  });
+
+  it('does not silently map a home resource to the only concrete project', async () => {
+    const inboxProject = makeCalendar('/dav/projects/12/', 'Inbox');
+    const projectsHome = makeCalendarHome('/dav/projects/', [inboxProject]);
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [projectsHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    await expectAsync(
+      (svc as unknown as TestGetCalendarTarget)._getCalendar({
+        ...MOCK_CFG,
+        caldavUrl: 'http://192.168.0.5:3456/dav/principals/loki/',
+        resourceName: 'projects',
+        username: 'loki',
+      }),
+    ).toBeRejectedWithError('CALENDAR NOT FOUND: projects');
+  });
+
+  it('selects a concrete Vikunja project by display name while skipping the home collection', async () => {
+    const projectsHomeCollection = makeCalendar('/dav/projects/', 'projects', false);
+    const inboxProject = makeCalendar('/dav/projects/12/', 'Inbox');
+    const projectsHome = makeCalendarHome('/dav/projects/', [
+      projectsHomeCollection,
+      inboxProject,
+    ]);
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [projectsHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    const calendar = await (svc as unknown as TestGetCalendarTarget)._getCalendar({
+      ...MOCK_CFG,
+      caldavUrl: 'http://192.168.0.5:3456/dav/principals/loki/',
+      resourceName: 'Inbox',
+      username: 'loki',
+    });
+
+    expect(calendar).toBe(inboxProject);
+  });
+
+  it('selects a concrete Vikunja project by final URL segment while skipping the home collection', async () => {
+    const projectsHomeCollection = makeCalendar('/dav/projects/', 'projects', false);
+    const inboxProject = makeCalendar('/dav/projects/12/', 'Inbox');
+    const projectsHome = makeCalendarHome('/dav/projects/', [
+      projectsHomeCollection,
+      inboxProject,
+    ]);
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [projectsHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    const calendar = await (svc as unknown as TestGetCalendarTarget)._getCalendar({
+      ...MOCK_CFG,
+      caldavUrl: 'http://192.168.0.5:3456/dav/principals/loki/',
+      resourceName: '12',
+      username: 'loki',
+    });
+
+    expect(calendar).toBe(inboxProject);
+  });
+
+  it('continues to later calendar homes when an earlier home fails', async () => {
+    const firstHome = makeFailingCalendarHome(
+      '/dav/broken/',
+      new Error('temporary failure'),
+    );
+    const secondHomeCalendar = makeCalendar('/dav/projects/12/', 'Inbox');
+    const secondHome = makeCalendarHome('/dav/projects/', [secondHomeCalendar]);
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [firstHome, secondHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    const calendar = await (svc as unknown as TestGetCalendarTarget)._getCalendar({
+      ...MOCK_CFG,
+      resourceName: 'Inbox',
+    });
+
+    expect(calendar).toBe(secondHomeCalendar);
+    expect(firstHome.findAllCalendars).toHaveBeenCalledTimes(1);
+    expect(secondHome.findAllCalendars).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a network error when all calendar homes fail', async () => {
+    const firstHome = makeFailingCalendarHome('/dav/broken-1/', new Error('failure 1'));
+    const secondHome = makeFailingCalendarHome('/dav/broken-2/', new Error('failure 2'));
+    spyOn(svc as unknown as TestGetClientTarget, '_get_client').and.resolveTo({
+      client: { calendarHomes: [firstHome, secondHome] },
+      calendars: new Map<string, TestCalendarLike>(),
+    });
+
+    await expectAsync(
+      (svc as unknown as TestGetCalendarTarget)._getCalendar({
+        ...MOCK_CFG,
+        resourceName: 'Inbox',
+      }),
+    ).toBeRejectedWithError(/CALDAV NETWORK ERROR/);
   });
 });
 

--- a/src/app/features/issue/providers/caldav/caldav-client.service.ts
+++ b/src/app/features/issue/providers/caldav/caldav-client.service.ts
@@ -45,6 +45,12 @@ interface ClientCache {
   calendars: Map<string, Calendar>;
 }
 
+interface CalendarHomeLike {
+  displayname?: string;
+  url: string;
+  findAllCalendars: () => Promise<Calendar[]>;
+}
+
 interface CalDavTaskData {
   data: string;
   url: string;
@@ -74,12 +80,51 @@ export class CaldavClientService {
     );
   }
 
-  private static _getCalendarUriFromUrl(url: string): string {
-    if (url.endsWith('/')) {
-      url = url.substring(0, url.length - 1);
-    }
+  private static _normalizeCalDavPath(value: string): string {
+    return value.replace(/\/+$/, '');
+  }
 
-    return url.substring(url.lastIndexOf('/') + 1);
+  private static _getCalendarUriFromUrl(url: string): string {
+    const normalizedUrl = CaldavClientService._normalizeCalDavPath(url);
+    return normalizedUrl.substring(normalizedUrl.lastIndexOf('/') + 1);
+  }
+
+  private static _isSameCalDavPath(a: string, b: string): boolean {
+    return (
+      CaldavClientService._normalizeCalDavPath(a) ===
+      CaldavClientService._normalizeCalDavPath(b)
+    );
+  }
+
+  private static _matchesCalendarDisplayName(
+    item: { displayname?: string },
+    resource: string,
+  ): boolean {
+    return item.displayname === resource;
+  }
+
+  private static _matchesCalendarUri(item: { url: string }, resource: string): boolean {
+    return CaldavClientService._getCalendarUriFromUrl(item.url) === resource;
+  }
+
+  private static _findMatchingCalendar(
+    calendars: Calendar[],
+    resource: string,
+    calendarHome: CalendarHomeLike,
+  ): Calendar | undefined {
+    const concreteCalendars = calendars.filter(
+      (item) => !CaldavClientService._isSameCalDavPath(item.url, calendarHome.url),
+    );
+    const displayNameMatch = concreteCalendars.find((item) =>
+      CaldavClientService._matchesCalendarDisplayName(item, resource),
+    );
+
+    return (
+      displayNameMatch ??
+      concreteCalendars.find((item) =>
+        CaldavClientService._matchesCalendarUri(item, resource),
+      )
+    );
   }
 
   private static async _getAllTodos(
@@ -258,19 +303,32 @@ export class CaldavClientService {
       return clientCache.calendars.get(resource);
     }
 
-    const calendars = await clientCache.client.calendarHomes[0]
-      .findAllCalendars()
-      .catch((err) => this._handleNetErr(err));
+    let lastCalendarHomeError: unknown;
 
-    const calendar = calendars.find(
-      (item: Calendar) =>
-        (item.displayname || CaldavClientService._getCalendarUriFromUrl(item.url)) ===
+    for (const calendarHome of clientCache.client.calendarHomes as CalendarHomeLike[]) {
+      const calendars = await calendarHome.findAllCalendars().catch((err: unknown) => {
+        lastCalendarHomeError = err;
+        return null;
+      });
+
+      if (!calendars) {
+        continue;
+      }
+
+      const calendar = CaldavClientService._findMatchingCalendar(
+        calendars,
         resource,
-    );
+        calendarHome,
+      );
 
-    if (calendar !== undefined) {
-      clientCache.calendars.set(resource, calendar);
-      return calendar;
+      if (calendar !== undefined) {
+        clientCache.calendars.set(resource, calendar);
+        return calendar;
+      }
+    }
+
+    if (lastCalendarHomeError) {
+      this._handleNetErr(lastCalendarHomeError);
     }
 
     this._snackService.open({


### PR DESCRIPTION
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## What changed

Fixes CalDAV Todo calendar discovery for Vikunja-style setups where the configured URL points to the principal endpoint, e.g. `/dav/principals/<user>/`, and discovery returns `/dav/projects/` as the calendar home.

The CalDAV provider now:
- checks all discovered calendar homes instead of only the first one
- avoids selecting the calendar home/root collection itself as the VTODO calendar
- matches concrete project calendars by display name, URL segment, or normalized path
- documents the Vikunja principal URL + project resource setup

Fixes #8471

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- `npm run test:file src/app/features/issue/providers/caldav/caldav-client.service.spec.ts`
- `npm run checkFile src/app/features/issue/providers/caldav/caldav-client.service.ts`
- `npm run checkFile src/app/features/issue/providers/caldav/caldav-client.service.spec.ts`
- `npx prettier --write docs/wiki/3.07-Issue-Integration-Comparison.md`
- `npm test`

Manual Vikunja smoke test was not run because I do not have access to a Vikunja instance.