### PR TITLE
fix(sync): reject forged encrypted full-state operations

### DIFF
--- a/docs/sync-and-op-log/supersync-encryption-architecture.md
+++ b/docs/sync-and-op-log/supersync-encryption-architecture.md
@@ -263,7 +263,9 @@ privateCfg: {
 >   the authenticated payload as complete application data before the metadata can
 >   promote it to `loadAllData`. Both direct and `appDataComplete`-wrapped payloads
 >   are supported. Supported legacy payloads are migrated on a validation copy;
->   the original remains unchanged for the existing operation-processing pipeline
+>   known compatible omissions (pre-section backups and the device-local sync
+>   interval stripped from wire snapshots) are restored only on that copy. The
+>   original remains unchanged for the existing operation-processing pipeline
 >   (`assertDecryptedFullStateOpIntegrity`).
 >
 > This is **not** full integrity. Still open pending the durable fix:

--- a/docs/sync-and-op-log/supersync-encryption-architecture.md
+++ b/docs/sync-and-op-log/supersync-encryption-architecture.md
@@ -241,7 +241,7 @@ privateCfg: {
 > `schemaVersion`, `syncImportReason`, **and the `isPayloadEncrypted` flag
 > itself** — travels as **plaintext** and is **not** bound as Additional
 > Authenticated Data (AAD), so a malicious/compromised sync server or a TLS MITM
-> can tamper with it. As **defense-in-depth**, the client fails closed on two
+> can tamper with it. As **defense-in-depth**, the client fails closed on three
 > tamper vectors:
 >
 > - **Plaintext-injection downgrade:** a forged op with `isPayloadEncrypted=false`
@@ -258,10 +258,16 @@ privateCfg: {
 > - **LWW `entityId` retarget:** the client rejects an _encrypted_ LWW-update op
 >   whose authenticated `payload.id` does not equal `op.entityId`
 >   (`verify-decrypted-op-integrity.ts`).
+> - **Full-state `opType` promotion:** after decrypting an operation tagged as
+>   `SYNC_IMPORT`, `BACKUP_IMPORT`, or `REPAIR`, the client structurally validates
+>   the authenticated payload as complete application data before the metadata can
+>   promote it to `loadAllData`. Both direct and `appDataComplete`-wrapped payloads
+>   are supported. Supported legacy payloads are migrated on a validation copy;
+>   the original remains unchanged for the existing operation-processing pipeline
+>   (`assertDecryptedFullStateOpIntegrity`).
 >
 > This is **not** full integrity. Still open pending the durable fix:
 >
-> - `opType` promotion to a full-state (`loadAllData`) op.
 > - Within-LWW `entityType`/`actionType` swap (ids left equal, so it passes).
 > - `vectorClock`/`timestamp` reorder/replay.
 > - The restore-to-point path (`getStateAtSeq` → `importCompleteBackup`) applies

--- a/src/app/op-log/sync/assert-ops-encryption-expected.ts
+++ b/src/app/op-log/sync/assert-ops-encryption-expected.ts
@@ -8,8 +8,8 @@ import { SyncLog } from '../../core/log';
  * The `isPayloadEncrypted` flag is itself unauthenticated plaintext metadata
  * (GHSA-8pxh-mgc7-gp3g). A compromised SuperSync server or a MITM can set it to
  * `false` and supply a fully attacker-authored plaintext op. Such an op skips
- * decryption AND the payload/metadata integrity check
- * (`assertDecryptedOpMetadataIntegrity`) entirely and is applied verbatim —
+ * decryption AND the post-decrypt payload/metadata integrity checks entirely
+ * and is applied verbatim —
  * arbitrary op forgery on an encryption-mandatory client, strictly more powerful
  * than retagging a genuine ciphertext op.
  *

--- a/src/app/op-log/sync/operation-encryption.service.spec.ts
+++ b/src/app/op-log/sync/operation-encryption.service.spec.ts
@@ -6,6 +6,8 @@ import { ActionType, OpType } from '../core/operation.types';
 import { toLwwUpdateActionType } from '../core/lww-update-action-types';
 import { clearSessionKeyCache, setArgon2ParamsForTesting } from '@sp/sync-core';
 import { createValidAppData } from '../validation/state-validity-test-utils';
+import { stripLocalOnlySyncSettingsFromAppData } from '../../features/config/local-only-sync-settings.util';
+import { CURRENT_SCHEMA_VERSION } from '@sp/shared-schema';
 
 describe('OperationEncryptionService', () => {
   let service: OperationEncryptionService;
@@ -288,6 +290,7 @@ describe('OperationEncryptionService', () => {
       const createFullStateOp = (
         opType: OpType.SyncImport | OpType.BackupImport | OpType.Repair,
         payload: unknown,
+        schemaVersion: number = CURRENT_SCHEMA_VERSION,
       ): SyncOperation => ({
         ...createMockSyncOp(payload),
         actionType:
@@ -295,6 +298,7 @@ describe('OperationEncryptionService', () => {
         opType,
         entityType: 'ALL',
         entityId: opType === OpType.BackupImport ? 'backup-import-1' : undefined,
+        schemaVersion,
       });
 
       const createLegacyV1AppData = (): unknown => {
@@ -371,10 +375,24 @@ describe('OperationEncryptionService', () => {
         expect(decrypted.payload).toEqual(jsonRoundTrip(state));
       });
 
-      it('accepts a legitimate schema-v1 SYNC_IMPORT payload', async () => {
-        const state = createLegacyV1AppData();
+      it('accepts a direct SYNC_IMPORT wire payload without local-only schedule settings', async () => {
+        const state = stripLocalOnlySyncSettingsFromAppData(
+          jsonRoundTrip(createValidAppData()),
+        );
         const encrypted = await service.encryptOperation(
           createFullStateOp(OpType.SyncImport, state),
+          TEST_PASSWORD,
+        );
+
+        const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+        expect(decrypted.payload).toEqual(state);
+      });
+
+      it('accepts a schema-v1 SYNC_IMPORT at the decryption boundary without mutating it', async () => {
+        const state = createLegacyV1AppData();
+        const encrypted = await service.encryptOperation(
+          createFullStateOp(OpType.SyncImport, state, 1),
           TEST_PASSWORD,
         );
 
@@ -416,6 +434,30 @@ describe('OperationEncryptionService', () => {
         const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
 
         expect(decrypted.payload).toEqual(jsonRoundTrip(payload));
+      });
+
+      it('accepts a wrapped REPAIR wire payload without the legacy section slice in a batch', async () => {
+        const state = jsonRoundTrip(createValidAppData()) as Record<string, unknown>;
+        delete state['section'];
+        const payload = {
+          appDataComplete: state,
+          repairSummary: {
+            entityStateFixed: 1,
+            orphanedEntitiesRestored: 0,
+            invalidReferencesRemoved: 0,
+            relationshipsFixed: 0,
+            structureRepaired: 0,
+            typeErrorsFixed: 0,
+          },
+        };
+        const [encrypted] = await service.encryptOperations(
+          [createFullStateOp(OpType.Repair, payload)],
+          TEST_PASSWORD,
+        );
+
+        const [decrypted] = await service.decryptOperations([encrypted], TEST_PASSWORD);
+
+        expect(decrypted.payload).toEqual(payload);
       });
     });
   });

--- a/src/app/op-log/sync/operation-encryption.service.spec.ts
+++ b/src/app/op-log/sync/operation-encryption.service.spec.ts
@@ -2,9 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { OperationEncryptionService } from './operation-encryption.service';
 import { SyncOperation } from '../sync-providers/provider.interface';
 import { DecryptError, OperationIntegrityError } from '../core/errors/sync-errors';
-import { ActionType } from '../core/operation.types';
+import { ActionType, OpType } from '../core/operation.types';
 import { toLwwUpdateActionType } from '../core/lww-update-action-types';
 import { clearSessionKeyCache, setArgon2ParamsForTesting } from '@sp/sync-core';
+import { createValidAppData } from '../validation/state-validity-test-utils';
 
 describe('OperationEncryptionService', () => {
   let service: OperationEncryptionService;
@@ -23,6 +24,8 @@ describe('OperationEncryptionService', () => {
     timestamp: Date.now(),
     schemaVersion: 1,
   });
+
+  const jsonRoundTrip = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
 
   // Use real encryption with weakened Argon2 params (8KiB memory, 1 iteration).
   // The session cache derives the key once per password across the whole spec,
@@ -278,6 +281,141 @@ describe('OperationEncryptionService', () => {
       expect(decrypted.payload).toEqual({
         id: 'task-123',
         changes: { title: 'legit change' },
+      });
+    });
+
+    describe('full-state opType promotion', () => {
+      const createFullStateOp = (
+        opType: OpType.SyncImport | OpType.BackupImport | OpType.Repair,
+        payload: unknown,
+      ): SyncOperation => ({
+        ...createMockSyncOp(payload),
+        actionType:
+          opType === OpType.Repair ? ActionType.REPAIR_AUTO : ActionType.LOAD_ALL_DATA,
+        opType,
+        entityType: 'ALL',
+        entityId: opType === OpType.BackupImport ? 'backup-import-1' : undefined,
+      });
+
+      const createLegacyV1AppData = (): unknown => {
+        const state = jsonRoundTrip(createValidAppData());
+        const {
+          isAutoMarkParentAsDone,
+          isAutoAddWorkedOnToToday,
+          isConfirmBeforeDelete,
+          isTrayShowCurrent,
+          isMarkdownFormattingInNotesEnabled,
+          defaultProjectId,
+          notesTemplate,
+          ...unmigratedTaskSettings
+        } = state.globalConfig.tasks;
+
+        return {
+          ...state,
+          globalConfig: {
+            ...state.globalConfig,
+            misc: {
+              ...state.globalConfig.misc,
+              isAutMarkParentAsDone: isAutoMarkParentAsDone,
+              isAutoAddWorkedOnToToday,
+              isConfirmBeforeTaskDelete: isConfirmBeforeDelete,
+              isTrayShowCurrentTask: isTrayShowCurrent,
+              isTurnOffMarkdown: !isMarkdownFormattingInNotesEnabled,
+              defaultProjectId,
+              taskNotesTpl: notesTemplate,
+            },
+            tasks: unmigratedTaskSettings,
+          },
+        };
+      };
+
+      it('rejects an ordinary encrypted op promoted to SYNC_IMPORT (single)', async () => {
+        const encrypted = await service.encryptOperation(
+          createMockSyncOp({ task: { id: 'task-123', changes: { title: 'x' } } }),
+          TEST_PASSWORD,
+        );
+        const tampered: SyncOperation = {
+          ...encrypted,
+          opType: OpType.SyncImport,
+        };
+
+        await expectAsync(
+          service.decryptOperation(tampered, TEST_PASSWORD),
+        ).toBeRejectedWithError(OperationIntegrityError);
+      });
+
+      it('rejects an ordinary encrypted op promoted to REPAIR (batch)', async () => {
+        const [encrypted] = await service.encryptOperations(
+          [createMockSyncOp({ task: { id: 'task-123', changes: { title: 'x' } } })],
+          TEST_PASSWORD,
+        );
+        const tampered: SyncOperation = {
+          ...encrypted,
+          opType: OpType.Repair,
+        };
+
+        await expectAsync(
+          service.decryptOperations([tampered], TEST_PASSWORD),
+        ).toBeRejectedWithError(OperationIntegrityError);
+      });
+
+      it('accepts a legitimate direct SYNC_IMPORT payload', async () => {
+        const state = createValidAppData();
+        const encrypted = await service.encryptOperation(
+          createFullStateOp(OpType.SyncImport, state),
+          TEST_PASSWORD,
+        );
+
+        const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+        expect(decrypted.payload).toEqual(jsonRoundTrip(state));
+      });
+
+      it('accepts a legitimate schema-v1 SYNC_IMPORT payload', async () => {
+        const state = createLegacyV1AppData();
+        const encrypted = await service.encryptOperation(
+          createFullStateOp(OpType.SyncImport, state),
+          TEST_PASSWORD,
+        );
+
+        const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+        expect(decrypted.payload).toEqual(state);
+      });
+
+      it('accepts a legitimate direct BACKUP_IMPORT payload', async () => {
+        const state = createValidAppData();
+        const encrypted = await service.encryptOperation(
+          createFullStateOp(OpType.BackupImport, state),
+          TEST_PASSWORD,
+        );
+
+        const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+        expect(decrypted.payload).toEqual(jsonRoundTrip(state));
+      });
+
+      it('accepts a legitimate wrapped REPAIR payload', async () => {
+        const state = createValidAppData();
+        const payload = {
+          appDataComplete: state,
+          repairSummary: {
+            entityStateFixed: 1,
+            orphanedEntitiesRestored: 0,
+            invalidReferencesRemoved: 0,
+            relationshipsFixed: 0,
+            structureRepaired: 0,
+            typeErrorsFixed: 0,
+          },
+        };
+        const encrypted = await service.encryptOperation(
+          createFullStateOp(OpType.Repair, payload),
+          TEST_PASSWORD,
+        );
+
+        const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+        expect(decrypted.payload).toEqual(jsonRoundTrip(payload));
       });
     });
   });

--- a/src/app/op-log/sync/operation-encryption.service.spec.ts
+++ b/src/app/op-log/sync/operation-encryption.service.spec.ts
@@ -333,6 +333,25 @@ describe('OperationEncryptionService', () => {
         };
       };
 
+      const requiredFullStateKeys = [
+        'task',
+        'project',
+        'tag',
+        'note',
+        'menuTree',
+        'globalConfig',
+        'simpleCounter',
+        'taskRepeatCfg',
+        'reminders',
+        'planner',
+        'boards',
+        'issueProvider',
+        'metric',
+        'timeTracking',
+      ] as const;
+
+      const optionalFullStateKeys = ['pluginUserData', 'pluginMetadata'] as const;
+
       it('rejects an ordinary encrypted op promoted to SYNC_IMPORT (single)', async () => {
         const encrypted = await service.encryptOperation(
           createMockSyncOp({ task: { id: 'task-123', changes: { title: 'x' } } }),
@@ -361,6 +380,49 @@ describe('OperationEncryptionService', () => {
         await expectAsync(
           service.decryptOperations([tampered], TEST_PASSWORD),
         ).toBeRejectedWithError(OperationIntegrityError);
+      });
+
+      it('rejects missing or malformed required roots and malformed optional roots', async () => {
+        for (const key of requiredFullStateKeys) {
+          for (const invalidValue of ['missing', null] as const) {
+            const state = jsonRoundTrip(createValidAppData()) as Record<string, unknown>;
+            if (invalidValue === 'missing') {
+              delete state[key];
+            } else {
+              state[key] = invalidValue;
+            }
+
+            const encrypted = await service.encryptOperation(
+              createMockSyncOp(state),
+              TEST_PASSWORD,
+            );
+            const promoted: SyncOperation = {
+              ...encrypted,
+              opType: OpType.SyncImport,
+            };
+
+            await expectAsync(service.decryptOperation(promoted, TEST_PASSWORD))
+              .withContext(`${key} must reject ${invalidValue}`)
+              .toBeRejectedWithError(OperationIntegrityError);
+          }
+        }
+
+        for (const key of optionalFullStateKeys) {
+          const state = jsonRoundTrip(createValidAppData()) as Record<string, unknown>;
+          state[key] = null;
+          const encrypted = await service.encryptOperation(
+            createMockSyncOp(state),
+            TEST_PASSWORD,
+          );
+          const promoted: SyncOperation = {
+            ...encrypted,
+            opType: OpType.SyncImport,
+          };
+
+          await expectAsync(service.decryptOperation(promoted, TEST_PASSWORD))
+            .withContext(`${key} must reject malformed values when present`)
+            .toBeRejectedWithError(OperationIntegrityError);
+        }
       });
 
       it('accepts a legitimate direct SYNC_IMPORT payload', async () => {

--- a/src/app/op-log/sync/operation-encryption.service.ts
+++ b/src/app/op-log/sync/operation-encryption.service.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@angular/core';
 import { decrypt, decryptBatch, encrypt, encryptBatch } from '@sp/sync-core';
 import { SyncOperation } from '../sync-providers/provider.interface';
 import { DecryptError } from '../core/errors/sync-errors';
-import { assertDecryptedOpMetadataIntegrity } from './verify-decrypted-op-integrity';
+import { isFullStateOpType } from '../core/operation.types';
+import {
+  assertDecryptedFullStateOpIntegrity,
+  assertDecryptedOpMetadataIntegrity,
+} from './verify-decrypted-op-integrity';
 
 /**
  * Handles E2E encryption/decryption of operation payloads for SuperSync.
@@ -62,6 +66,9 @@ export class OperationEncryptionService {
     // Verify the untrusted metadata against the now-authenticated payload before
     // trusting it downstream (GHSA-8pxh-mgc7-gp3g). Throws on tampering.
     assertDecryptedOpMetadataIntegrity(op, parsedPayload);
+    if (isFullStateOpType(op.opType)) {
+      await assertDecryptedFullStateOpIntegrity(op, parsedPayload);
+    }
     return {
       ...op,
       payload: parsedPayload,
@@ -142,6 +149,9 @@ export class OperationEncryptionService {
       // Verify the untrusted metadata against the now-authenticated payload
       // before trusting it downstream (GHSA-8pxh-mgc7-gp3g). Throws on tampering.
       assertDecryptedOpMetadataIntegrity(op, parsedPayload);
+      if (isFullStateOpType(op.opType)) {
+        await assertDecryptedFullStateOpIntegrity(op, parsedPayload);
+      }
       results[index] = {
         ...op,
         payload: parsedPayload,

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.ts
@@ -5,6 +5,56 @@ import { isSingletonEntityId } from '../core/entity-registry';
 import { OperationIntegrityError } from '../core/errors/sync-errors';
 import { ACTION_TYPE_ALIASES } from '../apply/operation-converter.util';
 import { SyncLog } from '../../core/log';
+import { FULL_STATE_OP_TYPES, OpType } from '../core/operation.types';
+import {
+  CURRENT_SCHEMA_VERSION,
+  MIN_SUPPORTED_SCHEMA_VERSION,
+  migrateState,
+} from '@sp/shared-schema';
+
+let _validateAllDataPromise:
+  | Promise<typeof import('../validation/validation-fn').validateAllData>
+  | undefined;
+
+const _loadValidateAllData = (): Promise<
+  typeof import('../validation/validation-fn').validateAllData
+> => {
+  if (!_validateAllDataPromise) {
+    _validateAllDataPromise = import('../validation/validation-fn')
+      .then((m) => m.validateAllData)
+      .catch((err) => {
+        _validateAllDataPromise = undefined;
+        throw err;
+      });
+  }
+  return _validateAllDataPromise;
+};
+
+const _extractFullState = (payload: unknown): unknown => {
+  if (typeof payload === 'object' && payload !== null && 'appDataComplete' in payload) {
+    return (payload as { appDataComplete: unknown }).appDataComplete;
+  }
+  return payload;
+};
+
+const _migrateFullStateForValidation = (
+  op: SyncOperation,
+  fullState: unknown,
+): unknown => {
+  const rawSchemaVersion = (op as { schemaVersion?: unknown }).schemaVersion;
+  const schemaVersion = rawSchemaVersion === undefined ? 1 : rawSchemaVersion;
+  if (
+    typeof schemaVersion !== 'number' ||
+    !Number.isInteger(schemaVersion) ||
+    schemaVersion < MIN_SUPPORTED_SCHEMA_VERSION ||
+    schemaVersion >= CURRENT_SCHEMA_VERSION
+  ) {
+    return fullState;
+  }
+
+  const migrationResult = migrateState(fullState, schemaVersion, CURRENT_SCHEMA_VERSION);
+  return migrationResult.success ? migrationResult.data : fullState;
+};
 
 /**
  * Verifies that a just-decrypted operation's UNAUTHENTICATED metadata is
@@ -37,9 +87,9 @@ import { SyncLog } from '../../core/log';
  * NOTE: interim hardening only. The plaintext-injection downgrade (a forged op
  * with `isPayloadEncrypted=false` that would skip decryption AND this check) is
  * handled separately by `assertOpsEncryptedWhenExpected` at the download
- * boundary. Still OPEN pending the durable fix (bind metadata as GCM AAD behind
- * an envelope-versioned migration):
- *  - `opType` promotion to a full-state (`loadAllData`) op.
+ * boundary. Full-state `opType` promotion is handled below by
+ * `assertDecryptedFullStateOpIntegrity`. Still OPEN pending the durable fix
+ * (bind metadata as GCM AAD behind an envelope-versioned migration):
  *  - Within-LWW `entityType`/`actionType` swap (ids left equal so this passes).
  *  - `vectorClock`/`timestamp` reorder/replay.
  * See GHSA-8pxh-mgc7-gp3g and
@@ -92,6 +142,60 @@ export const assertDecryptedOpMetadataIntegrity = (
   throw new OperationIntegrityError(
     `Operation ${op.id} failed metadata integrity check: encrypted payload id ` +
       `does not match op.entityId (possible sync-server tampering). ` +
+      `GHSA-8pxh-mgc7-gp3g`,
+  );
+};
+
+/**
+ * Rejects an encrypted operation whose unauthenticated `opType` was promoted
+ * to a full-state operation while its authenticated payload is not complete
+ * application data.
+ *
+ * Full-state payloads exist in two legitimate formats: direct app data for
+ * SYNC_IMPORT/BACKUP_IMPORT and an `appDataComplete` wrapper for REPAIR (plus
+ * legacy wrapped imports). Validation is loaded lazily because Typia's
+ * generated full-state validator is large and must stay out of the initial
+ * application bundle.
+ *
+ * Supported legacy state is migrated on a copy before validation because this
+ * boundary runs before RemoteOpsProcessingService's normal operation processing.
+ * The decrypted payload itself remains unchanged for the existing downstream path.
+ * This check intentionally uses structural Typia validation only. Cross-model
+ * relationship validation would turn recoverable data inconsistencies into a
+ * security failure and is not needed to distinguish ordinary entity payloads
+ * from complete state.
+ *
+ * @throws OperationIntegrityError when a full-state op carries a non-full-state payload.
+ */
+export const assertDecryptedFullStateOpIntegrity = async (
+  op: SyncOperation,
+  decryptedPayload: unknown,
+): Promise<void> => {
+  if (!FULL_STATE_OP_TYPES.has(op.opType as OpType)) {
+    return;
+  }
+
+  const validateAllData = await _loadValidateAllData();
+  const fullState = _extractFullState(decryptedPayload);
+  const stateToValidate = _migrateFullStateForValidation(op, fullState);
+  const validationResult = validateAllData(stateToValidate);
+  if (validationResult.success) {
+    return;
+  }
+
+  // Never log validator values: they can contain task titles, notes, and other
+  // user content. `opType` is safe here because it matched the fixed allowlist.
+  SyncLog.err(
+    '[assertDecryptedFullStateOpIntegrity] encrypted full-state op payload is not complete app data — rejecting (possible sync-server tampering)',
+    {
+      opId: op.id,
+      opType: op.opType,
+      validationErrorCount: validationResult.errors.length,
+    },
+  );
+  throw new OperationIntegrityError(
+    `Operation ${op.id} failed metadata integrity check: encrypted payload is not ` +
+      `valid full-state data for ${op.opType} (possible sync-server tampering). ` +
       `GHSA-8pxh-mgc7-gp3g`,
   );
 };

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.ts
@@ -5,7 +5,11 @@ import { isSingletonEntityId } from '../core/entity-registry';
 import { OperationIntegrityError } from '../core/errors/sync-errors';
 import { ACTION_TYPE_ALIASES } from '../apply/operation-converter.util';
 import { SyncLog } from '../../core/log';
-import { FULL_STATE_OP_TYPES, OpType } from '../core/operation.types';
+import {
+  extractFullStateFromPayload,
+  FULL_STATE_OP_TYPES,
+  OpType,
+} from '../core/operation.types';
 import {
   CURRENT_SCHEMA_VERSION,
   MIN_SUPPORTED_SCHEMA_VERSION,
@@ -30,11 +34,36 @@ const _loadValidateAllData = (): Promise<
   return _validateAllDataPromise;
 };
 
-const _extractFullState = (payload: unknown): unknown => {
-  if (typeof payload === 'object' && payload !== null && 'appDataComplete' in payload) {
-    return (payload as { appDataComplete: unknown }).appDataComplete;
+const _isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const _restoreKnownFullStateOmissionsForValidation = (fullState: unknown): unknown => {
+  if (!_isRecord(fullState)) {
+    return fullState;
   }
-  return payload;
+
+  // Pre-section backups are still supported by the loadAllData reducers.
+  const stateForValidation = Object.hasOwn(fullState, 'section')
+    ? fullState
+    : { ...fullState, section: { ids: [], entities: {} } };
+  const globalConfig = stateForValidation['globalConfig'];
+  if (!_isRecord(globalConfig)) {
+    return stateForValidation;
+  }
+  const syncConfig = globalConfig['sync'];
+  if (!_isRecord(syncConfig) || Object.hasOwn(syncConfig, 'syncInterval')) {
+    return stateForValidation;
+  }
+
+  // Snapshot uploads intentionally omit this device-local setting. Its actual
+  // value is restored downstream; only its required numeric shape matters here.
+  return {
+    ...stateForValidation,
+    globalConfig: {
+      ...globalConfig,
+      sync: { ...syncConfig, syncInterval: 0 },
+    },
+  };
 };
 
 const _migrateFullStateForValidation = (
@@ -159,6 +188,8 @@ export const assertDecryptedOpMetadataIntegrity = (
  *
  * Supported legacy state is migrated on a copy before validation because this
  * boundary runs before RemoteOpsProcessingService's normal operation processing.
+ * Known compatible omissions are also restored on that copy: pre-section backups
+ * and the device-local sync interval intentionally stripped from wire snapshots.
  * The decrypted payload itself remains unchanged for the existing downstream path.
  * This check intentionally uses structural Typia validation only. Cross-model
  * relationship validation would turn recoverable data inconsistencies into a
@@ -176,8 +207,9 @@ export const assertDecryptedFullStateOpIntegrity = async (
   }
 
   const validateAllData = await _loadValidateAllData();
-  const fullState = _extractFullState(decryptedPayload);
-  const stateToValidate = _migrateFullStateForValidation(op, fullState);
+  const fullState = extractFullStateFromPayload(decryptedPayload);
+  const migratedState = _migrateFullStateForValidation(op, fullState);
+  const stateToValidate = _restoreKnownFullStateOmissionsForValidation(migratedState);
   const validationResult = validateAllData(stateToValidate);
   if (validationResult.success) {
     return;

--- a/src/app/op-log/testing/integration/service-logic.integration.spec.ts
+++ b/src/app/op-log/testing/integration/service-logic.integration.spec.ts
@@ -56,6 +56,10 @@ import { SyncHydrationService } from '../../persistence/sync-hydration.service';
 import { OperationLogCompactionService } from '../../persistence/operation-log-compaction.service';
 import { SyncImportFilterService } from '../../sync/sync-import-filter.service';
 import { OperationLogEffects } from '../../capture/operation-log.effects';
+import { createValidAppData } from '../../validation/state-validity-test-utils';
+import { CURRENT_SCHEMA_VERSION } from '@sp/shared-schema';
+import { DEFAULT_GLOBAL_CONFIG } from '../../../features/config/default-global-config.const';
+import { selectSyncConfig } from '../../../features/config/store/global-config.reducer';
 
 // Mock Sync Provider that supports operation sync
 class MockOperationSyncProvider
@@ -348,8 +352,12 @@ describe('Service Logic Integration', () => {
     // Mock OperationWriteFlushService
     const writeFlushSpy = jasmine.createSpyObj('OperationWriteFlushService', [
       'flushPendingWrites',
+      'flushThenRunExclusive',
     ]);
     writeFlushSpy.flushPendingWrites.and.returnValue(Promise.resolve());
+    writeFlushSpy.flushThenRunExclusive.and.callFake(
+      async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+    );
 
     // Mock RejectedOpsHandlerService
     const rejectedOpsHandlerSpy = jasmine.createSpyObj('RejectedOpsHandlerService', [
@@ -384,7 +392,14 @@ describe('Service Logic Integration', () => {
         VectorClockService,
         SchemaMigrationService,
         RemoteOpsProcessingService,
-        provideMockStore(),
+        provideMockStore({
+          selectors: [
+            {
+              selector: selectSyncConfig,
+              value: DEFAULT_GLOBAL_CONFIG.sync,
+            },
+          ],
+        }),
         { provide: ConflictResolutionService, useValue: conflictServiceSpy },
         { provide: OperationApplierService, useValue: applierSpy },
         { provide: SuperSyncStatusService, useValue: superSyncStatusSpy },
@@ -527,6 +542,70 @@ describe('Service Logic Integration', () => {
       expect(appliedOps.length).toBe(1);
       expect(appliedOps[0].id).toBe('op-remote-1');
       expect(appliedOps[0].payload).toEqual(payload);
+    });
+
+    it('should upload, download, verify, and apply an encrypted full-state operation', async (): Promise<void> => {
+      mockProvider.setEncryption(true, TEST_KEY);
+      const uploadSnapshotSpy = spyOn(mockProvider, 'uploadSnapshot').and.callThrough();
+      const validState = structuredClone(createValidAppData());
+      const state = {
+        ...validState,
+        globalConfig: {
+          ...validState.globalConfig,
+          sync: {
+            ...validState.globalConfig.sync,
+            syncInterval: 123456,
+          },
+        },
+      };
+      const fullStateOp: Operation = {
+        id: 'encrypted-full-state-round-trip',
+        clientId: 'origin-client',
+        actionType: ActionType.LOAD_ALL_DATA,
+        opType: OpType.SyncImport,
+        entityType: 'ALL',
+        payload: { appDataComplete: state },
+        vectorClock: { originClient: 1 },
+        timestamp: Date.now(),
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      };
+      await opLogStore.append(fullStateOp, 'local');
+
+      await syncService.uploadPendingOps(mockProvider);
+
+      const uploadArgs = uploadSnapshotSpy.calls.mostRecent().args;
+      expect(typeof uploadArgs[0]).toBe('string');
+      expect(uploadArgs[5]).toBe(true);
+
+      await opLogStore._clearAllDataForTesting();
+      await mockProvider.setLastServerSeq(0);
+      applierSpy.applyOperations.calls.reset();
+      spyOn(mockProvider, 'downloadOps').and.resolveTo({
+        ops: [
+          {
+            op: {
+              ...fullStateOp,
+              payload: uploadArgs[0],
+              isPayloadEncrypted: true,
+            },
+            serverSeq: 1,
+            receivedAt: Date.now(),
+          },
+        ],
+        hasMore: false,
+        latestSeq: 1,
+      });
+
+      await syncService.downloadRemoteOps(mockProvider);
+
+      expect(applierSpy.applyOperations).toHaveBeenCalledTimes(1);
+      const [appliedOp] = applierSpy.applyOperations.calls.mostRecent().args[0];
+      expect(appliedOp.opType).toBe(OpType.SyncImport);
+      const appliedState = appliedOp.payload as typeof state;
+      expect(appliedState.project.entities['INBOX']?.title).toBe('Inbox');
+      expect(appliedState.globalConfig.sync.syncInterval).toBe(
+        DEFAULT_GLOBAL_CONFIG.sync.syncInterval,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Reject encrypted operations retagged as `SYNC_IMPORT`, `BACKUP_IMPORT`, or `REPAIR` unless the authenticated decrypted payload structurally validates as complete application state.
- Preserve supported legacy and wire-compatible payloads by migrating and normalizing a validation-only copy; the decrypted payload and wire format remain unchanged.
- Keep the full-state validator lazy-loaded and add rejection-matrix plus real upload → encrypted download → apply coverage.

## Root cause

SuperSync E2EE authenticates `op.payload`, but metadata such as `opType` remains plaintext. A malicious or compromised sync server could promote an ordinary encrypted entity operation to a full-state operation. The existing conversion path would then dispatch it as `loadAllData`, potentially replacing application state with an authenticated but structurally invalid entity payload.

This change fails closed with `OperationIntegrityError` before conversion while retaining compatibility for legitimate full-state operations, supported older schemas, pre-section backups, and snapshots that intentionally omit the device-local sync interval.

## Impact and scope

- Prevents the destructive full-state promotion vector tracked in GHSA-8pxh-mgc7-gp3g.
- Does not change the encryption envelope, sync wire format, persisted state, dependencies, or user-facing settings.
- The broader durable fix—binding metadata as AES-GCM AAD behind a versioned envelope—remains out of scope.

## Validation

- `npm run checkFile <filepath>` passed for every modified TypeScript file.
- Related sync suites: 223 tests passed.
- Sync core: 226 tests passed.
- Sync providers: 394 tests passed.
- Release tooling: 24 tests passed.
- Full Angular suite, Europe/Berlin: 12,401 passed, 2 skipped.
- Full Angular suite, America/Los_Angeles: 12,387 passed, 16 skipped.
- Production frontend build passed; the generated full-state validator remains lazy-loaded.
- [Scheduled E2E workflow](https://github.com/super-productivity/super-productivity/actions/runs/29269841805): server tests, build, regular E2E, WebDAV, and all six SuperSync shards passed. One shard initially hit the job timeout and passed its isolated rerun in 14m46s.

Fixes #8905
