### PR TITLE
fix(electron): use display name for Linux notifications

### DIFF
--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -26,6 +26,7 @@ import { evaluateGpuStartupGuard } from './gpu-startup-guard';
 import * as fs from 'fs';
 
 const ICONS_FOLDER = __dirname + '/assets/icons/';
+const APP_DISPLAY_NAME = 'Super Productivity';
 const IS_MAC = process.platform === 'darwin';
 // const DESKTOP_ENV = process.env.DESKTOP_SESSION;
 // const IS_GNOME = DESKTOP_ENV === 'gnome' || DESKTOP_ENV === 'gnome-xorg';
@@ -150,6 +151,14 @@ export const startApp = (): void => {
     // set userDa dir to common data to avoid the data being accessed by the update process
     app.setPath('userData', newPath);
     app.setAppLogsPath();
+  }
+
+  if (process.platform === 'linux') {
+    // Preserve the historical userData path based on package.json `name`, while
+    // exposing a human-readable app name to Linux desktop environments.
+    const userDataPath = app.getPath('userData');
+    app.setPath('userData', userDataPath);
+    app.setName(APP_DISPLAY_NAME);
   }
 
   // Defense-in-depth against GPU init failures on confined Linux packages


### PR DESCRIPTION
## Summary

Fixes the application name shown for desktop notifications on Linux/KDE Plasma.

Notifications were shown as coming from `superProductivity`, while the rest of the desktop shell shows the app as `Super Productivity`.

## Changes

- Set the Electron app name to `Super Productivity` on Linux.
- Preserve the existing `userData` path before changing the runtime app name, so existing user data stays in the historical `superProductivity` directory.
- Leave package metadata and non-Linux behavior unchanged.

## Verification

- `npm run checkFile electron/start-app.ts`
- `npm run electron:build`
- Verified via DBus notification monitoring that the notification `app_name` is now `Super Productivity`.

DBus result:

```text
member=Notify
   string "Super Productivity"
```
