### PR TITLE
chore(lint): remove unused eslint-disable directives

### DIFF
--- a/src/app/core/update-check/update-check.service.spec.ts
+++ b/src/app/core/update-check/update-check.service.spec.ts
@@ -60,7 +60,6 @@ describe('UpdateCheckService', () => {
 
   describe('checkForUpdate()', () => {
     it('should open a banner when a newer version is available', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: 'v99.0.0' });
       expect(bannerService.open).toHaveBeenCalledTimes(1);
       const banner: Banner = bannerService.open.calls.mostRecent().args[0];
@@ -70,21 +69,18 @@ describe('UpdateCheckService', () => {
     });
 
     it('should do nothing when already on the latest version', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: `v${environment.version}` });
       expect(bannerService.open).not.toHaveBeenCalled();
       expect(snackService.open).not.toHaveBeenCalled();
     });
 
     it('should do nothing when the latest release is older (dev build)', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: 'v0.0.1' });
       expect(bannerService.open).not.toHaveBeenCalled();
     });
 
     it('should show an up-to-date snack for a user-triggered check', async () => {
       await checkAndRespond(
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         { tag_name: `v${environment.version}` },
         { isUserTriggered: true },
       );
@@ -96,21 +92,18 @@ describe('UpdateCheckService', () => {
 
     it('should not re-show the banner for a dismissed version', async () => {
       localStorage.setItem(LS.UPDATE_CHECK_DISMISSED_VERSION, 'v99.0.0');
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: 'v99.0.0' });
       expect(bannerService.open).not.toHaveBeenCalled();
     });
 
     it('should show the banner for a dismissed version when user-triggered', async () => {
       localStorage.setItem(LS.UPDATE_CHECK_DISMISSED_VERSION, 'v99.0.0');
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: 'v99.0.0' }, { isUserTriggered: true });
       expect(bannerService.open).toHaveBeenCalledTimes(1);
     });
 
     it('should show the banner again for a newer version than the dismissed one', async () => {
       localStorage.setItem(LS.UPDATE_CHECK_DISMISSED_VERSION, 'v99.0.0');
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: 'v99.0.1' });
       expect(bannerService.open).toHaveBeenCalledTimes(1);
     });
@@ -159,7 +152,6 @@ describe('UpdateCheckService', () => {
     it('should reject a tag that is not strictly a version tag', async () => {
       // lenient parsing is fine for the LOCAL version, but remote tags are
       // untrusted input and must match exactly
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: '99.0.0<img src=x>' }, { isUserTriggered: true });
       expect(bannerService.open).not.toHaveBeenCalled();
       expect(snackService.open).toHaveBeenCalledWith(
@@ -171,7 +163,7 @@ describe('UpdateCheckService', () => {
       const p1 = service.checkForUpdate();
       const p2 = service.checkForUpdate();
       // expectOne throws if the guard failed and two requests were made
-      httpMock.expectOne(RELEASES_API_URL).flush({ tag_name: 'v99.0.0' }); // eslint-disable-line @typescript-eslint/naming-convention
+      httpMock.expectOne(RELEASES_API_URL).flush({ tag_name: 'v99.0.0' });
       await Promise.all([p1, p2]);
       expect(bannerService.open).toHaveBeenCalledTimes(1);
     });
@@ -200,7 +192,6 @@ describe('UpdateCheckService', () => {
       expect(localStorage.getItem(LS.UPDATE_CHECK_DISMISSED_VERSION)).toBe('v99.0.0');
 
       bannerService.open.calls.reset();
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       await checkAndRespond({ tag_name: 'v99.0.0' });
       expect(bannerService.open).not.toHaveBeenCalled();
     });

--- a/src/app/features/work-context/work-context.const.spec.ts
+++ b/src/app/features/work-context/work-context.const.spec.ts
@@ -162,7 +162,6 @@ describe('work-context theme background slider persistence (#8504)', () => {
     key: keyof WorkContextThemeCfg,
   ): FormlyFieldConfig => fields.find((f) => f.key === key)!;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const checkExpressions = (field: FormlyFieldConfig): void => {
     const opts = field.options as any;
     opts.checkExpressions({ fieldGroup: [field], options: opts });


### PR DESCRIPTION
## Problem

`npm run lint` reports 11 `Unused eslint-disable directive` warnings — the directives no longer suppress any reported problems (10 `@typescript-eslint/naming-convention` in `update-check.service.spec.ts`, 1 `@typescript-eslint/no-explicit-any` in `work-context.const.spec.ts`).

## Solution

Remove the stale `eslint-disable` directives. The suppressed rules no longer fire on the annotated lines, so the comments are pure noise. No functional/test behavior changes.

## Type of Change

- [x] Other (lint cleanup)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)