### PR TITLE
fix(dnd): allow dragging recurring tasks onto sidebar projects

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
@@ -1,4 +1,4 @@
-﻿import { of } from 'rxjs';
+import { of } from 'rxjs';
 import { TaskWithSubTasks } from '../../features/tasks/task.model';
 import { createTask } from '../../features/tasks/task.test-helper';
 import { MagicSideNavComponent } from './magic-side-nav.component';
@@ -19,13 +19,15 @@ const buildReceiver = (
   activeTask: TaskWithSubTasks | null,
 ): {
   receiver: MagicSideNavComponent;
-  moveToProject: jasmine.Spy;
+  moveTaskToProjectWithRepeatCfgAwareness$: jasmine.Spy;
   addToToday: jasmine.Spy;
   updateTags: jasmine.Spy;
   setCancelNextDrop: jasmine.Spy;
   setActiveTask: jasmine.Spy;
 } => {
-  const moveToProject = jasmine.createSpy('moveToProject');
+  const moveTaskToProjectWithRepeatCfgAwareness$ = jasmine
+    .createSpy('moveTaskToProjectWithRepeatCfgAwareness$')
+    .and.returnValue(of('moved'));
   const addToToday = jasmine.createSpy('addToToday');
   const updateTags = jasmine.createSpy('updateTags');
   const setCancelNextDrop = jasmine.createSpy('setCancelNextDrop');
@@ -33,7 +35,7 @@ const buildReceiver = (
 
   const receiver = Object.assign(Object.create(MagicSideNavComponent.prototype), {
     _taskService: {
-      moveToProject,
+      moveTaskToProjectWithRepeatCfgAwareness$,
       addToToday,
       updateTags,
     },
@@ -47,7 +49,7 @@ const buildReceiver = (
 
   return {
     receiver,
-    moveToProject,
+    moveTaskToProjectWithRepeatCfgAwareness$,
     addToToday,
     updateTags,
     setCancelNextDrop,
@@ -80,25 +82,32 @@ describe('MagicSideNavComponent._handlePointerUp', () => {
         dueWithTime: Date.now(),
         repeatCfgId: 'repeat-1',
       }) as unknown as TaskWithSubTasks;
-      const { receiver, moveToProject, setCancelNextDrop } = buildReceiver(task);
+      const { receiver, moveTaskToProjectWithRepeatCfgAwareness$, setCancelNextDrop } =
+        buildReceiver(task);
 
       withNavItem('data-project-id', 'project-1', () => {
         callHandlePointerUp(receiver, pointerUpEvent());
       });
 
       expect(setCancelNextDrop).toHaveBeenCalledWith(true);
-      expect(moveToProject).toHaveBeenCalledWith(task, 'project-1');
+      expect(moveTaskToProjectWithRepeatCfgAwareness$).toHaveBeenCalledWith(
+        task,
+        'project-1',
+      );
     });
 
     it('moves a non-recurring task to the project', () => {
       const task = createTask({ id: 't2' }) as unknown as TaskWithSubTasks;
-      const { receiver, moveToProject } = buildReceiver(task);
+      const { receiver, moveTaskToProjectWithRepeatCfgAwareness$ } = buildReceiver(task);
 
       withNavItem('data-project-id', 'project-1', () => {
         callHandlePointerUp(receiver, pointerUpEvent());
       });
 
-      expect(moveToProject).toHaveBeenCalledWith(task, 'project-1');
+      expect(moveTaskToProjectWithRepeatCfgAwareness$).toHaveBeenCalledWith(
+        task,
+        'project-1',
+      );
     });
 
     it('does not move a subtask dropped on a project', () => {
@@ -106,13 +115,13 @@ describe('MagicSideNavComponent._handlePointerUp', () => {
         id: 'sub1',
         parentId: 'parent1',
       }) as unknown as TaskWithSubTasks;
-      const { receiver, moveToProject } = buildReceiver(task);
+      const { receiver, moveTaskToProjectWithRepeatCfgAwareness$ } = buildReceiver(task);
 
       withNavItem('data-project-id', 'project-1', () => {
         callHandlePointerUp(receiver, pointerUpEvent());
       });
 
-      expect(moveToProject).not.toHaveBeenCalled();
+      expect(moveTaskToProjectWithRepeatCfgAwareness$).not.toHaveBeenCalled();
     });
   });
 
@@ -149,13 +158,14 @@ describe('MagicSideNavComponent._handlePointerUp', () => {
   });
 
   it('does nothing when there is no active dragged task', () => {
-    const { receiver, moveToProject, addToToday, updateTags } = buildReceiver(null);
+    const { receiver, moveTaskToProjectWithRepeatCfgAwareness$, addToToday, updateTags } =
+      buildReceiver(null);
 
     withNavItem('data-project-id', 'project-1', () => {
       callHandlePointerUp(receiver, pointerUpEvent());
     });
 
-    expect(moveToProject).not.toHaveBeenCalled();
+    expect(moveTaskToProjectWithRepeatCfgAwareness$).not.toHaveBeenCalled();
     expect(addToToday).not.toHaveBeenCalled();
     expect(updateTags).not.toHaveBeenCalled();
   });

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
@@ -1,0 +1,162 @@
+﻿import { of } from 'rxjs';
+import { TaskWithSubTasks } from '../../features/tasks/task.model';
+import { createTask } from '../../features/tasks/task.test-helper';
+import { MagicSideNavComponent } from './magic-side-nav.component';
+
+// _handlePointerUp reaches into a large DI graph (Router, LayoutService,
+// MagicNavConfigService, DataInitStateService, ...) that the full component
+// doesn't need for this logic. Mirrors the DailySummaryComponent spec pattern:
+// patch only the private fields the method under test touches, then invoke it
+// directly, instead of paying for a full TestBed render of the nav tree.
+const callHandlePointerUp = (receiver: MagicSideNavComponent, event: MouseEvent): void =>
+  (
+    MagicSideNavComponent.prototype as unknown as {
+      _handlePointerUp: (event: MouseEvent) => void;
+    }
+  )._handlePointerUp.call(receiver, event);
+
+const buildReceiver = (
+  activeTask: TaskWithSubTasks | null,
+): {
+  receiver: MagicSideNavComponent;
+  moveToProject: jasmine.Spy;
+  addToToday: jasmine.Spy;
+  updateTags: jasmine.Spy;
+  setCancelNextDrop: jasmine.Spy;
+  setActiveTask: jasmine.Spy;
+} => {
+  const moveToProject = jasmine.createSpy('moveToProject');
+  const addToToday = jasmine.createSpy('addToToday');
+  const updateTags = jasmine.createSpy('updateTags');
+  const setCancelNextDrop = jasmine.createSpy('setCancelNextDrop');
+  const setActiveTask = jasmine.createSpy('setActiveTask');
+
+  const receiver = Object.assign(Object.create(MagicSideNavComponent.prototype), {
+    _taskService: {
+      moveToProject,
+      addToToday,
+      updateTags,
+    },
+    _externalDragService: {
+      activeTask: () => activeTask,
+      activeDragRef: () => ({ ended: of(undefined) }),
+      setCancelNextDrop,
+      setActiveTask,
+    },
+  }) as MagicSideNavComponent;
+
+  return {
+    receiver,
+    moveToProject,
+    addToToday,
+    updateTags,
+    setCancelNextDrop,
+    setActiveTask,
+  };
+};
+
+// getPointerPosition() just reads clientX/clientY off a MouseEvent.
+const pointerUpEvent = (): MouseEvent => ({ clientX: 5, clientY: 5 }) as MouseEvent;
+
+// Mounts a detached <nav-item> so document.elementFromPoint(...).closest('nav-item')
+// resolves to it, same technique as TaskListComponent's enterPredicate specs.
+const withNavItem = (attrName: string, attrValue: string, run: () => void): void => {
+  const navItem = document.createElement('nav-item');
+  navItem.setAttribute(attrName, attrValue);
+  document.body.appendChild(navItem);
+  spyOn(document, 'elementFromPoint').and.returnValue(navItem);
+  try {
+    run();
+  } finally {
+    navItem.remove();
+  }
+};
+
+describe('MagicSideNavComponent._handlePointerUp', () => {
+  describe('dropping on a project', () => {
+    it('moves a recurring task to the project (#8739)', () => {
+      const task = createTask({
+        id: 't1',
+        dueWithTime: Date.now(),
+        repeatCfgId: 'repeat-1',
+      }) as unknown as TaskWithSubTasks;
+      const { receiver, moveToProject, setCancelNextDrop } = buildReceiver(task);
+
+      withNavItem('data-project-id', 'project-1', () => {
+        callHandlePointerUp(receiver, pointerUpEvent());
+      });
+
+      expect(setCancelNextDrop).toHaveBeenCalledWith(true);
+      expect(moveToProject).toHaveBeenCalledWith(task, 'project-1');
+    });
+
+    it('moves a non-recurring task to the project', () => {
+      const task = createTask({ id: 't2' }) as unknown as TaskWithSubTasks;
+      const { receiver, moveToProject } = buildReceiver(task);
+
+      withNavItem('data-project-id', 'project-1', () => {
+        callHandlePointerUp(receiver, pointerUpEvent());
+      });
+
+      expect(moveToProject).toHaveBeenCalledWith(task, 'project-1');
+    });
+
+    it('does not move a subtask dropped on a project', () => {
+      const task = createTask({
+        id: 'sub1',
+        parentId: 'parent1',
+      }) as unknown as TaskWithSubTasks;
+      const { receiver, moveToProject } = buildReceiver(task);
+
+      withNavItem('data-project-id', 'project-1', () => {
+        callHandlePointerUp(receiver, pointerUpEvent());
+      });
+
+      expect(moveToProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dropping on a tag', () => {
+    it('does not move/tag a recurring task (due-date reschedule conflicts with its repeat)', () => {
+      const task = createTask({
+        id: 't1',
+        repeatCfgId: 'repeat-1',
+        tagIds: [],
+      }) as unknown as TaskWithSubTasks;
+      const { receiver, addToToday, updateTags } = buildReceiver(task);
+
+      withNavItem('data-tag-id', 'tag-1', () => {
+        callHandlePointerUp(receiver, pointerUpEvent());
+      });
+
+      expect(addToToday).not.toHaveBeenCalled();
+      expect(updateTags).not.toHaveBeenCalled();
+    });
+
+    it('adds the tag to a non-recurring task', () => {
+      const task = createTask({
+        id: 't2',
+        tagIds: [],
+      }) as unknown as TaskWithSubTasks;
+      const { receiver, updateTags } = buildReceiver(task);
+
+      withNavItem('data-tag-id', 'tag-1', () => {
+        callHandlePointerUp(receiver, pointerUpEvent());
+      });
+
+      expect(updateTags).toHaveBeenCalledWith(task, ['tag-1']);
+    });
+  });
+
+  it('does nothing when there is no active dragged task', () => {
+    const { receiver, moveToProject, addToToday, updateTags } = buildReceiver(null);
+
+    withNavItem('data-project-id', 'project-1', () => {
+      callHandlePointerUp(receiver, pointerUpEvent());
+    });
+
+    expect(moveToProject).not.toHaveBeenCalled();
+    expect(addToToday).not.toHaveBeenCalled();
+    expect(updateTags).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -671,8 +671,7 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
   private _handlePointerUp(event: MouseEvent | TouchEvent): void {
     const draggedTask = this._externalDragService.activeTask();
 
-    // exclude recurring tasks
-    if (!draggedTask || draggedTask.repeatCfgId) {
+    if (!draggedTask) {
       return;
     }
 
@@ -713,6 +712,14 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
         this._taskService.moveToProject(draggedTask, projectId!);
       });
     } else if (navItemElement.hasAttribute('data-tag-id')) {
+      // Exclude recurring tasks from tag drops: the "Today" tag branch below
+      // reschedules the task's due date, which conflicts with its own repeat
+      // scheduling. Project drops (above) don't touch due dates, so they're
+      // unaffected by this.
+      if (draggedTask.repeatCfgId) {
+        return;
+      }
+
       // Task is dropped on a tag
       const tagId = navItemElement.getAttribute('data-tag-id');
       Log.debug('Task dropped on Tag', { taskId: draggedTask.id, tagId });

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -709,13 +709,15 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
       // if the dom element is removed before the return animation has finished
       const dragref = this._externalDragService.activeDragRef();
       dragref?.ended.pipe(take(1)).subscribe(() => {
-        this._taskService.moveToProject(draggedTask, projectId!);
+        this._taskService
+          .moveTaskToProjectWithRepeatCfgAwareness$(draggedTask, projectId!)
+          .subscribe();
       });
     } else if (navItemElement.hasAttribute('data-tag-id')) {
-      // Exclude recurring tasks from tag drops: the "Today" tag branch below
-      // reschedules the task's due date, which conflicts with its own repeat
-      // scheduling. Project drops (above) don't touch due dates, so they're
-      // unaffected by this.
+      // Exclude recurring tasks from all tag drops, not just "Today": this
+      // conservatively preserves prior behavior (recurring tasks were never
+      // tag-dropped here) rather than assuming untested paths are safe. A
+      // non-Today tag drop just adds/removes a tag via updateTags below.
       if (draggedTask.repeatCfgId) {
         return;
       }

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.spec.ts
@@ -15,7 +15,7 @@ import { WorkContextService } from '../../../work-context/work-context.service';
 import { TaskFocusService } from '../../task-focus.service';
 import { LocaleDatePipe } from 'src/app/ui/pipes/locale-date.pipe';
 import { DateAdapter } from '@angular/material/core';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 import { selectTaskByIdWithSubTaskData } from '../../store/task.selectors';
 import { addSubTask } from '../../store/task.actions';
 import { TaskSharedActions } from '../../../../root-store/meta/task-shared.actions';
@@ -55,9 +55,7 @@ describe('TaskContextMenuInnerComponent', () => {
       'add',
       'createNewTaskWithDefaults',
       'currentTaskId',
-      'moveToProject',
-      'getTasksWithSubTasksByRepeatCfgId$',
-      'getArchiveTasksForRepeatCfgId',
+      'moveTaskToProjectWithRepeatCfgAwareness$',
     ]);
     taskService.currentTaskId.and.returnValue('some-id');
     addSubtaskInputService = jasmine.createSpyObj<AddSubtaskInputService>(
@@ -400,39 +398,29 @@ describe('TaskContextMenuInnerComponent', () => {
     });
   });
 
-  // #8715: a task can reference a repeat config that was already deleted (e.g.
-  // via cross-client sync). Moving it must not throw ('Missing taskRepeatCfg')
-  // and crash — it should fall back to a plain task move.
-  describe('moveTaskToProject() with a deleted repeat config (#8715)', () => {
-    it('falls back to a plain move instead of crashing on the missing config', fakeAsync(() => {
+  // The recurring-aware move logic (incl. the #8715 deleted-config fallback)
+  // lives in TaskService.moveTaskToProjectWithRepeatCfgAwareness$ and is tested
+  // in task.service.spec.ts; here we only verify the delegation.
+  describe('moveTaskToProject()', () => {
+    it('delegates to the shared repeat-cfg-aware move', fakeAsync(() => {
       const taskWithRepeat = {
         ...DEFAULT_TASK,
         id: 'task-repeat',
         title: 'Repeat Task',
         projectId: 'project-current',
-        repeatCfgId: 'deleted-cfg',
+        repeatCfgId: 'cfg-1',
       } as Task;
       component.task = taskWithRepeat;
 
       const taskWithSubTasks = { ...taskWithRepeat, subTasks: [] } as any;
       store.overrideSelector(selectTaskByIdWithSubTaskData, taskWithSubTasks);
-      // config resolves to undefined (deleted); the other repeat lookups still run
-      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(
-        of([taskWithSubTasks]),
-      );
-      taskService.getArchiveTasksForRepeatCfgId.and.returnValue(Promise.resolve([]));
-      // guard against regressing to the throwing selector (the #8715 root cause)
-      const repeatCfgService = TestBed.inject(TaskRepeatCfgService);
-      (
-        repeatCfgService as unknown as { getTaskRepeatCfgById$: () => unknown }
-      ).getTaskRepeatCfgById$ = () =>
-        throwError(() => new Error('Missing taskRepeatCfg'));
+      taskService.moveTaskToProjectWithRepeatCfgAwareness$.and.returnValue(of('moved'));
 
       component.moveTaskToProject('project-b');
       tick(50); // _getTaskWithSubtasks delay(50)
       flush(); // focusRelatedTaskOrNext setTimeout
 
-      expect(taskService.moveToProject).toHaveBeenCalledWith(
+      expect(taskService.moveTaskToProjectWithRepeatCfgAwareness$).toHaveBeenCalledWith(
         taskWithSubTasks,
         'project-b',
       );

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.ts
@@ -23,10 +23,9 @@ import {
 } from '@angular/material/menu';
 import { MatDivider } from '@angular/material/divider';
 import { ESTIMATE_OPTIONS } from '../../add-task-bar/add-task-bar.const';
-import { Task, TaskCopy, TaskWithSubTasks } from '../../task.model';
-import { EMPTY, forkJoin, from, Observable, of, ReplaySubject, Subject } from 'rxjs';
+import { Task, TaskWithSubTasks } from '../../task.model';
+import { from, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import {
-  concatMap,
   delay,
   distinctUntilChanged,
   first,
@@ -34,16 +33,14 @@ import {
   switchMap,
   take,
   takeUntil,
-  tap,
 } from 'rxjs/operators';
 import { Project } from '../../../project/project.model';
 import { TaskService } from '../../task.service';
-import { TaskRepeatCfgService } from '../../../task-repeat-cfg/task-repeat-cfg.service';
 import { MatDialog } from '@angular/material/dialog';
 import { IssueService } from '../../../issue/issue.service';
 import { SnackService } from '../../../../core/snack/snack.service';
 import { ProjectService } from '../../../project/project.service';
-import { _MISSING_PROJECT_, DEFAULT_PROJECT_ICON } from '../../../project/project.const';
+import { DEFAULT_PROJECT_ICON } from '../../../project/project.const';
 import { WorkContextService } from '../../../work-context/work-context.service';
 import { GlobalConfigService } from '../../../config/global-config.service';
 import { KeyboardConfig } from '@sp/keyboard-config';
@@ -52,7 +49,6 @@ import { DialogDeadlineComponent } from '../../dialog-deadline/dialog-deadline.c
 import { DialogTimeEstimateComponent } from '../../dialog-time-estimate/dialog-time-estimate.component';
 import { throttle } from '../../../../util/decorators';
 import { DialogConfirmComponent } from '../../../../ui/dialog-confirm/dialog-confirm.component';
-import { Update } from '@ngrx/entity';
 import { isTouchActive } from 'src/app/util/input-intent';
 import { T } from 'src/app/t.const';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -109,7 +105,6 @@ import { AddSubtaskInputService } from '../../add-subtask-input/add-subtask-inpu
 export class TaskContextMenuInnerComponent implements AfterViewInit, OnDestroy {
   private readonly _datePipe = inject(LocaleDatePipe);
   private readonly _taskService = inject(TaskService);
-  private readonly _taskRepeatCfgService = inject(TaskRepeatCfgService);
   private readonly _matDialog = inject(MatDialog);
   private readonly _issueService = inject(IssueService);
   private readonly _elementRef = inject(ElementRef);
@@ -575,110 +570,14 @@ export class TaskContextMenuInnerComponent implements AfterViewInit, OnDestroy {
       });
   }
 
-  // TODO move to service
   async moveTaskToProject(projectId: string): Promise<void> {
     if (projectId === this.task.projectId) {
       return;
-    } else if (!this.task.repeatCfgId) {
-      const taskWithSubTasks = await this._getTaskWithSubtasks();
-      this._taskService.moveToProject(taskWithSubTasks, projectId);
-      this.onClose();
-    } else {
-      const taskWithSubTasks = await this._getTaskWithSubtasks();
-
-      forkJoin([
-        this._taskRepeatCfgService
-          .getTaskRepeatCfgByIdAllowUndefined$(this.task.repeatCfgId)
-          .pipe(first()),
-        this._taskService
-          .getTasksWithSubTasksByRepeatCfgId$(this.task.repeatCfgId)
-          .pipe(first()),
-        this._taskService.getArchiveTasksForRepeatCfgId(this.task.repeatCfgId),
-        this._projectService.getByIdOnce$(projectId),
-      ])
-        .pipe(
-          concatMap(
-            ([
-              reminderCfg,
-              nonArchiveInstancesWithSubTasks,
-              archiveInstances,
-              targetProject,
-            ]) => {
-              TaskLog.log({
-                reminderCfg,
-                nonArchiveInstancesWithSubTasks,
-                archiveInstances,
-              });
-
-              // Repeat config was deleted (e.g. via cross-client sync) but the task
-              // still references it — treat it as a plain task move instead of
-              // crashing on the missing config. (#8715)
-              if (!reminderCfg) {
-                this._taskService.moveToProject(taskWithSubTasks, projectId);
-                this.onClose();
-                return EMPTY;
-              }
-
-              // if there is only a single instance (probably just created) than directly update the task repeat cfg
-              if (
-                nonArchiveInstancesWithSubTasks.length === 1 &&
-                archiveInstances.length === 0
-              ) {
-                this._taskRepeatCfgService.updateTaskRepeatCfg(reminderCfg.id, {
-                  projectId,
-                });
-                this._taskService.moveToProject(taskWithSubTasks, projectId);
-                this.onClose();
-                return EMPTY;
-              }
-
-              return this._matDialog
-                .open(DialogConfirmComponent, {
-                  data: {
-                    okTxt: T.F.TASK_REPEAT.D_CONFIRM_MOVE_TO_PROJECT.OK,
-                    message: T.F.TASK_REPEAT.D_CONFIRM_MOVE_TO_PROJECT.MSG,
-                    translateParams: {
-                      projectName: targetProject?.title ?? _MISSING_PROJECT_,
-                      tasksNr:
-                        nonArchiveInstancesWithSubTasks.length + archiveInstances.length,
-                    },
-                  },
-                })
-                .afterClosed()
-                .pipe(
-                  tap((isConfirm) => {
-                    if (isConfirm) {
-                      this._taskRepeatCfgService.updateTaskRepeatCfg(reminderCfg.id, {
-                        projectId,
-                      });
-                      nonArchiveInstancesWithSubTasks.forEach((nonArchiveTask) => {
-                        this._taskService.moveToProject(nonArchiveTask, projectId);
-                      });
-
-                      const archiveUpdates: Update<TaskCopy>[] = [];
-                      archiveInstances.forEach((archiveTask) => {
-                        archiveUpdates.push({
-                          id: archiveTask.id,
-                          changes: { projectId },
-                        });
-                        if (archiveTask.subTaskIds.length) {
-                          archiveTask.subTaskIds.forEach((subId) => {
-                            archiveUpdates.push({
-                              id: subId,
-                              changes: { projectId },
-                            });
-                          });
-                        }
-                      });
-                      this._taskService.updateArchiveTasks(archiveUpdates);
-                    }
-                  }),
-                );
-            },
-          ),
-        )
-        .subscribe(() => this.onClose());
     }
+    const taskWithSubTasks = await this._getTaskWithSubtasks();
+    this._taskService
+      .moveTaskToProjectWithRepeatCfgAwareness$(taskWithSubTasks, projectId)
+      .subscribe(() => this.onClose());
   }
 
   moveToBacklog(): void {

--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -544,6 +544,96 @@ describe('TaskService', () => {
     });
   });
 
+  describe('moveTaskToProjectWithRepeatCfgAwareness$', () => {
+    it('updates the repeat cfg projectId and moves the lone instance directly', (done) => {
+      const task = createMockTaskWithSubTasks(
+        createMockTask('task-1', { repeatCfgId: 'repeat-1' }),
+      );
+      const repeatCfg = { id: 'repeat-1', projectId: 'old-project' } as any;
+
+      spyOn(service, 'getTasksWithSubTasksByRepeatCfgId$').and.returnValue(of([task]));
+      spyOn(service, 'getArchiveTasksForRepeatCfgId').and.returnValue(
+        Promise.resolve([]),
+      );
+
+      // TaskRepeatCfgService/ProjectService are resolved lazily (circular DI, see
+      // lazy-inject.ts); patch the lazy getters directly instead of paying for a
+      // full TestBed provider graph for two services this test doesn't otherwise need.
+      const taskRepeatCfgServiceSpy = jasmine.createSpyObj('TaskRepeatCfgService', [
+        'getTaskRepeatCfgByIdAllowUndefined$',
+        'updateTaskRepeatCfg',
+      ]);
+      taskRepeatCfgServiceSpy.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+        of(repeatCfg),
+      );
+      const projectServiceSpy = jasmine.createSpyObj('ProjectService', ['getByIdOnce$']);
+      projectServiceSpy.getByIdOnce$.and.returnValue(
+        of({ id: 'new-project', title: 'New Project' }),
+      );
+      (service as any)._getTaskRepeatCfgService = (): unknown => taskRepeatCfgServiceSpy;
+      (service as any)._getProjectService = (): unknown => projectServiceSpy;
+
+      service
+        .moveTaskToProjectWithRepeatCfgAwareness$(task, 'new-project')
+        .subscribe((result) => {
+          expect(result).toBe('moved');
+          expect(taskRepeatCfgServiceSpy.updateTaskRepeatCfg).toHaveBeenCalledWith(
+            'repeat-1',
+            { projectId: 'new-project' },
+          );
+          expect(store.dispatch).toHaveBeenCalledWith(
+            TaskSharedActions.moveToOtherProject({
+              task,
+              targetProjectId: 'new-project',
+            }),
+          );
+          done();
+        });
+    });
+
+    // #8715: a task can reference a repeat config that was already deleted
+    // (e.g. via cross-client sync). Moving it must not crash — it should fall
+    // back to a plain task move without touching any repeat config.
+    it('falls back to a plain move when the repeat config was deleted (#8715)', (done) => {
+      const task = createMockTaskWithSubTasks(
+        createMockTask('task-1', { repeatCfgId: 'deleted-cfg' }),
+      );
+
+      spyOn(service, 'getTasksWithSubTasksByRepeatCfgId$').and.returnValue(of([task]));
+      spyOn(service, 'getArchiveTasksForRepeatCfgId').and.returnValue(
+        Promise.resolve([]),
+      );
+
+      const taskRepeatCfgServiceSpy = jasmine.createSpyObj('TaskRepeatCfgService', [
+        'getTaskRepeatCfgByIdAllowUndefined$',
+        'updateTaskRepeatCfg',
+      ]);
+      taskRepeatCfgServiceSpy.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+        of(undefined),
+      );
+      const projectServiceSpy = jasmine.createSpyObj('ProjectService', ['getByIdOnce$']);
+      projectServiceSpy.getByIdOnce$.and.returnValue(
+        of({ id: 'new-project', title: 'New Project' }),
+      );
+      (service as any)._getTaskRepeatCfgService = (): unknown => taskRepeatCfgServiceSpy;
+      (service as any)._getProjectService = (): unknown => projectServiceSpy;
+
+      service
+        .moveTaskToProjectWithRepeatCfgAwareness$(task, 'new-project')
+        .subscribe((result) => {
+          expect(result).toBe('moved');
+          expect(taskRepeatCfgServiceSpy.updateTaskRepeatCfg).not.toHaveBeenCalled();
+          expect(store.dispatch).toHaveBeenCalledWith(
+            TaskSharedActions.moveToOtherProject({
+              task,
+              targetProjectId: 'new-project',
+            }),
+          );
+          done();
+        });
+    });
+  });
+
   describe('restoreTask', () => {
     it('should dispatch restoreTask', () => {
       const task = createMockTask('task-1');

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -1,9 +1,16 @@
 import { nanoid } from 'nanoid';
 import typia from 'typia';
-import { distinctUntilChanged, first, map, take, withLatestFrom } from 'rxjs/operators';
-import { computed, effect, inject, Injectable, untracked } from '@angular/core';
+import {
+  concatMap,
+  distinctUntilChanged,
+  first,
+  map,
+  take,
+  withLatestFrom,
+} from 'rxjs/operators';
+import { computed, effect, inject, Injectable, Injector, untracked } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Observable } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
 import {
   ArchiveTask,
   DEFAULT_TASK,
@@ -97,7 +104,7 @@ import { TaskArchiveService } from '../archive/task-archive.service';
 import { TODAY_TAG } from '../tag/tag.const';
 import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 import { getDbDateStr, isDBDateStr } from '../../util/get-db-date-str';
-import { INBOX_PROJECT } from '../project/project.const';
+import { INBOX_PROJECT, _MISSING_PROJECT_ } from '../project/project.const';
 import { GlobalConfigService } from '../config/global-config.service';
 import { TaskLog } from '../../core/log';
 import { devError } from '../../util/dev-error';
@@ -106,6 +113,12 @@ import { TaskFocusService } from './task-focus.service';
 import { DeletedTaskIssueSidecarService } from '../issue/two-way-sync/deleted-task-issue-sidecar.service';
 import { TimeBlockDeleteSidecarService } from '../calendar-integration/time-block/time-block-delete-sidecar.service';
 import { getDeadlineAutoPlanFields } from './util/get-deadline-auto-plan-fields';
+import { MatDialog } from '@angular/material/dialog';
+import { DialogConfirmComponent } from '../../ui/dialog-confirm/dialog-confirm.component';
+import { ProjectService } from '../project/project.service';
+import { TaskRepeatCfgService } from '../task-repeat-cfg/task-repeat-cfg.service';
+import { lazyInject } from '../../util/lazy-inject';
+import { T } from '../../t.const';
 
 @Injectable({
   providedIn: 'root',
@@ -123,6 +136,15 @@ export class TaskService {
   private readonly _taskFocusService = inject(TaskFocusService);
   private readonly _deletedTaskIssueSidecar = inject(DeletedTaskIssueSidecarService);
   private readonly _timeBlockDeleteSidecar = inject(TimeBlockDeleteSidecarService);
+  private readonly _matDialog = inject(MatDialog);
+  // ProjectService and TaskRepeatCfgService both inject TaskService, so they
+  // are resolved lazily here to break the circular dependency (see lazy-inject.ts).
+  private readonly _injector = inject(Injector);
+  private readonly _getProjectService = lazyInject(this._injector, ProjectService);
+  private readonly _getTaskRepeatCfgService = lazyInject(
+    this._injector,
+    TaskRepeatCfgService,
+  );
 
   currentTaskId$: Observable<string | null> = this._store.pipe(
     select(selectCurrentTaskId),
@@ -985,6 +1007,126 @@ export class TaskService {
     }
     this._store.dispatch(
       TaskSharedActions.moveToOtherProject({ task, targetProjectId: projectId }),
+    );
+  }
+
+  /**
+   * Moves a task to another project, taking recurring tasks into account.
+   *
+   * A plain (non-recurring) task is just moved. A recurring task (has
+   * `repeatCfgId`) additionally updates the repeat config's `projectId`
+   * (so future occurrences spawn in the new project) and moves the other
+   * existing instances of that config (both present and archived). If more
+   * than one instance exists, the user is asked to confirm via a
+   * `D_CONFIRM_MOVE_TO_PROJECT` dialog first; a lone instance (e.g. one
+   * that was just created) is moved directly without prompting.
+   *
+   * @param task the task (with sub tasks) to move
+   * @param projectId the target project id
+   * @returns an observable that emits once the flow concludes:
+   * - `'moved'` when the task was moved directly, without showing a dialog
+   * - `'confirmed'` when a dialog was shown and the move was confirmed
+   * - `'cancelled'` when a dialog was shown and the move was cancelled
+   */
+  moveTaskToProjectWithRepeatCfgAwareness$(
+    task: TaskWithSubTasks,
+    projectId: string,
+  ): Observable<'moved' | 'confirmed' | 'cancelled'> {
+    if (!task.repeatCfgId) {
+      this.moveToProject(task, projectId);
+      return of('moved');
+    }
+
+    const repeatCfgId = task.repeatCfgId;
+    return forkJoin([
+      this._getTaskRepeatCfgService()
+        .getTaskRepeatCfgByIdAllowUndefined$(repeatCfgId)
+        .pipe(first()),
+      this.getTasksWithSubTasksByRepeatCfgId$(repeatCfgId).pipe(first()),
+      this.getArchiveTasksForRepeatCfgId(repeatCfgId),
+      this._getProjectService().getByIdOnce$(projectId),
+    ]).pipe(
+      concatMap(
+        ([
+          reminderCfg,
+          nonArchiveInstancesWithSubTasks,
+          archiveInstances,
+          targetProject,
+        ]) => {
+          TaskLog.log({
+            reminderCfg,
+            nonArchiveInstancesWithSubTasks,
+            archiveInstances,
+          });
+
+          // Repeat config was deleted (e.g. via cross-client sync) but the task
+          // still references it — treat it as a plain task move instead of
+          // crashing on the missing config. (#8715)
+          if (!reminderCfg) {
+            this.moveToProject(task, projectId);
+            return of('moved' as const);
+          }
+
+          // if there is only a single instance (probably just created) than directly update the task repeat cfg
+          if (
+            nonArchiveInstancesWithSubTasks.length === 1 &&
+            archiveInstances.length === 0
+          ) {
+            this._getTaskRepeatCfgService().updateTaskRepeatCfg(reminderCfg.id, {
+              projectId,
+            });
+            this.moveToProject(task, projectId);
+            return of('moved' as const);
+          }
+
+          return this._matDialog
+            .open(DialogConfirmComponent, {
+              data: {
+                okTxt: T.F.TASK_REPEAT.D_CONFIRM_MOVE_TO_PROJECT.OK,
+                message: T.F.TASK_REPEAT.D_CONFIRM_MOVE_TO_PROJECT.MSG,
+                translateParams: {
+                  projectName: targetProject?.title ?? _MISSING_PROJECT_,
+                  tasksNr:
+                    nonArchiveInstancesWithSubTasks.length + archiveInstances.length,
+                },
+              },
+            })
+            .afterClosed()
+            .pipe(
+              map((isConfirm) => {
+                if (!isConfirm) {
+                  return 'cancelled' as const;
+                }
+
+                this._getTaskRepeatCfgService().updateTaskRepeatCfg(reminderCfg.id, {
+                  projectId,
+                });
+                nonArchiveInstancesWithSubTasks.forEach((nonArchiveTask) => {
+                  this.moveToProject(nonArchiveTask, projectId);
+                });
+
+                const archiveUpdates: Update<TaskCopy>[] = [];
+                archiveInstances.forEach((archiveTask) => {
+                  archiveUpdates.push({
+                    id: archiveTask.id,
+                    changes: { projectId },
+                  });
+                  if (archiveTask.subTaskIds.length) {
+                    archiveTask.subTaskIds.forEach((subId) => {
+                      archiveUpdates.push({
+                        id: subId,
+                        changes: { projectId },
+                      });
+                    });
+                  }
+                });
+                this.updateArchiveTasks(archiveUpdates);
+
+                return 'confirmed' as const;
+              }),
+            );
+        },
+      ),
     );
   }
 

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -16,7 +16,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { TaskService } from '../task.service';
-import { EMPTY, forkJoin, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import {
   HideSubTasksMode,
   SubmitTrigger,
@@ -35,7 +35,6 @@ import {
   getChecklistProgress,
 } from '../../markdown-checklist/get-checklist-progress';
 import { GlobalConfigService } from '../../config/global-config.service';
-import { concatMap, first, tap } from 'rxjs/operators';
 import { DoneToggleComponent } from '../../../ui/done-toggle/done-toggle.component';
 import { SwipeBlockComponent } from '../../../ui/swipe-block/swipe-block.component';
 import {
@@ -47,7 +46,7 @@ import { TaskAttachmentService } from '../task-attachment/task-attachment.servic
 import { DialogEditTaskAttachmentComponent } from '../task-attachment/dialog-edit-attachment/dialog-edit-task-attachment.component';
 import { ProjectService } from '../../project/project.service';
 import { Project } from '../../project/project.model';
-import { _MISSING_PROJECT_, DEFAULT_PROJECT_ICON } from '../../project/project.const';
+import { DEFAULT_PROJECT_ICON } from '../../project/project.const';
 import { T } from '../../../t.const';
 import {
   MatMenu,
@@ -57,11 +56,9 @@ import {
 } from '@angular/material/menu';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { throttle } from '../../../util/decorators';
-import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
 import { openFullscreenMarkdownDialog } from '../../../ui/dialog-fullscreen-markdown/open-fullscreen-markdown-dialog';
 import { Location } from '@angular/common';
-import { Update } from '@ngrx/entity';
 import { DateAdapter } from '@angular/material/core';
 import { getDbDateStr, isDBDateStr } from '../../../util/get-db-date-str';
 import { combineDateAndTime } from '../../../util/combine-date-and-time';
@@ -167,7 +164,6 @@ import { AddSubtaskInputService } from '../add-subtask-input/add-subtask-input.s
 })
 export class TaskComponent implements OnDestroy, AfterViewInit {
   private readonly _taskService = inject(TaskService);
-  private readonly _taskRepeatCfgService = inject(TaskRepeatCfgService);
   private readonly _matDialog = inject(MatDialog);
   private readonly _location = inject(Location);
   private readonly _configService = inject(GlobalConfigService);
@@ -1249,107 +1245,23 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     this._taskService.updateTags(this.task(), tagIds);
   }
 
-  // TODO extract so service
   moveTaskToProject(projectId: string): void {
     const t = this.task();
     if (projectId === t.projectId) {
       return;
-    } else if (!t.repeatCfgId) {
-      this._taskService.moveToProject(t, projectId);
-      setTimeout(() => this.focusNext(true));
-    } else {
-      forkJoin([
-        this._taskRepeatCfgService
-          .getTaskRepeatCfgByIdAllowUndefined$(t.repeatCfgId)
-          .pipe(first()),
-        this._taskService.getTasksWithSubTasksByRepeatCfgId$(t.repeatCfgId).pipe(first()),
-        this._taskService.getArchiveTasksForRepeatCfgId(t.repeatCfgId),
-        this._projectService.getByIdOnce$(projectId),
-      ])
-        .pipe(
-          concatMap(
-            ([
-              reminderCfg,
-              nonArchiveInstancesWithSubTasks,
-              archiveInstances,
-              targetProject,
-            ]) => {
-              TaskLog.log({
-                reminderCfg,
-                nonArchiveInstancesWithSubTasks,
-                archiveInstances,
-              });
-
-              // Repeat config was deleted (e.g. via cross-client sync) but the task
-              // still references it — treat it as a plain task move instead of
-              // crashing on the missing config. (#8715)
-              if (!reminderCfg) {
-                this._taskService.moveToProject(this.task(), projectId);
-                setTimeout(() => this.focusNext(true));
-                return EMPTY;
-              }
-
-              // if there is only a single instance (probably just created) than directly update the task repeat cfg
-              if (
-                nonArchiveInstancesWithSubTasks.length === 1 &&
-                archiveInstances.length === 0
-              ) {
-                this._taskRepeatCfgService.updateTaskRepeatCfg(reminderCfg.id, {
-                  projectId,
-                });
-                this._taskService.moveToProject(this.task(), projectId);
-                setTimeout(() => this.focusNext(true));
-                return EMPTY;
-              }
-
-              return this._matDialog
-                .open(DialogConfirmComponent, {
-                  data: {
-                    okTxt: T.F.TASK_REPEAT.D_CONFIRM_MOVE_TO_PROJECT.OK,
-                    message: T.F.TASK_REPEAT.D_CONFIRM_MOVE_TO_PROJECT.MSG,
-                    translateParams: {
-                      projectName: targetProject?.title ?? _MISSING_PROJECT_,
-                      tasksNr:
-                        nonArchiveInstancesWithSubTasks.length + archiveInstances.length,
-                    },
-                  },
-                })
-                .afterClosed()
-                .pipe(
-                  tap((isConfirm) => {
-                    if (isConfirm) {
-                      this._taskRepeatCfgService.updateTaskRepeatCfg(reminderCfg.id, {
-                        projectId,
-                      });
-                      nonArchiveInstancesWithSubTasks.forEach((nonArchiveTask) => {
-                        this._taskService.moveToProject(nonArchiveTask, projectId);
-                      });
-
-                      const archiveUpdates: Update<TaskCopy>[] = [];
-                      archiveInstances.forEach((archiveTask) => {
-                        archiveUpdates.push({
-                          id: archiveTask.id,
-                          changes: { projectId },
-                        });
-                        if (archiveTask.subTaskIds.length) {
-                          archiveTask.subTaskIds.forEach((subId) => {
-                            archiveUpdates.push({
-                              id: subId,
-                              changes: { projectId },
-                            });
-                          });
-                        }
-                      });
-                      this._taskService.updateArchiveTasks(archiveUpdates);
-                      setTimeout(() => this.focusNext(true));
-                    }
-                  }),
-                );
-            },
-          ),
-        )
-        .subscribe(() => this.focusSelf());
     }
+    this._taskService
+      .moveTaskToProjectWithRepeatCfgAwareness$(t, projectId)
+      .subscribe((result) => {
+        if (result === 'cancelled') {
+          this.focusSelf();
+          return;
+        }
+        if (result === 'confirmed') {
+          this.focusSelf();
+        }
+        setTimeout(() => this.focusNext(true));
+      });
   }
 
   moveToBacklog(): void {


### PR DESCRIPTION
## Problem

Dragging a **recurring** task from the task list onto a project in the sidebar silently does nothing: `_handlePointerUp` in `magic-side-nav.component.ts` has a blanket early return for any task with a `repeatCfgId`, which discards project drops along with tag drops.

Fixes #8739

## Solution

Move the `repeatCfgId` exclusion from the top of `_handlePointerUp` down into the tag-drop branch, which is the only path that needs it (the Today-tag branch reschedules the task's due date, which conflicts with repeat scheduling). Project moves never touch scheduling fields, so recurring tasks can now be dropped onto sidebar projects like any other task.

Added a `magic-side-nav.component.spec.ts` covering: regular + recurring task dropped on a project (both move), recurring task dropped on a tag (still excluded), regular task dropped on a tag (still works).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
