### PR TITLE
fix(sync): bind empty string, not null, for the sync badge description at 0

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -48,6 +48,13 @@
       }
 
       @if (isSyncIconEnabled()) {
+        <!--
+          matBadgeHidden only hides the badge VISUALLY (CSS) — MatBadge keeps an
+          aria description active regardless of hidden state. So at count 0 the
+          badge description must be empty (not a stale "0 conflicts" announced to
+          screen readers on every encounter). '' is the type-correct
+          "no description" value; MatBadge removes the aria-describedby for it.
+        -->
         <button
           class="sync-btn"
           [matBadge]="unreviewedConflictCount()"
@@ -59,7 +66,7 @@
             unreviewedConflictCount() > 0
               ? (T.F.SYNC.CONFLICT_REVIEW.BADGE_TOOLTIP
                 | translate: { count: unreviewedConflictCount() })
-              : null
+              : ''
           "
           [attr.aria-label]="syncTooltip() | translate"
           matTooltip="{{ syncTooltip() | translate }}"


### PR DESCRIPTION
Small follow-up to #8874 (deferred LOW from its review): the sync-icon badge bound `null` to `matBadgeDescription` (a `string` input) when the unreviewed count is 0.

Verified the hidden-state semantics in the installed Material version before changing anything: `matBadgeHidden` hides the badge via CSS only — MatBadge keeps its aria description active regardless of hidden state. So at count 0 the description genuinely must be absent (otherwise screen readers would announce a stale "0 conflicts" description on every encounter with the sync button); the previous `null` achieved that only by `AriaDescriber.describe()` silently no-op'ing on falsy input. `''` is the type-correct value whose removal path (`_updateDescription`) is explicit. A template comment documents the verified semantics so this doesn't regress to a "stable always-on description" later.

No behavior change (template-literal swap; the semantics live in Material) — so no new spec; dev build compiles, main-header specs green, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)