### PR TITLE
fix(calendar): show agenda-view plugin events without re-navigation

### DIFF
--- a/src/app/features/calendar-integration/calendar-integration.service.spec.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.spec.ts
@@ -29,6 +29,7 @@ import { Subscription } from 'rxjs';
 import { getDbDateStr } from '../../util/get-db-date-str';
 import { PluginIssueProviderRegistryService } from '../../plugins/issue-provider/plugin-issue-provider-registry.service';
 import { PluginHttpService } from '../../plugins/issue-provider/plugin-http.service';
+import { IssueProviderPluginDefinition } from '../../plugins/issue-provider/plugin-issue-provider.model';
 import { IssueProviderPluginType } from '../issue/issue.model';
 import { NotIcalResponseError } from '../schedule/ical/is-likely-ical';
 // Static import forces ical.js into the main test bundle so the dynamic
@@ -2283,5 +2284,105 @@ END:VCALENDAR`;
       expect(allDay).toEqual(jasmine.objectContaining({ id: 'evt-without-time' }));
       expect(allDay.dueWithTime).toBeUndefined();
     });
+  });
+
+  // Regression: plugin issue-provider calendars (e.g. the Google Calendar plugin) register
+  // asynchronously AFTER the issue-provider store is hydrated. calendarEvents$ must react to
+  // that registration (via PluginIssueProviderRegistryService.registrationChanges$) and surface
+  // the plugin's events WITHOUT needing a re-subscription — otherwise agenda events only appear
+  // after navigating away and back to the Today view.
+  describe('plugin registering after subscription', () => {
+    it('surfaces plugin calendar events once the plugin registers (no re-subscribe)', fakeAsync(() => {
+      const PLUGIN_KEY = 'plugin:gcal';
+      const pluginProvider = {
+        id: 'gcal-provider-id',
+        issueProviderKey: PLUGIN_KEY,
+        isEnabled: true,
+        pluginConfig: {},
+      } as unknown as IssueProviderPluginType;
+
+      const twoHoursMs = 2 * 60 * 60 * 1000;
+      const futureStart = Date.now() + twoHoursMs;
+      const getNewIssuesForBacklog = jasmine
+        .createSpy('getNewIssuesForBacklog')
+        .and.returnValue(
+          Promise.resolve([
+            {
+              id: 'gcal-evt-1',
+              title: 'Standup',
+              start: futureStart,
+              dueWithTime: futureStart,
+              duration: 30 * 60 * 1000,
+            },
+          ]),
+        );
+      const mockPluginHttp = {
+        createHttpHelper: jasmine.createSpy('createHttpHelper').and.returnValue({}),
+      };
+
+      TestBed.resetTestingModule();
+      localStorage.clear();
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [
+          CalendarIntegrationService,
+          provideMockStore({
+            selectors: [
+              { selector: selectCalendarProviders, value: [] },
+              // The provider config is already hydrated in the store before the plugin
+              // (which supplies `useAgendaView`) has registered.
+              { selector: selectEnabledIssueProviders, value: [pluginProvider] },
+              { selector: selectAllCalendarTaskEventIds, value: [] },
+            ],
+          }),
+          { provide: SnackService, useValue: mockSnackService },
+          { provide: PluginHttpService, useValue: mockPluginHttp },
+          { provide: TaskArchiveService, useValue: mockTaskArchiveService },
+        ],
+      });
+
+      const freshService = TestBed.inject(CalendarIntegrationService);
+      const registry = TestBed.inject(PluginIssueProviderRegistryService);
+
+      const emissions: string[][] = [];
+      const sub = freshService.calendarEvents$.subscribe((entries) =>
+        emissions.push(entries.flatMap((e) => e.items.map((i) => i.id))),
+      );
+
+      // Before registration `getUseAgendaView` is false → the provider is not treated as a
+      // calendar source and nothing is fetched.
+      tick(0);
+      flushMicrotasks();
+      expect(emissions.flat()).not.toContain('gcal-evt-1');
+      expect(getNewIssuesForBacklog).not.toHaveBeenCalled();
+
+      // Plugin finishes loading and registers as an agenda-view calendar provider.
+      registry.register({
+        pluginId: 'gcal',
+        issueProviderKey: PLUGIN_KEY,
+        definition: {
+          getHeaders: () => ({}),
+          getNewIssuesForBacklog,
+        } as unknown as IssueProviderPluginDefinition,
+        name: 'Google Calendar',
+        humanReadableName: 'Google Calendar',
+        icon: 'calendar',
+        pollIntervalMs: 60000,
+        issueStrings: { singular: 'Event', plural: 'Events' },
+        useAgendaView: true,
+      });
+
+      // Without any re-subscription, the plugin's event must now appear.
+      tick(0);
+      flushMicrotasks();
+      tick(100);
+      flushMicrotasks();
+
+      expect(getNewIssuesForBacklog).toHaveBeenCalled();
+      expect(emissions[emissions.length - 1]).toContain('gcal-evt-1');
+
+      sub.unsubscribe();
+      discardPeriodicTasks();
+    }));
   });
 });

--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -120,8 +120,18 @@ export class CalendarIntegrationService {
     this._store
       .select(selectCalendarProviders)
       .pipe(distinctUntilChanged(fastArrayCompare)),
-    this._store.select(selectEnabledIssueProviders).pipe(
-      map((providers) =>
+    // `registrationChanges$` emits when a plugin (un)registers. Plugins load
+    // asynchronously after bootstrap, while the issue-provider store is hydrated
+    // early — so without this trigger `getUseAgendaView` is read once (before the
+    // plugin registers, returning false), the store never re-emits, and the
+    // plugin's calendar events stay absent until a re-subscription forces a
+    // re-projection (e.g. navigating away and back). Re-run the filter on
+    // registration so agenda-view plugin events surface without navigation.
+    combineLatest([
+      this._store.select(selectEnabledIssueProviders),
+      this._pluginRegistry.registrationChanges$,
+    ]).pipe(
+      map(([providers]) =>
         providers.filter(
           (p): p is IssueProviderPluginType =>
             isPluginIssueProvider(p.issueProviderKey) &&

--- a/src/app/plugins/issue-provider/plugin-issue-provider-registry.service.ts
+++ b/src/app/plugins/issue-provider/plugin-issue-provider-registry.service.ts
@@ -1,4 +1,6 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { BehaviorSubject, Observable } from 'rxjs';
 import {
   RegisteredPluginIssueProvider,
   IssueProviderPluginDefinition,
@@ -16,8 +18,21 @@ export class PluginIssueProviderRegistryService {
   /** Maps pluginId → registeredKey for cleanup */
   private _pluginIdToKey = new Map<string, string>();
 
-  /** Signal that increments on each registration/unregistration, so computed signals can react */
-  readonly registrationVersion = signal(0);
+  /**
+   * Single source of truth for "a plugin (un)registered", exposed two ways so signal-
+   * and stream-based consumers react to the same event without drifting:
+   * - `registrationChanges$` (RxJS) for observable pipelines that must re-run without an
+   *   effect/CD flush AND emit synchronously on subscribe — e.g.
+   *   `CalendarIntegrationService.calendarEvents$`. (A `toObservable(signal)` only emits
+   *   once its effect runs, delaying even the initial value; a `BehaviorSubject` does not.)
+   * - `registrationVersion` (signal) for `computed()` consumers, e.g. `tag-list`.
+   */
+  private readonly _registrationVersion$ = new BehaviorSubject(0);
+  readonly registrationChanges$: Observable<number> =
+    this._registrationVersion$.asObservable();
+  readonly registrationVersion = toSignal(this._registrationVersion$, {
+    requireSync: true,
+  });
 
   register(opts: {
     pluginId: string;
@@ -53,7 +68,7 @@ export class PluginIssueProviderRegistryService {
       allowPrivateNetwork: opts.allowPrivateNetwork,
     });
     this._pluginIdToKey.set(opts.pluginId, key);
-    this.registrationVersion.update((v) => v + 1);
+    this._bumpRegistrationVersion();
   }
 
   unregister(pluginId: string): void {
@@ -61,8 +76,14 @@ export class PluginIssueProviderRegistryService {
     if (key) {
       this._providers.delete(key);
       this._pluginIdToKey.delete(pluginId);
-      this.registrationVersion.update((v) => v + 1);
+      this._bumpRegistrationVersion();
     }
+  }
+
+  /** Advance the single registration counter; both `registrationChanges$` and the
+   * derived `registrationVersion` signal update from it. */
+  private _bumpRegistrationVersion(): void {
+    this._registrationVersion$.next(this._registrationVersion$.value + 1);
   }
 
   /** Get the registered key for a pluginId (e.g. 'GITHUB' or 'plugin:my-plugin') */


### PR DESCRIPTION
## Problem

On the **Today** view, the **"Later Today"** section did not show Google Calendar plugin events on initial app load. Today's upcoming timed events only appeared after navigating away from Today and back.

**Root cause:** `CalendarIntegrationService.calendarEvents$` builds its set of plugin calendar providers by calling `PluginIssueProviderRegistryService.getUseAgendaView(key)` **imperatively inside a `map()`** over the `selectEnabledIssueProviders` store stream. Plugins (including Google Calendar) register **asynchronously** after bootstrap, while the issue-provider NgRx store is hydrated early. So on first subscription the filter ran before the plugin had registered → `getUseAgendaView` returned `false` → the provider was excluded → the stream returned `of([])`. Nothing re-emitted (the stream had no dependency on plugin registration), so plugin events stayed absent until a re-subscription (navigating away and back) re-projected the stream. The issue-provider panel's agenda view already worked because it reads the registry's `registrationVersion` signal (like `tag-list.component.ts`).

## Solution

- `PluginIssueProviderRegistryService`: expose registration changes as `registrationChanges$`, a `BehaviorSubject`-backed RxJS stream (single source of truth; `registrationVersion` signal is now derived from it via `toSignal(..., { requireSync: true })`, so signal- and stream-consumers can't drift). A `BehaviorSubject` — not `toObservable(signal)` — is used deliberately: `toObservable`'s effect doesn't emit until a CD/effect flush, which would delay `calendarEvents$`'s first synchronous (cache-first) emission.
- `CalendarIntegrationService.calendarEvents$`: fold `registrationChanges$` into the plugin-provider branch's `combineLatest`, so the `getUseAgendaView` filter re-runs when a plugin (un)registers. `distinctUntilChanged(fastArrayCompare)` still suppresses re-fetches when the calendar-provider set is unchanged (unrelated plugins registering cause no extra fetches).
- Added a regression test: provider present in store, plugin registers **after** subscription → the event surfaces without a re-subscribe. Verified it fails against the old code and passes with the fix.

Verified: `npm run checkFile` clean on all 3 files; calendar spec 76 passing (incl. new test), registry spec 28, tag-list spec 15.

### Reviewed via multi-agent review — follow-ups (out of scope here)
The same "read the registry imperatively inside a stream, with no dependency on registration" pattern exists elsewhere and has the same latent staleness; filing/fixing separately:
- `issue-provider-tab.component.ts` `useAgendaView` computed (gates agenda-view vs. search in the issue panel) — doesn't read `registrationVersion()`.
- `poll-to-backlog.effects.ts` and `time-block-sync.effects.ts` — same-class registry reads.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/wiki (n/a — internal reactivity fix, no user-facing docs)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
