### PR TITLE
fix(sync): keep the conflict summary banner counts live during review

### DIFF
--- a/src/app/core/banner/banner.service.ts
+++ b/src/app/core/banner/banner.service.ts
@@ -135,6 +135,11 @@ export class BannerService {
     });
   }
 
+  /** Whether a banner with this id is currently shown (open and not dismissed). */
+  isShown(bannerId: BannerId): boolean {
+    return this._banners().some((banner) => banner.id === bannerId);
+  }
+
   dismiss(bannerId: BannerId): void {
     // Log.log('BannerService -> dismissing Banner', bannerId);
     this._banners.update((banners) => {

--- a/src/app/op-log/sync/conflict-journal.service.ts
+++ b/src/app/op-log/sync/conflict-journal.service.ts
@@ -59,6 +59,15 @@ export class ConflictJournalService {
   /** Number of entries still awaiting review (status === 'unreviewed'). */
   readonly unreviewedCount = this._unreviewedCount.asReadonly();
 
+  private readonly _revision = signal(0);
+  /**
+   * Monotonic counter bumped on EVERY journal mutation (record / status change /
+   * prune / clearAll), regardless of whether `unreviewedCount` changed. Consumers
+   * that must react to composition changes at an equal total (e.g. one remote-win
+   * reviewed while one local-win is recorded) key off this instead of the count.
+   */
+  readonly revision = this._revision.asReadonly();
+
   private _openDb(): Promise<IDBPDatabase<ConflictJournalDB>> {
     return openDB<ConflictJournalDB>(
       CONFLICT_JOURNAL_DB_NAME,
@@ -264,6 +273,12 @@ export class ConflictJournalService {
   private async _refreshUnreviewedCount(
     db: IDBPDatabase<ConflictJournalDB>,
   ): Promise<void> {
+    // Advance `revision` FIRST, so a committed mutation always notifies consumers
+    // even if the count query below throws (callers swallow that error). The
+    // banner keys off `revision` and re-reads the journal itself, so it still
+    // reflects the committed change; `unreviewedCount` catches up once the query
+    // succeeds. Fires on every mutation even when the count is unchanged.
+    this._revision.update((r) => r + 1);
     const count = await db.countFromIndex(
       CONFLICT_JOURNAL_STORE,
       CONFLICT_JOURNAL_INDEX_STATUS,

--- a/src/app/op-log/sync/sync-conflict-banner.service.spec.ts
+++ b/src/app/op-log/sync/sync-conflict-banner.service.spec.ts
@@ -146,4 +146,92 @@ describe('SyncConflictBannerService', () => {
 
     expect(bannerService.open).toHaveBeenCalledTimes(1); // no re-open
   });
+
+  // --- Concurrency guards (SPAP-35 review hardening) ---
+  // The refresh does an async journal read between "is the banner shown?" and
+  // open()/dismiss(). These cover the three ways that gap can misbehave.
+
+  it('does NOT resurrect the banner when the user dismisses while a refresh read is in flight (SPAP-35)', async () => {
+    const a = makeEntry({ winner: 'remote' });
+    const b = makeEntry({ winner: 'local' });
+    await journal.record(a);
+    await journal.record(b);
+    await service.maybeShowSummaryBanner();
+    expect(bannerService.open).toHaveBeenCalledTimes(1);
+
+    bannerService.isShown.and.returnValue(true); // banner on screen when review starts
+    // Hold the refresh's journal read open so a dismiss can land mid-await.
+    let releaseRead!: () => void;
+    const readGate = new Promise<void>((resolve) => (releaseRead = resolve));
+    const realList = journal.list.bind(journal);
+    spyOn(journal, 'list').and.callFake((view) => readGate.then(() => realList(view)));
+
+    await journal.markKept(a.id); // count 2 -> 1: refresh starts, read now pending
+    await flushAsync();
+    bannerService.isShown.and.returnValue(false); // user clicks the banner's DISMISS (X)
+    releaseRead();
+    await flushAsync();
+    await flushAsync();
+
+    // One entry still unreviewed (count 1 > 0), but the banner was dismissed:
+    // the post-await isShown() re-check must stop it re-opening.
+    expect(bannerService.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a stale in-flight refresh when a newer count change supersedes it (SPAP-35)', async () => {
+    const a = makeEntry({ winner: 'remote' });
+    const b = makeEntry({ winner: 'local' });
+    const c = makeEntry({ winner: 'remote' });
+    await journal.record(a);
+    await journal.record(b);
+    await journal.record(c);
+    await service.maybeShowSummaryBanner();
+    bannerService.isShown.and.returnValue(true);
+
+    // Two refreshes fire; force the OLDER read to resolve LAST with a stale set.
+    let resolveOld!: (v: ConflictJournalEntry[]) => void;
+    let resolveNew!: (v: ConflictJournalEntry[]) => void;
+    const oldRead = new Promise<ConflictJournalEntry[]>((r) => (resolveOld = r));
+    const newRead = new Promise<ConflictJournalEntry[]>((r) => (resolveNew = r));
+    spyOn(journal, 'list').and.returnValues(oldRead, newRead);
+
+    await journal.markKept(a.id); // count 3 -> 2: refresh #0 (awaits oldRead)
+    await flushAsync();
+    await journal.markKept(b.id); // count 2 -> 1: refresh #1 (awaits newRead)
+    await flushAsync();
+
+    resolveNew([c]); // newer refresh completes first -> renders count 1
+    await flushAsync();
+    resolveOld([a, b, c]); // stale older refresh resolves last with count 3
+    await flushAsync();
+    await flushAsync();
+
+    // The sequence guard must drop the stale refresh: last render stays at count 1.
+    expect(bannerService.open.calls.mostRecent().args[0].translateParams).toEqual({
+      count: 1,
+      remoteWins: 1,
+      localWins: 0,
+    });
+  });
+
+  it('does NOT dismiss the banner on a phantom zero from a failed journal read (SPAP-35)', async () => {
+    const a = makeEntry({ winner: 'remote' });
+    const b = makeEntry({ winner: 'local' });
+    await journal.record(a);
+    await journal.record(b);
+    await service.maybeShowSummaryBanner();
+    expect(bannerService.open).toHaveBeenCalledTimes(1);
+
+    bannerService.isShown.and.returnValue(true);
+    bannerService.dismiss.calls.reset();
+    // list() degrades to [] on a transient DB error — a real entry still remains.
+    spyOn(journal, 'list').and.resolveTo([]);
+
+    await journal.markKept(a.id); // count 2 -> 1 emitted; read (falsely) sees []
+    await flushAsync();
+    await flushAsync();
+
+    // count stream says 1 (> 0) but the read is empty: don't dismiss a valid banner.
+    expect(bannerService.dismiss).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/op-log/sync/sync-conflict-banner.service.spec.ts
+++ b/src/app/op-log/sync/sync-conflict-banner.service.spec.ts
@@ -34,8 +34,13 @@ describe('SyncConflictBannerService', () => {
   let bannerService: jasmine.SpyObj<BannerService>;
   let router: jasmine.SpyObj<Router>;
 
+  /** Lets the count-change subscription's async refresh settle. */
+  const flushAsync = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 0));
+
   beforeEach(() => {
-    bannerService = jasmine.createSpyObj('BannerService', ['open', 'dismiss']);
+    bannerService = jasmine.createSpyObj('BannerService', ['open', 'dismiss', 'isShown']);
+    bannerService.isShown.and.returnValue(false);
     router = jasmine.createSpyObj('Router', ['navigate']);
 
     TestBed.configureTestingModule({
@@ -87,5 +92,58 @@ describe('SyncConflictBannerService', () => {
     banner.action?.fn();
 
     expect(router.navigate).toHaveBeenCalledWith([SYNC_CONFLICTS_ROUTE]);
+  });
+
+  it('refreshes the OPEN banner counts when entries are reviewed in-page (SPAP-35)', async () => {
+    const a = makeEntry({ winner: 'remote' });
+    const b = makeEntry({ winner: 'local' });
+    await journal.record(a);
+    await journal.record(b);
+    await service.maybeShowSummaryBanner();
+    expect(bannerService.open.calls.mostRecent().args[0].translateParams).toEqual({
+      count: 2,
+      remoteWins: 1,
+      localWins: 1,
+    });
+
+    bannerService.isShown.and.returnValue(true); // banner still on screen
+    await journal.markKept(a.id);
+    await flushAsync();
+
+    expect(bannerService.open.calls.mostRecent().args[0].translateParams).toEqual({
+      count: 1,
+      remoteWins: 0,
+      localWins: 1,
+    });
+  });
+
+  it('dismisses the OPEN banner when the last entry is reviewed in-page (SPAP-35)', async () => {
+    const a = makeEntry({ winner: 'remote' });
+    await journal.record(a);
+    await service.maybeShowSummaryBanner();
+    expect(bannerService.open).toHaveBeenCalledTimes(1);
+
+    bannerService.isShown.and.returnValue(true);
+    await journal.markKept(a.id);
+    await flushAsync();
+
+    expect(bannerService.dismiss).toHaveBeenCalledWith(
+      BannerId.SyncConflictsAutoResolved,
+    );
+  });
+
+  it('does NOT resurrect a banner the user dismissed when the count changes (SPAP-35)', async () => {
+    const a = makeEntry({ winner: 'remote' });
+    const b = makeEntry({ winner: 'local' });
+    await journal.record(a);
+    await journal.record(b);
+    await service.maybeShowSummaryBanner();
+    expect(bannerService.open).toHaveBeenCalledTimes(1);
+
+    bannerService.isShown.and.returnValue(false); // user hit DISMISS
+    await journal.markKept(a.id);
+    await flushAsync();
+
+    expect(bannerService.open).toHaveBeenCalledTimes(1); // no re-open
   });
 });

--- a/src/app/op-log/sync/sync-conflict-banner.service.spec.ts
+++ b/src/app/op-log/sync/sync-conflict-banner.service.spec.ts
@@ -1,3 +1,4 @@
+import { signal, WritableSignal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import {
@@ -34,9 +35,13 @@ describe('SyncConflictBannerService', () => {
   let bannerService: jasmine.SpyObj<BannerService>;
   let router: jasmine.SpyObj<Router>;
 
-  /** Lets the count-change subscription's async refresh settle. */
+  /**
+   * Lets the revision-triggered live refresh settle. The service coalesces
+   * mutation bursts with a 100ms `auditTime` window, so this waits past it
+   * (plus the async journal read).
+   */
   const flushAsync = (): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, 0));
+    new Promise((resolve) => setTimeout(resolve, 160));
 
   beforeEach(() => {
     bannerService = jasmine.createSpyObj('BannerService', ['open', 'dismiss', 'isShown']);
@@ -233,5 +238,106 @@ describe('SyncConflictBannerService', () => {
 
     // count stream says 1 (> 0) but the read is empty: don't dismiss a valid banner.
     expect(bannerService.dismiss).not.toHaveBeenCalled();
+  });
+
+  it('coalesces a burst of reviews into a bounded number of journal scans (#8946)', async () => {
+    const entries = Array.from({ length: 12 }, () => makeEntry({ winner: 'remote' }));
+    for (const e of entries) {
+      await journal.record(e);
+    }
+    await service.maybeShowSummaryBanner();
+
+    bannerService.isShown.and.returnValue(true);
+    // Spy AFTER the open so only refresh-driven reads are counted.
+    const listSpy = spyOn(journal, 'list').and.callThrough();
+
+    // Bulk "Keep All": a burst of mutations. Each bumps the journal revision.
+    for (const e of entries) {
+      await journal.markKept(e.id);
+    }
+    await flushAsync();
+
+    // Coalesced: the whole burst collapses to a single trailing refresh (one
+    // scan), not one full journal scan per entry.
+    expect(listSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SyncConflictBannerService — mutation-aware trigger (#8946)', () => {
+  let bannerService: jasmine.SpyObj<BannerService>;
+  let revision: WritableSignal<number>;
+  let unreviewedCount: WritableSignal<number>;
+  let listSpy: jasmine.Spy;
+
+  // The live refresh coalesces bursts with a 100ms auditTime window.
+  const flushAsync = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 160));
+
+  beforeEach(() => {
+    bannerService = jasmine.createSpyObj('BannerService', ['open', 'dismiss', 'isShown']);
+    bannerService.isShown.and.returnValue(false);
+    revision = signal(0);
+    unreviewedCount = signal(0);
+    listSpy = jasmine.createSpy('list').and.resolveTo([]);
+
+    // Mock journal: revision and unreviewedCount are controlled independently so
+    // the count-race is reproducible deterministically (both count queries run
+    // after both writes -> the count is unchanged while the content changed).
+    const mockJournal = {
+      revision: revision.asReadonly(),
+      unreviewedCount: unreviewedCount.asReadonly(),
+      list: listSpy,
+    } as unknown as ConflictJournalService;
+
+    TestBed.configureTestingModule({
+      providers: [
+        SyncConflictBannerService,
+        { provide: ConflictJournalService, useValue: mockJournal },
+        { provide: BannerService, useValue: bannerService },
+        {
+          provide: Router,
+          useValue: jasmine.createSpyObj('Router', ['navigate']),
+        },
+      ],
+    });
+  });
+
+  it('refreshes the breakdown on an equal-total composition change (count stays 1, remote -> local)', async () => {
+    const service = TestBed.inject(SyncConflictBannerService);
+    // Let the initial revision emission flush so skip(1) consumes it here (not a
+    // later, meaningful change).
+    await flushAsync();
+
+    // Open with a single remote-win.
+    listSpy.and.resolveTo([makeEntry({ winner: 'remote' })]);
+    unreviewedCount.set(1);
+    await service.maybeShowSummaryBanner();
+    expect(bannerService.open.calls.mostRecent().args[0].translateParams).toEqual({
+      count: 1,
+      remoteWins: 1,
+      localWins: 0,
+    });
+
+    bannerService.isShown.and.returnValue(true);
+    // Drain any count-driven refresh (a count-keyed trigger would have fired one
+    // when the count went 0 -> 1 above) while the content is still the remote-win,
+    // so the change below is revision-only and the two triggers are distinguished.
+    await flushAsync();
+    await flushAsync();
+
+    // The race: one remote-win reviewed AND one local-win recorded, with both
+    // count queries observing the post-both-writes state -> unreviewedCount stays
+    // 1 (UNCHANGED) while the content flipped to one local-win. A trigger keyed on
+    // the count suppresses this refresh; keyed on the revision it must fire.
+    listSpy.and.resolveTo([makeEntry({ winner: 'local' })]);
+    revision.set(1); // NOTE: unreviewedCount deliberately left at 1
+    await flushAsync();
+    await flushAsync();
+
+    expect(bannerService.open.calls.mostRecent().args[0].translateParams).toEqual({
+      count: 1,
+      remoteWins: 0,
+      localWins: 1,
+    });
   });
 });

--- a/src/app/op-log/sync/sync-conflict-banner.service.ts
+++ b/src/app/op-log/sync/sync-conflict-banner.service.ts
@@ -9,12 +9,13 @@
  */
 
 import { inject, Injectable } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { distinctUntilChanged, skip } from 'rxjs';
 import { BannerService } from '../../core/banner/banner.service';
 import { BannerId } from '../../core/banner/banner.model';
 import { ConflictJournalService } from './conflict-journal.service';
-import { computeWinCounts } from './sync-conflict-review.util';
+import { computeWinCounts, ConflictWinCounts } from './sync-conflict-review.util';
 import { T } from '../../t.const';
 
 /** Route path of the Sync Conflicts review page. */
@@ -30,18 +31,20 @@ export class SyncConflictBannerService {
   private readonly _router = inject(Router, { optional: true });
   private readonly _journal = inject(ConflictJournalService);
 
+  // Monotonic guard shared by every async banner update (open + live refresh):
+  // each attempt claims a sequence before its journal read and bails if a newer
+  // attempt has started, so a slow read can never overwrite a fresher decision.
+  private _bannerSeq = 0;
+
   constructor() {
     // SPAP-35: the banner captures its counts when it opens; the sync-icon badge
     // updates live but an OPEN banner would go stale while the user reviews
     // entries on the page. Refresh (or dismiss at zero) the banner on every
     // unreviewed-count change — but only while it is actually still shown, so a
     // banner the user dismissed is never resurrected by reviewing activity.
-    // Root-scoped service → the subscription lives for the app's lifetime.
-    this._journal.unreviewedCount$.pipe(skip(1), distinctUntilChanged()).subscribe(() => {
-      if (this._bannerService.isShown(BannerId.SyncConflictsAutoResolved)) {
-        void this.maybeShowSummaryBanner();
-      }
-    });
+    this._journal.unreviewedCount$
+      .pipe(skip(1), distinctUntilChanged(), takeUntilDestroyed())
+      .subscribe((count) => void this._refreshOpenBanner(count));
   }
 
   /** Navigate to the review page (shared by the banner action and elsewhere). */
@@ -52,12 +55,44 @@ export class SyncConflictBannerService {
   /**
    * Opens the summary banner iff there are unreviewed conflicts. No-ops (and
    * dismisses any stale banner) when the unreviewed count is zero, so routine
-   * self-healing syncs stay silent.
+   * self-healing syncs stay silent. Called after a sync resolves conflicts.
    */
   async maybeShowSummaryBanner(): Promise<void> {
+    const seq = ++this._bannerSeq;
     const unreviewed = await this._journal.list('unreviewed');
-    const { total, remoteWins, localWins } = computeWinCounts(unreviewed);
+    if (seq !== this._bannerSeq) return; // superseded by a newer banner update
+    this._renderSummaryBanner(computeWinCounts(unreviewed));
+  }
 
+  /**
+   * SPAP-35 live-refresh path: keep an ALREADY-OPEN banner in sync with the
+   * current unreviewed count, or dismiss it at zero. Unlike the opener it must
+   * never OPEN a banner the user isn't already looking at, and it has to survive
+   * the async journal read racing with either a dismiss or a newer refresh:
+   *   - re-check `isShown()` AFTER the await, so a banner dismissed mid-read is
+   *     not resurrected (the pre-await check alone is a check-then-act TOCTOU);
+   *   - re-check the sequence, so a slow older read can't clobber newer counts;
+   *   - ignore a phantom zero: `list()` returns `[]` on a transient DB error, so
+   *     a zero read while the count stream still reports >0 must not dismiss a
+   *     valid banner.
+   */
+  private async _refreshOpenBanner(emittedCount: number): Promise<void> {
+    if (!this._bannerService.isShown(BannerId.SyncConflictsAutoResolved)) return;
+    const seq = ++this._bannerSeq;
+    const unreviewed = await this._journal.list('unreviewed');
+    if (seq !== this._bannerSeq) return; // a newer refresh/open superseded us
+    if (!this._bannerService.isShown(BannerId.SyncConflictsAutoResolved)) return; // dismissed mid-read
+    const wins = computeWinCounts(unreviewed);
+    if (wins.total === 0 && emittedCount > 0) return; // phantom zero from a failed read
+    this._renderSummaryBanner(wins);
+  }
+
+  /** Applies a resolved count to the banner: dismiss at zero, else (re)open. */
+  private _renderSummaryBanner({
+    total,
+    remoteWins,
+    localWins,
+  }: ConflictWinCounts): void {
     if (total === 0) {
       this._bannerService.dismiss(BannerId.SyncConflictsAutoResolved);
       return;

--- a/src/app/op-log/sync/sync-conflict-banner.service.ts
+++ b/src/app/op-log/sync/sync-conflict-banner.service.ts
@@ -10,6 +10,7 @@
 
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+import { distinctUntilChanged, skip } from 'rxjs';
 import { BannerService } from '../../core/banner/banner.service';
 import { BannerId } from '../../core/banner/banner.model';
 import { ConflictJournalService } from './conflict-journal.service';
@@ -28,6 +29,20 @@ export class SyncConflictBannerService {
   // now depend on this) don't all have to provide a Router.
   private readonly _router = inject(Router, { optional: true });
   private readonly _journal = inject(ConflictJournalService);
+
+  constructor() {
+    // SPAP-35: the banner captures its counts when it opens; the sync-icon badge
+    // updates live but an OPEN banner would go stale while the user reviews
+    // entries on the page. Refresh (or dismiss at zero) the banner on every
+    // unreviewed-count change — but only while it is actually still shown, so a
+    // banner the user dismissed is never resurrected by reviewing activity.
+    // Root-scoped service → the subscription lives for the app's lifetime.
+    this._journal.unreviewedCount$.pipe(skip(1), distinctUntilChanged()).subscribe(() => {
+      if (this._bannerService.isShown(BannerId.SyncConflictsAutoResolved)) {
+        void this.maybeShowSummaryBanner();
+      }
+    });
+  }
 
   /** Navigate to the review page (shared by the banner action and elsewhere). */
   navigateToReview(): void {

--- a/src/app/op-log/sync/sync-conflict-banner.service.ts
+++ b/src/app/op-log/sync/sync-conflict-banner.service.ts
@@ -9,9 +9,9 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { distinctUntilChanged, skip } from 'rxjs';
+import { auditTime, skip } from 'rxjs';
 import { BannerService } from '../../core/banner/banner.service';
 import { BannerId } from '../../core/banner/banner.model';
 import { ConflictJournalService } from './conflict-journal.service';
@@ -20,6 +20,13 @@ import { T } from '../../t.const';
 
 /** Route path of the Sync Conflicts review page. */
 export const SYNC_CONFLICTS_ROUTE = '/sync-conflicts';
+
+/**
+ * Coalesce window for the live banner refresh. A burst of journal mutations
+ * (e.g. Keep All over the whole journal) collapses into one trailing refresh
+ * instead of one full journal scan per entry.
+ */
+const BANNER_REFRESH_COALESCE_MS = 100;
 
 const CR = T.F.SYNC.CONFLICT_REVIEW;
 
@@ -37,14 +44,20 @@ export class SyncConflictBannerService {
   private _bannerSeq = 0;
 
   constructor() {
-    // SPAP-35: the banner captures its counts when it opens; the sync-icon badge
-    // updates live but an OPEN banner would go stale while the user reviews
-    // entries on the page. Refresh (or dismiss at zero) the banner on every
-    // unreviewed-count change — but only while it is actually still shown, so a
-    // banner the user dismissed is never resurrected by reviewing activity.
-    this._journal.unreviewedCount$
-      .pipe(skip(1), distinctUntilChanged(), takeUntilDestroyed())
-      .subscribe((count) => void this._refreshOpenBanner(count));
+    // SPAP-35 / #8946: the banner captures its counts when it opens; the
+    // sync-icon badge updates live but an OPEN banner would go stale while the
+    // user reviews entries on the page. Refresh (or dismiss at zero) an
+    // already-open banner on every journal MUTATION — keyed on the `revision`
+    // signal, NOT the numeric unreviewed count, so an equal-total composition
+    // change (one remote-win reviewed while one local-win is recorded, total
+    // unchanged) still refreshes the "X remote, Y local" breakdown. `auditTime`
+    // coalesces a burst of mutations (e.g. Keep All over the whole journal) into
+    // one trailing refresh, so a bulk review can't fire one full journal scan per
+    // entry. Only refreshes while the banner is still shown, so reviewing never
+    // resurrects a dismissed banner.
+    toObservable(this._journal.revision)
+      .pipe(skip(1), auditTime(BANNER_REFRESH_COALESCE_MS), takeUntilDestroyed())
+      .subscribe(() => void this._refreshOpenBanner());
   }
 
   /** Navigate to the review page (shared by the banner action and elsewhere). */
@@ -61,7 +74,12 @@ export class SyncConflictBannerService {
     const seq = ++this._bannerSeq;
     const unreviewed = await this._journal.list('unreviewed');
     if (seq !== this._bannerSeq) return; // superseded by a newer banner update
-    this._renderSummaryBanner(computeWinCounts(unreviewed));
+    const wins = computeWinCounts(unreviewed);
+    // Ignore a phantom zero: list() returns [] on a transient DB error. If the
+    // authoritative count still reports >0, don't dismiss/skip a valid banner
+    // (same guard the live-refresh path applies).
+    if (wins.total === 0 && this._journal.unreviewedCount() > 0) return;
+    this._renderSummaryBanner(wins);
   }
 
   /**
@@ -73,17 +91,17 @@ export class SyncConflictBannerService {
    *     not resurrected (the pre-await check alone is a check-then-act TOCTOU);
    *   - re-check the sequence, so a slow older read can't clobber newer counts;
    *   - ignore a phantom zero: `list()` returns `[]` on a transient DB error, so
-   *     a zero read while the count stream still reports >0 must not dismiss a
-   *     valid banner.
+   *     a zero read while the authoritative count signal still reports >0 must
+   *     not dismiss a valid banner.
    */
-  private async _refreshOpenBanner(emittedCount: number): Promise<void> {
+  private async _refreshOpenBanner(): Promise<void> {
     if (!this._bannerService.isShown(BannerId.SyncConflictsAutoResolved)) return;
     const seq = ++this._bannerSeq;
     const unreviewed = await this._journal.list('unreviewed');
     if (seq !== this._bannerSeq) return; // a newer refresh/open superseded us
     if (!this._bannerService.isShown(BannerId.SyncConflictsAutoResolved)) return; // dismissed mid-read
     const wins = computeWinCounts(unreviewed);
-    if (wins.total === 0 && emittedCount > 0) return; // phantom zero from a failed read
+    if (wins.total === 0 && this._journal.unreviewedCount() > 0) return; // phantom zero
     this._renderSummaryBanner(wins);
   }
 


### PR DESCRIPTION
Small follow-up to #8874 (deferred LOW from its review): the "N sync conflicts auto-resolved" banner captured its counts at open time. The sync-icon badge updates live, but an open banner went stale while the user reviewed entries on `/sync-conflicts` — and lingered with a nonzero count after everything was reviewed.

- The banner service now subscribes to the journal's unreviewed count and, on every change, refreshes the open banner's counts (same-id `BannerService.open()` updates in place) or dismisses it at zero.
- Guarded by a new `BannerService.isShown(id)` so a banner the user explicitly dismissed is never resurrected by reviewing activity.
- Specs: refresh-on-review, dismiss-at-zero, and no-resurrection-after-dismiss (banner suite 6/6; conflict + backup suites 297/297 for regressions). `tsc`/`eslint`/`prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)