### PR TITLE
docs(android): document SDK 28 (API 28) behind-keyboard add-task bar root cause

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -47,14 +47,11 @@ class CapacitorMainActivity : BridgeActivity() {
     private var isFrontendReady = false
     private var startupOverlayManager: StartupOverlayManager? = null
 
-    // SDK < 30 fallback for the add-task bar sitting behind the soft keyboard
-    // (#8508 follow-up, reported on Android 9 / API 28). See
-    // adjustWebViewForKeyboardBelowApi30. The pre-keyboard WebView bottom margin
-    // is captured so it can be restored exactly on hide; the applied inset is
-    // tracked separately so it self-corrects as the keyboard height changes.
-    private var isWebViewKeyboardInsetApplied = false
-    private var webViewOriginalBottomMargin = 0
-    private var appliedKeyboardInsetPx = 0
+    // SDK < 30 soft-keyboard workaround: the WebView's resting layout height
+    // (e.g. MATCH_PARENT), captured so it can be restored when the keyboard hides.
+    // See adjustWebViewHeightForKeyboardBelowApi30.
+    private var webViewLayoutHeightDefault: Int? = null
+
     private var isTimerCompleteReceiverRegistered = false
     private var isForegroundServiceFailureReceiverRegistered = false
 
@@ -184,6 +181,11 @@ class CapacitorMainActivity : BridgeActivity() {
         WebViewCompatibilityChecker.recordSuccessfulLoad(this, webViewCompatibility?.majorVersion)
 
 
+        // Remember the WebView's resting layout height (e.g. MATCH_PARENT) so the
+        // SDK < 30 keyboard workaround can restore it on hide. See
+        // adjustWebViewHeightForKeyboardBelowApi30.
+        webViewLayoutHeightDefault = bridge?.webView?.layoutParams?.height
+
         // Handle keyboard visibility changes
         val rootView = findViewById<View>(android.R.id.content)
         rootView.viewTreeObserver.addOnGlobalLayoutListener {
@@ -198,7 +200,7 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
-            adjustWebViewForKeyboardBelowApi30(rect, keypadHeight, isKeyboardOpen)
+            adjustWebViewHeightForKeyboardBelowApi30(rect, isKeyboardOpen)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -446,85 +448,60 @@ class CapacitorMainActivity : BridgeActivity() {
     }
 
     /**
-     * SDK < 30 fallback for the add-task bar sitting behind the soft keyboard
-     * (#8508 follow-up, reported on Android 9 / API 28).
+     * SDK < 30 soft-keyboard workaround for the add-task bar sitting behind the
+     * keyboard (#8508 follow-up, Android 9 / API 28).
      *
-     * On API < 30 under enforced edge-to-edge (targetSdk 36) the system does not
-     * resize the window for the IME and `WindowInsetsCompat.Type.ime()` is
-     * unreliable, so the edge-to-edge plugin never insets the WebView and neither
-     * the window nor the VisualViewport shrinks. `--keyboard-height` then stays 0
-     * and the `position: fixed` bar sits behind the keyboard.
-     * `getWindowVisibleDisplayFrame` (the same measurement used above for
-     * visibility) is reliable on every API level, so we lift the WebView by the
-     * exact overlap between its on-screen bottom and the visible-frame bottom
-     * (the keyboard top). Shrinking the WebView from the bottom shortens its
-     * layout viewport, so the existing CSS positions the bar above the keyboard
-     * with no web-side keyboard-height math (avoiding the reverted #8295
-     * fallback). See docs/android-edge-to-edge-keyboard.md.
+     * Root cause: the `@capawesome` edge-to-edge plugin sets the WebView
+     * `bottomMargin = 0` whenever the IME is visible (`EdgeToEdge.applyInsetsInternal`:
+     * "the system already resizes the window for the keyboard"), but under enforced
+     * edge-to-edge (targetSdk 36) the window does NOT resize on API < 30, so the
+     * WebView keeps its full height and the `position: fixed` bar sits behind the
+     * keyboard.
      *
-     * Resize-detecting and a strict no-op everywhere it isn't needed:
-     *  - API >= 30 (every device #8508/18.12.0 verified) is excluded entirely, so
-     *    this cannot perturb the behavior that was just fixed there.
-     *  - if the WebView already ends at/above the keyboard (system resized, or the
-     *    plugin inset it), the overlap is ~0 and nothing changes.
+     * We must NOT correct this via `bottomMargin`: the plugin owns that property and
+     * rewrites it on every inset dispatch, so a second writer just flickers
+     * (confirmed on an API 28 device — the margin alternated `0 ↔ lift`). WebView
+     * *padding* does not move the web layout viewport either.
      *
-     * Uses bottomMargin to match how the edge-to-edge plugin insets the WebView.
-     * On API < 30 the plugin's inset listener does not fire for the IME (that is
-     * the root cause), so capturing and restoring the pre-keyboard margin here
-     * does not fight it; if it ever does overwrite the margin, the next layout
-     * pass re-detects the overlap and re-applies.
+     * Instead, while the keyboard is up we set an explicit WebView **layout height**
+     * (to the keyboard top), and restore the resting height ([webViewLayoutHeightDefault],
+     * e.g. MATCH_PARENT) on hide. Height is a different property than the margin the
+     * plugin manages, and for an explicit-height view the bottom margin does not
+     * change the view's size — so the two never fight, and the plugin keeps doing
+     * everything else (system-bar insets AND its color overlays, so no white navbar
+     * gap). Shrinking the view shrinks the web layout viewport, so the existing CSS
+     * resolves the bar above the keyboard with no web-side keyboard-height math
+     * (avoiding the reverted #8295 fallback). The target (`rect.bottom − webViewTop`)
+     * is read from `getWindowVisibleDisplayFrame` (reliable on API 28) and does not
+     * depend on the WebView's own height, so it is stable across passes — no
+     * feedback loop. See docs/android-edge-to-edge-keyboard.md.
+     *
+     * API >= 30 is a strict no-op — the plugin stays fully in charge, so the
+     * behavior verified in 18.12.0 is unchanged.
      */
-    private fun adjustWebViewForKeyboardBelowApi30(
-        rect: Rect,
-        keypadHeight: Int,
-        isKeyboardOpen: Boolean
-    ) {
+    private fun adjustWebViewHeightForKeyboardBelowApi30(rect: Rect, isKeyboardOpen: Boolean) {
         if (android.os.Build.VERSION.SDK_INT >= 30) return
         val webView = bridge?.webView ?: return
-        val params = webView.layoutParams as? ViewGroup.MarginLayoutParams ?: return
+        val params = webView.layoutParams ?: return
+        // Ignore stale/pre-layout geometry so the height is not set from a bad frame.
+        if (isKeyboardOpen && webView.height == 0) return
 
-        if (!isKeyboardOpen) {
-            if (isWebViewKeyboardInsetApplied) {
-                if (params.bottomMargin != webViewOriginalBottomMargin) {
-                    params.bottomMargin = webViewOriginalBottomMargin
-                    webView.layoutParams = params
-                }
-                isWebViewKeyboardInsetApplied = false
-                appliedKeyboardInsetPx = 0
-            }
-            return
+        val targetHeight = if (isKeyboardOpen) {
+            val loc = IntArray(2)
+            webView.getLocationOnScreen(loc)
+            (rect.bottom - loc[1]).coerceAtLeast(0)
+        } else {
+            webViewLayoutHeightDefault ?: ViewGroup.LayoutParams.MATCH_PARENT
         }
 
-        // Keyboard is open. Ignore stale/pre-layout geometry so an already-applied
-        // inset is not yanked to 0 for a frame on a transient zero-height pass.
-        if (webView.height == 0) return
-
-        val loc = IntArray(2)
-        webView.getLocationOnScreen(loc)
-        // Positive delta => the WebView still extends below the keyboard top.
-        val delta = (loc[1] + webView.height) - rect.bottom
-        val thresholdPx = (KEYBOARD_INSET_THRESHOLD_DP * resources.displayMetrics.density).toInt()
-
-        if (!isWebViewKeyboardInsetApplied) {
-            // Nothing to do until the WebView actually sits behind the keyboard
-            // (i.e. the system/plugin did not already handle the IME).
-            if (delta <= thresholdPx) return
-            webViewOriginalBottomMargin = params.bottomMargin
-            appliedKeyboardInsetPx = 0
-            isWebViewKeyboardInsetApplied = true
-        }
-        if (kotlin.math.abs(delta) > thresholdPx) {
-            // The lift never needs to exceed the keyboard height; clamping bounds
-            // the feedback loop even if the WebView height does not shrink by the
-            // margin (e.g. the edge-to-edge plugin rewriting it on the same pass).
-            appliedKeyboardInsetPx = (appliedKeyboardInsetPx + delta).coerceIn(0, keypadHeight)
-            val newBottomMargin = webViewOriginalBottomMargin + appliedKeyboardInsetPx
-            // Skip redundant writes so a non-responsive height can't drive an
-            // endless requestLayout loop, and to avoid needless relayout churn.
-            if (newBottomMargin != params.bottomMargin) {
-                params.bottomMargin = newBottomMargin
-                webView.layoutParams = params
-            }
+        if (params.height == targetHeight) return
+        params.height = targetHeight
+        webView.layoutParams = params
+        if (BuildConfig.DEBUG) {
+            Log.d(
+                "SUPKeyboard",
+                "webView height -> $targetHeight (kbOpen=$isKeyboardOpen rectB=${rect.bottom})"
+            )
         }
     }
 
@@ -563,10 +540,5 @@ class CapacitorMainActivity : BridgeActivity() {
     companion object {
         const val WINDOW_INTERFACE_PROPERTY: String = "SUPAndroid"
         const val WINDOW_PROPERTY_F_DROID: String = "SUPFDroid"
-
-        // Dead-band (dp) for the SDK < 30 keyboard inset so it settles in a
-        // couple of layout passes instead of jittering on sub-pixel overlap.
-        // dp (not px) keeps the band visually constant across densities.
-        private const val KEYBOARD_INSET_THRESHOLD_DP = 8
     }
 }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -52,6 +52,10 @@ class CapacitorMainActivity : BridgeActivity() {
     // See adjustWebViewHeightForKeyboardBelowApi30.
     private var webViewLayoutHeightDefault: Int? = null
 
+    // Reused scratch for getLocationOnScreen in the keyboard layout listener (hot
+    // path) to avoid allocating an IntArray on every pass while the IME is up.
+    private val webViewLocationOnScreen = IntArray(2)
+
     private var isTimerCompleteReceiverRegistered = false
     private var isForegroundServiceFailureReceiverRegistered = false
 
@@ -478,6 +482,12 @@ class CapacitorMainActivity : BridgeActivity() {
      *
      * API >= 30 is a strict no-op — the plugin stays fully in charge, so the
      * behavior verified in 18.12.0 is unchanged.
+     *
+     * NOTE: [StartupOverlayManager.updateOverlayInsets] also reads the WebView's
+     * geometry (`webView.height`) to align the native startup overlay. It only
+     * stays correct because it early-returns once its input bar is visible (the
+     * keyboard phase) — i.e. it never reads the height while this method is
+     * shrinking it. Keep that guard if you touch either side.
      */
     private fun adjustWebViewHeightForKeyboardBelowApi30(rect: Rect, isKeyboardOpen: Boolean) {
         if (android.os.Build.VERSION.SDK_INT >= 30) return
@@ -486,12 +496,17 @@ class CapacitorMainActivity : BridgeActivity() {
         // Ignore stale/pre-layout geometry so the height is not set from a bad frame.
         if (isKeyboardOpen && webView.height == 0) return
 
-        val targetHeight = if (isKeyboardOpen) {
-            val loc = IntArray(2)
-            webView.getLocationOnScreen(loc)
-            (rect.bottom - loc[1]).coerceAtLeast(0)
+        val targetHeight: Int
+        if (isKeyboardOpen) {
+            webView.getLocationOnScreen(webViewLocationOnScreen)
+            val heightToKeyboardTop = rect.bottom - webViewLocationOnScreen[1]
+            // Guard against a degenerate/transient measurement collapsing the
+            // WebView to 0 — the height==0 check above would then latch and stop
+            // recomputing. Keep the current height until a sane value appears.
+            if (heightToKeyboardTop <= 0) return
+            targetHeight = heightToKeyboardTop
         } else {
-            webViewLayoutHeightDefault ?: ViewGroup.LayoutParams.MATCH_PARENT
+            targetHeight = webViewLayoutHeightDefault ?: ViewGroup.LayoutParams.MATCH_PARENT
         }
 
         if (params.height == targetHeight) return

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -198,7 +198,7 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
-            adjustWebViewForKeyboardBelowApi30(rect, isKeyboardOpen)
+            adjustWebViewForKeyboardBelowApi30(rect, keypadHeight, isKeyboardOpen)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -474,34 +474,57 @@ class CapacitorMainActivity : BridgeActivity() {
      * does not fight it; if it ever does overwrite the margin, the next layout
      * pass re-detects the overlap and re-applies.
      */
-    private fun adjustWebViewForKeyboardBelowApi30(rect: Rect, isKeyboardOpen: Boolean) {
+    private fun adjustWebViewForKeyboardBelowApi30(
+        rect: Rect,
+        keypadHeight: Int,
+        isKeyboardOpen: Boolean
+    ) {
         if (android.os.Build.VERSION.SDK_INT >= 30) return
         val webView = bridge?.webView ?: return
         val params = webView.layoutParams as? ViewGroup.MarginLayoutParams ?: return
 
-        if (isKeyboardOpen) {
-            val loc = IntArray(2)
-            webView.getLocationOnScreen(loc)
-            // Positive delta => the WebView still extends below the keyboard top.
-            val delta = (loc[1] + webView.height) - rect.bottom
-            if (!isWebViewKeyboardInsetApplied) {
-                // Nothing to do until the WebView actually sits behind the keyboard
-                // (i.e. the system/plugin did not already handle the IME).
-                if (delta <= KEYBOARD_INSET_THRESHOLD_PX) return
-                webViewOriginalBottomMargin = params.bottomMargin
+        if (!isKeyboardOpen) {
+            if (isWebViewKeyboardInsetApplied) {
+                if (params.bottomMargin != webViewOriginalBottomMargin) {
+                    params.bottomMargin = webViewOriginalBottomMargin
+                    webView.layoutParams = params
+                }
+                isWebViewKeyboardInsetApplied = false
                 appliedKeyboardInsetPx = 0
-                isWebViewKeyboardInsetApplied = true
             }
-            if (kotlin.math.abs(delta) > KEYBOARD_INSET_THRESHOLD_PX) {
-                appliedKeyboardInsetPx = (appliedKeyboardInsetPx + delta).coerceAtLeast(0)
-                params.bottomMargin = webViewOriginalBottomMargin + appliedKeyboardInsetPx
+            return
+        }
+
+        // Keyboard is open. Ignore stale/pre-layout geometry so an already-applied
+        // inset is not yanked to 0 for a frame on a transient zero-height pass.
+        if (webView.height == 0) return
+
+        val loc = IntArray(2)
+        webView.getLocationOnScreen(loc)
+        // Positive delta => the WebView still extends below the keyboard top.
+        val delta = (loc[1] + webView.height) - rect.bottom
+        val thresholdPx = (KEYBOARD_INSET_THRESHOLD_DP * resources.displayMetrics.density).toInt()
+
+        if (!isWebViewKeyboardInsetApplied) {
+            // Nothing to do until the WebView actually sits behind the keyboard
+            // (i.e. the system/plugin did not already handle the IME).
+            if (delta <= thresholdPx) return
+            webViewOriginalBottomMargin = params.bottomMargin
+            appliedKeyboardInsetPx = 0
+            isWebViewKeyboardInsetApplied = true
+        }
+        if (kotlin.math.abs(delta) > thresholdPx) {
+            // The lift never needs to exceed the keyboard height; clamping bounds
+            // the feedback loop even if the WebView height does not shrink by the
+            // margin (e.g. the edge-to-edge plugin rewriting it on the same pass).
+            appliedKeyboardInsetPx = (appliedKeyboardInsetPx + delta).coerceIn(0, keypadHeight)
+            val newBottomMargin = webViewOriginalBottomMargin + appliedKeyboardInsetPx
+            // Skip redundant writes so a non-responsive height can't drive an
+            // endless requestLayout loop, and to avoid needless relayout churn.
+            if (newBottomMargin != params.bottomMargin) {
+                params.bottomMargin = newBottomMargin
                 webView.layoutParams = params
             }
-        } else if (isWebViewKeyboardInsetApplied) {
-            params.bottomMargin = webViewOriginalBottomMargin
-            webView.layoutParams = params
-            isWebViewKeyboardInsetApplied = false
-            appliedKeyboardInsetPx = 0
         }
     }
 
@@ -541,8 +564,9 @@ class CapacitorMainActivity : BridgeActivity() {
         const val WINDOW_INTERFACE_PROPERTY: String = "SUPAndroid"
         const val WINDOW_PROPERTY_F_DROID: String = "SUPFDroid"
 
-        // Dead-band (px) for the SDK < 30 keyboard inset so it settles in a
+        // Dead-band (dp) for the SDK < 30 keyboard inset so it settles in a
         // couple of layout passes instead of jittering on sub-pixel overlap.
-        private const val KEYBOARD_INSET_THRESHOLD_PX = 16
+        // dp (not px) keeps the band visually constant across densities.
+        private const val KEYBOARD_INSET_THRESHOLD_DP = 8
     }
 }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -10,6 +10,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
@@ -45,6 +46,15 @@ class CapacitorMainActivity : BridgeActivity() {
     private var pendingShareIntent: JSONObject? = null
     private var isFrontendReady = false
     private var startupOverlayManager: StartupOverlayManager? = null
+
+    // SDK < 30 fallback for the add-task bar sitting behind the soft keyboard
+    // (#8508 follow-up, reported on Android 9 / API 28). See
+    // adjustWebViewForKeyboardBelowApi30. The pre-keyboard WebView bottom margin
+    // is captured so it can be restored exactly on hide; the applied inset is
+    // tracked separately so it self-corrects as the keyboard height changes.
+    private var isWebViewKeyboardInsetApplied = false
+    private var webViewOriginalBottomMargin = 0
+    private var appliedKeyboardInsetPx = 0
     private var isTimerCompleteReceiverRegistered = false
     private var isForegroundServiceFailureReceiverRegistered = false
 
@@ -182,13 +192,13 @@ class CapacitorMainActivity : BridgeActivity() {
             val screenHeight = rootView.rootView.height
 
             val keypadHeight = screenHeight - rect.bottom
-            if (keypadHeight > screenHeight * 0.15) {
-                // keyboard is opened
-                callJSInterfaceFunctionIfExists("next", "isKeyboardShown$", "true")
-            } else {
-                // keyboard is closed
-                callJSInterfaceFunctionIfExists("next", "isKeyboardShown$", "false")
-            }
+            val isKeyboardOpen = keypadHeight > screenHeight * 0.15
+            callJSInterfaceFunctionIfExists(
+                "next",
+                "isKeyboardShown$",
+                if (isKeyboardOpen) "true" else "false"
+            )
+            adjustWebViewForKeyboardBelowApi30(rect, isKeyboardOpen)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -435,6 +445,66 @@ class CapacitorMainActivity : BridgeActivity() {
         callJSInterfaceFunctionIfExists("next", "onResume$")
     }
 
+    /**
+     * SDK < 30 fallback for the add-task bar sitting behind the soft keyboard
+     * (#8508 follow-up, reported on Android 9 / API 28).
+     *
+     * On API < 30 under enforced edge-to-edge (targetSdk 36) the system does not
+     * resize the window for the IME and `WindowInsetsCompat.Type.ime()` is
+     * unreliable, so the edge-to-edge plugin never insets the WebView and neither
+     * the window nor the VisualViewport shrinks. `--keyboard-height` then stays 0
+     * and the `position: fixed` bar sits behind the keyboard.
+     * `getWindowVisibleDisplayFrame` (the same measurement used above for
+     * visibility) is reliable on every API level, so we lift the WebView by the
+     * exact overlap between its on-screen bottom and the visible-frame bottom
+     * (the keyboard top). Shrinking the WebView from the bottom shortens its
+     * layout viewport, so the existing CSS positions the bar above the keyboard
+     * with no web-side keyboard-height math (avoiding the reverted #8295
+     * fallback). See docs/android-edge-to-edge-keyboard.md.
+     *
+     * Resize-detecting and a strict no-op everywhere it isn't needed:
+     *  - API >= 30 (every device #8508/18.12.0 verified) is excluded entirely, so
+     *    this cannot perturb the behavior that was just fixed there.
+     *  - if the WebView already ends at/above the keyboard (system resized, or the
+     *    plugin inset it), the overlap is ~0 and nothing changes.
+     *
+     * Uses bottomMargin to match how the edge-to-edge plugin insets the WebView.
+     * On API < 30 the plugin's inset listener does not fire for the IME (that is
+     * the root cause), so capturing and restoring the pre-keyboard margin here
+     * does not fight it; if it ever does overwrite the margin, the next layout
+     * pass re-detects the overlap and re-applies.
+     */
+    private fun adjustWebViewForKeyboardBelowApi30(rect: Rect, isKeyboardOpen: Boolean) {
+        if (android.os.Build.VERSION.SDK_INT >= 30) return
+        val webView = bridge?.webView ?: return
+        val params = webView.layoutParams as? ViewGroup.MarginLayoutParams ?: return
+
+        if (isKeyboardOpen) {
+            val loc = IntArray(2)
+            webView.getLocationOnScreen(loc)
+            // Positive delta => the WebView still extends below the keyboard top.
+            val delta = (loc[1] + webView.height) - rect.bottom
+            if (!isWebViewKeyboardInsetApplied) {
+                // Nothing to do until the WebView actually sits behind the keyboard
+                // (i.e. the system/plugin did not already handle the IME).
+                if (delta <= KEYBOARD_INSET_THRESHOLD_PX) return
+                webViewOriginalBottomMargin = params.bottomMargin
+                appliedKeyboardInsetPx = 0
+                isWebViewKeyboardInsetApplied = true
+            }
+            if (kotlin.math.abs(delta) > KEYBOARD_INSET_THRESHOLD_PX) {
+                appliedKeyboardInsetPx = (appliedKeyboardInsetPx + delta).coerceAtLeast(0)
+                params.bottomMargin = webViewOriginalBottomMargin + appliedKeyboardInsetPx
+                webView.layoutParams = params
+            }
+        } else if (isWebViewKeyboardInsetApplied) {
+            params.bottomMargin = webViewOriginalBottomMargin
+            webView.layoutParams = params
+            isWebViewKeyboardInsetApplied = false
+            appliedKeyboardInsetPx = 0
+        }
+    }
+
     private fun callJSInterfaceFunctionIfExists(
         fnName: String,
         objectPath: String,
@@ -470,5 +540,9 @@ class CapacitorMainActivity : BridgeActivity() {
     companion object {
         const val WINDOW_INTERFACE_PROPERTY: String = "SUPAndroid"
         const val WINDOW_PROPERTY_F_DROID: String = "SUPFDroid"
+
+        // Dead-band (px) for the SDK < 30 keyboard inset so it settles in a
+        // couple of layout passes instead of jittering on sub-pixel overlap.
+        private const val KEYBOARD_INSET_THRESHOLD_PX = 16
     }
 }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/widget/StartupOverlayManager.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/widget/StartupOverlayManager.kt
@@ -111,6 +111,11 @@ class StartupOverlayManager(private val activity: android.app.Activity) {
         // during the keyboard phase would read ~0 and drop the bar behind the
         // keyboard. The FAB-phase value (keyboard down) is the one the keyboard
         // listener needs. This also stops dead work once the FAB is gone.
+        //
+        // This early-return is also what keeps us off CapacitorMainActivity's
+        // adjustWebViewHeightForKeyboardBelowApi30, which shrinks `webView.height`
+        // while the IME is up (API < 30): we only read the height in the keyboard-
+        // down FAB phase, never while it is being shrunk. Keep this guard.
         if (isBarVisible) return
         val webView = (activity as? BridgeActivity)?.bridge?.webView ?: return
         if (overlay.height == 0 || webView.height == 0) return

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -109,10 +109,11 @@ bar sits just above the keyboard (no behind-keyboard regression).**
 
 ## #8508 follow-up — SDK 28 (Android 9): add-task bar sits BEHIND the keyboard
 
-**Status: confirmed-by-report, NOT yet fixed.** After 18.12.0 (patch removed) a
-user on **Android 9 / API 28** reports the global add-task bar sits _below /
-behind_ the soft keyboard. This is the realization of open item #4 above, and
-the device class it predicted.
+**Status: fix implemented (`CapacitorMainActivity.adjustWebViewForKeyboardBelowApi30`),
+PENDING ON-DEVICE VALIDATION across the matrix below.** After 18.12.0 (patch
+removed) a user on **Android 9 / API 28** reports the global add-task bar sits
+_below / behind_ the soft keyboard. This is the realization of open item #4
+above, and the device class it predicted.
 
 **Why API 28 specifically.** The bar is positioned _only_ from
 `--keyboard-height`, which `GlobalThemeService._initVisualViewportKeyboardTracking()`
@@ -143,23 +144,34 @@ reverted #8295 formula in "What NOT to do" below**. On a device that _does_
 resize, that double-counts and floats the bar mid-screen. The web layer lacks
 the signal to disambiguate; native has it unambiguously.
 
-**Correct fix (native, resize-detecting — do on a device).** In the native
-layer that already has the real geometry:
+**Implemented fix (native, resize-detecting) —
+`CapacitorMainActivity.adjustWebViewForKeyboardBelowApi30`.** In the native
+layer that already has the real geometry, driven from the existing keyboard
+`OnGlobalLayoutListener`:
 
 - height source: `getWindowVisibleDisplayFrame` (works on API 28, unlike
   `Type.ime()`), not the plugin's `imeInsets.bottom`.
 - resize detection: compare the WebView's current bottom on screen against the
   visible-frame bottom (`rect.bottom`). If the WebView already ends above the
-  keyboard (system resized / margin applied), do **nothing**. Only when the
-  WebView extends _behind_ the keyboard, lift it by exactly the overlap.
-- apply only while the IME is up; restore on hide.
+  keyboard (system resized / margin applied), `delta <= threshold` → do
+  **nothing**. Only when the WebView extends _behind_ the keyboard is it lifted
+  by exactly the overlap (via `bottomMargin`, matching the plugin), tracked so it
+  self-corrects as the keyboard height changes and restores the captured margin
+  on hide.
+- gated `Build.VERSION.SDK_INT < 30` so it is a strict no-op on every device
+  18.12.0 verified — it cannot perturb the behavior that was just fixed there.
 
-This keeps it a strict no-op on every device 18.12.0 already verified (they
-resize), and only acts on the API-28-style "edge-to-edge + no resize + no
-`Type.ime()`" class. Gate it narrowly (e.g. `Build.VERSION.SDK_INT < 30`, or
-key off "WebView bottom is behind the visible frame") so it can't perturb
-API 30+ behavior. **Must be validated across the device matrix below before
-release** — this area has silently regressed at #8295 and twice at #8508.
+**Why not the web side:** see the paragraph above — `obscured` cannot
+distinguish "window resized" from "nothing resized", so a web fallback is the
+reverted #8295 formula. Native has the unambiguous geometry.
+
+**Still REQUIRED before release:** validate across the device matrix below — this
+area has silently regressed at #8295 and twice at #8508. Confirm on a real
+API < 30 device that the bar lifts above the keyboard, and on an API >= 30
+device that nothing changed. Watch for: a one-frame settle as the inset
+converges; the plugin overwriting the margin (self-heals next layout pass); and
+that the WebView background fills the lifted area (it does — `WebHelper`
+paints it).
 
 ## What NOT to do
 

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -107,6 +107,60 @@ bar sits just above the keyboard (no behind-keyboard regression).**
    On the web side, `chrome://inspect` →
    `{innerH: innerHeight, vvH: visualViewport.height, kb: getComputedStyle(document.documentElement).getPropertyValue('--keyboard-height')}`.
 
+## #8508 follow-up — SDK 28 (Android 9): add-task bar sits BEHIND the keyboard
+
+**Status: confirmed-by-report, NOT yet fixed.** After 18.12.0 (patch removed) a
+user on **Android 9 / API 28** reports the global add-task bar sits _below /
+behind_ the soft keyboard. This is the realization of open item #4 above, and
+the device class it predicted.
+
+**Why API 28 specifically.** The bar is positioned _only_ from
+`--keyboard-height`, which `GlobalThemeService._initVisualViewportKeyboardTracking()`
+derives from `obscured = window.innerHeight - visualViewport.height`. It is
+correct iff **either** the window resized for the IME **or** the VisualViewport
+shrank. On API 28 _neither_ does:
+
+1. `targetSdk 36` + the `@capawesome` edge-to-edge plugin call
+   `setDecorFitsSystemWindows(window, false)` on **all** API levels → the window
+   goes edge-to-edge → the system stops resizing for the IME.
+2. With the patch gone the plugin sets WebView `bottomMargin = 0` while the
+   keyboard is up, _relying on the system resizing_. But `WindowInsetsCompat.Type.ime()`
+   is unreliable below **API 30**, so on API 28 the plugin neither detects the
+   IME nor insets the WebView.
+3. The old WebView's VisualViewport doesn't report the obscured area either →
+   `obscured ≈ 0` → `--keyboard-height = 0` → the `position: fixed` bar sits
+   behind the keyboard.
+
+**Do NOT "fix" this on the web side.** It is tempting to feed `--keyboard-height`
+from a native height fallback (the activity already measures the IME on every
+layout pass — `CapacitorMainActivity` `OnGlobalLayoutListener`:
+`keypadHeight = screenHeight - rect.bottom`, reliable on every API level). The
+trap: `obscured` is `≈0` in **both** the working case (window resized 732→141)
+and this broken case (nothing resized), so the web side cannot tell them apart
+without tracking a baseline `innerHeight` and computing
+`max(obscured, nativeKbHeight - layoutShrink)` — which is **precisely the
+reverted #8295 formula in "What NOT to do" below**. On a device that _does_
+resize, that double-counts and floats the bar mid-screen. The web layer lacks
+the signal to disambiguate; native has it unambiguously.
+
+**Correct fix (native, resize-detecting — do on a device).** In the native
+layer that already has the real geometry:
+
+- height source: `getWindowVisibleDisplayFrame` (works on API 28, unlike
+  `Type.ime()`), not the plugin's `imeInsets.bottom`.
+- resize detection: compare the WebView's current bottom on screen against the
+  visible-frame bottom (`rect.bottom`). If the WebView already ends above the
+  keyboard (system resized / margin applied), do **nothing**. Only when the
+  WebView extends _behind_ the keyboard, lift it by exactly the overlap.
+- apply only while the IME is up; restore on hide.
+
+This keeps it a strict no-op on every device 18.12.0 already verified (they
+resize), and only acts on the API-28-style "edge-to-edge + no resize + no
+`Type.ime()`" class. Gate it narrowly (e.g. `Build.VERSION.SDK_INT < 30`, or
+key off "WebView bottom is behind the visible frame") so it can't perturb
+API 30+ behavior. **Must be validated across the device matrix below before
+release** — this area has silently regressed at #8295 and twice at #8508.
+
 ## What NOT to do
 
 Do not stack a second/third keyboard-height source on top of the VisualViewport

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -124,11 +124,14 @@ shrank. On API 28 _neither_ does:
 1. `targetSdk 36` + the `@capawesome` edge-to-edge plugin call
    `setDecorFitsSystemWindows(window, false)` on **all** API levels → the window
    goes edge-to-edge → the system stops resizing for the IME.
-2. With the patch gone the plugin sets WebView `bottomMargin = 0` while the
-   keyboard is up, _relying on the system resizing_. But `WindowInsetsCompat.Type.ime()`
-   is unreliable below **API 30**, so on API 28 the plugin neither detects the
-   IME nor insets the WebView.
-3. The old WebView's VisualViewport doesn't report the obscured area either →
+2. The plugin _does_ detect the IME on this device
+   (`WindowInsetsCompat.Type.ime()` reports visible) and sets WebView
+   `bottomMargin = 0` while the keyboard is up — `EdgeToEdge.applyInsetsInternal`:
+   "the system already resizes the window for the keyboard". But it does **not**
+   resize (point 1), so the WebView keeps its full height and the bar stays put.
+   _(An on-device logcat confirmed `keyboardVisible == true` here; the earlier
+   guess that `Type.ime()` is simply unreliable < 30 was wrong for this device.)_
+3. The WebView's VisualViewport doesn't shrink either →
    `obscured ≈ 0` → `--keyboard-height = 0` → the `position: fixed` bar sits
    behind the keyboard.
 
@@ -144,34 +147,59 @@ reverted #8295 formula in "What NOT to do" below**. On a device that _does_
 resize, that double-counts and floats the bar mid-screen. The web layer lacks
 the signal to disambiguate; native has it unambiguously.
 
-**Implemented fix (native, resize-detecting) —
-`CapacitorMainActivity.adjustWebViewForKeyboardBelowApi30`.** In the native
-layer that already has the real geometry, driven from the existing keyboard
-`OnGlobalLayoutListener`:
+**Implemented fix (native, explicit WebView height while the IME is up, scoped to
+API < 30) — `CapacitorMainActivity.adjustWebViewHeightForKeyboardBelowApi30`.**
+Driven from the existing keyboard `OnGlobalLayoutListener`:
 
-- height source: `getWindowVisibleDisplayFrame` (works on API 28, unlike
-  `Type.ime()`), not the plugin's `imeInsets.bottom`.
-- resize detection: compare the WebView's current bottom on screen against the
-  visible-frame bottom (`rect.bottom`). If the WebView already ends above the
-  keyboard (system resized / margin applied), `delta <= threshold` → do
-  **nothing**. Only when the WebView extends _behind_ the keyboard is it lifted
-  by exactly the overlap (via `bottomMargin`, matching the plugin), tracked so it
-  self-corrects as the keyboard height changes and restores the captured margin
-  on hide.
-- gated `Build.VERSION.SDK_INT < 30` so it is a strict no-op on every device
-  18.12.0 verified — it cannot perturb the behavior that was just fixed there.
+- while the keyboard is up: set an explicit WebView **layout height** to the
+  keyboard top, `height = rect.bottom − webViewTopOnScreen`
+  (`getWindowVisibleDisplayFrame`, reliable on API 28). Shrinking the view shrinks
+  the web layout viewport, so the existing CSS resolves the bar above the keyboard
+  with no web-side keyboard-height math.
+- while the keyboard is down: restore the resting height
+  (`webViewLayoutHeightDefault`, captured at startup, e.g. `MATCH_PARENT`), so the
+  plugin's normal margin-based layout applies unchanged.
+- gated `Build.VERSION.SDK_INT < 30`, so on API >= 30 it is a strict no-op and the
+  behavior verified in 18.12.0 is **untouched**.
 
-**Why not the web side:** see the paragraph above — `obscured` cannot
-distinguish "window resized" from "nothing resized", so a web fallback is the
-reverted #8295 formula. Native has the unambiguous geometry.
+> **Why height, not `bottomMargin` and not the plugin's listener.** The plugin owns
+> `webView.bottomMargin` and rewrites it to 0 on every inset dispatch while the IME
+> is visible (`EdgeToEdge.applyInsetsInternal`, because it expects the system to
+> resize — which enforced edge-to-edge prevents on API < 30). Correcting the margin
+> from a second writer made the bar **flicker constantly** (on-device logcat showed
+> the margin alternating `0 ↔ lift` every frame); WebView bottom *padding* doesn't
+> move the web layout viewport; and fully replacing the plugin's listener fixed the
+> flicker but stopped the plugin re-sizing its status/nav **color overlays**, so the
+> navbar showed a **white gap**. Setting an explicit `layout_height` is the way out:
+> it is a different property than the margin the plugin manages, and for an
+> explicit-height view the bottom margin does not change the view's size — so the two
+> never fight, and the plugin keeps doing *everything else* (insets + color overlays,
+> no white gap). The target is read from the visible frame and does not depend on the
+> WebView's own height, so it is stable pass-to-pass (no feedback loop).
+
+**Upstream status (why a local workaround at all).** This is a known, repeatedly
+regressed area in `@capawesome/capacitor-android-edge-to-edge-support` (pinned
+8.0.8): see `capawesome-team/capacitor-plugins` #845/#490/#596/#725/#819 (closed)
+and #847 (open). The buggy `keyboardVisible ? 0 : max(ime, navbar)` ternary in
+`EdgeToEdge.applyInsetsInternal` is acknowledged — the maintainer redirects to
+Capacitor core `ionic-team/capacitor#8466` (fixed for the **built-in** `SystemBars`
+by core PR #8481, merged), and plugin PR #848 ("correct WebView margin
+calculation") would fix the ternary but is **still open/unreleased**. So there is no
+shipped fix on the plugin path we use; this native workaround is independent of that
+timeline. Longer term, migrating to Capacitor 8's built-in `SystemBars`
+(`insetsHandling`) + dropping the plugin is the maintainer's implied direction.
+
+**Why not the web side:** `obscured` cannot distinguish "window resized" from
+"nothing resized", so a web `--keyboard-height` fallback is the reverted #8295
+formula. Native has the unambiguous geometry.
 
 **Still REQUIRED before release:** validate across the device matrix below — this
 area has silently regressed at #8295 and twice at #8508. Confirm on a real
-API < 30 device that the bar lifts above the keyboard, and on an API >= 30
-device that nothing changed. Watch for: a one-frame settle as the inset
-converges; the plugin overwriting the margin (self-heals next layout pass); and
-that the WebView background fills the lifted area (it does — `WebHelper`
-paints it).
+API < 30 device that the bar lands flush on the keyboard top (no white gap, no
+flicker) and that the status/nav-bar layout is unchanged with the keyboard down,
+and on an API >= 30 device that nothing changed at all. A debug-only
+`Log.d("SUPKeyboard", "webView height …")` reports each height write — in steady
+state expect one per show/hide, not a stream. Remove that log before merge.
 
 ## What NOT to do
 

--- a/docs/plans/2026-06-22-android-keyboard-and-systembars-handover.md
+++ b/docs/plans/2026-06-22-android-keyboard-and-systembars-handover.md
@@ -1,0 +1,206 @@
+# Handover: Android API < 30 keyboard fix (PR #8528) + SystemBars migration
+
+**Date:** 2026-06-22
+**Branch:** `claude/android-task-bar-keyboard-overlap-jzd814` (PR #8528), worktree
+`.worktrees/feat/pr-8528-c391fc`
+**Author of handover:** prior session (Claude)
+
+---
+
+## TL;DR
+
+- **Bug:** on Android 9 / **API 28** (the open device-class item #4 from #8508), the
+  global add-task bar sits **behind the soft keyboard**.
+- **Shipping fix (this PR, #8528):** a small **native workaround** in
+  `CapacitorMainActivity` that gives the WebView an explicit layout **height** while
+  the IME is up. Keyboard verified fixed on-device; one final visual check pending
+  (no white navbar gap). **Recommend merging this as the fix.**
+- **Migration (this handover's main ask):** move off the buggy
+  `@capawesome/capacitor-android-edge-to-edge-support` plugin to Capacitor 8's
+  **built-in `SystemBars`**. This is the right long-term direction but is a
+  **re-architecture, not a drop-in** — do it as its **own PR**, not bundled with
+  #8528. Detailed plan + gotchas below.
+
+---
+
+## 1. The shipping fix (PR #8528) — what's implemented now
+
+**File:** `android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt`
+**Method:** `adjustWebViewHeightForKeyboardBelowApi30(rect, isKeyboardOpen)`, called
+from the existing keyboard `OnGlobalLayoutListener`. Field
+`webViewLayoutHeightDefault` captures the resting height at startup.
+
+How it works:
+- API ≥ 30 → strict no-op (gate). The 18.12.0-verified path is untouched.
+- Keyboard up → set explicit WebView `layout_height = rect.bottom − webViewTopOnScreen`
+  (keyboard top, from `getWindowVisibleDisplayFrame`, reliable on API 28). Shrinks
+  the web layout viewport so the existing CSS lifts the bar above the keyboard.
+- Keyboard down → restore `webViewLayoutHeightDefault` (e.g. `MATCH_PARENT`).
+
+Why height (not margin / padding / listener takeover) — see §3.
+
+**Before merge:**
+- [ ] Remove the debug `Log.d("SUPKeyboard", ...)` in `adjustWebViewHeightForKeyboardBelowApi30`.
+- [ ] Re-title the PR `fix(android): ...` (currently `docs(android): ...`; squash subject matters).
+- [ ] On-device: bar flush above keyboard, no flicker, **no white navbar gap**, and
+      resting layout unchanged. Also sanity-check an API ≥ 30 device (no change).
+- [ ] Doc updated: `docs/android-edge-to-edge-keyboard.md` (#8508 follow-up section).
+
+---
+
+## 2. Root cause (definitive, confirmed by on-device logcat)
+
+The `@capawesome` edge-to-edge plugin (`EdgeToEdge.applyInsetsInternal`) sets the
+WebView `bottomMargin = keyboardVisible ? 0 : max(imeInsets.bottom, navbar)`.
+On this device `isVisible(ime())` returns **true**, so it zeroes the bottom margin
+while the keyboard is up — *expecting the system to resize the window*. But under
+enforced edge-to-edge (targetSdk 36, `windowOptOutEdgeToEdgeEnforcement` only opts
+out the *enforcement*, the plugin still calls `setDecorFitsSystemWindows(false)`)
+the window does **not** resize on API < 30, so the WebView keeps full height and the
+`position: fixed` bar is behind the keyboard.
+
+Logcat proof (API 28, screen 2400, keyboard top `rect.bottom=1533`): margin
+alternated `0` (plugin) ↔ `867` (our correction) every frame — the flicker.
+
+---
+
+## 3. What was tried and FAILED (do not repeat)
+
+1. **Margin, accumulate overlap** (`margin += delta`, clamp `keypadHeight`):
+   flicker + over-lift (clamp = `navbar + keypadHeight`, a white gap).
+2. **Margin, absolute target** (`margin = keypadHeight`, idempotent): still flickers
+   — the plugin rewrites `bottomMargin=0` on every inset dispatch (two writers).
+3. **WebView bottom padding**: WebView ignores View padding for the web layout
+   viewport → bar stayed behind the keyboard.
+4. **Replace the plugin's `OnApplyWindowInsetsListener`** (single-writer override):
+   fixed the keyboard, but the plugin's `updateColorOverlays` then never ran → the
+   status/nav **color overlays weren't painted → white navbar gap**.
+5. **Explicit WebView height (CURRENT):** height is a different property than the
+   margin the plugin manages, and for an explicit-height view the bottom margin does
+   not change the view size → no fight, and the plugin keeps doing everything else
+   (insets + color overlays). This is the shipping fix.
+
+Key lesson: the plugin **owns `webView.bottomMargin`** and its color overlays are
+coupled to its inset listener — don't fight either.
+
+---
+
+## 4. Upstream findings
+
+- Plugin (`@capawesome/capacitor-android-edge-to-edge-support`) pinned **8.0.8**;
+  Capacitor **^8.3.4**.
+- Repeatedly-regressed area: `capawesome-team/capacitor-plugins` issues
+  **#845** (API 29 collapse), #490, #596, #725 (the white gap), #819, #812; **#847
+  open** (Android 15+).
+- The maintainer redirects these to Capacitor core **`ionic-team/capacitor#8466`**
+  ("insetsHandling 'disable' … breaks WebView on API 29 with keyboard"), **fixed for
+  the built-in `SystemBars`** by core PR **#8481 (merged)**.
+- Plugin PR **#848** ("correct WebView margin calculation") would fix the buggy
+  ternary but is **open / unreleased**. Its premise ("API 29 resizes via
+  adjustResize") did **not** match our logcat (no resize on API 28), so even #848
+  may not fix our case. → our native workaround is independent and justified.
+
+---
+
+## 5. SystemBars migration plan (the main ask)
+
+> **⚠️ Correction (added later):** Capacitor's built-in `SystemBars` effectively
+> **no-ops below WebView 140 / API 35**, and this app supports **WebView 107+**. A
+> naive `@capawesome` → `SystemBars` swap therefore **regresses API < 35 /
+> WebView < 140** devices (the exact old-device class this whole bug is about). The
+> migration must keep a fallback for that band (or stay on the plugin there). Treat
+> §5c below as the *shape* of the work, gated behind this WebView/API check. See the
+> corrected migration plan if present.
+
+### 5a. Why it's NOT a drop-in
+`SystemBars` (in `@capacitor/core` 8.3.4) exposes only `setStyle` (light/dark
+content), `show`, `hide`, `setAnimation` — **no `setStatusBarColor` /
+`setNavigationBarColor`**. The modern edge-to-edge model is **transparent system
+bars with the web content drawn behind them**, padded via `env(safe-area-inset-*)`.
+The app currently does the opposite on purpose: `@capawesome` paints opaque color
+overlays behind the bars, and config sets `SystemBars.insetsHandling: 'disable'` +
+`windowOptOutEdgeToEdgeEnforcement=true` so the plugin owns insets. Migrating
+**reverses these deliberate choices**.
+
+### 5b. Current edge-to-edge stack (all the moving parts)
+- `capacitor.config.ts`: `SystemBars.insetsHandling: 'disable'`,
+  `EdgeToEdge.{statusBarColor,navigationBarColor}: '#131314'`,
+  `Keyboard.resizeOnFullScreen: false`, `StatusBar.overlaysWebView: true` (iOS),
+  `android.includePlugins[...]` includes the `@capawesome` edge-to-edge plugin.
+- `android/app/src/main/res/values-v35/styles.xml`:
+  `android:windowOptOutEdgeToEdgeEnforcement = true`.
+- `src/app/core/theme/global-theme.service.ts`:
+  - `StatusBar.setStyle({ Dark|Light })`
+  - `EdgeToEdge.setStatusBarColor / setNavigationBarColor` (theme bg) — **needs a
+    replacement; SystemBars has none.**
+  - app's **custom `NavigationBar` plugin** (`setColor` + `setSystemBarsAppearance`)
+    — still drives nav-bar icon/pill appearance; may be the place to keep bar color.
+  - `_initSafeAreaInsets()` + `_patchCdkViewportForSafeArea()` (via
+    `capacitor-plugin-safe-area`) — becomes MORE important under transparent bars.
+- `CapacitorMainActivity.kt`: keyboard JS-interface + the new height workaround;
+  references `bridge.webView`.
+- `StartupOverlayManager.kt`: reads the plugin-applied WebView bottom inset
+  (`webViewBottomInset`) from WebView geometry to align the native startup overlay —
+  **coupled to the plugin's insets; will need rework.**
+
+### 5c. Migration steps (suggested order, each device-validated)
+1. **Spike on a fresh branch** off master (not on #8528). Keep #8528's keyboard fix
+   independent.
+2. **Config:** remove `EdgeToEdge` plugin config; drop the plugin from
+   `android.includePlugins`; remove the dep from `package.json`; `npx cap sync`.
+   Decide `SystemBars.insetsHandling`: `'css'` (expose `env(safe-area-inset-*)`,
+   web pads itself) is the likely target — verify the core #8481 behavior.
+3. **Enforcement:** reconsider `windowOptOutEdgeToEdgeEnforcement` (likely remove so
+   Android 15+ enforces edge-to-edge natively; verify status-bar/cutout layout).
+4. **Colors:** replace `EdgeToEdge.set*BarColor` with either (a) transparent bars +
+   web background showing through (preferred, true edge-to-edge), or (b) the app's
+   custom `NavigationBar` plugin for the nav bar + `SystemBars.setStyle` for content
+   style. Status-bar color under edge-to-edge = the web content behind it.
+5. **Safe-area:** ensure `_initSafeAreaInsets` / CDK patch cover all surfaces now
+   that content draws behind the bars (bottom nav, add-task bar, dialogs, menus).
+6. **Keyboard:** re-test API < 30. With `insetsHandling` core-handled (#8481) the
+   bar-behind-keyboard bug may be resolved by core; if not, keep the
+   `adjustWebViewHeightForKeyboardBelowApi30` workaround (it's plugin-agnostic — it
+   only reads geometry — so it should still work).
+7. **StartupOverlayManager:** re-derive its inset from the new model (system insets
+   instead of the plugin's applied WebView margin).
+8. Remove now-dead pieces (the `EdgeToEdge` import in `global-theme.service.ts`, etc.).
+
+### 5d. Risks / gotchas
+- **Highest risk:** this re-touches edge-to-edge across **all** API levels and
+  themes — the exact area that silently regressed at #8295 and twice at #8508.
+- No color API → **status/nav bar appearance changes** (transparent vs opaque). Get
+  design sign-off; check light + dark themes, notch/cutout, gesture vs 3-button nav.
+- `capacitor-plugin-safe-area` + the CDK overlay patch must cover every floating
+  surface or content slides under the bars.
+- iOS path (`StatusBar.overlaysWebView`, `ios.contentInset/backgroundColor`) is
+  separate — verify the migration doesn't disturb it.
+
+### 5e. Validation matrix (minimum)
+API 28/29 (no edge-to-edge resize), API 30–34, API 35+ (enforced edge-to-edge);
+light + dark theme; gesture + 3-button nav; device with a display cutout; keyboard
+open/close on each; rotation. Watch: bar colors, content behind bars, add-task bar
+vs keyboard, startup overlay alignment.
+
+---
+
+## 6. Recommendation / sequencing
+
+1. **Merge #8528** (height workaround) to fix the user's reported bug now — low
+   risk, scoped to API < 30, plugin untouched.
+2. **Then** do the SystemBars migration as its own spike → PR, using §5. Treat it as
+   a deliberate edge-to-edge re-architecture with full device-matrix validation, not
+   a quick swap. Link the PR to `ionic-team/capacitor#8466`, core #8481, plugin #848.
+3. Open a tracking issue: "Migrate Android edge-to-edge from @capawesome plugin to
+   Capacitor built-in SystemBars" referencing this handover.
+
+---
+
+## Key files
+- `android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt` (keyboard workaround)
+- `android/app/src/main/java/com/superproductivity/superproductivity/widget/StartupOverlayManager.kt` (inset coupling)
+- `src/app/core/theme/global-theme.service.ts` (EdgeToEdge color calls, safe-area, NavigationBar)
+- `capacitor.config.ts` (plugin config, insetsHandling, includePlugins)
+- `android/app/src/main/res/values-v35/styles.xml` (edge-to-edge opt-out)
+- `docs/android-edge-to-edge-keyboard.md` (full history + current fix)
+- Plugin source (reference): `node_modules/@capawesome/capacitor-android-edge-to-edge-support/android/src/main/java/io/capawesome/capacitorjs/plugins/androidedgetoedgesupport/EdgeToEdge.java`


### PR DESCRIPTION
After #8508 (patch removed in 18.12.0) a user on Android 9 / API 28 reports the
global add-task bar sitting behind the soft keyboard — the device class open
item #4 predicted.

Capture the precise root cause (edge-to-edge forces no system resize; Type.ime()
unreliable < API 30; old WebView VisualViewport doesn't shrink, so
--keyboard-height stays 0) and why a web-side height fallback is the reverted
#8295 trap (obscured ≈ 0 in both the resized and non-resized cases). Record the
correct resize-detecting native fix recipe and the device-matrix gate it needs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017gqH2i456UwdTJXwW5YHPs