### PR TITLE
fix: allow drops into collapsed project sections

### DIFF
--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -228,6 +228,14 @@
                         [listModelId]="section.id"
                       ></task-list>
                     </collapsible>
+                    @if (!section.isExpanded) {
+                      <task-list
+                        class="collapsed-section-drop-target"
+                        [tasks]="[]"
+                        [listId]="'PARENT'"
+                        [listModelId]="section.id"
+                      ></task-list>
+                    }
                   </div>
                 }
               </div>


### PR DESCRIPTION
## Summary\n- keep an empty task drop target available while a project section is collapsed\n- reuse the existing section-aware task move handling\n\nFixes #8968\n\n## Testing\n- git diff --check passed\n- Repository checker and targeted tests could not run: locked dependency installation timed out on Windows before npm binaries were available.