### PR TITLE
fix(sync): scan all tags when archiving to avoid dangling tag refs

### DIFF
--- a/src/app/root-store/meta/task-shared-meta-reducers/project-shared.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/project-shared.reducer.ts
@@ -3,23 +3,20 @@ import { Update } from '@ngrx/entity';
 import { RootState } from '../../root-state';
 import { TaskSharedActions } from '../task-shared.actions';
 import { PROJECT_FEATURE_NAME } from '../../../features/project/store/project.reducer';
-import { TAG_FEATURE_NAME } from '../../../features/tag/store/tag.reducer';
 import {
   TASK_FEATURE_NAME,
   taskAdapter,
 } from '../../../features/tasks/store/task.reducer';
 import { TIME_TRACKING_FEATURE_KEY } from '../../../features/time-tracking/store/time-tracking.reducer';
 import { TimeTrackingState } from '../../../features/time-tracking/time-tracking.model';
-import { Tag } from '../../../features/tag/tag.model';
 import { Task, TaskWithSubTasks } from '../../../features/tasks/task.model';
 import { unique } from '../../../util/unique';
 import {
   ActionHandlerMap,
   getProject,
-  getTag,
+  removeTasksFromAllTags,
   removeTasksFromList,
   updateProject,
-  updateTags,
 } from './task-shared-helpers';
 import { TASK_REPEAT_CFG_FEATURE_NAME } from '../../../features/task-repeat-cfg/store/task-repeat-cfg.selectors';
 import { TaskRepeatCfgState } from '../../../features/task-repeat-cfg/task-repeat-cfg.model';
@@ -140,17 +137,9 @@ const handleDeleteProject = (
   projectId: string,
   allTaskIds: string[],
 ): ExtendedState => {
-  const tagUpdates = (state[TAG_FEATURE_NAME].ids as string[]).map(
-    (tagId): Update<Tag> => ({
-      id: tagId,
-      changes: {
-        taskIds: removeTasksFromList(getTag(state, tagId).taskIds, allTaskIds),
-      },
-    }),
-  );
-
-  // First update tags
-  const stateWithUpdatedTags = updateTags(state, tagUpdates) as ExtendedState;
+  // First strip the deleted project's tasks from every tag (same all-tags
+  // scan the delete/archive paths use — handles one-sided refs after sync).
+  const stateWithUpdatedTags = removeTasksFromAllTags(state, allTaskIds) as ExtendedState;
 
   // Cleanup TIME_TRACKING for deleted project
   const updatedTimeTracking = cleanupTimeTrackingForProject(

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -39,6 +39,7 @@ import {
   ProjectTaskList,
   filterOutTodayTag,
   removeTaskFromPlannerDays,
+  removeTasksFromAllTags,
   removeTasksFromList,
   TaskWithTags,
   updateProject,
@@ -138,28 +139,6 @@ const handleAddTask = (
   }
 
   return updatedState;
-};
-
-/**
- * Removes the given task IDs from every tag's `taskIds`. Scans all tags from
- * the CURRENT state (not a payload-provided list) so sync replays with
- * divergent tag associations are fully cleaned up. Uses a Set for O(1) lookup.
- * Returns state unchanged when no tag references the tasks.
- */
-const removeTasksFromAllTags = (state: RootState, taskIds: string[]): RootState => {
-  const taskIdSet = new Set(taskIds);
-  const tagUpdates = (state[TAG_FEATURE_NAME].ids as string[])
-    .map((tagId) => state[TAG_FEATURE_NAME].entities[tagId])
-    .filter((tag): tag is Tag => !!tag && tag.taskIds.some((id) => taskIdSet.has(id)))
-    .map(
-      (tag): Update<Tag> => ({
-        id: tag.id,
-        changes: {
-          taskIds: removeTasksFromList(tag.taskIds, taskIds),
-        },
-      }),
-    );
-  return updateTags(state, tagUpdates);
 };
 
 const handleConvertToMainTask = (

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-helpers.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-helpers.ts
@@ -46,6 +46,34 @@ export const updateTags = (state: RootState, updates: Update<Tag>[]): RootState 
   [TAG_FEATURE_NAME]: tagAdapter.updateMany(updates, state[TAG_FEATURE_NAME]),
 });
 
+/**
+ * Removes the given task IDs from every tag's `taskIds`. Scans ALL tags from
+ * the CURRENT state (not a payload-provided list or the task's own `tagIds`)
+ * so sync replays with divergent tag associations are fully cleaned up: a
+ * receiving client can hold a one-sided `tag.taskIds` → task reference even
+ * when the task's own `tagIds` omits that tag, and only scanning `tagIds`
+ * would leave it dangling. Uses a Set for O(1) lookup; tags that reference
+ * none of the ids are left untouched.
+ */
+export const removeTasksFromAllTags = (
+  state: RootState,
+  taskIds: string[],
+): RootState => {
+  const taskIdSet = new Set(taskIds);
+  const tagUpdates = (state[TAG_FEATURE_NAME].ids as string[])
+    .map((tagId) => state[TAG_FEATURE_NAME].entities[tagId])
+    .filter((tag): tag is Tag => !!tag && tag.taskIds.some((id) => taskIdSet.has(id)))
+    .map(
+      (tag): Update<Tag> => ({
+        id: tag.id,
+        changes: {
+          taskIds: removeTasksFromList(tag.taskIds, taskIds),
+        },
+      }),
+    );
+  return updateTags(state, tagUpdates);
+};
+
 // =============================================================================
 // ENTITY GETTERS
 // =============================================================================
@@ -106,32 +134,6 @@ export const removeTasksFromList = (taskIds: string[], toRemove: string[]): stri
   // This changes overall complexity from O(n*m) to O(n+m)
   const removeSet = new Set(toRemove);
   return taskIds.filter((id) => !removeSet.has(id));
-};
-
-/**
- * Removes the given task IDs from every tag's `taskIds`. Scans ALL tags from
- * the CURRENT state (not a payload-provided list or the task's own `tagIds`)
- * so sync replays with divergent/one-sided tag associations are fully cleaned
- * up. Uses a Set for O(1) lookup. Returns state unchanged when no tag
- * references the tasks.
- */
-export const removeTasksFromAllTags = (
-  state: RootState,
-  taskIds: string[],
-): RootState => {
-  const taskIdSet = new Set(taskIds);
-  const tagUpdates = (state[TAG_FEATURE_NAME].ids as string[])
-    .map((tagId) => state[TAG_FEATURE_NAME].entities[tagId])
-    .filter((tag): tag is Tag => !!tag && tag.taskIds.some((id) => taskIdSet.has(id)))
-    .map(
-      (tag): Update<Tag> => ({
-        id: tag.id,
-        changes: {
-          taskIds: removeTasksFromList(tag.taskIds, taskIds),
-        },
-      }),
-    );
-  return updateTags(state, tagUpdates);
 };
 
 // =============================================================================

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-helpers.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-helpers.ts
@@ -108,6 +108,32 @@ export const removeTasksFromList = (taskIds: string[], toRemove: string[]): stri
   return taskIds.filter((id) => !removeSet.has(id));
 };
 
+/**
+ * Removes the given task IDs from every tag's `taskIds`. Scans ALL tags from
+ * the CURRENT state (not a payload-provided list or the task's own `tagIds`)
+ * so sync replays with divergent/one-sided tag associations are fully cleaned
+ * up. Uses a Set for O(1) lookup. Returns state unchanged when no tag
+ * references the tasks.
+ */
+export const removeTasksFromAllTags = (
+  state: RootState,
+  taskIds: string[],
+): RootState => {
+  const taskIdSet = new Set(taskIds);
+  const tagUpdates = (state[TAG_FEATURE_NAME].ids as string[])
+    .map((tagId) => state[TAG_FEATURE_NAME].entities[tagId])
+    .filter((tag): tag is Tag => !!tag && tag.taskIds.some((id) => taskIdSet.has(id)))
+    .map(
+      (tag): Update<Tag> => ({
+        id: tag.id,
+        changes: {
+          taskIds: removeTasksFromList(tag.taskIds, taskIds),
+        },
+      }),
+    );
+  return updateTags(state, tagUpdates);
+};
+
 // =============================================================================
 // PLANNER DAY HELPERS
 // =============================================================================

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-lifecycle.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-lifecycle.reducer.spec.ts
@@ -296,6 +296,49 @@ describe('taskSharedLifecycleMetaReducer', () => {
       );
     });
 
+    // Regression: divergent/one-sided tag→task reference from a sync replay.
+    // A receiving client can end up with `tag.taskIds` containing a task id that
+    // is NOT listed in the task's own `tagIds`. The archive path used to only
+    // visit tags named in `task.tagIds`, so it left this reference dangling —
+    // which later tripped cross-model validation and forced a reconciliation
+    // (observed in SP-logs: an archived repeating-task instance still held by a
+    // regular tag). Cleanup must scan ALL tags, like the delete path does.
+    it('should remove archived task from a tag that references it even when the task.tagIds omits that tag', () => {
+      const testState = createStateWithExistingTasks(
+        ['rpt-task', 'keep-task'],
+        [],
+        ['rpt-task', 'keep-task'], // regular tag1 references rpt-task
+        [], // TODAY empty
+      );
+
+      // One-sided reference: the task itself does NOT list tag1.
+      testState[TASK_FEATURE_NAME].entities['rpt-task'] = createMockTask({
+        id: 'rpt-task',
+        projectId: 'project1',
+        tagIds: [],
+      });
+
+      const tasksToArchive: TaskWithSubTasks[] = [
+        createTaskWithSubTasks({
+          id: 'rpt-task',
+          projectId: 'project1',
+          tagIds: [], // payload also omits the tag
+        }),
+      ];
+
+      const action = createArchiveAction(tasksToArchive);
+
+      metaReducer(testState, action);
+      expectStateUpdate(
+        {
+          ...expectTagUpdate('tag1', { taskIds: ['keep-task'] }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
     it('should handle archiving tasks from multiple projects', () => {
       const testState = createStateWithExistingTasks(
         ['task1'],

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-lifecycle.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-lifecycle.reducer.ts
@@ -72,12 +72,8 @@ const handleMoveToArchive = (state: RootState, tasks: TaskWithSubTasks[]): RootS
     }
   }
 
-  // Scan EVERY tag (incl. TODAY_TAG) from CURRENT STATE for references to the
-  // archived tasks — not just the tags named in each task's own `tagIds`.
-  // During sync a receiving client can hold a one-sided tag→task reference
-  // (tag.taskIds contains the id even though task.tagIds does not); only
-  // visiting the task's own tagIds would leave that dangling reference behind,
-  // which later trips cross-model validation and forces a reconciliation.
+  // Scan every tag, not just each task's own `tagIds` — see
+  // removeTasksFromAllTags for why (one-sided tag refs after sync).
   return removeTasksFromAllTags(updatedState, taskIdsToArchive);
 };
 

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-lifecycle.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-lifecycle.reducer.ts
@@ -22,6 +22,7 @@ import {
   ActionHandlerMap,
   getProject,
   getTag,
+  removeTasksFromAllTags,
   removeTasksFromList,
   TaskEntity,
   updateTags,
@@ -71,28 +72,13 @@ const handleMoveToArchive = (state: RootState, tasks: TaskWithSubTasks[]): RootS
     }
   }
 
-  // Get tag associations from CURRENT STATE for the same reason as above.
-  // Always include TODAY_TAG to ensure cleanup even if tasks aren't in it.
-  const affectedTagIds = unique([
-    TODAY_TAG.id,
-    ...taskIdsToArchive.flatMap((taskId) => {
-      const task = state[TASK_FEATURE_NAME].entities[taskId];
-      return task?.tagIds ?? [];
-    }),
-  ]);
-
-  const tagUpdates = affectedTagIds
-    .filter((tagId) => !!state[TAG_FEATURE_NAME].entities[tagId])
-    .map(
-      (tagId): Update<Tag> => ({
-        id: tagId,
-        changes: {
-          taskIds: removeTasksFromList(getTag(state, tagId).taskIds, taskIdsToArchive),
-        },
-      }),
-    );
-
-  return updateTags(updatedState, tagUpdates);
+  // Scan EVERY tag (incl. TODAY_TAG) from CURRENT STATE for references to the
+  // archived tasks — not just the tags named in each task's own `tagIds`.
+  // During sync a receiving client can hold a one-sided tag→task reference
+  // (tag.taskIds contains the id even though task.tagIds does not); only
+  // visiting the task's own tagIds would leave that dangling reference behind,
+  // which later trips cross-model validation and forces a reconciliation.
+  return removeTasksFromAllTags(updatedState, taskIdsToArchive);
 };
 
 /**


### PR DESCRIPTION
## What

Fixes a sync-related bug where archiving a task could leave a **dangling tag → task reference** behind, plus a follow-up refactor that consolidates the tag-cleanup logic.

### The bug (`fix(sync): scan all tags when archiving`)

When a task is moved to the archive, the meta-reducer must remove that task's id from every tag's `taskIds`. The old archive path only visited the tags named in each task's own `task.tagIds` (plus `TODAY_TAG`).

During SuperSync a receiving client can end up with a **one-sided** reference: `tag.taskIds` contains the task id even though the task's own `tagIds` no longer lists that tag. The old archive path never visited such a tag, so the reference was left dangling — which later tripped cross-model validation and forced a reconciliation (observed in logs as an archived repeating-task instance still held by a regular tag).

The archive path now scans **every** tag in current state via the shared `removeTasksFromAllTags` helper — the same all-tags cleanup the delete/convert paths already used. Behaviorally it's a strict superset of the old logic (every tag the old code actually mutated is still mutated; `TODAY_TAG` remains covered because it's a real store entity).

### The refactor (`refactor(store): route project-delete tag cleanup through shared helper`)

`handleDeleteProject` was the last remaining hand-rolled copy of the "scan all tags, strip these ids" operation. It now calls the shared `removeTasksFromAllTags` helper too, so all removal paths (delete-task, delete-tasks, convert-to-subtask, archive, delete-project) share one canonical implementation. Also moved the helper into the `STATE UPDATE HELPERS` section and de-duplicated the rationale comment.

No behavior change in the refactor: final `tag.taskIds` values are identical; unaffected tags simply keep their reference identity instead of being rewritten to equal arrays.

## Testing

- New regression test for the one-sided reference case in `task-shared-lifecycle.reducer.spec.ts`.
- Full meta-reducer suite green: project-shared 17/17, lifecycle 23/23, crud 110/110, section-shared 20/20.
- `checkFile` (prettier + lint) clean on all modified files.

## Risk

Sync-critical path, so reviewed carefully: the change is replay-deterministic (reads only from state, no wall-clock/random), performs no state mutation, and keeps one reducer pass = one op. Reviewed via multi-agent review + an independent pass — no critical or warning findings.
