### PR TITLE
fix(ios): prevent keyboard frames from resizing webview

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,4 +1,5 @@
 import type { CapacitorConfig } from '@capacitor/cli';
+import { KeyboardResize } from '@capacitor/keyboard';
 
 const config: CapacitorConfig = {
   appId: 'com.super-productivity.app',
@@ -15,11 +16,11 @@ const config: CapacitorConfig = {
     Keyboard: {
       // iOS-only: Android excludes @capacitor/keyboard via includePlugins below
       // and uses JavaScriptInterface for keyboard visibility instead.
-      // 'native' resizes the WKWebView so 100vh fits above the keyboard.
-      resize: 'native',
-      // iOS-only; ignored on Android (plugin excluded). Kept false so the
-      // WKWebView is not force-resized in fullscreen.
-      resizeOnFullScreen: false,
+      // Keep the native plugin from resizing WKWebView with an unsanitized
+      // third-party keyboard frame (#8778). The app derives its iOS viewport
+      // and overlay offsets from KeyboardInfo + VisualViewport instead.
+      // https://capacitorjs.com/docs/apis/keyboard#keyboardresize
+      resize: KeyboardResize.None,
     },
     StatusBar: {
       // iOS: overlay the status bar so content can sit beneath it.

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -47,7 +47,8 @@
 }
 
 // iOS keeps 100vh tied to the layout viewport while the soft keyboard is open.
-// Use visualViewport height from JS so the app shell shrinks above the keyboard.
+// Use VisualViewport's bottom edge from JS so the top-anchored shell fills the
+// visible area even when iOS pans the viewport to keep an input in view.
 :host-context(body.isIOS.isKeyboardVisible) .app-container {
   height: calc(var(--visual-viewport-height) - var(--safe-area-top));
   min-height: calc(var(--visual-viewport-height) - var(--safe-area-top));

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -61,6 +61,10 @@ import { LS } from '../persistence/storage-keys.const';
 import { Log } from '../log';
 import { LayoutService } from '../../core-ui/layout/layout.service';
 import { sanitizeIosKeyboardHeight } from './sanitize-ios-keyboard-height.util';
+import {
+  IosKeyboardViewport,
+  resolveIosKeyboardViewport,
+} from './ios-keyboard-viewport.util';
 
 interface NavigationBarPlugin {
   setColor(options: { color: string; style: 'LIGHT' | 'DARK' }): Promise<void>;
@@ -78,7 +82,6 @@ const CSS_VAR_SAFE_AREA_TOP = '--safe-area-inset-top';
 const CSS_VAR_SAFE_AREA_BOTTOM = '--safe-area-inset-bottom';
 const CSS_VAR_SAFE_AREA_LEFT = '--safe-area-inset-left';
 const CSS_VAR_SAFE_AREA_RIGHT = '--safe-area-inset-right';
-const VIEWPORT_RESIZE_EPSILON_PX = 1;
 
 /** The four wallpaper fields of the app-level (global) background config. */
 export type GlobalWallpaperCfg = Pick<
@@ -164,14 +167,9 @@ export class GlobalThemeService {
   private _hasInitialized = false;
   private _keyboardListenerHandles: PluginListenerHandle[] = [];
   private _focusinListener: ((event: FocusEvent) => void) | null = null;
-  private _visualViewportResizeListener: (() => void) | null = null;
+  private _visualViewportChangeListener: (() => void) | null = null;
   private _iosKeyboardHeight = 0;
-  private _iosViewportHeightBeforeKeyboard = 0;
   private _iosViewportChangeRaf: number | null = null;
-  // True only when the plugin reported an implausible keyboard frame (the clamp
-  // had to correct it). Gates the measured-viewport override so well-behaved
-  // keyboards keep their exact pre-existing behaviour (#8778).
-  private _iosKeyboardFrameUnreliable = false;
 
   private _isCustomWindowTitleBarEnabled(): boolean {
     // The main process (main-window.ts) force-disables the custom title bar on
@@ -616,41 +614,44 @@ export class GlobalThemeService {
     this._updateIOSKeyboardViewportVars();
 
     if (window.visualViewport) {
-      this._visualViewportResizeListener = (): void => {
-        this._updateIOSKeyboardViewportVars();
+      this._visualViewportChangeListener = (): void => {
+        if (this.document.body.classList.contains(BodyClass.isKeyboardVisible)) {
+          this._updateIOSKeyboardViewportVars();
+        }
       };
       window.visualViewport.addEventListener(
         'resize',
-        this._visualViewportResizeListener,
+        this._visualViewportChangeListener,
+        { passive: true },
+      );
+      window.visualViewport.addEventListener(
+        'scroll',
+        this._visualViewportChangeListener,
         { passive: true },
       );
     }
 
     Keyboard.addListener('keyboardWillShow', (info: KeyboardInfo) => {
-      Log.log('iOS keyboard will show', info);
-      if (!this.document.body.classList.contains(BodyClass.isKeyboardVisible)) {
-        this._iosViewportHeightBeforeKeyboard = window.innerHeight;
-      }
       // Some third-party keyboards (e.g. Sogou) report a bogus near-full-screen
-      // keyboard frame here; clamp it so it can't fling the fixed add-task bar
-      // to the top of the screen (#8778).
-      const referenceHeight = this._iosViewportHeightBeforeKeyboard || window.innerHeight;
+      // frame here. It is only a bounded fallback until VisualViewport exposes
+      // the real visible area; it can never resize the native WebView (#8778).
+      const referenceHeight = window.innerHeight;
       const keyboardHeight = sanitizeIosKeyboardHeight(
         info.keyboardHeight,
         referenceHeight,
       );
-      // Only a frame the clamp had to correct opts into the measured-viewport
-      // override in _updateIOSKeyboardViewportVars; well-behaved keyboards keep
-      // the exact pre-existing behaviour, so this cannot regress them.
-      this._iosKeyboardFrameUnreliable = keyboardHeight !== info.keyboardHeight;
       this._iosKeyboardHeight = keyboardHeight;
       this.document.body.classList.add(BodyClass.isKeyboardVisible);
-      // Set CSS variable for keyboard height to adjust layout
-      this.document.documentElement.style.setProperty(
-        CSS_VAR_KEYBOARD_HEIGHT,
-        `${keyboardHeight}px`,
-      );
-      this._updateIOSKeyboardViewportVars();
+      const viewport = this._updateIOSKeyboardViewportVars();
+      Log.log('iOS keyboard will show', {
+        reportedKeyboardHeight: info.keyboardHeight,
+        sanitizedKeyboardHeight: keyboardHeight,
+        baseHeight: referenceHeight,
+        visualViewportHeight: window.visualViewport?.height,
+        visualViewportOffsetTop: window.visualViewport?.offsetTop,
+        viewportHeight: viewport.viewportHeight,
+        keyboardOffset: viewport.keyboardOffset,
+      });
     }).then((handle) => this._keyboardListenerHandles.push(handle));
 
     // Use keyboardDidShow for scroll (after animation completes)
@@ -662,14 +663,7 @@ export class GlobalThemeService {
     Keyboard.addListener('keyboardWillHide', () => {
       Log.log('iOS keyboard will hide');
       this._iosKeyboardHeight = 0;
-      this._iosViewportHeightBeforeKeyboard = 0;
-      this._iosKeyboardFrameUnreliable = false;
       this.document.body.classList.remove(BodyClass.isKeyboardVisible);
-      this.document.documentElement.style.setProperty(CSS_VAR_KEYBOARD_HEIGHT, '0px');
-      this.document.documentElement.style.setProperty(
-        CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
-        '0px',
-      );
       this._updateIOSKeyboardViewportVars();
     }).then((handle) => this._keyboardListenerHandles.push(handle));
 
@@ -693,10 +687,14 @@ export class GlobalThemeService {
     // Cleanup listeners on destroy
     this._destroyRef.onDestroy(() => {
       this._keyboardListenerHandles.forEach((handle) => handle.remove());
-      if (this._visualViewportResizeListener && window.visualViewport) {
+      if (this._visualViewportChangeListener && window.visualViewport) {
         window.visualViewport.removeEventListener(
           'resize',
-          this._visualViewportResizeListener,
+          this._visualViewportChangeListener,
+        );
+        window.visualViewport.removeEventListener(
+          'scroll',
+          this._visualViewportChangeListener,
         );
       }
       if (this._iosViewportChangeRaf !== null) {
@@ -708,74 +706,31 @@ export class GlobalThemeService {
     });
   }
 
-  private _updateIOSKeyboardViewportVars(): void {
+  private _updateIOSKeyboardViewportVars(): IosKeyboardViewport {
     const root = this.document.documentElement;
     const visualViewportHeight = window.visualViewport?.height;
-    const baseHeight = this._iosViewportHeightBeforeKeyboard || window.innerHeight;
-    const isKeyboardVisible = this._iosKeyboardHeight > 0;
-    const isVisualViewportAlreadyResized = this._isVisualViewportResizedForKeyboard(
-      isKeyboardVisible,
+    const baseHeight = window.innerHeight;
+    const viewport = resolveIosKeyboardViewport({
       baseHeight,
+      keyboardHeight: this._iosKeyboardHeight,
+      isKeyboardVisible: this.document.body.classList.contains(
+        BodyClass.isKeyboardVisible,
+      ),
       visualViewportHeight,
-    );
-    const height = isKeyboardVisible
-      ? this._getKeyboardAdjustedViewportHeight(baseHeight, visualViewportHeight)
-      : (visualViewportHeight ?? window.innerHeight);
+      visualViewportOffsetTop: window.visualViewport?.offsetTop,
+    });
 
-    root.style.setProperty(CSS_VAR_VISUAL_VIEWPORT_HEIGHT, `${Math.max(0, height)}px`);
+    root.style.setProperty(
+      CSS_VAR_VISUAL_VIEWPORT_HEIGHT,
+      `${viewport.viewportHeight}px`,
+    );
     root.style.setProperty(
       CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
-      `${isKeyboardVisible && !isVisualViewportAlreadyResized ? this._iosKeyboardHeight : 0}px`,
+      `${viewport.keyboardOffset}px`,
     );
-
-    // For a keyboard whose reported frame was implausible, once the viewport has
-    // actually shrunk its measured obscured area (`baseHeight -
-    // visualViewportHeight`) is a far more reliable keyboard height than the
-    // bogus plugin frame (#8778), and is correct under both `resize: 'native'`
-    // and non-resizing modes. Correct `--keyboard-height` to the measurement
-    // (still clamped as a safety net). Well-behaved keyboards skip this entirely
-    // and keep the plugin value set in keyboardWillShow — no behaviour change.
-    if (
-      this._iosKeyboardFrameUnreliable &&
-      this._isVisualViewportResizedForKeyboard(
-        isKeyboardVisible,
-        baseHeight,
-        visualViewportHeight,
-      )
-    ) {
-      root.style.setProperty(
-        CSS_VAR_KEYBOARD_HEIGHT,
-        `${sanitizeIosKeyboardHeight(baseHeight - visualViewportHeight, baseHeight)}px`,
-      );
-    }
+    root.style.setProperty(CSS_VAR_KEYBOARD_HEIGHT, `${viewport.keyboardOffset}px`);
     this._notifyIOSViewportChange();
-  }
-
-  private _getKeyboardAdjustedViewportHeight(
-    baseHeight: number,
-    visualViewportHeight?: number,
-  ): number {
-    const keyboardAdjustedHeight = baseHeight - this._iosKeyboardHeight;
-
-    if (
-      this._isVisualViewportResizedForKeyboard(true, baseHeight, visualViewportHeight)
-    ) {
-      return visualViewportHeight;
-    }
-
-    return keyboardAdjustedHeight;
-  }
-
-  private _isVisualViewportResizedForKeyboard(
-    isKeyboardVisible: boolean,
-    baseHeight: number,
-    visualViewportHeight?: number,
-  ): visualViewportHeight is number {
-    return (
-      isKeyboardVisible &&
-      visualViewportHeight !== undefined &&
-      visualViewportHeight < baseHeight - VIEWPORT_RESIZE_EPSILON_PX
-    );
+    return viewport;
   }
 
   private _notifyIOSViewportChange(): void {

--- a/src/app/core/theme/ios-keyboard-config.spec.ts
+++ b/src/app/core/theme/ios-keyboard-config.spec.ts
@@ -1,0 +1,10 @@
+import config from '../../../../capacitor.config';
+import { KeyboardResize } from '@capacitor/keyboard';
+
+describe('iOS keyboard Capacitor configuration', () => {
+  it('does not let an unsanitized keyboard frame resize the native WebView', () => {
+    const keyboardConfig = config.plugins?.['Keyboard'];
+
+    expect(keyboardConfig?.['resize']).toBe(KeyboardResize.None);
+  });
+});

--- a/src/app/core/theme/ios-keyboard-viewport.util.spec.ts
+++ b/src/app/core/theme/ios-keyboard-viewport.util.spec.ts
@@ -1,0 +1,76 @@
+import { resolveIosKeyboardViewport } from './ios-keyboard-viewport.util';
+
+describe('resolveIosKeyboardViewport', () => {
+  it('uses the sanitized plugin height until VisualViewport exposes the keyboard', () => {
+    const result = resolveIosKeyboardViewport({
+      baseHeight: 812,
+      keyboardHeight: 300,
+      isKeyboardVisible: true,
+      visualViewportHeight: 812,
+    });
+
+    expect(result.viewportHeight).toBe(512);
+    expect(result.keyboardOffset).toBe(300);
+  });
+
+  it('prefers measured geometry over a plausible but incorrect plugin height', () => {
+    const result = resolveIosKeyboardViewport({
+      baseHeight: 812,
+      keyboardHeight: 75,
+      isKeyboardVisible: true,
+      visualViewportHeight: 415,
+    });
+
+    expect(result.viewportHeight).toBe(415);
+    expect(result.keyboardOffset).toBe(397);
+  });
+
+  it('uses the visible viewport bottom when the viewport is shifted', () => {
+    const result = resolveIosKeyboardViewport({
+      baseHeight: 812,
+      keyboardHeight: 300,
+      isKeyboardVisible: true,
+      visualViewportHeight: 482,
+      visualViewportOffsetTop: 30,
+    });
+
+    expect(result.viewportHeight).toBe(512);
+    expect(result.keyboardOffset).toBe(300);
+  });
+
+  it('does not apply the plugin-frame ceiling to measured viewport geometry', () => {
+    const result = resolveIosKeyboardViewport({
+      baseHeight: 375,
+      keyboardHeight: 225,
+      isKeyboardVisible: true,
+      visualViewportHeight: 120,
+    });
+
+    expect(result.viewportHeight).toBe(120);
+    expect(result.keyboardOffset).toBe(255);
+  });
+
+  it('uses measured geometry even when the plugin reports zero', () => {
+    const result = resolveIosKeyboardViewport({
+      baseHeight: 812,
+      keyboardHeight: 0,
+      isKeyboardVisible: true,
+      visualViewportHeight: 512,
+    });
+
+    expect(result.viewportHeight).toBe(512);
+    expect(result.keyboardOffset).toBe(300);
+  });
+
+  it('uses the current visual viewport when the keyboard is hidden', () => {
+    const result = resolveIosKeyboardViewport({
+      baseHeight: 812,
+      keyboardHeight: 0,
+      isKeyboardVisible: false,
+      visualViewportHeight: 780,
+    });
+
+    expect(result.viewportHeight).toBe(780);
+    expect(result.keyboardOffset).toBe(0);
+  });
+});

--- a/src/app/core/theme/ios-keyboard-viewport.util.ts
+++ b/src/app/core/theme/ios-keyboard-viewport.util.ts
@@ -1,0 +1,55 @@
+const VIEWPORT_RESIZE_EPSILON_PX = 1;
+
+export interface IosKeyboardViewportInput {
+  baseHeight: number;
+  keyboardHeight: number;
+  isKeyboardVisible: boolean;
+  visualViewportHeight?: number;
+  visualViewportOffsetTop?: number;
+}
+
+export interface IosKeyboardViewport {
+  viewportHeight: number;
+  keyboardOffset: number;
+}
+
+/**
+ * Resolve the iOS keyboard geometry without coupling layout to native WebView
+ * resizing. VisualViewport is authoritative once it shrinks; until then, the
+ * sanitized plugin height is the bounded fallback. Fixed surfaces and the app
+ * shell are anchored to the layout viewport, so the usable bottom edge is
+ * VisualViewport.offsetTop + VisualViewport.height.
+ */
+export const resolveIosKeyboardViewport = ({
+  baseHeight,
+  keyboardHeight,
+  isKeyboardVisible,
+  visualViewportHeight,
+  visualViewportOffsetTop = 0,
+}: IosKeyboardViewportInput): IosKeyboardViewport => {
+  const clampedBaseHeight = Math.max(0, baseHeight);
+  const isVisualViewportResized =
+    isKeyboardVisible &&
+    visualViewportHeight !== undefined &&
+    visualViewportHeight < clampedBaseHeight - VIEWPORT_RESIZE_EPSILON_PX;
+
+  const clampToLayoutViewport = (value: number): number =>
+    Math.min(clampedBaseHeight, Math.max(0, value));
+
+  let keyboardOffset = 0;
+  if (isKeyboardVisible) {
+    keyboardOffset = isVisualViewportResized
+      ? clampedBaseHeight -
+        clampToLayoutViewport(visualViewportHeight + visualViewportOffsetTop)
+      : clampToLayoutViewport(keyboardHeight);
+  }
+
+  const viewportHeight = isKeyboardVisible
+    ? clampedBaseHeight - keyboardOffset
+    : clampToLayoutViewport(visualViewportHeight ?? clampedBaseHeight);
+
+  return {
+    viewportHeight,
+    keyboardOffset,
+  };
+};

--- a/src/app/core/theme/sanitize-ios-keyboard-height.util.ts
+++ b/src/app/core/theme/sanitize-ios-keyboard-height.util.ts
@@ -1,20 +1,17 @@
 /**
- * Largest share of the pre-keyboard viewport height we accept as a real
+ * Largest share of the current layout viewport height we accept as a real
  * on-screen keyboard height.
  *
  * iOS reports a bogus, near-full-screen keyboard frame in `keyboardWillShow`
  * for some third-party input methods (e.g. Sogou on iOS 18 — issue #8778).
- * Written verbatim to `--keyboard-height`, that value flings the fixed
- * add-task bar (`bottom: calc(var(--keyboard-height) + …)`) to the top of the
- * screen. A real keyboard — even a tall third-party one with a candidate /
+ * Used as a layout offset, that value can fling fixed surfaces to the top of
+ * the screen. A real keyboard — even a tall third-party one with a candidate /
  * toolbar bar, in portrait or landscape — stays comfortably under this
  * fraction, so anything above it is the known bad frame.
  *
- * shortcut: a fixed fraction, not a measurement. A `visualViewport`-derived
- * obscured-area reading would be more precise, but is unreliable under
- * Capacitor's `resize: 'native'` (the whole web view resizes, so the visual
- * viewport shrinks in lock-step and reports ~0 obscured). If real keyboards
- * ever approach this ceiling, revisit with a measured value.
+ * This is only a short-lived fallback ceiling. Once VisualViewport reports the
+ * visible area, the iOS viewport resolver uses that physically bounded browser
+ * measurement without applying this heuristic.
  */
 export const MAX_IOS_KEYBOARD_HEIGHT_FRACTION = 0.6;
 
@@ -22,8 +19,8 @@ export const MAX_IOS_KEYBOARD_HEIGHT_FRACTION = 0.6;
  * Clamp the iOS keyboard height reported by the Capacitor Keyboard plugin to a
  * physically plausible range before it drives layout CSS variables.
  *
- * `referenceHeight` is the viewport height captured *before* the keyboard
- * appeared (the full usable height). The result is never negative and never
+ * `referenceHeight` is the current non-resized layout viewport height. The result
+ * is never negative and never
  * exceeds `referenceHeight * maxFraction`. A non-positive or unknown reference
  * height disables the ceiling (we only floor at 0): without a baseline we
  * cannot judge plausibility, and clamping against a bad baseline would be

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -39,6 +39,13 @@
   transition: bottom var(--transition-duration-m) ease-out;
 }
 
+// iOS runs the Capacitor keyboard in non-resizing mode. Its viewport service
+// offsets fixed content by the area below VisualViewport, with the sanitized
+// plugin height used only until the viewport exposes that geometry.
+:host-context(body.isIOS.isTouchOnly).global {
+  bottom: calc(var(--keyboard-overlay-offset) + var(--s2));
+}
+
 .add-task-container {
   width: 100%;
   position: relative;

--- a/src/app/op-log/testing/integration/file-based-sync/conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/conflict-resolution.integration.spec.ts
@@ -3,6 +3,23 @@ import { FILE_BASED_SYNC_CONSTANTS } from '../../../sync-providers/file-based/fi
 import { UploadRevToMatchMismatchAPIError } from '../../../core/errors/sync-errors';
 import { SyncOperation } from '../../../sync-providers/provider.interface';
 
+describe('FileBasedSyncTestHarness', () => {
+  const stateKey = FILE_BASED_SYNC_CONSTANTS.SYNC_VERSION_STORAGE_KEY_PREFIX + 'state';
+  let harness: FileBasedSyncTestHarness | undefined;
+
+  afterEach(() => {
+    harness?.reset();
+  });
+
+  it('clears persisted adapter state before creating a harness', () => {
+    localStorage.setItem(stateKey, JSON.stringify({ syncVersions: { stale: 42 } }));
+
+    harness = FileBasedSyncTestHarness.create({});
+
+    expect(localStorage.getItem(stateKey)).toBeNull();
+  });
+});
+
 describe('File-Based Sync Integration - Conflict Resolution', () => {
   let harness: FileBasedSyncTestHarness;
 

--- a/src/app/op-log/testing/integration/helpers/file-based-sync-test-harness.ts
+++ b/src/app/op-log/testing/integration/helpers/file-based-sync-test-harness.ts
@@ -2,6 +2,7 @@ import { runInInjectionContext, EnvironmentInjector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MockFileProvider } from './mock-file-provider.helper';
 import { FileBasedSyncAdapterService } from '../../../sync-providers/file-based/file-based-sync-adapter.service';
+import { FILE_BASED_SYNC_CONSTANTS } from '../../../sync-providers/file-based/file-based-sync.types';
 import {
   OperationSyncCapable,
   SyncOperation,
@@ -226,6 +227,8 @@ export class FileBasedSyncTestHarness {
    * ```
    */
   static create(config: HarnessConfig = {}): FileBasedSyncTestHarness {
+    FileBasedSyncTestHarness._clearLocalStorage();
+
     // Create mock instances that will be shared
     const mockArchiveDb = new MockArchiveDbAdapter();
     const mockStateSnapshot = new MockStateSnapshotService();
@@ -414,7 +417,7 @@ export class FileBasedSyncTestHarness {
     this._mockArchiveDb.reset();
     this._mockStateSnapshot.reset();
     // Clear localStorage keys used by FileBasedSyncAdapterService
-    this._clearLocalStorage();
+    FileBasedSyncTestHarness._clearLocalStorage();
   }
 
   /**
@@ -435,11 +438,11 @@ export class FileBasedSyncTestHarness {
   /**
    * Clears localStorage keys used by FileBasedSyncAdapterService.
    */
-  private _clearLocalStorage(): void {
+  private static _clearLocalStorage(): void {
     const keysToRemove: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key?.startsWith('FILE_SYNC_VERSION_')) {
+      if (key?.startsWith(FILE_BASED_SYNC_CONSTANTS.SYNC_VERSION_STORAGE_KEY_PREFIX)) {
         keysToRemove.push(key);
       }
     }


### PR DESCRIPTION
## Summary

- prevent Capacitor keyboard notifications from resizing the iOS WKWebView
- derive keyboard-aware layout from the current layout viewport and `VisualViewport` geometry
- retain the sanitized native keyboard height only as a short-lived fallback
- keep the global add-task bar aligned with the visible viewport bottom
- add regression coverage for the Capacitor configuration and iOS viewport calculations

## Root cause

Capacitor's native resize mode applies each iOS keyboard frame notification directly to the WKWebView. Keyboard transitions can emit several different frame heights—such as the reported 75 → 397 → 357 sequence—and even a stable system-keyboard height can leave the web layout and fixed UI using inconsistent geometry.

Using non-resizing mode keeps the layout viewport stable. The app now calculates the actually visible bottom edge from `VisualViewport.offsetTop + VisualViewport.height`, including viewport panning and rotation, and uses the bounded plugin height only until browser geometry is available.

## User impact

The add-task bar and other keyboard-aware fixed surfaces should remain immediately above the keyboard instead of jumping to the top of the screen. The change is isolated to iOS; Android behavior is unchanged.

Addresses the iOS behavior reported in #8778.

## Validation

- full `npm test` suite, including 12,576 default-timezone and 12,562 alternate-timezone Angular tests
- full production `npm run build`
- focused iOS keyboard/config regression specs
- `npm run checkFile` for every modified TypeScript and SCSS file
- TypeScript, SCSS, and custom lint-rule checks
