### PR TITLE
docs(plugins): correct misleading secret-purge orphan comment

### DIFF
--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -1639,8 +1639,9 @@ export class PluginService implements OnDestroy {
 
     // Purge local-only credentials (secrets + OAuth tokens) FIRST so they
     // never outlive their plugin — even if a later cleanup step throws.
-    // Best-effort: a purge failure is logged but must not abort the uninstall
-    // (on IndexedDB failure the credentials orphan locally until a later purge).
+    // Best-effort: a purge failure is logged but must not abort the uninstall.
+    // There is no later reconcile, so on IndexedDB failure the credentials
+    // orphan on disk until the same plugin id is reinstalled and removed again.
     try {
       await this._pluginSecretService.removeSecretsForPlugin(pluginId);
     } catch (error) {


### PR DESCRIPTION
Follow-up to #8633, addressing @sbomsdorf's review comment.

The uninstall purge comment in `removeUploadedPlugin` claimed orphaned credentials persist "until a later purge" — but there is no later purge. Once a plugin is uninstalled, its `pluginId` is dropped from the registry, so `removeSecretsForPlugin` / `clearOAuthTokens` are never re-triggered for it. On an IndexedDB failure during uninstall, the secret/token orphans on disk indefinitely (until the same plugin id happens to be reinstalled and removed again successfully).

This reword states that honestly. Comment-only change; no behavior change.

**Why not a startup reconcile (the reviewer's option a):** dropping secrets whose owner isn't installed would have to run strictly after every installed plugin is registered, or it silently deletes live credentials for a not-yet-loaded plugin — a worse failure than a rare orphan. It's also powerless against the failure it targets (if IndexedDB is broken at uninstall, it's broken at reconcile too). Secrets are already plaintext-at-rest by accepted design, same as OAuth tokens, so the honest comment is the right-sized fix.

Refs #8633
