### PR TITLE
fix(localization): correct time-format note + 24h schedule folding (#8565)

### DIFF
--- a/src/app/core/date-time-format/date-time-format.service.spec.ts
+++ b/src/app/core/date-time-format/date-time-format.service.spec.ts
@@ -6,10 +6,12 @@ import { DateAdapter, MatNativeDateModule } from '@angular/material/core';
 import {
   DateTimeLocales,
   DEFAULT_FIRST_DAY_OF_WEEK,
+  LanguageCode,
 } from 'src/app/core/locale.constants';
 import { GlobalConfigState } from '../../features/config/global-config.model';
 import { CustomDateAdapter } from './custom-date-adapter';
 import { TranslateService } from '@ngx-translate/core';
+import { LanguageService } from '../language/language.service';
 
 describe('DateTimeFormatService', () => {
   let service: DateTimeFormatService;
@@ -372,6 +374,65 @@ describe('DateTimeFormatService', () => {
 
       // en (US) → 12h AM/PM
       expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('2:00 PM');
+    });
+  });
+
+  describe('LanguageService wiring keeps the dateTimeLocale override (#8565)', () => {
+    const TIME_FORMAT: Intl.DateTimeFormatOptions = {
+      hour: 'numeric',
+      minute: 'numeric',
+    };
+    const testDate = new Date(2000, 11, 31, 14, 0, 0);
+
+    // Integration guard: the existing #8565 specs call setUiLanguage() directly.
+    // This one boots the *real* LanguageService so a regression that points
+    // _set() back at setDateAdapterLocale() (re-introducing the original race)
+    // is caught — that is the actual code path that clobbered the override.
+    it('renders 24h after LanguageService applies UI language "en" over a ja-jp override', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MatNativeDateModule],
+        providers: [
+          DateTimeFormatService,
+          LanguageService,
+          { provide: DateAdapter, useClass: CustomDateAdapter },
+          {
+            provide: TranslateService,
+            useValue: {
+              currentLang: 'en',
+              defaultLang: 'en',
+              use: () => {},
+              getBrowserCultureLang: () => undefined,
+              getBrowserLang: () => undefined,
+            },
+          },
+          provideMockStore({
+            initialState: {
+              globalConfig: {
+                ...DEFAULT_GLOBAL_CONFIG,
+                localization: {
+                  ...DEFAULT_GLOBAL_CONFIG.localization,
+                  dateTimeLocale: DateTimeLocales.ja_jp,
+                },
+              },
+            },
+          }),
+        ],
+      });
+
+      const adapter = TestBed.inject(DateAdapter);
+      TestBed.inject(DateTimeFormatService); // construct → owning effect registers
+      TestBed.flushEffects(); // applies the ja-jp override
+      expect(adapter.format(testDate, TIME_FORMAT)).toBe('14:00');
+
+      // Apply the UI language through the real service. It must route through
+      // setUiLanguage() (a fallback), not write the adapter — so the override
+      // still wins in the synchronous pre-flush window where the race struck.
+      TestBed.inject(LanguageService).setLng(LanguageCode.en);
+      expect(adapter.format(testDate, TIME_FORMAT)).toBe('14:00');
+
+      TestBed.flushEffects();
+      expect(adapter.format(testDate, TIME_FORMAT)).toBe('14:00');
     });
   });
 });

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -64,7 +64,8 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
         },
         {
           provide: DateTimeFormatService,
-          useValue: { is24HourFormat: true },
+          // is24HourFormat is a signal (a function); the component must call it.
+          useValue: { is24HourFormat: () => true },
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -194,6 +195,56 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
       fixture.detectChanges();
 
       expect(component.style()).toBe('grid-column: 2;  grid-row: 121 / span 12');
+    });
+  });
+
+  describe('scheduledClockStr 12/24-hour folding (#8565)', () => {
+    // is24HourFormat is a signal; calling it (vs. negating the function ref,
+    // which is always truthy) is what makes 12h locales fold 14:00 → 2:00.
+    const setupWith24h = async (is24Hour: boolean): Promise<ScheduleEventComponent> => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [ScheduleEventComponent, DragDropModule, TranslateModule.forRoot()],
+        providers: [
+          provideMockStore(),
+          { provide: MatDialog, useValue: { open: jasmine.createSpy('open') } },
+          {
+            provide: TaskService,
+            useValue: { setSelectedId: jasmine.createSpy('setSelectedId') },
+          },
+          {
+            provide: CalendarEventActionsService,
+            useValue: {
+              hasEventUrl: jasmine.createSpy('hasEventUrl').and.returnValue(false),
+              isPluginEvent: jasmine.createSpy('isPluginEvent').and.returnValue(false),
+              canMoveEvent: jasmine.createSpy('canMoveEvent').and.returnValue(false),
+              createAsTask: jasmine.createSpy('createAsTask'),
+              hideForever: jasmine.createSpy('hideForever'),
+            },
+          },
+          {
+            provide: DateTimeFormatService,
+            useValue: { is24HourFormat: () => is24Hour },
+          },
+        ],
+        schemas: [NO_ERRORS_SCHEMA],
+      }).compileComponents();
+
+      const f = TestBed.createComponent(ScheduleEventComponent);
+      const event = { ...makeTaskScheduleEvent(), startHours: 14 };
+      f.componentRef.setInput('event', event);
+      f.detectChanges();
+      return f.componentInstance;
+    };
+
+    it('keeps 24-hour time for a 24h locale', async () => {
+      const c = await setupWith24h(true);
+      expect(c.scheduledClockStr()).toBe('14:00');
+    });
+
+    it('folds to 12-hour time for a 12h locale', async () => {
+      const c = await setupWith24h(false);
+      expect(c.scheduledClockStr()).toBe('2:00');
     });
   });
 });

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -147,7 +147,7 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
 
   readonly scheduledClockStr = computed(() => {
     const evt = this.se();
-    const is12Hour = !this._dateTimeFormatService.is24HourFormat;
+    const is12Hour = !this._dateTimeFormatService.is24HourFormat();
     return getClockStringFromHours(
       is12Hour && evt.startHours > 12 ? evt.startHours - 12 : evt.startHours,
     );
@@ -159,7 +159,7 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
 
   readonly hoverTitle = computed(() => {
     const evt = this.se();
-    const is12Hour = !this._dateTimeFormatService.is24HourFormat;
+    const is12Hour = !this._dateTimeFormatService.is24HourFormat();
     const startClockStr = getClockStringFromHours(
       is12Hour && evt.startHours > 12 ? evt.startHours - 12 : evt.startHours,
     );

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2446,7 +2446,7 @@
       "TIME_LOCALE_AUTO": "System default",
       "TIME_LOCALE_CS_CZ": "Czech: 24-hour, DD. MM. YYYY",
       "TIME_LOCALE_DE_DE": "German: 24-hour, DD.MM.YYYY",
-      "TIME_LOCALE_DESCRIPTION": "NOTE: This option cannot change the time input format (12/24 hour) because it is controlled by your OS.",
+      "TIME_LOCALE_DESCRIPTION": "Sets the date format and the 12/24-hour time format used across the app. \"System default\" follows your browser's language/region — to force 12- or 24-hour time, pick a specific locale.",
       "TIME_LOCALE_EN_GB": "English (UK): 24-hour, DD/MM/YYYY",
       "TIME_LOCALE_EN_US": "English (US): 12-hour AM/PM, MM/DD/YYYY",
       "TIME_LOCALE_ES_ES": "Spanish: 24-hour, DD/MM/YYYY",


### PR DESCRIPTION
Follow-ups to #8574 (locale clock, #8565), found while reviewing the reporter's feedback that it "still shows 12h".

### 1. `fix(localization)`: correct the misleading setting note
The *Datetime format locale* note still read:

> "This option cannot change the time input format (12/24 hour) because it is controlled by your OS."

After #8574 this is false: the dropdown **does** control the 12/24-hour time input, and the "System default" fallback follows the **browser language** (`navigator.languages[0]`), not the OS clock. This note was the source of the reporter's confusion (24h OS, English browser → 12h app). New text states what actually drives the format.

### 2. `fix(schedule)`: call the `is24HourFormat` signal
`schedule-event.component.ts` negated the `is24HourFormat` **signal** (a function reference, always truthy) instead of its value, so `is12Hour` was always `false` and schedule events never folded to 12h — an `en-US` user saw `14:00` instead of `2:00`. Pre-existing (commit `2485c7ae51`), unrelated to #8574 but same feature. Now calls `is24HourFormat()`, matching `schedule-week.component.ts`. Adds folding coverage for both 12h and 24h.

### 3. `test(localization)`: integration guard for the override
The existing #8565 specs call `setUiLanguage()` directly. This one boots the **real `LanguageService`** alongside `DateTimeFormatService` with a `ja-jp` override and asserts the adapter still renders 24h after the UI language is applied — so a regression that routes `_set()` back at the adapter (re-introducing the original startup race) is caught. Verified non-vacuous: reintroducing the clobber turns it red.

---
All affected specs pass (`date-time-format` 21/21, `schedule-event` 13/13); each `.ts` passes `checkFile`; `en.json` is Prettier-clean. Only `en.json` touched per the translations rule.
