### PR TITLE
ci(electron-build): cache electron binary + retry npm i to fix flaky install

### DIFF
--- a/.github/actions/setup-electron-build/action.yml
+++ b/.github/actions/setup-electron-build/action.yml
@@ -1,0 +1,41 @@
+name: 'Setup Electron Build'
+description: >
+  Shared setup for Electron build/package jobs: Node 22, the git-over-HTTPS
+  workaround, and the npm + electron-binary caches. Does NOT run `npm i` —
+  callers run it themselves (with a retry) because some jobs install platform
+  workarounds immediately before it.
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version: 22
+
+    # work around for npm installs from git+https://github.com/johannesjo/J2M.git
+    - name: Reconfigure git to use HTTP authentication
+      shell: bash
+      run: >
+        git config --global url."https://github.com/".insteadOf
+        ssh://git@github.com/
+
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      shell: bash
+      run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        # npm registry tarballs + electron's prebuilt binary. Caching the
+        # binary lets warm runs skip its GitHub download — the flaky step that
+        # times out (ETIMEDOUT) and fails the job. electron's cache dir is
+        # OS-specific, so list all three; actions/cache ignores the paths that
+        # don't exist on the current runner.
+        path: |
+          ${{ steps.npm-cache-dir.outputs.dir }}
+          ~/.cache/electron
+          ~/Library/Caches/electron
+          ~/AppData/Local/electron/Cache
+        key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node22-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,34 +77,25 @@ jobs:
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
 
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      # work around for npm installs from git+https://github.com/johannesjo/J2M.git
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
 
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-
+      - name: Setup Electron build environment
+        uses: ./.github/actions/setup-electron-build
 
       - name: Install npm Packages
-        #  if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm i
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          # Retry electron's flaky postinstall binary download. Drop
+          # node_modules/electron between tries so npm re-runs the postinstall
+          # (a plain re-`npm i` skips scripts for an already-present package).
+          command: npm i || { rm -rf node_modules/electron; exit 1; }
 
       - name: Install Playwright Browsers
         run: |
@@ -214,42 +205,32 @@ jobs:
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
 
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Check out Git repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          node-version: 22
+          persist-credentials: false
+
       - name: Echo is Release
         run: echo "IS_RELEASE $IS_RELEASE, ${{ startsWith(github.ref, 'refs/tags/v') }}"
         env:
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Check out Git repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      # work around for npm installs from git+https://github.com/johannesjo/J2M.git
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
+      - name: Setup Electron build environment
+        uses: ./.github/actions/setup-electron-build
 
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-
-
-      - name: Workaround for nx issue and dmg licence issue
-        run: npm install @nx/nx-darwin-arm64 dmg-license
-
+      # @nx/nx-darwin-arm64 + dmg-license aren't in package.json (npm's
+      # optional-dep bug skips them), so install them explicitly. That install
+      # and `npm i` both run electron's flaky postinstall binary download, so
+      # retry the whole thing — dropping node_modules/electron between tries
+      # forces the postinstall to re-run (npm skips it for a present package).
       - name: Install npm Packages
-        #  if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm i
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i || { rm -rf node_modules/electron; exit 1; }
 
       - run: 'echo "$PROVISION_PROFILE" | base64 --decode > embedded.provisionprofile'
         shell: bash
@@ -313,9 +294,6 @@ jobs:
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
 
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
       # required because setting via env.TZ does not work on windows
       - name: Set timezone to Europe Standard Time
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
@@ -326,31 +304,23 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      # work around for npm installs from git+https://github.com/johannesjo/J2M.git
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
 
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-
+      - name: Setup Electron build environment
+        uses: ./.github/actions/setup-electron-build
 
-      - name: Workaround for nx issue
-        run: npm install @nx/nx-win32-x64-msvc
-
+      # @nx/nx-win32-x64-msvc isn't in package.json (npm's optional-dep bug
+      # skips it), so install it explicitly. That install and `npm i` both run
+      # electron's flaky postinstall binary download, so retry the whole thing
+      # — dropping node_modules/electron between tries forces the postinstall
+      # to re-run (npm skips it for a present package).
       - name: Install npm Packages
-        #  if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm i
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: npm install @nx/nx-win32-x64-msvc && npm i || { rm -rf node_modules/electron; exit 1; }
 
       - name: Setup Chrome
         id: setup-chrome

--- a/.github/workflows/electron-smoke.yml
+++ b/.github/workflows/electron-smoke.yml
@@ -49,34 +49,25 @@ jobs:
       UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
-
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      # Work around npm installs from git+https://github.com/johannesjo/J2M.git
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
-
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-
+      - name: Setup Electron build environment
+        uses: ./.github/actions/setup-electron-build
 
       - name: Install npm packages
-        run: npm i
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          # Retry electron's flaky postinstall binary download. Drop
+          # node_modules/electron between tries so npm re-runs the postinstall
+          # (a plain re-`npm i` skips scripts for an already-present package).
+          command: npm i || { rm -rf node_modules/electron; exit 1; }
 
       - run: npm run env
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -18,38 +18,27 @@ jobs:
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
 
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
-      # required because setting via env.TZ does not work on windows
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      # work around for npm installs from git+https://github.com/johannesjo/J2M.git
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-
 
-      - name: Workaround for nx issue
-        run: npm install @nx/nx-win32-x64-msvc
+      - name: Setup Electron build environment
+        uses: ./.github/actions/setup-electron-build
 
+      # @nx/nx-win32-x64-msvc isn't in package.json (npm's optional-dep bug
+      # skips it), so install it explicitly. That install and `npm i` both run
+      # electron's flaky postinstall binary download, so retry the whole thing
+      # — dropping node_modules/electron between tries forces the postinstall
+      # to re-run (npm skips it for a present package).
       - name: Install npm Packages
-        #  if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm i
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: npm install @nx/nx-win32-x64-msvc && npm i || { rm -rf node_modules/electron; exit 1; }
 
       - name: Build Frontend & Electron TS
         run: npm run buildAllElectron:noTests:prod
@@ -74,42 +63,32 @@ jobs:
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
 
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Check out Git repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          node-version: 22
+          persist-credentials: false
+
       - name: Echo is Release
         run: echo "IS_RELEASE $IS_RELEASE, ${{ startsWith(github.ref, 'refs/tags/v') }}"
         env:
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Check out Git repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      # work around for npm installs from git+https://github.com/johannesjo/J2M.git
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
+      - name: Setup Electron build environment
+        uses: ./.github/actions/setup-electron-build
 
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-
-
-      - name: Workaround for nx issue and dmg licence issue
-        run: npm install @nx/nx-darwin-arm64 dmg-license
-
+      # @nx/nx-darwin-arm64 + dmg-license aren't in package.json (npm's
+      # optional-dep bug skips them), so install them explicitly. That install
+      # and `npm i` both run electron's flaky postinstall binary download, so
+      # retry the whole thing — dropping node_modules/electron between tries
+      # forces the postinstall to re-run (npm skips it for a present package).
       - name: Install npm Packages
-        #  if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm i
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i || { rm -rf node_modules/electron; exit 1; }
 
       - run: 'echo "$PROVISION_PROFILE" | base64 --decode > embedded.provisionprofile'
         shell: bash

--- a/.github/workflows/test-mac-dmg-build.yml
+++ b/.github/workflows/test-mac-dmg-build.yml
@@ -14,30 +14,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Reconfigure git to use HTTP authentication
-        run: |
-          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+      - name: Setup Electron build environment
+        uses: ./.github/actions/setup-electron-build
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 22
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: npm-cache
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node22-
-
-      - name: Install native helpers
-        run: npm install @nx/nx-darwin-arm64 dmg-license
-
+      # @nx/nx-darwin-arm64 + dmg-license aren't in package.json (npm's
+      # optional-dep bug skips them), so install them explicitly. That install
+      # and `npm i` both run electron's flaky postinstall binary download, so
+      # retry the whole thing — dropping node_modules/electron between tries
+      # forces the postinstall to re-run (npm skips it for a present package).
       - name: Install npm packages
-        run: npm i
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i || { rm -rf node_modules/electron; exit 1; }
 
       - name: Decode provisioning profile
         shell: bash


### PR DESCRIPTION
## Why

CI run [27780507031](https://github.com/super-productivity/super-productivity/actions/runs/27780507031) (master "Electron Packaging Smoke Test") failed at `npm i`. Root cause was **not** a code defect — electron's postinstall (`node install.js`) downloads a prebuilt binary from GitHub releases, and the TCP connect timed out:

```
npm error path .../node_modules/electron
npm error command sh -c node install.js
npm error RequestError: connect ETIMEDOUT 140.82.114.4:443
```

A transient network blip on the runner. This PR hardens every Electron build/package job against it.

## What changed

**New composite action** `.github/actions/setup-electron-build` — node 22 + the git-over-HTTPS workaround + a combined npm-registry **and electron-binary** cache. Caching `~/.cache/electron` (and the macOS/Windows equivalents) lets warm runs skip the flaky GitHub download entirely. The cache key/restore-keys are unchanged from before.

**Retried `npm i`** in every consuming job via `nick-fields/retry` (the repo's existing retry idiom, already used in `e2e-scheduled`/`build`) to absorb a cold-cache timeout. `node_modules/electron` is dropped between attempts so npm actually re-runs the postinstall.

Routed through the composite:

| Workflow | Jobs |
| --- | --- |
| `electron-smoke.yml` | linux |
| `build.yml` | linux, mac, windows |
| `manual-build.yml` | windows, mac |
| `test-mac-dmg-build.yml` | mac |

The composite removes ~6 copies of the node/git/cache boilerplate, so the change is a net line reduction despite adding resilience.

## Notes verified during review

- **`npm i` skips a postinstall for an already-present package** (tested) → hence `rm -rf node_modules/electron` before retry, to force the binary re-download.
- **`npm install <pkg>` reifies the *whole* tree** (tested) → on mac/windows the electron download happens during the pre-existing `npm install @nx/<platform>` step, so the nx workaround is folded into the same retried command rather than left unprotected.
- **`nick-fields/retry` runs `command` under `shell: bash` on all OSes** (Git Bash on Windows; verified from the action source). The cleanup is inlined into `command` rather than using `on_retry_command`, because `on_retry_command` runs via `execSync`/cmd and ignores `shell`, which would break the `rm -rf` on Windows.

## Risk

CI-only; no app code. The linux smoke + linux build jobs run on every PR/push and validate the composite continuously. The mac/windows/manual jobs are tag- or dispatch-only and can't be exercised before a release — the only mac/win-specific change is merging the nx workaround into the retried install (behavior-preserving: same commands, same order). A `workflow_dispatch` run of `manual-build.yml` exercises the full mac+windows path without needing a tag.

## Follow-up (not in this PR)

`build-publish-to-mac-store-on-release.yml` and `build-create-windows-store-on-release.yml` use the same install pattern and remain exposed on actual store releases. Same mechanical fix; left out to keep this PR scoped.
