### PR TITLE
fix(caldav): route WebDAV verbs through native HTTP on Android (#8558)

### DIFF
--- a/docs/wiki/3.05-Web-App-vs-Desktop.md
+++ b/docs/wiki/3.05-Web-App-vs-Desktop.md
@@ -25,7 +25,7 @@ In the web version, time tracking only works while the app is open. Idle time tr
 
 ### CORS (Cross-Origin Resource Sharing)
 
-WebDAV sync and calendar integration are likely to fail in the browser due to CORS. The app detects CORS-related failures and can show localized messages suggesting the user check server configuration. The desktop app can bypass CORS for these requests; the web app cannot.
+WebDAV sync and calendar integration are likely to fail in the browser due to CORS. The app detects CORS-related failures and can show localized messages suggesting the user check server configuration. The desktop and mobile (iOS/Android) apps issue these requests through a native HTTP layer and are not subject to browser CORS; the web app is. This is why CalDAV calendar sync (e.g. with iCloud) works in the desktop and mobile apps but typically fails in the web app, where the server does not send the required CORS headers.
 
 ### WebCrypto API
 

--- a/src/app/plugins/issue-provider/plugin-http.service.spec.ts
+++ b/src/app/plugins/issue-provider/plugin-http.service.spec.ts
@@ -4,7 +4,12 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { PluginHttpService } from './plugin-http.service';
+import type { NativeHttpResponse } from '@sp/sync-providers/http';
+import {
+  PluginHttpService,
+  PLUGIN_HTTP_IS_NATIVE,
+  PLUGIN_HTTP_NATIVE_EXECUTOR,
+} from './plugin-http.service';
 
 describe('PluginHttpService', () => {
   let service: PluginHttpService;
@@ -182,5 +187,100 @@ describe('PluginHttpService', () => {
       req.flush({ ok: true });
       await expectAsync(promise).toBeResolved();
     });
+  });
+});
+
+describe('PluginHttpService - native WebDAV/CalDAV method routing (#8558)', () => {
+  let service: PluginHttpService;
+  let httpMock: HttpTestingController;
+  let nativeHttp: jasmine.Spy<(c: unknown) => Promise<NativeHttpResponse>>;
+
+  const okResponse = (over: Partial<NativeHttpResponse> = {}): NativeHttpResponse => ({
+    status: 207,
+    headers: {},
+    data: '<multistatus/>',
+    url: 'https://caldav.icloud.com/',
+    ...over,
+  });
+
+  beforeEach(() => {
+    nativeHttp = jasmine
+      .createSpy('nativeHttp')
+      .and.resolveTo(okResponse() as NativeHttpResponse);
+    TestBed.configureTestingModule({
+      providers: [
+        PluginHttpService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: PLUGIN_HTTP_IS_NATIVE, useValue: true },
+        { provide: PLUGIN_HTTP_NATIVE_EXECUTOR, useValue: nativeHttp },
+      ],
+    });
+    service = TestBed.inject(PluginHttpService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  const authHeaders = (): Record<string, string> => ({ Authorization: 'Basic abc' });
+
+  it('routes PROPFIND through the native executor (not HttpClient)', async () => {
+    const http = service.createHttpHelper(authHeaders);
+    const result = await http.request<string>(
+      'PROPFIND',
+      'https://caldav.icloud.com/',
+      '<propfind/>',
+      { responseType: 'text', headers: { Depth: '0' } },
+    );
+    expect(nativeHttp).toHaveBeenCalledTimes(1);
+    const cfg = nativeHttp.calls.mostRecent().args[0] as Record<string, unknown>;
+    expect(cfg['method']).toBe('PROPFIND');
+    expect(cfg['data']).toBe('<propfind/>');
+    expect((cfg['headers'] as Record<string, string>)['Authorization']).toBe('Basic abc');
+    expect((cfg['headers'] as Record<string, string>)['Depth']).toBe('0');
+    expect(result).toBe('<multistatus/>');
+    httpMock.expectNone(() => true);
+  });
+
+  it('routes REPORT through the native executor', async () => {
+    const http = service.createHttpHelper(authHeaders);
+    await http.request('REPORT', 'https://caldav.icloud.com/cal/', '<query/>', {
+      responseType: 'text',
+    });
+    expect(nativeHttp).toHaveBeenCalledTimes(1);
+    expect((nativeHttp.calls.mostRecent().args[0] as { method: string }).method).toBe(
+      'REPORT',
+    );
+  });
+
+  it('rejects with an error carrying .status on a non-2xx native response', async () => {
+    nativeHttp.and.resolveTo(okResponse({ status: 404, data: '' }));
+    const http = service.createHttpHelper(authHeaders);
+    await expectAsync(
+      http.request('PROPFIND', 'https://caldav.icloud.com/', '<propfind/>', {
+        responseType: 'text',
+      }),
+    ).toBeRejectedWith(jasmine.objectContaining({ status: 404 }));
+  });
+
+  it('parses JSON when responseType is not text', async () => {
+    nativeHttp.and.resolveTo(okResponse({ status: 200, data: '{"ok":true}' }));
+    const http = service.createHttpHelper(authHeaders);
+    const result = await http.request<{ ok: boolean }>(
+      'PROPFIND',
+      'https://caldav.icloud.com/',
+      '<propfind/>',
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('does NOT reroute standard verbs — GET still uses HttpClient', async () => {
+    const http = service.createHttpHelper(authHeaders);
+    const promise = http.get('https://caldav.icloud.com/');
+    await new Promise((r) => setTimeout(r, 0));
+    const req = httpMock.expectOne('https://caldav.icloud.com/');
+    req.flush({ ok: true });
+    await expectAsync(promise).toBeResolved();
+    expect(nativeHttp).not.toHaveBeenCalled();
   });
 });

--- a/src/app/plugins/issue-provider/plugin-http.service.ts
+++ b/src/app/plugins/issue-provider/plugin-http.service.ts
@@ -1,11 +1,54 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 import { firstValueFrom, timeout } from 'rxjs';
+import type { NativeHttpExecutor } from '@sp/sync-providers/http';
 import { PluginHttp, PluginHttpOptions } from './plugin-issue-provider.model';
+import { IS_NATIVE_PLATFORM } from '../../util/is-native-platform';
+// Reuses the app's OkHttp/URLSession-backed native HTTP executor. It lives under
+// the WebDAV sync feature today, but is protocol-agnostic (a thin {url, method,
+// headers, data} → response pipe). A future refactor could lift it to a neutral
+// `NativeHttp` home shared by sync and plugins. See issue #8558.
+import { APP_WEBDAV_NATIVE_HTTP } from '../../op-log/sync-providers/file-based/webdav/capacitor-webdav-http/app-webdav-native-http';
 
 const DEFAULT_TIMEOUT = 30000;
 const MIN_TIMEOUT = 1000;
 const MAX_TIMEOUT = 120000;
+
+/**
+ * WebDAV/CalDAV verbs that Java's `HttpURLConnection` (the engine behind
+ * Capacitor's native `CapacitorHttp`, which intercepts every non-GET/HEAD/
+ * OPTIONS/TRACE XHR on-device) refuses with `ProtocolException`. On native
+ * platforms these are issued through the OkHttp/URLSession-backed executor
+ * instead, which accepts arbitrary method strings. Standard verbs keep using the
+ * normal `HttpClient` path (it handles JSON + works on every platform).
+ *
+ * Scoped to the verbs the CalDAV calendar plugin actually uses (discovery +
+ * event query). Entries MUST stay within the set the native `WebDavHttp` plugin
+ * implements (e.g. it rejects `MKCALENDAR`). `PATCH` is also rejected by
+ * `HttpURLConnection` and would belong here, but it's used by other providers
+ * (GitHub, Google Calendar) whose JSON round-trips need separate on-device
+ * verification — tracked separately, intentionally not rerouted here.
+ * See issue #8558.
+ */
+const NATIVE_HTTP_METHODS = new Set(['PROPFIND', 'REPORT']);
+
+/**
+ * Whether plugin HTTP runs in a native Capacitor context. Injectable so tests
+ * can exercise the native-reroute branch without a device.
+ */
+export const PLUGIN_HTTP_IS_NATIVE = new InjectionToken<boolean>(
+  'PLUGIN_HTTP_IS_NATIVE',
+  {
+    providedIn: 'root',
+    factory: () => IS_NATIVE_PLATFORM,
+  },
+);
+
+/** The native HTTP executor used for WebDAV verbs. Injectable for test override. */
+export const PLUGIN_HTTP_NATIVE_EXECUTOR = new InjectionToken<NativeHttpExecutor>(
+  'PLUGIN_HTTP_NATIVE_EXECUTOR',
+  { providedIn: 'root', factory: () => APP_WEBDAV_NATIVE_HTTP },
+);
 
 const BLOCKED_HOSTNAMES = new Set([
   'localhost',
@@ -63,6 +106,8 @@ export interface PluginHttpHelperOpts {
 @Injectable({ providedIn: 'root' })
 export class PluginHttpService {
   private _http = inject(HttpClient);
+  private _isNativePlatform = inject(PLUGIN_HTTP_IS_NATIVE);
+  private _nativeHttp = inject(PLUGIN_HTTP_NATIVE_EXECUTOR);
 
   createHttpHelper(
     getHeaders: () => Record<string, string> | Promise<Record<string, string>>,
@@ -113,6 +158,19 @@ export class PluginHttpService {
     const authHeaders = await Promise.resolve(getHeaders());
     const mergedHeaders = { ...options?.headers, ...authHeaders };
 
+    // On-device, route WebDAV/CalDAV verbs through the native OkHttp/URLSession
+    // executor — Capacitor's CapacitorHttp would otherwise reject them via
+    // Android's HttpURLConnection. See issue #8558.
+    if (this._isNativePlatform && NATIVE_HTTP_METHODS.has(upperMethod)) {
+      return this._requestViaNativeHttp<T>(
+        upperMethod,
+        url,
+        body,
+        options,
+        mergedHeaders,
+      );
+    }
+
     let params = new HttpParams();
     if (options?.params) {
       for (const [k, v] of Object.entries(options.params)) {
@@ -137,6 +195,66 @@ export class PluginHttpService {
       .pipe(timeout(timeoutMs));
 
     return firstValueFrom(obs$) as Promise<T>;
+  }
+
+  /**
+   * Issue a request through the native HTTP executor (OkHttp on Android,
+   * URLSession on iOS). Returns text verbatim; on non-2xx it rejects with an
+   * error carrying `.status`, mirroring `HttpClient`'s `HttpErrorResponse` so
+   * plugin status checks (e.g. 404 on delete, 429/503 retry) behave identically.
+   *
+   * Note: `options.timeout` is not honored here — the native executor uses its
+   * own fixed timeout (~30s). Acceptable for the current CalDAV callers, which
+   * set no custom timeout.
+   */
+  private async _requestViaNativeHttp<T>(
+    method: string,
+    url: string,
+    body: unknown,
+    options: PluginHttpOptions | undefined,
+    headers: Record<string, string>,
+  ): Promise<T> {
+    let finalUrl = url;
+    if (options?.params && Object.keys(options.params).length) {
+      const withParams = new URL(url);
+      for (const [k, v] of Object.entries(options.params)) {
+        withParams.searchParams.set(k, v);
+      }
+      finalUrl = withParams.toString();
+    }
+
+    const data =
+      body == null ? undefined : typeof body === 'string' ? body : JSON.stringify(body);
+
+    const res = await this._nativeHttp({
+      url: finalUrl,
+      method,
+      headers,
+      data,
+      responseType: options?.responseType === 'text' ? 'text' : 'json',
+    });
+
+    if (res.status < 200 || res.status >= 300) {
+      throw Object.assign(
+        new Error(`[PluginHttp] Request failed with status ${res.status}`),
+        { status: res.status },
+      );
+    }
+
+    if (options?.responseType === 'text') {
+      return (typeof res.data === 'string' ? res.data : String(res.data ?? '')) as T;
+    }
+    // Default responseType is 'json'; the native executor returns text, so parse
+    // it here to match the HttpClient path. Fall back to the raw text if it
+    // isn't valid JSON (e.g. an empty body).
+    if (typeof res.data === 'string') {
+      try {
+        return (res.data ? JSON.parse(res.data) : null) as T;
+      } catch {
+        return res.data as T;
+      }
+    }
+    return res.data as T;
   }
 
   private _validateUrl(url: string, allowPrivateNetwork: boolean): void {


### PR DESCRIPTION
## What

Fixes CalDAV calendar (Apple/iCloud) sync on **Android**. Closes #8558.

`PROPFIND` (calendar discovery) and `REPORT` (event search) failed on the Android app — Capacitor's `CapacitorHttp` routes non-`GET`/`HEAD`/`OPTIONS`/`TRACE` requests through Java's `HttpURLConnection`, which throws `ProtocolException` for WebDAV/CalDAV verbs. (iOS works via URLSession; desktop works via Electron's CORS header injection.)

This reroutes those verbs through the app's existing OkHttp/URLSession-backed native HTTP executor (`WebDavHttp`, already used by WebDAV sync) on native platforms. Standard verbs keep the Angular `HttpClient` path unchanged.

## Scope & non-goals

- **Android (reads)**: fixed — discovery + event search work.
- **Web**: unchanged and still limited by **CORS** — iCloud sends no `Access-Control-Allow-Origin`, unfixable client-side. Documented in `3.05-Web-App-vs-Desktop.md`.
- Rerouted set scoped to `{PROPFIND, REPORT}` (what the CalDAV plugin uses) and kept within what the native `WebDavHttp` plugin implements.

## Safety

- Reroute runs **after** `_validateUrl` (SSRF) and the method allow-list, so those protections are preserved.
- Auth headers forwarded; non-2xx rejects with an error carrying `.status` so plugin `isHttpStatus` checks (404-on-delete, 429/503 retry) behave identically to the `HttpClient` path.
- Gated by injectable tokens (`PLUGIN_HTTP_IS_NATIVE`, `PLUGIN_HTTP_NATIVE_EXECUTOR`) for testability.

## Tests

`plugin-http.service.spec.ts`: 25/25 pass (5 new — PROPFIND/REPORT reroute, non-2xx `.status`, JSON parse, GET-not-rerouted). `checkFile` clean.

## Needs on-device verification

- Android: confirm CalDAV discovery/search now work end-to-end.
- iOS: regression check — `PROPFIND`/`REPORT` now go through `WebDavHttp`/URLSession instead of `CapacitorHttp`/URLSession (equivalent transport; avoids `CapacitorHttp`'s documented WebDAV-response quirks).

## Follow-ups (separate)

- `PATCH` has the same Android limitation and affects GitHub / Google Calendar providers — tracked separately.
- iOS `WebDavHttp` could strip `Authorization` on cross-host redirects (hardening; benefits WebDAV sync too).
