### PR TITLE
feat(plainspace): poll for new tasks in the background by default

### DIFF
--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -239,22 +239,28 @@ export class IssueService {
   async checkAndImportNewIssuesToBacklogForProject(
     providerKey: IssueProviderKey,
     issueProviderId: string,
+    isBackgroundPoll = false,
   ): Promise<void> {
     const service = this._getService(providerKey);
     if (!service?.getNewIssuesToAddToBacklog) {
       return;
     }
-    this._snackService.open({
-      svgIco: this._getProviderIcon(providerKey),
-      msg: T.F.ISSUE.S.POLLING_BACKLOG,
-      isSpinner: true,
-      translateParams: {
-        issueProviderName: this._getProviderName(providerKey),
-        issuesStr: this._translateService.instant(
-          this._getIssueStrings(providerKey).ISSUES_STR,
-        ),
-      },
-    });
+    // Background ('always'-mode) polls run every few minutes regardless of
+    // navigation, so keep them quiet — only the import result snack below is
+    // shown, and only when something is actually added.
+    if (!isBackgroundPoll) {
+      this._snackService.open({
+        svgIco: this._getProviderIcon(providerKey),
+        msg: T.F.ISSUE.S.POLLING_BACKLOG,
+        isSpinner: true,
+        translateParams: {
+          issueProviderName: this._getProviderName(providerKey),
+          issuesStr: this._translateService.instant(
+            this._getIssueStrings(providerKey).ISSUES_STR,
+          ),
+        },
+      });
+    }
 
     const allExistingIssueIds: string[] | number[] =
       await this._taskService.getAllIssueIdsForProviderEverywhere(issueProviderId);

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { unique } from '../../util/unique';
 import { generateCalendarTaskId } from '../calendar-integration/generate-calendar-task-id';
+import { generatePlainspaceTaskId } from './providers/plainspace/generate-plainspace-task-id';
 import {
   BuiltInIssueProviderKey,
   IssueData,
@@ -574,6 +575,14 @@ export class IssueService {
       additional = {
         ...additional,
         id: generateCalendarTaskId(issueProviderId, issueDataReduced.id.toString()),
+      };
+    } else if (issueProviderKey === PLAINSPACE_TYPE) {
+      // Plainspace auto-imports in the background on every device, so concurrent
+      // imports of the same issue must converge on one task id (see
+      // generatePlainspaceTaskId) instead of creating cross-device duplicates.
+      additional = {
+        ...additional,
+        id: generatePlainspaceTaskId(issueProviderId, issueDataReduced.id.toString()),
       };
     }
 

--- a/src/app/features/issue/providers/plainspace/generate-plainspace-task-id.spec.ts
+++ b/src/app/features/issue/providers/plainspace/generate-plainspace-task-id.spec.ts
@@ -1,0 +1,32 @@
+import { generatePlainspaceTaskId } from './generate-plainspace-task-id';
+
+describe('generatePlainspaceTaskId', () => {
+  it('should return a deterministic ID for the same inputs', () => {
+    const id1 = generatePlainspaceTaskId('provider-abc', 'issue-123');
+    const id2 = generatePlainspaceTaskId('provider-abc', 'issue-123');
+    expect(id1).toBe(id2);
+  });
+
+  it('should return different IDs for different provider IDs', () => {
+    const id1 = generatePlainspaceTaskId('provider-abc', 'issue-123');
+    const id2 = generatePlainspaceTaskId('provider-xyz', 'issue-123');
+    expect(id1).not.toBe(id2);
+  });
+
+  it('should return different IDs for different issue IDs', () => {
+    const id1 = generatePlainspaceTaskId('provider-abc', 'issue-123');
+    const id2 = generatePlainspaceTaskId('provider-abc', 'issue-456');
+    expect(id1).not.toBe(id2);
+  });
+
+  it('should start with ps_ prefix and not collide with calendar (cal_) ids', () => {
+    const id = generatePlainspaceTaskId('provider-abc', 'issue-123');
+    expect(id).toMatch(/^ps_/);
+    expect(id).not.toMatch(/^cal_/);
+  });
+
+  it('should produce a stable known value to guard against algorithm changes', () => {
+    const id = generatePlainspaceTaskId('provider-abc', 'issue-123');
+    expect(id).toBe('ps_provider-abc_issue-123');
+  });
+});

--- a/src/app/features/issue/providers/plainspace/generate-plainspace-task-id.ts
+++ b/src/app/features/issue/providers/plainspace/generate-plainspace-task-id.ts
@@ -1,0 +1,19 @@
+/**
+ * Generates a deterministic task ID from a Plainspace provider ID and issue ID.
+ *
+ * Plainspace auto-imports assigned tasks in the background on every device
+ * (default `pollingMode: 'always'`), so two clients can import the same issue
+ * within a single sync round-trip. Local dedup can't see the other client's
+ * not-yet-synced task, so without a shared ID each would create its own task
+ * with a random `nanoid()` and the op-log would keep both. A deterministic
+ * natural-key ID makes those concurrent `addTask` ops collide on one entity id
+ * and converge to a single task. Mirrors `generateCalendarTaskId`.
+ *
+ * Uses the raw inputs as a natural key — zero collision risk.
+ */
+export const generatePlainspaceTaskId = (
+  issueProviderId: string,
+  issueId: string,
+): string => {
+  return `ps_${issueProviderId}_${issueId}`;
+};

--- a/src/app/features/issue/providers/plainspace/plainspace-cfg-form.const.ts
+++ b/src/app/features/issue/providers/plainspace/plainspace-cfg-form.const.ts
@@ -16,6 +16,10 @@ export const DEFAULT_PLAINSPACE_CFG: PlainspaceCfg = {
   // Tasks assigned to me auto-import into the bound project's backlog, and the
   // poll keeps them in sync — Plainspace is meant to feel automatic.
   isAutoAddToBacklog: true,
+  // Poll in the background regardless of which project is open, so assigned
+  // tasks appear without navigating to the bound project. Background polls stay
+  // silent (no polling spinner) — see checkAndImportNewIssuesToBacklogForProject.
+  pollingMode: 'always',
 };
 
 export const PLAINSPACE_CONFIG_FORM: LimitedFormlyFieldConfig<IssueProviderPlainspace>[] =

--- a/src/app/features/issue/providers/plainspace/plainspace-cfg-form.const.ts
+++ b/src/app/features/issue/providers/plainspace/plainspace-cfg-form.const.ts
@@ -17,8 +17,9 @@ export const DEFAULT_PLAINSPACE_CFG: PlainspaceCfg = {
   // poll keeps them in sync — Plainspace is meant to feel automatic.
   isAutoAddToBacklog: true,
   // Poll in the background regardless of which project is open, so assigned
-  // tasks appear without navigating to the bound project. Background polls stay
-  // silent (no polling spinner) — see checkAndImportNewIssuesToBacklogForProject.
+  // tasks appear without navigating to the bound project. The backlog-poll
+  // spinner is suppressed for these background polls (see
+  // checkAndImportNewIssuesToBacklogForProject).
   pollingMode: 'always',
 };
 

--- a/src/app/features/issue/providers/plainspace/plainspace.model.ts
+++ b/src/app/features/issue/providers/plainspace/plainspace.model.ts
@@ -1,4 +1,4 @@
-import { BaseIssueProviderCfg } from '../../issue.model';
+import { BaseIssueProviderCfg, IssueProviderPollingMode } from '../../issue.model';
 
 /**
  * Per-instance config for the Plainspace (plainspace.org / `Johannesjo/spaces`)
@@ -16,4 +16,5 @@ export interface PlainspaceCfg extends BaseIssueProviderCfg {
   token?: string | null;
   isAutoPoll?: boolean;
   isAutoAddToBacklog?: boolean;
+  pollingMode?: IssueProviderPollingMode;
 }

--- a/src/app/features/issue/store/poll-to-backlog.effects.spec.ts
+++ b/src/app/features/issue/store/poll-to-backlog.effects.spec.ts
@@ -109,7 +109,7 @@ describe('PollToBacklogEffects', () => {
 
       expect(
         issueServiceSpy.checkAndImportNewIssuesToBacklogForProject,
-      ).toHaveBeenCalledWith(JIRA_TYPE, 'jira-1');
+      ).toHaveBeenCalledWith(JIRA_TYPE, 'jira-1', false);
     }));
 
     it('should NOT poll providers with pollingMode always (handled by separate effect)', fakeAsync(() => {
@@ -194,7 +194,7 @@ describe('PollToBacklogEffects', () => {
 
       expect(
         issueServiceSpy.checkAndImportNewIssuesToBacklogForProject,
-      ).toHaveBeenCalledWith(JIRA_TYPE, 'jira-1');
+      ).toHaveBeenCalledWith(JIRA_TYPE, 'jira-1', true);
     }));
 
     it('should NOT poll always-mode providers without isAutoAddToBacklog', fakeAsync(() => {

--- a/src/app/features/issue/store/poll-to-backlog.effects.ts
+++ b/src/app/features/issue/store/poll-to-backlog.effects.ts
@@ -133,6 +133,7 @@ export class PollToBacklogEffects {
           this._issueService.checkAndImportNewIssuesToBacklogForProject(
             provider.issueProviderKey,
             provider.id,
+            provider.pollingMode === 'always',
           ),
         ).pipe(
           catchError((e) => {


### PR DESCRIPTION
## What

Plainspace now polls for **new tasks in the background by default**. Previously it inherited the default `pollingMode: 'whenProjectOpen'`, so its 5-min backlog poll only ran while its bound project was the active work context — assigned tasks wouldn't appear unless you navigated there. It now defaults to `pollingMode: 'always'`, so tasks assigned to you auto-import into the bound project's backlog without opening the project, matching Plainspace's "meant to feel automatic" design.

## Details

- **New connections only.** The default flip lives in `DEFAULT_PLAINSPACE_CFG` and reaches both creation paths (share auto-provision + the generic add-provider dialog), which spread the provider default after the common default. Existing stored providers keep their `pollingMode` — no synced-config migration, nothing rewritten.
- **Background polls stay quiet.** The per-poll "Polling backlog…" spinner snack is suppressed for background (`always`-mode) polls via a new `isBackgroundPoll` flag; you still get a snack only when a task is actually imported. (The subtle global progress bar from the separate *update* poll is intentionally left as ambient status.)
- **Cross-device duplicate fix.** Surfaced by review: Plainspace imports used a random `nanoid()` id and dedup is purely local, so two open clients polling within one sync round-trip would each create their own task for the same issue and the op-log would keep both. Background `always` polling widens that race from "both viewing the project" to "both merely open." Imports now use a deterministic natural-key id (`ps_<providerId>_<issueId>`), mirroring the existing `generateCalendarTaskId` pattern, so concurrent `addTask` ops converge on one entity id.

## Review

Ran a multi-agent review (correctness, architecture/product, simplicity, sync-correctness). It caught the duplicate-id race (now fixed) and flagged the config comment overpromising silence (now scoped to what's actually suppressed). One low-severity residual — background imports inheriting the currently-viewed tag — was deliberately left out as it belongs in shared `getTaskDefaults` logic and affects all `always`-mode providers; tracked in #8673.

## Testing

- `generate-plainspace-task-id.spec.ts` — 5 cases (determinism, uniqueness, prefix, stable value). Green.
- `poll-to-backlog.effects.spec.ts` — updated to assert the `isBackgroundPoll` arg (foreground `false`, background `true`). 8 cases green.
- `checkFile` clean on all touched files.

Follow-up: #8673 (tag-inheritance on background auto-import).
