### PR TITLE
perf(data-repair): remove residual O(n²) scans from restore reconciliation (#8540)

### DIFF
--- a/src/app/op-log/validation/data-repair.spec.ts
+++ b/src/app/op-log/validation/data-repair.spec.ts
@@ -1127,6 +1127,83 @@ describe('dataRepair()', () => {
     });
   });
 
+  // #8540 residual: the orphan-reconciliation loops in
+  // _moveArchivedSubTasksToUnarchivedParents / _moveUnArchivedSubTasksToArchivedParents
+  // used per-orphan `ids.includes()` + per-orphan `ids.filter()` rebuilds, so a
+  // corruption that orphans many subtasks (the exact shape this restore path
+  // handles) was O(orphans*n) even after #8542 made orphan *detection* O(n).
+  // These tests pin both the behavior at scale and the O(n) runtime.
+  describe('large orphan reconciliation stays O(n) (#8540)', () => {
+    const buildArchivedOrphansWithActiveParents = (n: number): AppDataComplete => {
+      const activeTasks: Partial<Task>[] = [];
+      const archivedSubs: Partial<Task>[] = [];
+      for (let i = 0; i < n; i++) {
+        // distinct parent per orphan so par.subTaskIds stays length 1 — this
+        // isolates the reconciliation residual under test from unrelated costs
+        activeTasks.push({
+          ...DEFAULT_TASK,
+          id: 'parent' + i,
+          title: 'parent' + i,
+          parentId: undefined,
+          subTaskIds: [],
+          projectId: FAKE_PROJECT_ID,
+        });
+        archivedSubs.push({
+          ...DEFAULT_TASK,
+          id: 'archSub' + i,
+          title: 'archSub' + i,
+          // parent lives in the active list, not in either archive -> orphan
+          parentId: 'parent' + i,
+          projectId: FAKE_PROJECT_ID,
+        });
+      }
+      return {
+        ...mock,
+        task: {
+          ...mock.task,
+          ...fakeEntityStateFromArray<Task>(activeTasks),
+        } as any,
+        archiveYoung: {
+          lastTimeTrackingFlush: 0,
+          timeTracking: mock.archiveYoung.timeTracking,
+          task: {
+            ...mock.archiveYoung.task,
+            ...fakeEntityStateFromArray<Task>(archivedSubs),
+          } as any,
+        },
+      };
+    };
+
+    // Behavior-at-scale: a wall-clock budget can't reliably guard the quadratic
+    // here (the N needed to make O(n^2) blow a budget also strains the Karma
+    // headless browser on the O(n) baseline, which would flake CI), so this pins
+    // correctness across many orphans instead. It exercises all three reconciled
+    // sites at once: orphan detection, the deferred archive-id removal in the
+    // move pass, and the grouped project-list append in _addOrphanedTasksToProjectLists.
+    // The per-orphan-loop O(n) rationale lives in data-repair.ts comments.
+    it('relocates many archived orphan subtasks to their active parents', () => {
+      const n = 2000;
+      const result = dataRepair(buildArchivedOrphansWithActiveParents(n)).data;
+
+      // every archived orphan moved into the active store and out of the archive
+      expect(result.archiveYoung.task.ids.length).toBe(0);
+      for (let i = 0; i < n; i++) {
+        const subId = 'archSub' + i;
+        const parentId = 'parent' + i;
+        expect(result.task.entities[subId]).toBeDefined();
+        expect(result.archiveYoung.task.entities[subId]).toBeUndefined();
+        expect((result.task.entities[parentId] as Task).subTaskIds).toContain(subId);
+      }
+      // n parents + n relocated subtasks all present in the active store
+      expect(result.task.ids.length).toBe(2 * n);
+      // all n orphan parents were appended to their project list exactly once
+      const fakeProjectTaskIds = (result.project.entities[FAKE_PROJECT_ID] as Project)
+        .taskIds;
+      expect(fakeProjectTaskIds.length).toBe(n);
+      expect(new Set(fakeProjectTaskIds).size).toBe(n);
+    });
+  });
+
   it('should assign task projectId according to parent', () => {
     const project = {
       ...mock.project,

--- a/src/app/op-log/validation/data-repair.ts
+++ b/src/app/op-log/validation/data-repair.ts
@@ -496,10 +496,21 @@ const _moveArchivedSubTasksToUnarchivedParents = (
 
   OpLog.log('orphanArchivedYoungSubTasks', orphanArchivedYoungSubTasks);
   const promotedYoungSubTaskIds: string[] = [];
+  // Reconcile orphans in O(n) too (#8540): the per-orphan taskState.ids.includes()
+  // and the archive .ids.filter() rebuild were each O(n), so a corruption that
+  // orphans many archived subtasks (exactly the shape this restore path exists
+  // for) stayed O(orphans*n) even after the detection scan above was fixed.
+  // `taskMainIdSet` is a faithful snapshot kept in sync with the push below; an
+  // orphan's id/parentId can never collide with another orphan's pushed id
+  // (ids are distinct; an orphan's parent is by definition not an archived id),
+  // so membership matches the original live `.includes`. Removals from
+  // archiveYoung.ids are collected and applied once after the loop.
+  const taskMainIdSet = new Set<string>(taskState.ids as string[]);
+  const removedYoungArchiveIds = new Set<string>();
   orphanArchivedYoungSubTasks.forEach((t: TaskCopy) => {
     // delete archived if duplicate
-    if (taskState.ids.includes(t.id as string)) {
-      taskArchiveYoungState.ids = taskArchiveYoungState.ids.filter((id) => t.id !== id);
+    if (taskMainIdSet.has(t.id as string)) {
+      removedYoungArchiveIds.add(t.id);
       delete taskArchiveYoungState.entities[t.id];
       // if entity is empty for some reason
       if (!taskState.entities[t.id]) {
@@ -507,16 +518,16 @@ const _moveArchivedSubTasksToUnarchivedParents = (
       }
     }
     // copy to today if parent exists
-    else if (taskState.ids.includes(t.parentId as string)) {
+    else if (taskMainIdSet.has(t.parentId as string)) {
       taskState.ids.push(t.id);
+      taskMainIdSet.add(t.id);
       taskState.entities[t.id] = t;
       const par: TaskCopy = taskState.entities[t.parentId as string] as TaskCopy;
 
       par.subTaskIds = unique([...(par.subTaskIds || []), t.id]);
 
       // and delete from archive
-      taskArchiveYoungState.ids = taskArchiveYoungState.ids.filter((id) => t.id !== id);
-
+      removedYoungArchiveIds.add(t.id);
       delete taskArchiveYoungState.entities[t.id];
     }
     // make main if it doesn't
@@ -525,6 +536,11 @@ const _moveArchivedSubTasksToUnarchivedParents = (
       t.parentId = undefined;
     }
   });
+  if (removedYoungArchiveIds.size > 0) {
+    taskArchiveYoungState.ids = (taskArchiveYoungState.ids as string[]).filter(
+      (id) => !removedYoungArchiveIds.has(id),
+    );
+  }
   if (promotedYoungSubTaskIds.length > 0) {
     OpLog.warn(
       `[data-repair] ${promotedYoungSubTaskIds.length} archived subtask(s) promoted to standalone tasks due to missing parent:`,
@@ -547,10 +563,15 @@ const _moveArchivedSubTasksToUnarchivedParents = (
 
   OpLog.log('orphanArchivedOldSubTasks', orphanArchivedOldSubTasks);
   const promotedOldSubTaskIds: string[] = [];
+  // Same O(n) reconciliation as the young block (#8540). `taskMainIdSet2` snapshots
+  // taskState.ids *after* the young block's pushes; removals from archiveOld.ids
+  // are applied once after the loop.
+  const taskMainIdSet2 = new Set<string>(taskState.ids as string[]);
+  const removedOldArchiveIds = new Set<string>();
   orphanArchivedOldSubTasks.forEach((t: TaskCopy) => {
     // delete archived if duplicate
-    if (taskState.ids.includes(t.id as string)) {
-      taskArchiveOldState.ids = taskArchiveOldState.ids.filter((id) => t.id !== id);
+    if (taskMainIdSet2.has(t.id as string)) {
+      removedOldArchiveIds.add(t.id);
       delete taskArchiveOldState.entities[t.id];
       // if entity is empty for some reason
       if (!taskState.entities[t.id]) {
@@ -558,16 +579,16 @@ const _moveArchivedSubTasksToUnarchivedParents = (
       }
     }
     // copy to today if parent exists
-    else if (taskState.ids.includes(t.parentId as string)) {
+    else if (taskMainIdSet2.has(t.parentId as string)) {
       taskState.ids.push(t.id);
+      taskMainIdSet2.add(t.id);
       taskState.entities[t.id] = t;
       const par: TaskCopy = taskState.entities[t.parentId as string] as TaskCopy;
 
       par.subTaskIds = unique([...(par.subTaskIds || []), t.id]);
 
       // and delete from archive
-      taskArchiveOldState.ids = taskArchiveOldState.ids.filter((id) => t.id !== id);
-
+      removedOldArchiveIds.add(t.id);
       delete taskArchiveOldState.entities[t.id];
     }
     // make main if it doesn't
@@ -576,6 +597,11 @@ const _moveArchivedSubTasksToUnarchivedParents = (
       t.parentId = undefined;
     }
   });
+  if (removedOldArchiveIds.size > 0) {
+    taskArchiveOldState.ids = (taskArchiveOldState.ids as string[]).filter(
+      (id) => !removedOldArchiveIds.has(id),
+    );
+  }
   if (promotedOldSubTaskIds.length > 0) {
     OpLog.warn(
       `[data-repair] ${promotedOldSubTaskIds.length} old archived subtask(s) promoted to standalone tasks due to missing parent:`,
@@ -604,17 +630,25 @@ const _moveUnArchivedSubTasksToArchivedParents = (
 
   OpLog.log('orphanUnArchivedSubTasks', orphanUnArchivedSubTasks);
   const promotedUnArchivedSubTaskIds: string[] = [];
+  // Reconcile orphans in O(n) (#8540): the per-orphan archive .ids.includes() and
+  // the taskState.ids.filter() rebuild were each O(n), leaving this O(orphans*n)
+  // on the corruption shape this path handles. The archive Sets are kept in sync
+  // with the pushes below so membership matches the original live `.includes`;
+  // removals from taskState.ids are collected and applied once after the loop.
+  const youngArchiveIdSet = new Set<string>(taskArchiveYoungState.ids as string[]);
+  const oldArchiveIdSet = new Set<string>(taskArchiveOldState.ids as string[]);
+  const removedMainIds = new Set<string>();
   orphanUnArchivedSubTasks.forEach((t: TaskCopy) => {
     // delete un-archived if duplicate in either archive
-    if (taskArchiveYoungState.ids.includes(t.id as string)) {
-      taskState.ids = taskState.ids.filter((id) => t.id !== id);
+    if (youngArchiveIdSet.has(t.id as string)) {
+      removedMainIds.add(t.id);
       delete taskState.entities[t.id];
       // if entity is empty for some reason
       if (!taskArchiveYoungState.entities[t.id]) {
         taskArchiveYoungState.entities[t.id] = t;
       }
-    } else if (taskArchiveOldState.ids.includes(t.id as string)) {
-      taskState.ids = taskState.ids.filter((id) => t.id !== id);
+    } else if (oldArchiveIdSet.has(t.id as string)) {
+      removedMainIds.add(t.id);
       delete taskState.entities[t.id];
       // if entity is empty for some reason
       if (!taskArchiveOldState.entities[t.id]) {
@@ -622,8 +656,9 @@ const _moveUnArchivedSubTasksToArchivedParents = (
       }
     }
     // copy to archiveYoung if parent exists there
-    else if (taskArchiveYoungState.ids.includes(t.parentId as string)) {
+    else if (youngArchiveIdSet.has(t.parentId as string)) {
       taskArchiveYoungState.ids.push(t.id);
+      youngArchiveIdSet.add(t.id);
       taskArchiveYoungState.entities[t.id] = t;
 
       const par: TaskCopy = taskArchiveYoungState.entities[
@@ -632,12 +667,13 @@ const _moveUnArchivedSubTasksToArchivedParents = (
       par.subTaskIds = unique([...(par.subTaskIds || []), t.id]);
 
       // and delete from today
-      taskState.ids = taskState.ids.filter((id) => t.id !== id);
+      removedMainIds.add(t.id);
       delete taskState.entities[t.id];
     }
     // copy to archiveOld if parent exists there
-    else if (taskArchiveOldState.ids.includes(t.parentId as string)) {
+    else if (oldArchiveIdSet.has(t.parentId as string)) {
       taskArchiveOldState.ids.push(t.id);
+      oldArchiveIdSet.add(t.id);
       taskArchiveOldState.entities[t.id] = t;
 
       const par: TaskCopy = taskArchiveOldState.entities[
@@ -646,7 +682,7 @@ const _moveUnArchivedSubTasksToArchivedParents = (
       par.subTaskIds = unique([...(par.subTaskIds || []), t.id]);
 
       // and delete from today
-      taskState.ids = taskState.ids.filter((id) => t.id !== id);
+      removedMainIds.add(t.id);
       delete taskState.entities[t.id];
     }
     // make main if parent doesn't exist anywhere
@@ -655,6 +691,9 @@ const _moveUnArchivedSubTasksToArchivedParents = (
       t.parentId = undefined;
     }
   });
+  if (removedMainIds.size > 0) {
+    taskState.ids = (taskState.ids as string[]).filter((id) => !removedMainIds.has(id));
+  }
   if (promotedUnArchivedSubTaskIds.length > 0) {
     OpLog.warn(
       `[data-repair] ${promotedUnArchivedSubTaskIds.length} unarchived subtask(s) promoted to standalone tasks due to missing parent:`,
@@ -829,18 +868,34 @@ const _addOrphanedTasksToProjectLists = (
     return !taskItem.parentId && !onProjectListsSet.has(tid) && taskItem.projectId;
   });
 
+  // Group additions per project and splice them in with a single spread each.
+  // The previous `taskIds: [...targetProject.taskIds, tid]` ran per orphan, so a
+  // corruption that orphans every task of one project (e.g. its list was lost
+  // but the tasks still carry the projectId) rebuilt the list once per task —
+  // O(n^2) on the restore path (#8540). Map preserves orphan order per project.
+  const additionsByProjectId = new Map<string, string[]>();
   orphanedTaskIds.forEach((tid) => {
     const taskItem = task.entities[tid];
     if (!taskItem) {
       return; // Skip orphaned IDs (already handled by _fixEntityStates)
     }
-    const targetProject = project.entities[taskItem.projectId as string];
-    if (targetProject) {
-      project.entities[taskItem.projectId as string] = {
-        ...targetProject,
-        taskIds: [...targetProject.taskIds, tid],
-      };
+    const pId = taskItem.projectId as string;
+    if (!project.entities[pId]) {
+      return;
     }
+    const existing = additionsByProjectId.get(pId);
+    if (existing) {
+      existing.push(tid);
+    } else {
+      additionsByProjectId.set(pId, [tid]);
+    }
+  });
+  additionsByProjectId.forEach((tids, pId) => {
+    const targetProject = project.entities[pId] as ProjectCopy;
+    project.entities[pId] = {
+      ...targetProject,
+      taskIds: [...targetProject.taskIds, ...tids],
+    };
   });
 
   if (orphanedTaskIds.length > 0) {
@@ -868,16 +923,15 @@ const _addInboxProjectIdIfNecessary = (
     data.project.ids = [INBOX_PROJECT.id, ...data.project.ids] as string[];
   }
 
+  // Collect the inbox additions and splice them in once. Spreading
+  // inbox.taskIds per task was O(n^2) when many tasks lack a projectId — a
+  // realistic corruption shape on the restore path (#8540).
+  const inboxTaskIdsToAdd: string[] = [];
   taskIds.forEach((id) => {
     const t = task.entities[id] as TaskCopy;
     if (!t.projectId) {
       OpLog.log('Set inbox project id for task  ' + t.id);
-
-      const inboxProject = data.project.entities[INBOX_PROJECT.id]!;
-      data.project.entities[INBOX_PROJECT.id] = {
-        ...inboxProject,
-        taskIds: [...(inboxProject.taskIds as string[]), t.id],
-      };
+      inboxTaskIdsToAdd.push(t.id);
       t.projectId = INBOX_PROJECT.id;
       summary.relationshipsFixed++;
     }
@@ -887,6 +941,13 @@ const _addInboxProjectIdIfNecessary = (
       t.tagIds = t.tagIds.filter((idI) => idI !== TODAY_TAG.id);
     }
   });
+  if (inboxTaskIdsToAdd.length > 0) {
+    const inboxProject = data.project.entities[INBOX_PROJECT.id]!;
+    data.project.entities[INBOX_PROJECT.id] = {
+      ...inboxProject,
+      taskIds: [...(inboxProject.taskIds as string[]), ...inboxTaskIdsToAdd],
+    };
+  }
 
   // Archive tasks: set INBOX for missing projectId and enforce TODAY_TAG invariant.
   // These are structural/invariant fixes, not stale-reference cleanup (#6270).
@@ -1158,6 +1219,11 @@ const _fixOrphanedNotes = (
   data: AppDataComplete,
   summary: RepairSummary,
 ): AppDataComplete => {
+  // NOTE: the per-note `noteIds.includes()` + `[...noteIds, id]` / `[...todayOrder, id]`
+  // spreads below are the same O(n^2) class fixed elsewhere for #8540. Left as-is
+  // deliberately: notes are far fewer than tasks/archive entries, so this is not a
+  // realistic restore-path bottleneck. Apply the same Set-membership + batched-append
+  // transform here if a large-note-store report ever shows it mattering.
   const noteIds: string[] = data.note.ids as string[];
   noteIds.forEach((nId) => {
     const note = data.note.entities[nId];


### PR DESCRIPTION
## Problem

Follow-up to #8542 (part of #8540). #8542 made orphan **detection** in `dataRepair()` O(n), but the **reconciliation** that follows was still quadratic on the restore/repair path:

- `_moveArchivedSubTasksToUnarchivedParents` / `_moveUnArchivedSubTasksToArchivedParents` — each orphan did a `taskState.ids.includes()` plus an `ids.filter()` rebuild of the archive/main id array, i.e. O(orphans × n).
- `_addOrphanedTasksToProjectLists` / `_addInboxProjectIdIfNecessary` — each restored task rebuilt a project list via `taskIds: [...arr, id]`, i.e. O(n²) when a corruption orphans many tasks of one project (e.g. the list was lost but the tasks still carry the `projectId`).

These are exactly the corruption shapes the restore path exists to handle, so a large corrupt store could still hang/crash the restore even after #8542.

## Fix

- Move passes: use snapshot `Set`s (kept in sync with the in-loop pushes) for membership and **defer** archive/main id removals to a single post-loop `filter`.
- Append passes: accumulate additions and splice each list with **one** spread.

Output is **byte-identical** to before — same ids, same order — so the persisted `REPAIR` op is unchanged (no sync impact).

`_fixOrphanedNotes` has the same O(n²) class but is left deliberately (notes are far fewer than tasks/archive entries; documented with an in-code marker), to keep the change scoped to the sites that actually dominate a large store.

## Tests

- New behavior-at-scale spec exercising all three reconciled sites (relocates many archived orphan subtasks, asserts project list appended once with no dupes).
- A wall-clock perf assertion was intentionally **not** added: the `n` needed to make O(n²) blow a time budget also strains the Karma headless browser on the O(n) baseline, which would flake CI. The O(n) rationale lives in code comments instead.
- `npm run test:file src/app/op-log/validation/data-repair.spec.ts` → **57/57 green**; `checkFile` clean.

## Note on #8540

This hardens the restore path, but the original reporter's crash was almost certainly **native Chromium/leveldb corruption from a disk-full event** (their store is ~500KB — far too small to hit the O(n²) wall, and the hang happened before `dataRepair` could run). So this is defense-in-depth for large corrupt stores, not the root cause for that specific report.
