### PR TITLE
docs(development): add instructions for setting up local tests with Chromium

### DIFF
--- a/docs/wiki/2.16-Set-Up-Development-Environment.md
+++ b/docs/wiki/2.16-Set-Up-Development-Environment.md
@@ -58,28 +58,32 @@ ERROR [launcher]: No binary for Chrome browser on your platform.
 
 Karma's `karma-chrome-launcher` locates the browser via the `CHROME_BIN` environment variable, falling back to a system Chrome/Chromium install. Pick one of the options below.
 
-### Option A — Use a system Chrome/Chromium
+### Option A — Use a system Google Chrome
 
-Install Google Chrome or Chromium through your OS package manager. On most platforms `karma-chrome-launcher` then finds it automatically. If it doesn't (or you keep it in a non-standard location), set `CHROME_BIN` explicitly as in Option B.
+Install **Google Chrome** through your OS package manager. The karma config uses `karma-chrome-launcher`'s `Chrome` launcher (`base: 'Chrome'` in `src/karma.conf.js`), which on Linux only auto-detects real Google Chrome — it probes for `google-chrome` / `google-chrome-stable`, **not** `chromium` / `chromium-browser`. So a distro **Chromium** package is generally _not_ picked up automatically; for anything other than Google Chrome (or a Chrome in a non-standard location) set `CHROME_BIN` explicitly, as in Option B.
 
 > **Snap / Flatpak caveat.** `karma-chrome-launcher` `exec`s the browser binary directly with its own flags (including a temp `--user-data-dir`), so sandboxed packages need extra care:
 >
-> - **Snap** works, but isn't auto-detected — the launcher only probes for `google-chrome`/`chromium-browser`, not `/snap/bin/chromium`. Set it explicitly: `export CHROME_BIN=/snap/bin/chromium` (verified: `Chrome Headless 150`, full unit suite green).
-> - **Flatpak** is not recommended. There's no plain executable to point `CHROME_BIN` at — you'd have to wrap `flatpak run org.chromium.Chromium "$@"` in a script — and even then the sandbox blocks Karma's temp profile directory, so it typically fails to launch. Prefer a native/distro package (this option) or Chrome for Testing (Option B).
+> - **Snap** works, but isn't auto-detected (the launcher doesn't probe `/snap/bin/chromium`). Set it explicitly: `export CHROME_BIN=/snap/bin/chromium` (verified: `Chrome Headless 150`, full unit suite green).
+> - **Flatpak** is not recommended. There's no plain executable to point `CHROME_BIN` at — you'd have to wrap `flatpak run org.chromium.Chromium "$@"` in a script — and even then the sandbox blocks Karma's temp profile directory, so it typically fails to launch. Prefer a native Google Chrome package (this option) or Chrome for Testing (Option B).
 
 ### Option B — Install Chrome for Testing and set `CHROME_BIN`
 
-Install a pinned Chrome for Testing build (downloaded to `~/.cache/puppeteer`), then point `CHROME_BIN` at it:
+Install a pinned Chrome for Testing build into `~/.cache/puppeteer`, then point `CHROME_BIN` at it:
 
 ```bash
-npx @puppeteer/browsers install chrome@stable
+npx @puppeteer/browsers install chrome@stable --path "$HOME/.cache/puppeteer"
 ```
+
+The `--path` flag is required: the standalone `@puppeteer/browsers` CLI defaults its download location to the **current working directory** (not `~/.cache/puppeteer`), so without it you'd get an untracked `./chrome/` folder inside the repo and the `find` below would match nothing.
 
 Add the resolved path to your shell profile (`~/.zshrc`, `~/.bashrc`, …) so it's set for every session — including the non-interactive shell the git hook runs in:
 
 ```bash
 export CHROME_BIN="$(find "$HOME/.cache/puppeteer/chrome" -name chrome -type f | sort | tail -n1)"
 ```
+
+> **macOS:** the commands above are Linux. On macOS the Chrome-for-Testing binary is `Google Chrome for Testing` inside an `.app` bundle, so `find … -name chrome` matches nothing — point `CHROME_BIN` at, e.g., `"$HOME/.cache/puppeteer/chrome/mac"*"/chrome-mac-"*"/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"` instead.
 
 Reload your shell (or `source` the profile) and verify:
 

--- a/docs/wiki/2.16-Set-Up-Development-Environment.md
+++ b/docs/wiki/2.16-Set-Up-Development-Environment.md
@@ -52,6 +52,11 @@ Karma's `karma-chrome-launcher` locates the browser via the `CHROME_BIN` environ
 
 Install Google Chrome or Chromium through your OS package manager. On most platforms `karma-chrome-launcher` then finds it automatically. If it doesn't (or you keep it in a non-standard location), set `CHROME_BIN` explicitly as in Option B.
 
+> **Snap / Flatpak caveat.** `karma-chrome-launcher` `exec`s the browser binary directly with its own flags (including a temp `--user-data-dir`), so sandboxed packages need extra care:
+>
+> - **Snap** works, but isn't auto-detected — the launcher only probes for `google-chrome`/`chromium-browser`, not `/snap/bin/chromium`. Set it explicitly: `export CHROME_BIN=/snap/bin/chromium` (verified: `Chrome Headless 150`, full unit suite green).
+> - **Flatpak** is not recommended. There's no plain executable to point `CHROME_BIN` at — you'd have to wrap `flatpak run org.chromium.Chromium "$@"` in a script — and even then the sandbox blocks Karma's temp profile directory, so it typically fails to launch. Prefer a native/distro package (this option) or Chrome for Testing (Option B).
+
 ### Option B — Install Chrome for Testing and set `CHROME_BIN`
 
 Install a pinned Chrome for Testing build (downloaded to `~/.cache/puppeteer`), then point `CHROME_BIN` at it:

--- a/docs/wiki/2.16-Set-Up-Development-Environment.md
+++ b/docs/wiki/2.16-Set-Up-Development-Environment.md
@@ -37,6 +37,44 @@ Types and keys are derived from `.env` when you run any build or serve command.
 2. Run `ng serve` or a build command so `env.generated.ts` is regenerated.
 3. Use `ENV.NEW_KEY` or `getEnv('NEW_KEY')` in code.
 
+## Unit Test Browser (Chrome)
+
+The unit tests run in headless Chrome via Karma (`npm test`, `npm run test:file`). The `pre-push` git hook runs `npm run lint && npm run test`, so **a Chrome binary must be resolvable or `git push` will fail** with:
+
+```
+ERROR [launcher]: No binary for Chrome browser on your platform.
+  Please, set "CHROME_BIN" env variable.
+```
+
+Karma's `karma-chrome-launcher` locates the browser via the `CHROME_BIN` environment variable, falling back to a system Chrome/Chromium install. Pick one of the options below.
+
+### Option A — Use a system Chrome/Chromium
+
+Install Google Chrome or Chromium through your OS package manager. On most platforms `karma-chrome-launcher` then finds it automatically. If it doesn't (or you keep it in a non-standard location), set `CHROME_BIN` explicitly as in Option B.
+
+### Option B — Install Chrome for Testing and set `CHROME_BIN`
+
+Install a pinned Chrome for Testing build (downloaded to `~/.cache/puppeteer`), then point `CHROME_BIN` at it:
+
+```bash
+npx @puppeteer/browsers install chrome@stable
+```
+
+Add the resolved path to your shell profile (`~/.zshrc`, `~/.bashrc`, …) so it's set for every session — including the non-interactive shell the git hook runs in:
+
+```bash
+export CHROME_BIN="$(find "$HOME/.cache/puppeteer/chrome" -name chrome -type f | sort | tail -n1)"
+```
+
+Reload your shell (or `source` the profile) and verify:
+
+```bash
+echo "$CHROME_BIN"        # should print a path
+"$CHROME_BIN" --version   # should print a Chrome version
+```
+
+With `CHROME_BIN` set, `npm test` and `git push` (via the hook) work without further configuration.
+
 ## Static Vs Dynamic Config
 
 - **Static**: `src/environments/environment.ts`, `environment.prod.ts`, `environment.stage.ts` (production/stage flags, version).

--- a/docs/wiki/2.16-Set-Up-Development-Environment.md
+++ b/docs/wiki/2.16-Set-Up-Development-Environment.md
@@ -49,41 +49,50 @@ Types and keys are derived from `.env` when you run any build or serve command.
 
 ## Unit Test Browser (Chrome)
 
-The unit tests run in headless Chrome via Karma (`npm test`, `npm run test:file`). The `pre-push` git hook runs `npm run lint && npm run test`, so **a Chrome binary must be resolvable or `git push` will fail** with:
+The unit tests run in headless Chrome via Karma (`npm test`, `npm run test:file`). The `pre-push` git hook runs `npm run lint && npm run test`, so **a Chrome binary must be resolvable or `git push` will fail** with the following error:
 
 ```bash
 ERROR [launcher]: No binary for Chrome browser on your platform.
   Please, set "CHROME_BIN" env variable.
 ```
 
-Karma's `karma-chrome-launcher` locates the browser via the `CHROME_BIN` environment variable, falling back to a system Chrome/Chromium install. Pick one of the options below.
+Karma's `karma-chrome-launcher` locates the browser via the `CHROME_BIN` environment variable, falling back to a system Chrome install. There are two paths you can take:
 
 ### Option A — Use a system Google Chrome
 
 Install **Google Chrome** through your OS package manager. The karma config uses `karma-chrome-launcher`'s `Chrome` launcher (`base: 'Chrome'` in `src/karma.conf.js`), which on Linux only auto-detects real Google Chrome — it probes for `google-chrome` / `google-chrome-stable`, **not** `chromium` / `chromium-browser`. So a distro **Chromium** package is generally _not_ picked up automatically; for anything other than Google Chrome (or a Chrome in a non-standard location) set `CHROME_BIN` explicitly, as in Option B.
 
-> **Snap / Flatpak caveat.** `karma-chrome-launcher` `exec`s the browser binary directly with its own flags (including a temp `--user-data-dir`), so sandboxed packages need extra care:
->
-> - **Snap** works, but isn't auto-detected (the launcher doesn't probe `/snap/bin/chromium`). Set it explicitly: `export CHROME_BIN=/snap/bin/chromium` (verified: `Chrome Headless 150`, full unit suite green).
-> - **Flatpak** is not recommended. There's no plain executable to point `CHROME_BIN` at — you'd have to wrap `flatpak run org.chromium.Chromium "$@"` in a script — and even then the sandbox blocks Karma's temp profile directory, so it typically fails to launch. Prefer a native Google Chrome package (this option) or Chrome for Testing (Option B).
+#### Snap / Flatpak Caveat
+
+`karma-chrome-launcher` `exec`s the browser binary directly with its own flags (including a temp `--user-data-dir`), so sandboxed packages need extra care:
+
+**Snap** works, but isn't auto-detected (the launcher doesn't probe `/snap/bin/chromium`). Set it explicitly in your shell profile: `export CHROME_BIN=/snap/bin/chromium`
+
+**Flatpak** is not recommended. There's no plain executable to point `CHROME_BIN` at — you'd have to wrap `flatpak run org.chromium.Chromium "$@"` in a script — and even then the sandbox blocks Karma's temp profile directory, so it typically fails to launch. Prefer a native Google Chrome package (this option) or Chrome for Testing (Option B).
 
 ### Option B — Install Chrome for Testing and set `CHROME_BIN`
 
-Install a pinned Chrome for Testing build into `~/.cache/puppeteer`, then point `CHROME_BIN` at it:
+Install a pinned [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) build into a folder of your choice (all examples below use `~/.cache/puppeteer`), then point `CHROME_BIN` at it:
 
 ```bash
 npx @puppeteer/browsers install chrome@stable --path "$HOME/.cache/puppeteer"
 ```
 
-The `--path` flag is required: the standalone `@puppeteer/browsers` CLI defaults its download location to the **current working directory** (not `~/.cache/puppeteer`), so without it you'd get an untracked `./chrome/` folder inside the repo and the `find` below would match nothing.
+The `--path` flag is recommended: the standalone `@puppeteer/browsers` CLI defaults its download location to the **current working directory** so without it you'd get an untracked `./chrome/` folder inside the repo and the `find` below would match nothing.
 
 Add the resolved path to your shell profile (`~/.zshrc`, `~/.bashrc`, …) so it's set for every session — including the non-interactive shell the git hook runs in:
 
 ```bash
+# Looks for the Chrome for Testing binary in ~/.cache/puppeteer/chrome, sorted by name so the (likely) latest version is picked if you happen to have multiple
 export CHROME_BIN="$(find "$HOME/.cache/puppeteer/chrome" -name chrome -type f | sort | tail -n1)"
 ```
 
-> **macOS:** the commands above are Linux. On macOS the Chrome-for-Testing binary is `Google Chrome for Testing` inside an `.app` bundle, so `find … -name chrome` matches nothing — point `CHROME_BIN` at, e.g., `"$HOME/.cache/puppeteer/chrome/mac"*"/chrome-mac-"*"/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"` instead.
+On macOS the binary is named `Google Chrome for Testing` inside an `.app` bundle, so the `-name chrome` filter above matches nothing. Use this instead:
+
+```bash
+# Same idea, but matches the macOS executable inside the .app bundle
+export CHROME_BIN="$(find "$HOME/.cache/puppeteer/chrome" -type f -name 'Google Chrome for Testing' -path '*Contents/MacOS*' | sort | tail -n1)"
+```
 
 Reload your shell (or `source` the profile) and verify:
 

--- a/docs/wiki/2.16-Set-Up-Development-Environment.md
+++ b/docs/wiki/2.16-Set-Up-Development-Environment.md
@@ -37,6 +37,16 @@ Types and keys are derived from `.env` when you run any build or serve command.
 2. Run `ng serve` or a build command so `env.generated.ts` is regenerated.
 3. Use `ENV.NEW_KEY` or `getEnv('NEW_KEY')` in code.
 
+## Static Vs Dynamic Config
+
+- **Static**: `src/environments/environment.ts`, `environment.prod.ts`, `environment.stage.ts` (production/stage flags, version).
+- **Dynamic**: `.env` → `src/app/config/env.generated.ts` (secrets and per-developer values).
+
+## Related
+
+- [ENV_SETUP.md](https://github.com/super-productivity/super-productivity/blob/master/docs/ENV_SETUP.md) (full reference in the repo)
+- [[2.11-Run-the-Development-Server]]
+
 ## Unit Test Browser (Chrome)
 
 The unit tests run in headless Chrome via Karma (`npm test`, `npm run test:file`). The `pre-push` git hook runs `npm run lint && npm run test`, so **a Chrome binary must be resolvable or `git push` will fail** with:
@@ -79,13 +89,3 @@ echo "$CHROME_BIN"        # should print a path
 ```
 
 With `CHROME_BIN` set, `npm test` and `git push` (via the hook) work without further configuration.
-
-## Static Vs Dynamic Config
-
-- **Static**: `src/environments/environment.ts`, `environment.prod.ts`, `environment.stage.ts` (production/stage flags, version).
-- **Dynamic**: `.env` → `src/app/config/env.generated.ts` (secrets and per-developer values).
-
-## Related
-
-- [ENV_SETUP.md](https://github.com/super-productivity/super-productivity/blob/master/docs/ENV_SETUP.md) (full reference in the repo)
-- [[2.11-Run-the-Development-Server]]

--- a/docs/wiki/2.16-Set-Up-Development-Environment.md
+++ b/docs/wiki/2.16-Set-Up-Development-Environment.md
@@ -51,7 +51,7 @@ Types and keys are derived from `.env` when you run any build or serve command.
 
 The unit tests run in headless Chrome via Karma (`npm test`, `npm run test:file`). The `pre-push` git hook runs `npm run lint && npm run test`, so **a Chrome binary must be resolvable or `git push` will fail** with the following error:
 
-```bash
+```text
 ERROR [launcher]: No binary for Chrome browser on your platform.
   Please, set "CHROME_BIN" env variable.
 ```
@@ -83,8 +83,8 @@ The `--path` flag is recommended: the standalone `@puppeteer/browsers` CLI defau
 Add the resolved path to your shell profile (`~/.zshrc`, `~/.bashrc`, …) so it's set for every session — including the non-interactive shell the git hook runs in:
 
 ```bash
-# Looks for the Chrome for Testing binary in ~/.cache/puppeteer/chrome, sorted by name so the (likely) latest version is picked if you happen to have multiple
-export CHROME_BIN="$(find "$HOME/.cache/puppeteer/chrome" -name chrome -type f | sort | tail -n1)"
+# Looks for the Chrome for Testing binary in ~/.cache/puppeteer/chrome, sorted by version so the latest version is picked if you happen to have multiple
+export CHROME_BIN="$(find "$HOME/.cache/puppeteer/chrome" -name chrome -type f | sort -V | tail -n1)"
 ```
 
 On macOS the binary is named `Google Chrome for Testing` inside an `.app` bundle, so the `-name chrome` filter above matches nothing. Use this instead:

--- a/docs/wiki/2.16-Set-Up-Development-Environment.md
+++ b/docs/wiki/2.16-Set-Up-Development-Environment.md
@@ -51,7 +51,7 @@ Types and keys are derived from `.env` when you run any build or serve command.
 
 The unit tests run in headless Chrome via Karma (`npm test`, `npm run test:file`). The `pre-push` git hook runs `npm run lint && npm run test`, so **a Chrome binary must be resolvable or `git push` will fail** with:
 
-```
+```bash
 ERROR [launcher]: No binary for Chrome browser on your platform.
   Please, set "CHROME_BIN" env variable.
 ```


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

I don't use Chromium browsers, but without one one my system, `npm run test` fails. But I want to push my commits and feel gross using `--no-verify`. I'd also like the on-boarding experience to give me a heads up about this potential pitfall.

## Solution

<!-- Describe your changes in detail. -->

Adds a section about needing Chromium on your system to run the tests locally, and a few different ways to get that set up.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
