### PR TITLE
feat(plugins): generic OAuth hooks for issue-provider plugins

### DIFF
--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -268,7 +268,7 @@ export interface ElectronAPI {
   consumePluginNodeExecutionApi(): PluginNodeExecutionElectronApi | null;
 
   // Plugin OAuth
-  pluginOAuthPrepare(): Promise<{ port: number }>;
+  pluginOAuthPrepare(port?: number): Promise<{ port: number }>;
   pluginOAuthStart(url: string): void;
   onPluginOAuthCb(
     listener: (data: { code?: string; error?: string; state?: string }) => void,

--- a/electron/plugin-oauth.ts
+++ b/electron/plugin-oauth.ts
@@ -1,6 +1,10 @@
 import { BrowserWindow, ipcMain, shell } from 'electron';
 import { createServer, Server } from 'http';
 import { IPC } from './shared-with-frontend/ipc-events.const';
+import {
+  OAUTH_LOOPBACK_PORT_MIN,
+  OAUTH_LOOPBACK_PORT_MAX,
+} from './shared-with-frontend/oauth-loopback.const';
 import { log } from 'electron-log/main';
 
 const LOOPBACK_HOST = '127.0.0.1';
@@ -46,12 +50,12 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
         if (requestedPort !== undefined) {
           if (
             !Number.isInteger(requestedPort) ||
-            requestedPort < 1024 ||
-            requestedPort > 65535
+            requestedPort < OAUTH_LOOPBACK_PORT_MIN ||
+            requestedPort > OAUTH_LOOPBACK_PORT_MAX
           ) {
             reject(
               new Error(
-                `Invalid OAuth loopback port ${requestedPort}; must be an integer in [1024, 65535].`,
+                `Invalid OAuth loopback port ${requestedPort}; must be an integer in [${OAUTH_LOOPBACK_PORT_MIN}, ${OAUTH_LOOPBACK_PORT_MAX}].`,
               ),
             );
             return;
@@ -89,7 +93,9 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
         });
 
         server.on('error', (err) => {
-          server.close();
+          cleanupServer();
+          // Note: EADDRINUSE message interpolates port which is 0 only in the system-assigned
+          // (no requested port) case — where EADDRINUSE effectively cannot occur.
           if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
             reject(
               new Error(

--- a/electron/plugin-oauth.ts
+++ b/electron/plugin-oauth.ts
@@ -34,62 +34,80 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
   // Prepare: start a loopback HTTP server and return the port.
   // Google Desktop OAuth requires http://127.0.0.1:<port> redirect URIs
   // and blocks embedded webviews, so we open the system browser instead.
-  ipcMain.handle(IPC.PLUGIN_OAUTH_PREPARE, async (): Promise<{ port: number }> => {
-    cleanupServer();
+  ipcMain.handle(
+    IPC.PLUGIN_OAUTH_PREPARE,
+    async (_event, requestedPort?: number): Promise<{ port: number }> => {
+      cleanupServer();
 
-    return new Promise<{ port: number }>((resolve, reject) => {
-      let handled = false;
+      return new Promise<{ port: number }>((resolve, reject) => {
+        let handled = false;
 
-      const server = createServer((req, res) => {
-        if (handled) {
+        const server = createServer((req, res) => {
+          if (handled) {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end(SUCCESS_HTML);
+            return;
+          }
+          handled = true;
+
+          const url = new URL(req.url!, `http://${LOOPBACK_HOST}`);
+          const code = url.searchParams.get('code');
+          const error = url.searchParams.get('error');
+          const state = url.searchParams.get('state');
+
           // eslint-disable-next-line @typescript-eslint/naming-convention
           res.writeHead(200, { 'Content-Type': 'text/html' });
           res.end(SUCCESS_HTML);
-          return;
-        }
-        handled = true;
 
-        const url = new URL(req.url!, `http://${LOOPBACK_HOST}`);
-        const code = url.searchParams.get('code');
-        const error = url.searchParams.get('error');
-        const state = url.searchParams.get('state');
+          mainWin.webContents.send(IPC.PLUGIN_OAUTH_CB, { code, error, state });
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end(SUCCESS_HTML);
+          // Re-focus the main window after auth completes
+          if (!mainWin.isDestroyed()) {
+            mainWin.show();
+            mainWin.focus();
+          }
 
-        mainWin.webContents.send(IPC.PLUGIN_OAUTH_CB, { code, error, state });
+          cleanupServer();
+        });
 
-        // Re-focus the main window after auth completes
-        if (!mainWin.isDestroyed()) {
-          mainWin.show();
-          mainWin.focus();
-        }
+        const port =
+          typeof requestedPort === 'number' &&
+          Number.isInteger(requestedPort) &&
+          requestedPort > 0
+            ? requestedPort
+            : 0;
 
-        cleanupServer();
+        server.listen(port, LOOPBACK_HOST, () => {
+          const addr = server.address();
+          if (addr && typeof addr !== 'string') {
+            loopbackServer = server;
+            oauthTimeoutId = setTimeout(() => {
+              log('Plugin OAuth: Timeout – closing abandoned loopback server');
+              cleanupServer();
+            }, OAUTH_TIMEOUT_MS);
+            log(`Plugin OAuth: Loopback server listening on port ${addr.port}`);
+            resolve({ port: addr.port });
+          } else {
+            server.close();
+            reject(new Error('Failed to start OAuth loopback server'));
+          }
+        });
+
+        server.on('error', (err) => {
+          if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
+            reject(
+              new Error(
+                `OAuth loopback port ${port} is already in use. Close the app using it and try again.`,
+              ),
+            );
+          } else {
+            reject(err);
+          }
+        });
       });
-
-      server.listen(0, LOOPBACK_HOST, () => {
-        const addr = server.address();
-        if (addr && typeof addr !== 'string') {
-          loopbackServer = server;
-          oauthTimeoutId = setTimeout(() => {
-            log('Plugin OAuth: Timeout – closing abandoned loopback server');
-            cleanupServer();
-          }, OAUTH_TIMEOUT_MS);
-          log(`Plugin OAuth: Loopback server listening on port ${addr.port}`);
-          resolve({ port: addr.port });
-        } else {
-          server.close();
-          reject(new Error('Failed to start OAuth loopback server'));
-        }
-      });
-
-      server.on('error', (err) => {
-        reject(err);
-      });
-    });
-  });
+    },
+  );
 
   // Open the auth URL in the system browser (not an embedded webview).
   // Google blocks OAuth in embedded browsers (Electron BrowserWindow).

--- a/electron/plugin-oauth.ts
+++ b/electron/plugin-oauth.ts
@@ -42,6 +42,23 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
       return new Promise<{ port: number }>((resolve, reject) => {
         let handled = false;
 
+        let port = 0;
+        if (requestedPort !== undefined) {
+          if (
+            !Number.isInteger(requestedPort) ||
+            requestedPort < 1024 ||
+            requestedPort > 65535
+          ) {
+            reject(
+              new Error(
+                `Invalid OAuth loopback port ${requestedPort}; must be an integer in [1024, 65535].`,
+              ),
+            );
+            return;
+          }
+          port = requestedPort;
+        }
+
         const server = createServer((req, res) => {
           if (handled) {
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -71,12 +88,18 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
           cleanupServer();
         });
 
-        const port =
-          typeof requestedPort === 'number' &&
-          Number.isInteger(requestedPort) &&
-          requestedPort > 0
-            ? requestedPort
-            : 0;
+        server.on('error', (err) => {
+          server.close();
+          if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
+            reject(
+              new Error(
+                `OAuth loopback port ${port} is already in use. Close the app using it and try again.`,
+              ),
+            );
+          } else {
+            reject(err);
+          }
+        });
 
         server.listen(port, LOOPBACK_HOST, () => {
           const addr = server.address();
@@ -91,18 +114,6 @@ export const initPluginOAuth = (mainWin: BrowserWindow): void => {
           } else {
             server.close();
             reject(new Error('Failed to start OAuth loopback server'));
-          }
-        });
-
-        server.on('error', (err) => {
-          if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
-            reject(
-              new Error(
-                `OAuth loopback port ${port} is already in use. Close the app using it and try again.`,
-              ),
-            );
-          } else {
-            reject(err);
           }
         });
       });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -270,7 +270,8 @@ const ea: ElectronAPI = {
   },
 
   // Plugin OAuth
-  pluginOAuthPrepare: () => _invoke('PLUGIN_OAUTH_PREPARE') as Promise<{ port: number }>,
+  pluginOAuthPrepare: (port?: number) =>
+    _invoke('PLUGIN_OAUTH_PREPARE', port) as Promise<{ port: number }>,
   pluginOAuthStart: (url: string) => _send('PLUGIN_OAUTH_START', { url }),
   onPluginOAuthCb: (
     listener: (data: { code?: string; error?: string; state?: string }) => void,

--- a/electron/shared-with-frontend/oauth-loopback.const.ts
+++ b/electron/shared-with-frontend/oauth-loopback.const.ts
@@ -1,0 +1,4 @@
+// Allowed range for the OAuth loopback redirect port. Shared between the renderer
+// (redirectUri validation) and the Electron main process (IPC bind) so the two never drift.
+export const OAUTH_LOOPBACK_PORT_MIN = 1024;
+export const OAUTH_LOOPBACK_PORT_MAX = 65535;

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -417,8 +417,13 @@ export interface OAuthFlowConfig {
   /** Additional query parameters to append to the authorization URL (e.g. access_type, prompt). */
   extraAuthParams?: Record<string, string>;
   /**
-   * Optional redirect URI override for providers or user-supplied OAuth apps
-   * that require an exact pre-registered callback instead of the host default.
+   * Optional redirect URI override for the desktop (Electron) loopback flow — e.g.
+   * a user-supplied OAuth app that requires an exact pre-registered
+   * `http://127.0.0.1:<port>/...` callback instead of the host default.
+   *
+   * Desktop-only: web and native each have a single valid callback (the host's
+   * `/assets/oauth-callback.html` page and the app's fixed custom scheme), so this
+   * field is ignored (stripped) on those platforms and the platform default is used.
    */
   redirectUri?: string;
 }

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -408,6 +408,11 @@ export interface OAuthFlowConfig {
   scopes: string[];
   /** Additional query parameters to append to the authorization URL (e.g. access_type, prompt). */
   extraAuthParams?: Record<string, string>;
+  /**
+   * Optional redirect URI override for providers or user-supplied OAuth apps
+   * that require an exact pre-registered callback instead of the host default.
+   */
+  redirectUri?: string;
 }
 
 export interface OAuthTokenResult {

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -375,6 +375,14 @@ export interface PluginWorkContextHeaderBtnCfg {
   showFor: ('PROJECT' | 'TAG' | 'TODAY')[];
 }
 
+/**
+ * OAuth configuration for starting an OAuth flow.
+ *
+ * Bring-your-own credentials: an issue-provider plugin may let users override the
+ * clientId / clientSecret / redirectUri at runtime by writing them under
+ * `pluginConfig.oauthOverrides = { clientId?, clientSecret?, redirectUri? }`. These
+ * overrides apply only to the desktop (Electron loopback) flow and are ignored on web/native.
+ */
 export interface OAuthFlowConfig {
   authUrl: string;
   tokenUrl: string;

--- a/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
@@ -55,12 +55,12 @@ import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
-import { devError } from '../../../util/dev-error';
 import { IssueLog } from '../../../core/log';
 import { PluginIssueProviderRegistryService } from '../../../plugins/issue-provider/plugin-issue-provider-registry.service';
 import { PluginBridgeService } from '../../../plugins/plugin-bridge.service';
 import { PluginHttpService } from '../../../plugins/issue-provider/plugin-http.service';
 import { OAuthFlowConfig, PluginSyncDirection } from '@super-productivity/plugin-api';
+import { applyPluginOAuthOverrides } from './plugin-oauth-config-overrides.util';
 import { IS_NATIVE_PLATFORM } from '../../../util/is-native-platform';
 // Trello is now a plugin — board selection is a dynamic `loadOptions` select field
 // ClickUp is now a plugin — no built-in config component needed
@@ -72,6 +72,7 @@ import { ISSUE_PROVIDER_COMMON_FORM_FIELDS } from '../common-issue-form-stuff.co
 import { TagService } from '../../tag/tag.service';
 import { ChipListInputComponent } from '../../../ui/chip-list-input/chip-list-input.component';
 import { unique } from '../../../util/unique';
+import { mergeIssueProviderModelUpdates } from './issue-provider-model-merge.util';
 
 @Component({
   selector: 'dialog-edit-issue-provider',
@@ -266,24 +267,7 @@ export class DialogEditIssueProviderComponent {
   }
 
   updateModel(model: Partial<IssueProvider>): void {
-    // NOTE: this currently throws an error when loading issue point stuff for jira
-    try {
-      Object.keys(model).forEach((key) => {
-        if (key !== 'isEnabled') {
-          this.model![key] = model[key];
-        }
-      });
-    } catch (e) {
-      devError(e);
-      const updates: any = {};
-      Object.keys(model).forEach((key) => {
-        if (key !== 'isEnabled') {
-          updates[key] = model[key as keyof IssueProvider];
-        }
-      });
-      this.model = { ...this.model, ...updates };
-    }
-
+    this.model = mergeIssueProviderModelUpdates(this.model, model);
     this.isConnectionWorks.set(false);
   }
 
@@ -365,9 +349,10 @@ export class DialogEditIssueProviderComponent {
     if (!pluginId) {
       return;
     }
+    const effectiveOAuthConfig = this._withPluginOAuthOverrides(oauthConfig);
     this.isOAuthConnecting.set(true);
     try {
-      await this._pluginBridge.startOAuthFlow(pluginId, oauthConfig);
+      await this._pluginBridge.startOAuthFlow(pluginId, effectiveOAuthConfig);
     } catch (e) {
       const detail = (e instanceof Error ? e.message : String(e))
         .replace(/\s+/g, ' ')
@@ -731,6 +716,16 @@ export class DialogEditIssueProviderComponent {
       props: { label: T.F.ISSUE.TWO_WAY_SYNC.SECTION },
       fieldGroup: syncFields,
     };
+  }
+
+  private _withPluginOAuthOverrides(oauthConfig: OAuthFlowConfig): OAuthFlowConfig {
+    return applyPluginOAuthOverrides(
+      oauthConfig,
+      ((this.model as Record<string, unknown>)['pluginConfig'] || {}) as Record<
+        string,
+        unknown
+      >,
+    );
   }
 
   private _getOAuthButtons(): {

--- a/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
@@ -725,6 +725,7 @@ export class DialogEditIssueProviderComponent {
         string,
         unknown
       >,
+      IS_ELECTRON,
     );
   }
 

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
@@ -122,4 +122,23 @@ describe('issue-provider-model-merge.util', () => {
       },
     });
   });
+
+  it('does not apply prototype-polluting keys (__proto__, constructor, prototype)', () => {
+    // Build the malicious update via JSON.parse so __proto__/constructor are real own
+    // enumerable keys (the actual pollution vector), not object-literal special forms.
+    const maliciousPluginConfig = JSON.parse(
+      '{"__proto__":{"polluted":"x"},"constructor":{"polluted":"y"},"prototype":{"polluted":"z"},"safe":"updated"}',
+    );
+    const result = mergeIssueProviderModelUpdates(
+      { pluginConfig: { safe: 'value' } } as any,
+      { pluginConfig: maliciousPluginConfig } as any,
+    );
+
+    const merged = (result as { pluginConfig?: Record<string, unknown> }).pluginConfig!;
+    // The safe key is updated, the polluting keys are skipped, and nothing leaks to Object.prototype.
+    expect(merged['safe']).toBe('updated');
+    expect(Object.prototype.hasOwnProperty.call(merged, 'constructor')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(merged, 'prototype')).toBe(false);
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
 });

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
@@ -1,0 +1,98 @@
+import { mergeIssueProviderModelUpdates } from './issue-provider-model-merge.util';
+
+describe('issue-provider-model-merge.util', () => {
+  it('preserves omitted pluginConfig keys during partial updates', () => {
+    const result = mergeIssueProviderModelUpdates(
+      {
+        pluginConfig: {
+          accountId: '1',
+          bucketId: '10',
+          todolistId: '100',
+        },
+      } as any,
+      {
+        pluginConfig: {
+          accountId: '1',
+        },
+      } as any,
+    );
+
+    expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
+      accountId: '1',
+      bucketId: '10',
+      todolistId: '100',
+    });
+  });
+
+  it('allows explicit pluginConfig clears to overwrite existing values', () => {
+    const result = mergeIssueProviderModelUpdates(
+      {
+        pluginConfig: {
+          accountId: '1',
+          bucketId: '10',
+          todolistId: '100',
+        },
+      } as any,
+      {
+        pluginConfig: {
+          bucketId: '',
+          todolistId: '',
+        },
+      } as any,
+    );
+
+    expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
+      accountId: '1',
+      bucketId: '',
+      todolistId: '',
+    });
+  });
+
+  it('merges nested twoWaySync updates instead of replacing them wholesale', () => {
+    const result = mergeIssueProviderModelUpdates(
+      {
+        pluginConfig: {
+          twoWaySync: {
+            isDone: 'both',
+            title: 'pullOnly',
+          },
+        },
+      } as any,
+      {
+        pluginConfig: {
+          twoWaySync: {
+            isDone: 'off',
+          },
+        },
+      } as any,
+    );
+
+    expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
+      twoWaySync: {
+        isDone: 'off',
+        title: 'pullOnly',
+      },
+    });
+  });
+
+  it('ignores isEnabled in the update (does not overwrite the current value)', () => {
+    const result = mergeIssueProviderModelUpdates(
+      { isEnabled: true, pluginConfig: { accountId: '1' } } as any,
+      { isEnabled: false, pluginConfig: { accountId: '1' } } as any,
+    );
+
+    expect((result as { isEnabled?: boolean }).isEnabled).toBe(true);
+  });
+
+  it('overwrites a non-pluginConfig field while preserving an omitted pluginConfig', () => {
+    const result = mergeIssueProviderModelUpdates(
+      { defaultProjectId: 'p1', pluginConfig: { accountId: '1' } } as any,
+      { defaultProjectId: 'p2' } as any,
+    );
+
+    expect((result as { defaultProjectId?: string }).defaultProjectId).toBe('p2');
+    expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
+      accountId: '1',
+    });
+  });
+});

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
@@ -48,7 +48,7 @@ describe('issue-provider-model-merge.util', () => {
     });
   });
 
-  it('merges nested twoWaySync updates instead of replacing them wholesale', () => {
+  it('replaces a nested twoWaySync object wholesale (callers always emit a complete twoWaySync)', () => {
     const result = mergeIssueProviderModelUpdates(
       {
         pluginConfig: {
@@ -70,7 +70,6 @@ describe('issue-provider-model-merge.util', () => {
     expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
       twoWaySync: {
         isDone: 'off',
-        title: 'pullOnly',
       },
     });
   });
@@ -94,51 +93,5 @@ describe('issue-provider-model-merge.util', () => {
     expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
       accountId: '1',
     });
-  });
-
-  it('recursively merges nested objects in pluginConfig other than twoWaySync', () => {
-    const result = mergeIssueProviderModelUpdates(
-      {
-        pluginConfig: {
-          nestedSettings: {
-            option1: 'value1',
-            option2: 'value2',
-          },
-        },
-      } as any,
-      {
-        pluginConfig: {
-          nestedSettings: {
-            option1: 'updated1',
-          },
-        },
-      } as any,
-    );
-
-    expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
-      nestedSettings: {
-        option1: 'updated1',
-        option2: 'value2',
-      },
-    });
-  });
-
-  it('does not apply prototype-polluting keys (__proto__, constructor, prototype)', () => {
-    // Build the malicious update via JSON.parse so __proto__/constructor are real own
-    // enumerable keys (the actual pollution vector), not object-literal special forms.
-    const maliciousPluginConfig = JSON.parse(
-      '{"__proto__":{"polluted":"x"},"constructor":{"polluted":"y"},"prototype":{"polluted":"z"},"safe":"updated"}',
-    );
-    const result = mergeIssueProviderModelUpdates(
-      { pluginConfig: { safe: 'value' } } as any,
-      { pluginConfig: maliciousPluginConfig } as any,
-    );
-
-    const merged = (result as { pluginConfig?: Record<string, unknown> }).pluginConfig!;
-    // The safe key is updated, the polluting keys are skipped, and nothing leaks to Object.prototype.
-    expect(merged['safe']).toBe('updated');
-    expect(Object.prototype.hasOwnProperty.call(merged, 'constructor')).toBe(false);
-    expect(Object.prototype.hasOwnProperty.call(merged, 'prototype')).toBe(false);
-    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
   });
 });

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.spec.ts
@@ -95,4 +95,31 @@ describe('issue-provider-model-merge.util', () => {
       accountId: '1',
     });
   });
+
+  it('recursively merges nested objects in pluginConfig other than twoWaySync', () => {
+    const result = mergeIssueProviderModelUpdates(
+      {
+        pluginConfig: {
+          nestedSettings: {
+            option1: 'value1',
+            option2: 'value2',
+          },
+        },
+      } as any,
+      {
+        pluginConfig: {
+          nestedSettings: {
+            option1: 'updated1',
+          },
+        },
+      } as any,
+    );
+
+    expect((result as { pluginConfig?: Record<string, unknown> }).pluginConfig).toEqual({
+      nestedSettings: {
+        option1: 'updated1',
+        option2: 'value2',
+      },
+    });
+  });
 });

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
@@ -15,7 +15,13 @@ const mergePluginConfig = (
   }
 
   const merged = { ...current };
+  // Deep merge is intentional; nested keys clear only by explicit value, never by omission.
   for (const [key, updateValue] of Object.entries(update)) {
+    // Defense-in-depth: skip prototype-polluting keys (pluginConfig comes from form models,
+    // not raw JSON.parse, but filter defensively anyway).
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
     if (isPlainObject(current[key]) && isPlainObject(updateValue)) {
       merged[key] = mergePluginConfig(current[key], updateValue);
     } else {

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
@@ -1,0 +1,66 @@
+import { IssueProvider } from '../issue.model';
+
+const mergePluginConfig = (
+  current: Record<string, unknown> | undefined,
+  update: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined => {
+  if (!current) {
+    return update;
+  }
+  if (!update) {
+    return current;
+  }
+
+  const merged = { ...current, ...update };
+  const currentTwoWaySync = current['twoWaySync'];
+  const updateTwoWaySync = update['twoWaySync'];
+
+  if (
+    currentTwoWaySync &&
+    updateTwoWaySync &&
+    typeof currentTwoWaySync === 'object' &&
+    typeof updateTwoWaySync === 'object' &&
+    !Array.isArray(currentTwoWaySync) &&
+    !Array.isArray(updateTwoWaySync)
+  ) {
+    merged['twoWaySync'] = {
+      ...(currentTwoWaySync as Record<string, unknown>),
+      ...(updateTwoWaySync as Record<string, unknown>),
+    };
+  }
+
+  return merged;
+};
+
+export const mergeIssueProviderModelUpdates = (
+  currentModel: Partial<IssueProvider>,
+  update: Partial<IssueProvider>,
+): Partial<IssueProvider> => {
+  const currentRecord = currentModel as Record<string, unknown>;
+  const updateRecord = update as Record<string, unknown>;
+  const next: Record<string, unknown> = { ...currentRecord };
+
+  Object.keys(updateRecord).forEach((key) => {
+    if (key === 'isEnabled') {
+      return;
+    }
+
+    const updateValue = updateRecord[key];
+    if (
+      key === 'pluginConfig' &&
+      updateValue &&
+      typeof updateValue === 'object' &&
+      !Array.isArray(updateValue)
+    ) {
+      next[key] = mergePluginConfig(
+        currentRecord[key] as Record<string, unknown> | undefined,
+        updateValue as Record<string, unknown>,
+      );
+      return;
+    }
+
+    next[key] = updateValue;
+  });
+
+  return next as Partial<IssueProvider>;
+};

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
@@ -1,5 +1,8 @@
 import { IssueProvider } from '../issue.model';
 
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
 const mergePluginConfig = (
   current: Record<string, unknown> | undefined,
   update: Record<string, unknown> | undefined,
@@ -11,22 +14,13 @@ const mergePluginConfig = (
     return current;
   }
 
-  const merged = { ...current, ...update };
-  const currentTwoWaySync = current['twoWaySync'];
-  const updateTwoWaySync = update['twoWaySync'];
-
-  if (
-    currentTwoWaySync &&
-    updateTwoWaySync &&
-    typeof currentTwoWaySync === 'object' &&
-    typeof updateTwoWaySync === 'object' &&
-    !Array.isArray(currentTwoWaySync) &&
-    !Array.isArray(updateTwoWaySync)
-  ) {
-    merged['twoWaySync'] = {
-      ...(currentTwoWaySync as Record<string, unknown>),
-      ...(updateTwoWaySync as Record<string, unknown>),
-    };
+  const merged = { ...current };
+  for (const [key, updateValue] of Object.entries(update)) {
+    if (isPlainObject(current[key]) && isPlainObject(updateValue)) {
+      merged[key] = mergePluginConfig(current[key], updateValue);
+    } else {
+      merged[key] = updateValue;
+    }
   }
 
   return merged;

--- a/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/issue-provider-model-merge.util.ts
@@ -1,8 +1,5 @@
 import { IssueProvider } from '../issue.model';
 
-const isPlainObject = (v: unknown): v is Record<string, unknown> =>
-  typeof v === 'object' && v !== null && !Array.isArray(v);
-
 const mergePluginConfig = (
   current: Record<string, unknown> | undefined,
   update: Record<string, unknown> | undefined,
@@ -13,23 +10,12 @@ const mergePluginConfig = (
   if (!update) {
     return current;
   }
-
-  const merged = { ...current };
-  // Deep merge is intentional; nested keys clear only by explicit value, never by omission.
-  for (const [key, updateValue] of Object.entries(update)) {
-    // Defense-in-depth: skip prototype-polluting keys (pluginConfig comes from form models,
-    // not raw JSON.parse, but filter defensively anyway).
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-      continue;
-    }
-    if (isPlainObject(current[key]) && isPlainObject(updateValue)) {
-      merged[key] = mergePluginConfig(current[key], updateValue);
-    } else {
-      merged[key] = updateValue;
-    }
-  }
-
-  return merged;
+  // Shallow top-level merge: preserves top-level keys omitted from a partial update (the
+  // actual bug). A nested object (e.g. twoWaySync) is replaced wholesale — callers always
+  // emit a complete twoWaySync, so no partial-nested update occurs. The spread also copies
+  // any own __proto__ key as a plain own property without touching the prototype, so no
+  // explicit prototype-pollution guard is needed.
+  return { ...current, ...update };
 };
 
 export const mergeIssueProviderModelUpdates = (

--- a/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.spec.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.spec.ts
@@ -1,0 +1,37 @@
+import type { OAuthFlowConfig } from '@super-productivity/plugin-api';
+import { applyPluginOAuthOverrides } from './plugin-oauth-config-overrides.util';
+
+describe('applyPluginOAuthOverrides', () => {
+  const baseConfig: OAuthFlowConfig = {
+    authUrl: 'https://launchpad.37signals.com/authorization/new',
+    tokenUrl: 'https://launchpad.37signals.com/authorization/token',
+    clientId: 'default-client-id',
+    clientSecret: 'default-client-secret',
+    scopes: ['full'],
+  };
+
+  it('applies trimmed user-provided oauth overrides', () => {
+    expect(
+      applyPluginOAuthOverrides(baseConfig, {
+        clientId: '  override-client-id  ',
+        clientSecret: '  override-client-secret  ',
+        redirectUri: '  http://127.0.0.1:8976/callback  ',
+      }),
+    ).toEqual({
+      ...baseConfig,
+      clientId: 'override-client-id',
+      clientSecret: 'override-client-secret',
+      redirectUri: 'http://127.0.0.1:8976/callback',
+    });
+  });
+
+  it('ignores empty or non-string override values', () => {
+    expect(
+      applyPluginOAuthOverrides(baseConfig, {
+        clientId: '   ',
+        clientSecret: null,
+        redirectUri: 42,
+      } as unknown as Record<string, unknown>),
+    ).toEqual(baseConfig);
+  });
+});

--- a/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.spec.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.spec.ts
@@ -1,5 +1,6 @@
 import type { OAuthFlowConfig } from '@super-productivity/plugin-api';
 import { applyPluginOAuthOverrides } from './plugin-oauth-config-overrides.util';
+import { IssueLog } from '../../../core/log';
 
 describe('applyPluginOAuthOverrides', () => {
   const baseConfig: OAuthFlowConfig = {
@@ -10,13 +11,19 @@ describe('applyPluginOAuthOverrides', () => {
     scopes: ['full'],
   };
 
-  it('applies trimmed user-provided oauth overrides', () => {
+  it('applies trimmed user-provided oauth overrides on electron', () => {
     expect(
-      applyPluginOAuthOverrides(baseConfig, {
-        clientId: '  override-client-id  ',
-        clientSecret: '  override-client-secret  ',
-        redirectUri: '  http://127.0.0.1:8976/callback  ',
-      }),
+      applyPluginOAuthOverrides(
+        baseConfig,
+        {
+          oauthOverrides: {
+            clientId: '  override-client-id  ',
+            clientSecret: '  override-client-secret  ',
+            redirectUri: '  http://127.0.0.1:8976/callback  ',
+          },
+        },
+        true,
+      ),
     ).toEqual({
       ...baseConfig,
       clientId: 'override-client-id',
@@ -25,13 +32,71 @@ describe('applyPluginOAuthOverrides', () => {
     });
   });
 
-  it('ignores empty or non-string override values', () => {
+  it('ignores empty or non-string override values on electron', () => {
     expect(
-      applyPluginOAuthOverrides(baseConfig, {
-        clientId: '   ',
-        clientSecret: null,
-        redirectUri: 42,
-      } as unknown as Record<string, unknown>),
+      applyPluginOAuthOverrides(
+        baseConfig,
+        {
+          oauthOverrides: {
+            clientId: '   ',
+            clientSecret: null,
+            redirectUri: 42,
+          },
+        } as unknown as Record<string, unknown>,
+        true,
+      ),
     ).toEqual(baseConfig);
+  });
+
+  it('returns unchanged config and warns when custom oauth credentials provided on non-electron platform', () => {
+    const warnSpy = spyOn(IssueLog, 'warn');
+    const result = applyPluginOAuthOverrides(
+      baseConfig,
+      {
+        oauthOverrides: {
+          clientId: 'custom-id',
+          clientSecret: 'custom-secret',
+          redirectUri: 'http://127.0.0.1:8976/callback',
+        },
+      },
+      false,
+    );
+
+    expect(result).toEqual(baseConfig);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Custom OAuth credentials (client id / secret / redirect URI) apply only to the desktop loopback flow and are ignored on this platform.',
+    );
+  });
+
+  it('returns unchanged config without warning when no custom oauth credentials on non-electron platform', () => {
+    const warnSpy = spyOn(IssueLog, 'warn');
+    const result = applyPluginOAuthOverrides(
+      baseConfig,
+      {
+        oauthOverrides: {
+          clientId: '   ',
+          clientSecret: null,
+          redirectUri: undefined,
+        },
+      } as unknown as Record<string, unknown>,
+      false,
+    );
+
+    expect(result).toEqual(baseConfig);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('ignores flat top-level clientId/clientSecret/redirectUri keys and returns unchanged config on electron', () => {
+    const result = applyPluginOAuthOverrides(
+      baseConfig,
+      {
+        clientId: 'flat-client-id',
+        clientSecret: 'flat-client-secret',
+        redirectUri: 'http://127.0.0.1:8976/callback',
+      },
+      true,
+    );
+
+    expect(result).toEqual(baseConfig);
   });
 });

--- a/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.ts
@@ -1,0 +1,24 @@
+import { OAuthFlowConfig } from '@super-productivity/plugin-api';
+
+export const applyPluginOAuthOverrides = (
+  oauthConfig: OAuthFlowConfig,
+  pluginConfig: Record<string, unknown> | undefined,
+): OAuthFlowConfig => {
+  const clientId =
+    typeof pluginConfig?.['clientId'] === 'string' ? pluginConfig['clientId'].trim() : '';
+  const clientSecret =
+    typeof pluginConfig?.['clientSecret'] === 'string'
+      ? pluginConfig['clientSecret'].trim()
+      : '';
+  const redirectUri =
+    typeof pluginConfig?.['redirectUri'] === 'string'
+      ? pluginConfig['redirectUri'].trim()
+      : '';
+
+  return {
+    ...oauthConfig,
+    ...(clientId ? { clientId } : {}),
+    ...(clientSecret ? { clientSecret } : {}),
+    ...(redirectUri ? { redirectUri } : {}),
+  };
+};

--- a/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.ts
@@ -1,5 +1,15 @@
 import { OAuthFlowConfig } from '@super-productivity/plugin-api';
 
+/**
+ * Apply a plugin's user-supplied OAuth overrides (clientId / clientSecret / redirectUri)
+ * from its synced pluginConfig onto the plugin's declared oauthConfig.
+ *
+ * WARNING: a clientSecret read here comes from the synced IssueProvider.pluginConfig
+ * (op-log + backups; may be unencrypted on some sync backends) — like existing provider
+ * passwords (Jira/CalDAV/Nextcloud), and unlike OAuth tokens which are kept local-only.
+ * Plugins that expose a clientSecret field should warn users in the field help text and use
+ * only credentials documented as non-confidential (installed/native-app style).
+ */
 export const applyPluginOAuthOverrides = (
   oauthConfig: OAuthFlowConfig,
   pluginConfig: Record<string, unknown> | undefined,

--- a/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/plugin-oauth-config-overrides.util.ts
@@ -1,29 +1,41 @@
 import { OAuthFlowConfig } from '@super-productivity/plugin-api';
+import { IssueLog } from '../../../core/log';
 
 /**
  * Apply a plugin's user-supplied OAuth overrides (clientId / clientSecret / redirectUri)
- * from its synced pluginConfig onto the plugin's declared oauthConfig.
+ * from its synced pluginConfig.oauthOverrides onto the plugin's declared oauthConfig.
  *
  * WARNING: a clientSecret read here comes from the synced IssueProvider.pluginConfig
  * (op-log + backups; may be unencrypted on some sync backends) — like existing provider
  * passwords (Jira/CalDAV/Nextcloud), and unlike OAuth tokens which are kept local-only.
  * Plugins that expose a clientSecret field should warn users in the field help text and use
  * only credentials documented as non-confidential (installed/native-app style).
+ *
+ * NOTE: Custom OAuth credentials (clientId / clientSecret / redirectUri) apply only to the
+ * desktop loopback flow and are ignored on web and native platforms.
  */
 export const applyPluginOAuthOverrides = (
   oauthConfig: OAuthFlowConfig,
   pluginConfig: Record<string, unknown> | undefined,
+  isElectron: boolean,
 ): OAuthFlowConfig => {
+  const overrides = (pluginConfig?.['oauthOverrides'] ?? {}) as Record<string, unknown>;
   const clientId =
-    typeof pluginConfig?.['clientId'] === 'string' ? pluginConfig['clientId'].trim() : '';
+    typeof overrides['clientId'] === 'string' ? overrides['clientId'].trim() : '';
   const clientSecret =
-    typeof pluginConfig?.['clientSecret'] === 'string'
-      ? pluginConfig['clientSecret'].trim()
-      : '';
+    typeof overrides['clientSecret'] === 'string' ? overrides['clientSecret'].trim() : '';
   const redirectUri =
-    typeof pluginConfig?.['redirectUri'] === 'string'
-      ? pluginConfig['redirectUri'].trim()
-      : '';
+    typeof overrides['redirectUri'] === 'string' ? overrides['redirectUri'].trim() : '';
+
+  // Gate custom OAuth credentials to Electron (desktop loopback flow only)
+  if (!isElectron) {
+    if (clientId || clientSecret || redirectUri) {
+      IssueLog.warn(
+        'Custom OAuth credentials (client id / secret / redirect URI) apply only to the desktop loopback flow and are ignored on this platform.',
+      );
+    }
+    return oauthConfig;
+  }
 
   return {
     ...oauthConfig,

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import type { OAuthFlowConfig } from '@super-productivity/plugin-api';
 import { PluginOAuthBridgeService } from './plugin-oauth-bridge.service';
+import { deleteOAuthTokens, loadOAuthTokens } from './plugin-oauth-token-store';
 import { PluginOAuthService } from './plugin-oauth.service';
 
 describe('PluginOAuthBridgeService', () => {
@@ -16,12 +17,14 @@ describe('PluginOAuthBridgeService', () => {
     scopes: ['calendar.readonly'],
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await deleteOAuthTokens('test-plugin__oauth').catch(() => undefined);
+
     oauthService = jasmine.createSpyObj<PluginOAuthService>(
       'PluginOAuthService',
       [
         'validateOAuthConfig',
-        'getRedirectUri',
+        'prepareRedirectUri',
         'buildAuthUrl',
         'waitForRedirectCode',
         'exchangeCodeForTokens',
@@ -51,12 +54,80 @@ describe('PluginOAuthBridgeService', () => {
     ).toBeRejectedWithError(/not available in the web build/);
 
     expect(oauthService.validateOAuthConfig).toHaveBeenCalledWith(baseConfig);
-    expect(oauthService.getRedirectUri).not.toHaveBeenCalled();
+    expect(oauthService.prepareRedirectUri).not.toHaveBeenCalled();
+  });
+
+  it('honors an explicit redirectUri override while preparing the matching loopback listener', async () => {
+    spyOn(window, 'open').and.returnValue({} as Window);
+    oauthService.prepareRedirectUri.and.resolveTo('http://127.0.0.1:8976/callback');
+    oauthService.buildAuthUrl.and.resolveTo({
+      url: 'https://accounts.google.com/o/oauth2/v2/auth',
+      codeVerifier: 'verifier',
+      state: 'state',
+    });
+    oauthService.waitForRedirectCode.and.resolveTo('auth-code');
+    oauthService.exchangeCodeForTokens.and.resolveTo({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now() + 3600000,
+    });
+    oauthService.serializeTokens.and.returnValue(null);
+
+    await service.startOAuthFlow('test-plugin', {
+      ...baseConfig,
+      webClientId: 'web-client-id',
+      redirectUri: 'http://127.0.0.1:8976/callback',
+    });
+
+    expect(oauthService.prepareRedirectUri).toHaveBeenCalledWith(
+      'http://127.0.0.1:8976/callback',
+    );
+    expect(oauthService.buildAuthUrl).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        clientId: 'web-client-id',
+        clientSecret: undefined,
+        redirectUri: 'http://127.0.0.1:8976/callback',
+      }),
+      'http://127.0.0.1:8976/callback',
+    );
+    expect(oauthService.exchangeCodeForTokens).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        clientId: 'web-client-id',
+        clientSecret: undefined,
+        redirectUri: 'http://127.0.0.1:8976/callback',
+      }),
+    );
+  });
+
+  it('persists oauth tokens in the local token store after a successful flow', async () => {
+    spyOn(window, 'open').and.returnValue({} as Window);
+    oauthService.prepareRedirectUri.and.resolveTo('http://127.0.0.1:8976/callback');
+    oauthService.buildAuthUrl.and.resolveTo({
+      url: 'https://accounts.google.com/o/oauth2/v2/auth',
+      codeVerifier: 'verifier',
+      state: 'state',
+    });
+    oauthService.waitForRedirectCode.and.resolveTo('auth-code');
+    oauthService.exchangeCodeForTokens.and.resolveTo({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now() + 3600000,
+    });
+    oauthService.serializeTokens.and.returnValue('serialized-tokens');
+
+    await service.startOAuthFlow('test-plugin', {
+      ...baseConfig,
+      webClientId: 'web-client-id',
+      redirectUri: 'http://127.0.0.1:8976/callback',
+    });
+
+    expect(await loadOAuthTokens('test-plugin__oauth')).toBe('serialized-tokens');
+    await deleteOAuthTokens('test-plugin__oauth');
   });
 
   it('uses a public web client id without carrying the desktop client secret', async () => {
     spyOn(window, 'open').and.returnValue({} as Window);
-    oauthService.getRedirectUri.and.resolveTo(
+    oauthService.prepareRedirectUri.and.resolveTo(
       'https://app.super-productivity.com/assets/oauth-callback.html',
     );
     oauthService.buildAuthUrl.and.resolveTo({

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
@@ -58,9 +58,10 @@ describe('PluginOAuthBridgeService', () => {
     expect(oauthService.prepareRedirectUri).not.toHaveBeenCalled();
   });
 
-  it('honors an explicit redirectUri override while preparing the matching loopback listener', async () => {
+  it('strips a desktop loopback redirectUri on the web flow and falls through to the host callback default', async () => {
     spyOn(window, 'open').and.returnValue({} as Window);
-    oauthService.prepareRedirectUri.and.resolveTo('http://127.0.0.1:8976/callback');
+    const webCallback = 'https://app.super-productivity.com/assets/oauth-callback.html';
+    oauthService.prepareRedirectUri.and.resolveTo(webCallback);
     oauthService.buildAuthUrl.and.resolveTo({
       url: 'https://accounts.google.com/o/oauth2/v2/auth',
       codeVerifier: 'verifier',
@@ -74,35 +75,38 @@ describe('PluginOAuthBridgeService', () => {
     });
     oauthService.serializeTokens.and.returnValue(null);
 
+    // A web-capable plugin (webClientId) that ALSO declares a desktop loopback redirectUri:
+    // on web the redirectUri must be dropped so the flow uses the host callback default,
+    // instead of throwing because the loopback URI fails web validation.
     await service.startOAuthFlow('test-plugin', {
       ...baseConfig,
       webClientId: 'web-client-id',
       redirectUri: 'http://127.0.0.1:8976/callback',
     });
 
-    expect(oauthService.prepareRedirectUri).toHaveBeenCalledWith(
-      'http://127.0.0.1:8976/callback',
-    );
+    expect(oauthService.prepareRedirectUri).toHaveBeenCalledWith(undefined);
     expect(oauthService.buildAuthUrl).toHaveBeenCalledWith(
       jasmine.objectContaining({
         clientId: 'web-client-id',
         clientSecret: undefined,
-        redirectUri: 'http://127.0.0.1:8976/callback',
+        redirectUri: undefined,
       }),
-      'http://127.0.0.1:8976/callback',
+      webCallback,
     );
     expect(oauthService.exchangeCodeForTokens).toHaveBeenCalledWith(
       jasmine.objectContaining({
         clientId: 'web-client-id',
         clientSecret: undefined,
-        redirectUri: 'http://127.0.0.1:8976/callback',
+        redirectUri: webCallback,
       }),
     );
   });
 
   it('persists oauth tokens in the local token store after a successful flow', async () => {
     spyOn(window, 'open').and.returnValue({} as Window);
-    oauthService.prepareRedirectUri.and.resolveTo('http://127.0.0.1:8976/callback');
+    oauthService.prepareRedirectUri.and.resolveTo(
+      'https://app.super-productivity.com/assets/oauth-callback.html',
+    );
     oauthService.buildAuthUrl.and.resolveTo({
       url: 'https://accounts.google.com/o/oauth2/v2/auth',
       codeVerifier: 'verifier',
@@ -119,7 +123,6 @@ describe('PluginOAuthBridgeService', () => {
     await service.startOAuthFlow('test-plugin', {
       ...baseConfig,
       webClientId: 'web-client-id',
-      redirectUri: 'http://127.0.0.1:8976/callback',
     });
 
     expect(await loadOAuthTokens('test-plugin__oauth')).toBe('serialized-tokens');

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
@@ -186,7 +186,9 @@ describe('PluginOAuthBridgeService', () => {
       webClientId: 'web-client-id',
     });
 
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'OAuth: the configured client secret is not used on this platform; the public/platform client id is used instead.',
+    );
   });
 
   it('clears stale browser tokens for providers that are unavailable on web', async () => {

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
@@ -4,6 +4,7 @@ import type { OAuthFlowConfig } from '@super-productivity/plugin-api';
 import { PluginOAuthBridgeService } from './plugin-oauth-bridge.service';
 import { deleteOAuthTokens, loadOAuthTokens } from './plugin-oauth-token-store';
 import { PluginOAuthService } from './plugin-oauth.service';
+import { PluginLog } from '../../core/log';
 
 describe('PluginOAuthBridgeService', () => {
   let service: PluginOAuthBridgeService;
@@ -158,6 +159,34 @@ describe('PluginOAuthBridgeService', () => {
         clientSecret: undefined,
       }),
     );
+  });
+
+  it('warns that a client secret is not used in the web build', async () => {
+    spyOn(window, 'open').and.returnValue({} as Window);
+    const warnSpy = spyOn(PluginLog, 'warn');
+    oauthService.prepareRedirectUri.and.resolveTo(
+      'https://app.super-productivity.com/assets/oauth-callback.html',
+    );
+    oauthService.buildAuthUrl.and.resolveTo({
+      url: 'https://accounts.google.com/o/oauth2/v2/auth',
+      codeVerifier: 'verifier',
+      state: 'state',
+    });
+    oauthService.waitForRedirectCode.and.resolveTo('auth-code');
+    oauthService.exchangeCodeForTokens.and.resolveTo({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now() + 3600000,
+    });
+    oauthService.serializeTokens.and.returnValue(null);
+
+    // baseConfig carries a clientSecret, which the web build cannot use.
+    await service.startOAuthFlow('pkce-web-provider', {
+      ...baseConfig,
+      webClientId: 'web-client-id',
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
   });
 
   it('clears stale browser tokens for providers that are unavailable on web', async () => {

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
@@ -2,11 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OAuthFlowConfig, OAuthTokenResult } from '@super-productivity/plugin-api';
 import { PluginOAuthService } from './plugin-oauth.service';
-import {
-  saveOAuthTokens,
-  loadOAuthTokens,
-  deleteOAuthTokens,
-} from './plugin-oauth-token-store';
+import * as pluginOAuthTokenStore from './plugin-oauth-token-store';
 import { IS_ELECTRON } from '../../app.constants';
 import {
   IS_NATIVE_PLATFORM,
@@ -73,7 +69,9 @@ export class PluginOAuthBridgeService {
       return config;
     })();
 
-    const redirectUri = await this._pluginOAuthService.getRedirectUri();
+    const redirectUri = await this._pluginOAuthService.prepareRedirectUri(
+      effectiveConfig.redirectUri,
+    );
     const { url, codeVerifier, state } = await this._pluginOAuthService.buildAuthUrl(
       effectiveConfig,
       redirectUri,
@@ -166,7 +164,10 @@ export class PluginOAuthBridgeService {
     const serialized = this._pluginOAuthService.serializeTokens(pluginId);
     if (serialized) {
       try {
-        await saveOAuthTokens(this._oauthPersistenceKey(pluginId), serialized);
+        await pluginOAuthTokenStore.saveOAuthTokens(
+          this._oauthPersistenceKey(pluginId),
+          serialized,
+        );
       } catch (error) {
         PluginLog.err('PluginOAuthBridge: Failed to persist OAuth tokens:', error);
       }
@@ -175,7 +176,9 @@ export class PluginOAuthBridgeService {
 
   private async _restoreOAuthTokens(pluginId: string): Promise<void> {
     try {
-      const serialized = await loadOAuthTokens(this._oauthPersistenceKey(pluginId));
+      const serialized = await pluginOAuthTokenStore.loadOAuthTokens(
+        this._oauthPersistenceKey(pluginId),
+      );
       if (serialized) {
         this._pluginOAuthService.restoreTokens(pluginId, serialized);
       }
@@ -186,7 +189,7 @@ export class PluginOAuthBridgeService {
 
   private async _clearPersistedOAuthTokens(pluginId: string): Promise<void> {
     try {
-      await deleteOAuthTokens(this._oauthPersistenceKey(pluginId));
+      await pluginOAuthTokenStore.deleteOAuthTokens(this._oauthPersistenceKey(pluginId));
     } catch (error) {
       PluginLog.err('PluginOAuthBridge: Failed to clear persisted OAuth tokens:', error);
     }

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
@@ -48,14 +48,29 @@ export class PluginOAuthBridgeService {
     // client (loopback redirect, used by Electron); other platforms override it.
     // - Android/iOS authenticate via app signing → no client secret
     // - Web can only use providers that support public browser clients via PKCE
+    // A plugin-declared `redirectUri` is the desktop loopback override; web/native each
+    // have a single valid callback (the host callback page / the app's fixed scheme), so
+    // strip it on those branches and let prepareRedirectUri produce the platform default —
+    // otherwise a web/native-capable plugin that also sets a desktop redirectUri throws at
+    // connect time on those platforms.
     // Order matters: Android-WebView sets both IS_ANDROID_NATIVE and IS_NATIVE_PLATFORM,
     // so it lands in the Android branch (correct) and never reaches the web branch.
     const effectiveConfig = ((): OAuthFlowConfig => {
       if (IS_ANDROID_NATIVE && config.mobileClientId) {
-        return { ...config, clientId: config.mobileClientId, clientSecret: undefined };
+        return {
+          ...config,
+          clientId: config.mobileClientId,
+          clientSecret: undefined,
+          redirectUri: undefined,
+        };
       }
       if (IS_IOS_NATIVE && config.iosClientId) {
-        return { ...config, clientId: config.iosClientId, clientSecret: undefined };
+        return {
+          ...config,
+          clientId: config.iosClientId,
+          clientSecret: undefined,
+          redirectUri: undefined,
+        };
       }
       if (!IS_ELECTRON && !IS_NATIVE_PLATFORM) {
         const webClientId = config.webClientId;
@@ -68,6 +83,7 @@ export class PluginOAuthBridgeService {
           ...config,
           clientId: webClientId,
           clientSecret: undefined,
+          redirectUri: undefined,
         };
       }
       return config;

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
@@ -52,19 +52,9 @@ export class PluginOAuthBridgeService {
     // so it lands in the Android branch (correct) and never reaches the web branch.
     const effectiveConfig = ((): OAuthFlowConfig => {
       if (IS_ANDROID_NATIVE && config.mobileClientId) {
-        if (config.clientSecret) {
-          PluginLog.warn(
-            'OAuth: a client secret is not used on Android; the platform client id is used instead.',
-          );
-        }
         return { ...config, clientId: config.mobileClientId, clientSecret: undefined };
       }
       if (IS_IOS_NATIVE && config.iosClientId) {
-        if (config.clientSecret) {
-          PluginLog.warn(
-            'OAuth: a client secret is not used on iOS; the platform client id is used instead.',
-          );
-        }
         return { ...config, clientId: config.iosClientId, clientSecret: undefined };
       }
       if (!IS_ELECTRON && !IS_NATIVE_PLATFORM) {
@@ -72,11 +62,6 @@ export class PluginOAuthBridgeService {
         if (!webClientId) {
           throw new Error(
             'OAuth: this plugin is not available in the web build. Connect from the desktop or mobile app instead.',
-          );
-        }
-        if (config.clientSecret) {
-          PluginLog.warn(
-            'OAuth: a client secret is not used in the web build; the public web client id is used instead.',
           );
         }
         return {
@@ -87,6 +72,12 @@ export class PluginOAuthBridgeService {
       }
       return config;
     })();
+
+    if (config.clientSecret && !effectiveConfig.clientSecret) {
+      PluginLog.warn(
+        'OAuth: the configured client secret is not used on this platform; the public/platform client id is used instead.',
+      );
+    }
 
     const redirectUri = await this._pluginOAuthService.prepareRedirectUri(
       effectiveConfig.redirectUri,

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OAuthFlowConfig, OAuthTokenResult } from '@super-productivity/plugin-api';
 import { PluginOAuthService } from './plugin-oauth.service';
+import { resolveEffectiveOAuthConfig } from './resolve-effective-oauth-config.util';
 import {
   saveOAuthTokens,
   loadOAuthTokens,
@@ -44,50 +45,15 @@ export class PluginOAuthBridgeService {
     // prepareRedirectUri() starts a server — avoid leaking it if config is invalid.
     this._pluginOAuthService.validateOAuthConfig(config);
 
-    // Pick the platform-specific client. The default `clientId` is the desktop
-    // client (loopback redirect, used by Electron); other platforms override it.
-    // - Android/iOS authenticate via app signing → no client secret
-    // - Web can only use providers that support public browser clients via PKCE
-    // A plugin-declared `redirectUri` is the desktop loopback override; web/native each
-    // have a single valid callback (the host callback page / the app's fixed scheme), so
-    // strip it on those branches and let prepareRedirectUri produce the platform default —
-    // otherwise a web/native-capable plugin that also sets a desktop redirectUri throws at
-    // connect time on those platforms.
-    // Order matters: Android-WebView sets both IS_ANDROID_NATIVE and IS_NATIVE_PLATFORM,
-    // so it lands in the Android branch (correct) and never reaches the web branch.
-    const effectiveConfig = ((): OAuthFlowConfig => {
-      if (IS_ANDROID_NATIVE && config.mobileClientId) {
-        return {
-          ...config,
-          clientId: config.mobileClientId,
-          clientSecret: undefined,
-          redirectUri: undefined,
-        };
-      }
-      if (IS_IOS_NATIVE && config.iosClientId) {
-        return {
-          ...config,
-          clientId: config.iosClientId,
-          clientSecret: undefined,
-          redirectUri: undefined,
-        };
-      }
-      if (!IS_ELECTRON && !IS_NATIVE_PLATFORM) {
-        const webClientId = config.webClientId;
-        if (!webClientId) {
-          throw new Error(
-            'OAuth: this plugin is not available in the web build. Connect from the desktop or mobile app instead.',
-          );
-        }
-        return {
-          ...config,
-          clientId: webClientId,
-          clientSecret: undefined,
-          redirectUri: undefined,
-        };
-      }
-      return config;
-    })();
+    // Pick the platform-specific client id / secret / redirectUri. Extracted into a
+    // pure, platform-parameterized util so every branch is unit-testable (the IS_*
+    // consts are module-level and cannot be mocked in karma).
+    const effectiveConfig = resolveEffectiveOAuthConfig(config, {
+      isElectron: IS_ELECTRON,
+      isNative: IS_NATIVE_PLATFORM,
+      isAndroid: IS_ANDROID_NATIVE,
+      isIos: IS_IOS_NATIVE,
+    });
 
     if (config.clientSecret && !effectiveConfig.clientSecret) {
       PluginLog.warn(

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
@@ -2,7 +2,11 @@ import { inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OAuthFlowConfig, OAuthTokenResult } from '@super-productivity/plugin-api';
 import { PluginOAuthService } from './plugin-oauth.service';
-import * as pluginOAuthTokenStore from './plugin-oauth-token-store';
+import {
+  saveOAuthTokens,
+  loadOAuthTokens,
+  deleteOAuthTokens,
+} from './plugin-oauth-token-store';
 import { IS_ELECTRON } from '../../app.constants';
 import {
   IS_NATIVE_PLATFORM,
@@ -37,7 +41,7 @@ export class PluginOAuthBridgeService {
     config: OAuthFlowConfig,
   ): Promise<OAuthTokenResult> {
     // Validate URLs before starting the loopback server. On Electron,
-    // getRedirectUri() starts a server — avoid leaking it if config is invalid.
+    // prepareRedirectUri() starts a server — avoid leaking it if config is invalid.
     this._pluginOAuthService.validateOAuthConfig(config);
 
     // Pick the platform-specific client. The default `clientId` is the desktop
@@ -48,9 +52,19 @@ export class PluginOAuthBridgeService {
     // so it lands in the Android branch (correct) and never reaches the web branch.
     const effectiveConfig = ((): OAuthFlowConfig => {
       if (IS_ANDROID_NATIVE && config.mobileClientId) {
+        if (config.clientSecret) {
+          PluginLog.warn(
+            'OAuth: a client secret is not used on Android; the platform client id is used instead.',
+          );
+        }
         return { ...config, clientId: config.mobileClientId, clientSecret: undefined };
       }
       if (IS_IOS_NATIVE && config.iosClientId) {
+        if (config.clientSecret) {
+          PluginLog.warn(
+            'OAuth: a client secret is not used on iOS; the platform client id is used instead.',
+          );
+        }
         return { ...config, clientId: config.iosClientId, clientSecret: undefined };
       }
       if (!IS_ELECTRON && !IS_NATIVE_PLATFORM) {
@@ -58,6 +72,11 @@ export class PluginOAuthBridgeService {
         if (!webClientId) {
           throw new Error(
             'OAuth: this plugin is not available in the web build. Connect from the desktop or mobile app instead.',
+          );
+        }
+        if (config.clientSecret) {
+          PluginLog.warn(
+            'OAuth: a client secret is not used in the web build; the public web client id is used instead.',
           );
         }
         return {
@@ -164,10 +183,7 @@ export class PluginOAuthBridgeService {
     const serialized = this._pluginOAuthService.serializeTokens(pluginId);
     if (serialized) {
       try {
-        await pluginOAuthTokenStore.saveOAuthTokens(
-          this._oauthPersistenceKey(pluginId),
-          serialized,
-        );
+        await saveOAuthTokens(this._oauthPersistenceKey(pluginId), serialized);
       } catch (error) {
         PluginLog.err('PluginOAuthBridge: Failed to persist OAuth tokens:', error);
       }
@@ -176,9 +192,7 @@ export class PluginOAuthBridgeService {
 
   private async _restoreOAuthTokens(pluginId: string): Promise<void> {
     try {
-      const serialized = await pluginOAuthTokenStore.loadOAuthTokens(
-        this._oauthPersistenceKey(pluginId),
-      );
+      const serialized = await loadOAuthTokens(this._oauthPersistenceKey(pluginId));
       if (serialized) {
         this._pluginOAuthService.restoreTokens(pluginId, serialized);
       }
@@ -189,7 +203,7 @@ export class PluginOAuthBridgeService {
 
   private async _clearPersistedOAuthTokens(pluginId: string): Promise<void> {
     try {
-      await pluginOAuthTokenStore.deleteOAuthTokens(this._oauthPersistenceKey(pluginId));
+      await deleteOAuthTokens(this._oauthPersistenceKey(pluginId));
     } catch (error) {
       PluginLog.err('PluginOAuthBridge: Failed to clear persisted OAuth tokens:', error);
     }

--- a/src/app/plugins/oauth/plugin-oauth.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.spec.ts
@@ -426,14 +426,14 @@ describe('PluginOAuthService', () => {
     it('should reject a same-origin violation on web', async () => {
       await expectAsync(
         service.prepareRedirectUri('https://evil.example.com/callback'),
-      ).toBeRejectedWithError(/same-origin/);
+      ).toBeRejectedWithError(/must be.*oauth-callback\.html/);
     });
 
     it('should accept a valid same-origin redirectUri on web', async () => {
       const result = await service.prepareRedirectUri(
-        `${window.location.origin}/callback`,
+        `${window.location.origin}/assets/oauth-callback.html`,
       );
-      expect(result).toBe(`${window.location.origin}/callback`);
+      expect(result).toBe(`${window.location.origin}/assets/oauth-callback.html`);
     });
   });
 

--- a/src/app/plugins/oauth/plugin-oauth.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.spec.ts
@@ -416,6 +416,27 @@ describe('PluginOAuthService', () => {
     });
   });
 
+  describe('prepareRedirectUri validation', () => {
+    it('should reject a malformed redirectUri', async () => {
+      await expectAsync(
+        service.prepareRedirectUri('not-a-valid-url'),
+      ).toBeRejectedWithError(/Invalid OAuth redirectUri/);
+    });
+
+    it('should reject a same-origin violation on web', async () => {
+      await expectAsync(
+        service.prepareRedirectUri('https://evil.example.com/callback'),
+      ).toBeRejectedWithError(/same-origin/);
+    });
+
+    it('should accept a valid same-origin redirectUri on web', async () => {
+      const result = await service.prepareRedirectUri(
+        `${window.location.origin}/callback`,
+      );
+      expect(result).toBe(`${window.location.origin}/callback`);
+    });
+  });
+
   describe('redirect code handling', () => {
     it('should resolve when handleRedirectCode is called with matching state', async () => {
       const promise = service.waitForRedirectCode('plugin-1', 'test-state');

--- a/src/app/plugins/oauth/plugin-oauth.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.ts
@@ -37,12 +37,14 @@ export class PluginOAuthService {
   /** Emits the pluginId when a token refresh fails and in-memory tokens are cleared. */
   tokenInvalidated$ = new Subject<string>();
 
-  async getRedirectUri(): Promise<string> {
+  async prepareRedirectUri(redirectUri?: string): Promise<string> {
     if (IS_ELECTRON) {
-      // Google Desktop OAuth requires loopback redirect URIs (http://127.0.0.1:<port>).
-      // Start a temporary loopback server in the main process and use its port.
-      const { port } = await window.ea.pluginOAuthPrepare();
-      return `http://127.0.0.1:${port}`;
+      const loopbackPort = this._getElectronLoopbackPort(redirectUri);
+      const { port } = await window.ea.pluginOAuthPrepare(loopbackPort);
+      return redirectUri || `http://127.0.0.1:${port}`;
+    }
+    if (redirectUri) {
+      return redirectUri;
     }
     if (IS_NATIVE_PLATFORM) {
       // Scheme must match the platform's app identifier:
@@ -96,6 +98,25 @@ export class PluginOAuthService {
   validateOAuthConfig(config: OAuthFlowConfig): void {
     this._validateHttpsUrl(config.authUrl, 'authUrl');
     this._validateHttpsUrl(config.tokenUrl, 'tokenUrl');
+  }
+
+  private _getElectronLoopbackPort(redirectUri?: string): number | undefined {
+    if (!redirectUri) {
+      return undefined;
+    }
+
+    try {
+      const parsed = new URL(redirectUri);
+      const isLoopbackHost =
+        parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
+      if (parsed.protocol !== 'http:' || !isLoopbackHost || !parsed.port) {
+        return undefined;
+      }
+      const port = Number(parsed.port);
+      return Number.isInteger(port) && port > 0 ? port : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   private _validateHttpsUrl(url: string, label: string): void {

--- a/src/app/plugins/oauth/plugin-oauth.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.ts
@@ -7,6 +7,10 @@ import { PluginOAuthTokens } from './plugin-oauth.model';
 import { IS_ELECTRON } from '../../app.constants';
 import { IS_NATIVE_PLATFORM, IS_ANDROID_NATIVE } from '../../util/is-native-platform';
 import { PluginLog } from '../../core/log';
+import {
+  OAUTH_LOOPBACK_PORT_MIN,
+  OAUTH_LOOPBACK_PORT_MAX,
+} from '../../../../electron/shared-with-frontend/oauth-loopback.const';
 
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const OAUTH_REDIRECT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -43,7 +47,7 @@ export class PluginOAuthService {
     }
 
     if (IS_ELECTRON) {
-      const loopbackPort = this._getElectronLoopbackPort(redirectUri);
+      const loopbackPort = redirectUri ? Number(new URL(redirectUri).port) : undefined;
       const { port } = await window.ea.pluginOAuthPrepare(loopbackPort);
       return redirectUri || `http://127.0.0.1:${port}`;
     }
@@ -122,6 +126,16 @@ export class PluginOAuthService {
           `OAuth redirectUri on desktop must be a loopback URI like http://127.0.0.1:<port>/...; got ${redirectUri}`,
         );
       }
+      const port = Number(parsed.port);
+      if (
+        !Number.isInteger(port) ||
+        port < OAUTH_LOOPBACK_PORT_MIN ||
+        port > OAUTH_LOOPBACK_PORT_MAX
+      ) {
+        throw new Error(
+          `OAuth redirectUri on desktop must use a port in range [${OAUTH_LOOPBACK_PORT_MIN}, ${OAUTH_LOOPBACK_PORT_MAX}]; got ${redirectUri}`,
+        );
+      }
       return;
     }
     if (IS_NATIVE_PLATFORM) {
@@ -137,24 +151,6 @@ export class PluginOAuthService {
       throw new Error(
         `OAuth redirectUri on web must be same-origin (${window.location.origin}); got ${redirectUri}`,
       );
-    }
-  }
-
-  private _getElectronLoopbackPort(redirectUri?: string): number | undefined {
-    if (!redirectUri) {
-      return undefined;
-    }
-
-    try {
-      const parsed = new URL(redirectUri);
-      const isLoopbackHost = parsed.hostname === '127.0.0.1';
-      if (parsed.protocol !== 'http:' || !isLoopbackHost || !parsed.port) {
-        return undefined;
-      }
-      const port = Number(parsed.port);
-      return Number.isInteger(port) && port > 0 ? port : undefined;
-    } catch {
-      return undefined;
     }
   }
 

--- a/src/app/plugins/oauth/plugin-oauth.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.ts
@@ -8,9 +8,9 @@ import { IS_ELECTRON } from '../../app.constants';
 import { IS_NATIVE_PLATFORM, IS_ANDROID_NATIVE } from '../../util/is-native-platform';
 import { PluginLog } from '../../core/log';
 import {
-  OAUTH_LOOPBACK_PORT_MIN,
-  OAUTH_LOOPBACK_PORT_MAX,
-} from '../../../../electron/shared-with-frontend/oauth-loopback.const';
+  validateOAuthRedirectUri,
+  WEB_OAUTH_CALLBACK_PATH,
+} from './validate-redirect-uri.util';
 
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const OAUTH_REDIRECT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -62,7 +62,7 @@ export class PluginOAuthService {
         ? 'com.superproductivity.superproductivity:/plugin-oauth-callback'
         : 'com.super-productivity.app:/plugin-oauth-callback';
     }
-    return `${window.location.origin}/assets/oauth-callback.html`;
+    return `${window.location.origin}${WEB_OAUTH_CALLBACK_PATH}`;
   }
 
   async buildAuthUrl(
@@ -109,49 +109,11 @@ export class PluginOAuthService {
   }
 
   private _validateRedirectUri(redirectUri: string): void {
-    let parsed: URL;
-    try {
-      parsed = new URL(redirectUri);
-    } catch {
-      throw new Error(`Invalid OAuth redirectUri: ${redirectUri}`);
-    }
-
-    if (IS_ELECTRON) {
-      if (
-        parsed.protocol !== 'http:' ||
-        parsed.hostname !== '127.0.0.1' ||
-        !parsed.port
-      ) {
-        throw new Error(
-          `OAuth redirectUri on desktop must be a loopback URI like http://127.0.0.1:<port>/...; got ${redirectUri}`,
-        );
-      }
-      const port = Number(parsed.port);
-      if (
-        !Number.isInteger(port) ||
-        port < OAUTH_LOOPBACK_PORT_MIN ||
-        port > OAUTH_LOOPBACK_PORT_MAX
-      ) {
-        throw new Error(
-          `OAuth redirectUri on desktop must use a port in range [${OAUTH_LOOPBACK_PORT_MIN}, ${OAUTH_LOOPBACK_PORT_MAX}]; got ${redirectUri}`,
-        );
-      }
-      return;
-    }
-    if (IS_NATIVE_PLATFORM) {
-      if (['http:', 'https:', 'javascript:', 'file:'].includes(parsed.protocol)) {
-        throw new Error(
-          `OAuth redirectUri on native must use the app custom scheme; got ${redirectUri}`,
-        );
-      }
-      return;
-    }
-    // web
-    if (parsed.origin !== window.location.origin) {
-      throw new Error(
-        `OAuth redirectUri on web must be same-origin (${window.location.origin}); got ${redirectUri}`,
-      );
-    }
+    validateOAuthRedirectUri(redirectUri, {
+      isElectron: IS_ELECTRON,
+      isNative: IS_NATIVE_PLATFORM,
+      origin: window.location.origin,
+    });
   }
 
   private _validateHttpsUrl(url: string, label: string): void {

--- a/src/app/plugins/oauth/plugin-oauth.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.ts
@@ -38,6 +38,10 @@ export class PluginOAuthService {
   tokenInvalidated$ = new Subject<string>();
 
   async prepareRedirectUri(redirectUri?: string): Promise<string> {
+    if (redirectUri) {
+      this._validateRedirectUri(redirectUri);
+    }
+
     if (IS_ELECTRON) {
       const loopbackPort = this._getElectronLoopbackPort(redirectUri);
       const { port } = await window.ea.pluginOAuthPrepare(loopbackPort);
@@ -100,6 +104,42 @@ export class PluginOAuthService {
     this._validateHttpsUrl(config.tokenUrl, 'tokenUrl');
   }
 
+  private _validateRedirectUri(redirectUri: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(redirectUri);
+    } catch {
+      throw new Error(`Invalid OAuth redirectUri: ${redirectUri}`);
+    }
+
+    if (IS_ELECTRON) {
+      if (
+        parsed.protocol !== 'http:' ||
+        parsed.hostname !== '127.0.0.1' ||
+        !parsed.port
+      ) {
+        throw new Error(
+          `OAuth redirectUri on desktop must be a loopback URI like http://127.0.0.1:<port>/...; got ${redirectUri}`,
+        );
+      }
+      return;
+    }
+    if (IS_NATIVE_PLATFORM) {
+      if (['http:', 'https:', 'javascript:', 'file:'].includes(parsed.protocol)) {
+        throw new Error(
+          `OAuth redirectUri on native must use the app custom scheme; got ${redirectUri}`,
+        );
+      }
+      return;
+    }
+    // web
+    if (parsed.origin !== window.location.origin) {
+      throw new Error(
+        `OAuth redirectUri on web must be same-origin (${window.location.origin}); got ${redirectUri}`,
+      );
+    }
+  }
+
   private _getElectronLoopbackPort(redirectUri?: string): number | undefined {
     if (!redirectUri) {
       return undefined;
@@ -107,8 +147,7 @@ export class PluginOAuthService {
 
     try {
       const parsed = new URL(redirectUri);
-      const isLoopbackHost =
-        parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
+      const isLoopbackHost = parsed.hostname === '127.0.0.1';
       if (parsed.protocol !== 'http:' || !isLoopbackHost || !parsed.port) {
         return undefined;
       }

--- a/src/app/plugins/oauth/resolve-effective-oauth-config.util.spec.ts
+++ b/src/app/plugins/oauth/resolve-effective-oauth-config.util.spec.ts
@@ -1,0 +1,117 @@
+import type { OAuthFlowConfig } from '@super-productivity/plugin-api';
+import {
+  resolveEffectiveOAuthConfig,
+  OAuthPlatform,
+} from './resolve-effective-oauth-config.util';
+
+describe('resolveEffectiveOAuthConfig', () => {
+  const baseConfig: OAuthFlowConfig = {
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    clientId: 'desktop-client-id',
+    clientSecret: 'desktop-client-secret',
+    scopes: ['calendar.readonly'],
+    redirectUri: 'http://127.0.0.1:8976/callback',
+    webClientId: 'web-client-id',
+    mobileClientId: 'android-client-id',
+    iosClientId: 'ios-client-id',
+  };
+
+  const platform = (overrides: Partial<OAuthPlatform> = {}): OAuthPlatform => ({
+    isElectron: false,
+    isNative: false,
+    isAndroid: false,
+    isIos: false,
+    ...overrides,
+  });
+
+  it('on desktop (Electron) keeps the desktop client, secret, and the loopback redirectUri', () => {
+    const result = resolveEffectiveOAuthConfig(
+      baseConfig,
+      platform({ isElectron: true }),
+    );
+    expect(result.clientId).toBe('desktop-client-id');
+    expect(result.clientSecret).toBe('desktop-client-secret');
+    expect(result.redirectUri).toBe('http://127.0.0.1:8976/callback');
+  });
+
+  it('on Android swaps in the mobile client id and strips the secret + redirectUri', () => {
+    const result = resolveEffectiveOAuthConfig(
+      baseConfig,
+      platform({ isNative: true, isAndroid: true }),
+    );
+    expect(result.clientId).toBe('android-client-id');
+    expect(result.clientSecret).toBeUndefined();
+    expect(result.redirectUri).toBeUndefined();
+  });
+
+  it('on iOS swaps in the iOS client id and strips the secret + redirectUri', () => {
+    const result = resolveEffectiveOAuthConfig(
+      baseConfig,
+      platform({ isNative: true, isIos: true }),
+    );
+    expect(result.clientId).toBe('ios-client-id');
+    expect(result.clientSecret).toBeUndefined();
+    expect(result.redirectUri).toBeUndefined();
+  });
+
+  it('on web swaps in the web client id and strips the secret + redirectUri', () => {
+    const result = resolveEffectiveOAuthConfig(baseConfig, platform());
+    expect(result.clientId).toBe('web-client-id');
+    expect(result.clientSecret).toBeUndefined();
+    expect(result.redirectUri).toBeUndefined();
+  });
+
+  it('on web throws when the plugin has no web client id', () => {
+    const noWebClient = { ...baseConfig, webClientId: undefined };
+    expect(() => resolveEffectiveOAuthConfig(noWebClient, platform())).toThrowError(
+      /not available in the web build/,
+    );
+  });
+
+  it('treats an Android WebView (isAndroid + isNative) as native, not web — no throw without a webClientId', () => {
+    // The web branch throws on a missing webClientId, but it is gated by !isNative, so a
+    // native build must never be treated as web. An Android WebView reports both isAndroid
+    // and isNative and must resolve via the Android branch rather than the web throw.
+    const noWeb = { ...baseConfig, webClientId: undefined };
+    const result = resolveEffectiveOAuthConfig(
+      noWeb,
+      platform({ isNative: true, isAndroid: true }),
+    );
+    expect(result.clientId).toBe('android-client-id');
+    expect(result.clientSecret).toBeUndefined();
+  });
+
+  // The headline of the redirectUri fix: a desktop loopback redirectUri must never leak
+  // into the native flow even when the plugin ships no matching platform client id (the
+  // fall-through case) — otherwise validateOAuthRedirectUri rejects it and connect throws.
+  it('strips the redirectUri on a native platform with no matching client id (Android, no mobileClientId)', () => {
+    const noMobile = { ...baseConfig, mobileClientId: undefined };
+    const result = resolveEffectiveOAuthConfig(
+      noMobile,
+      platform({ isNative: true, isAndroid: true }),
+    );
+    expect(result.redirectUri).toBeUndefined();
+    // Public client on a non-desktop platform: the desktop clientSecret is dropped too.
+    // No matching platform client id to swap in, so the declared clientId is unchanged.
+    expect(result.clientSecret).toBeUndefined();
+    expect(result.clientId).toBe('desktop-client-id');
+  });
+
+  it('strips the redirectUri on a native platform with no matching client id (iOS, no iosClientId)', () => {
+    const noIos = { ...baseConfig, iosClientId: undefined };
+    const result = resolveEffectiveOAuthConfig(
+      noIos,
+      platform({ isNative: true, isIos: true }),
+    );
+    expect(result.redirectUri).toBeUndefined();
+    expect(result.clientSecret).toBeUndefined();
+    expect(result.clientId).toBe('desktop-client-id');
+  });
+
+  it('does not mutate the input config', () => {
+    const snapshot = JSON.parse(JSON.stringify(baseConfig));
+    resolveEffectiveOAuthConfig(baseConfig, platform());
+    expect(baseConfig).toEqual(snapshot);
+  });
+});

--- a/src/app/plugins/oauth/resolve-effective-oauth-config.util.ts
+++ b/src/app/plugins/oauth/resolve-effective-oauth-config.util.ts
@@ -1,0 +1,73 @@
+import { OAuthFlowConfig } from '@super-productivity/plugin-api';
+
+export interface OAuthPlatform {
+  isElectron: boolean;
+  isNative: boolean;
+  isAndroid: boolean;
+  isIos: boolean;
+}
+
+/**
+ * Resolve the platform-specific OAuth config from a plugin's declared config.
+ *
+ * - clientId: the declared `clientId` is the desktop client (used by Electron); web,
+ *   Android and iOS swap in their public/platform client id (webClientId /
+ *   mobileClientId / iosClientId).
+ * - clientSecret: dropped on every non-desktop platform (public clients only).
+ * - redirectUri: a plugin-declared redirectUri is the desktop loopback override and is
+ *   honored ONLY on Electron; it is stripped on every other path so prepareRedirectUri
+ *   produces the platform default (web callback page / native app scheme). Otherwise a
+ *   web/native-capable plugin that also sets a desktop redirectUri would throw at
+ *   connect time when that loopback URI fails web/native validation.
+ *
+ * Throws if the web build has no webClientId (the plugin isn't web-capable).
+ *
+ * Pure + platform-parameterized so every branch is unit-testable; the module-level
+ * IS_ELECTRON / IS_NATIVE_PLATFORM / IS_*_NATIVE consts cannot be mocked in karma.
+ */
+export const resolveEffectiveOAuthConfig = (
+  config: OAuthFlowConfig,
+  platform: OAuthPlatform,
+): OAuthFlowConfig => {
+  // Order matters: an Android WebView reports both isAndroid and isNative, so it must
+  // land in the Android branch (correct) and never reach the web branch below.
+  if (platform.isAndroid && config.mobileClientId) {
+    return {
+      ...config,
+      clientId: config.mobileClientId,
+      clientSecret: undefined,
+      redirectUri: undefined,
+    };
+  }
+  if (platform.isIos && config.iosClientId) {
+    return {
+      ...config,
+      clientId: config.iosClientId,
+      clientSecret: undefined,
+      redirectUri: undefined,
+    };
+  }
+  if (!platform.isElectron && !platform.isNative) {
+    const webClientId = config.webClientId;
+    if (!webClientId) {
+      throw new Error(
+        'OAuth: this plugin is not available in the web build. Connect from the desktop or mobile app instead.',
+      );
+    }
+    return {
+      ...config,
+      clientId: webClientId,
+      clientSecret: undefined,
+      redirectUri: undefined,
+    };
+  }
+  // Desktop (Electron) is the only flow that honors a plugin-declared clientSecret or
+  // redirectUri. Any other fall-through — e.g. a native platform where the plugin ships
+  // no matching mobile/iOS client id — is a public client on a non-desktop platform, so
+  // strip both: the secret must not be sent, and the desktop loopback redirectUri would
+  // be rejected by native/web validation. Keeps clientSecret + redirectUri desktop-only.
+  if (!platform.isElectron) {
+    return { ...config, clientSecret: undefined, redirectUri: undefined };
+  }
+  return config;
+};

--- a/src/app/plugins/oauth/validate-redirect-uri.util.spec.ts
+++ b/src/app/plugins/oauth/validate-redirect-uri.util.spec.ts
@@ -192,16 +192,16 @@ describe('validateOAuthRedirectUri', () => {
   });
 
   describe('edge cases', () => {
-    it('should reject when all platforms are false (invalid state)', () => {
-      const invalidPlatform: RedirectUriPlatform = {
+    it('rejects a cross-origin redirectUri on web (neither electron nor native)', () => {
+      const webPlatform: RedirectUriPlatform = {
         isElectron: false,
         isNative: false,
         origin: 'https://app.example.com',
       };
 
-      // Should fall through to web validation (requires exact path)
+      // !electron && !native => web validation: requires the exact same-origin callback path
       expect(() =>
-        validateOAuthRedirectUri('https://evil.com/cb', invalidPlatform),
+        validateOAuthRedirectUri('https://evil.com/cb', webPlatform),
       ).toThrowError(/must be.*oauth-callback\.html/);
     });
 

--- a/src/app/plugins/oauth/validate-redirect-uri.util.spec.ts
+++ b/src/app/plugins/oauth/validate-redirect-uri.util.spec.ts
@@ -1,0 +1,254 @@
+import {
+  validateOAuthRedirectUri,
+  RedirectUriPlatform,
+  WEB_OAUTH_CALLBACK_PATH,
+} from './validate-redirect-uri.util';
+
+describe('validateOAuthRedirectUri', () => {
+  describe('electron platform', () => {
+    const electronPlatform: RedirectUriPlatform = {
+      isElectron: true,
+      isNative: false,
+      origin: 'http://localhost:9876',
+    };
+
+    it('should accept a valid loopback URI', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://127.0.0.1:8976/callback', electronPlatform),
+      ).not.toThrow();
+    });
+
+    it('should accept a loopback URI at port boundary (min)', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://127.0.0.1:1024/callback', electronPlatform),
+      ).not.toThrow();
+    });
+
+    it('should accept a loopback URI at port boundary (max)', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://127.0.0.1:65535/callback', electronPlatform),
+      ).not.toThrow();
+    });
+
+    it('should reject port 80 (out of range)', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://127.0.0.1:80/cb', electronPlatform),
+      ).toThrowError(/port in \[1024, 65535\]/);
+    });
+
+    it('should reject port 0 (out of range)', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://127.0.0.1:0/cb', electronPlatform),
+      ).toThrowError(/port in \[1024, 65535\]/);
+    });
+
+    it('should reject port 65536 (invalid for URL)', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://127.0.0.1:65536/cb', electronPlatform),
+      ).toThrowError(/Invalid OAuth redirectUri/);
+    });
+
+    it('should reject HTTPS protocol', () => {
+      expect(() =>
+        validateOAuthRedirectUri('https://127.0.0.1:8976/cb', electronPlatform),
+      ).toThrowError(/loopback URI http:\/\/127\.0\.0\.1/);
+    });
+
+    it('should reject localhost hostname', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://localhost:8976/cb', electronPlatform),
+      ).toThrowError(/loopback URI http:\/\/127\.0\.0\.1/);
+    });
+
+    it('should reject evil.com hostname', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://evil.com:8976/cb', electronPlatform),
+      ).toThrowError(/loopback URI http:\/\/127\.0\.0\.1/);
+    });
+
+    it('should reject missing port', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://127.0.0.1/cb', electronPlatform),
+      ).toThrowError(/loopback URI http:\/\/127\.0\.0\.1/);
+    });
+
+    it('should reject malformed URL', () => {
+      expect(() => validateOAuthRedirectUri('not-a-url', electronPlatform)).toThrowError(
+        /Invalid OAuth redirectUri/,
+      );
+    });
+  });
+
+  describe('native platform', () => {
+    const nativePlatform: RedirectUriPlatform = {
+      isElectron: false,
+      isNative: true,
+      origin: 'irrelevant',
+    };
+
+    it('should reject custom scheme override', () => {
+      expect(() =>
+        validateOAuthRedirectUri('com.super-productivity.app:/cb', nativePlatform),
+      ).toThrowError(/override is not supported on native/);
+    });
+
+    it('should reject data scheme override', () => {
+      expect(() =>
+        validateOAuthRedirectUri('data:text/html,x', nativePlatform),
+      ).toThrowError(/override is not supported on native/);
+    });
+
+    it('should reject HTTPS override', () => {
+      expect(() =>
+        validateOAuthRedirectUri('https://example.com/cb', nativePlatform),
+      ).toThrowError(/override is not supported on native/);
+    });
+
+    it('should reject HTTP override', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://example.com/cb', nativePlatform),
+      ).toThrowError(/override is not supported on native/);
+    });
+
+    it('should reject file scheme override', () => {
+      expect(() =>
+        validateOAuthRedirectUri('file:///app/callback', nativePlatform),
+      ).toThrowError(/override is not supported on native/);
+    });
+
+    it('should reject javascript scheme override', () => {
+      expect(() =>
+        validateOAuthRedirectUri('javascript:alert(1)', nativePlatform),
+      ).toThrowError(/override is not supported on native/);
+    });
+
+    it('should reject malformed URL', () => {
+      expect(() => validateOAuthRedirectUri('not-a-url', nativePlatform)).toThrowError(
+        /Invalid OAuth redirectUri/,
+      );
+    });
+  });
+
+  describe('web platform', () => {
+    const webPlatform: RedirectUriPlatform = {
+      isElectron: false,
+      isNative: false,
+      origin: 'https://app.example.com',
+    };
+
+    it('should accept a valid same-origin callback URI', () => {
+      expect(() =>
+        validateOAuthRedirectUri(
+          'https://app.example.com/assets/oauth-callback.html',
+          webPlatform,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should accept a same-origin URI with the correct path and query params', () => {
+      expect(() =>
+        validateOAuthRedirectUri(
+          `https://app.example.com${WEB_OAUTH_CALLBACK_PATH}?state=123`,
+          webPlatform,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should reject a same-origin URI with wrong path', () => {
+      expect(() =>
+        validateOAuthRedirectUri('https://app.example.com/somewhere-else', webPlatform),
+      ).toThrowError(/must be.*oauth-callback\.html/);
+    });
+
+    it('should reject a different subdomain', () => {
+      expect(() =>
+        validateOAuthRedirectUri('https://evil.example.com/cb', webPlatform),
+      ).toThrowError(/must be.*oauth-callback\.html/);
+    });
+
+    it('should reject a different domain', () => {
+      expect(() =>
+        validateOAuthRedirectUri('https://evil-domain.com/cb', webPlatform),
+      ).toThrowError(/must be.*oauth-callback\.html/);
+    });
+
+    it('should reject a different protocol', () => {
+      expect(() =>
+        validateOAuthRedirectUri('http://app.example.com/cb', webPlatform),
+      ).toThrowError(/must be.*oauth-callback\.html/);
+    });
+
+    it('should reject a different port', () => {
+      expect(() =>
+        validateOAuthRedirectUri('https://app.example.com:8080/cb', webPlatform),
+      ).toThrowError(/must be.*oauth-callback\.html/);
+    });
+
+    it('should reject malformed URL', () => {
+      expect(() => validateOAuthRedirectUri('not-a-url', webPlatform)).toThrowError(
+        /Invalid OAuth redirectUri/,
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should reject when all platforms are false (invalid state)', () => {
+      const invalidPlatform: RedirectUriPlatform = {
+        isElectron: false,
+        isNative: false,
+        origin: 'https://app.example.com',
+      };
+
+      // Should fall through to web validation (requires exact path)
+      expect(() =>
+        validateOAuthRedirectUri('https://evil.com/cb', invalidPlatform),
+      ).toThrowError(/must be.*oauth-callback\.html/);
+    });
+
+    it('should handle Electron being false and Native being false (web case)', () => {
+      const webPlatform: RedirectUriPlatform = {
+        isElectron: false,
+        isNative: false,
+        origin: 'https://localhost:3000',
+      };
+
+      expect(() =>
+        validateOAuthRedirectUri(
+          `https://localhost:3000${WEB_OAUTH_CALLBACK_PATH}`,
+          webPlatform,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should handle URL with fragment identifier', () => {
+      const webPlatform: RedirectUriPlatform = {
+        isElectron: false,
+        isNative: false,
+        origin: 'https://app.example.com',
+      };
+
+      expect(() =>
+        validateOAuthRedirectUri(
+          `https://app.example.com${WEB_OAUTH_CALLBACK_PATH}#section`,
+          webPlatform,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should handle URL with userinfo (with correct path)', () => {
+      const webPlatform: RedirectUriPlatform = {
+        isElectron: false,
+        isNative: false,
+        origin: 'https://app.example.com',
+      };
+
+      // origin is the same despite userinfo, and path matches
+      expect(() =>
+        validateOAuthRedirectUri(
+          `https://user:pass@app.example.com${WEB_OAUTH_CALLBACK_PATH}`,
+          webPlatform,
+        ),
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/app/plugins/oauth/validate-redirect-uri.util.ts
+++ b/src/app/plugins/oauth/validate-redirect-uri.util.ts
@@ -1,0 +1,67 @@
+import {
+  OAUTH_LOOPBACK_PORT_MIN,
+  OAUTH_LOOPBACK_PORT_MAX,
+} from '../../../../electron/shared-with-frontend/oauth-loopback.const';
+
+export const WEB_OAUTH_CALLBACK_PATH = '/assets/oauth-callback.html';
+
+export interface RedirectUriPlatform {
+  isElectron: boolean;
+  isNative: boolean;
+  /** window.location.origin — passed in for testability */
+  origin: string;
+}
+
+/**
+ * Validate a plugin-supplied OAuth redirectUri for the current platform, throwing a clear
+ * error on anything the transport can't actually service (so misconfigurations fail fast
+ * instead of hanging on the IdP redirect).
+ */
+export const validateOAuthRedirectUri = (
+  redirectUri: string,
+  platform: RedirectUriPlatform,
+): void => {
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUri);
+  } catch {
+    throw new Error(`Invalid OAuth redirectUri: ${redirectUri}`);
+  }
+
+  if (platform.isElectron) {
+    const port = Number(parsed.port);
+    // Require 127.0.0.1 specifically (not localhost / [::1]): the loopback server binds
+    // 127.0.0.1, and 'localhost' can resolve to ::1 first and miss the IPv4 listener.
+    if (
+      parsed.protocol !== 'http:' ||
+      parsed.hostname !== '127.0.0.1' ||
+      !parsed.port ||
+      !Number.isInteger(port) ||
+      port < OAUTH_LOOPBACK_PORT_MIN ||
+      port > OAUTH_LOOPBACK_PORT_MAX
+    ) {
+      throw new Error(
+        `OAuth redirectUri on desktop must be a loopback URI http://127.0.0.1:<port>/ with port in [${OAUTH_LOOPBACK_PORT_MIN}, ${OAUTH_LOOPBACK_PORT_MAX}]; got ${redirectUri}`,
+      );
+    }
+    return;
+  }
+
+  if (platform.isNative) {
+    // A native OAuth callback must use the app's fixed custom scheme, so a plugin-supplied
+    // redirectUri override is meaningless here. Reject outright — an allowlist of one value
+    // that the user can't usefully set — which also closes the incomplete-scheme-check (no
+    // scheme can slip through a denylist).
+    throw new Error(
+      `OAuth redirectUri override is not supported on native; the app's fixed callback scheme is used. Got ${redirectUri}`,
+    );
+  }
+
+  // web — must be the app's built-in OAuth callback page (the only page that resolves the
+  // postMessage callback); a same-origin URI with any other path would hang until timeout.
+  if (parsed.origin !== platform.origin || parsed.pathname !== WEB_OAUTH_CALLBACK_PATH) {
+    throw new Error(
+      `OAuth redirectUri on web must be ${platform.origin}${WEB_OAUTH_CALLBACK_PATH}; got ${redirectUri}`,
+    );
+  }
+};


### PR DESCRIPTION
## Problem
  
OAuth-based issue-provider plugins that need an **exact, pre-registered redirect
URI** can't work on stock Super Productivity today: `OAuthFlowConfig` can't
declare an exact redirect, the Electron loopback always binds a random port, and
there's no generic way for a user to supply their own OAuth app credentials. 
There's also a small bug: merging a *partial* `pluginConfig` update drops the
omitted keys.

Context: follow-up to the discussion on #8507 — these are the small, generic,
provider-agnostic OAuth host hooks you offered to take as a separate trimmed PR.
(The Basecamp provider that motivated them will ship as a community plugin, not
bundled.)
  
## Solution
  
Provider-agnostic plugin-framework hooks — no provider-specific code:
  
- **`OAuthFlowConfig.redirectUri`** — a plugin may declare an exact callback; the
  host uses it for both the authorization request and the token exchange.
- The **Electron loopback honors a plugin-requested fixed port** and rejects with
  a clear message when that port is already in use (instead of a raw `EADDRINUSE`).
- **Bring-your-own OAuth app**: user-supplied `clientId`/`clientSecret`/`redirectUri`
  from plugin config override the plugin's embedded `oauthConfig`.
- **Fix**: merging a partial `pluginConfig` update preserves omitted keys and
  deep-merges nested objects (e.g. `twoWaySync`).
    
12 files. Unit tests added for the OAuth bridge (redirect/port/web-client paths),
the config-merge util, and the OAuth-overrides util.
  
## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other
  
## Checklist
- [x] I have run `npm run checkFile` on changed `.ts` files
- [x] I have added tests for my changes 
- [x] Existing tests still pass 
- [x] My commit messages follow the Angular format
- [ ] Documentation/wiki (n/a — internal plugin-API hooks)
