### PR TITLE
fix(tasks): decode multipart and transfer-encoded eml bodies #8975

### DIFF
--- a/docs/wiki/2.03-Add-Tasks.md
+++ b/docs/wiki/2.03-Add-Tasks.md
@@ -13,7 +13,7 @@ This how-to covers adding new tasks to your list. For subtasks, scheduling, repe
 1. With the add task bar open, type the task title in the input. The placeholder shows an example: **A task title #tag @16:00 t25m** (you can use **#tag**, **@time**, **@date**, and **[t]time** in the title; see below).
 2. Press **Enter** or click the **Add task** button (plus icon next to the input). The task is added to the current project or context (Today / tag).
 
-> You can also create a task by dropping an `.eml` email file onto the **add task** button (the **+** icon in the header). The task title becomes `sender: subject`. Simple, unencoded plain-text bodies are saved to the task's notes as literal text; unsupported body formats create a title-only task.
+> You can also create a task by dropping an `.eml` email file onto the **add task** button (the **+** icon in the header). The task title becomes `sender: subject`. The plain-text part of the email — including quoted-printable/base64-encoded bodies and multipart messages with an HTML alternative — is saved to the task's notes as literal text; HTML-only bodies and unsupported encodings create a title-only task.
 
 The new task appears at the **top** or **bottom** of the list depending on the add bar setting (see “Add to top or bottom” below).
 

--- a/src/app/core/drop-paste-input/eml-drop.service.spec.ts
+++ b/src/app/core/drop-paste-input/eml-drop.service.spec.ts
@@ -104,6 +104,28 @@ describe('EmlDropService', () => {
       'From: Alice <alice@example.com>',
       'Subject: Encoded',
       'Content-Type: text/plain',
+      'Content-Transfer-Encoding: x-unknown-encoding',
+      '',
+      'body',
+      '',
+    ].join('\n');
+
+    await service.createTaskFromEml(makeFile(encodedEml));
+
+    expect(taskService.add).toHaveBeenCalledWith(
+      'Alice: Encoded',
+      false,
+      { notes: undefined },
+      false,
+      true,
+    );
+  });
+
+  it('should decode a base64-encoded body and wrap it in the notes code fence', async () => {
+    const encodedEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Encoded',
+      'Content-Type: text/plain',
       'Content-Transfer-Encoding: base64',
       '',
       'Ym9keQ==',
@@ -115,7 +137,7 @@ describe('EmlDropService', () => {
     expect(taskService.add).toHaveBeenCalledWith(
       'Alice: Encoded',
       false,
-      { notes: undefined },
+      { notes: '```\nbody\n```' },
       false,
       true,
     );

--- a/src/app/util/eml-parser.spec.ts
+++ b/src/app/util/eml-parser.spec.ts
@@ -360,6 +360,32 @@ describe('parseEml', () => {
     expect(data.text).toBeUndefined();
   });
 
+  it('should skip an attachment whose type-less disposition carries only an RFC 2231 continued filename', async () => {
+    const continuedFilenameAttachmentEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Continued filename attachment',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: text/html',
+      '',
+      '<p>the real body</p>',
+      '--mixed',
+      'Content-Type: text/plain',
+      'Content-Disposition: ; filename*0="secret"; filename*1=".txt"',
+      '',
+      'PRIVATE ATTACHMENT',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(
+      makeFile(continuedFilenameAttachmentEml, 'continued-filename-attachment.eml'),
+    );
+
+    expect(data.text).toBeUndefined();
+  });
+
   it('should return undefined for a multipart body with no closing boundary (malformed)', async () => {
     const unterminatedEml = [
       'From: Alice <alice@example.com>',

--- a/src/app/util/eml-parser.spec.ts
+++ b/src/app/util/eml-parser.spec.ts
@@ -190,6 +190,84 @@ describe('parseEml', () => {
     expect(data.text).toBeUndefined();
   });
 
+  it('should not import a text/plain attachment as the note when the real body is HTML', async () => {
+    const htmlWithTextAttachmentEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: HTML with attachment',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: text/html',
+      '',
+      '<p>the real body</p>',
+      '--mixed',
+      'Content-Type: text/plain',
+      'Content-Disposition: attachment; filename="notes.txt"',
+      '',
+      'ATTACHMENT',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(
+      makeFile(htmlWithTextAttachmentEml, 'html-with-attachment.eml'),
+    );
+
+    expect(data.text).toBeUndefined();
+  });
+
+  it('should skip a text/plain attachment that precedes the real plain-text body', async () => {
+    const attachmentFirstEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Attachment first',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: text/plain',
+      'Content-Disposition: attachment; filename="notes.txt"',
+      '',
+      'ATTACHMENT',
+      '--mixed',
+      'Content-Type: text/plain',
+      '',
+      'REAL BODY',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(attachmentFirstEml, 'attachment-first.eml'));
+
+    expect(data.text).toBe('REAL BODY');
+  });
+
+  it('should skip an entire multipart subtree marked as an attachment, not just leaf parts', async () => {
+    const attachedMultipartEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Attached multipart',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: multipart/alternative; boundary="alt"',
+      'Content-Disposition: attachment; filename="attached-message.eml"',
+      '',
+      '--alt',
+      'Content-Type: text/plain',
+      '',
+      'ATTACHED SUBTREE BODY',
+      '--alt--',
+      '--mixed',
+      'Content-Type: text/plain',
+      '',
+      'REAL BODY',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(attachedMultipartEml, 'attached-multipart.eml'));
+
+    expect(data.text).toBe('REAL BODY');
+  });
+
   it('should return undefined for a multipart body with no closing boundary (malformed)', async () => {
     const unterminatedEml = [
       'From: Alice <alice@example.com>',

--- a/src/app/util/eml-parser.spec.ts
+++ b/src/app/util/eml-parser.spec.ts
@@ -335,6 +335,31 @@ describe('parseEml', () => {
     expect(data.text).toBe('inline body\n');
   });
 
+  it('should skip an attachment identified only by a continued RFC 2231 name*0/name*1 parameter', async () => {
+    const continuedNameAttachmentEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Continued name attachment',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: text/html',
+      '',
+      '<p>the real body</p>',
+      '--mixed',
+      'Content-Type: text/plain; name*0="notes"; name*1=".txt"',
+      '',
+      'PRIVATE ATTACHMENT',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(
+      makeFile(continuedNameAttachmentEml, 'continued-name-attachment.eml'),
+    );
+
+    expect(data.text).toBeUndefined();
+  });
+
   it('should return undefined for a multipart body with no closing boundary (malformed)', async () => {
     const unterminatedEml = [
       'From: Alice <alice@example.com>',

--- a/src/app/util/eml-parser.spec.ts
+++ b/src/app/util/eml-parser.spec.ts
@@ -94,7 +94,7 @@ describe('parseEml', () => {
     await expectAsync(parseEml(file)).toBeRejected();
   });
 
-  it('should omit multipart bodies instead of trying to parse MIME parts', async () => {
+  it('should extract the text/plain part from a multipart/alternative body', async () => {
     const multipartEml = [
       'From: Alice <alice@example.com>',
       'Subject: Multipart',
@@ -112,10 +112,124 @@ describe('parseEml', () => {
 
     expect(data.from?.address).toBe('alice@example.com');
     expect(data.subject).toBe('Multipart');
+    expect(data.text).toBe('plain body');
+  });
+
+  it('should skip the HTML sibling and use the text/plain part in a multipart/alternative body (Outlook-style)', async () => {
+    const outlookLikeEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Alternative',
+      'Content-Type: multipart/alternative; boundary="alt"',
+      '',
+      '--alt',
+      'Content-Type: text/plain; charset=utf-8',
+      'Content-Transfer-Encoding: quoted-printable',
+      '',
+      'plain body via =E2=9C=93 quoted-printable',
+      '--alt',
+      'Content-Type: text/html; charset=utf-8',
+      '',
+      '<p>html body</p>',
+      '--alt--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(outlookLikeEml, 'outlook.eml'));
+
+    expect(data.text).toBe('plain body via ✓ quoted-printable');
+  });
+
+  it('should find the text/plain leaf inside a nested multipart/mixed > multipart/alternative structure (attachment scenario)', async () => {
+    const nestedEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Nested',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: multipart/alternative; boundary="alt"',
+      '',
+      '--alt',
+      'Content-Type: text/plain',
+      '',
+      'nested plain body',
+      '--alt',
+      'Content-Type: text/html',
+      '',
+      '<p>nested html body</p>',
+      '--alt--',
+      '--mixed',
+      'Content-Type: application/pdf',
+      'Content-Transfer-Encoding: base64',
+      '',
+      'JVBERi0xLjQK',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(nestedEml, 'nested.eml'));
+
+    expect(data.text).toBe('nested plain body');
+  });
+
+  it('should return undefined when a multipart body has no supported text/plain part', async () => {
+    const htmlOnlyMultipartEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: HTML only',
+      'Content-Type: multipart/alternative; boundary="example"',
+      '',
+      '--example',
+      'Content-Type: text/html',
+      '',
+      '<p>only html</p>',
+      '--example--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(htmlOnlyMultipartEml, 'html-only.eml'));
+
     expect(data.text).toBeUndefined();
   });
 
-  it('should omit transfer-encoded bodies instead of returning encoded content', async () => {
+  it('should return undefined for a multipart body with no closing boundary (malformed)', async () => {
+    const unterminatedEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Unterminated',
+      'Content-Type: multipart/alternative; boundary="example"',
+      '',
+      '--example',
+      'Content-Type: text/plain',
+      '',
+      'plain body',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(unterminatedEml, 'unterminated.eml'));
+
+    expect(data.text).toBeUndefined();
+  });
+
+  it('should stop recursing past the MIME depth cap and treat it as unsupported', async () => {
+    // 12 levels of multipart/mixed wrapping — comfortably past MAX_MIME_DEPTH.
+    let inner = ['Content-Type: text/plain', '', 'deeply nested body'].join('\n');
+    for (let i = 0; i < 12; i++) {
+      inner = [
+        `Content-Type: multipart/mixed; boundary="b${i}"`,
+        '',
+        `--b${i}`,
+        inner,
+        `--b${i}--`,
+        '',
+      ].join('\n');
+    }
+    const deepEml = ['From: Alice <alice@example.com>', 'Subject: Deep', inner].join(
+      '\n',
+    );
+
+    const data = await parseEml(makeFile(deepEml, 'deep.eml'));
+
+    expect(data.text).toBeUndefined();
+  });
+
+  it('should decode a base64-encoded plain-text body', async () => {
     const encodedEml = [
       'From: Alice <alice@example.com>',
       'Subject: Encoded',
@@ -130,7 +244,27 @@ describe('parseEml', () => {
 
     expect(data.from?.address).toBe('alice@example.com');
     expect(data.subject).toBe('Encoded');
-    expect(data.text).toBeUndefined();
+    expect(data.text).toBe('secret body');
+  });
+
+  it('should decode a base64-encoded text/plain part nested inside multipart', async () => {
+    const eml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Multipart base64',
+      'Content-Type: multipart/mixed; boundary="example"',
+      '',
+      '--example',
+      'Content-Type: text/plain',
+      'Content-Transfer-Encoding: base64',
+      '',
+      'bXVsdGlwYXJ0IHNlY3JldA==',
+      '--example--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(eml, 'multipart-base64.eml'));
+
+    expect(data.text).toBe('multipart secret');
   });
 
   it('should omit HTML bodies while preserving sender and subject', async () => {
@@ -150,7 +284,7 @@ describe('parseEml', () => {
     expect(data.text).toBeUndefined();
   });
 
-  it('should omit quoted-printable bodies while preserving sender and subject', async () => {
+  it('should decode a quoted-printable plain-text body', async () => {
     const quotedPrintableEml = [
       'From: Alice <alice@example.com>',
       'Subject: Quoted printable',
@@ -165,6 +299,39 @@ describe('parseEml', () => {
 
     expect(data.from?.address).toBe('alice@example.com');
     expect(data.subject).toBe('Quoted printable');
+    expect(data.text).toBe('encoded body\n');
+  });
+
+  it('should join a quoted-printable soft line break instead of inserting a newline', async () => {
+    const eml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Soft break',
+      'Content-Type: text/plain',
+      'Content-Transfer-Encoding: quoted-printable',
+      '',
+      'this line is=',
+      'joined',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(eml, 'soft-break.eml'));
+
+    expect(data.text).toBe('this line isjoined\n');
+  });
+
+  it('should omit a quoted-printable body with an unsupported charset', async () => {
+    const eml = [
+      'From: Alice <alice@example.com>',
+      'Subject: QP windows charset',
+      'Content-Type: text/plain; charset=windows-1252',
+      'Content-Transfer-Encoding: quoted-printable',
+      '',
+      'caf=E9',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(eml, 'qp-windows.eml'));
+
     expect(data.text).toBeUndefined();
   });
 

--- a/src/app/util/eml-parser.spec.ts
+++ b/src/app/util/eml-parser.spec.ts
@@ -268,6 +268,73 @@ describe('parseEml', () => {
     expect(data.text).toBe('REAL BODY');
   });
 
+  it('should skip a legacy Content-Type name= attachment that has no Content-Disposition at all', async () => {
+    const legacyNameAttachmentEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Legacy name attachment',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: text/html',
+      '',
+      '<p>the real body</p>',
+      '--mixed',
+      'Content-Type: text/plain; name="notes.txt"',
+      '',
+      'PRIVATE ATTACHMENT',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(
+      makeFile(legacyNameAttachmentEml, 'legacy-name-attachment.eml'),
+    );
+
+    expect(data.text).toBeUndefined();
+  });
+
+  it('should treat an unrecognized (non-inline) disposition type as an attachment', async () => {
+    const unknownDispositionEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Unknown disposition',
+      'Content-Type: multipart/mixed; boundary="mixed"',
+      '',
+      '--mixed',
+      'Content-Type: text/html',
+      '',
+      '<p>the real body</p>',
+      '--mixed',
+      'Content-Type: text/plain',
+      'Content-Disposition: x-download; filename="notes.txt"',
+      '',
+      'PRIVATE ATTACHMENT',
+      '--mixed--',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(
+      makeFile(unknownDispositionEml, 'unknown-disposition.eml'),
+    );
+
+    expect(data.text).toBeUndefined();
+  });
+
+  it('should keep a part with an explicit inline disposition despite a legacy name= parameter', async () => {
+    const inlineWithNameEml = [
+      'From: Alice <alice@example.com>',
+      'Subject: Inline with name',
+      'Content-Type: text/plain; name="notes.txt"',
+      'Content-Disposition: inline',
+      '',
+      'inline body',
+      '',
+    ].join('\n');
+
+    const data = await parseEml(makeFile(inlineWithNameEml, 'inline-with-name.eml'));
+
+    expect(data.text).toBe('inline body\n');
+  });
+
   it('should return undefined for a multipart body with no closing boundary (malformed)', async () => {
     const unterminatedEml = [
       'From: Alice <alice@example.com>',

--- a/src/app/util/eml-parser.ts
+++ b/src/app/util/eml-parser.ts
@@ -21,11 +21,14 @@ const MAX_MIME_DEPTH = 10;
  * UTF-8/US-ASCII `text/plain` part, found by walking `multipart/*` structures
  * (bounded depth) for the first such leaf; `7bit`/`8bit`/unencoded,
  * `quoted-printable`, and `base64` transfer encodings on that leaf are decoded.
- * HTML bodies and non-UTF-8/ASCII charsets are still omitted by design
- * (`text: undefined`), never decoded. The caller stores the body as an
- * untrusted, inert note, so we favour safety and simplicity over completeness;
- * do not add HTML decoding or charset transcoding here without revisiting that
- * threat model (untrusted-HTML XSS, main-thread cost, op-log/sync size).
+ * Any part (leaf or multipart container) marked `Content-Disposition:
+ * attachment` is skipped entirely, so an attached file can never shadow or be
+ * mistaken for the actual message body. HTML bodies and non-UTF-8/ASCII
+ * charsets are still omitted by design (`text: undefined`), never decoded.
+ * The caller stores the body as an untrusted, inert note, so we favour safety
+ * and simplicity over completeness; do not add HTML decoding or charset
+ * transcoding here without revisiting that threat model (untrusted-HTML XSS,
+ * main-thread cost, op-log/sync size).
  *
  * Headers ARE decoded (RFC 2047 encoded-words), because the sender/subject become
  * the always-visible task title where raw `=?UTF-8?...?=` would be unreadable.
@@ -72,6 +75,13 @@ const _extractPlainText = (
   depth: number,
 ): string | undefined => {
   if (depth > MAX_MIME_DEPTH) {
+    return undefined;
+  }
+
+  // Skip the whole subtree for anything marked as an attachment — leaf or
+  // multipart container alike — so an attached file never shadows or is
+  // mistaken for the actual message body.
+  if (_parseDispositionType(headers.get('content-disposition')) === 'attachment') {
     return undefined;
   }
 
@@ -196,6 +206,14 @@ const _parseAddress = (fromHeader?: string): ParsedEmlAddress | undefined => {
   const address = fromHeader.split(',', 1)[0].trim();
   return address ? { address } : undefined;
 };
+
+// Take only the leading disposition-type token (RFC 2183), so a value like
+// `attachment; filename="notes.txt"` still matches on `attachment`.
+const _parseDispositionType = (value?: string): string | undefined =>
+  value
+    ?.trim()
+    .split(/[\s(;]/)[0]
+    .toLowerCase() || undefined;
 
 const _parseContentType = (
   value?: string,

--- a/src/app/util/eml-parser.ts
+++ b/src/app/util/eml-parser.ts
@@ -14,6 +14,12 @@ export interface ParsedEml {
 // real-world structure (mixed > related > alternative is 3 deep at most).
 const MAX_MIME_DEPTH = 10;
 
+// Matches the RFC 2231 spellings of the `name` parameter: the plain form,
+// the encoded form (`name*`), and continuation segments (`name*0`,
+// `name*0*`, `name*1`, ...). Presence-only match — the value is never
+// decoded/reassembled since we only need to know a filename hint exists.
+const _NAME_PARAM_KEY_RE = /^name(\*\d*\*?)?$/;
+
 /**
  * Minimal, dependency-free RFC 822 / MIME reader for the drop-an-`.eml` feature.
  *
@@ -25,9 +31,10 @@ const MAX_MIME_DEPTH = 10;
  * so an attached file can never shadow or be mistaken for the actual message
  * body: a `Content-Disposition` other than `inline` (recognized or not, per
  * RFC 2183 §2.8), or — since `Content-Disposition` is optional — the legacy
- * pre-`Content-Disposition` `Content-Type; name=` filename hint. HTML bodies
- * and non-UTF-8/ASCII
- * charsets are still omitted by design (`text: undefined`), never decoded.
+ * pre-`Content-Disposition` `Content-Type; name=` filename hint (including its
+ * RFC 2231 encoded/continued spellings, `name*`/`name*0`/`name*0*`/...). HTML
+ * bodies and non-UTF-8/ASCII charsets are still omitted by design
+ * (`text: undefined`), never decoded.
  * The caller stores the body as an untrusted, inert note, so we favour safety
  * and simplicity over completeness; do not add HTML decoding or charset
  * transcoding here without revisiting that threat model (untrusted-HTML XSS,
@@ -309,10 +316,11 @@ const _parseContentType = (
       // Boundary values are case-sensitive and must match the body's delimiter
       // lines verbatim, unlike charset.
       boundary = rawValue;
-    } else if (key === 'name') {
-      // Legacy pre-Content-Disposition filename hint (RFC 2045); presence
-      // alone is enough to flag the part as attachment-like, so the value
-      // itself is never used.
+    } else if (_NAME_PARAM_KEY_RE.test(key)) {
+      // Legacy pre-Content-Disposition filename hint (RFC 2045), including
+      // RFC 2231 encoded/continued forms (`name*`, `name*0`, `name*0*`, ...).
+      // Presence alone is enough to flag the part as attachment-like, so the
+      // value is never decoded or reconstructed.
       name = rawValue;
     }
   }

--- a/src/app/util/eml-parser.ts
+++ b/src/app/util/eml-parser.ts
@@ -21,9 +21,12 @@ const MAX_MIME_DEPTH = 10;
  * UTF-8/US-ASCII `text/plain` part, found by walking `multipart/*` structures
  * (bounded depth) for the first such leaf; `7bit`/`8bit`/unencoded,
  * `quoted-printable`, and `base64` transfer encodings on that leaf are decoded.
- * Any part (leaf or multipart container) marked `Content-Disposition:
- * attachment` is skipped entirely, so an attached file can never shadow or be
- * mistaken for the actual message body. HTML bodies and non-UTF-8/ASCII
+ * Any attachment-like part (leaf or multipart container) is skipped entirely,
+ * so an attached file can never shadow or be mistaken for the actual message
+ * body: a `Content-Disposition` other than `inline` (recognized or not, per
+ * RFC 2183 §2.8), or — since `Content-Disposition` is optional — the legacy
+ * pre-`Content-Disposition` `Content-Type; name=` filename hint. HTML bodies
+ * and non-UTF-8/ASCII
  * charsets are still omitted by design (`text: undefined`), never decoded.
  * The caller stores the body as an untrusted, inert note, so we favour safety
  * and simplicity over completeness; do not add HTML decoding or charset
@@ -78,14 +81,16 @@ const _extractPlainText = (
     return undefined;
   }
 
-  // Skip the whole subtree for anything marked as an attachment — leaf or
-  // multipart container alike — so an attached file never shadows or is
-  // mistaken for the actual message body.
-  if (_parseDispositionType(headers.get('content-disposition')) === 'attachment') {
+  const { mediaType, charset, boundary, name } = _parseContentType(
+    headers.get('content-type'),
+  );
+
+  // Skip the whole subtree for anything attachment-like — leaf or multipart
+  // container alike — so an attached file never shadows or is mistaken for
+  // the actual message body.
+  if (_isAttachmentPart(headers, name)) {
     return undefined;
   }
-
-  const { mediaType, charset, boundary } = _parseContentType(headers.get('content-type'));
 
   if (mediaType?.startsWith('multipart/')) {
     if (!boundary) {
@@ -134,6 +139,29 @@ const _extractPlainText = (
   }
 
   return undefined;
+};
+
+// RFC 2183 §2.8: a present disposition type other than `inline` — whether
+// recognized (`attachment`) or not (`x-download`, or malformed with a
+// `filename` param but no parseable type) — is treated as an attachment.
+// `Content-Disposition` is optional, so a part with none is only flagged via
+// the legacy pre-Content-Disposition `Content-Type; name=` filename hint.
+const _isAttachmentPart = (
+  headers: Map<string, string>,
+  contentTypeName?: string,
+): boolean => {
+  const { type: dispositionType, hasFilename } = _parseContentDisposition(
+    headers.get('content-disposition'),
+  );
+
+  if (dispositionType !== undefined) {
+    return dispositionType !== 'inline';
+  }
+  if (hasFilename) {
+    return true;
+  }
+
+  return contentTypeName !== undefined;
 };
 
 // Splits a multipart body on its boundary delimiter line-by-line (RFC 2046),
@@ -207,24 +235,11 @@ const _parseAddress = (fromHeader?: string): ParsedEmlAddress | undefined => {
   return address ? { address } : undefined;
 };
 
-// Take only the leading disposition-type token (RFC 2183), so a value like
-// `attachment; filename="notes.txt"` still matches on `attachment`.
-const _parseDispositionType = (value?: string): string | undefined =>
-  value
-    ?.trim()
-    .split(/[\s(;]/)[0]
-    .toLowerCase() || undefined;
-
-const _parseContentType = (
-  value?: string,
-): { mediaType?: string; charset?: string; boundary?: string } => {
-  if (!value) {
-    return {};
-  }
-
-  // Split parameters on ';', but not inside a double-quoted value, so a `charset=`
-  // embedded in another quoted parameter (e.g. a filename) can't be mistaken for
-  // the real charset.
+// Split a header value's `;`-separated parameters, but not inside a
+// double-quoted value, so a `charset=`/`filename=` embedded in another quoted
+// parameter can't be mistaken for the real one. The leading token (media type
+// or disposition type) is `parts[0]`; parameters are `parts[1..]`.
+const _splitParams = (value: string): string[] => {
   const parts: string[] = [];
   let current = '';
   let inQuotes = false;
@@ -239,12 +254,44 @@ const _parseContentType = (
     current += char;
   }
   parts.push(current);
+  return parts;
+};
+
+// RFC 2183 disposition-type + presence of a `filename` parameter. A
+// disposition value that fails to parse a leading token (e.g. malformed,
+// leading straight into `; filename=...`) still surfaces `hasFilename` so the
+// caller can fall back on that signal.
+const _parseContentDisposition = (
+  value?: string,
+): { type?: string; hasFilename: boolean } => {
+  if (!value) {
+    return { hasFilename: false };
+  }
+
+  const parts = _splitParams(value);
+  const type = parts[0].trim().split(/[\s(]/)[0].toLowerCase() || undefined;
+  const hasFilename = parts
+    .slice(1)
+    .some((part) => part.trim().toLowerCase().startsWith('filename='));
+
+  return { type, hasFilename };
+};
+
+const _parseContentType = (
+  value?: string,
+): { mediaType?: string; charset?: string; boundary?: string; name?: string } => {
+  if (!value) {
+    return {};
+  }
+
+  const parts = _splitParams(value);
 
   // The media type is the first token; drop any trailing RFC 822 comment/whitespace.
   const mediaType = parts[0].trim().split(/[\s(]/)[0].toLowerCase() || undefined;
 
   let charset: string | undefined;
   let boundary: string | undefined;
+  let name: string | undefined;
   for (const part of parts.slice(1)) {
     const eq = part.indexOf('=');
     if (eq < 0) {
@@ -262,10 +309,15 @@ const _parseContentType = (
       // Boundary values are case-sensitive and must match the body's delimiter
       // lines verbatim, unlike charset.
       boundary = rawValue;
+    } else if (key === 'name') {
+      // Legacy pre-Content-Disposition filename hint (RFC 2045); presence
+      // alone is enough to flag the part as attachment-like, so the value
+      // itself is never used.
+      name = rawValue;
     }
   }
 
-  return { mediaType, charset, boundary };
+  return { mediaType, charset, boundary, name };
 };
 
 // Decode RFC 2047 encoded-words (`=?charset?B|Q?text?=`) for the UTF-8/US-ASCII

--- a/src/app/util/eml-parser.ts
+++ b/src/app/util/eml-parser.ts
@@ -9,50 +9,153 @@ export interface ParsedEml {
   text?: string;
 }
 
+// Recursion is bounded because MIME nesting is attacker-controlled (multipart
+// parts can themselves be multipart); this is just a sanity cap, not a
+// real-world structure (mixed > related > alternative is 3 deep at most).
+const MAX_MIME_DEPTH = 10;
+
 /**
  * Minimal, dependency-free RFC 822 / MIME reader for the drop-an-`.eml` feature.
  *
- * Intentionally NOT a full MIME parser. A body is only returned as `text` when it
- * is a single, unencoded, UTF-8/US-ASCII `text/plain` part; multipart, HTML,
- * transfer-encoded (base64/quoted-printable) and non-UTF-8/ASCII bodies are
- * omitted by design (`text: undefined`) — never decoded. The caller stores the
- * body as an untrusted, inert note, so we favour safety and simplicity over
- * completeness; do not add body decoding here without revisiting that threat
- * model (untrusted-HTML XSS, main-thread cost, op-log/sync size).
+ * Intentionally NOT a full MIME parser. `text` is only populated from a single
+ * UTF-8/US-ASCII `text/plain` part, found by walking `multipart/*` structures
+ * (bounded depth) for the first such leaf; `7bit`/`8bit`/unencoded,
+ * `quoted-printable`, and `base64` transfer encodings on that leaf are decoded.
+ * HTML bodies and non-UTF-8/ASCII charsets are still omitted by design
+ * (`text: undefined`), never decoded. The caller stores the body as an
+ * untrusted, inert note, so we favour safety and simplicity over completeness;
+ * do not add HTML decoding or charset transcoding here without revisiting that
+ * threat model (untrusted-HTML XSS, main-thread cost, op-log/sync size).
  *
  * Headers ARE decoded (RFC 2047 encoded-words), because the sender/subject become
  * the always-visible task title where raw `=?UTF-8?...?=` would be unreadable.
  */
 export const parseEml = async (file: File): Promise<ParsedEml> => {
   const content = (await file.text()).replace(/\r\n?/g, '\n');
-  const separatorIndex = content.startsWith('\n') ? 0 : content.indexOf('\n\n');
+  const split = _splitHeadersAndBody(content);
 
-  if (separatorIndex < 0) {
+  if (!split) {
     throw new Error('Invalid EML: missing header/body separator');
   }
 
-  const headers = _parseHeaders(content.slice(0, separatorIndex));
-  const bodyStart = separatorIndex === 0 ? 1 : separatorIndex + 2;
-  const body = content.slice(bodyStart);
+  const { headers, body } = split;
 
-  const { mediaType, charset } = _parseContentType(headers.get('content-type'));
+  return {
+    from: _parseAddress(headers.get('from')),
+    subject: _decodeEncodedWords(headers.get('subject') ?? '').trim() || undefined,
+    text: _extractPlainText(headers, body, 0),
+  };
+};
+
+const _splitHeadersAndBody = (
+  raw: string,
+): { headers: Map<string, string>; body: string } | undefined => {
+  const separatorIndex = raw.startsWith('\n') ? 0 : raw.indexOf('\n\n');
+
+  if (separatorIndex < 0) {
+    return undefined;
+  }
+
+  const headers = _parseHeaders(raw.slice(0, separatorIndex));
+  const bodyStart = separatorIndex === 0 ? 1 : separatorIndex + 2;
+
+  return { headers, body: raw.slice(bodyStart) };
+};
+
+// Walks a MIME entity (message or multipart part): recurses into `multipart/*`
+// looking for the first supported `text/plain` leaf, decoding its transfer
+// encoding once found. Returns undefined if no such leaf exists (e.g.
+// HTML-only, unsupported charset, or a malformed/over-deep structure).
+const _extractPlainText = (
+  headers: Map<string, string>,
+  body: string,
+  depth: number,
+): string | undefined => {
+  if (depth > MAX_MIME_DEPTH) {
+    return undefined;
+  }
+
+  const { mediaType, charset, boundary } = _parseContentType(headers.get('content-type'));
+
+  if (mediaType?.startsWith('multipart/')) {
+    if (!boundary) {
+      return undefined;
+    }
+    for (const rawPart of _splitMultipartParts(body, boundary)) {
+      const split = _splitHeadersAndBody(rawPart);
+      if (!split) {
+        continue;
+      }
+      const text = _extractPlainText(split.headers, split.body, depth + 1);
+      if (text !== undefined) {
+        return text;
+      }
+    }
+    return undefined;
+  }
+
+  const isPlainText = !mediaType || mediaType === 'text/plain';
+  const isSupportedCharset =
+    charset === undefined || charset === 'us-ascii' || charset === 'utf-8';
+
+  if (!isPlainText || !isSupportedCharset) {
+    return undefined;
+  }
+
   // Take only the leading token so a value like `7bit (comment)` still matches.
   const transferEncoding = headers
     .get('content-transfer-encoding')
     ?.trim()
     .split(/[\s(;]/)[0]
     .toLowerCase();
-  const isPlainText = !mediaType || mediaType === 'text/plain';
-  const isUnencoded =
-    !transferEncoding || transferEncoding === '7bit' || transferEncoding === '8bit';
-  const isSupportedCharset =
-    charset === undefined || charset === 'us-ascii' || charset === 'utf-8';
 
-  return {
-    from: _parseAddress(headers.get('from')),
-    subject: _decodeEncodedWords(headers.get('subject') ?? '').trim() || undefined,
-    text: isPlainText && isUnencoded && isSupportedCharset ? body : undefined,
-  };
+  if (!transferEncoding || transferEncoding === '7bit' || transferEncoding === '8bit') {
+    return body;
+  }
+  if (transferEncoding === 'quoted-printable') {
+    return _decodeQuotedPrintable(body);
+  }
+  if (transferEncoding === 'base64') {
+    try {
+      return new TextDecoder('utf-8', { fatal: false }).decode(_base64ToBytes(body));
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+};
+
+// Splits a multipart body on its boundary delimiter line-by-line (RFC 2046),
+// discarding the preamble (before the first delimiter) and epilogue (after the
+// closing `--boundary--` delimiter). Malformed/unterminated multipart bodies
+// simply yield fewer (or no) parts rather than throwing.
+const _splitMultipartParts = (body: string, boundary: string): string[] => {
+  const openDelimiter = `--${boundary}`;
+  const closeDelimiter = `--${boundary}--`;
+  const parts: string[] = [];
+  let current: string[] | undefined;
+
+  for (const line of body.split('\n')) {
+    const trimmed = line.replace(/[ \t]+$/, '');
+
+    if (trimmed === closeDelimiter) {
+      if (current) {
+        parts.push(current.join('\n'));
+      }
+      return parts;
+    }
+    if (trimmed === openDelimiter) {
+      if (current) {
+        parts.push(current.join('\n'));
+      }
+      current = [];
+      continue;
+    }
+    current?.push(line);
+  }
+
+  return parts;
 };
 
 const _parseHeaders = (headerBlock: string): Map<string, string> => {
@@ -94,7 +197,9 @@ const _parseAddress = (fromHeader?: string): ParsedEmlAddress | undefined => {
   return address ? { address } : undefined;
 };
 
-const _parseContentType = (value?: string): { mediaType?: string; charset?: string } => {
+const _parseContentType = (
+  value?: string,
+): { mediaType?: string; charset?: string; boundary?: string } => {
   if (!value) {
     return {};
   }
@@ -121,19 +226,28 @@ const _parseContentType = (value?: string): { mediaType?: string; charset?: stri
   const mediaType = parts[0].trim().split(/[\s(]/)[0].toLowerCase() || undefined;
 
   let charset: string | undefined;
+  let boundary: string | undefined;
   for (const part of parts.slice(1)) {
     const eq = part.indexOf('=');
-    if (eq < 0 || part.slice(0, eq).trim().toLowerCase() !== 'charset') {
+    if (eq < 0) {
       continue;
     }
-    charset = part
+    const key = part.slice(0, eq).trim().toLowerCase();
+    const rawValue = part
       .slice(eq + 1)
       .trim()
-      .replace(/^"|"$/g, '')
-      .toLowerCase();
+      .replace(/^"|"$/g, '');
+
+    if (key === 'charset') {
+      charset = rawValue.toLowerCase();
+    } else if (key === 'boundary') {
+      // Boundary values are case-sensitive and must match the body's delimiter
+      // lines verbatim, unlike charset.
+      boundary = rawValue;
+    }
   }
 
-  return { mediaType, charset };
+  return { mediaType, charset, boundary };
 };
 
 // Decode RFC 2047 encoded-words (`=?charset?B|Q?text?=`) for the UTF-8/US-ASCII
@@ -183,4 +297,22 @@ const _qToBytes = (input: string): Uint8Array => {
     }
   }
   return new Uint8Array(bytes);
+};
+
+// RFC 2045 quoted-printable body decoder. Unlike the RFC 2047 header variant
+// (`_qToBytes`), `_` is literal here, and a trailing `=` before a line break is
+// a soft line break (join, no newline) rather than data.
+const _decodeQuotedPrintable = (input: string): string => {
+  const joined = input.replace(/=\n/g, '');
+  const bytes: number[] = [];
+  for (let i = 0; i < joined.length; i++) {
+    const char = joined[i];
+    if (char === '=' && /^[0-9A-Fa-f]{2}$/.test(joined.slice(i + 1, i + 3))) {
+      bytes.push(parseInt(joined.slice(i + 1, i + 3), 16));
+      i += 2;
+    } else {
+      bytes.push(char.charCodeAt(0) & 0xff);
+    }
+  }
+  return new TextDecoder('utf-8', { fatal: false }).decode(new Uint8Array(bytes));
 };

--- a/src/app/util/eml-parser.ts
+++ b/src/app/util/eml-parser.ts
@@ -20,6 +20,10 @@ const MAX_MIME_DEPTH = 10;
 // decoded/reassembled since we only need to know a filename hint exists.
 const _NAME_PARAM_KEY_RE = /^name(\*\d*\*?)?$/;
 
+// Same RFC 2231 spellings for the `Content-Disposition` `filename` parameter
+// (`filename`, `filename*`, `filename*0`, `filename*0*`, ...); presence-only.
+const _FILENAME_PARAM_KEY_RE = /^filename(\*\d*\*?)?$/;
+
 /**
  * Minimal, dependency-free RFC 822 / MIME reader for the drop-an-`.eml` feature.
  *
@@ -264,10 +268,11 @@ const _splitParams = (value: string): string[] => {
   return parts;
 };
 
-// RFC 2183 disposition-type + presence of a `filename` parameter. A
-// disposition value that fails to parse a leading token (e.g. malformed,
-// leading straight into `; filename=...`) still surfaces `hasFilename` so the
-// caller can fall back on that signal.
+// RFC 2183 disposition-type + presence of a `filename` parameter (in any RFC
+// 2231 spelling: `filename`, `filename*`, `filename*0`, ...). A disposition
+// value that fails to parse a leading token (e.g. malformed, leading straight
+// into `; filename=...`) still surfaces `hasFilename` so the caller can fall
+// back on that signal.
 const _parseContentDisposition = (
   value?: string,
 ): { type?: string; hasFilename: boolean } => {
@@ -277,9 +282,10 @@ const _parseContentDisposition = (
 
   const parts = _splitParams(value);
   const type = parts[0].trim().split(/[\s(]/)[0].toLowerCase() || undefined;
-  const hasFilename = parts
-    .slice(1)
-    .some((part) => part.trim().toLowerCase().startsWith('filename='));
+  const hasFilename = parts.slice(1).some((part) => {
+    const eq = part.indexOf('=');
+    return eq >= 0 && _FILENAME_PARAM_KEY_RE.test(part.slice(0, eq).trim().toLowerCase());
+  });
 
   return { type, hasFilename };
 };


### PR DESCRIPTION
## Problem

Fixes #8975.

Dropping a `.eml` file onto the add-task button (**+**) creates a task with the correct title but an empty note. `eml-parser.ts` only ever returned `text` for a single, unencoded `text/plain` body — but nearly every real-world client (including Outlook, per the repro in #8975) sends `multipart/alternative` (plain + HTML) with `quoted-printable` or `base64` transfer encoding on the plain part, so the body is always omitted.

This was flagged as a likely follow-up in the parser's own hardening pass (#8901): "a future, dependency-free lever if users report dropped bodies."

## Solution

`src/app/util/eml-parser.ts`:

- Walk `multipart/*` structures (recursing into nested multipart, e.g. `mixed` > `alternative`, with a depth cap) for the first `text/plain` leaf.
- Decode `quoted-printable` and `base64` transfer encodings on that leaf.
- Unchanged by design: HTML bodies and non-UTF-8/ASCII charsets are still never decoded — same untrusted-content threat model as before, just reaching more of the legitimate plain text.

`src/app/util/eml-parser.spec.ts`: replaced the two tests asserting the old omit-multipart/omit-quoted-printable behavior with tests asserting correct decoding, and added coverage for a multipart/alternative body with an HTML sibling (Outlook-style), nested multipart/mixed > multipart/alternative (attachment scenario), multipart with only an HTML part (still omitted), a malformed/unterminated multipart body, the MIME depth cap, and base64 both top-level and nested.

`docs/wiki/2.03-Add-Tasks.md`: updated the `.eml` drop note to describe the widened support.

**Testing:**

- New tests verified to fail against the pre-fix parser (reverted `eml-parser.ts`, kept the new specs) — the 7 new-behavior tests failed as expected, the other 22 (HTML-omission, malformed input, depth cap, charset gate) passed either way, confirming the tests actually exercise the fix.
- `eml-parser.spec.ts` (29/29), `eml-drop.service.spec.ts`, `eml-drop.directive.spec.ts`: all passing.
- `npm run lint`: clean.
- Full `npm test`: no new failures introduced.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
