### PR TITLE
docs: update styling breakpoint table

### DIFF
--- a/docs/styling-guide.md
+++ b/docs/styling-guide.md
@@ -164,16 +164,16 @@ Quickest adoption — add the `.focus-ring` utility class from `util.scss`, whic
 
 ## Responsive Breakpoints
 
-Available as CSS vars (`--layout-xxxs` through `--layout-xl`) and as SCSS mixins in `src/styles/mixins/_media-queries.scss`:
+Available as CSS vars (`--layout-xxxs` through `--layout-xl`) and as SCSS variables and mixins in `src/styles/mixins/_media-queries.scss`:
 
 | Breakpoint | Value  |
 | ---------- | ------ |
 | `xxxs`     | 398px  |
-| `xxs`      | 450px  |
+| `xxs`      | 440px  |
 | `xs`       | 600px  |
-| `s`        | 800px  |
-| `m`        | 1000px |
-| `l`        | 1200px |
+| `sm`       | 960px  |
+| `md`       | 1280px |
+| `lg`       | 1920px |
 | `xl`       | 2000px |
 
 ## Utility Classes


### PR DESCRIPTION
## Summary
- update the styling guide breakpoint names and values to match `src/styles/mixins/_media-queries.scss`
- clarify that the same file provides the SCSS variables and mixins

Closes #8829

## Validation
- Not run; documentation-only Markdown change.