### PR TITLE
fix(gitlab): reject invalid project identifiers in config validation

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.spec.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.spec.ts
@@ -1,0 +1,62 @@
+import {
+  GITLAB_CONFIG_FORM_SECTION,
+  GITLAB_PROJECT_REGEX,
+} from './gitlab-cfg-form.const';
+
+describe('GITLAB_PROJECT_REGEX', () => {
+  let projectPattern: RegExp;
+
+  beforeAll(() => {
+    // Verify the form field is actually wired to the exported regex, so this
+    // spec fails if someone swaps the field's `pattern` out from under it.
+    const projectField = GITLAB_CONFIG_FORM_SECTION.items!.find(
+      (item) => item.key === 'project',
+    );
+    const pattern = projectField?.templateOptions?.pattern as RegExp;
+    expect(pattern).toBe(GITLAB_PROJECT_REGEX);
+    projectPattern = pattern;
+  });
+
+  // Angular's Validators.pattern uses `regex.test(value)` as-is for a RegExp
+  // (no auto-anchoring), so the regex itself must be anchored at both ends.
+  const isValid = (value: string): boolean => projectPattern.test(value);
+
+  describe('valid project identifiers', () => {
+    const validCases = [
+      'super-productivity/super-productivity',
+      'group/subgroup/project',
+      'my_group/my.project',
+      'a.b-c/d_e',
+      'group%2Fproject',
+      'group%2Fsub%2Fproject',
+      // GitLab allows consecutive hyphens in a path segment; must not be rejected.
+      'foo--bar',
+      'single',
+      '12345',
+    ];
+    validCases.forEach((value) => {
+      it(`accepts "${value}"`, () => {
+        expect(isValid(value)).toBe(true);
+      });
+    });
+  });
+
+  describe('invalid project identifiers', () => {
+    // Regression for #8665: a display name with a space must be rejected inline
+    // instead of producing a confusing 404 at poll time.
+    const invalidCases = [
+      'My Group/My Gitlab',
+      'group/Test Gitlab',
+      'has space',
+      ' leadingSpace',
+      'trailingSpace ',
+      'https://gitlab.com/foo/bar',
+      'foo/bar?scope=all',
+    ];
+    invalidCases.forEach((value) => {
+      it(`rejects "${value}"`, () => {
+        expect(isValid(value)).toBe(false);
+      });
+    });
+  });
+});

--- a/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.ts
@@ -8,7 +8,14 @@ import {
   CROSS_ORIGIN_WARNING,
   ISSUE_PROVIDER_COMMON_FORM_FIELDS,
 } from '../../common-issue-form-stuff.const';
-export const GITLAB_PROJECT_REGEX = /(^[1-9][0-9]*$)|((\/|%2F|\w-?|\.-?)+$)/i;
+// Matches either a numeric project ID or a path (namespace/project-slug, or its
+// %2F-encoded form). Anchored at both ends: without a leading `^` the original
+// pattern only matched a valid *tail*, so display names with spaces (e.g.
+// "My Group/My Gitlab") passed validation and produced a 404 at poll time (#8665).
+// This is a "did you paste a display name?" sanity guard, not a strict GitLab
+// path validator, so the char class stays permissive (e.g. accepts consecutive
+// hyphens, which GitLab paths allow) rather than risk false-rejecting valid paths.
+export const GITLAB_PROJECT_REGEX = /^(?:[1-9][0-9]*|[\w%./-]+)$/i;
 
 export const GITLAB_CONFIG_FORM: LimitedFormlyFieldConfig<IssueProviderGitlab>[] = [
   ...CROSS_ORIGIN_WARNING,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -415,7 +415,7 @@
         "FILTER_USER": "Filter username",
         "GITLAB_BASE_URL": "Custom GitLab base URL (optional)",
         "PROJECT": "user name/project",
-        "PROJECT_HINT": "e.g. super-productivity/super-productivity",
+        "PROJECT_HINT": "Project path (namespace/project-slug) or numeric project ID, not the display name (e.g. super-productivity/super-productivity or 12345)",
         "SCOPE": "Scope",
         "SCOPE_ALL": "All",
         "SCOPE_ASSIGNED": "Assigned to me",


### PR DESCRIPTION
## Problem

Fixes #8665. Configuring a GitLab issue provider failed at import time with a snackbar:

> GITLAB: Failed to poll new issues for backlog import – GitLab: Http failure response for `https://<host>/api/v4/projects/<…>%20Gitlab/issues?…`: 404 OK

The `%20` in the project path is a URL-encoded **space** — the **Project** field held a project's *display name* (e.g. "My Group/My Gitlab") rather than the value GitLab's API needs (a numeric ID or the `namespace/project-slug` path).

## Root cause

`GITLAB_PROJECT_REGEX` was only **end-anchored**:

```js
/(^[1-9][0-9]*$)|((\/|%2F|\w-?|\.-?)+$)/i
```

Angular's `Validators.pattern` (which Formly's `templateOptions.pattern` delegates to) uses a `RegExp` **as-is** — it does *not* add `^…$` anchors for a RegExp. So any string whose *tail* matched (like `…Gitlab`) passed validation, and the malformed path only failed later as a confusing 404 at poll time.

## Fix

- **Anchor the regex at both ends** and simplify the path branch to a plain character class:
  ```js
  /^(?:[1-9][0-9]*|[\w%./-]+)$/i
  ```
  This is a "did you paste a display name?" sanity guard, not a strict GitLab-path validator, so it stays intentionally permissive (still accepts consecutive hyphens, `%2F`, nested groups, etc.) rather than risk false-rejecting valid paths.
- **Clarify the field hint** to ask for the path slug or numeric project ID, not the display name.
- **Add regression tests** for the space cases plus a field-wiring check (the form field must use the exported regex).

The GitLab **API layer was deliberately left unchanged** — switching `_projectApiLink`'s `.replace(/\//g, '%2F')` to `encodeURIComponent` would double-encode a user's literal `%2F` (`%2F` → `%252F`) and break existing configs. Validation is the correct gate.

## Note / scope boundary

This guards **new and edited** input. An already-saved bad `project` value keeps 404-ing on poll until the user reopens the provider config and re-saves (the form will now flag the stored value as invalid). This is inherent to a validation-layer fix — it does not auto-heal existing configs.

## Testing

- New `gitlab-cfg-form.const.spec.ts` — 16 cases, all green (valid: numeric ID, `namespace/project`, nested groups, dots/underscores, consecutive hyphens, `%2F`; invalid: space-containing display names, leading/trailing spaces, full URLs, query strings).
- `npm run checkFile` clean on both `.ts` files; `en.json` valid (existing `PROJECT_HINT` key, no `t.const.ts` regeneration needed).

## Review

Reviewed via multi-agent pass (correctness / architecture / simplicity + Codex). It caught a regression in the first iteration — the original anchored token soup (`\w-?|\.-?`) rejected GitLab-valid consecutive hyphens — which is fixed by the character-class form above.
