### PR TITLE
fix(localization): keep dateTimeLocale override from being clobbered by UI language

### DIFF
--- a/src/app/core/date-time-format/date-time-format.service.spec.ts
+++ b/src/app/core/date-time-format/date-time-format.service.spec.ts
@@ -296,4 +296,82 @@ describe('DateTimeFormatService', () => {
       expect(service.currentLocale()).toBe('fr');
     });
   });
+
+  describe('explicit dateTimeLocale override (#8565)', () => {
+    const TIME_FORMAT: Intl.DateTimeFormatOptions = {
+      hour: 'numeric',
+      minute: 'numeric',
+    };
+    // 14:00 — renders "14:00" in 24h locales, "2:00 PM" in 12h (en-US) locales.
+    // The adapter time path (matTimepicker) uses the adapter's setLocale value,
+    // which is what the bug clobbered with the UI language.
+    const testDate = new Date(2000, 11, 31, 14, 0, 0);
+
+    const setup = (
+      dateTimeLocale: string | null,
+      currentLang: string,
+    ): DateTimeFormatService => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MatNativeDateModule],
+        providers: [
+          DateTimeFormatService,
+          { provide: DateAdapter, useClass: CustomDateAdapter },
+          {
+            provide: TranslateService,
+            useValue: { currentLang, defaultLang: 'en' },
+          },
+          provideMockStore({
+            initialState: {
+              globalConfig: {
+                ...DEFAULT_GLOBAL_CONFIG,
+                localization: {
+                  ...DEFAULT_GLOBAL_CONFIG.localization,
+                  lng: currentLang,
+                  dateTimeLocale,
+                },
+              },
+            },
+          }),
+        ],
+      });
+      dateAdapter = TestBed.inject(DateAdapter);
+      return TestBed.inject(DateTimeFormatService);
+    };
+
+    it('renders adapter time in 24h when dateTimeLocale is 24h but UI language is en', () => {
+      service = setup(DateTimeLocales.ja_jp, 'en');
+      TestBed.flushEffects();
+
+      expect(service.currentLocale()).toBe(DateTimeLocales.ja_jp);
+      expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('14:00');
+    });
+
+    it('does not let UI-language application clobber the dateTimeLocale override', () => {
+      service = setup(DateTimeLocales.ja_jp, 'en');
+      TestBed.flushEffects();
+      expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('14:00');
+
+      // Applying the UI language must NOT synchronously touch the adapter locale
+      // (DateTimeFormatService is the single owner). Before the fix this called
+      // setDateAdapterLocale('en') → 12h, and in the real-app startup race that
+      // clobbering write was the last one, so it stuck (#8565). Assert without
+      // flushing effects to capture exactly that window.
+      service.setUiLanguage('en');
+      expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('14:00');
+
+      // Re-running the owning effect keeps the override applied.
+      TestBed.flushEffects();
+      expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('14:00');
+    });
+
+    it('uses the UI language only as a fallback when no override is set', () => {
+      service = setup(null, 'en');
+      service.setUiLanguage('en');
+      TestBed.flushEffects();
+
+      // en (US) → 12h AM/PM
+      expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('2:00 PM');
+    });
+  });
 });

--- a/src/app/core/date-time-format/date-time-format.service.ts
+++ b/src/app/core/date-time-format/date-time-format.service.ts
@@ -12,6 +12,10 @@ export class DateTimeFormatService {
   private _dateAdapter = inject(DateAdapter, { optional: true });
   private readonly _translateService = inject(TranslateService);
   private readonly _localeSig = signal<DateTimeLocale>(DEFAULT_LOCALE);
+  // UI translation language, pushed in by LanguageService. Used only as the
+  // lowest-priority fallback when no explicit dateTimeLocale override is set.
+  // Kept as a signal so the locale effect re-runs when the language changes.
+  private readonly _uiLangSig = signal<string | null>(null);
 
   // Signal for the locale to use
   readonly currentLocale = computed<DateTimeLocale>(() => {
@@ -55,11 +59,17 @@ export class DateTimeFormatService {
   });
 
   constructor() {
-    // Use effect to reactively update date adapter locale when config changes
+    // This effect is the single owner of the date adapter locale: it resolves
+    // the effective locale (explicit override first, UI language only as a
+    // fallback) and is the sole writer. Other services must register intent via
+    // setUiLanguage() rather than set the adapter, otherwise an explicit
+    // dateTimeLocale override gets clobbered (e.g. #8565: 24h ja-jp shown 12h).
     effect(() => {
       const cfgValue = this._globalConfigService.localization()?.dateTimeLocale;
+      // Track the UI language so a language change re-applies the fallback.
+      const uiLang = this._uiLangSig();
       if (cfgValue) {
-        this.setDateAdapterLocale(cfgValue);
+        this._setDateAdapterLocale(cfgValue);
       } else {
         // No explicit date/time override: follow the browser's regional locale
         // (e.g. 'en-GB' → DD/MM/YYYY) rather than the UI translation language.
@@ -68,16 +78,31 @@ export class DateTimeFormatService {
         // picked a date locale. Fall back to UI language, then the default.
         const fallbackLocale =
           this._translateService.getBrowserCultureLang?.()?.toLowerCase() ||
+          uiLang ||
           this._translateService.currentLang ||
           this._translateService.defaultLang ||
           DEFAULT_LOCALE;
-        this.setDateAdapterLocale(fallbackLocale as DateTimeLocale);
+        this._setDateAdapterLocale(fallbackLocale as DateTimeLocale);
       }
     });
   }
 
-  /** Set the locale for the date adapter formatting */
-  setDateAdapterLocale(locale: DateTimeLocale): void {
+  /**
+   * Register the active UI translation language as a fallback for the date
+   * adapter locale (used only when no explicit dateTimeLocale is set). The
+   * owning effect resolves and applies the effective locale — this is how other
+   * services influence the adapter without clobbering an override (see #8565).
+   */
+  setUiLanguage(lng: string): void {
+    this._uiLangSig.set(lng);
+  }
+
+  /**
+   * Apply the locale to the date adapter. Private by design: only the owning
+   * effect may write the adapter locale, so an explicit dateTimeLocale override
+   * cannot be clobbered (see #8565).
+   */
+  private _setDateAdapterLocale(locale: DateTimeLocale): void {
     if (this._dateAdapter && typeof this._dateAdapter.setLocale === 'function') {
       this._dateAdapter.setLocale(locale);
     }

--- a/src/app/core/language/language.service.ts
+++ b/src/app/core/language/language.service.ts
@@ -60,7 +60,10 @@ export class LanguageService {
     this._isRTL.set(this._checkIsRTL(lng));
     this._translateService.use(lng);
 
-    this._dateTimeFormatService.setDateAdapterLocale(lng);
+    // Register the UI language as a *fallback* only; DateTimeFormatService owns
+    // the adapter locale and keeps an explicit dateTimeLocale override winning.
+    // Setting the adapter locale directly here would clobber that override (#8565).
+    this._dateTimeFormatService.setUiLanguage(lng);
   }
 
   private _checkIsRTL(lng: LanguageCode): boolean {


### PR DESCRIPTION
Closes #8565

## Problem
With UI Language = English but **Datetime format locale** = a 24h locale (e.g. Japanese), the task scheduling dialog's time field rendered 12h AM/PM (typing `14` → `02:00 PM`).

## Root cause
Two services wrote the shared Angular Material `DateAdapter` locale — `DateTimeFormatService` (applying the explicit `dateTimeLocale`) and `LanguageService` (applying the UI *language*). On startup these raced; the language write (`en`) won, so the timepicker used a 12h locale. Only *time* broke because `CustomDateAdapter` formats dates via `currentLocale()` (always honors the override) but routes time formats through `super.format()`, which uses the adapter's contested `setLocale` value.

## Fix
Make `DateTimeFormatService` the single owner of the adapter locale:
- The UI language is registered via `setUiLanguage()` as a signal-backed, lowest-priority fallback the effect reads (chain: `dateTimeLocale → browserCultureLang → uiLang → currentLang → default`).
- `_setDateAdapterLocale` is now private, so the single-owner invariant is compiler-enforced rather than comment-enforced. It is the only `.setLocale()` call in the app.
- Adds 3 regression tests; all 20 specs in the suite pass.

## Behavior note
For users with **no** explicit `dateTimeLocale`, the adapter's time path now deterministically follows browser region over UI language (consistent with #8000/#8023's intent), removing the prior startup race. A user who previously relied on the UI language alone to drive 12/24h could see a different clock format — worth a changelog line.

## Scope
Localization-only. Split out of the original combined PR #8570; the "Later Today start time" planner feature ships separately.
