### PR TITLE
fix(issue): don't stamp ambient tag on automatic issue imports

### DIFF
--- a/src/app/features/calendar-integration/store/calendar-integration.effects.spec.ts
+++ b/src/app/features/calendar-integration/store/calendar-integration.effects.spec.ts
@@ -162,6 +162,8 @@ describe('CalendarIntegrationEffects pollChanges$ startup guard', () => {
         issueProviderId: PROVIDER_ID,
         issueDataReduced: jasmine.objectContaining({ id: 'cal-evt-1' }),
         isForceDefaultProject: true,
+        // Automatic auto-import must not inherit the active context's tag (#8673).
+        isAutoImport: true,
       }),
     );
   }));

--- a/src/app/features/calendar-integration/store/calendar-integration.effects.ts
+++ b/src/app/features/calendar-integration/store/calendar-integration.effects.ts
@@ -139,6 +139,10 @@ export class CalendarIntegrationEffects {
                                 issueDataReduced: calEv,
                                 // from this context we should always add to the default project rather than current context
                                 isForceDefaultProject: true,
+                                // Automatic auto-import fires regardless of what
+                                // the user is viewing; don't stamp the incidentally
+                                // active tag onto the event task (#8673).
+                                isAutoImport: true,
                               });
                             }
                           });

--- a/src/app/features/issue/issue.service.spec.ts
+++ b/src/app/features/issue/issue.service.spec.ts
@@ -494,6 +494,65 @@ describe('IssueService', () => {
     });
   });
 
+  describe('addTaskFromIssue - auto-import tag inheritance (#8673)', () => {
+    const jiraIssue = { id: 'JIRA-8673', title: 'Auto Import' };
+
+    const setActiveTag = (tagId: string): void => {
+      Object.defineProperty(workContextServiceSpy, 'activeWorkContextType', {
+        get: () => WorkContextType.TAG,
+        configurable: true,
+      });
+      Object.defineProperty(workContextServiceSpy, 'activeWorkContextId', {
+        get: () => tagId,
+        configurable: true,
+      });
+    };
+
+    beforeEach(() => {
+      taskServiceSpy.checkForTaskWithIssueEverywhere.and.resolveTo(null);
+      taskServiceSpy.add.and.returnValue('new-task-id');
+      (service.ISSUE_SERVICE_MAP['JIRA'] as any).getAddTaskData = () => ({
+        title: 'Auto Import',
+      });
+      issueProviderServiceSpy.getCfgOnce$.and.returnValue(
+        of({
+          defaultProjectId: 'proj-1',
+          defaultTagIds: ['default-tag'],
+        } as any),
+      );
+      // Auto-imports always target the backlog; the leak only surfaces via the
+      // non-PROJECT branch, i.e. while a non-Today tag is the active context.
+      setActiveTag('errands-tag');
+    });
+
+    it('inherits the ambient tag for a foreground import (isAutoImport unset)', async () => {
+      await service.addTaskFromIssue({
+        issueDataReduced: jiraIssue as any,
+        issueProviderId: 'jira-provider-1',
+        issueProviderKey: 'JIRA',
+        isAddToBacklog: true,
+      });
+
+      const taskData = taskServiceSpy.add.calls.mostRecent().args[2] as Partial<Task>;
+      expect(taskData.tagIds).toEqual(['errands-tag', 'default-tag']);
+      expect(taskData.projectId).toBe('proj-1');
+    });
+
+    it('does NOT inherit the ambient tag for an automatic import', async () => {
+      await service.addTaskFromIssue({
+        issueDataReduced: jiraIssue as any,
+        issueProviderId: 'jira-provider-1',
+        issueProviderKey: 'JIRA',
+        isAddToBacklog: true,
+        isAutoImport: true,
+      });
+
+      const taskData = taskServiceSpy.add.calls.mostRecent().args[2] as Partial<Task>;
+      expect(taskData.tagIds).toEqual(['default-tag']);
+      expect(taskData.projectId).toBe('proj-1');
+    });
+  });
+
   describe('addTaskFromIssue - CalDAV sub-task / archived-parent path', () => {
     const caldavIssue = {
       id: 'child-uid',

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -270,11 +270,17 @@ export class IssueService {
 
     issuesToAdd.forEach((issue: IssueDataReduced) => {
       // TODO add correct project id
+      // Every import here is an automatic backlog poll targeting the provider's
+      // default project, so the currently-viewed context is incidental and must
+      // not leak its tag onto the task (#8673). Flagging it here (rather than in
+      // the effect) also covers the classic poll's mid-fetch context-switch race
+      // — getTaskDefaults reads the *live* context after several awaits.
       this.addTaskFromIssue({
         issueDataReduced: issue,
         issueProviderId,
         issueProviderKey: providerKey,
         isAddToBacklog: true,
+        isAutoImport: true,
       });
     });
 
@@ -535,6 +541,7 @@ export class IssueService {
     additional = {},
     isAddToBacklog = false,
     isForceDefaultProject = false,
+    isAutoImport = false,
   }: {
     issueDataReduced: IssueDataReduced;
     issueProviderId: string;
@@ -542,6 +549,10 @@ export class IssueService {
     additional?: Partial<Task>;
     isAddToBacklog?: boolean;
     isForceDefaultProject?: boolean;
+    // Automatic (non-user-initiated) import — a background backlog poll or
+    // calendar auto-import. Such imports fire regardless of what the user is
+    // viewing, so they must not inherit the active context's tag (#8673).
+    isAutoImport?: boolean;
   }): Promise<string | undefined> {
     if (!issueDataReduced || !issueDataReduced.id || !issueProviderId) {
       throw new Error('No issueData');
@@ -615,7 +626,13 @@ export class IssueService {
         }
         return result;
       } else {
+        // An automatic import (background backlog poll / calendar auto-import)
+        // fires regardless of what the user is currently viewing, so the active
+        // tag is incidental. Inheriting it would stamp an unrelated tag onto the
+        // imported task and sync that stray tag to every device. Only inherit the
+        // ambient tag for user-initiated (foreground) imports.
         const contextTagIds =
+          !isAutoImport &&
           this._workContextService.activeWorkContextType === WorkContextType.TAG &&
           this._workContextService.activeWorkContextId !== TODAY_TAG.id
             ? [this._workContextService.activeWorkContextId]


### PR DESCRIPTION
## What & why

Fixes #8673. A **background auto-import** was stamping the currently-viewed tag onto imported tasks. Background imports fire regardless of navigation, so if the user happened to be on a non-Today tag (e.g. "Errands") when the import ran, `getTaskDefaults` inherited that incidental tag — and the stray tag then **synced to every device**.

Not data loss (one extra, easily-removed tag), but it writes incorrect *synced* state and is surprising. Reachable by default now that Plainspace defaults to `pollingMode: 'always'`.

## Root cause

`IssueService.addTaskFromIssue → getTaskDefaults` derives tags from the **active work context**. That's correct for a user-initiated import, but wrong for an automatic import where the ambient context is incidental. Only the non-PROJECT `else` branch leaks (via `contextTagIds`); PROJECT context and the Today tag were already clean.

## Fix

Add an `isAutoImport` flag to `addTaskFromIssue` and skip the ambient-tag inheritance when it's set. Naming follows the existing `isAutoImportForCurrentDay` / `isAutoAddToBacklog`.

Set for every automatic import path:
- **Issue-provider backlog polls** — set once inside `checkAndImportNewIssuesToBacklogForProject` (its only callers are the two poll effects, and every import there targets the provider's default-project backlog, so the ambient tag is never wanted). This also closes a pre-existing race in the classic `whenProjectOpen` poll, whose in-flight import can resolve *after* a context switch and read the live tag.
- **Calendar auto-import for the current day** (`calendar-integration.effects.ts`) — the identical leak on a sibling background timer; its own comment already said "always add to the default project rather than current context", but `isForceDefaultProject` only forced the project, not the tag.

Foreground (user-initiated) imports — add-task-bar issue search, the Plainspace claim pool, the calendar "Add as task" banner — are **unchanged** and still inherit the active tag, consistent with how a normal task-add behaves in the same context.

The fix lives entirely in the shared `getTaskDefaults` logic plus the two automatic call sites — no effect/timer plumbing.

## Tests

- New unit tests in `issue.service.spec.ts`: automatic import from a non-Today tag → only provider defaults; foreground import → still inherits the tag.
- `calendar-integration.effects.spec.ts` pins `isAutoImport: true` on the auto-import call.
- All affected specs green; all changed files lint clean.

## Notes

Scope, correctness, and design were validated via a 7-way parallel review (correctness, architecture, sync-correctness, alternatives + Codex). That review caught the calendar sibling-leak and the classic-poll race (both fixed here) and confirmed the shared-flag approach over gating on `isAddToBacklog` (which would wrongly strip the tag from the foreground claim path).
