### PR TITLE
fix(focus-mode): preserve flowtime break settings across mode switch

### DIFF
--- a/e2e/tests/focus-mode/flowtime-settings-preserve.spec.ts
+++ b/e2e/tests/focus-mode/flowtime-settings-preserve.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '../../fixtures/test.fixture';
+import { Locator, Page } from '@playwright/test';
+
+/**
+ * Real-DOM verification for the Flowtime break-settings preservation fix
+ * (issue #7581). Drives the actual `mat-select` and number inputs in the
+ * running app — the unit specs use `setValue`, this proves the real dialog.
+ */
+
+const openFlowtimeDialog = async (page: Page): Promise<void> => {
+  const mainFocusButton = page
+    .getByRole('button')
+    .filter({ hasText: 'center_focus_strong' });
+  await mainFocusButton.click();
+  await expect(page.locator('focus-mode-overlay')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('focus-mode-main')).toBeVisible({ timeout: 5000 });
+
+  await page.locator('segmented-button-group button', { hasText: 'Flowtime' }).click();
+
+  await page.locator('focus-mode-main .mode-settings-btn').click();
+  await expect(page.locator('dialog-flowtime-settings')).toBeVisible({ timeout: 5000 });
+};
+
+const selectBreakMode = async (page: Page, label: string): Promise<void> => {
+  await page.locator('dialog-flowtime-settings mat-select').click();
+  await page.locator('mat-option', { hasText: label }).click();
+  // mat-option overlay closes
+  await expect(page.locator('mat-option')).toHaveCount(0);
+};
+
+// The three rule number inputs in render order: min, max, break. Scoped to the
+// rule section so the ratio-mode percentage input is not matched.
+const ruleInputs = (page: Page): Locator =>
+  page.locator('dialog-flowtime-settings .flowtime-break-rules input[type="number"]');
+
+test.describe('Flowtime settings preservation (#7581)', () => {
+  test.beforeEach(async ({ page, workViewPage }) => {
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask('FlowtimeTest sd:today');
+
+    const firstTask = page.locator('task').first();
+    await expect(firstTask).toBeVisible();
+    await firstTask.hover();
+    const playBtn = page.locator('.play-btn.tour-playBtn').first();
+    await playBtn.waitFor({ state: 'visible' });
+    await playBtn.click();
+    await expect(firstTask).toHaveClass(/isCurrent/, { timeout: 5000 });
+  });
+
+  test('rule values survive a real Rule -> Ratio -> Rule switch', async ({ page }) => {
+    await openFlowtimeDialog(page);
+
+    // Enable breaks so the mode-dependent fields render.
+    await page
+      .locator('dialog-flowtime-settings mat-checkbox', { hasText: 'Enable' })
+      .click();
+
+    await selectBreakMode(page, 'Rule-based');
+    await expect(ruleInputs(page)).toHaveCount(3);
+
+    // Edit the seeded rule to non-default values so we prove real edits survive.
+    await ruleInputs(page).nth(1).fill('40'); // max
+    await ruleInputs(page).nth(2).fill('12'); // break
+    await expect(ruleInputs(page).nth(0)).toHaveValue('0');
+
+    // Round-trip through ratio mode.
+    await selectBreakMode(page, 'Ratio-based');
+    await expect(ruleInputs(page)).toHaveCount(0); // rules hidden in ratio mode
+    await selectBreakMode(page, 'Rule-based');
+
+    // The edited values must still be there.
+    await expect(ruleInputs(page)).toHaveCount(3);
+    await expect(ruleInputs(page).nth(0)).toHaveValue('0');
+    await expect(ruleInputs(page).nth(1)).toHaveValue('40');
+    await expect(ruleInputs(page).nth(2)).toHaveValue('12');
+  });
+
+  test('a field can be cleared after a mode switch (no cache snap-back)', async ({
+    page,
+  }) => {
+    await openFlowtimeDialog(page);
+    await page
+      .locator('dialog-flowtime-settings mat-checkbox', { hasText: 'Enable' })
+      .click();
+    await selectBreakMode(page, 'Rule-based');
+    await selectBreakMode(page, 'Ratio-based');
+    await selectBreakMode(page, 'Rule-based');
+
+    // Clear the Min field by selecting all + delete, as a user would.
+    const minInput = ruleInputs(page).nth(0);
+    await minInput.click();
+    await minInput.press('ControlOrMeta+a');
+    await minInput.press('Backspace');
+
+    await expect(minInput).toHaveValue('');
+  });
+});

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.spec.ts
@@ -123,6 +123,110 @@ describe('DialogFlowtimeSettingsComponent', () => {
     });
   });
 
+  // Footgun guard: the preservation only works while every level of the
+  // breakRules `repeat` opts out of Formly's hide-reset. A future field added
+  // without `resetOnHide: false` would silently re-introduce the #7581 wipe.
+  // This assertion is deterministic (no async hide settling) and fails fast.
+  describe('field config opts out of hide-reset at every level', () => {
+    it('sets resetOnHide:false on every hideable break field', () => {
+      const fields = component.fields() as any[];
+      const byKey = (key: string): any => fields.find((f) => f.key === key);
+
+      expect(byKey('breakPercentage').resetOnHide)
+        .withContext('breakPercentage')
+        .toBe(false);
+
+      const breakRules = byKey('breakRules');
+      expect(breakRules.resetOnHide).withContext('breakRules field').toBe(false);
+      expect(breakRules.fieldArray.resetOnHide)
+        .withContext('breakRules.fieldArray')
+        .toBe(false);
+      breakRules.fieldArray.fieldGroup.forEach((inner: any) => {
+        expect(inner.resetOnHide)
+          .withContext(`breakRules row field "${inner.key}"`)
+          .toBe(false);
+      });
+    });
+  });
+
+  // Regression: switching break mode hides the rule/percentage section. Without
+  // `resetOnHide: false` on every level of the `repeat` (field, fieldArray and
+  // each inner input), Formly strips the hidden rule rows' values, wiping the
+  // user's break rules on a Rule -> Ratio -> Rule round-trip (issue #7581).
+  // These drive the real `breakMode` control rather than calling internal model
+  // setters, so they fail the way the bug actually reproduces in the dialog.
+  describe('break-mode switch preserves hidden values', () => {
+    const switchMode = (mode: 'ratio' | 'rule'): void => {
+      (component.form.get('breakMode') as any).setValue(mode);
+      fixture.detectChanges();
+    };
+    const rulesCtrl = (): any => component.form.get('breakRules');
+
+    it('preserves a single rule across Rule -> Ratio -> Rule', () => {
+      const expected = JSON.stringify(component.model().breakRules);
+      switchMode('ratio');
+      switchMode('rule');
+      expect(JSON.stringify(component.model().breakRules))
+        .withContext('model')
+        .toEqual(expected);
+      expect(JSON.stringify(rulesCtrl().value)).withContext('form').toEqual(expected);
+    });
+
+    it('preserves two rules across the round-trip', () => {
+      component.model.set({
+        ...component.model(),
+        breakRules: [
+          { minDuration: 0, maxDuration: 25, breakDuration: 5 },
+          { minDuration: 25, maxDuration: 60, breakDuration: 10 },
+        ],
+      });
+      fixture.detectChanges();
+      const expected = JSON.stringify(component.model().breakRules);
+      switchMode('ratio');
+      switchMode('rule');
+      expect(JSON.stringify(component.model().breakRules))
+        .withContext('model with two rules')
+        .toEqual(expected);
+    });
+
+    it('preserves an edited rule value across the round-trip', () => {
+      rulesCtrl().at(0).get('maxDuration').setValue(40);
+      rulesCtrl().at(0).get('breakDuration').setValue(12);
+      fixture.detectChanges();
+      switchMode('ratio');
+      switchMode('rule');
+      expect(rulesCtrl().at(0).value)
+        .withContext('edited values survive')
+        .toEqual({ minDuration: 0, maxDuration: 40, breakDuration: 12 });
+    });
+
+    it('lets the user clear a field right after the switch (no snap-back)', () => {
+      switchMode('ratio');
+      switchMode('rule');
+      rulesCtrl().at(0).get('minDuration').setValue(null);
+      fixture.detectChanges();
+      expect(rulesCtrl().at(0).get('minDuration').value)
+        .withContext('cleared field stays cleared')
+        .toBe(null);
+    });
+
+    it('save() after the round-trip persists the original rule in ms', () => {
+      switchMode('ratio');
+      switchMode('rule');
+      component.save();
+      const saved = globalConfigServiceMock.updateSection.calls.mostRecent().args[1];
+      expect(saved.breakRules).toEqual([
+        { minDuration: 0, maxDuration: 1500000, breakDuration: 300000 },
+      ]);
+    });
+
+    it('keeps the form valid in rule mode (hidden required percentage does not block)', () => {
+      switchMode('ratio');
+      switchMode('rule');
+      expect(component.form.valid).withContext('form.valid in rule mode').toBe(true);
+    });
+  });
+
   describe('validator', () => {
     it('should mark rule row invalid if maxDuration < minDuration', () => {
       const breakRules = component.form.get('breakRules') as any;

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.ts
@@ -123,9 +123,16 @@ export class DialogFlowtimeSettingsComponent {
         ],
       },
     },
+    // `breakPercentage` (ratio mode) and `breakRules` (rule mode) hide each
+    // other when the mode switches. `resetOnHide: false` keeps Formly from
+    // wiping the hidden side's values, preserving them across mode switches.
+    // For the `repeat` it must be set at every level — field, fieldArray and
+    // each inner input — otherwise Formly keeps the rows but strips their
+    // values. See issue #7581.
     {
       key: 'breakPercentage',
       type: 'input',
+      resetOnHide: false,
       expressions: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'props.disabled': this._disabledWhenBreaksOff,
@@ -145,6 +152,7 @@ export class DialogFlowtimeSettingsComponent {
       className: 'flowtime-break-rules',
       description: T.F.FOCUS_MODE.FLOWTIME_BREAK_RULES_DESC,
       type: 'repeat',
+      resetOnHide: false,
       expressions: {
         hide: (field: FormlyFieldConfig) => field.parent?.model?.breakMode !== 'rule',
       },
@@ -158,6 +166,7 @@ export class DialogFlowtimeSettingsComponent {
       },
       fieldArray: {
         fieldGroupClassName: 'formly-row',
+        resetOnHide: false,
         validators: {
           minMaxDuration: {
             expression: (control: AbstractControl) => {
@@ -176,6 +185,7 @@ export class DialogFlowtimeSettingsComponent {
           {
             key: 'minDuration',
             type: 'input',
+            resetOnHide: false,
             expressions: {
               // eslint-disable-next-line @typescript-eslint/naming-convention
               'props.disabled': this._disabledWhenBreaksOff,
@@ -191,6 +201,7 @@ export class DialogFlowtimeSettingsComponent {
           {
             key: 'maxDuration',
             type: 'input',
+            resetOnHide: false,
             expressions: {
               // eslint-disable-next-line @typescript-eslint/naming-convention
               'props.disabled': this._disabledWhenBreaksOff,
@@ -205,6 +216,7 @@ export class DialogFlowtimeSettingsComponent {
           {
             key: 'breakDuration',
             type: 'input',
+            resetOnHide: false,
             expressions: {
               // eslint-disable-next-line @typescript-eslint/naming-convention
               'props.disabled': this._disabledWhenBreaksOff,


### PR DESCRIPTION
Part of #7581. Supersedes #8172.

## Problem

Switching the Flowtime break mode (Ratio-based ⇄ Rule-based) hides the inactive section. ngx-formly resets hidden fields by default, so a **Rule → Ratio → Rule** round-trip wipes the user's break rules (and percentage). Proven against `master` with a test driving the real `breakMode` control: after the round-trip, `model.breakRules` → `undefined` and the form control → `[]`.

(The separate "settings wiped when breaks are *disabled*" trigger is already handled on master by the #7586 overhaul, which *disables* rather than hides those fields. This PR targets only the remaining mode-switch path.)

## Fix

Set `resetOnHide: false` at **every level** of the `breakRules` repeat — the field, its `fieldArray`, and each inner input — plus on `breakPercentage`. Setting it only on the top-level field preserves the rows but strips their *values* (`[{}]`/`[null]`); that partial behaviour is what made a heavier cache/restore approach look necessary. This is 6 declarative lines and removes the need for any stateful restore layer.

## Why this over #8172

#8172 fought the same bug with a ~230-line stateful cache-and-restore interceptor that couldn't distinguish "Formly transiently blanked a hidden field" from "user cleared a visible field", which introduced new bugs (couldn't clear a field after a switch; typing glitches). `resetOnHide: false` stops the reset at the source, so none of that machinery is needed and the can't-clear regression can't occur.

## Verification

Proven in **both directions** — the tests fail without the fix and pass with it:

- **Unit** (`dialog-flowtime-settings.component.spec.ts`): 7 regression specs — 6 drive the real `breakMode` control (single/two/edited rules survive a round-trip; a field can be cleared afterward; save persists the right ms; form stays valid), plus 1 deterministic config-guard asserting `resetOnHide: false` at every level (guards the "future field forgets the flag → silent data loss" footgun). Deterministic across repeated runs.
- **E2E** (`e2e/tests/focus-mode/flowtime-settings-preserve.spec.ts`): real-DOM `mat-select` Rule → Ratio → Rule with edited values, and a real `Ctrl+A`/`Backspace` clear. Verified to **fail without the fix** (rule inputs are stripped after the round-trip) — guarding the bug at the layer where it actually reproduced for testers.
