### PR TITLE
fix(menu): resolve camel case label in menu bar #8445

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -566,11 +566,11 @@ function createMenu(quitApp: () => void): void {
   // Create application menu to enable copy & pasting on MacOS
   const menuTpl: MenuItemConstructorOptions[] = [
     {
-      label: 'Application',
+      label: 'Super Productivity',
       submenu: [
-        { role: 'about' },
+        { role: 'about', label: 'About Super Productivity' },
         { type: 'separator' },
-        { role: 'hide' },
+        { role: 'hide', label: 'Hide Super Productivity' },
         { role: 'hideOthers' },
         { role: 'unhide' },
         { type: 'separator' },


### PR DESCRIPTION
## Problem

Fixes #8445

The main application menu bar on MacOS was displaying camel case default 'superProductivity', instead of the app name 'Super Productivity'. 

## Solution

Updated the Mac specific menu component to display: Super Productivity for both the About and Hide options.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
