### PR TITLE
fix(android): push header below status bar on API 30-34 with old WebView (#8283)

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -57,9 +57,9 @@ class CapacitorMainActivity : BridgeActivity() {
     // path) to avoid allocating an IntArray on every pass while the IME is up.
     private val webViewLocationOnScreen = IntArray(2)
 
-    // SDK < 30 status-bar overlap workaround: last value pushed to JS, to dedupe
+    // SDK < 35 status-bar overlap workaround: last value pushed to JS, to dedupe
     // the per-layout-pass listener. -1 = nothing pushed yet.
-    // See pushStatusBarOverlapBelowApi30.
+    // See pushStatusBarOverlapBelowApi35.
     private var lastStatusBarOverlapCssPx: Int = -1
 
     private var isTimerCompleteReceiverRegistered = false
@@ -223,7 +223,7 @@ class CapacitorMainActivity : BridgeActivity() {
                 if (isKeyboardOpen) "true" else "false"
             )
             adjustWebViewHeightForKeyboardBelowApi30(rect, isKeyboardOpen)
-            pushStatusBarOverlapBelowApi30(rect)
+            pushStatusBarOverlapBelowApi35(rect)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -348,8 +348,8 @@ class CapacitorMainActivity : BridgeActivity() {
         // re-enters here, but it also wipes the inline --android-status-bar-overlap
         // off the fresh document. Re-arm the dedupe so the next layout pass
         // re-publishes it; otherwise the unchanged value is skipped and the
-        // header overlaps the status bar again on the WebView < 140 / API < 30
-        // tail. See pushStatusBarOverlapBelowApi30.
+        // header overlaps the status bar again on the WebView < 140 / API < 35
+        // tail. See pushStatusBarOverlapBelowApi35.
         lastStatusBarOverlapCssPx = -1
         pendingShareIntent?.let {
             Log.d("SP_SHARE", "Flushing pending share intent: $it")
@@ -549,37 +549,39 @@ class CapacitorMainActivity : BridgeActivity() {
 
     /**
      * Status-bar overlap workaround for the web header drawing BEHIND the status
-     * bar on the WebView < 140 tail (#8508 / #8283 follow-up, Android 9 / API 28).
+     * bar on the WebView < 140 tail (#8508 / #8283, Android 9 / API 28 through
+     * Android 14 / API 34).
      *
      * Edge-to-edge insets are owned by Capacitor's built-in SystemBars now. On
      * **API >= 35** it injects the real `--safe-area-inset-*` px, and on
      * **WebView >= 140** the WebView's own `env(safe-area-inset-*)` is correct
-     * (passthrough). But on the **WebView < 140** tail under enforced edge-to-edge
-     * the WebView extends under the status bar while `env(safe-area-inset-top)`
-     * resolves to 0 (old WebViews map only display cutouts into safe-area insets,
-     * not the status bar) — so the web side has no top inset and content overlaps
-     * the status bar.
+     * (passthrough). But on the **WebView < 140 / API < 35** tail under enforced
+     * edge-to-edge the WebView extends under the status bar while
+     * `env(safe-area-inset-top)` resolves to 0 (old WebViews map only display
+     * cutouts into safe-area insets, not the status bar) — so the web side has no
+     * top inset and content overlaps the status bar.
      *
      * We measure the overlap natively and publish it as the `--android-status-bar-
      * overlap` CSS var, which the web side folds into `--safe-area-top` via
      * `var(--safe-area-inset-top, max(env(...), var(--android-status-bar-overlap)))`.
      * The overlap is how much of the status bar covers the WebView: `rect.top`
-     * (top of the visible display frame = status-bar height, reliable on API 28,
+     * (top of the visible display frame = status-bar height, reliable API 28–34,
      * the same frame the keyboard path uses) minus the WebView's top on screen
      * (`getLocationOnScreen`: 0 when edge-to-edge, == status-bar height once
      * inset). So it is the status-bar height when the WebView is NOT inset and 0
      * once it is — `max()` never double-counts. Physical px → CSS px via display
      * density; deduped so the per-layout listener does not spam evaluateJavascript.
      *
-     * Gated to **SDK < 30 AND WebView < 140** (mirrors
-     * adjustWebViewHeightForKeyboardBelowApi30) so it never fights SystemBars; on
-     * API >= 35 the injected --safe-area-inset-top wins via var() precedence and
-     * the published var is ignored regardless. (Known small gap: an API 30–34
-     * device on an old WebView < 140 also has env()==0; rare, since WebView
-     * auto-updates above API 30 — broaden the gate if it ever surfaces.)
+     * Gated to **SDK < 35 AND WebView < 140** so it never fights SystemBars: on
+     * API >= 35 SystemBars injects --safe-area-inset-top (wins via var()
+     * precedence), and WebView >= 140 has correct env() passthrough. The full
+     * API < 35 range (not just < 30) is required because API 30–34 devices on an
+     * un-updated WebView < 140 — e.g. de-Googled ROMs where the system WebView is
+     * not refreshed via Play — also report env()==0 (#8283, Pixel 7a / Android 14
+     * / LineageOS-microG).
      */
-    private fun pushStatusBarOverlapBelowApi30(rect: Rect) {
-        if (android.os.Build.VERSION.SDK_INT >= 30) return
+    private fun pushStatusBarOverlapBelowApi35(rect: Rect) {
+        if (android.os.Build.VERSION.SDK_INT >= 35) return
         // Skip when SystemBars/env() already give the correct top inset (WebView
         // >= 140 passthrough). Unknown version (null) -> run it, the safe default.
         val wvMajor = webViewCompatibility?.majorVersion

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -48,10 +48,11 @@
   // Uses env() for native iOS safe areas
   // -----------------------------
   // `--android-status-bar-overlap` is fed natively (CapacitorMainActivity
-  // .pushStatusBarOverlapBelowApi30) on the WebView < 140 tail, where
+  // .pushStatusBarOverlapBelowApi35) on the WebView < 140 / API < 35 tail, where
   // env(safe-area-inset-top) wrongly resolves to 0 under edge-to-edge (old
   // WebViews map only display cutouts into safe-area insets, not the status bar)
-  // — #8508 / #8283 (Android 9 / API 28). It is 0 once the WebView is inset, so
+  // — #8508 / #8283 (Android 9 / API 28 through Android 14 / API 34). It is 0
+  // once the WebView is inset, so
   // max() never double-counts; on API >= 35 / WebView >= 140 the injected
   // --safe-area-inset-top wins via var() precedence and this fallback is ignored.
   // Declared 0px so the token is always defined (it is only ever overridden by


### PR DESCRIPTION
Fixes #8283.

## Problem

On **Pixel 7a / Android 14 (API 34) / LineageOS-microG** the app header draws behind the status bar, making the buttons unreachable. Reported on 18.8.0, still reproducing on 18.13.1.

## Root cause

Edge-to-edge insets are owned by Capacitor's built-in `SystemBars` (since the migration in #8543). Its behaviour splits three ways:

| Band | Top inset source |
| --- | --- |
| WebView ≥ 140 (any API) | native `env(safe-area-inset-top)` passthrough |
| WebView < 140, **API ≥ 35** | SystemBars injects `--safe-area-inset-*` px |
| WebView < 140, **API < 35** | **nothing** — `env(safe-area-inset-top)` resolves to 0 |

The native fallback `pushStatusBarOverlap*()` in `CapacitorMainActivity` fills that third band by measuring the overlap and publishing `--android-status-bar-overlap` (folded into `--safe-area-top` in `_css-variables.scss`). But it was gated `if (SDK_INT >= 30) return` — active only on Android ≤ 10.

That left **API 30–34 + WebView < 140** uncovered, which is exactly the reporter's device: de-Googled ROMs like LineageOS/microG don't refresh the System WebView via Play, so it stays below 140, and on API < 35 nothing provides the top inset → header at y=0 behind the bar. The code already flagged this as a known gap ("broaden the gate if it ever surfaces").

## Fix

Broaden the gate `SDK < 30` → `SDK < 35` and rename `pushStatusBarOverlapBelowApi30` → `pushStatusBarOverlapBelowApi35`.

- The `wvMajor >= 140` early-return is unchanged, so the WebView-passthrough band is still skipped.
- Fails safe: the `max(env(), overlap)` fold self-corrects to 0 once the WebView is natively inset (`getLocationOnScreen` == `rect.top`), so there is no double-count. Every device in the newly-covered band is already broken (header behind the bar), so the change can only improve or no-op — it can't regress a currently-working device.

## Verification

- [x] `_css-variables.scss` passes `checkFile`
- [ ] **On-device**: confirm on API 30–34 + WebView < 140 (reporter's Pixel 7a via debug build) that the header clears the status bar and the top inset isn't doubled. Android can't be built/run in the dev sandbox (gradle read-only), and CI has no device tests — this is the real gate before merge.
- [ ] Confirm reporter's WebView version is < 140 (asked in the issue); if ≥ 140 the cause is different and this fix won't apply.

Draft until on-device confirmation lands.
