### PR TITLE
feat(markdown): continue dated bullets with today's date on Enter

### DIFF
--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.spec.ts
@@ -131,6 +131,32 @@ describe('DialogFullscreenMarkdownComponent', () => {
       expect(component.close).toHaveBeenCalled();
     });
 
+    it('continues a dated bullet using logical-today from DateService (#8602)', () => {
+      // Spy returns a date far from the real "today" so the assertion also fails
+      // if a regression sourced the date from `new Date()` instead.
+      const dateServiceSpy = spyOn(
+        component['_dateService'],
+        'getLogicalTodayDate',
+      ).and.returnValue(new Date(2020, 0, 15)); // 15 Jan 2020
+      mockTextarea.value = '- 18.06.: Phone call';
+      mockTextarea.setSelectionRange(
+        mockTextarea.value.length,
+        mockTextarea.value.length,
+      );
+      const event = {
+        key: 'Enter',
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        preventDefault: jasmine.createSpy('preventDefault'),
+      } as unknown as KeyboardEvent;
+
+      component.keydownHandler(event);
+
+      expect(dateServiceSpy).toHaveBeenCalled();
+      expect(mockTextarea.value).toBe('- 18.06.: Phone call\n- 15.01.: ');
+    });
+
     it('should call onApplyBold and preventDefault on Ctrl+B', () => {
       spyOn(component, 'onApplyBold');
       const event = {

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.ts
@@ -27,6 +27,7 @@ import { debounceTime } from 'rxjs/operators';
 import { LS } from '../../core/persistence/storage-keys.const';
 import { T } from '../../t.const';
 import { isSmallScreen } from '../../util/is-small-screen';
+import { DateService } from '../../core/date/date.service';
 import {
   handleListKeydown,
   TextTransformResult,
@@ -88,6 +89,7 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
   private readonly _taskAttachmentService = inject(TaskAttachmentService);
   private readonly _clipboardPasteHandler = inject(ClipboardPasteHandlerService);
   private readonly _cdr = inject(ChangeDetectorRef);
+  private readonly _dateService = inject(DateService);
   _matDialogRef = inject<MatDialogRef<DialogFullscreenMarkdownComponent>>(MatDialogRef);
   data: { content: string; taskId?: string } = inject(MAT_DIALOG_DATA) || { content: '' };
 
@@ -272,6 +274,7 @@ export class DialogFullscreenMarkdownComponent implements OnInit, AfterViewInit 
       ev.shiftKey,
       ev.ctrlKey,
       ev.metaKey,
+      this._dateService.getLogicalTodayDate(),
     );
     if (result) {
       ev.preventDefault();

--- a/src/app/ui/inline-markdown/date-prefix.util.spec.ts
+++ b/src/app/ui/inline-markdown/date-prefix.util.spec.ts
@@ -1,0 +1,90 @@
+import { formatTodayPrefix, parseDatePrefix } from './date-prefix.util';
+
+describe('date-prefix.util', () => {
+  describe('parseDatePrefix', () => {
+    it('matches dotted dd.MM.', () => {
+      expect(parseDatePrefix('18.06.: Phone call')).toEqual({
+        format: 'dotted',
+        length: 8,
+      });
+    });
+
+    it('matches dotted dd.MM.yyyy', () => {
+      expect(parseDatePrefix('18.06.2026: x')).toEqual({
+        format: 'dottedYear',
+        length: 12,
+      });
+    });
+
+    it('matches ISO yyyy-MM-dd', () => {
+      expect(parseDatePrefix('2026-06-18: x')).toEqual({ format: 'iso', length: 12 });
+    });
+
+    it('matches an unpadded dotted date', () => {
+      expect(parseDatePrefix('8.6.: x')).toEqual({ format: 'dotted', length: 6 });
+    });
+
+    it('matches an unpadded ISO date', () => {
+      expect(parseDatePrefix('2026-6-8: x')).toEqual({ format: 'iso', length: 10 });
+    });
+
+    it('accepts a calendar-invalid but in-range date (validation is range-only by design)', () => {
+      // 31 Feb never exists, but day/month are individually in range. We do not do
+      // full calendar validation — today is always regenerated correctly, so the
+      // only cost is mirroring a nonsensical source date the user typed themselves.
+      expect(parseDatePrefix('31.02.: x')).toEqual({ format: 'dotted', length: 8 });
+    });
+
+    it('returns null for slashed dates (ambiguous field order)', () => {
+      expect(parseDatePrefix('18/06: x')).toBeNull();
+    });
+
+    it('returns null for textual months', () => {
+      expect(parseDatePrefix('June 18: x')).toBeNull();
+    });
+
+    it('returns null for a 2-digit year', () => {
+      expect(parseDatePrefix('18.06.26: x')).toBeNull();
+    });
+
+    it('returns null when the colon is missing', () => {
+      expect(parseDatePrefix('18.06. release notes')).toBeNull();
+    });
+
+    it('returns null when the colon has no trailing space', () => {
+      expect(parseDatePrefix('18.06.:x')).toBeNull();
+    });
+
+    it('returns null for an out-of-range month', () => {
+      expect(parseDatePrefix('1.13.: x')).toBeNull();
+    });
+
+    it('returns null for an out-of-range day', () => {
+      expect(parseDatePrefix('32.01.: x')).toBeNull();
+    });
+
+    it('returns null for a time stamp', () => {
+      expect(parseDatePrefix('14:30: standup')).toBeNull();
+    });
+  });
+
+  describe('formatTodayPrefix', () => {
+    const today = new Date(2026, 5, 26); // 26 Jun 2026 (month is 0-indexed)
+
+    it('formats the dotted layout', () => {
+      expect(formatTodayPrefix('dotted', today)).toBe('26.06.: ');
+    });
+
+    it('formats the dotted-with-year layout', () => {
+      expect(formatTodayPrefix('dottedYear', today)).toBe('26.06.2026: ');
+    });
+
+    it('formats the ISO layout', () => {
+      expect(formatTodayPrefix('iso', today)).toBe('2026-06-26: ');
+    });
+
+    it('zero-pads single-digit day and month', () => {
+      expect(formatTodayPrefix('dotted', new Date(2026, 0, 5))).toBe('05.01.: ');
+    });
+  });
+});

--- a/src/app/ui/inline-markdown/date-prefix.util.ts
+++ b/src/app/ui/inline-markdown/date-prefix.util.ts
@@ -1,0 +1,89 @@
+/**
+ * Date detection/formatting for "dated bullet" continuation (#8602).
+ *
+ * A dated bullet looks like `- 18.06.: Phone call`. When the user presses Enter
+ * on such a line, `handleEnterKey` continues it with TODAY's date in the same
+ * format the line already uses. This module owns format detection and
+ * today-generation so the two can never disagree, and so `markdown-toolbar.util.ts`
+ * (already large) does not grow a second concern.
+ *
+ * Kept deliberately small: an explicit allow-list of formats, falling back to
+ * plain bullet continuation for anything not listed rather than guessing.
+ */
+
+/**
+ * The date layouts we mirror. Field order, separators, and zero-padding are
+ * fixed per layout, so the layout name fully describes how to regenerate it.
+ */
+export type DatePrefixFormat = 'dotted' | 'dottedYear' | 'iso';
+
+export interface DatePrefixMatch {
+  /** Detected layout, used to regenerate the prefix with today's date. */
+  format: DatePrefixFormat;
+  /** Length of the matched `<date>: ` prefix (including the trailing ": "). */
+  length: number;
+}
+
+// Each pattern is anchored at the start of the content after the "- " bullet and
+// requires the date to be immediately followed by ": " (colon + space). Capture
+// groups expose the fields we range-check.
+//   iso         2026-06-18:   yyyy-MM-dd
+//   dottedYear  18.06.2026:   dd.MM.yyyy
+//   dotted      18.06.:       dd.MM.
+const ISO_RE = /^(\d{4})-(\d{1,2})-(\d{1,2}): /;
+const DOTTED_YEAR_RE = /^(\d{1,2})\.(\d{1,2})\.(\d{4}): /;
+const DOTTED_RE = /^(\d{1,2})\.(\d{1,2})\.: /;
+
+const isValidDayMonth = (day: number, month: number): boolean =>
+  day >= 1 && day <= 31 && month >= 1 && month <= 12;
+
+/**
+ * If `content` (the text after the "- " bullet) starts with a supported dated
+ * prefix `<date>: `, returns its layout and matched length. Returns null for
+ * anything unsupported — slashed dates (ambiguous field order), textual months,
+ * 2-digit years, out-of-range day/month, or a missing colon — so the caller
+ * falls back to plain bullet continuation rather than guessing.
+ */
+export const parseDatePrefix = (content: string): DatePrefixMatch | null => {
+  const iso = content.match(ISO_RE);
+  if (iso) {
+    return isValidDayMonth(+iso[3], +iso[2])
+      ? { format: 'iso', length: iso[0].length }
+      : null;
+  }
+  const dottedYear = content.match(DOTTED_YEAR_RE);
+  if (dottedYear) {
+    return isValidDayMonth(+dottedYear[1], +dottedYear[2])
+      ? { format: 'dottedYear', length: dottedYear[0].length }
+      : null;
+  }
+  const dotted = content.match(DOTTED_RE);
+  if (dotted) {
+    return isValidDayMonth(+dotted[1], +dotted[2])
+      ? { format: 'dotted', length: dotted[0].length }
+      : null;
+  }
+  return null;
+};
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+
+/**
+ * Builds the `<today>: ` prefix in the given layout. Day/month are zero-padded
+ * to 2 digits and the year to 4; the source's own padding is intentionally not
+ * preserved (an unpadded `8.6.` still yields a padded `08.06.`), since a source
+ * like `26.11.` carries no padding signal and pad-to-2 is the defined default.
+ */
+export const formatTodayPrefix = (format: DatePrefixFormat, today: Date): string => {
+  const day = pad2(today.getDate());
+  const month = pad2(today.getMonth() + 1);
+  const year = String(today.getFullYear());
+  switch (format) {
+    case 'iso':
+      return `${year}-${month}-${day}: `;
+    case 'dottedYear':
+      return `${day}.${month}.${year}: `;
+    case 'dotted':
+      return `${day}.${month}.: `;
+  }
+};

--- a/src/app/ui/inline-markdown/inline-markdown.component.ts
+++ b/src/app/ui/inline-markdown/inline-markdown.component.ts
@@ -43,6 +43,7 @@ import { Location } from '@angular/common';
 import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 import { Log } from '../../core/log';
 import { handleListKeydown } from './markdown-toolbar.util';
+import { DateService } from '../../core/date/date.service';
 
 const HIDE_OVERFLOW_TIMEOUT_DURATION = 300;
 
@@ -78,6 +79,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
   private _clipboardPasteHandler = inject(ClipboardPasteHandlerService);
   private _store = inject(Store);
   private _location = inject(Location);
+  private _dateService = inject(DateService);
   private _currentPastePlaceholder: string | null = null;
   private _isFullscreenDialogOpen = false;
   private _isDestroyed = false;
@@ -280,6 +282,7 @@ export class InlineMarkdownComponent implements OnInit, OnDestroy {
       ev.shiftKey,
       ev.ctrlKey,
       ev.metaKey,
+      this._dateService.getLogicalTodayDate(),
     );
     if (result) {
       ev.preventDefault();

--- a/src/app/ui/inline-markdown/markdown-toolbar.util.spec.ts
+++ b/src/app/ui/inline-markdown/markdown-toolbar.util.spec.ts
@@ -18,6 +18,10 @@ import {
   insertTable,
 } from './markdown-toolbar.util';
 
+// Fixed "today" for the dated-bullet continuation tests (#8602) and to satisfy
+// the required `today` param on the date-unrelated Enter/keydown cases.
+const TODAY = new Date(2026, 5, 26); // 26 Jun 2026 (month is 0-indexed)
+
 describe('markdown-toolbar.util', () => {
   // =========================================================================
   // Inline formatting tests
@@ -448,23 +452,23 @@ describe('markdown-toolbar.util', () => {
 
   describe('handleEnterKey', () => {
     it('should return null when no list prefix', () => {
-      const result = handleEnterKey('hello world', 5, 5);
+      const result = handleEnterKey('hello world', 5, 5, TODAY);
       expect(result).toBeNull();
     });
 
     it('should return null when selection spans multiple characters', () => {
-      const result = handleEnterKey('- [ ] hello', 0, 5);
+      const result = handleEnterKey('- [ ] hello', 0, 5, TODAY);
       expect(result).toBeNull();
     });
 
     it('should return null when cursor is before prefix end', () => {
-      const result = handleEnterKey('- [ ] hello', 2, 2);
+      const result = handleEnterKey('- [ ] hello', 2, 2, TODAY);
       expect(result).toBeNull();
     });
 
     it('should continue checkbox with unchecked prefix', () => {
       const text = '- [ ] Buy milk';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- [ ] Buy milk\n- [ ] ');
       expect(result!.selectionStart).toBe(21);
@@ -473,7 +477,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should continue checked checkbox with unchecked prefix', () => {
       const text = '- [x] Done';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- [x] Done\n- [ ] ');
       expect(result!.selectionStart).toBe(17);
@@ -481,7 +485,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should continue bullet list', () => {
       const text = '- Buy milk';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- Buy milk\n- ');
       expect(result!.selectionStart).toBe(13);
@@ -489,7 +493,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should continue numbered list with auto-increment', () => {
       const text = '3. Buy milk';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('3. Buy milk\n4. ');
       expect(result!.selectionStart).toBe(15);
@@ -497,7 +501,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should handle multi-digit number increment', () => {
       const text = '9. item';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('9. item\n10. ');
       expect(result!.selectionStart).toBe(12);
@@ -505,7 +509,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should degrade empty checkbox to bullet', () => {
       const text = '- [ ] ';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- ');
       expect(result!.selectionStart).toBe(2);
@@ -513,7 +517,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should degrade empty checked checkbox to bullet', () => {
       const text = '- [x] ';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- ');
       expect(result!.selectionStart).toBe(2);
@@ -521,7 +525,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should degrade empty bullet to blank line', () => {
       const text = '- ';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('');
       expect(result!.selectionStart).toBe(0);
@@ -529,7 +533,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should degrade empty numbered list to blank line', () => {
       const text = '1. ';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('');
       expect(result!.selectionStart).toBe(0);
@@ -537,7 +541,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should preserve indentation on continuation', () => {
       const text = '  - [ ] Buy milk';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('  - [ ] Buy milk\n  - [ ] ');
       expect(result!.selectionStart).toBe(25);
@@ -545,7 +549,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should preserve indentation on degradation', () => {
       const text = '  - [ ] ';
-      const result = handleEnterKey(text, text.length, text.length);
+      const result = handleEnterKey(text, text.length, text.length, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('  - ');
       expect(result!.selectionStart).toBe(4);
@@ -553,7 +557,7 @@ describe('markdown-toolbar.util', () => {
 
     it('should split line when cursor is in the middle', () => {
       const text = '- [ ] Buy milk';
-      const result = handleEnterKey(text, 10, 10); // cursor after "Buy "
+      const result = handleEnterKey(text, 10, 10, TODAY); // cursor after "Buy "
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- [ ] Buy \n- [ ] milk');
       expect(result!.selectionStart).toBe(17);
@@ -562,7 +566,7 @@ describe('markdown-toolbar.util', () => {
     it('should handle Enter in middle of multi-line text', () => {
       const text = 'line 1\n- [ ] Buy milk\nline 3';
       const cursor = 7 + 14; // end of "- [ ] Buy milk"
-      const result = handleEnterKey(text, cursor, cursor);
+      const result = handleEnterKey(text, cursor, cursor, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('line 1\n- [ ] Buy milk\n- [ ] \nline 3');
     });
@@ -570,7 +574,7 @@ describe('markdown-toolbar.util', () => {
     it('should degrade empty bullet in middle of text', () => {
       const text = '- [ ] task\n- \nline 3';
       const cursor = 13; // end of "- " on line 2
-      const result = handleEnterKey(text, cursor, cursor);
+      const result = handleEnterKey(text, cursor, cursor, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- [ ] task\n\nline 3');
       expect(result!.selectionStart).toBe(11);
@@ -694,6 +698,118 @@ describe('markdown-toolbar.util', () => {
     });
   });
 
+  describe('handleEnterKey - dated bullet continuation (#8602)', () => {
+    // TODAY is 26 Jun 2026, so a continued date becomes 26.06. / 26.06.2026 /
+    // 2026-06-26 regardless of the previous entry's date.
+    const enter = (
+      text: string,
+      cursor = text.length,
+    ): ReturnType<typeof handleEnterKey> => handleEnterKey(text, cursor, cursor, TODAY);
+
+    it('mirrors a dotted dd.MM. date with today', () => {
+      const result = enter('- 18.06.: Phone call');
+      expect(result!.text).toBe('- 18.06.: Phone call\n- 26.06.: ');
+      // cursor sits right after the "- 26.06.: " prefix
+      expect(result!.selectionStart).toBe(result!.text.length);
+    });
+
+    it('mirrors a dotted dd.MM.yyyy date with today', () => {
+      const result = enter('- 18.06.2026: x');
+      expect(result!.text).toBe('- 18.06.2026: x\n- 26.06.2026: ');
+      expect(result!.selectionStart).toBe('- 18.06.2026: x\n- 26.06.2026: '.length);
+    });
+
+    it('mirrors an ISO yyyy-MM-dd date with today', () => {
+      const result = enter('- 2026-06-18: x');
+      expect(result!.text).toBe('- 2026-06-18: x\n- 2026-06-26: ');
+      expect(result!.selectionStart).toBe('- 2026-06-18: x\n- 2026-06-26: '.length);
+    });
+
+    it('zero-pads when continuing an unpadded source date', () => {
+      const result = enter('- 8.6.: x');
+      expect(result!.text).toBe('- 8.6.: x\n- 26.06.: ');
+    });
+
+    it('splits mid-content and still inserts today after the prefix', () => {
+      const text = '- 18.06.: Phone call';
+      const cursor = '- 18.06.: Phone '.length;
+      const result = enter(text, cursor);
+      expect(result!.text).toBe('- 18.06.: Phone \n- 26.06.: call');
+      expect(result!.selectionStart).toBe('- 18.06.: Phone \n- 26.06.: '.length);
+    });
+
+    it('exits the list in one Enter on an empty dated entry (last line of a list)', () => {
+      const text = '- 18.06.: done\n- 18.06.: ';
+      const result = enter(text); // cursor at end, on the empty trailing dated entry
+      expect(result!.text).toBe('- 18.06.: done\n');
+      expect(result!.selectionStart).toBe('- 18.06.: done\n'.length);
+    });
+
+    it('fills today when the cursor is exactly at the content start (>= boundary)', () => {
+      // cursor right after "- 18.06.: ", before the content
+      const result = enter('- 18.06.: x', '- 18.06.: '.length);
+      expect(result!.text).toBe('- 18.06.: \n- 26.06.: x');
+    });
+
+    it('falls back to a plain bullet when the cursor is right after the "- " bullet', () => {
+      const result = enter('- 18.06.: x', '- '.length);
+      expect(result!.text).toBe('- \n- 18.06.: x');
+    });
+
+    it('preserves indentation of an indented dated bullet', () => {
+      const result = enter('  - 18.06.: x');
+      expect(result!.text).toBe('  - 18.06.: x\n  - 26.06.: ');
+    });
+
+    it('falls back to a plain bullet (no date) when the colon is missing', () => {
+      const result = enter('- 1.2. release notes');
+      expect(result!.text).toBe('- 1.2. release notes\n- ');
+    });
+
+    it('falls back to a plain bullet for an out-of-range month', () => {
+      const result = enter('- 1.13.: x');
+      expect(result!.text).toBe('- 1.13.: x\n- ');
+    });
+
+    it('falls back to a plain bullet for a time stamp', () => {
+      const result = enter('- 14:30: standup');
+      expect(result!.text).toBe('- 14:30: standup\n- ');
+    });
+
+    it('falls back to a plain bullet for a slashed date', () => {
+      const result = enter('- 18/06: x');
+      expect(result!.text).toBe('- 18/06: x\n- ');
+    });
+
+    it('falls back to a plain bullet for a textual month', () => {
+      const result = enter('- June 18: x');
+      expect(result!.text).toBe('- June 18: x\n- ');
+    });
+
+    it('falls back to a plain bullet for a 2-digit year', () => {
+      const result = enter('- 18.06.26: x');
+      expect(result!.text).toBe('- 18.06.26: x\n- ');
+    });
+
+    it('cursor inside the date falls back to plain bullet (never null, never a date fill)', () => {
+      const text = '- 18.06.: x';
+      const cursor = '- 18.'.length; // inside the date
+      const result = enter(text, cursor);
+      expect(result).not.toBeNull();
+      expect(result!.text).toBe('- 18.\n- 06.: x');
+    });
+
+    it('does not fill a date on a checkbox bullet (v1: plain bullets only)', () => {
+      const result = enter('- [ ] 18.06.: x');
+      expect(result!.text).toBe('- [ ] 18.06.: x\n- [ ] ');
+    });
+
+    it('does not fill a date on a numbered bullet (v1: plain bullets only)', () => {
+      const result = enter('1. 18.06.: x');
+      expect(result!.text).toBe('1. 18.06.: x\n2. ');
+    });
+  });
+
   describe('handleListKeydown', () => {
     it('should dispatch Enter to handleEnterKey', () => {
       const text = '- [ ] task';
@@ -704,21 +820,38 @@ describe('markdown-toolbar.util', () => {
         'Enter',
         false,
         false,
+        false,
+        TODAY,
       );
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- [ ] task\n- [ ] ');
     });
 
+    it('should thread today through Enter to fill a dated bullet (#8602)', () => {
+      const text = '- 18.06.: x';
+      const result = handleListKeydown(
+        text,
+        text.length,
+        text.length,
+        'Enter',
+        false,
+        false,
+        false,
+        TODAY,
+      );
+      expect(result!.text).toBe('- 18.06.: x\n- 26.06.: ');
+    });
+
     it('should dispatch Tab to handleTabKey', () => {
       const text = '- [ ] ';
-      const result = handleListKeydown(text, 6, 6, 'Tab', false, false);
+      const result = handleListKeydown(text, 6, 6, 'Tab', false, false, false, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('  - [ ] ');
     });
 
     it('should dispatch Shift+Tab to handleShiftTabKey', () => {
       const text = '  - [ ] task';
-      const result = handleListKeydown(text, 8, 8, 'Tab', true, false);
+      const result = handleListKeydown(text, 8, 8, 'Tab', true, false, false, TODAY);
       expect(result).not.toBeNull();
       expect(result!.text).toBe('- [ ] task');
     });
@@ -732,12 +865,23 @@ describe('markdown-toolbar.util', () => {
         'Enter',
         false,
         true,
+        false,
+        TODAY,
       );
       expect(result).toBeNull();
     });
 
     it('should return null for unrelated keys', () => {
-      const result = handleListKeydown('- [ ] task', 6, 6, 'a', false, false);
+      const result = handleListKeydown(
+        '- [ ] task',
+        6,
+        6,
+        'a',
+        false,
+        false,
+        false,
+        TODAY,
+      );
       expect(result).toBeNull();
     });
 
@@ -750,6 +894,8 @@ describe('markdown-toolbar.util', () => {
         'Enter',
         true,
         false,
+        false,
+        TODAY,
       );
       expect(result).toBeNull();
     });
@@ -764,6 +910,7 @@ describe('markdown-toolbar.util', () => {
         false,
         false,
         true,
+        TODAY,
       );
       expect(result).toBeNull();
     });

--- a/src/app/ui/inline-markdown/markdown-toolbar.util.ts
+++ b/src/app/ui/inline-markdown/markdown-toolbar.util.ts
@@ -3,6 +3,8 @@
  * Each function takes text + selection range and returns transformed text + new selection.
  */
 
+import { DatePrefixMatch, formatTodayPrefix, parseDatePrefix } from './date-prefix.util';
+
 export interface TextTransformResult {
   text: string;
   selectionStart: number;
@@ -585,11 +587,17 @@ const degradeEmptyPrefix = (
 /**
  * Handle Enter key on a list line.
  * Returns null if cursor is not on a list line (caller should not preventDefault).
+ *
+ * `today` is the logical "today" (from DateService.getLogicalTodayDate at the
+ * call site) used to continue a dated bullet — `- 18.06.: …` → `- <today>: …`
+ * (#8602). It is threaded in rather than read here so this stays a pure,
+ * deterministic transform.
  */
 export const handleEnterKey = (
   text: string,
   selectionStart: number,
   selectionEnd: number,
+  today: Date,
 ): TextTransformResult | null => {
   if (selectionStart !== selectionEnd) {
     return null;
@@ -607,10 +615,32 @@ export const handleEnterKey = (
     return null;
   }
   const contentAfterPrefix = currentLine.substring(prefixLen);
-  if (contentAfterPrefix.trim().length === 0) {
+
+  // #8602: dated-bullet continuation — plain bullets only (not checkbox/numbered
+  // in v1). Detect a leading "<date>: " and continue with today in the same
+  // layout. Skip the date fill when the cursor sits inside the date (before the
+  // full prefix): fall through to the normal bullet continuation rather than
+  // returning null, since a raw newline mid-date would be worse.
+  let datePrefix: DatePrefixMatch | null = null;
+  if (prefix === '- ') {
+    const parsed = parseDatePrefix(contentAfterPrefix);
+    if (parsed && cursorInLine >= prefixLen + parsed.length) {
+      datePrefix = parsed;
+    }
+  }
+
+  // Empty entry exits the list in one Enter. For a dated bullet, "empty" means
+  // nothing after the full "<date>: " prefix — the date itself is non-empty, so
+  // the bullet-only check would otherwise treat a bare dated entry as content.
+  const contentStart = prefixLen + (datePrefix?.length ?? 0);
+  if (currentLine.substring(contentStart).trim().length === 0) {
     return degradeEmptyPrefix(text, lineStart, lineEnd, whitespace, prefix);
   }
-  const continuation = buildContinuationPrefix(whitespace, prefix);
+
+  let continuation = buildContinuationPrefix(whitespace, prefix);
+  if (datePrefix) {
+    continuation += formatTodayPrefix(datePrefix.format, today);
+  }
   const before = text.substring(0, selectionStart);
   const after = text.substring(selectionStart);
   const newText = before + '\n' + continuation + after;
@@ -691,13 +721,16 @@ export const handleListKeydown = (
   key: string,
   shiftKey: boolean,
   ctrlKey: boolean,
-  metaKey: boolean = false,
+  metaKey: boolean,
+  // `today` is only used by the Enter path (dated-bullet continuation, #8602);
+  // the Tab / Shift-Tab branches ignore it.
+  today: Date,
 ): TextTransformResult | null => {
   if (ctrlKey || metaKey) {
     return null;
   }
   if (key === 'Enter' && !shiftKey) {
-    return handleEnterKey(text, selectionStart, selectionEnd);
+    return handleEnterKey(text, selectionStart, selectionEnd, today);
   }
   if (key === 'Tab' && !shiftKey) {
     return handleTabKey(text, selectionStart, selectionEnd);


### PR DESCRIPTION
Implements the "Sequential dates" continuation from #8602, following your spec.

## What

Pressing Enter on a dated bullet like `- 18.06.: Phone call` now starts the next line with today's date in the same format (`- 26.06.: `), extending the existing markdown list continuation. Pressing Enter on an empty dated entry exits the list in one keystroke, exactly like a plain bullet.

## Scope / decisions (per the spec on #8602)

- **Extends existing behavior, not new behavior** — a `- <date>:` line already continues as `- ` today; this just fills in today's date.
- **Format mirrored from the line**, no locale config: dotted `dd.MM.` / `dd.MM.yyyy` and ISO `yyyy-MM-dd`. Slashed (ambiguous field order), textual, 2-digit-year, and out-of-range dates fall back to the plain bullet continuation rather than guessing.
- **Always-on, no setting** — it rides on already-always-on bullet continuation and is trivially reversible (Ctrl+Z / edit the date).
- **Plain bullets only in v1** — checkbox and numbered lists continue unchanged.
- **Detection guard**: requires a `<date>: ` prefix (colon + space) and validates day 1-31 / month 1-12, so version bullets without a colon and time stamps (`14:30:`) don't mis-fire. (Range-only validation by design: a calendar-invalid but in-range source like `31.02.` is mirrored rather than rejected; today is always regenerated correctly.)
- **Cursor inside the date** falls back to plain bullet continuation (never returns null).
- `today` is threaded in from `DateService.getLogicalTodayDate()` at the call sites so the inserted date respects the configured start-of-day; the date util itself reads no clock and stays pure/deterministic.

## Implementation

- New pure util `date-prefix.util.ts` (`parseDatePrefix` + `formatTodayPrefix`) so `markdown-toolbar.util.ts` doesn't grow a second concern.
- `handleEnterKey` gains a `today` param, threaded through `handleListKeydown`; both call sites (`inline-markdown`, `dialog-fullscreen-markdown`) pass `getLogicalTodayDate()`.

## Tests

- `date-prefix.util.spec.ts`: format detection, padding, range/colon/timestamp/slashed/textual/2-digit-year fallbacks, unpadded variants.
- `markdown-toolbar.util.spec.ts`: each format mirrors today (not the source date), mid-content split, empty-entry exit, indentation, cursor-guard boundary, checkbox/numbered no-fill, Shift/Ctrl/Meta+Enter unaffected.
- Component test asserting the continuation is sourced from `DateService`.

Closes #8602
