### PR TITLE
fix(gitlab): link issues API doc for search help (#8884)

### DIFF
--- a/src/app/features/issue/mapping-helper/get-issue-provider-help-link.ts
+++ b/src/app/features/issue/mapping-helper/get-issue-provider-help-link.ts
@@ -9,8 +9,11 @@ export const getIssueProviderHelpLink = (
     //   return 'https://support.atlassian.com/jira-service-management-cloud/docs/use-advanced-search-with-jira-query-language-jql/';
     case 'GITHUB':
       return 'https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests';
+    // NOTE: the GitLab search box hits the Issues API `search=` param (plain
+    // substring match), not Advanced Search — so link the issues endpoint, not
+    // the advanced-search syntax page (#8884).
     case 'GITLAB':
-      return 'https://docs.gitlab.com/ee/user/search/advanced_search.html';
+      return 'https://docs.gitlab.com/api/issues/#list-project-issues';
     // case 'GITEA':
     // case 'CALDAV':
     // case 'REDMINE':


### PR DESCRIPTION
## Problem

The GitLab issue-provider **search box** (add-task panel) shows a help-link hint labeled "GitLab search syntax" that pointed to GitLab's **Advanced Search** feature docs (`docs.gitlab.com/ee/user/search/advanced_search.html`).

But that search box actually calls the plain **Issues API** — `GET /api/v4/projects/:id/issues?search=<text>&…` (`gitlab-api.service.ts` `searchIssueInProject$`). The `search=` param there is a substring match on title/description and does **not** interpret Advanced Search operators, so the old link misled users into trying syntax that is silently ignored (#8884).

## Fix

Repoint the GitLab help link to the endpoint the code actually uses:
`https://docs.gitlab.com/api/issues/#list-project-issues` (current canonical docs format; `#list-project-issues` matches the project-scoped endpoint the app hits). Added a `why` comment for traceability.

## Notes / scope

- The provider **Custom Filter** config field already links the correct Issues API doc — untouched.
- Left the shared "… search syntax" hint label and the reporter's suggested pre-seeded default query (`&state=opened&assignee_username=…`) out: the label is shared with GitHub, and a default query overlaps the existing Scope dropdown + Custom Filter config (feature-creep guard).
- Static string map — no test/sync/state/hot-path surface touched.

Closes #8884