### PR TITLE
feat(macos): declare NSRemindersUsageDescription so plugins can integrate with Apple Reminders

### DIFF
--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -193,6 +193,12 @@ mac:
   notarize: true
   extendInfo:
     ITSAppUsesNonExemptEncryption: false
+    # Optional Apple Reminders access for plugins/integrations (e.g. syncing tasks
+    # with Apple Reminders, which brings Apple Watch / Siri / iCloud shared lists).
+    # Declaring this string does NOT request or grant access on its own; macOS only
+    # prompts if a user-enabled plugin actually accesses Reminders, and users can
+    # deny or later revoke it in System Settings > Privacy & Security > Reminders.
+    NSRemindersUsageDescription: Super Productivity only accesses Apple Reminders if you enable a plugin or integration that syncs your tasks with the Reminders app.
   publish:
     - github
   target:


### PR DESCRIPTION
## What

Adds a single `NSRemindersUsageDescription` string under `mac.extendInfo` in `electron-builder.yaml` so the notarized macOS build can *optionally* access Apple Reminders.

## Why

macOS silently denies EventKit **Reminders** access to any app whose `Info.plist` lacks `NSRemindersUsageDescription` — **no permission prompt is shown**, and the app never appears under **System Settings → Privacy & Security → Reminders**, so users cannot grant it manually.

Because Super Productivity is signed with the hardened runtime and notarized, this string can only be added correctly in an upstream build (editing the shipped `Info.plist` locally breaks the signature). That makes this a small but necessary **ecosystem enabler**: it lets community plugins/integrations sync tasks with Apple Reminders, which is the hub for **Apple Watch, Siri, HomePod, and shared iCloud lists**.

Full rationale, TCC evidence, and privacy analysis are in **#8716**.

## Privacy — this is inert by default

Declaring the string does **not** request or grant anything on its own. It only enables three user-controlled layers:

1. **Nothing happens unless the user enables** a plugin/integration that uses Reminders.
2. When one first accesses Reminders, macOS shows the standard **Allow / Don't Allow** prompt — the user can deny.
3. The user can revoke anytime in **System Settings → Privacy & Security → Reminders**.

## Change

```yaml
mac:
  extendInfo:
    ITSAppUsesNonExemptEncryption: false
    NSRemindersUsageDescription: Super Productivity only accesses Apple Reminders if you enable a plugin or integration that syncs your tasks with the Reminders app.
```

- Correct location: `mac.extendInfo` (not the entitlements plist, which is for hardened-runtime code-signing flags).
- No entitlement change, no capability added by default, no new dependency.
- Windows/Linux builds are unaffected.

## Motivation / context

I built a standalone Super Productivity plugin that bidirectionally syncs tasks with Apple Reminders via the `remi` CLI: https://github.com/Rahulsharma0810/superproductivity-apple-reminders-sync — it works end to end except that the shipped macOS build is TCC-denied for Reminders for the reason above. This one line unblocks that whole class of integrations.

Refs #8716
