### PR TITLE
refactor(sync): remove dead SyncService facade methods

### DIFF
--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -343,20 +343,6 @@ export class SyncService {
   // === Download Operations ===
   // Delegated to OperationDownloadService
 
-  async getOpsSince(
-    userId: number,
-    sinceSeq: number,
-    excludeClient?: string,
-    limit: number = 500,
-  ): Promise<ServerOperation[]> {
-    return this.operationDownloadService.getOpsSince(
-      userId,
-      sinceSeq,
-      excludeClient,
-      limit,
-    );
-  }
-
   async getOpsSinceWithSeq(
     userId: number,
     sinceSeq: number,
@@ -386,15 +372,6 @@ export class SyncService {
   // === Snapshot Management ===
   // Delegated to SnapshotService
 
-  async getCachedSnapshot(userId: number): Promise<{
-    state: unknown;
-    serverSeq: number;
-    generatedAt: number;
-    schemaVersion: number;
-  } | null> {
-    return this.snapshotService.getCachedSnapshot(userId);
-  }
-
   async prepareSnapshotCache(state: unknown): Promise<PreparedSnapshotCache> {
     return this.snapshotService.prepareSnapshotCache(state);
   }
@@ -405,15 +382,6 @@ export class SyncService {
 
   async getCachedSnapshotGeneratedAt(userId: number): Promise<number | null> {
     return this.snapshotService.getCachedSnapshotGeneratedAt(userId);
-  }
-
-  async cacheSnapshot(
-    userId: number,
-    state: unknown,
-    serverSeq: number,
-    preparedSnapshot?: PreparedSnapshotCache,
-  ): Promise<CacheSnapshotResult> {
-    return this.snapshotService.cacheSnapshot(userId, state, serverSeq, preparedSnapshot);
   }
 
   async cacheSnapshotIfReplayable(
@@ -525,15 +493,6 @@ export class SyncService {
   // === Storage Quota ===
   // Delegated to StorageQuotaService
 
-  async calculateStorageUsage(userId: number): Promise<{
-    operationsBytes: number;
-    snapshotBytes: number;
-    totalBytes: number;
-    hasUnbackfilledRows: boolean;
-  }> {
-    return this.storageQuotaService.calculateStorageUsage(userId);
-  }
-
   async assertPayloadBytesBackfillComplete(): Promise<void> {
     return this.storageQuotaService.assertPayloadBytesBackfillComplete();
   }
@@ -636,14 +595,6 @@ export class SyncService {
     this.snapshotService.clearForUser(userId);
     this.storageQuotaService.clearForUser(userId);
     this.requestDeduplicationService.clearForUser(userId);
-  }
-
-  async isDeviceOwner(userId: number, clientId: string): Promise<boolean> {
-    return this.deviceService.isDeviceOwner(userId, clientId);
-  }
-
-  async getAllUserIds(): Promise<number[]> {
-    return this.deviceService.getAllUserIds();
   }
 
   async getOnlineDeviceCount(userId: number): Promise<number> {

--- a/packages/super-sync-server/tests/conflict-detection.spec.ts
+++ b/packages/super-sync-server/tests/conflict-detection.spec.ts
@@ -302,6 +302,7 @@ vi.mock('../src/db', async () => {
 });
 
 import { initSyncService, getSyncService } from '../src/sync/sync.service';
+import { OperationDownloadService } from '../src/sync/services/operation-download.service';
 import {
   Operation,
   SYNC_ERROR_CODES,
@@ -313,6 +314,7 @@ describe('Conflict Detection', () => {
   const userId = 1;
   const clientA = 'client-a';
   const clientB = 'client-b';
+  let operationDownloadService: OperationDownloadService;
 
   const createOp = (overrides: Partial<Operation> & { entityId: string }): Operation => ({
     id: uuidv7(),
@@ -340,6 +342,7 @@ describe('Conflict Detection', () => {
 
     vi.clearAllMocks();
     initSyncService();
+    operationDownloadService = new OperationDownloadService();
   });
 
   describe('Vector Clock Comparison', () => {
@@ -860,7 +863,7 @@ describe('Conflict Detection', () => {
       // Verify the clock was pruned to MAX_VECTOR_CLOCK_SIZE (20) before storage.
       // clientA ('client-a') is not in the clock, so only the MAX most active
       // clients are kept (the ones with highest counters).
-      const ops = await service.getOpsSince(userId, 0);
+      const ops = await operationDownloadService.getOpsSince(userId, 0);
       const storedClock = ops[0].op.vectorClock;
       expect(Object.keys(storedClock).length).toBe(MAX_VECTOR_CLOCK_SIZE);
       // The most active clients should be preserved (top MAX entries by counter)
@@ -890,7 +893,7 @@ describe('Conflict Detection', () => {
       expect(result[0].accepted).toBe(true);
 
       // Verify the clock was pruned to MAX_VECTOR_CLOCK_SIZE
-      const ops = await service.getOpsSince(userId, 0);
+      const ops = await operationDownloadService.getOpsSince(userId, 0);
       const storedClock = ops[0].op.vectorClock;
       expect(Object.keys(storedClock).length).toBe(MAX_VECTOR_CLOCK_SIZE);
       // clientA should be preserved despite having the lowest counter
@@ -944,7 +947,7 @@ describe('Conflict Detection', () => {
       expect(resolvedResult[0].accepted).toBe(true);
 
       // Verify the stored clock was pruned to MAX after acceptance
-      const ops = await service.getOpsSince(userId, 0);
+      const ops = await operationDownloadService.getOpsSince(userId, 0);
       const latestOp = ops.find((o: any) => o.op.id === resolvedOp.id);
       expect(latestOp).toBeDefined();
       const storedClock = latestOp!.op.vectorClock;

--- a/packages/super-sync-server/tests/sync-fixes.spec.ts
+++ b/packages/super-sync-server/tests/sync-fixes.spec.ts
@@ -416,8 +416,6 @@ describe('Sync System Fixes', () => {
   // =============================================================================
   describe('Issue 3: Encrypted snapshot uploads', () => {
     it('should store isPayloadEncrypted flag from snapshot upload', async () => {
-      const cacheSnapshotSpy = vi.spyOn(getSyncService(), 'cacheSnapshot');
-
       const snapshotResponse = await app.inject({
         method: 'POST',
         url: '/api/sync/snapshot',
@@ -435,7 +433,6 @@ describe('Sync System Fixes', () => {
       expect(snapshotResponse.statusCode).toBe(200);
       const snapshotBody = snapshotResponse.json();
       expect(snapshotBody.accepted).toBe(true);
-      expect(cacheSnapshotSpy).not.toHaveBeenCalled();
 
       const serverSnapshotResponse = await app.inject({
         method: 'GET',

--- a/packages/super-sync-server/tests/sync-operations.spec.ts
+++ b/packages/super-sync-server/tests/sync-operations.spec.ts
@@ -543,10 +543,14 @@ vi.mock('../src/db', async () => {
 });
 
 import { initSyncService, getSyncService } from '../src/sync/sync.service';
+import { DeviceService } from '../src/sync/services/device.service';
+import { OperationDownloadService } from '../src/sync/services/operation-download.service';
 
 describe('Sync Operations', () => {
   const userId = 1;
   const clientId = 'test-client';
+  let deviceService: DeviceService;
+  let operationDownloadService: OperationDownloadService;
 
   const createOp = (
     entityId: string,
@@ -576,6 +580,8 @@ describe('Sync Operations', () => {
       createdAt: new Date(),
     });
     initSyncService();
+    deviceService = new DeviceService();
+    operationDownloadService = new OperationDownloadService();
   });
 
   describe('Full-state op upload', () => {
@@ -963,7 +969,7 @@ describe('Sync Operations', () => {
       expect(result.affectedUserIds).toContain(userId);
 
       // Verify correct operation was deleted
-      const ops = await service.getOpsSince(userId, 0);
+      const ops = await operationDownloadService.getOpsSince(userId, 0);
       expect(ops.length).toBe(1);
       expect(ops[0].serverSeq).toBe(2);
     });
@@ -1097,24 +1103,24 @@ describe('Sync Operations', () => {
     });
   });
 
-  describe('Device Ownership', () => {
+  describe('DeviceService ownership after sync upload', () => {
     it('should track device ownership after upload', async () => {
       const service = getSyncService();
 
       // Before upload, device is not registered
-      expect(await service.isDeviceOwner(userId, clientId)).toBe(false);
+      expect(await deviceService.isDeviceOwner(userId, clientId)).toBe(false);
 
       // Upload creates device entry
       await service.uploadOps(userId, clientId, [createOp('task-1', 'CRT')]);
 
       // Now device should be owned by user
-      expect(await service.isDeviceOwner(userId, clientId)).toBe(true);
+      expect(await deviceService.isDeviceOwner(userId, clientId)).toBe(true);
     });
 
     it('should return false for non-existent device', async () => {
-      const service = getSyncService();
-
-      expect(await service.isDeviceOwner(userId, 'non-existent-device')).toBe(false);
+      expect(await deviceService.isDeviceOwner(userId, 'non-existent-device')).toBe(
+        false,
+      );
     });
 
     it('should track device ownership per user', async () => {
@@ -1124,11 +1130,11 @@ describe('Sync Operations', () => {
       await service.uploadOps(userId, clientId, [createOp('task-1', 'CRT')]);
 
       // Device should not be owned by user 2
-      expect(await service.isDeviceOwner(2, clientId)).toBe(false);
+      expect(await deviceService.isDeviceOwner(2, clientId)).toBe(false);
     });
   });
 
-  describe('User ID Retrieval', () => {
+  describe('DeviceService user ID retrieval after sync upload', () => {
     it('should return all user IDs with sync state', async () => {
       const service = getSyncService();
 
@@ -1153,7 +1159,7 @@ describe('Sync Operations', () => {
       await service.uploadOps(2, 'client-2', [createOp('task-1', 'CRT')]);
       // User 3 has no sync state
 
-      const userIds = await service.getAllUserIds();
+      const userIds = await deviceService.getAllUserIds();
 
       expect(userIds).toContain(1);
       expect(userIds).toContain(2);

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -601,12 +601,16 @@ vi.mock('../src/auth', () => ({
 
 // Import AFTER mocking
 import { initSyncService, getSyncService, SyncService } from '../src/sync/sync.service';
+import { DeviceService } from '../src/sync/services/device.service';
+import { OperationDownloadService } from '../src/sync/services/operation-download.service';
 import { Operation, DEFAULT_SYNC_CONFIG, SYNC_ERROR_CODES } from '../src/sync/sync.types';
 import { prisma } from '../src/db';
 
 describe('SyncService', () => {
   const userId = 1;
   const clientId = 'test-device-1';
+  let deviceService: DeviceService;
+  let operationDownloadService: OperationDownloadService;
 
   // Factory for the repeated Operation fixture (mirrors createOp in
   // sync-fixes.spec.ts). Override only the fields a test cares about.
@@ -640,6 +644,8 @@ describe('SyncService', () => {
 
     // Initialize service
     initSyncService();
+    deviceService = new DeviceService();
+    operationDownloadService = new OperationDownloadService();
   });
 
   afterEach(() => {
@@ -1611,7 +1617,7 @@ describe('SyncService', () => {
       expect(results[0].accepted).toBe(true);
 
       // Verify round-trip
-      const ops = await service.getOpsSince(userId, 0);
+      const ops = await operationDownloadService.getOpsSince(userId, 0);
       expect(ops[0].op.entityId).toBe('task-日本語-émoji-🎉');
     });
 
@@ -1636,7 +1642,7 @@ describe('SyncService', () => {
     });
   });
 
-  describe('getOpsSince', () => {
+  describe('uploadOps + OperationDownloadService', () => {
     it('should return operations after given sequence', async () => {
       const service = getSyncService();
 
@@ -1657,7 +1663,7 @@ describe('SyncService', () => {
         await service.uploadOps(userId, clientId, [op]);
       }
 
-      const ops = await service.getOpsSince(userId, 2);
+      const ops = await operationDownloadService.getOpsSince(userId, 2);
 
       expect(ops).toHaveLength(3);
       expect(ops[0].serverSeq).toBe(3);
@@ -1702,7 +1708,7 @@ describe('SyncService', () => {
         },
       ]);
 
-      const ops = await service.getOpsSince(userId, 0, client1);
+      const ops = await operationDownloadService.getOpsSince(userId, 0, client1);
 
       expect(ops).toHaveLength(1);
       expect(ops[0].op.entityId).toBe('task-2');
@@ -1729,15 +1735,13 @@ describe('SyncService', () => {
         ]);
       }
 
-      const ops = await service.getOpsSince(userId, 0, undefined, 3);
+      const ops = await operationDownloadService.getOpsSince(userId, 0, undefined, 3);
 
       expect(ops).toHaveLength(3);
     });
 
     it('should return empty array when no operations exist', async () => {
-      const service = getSyncService();
-
-      const ops = await service.getOpsSince(userId, 0);
+      const ops = await operationDownloadService.getOpsSince(userId, 0);
 
       expect(ops).toHaveLength(0);
     });
@@ -2027,7 +2031,7 @@ describe('SyncService', () => {
       expect(totalDeleted).toBe(2);
       expect(affectedUserIds).toContain(userId);
 
-      const remaining = await service.getOpsSince(userId, 0);
+      const remaining = await operationDownloadService.getOpsSince(userId, 0);
       expect(remaining).toHaveLength(3);
     });
 
@@ -2281,8 +2285,8 @@ describe('SyncService', () => {
       expect(affectedUserIds).toContain(userId);
       expect(affectedUserIds).toContain(user2Id);
 
-      expect((await service.getOpsSince(userId, 0)).length).toBe(0);
-      expect((await service.getOpsSince(user2Id, 0)).length).toBe(0);
+      expect((await operationDownloadService.getOpsSince(userId, 0)).length).toBe(0);
+      expect((await operationDownloadService.getOpsSince(user2Id, 0)).length).toBe(0);
     });
 
     it('should delete stale devices', async () => {
@@ -2347,7 +2351,7 @@ describe('SyncService', () => {
 
       expect(totalDeleted).toBe(0);
       expect(affectedUserIds).toHaveLength(0);
-      expect((await service.getOpsSince(userId, 0)).length).toBe(3);
+      expect((await operationDownloadService.getOpsSince(userId, 0)).length).toBe(3);
     });
 
     it('should not delete recent devices', async () => {
@@ -2491,7 +2495,7 @@ describe('SyncService', () => {
     });
   });
 
-  describe('getAllUserIds', () => {
+  describe('uploadOps + DeviceService user lookup', () => {
     it('should return all users with sync state', async () => {
       const service = getSyncService();
       const user2Id = 2;
@@ -2535,7 +2539,7 @@ describe('SyncService', () => {
         },
       ]);
 
-      const userIds = await service.getAllUserIds();
+      const userIds = await deviceService.getAllUserIds();
 
       expect(userIds).toContain(userId);
       expect(userIds).toContain(user2Id);
@@ -2976,14 +2980,14 @@ describe('SyncService', () => {
       ]);
 
       // Verify operations exist
-      const opsBefore = await service.getOpsSince(userId, 0);
+      const opsBefore = await operationDownloadService.getOpsSince(userId, 0);
       expect(opsBefore.length).toBe(2);
 
       // Delete all user data
       await service.deleteAllUserData(userId);
 
       // Verify operations are gone
-      const opsAfter = await service.getOpsSince(userId, 0);
+      const opsAfter = await operationDownloadService.getOpsSince(userId, 0);
       expect(opsAfter.length).toBe(0);
     });
 
@@ -3028,7 +3032,7 @@ describe('SyncService', () => {
       expect(results[0].accepted).toBe(true);
 
       // Verify only new operation exists
-      const ops = await service.getOpsSince(userId, 0);
+      const ops = await operationDownloadService.getOpsSince(userId, 0);
       expect(ops.length).toBe(1);
       expect(ops[0].op.entityId).toBe('t2');
     });
@@ -3080,11 +3084,11 @@ describe('SyncService', () => {
       await service.deleteAllUserData(userId);
 
       // Verify user 1's data is gone
-      const user1Ops = await service.getOpsSince(userId, 0);
+      const user1Ops = await operationDownloadService.getOpsSince(userId, 0);
       expect(user1Ops.length).toBe(0);
 
       // Verify user 2's data still exists
-      const user2Ops = await service.getOpsSince(otherUserId, 0);
+      const user2Ops = await operationDownloadService.getOpsSince(otherUserId, 0);
       expect(user2Ops.length).toBe(1);
       expect(user2Ops[0].op.entityId).toBe('t2');
     });

--- a/packages/super-sync-server/tests/time-tracking-operations.spec.ts
+++ b/packages/super-sync-server/tests/time-tracking-operations.spec.ts
@@ -411,10 +411,12 @@ vi.mock('../src/db', async () => {
 });
 
 import { initSyncService, getSyncService } from '../src/sync/sync.service';
+import { OperationDownloadService } from '../src/sync/services/operation-download.service';
 
 describe('TIME_TRACKING Operations', () => {
   const userId = 1;
   const clientId = 'time-tracking-client';
+  let operationDownloadService: OperationDownloadService;
 
   /**
    * Creates a TIME_TRACKING operation with the standard structure.
@@ -459,6 +461,7 @@ describe('TIME_TRACKING Operations', () => {
       createdAt: new Date(),
     });
     initSyncService();
+    operationDownloadService = new OperationDownloadService();
   });
 
   describe('Operation Upload', () => {
@@ -814,7 +817,7 @@ describe('TIME_TRACKING Operations', () => {
       await service.uploadOps(userId, clientId, [op]);
 
       // Another client downloads - getOpsSince returns { op: Operation, serverSeq }[]
-      const downloadedOps = await service.getOpsSince(userId, 0);
+      const downloadedOps = await operationDownloadService.getOpsSince(userId, 0);
 
       expect(downloadedOps).toHaveLength(1);
       expect(downloadedOps[0].op.entityType).toBe('TIME_TRACKING');
@@ -833,7 +836,7 @@ describe('TIME_TRACKING Operations', () => {
 
       await service.uploadOps(userId, clientId, [op]);
 
-      const downloadedOps = await service.getOpsSince(userId, 0);
+      const downloadedOps = await operationDownloadService.getOpsSince(userId, 0);
 
       expect(downloadedOps[0].op.payload).toEqual({
         contextType: 'PROJECT',


### PR DESCRIPTION
## What changed

- Removed the dead `SyncService` facade methods for operation download, cached snapshots, storage usage calculation, and device/user lookup.
- Repointed affected SuperSync tests to the owning services (`OperationDownloadService` and `DeviceService`).
- Cleaned up the test structure so removed facade APIs are no longer described as `SyncService` behavior.
- Updated the encrypted snapshot regression test to assert behavior without spying on the removed `cacheSnapshot` facade method.

## Why

Issue #8349 identified these facade methods as having no production callers. Keeping them on `SyncService` made the server orchestration facade wider than needed while the actual ownership already lives in the extracted sub-services.

Fixes #8349.

## Validation

- `cd packages/super-sync-server && npm test` — 43 files / 815 tests passed
- `npm test -- --run tests/sync-fixes.spec.ts` — 9 tests passed
- `npm test -- --run tests/sync.service.spec.ts tests/sync-operations.spec.ts tests/conflict-detection.spec.ts tests/time-tracking-operations.spec.ts tests/operation-download.service.spec.ts tests/device.service.spec.ts tests/snapshot.service.spec.ts tests/storage-quota.service.spec.ts` — 297 tests passed
- `npm run checkFile packages/super-sync-server/src/sync/sync.service.ts`
- `npm run checkFile packages/super-sync-server/tests/sync.service.spec.ts`
- `npm run checkFile packages/super-sync-server/tests/sync-operations.spec.ts`
- `npm run checkFile packages/super-sync-server/tests/conflict-detection.spec.ts`
- `npm run checkFile packages/super-sync-server/tests/time-tracking-operations.spec.ts`
- `npm run checkFile packages/super-sync-server/tests/sync-fixes.spec.ts`
- `cd packages/super-sync-server && npm run build`
- Pre-push hook passed on the follow-up push, including lint, package tests, release-notes tests, main Angular test run, and LA timezone Angular test run.