### PR TITLE
fix(tasks): allow adding sub-tasks while IME composition is active

### DIFF
--- a/src/app/features/tasks/add-subtask-input/add-subtask-input.component.spec.ts
+++ b/src/app/features/tasks/add-subtask-input/add-subtask-input.component.spec.ts
@@ -137,6 +137,31 @@ describe('AddSubtaskInputComponent', () => {
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('commits text still held in an active IME/predictive-text composition (#8747)', fakeAsync(() => {
+    // Angular's DefaultValueAccessor buffers ngModelChange during composition,
+    // so titleDraft() stays empty until compositionend (which a predictive
+    // keyboard only fires on a trailing space). Committing on Enter must read
+    // the live input value, otherwise the subtask cannot be added unless the
+    // user types a trailing space first.
+    const input = getInput();
+    input.dispatchEvent(new CompositionEvent('compositionstart'));
+    input.value = 'Composed subtask';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true, isComposing: true }));
+    fixture.detectChanges();
+
+    // Buffering leaves the model empty while the DOM already has the text.
+    expect(component.titleDraft()).toBe('');
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+    tick(100);
+
+    expect(taskServiceSpy.addSubTaskTo).toHaveBeenCalledOnceWith('parent-1', {
+      title: 'Composed subtask',
+    });
+    expect(getInput().value).toBe('');
+  }));
+
   it('ignores repeated and composing Enter events', () => {
     setInputValue('New subtask');
 

--- a/src/app/features/tasks/add-subtask-input/add-subtask-input.component.ts
+++ b/src/app/features/tasks/add-subtask-input/add-subtask-input.component.ts
@@ -87,13 +87,27 @@ export class AddSubtaskInputComponent {
   }
 
   private _commit(): void {
-    const title = this.titleDraft().trim();
+    // Read the live DOM value rather than the titleDraft signal: Angular's
+    // DefaultValueAccessor buffers ngModelChange during IME / predictive-text
+    // composition, so the signal can still be empty when Enter is pressed
+    // mid-composition (the composition only ends — and the signal only
+    // updates — once a trailing space or punctuation is typed). The input
+    // element itself always holds the current text. Falls back to the signal
+    // if the view child is not available (e.g. in unit tests without a DOM).
+    const inputEl = this.inputEl()?.nativeElement;
+    const title = (inputEl?.value ?? this.titleDraft()).trim();
     if (!title) {
       return;
     }
 
     this._taskService.addSubTaskTo(this.parentId(), { title });
     this.titleDraft.set('');
+    // Clear the element directly too: when composition buffering kept the
+    // signal empty, it is already '' and re-setting it would not write the
+    // cleared value back through the one-way [ngModel] binding.
+    if (inputEl) {
+      inputEl.value = '';
+    }
 
     this._isKeepingOpenAfterSubmit = true;
     afterNextRender(

--- a/src/app/features/tasks/add-subtask-input/add-subtask-input.component.ts
+++ b/src/app/features/tasks/add-subtask-input/add-subtask-input.component.ts
@@ -92,8 +92,11 @@ export class AddSubtaskInputComponent {
     // composition, so the signal can still be empty when Enter is pressed
     // mid-composition (the composition only ends — and the signal only
     // updates — once a trailing space or punctuation is typed). The input
-    // element itself always holds the current text. Falls back to the signal
-    // if the view child is not available (e.g. in unit tests without a DOM).
+    // element itself always holds the current text. Enter that instead
+    // *confirms* an IME candidate carries isComposing and is already filtered
+    // out in onKeydown, so this only commits genuinely-entered text. The
+    // signal is a defensive fallback for the impossible case of inputEl being
+    // unresolved (_commit only runs from a keydown on the rendered input).
     const inputEl = this.inputEl()?.nativeElement;
     const title = (inputEl?.value ?? this.titleDraft()).trim();
     if (!title) {


### PR DESCRIPTION
The inline sub-task input committed the titleDraft signal on Enter, but
Angular's DefaultValueAccessor buffers ngModelChange during IME /
predictive-text composition. The signal therefore stayed empty until
compositionend, which many predictive keyboards only fire once a trailing
space is typed. Pressing Enter mid-composition read an empty title and
silently dropped the sub-task, so it could only be added when a trailing
space was present.

Read the live input element value on commit (falling back to the signal
when no DOM is available) and clear the element directly, so composition
buffering no longer strands the draft.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DresRBp5yMkoLK2NZAKmrV