### PR TITLE
fix(settings): Prevent tab shift in settings tabs when page is scrollable

### DIFF
--- a/src/app/pages/config-page/config-page.component.html
+++ b/src/app/pages/config-page/config-page.component.html
@@ -1,4 +1,4 @@
-<div class="page-settings page-wrapper">
+<div class="page-settings">
   @if (globalCfg) {
     <div class="settings-container">
       <!-- Shared by every tab's `mat-tab-label`: an icon + translated title. -->
@@ -13,6 +13,58 @@
           >{{ icon }}</mat-icon
         >
         <span class="tab-label">{{ labelKey | translate }}</span>
+      </ng-template>
+
+      <!-- Rendered at the bottom of every tab so it scrolls away with the tab's
+           content (the tab body, not the page, is the scroll container). -->
+      <ng-template #versionFooter>
+        <footer
+          class="version-footer"
+          title="Rev {{ versions?.revision }} {{ versions?.branch }} {{
+            versions?.version
+          }}"
+        >
+          Super Productivity
+          <a
+            class="version"
+            [matTooltip]="T.PS.CLICK_TO_COPY_VERSION | translate"
+            (click)="copyVersionToClipboard(appVersion); $event?.preventDefault()"
+            href="#"
+            >{{ appVersion }}<mat-icon>content_copy</mat-icon></a
+          >
+          –
+          <a
+            href="https://github.com/super-productivity/super-productivity/releases/latest"
+            target="_blank"
+            >Changelog</a
+          >
+          @if (isUpdateCheckPossible) {
+            –
+            <a
+              (click)="checkForUpdates(); $event?.preventDefault()"
+              href="#"
+              >{{ T.PS.CHECK_FOR_UPDATES | translate }}</a
+            >
+          }
+          –
+          <a
+            (click)="showLogs(); $event?.preventDefault()"
+            href="#"
+            >Logs</a
+          >
+          –
+          <a
+            href="https://super-productivity.com/privacy/"
+            target="_blank"
+            >{{ T.PS.PRIVACY_POLICY | translate }}</a
+          >
+          –
+          <a
+            href="https://github.com/super-productivity/super-productivity/discussions/new"
+            target="_blank"
+            >{{ T.PS.PROVIDE_FEEDBACK | translate }}</a
+          >
+        </footer>
       </ng-template>
 
       <mat-tab-group
@@ -45,6 +97,7 @@
                 ></config-section>
               </section>
             }
+            <ng-container *ngTemplateOutlet="versionFooter"></ng-container>
           </div>
         </mat-tab>
 
@@ -82,6 +135,7 @@
                 (save)="saveGlobalCfg($event)"
               ></config-sound-form>
             </section>
+            <ng-container *ngTemplateOutlet="versionFooter"></ng-container>
           </div>
         </mat-tab>
 
@@ -109,6 +163,7 @@
                 ></config-section>
               </section>
             }
+            <ng-container *ngTemplateOutlet="versionFooter"></ng-container>
           </div>
         </mat-tab>
 
@@ -136,6 +191,7 @@
                 ></config-section>
               </section>
             }
+            <ng-container *ngTemplateOutlet="versionFooter"></ng-container>
           </div>
         </mat-tab>
 
@@ -166,6 +222,7 @@
                 ></config-section>
               </section>
             }
+            <ng-container *ngTemplateOutlet="versionFooter"></ng-container>
           </div>
         </mat-tab>
 
@@ -258,55 +315,10 @@
                 ></config-section>
               </section>
             }
+            <ng-container *ngTemplateOutlet="versionFooter"></ng-container>
           </div>
         </mat-tab>
       </mat-tab-group>
     </div>
   }
 </div>
-
-<footer
-  class="version-footer"
-  title="Rev {{ versions?.revision }} {{ versions?.branch }} {{ versions?.version }}"
->
-  Super Productivity
-  <a
-    class="version"
-    [matTooltip]="T.PS.CLICK_TO_COPY_VERSION | translate"
-    (click)="copyVersionToClipboard(appVersion); $event?.preventDefault()"
-    href="#"
-    >{{ appVersion }}<mat-icon>content_copy</mat-icon></a
-  >
-  –
-  <a
-    href="https://github.com/super-productivity/super-productivity/releases/latest"
-    target="_blank"
-    >Changelog</a
-  >
-  @if (isUpdateCheckPossible) {
-    –
-    <a
-      (click)="checkForUpdates(); $event?.preventDefault()"
-      href="#"
-      >{{ T.PS.CHECK_FOR_UPDATES | translate }}</a
-    >
-  }
-  –
-  <a
-    (click)="showLogs(); $event?.preventDefault()"
-    href="#"
-    >Logs</a
-  >
-  –
-  <a
-    href="https://super-productivity.com/privacy/"
-    target="_blank"
-    >{{ T.PS.PRIVACY_POLICY | translate }}</a
-  >
-  –
-  <a
-    href="https://github.com/super-productivity/super-productivity/discussions/new"
-    target="_blank"
-    >{{ T.PS.PROVIDE_FEEDBACK | translate }}</a
-  >
-</footer>

--- a/src/app/pages/config-page/config-page.component.scss
+++ b/src/app/pages/config-page/config-page.component.scss
@@ -1,25 +1,24 @@
 @use '../../../styles/_globals.scss' as *;
 
+:host {
+  display: flex;
+}
+
 .page-settings {
   text-align: start;
+  display: flex;
+  flex: 1;
 
   .settings-container {
-    max-width: 100%;
+    display: flex;
+    flex: 1;
   }
 
   .settings-tabs {
-    // Prevent focus-induced scroll jumps: Material tab body containers default to
-    // overflow:auto/hidden, which makes the browser's focus-scrolling algorithm
-    // treat them as scroll boundaries and reset the parent scroll position.
-    ::ng-deep .mat-mdc-tab-body-wrapper,
-    ::ng-deep .mat-mdc-tab-body-active,
-    ::ng-deep .mat-mdc-tab-body-content {
-      overflow: visible !important;
-    }
+    flex: 1;
 
     ::ng-deep .mat-mdc-tab-header {
       border-bottom: 1px solid var(--divider-color);
-      margin-bottom: var(--s2);
     }
 
     ::ng-deep .mat-mdc-tab {
@@ -54,6 +53,7 @@
 
   .tab-content {
     padding-top: var(--s2);
+    padding-inline: var(--s2);
     max-width: 900px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

While getting to know the app better, I noticed that when I switched to a tab that was tall enough to activate the scrollbar, the entire settings page tab navigation would shift:

https://github.com/user-attachments/assets/7a409478-79e2-473c-bef0-cd4215056f73

## Solution

<!-- Describe your changes in detail. -->

This PR modifies the CSS so that:
1. The tabs no longer are part of the scrollable area, they will never move when the scrollbar comes in or out
2. Makes the tab flush with the side of the page instead of having a small bit of padding. This puts it in line with other tab pages, like Boards, which don't have the gap
3. Makes the tabs sticky, that seems genuinely useful to always have access to the navigation when looking at settings

https://github.com/user-attachments/assets/bdf1b0df-403a-4119-9d20-098fb17bd5c8

This works in mobile view too. Everything should be practically identical, just without the shift on tall pages!

I felt like the footer shouldn't always be visible, which happened when I first changed the scrollable area, so there's a 50-odd line copy/paste and render of a template refactor included so that the footer is at the bottom of each settings page and not always visible.

## Screenshots

Mobile view of scrolling page
<img width="776" height="1293" alt="image" src="https://github.com/user-attachments/assets/b35fcc3a-184c-4505-9483-f10273d6a0fa" />

Mobile view of short page:
<img width="776" height="1293" alt="image" src="https://github.com/user-attachments/assets/57281efd-2713-4921-ac98-3a1c283342d1" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
