### PR TITLE
fix(app): hide donation page on macOS

### DIFF
--- a/docs/wiki/3.05-Web-App-vs-Desktop.md
+++ b/docs/wiki/3.05-Web-App-vs-Desktop.md
@@ -25,6 +25,10 @@ In the web version, time tracking only works while the app is open. Idle time tr
 
 The web app updates itself through its service worker and prompts for a reload when a new version is deployed. The desktop app instead checks the GitHub releases API once a day and shows a dismissible notice linking to the download page (configurable via the Misc setting "Automatically check for new versions"; not present on Microsoft Store, Mac App Store, or Snap builds, which update through their stores).
 
+### Donation and Contribution Links
+
+The Support Us page and links that can lead to GitHub Sponsors are unavailable in native iOS and macOS desktop builds. They remain available in the web app and on other desktop platforms.
+
 ## Browser-Related Limitations
 
 ### CORS (Cross-Origin Resource Sharing)

--- a/docs/wiki/3.05-Web-App-vs-Desktop.md
+++ b/docs/wiki/3.05-Web-App-vs-Desktop.md
@@ -25,10 +25,6 @@ In the web version, time tracking only works while the app is open. Idle time tr
 
 The web app updates itself through its service worker and prompts for a reload when a new version is deployed. The desktop app instead checks the GitHub releases API once a day and shows a dismissible notice linking to the download page (configurable via the Misc setting "Automatically check for new versions"; not present on Microsoft Store, Mac App Store, or Snap builds, which update through their stores).
 
-### Donation and Contribution Links
-
-The Support Us page and links that can lead to GitHub Sponsors are unavailable in native iOS and macOS desktop builds. They remain available in the web app and on other desktop platforms.
-
 ## Browser-Related Limitations
 
 ### CORS (Cross-Origin Resource Sharing)
@@ -125,6 +121,12 @@ The web version does not have:
 - Global keyboard shortcuts (only in-page shortcuts; desktop can register system-wide shortcuts).
 
 Certain UI elements tied to these features are hidden in the web build via platform-specific CSS or logic.
+
+## Platform-Specific Availability
+
+### Donation and Contribution Links
+
+The Support Us page and links that can lead to GitHub Sponsors are unavailable in native iOS and macOS desktop builds. They remain available in the web app, native Android, Windows desktop, and Linux desktop builds.
 
 ## Documented Error Conditions (Web)
 

--- a/src/app/app.constants.spec.ts
+++ b/src/app/app.constants.spec.ts
@@ -1,0 +1,41 @@
+import { isDonationUiRestricted } from './app.constants';
+
+describe('isDonationUiRestricted', () => {
+  const cases: Array<
+    [
+      label: string,
+      context: Parameters<typeof isDonationUiRestricted>[0],
+      expected: boolean,
+    ]
+  > = [
+    ['native iOS', { isIosNative: true, isElectron: false, isMacOS: false }, true],
+    ['macOS Electron DMG', { isIosNative: false, isElectron: true, isMacOS: true }, true],
+    [
+      'macOS Electron App Store',
+      { isIosNative: false, isElectron: true, isMacOS: true },
+      true,
+    ],
+    [
+      'macOS Electron development build',
+      { isIosNative: false, isElectron: true, isMacOS: true },
+      true,
+    ],
+    [
+      'Windows or Linux Electron',
+      { isIosNative: false, isElectron: true, isMacOS: false },
+      false,
+    ],
+    [
+      'macOS web browser',
+      { isIosNative: false, isElectron: false, isMacOS: true },
+      false,
+    ],
+    ['native Android', { isIosNative: false, isElectron: false, isMacOS: false }, false],
+  ];
+
+  cases.forEach(([label, context, expected]) => {
+    it(`${expected ? 'restricts' : 'allows'} donation UI on ${label}`, () => {
+      expect(isDonationUiRestricted(context)).toBe(expected);
+    });
+  });
+});

--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -23,15 +23,18 @@ export const IS_GNOME_WAYLAND = IS_ELECTRON && window.ea.isGnomeWayland();
 // True only inside the Electron build — preload exposes process.arch.
 // Web builds can't reliably distinguish Apple Silicon from Intel and stay false.
 export const IS_APPLE_SILICON = IS_ELECTRON && window.ea.isAppleSilicon();
-// True only in a Mac App Store (sandboxed) Electron build. Reuses the existing
-// dist-channel bridge (driven by Electron's process.mas); direct-download macOS
-// (mac-dmg), other channels and web builds stay false.
-export const IS_MAC_APP_STORE = IS_ELECTRON && window.ea.getDistChannel() === 'mac-store';
 // Apple's App Store guidelines forbid donation/contribution links that route
-// around In-App Purchase (Guideline 3.1.1). True for both Apple App Store
-// distribution channels (iOS App Store and Mac App Store); direct-download and
-// web builds stay false, so they keep the donation UI.
-export const IS_APPLE_APP_STORE = IS_IOS_NATIVE || IS_MAC_APP_STORE;
+// around In-App Purchase (Guideline 3.1.1). Use the reliable OS bridge instead
+// of process.mas so review and local builds behave identically on macOS.
+export const IS_APPLE_APP_STORE = IS_IOS_NATIVE || (IS_ELECTRON && window.ea.isMacOS());
+
+export const IS_APPLE_APP_STORE_TOKEN = new InjectionToken<boolean>(
+  'IS_APPLE_APP_STORE',
+  {
+    providedIn: 'root',
+    factory: () => IS_APPLE_APP_STORE,
+  },
+);
 
 export const TRACKING_INTERVAL = 1000;
 

--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -23,16 +23,33 @@ export const IS_GNOME_WAYLAND = IS_ELECTRON && window.ea.isGnomeWayland();
 // True only inside the Electron build — preload exposes process.arch.
 // Web builds can't reliably distinguish Apple Silicon from Intel and stay false.
 export const IS_APPLE_SILICON = IS_ELECTRON && window.ea.isAppleSilicon();
-// Apple's App Store guidelines forbid donation/contribution links that route
-// around In-App Purchase (Guideline 3.1.1). Use the reliable OS bridge instead
-// of process.mas so review and local builds behave identically on macOS.
-export const IS_APPLE_APP_STORE = IS_IOS_NATIVE || (IS_ELECTRON && window.ea.isMacOS());
+interface DonationUiPlatformContext {
+  isIosNative: boolean;
+  isElectron: boolean;
+  isMacOS: boolean;
+}
 
-export const IS_APPLE_APP_STORE_TOKEN = new InjectionToken<boolean>(
-  'IS_APPLE_APP_STORE',
+export const isDonationUiRestricted = ({
+  isIosNative,
+  isElectron,
+  isMacOS,
+}: DonationUiPlatformContext): boolean => isIosNative || (isElectron && isMacOS);
+
+// Apple's App Store guidelines forbid donation/contribution links that route
+// around In-App Purchase (Guideline 3.1.1). Apply the restriction to every
+// macOS Electron build so App Store, direct-download and local review behavior
+// cannot diverge based on the unreliable process.mas signal.
+export const IS_DONATION_UI_RESTRICTED = isDonationUiRestricted({
+  isIosNative: IS_IOS_NATIVE,
+  isElectron: IS_ELECTRON,
+  isMacOS: IS_ELECTRON && window.ea.isMacOS(),
+});
+
+export const IS_DONATION_UI_RESTRICTED_TOKEN = new InjectionToken<boolean>(
+  'IS_DONATION_UI_RESTRICTED',
   {
     providedIn: 'root',
-    factory: () => IS_APPLE_APP_STORE,
+    factory: () => IS_DONATION_UI_RESTRICTED,
   },
 );
 

--- a/src/app/app.guard.spec.ts
+++ b/src/app/app.guard.spec.ts
@@ -1,13 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 import { Router, UrlTree } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
-import { DefaultStartPageGuard } from './app.guard';
+import { DefaultStartPageGuard, DonatePageGuard } from './app.guard';
+import { IS_APPLE_APP_STORE_TOKEN } from './app.constants';
 import { DataInitStateService } from './core/data-init/data-init-state.service';
 import { GlobalConfigService } from './features/config/global-config.service';
 import { ProjectService } from './features/project/project.service';
 import { TODAY_TAG } from './features/tag/tag.const';
 import { INBOX_PROJECT } from './features/project/project.const';
 import { Project } from './features/project/project.model';
+import { APP_ROUTES } from './app.routes';
 
 describe('DefaultStartPageGuard', () => {
   let guard: DefaultStartPageGuard;
@@ -162,5 +164,34 @@ describe('DefaultStartPageGuard', () => {
   it('falls back to Today when misc config itself is undefined', async () => {
     misc$.next(undefined);
     expectUrl(await runGuard(), TODAY_URL);
+  });
+});
+
+describe('DonatePageGuard', () => {
+  const setup = (isRestricted: boolean): DonatePageGuard => {
+    TestBed.configureTestingModule({
+      providers: [
+        DonatePageGuard,
+        { provide: IS_APPLE_APP_STORE_TOKEN, useValue: isRestricted },
+      ],
+    });
+    return TestBed.inject(DonatePageGuard);
+  };
+
+  it('allows the donate page on unrestricted platforms', () => {
+    expect(setup(false).canActivate()).toBeTrue();
+  });
+
+  it('redirects the donate page on restricted Apple platforms', () => {
+    const guard = setup(true);
+    const router = TestBed.inject(Router);
+
+    expect(router.serializeUrl(guard.canActivate() as UrlTree)).toBe('/');
+  });
+
+  it('protects the donate route', () => {
+    const donateRoute = APP_ROUTES.find((route) => route.path === 'donate');
+
+    expect(donateRoute?.canActivate).toContain(DonatePageGuard);
   });
 });

--- a/src/app/app.guard.spec.ts
+++ b/src/app/app.guard.spec.ts
@@ -1,8 +1,10 @@
+import { Component } from '@angular/core';
+import { provideLocationMocks } from '@angular/common/testing';
 import { TestBed } from '@angular/core/testing';
-import { Router, UrlTree } from '@angular/router';
+import { provideRouter, Router, UrlTree } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { DefaultStartPageGuard, DonatePageGuard } from './app.guard';
-import { IS_APPLE_APP_STORE_TOKEN } from './app.constants';
+import { IS_DONATION_UI_RESTRICTED_TOKEN } from './app.constants';
 import { DataInitStateService } from './core/data-init/data-init-state.service';
 import { GlobalConfigService } from './features/config/global-config.service';
 import { ProjectService } from './features/project/project.service';
@@ -10,6 +12,12 @@ import { TODAY_TAG } from './features/tag/tag.const';
 import { INBOX_PROJECT } from './features/project/project.const';
 import { Project } from './features/project/project.model';
 import { APP_ROUTES } from './app.routes';
+
+@Component({ standalone: true, template: '' })
+class DonateRouteTestComponent {}
+
+@Component({ standalone: true, template: '' })
+class HomeRouteTestComponent {}
 
 describe('DefaultStartPageGuard', () => {
   let guard: DefaultStartPageGuard;
@@ -168,25 +176,38 @@ describe('DefaultStartPageGuard', () => {
 });
 
 describe('DonatePageGuard', () => {
-  const setup = (isRestricted: boolean): DonatePageGuard => {
+  const setup = (isRestricted: boolean): Router => {
     TestBed.configureTestingModule({
       providers: [
-        DonatePageGuard,
-        { provide: IS_APPLE_APP_STORE_TOKEN, useValue: isRestricted },
+        provideLocationMocks(),
+        provideRouter([
+          {
+            path: 'donate',
+            component: DonateRouteTestComponent,
+            canActivate: [DonatePageGuard],
+          },
+          { path: '', component: HomeRouteTestComponent },
+        ]),
+        { provide: IS_DONATION_UI_RESTRICTED_TOKEN, useValue: isRestricted },
       ],
     });
-    return TestBed.inject(DonatePageGuard);
+    return TestBed.inject(Router);
   };
 
-  it('allows the donate page on unrestricted platforms', () => {
-    expect(setup(false).canActivate()).toBeTrue();
+  it('navigates to the donate page on unrestricted platforms', async () => {
+    const router = setup(false);
+
+    await router.navigateByUrl('/donate');
+
+    expect(router.url).toBe('/donate');
   });
 
-  it('redirects the donate page on restricted Apple platforms', () => {
-    const guard = setup(true);
-    const router = TestBed.inject(Router);
+  it('redirects donate navigation on restricted platforms', async () => {
+    const router = setup(true);
 
-    expect(router.serializeUrl(guard.canActivate() as UrlTree)).toBe('/');
+    await router.navigateByUrl('/donate');
+
+    expect(router.url).toBe('/');
   });
 
   it('protects the donate route', () => {

--- a/src/app/app.guard.ts
+++ b/src/app/app.guard.ts
@@ -17,6 +17,17 @@ import { selectIsOverlayShown } from './features/focus-mode/store/focus-mode.sel
 import { DataInitStateService } from './core/data-init/data-init-state.service';
 import { GlobalConfigService } from './features/config/global-config.service';
 import { getStartPageUrlPath } from './features/config/default-start-page.util';
+import { IS_APPLE_APP_STORE_TOKEN } from './app.constants';
+
+@Injectable({ providedIn: 'root' })
+export class DonatePageGuard {
+  private _isAppleAppStore = inject(IS_APPLE_APP_STORE_TOKEN);
+  private _router = inject(Router);
+
+  canActivate(): true | UrlTree {
+    return this._isAppleAppStore ? this._router.parseUrl('/') : true;
+  }
+}
 
 @Injectable({ providedIn: 'root' })
 export class ActiveWorkContextGuard {

--- a/src/app/app.guard.ts
+++ b/src/app/app.guard.ts
@@ -17,15 +17,15 @@ import { selectIsOverlayShown } from './features/focus-mode/store/focus-mode.sel
 import { DataInitStateService } from './core/data-init/data-init-state.service';
 import { GlobalConfigService } from './features/config/global-config.service';
 import { getStartPageUrlPath } from './features/config/default-start-page.util';
-import { IS_APPLE_APP_STORE_TOKEN } from './app.constants';
+import { IS_DONATION_UI_RESTRICTED_TOKEN } from './app.constants';
 
 @Injectable({ providedIn: 'root' })
 export class DonatePageGuard {
-  private _isAppleAppStore = inject(IS_APPLE_APP_STORE_TOKEN);
+  private _isDonationUiRestricted = inject(IS_DONATION_UI_RESTRICTED_TOKEN);
   private _router = inject(Router);
 
   canActivate(): true | UrlTree {
-    return this._isAppleAppStore ? this._router.parseUrl('/') : true;
+    return this._isDonationUiRestricted ? this._router.parseUrl('/') : true;
   }
 }
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { Routes } from '@angular/router';
 import {
   ActiveWorkContextGuard,
   DefaultStartPageGuard,
+  DonatePageGuard,
   FocusOverlayOpenGuard,
   ValidProjectIdGuard,
   ValidTagIdGuard,
@@ -94,7 +95,7 @@ export const APP_ROUTES: Routes = [
     loadComponent: () =>
       import('./routes/pages.routes').then((m) => m.DonatePageComponent),
     data: { page: 'donate' },
-    canActivate: [FocusOverlayOpenGuard],
+    canActivate: [DonatePageGuard, FocusOverlayOpenGuard],
   },
   {
     path: 'contrast-test',

--- a/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
+++ b/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
@@ -36,7 +36,7 @@ import {
 import { GlobalConfigService } from '../../features/config/global-config.service';
 import { AppFeaturesConfig } from '../../features/config/global-config.model';
 import { SnackService } from '../../core/snack/snack.service';
-import { IS_APPLE_APP_STORE } from '../../app.constants';
+import { IS_DONATION_UI_RESTRICTED } from '../../app.constants';
 
 @Injectable({
   providedIn: 'root',
@@ -252,9 +252,9 @@ export class MagicNavConfigService {
       },
 
       // Help Menu (rendered as mat-menu)
-      // Not allowed to display donation stuff on the iOS or Mac App Store per
-      // App Store guidelines (Guideline 3.1.1)
-      ...(this.isDonatePageEnabled() && !IS_APPLE_APP_STORE
+      // Donation links are disabled on native iOS and every macOS desktop build
+      // to keep App Store review behavior deterministic (Guideline 3.1.1).
+      ...(this.isDonatePageEnabled() && !IS_DONATION_UI_RESTRICTED
         ? [
             {
               type: 'route',
@@ -293,9 +293,9 @@ export class MagicNavConfigService {
             icon: 'feedback',
             href: 'https://github.com/super-productivity/super-productivity/discussions',
           },
-          // Not allowed to display donation stuff on the iOS or Mac App Store
-          // per App Store guidelines (Guideline 3.1.1)
-          ...(!IS_APPLE_APP_STORE
+          // Donation links are disabled on native iOS and every macOS desktop
+          // build to keep App Store review behavior deterministic.
+          ...(!IS_DONATION_UI_RESTRICTED
             ? [
                 {
                   type: 'href' as const,

--- a/src/app/features/config/form-cfgs/app-features-form.const.ts
+++ b/src/app/features/config/form-cfgs/app-features-form.const.ts
@@ -1,6 +1,6 @@
 import { ConfigFormSection, AppFeaturesConfig } from '../global-config.model';
 import { T } from '../../../t.const';
-import { IS_APPLE_APP_STORE } from '../../../app.constants';
+import { IS_DONATION_UI_RESTRICTED } from '../../../app.constants';
 
 export const EXPERIMENTAL_APP_FEATURE_KEYS: ReadonlyArray<keyof AppFeaturesConfig> = [
   'isEnableUserProfiles',
@@ -94,9 +94,9 @@ export const APP_FEATURES_FORM_CFG: ConfigFormSection<AppFeaturesConfig> = {
     {
       key: 'isDonatePageEnabled',
       type: 'slide-toggle',
-      // Donations are fully hidden on Apple App Store builds (Guideline 3.1.1),
-      // so this toggle would be inert there — hide it to avoid a dead control.
-      hideExpression: () => IS_APPLE_APP_STORE,
+      // Donations are fully hidden on native iOS and macOS desktop builds, so
+      // this toggle would be inert there — hide it to avoid a dead control.
+      hideExpression: () => IS_DONATION_UI_RESTRICTED,
       templateOptions: {
         label: T.GCF.APP_FEATURES.DONATE_PAGE,
         icon: 'favorite',

--- a/src/app/features/dialog-please-rate/dialog-please-rate.component.html
+++ b/src/app/features/dialog-please-rate/dialog-please-rate.component.html
@@ -79,7 +79,7 @@
       <!-- Fallback: if no mail client is registered the mailto: link above does
            nothing, so show the address as selectable text (never a dead end). -->
       <small class="feedback-email">{{ maintainerEmail }}</small>
-      @if (!IS_APPLE_APP_STORE) {
+      @if (!IS_DONATION_UI_RESTRICTED) {
         <a
           class="action-item"
           [href]="contributingUrl"

--- a/src/app/features/dialog-please-rate/dialog-please-rate.component.ts
+++ b/src/app/features/dialog-please-rate/dialog-please-rate.component.ts
@@ -6,7 +6,7 @@ import {
   MatDialogTitle,
 } from '@angular/material/dialog';
 import { T } from '../../t.const';
-import { IS_APPLE_APP_STORE } from '../../app.constants';
+import { IS_DONATION_UI_RESTRICTED } from '../../app.constants';
 import { MatButton } from '@angular/material/button';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatIcon } from '@angular/material/icon';
@@ -47,11 +47,10 @@ export class DialogPleaseRateComponent {
   protected readonly mailtoUrl = buildFeedbackMailto();
   protected readonly discussionsUrl = DISCUSSIONS_URL;
   protected readonly contributingUrl = CONTRIBUTING_URL;
-  // CONTRIBUTING.md links to GitHub Sponsors; Apple App Store builds must not
-  // surface donation paths outside In-App Purchase (Guideline 3.1.1). Mirrors
-  // the gate on the identical Help-menu link. This dialog isn't shown on iOS
-  // (native StoreReview card) but is shown on the Mac App Store (Electron).
-  protected readonly IS_APPLE_APP_STORE = IS_APPLE_APP_STORE;
+  // CONTRIBUTING.md links to GitHub Sponsors. This dialog isn't shown on iOS
+  // (native StoreReview card), but it is shown on macOS, where the link remains
+  // hidden alongside the identical Help-menu link.
+  protected readonly IS_DONATION_UI_RESTRICTED = IS_DONATION_UI_RESTRICTED;
   // Shown as selectable text under the email option so the channel isn't a dead
   // end when no mail client is registered (common on Linux/web) and the mailto:
   // link silently does nothing.

--- a/src/app/pages/donate-page/donate-page.component.html
+++ b/src/app/pages/donate-page/donate-page.component.html
@@ -1,6 +1,6 @@
 <div class="page-wrapper">
   <div class="content">
-    @if (!IS_APPLE_APP_STORE) {
+    @if (!IS_DONATION_UI_RESTRICTED) {
       <p>
         {{ T.DONATE_PAGE.INTRO_1 | translate }}
       </p>

--- a/src/app/pages/donate-page/donate-page.component.ts
+++ b/src/app/pages/donate-page/donate-page.component.ts
@@ -3,7 +3,7 @@ import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { T } from '../../t.const';
 import { TranslatePipe } from '@ngx-translate/core';
-import { IS_APPLE_APP_STORE } from '../../app.constants';
+import { IS_DONATION_UI_RESTRICTED } from '../../app.constants';
 
 @Component({
   selector: 'donate-page',
@@ -15,7 +15,7 @@ import { IS_APPLE_APP_STORE } from '../../app.constants';
 })
 export class DonatePageComponent {
   readonly T = T;
-  // Hides the whole page body on Apple App Store builds — the route stays
-  // reachable by direct URL even though the nav entry is gone. See IS_APPLE_APP_STORE.
-  readonly IS_APPLE_APP_STORE = IS_APPLE_APP_STORE;
+  // Defense in depth: DonatePageGuard redirects restricted platforms before
+  // this component renders, and this gate prevents accidental direct rendering.
+  readonly IS_DONATION_UI_RESTRICTED = IS_DONATION_UI_RESTRICTED;
 }


### PR DESCRIPTION
## Summary

- replace the Mac App Store-specific donation check with a behavior-specific restriction that covers native iOS and every macOS Electron build
- protect `/donate` with a route guard so direct or persisted navigation cannot render the Support Us page
- keep donation UI available on web, Android, Windows, and Linux
- update the platform documentation and all existing donation UI gates

## Root cause

The previous macOS gate depended on Electron's `process.mas` distribution signal. That allowed review and non-MAS macOS environments to diverge, while the `/donate` route itself also remained navigable after its menu entry was hidden.

The new gate uses the stable macOS OS bridge and is named for the behavior it controls, avoiding an App-Store-specific contract that could accidentally affect future consumers.

## User impact

Donation and contribution transaction links are unavailable throughout native iOS and macOS builds. Other supported platforms retain their existing Support Us behavior.

## Validation

- repository-required `npm run checkFile` passed for every modified TypeScript file
- platform classification tests: 7 passed
- guard and real-router navigation tests: 17 passed
- rate-dialog tests: 4 passed
- full production build passed
- pre-push full test suite passed:
  - sync-core: 206 tests
  - sync-providers: 394 tests
  - Angular/Karma default timezone: 12,087 tests
  - Angular/Karma Los Angeles timezone: 12,073 tests
- adversarial sub-agent review and remediation re-review completed with no substantive issues remaining

The lint run reports 11 pre-existing unused-disable warnings in unrelated spec files and no errors.
