### PR TITLE
fix(local-rest-api): validate PATCH/create field value types

### DIFF
--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -397,10 +397,10 @@ curl http://127.0.0.1:3876/tags
 
 | Code             | HTTP Status | Description           |
 | ---------------- | ----------- | --------------------- |
-| `TASK_NOT_FOUND` | 404         | Task does not exist   |
-| `INVALID_INPUT`  | 400         | Invalid request body  |
-| `NOT_FOUND`      | 404         | Route not found       |
-| `INTERNAL_ERROR` | 500         | Internal server error |
+| `TASK_NOT_FOUND` | 404         | Task does not exist                                                          |
+| `INVALID_INPUT`  | 400         | Invalid request body, or a field has the wrong value type (see `error.details`) |
+| `NOT_FOUND`      | 404         | Route not found                                                              |
+| `INTERNAL_ERROR` | 500         | Internal server error                                                        |
 
 ---
 

--- a/electron/local-rest-api.ts
+++ b/electron/local-rest-api.ts
@@ -122,6 +122,20 @@ const handleHttpRequest = async (
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<void> => {
+  // Reject everything while disabled. server.close() stops accepting new
+  // sockets, but an in-flight keep-alive connection could still be served
+  // during the close window; this makes the off switch immediate.
+  if (!isEnabled) {
+    writeJson(res, 503, {
+      ok: false,
+      error: {
+        code: 'API_DISABLED',
+        message: 'Local REST API is disabled',
+      },
+    });
+    return;
+  }
+
   // Block DNS rebinding: reject requests with unexpected Host headers
   const host = req.headers.host;
   if (!host || !ALLOWED_HOSTS.has(host)) {
@@ -237,8 +251,15 @@ export const initLocalRestApi = (): void => {
     void handleHttpRequest(req, res);
   });
 
-  server.on('error', (error) => {
+  server.on('error', (error: NodeJS.ErrnoException) => {
     isListening = false;
+    if (error.code === 'EADDRINUSE') {
+      warn(
+        `[local-rest-api] Port ${LOCAL_REST_API_PORT} is in use — API could not start. ` +
+          `Another process is holding it; free it and toggle the API off/on to retry.`,
+      );
+      return;
+    }
     warn('[local-rest-api] Server error', error);
   });
 
@@ -267,15 +288,23 @@ const stopServer = (): void => {
     return;
   }
 
+  // Reset eagerly: server.close() only invokes its callback once every socket
+  // has closed, so a lingering keep-alive connection would otherwise leave
+  // isListening=true forever and make a later re-enable a no-op (#7484).
+  isListening = false;
+
   server.close((error) => {
     if (error) {
       warn('[local-rest-api] Failed to stop server', error);
       return;
     }
 
-    isListening = false;
     log('[local-rest-api] Server stopped');
   });
+
+  // Force keep-alive sockets shut so the API stops serving immediately on
+  // disable and close() can actually complete.
+  server.closeAllConnections();
 };
 
 export const updateLocalRestApiConfig = (cfg: GlobalConfigState): void => {

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -537,6 +537,19 @@ describe('LocalRestApiHandlerService', () => {
         });
       });
 
+      it('should return 400 when an allowed field has an invalid type', async () => {
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/tasks', {
+            body: { title: 'New Task', timeEstimate: 'not-a-number' },
+          }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('INVALID_INPUT');
+        expect(taskServiceMock.add).not.toHaveBeenCalled();
+      });
+
       it('should reject subTaskIds in body with 400', async () => {
         const response = await sendRequestAndWait(
           createRequest('POST', '/tasks', {
@@ -779,6 +792,44 @@ describe('LocalRestApiHandlerService', () => {
         expect(response.status).toBe(400);
         expect((response.body as any).error.code).toBe('UNSUPPORTED_FIELD');
         expect(taskServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should return 400 (not dispatch) when a field has an invalid type', async () => {
+        const mockTask = createMockTask('task-1');
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(mockTask),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('PATCH', '/tasks/task-1', {
+            body: { tagIds: 123, timeEstimate: 'abc' },
+          }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('INVALID_INPUT');
+        expect(taskServiceMock.update).not.toHaveBeenCalled();
+      });
+
+      it('should accept valid typed fields and dispatch them', async () => {
+        const mockTask = createMockTask('task-1');
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(mockTask),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('PATCH', '/tasks/task-1', {
+            body: { tagIds: ['tag-1'], timeEstimate: 1000, isDone: true },
+          }),
+        );
+
+        expect(response.body.ok).toBe(true);
+        expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
+          tagIds: ['tag-1'],
+          timeEstimate: 1000,
+          isDone: true,
+        });
       });
     });
 

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
+import typia from 'typia';
 import { TaskService } from '../../features/tasks/task.service';
 import { Task, TaskWithSubTasks } from '../../features/tasks/task.model';
 import { TaskArchiveService } from '../../features/archive/task-archive.service';
@@ -54,6 +55,48 @@ const pickAllowedFields = (body: Record<string, unknown>): Partial<Task> => {
     }
   }
   return result as Partial<Task>;
+};
+
+/**
+ * Value-level types for the fields writable via the REST API. Keys mirror
+ * ALLOWED_TASK_FIELDS; `pickAllowedFields` filters by key only, so this is
+ * where the *values* get checked. Without it a caller could push a wrong-typed
+ * value (e.g. `tagIds: 123`, `timeEstimate: 'abc'`) straight into the store and
+ * the synced op-log, where it corrupts state locally and trips typia-as-corrupt
+ * on other devices when the op replays.
+ */
+interface WritableTaskFields {
+  title?: string;
+  notes?: string;
+  isDone?: boolean;
+  timeEstimate?: number;
+  timeSpent?: number;
+  projectId?: string;
+  tagIds?: string[];
+  dueDay?: string | null;
+  dueWithTime?: number | null;
+  plannedAt?: number;
+}
+
+type FieldTypeError = { path: string; expected: string };
+
+/**
+ * Validates the value types of already-key-filtered task fields. The create
+ * path is separately guarded by `typia.assert<Task>` in the task service (a
+ * bad value throws → generic 500); validating here lets both create and PATCH
+ * reject bad input with a clean 400 before anything is dispatched.
+ */
+const validateWritableFields = (
+  fields: Partial<Task>,
+): { ok: true } | { ok: false; errors: FieldTypeError[] } => {
+  const result = typia.validate<WritableTaskFields>(fields);
+  if (result.success) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    errors: result.errors.map((e) => ({ path: e.path, expected: e.expected })),
+  };
 };
 
 const firstRejectedField = (body: Record<string, unknown>): string | undefined =>
@@ -351,6 +394,17 @@ export class LocalRestApiHandlerService {
     const title = body.title.trim();
     const additionalFields = pickAllowedFields(body);
 
+    const validation = validateWritableFields(additionalFields);
+    if (!validation.ok) {
+      return createErrorResponse(
+        requestId,
+        400,
+        'INVALID_INPUT',
+        'One or more task fields have an invalid type',
+        validation.errors,
+      );
+    }
+
     if ('parentId' in body) {
       if (typeof body.parentId !== 'string' || !body.parentId) {
         return createErrorResponse(
@@ -441,12 +495,24 @@ export class LocalRestApiHandlerService {
           );
         }
 
+        const changes = pickAllowedFields(body);
+        const validation = validateWritableFields(changes);
+        if (!validation.ok) {
+          return createErrorResponse(
+            requestId,
+            400,
+            'INVALID_INPUT',
+            'One or more task fields have an invalid type',
+            validation.errors,
+          );
+        }
+
         const task = await this._getTaskById(taskId);
         if (!task) {
           return createErrorResponse(requestId, 404, 'TASK_NOT_FOUND', 'Task not found');
         }
 
-        this._taskService.update(taskId, pickAllowedFields(body));
+        this._taskService.update(taskId, changes);
         return createSuccessResponse(requestId, 200, await this._getTaskById(taskId));
       }
 


### PR DESCRIPTION
## What

Hardens the Local REST API's write path and the Electron HTTP server. Fixes #8732; addresses the root cause of #7484.

## Why

`PATCH /tasks/:id` filtered the body to allowed **keys** but never checked the **value types** (`pickAllowedFields` casts `unknown` → `Partial<Task>`). The create path is guarded by `typia.assert<Task>` deep in `TaskService`, but PATCH dispatched `updateTask` straight into the reducer with no validation. So a request like:

```
curl -X PATCH http://127.0.0.1:3876/tasks/<id> -d '{"tagIds":123,"timeEstimate":"abc"}'
```

returned `200`, wrote a non-array `tagIds` into the store, and captured the malformed change into the **synced op-log** — where it corrupts state locally and can trip typia-as-corrupt on other devices when the op replays. A merely sloppy MCP client trips this, no malice needed.

## Changes

- **Validate field value types on both PATCH and create** (`local-rest-api-handler.service.ts`): a small `WritableTaskFields` type + `typia.validate` reject wrong-typed values with `400 INVALID_INPUT` and a `details` array (`{path, expected}`) before anything is dispatched. Create now returns a clean 400 instead of the previous generic 500.
- **Electron server hardening** (`local-rest-api.ts`):
  - Reset `isListening` eagerly and call `server.closeAllConnections()` in `stopServer`, so a lingering keep-alive socket can't leave the server stuck and no-op a later re-enable. This is the root cause of #7484 ("REST API won't start on subsequent launches").
  - Reject requests with `503 API_DISABLED` while disabled, so the off switch is immediate even for in-flight keep-alive connections.
  - Log an actionable message on `EADDRINUSE` (rather than a generic warn). No user-facing notification — a genuine port conflict is rare given the single-instance lock, so this stays a quiet log per the app's "less noise" principle.
- **Docs**: note that `INVALID_INPUT` now also covers wrong field value types (`docs/wiki/3.01-API.md`).

## Tests

3 new specs (60/60 pass): create rejects a bad-typed field; PATCH rejects `tagIds:123`/`timeEstimate:"abc"` without dispatching; PATCH accepts and dispatches valid typed fields.

## Verification

- `npm run test:file` on the handler spec: 60/60 green (typia transform works under Karma).
- `checkFile` clean on all changed `.ts` files; electron file type-checks (`closeAllConnections` is valid on the bundled Node 22 types).
- The renderer path is fully unit-tested. The Electron server changes are verified by inspection + typecheck only — `electron/local-rest-api.ts` has no test harness yet (tracked separately). **#7484 in particular is worth a quick on-device confirmation before closing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
