### PR TITLE
fix(markdown): prevent checkbox icon ligature text from polluting cli

### DIFF
--- a/src/styles/components/markdown.scss
+++ b/src/styles/components/markdown.scss
@@ -111,6 +111,8 @@
     padding-right: var(--s);
     position: relative;
     cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
 
     &:after {
       content: '';


### PR DESCRIPTION
## Problem
Fixes #8545.
When selecting and copying checklist items from the rendered markdown preview, the Material Icons ligature text (`check_box_outline_blank` / `check_box`) was included in the clipboard because the underlying text content of the icon span is selectable.
## Solution
Added `user-select: none` (and `-webkit-user-select: none`) to `.checkbox` in `src/styles/components/markdown.scss`. This prevents the icon text from being selected or copied while preserving the visual checkbox and clickable behavior.
This is the minimal fix discussed in the issue; it removes the garbage text from the clipboard without attempting full markdown reconstruction.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)
## Checklist
- [ ] I have included relevant changes to the [documentation/wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)