### PR TITLE
 ci(actions): SHA-pin remaining workflow actions

### DIFF
--- a/.github/workflows/issue-open-auto-reply.yml
+++ b/.github/workflows/issue-open-auto-reply.yml
@@ -12,11 +12,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: derekprior/add-autoresponse@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
-          respondableId: ${{ github.event.issue.node_id }}
-          response: "Thank you very much for opening up this issue! I am currently a bit overwhelmed by the many requests that arrive each week, so please forgive me, if I fail to respond personally. I am still very likely to at least skim read your request and I'll probably try to fix all (real) bugs if possible and I will likely review every single PR being made (please, give me a heads up if you intent to do so) and I will try to work on popular requests (please upvote via thumbs up on the original issue) whenever possible, but trying to respond to every single issue over the last years has been kind of draining and I need to adjust my approach for this project to remain fun for me and to make any progress with actually coding new stuff. Thanks for your understanding!"
-          author: ${{ github.event.issue.user.login }}
-          exemptedAuthors: 'johannesjo'
+          script: |
+            const exemptedAuthors = ['johannesjo'];
+            if (!context.payload.issue) {
+              core.warning("No issue payload found. This likely indicates this Action is misconfigured.");
+              return;
+            }
+
+            const author = context.payload.issue.user.login;
+            if (exemptedAuthors.includes(author)) {
+              core.info(`Author ${author} is exempted; skipping auto-response.`);
+              return;
+            }
+
+            const response = "Thank you very much for opening up this issue! I am currently a bit overwhelmed by the many requests that arrive each week, so please forgive me, if I fail to respond personally. I am still very likely to at least skim read your request and I'll probably try to fix all (real) bugs if possible and I will likely review every single PR being made (please, give me a heads up if you intent to do so) and I will try to work on popular requests (please upvote via thumbs up on the original issue) whenever possible, but trying to respond to every single issue over the last years has been kind of draining and I need to adjust my approach for this project to remain fun for me and to make any progress with actually coding new stuff. Thanks for your understanding!";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: response,
+            });

--- a/.github/workflows/issue-open-auto-reply.yml
+++ b/.github/workflows/issue-open-auto-reply.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const exemptedAuthors = ['johannesjo'];

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ github.repository }}
           path: ${{ env.CODE_ROOT }}
@@ -92,7 +92,7 @@ jobs:
         # includeIf matcher, which intermittently leaves the wiki push without
         # credentials on github-hosted runners (run 26335467138). v5 uses the
         # path-independent extraheader and is stable for this second checkout.
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ github.repository }}.wiki
           path: ${{ env.WIKI_ROOT }}


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

#8843 identified a few missing SHAs in the GitHub Actions, and the desire to move to `actions/github-scripts` instead of `derekprior/add-autoresponse`

## Solution

<!-- Describe your changes in detail. -->

Updated `wiki-sync.yml` to use `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`, which matches the other `actions/checkout` SHAs in the repo

Wrote a small script that _should_ replicate what `derekprior/add-autoresponse`, but testing GitHub Actions is always a pain so extra scrutiny on that code would be very appreciated!

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
