### PR TITLE
fix(sync): suppress the "Project updated" snack on conflict-review flips

### DIFF
--- a/src/app/features/project/store/project.actions.ts
+++ b/src/app/features/project/store/project.actions.ts
@@ -31,7 +31,9 @@ export const addProjects = createAction(
 
 export const updateProject = createAction(
   '[Project] Update Project',
-  (projectProps: { project: Update<Project> }) => ({
+  // isSkipSnack: suppress the unconditional "Project updated" snack — used by
+  // flows that surface their own outcome (e.g. the conflict-review flip).
+  (projectProps: { project: Update<Project>; isSkipSnack?: boolean }) => ({
     ...projectProps,
     meta: {
       isPersistent: true,

--- a/src/app/features/project/store/project.effects.spec.ts
+++ b/src/app/features/project/store/project.effects.spec.ts
@@ -187,6 +187,35 @@ describe('ProjectEffects', () => {
     });
   });
 
+  describe('snackUpdateBaseSettings$', () => {
+    it('shows the "Project updated" snack for a normal updateProject', fakeAsync(() => {
+      effects.snackUpdateBaseSettings$.subscribe();
+
+      actions$.next(
+        updateProject({
+          project: { id: 'project-1', changes: { title: 'New title' } },
+        }),
+      );
+
+      tick(100);
+      expect(snackServiceSpy.open).toHaveBeenCalled();
+    }));
+
+    it('suppresses the snack when isSkipSnack is set (conflict-review flip)', fakeAsync(() => {
+      effects.snackUpdateBaseSettings$.subscribe();
+
+      actions$.next(
+        updateProject({
+          project: { id: 'project-1', changes: { title: 'Flipped title' } },
+          isSkipSnack: true,
+        }),
+      );
+
+      tick(100);
+      expect(snackServiceSpy.open).not.toHaveBeenCalled();
+    }));
+  });
+
   describe('moveAllProjectToTodayListWhenBacklogIsDisabled$', () => {
     it('should dispatch moveAllProjectBacklogTasksToRegularList when backlog is disabled', (done) => {
       effects.moveAllProjectToTodayListWhenBacklogIsDisabled$.subscribe((action: any) => {

--- a/src/app/features/project/store/project.effects.ts
+++ b/src/app/features/project/store/project.effects.ts
@@ -107,7 +107,8 @@ export class ProjectEffects {
   snackUpdateBaseSettings$: Observable<unknown> = createEffect(
     () =>
       this._actions$.pipe(
-        ofType(updateProject.type),
+        ofType(updateProject),
+        filter((a) => !a.isSkipSnack),
         tap(() => {
           this._snackService.open({
             type: 'SUCCESS',

--- a/src/app/op-log/sync/sync-conflict-ui.service.spec.ts
+++ b/src/app/op-log/sync/sync-conflict-ui.service.spec.ts
@@ -10,6 +10,9 @@ import { SnackService } from '../../core/snack/snack.service';
 import { EntityType } from '../core/operation.types';
 import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 import { selectTaskById } from '../../features/tasks/store/task.selectors';
+import { selectProjectById } from '../../features/project/store/project.selectors';
+import { updateProject } from '../../features/project/store/project.actions';
+import { Project } from '../../features/project/project.model';
 import { Task } from '../../features/tasks/task.model';
 
 const makeEntry = (over: Partial<ConflictJournalEntry> = {}): ConflictJournalEntry => ({
@@ -73,6 +76,13 @@ describe('SyncConflictUiService', () => {
       title: 'Remote title',
     } as Task);
     dispatchSpy = spyOn(store, 'dispatch').and.callThrough();
+  });
+
+  afterEach(() => {
+    // overrideSelector mutates the SHARED selector references (selectTaskById /
+    // selectProjectById) — without a reset the overrides leak into other spec
+    // files in the same karma bundle (e.g. project.service.spec).
+    store.resetSelectors();
   });
 
   it('keep() marks the entry kept', async () => {
@@ -380,6 +390,36 @@ describe('SyncConflictUiService', () => {
     const changes = dispatched.task.changes as Record<string, unknown>;
     expect(changes).toEqual({ title: 'Local title' });
     expect(Object.prototype.hasOwnProperty.call(changes, 'notes')).toBe(false);
+  });
+
+  it('flip() on a PROJECT entry suppresses the "Project updated" snack (isSkipSnack)', async () => {
+    // The flip already reports its own outcome; without isSkipSnack the
+    // unconditional snackUpdateBaseSettings$ effect would ALSO pop
+    // "Project updated" on top of it.
+    const entry = makeEntry({
+      id: 'p1',
+      entityType: 'PROJECT' as EntityType,
+      entityId: 'project-1',
+    });
+    await journal.record(entry);
+    store.overrideSelector(selectProjectById, {
+      id: 'project-1',
+      title: 'Remote title',
+    } as Project);
+    store.refreshState();
+
+    const result = await service.flip(entry);
+
+    expect(result).toBe('applied');
+    const dispatched = dispatchSpy.calls.mostRecent().args[0] as ReturnType<
+      typeof updateProject
+    >;
+    expect(dispatched.type).toBe(updateProject.type);
+    expect(dispatched.project).toEqual({
+      id: 'project-1',
+      changes: { title: 'Local title' },
+    });
+    expect((dispatched as { isSkipSnack?: boolean }).isSkipSnack).toBe(true);
   });
 
   it('canFlip() is false for delete-lost and delete-wins entries', () => {

--- a/src/app/op-log/sync/sync-conflict-ui.service.ts
+++ b/src/app/op-log/sync/sync-conflict-ui.service.ts
@@ -280,6 +280,9 @@ export class SyncConflictUiService {
             id: entityId,
             changes: changes as Partial<Project>,
           } as Update<Project>,
+          // The flip flow reports its own outcome — without this the
+          // unconditional "Project updated" snack pops on top of it.
+          isSkipSnack: true,
         });
       case 'NOTE':
         return updateNote({


### PR DESCRIPTION
Follow-up from the independent review passes of #8874: flipping a PROJECT conflict entry dispatches `updateProject`, whose `snackUpdateBaseSettings$` effect popped an unconditional "Project updated" snack on top of the flip flow's own outcome reporting.

- `updateProject` gains an optional `isSkipSnack` flag (mirroring `updateTask`'s `isIgnoreShortSyntax` precedent for flow-specific flags riding on the action); the snack effect filters on it; the flip path sets it.
- Specs: snack still shown for a normal update, suppressed with the flag, and the PROJECT flip dispatches with the flag set.
- Also adds a `MockStore.resetSelectors()` `afterEach` to the conflict-ui spec — `overrideSelector` mutates the shared selector references, and the new `selectProjectById` override otherwise leaked into `project.service.spec` when bundled in the same karma run (the pre-existing `selectTaskById` override had the same latent issue).

Of the three below-fix-bar items noted in that review: item 2 (journal `clearAll()` outside the op-log lock window) is already fixed on master (clearAll now runs inside the lock); item 3 (journaled post-resolution baseline for local-won stale detection) is the maintainer's documented follow-up and is deliberately not attempted here.

Verification: project + conflict suites 346/346, `tsc`/`eslint`/`prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)