### PR TITLE
Add Invoice Ninja Export to community plugins list

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -110,5 +110,13 @@
     "author": "giba0",
     "authorUrl": "https://github.com/giba0",
     "stars": 2
+  },
+  {
+    "name": "Invoice Ninja Export",
+    "shortDescription": "Exports completed tasks to Invoice Ninja as billable Client Tasks, grouped by SP project (matched by name to an Invoice Ninja Client).",
+    "url": "https://github.com/clinkin-lawyer/sp-invoice-ninja-export",
+    "author": "clinkin-lawyer",
+    "authorUrl": "https://github.com/clinkin-lawyer",
+    "stars": 0
   }
 ]


### PR DESCRIPTION
## Summary
Adds a new entry to `src/assets/community-plugins.json` for **Invoice Ninja Export** — a plugin that exports completed SP tasks to Invoice Ninja as billable Client Tasks (grouped by SP project, matched by exact name to an Invoice Ninja Client).

- Repo: https://github.com/clinkin-lawyer/sp-invoice-ninja-export
- License: MIT
- Tested manually against a live Invoice Ninja (invoicing.co) instance: project/client name matching, task export with time logs, and dedup via export history tracking all confirmed working.

## Test plan
- [x] `community-plugins.json` validated as well-formed JSON
- [x] Plugin installs and runs in SuperProductivity via both "Load Plugin from Folder" and "Upload Plugin" (zip)
- [x] README documents setup (API token generation/configuration) and the project-name-to-client-name matching requirement