### PR TITLE
fix(sync): share quota pre-gate helper

### DIFF
--- a/packages/super-sync-server/src/sync/sync.routes.quota.ts
+++ b/packages/super-sync-server/src/sync/sync.routes.quota.ts
@@ -110,6 +110,10 @@ type ExistingSyncImport = {
   serverSeq: number;
 };
 
+export type EnforceStorageQuotaOptions = {
+  allowCleanup?: boolean;
+};
+
 /**
  * Look up an existing full-state op for the user.
  *
@@ -196,7 +200,9 @@ export async function enforceStorageQuota(
   userId: number,
   storageDeltaBytes: number,
   reply: FastifyReply,
+  options: EnforceStorageQuotaOptions = {},
 ): Promise<boolean> {
+  const { allowCleanup = true } = options;
   const syncService = getSyncService();
   let quotaCheck = await syncService.checkStorageQuota(userId, storageDeltaBytes);
   if (quotaCheck.allowed) return true;
@@ -207,7 +213,8 @@ export async function enforceStorageQuota(
   // upload success, not on quota misses. Also guards against pre-deploy stale
   // counters where the old code's pg_column_size SUM left an inflated value.
   Logger.info(
-    `[user:${userId}] Quota cache miss (cached: ${quotaCheck.currentUsage}/${quotaCheck.quota}). Reconciling before cleanup...`,
+    `[user:${userId}] Quota cache miss (cached: ${quotaCheck.currentUsage}/${quotaCheck.quota}). ` +
+      `Reconciling before ${allowCleanup ? 'cleanup' : 'rejecting'}...`,
   );
   try {
     await syncService.updateStorageUsage(userId);
@@ -220,8 +227,22 @@ export async function enforceStorageQuota(
     }
   } catch (err) {
     Logger.warn(
-      `[user:${userId}] Reconcile failed, proceeding with cleanup: ${errorMessage(err)}`,
+      `[user:${userId}] Reconcile failed, ${
+        allowCleanup ? 'proceeding with cleanup' : 'rejecting without cleanup'
+      }: ${errorMessage(err)}`,
     );
+  }
+
+  if (!allowCleanup) {
+    Logger.warn(
+      `[user:${userId}] Storage quota exceeded: ${quotaCheck.currentUsage}/${quotaCheck.quota} bytes. Cleanup disabled for this route.`,
+    );
+    sendQuotaExceededReply(reply, {
+      storageUsedBytes: quotaCheck.currentUsage,
+      storageQuotaBytes: quotaCheck.quota,
+      autoCleanupAttempted: false,
+    });
+    return false;
   }
 
   Logger.warn(

--- a/packages/super-sync-server/src/sync/sync.routes.snapshot-handler.ts
+++ b/packages/super-sync-server/src/sync/sync.routes.snapshot-handler.ts
@@ -14,7 +14,6 @@ import {
 import type { SnapshotDedupResponse } from './services';
 import {
   createValidationErrorResponse,
-  errorMessage,
   MAX_COMPRESSED_SIZE_SNAPSHOT,
   MAX_DECOMPRESSED_SIZE_SNAPSHOT,
   sendCompressedBodyParseFailure,
@@ -26,7 +25,6 @@ import {
   enforceStorageQuota,
   findExistingSyncImport,
   isIdempotentSyncImportRetry,
-  sendQuotaExceededReply,
   sendSyncImportExistsReply,
 } from './sync.routes.quota';
 
@@ -111,30 +109,15 @@ export const uploadSnapshotHandler = async (
     }
 
     // Cheap pre-quota gate BEFORE prepareSnapshotCache so quota-exhausted
-    // clients can't burn CPU on JSON.stringify + zlib.gzipSync. Uses only
-    // the cached counter; if it says we're already at quota, reconcile
-    // once before rejecting — a stale-high counter would otherwise lock
-    // out a user whose new snapshot would actually shrink storage. Skip
-    // for clean-slate which wipes existing usage.
+    // clients can't burn CPU on JSON.stringify + zlib.gzipSync. Use 1 byte
+    // so the cheap gate preserves the existing used >= quota rejection
+    // boundary, and disable cleanup so this early path never deletes data.
+    // Skip for clean-slate which wipes existing usage.
     if (!isCleanSlate) {
-      let cachedInfo = await syncService.getStorageInfo(userId);
-      if (cachedInfo.storageUsedBytes >= cachedInfo.storageQuotaBytes) {
-        try {
-          await syncService.updateStorageUsage(userId);
-          cachedInfo = await syncService.getStorageInfo(userId);
-        } catch (err) {
-          Logger.warn(
-            `[user:${userId}] Snapshot pre-gate reconcile failed: ${errorMessage(err)}`,
-          );
-        }
-        if (cachedInfo.storageUsedBytes >= cachedInfo.storageQuotaBytes) {
-          return sendQuotaExceededReply(reply, {
-            storageUsedBytes: cachedInfo.storageUsedBytes,
-            storageQuotaBytes: cachedInfo.storageQuotaBytes,
-            autoCleanupAttempted: false,
-          });
-        }
-      }
+      const quotaOk = await enforceStorageQuota(userId, 1, reply, {
+        allowCleanup: false,
+      });
+      if (!quotaOk) return;
     }
 
     // Reject duplicate SYNC_IMPORT before we acquire the per-user lock — a

--- a/packages/super-sync-server/tests/sync-compressed-body.routes.spec.ts
+++ b/packages/super-sync-server/tests/sync-compressed-body.routes.spec.ts
@@ -621,7 +621,7 @@ describe('Sync compressed body routes', () => {
       existingImportId: 'existing-import',
     });
     expect(mocks.prisma.operation.findFirst).toHaveBeenCalledTimes(2);
-    expect(mocks.syncService.checkStorageQuota).not.toHaveBeenCalled();
+    expect(mocks.syncService.checkStorageQuota.mock.calls[0]).toEqual([1, 1]);
     expect(mocks.syncService.uploadOps).not.toHaveBeenCalled();
   });
 
@@ -844,16 +844,18 @@ describe('Sync compressed body routes', () => {
     const clientId = 'pre-gate-reconcile-client';
     const vectorClock = { [clientId]: 1 };
 
-    // 1st getStorageInfo returns stale-high (over quota). After reconcile,
+    // 1st quota check returns stale-high (at quota). After reconcile,
     // the 2nd call returns the corrected (under quota) value.
-    mocks.syncService.getStorageInfo
+    mocks.syncService.checkStorageQuota
       .mockResolvedValueOnce({
-        storageUsedBytes: 100 * 1024 * 1024,
-        storageQuotaBytes: 100 * 1024 * 1024,
+        allowed: false,
+        currentUsage: 100 * 1024 * 1024,
+        quota: 100 * 1024 * 1024,
       })
       .mockResolvedValue({
-        storageUsedBytes: 50_000,
-        storageQuotaBytes: 100 * 1024 * 1024,
+        allowed: true,
+        currentUsage: 50_000,
+        quota: 100 * 1024 * 1024,
       });
 
     const response = await app.inject({
@@ -869,17 +871,20 @@ describe('Sync compressed body routes', () => {
     });
 
     expect(mocks.syncService.updateStorageUsage).toHaveBeenCalledWith(1);
+    expect(mocks.syncService.checkStorageQuota.mock.calls[0]).toEqual([1, 1]);
+    expect(mocks.syncService.freeStorageForUpload).not.toHaveBeenCalled();
     expect(response.statusCode).toBe(200);
   });
 
-  it('should still 413 on the snapshot pre-gate when reconcile confirms over-quota', async () => {
+  it('should still 413 on the snapshot pre-gate when reconcile confirms quota is full', async () => {
     // Same path as above, but reconcile does not move the counter. The
     // rejection now uses errorCode (not code) and routes through the unified
     // 413 helper.
     const clientId = 'pre-gate-no-reconcile-client';
-    mocks.syncService.getStorageInfo.mockResolvedValue({
-      storageUsedBytes: 100 * 1024 * 1024,
-      storageQuotaBytes: 100 * 1024 * 1024,
+    mocks.syncService.checkStorageQuota.mockResolvedValue({
+      allowed: false,
+      currentUsage: 100 * 1024 * 1024,
+      quota: 100 * 1024 * 1024,
     });
 
     const response = await app.inject({
@@ -897,8 +902,12 @@ describe('Sync compressed body routes', () => {
     expect(response.statusCode).toBe(413);
     const body = response.json();
     expect(body.errorCode).toBe('STORAGE_QUOTA_EXCEEDED');
+    expect(body.autoCleanupAttempted).toBe(false);
+    expect(body.cleanupStats).toBeUndefined();
     // No legacy `code:` key — clients dispatch on errorCode.
     expect(body.code).toBeUndefined();
+    expect(mocks.syncService.checkStorageQuota.mock.calls[0]).toEqual([1, 1]);
+    expect(mocks.syncService.freeStorageForUpload).not.toHaveBeenCalled();
     expect(mocks.syncService.uploadOps).not.toHaveBeenCalled();
   });
 
@@ -907,9 +916,10 @@ describe('Sync compressed body routes', () => {
     // cached read. Either accept (cached < quota) or reject with 413 — but
     // never bubble a 500.
     const clientId = 'pre-gate-reconcile-throws';
-    mocks.syncService.getStorageInfo.mockResolvedValue({
-      storageUsedBytes: 100 * 1024 * 1024,
-      storageQuotaBytes: 100 * 1024 * 1024,
+    mocks.syncService.checkStorageQuota.mockResolvedValue({
+      allowed: false,
+      currentUsage: 100 * 1024 * 1024,
+      quota: 100 * 1024 * 1024,
     });
     mocks.syncService.updateStorageUsage.mockRejectedValueOnce(new Error('db down'));
 
@@ -926,7 +936,12 @@ describe('Sync compressed body routes', () => {
     });
 
     expect(response.statusCode).toBe(413);
-    expect(response.json().errorCode).toBe('STORAGE_QUOTA_EXCEEDED');
+    const body = response.json();
+    expect(body.errorCode).toBe('STORAGE_QUOTA_EXCEEDED');
+    expect(body.autoCleanupAttempted).toBe(false);
+    expect(body.cleanupStats).toBeUndefined();
+    expect(mocks.syncService.checkStorageQuota.mock.calls[0]).toEqual([1, 1]);
+    expect(mocks.syncService.freeStorageForUpload).not.toHaveBeenCalled();
   });
 
   it('should mark the user for forced reconcile when post-commit counter delta fails', async () => {


### PR DESCRIPTION
## Summary

Fixes #8353.

The snapshot upload handler had its own quota pre-gate that duplicated part of `enforceStorageQuota`: it read cached storage info, reconciled once, then returned a 413 response directly. This PR routes that early snapshot gate through the shared quota helper instead.

## What changed

- Added `allowCleanup?: boolean` to `enforceStorageQuota`, defaulting to the existing cleanup-enabled behavior.
- Switched the snapshot pre-gate to call `enforceStorageQuota(userId, 1, reply, { allowCleanup: false })`.
- Preserved the existing inclusive boundary where `used == quota` rejects before expensive snapshot preparation.
- Kept the early pre-gate non-destructive: no `freeStorageForUpload` call, `autoCleanupAttempted: false`, and no `cleanupStats` in that 413 response.
- Added regression coverage for reconcile-before-reject, no-cleanup 413 responses, and the `checkStorageQuota(1, 1)` pre-gate call.

## Validation

- `npm run checkFile packages/super-sync-server/src/sync/sync.routes.quota.ts`
- `npm run checkFile packages/super-sync-server/src/sync/sync.routes.snapshot-handler.ts`
- `npm run checkFile packages/super-sync-server/tests/sync-compressed-body.routes.spec.ts`
- `npm --prefix packages/super-sync-server test -- tests/sync-compressed-body.routes.spec.ts`
- `npm --prefix packages/super-sync-server test`
- `git diff --check`
- Pre-push hook: full lint/package tests, Angular test suite, and LA timezone test suite passed
