### PR TITLE
fix(tasks): parse short syntax for sub-tasks added via inline input (#8568)

### DIFF
--- a/src/app/features/tasks/store/short-syntax.effects.spec.ts
+++ b/src/app/features/tasks/store/short-syntax.effects.spec.ts
@@ -4,7 +4,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { ShortSyntaxEffects } from './short-syntax.effects';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
-import { addNewTagsFromShortSyntax } from './task.actions';
+import { addNewTagsFromShortSyntax, addSubTask } from './task.actions';
 import { TaskService } from '../task.service';
 import { TagService } from '../../tag/tag.service';
 import { ProjectService } from '../../project/project.service';
@@ -182,6 +182,46 @@ describe('ShortSyntaxEffects', () => {
       // The effect should emit an applyShortSyntax action
       expect(emittedAction).toBeDefined();
       expect(emittedAction.type).toBe(TaskSharedActions.applyShortSyntax.type);
+    }));
+
+    it('should parse short syntax for sub-tasks added via addSubTask (#8568)', fakeAsync(() => {
+      const task = createTask('sub-1', {
+        title: 'Buy milk 15m',
+        parentId: 'parent-1',
+      });
+      taskServiceMock.getByIdOnce$.and.returnValue(of(task));
+
+      let emittedAction: any = null;
+      effects.shortSyntax$.subscribe((action) => {
+        emittedAction = action;
+      });
+
+      actions$.next(addSubTask({ task, parentId: 'parent-1' }));
+
+      tick(100);
+
+      expect(emittedAction).toBeDefined();
+      expect(emittedAction.type).toBe(TaskSharedActions.applyShortSyntax.type);
+      expect(emittedAction.taskChanges.timeEstimate).toBe(15 * 60 * 1000);
+      expect(emittedAction.taskChanges.title).toBe('Buy milk');
+    }));
+
+    it('should NOT parse short syntax for addSubTask when isIgnoreShortSyntax is true', fakeAsync(() => {
+      const task = createTask('sub-1', {
+        title: 'Buy milk 15m',
+        parentId: 'parent-1',
+      });
+      taskServiceMock.getByIdOnce$.and.returnValue(of(task));
+
+      let emitted = false;
+      effects.shortSyntax$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(addSubTask({ task, parentId: 'parent-1', isIgnoreShortSyntax: true }));
+
+      tick(100);
+      expect(emitted).toBe(false);
     }));
 
     it('should NOT process update actions that do not change title', fakeAsync(() => {

--- a/src/app/features/tasks/store/short-syntax.effects.spec.ts
+++ b/src/app/features/tasks/store/short-syntax.effects.spec.ts
@@ -218,7 +218,9 @@ describe('ShortSyntaxEffects', () => {
         emitted = true;
       });
 
-      actions$.next(addSubTask({ task, parentId: 'parent-1', isIgnoreShortSyntax: true }));
+      actions$.next(
+        addSubTask({ task, parentId: 'parent-1', isIgnoreShortSyntax: true }),
+      );
 
       tick(100);
       expect(emitted).toBe(false);

--- a/src/app/features/tasks/store/short-syntax.effects.ts
+++ b/src/app/features/tasks/store/short-syntax.effects.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { createEffect, ofType } from '@ngrx/effects';
 import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
 import { Action } from '@ngrx/store';
-import { addNewTagsFromShortSyntax } from './task.actions';
+import { addNewTagsFromShortSyntax, addSubTask } from './task.actions';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import {
   catchError,
@@ -53,11 +53,13 @@ export class ShortSyntaxEffects {
 
   shortSyntax$ = createEffect(() =>
     this._actions$.pipe(
-      ofType(TaskSharedActions.addTask, TaskSharedActions.updateTask),
+      ofType(TaskSharedActions.addTask, TaskSharedActions.updateTask, addSubTask),
       filter((action): boolean => {
         if (action.isIgnoreShortSyntax) {
           return false;
         }
+        // addTask and addSubTask always carry a full title to parse; only
+        // updateTask is gated to title-only changes below.
         if (action.type !== TaskSharedActions.updateTask.type) {
           return true;
         }

--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -137,7 +137,7 @@ export const removeTimeSpent = createAction(
 
 export const addSubTask = createAction(
   '[Task] Add SubTask',
-  (taskProps: { task: Task; parentId: string }) => ({
+  (taskProps: { task: Task; parentId: string; isIgnoreShortSyntax?: boolean }) => ({
     ...taskProps,
     meta: {
       isPersistent: true,

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -827,12 +827,12 @@ export class PluginBridgeService implements OnDestroy {
 
     let createdTask: Task;
     if (taskData.parentId) {
-      // For subtasks, we need to use the addSubTask action to properly update parent.
-      // Short-syntax (e.g. "15m") is normally applied by ShortSyntaxEffects, but that
-      // effect only listens to `addTask`/`updateTask` — not `addSubTask`. So the
-      // bridge has to parse subtask titles itself, mirroring MarkdownPasteService.
-      // Tags/projects are intentionally not parsed: subtasks always inherit them
-      // from the parent (see addSubTask reducer).
+      // For subtasks, we use the addSubTask action to properly update the parent.
+      // ShortSyntaxEffects now also parses addSubTask, but we opt this path out via
+      // `isIgnoreShortSyntax` and parse only time here (mirroring MarkdownPasteService):
+      // subtasks created via the plugin API intentionally inherit tags/project from
+      // the parent and must not have them reassigned from the title (see addSubTask
+      // reducer).
       const subTaskTitleProps = this._parseSubTaskTitleTimeProps(taskData.title);
       const newTask = this._taskService.createNewTaskWithDefaults({
         title: subTaskTitleProps.title,
@@ -851,6 +851,7 @@ export class PluginBridgeService implements OnDestroy {
         addSubTask({
           task: newTask,
           parentId: taskData.parentId,
+          isIgnoreShortSyntax: true,
         }),
       );
       createdTask = newTask;
@@ -1598,8 +1599,9 @@ export class PluginBridgeService implements OnDestroy {
    */
   // Mirrors MarkdownPasteService._parseTimeProps: respects the user's
   // shortSyntax.isEnableDue config, returns the cleaned title and any parsed
-  // time fields. Used for subtasks because `addSubTask` doesn't trigger the
-  // ShortSyntaxEffects pipeline.
+  // time fields. Used for subtasks created via the plugin API, which opt out of
+  // the ShortSyntaxEffects pipeline (isIgnoreShortSyntax) to parse time only and
+  // keep tags/project inherited from the parent.
   private _parseSubTaskTitleTimeProps(originalTitle: string): {
     title: string;
     timeProps: Partial<TaskCopy>;


### PR DESCRIPTION
Fixes #8568

## Problem
Since v18.12, typing a sub-task like `Task title 15m @tomorrow` in the new
inline sub-task input kept the raw string as the title instead of parsing the
metadata. Top-level tasks were unaffected.

## Root cause
Short-syntax parsing is done by `ShortSyntaxEffects`, which only listened to
`addTask`/`updateTask`. The new inline input (#8423) commits via the
`addSubTask` action, which the effect never handled. (The pre-18.12 flow
created an empty sub-task + inline title-edit, committing via `updateTask`,
which *was* parsed.)

## Fix
- Add `addSubTask` to the `shortSyntax$` effect so sub-tasks parse exactly
  like parent tasks, and give it the same optional `isIgnoreShortSyntax` flag.
- The effect injects `LOCAL_ACTIONS`, so remote/replayed ops won't re-parse
  (replay determinism preserved) — same as `addTask` today.
- Plugin task API opts out via `isIgnoreShortSyntax` (structured input sets
  fields explicitly); markdown bulk-paste parses fully, consistent with
  pasted parent tasks.

## Tests
New unit coverage for the `addSubTask` path (parses `15m`; honors the flag).
short-syntax effects 9/9, plugin-bridge 26/26, checkFile clean.