### PR TITLE
fix(archive): write compressed archives in a single atomic transaction

### DIFF
--- a/src/app/features/archive/archive-compression.service.spec.ts
+++ b/src/app/features/archive/archive-compression.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { ArchiveCompressionService } from './archive-compression.service';
+import { ArchiveDbAdapter } from '../../core/persistence/archive-db-adapter.service';
+import { ArchiveModel } from './archive.model';
+
+const emptyArchive = (): ArchiveModel => ({
+  task: { ids: [], entities: {} },
+  timeTracking: { project: {}, tag: {} },
+  lastTimeTrackingFlush: 0,
+});
+
+describe('ArchiveCompressionService', () => {
+  let service: ArchiveCompressionService;
+  let archiveDbAdapterMock: jasmine.SpyObj<ArchiveDbAdapter>;
+
+  beforeEach(() => {
+    archiveDbAdapterMock = jasmine.createSpyObj<ArchiveDbAdapter>('ArchiveDbAdapter', [
+      'loadArchiveYoung',
+      'loadArchiveOld',
+      'saveArchiveYoung',
+      'saveArchiveOld',
+      'saveArchivesAtomic',
+    ]);
+    archiveDbAdapterMock.loadArchiveYoung.and.resolveTo(emptyArchive());
+    archiveDbAdapterMock.loadArchiveOld.and.resolveTo(emptyArchive());
+    archiveDbAdapterMock.saveArchiveYoung.and.resolveTo(undefined);
+    archiveDbAdapterMock.saveArchiveOld.and.resolveTo(undefined);
+    archiveDbAdapterMock.saveArchivesAtomic.and.resolveTo(undefined);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ArchiveCompressionService,
+        { provide: ArchiveDbAdapter, useValue: archiveDbAdapterMock },
+      ],
+    });
+
+    service = TestBed.inject(ArchiveCompressionService);
+  });
+
+  // Issue #8843: compressArchive wrote archiveYoung and archiveOld as two
+  // independent transactions. A crash between them left a half-compressed
+  // archive, and since compression is op-replayed on other clients, a torn
+  // local result diverged from replicas. Both archives must be written in a
+  // single atomic transaction via the existing saveArchivesAtomic API.
+  describe('compressArchive atomic write (#8843)', () => {
+    it('persists both archives via saveArchivesAtomic', async () => {
+      await service.compressArchive(Date.now());
+
+      expect(archiveDbAdapterMock.saveArchivesAtomic).toHaveBeenCalledTimes(1);
+      const [youngArg, oldArg] =
+        archiveDbAdapterMock.saveArchivesAtomic.calls.mostRecent().args;
+      expect(youngArg.task).toEqual({ ids: [], entities: {} });
+      expect(oldArg.task).toEqual({ ids: [], entities: {} });
+    });
+
+    it('does not write the archives as two independent transactions', async () => {
+      await service.compressArchive(Date.now());
+
+      expect(archiveDbAdapterMock.saveArchiveYoung).not.toHaveBeenCalled();
+      expect(archiveDbAdapterMock.saveArchiveOld).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/archive/archive-compression.service.ts
+++ b/src/app/features/archive/archive-compression.service.ts
@@ -82,10 +82,11 @@ export class ArchiveCompressionService {
     const newArchiveYoung = this._compressArchiveData(archiveYoung, oneYearAgoTimestamp);
     const newArchiveOld = this._compressArchiveData(archiveOld, oneYearAgoTimestamp);
 
-    await Promise.all([
-      this._archiveDbAdapter.saveArchiveYoung(newArchiveYoung),
-      this._archiveDbAdapter.saveArchiveOld(newArchiveOld),
-    ]);
+    // Atomic write: both archives written in a single IndexedDB transaction.
+    // Two independent writes could tear on a crash between them, and since
+    // compression is op-replayed on other clients a half-compressed local
+    // result would diverge from replicas (#8843).
+    await this._archiveDbAdapter.saveArchivesAtomic(newArchiveYoung, newArchiveOld);
   }
 
   private _compressArchiveData(


### PR DESCRIPTION
## Problem

`ArchiveCompressionService.compressArchive()` wrote `archiveYoung` and `archiveOld` as two independent transactions (`Promise.all([saveArchiveYoung, saveArchiveOld])`). A crash between the two writes leaves a half-compressed archive, and since compression is op-replayed on other clients, a torn local result diverges from replicas.

Addresses the "atomic archive write" item in #8843.

## Solution

Route both writes through the existing `ArchiveDbAdapter.saveArchivesAtomic(young, old)`, which commits both stores in a single IndexedDB transaction, so either both writes land or neither does. This mirrors the flush-young-to-old path already using `saveArchivesAtomic` in `archive-operation-handler.service.ts`.

Adds `archive-compression.service.spec.ts` asserting compression routes through the atomic API and never falls back to the two independent writes.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/wiki. (n/a — no doc or user-facing surface change)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
