### PR TITLE
fix(issue): prevent config dialog freeze on multi-select calendar fields

### DIFF
--- a/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.spec.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.spec.ts
@@ -1,0 +1,136 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Store } from '@ngrx/store';
+import { DialogEditIssueProviderComponent } from './dialog-edit-issue-provider.component';
+import { ICAL_TYPE } from '../issue.const';
+import { IssueProvider } from '../issue.model';
+import { PluginIssueProviderRegistryService } from '../../../plugins/issue-provider/plugin-issue-provider-registry.service';
+import { PluginBridgeService } from '../../../plugins/plugin-bridge.service';
+import { PluginHttpService } from '../../../plugins/issue-provider/plugin-http.service';
+import { IssueService } from '../issue.service';
+import { SnackService } from '../../../core/snack/snack.service';
+import { TaskService } from '../../tasks/task.service';
+import { TagService } from '../../tag/tag.service';
+
+describe('DialogEditIssueProviderComponent', () => {
+  let fixture: ComponentFixture<DialogEditIssueProviderComponent>;
+  let component: DialogEditIssueProviderComponent;
+
+  beforeEach(async () => {
+    const pluginRegistry = jasmine.createSpyObj('PluginIssueProviderRegistryService', [
+      'hasProvider',
+      'getUseAgendaView',
+      'getProvider',
+      'getName',
+      'getConfigFields',
+      'getFieldMappings',
+    ]);
+    // ICAL is a built-in (non-plugin) provider — keep the plugin code paths inert.
+    pluginRegistry.hasProvider.and.returnValue(false);
+    pluginRegistry.getUseAgendaView.and.returnValue(false);
+    pluginRegistry.getProvider.and.returnValue(undefined);
+    pluginRegistry.getConfigFields.and.returnValue([]);
+    pluginRegistry.getFieldMappings.and.returnValue([]);
+
+    await TestBed.configureTestingModule({
+      imports: [DialogEditIssueProviderComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: { issueProviderKey: ICAL_TYPE } },
+        { provide: PluginIssueProviderRegistryService, useValue: pluginRegistry },
+        {
+          provide: PluginBridgeService,
+          useValue: jasmine.createSpyObj('PluginBridgeService', [
+            'restoreAndCheckOAuthTokens',
+            'clearOAuthTokens',
+            'startOAuthFlow',
+          ]),
+        },
+        {
+          provide: PluginHttpService,
+          useValue: jasmine.createSpyObj('PluginHttpService', ['createHttpHelper']),
+        },
+        {
+          provide: MatDialogRef,
+          useValue: jasmine.createSpyObj('MatDialogRef', ['close']),
+        },
+        { provide: MatDialog, useValue: jasmine.createSpyObj('MatDialog', ['open']) },
+        {
+          provide: Store,
+          useValue: jasmine.createSpyObj('Store', ['dispatch', 'select', 'pipe']),
+        },
+        {
+          provide: IssueService,
+          useValue: jasmine.createSpyObj('IssueService', ['testConnection']),
+        },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', ['open']),
+        },
+        { provide: TaskService, useValue: { allTasks$: of([]) } },
+        { provide: TagService, useValue: { tagsNoMyDayAndNoList$: of([]) } },
+      ],
+    })
+      // Render nothing: we only exercise the model-change handlers, not the
+      // (heavy) template with its Material + child-component dependencies.
+      .overrideComponent(DialogEditIssueProviderComponent, {
+        set: { template: '', imports: [] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(DialogEditIssueProviderComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('formlyModelChange (#8777 infinite rebuild-loop guard)', () => {
+    // Formly runs in immutable mode (see formly-config.module.ts) and emits a
+    // fresh clone of the full model on every change, short-circuiting its own
+    // rebuild ONLY when it receives that exact reference back
+    // (`_modelChangeValue === model`). If the handler runs the emitted model
+    // through mergeIssueProviderModelUpdates() it produces a NEW object, defeats
+    // that guard, and — because immutable mode re-clones array field values on
+    // each rebuild — spins an infinite rebuild -> patchValue -> modelChange loop
+    // that froze the whole app when picking a "Calendars to display" entry (an
+    // array-valued multiSelect field). #8777
+    it('assigns the emitted model by reference (no merged copy)', () => {
+      const emitted = {
+        ...component.model,
+        pluginConfig: { readCalendarIds: ['primary'] },
+      } as Partial<IssueProvider>;
+
+      component.formlyModelChange(emitted);
+
+      // Formly's immutable guard compares the top-level model reference; a merged
+      // copy would differ and re-trigger a rebuild, looping forever on arrays.
+      expect(component.model).toBe(emitted);
+    });
+
+    it('resets isConnectionWorks so a prior success is invalidated', () => {
+      component.isConnectionWorks.set(true);
+
+      component.formlyModelChange({ ...component.model } as Partial<IssueProvider>);
+
+      expect(component.isConnectionWorks()).toBe(false);
+    });
+  });
+
+  describe('customCfgCmpSave', () => {
+    // Custom cfg components (Jira/OpenProject/Nextcloud-Deck) emit PARTIAL config
+    // updates, so this path must still merge to preserve omitted keys.
+    it('merges partial pluginConfig updates, preserving omitted keys', () => {
+      component.model = {
+        ...component.model,
+        pluginConfig: { accountId: '1', bucketId: '10' },
+      } as Partial<IssueProvider>;
+
+      component.customCfgCmpSave({
+        pluginConfig: { accountId: '2' },
+      } as unknown as Parameters<typeof component.customCfgCmpSave>[0]);
+
+      expect((component.model as { pluginConfig?: unknown }).pluginConfig).toEqual({
+        accountId: '2',
+        bucketId: '10',
+      });
+    });
+  });
+});

--- a/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
@@ -254,7 +254,17 @@ export class DialogEditIssueProviderComponent {
   }
 
   formlyModelChange(model: Partial<IssueProvider>): void {
-    this.updateModel(model);
+    // Assign Formly's emitted model by reference. Formly runs in immutable mode
+    // and emits a clone of the full model, short-circuiting its own rebuild only
+    // when it receives that exact reference back (`_modelChangeValue === model`).
+    // Running it through mergeIssueProviderModelUpdates() would create a new
+    // object, defeat that guard, and — because immutable mode re-clones array
+    // field values on every rebuild — spin an infinite
+    // rebuild→patchValue→modelChange loop that freezes the app whenever a
+    // multiSelect field (e.g. "Calendars to display") holds an array value (#8777).
+    // Partial updates from custom cfg components still go through updateModel().
+    this.model = model;
+    this.isConnectionWorks.set(false);
   }
 
   customCfgCmpSave(cfgUpdates: IssueIntegrationCfg): void {


### PR DESCRIPTION
## Problem

Fixes #8777 — the app freezes hard when checking a calendar in the **"Calendars to display"** dropdown of a calendar integration (Google Calendar plugin, or CalDAV/Nextcloud). Confirmed by 6 reporters across Windows/Linux/macOS/Android on v18.13.1. Symptoms: UI fully unresponsive, console empty (no error), memory climbing — an infinite synchronous loop.

## Root cause

The "Calendars to display" field is a plugin `multiSelect` config field, mapped to a Formly Material `select` with `multiple: true`, so its model value is an **array**.

- Formly runs in `immutable: true` mode (`src/app/ui/formly-config.module.ts`). On every rebuild it deep-clones the model, and `clone()` always produces a **new array reference**.
- `FormlyForm.set model` skips a rebuild only when it receives back the **exact** reference it emitted (`immutable && this._modelChangeValue === model`).
- `formlyModelChange()` ran the emitted model through `mergeIssueProviderModelUpdates()`, which returns a **new object** → the guard is defeated → full rebuild.
- During rebuild, Formly compares `control.value !== value` **by reference** and calls `control.patchValue(value)` (which emits) when they differ. For an array the freshly-cloned reference is never `===` the control's array → `patchValue` fires every cycle → `valueChanges` → `modelChange` → new object → rebuild → **infinite loop**. Scalar fields converge because they compare equal by `===`, which is why only the multi-select froze.

(The Boards form's `multiple: true` select never froze because it stores the emitted model verbatim — `boardCfg.set($event)` — so the guard holds.)

## Fix

`formlyModelChange()` now assigns Formly's emitted model **by reference** instead of merging it:

```ts
this.model = model;
this.isConnectionWorks.set(false);
```

Formly emits the complete immutably-cloned model, so no merge is needed on this path, and assigning the emitted reference back satisfies Formly's immutable guard (the same pattern every other `formly-form` dialog in the app already uses). The merge (`mergeIssueProviderModelUpdates`) is still applied on the `customCfgCmpSave()` path, which handles **partial** config updates from custom cfg components (Jira / OpenProject / Nextcloud-Deck) that must preserve omitted keys.

Verified that dropping the merge on the Formly path is safe: `isEnabled` (managed by the separate standalone slide-toggle, which the merge deliberately skipped) stays correct because Formly's internal model is always re-synced from `this.model`, and the special `pluginConfig` deep-merge is only needed for the partial custom-cfg emits, which are untouched.

## Tests

New `dialog-edit-issue-provider.component.spec.ts` (3 tests): asserts `formlyModelChange` assigns the emitted model by reference (**confirmed to fail against the pre-fix code and pass after**), resets `isConnectionWorks`, and that `customCfgCmpSave` still merges partial `pluginConfig` updates. `npm run checkFile` clean on both files.

## Review

Ran a 6-agent parallel review (correctness, security, architecture, alternatives, performance, simplicity) — unanimous approval, no CRITICAL/WARNING findings against the diff. The review also surfaced a *pre-existing* latent copy of this same footgun in `dialog-work-context-settings` (builds a new object on its modelChange path; harmless today only because that form has no array field) — left for a separate follow-up.
