### PR TITLE
fix(electron): block executable launch via shell.openPath

### DIFF
--- a/electron/ipc-handlers/system.ts
+++ b/electron/ipc-handlers/system.ts
@@ -1,6 +1,7 @@
 import { app, dialog, ipcMain, shell } from 'electron';
 import { IPC } from '../shared-with-frontend/ipc-events.const';
 import {
+  hasExecutableFileExtension,
   isExternalUrlSchemeAllowed,
   isPathSafeToOpen,
 } from '../shared-with-frontend/is-external-url-allowed';
@@ -13,6 +14,14 @@ export const initSystemIpc = (): void => {
     // the user's NTLM hash. FILE-type task-attachment paths are synced and thus
     // attacker-controllable. See GHSA-hr87-735w-hfq3.
     if (!isPathSafeToOpen(path)) {
+      return;
+    }
+    // Never launch an executable/script. shell.openPath runs .bat/.cmd/.vbs/...
+    // via the OS handler (ShellExecute on Windows needs no exec bit), so a
+    // renderer that drops a file into a writable dir + calls openPath — or a
+    // malicious synced FILE attachment clicked by the user — would get native
+    // code execution that bypasses the nodeExecution consent gate.
+    if (hasExecutableFileExtension(path)) {
       return;
     }
     shell.openPath(path);

--- a/electron/shared-with-frontend/is-external-url-allowed.ts
+++ b/electron/shared-with-frontend/is-external-url-allowed.ts
@@ -232,12 +232,13 @@ export const hasExecutableFileExtension = (path: unknown): boolean => {
     return false;
   }
   const trimmed = path.trim();
-  // Drop the query/fragment ONLY for real `file:` URLs (`file:///x.bat?y`). In a
-  // bare filesystem path `#` is a legal filename char on Windows/NTFS (and both
-  // `#` and `?` are legal on POSIX), so splitting on them there would let
+  // Drop the query/fragment ONLY for a real `file://` URL (`file:///x.bat?y`). In
+  // a bare filesystem path `#` is a legal filename char on Windows/NTFS (and `#`,
+  // `?` and `:` are all legal on POSIX), so splitting on them there would let
   // `evil.txt#.bat` — whose real extension ShellExecute reads as `.bat` — slip
-  // through as the harmless-looking `.txt`.
-  const withoutQuery = /^file:/i.test(trimmed) ? trimmed.split(/[?#]/)[0] : trimmed;
+  // through as the harmless-looking `.txt`. Require the `//` so a POSIX file that
+  // merely starts with the literal `file:` isn't mistaken for a URL either.
+  const withoutQuery = /^file:\/\//i.test(trimmed) ? trimmed.split(/[?#]/)[0] : trimmed;
   // Strip trailing Windows dots/spaces (a real filesystem normalization).
   const candidate = withoutQuery.replace(/[ .]+$/, '');
   const lastSep = Math.max(candidate.lastIndexOf('/'), candidate.lastIndexOf('\\'));

--- a/electron/shared-with-frontend/is-external-url-allowed.ts
+++ b/electron/shared-with-frontend/is-external-url-allowed.ts
@@ -184,12 +184,27 @@ const EXECUTABLE_FILE_EXTENSIONS = new Set<string>([
   'jnlp',
   'gadget',
   'application',
+  'appref-ms', // ClickOnce launcher (sibling of .application)
+  'settingcontent-ms', // runs arbitrary commands via ShellExecute (LOLBin RCE)
+  'library-ms', // crafted library files have been used for code exec
+  'wsc', // Windows Script Component (sibling of .wsf/.wsh)
+  'chm', // compiled HTML help — executes on open
+  'hlp', // legacy WinHelp — executes on open
+  'diagcab', // Windows troubleshooter package — runs on open
+  'msix',
+  'msixbundle',
+  'appx',
+  'appxbundle',
   // macOS
   'command',
   'app',
   'workflow',
   'action',
   'scpt',
+  'pkg', // launches the Installer for an arbitrary package
+  'terminal', // Terminal settings file that also runs a command on open
+  'fileloc', // location files abused to run commands (CVE-2022-42821)
+  'inetloc',
   // Linux / cross-platform
   'sh',
   'bash',
@@ -216,11 +231,15 @@ export const hasExecutableFileExtension = (path: unknown): boolean => {
   if (typeof path !== 'string') {
     return false;
   }
-  // Drop query/fragment (`file:///x.bat?y`) and trailing Windows dots/spaces.
-  const candidate = path
-    .trim()
-    .split(/[?#]/)[0]
-    .replace(/[ .]+$/, '');
+  const trimmed = path.trim();
+  // Drop the query/fragment ONLY for real `file:` URLs (`file:///x.bat?y`). In a
+  // bare filesystem path `#` is a legal filename char on Windows/NTFS (and both
+  // `#` and `?` are legal on POSIX), so splitting on them there would let
+  // `evil.txt#.bat` — whose real extension ShellExecute reads as `.bat` — slip
+  // through as the harmless-looking `.txt`.
+  const withoutQuery = /^file:/i.test(trimmed) ? trimmed.split(/[?#]/)[0] : trimmed;
+  // Strip trailing Windows dots/spaces (a real filesystem normalization).
+  const candidate = withoutQuery.replace(/[ .]+$/, '');
   const lastSep = Math.max(candidate.lastIndexOf('/'), candidate.lastIndexOf('\\'));
   const base = candidate.slice(lastSep + 1);
   const dot = base.lastIndexOf('.');

--- a/electron/shared-with-frontend/is-external-url-allowed.ts
+++ b/electron/shared-with-frontend/is-external-url-allowed.ts
@@ -136,3 +136,101 @@ export const isPathSafeToOpen = (path: unknown): boolean => {
   }
   return true;
 };
+
+/**
+ * Executable / script extensions that `shell.openPath` must never launch.
+ *
+ * `shell.openPath` hands the file to the OS default handler, and on Windows
+ * `ShellExecute` *runs* these from a plain file with no exec bit — so a renderer
+ * (a plugin or XSS) that can drop a file into a writable dir (e.g. the
+ * local-file sync folder via `FILE_SYNC_SAVE`) and then call
+ * `window.ea.openPath()` on it gets native code execution that bypasses the
+ * `nodeExecution` consent gate. A malicious synced FILE attachment whose path
+ * points at such a file is the same vector on user click.
+ *
+ * shortcut: a curated denylist — executable extensions vary by platform and new
+ * ones appear. If this proves leaky, the upgrade path is to invert it into an
+ * allowlist of openable document types (or a user confirm) at the openPath sink.
+ */
+const EXECUTABLE_FILE_EXTENSIONS = new Set<string>([
+  // Windows — run directly by ShellExecute
+  'exe',
+  'com',
+  'bat',
+  'cmd',
+  'pif',
+  'scr',
+  'cpl',
+  'msi',
+  'msp',
+  'msc',
+  'vbs',
+  'vbe',
+  'js',
+  'jse',
+  'ws',
+  'wsf',
+  'wsh',
+  'ps1',
+  'psm1',
+  'psc1',
+  'hta',
+  'reg',
+  'inf',
+  'scf',
+  'lnk',
+  'url',
+  'jar',
+  'jnlp',
+  'gadget',
+  'application',
+  // macOS
+  'command',
+  'app',
+  'workflow',
+  'action',
+  'scpt',
+  // Linux / cross-platform
+  'sh',
+  'bash',
+  'zsh',
+  'csh',
+  'ksh',
+  'run',
+  'out',
+  'bin',
+  'appimage',
+  'desktop',
+  'deb',
+  'rpm',
+]);
+
+/**
+ * True if `path` ends in a known-executable/script extension (see
+ * {@link EXECUTABLE_FILE_EXTENSIONS}). Windows strips trailing dots/spaces from
+ * filenames (so `evil.bat.` / `evil.bat ` execute as `evil.bat`) and supports
+ * NTFS alternate data streams (`evil.bat::$DATA`), so both are normalized away
+ * before the check. Double extensions (`invoice.pdf.bat`) resolve to `.bat`.
+ */
+export const hasExecutableFileExtension = (path: unknown): boolean => {
+  if (typeof path !== 'string') {
+    return false;
+  }
+  // Drop query/fragment (`file:///x.bat?y`) and trailing Windows dots/spaces.
+  const candidate = path
+    .trim()
+    .split(/[?#]/)[0]
+    .replace(/[ .]+$/, '');
+  const lastSep = Math.max(candidate.lastIndexOf('/'), candidate.lastIndexOf('\\'));
+  const base = candidate.slice(lastSep + 1);
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0) {
+    return false; // no extension, or a dotfile with none
+  }
+  // `.slice` after the dot, then strip an NTFS ADS suffix (`bat:$DATA`).
+  const ext = base
+    .slice(dot + 1)
+    .toLowerCase()
+    .split(':')[0];
+  return EXECUTABLE_FILE_EXTENSIONS.has(ext);
+};

--- a/src/app/ui/is-external-url-allowed.spec.ts
+++ b/src/app/ui/is-external-url-allowed.spec.ts
@@ -224,6 +224,36 @@ describe('hasExecutableFileExtension (shell.openPath execution gate)', () => {
     ].forEach((p) => expect(hasExecutableFileExtension(p)).toBe(false));
   });
 
+  it('does NOT treat `#`/`?` in a bare path as a URL delimiter (real ext wins)', () => {
+    // `#` is a legal Windows/NTFS filename char; both `#` and `?` are legal on
+    // POSIX. Splitting on them for a bare path would misread the extension and
+    // let the executable through. The real extension must win here.
+    [
+      'C:\\sync\\evil.txt#.bat', // ShellExecute runs this as .bat
+      '/home/u/evil.txt#.sh',
+      '/home/u/launcher.txt?.desktop',
+      'C:\\sync\\report.pdf#.cmd',
+    ].forEach((p) => expect(hasExecutableFileExtension(p)).toBe(true));
+  });
+
+  it('flags additional ShellExecute / launcher vectors', () => {
+    [
+      'x.settingcontent-ms',
+      'x.appref-ms',
+      'x.library-ms',
+      'x.wsc',
+      'x.chm',
+      'x.hlp',
+      'x.diagcab',
+      'x.msix',
+      'x.appx',
+      'payload.pkg',
+      'payload.terminal',
+      'payload.fileloc',
+      'payload.inetloc',
+    ].forEach((p) => expect(hasExecutableFileExtension(p)).toBe(true));
+  });
+
   it('returns false for non-string input', () => {
     [undefined, null, 42, { path: 'x.bat' }].forEach((p) =>
       expect(hasExecutableFileExtension(p as unknown as string)).toBe(false),

--- a/src/app/ui/is-external-url-allowed.spec.ts
+++ b/src/app/ui/is-external-url-allowed.spec.ts
@@ -233,6 +233,10 @@ describe('hasExecutableFileExtension (shell.openPath execution gate)', () => {
       '/home/u/evil.txt#.sh',
       '/home/u/launcher.txt?.desktop',
       'C:\\sync\\report.pdf#.cmd',
+      // POSIX filename that merely starts with the literal `file:` (not a URL) —
+      // `#`/`?` are legal chars here, so the real `.sh`/`.desktop` ext must win.
+      'file:notes.txt#.sh',
+      'file:launcher.txt?.desktop',
     ].forEach((p) => expect(hasExecutableFileExtension(p)).toBe(true));
   });
 

--- a/src/app/ui/is-external-url-allowed.spec.ts
+++ b/src/app/ui/is-external-url-allowed.spec.ts
@@ -1,5 +1,6 @@
 import {
   ALLOWED_EXTERNAL_URL_SCHEMES,
+  hasExecutableFileExtension,
   isExternalUrlSchemeAllowed,
   isPathSafeToOpen,
   isUncPath,
@@ -159,5 +160,73 @@ describe('isExternalUrlSchemeAllowed', () => {
       expect(isExternalUrlSchemeAllowed(42)).toBe(false);
       expect(isExternalUrlSchemeAllowed({ href: 'https://example.com' })).toBe(false);
     });
+  });
+});
+
+describe('hasExecutableFileExtension (shell.openPath execution gate)', () => {
+  it('flags executable / script extensions across platforms', () => {
+    [
+      'C:\\Users\\me\\evil.bat',
+      '/home/u/evil.sh',
+      './rel/evil.cmd',
+      'x.exe',
+      'x.com',
+      'x.vbs',
+      'x.js',
+      'x.jse',
+      'x.wsf',
+      'x.hta',
+      'x.ps1',
+      'x.msi',
+      'x.scr',
+      'x.lnk',
+      'x.reg',
+      'x.jar',
+      'payload.command',
+      'payload.app',
+      'payload.desktop',
+      'payload.appimage',
+      'payload.run',
+      'file:///C:/tools/evil.bat',
+    ].forEach((p) => expect(hasExecutableFileExtension(p)).toBe(true));
+  });
+
+  it('is case-insensitive and resolves double extensions to the last one', () => {
+    ['EVIL.BAT', 'x.ExE', 'invoice.pdf.bat', 'photo.png.cmd'].forEach((p) =>
+      expect(hasExecutableFileExtension(p)).toBe(true),
+    );
+  });
+
+  it('normalizes Windows trailing dots/spaces and NTFS alternate data streams', () => {
+    [
+      'evil.bat.', // trailing dot — Windows executes as evil.bat
+      'evil.bat   ', // trailing spaces
+      'evil.bat . ',
+      'evil.bat::$DATA', // NTFS ADS
+      'C:\\x\\evil.bat:stream',
+      'file:///C:/x.bat?download=1', // query stripped before the check
+    ].forEach((p) => expect(hasExecutableFileExtension(p)).toBe(true));
+  });
+
+  it('allows documents, folders, and extensionless paths', () => {
+    [
+      '/home/u/report.pdf',
+      'C:\\docs\\sheet.xlsx',
+      'notes.txt',
+      'image.png',
+      'archive.zip',
+      'data.json',
+      'page.html',
+      '/home/u/folder',
+      'C:\\Users\\me',
+      'README',
+      '.bashrc', // dotfile with no extension
+    ].forEach((p) => expect(hasExecutableFileExtension(p)).toBe(false));
+  });
+
+  it('returns false for non-string input', () => {
+    [undefined, null, 42, { path: 'x.bat' }].forEach((p) =>
+      expect(hasExecutableFileExtension(p as unknown as string)).toBe(false),
+    );
   });
 });


### PR DESCRIPTION
## What

`window.ea.openPath` → `shell.openPath` opens a local path in the OS default manner. On Windows that runs script/executable file types (`.bat/.cmd/.vbs/.hta/.exe/…`) with no execute bit. The handler's only guard blocked UNC/remote paths (NTLM-leak, GHSA-hr87); it did **not** block executables — so renderer code (a plugin, a same-origin iframe plugin, or XSS) that can place a file at a known local path, or a malicious synced FILE attachment clicked by the user, could launch native code, bypassing the `nodeExecution` consent gate.

## Fix

- Add `hasExecutableFileExtension()` (curated cross-platform denylist; normalizes Windows trailing dots/spaces, NTFS ADS, double extensions, and `file://` query/fragment).
- Enforce it at the `shell.openPath` sink in `system.ts` — deliberately **not** in the shared `isPathSafeToOpen`, which also gates link/image rendering where a remote `https://…/x.exe` is a legitimate link. Opening documents/folders is unchanged.

## Testing

- 55 unit tests in `src/app/ui/is-external-url-allowed.spec.ts` (runs in CI); electron suite 160/160; typecheck clean.

## Notes

- The denylist is an arms-race by nature; the code comments the upgrade path (invert to a document allowlist / user confirm).
- A blocked open is a silent no-op (matches the existing UNC guard).
- Related: GHSA-256q (`exec` removed), GHSA-hr87 (this sink's UNC guard), GHSA-x937.
