### PR TITLE
perf(tasks): content-stable scheduling snapshot for collection task selectors

### DIFF
--- a/src/app/features/tasks/store/task-later-today.selectors.spec.ts
+++ b/src/app/features/tasks/store/task-later-today.selectors.spec.ts
@@ -1,6 +1,42 @@
-import { selectLaterTodayTasksWithSubTasks } from './task.selectors';
-import { Task } from '../task.model';
+import { selectLaterTodayStructure, SchedulingSnapshot } from './task.selectors';
+import { Task, TaskWithSubTasks } from '../task.model';
 import { getDbDateStr } from '../../../util/get-db-date-str';
+
+// SPAP-20: selectLaterTodayTasksWithSubTasks was split into a snapshot-based
+// decision (selectLaterTodayStructure → ordered {id, subTaskIds}) + a live-entity
+// re-map. This helper reproduces the old single-projector output shape from a raw
+// task array so the existing behavioral assertions below stay unchanged.
+const runLaterToday = (
+  tasks: (Task | undefined)[],
+  todayStr: string,
+  offset: number = 0,
+): TaskWithSubTasks[] => {
+  const snapshot: SchedulingSnapshot[] = tasks
+    .filter((t): t is Task => !!t)
+    .map((t) => ({
+      id: t.id,
+      isDone: t.isDone,
+      dueDay: t.dueDay ?? null,
+      dueWithTime: t.dueWithTime ?? null,
+      deadlineDay: t.deadlineDay ?? null,
+      deadlineWithTime: t.deadlineWithTime ?? null,
+      parentId: t.parentId ?? null,
+      subTaskIds: t.subTaskIds,
+    }));
+  const structure = selectLaterTodayStructure.projector(snapshot, todayStr, offset);
+  const entities: Record<string, Task | undefined> = {};
+  tasks.forEach((t) => {
+    if (t) {
+      entities[t.id] = t;
+    }
+  });
+  return structure.map(
+    (e): TaskWithSubTasks => ({
+      ...(entities[e.id] as Task),
+      subTasks: e.subTaskIds.map((id) => entities[id]).filter((t): t is Task => !!t),
+    }),
+  );
+};
 
 describe('selectLaterTodayTasksWithSubTasks', () => {
   const now = new Date();
@@ -151,7 +187,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
   it('should select tasks scheduled for later today', () => {
     // Virtual tag pattern: tasks are "in TODAY" because of dueDay or dueWithTime for today
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockAllTasks, todayStr, 0);
+    const result = runLaterToday(mockAllTasks, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     // The result includes main tasks and their subtasks (for display purposes)
@@ -172,28 +208,28 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
   });
 
   it('should not include tasks scheduled for earlier today', () => {
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockAllTasks, todayStr, 0);
+    const result = runLaterToday(mockAllTasks, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     expect(taskIds).not.toContain('EARLIER_TODAY');
   });
 
   it('should not include tasks scheduled for tomorrow', () => {
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockAllTasks, todayStr, 0);
+    const result = runLaterToday(mockAllTasks, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     expect(taskIds).not.toContain('TOMORROW_TASK');
   });
 
   it('should not include unscheduled tasks', () => {
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockAllTasks, todayStr, 0);
+    const result = runLaterToday(mockAllTasks, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     expect(taskIds).not.toContain('UNSCHEDULED_TODAY');
   });
 
   it('should not include done tasks', () => {
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockAllTasks, todayStr, 0);
+    const result = runLaterToday(mockAllTasks, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     expect(taskIds).not.toContain('DONE_LATER_TODAY');
@@ -222,18 +258,14 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
       dueDay: tomorrowStr,
     });
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(
-      [...mockAllTasks, taskForTomorrow],
-      todayStr,
-      0,
-    );
+    const result = runLaterToday([...mockAllTasks, taskForTomorrow], todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     expect(taskIds).not.toContain('SCHEDULED_FOR_TOMORROW');
   });
 
   it('should include parent tasks with all their subtasks (not as separate items)', () => {
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockAllTasks, todayStr, 0);
+    const result = runLaterToday(mockAllTasks, todayStr, 0);
 
     const parentIndex = result.findIndex((t) => t.id === 'PARENT_LATER');
     expect(parentIndex).toBeGreaterThan(-1);
@@ -258,11 +290,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
     });
 
     const tasksWithCurrent = [...mockAllTasks, taskAtCurrentTime];
-    const result = selectLaterTodayTasksWithSubTasks.projector(
-      tasksWithCurrent,
-      todayStr,
-      0,
-    );
+    const result = runLaterToday(tasksWithCurrent, todayStr, 0);
 
     // Task scheduled at exactly current time should be included
     const taskIds = result.map((t) => t.id);
@@ -283,11 +311,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
     });
 
     const tasksWithMidnight = [...mockAllTasks, taskAtMidnight];
-    const result = selectLaterTodayTasksWithSubTasks.projector(
-      tasksWithMidnight,
-      todayStr,
-      0,
-    );
+    const result = runLaterToday(tasksWithMidnight, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     expect(taskIds).toContain('MIDNIGHT_TASK');
@@ -307,21 +331,13 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
       }),
     ];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(
-      noMatchingTasks,
-      todayStr,
-      0,
-    );
+    const result = runLaterToday(noMatchingTasks, todayStr, 0);
 
     expect(result.length).toBe(0);
   });
 
   it('should return empty array when todayStr is null', () => {
-    const result = selectLaterTodayTasksWithSubTasks.projector(
-      mockAllTasks,
-      null as any,
-      0,
-    );
+    const result = runLaterToday(mockAllTasks, null as any, 0);
 
     expect(result.length).toBe(0);
   });
@@ -345,7 +361,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parentWithScheduledSubtask, scheduledSubtask];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     // Should include parent (because it has scheduled subtask) - not the subtask as separate item
     expect(result.length).toBe(1);
@@ -373,7 +389,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parentTask, scheduledSubtask];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     // Parent SHOULD be included because it has scheduled subtask
@@ -424,7 +440,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parent1, sub1, parent2, sub2];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     // Should be sorted by earliest time: Parent 1 (has subtask at 2 PM), then Parent 2 (has subtask at 3 PM)
     expect(result.length).toBe(2);
@@ -465,7 +481,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parentUnscheduled, subUnscheduled, subPast];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     // Should not include any tasks
     expect(result.length).toBe(0);
@@ -490,7 +506,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parentTask, subtask];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     const taskIds = result.map((t) => t.id);
     // Only parent should appear as top-level
@@ -534,7 +550,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parentNotToday, orphanedSubtask];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     // Only orphaned subtask should appear (parent is for tomorrow)
     expect(result.length).toBe(1);
@@ -556,11 +572,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     // Parent 'MISSING_PARENT' is absent from state entirely —
     // only the subtask exists in the flat task list.
-    const result = selectLaterTodayTasksWithSubTasks.projector(
-      [orphanedSubtask],
-      todayStr,
-      0,
-    );
+    const result = runLaterToday([orphanedSubtask], todayStr, 0);
 
     expect(result.length).toBe(1);
     expect(result[0].id).toBe('ORPHANED_SUB');
@@ -593,7 +605,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parentTask, scheduledSubtask, unscheduledSubtask];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     // Parent should be included because it has a scheduled subtask
     expect(result.length).toBe(1);
@@ -634,7 +646,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [grandparent, parent, child];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     expect(result.length).toBe(1);
     expect(result[0].id).toBe('CHILD_SCHEDULED');
@@ -651,11 +663,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
       dueDay: undefined, // No dueDay set - this was the bug scenario
     });
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(
-      [taskWithTimeOnly],
-      todayStr,
-      0,
-    );
+    const result = runLaterToday([taskWithTimeOnly], todayStr, 0);
 
     // Task should be included because dueWithTime is for today
     expect(result.length).toBe(1);
@@ -691,7 +699,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
 
     const mockTasks = [parentTask, doneSubtask, notDoneSubtask];
 
-    const result = selectLaterTodayTasksWithSubTasks.projector(mockTasks, todayStr, 0);
+    const result = runLaterToday(mockTasks, todayStr, 0);
 
     // Parent should be included
     expect(result.length).toBe(1);
@@ -734,11 +742,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
         dueDay: null,
       });
 
-      const result = selectLaterTodayTasksWithSubTasks.projector(
-        [taskAt2amFeb16],
-        feb15Str,
-        FOUR_HOURS_MS,
-      );
+      const result = runLaterToday([taskAt2amFeb16], feb15Str, FOUR_HOURS_MS);
 
       expect(result.length).toBe(1);
       expect(result[0].id).toBe('TASK_2AM_FEB16');
@@ -755,11 +759,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
         dueDay: null,
       });
 
-      const result = selectLaterTodayTasksWithSubTasks.projector(
-        [taskAt5amFeb16],
-        feb15Str,
-        FOUR_HOURS_MS,
-      );
+      const result = runLaterToday([taskAt5amFeb16], feb15Str, FOUR_HOURS_MS);
 
       expect(result.length).toBe(0);
     });
@@ -776,11 +776,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
         dueDay: null,
       });
 
-      const result = selectLaterTodayTasksWithSubTasks.projector(
-        [taskAt359amFeb16],
-        feb15Str,
-        FOUR_HOURS_MS,
-      );
+      const result = runLaterToday([taskAt359amFeb16], feb15Str, FOUR_HOURS_MS);
 
       expect(result.length).toBe(1);
       expect(result[0].id).toBe('TASK_359AM_FEB16');
@@ -798,11 +794,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
         dueDay: null,
       });
 
-      const result = selectLaterTodayTasksWithSubTasks.projector(
-        [taskAt401amFeb16],
-        feb15Str,
-        FOUR_HOURS_MS,
-      );
+      const result = runLaterToday([taskAt401amFeb16], feb15Str, FOUR_HOURS_MS);
 
       expect(result.length).toBe(0);
     });
@@ -816,11 +808,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
         dueDay: feb15Str,
       });
 
-      const result = selectLaterTodayTasksWithSubTasks.projector(
-        [taskAt3pmFeb15],
-        feb15Str,
-        FOUR_HOURS_MS,
-      );
+      const result = runLaterToday([taskAt3pmFeb15], feb15Str, FOUR_HOURS_MS);
 
       expect(result.length).toBe(1);
       expect(result[0].id).toBe('TASK_3PM_FEB15');
@@ -835,11 +823,7 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
         dueDay: feb15Str,
       });
 
-      const result = selectLaterTodayTasksWithSubTasks.projector(
-        [taskAt8amFeb15],
-        feb15Str,
-        FOUR_HOURS_MS,
-      );
+      const result = runLaterToday([taskAt8amFeb15], feb15Str, FOUR_HOURS_MS);
 
       expect(result.length).toBe(0);
     });

--- a/src/app/features/tasks/store/task.selectors.spec.ts
+++ b/src/app/features/tasks/store/task.selectors.spec.ts
@@ -1033,10 +1033,28 @@ describe('Task Selectors', () => {
     });
   });
 
+  // SPAP-20: these selectors were split into a snapshot-based decision (ids) +
+  // a live-entity re-map, so `.projector(tasks)` no longer applies. Exercise the
+  // full public selectors against real state instead (same observable behavior).
+  const withArchivedProject1 = (): any => ({
+    ...mockState,
+    [PROJECT_FEATURE_NAME]: {
+      ...mockState[PROJECT_FEATURE_NAME],
+      entities: {
+        ...mockState[PROJECT_FEATURE_NAME].entities,
+        project1: {
+          id: 'project1',
+          title: 'Project 1',
+          isHiddenFromMenu: false,
+          isArchived: true,
+        },
+      },
+    },
+  });
+
   describe('selectAllTasksWithDueTimeSorted', () => {
     it('should return only tasks with dueWithTime, sorted ascending', () => {
-      const allTasks = Object.values(mockTasks);
-      const result = fromSelectors.selectAllTasksWithDueTimeSorted.projector(allTasks);
+      const result = fromSelectors.selectAllTasksWithDueTimeSorted(mockState);
       expect(result.map((t) => t.id)).toContain('task5');
       expect(result.every((t) => typeof t.dueWithTime === 'number')).toBe(true);
     });
@@ -1044,28 +1062,23 @@ describe('Task Selectors', () => {
 
   describe('selectAllUndoneTasksWithDueDay', () => {
     it('should exclude tasks from archived projects', () => {
-      const activeTasks = Object.values(mockTasks).filter(
-        (t) => t.projectId !== 'project1',
-      );
-      const result = fromSelectors.selectAllUndoneTasksWithDueDay.projector(activeTasks);
+      const result = fromSelectors.selectAllUndoneTasksWithDueDay(withArchivedProject1());
+      // task3 lives in project1 which is now archived
       expect(result.map((t) => t.id)).not.toContain('task3');
     });
 
     it('should include tasks when project is not archived', () => {
-      const allTasks = Object.values(mockTasks);
-      const result = fromSelectors.selectAllUndoneTasksWithDueDay.projector(allTasks);
+      const result = fromSelectors.selectAllUndoneTasksWithDueDay(mockState);
       expect(result.map((t) => t.id)).toContain('task3');
     });
 
     it('should exclude done tasks', () => {
-      const allTasks = Object.values(mockTasks);
-      const result = fromSelectors.selectAllUndoneTasksWithDueDay.projector(allTasks);
+      const result = fromSelectors.selectAllUndoneTasksWithDueDay(mockState);
       expect(result.every((t) => !t.isDone)).toBeTrue();
     });
 
     it('should sort results by dueDay chronologically', () => {
-      const allTasks = Object.values(mockTasks);
-      const result = fromSelectors.selectAllUndoneTasksWithDueDay.projector(allTasks);
+      const result = fromSelectors.selectAllUndoneTasksWithDueDay(mockState);
       const dueDays = result.map((t) => t.dueDay);
       for (let i = 1; i < dueDays.length; i++) {
         expect(dueDays[i - 1].localeCompare(dueDays[i])).toBeLessThanOrEqual(0);
@@ -1088,18 +1101,22 @@ describe('Task Selectors', () => {
         timeSpent: 0,
         attachments: [],
       };
-      const tasksWithSubtask = [...Object.values(mockTasks), subtaskWithDueDay];
-      const result =
-        fromSelectors.selectAllUndoneTasksWithDueDay.projector(tasksWithSubtask);
+      const stateWithSubtask: any = {
+        ...mockState,
+        [TASK_FEATURE_NAME]: {
+          ...mockTaskState,
+          ids: [...mockTaskState.ids, 'subtaskWithDue'],
+          entities: { ...mockTaskState.entities, subtaskWithDue: subtaskWithDueDay },
+        },
+      };
+      const result = fromSelectors.selectAllUndoneTasksWithDueDay(stateWithSubtask);
       expect(result.map((t) => t.id)).toContain('subtaskWithDue');
     });
   });
 
   describe('selectAllUndoneTasksWithDeadlineSorted', () => {
     it('should return only undone tasks with deadline, sorted', () => {
-      const allTasks = Object.values(mockTasks);
-      const result =
-        fromSelectors.selectAllUndoneTasksWithDeadlineSorted.projector(allTasks);
+      const result = fromSelectors.selectAllUndoneTasksWithDeadlineSorted(mockState);
       expect(result.map((t) => t.id)).toContain('task9');
       expect(result.every((t) => !t.isDone)).toBe(true);
     });
@@ -1146,7 +1163,6 @@ describe('Task Selectors', () => {
     expect(ids).toContain('task6');
   });
 
-  // SPAP-19: per-subscription stable task selector factories
   // -------------------------------------------------------------------------
   describe('SPAP-19 stable selector factories', () => {
     const makeTask = (id: string, over: Partial<Task> = {}): Task =>
@@ -1293,6 +1309,158 @@ describe('Task Selectors', () => {
         expect(res.length).toBe(2);
         expect(res[0]).toBe(a);
         expect(res[1]).toBe(b);
+      });
+    });
+  });
+
+  // SPAP-20: content-stable scheduling snapshot boundary.
+  describe('SPAP-20 scheduling snapshot', () => {
+    // Simulate a real "time tracking tick": replace ONLY the ticked task's entity
+    // (bump timeSpent), keeping every other task's ref intact.
+    const bumpTimeSpent = (taskId: string): any => {
+      const prev = mockTaskState.entities[taskId] as Task;
+      return {
+        ...mockState,
+        [TASK_FEATURE_NAME]: {
+          ...mockTaskState,
+          entities: {
+            ...mockTaskState.entities,
+            [taskId]: { ...prev, timeSpent: (prev.timeSpent || 0) + 1000 },
+          },
+        },
+      };
+    };
+    const patchTask = (taskId: string, patch: Partial<Task>): any => {
+      const prev = mockTaskState.entities[taskId] as Task;
+      return {
+        ...mockState,
+        [TASK_FEATURE_NAME]: {
+          ...mockTaskState,
+          entities: {
+            ...mockTaskState.entities,
+            [taskId]: { ...prev, ...patch },
+          },
+        },
+      };
+    };
+
+    describe('selectTaskSchedulingSnapshot', () => {
+      it('returns the IDENTICAL array ref (and element refs) on a timeSpent-only tick', () => {
+        const r1 = fromSelectors.selectTaskSchedulingSnapshot(mockState);
+        // task3 is a member (due today); its timeSpent bump must not change the snapshot
+        const r2 = fromSelectors.selectTaskSchedulingSnapshot(bumpTimeSpent('task3'));
+        expect(r2).toBe(r1);
+        r1.forEach((el, i) => expect(r2[i]).toBe(el));
+      });
+
+      it('returns a NEW array + changed element when a scheduling field (dueDay) changes', () => {
+        const r1 = fromSelectors.selectTaskSchedulingSnapshot(mockState);
+        const idx = r1.findIndex((s) => s.id === 'task4');
+        const r2 = fromSelectors.selectTaskSchedulingSnapshot(
+          patchTask('task4', { dueDay: today }),
+        );
+        expect(r2).not.toBe(r1);
+        expect(r2[idx]).not.toBe(r1[idx]);
+        expect(r2[idx].dueDay).toBe(today);
+      });
+    });
+
+    describe('decision selectors skipped on a timeSpent tick (identical output ref)', () => {
+      it('selectOverdueTaskIds + selectOverdueTasks are referentially stable', () => {
+        const ids1 = fromSelectors.selectOverdueTaskIds(mockState);
+        const r1 = fromSelectors.selectOverdueTasks(mockState);
+        // task3 is due today (NOT overdue) → not a member of overdue
+        const ticked = bumpTimeSpent('task3');
+        expect(fromSelectors.selectOverdueTaskIds(ticked)).toBe(ids1);
+        expect(fromSelectors.selectOverdueTasks(ticked)).toBe(r1);
+      });
+
+      it('selectAllTasksWithDueTimeSorted is referentially stable', () => {
+        const r1 = fromSelectors.selectAllTasksWithDueTimeSorted(mockState);
+        // task3 has no dueWithTime → not a member
+        expect(
+          fromSelectors.selectAllTasksWithDueTimeSorted(bumpTimeSpent('task3')),
+        ).toBe(r1);
+      });
+
+      it('selectTimeConflictTaskIds is stable when a non-due-time task ticks', () => {
+        const r1 = fromSelectors.selectTimeConflictTaskIds(mockState);
+        expect(fromSelectors.selectTimeConflictTaskIds(bumpTimeSpent('task3'))).toBe(r1);
+      });
+
+      it('selectAllUndoneTasksWithDeadlineSorted is referentially stable', () => {
+        const r1 = fromSelectors.selectAllUndoneTasksWithDeadlineSorted(mockState);
+        // task3 has no deadline → not a member
+        expect(
+          fromSelectors.selectAllUndoneTasksWithDeadlineSorted(bumpTimeSpent('task3')),
+        ).toBe(r1);
+      });
+
+      it('selectAllUndoneTasksWithDueDay is referentially stable', () => {
+        const r1 = fromSelectors.selectAllUndoneTasksWithDueDay(mockState);
+        // bump task5 (dueWithTime, not dueDay) → not a dueDay member
+        expect(fromSelectors.selectAllUndoneTasksWithDueDay(bumpTimeSpent('task5'))).toBe(
+          r1,
+        );
+      });
+    });
+
+    describe('selectAllTasksWithSubTasks (per-id live re-map)', () => {
+      it('keeps unchanged parents identical but updates the ticked member with live data', () => {
+        const r1 = fromSelectors.selectAllTasksWithSubTasks(mockState);
+        const r2 = fromSelectors.selectAllTasksWithSubTasks(bumpTimeSpent('task3'));
+        // task1 (unchanged parent) → exact same object
+        expect(r2.find((t) => t.id === 'task1')).toBe(r1.find((t) => t.id === 'task1'));
+        // task3 (ticked, top-level) → new object reflecting LIVE timeSpent
+        const t3a = r1.find((t) => t.id === 'task3')!;
+        const t3b = r2.find((t) => t.id === 'task3')!;
+        expect(t3b).not.toBe(t3a);
+        expect(t3b.timeSpent).toBe((mockTasks.task3.timeSpent || 0) + 1000);
+      });
+
+      it('rebuilds a parent when its subtask ref changes', () => {
+        const r1 = fromSelectors.selectAllTasksWithSubTasks(mockState);
+        // subtask1's parent is task1 → task1 must get a new object with live subtask
+        const r2 = fromSelectors.selectAllTasksWithSubTasks(bumpTimeSpent('subtask1'));
+        expect(r2.find((t) => t.id === 'task1')).not.toBe(
+          r1.find((t) => t.id === 'task1'),
+        );
+      });
+    });
+
+    describe('recompute + live-ref correctness on a real scheduling change', () => {
+      it('selectOverdueTasks recomputes and reflects a newly-overdue task', () => {
+        const r1 = fromSelectors.selectOverdueTasks(mockState);
+        expect(r1.map((t) => t.id)).not.toContain('task4');
+        const r2 = fromSelectors.selectOverdueTasks(
+          patchTask('task4', { dueDay: yesterday }),
+        );
+        expect(r2).not.toBe(r1);
+        expect(r2.map((t) => t.id)).toContain('task4');
+      });
+
+      it('a member task with a non-scheduling change is served with its LIVE ref', () => {
+        // task6 is overdue. Change its title only (not a scheduling field): the
+        // decision (ids) is unchanged, but the public selector re-maps live so the
+        // returned task6 carries the new title.
+        const r2 = fromSelectors.selectOverdueTasks(
+          patchTask('task6', { title: 'renamed' }),
+        );
+        const t6 = r2.find((t) => t.id === 'task6')!;
+        expect(t6.title).toBe('renamed');
+      });
+    });
+
+    describe('shape parity with the pre-refactor logic', () => {
+      it('selectAllUndoneTasksWithDueDay returns the expected ids in the expected order', () => {
+        const result = fromSelectors.selectAllUndoneTasksWithDueDay(mockState);
+        // undone + has dueDay, sorted lexically: task6 (yesterday) < task3 (today) < task4 (tomorrow)
+        expect(result.map((t) => t.id)).toEqual(['task6', 'task3', 'task4']);
+      });
+
+      it('selectOverdueTasks returns exactly the overdue members', () => {
+        const result = fromSelectors.selectOverdueTasks(mockState);
+        expect(result.map((t) => t.id)).toEqual(['task6']);
       });
     });
   });

--- a/src/app/features/tasks/store/task.selectors.spec.ts
+++ b/src/app/features/tasks/store/task.selectors.spec.ts
@@ -236,6 +236,10 @@ describe('Task Selectors', () => {
     fromSelectors.selectAllTasks.clearResult();
     fromSelectors.selectAllTasksInActiveProjects.clearResult();
     fromSelectors.selectOverdueTasks.clearResult();
+    // dialog-schedule-task.* and time-block-sync.effects specs overrideSelector
+    // selectAllTasksWithDueTimeSorted (setResult persists across files), which
+    // would leak into selectAllTasksWithDueTimeSorted(mockState) here.
+    fromSelectors.selectAllTasksWithDueTimeSorted.clearResult();
     // work-view.component.spec overrides these via overrideSelector (setResult);
     // selectOverdueTasks reads them, so the leaked "today"/offset must be cleared too.
     selectTodayStr.clearResult();
@@ -255,6 +259,7 @@ describe('Task Selectors', () => {
     fromSelectors.selectAllTasks.release();
     fromSelectors.selectAllTasksInActiveProjects.release();
     fromSelectors.selectOverdueTasks.release();
+    fromSelectors.selectAllTasksWithDueTimeSorted.release();
     selectTodayStr.release();
     selectStartOfNextDayDiffMs.release();
     selectProjectFeatureState.release();

--- a/src/app/features/tasks/store/task.selectors.ts
+++ b/src/app/features/tasks/store/task.selectors.ts
@@ -10,6 +10,7 @@ import {
 } from '../task.model';
 import { taskAdapter } from './task.adapter';
 import { devError } from '../../../util/dev-error';
+import { fastArrayCompare } from '../../../util/fast-array-compare';
 import { isDBDateStr } from '../../../util/get-db-date-str';
 import { IssueProvider, isPluginIssueProvider } from '../../issue/issue.model';
 import { selectArchivedProjectIds } from '../../project/store/project.selectors';
@@ -27,35 +28,6 @@ export const isCalendarIssueTask = (task: Task | undefined): task is Task =>
   !!task.issueType &&
   (task.issueType === 'ICAL' || isPluginIssueProvider(task.issueType));
 
-const mapSubTasksToTasks = (tasksIN: Task[]): TaskWithSubTasks[] => {
-  // Create a Map for O(1) lookups instead of O(n) find() calls
-  const taskMap = new Map<string, Task>();
-  for (const task of tasksIN) {
-    // Guard against undefined tasks during sync operations
-    if (task?.id) {
-      taskMap.set(task.id, task);
-    }
-  }
-
-  const result: TaskWithSubTasks[] = [];
-  for (const task of tasksIN) {
-    // Guard against undefined tasks during sync operations
-    if (!task) continue;
-    if (task.parentId) continue;
-
-    if (task.subTaskIds && task.subTaskIds.length > 0) {
-      const subTasks: Task[] = [];
-      for (const subTaskId of task.subTaskIds) {
-        const subTask = taskMap.get(subTaskId);
-        if (subTask) subTasks.push(subTask);
-      }
-      result.push({ ...task, subTasks });
-    } else {
-      result.push({ ...task, subTasks: [] });
-    }
-  }
-  return result;
-};
 export const mapSubTasksToTask = (
   task: Task | null,
   s: TaskState,
@@ -171,10 +143,8 @@ export const selectAllTasks = createSelector(
   },
 );
 
-export const selectAllTasksWithSubTasks = createSelector(
-  selectAllTasks,
-  mapSubTasksToTasks,
-);
+// NOTE: selectAllTasksWithSubTasks is defined below, after the scheduling
+// snapshot infrastructure it now depends on (SPAP-20).
 
 export const selectAllTasksInActiveProjects = createSelector(
   selectAllTasks,
@@ -191,25 +161,288 @@ export const selectMapOfAllTasksInActiveProjects = createSelector(
   (activeTasks): Map<string, Task> => new Map(activeTasks.map((t) => [t.id, t])),
 );
 
-export const selectOverdueTasks = createSelector(
+// SPAP-20: Scheduling snapshot boundary.
+// --------------------------------------
+// selectAllTasks(InActiveProjects) returns a NEW array every second while a task
+// tracks time (its `timeSpent` bump replaces the entity ref). Every collection
+// selector derived from it re-ran its O(n) filter/sort + fresh allocations each
+// tick even though NONE of them read `timeSpent`. We interpose a content-stable
+// "scheduling snapshot": a projection holding ONLY the fields those selectors
+// filter/sort on. A `timeSpent`-only tick yields the IDENTICAL snapshot array
+// ref, so every snapshot-derived DECISION selector (which outputs an ordered id
+// list) is skipped by NgRx memoization. The PUBLIC selectors keep their existing
+// output types by re-mapping the stable id list back through the LIVE task
+// entities — so a member task always reflects current data (no staleness) while
+// unchanged members keep referentially-identical objects.
+
+export interface SchedulingSnapshot {
+  readonly id: string;
+  readonly isDone: boolean;
+  readonly dueDay: string | null;
+  readonly dueWithTime: number | null;
+  readonly deadlineDay: string | null;
+  readonly deadlineWithTime: number | null;
+  readonly parentId: string | null;
+  readonly subTaskIds: string[];
+}
+
+export interface SnapshotStructureEntry {
+  readonly id: string;
+  readonly subTaskIds: string[];
+}
+
+interface SchedulingSnapshotCacheEntry {
+  taskRef: Task;
+  snap: SchedulingSnapshot;
+}
+
+const _schedulingSnapEqual = (a: SchedulingSnapshot, b: SchedulingSnapshot): boolean =>
+  a.isDone === b.isDone &&
+  a.dueDay === b.dueDay &&
+  a.dueWithTime === b.dueWithTime &&
+  a.deadlineDay === b.deadlineDay &&
+  a.deadlineWithTime === b.deadlineWithTime &&
+  a.parentId === b.parentId &&
+  fastArrayCompare(a.subTaskIds, b.subTaskIds);
+
+// Builds a scheduling snapshot from an ordered task array. A per-id cache keyed
+// on the task entity ref lets an unchanged task reuse its exact previous `snap`
+// object; when the ref DID change but the scheduling fields did not (e.g. a
+// `timeSpent`-only tick), the field-for-field compare still returns the cached
+// `snap`. When every element is unchanged the PREVIOUS array ref is returned, so
+// downstream memoized selectors are skipped entirely.
+const createSchedulingSnapshotProjector = (): ((
+  tasks: Task[],
+) => SchedulingSnapshot[]) => {
+  const cache = new Map<string, SchedulingSnapshotCacheEntry>();
+  let prevResult: SchedulingSnapshot[] = [];
+  return (tasks: Task[]): SchedulingSnapshot[] => {
+    const result: SchedulingSnapshot[] = [];
+    const seen = new Set<string>();
+    let changed = tasks.length !== prevResult.length;
+    for (let i = 0; i < tasks.length; i++) {
+      const task = tasks[i];
+      if (!task) {
+        continue;
+      }
+      seen.add(task.id);
+      const cached = cache.get(task.id);
+      let snap: SchedulingSnapshot;
+      if (cached && cached.taskRef === task) {
+        snap = cached.snap;
+      } else {
+        const built: SchedulingSnapshot = {
+          id: task.id,
+          isDone: task.isDone,
+          dueDay: task.dueDay ?? null,
+          dueWithTime: task.dueWithTime ?? null,
+          deadlineDay: task.deadlineDay ?? null,
+          deadlineWithTime: task.deadlineWithTime ?? null,
+          parentId: task.parentId ?? null,
+          subTaskIds: task.subTaskIds,
+        };
+        snap = cached && _schedulingSnapEqual(cached.snap, built) ? cached.snap : built;
+        cache.set(task.id, { taskRef: task, snap });
+      }
+      result.push(snap);
+      if (!changed && prevResult[i] !== snap) {
+        changed = true;
+      }
+    }
+    // Prune entries for ids no longer present so the cache can't grow unbounded.
+    if (cache.size > seen.size) {
+      for (const key of cache.keys()) {
+        if (!seen.has(key)) {
+          cache.delete(key);
+        }
+      }
+    }
+    if (!changed) {
+      return prevResult;
+    }
+    prevResult = result;
+    return result;
+  };
+};
+
+// Snapshot over active-project tasks — matches selectAllTasksInActiveProjects'
+// archived-project filtering AND ordering exactly (it IS its source). Drives the
+// overdue / due-time / deadline / due-day / later-today / today decisions.
+export const selectTaskSchedulingSnapshot = createSelector(
   selectAllTasksInActiveProjects,
+  createSchedulingSnapshotProjector(),
+);
+
+// Snapshot over ALL tasks (incl. archived-project tasks) — mirrors the unfiltered
+// selectAllTasks source that selectAllTasksWithSubTasks intentionally uses.
+export const selectAllTasksSchedulingSnapshot = createSelector(
+  selectAllTasks,
+  createSchedulingSnapshotProjector(),
+);
+
+// The active snapshot re-expressed as a Record keyed by id. selectTodayTaskIds'
+// computeOrderedTaskIdsForToday reads a Record of {id,dueDay,dueWithTime,parentId}
+// — this keeps that projector's input shape (and its spec's `.projector(...)`
+// calls) unchanged while gating its recompute on the stable snapshot.
+export const selectTaskSchedulingSnapshotRecord = createSelector(
+  selectTaskSchedulingSnapshot,
+  (snapshot): Record<string, SchedulingSnapshot> => {
+    const rec: Record<string, SchedulingSnapshot> = {};
+    for (const snap of snapshot) {
+      rec[snap.id] = snap;
+    }
+    return rec;
+  },
+);
+
+// Re-maps an ordered id list back to LIVE task entities, returning the PREVIOUS
+// array ref when every mapped entity is unchanged; only genuinely-changed members
+// (e.g. the tracked task, if it is a member) get a new ref.
+const createStableTaskIdMapper = <T extends Task = Task>(): ((
+  ids: string[],
+  entities: Record<string, Task | undefined>,
+) => T[]) => {
+  let prevResult: T[] = [];
+  return (ids: string[], entities: Record<string, Task | undefined>): T[] => {
+    const result: T[] = [];
+    let changed = ids.length !== prevResult.length;
+    for (let i = 0; i < ids.length; i++) {
+      // Ids come from a snapshot derived from the SAME state as `entities`, so
+      // the entity is always present.
+      const task = entities[ids[i]] as T;
+      result.push(task);
+      if (!changed && prevResult[i] !== task) {
+        changed = true;
+      }
+    }
+    if (!changed) {
+      return prevResult;
+    }
+    prevResult = result;
+    return result;
+  };
+};
+
+// Re-maps an ordered {id, subTaskIds} structure to TaskWithSubTasks built from
+// LIVE entities, reusing the exact previous TaskWithSubTasks object for any parent
+// whose entity ref AND resolved subtask refs are unchanged (SPAP-19 per-id cache).
+// Missing subtask entities are skipped (parity with legacy mapSubTasksToTasks /
+// subtasksByParentId shaping).
+const createStableWithSubTasksMapper = (): ((
+  structure: readonly SnapshotStructureEntry[],
+  entities: Record<string, Task | undefined>,
+) => TaskWithSubTasks[]) => {
+  const cache = new Map<
+    string,
+    { task: Task; subTasks: Task[]; result: TaskWithSubTasks }
+  >();
+  let prevResult: TaskWithSubTasks[] = [];
+  return (
+    structure: readonly SnapshotStructureEntry[],
+    entities: Record<string, Task | undefined>,
+  ): TaskWithSubTasks[] => {
+    const result: TaskWithSubTasks[] = [];
+    const seen = new Set<string>();
+    let changed = structure.length !== prevResult.length;
+    for (let i = 0; i < structure.length; i++) {
+      const entry = structure[i];
+      const task = entities[entry.id];
+      if (!task) {
+        changed = true;
+        continue;
+      }
+      seen.add(entry.id);
+      const subTasks: Task[] = [];
+      for (const sid of entry.subTaskIds) {
+        const sub = entities[sid];
+        if (sub) {
+          subTasks.push(sub);
+        }
+      }
+      const cached = cache.get(entry.id);
+      let built: TaskWithSubTasks;
+      if (cached && cached.task === task && fastArrayCompare(cached.subTasks, subTasks)) {
+        built = cached.result;
+      } else {
+        built = { ...task, subTasks };
+        cache.set(entry.id, { task, subTasks, result: built });
+      }
+      result.push(built);
+      if (!changed && prevResult[i] !== built) {
+        changed = true;
+      }
+    }
+    if (cache.size > seen.size) {
+      for (const key of cache.keys()) {
+        if (!seen.has(key)) {
+          cache.delete(key);
+        }
+      }
+    }
+    if (!changed) {
+      return prevResult;
+    }
+    prevResult = result;
+    return result;
+  };
+};
+
+// selectAllTasksWithSubTasks (rebased): ordered top-level task ids + their raw
+// subTaskIds from the ALL-tasks snapshot (decision skipped on a timeSpent tick),
+// re-mapped to live TaskWithSubTasks. Mirrors legacy mapSubTasksToTasks: every
+// non-subtask task in order; missing subtasks dropped at re-map.
+export const selectAllTasksWithSubTasksStructure = createSelector(
+  selectAllTasksSchedulingSnapshot,
+  (snapshot): SnapshotStructureEntry[] => {
+    const structure: SnapshotStructureEntry[] = [];
+    for (const snap of snapshot) {
+      if (snap.parentId) {
+        continue;
+      }
+      structure.push({ id: snap.id, subTaskIds: snap.subTaskIds });
+    }
+    return structure;
+  },
+);
+
+const _allTasksWithSubTasksMapper = createStableWithSubTasksMapper();
+export const selectAllTasksWithSubTasks = createSelector(
+  selectAllTasksWithSubTasksStructure,
+  selectTaskEntities,
+  _allTasksWithSubTasksMapper,
+);
+
+// selectOverdueTasks (rebased): decision reads only dueDay/dueWithTime from the
+// snapshot; public re-maps ids to live Task refs.
+export const selectOverdueTaskIds = createSelector(
+  selectTaskSchedulingSnapshot,
   selectTodayStr,
   selectStartOfNextDayDiffMs,
-  (tasks, todayStr, startOfNextDayDiffMs): Task[] => {
+  (snapshot, todayStr, startOfNextDayDiffMs): string[] => {
     const today = dateStrToUtcDate(todayStr);
     today.setHours(0, 0, 0, 0);
     // The logical start of "today" is shifted by the offset
     const todayStartMs = today.getTime() + startOfNextDayDiffMs;
-    return tasks.filter(
-      (task): task is Task =>
-        // Note: String comparison works correctly here because dueDay is in YYYY-MM-DD format
-        // which is lexicographically sortable. This avoids timezone conversion issues.
-        !!(
-          (task.dueDay && isDBDateStr(task.dueDay) && task.dueDay < todayStr) ||
-          (task.dueWithTime && task.dueWithTime < todayStartMs)
-        ),
-    );
+    const ids: string[] = [];
+    for (const snap of snapshot) {
+      // Note: String comparison works correctly here because dueDay is in YYYY-MM-DD format
+      // which is lexicographically sortable. This avoids timezone conversion issues.
+      if (
+        (snap.dueDay && isDBDateStr(snap.dueDay) && snap.dueDay < todayStr) ||
+        (snap.dueWithTime && snap.dueWithTime < todayStartMs)
+      ) {
+        ids.push(snap.id);
+      }
+    }
+    return ids;
   },
+);
+
+const _overdueTasksMapper = createStableTaskIdMapper();
+export const selectOverdueTasks = createSelector(
+  selectOverdueTaskIds,
+  selectTaskEntities,
+  _overdueTasksMapper,
 );
 
 export const selectUndoneOverdue = createSelector(
@@ -361,11 +594,17 @@ export const selectCurrentTaskParentOrCurrent = createSelector(
 // Uses virtual tag pattern to determine TODAY membership:
 // A task is "in TODAY" if dueDay === today OR dueWithTime is for today
 // PERF: Single-pass iteration instead of multiple passes over all tasks
-export const selectLaterTodayTasksWithSubTasks = createSelector(
-  selectAllTasksInActiveProjects,
+// selectLaterTodayTasksWithSubTasks (rebased): the membership/grouping/sort
+// DECISION runs on the snapshot only (skipped on a timeSpent tick) and emits an
+// ordered {id, subTaskIds} structure; the public selector re-maps it to live
+// TaskWithSubTasks. NOTE: like the original this reads Date.now() for the
+// "later today" cutoff; the snapshot boundary means `now` only advances when a
+// scheduling field (or todayStr/offset) changes rather than on every store tick.
+export const selectLaterTodayStructure = createSelector(
+  selectTaskSchedulingSnapshot,
   selectTodayStr,
   selectStartOfNextDayDiffMs,
-  (allTasks, todayStr, startOfNextDayDiffMs): TaskWithSubTasks[] => {
+  (snapshot, todayStr, startOfNextDayDiffMs): SnapshotStructureEntry[] => {
     if (!todayStr) {
       return [];
     }
@@ -378,45 +617,46 @@ export const selectLaterTodayTasksWithSubTasks = createSelector(
 
     // Helper to check if task is "in TODAY" via virtual tag pattern
     // Priority: dueWithTime takes precedence over dueDay (mutual exclusivity)
-    const isInToday = (task: Task): boolean => {
-      if (task.dueWithTime) {
-        return isTodayWithOffset(task.dueWithTime, todayStr, startOfNextDayDiffMs);
+    const isInToday = (snap: SchedulingSnapshot): boolean => {
+      if (snap.dueWithTime) {
+        return isTodayWithOffset(snap.dueWithTime, todayStr, startOfNextDayDiffMs);
       }
-      return task.dueDay === todayStr;
+      return snap.dueDay === todayStr;
     };
 
     // Helper to check if task is scheduled for later today
-    const isScheduledLaterToday = (task: Task): boolean =>
-      !!task.dueWithTime && task.dueWithTime >= now && task.dueWithTime <= todayEndTime;
+    const isScheduledLaterToday = (snap: SchedulingSnapshot): boolean =>
+      !!snap.dueWithTime && snap.dueWithTime >= now && snap.dueWithTime <= todayEndTime;
 
     // PERF: Single pass to categorize all tasks (was 2 passes before)
-    const scheduledParentTasks: Task[] = [];
-    const scheduledSubtasks: Task[] = [];
-    const unscheduledParentsInToday: Task[] = [];
-    const subtasksByParentId: Record<string, Task[]> = {};
+    const scheduledParentTasks: SchedulingSnapshot[] = [];
+    const scheduledSubtasks: SchedulingSnapshot[] = [];
+    const unscheduledParentsInToday: SchedulingSnapshot[] = [];
+    const subtaskIdsByParentId: Record<string, string[]> = {};
+    const dueWithTimeById = new Map<string, number | null>();
 
-    for (const task of allTasks) {
-      if (task.parentId) {
-        if (!subtasksByParentId.hasOwnProperty(task.parentId)) {
-          subtasksByParentId[task.parentId] = [];
+    for (const snap of snapshot) {
+      dueWithTimeById.set(snap.id, snap.dueWithTime);
+      if (snap.parentId) {
+        if (!subtaskIdsByParentId.hasOwnProperty(snap.parentId)) {
+          subtaskIdsByParentId[snap.parentId] = [];
         }
-
-        subtasksByParentId[task.parentId].push(task);
+        subtaskIdsByParentId[snap.parentId].push(snap.id);
       }
 
-      if (!task || task.isDone || !isInToday(task)) continue;
+      if (snap.isDone || !isInToday(snap)) continue;
 
-      if (task.parentId) {
+      if (snap.parentId) {
         // Subtask - only care about scheduled ones
-        if (isScheduledLaterToday(task)) {
-          scheduledSubtasks.push(task);
+        if (isScheduledLaterToday(snap)) {
+          scheduledSubtasks.push(snap);
         }
       } else {
         // Parent task - categorize by scheduled status
-        if (isScheduledLaterToday(task)) {
-          scheduledParentTasks.push(task);
+        if (isScheduledLaterToday(snap)) {
+          scheduledParentTasks.push(snap);
         } else {
-          unscheduledParentsInToday.push(task);
+          unscheduledParentsInToday.push(snap);
         }
       }
     }
@@ -435,7 +675,7 @@ export const selectLaterTodayTasksWithSubTasks = createSelector(
     ];
 
     // Get IDs of parents that will be included
-    const parentIdsInLaterToday = new Set(parentsToInclude.map((task) => task.id));
+    const parentIdsInLaterToday = new Set(parentsToInclude.map((snap) => snap.id));
 
     // Find orphaned subtasks (scheduled subtasks whose parents are NOT in Later Today)
     const orphanedScheduledSubtasks = scheduledSubtasks.filter(
@@ -443,27 +683,29 @@ export const selectLaterTodayTasksWithSubTasks = createSelector(
     );
 
     // Combine parents and orphaned subtasks
-    const allTopLevelTasks = [...parentsToInclude, ...orphanedScheduledSubtasks];
+    const allTopLevel = [...parentsToInclude, ...orphanedScheduledSubtasks];
 
-    // Map to include subtasks for parents and sort by time
-    // PERF: Pre-compute earliest times to avoid recalculating in sort comparator
-    const tasksWithTimes = allTopLevelTasks.map((task) => {
-      const taskWithSubTasks = {
-        ...task,
-        subTasks: subtasksByParentId[task.id] ?? [],
-      } as TaskWithSubTasks;
-
-      // Pre-compute earliest scheduled time for sorting
+    // Sort by earliest scheduled time (parent's own dueWithTime or its subtasks').
+    // PERF: Pre-compute earliest times to avoid recalculating in sort comparator.
+    const withTimes = allTopLevel.map((snap) => {
+      const childIds = subtaskIdsByParentId[snap.id] ?? [];
       const earliestTime = Math.min(
-        taskWithSubTasks.dueWithTime || Infinity,
-        ...(taskWithSubTasks.subTasks || []).map((st) => st.dueWithTime || Infinity),
+        snap.dueWithTime || Infinity,
+        ...childIds.map((cid) => dueWithTimeById.get(cid) || Infinity),
       );
-      return { task: taskWithSubTasks, earliestTime };
+      return { entry: { id: snap.id, subTaskIds: childIds }, earliestTime };
     });
 
-    tasksWithTimes.sort((a, b) => a.earliestTime - b.earliestTime);
-    return tasksWithTimes.map((t) => t.task);
+    withTimes.sort((a, b) => a.earliestTime - b.earliestTime);
+    return withTimes.map((w) => w.entry);
   },
+);
+
+const _laterTodayWithSubTasksMapper = createStableWithSubTasksMapper();
+export const selectLaterTodayTasksWithSubTasks = createSelector(
+  selectLaterTodayStructure,
+  selectTaskEntities,
+  _laterTodayWithSubTasksMapper,
 );
 
 export const selectAllDoneIds = createSelector(
@@ -671,17 +913,32 @@ export const selectAllTasksWithDueTime = createSelector(
   },
 );
 
-export const selectAllTasksWithDueTimeSorted = createSelector(
-  selectAllTasksInActiveProjects,
-  (tasks: Task[]): TaskWithDueTime[] => {
-    return tasks
+// Decision: ids of tasks with a dueWithTime, sorted ascending, from the snapshot.
+export const selectDueTimeSortedTaskIds = createSelector(
+  selectTaskSchedulingSnapshot,
+  (snapshot): string[] =>
+    snapshot
       .filter(
-        (task): task is TaskWithDueTime => !!task && typeof task.dueWithTime === 'number',
+        (snap): snap is SchedulingSnapshot & { dueWithTime: number } =>
+          typeof snap.dueWithTime === 'number',
       )
-      .sort((a, b) => a.dueWithTime - b.dueWithTime);
-  },
+      .sort((a, b) => a.dueWithTime - b.dueWithTime)
+      .map((snap) => snap.id),
 );
 
+const _allTasksWithDueTimeSortedMapper = createStableTaskIdMapper<TaskWithDueTime>();
+export const selectAllTasksWithDueTimeSorted = createSelector(
+  selectDueTimeSortedTaskIds,
+  selectTaskEntities,
+  _allTasksWithDueTimeSortedMapper,
+);
+
+// NOTE: selectTimeConflictTaskIds intentionally keeps consuming the PUBLIC
+// selectAllTasksWithDueTimeSorted (LIVE refs) rather than the snapshot decision:
+// getTimeConflictTaskIds → getTimeLeftForTask READS `timeSpent`, so a tracked
+// due-time task's shrinking time-left can genuinely change conflicts each tick.
+// The live re-map yields a new array (with the tracked task's live ref) only when
+// a due-time member actually changed, so conflicts recompute exactly when needed.
 export const selectTimeConflictTaskIds = createSelector(
   selectAllTasksWithDueTimeSorted,
   getTimeConflictTaskIds,
@@ -705,15 +962,13 @@ export const selectAllTasksWithDeadlineReminder = createSelector(
   },
 );
 
-export const selectAllUndoneTasksWithDeadlineSorted = createSelector(
-  selectAllTasksInActiveProjects,
-  (tasks: Task[]): Task[] => {
-    return tasks
+export const selectUndoneDeadlineSortedTaskIds = createSelector(
+  selectTaskSchedulingSnapshot,
+  (snapshot): string[] =>
+    snapshot
       .filter(
-        (task) =>
-          task &&
-          !task.isDone &&
-          (task.deadlineDay || typeof task.deadlineWithTime === 'number'),
+        (snap) =>
+          !snap.isDone && (snap.deadlineDay || typeof snap.deadlineWithTime === 'number'),
       )
       .sort((a, b) => {
         const aTime =
@@ -725,8 +980,15 @@ export const selectAllUndoneTasksWithDeadlineSorted = createSelector(
             ? b.deadlineWithTime
             : dateStrToUtcDate(b.deadlineDay!).getTime();
         return aTime - bTime;
-      });
-  },
+      })
+      .map((snap) => snap.id),
+);
+
+const _allUndoneTasksWithDeadlineSortedMapper = createStableTaskIdMapper();
+export const selectAllUndoneTasksWithDeadlineSorted = createSelector(
+  selectUndoneDeadlineSortedTaskIds,
+  selectTaskEntities,
+  _allUndoneTasksWithDeadlineSortedMapper,
 );
 
 export const selectUndoneTasksWithDueDayNoReminder = createSelector(
@@ -795,13 +1057,19 @@ export const selectAllTaskIssueIdsForIssueProvider = (issueProvider: IssueProvid
   });
 };
 
+export const selectUndoneDueDayTaskIds = createSelector(
+  selectTaskSchedulingSnapshot,
+  (snapshot): string[] =>
+    snapshot
+      .filter((snap) => !!snap.dueDay && !snap.isDone)
+      // Sort by dueDay (YYYY-MM-DD format is lexicographically sortable)
+      .sort((a, b) => a.dueDay!.localeCompare(b.dueDay!))
+      .map((snap) => snap.id),
+);
+
+const _allUndoneTasksWithDueDayMapper = createStableTaskIdMapper<TaskWithDueDay>();
 export const selectAllUndoneTasksWithDueDay = createSelector(
-  selectAllTasksInActiveProjects,
-  (tasks): TaskWithDueDay[] => {
-    const tasksWithDueDay = tasks.filter(
-      (t): t is TaskWithDueDay => !!t.dueDay && !t.isDone,
-    );
-    // Sort by dueDay (YYYY-MM-DD format is lexicographically sortable)
-    return tasksWithDueDay.sort((a, b) => a.dueDay.localeCompare(b.dueDay));
-  },
+  selectUndoneDueDayTaskIds,
+  selectTaskEntities,
+  _allUndoneTasksWithDueDayMapper,
 );

--- a/src/app/features/work-context/store/work-context.selectors.ts
+++ b/src/app/features/work-context/store/work-context.selectors.ts
@@ -11,6 +11,7 @@ import {
   selectTaskEntities,
   selectTaskEntitiesInActiveProjects,
   selectTaskFeatureState,
+  selectTaskSchedulingSnapshotRecord,
 } from '../../tasks/store/task.selectors';
 import { Task, TaskWithDueTime, TaskWithSubTasks } from '../../tasks/task.model';
 import { devError } from '../../../util/dev-error';
@@ -330,9 +331,13 @@ export const selectDoneBacklogTaskIdsForActiveContext = createSelector(
  *
  * See: docs/ai/today-tag-architecture.md
  */
+// SPAP-20: fed by the scheduling snapshot (as a Record) instead of the full
+// active-project task entities, so a `timeSpent`-only tick — which does not
+// change any field computeOrderedTaskIdsForToday reads (id/dueDay/dueWithTime/
+// parentId) — leaves the snapshot ref stable and this selector is skipped.
 export const selectTodayTaskIds = createSelector(
   selectTagFeatureState,
-  selectTaskEntitiesInActiveProjects,
+  selectTaskSchedulingSnapshotRecord,
   selectTodayStr,
   selectStartOfNextDayDiffMs,
   (tagState, activeTaskEntities, todayStr, startOfNextDayDiffMs): string[] => {


### PR DESCRIPTION
## Problem
The collection task selectors — `selectOverdueTasks`, `selectAllTasksWithDueTimeSorted` → `selectTimeConflictTaskIds`, `selectAllUndoneTasksWithDeadlineSorted`, `selectAllUndoneTasksWithDueDay`, `selectLaterTodayTasksWithSubTasks`, `selectAllTasksWithSubTasks`, and work-context's `selectTodayTaskIds` — all derive from `selectAllTasks`, which returns a **new array every second** while a task tracks time (the tracked task's `timeSpent` bump changes the entities slice). None of them read `timeSpent`, yet each re-ran its O(n) filter/sort and reallocated on every tick.

## Fix
Introduce `selectTaskSchedulingSnapshot`: a projection of each task to **scheduling fields only** (`id, isDone, dueDay, dueWithTime, deadlineDay, deadlineWithTime, parentId, subTaskIds`), per-entity ref-cached and array-ref-stable — so a `timeSpent`-only tick yields the **identical** snapshot reference. Each collection selector now:
1. derives its filter/sort **decision** (an ordered id list) from the snapshot — skipped by NgRx memoization when the snapshot is unchanged; and
2. re-maps that stable id list back to **live** task entities through a per-selector memoized mapper, preserving the existing output types and returning the previous array reference unless a genuine member changed.

Net: while a task tracks time, the expensive filter/sort no longer runs and downstream consumers keep stable references — but any real scheduling change (dueDay/dueWithTime/isDone/deadline/membership) still recomputes, and members are always served with their live refs (no staleness).

`selectTimeConflictTaskIds` is intentionally left on the live sorted selector because `getTimeLeftForTask` reads `timeSpent`.

## Notes
- Builds on the merged per-subscription selector factories (#8809); this branch is rebased onto current `master` and the two coexist.
- Two minor documented behaviours: `selectLaterTodayTasksWithSubTasks`'s `Date.now()` cutoff now re-evaluates on scheduling/day changes rather than incidentally per tick; `selectTodayTaskIds`'s unpinned-task tail is ordered by `state.ids` (same set, arbitrary-but-stable either way).

## Tests
`task.selectors.spec` (+ snapshot suite): a `timeSpent`-only change → snapshot identical ref and decision selectors return identical refs; a real scheduling change → recompute + live member ref; shape-parity `toEqual` vs the pre-refactor logic. `work-context.selectors.spec` and `task-later-today.selectors.spec` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)