### PR TITLE
test(sync): reliably dismiss setup-time E2EE dialog in webdav e2e helper

### DIFF
--- a/e2e/pages/sync.page.ts
+++ b/e2e/pages/sync.page.ts
@@ -253,9 +253,21 @@ export class SyncPage extends BasePage {
    * Skip so setup stays unencrypted. No-op if the dialog did not appear.
    */
   private async _skipSetupEncryptionDialogIfPresent(): Promise<void> {
+    // The dialog opens only AFTER save()'s awaited provider-auth/connection check
+    // and a lazy import() of the dialog chunk, so it appears a beat after the
+    // Save click — often after CI load stalls it for a second or more. Use
+    // waitFor(), NOT isVisible(): isVisible() returns the CURRENT state
+    // immediately (its `timeout` never polls), so it raced the dialog and
+    // returned false, leaving the disableClose modal open with its backdrop
+    // blocking the rest of the test. waitFor() actually polls until it appears.
     const skipBtn = this.page.locator('.e2e-setup-encrypt-skip');
-    if (await skipBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+    const appeared = await skipBtn
+      .waitFor({ state: 'visible', timeout: 20000 })
+      .then(() => true)
+      .catch(() => false);
+    if (appeared) {
       await skipBtn.click();
+      await skipBtn.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {});
     }
   }
 
@@ -269,7 +281,9 @@ export class SyncPage extends BasePage {
     const confirmInput = this.page.locator('.e2e-setup-encrypt-confirm-password');
     const submitBtn = this.page.locator('.e2e-setup-encrypt-submit');
 
-    await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
+    // The dialog opens only after save()'s awaited auth check + lazy import(),
+    // which can exceed 5s under CI load (see _skipSetupEncryptionDialogIfPresent).
+    await passwordInput.waitFor({ state: 'visible', timeout: 20000 });
     await passwordInput.click();
     await passwordInput.fill(password);
     await expect(passwordInput).toHaveValue(password);


### PR DESCRIPTION
## What
Fixes the `E2E Tests (WebDAV)` suite, which went red after #8709 (visible on the nightly `E2E Tests (Scheduled)` runs).

## Root cause
#8709 added a mandatory `disableClose` "Encrypt before first upload?" modal on every fresh file-based sync setup. The `setupWebdavSync` e2e helper dismissed it with `locator.isVisible({ timeout })` — but `isVisible()` returns the *current* state immediately and never polls, so its `timeout` is effectively ignored. The modal opens only after `save()`'s awaited provider-auth check and a lazy `import()` of the dialog chunk, so it appears a beat after the Save click; the check raced it, returned `false`, and the Skip click was never issued. The leftover backdrop then blocked every following interaction, failing ~11–12 `@webdav` specs per run with `cdk-overlay-backdrop … intercepts pointer events` and conflict dialogs that never appeared. It passed only when the modal happened to already be up at the instant of the check — hence the flaky-looking spread of failing specs.

## Fix
Use `waitFor({ state: 'visible' })`, which actually polls until the modal appears, then click Skip and confirm it closes. Same wait applied to the encrypt-at-setup fill path. Test-helper only — no product change.

## Verification
- Full `@webdav` CI run green (dispatched run 28659865849 — all jobs pass).
- `npm run checkFile e2e/pages/sync.page.ts` + `tsc -p e2e/tsconfig.json` clean.

## Note (not in this PR)
#8709 makes every fresh file-based sync setup show a mandatory extra modal — reasonable given the plaintext-upload risk it closes, but a new step on a hot setup path, worth a second look against the "calm default" principle if a lighter/dismissible variant is preferred.