### PR TITLE
fix(android): reserve full system-bar inset for the mobile bottom nav (#8792)

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -79,7 +79,7 @@
 .has-mobile-bottom-nav {
   @include mq(xs, max) {
     .main-content {
-      padding-bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom) / 2);
+      padding-bottom: calc(var(--bottom-nav-height) + var(--bottom-nav-safe-area));
     }
   }
 }

--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
@@ -9,7 +9,9 @@
   bottom: 0;
   left: 0;
   right: 0;
-  height: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom) / 2);
+  // Background fills the full height incl. the reserved system-bar area; the
+  // padding-bottom below keeps the buttons above it (see --bottom-nav-safe-area).
+  height: calc(var(--bottom-nav-height) + var(--bottom-nav-safe-area));
   box-sizing: border-box;
   background: var(--bottom-nav-bg);
   border-top: 1px solid var(--separator-color);
@@ -17,7 +19,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 var(--s);
-  padding-bottom: calc(env(safe-area-inset-bottom) / 2);
+  padding-bottom: var(--bottom-nav-safe-area);
   z-index: var(--z-mobile-bottom-nav);
   display: flex;
 
@@ -113,12 +115,6 @@
       pointer-events: none;
     }
   }
-}
-
-// iOS: nav extends its background into the home indicator area,
-// padding keeps buttons above it
-:host-context(.isIOS) .mobile-bottom-nav {
-  padding-bottom: calc(env(safe-area-inset-bottom) / 2);
 }
 
 // Material Design touch target improvements

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,6 +56,12 @@ body.isNativeMobile {
   }
 }
 
+// Native Android's opaque system bars need the full inset, not the iOS half
+// default — see --bottom-nav-safe-area in _css-variables.scss (#8792).
+body.isNativeMobile:not(.isIOS) {
+  --bottom-nav-safe-area: var(--safe-area-bottom);
+}
+
 // iOS-specific adjustments
 body.isIOS {
   // Prevent overscroll bounce effect

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -65,6 +65,20 @@
   --safe-area-left: var(--safe-area-inset-left, env(safe-area-inset-left, 0px));
   --safe-area-right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));
 
+  // Bottom clearance reserved by the mobile bottom nav and everything stacked
+  // above it (scroll content, snackbars). Half the inset by default: iOS's home
+  // indicator is thin and translucent, so a full inset reads as an oversized gap.
+  // Native Android's system bars (3-button / gesture) are opaque and must be
+  // cleared in full or the nav buttons draw under them (#8792) — overridden to
+  // the full inset for native Android in styles.scss. Reads through the shared
+  // --safe-area-bottom (not raw env()) so this tracks the same source as the
+  // header/side-nav/body insets and all bottom-inset UI behaves uniformly across
+  // SystemBars WebView bands. Caveat: on the narrow API >= 35 / WebView < 140
+  // band the shared source can double-count vs SystemBars' native padding (a
+  // cosmetic gap, not an overlap — see the device-matrix risks in
+  // docs/plans/2026-06-22-android-systembars-migration-corrected.md).
+  --bottom-nav-safe-area: calc(var(--safe-area-bottom) / 2);
+
   // Keyboard height (set dynamically via JS)
   --keyboard-height: 0px;
   --keyboard-overlay-offset: 0px;

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -504,14 +504,14 @@ body.isVerticalActionBar .cdk-overlay-pane.mat-mdc-tooltip-panel {
   }
   body.hasMobileBottomNav mat-snack-bar-container {
     margin-bottom: calc(
-      var(--bottom-nav-height) + env(safe-area-inset-bottom) / 2 + 24px
+      var(--bottom-nav-height) + var(--bottom-nav-safe-area) + 24px
     ) !important;
     pointer-events: auto;
     transition: 150ms margin;
   }
   body.hasMobileBottomNav.isAddTaskBarOpen mat-snack-bar-container {
     margin-bottom: calc(
-      var(--bottom-nav-height) + env(safe-area-inset-bottom) / 2 + 48px
+      var(--bottom-nav-height) + var(--bottom-nav-safe-area) + 48px
     ) !important;
     pointer-events: auto;
   }


### PR DESCRIPTION
## Fixes #8792

On Android with **3-button navigation** (reported on POCO F7 / HyperOS / Android 16), the system nav buttons (◄ ● ■) overlap the app's own mobile bottom nav — the "+" FAB and nav icons draw *under* the system bar.

### Root cause

The bottom nav reserved only `env(safe-area-inset-bottom) / 2` (half the inset). That `/2` was introduced deliberately in `c115c46b53` (Feb 2026) to avoid an oversized gap above **iOS's** thin/translucent home indicator — but it was applied globally. Android's system bars (3-button *and* gesture) are **opaque** and must be cleared in full, so half leaves the buttons underneath.

It only became visible on Android ~2 weeks before this fix: before the SystemBars edge-to-edge migration (`bb3ed74480`, Jun 2026), `@capawesome` natively inset the WebView so `env(safe-area-inset-bottom) ≈ 0` on Android and full-vs-half was a no-op there. The migration made `env()` report the real inset, turning the pre-existing `/2` into a visible half-overlap on opaque bars.

### Fix

Introduce a `--bottom-nav-safe-area` token:

- **Default** (iOS / web / desktop): `calc(var(--safe-area-bottom) / 2)` — behaviour unchanged, iOS keeps its deliberate half-inset.
- **Native Android** (`body.isNativeMobile:not(.isIOS)`): full `var(--safe-area-bottom)`.

All six previous `env(...bottom) / 2` sites (nav height, nav padding, `.main-content` padding, two snackbar margins) route through the token so the nav footprint and everything stacked above it stay in lockstep. This aligns the bottom nav with the header, side-nav drawer, body padding and focus overlay, which already reserve the full `var(--safe-area-*)` inset on the same devices.

### Scope / risk

- iOS, iPad (always `.isIOS`), and web/desktop render **byte-for-byte unchanged**; only native Android changes.
- **Device-matrix caveat to verify:** on the narrow **API ≥ 35 + WebView < 140** band, SystemBars natively pads the WebView *and* injects `--safe-area-inset-*`, so any `var(--safe-area-*)` consumer can double-count → a small cosmetic gap (not an overlap). The common API-36 case (incl. the reporter's device) is WebView ≥ 140 passthrough, where the fix is exactly correct. This corner is already shared by the existing full-inset consumers and is tracked as a device-matrix item in `docs/plans/2026-06-22-android-systembars-migration-corrected.md`.

### Testing

`npm run checkFile` passes on all modified files. **Not verified on-device** (CSS-only change; Android build not available in my environment) — ideally smoke-tested on both a gesture-nav and a 3-button device before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
