### PR TITLE
fix(android): keyboard + status-bar follow-ups for edge-to-edge (#8508)

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -56,6 +56,11 @@ class CapacitorMainActivity : BridgeActivity() {
     // path) to avoid allocating an IntArray on every pass while the IME is up.
     private val webViewLocationOnScreen = IntArray(2)
 
+    // SDK < 30 status-bar overlap workaround: last value pushed to JS, to dedupe
+    // the per-layout-pass listener. -1 = nothing pushed yet.
+    // See pushStatusBarOverlapBelowApi30.
+    private var lastStatusBarOverlapCssPx: Int = -1
+
     private var isTimerCompleteReceiverRegistered = false
     private var isForegroundServiceFailureReceiverRegistered = false
 
@@ -205,6 +210,7 @@ class CapacitorMainActivity : BridgeActivity() {
                 if (isKeyboardOpen) "true" else "false"
             )
             adjustWebViewHeightForKeyboardBelowApi30(rect, isKeyboardOpen)
+            pushStatusBarOverlapBelowApi30(rect)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -511,6 +517,63 @@ class CapacitorMainActivity : BridgeActivity() {
             Log.d(
                 "SUPKeyboard",
                 "webView height -> $targetHeight (kbOpen=$isKeyboardOpen rectB=${rect.bottom})"
+            )
+        }
+    }
+
+    /**
+     * Status-bar overlap workaround for the web header drawing BEHIND the status
+     * bar on the WebView < 140 tail (#8508 / #8283 follow-up, Android 9 / API 28).
+     *
+     * Edge-to-edge insets are owned by Capacitor's built-in SystemBars now. On
+     * **API >= 35** it injects the real `--safe-area-inset-*` px, and on
+     * **WebView >= 140** the WebView's own `env(safe-area-inset-*)` is correct
+     * (passthrough). But on the **WebView < 140** tail under enforced edge-to-edge
+     * the WebView extends under the status bar while `env(safe-area-inset-top)`
+     * resolves to 0 (old WebViews map only display cutouts into safe-area insets,
+     * not the status bar) — so the web side has no top inset and content overlaps
+     * the status bar.
+     *
+     * We measure the overlap natively and publish it as the `--android-status-bar-
+     * overlap` CSS var, which the web side folds into `--safe-area-top` via
+     * `var(--safe-area-inset-top, max(env(...), var(--android-status-bar-overlap)))`.
+     * The overlap is how much of the status bar covers the WebView: `rect.top`
+     * (top of the visible display frame = status-bar height, reliable on API 28,
+     * the same frame the keyboard path uses) minus the WebView's top on screen
+     * (`getLocationOnScreen`: 0 when edge-to-edge, == status-bar height once
+     * inset). So it is the status-bar height when the WebView is NOT inset and 0
+     * once it is — `max()` never double-counts. Physical px → CSS px via display
+     * density; deduped so the per-layout listener does not spam evaluateJavascript.
+     *
+     * Gated to **SDK < 30 AND WebView < 140** (mirrors
+     * adjustWebViewHeightForKeyboardBelowApi30) so it never fights SystemBars; on
+     * API >= 35 the injected --safe-area-inset-top wins via var() precedence and
+     * the published var is ignored regardless. (Known small gap: an API 30–34
+     * device on an old WebView < 140 also has env()==0; rare, since WebView
+     * auto-updates above API 30 — broaden the gate if it ever surfaces.)
+     */
+    private fun pushStatusBarOverlapBelowApi30(rect: Rect) {
+        if (android.os.Build.VERSION.SDK_INT >= 30) return
+        // Skip when SystemBars/env() already give the correct top inset (WebView
+        // >= 140 passthrough). Unknown version (null) -> run it, the safe default.
+        val wvMajor = webViewCompatibility?.majorVersion
+        if (wvMajor != null && wvMajor >= 140) return
+        if (!::javaScriptInterface.isInitialized) return
+        val webView = bridge?.webView ?: return
+        webView.getLocationOnScreen(webViewLocationOnScreen)
+        val overlapPx = (rect.top - webViewLocationOnScreen[1]).coerceAtLeast(0)
+        val density = resources.displayMetrics.density
+        val overlapCssPx = if (density > 0f) Math.round(overlapPx / density) else overlapPx
+        if (overlapCssPx == lastStatusBarOverlapCssPx) return
+        lastStatusBarOverlapCssPx = overlapCssPx
+        javaScriptInterface.callJavaScriptFunction(
+            "document.documentElement.style.setProperty(" +
+                "'--android-status-bar-overlap','${overlapCssPx}px')"
+        )
+        if (BuildConfig.DEBUG) {
+            Log.d(
+                "SUPKeyboard",
+                "statusBarOverlap -> ${overlapCssPx}px (rectTop=${rect.top} wvTop=${webViewLocationOnScreen[1]})"
             )
         }
     }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -325,6 +325,14 @@ class CapacitorMainActivity : BridgeActivity() {
 
     fun flushPendingShareIntent() {
         isFrontendReady = true
+        // A web-side reload (e.g. language change, PWA update, sync-conflict
+        // recovery — all do window.location.reload()) re-runs the bundle and
+        // re-enters here, but it also wipes the inline --android-status-bar-overlap
+        // off the fresh document. Re-arm the dedupe so the next layout pass
+        // re-publishes it; otherwise the unchanged value is skipped and the
+        // header overlaps the status bar again on the WebView < 140 / API < 30
+        // tail. See pushStatusBarOverlapBelowApi30.
+        lastStatusBarOverlapCssPx = -1
         pendingShareIntent?.let {
             Log.d("SP_SHARE", "Flushing pending share intent: $it")
             callJSInterfaceFunctionIfExists("next", "onShareWithAttachment$", it.toString())

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -229,11 +229,14 @@ device, or the squashed sliver on the buggy v18.11.0 WebView.
 
 **Fix (`dialog-fullscreen-markdown.component.scss`).** Use the same
 resize-detecting `--keyboard-height` the add-task bar uses for the
-Android / mobile-web case; keep the iOS `--keyboard-overlay-offset` path as a
-second, source-order-later rule (equal specificity → wins on iOS):
+Android / mobile-web case; keep the iOS `--keyboard-overlay-offset` path in a
+separate rule. iOS carries **both** `isNativeMobile` and `isIOS` (and sets
+`--keyboard-height` non-zero), so the Android rule excludes iOS with
+`:not(.isIOS)` — the two rules are mutually exclusive and order-independent
+(rather than relying on equal-specificity source order):
 
 ```scss
-:host-context(body.isNativeMobile.isKeyboardVisible) {
+:host-context(body.isNativeMobile:not(.isIOS).isKeyboardVisible) {
   height: calc(100% - var(--keyboard-height, 0px));
 }
 :host-context(body.isIOS.isKeyboardVisible) {
@@ -316,6 +319,12 @@ SystemBars on `--safe-area-inset-*`:
 - Known small gap: an **API 30–34** device on an **old WebView < 140** also has
   env()==0 but is excluded by the SDK < 30 gate; rare (WebView auto-updates above
   API 30) — broaden the gate to WebView-only if it ever surfaces.
+- The var lives only as an inline style on the document, so a web-side reload
+  (`window.location.reload()` — language change, PWA update, sync-conflict
+  recovery) wipes it. The native dedupe (`lastStatusBarOverlapCssPx`) is reset in
+  `flushPendingShareIntent()` (runs on every frontend (re)load) so the next layout
+  pass re-publishes it; without the reset the unchanged value would be skipped and
+  the overlap would regress after a reload.
 
 ## What NOT to do
 

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -179,13 +179,13 @@ Driven from the existing keyboard `OnGlobalLayoutListener`:
 > is visible (`EdgeToEdge.applyInsetsInternal`, because it expects the system to
 > resize — which enforced edge-to-edge prevents on API < 30). Correcting the margin
 > from a second writer made the bar **flicker constantly** (on-device logcat showed
-> the margin alternating `0 ↔ lift` every frame); WebView bottom *padding* doesn't
+> the margin alternating `0 ↔ lift` every frame); WebView bottom _padding_ doesn't
 > move the web layout viewport; and fully replacing the plugin's listener fixed the
 > flicker but stopped the plugin re-sizing its status/nav **color overlays**, so the
 > navbar showed a **white gap**. Setting an explicit `layout_height` is the way out:
 > it is a different property than the margin the plugin manages, and for an
 > explicit-height view the bottom margin does not change the view's size — so the two
-> never fight, and the plugin keeps doing *everything else* (insets + color overlays,
+> never fight, and the plugin keeps doing _everything else_ (insets + color overlays,
 > no white gap). The target is read from the visible frame and does not depend on the
 > WebView's own height, so it is stable pass-to-pass (no feedback loop).
 
@@ -212,6 +212,48 @@ flicker) and that the status/nav-bar layout is unchanged with the keyboard down,
 and on an API >= 30 device that nothing changed at all. A debug-only
 `Log.d("SUPKeyboard", "webView height …")` reports each height write — in steady
 state expect one per show/hide, not a stream. Remove that log before merge.
+
+## #8508 follow-up — fullscreen markdown / notes editor squashed
+
+**Status: CSS fix implemented, PENDING ON-DEVICE VALIDATION.** Reported on #8508:
+editing a project (or task) note on Android with the keyboard up, the
+`DialogFullscreenMarkdownComponent` toolbar + textarea + Close/Save controls were
+squashed into the top of the screen with a large blank gap down to the keyboard.
+
+**Why.** The bar is not the only `position: fixed` surface that must clear the
+keyboard — this dialog is `position: fixed; height: 100%` too. Its keyboard rule
+subtracted `--keyboard-overlay-offset`, which is set **only on iOS**, so on
+Android it was a no-op. With the keyboard up the dialog therefore kept whatever
+height `100%` resolved to: full (content behind the keyboard) on a non-resizing
+device, or the squashed sliver on the buggy v18.11.0 WebView.
+
+**Fix (`dialog-fullscreen-markdown.component.scss`).** Use the same
+resize-detecting `--keyboard-height` the add-task bar uses, for the
+Android / mobile-web case; keep the iOS `--keyboard-overlay-offset` path as a
+second, source-order-later rule (equal specificity → wins on iOS):
+
+```scss
+:host-context(body.isNativeMobile.isKeyboardVisible) {
+  height: calc(100% - var(--keyboard-height, 0px) - var(--safe-area-top));
+}
+:host-context(body.isIOS.isKeyboardVisible) {
+  height: calc(100% - var(--keyboard-overlay-offset, 0px) - var(--safe-area-top));
+}
+```
+
+This is **not** the reverted-#8295 trap above: it reads the pure VisualViewport
+`--keyboard-height`, never augments it with native data. Coverage across the
+device classes this doc tracks:
+
+- **API < 30** — the SDK 28 native fix shrinks the WebView layout height, so
+  `100%` is already above the keyboard and `--keyboard-height == 0`; the rule is
+  `100% - 0 - safe-top` (same as before there). Works.
+- **API >= 30, window resizes** (verified 18.12.0) — `--keyboard-height == 0`,
+  identical to the old rule. Works; never worse than before.
+- **API >= 30, no resize but VisualViewport shrinks** (open item #4) —
+  `--keyboard-height > 0` lifts the dialog above the keyboard. This is the case
+  the old iOS-only rule got wrong and the new rule fixes, bringing the dialog to
+  parity with the add-task bar.
 
 ## What NOT to do
 

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -12,7 +12,7 @@ area has regressed repeatedly (#8295, then #8508).**
 > WebView < 140 so it never fights SystemBars). Bar backgrounds are no longer
 > painted by a plugin (SystemBars has no color API) — the bars are transparent
 > and the theme color shows through via `NavigationBarPlugin.setWebViewBackgroundColor`
-> (window decor + WebView surface). The #8508 sections below describe the *former*
+> (window decor + WebView surface). The #8508 sections below describe the _former_
 > `@capawesome` mechanics and are kept as history. Full rationale + device matrix:
 > [`docs/plans/2026-06-22-android-systembars-migration-corrected.md`](plans/2026-06-22-android-systembars-migration-corrected.md).
 
@@ -254,6 +254,57 @@ device classes this doc tracks:
   `--keyboard-height > 0` lifts the dialog above the keyboard. This is the case
   the old iOS-only rule got wrong and the new rule fixes, bringing the dialog to
   parity with the add-task bar.
+
+## #8508 follow-up — SDK 28 (Android 9): header draws BEHIND the status bar
+
+**Status: fix implemented (`CapacitorMainActivity.pushStatusBarOverlapBelowApi30`),
+PENDING ON-DEVICE VALIDATION.** Separate from the keyboard — on API 28 the web
+header overlaps the **status bar** (no top gap), reported on #8508.
+
+**Root cause.** Post the SystemBars migration, Android no longer writes
+`--safe-area-inset-*` from JS; `--safe-area-top` resolves via the SCSS fallback
+`var(--safe-area-inset-top, env(safe-area-inset-top, 0px))` (`_css-variables.scss`).
+On **API >= 35** SystemBars injects `--safe-area-inset-top`, and on **WebView >= 140**
+the WebView's own `env(safe-area-inset-top)` is correct — but on the
+**WebView < 140 tail** under enforced edge-to-edge the WebView extends under the
+status bar while `env(safe-area-inset-top)` resolves to **0** (old WebViews map
+only display _cutouts_ into safe-area insets, not the status bar). So
+`--safe-area-top == 0` and content draws under the status bar (Android 9 / API 28).
+
+**Why not a pure web-side fallback.** The web side cannot tell "WebView is
+edge-to-edge under the status bar" from "WebView is already inset below it" —
+`env()` is 0 in both, and adding the status-bar height blindly would double-count
+in the inset case. Native has the geometry.
+
+**Fix (native overlap → SCSS fallback) — `pushStatusBarOverlapBelowApi30`.** From
+the existing keyboard `OnGlobalLayoutListener`, measure the overlap
+`max(0, rect.top − webViewTopOnScreen)` — `rect.top` is the visible-frame top
+(= status-bar height, reliable on API 28; the same frame the keyboard path reads)
+and `getLocationOnScreen` is the WebView's top (0 edge-to-edge, == status-bar
+height once inset). Publish it (physical px → CSS px, deduped) as the
+`--android-status-bar-overlap` CSS var, gated **SDK < 30 AND WebView < 140**
+(mirrors the keyboard shim, never fights SystemBars). The var is folded into the
+SCSS fallback (`_css-variables.scss`) — NOT written from JS, so it never races
+SystemBars on `--safe-area-inset-*`:
+
+```scss
+--safe-area-top: var(
+  --safe-area-inset-top,
+  max(env(safe-area-inset-top, 0px), var(--android-status-bar-overlap, 0px))
+);
+```
+
+- `max()`, not a sum, so it never double-counts: WebView < 140 edge-to-edge →
+  env 0, overlap = status bar → status bar; once inset → env 0, overlap 0 → 0.
+- On **API >= 35 / WebView >= 140** `--safe-area-inset-top` is set (SystemBars) or
+  env() is correct, so `var()` precedence / `max()` ignore the overlap entirely —
+  verified behavior untouched.
+- JS readers (`_patchCdkViewportForSafeArea`) still parse the `var(max(...))`
+  token to 0, so overlay positioning is unchanged — preserving #8283 scoping
+  (only the header padding is affected).
+- Known small gap: an **API 30–34** device on an **old WebView < 140** also has
+  env()==0 but is excluded by the SDK < 30 gate; rare (WebView auto-updates above
+  API 30) — broaden the gate to WebView-only if it ever surfaces.
 
 ## What NOT to do
 

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -228,13 +228,13 @@ height `100%` resolved to: full (content behind the keyboard) on a non-resizing
 device, or the squashed sliver on the buggy v18.11.0 WebView.
 
 **Fix (`dialog-fullscreen-markdown.component.scss`).** Use the same
-resize-detecting `--keyboard-height` the add-task bar uses, for the
+resize-detecting `--keyboard-height` the add-task bar uses for the
 Android / mobile-web case; keep the iOS `--keyboard-overlay-offset` path as a
 second, source-order-later rule (equal specificity → wins on iOS):
 
 ```scss
 :host-context(body.isNativeMobile.isKeyboardVisible) {
-  height: calc(100% - var(--keyboard-height, 0px) - var(--safe-area-top));
+  height: calc(100% - var(--keyboard-height, 0px));
 }
 :host-context(body.isIOS.isKeyboardVisible) {
   height: calc(100% - var(--keyboard-overlay-offset, 0px) - var(--safe-area-top));
@@ -247,13 +247,24 @@ device classes this doc tracks:
 
 - **API < 30** — the SDK 28 native fix shrinks the WebView layout height, so
   `100%` is already above the keyboard and `--keyboard-height == 0`; the rule is
-  `100% - 0 - safe-top` (same as before there). Works.
+  `100% - 0`. Works.
 - **API >= 30, window resizes** (verified 18.12.0) — `--keyboard-height == 0`,
-  identical to the old rule. Works; never worse than before.
+  so `100% - 0`. Works.
 - **API >= 30, no resize but VisualViewport shrinks** (open item #4) —
-  `--keyboard-height > 0` lifts the dialog above the keyboard. This is the case
-  the old iOS-only rule got wrong and the new rule fixes, bringing the dialog to
-  parity with the add-task bar.
+  `--keyboard-height > 0` lifts the dialog above the keyboard, on par with the
+  add-task bar.
+
+**Do NOT also subtract `--safe-area-top` here.** An earlier version of this fix
+did (`100% - --keyboard-height - --safe-area-top`). That is a double-count:
+`:host` is `border-box` (global `* { box-sizing: border-box }`) and already has
+`padding-top: var(--safe-area-top)`, so the top inset is _inside_ `height: 100%`.
+Subtracting it again left a `--safe-area-top`-sized gap between the Close/Save
+controls and the keyboard. It was invisible while `--safe-area-top` was 0 on
+API < 30, then surfaced the moment the status-bar fix above made it non-zero
+(also latent on API >= 30, where env() already gave a non-zero `--safe-area-top`).
+The iOS rule keeps its `- --safe-area-top` term for now — its keyboard runtime
+differs (the WebView does not resize) and it is unverified on an iOS device; if
+an iOS bottom gap appears, drop the term there too.
 
 ## #8508 follow-up — SDK 28 (Android 9): header draws BEHIND the status bar
 

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
@@ -28,18 +28,25 @@
 }
 
 // Keyboard open: shrink the dialog above the IME, or its textarea + Close/Save
-// get squashed/hidden behind the keyboard. The amount to subtract is "resize-
-// detecting" and differs per platform (full rationale + device matrix in
-// docs/android-edge-to-edge-keyboard.md, #8508):
-//   Android/web: `--keyboard-height` is the resize-detecting value (0 once the
-//                system resized the window), same signal as the add-task bar.
-//   iOS:         `--keyboard-height` there is the FULL height (would double-
-//                count), so use the iOS resize-detecting `--keyboard-overlay-
-//                offset`. Equal specificity → this rule must stay last to win.
+// get squashed/hidden behind the keyboard. Subtract only the keyboard amount —
+// `:host` is border-box (global `* { box-sizing: border-box }`) so the
+// padding-top/bottom safe areas above are ALREADY inside `height`; subtracting
+// `--safe-area-top` again would double-remove the top inset and leave a
+// safe-area-top-sized gap between the controls and the keyboard (#8508 API 28
+// follow-up — invisible until --safe-area-top became non-zero on API < 30).
+// `--keyboard-height` is the resize-detecting value (0 once the system/native
+// shrank the window, the obscured amount otherwise), same signal as the
+// add-task bar. Full rationale + device matrix in
+// docs/android-edge-to-edge-keyboard.md (#8508).
 :host-context(body.isNativeMobile.isKeyboardVisible) {
-  height: calc(100% - var(--keyboard-height, 0px) - var(--safe-area-top));
+  height: calc(100% - var(--keyboard-height, 0px));
 }
 
+// iOS keeps its own override (different keyboard runtime: the WebView does not
+// resize, so it uses `--keyboard-overlay-offset`). Left as-is — the
+// `- --safe-area-top` term here is unverified on an iOS device and out of scope
+// for the API 28 fix; check it separately if an iOS bottom gap shows up. Equal
+// specificity → this rule stays last so it wins on iOS.
 :host-context(body.isIOS.isKeyboardVisible) {
   height: calc(100% - var(--keyboard-overlay-offset, 0px) - var(--safe-area-top));
 }

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
@@ -27,10 +27,20 @@
   padding-right: var(--safe-area-right);
 }
 
-// On iOS, the virtual keyboard overlaps position:fixed elements since the CDK
-// overlay container does not shrink with Capacitor's resize:'native' mode.
-// Subtract only the keyboard overlap not already handled by viewport resizing.
+// Keyboard open: shrink the dialog above the IME, or its textarea + Close/Save
+// get squashed/hidden behind the keyboard. The amount to subtract is "resize-
+// detecting" and differs per platform (full rationale + device matrix in
+// docs/android-edge-to-edge-keyboard.md, #8508):
+//   Android/web: `--keyboard-height` is the resize-detecting value (0 once the
+//                system resized the window), same signal as the add-task bar.
+//   iOS:         `--keyboard-height` there is the FULL height (would double-
+//                count), so use the iOS resize-detecting `--keyboard-overlay-
+//                offset`. Equal specificity → this rule must stay last to win.
 :host-context(body.isNativeMobile.isKeyboardVisible) {
+  height: calc(100% - var(--keyboard-height, 0px) - var(--safe-area-top));
+}
+
+:host-context(body.isIOS.isKeyboardVisible) {
   height: calc(100% - var(--keyboard-overlay-offset, 0px) - var(--safe-area-top));
 }
 

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
@@ -38,15 +38,18 @@
 // shrank the window, the obscured amount otherwise), same signal as the
 // add-task bar. Full rationale + device matrix in
 // docs/android-edge-to-edge-keyboard.md (#8508).
-:host-context(body.isNativeMobile.isKeyboardVisible) {
+// `:not(.isIOS)` makes this mutually exclusive with the iOS rule below — iOS
+// carries BOTH isNativeMobile and isIOS and sets --keyboard-height non-zero, so
+// without it the two equal-specificity rules would both match and iOS would
+// depend on source order. Excluding iOS here removes that fragility.
+:host-context(body.isNativeMobile:not(.isIOS).isKeyboardVisible) {
   height: calc(100% - var(--keyboard-height, 0px));
 }
 
 // iOS keeps its own override (different keyboard runtime: the WebView does not
 // resize, so it uses `--keyboard-overlay-offset`). Left as-is — the
 // `- --safe-area-top` term here is unverified on an iOS device and out of scope
-// for the API 28 fix; check it separately if an iOS bottom gap shows up. Equal
-// specificity → this rule stays last so it wins on iOS.
+// for the API 28 fix; check it separately if an iOS bottom gap shows up.
 :host-context(body.isIOS.isKeyboardVisible) {
   height: calc(100% - var(--keyboard-overlay-offset, 0px) - var(--safe-area-top));
 }

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -47,7 +47,17 @@
   // Safe Areas (iOS notch, home indicator)
   // Uses env() for native iOS safe areas
   // -----------------------------
-  --safe-area-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  // `--android-status-bar-overlap` is fed natively (CapacitorMainActivity
+  // .pushStatusBarOverlapBelowApi30) on the WebView < 140 tail, where
+  // env(safe-area-inset-top) wrongly resolves to 0 under edge-to-edge (old
+  // WebViews map only display cutouts into safe-area insets, not the status bar)
+  // — #8508 / #8283 (Android 9 / API 28). It is 0 once the WebView is inset, so
+  // max() never double-counts; on API >= 35 / WebView >= 140 the injected
+  // --safe-area-inset-top wins via var() precedence and this fallback is ignored.
+  --safe-area-top: var(
+    --safe-area-inset-top,
+    max(env(safe-area-inset-top, 0px), var(--android-status-bar-overlap, 0px))
+  );
   --safe-area-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
   --safe-area-left: var(--safe-area-inset-left, env(safe-area-inset-left, 0px));
   --safe-area-right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -54,6 +54,9 @@
   // — #8508 / #8283 (Android 9 / API 28). It is 0 once the WebView is inset, so
   // max() never double-counts; on API >= 35 / WebView >= 140 the injected
   // --safe-area-inset-top wins via var() precedence and this fallback is ignored.
+  // Declared 0px so the token is always defined (it is only ever overridden by
+  // the native inline write on the affected tail).
+  --android-status-bar-overlap: 0px;
   --safe-area-top: var(
     --safe-area-inset-top,
     max(env(safe-area-inset-top, 0px), var(--android-status-bar-overlap, 0px))


### PR DESCRIPTION
## What

Three small Android layout fixes downstream of the #8508 edge-to-edge + soft-keyboard saga, sitting on top of the SystemBars migration (#8543), plus review-driven follow-ups.

Canonical reference (full mechanics + device matrix): [`docs/android-edge-to-edge-keyboard.md`](docs/android-edge-to-edge-keyboard.md) — the two "#8508 follow-up" sections.

## Changes

1. **Note/markdown dialog sized above the keyboard.** `DialogFullscreenMarkdownComponent` (`position: fixed; height: 100%`) only subtracted `--keyboard-overlay-offset`, which is set **only on iOS** → a no-op on Android, so the toolbar + textarea + Close/Save got squashed with a gap to the keyboard. The Android/mobile-web rule now uses the resize-detecting `--keyboard-height` (pure VisualViewport signal, same as the add-task bar); iOS keeps its own rule.

2. **Header inset below the status bar on API < 30.** Under SystemBars, `--safe-area-top` resolves via the SCSS fallback to `env(safe-area-inset-top)`, but old WebViews (<140) under enforced edge-to-edge map only display *cutouts* (not the status bar) into safe-area insets → `env()` = 0 → content draws under the status bar (Android 9 / API 28). New native `pushStatusBarOverlapBelowApi30` measures `max(0, rect.top − webViewTopOnScreen)` and publishes `--android-status-bar-overlap`; SCSS folds it via `max(env(...), var(--android-status-bar-overlap))`. Gated `SDK < 30 && WebView < 140` (mirrors the #8528 keyboard shim) so it never fights SystemBars. The native write uses a **separate** CSS var (not `--safe-area-inset-*`), so it never races SystemBars.

3. **Stop double-counting `--safe-area-top` in the dialog height.** `:host` is border-box (global reset) with `padding-top: var(--safe-area-top)`, so the inset is already inside `height: 100%`; the Android keyboard rule no longer also subtracts `--safe-area-top` (which left a safe-area-top-sized gap once fix #2 made the var non-zero).

### Review follow-ups (multi-agent review)

- **Re-publish the overlap after a web reload.** `--android-status-bar-overlap` lives only as an inline style on the document, so a `window.location.reload()` (language change, PWA update, sync-conflict recovery) wipes it while the native dedupe field survives → the unchanged value was skipped and the header regressed on the API<30/WebView<140 tail. Now reset in `flushPendingShareIntent()` (runs on every frontend (re)load).
- **iOS dialog rule hardening.** iOS carries both `isNativeMobile` and `isIOS` and sets `--keyboard-height` non-zero, so the two equal-specificity rules both matched and iOS correctness depended on source order. The Android rule now uses `:not(.isIOS)` → mutually exclusive, order-independent.
- Declared `--android-status-bar-overlap: 0px` in `:root` for discoverability.

## Risk / scope

- No data shape, sync format, or public/plugin API touched. `--android-status-bar-overlap` is an internal CSS var on a single legacy device tail, cleanly removable once WebView<140/API<30 ages out.
- The per-`OnGlobalLayoutListener` work is gated by an `SDK_INT >= 30` early return (≈ one int compare on the 99% of devices), deduped, and reuses a shared `IntArray` — negligible hot-path cost.
- `_patchCdkViewportForSafeArea` reads the raw `--safe-area-inset-top` (not the computed `--safe-area-top`), so overlay/menu positioning is unchanged (#8283 scoping preserved).

## ⚠️ Not yet verified — on-device validation required

- **No on-device testing yet.** The Kotlin does not compile in CI's review env (gradle); the native method was reviewed by reading, reusing patterns proven in #8528.
- The iOS dialog rule's `− --safe-area-top` term is unverified on an iOS device (flagged in code + doc); by border-box logic it *may* have a latent gap too — drop the term there if an iOS bottom gap appears.

### Device test matrix

| Device class | Check |
| --- | --- |
| **API 28 / WebView < 140** | status bar clear of content; rotate → top inset updates; note dialog Close/Save flush to keyboard; add-task bar above keyboard (#8528); **change language (forces reload) → status bar stays clear** |
| **API 30–34** | status bar correct; note dialog correct |
| **API ≥ 35 / WebView ≥ 140** | no-op check — identical to pre-change; `--android-status-bar-overlap` never set; SystemBars owns insets |
| **iOS** | note dialog Close/Save flush to keyboard (watch for a `--safe-area-top`-sized gap) |

Debug: `adb logcat -s SUPKeyboard` shows `statusBarOverlap -> Npx` (deduped).