### PR TITLE
fix(nav): prevent icon jump on sidebar close

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -39,7 +39,9 @@ import { HISTORY_STATE } from '../../app.constants';
 import { SwipeDirective } from '../../ui/swipe-gesture/swipe.directive';
 import { DataInitStateService } from '../../core/data-init/data-init-state.service';
 
-const COLLAPSED_WIDTH = 64;
+// 56px = 24px icon + 16px (var(--s2)) padding on each side, so the left-aligned
+// nav icons sit centered in the collapsed rail.
+const COLLAPSED_WIDTH = 56;
 const MOBILE_NAV_WIDTH = 300;
 const FOCUS_DELAY_MS = 10;
 const INITIAL_ENTER_ANIMATION_DURATION_MS = 425;

--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -294,8 +294,7 @@ button[mat-menu-item].nav-link.active {
 
 :host-context(.nav-sidenav.compactMode) {
   .nav-link {
-    justify-content: center;
-    padding: 12px;
+    justify-content: flex-start;
 
     &:focus,
     &:hover {
@@ -305,7 +304,7 @@ button[mat-menu-item].nav-link.active {
 
     ::ng-deep .mat-mdc-menu-item-text {
       display: flex;
-      justify-content: center;
+      justify-content: flex-start;
       width: 100%;
       padding: 0;
 


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

I noticed that on opening and closing the sidebar, the icons shift. On open, they move a few pixels to the left, on close, they jump all the way to the right and travel back with the closing sidebar.


https://github.com/user-attachments/assets/21b72898-26e0-4c00-b5ec-a57d155f41d4

## Solution

<!-- Describe your changes in detail. -->

This keeps the icons from moving at all. I did need to make the sidebar a little bit smaller for them to be centered. Happy to modify a handful of padding/margin variables to make the math work with the current sidebar width if that's preferred though! There were fewer changes necessary if I just shrank the sidebar so I went that direction to begin with.

https://github.com/user-attachments/assets/a09341f3-b7ba-4a95-8e7d-bbeba1abbb72

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
