### PR TITLE
feat(tasks): navigate from empty add-subtask input

### DIFF
--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -83,6 +83,7 @@ The following shortcuts apply for the currently selected task (selected via tab 
 #### Unconfigurable
 
 - `Arrow keys`: Navigate around task list
+- In an empty or whitespace-only add-subtask input, `ArrowUp` focuses the preceding subtask or parent task, and `ArrowDown` focuses the next task when available. At the end of the list, focus stays on the closest task row or control.
 - `ArrowRight`: Open additional info panel for currently focused task
 - `Ctrl`+`C` / `Cmd`+`C`: Copy the currently focused task title when focus is on the task, no text is selected, and focus is not inside an input
 

--- a/src/app/features/tasks/add-subtask-input/add-subtask-input.component.spec.ts
+++ b/src/app/features/tasks/add-subtask-input/add-subtask-input.component.spec.ts
@@ -112,6 +112,56 @@ describe('AddSubtaskInputComponent', () => {
     expect(closeSpy).toHaveBeenCalledOnceWith('escape');
   });
 
+  it('closes toward the previous task on ArrowUp when the input is empty', () => {
+    const closeSpy = jasmine.createSpy('closed');
+    component.closed.subscribe(closeSpy);
+    const ev = new KeyboardEvent('keydown', {
+      key: 'ArrowUp',
+      cancelable: true,
+    });
+
+    getInput().dispatchEvent(ev);
+
+    expect(ev.defaultPrevented).toBe(true);
+    expect(closeSpy).toHaveBeenCalledOnceWith('prev');
+  });
+
+  it('closes toward the next task on ArrowDown when the input is empty', () => {
+    const closeSpy = jasmine.createSpy('closed');
+    component.closed.subscribe(closeSpy);
+    const ev = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      cancelable: true,
+    });
+
+    getInput().dispatchEvent(ev);
+
+    expect(ev.defaultPrevented).toBe(true);
+    expect(closeSpy).toHaveBeenCalledOnceWith('next');
+  });
+
+  it('treats a whitespace-only draft as empty for arrow navigation', () => {
+    const closeSpy = jasmine.createSpy('closed');
+    component.closed.subscribe(closeSpy);
+    setInputValue('   ');
+
+    getInput().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+
+    expect(closeSpy).toHaveBeenCalledOnceWith('prev');
+  });
+
+  it('keeps a non-empty draft open when ArrowUp or ArrowDown is pressed', () => {
+    const closeSpy = jasmine.createSpy('closed');
+    component.closed.subscribe(closeSpy);
+    setInputValue('Keep editing');
+
+    getInput().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    getInput().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(getInput().value).toBe('Keep editing');
+  });
+
   it('does not commit when Escape is followed by blur', () => {
     const closeSpy = jasmine.createSpy('closed');
     component.closed.subscribe(closeSpy);

--- a/src/app/features/tasks/add-subtask-input/add-subtask-input.component.ts
+++ b/src/app/features/tasks/add-subtask-input/add-subtask-input.component.ts
@@ -21,11 +21,11 @@ import { TaskService } from '../task.service';
 
 /**
  * Why the inline draft input closed. `escape` is a keyboard cancel (the draft
- * is discarded and focus returns to the task row); `blur` means focus already
- * moved elsewhere, so any pending draft is committed and focus is not stolen
- * back.
+ * is discarded and focus returns to the task row); `prev` and `next` continue
+ * keyboard navigation from an empty input; `blur` means focus already moved
+ * elsewhere, so any pending draft is committed and focus is not stolen back.
  */
-export type AddSubtaskInputCloseReason = 'escape' | 'blur';
+export type AddSubtaskInputCloseReason = 'escape' | 'blur' | 'prev' | 'next';
 
 @Component({
   selector: 'add-subtask-input',
@@ -65,6 +65,20 @@ export class AddSubtaskInputComponent {
     if (ev.key === 'Escape') {
       ev.preventDefault();
       this._close('escape');
+      return;
+    }
+
+    if (
+      (ev.key === 'ArrowUp' || ev.key === 'ArrowDown') &&
+      !ev.isComposing &&
+      !ev.ctrlKey &&
+      !ev.metaKey &&
+      !ev.altKey &&
+      !ev.shiftKey &&
+      !(this.inputEl()?.nativeElement.value ?? this.titleDraft()).trim()
+    ) {
+      ev.preventDefault();
+      this._close(ev.key === 'ArrowUp' ? 'prev' : 'next');
       return;
     }
 

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
@@ -428,6 +428,7 @@ describe('TaskDetailPanelComponent notes target does not auto-edit', () => {
  * sub-task is handled by TaskService.focusTaskById (covered separately).
  */
 describe('TaskDetailPanelComponent add sub-task', () => {
+  let fixture: ComponentFixture<TaskDetailPanelComponent>;
   let component: TaskDetailPanelComponent;
   let addSubTaskToSpy: jasmine.Spy;
 
@@ -485,7 +486,7 @@ describe('TaskDetailPanelComponent add sub-task', () => {
       })
       .compileComponents();
 
-    const fixture = TestBed.createComponent(TaskDetailPanelComponent);
+    fixture = TestBed.createComponent(TaskDetailPanelComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('task', fakeTask('P'));
     fixture.detectChanges();
@@ -501,15 +502,15 @@ describe('TaskDetailPanelComponent add sub-task', () => {
   });
 
   it('creates a sibling directly when adding a subtask from a subtask panel', () => {
-    const fixture = TestBed.createComponent(TaskDetailPanelComponent);
-    const subComponent = fixture.componentInstance;
-    fixture.componentRef.setInput('task', {
+    const subFixture = TestBed.createComponent(TaskDetailPanelComponent);
+    const subComponent = subFixture.componentInstance;
+    subFixture.componentRef.setInput('task', {
       id: 'SUB',
       parentId: 'P',
       subTasks: [],
       tagIds: [],
     } as unknown as TaskWithSubTasks);
-    fixture.detectChanges();
+    subFixture.detectChanges();
 
     subComponent.addSubTask();
 
@@ -525,6 +526,56 @@ describe('TaskDetailPanelComponent add sub-task', () => {
     // The section stays expanded so the just-added subtasks remain visible.
     expect(component.isSubTasksExpanded()).toBe(true);
   });
+
+  it('focuses the last panel subtask on previous navigation', fakeAsync(() => {
+    const lastSubtask = document.createElement('task');
+    lastSubtask.tabIndex = 0;
+    fixture.nativeElement.append(lastSubtask);
+    component.isAddSubtaskInputVisible.set(true);
+
+    component.onAddSubtaskInputClosed('prev');
+    tick();
+
+    expect(document.activeElement).toBe(lastSubtask);
+  }));
+
+  it('focuses the next main-list task on next navigation', fakeAsync(() => {
+    const mainList = document.createElement('div');
+    const parentTask = document.createElement('task');
+    const mainSubtask = document.createElement('task');
+    const nextTask = document.createElement('task');
+    parentTask.id = 't-P';
+    parentTask.tabIndex = 0;
+    mainSubtask.tabIndex = 0;
+    nextTask.tabIndex = 0;
+    parentTask.append(mainSubtask);
+    mainList.append(parentTask, nextTask);
+    document.body.append(mainList);
+    component.isAddSubtaskInputVisible.set(true);
+
+    component.onAddSubtaskInputClosed('next');
+    tick();
+
+    expect(document.activeElement).toBe(nextTask);
+    mainList.remove();
+  }));
+
+  it('keeps focus on the last panel subtask when there is no next task', fakeAsync(() => {
+    const mainParentTask = document.createElement('task');
+    const panelSubtask = document.createElement('task');
+    mainParentTask.id = 't-P';
+    mainParentTask.tabIndex = 0;
+    panelSubtask.tabIndex = 0;
+    document.body.append(mainParentTask);
+    fixture.nativeElement.append(panelSubtask);
+    component.isAddSubtaskInputVisible.set(true);
+
+    component.onAddSubtaskInputClosed('next');
+    tick();
+
+    expect(document.activeElement).toBe(panelSubtask);
+    mainParentTask.remove();
+  }));
 
   it('routes the add-subtask shortcut to addSubTask (with prevent/stopPropagation)', () => {
     spyOn(component, 'addSubTask');

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -93,6 +93,7 @@ import {
   AddSubtaskInputComponent,
   AddSubtaskInputCloseReason,
 } from '../add-subtask-input/add-subtask-input.component';
+import { findNextTaskAfterSubtree } from '../../../util/find-adjacent-focusable';
 
 @Component({
   selector: 'task-detail-panel',
@@ -130,6 +131,7 @@ import {
   ],
 })
 export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestroy {
+  private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   // Services
   attachmentService = inject(TaskAttachmentService);
   taskService = inject(TaskService);
@@ -687,7 +689,28 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
     // keyboard navigation continues from the panel rather than falling to body.
     if (reason === 'escape') {
       window.setTimeout(() => this.addSubTaskBtn()?.nativeElement.focus());
+    } else if (reason === 'prev' || reason === 'next') {
+      this._focusFromClosedSubtaskInput(reason);
     }
+  }
+
+  private _focusFromClosedSubtaskInput(direction: 'prev' | 'next'): void {
+    const panelSubtaskEls = Array.from(
+      this._elementRef.nativeElement.querySelectorAll<HTMLElement>('task'),
+    );
+    const mainParentTaskEl = Array.from(
+      document.querySelectorAll<HTMLElement>(`#t-${CSS.escape(this.task().id)}`),
+    ).find((taskEl) => !taskEl.closest('task-detail-panel'));
+    const fallbackTarget =
+      panelSubtaskEls[panelSubtaskEls.length - 1] ??
+      mainParentTaskEl ??
+      this.addSubTaskBtn()?.nativeElement;
+    const target =
+      direction === 'next' && mainParentTaskEl
+        ? (findNextTaskAfterSubtree(mainParentTaskEl) ?? fallbackTarget)
+        : fallbackTarget;
+
+    window.setTimeout(() => target?.focus());
   }
 
   collapseParent(): void {

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -557,6 +557,82 @@ describe('TaskComponent shortcut handling', () => {
       expect(component.isAddSubtaskInputVisible()).toBe(false);
       expect(focusByIdSpy).not.toHaveBeenCalled();
     }));
+
+    it('focuses the last visible subtask on previous navigation', fakeAsync(() => {
+      const host = fixture.nativeElement as HTMLElement;
+      const firstSubtask = document.createElement('task');
+      const lastSubtask = document.createElement('task');
+      firstSubtask.tabIndex = 0;
+      lastSubtask.tabIndex = 0;
+      host.append(firstSubtask, lastSubtask);
+      component.isAddSubtaskInputVisible.set(true);
+
+      component.onAddSubtaskInputClosed('prev');
+      tick();
+
+      expect(document.activeElement).toBe(lastSubtask);
+    }));
+
+    it('focuses the parent task on previous navigation when it has no visible subtasks', fakeAsync(() => {
+      // The overridden empty test template uses a generic Angular root element,
+      // so mirror the real <task tabindex="0"> host binding explicitly.
+      (fixture.nativeElement as HTMLElement).tabIndex = 0;
+      component.isAddSubtaskInputVisible.set(true);
+
+      component.onAddSubtaskInputClosed('prev');
+      tick();
+
+      expect(document.activeElement).toBe(fixture.nativeElement);
+    }));
+
+    it('focuses the next task after the parent and its subtasks', fakeAsync(() => {
+      const host = fixture.nativeElement as HTMLElement;
+      const subtask = document.createElement('task');
+      const nextTask = document.createElement('task');
+      subtask.tabIndex = 0;
+      nextTask.tabIndex = 0;
+      host.append(subtask);
+      host.after(nextTask);
+      component.isAddSubtaskInputVisible.set(true);
+
+      component.onAddSubtaskInputClosed('next');
+      tick();
+
+      expect(document.activeElement).toBe(nextTask);
+      nextTask.remove();
+    }));
+
+    it('keeps focus on the last visible row when there is no next task', fakeAsync(() => {
+      const host = fixture.nativeElement as HTMLElement;
+      const lastSubtask = document.createElement('task');
+      lastSubtask.tabIndex = 0;
+      host.append(lastSubtask);
+      component.isAddSubtaskInputVisible.set(true);
+
+      component.onAddSubtaskInputClosed('next');
+      tick();
+
+      expect(document.activeElement).toBe(lastSubtask);
+    }));
+
+    it('does not navigate into task copies rendered in the detail panel', fakeAsync(() => {
+      const host = fixture.nativeElement as HTMLElement;
+      const lastSubtask = document.createElement('task');
+      const detailPanel = document.createElement('task-detail-panel');
+      const duplicateTask = document.createElement('task');
+      lastSubtask.tabIndex = 0;
+      duplicateTask.tabIndex = 0;
+      host.append(lastSubtask);
+      detailPanel.append(duplicateTask);
+      host.after(detailPanel);
+      component.isAddSubtaskInputVisible.set(true);
+
+      component.onAddSubtaskInputClosed('next');
+      tick();
+
+      expect(document.activeElement).toBe(lastSubtask);
+      detailPanel.remove();
+    }));
   });
 
   describe('moveToToday overdue branch (#8851)', () => {

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -42,7 +42,11 @@ import {
   CollapsibleComponent,
   GROUP_NAV_SELECTOR,
 } from '../../../ui/collapsible/collapsible.component';
-import { findAdjacentFocusable } from '../../../util/find-adjacent-focusable';
+import {
+  findAdjacentFocusable,
+  findLastTaskInSubtree,
+  findNextTaskAfterSubtree,
+} from '../../../util/find-adjacent-focusable';
 import { TaskAttachmentService } from '../task-attachment/task-attachment.service';
 import { DialogEditTaskAttachmentComponent } from '../task-attachment/dialog-edit-attachment/dialog-edit-task-attachment.component';
 import { ProjectService } from '../../project/project.service';
@@ -951,7 +955,22 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
       // Return focus to the task the draft was opened from (which may be a
       // subtask) so keyboard navigation continues from there after cancelling.
       this._refocusTaskAfterDraftCancel(originTaskId);
+    } else if (reason === 'prev' || reason === 'next') {
+      this._focusFromClosedSubtaskInput(reason);
     }
+  }
+
+  private _focusFromClosedSubtaskInput(direction: 'prev' | 'next'): void {
+    // The input follows the rendered subtask list. Its previous row is therefore
+    // the last visible subtask (or the parent), while its next row follows the
+    // entire parent subtree in document order.
+    window.setTimeout(() => {
+      const host = this._elementRef.nativeElement as HTMLElement;
+      const lastRow = findLastTaskInSubtree(host);
+      const target =
+        direction === 'prev' ? lastRow : (findNextTaskAfterSubtree(host) ?? lastRow);
+      target.focus();
+    });
   }
 
   private _refocusTaskAfterDraftCancel(taskId: string | null): void {

--- a/src/app/util/find-adjacent-focusable.spec.ts
+++ b/src/app/util/find-adjacent-focusable.spec.ts
@@ -1,4 +1,8 @@
-import { findAdjacentFocusable } from './find-adjacent-focusable';
+import {
+  findAdjacentFocusable,
+  findLastTaskInSubtree,
+  findNextTaskAfterSubtree,
+} from './find-adjacent-focusable';
 
 describe('findAdjacentFocusable', () => {
   let root: HTMLElement;
@@ -88,5 +92,21 @@ describe('findAdjacentFocusable', () => {
     const outsider = document.createElement('div');
     root.insertBefore(outsider, root.firstChild);
     expect(findAdjacentFocusable(outsider, 'next', SELECTOR)).toBeNull();
+  });
+
+  it('finds the last rendered task in a parent subtree', () => {
+    const { taskA2, subA2 } = setupTree();
+
+    expect(findLastTaskInSubtree(taskA2)).toBe(subA2);
+  });
+
+  it('finds the next task after a subtree without entering the detail panel', () => {
+    root.innerHTML = `
+      <task id="parent"><task id="subtask"></task></task>
+      <task-detail-panel><task id="duplicate"></task></task-detail-panel>
+    `;
+    const parent = root.querySelector<HTMLElement>('#parent')!;
+
+    expect(findNextTaskAfterSubtree(parent)).toBeNull();
   });
 });

--- a/src/app/util/find-adjacent-focusable.ts
+++ b/src/app/util/find-adjacent-focusable.ts
@@ -22,3 +22,28 @@ export const findAdjacentFocusable = (
   const step = direction === 'next' ? 1 : -1;
   return all[idx + step] ?? null;
 };
+
+/**
+ * Returns the final rendered row in a parent task's subtree. The parent itself
+ * is returned when it has no rendered subtasks.
+ */
+export const findLastTaskInSubtree = (parentTaskEl: HTMLElement): HTMLElement => {
+  const subtaskEls = Array.from(parentTaskEl.querySelectorAll<HTMLElement>('task'));
+  return subtaskEls[subtaskEls.length - 1] ?? parentTaskEl;
+};
+
+/**
+ * Finds the next main-list task after a parent and all of its rendered
+ * subtasks. Task copies inside the detail panel are excluded so navigation
+ * cannot jump into a second rendering of the same subtree.
+ */
+export const findNextTaskAfterSubtree = (
+  parentTaskEl: HTMLElement,
+): HTMLElement | null => {
+  const lastRow = findLastTaskInSubtree(parentTaskEl);
+  const mainTaskEls = Array.from(document.querySelectorAll<HTMLElement>('task')).filter(
+    (taskEl) => !taskEl.closest('task-detail-panel'),
+  );
+  const currentIndex = mainTaskEls.indexOf(lastRow);
+  return currentIndex < 0 ? null : (mainTaskEls[currentIndex + 1] ?? null);
+};


### PR DESCRIPTION
## Summary

- allow bare `ArrowUp` and `ArrowDown` to leave an empty or whitespace-only add-subtask input
- focus the previous visible subtask/parent or the next available task without discarding typed drafts
- support both main-list and detail-panel inputs while avoiding duplicate detail-panel task renderings and retaining focus at list boundaries
- document the keyboard behavior

## Why

The inline add-subtask input remains open after adding a subtask for rapid entry, but it intercepts task-level arrow shortcuts. This made it awkward for keyboard users to leave the empty input and continue navigating the task list.

## Validation

- `npm run test:file src/app/util/find-adjacent-focusable.spec.ts -- --watch=false`
- `npm run test:file src/app/features/tasks/add-subtask-input/add-subtask-input.component.spec.ts -- --watch=false`
- `npm run test:file src/app/features/tasks/task/task-shortcuts.spec.ts -- --watch=false`
- `npm run test:file src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts -- --watch=false`
- `npm run checkFile <filepath>` for every modified TypeScript file
- verified main-list and detail-panel keyboard flows in Chrome with no console errors or warnings
- completed independent correctness, architecture/performance, and accessibility reviews
