### PR TITLE
fix(tasks): refocus add-task input after clicking + button

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.html
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.html
@@ -32,7 +32,7 @@
           <button
             mat-icon-button
             class="switch-add-to-btn e2e-add-task-submit"
-            (click)="addTask()"
+            (click)="onSubmitBtnClick()"
             type="submit"
             [matTooltip]="T.F.TASK.ADD_TASK_BAR.TOOLTIP_ADD_TASK | translate"
             matTooltipPosition="above"

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -434,6 +434,47 @@ describe('AddTaskBarComponent', () => {
     });
   });
 
+  describe('onSubmitBtnClick', () => {
+    it('should add the task and refocus the input for rapid entry', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const focusSpy = spyOn(component, 'focusInput');
+      component.stateService.updateInputTxt('Buy milk');
+      component.stateService.updateCleanText('Buy milk');
+
+      component.onSubmitBtnClick();
+      // Wait for the addTask promise (and its .finally) to settle.
+      await Promise.resolve();
+
+      expect(mockTaskService.add).toHaveBeenCalled();
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
+    it('should refocus the input even when nothing is added', async () => {
+      const focusSpy = spyOn(component, 'focusInput');
+      component.stateService.updateInputTxt('   ');
+
+      component.onSubmitBtnClick();
+      await Promise.resolve();
+
+      expect(mockTaskService.add).not.toHaveBeenCalled();
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
+    it('should NOT refocus for CUSTOM repeat (it opens a dialog)', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const focusSpy = spyOn(component, 'focusInput');
+      component.stateService.updateInputTxt('Buy milk');
+      component.stateService.updateCleanText('Buy milk');
+      component.stateService.updateRepeatSetting('CUSTOM');
+
+      component.onSubmitBtnClick();
+      await Promise.resolve();
+
+      expect(mockTaskService.add).toHaveBeenCalled();
+      expect(focusSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('note panel', () => {
     it('toggleNote should flip the expanded state', () => {
       // focusInput re-focuses the title input, which tries to open the

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -571,6 +571,21 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     }
   }
 
+  onSubmitBtnClick(): void {
+    // Clicking the + button moves focus onto the button, which then vanishes
+    // once the input clears — refocus the input so the next task can be typed
+    // right away. (The Enter-key submit path never loses input focus.)
+    // Skip the refocus for CUSTOM repeat: addTask() opens the repeat-config
+    // dialog asynchronously, and refocusing would steal focus from it.
+    const willOpenRepeatDialog =
+      this.stateService.state().repeatQuickSetting === 'CUSTOM';
+    void this.addTask().finally(() => {
+      if (!willOpenRepeatDialog) {
+        this.focusInput();
+      }
+    });
+  }
+
   onTaskSuggestionActivated(suggestion: AddTaskSuggestion | null): void {
     this.activatedSuggestion$.next(suggestion);
   }


### PR DESCRIPTION
Clicking the + button moved focus onto the button, which unmounts once the input clears, dropping focus to <body>. Route the click through a new onSubmitBtnClick() that refocuses the input after addTask() settles so the next task can be typed right away. The Enter-key path already retained input focus, so it is unchanged.

## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

## Solution

<!-- Describe your changes in detail. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)
