### PR TITLE
fix(sync): silence lock-timeout snack on automatic syncs (#7562)

### DIFF
--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -30,6 +30,7 @@ import {
 import {
   SyncAlreadyInProgressError,
   LocalDataConflictError,
+  LockAcquisitionTimeoutError,
   MissingRefreshTokenAPIError,
   JsonParseError,
   SyncDataCorruptedError,
@@ -1146,6 +1147,35 @@ describe('SyncWrapperService', () => {
       // ERROR snack, so a future refactor that re-classifies 504 is caught.
       mockSyncService.downloadRemoteOps.and.returnValue(
         Promise.reject(new Error('HTTP 504 Gateway Timeout')),
+      );
+
+      const result = await service.sync();
+
+      expect(result).toBe('HANDLED_ERROR');
+      expect(mockSnackService.open).not.toHaveBeenCalled();
+    });
+
+    it('should surface a lock-acquisition timeout for user-triggered syncs', async () => {
+      mockSyncService.downloadRemoteOps.and.returnValue(
+        Promise.reject(new LockAcquisitionTimeoutError('sp_op_log', 30000)),
+      );
+
+      const result = await service.sync(true);
+
+      expect(result).toBe('HANDLED_ERROR');
+      expect(mockSnackService.open).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          msg: T.F.SYNC.S.LOCK_TIMEOUT_ERROR,
+        }),
+      );
+    });
+
+    it('should silence a lock-acquisition timeout for automatic syncs', async () => {
+      // #7562: a lock timeout is self-healing (the next cycle retries once the
+      // holder frees) and since #8306 it no longer wedges the write queue, so an
+      // automatic resume/interval sync should not flash the "try again" snack.
+      mockSyncService.downloadRemoteOps.and.returnValue(
+        Promise.reject(new LockAcquisitionTimeoutError('sp_op_log', 30000)),
       );
 
       const result = await service.sync();

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -791,10 +791,18 @@ export class SyncWrapperService {
         SyncLog.err(
           `Lock acquisition timed out for "${error.lockName}" after ${error.timeoutMs}ms`,
         );
-        this._snackService.open({
-          msg: T.F.SYNC.S.LOCK_TIMEOUT_ERROR,
-          type: 'ERROR',
-        });
+        // Self-healing like the network/timeout branches below: the lock is held
+        // by another in-flight op-log operation (compaction, a prior cycle, a
+        // queued write) and the next sync cycle retries once it frees. Since
+        // #8306 a lock timeout no longer wedges the write queue, so for automatic
+        // syncs (resume/focus/interval) the snack would just flash and vanish on
+        // its own — only surface it when the user explicitly asked to sync.
+        if (isUserTriggered) {
+          this._snackService.open({
+            msg: T.F.SYNC.S.LOCK_TIMEOUT_ERROR,
+            type: 'ERROR',
+          });
+        }
         return 'HANDLED_ERROR';
       } else if (error instanceof LocalDataConflictError) {
         // File-based sync: Local data exists and remote snapshot would overwrite it


### PR DESCRIPTION
## What

Gates the `LOCK_TIMEOUT_ERROR` snackbar ("Sync timed out waiting for a previous operation to finish. Please try again.") on `isUserTriggered`, so it no longer fires on **automatic** syncs (resume / focus / interval).

## Why

Part of triaging #7562 (Bug 1). A `LockAcquisitionTimeoutError` is self-healing — the next sync cycle retries once the lock holder frees — and since #8306 it no longer wedges the write queue. So on an automatic sync the snack just flashes and vanishes on its own, which is exactly the noise the adjacent `NETWORK_ERROR` and `TIMEOUT_ERROR` branches already suppress for automatic syncs. This change makes the lock-timeout branch consistent with them.

The diagnostic `SyncLog.err(...)` line stays **unconditional**, so every occurrence is still recorded in the sync log. User-triggered syncs still surface the snack unchanged.

## Not in scope

This addresses only the snackbar noise (Bug 1's residual symptom — the cascade itself was already fixed in #8306, shipped ~v18.11.0). **Bug 2** in #7562 (a stale device overwriting newer data) is a separate data-loss investigation that needs reporter sync logs to pin down the trigger before a safe fix can be made; it is intentionally not touched here.

## Testing

- `src/app/imex/sync/sync-wrapper.service.spec.ts`: +2 tests asserting the snack shows for user-triggered syncs and is silenced for automatic ones.
- Full spec file passes (125/125); both files pass `npm run checkFile`.

## Note on status handling

The lock-timeout branch does not call `setSyncStatus('UNKNOWN_OR_CHANGED')`, but the `finally` safeguard in `sync()` already resets `'SYNCING' → 'UNKNOWN_OR_CHANGED'` for any branch that returns without a final status (`isSyncInProgress` is true for `'SYNCING'`). So the end state matches the network/timeout branches. This is unchanged, pre-existing behavior.

Refs #7562
