### PR TITLE
fix(work-context): make isTodayListActive reactive to context changes

### DIFF
--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -234,7 +234,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     return 'chat';
   });
 
-  isTodayListActive = computed(() => this.workContextService.isTodayList);
+  isTodayListActive = computed(() => this.workContextService.isTodayListSignal());
   taskIdWithPrefix = computed(() => 't-' + this.task().id);
   isRepeatTaskCreatedToday = computed(
     () => !!(this.task().repeatCfgId && this._dateService.isToday(this.task().created)),

--- a/src/app/features/work-context/work-context.service.spec.ts
+++ b/src/app/features/work-context/work-context.service.spec.ts
@@ -13,7 +13,10 @@ import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { TaskArchiveService } from '../archive/task-archive.service';
 import { TODAY_TAG } from '../tag/tag.const';
 import { WorkContext, WorkContextType } from './work-context.model';
-import { selectActiveWorkContext } from './store/work-context.selectors';
+import {
+  selectActiveContextId,
+  selectActiveWorkContext,
+} from './store/work-context.selectors';
 import { allDataWasLoaded } from '../../root-store/meta/all-data-was-loaded.actions';
 
 describe('WorkContextService - undoneTasks$ filtering', () => {
@@ -640,5 +643,81 @@ describe('WorkContextService - activeWorkContext$ distinctUntilChanged', () => {
 
     ttSub.unsubscribe();
     sub.unsubscribe();
+  });
+});
+
+// #8843: `task.component.ts` read `workContextService.isTodayList` (a plain
+// mutable boolean) inside a `computed()`, so the computed had no signal producer
+// and never invalidated. `isTodayListSignal` is a `toSignal(isTodayList$)` mirror
+// that must reactively track the active work context.
+describe('WorkContextService - isTodayListSignal reactivity', () => {
+  let store: MockStore;
+  let service: WorkContextService;
+
+  beforeEach(() => {
+    const tagServiceMock = jasmine.createSpyObj('TagService', ['getTagById$']);
+    tagServiceMock.getTagById$.and.returnValue(of(TODAY_TAG));
+
+    const globalTrackingIntervalServiceMock = jasmine.createSpyObj(
+      'GlobalTrackingIntervalService',
+      [],
+      { todayDateStr$: of('2026-04-06') },
+    );
+
+    const dateServiceMock = jasmine.createSpyObj('DateService', ['todayStr']);
+    dateServiceMock.todayStr.and.returnValue('2026-04-06');
+
+    const timeTrackingServiceMock = jasmine.createSpyObj('TimeTrackingService', [
+      'getWorkStartEndForWorkContext$',
+    ]);
+    timeTrackingServiceMock.getWorkStartEndForWorkContext$.and.returnValue(of({}));
+
+    const taskArchiveServiceMock = jasmine.createSpyObj('TaskArchiveService', [
+      'loadYoung',
+    ]);
+    taskArchiveServiceMock.loadYoung.and.returnValue(
+      Promise.resolve({ ids: [], entities: {} }),
+    );
+
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideMockStore({
+          initialState: {
+            workContext: { activeId: TODAY_TAG.id, activeType: 'TAG' },
+            tag: { entities: {}, ids: [] },
+            project: { entities: {}, ids: [] },
+            task: { entities: {}, ids: [] },
+          },
+        }),
+        // activeWorkContextId$ is gated behind the allDataWasLoaded action.
+        provideMockActions(() => of(allDataWasLoaded())),
+        { provide: Router, useValue: { events: of(), url: '/' } },
+        { provide: TagService, useValue: tagServiceMock },
+        {
+          provide: GlobalTrackingIntervalService,
+          useValue: globalTrackingIntervalServiceMock,
+        },
+        { provide: DateService, useValue: dateServiceMock },
+        { provide: TimeTrackingService, useValue: timeTrackingServiceMock },
+        { provide: TaskArchiveService, useValue: taskArchiveServiceMock },
+        WorkContextService,
+      ],
+    });
+
+    store = TestBed.inject(MockStore);
+    store.overrideSelector(selectActiveContextId, TODAY_TAG.id);
+    store.refreshState();
+
+    service = TestBed.inject(WorkContextService);
+  });
+
+  it('is true on the Today list and flips to false when the context changes', () => {
+    expect(service.isTodayListSignal()).toBe(true);
+
+    store.overrideSelector(selectActiveContextId, 'some-other-context');
+    store.refreshState();
+
+    expect(service.isTodayListSignal()).toBe(false);
   });
 });

--- a/src/app/features/work-context/work-context.service.ts
+++ b/src/app/features/work-context/work-context.service.ts
@@ -373,6 +373,11 @@ export class WorkContextService {
     map((id) => id === TODAY_TAG.id),
     shareReplay(1),
   );
+  // Signal mirror of `isTodayList$`. The `isTodayList` boolean above is a plain
+  // mutable field kept in sync via subscribe, so reading it inside a `computed()`
+  // never invalidates the computed (a non-signal is not a producer, #8843). Reactive
+  // consumers should read this signal instead; the boolean stays for synchronous reads.
+  readonly isTodayListSignal = toSignal(this.isTodayList$, { initialValue: false });
 
   isHasTasksToWorkOn$: Observable<boolean> = combineLatest([
     this.mainListTasks$,


### PR DESCRIPTION
## Problem

`task.component.ts`'s `isTodayListActive` was `computed(() => this.workContextService.isTodayList)`. `WorkContextService.isTodayList` is a plain mutable boolean (kept in sync via a constructor subscribe), not a signal, so the `computed()` has no producer and never invalidates — it returns its first value for the component's lifetime. Masked in practice by per-work-context component recreation + shareReplay(1), but a signals anti-pattern in the hot path.

Addresses the "stale computed in the task hot path" item in #8843.

## Solution

Expose `isTodayListSignal = toSignal(this.isTodayList$, { initialValue: false })` on `WorkContextService` and read that from the computed, so it tracks context changes reactively. Placed on the service (rather than a component-local `toSignal`) as the shared home for this derived signal; the plain `isTodayList` boolean is kept because `history.component.ts` reads it synchronously in a non-reactive method.

Adds a `work-context.service.spec.ts` test asserting the signal is true on the Today context and flips to false when the active context changes.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/wiki. (n/a — no doc or user-facing surface change)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
