### PR TITLE
refactor(ui): unify primary/secondary action button treatment across dialogs

### DIFF
--- a/docs/styling-guide.md
+++ b/docs/styling-guide.md
@@ -19,6 +19,24 @@
 | Custom z-index values                | Z-index variables (`--z-main-header`, `--z-backdrop`, etc.)               |
 | New styled elements without checking | Check `src/app/ui/` for existing reusable components first                |
 
+## Dialog action buttons
+
+One treatment per role so dialogs feel consistent. Classify by **function, not label** ("Close" that dismisses a read-only view is secondary; "Close" that commits is primary).
+
+| Role                             | Treatment                         | Notes                                                            |
+| -------------------------------- | --------------------------------- | ---------------------------------------------------------------- |
+| Primary / confirming             | `mat-flat-button color="primary"` | Save, OK, Submit, Create, Schedule — the main affirmative action |
+| Cancel / dismiss / secondary     | `mat-button` (no `color`)         | De-emphasized text button                                        |
+| Destructive                      | `color="warn"` (keep the variant) | Delete, Remove, Unschedule — never folded into primary           |
+| Genuine alternative (not cancel) | `mat-stroked-button`              | e.g. "Skip instance", "Configure" next to a primary action       |
+
+Rules:
+
+- **Icons:** drop generic `check`/`close` icons on OK/Cancel/Save/Submit — they add nothing. Keep icons that carry meaning (`alarm`/`today`/`event_busy` in scheduling, `wb_sunny`, `save`, `cloud_upload`, `delete_forever`).
+- **No `color` on cancel/close** — leftover `color="primary"` on a Cancel just tints it; remove it.
+- **No dead classes** — the legacy Bootstrap `btn btn-primary` classes are gone; don't reintroduce them. `submit-button` is only styled inside `dialog-create-tag`.
+- **Symmetric choice dialogs** (e.g. sync "use remote" vs "use local") may use two matched `mat-stroked-button`s — there is no single primary.
+
 ## Key Files
 
 | File                             | Purpose                                                       |

--- a/e2e/pages/supersync.page.ts
+++ b/e2e/pages/supersync.page.ts
@@ -81,16 +81,14 @@ export class SuperSyncPage extends BasePage {
     this.enableEncryptionBtn = page.locator('.e2e-enable-encryption-btn button');
     this.disableEncryptionBtn = page.locator('.e2e-disable-encryption-btn button');
     this.encryptionPasswordInput = page.locator('.e2e-encryptKey input[type="password"]');
-    this.saveBtn = page.locator('mat-dialog-actions button[mat-stroked-button]');
+    this.saveBtn = page.locator('mat-dialog-actions button[mat-flat-button]');
     this.syncSpinner = page.locator('.sync-btn mat-icon.spin');
     this.syncCheckIcon = page.locator('.sync-btn mat-icon.sync-state-ico');
     // Error state shows sync_problem icon (no special class, just the icon name)
     this.syncErrorIcon = page.locator('.sync-btn mat-icon:has-text("sync_problem")');
     // Fresh client confirmation dialog elements
     this.freshClientDialog = page.locator('dialog-confirm');
-    this.freshClientConfirmBtn = page.locator(
-      'dialog-confirm button[mat-stroked-button]',
-    );
+    this.freshClientConfirmBtn = page.locator('dialog-confirm button[mat-flat-button]');
     // Conflict resolution dialog elements
     this.conflictDialog = page.locator('dialog-conflict-resolution');
     this.conflictUseRemoteBtn = page.locator(

--- a/e2e/pages/sync.page.ts
+++ b/e2e/pages/sync.page.ts
@@ -23,7 +23,7 @@ export class SyncPage extends BasePage {
     this.userNameInput = page.locator('.e2e-userName input');
     this.passwordInput = page.locator('.e2e-password input');
     this.syncFolderInput = page.locator('.e2e-syncFolderPath input');
-    this.saveBtn = page.locator('mat-dialog-actions button[mat-stroked-button]');
+    this.saveBtn = page.locator('mat-dialog-actions button[mat-flat-button]');
     this.syncSpinner = page.locator('.sync-btn mat-icon.spin');
     this.syncCheckIcon = page.locator('.sync-btn mat-icon.sync-state-ico');
     // Encryption-related locators

--- a/e2e/tests/sync/supersync-archive-subtasks.spec.ts
+++ b/e2e/tests/sync/supersync-archive-subtasks.spec.ts
@@ -94,7 +94,7 @@ const markTaskDone = async (
 
   // Handle confirmation dialog if it appears (when marking parent with undone subtasks)
   await page.waitForTimeout(200);
-  const confirmBtn = page.locator('dialog-confirm button[mat-stroked-button]');
+  const confirmBtn = page.locator('dialog-confirm button[mat-flat-button]');
   if (await confirmBtn.isVisible().catch(() => false)) {
     await confirmBtn.click();
   }

--- a/e2e/tests/sync/webdav-sync-archive.spec.ts
+++ b/e2e/tests/sync/webdav-sync-archive.spec.ts
@@ -583,7 +583,7 @@ test.describe('@webdav WebDAV Archive Sync', () => {
     // Handle potential confirmation dialog for marking parent done
     const confirmDialog = pageA.locator('dialog-confirm');
     if (await confirmDialog.isVisible().catch(() => false)) {
-      await confirmDialog.locator('button[mat-stroked-button]').click();
+      await confirmDialog.locator('button[mat-flat-button]').click();
       await pageA.waitForTimeout(200);
     }
 

--- a/src/app/core/share/dialog-share/dialog-share.component.html
+++ b/src/app/core/share/dialog-share/dialog-share.component.html
@@ -5,7 +5,7 @@
     <!-- Native Share Button (if available) -->
     @if (data.showNative) {
       <button
-        mat-raised-button
+        mat-flat-button
         color="primary"
         class="share-target-button native-button"
         (click)="shareNative()"

--- a/src/app/features/boards/board-edit/board-edit.component.html
+++ b/src/app/features/boards/board-edit/board-edit.component.html
@@ -20,9 +20,8 @@
     <button
       [disabled]="!form.valid"
       (click)="save()"
-      class="btn btn-primary submit-button"
       color="primary"
-      mat-raised-button
+      mat-flat-button
       type="submit"
     >
       <mat-icon>save</mat-icon>

--- a/src/app/features/boards/dialog-board-edit/dialog-board-edit.component.html
+++ b/src/app/features/boards/dialog-board-edit/dialog-board-edit.component.html
@@ -13,7 +13,6 @@
 <mat-dialog-actions align="end">
   <button
     (click)="close()"
-    color="primary"
     mat-button
   >
     {{ T.G.CANCEL | translate }}
@@ -31,9 +30,8 @@
   <button
     [disabled]="!boarEditCmp()?.form.valid"
     (click)="save()"
-    class="btn btn-primary submit-button"
     color="primary"
-    mat-raised-button
+    mat-flat-button
     type="submit"
   >
     <mat-icon>save</mat-icon>

--- a/src/app/features/config/clipboard-images-cfg/dialog-clipboard-images-manager/dialog-clipboard-images-manager.component.html
+++ b/src/app/features/config/clipboard-images-cfg/dialog-clipboard-images-manager/dialog-clipboard-images-manager.component.html
@@ -100,8 +100,7 @@
   }
   <button
     (click)="close()"
-    color="primary"
-    mat-stroked-button
+    mat-button
   >
     {{ T.G.CLOSE | translate }}
   </button>

--- a/src/app/features/finish-day-before-close/dialog-finish-day-before-close/dialog-finish-day-before-close.component.html
+++ b/src/app/features/finish-day-before-close/dialog-finish-day-before-close/dialog-finish-day-before-close.component.html
@@ -10,7 +10,6 @@
       mat-button
       type="button"
     >
-      <mat-icon>close</mat-icon>
       {{ T.F.FINISH_DAY_BEFORE_EXIT.C.DONT_QUIT | translate }}
     </button>
     <button
@@ -24,13 +23,11 @@
     <button
       (click)="close('finish-day')"
       e2e="finishDayBtn"
-      class="submit-button"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
       type="button"
       cdkFocusInitial
     >
-      <mat-icon>check</mat-icon>
       {{ T.F.FINISH_DAY_BEFORE_EXIT.C.FINISH_DAY | translate }}
     </button>
   </div>

--- a/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.html
+++ b/src/app/features/focus-mode/dialog-flowtime-settings/dialog-flowtime-settings.component.html
@@ -17,7 +17,7 @@
       {{ T.G.CANCEL | translate }}
     </button>
     <button
-      mat-button
+      mat-flat-button
       color="primary"
       (click)="save()"
     >

--- a/src/app/features/idle/dialog-idle/dialog-idle.component.html
+++ b/src/app/features/idle/dialog-idle/dialog-idle.component.html
@@ -244,7 +244,7 @@
       <button
         [disabled]="!isConfirmEnabled"
         color="primary"
-        mat-stroked-button
+        mat-flat-button
         type="submit"
       >
         <mat-icon>{{ confirmIcon }}</mat-icon>

--- a/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.html
+++ b/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.html
@@ -248,7 +248,6 @@
   <mat-dialog-actions align="end">
     <button
       (click)="cancel()"
-      color="primary"
       mat-button
       type="button"
     >
@@ -296,7 +295,7 @@
     }
     <button
       color="primary"
-      mat-stroked-button
+      mat-flat-button
       type="submit"
       [disabled]="form.invalid"
     >

--- a/src/app/features/issue/providers/gitlab/dialog-gitlab-submit-worklog-for-day/dialog-gitlab-submit-worklog-for-day.component.html
+++ b/src/app/features/issue/providers/gitlab/dialog-gitlab-submit-worklog-for-day/dialog-gitlab-submit-worklog-for-day.component.html
@@ -116,7 +116,6 @@
 <mat-dialog-actions align="end">
   <button
     (click)="close()"
-    color="primary"
     mat-button
     type="button"
   >
@@ -125,7 +124,7 @@
 
   <button
     color="primary"
-    mat-stroked-button
+    mat-flat-button
     type="button"
     (click)="submit()"
   >

--- a/src/app/features/issue/providers/jira/jira-view-components/dialog-jira-transition/dialog-jira-transition.component.html
+++ b/src/app/features/issue/providers/jira/jira-view-components/dialog-jira-transition/dialog-jira-transition.component.html
@@ -44,8 +44,6 @@
   <div class="wrap-buttons">
     <button
       (click)="close()"
-      class="btn btn-primary submit-button"
-      color="primary"
       mat-button
       type="button"
     >
@@ -53,9 +51,8 @@
     </button>
     <button
       (click)="transitionIssue()"
-      class="btn btn-primary submit-button"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
     >
       {{ T.F.JIRA.DIALOG_TRANSITION.TITLE | translate }}
     </button>

--- a/src/app/features/issue/providers/open-project/open-project-view-components/dialog-openproject-transition/dialog-open-project-transition.component.html
+++ b/src/app/features/issue/providers/open-project/open-project-view-components/dialog-openproject-transition/dialog-open-project-transition.component.html
@@ -70,8 +70,6 @@
   <div class="wrap-buttons">
     <button
       (click)="close()"
-      class="btn btn-primary submit-button"
-      color="primary"
       mat-button
       type="button"
     >
@@ -79,9 +77,8 @@
     </button>
     <button
       (click)="transitionIssue()"
-      class="btn btn-primary submit-button"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
     >
       {{ T.F.OPEN_PROJECT.DIALOG_TRANSITION.TITLE | translate }}
     </button>

--- a/src/app/features/issue/shared/dialog-track-time/dialog-track-time.component.html
+++ b/src/app/features/issue/shared/dialog-track-time/dialog-track-time.component.html
@@ -138,7 +138,6 @@
     <div class="wrap-buttons">
       <button
         (click)="close()"
-        color="primary"
         mat-button
         type="button"
       >
@@ -146,7 +145,7 @@
       </button>
       <button
         color="primary"
-        mat-stroked-button
+        mat-flat-button
         type="submit"
       >
         <mat-icon>save</mat-icon>

--- a/src/app/features/metric/dialog-focus-session-edit/dialog-focus-session-edit.component.html
+++ b/src/app/features/metric/dialog-focus-session-edit/dialog-focus-session-edit.component.html
@@ -117,7 +117,7 @@
       {{ T.G.CANCEL | translate }}
     </button>
     <button
-      mat-stroked-button
+      mat-flat-button
       color="primary"
       type="submit"
     >

--- a/src/app/features/metric/dialog-productivity-breakdown/dialog-productivity-breakdown.component.html
+++ b/src/app/features/metric/dialog-productivity-breakdown/dialog-productivity-breakdown.component.html
@@ -60,8 +60,7 @@
   align="end"
 >
   <button
-    mat-flat-button
-    color="primary"
+    mat-button
     (click)="close()"
   >
     {{ T.G.CLOSE | translate }}

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
@@ -60,7 +60,7 @@
         }
         <button
           color="primary"
-          mat-stroked-button
+          mat-flat-button
           [disabled]="!selectedDate"
           (click)="submit()"
           type="button"
@@ -76,8 +76,7 @@
       </div>
       <button
         class="dialog-cancel-btn"
-        mat-stroked-button
-        color="default"
+        mat-button
         (click)="close()"
         type="button"
         data-test-id="schedule-cancel-btn"

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
@@ -62,10 +62,6 @@ mat-dialog-content {
   text-align: center;
 }
 
-.mat-stroked-button {
-  height: auto;
-}
-
 .schedule-actions button:not(:last-child) {
   margin-right: var(--s-quarter);
 }

--- a/src/app/features/project/dialogs/create-project/dialog-create-project.component.html
+++ b/src/app/features/project/dialogs/create-project/dialog-create-project.component.html
@@ -26,8 +26,6 @@
     <div class="wrap-buttons">
       <button
         (click)="cancelEdit()"
-        class="btn btn-primary submit-button"
-        color="primary"
         mat-button
         type="button"
       >
@@ -35,9 +33,8 @@
       </button>
       <button
         [disabled]="!formBasic.valid"
-        class="btn btn-primary submit-button"
         color="primary"
-        mat-stroked-button
+        mat-flat-button
         type="submit"
       >
         {{ T.G.SAVE | translate }}

--- a/src/app/features/simple-counter/dialog-simple-counter-edit-settings/dialog-simple-counter-edit-settings.component.html
+++ b/src/app/features/simple-counter/dialog-simple-counter-edit-settings/dialog-simple-counter-edit-settings.component.html
@@ -34,7 +34,7 @@
       {{ T.G.CANCEL | translate }}
     </button>
     <button
-      mat-stroked-button
+      mat-flat-button
       color="primary"
       type="submit"
       [disabled]="!isDirty()"

--- a/src/app/features/simple-counter/dialog-simple-counter-edit/dialog-simple-counter-edit.component.html
+++ b/src/app/features/simple-counter/dialog-simple-counter-edit/dialog-simple-counter-edit.component.html
@@ -107,7 +107,7 @@
       {{ T.G.CANCEL | translate }}
     </button>
     <button
-      mat-stroked-button
+      mat-flat-button
       color="primary"
       type="submit"
     >

--- a/src/app/features/tag/dialog-edit-tags/dialog-edit-tags-for-task.component.html
+++ b/src/app/features/tag/dialog-edit-tags/dialog-edit-tags-for-task.component.html
@@ -26,11 +26,9 @@
 <mat-dialog-actions align="end">
   <button
     (click)="close()"
-    color="primary"
-    mat-stroked-button
+    mat-button
     type="submit"
   >
-    <mat-icon>close</mat-icon>
     {{ T.G.CLOSE | translate }}
   </button>
 </mat-dialog-actions>

--- a/src/app/features/tag/dialog-edit-tags/dialog-edit-tags-for-task.component.ts
+++ b/src/app/features/tag/dialog-edit-tags/dialog-edit-tags-for-task.component.ts
@@ -17,7 +17,6 @@ import { Observable, Subscription } from 'rxjs';
 import { Tag } from '../tag.model';
 import { ChipListInputComponent } from '../../../ui/chip-list-input/chip-list-input.component';
 import { MatButton } from '@angular/material/button';
-import { MatIcon } from '@angular/material/icon';
 import { AsyncPipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
 import { Store } from '@ngrx/store';
@@ -35,7 +34,6 @@ import { addTag } from '../store/tag.actions';
     ChipListInputComponent,
     MatDialogActions,
     MatButton,
-    MatIcon,
     AsyncPipe,
     TranslatePipe,
   ],

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.html
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.html
@@ -87,7 +87,6 @@
       (click)="close()"
       [attr.aria-label]="T.G.CANCEL | translate"
       class="icon-on-small"
-      color="primary"
       mat-button
       type="button"
     >
@@ -133,7 +132,7 @@
       [attr.aria-describedby]="isWeekdaySelectionInvalid() ? 'weekday-error' : null"
       class="icon-on-small"
       color="primary"
-      mat-raised-button
+      mat-flat-button
       type="submit"
     >
       <mat-icon>save</mat-icon>

--- a/src/app/features/tasks/dialog-add-time-estimate-for-other-day/dialog-add-time-estimate-for-other-day.component.html
+++ b/src/app/features/tasks/dialog-add-time-estimate-for-other-day/dialog-add-time-estimate-for-other-day.component.html
@@ -44,7 +44,6 @@
     <mat-dialog-actions align="end">
       <button
         [mat-dialog-close]="true"
-        color="primary"
         mat-button
         type="button"
       >
@@ -53,7 +52,7 @@
 
       <button
         color="primary"
-        mat-stroked-button
+        mat-flat-button
         type="submit"
         [disabled]="!newEntry.timeSpent || !newEntry.date"
       >

--- a/src/app/features/tasks/dialog-deadline/dialog-deadline.component.html
+++ b/src/app/features/tasks/dialog-deadline/dialog-deadline.component.html
@@ -32,7 +32,7 @@
       }
       <button
         color="primary"
-        mat-stroked-button
+        mat-flat-button
         [disabled]="!selectedDate"
         (click)="submit()"
         type="button"
@@ -43,8 +43,7 @@
     </div>
     <button
       class="dialog-cancel-btn"
-      mat-stroked-button
-      color="default"
+      mat-button
       (click)="close()"
       type="button"
     >

--- a/src/app/features/tasks/dialog-select-date-time/dialog-select-date-time.component.html
+++ b/src/app/features/tasks/dialog-select-date-time/dialog-select-date-time.component.html
@@ -42,13 +42,12 @@
   <button
     mat-button
     type="button"
-    color="primary"
     mat-dialog-close
   >
     {{ T.G.CANCEL | translate }}
   </button>
   <button
-    mat-stroked-button
+    mat-flat-button
     type="button"
     color="primary"
     [disabled]="!hasDateTime()"

--- a/src/app/features/tasks/dialog-time-estimate/dialog-time-estimate.component.html
+++ b/src/app/features/tasks/dialog-time-estimate/dialog-time-estimate.component.html
@@ -75,7 +75,6 @@
     <mat-dialog-actions align="end">
       <button
         [mat-dialog-close]="true"
-        color="primary"
         mat-button
         type="button"
       >
@@ -85,7 +84,7 @@
       <button
         (click)="submit()"
         color="primary"
-        mat-stroked-button
+        mat-flat-button
         type="submit"
       >
         <mat-icon>save</mat-icon>

--- a/src/app/features/tasks/task-attachment/dialog-edit-attachment/dialog-edit-task-attachment.component.html
+++ b/src/app/features/tasks/task-attachment/dialog-edit-attachment/dialog-edit-task-attachment.component.html
@@ -54,7 +54,6 @@
   <mat-dialog-actions align="end">
     <button
       (click)="close()"
-      color="primary"
       mat-button
       type="button"
     >
@@ -64,7 +63,7 @@
     <button
       [disabled]="!form.valid"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
       type="submit"
     >
       <mat-icon>save</mat-icon>

--- a/src/app/features/tracking-reminder/dialog-tracking-reminder/dialog-tracking-reminder.component.html
+++ b/src/app/features/tracking-reminder/dialog-tracking-reminder/dialog-tracking-reminder.component.html
@@ -31,18 +31,16 @@
   >
     <button
       (click)="cancel()"
-      color=""
       mat-button
       type="button"
     >
-      <mat-icon>close</mat-icon>
       {{ T.G.CANCEL | translate }}
     </button>
 
     <button
       [disabled]="!(selectedTask || newTaskTitle)"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
       type="submit"
     >
       @if (!isCreate) {

--- a/src/app/features/user-profile/dialog-user-profile-management/dialog-user-profile-management.component.html
+++ b/src/app/features/user-profile/dialog-user-profile-management/dialog-user-profile-management.component.html
@@ -15,7 +15,7 @@
         />
       </mat-form-field>
       <button
-        mat-raised-button
+        mat-flat-button
         color="primary"
         (click)="createProfile()"
         [disabled]="!newProfileName() || isCreating()"

--- a/src/app/features/work-context/dialog-work-context-settings/dialog-work-context-settings.component.html
+++ b/src/app/features/work-context/dialog-work-context-settings/dialog-work-context-settings.component.html
@@ -16,8 +16,6 @@
   <div class="wrap-buttons">
     <button
       (click)="cancelEdit()"
-      class="btn btn-primary submit-button"
-      color="primary"
       mat-button
       type="button"
     >
@@ -25,9 +23,8 @@
     </button>
     <button
       (click)="done()"
-      class="btn btn-primary submit-button"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
       type="button"
     >
       {{ T.G.SAVE | translate }}

--- a/src/app/features/worklog/worklog-export/worklog-export.component.html
+++ b/src/app/features/worklog/worklog-export/worklog-export.component.html
@@ -212,8 +212,7 @@
   @if (isShowClose()) {
     <button
       (click)="onCloseClick()"
-      color="primary"
-      mat-stroked-button
+      mat-button
       type="button"
     >
       {{ T.G.CLOSE | translate }}

--- a/src/app/imex/dialog-confirm-url-import/dialog-confirm-url-import.component.html
+++ b/src/app/imex/dialog-confirm-url-import/dialog-confirm-url-import.component.html
@@ -21,13 +21,13 @@
 </mat-dialog-content>
 <mat-dialog-actions align="end">
   <button
-    mat-stroked-button
+    mat-button
     (click)="onCancel()"
   >
     {{ T.G.CANCEL | translate }}
   </button>
   <button
-    mat-raised-button
+    mat-flat-button
     color="primary"
     (click)="onConfirm()"
   >

--- a/src/app/imex/dialog-confirm-url-import/dialog-confirm-url-import.component.spec.ts
+++ b/src/app/imex/dialog-confirm-url-import/dialog-confirm-url-import.component.spec.ts
@@ -120,9 +120,7 @@ describe('ConfirmUrlImportDialogComponent', () => {
     it('should call onCancel when cancel button is clicked', () => {
       spyOn(component, 'onCancel');
 
-      const cancelButton = fixture.debugElement.query(
-        By.css('button[mat-stroked-button]'),
-      );
+      const cancelButton = fixture.debugElement.query(By.css('button[mat-button]'));
       cancelButton.nativeElement.click();
 
       expect(component.onCancel).toHaveBeenCalled();
@@ -180,14 +178,12 @@ describe('ConfirmUrlImportDialogComponent', () => {
   describe('accessibility and template structure', () => {
     it('should have proper button types and attributes', () => {
       const confirmButton = fixture.debugElement.query(By.css('button[color="primary"]'));
-      const cancelButton = fixture.debugElement.query(
-        By.css('button[mat-stroked-button]'),
-      );
+      const cancelButton = fixture.debugElement.query(By.css('button[mat-button]'));
 
-      expect(confirmButton.nativeElement.hasAttribute('mat-raised-button')).toBe(true);
+      expect(confirmButton.nativeElement.hasAttribute('mat-flat-button')).toBe(true);
       expect(confirmButton.attributes['color']).toBe('primary');
 
-      expect(cancelButton.nativeElement.hasAttribute('mat-stroked-button')).toBe(true);
+      expect(cancelButton.nativeElement.hasAttribute('mat-button')).toBe(true);
       expect(cancelButton.attributes['color']).toBeUndefined();
     });
 

--- a/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.html
+++ b/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.html
@@ -28,7 +28,7 @@
     {{ T.G.CANCEL | translate }}
   </button>
   <button
-    mat-raised-button
+    mat-flat-button
     color="primary"
     (click)="submit()"
     [disabled]="!url() || url().trim() === '' || urlCtrl.invalid"

--- a/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.spec.ts
+++ b/src/app/imex/dialog-import-from-url/dialog-import-from-url.component.spec.ts
@@ -379,7 +379,7 @@ describe('DialogImportFromUrlComponent', () => {
         By.css('button:not([color="primary"])'),
       );
 
-      expect(submitButton.nativeElement.hasAttribute('mat-raised-button')).toBe(true);
+      expect(submitButton.nativeElement.hasAttribute('mat-flat-button')).toBe(true);
       expect(cancelButton.nativeElement.hasAttribute('mat-button')).toBe(true);
     });
   });

--- a/src/app/imex/sync/dialog-get-and-enter-auth-code/dialog-get-and-enter-auth-code.component.html
+++ b/src/app/imex/sync/dialog-get-and-enter-auth-code/dialog-get-and-enter-auth-code.component.html
@@ -72,7 +72,6 @@
   <div class="wrap-buttons">
     <button
       (click)="close()"
-      color="primary"
       mat-button
     >
       {{ T.G.CANCEL | translate }}
@@ -82,7 +81,7 @@
         (click)="close(token)"
         [disabled]="!token"
         color="primary"
-        mat-stroked-button
+        mat-flat-button
       >
         <mat-icon>save</mat-icon>
         {{ T.G.SAVE | translate }}

--- a/src/app/imex/sync/dialog-handle-decrypt-error/dialog-handle-decrypt-error.component.html
+++ b/src/app/imex/sync/dialog-handle-decrypt-error/dialog-handle-decrypt-error.component.html
@@ -24,7 +24,6 @@
           [innerHTML]="T.F.SYNC.D_DECRYPT_ERROR.P2_FORGOT_PW | translate"
         ></p>
         <button
-          class="btn btn-primary submit-button"
           mat-flat-button
           color="primary"
           (click)="formEl.valid && updatePwAndResync()"
@@ -62,11 +61,9 @@
   <div class="wrap-buttons">
     <button
       (click)="cancel()"
-      class="btn btn-primary submit-button"
       mat-button
       type="button"
     >
-      <mat-icon>close</mat-icon>
       {{ T.G.CANCEL | translate }}
     </button>
   </div>

--- a/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.html
+++ b/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.html
@@ -26,7 +26,7 @@
       [disabled]="!form.valid"
       (click)="save()"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
     >
       <mat-icon>save</mat-icon>
       {{

--- a/src/app/pages/config-page/config-page.component.html
+++ b/src/app/pages/config-page/config-page.component.html
@@ -194,7 +194,7 @@
                   <button
                     (click)="openSyncCfgDialog()"
                     color="primary"
-                    mat-raised-button
+                    mat-flat-button
                     type="button"
                   >
                     <mat-icon>cloud_sync</mat-icon>
@@ -223,7 +223,7 @@
                   <button
                     (click)="triggerSync()"
                     color="primary"
-                    mat-raised-button
+                    mat-flat-button
                     type="button"
                   >
                     <mat-icon>sync</mat-icon>

--- a/src/app/ui/dialog-confirm/dialog-confirm.component.html
+++ b/src/app/ui/dialog-confirm/dialog-confirm.component.html
@@ -26,12 +26,10 @@
         tabindex="1"
         #cancelButton
         (click)="close(false)"
-        class="btn btn-primary"
         mat-button
         type="button"
         (keydown.ArrowRight)="focusNextButton(confirmButton)"
       >
-        <mat-icon>close</mat-icon>
         {{ data.cancelTxt || T.G.CANCEL | translate }}
       </button>
     }
@@ -41,13 +39,11 @@
       #confirmButton
       (click)="close(true)"
       e2e="confirmBtn"
-      class="btn btn-primary submit-button"
       color="primary"
       type="button"
-      mat-stroked-button
+      mat-flat-button
       (keydown.ArrowLeft)="!data.hideCancelButton && focusCancelButton()"
     >
-      <mat-icon>check</mat-icon>
       {{ data.okTxt || T.G.OK | translate }}
     </button>
   </div>

--- a/src/app/ui/dialog-create-tag/dialog-create-tag.component.html
+++ b/src/app/ui/dialog-create-tag/dialog-create-tag.component.html
@@ -56,22 +56,20 @@
   <div class="wrap-buttons">
     <button
       (click)="close(false)"
-      class="btn btn-primary submit-button"
+      class="submit-button"
       mat-button
       type="button"
     >
-      <mat-icon>close</mat-icon>
       {{ T.G.CANCEL | translate }}
     </button>
 
     <button
       (click)="close(true)"
-      class="btn btn-primary submit-button"
+      class="submit-button"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
       [disabled]="!title.trim()"
     >
-      <mat-icon>check</mat-icon>
       {{ T.G.SAVE | translate }}
     </button>
   </div>

--- a/src/app/ui/dialog-logs/dialog-logs.component.html
+++ b/src/app/ui/dialog-logs/dialog-logs.component.html
@@ -14,18 +14,15 @@
   <div class="wrap-buttons">
     <button
       (click)="close()"
-      class="btn"
       mat-button
       type="button"
     >
-      <mat-icon>close</mat-icon>
       {{ T.G.CLOSE | translate }}
     </button>
 
     @if (isNative) {
       <button
         (click)="shareFile()"
-        class="btn"
         mat-button
         type="button"
       >
@@ -36,9 +33,8 @@
 
     <button
       (click)="copy()"
-      class="btn submit-button"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
       type="button"
     >
       <mat-icon>content_copy</mat-icon>

--- a/src/app/ui/dialog-prompt/dialog-prompt.component.html
+++ b/src/app/ui/dialog-prompt/dialog-prompt.component.html
@@ -41,21 +41,17 @@
   <div class="wrap-buttons">
     <button
       (click)="close(false)"
-      class="btn btn-primary submit-button"
       mat-button
       type="button"
     >
-      <mat-icon>close</mat-icon>
       {{ data.cancelTxt || T.G.CANCEL | translate }}
     </button>
 
     <button
       (click)="close(true)"
-      class="btn btn-primary submit-button"
       color="primary"
-      mat-stroked-button
+      mat-flat-button
     >
-      <mat-icon>check</mat-icon>
       {{ data.saveTxt || T.G.SAVE | translate }}
     </button>
   </div>

--- a/src/app/ui/dialog-prompt/dialog-prompt.component.ts
+++ b/src/app/ui/dialog-prompt/dialog-prompt.component.ts
@@ -10,7 +10,6 @@ import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
-import { MatIcon } from '@angular/material/icon';
 import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
@@ -26,7 +25,6 @@ import { TranslatePipe } from '@ngx-translate/core';
     FormsModule,
     MatDialogActions,
     MatButton,
-    MatIcon,
     TranslatePipe,
   ],
 })


### PR DESCRIPTION
Closes #8683

Standardizes dialog action buttons app-wide so dialogs feel consistent:

- **Primary / confirming** (Save/OK/Submit/Create/Schedule) → `mat-flat-button color="primary"`
- **Cancel / dismiss / secondary** → `mat-button` (no `color`)
- **Destructive** → `color="warn"` (variant kept)
- **Genuine alternative** (Skip instance, Configure) → `mat-stroked-button`
- Dropped dead Bootstrap `btn btn-primary` classes and decorative `check`/`close` icons; kept meaningful icons (alarm/today/save/cloud_upload/…)
- Symmetric-choice dialogs (sync use-remote vs use-local) keep two matched stroked buttons
- Convention documented in `docs/styling-guide.md`

Also:
- Updated e2e page-objects/specs and two co-located unit specs that keyed on the old stroked/raised variants
- Removed two now-unused `MatIcon` imports and one orphaned `.mat-stroked-button` SCSS override

Scope: 49 files — template-only changes plus test/selector updates and docs.

**Verification**
- prettier / eslint / `checkFile` clean on all changed files
- Unit specs for the changed dialogs pass (dialog-confirm 17/17, create-tag 3/3, schedule-task 13/13, confirm-url-import 20/20, import-from-url 35/35, flowtime-settings 16/16)
- Reviewed twice via independent sub-agents (approved); no functional attributes dropped, no residual `btn btn-primary` or `mat-raised-button` in dialogs

_Note: change is verified for compilation + tests; not yet visually diffed across all dialogs._