### PR TITLE
refactor(schedule): centralize logical-day bucketing and visible-day generation

### DIFF
--- a/src/app/features/planner/planner.service.ts
+++ b/src/app/features/planner/planner.service.ts
@@ -12,6 +12,7 @@ import { GlobalTrackingIntervalService } from '../../core/global-tracking-interv
 import { selectTodayTaskIds } from '../work-context/store/work-context.selectors';
 import { msToString } from '../../ui/duration/ms-to-string.pipe';
 import { getDbDateStr } from '../../util/get-db-date-str';
+import { getVisibleDaySequence } from '../../util/get-visible-day-sequence';
 import { parseDbDateStr } from '../../util/parse-db-date-str';
 import { getDiffInDays } from '../../util/get-diff-in-days';
 import { selectActiveTaskRepeatCfgs } from '../task-repeat-cfg/store/task-repeat-cfg.selectors';
@@ -66,32 +67,8 @@ export class PlannerService {
   ]).pipe(
     tap(([count, todayStr]) => Log.log('daysToShow$', { count, todayStr })),
     map(([count, _, includedWeekDays]) => {
-      // Guard against empty includedWeekDays to prevent infinite loop
-      if (includedWeekDays.length === 0) {
-        return [];
-      }
-
       const today = new Date().getTime();
-      const daysToShow: string[] = [];
-
-      // CRITICAL FIX: Loop until we have the required count of days
-      // (not just iterate N times which produces fewer days if weekends are excluded)
-      let daysAdded = 0;
-      let offset = 0;
-      while (daysAdded < count) {
-        // eslint-disable-next-line no-mixed-operators
-        const dayOfWeek = new Date(today + offset * 24 * 60 * 60 * 1000).getDay();
-        if (includedWeekDays.includes(dayOfWeek)) {
-          daysToShow.push(
-            // eslint-disable-next-line no-mixed-operators
-            this._dateService.todayStr(today + offset * 24 * 60 * 60 * 1000),
-          );
-          daysAdded++;
-        }
-        offset++;
-      }
-
-      return daysToShow;
+      return getVisibleDaySequence(today, count, includedWeekDays);
     }),
   );
 

--- a/src/app/features/planner/store/planner.selectors.ts
+++ b/src/app/features/planner/store/planner.selectors.ts
@@ -23,7 +23,7 @@ import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clo
 import { isValidSplitTime } from '../../../util/is-valid-split-time';
 import { devError } from '../../../util/dev-error';
 import { getTimeLeftForTask } from '../../../util/get-time-left-for-task';
-import { getDbDateStr } from '../../../util/get-db-date-str';
+import { getDbDateStrWithOffset } from '../../../util/get-db-date-str';
 import { ScheduleCalendarMapEntry } from '../../schedule/schedule.model';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { calculateAvailableHours } from '../util/calculate-available-hours';
@@ -349,7 +349,7 @@ const getScheduledTaskItems = (
   allPlannedTasks
     .filter(
       (task) =>
-        getDbDateStr(new Date(task.dueWithTime - startOfNextDayDiffMs)) === dayDate,
+        getDbDateStrWithOffset(task.dueWithTime, startOfNextDayDiffMs) === dayDate,
     )
     .map((task) => {
       const start = task.dueWithTime;
@@ -383,7 +383,7 @@ const getIcalEventsForDay = (
   calendarEvents.forEach((icalMapEntry) => {
     icalMapEntry.items.forEach((calEv) => {
       const start = calEv.start;
-      if (getDbDateStr(new Date(start - startOfNextDayDiffMs)) === dayDate) {
+      if (getDbDateStrWithOffset(start, startOfNextDayDiffMs) === dayDate) {
         if (isAllDayCalendarEvent(calEv)) {
           // Some providers expose all-day events as 24h timed events.
           allDayEvents.push({ ...calEv, isAllDay: true });
@@ -420,7 +420,7 @@ const groupDeadlineTasksByDay = (
 
     let dayKey: string | undefined;
     if (task.deadlineWithTime) {
-      dayKey = getDbDateStr(new Date(task.deadlineWithTime - startOfNextDayDiffMs));
+      dayKey = getDbDateStrWithOffset(task.deadlineWithTime, startOfNextDayDiffMs);
     } else if (task.deadlineDay) {
       dayKey = task.deadlineDay;
     }

--- a/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
+++ b/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
@@ -35,67 +35,31 @@ export const createScheduleDays = (
   realNow?: number, // Actual current time for determining "current week"
 ): ScheduleDay[] => {
   let viewEntriesPushedToNextDay: SVEEntryForNextDay[];
-  let flowTasksLeftAfterDay: ScheduleFlowTask[] = nonScheduledTasks.map((task) => {
-    if (task.timeEstimate === 0 && task.timeSpent === 0) {
-      return {
-        ...task,
-        timeEstimate: SCHEDULE_TASK_MIN_DURATION_IN_MS,
-      };
-    }
-    return task;
-  });
+  let flowTasksLeftAfterDay: ScheduleFlowTask[] =
+    normalizeZeroEstimateTasks(nonScheduledTasks);
   let beyondBudgetTasks: ScheduleFlowTask[];
 
   // Calculate current week boundary (today + next 6 days = 7 days total)
   // Always use real current time to determine what "current week" means
   const actualNow = realNow ?? now;
-  const todayMidnight = new Date(actualNow);
-  todayMidnight.setHours(0, 0, 0, 0);
-  const todayStart = todayMidnight.getTime();
-  const currentWeekEnd = new Date(todayMidnight);
-  currentWeekEnd.setDate(currentWeekEnd.getDate() + 7);
-  const currentWeekEndTime = currentWeekEnd.getTime();
+  const { todayStart, currentWeekEndTime } = getCurrentWeekBoundary(actualNow);
 
-  // Check if the first day is within the current week
-  // If not, filter out unscheduled tasks before processing any days
-  if (dayDates.length > 0) {
-    const firstDayDate = dateStrToUtcDate(dayDates[0]);
-    firstDayDate.setHours(0, 0, 0, 0);
-    const firstDayStartTime = firstDayDate.getTime();
-    const isFirstDayInCurrentWeek =
-      firstDayStartTime >= todayStart && firstDayStartTime < currentWeekEndTime;
-
-    if (!isFirstDayInCurrentWeek) {
-      // Viewing a week outside the current week
-      // Filter out tasks that don't belong in this week
-      flowTasksLeftAfterDay = flowTasksLeftAfterDay.filter((task) =>
-        isTaskOnOrAfterDay(task, firstDayStartTime),
-      );
-    }
-  }
+  flowTasksLeftAfterDay = filterTasksOutsideFirstVisibleWeek(
+    flowTasksLeftAfterDay,
+    dayDates,
+    todayStart,
+    currentWeekEndTime,
+  );
 
   const v: ScheduleDay[] = dayDates.map((dayDate, i) => {
-    const nextDayStartDate = dateStrToUtcDate(dayDate);
-    nextDayStartDate.setHours(24, 0, 0, 0);
-    const nextDayStart = nextDayStartDate.getTime();
-    const dayStartDate = dateStrToUtcDate(dayDate);
-    dayStartDate.setHours(0, 0, 0, 0);
-    const dayStartTime = dayStartDate.getTime();
-
-    // Check if this day is within the current week (today through next 6 days)
-    const isInCurrentWeek =
-      dayStartTime >= todayStart && dayStartTime < currentWeekEndTime;
-
-    let startTime = i == 0 ? now : dayStartTime;
-    if (workStartEndCfg) {
-      const startTimeToday = getDateTimeFromClockString(
-        workStartEndCfg.startTime,
-        dateStrToUtcDate(dayDate),
-      );
-      if (startTimeToday > now) {
-        startTime = startTimeToday;
-      }
-    }
+    const { nextDayStart, dayStartTime, isInCurrentWeek, startTime } = getDayTiming(
+      dayDate,
+      i,
+      now,
+      workStartEndCfg,
+      todayStart,
+      currentWeekEndTime,
+    );
 
     const nonScheduledRepeatCfgsDueOnDay = selectTaskRepeatCfgsForExactDay.projector(
       unScheduledTaskRepeatCfgs,
@@ -288,6 +252,90 @@ export const createScheduleDays = (
   });
 
   return v;
+};
+
+const normalizeZeroEstimateTasks = (tasks: TaskWithoutReminder[]): ScheduleFlowTask[] =>
+  tasks.map((task) => {
+    if (task.timeEstimate === 0 && task.timeSpent === 0) {
+      return {
+        ...task,
+        timeEstimate: SCHEDULE_TASK_MIN_DURATION_IN_MS,
+      };
+    }
+    return task;
+  });
+
+const getCurrentWeekBoundary = (
+  actualNow: number,
+): { todayStart: number; currentWeekEndTime: number } => {
+  const todayMidnight = new Date(actualNow);
+  todayMidnight.setHours(0, 0, 0, 0);
+  const todayStart = todayMidnight.getTime();
+  const currentWeekEnd = new Date(todayMidnight);
+  currentWeekEnd.setDate(currentWeekEnd.getDate() + 7);
+  return { todayStart, currentWeekEndTime: currentWeekEnd.getTime() };
+};
+
+// Check if the first day is within the current week.
+// If not, filter out unscheduled tasks before processing any days.
+const filterTasksOutsideFirstVisibleWeek = (
+  flowTasks: ScheduleFlowTask[],
+  dayDates: string[],
+  todayStart: number,
+  currentWeekEndTime: number,
+): ScheduleFlowTask[] => {
+  if (dayDates.length === 0) {
+    return flowTasks;
+  }
+  const firstDayDate = dateStrToUtcDate(dayDates[0]);
+  firstDayDate.setHours(0, 0, 0, 0);
+  const firstDayStartTime = firstDayDate.getTime();
+  const isFirstDayInCurrentWeek =
+    firstDayStartTime >= todayStart && firstDayStartTime < currentWeekEndTime;
+
+  if (isFirstDayInCurrentWeek) {
+    return flowTasks;
+  }
+  // Viewing a week outside the current week: filter out tasks that don't
+  // belong in this week.
+  return flowTasks.filter((task) => isTaskOnOrAfterDay(task, firstDayStartTime));
+};
+
+const getDayTiming = (
+  dayDate: string,
+  i: number,
+  now: number,
+  workStartEndCfg: ScheduleWorkStartEndCfg | undefined,
+  todayStart: number,
+  currentWeekEndTime: number,
+): {
+  nextDayStart: number;
+  dayStartTime: number;
+  isInCurrentWeek: boolean;
+  startTime: number;
+} => {
+  const nextDayStartDate = dateStrToUtcDate(dayDate);
+  nextDayStartDate.setHours(24, 0, 0, 0);
+  const nextDayStart = nextDayStartDate.getTime();
+  const dayStartDate = dateStrToUtcDate(dayDate);
+  dayStartDate.setHours(0, 0, 0, 0);
+  const dayStartTime = dayStartDate.getTime();
+
+  // Check if this day is within the current week (today through next 6 days)
+  const isInCurrentWeek = dayStartTime >= todayStart && dayStartTime < currentWeekEndTime;
+
+  let startTime = i == 0 ? now : dayStartTime;
+  if (workStartEndCfg) {
+    const startTimeToday = getDateTimeFromClockString(
+      workStartEndCfg.startTime,
+      dateStrToUtcDate(dayDate),
+    );
+    if (startTimeToday > now) {
+      startTime = startTimeToday;
+    }
+  }
+
+  return { nextDayStart, dayStartTime, isInCurrentWeek, startTime };
 };
 
 const isPlannedForDayTask = (

--- a/src/app/features/schedule/schedule.service.ts
+++ b/src/app/features/schedule/schedule.service.ts
@@ -25,6 +25,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { TaskService } from '../tasks/task.service';
 import { startWith } from 'rxjs/operators';
 import { parseDbDateStr } from '../../util/parse-db-date-str';
+import { getVisibleDaySequence } from '../../util/get-visible-day-sequence';
 
 @Injectable({
   providedIn: 'root',
@@ -154,12 +155,7 @@ export class ScheduleService {
 
   getDaysToShow(nrOfDaysToShow: number, referenceDate: Date | null = null): string[] {
     const today = referenceDate ? referenceDate.getTime() : new Date().getTime();
-    const daysToShow: string[] = [];
-    for (let i = 0; i < nrOfDaysToShow; i++) {
-      // eslint-disable-next-line no-mixed-operators
-      daysToShow.push(this._dateService.todayStr(today + i * 24 * 60 * 60 * 1000));
-    }
-    return daysToShow;
+    return getVisibleDaySequence(today, nrOfDaysToShow);
   }
 
   getMonthDaysToShow(

--- a/src/app/util/get-db-date-str.spec.ts
+++ b/src/app/util/get-db-date-str.spec.ts
@@ -1,4 +1,4 @@
-import { getDbDateStr, isDBDateStr } from './get-db-date-str';
+import { getDbDateStr, getDbDateStrWithOffset, isDBDateStr } from './get-db-date-str';
 
 describe('getDbDateStr', () => {
   it('should return YYYY-MM-DD for a given date', () => {
@@ -12,6 +12,45 @@ describe('getDbDateStr', () => {
   it('should accept a timestamp number', () => {
     const ts = new Date(2026, 11, 25).getTime();
     expect(getDbDateStr(ts)).toBe('2026-12-25');
+  });
+});
+
+describe('getDbDateStrWithOffset', () => {
+  it('should behave like getDbDateStr when offset is 0', () => {
+    const ts = new Date(2026, 2, 21, 10, 0, 0).getTime();
+    expect(getDbDateStrWithOffset(ts, 0)).toBe(getDbDateStr(ts));
+  });
+
+  it('should default to a 0 offset when none is passed', () => {
+    const ts = new Date(2026, 2, 21, 10, 0, 0).getTime();
+    expect(getDbDateStrWithOffset(ts)).toBe(getDbDateStr(ts));
+  });
+
+  it('should bucket a timestamp before the offset cutoff into the previous day', () => {
+    // 1 AM with a 4-hour offset still belongs to the previous logical day
+    const oneAm = new Date(2026, 2, 21, 1, 0, 0).getTime();
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+    expect(getDbDateStrWithOffset(oneAm, fourHoursMs)).toBe('2026-03-20');
+  });
+
+  it('should keep a timestamp at/after the offset cutoff on the same day', () => {
+    const fourAm = new Date(2026, 2, 21, 4, 0, 0).getTime();
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+    expect(getDbDateStrWithOffset(fourAm, fourHoursMs)).toBe('2026-03-21');
+  });
+
+  it('should accept a Date object', () => {
+    const date = new Date(2026, 2, 21, 1, 0, 0);
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+    expect(getDbDateStrWithOffset(date, fourHoursMs)).toBe('2026-03-20');
+  });
+
+  it('should shift across a DST spring-forward boundary (e.g. US: Mar 8, 2026, 2 AM -> 3 AM)', () => {
+    // 1:30 AM local time shifted back by a 3-hour offset lands the previous
+    // calendar day regardless of the DST transition happening later that day.
+    const beforeDstJump = new Date(2026, 2, 8, 1, 30, 0).getTime();
+    const threeHoursMs = 3 * 60 * 60 * 1000;
+    expect(getDbDateStrWithOffset(beforeDstJump, threeHoursMs)).toBe('2026-03-07');
   });
 });
 

--- a/src/app/util/get-db-date-str.ts
+++ b/src/app/util/get-db-date-str.ts
@@ -14,6 +14,21 @@ export const getDbDateStr = (date: Date | number | string = new Date()): string 
   return `${year}-${month}-${day}`;
 };
 
+/**
+ * Buckets a timestamp/Date into its *logical* day string by shifting it back
+ * by the start-of-next-day offset before formatting (e.g. a 1 AM task with a
+ * 4-hour offset still belongs to the previous day). Centralizes the
+ * `getDbDateStr(new Date(ts - startOfNextDayDiffMs))` pattern repeated across
+ * planner/schedule day-bucketing (tasks, calendar events, deadlines).
+ */
+export const getDbDateStrWithOffset = (
+  date: number | Date,
+  startOfNextDayDiffMs: number = 0,
+): string => {
+  const ts = typeof date === 'number' ? date : date.getTime();
+  return getDbDateStr(new Date(ts - startOfNextDayDiffMs));
+};
+
 export const isDBDateStr = (str: string): boolean => {
   if (str.length !== 10 || str[4] !== '-' || str[7] !== '-') return false;
   for (let i = 0; i < 10; i++) {

--- a/src/app/util/get-visible-day-sequence.spec.ts
+++ b/src/app/util/get-visible-day-sequence.spec.ts
@@ -1,0 +1,86 @@
+import { getDbDateStr } from './get-db-date-str';
+import { getVisibleDaySequence } from './get-visible-day-sequence';
+
+describe('getVisibleDaySequence', () => {
+  describe('multi-day sequences', () => {
+    it('should return the requested number of consecutive day strings', () => {
+      const start = new Date(2026, 0, 20, 10, 0, 0).getTime();
+      const result = getVisibleDaySequence(start, 5);
+
+      expect(result).toEqual([
+        '2026-01-20',
+        '2026-01-21',
+        '2026-01-22',
+        '2026-01-23',
+        '2026-01-24',
+      ]);
+    });
+
+    it('should start on the day of startMs', () => {
+      const start = new Date(2026, 0, 20, 10, 0, 0).getTime();
+      const result = getVisibleDaySequence(start, 1);
+
+      expect(result).toEqual([getDbDateStr(start)]);
+    });
+
+    it('should return an empty array for count 0', () => {
+      const start = new Date(2026, 0, 20).getTime();
+      expect(getVisibleDaySequence(start, 0)).toEqual([]);
+    });
+
+    it('should roll over month and year boundaries', () => {
+      const start = new Date(2025, 11, 30).getTime(); // Dec 30, 2025
+      const result = getVisibleDaySequence(start, 4);
+
+      expect(result).toEqual(['2025-12-30', '2025-12-31', '2026-01-01', '2026-01-02']);
+    });
+  });
+
+  describe('DST boundary (US spring-forward, Mar 8 2026)', () => {
+    it('should produce exactly one entry per calendar day with no skip or repeat', () => {
+      const start = new Date(2026, 2, 7, 0, 0, 0).getTime(); // day before the jump
+      const result = getVisibleDaySequence(start, 4);
+
+      expect(result).toEqual(['2026-03-07', '2026-03-08', '2026-03-09', '2026-03-10']);
+    });
+  });
+
+  describe('includedWeekDays filter', () => {
+    it('should skip days not in includedWeekDays and still return `count` matches', () => {
+      // 2026-01-19 is a Monday
+      const monday = new Date(2026, 0, 19).getTime();
+      // Weekdays only (Mon-Fri)
+      const result = getVisibleDaySequence(monday, 5, [1, 2, 3, 4, 5]);
+
+      expect(result).toEqual([
+        '2026-01-19', // Mon
+        '2026-01-20', // Tue
+        '2026-01-21', // Wed
+        '2026-01-22', // Thu
+        '2026-01-23', // Fri
+      ]);
+    });
+
+    it('should skip weekend days when the range spans one', () => {
+      // 2026-01-23 is a Friday
+      const friday = new Date(2026, 0, 23).getTime();
+      const result = getVisibleDaySequence(friday, 2, [1, 2, 3, 4, 5]);
+
+      // Sat 24th and Sun 25th are skipped
+      expect(result).toEqual(['2026-01-23', '2026-01-26']);
+    });
+
+    it('should return an empty array when includedWeekDays is empty', () => {
+      const start = new Date(2026, 0, 19).getTime();
+      expect(getVisibleDaySequence(start, 5, [])).toEqual([]);
+    });
+
+    it('should behave the same as no filter when all week days are included', () => {
+      const start = new Date(2026, 0, 19).getTime();
+      const withAllDays = getVisibleDaySequence(start, 7, [0, 1, 2, 3, 4, 5, 6]);
+      const withoutFilter = getVisibleDaySequence(start, 7);
+
+      expect(withAllDays).toEqual(withoutFilter);
+    });
+  });
+});

--- a/src/app/util/get-visible-day-sequence.ts
+++ b/src/app/util/get-visible-day-sequence.ts
@@ -1,0 +1,42 @@
+import { getDbDateStr } from './get-db-date-str';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Generates a sequence of `count` day-date strings (YYYY-MM-DD), starting at
+ * `startMs` and stepping forward one day (24h) at a time. When
+ * `includedWeekDays` is given, candidate days whose `Date#getDay()` is not in
+ * the list are skipped so the returned sequence still contains exactly
+ * `count` matching days (e.g. planner's "included week days" filter) rather
+ * than fewer days for the same iteration count. Passing an empty
+ * `includedWeekDays` array returns an empty sequence instead of looping
+ * forever.
+ *
+ * Centralizes the day-millisecond arithmetic that planner.service.ts
+ * (`daysToShow$`) and schedule.service.ts (`getDaysToShow`) previously
+ * duplicated for visible-day generation.
+ */
+export const getVisibleDaySequence = (
+  startMs: number,
+  count: number,
+  includedWeekDays?: number[],
+): string[] => {
+  const daysToShow: string[] = [];
+  if (includedWeekDays && includedWeekDays.length === 0) {
+    return daysToShow;
+  }
+
+  let daysAdded = 0;
+  let offset = 0;
+  while (daysAdded < count) {
+    // eslint-disable-next-line no-mixed-operators
+    const candidateMs = startMs + offset * MS_PER_DAY;
+    if (!includedWeekDays || includedWeekDays.includes(new Date(candidateMs).getDay())) {
+      daysToShow.push(getDbDateStr(candidateMs));
+      daysAdded++;
+    }
+    offset++;
+  }
+
+  return daysToShow;
+};

--- a/src/app/util/is-today.util.ts
+++ b/src/app/util/is-today.util.ts
@@ -1,4 +1,4 @@
-import { getDbDateStr } from './get-db-date-str';
+import { getDbDateStrWithOffset } from './get-db-date-str';
 
 export const isTodayWithOffset = (
   date: number | Date,
@@ -9,7 +9,7 @@ export const isTodayWithOffset = (
   if (!(d.getTime() > 0)) {
     throw new Error('Invalid date passed');
   }
-  return getDbDateStr(new Date(d.getTime() - startOfNextDayDiffMs)) === todayStr;
+  return getDbDateStrWithOffset(d, startOfNextDayDiffMs) === todayStr;
 };
 
 /** @deprecated Use `DateService.isToday()` or `isTodayWithOffset()` instead for offset-aware comparison. */


### PR DESCRIPTION
## Problem

Logical-day ("start of next day offset") bucketing and visible-day generation are duplicated across the planner and schedule features:

- the `getDbDateStr(new Date(ts - startOfNextDayDiffMs))` pattern is repeated by planner selectors and `isTodayWithOffset`,
- `planner.service.ts` (`daysToShow$`) and `schedule.service.ts` (`getDaysToShow`) each hand-roll the same day-millisecond loop for generating visible days,
- `createScheduleDays()` is one long function mixing several distinct steps.

Closes #7915

## Solution

Behavior-preserving refactor:

- `getDbDateStrWithOffset(date, startOfNextDayDiffMs)` in `get-db-date-str.ts` centralizes the offset-shift pattern; planner selectors and `isTodayWithOffset` now use it.
- New `getVisibleDaySequence(startMs, count, includedWeekDays?)` util replaces the duplicated visible-day loops in `planner.service.ts` and `schedule.service.ts` (including the "skip excluded weekdays but still return `count` days" behavior, and returning an empty list for an empty `includedWeekDays` instead of looping forever).
- `createScheduleDays()` split into named steps: `normalizeZeroEstimateTasks`, `getCurrentWeekBoundary`, `filterTasksOutsideFirstVisibleWeek`, `getDayTiming`.

New specs for `getVisibleDaySequence` and `getDbDateStrWithOffset`; existing planner/schedule specs unchanged and passing.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
