### PR TITLE
fix(locale): localize ISO weekday labels

### DIFF
--- a/docs/wiki/3.02-Settings-and-Preferences.md
+++ b/docs/wiki/3.02-Settings-and-Preferences.md
@@ -8,6 +8,11 @@ Note: Differences between the Web app and the Desktop app are specified in [[3.0
 
 ### global-settings.Localization
 
+- **Datetime format locale** — Controls numeric date formatting and the
+  12/24-hour time format. The ISO 8601 option uses `YYYY-MM-DD` and a 24-hour
+  clock. With ISO 8601 selected, weekday labels in Schedule, Habits, and Planner
+  follow the app language.
+
 #### global-settings.App-Features
 
 #### global-settings.Misc-Settings

--- a/src/app/core/date-time-format/date-time-format.service.spec.ts
+++ b/src/app/core/date-time-format/date-time-format.service.spec.ts
@@ -292,6 +292,19 @@ describe('DateTimeFormatService', () => {
       expect(parsed?.getMonth()).toBe(1);
       expect(parsed?.getDate()).toBe(12);
     });
+
+    it('updates text labels when the UI language changes without changing ISO formats', () => {
+      expect(service.currentLocale()).toBe(DateTimeLocales.sv);
+      expect(service.isoTextLocale()).toBe('en');
+
+      service.setUiLanguage('de');
+      TestBed.flushEffects();
+
+      expect(service.isoTextLocale()).toBe('de');
+      expect(service.currentLocale()).toBe(DateTimeLocales.sv);
+      expect(service.dateFormat().raw).toBe('yyyy-MM-dd');
+      expect(service.is24HourFormat()).toBe(true);
+    });
   });
 
   describe('dateTimeLocale config fallback', () => {
@@ -397,6 +410,7 @@ describe('DateTimeFormatService', () => {
       TestBed.flushEffects();
 
       expect(service.currentLocale()).toBe(DateTimeLocales.ja_jp);
+      expect(service.isoTextLocale()).toBeNull();
       expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('14:00');
     });
 

--- a/src/app/core/date-time-format/date-time-format.service.ts
+++ b/src/app/core/date-time-format/date-time-format.service.ts
@@ -1,7 +1,12 @@
 import { computed, effect, inject, Injectable, signal } from '@angular/core';
 import { GlobalConfigService } from '../../features/config/global-config.service';
 import { DateAdapter } from '@angular/material/core';
-import { DEFAULT_LOCALE, DateTimeLocale } from 'src/app/core/locale.constants';
+import {
+  DEFAULT_LANGUAGE,
+  DEFAULT_LOCALE,
+  DateTimeLocale,
+  DateTimeLocales,
+} from 'src/app/core/locale.constants';
 import { TranslateService } from '@ngx-translate/core';
 
 @Injectable({
@@ -12,14 +17,34 @@ export class DateTimeFormatService {
   private _dateAdapter = inject(DateAdapter, { optional: true });
   private readonly _translateService = inject(TranslateService);
   private readonly _localeSig = signal<DateTimeLocale>(DEFAULT_LOCALE);
-  // UI translation language, pushed in by LanguageService. Used only as the
-  // lowest-priority fallback when no explicit dateTimeLocale override is set.
-  // Kept as a signal so the locale effect re-runs when the language changes.
+  // UI translation language, pushed in by LanguageService. Used for ISO text
+  // labels and as a fallback when no explicit dateTimeLocale override is set.
+  // Kept as a signal so locale-dependent computed values update reactively.
   private readonly _uiLangSig = signal<string | null>(null);
 
   // Signal for the locale to use
   readonly currentLocale = computed<DateTimeLocale>(() => {
     return this._globalConfigService.localization()?.dateTimeLocale || this._localeSig();
+  });
+
+  /**
+   * UI locale for ISO weekday labels. `null` preserves the existing formatter
+   * for every non-ISO option. The ISO option persists `sv` as a
+   * backward-compatible sync marker.
+   */
+  readonly isoTextLocale = computed<string | null>(() => {
+    const configuredLocale = this._globalConfigService.localization()?.dateTimeLocale;
+
+    if (configuredLocale !== DateTimeLocales.sv) {
+      return null;
+    }
+
+    return (
+      this._uiLangSig() ||
+      this._translateService.currentLang ||
+      this._translateService.defaultLang ||
+      DEFAULT_LANGUAGE
+    );
   });
 
   /** Test formats to detect locale-specific time and date formats (e.g., 24h vs 12h, DD/MM vs MM/DD) */

--- a/src/app/core/language/language.service.ts
+++ b/src/app/core/language/language.service.ts
@@ -60,9 +60,9 @@ export class LanguageService {
     this._isRTL.set(this._checkIsRTL(lng));
     this._translateService.use(lng);
 
-    // Register the UI language as a *fallback* only; DateTimeFormatService owns
-    // the adapter locale and keeps an explicit dateTimeLocale override winning.
-    // Setting the adapter locale directly here would clobber that override (#8565).
+    // Register the UI language for ISO text labels and as the locale fallback.
+    // DateTimeFormatService owns the adapter locale so an explicit date/time
+    // override keeps winning (#8565).
     this._dateTimeFormatService.setUiLanguage(lng);
   }
 

--- a/src/app/features/planner/planner-day/planner-day.component.spec.ts
+++ b/src/app/features/planner/planner-day/planner-day.component.spec.ts
@@ -1,0 +1,62 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { registerLocaleData } from '@angular/common';
+import localeDe from '@angular/common/locales/de';
+import { provideMockStore } from '@ngrx/store/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { PlannerDayComponent } from './planner-day.component';
+import { PlannerDay } from '../planner.model';
+import { TaskService } from '../../tasks/task.service';
+import { DateService } from '../../../core/date/date.service';
+import { LayoutService } from '../../../core-ui/layout/layout.service';
+import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
+
+describe('PlannerDayComponent', () => {
+  const createComponent = (
+    currentLocale: string,
+    isoTextLocale: string | null,
+  ): PlannerDayComponent => {
+    TestBed.configureTestingModule({
+      imports: [PlannerDayComponent],
+      providers: [
+        provideMockStore(),
+        { provide: MatDialog, useValue: jasmine.createSpyObj('MatDialog', ['open']) },
+        { provide: TaskService, useValue: {} },
+        { provide: DateService, useValue: {} },
+        { provide: LayoutService, useValue: { isXs: signal(false) } },
+        {
+          provide: DateTimeFormatService,
+          useValue: {
+            currentLocale: signal(currentLocale),
+            isoTextLocale: signal(isoTextLocale),
+          },
+        },
+      ],
+    });
+    TestBed.overrideComponent(PlannerDayComponent, { set: { template: '' } });
+    const component = TestBed.createComponent(PlannerDayComponent).componentInstance;
+    component.day = { dayDate: '2026-05-11' } as PlannerDay;
+    return component;
+  };
+
+  const getDayLabel = (component: PlannerDayComponent): string =>
+    (
+      component as unknown as {
+        dayLabel: () => string;
+      }
+    ).dayLabel();
+
+  beforeAll(() => registerLocaleData(localeDe, 'de-DE'));
+
+  it('uses the UI language for the weekday label with ISO formatting enabled', () => {
+    const component = createComponent('sv', 'de');
+
+    expect(getDayLabel(component)).toBe('Mo');
+  });
+
+  it('preserves Angular weekday formatting for non-ISO locales', () => {
+    const component = createComponent('de-DE', null);
+
+    expect(getDayLabel(component)).toBe('Mo.');
+  });
+});

--- a/src/app/features/planner/planner-day/planner-day.component.ts
+++ b/src/app/features/planner/planner-day/planner-day.component.ts
@@ -35,6 +35,7 @@ import { ProgressBarComponent } from '../../../ui/progress-bar/progress-bar.comp
 import { dragDelayForTouch } from '../../../util/input-intent';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
+import { parseDbDateStr } from '../../../util/parse-db-date-str';
 import { safeFormatDate } from '../../../util/safe-format-date';
 
 @Component({
@@ -88,9 +89,18 @@ export class PlannerDayComponent {
   // Replaces a per-CD `| localeDate: 'EEE'` pipe. The parent tracks planner-day
   // by `day.dayDate`, so the instance (and thus `this.day.dayDate`) is stable
   // for its lifetime; only a locale change needs to recompute the label.
-  protected readonly dayLabel = computed(() =>
-    safeFormatDate(this.day.dayDate, 'EEE', this._dateTimeFormatService.currentLocale()),
-  );
+  protected readonly dayLabel = computed(() => {
+    const isoTextLocale = this._dateTimeFormatService.isoTextLocale();
+    return isoTextLocale
+      ? parseDbDateStr(this.day.dayDate).toLocaleDateString(isoTextLocale, {
+          weekday: 'short',
+        })
+      : safeFormatDate(
+          this.day.dayDate,
+          'EEE',
+          this._dateTimeFormatService.currentLocale(),
+        );
+  });
 
   getProgressBarClass(percentage: number | undefined): string {
     if (!percentage) return 'bg-success';

--- a/src/app/features/schedule/schedule-month/schedule-month.component.spec.ts
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.spec.ts
@@ -3,6 +3,7 @@ import { Component, Input, signal } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de';
+import localeSv from '@angular/common/locales/sv';
 import { ScheduleMonthComponent } from './schedule-month.component';
 import { ScheduleService } from '../schedule.service';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
@@ -28,8 +29,11 @@ describe('ScheduleMonthComponent', () => {
     mockScheduleService.getEventDayStr.and.returnValue(null);
 
     mockDateTimeFormatService = jasmine.createSpyObj('DateTimeFormatService', ['-'], {
-      currentLocale: () => 'en-US',
+      currentLocale: () => 'sv',
+      isoTextLocale: () => 'de',
     });
+
+    registerLocaleData(localeSv, 'sv');
 
     await TestBed.configureTestingModule({
       imports: [ScheduleMonthComponent],
@@ -301,7 +305,7 @@ describe('ScheduleMonthComponent', () => {
 
       // Assert
       // Sunday should be first
-      expect(headers[0]).toContain('Sun');
+      expect(headers[0]).toBe('So');
     });
 
     it('should start with Monday when firstDayOfWeek is 1', () => {
@@ -314,7 +318,7 @@ describe('ScheduleMonthComponent', () => {
 
       // Assert
       // Monday should be first
-      expect(headers[0]).toContain('Mon');
+      expect(headers[0]).toBe('Mo');
     });
 
     it('should cycle correctly for all days of week', () => {
@@ -453,7 +457,10 @@ describe('ScheduleMonthComponent dayNumberByDay (SPAP-26)', () => {
       imports: [ScheduleMonthComponent],
       providers: [
         { provide: ScheduleService, useValue: scheduleServiceStub },
-        { provide: DateTimeFormatService, useValue: { currentLocale: localeSig } },
+        {
+          provide: DateTimeFormatService,
+          useValue: { currentLocale: localeSig, isoTextLocale: () => null },
+        },
       ],
     })
       .overrideComponent(ScheduleMonthComponent, {

--- a/src/app/features/schedule/schedule-month/schedule-month.component.ts
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.ts
@@ -34,6 +34,11 @@ export class ScheduleMonthComponent {
   readonly weekdayHeaders = computed(() => {
     const firstDay = this.firstDayOfWeek();
     const headers: string[] = [];
+    const isoTextLocale = this._dateTimeFormatService.isoTextLocale();
+    const formatter = isoTextLocale
+      ? new Intl.DateTimeFormat(isoTextLocale, { weekday: 'short' })
+      : null;
+    const locale = this._dateTimeFormatService.currentLocale();
 
     // Create a date for each day of week (using a week starting on Sunday)
     // January 2, 2000 was a Sunday
@@ -43,9 +48,8 @@ export class ScheduleMonthComponent {
       const dayIndex = (firstDay + i) % 7;
       const date = new Date(sundayDate);
       date.setDate(sundayDate.getDate() + dayIndex);
-      // 'EEE' format gives abbreviated day name (e.g., 'Mon', 'Tue')
       headers.push(
-        safeFormatDate(date, 'EEE', this._dateTimeFormatService.currentLocale()),
+        formatter ? formatter.format(date) : safeFormatDate(date, 'EEE', locale),
       );
     }
 

--- a/src/app/features/schedule/schedule-week/schedule-week.component.spec.ts
+++ b/src/app/features/schedule/schedule-week/schedule-week.component.spec.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { registerLocaleData } from '@angular/common';
+import localeSv from '@angular/common/locales/sv';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideMockStore } from '@ngrx/store/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -16,6 +18,8 @@ describe('ScheduleWeekComponent', () => {
   let fixture: ComponentFixture<ScheduleWeekComponent>;
 
   beforeEach(async () => {
+    registerLocaleData(localeSv, 'sv');
+
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, ScheduleWeekComponent, TranslateModule.forRoot()],
       providers: [
@@ -24,7 +28,8 @@ describe('ScheduleWeekComponent', () => {
           provide: DateTimeFormatService,
           useValue: {
             is24HourFormat: signal(true),
-            currentLocale: signal('en-US'),
+            currentLocale: signal('sv'),
+            isoTextLocale: signal('en-US'),
           },
         },
         {
@@ -49,6 +54,15 @@ describe('ScheduleWeekComponent', () => {
       .compileComponents();
 
     fixture = TestBed.createComponent(ScheduleWeekComponent);
+  });
+
+  it('uses the UI language for weekday headers with ISO formatting enabled', () => {
+    fixture.componentRef.setInput('daysToShow', ['2026-05-11']);
+
+    expect(fixture.componentInstance.dayHeaderLabels()['2026-05-11']).toEqual({
+      num: '11',
+      day: 'Mon',
+    });
   });
 
   it('should dedupe visible and hidden beyond-budget tasks in the day badge', () => {

--- a/src/app/features/schedule/schedule-week/schedule-week.component.ts
+++ b/src/app/features/schedule/schedule-week/schedule-week.component.ts
@@ -133,17 +133,23 @@ export class ScheduleWeekComponent implements OnInit, AfterViewInit, OnDestroy {
   });
 
   // Precompute the day-number ('d') and weekday ('EEE') header labels for each
-  // visible day, keyed on the day list + current locale. Replaces two per-column
-  // `| localeDate` pipes so no date formatting runs during change detection;
-  // recomputes only when the days or the locale change.
+  // visible day, keyed on the day list + numeric/text locales. Replaces two
+  // per-column `| localeDate` pipes so no date formatting runs during change
+  // detection; recomputes only when the days or either locale change.
   readonly dayHeaderLabels = computed<Record<string, { num: string; day: string }>>(
     () => {
       const locale = this._dateTimeFormatService.currentLocale();
+      const isoTextLocale = this._dateTimeFormatService.isoTextLocale();
+      const weekdayFormatter = isoTextLocale
+        ? new Intl.DateTimeFormat(isoTextLocale, { weekday: 'short' })
+        : null;
       const map: Record<string, { num: string; day: string }> = {};
       for (const day of this.daysToShow()) {
         map[day] = {
           num: safeFormatDate(day, 'd', locale),
-          day: safeFormatDate(day, 'EEE', locale),
+          day: weekdayFormatter
+            ? weekdayFormatter.format(parseDbDateStr(day))
+            : safeFormatDate(day, 'EEE', locale),
         };
       }
       return map;

--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.html
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.html
@@ -41,7 +41,11 @@
       @for (day of days(); track day.str) {
         <div class="day-header">
           <div class="day-name">
-            {{ day.date | localeDate: 'EEE' : undefined : locale() }}
+            @if (day.weekdayLabel) {
+              {{ day.weekdayLabel }}
+            } @else {
+              {{ day.date | localeDate: 'EEE' : undefined : locale() }}
+            }
           </div>
           <div class="day-date">
             {{ day.date | localeDate: 'dd' : undefined : locale() }}

--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.spec.ts
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { registerLocaleData } from '@angular/common';
+import localeSv from '@angular/common/locales/sv';
 import { HabitTrackerComponent } from './habit-tracker.component';
 import { SimpleCounterService } from '../simple-counter.service';
 import { DateService } from '../../../core/date/date.service';
@@ -29,6 +31,7 @@ describe('HabitTrackerComponent', () => {
   };
 
   beforeEach(async () => {
+    registerLocaleData(localeSv, 'sv');
     simpleCounterService = jasmine.createSpyObj('SimpleCounterService', [
       'setCounterForDate',
       'updateOrder',
@@ -43,7 +46,13 @@ describe('HabitTrackerComponent', () => {
         { provide: SimpleCounterService, useValue: simpleCounterService },
         { provide: MatDialog, useValue: matDialog },
         { provide: DateService, useValue: { todayStr: () => '2026-05-18' } },
-        { provide: DateTimeFormatService, useValue: { currentLocale: () => 'en-US' } },
+        {
+          provide: DateTimeFormatService,
+          useValue: {
+            currentLocale: () => 'sv',
+            isoTextLocale: () => 'en-US',
+          },
+        },
       ],
     }).compileComponents();
 
@@ -51,6 +60,19 @@ describe('HabitTrackerComponent', () => {
     component = fixture.componentInstance;
     fixture.componentRef.setInput('simpleCounters', [mockCounter]);
     fixture.detectChanges();
+  });
+
+  it('uses the UI language for weekday headers with ISO formatting enabled', () => {
+    const element = fixture.nativeElement as HTMLElement;
+    const dayNames = Array.from(
+      element.querySelectorAll<HTMLElement>('.day-name'),
+      (dayName) => dayName.textContent?.trim(),
+    );
+
+    expect(dayNames).toHaveSize(7);
+    expect(dayNames).toEqual(
+      jasmine.arrayWithExactContents(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']),
+    );
   });
 
   it('should not open edit dialog on long-press if day is disabled', fakeAsync(() => {

--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.ts
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.ts
@@ -30,6 +30,7 @@ interface HabitDay {
   str: string;
   date: Date;
   dow: number;
+  weekdayLabel?: string;
 }
 
 @Component({
@@ -72,6 +73,10 @@ export class HabitTrackerComponent {
 
   days = computed(() => {
     const days: HabitDay[] = [];
+    const isoTextLocale = this._dateTimeFormatService.isoTextLocale();
+    const weekdayFormatter = isoTextLocale
+      ? new Intl.DateTimeFormat(isoTextLocale, { weekday: 'short' })
+      : null;
     const today = new Date();
     const offset = this.dayOffset();
     for (let i = 6; i >= 0; i--) {
@@ -81,6 +86,7 @@ export class HabitTrackerComponent {
         str: this._dateService.todayStr(d),
         date: d,
         dow: d.getDay(),
+        weekdayLabel: weekdayFormatter?.format(d),
       });
     }
     return days;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2560,7 +2560,7 @@
       "TIME_LOCALE_AUTO": "System default",
       "TIME_LOCALE_CS_CZ": "Czech: 24-hour, DD. MM. YYYY",
       "TIME_LOCALE_DE_DE": "German: 24-hour, DD.MM.YYYY",
-      "TIME_LOCALE_DESCRIPTION": "Sets the date format and the 12/24-hour time format used across the app. \"System default\" follows your browser's language/region — to force 12- or 24-hour time, pick a specific locale. Spelled-out month and weekday names follow this locale too (for example, ISO 8601 shows Swedish names).",
+      "TIME_LOCALE_DESCRIPTION": "Sets the date format and the 12/24-hour time format used across the app. \"System default\" follows your browser's language/region — to force 12- or 24-hour time, pick a specific locale. With ISO 8601, weekday labels in Schedule, Habits, and Planner follow the app language.",
       "TIME_LOCALE_EN_GB": "English (UK): 24-hour, DD/MM/YYYY",
       "TIME_LOCALE_EN_US": "English (US): 12-hour AM/PM, MM/DD/YYYY",
       "TIME_LOCALE_ES_ES": "Spanish: 24-hour, DD/MM/YYYY",


### PR DESCRIPTION
## Problem

The ISO 8601 datetime option uses Swedish as a stable formatting sentinel for `YYYY-MM-DD` and 24-hour time. Weekday labels in Schedule, Habits, and Planner were therefore rendered in Swedish even when the UI language was different.

Fixes #8987.

## Solution

- Use the UI language for weekday text when the ISO 8601 datetime option is selected.
- Keep numeric ISO date and time formatting unchanged.
- Preserve the existing locale formatter for every non-ISO datetime option.
- Add regression tests for ISO labels, UI-language changes, and non-ISO formatting parity.
- Clarify the localization setting in the wiki and English UI copy.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Validation

- `npm test`
- `npm run build`
- Targeted DateTimeFormatService, Schedule, Habits, and Planner unit tests
