### PR TITLE
feat(work-view): show start time on Later Today calendar events

### DIFF
--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.html
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.html
@@ -9,6 +9,12 @@
   <div class="planner-time-remaining-shared">
     {{ calendarEvent().duration | msToString }}
   </div>
+  @if (showStartTime()) {
+    <div
+      class="start-time"
+      [innerHTML]="calendarEvent().start | shortPlannedAt"
+    ></div>
+  }
 </div>
 
 <div

--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.scss
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.scss
@@ -64,3 +64,22 @@
     font-size: var(--planner-font-size);
   }
 }
+
+// Clock start time at the far right, mirroring a scheduled task's time badge.
+.start-time {
+  flex-shrink: 0;
+  align-self: center;
+  padding-right: var(--s);
+  text-align: right;
+  line-height: 1;
+  white-space: nowrap;
+  font-size: var(--planner-font-size-mobile);
+
+  @include mq(xs) {
+    font-size: var(--planner-font-size);
+  }
+
+  ::ng-deep span {
+    font-size: 10px;
+  }
+}

--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { PlannerCalendarEventComponent } from './planner-calendar-event.component';
+import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
+import { DateService } from '../../../core/date/date.service';
+import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
+import { ShortTimeHtmlPipe } from '../../../ui/pipes/short-time-html.pipe';
+import { ShortTimePipe } from '../../../ui/pipes/short-time.pipe';
+import { ScheduleFromCalendarEvent } from '../../schedule/schedule.model';
+
+const EVENT: ScheduleFromCalendarEvent = {
+  id: 'e1',
+  calProviderId: 'cal-1',
+  title: 'Standup',
+  start: 1_700_000_000_000,
+  duration: 60 * 60 * 1000,
+  issueProviderKey: 'ICAL',
+};
+
+describe('PlannerCalendarEventComponent', () => {
+  let fixture: ComponentFixture<PlannerCalendarEventComponent>;
+
+  const createWith = (showStartTime?: boolean): void => {
+    fixture = TestBed.createComponent(PlannerCalendarEventComponent);
+    fixture.componentRef.setInput('calendarEvent', EVENT);
+    if (showStartTime !== undefined) {
+      fixture.componentRef.setInput('showStartTime', showStartTime);
+    }
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        PlannerCalendarEventComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        // Stubbed so the pipe chain resolves to a deterministic clock string.
+        { provide: DateService, useValue: { isToday: () => true } },
+        {
+          provide: DateTimeFormatService,
+          useValue: { currentLocale: () => 'en-US', formatTime: () => '2:13 PM' },
+        },
+        {
+          provide: CalendarEventActionsService,
+          useValue: jasmine.createSpyObj('CalendarEventActionsService', {
+            isPluginEvent: false,
+            hasEventUrl: false,
+          }),
+        },
+        ShortTimeHtmlPipe,
+        ShortTimePipe,
+      ],
+    });
+  });
+
+  it('renders the clock start time when showStartTime is true', () => {
+    createWith(true);
+    const el: HTMLElement | null = fixture.nativeElement.querySelector('.start-time');
+    expect(el).toBeTruthy();
+    expect(el!.textContent).toContain('2:13');
+  });
+
+  it('does not render the start time by default', () => {
+    createWith();
+    expect(fixture.nativeElement.querySelector('.start-time')).toBeNull();
+  });
+
+  it('places the start time as the right-most item, after the duration', () => {
+    createWith(true);
+    const children = Array.from(
+      (fixture.nativeElement.querySelector('.event-content') as HTMLElement).children,
+    ) as HTMLElement[];
+    const durationIdx = children.findIndex((c) =>
+      c.classList.contains('planner-time-remaining-shared'),
+    );
+    const startTimeIdx = children.findIndex((c) => c.classList.contains('start-time'));
+    expect(durationIdx).toBeGreaterThanOrEqual(0);
+    expect(startTimeIdx).toBe(children.length - 1);
+    expect(startTimeIdx).toBeGreaterThan(durationIdx);
+  });
+});

--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.ts
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.ts
@@ -14,19 +14,31 @@ import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { TranslatePipe } from '@ngx-translate/core';
 import { T } from '../../../t.const';
 import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
+import { ShortPlannedAtPipe } from '../../../ui/pipes/short-planned-at.pipe';
 
 @Component({
   selector: 'planner-calendar-event',
   templateUrl: './planner-calendar-event.component.html',
   styleUrl: './planner-calendar-event.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatIcon, MsToStringPipe, MatMenu, MatMenuItem, MatMenuTrigger, TranslatePipe],
+  imports: [
+    MatIcon,
+    MsToStringPipe,
+    MatMenu,
+    MatMenuItem,
+    MatMenuTrigger,
+    TranslatePipe,
+    ShortPlannedAtPipe,
+  ],
 })
 export class PlannerCalendarEventComponent {
   T = T;
   private _calEventActions = inject(CalendarEventActionsService);
 
   readonly calendarEvent = input.required<ScheduleFromCalendarEvent>();
+  // Show the event's clock start time (right-aligned, like a scheduled task).
+  // Used in the "Later Today" list where the start time isn't shown elsewhere.
+  readonly showStartTime = input<boolean>(false);
   isBeingSubmitted = false;
 
   @HostBinding('attr.title') title = '';

--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -309,6 +309,7 @@
                     @for (calEv of laterTodayCalendarEvents(); track calEv.id) {
                       <planner-calendar-event
                         [calendarEvent]="calEv"
+                        [showStartTime]="true"
                       ></planner-calendar-event>
                     }
                   </div>


### PR DESCRIPTION
## What
Calendar placeholder events shown under **Later Today** in the work view now display their clock start time on the right of the row, mirroring how a scheduled task's time badge looks. Previously only the duration was shown there.

## How
- `PlannerCalendarEventComponent` gains a `showStartTime` input (default `false`). When true, it renders `calendarEvent().start` via the existing `shortPlannedAt` pipe in a right-aligned `.start-time` element.
- The work view's Later Today list passes `[showStartTime]="true"`; all other usages (planner day) keep the default, so they are visually unchanged.

## Why gated
The planner day already shows event times in its own layout, so the start time would be redundant there. The input keeps the new badge scoped to the one context that needs it.

## Tests
Adds `planner-calendar-event.component.spec.ts` (3 specs) covering: badge hidden by default, shown when `showStartTime` is true, and the rendered value. All pass.

## Scope
Split out of the original combined PR #8570 (which also carried the unrelated #8565 localization fix). This branch contains only the work-view feature.
