### PR TITLE
fix(sync): tolerate unknown issue-provider keys instead of flagging corruption

### DIFF
--- a/src/app/features/issue/issue.model.ts
+++ b/src/app/features/issue/issue.model.ts
@@ -39,7 +39,11 @@ export interface BaseIssueProviderCfg {
   isEnabled: boolean;
 }
 
-// Built-in issue provider keys (strict union for type safety)
+// Built-in issue provider keys (strict union for type safety).
+// NOTE: adding a key here is forward-compatible for OLDER clients only because
+// `isForwardCompatibleProviderKeyError` (op-log/validation/validation-fn.ts) tolerates
+// unknown provider-key values during sync validation. Without that, an older build's
+// typia validator would treat a synced task/provider using the new key as corruption.
 export type BuiltInIssueProviderKey =
   | 'JIRA'
   | 'GITLAB'

--- a/src/app/op-log/validation/validation-fn.spec.ts
+++ b/src/app/op-log/validation/validation-fn.spec.ts
@@ -1,0 +1,247 @@
+import { IValidation } from 'typia';
+import {
+  isForwardCompatibleProviderKeyError,
+  validateAppDataProperty,
+  validateAllData,
+  validateFull,
+} from './validation-fn';
+import { createValidAppData, createValidTask } from './state-validity-test-utils';
+import {
+  IssueProvider,
+  IssueProviderKey,
+  IssueProviderState,
+} from '../../features/issue/issue.model';
+import { Task, TaskState } from '../../features/tasks/task.model';
+import { ArchiveModel } from '../../features/time-tracking/time-tracking.model';
+
+/**
+ * Regression guard for the forward-compatibility break that surfaced as a false
+ * "data corruption" / repair dialog on older clients after a newer client added a
+ * provider key (`PLAINSPACE`, #8424) and synced tasks using it. See
+ * `isForwardCompatibleProviderKeyError` in validation-fn.ts.
+ *
+ * `'__FUTURE_PROVIDER__'` stands in for any provider key newer than the running
+ * build (PLAINSPACE itself is now in the union, so it would no longer reproduce).
+ */
+describe('validation-fn — forward-compatible provider keys', () => {
+  const FUTURE_KEY = '__FUTURE_PROVIDER__' as unknown as IssueProviderKey;
+
+  const taskState = (tasks: Task[]): TaskState => ({
+    ...createValidAppData().task,
+    ids: tasks.map((t) => t.id),
+    entities: Object.fromEntries(tasks.map((t) => [t.id, t])),
+  });
+
+  describe('end-to-end typia validation', () => {
+    it('accepts a task whose issueType is an unknown (future) provider key', () => {
+      const state = taskState([createValidTask('t1', { issueType: FUTURE_KEY })]);
+      const result = validateAppDataProperty('task', state);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a known plugin: provider key (sanity check baseline)', () => {
+      const state = taskState([
+        createValidTask('t1', { issueType: 'plugin:some-future-plugin' }),
+      ]);
+      expect(validateAppDataProperty('task', state).success).toBe(true);
+    });
+
+    it('accepts an issue provider whose key is an unknown (future) provider', () => {
+      // IssueProvider is a discriminated union; an unknown discriminant produces a
+      // parent-object typia error, not a `.issueProviderKey` field error.
+      const provider = {
+        id: 'p1',
+        isEnabled: true,
+        issueProviderKey: '__FUTURE_PROVIDER__',
+      } as unknown as IssueProvider;
+      const state: IssueProviderState = { ids: ['p1'], entities: { p1: provider } };
+      expect(validateAppDataProperty('issueProvider', state).success).toBe(true);
+    });
+
+    it('still rejects an issue provider whose key is a non-string', () => {
+      const provider = {
+        id: 'p1',
+        isEnabled: true,
+        issueProviderKey: 123,
+      } as unknown as IssueProvider;
+      const state: IssueProviderState = { ids: ['p1'], entities: { p1: provider } };
+      expect(validateAppDataProperty('issueProvider', state).success).toBe(false);
+    });
+
+    it('still rejects a KNOWN-key provider with a malformed field (not over-relaxed)', () => {
+      // A known discriminant matches its branch, so typia reports child-field errors
+      // (not the parent "unknown key" error) — these must NOT be relaxed.
+      const provider = {
+        id: 'p1',
+        isEnabled: 'not-a-boolean',
+        issueProviderKey: 'JIRA',
+      } as unknown as IssueProvider;
+      const state: IssueProviderState = { ids: ['p1'], entities: { p1: provider } };
+      expect(validateAppDataProperty('issueProvider', state).success).toBe(false);
+    });
+
+    it('accepts an archived task with an unknown provider key', () => {
+      const base = createValidAppData().archiveYoung;
+      const archive: ArchiveModel = {
+        ...base,
+        task: {
+          ids: ['a1'],
+          entities: { a1: createValidTask('a1', { issueType: FUTURE_KEY }) },
+        },
+      };
+      expect(validateAppDataProperty('archiveYoung', archive).success).toBe(true);
+    });
+
+    it('still rejects a non-string issueType (genuine corruption)', () => {
+      const state = taskState([
+        createValidTask('t1', {
+          issueType: 123 as unknown as IssueProviderKey,
+        }),
+      ]);
+      expect(validateAppDataProperty('task', state).success).toBe(false);
+    });
+
+    it('still rejects when a real error coexists with an unknown provider key', () => {
+      const state = taskState([
+        createValidTask('t1', {
+          issueType: FUTURE_KEY,
+          timeEstimate: 'not-a-number' as unknown as number,
+        }),
+      ]);
+      const result = validateAppDataProperty('task', state);
+      expect(result.success).toBe(false);
+      // the only surviving error must be the genuine one, not the relaxed issueType
+      if (!result.success) {
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].path).toContain('timeEstimate');
+      }
+    });
+
+    // The production sync-receive path validates via validateAllData/validateFull
+    // (whole-app validators), whose error paths are prefixed (e.g.
+    // `$input.task.entities.X.issueType`) — distinct from the per-property entry
+    // exercised above. These guard that the relaxation fires there too.
+    it('accepts unknown task + provider keys via validateAllData (whole-app entry)', () => {
+      const appData = {
+        ...createValidAppData(),
+        task: taskState([createValidTask('t1', { issueType: FUTURE_KEY })]),
+        issueProvider: {
+          ids: ['p1'],
+          entities: {
+            p1: {
+              id: 'p1',
+              isEnabled: true,
+              issueProviderKey: FUTURE_KEY,
+            } as unknown as IssueProvider,
+          },
+        } as IssueProviderState,
+      };
+      expect(validateAllData(appData).success).toBe(true);
+    });
+
+    it('accepts unknown task + provider keys via validateFull (typia + cross-model)', () => {
+      const base = createValidAppData();
+      const appData = {
+        ...base,
+        task: taskState([createValidTask('t1', { issueType: FUTURE_KEY })]),
+        // wire the task into INBOX so cross-model relationship checks pass
+        project: {
+          ...base.project,
+          entities: {
+            ...base.project.entities,
+            INBOX: { ...base.project.entities['INBOX']!, taskIds: ['t1'] },
+          },
+        },
+        issueProvider: {
+          ids: ['p1'],
+          entities: {
+            p1: {
+              id: 'p1',
+              isEnabled: true,
+              issueProviderKey: FUTURE_KEY,
+            } as unknown as IssueProvider,
+          },
+        } as IssueProviderState,
+      };
+      expect(validateFull(appData).isValid).toBe(true);
+    });
+  });
+
+  describe('isForwardCompatibleProviderKeyError', () => {
+    const err = (path: string, expected: string, value: unknown): IValidation.IError => ({
+      path,
+      expected,
+      value,
+    });
+
+    // The two `expected` strings below mirror the real typia output captured from the
+    // compiled validators (scalar union vs discriminated-union member names).
+    const ISSUE_TYPE_UNION =
+      '("JIRA" | "GITLAB" | "NEXTCLOUD_DECK" | `plugin:${string}` | undefined)';
+    const PROVIDER_MEMBER_UNION =
+      '(IssueProviderJira | IssueProviderGithub | IssueProviderPluginType | undefined)';
+
+    it('matches an unknown string issueType (scalar union field)', () => {
+      expect(
+        isForwardCompatibleProviderKeyError(
+          err('$input.task.entities.x.issueType', ISSUE_TYPE_UNION, 'PLAINSPACE'),
+        ),
+      ).toBe(true);
+    });
+
+    it('matches an unknown issueProviderKey via the discriminated-union parent error', () => {
+      expect(
+        isForwardCompatibleProviderKeyError(
+          err('$input.issueProvider.entities.y', PROVIDER_MEMBER_UNION, {
+            id: 'y',
+            isEnabled: true,
+            issueProviderKey: 'PLAINSPACE',
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('does NOT match a non-string issueType (genuine corruption)', () => {
+      expect(
+        isForwardCompatibleProviderKeyError(
+          err('$input.task.entities.x.issueType', ISSUE_TYPE_UNION, 42),
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT match an empty string issueType', () => {
+      expect(
+        isForwardCompatibleProviderKeyError(
+          err('$input.task.entities.x.issueType', ISSUE_TYPE_UNION, ''),
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT match a provider object whose key is a non-string', () => {
+      expect(
+        isForwardCompatibleProviderKeyError(
+          err('$input.issueProvider.entities.y', PROVIDER_MEMBER_UNION, {
+            id: 'y',
+            issueProviderKey: 42,
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT match an unrelated field', () => {
+      expect(
+        isForwardCompatibleProviderKeyError(
+          err('$input.task.entities.x.title', '(string)', 'whatever'),
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT match a same-named field with a different (closed) expected type', () => {
+      expect(
+        isForwardCompatibleProviderKeyError(
+          err('$input.task.entities.x.issueType', '("A" | "B")', 'C'),
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/app/op-log/validation/validation-fn.ts
+++ b/src/app/op-log/validation/validation-fn.ts
@@ -11,7 +11,7 @@ import { ProjectState } from '../../features/project/project.model';
 import { SectionState } from '../../features/section/section.model';
 import { MenuTreeState } from '../../features/menu-tree/store/menu-tree.model';
 import { TaskState } from '../../features/tasks/task.model';
-import { createValidate } from 'typia';
+import { createValidate, IValidation } from 'typia';
 import { TagState } from '../../features/tag/tag.model';
 import { SimpleCounterState } from '../../features/simple-counter/simple-counter.model';
 import { Reminder } from '../../features/reminder/reminder.model';
@@ -55,6 +55,85 @@ const _validateTimeTracking = createValidate<TimeTrackingState>();
 const _validatePluginUserData = createValidate<PluginUserDataState>();
 const _validatePluginMetadata = createValidate<PluginMetaDataState>();
 const _validateSection = createValidate<SectionState>();
+
+/**
+ * `Task.issueType` and `IssueProvider.issueProviderKey` are validated against the
+ * `IssueProviderKey` union, a set typia compiles into a *closed* membership check at
+ * build time. That set is open-ended by design: new built-in providers (e.g. the
+ * Plainspace integration, #8424) and plugin providers (`plugin:${string}`) keep being
+ * added. When a newer client syncs a task/provider using a key an older client's build
+ * does not know yet, typia would otherwise report the unknown — but well-formed —
+ * value as data corruption. That surfaces a "repair your data?" dialog; declining it
+ * wedges sync (state never marked IN_SYNC) and accepting it risks mangling valid data.
+ * An unknown *string* provider key is a forward-compatible value, not damage, so we
+ * drop those specific errors and carry the value through untouched.
+ *
+ * typia reports the two fields with different error shapes (both verified against the
+ * real validator in the spec), so we match both:
+ *  1. `Task.issueType` is a plain optional union field → the error is AT the field,
+ *     `value` is the unknown string, `expected` is the union (identified by its
+ *     `plugin:${string}` branch).
+ *  2. `IssueProvider` is a *discriminated union* keyed on `issueProviderKey` → an
+ *     unknown discriminant produces a parent-OBJECT error (`value` is the whole
+ *     entity, `expected` lists the member type names, NOT a `.issueProviderKey`
+ *     path). We tolerate it when that object carries a non-empty string
+ *     `issueProviderKey` and `expected` names the union via its
+ *     `IssueProviderPluginType` member.
+ *
+ * Either way a non-string key (null/number/object) stays a corruption error, and a
+ * known-but-malformed entity fails on its own child-field errors (not these), so
+ * genuine damage is never masked.
+ *
+ * shortcut: matched by typia error shape — if more open-ended enums appear, prefer
+ * typing them as opaque strings in the synced model over extending this matcher.
+ */
+const _ISSUE_TYPE_PATH_RE = /\.issueType$/;
+
+const _hasUnknownStringProviderKey = (value: unknown): boolean =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { issueProviderKey?: unknown }).issueProviderKey === 'string' &&
+  (value as { issueProviderKey: string }).issueProviderKey.length > 0;
+
+export const isForwardCompatibleProviderKeyError = (err: IValidation.IError): boolean => {
+  // (1) Task.issueType — scalar union field, error reported at the field itself.
+  if (
+    typeof err.value === 'string' &&
+    err.value.length > 0 &&
+    _ISSUE_TYPE_PATH_RE.test(err.path) &&
+    err.expected.includes('plugin:')
+  ) {
+    return true;
+  }
+  // (2) IssueProvider — discriminated union, unknown discriminant reported as a
+  //     parent-object error. Only the IssueProvider union names IssueProviderPluginType.
+  return (
+    err.expected.includes('IssueProviderPluginType') &&
+    _hasUnknownStringProviderKey(err.value)
+  );
+};
+
+/**
+ * Strips forward-compatible provider-key errors from a typia result, recomputing
+ * `success` if those were the only failures. See {@link isForwardCompatibleProviderKeyError}.
+ */
+const _relaxForwardCompatibleErrors = <R>(
+  result: ValidationResult<R>,
+): ValidationResult<R> => {
+  if (result.success) {
+    return result;
+  }
+  const remaining = result.errors.filter(
+    (err) => !isForwardCompatibleProviderKeyError(err),
+  );
+  if (remaining.length === result.errors.length) {
+    return result;
+  }
+  if (remaining.length === 0) {
+    return { success: true, data: result.data as R };
+  }
+  return { ...result, errors: remaining };
+};
 
 export const validateAllData = <R>(
   d: AppDataComplete | R,
@@ -132,7 +211,7 @@ const validateArchiveModel = <R>(
   d: ArchiveModel | R,
   context: 'archiveYoung' | 'archiveOld',
 ): ValidationResult<ArchiveModel> => {
-  const r = _validateArchive(d);
+  const r = _relaxForwardCompatibleErrors(_validateArchive(d));
   if (!r.success) {
     logValidationFailure(context, r, d);
   }
@@ -154,11 +233,12 @@ export const validateAppDataProperty = <K extends keyof AppDataComplete>(
 };
 
 const _wrapValidate = <R>(
-  result: ValidationResult<R>,
+  rawResult: ValidationResult<R>,
   d?: unknown,
   isEntityCheck = false,
   context = 'unknown',
 ): ValidationResult<R> => {
+  const result = _relaxForwardCompatibleErrors(rawResult);
   if (!result.success) {
     logValidationFailure(context, result, d, isEntityCheck);
   }


### PR DESCRIPTION
## Problem

A mobile error log showed post-sync state validation failing as **data corruption**, surfacing the "repair your data?" dialog; declining it left sync wedged (`SyncWrapperService: Post-sync state validation failed, not marking as IN_SYNC`).

Root cause: a newer client added the `PLAINSPACE` provider key (#8424) and synced tasks/providers using it. Older clients compile the `IssueProviderKey` literal union into a **closed** typia membership check at build time, so `task.issueType: 'PLAINSPACE'` (and an `IssueProvider` with `issueProviderKey: 'PLAINSPACE'`) is rejected as corrupt on the sync-receive path. The validation log confirms it:

```
firstErrorPath:    $input.task.entities.<id>.issueType
firstErrorExpected: "AZURE_DEVOPS" | ... | "TRELLO" | `plugin:${string}` | undefined   ← no PLAINSPACE
```

These provider-key fields are **open-ended by design** — new built-in providers and plugin keys (`plugin:${string}`) get added over time — so an unknown but well-formed *string* value is a forward-compatible value, not damage.

## Fix

At the typia validation seam (`op-log/validation/validation-fn.ts`), drop the specific errors that represent an unknown-but-well-formed provider key, recomputing `success` when those were the only failures. Wired into `_wrapValidate` (whole-app + per-property `task`/`issueProvider`) and `validateArchiveModel` (archived tasks).

typia reports the two fields with **different error shapes** (both verified against the real validator), so the matcher handles both:
1. `Task.issueType` — a scalar union field → error *at* the field; `value` is the unknown string; `expected` carries the `plugin:${string}` branch.
2. `IssueProvider` — a *discriminated union* keyed on `issueProviderKey` → an unknown discriminant yields a **parent-object** error (`value` = the whole entity, `expected` lists the member type names via `IssueProviderPluginType`, no `.issueProviderKey` path).

A non-string key (null/number/object) still fails as corruption, and a known-key-but-malformed entity fails on its own child-field errors — so genuine damage is never masked.

## Misspelling protection is unchanged

Only runtime sync-validation is relaxed. The app-facing `IssueProviderKey` strict union is untouched, so `task.issueType = 'JRIA'` is still a **compile error** — typos in code are still caught. An unknown runtime value is also inert (issue-provider registry/service-map miss → no integration behavior, no data loss).

## Testing

- 17 unit tests in `validation-fn.spec.ts`, all through the **real** typia validator, covering: unknown `issueType` and `issueProvider` keys accepted via the per-property, `validateAllData`, and `validateFull` (typia + cross-model) entry points; archived tasks; and negatives — non-string keys and a known-key malformed entity still fail.
- Full op-log validation suite green (252+ specs); changed files lint-clean.

## Follow-up (not in this PR)

The cleanest long-term fix is to model `Task.issueType` as an opaque string in the synced schema (would drop branch 1). `IssueProvider.issueProviderKey` can't be opaque-stringed easily — it's a discriminated-union discriminant — so the seam relaxation is the right interim trade. The matcher couples to typia's error-string format; the end-to-end tests pin both real shapes so a typia upgrade fails CI (fail-safe direction).