### PR TITLE
test(sync): arm setup-sync flag so encryption prompt spec exercises dialog path

### DIFF
--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -1839,6 +1839,10 @@ describe('SyncWrapperService', () => {
         privateCfg: { load: privateCfgLoad },
       } as any);
       mockMatDialog.open.and.returnValue({ afterClosed: () => of(undefined) } as any);
+      // Arm the one-shot setup-sync flag the prompt consumes; without it the method
+      // early-returns (the migration banner owns established accounts) and never
+      // evaluates the dialog logic these tests cover.
+      service.markPromptEncryptionAfterSetupSync();
     });
 
     const callPrompt = (): Promise<void> =>

--- a/src/app/op-log/encryption/encryption.browser.spec.ts
+++ b/src/app/op-log/encryption/encryption.browser.spec.ts
@@ -18,6 +18,22 @@ import {
   setArgon2ParamsForTesting,
 } from '@sp/sync-core';
 
+// crypto.subtle is an accessor inherited from Crypto.prototype, not an own
+// property, so getOwnPropertyDescriptor(crypto, 'subtle') returns undefined and
+// stubbing it defines a shadowing OWN property. Restoring must then DELETE that
+// own property to re-expose the prototype getter — merely skipping restore when
+// there was no own descriptor leaks `subtle: undefined` into every later spec in
+// the karma run (isCryptoSubtleAvailable() then returns false suite-wide).
+const restoreCryptoSubtle = (
+  originalDescriptor: PropertyDescriptor | undefined,
+): void => {
+  if (originalDescriptor) {
+    Object.defineProperty(window.crypto, 'subtle', originalDescriptor);
+  } else {
+    delete (window.crypto as { subtle?: unknown }).subtle;
+  }
+};
+
 describe('Encryption (browser smoke)', () => {
   const PASSWORD = 'super_secret_password';
   const DATA = 'some very secret data';
@@ -69,9 +85,7 @@ describe('Encryption (browser smoke)', () => {
       const ct = await encrypt(DATA, PASSWORD);
       expect(await decrypt(ct, PASSWORD)).toBe(DATA);
     } finally {
-      if (originalDescriptor) {
-        Object.defineProperty(window.crypto, 'subtle', originalDescriptor);
-      }
+      restoreCryptoSubtle(originalDescriptor);
     }
   });
 
@@ -89,9 +103,7 @@ describe('Encryption (browser smoke)', () => {
     try {
       expect(await decrypt(ct, PASSWORD)).toBe(DATA);
     } finally {
-      if (originalDescriptor) {
-        Object.defineProperty(window.crypto, 'subtle', originalDescriptor);
-      }
+      restoreCryptoSubtle(originalDescriptor);
     }
   });
 });


### PR DESCRIPTION
The two _promptSuperSyncEncryptionIfNeeded() specs added in #8679 predated the
_shouldPromptEncryptionAfterSetupSync one-shot guard introduced by #8678. After
both merged, the method early-returns unless the flag is armed, so MatDialog.open
was never called and the "opens immediately" / "defers then opens (#8670)" specs
failed. Arm the flag via the public markPromptEncryptionAfterSetupSync() in the
describe beforeEach; this also makes the "does not prompt" specs exercise their
real code paths instead of passing on the early return.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016QwEVhejcpqtTknDqaCNic