### PR TITLE
[WIP] Honor dateTimeLocale in schedule time field (#8565)

### DIFF
--- a/.github/workflows/auto-publish-google-play-on-release.yml
+++ b/.github/workflows/auto-publish-google-play-on-release.yml
@@ -3,13 +3,19 @@ name: Auto Publish to Google Play on Release
 on:
   release:
     types: [published]
+  # Manual trigger for Android-only releases: promote the build already on the
+  # internal track (uploaded by build-android.yml on the v* tag push) straight to
+  # production, without publishing a GitHub release that would fan out to the
+  # desktop/web channels (AUR, Docker, snap, web).
+  workflow_dispatch:
+    inputs: {}
 
 jobs:
   auto-publish-google-play:
     runs-on: ubuntu-latest
 
-    # Only run for actual releases, not pre-releases
-    if: '!github.event.release.prerelease'
+    # Run on manual dispatch, or for actual (non-pre-) releases.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
 
     steps:
       - name: Harden Runner

--- a/e2e/constants/selectors.ts
+++ b/e2e/constants/selectors.ts
@@ -121,8 +121,11 @@ export const cssSelectors = {
   // DATE/TIME SELECTORS
   // ============================================================================
   EDIT_DATE_INFO: '.edit-date-info',
-  TIME_INPUT: 'input[type="time"]',
-  MAT_TIME_INPUT: 'mat-form-field input[type="time"]',
+  // The datetime-picker uses a native <input type="time"> on touch and a
+  // mat-timepicker text input on desktop; both carry data-test-id="time-input".
+  // Keep the native fallback for other plain time inputs (e.g. settings).
+  TIME_INPUT: '[data-test-id="time-input"], input[type="time"]',
+  MAT_TIME_INPUT: '[data-test-id="time-input"]',
 
   // ============================================================================
   // TASK DETAIL PANEL SELECTORS

--- a/e2e/pages/planner.page.ts
+++ b/e2e/pages/planner.page.ts
@@ -64,7 +64,7 @@ export class PlannerPage extends BasePage {
 
   async scheduleTaskForTime(taskName: string, time: string): Promise<void> {
     const task = this.page.locator(`task:has-text("${taskName}")`);
-    const timeInput = task.locator('input[type="time"]');
+    const timeInput = task.locator('[data-test-id="time-input"], input[type="time"]');
 
     await timeInput.fill(time);
     await this.page.keyboard.press('Enter');

--- a/e2e/tests/reminders/reminders-default-task-remind-option.spec.ts
+++ b/e2e/tests/reminders/reminders-default-task-remind-option.spec.ts
@@ -95,7 +95,7 @@ test.describe('Default task reminder option', () => {
     await scheduleDialog.waitFor({ state: 'visible', timeout: 10000 });
 
     // Click on the time input in the schedule dialog to reveal the reminder input
-    const timeInput = scheduleDialog.locator('input[type="time"]');
+    const timeInput = scheduleDialog.locator('[data-test-id="time-input"]');
     await timeInput.waitFor({ state: 'visible', timeout: 10000 });
     await timeInput.click();
 

--- a/e2e/utils/time-input-helper.ts
+++ b/e2e/utils/time-input-helper.ts
@@ -15,10 +15,12 @@ export const fillTimeInput = async (
   const d = new Date(scheduleTime);
   const timeValue = `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
 
-  // Try multiple selectors for the time input
+  // Try multiple selectors for the time input. The datetime-picker renders a
+  // native <input type="time"> on touch and a mat-timepicker text input on
+  // desktop; both carry data-test-id="time-input".
   const timeInput = page
-    .locator('mat-dialog-container input[type="time"]')
-    .or(page.locator('mat-form-field input[type="time"]'))
+    .locator('mat-dialog-container [data-test-id="time-input"]')
+    .or(page.locator('[data-test-id="time-input"]'))
     .or(page.locator('input[type="time"]'))
     .first();
   await timeInput.waitFor({ state: 'visible', timeout: 10000 });
@@ -36,7 +38,7 @@ export const fillTimeInput = async (
     await page.evaluate(
       ({ value }: { value: string }) => {
         const timeInputEl = document.querySelector(
-          'mat-form-field input[type="time"]',
+          '[data-test-id="time-input"]',
         ) as HTMLInputElement;
         if (timeInputEl) {
           timeInputEl.value = value;

--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.html
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.html
@@ -9,6 +9,12 @@
   <div class="planner-time-remaining-shared">
     {{ calendarEvent().duration | msToString }}
   </div>
+  @if (showStartTime()) {
+    <div
+      class="start-time"
+      [innerHTML]="calendarEvent().start | shortPlannedAt"
+    ></div>
+  }
 </div>
 
 <div

--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.scss
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.scss
@@ -64,3 +64,22 @@
     font-size: var(--planner-font-size);
   }
 }
+
+// Clock start time at the far right, mirroring a scheduled task's time badge.
+.start-time {
+  flex-shrink: 0;
+  align-self: center;
+  padding-right: var(--s);
+  text-align: right;
+  line-height: 1;
+  white-space: nowrap;
+  font-size: var(--planner-font-size-mobile);
+
+  @include mq(xs) {
+    font-size: var(--planner-font-size);
+  }
+
+  ::ng-deep span {
+    font-size: 10px;
+  }
+}

--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { PlannerCalendarEventComponent } from './planner-calendar-event.component';
+import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
+import { DateService } from '../../../core/date/date.service';
+import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
+import { ShortTimeHtmlPipe } from '../../../ui/pipes/short-time-html.pipe';
+import { ShortTimePipe } from '../../../ui/pipes/short-time.pipe';
+import { ScheduleFromCalendarEvent } from '../../schedule/schedule.model';
+
+const EVENT: ScheduleFromCalendarEvent = {
+  id: 'e1',
+  calProviderId: 'cal-1',
+  title: 'Standup',
+  start: 1_700_000_000_000,
+  duration: 60 * 60 * 1000,
+  issueProviderKey: 'ICAL',
+};
+
+describe('PlannerCalendarEventComponent', () => {
+  let fixture: ComponentFixture<PlannerCalendarEventComponent>;
+
+  const createWith = (showStartTime?: boolean): void => {
+    fixture = TestBed.createComponent(PlannerCalendarEventComponent);
+    fixture.componentRef.setInput('calendarEvent', EVENT);
+    if (showStartTime !== undefined) {
+      fixture.componentRef.setInput('showStartTime', showStartTime);
+    }
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        PlannerCalendarEventComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        // Stubbed so the pipe chain resolves to a deterministic clock string.
+        { provide: DateService, useValue: { isToday: () => true } },
+        {
+          provide: DateTimeFormatService,
+          useValue: { currentLocale: () => 'en-US', formatTime: () => '2:13 PM' },
+        },
+        {
+          provide: CalendarEventActionsService,
+          useValue: jasmine.createSpyObj('CalendarEventActionsService', {
+            isPluginEvent: false,
+            hasEventUrl: false,
+          }),
+        },
+        ShortTimeHtmlPipe,
+        ShortTimePipe,
+      ],
+    });
+  });
+
+  it('renders the clock start time when showStartTime is true', () => {
+    createWith(true);
+    const el: HTMLElement | null = fixture.nativeElement.querySelector('.start-time');
+    expect(el).toBeTruthy();
+    expect(el!.textContent).toContain('2:13');
+  });
+
+  it('does not render the start time by default', () => {
+    createWith();
+    expect(fixture.nativeElement.querySelector('.start-time')).toBeNull();
+  });
+
+  it('places the start time as the right-most item, after the duration', () => {
+    createWith(true);
+    const children = Array.from(
+      (fixture.nativeElement.querySelector('.event-content') as HTMLElement).children,
+    ) as HTMLElement[];
+    const durationIdx = children.findIndex((c) =>
+      c.classList.contains('planner-time-remaining-shared'),
+    );
+    const startTimeIdx = children.findIndex((c) => c.classList.contains('start-time'));
+    expect(durationIdx).toBeGreaterThanOrEqual(0);
+    expect(startTimeIdx).toBe(children.length - 1);
+    expect(startTimeIdx).toBeGreaterThan(durationIdx);
+  });
+});

--- a/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.ts
+++ b/src/app/features/planner/planner-calendar-event/planner-calendar-event.component.ts
@@ -14,19 +14,31 @@ import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { TranslatePipe } from '@ngx-translate/core';
 import { T } from '../../../t.const';
 import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
+import { ShortPlannedAtPipe } from '../../../ui/pipes/short-planned-at.pipe';
 
 @Component({
   selector: 'planner-calendar-event',
   templateUrl: './planner-calendar-event.component.html',
   styleUrl: './planner-calendar-event.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatIcon, MsToStringPipe, MatMenu, MatMenuItem, MatMenuTrigger, TranslatePipe],
+  imports: [
+    MatIcon,
+    MsToStringPipe,
+    MatMenu,
+    MatMenuItem,
+    MatMenuTrigger,
+    TranslatePipe,
+    ShortPlannedAtPipe,
+  ],
 })
 export class PlannerCalendarEventComponent {
   T = T;
   private _calEventActions = inject(CalendarEventActionsService);
 
   readonly calendarEvent = input.required<ScheduleFromCalendarEvent>();
+  // Show the event's clock start time (right-aligned, like a scheduled task).
+  // Used in the "Later Today" list where the start time isn't shown elsewhere.
+  readonly showStartTime = input<boolean>(false);
   isBeingSubmitted = false;
 
   @HostBinding('attr.title') title = '';

--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -309,6 +309,7 @@
                     @for (calEv of laterTodayCalendarEvents(); track calEv.id) {
                       <planner-calendar-event
                         [calendarEvent]="calEv"
+                        [showStartTime]="true"
                       ></planner-calendar-event>
                     }
                   </div>

--- a/src/app/ui/datetime-picker/datetime-picker.component.html
+++ b/src/app/ui/datetime-picker/datetime-picker.component.html
@@ -57,17 +57,41 @@
 <div class="form-ctrl-wrapper">
   <mat-form-field class="time-form-field">
     <mat-label>{{ timeLabel() }}</mat-label>
-    <mat-icon matPrefix>schedule</mat-icon>
-    <input
-      type="time"
-      spTimeStep
-      (focus)="onTimeFocus()"
-      [ngModel]="selectedTime()"
-      (ngModelChange)="onTimeChange($event)"
-      step="60"
-      matInput
-      (keydown)="onTimeKeyDown($event)"
-    />
+    @if (useMatTimepicker) {
+      <!-- Desktop: type the time directly (panel does NOT auto-open), or click
+           the clock toggle to pick. Honors the app's 12h/24h locale setting. -->
+      <mat-timepicker-toggle
+        matPrefix
+        [for]="timepicker"
+      />
+      <input
+        #timeInputEl
+        type="text"
+        data-test-id="time-input"
+        [matTimepicker]="timepicker"
+        [matTimepickerOpenOnClick]="false"
+        [ngModel]="timeAsDate()"
+        [ngModelOptions]="{ updateOn: 'blur' }"
+        (ngModelChange)="onTimeDateChange($event)"
+        (focus)="onTimeFocus()"
+        (keydown)="onTimeKeyDown($event)"
+        matInput
+      />
+      <mat-timepicker #timepicker />
+    } @else {
+      <mat-icon matPrefix>schedule</mat-icon>
+      <input
+        type="time"
+        data-test-id="time-input"
+        spTimeStep
+        (focus)="onTimeFocus()"
+        [ngModel]="selectedTime()"
+        (ngModelChange)="onTimeChange($event)"
+        step="60"
+        matInput
+        (keydown)="onTimeKeyDown($event)"
+      />
+    }
     @if (selectedTime()) {
       <mat-icon
         class="time-clear-btn"

--- a/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
@@ -89,6 +89,26 @@ describe('DateTimePickerComponent', () => {
     );
   });
 
+  it('should emit canonical HH:mm when the mat-timepicker Date changes (onTimeDateChange)', () => {
+    spyOn(component.timeChanged, 'emit');
+    component.onTimeDateChange(new Date(2026, 4, 6, 14, 30));
+    expect(component.timeChanged.emit).toHaveBeenCalledWith('14:30');
+
+    component.onTimeDateChange(null);
+    expect(component.timeChanged.emit).toHaveBeenCalledWith(null);
+  });
+
+  it('should bridge selectedTime string to a Date for the mat-timepicker (timeAsDate)', () => {
+    fixture.componentRef.setInput('selectedDate', new Date(2026, 4, 6));
+    fixture.componentRef.setInput('selectedTime', '14:30');
+    const d = component.timeAsDate()!;
+    expect(d.getHours()).toBe(14);
+    expect(d.getMinutes()).toBe(30);
+
+    fixture.componentRef.setInput('selectedTime', null);
+    expect(component.timeAsDate()).toBeNull();
+  });
+
   it('should autofill time on focus', () => {
     spyOn(component.timeChanged, 'emit');
     spyOn(component.dateSelected, 'emit');
@@ -233,7 +253,19 @@ describe('DateTimePickerComponent', () => {
     expect(component.isShowEnterMsg).toBeTrue();
   });
 
-  it('should require two Enter presses to emit enterSubmit on time input', () => {
+  it('should commit and submit on a single Enter on the desktop (mat-timepicker) path', () => {
+    // Default in the (non-touch) test env: useMatTimepicker === true.
+    spyOn(component.enterSubmit, 'emit');
+    fixture.componentRef.setInput('selectedTime', '10:30');
+    fixture.detectChanges();
+
+    component.onTimeKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(component.enterSubmit.emit).toHaveBeenCalled();
+  });
+
+  it('should require two Enter presses on the native time input path', () => {
+    // Force the native (touch) branch so the double-Enter confirm is exercised.
+    Object.defineProperty(component, 'useMatTimepicker', { value: false });
     spyOn(component.enterSubmit, 'emit');
     fixture.componentRef.setInput('selectedTime', '10:30');
     fixture.detectChanges();

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -24,6 +24,11 @@ import {
   MatSuffix,
 } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
+import {
+  MatTimepicker,
+  MatTimepickerInput,
+  MatTimepickerToggle,
+} from '@angular/material/timepicker';
 import { MatSelect } from '@angular/material/select';
 import { MatOption } from '@angular/material/core';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -40,6 +45,9 @@ import { TimeStepDirective } from '../time-step/time-step.directive';
 import { expandFadeAnimation } from '../animations/expand.ani';
 import { fadeAnimation } from '../animations/fade.ani';
 import { getClockStringFromHours } from '../../util/get-clock-string-from-hours';
+import { IS_TOUCH_ONLY } from '../../util/is-touch-only';
+import { clockStrToDate, dateToClockStr } from '../../util/clock-str-and-date';
+import { DateTimeFormatService } from '../../core/date-time-format/date-time-format.service';
 
 const DEFAULT_TIME = '09:00';
 
@@ -56,6 +64,9 @@ const DEFAULT_TIME = '09:00';
     MatPrefix,
     MatSuffix,
     MatInput,
+    MatTimepicker,
+    MatTimepickerInput,
+    MatTimepickerToggle,
     MatSelect,
     MatOption,
     MatTooltip,
@@ -70,6 +81,7 @@ const DEFAULT_TIME = '09:00';
 })
 export class DateTimePickerComponent implements AfterViewInit {
   private _dateService = inject(DateService);
+  private _dateTimeFormat = inject(DateTimeFormatService);
   private _globalConfigService = inject(GlobalConfigService);
   private readonly _cdr = inject(ChangeDetectorRef);
   private _el = inject(ElementRef);
@@ -94,16 +106,33 @@ export class DateTimePickerComponent implements AfterViewInit {
 
   // Template variables
   T: typeof T = T;
+  // On touch-only devices the OS-native time wheel (`<input type="time">`) is
+  // the better experience and already follows the device locale. On desktop the
+  // native control ignores the in-app `dateTimeLocale` (its 12h/24h is fixed by
+  // the browser/OS locale — see #8565), so use `<mat-timepicker>`, which formats
+  // via the Material DateAdapter that DateTimeFormatService drives from the
+  // user's setting.
+  readonly useMatTimepicker = !IS_TOUCH_ONLY;
   isInitValOnTimeFocus = true;
   isShowEnterMsg = false;
   @HostBinding('class.sp-hide-cursor') isKeyboardNavigating = false;
   @HostBinding('class.sp-initial-focus') isInitialFocus = true;
 
   readonly calendar = viewChild(MatCalendar);
+  // Only present on the desktop (mat-timepicker) path; used to flush its
+  // blur-committed value before an Enter submit.
+  readonly timeInputEl = viewChild<ElementRef<HTMLInputElement>>('timeInputEl');
 
   readonly isConfigReady = computed(
     () => this._globalConfigService.localization() !== undefined,
   );
+
+  // `<mat-timepicker>` binds to a Date; bridge it to/from the canonical `HH:mm`
+  // string contract so the component's inputs/outputs stay unchanged. The
+  // timepicker only reads hours/minutes, so the date portion is irrelevant —
+  // we intentionally do NOT depend on selectedDate() to avoid recomputing (and
+  // re-writing the bound Date) on every calendar-day click.
+  readonly timeAsDate = computed(() => clockStrToDate(this.selectedTime()));
 
   private _lastView: MatCalendarView | null = null;
   private _viewChangeEffect = effect((onCleanup) => {
@@ -208,6 +237,18 @@ export class DateTimePickerComponent implements AfterViewInit {
         this.dateSelected.emit(targetDate);
       }
       this.timeChanged.emit(targetTime);
+
+      // mat-timepicker only writes its formatted value to the input when the
+      // input is NOT focused, so an autofill-on-focus would leave the field
+      // looking empty. Paint the value ourselves (same locale format the
+      // adapter uses) so the focused field shows the autofilled time.
+      if (this.useMatTimepicker) {
+        const el = this.timeInputEl()?.nativeElement;
+        const date = clockStrToDate(targetTime);
+        if (el && date) {
+          el.value = this._dateTimeFormat.formatTime(date.getTime());
+        }
+      }
     }
   }
 
@@ -215,20 +256,36 @@ export class DateTimePickerComponent implements AfterViewInit {
     this.timeChanged.emit(newTime);
   }
 
+  onTimeDateChange(date: Date | null): void {
+    this.timeChanged.emit(dateToClockStr(date));
+  }
+
   onReminderChange(newReminder: TaskReminderOptionId): void {
     this.reminderChanged.emit(newReminder);
   }
 
   onTimeKeyDown(ev: KeyboardEvent): void {
-    if (ev.key === 'Enter') {
-      this.isShowEnterMsg = true;
-      if (this._timeCheckVal === this.selectedTime()) {
-        this.enterSubmit.emit();
-      }
-      this._timeCheckVal = this.selectedTime();
-    } else {
+    if (ev.key !== 'Enter') {
       this.isShowEnterMsg = false;
+      return;
     }
+
+    if (this.useMatTimepicker) {
+      // mat-timepicker commits its value on blur (updateOn: 'blur'). Flush the
+      // typed value first — blur() propagates it synchronously to the parent via
+      // timeChanged — so the submit acts on what the user just typed, not the
+      // stale previous value. A single Enter commits and submits.
+      this.timeInputEl()?.nativeElement.blur();
+      this.enterSubmit.emit();
+      return;
+    }
+
+    // Native path: confirm-on-double-Enter (value updates live as you type).
+    this.isShowEnterMsg = true;
+    if (this._timeCheckVal === this.selectedTime()) {
+      this.enterSubmit.emit();
+    }
+    this._timeCheckVal = this.selectedTime();
   }
 
   onTimeClear(ev: MouseEvent): void {

--- a/src/app/util/clock-str-and-date.spec.ts
+++ b/src/app/util/clock-str-and-date.spec.ts
@@ -1,0 +1,54 @@
+import { clockStrToDate, dateToClockStr } from './clock-str-and-date';
+
+describe('clockStrToDate', () => {
+  it('converts HH:mm to a Date with those hours/minutes', () => {
+    const base = new Date(2020, 0, 15, 5, 5, 5, 5);
+    const d = clockStrToDate('14:30', base)!;
+    expect(d.getHours()).toBe(14);
+    expect(d.getMinutes()).toBe(30);
+    expect(d.getSeconds()).toBe(0);
+    expect(d.getMilliseconds()).toBe(0);
+  });
+
+  it('keeps the date portion from baseDate', () => {
+    const d = clockStrToDate('08:15', new Date(2021, 5, 9))!;
+    expect(d.getFullYear()).toBe(2021);
+    expect(d.getMonth()).toBe(5);
+    expect(d.getDate()).toBe(9);
+  });
+
+  it('normalizes legacy unpadded values', () => {
+    const d = clockStrToDate('9:00', new Date(2020, 0, 1))!;
+    expect(d.getHours()).toBe(9);
+    expect(d.getMinutes()).toBe(0);
+  });
+
+  it('returns null for empty or invalid input', () => {
+    expect(clockStrToDate(null)).toBeNull();
+    expect(clockStrToDate(undefined)).toBeNull();
+    expect(clockStrToDate('')).toBeNull();
+    expect(clockStrToDate('25:00', new Date())).toBeNull();
+    expect(clockStrToDate('13:60', new Date())).toBeNull();
+    expect(clockStrToDate('abc', new Date())).toBeNull();
+  });
+});
+
+describe('dateToClockStr', () => {
+  it('formats a Date to canonical 24h HH:mm', () => {
+    expect(dateToClockStr(new Date(2020, 0, 1, 14, 30))).toBe('14:30');
+    expect(dateToClockStr(new Date(2020, 0, 1, 9, 5))).toBe('09:05');
+    expect(dateToClockStr(new Date(2020, 0, 1, 0, 0))).toBe('00:00');
+    expect(dateToClockStr(new Date(2020, 0, 1, 23, 59))).toBe('23:59');
+  });
+
+  it('returns null for null or invalid Date', () => {
+    expect(dateToClockStr(null)).toBeNull();
+    expect(dateToClockStr(undefined)).toBeNull();
+    expect(dateToClockStr(new Date('not-a-date'))).toBeNull();
+  });
+
+  it('round-trips with clockStrToDate', () => {
+    expect(dateToClockStr(clockStrToDate('23:45', new Date()))).toBe('23:45');
+    expect(dateToClockStr(clockStrToDate('00:00', new Date()))).toBe('00:00');
+  });
+});

--- a/src/app/util/clock-str-and-date.ts
+++ b/src/app/util/clock-str-and-date.ts
@@ -1,0 +1,47 @@
+import { toPaddedClockStr } from './to-padded-clock-str';
+import { formatTimeHHmm } from './format-time-hhmm';
+
+/**
+ * Convert a canonical `HH:mm` clock string into a `Date`, which is the value
+ * type Angular Material's `<mat-timepicker>` binds to (it has no string mode).
+ *
+ * Only the hours/minutes carry meaning for a time field, but the timepicker
+ * needs a full `Date`, so the date portion is taken from `baseDate` (or today).
+ * Input is normalized via {@link toPaddedClockStr}, so legacy unpadded values
+ * (`9:00`) and stray seconds (`13:30:00`) are handled; invalid/empty input
+ * yields `null` so the field renders empty.
+ *
+ * @example
+ * clockStrToDate('14:30', new Date(2020, 0, 15)); // Date: 2020-01-15 14:30:00
+ * clockStrToDate('25:00'); // null
+ */
+export const clockStrToDate = (
+  clockStr: string | null | undefined,
+  baseDate?: Date | null,
+): Date | null => {
+  const padded = toPaddedClockStr(clockStr);
+  if (!padded) {
+    return null;
+  }
+  const [h, m] = padded.split(':').map(Number);
+  const date = baseDate ? new Date(baseDate) : new Date();
+  date.setHours(h, m, 0, 0);
+  return date;
+};
+
+/**
+ * Convert a `Date` from the Material timepicker back into the app's canonical
+ * `HH:mm` string contract (always 24h, regardless of how the picker displayed
+ * it). Returns `null` for an empty or invalid `Date`.
+ *
+ * @example
+ * dateToClockStr(new Date(2020, 0, 1, 14, 30)); // '14:30'
+ * dateToClockStr(null); // null
+ */
+export const dateToClockStr = (date: Date | null | undefined): string | null => {
+  if (!date || isNaN(date.getTime())) {
+    return null;
+  }
+  // Reuse the canonical Date -> 'HH:mm' formatter; we only add the null/NaN guard.
+  return formatTimeHHmm(date);
+};


### PR DESCRIPTION
**Status: 🚧 WIP / Draft — not ready to merge.** Opening for visibility/feedback.

Addresses the task **scheduling dialog's time field ignoring** the in-app
**Settings → Localization → Datetime format locale** setting (it always rendered
12h/24h per the browser/OS locale). Refs #8565.

## Approach
A native `<input type="time">` renders 12h/24h from the browser/OS locale and
**cannot** be controlled from web content (verified across Chromium/Electron/Firefox
primary sources). So:

- **Desktop (web + Electron):** use Angular Material `<mat-timepicker>`, which
  formats via the `DateAdapter` locale that `DateTimeFormatService` drives from
  `dateTimeLocale`. Type-to-enter + clock toggle; a single Enter commits & submits.
- **Touch (Capacitor/mobile):** keep the native `<input type="time">` — the OS time
  wheel is the better UX there and already follows the device locale.
- Small `HH:mm` string ⇄ `Date` bridge keeps the component's public contract unchanged.

## ✅ Done
- mat-timepicker integration + platform split (`\!IS_TOUCH_ONLY`)
- unit tests: datetime-picker **21**, clock-str-and-date **7**; e2e reminders **6/6**
- e2e selectors moved to `data-test-id="time-input"` (field is no longer `type=time`)
- typecheck clean

## 🚧 Known issues / TODO before merge
- **Desktop field layout/styling is still broken** — needs work.
- Likely other rough edges — needs a **manual click-through in real Electron**:
  keyboard (type `14:30`, Enter), mouse (clock toggle → pick), and a **12h locale
  (en-US)** to confirm the 12h display path.
- **Depends on #8574** (DateAdapter single-owner), which is on `master` but not in
  this branch — **rebase onto master** before the locale display is actually correct.

## Note on commits
This branch currently also carries 3 unrelated commits (work-view "Later Today"
start-time + an android CI tweak). Only `b214b93631` is the #8565 work.
