### PR TITLE
fix(tasks): treat a missing title as blank instead of crashing isBlankTask

### DIFF
--- a/src/app/features/tasks/util/is-blank-task.spec.ts
+++ b/src/app/features/tasks/util/is-blank-task.spec.ts
@@ -32,6 +32,12 @@ describe('isBlankTask', () => {
     expect(isBlankTask(createTaskWithSubTasks())).toBe(true);
   });
 
+  it('should be true (and not throw) when the title is missing entirely', () => {
+    const t = createTaskWithSubTasks() as any;
+    delete t.title;
+    expect(isBlankTask(t)).toBe(true);
+  });
+
   it('should be true when the title is only whitespace', () => {
     expect(isBlankTask(createTaskWithSubTasks({ title: '   ' }))).toBe(true);
   });

--- a/src/app/features/tasks/util/is-blank-task.ts
+++ b/src/app/features/tasks/util/is-blank-task.ts
@@ -13,7 +13,9 @@ import { Task, TaskWithSubTasks } from '../task.model';
 export const isBlankTask = (task: Task | TaskWithSubTasks): boolean => {
   const subTasks = (task as TaskWithSubTasks).subTasks;
   return (
-    !task.title.trim() &&
+    // Corrupted/legacy tasks can lack a title entirely; treat that as blank
+    // instead of crashing the callers (e.g. the delete-undo snack effect).
+    !task.title?.trim() &&
     !task.notes?.trim() &&
     !task.timeSpent &&
     !task.timeEstimate &&


### PR DESCRIPTION
Fixes #8713.

isBlankTask read task.title.trim() unguarded. A task without a title (they exist in long-lived databases, e.g. old orphaned subtasks) made the call throw, and because it runs inside the snackDelete$ effect's filter, the whole effect stream died for the rest of the session.

A missing title is at least as blank as an empty one, so this guards with task.title?.trim() and adds a regression spec (missing title returns true and does not throw). The spec file's other 15 cases still pass.
