### PR TITLE
Add 'YouTrack Importer for SuperProductivity' plugin to community plugins list

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -110,5 +110,13 @@
     "author": "giba0",
     "authorUrl": "https://github.com/giba0",
     "stars": 2
+  },
+  {
+    "name": "YouTrack Importer for SuperProductivity",
+    "shortDescription": "Bring YouTrack issues into SuperProductivity, either as a one-off CSV import or as a live, repeatable sync directly against the YouTrack REST API.",
+    "url": "https://github.com/coissay/superProductivity-YoutrackPlugin",
+    "author": "coissay",
+    "authorUrl": "https://github.com/coissay",
+    "stars": 0
   }
 ]


### PR DESCRIPTION
Add 'YouTrack Importer for SuperProductivity' plugin to community plugins list

## Problem

No integration for Youtrack 

## Solution

Add integration as plugin by importing csv out of youtrack or via youtrack apikey

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
