### PR TITLE
fix(sync): invalidate unsynced cache on failed rejection

### DIFF
--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -1775,6 +1775,22 @@ describe('OperationLogStoreService', () => {
       expect(unsynced2[0].op.id).toBe(op2.id);
     });
 
+    it('should invalidate cache when markFailed terminally rejects an op', async () => {
+      const op1 = createTestOperation({ entityId: 'task1' });
+      const op2 = createTestOperation({ entityId: 'task2' });
+      await service.append(op1);
+      await service.append(op2);
+
+      const unsynced1 = await service.getUnsynced();
+      expect(unsynced1.length).toBe(2);
+
+      await service.markFailed([op1.id], 1);
+
+      const unsynced2 = await service.getUnsynced();
+      expect(unsynced2.length).toBe(1);
+      expect(unsynced2[0].op.id).toBe(op2.id);
+    });
+
     it('should not include already synced ops when incrementally updating', async () => {
       // Add initial ops
       const op1 = createTestOperation({ entityId: 'task1' });

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -1070,6 +1070,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
   async markFailed(opIds: string[], maxRetries?: number): Promise<void> {
     await this._ensureInit();
     const now = Date.now();
+    let terminallyRejected = false;
     await this._adapter.transaction([STORE_NAMES.OPS], 'readwrite', async (tx) => {
       for (const opId of opIds) {
         const entry = await tx.getFromIndex<StoredOperationLogEntry>(
@@ -1084,6 +1085,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
           if (maxRetries !== undefined && newRetryCount >= maxRetries) {
             entry.rejectedAt = now;
             entry.applicationStatus = undefined;
+            terminallyRejected = true;
           } else {
             entry.applicationStatus = 'failed';
             entry.retryCount = newRetryCount;
@@ -1092,6 +1094,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         }
       }
     });
+    if (terminallyRejected) {
+      this._invalidateUnsyncedCache();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Invalidate the unsynced operation cache when `markFailed()` terminally rejects an operation after reaching `maxRetries`.
- Add a regression test that first populates `getUnsynced()` cache, then verifies a terminally rejected op disappears from the cached result.

## Root cause
`markFailed()` can set `rejectedAt` when retry count reaches `maxRetries`, but unlike `markSynced()`, `markRejected()`, and `clearUnsyncedOps()`, it did not invalidate `_unsyncedCache`. If the cache was already populated, a terminally rejected local op could stay in `getUnsynced()` until some later cache rebuild.

## Validation
- RED: new regression test failed before the fix with stale cache (`Expected 2 to be 1`).
- `npm run checkFile src/app/op-log/persistence/operation-log-store.service.ts`
- `npm run checkFile src/app/op-log/persistence/operation-log-store.service.spec.ts`
- `npm run test:file src/app/op-log/persistence/operation-log-store.service.spec.ts` → `185 SUCCESS`
- Pre-push hook: lint completed with existing unrelated warnings only; package tests passed; Angular suite `11315 SUCCESS`; LA timezone suite `11301 SUCCESS`.
