### PR TITLE
feat(plugins): allow uploaded nodeExecution behind consent gate

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -552,10 +552,19 @@ console.log(data); // '{ count: 42 }'
 Plugins with `"permissions": ["nodeExecution"]` can run Node.js scripts in the Electron
 desktop app after the user allows the desktop permission prompt.
 
-The desktop grant is currently issued only for packaged built-in plugins whose
-manifest can be verified by the main process. Uploaded plugins that request
-`nodeExecution` are rejected until uploaded plugin installation is moved to a
-main-process-owned verification path.
+Both built-in and uploaded (community) plugins may request `nodeExecution`. The grant is
+issued by the Electron **main** process after a native consent dialog, and is bound to
+the plugin id for the current app session (it is never persisted or synced). For uploaded
+plugins the app cannot verify the manifest, so the dialog flags the plugin as unverified
+third-party code with full machine access that Super Productivity cannot sandbox, and
+defaults to **Deny** — only allow plugins whose source you trust. If the user denies,
+the plugin stays enabled but its node calls fail until it is re-enabled or the app is
+restarted (consent is re-requested once per session).
+
+> **Security note:** a granted `nodeExecution` plugin can run any program with full
+> access to your files and system. The file/IPC channel a plugin uses to talk to a
+> companion process is an open local channel — treat any data it reads as untrusted
+> input (never `eval`/`require` its contents).
 
 ```javascript
 const result = await plugin.executeNodeScript({

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -561,6 +561,11 @@ defaults to **Deny** — only allow plugins whose source you trust. If the user 
 the plugin stays enabled but its node calls fail until it is re-enabled or the app is
 restarted (consent is re-requested once per session).
 
+> **Plugin id constraints (for `nodeExecution`):** the consent grant keys on your
+> manifest `id`, so it must be a single safe token — no whitespace, control/bidi
+> characters, `:`, path separators (`/`, `\`), and at most 100 characters. Lowercase
+> kebab-case is recommended; dots and uppercase are accepted.
+
 > **Security note:** a granted `nodeExecution` plugin can run any program with full
 > access to your files and system. The file/IPC channel a plugin uses to talk to a
 > companion process is an open local channel — treat any data it reads as untrusted

--- a/electron/bundled-plugin-ids.test.cjs
+++ b/electron/bundled-plugin-ids.test.cjs
@@ -1,0 +1,149 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// SECURITY INVARIANT (cross-layer regression guard)
+// --------------------------------------------------
+// `src/app/plugins/plugin.service.ts` declares two top-of-file lists:
+//   - BUNDLED_PLUGIN_PATHS: the on-disk asset dirs of the plugins we ship.
+//   - BUNDLED_PLUGIN_IDS:   the reserved set of *manifest ids* that an uploaded
+//                           plugin is forbidden from claiming.
+// The renderer rejects an uploaded plugin whose manifest id is in
+// BUNDLED_PLUGIN_IDS so unverified code cannot impersonate a built-in. With
+// nodeExecution now openable to uploaded plugins, an unguarded id would also
+// let an upload borrow a bundled dir's "verified built-in" consent dialog in
+// the main process. PATHS are keyed by on-disk dir name; IDS by manifest id;
+// the dir->id mapping is NOT identity (e.g. dir `yesterday-tasks-plugin` has
+// manifest id `yesterday-tasks`). The two lists already drifted once (gitea /
+// linear / trello / azure issue-providers were in PATHS but missing from IDS),
+// which silently opened the impersonation gap for those ids.
+//
+// This test enforces PATHS ⊆ IDS: every bundled plugin's real manifest id MUST
+// be reserved. It deliberately does NOT require equality — IDS may reserve ids
+// for plugins not currently shipped via PATHS (e.g. `ai-productivity-prompts`),
+// which only widens the reserved set and is harmless.
+//
+// A Karma/browser unit test cannot read the filesystem, and importing
+// plugin.service.ts would drag in the whole Angular DI graph. So we parse the
+// file as text here, in the filesystem-capable `node --test` (electron) suite,
+// and read manifests straight off disk.
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PLUGIN_SERVICE_PATH = path.join(
+  REPO_ROOT,
+  'src/app/plugins/plugin.service.ts',
+);
+const PLUGIN_DEV_DIR = path.join(REPO_ROOT, 'packages/plugin-dev');
+
+/**
+ * Extract a named array/Set literal's quoted string entries from the source
+ * text. We don't evaluate the file (no Angular import) — we slice the literal
+ * between its opening token and the matching close bracket, then pull every
+ * single/double-quoted string out of that slice. This stays robust to
+ * formatting (line breaks, trailing commas, `as const`) without executing code.
+ *
+ * @param {string} source   full plugin.service.ts text
+ * @param {string} declStart the literal's opening, e.g. `BUNDLED_PLUGIN_PATHS = [`
+ * @param {string} closeChar the matching close bracket, `]` or `)`
+ * @returns {string[]} the quoted entries, in source order
+ */
+const extractStringLiteralList = (source, declStart, closeChar) => {
+  const startIdx = source.indexOf(declStart);
+  assert.notEqual(
+    startIdx,
+    -1,
+    `Could not find "${declStart}" in plugin.service.ts — the const may have been renamed; update this regression test.`,
+  );
+  const contentStart = startIdx + declStart.length;
+  const closeIdx = source.indexOf(closeChar, contentStart);
+  assert.notEqual(
+    closeIdx,
+    -1,
+    `Could not find closing "${closeChar}" for "${declStart}" in plugin.service.ts.`,
+  );
+  const slice = source.slice(contentStart, closeIdx);
+  const matches = slice.match(/['"]([^'"]+)['"]/g) || [];
+  return matches.map((m) => m.slice(1, -1));
+};
+
+/**
+ * Locate a bundled plugin's manifest. Both layouts exist in the repo:
+ *   packages/plugin-dev/<dir>/manifest.json
+ *   packages/plugin-dev/<dir>/src/manifest.json
+ * Returns the first that exists, or null if neither does.
+ */
+const findManifestPath = (dirName) => {
+  const candidates = [
+    path.join(PLUGIN_DEV_DIR, dirName, 'manifest.json'),
+    path.join(PLUGIN_DEV_DIR, dirName, 'src', 'manifest.json'),
+  ];
+  return candidates.find((p) => fs.existsSync(p)) || null;
+};
+
+test('every BUNDLED_PLUGIN_PATHS plugin has its manifest id reserved in BUNDLED_PLUGIN_IDS', () => {
+  const source = fs.readFileSync(PLUGIN_SERVICE_PATH, 'utf8');
+
+  const bundledPaths = extractStringLiteralList(
+    source,
+    'BUNDLED_PLUGIN_PATHS = [',
+    ']',
+  );
+  const bundledIds = new Set(
+    extractStringLiteralList(source, 'BUNDLED_PLUGIN_IDS = new Set<string>([', ']'),
+  );
+
+  // Sanity: if either list parsed empty, the source format changed and the
+  // guard is silently inert — fail loudly rather than pass vacuously.
+  assert.ok(
+    bundledPaths.length > 0,
+    'Parsed zero entries from BUNDLED_PLUGIN_PATHS — the source format likely changed; update this test.',
+  );
+  assert.ok(
+    bundledIds.size > 0,
+    'Parsed zero entries from BUNDLED_PLUGIN_IDS — the source format likely changed; update this test.',
+  );
+
+  const missingIds = [];
+  const missingManifests = [];
+
+  for (const assetPath of bundledPaths) {
+    const dirName = assetPath.split('/').pop();
+    const manifestPath = findManifestPath(dirName);
+
+    if (!manifestPath) {
+      missingManifests.push(dirName);
+      continue;
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const id = manifest.id;
+    assert.ok(
+      typeof id === 'string' && id.length > 0,
+      `Manifest for "${dirName}" has no string "id" field (${manifestPath}).`,
+    );
+
+    if (!bundledIds.has(id)) {
+      missingIds.push(`${dirName} -> "${id}"`);
+    }
+  }
+
+  // A missing manifest for a listed dir is itself drift/misconfig.
+  assert.equal(
+    missingManifests.length,
+    0,
+    `No manifest.json (top-level or src/) found under packages/plugin-dev for bundled plugin dir(s): ${missingManifests.join(
+      ', ',
+    )}. Each BUNDLED_PLUGIN_PATHS entry must have a manifest so its id can be verified.`,
+  );
+
+  // The core invariant. List ALL offenders, not just the first.
+  assert.equal(
+    missingIds.length,
+    0,
+    `SECURITY: the following bundled plugins' manifest ids are NOT reserved in ` +
+      `BUNDLED_PLUGIN_IDS (src/app/plugins/plugin.service.ts). An uploaded plugin ` +
+      `could claim these ids and impersonate a built-in. Add each missing id to ` +
+      `BUNDLED_PLUGIN_IDS:\n  ${missingIds.join('\n  ')}`,
+  );
+});

--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -10,28 +10,12 @@ import { AppDataCompleteLegacy } from '../src/app/imex/sync/sync.model';
 import { Task } from '../src/app/features/tasks/task.model';
 import { LocalBackupMeta } from '../src/app/imex/local-backup/local-backup.model';
 import { AppDataComplete } from '../src/app/op-log/model/model-config';
-import {
-  PluginNodeScriptRequest,
-  PluginNodeScriptResult,
-} from '../packages/plugin-api/src/types';
+import { PluginNodeExecutionElectronApi } from './shared-with-frontend/plugin-node-execution.model';
 import {
   LocalRestApiRequestPayload,
   LocalRestApiResponsePayload,
 } from './shared-with-frontend/local-rest-api.model';
 import { ElectronDistChannel } from './shared-with-frontend/get-dist-channel';
-
-export interface PluginNodeExecutionElectronApi {
-  requestGrant(
-    pluginId: string,
-    displayInfo?: { name?: string; version?: string },
-  ): Promise<{ token: string } | null>;
-  executeScript(
-    pluginId: string,
-    grantToken: string,
-    request: PluginNodeScriptRequest,
-  ): Promise<PluginNodeScriptResult>;
-  revokeGrant(pluginId: string, grantToken: string): Promise<void>;
-}
 
 export interface ElectronAPI {
   on(

--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -21,7 +21,10 @@ import {
 import { ElectronDistChannel } from './shared-with-frontend/get-dist-channel';
 
 export interface PluginNodeExecutionElectronApi {
-  requestGrant(pluginId: string): Promise<{ token: string } | null>;
+  requestGrant(
+    pluginId: string,
+    displayInfo?: { name?: string; version?: string },
+  ): Promise<{ token: string } | null>;
   executeScript(
     pluginId: string,
     grantToken: string,

--- a/electron/plugin-node-executor.test.cjs
+++ b/electron/plugin-node-executor.test.cjs
@@ -402,3 +402,79 @@ test('revoke from the issuing webContents drops the grant even without the token
     /not authorized/,
   );
 });
+
+test('rejects bidi/zero-width/homoglyph and leading-dot ids the allowlist must exclude', async () => {
+  loadModule();
+  const webContents = new FakeWebContents(16);
+
+  // These are exactly the dialog-anchor spoofing vectors a denylist of explicit Unicode
+  // ranges tends to miss; the allowlist rejects every non-[A-Za-z0-9._-] id by construction.
+  const badIds = [
+    `sync${String.fromCodePoint(0x061c)}md`, // U+061C ARABIC LETTER MARK (bidi)
+    `sync${String.fromCodePoint(0x2060)}md`, // U+2060 WORD JOINER (zero-width)
+    `sync${String.fromCodePoint(0x3164)}md`, // U+3164 HANGUL FILLER (invisible)
+    `${String.fromCodePoint(0xff53)}ync-md`, // U+FF53 fullwidth 's' (homoglyph)
+    '.hidden', // leading dot-segment
+    '-leading-dash',
+    'a b', // whitespace
+  ];
+
+  for (const badId of badIds) {
+    await assert.rejects(
+      () =>
+        callIpc('PLUGIN_REQUEST_NODE_EXECUTION_GRANT', webContents, badId, {
+          name: 'x',
+          version: '1',
+        }),
+      /Invalid pluginId/,
+      `expected ${JSON.stringify(badId)} to be rejected`,
+    );
+  }
+});
+
+test('strips bidi/zero-width chars from self-declared display strings', async () => {
+  loadModule();
+  const webContents = new FakeWebContents(17);
+
+  const name = `Tru${String.fromCodePoint(0x061c)}sted${String.fromCodePoint(0x2060)} Plugin`;
+  const grant = await callIpc(
+    'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+    webContents,
+    'display-sanitize-plugin',
+    { name, version: `1.0${String.fromCodePoint(0xfeff)}.0` },
+  );
+
+  assert.equal(typeof grant.token, 'string');
+  const detail = dialogCalls[dialogCalls.length - 1][1].detail;
+  // The control/format chars are gone; the visible text survives.
+  assert.equal(detail.includes(String.fromCodePoint(0x061c)), false);
+  assert.equal(detail.includes(String.fromCodePoint(0x2060)), false);
+  assert.equal(detail.includes(String.fromCodePoint(0xfeff)), false);
+  assert.match(detail, /Trusted Plugin/);
+});
+
+test('never upgrades trust: an on-disk match that does not cleanly verify uses the unverified dialog', async () => {
+  // Simulate a bundled dir whose manifest exists but is not a grantable nodeExecution
+  // built-in (here: missing the permission). The verified-built-in branch must return
+  // null and fall back to the unverified-uploaded dialog rather than throw or upgrade.
+  const originalPermissions = BUILT_IN_PLUGIN_MANIFEST.permissions;
+  BUILT_IN_PLUGIN_MANIFEST.permissions = [];
+  try {
+    loadModule();
+    const webContents = new FakeWebContents(18);
+    const grant = await callIpc(
+      'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+      webContents,
+      BUILT_IN_PLUGIN_MANIFEST.id,
+      { name: 'Impersonator', version: '9.9.9' },
+    );
+
+    assert.equal(typeof grant.token, 'string');
+    const opts = dialogCalls[dialogCalls.length - 1][1];
+    assert.match(opts.title, /run code on your machine/);
+    assert.match(opts.detail, /self-declared, unverified/);
+    assert.equal(opts.defaultId, 1);
+  } finally {
+    BUILT_IN_PLUGIN_MANIFEST.permissions = originalPermissions;
+  }
+});

--- a/electron/plugin-node-executor.test.cjs
+++ b/electron/plugin-node-executor.test.cjs
@@ -221,7 +221,7 @@ test('does not mint a token when the sender navigates while consent is pending',
   assert.equal(await grantPromise, null);
 });
 
-test('revoke requires the issuing webContents and token', async () => {
+test('revoke is scoped to the issuing webContents', async () => {
   loadModule();
   const webContents = new FakeWebContents(6);
   const otherWebContents = new FakeWebContents(7);
@@ -252,6 +252,140 @@ test('revoke requires the issuing webContents and token', async () => {
       callIpc('PLUGIN_EXEC_NODE_SCRIPT', webContents, 'sync-md', grant.token, {
         script: 'return true;',
       }),
+    /not authorized/,
+  );
+});
+
+test('issues a grant to an uploaded (non-bundled) plugin and labels it unverified', async () => {
+  loadModule();
+  const webContents = new FakeWebContents(10);
+
+  const grant = await callIpc(
+    'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+    webContents,
+    'uploaded-node-plugin',
+    { name: 'Uploaded Node Plugin', version: '1.2.3' },
+  );
+
+  assert.equal(typeof grant.token, 'string');
+  assert.equal(dialogCalls.length, 1);
+  const opts = dialogCalls[0][1];
+  // Dialog anchors on the validated id and flags the self-declared name as unverified,
+  // and defaults to Deny.
+  assert.match(opts.detail, /Plugin ID: uploaded-node-plugin/);
+  assert.match(opts.detail, /self-declared, unverified/);
+  assert.equal(opts.defaultId, 1);
+});
+
+test('uploaded plugin executes after grant; a denied request leaves exec unauthorized', async () => {
+  loadModule();
+  const allowWc = new FakeWebContents(11);
+  const grant = await callIpc(
+    'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+    allowWc,
+    'uploaded-node-plugin',
+    { name: 'Uploaded', version: '1.0.0' },
+  );
+  const okResult = await callIpc(
+    'PLUGIN_EXEC_NODE_SCRIPT',
+    allowWc,
+    'uploaded-node-plugin',
+    grant.token,
+    { script: 'return args[0] + 1;', args: [4] },
+  );
+  assert.equal(okResult.success, true);
+  assert.equal(okResult.result, 5);
+
+  // A denied request mints no token, so exec stays unauthorized.
+  nextDialogResult = { response: 1 };
+  const denyWc = new FakeWebContents(12);
+  const denied = await callIpc(
+    'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+    denyWc,
+    'denied-plugin',
+    { name: 'Denied', version: '1.0.0' },
+  );
+  assert.equal(denied, null);
+  await assert.rejects(
+    () =>
+      callIpc('PLUGIN_EXEC_NODE_SCRIPT', denyWc, 'denied-plugin', 'made-up-token', {
+        script: 'return true;',
+      }),
+    /not authorized/,
+  );
+});
+
+test('accepts a non-kebab uploaded id (dots/uppercase) the built-in rule would reject', async () => {
+  loadModule();
+  const webContents = new FakeWebContents(13);
+
+  const grant = await callIpc(
+    'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+    webContents,
+    'Community.Plugin-2',
+    { name: 'Community Plugin', version: '2.0.0' },
+  );
+
+  assert.equal(typeof grant.token, 'string');
+});
+
+test('rejects unsafe ids and sanitizes self-declared display strings', async () => {
+  loadModule();
+  const webContents = new FakeWebContents(14);
+
+  // A newline in the id is rejected outright (it is a grant Map key + dialog text).
+  await assert.rejects(
+    () =>
+      callIpc('PLUGIN_REQUEST_NODE_EXECUTION_GRANT', webContents, 'evil\nid', {
+        name: 'x',
+        version: '1',
+      }),
+    /Invalid pluginId/,
+  );
+
+  // A crafted name cannot inject an extra dialog line and is length-capped.
+  const craftedName = `${'A'.repeat(500)}\nVerified by Super Productivity`;
+  const grant = await callIpc(
+    'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+    webContents,
+    'crafted-name-plugin',
+    { name: craftedName, version: '1.0.0' },
+  );
+  assert.equal(typeof grant.token, 'string');
+  const detail = dialogCalls[dialogCalls.length - 1][1].detail;
+  assert.equal(detail.includes('Verified by Super Productivity'), false);
+  assert.ok(detail.includes('…'));
+});
+
+test('revoke from the issuing webContents drops the grant even without the token', async () => {
+  loadModule();
+  const webContents = new FakeWebContents(15);
+  const grant = await callIpc(
+    'PLUGIN_REQUEST_NODE_EXECUTION_GRANT',
+    webContents,
+    'uploaded-node-plugin',
+    { name: 'Uploaded', version: '1.0.0' },
+  );
+
+  // Teardown/re-upload revokes by id without resupplying the token, so a re-uploaded
+  // plugin reusing the id cannot inherit this live grant.
+  await callIpc(
+    'PLUGIN_REVOKE_NODE_EXECUTION_GRANT',
+    webContents,
+    'uploaded-node-plugin',
+    '',
+  );
+  await assert.rejects(
+    () =>
+      callIpc(
+        'PLUGIN_EXEC_NODE_SCRIPT',
+        webContents,
+        'uploaded-node-plugin',
+        grant.token,
+        {
+          script: 'return true;',
+        },
+      ),
     /not authorized/,
   );
 });

--- a/electron/plugin-node-executor.test.cjs
+++ b/electron/plugin-node-executor.test.cjs
@@ -343,6 +343,19 @@ test('rejects unsafe ids and sanitizes self-declared display strings', async () 
     /Invalid pluginId/,
   );
 
+  // Path separators / dot-segments are rejected (the id is used as a path component in
+  // the bundled-manifest existsSync probe).
+  for (const badId of ['../../etc', '..', '.', 'a/b', 'a\\b']) {
+    await assert.rejects(
+      () =>
+        callIpc('PLUGIN_REQUEST_NODE_EXECUTION_GRANT', webContents, badId, {
+          name: 'x',
+          version: '1',
+        }),
+      /Invalid pluginId/,
+    );
+  }
+
   // A crafted name cannot inject an extra dialog line and is length-capped.
   const craftedName = `${'A'.repeat(500)}\nVerified by Super Productivity`;
   const grant = await callIpc(

--- a/electron/plugin-node-executor.ts
+++ b/electron/plugin-node-executor.ts
@@ -16,19 +16,23 @@ const DEFAULT_TIMEOUT = 30000; // 30 seconds
 const MAX_TIMEOUT = 300000; // 5 minutes
 const BUILT_IN_PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
-// Uploaded (community) plugin ids are NOT held to the strict built-in kebab rule —
-// they may legitimately use dots/uppercase — but an uploaded id is attacker-controlled
-// and used both as a grant Map key and as consent-dialog text, so it must reject
-// anything unsafe for those uses (control/zero-width/bidi chars that could spoof the
-// dialog, whitespace that could inject extra dialog lines, the ':' persistence
-// delimiter) and stay within a sane length.
+// An uploaded (community) plugin id is attacker-controlled and used both as a grant Map
+// key and as the consent dialog's trust anchor ("Plugin ID: ..."), and as a path segment
+// in getBuiltInManifestPath(). It is NOT held to the strict built-in kebab rule —
+// community ids may use dots/uppercase, e.g. `super-productivity-mcp` — but it must be a
+// single safe ASCII token. We use an allowlist rather than a denylist on purpose: the
+// allowlist rejects control/zero-width/bidi/homoglyph characters that could spoof the
+// dialog, whitespace that could inject extra dialog lines, the ':' persistence delimiter,
+// and path separators / leading-dot segments ('.', '..', '/', '\\') — all by construction,
+// with no Unicode range to keep updated as new code points are assigned.
 const MAX_UPLOADED_PLUGIN_ID_LENGTH = 100;
-const UNSAFE_ID_CHARS_RE =
-  /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2066-\u2069:\s]/;
-// Self-declared name/version are display-only; strip control/bidi chars and collapse
-// whitespace (global flag is for replace, not test, so no lastIndex statefulness).
-const UNSAFE_DISPLAY_CHARS_RE =
-  /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2066-\u2069]/g;
+const SAFE_UPLOADED_PLUGIN_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+// Self-declared name/version are display-only. Strip every Unicode control (Cc) and
+// format (Cf) character — this covers C0/C1 controls, all zero-width characters, the BOM,
+// and every bidi control (incl. U+061C ALM, the word-joiner range, and the isolate marks)
+// without enumerating ranges — then collapse whitespace so a crafted value cannot inject
+// extra dialog lines. (Global flag is for replace, not test, so no lastIndex statefulness.)
+const UNSAFE_DISPLAY_CHARS_RE = /[\p{Cc}\p{Cf}]/gu;
 
 const assertSafePluginId = (pluginId: unknown): string => {
   if (typeof pluginId !== 'string' || pluginId.length === 0) {
@@ -37,18 +41,11 @@ const assertSafePluginId = (pluginId: unknown): string => {
   if (pluginId.length > MAX_UPLOADED_PLUGIN_ID_LENGTH) {
     throw new Error('Invalid pluginId');
   }
-  if (UNSAFE_ID_CHARS_RE.test(pluginId)) {
-    throw new Error('Invalid pluginId');
-  }
-  // The id is used as a path segment in getBuiltInManifestPath() (existsSync probe),
-  // so reject path separators and dot-segments — otherwise an id like '..' could probe
-  // outside the bundled-plugins dir and render misleadingly in the dialog.
-  if (
-    pluginId.includes('/') ||
-    pluginId.includes('\\') ||
-    pluginId === '.' ||
-    pluginId === '..'
-  ) {
+  // Allowlist match also rejects path separators ('/'/'\\'), leading-dot segments
+  // ('.', '..'), ':', whitespace and all non-ASCII (bidi/zero-width/homoglyph), so the id
+  // can neither escape the bundled-plugins dir in getBuiltInManifestPath() nor spoof the
+  // consent dialog's trust anchor.
+  if (!SAFE_UPLOADED_PLUGIN_ID_RE.test(pluginId)) {
     throw new Error('Invalid pluginId');
   }
   return pluginId;
@@ -133,11 +130,14 @@ class PluginNodeExecutor {
         }
 
         // Bundled vs uploaded is decided by the main-owned filesystem, never by a
-        // renderer-supplied flag: a bundled id always uses its verified on-disk
-        // manifest, so uploaded code can't borrow a built-in plugin's trusted name.
-        const dialogOptions = this.getBuiltInManifestPath(safeId)
-          ? this.describeVerifiedBuiltInDialog(safeId)
-          : this.describeUnverifiedUploadedDialog(safeId, displayInfo);
+        // renderer-supplied flag, and only an id that resolves to a cleanly-verified
+        // on-disk manifest gets the trusted built-in dialog. A partial or colliding match
+        // (id mismatch, missing nodeExecution permission, unreadable manifest) returns
+        // null and falls back to the unverified dialog, so uploaded code can never borrow
+        // a built-in plugin's trusted name even if its id collides with a bundled dir.
+        const dialogOptions =
+          this.describeVerifiedBuiltInDialog(safeId) ??
+          this.describeUnverifiedUploadedDialog(safeId, displayInfo);
 
         const requestUrl = event.sender.getURL();
         this.registerGrantCleanup(event.sender);
@@ -184,9 +184,18 @@ class PluginNodeExecutor {
       // could inherit a live session grant. The webContents binding still prevents
       // another window from revoking this one's grant.
       (event, pluginId: string, _grantToken?: string) => {
-        const grant = this.grants.get(pluginId);
+        // Key the lookup through the same validator the request handler uses, so the
+        // "always revoke by id on teardown/re-upload" guarantee holds even if the id
+        // canonicalisation ever changes (an unsafe id can never hold a grant anyway).
+        let safeId: string;
+        try {
+          safeId = assertSafePluginId(pluginId);
+        } catch {
+          return;
+        }
+        const grant = this.grants.get(safeId);
         if (grant && grant.webContentsId === event.sender.id) {
-          this.grants.delete(pluginId);
+          this.grants.delete(safeId);
         }
       },
     );
@@ -204,7 +213,15 @@ class PluginNodeExecutor {
           throw new Error('No window found for event sender');
         }
 
-        const grant = this.grants.get(pluginId);
+        // Validate the id the same way the grant handler does so the Map keys match.
+        // An unsafe id can never hold a grant, so treat it as unauthorized.
+        let safeId: string;
+        try {
+          safeId = assertSafePluginId(pluginId);
+        } catch {
+          throw new Error('Plugin is not authorized for nodeExecution');
+        }
+        const grant = this.grants.get(safeId);
         if (
           !grant ||
           grant.token !== grantToken ||
@@ -213,7 +230,7 @@ class PluginNodeExecutor {
           throw new Error('Plugin is not authorized for nodeExecution');
         }
 
-        return await this.executeScript(pluginId, request);
+        return await this.executeScript(safeId, request);
       },
     );
   }
@@ -280,9 +297,23 @@ class PluginNodeExecutor {
     this.unregisterGrantCleanup(webContentsId);
   }
 
-  /** Consent dialog for a verified built-in plugin (name/version read from disk). */
-  private describeVerifiedBuiltInDialog(pluginId: string): Electron.MessageBoxOptions {
-    const manifest = this.getVerifiedBuiltInNodeExecutionManifest(pluginId);
+  /**
+   * Consent dialog for a verified built-in plugin (name/version read from disk).
+   * Returns null when the id does not resolve to a cleanly-verified built-in
+   * nodeExecution manifest (no on-disk match, id mismatch, missing permission, or
+   * unreadable/invalid manifest), so the caller falls back to the unverified-uploaded
+   * dialog — a partial or colliding match must never *upgrade* trust to the built-in
+   * dialog.
+   */
+  private describeVerifiedBuiltInDialog(
+    pluginId: string,
+  ): Electron.MessageBoxOptions | null {
+    let manifest: PluginManifest;
+    try {
+      manifest = this.getVerifiedBuiltInNodeExecutionManifest(pluginId);
+    } catch {
+      return null;
+    }
     return {
       ...NODE_CONSENT_DIALOG_BASE,
       title: 'Allow plugin Node.js execution?',

--- a/electron/plugin-node-executor.ts
+++ b/electron/plugin-node-executor.ts
@@ -16,9 +16,50 @@ const DEFAULT_TIMEOUT = 30000; // 30 seconds
 const MAX_TIMEOUT = 300000; // 5 minutes
 const BUILT_IN_PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
+// Uploaded (community) plugin ids are NOT held to the strict built-in kebab rule —
+// they may legitimately use dots/uppercase — but an uploaded id is attacker-controlled
+// and used both as a grant Map key and as consent-dialog text, so it must reject
+// anything unsafe for those uses (control/zero-width/bidi chars that could spoof the
+// dialog, whitespace that could inject extra dialog lines, the ':' persistence
+// delimiter) and stay within a sane length.
+const MAX_UPLOADED_PLUGIN_ID_LENGTH = 100;
+const UNSAFE_ID_CHARS_RE =
+  /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2066-\u2069:\s]/;
+// Self-declared name/version are display-only; strip control/bidi chars and collapse
+// whitespace (global flag is for replace, not test, so no lastIndex statefulness).
+const UNSAFE_DISPLAY_CHARS_RE =
+  /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2066-\u2069]/g;
+
+const assertSafePluginId = (pluginId: unknown): string => {
+  if (typeof pluginId !== 'string' || pluginId.length === 0) {
+    throw new Error('Invalid pluginId');
+  }
+  if (pluginId.length > MAX_UPLOADED_PLUGIN_ID_LENGTH) {
+    throw new Error('Invalid pluginId');
+  }
+  if (UNSAFE_ID_CHARS_RE.test(pluginId)) {
+    throw new Error('Invalid pluginId');
+  }
+  return pluginId;
+};
+
+const sanitizeDialogString = (value: unknown, maxLength: number): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const cleaned = value.replace(UNSAFE_DISPLAY_CHARS_RE, '').replace(/\s+/g, ' ').trim();
+  return cleaned.length > maxLength ? `${cleaned.slice(0, maxLength)}…` : cleaned;
+};
+
 interface NodeExecutionGrant {
   token: string;
   webContentsId: number;
+}
+
+/** Self-declared, unverified display metadata supplied by the renderer for uploaded plugins. */
+interface NodeExecutionGrantDisplayInfo {
+  name?: string;
+  version?: string;
 }
 
 interface WebContentsGrantCleanup {
@@ -48,42 +89,39 @@ class PluginNodeExecutor {
   private setupIpcHandler(): void {
     ipcMain.handle(
       IPC.PLUGIN_REQUEST_NODE_EXECUTION_GRANT,
-      async (event, pluginId: string) => {
+      async (event, pluginId: string, displayInfo?: NodeExecutionGrantDisplayInfo) => {
         const window = BrowserWindow.fromWebContents(event.sender);
         if (!window) {
           throw new Error('No window found for event sender');
         }
 
+        // Sanitize first: the id is used as a grant Map key AND shown in the consent
+        // dialog, and for uploaded plugins it is attacker-controlled.
+        const safeId = assertSafePluginId(pluginId);
+
         const webContentsId = event.sender.id;
-        const existingGrant = this.grants.get(pluginId);
+        const existingGrant = this.grants.get(safeId);
         if (existingGrant) {
           if (existingGrant.webContentsId === webContentsId) {
             return { token: existingGrant.token };
           }
-          this.grants.delete(pluginId);
+          this.grants.delete(safeId);
           this.releaseGrantCleanupIfUnused(existingGrant.webContentsId);
         }
 
-        const manifest = this.getVerifiedBuiltInNodeExecutionManifest(pluginId);
+        // Bundled vs uploaded is decided by the main-owned filesystem, never by a
+        // renderer-supplied flag: a bundled id always uses its verified on-disk
+        // manifest, so uploaded code can't borrow a built-in plugin's trusted name.
+        const dialogOptions = this.getBuiltInManifestPath(safeId)
+          ? this.describeVerifiedBuiltInDialog(safeId)
+          : this.describeUnverifiedUploadedDialog(safeId, displayInfo);
+
         const requestUrl = event.sender.getURL();
         this.registerGrantCleanup(event.sender);
 
-        let result;
+        let result: Electron.MessageBoxReturnValue;
         try {
-          result = await dialog.showMessageBox(window, {
-            type: 'warning',
-            buttons: ['Allow', 'Deny'],
-            defaultId: 1,
-            cancelId: 1,
-            title: 'Allow plugin Node.js execution?',
-            message: `Allow "${manifest.name}" to run Node.js scripts?`,
-            detail: [
-              `Plugin ID: ${pluginId}`,
-              `Version: ${manifest.version}`,
-              '',
-              'This permission is valid for the current app session. Node.js execution can access local files and desktop APIs. Only allow plugins you trust.',
-            ].join('\n'),
-          });
+          result = await dialog.showMessageBox(window, dialogOptions);
         } catch (error) {
           this.releaseGrantCleanupIfUnused(webContentsId);
           throw error;
@@ -94,19 +132,19 @@ class PluginNodeExecutor {
           !this.grantCleanupByWebContents.has(webContentsId) ||
           event.sender.getURL() !== requestUrl
         ) {
-          this.grants.delete(pluginId);
+          this.grants.delete(safeId);
           this.releaseGrantCleanupIfUnused(webContentsId);
           return null;
         }
 
         if (result.response !== 0) {
-          this.grants.delete(pluginId);
+          this.grants.delete(safeId);
           this.releaseGrantCleanupIfUnused(webContentsId);
           return null;
         }
 
         const token = randomBytes(32).toString('base64url');
-        this.grants.set(pluginId, {
+        this.grants.set(safeId, {
           token,
           webContentsId,
         });
@@ -116,9 +154,15 @@ class PluginNodeExecutor {
 
     ipcMain.handle(
       IPC.PLUGIN_REVOKE_NODE_EXECUTION_GRANT,
-      (event, pluginId: string, grantToken: string) => {
+      // grantToken is accepted for signature compatibility but intentionally not
+      // required: revoking only removes a capability, and the issuing window must be
+      // able to drop its own grant during teardown even if it no longer holds the
+      // token (e.g. on re-upload) — otherwise a re-uploaded plugin reusing the id
+      // could inherit a live session grant. The webContents binding still prevents
+      // another window from revoking this one's grant.
+      (event, pluginId: string, _grantToken?: string) => {
         const grant = this.grants.get(pluginId);
-        if (grant?.token === grantToken && grant.webContentsId === event.sender.id) {
+        if (grant && grant.webContentsId === event.sender.id) {
           this.grants.delete(pluginId);
         }
       },
@@ -211,6 +255,56 @@ class PluginNodeExecutor {
       }
     }
     this.unregisterGrantCleanup(webContentsId);
+  }
+
+  /** Consent dialog for a verified built-in plugin (name/version read from disk). */
+  private describeVerifiedBuiltInDialog(pluginId: string): Electron.MessageBoxOptions {
+    const manifest = this.getVerifiedBuiltInNodeExecutionManifest(pluginId);
+    return {
+      type: 'warning',
+      buttons: ['Allow', 'Deny'],
+      defaultId: 1,
+      cancelId: 1,
+      title: 'Allow plugin Node.js execution?',
+      message: `Allow "${manifest.name}" to run Node.js scripts?`,
+      detail: [
+        `Plugin ID: ${pluginId}`,
+        `Version: ${manifest.version}`,
+        '',
+        'This permission is valid for the current app session. Node.js execution can access local files and desktop APIs. Only allow plugins you trust.',
+      ].join('\n'),
+    };
+  }
+
+  /**
+   * Consent dialog for an uploaded (community) plugin. The app cannot verify an
+   * uploaded plugin's identity, so the dialog anchors on the validated id and marks
+   * the renderer-supplied name/version as self-declared/unverified. Default = Deny.
+   */
+  private describeUnverifiedUploadedDialog(
+    pluginId: string,
+    displayInfo?: NodeExecutionGrantDisplayInfo,
+  ): Electron.MessageBoxOptions {
+    const name = sanitizeDialogString(displayInfo?.name, 80) || '(unnamed)';
+    const version = sanitizeDialogString(displayInfo?.version, 32) || '(unknown)';
+    return {
+      type: 'warning',
+      buttons: ['Allow', 'Deny'],
+      defaultId: 1,
+      cancelId: 1,
+      title: 'Allow this plugin to run code on your machine?',
+      message: `Plugin "${pluginId}" wants to run Node.js code`,
+      detail: [
+        `Plugin ID: ${pluginId}`,
+        `Name (self-declared, unverified): ${name}`,
+        `Version (self-declared): ${version}`,
+        '',
+        'This is a third-party plugin. Super Productivity cannot verify its identity and cannot sandbox it.',
+        'If you allow it, the plugin can run any program with full access to your files and system for this app session.',
+        '',
+        'Only allow this if you trust the source of this plugin.',
+      ].join('\n'),
+    };
   }
 
   private getVerifiedBuiltInNodeExecutionManifest(pluginId: string): PluginManifest {

--- a/electron/plugin-node-executor.ts
+++ b/electron/plugin-node-executor.ts
@@ -40,6 +40,17 @@ const assertSafePluginId = (pluginId: unknown): string => {
   if (UNSAFE_ID_CHARS_RE.test(pluginId)) {
     throw new Error('Invalid pluginId');
   }
+  // The id is used as a path segment in getBuiltInManifestPath() (existsSync probe),
+  // so reject path separators and dot-segments — otherwise an id like '..' could probe
+  // outside the bundled-plugins dir and render misleadingly in the dialog.
+  if (
+    pluginId.includes('/') ||
+    pluginId.includes('\\') ||
+    pluginId === '.' ||
+    pluginId === '..'
+  ) {
+    throw new Error('Invalid pluginId');
+  }
   return pluginId;
 };
 
@@ -49,6 +60,18 @@ const sanitizeDialogString = (value: unknown, maxLength: number): string => {
   }
   const cleaned = value.replace(UNSAFE_DISPLAY_CHARS_RE, '').replace(/\s+/g, ' ').trim();
   return cleaned.length > maxLength ? `${cleaned.slice(0, maxLength)}…` : cleaned;
+};
+
+// Shared shell for both nodeExecution consent dialogs: a warning with Allow/Deny where
+// Deny is the default + cancel action, so a reflexive Enter/Escape denies.
+const NODE_CONSENT_DIALOG_BASE: Pick<
+  Electron.MessageBoxOptions,
+  'type' | 'buttons' | 'defaultId' | 'cancelId'
+> = {
+  type: 'warning',
+  buttons: ['Allow', 'Deny'],
+  defaultId: 1,
+  cancelId: 1,
 };
 
 interface NodeExecutionGrant {
@@ -261,10 +284,7 @@ class PluginNodeExecutor {
   private describeVerifiedBuiltInDialog(pluginId: string): Electron.MessageBoxOptions {
     const manifest = this.getVerifiedBuiltInNodeExecutionManifest(pluginId);
     return {
-      type: 'warning',
-      buttons: ['Allow', 'Deny'],
-      defaultId: 1,
-      cancelId: 1,
+      ...NODE_CONSENT_DIALOG_BASE,
       title: 'Allow plugin Node.js execution?',
       message: `Allow "${manifest.name}" to run Node.js scripts?`,
       detail: [
@@ -288,10 +308,7 @@ class PluginNodeExecutor {
     const name = sanitizeDialogString(displayInfo?.name, 80) || '(unnamed)';
     const version = sanitizeDialogString(displayInfo?.version, 32) || '(unknown)';
     return {
-      type: 'warning',
-      buttons: ['Allow', 'Deny'],
-      defaultId: 1,
-      cancelId: 1,
+      ...NODE_CONSENT_DIALOG_BASE,
       title: 'Allow this plugin to run code on your machine?',
       message: `Plugin "${pluginId}" wants to run Node.js code`,
       detail: [

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -245,8 +245,11 @@ const ea: ElectronAPI = {
     }
     pluginNodeExecutionApiConsumed = true;
     return {
-      requestGrant: (pluginId: string) =>
-        _invoke('PLUGIN_REQUEST_NODE_EXECUTION_GRANT', pluginId) as Promise<{
+      requestGrant: (
+        pluginId: string,
+        displayInfo?: { name?: string; version?: string },
+      ) =>
+        _invoke('PLUGIN_REQUEST_NODE_EXECUTION_GRANT', pluginId, displayInfo) as Promise<{
           token: string;
         } | null>,
       executeScript: (

--- a/electron/shared-with-frontend/plugin-node-execution.model.ts
+++ b/electron/shared-with-frontend/plugin-node-execution.model.ts
@@ -1,0 +1,24 @@
+import {
+  PluginNodeScriptRequest,
+  PluginNodeScriptResult,
+} from '../../packages/plugin-api/src/types';
+
+/**
+ * Shape of the Electron main-process bridge the renderer uses to grant, run, and
+ * revoke Node script execution for a plugin. This is a host-internal IPC contract
+ * (not part of the public plugin API), shared between the renderer
+ * (`plugin-bridge.service.ts`) and the Electron API typing
+ * (`electron/electronAPI.d.ts`) so the two cannot drift.
+ */
+export interface PluginNodeExecutionElectronApi {
+  requestGrant(
+    pluginId: string,
+    displayInfo?: { name?: string; version?: string },
+  ): Promise<{ token: string } | null>;
+  executeScript(
+    pluginId: string,
+    grantToken: string,
+    request: PluginNodeScriptRequest,
+  ): Promise<PluginNodeScriptResult>;
+  revokeGrant(pluginId: string, grantToken: string): Promise<void>;
+}

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -117,19 +117,7 @@ import {
 } from '../features/simple-counter/store/simple-counter.actions';
 import { getDbDateStr } from '../util/get-db-date-str';
 import { DataInitService } from '../core/data-init/data-init.service';
-
-interface PluginNodeExecutionElectronApi {
-  requestGrant(
-    pluginId: string,
-    displayInfo?: { name?: string; version?: string },
-  ): Promise<{ token: string } | null>;
-  executeScript(
-    pluginId: string,
-    grantToken: string,
-    request: PluginNodeScriptRequest,
-  ): Promise<PluginNodeScriptResult>;
-  revokeGrant(pluginId: string, grantToken: string): Promise<void>;
-}
+import { PluginNodeExecutionElectronApi } from '../../../electron/shared-with-frontend/plugin-node-execution.model';
 
 type PluginDateFormat = 'short' | 'medium' | 'long' | 'time' | 'datetime';
 

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -119,7 +119,10 @@ import { getDbDateStr } from '../util/get-db-date-str';
 import { DataInitService } from '../core/data-init/data-init.service';
 
 interface PluginNodeExecutionElectronApi {
-  requestGrant(pluginId: string): Promise<{ token: string } | null>;
+  requestGrant(
+    pluginId: string,
+    displayInfo?: { name?: string; version?: string },
+  ): Promise<{ token: string } | null>;
   executeScript(
     pluginId: string,
     grantToken: string,
@@ -1714,8 +1717,11 @@ export class PluginBridgeService implements OnDestroy {
     return this.#nodeExecutionGrantTokens.get(pluginId);
   }
 
-  async requestNodeExecutionGrant(pluginId: string): Promise<{ token: string } | null> {
-    return (await this.#nodeExecutionApi?.requestGrant(pluginId)) ?? null;
+  async requestNodeExecutionGrant(
+    pluginId: string,
+    displayInfo?: { name?: string; version?: string },
+  ): Promise<{ token: string } | null> {
+    return (await this.#nodeExecutionApi?.requestGrant(pluginId, displayInfo)) ?? null;
   }
 
   revokeNodeExecutionGrantToken(pluginId: string): string | undefined {

--- a/src/app/plugins/plugin.service.load-from-zip.spec.ts
+++ b/src/app/plugins/plugin.service.load-from-zip.spec.ts
@@ -220,7 +220,7 @@ describe('PluginService loadPluginFromZip iframe-only plugins', () => {
     expect(pluginCache.storePlugin).not.toHaveBeenCalled();
   });
 
-  it('rejects uploaded plugins that declare nodeExecution before storing or loading code', async () => {
+  it('accepts uploaded plugins that declare nodeExecution (gated later by main-process consent)', async () => {
     const nodeExecutionManifest: PluginManifest = {
       ...iframeManifest,
       id: 'uploaded-node-plugin',
@@ -229,13 +229,17 @@ describe('PluginService loadPluginFromZip iframe-only plugins', () => {
     };
     const files: Record<string, string> = {};
     files['manifest.json'] = JSON.stringify(nodeExecutionManifest);
-    files['plugin.js'] = 'PluginAPI.log.log("should not run")';
+    files['plugin.js'] = 'PluginAPI.log.log("node plugin")';
     const file = createZipFile(files);
 
-    await expectAsync(service.loadPluginFromZip(file)).toBeRejectedWithError(
-      T.PLUGINS.NODE_EXECUTION_BUILT_IN_ONLY,
-    );
-    expect(pluginCache.storePlugin).not.toHaveBeenCalled();
-    expect(pluginRunner.loadPlugin).not.toHaveBeenCalled();
+    // Resolving (instead of throwing NODE_EXECUTION_BUILT_IN_ONLY) is the behaviour
+    // change: uploaded node plugins are no longer rejected at upload time. The
+    // nodeExecution capability is gated by the main-process consent dialog at grant
+    // time instead.
+    const instance = await service.loadPluginFromZip(file);
+
+    expect(instance).toBeTruthy();
+    expect(instance.manifest.id).toBe('uploaded-node-plugin');
+    expect(pluginCache.storePlugin).toHaveBeenCalled();
   });
 });

--- a/src/app/plugins/plugin.service.spec.ts
+++ b/src/app/plugins/plugin.service.spec.ts
@@ -255,7 +255,10 @@ describe('PluginService', () => {
     const result = await service.enableAndActivatePlugin(manifest.id);
 
     expect(result).toBeNull();
-    expect(pluginBridge.requestNodeExecutionGrant).toHaveBeenCalledOnceWith(manifest.id);
+    expect(pluginBridge.requestNodeExecutionGrant).toHaveBeenCalledOnceWith(manifest.id, {
+      name: manifest.name,
+      version: manifest.version,
+    });
     expect(pluginMetaPersistenceService.setPluginEnabled).not.toHaveBeenCalled();
     expect(pluginLoader.loadPluginAssets).not.toHaveBeenCalled();
     expect(service.getAllPluginStates().get(manifest.id)).toEqual(
@@ -264,6 +267,31 @@ describe('PluginService', () => {
         isEnabled: false,
       }),
     );
+  });
+
+  it('does not re-prompt for nodeExecution after a denial within the same session', async () => {
+    const runtime = service as unknown as { _isElectronRuntime: () => boolean };
+    spyOn(runtime, '_isElectronRuntime').and.returnValue(true);
+    const manifest: PluginManifest = {
+      ...mockManifest,
+      id: 'node-plugin',
+      name: 'Node Plugin',
+      permissions: ['nodeExecution'],
+    };
+    const ensureGrant = (
+      service as unknown as {
+        _ensureNodeExecutionGrant: (m: PluginManifest) => Promise<boolean>;
+      }
+    )._ensureNodeExecutionGrant.bind(service);
+
+    // First interactive attempt prompts and is denied (requestNodeExecutionGrant -> null).
+    await expectAsync(service.checkNodeExecutionPermission(manifest)).toBeResolvedTo(
+      false,
+    );
+    // A later non-interactive grant attempt this session (e.g. startup re-entry via
+    // _fireOnReady) must NOT re-open the native prompt.
+    await expectAsync(ensureGrant(manifest)).toBeResolvedTo(false);
+    expect(pluginBridge.requestNodeExecutionGrant).toHaveBeenCalledTimes(1);
   });
 
   it('stores main-issued nodeExecution grants for Electron plugins', async () => {
@@ -281,7 +309,10 @@ describe('PluginService', () => {
       true,
     );
 
-    expect(pluginBridge.requestNodeExecutionGrant).toHaveBeenCalledOnceWith(manifest.id);
+    expect(pluginBridge.requestNodeExecutionGrant).toHaveBeenCalledOnceWith(manifest.id, {
+      name: manifest.name,
+      version: manifest.version,
+    });
     expect(pluginBridge.setNodeExecutionGrantToken).toHaveBeenCalledOnceWith(
       manifest.id,
       'token-1',

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -62,18 +62,29 @@ const BUNDLED_PLUGIN_PATHS = [
   'assets/bundled-plugins/doc-mode',
 ] as const;
 
+// Reserved ids: an uploaded plugin may not reuse a bundled plugin's manifest id (it would
+// let unverified code impersonate a built-in — and, with nodeExecution now openable to
+// uploaded plugins, claim a bundled dir's "verified built-in" consent dialog in the main
+// process, which decides bundled-vs-uploaded by on-disk dir). This set MUST contain the
+// manifest id of every entry in BUNDLED_PLUGIN_PATHS; the invariant is guarded by
+// electron/bundled-plugin-ids.test.cjs (a filesystem-reading node test, since a browser
+// Karma spec cannot read the manifests) so the two lists cannot silently drift again.
 const BUNDLED_PLUGIN_IDS = new Set<string>([
   'ai-productivity-prompts',
   'api-test-plugin',
   'automations',
+  'azure-devops-issue-provider',
   'brain-dump',
   'caldav-calendar-provider',
   'clickup-issue-provider',
   'doc-mode',
+  'gitea-issue-provider',
   'github-issue-provider',
   'google-calendar-provider',
+  'linear-issue-provider',
   'procrastination-buster',
   'sync-md',
+  'trello-issue-provider',
   'voice-reminder',
   'yesterday-tasks',
 ]);
@@ -1567,6 +1578,10 @@ export class PluginService implements OnDestroy {
     // Remove icon content
     this._pluginIcons.delete(pluginId);
     this._pluginIconsSignal.set(new Map(this._pluginIcons));
+
+    // Drop any session nodeExecution denial so a fresh re-upload of this id is prompted
+    // again rather than silently failing closed against the removed plugin's decision.
+    this._nodeExecutionDeniedThisSession.delete(pluginId);
 
     // Remove from plugin states
     this._deletePluginState(pluginId);

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -109,6 +109,11 @@ export class PluginService implements OnDestroy {
   private _pluginIcons: Map<string, string> = new Map(); // Store plugin ID -> SVG icon content
   private _pluginIframeGenerations: Map<string, number> = new Map();
   private _pluginIconsSignal = signal<Map<string, string>>(new Map());
+  // Plugin ids the user denied nodeExecution for this app session. In-memory only —
+  // never persisted or synced (consent is session-scoped). Prevents re-prompting from
+  // the multiple grant call-sites of a single enable flow, and keeps a denial sticky
+  // until the user explicitly re-enables the plugin. Cleared in checkNodeExecutionPermission.
+  private readonly _nodeExecutionDeniedThisSession = new Set<string>();
 
   // Lazy loading state management
   private _pluginStates = signal<Map<string, PluginState>>(new Map());
@@ -1796,14 +1801,25 @@ export class PluginService implements OnDestroy {
     if (this._pluginBridge.hasNodeExecutionGrantToken(manifest.id)) {
       return true;
     }
+    // A single enable flow reaches this from several call-sites; once the user has
+    // denied this session, don't re-open the native prompt until they re-enable.
+    if (this._nodeExecutionDeniedThisSession.has(manifest.id)) {
+      return false;
+    }
     let grant: { token: string } | null;
     try {
-      grant = await this._pluginBridge.requestNodeExecutionGrant(manifest.id);
+      // name/version are sent for the consent dialog only; main treats them as
+      // self-declared/unverified for uploaded plugins (it never trusts them for auth).
+      grant = await this._pluginBridge.requestNodeExecutionGrant(manifest.id, {
+        name: manifest.name,
+        version: manifest.version,
+      });
     } catch (error) {
       PluginLog.err(`Failed to get nodeExecution grant for ${manifest.id}:`, error);
       return false;
     }
     if (!grant) {
+      this._nodeExecutionDeniedThisSession.add(manifest.id);
       return false;
     }
 
@@ -1813,10 +1829,13 @@ export class PluginService implements OnDestroy {
 
   private async _revokeNodeExecutionGrant(pluginId: string): Promise<void> {
     const grantToken = this._pluginBridge.revokeNodeExecutionGrantToken(pluginId);
-    if (!grantToken || !this._isElectronRuntime()) {
+    if (!this._isElectronRuntime()) {
       return;
     }
-    await this._pluginBridge.revokeNodeExecutionGrant(pluginId, grantToken);
+    // Always tell main to drop the grant for this id, even if the renderer no longer
+    // holds the token (main revokes by pluginId + webContents), so a re-upload under
+    // the same id can never inherit a live session grant.
+    await this._pluginBridge.revokeNodeExecutionGrant(pluginId, grantToken ?? '');
   }
 
   /**
@@ -1836,6 +1855,9 @@ export class PluginService implements OnDestroy {
       return false;
     }
 
+    // This is the interactive (user-initiated) entry point, so an explicit enable
+    // attempt clears any earlier this-session denial and re-opens the prompt.
+    this._nodeExecutionDeniedThisSession.delete(manifest.id);
     return this._ensureNodeExecutionGrant(manifest);
   }
 
@@ -1886,16 +1908,14 @@ export class PluginService implements OnDestroy {
   }
 
   private _assertUploadedPluginAllowed(manifest: PluginManifest): void {
+    // Uploaded plugins may not reuse a bundled plugin's id (it would let unverified
+    // code impersonate a built-in). nodeExecution is no longer blocked here: uploaded
+    // node plugins are gated by the main-process consent dialog at grant time instead.
     if (this._isBundledPluginId(manifest.id)) {
       throw new Error(
         this._translateService.instant(T.PLUGINS.PLUGIN_ID_RESERVED, {
           pluginId: manifest.id,
         }),
-      );
-    }
-    if (manifest.permissions?.includes('nodeExecution')) {
-      throw new Error(
-        this._translateService.instant(T.PLUGINS.NODE_EXECUTION_BUILT_IN_ONLY),
       );
     }
   }

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -110,9 +110,11 @@ export class PluginService implements OnDestroy {
   private _pluginIframeGenerations: Map<string, number> = new Map();
   private _pluginIconsSignal = signal<Map<string, string>>(new Map());
   // Plugin ids the user denied nodeExecution for this app session. In-memory only —
-  // never persisted or synced (consent is session-scoped). Prevents re-prompting from
-  // the multiple grant call-sites of a single enable flow, and keeps a denial sticky
-  // until the user explicitly re-enables the plugin. Cleared in checkNodeExecutionPermission.
+  // never persisted or synced (consent is session-scoped). Makes a denial sticky so a
+  // later non-interactive grant attempt (e.g. startup re-activation via _fireOnReady,
+  // which doesn't pass through checkNodeExecutionPermission) doesn't re-open the native
+  // prompt. Added on deny in _ensureNodeExecutionGrant; cleared only on an explicit
+  // user-initiated enable in checkNodeExecutionPermission (so re-enable always re-asks).
   private readonly _nodeExecutionDeniedThisSession = new Set<string>();
 
   // Lazy loading state management


### PR DESCRIPTION
## What & why

**Phase 1 of #8512.** Resolves the regression reported in discussion #8385 (Super Productivity MCP plugin broke on v18.10.0).

PR #8205 moved `nodeExecution` consent into the Electron **main** process and, as a side effect, blocked uploaded/community plugins from using `nodeExecution` entirely (built-in only). This PR re-opens it for uploaded plugins **behind the existing main-process consent dialog**, keeping the trust decision with the user and the plugin clearly flagged as unverified third-party.

Per the discussion, we deliberately **do not** bundle individual community plugins — that would pull third-party native code into SP's signed release and make it look first-party. The general consent gate unblocks any node plugin, not just one.

## Design decisions

- **Deny = stay enabled, fail closed — not auto-disable.** `pluginMetadata.isEnabled` is a synced op-log model, so auto-disabling on deny (or a misclick on the default-Deny dialog) would propagate a per-device, per-session security denial to every device. Instead, deny keeps the plugin enabled but node calls fail until re-enable or restart; consent is re-requested once per session. (The persisted "ask once, remember per-plugin" + a "re-request access" affordance are **Phase 2**.)
- **Session-scoped consent only.** Grants stay in-memory in the main process; nothing is persisted or synced. An in-memory, never-synced "denied this session" set makes a denial sticky (no re-prompt loop) until the user explicitly re-enables. This does **not** reintroduce the known `nodeExecutionConsent`-must-not-sync footgun (guarded by `plugin-meta-persistence.service.spec.ts`).
- **Main-side input sanitization.** For uploaded plugins the id (a grant-map key **and** dialog text) and the self-declared name/version (display-only) are attacker-controlled, so they're sanitized in the **main** process before reaching the dialog or the grant map: control/zero-width/bidi chars, whitespace, `:`, path separators and dot-segments rejected; name/version length-capped. Uploaded ids are intentionally **not** held to the strict built-in kebab rule (community ids may use dots/uppercase, e.g. `super-productivity-mcp`).
- **Bundled vs uploaded is decided by the on-disk manifest**, never a renderer-supplied flag — so uploaded code can't borrow a built-in plugin's verified name. Bundled → verified-manifest dialog; uploaded → an explicit "unverified third-party, full machine access, cannot sandbox, default **Deny**" dialog.
- **Revoke is main-authoritative** by `(pluginId, webContents)` — the token is no longer required (revoking only removes capability). This guarantees teardown/re-upload drops the grant even if the renderer no longer holds the token, so a re-upload reusing an id can't inherit a live session grant.
- **IPC signature** is an options object (`requestGrant(pluginId, { name, version })`) so Phase 2 display fields don't force another breaking change.

## Review

Multi-agent reviewed (correctness, security, architecture, simplicity, performance). The cross-cutting finding — the uploaded id flowing unsanitized into the bundled-manifest `existsSync` probe — was fixed in the second commit (reject path separators / dot-segments; impact was bounded, no code-exec/file-read/dialog-spoof, but it left a filesystem-existence oracle and misleading dialog text).

## Tests

- Electron main: uploaded (non-bundled) id obtains a grant; deny → exec rejects; non-kebab id accepted; crafted name/id can't inject extra dialog lines; path-segment ids rejected; revoke without token still drops the grant. (148 electron tests green.)
- Renderer: `_assertUploadedPluginAllowed` no longer throws for `nodeExecution` but still throws on bundled-id collision; denied-cache prevents re-prompt; grant request passes display info.

## Not in this PR / follow-ups

- Persisted per-plugin consent + "re-request access" UI affordance (Phase 2, #8512).
- Hoisting the uploaded-id rule to install-time validation for a clearer error (currently fails closed at grant time).
- Web build unchanged (`nodeExecution` is `IS_ELECTRON`-gated end to end).

> **Note:** the consent dialog copy/flow is unit-tested but has **not** been visually verified in a packaged Electron build yet.
