### PR TITLE
refactor: add type annotation to DEFAULT_SNACK_CFG

### DIFF
--- a/src/app/core/snack/snack.const.ts
+++ b/src/app/core/snack/snack.const.ts
@@ -1,3 +1,3 @@
-export const DEFAULT_SNACK_CFG = {
+export const DEFAULT_SNACK_CFG: { duration: number } = {
   duration: 3000,
 };


### PR DESCRIPTION
### 问题背景
常量 `DEFAULT_SNACK_CFG` 缺少显式类型注解。虽然 TypeScript 可以推断类型，但显式注解可以提高代码清晰度和类型安全性，尤其是在公共 API 中，有助于减少潜在错误并增强代码可维护性。

### 修改内容
- **修改了什么**：为 `DEFAULT_SNACK_CFG` 常量添加了显式类型注解 `{ duration: number }`。
- **为什么这样改**：提升类型安全性，使代码更易读和维护，符合 TypeScript 最佳实践。
- **对代码质量/性能/安全性的提升**：增强类型检查，减少运行时错误风险，不改变功能，仅改进代码质量。

### 验证方式
- 通过现有 TypeScript 编译检查，确保无类型错误。
- 运行现有测试套件，验证功能不变。
- 手动检查应用行为，确认无 breaking changes。

### 其他信息
- **Breaking changes**：无，仅添加类型注解，不影响外部 API 或功能。
- **文档更新**：不需要，因为是内部代码改进。
- **已知限制**：无。