### PR TITLE
fix(theme): keep background overlay/blur sliders across image removal

### DIFF
--- a/src/app/features/work-context/work-context.const.spec.ts
+++ b/src/app/features/work-context/work-context.const.spec.ts
@@ -1,3 +1,12 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { UntypedFormGroup } from '@angular/forms';
+import {
+  FieldType,
+  FormlyFieldConfig,
+  FormlyFormBuilder,
+  FormlyModule,
+} from '@ngx-formly/core';
 import {
   DEFAULT_BACKGROUND_IMAGE_BLUR,
   hasAllBackgroundImages,
@@ -7,6 +16,7 @@ import {
   WORK_CONTEXT_DEFAULT_THEME,
   WORK_CONTEXT_THEME_CONFIG_FORM_CONFIG,
 } from './work-context.const';
+import { WorkContextThemeCfg } from './work-context.model';
 
 describe('work-context theme background image helpers', () => {
   it('should detect no background images', () => {
@@ -84,5 +94,154 @@ describe('work-context theme background image blur config', () => {
     expect(normalizeBackgroundImageBlur(MAX_BACKGROUND_IMAGE_BLUR + 1)).toBe(
       MAX_BACKGROUND_IMAGE_BLUR,
     );
+  });
+});
+
+/**
+ * Regression for #8504. The overlay-opacity and blur sliders are hidden when no
+ * background image is set. Formly's default `resetFieldOnHide: true` wipes the
+ * model value of a field while it is hidden, so removing the image dropped
+ * `backgroundOverlayOpacity` to `undefined`. Re-adding an image then showed the
+ * slider at 0% (its min) instead of the configured value. Marking the sliders
+ * `resetOnHide: false` keeps the value across the hide/show cycle.
+ */
+describe('work-context theme background slider persistence (#8504)', () => {
+  @Component({ selector: 'noop-formly-field', template: '', standalone: true })
+  class NoopFormlyFieldComponent extends FieldType {}
+
+  const TYPE_STUBS = [
+    'input',
+    'color',
+    'checkbox',
+    'select',
+    'image-input',
+    'slider',
+  ].map((name) => ({ name, component: NoopFormlyFieldComponent }));
+
+  let builder: FormlyFormBuilder;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopFormlyFieldComponent, FormlyModule.forRoot({ types: TYPE_STUBS })],
+    });
+    builder = TestBed.inject(FormlyFormBuilder);
+  });
+
+  // JSON/structuredClone drop the function-based `expressions.hide`, so clone
+  // manually and keep function references (they are pure) to isolate per-test
+  // field state from Formly's in-place mutations.
+  const cloneItems = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      return value.map(cloneItems);
+    }
+    if (value && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value).map(([k, v]) => [k, cloneItems(v)]),
+      );
+    }
+    return value;
+  };
+
+  // Formly mutates the model in place; the persisted type is `Readonly`.
+  type MutableThemeCfg = {
+    -readonly [K in keyof WorkContextThemeCfg]: WorkContextThemeCfg[K];
+  };
+
+  const buildThemeForm = (
+    model: MutableThemeCfg,
+  ): { fields: FormlyFieldConfig[]; model: MutableThemeCfg } => {
+    const fields = cloneItems(
+      WORK_CONTEXT_THEME_CONFIG_FORM_CONFIG.items,
+    ) as FormlyFieldConfig[];
+    builder.buildForm(new UntypedFormGroup({}), fields, model, {});
+    return { fields, model };
+  };
+
+  const fieldByKey = (
+    fields: FormlyFieldConfig[],
+    key: keyof WorkContextThemeCfg,
+  ): FormlyFieldConfig => fields.find((f) => f.key === key)!;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const checkExpressions = (field: FormlyFieldConfig): void => {
+    const opts = field.options as any;
+    opts.checkExpressions({ fieldGroup: [field], options: opts });
+  };
+
+  it('keeps the overlay opacity after removing and re-adding the image', () => {
+    const model: MutableThemeCfg = {
+      backgroundImageDark: 'image:first',
+      backgroundImageLight: null,
+      backgroundOverlayOpacity: 20,
+    };
+    const { fields } = buildThemeForm(model);
+    const opacity = fieldByKey(fields, 'backgroundOverlayOpacity');
+    const image = fieldByKey(fields, 'backgroundImageDark');
+
+    checkExpressions(opacity);
+    expect(opacity.hide).toBeFalsy();
+    expect(model.backgroundOverlayOpacity).toBe(20);
+
+    // Remove the image -> the opacity slider hides.
+    image.formControl!.setValue('');
+    model.backgroundImageDark = '';
+    checkExpressions(opacity);
+    expect(opacity.hide).toBe(true);
+
+    // Re-add an image -> the opacity slider reappears.
+    image.formControl!.setValue('image:second');
+    model.backgroundImageDark = 'image:second';
+    checkExpressions(opacity);
+    expect(opacity.hide).toBeFalsy();
+
+    expect(model.backgroundOverlayOpacity).toBe(20);
+  });
+
+  it('shows the configured opacity when an image is added to a context without one', () => {
+    // Opacity slider is hidden at init (no image), but the theme still carries
+    // the default opacity. Adding an image must reveal it at that value, not 0%.
+    const model: MutableThemeCfg = {
+      backgroundImageDark: null,
+      backgroundImageLight: null,
+      backgroundOverlayOpacity: 20,
+    };
+    const { fields } = buildThemeForm(model);
+    const opacity = fieldByKey(fields, 'backgroundOverlayOpacity');
+    const image = fieldByKey(fields, 'backgroundImageDark');
+
+    checkExpressions(opacity);
+    expect(opacity.hide).toBe(true);
+
+    image.formControl!.setValue('image:added');
+    model.backgroundImageDark = 'image:added';
+    checkExpressions(opacity);
+
+    expect(opacity.hide).toBeFalsy();
+    expect(model.backgroundOverlayOpacity).toBe(20);
+  });
+
+  it('keeps a custom blur value after removing and re-adding the image', () => {
+    const model: MutableThemeCfg = {
+      backgroundImageDark: 'image:first',
+      backgroundImageLight: null,
+      backgroundImageBlur: 8,
+    };
+    const { fields } = buildThemeForm(model);
+    const blur = fieldByKey(fields, 'backgroundImageBlur');
+    const image = fieldByKey(fields, 'backgroundImageDark');
+
+    checkExpressions(blur);
+    expect(model.backgroundImageBlur).toBe(8);
+
+    image.formControl!.setValue('');
+    model.backgroundImageDark = '';
+    checkExpressions(blur);
+    expect(blur.hide).toBe(true);
+
+    image.formControl!.setValue('image:second');
+    model.backgroundImageDark = 'image:second';
+    checkExpressions(blur);
+
+    expect(model.backgroundImageBlur).toBe(8);
   });
 });

--- a/src/app/features/work-context/work-context.const.ts
+++ b/src/app/features/work-context/work-context.const.ts
@@ -189,6 +189,11 @@ export const WORK_CONTEXT_THEME_CONFIG_FORM_CONFIG: ConfigFormSection<WorkContex
       {
         key: 'backgroundOverlayOpacity',
         type: 'slider',
+        // Keep the value while the slider is hidden (no background image set).
+        // Formly's default `resetFieldOnHide` would otherwise wipe it to
+        // `undefined`, so removing and re-adding an image reset the slider to
+        // 0% instead of the configured value. See #8504.
+        resetOnHide: false,
         props: {
           label: T.F.PROJECT.FORM_THEME.L_BACKGROUND_OVERLAY_OPACITY,
           description: T.F.PROJECT.FORM_THEME.D_BACKGROUND_OVERLAY_OPACITY,
@@ -207,6 +212,8 @@ export const WORK_CONTEXT_THEME_CONFIG_FORM_CONFIG: ConfigFormSection<WorkContex
       {
         key: 'backgroundImageBlur',
         type: 'slider',
+        // See backgroundOverlayOpacity above (#8504).
+        resetOnHide: false,
         props: {
           label: T.F.PROJECT.FORM_THEME.L_BACKGROUND_IMAGE_BLUR,
           description: T.F.PROJECT.FORM_THEME.D_BACKGROUND_IMAGE_BLUR,


### PR DESCRIPTION
## Problem

Closes #8504.

The "Darken/lighten background image" (overlay opacity) setting shows **0%** instead of the default **20%** after this sequence:

1. Add a background image
2. Remove the background image
3. Add a background image again

## Root cause

The overlay-opacity and blur sliders in `WORK_CONTEXT_THEME_CONFIG_FORM_CONFIG` are hidden (via a `hide` expression on `hasAnyBackgroundImage`) whenever no background image is set. ngx-formly's default `resetFieldOnHide: true` **wipes a field's model value to `undefined` when it transitions visible→hidden**. Removing the image therefore drops `backgroundOverlayOpacity` to `undefined`; re-adding the image re-shows the slider, but with no `defaultValue` configured formly leaves it `undefined`, so the slider renders its `min` (0%).

## Fix

Add `resetOnHide: false` to both slider fields so the configured value survives the hide/show cycle. This is preferable to adding `defaultValue: 20`, which would still discard a user-customized value (e.g. 50%) on remove/re-add. The blur slider has the identical latent bug (less visible only because its default is 0), so it's fixed too.

**Why it's safe:** the overlay/blur only render when a background image is present (`app.component.html` gates on `resolvedBgImage()`), and the default theme already carries these keys — so retaining the value in the model while hidden is harmless. No sync/op-log surface is touched (pure form-config change).

## Tests

Added regression tests that drive the real form config through formly's `FormlyFormBuilder` + `checkExpressions` (the same path a live `(modelChange)` triggers):

- Opacity and blur values survive remove → re-add (fail before the fix: `Expected undefined to be 20` / `8`, pass after).
- Adding an image to a context that never had one shows the configured opacity (guards the happy path).

All specs in the file pass; `app.component` and `dialog-project-complete` specs (the opacity readers) still pass; `checkFile` clean on both files.