### PR TITLE
fix(task-repeat-cfg): don't crash on a deleted repeat config (#8715)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -99,22 +99,64 @@ end
 # direction.
 REVIEW_SUBMISSION_RACE = 'review submission is already in progress'
 
+# App Store Connect also serializes review state per app across releases: while
+# one version is still in review, the next version can neither be created nor
+# have a build attached. So a release tagged before the previous one clears
+# review fails either at version creation ("You cannot create a new version of
+# the App in the current state") or at build-attach ("The specified pre-release
+# build could not be added"). Unlike the race above this is NOT softened -- the
+# version genuinely did not go out, and a green run would falsely read as
+# "released". We only trade the raw spaceship stacktrace for a one-line,
+# actionable explanation; the lane still fails. Message-matched against fastlane
+# deliver 2.225.0 -- if the phrasing drifts it simply falls back to the raw
+# error, which is fine (the job still fails).
+VERSION_IN_REVIEW_BLOCKS = [
+  'cannot create a new version',
+  'pre-release build could not be added',
+].freeze
+
 def submit_to_app_store(extra)
   upload_to_app_store(deliver_options(extra))
 rescue => e
-  raise unless submit_for_review? && e.message.to_s.downcase.include?(REVIEW_SUBMISSION_RACE)
-  # Surface as a GitHub Actions run annotation, not just a buried log line, so a
-  # green job still flags the required manual step. Static text only -- never
-  # interpolate e/options here (they can carry API key material; see header).
-  if ENV['GITHUB_ACTIONS']
-    puts '::warning title=App Store build uploaded but NOT submitted::A review ' \
-         'submission is already open for this app. Add this build to it in App ' \
-         'Store Connect, or this platform skips this version.'
+  msg = e.message.to_s.downcase
+
+  # Soft success: the other platform's release lane already opened the shared
+  # per-app review submission. The binary is uploaded and safe; it just needs to
+  # be added to the open submission by hand. Surface as a GitHub Actions run
+  # annotation, not just a buried log line, so a green job still flags the
+  # required manual step. Static text only -- never interpolate e/options here
+  # (they can carry API key material; see header).
+  if submit_for_review? && msg.include?(REVIEW_SUBMISSION_RACE)
+    if ENV['GITHUB_ACTIONS']
+      puts '::warning title=App Store build uploaded but NOT submitted::A review ' \
+           'submission is already open for this app. Add this build to it in App ' \
+           'Store Connect, or this platform skips this version.'
+    end
+    UI.important('Build uploaded, but a review submission is already open for this app')
+    UI.important("(the other platform's release lane created it first). Add this build to")
+    UI.important('the open submission in App Store Connect for this version, or this platform')
+    UI.important('will skip this version. Not failing the lane: the binary is uploaded.')
+    return
   end
-  UI.important('Build uploaded, but a review submission is already open for this app')
-  UI.important("(the other platform's release lane created it first). Add this build to")
-  UI.important('the open submission in App Store Connect for this version, or this platform')
-  UI.important('will skip this version. Not failing the lane: the binary is uploaded.')
+
+  # Known "a previous version is still in review" block. Still a hard failure --
+  # we only replace the raw stacktrace with a clear, actionable one-liner (the
+  # raw error still prints after the re-raise). Static text only, same
+  # key-material reason as above.
+  if submit_for_review? && VERSION_IN_REVIEW_BLOCKS.any? { |m| msg.include?(m) }
+    if ENV['GITHUB_ACTIONS']
+      puts '::error title=App Store submit blocked: previous version still in review::' \
+           'App Store Connect will not create or submit this version while the ' \
+           'previous version is still in review. Let it finish review (or remove ' \
+           'it from review in App Store Connect), then re-run this release.'
+    end
+    UI.error('App Store submit blocked: a previous version is still in review.')
+    UI.error('App Store Connect will not create or submit this version until the')
+    UI.error('previous one clears review. Let it finish (or pull it from review in')
+    UI.error('App Store Connect), then re-run this release.')
+  end
+
+  raise
 end
 
 platform :ios do

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -71,7 +71,9 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       repeatCfg?: TaskRepeatCfg;
       targetDate?: string;
     },
-    getTaskRepeatCfgById$ReturnValue?: Observable<TaskRepeatCfg> | Subject<TaskRepeatCfg>,
+    getRepeatCfgReturnValue?:
+      | Observable<TaskRepeatCfg | undefined>
+      | Subject<TaskRepeatCfg>,
   ): Promise<ComponentFixture<DialogEditTaskRepeatCfgComponent>> => {
     mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
     mockMatDialog = jasmine.createSpyObj('MatDialog', ['open']);
@@ -80,6 +82,7 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
     } as any);
     mockTaskRepeatCfgService = jasmine.createSpyObj('TaskRepeatCfgService', [
       'getTaskRepeatCfgById$',
+      'getTaskRepeatCfgByIdAllowUndefined$',
       'updateTaskRepeatCfg',
       'addTaskRepeatCfgToTask',
       'deleteTaskRepeatCfgWithDialog',
@@ -91,10 +94,10 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
     mockDateService.todayStr.and.returnValue(MOCK_TODAY_STR);
     mockDateService.getLogicalTodayDate.and.returnValue(new Date(MOCK_TODAY));
 
-    // Set up the return value for getTaskRepeatCfgById$ before creating the component
-    if (getTaskRepeatCfgById$ReturnValue) {
-      mockTaskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
-        getTaskRepeatCfgById$ReturnValue,
+    // Set up the return value for the repeat-config lookup before creating the component
+    if (getRepeatCfgReturnValue) {
+      mockTaskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+        getRepeatCfgReturnValue,
       );
     }
 
@@ -215,6 +218,24 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       // repeatCfgInitial should now be set
       expect(component.repeatCfgInitial()).toBeDefined();
       expect(component.repeatCfgInitial()?.id).toBe('repeat-cfg-123');
+    }));
+
+    // #8715: the task can reference a repeat config that was already deleted
+    // (e.g. via cross-client sync). The lookup must not throw and crash — the
+    // dialog should abort editing and close.
+    it('should close instead of crashing when the repeat config was deleted (#8715)', fakeAsync(async () => {
+      const taskWithRepeatCfg = {
+        ...mockTask,
+        repeatCfgId: 'repeat-cfg-123',
+      } as TaskCopy;
+
+      const fixture = await setupTestBed({ task: taskWithRepeatCfg }, of(undefined));
+      const component = fixture.componentInstance;
+      fixture.detectChanges();
+      tick();
+
+      expect(component.isLoading()).toBe(false);
+      expect(mockDialogRef.close).toHaveBeenCalled();
     }));
   });
 

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -282,9 +282,16 @@ export class DialogEditTaskRepeatCfgComponent {
       if (this.isEdit() && this._data.task?.repeatCfgId) {
         this.isLoading.set(true);
         this._taskRepeatCfgService
-          .getTaskRepeatCfgById$(this._data.task.repeatCfgId)
+          .getTaskRepeatCfgByIdAllowUndefined$(this._data.task.repeatCfgId)
           .pipe(first())
           .subscribe((cfg) => {
+            // Repeat config was deleted (e.g. via cross-client sync) but the task
+            // still references it — abort editing instead of crashing. (#8715)
+            if (!cfg) {
+              this.isLoading.set(false);
+              this.close();
+              return;
+            }
             this._setRepeatCfgInitiallyForEditOnly(cfg);
             this._checkCanRemoveInstance();
             this.isLoading.set(false);

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { TaskRepeatCfgEffects } from './task-repeat-cfg.effects';
 import { TaskService } from '../../tasks/task.service';
@@ -94,8 +94,14 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
     const taskRepeatCfgServiceSpy = jasmine.createSpyObj('TaskRepeatCfgService', [
       'updateTaskRepeatCfg',
       'getTaskRepeatCfgById$',
+      'getTaskRepeatCfgByIdAllowUndefined$',
       '_getActionsForTaskRepeatCfg',
     ]);
+    // Default: config exists. Individual tests override; the "deleted config"
+    // tests set this to of(undefined) to exercise the #8715 crash-guard.
+    taskRepeatCfgServiceSpy.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+      of(undefined),
+    );
 
     const matDialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
     const taskArchiveServiceSpy = jasmine.createSpyObj('TaskArchiveService', ['load']);
@@ -1023,7 +1029,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         taskService.getByIdOnce$.and.returnValue(of(mockTask));
 
         // repeat cfg with repeatOnComplete true
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({ ...mockRepeatCfg, repeatFromCompletionDate: true }),
         );
 
@@ -1070,7 +1076,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         actions$ = hot('-a', { a: action });
 
         taskService.getByIdOnce$.and.returnValue(of(mockTask));
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({ ...mockRepeatCfg, repeatFromCompletionDate: false }),
         );
 
@@ -1093,7 +1099,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         actions$ = hot('-a', { a: action });
 
         taskService.getByIdOnce$.and.returnValue(of(oldTask));
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({
             ...mockRepeatCfg,
             repeatFromCompletionDate: true,
@@ -1119,7 +1125,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
 
         actions$ = hot('-a', { a: action });
         taskService.getByIdOnce$.and.returnValue(of(legacyTask));
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({
             ...mockRepeatCfg,
             repeatFromCompletionDate: true,
@@ -1173,7 +1179,9 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
           },
         } as any),
       );
-      taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(of(repeatCfg));
+      taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+        of(repeatCfg),
+      );
       taskRepeatCfgService._getActionsForTaskRepeatCfg.and.returnValue(
         Promise.resolve([expectedAction]),
       );
@@ -1216,7 +1224,9 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
 
       actions$ = of(action);
       taskService.getByIdOnce$.and.returnValue(of(oldTask));
-      taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(of(repeatCfg));
+      taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+        of(repeatCfg),
+      );
       taskRepeatCfgService._getActionsForTaskRepeatCfg.and.returnValue(
         Promise.resolve([expectedAction]),
       );
@@ -1233,6 +1243,32 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         error: done.fail,
       });
     });
+
+    // #8715: a completed instance can reference a repeat config that was
+    // already deleted (e.g. via cross-client sync). The lookup must not throw
+    // ('Missing taskRepeatCfg') and crash the whole app — the effect just skips.
+    it('should not throw when the referenced repeat config was deleted (#8715)', () => {
+      testScheduler.run(({ hot, expectObservable }) => {
+        const action = TaskSharedActions.updateTask({
+          task: { id: 'parent-task-id', changes: { isDone: true } },
+        });
+
+        actions$ = hot('-a', { a: action });
+
+        // task still references the (now missing) config
+        taskService.getByIdOnce$.and.returnValue(of(mockTask));
+        // config no longer exists -> non-throwing selector yields undefined
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+          of(undefined),
+        );
+        // guard against regressing to the throwing selector (the #8715 root cause)
+        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+          throwError(() => new Error('Missing taskRepeatCfg')),
+        );
+
+        expectObservable(effects.updateStartDateOnComplete$).toBe('--');
+      });
+    });
   });
 
   describe('autoSyncSubtaskTemplatesFromNewest$', () => {
@@ -1246,7 +1282,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         actions$ = hot('-a', { a: action });
 
         taskService.getByIdOnce$.and.returnValue(of(mockTask));
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({
             ...mockRepeatCfg,
             shouldInheritSubtasks: true,
@@ -1285,7 +1321,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         actions$ = hot('-a', { a: action });
 
         taskService.getByIdOnce$.and.returnValue(of(mockTask));
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({ ...mockRepeatCfg, shouldInheritSubtasks: false }),
         );
 
@@ -1303,7 +1339,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         actions$ = hot('-a', { a: action });
 
         taskService.getByIdOnce$.and.returnValue(of(mockTask));
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({
             ...mockRepeatCfg,
             shouldInheritSubtasks: true,
@@ -1330,7 +1366,7 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         ];
 
         taskService.getByIdOnce$.and.returnValue(of(mockTask));
-        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
           of({
             ...mockRepeatCfg,
             shouldInheritSubtasks: true,
@@ -1339,6 +1375,32 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         );
         taskService.getTasksByRepeatCfgId$.and.returnValue(of([mockTask]));
         taskService.getByIdsLive$.and.returnValue(of([mockSubTask1, mockSubTask2]));
+
+        expectObservable(effects.autoSyncSubtaskTemplatesFromNewest$).toBe('--');
+      });
+    });
+
+    // #8715: the parent task can reference a repeat config that was already
+    // deleted (e.g. via cross-client sync). The lookup must not throw and
+    // crash the whole app — the effect should simply skip.
+    it('should not throw when the referenced repeat config was deleted (#8715)', () => {
+      testScheduler.run(({ hot, expectObservable }) => {
+        const action = addSubTask({
+          task: mockSubTask1,
+          parentId: 'parent-task-id',
+        });
+
+        actions$ = hot('-a', { a: action });
+
+        taskService.getByIdOnce$.and.returnValue(of(mockTask));
+        // config no longer exists -> non-throwing selector yields undefined
+        taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+          of(undefined),
+        );
+        // guard against regressing to the throwing selector (the #8715 root cause)
+        taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(
+          throwError(() => new Error('Missing taskRepeatCfg')),
+        );
 
         expectObservable(effects.autoSyncSubtaskTemplatesFromNewest$).toBe('--');
       });

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
@@ -18,7 +18,7 @@ import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions'
 import { PlannerActions } from '../../planner/store/planner.actions';
 import { TaskService } from '../../tasks/task.service';
 import { TaskRepeatCfgService } from '../task-repeat-cfg.service';
-import { TaskRepeatCfgCopy } from '../task-repeat-cfg.model';
+import { TaskRepeatCfg, TaskRepeatCfgCopy } from '../task-repeat-cfg.model';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
 import { T } from '../../../t.const';
@@ -450,42 +450,46 @@ export class TaskRepeatCfgEffects {
               }
               const repeatCfgId = parent.repeatCfgId;
               // Load config and verify flags
-              return this._taskRepeatCfgService.getTaskRepeatCfgById$(repeatCfgId).pipe(
-                first(),
-                switchMap((cfg) => {
-                  if (!cfg.shouldInheritSubtasks) {
-                    return EMPTY;
-                  }
-                  // auto-update is default unless explicitly disabled
-                  const isAutoEnabled = !cfg.disableAutoUpdateSubtasks;
-                  if (!isAutoEnabled) {
-                    return EMPTY;
-                  }
-                  // Ensure parent is the newest live instance
-                  return this._taskService.getTasksByRepeatCfgId$(repeatCfgId).pipe(
-                    first(),
-                    switchMap((liveInstances) => {
-                      if (!liveInstances || liveInstances.length === 0) {
-                        return EMPTY;
-                      }
-                      const newest = liveInstances.reduce((a, b) =>
-                        a.created > b.created ? a : b,
-                      );
-                      if (newest.id !== parent.id) {
-                        return EMPTY;
-                      }
-                      // Build templates from newest.subTaskIds order
-                      return rxOf({
-                        cfg,
-                        newest,
-                      } as {
-                        cfg: TaskRepeatCfgCopy;
-                        newest: Task;
-                      });
-                    }),
-                  );
-                }),
-              );
+              return this._taskRepeatCfgService
+                .getTaskRepeatCfgByIdAllowUndefined$(repeatCfgId)
+                .pipe(
+                  first(),
+                  switchMap((cfg) => {
+                    // Config may be gone (e.g. deleted via cross-client sync) while a
+                    // task still references it — skip instead of crashing. See #8715.
+                    if (!cfg || !cfg.shouldInheritSubtasks) {
+                      return EMPTY;
+                    }
+                    // auto-update is default unless explicitly disabled
+                    const isAutoEnabled = !cfg.disableAutoUpdateSubtasks;
+                    if (!isAutoEnabled) {
+                      return EMPTY;
+                    }
+                    // Ensure parent is the newest live instance
+                    return this._taskService.getTasksByRepeatCfgId$(repeatCfgId).pipe(
+                      first(),
+                      switchMap((liveInstances) => {
+                        if (!liveInstances || liveInstances.length === 0) {
+                          return EMPTY;
+                        }
+                        const newest = liveInstances.reduce((a, b) =>
+                          a.created > b.created ? a : b,
+                        );
+                        if (newest.id !== parent.id) {
+                          return EMPTY;
+                        }
+                        // Build templates from newest.subTaskIds order
+                        return rxOf({
+                          cfg,
+                          newest,
+                        } as {
+                          cfg: TaskRepeatCfgCopy;
+                          newest: Task;
+                        });
+                      }),
+                    );
+                  }),
+                );
             }),
             filter((res): res is { cfg: TaskRepeatCfgCopy; newest: Task } => !!res),
             switchMap(({ cfg, newest }) =>
@@ -624,15 +628,20 @@ export class TaskRepeatCfgEffects {
       ),
       filter((task): task is Task => !!task?.repeatCfgId),
       switchMap((task) =>
-        this._taskRepeatCfgService.getTaskRepeatCfgById$(task.repeatCfgId as string).pipe(
-          take(1),
-          map((cfg) => ({ task, cfg })),
-        ),
+        // Use the non-throwing lookup: a completed instance can reference a
+        // repeat config that was already deleted (e.g. via cross-client sync).
+        // The throwing selector would crash the whole app here (#8715).
+        this._taskRepeatCfgService
+          .getTaskRepeatCfgByIdAllowUndefined$(task.repeatCfgId as string)
+          .pipe(
+            take(1),
+            map((cfg) => ({ task, cfg })),
+          ),
       ),
       filter(
-        ({ cfg }) =>
-          !!cfg &&
-          (cfg.repeatFromCompletionDate === true || cfg.waitForCompletion === true),
+        (v): v is { task: Task; cfg: TaskRepeatCfg } =>
+          !!v.cfg &&
+          (v.cfg.repeatFromCompletionDate === true || v.cfg.waitForCompletion === true),
       ),
       concatMap(({ task, cfg }) => {
         const today = this._dateService.todayStr();

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts
@@ -1,5 +1,5 @@
 import { TaskContextMenuInnerComponent } from './task-context-menu-inner.component';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { TaskService } from '../../task.service';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
@@ -15,7 +15,7 @@ import { WorkContextService } from '../../../work-context/work-context.service';
 import { TaskFocusService } from '../../task-focus.service';
 import { LocaleDatePipe } from 'src/app/ui/pipes/locale-date.pipe';
 import { DateAdapter } from '@angular/material/core';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { selectTaskByIdWithSubTaskData } from '../../store/task.selectors';
 import { addSubTask } from '../../store/task.actions';
 import { TaskSharedActions } from '../../../../root-store/meta/task-shared.actions';
@@ -55,6 +55,9 @@ describe('TaskContextMenuInnerComponent', () => {
       'add',
       'createNewTaskWithDefaults',
       'currentTaskId',
+      'moveToProject',
+      'getTasksWithSubTasksByRepeatCfgId$',
+      'getArchiveTasksForRepeatCfgId',
     ]);
     taskService.currentTaskId.and.returnValue('some-id');
     addSubtaskInputService = jasmine.createSpyObj<AddSubtaskInputService>(
@@ -74,7 +77,10 @@ describe('TaskContextMenuInnerComponent', () => {
         { provide: AddSubtaskInputService, useValue: addSubtaskInputService },
         {
           provide: TaskRepeatCfgService,
-          useValue: { getTaskRepeatCfgById$: () => of(null) },
+          useValue: {
+            getTaskRepeatCfgById$: () => of(null),
+            getTaskRepeatCfgByIdAllowUndefined$: () => of(undefined),
+          },
         },
         { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of() }) } },
         {
@@ -114,7 +120,10 @@ describe('TaskContextMenuInnerComponent', () => {
         { provide: WorkContextService, useValue: { activeWorkContext$: of({}) } },
         {
           provide: TaskFocusService,
-          useValue: { focusedTaskId: { set: () => {} } },
+          useValue: {
+            focusedTaskId: { set: () => {} },
+            isTaskContextMenuOpen: { set: () => {} },
+          },
         },
         { provide: LocaleDatePipe, useValue: {} },
         { provide: DateAdapter, useValue: { getFirstDayOfWeek: () => 0 } },
@@ -389,5 +398,44 @@ describe('TaskContextMenuInnerComponent', () => {
         .map((args) => (args[0] as unknown as { type: string }).type);
       expect(dispatchedTypes).not.toContain(TaskSharedActions.unscheduleTask.type);
     });
+  });
+
+  // #8715: a task can reference a repeat config that was already deleted (e.g.
+  // via cross-client sync). Moving it must not throw ('Missing taskRepeatCfg')
+  // and crash — it should fall back to a plain task move.
+  describe('moveTaskToProject() with a deleted repeat config (#8715)', () => {
+    it('falls back to a plain move instead of crashing on the missing config', fakeAsync(() => {
+      const taskWithRepeat = {
+        ...DEFAULT_TASK,
+        id: 'task-repeat',
+        title: 'Repeat Task',
+        projectId: 'project-current',
+        repeatCfgId: 'deleted-cfg',
+      } as Task;
+      component.task = taskWithRepeat;
+
+      const taskWithSubTasks = { ...taskWithRepeat, subTasks: [] } as any;
+      store.overrideSelector(selectTaskByIdWithSubTaskData, taskWithSubTasks);
+      // config resolves to undefined (deleted); the other repeat lookups still run
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(
+        of([taskWithSubTasks]),
+      );
+      taskService.getArchiveTasksForRepeatCfgId.and.returnValue(Promise.resolve([]));
+      // guard against regressing to the throwing selector (the #8715 root cause)
+      const repeatCfgService = TestBed.inject(TaskRepeatCfgService);
+      (
+        repeatCfgService as unknown as { getTaskRepeatCfgById$: () => unknown }
+      ).getTaskRepeatCfgById$ = () =>
+        throwError(() => new Error('Missing taskRepeatCfg'));
+
+      component.moveTaskToProject('project-b');
+      tick(50); // _getTaskWithSubtasks delay(50)
+      flush(); // focusRelatedTaskOrNext setTimeout
+
+      expect(taskService.moveToProject).toHaveBeenCalledWith(
+        taskWithSubTasks,
+        'project-b',
+      );
+    }));
   });
 });

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
@@ -588,7 +588,7 @@ export class TaskContextMenuInnerComponent implements AfterViewInit, OnDestroy {
 
       forkJoin([
         this._taskRepeatCfgService
-          .getTaskRepeatCfgById$(this.task.repeatCfgId)
+          .getTaskRepeatCfgByIdAllowUndefined$(this.task.repeatCfgId)
           .pipe(first()),
         this._taskService
           .getTasksWithSubTasksByRepeatCfgId$(this.task.repeatCfgId)
@@ -609,6 +609,15 @@ export class TaskContextMenuInnerComponent implements AfterViewInit, OnDestroy {
                 nonArchiveInstancesWithSubTasks,
                 archiveInstances,
               });
+
+              // Repeat config was deleted (e.g. via cross-client sync) but the task
+              // still references it — treat it as a plain task move instead of
+              // crashing on the missing config. (#8715)
+              if (!reminderCfg) {
+                this._taskService.moveToProject(taskWithSubTasks, projectId);
+                this.onClose();
+                return EMPTY;
+              }
 
               // if there is only a single instance (probably just created) than directly update the task repeat cfg
               if (

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -1247,7 +1247,9 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
       setTimeout(() => this.focusNext(true));
     } else {
       forkJoin([
-        this._taskRepeatCfgService.getTaskRepeatCfgById$(t.repeatCfgId).pipe(first()),
+        this._taskRepeatCfgService
+          .getTaskRepeatCfgByIdAllowUndefined$(t.repeatCfgId)
+          .pipe(first()),
         this._taskService.getTasksWithSubTasksByRepeatCfgId$(t.repeatCfgId).pipe(first()),
         this._taskService.getArchiveTasksForRepeatCfgId(t.repeatCfgId),
         this._projectService.getByIdOnce$(projectId),
@@ -1265,6 +1267,15 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
                 nonArchiveInstancesWithSubTasks,
                 archiveInstances,
               });
+
+              // Repeat config was deleted (e.g. via cross-client sync) but the task
+              // still references it — treat it as a plain task move instead of
+              // crashing on the missing config. (#8715)
+              if (!reminderCfg) {
+                this._taskService.moveToProject(this.task(), projectId);
+                setTimeout(() => this.focusNext(true));
+                return EMPTY;
+              }
 
               // if there is only a single instance (probably just created) than directly update the task repeat cfg
               if (


### PR DESCRIPTION
Fixes #8715 — the `💥 Missing taskRepeatCfg` full-app crash.

## Root cause
`selectTaskRepeatCfgById` throws when a `task.repeatCfgId` points at a
deleted config. Such dangling references arise from cross-client sync /
conflict resolution (the scenario prevention commit `0bd1bafcef` targeted).
Any live `store.select(...)` on that selector re-projects on a state change
and the throw propagates to the global error handler → crash. The reported
stack (`select → pluck → map → next`) is exactly this shape.

## Fix
Route every lookup that resolves a config from a **task-derived** id through
the existing non-throwing `getTaskRepeatCfgByIdAllowUndefined$` and degrade
gracefully instead of crashing:

| Path | Behavior when config is missing |
|---|---|
| `updateStartDateOnComplete$` (complete a recurring task) | skip |
| `autoSyncSubtaskTemplatesFromNewest$` (edit subtasks) | skip |
| `moveTaskToProject` — task component | plain task move |
| `moveTaskToProject` — context menu | plain task move |
| edit-repeat dialog | abort + close (no hung spinner) |

Config-id-derived callers (`rescheduleTaskOnRepeatCfgUpdate$`,
`enableAutoUpdateOrInheritSnapshot$`, `checkToUpdateAllTaskInstances$`) keep
the throwing selector — they resolve the id from the edited config's own
action payload, so it exists by construction and the throw is a valid
invariant assertion. The `conflict-resolution.service` caller is already
`try/catch`-wrapped.

## Sync-correctness
No ops added or removed; the config-exists path is behaviorally identical.
The only change is *missing config → deterministic skip* instead of a crash,
which is safe across clients.

## Tests
5 regression tests (2 effects + dialog + context-menu), each verified to
**fail** against the throwing selector and **pass** with the fix. Affected
suites green: effects 89/89, dialog 29/29, context-menu 12/12.
