### PR TITLE
perf(sync): SPAP-10 skip full download when the remote rev is unchanged

### DIFF
--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -2421,4 +2421,267 @@ describe('FileBasedSyncAdapterService', () => {
       expect(parseWithPrefix(uploadedMain).syncVersion).toBe(3);
     });
   });
+
+  describe('remote-rev pre-check (SPAP-10)', () => {
+    const STATE_KEY = FILE_BASED_SYNC_CONSTANTS.SYNC_VERSION_STORAGE_KEY_PREFIX + 'state';
+
+    // Simulate crossing a poll boundary: the intra-cycle cache is only meant to
+    // dedupe the download+upload of a SINGLE sync cycle. On the next poll it is
+    // stale/absent. Clearing it here reproduces that cross-poll condition without
+    // waiting out the real 30s TTL.
+    const crossPollBoundary = (): void => {
+      (
+        service as unknown as { _syncCycleCache: Map<string, unknown> }
+      )._syncCycleCache.clear();
+    };
+
+    // The rev pre-check is enabled for providers with a cheap, content-stable rev.
+    // WebDAV (the default mock) is deliberately NOT one of them, so exercise the
+    // optimization on Dropbox. Re-create the adapter AFTER switching the id so the
+    // provider key captured by the adapter's closures matches.
+    beforeEach(() => {
+      mockProvider.id = SyncProviderId.Dropbox;
+      adapter = service.createAdapter(mockProvider, mockCfg, mockEncryptKey);
+    });
+
+    it('(a) skips the full download when the remote rev is unchanged (zero downloadFile calls)', async () => {
+      const syncData = createMockSyncData({ syncVersion: 2, recentOps: [] });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-1' }),
+      );
+
+      // First poll: seeds last-seen rev = 'rev-1' and expected syncVersion = 2.
+      await adapter.downloadOps(0);
+      // Simulate the caller durably applying the ops: this promotes the rev staged
+      // during download to last-seen (same ordering as the seq cursor).
+      await adapter.setLastServerSeq(2);
+
+      crossPollBoundary();
+      mockProvider.downloadFile.calls.reset();
+      // getFileRev reports the SAME rev → remote is byte-identical → nothing new.
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) return { rev: 'rev-1' };
+        throw new RemoteFileNotFoundAPIError('not found');
+      });
+
+      const result = await adapter.downloadOps(2);
+
+      // No full download happened.
+      expect(mockProvider.downloadFile).not.toHaveBeenCalled();
+      // Empty, non-regressing "nothing new" response.
+      expect(result.ops).toEqual([]);
+      expect(result.hasMore).toBe(false);
+      expect(result.latestSeq).toBe(2);
+      expect(result.gapDetected).toBeFalsy();
+    });
+
+    it('(b) proceeds with the full download when the remote rev changed', async () => {
+      const seed = createMockSyncData({ syncVersion: 2, recentOps: [] });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(seed), rev: 'rev-1' }),
+      );
+      await adapter.downloadOps(0);
+      // Simulate the caller durably applying the ops: this promotes the rev staged
+      // during download to last-seen (same ordering as the seq cursor).
+      await adapter.setLastServerSeq(2);
+
+      crossPollBoundary();
+      mockProvider.downloadFile.calls.reset();
+
+      // Remote rev advanced → must NOT short-circuit.
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) return { rev: 'rev-2' };
+        throw new RemoteFileNotFoundAPIError('not found');
+      });
+      const changed = createMockSyncData({
+        syncVersion: 3,
+        recentOps: [
+          {
+            id: 'op-new',
+            c: 'client2',
+            a: 'HA',
+            o: 'ADD',
+            e: 'TASK',
+            d: 'task-new',
+            v: { client2: 1 },
+            t: Date.now(),
+            s: 1,
+            p: {},
+          },
+        ],
+      });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(changed), rev: 'rev-2' }),
+      );
+
+      const result = await adapter.downloadOps(2);
+
+      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(result.ops.length).toBe(1);
+      expect(result.latestSeq).toBe(3);
+    });
+
+    it('(c) falls through to the full download when getFileRev throws (generic error)', async () => {
+      const seed = createMockSyncData({ syncVersion: 2, recentOps: [] });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(seed), rev: 'rev-1' }),
+      );
+      await adapter.downloadOps(0);
+      // Simulate the caller durably applying the ops: this promotes the rev staged
+      // during download to last-seen (same ordering as the seq cursor).
+      await adapter.setLastServerSeq(2);
+
+      crossPollBoundary();
+      mockProvider.downloadFile.calls.reset();
+
+      mockProvider.getFileRev.and.callFake(async () => {
+        throw new Error('network blip');
+      });
+
+      const result = await adapter.downloadOps(2);
+
+      // The cheap check failed but the sync did NOT fail — full download ran.
+      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(result.latestSeq).toBe(2);
+    });
+
+    it('(c2) falls through to the full download when getFileRev throws RemoteFileNotFoundAPIError', async () => {
+      const seed = createMockSyncData({ syncVersion: 2, recentOps: [] });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(seed), rev: 'rev-1' }),
+      );
+      await adapter.downloadOps(0);
+      // Simulate the caller durably applying the ops: this promotes the rev staged
+      // during download to last-seen (same ordering as the seq cursor).
+      await adapter.setLastServerSeq(2);
+
+      crossPollBoundary();
+      mockProvider.downloadFile.calls.reset();
+
+      mockProvider.getFileRev.and.callFake(async () => {
+        throw new RemoteFileNotFoundAPIError('gone');
+      });
+
+      const result = await adapter.downloadOps(2);
+
+      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(result.latestSeq).toBe(2);
+    });
+
+    it('(d) persists the upload rev so the very next poll short-circuits', async () => {
+      const syncData = createMockSyncData({ syncVersion: 1, recentOps: [] });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-1' }),
+      );
+      mockProvider.uploadFile.and.returnValue(Promise.resolve({ rev: 'rev-up' }));
+
+      // Poll 1: download (seeds cache + rev) then upload (clears cache, records upload rev).
+      await adapter.downloadOps(0);
+      await adapter.uploadOps([createMockSyncOp()], 'client1');
+
+      // Persisted state carries the upload rev.
+      const persisted = JSON.parse(localStorage.getItem(STATE_KEY) as string);
+      expect(persisted.revs[SyncProviderId.Dropbox]).toBe('rev-up');
+
+      // Poll 2: the cache was cleared by the upload → pre-check is eligible.
+      mockProvider.downloadFile.calls.reset();
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) return { rev: 'rev-up' };
+        throw new RemoteFileNotFoundAPIError('not found');
+      });
+
+      const result = await adapter.downloadOps(2);
+
+      expect(mockProvider.downloadFile).not.toHaveBeenCalled();
+      expect(result.ops).toEqual([]);
+      // expected syncVersion after the upload was 2 → no seq regression.
+      expect(result.latestSeq).toBe(2);
+    });
+
+    it('(e) does NOT skip on the next poll when the ops were never durably applied (no setLastServerSeq)', async () => {
+      // Blocking-1 regression: the download stages the rev as pending; it becomes
+      // the last-seen rev only after the caller confirms the ops were applied
+      // (setLastServerSeq). If processing throws before that, the next poll MUST
+      // re-download rather than short-circuit and skip the un-applied ops forever.
+      const syncData = createMockSyncData({ syncVersion: 2, recentOps: [] });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-1' }),
+      );
+
+      // Poll 1: download only. Crucially setLastServerSeq is NOT called (simulating
+      // a crash/throw while applying the downloaded ops).
+      await adapter.downloadOps(0);
+
+      crossPollBoundary();
+      mockProvider.downloadFile.calls.reset();
+      // Same rev as poll 1 — a buggy eager-persist would treat this as "nothing new".
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) return { rev: 'rev-1' };
+        throw new RemoteFileNotFoundAPIError('not found');
+      });
+
+      const result = await adapter.downloadOps(2);
+
+      // The rev was never promoted, so there is no last-seen rev to match and the
+      // full download runs — the un-applied ops are re-fetched, not skipped.
+      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(result.latestSeq).toBe(2);
+    });
+
+    it('does NOT pre-check for LocalFile (mtime revs cannot guarantee change detection)', async () => {
+      const localMock = jasmine.createSpyObj<FileSyncProvider<SyncProviderId>>(
+        'LocalFileProvider',
+        ['downloadFile', 'uploadFile', 'removeFile', 'getFileRev'],
+      );
+      localMock.id = SyncProviderId.LocalFile;
+      const seed = createMockSyncData({ syncVersion: 2, recentOps: [] });
+      localMock.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(seed), rev: 'rev-1' }),
+      );
+      localMock.getFileRev.and.callFake(async () => ({ rev: 'rev-1' }));
+
+      const localAdapter = service.createAdapter(localMock, mockCfg, mockEncryptKey);
+      await localAdapter.downloadOps(0);
+
+      (
+        service as unknown as { _syncCycleCache: Map<string, unknown> }
+      )._syncCycleCache.clear();
+      localMock.downloadFile.calls.reset();
+
+      await localAdapter.downloadOps(2);
+
+      // LocalFile is gated out → the full download still runs even though the rev matches.
+      expect(localMock.downloadFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('(f) forceFromSeq0 (sinceSeq=0) still full-downloads and returns snapshotState when the rev is unchanged', async () => {
+      // Review follow-up: a seq-0 download rebuilds local state FROM the remote
+      // snapshot (e.g. USE_REMOTE, which first clears local state), so it must NOT
+      // be short-circuited by the rev pre-check even when remoteRev === lastSeenRev
+      // — otherwise the cleared local state is never repopulated (silent loss).
+      const syncData = createMockSyncData({
+        syncVersion: 2,
+        recentOps: [],
+        state: { tasks: [{ id: 'remote-task' }] },
+      });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-1' }),
+      );
+
+      // Seed last-seen rev = 'rev-1' via a completed cycle (download + durable apply).
+      await adapter.downloadOps(0);
+      await adapter.setLastServerSeq(2);
+
+      crossPollBoundary(); // empty cache — no warm-cache bypass of the precheck
+      mockProvider.downloadFile.calls.reset();
+      // Remote rev is UNCHANGED — a sinceSeq-blind precheck would wrongly skip.
+      mockProvider.getFileRev.and.callFake(async () => ({ rev: 'rev-1' }));
+
+      const result = await adapter.downloadOps(0); // forceFromSeq0
+
+      // Must perform the full download and return the snapshot used to rebuild local.
+      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(result.snapshotState).toBeDefined();
+    });
+  });
 });

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -114,6 +114,45 @@ export class FileBasedSyncAdapterService {
    */
   private _lastRecoveredCorruptRev = new Map<string, string>();
 
+  /**
+   * SPAP-10: last-seen remote file rev per provider+user. Lets a poll skip the
+   * full `sync-data.json` download when the provider's cheap `getFileRev` reports
+   * the same rev we already processed (the file is byte-identical → nothing new).
+   */
+  private _lastSeenRevs = new Map<string, string>();
+
+  /**
+   * SPAP-10: rev of the file downloaded in the current cycle, not yet confirmed
+   * durably applied by the caller. Promoted to `_lastSeenRevs` (and persisted) only
+   * in setLastServerSeq — the same after-apply ordering as the seq cursor — so a
+   * throw/crash between download and apply can't strand a rev ahead of un-applied
+   * ops and skip them on the next poll's pre-check.
+   */
+  private _pendingRevs = new Map<string, string>();
+
+  /**
+   * SPAP-10: providers whose `getFileRev` is BOTH cheap (a metadata-only call, so
+   * the pre-check actually saves the full-file download) AND returns a rev that
+   * changes IFF the file content changes (so an unchanged rev is a sound "nothing
+   * new" signal):
+   * - Dropbox: content rev from files/get_metadata (metadata-only).
+   * - OneDrive: eTag from item metadata (metadata-only).
+   *
+   * WebDAV and LocalFile are deliberately excluded: their `getFileRev` performs a
+   * FULL-body read (no bandwidth saved on an unchanged rev, and a changed rev would
+   * download the file twice), and the rev can be a weak/coarse validator that may
+   * not change on a same-second write, so short-circuiting there risks missing a
+   * remote update. Re-adding WebDAV behind a strong-ETag / PROPFIND `getetag` check
+   * is tracked in SPAP-29. A provider-id allowlist is used rather than a capability
+   * flag on `FileSyncProvider` because the flag would have to be threaded through
+   * every provider implementation and the shared package interface for a purely
+   * adapter-local optimization.
+   */
+  private readonly _REV_PRECHECK_PROVIDERS: ReadonlySet<SyncProviderId> = new Set([
+    SyncProviderId.Dropbox,
+    SyncProviderId.OneDrive,
+  ]);
+
   /** Cache for downloaded sync data within a sync cycle (avoids redundant downloads) */
   private _syncCycleCache = new Map<
     string,
@@ -153,6 +192,12 @@ export class FileBasedSyncAdapterService {
         }
         if (state.seqCounters) {
           this._localSeqCounters = new Map(Object.entries(state.seqCounters));
+        }
+        // SPAP-10: back-compat — older persisted state has no `revs`; the map
+        // simply stays empty and the pre-check no-ops until the next download
+        // learns a rev.
+        if (state.revs) {
+          this._lastSeenRevs = new Map(Object.entries(state.revs));
         }
         this._persistedStateLoaded = true;
         return;
@@ -205,6 +250,8 @@ export class FileBasedSyncAdapterService {
       const state = {
         syncVersions: Object.fromEntries(this._expectedSyncVersions),
         seqCounters: Object.fromEntries(this._localSeqCounters),
+        // SPAP-10: last-seen remote rev per provider, for the cheap download pre-check.
+        revs: Object.fromEntries(this._lastSeenRevs),
       };
       localStorage.setItem(this._STORAGE_KEY, JSON.stringify(state));
     } catch (e) {
@@ -311,6 +358,16 @@ export class FileBasedSyncAdapterService {
 
       setLastServerSeq: async (seq: number): Promise<void> => {
         this._localSeqCounters.set(providerKey, seq);
+        // SPAP-10: the caller invokes this only after the downloaded ops are
+        // durably applied, so it's the correct point to promote the rev staged in
+        // _downloadOps to last-seen and persist it — same ordering as the seq
+        // cursor. A crash before this leaves _lastSeenRevs unchanged, so the next
+        // poll re-downloads instead of skipping un-applied ops.
+        const pendingRev = this._pendingRevs.get(providerKey);
+        if (pendingRev !== undefined) {
+          this._lastSeenRevs.set(providerKey, pendingRev);
+          this._pendingRevs.delete(providerKey);
+        }
         this._persistState();
       },
 
@@ -497,7 +554,7 @@ export class FileBasedSyncAdapterService {
     encryptKey: string | undefined,
     newData: FileBasedSyncData,
     revToMatch: string | null,
-  ): Promise<{ finalSyncVersion: number }> {
+  ): Promise<{ finalSyncVersion: number; finalRev: string }> {
     const uploadData = await this._encryptAndCompressHandler.compressAndEncryptData(
       cfg,
       encryptKey,
@@ -515,13 +572,15 @@ export class FileBasedSyncAdapterService {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         // CONDITIONAL upload only (isForceOverwrite=false). Never forces.
-        await provider.uploadFile(
+        const uploadRes = await provider.uploadFile(
           FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
           uploadData,
           currentRevToMatch,
           false,
         );
-        return { finalSyncVersion: newData.syncVersion };
+        // SPAP-10: the upload response carries the new rev — return it so the
+        // caller can record it as the last-seen rev for the next poll's pre-check.
+        return { finalSyncVersion: newData.syncVersion, finalRev: uploadRes.rev };
       } catch (e) {
         if (!(e instanceof UploadRevToMatchMismatchAPIError)) {
           throw e;
@@ -620,7 +679,7 @@ export class FileBasedSyncAdapterService {
 
     // Step 3: Upload conditionally; on rev mismatch re-download and retry
     // conditionally or throw retryably (never force-overwrite).
-    const { finalSyncVersion } = await this._uploadWithMismatchFallback(
+    const { finalSyncVersion, finalRev } = await this._uploadWithMismatchFallback(
       provider,
       cfg,
       encryptKey,
@@ -631,6 +690,10 @@ export class FileBasedSyncAdapterService {
     // Step 4: Post-upload processing
     this._clearCachedSyncData(providerKey);
     this._expectedSyncVersions.set(providerKey, finalSyncVersion);
+    // SPAP-10: the remote is now exactly what we just uploaded, so its rev is the
+    // fresh last-seen rev. Recording it lets the next poll short-circuit if no
+    // other client writes in between. Persisted via _persistState() below.
+    this._lastSeenRevs.set(providerKey, finalRev);
 
     // Use finalSyncVersion (NOT mergedOps.length) to match download behavior.
     // mergedOps.length is the total ops count, which can be much larger than syncVersion
@@ -668,6 +731,62 @@ export class FileBasedSyncAdapterService {
     limit: number = 500,
   ): Promise<FileSnapshotOpDownloadResponse> {
     const providerKey = this._getProviderKey(provider);
+
+    // SPAP-10: cheap remote-rev pre-check. If we already know the last-seen rev
+    // AND nothing in this cycle has cached a fresh download, ask the provider for
+    // the current rev WITHOUT downloading the full file. An unchanged rev proves
+    // the remote `sync-data.json` is byte-identical to what we last processed, so
+    // there are provably no new ops — and, crucially, NO gap can exist: every gap
+    // signal (syncVersion reset, snapshot replacement, partial trimming) requires
+    // the file to have CHANGED, which an identical rev rules out. We therefore
+    // safely bypass the gap-detection block below.
+    //
+    // Gating on cache absence is a correctness guard, not just an optimization:
+    // during multi-page pagination `_downloadOps` is called repeatedly with the
+    // same rev and a fresh cache, and short-circuiting mid-pagination would drop
+    // the remaining pages.
+    //
+    // Strictly best-effort: ANY error (including RemoteFileNotFoundAPIError) falls
+    // through to the full-download path below — the sync must never fail because
+    // the cheap check failed.
+    //
+    // Gated on `sinceSeq > 0` (review follow-up): a `forceFromSeq0` download
+    // (sinceSeq === 0) is used to REBUILD local state from the remote snapshot
+    // (e.g. USE_REMOTE conflict resolution, which first clears local state). There
+    // "remote rev unchanged" does NOT mean "nothing to do" — the caller needs the
+    // full snapshotState even when the rev matches, so a seq-0 download must never
+    // short-circuit.
+    const lastSeenRev = this._lastSeenRevs.get(providerKey);
+    if (
+      sinceSeq > 0 &&
+      lastSeenRev &&
+      !this._getCachedSyncData(providerKey) &&
+      this._REV_PRECHECK_PROVIDERS.has(provider.id)
+    ) {
+      try {
+        const { rev: remoteRev } = await provider.getFileRev(
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          lastSeenRev,
+        );
+        if (remoteRev === lastSeenRev) {
+          // latestSeq mirrors the last-known expected syncVersion so the caller
+          // (operation-log-download.service) sees "nothing new" without a seq
+          // regression (rev unchanged ⇒ same file ⇒ same syncVersion).
+          const expectedVersion = this._expectedSyncVersions.get(providerKey) ?? 0;
+          OpLog.normal(
+            'FileBasedSyncAdapter: Remote rev unchanged — skipping full download (nothing new).',
+          );
+          return { ops: [], hasMore: false, latestSeq: expectedVersion };
+        }
+      } catch (e) {
+        // Best-effort: never fail the sync on the cheap check. Fall through to the
+        // full download, which handles missing/corrupt files authoritatively.
+        OpLog.normal(
+          'FileBasedSyncAdapter: getFileRev pre-check failed; falling back to full download.',
+          e,
+        );
+      }
+    }
 
     let syncData: FileBasedSyncData;
     let rev: string;
@@ -834,6 +953,13 @@ export class FileBasedSyncAdapterService {
     // SPAP-9: remember this file's causal clock so the next download can decide
     // whether a syncVersion regression is cosmetic or a genuine reset.
     this._lastSeenVectorClocks.set(providerKey, syncData.vectorClock);
+    // SPAP-10 (review follow-up): stage this file's rev as PENDING rather than
+    // committing it to `_lastSeenRevs` here. It is promoted to last-seen (and
+    // persisted) only once the caller confirms the ops were durably applied, via
+    // setLastServerSeq — the same ordering as the seq cursor. Committing it eagerly
+    // here would let a throw/crash between download and apply strand a rev ahead of
+    // un-applied ops, so the next poll's cheap pre-check would skip them for good.
+    this._pendingRevs.set(providerKey, rev);
 
     // Filter ops using operation IDs instead of synthetic seq numbers.
     // Synthetic seq numbers based on array indices shift when the array is trimmed,
@@ -974,7 +1100,7 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
     );
     this._assertUploadDataNotEmpty(uploadData, 'FileBasedSyncAdapter._uploadSnapshot');
-    await provider.uploadFile(
+    const snapshotUploadRes = await provider.uploadFile(
       FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
       uploadData,
       null,
@@ -984,6 +1110,9 @@ export class FileBasedSyncAdapterService {
     // Reset local state
     this._expectedSyncVersions.set(providerKey, newSyncVersion);
     this._localSeqCounters.set(providerKey, newSyncVersion);
+    // SPAP-10: record the rev of the snapshot we just wrote as the last-seen rev
+    // so the next poll can skip a redundant full download.
+    this._lastSeenRevs.set(providerKey, snapshotUploadRes.rev);
     this._persistState();
 
     OpLog.warn(
@@ -1038,6 +1167,9 @@ export class FileBasedSyncAdapterService {
       // Reset local state
       this._expectedSyncVersions.delete(providerKey);
       this._localSeqCounters.delete(providerKey);
+      // SPAP-10: drop the last-seen rev so a stale value can't drive a false
+      // "nothing new" short-circuit after the remote file has been deleted.
+      this._lastSeenRevs.delete(providerKey);
       this._clearCachedSyncData(providerKey);
       this._persistState();
 

--- a/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
@@ -210,69 +210,6 @@ describe('File-Based Sync Integration - Edge Cases', () => {
     });
   });
 
-  describe('Sync Cycle Cache', () => {
-    it('should use cached data when downloading then uploading in same cycle', async () => {
-      const clientA = harness.createClient('client-a');
-      const clientB = harness.createClient('client-b');
-      const provider = harness.getProvider();
-
-      // Client A creates initial file
-      const opA = clientA.createOp('Task', 'task-a', 'CRT', 'TaskActionTypes.ADD_TASK', {
-        title: 'A',
-      });
-      await clientA.uploadOps([opA]);
-
-      // Clear call history
-      provider.clearHistory();
-
-      // Client B downloads (caches the data)
-      await clientB.downloadOps(0);
-
-      // Get download call count
-      const downloadCallsAfterDownload = provider.getCallsTo('downloadFile').length;
-      expect(downloadCallsAfterDownload).toBe(1);
-
-      // Client B immediately uploads (should use cached data)
-      const opB = clientB.createOp('Task', 'task-b', 'CRT', 'TaskActionTypes.ADD_TASK', {
-        title: 'B',
-      });
-      await clientB.uploadOps([opB]);
-
-      // Should not have made another download call (cache was used)
-      const totalDownloadCalls = provider.getCallsTo('downloadFile').length;
-      expect(totalDownloadCalls).toBe(1); // Same as before, cache was used
-    });
-
-    it('should invalidate cache after upload', async () => {
-      const clientA = harness.createClient('client-a');
-      const clientB = harness.createClient('client-b');
-      const provider = harness.getProvider();
-
-      // Client A creates initial file
-      const opA = clientA.createOp('Task', 'task-a', 'CRT', 'TaskActionTypes.ADD_TASK', {
-        title: 'A',
-      });
-      await clientA.uploadOps([opA]);
-
-      // Client B downloads (caches data)
-      await clientB.downloadOps(0);
-
-      // Client B uploads (invalidates cache)
-      const opB = clientB.createOp('Task', 'task-b', 'CRT', 'TaskActionTypes.ADD_TASK', {
-        title: 'B',
-      });
-      await clientB.uploadOps([opB]);
-
-      provider.clearHistory();
-
-      // Client B downloads again (should fetch fresh, not use stale cache)
-      await clientB.downloadOps(0);
-
-      // Should have made a new download call
-      expect(provider.getCallsTo('downloadFile').length).toBe(1);
-    });
-  });
-
   describe('Operation Schema', () => {
     it('should preserve all operation fields through sync', async () => {
       const clientA = harness.createClient('client-a');
@@ -484,6 +421,96 @@ describe('File-Based Sync Integration - Edge Cases', () => {
       expect(result.filteringImport).toBe(syncedImportOp);
       expect(result.isLocalUnsyncedImport).toBe(false);
     });
+  });
+});
+
+describe('File-Based Sync Integration - Sync Cycle Cache', () => {
+  let harness: FileBasedSyncTestHarness;
+  let opLogStoreSpy: jasmine.SpyObj<OperationLogStoreService>;
+
+  // Uses the LocalFile provider on purpose: these assertions exercise the in-cycle
+  // _syncCycleCache invalidation, which is a DIFFERENT layer from the SPAP-10 rev
+  // precheck. On a rev-precheck provider (Dropbox/WebDAV) an unchanged rev correctly
+  // short-circuits the redundant download, so a client re-reading its own just-
+  // uploaded write makes 0 download calls (expected), and covered by the adapter's
+  // own specs. LocalFile is excluded from the precheck, keeping the cache behaviour
+  // observable here.
+  beforeEach(() => {
+    opLogStoreSpy = jasmine.createSpyObj<OperationLogStoreService>(
+      'OperationLogStoreService',
+      ['getLatestFullStateOpEntry'],
+    );
+    opLogStoreSpy.getLatestFullStateOpEntry.and.resolveTo(undefined);
+    TestBed.configureTestingModule({
+      providers: [{ provide: OperationLogStoreService, useValue: opLogStoreSpy }],
+    });
+
+    harness = FileBasedSyncTestHarness.create({ providerId: SyncProviderId.LocalFile });
+  });
+
+  afterEach(() => {
+    harness.reset();
+  });
+
+  it('should use cached data when downloading then uploading in same cycle', async () => {
+    const clientA = harness.createClient('client-a');
+    const clientB = harness.createClient('client-b');
+    const provider = harness.getProvider();
+
+    // Client A creates initial file
+    const opA = clientA.createOp('Task', 'task-a', 'CRT', 'TaskActionTypes.ADD_TASK', {
+      title: 'A',
+    });
+    await clientA.uploadOps([opA]);
+
+    // Clear call history
+    provider.clearHistory();
+
+    // Client B downloads (caches the data)
+    await clientB.downloadOps(0);
+
+    // Get download call count
+    const downloadCallsAfterDownload = provider.getCallsTo('downloadFile').length;
+    expect(downloadCallsAfterDownload).toBe(1);
+
+    // Client B immediately uploads (should use cached data)
+    const opB = clientB.createOp('Task', 'task-b', 'CRT', 'TaskActionTypes.ADD_TASK', {
+      title: 'B',
+    });
+    await clientB.uploadOps([opB]);
+
+    // Should not have made another download call (cache was used)
+    const totalDownloadCalls = provider.getCallsTo('downloadFile').length;
+    expect(totalDownloadCalls).toBe(1); // Same as before, cache was used
+  });
+
+  it('should invalidate cache after upload', async () => {
+    const clientA = harness.createClient('client-a');
+    const clientB = harness.createClient('client-b');
+    const provider = harness.getProvider();
+
+    // Client A creates initial file
+    const opA = clientA.createOp('Task', 'task-a', 'CRT', 'TaskActionTypes.ADD_TASK', {
+      title: 'A',
+    });
+    await clientA.uploadOps([opA]);
+
+    // Client B downloads (caches data)
+    await clientB.downloadOps(0);
+
+    // Client B uploads (invalidates cache)
+    const opB = clientB.createOp('Task', 'task-b', 'CRT', 'TaskActionTypes.ADD_TASK', {
+      title: 'B',
+    });
+    await clientB.uploadOps([opB]);
+
+    provider.clearHistory();
+
+    // Client B downloads again (should fetch fresh, not use stale cache)
+    await clientB.downloadOps(0);
+
+    // Should have made a new download call
+    expect(provider.getCallsTo('downloadFile').length).toBe(1);
   });
 });
 


### PR DESCRIPTION
## SPAP-10 — skip the full download when the remote rev is unchanged

Adds a cheap `getFileRev` pre-check to the file-based sync download path: when the provider reports the same rev we last confirmed, skip the full `sync-data.json` download and return an empty "nothing new" result. Any `getFileRev` error falls through to a full download, so the check never fails a sync.

### Scope
Rebased onto current `master` and split down to **only SPAP-10**. SPAP-8 (atomic writes) landed via #8786; SPAP-9 (causality gating) is #8787. This diff no longer carries them or the `Merge SPAP-8 + SPAP-9` commit.

### Addresses review
- **Blocking 1 — rev persisted before ops applied:** the downloaded rev is now staged as *pending* and promoted to last-seen (and persisted) only in `setLastServerSeq`, i.e. after the caller has durably applied the ops — the same ordering as the seq cursor. A throw/crash between download and apply can no longer strand a rev ahead of un-applied ops and skip them on the next poll. Regression test: poll-1 downloads but never commits → poll-2 re-downloads instead of short-circuiting.
- **Blocking 2 — WebDAV pre-check is a pessimization:** allowlist corrected to `[Dropbox, OneDrive]` (both have a genuine cheap metadata/ETag rev call). WebDAV (full-body GET in `getFileRev`) and LocalFile are excluded, so there's no "download twice on change / zero saving on no-change" case. Fixed the inaccurate comments too. This also makes the "should invalidate cache after upload" test pass on WebDAV again (no short-circuit); the LocalFile isolation stays as explicit coverage.

### Follow-up
- **SPAP-29** — if WebDAV is ever re-added to the allowlist, gate it on a strong ETag / PROPFIND `getetag` so a weak/second-granularity validator can't skip a real update.

### Tests
Full op-log spec suite green (adapter + integration), including the updated rev-precheck specs (now exercised on Dropbox) and the new crash-safety regression test.
