### PR TITLE
fix(app): hide donation UI in Mac App Store build (Guideline 3.1.1)

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -1,5 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { IS_ANDROID_WEB_VIEW } from './util/is-android-web-view';
+import { IS_IOS_NATIVE } from './util/is-native-platform';
 
 export const IS_ELECTRON = navigator.userAgent.toLowerCase().indexOf(' electron/') > -1;
 
@@ -22,6 +23,15 @@ export const IS_GNOME_WAYLAND = IS_ELECTRON && window.ea.isGnomeWayland();
 // True only inside the Electron build — preload exposes process.arch.
 // Web builds can't reliably distinguish Apple Silicon from Intel and stay false.
 export const IS_APPLE_SILICON = IS_ELECTRON && window.ea.isAppleSilicon();
+// True only in a Mac App Store (sandboxed) Electron build. Reuses the existing
+// dist-channel bridge (driven by Electron's process.mas); direct-download macOS
+// (mac-dmg), other channels and web builds stay false.
+export const IS_MAC_APP_STORE = IS_ELECTRON && window.ea.getDistChannel() === 'mac-store';
+// Apple's App Store guidelines forbid donation/contribution links that route
+// around In-App Purchase (Guideline 3.1.1). True for both Apple App Store
+// distribution channels (iOS App Store and Mac App Store); direct-download and
+// web builds stay false, so they keep the donation UI.
+export const IS_APPLE_APP_STORE = IS_IOS_NATIVE || IS_MAC_APP_STORE;
 
 export const TRACKING_INTERVAL = 1000;
 

--- a/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
+++ b/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
@@ -36,7 +36,7 @@ import {
 import { GlobalConfigService } from '../../features/config/global-config.service';
 import { AppFeaturesConfig } from '../../features/config/global-config.model';
 import { SnackService } from '../../core/snack/snack.service';
-import { IS_IOS_NATIVE } from '../../util/is-native-platform';
+import { IS_APPLE_APP_STORE } from '../../app.constants';
 
 @Injectable({
   providedIn: 'root',
@@ -252,8 +252,9 @@ export class MagicNavConfigService {
       },
 
       // Help Menu (rendered as mat-menu)
-      // Not allowed to display donation stuff on iOS per App Store guidelines
-      ...(this.isDonatePageEnabled() && !IS_IOS_NATIVE
+      // Not allowed to display donation stuff on the iOS or Mac App Store per
+      // App Store guidelines (Guideline 3.1.1)
+      ...(this.isDonatePageEnabled() && !IS_APPLE_APP_STORE
         ? [
             {
               type: 'route',
@@ -292,8 +293,9 @@ export class MagicNavConfigService {
             icon: 'feedback',
             href: 'https://github.com/super-productivity/super-productivity/discussions',
           },
-          // Not allowed to display donation stuff on iOS per App Store guidelines
-          ...(!IS_IOS_NATIVE
+          // Not allowed to display donation stuff on the iOS or Mac App Store
+          // per App Store guidelines (Guideline 3.1.1)
+          ...(!IS_APPLE_APP_STORE
             ? [
                 {
                   type: 'href' as const,

--- a/src/app/features/config/form-cfgs/app-features-form.const.ts
+++ b/src/app/features/config/form-cfgs/app-features-form.const.ts
@@ -1,5 +1,6 @@
 import { ConfigFormSection, AppFeaturesConfig } from '../global-config.model';
 import { T } from '../../../t.const';
+import { IS_APPLE_APP_STORE } from '../../../app.constants';
 
 export const EXPERIMENTAL_APP_FEATURE_KEYS: ReadonlyArray<keyof AppFeaturesConfig> = [
   'isEnableUserProfiles',
@@ -93,6 +94,9 @@ export const APP_FEATURES_FORM_CFG: ConfigFormSection<AppFeaturesConfig> = {
     {
       key: 'isDonatePageEnabled',
       type: 'slide-toggle',
+      // Donations are fully hidden on Apple App Store builds (Guideline 3.1.1),
+      // so this toggle would be inert there — hide it to avoid a dead control.
+      hideExpression: () => IS_APPLE_APP_STORE,
       templateOptions: {
         label: T.GCF.APP_FEATURES.DONATE_PAGE,
         icon: 'favorite',

--- a/src/app/features/dialog-please-rate/dialog-please-rate.component.html
+++ b/src/app/features/dialog-please-rate/dialog-please-rate.component.html
@@ -79,20 +79,22 @@
       <!-- Fallback: if no mail client is registered the mailto: link above does
            nothing, so show the address as selectable text (never a dead end). -->
       <small class="feedback-email">{{ maintainerEmail }}</small>
-      <a
-        class="action-item"
-        [href]="contributingUrl"
-        target="_blank"
-        rel="noopener noreferrer"
-        (click)="close('feedback')"
-      >
-        <mat-icon class="action-item-icon">volunteer_activism</mat-icon>
-        <span class="action-item-text">
-          <strong>{{ T.F.D_RATE.FEEDBACK_CONTRIBUTE | translate }}</strong>
-          <small>{{ T.F.D_RATE.FEEDBACK_CONTRIBUTE_DESC | translate }}</small>
-        </span>
-        <mat-icon class="action-item-trailing">open_in_new</mat-icon>
-      </a>
+      @if (!IS_APPLE_APP_STORE) {
+        <a
+          class="action-item"
+          [href]="contributingUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          (click)="close('feedback')"
+        >
+          <mat-icon class="action-item-icon">volunteer_activism</mat-icon>
+          <span class="action-item-text">
+            <strong>{{ T.F.D_RATE.FEEDBACK_CONTRIBUTE | translate }}</strong>
+            <small>{{ T.F.D_RATE.FEEDBACK_CONTRIBUTE_DESC | translate }}</small>
+          </span>
+          <mat-icon class="action-item-trailing">open_in_new</mat-icon>
+        </a>
+      }
     </div>
   </mat-dialog-content>
 

--- a/src/app/features/dialog-please-rate/dialog-please-rate.component.ts
+++ b/src/app/features/dialog-please-rate/dialog-please-rate.component.ts
@@ -6,6 +6,7 @@ import {
   MatDialogTitle,
 } from '@angular/material/dialog';
 import { T } from '../../t.const';
+import { IS_APPLE_APP_STORE } from '../../app.constants';
 import { MatButton } from '@angular/material/button';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatIcon } from '@angular/material/icon';
@@ -46,6 +47,11 @@ export class DialogPleaseRateComponent {
   protected readonly mailtoUrl = buildFeedbackMailto();
   protected readonly discussionsUrl = DISCUSSIONS_URL;
   protected readonly contributingUrl = CONTRIBUTING_URL;
+  // CONTRIBUTING.md links to GitHub Sponsors; Apple App Store builds must not
+  // surface donation paths outside In-App Purchase (Guideline 3.1.1). Mirrors
+  // the gate on the identical Help-menu link. This dialog isn't shown on iOS
+  // (native StoreReview card) but is shown on the Mac App Store (Electron).
+  protected readonly IS_APPLE_APP_STORE = IS_APPLE_APP_STORE;
   // Shown as selectable text under the email option so the channel isn't a dead
   // end when no mail client is registered (common on Linux/web) and the mailto:
   // link silently does nothing.

--- a/src/app/pages/donate-page/donate-page.component.html
+++ b/src/app/pages/donate-page/donate-page.component.html
@@ -1,21 +1,23 @@
 <div class="page-wrapper">
   <div class="content">
-    <p>
-      {{ T.DONATE_PAGE.INTRO_1 | translate }}
-    </p>
-    <p>
-      {{ T.DONATE_PAGE.INTRO_2 | translate }}
-    </p>
-    <p>
-      <a
-        href="https://github.com/sponsors/johannesjo"
-        target="_blank"
-        mat-raised-button
-        color="primary"
-      >
-        <mat-icon>favorite</mat-icon>
-        {{ T.DONATE_PAGE.BUTTON_TEXT | translate }}
-      </a>
-    </p>
+    @if (!IS_APPLE_APP_STORE) {
+      <p>
+        {{ T.DONATE_PAGE.INTRO_1 | translate }}
+      </p>
+      <p>
+        {{ T.DONATE_PAGE.INTRO_2 | translate }}
+      </p>
+      <p>
+        <a
+          href="https://github.com/sponsors/johannesjo"
+          target="_blank"
+          mat-raised-button
+          color="primary"
+        >
+          <mat-icon>favorite</mat-icon>
+          {{ T.DONATE_PAGE.BUTTON_TEXT | translate }}
+        </a>
+      </p>
+    }
   </div>
 </div>

--- a/src/app/pages/donate-page/donate-page.component.ts
+++ b/src/app/pages/donate-page/donate-page.component.ts
@@ -3,6 +3,7 @@ import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { T } from '../../t.const';
 import { TranslatePipe } from '@ngx-translate/core';
+import { IS_APPLE_APP_STORE } from '../../app.constants';
 
 @Component({
   selector: 'donate-page',
@@ -14,4 +15,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 })
 export class DonatePageComponent {
   readonly T = T;
+  // Hides the whole page body on Apple App Store builds — the route stays
+  // reachable by direct URL even though the nav entry is gone. See IS_APPLE_APP_STORE.
+  readonly IS_APPLE_APP_STORE = IS_APPLE_APP_STORE;
 }


### PR DESCRIPTION
## Problem

Apple rejected the macOS **Mac App Store** build (18.13.1) under **Guideline 3.1.1 – Business – Payments – In-App Purchase**: the app links to GitHub Sponsors donations outside of In-App Purchase. Donations tied to "digital content or services" must use IAP or be removed.

The app already hid donation UI on **iOS** via a `!IS_IOS_NATIVE` gate, but the **Mac App Store** (Electron) build had no equivalent gate — it's an Electron/macOS build that was indistinguishable at runtime from the direct-download macOS build.

Super Productivity is free with no IAP and a privacy/offline-first ethos, so the resolution is to **hide all donation UI in Apple App Store distribution builds** (not implement IAP).

## Solution

Detect the Mac App Store build by **reusing the existing `getDistChannel()` preload bridge** (already driven by Electron's `process.mas` → `'mac-store'`), rather than adding a new bridge method. Add a combined constant and gate every donation surface on it:

- `IS_MAC_APP_STORE = IS_ELECTRON && window.ea.getDistChannel() === 'mac-store'`
- `IS_APPLE_APP_STORE = IS_IOS_NATIVE || IS_MAC_APP_STORE`

Gated on `!IS_APPLE_APP_STORE`:
- the **Donate** nav item and the **Help → Contribute** link
- the entire **`/donate` page body** (route stays reachable by direct URL)
- the **"Contribute to the project"** link in the rate dialog (which points to `CONTRIBUTING.md` → GitHub Sponsors; this dialog is shown on the Mac App Store but not on iOS, where the native StoreReview card is used)
- the now-inert **"Donate Page"** toggle in App-Features settings

Also closes a pre-existing iOS gap where the `/donate` page body was reachable by direct URL. **Direct-download macOS (DMG/Homebrew), Linux, Windows and web builds keep the donation UI** (`process.mas` is only set in the `mas`/`mas-dev` electron-builder target).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

> Note: no new unit tests — the change is composed of module-load-time platform constants (like the existing `IS_IOS_NATIVE`/`IS_APPLE_SILICON`), which are intentionally untested here. Pre-merge verification is a `dist:mac:mas:dev` build confirming the donation UI is absent.
