### PR TITLE
fix(sync): stop file-based E2EE key loss from leaking plaintext (GHSA-9544)

### DIFF
--- a/packages/sync-providers/src/file-based/dropbox/dropbox.ts
+++ b/packages/sync-providers/src/file-based/dropbox/dropbox.ts
@@ -32,6 +32,13 @@ export interface DropboxCfg {
 
 export interface DropboxPrivateCfg {
   encryptKey?: string;
+  /**
+   * Durable per-provider record that the user enabled encryption, kept
+   * separately from the key so a silently dropped `encryptKey` stays
+   * detectable (GHSA-9544-hjjr-fg8h). Absent on pre-fix configs — read as
+   * `isEncryptionEnabled ?? !!encryptKey`.
+   */
+  isEncryptionEnabled?: boolean;
   accessToken: string;
   refreshToken: string;
 }

--- a/packages/sync-providers/src/file-based/local-file/local-file.model.ts
+++ b/packages/sync-providers/src/file-based/local-file/local-file.model.ts
@@ -8,6 +8,13 @@ export const PROVIDER_ID_LOCAL_FILE = 'LocalFile' as const;
 export interface LocalFileSyncPrivateCfg {
   encryptKey?: string;
   /**
+   * Durable per-provider record that the user enabled encryption, kept
+   * separately from the key so a silently dropped `encryptKey` stays
+   * detectable (GHSA-9544-hjjr-fg8h). Absent on pre-fix configs — read as
+   * `isEncryptionEnabled ?? !!encryptKey`.
+   */
+  isEncryptionEnabled?: boolean;
+  /**
    * @deprecated Electron-selected sync folder path, kept only so older
    * persisted configs can still be parsed. Post-#8228 the authoritative
    * sync folder lives main-side (inlined cache backed by `simple-store`

--- a/packages/sync-providers/src/file-based/onedrive/onedrive.model.ts
+++ b/packages/sync-providers/src/file-based/onedrive/onedrive.model.ts
@@ -1,5 +1,12 @@
 export interface OneDrivePrivateCfg {
   encryptKey?: string;
+  /**
+   * Durable per-provider record that the user enabled encryption, kept
+   * separately from the key so a silently dropped `encryptKey` stays
+   * detectable (GHSA-9544-hjjr-fg8h). Absent on pre-fix configs — read as
+   * `isEncryptionEnabled ?? !!encryptKey`.
+   */
+  isEncryptionEnabled?: boolean;
   useCustomApp?: boolean;
   clientId: string;
   tenantId: string;

--- a/packages/sync-providers/src/file-based/webdav/nextcloud.model.ts
+++ b/packages/sync-providers/src/file-based/webdav/nextcloud.model.ts
@@ -1,5 +1,12 @@
 export interface NextcloudPrivateCfg {
   encryptKey?: string;
+  /**
+   * Durable per-provider record that the user enabled encryption, kept
+   * separately from the key so a silently dropped `encryptKey` stays
+   * detectable (GHSA-9544-hjjr-fg8h). Absent on pre-fix configs — read as
+   * `isEncryptionEnabled ?? !!encryptKey`.
+   */
+  isEncryptionEnabled?: boolean;
   serverUrl: string;
   /**
    * Optional login identifier used for authentication. Some Nextcloud

--- a/packages/sync-providers/src/file-based/webdav/webdav.model.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav.model.ts
@@ -1,5 +1,12 @@
 export interface WebdavPrivateCfg {
   encryptKey?: string;
+  /**
+   * Durable per-provider record that the user enabled encryption, kept
+   * separately from the key so a silently dropped `encryptKey` stays
+   * detectable (GHSA-9544-hjjr-fg8h). Absent on pre-fix configs — read as
+   * `isEncryptionEnabled ?? !!encryptKey`.
+   */
+  isEncryptionEnabled?: boolean;
   baseUrl: string;
   userName: string;
   password: string;

--- a/packages/sync-providers/src/provider-types.ts
+++ b/packages/sync-providers/src/provider-types.ts
@@ -189,6 +189,16 @@ export interface OperationSyncCapable<
    */
   isEncryptionEnabled?(): Promise<boolean>;
   /**
+   * Whether encryption is enabled for this provider but no usable key is
+   * available — the dropped-credential signature (GHSA-9544-hjjr-fg8h).
+   * File-based providers encrypt inside the adapter and do not expose
+   * `getEncryptKey`, so the upload path cannot infer their missing key from the
+   * `isEncryptionMandatory` guard; it queries this instead and fails closed
+   * (refuses to upload) rather than silently sending plaintext. Providers that
+   * surface their key via `getEncryptKey` (SuperSync) leave this unset.
+   */
+  isEncryptionKeyMissing?(): Promise<boolean>;
+  /**
    * Whether this provider mandates end-to-end encryption and must NEVER transmit
    * plaintext operations. When true, the upload path refuses to push ops while no
    * usable encryption key is configured yet (e.g. first-time setup, before the

--- a/src/app/imex/sync/file-based-encryption.service.spec.ts
+++ b/src/app/imex/sync/file-based-encryption.service.spec.ts
@@ -194,6 +194,20 @@ describe('FileBasedEncryptionService', () => {
       });
     });
 
+    // GHSA-9544-hjjr-fg8h: intent must be persisted per-provider in privateCfg,
+    // atomically with the key, so it survives a later silent key drop.
+    it('should persist isEncryptionEnabled: true into privateCfg with the key', async () => {
+      await service.enableEncryption('my-password');
+
+      expect(mockProviderManager.setProviderConfig).toHaveBeenCalledWith(
+        SyncProviderId.WebDAV,
+        jasmine.objectContaining({
+          encryptKey: 'my-password',
+          isEncryptionEnabled: true,
+        }),
+      );
+    });
+
     it('should clear derived key cache', async () => {
       await service.enableEncryption('my-password');
 
@@ -363,6 +377,21 @@ describe('FileBasedEncryptionService', () => {
 
       // Should NOT call setPrivateCfg directly
       expect(mockProvider.setPrivateCfg).not.toHaveBeenCalled();
+    });
+
+    // GHSA-9544-hjjr-fg8h: clearing the key and recording intent=false must be a
+    // single atomic privateCfg write, so a crash before the global flag update
+    // cannot leave "encryption on, key gone" and wrongly block plaintext sync.
+    it('should persist isEncryptionEnabled: false into privateCfg atomically with key removal', async () => {
+      await service.disableEncryption();
+
+      expect(mockProviderManager.setProviderConfig).toHaveBeenCalledWith(
+        SyncProviderId.WebDAV,
+        jasmine.objectContaining({
+          encryptKey: undefined,
+          isEncryptionEnabled: false,
+        }),
+      );
     });
 
     it('should update global config to disable encryption', async () => {

--- a/src/app/imex/sync/file-based-encryption.service.ts
+++ b/src/app/imex/sync/file-based-encryption.service.ts
@@ -107,10 +107,16 @@ export class FileBasedEncryptionService {
     try {
       if (isDisable) {
         // Use providerManager.setProviderConfig() instead of direct setPrivateCfg()
-        // to ensure the currentProviderPrivateCfg$ observable is updated
+        // to ensure the currentProviderPrivateCfg$ observable is updated.
+        // GHSA-9544: write the intent flag ATOMICALLY with the key removal in the
+        // single privateCfg write, so a crash before the global updateSection
+        // below cannot leave the durable per-provider state at "encryption on,
+        // key gone" — which would then (correctly) block all uploads for a
+        // provider the user deliberately switched to plaintext.
         await this._providerManager.setProviderConfig(provider.id, {
           ...existingCfg,
           encryptKey: undefined,
+          isEncryptionEnabled: false,
         });
         this._globalConfigService.updateSection('sync', {
           isEncryptionEnabled: false,
@@ -120,6 +126,7 @@ export class FileBasedEncryptionService {
         await this._providerManager.setProviderConfig(provider.id, {
           ...existingCfg,
           encryptKey,
+          isEncryptionEnabled: true,
         });
         this._globalConfigService.updateSection('sync', {
           isEncryptionEnabled: true,

--- a/src/app/imex/sync/sync-config.service.spec.ts
+++ b/src/app/imex/sync/sync-config.service.spec.ts
@@ -151,6 +151,8 @@ describe('SyncConfigService', () => {
           password: 'oldpass', // Preserved from old config
           syncFolderPath: '/old', // Preserved from old config
           encryptKey: 'test-key', // New value from settings
+          // GHSA-9544: durable intent backfilled from the key present at save.
+          isEncryptionEnabled: true,
         },
       );
     });
@@ -180,6 +182,8 @@ describe('SyncConfigService', () => {
         SyncProviderId.LocalFile,
         {
           encryptKey: 'test-key',
+          // GHSA-9544: durable intent backfilled from the key present at save.
+          isEncryptionEnabled: true,
         },
       );
     });
@@ -338,6 +342,8 @@ describe('SyncConfigService', () => {
           accessToken: 'existing-access-token', // Preserved OAuth tokens
           refreshToken: 'existing-refresh-token', // Preserved OAuth tokens
           encryptKey: 'dropbox-key', // Updated from settings
+          // GHSA-9544: durable intent backfilled from the key present at save.
+          isEncryptionEnabled: true,
         },
       );
     });
@@ -809,6 +815,8 @@ describe('SyncConfigService', () => {
           password: 'newpass',
           syncFolderPath: '/new',
           encryptKey: 'new-key',
+          // GHSA-9544: durable intent backfilled from the key present at save.
+          isEncryptionEnabled: true,
         },
       );
     });

--- a/src/app/imex/sync/sync-config.service.ts
+++ b/src/app/imex/sync/sync-config.service.ts
@@ -155,8 +155,13 @@ export class SyncConfigService {
       };
     }
 
+    // File-based providers: prefer the durable per-provider intent flag over key
+    // presence (GHSA-9544-hjjr-fg8h). A silently dropped key must still show the
+    // form as "encryption on" so the user isn't misled into thinking they turned
+    // it off, and so a settings save preserves the intent instead of flipping it
+    // off. Pre-fix configs without the flag fall back to key presence.
     return {
-      isEncryptionEnabled: !!encryptKey,
+      isEncryptionEnabled: privateCfg.isEncryptionEnabled ?? !!encryptKey,
       encryptKey,
     };
   }
@@ -435,10 +440,18 @@ export class SyncConfigService {
     // For SuperSync, isEncryptionEnabled is managed exclusively by dedicated dialogs
     // (EnableEncryption, DisableEncryption, HandleDecryptError), NOT the form.
     // Preserve the saved value to prevent accidental overwrites during config saves.
+    //
+    // For file-based providers, persist the durable per-provider intent flag
+    // (GHSA-9544-hjjr-fg8h): PRESERVE an existing value so a routine save while
+    // the key is missing cannot silently disarm the plaintext-upload guard, and
+    // otherwise backfill from the key present at save time (capturing intent
+    // while the key still proves it, before any later silent drop).
+    const oldIsEncryptionEnabled = (oldConfig as { isEncryptionEnabled?: boolean })
+      ?.isEncryptionEnabled;
     const savedIsEncryptionEnabled =
       providerId === SyncProviderId.SuperSync
-        ? (oldConfig as { isEncryptionEnabled?: boolean })?.isEncryptionEnabled
-        : undefined;
+        ? oldIsEncryptionEnabled
+        : (oldIsEncryptionEnabled ?? !!resolvedEncryptKey);
 
     const configWithDefaults = {
       ...PROVIDER_FIELD_DEFAULTS[providerId],

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -36,7 +36,9 @@ import {
   SyncDataCorruptedError,
   UploadRevToMatchMismatchAPIError,
   WebDavNativeRequestError,
+  EncryptNoPasswordError,
 } from '../../op-log/core/errors/sync-errors';
+import { DialogEnterEncryptionPasswordComponent } from './dialog-enter-encryption-password/dialog-enter-encryption-password.component';
 import { MAX_LWW_REUPLOAD_RETRIES } from '../../op-log/core/operation-log.const';
 
 describe('SyncWrapperService', () => {
@@ -1620,6 +1622,37 @@ describe('SyncWrapperService', () => {
           jasmine.objectContaining({
             type: 'ERROR',
           }),
+        );
+      });
+
+      // GHSA-9544-hjjr-fg8h: USE_LOCAL force-uploads, which refuses to send
+      // plaintext when the key is missing. Route to the enter-password recovery
+      // dialog instead of a dead-end error snack.
+      it('should open the enter-password dialog (not an error snack) when USE_LOCAL hits a missing key', async () => {
+        const conflictError = new LocalDataConflictError(
+          2,
+          { tasks: [] },
+          { clientB: 3 },
+        );
+        mockSyncService.downloadRemoteOps.and.returnValue(Promise.reject(conflictError));
+
+        mockMatDialog.open.and.returnValue({
+          afterClosed: () => of('USE_LOCAL'),
+        } as any);
+
+        mockSyncService.forceUploadLocalState = jasmine
+          .createSpy('forceUploadLocalState')
+          .and.rejectWith(new EncryptNoPasswordError('key missing'));
+
+        const result = await service.sync();
+
+        expect(result).toBe('HANDLED_ERROR');
+        expect(mockMatDialog.open).toHaveBeenCalledWith(
+          DialogEnterEncryptionPasswordComponent,
+          jasmine.anything(),
+        );
+        expect(mockSnackService.open).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({ type: 'ERROR' }),
         );
       });
 

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -36,6 +36,7 @@ import {
   ConflictReason,
   DecryptError,
   DecryptNoPasswordError,
+  EncryptNoPasswordError,
   MissingCredentialsSPError,
   NetworkUnavailableSPError,
   PotentialCorsError,
@@ -800,7 +801,13 @@ export class SyncWrapperService {
           type: 'ERROR',
         });
         return 'HANDLED_ERROR';
-      } else if (error instanceof DecryptNoPasswordError) {
+      } else if (
+        error instanceof DecryptNoPasswordError ||
+        // Upload-side twin (GHSA-9544-hjjr-fg8h): encryption is enabled but the
+        // key is gone (dropped credentials) — same recovery as the download
+        // case: prompt for the password instead of syncing plaintext.
+        error instanceof EncryptNoPasswordError
+      ) {
         this._handleMissingPasswordDialog();
         return 'HANDLED_ERROR';
       } else if (error instanceof DecryptError) {
@@ -994,12 +1001,20 @@ export class SyncWrapperService {
         this._providerManager.setSyncStatus('IN_SYNC');
         SyncLog.log('SyncWrapperService: Force upload complete');
       } catch (error) {
-        SyncLog.err('SyncWrapperService: Force upload failed:', error);
-        const errStr = getSyncErrorStr(error);
-        this._snackService.open({
-          msg: errStr,
-          type: 'ERROR',
-        });
+        // GHSA-9544-hjjr-fg8h: a keyless-but-encryption-enabled provider makes
+        // force upload refuse to send plaintext. Route to the enter-password
+        // recovery dialog like the main sync path, not a dead-end error snack —
+        // otherwise "force overwrite" (offered as the lost-key recovery) loops.
+        if (error instanceof EncryptNoPasswordError) {
+          this._handleMissingPasswordDialog();
+        } else {
+          SyncLog.err('SyncWrapperService: Force upload failed:', error);
+          const errStr = getSyncErrorStr(error);
+          this._snackService.open({
+            msg: errStr,
+            type: 'ERROR',
+          });
+        }
       } finally {
         this._syncCycleGuard.end();
       }
@@ -1286,6 +1301,13 @@ export class SyncWrapperService {
         return 'HANDLED_ERROR';
       }
     } catch (resolutionError) {
+      // GHSA-9544-hjjr-fg8h: USE_LOCAL force-uploads, which refuses to send
+      // plaintext when the key is missing. Route to the enter-password recovery
+      // dialog instead of a dead-end error snack (mirrors the main sync path).
+      if (resolutionError instanceof EncryptNoPasswordError) {
+        this._handleMissingPasswordDialog();
+        return 'HANDLED_ERROR';
+      }
       // Error during conflict resolution (forceUpload or forceDownload failed)
       SyncLog.err(
         'SyncWrapperService: Error during conflict resolution:',

--- a/src/app/op-log/core/errors/sync-errors.ts
+++ b/src/app/op-log/core/errors/sync-errors.ts
@@ -110,6 +110,17 @@ export class DecryptNoPasswordError extends AdditionalLogErrorBase {
   override name = 'DecryptNoPasswordError';
 }
 
+/**
+ * Encryption is expected (isEncrypt=true) but no key is available at upload
+ * time — the dropped-credential signature (GHSA-9544-hjjr-fg8h). Uploading
+ * plaintext instead would silently break the E2EE promise, so the upload path
+ * throws this to trigger the enter-password recovery dialog.
+ * NEVER attach the payload that was about to be encrypted (user content).
+ */
+export class EncryptNoPasswordError extends AdditionalLogErrorBase {
+  override name = 'EncryptNoPasswordError';
+}
+
 export class DecryptError extends AdditionalLogErrorBase {
   override name = 'DecryptError';
 }

--- a/src/app/op-log/encryption/encrypt-and-compress-handler.service.spec.ts
+++ b/src/app/op-log/encryption/encrypt-and-compress-handler.service.spec.ts
@@ -1,6 +1,10 @@
 import { OpLog } from '../../core/log';
 import type { SyncLogger } from '@sp/sync-core';
-import { extractErrorMessage, JsonParseError } from '../core/errors/sync-errors';
+import {
+  EncryptNoPasswordError,
+  extractErrorMessage,
+  JsonParseError,
+} from '../core/errors/sync-errors';
 import { EncryptAndCompressHandlerService } from './encrypt-and-compress-handler.service';
 import { getErrorTxt } from '../../util/get-error-text';
 
@@ -48,6 +52,33 @@ describe('EncryptAndCompressHandlerService', () => {
         isEncrypt: false,
       },
     );
+  });
+
+  describe('compressAndEncrypt', () => {
+    // GHSA-9544-hjjr-fg8h: encryption expected but no key → must throw instead
+    // of silently producing plaintext output.
+    it('should throw EncryptNoPasswordError when isEncrypt is true but no key is set', async () => {
+      await expectAsync(
+        service.compressAndEncrypt({
+          data: { id: 'test-id' },
+          modelVersion: 1,
+          isCompress: false,
+          isEncrypt: true,
+          encryptKey: undefined,
+        }),
+      ).toBeRejectedWithError(EncryptNoPasswordError);
+    });
+
+    it('should throw EncryptNoPasswordError when isEncrypt is true but key is empty', async () => {
+      await expectAsync(
+        service.compressAndEncryptData(
+          { isEncrypt: true, isCompress: false },
+          '',
+          { id: 'test-id' },
+          1,
+        ),
+      ).toBeRejectedWithError(EncryptNoPasswordError);
+    });
   });
 
   describe('decompressAndDecrypt', () => {

--- a/src/app/op-log/encryption/encrypt-and-compress-handler.service.ts
+++ b/src/app/op-log/encryption/encrypt-and-compress-handler.service.ts
@@ -7,6 +7,7 @@ import { OP_LOG_SYNC_LOGGER } from '../core/sync-logger.adapter';
 import {
   DecryptError,
   DecryptNoPasswordError,
+  EncryptNoPasswordError,
   JsonParseError,
 } from '../core/errors/sync-errors';
 import {
@@ -82,7 +83,14 @@ export class EncryptAndCompressHandlerService {
     }
     if (isEncrypt) {
       if (!encryptKey || encryptKey.length === 0) {
-        throw new Error('No encryption password provided');
+        // GHSA-9544-hjjr-fg8h: this is the single chokepoint every file-based
+        // upload passes through. Encryption expected but key missing (e.g.
+        // silently dropped credentials) must hard-stop here — falling back to
+        // plaintext would leak the full sync data to the remote.
+        // No payload in the error: it is user content.
+        throw new EncryptNoPasswordError(
+          'Encryption is enabled but no encryption password is available',
+        );
       }
 
       dataStr = await encrypt(dataStr, encryptKey);

--- a/src/app/op-log/sync-exports.ts
+++ b/src/app/op-log/sync-exports.ts
@@ -34,6 +34,7 @@ export {
   ImpossibleError,
   DecryptError,
   DecryptNoPasswordError,
+  EncryptNoPasswordError,
   DataRepairNotPossibleError,
   BackupImportFailedError,
   WebCryptoNotAvailableError,

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../provider.interface';
 import { FILE_BASED_SYNC_CONSTANTS, FileBasedSyncData } from './file-based-sync.types';
 import {
+  EncryptNoPasswordError,
   InvalidDataSPError,
   RemoteFileNotFoundAPIError,
   SyncDataCorruptedError,
@@ -459,6 +460,81 @@ describe('FileBasedSyncAdapterService', () => {
 
       // Download should be called because cache was cleared after first upload
       expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // GHSA-9544-hjjr-fg8h: encryption enabled but key missing (silently dropped
+  // credentials). Every upload path must refuse to transmit plaintext — the
+  // leak scenario is an absent remote file, where no decrypt error trips first.
+  describe('encryption enabled but key missing', () => {
+    let encryptedAdapter: OperationSyncCapable;
+
+    beforeEach(() => {
+      encryptedAdapter = service.createAdapter(
+        mockProvider,
+        { isEncrypt: true, isCompress: false },
+        undefined,
+      );
+      // Fresh remote — the advisory's exposure scenario
+      mockProvider.downloadFile.and.throwError(
+        new RemoteFileNotFoundAPIError('sync-data.json'),
+      );
+    });
+
+    it('should reject uploadOps and never upload plaintext', async () => {
+      const op = createMockSyncOp();
+
+      await expectAsync(
+        encryptedAdapter.uploadOps([op], 'client1'),
+      ).toBeRejectedWithError(EncryptNoPasswordError);
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject the no-ops initial file creation and never upload plaintext', async () => {
+      await expectAsync(encryptedAdapter.uploadOps([], 'client1')).toBeRejectedWithError(
+        EncryptNoPasswordError,
+      );
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject uploadSnapshot and never upload plaintext', async () => {
+      await expectAsync(
+        encryptedAdapter.uploadSnapshot(
+          { tasks: [] },
+          'client1',
+          'recovery',
+          { client1: 1 },
+          1,
+          true,
+          'op-id-1',
+        ),
+      ).toBeRejectedWithError(EncryptNoPasswordError);
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should report enabled + key-missing via the upload-guard hooks', async () => {
+      expect(await encryptedAdapter.isEncryptionEnabled!()).toBe(true);
+      expect(await encryptedAdapter.isEncryptionKeyMissing!()).toBe(true);
+    });
+  });
+
+  describe('encryption enabled with a key present', () => {
+    it('should report enabled and key NOT missing (no false block)', async () => {
+      const keyedAdapter = service.createAdapter(
+        mockProvider,
+        { isEncrypt: true, isCompress: false },
+        'a-key',
+      );
+      expect(await keyedAdapter.isEncryptionEnabled!()).toBe(true);
+      expect(await keyedAdapter.isEncryptionKeyMissing!()).toBe(false);
+    });
+  });
+
+  describe('encryption disabled (plaintext)', () => {
+    it('should report disabled and key not missing', async () => {
+      // The default `adapter` (outer beforeEach) is created with isEncrypt=false.
+      expect(await adapter.isEncryptionEnabled!()).toBe(false);
+      expect(await adapter.isEncryptionKeyMissing!()).toBe(false);
     });
   });
 

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -311,6 +311,16 @@ export class FileBasedSyncAdapterService {
       deleteAllData: async (): Promise<{ success: boolean }> => {
         return this._deleteAllData(provider);
       },
+
+      // GHSA-9544-hjjr-fg8h: file-based encryption happens inside this adapter
+      // (the key is never handed to the upload service via getEncryptKey), so
+      // the upload path relies on these hooks to detect the dropped-credential
+      // state. `encryptAndCompressCfg.isEncrypt` carries the durable per-provider
+      // intent resolved in WrappedProviderService.
+      isEncryptionEnabled: async (): Promise<boolean> =>
+        !!encryptAndCompressCfg.isEncrypt,
+      isEncryptionKeyMissing: async (): Promise<boolean> =>
+        !!encryptAndCompressCfg.isEncrypt && !encryptKey,
     };
   }
 

--- a/src/app/op-log/sync-providers/wrapped-provider.service.spec.ts
+++ b/src/app/op-log/sync-providers/wrapped-provider.service.spec.ts
@@ -70,13 +70,14 @@ describe('WrappedProviderService', () => {
 
     mockProviderManager = jasmine.createSpyObj(
       'SyncProviderManager',
-      ['getEncryptAndCompressCfg'],
+      ['getEncryptAndCompressCfg', 'setProviderConfig'],
       { providerConfigChanged$ },
     );
     mockProviderManager.getEncryptAndCompressCfg.and.returnValue({
       isEncrypt: true,
       isCompress: true,
     });
+    mockProviderManager.setProviderConfig.and.returnValue(Promise.resolve());
 
     mockFileBasedAdapter = jasmine.createSpyObj('FileBasedSyncAdapterService', [
       'createAdapter',
@@ -160,11 +161,39 @@ describe('WrappedProviderService', () => {
       expect(mockFileBasedAdapter.createAdapter).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle provider without encryptKey', async () => {
+    // GHSA-9544-hjjr-fg8h: the encrypt decision comes from the durable
+    // per-provider `isEncryptionEnabled` in privateCfg, NOT the global flag.
+    const setPrivateCfg = (
+      provider: jasmine.SpyObj<FileSyncProvider<SyncProviderId>>,
+      cfg: { encryptKey?: string; isEncryptionEnabled?: boolean } | null,
+    ): void => {
+      (provider.privateCfg.load as jasmine.Spy).and.returnValue(Promise.resolve(cfg));
+    };
+
+    it('should keep isEncrypt true when intent is stored true but key is missing', async () => {
       const dropboxProvider = createMockFileProvider(SyncProviderId.Dropbox);
-      (dropboxProvider.privateCfg.load as jasmine.Spy).and.returnValue(
-        Promise.resolve(null),
+      setPrivateCfg(dropboxProvider, { isEncryptionEnabled: true });
+      const mockAdapter = createMockSyncCapableAdapter();
+      mockFileBasedAdapter.createAdapter.and.returnValue(mockAdapter);
+
+      await service.getOperationSyncCapable(dropboxProvider);
+
+      expect(mockFileBasedAdapter.createAdapter).toHaveBeenCalledWith(
+        dropboxProvider,
+        { isEncrypt: true, isCompress: true },
+        undefined,
       );
+      // Intent already recorded → no backfill write.
+      expect(mockProviderManager.setProviderConfig).not.toHaveBeenCalled();
+    });
+
+    it('should keep isEncrypt false when intent is stored false, even with a stale global flag', async () => {
+      mockProviderManager.getEncryptAndCompressCfg.and.returnValue({
+        isEncrypt: true, // stale global flag (e.g. left over from SuperSync)
+        isCompress: true,
+      });
+      const dropboxProvider = createMockFileProvider(SyncProviderId.Dropbox);
+      setPrivateCfg(dropboxProvider, { isEncryptionEnabled: false });
       const mockAdapter = createMockSyncCapableAdapter();
       mockFileBasedAdapter.createAdapter.and.returnValue(mockAdapter);
 
@@ -175,6 +204,72 @@ describe('WrappedProviderService', () => {
         { isEncrypt: false, isCompress: true },
         undefined,
       );
+      expect(mockProviderManager.setProviderConfig).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to key presence for pre-fix configs without stored intent', async () => {
+      const dropboxProvider = createMockFileProvider(SyncProviderId.Dropbox);
+      setPrivateCfg(dropboxProvider, null);
+      const mockAdapter = createMockSyncCapableAdapter();
+      mockFileBasedAdapter.createAdapter.and.returnValue(mockAdapter);
+
+      await service.getOperationSyncCapable(dropboxProvider);
+
+      // No stored intent + no key → plaintext (legitimate un-encrypted user).
+      expect(mockFileBasedAdapter.createAdapter).toHaveBeenCalledWith(
+        dropboxProvider,
+        { isEncrypt: false, isCompress: true },
+        undefined,
+      );
+      expect(mockProviderManager.setProviderConfig).not.toHaveBeenCalled();
+    });
+
+    it('should backfill the intent flag for a pre-fix config that has a key', async () => {
+      const dropboxProvider = createMockFileProvider(SyncProviderId.Dropbox);
+      // Pre-fix: key present, intent never recorded.
+      setPrivateCfg(dropboxProvider, { encryptKey: 'legacy-key' });
+      const mockAdapter = createMockSyncCapableAdapter();
+      mockFileBasedAdapter.createAdapter.and.returnValue(mockAdapter);
+
+      await service.getOperationSyncCapable(dropboxProvider);
+      // The backfill re-loads fresh and writes asynchronously (fire-and-forget);
+      // flush the microtask/macrotask queue so its write has landed.
+      await new Promise((r) => setTimeout(r));
+
+      // Encrypts now (key present) …
+      expect(mockFileBasedAdapter.createAdapter).toHaveBeenCalledWith(
+        dropboxProvider,
+        { isEncrypt: true, isCompress: true },
+        'legacy-key',
+      );
+      // … and records the intent while the key still proves it, so a later
+      // silent key drop stays detectable. Written by merging onto a FRESH reload
+      // so a concurrent config mutation cannot be clobbered.
+      expect(mockProviderManager.setProviderConfig).toHaveBeenCalledWith(
+        SyncProviderId.Dropbox,
+        { encryptKey: 'legacy-key', isEncryptionEnabled: true },
+      );
+    });
+
+    // Regression for the review's stale-snapshot race: if the key was removed
+    // (e.g. a concurrent disable-encryption) by the time the backfill re-reads,
+    // it must NOT resurrect it — skip the write entirely.
+    it('should NOT backfill if the key is gone by the time it re-reads (no clobber)', async () => {
+      const dropboxProvider = createMockFileProvider(SyncProviderId.Dropbox);
+      const load = dropboxProvider.privateCfg.load as jasmine.Spy;
+      // First read (adapter decision) sees the key; the backfill's re-read sees it
+      // already cleared by a concurrent disable.
+      load.and.returnValues(
+        Promise.resolve({ encryptKey: 'legacy-key' }),
+        Promise.resolve({ encryptKey: undefined, isEncryptionEnabled: false }),
+      );
+      const mockAdapter = createMockSyncCapableAdapter();
+      mockFileBasedAdapter.createAdapter.and.returnValue(mockAdapter);
+
+      await service.getOperationSyncCapable(dropboxProvider);
+      await new Promise((r) => setTimeout(r));
+
+      expect(mockProviderManager.setProviderConfig).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/op-log/sync-providers/wrapped-provider.service.ts
+++ b/src/app/op-log/sync-providers/wrapped-provider.service.ts
@@ -102,21 +102,66 @@ export class WrappedProviderService {
     const baseCfg = this._providerManager.getEncryptAndCompressCfg();
     const privateCfg = await provider.privateCfg.load();
     const encryptKey = privateCfg?.encryptKey;
+    const storedIntent = privateCfg?.isEncryptionEnabled;
 
-    // For file-based providers (Dropbox, WebDAV, LocalFile), the encryptKey
-    // in privateCfg is the source of truth for whether to encrypt.
-    // - If encryptKey exists, encryption is enabled
-    // - If encryptKey is undefined/empty, encryption is disabled
-    // This ensures that when encryption is disabled (encryptKey cleared),
-    // sync works even if the global config update hasn't propagated yet.
+    // Encryption intent for file-based providers (GHSA-9544-hjjr-fg8h) comes from
+    // the PER-PROVIDER `isEncryptionEnabled` persisted in privateCfg — NOT the
+    // global `sync.isEncryptionEnabled` in baseCfg, which is shared across
+    // providers and re-derived from key presence in the settings form, so it is
+    // stale after a provider switch and can be flipped off by an unrelated save.
+    // privateCfg is per-provider, written atomically with the key, and survives
+    // a silent key drop (the dropped-credential failure this fix targets).
+    //   - intent ON + no key → isEncrypt stays true WITHOUT a key, so the adapter
+    //     refuses to upload plaintext instead of leaking (upload-path guard +
+    //     EncryptNoPasswordError chokepoint).
+    //   - pre-fix configs have no stored intent → fall back to key presence, which
+    //     is the exact old behaviour (no regression) and captures existing users
+    //     while their key is still present.
+    const isEncrypt = storedIntent ?? !!encryptKey;
+
+    // Migration: record the intent for pre-fix configs while the key still proves
+    // it, so a later silent key drop becomes detectable. Fire-and-forget — the
+    // adapter below already uses the correct `isEncrypt`; only future loads
+    // benefit. Runs at most once per provider (skips once an explicit value
+    // exists). Self-contained so it re-reads fresh before writing.
+    if (storedIntent === undefined && !!encryptKey) {
+      void this._backfillEncryptionIntent(provider);
+    }
+
     const cfg = {
       ...baseCfg,
-      isEncrypt: !!encryptKey,
+      isEncrypt,
     };
 
     const adapter = this._fileBasedAdapter.createAdapter(provider, cfg, encryptKey);
     this._cache.set(provider.id, adapter);
     return adapter;
+  }
+
+  /**
+   * One-time migration write of the per-provider encryption-intent flag for
+   * pre-fix configs (GHSA-9544-hjjr-fg8h). Re-loads the config immediately before
+   * writing and re-checks on that FRESH state, then merges the flag onto it — so a
+   * concurrent privateCfg mutation that landed since the caller's load (an
+   * explicit disable-encryption that cleared the key, or an OAuth token rotation)
+   * is neither clobbered nor overridden: we skip if the key is gone or an explicit
+   * intent already exists, and preserve every other field at its freshest value.
+   */
+  private async _backfillEncryptionIntent(
+    provider: FileSyncProvider<SyncProviderId>,
+  ): Promise<void> {
+    try {
+      const fresh = await provider.privateCfg.load();
+      if (!fresh || fresh.isEncryptionEnabled !== undefined || !fresh.encryptKey) {
+        return;
+      }
+      await this._providerManager.setProviderConfig(provider.id, {
+        ...fresh,
+        isEncryptionEnabled: true,
+      });
+    } catch (e) {
+      OpLog.warn('WrappedProviderService: encryption-intent backfill failed', e);
+    }
   }
 
   /**

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -7,6 +7,7 @@ import {
   OperationSyncCapable,
 } from '../sync-providers/provider.interface';
 import { SyncProviderId } from '../sync-providers/provider.const';
+import { EncryptNoPasswordError } from '../core/errors/sync-errors';
 import { ActionType, OpType, OperationLogEntry } from '../core/operation.types';
 import { SnackService } from '../../core/snack/snack.service';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -196,6 +197,58 @@ describe('OperationLogUploadService', () => {
 
           // Guard no longer blocks once a usable key exists; the ops are uploaded
           // (encrypted by the encryption service, covered by its own specs).
+          expect(mockApiProvider.uploadOps).toHaveBeenCalled();
+        });
+      });
+
+      // Regression guard for GHSA-9544-hjjr-fg8h: file-based providers encrypt
+      // inside the adapter (no getEncryptKey), so the mandatory-encryption guard
+      // above cannot see their missing key. When encryption is enabled for the
+      // provider but the key is gone (dropped credentials), the upload must fail
+      // CLOSED before either loop — never plaintext, never a permanent reject.
+      describe('file-based provider with encryption enabled but key missing (GHSA-9544-hjjr-fg8h)', () => {
+        beforeEach(() => {
+          // File-based: no getEncryptKey, not mandatory; exposes the intent hooks.
+          delete (mockApiProvider as any).getEncryptKey;
+          (mockApiProvider as any).isEncryptionMandatory = undefined;
+          (mockApiProvider as any).isEncryptionKeyMissing = jasmine
+            .createSpy('isEncryptionKeyMissing')
+            .and.returnValue(Promise.resolve(true));
+          mockOpLogStore.getUnsynced.and.returnValue(
+            Promise.resolve([createMockEntry(1, 'op-1', 'client-1')]),
+          );
+        });
+
+        it('throws EncryptNoPasswordError and uploads nothing', async () => {
+          await expectAsync(
+            service.uploadPendingOps(mockApiProvider),
+          ).toBeRejectedWithError(EncryptNoPasswordError);
+
+          expect(mockApiProvider.uploadOps).not.toHaveBeenCalled();
+        });
+
+        it('does NOT permanently reject the pending ops', async () => {
+          await expectAsync(service.uploadPendingOps(mockApiProvider)).toBeRejected();
+
+          // Left unsynced for retry once the key is restored — not markRejected.
+          expect(mockOpLogStore.markRejected).not.toHaveBeenCalled();
+          expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
+        });
+
+        it('uploads normally once the key is restored', async () => {
+          (mockApiProvider as any).isEncryptionKeyMissing.and.returnValue(
+            Promise.resolve(false),
+          );
+          mockApiProvider.uploadOps.and.returnValue(
+            Promise.resolve({
+              results: [{ opId: 'op-1', accepted: true }],
+              latestSeq: 1,
+              newOps: [],
+            }),
+          );
+
+          await service.uploadPendingOps(mockApiProvider);
+
           expect(mockApiProvider.uploadOps).toHaveBeenCalled();
         });
       });

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -31,7 +31,10 @@ import {
 } from '../core/types/sync-results.types';
 import { isRetryableUploadError } from '@sp/sync-providers/http';
 import { handleStorageQuotaError } from './sync-error-utils';
-import { DecryptNoPasswordError } from '../core/errors/sync-errors';
+import {
+  DecryptNoPasswordError,
+  EncryptNoPasswordError,
+} from '../core/errors/sync-errors';
 import {
   stripLocalOnlySyncScheduleSettings,
   stripLocalOnlySyncSettingsFromAppData,
@@ -146,6 +149,26 @@ export class OperationLogUploadService {
             'no key is configured yet — skipping upload until encryption setup completes.',
         );
         return;
+      }
+
+      // GHSA-9544-hjjr-fg8h: file-based providers encrypt inside the adapter and
+      // hide the key from this service (no getEncryptKey), so the SuperSync guard
+      // above cannot see their missing key. Ask the adapter directly whether
+      // encryption is enabled for this provider but the key is gone (silently
+      // dropped credentials) and fail CLOSED before either upload loop. Throwing
+      // (rather than returning) both leaves the pending ops unsynced for retry —
+      // never permanently rejected via the snapshot path's markRejected — and
+      // routes to the enter-password recovery dialog in SyncWrapperService. Unlike
+      // the mandatory-encryption case above this is never an expected steady
+      // state, so it warrants an error, not a silent skip.
+      if (
+        syncProvider.isEncryptionKeyMissing &&
+        (await syncProvider.isEncryptionKeyMissing())
+      ) {
+        throw new EncryptNoPasswordError(
+          'File-based sync: encryption is enabled for this provider but the ' +
+            'encryption key is missing — refusing to upload until it is restored.',
+        );
       }
 
       // Separate full-state operations (backup imports, repairs) from regular ops


### PR DESCRIPTION
## What

Fixes **GHSA-9544-hjjr-fg8h** (draft advisory): file-based sync providers (WebDAV, Dropbox, OneDrive, Nextcloud, LocalFile) with end-to-end encryption enabled could upload the full `sync-data.json` **in plaintext** if the stored encryption key was silently lost (credential-store eviction) and the remote file was absent — with no error and no user-visible signal. Same class as GHSA-9v8x, which only covered SuperSync.

## Why it happened

The encrypt decision was derived from key **presence** alone, so a lost key was indistinguishable from "encryption off". There was no durable, per-provider record of encryption *intent*: the global `sync.isEncryptionEnabled` flag is shared across providers and re-derived from key presence in the settings form, so it was unreliable in both directions (stale-true after a SuperSync→file switch → over-blocks; flipped false by a routine save once the key was gone → under-blocks).

## The fix

Persist intent per-provider, enforce at one boundary, recover uniformly:

- **Per-provider intent** — `isEncryptionEnabled` added to each file-based provider's `privateCfg`, written **atomically with the key** on enable/disable and backfilled from the key present at save time / first sync for pre-fix configs. Read everywhere as `isEncryptionEnabled ?? !!encryptKey`.
- **Adapter decides from privateCfg, not the global flag** (`WrappedProviderService`) — kills the stale-global-flag over-block and keeps the adapter cache correct (privateCfg writes already invalidate it). The migration backfill re-reads fresh and re-checks before writing, so it can't clobber a concurrent disable/OAuth-token write.
- **Fail closed at the upload boundary** — new adapter hook `isEncryptionKeyMissing`; the upload service throws `EncryptNoPasswordError` **before** either upload loop, so a missing key never produces plaintext and never triggers the snapshot path's permanent `markRejected`. SuperSync is unaffected (keeps its `isEncryptionMandatory` guard).
- **Recovery on every path** — `EncryptNoPasswordError` routes to the enter-password dialog on the main sync, force-upload, and USE_LOCAL conflict paths (previously only main sync; the others dead-ended in an error snack). The encrypt handler keeps throwing on `isEncrypt`-without-key as a last-line backstop.
- The settings form reads the durable intent, so a dropped key shows encryption as *on* (no misleading "off") and a save preserves it.

## Known residuals (deliberate)

- A pre-fix config whose key is dropped before intent was **ever** recorded (never synced or saved after upgrade) can't be distinguished from "never encrypted" — no record exists to recover.
- Cross-device: a device with local intent on and a lost key prompts for the password even if another device set the remote to plaintext. This is a deliberate **fail-closed** stance — silently converging to plaintext is the vulnerability (and would allow a downgrade attack). The user resolves it by entering the password or disabling encryption in settings; there's no infinite nag.

## Testing

Unit tests per layer — adapter hooks, upload-boundary guard (throws, no permanent reject, recovers once the key returns), atomic intent persistence on enable/disable, `_updatePrivateConfig` backfill, per-provider intent/backfill decisions in `WrappedProviderService` (including a no-clobber race regression), and conflict-path dialog routing. All affected suites green; `npm run checkFile` clean on every touched file.

The change was reviewed across two rounds of multi-agent review; all confirmed findings are resolved.

## Follow-ups (not in this PR)

- A per-provider E2E covering the key-loss path (runnable on CI only).
- Publishing the GHSA-9544 advisory once a fixed version ships.
