### PR TITLE
[codex] Route plugin PATCH through native HTTP

### DIFF
--- a/src/app/plugins/issue-provider/plugin-http.service.spec.ts
+++ b/src/app/plugins/issue-provider/plugin-http.service.spec.ts
@@ -223,6 +223,7 @@ describe('PluginHttpService - native WebDAV/CalDAV method routing (#8558)', () =
   afterEach(() => httpMock.verify());
 
   const authHeaders = (): Record<string, string> => ({ Authorization: 'Basic abc' });
+  const GITHUB_API_VERSION_HEADER = 'X-GitHub-Api-Version';
 
   it('routes PROPFIND through the native executor (not HttpClient)', async () => {
     const http = service.createHttpHelper(authHeaders);
@@ -251,6 +252,40 @@ describe('PluginHttpService - native WebDAV/CalDAV method routing (#8558)', () =
     expect((nativeHttp.calls.mostRecent().args[0] as { method: string }).method).toBe(
       'REPORT',
     );
+  });
+
+  it('routes PATCH JSON requests through the native executor', async () => {
+    nativeHttp.and.resolveTo(
+      okResponse({
+        status: 200,
+        data: '{"id":"issue-1","title":"Updated"}',
+        url: 'https://api.github.com/repos/owner/repo/issues/1?state=open',
+      }),
+    );
+    const http = service.createHttpHelper(authHeaders);
+    const result = await http.patch<{ id: string; title: string }>(
+      'https://api.github.com/repos/owner/repo/issues/1',
+      { title: 'Updated' },
+      {
+        headers: { [GITHUB_API_VERSION_HEADER]: '2022-11-28' },
+        params: { state: 'open' },
+      },
+    );
+
+    expect(nativeHttp).toHaveBeenCalledTimes(1);
+    const cfg = nativeHttp.calls.mostRecent().args[0] as Record<string, unknown>;
+    expect(cfg['url']).toBe(
+      'https://api.github.com/repos/owner/repo/issues/1?state=open',
+    );
+    expect(cfg['method']).toBe('PATCH');
+    expect(cfg['data']).toBe('{"title":"Updated"}');
+    expect(cfg['responseType']).toBe('json');
+    expect((cfg['headers'] as Record<string, string>)['Authorization']).toBe('Basic abc');
+    expect((cfg['headers'] as Record<string, string>)[GITHUB_API_VERSION_HEADER]).toBe(
+      '2022-11-28',
+    );
+    expect(result).toEqual({ id: 'issue-1', title: 'Updated' });
+    httpMock.expectNone(() => true);
   });
 
   it('rejects with an error carrying .status on a non-2xx native response', async () => {

--- a/src/app/plugins/issue-provider/plugin-http.service.ts
+++ b/src/app/plugins/issue-provider/plugin-http.service.ts
@@ -22,15 +22,13 @@ const MAX_TIMEOUT = 120000;
  * instead, which accepts arbitrary method strings. Standard verbs keep using the
  * normal `HttpClient` path (it handles JSON + works on every platform).
  *
- * Scoped to the verbs the CalDAV calendar plugin actually uses (discovery +
- * event query). Entries MUST stay within the set the native `WebDavHttp` plugin
- * implements (e.g. it rejects `MKCALENDAR`). `PATCH` is also rejected by
- * `HttpURLConnection` and would belong here, but it's used by other providers
- * (GitHub, Google Calendar) whose JSON round-trips need separate on-device
- * verification — tracked separately, intentionally not rerouted here.
- * See issue #8558.
+ * Scoped to the verbs issue-provider plugins need on native platforms. Entries
+ * MUST stay within the set the native `WebDavHttp` plugin implements (e.g. it
+ * rejects `MKCALENDAR`). `PATCH` is required by the GitHub and Google Calendar
+ * issue providers; keep it off any automatic transient retry path because PATCH
+ * is not guaranteed to be idempotent. See issues #8558 and #8579.
  */
-const NATIVE_HTTP_METHODS = new Set(['PROPFIND', 'REPORT']);
+const NATIVE_HTTP_METHODS = new Set(['PROPFIND', 'REPORT', 'PATCH']);
 
 /**
  * Whether plugin HTTP runs in a native Capacitor context. Injectable so tests


### PR DESCRIPTION
## What

Routes plugin `PATCH` requests through the existing native `WebDavHttp` executor on native platforms, alongside the existing `PROPFIND` and `REPORT` routing. This fixes Android issue-provider updates that use `PATCH`, including GitHub issue updates and Google Calendar event edits.

## Why

On Android, Capacitor routes non-basic HTTP methods through Java `HttpURLConnection`, which rejects `PATCH` with `ProtocolException`. The app already has an OkHttp/URLSession-backed native executor for methods that `HttpURLConnection` cannot handle.

## Validation

- Confirmed RED first: the new `PATCH` regression test failed while `PATCH` still used `HttpClient`.
- `npm run test:file src/app/plugins/issue-provider/plugin-http.service.spec.ts` — 26/26 passed.
- `npm run checkFile src/app/plugins/issue-provider/plugin-http.service.ts` — passed.
- `npm run checkFile src/app/plugins/issue-provider/plugin-http.service.spec.ts` — passed.
- `git diff --check` — passed.
- Pre-push hook ran `npm run lint` and `npm test`; lint had existing warnings in unrelated files, and tests passed, including the main Karma suite and timezone suite.

## Android verification

Android device verification was **not** run. Before merging, please verify on a real Android device that GitHub issue updates and Google Calendar event edits no longer fail.

Fixes #8579
