### PR TITLE
fix(supersync-server): op data-loss on retention/cleanup & auth-endpoint hardening

### DIFF
--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -39,7 +39,7 @@ All sync endpoints require **JWT Bearer** authentication: `Authorization: Bearer
 - `POST /api/login/magic-link` — Request magic link email.
 - `POST /api/login/magic-link/verify` — Verify magic link token.
 
-Registration and email-link request responses are intentionally neutral: they do not reveal whether an email address already has an account. While an unexpired login or passkey-recovery link is outstanding, another request returns the same response without rotating the token or sending another email.
+Registration and email-link request responses are intentionally neutral: they do not reveal whether an email address already has an account. Delivery failures and verification resend caps are logged internally but return the same public response. While an unexpired login or passkey-recovery link is outstanding, another request returns the same response without rotating the token or sending another email.
 
 **Account:**
 
@@ -111,7 +111,7 @@ Configurable via environment/config. Typical allowed headers include `Authorizat
 
 ### Data Retention
 
-Stored operations and devices use a default **45-day** retention window, measured from when the server received an operation or last saw a device rather than from the operation's client timestamp. This allows a device that was offline for a long time to upload its pending operations without changing their conflict-resolution timestamps. Eligible operation cleanup preserves the latest covered full-state operation and every operation after it so a new client can still replay the retained log; without a full-state base, the operation log is left intact.
+Stored operations and devices use a default **45-day** retention window, measured from when the server received an operation or last saw a device rather than from the operation's client timestamp. This allows a device that was offline for a long time to upload its pending operations without changing their conflict-resolution timestamps. Eligible operation cleanup preserves the latest covered full-state operation and every operation after it so a new client can still replay the retained log. Without a full-state base, the operation log is left intact and the server emits a cleanup warning: this deliberately favors recoverability over retention/quota reclamation until a replay base exists.
 
 ### Request Deduplication
 

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -111,7 +111,7 @@ Configurable via environment/config. Typical allowed headers include `Authorizat
 
 ### Data Retention
 
-Stored operations and devices use a default **45-day** retention window, measured from when the server received an operation or last saw a device rather than from the operation's client timestamp. This allows a device that was offline for a long time to upload its pending operations without changing their conflict-resolution timestamps. Eligible operation cleanup preserves the latest covered full-state operation and every operation after it so a new client can still replay the retained log. Without a full-state base, the operation log is left intact and the server emits a cleanup warning: this deliberately favors recoverability over retention/quota reclamation until a replay base exists.
+Stored operations and devices use a default **45-day** retention window, measured from when the server received an operation or last saw a device rather than from the operation's client timestamp. This allows a device that was offline for a long time to upload its pending operations without changing their conflict-resolution timestamps. Eligible operation cleanup preserves the latest covered full-state operation and every operation after it so a new client can still replay the retained log. When an eligible cleanup candidate has no full-state base, its operation log is left intact and the server includes it in an aggregate cleanup warning. This deliberately favors recoverability over retention/quota reclamation until a replay base exists.
 
 ### Request Deduplication
 

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -39,6 +39,8 @@ All sync endpoints require **JWT Bearer** authentication: `Authorization: Bearer
 - `POST /api/login/magic-link` — Request magic link email.
 - `POST /api/login/magic-link/verify` — Verify magic link token.
 
+Registration and email-link request responses are intentionally neutral: they do not reveal whether an email address already has an account. While an unexpired login or passkey-recovery link is outstanding, another request returns the same response without rotating the token or sending another email.
+
 **Account:**
 
 - `DELETE /api/account` — Delete user and all data (requires auth).
@@ -109,7 +111,7 @@ Configurable via environment/config. Typical allowed headers include `Authorizat
 
 ### Data Retention
 
-Operations, devices, and related validation data are retained for **45 days**. Older data is purged.
+Stored operations and devices use a default **45-day** retention window, measured from when the server received an operation or last saw a device rather than from the operation's client timestamp. This allows a device that was offline for a long time to upload its pending operations without changing their conflict-resolution timestamps. Eligible operation cleanup preserves the latest covered full-state operation and every operation after it so a new client can still replay the retained log; without a full-state base, the operation log is left intact.
 
 ### Request Deduplication
 

--- a/packages/super-sync-server/src/api.ts
+++ b/packages/super-sync-server/src/api.ts
@@ -99,20 +99,16 @@ const SAFE_ERROR_MESSAGES = new Set([
   'Invalid verification token',
   'Verification token has expired',
   'Registration successful. Please check your email to verify your account.',
-  'Failed to send verification email. Please try again later.',
   // Passkey-specific messages
   'Challenge expired or not found. Please try again.',
   'Passkey verification failed. Please try again.',
   'Passkey verification failed',
   'If an account with that email exists, a recovery link has been sent.',
-  'Failed to send recovery email. Please try again later.',
   'Invalid or expired recovery token',
   'Passkey has been reset successfully. You can now log in with your new passkey.',
   // Magic link messages
   'If an account with that email exists, a login link has been sent.',
-  'Failed to send login email. Please try again later.',
   'Invalid or expired login link',
-  'Too many verification attempts. Please try again later or contact support.',
 ]);
 
 // Returns a safe error message for clients (hides internal details)

--- a/packages/super-sync-server/src/api.ts
+++ b/packages/super-sync-server/src/api.ts
@@ -101,7 +101,6 @@ const SAFE_ERROR_MESSAGES = new Set([
   'Registration successful. Please check your email to verify your account.',
   'Failed to send verification email. Please try again later.',
   // Passkey-specific messages
-  'An account with this email already exists',
   'Challenge expired or not found. Please try again.',
   'Passkey verification failed. Please try again.',
   'Passkey verification failed',

--- a/packages/super-sync-server/src/auth.ts
+++ b/packages/super-sync-server/src/auth.ts
@@ -269,7 +269,7 @@ export const requestLoginMagicLink = async (
         loginTokenExpiresAt: null,
       },
     });
-    throw new Error('Failed to send login email. Please try again later.');
+    return successMessage;
   }
 
   Logger.info(`Magic link login requested (ID: ${user.id})`);
@@ -290,9 +290,10 @@ export const verifyLoginMagicLink = async (
     throw new Error('Invalid or expired login link');
   }
 
-  if (user.loginTokenExpiresAt && user.loginTokenExpiresAt < BigInt(Date.now())) {
-    await prisma.user.update({
-      where: { id: user.id },
+  const now = BigInt(Date.now());
+  if (user.loginTokenExpiresAt && user.loginTokenExpiresAt < now) {
+    await prisma.user.updateMany({
+      where: { id: user.id, loginToken: token },
       data: {
         loginToken: null,
         loginTokenExpiresAt: null,
@@ -301,9 +302,14 @@ export const verifyLoginMagicLink = async (
     throw new Error('Invalid or expired login link');
   }
 
-  // Clear the token (single use) and reset any failed attempts
-  await prisma.user.update({
-    where: { id: user.id },
+  // Consume the exact token atomically. A concurrent redemption or renewal
+  // must not issue a second JWT or clear a replacement token.
+  const consume = await prisma.user.updateMany({
+    where: {
+      id: user.id,
+      loginToken: token,
+      OR: [{ loginTokenExpiresAt: null }, { loginTokenExpiresAt: { gte: now } }],
+    },
     data: {
       loginToken: null,
       loginTokenExpiresAt: null,
@@ -311,6 +317,9 @@ export const verifyLoginMagicLink = async (
       lockedUntil: null,
     },
   });
+  if (consume.count !== 1) {
+    throw new Error('Invalid or expired login link');
+  }
 
   const tokenVersion = user.tokenVersion ?? 0;
   const jwtToken = jwt.sign(
@@ -353,16 +362,15 @@ export const registerWithMagicLink = async (
 
     if (existingUser) {
       if (existingUser.verificationResendCount >= MAX_VERIFICATION_RESEND_COUNT) {
-        throw new Error(
-          'Too many verification attempts. Please try again later or contact support.',
-        );
+        Logger.warn(`Verification resend cap reached (ID: ${existingUser.id})`);
+        return { message: REGISTRATION_SUCCESS_MESSAGE };
       }
 
       if (!config.testMode?.autoVerifyUsers) {
         // Send email BEFORE updating DB to avoid invalidating the old token on failure
         const emailSent = await sendVerificationEmail(normalizedEmail, verificationToken);
         if (!emailSent) {
-          throw new Error('Failed to send verification email. Please try again later.');
+          return { message: REGISTRATION_SUCCESS_MESSAGE };
         }
       }
 
@@ -407,7 +415,7 @@ export const registerWithMagicLink = async (
             where: { email: normalizedEmail, isVerified: 0 },
           });
           Logger.info(`Cleaned up failed magic-link registration for new user`);
-          throw new Error('Failed to send verification email. Please try again later.');
+          return { message: REGISTRATION_SUCCESS_MESSAGE };
         }
       }
     }

--- a/packages/super-sync-server/src/auth.ts
+++ b/packages/super-sync-server/src/auth.ts
@@ -18,6 +18,8 @@ export const JWT_EXPIRY = '365d';
 
 export const VERIFICATION_TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const MAX_VERIFICATION_RESEND_COUNT = 20;
+const REGISTRATION_SUCCESS_MESSAGE =
+  'Registration successful. Please check your email to verify your account.';
 const LOGIN_MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
 
 export const getJwtSecret = (): string => {
@@ -228,21 +230,40 @@ export const requestLoginMagicLink = async (
     return successMessage;
   }
 
-  const loginToken = randomBytes(32).toString('hex');
-  const expiresAt = BigInt(Date.now() + LOGIN_MAGIC_LINK_EXPIRY_MS);
+  const now = Date.now();
+  if (
+    user.loginToken &&
+    user.loginTokenExpiresAt !== null &&
+    user.loginTokenExpiresAt > BigInt(now)
+  ) {
+    return successMessage;
+  }
 
-  await prisma.user.update({
-    where: { id: user.id },
+  const loginToken = randomBytes(32).toString('hex');
+  const expiresAt = BigInt(now + LOGIN_MAGIC_LINK_EXPIRY_MS);
+
+  // Claim the expired/empty token slot atomically. Concurrent requests for the
+  // same account must not each rotate the token and send another email.
+  const claim = await prisma.user.updateMany({
+    where: {
+      id: user.id,
+      OR: [
+        { loginToken: null },
+        { loginTokenExpiresAt: null },
+        { loginTokenExpiresAt: { lte: BigInt(now) } },
+      ],
+    },
     data: {
       loginToken,
       loginTokenExpiresAt: expiresAt,
     },
   });
+  if (claim.count === 0) return successMessage;
 
   const emailSent = await sendLoginMagicLinkEmail(email, loginToken);
   if (!emailSent) {
-    await prisma.user.update({
-      where: { id: user.id },
+    await prisma.user.updateMany({
+      where: { id: user.id, loginToken },
       data: {
         loginToken: null,
         loginTokenExpiresAt: null,
@@ -319,7 +340,7 @@ export const registerWithMagicLink = async (
   });
 
   if (existingUser?.isVerified === 1) {
-    throw new Error('An account with this email already exists');
+    return { message: REGISTRATION_SUCCESS_MESSAGE };
   }
 
   const verificationToken = randomBytes(32).toString('hex');
@@ -407,12 +428,10 @@ export const registerWithMagicLink = async (
     }
 
     Logger.info(`Magic-link registration initiated`);
-    return {
-      message: 'Registration successful. Please check your email to verify your account.',
-    };
+    return { message: REGISTRATION_SUCCESS_MESSAGE };
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
-      throw new Error('An account with this email already exists');
+      return { message: REGISTRATION_SUCCESS_MESSAGE };
     }
     throw err;
   }

--- a/packages/super-sync-server/src/passkey.ts
+++ b/packages/super-sync-server/src/passkey.ts
@@ -22,6 +22,8 @@ import { authCache } from './auth-cache';
 // Constants
 const CHALLENGE_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
 const RECOVERY_TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+const REGISTRATION_SUCCESS_MESSAGE =
+  'Registration successful. Please check your email to verify your account.';
 
 // WebAuthn configuration from environment
 const getWebAuthnConfig = (): { rpName: string; rpID: string; origin: string } => {
@@ -85,28 +87,15 @@ export const generateRegistrationOptions = async (
 ): Promise<PublicKeyCredentialCreationOptionsJSON> => {
   const { rpName, rpID } = getWebAuthnConfig();
 
-  // Check if email already exists and is verified
-  const existingUser = await prisma.user.findUnique({
-    where: { email: email.toLowerCase() },
-    include: { passkeys: true },
-  });
-
-  if (existingUser?.isVerified === 1) {
-    throw new Error('An account with this email already exists');
-  }
-
   // Generate options
   const options = await webAuthnGenerateRegistration({
     rpName,
     rpID,
     userName: email,
     userDisplayName: email,
-    // Prevent re-registering existing passkeys
-    excludeCredentials:
-      existingUser?.passkeys.map((pk) => ({
-        id: Buffer.from(pk.credentialId).toString('base64url'),
-        transports: pk.transports ? JSON.parse(pk.transports) : undefined,
-      })) || [],
+    // Registration options must not reveal whether this email or any of its
+    // credentials already exist.
+    excludeCredentials: [],
     authenticatorSelection: {
       residentKey: 'required', // Required for synced passkeys (Google Password Manager)
       userVerification: 'preferred',
@@ -183,7 +172,7 @@ export const verifyRegistration = async (
 
     if (existingUser) {
       if (existingUser.isVerified === 1) {
-        throw new Error('An account with this email already exists');
+        return { message: REGISTRATION_SUCCESS_MESSAGE };
       }
 
       if (existingUser.verificationResendCount >= MAX_VERIFICATION_RESEND_COUNT) {
@@ -285,12 +274,10 @@ export const verifyRegistration = async (
     }
 
     Logger.info(`Passkey registration initiated`);
-    return {
-      message: 'Registration successful. Please check your email to verify your account.',
-    };
+    return { message: REGISTRATION_SUCCESS_MESSAGE };
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
-      throw new Error('An account with this email already exists');
+      return { message: REGISTRATION_SUCCESS_MESSAGE };
     }
     throw err;
   }
@@ -459,21 +446,38 @@ export const requestPasskeyRecovery = async (
     return successMessage;
   }
 
-  const recoveryToken = randomBytes(32).toString('hex');
-  const expiresAt = BigInt(Date.now() + RECOVERY_TOKEN_EXPIRY_MS);
+  const now = Date.now();
+  if (
+    user.passkeyRecoveryToken &&
+    user.passkeyRecoveryTokenExpiresAt !== null &&
+    user.passkeyRecoveryTokenExpiresAt > BigInt(now)
+  ) {
+    return successMessage;
+  }
 
-  await prisma.user.update({
-    where: { id: user.id },
+  const recoveryToken = randomBytes(32).toString('hex');
+  const expiresAt = BigInt(now + RECOVERY_TOKEN_EXPIRY_MS);
+
+  const claim = await prisma.user.updateMany({
+    where: {
+      id: user.id,
+      OR: [
+        { passkeyRecoveryToken: null },
+        { passkeyRecoveryTokenExpiresAt: null },
+        { passkeyRecoveryTokenExpiresAt: { lte: BigInt(now) } },
+      ],
+    },
     data: {
       passkeyRecoveryToken: recoveryToken,
       passkeyRecoveryTokenExpiresAt: expiresAt,
     },
   });
+  if (claim.count === 0) return successMessage;
 
   const emailSent = await sendPasskeyRecoveryEmail(email, recoveryToken);
   if (!emailSent) {
-    await prisma.user.update({
-      where: { id: user.id },
+    await prisma.user.updateMany({
+      where: { id: user.id, passkeyRecoveryToken: recoveryToken },
       data: {
         passkeyRecoveryToken: null,
         passkeyRecoveryTokenExpiresAt: null,

--- a/packages/super-sync-server/src/passkey.ts
+++ b/packages/super-sync-server/src/passkey.ts
@@ -24,6 +24,7 @@ const CHALLENGE_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
 const RECOVERY_TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
 const REGISTRATION_SUCCESS_MESSAGE =
   'Registration successful. Please check your email to verify your account.';
+type ChallengeCeremony = 'registration' | 'authentication' | 'recovery';
 
 // WebAuthn configuration from environment
 const getWebAuthnConfig = (): { rpName: string; rpID: string; origin: string } => {
@@ -35,7 +36,7 @@ const getWebAuthnConfig = (): { rpName: string; rpID: string; origin: string } =
   return { rpName, rpID, origin };
 };
 
-// In-memory challenge storage (short-lived, per-email)
+// In-memory challenge storage (short-lived, per ceremony and subject)
 // In production with multiple instances, use Redis or similar
 const challenges = new Map<string, { challenge: string; expiresAt: number }>();
 
@@ -58,15 +59,25 @@ setInterval(() => {
   }
 }, 60 * 1000); // Every minute
 
-const storeChallenge = (email: string, challenge: string): void => {
-  challenges.set(email.toLowerCase(), {
+const getChallengeKey = (ceremony: ChallengeCeremony, subject: string): string =>
+  `${ceremony}:${subject.toLowerCase()}`;
+
+const storeChallenge = (
+  ceremony: ChallengeCeremony,
+  subject: string,
+  challenge: string,
+): void => {
+  challenges.set(getChallengeKey(ceremony, subject), {
     challenge,
     expiresAt: Date.now() + CHALLENGE_EXPIRY_MS,
   });
 };
 
-const getAndClearChallenge = (email: string): string | null => {
-  const key = email.toLowerCase();
+const getAndClearChallenge = (
+  ceremony: ChallengeCeremony,
+  subject: string,
+): string | null => {
+  const key = getChallengeKey(ceremony, subject);
   const data = challenges.get(key);
   if (!data) return null;
 
@@ -103,7 +114,7 @@ export const generateRegistrationOptions = async (
     attestationType: 'none', // We don't need attestation
   });
 
-  storeChallenge(email, options.challenge);
+  storeChallenge('registration', email, options.challenge);
 
   Logger.info(
     `Registration options generated: ${JSON.stringify({
@@ -126,7 +137,7 @@ export const verifyRegistration = async (
 ): Promise<{ message: string }> => {
   const { rpID, origin } = getWebAuthnConfig();
 
-  const expectedChallenge = getAndClearChallenge(email);
+  const expectedChallenge = getAndClearChallenge('registration', email);
   if (!expectedChallenge) {
     throw new Error('Challenge expired or not found. Please try again.');
   }
@@ -176,9 +187,8 @@ export const verifyRegistration = async (
       }
 
       if (existingUser.verificationResendCount >= MAX_VERIFICATION_RESEND_COUNT) {
-        throw new Error(
-          'Too many verification attempts. Please try again later or contact support.',
-        );
+        Logger.warn(`Verification resend cap reached (ID: ${existingUser.id})`);
+        return { message: REGISTRATION_SUCCESS_MESSAGE };
       }
 
       // Update existing unverified user with new passkey
@@ -270,7 +280,7 @@ export const verifyRegistration = async (
         authCache.invalidate(user.id);
         Logger.info(`Cleaned up failed passkey registration (ID: ${user.id})`);
       }
-      throw new Error('Failed to send verification email. Please try again later.');
+      return { message: REGISTRATION_SUCCESS_MESSAGE };
     }
 
     Logger.info(`Passkey registration initiated`);
@@ -302,7 +312,7 @@ export const generateAuthenticationOptions = async (
       rpID,
       userVerification: 'preferred',
     });
-    storeChallenge(email, options.challenge);
+    storeChallenge('authentication', email, options.challenge);
     return options;
   }
 
@@ -318,7 +328,7 @@ export const generateAuthenticationOptions = async (
     userVerification: 'preferred',
   });
 
-  storeChallenge(email, options.challenge);
+  storeChallenge('authentication', email, options.challenge);
 
   Logger.info(
     `Generated passkey authentication options (userId: ${user.id}): rpId=${options.rpId}, discoverable=true`,
@@ -335,7 +345,7 @@ export const verifyAuthentication = async (
 ): Promise<{ userId: number; email: string }> => {
   const { rpID, origin } = getWebAuthnConfig();
 
-  const expectedChallenge = getAndClearChallenge(email);
+  const expectedChallenge = getAndClearChallenge('authentication', email);
   if (!expectedChallenge) {
     throw new Error('Challenge expired or not found. Please try again.');
   }
@@ -483,7 +493,7 @@ export const requestPasskeyRecovery = async (
         passkeyRecoveryTokenExpiresAt: null,
       },
     });
-    throw new Error('Failed to send recovery email. Please try again later.');
+    return successMessage;
   }
 
   Logger.info(`Passkey recovery requested (ID: ${user.id})`);
@@ -509,8 +519,8 @@ export const getRecoveryRegistrationOptions = async (
     user.passkeyRecoveryTokenExpiresAt &&
     user.passkeyRecoveryTokenExpiresAt < BigInt(Date.now())
   ) {
-    await prisma.user.update({
-      where: { id: user.id },
+    await prisma.user.updateMany({
+      where: { id: user.id, passkeyRecoveryToken: token },
       data: {
         passkeyRecoveryToken: null,
         passkeyRecoveryTokenExpiresAt: null,
@@ -536,7 +546,7 @@ export const getRecoveryRegistrationOptions = async (
   });
 
   // Store challenge with recovery token as key (since we don't want to leak email)
-  storeChallenge(`recovery:${token}`, options.challenge);
+  storeChallenge('recovery', token, options.challenge);
 
   Logger.debug(`Generated recovery registration options for user ${user.id}`);
   return { email: user.email, options };
@@ -563,10 +573,17 @@ export const completePasskeyRecovery = async (
     user.passkeyRecoveryTokenExpiresAt &&
     user.passkeyRecoveryTokenExpiresAt < BigInt(Date.now())
   ) {
+    await prisma.user.updateMany({
+      where: { id: user.id, passkeyRecoveryToken: token },
+      data: {
+        passkeyRecoveryToken: null,
+        passkeyRecoveryTokenExpiresAt: null,
+      },
+    });
     throw new Error('Invalid or expired recovery token');
   }
 
-  const expectedChallenge = getAndClearChallenge(`recovery:${token}`);
+  const expectedChallenge = getAndClearChallenge('recovery', token);
   if (!expectedChallenge) {
     throw new Error('Challenge expired or not found. Please try again.');
   }
@@ -601,6 +618,25 @@ export const completePasskeyRecovery = async (
 
   // Delete old passkeys and create new one, clear recovery token, invalidate sessions
   await prisma.$transaction(async (tx) => {
+    const consume = await tx.user.updateMany({
+      where: {
+        id: user.id,
+        passkeyRecoveryToken: token,
+        OR: [
+          { passkeyRecoveryTokenExpiresAt: null },
+          { passkeyRecoveryTokenExpiresAt: { gte: BigInt(Date.now()) } },
+        ],
+      },
+      data: {
+        passkeyRecoveryToken: null,
+        passkeyRecoveryTokenExpiresAt: null,
+        tokenVersion: { increment: 1 },
+      },
+    });
+    if (consume.count !== 1) {
+      throw new Error('Invalid or expired recovery token');
+    }
+
     await tx.passkey.deleteMany({ where: { userId: user.id } });
 
     await tx.passkey.create({
@@ -612,15 +648,6 @@ export const completePasskeyRecovery = async (
           ? JSON.stringify(credential.response.transports)
           : null,
         userId: user.id,
-      },
-    });
-
-    await tx.user.update({
-      where: { id: user.id },
-      data: {
-        passkeyRecoveryToken: null,
-        passkeyRecoveryTokenExpiresAt: null,
-        tokenVersion: { increment: 1 }, // Invalidate all existing JWT tokens
       },
     });
   });

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -416,6 +416,7 @@ export class StorageQuotaService {
     const affectedUserIds: number[] = [];
     const deleteBatchSize = getOldOpsCleanupDeleteBatchSize();
     let remainingDeleteBudget = getOldOpsCleanupMaxDeletedPerRun();
+    let usersWithoutReplayBase = 0;
 
     for (const state of states) {
       if (remainingDeleteBudget <= 0) break;
@@ -437,7 +438,11 @@ export class StorageQuotaService {
         orderBy: { serverSeq: 'desc' },
         select: { serverSeq: true },
       });
-      if (!latestFullStateOp || latestFullStateOp.serverSeq <= 1) continue;
+      if (!latestFullStateOp) {
+        usersWithoutReplayBase++;
+        continue;
+      }
+      if (latestFullStateOp.serverSeq <= 1) continue;
 
       // Drain this user across multiple batches until either they're empty or
       // the global per-run budget is exhausted. Without this, a single user
@@ -483,6 +488,13 @@ export class StorageQuotaService {
         // user is empty and another findMany would only confirm zero rows.
         if (deletedCount < batchLimit) break;
       }
+    }
+
+    if (usersWithoutReplayBase > 0) {
+      Logger.warn(
+        `Cleanup [old-ops]: ${usersWithoutReplayBase} user(s) have no full-state replay base; ` +
+          'retention cleanup is disabled for those histories.',
+      );
     }
 
     if (remainingDeleteBudget <= 0) {

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -423,8 +423,21 @@ export class StorageQuotaService {
       const snapshotAt = Number(state.snapshotAt);
       const lastSnapshotSeq = state.lastSnapshotSeq ?? 0;
 
-      // Only prune ops that are both older than the retention window and covered by a snapshot
+      // The cached snapshot is only exposed by restore endpoints; normal sync
+      // clients still bootstrap from the operation log. Therefore cleanup may
+      // only remove the superseded prefix before the newest full-state op and
+      // must keep that op plus its complete replay tail.
       if (!(snapshotAt >= cutoffTime && lastSnapshotSeq > 0)) continue;
+      const latestFullStateOp = await prisma.operation.findFirst({
+        where: {
+          userId: state.userId,
+          serverSeq: { lte: lastSnapshotSeq },
+          opType: { in: ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'] },
+        },
+        orderBy: { serverSeq: 'desc' },
+        select: { serverSeq: true },
+      });
+      if (!latestFullStateOp || latestFullStateOp.serverSeq <= 1) continue;
 
       // Drain this user across multiple batches until either they're empty or
       // the global per-run budget is exhausted. Without this, a single user
@@ -436,7 +449,7 @@ export class StorageQuotaService {
         const batchLimit = Math.min(deleteBatchSize, remainingDeleteBudget);
         const deletedCount = await this.deleteOldSyncedOpsBatch(
           state.userId,
-          lastSnapshotSeq,
+          latestFullStateOp.serverSeq,
           cutoffTime,
           batchLimit,
         );
@@ -485,14 +498,14 @@ export class StorageQuotaService {
 
   private async deleteOldSyncedOpsBatch(
     userId: number,
-    lastSnapshotSeq: number,
+    protectedFromSeq: number,
     cutoffTime: number,
     limit: number,
   ): Promise<number> {
     const doomedOps = await prisma.operation.findMany({
       where: {
         userId,
-        serverSeq: { lte: lastSnapshotSeq },
+        serverSeq: { lt: protectedFromSeq },
         receivedAt: { lt: BigInt(cutoffTime) },
       },
       orderBy: { serverSeq: 'asc' },

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -408,6 +408,7 @@ export class StorageQuotaService {
         userId: true,
         lastSnapshotSeq: true,
         snapshotAt: true,
+        latestFullStateSeq: true,
       },
       orderBy: { snapshotAt: 'asc' },
     });
@@ -416,7 +417,7 @@ export class StorageQuotaService {
     const affectedUserIds: number[] = [];
     const deleteBatchSize = getOldOpsCleanupDeleteBatchSize();
     let remainingDeleteBudget = getOldOpsCleanupMaxDeletedPerRun();
-    let usersWithoutReplayBase = 0;
+    let eligibleUsersWithoutReplayBase = 0;
 
     for (const state of states) {
       if (remainingDeleteBudget <= 0) break;
@@ -429,20 +430,33 @@ export class StorageQuotaService {
       // only remove the superseded prefix before the newest full-state op and
       // must keep that op plus its complete replay tail.
       if (!(snapshotAt >= cutoffTime && lastSnapshotSeq > 0)) continue;
-      const latestFullStateOp = await prisma.operation.findFirst({
-        where: {
-          userId: state.userId,
-          serverSeq: { lte: lastSnapshotSeq },
-          opType: { in: ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'] },
-        },
-        orderBy: { serverSeq: 'desc' },
-        select: { serverSeq: true },
-      });
-      if (!latestFullStateOp) {
-        usersWithoutReplayBase++;
+      let protectedFromSeq =
+        typeof state.latestFullStateSeq === 'number' &&
+        state.latestFullStateSeq <= lastSnapshotSeq
+          ? state.latestFullStateSeq
+          : null;
+
+      // Existing installations may have full-state rows created before the
+      // marker was introduced, and a snapshot can temporarily lag a newer
+      // marker. Fall back only for those legacy/stale-marker cases.
+      if (protectedFromSeq === null) {
+        const latestCoveredFullStateOp = await prisma.operation.findFirst({
+          where: {
+            userId: state.userId,
+            serverSeq: { lte: lastSnapshotSeq },
+            opType: { in: ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'] },
+          },
+          orderBy: { serverSeq: 'desc' },
+          select: { serverSeq: true },
+        });
+        protectedFromSeq = latestCoveredFullStateOp?.serverSeq ?? null;
+      }
+
+      if (protectedFromSeq === null) {
+        eligibleUsersWithoutReplayBase++;
         continue;
       }
-      if (latestFullStateOp.serverSeq <= 1) continue;
+      if (protectedFromSeq <= 1) continue;
 
       // Drain this user across multiple batches until either they're empty or
       // the global per-run budget is exhausted. Without this, a single user
@@ -454,7 +468,7 @@ export class StorageQuotaService {
         const batchLimit = Math.min(deleteBatchSize, remainingDeleteBudget);
         const deletedCount = await this.deleteOldSyncedOpsBatch(
           state.userId,
-          latestFullStateOp.serverSeq,
+          protectedFromSeq,
           cutoffTime,
           batchLimit,
         );
@@ -490,10 +504,10 @@ export class StorageQuotaService {
       }
     }
 
-    if (usersWithoutReplayBase > 0) {
+    if (eligibleUsersWithoutReplayBase > 0) {
       Logger.warn(
-        `Cleanup [old-ops]: ${usersWithoutReplayBase} user(s) have no full-state replay base; ` +
-          'retention cleanup is disabled for those histories.',
+        `Cleanup [old-ops]: skipped ${eligibleUsersWithoutReplayBase} eligible user(s) ` +
+          'without a full-state replay base; their operation histories were left intact.',
       );
     }
 

--- a/packages/super-sync-server/src/sync/services/validation.service.ts
+++ b/packages/super-sync-server/src/sync/services/validation.service.ts
@@ -226,17 +226,6 @@ export class ValidationService {
       };
     }
 
-    // Note: Future timestamp check removed - clamping is handled during operation upload
-    // to preserve data instead of rejecting. Only "too old" check remains.
-    const now = Date.now();
-    if (op.timestamp < now - this.config.retentionMs) {
-      return {
-        valid: false,
-        error: 'Operation too old',
-        errorCode: SYNC_ERROR_CODES.INVALID_TIMESTAMP,
-      };
-    }
-
     return { valid: true, payloadBytes };
   }
 

--- a/packages/super-sync-server/src/sync/services/validation.service.ts
+++ b/packages/super-sync-server/src/sync/services/validation.service.ts
@@ -171,6 +171,20 @@ export class ValidationService {
       }
     }
 
+    // A non-integer or non-finite timestamp cannot be persisted: uploads store
+    // clientTimestamp as BigInt, and BigInt() throws on such values, which would
+    // abort the whole batch mid-insert with an unstructured 500. Reject it here as
+    // a per-op error instead. Age is deliberately NOT bounded — old-but-valid ops
+    // are accepted so long-offline devices keep their backlog (#8961); causality
+    // is resolved by vector clocks, not by the client timestamp.
+    if (!Number.isSafeInteger(op.timestamp)) {
+      return {
+        valid: false,
+        error: 'Invalid timestamp',
+        errorCode: SYNC_ERROR_CODES.INVALID_TIMESTAMP,
+      };
+    }
+
     const clockValidation = sanitizeVectorClock(op.vectorClock);
     if (!clockValidation.valid) {
       return {

--- a/packages/super-sync-server/src/sync/sync.types.ts
+++ b/packages/super-sync-server/src/sync/sync.types.ts
@@ -428,7 +428,7 @@ export const validatePayload = (
 export interface SyncConfig {
   maxPayloadSizeBytes: number;
   uploadRateLimit: { max: number; windowMs: number };
-  retentionMs: number; // Unified retention period for ops, devices, and validation
+  retentionMs: number; // Unified retention period for stored ops and devices
   maxClockDriftMs: number;
   batchUpload: boolean;
 }
@@ -448,7 +448,7 @@ export const ONLINE_DEVICE_THRESHOLD_MS = 5 * MS_PER_MINUTE; // 5 minutes
 export const DEFAULT_SYNC_CONFIG: SyncConfig = {
   maxPayloadSizeBytes: 20 * 1024 * 1024, // 20MB - needed for large imports
   uploadRateLimit: { max: 100, windowMs: MS_PER_MINUTE },
-  retentionMs: RETENTION_MS, // 45 days - used for ops, devices, and validation
+  retentionMs: RETENTION_MS, // 45 days - used for stored ops and devices
   maxClockDriftMs: MS_PER_MINUTE, // 60 seconds
   batchUpload: false,
 };

--- a/packages/super-sync-server/tests/magic-link-registration.spec.ts
+++ b/packages/super-sync-server/tests/magic-link-registration.spec.ts
@@ -80,6 +80,12 @@ import {
 
 describe('Magic Link Registration', () => {
   const testEmail = 'test@example.com';
+  const registrationResponse = {
+    message: 'Registration successful. Please check your email to verify your account.',
+  };
+  const loginResponse = {
+    message: 'If an account with that email exists, a login link has been sent.',
+  };
 
   // Cast to access mock functions
   const mockPrisma = prisma as unknown as {
@@ -112,7 +118,7 @@ describe('Magic Link Registration', () => {
 
       const result = await registerWithMagicLink(testEmail, Date.now());
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockPrisma.user.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -182,7 +188,7 @@ describe('Magic Link Registration', () => {
 
       const result = await registerWithMagicLink(testEmail, Date.now());
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockPrisma.user.create).not.toHaveBeenCalled();
       expect(mockSendVerificationEmail).not.toHaveBeenCalled();
     });
@@ -198,7 +204,7 @@ describe('Magic Link Registration', () => {
 
       const result = await registerWithMagicLink(testEmail, Date.now());
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockPrisma.user.create).not.toHaveBeenCalled();
       // Email sent before DB update to avoid invalidating old token on failure
       expect(mockSendVerificationEmail).toHaveBeenCalledWith(
@@ -227,7 +233,7 @@ describe('Magic Link Registration', () => {
 
       const result = await registerWithMagicLink(testEmail, Date.now());
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockSendVerificationEmail).not.toHaveBeenCalled();
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
@@ -248,7 +254,7 @@ describe('Magic Link Registration', () => {
 
       const result = await registerWithMagicLink(testEmail, Date.now());
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockPrisma.user.deleteMany).toHaveBeenCalledWith({
         where: { email: testEmail, isVerified: 0 },
       });
@@ -265,7 +271,7 @@ describe('Magic Link Registration', () => {
 
       const result = await registerWithMagicLink(testEmail, Date.now());
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       // Should NOT delete the pre-existing user
       expect(mockPrisma.user.delete).not.toHaveBeenCalled();
       expect(mockPrisma.user.deleteMany).not.toHaveBeenCalled();
@@ -287,7 +293,7 @@ describe('Magic Link Registration', () => {
 
       const result = await registerWithMagicLink(testEmail, Date.now());
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
     });
   });
 
@@ -309,7 +315,7 @@ describe('Magic Link Registration', () => {
 
       const result = await requestLoginMagicLink(testEmail);
 
-      expect(result.message).toContain('login link has been sent');
+      expect(result).toEqual(loginResponse);
       expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
       expect(mockSendLoginMagicLinkEmail).not.toHaveBeenCalled();
     });
@@ -358,7 +364,7 @@ describe('Magic Link Registration', () => {
 
       const result = await requestLoginMagicLink(testEmail);
 
-      expect(result.message).toContain('login link has been sent');
+      expect(result).toEqual(loginResponse);
       const claimedToken = mockPrisma.user.updateMany.mock.calls[0][0].data.loginToken;
       expect(mockPrisma.user.updateMany.mock.calls[1][0]).toEqual({
         where: { id: verifiedUser.id, loginToken: claimedToken },

--- a/packages/super-sync-server/tests/magic-link-registration.spec.ts
+++ b/packages/super-sync-server/tests/magic-link-registration.spec.ts
@@ -20,6 +20,7 @@ vi.mock('../src/db', () => {
       findUnique: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       delete: vi.fn(),
       deleteMany: vi.fn(),
     },
@@ -66,11 +67,11 @@ vi.mock('../src/auth', async (importOriginal) => {
 
 // Import mocked modules to get references
 import { prisma } from '../src/db';
-import { sendVerificationEmail } from '../src/email';
+import { sendLoginMagicLinkEmail, sendVerificationEmail } from '../src/email';
 import { Prisma } from '@prisma/client';
 
 // Import module under test
-import { registerWithMagicLink } from '../src/auth';
+import { registerWithMagicLink, requestLoginMagicLink } from '../src/auth';
 
 describe('Magic Link Registration', () => {
   const testEmail = 'test@example.com';
@@ -81,12 +82,14 @@ describe('Magic Link Registration', () => {
       findUnique: Mock;
       create: Mock;
       update: Mock;
+      updateMany: Mock;
       delete: Mock;
       deleteMany: Mock;
     };
   };
 
   const mockSendVerificationEmail = sendVerificationEmail as Mock;
+  const mockSendLoginMagicLinkEmail = sendLoginMagicLinkEmail as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -164,17 +167,16 @@ describe('Magic Link Registration', () => {
   });
 
   describe('Existing user handling', () => {
-    it('should reject registration for existing verified user', async () => {
+    it('should return the neutral registration response for an existing verified user', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         id: 1,
         email: testEmail,
         isVerified: 1,
       });
 
-      await expect(registerWithMagicLink(testEmail, Date.now())).rejects.toThrow(
-        'An account with this email already exists',
-      );
+      const result = await registerWithMagicLink(testEmail, Date.now());
 
+      expect(result.message).toContain('check your email');
       expect(mockPrisma.user.create).not.toHaveBeenCalled();
       expect(mockSendVerificationEmail).not.toHaveBeenCalled();
     });
@@ -270,7 +272,7 @@ describe('Magic Link Registration', () => {
   });
 
   describe('P2002 unique constraint handling', () => {
-    it('should convert P2002 race condition to user-friendly error', async () => {
+    it('should return the neutral response after a P2002 registration race', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
 
       // Use the mocked PrismaClientKnownRequestError so instanceof check matches
@@ -280,9 +282,86 @@ describe('Magic Link Registration', () => {
       );
       mockPrisma.user.create.mockRejectedValue(prismaError);
 
-      await expect(registerWithMagicLink(testEmail, Date.now())).rejects.toThrow(
-        'An account with this email already exists',
+      const result = await registerWithMagicLink(testEmail, Date.now());
+
+      expect(result.message).toContain('check your email');
+    });
+  });
+
+  describe('Login magic-link requests', () => {
+    const verifiedUser = {
+      id: 1,
+      email: testEmail,
+      isVerified: 1,
+      loginToken: null,
+      loginTokenExpiresAt: null,
+    };
+
+    it('should not rotate or resend a still-valid login token', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        ...verifiedUser,
+        loginToken: 'active-token',
+        loginTokenExpiresAt: BigInt(Date.now() + 60_000),
+      });
+
+      const result = await requestLoginMagicLink(testEmail);
+
+      expect(result.message).toContain('login link has been sent');
+      expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
+      expect(mockSendLoginMagicLinkEmail).not.toHaveBeenCalled();
+    });
+
+    it('should atomically claim an expired token slot before sending', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        ...verifiedUser,
+        loginToken: 'expired-token',
+        loginTokenExpiresAt: BigInt(Date.now() - 1),
+      });
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
+
+      await requestLoginMagicLink(testEmail);
+
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: verifiedUser.id,
+          OR: [
+            { loginToken: null },
+            { loginTokenExpiresAt: null },
+            { loginTokenExpiresAt: { lte: expect.any(BigInt) } },
+          ],
+        },
+        data: {
+          loginToken: expect.any(String),
+          loginTokenExpiresAt: expect.any(BigInt),
+        },
+      });
+      expect(mockSendLoginMagicLinkEmail).toHaveBeenCalledOnce();
+    });
+
+    it('should not send when another request wins the token claim race', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(verifiedUser);
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 0 });
+
+      await requestLoginMagicLink(testEmail);
+
+      expect(mockSendLoginMagicLinkEmail).not.toHaveBeenCalled();
+    });
+
+    it('should only clear the token claimed by a failed email attempt', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(verifiedUser);
+      mockPrisma.user.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockPrisma.user.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockSendLoginMagicLinkEmail.mockResolvedValueOnce(false);
+
+      await expect(requestLoginMagicLink(testEmail)).rejects.toThrow(
+        'Failed to send login email',
       );
+
+      const claimedToken = mockPrisma.user.updateMany.mock.calls[0][0].data.loginToken;
+      expect(mockPrisma.user.updateMany.mock.calls[1][0]).toEqual({
+        where: { id: verifiedUser.id, loginToken: claimedToken },
+        data: { loginToken: null, loginTokenExpiresAt: null },
+      });
     });
   });
 });

--- a/packages/super-sync-server/tests/magic-link-registration.spec.ts
+++ b/packages/super-sync-server/tests/magic-link-registration.spec.ts
@@ -18,6 +18,7 @@ vi.mock('../src/db', () => {
   const mockPrisma = {
     user: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn(),
@@ -71,7 +72,11 @@ import { sendLoginMagicLinkEmail, sendVerificationEmail } from '../src/email';
 import { Prisma } from '@prisma/client';
 
 // Import module under test
-import { registerWithMagicLink, requestLoginMagicLink } from '../src/auth';
+import {
+  registerWithMagicLink,
+  requestLoginMagicLink,
+  verifyLoginMagicLink,
+} from '../src/auth';
 
 describe('Magic Link Registration', () => {
   const testEmail = 'test@example.com';
@@ -80,6 +85,7 @@ describe('Magic Link Registration', () => {
   const mockPrisma = prisma as unknown as {
     user: {
       findUnique: Mock;
+      findFirst: Mock;
       create: Mock;
       update: Mock;
       updateMany: Mock;
@@ -211,7 +217,7 @@ describe('Magic Link Registration', () => {
       );
     });
 
-    it('should reject when verification resend cap is reached', async () => {
+    it('should return the neutral response when verification resend cap is reached', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         id: 1,
         email: testEmail,
@@ -219,10 +225,9 @@ describe('Magic Link Registration', () => {
         verificationResendCount: 20,
       });
 
-      await expect(registerWithMagicLink(testEmail, Date.now())).rejects.toThrow(
-        'Too many verification attempts',
-      );
+      const result = await registerWithMagicLink(testEmail, Date.now());
 
+      expect(result.message).toContain('check your email');
       expect(mockSendVerificationEmail).not.toHaveBeenCalled();
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
@@ -241,10 +246,9 @@ describe('Magic Link Registration', () => {
       mockSendVerificationEmail.mockResolvedValueOnce(false);
       mockPrisma.user.deleteMany.mockResolvedValue({ count: 1 });
 
-      await expect(registerWithMagicLink(testEmail, Date.now())).rejects.toThrow(
-        'Failed to send verification email',
-      );
+      const result = await registerWithMagicLink(testEmail, Date.now());
 
+      expect(result.message).toContain('check your email');
       expect(mockPrisma.user.deleteMany).toHaveBeenCalledWith({
         where: { email: testEmail, isVerified: 0 },
       });
@@ -259,10 +263,9 @@ describe('Magic Link Registration', () => {
       });
       mockSendVerificationEmail.mockResolvedValueOnce(false);
 
-      await expect(registerWithMagicLink(testEmail, Date.now())).rejects.toThrow(
-        'Failed to send verification email',
-      );
+      const result = await registerWithMagicLink(testEmail, Date.now());
 
+      expect(result.message).toContain('check your email');
       // Should NOT delete the pre-existing user
       expect(mockPrisma.user.delete).not.toHaveBeenCalled();
       expect(mockPrisma.user.deleteMany).not.toHaveBeenCalled();
@@ -353,13 +356,81 @@ describe('Magic Link Registration', () => {
       mockPrisma.user.updateMany.mockResolvedValueOnce({ count: 1 });
       mockSendLoginMagicLinkEmail.mockResolvedValueOnce(false);
 
-      await expect(requestLoginMagicLink(testEmail)).rejects.toThrow(
-        'Failed to send login email',
-      );
+      const result = await requestLoginMagicLink(testEmail);
 
+      expect(result.message).toContain('login link has been sent');
       const claimedToken = mockPrisma.user.updateMany.mock.calls[0][0].data.loginToken;
       expect(mockPrisma.user.updateMany.mock.calls[1][0]).toEqual({
         where: { id: verifiedUser.id, loginToken: claimedToken },
+        data: { loginToken: null, loginTokenExpiresAt: null },
+      });
+    });
+
+    it('should consume a login token with a token-scoped atomic update', async () => {
+      const loginToken = 'single-use-token';
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: verifiedUser.id,
+        email: testEmail,
+        loginToken,
+        loginTokenExpiresAt: BigInt(Date.now() + 60_000),
+        tokenVersion: 0,
+      });
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await verifyLoginMagicLink(loginToken);
+
+      expect(result.user).toEqual({ id: verifiedUser.id, email: testEmail });
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: verifiedUser.id,
+          loginToken,
+          OR: [
+            { loginTokenExpiresAt: null },
+            { loginTokenExpiresAt: { gte: expect.any(BigInt) } },
+          ],
+        },
+        data: {
+          loginToken: null,
+          loginTokenExpiresAt: null,
+          failedLoginAttempts: 0,
+          lockedUntil: null,
+        },
+      });
+    });
+
+    it('should reject a login token already consumed by another request', async () => {
+      const loginToken = 'already-consumed-token';
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: verifiedUser.id,
+        email: testEmail,
+        loginToken,
+        loginTokenExpiresAt: BigInt(Date.now() + 60_000),
+        tokenVersion: 0,
+      });
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(verifyLoginMagicLink(loginToken)).rejects.toThrow(
+        'Invalid or expired login link',
+      );
+    });
+
+    it('should not clear a replacement when an expired login token races renewal', async () => {
+      const expiredToken = 'expired-login-token';
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: verifiedUser.id,
+        email: testEmail,
+        loginToken: expiredToken,
+        loginTokenExpiresAt: BigInt(Date.now() - 1),
+        tokenVersion: 0,
+      });
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(verifyLoginMagicLink(expiredToken)).rejects.toThrow(
+        'Invalid or expired login link',
+      );
+
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: { id: verifiedUser.id, loginToken: expiredToken },
         data: { loginToken: null, loginTokenExpiresAt: null },
       });
     });

--- a/packages/super-sync-server/tests/passkey.spec.ts
+++ b/packages/super-sync-server/tests/passkey.spec.ts
@@ -19,6 +19,7 @@ vi.mock('../src/db', () => {
       findFirst: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       delete: vi.fn(),
     },
     passkey: {
@@ -57,6 +58,7 @@ vi.mock('@simplewebauthn/server', () => ({
 
 // Import mocked modules to get references
 import { prisma } from '../src/db';
+import { sendPasskeyRecoveryEmail, sendVerificationEmail } from '../src/email';
 import * as simplewebauthn from '@simplewebauthn/server';
 
 // Import module under test
@@ -81,6 +83,7 @@ describe('Passkey Authentication', () => {
       findFirst: Mock;
       create: Mock;
       update: Mock;
+      updateMany: Mock;
       delete: Mock;
     };
     passkey: {
@@ -139,7 +142,7 @@ describe('Passkey Authentication', () => {
       );
     });
 
-    it('should reject registration for existing verified user', async () => {
+    it('should generate the same registration options for an existing verified user', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         id: 1,
         email: testEmail,
@@ -147,12 +150,15 @@ describe('Passkey Authentication', () => {
         passkeys: [],
       });
 
-      await expect(generateRegistrationOptions(testEmail)).rejects.toThrow(
-        'An account with this email already exists',
+      const options = await generateRegistrationOptions(testEmail);
+
+      expect(options.challenge).toBe(testChallenge);
+      expect(mockGenerateRegistration).toHaveBeenCalledWith(
+        expect.objectContaining({ excludeCredentials: [] }),
       );
     });
 
-    it('should allow re-registration for unverified user', async () => {
+    it('should not disclose an unverified user passkey through excluded credentials', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         id: 1,
         email: testEmail,
@@ -164,11 +170,7 @@ describe('Passkey Authentication', () => {
 
       expect(options).toBeDefined();
       expect(mockGenerateRegistration).toHaveBeenCalledWith(
-        expect.objectContaining({
-          excludeCredentials: expect.arrayContaining([
-            expect.objectContaining({ id: expect.any(String) }),
-          ]),
-        }),
+        expect.objectContaining({ excludeCredentials: [] }),
       );
     });
 
@@ -221,6 +223,45 @@ describe('Passkey Authentication', () => {
           result.message.includes('automatically verified'),
       ).toBe(true);
       expect(mockPrisma.user.create).toHaveBeenCalled();
+    });
+
+    it('should return the neutral response without changing an existing verified user', async () => {
+      const mockCredentialId = new Uint8Array([1, 2, 3, 4]);
+      mockVerifyRegistration.mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: mockCredentialId,
+            publicKey: new Uint8Array([5, 6, 7, 8]),
+            counter: 0,
+          },
+          credentialDeviceType: 'multiDevice',
+          credentialBackedUp: true,
+        },
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        email: testEmail,
+        isVerified: 1,
+      });
+      await generateRegistrationOptions(testEmail);
+
+      const result = await verifyRegistration(testEmail, {
+        id: 'credential-id-base64',
+        rawId: 'raw-id',
+        type: 'public-key',
+        response: {
+          clientDataJSON: 'client-data',
+          attestationObject: 'attestation',
+          transports: ['internal'],
+        },
+        clientExtensionResults: {},
+      } as any);
+
+      expect(result.message).toContain('check your email');
+      expect(mockPrisma.user.create).not.toHaveBeenCalled();
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+      expect(sendVerificationEmail).not.toHaveBeenCalled();
     });
 
     it('should reject verification with expired challenge', async () => {
@@ -474,14 +515,16 @@ describe('Passkey Authentication', () => {
         passwordHash: null, // Passkey-only user
         isVerified: 1,
         passkeys: [mockPasskey],
+        passkeyRecoveryToken: null,
+        passkeyRecoveryTokenExpiresAt: null,
       });
 
-      mockPrisma.user.update.mockResolvedValue({});
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
       const result = await requestPasskeyRecovery(testEmail);
 
       expect(result.message).toContain('recovery link has been sent');
-      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
             passkeyRecoveryToken: expect.any(String),
@@ -489,6 +532,40 @@ describe('Passkey Authentication', () => {
           }),
         }),
       );
+    });
+
+    it('should not rotate or resend a still-valid recovery token', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        email: testEmail,
+        passwordHash: null,
+        isVerified: 1,
+        passkeys: [mockPasskey],
+        passkeyRecoveryToken: 'active-token',
+        passkeyRecoveryTokenExpiresAt: BigInt(Date.now() + 60_000),
+      });
+
+      await requestPasskeyRecovery(testEmail);
+
+      expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
+      expect(sendPasskeyRecoveryEmail).not.toHaveBeenCalled();
+    });
+
+    it('should not send when another recovery request wins the token claim race', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        email: testEmail,
+        passwordHash: null,
+        isVerified: 1,
+        passkeys: [mockPasskey],
+        passkeyRecoveryToken: null,
+        passkeyRecoveryTokenExpiresAt: null,
+      });
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 0 });
+
+      await requestPasskeyRecovery(testEmail);
+
+      expect(sendPasskeyRecoveryEmail).not.toHaveBeenCalled();
     });
 
     it('should return success message for non-existent user (no enumeration)', async () => {

--- a/packages/super-sync-server/tests/passkey.spec.ts
+++ b/packages/super-sync-server/tests/passkey.spec.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, vi, afterEach, Mock } from 'vitest';
 import type {
   PublicKeyCredentialCreationOptionsJSON,
   PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
 } from '@simplewebauthn/server';
 
 // Mock prisma - use factory function to avoid hoisting issues
@@ -75,6 +76,20 @@ import {
 describe('Passkey Authentication', () => {
   const testEmail = 'test@example.com';
   const testChallenge = 'test-challenge-base64';
+  const registrationResponse = {
+    message: 'Registration successful. Please check your email to verify your account.',
+  };
+  const recoveryResponse = {
+    message: 'If an account with that email exists, a recovery link has been sent.',
+  };
+
+  type RecoveryTransaction = {
+    user: { updateMany: Mock };
+    passkey: { deleteMany: Mock; create: Mock };
+  };
+  type RecoveryTransactionCallback = (
+    transaction: RecoveryTransaction,
+  ) => Promise<unknown>;
 
   // Cast to access mock functions
   const mockPrisma = prisma as unknown as {
@@ -256,9 +271,9 @@ describe('Passkey Authentication', () => {
           transports: ['internal'],
         },
         clientExtensionResults: {},
-      } as any);
+      } as RegistrationResponseJSON);
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockPrisma.user.create).not.toHaveBeenCalled();
       expect(mockPrisma.$transaction).not.toHaveBeenCalled();
       expect(sendVerificationEmail).not.toHaveBeenCalled();
@@ -292,9 +307,9 @@ describe('Passkey Authentication', () => {
           attestationObject: 'attestation',
         },
         clientExtensionResults: {},
-      } as any);
+      } as RegistrationResponseJSON);
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockPrisma.$transaction).not.toHaveBeenCalled();
       expect(sendVerificationEmail).not.toHaveBeenCalled();
     });
@@ -326,9 +341,9 @@ describe('Passkey Authentication', () => {
           attestationObject: 'attestation',
         },
         clientExtensionResults: {},
-      } as any);
+      } as RegistrationResponseJSON);
 
-      expect(result.message).toContain('check your email');
+      expect(result).toEqual(registrationResponse);
       expect(mockPrisma.user.delete).toHaveBeenCalledWith({ where: { id: 1 } });
     });
 
@@ -591,7 +606,7 @@ describe('Passkey Authentication', () => {
 
       const result = await requestPasskeyRecovery(testEmail);
 
-      expect(result.message).toContain('recovery link has been sent');
+      expect(result).toEqual(recoveryResponse);
       expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
         where: {
           id: 1,
@@ -641,7 +656,7 @@ describe('Passkey Authentication', () => {
 
       const result = await requestPasskeyRecovery(testEmail);
 
-      expect(result.message).toContain('recovery link has been sent');
+      expect(result).toEqual(recoveryResponse);
       const claimedToken =
         mockPrisma.user.updateMany.mock.calls[0][0].data.passkeyRecoveryToken;
       expect(mockPrisma.user.updateMany.mock.calls[1][0]).toEqual({
@@ -676,7 +691,7 @@ describe('Passkey Authentication', () => {
       const result = await requestPasskeyRecovery(testEmail);
 
       // Should return same message to prevent user enumeration
-      expect(result.message).toContain('recovery link has been sent');
+      expect(result).toEqual(recoveryResponse);
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
 
@@ -692,7 +707,7 @@ describe('Passkey Authentication', () => {
       const result = await requestPasskeyRecovery(testEmail);
 
       // Should not send recovery email for password users
-      expect(result.message).toContain('recovery link has been sent');
+      expect(result).toEqual(recoveryResponse);
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
 
@@ -774,18 +789,20 @@ describe('Passkey Authentication', () => {
       const txPasskeyDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
       const txPasskeyCreate = vi.fn().mockResolvedValue({});
       const txUserUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
-      mockPrisma.$transaction.mockImplementation(async (callback: any) => {
-        const tx = {
-          passkey: {
-            deleteMany: txPasskeyDeleteMany,
-            create: txPasskeyCreate,
-          },
-          user: {
-            updateMany: txUserUpdateMany,
-          },
-        };
-        return callback(tx);
-      });
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: RecoveryTransactionCallback) => {
+          const tx = {
+            passkey: {
+              deleteMany: txPasskeyDeleteMany,
+              create: txPasskeyCreate,
+            },
+            user: {
+              updateMany: txUserUpdateMany,
+            },
+          };
+          return callback(tx);
+        },
+      );
 
       // First get recovery options to store challenge
       await getRecoveryRegistrationOptions(recoveryToken);
@@ -852,11 +869,12 @@ describe('Passkey Authentication', () => {
         },
       });
       const txPasskeyDeleteMany = vi.fn();
-      mockPrisma.$transaction.mockImplementation(async (callback: any) =>
-        callback({
-          user: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
-          passkey: { deleteMany: txPasskeyDeleteMany, create: vi.fn() },
-        }),
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: RecoveryTransactionCallback) =>
+          callback({
+            user: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+            passkey: { deleteMany: txPasskeyDeleteMany, create: vi.fn() },
+          }),
       );
       await getRecoveryRegistrationOptions(recoveryToken);
 
@@ -870,7 +888,7 @@ describe('Passkey Authentication', () => {
             attestationObject: 'attestation',
           },
           clientExtensionResults: {},
-        } as any),
+        } as RegistrationResponseJSON),
       ).rejects.toThrow('Invalid or expired recovery token');
       expect(txPasskeyDeleteMany).not.toHaveBeenCalled();
     });
@@ -918,7 +936,7 @@ describe('Passkey Authentication', () => {
           attestationObject: 'attestation',
         },
         clientExtensionResults: {},
-      } as any);
+      } as RegistrationResponseJSON);
 
       expect(mockVerifyRegistration).toHaveBeenCalledWith(
         expect.objectContaining({ expectedChallenge: registrationChallenge }),

--- a/packages/super-sync-server/tests/passkey.spec.ts
+++ b/packages/super-sync-server/tests/passkey.spec.ts
@@ -264,6 +264,74 @@ describe('Passkey Authentication', () => {
       expect(sendVerificationEmail).not.toHaveBeenCalled();
     });
 
+    it('should return the neutral response when an unverified user reaches the resend cap', async () => {
+      mockVerifyRegistration.mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: new Uint8Array([1, 2, 3, 4]),
+            publicKey: new Uint8Array([5, 6, 7, 8]),
+            counter: 0,
+          },
+        },
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        email: testEmail,
+        isVerified: 0,
+        verificationResendCount: 20,
+      });
+      await generateRegistrationOptions(testEmail);
+
+      const result = await verifyRegistration(testEmail, {
+        id: 'credential-id',
+        rawId: 'raw-id',
+        type: 'public-key',
+        response: {
+          clientDataJSON: 'client-data',
+          attestationObject: 'attestation',
+        },
+        clientExtensionResults: {},
+      } as any);
+
+      expect(result.message).toContain('check your email');
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+      expect(sendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('should return the neutral response when verification email delivery fails', async () => {
+      mockVerifyRegistration.mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: new Uint8Array([1, 2, 3, 4]),
+            publicKey: new Uint8Array([5, 6, 7, 8]),
+            counter: 0,
+          },
+        },
+      });
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: 1, email: testEmail, isVerified: 0 });
+      mockPrisma.user.create.mockResolvedValue({ id: 1 });
+      (sendVerificationEmail as Mock).mockResolvedValueOnce(false);
+      await generateRegistrationOptions(testEmail);
+
+      const result = await verifyRegistration(testEmail, {
+        id: 'credential-id',
+        rawId: 'raw-id',
+        type: 'public-key',
+        response: {
+          clientDataJSON: 'client-data',
+          attestationObject: 'attestation',
+        },
+        clientExtensionResults: {},
+      } as any);
+
+      expect(result.message).toContain('check your email');
+      expect(mockPrisma.user.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    });
+
     it('should reject verification with expired challenge', async () => {
       // Don't generate options first - no challenge stored
       const mockCredential = {
@@ -524,14 +592,20 @@ describe('Passkey Authentication', () => {
       const result = await requestPasskeyRecovery(testEmail);
 
       expect(result.message).toContain('recovery link has been sent');
-      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            passkeyRecoveryToken: expect.any(String),
-            passkeyRecoveryTokenExpiresAt: expect.any(BigInt),
-          }),
-        }),
-      );
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          OR: [
+            { passkeyRecoveryToken: null },
+            { passkeyRecoveryTokenExpiresAt: null },
+            { passkeyRecoveryTokenExpiresAt: { lte: expect.any(BigInt) } },
+          ],
+        },
+        data: {
+          passkeyRecoveryToken: expect.any(String),
+          passkeyRecoveryTokenExpiresAt: expect.any(BigInt),
+        },
+      });
     });
 
     it('should not rotate or resend a still-valid recovery token', async () => {
@@ -549,6 +623,34 @@ describe('Passkey Authentication', () => {
 
       expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
       expect(sendPasskeyRecoveryEmail).not.toHaveBeenCalled();
+    });
+
+    it('should return the neutral response and clear only its claimed token when email fails', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        email: testEmail,
+        passwordHash: null,
+        isVerified: 1,
+        passkeys: [mockPasskey],
+        passkeyRecoveryToken: null,
+        passkeyRecoveryTokenExpiresAt: null,
+      });
+      mockPrisma.user.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockPrisma.user.updateMany.mockResolvedValueOnce({ count: 1 });
+      (sendPasskeyRecoveryEmail as Mock).mockResolvedValueOnce(false);
+
+      const result = await requestPasskeyRecovery(testEmail);
+
+      expect(result.message).toContain('recovery link has been sent');
+      const claimedToken =
+        mockPrisma.user.updateMany.mock.calls[0][0].data.passkeyRecoveryToken;
+      expect(mockPrisma.user.updateMany.mock.calls[1][0]).toEqual({
+        where: { id: 1, passkeyRecoveryToken: claimedToken },
+        data: {
+          passkeyRecoveryToken: null,
+          passkeyRecoveryTokenExpiresAt: null,
+        },
+      });
     });
 
     it('should not send when another recovery request wins the token claim race', async () => {
@@ -629,21 +731,20 @@ describe('Passkey Authentication', () => {
         passkeys: [],
       });
 
-      mockPrisma.user.update.mockResolvedValue({});
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
 
       await expect(getRecoveryRegistrationOptions('expired-token')).rejects.toThrow(
         'Invalid or expired recovery token',
       );
 
       // Should clear expired token
-      expect(mockPrisma.user.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            passkeyRecoveryToken: null,
-            passkeyRecoveryTokenExpiresAt: null,
-          }),
-        }),
-      );
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: { id: 1, passkeyRecoveryToken: 'expired-token' },
+        data: {
+          passkeyRecoveryToken: null,
+          passkeyRecoveryTokenExpiresAt: null,
+        },
+      });
     });
 
     it('should complete recovery and invalidate old tokens', async () => {
@@ -670,14 +771,17 @@ describe('Passkey Authentication', () => {
         },
       });
 
+      const txPasskeyDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
+      const txPasskeyCreate = vi.fn().mockResolvedValue({});
+      const txUserUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
       mockPrisma.$transaction.mockImplementation(async (callback: any) => {
         const tx = {
           passkey: {
-            deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-            create: vi.fn().mockResolvedValue({}),
+            deleteMany: txPasskeyDeleteMany,
+            create: txPasskeyCreate,
           },
           user: {
-            update: vi.fn().mockResolvedValue({}),
+            updateMany: txUserUpdateMany,
           },
         };
         return callback(tx);
@@ -710,10 +814,117 @@ describe('Passkey Authentication', () => {
 
       expect(result.message).toContain('reset successfully');
       expect(mockPrisma.$transaction).toHaveBeenCalled();
+      expect(txUserUpdateMany).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          passkeyRecoveryToken: recoveryToken,
+          OR: [
+            { passkeyRecoveryTokenExpiresAt: null },
+            { passkeyRecoveryTokenExpiresAt: { gte: expect.any(BigInt) } },
+          ],
+        },
+        data: {
+          passkeyRecoveryToken: null,
+          passkeyRecoveryTokenExpiresAt: null,
+          tokenVersion: { increment: 1 },
+        },
+      });
+      expect(txPasskeyDeleteMany).toHaveBeenCalledWith({ where: { userId: 1 } });
+      expect(txPasskeyCreate).toHaveBeenCalledOnce();
+    });
+
+    it('should reject recovery already consumed by another request before replacing passkeys', async () => {
+      const recoveryToken = 'raced-recovery-token';
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 1,
+        email: testEmail,
+        passkeyRecoveryToken: recoveryToken,
+        passkeyRecoveryTokenExpiresAt: BigInt(Date.now() + 3600000),
+      });
+      mockVerifyRegistration.mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: new Uint8Array([9, 10, 11, 12]),
+            publicKey: new Uint8Array([13, 14, 15, 16]),
+            counter: 0,
+          },
+        },
+      });
+      const txPasskeyDeleteMany = vi.fn();
+      mockPrisma.$transaction.mockImplementation(async (callback: any) =>
+        callback({
+          user: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          passkey: { deleteMany: txPasskeyDeleteMany, create: vi.fn() },
+        }),
+      );
+      await getRecoveryRegistrationOptions(recoveryToken);
+
+      await expect(
+        completePasskeyRecovery(recoveryToken, {
+          id: 'new-credential-id',
+          rawId: 'raw-id',
+          type: 'public-key',
+          response: {
+            clientDataJSON: 'client-data',
+            attestationObject: 'attestation',
+          },
+          clientExtensionResults: {},
+        } as any),
+      ).rejects.toThrow('Invalid or expired recovery token');
+      expect(txPasskeyDeleteMany).not.toHaveBeenCalled();
     });
   });
 
   describe('Challenge Expiration', () => {
+    it('should isolate registration challenges from authentication challenges', async () => {
+      const registrationChallenge = 'registration-challenge';
+      const authenticationChallenge = 'authentication-challenge';
+      mockGenerateRegistration.mockResolvedValueOnce({
+        challenge: registrationChallenge,
+        rp: { name: 'Test', id: 'localhost' },
+        user: { id: 'user-id', name: testEmail, displayName: testEmail },
+        pubKeyCredParams: [],
+      });
+      mockGenerateAuthentication.mockResolvedValueOnce({
+        challenge: authenticationChallenge,
+        rpId: 'localhost',
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        email: testEmail,
+        isVerified: 1,
+        passkeys: [{}],
+      });
+      mockVerifyRegistration.mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: new Uint8Array([1, 2, 3, 4]),
+            publicKey: new Uint8Array([5, 6, 7, 8]),
+            counter: 0,
+          },
+        },
+      });
+
+      await generateRegistrationOptions(testEmail);
+      await generateAuthenticationOptions(testEmail);
+      await verifyRegistration(testEmail, {
+        id: 'credential-id',
+        rawId: 'raw-id',
+        type: 'public-key',
+        response: {
+          clientDataJSON: 'client-data',
+          attestationObject: 'attestation',
+        },
+        clientExtensionResults: {},
+      } as any);
+
+      expect(mockVerifyRegistration).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedChallenge: registrationChallenge }),
+      );
+    });
+
     it('should reject verification if challenge used twice', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
 

--- a/packages/super-sync-server/tests/retention-config.spec.ts
+++ b/packages/super-sync-server/tests/retention-config.spec.ts
@@ -1,12 +1,11 @@
 /**
  * Tests for unified retention configuration.
  *
- * The retention system uses a single `retentionMs` value (45 days) for:
- * - Operation age validation (rejecting old incoming ops)
- * - Old operation cleanup (deleteOldSyncedOpsForAllUsers)
- * - Stale device cleanup (deleteStaleDevices)
+ * The retention system uses a single `retentionMs` value (45 days) for stored
+ * operation cleanup and stale-device cleanup. Client operation timestamps are
+ * intentionally independent so long-offline devices can still sync.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   DEFAULT_SYNC_CONFIG,
   RETENTION_DAYS,
@@ -45,7 +44,7 @@ describe('Retention Configuration', () => {
     });
   });
 
-  describe('ValidationService - operation age validation', () => {
+  describe('ValidationService - offline operation age', () => {
     let validationService: ValidationService;
     const clientId = 'test-client';
 
@@ -80,18 +79,16 @@ describe('Retention Configuration', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should reject operation beyond retention window (46 days old)', () => {
+    it('should accept operation beyond retention window (46 days old)', () => {
       const fortysSixDaysAgo = Date.now() - 46 * MS_PER_DAY;
       const result = validationService.validateOp(createOp(fortysSixDaysAgo), clientId);
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain('too old');
+      expect(result.valid).toBe(true);
     });
 
-    it('should reject operation just past retention window (45 days + 1 second)', () => {
+    it('should accept operation just past retention window (45 days + 1 second)', () => {
       const justPastRetention = Date.now() - DEFAULT_SYNC_CONFIG.retentionMs - 1000;
       const result = validationService.validateOp(createOp(justPastRetention), clientId);
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain('too old');
+      expect(result.valid).toBe(true);
     });
 
     it('should accept recent operations', () => {
@@ -132,38 +129,6 @@ describe('Retention Configuration', () => {
       const devicesCutoff = now - DEFAULT_SYNC_CONFIG.retentionMs;
 
       expect(opsCutoff).toBe(devicesCutoff);
-    });
-  });
-
-  describe('Custom retention configuration', () => {
-    it('should allow overriding retentionMs via constructor', () => {
-      const customRetention = 7 * MS_PER_DAY; // 7 days
-      const customConfig = { ...DEFAULT_SYNC_CONFIG, retentionMs: customRetention };
-
-      const validationService = new ValidationService(customConfig);
-
-      // 6-day-old op should be valid with 7-day retention
-      const sixDaysAgo = Date.now() - 6 * MS_PER_DAY;
-      const validOp = {
-        id: 'test-op',
-        clientId: 'test',
-        actionType: 'ADD_TASK',
-        opType: 'CRT' as const,
-        entityType: 'TASK',
-        entityId: 'task-1',
-        payload: { title: 'Test' },
-        vectorClock: { test: 1 },
-        timestamp: sixDaysAgo,
-        schemaVersion: 1,
-      };
-
-      expect(validationService.validateOp(validOp, 'test').valid).toBe(true);
-
-      // 8-day-old op should be invalid with 7-day retention
-      const eightDaysAgo = Date.now() - 8 * MS_PER_DAY;
-      const invalidOp = { ...validOp, id: 'test-op-2', timestamp: eightDaysAgo };
-
-      expect(validationService.validateOp(invalidOp, 'test').valid).toBe(false);
     });
   });
 });

--- a/packages/super-sync-server/tests/sync-operations.spec.ts
+++ b/packages/super-sync-server/tests/sync-operations.spec.ts
@@ -370,6 +370,11 @@ vi.mock('../src/db', async () => {
               )
                 return false;
               if (
+                args.where?.serverSeq?.lt !== undefined &&
+                op.serverSeq >= args.where.serverSeq.lt
+              )
+                return false;
+              if (
                 args.where?.receivedAt?.lt !== undefined &&
                 op.receivedAt >= args.where.receivedAt.lt
               )
@@ -942,15 +947,28 @@ describe('Sync Operations', () => {
         createOp('task-1', 'CRT'),
         createOp('task-2', 'CRT'),
       ]);
+      await service.uploadOps(userId, clientId, [
+        {
+          id: uuidv7(),
+          clientId,
+          actionType: '[SP_ALL] Load(import) all data',
+          opType: 'SYNC_IMPORT',
+          entityType: 'ALL',
+          payload: {},
+          vectorClock: { [clientId]: 2 },
+          timestamp: Date.now(),
+          schemaVersion: 1,
+        },
+      ]);
 
       // Set up userSyncState with snapshot info (required for cleanup logic)
       const now = Date.now();
       testState.userSyncStates.set(userId, {
         userId,
-        lastSeq: 2,
-        lastSnapshotSeq: 2,
+        lastSeq: 3,
+        lastSnapshotSeq: 3,
         snapshotAt: BigInt(now),
-        opCount: 2,
+        opCount: 3,
       });
 
       // Manually set one operation to be "old" (received 100 days ago)
@@ -970,9 +988,11 @@ describe('Sync Operations', () => {
       expect(result.affectedUserIds).toContain(userId);
 
       // Verify correct operation was deleted
-      const ops = (await operationDownloadService.getOpsSinceWithSeq(userId, 0)).ops;
-      expect(ops.length).toBe(1);
-      expect(ops[0].serverSeq).toBe(2);
+      const remainingSeqs = Array.from(testState.operations.values())
+        .filter((op) => op.userId === userId)
+        .map((op) => op.serverSeq)
+        .sort((a, b) => a - b);
+      expect(remainingSeqs).toEqual([2, 3]);
     });
 
     it('should delete stale devices', async () => {

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -2414,7 +2414,7 @@ describe('SyncService', () => {
         expect(totalDeleted).toBe(0);
         expect(affectedUserIds).not.toContain(userId);
         expect(warnSpy).toHaveBeenCalledWith(
-          'Cleanup [old-ops]: 1 user(s) have no full-state replay base; retention cleanup is disabled for those histories.',
+          'Cleanup [old-ops]: skipped 1 eligible user(s) without a full-state replay base; their operation histories were left intact.',
         );
 
         const remaining = (await operationDownloadService.getOpsSinceWithSeq(userId, 0))
@@ -2456,11 +2456,13 @@ describe('SyncService', () => {
         lastSeq: 5,
         lastSnapshotSeq: 4,
         snapshotAt: BigInt(Date.now()),
+        latestFullStateSeq: 4,
       });
 
       const { totalDeleted } = await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
 
       expect(totalDeleted).toBe(3);
+      expect(prisma.operation.findFirst).not.toHaveBeenCalled();
       expect(Array.from(testState.operations.keys())).toEqual(['old-op-4', 'old-op-5']);
       const freshClientOps = (
         await operationDownloadService.getOpsSinceWithSeq(userId, 0)

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -1649,7 +1649,7 @@ describe('SyncService', () => {
       const results = await service.uploadOps(userId, clientId, [op]);
 
       expect(results[0].accepted).toBe(true);
-      expect(testState.operations.has(op.id)).toBe(true);
+      expect(testState.operations.get(op.id)?.clientTimestamp).toBe(BigInt(tooOld));
     });
 
     it('should reject operations with payload exceeding size limit', async () => {
@@ -2370,6 +2370,7 @@ describe('SyncService', () => {
 
     it('should not delete old operations when no full-state base exists', async () => {
       const service = getSyncService();
+      const warnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
 
       // Upload operations
       for (let i = 1; i <= 5; i++) {
@@ -2406,15 +2407,22 @@ describe('SyncService', () => {
         snapshotAt: BigInt(Date.now()), // Snapshot taken recently (>= cutoffTime)
       });
 
-      const { totalDeleted, affectedUserIds } =
-        await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+      try {
+        const { totalDeleted, affectedUserIds } =
+          await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
 
-      expect(totalDeleted).toBe(0);
-      expect(affectedUserIds).not.toContain(userId);
+        expect(totalDeleted).toBe(0);
+        expect(affectedUserIds).not.toContain(userId);
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Cleanup [old-ops]: 1 user(s) have no full-state replay base; retention cleanup is disabled for those histories.',
+        );
 
-      const remaining = (await operationDownloadService.getOpsSinceWithSeq(userId, 0))
-        .ops;
-      expect(remaining).toHaveLength(5);
+        const remaining = (await operationDownloadService.getOpsSinceWithSeq(userId, 0))
+          .ops;
+        expect(remaining).toHaveLength(5);
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('should preserve the latest full-state operation and its replay tail', async () => {
@@ -2422,17 +2430,18 @@ describe('SyncService', () => {
       const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
 
       for (let i = 1; i <= 5; i++) {
+        const isFullState = i === 2 || i === 4;
         testState.operations.set(`old-op-${i}`, {
           id: `old-op-${i}`,
           userId,
           clientId,
           serverSeq: i,
-          actionType: i === 3 ? 'LOAD_ALL_DATA' : 'ADD',
-          opType: i === 3 ? 'SYNC_IMPORT' : 'CRT',
-          entityType: i === 3 ? 'ALL' : 'TASK',
-          entityId: i === 3 ? null : `t${i}`,
+          actionType: isFullState ? 'LOAD_ALL_DATA' : 'ADD',
+          opType: i === 2 ? 'BACKUP_IMPORT' : i === 4 ? 'REPAIR' : 'CRT',
+          entityType: isFullState ? 'ALL' : 'TASK',
+          entityId: isFullState ? null : `t${i}`,
           entityIds: [],
-          payload: i === 3 ? { appDataComplete: { TASK: {} } } : {},
+          payload: isFullState ? { appDataComplete: { TASK: {} } } : {},
           vectorClock: {},
           schemaVersion: 1,
           clientTimestamp: BigInt(Date.now()),
@@ -2445,18 +2454,18 @@ describe('SyncService', () => {
       testState.userSyncStates.set(userId, {
         userId,
         lastSeq: 5,
-        lastSnapshotSeq: 5,
+        lastSnapshotSeq: 4,
         snapshotAt: BigInt(Date.now()),
       });
 
       const { totalDeleted } = await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
 
-      expect(totalDeleted).toBe(2);
-      expect(Array.from(testState.operations.keys())).toEqual([
-        'old-op-3',
-        'old-op-4',
-        'old-op-5',
-      ]);
+      expect(totalDeleted).toBe(3);
+      expect(Array.from(testState.operations.keys())).toEqual(['old-op-4', 'old-op-5']);
+      const freshClientOps = (
+        await operationDownloadService.getOpsSinceWithSeq(userId, 0)
+      ).ops;
+      expect(freshClientOps.map((op) => op.serverSeq)).toEqual([4, 5]);
     });
 
     it('drains a single user up to the per-run budget', async () => {

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -128,6 +128,11 @@ vi.mock('../src/db', async () => {
               op.serverSeq > args.where.serverSeq.lte
             )
               return false;
+            if (
+              args.where?.serverSeq?.lt !== undefined &&
+              op.serverSeq >= args.where.serverSeq.lt
+            )
+              return false;
             if (args.where?.clientId?.not && op.clientId === args.where.clientId.not)
               return false;
             if (args.where?.opType?.in && !args.where.opType.in.includes(op.opType))
@@ -157,6 +162,8 @@ vi.mock('../src/db', async () => {
         for (const [id, op] of state.operations) {
           let shouldDelete = true;
           if (args.where?.userId !== undefined && op.userId !== args.where.userId)
+            shouldDelete = false;
+          if (args.where?.id?.in && !args.where.id.in.includes(op.id))
             shouldDelete = false;
           if (
             args.where?.receivedAt?.lt !== undefined &&
@@ -442,6 +449,11 @@ vi.mock('../src/db', async () => {
               if (
                 args.where?.serverSeq?.lte !== undefined &&
                 op.serverSeq > args.where.serverSeq.lte
+              )
+                return false;
+              if (
+                args.where?.serverSeq?.lt !== undefined &&
+                op.serverSeq >= args.where.serverSeq.lt
               )
                 return false;
               if (
@@ -1617,7 +1629,7 @@ describe('SyncService', () => {
       }
     });
 
-    it('should reject operations that are too old', async () => {
+    it('should accept operations created before the server retention window', async () => {
       const service = getSyncService();
       const tooOld = Date.now() - DEFAULT_SYNC_CONFIG.retentionMs - 10000;
 
@@ -1636,8 +1648,8 @@ describe('SyncService', () => {
 
       const results = await service.uploadOps(userId, clientId, [op]);
 
-      expect(results[0].accepted).toBe(false);
-      expect(results[0].error).toBe('Operation too old');
+      expect(results[0].accepted).toBe(true);
+      expect(testState.operations.has(op.id)).toBe(true);
     });
 
     it('should reject operations with payload exceeding size limit', async () => {
@@ -2331,7 +2343,32 @@ describe('SyncService', () => {
   });
 
   describe('cleanup', () => {
-    it('should delete old operations (time-based)', async () => {
+    const seedFullStateOp = (
+      targetUserId: number,
+      serverSeq: number,
+      receivedAt: bigint,
+    ): void => {
+      testState.operations.set(`full-state-${targetUserId}-${serverSeq}`, {
+        id: `full-state-${targetUserId}-${serverSeq}`,
+        userId: targetUserId,
+        clientId: `client-${targetUserId}`,
+        serverSeq,
+        actionType: 'LOAD_ALL_DATA',
+        opType: 'SYNC_IMPORT',
+        entityType: 'ALL',
+        entityId: null,
+        entityIds: [],
+        payload: { appDataComplete: { TASK: {} } },
+        vectorClock: {},
+        schemaVersion: 1,
+        clientTimestamp: BigInt(Date.now()),
+        receivedAt,
+        isPayloadEncrypted: false,
+        syncImportReason: null,
+      });
+    };
+
+    it('should not delete old operations when no full-state base exists', async () => {
       const service = getSyncService();
 
       // Upload operations
@@ -2372,12 +2409,54 @@ describe('SyncService', () => {
       const { totalDeleted, affectedUserIds } =
         await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
 
-      expect(totalDeleted).toBe(2);
-      expect(affectedUserIds).toContain(userId);
+      expect(totalDeleted).toBe(0);
+      expect(affectedUserIds).not.toContain(userId);
 
       const remaining = (await operationDownloadService.getOpsSinceWithSeq(userId, 0))
         .ops;
-      expect(remaining).toHaveLength(3);
+      expect(remaining).toHaveLength(5);
+    });
+
+    it('should preserve the latest full-state operation and its replay tail', async () => {
+      const service = getSyncService();
+      const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
+
+      for (let i = 1; i <= 5; i++) {
+        testState.operations.set(`old-op-${i}`, {
+          id: `old-op-${i}`,
+          userId,
+          clientId,
+          serverSeq: i,
+          actionType: i === 3 ? 'LOAD_ALL_DATA' : 'ADD',
+          opType: i === 3 ? 'SYNC_IMPORT' : 'CRT',
+          entityType: i === 3 ? 'ALL' : 'TASK',
+          entityId: i === 3 ? null : `t${i}`,
+          entityIds: [],
+          payload: i === 3 ? { appDataComplete: { TASK: {} } } : {},
+          vectorClock: {},
+          schemaVersion: 1,
+          clientTimestamp: BigInt(Date.now()),
+          receivedAt: BigInt(cutoffTime - 1),
+          isPayloadEncrypted: false,
+          syncImportReason: null,
+        });
+      }
+
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: 5,
+        lastSnapshotSeq: 5,
+        snapshotAt: BigInt(Date.now()),
+      });
+
+      const { totalDeleted } = await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+
+      expect(totalDeleted).toBe(2);
+      expect(Array.from(testState.operations.keys())).toEqual([
+        'old-op-3',
+        'old-op-4',
+        'old-op-5',
+      ]);
     });
 
     it('drains a single user up to the per-run budget', async () => {
@@ -2406,11 +2485,12 @@ describe('SyncService', () => {
           syncImportReason: null,
         });
       }
+      seedFullStateOp(userId, totalOps + 1, BigInt(cutoffTime - 1));
 
       testState.userSyncStates.set(userId, {
         userId,
-        lastSeq: totalOps,
-        lastSnapshotSeq: totalOps,
+        lastSeq: totalOps + 1,
+        lastSnapshotSeq: totalOps + 1,
         snapshotAt: BigInt(Date.now()),
       });
 
@@ -2423,7 +2503,7 @@ describe('SyncService', () => {
       // deleting until the budget hits zero, not just one batch.
       expect(totalDeleted).toBe(250);
       expect(affectedUserIds).toEqual([userId]);
-      expect(testState.operations.size).toBe(5);
+      expect(testState.operations.size).toBe(6);
     });
 
     it('marks user for reconcile when a later batch throws mid-loop', async () => {
@@ -2452,11 +2532,12 @@ describe('SyncService', () => {
           syncImportReason: null,
         });
       }
+      seedFullStateOp(userId, totalOps + 1, BigInt(cutoffTime - 1));
 
       testState.userSyncStates.set(userId, {
         userId,
-        lastSeq: totalOps,
-        lastSnapshotSeq: totalOps,
+        lastSeq: totalOps + 1,
+        lastSnapshotSeq: totalOps + 1,
         snapshotAt: BigInt(Date.now()),
       });
 
@@ -2490,7 +2571,7 @@ describe('SyncService', () => {
       // First batch committed deletes; the user must still be marked so
       // the next request reconciles the now-stale-high counter.
       expect(storageQuotaService.needsReconcile(userId)).toBe(true);
-      expect(testState.operations.size).toBe(totalOps - 50);
+      expect(testState.operations.size).toBe(totalOps + 1 - 50);
     });
 
     it('shares the per-run budget across users; tail users wait for next pass', async () => {
@@ -2529,20 +2610,21 @@ describe('SyncService', () => {
             syncImportReason: null,
           });
         }
+        seedFullStateOp(uid, opsPerUser + 1, BigInt(cutoffTime - 1));
       }
 
       // userSyncStates are processed by `orderBy: snapshotAt asc`, so the
       // stalest snapshot wins the budget first. user1 here is staler.
       testState.userSyncStates.set(userId, {
         userId,
-        lastSeq: opsPerUser,
-        lastSnapshotSeq: opsPerUser,
+        lastSeq: opsPerUser + 1,
+        lastSnapshotSeq: opsPerUser + 1,
         snapshotAt: BigInt(Date.now() - 1000),
       });
       testState.userSyncStates.set(user2Id, {
         userId: user2Id,
-        lastSeq: opsPerUser,
-        lastSnapshotSeq: opsPerUser,
+        lastSeq: opsPerUser + 1,
+        lastSnapshotSeq: opsPerUser + 1,
         snapshotAt: BigInt(Date.now()),
       });
 
@@ -2554,7 +2636,7 @@ describe('SyncService', () => {
       // user1 drains fully, user2 only gets the remaining budget.
       expect(totalDeleted).toBe(250);
       expect(affectedUserIds).toEqual([userId, user2Id]);
-      expect(testState.operations.size).toBe(150);
+      expect(testState.operations.size).toBe(152);
     });
 
     it('should delete old operations from all users', async () => {
@@ -2608,16 +2690,18 @@ describe('SyncService', () => {
 
       // Set up userSyncState with required fields for both users
       const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
+      seedFullStateOp(userId, 2, BigInt(cutoffTime - 1));
+      seedFullStateOp(user2Id, 3, BigInt(cutoffTime - 1));
       testState.userSyncStates.set(userId, {
         userId,
-        lastSeq: 1,
-        lastSnapshotSeq: 1,
+        lastSeq: 2,
+        lastSnapshotSeq: 2,
         snapshotAt: BigInt(Date.now()),
       });
       testState.userSyncStates.set(user2Id, {
         userId: user2Id,
-        lastSeq: 2,
-        lastSnapshotSeq: 2,
+        lastSeq: 3,
+        lastSnapshotSeq: 3,
         snapshotAt: BigInt(Date.now()),
       });
 
@@ -2632,10 +2716,10 @@ describe('SyncService', () => {
 
       expect(
         (await operationDownloadService.getOpsSinceWithSeq(userId, 0)).ops.length,
-      ).toBe(0);
+      ).toBe(1);
       expect(
         (await operationDownloadService.getOpsSinceWithSeq(user2Id, 0)).ops.length,
-      ).toBe(0);
+      ).toBe(1);
     });
 
     it('should delete stale devices', async () => {

--- a/packages/super-sync-server/tests/validation.service.spec.ts
+++ b/packages/super-sync-server/tests/validation.service.spec.ts
@@ -452,6 +452,26 @@ describe('ValidationService', () => {
       const result = validationService.validateOp(op, clientId);
       expect(result.valid).toBe(true);
     });
+
+    it('should reject a non-integer timestamp that would throw on BigInt persistence', () => {
+      const result = validationService.validateOp(
+        createValidOp({ timestamp: Date.now() + 0.5 }),
+        clientId,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errorCode).toBe(SYNC_ERROR_CODES.INVALID_TIMESTAMP);
+    });
+
+    it('should reject a non-finite timestamp', () => {
+      for (const timestamp of [Infinity, NaN]) {
+        const result = validationService.validateOp(
+          createValidOp({ timestamp }),
+          clientId,
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errorCode).toBe(SYNC_ERROR_CODES.INVALID_TIMESTAMP);
+      }
+    });
   });
 
   describe('validatePayloadComplexity', () => {

--- a/packages/super-sync-server/tests/validation.service.spec.ts
+++ b/packages/super-sync-server/tests/validation.service.spec.ts
@@ -446,13 +446,11 @@ describe('ValidationService', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should reject timestamps too old', () => {
+    it('should accept timestamps older than server retention', () => {
       const oldTime = Date.now() - 50 * 24 * 60 * 60 * 1000; // 50 days ago (beyond 45-day retention)
       const op = createValidOp({ timestamp: oldTime });
       const result = validationService.validateOp(op, clientId);
-      expect(result.valid).toBe(false);
-      expect(result.errorCode).toBe(SYNC_ERROR_CODES.INVALID_TIMESTAMP);
-      expect(result.error).toContain('too old');
+      expect(result.valid).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the four server-side defects from #8961 in `packages/super-sync-server/`, plus one robustness gap surfaced during review. All queries were confirmed `userId`-scoped (no IDOR); these were the residual issues.

### Data-loss fixes
- **Long-offline ops no longer terminally rejected.** `validateOp` used to reject any op whose client capture timestamp was older than the 45-day retention window with `INVALID_TIMESTAMP` — which the client treats as a *permanent* rejection. A device offline > 45 days lost its entire pending backlog. The check tied a client capture time to a server storage concept and also ran before duplicate detection. Removed it; op age doesn't affect causality (vector clocks handle that), and retention is now measured from server `receivedAt`, not the client timestamp.
- **Daily cleanup can no longer delete the only base-state op.** `deleteOldSyncedOpsBatch` deleted everything `<= lastSnapshotSeq` with no exclusion for full-state ops (SYNC_IMPORT/BACKUP_IMPORT/REPAIR). Because a full-state op's `receivedAt` precedes the snapshot's `snapshotAt`, a daily run could land in that window and delete the latest (possibly only) replay base while newer deltas survived, leaving fresh clients unable to bootstrap. Cleanup now caps deletion at `protectedFromSeq` (the newest covered full-state op), preserving that op and its replay tail; users with no replay base are skipped and reported in an aggregate warning.

### Auth-endpoint hardening
- **Registration no longer leaks account existence.** Passkey and magic-link registration returned a distinct "account already exists" error (an enumeration oracle). They now return the same neutral response regardless, `excludeCredentials` is dropped from registration options (it echoed existing credential IDs), the leaking strings are removed from `SAFE_ERROR_MESSAGES`, and the in-memory WebAuthn challenge store is namespaced by ceremony so ceremonies can't cross-consume challenges.
- **Magic-link login & passkey recovery are throttled per account.** Both used to write a fresh token and send an email on every call, gated only per-IP — enabling victim email-bombing and repeated invalidation of the victim's pending token. They now reuse a still-valid outstanding token within its TTL and use atomic `updateMany` claim/consume so concurrent requests can't each rotate/send or double-consume.

### Robustness fix (added during review)
- **Malformed timestamps no longer 500 a whole upload batch.** The transport schema accepts `timestamp: z.number()` (not `.int()`), so a non-integer / non-finite value passed validation and then threw at `BigInt(op.timestamp)` mid-`createMany`, aborting the entire batch. `validateOp` now rejects such values as a structured per-op `INVALID_TIMESTAMP`. Uses `Number.isSafeInteger`, which also guarantees the value fits the Postgres `BIGINT` column (no overflow). Old-but-valid timestamps stay accepted — the retention regression above is not reintroduced.

## Testing
- `npx vitest run` on the affected specs: **235 passing** (retention, cleanup full-state preservation, atomic token claim/consume, challenge isolation, timestamp integrality).
- `tsc --noEmit` clean; `checkFile` clean on all modified files.

## Review
The branch was put through a multi-agent review (6 Claude reviewers + Codex). No CRITICAL issues; the four target defects verified correctly fixed and race-safe. The timestamp-integrality guard was the one correctness gap found and is included here.

## Deferred follow-up (not in this PR)
The daily cleanup's legacy-marker fallback (`latestFullStateSeq` was added nullable with no backfill) re-runs a per-user query each day until a user next uploads a full-state op. A safe fix must also persist the merged full-state vector clock (the marker is coupled to it in the download fast-forward), so it's out of scope here — worth a tracking issue.

Fixes #8961
