### PR TITLE
fix(sync): clean up verified op-log paths

### DIFF
--- a/src/app/op-log/capture/operation-log.effects.ts
+++ b/src/app/op-log/capture/operation-log.effects.ts
@@ -36,6 +36,8 @@ interface WriteOperationOptions {
   callerHoldsOperationLogLock?: boolean;
 }
 
+const KNOWN_ACTION_TYPES: ReadonlySet<string> = new Set(Object.values(ActionType));
+
 /**
  * NgRx Effects for persisting application state changes as operations to the
  * `OperationLogStoreService`. It listens for specific NgRx actions marked
@@ -193,7 +195,7 @@ export class OperationLogEffects implements DeferredLocalActionsPort {
 
     // Validate action type exists in ActionType enum
     // This catches mismatches during development when new actions are added but not registered
-    if (!Object.values(ActionType).includes(action.type as ActionType)) {
+    if (!KNOWN_ACTION_TYPES.has(action.type)) {
       devError(
         `[OperationLogEffects] Unknown action type: ${action.type} - not in ActionType enum`,
       );

--- a/src/app/op-log/persistence/operation-log-migration.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-migration.service.spec.ts
@@ -29,6 +29,7 @@ describe('OperationLogMigrationService', () => {
       'loadStateCache',
       'getOpsAfterSeq',
       'deleteOpsWhere',
+      'clearAllOperations',
       'append',
       'getLastSeq',
       'saveStateCache',
@@ -188,7 +189,7 @@ describe('OperationLogMigrationService', () => {
             source: 'local',
           },
         ]);
-        mockOpLogStore.deleteOpsWhere.and.resolveTo();
+        mockOpLogStore.clearAllOperations.and.resolveTo();
         // Legacy data exists - orphan ops should be cleared before migration
         mockLegacyPfDb.hasUsableEntityData.and.resolveTo(true);
         // Lock acquisition fails - prevents migration from proceeding (test focuses on clearing)
@@ -199,7 +200,8 @@ describe('OperationLogMigrationService', () => {
         expect(OpLog.warn).toHaveBeenCalledWith(
           jasmine.stringContaining('Found 2 orphan operations'),
         );
-        expect(mockOpLogStore.deleteOpsWhere).toHaveBeenCalled();
+        expect(mockOpLogStore.clearAllOperations).toHaveBeenCalled();
+        expect(mockOpLogStore.deleteOpsWhere).not.toHaveBeenCalled();
         expect(mockLegacyPfDb.hasUsableEntityData).toHaveBeenCalled();
       });
 

--- a/src/app/op-log/persistence/operation-log-migration.service.ts
+++ b/src/app/op-log/persistence/operation-log-migration.service.ts
@@ -111,7 +111,7 @@ export class OperationLogMigrationService {
           `OperationLogMigrationService: Found ${allOps.length} orphan operations. ` +
             `Clearing them before legacy migration.`,
         );
-        await this.opLogStore.deleteOpsWhere(() => true);
+        await this.opLogStore.clearAllOperations();
       } else {
         // Case 2: No legacy data - these are legitimate user operations from a fresh
         // install. Let the hydrator replay them. No migration needed.

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -486,6 +486,32 @@ describe('ConflictResolutionService', () => {
       expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['local-1']);
     });
 
+    it('should not duplicate already rejected local ops while adding superseded pending ops', async () => {
+      const now = Date.now();
+      const conflicts: EntityConflict[] = [
+        createConflict(
+          'task-1',
+          [createOpWithTimestamp('local-1', 'client-a', now - 1000)],
+          [createOpWithTimestamp('remote-1', 'client-b', now)],
+        ),
+      ];
+      mockOpLogStore.getUnsyncedByEntity.and.resolveTo(
+        new Map([
+          [
+            'TASK:task-1',
+            [
+              createOpWithTimestamp('local-1', 'client-a', now - 1000),
+              createOpWithTimestamp('local-2', 'client-a', now - 500),
+            ],
+          ],
+        ]),
+      );
+
+      await service.autoResolveConflictsLWW(conflicts);
+
+      expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['local-1', 'local-2']);
+    });
+
     it('should handle multiple conflicts in single batch', async () => {
       const now = Date.now();
       const conflicts: EntityConflict[] = [

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -306,6 +306,7 @@ export class ConflictResolutionService {
       remoteWinnerAffectedEntityKeys,
     } = lwwPartitions;
     const localOpsToReject = [...lwwPartitions.localOpsToReject];
+    const localOpsToRejectSet = new Set(localOpsToReject);
 
     for (const resolution of resolutions) {
       // Note: localWinOp is undefined for archive-wins sibling conflicts
@@ -357,8 +358,9 @@ export class ConflictResolutionService {
       for (const entityKey of remoteWinnerAffectedEntityKeys) {
         const pendingOps = pendingByEntity.get(entityKey) || [];
         for (const op of pendingOps) {
-          if (!localOpsToReject.includes(op.id)) {
+          if (!localOpsToRejectSet.has(op.id)) {
             localOpsToReject.push(op.id);
+            localOpsToRejectSet.add(op.id);
             OpLog.normal(
               `ConflictResolutionService: Also rejecting superseded op ${op.id} for entity ${entityKey}`,
             );

--- a/src/app/op-log/sync/operation-log-download.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-download.service.spec.ts
@@ -481,6 +481,141 @@ describe('OperationLogDownloadService', () => {
         );
       }));
 
+      it('should clear a pending clock drift retry when a newer check supersedes it', fakeAsync(() => {
+        const driftMs = CLOCK_DRIFT_THRESHOLD_MS + 60000;
+        const initialTime = Date.now();
+        const staleDriftedServerTime = initialTime - driftMs;
+        spyOn(Date, 'now').and.returnValue(initialTime);
+
+        mockApiProvider.downloadOps.and.returnValues(
+          Promise.resolve({
+            ops: [
+              {
+                serverSeq: 1,
+                receivedAt: staleDriftedServerTime,
+                op: {
+                  id: 'op-1',
+                  clientId: 'c1',
+                  actionType: '[Task] Add' as ActionType,
+                  opType: OpType.Create,
+                  entityType: 'TASK',
+                  payload: {},
+                  vectorClock: {},
+                  timestamp: initialTime,
+                  schemaVersion: 1,
+                },
+              },
+            ],
+            hasMore: false,
+            latestSeq: 1,
+            serverTime: staleDriftedServerTime,
+          }),
+          Promise.resolve({
+            ops: [
+              {
+                serverSeq: 2,
+                receivedAt: initialTime,
+                op: {
+                  id: 'op-2',
+                  clientId: 'c1',
+                  actionType: '[Task] Update' as ActionType,
+                  opType: OpType.Update,
+                  entityType: 'TASK',
+                  payload: {},
+                  vectorClock: {},
+                  timestamp: initialTime,
+                  schemaVersion: 1,
+                },
+              },
+            ],
+            hasMore: false,
+            latestSeq: 2,
+            serverTime: initialTime,
+          }),
+        );
+
+        service.downloadRemoteOps(mockApiProvider);
+        tick();
+        service.downloadRemoteOps(mockApiProvider);
+        tick();
+        flush();
+
+        expect(OpLog.warn).not.toHaveBeenCalled();
+        expect(mockSnackService.open).not.toHaveBeenCalled();
+      }));
+
+      it('should not postpone a pending clock drift retry when drift persists', fakeAsync(() => {
+        const driftMs = CLOCK_DRIFT_THRESHOLD_MS + 60000;
+        const initialTime = Date.now();
+        const firstServerTime = initialTime - driftMs;
+        const secondServerTime = initialTime - driftMs - 1000;
+        spyOn(Date, 'now').and.returnValue(initialTime);
+
+        mockApiProvider.downloadOps.and.returnValues(
+          Promise.resolve({
+            ops: [
+              {
+                serverSeq: 1,
+                receivedAt: firstServerTime,
+                op: {
+                  id: 'op-1',
+                  clientId: 'c1',
+                  actionType: '[Task] Add' as ActionType,
+                  opType: OpType.Create,
+                  entityType: 'TASK',
+                  payload: {},
+                  vectorClock: {},
+                  timestamp: initialTime,
+                  schemaVersion: 1,
+                },
+              },
+            ],
+            hasMore: false,
+            latestSeq: 1,
+            serverTime: firstServerTime,
+          }),
+          Promise.resolve({
+            ops: [
+              {
+                serverSeq: 2,
+                receivedAt: secondServerTime,
+                op: {
+                  id: 'op-2',
+                  clientId: 'c1',
+                  actionType: '[Task] Update' as ActionType,
+                  opType: OpType.Update,
+                  entityType: 'TASK',
+                  payload: {},
+                  vectorClock: {},
+                  timestamp: initialTime,
+                  schemaVersion: 1,
+                },
+              },
+            ],
+            hasMore: false,
+            latestSeq: 2,
+            serverTime: secondServerTime,
+          }),
+        );
+
+        service.downloadRemoteOps(mockApiProvider);
+        tick();
+        tick(500);
+
+        service.downloadRemoteOps(mockApiProvider);
+        tick();
+        tick(500);
+
+        expect(OpLog.warn).toHaveBeenCalledWith(
+          'OperationLogDownloadService: Clock drift detected',
+          jasmine.objectContaining({
+            driftMinutes: jasmine.any(String),
+            direction: 'client ahead',
+          }),
+        );
+        expect(mockSnackService.open).toHaveBeenCalledTimes(1);
+      }));
+
       it('should skip clock drift check when serverTime is not provided (backwards compatibility)', fakeAsync(() => {
         // Old servers may not provide serverTime. In this case, we should NOT
         // check clock drift at all because using receivedAt would give false positives.

--- a/src/app/op-log/sync/operation-log-download.service.ts
+++ b/src/app/op-log/sync/operation-log-download.service.ts
@@ -58,12 +58,18 @@ export class OperationLogDownloadService implements OnDestroy {
 
   /** Timeout handle for clock drift retry check (cleaned up on destroy) */
   private clockDriftTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private clockDriftRetryServerTimestamp: number | null = null;
 
   ngOnDestroy(): void {
+    this._clearClockDriftTimeout();
+  }
+
+  private _clearClockDriftTimeout(): void {
     if (this.clockDriftTimeoutId) {
       clearTimeout(this.clockDriftTimeoutId);
       this.clockDriftTimeoutId = null;
     }
+    this.clockDriftRetryServerTimestamp = null;
   }
 
   async downloadRemoteOps(
@@ -463,33 +469,45 @@ export class OperationLogDownloadService implements OnDestroy {
       return;
     }
 
-    const getDriftMinutes = (): number => Math.abs(Date.now() - serverTimestamp) / 60000;
+    const getDriftMinutes = (timestamp: number): number =>
+      Math.abs(Date.now() - timestamp) / 60000;
     const thresholdMinutes = CLOCK_DRIFT_THRESHOLD_MS / 60000;
 
-    const driftMinutes = getDriftMinutes();
+    const driftMinutes = getDriftMinutes(serverTimestamp);
 
-    if (driftMinutes > thresholdMinutes) {
-      // Retry after 1 second - clock may sync after device wake-up
-      this.clockDriftTimeoutId = setTimeout(() => {
-        this.clockDriftTimeoutId = null;
-        if (this.hasWarnedClockDrift) {
-          return;
-        }
-        const retryDriftMinutes = getDriftMinutes();
-        if (retryDriftMinutes > thresholdMinutes) {
-          this.hasWarnedClockDrift = true;
-          const retryDrift = Date.now() - serverTimestamp;
-          OpLog.warn('OperationLogDownloadService: Clock drift detected', {
-            driftMinutes: retryDriftMinutes.toFixed(1),
-            direction: retryDrift > 0 ? 'client ahead' : 'client behind',
-          });
-          this.snackService.open({
-            type: 'ERROR',
-            msg: T.F.SYNC.S.CLOCK_DRIFT_WARNING,
-            translateParams: { minutes: Math.round(retryDriftMinutes) },
-          });
-        }
-      }, 1000);
+    if (driftMinutes <= thresholdMinutes) {
+      this._clearClockDriftTimeout();
+      return;
     }
+
+    this.clockDriftRetryServerTimestamp = serverTimestamp;
+
+    if (this.clockDriftTimeoutId) {
+      return;
+    }
+
+    // Retry after 1 second - clock may sync after device wake-up
+    this.clockDriftTimeoutId = setTimeout(() => {
+      this.clockDriftTimeoutId = null;
+      const retryServerTimestamp = this.clockDriftRetryServerTimestamp;
+      this.clockDriftRetryServerTimestamp = null;
+      if (this.hasWarnedClockDrift || retryServerTimestamp === null) {
+        return;
+      }
+      const retryDriftMinutes = getDriftMinutes(retryServerTimestamp);
+      if (retryDriftMinutes > thresholdMinutes) {
+        this.hasWarnedClockDrift = true;
+        const retryDrift = Date.now() - retryServerTimestamp;
+        OpLog.warn('OperationLogDownloadService: Clock drift detected', {
+          driftMinutes: retryDriftMinutes.toFixed(1),
+          direction: retryDrift > 0 ? 'client ahead' : 'client behind',
+        });
+        this.snackService.open({
+          type: 'ERROR',
+          msg: T.F.SYNC.S.CLOCK_DRIFT_WARNING,
+          translateParams: { minutes: Math.round(retryDriftMinutes) },
+        });
+      }
+    }, 1000);
   }
 }

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -177,6 +177,31 @@ describe('OperationLogUploadService', () => {
         expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([1, 2]);
       });
 
+      it('should mark accepted seqs correctly when server results are out of order', async () => {
+        const pendingOps = [
+          createMockEntry(1, 'op-1', 'client-1'),
+          createMockEntry(2, 'op-2', 'client-1'),
+          createMockEntry(3, 'op-3', 'client-1'),
+        ];
+        mockOpLogStore.getUnsynced.and.returnValue(Promise.resolve(pendingOps));
+        mockApiProvider.uploadOps.and.returnValue(
+          Promise.resolve({
+            results: [
+              { opId: 'op-3', accepted: true },
+              { opId: 'op-1', accepted: true },
+              { opId: 'op-2', accepted: false, error: 'conflict' },
+            ],
+            latestSeq: 10,
+            newOps: [],
+          }),
+        );
+
+        const result = await service.uploadPendingOps(mockApiProvider);
+
+        expect(result.uploadedCount).toBe(2);
+        expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([3, 1]);
+      });
+
       it('should strip local sync schedule settings from regular config ops before upload', async () => {
         const entry = createMockEntry(1, 'op-1', 'client-1');
         entry.op.actionType = ActionType.GLOBAL_CONFIG_UPDATE_SECTION;

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -229,15 +229,18 @@ export class OperationLogUploadService {
 
       // Convert to SyncOperation format. Local-only operations remain in the
       // local op-log for replay, but are acknowledged locally instead of uploaded.
-      const syncOpPairs = regularOps
-        .map((entry) => ({ entry, syncOp: this._entryToSyncOp(entry) }))
-        .filter(
-          (pair): pair is { entry: OperationLogEntry; syncOp: SyncOperation } =>
-            pair.syncOp !== null,
-        );
-      const localOnlySeqs = regularOps
-        .filter((entry) => !syncOpPairs.some((pair) => pair.entry.seq === entry.seq))
-        .map((entry) => entry.seq);
+      let syncOps: SyncOperation[] = [];
+      const uploadEntries: OperationLogEntry[] = [];
+      const localOnlySeqs: number[] = [];
+      for (const entry of regularOps) {
+        const syncOp = this._entryToSyncOp(entry);
+        if (syncOp === null) {
+          localOnlySeqs.push(entry.seq);
+        } else {
+          syncOps.push(syncOp);
+          uploadEntries.push(entry);
+        }
+      }
       if (localOnlySeqs.length > 0) {
         await this.opLogStore.markSynced(localOnlySeqs);
         uploadedCount += localOnlySeqs.length;
@@ -245,12 +248,9 @@ export class OperationLogUploadService {
           `OperationLogUploadService: Marked ${localOnlySeqs.length} local-only op(s) as synced without upload`,
         );
       }
-      if (syncOpPairs.length === 0) {
+      if (syncOps.length === 0) {
         return;
       }
-
-      let syncOps: SyncOperation[] = syncOpPairs.map((pair) => pair.syncOp);
-      const uploadEntries = syncOpPairs.map((pair) => pair.entry);
 
       // Encrypt payloads if E2E encryption is enabled
       if (isEncryptionEnabled && encryptKey) {
@@ -281,12 +281,10 @@ export class OperationLogUploadService {
         }
 
         // Mark successfully accepted ops as synced
+        const entrySeqByOpId = new Map(entries.map((entry) => [entry.op.id, entry.seq]));
         const acceptedSeqs = response.results
           .filter((r) => r.accepted)
-          .map((r) => {
-            const entry = entries.find((e) => e.op.id === r.opId);
-            return entry?.seq;
-          })
+          .map((r) => entrySeqByOpId.get(r.opId))
           .filter((seq): seq is number => seq !== undefined);
 
         if (acceptedSeqs.length > 0) {

--- a/src/app/op-log/sync/server-migration.service.spec.ts
+++ b/src/app/op-log/sync/server-migration.service.spec.ts
@@ -17,6 +17,7 @@ import {
 import { SyncProviderId } from '../sync-providers/provider.const';
 import { OpType } from '../core/operation.types';
 import { SYSTEM_TAG_IDS } from '../../features/tag/tag.const';
+import { INBOX_PROJECT } from '../../features/project/project.const';
 import { loadAllData } from '../../root-store/meta/load-all-data.action';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 
@@ -259,6 +260,64 @@ describe('ServerMigrationService', () => {
       expect(opLogStoreSpy.append).not.toHaveBeenCalled();
     });
 
+    it('should skip if state only has the default INBOX project', async () => {
+      stateSnapshotServiceSpy.getStateSnapshotAsync.and.returnValue(
+        Promise.resolve({
+          task: { ids: [], entities: {} },
+          project: {
+            ids: [INBOX_PROJECT.id],
+            entities: { [INBOX_PROJECT.id]: INBOX_PROJECT },
+          },
+          tag: { ids: [], entities: {} },
+          note: { ids: [], entities: {} },
+        } as any),
+      );
+
+      await service.handleServerMigration(defaultProvider);
+
+      expect(opLogStoreSpy.append).not.toHaveBeenCalled();
+    });
+
+    it('should proceed if state has notes', async () => {
+      stateSnapshotServiceSpy.getStateSnapshotAsync.and.returnValue(
+        Promise.resolve({
+          task: { ids: [], entities: {} },
+          project: {
+            ids: [INBOX_PROJECT.id],
+            entities: { [INBOX_PROJECT.id]: INBOX_PROJECT },
+          },
+          tag: { ids: [], entities: {} },
+          note: { ids: ['note-1'], entities: { 'note-1': { id: 'note-1' } } },
+        } as any),
+      );
+
+      await service.handleServerMigration(defaultProvider);
+
+      expect(opLogStoreSpy.append).toHaveBeenCalled();
+    });
+
+    it('should proceed if non-entity sync state differs from defaults', async () => {
+      stateSnapshotServiceSpy.getStateSnapshotAsync.and.returnValue(
+        Promise.resolve({
+          task: { ids: [], entities: {} },
+          project: {
+            ids: [INBOX_PROJECT.id],
+            entities: { [INBOX_PROJECT.id]: INBOX_PROJECT },
+          },
+          tag: { ids: [], entities: {} },
+          note: { ids: [], entities: {} },
+          planner: {
+            days: { '2026-06-19': ['task-1'] },
+            addPlannedTasksDialogLastShown: undefined,
+          },
+        } as any),
+      );
+
+      await service.handleServerMigration(defaultProvider);
+
+      expect(opLogStoreSpy.append).toHaveBeenCalled();
+    });
+
     it('should abort if state validation fails', async () => {
       validateStateServiceSpy.validateAndRepair.and.resolveTo({
         isValid: false,
@@ -335,11 +394,13 @@ describe('ServerMigrationService', () => {
     });
 
     it('should proceed if state has tasks', async () => {
-      stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
-        task: { ids: ['task-1'], entities: { 'task-1': { id: 'task-1' } } },
-        project: { ids: [], entities: {} },
-        tag: { ids: [], entities: {} },
-      } as any);
+      stateSnapshotServiceSpy.getStateSnapshotAsync.and.returnValue(
+        Promise.resolve({
+          task: { ids: ['task-1'], entities: { 'task-1': { id: 'task-1' } } },
+          project: { ids: [], entities: {} },
+          tag: { ids: [], entities: {} },
+        } as any),
+      );
 
       await service.handleServerMigration(defaultProvider);
 
@@ -347,11 +408,13 @@ describe('ServerMigrationService', () => {
     });
 
     it('should proceed if state has projects', async () => {
-      stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
-        task: { ids: [], entities: {} },
-        project: { ids: ['proj-1'], entities: { 'proj-1': { id: 'proj-1' } } },
-        tag: { ids: [], entities: {} },
-      } as any);
+      stateSnapshotServiceSpy.getStateSnapshotAsync.and.returnValue(
+        Promise.resolve({
+          task: { ids: [], entities: {} },
+          project: { ids: ['proj-1'], entities: { 'proj-1': { id: 'proj-1' } } },
+          tag: { ids: [], entities: {} },
+        } as any),
+      );
 
       await service.handleServerMigration(defaultProvider);
 
@@ -359,11 +422,16 @@ describe('ServerMigrationService', () => {
     });
 
     it('should proceed if state has user-created tags', async () => {
-      stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
-        task: { ids: [], entities: {} },
-        project: { ids: [], entities: {} },
-        tag: { ids: ['user-tag-1'], entities: { 'user-tag-1': { id: 'user-tag-1' } } },
-      } as any);
+      stateSnapshotServiceSpy.getStateSnapshotAsync.and.returnValue(
+        Promise.resolve({
+          task: { ids: [], entities: {} },
+          project: { ids: [], entities: {} },
+          tag: {
+            ids: ['user-tag-1'],
+            entities: { 'user-tag-1': { id: 'user-tag-1' } },
+          },
+        } as any),
+      );
 
       await service.handleServerMigration(defaultProvider);
 
@@ -371,7 +439,7 @@ describe('ServerMigrationService', () => {
     });
   });
 
-  describe('_isEmptyState (tested via handleServerMigration)', () => {
+  describe('empty-state detection (tested via handleServerMigration)', () => {
     it('should treat null state as empty', async () => {
       stateSnapshotServiceSpy.getStateSnapshotAsync.and.returnValue(
         Promise.resolve(null as any),
@@ -403,7 +471,7 @@ describe('ServerMigrationService', () => {
     });
   });
 
-  describe('_hasNoUserCreatedTags (tested via handleServerMigration)', () => {
+  describe('system-tag empty-state detection (tested via handleServerMigration)', () => {
     it('should identify system tags correctly', async () => {
       for (const systemTagId of SYSTEM_TAG_IDS) {
         opLogStoreSpy.append.calls.reset();

--- a/src/app/op-log/sync/server-migration.service.ts
+++ b/src/app/op-log/sync/server-migration.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { MatDialog } from '@angular/material/dialog';
+import { deepEqual } from '@sp/sync-core';
 import { firstValueFrom } from 'rxjs';
 import { OperationSyncCapable } from '../sync-providers/provider.interface';
 import { OperationLogStoreService } from '../persistence/operation-log-store.service';
@@ -20,9 +21,37 @@ import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service'
 import { ActionType, Operation, OpType, SyncImportReason } from '../core/operation.types';
 import { uuidv7 } from '../../util/uuid-v7';
 import { OpLog } from '../../core/log';
-import { SYSTEM_TAG_IDS } from '../../features/tag/tag.const';
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
 import { DialogServerMigrationConfirmComponent } from './dialog-server-migration-confirm/dialog-server-migration-confirm.component';
+import { hasMeaningfulStateData } from '../validation/has-meaningful-state-data.util';
+import { MODEL_CONFIGS } from '../model/model-config';
+
+const MEANINGFUL_ENTITY_STATE_KEYS = new Set(['task', 'project', 'tag', 'note']);
+
+const hasServerMigrationStateData = (state: unknown): boolean => {
+  if (!state || typeof state !== 'object') {
+    return false;
+  }
+  const s = state as Record<string, unknown>;
+
+  if (hasMeaningfulStateData(s)) {
+    return true;
+  }
+
+  for (const [key, config] of Object.entries(MODEL_CONFIGS)) {
+    if (MEANINGFUL_ENTITY_STATE_KEYS.has(key)) {
+      continue;
+    }
+    if (!Object.prototype.hasOwnProperty.call(s, key) || s[key] === undefined) {
+      continue;
+    }
+    if (!deepEqual(s[key], config.defaultData)) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 /**
  * Service responsible for handling server migration scenarios.
@@ -178,7 +207,7 @@ export class ServerMigrationService {
       >;
 
     // Skip if local state is effectively empty
-    if (this._isEmptyState(currentState)) {
+    if (!hasServerMigrationStateData(currentState)) {
       OpLog.warn('ServerMigrationService: Skipping SYNC_IMPORT - local state is empty.');
       return;
     }
@@ -287,43 +316,5 @@ export class ServerMigrationService {
     } finally {
       stopWaiting();
     }
-  }
-
-  /**
-   * Checks if the state is effectively empty (no meaningful data to sync).
-   * An empty state has no tasks, projects, or user-created tags.
-   */
-  private _isEmptyState(state: unknown): boolean {
-    if (!state || typeof state !== 'object') {
-      return true;
-    }
-
-    const s = state as Record<string, unknown>;
-
-    // Check for meaningful data in key entity collections
-    const taskState = s['task'] as { ids?: unknown[] } | undefined;
-    const projectState = s['project'] as { ids?: unknown[] } | undefined;
-    const tagState = s['tag'] as { ids?: (string | unknown)[] } | undefined;
-
-    const hasNoTasks = !taskState?.ids || taskState.ids.length === 0;
-    const hasNoProjects = !projectState?.ids || projectState.ids.length === 0;
-    const hasNoUserTags = this._hasNoUserCreatedTags(tagState?.ids);
-
-    // Consider empty if there are no tasks, projects, or user-defined tags
-    return hasNoTasks && hasNoProjects && hasNoUserTags;
-  }
-
-  /**
-   * Checks if there are no user-created tags.
-   * System tags (TODAY, URGENT, IMPORTANT, IN_PROGRESS) are excluded from the count.
-   */
-  private _hasNoUserCreatedTags(tagIds: (string | unknown)[] | undefined): boolean {
-    if (!tagIds || tagIds.length === 0) {
-      return true;
-    }
-    const userTagCount = tagIds.filter(
-      (id) => typeof id === 'string' && !SYSTEM_TAG_IDS.has(id),
-    ).length;
-    return userTagCount === 0;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the verified client-sync cleanup items from #8360 across the op-log sync path.

## Changes

- Optimized upload filtering by splitting local-only and uploadable ops in one pass.
- Mapped accepted upload results through an `opId -> seq` map instead of per-result entry scans.
- Replaced full orphan-op cleanup with `clearAllOperations()` in the migration service.
- Cached known `ActionType` values in a module-level set for persistence validation.
- Fixed clock-drift retry cleanup without allowing repeated drift checks to postpone the warning forever.
- Kept conflict rejection order stable while using a companion set for duplicate checks.
- Replaced duplicated server-migration empty-state checks with shared meaningful-state detection plus migration-specific default-state safeguards.
- Added focused regression coverage for local-only uploads, out-of-order accepted upload results, orphan cleanup, clock-drift timer behavior, conflict rejection dedupe, and server-migration empty-state handling.

## Verification

- `npm run test:file src/app/op-log/sync/operation-log-upload.service.spec.ts`
- `npm run test:file src/app/op-log/persistence/operation-log-migration.service.spec.ts`
- `npm run test:file src/app/op-log/capture/operation-log.effects.spec.ts`
- `npm run test:file src/app/op-log/sync/operation-log-download.service.spec.ts`
- `npm run test:file src/app/op-log/sync/conflict-resolution.service.spec.ts`
- `npm run test:file src/app/op-log/sync/server-migration.service.spec.ts`
- `npm run checkFile` for all modified `.ts` files
- pre-push hook: `npm run lint`
- pre-push hook: `npm test` including package tests, Angular suite, and timezone suite
