### PR TITLE
fix(gitlab): reject bare project slugs in config validation (#8665)

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.spec.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.spec.ts
@@ -29,9 +29,9 @@ describe('GITLAB_PROJECT_REGEX', () => {
       'a.b-c/d_e',
       'group%2Fproject',
       'group%2Fsub%2Fproject',
-      // GitLab allows consecutive hyphens in a path segment; must not be rejected.
-      'foo--bar',
-      'single',
+      // GitLab allows consecutive hyphens in a path segment; must not be rejected
+      // (as long as the reference is still namespace-qualified).
+      'group/foo--bar',
       '12345',
     ];
     validCases.forEach((value) => {
@@ -42,8 +42,9 @@ describe('GITLAB_PROJECT_REGEX', () => {
   });
 
   describe('invalid project identifiers', () => {
-    // Regression for #8665: a display name with a space must be rejected inline
-    // instead of producing a confusing 404 at poll time.
+    // Regression for #8665: both a display name with a space AND a bare
+    // single-segment slug (which the REST API can never resolve, so it 404s at
+    // poll time) must be rejected inline instead.
     const invalidCases = [
       'My Group/My Gitlab',
       'group/Test Gitlab',
@@ -52,6 +53,10 @@ describe('GITLAB_PROJECT_REGEX', () => {
       'trailingSpace ',
       'https://gitlab.com/foo/bar',
       'foo/bar?scope=all',
+      // Missing namespace — the exact value from the #8665 logs.
+      'test_config',
+      'single',
+      'foo--bar',
     ];
     invalidCases.forEach((value) => {
       it(`rejects "${value}"`, () => {

--- a/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-cfg-form.const.ts
@@ -8,14 +8,15 @@ import {
   CROSS_ORIGIN_WARNING,
   ISSUE_PROVIDER_COMMON_FORM_FIELDS,
 } from '../../common-issue-form-stuff.const';
-// Matches either a numeric project ID or a path (namespace/project-slug, or its
-// %2F-encoded form). Anchored at both ends: without a leading `^` the original
-// pattern only matched a valid *tail*, so display names with spaces (e.g.
-// "My Group/My Gitlab") passed validation and produced a 404 at poll time (#8665).
-// This is a "did you paste a display name?" sanity guard, not a strict GitLab
-// path validator, so the char class stays permissive (e.g. accepts consecutive
-// hyphens, which GitLab paths allow) rather than risk false-rejecting valid paths.
-export const GITLAB_PROJECT_REGEX = /^(?:[1-9][0-9]*|[\w%./-]+)$/i;
+// A GitLab project reference is EITHER a numeric project ID OR a namespace-qualified
+// path (`group/project`, subgroups, or the `%2F`-encoded form) — the REST API has no
+// way to resolve a project by a bare slug, so a single-segment name like `test_config`
+// always 404s at poll time (#8665). Require a path separator (`/` or `%2F`) for the
+// non-numeric branch so that mistake gets inline feedback instead. Still permissive
+// about the segment chars (e.g. consecutive hyphens, which GitLab paths allow) to
+// avoid false-rejecting valid paths; the separator lookahead keeps the char class a
+// single unnested quantifier (no catastrophic backtracking).
+export const GITLAB_PROJECT_REGEX = /^(?:[1-9][0-9]*|(?=.*(?:\/|%2F))[\w.%/-]+)$/i;
 
 export const GITLAB_CONFIG_FORM: LimitedFormlyFieldConfig<IssueProviderGitlab>[] = [
   ...CROSS_ORIGIN_WARNING,


### PR DESCRIPTION
## Problem

Fixes #8665. GitLab auto-import fails with a 404 at poll time:

```
GET https://<host>/api/v4/projects/test_config/issues?... → 404
```

The user entered a bare, single-segment project slug (`test_config`). GitLab's REST API can only resolve a project by a **numeric ID** or a **namespace-qualified path** (`group/project`, subgroups, or the `%2F`-encoded form) — a project always lives under a user/group namespace, so a bare slug can never resolve.

The earlier fix #8667 tightened validation to reject pasted *display names* (values with spaces), but its regex `^(?:[1-9][0-9]*|[\w%./-]+)$` still accepts bare slugs like `test_config`, so it didn't cover this case.

## Fix

Require a path separator (`/` or `%2F`) on the non-numeric branch:

```
/^(?:[1-9][0-9]*|(?=.*(?:\/|%2F))[\w.%/-]+)$/i
```

Now a bare slug is flagged inline (Save and Test-Connection are gated on `form.invalid`, and `submit()` guards on `form.valid`), so an already-saved `test_config` is re-flagged when the config dialog is reopened — instead of silently 404ing on every poll. The separator check is a lookahead over a single unnested char class, so no catastrophic backtracking on this per-keystroke validator.

This completes #8667's stated goal ("inline feedback instead of a confusing 404"). It reverses two of that PR's spec assertions (`single`/`foo--bar` were marked valid) because a bare slug 404s regardless of segment-char legality; consecutive-hyphen coverage is preserved via a `group/foo--bar` valid case.

## Verification

- **Live GitLab API** (public, no auth): `/projects/gitlab/issues` → `404 {"message":"404 Project Not Found"}`; `/projects/gitlab-org%2Fgitlab/issues` → `200` + issues; numeric `278964` is the canonical form GitLab emits.
- **Unit tests**: 18/18 pass. Added `test_config` (the exact value from the #8665 logs) plus `single`/`foo--bar` as regression cases; the spec also asserts the form field's `pattern` is the exported regex so it can't silently drift.

## Scope / risk

Config-only, client-side form validation. Not synced state, not a plugin/API or sync format. Existing stored `project` values are not mutated (only re-save is gated). Trivially reversible.

## Note

One follow-up is intentionally left out of scope: an already-broken config still 404s silently at poll time until the dialog is reopened. A clearer GitLab-specific poll-time error ("check the project path/permissions") would help there but touches the shared issue-provider error handler (all providers) — better as a separate change.