### PR TITLE
feat(task-repeat): default skip-overdue for new everyday recurring tasks

### DIFF
--- a/docs/wiki/2.06-Manage-Repeating-Tasks.md
+++ b/docs/wiki/2.06-Manage-Repeating-Tasks.md
@@ -30,7 +30,7 @@ You can also open the dialog from a repeating task instance or from a repeat pro
 5. Optionally set **Tags to add** (chip list).
 6. Optionally set **Scheduled start time** (e.g. 15:00; leave blank for all-day). If you set a time, **Remind at** appears — choose when to be reminded (e.g. when it starts, 5 minutes before).
 7. Optionally set **Default Estimate** (duration). **Order** (number) controls creation order when several recurring tasks are created at the same time; see the field description in the dialog.
-8. In the advanced section: **Default notes**, **Inherit subtasks** (copy subtasks from the latest instance to the next), if inherit is on, **Disable auto-updating subtasks** (do not update inherited subtasks when the newest instance changes), and **Don't let overdue instances pile up** (keep a single up-to-date instance instead of a stack of missed duplicates). The last option defaults **on** for the **Every day** preset and **off** for every other schedule; see [[4.13-Repeating-Tasks]]. You can change it per task.
+8. In the advanced section: **Default notes**, **Inherit subtasks** (copy subtasks from the latest instance to the next), if inherit is on, **Disable auto-updating subtasks** (do not update inherited subtasks when the newest instance changes), and **Don't let overdue instances pile up** (keep a single up-to-date instance instead of a stack of missed duplicates). The last option defaults **on** for the **Every day** preset (or an equivalent custom every-single-day cycle) and **off** for every other schedule; see [[4.13-Repeating-Tasks]]. You can change it per task.
 9. Click **Save**. New instances are created according to the pattern when you open the project or the app.
 
 ## Add a time and Reminder to a Repeating Task

--- a/docs/wiki/2.06-Manage-Repeating-Tasks.md
+++ b/docs/wiki/2.06-Manage-Repeating-Tasks.md
@@ -30,7 +30,7 @@ You can also open the dialog from a repeating task instance or from a repeat pro
 5. Optionally set **Tags to add** (chip list).
 6. Optionally set **Scheduled start time** (e.g. 15:00; leave blank for all-day). If you set a time, **Remind at** appears — choose when to be reminded (e.g. when it starts, 5 minutes before).
 7. Optionally set **Default Estimate** (duration). **Order** (number) controls creation order when several recurring tasks are created at the same time; see the field description in the dialog.
-8. In the advanced section: **Default notes**, **Inherit subtasks** (copy subtasks from the latest instance to the next), and, if inherit is on, **Disable auto-updating subtasks** (do not update inherited subtasks when the newest instance changes).
+8. In the advanced section: **Default notes**, **Inherit subtasks** (copy subtasks from the latest instance to the next), if inherit is on, **Disable auto-updating subtasks** (do not update inherited subtasks when the newest instance changes), and **Don't let overdue instances pile up** (keep a single up-to-date instance instead of a stack of missed duplicates). The last option defaults **on** for the **Every day** preset and **off** for every other schedule; see [[4.13-Repeating-Tasks]]. You can change it per task.
 9. Click **Save**. New instances are created according to the pattern when you open the project or the app.
 
 ## Add a time and Reminder to a Repeating Task

--- a/docs/wiki/4.13-Repeating-Tasks.md
+++ b/docs/wiki/4.13-Repeating-Tasks.md
@@ -101,3 +101,19 @@ When you enable **"Wait for completion"** on a repeating task, the app will not 
 - **Habit tracking**: Tasks where you want to ensure completion before moving to the next occurrence
 
 This option works independently from "Repeat from completion date" (which re-anchors the schedule to the completion day). You can enable both if you want the task to repeat N days after completion AND wait for completion before creating the next instance.
+
+## Don't Let Overdue Instances Pile Up Option
+
+When you enable **"Don't let overdue instances pile up"** on a repeating task, missed occurrences don't accumulate as a stack of duplicate overdue tasks—you keep a single, up-to-date instance instead. An empty missed instance is removed once a newer one exists; any instance where you tracked time, completed subtasks, or made edits is always kept.
+
+### Default Behavior
+
+- **On by default for the Every day preset.** An everyday task is the only schedule that actually piles up (one empty overdue copy per day if you fall behind), and today is always a scheduled day, so a missed instance reliably comes back the same day—it can never silently vanish. You get one current instance instead of a growing stack.
+- **Off by default for every other schedule** (workday, weekly, monthly, yearly, and every-N-days custom cycles). These have at most one missed occurrence, so nothing piles up—and an overdue "pay rent on the 1st" or "renew the domain" should stay visible as a reminder rather than quietly disappear until its next occurrence.
+
+This only sets the **default** for newly created repeating tasks. Existing tasks keep whatever they were configured with, and you can turn the option on or off for any task under the repeat dialog's **Advanced** section.
+
+### When to Use It
+
+- **Daily habits and routines**: Water the plants, daily standup, inbox zero—skip the guilt-pile of stale duplicates and just see today's.
+- **Keep it off for bills and renewals**: Leave it off (the default) for monthly or yearly obligations so a missed one stays on your list until you handle it.

--- a/docs/wiki/4.13-Repeating-Tasks.md
+++ b/docs/wiki/4.13-Repeating-Tasks.md
@@ -108,8 +108,8 @@ When you enable **"Don't let overdue instances pile up"** on a repeating task, m
 
 ### Default Behavior
 
-- **On by default for the Every day preset.** An everyday task is the only schedule that actually piles up (one empty overdue copy per day if you fall behind), and today is always a scheduled day, so a missed instance reliably comes back the same day—it can never silently vanish. You get one current instance instead of a growing stack.
-- **Off by default for every other schedule** (workday, weekly, monthly, yearly, and every-N-days custom cycles). These have at most one missed occurrence, so nothing piles up—and an overdue "pay rent on the 1st" or "renew the domain" should stay visible as a reminder rather than quietly disappear until its next occurrence.
+- **On by default for the Every day preset** (or an equivalent custom every-single-day cycle). An everyday task is the only schedule that actually piles up (one empty overdue copy per day if you fall behind), and today is always a scheduled day, so a missed instance reliably comes back the same day—it can never silently vanish. You get one current instance instead of a growing stack.
+- **Off by default for every other schedule** (workday, weekly, monthly, yearly, and custom cycles longer than a day). These have at most one missed occurrence, so nothing piles up—and an overdue "pay rent on the 1st" or "renew the domain" should stay visible as a reminder rather than quietly disappear until its next occurrence.
 
 This only sets the **default** for newly created repeating tasks. Existing tasks keep whatever they were configured with, and you can turn the option on or off for any task under the repeat dialog's **Advanced** section.
 

--- a/e2e/tests/recurring/skip-overdue-default-8644.spec.ts
+++ b/e2e/tests/recurring/skip-overdue-default-8644.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import { type Page } from '@playwright/test';
+import { openRecurDialog, saveRecurDialog } from '../../utils/recurring-task-helpers';
+
+/**
+ * PR #8644: new recurring configs default `skipOverdue` ("Don't let overdue
+ * instances pile up") to ON for the plain everyday Daily schedule (where missed
+ * instances pile up and skipping is safe — today is always scheduled), and OFF
+ * for every other schedule (where a missed occurrence is a real obligation that
+ * must stay visible).
+ *
+ * These assert the persisted default via the NgRx store — the user never has
+ * to open Advanced for it to apply.
+ */
+
+/** Read the persisted skipOverdue flag for the config created for `title`. */
+const getPersistedSkipOverdue = async (
+  page: Page,
+  title: string,
+): Promise<boolean | null | undefined> =>
+  page.evaluate((taskTitle: string) => {
+    type RepeatCfgLike = { title?: string | null; skipOverdue?: boolean };
+    type StoreState = {
+      taskRepeatCfg?: { entities?: Record<string, RepeatCfgLike | undefined> };
+    };
+    type StoreLike = {
+      subscribe: (next: (s: StoreState) => void) => { unsubscribe: () => void };
+    };
+    const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+      .__e2eTestHelpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+    let latest: StoreState | undefined;
+    store
+      .subscribe((s) => {
+        latest = s;
+      })
+      .unsubscribe();
+    const cfg = Object.values(latest?.taskRepeatCfg?.entities ?? {}).find((c) =>
+      c?.title?.includes(taskTitle),
+    );
+    return cfg ? (cfg.skipOverdue ?? null) : undefined;
+  }, title);
+
+test.describe('Recurring task - skipOverdue default by schedule (#8644)', () => {
+  test('a new Daily recurring task defaults skipOverdue to ON', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    const taskTitle = `${testPrefix}-DailySkip8644`;
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask(taskTitle);
+    const task = taskPage.getTaskByText(taskTitle).first();
+    await expect(task).toBeVisible({ timeout: 10000 });
+    await taskPage.openTaskDetail(task);
+
+    // The dialog opens on the Daily quick setting by default — just save.
+    await openRecurDialog(page);
+    await saveRecurDialog(page);
+
+    await expect.poll(() => getPersistedSkipOverdue(page, taskTitle)).toBe(true);
+  });
+
+  test('a new Monthly recurring task keeps skipOverdue OFF', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    const taskTitle = `${testPrefix}-MonthlySkip8644`;
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask(taskTitle);
+    const task = taskPage.getTaskByText(taskTitle).first();
+    await expect(task).toBeVisible({ timeout: 10000 });
+    await taskPage.openTaskDetail(task);
+
+    const dialog = await openRecurDialog(page);
+    await dialog.locator('mat-select').first().click();
+    const monthlyOption = page.locator('mat-option').filter({ hasText: /first day/i });
+    await expect(monthlyOption).toBeVisible({ timeout: 5000 });
+    await monthlyOption.click();
+    await saveRecurDialog(page);
+
+    await expect.poll(() => getPersistedSkipOverdue(page, taskTitle)).toBe(false);
+  });
+});

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -11,7 +11,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideMockStore } from '@ngrx/store/testing';
 import { Observable, of, Subject } from 'rxjs';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 // FormlyConfigModule (not FormlyModule) is needed here to register custom
 // field types and validation within the TestBed injector.
 import { FormlyConfigModule } from '../../../ui/formly-config.module';
@@ -682,6 +682,54 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       expect(mockTaskRepeatCfgService.addTaskRepeatCfgToTask).not.toHaveBeenCalled();
       expect(mockTaskRepeatCfgService.updateTaskRepeatCfg).not.toHaveBeenCalled();
       expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('skipOverdue default seeding (#8644)', () => {
+    const savedCfg = (): TaskRepeatCfg =>
+      mockTaskRepeatCfgService.addTaskRepeatCfgToTask.calls.mostRecent()
+        .args[2] as TaskRepeatCfg;
+
+    it('seeds skipOverdue ON for a new Daily config (the default schedule)', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // A new config defaults to the Daily quick setting; no user interaction.
+      component.save();
+
+      expect(mockTaskRepeatCfgService.addTaskRepeatCfgToTask).toHaveBeenCalledTimes(1);
+      expect(savedCfg().skipOverdue).toBe(true);
+    });
+
+    it('seeds skipOverdue OFF when the final schedule is Monthly', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // User switched the preset to monthly without touching the checkbox.
+      component.repeatCfg.update((c) => ({ ...c, quickSetting: 'MONTHLY_FIRST_DAY' }));
+      component.save();
+
+      expect(savedCfg().skipOverdue).toBe(false);
+    });
+
+    it('respects an explicit user toggle over the schedule-derived default', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      const component = fixture.componentInstance;
+
+      // User opened Advanced and ticked skipOverdue ON for a monthly task;
+      // a dirty control means the derived OFF default must not override it.
+      const ctrl = new FormControl(true);
+      ctrl.markAsDirty();
+      component.formGroup2().addControl('skipOverdue', ctrl);
+      component.repeatCfg.update((c) => ({
+        ...c,
+        quickSetting: 'MONTHLY_FIRST_DAY',
+        skipOverdue: true,
+      }));
+
+      component.save();
+
+      expect(savedCfg().skipOverdue).toBe(true);
     });
   });
 });

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -38,6 +38,7 @@ import { formatMonthDay } from '../../../util/format-month-day.util';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { first } from 'rxjs/operators';
 import { getQuickSettingUpdates } from './get-quick-setting-updates';
+import { getDefaultSkipOverdue } from './get-default-skip-overdue';
 import { getTaskRepeatCfgChanges } from './get-task-repeat-cfg-changes';
 import { clockStringFromDate } from '../../../ui/duration/clock-string-from-date';
 import { ChipListInputComponent } from '../../../ui/chip-list-input/chip-list-input.component';
@@ -321,6 +322,10 @@ export class DialogEditTaskRepeatCfgComponent {
         : undefined;
       return {
         ...DEFAULT_TASK_REPEAT_CFG,
+        // New configs open on the "Daily" quick setting, where collapsing empty
+        // overdue instances is both useful and safe; see getDefaultSkipOverdue.
+        // Re-derived from the final schedule on save in case the user switches.
+        skipOverdue: getDefaultSkipOverdue(DEFAULT_TASK_REPEAT_CFG),
         startDate:
           this._data.task.dueDay ??
           getDbDateStr(this._data.task.dueWithTime || undefined),
@@ -463,10 +468,21 @@ export class DialogEditTaskRepeatCfgComponent {
       );
       this.close();
     } else {
+      // Seed skipOverdue from the FINAL schedule (the initial default assumed
+      // Daily; the user may have switched to e.g. Monthly). Skip this only when
+      // the user explicitly toggled the Advanced checkbox, so an opt-in/out is
+      // honoured. If Advanced was opened on a Daily config and then the schedule
+      // was switched, the still-pristine checkbox may visibly show the old ON
+      // while we persist the safe re-derived value — an accepted, conservative
+      // display gap in a rarely-opened panel (never persists the wrong value).
+      const skipOverdueTouched = this.formGroup2().get('skipOverdue')?.dirty ?? false;
+      const newRepeatCfg = skipOverdueTouched
+        ? finalRepeatCfg
+        : { ...finalRepeatCfg, skipOverdue: getDefaultSkipOverdue(finalRepeatCfg) };
       this._taskRepeatCfgService.addTaskRepeatCfgToTask(
         (this._data.task as Task).id,
         (this._data.task as Task).projectId || null,
-        finalRepeatCfg,
+        newRepeatCfg,
       );
       this.close();
     }

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -471,10 +471,10 @@ export class DialogEditTaskRepeatCfgComponent {
       // Seed skipOverdue from the FINAL schedule (the initial default assumed
       // Daily; the user may have switched to e.g. Monthly). Skip this only when
       // the user explicitly toggled the Advanced checkbox, so an opt-in/out is
-      // honoured. If Advanced was opened on a Daily config and then the schedule
-      // was switched, the still-pristine checkbox may visibly show the old ON
-      // while we persist the safe re-derived value — an accepted, conservative
-      // display gap in a rarely-opened panel (never persists the wrong value).
+      // honoured. For any new non-Daily config whose Advanced panel is opened
+      // but left untouched, the checkbox may visibly show the seeded ON while we
+      // persist the safe re-derived value — an accepted, conservative display
+      // gap in a rarely-opened panel (never persists the wrong value).
       const skipOverdueTouched = this.formGroup2().get('skipOverdue')?.dirty ?? false;
       const newRepeatCfg = skipOverdueTouched
         ? finalRepeatCfg

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.spec.ts
@@ -1,0 +1,62 @@
+import { getDefaultSkipOverdue } from './get-default-skip-overdue';
+import { RepeatCycleOption, RepeatQuickSetting } from '../task-repeat-cfg.model';
+
+const cfg = (
+  quickSetting: RepeatQuickSetting,
+  repeatCycle: RepeatCycleOption = 'DAILY',
+  repeatEvery = 1,
+): {
+  quickSetting: RepeatQuickSetting;
+  repeatCycle: RepeatCycleOption;
+  repeatEvery: number;
+} => ({
+  quickSetting,
+  repeatCycle,
+  repeatEvery,
+});
+
+describe('getDefaultSkipOverdue', () => {
+  it('is ON for the Daily preset (everyday → never drops to zero)', () => {
+    expect(getDefaultSkipOverdue(cfg('DAILY', 'DAILY', 1))).toBe(true);
+  });
+
+  it('is OFF for the Mon–Fri preset (a missed workday must stay visible)', () => {
+    expect(getDefaultSkipOverdue(cfg('MONDAY_TO_FRIDAY', 'WEEKLY', 1))).toBe(false);
+  });
+
+  it('is OFF for weekly/monthly/yearly presets (missed occurrence must stay visible)', () => {
+    const offPresets: RepeatQuickSetting[] = [
+      'WEEKLY_CURRENT_WEEKDAY',
+      'MONTHLY_CURRENT_DATE',
+      'MONTHLY_FIRST_DAY',
+      'MONTHLY_LAST_DAY',
+      'MONTHLY_NTH_WEEKDAY',
+      'YEARLY_CURRENT_DATE',
+    ];
+    offPresets.forEach((preset) => {
+      expect(getDefaultSkipOverdue(cfg(preset, 'WEEKLY', 1))).toBe(false);
+    });
+  });
+
+  describe('CUSTOM', () => {
+    it('is ON only for an every-single-day custom cycle (same as the Daily preset)', () => {
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'DAILY', 1))).toBe(true);
+    });
+
+    it('is OFF for every-N-days (N > 1) — today is no longer always scheduled', () => {
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'DAILY', 2))).toBe(false);
+    });
+
+    it('is OFF for weekly/monthly/yearly custom cycles', () => {
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'WEEKLY', 1))).toBe(false);
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'MONTHLY', 1))).toBe(false);
+      expect(getDefaultSkipOverdue(cfg('CUSTOM', 'YEARLY', 1))).toBe(false);
+    });
+
+    it('treats a missing repeatEvery as 1', () => {
+      expect(
+        getDefaultSkipOverdue({ quickSetting: 'CUSTOM', repeatCycle: 'DAILY' }),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.ts
@@ -1,4 +1,4 @@
-import { TaskRepeatCfgCopy } from '../task-repeat-cfg.model';
+import type { TaskRepeatCfgCopy } from '../task-repeat-cfg.model';
 
 /**
  * Default value for `skipOverdue` ("Don't let overdue instances pile up") when a

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue.ts
@@ -1,0 +1,32 @@
+import { TaskRepeatCfgCopy } from '../task-repeat-cfg.model';
+
+/**
+ * Default value for `skipOverdue` ("Don't let overdue instances pile up") when a
+ * NEW recurring config is created.
+ *
+ * ON only for a plain everyday schedule — reached via the "Daily" preset or a
+ * CUSTOM every-single-day cycle (both are literally the same schedule, so they
+ * get the same default; no "same schedule, different default" surprise). That is
+ * the one case where the option is both useful and provably safe:
+ * - Useful: everyday tasks are the only ones that actually pile up — one empty
+ *   overdue copy per day you fall behind. Collapsing those into a single current
+ *   instance is the calm default.
+ * - Safe: today is always a scheduled day, so a missed instance regenerates the
+ *   same day and can never silently vanish (it cannot even drop to zero).
+ *
+ * Everything else stays OFF — weekly/monthly/yearly and any every-N-days custom
+ * cycle keep their one missed occurrence visible, so a real obligation ("pay
+ * rent on the 1st", "renew the domain") never disappears until its next
+ * occurrence. Users can still flip the option per config either way.
+ *
+ * Existing configs are unaffected — this only seeds the default for new ones.
+ */
+export const getDefaultSkipOverdue = (
+  cfg: Pick<TaskRepeatCfgCopy, 'quickSetting' | 'repeatCycle'> & {
+    repeatEvery?: number;
+  },
+): boolean =>
+  cfg.quickSetting === 'DAILY' ||
+  (cfg.quickSetting === 'CUSTOM' &&
+    cfg.repeatCycle === 'DAILY' &&
+    (cfg.repeatEvery ?? 1) === 1);

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.model.spec.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.model.spec.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_TASK_REPEAT_CFG } from './task-repeat-cfg.model';
+
+describe('DEFAULT_TASK_REPEAT_CFG', () => {
+  it('keeps skipOverdue false as the safe baseline', () => {
+    // The model default is intentionally the OFF baseline: it is what fixtures
+    // and any non-dialog spread inherit, and OFF can never silently drop a
+    // missed occurrence. The real, schedule-aware default for newly created
+    // configs (ON only for a plain everyday schedule) is seeded at creation by
+    // getDefaultSkipOverdue — see get-default-skip-overdue.ts. Pinned so a
+    // future change cannot quietly flip this to a blanket default.
+    expect(DEFAULT_TASK_REPEAT_CFG.skipOverdue).toBe(false);
+  });
+});

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.model.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.model.ts
@@ -136,5 +136,9 @@ export const DEFAULT_TASK_REPEAT_CFG: Omit<TaskRepeatCfgCopy, 'id'> = {
   notes: undefined,
   shouldInheritSubtasks: false,
   disableAutoUpdateSubtasks: false,
+  // Safe baseline only. New configs get a schedule-aware default at creation
+  // (ON for a plain everyday schedule) via getDefaultSkipOverdue — see
+  // dialog-edit-task-repeat-cfg/get-default-skip-overdue.ts. Keep this false so
+  // fixtures and any non-dialog spread inherit the conservative value.
   skipOverdue: false,
 };

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -380,6 +380,38 @@ describe('AddTaskBarComponent', () => {
       expect(repeatCfg.startDate).toBe('2024-05-19');
     });
 
+    it('seeds skipOverdue ON for an inline Daily repeat (#8644)', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const addRepeatCfgSpy = spyOn(
+        TestBed.inject(TaskRepeatCfgService),
+        'addTaskRepeatCfgToTask',
+      );
+
+      component.stateService.updateInputTxt('Daily standup');
+      component.stateService.updateCleanText('Daily standup');
+      component.stateService.updateRepeatSetting('DAILY');
+
+      await component.addTask();
+
+      expect(addRepeatCfgSpy.calls.mostRecent().args[2].skipOverdue).toBe(true);
+    });
+
+    it('keeps skipOverdue OFF for an inline Monthly repeat (#8644)', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const addRepeatCfgSpy = spyOn(
+        TestBed.inject(TaskRepeatCfgService),
+        'addTaskRepeatCfgToTask',
+      );
+
+      component.stateService.updateInputTxt('Pay rent');
+      component.stateService.updateCleanText('Pay rent');
+      component.stateService.updateRepeatSetting('MONTHLY_CURRENT_DATE');
+
+      await component.addTask();
+
+      expect(addRepeatCfgSpy.calls.mostRecent().args[2].skipOverdue).toBe(false);
+    });
+
     it('should pass deadlineDay when a deadline date is set without a time', async () => {
       mockTaskService.add.and.returnValue('task-1');
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -72,6 +72,7 @@ import { MentionConfigService } from '../mention-config.service';
 import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { DEFAULT_TASK_REPEAT_CFG } from '../../task-repeat-cfg/task-repeat-cfg.model';
 import { getQuickSettingUpdates } from '../../task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates';
+import { getDefaultSkipOverdue } from '../../task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ShortSyntaxTag, shortSyntaxToTags } from './short-syntax-to-tags';
 import { DEFAULT_PROJECT_COLOR } from '../../work-context/work-context.const';
@@ -545,7 +546,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
           const referenceDate = dateStrToUtcDate(startDate);
           const quickSettingUpdates =
             getQuickSettingUpdates(state.repeatQuickSetting, referenceDate) || {};
-          this._taskRepeatCfgService.addTaskRepeatCfgToTask(taskId, state.projectId, {
+          const newRepeatCfg = {
             ...DEFAULT_TASK_REPEAT_CFG,
             startDate,
             ...quickSettingUpdates,
@@ -555,6 +556,12 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
             defaultEstimate: state.estimate || 0,
             startTime: state.time || undefined,
             remindAt: state.time ? resolvedRemindOption : undefined,
+          };
+          // Seed the skipOverdue default from the chosen schedule, same as the
+          // repeat dialog (there is no advanced toggle in the inline add-bar).
+          this._taskRepeatCfgService.addTaskRepeatCfgToTask(taskId, state.projectId, {
+            ...newRepeatCfg,
+            skipOverdue: getDefaultSkipOverdue(newRepeatCfg),
           });
         }
       }


### PR DESCRIPTION
## What

New recurring configs default the `skipOverdue` option ("Don't let overdue instances pile up") **on** for a **plain everyday schedule** — the **Daily** preset or a CUSTOM every-single-day cycle — and **off** for every other schedule (workday/Mon–Fri, weekly, monthly, yearly, every-N-days).

This supersedes #8644, which scoped the ON default to daily **and** the Mon–Fri preset (plus checkbox re-sync machinery). This variant narrows it to the one provably-safe case and drops ~60 lines of the fiddliest code.

## Why

Daily duplication of stale recurring tasks is exactly the noise/guilt-clutter the manifesto rejects ("less noise, more depth"; "one calm default"). But a blanket default is the wrong tool — the benefit and the risk sit on opposite ends of the frequency spectrum:

- **Pile-up only happens for everyday tasks.** A weekly/monthly/yearly task has at most one missed occurrence — nothing piles up, so the option buys nothing there.
- **Silently dropping a missed occurrence only hurts infrequent tasks.** For weekly/monthly/yearly, `skipOverdue` could make a real obligation ("pay rent on the 1st", "renew the domain") vanish until its next occurrence. For a plain everyday schedule it can't meaningfully hurt: **today is always a scheduled day**, so a missed instance regenerates the same day and can never silently vanish (it can't even drop to zero).

Why **not** also default-on for Mon–Fri (as #8644 did): the safety argument there is only "at most a weekend away", and it drew the boundary at *named presets* — so the identical Mon–Fri schedule built via CUSTOM weekday checkboxes would default off, a "same schedule, different default" surprise. Narrowing to a plain everyday schedule makes the safety airtight and the rule explainable in one sentence: **everyday tasks don't pile up; everything else is unchanged.** Deriving purely from the effective schedule also means the Daily preset and a CUSTOM every-day cycle (same schedule, two ways to enter it) get the same default.

## How

- New pure predicate `getDefaultSkipOverdue(cfg)` — ON iff the effective schedule is every-single-day (`quickSetting === 'DAILY'`, or `CUSTOM` + `repeatCycle === 'DAILY'` + `repeatEvery === 1`). Any future `RepeatQuickSetting` defaults OFF (the conservative direction).
- Seeded from the chosen schedule in **both** config-creation paths:
  - the **repeat dialog** — seeded on the new-config model, re-derived from the *final* schedule at save, and **skipped when the user explicitly toggled the checkbox** (`formGroup2().get('skipOverdue')?.dirty`), so per-config opt-in/out is preserved;
  - the inline **add-task-bar** recurrence (no advanced toggle there).
- `DEFAULT_TASK_REPEAT_CFG.skipOverdue` stays `false` — the safe baseline for fixtures and any non-dialog spread; the real default is seeded at creation. Pinned by a test so it can't silently become a blanket default again.

### Dropped vs. #8644

The `onScheduleModelChange` checkbox re-sync machinery and the Mon–Fri/custom-nuance branches are gone. Accepted tradeoff: if the Advanced panel is opened on a new config and left untouched, the pristine checkbox may briefly *show* the seeded ON while `save()` *persists* the safe re-derived value — a cosmetic gap in a collapsed-by-default panel that never persists the wrong value. Documented in a comment in `save()`.

## Scope & safety

- **Only affects newly created configs.** Existing configs keep their stored value; no migration, no op-log/replay change, no sync-format change (`skipOverdue` is an existing field; the seeded value lands as a concrete boolean in the dispatched action).
- **No data loss.** The existing cleanup effect only reaps *empty, untouched, overdue* instances; anything with tracked time, completion, subtask progress, or edits is preserved, and a single lone instance is never removed.

## Tests

- `get-default-skip-overdue.spec.ts` — the predicate across all presets + CUSTOM edges.
- Dialog spec — daily seeds ON, monthly seeds OFF, explicit user toggle respected.
- add-task-bar spec — inline daily seeds ON, inline monthly stays OFF.
- `task-repeat-cfg.model.spec.ts` — pins the `false` baseline.
- E2E `skip-overdue-default-8644.spec.ts` — daily persists `true`, monthly persists `false` through the **real** form (the dialog unit tests stub the template, so this is the only end-to-end coverage of the formly → save path).

## Docs

`docs/wiki/4.13` (reference) and `2.06` (how-to) document the option and the by-schedule default.

## Review

Reworked from #8644 after a UX discussion (schedule-dependent defaults are hard for users to reason about) and a 7-reviewer pass (correctness, security, architecture, alternatives, performance, simplicity, Codex): no correctness/security/perf findings; the formly control's `dirty` flag was verified to survive Advanced collapse/reopen, so explicit toggles are never lost. Follow-up polish (docs accuracy for the custom every-day case, baseline signpost) folded in.
