### PR TITLE
fix(sync): defer SuperSync encryption prompt instead of dropping it when a dialog is open

### DIFF
--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -1819,6 +1819,99 @@ describe('SyncWrapperService', () => {
     });
   });
 
+  describe('_promptSuperSyncEncryptionIfNeeded() — post-sync encryption prompt', () => {
+    let privateCfgLoad: jasmine.Spy;
+    // Drive openDialogs through a getter over a closure variable so mutations are
+    // reliably observed by the service (Jasmine property-bag values are not).
+    let openDialogs: unknown[];
+
+    beforeEach(() => {
+      openDialogs = [];
+      Object.defineProperty(mockMatDialog, 'openDialogs', {
+        configurable: true,
+        get: () => openDialogs,
+      });
+      privateCfgLoad = jasmine
+        .createSpy('privateCfg.load')
+        .and.resolveTo({ isEncryptionEnabled: false, encryptKey: '' });
+      mockProviderManager.getActiveProvider.and.returnValue({
+        id: SyncProviderId.SuperSync,
+        privateCfg: { load: privateCfgLoad },
+      } as any);
+      mockMatDialog.open.and.returnValue({ afterClosed: () => of(undefined) } as any);
+    });
+
+    const callPrompt = (): Promise<void> =>
+      (service as any)._promptSuperSyncEncryptionIfNeeded();
+
+    const waitMs = (ms: number): Promise<void> =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+
+    it('opens the encryption dialog immediately when no other dialog is open', async () => {
+      openDialogs = [];
+
+      await callPrompt();
+
+      expect(mockMatDialog.open).toHaveBeenCalled();
+    });
+
+    it('defers the prompt while a dialog is open, then opens it once it closes (#8670)', async () => {
+      // Simulate the sync-config dialog still playing its close animation: with the
+      // E2EE-mandatory upload guard the first sync now completes almost instantly,
+      // so the prompt fires while the config dialog is still in openDialogs.
+      openDialogs = [{}];
+
+      const done = callPrompt();
+      // Prompt must NOT open while the dialog is still there (several poll cycles)…
+      await waitMs(250);
+      expect(mockMatDialog.open).not.toHaveBeenCalled();
+
+      // …but must open once the dialog finishes closing (never dropped).
+      openDialogs = [];
+      await done;
+      expect(mockMatDialog.open).toHaveBeenCalled();
+    });
+
+    it('does not prompt if encryption gets configured while waiting for the dialog to close', async () => {
+      openDialogs = [{}];
+
+      const done = callPrompt();
+      await waitMs(250);
+
+      // The open dialog configured encryption itself (e.g. an enter-password flow);
+      // once it closes the re-check must see the key and skip the enable prompt.
+      privateCfgLoad.and.resolveTo({ isEncryptionEnabled: true, encryptKey: 'key' });
+      openDialogs = [];
+      await done;
+
+      expect(mockMatDialog.open).not.toHaveBeenCalled();
+    });
+
+    it('skips when encryption is already enabled', async () => {
+      privateCfgLoad.and.resolveTo({ isEncryptionEnabled: true, encryptKey: 'key' });
+      openDialogs = [];
+
+      await callPrompt();
+
+      expect(mockMatDialog.open).not.toHaveBeenCalled();
+    });
+
+    it('does not prompt if the active provider is no longer SuperSync after the wait', async () => {
+      openDialogs = [{}];
+
+      const done = callPrompt();
+      await waitMs(250);
+
+      // The closing dialog switched provider / disabled SuperSync while we waited;
+      // the disableClose setup dialog must not open for a stale provider.
+      configSubject.next(createMockSyncConfig(SyncProviderId.Dropbox));
+      openDialogs = [];
+      await done;
+
+      expect(mockMatDialog.open).not.toHaveBeenCalled();
+    });
+  });
+
   describe('runWithSyncBlocked()', () => {
     it('should execute the operation and return its result', async () => {
       const result = await service.runWithSyncBlocked(async () => {

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -89,6 +89,16 @@ export type ForceUploadTriggerSource =
   | 'DecryptError'
   | 'unknown';
 
+/**
+ * When the post-sync SuperSync encryption prompt fires while another dialog is
+ * still open (typically the sync-config dialog still playing its close animation
+ * right after first-time setup), defer rather than drop the prompt: poll until
+ * dialogs clear, up to this bound, then re-check state.
+ * See `_promptSuperSyncEncryptionIfNeeded` (#8670 regression).
+ */
+const ENCRYPTION_PROMPT_DIALOG_WAIT_MS = 8000;
+const ENCRYPTION_PROMPT_DIALOG_POLL_MS = 100;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -1369,13 +1379,59 @@ export class SyncWrapperService {
       !!this._encryptionRequiredDialog,
     );
 
-    // Don't open if ANY dialog is already open. The config dialog's save() method
-    // handles encryption setup (either "enable encryption" or "enter password" based
-    // on a server probe). Opening a competing dialog causes duplicate encryption
-    // prompts and can trigger unwanted clean-slate operations.
-    if (this._matDialog.openDialogs.length > 0) {
-      SyncLog.log('Dialog already open — skipping encryption prompt');
+    // If our own encryption prompt is already open or being opened, there is
+    // nothing to do — and we must not wait on it below.
+    if (this._encryptionRequiredDialog || this._isOpeningEncryptionDialog) {
+      SyncLog.log('Encryption prompt already open/opening — skipping');
       return;
+    }
+
+    // A transiently-open dialog — typically the sync-config dialog still playing
+    // its close animation right after first-time setup — must only DEFER this
+    // prompt, never drop it. With the E2EE-mandatory upload guard (GHSA-9v8x) the
+    // initial sync finishes almost instantly (upload is skipped until a key
+    // exists), so it can now beat the config dialog's close animation; a one-shot
+    // skip here then leaves SuperSync enabled with no encryption configured and no
+    // prompt shown (#8670 regression). Wait (bounded) for open dialogs to clear,
+    // then re-check state before prompting. A competing dialog that is still open
+    // after the wait (e.g. an enter-password flow the user is interacting with) is
+    // left alone — the next sync re-runs this check.
+    if (this._matDialog.openDialogs.length > 0) {
+      SyncLog.log('Dialog open — deferring encryption prompt until it closes');
+      const waitStart = Date.now();
+      while (
+        this._matDialog.openDialogs.length > 0 &&
+        Date.now() - waitStart < ENCRYPTION_PROMPT_DIALOG_WAIT_MS
+      ) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, ENCRYPTION_PROMPT_DIALOG_POLL_MS),
+        );
+      }
+      if (this._matDialog.openDialogs.length > 0) {
+        SyncLog.log('Dialog still open after wait — skipping encryption prompt');
+        return;
+      }
+      // Provider/encryption state can change during the wait: the closing dialog
+      // may switch providers, disable SuperSync, or configure encryption itself
+      // (e.g. an enter-password flow). Re-validate the active provider and its
+      // config before prompting — otherwise we could open the disableClose setup
+      // dialog for a provider that is no longer active, trapping the user.
+      const providerIdAfterWait = await firstValueFrom(this.syncProviderId$);
+      if (providerIdAfterWait !== SyncProviderId.SuperSync) {
+        SyncLog.log('Provider changed while waiting — skipping encryption prompt');
+        return;
+      }
+      const providerAfterWait = this._providerManager.getActiveProvider();
+      if (!providerAfterWait) {
+        return;
+      }
+      const cfgAfterWait = (await providerAfterWait.privateCfg.load()) as
+        | { isEncryptionEnabled?: boolean; encryptKey?: string }
+        | undefined;
+      if (cfgAfterWait?.isEncryptionEnabled && cfgAfterWait?.encryptKey) {
+        SyncLog.log('Encryption enabled while waiting — skipping prompt');
+        return;
+      }
     }
 
     if (!this._encryptionRequiredDialog && !this._isOpeningEncryptionDialog) {


### PR DESCRIPTION
## Problem

The scheduled master **E2E Tests (Scheduled)** run [28530542837](https://github.com/super-productivity/super-productivity/actions/runs/28530542837) went red across **all 6 `@supersync` shards** (~72 failures), every one with the same error from the shared setup helper:

```
Error: Unable to determine Client A vs B - sync state unclear after timeout
  e2e/pages/supersync.page.ts:726
```

## Root cause

Regression introduced by #8670 ("never transmit plaintext operations for E2EE-mandatory providers"). That fix makes first-time SuperSync setup **skip the initial upload** until an encryption key exists — which also makes the first sync reach `IN_SYNC` almost instantly (~18 ms) instead of doing a slow network upload.

The mandatory-encryption prompt is opened by `_promptSuperSyncEncryptionIfNeeded()` **after a successful sync**, and it bailed out one-shot if *any* dialog was still open (to avoid competing dialogs). `dialog-sync-cfg.component.ts` `save()` does `close()` (a ~200 ms leave animation) and then fires sync **un-awaited**. Previously the slow upload meant the config dialog had finished closing by the time the prompt fired; now the sync finishes first, so the prompt sees the config dialog still in `openDialogs` and **skips permanently** — the prompt never reappears.

Result: first-time setup finishes with a green "in sync" check but **no encryption configured and nothing uploaded**, and the e2e helper (which waits for that prompt) times out.

Confirmed directly from the failing run's Playwright trace:

```
skipping upload (E2EE mandatory, no key)
Sync complete, status=IN_SYNC          ← ~18ms
_promptSuperSyncEncryptionIfNeeded ... openDialogs=1   ← config dialog still closing
Dialog already open — skipping encryption prompt        ← prompt permanently dropped
```

For SuperSync the config dialog's `save()` does **not** open the encryption dialog itself (it delegates to this post-sync prompt), so this was the only path — hence the hard failure.

Not a security regression: the #8670 goal (no plaintext upload) still holds; nothing is uploaded before a key exists.

## Fix

Make the guard **defer instead of drop**: wait (bounded) for open dialogs to clear, then **re-validate the active provider** and re-check encryption state before prompting. A fast-path avoids waiting on our own prompt dialog. Re-checking the provider after the wait prevents opening the `disableClose` setup dialog for a provider that was switched/disabled while waiting.

## Tests

New regression tests in `sync-wrapper.service.spec.ts` cover: immediate open when no dialog is open, defer-then-open once the dialog closes (#8670), skip when encryption gets configured while waiting, skip when the provider is no longer SuperSync after the wait, and skip when already enabled.

## Notes

- This branch was cut before #8670 landed; it targets `master` (which contains the `isEncryptionMandatory` guard) and touches only `sync-wrapper.service.ts`, so it applies cleanly and actually turns the red `@supersync` CI green.
- SuperSync docker e2e was not runnable in my sandbox; validation is via unit tests + the trace-level root-cause analysis.
- Reviewers also suggested (optional follow-up) swapping the bounded poll loop for `MatDialog.afterAllClosed` + `timeout` to drop a constant and simplify the test mock.
