### PR TITLE
feat(task-repeat): default skip-overdue for new daily & weekday recurring tasks

### DIFF
--- a/docs/wiki/2.06-Manage-Repeating-Tasks.md
+++ b/docs/wiki/2.06-Manage-Repeating-Tasks.md
@@ -30,7 +30,7 @@ You can also open the dialog from a repeating task instance or from a repeat pro
 5. Optionally set **Tags to add** (chip list).
 6. Optionally set **Scheduled start time** (e.g. 15:00; leave blank for all-day). If you set a time, **Remind at** appears — choose when to be reminded (e.g. when it starts, 5 minutes before).
 7. Optionally set **Default Estimate** (duration). **Order** (number) controls creation order when several recurring tasks are created at the same time; see the field description in the dialog.
-8. In the advanced section: **Default notes**, **Inherit subtasks** (copy subtasks from the latest instance to the next), and, if inherit is on, **Disable auto-updating subtasks** (do not update inherited subtasks when the newest instance changes).
+8. In the advanced section: **Default notes**, **Inherit subtasks** (copy subtasks from the latest instance to the next), if inherit is on, **Disable auto-updating subtasks** (do not update inherited subtasks when the newest instance changes), and **Don't let overdue instances pile up** (keep a single up-to-date instance instead of a stack of missed duplicates). The last option defaults **on** for the **Every day** and **Every Monday through Friday** presets and **off** for weekly/monthly/yearly tasks; see [[4.13-Repeating-Tasks]]. You can change it per task.
 9. Click **Save**. New instances are created according to the pattern when you open the project or the app.
 
 ## Add a time and Reminder to a Repeating Task

--- a/docs/wiki/4.13-Repeating-Tasks.md
+++ b/docs/wiki/4.13-Repeating-Tasks.md
@@ -115,7 +115,7 @@ The default depends on how often the task recurs, because that is where the opti
 
 This only sets the **default** for newly created repeating tasks. Existing tasks keep whatever they were configured with, and you can turn the option on or off for any task under the repeat dialog's **Advanced** section.
 
-### Use Cases
+### When to Use It
 
 - **Daily habits and routines**: Water the plants, daily standup, inbox zero—skip the guilt-pile of stale duplicates and just see today's.
 - **Workday tasks**: A Monday–Friday routine collapses to one current instance instead of five after a few days away.

--- a/docs/wiki/4.13-Repeating-Tasks.md
+++ b/docs/wiki/4.13-Repeating-Tasks.md
@@ -101,3 +101,22 @@ When you enable **"Wait for completion"** on a repeating task, the app will not 
 - **Habit tracking**: Tasks where you want to ensure completion before moving to the next occurrence
 
 This option works independently from "Repeat from completion date" (which re-anchors the schedule to the completion day). You can enable both if you want the task to repeat N days after completion AND wait for completion before creating the next instance.
+
+## Don't Let Overdue Instances Pile Up Option
+
+When you enable **"Don't let overdue instances pile up"** on a repeating task, missed occurrences don't accumulate as a stack of duplicate overdue tasks—you keep a single, up-to-date instance instead. An empty missed instance is removed once a newer one exists; any instance where you tracked time, completed subtasks, or made edits is always kept.
+
+### Default Behavior
+
+The default depends on how often the task recurs, because that is where the option helps versus where it would hide something you need to see:
+
+- **On by default for near-daily schedules** — the **Daily** and **Every workday (Mon–Fri)** presets. These are the schedules that actually pile up (one empty overdue copy per scheduled day if you fall behind), and the next scheduled day is at most a weekend away, so a missed instance reliably comes back. You get one current instance instead of a growing stack.
+- **Off by default for weekly, monthly, and yearly schedules.** These have at most one missed occurrence, so nothing piles up—and an overdue "pay rent on the 1st" or "renew the domain" should stay visible as a reminder rather than quietly disappear until its next occurrence.
+
+This only sets the **default** for newly created repeating tasks. Existing tasks keep whatever they were configured with, and you can turn the option on or off for any task under the repeat dialog's **Advanced** section.
+
+### Use Cases
+
+- **Daily habits and routines**: Water the plants, daily standup, inbox zero—skip the guilt-pile of stale duplicates and just see today's.
+- **Workday tasks**: A Monday–Friday routine collapses to one current instance instead of five after a few days away.
+- **Keep it off for bills and renewals**: Leave it off (the default) for monthly or yearly obligations so a missed one stays on your list until you handle it.

--- a/e2e/tests/recurring/skip-overdue-default-8644.spec.ts
+++ b/e2e/tests/recurring/skip-overdue-default-8644.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import { type Page } from '@playwright/test';
+import { openRecurDialog, saveRecurDialog } from '../../utils/recurring-task-helpers';
+
+/**
+ * PR #8644: new recurring configs default `skipOverdue` ("Don't let overdue
+ * instances pile up") to ON for the everyday Daily schedule (where missed
+ * instances pile up and skipping is safe), and OFF for weekly/monthly/yearly
+ * (where a missed occurrence is a real obligation that must stay visible).
+ *
+ * These assert the persisted default via the NgRx store — the user never has
+ * to open Advanced for it to apply.
+ */
+
+/** Read the persisted skipOverdue flag for the config created for `title`. */
+const getPersistedSkipOverdue = async (
+  page: Page,
+  title: string,
+): Promise<boolean | null | undefined> =>
+  page.evaluate((taskTitle: string) => {
+    type RepeatCfgLike = { title?: string | null; skipOverdue?: boolean };
+    type StoreState = {
+      taskRepeatCfg?: { entities?: Record<string, RepeatCfgLike | undefined> };
+    };
+    type StoreLike = {
+      subscribe: (next: (s: StoreState) => void) => { unsubscribe: () => void };
+    };
+    const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+      .__e2eTestHelpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+    let latest: StoreState | undefined;
+    store
+      .subscribe((s) => {
+        latest = s;
+      })
+      .unsubscribe();
+    const cfg = Object.values(latest?.taskRepeatCfg?.entities ?? {}).find((c) =>
+      c?.title?.includes(taskTitle),
+    );
+    return cfg ? (cfg.skipOverdue ?? null) : undefined;
+  }, title);
+
+test.describe('Recurring task - skipOverdue default by schedule (#8644)', () => {
+  test('a new Daily recurring task defaults skipOverdue to ON', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    const taskTitle = `${testPrefix}-DailySkip8644`;
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask(taskTitle);
+    const task = taskPage.getTaskByText(taskTitle).first();
+    await expect(task).toBeVisible({ timeout: 10000 });
+    await taskPage.openTaskDetail(task);
+
+    // The dialog opens on the Daily quick setting by default — just save.
+    await openRecurDialog(page);
+    await saveRecurDialog(page);
+
+    await expect.poll(() => getPersistedSkipOverdue(page, taskTitle)).toBe(true);
+  });
+
+  test('a new Monthly recurring task keeps skipOverdue OFF', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    const taskTitle = `${testPrefix}-MonthlySkip8644`;
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask(taskTitle);
+    const task = taskPage.getTaskByText(taskTitle).first();
+    await expect(task).toBeVisible({ timeout: 10000 });
+    await taskPage.openTaskDetail(task);
+
+    const dialog = await openRecurDialog(page);
+    await dialog.locator('mat-select').first().click();
+    const monthlyOption = page.locator('mat-option').filter({ hasText: /first day/i });
+    await expect(monthlyOption).toBeVisible({ timeout: 5000 });
+    await monthlyOption.click();
+    await saveRecurDialog(page);
+
+    await expect.poll(() => getPersistedSkipOverdue(page, taskTitle)).toBe(false);
+  });
+});

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.html
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.html
@@ -46,7 +46,7 @@
       </div>
 
       <formly-form
-        (modelChange)="repeatCfg.set($event)"
+        (modelChange)="onScheduleModelChange($event)"
         [form]="formGroup1()"
         [fields]="essentialFormFields()"
         [model]="repeatCfg()"

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -11,7 +11,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideMockStore } from '@ngrx/store/testing';
 import { Observable, of, Subject } from 'rxjs';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 // FormlyConfigModule (not FormlyModule) is needed here to register custom
 // field types and validation within the TestBed injector.
 import { FormlyConfigModule } from '../../../ui/formly-config.module';
@@ -661,6 +661,64 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       expect(mockTaskRepeatCfgService.addTaskRepeatCfgToTask).not.toHaveBeenCalled();
       expect(mockTaskRepeatCfgService.updateTaskRepeatCfg).not.toHaveBeenCalled();
       expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('skipOverdue default seeding (#8644)', () => {
+    const savedCfg = (): TaskRepeatCfg =>
+      mockTaskRepeatCfgService.addTaskRepeatCfgToTask.calls.mostRecent()
+        .args[2] as TaskRepeatCfg;
+
+    it('seeds skipOverdue ON for a new Daily config (the default schedule)', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // A new config defaults to the Daily quick setting; no user interaction.
+      component.save();
+
+      expect(mockTaskRepeatCfgService.addTaskRepeatCfgToTask).toHaveBeenCalledTimes(1);
+      expect(savedCfg().skipOverdue).toBe(true);
+    });
+
+    it('seeds skipOverdue ON for the Mon–Fri (every workday) preset', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      component.repeatCfg.update((c) => ({ ...c, quickSetting: 'MONDAY_TO_FRIDAY' }));
+      component.save();
+
+      expect(savedCfg().skipOverdue).toBe(true);
+    });
+
+    it('seeds skipOverdue OFF when the final schedule is Monthly', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // User switched the preset to monthly without touching the checkbox.
+      component.repeatCfg.update((c) => ({ ...c, quickSetting: 'MONTHLY_FIRST_DAY' }));
+      component.save();
+
+      expect(savedCfg().skipOverdue).toBe(false);
+    });
+
+    it('respects an explicit user toggle over the cycle-derived default', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // User opened Advanced and ticked skipOverdue ON for a monthly task;
+      // a dirty control means the derived OFF default must not override it.
+      const ctrl = new FormControl(true);
+      ctrl.markAsDirty();
+      component.formGroup2().addControl('skipOverdue', ctrl);
+      component.repeatCfg.update((c) => ({
+        ...c,
+        quickSetting: 'MONTHLY_FIRST_DAY',
+        skipOverdue: true,
+      }));
+
+      component.save();
+
+      expect(savedCfg().skipOverdue).toBe(true);
     });
   });
 });

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -721,4 +721,59 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       expect(savedCfg().skipOverdue).toBe(true);
     });
   });
+
+  describe('skipOverdue display stays honest while pristine (#8644)', () => {
+    it('re-derives skipOverdue OFF when the schedule changes to Monthly', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // A new config starts on Daily → seeded ON.
+      expect(component.repeatCfg().skipOverdue).toBe(true);
+
+      // User switches the preset (essential-form change), checkbox untouched.
+      component.onScheduleModelChange({
+        ...component.repeatCfg(),
+        quickSetting: 'MONTHLY_FIRST_DAY',
+      });
+
+      expect(component.repeatCfg().skipOverdue).toBe(false);
+    });
+
+    it('updates a rendered (pristine) checkbox to match the new schedule', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // Advanced is open: a pristine control reflecting the Daily default.
+      const ctrl = new FormControl(true);
+      component.formGroup2().addControl('skipOverdue', ctrl);
+
+      component.onScheduleModelChange({
+        ...component.repeatCfg(),
+        quickSetting: 'MONTHLY_FIRST_DAY',
+      });
+
+      expect(ctrl.value).toBe(false);
+      expect(ctrl.dirty).toBe(false);
+      expect(component.repeatCfg().skipOverdue).toBe(false);
+    });
+
+    it('does not re-derive once the user has toggled the checkbox', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // User explicitly ticked it ON; switching schedule must not override.
+      const ctrl = new FormControl(true);
+      ctrl.markAsDirty();
+      component.formGroup2().addControl('skipOverdue', ctrl);
+
+      component.onScheduleModelChange({
+        ...component.repeatCfg(),
+        quickSetting: 'MONTHLY_FIRST_DAY',
+        skipOverdue: true,
+      });
+
+      expect(component.repeatCfg().skipOverdue).toBe(true);
+      expect(ctrl.value).toBe(true);
+    });
+  });
 });

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -477,6 +477,32 @@ export class DialogEditTaskRepeatCfgComponent {
     }
   }
 
+  /**
+   * Essential-form change handler. Persists the model and, while the user has
+   * not explicitly toggled the checkbox, re-derives the `skipOverdue` default
+   * from the *current* schedule. Without this, the seed (computed once from the
+   * initial Daily default) goes stale when the schedule changes, so the Advanced
+   * checkbox would display a value that disagrees with what `save()` persists —
+   * e.g. showing ON for a Monthly schedule that `save()` re-derives to OFF.
+   *
+   * Only for new configs; an existing config keeps its stored value untouched.
+   */
+  onScheduleModelChange(model: Omit<TaskRepeatCfgCopy, 'id'> | TaskRepeatCfg): void {
+    const skipOverdueCtrl = this.formGroup2().get('skipOverdue');
+    const isSkipOverduePristine = !(skipOverdueCtrl?.dirty ?? false);
+    if (!this.isEdit() && isSkipOverduePristine) {
+      const derived = getDefaultSkipOverdue(model);
+      if (model.skipOverdue !== derived) {
+        // Mirror the derived value into the rendered control (if Advanced is
+        // open) without emitting — keeps it pristine and avoids a feedback loop.
+        skipOverdueCtrl?.setValue(derived, { emitEvent: false });
+        this.repeatCfg.set({ ...model, skipOverdue: derived });
+        return;
+      }
+    }
+    this.repeatCfg.set(model);
+  }
+
   private _normalizeMonthlyAnchor<
     T extends {
       monthlyWeekOfMonth?: unknown;

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -38,6 +38,7 @@ import { formatMonthDay } from '../../../util/format-month-day.util';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { first } from 'rxjs/operators';
 import { getQuickSettingUpdates } from './get-quick-setting-updates';
+import { getDefaultSkipOverdue } from './get-default-skip-overdue';
 import { getTaskRepeatCfgChanges } from './get-task-repeat-cfg-changes';
 import { clockStringFromDate } from '../../../ui/duration/clock-string-from-date';
 import { ChipListInputComponent } from '../../../ui/chip-list-input/chip-list-input.component';
@@ -314,6 +315,10 @@ export class DialogEditTaskRepeatCfgComponent {
         : undefined;
       return {
         ...DEFAULT_TASK_REPEAT_CFG,
+        // New configs default to the "Daily" quick setting, where collapsing
+        // overdue instances is both useful and safe; see getDefaultSkipOverdue.
+        // Re-derived from the final schedule on save in case the user switches.
+        skipOverdue: getDefaultSkipOverdue(DEFAULT_TASK_REPEAT_CFG),
         startDate:
           this._data.task.dueDay ??
           getDbDateStr(this._data.task.dueWithTime || undefined),
@@ -456,10 +461,17 @@ export class DialogEditTaskRepeatCfgComponent {
       );
       this.close();
     } else {
+      // Seed skipOverdue from the FINAL schedule (the initial default assumed
+      // Daily; the user may have switched to e.g. Monthly). Skip this only when
+      // the user explicitly toggled the checkbox, so an opt-in/out is honoured.
+      const skipOverdueTouched = this.formGroup2().get('skipOverdue')?.dirty ?? false;
+      const newRepeatCfg = skipOverdueTouched
+        ? finalRepeatCfg
+        : { ...finalRepeatCfg, skipOverdue: getDefaultSkipOverdue(finalRepeatCfg) };
       this._taskRepeatCfgService.addTaskRepeatCfgToTask(
         (this._data.task as Task).id,
         (this._data.task as Task).projectId || null,
-        finalRepeatCfg,
+        newRepeatCfg,
       );
       this.close();
     }

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.spec.ts
@@ -1,0 +1,62 @@
+import { getDefaultSkipOverdue } from './get-default-skip-overdue';
+import { RepeatCycleOption, RepeatQuickSetting } from '../task-repeat-cfg.model';
+
+const cfg = (
+  quickSetting: RepeatQuickSetting,
+  repeatCycle: RepeatCycleOption = 'DAILY',
+  repeatEvery = 1,
+): {
+  quickSetting: RepeatQuickSetting;
+  repeatCycle: RepeatCycleOption;
+  repeatEvery: number;
+} => ({
+  quickSetting,
+  repeatCycle,
+  repeatEvery,
+});
+
+describe('getDefaultSkipOverdue', () => {
+  it('is ON for the Daily preset (everyday → never drops to zero)', () => {
+    expect(getDefaultSkipOverdue(cfg('DAILY', 'DAILY', 1))).toBe(true);
+  });
+
+  it('is ON for the Mon–Fri preset (near-daily → at most a weekend gap)', () => {
+    expect(getDefaultSkipOverdue(cfg('MONDAY_TO_FRIDAY', 'WEEKLY', 1))).toBe(true);
+  });
+
+  it('is OFF for weekly/monthly/yearly presets (missed occurrence must stay visible)', () => {
+    const offPresets: RepeatQuickSetting[] = [
+      'WEEKLY_CURRENT_WEEKDAY',
+      'MONTHLY_CURRENT_DATE',
+      'MONTHLY_FIRST_DAY',
+      'MONTHLY_LAST_DAY',
+      'MONTHLY_NTH_WEEKDAY',
+      'YEARLY_CURRENT_DATE',
+    ];
+    offPresets.forEach((preset) => {
+      expect(getDefaultSkipOverdue(cfg(preset, 'WEEKLY', 1))).toBe(false);
+    });
+  });
+
+  describe('CUSTOM', () => {
+    it('is ON only for an every-single-day custom cycle', () => {
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'DAILY', 1))).toBe(true);
+    });
+
+    it('is OFF for every-N-days (N > 1) — today is no longer always scheduled', () => {
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'DAILY', 2))).toBe(false);
+    });
+
+    it('is OFF for weekly/monthly/yearly custom cycles', () => {
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'WEEKLY', 1))).toBe(false);
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'MONTHLY', 1))).toBe(false);
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'YEARLY', 1))).toBe(false);
+    });
+
+    it('treats a missing repeatEvery as 1', () => {
+      expect(
+        getDefaultSkipOverdue({ quickSetting: 'CUSTOM', repeatCycle: 'DAILY' }),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.ts
@@ -1,0 +1,40 @@
+import { TaskRepeatCfgCopy } from '../task-repeat-cfg.model';
+
+/**
+ * Default value for `skipOverdue` ("Don't let overdue instances pile up") when a
+ * NEW recurring config is created.
+ *
+ * It is ON only for near-daily schedules — the plain "Daily" preset and the
+ * "Every workday (Mon–Fri)" preset — because that is where skipping is both
+ * useful and safe:
+ * - Useful: these are the schedules that actually pile up. Opening the app
+ *   across several scheduled days without finishing leaves one empty overdue
+ *   copy per day; collapsing those into a single current instance is the calm
+ *   default. (A weekly/monthly task has at most one missed occurrence — nothing
+ *   piles up, so the default buys nothing there.)
+ * - Safe: the next scheduled day is at most a weekend away, so a missed instance
+ *   reliably regenerates — it never silently vanishes for a meaningful stretch.
+ *   (For "Daily" today is always scheduled, so it can never even drop to zero.)
+ *
+ * Everything else stays OFF: weekly/monthly/yearly (and sparser custom)
+ * schedules keep at most one missed occurrence visible as overdue, so a real
+ * obligation — "pay rent on the 1st", "renew the domain" — never silently
+ * disappears until its next occurrence. Custom is intentionally limited to the
+ * every-single-day case so the rule needs no weekday-count or interval
+ * threshold. Users can still flip the option per config either way.
+ *
+ * Existing configs are unaffected — this only seeds the default for new ones.
+ */
+export const getDefaultSkipOverdue = (
+  cfg: Pick<TaskRepeatCfgCopy, 'quickSetting' | 'repeatCycle'> & {
+    repeatEvery?: number;
+  },
+): boolean => {
+  // CUSTOM has no preset; derive from the raw cycle: every single day only.
+  // (Deliberately no weekday-count / interval heuristic — see doc above.)
+  if (cfg.quickSetting === 'CUSTOM') {
+    return cfg.repeatCycle === 'DAILY' && (cfg.repeatEvery ?? 1) === 1;
+  }
+  // Presets: "Daily" and "Every workday (Mon–Fri)" are the near-daily ones.
+  return cfg.quickSetting === 'DAILY' || cfg.quickSetting === 'MONDAY_TO_FRIDAY';
+};

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.model.spec.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.model.spec.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_TASK_REPEAT_CFG } from './task-repeat-cfg.model';
+
+describe('DEFAULT_TASK_REPEAT_CFG', () => {
+  it('keeps skipOverdue false as the safe baseline', () => {
+    // The model default is intentionally the OFF baseline: it is what fixtures
+    // and any non-dialog spread inherit, and OFF can never silently drop a
+    // missed occurrence. The real, schedule-aware default for newly created
+    // configs (ON for daily/Mon-Fri) is seeded at creation by
+    // getDefaultSkipOverdue — see get-default-skip-overdue.ts. Pinned so a
+    // future change cannot quietly flip this to a blanket default.
+    expect(DEFAULT_TASK_REPEAT_CFG.skipOverdue).toBe(false);
+  });
+});

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -373,6 +373,38 @@ describe('AddTaskBarComponent', () => {
       expect(repeatCfg.startDate).toBe('2024-05-19');
     });
 
+    it('seeds skipOverdue ON for an inline Daily repeat (#8644)', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const addRepeatCfgSpy = spyOn(
+        TestBed.inject(TaskRepeatCfgService),
+        'addTaskRepeatCfgToTask',
+      );
+
+      component.stateService.updateInputTxt('Daily standup');
+      component.stateService.updateCleanText('Daily standup');
+      component.stateService.updateRepeatSetting('DAILY');
+
+      await component.addTask();
+
+      expect(addRepeatCfgSpy.calls.mostRecent().args[2].skipOverdue).toBe(true);
+    });
+
+    it('keeps skipOverdue OFF for an inline Monthly repeat (#8644)', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const addRepeatCfgSpy = spyOn(
+        TestBed.inject(TaskRepeatCfgService),
+        'addTaskRepeatCfgToTask',
+      );
+
+      component.stateService.updateInputTxt('Pay rent');
+      component.stateService.updateCleanText('Pay rent');
+      component.stateService.updateRepeatSetting('MONTHLY_CURRENT_DATE');
+
+      await component.addTask();
+
+      expect(addRepeatCfgSpy.calls.mostRecent().args[2].skipOverdue).toBe(false);
+    });
+
     it('should pass deadlineDay when a deadline date is set without a time', async () => {
       mockTaskService.add.and.returnValue('task-1');
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -73,6 +73,7 @@ import { MentionConfigService } from '../mention-config.service';
 import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { DEFAULT_TASK_REPEAT_CFG } from '../../task-repeat-cfg/task-repeat-cfg.model';
 import { getQuickSettingUpdates } from '../../task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates';
+import { getDefaultSkipOverdue } from '../../task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ShortSyntaxTag, shortSyntaxToTags } from './short-syntax-to-tags';
 import { DEFAULT_PROJECT_COLOR } from '../../work-context/work-context.const';
@@ -550,7 +551,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
           const referenceDate = dateStrToUtcDate(startDate);
           const quickSettingUpdates =
             getQuickSettingUpdates(state.repeatQuickSetting, referenceDate) || {};
-          this._taskRepeatCfgService.addTaskRepeatCfgToTask(taskId, state.projectId, {
+          const newRepeatCfg = {
             ...DEFAULT_TASK_REPEAT_CFG,
             startDate,
             ...quickSettingUpdates,
@@ -560,6 +561,12 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
             defaultEstimate: state.estimate || 0,
             startTime: state.time || undefined,
             remindAt: state.time ? resolvedRemindOption : undefined,
+          };
+          // Seed the skipOverdue default from the chosen schedule, same as the
+          // repeat dialog (there is no advanced toggle in the inline add-bar).
+          this._taskRepeatCfgService.addTaskRepeatCfgToTask(taskId, state.projectId, {
+            ...newRepeatCfg,
+            skipOverdue: getDefaultSkipOverdue(newRepeatCfg),
           });
         }
       }


### PR DESCRIPTION
## What

Make new recurring tasks **stop piling up overdue duplicates by default — but only where that's safe**. The `skipOverdue` option ("Don't let overdue instances pile up") now defaults **on** for the **Daily** and **Every workday (Mon–Fri)** presets, and stays **off** for weekly/monthly/yearly schedules.

This supersedes the earlier "flip the default to `true` for everything" approach (see Why).

## Why

Daily duplication of stale recurring tasks is exactly the noise/guilt-clutter the manifesto rejects ("less noise, more depth"; "one calm default"). But a blanket default is the wrong tool: the benefit and the risk sit on opposite ends of the frequency spectrum.

- **Pile-up only happens for frequent tasks.** A monthly task has at most one missed occurrence — nothing piles up — so the option buys nothing there.
- **Silently dropping a missed occurrence only hurts infrequent tasks.** For weekly/monthly/yearly schedules, `skipOverdue` can make a real obligation ("pay rent on the 1st", "renew the domain") vanish until its next occurrence. For everyday/Mon–Fri schedules it can't meaningfully hurt: the next scheduled day is at most a weekend away, and a plain Daily task is always re-created for today (never drops to zero).

So the default is scoped to the near-daily schedules where pile-up is real and skipping is safe. This boundary was chosen via a UX review panel (safety, mainstream-mental-model, and simplicity lenses); they converged on **daily + the named Mon–Fri preset** — not an arbitrary "N+ weekdays" count, and explicitly *not* every-N-days / Mon-Wed-Fri-style schedules, where a missed occurrence is a multi-day vanish on potentially health-critical tasks.

## How

- New helper `getDefaultSkipOverdue(cfg)` — pure predicate: ON for the `DAILY` and `MONDAY_TO_FRIDAY` presets (and a CUSTOM cycle that is literally every single day); OFF otherwise. No weekday-count or interval threshold to maintain.
- Seeded in **both** config-creation paths so neither pile-up nor silent-drop slips through:
  - the **repeat dialog** — seeded on the new-config model and re-derived from the *final* schedule at save time, and **skipped when the user explicitly toggled the checkbox** (so per-config opt-in/out is preserved);
  - the inline **add-task-bar** recurrence.
- `DEFAULT_TASK_REPEAT_CFG.skipOverdue` stays `false` — the safe baseline for fixtures and any non-dialog spread; the real default is seeded at creation. Pinned by a test so it can't silently become a blanket default again.
- The option keeps its honest label **"Don't let overdue instances pile up"** (accurate for every schedule), rather than a "rolls into one" wording that is only true for the daily case.

## Scope & safety

- **Only affects newly created configs.** Existing configs keep their stored value; no migration, no op-log/replay change.
- **No data loss.** The existing cleanup effect only reaps *empty, untouched, overdue* instances; anything with tracked time, completion, subtask progress, or edits is preserved, and a single instance is never removed.

## Tests

- `get-default-skip-overdue.spec.ts` — the predicate across all presets + CUSTOM.
- Dialog spec — daily/Mon–Fri seed ON, monthly seed OFF, explicit user toggle respected.
- add-task-bar spec — inline daily seeds ON, inline monthly stays OFF.
- `task-repeat-cfg.model.spec.ts` — pins the `false` baseline.
- E2E `skip-overdue-default-8644.spec.ts` — daily persists `true`, monthly persists `false` through the real form.
- E2E `recurring-missed-day-bug-4559.spec.ts` still passes unchanged (monthly missed instance is still created).

## Docs

`docs/wiki/4.13` (reference) and `2.06` (how-to) document the option and the by-schedule default.
