### PR TITLE
fix(ios): clamp bogus third-party keyboard height (#8778)

### DIFF
--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -60,6 +60,7 @@ import { FlexibleConnectedPositionStrategy } from '@angular/cdk/overlay';
 import { LS } from '../persistence/storage-keys.const';
 import { Log } from '../log';
 import { LayoutService } from '../../core-ui/layout/layout.service';
+import { sanitizeIosKeyboardHeight } from './sanitize-ios-keyboard-height.util';
 
 interface NavigationBarPlugin {
   setColor(options: { color: string; style: 'LIGHT' | 'DARK' }): Promise<void>;
@@ -167,6 +168,10 @@ export class GlobalThemeService {
   private _iosKeyboardHeight = 0;
   private _iosViewportHeightBeforeKeyboard = 0;
   private _iosViewportChangeRaf: number | null = null;
+  // True only when the plugin reported an implausible keyboard frame (the clamp
+  // had to correct it). Gates the measured-viewport override so well-behaved
+  // keyboards keep their exact pre-existing behaviour (#8778).
+  private _iosKeyboardFrameUnreliable = false;
 
   private _isCustomWindowTitleBarEnabled(): boolean {
     // The main process (main-window.ts) force-disables the custom title bar on
@@ -626,12 +631,24 @@ export class GlobalThemeService {
       if (!this.document.body.classList.contains(BodyClass.isKeyboardVisible)) {
         this._iosViewportHeightBeforeKeyboard = window.innerHeight;
       }
-      this._iosKeyboardHeight = info.keyboardHeight;
+      // Some third-party keyboards (e.g. Sogou) report a bogus near-full-screen
+      // keyboard frame here; clamp it so it can't fling the fixed add-task bar
+      // to the top of the screen (#8778).
+      const referenceHeight = this._iosViewportHeightBeforeKeyboard || window.innerHeight;
+      const keyboardHeight = sanitizeIosKeyboardHeight(
+        info.keyboardHeight,
+        referenceHeight,
+      );
+      // Only a frame the clamp had to correct opts into the measured-viewport
+      // override in _updateIOSKeyboardViewportVars; well-behaved keyboards keep
+      // the exact pre-existing behaviour, so this cannot regress them.
+      this._iosKeyboardFrameUnreliable = keyboardHeight !== info.keyboardHeight;
+      this._iosKeyboardHeight = keyboardHeight;
       this.document.body.classList.add(BodyClass.isKeyboardVisible);
       // Set CSS variable for keyboard height to adjust layout
       this.document.documentElement.style.setProperty(
         CSS_VAR_KEYBOARD_HEIGHT,
-        `${info.keyboardHeight}px`,
+        `${keyboardHeight}px`,
       );
       this._updateIOSKeyboardViewportVars();
     }).then((handle) => this._keyboardListenerHandles.push(handle));
@@ -646,6 +663,7 @@ export class GlobalThemeService {
       Log.log('iOS keyboard will hide');
       this._iosKeyboardHeight = 0;
       this._iosViewportHeightBeforeKeyboard = 0;
+      this._iosKeyboardFrameUnreliable = false;
       this.document.body.classList.remove(BodyClass.isKeyboardVisible);
       this.document.documentElement.style.setProperty(CSS_VAR_KEYBOARD_HEIGHT, '0px');
       this.document.documentElement.style.setProperty(
@@ -709,6 +727,27 @@ export class GlobalThemeService {
       CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
       `${isKeyboardVisible && !isVisualViewportAlreadyResized ? this._iosKeyboardHeight : 0}px`,
     );
+
+    // For a keyboard whose reported frame was implausible, once the viewport has
+    // actually shrunk its measured obscured area (`baseHeight -
+    // visualViewportHeight`) is a far more reliable keyboard height than the
+    // bogus plugin frame (#8778), and is correct under both `resize: 'native'`
+    // and non-resizing modes. Correct `--keyboard-height` to the measurement
+    // (still clamped as a safety net). Well-behaved keyboards skip this entirely
+    // and keep the plugin value set in keyboardWillShow — no behaviour change.
+    if (
+      this._iosKeyboardFrameUnreliable &&
+      this._isVisualViewportResizedForKeyboard(
+        isKeyboardVisible,
+        baseHeight,
+        visualViewportHeight,
+      )
+    ) {
+      root.style.setProperty(
+        CSS_VAR_KEYBOARD_HEIGHT,
+        `${sanitizeIosKeyboardHeight(baseHeight - visualViewportHeight, baseHeight)}px`,
+      );
+    }
     this._notifyIOSViewportChange();
   }
 

--- a/src/app/core/theme/sanitize-ios-keyboard-height.util.spec.ts
+++ b/src/app/core/theme/sanitize-ios-keyboard-height.util.spec.ts
@@ -1,0 +1,47 @@
+import {
+  MAX_IOS_KEYBOARD_HEIGHT_FRACTION,
+  sanitizeIosKeyboardHeight,
+} from './sanitize-ios-keyboard-height.util';
+
+describe('sanitizeIosKeyboardHeight', () => {
+  // Typical iPhone portrait viewport.
+  const SCREEN = 812;
+  const CEILING = SCREEN * MAX_IOS_KEYBOARD_HEIGHT_FRACTION;
+
+  it('passes a normal native keyboard height through unchanged', () => {
+    // Native iOS keyboard ~300px sits well under the ceiling.
+    expect(sanitizeIosKeyboardHeight(300, SCREEN)).toBe(300);
+  });
+
+  it('passes a tall third-party keyboard (with candidate bar) through unchanged', () => {
+    // ~55% of screen — still plausible, must not be clamped.
+    expect(sanitizeIosKeyboardHeight(440, SCREEN)).toBe(440);
+  });
+
+  it('clamps a bogus near-full-screen height to the ceiling (Sogou / #8778)', () => {
+    // The reported frame that flings the add-task bar to the top of the screen.
+    expect(sanitizeIosKeyboardHeight(780, SCREEN)).toBe(CEILING);
+  });
+
+  it('clamps a height exactly equal to the screen height', () => {
+    expect(sanitizeIosKeyboardHeight(SCREEN, SCREEN)).toBe(CEILING);
+  });
+
+  it('floors a negative reported height to 0', () => {
+    expect(sanitizeIosKeyboardHeight(-10, SCREEN)).toBe(0);
+  });
+
+  it('floors NaN to 0', () => {
+    expect(sanitizeIosKeyboardHeight(NaN, SCREEN)).toBe(0);
+  });
+
+  it('only floors (no ceiling) when the reference height is unknown', () => {
+    // No baseline to judge plausibility → pass the positive value through.
+    expect(sanitizeIosKeyboardHeight(780, 0)).toBe(780);
+    expect(sanitizeIosKeyboardHeight(-5, 0)).toBe(0);
+  });
+
+  it('respects a custom max fraction', () => {
+    expect(sanitizeIosKeyboardHeight(780, SCREEN, 0.5)).toBe(SCREEN * 0.5);
+  });
+});

--- a/src/app/core/theme/sanitize-ios-keyboard-height.util.ts
+++ b/src/app/core/theme/sanitize-ios-keyboard-height.util.ts
@@ -1,0 +1,42 @@
+/**
+ * Largest share of the pre-keyboard viewport height we accept as a real
+ * on-screen keyboard height.
+ *
+ * iOS reports a bogus, near-full-screen keyboard frame in `keyboardWillShow`
+ * for some third-party input methods (e.g. Sogou on iOS 18 — issue #8778).
+ * Written verbatim to `--keyboard-height`, that value flings the fixed
+ * add-task bar (`bottom: calc(var(--keyboard-height) + …)`) to the top of the
+ * screen. A real keyboard — even a tall third-party one with a candidate /
+ * toolbar bar, in portrait or landscape — stays comfortably under this
+ * fraction, so anything above it is the known bad frame.
+ *
+ * shortcut: a fixed fraction, not a measurement. A `visualViewport`-derived
+ * obscured-area reading would be more precise, but is unreliable under
+ * Capacitor's `resize: 'native'` (the whole web view resizes, so the visual
+ * viewport shrinks in lock-step and reports ~0 obscured). If real keyboards
+ * ever approach this ceiling, revisit with a measured value.
+ */
+export const MAX_IOS_KEYBOARD_HEIGHT_FRACTION = 0.6;
+
+/**
+ * Clamp the iOS keyboard height reported by the Capacitor Keyboard plugin to a
+ * physically plausible range before it drives layout CSS variables.
+ *
+ * `referenceHeight` is the viewport height captured *before* the keyboard
+ * appeared (the full usable height). The result is never negative and never
+ * exceeds `referenceHeight * maxFraction`. A non-positive or unknown reference
+ * height disables the ceiling (we only floor at 0): without a baseline we
+ * cannot judge plausibility, and clamping against a bad baseline would be
+ * worse than passing the value through.
+ */
+export const sanitizeIosKeyboardHeight = (
+  reportedHeight: number,
+  referenceHeight: number,
+  maxFraction = MAX_IOS_KEYBOARD_HEIGHT_FRACTION,
+): number => {
+  const floored = reportedHeight > 0 ? reportedHeight : 0;
+  if (referenceHeight > 0) {
+    return Math.min(floored, referenceHeight * maxFraction);
+  }
+  return floored;
+};


### PR DESCRIPTION
Fixes #8778

## Problem

On iOS with a third-party input method (reported with **Sogou 20.11.0**, iPhone XS, iOS 18.4), tapping **+** positions the global add-task bar at the **top of the screen** instead of above the keyboard. The native iOS keyboard is unaffected.

## Root cause

The global add-task bar is positioned `bottom: calc(var(--keyboard-height) + var(--s2))` (`add-task-bar.component.scss`). On iOS, `keyboardWillShow` wrote the raw Capacitor `info.keyboardHeight` into `--keyboard-height` with **no clamping** (`global-theme.service.ts`). Some third-party keyboards report a bogus near-full-screen frame there, so `bottom` becomes huge and the bar is flung off the top. (The non-iOS path already derives keyboard height from `visualViewport`; iOS did not.)

## Fix

1. **Clamp** the plugin-reported height to a plausible range (`≤ 60%` of the pre-keyboard viewport height) — a new pure util `sanitizeIosKeyboardHeight` (with unit tests). This alone stops the "flies to the top" symptom.
2. **Measured override**: only for a frame the clamp had to correct, once the viewport has actually shrunk, set `--keyboard-height` to the measured obscured area `baseHeight - visualViewport.height` — the same reliable signal the non-iOS path already trusts, correct under both `resize: 'native'` and non-resizing modes. This positions the bar at the *real* keyboard top rather than a capped guess.

### Why this is safe to merge

The measured override is gated on an `_iosKeyboardFrameUnreliable` flag that is only set when the clamp actually changed the value. **Well-behaved keyboards (native + normal third-party) report a plausible height → the flag stays false → they keep byte-identical pre-existing behaviour.** The only code that runs differently is for keyboards that are *already* broken today, where any change is an improvement. So this cannot regress the common case.

## Testing

- New util spec: 8/8 (`sanitize-ios-keyboard-height.util.spec.ts`)
- `global-theme.service.spec`: 20/20
- `npm run checkFile` clean on all changed files; app bundle compiles.

⚠️ **Not yet verified on a physical iOS device with a third-party keyboard** — I can't reproduce that setup locally. The change is proven not to affect working keyboards; on-device confirmation is still wanted to verify it *fixes* Sogou and to sanity-check the `0.6` clamp bound. The reporter has the exact device + keyboard and offered to help test.