### PR TITLE
fix(ui): open time picker for Electron touch input

### DIFF
--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.invalid-time.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.invalid-time.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
 import { DateAdapter } from '@angular/material/core';
@@ -115,6 +115,10 @@ describe('DialogScheduleTaskComponent — malformed selectedTime', () => {
     })
       .overrideComponent(DialogScheduleTaskComponent, { set: { template: '' } })
       .compileComponents();
+  });
+
+  afterEach(() => {
+    TestBed.inject(MockStore).resetSelectors();
   });
 
   // --- pinning tests (must keep passing through the fix) ---

--- a/src/app/ui/datetime-picker/datetime-picker.component.html
+++ b/src/app/ui/datetime-picker/datetime-picker.component.html
@@ -66,6 +66,7 @@
       (ngModelChange)="onTimeChange($event)"
       step="60"
       matInput
+      (click)="onTimeInputClick($event)"
       (keydown)="onTimeKeyDown($event)"
     />
     @if (selectedTime()) {

--- a/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
@@ -7,6 +7,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
 import { signal } from '@angular/core';
 import { TaskReminderOptionId } from '../../features/tasks/task.model';
+import { IS_ELECTRON_TOKEN } from '../../app.constants';
 
 describe('DateTimePickerComponent', () => {
   let component: DateTimePickerComponent;
@@ -31,6 +32,7 @@ describe('DateTimePickerComponent', () => {
       providers: [
         { provide: DateService, useValue: dateServiceSpy },
         { provide: GlobalConfigService, useValue: globalConfigServiceMock },
+        { provide: IS_ELECTRON_TOKEN, useValue: true },
         TranslateService,
         TranslateStore,
       ],
@@ -99,6 +101,60 @@ describe('DateTimePickerComponent', () => {
     component.onTimeFocus();
 
     expect(component.timeChanged.emit).toHaveBeenCalledWith('09:00');
+  });
+
+  it('should open the native time picker when the time input is tapped', () => {
+    const timeInput = fixture.nativeElement.querySelector(
+      'input[type="time"]',
+    ) as HTMLInputElement;
+    const showPickerSpy = spyOn(timeInput, 'showPicker');
+
+    timeInput.dispatchEvent(
+      new PointerEvent('click', { bubbles: true, pointerType: 'touch' }),
+    );
+
+    expect(showPickerSpy).toHaveBeenCalledOnceWith();
+  });
+
+  it('should preserve native segment editing when the time input is clicked with a mouse', () => {
+    const timeInput = fixture.nativeElement.querySelector(
+      'input[type="time"]',
+    ) as HTMLInputElement;
+    const showPickerSpy = spyOn(timeInput, 'showPicker');
+
+    timeInput.dispatchEvent(
+      new PointerEvent('click', { bubbles: true, pointerType: 'mouse' }),
+    );
+
+    expect(showPickerSpy).not.toHaveBeenCalled();
+  });
+
+  it('should preserve native touch handling outside Electron', () => {
+    Object.defineProperty(component, '_isElectron', { value: false });
+    const timeInput = fixture.nativeElement.querySelector(
+      'input[type="time"]',
+    ) as HTMLInputElement;
+    const showPickerSpy = spyOn(timeInput, 'showPicker');
+
+    timeInput.dispatchEvent(
+      new PointerEvent('click', { bubbles: true, pointerType: 'touch' }),
+    );
+
+    expect(showPickerSpy).not.toHaveBeenCalled();
+  });
+
+  it('should keep the time input focused when the native picker cannot be opened', () => {
+    const timeInput = fixture.nativeElement.querySelector(
+      'input[type="time"]',
+    ) as HTMLInputElement;
+    spyOn(timeInput, 'showPicker').and.throwError('Picker unavailable');
+    timeInput.focus();
+
+    timeInput.dispatchEvent(
+      new PointerEvent('click', { bubbles: true, pointerType: 'touch' }),
+    );
+
+    expect(document.activeElement).toBe(timeInput);
   });
 
   it('should toggle isKeyboardNavigating based on keyboard navigation and mouse move', () => {

--- a/src/app/ui/datetime-picker/datetime-picker.component.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.ts
@@ -40,6 +40,7 @@ import { TimeStepDirective } from '../time-step/time-step.directive';
 import { expandFadeAnimation } from '../animations/expand.ani';
 import { fadeAnimation } from '../animations/fade.ani';
 import { getClockStringFromHours } from '../../util/get-clock-string-from-hours';
+import { IS_ELECTRON_TOKEN } from '../../app.constants';
 
 const DEFAULT_TIME = '09:00';
 
@@ -73,6 +74,7 @@ export class DateTimePickerComponent implements AfterViewInit {
   private _globalConfigService = inject(GlobalConfigService);
   private readonly _cdr = inject(ChangeDetectorRef);
   private _el = inject(ElementRef);
+  private readonly _isElectron = inject(IS_ELECTRON_TOKEN);
 
   // Inputs
   selectedDate = input<Date | null>(null);
@@ -213,6 +215,26 @@ export class DateTimePickerComponent implements AfterViewInit {
 
   onTimeChange(newTime: string | null): void {
     this.timeChanged.emit(newTime);
+  }
+
+  onTimeInputClick(ev: PointerEvent): void {
+    if (!this._isElectron || ev.pointerType !== 'touch') {
+      return;
+    }
+
+    const timeInput = ev.currentTarget;
+    if (
+      !(timeInput instanceof HTMLInputElement) ||
+      typeof timeInput.showPicker !== 'function'
+    ) {
+      return;
+    }
+
+    try {
+      timeInput.showPicker();
+    } catch {
+      // Keep the focused native input as the fallback when no picker is available.
+    }
   }
 
   onReminderChange(newReminder: TaskReminderOptionId): void {


### PR DESCRIPTION
## Problem

On Windows Electron touchscreen devices without a physical keyboard, tapping the planned-time input only selected a time segment. It neither opened the native time picker nor raised an on-screen keyboard, leaving the value effectively uneditable.

The shared native time input relied on Chromium's default click behavior, which works on Android but does not open the picker for this Electron touch flow.

Closes #8986

## Solution

- Open the native time picker synchronously for touch activation in Electron.
- Preserve existing mouse, keyboard, pen, Android, and web behavior.
- Keep the input focused as a fallback if `showPicker()` is unavailable or throws.
- Add regression coverage for Electron touch activation, mouse preservation, non-Electron touch behavior, and picker failure.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] Documentation changes are not required for this narrow platform-specific bug fix.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass (`22/22` focused component tests)
- [x] My commit messages follow the Angular format (`type(scope): description`)
