### PR TITLE
feat: add Home Assistant Bridge to community plugins

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -1,122 +1,130 @@
 [
-  {
-    "name": "Date Range Reporter Plugin",
-    "shortDescription": "Generates reports of completed tasks and tasks with work logs within a specified date range.",
-    "url": "https://github.com/dougcooper/sp-reporter",
-    "author": "dougcooper",
-    "authorUrl": "https://github.com/dougcooper",
-    "stars": 32
-  },
-  {
-    "name": "Archived Tasks Viewer",
-    "shortDescription": "Read-only viewer to browse archived tasks with grouping, filtering, subtasks preview, and theme toggle.",
-    "url": "https://github.com/baiyina/Archived-Tasks-Viewer",
-    "author": "baiyina",
-    "authorUrl": "https://github.com/baiyina",
-    "stars": 31
-  },
-  {
-    "name": "QuestArc",
-    "shortDescription": "Turn your workflow into an adventure! Gamify your tasks with Atomic Habit quests, epic boss fights, earnable badges, and a customizable hero profile.",
-    "url": "https://codeberg.org/Nexumia/QuestArc",
-    "author": "Nexumia",
-    "authorUrl": "https://codeberg.org/Nexumia",
-    "stars": 4
-  },
-  {
-    "name": "AutoPlan",
-    "shortDescription": "Smart non-AI plugin for the automatic scheduling of tasks using priorities assigned automatically based on tags, projects, and time estimation.",
-    "url": "https://codeberg.org/00sapo/sp-autoplan",
-    "author": "00sapo",
-    "authorUrl": "https://codeberg.org/00sapo",
-    "stars": 28
-  },
-  {
-    "name": "Asana Integration",
-    "shortDescription": "Provides 2-way sync between SP tasks and Asana tasks.",
-    "url": "https://codeberg.org/sinenomine/sp-asana",
-    "author": "sinenomine",
-    "authorUrl": "https://codeberg.org/sinenomine",
-    "stars": 0
-  },
-  {
-    "name": "Obsidian Integration",
-    "shortDescription": "Provides 2-way sync between SP tasks and Obsidian tasks.",
-    "url": "https://codeberg.org/sinenomine/sp-obsidian/",
-    "author": "sinenomine",
-    "authorUrl": "https://codeberg.org/sinenomine",
-    "stars": 5
-  },
-  {
-    "name": "MCP",
-    "shortDescription": "Bridge between the Super Productivity app and MCP (Model Context Protocol) servers for Claude Desktop integration.",
-    "url": "https://github.com/organicmoron/SP-MCP",
-    "author": "organicmoron",
-    "authorUrl": "https://github.com/organicmoron",
-    "stars": 68
-  },
-  {
-    "name": "Super Productivity MCP",
-    "shortDescription": "Feature-rich MCP server with 19 tools covering full task CRUD, time tracking summaries, project/tag management, and notifications.",
-    "url": "https://github.com/b0x42/Super-Productivity-MCP",
-    "author": "b0x42",
-    "authorUrl": "https://github.com/b0x42",
-    "stars": 11
-  },
-  {
-    "name": "Dashboard",
-    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
-    "url": "https://github.com/dougcooper/sp-dashboard",
-    "author": "dougcooper",
-    "authorUrl": "https://github.com/dougcooper",
-    "stars": 43
-  },
-  {
-    "name": "Invoicer",
-    "shortDescription": "Generate client invoices from tracked time in Super Productivity, with flexible billing periods, itemization levels, and PDF export.",
-    "url": "https://github.com/1jamesthompson1/sp-invoicer",
-    "author": "1jamesthompson1",
-    "authorUrl": "https://github.com/1jamesthompson1",
-    "stars": 11
-  },
-  {
-    "name": "StudyForge Leaderboard",
-    "shortDescription": "Syncs your daily study time from Super Productivity to the StudyForge leaderboard. Compete with friends, track streaks, and join 7-day study war challenges.",
-    "url": "https://github.com/dhananajay-030/studyforge-plugin",
-    "author": "dhananajay-030",
-    "authorUrl": "https://github.com/dhananajay-030",
-    "stars": 6
-  },
-  {
-    "name": "Print Tasks",
-    "shortDescription": "Want to go offline but take Super Productivity with you? This plugin provides print layouts for Today, All Tasks, All Projects, by Tag etc.",
-    "url": "https://codeberg.org/sinenomine/sp-task-print",
-    "author": "sinenomine",
-    "authorUrl": "https://codeberg.org/sinenomine/",
-    "stars": 1
-  },
-  {
-    "name": "AI Assistant",
-    "shortDescription": "OpenAI-powered AI assistant chat panel. Manage tasks, projects, and tags via natural language with function calling support. Configurable API key, model, and base URL.",
-    "url": "https://github.com/ai-eifying/ai-assistant-plugin",
-    "author": "ai-eifying",
-    "authorUrl": "https://github.com/ai-eifying",
-    "stars": 4
-  },
-  {
-    "name": "Memos Sync",
-    "shortDescription": "Syncs plugin-owned notes between Super Productivity and Memos with attachments, auto-sync, and conflict handling.",
-    "url": "https://github.com/giba0/memos-sync",
-    "author": "giba0",
-    "authorUrl": "https://github.com/giba0",
-    "stars": 2
-  },
-  {
-    "name": "YouTrack Importer for SuperProductivity",
-    "shortDescription": "Bring YouTrack issues into SuperProductivity, either as a one-off CSV import or as a live, repeatable sync directly against the YouTrack REST API.",
-    "url": "https://github.com/coissay/superProductivity-YoutrackPlugin",
-    "author": "coissay",
-    "authorUrl": "https://github.com/coissay",
-    "stars": 0
-  }
+    {
+        "name":  "Date Range Reporter Plugin",
+        "shortDescription":  "Generates reports of completed tasks and tasks with work logs within a specified date range.",
+        "url":  "https://github.com/dougcooper/sp-reporter",
+        "author":  "dougcooper",
+        "authorUrl":  "https://github.com/dougcooper",
+        "stars":  32
+    },
+    {
+        "name":  "Archived Tasks Viewer",
+        "shortDescription":  "Read-only viewer to browse archived tasks with grouping, filtering, subtasks preview, and theme toggle.",
+        "url":  "https://github.com/baiyina/Archived-Tasks-Viewer",
+        "author":  "baiyina",
+        "authorUrl":  "https://github.com/baiyina",
+        "stars":  31
+    },
+    {
+        "name":  "QuestArc",
+        "shortDescription":  "Turn your workflow into an adventure! Gamify your tasks with Atomic Habit quests, epic boss fights, earnable badges, and a customizable hero profile.",
+        "url":  "https://codeberg.org/Nexumia/QuestArc",
+        "author":  "Nexumia",
+        "authorUrl":  "https://codeberg.org/Nexumia",
+        "stars":  4
+    },
+    {
+        "name":  "AutoPlan",
+        "shortDescription":  "Smart non-AI plugin for the automatic scheduling of tasks using priorities assigned automatically based on tags, projects, and time estimation.",
+        "url":  "https://codeberg.org/00sapo/sp-autoplan",
+        "author":  "00sapo",
+        "authorUrl":  "https://codeberg.org/00sapo",
+        "stars":  28
+    },
+    {
+        "name":  "Asana Integration",
+        "shortDescription":  "Provides 2-way sync between SP tasks and Asana tasks.",
+        "url":  "https://codeberg.org/sinenomine/sp-asana",
+        "author":  "sinenomine",
+        "authorUrl":  "https://codeberg.org/sinenomine",
+        "stars":  0
+    },
+    {
+        "name":  "Obsidian Integration",
+        "shortDescription":  "Provides 2-way sync between SP tasks and Obsidian tasks.",
+        "url":  "https://codeberg.org/sinenomine/sp-obsidian/",
+        "author":  "sinenomine",
+        "authorUrl":  "https://codeberg.org/sinenomine",
+        "stars":  5
+    },
+    {
+        "name":  "MCP",
+        "shortDescription":  "Bridge between the Super Productivity app and MCP (Model Context Protocol) servers for Claude Desktop integration.",
+        "url":  "https://github.com/organicmoron/SP-MCP",
+        "author":  "organicmoron",
+        "authorUrl":  "https://github.com/organicmoron",
+        "stars":  68
+    },
+    {
+        "name":  "Super Productivity MCP",
+        "shortDescription":  "Feature-rich MCP server with 19 tools covering full task CRUD, time tracking summaries, project/tag management, and notifications.",
+        "url":  "https://github.com/b0x42/Super-Productivity-MCP",
+        "author":  "b0x42",
+        "authorUrl":  "https://github.com/b0x42",
+        "stars":  11
+    },
+    {
+        "name":  "Dashboard",
+        "shortDescription":  "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
+        "url":  "https://github.com/dougcooper/sp-dashboard",
+        "author":  "dougcooper",
+        "authorUrl":  "https://github.com/dougcooper",
+        "stars":  43
+    },
+    {
+        "name":  "Invoicer",
+        "shortDescription":  "Generate client invoices from tracked time in Super Productivity, with flexible billing periods, itemization levels, and PDF export.",
+        "url":  "https://github.com/1jamesthompson1/sp-invoicer",
+        "author":  "1jamesthompson1",
+        "authorUrl":  "https://github.com/1jamesthompson1",
+        "stars":  11
+    },
+    {
+        "name":  "StudyForge Leaderboard",
+        "shortDescription":  "Syncs your daily study time from Super Productivity to the StudyForge leaderboard. Compete with friends, track streaks, and join 7-day study war challenges.",
+        "url":  "https://github.com/dhananajay-030/studyforge-plugin",
+        "author":  "dhananajay-030",
+        "authorUrl":  "https://github.com/dhananajay-030",
+        "stars":  6
+    },
+    {
+        "name":  "Print Tasks",
+        "shortDescription":  "Want to go offline but take Super Productivity with you? This plugin provides print layouts for Today, All Tasks, All Projects, by Tag etc.",
+        "url":  "https://codeberg.org/sinenomine/sp-task-print",
+        "author":  "sinenomine",
+        "authorUrl":  "https://codeberg.org/sinenomine/",
+        "stars":  1
+    },
+    {
+        "name":  "AI Assistant",
+        "shortDescription":  "OpenAI-powered AI assistant chat panel. Manage tasks, projects, and tags via natural language with function calling support. Configurable API key, model, and base URL.",
+        "url":  "https://github.com/ai-eifying/ai-assistant-plugin",
+        "author":  "ai-eifying",
+        "authorUrl":  "https://github.com/ai-eifying",
+        "stars":  4
+    },
+    {
+        "name":  "Memos Sync",
+        "shortDescription":  "Syncs plugin-owned notes between Super Productivity and Memos with attachments, auto-sync, and conflict handling.",
+        "url":  "https://github.com/giba0/memos-sync",
+        "author":  "giba0",
+        "authorUrl":  "https://github.com/giba0",
+        "stars":  2
+    },
+    {
+        "name":  "YouTrack Importer for SuperProductivity",
+        "shortDescription":  "Bring YouTrack issues into SuperProductivity, either as a one-off CSV import or as a live, repeatable sync directly against the YouTrack REST API.",
+        "url":  "https://github.com/coissay/superProductivity-YoutrackPlugin",
+        "author":  "coissay",
+        "authorUrl":  "https://github.com/coissay",
+        "stars":  0
+    },
+    {
+        "author":  "jloops412",
+        "name":  "Home Assistant Bridge",
+        "stars":  0,
+        "authorUrl":  "https://github.com/jloops412",
+        "shortDescription":  "Bidirectional bridge between Super Productivity and Home Assistant. Rules-based automation engine: control lights, scenes, media, and notifications based on your tasks. Auto-focus mode, break reminders, daily summaries, and live HA sensor display.",
+        "url":  "https://github.com/jloops412/ha-super-productivity"
+    }
 ]

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -1,130 +1,130 @@
 [
-    {
-        "name":  "Date Range Reporter Plugin",
-        "shortDescription":  "Generates reports of completed tasks and tasks with work logs within a specified date range.",
-        "url":  "https://github.com/dougcooper/sp-reporter",
-        "author":  "dougcooper",
-        "authorUrl":  "https://github.com/dougcooper",
-        "stars":  32
-    },
-    {
-        "name":  "Archived Tasks Viewer",
-        "shortDescription":  "Read-only viewer to browse archived tasks with grouping, filtering, subtasks preview, and theme toggle.",
-        "url":  "https://github.com/baiyina/Archived-Tasks-Viewer",
-        "author":  "baiyina",
-        "authorUrl":  "https://github.com/baiyina",
-        "stars":  31
-    },
-    {
-        "name":  "QuestArc",
-        "shortDescription":  "Turn your workflow into an adventure! Gamify your tasks with Atomic Habit quests, epic boss fights, earnable badges, and a customizable hero profile.",
-        "url":  "https://codeberg.org/Nexumia/QuestArc",
-        "author":  "Nexumia",
-        "authorUrl":  "https://codeberg.org/Nexumia",
-        "stars":  4
-    },
-    {
-        "name":  "AutoPlan",
-        "shortDescription":  "Smart non-AI plugin for the automatic scheduling of tasks using priorities assigned automatically based on tags, projects, and time estimation.",
-        "url":  "https://codeberg.org/00sapo/sp-autoplan",
-        "author":  "00sapo",
-        "authorUrl":  "https://codeberg.org/00sapo",
-        "stars":  28
-    },
-    {
-        "name":  "Asana Integration",
-        "shortDescription":  "Provides 2-way sync between SP tasks and Asana tasks.",
-        "url":  "https://codeberg.org/sinenomine/sp-asana",
-        "author":  "sinenomine",
-        "authorUrl":  "https://codeberg.org/sinenomine",
-        "stars":  0
-    },
-    {
-        "name":  "Obsidian Integration",
-        "shortDescription":  "Provides 2-way sync between SP tasks and Obsidian tasks.",
-        "url":  "https://codeberg.org/sinenomine/sp-obsidian/",
-        "author":  "sinenomine",
-        "authorUrl":  "https://codeberg.org/sinenomine",
-        "stars":  5
-    },
-    {
-        "name":  "MCP",
-        "shortDescription":  "Bridge between the Super Productivity app and MCP (Model Context Protocol) servers for Claude Desktop integration.",
-        "url":  "https://github.com/organicmoron/SP-MCP",
-        "author":  "organicmoron",
-        "authorUrl":  "https://github.com/organicmoron",
-        "stars":  68
-    },
-    {
-        "name":  "Super Productivity MCP",
-        "shortDescription":  "Feature-rich MCP server with 19 tools covering full task CRUD, time tracking summaries, project/tag management, and notifications.",
-        "url":  "https://github.com/b0x42/Super-Productivity-MCP",
-        "author":  "b0x42",
-        "authorUrl":  "https://github.com/b0x42",
-        "stars":  11
-    },
-    {
-        "name":  "Dashboard",
-        "shortDescription":  "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
-        "url":  "https://github.com/dougcooper/sp-dashboard",
-        "author":  "dougcooper",
-        "authorUrl":  "https://github.com/dougcooper",
-        "stars":  43
-    },
-    {
-        "name":  "Invoicer",
-        "shortDescription":  "Generate client invoices from tracked time in Super Productivity, with flexible billing periods, itemization levels, and PDF export.",
-        "url":  "https://github.com/1jamesthompson1/sp-invoicer",
-        "author":  "1jamesthompson1",
-        "authorUrl":  "https://github.com/1jamesthompson1",
-        "stars":  11
-    },
-    {
-        "name":  "StudyForge Leaderboard",
-        "shortDescription":  "Syncs your daily study time from Super Productivity to the StudyForge leaderboard. Compete with friends, track streaks, and join 7-day study war challenges.",
-        "url":  "https://github.com/dhananajay-030/studyforge-plugin",
-        "author":  "dhananajay-030",
-        "authorUrl":  "https://github.com/dhananajay-030",
-        "stars":  6
-    },
-    {
-        "name":  "Print Tasks",
-        "shortDescription":  "Want to go offline but take Super Productivity with you? This plugin provides print layouts for Today, All Tasks, All Projects, by Tag etc.",
-        "url":  "https://codeberg.org/sinenomine/sp-task-print",
-        "author":  "sinenomine",
-        "authorUrl":  "https://codeberg.org/sinenomine/",
-        "stars":  1
-    },
-    {
-        "name":  "AI Assistant",
-        "shortDescription":  "OpenAI-powered AI assistant chat panel. Manage tasks, projects, and tags via natural language with function calling support. Configurable API key, model, and base URL.",
-        "url":  "https://github.com/ai-eifying/ai-assistant-plugin",
-        "author":  "ai-eifying",
-        "authorUrl":  "https://github.com/ai-eifying",
-        "stars":  4
-    },
-    {
-        "name":  "Memos Sync",
-        "shortDescription":  "Syncs plugin-owned notes between Super Productivity and Memos with attachments, auto-sync, and conflict handling.",
-        "url":  "https://github.com/giba0/memos-sync",
-        "author":  "giba0",
-        "authorUrl":  "https://github.com/giba0",
-        "stars":  2
-    },
-    {
-        "name":  "YouTrack Importer for SuperProductivity",
-        "shortDescription":  "Bring YouTrack issues into SuperProductivity, either as a one-off CSV import or as a live, repeatable sync directly against the YouTrack REST API.",
-        "url":  "https://github.com/coissay/superProductivity-YoutrackPlugin",
-        "author":  "coissay",
-        "authorUrl":  "https://github.com/coissay",
-        "stars":  0
-    },
-    {
-        "author":  "jloops412",
-        "name":  "Home Assistant Bridge",
-        "stars":  0,
-        "authorUrl":  "https://github.com/jloops412",
-        "shortDescription":  "Bidirectional bridge between Super Productivity and Home Assistant. Rules-based automation engine: control lights, scenes, media, and notifications based on your tasks. Auto-focus mode, break reminders, daily summaries, and live HA sensor display.",
-        "url":  "https://github.com/jloops412/ha-super-productivity"
-    }
+  {
+    "name": "Date Range Reporter Plugin",
+    "shortDescription": "Generates reports of completed tasks and tasks with work logs within a specified date range.",
+    "url": "https://github.com/dougcooper/sp-reporter",
+    "author": "dougcooper",
+    "authorUrl": "https://github.com/dougcooper",
+    "stars": 32
+  },
+  {
+    "name": "Archived Tasks Viewer",
+    "shortDescription": "Read-only viewer to browse archived tasks with grouping, filtering, subtasks preview, and theme toggle.",
+    "url": "https://github.com/baiyina/Archived-Tasks-Viewer",
+    "author": "baiyina",
+    "authorUrl": "https://github.com/baiyina",
+    "stars": 31
+  },
+  {
+    "name": "QuestArc",
+    "shortDescription": "Turn your workflow into an adventure! Gamify your tasks with Atomic Habit quests, epic boss fights, earnable badges, and a customizable hero profile.",
+    "url": "https://codeberg.org/Nexumia/QuestArc",
+    "author": "Nexumia",
+    "authorUrl": "https://codeberg.org/Nexumia",
+    "stars": 4
+  },
+  {
+    "name": "AutoPlan",
+    "shortDescription": "Smart non-AI plugin for the automatic scheduling of tasks using priorities assigned automatically based on tags, projects, and time estimation.",
+    "url": "https://codeberg.org/00sapo/sp-autoplan",
+    "author": "00sapo",
+    "authorUrl": "https://codeberg.org/00sapo",
+    "stars": 28
+  },
+  {
+    "name": "Asana Integration",
+    "shortDescription": "Provides 2-way sync between SP tasks and Asana tasks.",
+    "url": "https://codeberg.org/sinenomine/sp-asana",
+    "author": "sinenomine",
+    "authorUrl": "https://codeberg.org/sinenomine",
+    "stars": 0
+  },
+  {
+    "name": "Obsidian Integration",
+    "shortDescription": "Provides 2-way sync between SP tasks and Obsidian tasks.",
+    "url": "https://codeberg.org/sinenomine/sp-obsidian/",
+    "author": "sinenomine",
+    "authorUrl": "https://codeberg.org/sinenomine",
+    "stars": 5
+  },
+  {
+    "name": "MCP",
+    "shortDescription": "Bridge between the Super Productivity app and MCP (Model Context Protocol) servers for Claude Desktop integration.",
+    "url": "https://github.com/organicmoron/SP-MCP",
+    "author": "organicmoron",
+    "authorUrl": "https://github.com/organicmoron",
+    "stars": 68
+  },
+  {
+    "name": "Super Productivity MCP",
+    "shortDescription": "Feature-rich MCP server with 19 tools covering full task CRUD, time tracking summaries, project/tag management, and notifications.",
+    "url": "https://github.com/b0x42/Super-Productivity-MCP",
+    "author": "b0x42",
+    "authorUrl": "https://github.com/b0x42",
+    "stars": 11
+  },
+  {
+    "name": "Dashboard",
+    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
+    "url": "https://github.com/dougcooper/sp-dashboard",
+    "author": "dougcooper",
+    "authorUrl": "https://github.com/dougcooper",
+    "stars": 43
+  },
+  {
+    "name": "Invoicer",
+    "shortDescription": "Generate client invoices from tracked time in Super Productivity, with flexible billing periods, itemization levels, and PDF export.",
+    "url": "https://github.com/1jamesthompson1/sp-invoicer",
+    "author": "1jamesthompson1",
+    "authorUrl": "https://github.com/1jamesthompson1",
+    "stars": 11
+  },
+  {
+    "name": "StudyForge Leaderboard",
+    "shortDescription": "Syncs your daily study time from Super Productivity to the StudyForge leaderboard. Compete with friends, track streaks, and join 7-day study war challenges.",
+    "url": "https://github.com/dhananajay-030/studyforge-plugin",
+    "author": "dhananajay-030",
+    "authorUrl": "https://github.com/dhananajay-030",
+    "stars": 6
+  },
+  {
+    "name": "Print Tasks",
+    "shortDescription": "Want to go offline but take Super Productivity with you? This plugin provides print layouts for Today, All Tasks, All Projects, by Tag etc.",
+    "url": "https://codeberg.org/sinenomine/sp-task-print",
+    "author": "sinenomine",
+    "authorUrl": "https://codeberg.org/sinenomine/",
+    "stars": 1
+  },
+  {
+    "name": "AI Assistant",
+    "shortDescription": "OpenAI-powered AI assistant chat panel. Manage tasks, projects, and tags via natural language with function calling support. Configurable API key, model, and base URL.",
+    "url": "https://github.com/ai-eifying/ai-assistant-plugin",
+    "author": "ai-eifying",
+    "authorUrl": "https://github.com/ai-eifying",
+    "stars": 4
+  },
+  {
+    "name": "Memos Sync",
+    "shortDescription": "Syncs plugin-owned notes between Super Productivity and Memos with attachments, auto-sync, and conflict handling.",
+    "url": "https://github.com/giba0/memos-sync",
+    "author": "giba0",
+    "authorUrl": "https://github.com/giba0",
+    "stars": 2
+  },
+  {
+    "name": "YouTrack Importer for SuperProductivity",
+    "shortDescription": "Bring YouTrack issues into SuperProductivity, either as a one-off CSV import or as a live, repeatable sync directly against the YouTrack REST API.",
+    "url": "https://github.com/coissay/superProductivity-YoutrackPlugin",
+    "author": "coissay",
+    "authorUrl": "https://github.com/coissay",
+    "stars": 0
+  },
+  {
+    "name": "Home Assistant Bridge",
+    "shortDescription": "Bidirectional bridge between Super Productivity and Home Assistant. Rules-based automation engine: control lights, scenes, media, and notifications based on your tasks. Auto-focus mode, break reminders, daily summaries, and live HA sensor display.",
+    "url": "https://github.com/jloops412/ha-super-productivity",
+    "author": "jloops412",
+    "authorUrl": "https://github.com/jloops412",
+    "stars": 0
+  }
 ]


### PR DESCRIPTION
## Home Assistant Bridge Plugin

A bidirectional bridge between Super Productivity and Home Assistant with a rules-based automation engine.

### Security
- **Access token stored via \setSecret\/\getSecret\** - never in synced/exported data
- iframe is pure UI; plugin.js handles all secrets and authenticated API calls
- Auto-migrates old configs that had embedded tokens

### Architecture
- **plugin.js** = credential manager + HA API proxy + rules engine (survives navigation)
- **index.html** = pure UI, communicates via \window.parent.haBridge\ bridge object
- Matches the pattern used by SP-MCP and other community plugins

### What it does
- **20 triggers:** task_start, task_stop, task_switch, task_complete, task_created, task_updated, task_deleted, tags_changed, project_changed, due_date_changed, estimate_changed, estimate_exceeded, notes_changed, first_task_of_day, all_done, timer, idle, context_switch, project_list_changed, day_end
- **10 action types:** scenes, automations, scripts, toggle, light control, media control, TTS, custom services, phone notifications
- **Today detection:** uses \dueDay\/\dueWithTime\ (not virtual TODAY tag)
- **Smart entity discovery:** auto-fetches all HA devices for dropdown selectors
- **Non-blocking hooks:** all handlers deferred via \setTimeout\ to avoid SP timeout

### Links
- **Repository:** https://github.com/jloops412/ha-super-productivity
- **Release (v2.2.0):** https://github.com/jloops412/ha-super-productivity/releases/tag/v2.2.0
- **Plugin download:** [sp-plugin.zip](https://github.com/jloops412/ha-super-productivity/releases/download/v2.2.0/sp-plugin.zip)
- Also includes: A full Home Assistant custom integration (HACS compatible)

### Compatibility
- Super Productivity v10+
- Home Assistant 2024.1.0+
- Electron desktop app (Local REST API required)

### Formatting
- LF line endings preserved
- Trailing newline present
- Minimal diff (only new object appended)
