### PR TITLE
refactor: retire GET /api/sync/snapshot, re-scope GET /api/sync/status as diagnostic

### DIFF
--- a/docs/long-term-plans/supersync-encryption-at-rest.md
+++ b/docs/long-term-plans/supersync-encryption-at-rest.md
@@ -2247,10 +2247,6 @@ curl -X POST http://localhost:1900/api/sync/ops \
 curl -X GET "http://localhost:1900/api/sync/ops?sinceSeq=0&limit=10" \
   -H "Authorization: Bearer $TOKEN"
 
-# Test snapshot generation
-curl -X GET http://localhost:1900/api/sync/snapshot \
-  -H "Authorization: Bearer $TOKEN"
-
 # Test restore point creation
 curl -X POST http://localhost:1900/api/sync/restore \
   -H "Authorization: Bearer $TOKEN"

--- a/docs/sync-and-op-log/diagrams/02-server-sync.md
+++ b/docs/sync-and-op-log/diagrams/02-server-sync.md
@@ -88,8 +88,7 @@ graph TB
             DownAPI["GET /api/sync/ops<br/>━━━━━━━━━━━━━━━<br/>Download operations<br/>Query: sinceSeq, limit"]:::api
             OpsAPI["POST /api/sync/ops<br/>━━━━━━━━━━━━━━━<br/>Upload operations<br/>Body: ops[], clientId"]:::api
             SnapshotAPI["POST /api/sync/snapshot<br/>━━━━━━━━━━━━━━━<br/>Upload full state<br/>Body: state, reason"]:::api
-            GetSnapshotAPI["GET /api/sync/snapshot<br/>━━━━━━━━━━━━━━━<br/>Get full state"]:::api
-            StatusAPI["GET /api/sync/status<br/>━━━━━━━━━━━━━━━<br/>Check sync status"]:::api
+            StatusAPI["GET /api/sync/status<br/>━━━━━━━━━━━━━━━<br/>Check sync status (diagnostic)"]:::api
             RestoreAPI["GET /api/sync/restore/:seq<br/>━━━━━━━━━━━━━━━<br/>Restore to point"]:::api
         end
 
@@ -156,8 +155,6 @@ graph TB
     %% CONNECTIONS: Read endpoints -> Database
     DownAPI -.->|"SELECT ops > sinceSeq"| OpsTable
     DownAPI -.->|"SELECT lastSeq"| SyncState
-    GetSnapshotAPI -.->|"SELECT snapshot"| SyncState
-    GetSnapshotAPI -.->|"SELECT (replay)"| OpsTable
     StatusAPI -.->|"SELECT"| SyncState
     StatusAPI -.->|"COUNT"| Devices
     RestoreAPI -.->|"SELECT (replay)"| OpsTable
@@ -179,8 +176,7 @@ graph TB
 | `/api/sync/ops`            | POST   | Upload operations               | INSERT ops, UPDATE lastSeq, UPSERT device, UPSERT tombstone (if DEL) |
 | `/api/sync/ops?sinceSeq=N` | GET    | Download operations             | SELECT ops, SELECT lastSeq, find latest snapshot (skip optimization) |
 | `/api/sync/snapshot`       | POST   | Upload full state (SYNC_IMPORT) | Same as POST /ops + UPDATE snapshot cache                            |
-| `/api/sync/snapshot`       | GET    | Get full state                  | SELECT snapshot (or replay ops if stale)                             |
-| `/api/sync/status`         | GET    | Check sync status               | SELECT lastSeq, COUNT devices                                        |
+| `/api/sync/status`         | GET    | Check sync status (diagnostic)  | SELECT lastSeq, COUNT devices                                        |
 | `/api/sync/restore-points` | GET    | List restore points             | SELECT ops (filter SYNC_IMPORT, BACKUP_IMPORT, REPAIR)               |
 | `/api/sync/restore/:seq`   | GET    | Restore to specific point       | SELECT ops, replay to targetSeq                                      |
 

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -54,12 +54,11 @@ All require authentication.
 
 **Snapshots:**
 
-- `GET /api/sync/snapshot` — Get full state snapshot.
 - `POST /api/sync/snapshot` — Upload full state (backup/repair/migration). Body limit 30 MB (compressed).
 
 **Status and maintenance:**
 
-- `GET /api/sync/status` — Sync status and storage info.
+- `GET /api/sync/status` — Sync status and storage info (diagnostic — not used by the production client).
 - `DELETE /api/sync/data` — Delete all sync data for the user (e.g. encryption password change).
 - `GET /api/sync/restore-points?limit={limit}` — List restore points (limit 1–100).
 - `GET /api/sync/restore/{serverSeq}` — Get state snapshot at a specific sequence.

--- a/packages/super-sync-server/README.md
+++ b/packages/super-sync-server/README.md
@@ -261,17 +261,9 @@ Get changes from other devices.
 GET /api/sync/ops?sinceSeq=123
 ```
 
-#### 3. Get Snapshot
+#### 3. Sync Status (diagnostic)
 
-Get the full current state (optimized).
-
-```http
-GET /api/sync/snapshot
-```
-
-#### 4. Sync Status
-
-Check pending operations and device status.
+Check sync status and storage info. Not used by the production client — intended for operator/debugging use.
 
 ```http
 GET /api/sync/status

--- a/packages/super-sync-server/src/sync/services/snapshot.service.ts
+++ b/packages/super-sync-server/src/sync/services/snapshot.service.ts
@@ -278,8 +278,8 @@ export class SnapshotService {
    * `onCacheDelta` is invoked after the transaction commits with the byte
    * change applied to the `snapshotData` column when the cache was rewritten.
    * Callers should use it to keep the storage usage counter in sync with
-   * on-disk reality — otherwise `GET /snapshot` can grow `snapshotData` by up
-   * to ~MAX_SNAPSHOT_SIZE_BYTES without the counter noticing.
+   * on-disk reality — otherwise the cache can grow `snapshotData` by up to
+   * ~MAX_SNAPSHOT_SIZE_BYTES without the counter noticing.
    *
    * `maxCacheBytes` (B5) caps how large the persisted cache blob may be.
    * When the freshly compressed snapshot would exceed this cap (typically set

--- a/packages/super-sync-server/src/sync/sync.routes.ts
+++ b/packages/super-sync-server/src/sync/sync.routes.ts
@@ -6,7 +6,6 @@ import { Logger } from '../logger';
 import {
   UploadOpsRequest,
   DownloadOpsResponse,
-  SnapshotResponse,
   SyncStatusResponse,
   SYNC_ERROR_CODES,
 } from './sync.types';
@@ -22,7 +21,6 @@ import {
   MAX_RAW_BODY_SIZE_OPS,
   MAX_RAW_BODY_SIZE_SNAPSHOT,
 } from './sync.routes.payload';
-import { applyStorageUsageDelta } from './sync.routes.quota';
 import { uploadOpsHandler } from './sync.routes.ops-handler';
 import { uploadSnapshotHandler } from './sync.routes.snapshot-handler';
 
@@ -179,65 +177,6 @@ export const syncRoutes = async (fastify: FastifyInstance): Promise<void> => {
     },
   );
 
-  // GET /api/sync/snapshot - Get full state snapshot
-  // generateSnapshot() handles caching internally via sequence-based freshness:
-  // returns cached snapshot if up-to-date, only replays ops when new ones exist.
-  // Rate limited: Snapshot generation is CPU-intensive (can replay up to 100k ops)
-  fastify.get(
-    '/snapshot',
-    {
-      config: {
-        rateLimit: {
-          max: 10,
-          timeWindow: '5 minutes',
-        },
-      },
-    },
-    async (req: FastifyRequest, reply: FastifyReply) => {
-      try {
-        const userId = getAuthUser(req).userId;
-        const syncService = getSyncService();
-
-        Logger.info(`[user:${userId}] Snapshot requested`);
-        // B5: Cap cache growth at the user's remaining quota so a client
-        // already at/near quota cannot use GET /snapshot to keep growing
-        // `snapshotData`. Uses the cheap cached counter — if it's stale-high
-        // we may skip a cache write that would have fit; the snapshot itself
-        // is still returned to the client either way. The post-write hook
-        // keeps the counter consistent with what actually landed on disk.
-        const storageInfo = await syncService.getStorageInfo(userId);
-        const remainingQuota = Math.max(
-          0,
-          storageInfo.storageQuotaBytes - storageInfo.storageUsedBytes,
-        );
-        // Keep the storage counter in sync with snapshotData rewrites; without
-        // this hook GET /snapshot can grow up to MAX_SNAPSHOT_SIZE_BYTES of
-        // cached data with no quota accounting.
-        const snapshot = await syncService.generateSnapshot(
-          userId,
-          (deltaBytes) =>
-            applyStorageUsageDelta(userId, deltaBytes, 'after generateSnapshot'),
-          remainingQuota,
-        );
-        Logger.info(`[user:${userId}] Snapshot ready (seq=${snapshot.serverSeq})`);
-        return reply.send(snapshot as SnapshotResponse);
-      } catch (err) {
-        if (err instanceof EncryptedOpsNotSupportedError) {
-          Logger.info(
-            `[user:${getAuthUser(req).userId}] Snapshot blocked due to encrypted ops (count=${err.encryptedOpCount})`,
-          );
-          return reply.status(400).send({
-            error: ENCRYPTED_OPS_CLIENT_MESSAGE,
-            errorCode: SYNC_ERROR_CODES.ENCRYPTED_OPS_NOT_SUPPORTED,
-          });
-        }
-
-        Logger.error(`Get snapshot error: ${errorMessage(err)}`);
-        return reply.status(500).send({ error: 'Internal server error' });
-      }
-    },
-  );
-
   // POST /api/sync/snapshot - Upload full state
   // Supports gzip-compressed request bodies via Content-Encoding: gzip header
   // B8: per-user rate limit — uploads are expensive (up to 30MB body,
@@ -264,7 +203,7 @@ export const syncRoutes = async (fastify: FastifyInstance): Promise<void> => {
     uploadSnapshotHandler,
   );
 
-  // GET /api/sync/status - Get sync status
+  // GET /api/sync/status - Get sync status (diagnostic — not used by the production client)
   fastify.get(
     '/status',
     {

--- a/packages/super-sync-server/sync-server-architecture-diagrams.md
+++ b/packages/super-sync-server/sync-server-architecture-diagrams.md
@@ -269,8 +269,8 @@ flowchart LR
 flowchart TB
     subgraph Endpoints["Sync API Endpoints"]
         OpsEndpoint["/api/sync/ops<br/>POST: Upload ops<br/>GET: Download ops"]
-        SnapshotEndpoint["/api/sync/snapshot<br/>POST: Upload full state<br/>GET: Download full state"]
-        StatusEndpoint["/api/sync/status<br/>GET: Sync status info"]
+        SnapshotEndpoint["/api/sync/snapshot<br/>POST: Upload full state"]
+        StatusEndpoint["/api/sync/status<br/>GET: Sync status info (diagnostic)"]
     end
 
     subgraph Tables["Database Tables"]
@@ -349,38 +349,11 @@ sequenceDiagram
     Note over Client,Server: Client pages through with<br/>sinceSeq = last received server_seq<br/>until hasMore = false
 ```
 
-## 1.11 Get Snapshot - GET /api/sync/snapshot
+## 1.11 Get Snapshot (removed)
 
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Server
-    participant DB as PostgreSQL
+`GET /api/sync/snapshot` has been retired. No production client ever called this endpoint — snapshot data is delivered through `POST /api/sync/snapshot` (upload) and `GET /api/sync/ops` (download with piggyback).
 
-    Client->>Server: GET /api/sync/snapshot
-
-    Server->>DB: Get user_sync_state
-    DB-->>Server: {snapshot_data, last_snapshot_seq}
-
-    alt Snapshot exists and fresh
-        Server->>Server: Decompress snapshot_data
-        Server-->>Client: {state, serverSeq, fromCache: true}
-    else No snapshot or stale
-        Server->>DB: BEGIN TRANSACTION
-        Server->>DB: SELECT all ops for user<br/>ORDER BY server_seq
-        alt Too many ops > 100k
-            Server-->>Client: 500 Too many operations
-        else
-            Server->>Server: Replay ops to build state
-            Server->>Server: Compress state with gzip
-            Server->>DB: UPDATE user_sync_state<br/>SET snapshot_data, last_snapshot_seq
-            Server->>DB: COMMIT
-            Server-->>Client: {state, serverSeq, fromCache: false}
-        end
-    end
-
-    Note over Client,Server: Client uses snapshot when<br/>gapDetected=true from download<br/>or on first sync
-```
+The on-demand generation code (`generateSnapshot()`) is preserved internally for POST /snapshot cache management.
 
 ## 1.11b Upload Snapshot - POST /api/sync/snapshot
 
@@ -432,7 +405,7 @@ flowchart TB
     style Regular fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px
 ```
 
-## 1.12 Get Status - GET /api/sync/status
+## 1.12 Get Status - GET /api/sync/status (diagnostic)
 
 ```mermaid
 sequenceDiagram
@@ -904,9 +877,9 @@ sequenceDiagram
     Server-->>OpLog: {ops, hasMore, latestSeq, gapDetected}
 
     alt Gap Detected
-        OpLog->>Server: GET /api/sync/snapshot
-        Server-->>OpLog: {state, serverSeq}
-        OpLog->>IDB: Save snapshot to state_cache
+        OpLog->>Server: Download all ops sinceSeq=0
+        Server-->>OpLog: {ops, latestSeq}
+        OpLog->>IDB: Store all ops
         OpLog->>NgRx: Dispatch loadAllData state
     else Normal Download
         loop For each remote op
@@ -947,7 +920,7 @@ flowchart TB
         Poll[Poll for new ops]
         SendDownload[GET /api/sync/ops]
         CheckGap{Gap?}
-        GetSnapshot[GET /api/sync/snapshot]
+        DownloadAll[Download all ops]
         ApplyRemote[Apply remote ops]
         UpdateSeq[Update lastServerSeq]
     end

--- a/packages/super-sync-server/tests/integration/multi-client-sync.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/multi-client-sync.integration.spec.ts
@@ -18,7 +18,6 @@ import {
   ServerOperation,
   UploadOpsResponse,
   DownloadOpsResponse,
-  SnapshotResponse,
 } from '../../src/sync/sync.types';
 
 const JWT_SECRET = 'super-sync-dev-secret-do-not-use-in-production';
@@ -158,23 +157,6 @@ class SimulatedClient {
     }
 
     return allOps;
-  }
-
-  /** Gets snapshot from server */
-  async getSnapshot(): Promise<SnapshotResponse> {
-    const response = await this.app.inject({
-      method: 'GET',
-      url: '/api/sync/snapshot',
-      headers: { authorization: `Bearer ${this.authToken}` },
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json() as SnapshotResponse;
-
-    // Update our sequence to snapshot's seq
-    this.lastKnownSeq = body.serverSeq;
-
-    return body;
   }
 
   /** Applies remote operations to local state */
@@ -420,27 +402,6 @@ describe('Multi-Client Sync Integration', () => {
   });
 
   describe('Fresh Client Bootstrap', () => {
-    it('should allow fresh client to get snapshot after other clients uploaded', async () => {
-      const clientA = new SimulatedClient(app, userId);
-
-      // Client A uploads several operations
-      clientA.createOp('CRT', 'TASK', 'task-1', { title: 'Task 1' });
-      clientA.createOp('CRT', 'TASK', 'task-2', { title: 'Task 2' });
-      clientA.createOp('UPD', 'TASK', 'task-1', { title: 'Task 1 Updated' });
-      clientA.createOp('DEL', 'TASK', 'task-2', null);
-      await clientA.upload();
-
-      // Fresh client requests snapshot
-      const freshClient = new SimulatedClient(app, userId);
-      const snapshot = await freshClient.getSnapshot();
-
-      expect(snapshot.serverSeq).toBe(4);
-      expect(snapshot.state).toBeDefined();
-      // State should have task-1 (updated) but NOT task-2 (deleted)
-      const state = snapshot.state as Record<string, unknown>;
-      // Note: actual state structure depends on snapshot reconstruction logic
-    });
-
     it('should allow fresh client to continue with ops after snapshot', async () => {
       const clientA = new SimulatedClient(app, userId);
 
@@ -448,15 +409,15 @@ describe('Multi-Client Sync Integration', () => {
       clientA.createOp('CRT', 'TASK', 'task-1', { title: 'Task 1' });
       await clientA.upload();
 
-      // Fresh client gets snapshot
+      // Fresh client bootstraps by downloading all existing ops
       const freshClient = new SimulatedClient(app, userId);
-      await freshClient.getSnapshot();
+      await freshClient.downloadAll(false);
 
       // Client A adds more ops
       clientA.createOp('CRT', 'TASK', 'task-2', { title: 'Task 2' });
       await clientA.upload();
 
-      // Fresh client downloads ops since snapshot (don't exclude any client)
+      // Fresh client downloads ops since bootstrap (don't exclude any client)
       const downloaded = await freshClient.download(false);
 
       expect(downloaded.ops).toHaveLength(1);
@@ -1194,21 +1155,23 @@ describe('Gzip Compressed Snapshot Integration', () => {
 
     console.log(`Snapshot accepted at serverSeq: ${result.serverSeq}`);
 
-    // Client B should be able to download the snapshot
-    const snapshotResponse = await app.inject({
+    // Client B should be able to download the snapshot's SYNC_IMPORT op
+    const downloadResponse = await app.inject({
       method: 'GET',
-      url: '/api/sync/snapshot',
+      url: '/api/sync/ops?sinceSeq=0',
       headers: { authorization: `Bearer ${clientB.authToken}` },
     });
 
-    expect(snapshotResponse.statusCode).toBe(200);
-    const snapshot = snapshotResponse.json();
+    expect(downloadResponse.statusCode).toBe(200);
+    const downloadBody = downloadResponse.json();
+    const syncImportOp = downloadBody.ops.find(
+      (op: { op: { opType: string }; serverSeq: number }) =>
+        op.op.opType === 'SYNC_IMPORT',
+    );
+    expect(syncImportOp).toBeDefined();
+    expect(syncImportOp.serverSeq).toBe(result.serverSeq);
 
-    // Verify the state was correctly stored and retrieved
-    expect(snapshot.state).toBeDefined();
-    expect(snapshot.serverSeq).toBe(result.serverSeq);
-
-    console.log('Client B successfully retrieved snapshot from server');
+    console.log('Client B successfully retrieved snapshot SYNC_IMPORT op from server');
   });
 
   /**

--- a/packages/super-sync-server/tests/snapshot.service.spec.ts
+++ b/packages/super-sync-server/tests/snapshot.service.spec.ts
@@ -469,7 +469,7 @@ describe('SnapshotService', () => {
     });
 
     it('should invoke onCacheDelta with the bytes-written delta after a snapshot rewrite', async () => {
-      // Regression for C3: GET /snapshot rewrites snapshotData inside its
+      // Regression for C3: generateSnapshot rewrites snapshotData inside its
       // transaction, but the storage counter is updated incrementally based
       // on op deltas only. Without this hook the cache can grow up to
       // MAX_SNAPSHOT_SIZE_BYTES with no quota accounting.
@@ -526,7 +526,7 @@ describe('SnapshotService', () => {
     });
 
     it('should skip the cache write when the new blob exceeds maxCacheBytes (B5)', async () => {
-      // Regression for B5: GET /snapshot must not grow `snapshotData` beyond
+      // Regression for B5: generateSnapshot must not grow `snapshotData` beyond
       // the user's remaining quota. When `maxCacheBytes` is set and the new
       // compressed blob would exceed it (accounting for the bytes the
       // previously-cached snapshot will free), skip the cache write — the

--- a/packages/super-sync-server/tests/sync-fixes.spec.ts
+++ b/packages/super-sync-server/tests/sync-fixes.spec.ts
@@ -437,15 +437,6 @@ describe('Sync System Fixes', () => {
       expect(snapshotBody.accepted).toBe(true);
       expect(cacheSnapshotSpy).not.toHaveBeenCalled();
 
-      const serverSnapshotResponse = await app.inject({
-        method: 'GET',
-        url: '/api/sync/snapshot',
-        headers: { authorization: `Bearer ${authToken}` },
-      });
-
-      expect(serverSnapshotResponse.statusCode).toBe(400);
-      expect(serverSnapshotResponse.json().errorCode).toBe('ENCRYPTED_OPS_NOT_SUPPORTED');
-
       // Download ops and verify the SYNC_IMPORT has isPayloadEncrypted
       const downloadResponse = await app.inject({
         method: 'GET',

--- a/packages/super-sync-server/tests/sync.routes.spec.ts
+++ b/packages/super-sync-server/tests/sync.routes.spec.ts
@@ -333,49 +333,6 @@ describe('Sync Routes', () => {
     });
   });
 
-  describe('GET /api/sync/snapshot - Get Snapshot', () => {
-    beforeEach(async () => {
-      // Upload some operations
-      await app.inject({
-        method: 'POST',
-        url: '/api/sync/ops',
-        headers: { authorization: `Bearer ${authToken}` },
-        payload: {
-          ops: [
-            createOp(clientId, {
-              entityId: 't1',
-              payload: { title: 'Task 1', done: false },
-            }),
-          ],
-          clientId,
-        },
-      });
-    });
-
-    it('should return current state snapshot', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: '/api/sync/snapshot',
-        headers: { authorization: `Bearer ${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.serverSeq).toBe(1);
-      expect(body.state).toBeDefined();
-      expect(body.generatedAt).toBeDefined();
-    });
-
-    it('should return 401 without authorization', async () => {
-      const response = await app.inject({
-        method: 'GET',
-        url: '/api/sync/snapshot',
-      });
-
-      expect(response.statusCode).toBe(401);
-    });
-  });
-
   describe('POST /api/sync/snapshot - Upload Snapshot', () => {
     it('should upload snapshot successfully', async () => {
       const response = await app.inject({
@@ -595,33 +552,31 @@ describe('Multi-User Isolation', () => {
       },
     });
 
-    // Get user 1's snapshot
-    const user1Snapshot = await app.inject({
+    // User 1 should only see their operation
+    const user1Response = await app.inject({
       method: 'GET',
-      url: '/api/sync/snapshot',
+      url: '/api/sync/ops?sinceSeq=0',
       headers: { authorization: `Bearer ${user1Token}` },
     });
 
-    const user1State = user1Snapshot.json().state as Record<
-      string,
-      Record<string, { title: string }>
-    >;
-    expect(user1State.TASK['user1-task']).toBeDefined();
-    expect(user1State.TASK['user2-task']).toBeUndefined();
+    expect(user1Response.statusCode).toBe(200);
+    const user1Body = user1Response.json();
+    expect(user1Body.ops).toHaveLength(1);
+    expect(user1Body.ops[0].op.entityId).toBe('user1-task');
+    expect(user1Body.ops[0].op.payload.title).toBe('User 1 Task');
 
-    // Get user 2's snapshot
-    const user2Snapshot = await app.inject({
+    // User 2 should only see their operation
+    const user2Response = await app.inject({
       method: 'GET',
-      url: '/api/sync/snapshot',
+      url: '/api/sync/ops?sinceSeq=0',
       headers: { authorization: `Bearer ${user2Token}` },
     });
 
-    const user2State = user2Snapshot.json().state as Record<
-      string,
-      Record<string, { title: string }>
-    >;
-    expect(user2State.TASK['user2-task']).toBeDefined();
-    expect(user2State.TASK['user1-task']).toBeUndefined();
+    expect(user2Response.statusCode).toBe(200);
+    const user2Body = user2Response.json();
+    expect(user2Body.ops).toHaveLength(1);
+    expect(user2Body.ops[0].op.entityId).toBe('user2-task');
+    expect(user2Body.ops[0].op.payload.title).toBe('User 2 Task');
   });
 
   it('should isolate sync status between users', async () => {


### PR DESCRIPTION
## Problem
Addresses #2 in #8348
<!-- Describe the problem that these changes solve (links to issues are welcome). -->

## Solution
Discussed in https://github.com/super-productivity/super-productivity/issues/8348#issuecomment-4751770026 and https://github.com/super-productivity/super-productivity/issues/8348#issuecomment-4752148476
<!-- Describe your changes in detail. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
