### PR TITLE
fix(tasks): preserve manual order within a tag when sorting by tag (#8486)

### DIFF
--- a/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
@@ -357,7 +357,7 @@ describe('TaskViewCustomizerService', () => {
     ]);
   });
 
-  it('should sort by tag using the primary tag (sidebar order), with untagged last', () => {
+  it('should sort by primary-tag sidebar order, keeping manual order within a tag', () => {
     (service as unknown as { _allTags: Tag[] })._allTags = [
       { id: 'Tag B', title: 'Tag B' } as Tag,
       { id: 'Tag A', title: 'Tag A' } as Tag,
@@ -385,14 +385,23 @@ describe('TaskViewCustomizerService', () => {
       desc: service['applySort'](arr, SORT_OPTION_TYPE.tag, SORT_ORDER.DESC),
     };
 
+    // Tag groups follow sidebar order ([Tag B, Tag A]) and flip with the
+    // direction, but within a group the input (manual) order is preserved -
+    // it does NOT re-sort by task title, so DESC is not a plain reverse.
     const resultAsc = [
       'Beta(Tag B)',
       'Third Task(Tag A, Tag B)',
       'Alpha(Tag A)',
-      'Aardvark(-)',
       'Zebra(-)',
+      'Aardvark(-)',
     ];
-    const resultDesc = [...resultAsc].reverse();
+    const resultDesc = [
+      'Zebra(-)',
+      'Aardvark(-)',
+      'Alpha(Tag A)',
+      'Beta(Tag B)',
+      'Third Task(Tag A, Tag B)',
+    ];
 
     expect(sorted.asc.map((t) => t.id)).toEqual(resultAsc);
     expect(sorted.desc.map((t) => t.id)).toEqual(resultDesc);
@@ -472,7 +481,7 @@ describe('TaskViewCustomizerService', () => {
     ]);
   });
 
-  it('should sort by title for tasks with the same primary tag', () => {
+  it('should keep manual order for tasks with the same primary tag', () => {
     const samePrimary: TaskWithSubTasks[] = [
       {
         id: 'tA',
@@ -505,7 +514,8 @@ describe('TaskViewCustomizerService', () => {
     ];
     const sorted = service['applySort'](samePrimary, SORT_OPTION_TYPE.tag);
 
-    expect(sorted.map((t) => t.id)).toEqual(['tB', 'tA']);
+    // Input order is preserved (tA before tB) rather than re-sorted by title.
+    expect(sorted.map((t) => t.id)).toEqual(['tA', 'tB']);
   });
 
   it('should group by tag', () => {

--- a/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
@@ -378,7 +378,16 @@ describe('TaskViewCustomizerService', () => {
         attachments: [],
       },
     ];
-    const arr: TaskWithSubTasks[] = [...mockTasks, ...extra];
+    // Input order is deliberately anti-alphabetical within each tag group
+    // (Third Task before Beta in Tag B; Zebra before Aardvark when untagged) so
+    // the assertions fail under the old by-title tie-break, not just by luck.
+    const arr: TaskWithSubTasks[] = [
+      mockTasks[0], // Alpha (Tag A)
+      mockTasks[2], // Third Task (Tag A, Tag B) -> primary Tag B
+      mockTasks[1], // Beta (Tag B)
+      mockTasks[3], // Zebra (untagged)
+      ...extra, // Aardvark (untagged)
+    ];
 
     const sorted = {
       asc: service['applySort'](arr, SORT_OPTION_TYPE.tag, SORT_ORDER.ASC),
@@ -389,8 +398,8 @@ describe('TaskViewCustomizerService', () => {
     // direction, but within a group the input (manual) order is preserved -
     // it does NOT re-sort by task title, so DESC is not a plain reverse.
     const resultAsc = [
-      'Beta(Tag B)',
       'Third Task(Tag A, Tag B)',
+      'Beta(Tag B)',
       'Alpha(Tag A)',
       'Zebra(-)',
       'Aardvark(-)',
@@ -399,8 +408,8 @@ describe('TaskViewCustomizerService', () => {
       'Zebra(-)',
       'Aardvark(-)',
       'Alpha(Tag A)',
-      'Beta(Tag B)',
       'Third Task(Tag A, Tag B)',
+      'Beta(Tag B)',
     ];
 
     expect(sorted.asc.map((t) => t.id)).toEqual(resultAsc);
@@ -512,10 +521,14 @@ describe('TaskViewCustomizerService', () => {
         attachments: [],
       },
     ];
-    const sorted = service['applySort'](samePrimary, SORT_OPTION_TYPE.tag);
+    const asc = service['applySort'](samePrimary, SORT_OPTION_TYPE.tag, SORT_ORDER.ASC);
+    const desc = service['applySort'](samePrimary, SORT_OPTION_TYPE.tag, SORT_ORDER.DESC);
 
-    // Input order is preserved (tA before tB) rather than re-sorted by title.
-    expect(sorted.map((t) => t.id)).toEqual(['tA', 'tB']);
+    // Input order is preserved (tA="Zed" before tB="Alpha2") rather than re-sorted
+    // by title, and the direction does not re-order within a tag: ASC === DESC.
+    // (Under the old by-title tie-break these would differ: ASC=[tB,tA], DESC=[tA,tB].)
+    expect(asc.map((t) => t.id)).toEqual(['tA', 'tB']);
+    expect(desc.map((t) => t.id)).toEqual(['tA', 'tB']);
   });
 
   it('should group by tag', () => {

--- a/src/app/features/task-view-customizer/task-view-customizer.service.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.ts
@@ -311,59 +311,37 @@ export class TaskViewCustomizerService {
 
     const tagsInSidebarOrder = this._tagsInSidebarOrder();
     const tagOrderById = new Map(tagsInSidebarOrder.map((tag, index) => [tag.id, index]));
-    const tagById = new Map(this._allTags.map((tag) => [tag.id, tag]));
     const unknownTagRank = tagsInSidebarOrder.length;
     const noTagRank = unknownTagRank + 1;
-    const getPrimaryTagSortInfo = (
-      task: TaskWithSubTasks,
-    ): { rank: number; title: string | null } => {
+
+    // A task is placed by its highest-priority tag = the one with the lowest
+    // sidebar (menu-tree) index. Unknown tag ids rank after all known tags,
+    // untagged tasks last. (#8400)
+    const getPrimaryTagRank = (task: TaskWithSubTasks): number => {
       if (!task.tagIds?.length) {
-        return { rank: noTagRank, title: null };
+        return noTagRank;
       }
 
-      let best: { rank: number; title: string | null } | null = null;
-
-      task.tagIds.forEach((tagId) => {
-        const tag = tagById.get(tagId);
+      let min = unknownTagRank;
+      for (const tagId of task.tagIds) {
         const rank = tagOrderById.get(tagId) ?? unknownTagRank;
-        const candidate = { rank, title: tag?.title ?? null };
-
-        if (
-          !best ||
-          candidate.rank < best.rank ||
-          (candidate.rank === best.rank &&
-            candidate.title !== null &&
-            best.title !== null &&
-            sortByTitle(candidate.title, best.title) < 0)
-        ) {
-          best = candidate;
-        }
-      });
-
-      return best ?? { rank: unknownTagRank, title: null };
+        if (rank < min) min = rank;
+      }
+      return min;
     };
 
-    const sortByTagTitle = (a: TaskWithSubTasks, b: TaskWithSubTasks): number => {
-      const aTag = getPrimaryTagSortInfo(a);
-      const bTag = getPrimaryTagSortInfo(b);
-
-      if (aTag.rank !== bTag.rank) {
-        return (aTag.rank - bTag.rank) * factor;
-      }
-
-      if (aTag.title && bTag.title && aTag.title !== bTag.title) {
-        return sortByTitle(aTag.title, bTag.title, factor);
-      }
-
-      return sortByTitle(a.title, b.title, factor);
-    };
+    // Order by the primary tag's sidebar position. Equal ranks (same tag group)
+    // return 0 so the stable sort keeps the user's manual ordering within a tag
+    // instead of re-sorting it by task title. (#8486)
+    const sortByTagRank = (a: TaskWithSubTasks, b: TaskWithSubTasks): number =>
+      (getPrimaryTagRank(a) - getPrimaryTagRank(b)) * factor;
 
     switch (sortType) {
       case SORT_OPTION_TYPE.name:
         return tasksCopy.sort((a, b) => sortByTitle(a.title, b.title, factor));
 
       case SORT_OPTION_TYPE.tag: {
-        return tasksCopy.sort(sortByTagTitle);
+        return tasksCopy.sort(sortByTagRank);
       }
 
       case SORT_OPTION_TYPE.creationDate:

--- a/src/app/features/task-view-customizer/task-view-customizer.service.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.ts
@@ -331,8 +331,10 @@ export class TaskViewCustomizerService {
     };
 
     // Order by the primary tag's sidebar position. Equal ranks (same tag group)
-    // return 0 so the stable sort keeps the user's manual ordering within a tag
-    // instead of re-sorting it by task title. (#8486)
+    // return 0, so the stable sort keeps the user's manual ordering within a tag
+    // instead of re-sorting it by task title (#8486). Note this makes DESC flip
+    // only the group order, not the order within a group - that asymmetry is
+    // intentional; re-sorting within a group would bring the bug back.
     const sortByTagRank = (a: TaskWithSubTasks, b: TaskWithSubTasks): number =>
       (getPrimaryTagRank(a) - getPrimaryTagRank(b)) * factor;
 


### PR DESCRIPTION
## What

Fixes #8486 — **Sort by Tag** was re-sorting tasks *inside* each tag group by task name, silently discarding the order the user had arranged by hand.

## Root cause

`df8928c911` (#8400, "use sidebar order for tag grouping/sorting/menus") switched tag ordering to sidebar order and kept an alphabetical within-tag tie-break (`sortByTitle(a.title, b.title)`). That tie-break overrode the user's manual ordering within a tag.

## Change

- Keep the sidebar-order grouping from #8400 (tag groups still ordered by sidebar position, still flippable with the ASC/DESC arrow).
- Make the within-tag tie-break **stable**: equal ranks return `0`, so `Array.prototype.sort` preserves the user's manual order (`undoneTasks$` already arrives in `taskIds` order).
- Simplify the comparator to rank-only and drop the now-dead title machinery (`getPrimaryTagSortInfo` → `getPrimaryTagRank`, removed the unused `tagById` map and title tie-break tiers). Net −12 LOC in the service.

### Behavior

| | Tag-group order | Order inside a tag | DESC |
|---|---|---|---|
| Before | sidebar order | **alphabetical by name** (overrode manual order) | reverses groups **and** within-tag names |
| After | sidebar order *(unchanged)* | **manual order preserved** | reverses groups only; within-tag stays put |

Note: because within-tag order no longer reverses, **DESC is intentionally not a perfect mirror of ASC** — only the tag blocks swap ends. This is documented inline so it isn't "fixed" later (which would reintroduce the bug).

## Scope decision

The reporter also wanted the up/down arrows to order tag groups *alphabetically*. That was intentionally **not** changed — sidebar order from #8400 is kept. Only the within-tag manual-order regression is fixed here.

## Tests

- Updated the tag-sort specs: within-group input is deliberately anti-alphabetical so the assertions fail under the old by-title behavior (not by luck), plus an `ASC === DESC` assertion proving direction never re-orders inside a tag.
- `npm run test:file ...task-view-customizer.service.spec.ts` → 48/48 green. `checkFile` clean.

🤖 Reviewed via multi-agent pass (correctness/architecture/simplicity/performance/tests) before merge.
