### PR TITLE
fix(sync): never transmit plaintext operations for E2EE-mandatory providers

### DIFF
--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 2 * * *' # 2 AM UTC daily
 
   workflow_dispatch:
+    inputs:
+      grep:
+        description: 'Playwright --grep filter for the SuperSync job (default: @supersync)'
+        required: false
+        type: string
+        default: '@supersync'
 
   push:
     branches: [master, release/*]
@@ -208,7 +214,7 @@ jobs:
       - name: Run SuperSync E2E Tests
         env:
           E2E_REQUIRE_SUPERSYNC: 'true'
-        run: npm run e2e:all -- --grep "@supersync" --shard=${{ matrix.shard }}/6
+        run: npm run e2e:all -- --grep "${{ inputs.grep || '@supersync' }}" --shard=${{ matrix.shard }}/6
 
       - name: Stop Docker Services
         if: always()

--- a/e2e/tests/sync/supersync-encryption.spec.ts
+++ b/e2e/tests/sync/supersync-encryption.spec.ts
@@ -7,6 +7,8 @@ import {
   waitForTask,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
+import { expectConsistentState, expectTaskCount } from '../../utils/supersync-assertions';
+import { expectNoGlobalError } from '../../utils/assertions';
 
 /**
  * SuperSync Encryption E2E Tests
@@ -141,6 +143,68 @@ test.describe('@supersync SuperSync Encryption', () => {
     } finally {
       if (clientA) await closeClient(clientA);
       if (clientC) await closeClient(clientC);
+    }
+  });
+
+  // Regression test for GHSA-9v8x-68pf-p5x7 (+ the snapshot-consolidation
+  // follow-up): local task history exists BEFORE first-time encrypted SuperSync
+  // setup. The pre-encryption sync must not push plaintext, the enable-snapshot
+  // must subsume the pre-existing ops (so they are not re-uploaded on top of it),
+  // and a second client with the same password must receive exactly those tasks
+  // with no duplicates, conflicts, or errors.
+  test('First-time encrypted setup with pre-existing local data syncs cleanly to a 2nd client', async ({
+    browser,
+    baseURL,
+    testRunId,
+    serverHealthy,
+  }) => {
+    void serverHealthy;
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const baseConfig = getSuperSyncConfig(user);
+      const syncConfig = {
+        ...baseConfig,
+        isEncryptionEnabled: true,
+        password: `preexisting-${testRunId}`,
+      };
+
+      // --- Client A: create tasks BEFORE any sync/encryption is configured ---
+      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
+      await clientA.workView.waitForTaskList();
+
+      const task1 = `Pre1-${testRunId}`;
+      const task2 = `Pre2-${testRunId}`;
+      const task3 = `Pre3-${testRunId}`;
+      await clientA.workView.addTask(task1);
+      await clientA.page.waitForTimeout(100);
+      await clientA.workView.addTask(task2);
+      await clientA.page.waitForTimeout(100);
+      await clientA.workView.addTask(task3);
+
+      // First-time encrypted setup runs with the tasks already present.
+      await clientA.sync.setupSuperSync(syncConfig);
+      // A second sync must be a clean no-op: consolidation marks the pre-existing
+      // ops as synced, so there is nothing to re-upload on top of the snapshot.
+      await clientA.sync.syncAndWait();
+
+      await expectTaskCount(clientA, 3);
+      await expectNoGlobalError(clientA.page);
+
+      // --- Client B: same password → must receive exactly the 3 tasks ---
+      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
+      await clientB.sync.setupSuperSync(syncConfig);
+      await clientB.sync.syncAndWait();
+
+      await waitForTask(clientB.page, task1);
+      await expectConsistentState([clientA, clientB], [task1, task2, task3]);
+      await expectTaskCount(clientB, 3);
+      await expectNoGlobalError(clientB.page);
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
     }
   });
 

--- a/packages/sync-providers/src/provider-types.ts
+++ b/packages/sync-providers/src/provider-types.ts
@@ -188,6 +188,19 @@ export interface OperationSyncCapable<
    * encrypted config — the dropped-credential signature.
    */
   isEncryptionEnabled?(): Promise<boolean>;
+  /**
+   * Whether this provider mandates end-to-end encryption and must NEVER transmit
+   * plaintext operations. When true, the upload path refuses to push ops while no
+   * usable encryption key is configured yet (e.g. first-time setup, before the
+   * user has chosen a password): the encrypted snapshot uploaded by the
+   * encryption-enable flow becomes the first data to reach the server. Without
+   * this guard the initial-setup sync leaks all local ops in cleartext, breaking
+   * the E2EE promise even if they are later deleted (GHSA-9v8x-68pf-p5x7).
+   *
+   * Providers where unencrypted sync is a legitimate user choice (file-based)
+   * leave this unset.
+   */
+  readonly isEncryptionMandatory?: boolean;
 }
 
 export interface RestorePoint<TRestorePointType extends string = string> {

--- a/packages/sync-providers/src/super-sync/super-sync.ts
+++ b/packages/sync-providers/src/super-sync/super-sync.ts
@@ -123,6 +123,9 @@ export class SuperSyncProvider
   readonly maxConcurrentRequests = 10;
   readonly supportsOperationSync = true;
   readonly providerMode = 'superSyncOps' as const;
+  // SuperSync is E2EE-mandatory: the upload path must never push plaintext ops.
+  // See `isEncryptionMandatory` on OperationSyncCapable (GHSA-9v8x-68pf-p5x7).
+  readonly isEncryptionMandatory = true;
 
   public privateCfg: SyncCredentialStorePort<
     typeof PROVIDER_ID_SUPER_SYNC,

--- a/src/app/imex/sync/snapshot-upload.service.spec.ts
+++ b/src/app/imex/sync/snapshot-upload.service.spec.ts
@@ -389,6 +389,10 @@ describe('SnapshotUploadService', () => {
       });
 
       it('throws (before deleting) when enabling without a usable key', async () => {
+        // Crypto must be available so the WebCrypto-availability check passes and
+        // execution reaches the mandatory-encryption guard (the assertion target).
+        mockCryptoSubtleAvailable();
+
         await expectAsync(
           service.deleteAndReuploadWithNewEncryption({
             encryptKey: undefined,

--- a/src/app/imex/sync/snapshot-upload.service.spec.ts
+++ b/src/app/imex/sync/snapshot-upload.service.spec.ts
@@ -299,6 +299,54 @@ describe('SnapshotUploadService', () => {
       expect(mockSyncProvider.setLastServerSeq).toHaveBeenCalledWith(42);
     });
 
+    // Defense-in-depth for GHSA-9v8x-68pf-p5x7: for a provider that mandates E2E
+    // encryption, this method must never push a plaintext snapshot — it must fail
+    // closed BEFORE the destructive deleteAllData, regardless of caller.
+    describe('encryption-mandatory provider (GHSA-9v8x-68pf-p5x7)', () => {
+      beforeEach(() => {
+        (mockSyncProvider as any).isEncryptionMandatory = true;
+      });
+
+      it('throws (before deleting) when disabling encryption', async () => {
+        await expectAsync(
+          service.deleteAndReuploadWithNewEncryption({
+            encryptKey: undefined,
+            isEncryptionEnabled: false,
+            logPrefix: 'TestPrefix',
+          }),
+        ).toBeRejectedWithError(/unencrypted snapshot/);
+
+        expect(mockSyncProvider.deleteAllData).not.toHaveBeenCalled();
+        expect(mockSyncProvider.uploadSnapshot).not.toHaveBeenCalled();
+      });
+
+      it('throws (before deleting) when enabling without a usable key', async () => {
+        await expectAsync(
+          service.deleteAndReuploadWithNewEncryption({
+            encryptKey: undefined,
+            isEncryptionEnabled: true,
+            logPrefix: 'TestPrefix',
+          }),
+        ).toBeRejectedWithError(/unencrypted snapshot/);
+
+        expect(mockSyncProvider.deleteAllData).not.toHaveBeenCalled();
+      });
+
+      it('still succeeds when enabling with a usable key', async () => {
+        mockCryptoSubtleAvailable();
+        mockStateSnapshotService.getStateSnapshotAsync.and.resolveTo({ task: [] } as any);
+
+        await service.deleteAndReuploadWithNewEncryption({
+          encryptKey: 'my-key',
+          isEncryptionEnabled: true,
+          logPrefix: 'TestPrefix',
+        });
+
+        expect(mockSyncProvider.deleteAllData).toHaveBeenCalled();
+        expect(mockSyncProvider.uploadSnapshot).toHaveBeenCalled();
+      });
+    });
+
     it('should encrypt payload when enabling encryption', async () => {
       mockCryptoSubtleAvailable();
       const mockState = { task: [] };

--- a/src/app/imex/sync/snapshot-upload.service.spec.ts
+++ b/src/app/imex/sync/snapshot-upload.service.spec.ts
@@ -10,6 +10,7 @@ import {
   SyncProviderBase,
 } from '../../op-log/sync-providers/provider.interface';
 import { OperationEncryptionService } from '../../op-log/sync/operation-encryption.service';
+import { OperationLogStoreService } from '../../op-log/persistence/operation-log-store.service';
 import type { SuperSyncPrivateCfg } from '@sp/sync-providers/super-sync';
 import { WebCryptoNotAvailableError } from '../../op-log/core/errors/sync-errors';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
@@ -24,6 +25,7 @@ describe('SnapshotUploadService', () => {
     getOrGenerateClientId: jasmine.Spy;
   };
   let mockEncryptionService: jasmine.SpyObj<OperationEncryptionService>;
+  let mockOpLogStore: jasmine.SpyObj<OperationLogStoreService>;
   let mockSyncProvider: jasmine.SpyObj<
     SyncProviderBase<SyncProviderId> & OperationSyncCapable
   >;
@@ -94,6 +96,13 @@ describe('SnapshotUploadService', () => {
     ]);
     mockEncryptionService.encryptPayload.and.resolveTo('encrypted-state-data');
 
+    mockOpLogStore = jasmine.createSpyObj('OperationLogStoreService', [
+      'getUnsynced',
+      'markSynced',
+    ]);
+    mockOpLogStore.getUnsynced.and.resolveTo([]);
+    mockOpLogStore.markSynced.and.resolveTo(undefined);
+
     TestBed.configureTestingModule({
       providers: [
         SnapshotUploadService,
@@ -102,6 +111,7 @@ describe('SnapshotUploadService', () => {
         { provide: VectorClockService, useValue: mockVectorClockService },
         { provide: CLIENT_ID_PROVIDER, useValue: mockClientIdProvider },
         { provide: OperationEncryptionService, useValue: mockEncryptionService },
+        { provide: OperationLogStoreService, useValue: mockOpLogStore },
       ],
     });
 
@@ -297,6 +307,64 @@ describe('SnapshotUploadService', () => {
       );
       expect(mockSyncProvider.uploadSnapshot).toHaveBeenCalled();
       expect(mockSyncProvider.setLastServerSeq).toHaveBeenCalledWith(42);
+    });
+
+    // The snapshot subsumes all local ops, so they must be marked synced rather
+    // than left to re-upload incrementally on the next sync (GHSA-9v8x-68pf-p5x7
+    // follow-up: first-time setup would otherwise re-push the whole history).
+    describe('op-log consolidation', () => {
+      it('marks the ops subsumed by the snapshot as synced', async () => {
+        mockCryptoSubtleAvailable();
+        mockOpLogStore.getUnsynced.and.resolveTo([{ seq: 5 } as any, { seq: 6 } as any]);
+
+        await service.deleteAndReuploadWithNewEncryption({
+          encryptKey: 'my-key',
+          isEncryptionEnabled: true,
+          logPrefix: 'TestPrefix',
+        });
+
+        expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([5, 6]);
+      });
+
+      it('does NOT mark synced when the snapshot upload fails', async () => {
+        mockCryptoSubtleAvailable();
+        mockOpLogStore.getUnsynced.and.resolveTo([{ seq: 5 } as any]);
+        mockSyncProvider.uploadSnapshot.and.resolveTo({
+          accepted: false,
+          error: 'boom',
+        } as any);
+
+        await expectAsync(
+          service.deleteAndReuploadWithNewEncryption({
+            encryptKey: 'my-key',
+            isEncryptionEnabled: true,
+            logPrefix: 'TestPrefix',
+          }),
+        ).toBeRejected();
+
+        expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
+      });
+
+      it('captures ops BEFORE the destructive deleteAllData', async () => {
+        mockCryptoSubtleAvailable();
+        const callOrder: string[] = [];
+        mockOpLogStore.getUnsynced.and.callFake(async () => {
+          callOrder.push('getUnsynced');
+          return [{ seq: 5 } as any];
+        });
+        mockSyncProvider.deleteAllData.and.callFake(async () => {
+          callOrder.push('deleteAllData');
+          return { success: true };
+        });
+
+        await service.deleteAndReuploadWithNewEncryption({
+          encryptKey: 'my-key',
+          isEncryptionEnabled: true,
+          logPrefix: 'TestPrefix',
+        });
+
+        expect(callOrder).toEqual(['getUnsynced', 'deleteAllData']);
+      });
     });
 
     // Defense-in-depth for GHSA-9v8x-68pf-p5x7: for a provider that mandates E2E

--- a/src/app/imex/sync/snapshot-upload.service.ts
+++ b/src/app/imex/sync/snapshot-upload.service.ts
@@ -223,6 +223,20 @@ export class SnapshotUploadService {
       );
     }
 
+    // Capture the pending ops this full-state snapshot subsumes BEFORE taking the
+    // state snapshot below, so every captured op is guaranteed to be reflected in
+    // that snapshot. (If ordered the other way, an op landing between the state
+    // snapshot and this capture would be marked synced yet absent from the
+    // snapshot — silently lost.) A concurrent op arriving *after* this capture is
+    // simply left unsynced and re-uploaded on the next sync (safe, idempotent by
+    // op id), never dropped. After the snapshot lands, these ops are fully
+    // represented on the server, so we mark them synced to avoid a redundant
+    // re-upload on the next sync (for first-time SuperSync setup that would
+    // otherwise re-push the entire local history on top of the snapshot). Mirrors
+    // planRegularOpsAfterFullStateUpload in the op-log upload path, which this
+    // direct snapshot upload bypasses.
+    const opsSubsumedBySnapshot = await this._opLogStore.getUnsynced();
+
     const { syncProvider, existingCfg, state, vectorClock, clientId } =
       await this.gatherSnapshotData(logPrefix);
 
@@ -240,17 +254,6 @@ export class SnapshotUploadService {
           'encryption-mandatory provider',
       );
     }
-
-    // Capture the pending ops this full-state snapshot subsumes, BEFORE the
-    // destructive delete. This runs under runWithSyncBlocked behind a modal
-    // dialog, so no concurrent op can appear between here and the mark-synced
-    // below — the captured set exactly matches the uploaded snapshot. After the
-    // snapshot lands, these ops are fully represented on the server, so we mark
-    // them synced to avoid a redundant re-upload on the next sync (for first-time
-    // SuperSync setup that would otherwise re-push the entire local history on
-    // top of the snapshot). Mirrors planRegularOpsAfterFullStateUpload in the
-    // op-log upload path, which this direct snapshot upload bypasses.
-    const opsSubsumedBySnapshot = await this._opLogStore.getUnsynced();
 
     // Encrypt before delete (fail-early)
     let payload: unknown = state;

--- a/src/app/imex/sync/snapshot-upload.service.ts
+++ b/src/app/imex/sync/snapshot-upload.service.ts
@@ -224,6 +224,21 @@ export class SnapshotUploadService {
     const { syncProvider, existingCfg, state, vectorClock, clientId } =
       await this.gatherSnapshotData(logPrefix);
 
+    // GHSA-9v8x-68pf-p5x7 defense-in-depth: a provider that mandates E2E
+    // encryption (SuperSync) must never have a plaintext snapshot pushed. Fail
+    // closed — before any destructive delete — if this call would upload
+    // unencrypted (encryption turned off, or on without a usable key) rather
+    // than silently leaking. Complements the op-upload guard in
+    // OperationLogUploadService so the invariant holds regardless of caller
+    // (e.g. a keyless import, or a future disable-encryption wiring — currently
+    // UI-unreachable for SuperSync).
+    if (syncProvider.isEncryptionMandatory && !(isEncryptionEnabled && encryptKey)) {
+      throw new Error(
+        `${logPrefix}: refusing to upload an unencrypted snapshot for an ` +
+          'encryption-mandatory provider',
+      );
+    }
+
     // Encrypt before delete (fail-early)
     let payload: unknown = state;
     if (isEncryptionEnabled && encryptKey) {

--- a/src/app/imex/sync/snapshot-upload.service.ts
+++ b/src/app/imex/sync/snapshot-upload.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { SyncProviderManager } from '../../op-log/sync-providers/provider-manager.service';
+import { OperationLogStoreService } from '../../op-log/persistence/operation-log-store.service';
 import {
   AppStateSnapshot,
   StateSnapshotService,
@@ -69,6 +70,7 @@ export class SnapshotUploadService {
   private _vectorClockService = inject(VectorClockService);
   private _clientIdProvider: ClientIdProvider = inject(CLIENT_ID_PROVIDER);
   private _encryptionService = inject(OperationEncryptionService);
+  private _opLogStore = inject(OperationLogStoreService);
 
   /**
    * Validates that the active provider is SuperSync and operation-sync capable.
@@ -239,6 +241,17 @@ export class SnapshotUploadService {
       );
     }
 
+    // Capture the pending ops this full-state snapshot subsumes, BEFORE the
+    // destructive delete. This runs under runWithSyncBlocked behind a modal
+    // dialog, so no concurrent op can appear between here and the mark-synced
+    // below — the captured set exactly matches the uploaded snapshot. After the
+    // snapshot lands, these ops are fully represented on the server, so we mark
+    // them synced to avoid a redundant re-upload on the next sync (for first-time
+    // SuperSync setup that would otherwise re-push the entire local history on
+    // top of the snapshot). Mirrors planRegularOpsAfterFullStateUpload in the
+    // op-log upload path, which this direct snapshot upload bypasses.
+    const opsSubsumedBySnapshot = await this._opLogStore.getUnsynced();
+
     // Encrypt before delete (fail-early)
     let payload: unknown = state;
     if (isEncryptionEnabled && encryptKey) {
@@ -274,6 +287,15 @@ export class SnapshotUploadService {
     }
 
     await this.updateLastServerSeq(syncProvider, result.serverSeq, logPrefix);
+
+    // Consolidate: the snapshot now represents these ops on the server, so mark
+    // them synced instead of leaving them to re-upload incrementally next sync.
+    if (opsSubsumedBySnapshot.length > 0) {
+      await this._opLogStore.markSynced(opsSubsumedBySnapshot.map((entry) => entry.seq));
+      SyncLog.normal(
+        `${logPrefix}: Marked ${opsSubsumedBySnapshot.length} op(s) synced (subsumed by snapshot).`,
+      );
+    }
 
     return { ...result, existingCfg };
   }

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -132,6 +132,93 @@ describe('OperationLogUploadService', () => {
         expect(mockApiProvider.uploadOps).toHaveBeenCalled();
       });
 
+      // Regression guard for GHSA-9v8x-68pf-p5x7: a provider that mandates E2E
+      // encryption (SuperSync) must never upload plaintext ops. During first-time
+      // setup the config has no encryption key yet, so the initial sync used to
+      // push all local ops to the server in cleartext.
+      describe('encryption-mandatory provider without a key (GHSA-9v8x-68pf-p5x7)', () => {
+        beforeEach(() => {
+          (mockApiProvider as any).isEncryptionMandatory = true;
+          (mockApiProvider as any).getEncryptKey = jasmine
+            .createSpy('getEncryptKey')
+            .and.returnValue(Promise.resolve(undefined));
+          mockOpLogStore.getUnsynced.and.returnValue(
+            Promise.resolve([
+              createMockEntry(1, 'op-1', 'client-1'),
+              createMockEntry(2, 'op-2', 'client-1'),
+            ]),
+          );
+        });
+
+        it('does NOT upload any ops when no key is configured yet', async () => {
+          await service.uploadPendingOps(mockApiProvider);
+
+          expect(mockApiProvider.uploadOps).not.toHaveBeenCalled();
+        });
+
+        it('leaves pending ops unsynced (does NOT mark them synced)', async () => {
+          await service.uploadPendingOps(mockApiProvider);
+
+          // Must stay unsynced so they upload (encrypted) once encryption is set up.
+          expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
+        });
+
+        it('returns an empty upload result', async () => {
+          const result = await service.uploadPendingOps(mockApiProvider);
+
+          expect(result).toEqual({
+            uploadedCount: 0,
+            rejectedCount: 0,
+            piggybackedOps: [],
+            rejectedOps: [],
+          });
+        });
+
+        it('uploads (encrypted) once a key becomes available', async () => {
+          (mockApiProvider as any).getEncryptKey.and.returnValue(
+            Promise.resolve('the-key'),
+          );
+          mockApiProvider.uploadOps.and.returnValue(
+            Promise.resolve({
+              results: [
+                { opId: 'op-1', accepted: true },
+                { opId: 'op-2', accepted: true },
+              ],
+              latestSeq: 2,
+              newOps: [],
+            }),
+          );
+
+          await service.uploadPendingOps(mockApiProvider);
+
+          // Guard no longer blocks once a usable key exists; the ops are uploaded
+          // (encrypted by the encryption service, covered by its own specs).
+          expect(mockApiProvider.uploadOps).toHaveBeenCalled();
+        });
+      });
+
+      it('still uploads plaintext for providers that do NOT mandate encryption', async () => {
+        // File-based providers leave isEncryptionMandatory unset — unencrypted
+        // sync is a legitimate user choice there, so the guard must not fire.
+        (mockApiProvider as any).getEncryptKey = jasmine
+          .createSpy('getEncryptKey')
+          .and.returnValue(Promise.resolve(undefined));
+        mockOpLogStore.getUnsynced.and.returnValue(
+          Promise.resolve([createMockEntry(1, 'op-1', 'client-1')]),
+        );
+        mockApiProvider.uploadOps.and.returnValue(
+          Promise.resolve({
+            results: [{ opId: 'op-1', accepted: true }],
+            latestSeq: 1,
+            newOps: [],
+          }),
+        );
+
+        await service.uploadPendingOps(mockApiProvider);
+
+        expect(mockApiProvider.uploadOps).toHaveBeenCalled();
+      });
+
       it('should acquire lock before uploading', async () => {
         await service.uploadPendingOps(mockApiProvider);
 

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -124,6 +124,21 @@ export class OperationLogUploadService {
         : undefined;
       const isEncryptionEnabled = !!encryptKey;
 
+      // GHSA-9v8x-68pf-p5x7: providers that mandate E2E encryption (SuperSync)
+      // must NEVER transmit plaintext ops. While no usable key is configured yet
+      // — e.g. first-time setup, before the user has chosen a password — abort the
+      // upload entirely and leave every pending op unsynced. Downloads still run
+      // (merge-first), and the encryption-enable flow performs the first, encrypted
+      // upload. Without this guard the initial setup sync pushes all local ops to
+      // the server in cleartext, breaking the E2EE promise even if later deleted.
+      if (syncProvider.isEncryptionMandatory && !encryptKey) {
+        OpLog.warn(
+          'OperationLogUploadService: Encryption is mandatory for this provider but ' +
+            'no key is configured yet — skipping upload until encryption setup completes.',
+        );
+        return;
+      }
+
       // Separate full-state operations (backup imports, repairs) from regular ops
       // Full-state ops are uploaded via snapshot endpoint for better efficiency
       const fullStateOps = pendingOps.filter((entry) =>

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -132,7 +132,9 @@ export class OperationLogUploadService {
       // upload. Without this guard the initial setup sync pushes all local ops to
       // the server in cleartext, breaking the E2EE promise even if later deleted.
       if (syncProvider.isEncryptionMandatory && !encryptKey) {
-        OpLog.warn(
+        // Expected during the pre-encryption setup window (fires on every
+        // auto-sync until a key is set), so log at normal level, not warn.
+        OpLog.normal(
           'OperationLogUploadService: Encryption is mandatory for this provider but ' +
             'no key is configured yet — skipping upload until encryption setup completes.',
         );


### PR DESCRIPTION
## Summary

Fixes a privacy/E2EE issue in SuperSync setup (advisory GHSA-9v8x-68pf-p5x7).
During first-time SuperSync setup the initial sync runs **before** the user
chooses an encryption password, so all local operations — including task
content and issue-provider credentials — were uploaded to the server in
**cleartext**. Completing setup deletes that data; aborting leaves it stored
indefinitely, breaking the end-to-end-encryption promise shown to the user.

## Root cause

`OperationLogUploadService` only encrypts when a key is present
(`if (isEncryptionEnabled && encryptKey)`) and otherwise uploads plaintext.
Nothing prevented that for SuperSync during the pre-password window: the
`isReady()`/`_isEncryptionHalfConfigured` gate only catches "encryption on but
key missing", not "encryption never configured yet".

## Fix

- Add an optional `isEncryptionMandatory` capability to `OperationSyncCapable`
  (`true` for SuperSync; file-based providers, where unencrypted sync is a
  legitimate user choice, leave it unset).
- **Upload guard:** in the op-log upload path, refuse to upload while a
  mandatory-encryption provider has no usable key. Single choke point — covers
  normal sync, immediate-upload, and force-upload; placed before the full-state
  loop so snapshots are blocked too. Downloads still run (merge-first), and the
  encryption-enable flow performs the first, encrypted upload, so the setup flow
  and password prompt are unchanged.
- **Defense-in-depth:** `SnapshotUploadService.deleteAndReuploadWithNewEncryption`
  now fails closed (before any destructive delete) rather than pushing a
  plaintext snapshot for a mandatory-encryption provider — closing two adjacent
  paths (the UI-unreachable SuperSync disable-encryption flow, and a keyless
  import).
- **Consolidation:** the encryption-enable snapshot now marks the ops it subsumes
  as synced, so first-time setup no longer re-uploads the whole local history on
  top of the snapshot (also cleans up the enable-from-settings path). Mirrors
  `planRegularOpsAfterFullStateUpload`.

## Why it's safe (both setup cases)

Fresh-vs-join is discriminated by the **download**, not the upload: joining an
encrypted account throws `DecryptNoPasswordError` → enter-existing-password
dialog; a clean download → set-new-password dialog. The upload-only guard is
orthogonal, so both cases work and the encryption prompt still fires.

## Testing

- Unit: op-log upload (67), snapshot-upload (29), encryption-toggle (10),
  import-encryption-handler (15), sync-providers vitest (92) — all green.
- New multi-client e2e (`supersync-encryption.spec.ts`): local data → first-time
  encrypted setup → second client receives exactly those tasks, no duplicates,
  conflicts, or errors. **Verified green on CI** against the real docker SuperSync
  server (`1 passed (46.6s)`), full `@supersync` suite green.
- Reviewed via a 7-agent multi-review (correctness/security/architecture/
  simplicity/performance + Codex): leak fully closed, no critical findings.

## Not included (follow-ups)

- Server-side purge of already-leaked plaintext ops for users who aborted setup
  before this fix, plus a credential-rotation advisory (operational; server
  cannot distinguish plaintext from ciphertext by design).
- Optional: route the pre-existing `handleEncryptionStateMismatch` SuperSync
  check through `isEncryptionMandatory` for a single source of truth.

Also adds a `grep` input to the manual `e2e-scheduled.yml` dispatch for targeted
SuperSync runs.
