### PR TITLE
docs: fix breakpoint names and values in styling guide table #8829

### DIFF
--- a/docs/styling-guide.md
+++ b/docs/styling-guide.md
@@ -169,11 +169,11 @@ Available as CSS vars (`--layout-xxxs` through `--layout-xl`) and as SCSS mixins
 | Breakpoint | Value  |
 | ---------- | ------ |
 | `xxxs`     | 398px  |
-| `xxs`      | 450px  |
+| `xxs`      | 440px  |
 | `xs`       | 600px  |
-| `s`        | 800px  |
-| `m`        | 1000px |
-| `l`        | 1200px |
+| `sm`       | 960px  |
+| `md`       | 1280px |
+| `lg`       | 1920px |
 | `xl`       | 2000px |
 
 ## Utility Classes


### PR DESCRIPTION
## Problem

The breakpoint table in `docs/styling-guide.md` had stale names and values that didn't match the SCSS source. Anyone styling from the guide would be using mixin names and breakpoint widths that don't exist.

Three names were wrong: the table said `s`, `m`, `l` but the actual mixins are `sm`, `md`, `lg`. Four values were off: `xxs` was listed at 450px instead of 440px, and the `s`/`m`/`l` rows had values (800, 1000, 1200) that belong to an older version of the codebase — the real breakpoints at `sm`/`md`/`lg` are 960px, 1280px, and 1920px.

## Solution

Corrected the four wrong values and three wrong names in the table. The new numbers match `src/styles/mixins/_media-queries.scss` lines 5-11 and `src/styles/_css-variables.scss` lines 144-150.

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/wiki.
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

(n/a checkboxes: no `.ts` or `.scss` files changed, so checkFile and tests don't apply to a docs-only change.)

Closes #8829
