### PR TITLE
fix(sync): enforce conflict-journal retention mid-session, not only at start

### DIFF
--- a/docs/sync-and-op-log/conflict-journal-and-review.md
+++ b/docs/sync-and-op-log/conflict-journal-and-review.md
@@ -46,9 +46,14 @@ Contracts:
   `BackupService.importCompleteBackup` — the chokepoint every replacement path
   funnels through (profile switch, JSON import, local-backup restore, SuperSync
   restore) — calls `ConflictJournalService.clearAll()`.
-- **Retention.** Pruned on app start to whichever bound binds first: entries
-  older than 14 days (`JOURNAL_RETENTION_DAYS`) or beyond the newest 200
-  (`JOURNAL_MAX_ENTRIES`).
+- **Retention.** Each prune applies whichever bound binds first: entries older
+  than 14 days (`JOURNAL_RETENTION_DAYS`), then anything beyond the newest 200
+  (`JOURNAL_MAX_ENTRIES`). Pruning runs on app start, and opportunistically
+  mid-session from `record()` — but the mid-session prune is **count-triggered**:
+  it fires only once the store grows past the soft cap `JOURNAL_MAX_ENTRIES +
+JOURNAL_PRUNE_SLACK` (220), then prunes back to the newest 200. So a
+  long-running low-volume session (few entries, never crossing the soft cap)
+  relies on the next app start to enforce the 14-day age bound.
 
 ### Classification taxonomy
 

--- a/docs/wiki/3.06-User-Data.md
+++ b/docs/wiki/3.06-User-Data.md
@@ -80,7 +80,7 @@ The Windows Store build uses a different path that includes the Windows Store pa
 - **SUP_OPS** (current, version 8): Main database. Object stores: `ops`, `state_cache`, `import_backup`, `vector_clock`, `archive_young`, `archive_old`. Holds operations log, state snapshots, vector clocks, and archives.
 - **pf:** Legacy database used for migration and recovery.
 - **SUPPluginCache:** Plugin cache.
-- **SUP_CONFLICT_JOURNAL** (version 1): Sync **conflict journal** — a device-local record of automatic sync-conflict resolutions, reviewable under `/sync-conflicts`. One object store (`conflicts`). Deliberately separate from `SUP_OPS`, **never synced or uploaded** (entries capture the discarded side of conflicts verbatim), pruned on start to 14 days / newest 200 entries, and cleared whenever the full dataset is replaced (backup import/restore, profile switch).
+- **SUP_CONFLICT_JOURNAL** (version 1): Sync **conflict journal** — a device-local record of automatic sync-conflict resolutions, reviewable under `/sync-conflicts`. One object store (`conflicts`). Deliberately separate from `SUP_OPS`, **never synced or uploaded** (entries capture the discarded side of conflicts verbatim), pruned to 14 days / newest 200 entries — on app start, and mid-session once the store crosses a soft cap of 220 entries — and cleared whenever the full dataset is replaced (backup import/restore, profile switch).
 
 ### localStorage Keys
 

--- a/src/app/op-log/sync/conflict-journal.model.ts
+++ b/src/app/op-log/sync/conflict-journal.model.ts
@@ -115,13 +115,26 @@ export interface ConflictJournalEntry {
 export type ConflictJournalView = 'unreviewed' | 'history';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Retention (pruned on app-start; whichever bound binds first)
+// Retention. Pruned on app start (age + count bound), and opportunistically
+// mid-session when record() crosses the JOURNAL_MAX_ENTRIES + JOURNAL_PRUNE_SLACK
+// soft cap. Each prune applies the age bound first, then the count bound on the
+// survivors. Mid-session pruning is COUNT-triggered: a long-running low-volume
+// session (few entries, never crossing the soft cap) still relies on the next
+// app start to enforce the age bound.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Entries older than this many days are pruned on start. */
+/**
+ * Entries older than this many days are pruned — on app start, and mid-session
+ * whenever a count-triggered prune fires (not on a mid-session timer).
+ */
 export const JOURNAL_RETENTION_DAYS = 14;
 
-/** At most this many entries are kept (newest wins) — pruned on start. */
+/**
+ * The store is pruned back to this many entries (newest wins), on start and
+ * mid-session. NOTE: this is the post-prune retained size, not a hard live cap —
+ * mid-session the store may grow to JOURNAL_MAX_ENTRIES + JOURNAL_PRUNE_SLACK
+ * before the crossing record() prunes it back down to JOURNAL_MAX_ENTRIES.
+ */
 export const JOURNAL_MAX_ENTRIES = 200;
 
 /**

--- a/src/app/op-log/sync/conflict-journal.model.ts
+++ b/src/app/op-log/sync/conflict-journal.model.ts
@@ -124,6 +124,14 @@ export const JOURNAL_RETENTION_DAYS = 14;
 /** At most this many entries are kept (newest wins) — pruned on start. */
 export const JOURNAL_MAX_ENTRIES = 200;
 
+/**
+ * How far past JOURNAL_MAX_ENTRIES the store may grow before `record()` prunes
+ * mid-session (SPAP-36). Pruning reads the whole store, so it is amortized:
+ * the crossing record() prunes back down to JOURNAL_MAX_ENTRIES and the next
+ * prune is another JOURNAL_PRUNE_SLACK records away.
+ */
+export const JOURNAL_PRUNE_SLACK = 20;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // NOISE_FIELDS
 //

--- a/src/app/op-log/sync/conflict-journal.service.spec.ts
+++ b/src/app/op-log/sync/conflict-journal.service.spec.ts
@@ -227,6 +227,58 @@ describe('ConflictJournalService (store)', () => {
       expect(ids).toContain('before-term');
       expect(ids).toContain('after-term');
     });
+
+    it('awaits tx.done alongside the deletes so an aborted prune transaction cannot leak (SPAP-36)', async () => {
+      // MAX_ENTRIES + 1 entries: below the soft cap, so record()'s own
+      // opportunistic prune does NOT fire during setup (which would run under the
+      // real transaction and leave nothing to delete). pruneOnStart then has
+      // exactly one overflow entry to delete under the aborted transaction below.
+      const now = Date.now();
+      for (let i = 0; i <= JOURNAL_MAX_ENTRIES; i++) {
+        await service.record(
+          makeEntry({ id: `e-${i}`, resolvedAt: now - (JOURNAL_MAX_ENTRIES - i) }),
+        );
+      }
+
+      // Simulate an aborted delete transaction: both the delete requests and
+      // tx.done reject, exactly as idb reports an abort. Zone.js swallows the
+      // native `unhandledrejection` event under Karma, so rather than listening
+      // for the global leak we assert the fix's mechanism directly: the prune
+      // must AWAIT tx.done even when the delete aggregate rejects. With the old
+      // `Promise.all(deletes); await tx.done` sequencing, `await tx.done` is
+      // never reached once the deletes reject, so tx.done's rejection escapes;
+      // the fix puts tx.done inside the same Promise.all, which attaches a
+      // handler to it (its `.then` runs) regardless of the delete failure.
+      const db = await service['_ensureDb']();
+      const realTransaction = db.transaction.bind(db);
+      const abortErr = new DOMException('simulated abort', 'AbortError');
+      const doneThen = jasmine
+        .createSpy('tx.done.then')
+        .and.callFake((onFulfilled?: unknown, onRejected?: unknown) =>
+          Promise.reject(abortErr).then(onFulfilled as never, onRejected as never),
+        );
+      const fakeTx = {
+        store: { delete: (): Promise<void> => Promise.reject(abortErr) },
+        // A thenable, so Promise.all([...deletes, tx.done]) invokes its `.then`.
+        done: { then: doneThen },
+      } as unknown as ReturnType<typeof db.transaction>;
+      spyOn(db, 'transaction').and.callFake(((
+        storeName: unknown,
+        mode?: unknown,
+        ...rest: unknown[]
+      ) =>
+        mode === 'readwrite'
+          ? fakeTx
+          : (
+              realTransaction as (...args: unknown[]) => ReturnType<typeof db.transaction>
+            )(storeName, mode, ...rest)) as typeof db.transaction);
+
+      // Observe-only contract: the prune resolves, never rejects into the caller.
+      await expectAsync(service.pruneOnStart(now)).toBeResolved();
+      // The abort was observed: tx.done was awaited despite the delete failure.
+      // Old sequencing would leave it unhandled — doneThen never called.
+      expect(doneThen).toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/app/op-log/sync/conflict-journal.service.spec.ts
+++ b/src/app/op-log/sync/conflict-journal.service.spec.ts
@@ -3,6 +3,7 @@ import { ConflictJournalService } from './conflict-journal.service';
 import {
   ConflictJournalEntry,
   JOURNAL_MAX_ENTRIES,
+  JOURNAL_PRUNE_SLACK,
   JOURNAL_RETENTION_DAYS,
 } from './conflict-journal.model';
 import { buildConflictJournalEntry } from './conflict-journal-emission.util';
@@ -149,6 +150,39 @@ describe('ConflictJournalService (store)', () => {
       expect(await service.getEntry('entry-0')).toBeUndefined();
       expect((await service.list('history')).length).toBe(JOURNAL_MAX_ENTRIES);
       expect(await service.getEntry(`entry-${JOURNAL_MAX_ENTRIES}`)).toBeTruthy();
+    });
+  });
+
+  describe('opportunistic retention on record() (SPAP-36)', () => {
+    it('does NOT prune while the count is within the soft cap', async () => {
+      const now = Date.now();
+      const softCap = JOURNAL_MAX_ENTRIES + JOURNAL_PRUNE_SLACK;
+      for (let i = 0; i < softCap; i++) {
+        await service.record(
+          makeEntry({ id: `entry-${i}`, resolvedAt: now - (softCap - i) }),
+        );
+      }
+
+      // Exactly at the soft cap: nothing pruned mid-session yet.
+      expect((await service.list('history')).length).toBe(softCap);
+      expect(await service.getEntry('entry-0')).toBeTruthy();
+    });
+
+    it('prunes back to JOURNAL_MAX_ENTRIES when record() crosses the soft cap', async () => {
+      const now = Date.now();
+      const softCap = JOURNAL_MAX_ENTRIES + JOURNAL_PRUNE_SLACK;
+      // One entry past the soft cap → the crossing record() triggers the prune.
+      for (let i = 0; i <= softCap; i++) {
+        await service.record(
+          makeEntry({ id: `entry-${i}`, resolvedAt: now - (softCap - i) }),
+        );
+      }
+
+      const history = await service.list('history');
+      expect(history.length).toBe(JOURNAL_MAX_ENTRIES);
+      // Oldest overflow dropped, newest kept.
+      expect(await service.getEntry('entry-0')).toBeUndefined();
+      expect(await service.getEntry(`entry-${softCap}`)).toBeTruthy();
     });
   });
 

--- a/src/app/op-log/sync/conflict-journal.service.ts
+++ b/src/app/op-log/sync/conflict-journal.service.ts
@@ -256,8 +256,14 @@ export class ConflictJournalService {
 
     if (idsToDelete.size > 0) {
       const tx = db.transaction(CONFLICT_JOURNAL_STORE, 'readwrite');
-      await Promise.all(Array.from(idsToDelete, (id) => tx.store.delete(id)));
-      await tx.done;
+      // Await the delete requests AND tx.done together. If the transaction aborts
+      // while requests are still pending, both the delete aggregate and tx.done
+      // reject; awaiting them separately (delete first, then tx.done) leaves
+      // tx.done's rejection without a handler once the delete aggregate rejects,
+      // so it escapes as a global unhandled rejection. Putting tx.done inside the
+      // same Promise.all attaches a handler to it, so no rejection escapes.
+      const deletes = Array.from(idsToDelete, (id) => tx.store.delete(id));
+      await Promise.all([...deletes, tx.done]);
     }
 
     return idsToDelete.size;

--- a/src/app/op-log/sync/conflict-journal.service.ts
+++ b/src/app/op-log/sync/conflict-journal.service.ts
@@ -32,6 +32,7 @@ import {
   ConflictJournalStatus,
   ConflictJournalView,
   JOURNAL_MAX_ENTRIES,
+  JOURNAL_PRUNE_SLACK,
   JOURNAL_RETENTION_DAYS,
 } from './conflict-journal.model';
 
@@ -117,6 +118,14 @@ export class ConflictJournalService {
     try {
       const db = await this._ensureDb();
       await db.put(CONFLICT_JOURNAL_STORE, entry);
+      // SPAP-36: retention was only enforced at app start, so a long-lived
+      // session could grow the store unboundedly. count() is cheap; the O(n)
+      // prune runs only when the store exceeds the soft cap, i.e. amortized
+      // once every JOURNAL_PRUNE_SLACK records.
+      const count = await db.count(CONFLICT_JOURNAL_STORE);
+      if (count > JOURNAL_MAX_ENTRIES + JOURNAL_PRUNE_SLACK) {
+        await this._prune(db, Date.now());
+      }
       await this._refreshUnreviewedCount(db);
     } catch (err) {
       OpLog.err('ConflictJournalService: failed to record entry (ignored)', err);
@@ -203,42 +212,55 @@ export class ConflictJournalService {
     // return 0, not reject — and _ensureDb already resets its poisoned promise.
     try {
       const db = await this._ensureDb();
-      // Ascending by resolvedAt (oldest first).
-      const ascending = await db.getAllFromIndex(
-        CONFLICT_JOURNAL_STORE,
-        CONFLICT_JOURNAL_INDEX_RESOLVED_AT,
-      );
-
-      const retentionWindowMs = JOURNAL_RETENTION_DAYS * DAY_MS;
-      const cutoff = now - retentionWindowMs;
-      const idsToDelete = new Set<string>();
-
-      for (const entry of ascending) {
-        if (entry.resolvedAt < cutoff) {
-          idsToDelete.add(entry.id);
-        }
-      }
-
-      // Count bound applies to the survivors of the age prune; drop the oldest
-      // overflow so only the newest JOURNAL_MAX_ENTRIES remain.
-      const survivors = ascending.filter((entry) => !idsToDelete.has(entry.id));
-      const overflow = survivors.length - JOURNAL_MAX_ENTRIES;
-      for (let i = 0; i < overflow; i++) {
-        idsToDelete.add(survivors[i].id);
-      }
-
-      if (idsToDelete.size > 0) {
-        const tx = db.transaction(CONFLICT_JOURNAL_STORE, 'readwrite');
-        await Promise.all(Array.from(idsToDelete, (id) => tx.store.delete(id)));
-        await tx.done;
-      }
-
+      const deleted = await this._prune(db, now);
       await this._refreshUnreviewedCount(db);
-      return idsToDelete.size;
+      return deleted;
     } catch (err) {
       OpLog.err('ConflictJournalService: pruneOnStart failed (ignored)', err);
       return 0;
     }
+  }
+
+  /**
+   * Prune core shared by `pruneOnStart` and `record()`'s opportunistic prune:
+   * age bound first, then the count bound on the survivors. Returns the number
+   * of entries deleted. Callers own error handling and the count refresh.
+   */
+  private async _prune(
+    db: IDBPDatabase<ConflictJournalDB>,
+    now: number,
+  ): Promise<number> {
+    // Ascending by resolvedAt (oldest first).
+    const ascending = await db.getAllFromIndex(
+      CONFLICT_JOURNAL_STORE,
+      CONFLICT_JOURNAL_INDEX_RESOLVED_AT,
+    );
+
+    const retentionWindowMs = JOURNAL_RETENTION_DAYS * DAY_MS;
+    const cutoff = now - retentionWindowMs;
+    const idsToDelete = new Set<string>();
+
+    for (const entry of ascending) {
+      if (entry.resolvedAt < cutoff) {
+        idsToDelete.add(entry.id);
+      }
+    }
+
+    // Count bound applies to the survivors of the age prune; drop the oldest
+    // overflow so only the newest JOURNAL_MAX_ENTRIES remain.
+    const survivors = ascending.filter((entry) => !idsToDelete.has(entry.id));
+    const overflow = survivors.length - JOURNAL_MAX_ENTRIES;
+    for (let i = 0; i < overflow; i++) {
+      idsToDelete.add(survivors[i].id);
+    }
+
+    if (idsToDelete.size > 0) {
+      const tx = db.transaction(CONFLICT_JOURNAL_STORE, 'readwrite');
+      await Promise.all(Array.from(idsToDelete, (id) => tx.store.delete(id)));
+      await tx.done;
+    }
+
+    return idsToDelete.size;
   }
 
   /**


### PR DESCRIPTION
Small follow-up to #8874 (deferred LOW from its review): journal retention (`pruneOnStart`, 14 days / newest 200) ran only at app start, so a long-lived session could grow `SUP_CONFLICT_JOURNAL` without bound.

- `record()` now checks the store count after each put — `count()` is cheap — and when it exceeds `JOURNAL_MAX_ENTRIES + JOURNAL_PRUNE_SLACK` (200 + 20) runs the same age+count prune, bringing the store back to 200. The O(n) prune is amortized to once every 20 records.
- The prune core is extracted into a private `_prune()` shared with `pruneOnStart` (no behavior change there — its specs are untouched and green).
- `record()`'s observe-only never-throw contract is unchanged (the prune runs inside its existing try).
- Specs: no prune at the soft cap; crossing record prunes back to `JOURNAL_MAX_ENTRIES` (oldest dropped, newest kept). Journal suite 24/24; conflict + backup regression suites 289/289. `tsc`/`eslint`/`prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)