### PR TITLE
fix(plugins): keep toggle re-enableable after nodeExecution consent denial

### DIFF
--- a/src/app/plugins/plugin.service.spec.ts
+++ b/src/app/plugins/plugin.service.spec.ts
@@ -19,7 +19,7 @@ import { PluginRunner } from './plugin-runner';
 import { PluginSecurityService } from './plugin-security';
 import { PluginUserPersistenceService } from './plugin-user-persistence.service';
 import { PluginInstance, PluginManifest } from './plugin-api.model';
-import { PluginService } from './plugin.service';
+import { NodeExecutionConsentDeniedError, PluginService } from './plugin.service';
 import { PluginState } from './plugin-state.model';
 import { PluginBridgeService } from './plugin-bridge.service';
 import { T } from '../t.const';
@@ -466,6 +466,105 @@ describe('PluginService', () => {
         error: 'ready failed',
       }),
     );
+    expect(service.getLoadedPlugins()).toEqual([]);
+  });
+
+  // chokepoint #1: the actual #8385 path (startup re-activation / reload both flow through
+  // `activatePlugin`'s catch). Driven by making `_loadPluginLazy` reject with the denial
+  // sentinel, since the real `_fireOnReady` grant block is gated on the un-mockable
+  // `IS_ELECTRON` constant in the web test env.
+  it('disables (not errors) via activatePlugin when nodeExecution consent is denied (#8385)', async () => {
+    const runtime = service as unknown as { _isElectronRuntime: () => boolean };
+    spyOn(runtime, '_isElectronRuntime').and.returnValue(true);
+    const manifest: PluginManifest = {
+      ...mockManifest,
+      id: 'node-plugin',
+      name: 'Node Plugin',
+      permissions: ['nodeExecution'],
+    };
+    const svc = service as unknown as {
+      _setPluginState: (pluginId: string, state: PluginState) => void;
+      _loadPluginLazy: (state: PluginState) => Promise<PluginInstance>;
+    };
+    svc._setPluginState(manifest.id, {
+      manifest,
+      status: 'not-loaded',
+      path: 'uploaded://node-plugin',
+      type: 'uploaded',
+      isEnabled: true,
+    });
+    spyOn(svc, '_loadPluginLazy').and.rejectWith(
+      new NodeExecutionConsentDeniedError(T.PLUGINS.NODE_EXECUTION_PERMISSION_DENIED),
+    );
+
+    const result = await service.activatePlugin(manifest.id); // non-manual = startup
+
+    expect(result).toBeNull();
+    // Clean disabled state, NOT an error tile → `canEnablePlugin` (= !plugin.error) stays
+    // true, so the toggle is clickable and re-enabling re-prompts (no restart needed).
+    expect(service.getAllPluginStates().get(manifest.id)).toEqual(
+      jasmine.objectContaining({
+        status: 'not-loaded',
+        instance: undefined,
+        isEnabled: false,
+        error: undefined,
+      }),
+    );
+    // Device-local decision: a denial must NOT write the synced `pluginMetadata` entity,
+    // else it would disable the plugin on every other device too.
+    expect(pluginMetaPersistenceService.setPluginEnabled).not.toHaveBeenCalled();
+    // The main-process grant is still revoked on the way out (the security-load-bearing step).
+    expect(pluginBridge.revokeNodeExecutionGrantToken).toHaveBeenCalledWith(manifest.id);
+    // A denial is a deliberate choice, not a failure → no ERROR snack.
+    const snack = TestBed.inject(SnackService) as jasmine.SpyObj<SnackService>;
+    expect(snack.open).not.toHaveBeenCalled();
+  });
+
+  // chokepoint #2: the same normalisation when the denial surfaces via `_handleReadyFailure`
+  // (the live ZIP re-upload-of-an-enabled-id path).
+  it('disables (does not error) a plugin when nodeExecution consent is denied at onReady', () => {
+    const manifest: PluginManifest = {
+      ...mockManifest,
+      id: 'node-plugin',
+      name: 'Node Plugin',
+      permissions: ['nodeExecution'],
+    };
+    const instance: PluginInstance = { manifest, loaded: true, isEnabled: true };
+    const svc = service as unknown as {
+      _loadedPlugins: PluginInstance[];
+      _setPluginState: (pluginId: string, state: PluginState) => void;
+      _handleReadyFailure: (instance: PluginInstance, error: unknown) => void;
+    };
+    svc._loadedPlugins = [instance];
+    svc._setPluginState(manifest.id, {
+      manifest,
+      status: 'loaded',
+      path: 'uploaded://node-plugin',
+      type: 'uploaded',
+      isEnabled: true,
+      instance,
+    });
+
+    svc._handleReadyFailure(
+      instance,
+      new NodeExecutionConsentDeniedError(T.PLUGINS.NODE_EXECUTION_PERMISSION_DENIED),
+    );
+
+    // Clean disabled state, NOT an error tile (so `canEnablePlugin` stays true).
+    expect(service.getAllPluginStates().get(manifest.id)).toEqual(
+      jasmine.objectContaining({
+        status: 'not-loaded',
+        instance: undefined,
+        isEnabled: false,
+        error: undefined,
+      }),
+    );
+    // Device-local: never writes the synced pluginMetadata.
+    expect(pluginMetaPersistenceService.setPluginEnabled).not.toHaveBeenCalled();
+    // A denial is a deliberate choice, not a failure → no ERROR snack.
+    const snack = TestBed.inject(SnackService) as jasmine.SpyObj<SnackService>;
+    expect(snack.open).not.toHaveBeenCalled();
+    expect(pluginRunner.unloadPlugin).toHaveBeenCalledOnceWith(manifest.id);
     expect(service.getLoadedPlugins()).toEqual([]);
   });
 });

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -89,6 +89,18 @@ const BUNDLED_PLUGIN_IDS = new Set<string>([
   'yesterday-tasks',
 ]);
 
+/**
+ * Thrown by `_fireOnReady` when the user explicitly DENIES a nodeExecution consent
+ * prompt, so the failure handlers can treat it as a deliberate choice (clean disable)
+ * rather than a load failure (#8512). See `_handleNodeExecutionConsentDenied`.
+ */
+export class NodeExecutionConsentDeniedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NodeExecutionConsentDeniedError';
+  }
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -602,6 +614,12 @@ export class PluginService implements OnDestroy {
       }
       void this._revokeNodeExecutionGrant(pluginId);
 
+      // Deny = clean disable, not an error tile — see _handleNodeExecutionConsentDenied.
+      if (error instanceof NodeExecutionConsentDeniedError) {
+        this._handleNodeExecutionConsentDenied(pluginId);
+        return null;
+      }
+
       this._setPluginState(pluginId, {
         ...currentState,
         status: 'error',
@@ -671,6 +689,16 @@ export class PluginService implements OnDestroy {
     if (IS_ELECTRON && instance.manifest.permissions?.includes('nodeExecution')) {
       const hasGrant = await this._ensureNodeExecutionGrant(instance.manifest);
       if (!hasGrant) {
+        // `_ensureNodeExecutionGrant` returns false for two different reasons: a deliberate
+        // user DENIAL (which records the id in `_nodeExecutionDeniedThisSession`) and a
+        // technical grant-request failure (IPC/bridge error — not recorded). Only a real
+        // denial becomes the recoverable "clean disable"; a technical failure must surface
+        // as a normal error tile/snack so the user sees something actually went wrong.
+        if (this._nodeExecutionDeniedThisSession.has(instance.manifest.id)) {
+          throw new NodeExecutionConsentDeniedError(
+            this._translateService.instant(T.PLUGINS.NODE_EXECUTION_PERMISSION_DENIED),
+          );
+        }
         throw new Error(
           this._translateService.instant(T.PLUGINS.NODE_EXECUTION_PERMISSION_DENIED),
         );
@@ -719,6 +747,12 @@ export class PluginService implements OnDestroy {
     }
     void this._revokeNodeExecutionGrant(pluginId);
 
+    // Deny = clean disable (no error tile / no ERROR snack) — see the helper below.
+    if (error instanceof NodeExecutionConsentDeniedError) {
+      this._handleNodeExecutionConsentDenied(pluginId);
+      return;
+    }
+
     const currentState = this._pluginStates().get(pluginId);
     if (currentState) {
       this._setPluginState(pluginId, {
@@ -736,6 +770,34 @@ export class PluginService implements OnDestroy {
       }),
       type: 'ERROR',
     });
+  }
+
+  /**
+   * Normalise a plugin to a clean, re-enableable disabled state after the user DENIED its
+   * nodeExecution consent prompt (#8512 deny-recovery). Clears any `error` so the
+   * management toggle is no longer grayed out (`canEnablePlugin` is `!plugin.error`) and
+   * sets it OFF; flipping it back on clears the session-denied marker (see
+   * `checkNodeExecutionPermission`) and re-opens the prompt — no app restart needed.
+   *
+   * Deliberately IN-MEMORY ONLY — it does NOT persist `isEnabled=false`. nodeExecution
+   * consent is a per-device, session-scoped decision (see `_nodeExecutionDeniedThisSession`);
+   * persisting would write the synced `pluginMetadata` entity, propagating a local "not now"
+   * to every device as a durable disable. Leaving the persisted `isEnabled` untouched means
+   * the next start on THIS device re-prompts, which matches the existing session-scoped model.
+   * Runtime teardown (unload + grant revoke) is the caller's responsibility.
+   */
+  private _handleNodeExecutionConsentDenied(pluginId: string): void {
+    PluginLog.log(`nodeExecution consent denied; disabling plugin: ${pluginId}`);
+    const currentState = this._getPluginState(pluginId);
+    if (currentState) {
+      this._setPluginState(pluginId, {
+        ...currentState,
+        status: 'not-loaded',
+        instance: undefined,
+        isEnabled: false,
+        error: undefined,
+      });
+    }
   }
 
   private async _loadUploadedPlugins(): Promise<void> {


### PR DESCRIPTION
## Problem

Denying a plugin's native "Allow Node.js execution?" consent prompt left the plugin in a sticky `error` state. The plugin-management toggle is disabled whenever `plugin.error` is truthy (`canEnablePlugin()` returns `\!plugin.error && …`), so after a denial the toggle was **grayed out with no in-session recovery** — the only way to re-prompt was restarting the app.

Reported in [discussion #8385](https://github.com/super-productivity/super-productivity/discussions/8385) against the #8576 / #8512 Phase 1 consent gate.

## Fix

A consent denial is a deliberate user choice, not a load failure. A dedicated `NodeExecutionConsentDeniedError` is thrown from `_fireOnReady`, and both onReady-failure chokepoints (`activatePlugin`'s catch and `_handleReadyFailure`) normalise the plugin to a clean disabled state instead of an error tile: clear `error`, set status `not-loaded`, toggle off, no ERROR snack. Flipping the toggle back on clears the session-denied marker and re-opens the prompt — **no restart needed**.

## Design decisions (from multi-agent review)

- **Device-local, no sync write.** The normalisation is in-memory only and deliberately does **not** persist `isEnabled=false`. nodeExecution consent is a per-device, session-scoped decision; persisting would write the synced `pluginMetadata` entity and propagate a local "not now" as a durable disable to every other device. Leaving persisted `isEnabled` untouched means the next start on *this* device re-prompts — consistent with the existing session-scoped model.
- **Only a genuine denial becomes the recoverable clean-disable.** A technical grant-request failure (IPC/bridge error) still surfaces as a normal error tile/snack, distinguished via the session-denied marker.

## Scope

Covers startup re-activation / reload (`activatePlugin` catch — the reported path) and the ZIP re-upload-of-an-enabled-id path (`_handleReadyFailure`).

## Testing

- `plugin.service.spec.ts`: 12/12 green, including new tests for both chokepoints asserting the clean disabled state, **no synced `setPluginEnabled` write**, grant revoked, and no ERROR snack.
- `plugin-management.component.spec.ts`: 2/2 green.
- `npm run checkFile` clean on both touched files.