### PR TITLE
fix(backup): preserve section during legacy migration

### DIFF
--- a/src/app/op-log/backup/migrate-legacy-backup.spec.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { isLegacyBackupData, migrateLegacyBackup } from './migrate-legacy-backup';
 import { INBOX_PROJECT } from '../../features/project/project.const';
+import { createValidAppData } from '../validation/state-validity-test-utils';
+import { validateFull } from '../validation/validation-fn';
+import { AppDataComplete, MODEL_CONFIGS } from '../model/model-config';
+import { WorkContextType } from '../../features/work-context/work-context.model';
 import fixture from './test-fixtures/legacy-v10-backup.json';
 
 /**
@@ -129,6 +133,7 @@ const createModernBackup = (): Record<string, any> => ({
   globalConfig: { misc: { isDisableInitialDialog: true }, sync: { isEnabled: false } },
   note: { ids: [], entities: {}, todayOrder: [] },
   simpleCounter: { ids: [], entities: {} },
+  section: { ids: [], entities: {} },
   taskRepeatCfg: { ids: [], entities: {} },
   metric: { ids: [], entities: {} },
   planner: { days: {} },
@@ -151,26 +156,7 @@ const createModernBackup = (): Record<string, any> => ({
   },
 });
 
-const V17_REQUIRED_KEYS = [
-  'project',
-  'menuTree',
-  'globalConfig',
-  'planner',
-  'boards',
-  'note',
-  'issueProvider',
-  'metric',
-  'task',
-  'tag',
-  'simpleCounter',
-  'taskRepeatCfg',
-  'reminders',
-  'timeTracking',
-  'pluginUserData',
-  'pluginMetadata',
-  'archiveYoung',
-  'archiveOld',
-];
+const V17_REQUIRED_KEYS = Object.keys(MODEL_CONFIGS);
 
 const LEGACY_KEYS = [
   'bookmark',
@@ -180,6 +166,33 @@ const LEGACY_KEYS = [
   'lastLocalSyncModelChange',
   'lastArchiveUpdate',
 ];
+
+const createLegacyDetectedValidAppData = (): Record<string, any> => {
+  const data = structuredClone(createValidAppData()) as Record<string, any>;
+  const project = data.project.entities.INBOX!;
+  project.id = 'project-1';
+  project.title = 'Project';
+  delete data.project.entities.INBOX;
+  data.project.entities['project-1'] = project;
+  data.project.ids = ['project-1'];
+  data.menuTree.projectTree[0].id = 'project-1';
+  data.improvement = { ids: [], entities: {}, hiddenImprovementBannerItems: [] };
+  return data;
+};
+
+const expectValidWithoutRepair = (data: AppDataComplete): void => {
+  const validationResult = validateFull(data);
+  const validationError =
+    'errors' in validationResult.typiaResult
+      ? validationResult.typiaResult.errors
+          .map((error) => `${error.path}: ${error.expected}`)
+          .join('\n')
+      : validationResult.crossModelError;
+
+  expect(validationResult.isValid)
+    .withContext(validationError || '')
+    .toBe(true);
+};
 
 describe('migrate-legacy-backup', () => {
   describe('isLegacyBackupData', () => {
@@ -221,6 +234,39 @@ describe('migrate-legacy-backup', () => {
       for (const key of V17_REQUIRED_KEYS) {
         expect(key in result).toBe(true);
       }
+    });
+
+    it('should add missing section to legacy-detected data before full validation', () => {
+      const data = createLegacyDetectedValidAppData();
+      delete data.section;
+
+      const result = migrateLegacyBackup(data);
+
+      expect(result.section).toEqual(MODEL_CONFIGS.section.defaultData!);
+      expectValidWithoutRepair(result);
+    });
+
+    it('should preserve existing section data while stripping legacy keys', () => {
+      const data = createLegacyDetectedValidAppData();
+      data.section = {
+        ids: ['section-1'],
+        entities: {
+          'section-1': {
+            id: 'section-1',
+            contextId: 'project-1',
+            contextType: WorkContextType.PROJECT,
+            title: 'Focus',
+            taskIds: [],
+          },
+        },
+      };
+
+      const result = migrateLegacyBackup(data);
+
+      expect(result.section.ids).toEqual(['section-1']);
+      expect(result.section.entities['section-1']?.title).toBe('Focus');
+      expect('improvement' in (result as unknown as Record<string, unknown>)).toBe(false);
+      expectValidWithoutRepair(result);
     });
 
     it('should strip all legacy keys', () => {

--- a/src/app/op-log/backup/migrate-legacy-backup.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.ts
@@ -27,7 +27,6 @@ import { plannerInitialState } from '../../features/planner/store/planner.reduce
 import { issueProviderInitialState } from '../../features/issue/store/issue-provider.reducer';
 import { menuTreeInitialState } from '../../features/menu-tree/store/menu-tree.reducer';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
-import { initialTimeTrackingState } from '../../features/time-tracking/store/time-tracking.reducer';
 import { TTWorkContextSessionMap } from '../../features/time-tracking/time-tracking.model';
 import { TODAY_TAG } from '../../features/tag/tag.const';
 import {
@@ -39,15 +38,13 @@ import { isTodayWithOffset } from '../../util/is-today.util';
 // Matches DateService.setStartOfNextDayDiff semantics for legacy backup normalization.
 import { getStartOfNextDayDiffMs } from '../../util/start-of-next-day.util';
 import { LanguageCode } from '../../core/locale.constants';
-import {
-  initialPluginUserDataState,
-  initialPluginMetaDataState,
-} from '../../plugins/plugin-persistence.model';
-import { AppDataComplete } from '../model/model-config';
+import { AppDataComplete, MODEL_CONFIGS } from '../model/model-config';
 import { OpLog } from '../../core/log';
 import { migrateLegacyTaskRemindersIntoTasks } from '../../features/reminder/migrate-legacy-task-reminders.util';
 
 const LEGACY_INBOX_PROJECT_ID = 'INBOX' as const;
+const APP_DATA_MODEL_KEYS = Object.keys(MODEL_CONFIGS) as (keyof AppDataComplete)[];
+const V17_VALID_KEYS = new Set<keyof AppDataComplete>(APP_DATA_MODEL_KEYS);
 
 /**
  * Detects whether the incoming data is a legacy (pre-v14) backup that needs
@@ -775,43 +772,10 @@ function _migration45LowercaseLanguageCodes(
 // ---------------------------------------------------------------------------
 
 function _ensureV17Defaults(data: Record<string, any>): Record<string, any> {
-  if (!data.issueProvider) {
-    data.issueProvider = issueProviderInitialState;
-  }
-  if (!data.boards) {
-    data.boards = initialBoardsState;
-  }
-  if (!data.planner) {
-    data.planner = plannerInitialState;
-  }
-  if (!data.menuTree) {
-    data.menuTree = menuTreeInitialState;
-  }
-  if (!data.timeTracking) {
-    data.timeTracking = initialTimeTrackingState;
-  }
-  if (!data.pluginUserData) {
-    data.pluginUserData = initialPluginUserDataState;
-  }
-  if (!data.pluginMetadata) {
-    data.pluginMetadata = initialPluginMetaDataState;
-  }
-  if (!data.reminders) {
-    data.reminders = [];
-  }
-  if (!data.archiveYoung) {
-    data.archiveYoung = {
-      task: { ids: [], entities: {} },
-      timeTracking: initialTimeTrackingState,
-      lastTimeTrackingFlush: 0,
-    };
-  }
-  if (!data.archiveOld) {
-    data.archiveOld = {
-      task: { ids: [], entities: {} },
-      timeTracking: initialTimeTrackingState,
-      lastTimeTrackingFlush: 0,
-    };
+  for (const key of APP_DATA_MODEL_KEYS) {
+    if (!data[key]) {
+      data[key] = structuredClone(MODEL_CONFIGS[key].defaultData);
+    }
   }
   return data;
 }
@@ -820,31 +784,10 @@ function _ensureV17Defaults(data: Record<string, any>): Record<string, any> {
 // Final: strip keys that are not part of v17's AppDataComplete
 // ---------------------------------------------------------------------------
 
-const V17_VALID_KEYS = new Set([
-  'project',
-  'menuTree',
-  'globalConfig',
-  'planner',
-  'boards',
-  'note',
-  'issueProvider',
-  'metric',
-  'task',
-  'tag',
-  'simpleCounter',
-  'taskRepeatCfg',
-  'reminders',
-  'timeTracking',
-  'pluginUserData',
-  'pluginMetadata',
-  'archiveYoung',
-  'archiveOld',
-]);
-
 function _stripLegacyKeys(data: Record<string, any>): Record<string, any> {
   const stripped: Record<string, any> = {};
   for (const key of Object.keys(data)) {
-    if (V17_VALID_KEYS.has(key)) {
+    if (V17_VALID_KEYS.has(key as keyof AppDataComplete)) {
       stripped[key] = data[key];
     } else {
       OpLog.log(`migrateLegacyBackup: Stripping legacy key "${key}"`);


### PR DESCRIPTION
## Summary
- derive legacy backup default/valid model keys from MODEL_CONFIGS instead of a hand-maintained v17 key list
- ensure legacy-detected backups that omit section receive the section default before validation
- preserve existing section data while stripping obsolete legacy keys

## Tests
- npm run checkFile src/app/op-log/backup/migrate-legacy-backup.ts
- npm run checkFile src/app/op-log/backup/migrate-legacy-backup.spec.ts
- npm run test:file src/app/op-log/backup/migrate-legacy-backup.spec.ts
- git diff --check
- push hook: npm run lint
- push hook: npm test