### PR TITLE
fix(tasks): resolve dropped-file path via webUtils.getPathForFile

### DIFF
--- a/src/app/core/drop-paste-input/drop-paste-input.spec.ts
+++ b/src/app/core/drop-paste-input/drop-paste-input.spec.ts
@@ -1,0 +1,74 @@
+import { createFromDrop } from './drop-paste-input';
+
+// Minimal DragEvent stub: only the bits createFromDrop reads.
+const dropEventWithFile = (file: File, text = ''): DragEvent =>
+  ({
+    dataTransfer: {
+      getData: (type: string) => (type === 'text' ? text : ''),
+      files: [file] as unknown as FileList,
+    },
+  }) as unknown as DragEvent;
+
+describe('createFromDrop', () => {
+  let originalEa: typeof window.ea | undefined;
+
+  beforeEach(() => {
+    originalEa = window.ea;
+  });
+
+  afterEach(() => {
+    if (originalEa === undefined) {
+      delete (window as { ea?: typeof window.ea }).ea;
+    } else {
+      window.ea = originalEa;
+    }
+  });
+
+  it('should create a FILE attachment from a dropped file', () => {
+    const file = new File(['x'], 'photo.png', { type: 'image/png' });
+    const result = createFromDrop(dropEventWithFile(file));
+
+    expect(result).toEqual({
+      title: 'photo',
+      path: 'photo.png',
+      type: 'FILE',
+      icon: jasmine.any(String),
+    });
+  });
+
+  it('should resolve the absolute path via window.ea.getPathForFile in Electron (#8553)', () => {
+    // Simulate Electron, where File.path no longer exists (Electron 32+) and the
+    // real filesystem path must come from webUtils.getPathForFile.
+    const absPath = 'C:\\Users\\me\\Pictures\\photo.png';
+    window.ea = {
+      getPathForFile: (f: File) => (f.name === 'photo.png' ? absPath : null),
+    } as unknown as typeof window.ea;
+
+    const file = new File(['x'], 'photo.png', { type: 'image/png' });
+    const result = createFromDrop(dropEventWithFile(file));
+
+    // The path must be the absolute one so "open" works; the title stays clean.
+    expect(result?.path).toBe(absPath);
+    expect(result?.type).toBe('FILE');
+    expect(result?.title).toBe('photo');
+  });
+
+  it('should fall back to the file name when getPathForFile returns null', () => {
+    window.ea = {
+      getPathForFile: () => null,
+    } as unknown as typeof window.ea;
+
+    const file = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+    const result = createFromDrop(dropEventWithFile(file));
+
+    expect(result?.path).toBe('doc.pdf');
+  });
+
+  it('should treat dropped text as a link, not a file', () => {
+    const file = new File(['x'], 'ignored.png', { type: 'image/png' });
+    const result = createFromDrop(dropEventWithFile(file, 'https://example.com'));
+
+    expect(result?.type).toBe('LINK');
+    expect(result?.path).toBe('https://example.com');
+  });
+});

--- a/src/app/core/drop-paste-input/drop-paste-input.ts
+++ b/src/app/core/drop-paste-input/drop-paste-input.ts
@@ -46,18 +46,29 @@ const _createTextBookmark = (text: string): null | DropPasteInput => {
 };
 
 const _createFileBookmark = (dataTransfer: DataTransfer): null | DropPasteInput => {
-  const path =
-    dataTransfer.files[0] &&
-    ((dataTransfer.files[0] as any).path || dataTransfer.files[0].name);
-  if (path) {
-    return {
-      title: _baseName(path),
-      path,
-      type: 'FILE',
-      icon: DropPasteIcons.FILE,
-    };
+  const file = dataTransfer.files[0];
+  if (!file) {
+    return null;
   }
-  return null;
+
+  // Electron 32+ removed the non-standard File.path property. Without the
+  // absolute path the attachment only stores the bare file name, so "open"
+  // silently fails (shell.openPath can't resolve a relative path). Recover it
+  // via webUtils.getPathForFile (exposed on window.ea, Electron-only). See
+  // issue #8553.
+  const path = window.ea?.getPathForFile?.(file) || file.name;
+  if (!path) {
+    return null;
+  }
+
+  // Keep the title clean (file.name is already the bare name) so it isn't the
+  // full OS path once `path` resolves to an absolute Windows/Unix path.
+  return {
+    title: _baseName(file.name || path),
+    path,
+    type: 'FILE',
+    icon: DropPasteIcons.FILE,
+  };
 };
 
 const _baseName = (passedStr: string): string => {


### PR DESCRIPTION
Closes #8553

## Problem
On the desktop (Electron) build, dragging a file onto a task and clicking
"open attachment" did nothing — no action, no console output.

## Root cause
Electron 32+ removed the non-standard `File.path` property; the app ships
Electron 41.4.0. `_createFileBookmark` still read `dataTransfer.files[0].path`
(now `undefined`) and fell back to the bare file name. The attachment was
stored as `{ type: 'FILE', path: 'image.jpg' }`, so `shell.openPath('image.jpg')`
could not resolve the relative path and silently no-op'd.

## Fix
Resolve the absolute path via `window.ea.getPathForFile` — the official
`webUtils` replacement already used by `clipboard-image.service` — falling back
to `file.name` in the browser. The attachment title is sourced from `file.name`
so it stays clean rather than becoming the full OS path.

## Tests
New `drop-paste-input.spec.ts` (4 tests): file drop, Electron path resolution,
null fallback, dropped-text-as-link. `checkFile` passes; dependent specs green.

## Notes
- Security: the resolved path is synced, but `isPathSafeToOpen` still blocks
  UNC / `file://host` paths in the main process before `shell.openPath`
  (GHSA-hr87-735w-hfq3 defense intact).
- Not device-verified on Windows/Electron 41 in CI, but `getPathForFile` is the
  documented `File.path` replacement and already used identically elsewhere.
