### PR TITLE
fix(boards): keep Eisenhower "Not Completed" filter across restarts (#8723)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -99,22 +99,64 @@ end
 # direction.
 REVIEW_SUBMISSION_RACE = 'review submission is already in progress'
 
+# App Store Connect also serializes review state per app across releases: while
+# one version is still in review, the next version can neither be created nor
+# have a build attached. So a release tagged before the previous one clears
+# review fails either at version creation ("You cannot create a new version of
+# the App in the current state") or at build-attach ("The specified pre-release
+# build could not be added"). Unlike the race above this is NOT softened -- the
+# version genuinely did not go out, and a green run would falsely read as
+# "released". We only trade the raw spaceship stacktrace for a one-line,
+# actionable explanation; the lane still fails. Message-matched against fastlane
+# deliver 2.225.0 -- if the phrasing drifts it simply falls back to the raw
+# error, which is fine (the job still fails).
+VERSION_IN_REVIEW_BLOCKS = [
+  'cannot create a new version',
+  'pre-release build could not be added',
+].freeze
+
 def submit_to_app_store(extra)
   upload_to_app_store(deliver_options(extra))
 rescue => e
-  raise unless submit_for_review? && e.message.to_s.downcase.include?(REVIEW_SUBMISSION_RACE)
-  # Surface as a GitHub Actions run annotation, not just a buried log line, so a
-  # green job still flags the required manual step. Static text only -- never
-  # interpolate e/options here (they can carry API key material; see header).
-  if ENV['GITHUB_ACTIONS']
-    puts '::warning title=App Store build uploaded but NOT submitted::A review ' \
-         'submission is already open for this app. Add this build to it in App ' \
-         'Store Connect, or this platform skips this version.'
+  msg = e.message.to_s.downcase
+
+  # Soft success: the other platform's release lane already opened the shared
+  # per-app review submission. The binary is uploaded and safe; it just needs to
+  # be added to the open submission by hand. Surface as a GitHub Actions run
+  # annotation, not just a buried log line, so a green job still flags the
+  # required manual step. Static text only -- never interpolate e/options here
+  # (they can carry API key material; see header).
+  if submit_for_review? && msg.include?(REVIEW_SUBMISSION_RACE)
+    if ENV['GITHUB_ACTIONS']
+      puts '::warning title=App Store build uploaded but NOT submitted::A review ' \
+           'submission is already open for this app. Add this build to it in App ' \
+           'Store Connect, or this platform skips this version.'
+    end
+    UI.important('Build uploaded, but a review submission is already open for this app')
+    UI.important("(the other platform's release lane created it first). Add this build to")
+    UI.important('the open submission in App Store Connect for this version, or this platform')
+    UI.important('will skip this version. Not failing the lane: the binary is uploaded.')
+    return
   end
-  UI.important('Build uploaded, but a review submission is already open for this app')
-  UI.important("(the other platform's release lane created it first). Add this build to")
-  UI.important('the open submission in App Store Connect for this version, or this platform')
-  UI.important('will skip this version. Not failing the lane: the binary is uploaded.')
+
+  # Known "a previous version is still in review" block. Still a hard failure --
+  # we only replace the raw stacktrace with a clear, actionable one-liner (the
+  # raw error still prints after the re-raise). Static text only, same
+  # key-material reason as above.
+  if submit_for_review? && VERSION_IN_REVIEW_BLOCKS.any? { |m| msg.include?(m) }
+    if ENV['GITHUB_ACTIONS']
+      puts '::error title=App Store submit blocked: previous version still in review::' \
+           'App Store Connect will not create or submit this version while the ' \
+           'previous version is still in review. Let it finish review (or remove ' \
+           'it from review in App Store Connect), then re-run this release.'
+    end
+    UI.error('App Store submit blocked: a previous version is still in review.')
+    UI.error('App Store Connect will not create or submit this version until the')
+    UI.error('previous one clears review. Let it finish (or pull it from review in')
+    UI.error('App Store Connect), then re-run this release.')
+  end
+
+  raise
 end
 
 platform :ios do

--- a/src/app/features/boards/store/boards.reducer.spec.ts
+++ b/src/app/features/boards/store/boards.reducer.spec.ts
@@ -312,7 +312,9 @@ describe('fixBuggyDefaultBoardFilters (#7498)', () => {
     'NOT_URGENT_AND_NOT_IMPORTANT',
   ];
 
-  it('flips taskDoneState UnDone → All on the four default Eisenhower quadrants', () => {
+  // #8723: the Eisenhower taskDoneState revert used to run on every load and
+  // clobbered a user's intentional "Not Completed" (UnDone) choice back to All.
+  it('preserves an intentional UnDone taskDoneState on the Eisenhower quadrants', () => {
     const state: BoardsState = {
       boardCfgs: [
         makeBoard({
@@ -326,69 +328,10 @@ describe('fixBuggyDefaultBoardFilters (#7498)', () => {
 
     const result = fixBuggyDefaultBoardFilters(state);
 
+    expect(result).toBe(state);
     for (const panel of result.boardCfgs[0].panels) {
-      expect(panel.taskDoneState).toBe(BoardPanelCfgTaskDoneState.All);
+      expect(panel.taskDoneState).toBe(BoardPanelCfgTaskDoneState.UnDone);
     }
-  });
-
-  it('does not touch Eisenhower panels with non-default IDs (user customization)', () => {
-    const state: BoardsState = {
-      boardCfgs: [
-        makeBoard({
-          id: 'EISENHOWER_MATRIX',
-          panels: [
-            makePanel({
-              id: 'CUSTOM_PANEL',
-              taskDoneState: BoardPanelCfgTaskDoneState.UnDone,
-            }),
-          ],
-        }),
-      ],
-    };
-
-    const result = fixBuggyDefaultBoardFilters(state);
-
-    expect(result).toBe(state);
-    expect(result.boardCfgs[0].panels[0].taskDoneState).toBe(
-      BoardPanelCfgTaskDoneState.UnDone,
-    );
-  });
-
-  it('does not touch Eisenhower panels already set to All (idempotent)', () => {
-    const state: BoardsState = {
-      boardCfgs: [
-        makeBoard({
-          id: 'EISENHOWER_MATRIX',
-          panels: eisenhowerPanelIds.map((id) =>
-            makePanel({ id, taskDoneState: BoardPanelCfgTaskDoneState.All }),
-          ),
-        }),
-      ],
-    };
-
-    const result = fixBuggyDefaultBoardFilters(state);
-
-    expect(result).toBe(state);
-  });
-
-  it('does not touch a Done-state Eisenhower panel (user-added Done quadrant)', () => {
-    const state: BoardsState = {
-      boardCfgs: [
-        makeBoard({
-          id: 'EISENHOWER_MATRIX',
-          panels: [
-            makePanel({
-              id: 'URGENT_AND_IMPORTANT',
-              taskDoneState: BoardPanelCfgTaskDoneState.Done,
-            }),
-          ],
-        }),
-      ],
-    };
-
-    const result = fixBuggyDefaultBoardFilters(state);
-
-    expect(result).toBe(state);
   });
 
   it('strips IN_PROGRESS_TAG from the Kanban DONE panel excludedTagIds', () => {
@@ -441,7 +384,7 @@ describe('fixBuggyDefaultBoardFilters (#7498)', () => {
     expect(result).toBe(state);
   });
 
-  it('migrates both Eisenhower and Kanban defaults in one pass', () => {
+  it('migrates the Kanban default while leaving an Eisenhower UnDone choice intact', () => {
     const state: BoardsState = {
       boardCfgs: [
         makeBoard({
@@ -468,8 +411,33 @@ describe('fixBuggyDefaultBoardFilters (#7498)', () => {
     const result = fixBuggyDefaultBoardFilters(state);
 
     expect(result.boardCfgs[0].panels[0].taskDoneState).toBe(
-      BoardPanelCfgTaskDoneState.All,
+      BoardPanelCfgTaskDoneState.UnDone,
     );
     expect(result.boardCfgs[1].panels[0].excludedTagIds).toEqual([]);
+  });
+});
+
+describe('Boards Reducer - loadAllData preserves Eisenhower taskDoneState (#8723)', () => {
+  it('keeps a user-set "Not Completed" (UnDone) quadrant across a reload', () => {
+    const stored: BoardsState = {
+      boardCfgs: [
+        makeBoard({
+          id: 'EISENHOWER_MATRIX',
+          panels: [
+            makePanel({
+              id: 'URGENT_AND_IMPORTANT',
+              taskDoneState: BoardPanelCfgTaskDoneState.UnDone,
+            }),
+          ],
+        }),
+      ],
+    };
+    const appDataComplete = { boards: stored } as unknown as AppDataComplete;
+
+    const result = boardsReducer({ boardCfgs: [] }, loadAllData({ appDataComplete }));
+
+    expect(result.boardCfgs[0].panels[0].taskDoneState).toBe(
+      BoardPanelCfgTaskDoneState.UnDone,
+    );
   });
 });

--- a/src/app/features/boards/store/boards.reducer.ts
+++ b/src/app/features/boards/store/boards.reducer.ts
@@ -1,6 +1,6 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
 import { BoardsActions } from './boards.actions';
-import { BoardCfg, BoardPanelCfgTaskDoneState } from '../boards.model';
+import { BoardCfg } from '../boards.model';
 import { DEFAULT_BOARDS } from '../boards.const';
 import { loadAllData } from '../../../root-store/meta/load-all-data.action';
 import { nanoid } from 'nanoid';
@@ -44,18 +44,22 @@ export const initialBoardsState: BoardsState = {
 };
 
 /**
- * Fix for #7498: pre-existing default boards persisted to user state still
- * have the buggy filters that make tasks vanish on done-toggle. We narrowly
- * patch only panels still matching the original default IDs so customized
- * panels are never touched. Idempotent: re-running is a no-op.
+ * Fix for #7498: the default Kanban DONE column shipped with an IN_PROGRESS_TAG
+ * exclusion that hid completed tasks still carrying the tag. We narrowly patch
+ * only the default DONE panel (matched by board+panel id).
+ * Idempotent: re-running is a no-op.
+ *
+ * NOTE (#8723): this deliberately no longer reverts the Eisenhower quadrants'
+ * `taskDoneState` from UnDone → All. Because it runs on every `loadAllData`, it
+ * could not tell the old buggy default apart from a user's intentional "Not
+ * Completed" choice, so that choice reset to "All" on every restart. New
+ * installs are already covered by the relaxed `All` default in DEFAULT_BOARDS.
+ * The remaining Kanban branch has the same every-load / can't-tell-intent shape,
+ * so it is kept ONLY because re-excluding IN_PROGRESS_TAG from a Done-filtered
+ * column is not a plausible deliberate choice (unlike UnDone on Eisenhower) —
+ * not because "everyone is already migrated" (that reason is symmetric and would
+ * apply to Eisenhower too). Don't remove it via that misleading symmetry.
  */
-const EISENHOWER_PANEL_IDS = new Set([
-  'URGENT_AND_IMPORTANT',
-  'NOT_URGENT_AND_IMPORTANT',
-  'URGENT_AND_NOT_IMPORTANT',
-  'NOT_URGENT_AND_NOT_IMPORTANT',
-]);
-
 export const fixBuggyDefaultBoardFilters = (boardsState: BoardsState): BoardsState => {
   let changed = false;
 
@@ -63,20 +67,10 @@ export const fixBuggyDefaultBoardFilters = (boardsState: BoardsState): BoardsSta
     let boardChanged = false;
 
     const panels = board.panels.map((panel) => {
-      // Eisenhower quadrants: revert taskDoneState UnDone → All so completed
-      // tasks remain visible (struck through) instead of vanishing — Eisenhower
-      // has no Done column.
-      if (
-        board.id === 'EISENHOWER_MATRIX' &&
-        EISENHOWER_PANEL_IDS.has(panel.id) &&
-        panel.taskDoneState === BoardPanelCfgTaskDoneState.UnDone
-      ) {
-        boardChanged = true;
-        return { ...panel, taskDoneState: BoardPanelCfgTaskDoneState.All };
-      }
-
       // Kanban DONE column: drop the IN_PROGRESS_TAG exclusion so a completed
-      // task that still carries the tag actually lands here.
+      // task that still carries the tag actually lands here. Same latent
+      // #8723-class risk as the removed Eisenhower branch (a user who re-adds
+      // this exclusion gets it stripped on reload) — accepted, see the note above.
       if (
         board.id === 'KANBAN_DEFAULT' &&
         panel.id === 'DONE' &&


### PR DESCRIPTION
## Problem

Fixes #8723. On the default **Eisenhower Matrix** board, editing **Task Completion State** to **Not Completed** did not persist — after restarting Super Productivity it reverted to **All**, so completed tasks reappeared and cluttered the view. Reliably reproducible.

## Root cause

`fixBuggyDefaultBoardFilters` (added in `6bec7fb500` for #7498) runs on **every** `loadAllData` (app start, sync import, backup import). For panels whose id matched one of the four default Eisenhower quadrant ids, it reverted `taskDoneState: UnDone → All`. Because those panel ids never change, the migration could not tell the old buggy shipped default (`UnDone`) apart from a user's *intentional* "Not Completed" choice — so it clobbered the edit on every load.

Background: #7498 was the opposite complaint — with the old default `UnDone`, marking a task done made it vanish (Eisenhower has no Done column). That fix relaxed the shipped default to `All` **and** added this load-time revert to migrate already-persisted state. Implementing it as an every-load normalizer rather than a one-time migration is the defect.

## Fix (surgical)

- Remove the Eisenhower `taskDoneState UnDone → All` branch (plus the now-unused `EISENHOWER_PANEL_IDS` set + import) from `fixBuggyDefaultBoardFilters`.
- New installs already get the correct `All` default from `DEFAULT_BOARDS`; users who relaunched since #7498 were already migrated. The render-time filter always honored `UnDone`, so "Not Completed" now simply works and sticks.
- The **Kanban DONE** `IN_PROGRESS_TAG` branch is intentionally **kept** — re-excluding that tag from a Done-filtered column is not a plausible deliberate choice (unlike `UnDone` on Eisenhower), so its every-load clobber is effectively inert. Documented inline so it isn't removed later via misleading "already migrated" symmetry.

## Tests

- Dropped the tests asserting the Eisenhower clobber; added a test that the quadrants' `UnDone` is preserved (asserts referential identity).
- Added a `loadAllData`-level regression test (#8723) proving a user-set "Not Completed" survives a reload through the full hydration chain.
- `npm run test:file boards.reducer.spec.ts` → 18/18 pass.

## Sync note

Pure removal on the hydration path — no new action/effect/op. It's sync-positive: previously a synced `UnDone` choice was reverted on **every** client; now it's honored everywhere.

## Accepted tradeoff (Cohort C)

Users who set up boards **before** #7498 (v18.10.0, May 2026) and upgrade **directly** to this build without ever launching an intermediate build lose the auto-migration, so #7498's Eisenhower symptom (done tasks vanish) reappears until they set the quadrant to `All` manually — which now sticks. This is accepted deliberately: a one-time migration that fixes both this cohort **and** #8723 is infeasible here, because the op-log `migrateOperation` half faces the identical "can't distinguish intent from buggy default" ambiguity that is the root cause, and running it now would clobber the actual #8723 reporters one final time.

## Review

Reviewed via 7-way multi-agent review (correctness, security, architecture, alternatives, performance, simplicity + Codex): no critical or blocking issues; verdict APPROVED. Doc-accuracy suggestions applied.
