### PR TITLE
fix(tasks): add visible keyboard focus ring to subtasks (#8520)

### DIFF
--- a/src/app/features/tasks/task/_task-base.scss
+++ b/src/app/features/tasks/task/_task-base.scss
@@ -222,14 +222,6 @@
   }
 }
 
-:host-context(.sub-tasks):focus .inner-wrapper > .box {
-  @include noTouchOnly() {
-    border-color: var(--palette-primary-400) !important;
-    border-style: solid !important;
-    border-width: 1px !important;
-  }
-}
-
 :host-context(.isDarkTheme) ::ng-deep .isDone.isDone .box {
   background: var(--sub-task-c-bg-done);
 }

--- a/src/app/features/tasks/task/_task-base.scss
+++ b/src/app/features/tasks/task/_task-base.scss
@@ -222,6 +222,14 @@
   }
 }
 
+:host-context(.sub-tasks):focus .inner-wrapper > .box {
+  @include noTouchOnly() {
+    border-color: var(--palette-primary-400) !important;
+    border-style: solid !important;
+    border-width: 1px !important;
+  }
+}
+
 :host-context(.isDarkTheme) ::ng-deep .isDone.isDone .box {
   background: var(--sub-task-c-bg-done);
 }

--- a/src/assets/themes/liquid-glass.css
+++ b/src/assets/themes/liquid-glass.css
@@ -860,6 +860,14 @@ schedule-event {
   border-top-color: rgba(var(--ink-on-channel), 0.06) !important;
 }
 
+/* The single-edge separator above sets border-color: transparent !important,
+ * which also erases the base keyboard focus ring on subtasks
+ * (:host:focus … .box uses a non-!important border). Restore it so a focused
+ * subtask matches a focused parent task (both use --palette-primary-400 here). */
+.sub-tasks task:focus .box {
+  border-color: var(--palette-primary-400) !important;
+}
+
 /* Current task fill — applied in both modes. _task-base.scss only
  * sets a background for the current task in dark mode (light mode
  * gets only a dashed accent border), but with `position: sticky`

--- a/src/assets/themes/liquid-glass.css
+++ b/src/assets/themes/liquid-glass.css
@@ -863,8 +863,10 @@ schedule-event {
 /* The single-edge separator above sets border-color: transparent !important,
  * which also erases the base keyboard focus ring on subtasks
  * (:host:focus … .box uses a non-!important border). Restore it so a focused
- * subtask matches a focused parent task (both use --palette-primary-400 here). */
-.sub-tasks task:focus .box {
+ * subtask matches a focused parent task (both use --palette-primary-400 here).
+ * Scoped to .isNoTouchOnly to mirror the base ring, which is noTouchOnly-guarded
+ * (_task-base.scss:111) — no focus border on touch-only devices. */
+.isNoTouchOnly .sub-tasks task:focus .box {
   border-color: var(--palette-primary-400) !important;
 }
 


### PR DESCRIPTION
## Problem

When navigating the task list using the keyboard, subtasks do not display a visible focus indicator (focus ring). This creates the illusion that keyboard focus has been lost entirely, even though the subtask is technically focused. Resolves #8520.

## Solution

Added a specific focus style for subtasks using the `:host-context(.sub-tasks)` selector in `_task-base.scss`. When a subtask receives keyboard focus, a solid 1px focus ring of color `var(--palette-primary-400)` is now drawn around its box wrapper (`.box`), matching the focus indicator behavior of parent tasks:

```scss
:host-context(.sub-tasks):focus .inner-wrapper > .box {
  @include noTouchOnly() {
    border-color: var(--palette-primary-400) !important;
    border-style: solid !important;
    border-width: 1px !important;
  }
}
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)