### PR TITLE
fix(sync): file-based snapshot crash/corruption hardening (follow-up to #8960)

### DIFF
--- a/docs/sync-and-op-log/README.md
+++ b/docs/sync-and-op-log/README.md
@@ -19,7 +19,8 @@ vector clocks detect concurrent edits.
           │
           └──► Sync Providers
                ├── SuperSync   (operation-based, real-time)
-               └── WebDAV / Dropbox / LocalFile  (file-based, single sync-data.json)
+               └── WebDAV / Dropbox / OneDrive / LocalFile
+                   (file-based: v2 single file or opt-in v3 split files)
 ```
 
 ## Start here

--- a/docs/sync-and-op-log/diagrams/04-file-based-sync.md
+++ b/docs/sync-and-op-log/diagrams/04-file-based-sync.md
@@ -126,37 +126,72 @@ File snapshot bootstrap does not create a `SYNC_IMPORT`; it retains ordinary
 causality. Explicit Use Local/Use Remote and backup-import flows still use their
 full-state operation semantics.
 
+The downloaded state cache, vector clock, archives, and operations already
+represented by the snapshot commit in one IndexedDB transaction. A failed write
+therefore leaves the previous baseline intact. Buffered local intents are made
+durable against whichever complete baseline committed before their overwritten
+reducers are replayed; archive effects are then restored in sequence, including
+any additional local intents that arrive during restoration.
+
 ## Split Compaction and Recovery
 
-For v3 compaction, `sync-state.json` is backed up and conditionally written
-before `sync-ops.json` is changed to reference it. If the process stops between
-the two writes, readers keep using the previous ops commit point and recover the
-matching previous state from `sync-state.json.bak`.
+V3 compaction uses the same durable snapshot transaction as an authoritative
+snapshot replacement. The pending marker is written before either primary and
+binds the observed ops revision plus the exact encoded state/ops pair. The
+still-committed state is then backed up, the new state is conditionally written,
+the pending ops candidate is backed up, and `sync-ops.json` is CAS-written as the
+commit point. Only after the fresh state backup succeeds is the marker completed.
+The compacted ops payload omits the optional `snapshotRef.rev`: readers bind the
+state by `syncVersion`/vector clock, while the transaction marker binds its exact
+digest and published revision without a state-revision/encoded-ops cycle.
+
+If the process stops before the ops CAS, recovery owns the pending pair and
+finishes it while the original ops revision is still current. If the ops primary
+advanced to the marker's exact payload, recovery completes the marker first and
+refreshes backups best-effort. A different advanced payload proves a concurrent
+commit, so recovery aborts the marker rather than promoting stale compaction
+state. A second compactor encountering the pending marker recovers that owner and
+retries from the resulting commit point; it never publishes a competing state.
 
 A structurally corrupt primary state may be healed from the backup only when the
 backup matches `snapshotRef`. Healing conditionally matches the corrupt
 primary's own revision; a newer valid but unreferenced state is not overwritten.
-When NO snapshot matches the committed `snapshotRef` any more (state file
-deleted or replaced without commit), the next compaction self-heals by writing a
-fresh full snapshot — the ops-file CAS remains the concurrency gate. Rolling
+When NO snapshot matches the committed `snapshotRef` any more (for example, the
+state file and its backup were deleted), the next compaction self-heals by
+writing a fresh full snapshot — the ops-file CAS remains the concurrency gate.
+An unreferenced primary beside a valid committed backup is not overwritten unless
+an aborted marker's digest proves that candidate was abandoned; an unowned
+candidate may still belong to an in-flight older client and therefore fails
+closed. Rolling
 backup writes are non-fatal by contract: a provider that cannot write a `.bak`
-must still be able to sync.
+must still be able to sync. The state copy referenced by the still-committed ops
+file is the exception: that backup is part of the split commit protocol, so its
+failure aborts the state replacement.
 
-Authoritative snapshot replacement is separately crash-serialized. A durable
-pending transaction records the primary revision observed at begin time
+Split compaction and authoritative snapshot replacement are crash-serialized by
+a durable pending transaction. It records the primary revision observed at begin time
 (`basePrimaryRev`) and the exact encoded snapshot payloads (both state and ops
 in v3), then the adapter publishes the bound files before conditionally marking
-that same transaction complete. Startup/download completes a pending transaction
-before ordinary sync — but ONLY while the primary still has `basePrimaryRev`;
-if the primary advanced after the crash (e.g. a marker-unaware client committed
-new data), recovery durably marks the transaction `aborted` instead of promoting
-the stale payload. A torn/unreadable marker is likewise treated as unusable (not
-as fatal corruption) and conditionally replaced by the next snapshot upload.
+that same transaction complete. Startup/download checks a pending transaction
+before the unchanged-revision fast path. Recovery promotes it while the primary
+still has `basePrimaryRev`; if the revision advanced, the exact encoded payload
+at the new revision proves that this transaction already committed and lets the
+marker complete. Any different payload is a concurrent commit, so recovery
+durably marks the transaction `aborted` instead. A torn/unreadable marker is
+likewise treated as unusable (not as fatal corruption) and conditionally replaced
+by the next snapshot upload.
 Ordinary backup rotation verifies that the observed marker revision is
 unchanged. The completed marker keeps compact SHA-256 bindings plus the
 published revisions, allowing recovery to reject a stale backup written by a
-marker-unaware client. Replacement intent is never guessed from vector-clock
-order.
+marker-unaware client. Aborted markers bind the rejected state and ops payloads;
+their deduplicated rejection sets are inherited by every replacement and its
+completed or aborted marker, so an older rejected backup cannot re-enter after a
+later transaction. The sets intentionally have no fixed cap: they grow only once
+per distinct abandoned transaction, and dropping an old digest would make that
+payload recoverable again if cloud history or a marker-unaware client restored
+the stale `.bak`. Replacement intent is never guessed from vector-clock order.
+Encryption/authentication failures leave pending markers untouched because the
+payload may be valid with the correct key.
 
 ```mermaid
 sequenceDiagram
@@ -164,14 +199,18 @@ sequenceDiagram
     participant B as Compactor B
     participant R as Remote storage
 
-    A->>R: read state rev S1
-    B->>R: read state rev S1
-    A->>R: backup S1
-    A->>R: write new state if S1
-    R-->>A: state rev S2
-    A->>R: write ops if O1, snapshotRef=S2
-    B->>R: write new state if S1
-    R-->>B: mismatch; re-download/retry
+    A->>R: read ops O1 and marker M1
+    B->>R: read ops O1 and marker M1
+    A->>R: write pending A if M1
+    R-->>A: marker M2
+    B->>R: write pending B if M1
+    R-->>B: mismatch; recover A/retry
+    A->>R: preserve state referenced by O1
+    A->>R: write state S2 conditionally
+    A->>R: write pending ops recovery backup
+    A->>R: write ops O2 if O1
+    A->>R: refresh state backup with S2
+    A->>R: complete marker if M2
 ```
 
 ## One-Way v2 to v3 Migration
@@ -184,7 +223,7 @@ Migration uses a crash-resumable pending marker:
    a v3 split tombstone;
 4. conditionally protect the recovery backup and finalize the ops marker.
 
-The pending candidate is stored with a sentinel `version`
+The pending candidate and its required recovery backup are stored with a sentinel `version`
 (`SPLIT_MIGRATION_PENDING_OPS_VERSION`, not 3) so already-shipped split clients
 — which know neither the `migration` field nor that `sync-state.json` does not
 exist yet — reject it with a transient error instead of adopting truncated

--- a/docs/sync-and-op-log/diagrams/04-file-based-sync.md
+++ b/docs/sync-and-op-log/diagrams/04-file-based-sync.md
@@ -136,16 +136,27 @@ matching previous state from `sync-state.json.bak`.
 A structurally corrupt primary state may be healed from the backup only when the
 backup matches `snapshotRef`. Healing conditionally matches the corrupt
 primary's own revision; a newer valid but unreferenced state is not overwritten.
+When NO snapshot matches the committed `snapshotRef` any more (state file
+deleted or replaced without commit), the next compaction self-heals by writing a
+fresh full snapshot — the ops-file CAS remains the concurrency gate. Rolling
+backup writes are non-fatal by contract: a provider that cannot write a `.bak`
+must still be able to sync.
 
 Authoritative snapshot replacement is separately crash-serialized. A durable
-pending transaction contains the exact encoded snapshot payloads (both state and
-ops in v3), then the adapter publishes the bound files before conditionally
-marking that same transaction complete. Startup/download completes a pending
-transaction before ordinary sync, and ordinary backup rotation verifies that the
-observed marker revision is unchanged. The completed marker keeps compact
-SHA-256 bindings plus the published revisions, allowing recovery to reject a
-stale backup written by a marker-unaware client. Replacement intent is never
-guessed from vector-clock order.
+pending transaction records the primary revision observed at begin time
+(`basePrimaryRev`) and the exact encoded snapshot payloads (both state and ops
+in v3), then the adapter publishes the bound files before conditionally marking
+that same transaction complete. Startup/download completes a pending transaction
+before ordinary sync — but ONLY while the primary still has `basePrimaryRev`;
+if the primary advanced after the crash (e.g. a marker-unaware client committed
+new data), recovery durably marks the transaction `aborted` instead of promoting
+the stale payload. A torn/unreadable marker is likewise treated as unusable (not
+as fatal corruption) and conditionally replaced by the next snapshot upload.
+Ordinary backup rotation verifies that the observed marker revision is
+unchanged. The completed marker keeps compact SHA-256 bindings plus the
+published revisions, allowing recovery to reject a stale backup written by a
+marker-unaware client. Replacement intent is never guessed from vector-clock
+order.
 
 ```mermaid
 sequenceDiagram
@@ -172,6 +183,13 @@ Migration uses a crash-resumable pending marker:
 3. neutralize `sync-data.json.bak` and conditionally replace the v2 primary with
    a v3 split tombstone;
 4. conditionally protect the recovery backup and finalize the ops marker.
+
+The pending candidate is stored with a sentinel `version`
+(`SPLIT_MIGRATION_PENDING_OPS_VERSION`, not 3) so already-shipped split clients
+— which know neither the `migration` field nor that `sync-state.json` does not
+exist yet — reject it with a transient error instead of adopting truncated
+state or implicitly finalizing a half-done migration. Readers normalize the
+version back to 3 in memory; the finalized ops file is written as version 3.
 
 The required ops backup is revision- and causality-owned. A stale migrator must
 not overwrite a newer or concurrent backup before losing the primary CAS.

--- a/docs/sync-and-op-log/diagrams/04-file-based-sync.md
+++ b/docs/sync-and-op-log/diagrams/04-file-based-sync.md
@@ -1,511 +1,180 @@
 # File-Based Sync Architecture
 
-**Last Updated:** January 2026
+**Last Updated:** July 2026
+
 **Status:** Implemented
 
-This document contains diagrams explaining the unified operation-log sync architecture for file-based providers (WebDAV, Dropbox, LocalFile).
+This reference describes file-based operation sync for Dropbox, OneDrive,
+WebDAV/Nextcloud, and Local File. For the end-to-end decision tree, see
+[file-based-sync-flowchart.md](../file-based-sync-flowchart.md).
 
-## Overview
+## Remote Layouts
 
-File-based sync uses a single `sync-data.json` file that contains:
-
-- Full application state snapshot
-- Recent operations buffer (last 200 ops)
-- Vector clock for conflict detection
-- Archive data for late-joining clients
-
-```mermaid
-flowchart TB
-    subgraph Remote["Remote Storage (WebDAV/Dropbox/LocalFile)"]
-        subgraph Folder["/superProductivity/"]
-            SyncFile["sync-data.json<br/>━━━━━━━━━━━━━━━━━━━<br/>Encrypted + Compressed"]
-        end
-    end
-
-    subgraph Contents["sync-data.json Contents"]
-        direction TB
-        Meta["📋 Metadata<br/>• version: 2<br/>• syncVersion: N (locking)<br/>• schemaVersion<br/>• lastModified<br/>• clientId<br/>• checksum"]
-
-        VClock["🕐 Vector Clock<br/>• {clientA: 42, clientB: 17}<br/>• Tracks causality"]
-
-        State["📦 State Snapshot<br/>━━━━━━━━━━━━━━━━━━━<br/>• tasks: TaskState<br/>• projects: ProjectState<br/>• tags: TagState<br/>• notes: NoteState<br/>• globalConfig<br/>• issueProviders<br/>• planner<br/>• simpleCounters<br/>• taskRepeatCfg"]
-
-        Archive["📁 Archive Data<br/>━━━━━━━━━━━━━━━━━━━<br/>• archiveYoung: ArchiveModel<br/>• archiveOld: ArchiveModel<br/>━━━━━━━━━━━━━━━━━━━<br/>Ensures late-joiners get<br/>full archive history"]
-
-        Ops["📝 Recent Operations (last 200)<br/>━━━━━━━━━━━━━━━━━━━<br/>• id, clientId, actionType<br/>• opType, entityType, entityId<br/>• payload, vectorClock<br/>• timestamp<br/>━━━━━━━━━━━━━━━━━━━<br/>Used for conflict detection"]
-    end
-
-    SyncFile --> Contents
-
-    style SyncFile fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    style State fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
-    style Archive fill:#fce4ec,stroke:#c2185b,stroke-width:2px
-    style Ops fill:#e1f5fe,stroke:#01579b,stroke-width:2px
-```
-
-### Why Single File Instead of Separate Snapshot + Ops Files?
-
-| Single File (chosen)        | Two Files (considered)      |
-| --------------------------- | --------------------------- |
-| Atomic: all or nothing      | Partial upload risk         |
-| One version to track        | Version coordination        |
-| Simple conflict resolution  | Two places to handle        |
-| Easy recovery               | Inconsistent state possible |
-| Upload full state each time | Often just ops              |
-
-The bandwidth cost is acceptable: state compresses well (~90%), and sync is infrequent.
-
-## Architecture Overview
-
-Shows how `FileBasedSyncAdapter` integrates into the existing op-log system, implementing `OperationSyncCapable` using file operations.
+File-based sync supports two layouts. The default remains the version 2 single
+file. Version 3, exposed as **Surgical sync**, is opt-in and is a one-way
+migration for a sync folder.
 
 ```mermaid
-flowchart TB
-    subgraph Client["Client Application"]
-        NgRx["NgRx Store<br/>(Runtime State)"]
-        OpLogEffects["OperationLogEffects"]
-        OpLogStore["SUP_OPS IndexedDB<br/>(ops + state_cache)"]
-
-        subgraph SyncServices["Sync Services"]
-            SyncService["OperationLogSyncService"]
-            ConflictRes["ConflictResolutionService"]
-            VectorClock["VectorClockService"]
-        end
-
-        subgraph ProviderLayer["Provider Abstraction"]
-            FileAdapter["FileBasedSyncAdapter<br/>(implements OperationSyncCapable)"]
-            SuperSync["SuperSyncProvider<br/>(existing API-based)"]
-
-            subgraph FileProviders["File Providers"]
-                WebDAV["WebDAV"]
-                Dropbox["Dropbox"]
-                LocalFile["LocalFile"]
-            end
-        end
+flowchart LR
+    subgraph V2["Default v2"]
+        DATA["sync-data.json<br/>snapshot + archives<br/>vector clock + recent ops"]
+        DATA_BAK["sync-data.json.bak"]
     end
 
-    subgraph RemoteStorage["Remote Storage"]
-        SyncFile["sync-data.json<br/>━━━━━━━━━━━━━━━<br/>• syncVersion<br/>• state snapshot<br/>• recentOps (200)<br/>• vectorClock"]
+    subgraph V3["Opt-in v3: Surgical sync"]
+        OPS["sync-ops.json<br/>small commit point<br/>vector clock + recent ops"]
+        STATE["sync-state.json<br/>snapshot + archives"]
+        REF["snapshotRef<br/>syncVersion + vector clock"]
+        OPS_BAK["sync-ops.json.bak"]
+        STATE_BAK["sync-state.json.bak"]
+        TOMB["sync-data.json<br/>v3 split tombstone"]
+
+        OPS --> REF --> STATE
     end
 
-    NgRx --> OpLogEffects
-    OpLogEffects --> OpLogStore
-    OpLogStore --> SyncService
-    SyncService --> ConflictRes
-    SyncService --> VectorClock
-
-    SyncService --> FileAdapter
-    SyncService --> SuperSync
-
-    FileAdapter --> WebDAV
-    FileAdapter --> Dropbox
-    FileAdapter --> LocalFile
-
-    WebDAV --> SyncFile
-    Dropbox --> SyncFile
-    LocalFile --> SyncFile
-
-    style FileAdapter fill:#e1f5fe,stroke:#01579b,stroke-width:2px
-    style SyncFile fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    style OpLogStore fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    DATA -. migration .-> OPS
+    DATA -. migration .-> STATE
+    DATA -. replaced by .-> TOMB
+    DATA --- DATA_BAK
+    OPS --- OPS_BAK
+    STATE --- STATE_BAK
 ```
 
-## TypeScript Types
+| Property | Default v2 | Opt-in v3 |
+| --- | --- | --- |
+| Hot file | `sync-data.json` | `sync-ops.json` |
+| Snapshot | Embedded in every hot-file upload | `sync-state.json`, rewritten for compaction or authoritative replacement |
+| Recent-op cap | 2,000 | Grows to 2,000, then compacts to 1,000 |
+| Commit point | `sync-data.json` revision | `sync-ops.json` revision |
+| Compatibility | Default | Every client for the folder must enable Surgical sync |
 
-```mermaid
-classDiagram
-    class FileBasedSyncData {
-        +number version = 2
-        +number syncVersion
-        +number schemaVersion
-        +VectorClock vectorClock
-        +number lastModified
-        +string clientId
-        +AppDataComplete state
-        +ArchiveModel archiveYoung
-        +ArchiveModel archiveOld
-        +CompactOperation[] recentOps
-        +string checksum
-    }
+The transport envelope types and permanent file names live in
+`packages/sync-providers/src/file-based-sync-data.ts`.
 
-    class AppDataComplete {
-        +TaskState task
-        +ProjectState project
-        +TagState tag
-        +GlobalConfigState globalConfig
-        +NoteState note
-        +IssueProviderState issueProvider
-        +PlannerState planner
-        +SimpleCounterState simpleCounter
-        +TaskRepeatCfgState taskRepeatCfg
-    }
-
-    class ArchiveModel {
-        +TaskArchive task
-        +TimeTrackingState timeTracking
-        +number lastTimeTrackingFlush
-    }
-
-    class CompactOperation {
-        +string id
-        +string clientId
-        +string actionType
-        +OpType opType
-        +EntityType entityType
-        +string entityId
-        +unknown payload
-        +VectorClock vectorClock
-        +number timestamp
-    }
-
-    class VectorClock {
-        +Record~string, number~ clocks
-    }
-
-    FileBasedSyncData --> AppDataComplete : state
-    FileBasedSyncData --> ArchiveModel : archiveYoung?
-    FileBasedSyncData --> ArchiveModel : archiveOld?
-    FileBasedSyncData --> CompactOperation : recentOps[0..200]
-    FileBasedSyncData --> VectorClock : vectorClock
-    CompactOperation --> VectorClock : vectorClock
-```
-
-## Sync Flow (Content-Based Optimistic Locking with Piggybacking)
+## Ordinary Sync
 
 ```mermaid
 sequenceDiagram
-    participant Client as Client App
-    participant Adapter as FileBasedSyncAdapter
-    participant Provider as File Provider
-    participant Remote as sync-data.json
+    participant App as OperationLogSyncService
+    participant Adapter as FileBasedSyncAdapterService
+    participant Remote as File provider
 
-    Note over Client,Remote: ═══ DOWNLOAD FLOW ═══
-
-    Client->>Adapter: downloadOps(sinceSeq, clientId)
-    Adapter->>Provider: downloadFile("sync-data.json")
-    Provider->>Remote: GET
-    Remote-->>Provider: {data, rev}
-    Provider-->>Adapter: SyncData (syncVersion=N)
-
-    Adapter->>Adapter: Update _expectedSyncVersion = N
-    Adapter->>Adapter: Filter ops by sinceSeq
-    Adapter-->>Client: OpDownloadResponse
-
-    Client->>Client: Apply remote ops to NgRx
-    Client->>Client: setLastServerSeq(latestSeq)
-
-    Note over Client,Remote: ═══ UPLOAD FLOW (with Piggybacking) ═══
-
-    Client->>Adapter: uploadOps(ops, clientId, lastKnownSeq)
-    Adapter->>Provider: downloadFile("sync-data.json")
-    Provider->>Remote: GET
-    Remote-->>Provider: {data, rev}
-    Provider-->>Adapter: Current syncVersion=M
-
-    alt syncVersion matches expected (M=N)
-        Note over Adapter: No other client synced
-    else syncVersion changed (M>N)
-        Note over Adapter: Another client synced!<br/>Will piggyback their ops
-    end
-
-    Adapter->>Adapter: Merge local ops into recentOps
-    Adapter->>Adapter: Update vectorClock
-    Adapter->>Adapter: Trim recentOps to 200
-    Adapter->>Adapter: Set syncVersion = M+1
-    Adapter->>Adapter: Find piggybacked ops<br/>(ops from other clients we haven't seen)
-
-    Adapter->>Provider: uploadFile("sync-data.json", newData)
-    Provider->>Remote: PUT
-    Remote-->>Provider: Success
-
-    Adapter-->>Client: Success + piggybacked ops (newOps)
-
-    alt Has piggybacked ops
-        Client->>Client: Process piggybacked ops
-        Client->>Client: setLastServerSeq(latestSeq)
+    App->>Adapter: downloadOps(sinceSeq)
+    Adapter->>Remote: read active commit file
+    Remote-->>Adapter: payload + revision
+    Adapter-->>App: unseen ops, or snapshot on seq 0/gap
+    App->>App: validate and apply remote work
+    App->>Adapter: uploadOps(local ops)
+    Adapter->>Adapter: merge and increment syncVersion
+    Adapter->>Remote: conditional upload(revision)
+    alt revision still current
+        Remote-->>Adapter: new revision
+        Adapter-->>App: success
+    else another writer won
+        Remote-->>Adapter: revision mismatch
+        Adapter->>Remote: re-download
+        Adapter->>Adapter: merge and retry with backoff
     end
 ```
 
-### Key Insight: Piggybacking
+There is no file-provider “piggybacking” response. When a conditional write
+loses, the adapter discovers the winner's operations by re-downloading the
+active commit file.
 
-Instead of throwing an error on version mismatch, the adapter:
+## Conditional Write Contract
 
-1. Merges local ops with whatever is in the file
-2. Returns ops from other clients as `newOps` (piggybacked)
-3. The upload service processes these before updating `lastServerSeq`
+Every `FileSyncProvider` implements the same `uploadFile` contract:
 
-This ensures no ops are missed, even when clients sync concurrently.
+| Call | Required behavior |
+| --- | --- |
+| `revToMatch: "revision"` | Replace only that exact revision. |
+| `revToMatch: null` | Create only if the file is absent. |
+| `isForceOverwrite: true` | Intentionally replace without a precondition. |
 
-## Conflict Resolution (Two Clients Syncing Simultaneously)
+Dropbox maps this to atomic update/add modes. OneDrive uses `If-Match` or
+`conflictBehavior=fail`. WebDAV uses `If-Match` for strong ETags and
+`If-None-Match: *` for creation. Weak/missing WebDAV ETags fall back to a
+GET-and-content-hash check, which cannot close the GET-to-PUT race. Local File
+has the same single-writer limitation.
 
-```mermaid
-sequenceDiagram
-    participant A as Client A
-    participant B as Client B
-    participant File as sync-data.json<br/>(syncVersion: 5)
-
-    Note over A,File: Initial: syncVersion=5, both clients synced
-
-    rect rgb(232, 245, 233)
-        Note over A,B: Both make offline changes
-        A->>A: Create Task X
-        A->>A: expectedSyncVersion = 5
-        B->>B: Update Task Y
-        B->>B: expectedSyncVersion = 5
-    end
-
-    Note over A,File: Race condition begins
-
-    A->>File: Upload starts (downloads file, sees v=5)
-    B->>File: Upload starts (downloads file, sees v=5)
-
-    A->>A: Merge ops [TaskX], set syncVersion=6
-    A->>File: Upload sync-data.json (v=6)
-    Note over A,File: A wins the race ✓
-    File-->>A: Success
-    A->>A: expectedSyncVersion = 6
-
-    B->>B: Merge ops [TaskY]
-    Note over B: Downloads file again for upload...
-    B->>File: Download (sees syncVersion=6!)
-    Note over B,File: Version changed!<br/>Expected 5, found 6
-
-    rect rgb(225, 245, 254)
-        Note over B: Piggybacking (not retry!)
-        B->>B: Find piggybacked ops from file<br/>(A's TaskX op, seq > lastProcessedSeq)
-        B->>B: Merge [TaskX, TaskY] into recentOps
-        B->>B: Set syncVersion = 7
-        B->>File: Upload sync-data.json (v=7)
-        File-->>B: Success ✓
-
-        B->>B: Return piggybacked=[TaskX]
-        B->>B: Process TaskX op → apply to NgRx
-        B->>B: setLastServerSeq(latestSeq)
-    end
-
-    Note over A,File: A syncs B's TaskY on next sync
-    A->>File: Download (sinceSeq=6)
-    File-->>A: ops=[TaskY]
-    A->>A: Apply TaskY → both clients have both tasks
-```
-
-### How Piggybacking Resolves Conflicts
-
-| Step                         | What Happens                                                |
-| ---------------------------- | ----------------------------------------------------------- |
-| 1. Version mismatch detected | B expected v=5, found v=6                                   |
-| 2. No retry needed           | B proceeds with merge anyway                                |
-| 3. Find piggybacked ops      | Ops in file with seq > lastProcessedSeq, from other clients |
-| 4. Merge and upload          | B's ops + file's ops → new file                             |
-| 5. Return piggybacked        | Upload response includes A's ops                            |
-| 6. Process piggybacked       | Upload service applies them before advancing lastServerSeq  |
-
-**LWW (Last-Write-Wins) for Same Entity:**
-
-If both A and B modified the same task, the piggybacked ops flow through `ConflictResolutionService` which uses vector clocks and timestamps to determine the winner.
-
-## First-Sync Conflict Handling
-
-When a client with local data syncs for the first time to a remote that already has data, a conflict dialog is shown:
+## Snapshot and Gap Path
 
 ```mermaid
 flowchart TD
-    Start[First sync attempt] --> Download[Download sync-data.json]
-    Download --> HasLocal{Has local data?}
-    HasLocal -->|No| Apply[Apply remote state]
-    HasLocal -->|Yes| HasRemote{Remote has data?}
-    HasRemote -->|No| Upload[Upload local state]
-    HasRemote -->|Yes| Dialog[Show conflict dialog]
-
-    Dialog --> UseLocal[User chooses: Use Local]
-    Dialog --> UseRemote[User chooses: Use Remote]
-
-    UseLocal --> CreateImport[Create SYNC_IMPORT<br/>with local state]
-    CreateImport --> UploadImport[Upload to remote]
-
-    UseRemote --> ApplyRemote[Apply remote state<br/>Discard local]
-
-    style Dialog fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    START["seq 0 download or detected gap"] --> COMMIT["Read active commit file"]
+    COMMIT --> MODE{"Layout?"}
+    MODE -->|v2| EMBEDDED["Use embedded snapshot"]
+    MODE -->|v3| READ_STATE["Read sync-state.json"]
+    READ_STATE --> REF{"Matches snapshotRef<br/>clock + syncVersion?"}
+    REF -->|Yes| HYDRATE["Hydrate snapshot"]
+    REF -->|No| READ_BAK["Try sync-state.json.bak"]
+    READ_BAK --> BAK_REF{"Backup matches snapshotRef?"}
+    BAK_REF -->|Yes| HYDRATE
+    BAK_REF -->|No| GAP["Signal unresolved gap"]
+    EMBEDDED --> HYDRATE
+    HYDRATE --> ARCHIVE["Replace/read archives under TASK_ARCHIVE"]
+    ARCHIVE --> CACHE["Persist state cache + vector clock"]
+    CACHE --> LOAD["loadAllData"]
+    LOAD --> LOCAL["Persist buffered local intents,<br/>then replay overwritten reducers"]
 ```
 
-## Master Architecture Diagram
+File snapshot bootstrap does not create a `SYNC_IMPORT`; it retains ordinary
+causality. Explicit Use Local/Use Remote and backup-import flows still use their
+full-state operation semantics.
+
+## Split Compaction and Recovery
+
+For v3 compaction, `sync-state.json` is backed up and conditionally written
+before `sync-ops.json` is changed to reference it. If the process stops between
+the two writes, readers keep using the previous ops commit point and recover the
+matching previous state from `sync-state.json.bak`.
+
+A structurally corrupt primary state may be healed from the backup only when the
+backup matches `snapshotRef`. Healing conditionally matches the corrupt
+primary's own revision; a newer valid but unreferenced state is not overwritten.
 
 ```mermaid
-graph TB
-    %% Styles
-    classDef client fill:#fff,stroke:#333,stroke-width:2px,color:black;
-    classDef provider fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:black;
-    classDef storage fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:black;
-    classDef conflict fill:#ffebee,stroke:#c62828,stroke-width:2px,color:black;
-    classDef success fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:black;
+sequenceDiagram
+    participant A as Compactor A
+    participant B as Compactor B
+    participant R as Remote storage
 
-    %% CLIENT SIDE
-    subgraph Client["CLIENT (Angular)"]
-        direction TB
-
-        subgraph SyncLoop["Sync Loop"]
-            Scheduler((Scheduler)) -->|Interval| SyncService["OperationLogSyncService"]
-            SyncService -->|1. Get lastSeq| LocalMeta["SUP_OPS IndexedDB"]
-        end
-
-        subgraph DownloadFlow["Download Flow"]
-            SyncService -->|"2. downloadOps(sinceSeq)"| Adapter
-            Adapter -->|Response| VersionCheck{syncVersion<br/>Changed?}
-            VersionCheck -- "Yes (reset)" --> GapDetect{Gap Detected?}
-            VersionCheck -- "No change" --> FilterOps
-            GapDetect -- "Yes + No Ops" --> SnapshotCheck{Has Snapshot<br/>State?}
-            GapDetect -- "Yes + Has Ops" --> FilterOps
-            SnapshotCheck -- Yes --> LocalDataCheck{Has Local<br/>Unsynced Ops?}
-            SnapshotCheck -- No --> FilterOps
-            LocalDataCheck -- Yes --> ConflictDialog["Show Conflict Dialog"]:::conflict
-            LocalDataCheck -- No --> FreshCheck{Fresh Client?}
-            FreshCheck -- Yes --> ConfirmDialog["Confirmation Dialog"]
-            FreshCheck -- No --> HydrateSnapshot["Hydrate from Snapshot"]:::success
-            ConfirmDialog -- Confirmed --> HydrateSnapshot
-            ConfirmDialog -- Cancelled --> SkipSync[Skip]
-            ConflictDialog -- "Use Local" --> CreateSyncImport["Create SYNC_IMPORT"]
-            ConflictDialog -- "Use Remote" --> HydrateSnapshot
-            FilterOps["Filter ops by sinceSeq"]
-        end
-
-        subgraph ConflictMgmt["Conflict Management (LWW Auto-Resolution)"]
-            FilterOps --> ConflictDet{{"Compare<br/>Vector Clocks"}}:::conflict
-            ConflictDet -- Sequential --> ApplyRemote
-            ConflictDet -- Concurrent --> LWWCheck{{"LWW: Compare<br/>Timestamps"}}:::conflict
-
-            LWWCheck -- "Remote newer<br/>or tie" --> MarkRejected["Mark Local Rejected"]:::conflict
-            LWWCheck -- "Local newer" --> LocalWins["Create Update Op<br/>with local state"]:::conflict
-            LocalWins --> RejectBoth["Mark both rejected"]
-            RejectBoth --> CreateNewOp["New op syncs to remote"]
-            MarkRejected --> ApplyRemote
-        end
-
-        subgraph Application["Application & Validation"]
-            ApplyRemote -->|Dispatch| NgRx["NgRx Store"]
-            HydrateSnapshot -->|"Hydrate full state"| NgRx
-            NgRx --> UpdateSeq["setLastServerSeq()"]
-            UpdateSeq --> SyncDone((Done))
-        end
-
-        subgraph UploadFlow["Upload Flow"]
-            LocalMeta -->|Get Unsynced| PendingOps["Pending Ops"]
-            PendingOps --> ClassifyOp{Op Type?}
-
-            ClassifyOp -- "SYNC_IMPORT<br/>BACKUP_IMPORT" --> UploadSnapshot["Upload as Snapshot<br/>(full state in file)"]
-            ClassifyOp -- "CRT/UPD/DEL" --> MergeOps["Merge into recentOps"]
-
-            MergeOps --> BuildState["Build state snapshot<br/>from NgRx"]
-            BuildState --> IncrVersion["syncVersion++"]
-            IncrVersion --> UploadFile["Upload sync-data.json"]
-            UploadSnapshot --> UploadFile
-
-            UploadFile --> CheckPiggyback{Piggybacked<br/>Ops Found?}
-            CheckPiggyback -- Yes --> ProcessPiggyback["Process Piggybacked Ops<br/>(→ Conflict Detection)"]
-            ProcessPiggyback --> ConflictDet
-            CheckPiggyback -- No --> MarkSynced["Mark Ops Synced"]:::success
-        end
-    end
-
-    %% FILE PROVIDER LAYER
-    subgraph ProviderLayer["FILE PROVIDER LAYER"]
-        direction TB
-
-        subgraph Adapter["FileBasedSyncAdapter"]
-            DownloadOp["downloadOps()<br/>━━━━━━━━━━━━━━━<br/>• Download file<br/>• Filter by sinceSeq<br/>• Detect version changes<br/>• Return snapshotState if gap"]:::provider
-            UploadOp["uploadOps()<br/>━━━━━━━━━━━━━━━<br/>• Download current file<br/>• Merge ops + state<br/>• Increment syncVersion<br/>• Upload merged file<br/>• Return piggybacked ops"]:::provider
-            SeqTracking["Sequence Tracking<br/>━━━━━━━━━━━━━━━<br/>• _expectedSyncVersions<br/>• _localSeqCounters<br/>• _syncDataCache"]:::provider
-        end
-
-        subgraph Providers["File Providers"]
-            WebDAV["WebDAV<br/>━━━━━━━━━━━━<br/>downloadFile()<br/>uploadFile()"]:::provider
-            Dropbox["Dropbox<br/>━━━━━━━━━━━━<br/>downloadFile()<br/>uploadFile()"]:::provider
-            LocalFile["LocalFile<br/>━━━━━━━━━━━━<br/>downloadFile()<br/>uploadFile()"]:::provider
-        end
-    end
-
-    %% REMOTE STORAGE
-    subgraph Remote["REMOTE STORAGE"]
-        direction TB
-
-        SyncFile[("sync-data.json<br/>━━━━━━━━━━━━━━━━━━━<br/>📋 version: 2<br/>📋 syncVersion: N<br/>📋 clientId<br/>━━━━━━━━━━━━━━━━━━━<br/>🕐 vectorClock<br/>━━━━━━━━━━━━━━━━━━━<br/>📦 state (full snapshot)<br/>━━━━━━━━━━━━━━━━━━━<br/>📁 archiveYoung<br/>📁 archiveOld<br/>━━━━━━━━━━━━━━━━━━━<br/>📝 recentOps[0..200]")]:::storage
-    end
-
-    %% CONNECTIONS
-    Adapter --> WebDAV
-    Adapter --> Dropbox
-    Adapter --> LocalFile
-
-    WebDAV --> SyncFile
-    Dropbox --> SyncFile
-    LocalFile --> SyncFile
-
-    CreateSyncImport --> UploadSnapshot
-
-    %% Subgraph styles
-    style DownloadFlow fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    style ConflictMgmt fill:#ffebee,stroke:#c62828,stroke-width:2px
-    style UploadFlow fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
-    style Application fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
-    style ProviderLayer fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    style Remote fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    A->>R: read state rev S1
+    B->>R: read state rev S1
+    A->>R: backup S1
+    A->>R: write new state if S1
+    R-->>A: state rev S2
+    A->>R: write ops if O1, snapshotRef=S2
+    B->>R: write new state if S1
+    R-->>B: mismatch; re-download/retry
 ```
 
-## Quick Reference Tables
+## One-Way v2 to v3 Migration
 
-### File Operations
+Migration uses a crash-resumable pending marker:
 
-| Operation | Method               | Purpose              | Key Steps                                                                          |
-| --------- | -------------------- | -------------------- | ---------------------------------------------------------------------------------- |
-| Download  | `downloadOps()`      | Get remote changes   | Download file → Filter by sinceSeq → Detect gaps → Return ops or snapshot          |
-| Upload    | `uploadOps()`        | Push local changes   | Download current → Merge ops → Increment syncVersion → Upload → Return piggybacked |
-| Get Seq   | `getLastServerSeq()` | Get processed seq    | Read from `_localSeqCounters` map                                                  |
-| Set Seq   | `setLastServerSeq()` | Update processed seq | Write to `_localSeqCounters` + persist                                             |
+1. conditionally create or replace a pending `sync-ops.json` candidate;
+2. conditionally write `sync-state.json`;
+3. neutralize `sync-data.json.bak` and conditionally replace the v2 primary with
+   a v3 split tombstone;
+4. conditionally protect the recovery backup and finalize the ops marker.
 
-### sync-data.json Structure
+The required ops backup is revision- and causality-owned. A stale migrator must
+not overwrite a newer or concurrent backup before losing the primary CAS.
 
-| Field           | Type                 | Purpose                                              |
-| --------------- | -------------------- | ---------------------------------------------------- |
-| `version`       | `2`                  | File format version                                  |
-| `syncVersion`   | `number`             | Content-based lock counter (incremented each upload) |
-| `schemaVersion` | `number`             | App data schema version (for migrations)             |
-| `clientId`      | `string`             | Last client to modify file                           |
-| `lastModified`  | `number`             | Timestamp of last modification                       |
-| `vectorClock`   | `VectorClock`        | Causal ordering of all operations                    |
-| `state`         | `AppDataComplete`    | Full application state snapshot                      |
-| `archiveYoung`  | `ArchiveModel?`      | Tasks archived < 21 days                             |
-| `archiveOld`    | `ArchiveModel?`      | Tasks archived > 21 days                             |
-| `recentOps`     | `CompactOperation[]` | Last 200 operations (for conflict detection)         |
-| `checksum`      | `string?`            | SHA-256 of uncompressed state                        |
+## Browser WebDAV Requirements
 
-### Key Implementation Details
+Browser WebDAV must allow `GET`, `PUT`, `DELETE`, `MKCOL`, `PROPFIND`, and
+`OPTIONS`; accept `Authorization`, `Cache-Control`, `Content-Type`, `Depth`,
+`If-Match`, and `If-None-Match`; and expose `ETag`. See
+`docs/wiki/2.09-Configure-Sync-Backend.md` for user-facing setup guidance.
 
-| Feature                 | Implementation                                                               |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| **Optimistic Locking**  | `syncVersion` counter - no server ETags needed                               |
-| **Gap Detection**       | syncVersion reset or snapshot replacement triggers re-download from seq=0    |
-| **Piggybacking**        | On upload, ops from other clients (seq > lastProcessed) returned as `newOps` |
-| **First-Sync Conflict** | Local unsynced ops + remote snapshot → show conflict dialog                  |
-| **Fresh Client Safety** | Confirmation dialog before accepting first remote data                       |
-| **LWW Conflicts**       | Concurrent vector clocks → compare timestamps → later wins                   |
-| **Snapshot Bootstrap**  | Gap detected + has snapshot → hydrate full state (skip ops)                  |
-| **Cache Optimization**  | Downloaded sync data cached to avoid redundant download before upload        |
-| **Archive Sync**        | Archive data embedded in file; `ArchiveOperationHandler` writes to IndexedDB |
+## Key Files
 
-## Key Points
-
-1. **Single Sync File**: All data in `sync-data.json` - state snapshot + recent ops + vector clock
-2. **Content-Based Versioning**: `syncVersion` counter detects conflicts without server ETags
-3. **Piggybacking on Upload**: Version mismatch doesn't throw - ops from other clients are returned as `newOps`
-4. **Sequence Counter Separation**:
-   - `_expectedSyncVersions`: Tracks file's syncVersion (for version mismatch detection)
-   - `_localSeqCounters`: Tracks ops we've processed (updated via `setLastServerSeq`)
-5. **Archive via Op-Log**: Archive operations sync; `ArchiveOperationHandler` writes data
-6. **Deterministic Replay**: Same operation + same timestamp = same result everywhere
-
-## Implementation Files
-
-| File                                                                               | Purpose                        |
-| ---------------------------------------------------------------------------------- | ------------------------------ |
-| `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts`      | Main adapter (~800 LOC)        |
-| `src/app/op-log/sync-providers/file-based/file-based-sync.types.ts`                | TypeScript types and constants |
-| `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts` | Unit tests                     |
+| File | Responsibility |
+| --- | --- |
+| `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts` | Layout selection, migration, recovery, merge, compaction, and conditional retry |
+| `packages/sync-providers/src/file-based-sync-data.ts` | Provider-neutral v2/v3 envelopes and constants |
+| `packages/sync-providers/src/provider-types.ts` | `FileSyncProvider` conditional-write contract |
+| `src/app/op-log/persistence/sync-hydration.service.ts` | Snapshot/archive hydration and durable state cache |
+| `src/app/op-log/sync/operation-log-sync.service.ts` | Local/remote orchestration and conflict handling |

--- a/docs/sync-and-op-log/diagrams/04-file-based-sync.md
+++ b/docs/sync-and-op-log/diagrams/04-file-based-sync.md
@@ -19,6 +19,7 @@ flowchart LR
     subgraph V2["Default v2"]
         DATA["sync-data.json<br/>snapshot + archives<br/>vector clock + recent ops"]
         DATA_BAK["sync-data.json.bak"]
+        DATA_TX["sync-data.snapshot-transaction.json"]
     end
 
     subgraph V3["Opt-in v3: Surgical sync"]
@@ -26,6 +27,7 @@ flowchart LR
         STATE["sync-state.json<br/>snapshot + archives"]
         REF["snapshotRef<br/>syncVersion + vector clock"]
         OPS_BAK["sync-ops.json.bak"]
+        OPS_TX["sync-ops.snapshot-transaction.json"]
         STATE_BAK["sync-state.json.bak"]
         TOMB["sync-data.json<br/>v3 split tombstone"]
 
@@ -36,17 +38,19 @@ flowchart LR
     DATA -. migration .-> STATE
     DATA -. replaced by .-> TOMB
     DATA --- DATA_BAK
+    DATA --- DATA_TX
     OPS --- OPS_BAK
+    OPS --- OPS_TX
     STATE --- STATE_BAK
 ```
 
-| Property | Default v2 | Opt-in v3 |
-| --- | --- | --- |
-| Hot file | `sync-data.json` | `sync-ops.json` |
-| Snapshot | Embedded in every hot-file upload | `sync-state.json`, rewritten for compaction or authoritative replacement |
-| Recent-op cap | 2,000 | Grows to 2,000, then compacts to 1,000 |
-| Commit point | `sync-data.json` revision | `sync-ops.json` revision |
-| Compatibility | Default | Every client for the folder must enable Surgical sync |
+| Property      | Default v2                        | Opt-in v3                                                                |
+| ------------- | --------------------------------- | ------------------------------------------------------------------------ |
+| Hot file      | `sync-data.json`                  | `sync-ops.json`                                                          |
+| Snapshot      | Embedded in every hot-file upload | `sync-state.json`, rewritten for compaction or authoritative replacement |
+| Recent-op cap | 2,000                             | Grows to 2,000, then compacts to 1,000                                   |
+| Commit point  | `sync-data.json` revision         | `sync-ops.json` revision                                                 |
+| Compatibility | Default                           | Every client for the folder must enable Surgical sync                    |
 
 The transport envelope types and permanent file names live in
 `packages/sync-providers/src/file-based-sync-data.ts`.
@@ -73,7 +77,7 @@ sequenceDiagram
     else another writer won
         Remote-->>Adapter: revision mismatch
         Adapter->>Remote: re-download
-        Adapter->>Adapter: merge and retry with backoff
+        Adapter-->>App: abort current attempt; next sync downloads and merges
     end
 ```
 
@@ -85,10 +89,10 @@ active commit file.
 
 Every `FileSyncProvider` implements the same `uploadFile` contract:
 
-| Call | Required behavior |
-| --- | --- |
-| `revToMatch: "revision"` | Replace only that exact revision. |
-| `revToMatch: null` | Create only if the file is absent. |
+| Call                     | Required behavior                             |
+| ------------------------ | --------------------------------------------- |
+| `revToMatch: "revision"` | Replace only that exact revision.             |
+| `revToMatch: null`       | Create only if the file is absent.            |
 | `isForceOverwrite: true` | Intentionally replace without a precondition. |
 
 Dropbox maps this to atomic update/add modes. OneDrive uses `If-Match` or
@@ -133,6 +137,16 @@ A structurally corrupt primary state may be healed from the backup only when the
 backup matches `snapshotRef`. Healing conditionally matches the corrupt
 primary's own revision; a newer valid but unreferenced state is not overwritten.
 
+Authoritative snapshot replacement is separately crash-serialized. A durable
+pending transaction contains the exact encoded snapshot payloads (both state and
+ops in v3), then the adapter publishes the bound files before conditionally
+marking that same transaction complete. Startup/download completes a pending
+transaction before ordinary sync, and ordinary backup rotation verifies that the
+observed marker revision is unchanged. The completed marker keeps compact
+SHA-256 bindings plus the published revisions, allowing recovery to reject a
+stale backup written by a marker-unaware client. Replacement intent is never
+guessed from vector-clock order.
+
 ```mermaid
 sequenceDiagram
     participant A as Compactor A
@@ -171,10 +185,10 @@ Browser WebDAV must allow `GET`, `PUT`, `DELETE`, `MKCOL`, `PROPFIND`, and
 
 ## Key Files
 
-| File | Responsibility |
-| --- | --- |
+| File                                                                          | Responsibility                                                                  |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts` | Layout selection, migration, recovery, merge, compaction, and conditional retry |
-| `packages/sync-providers/src/file-based-sync-data.ts` | Provider-neutral v2/v3 envelopes and constants |
-| `packages/sync-providers/src/provider-types.ts` | `FileSyncProvider` conditional-write contract |
-| `src/app/op-log/persistence/sync-hydration.service.ts` | Snapshot/archive hydration and durable state cache |
-| `src/app/op-log/sync/operation-log-sync.service.ts` | Local/remote orchestration and conflict handling |
+| `packages/sync-providers/src/file-based-sync-data.ts`                         | Provider-neutral v2/v3 envelopes and constants                                  |
+| `packages/sync-providers/src/provider-types.ts`                               | `FileSyncProvider` conditional-write contract                                   |
+| `src/app/op-log/persistence/sync-hydration.service.ts`                        | Snapshot/archive hydration and durable state cache                              |
+| `src/app/op-log/sync/operation-log-sync.service.ts`                           | Local/remote orchestration and conflict handling                                |

--- a/docs/sync-and-op-log/diagrams/07-supersync-vs-file-based.md
+++ b/docs/sync-and-op-log/diagrams/07-supersync-vs-file-based.md
@@ -1,395 +1,149 @@
-# SuperSync vs File-Based Sync Comparison
+# SuperSync vs File-Based Sync
 
-**Last Updated:** January 2026
+**Last Updated:** July 2026
+
 **Status:** Implemented
 
-This document compares the two sync provider architectures: SuperSync (server-based) and File-Based (WebDAV/Dropbox/LocalFile).
+Both transports use the same local operation log, vector clocks, replay rules,
+validation, and conflict UI. They differ in where remote ordering and atomicity
+live.
 
-## Side-by-Side Architecture
-
-```mermaid
-graph TB
-    subgraph Title[" "]
-        direction LR
-        T1["<b>SUPERSYNC</b><br/>Server-Based"]
-        T2["<b>FILE-BASED</b><br/>File-Based"]
-    end
-
-    subgraph SS["SuperSync Architecture"]
-        direction TB
-
-        SS_Client["CLIENT"]
-        SS_Upload["Upload: POST /ops<br/>━━━━━━━━━━━━━━━<br/>Send ops array<br/>Server assigns seq"]
-        SS_Download["Download: GET /ops<br/>━━━━━━━━━━━━━━━<br/>Query since lastSeq<br/>Returns only new ops"]
-        SS_Server["SERVER<br/>━━━━━━━━━━━━━━━<br/>Validates sequence<br/>Detects gaps<br/>Returns 409 on conflict"]
-        SS_DB[("PostgreSQL<br/>━━━━━━━━━━━━━━━<br/>operations table<br/>All ops forever<br/>Server-assigned seq")]
-
-        SS_Client --> SS_Upload
-        SS_Client --> SS_Download
-        SS_Upload --> SS_Server
-        SS_Download --> SS_Server
-        SS_Server --> SS_DB
-    end
-
-    subgraph FB["File-Based Architecture"]
-        direction TB
-
-        FB_Client["CLIENT"]
-        FB_Upload["Upload: uploadFile()<br/>━━━━━━━━━━━━━━━<br/>Download first<br/>Merge + increment ver<br/>Upload entire file"]
-        FB_Download["Download: downloadFile()<br/>━━━━━━━━━━━━━━━<br/>Get entire file<br/>Filter ops locally<br/>Detect version changes"]
-        FB_Provider["FILE PROVIDER<br/>━━━━━━━━━━━━━━━<br/>WebDAV/Dropbox/Local<br/>Simple file operations<br/>No server logic"]
-        FB_File[("sync-data.json<br/>━━━━━━━━━━━━━━━<br/>Full state snapshot<br/>Last 200 ops<br/>Client-managed ver")]
-
-        FB_Client --> FB_Upload
-        FB_Client --> FB_Download
-        FB_Upload --> FB_Provider
-        FB_Download --> FB_Provider
-        FB_Provider --> FB_File
-    end
-
-    style SS fill:#e3f2fd,stroke:#1565c0,stroke-width:3px
-    style FB fill:#fff3e0,stroke:#e65100,stroke-width:3px
-    style SS_DB fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px
-    style FB_File fill:#ffe0b2,stroke:#e65100,stroke-width:2px
-    style Title fill:none,stroke:none
-```
-
-## Key Conceptual Differences
+## Architecture
 
 ```mermaid
-graph LR
-    subgraph Concept["KEY DIFFERENCE"]
-        direction TB
-        C1["Where is the<br/><b>source of truth</b>?"]
-        C2["Who manages<br/><b>sequence numbers</b>?"]
-        C3["How are<br/><b>conflicts detected</b>?"]
-        C4["What gets<br/><b>transferred</b>?"]
-        C5["How do<br/><b>late joiners</b> sync?"]
+flowchart LR
+    subgraph Client["Shared client"]
+        ACTION["Persistent action"] --> OPLOG["SUP_OPS"]
+        OPLOG --> ORCH["OperationLogSyncService"]
     end
 
-    subgraph SSAnswer["SuperSync"]
-        direction TB
-        A1["Server's PostgreSQL<br/>database"]
-        A2["Server assigns<br/>serverSeq on insert"]
-        A3["Server returns 409<br/>with missing ops"]
-        A4["Only the ops<br/>that changed"]
-        A5["Replay all ops<br/>from server"]
+    subgraph SuperSync["SuperSync"]
+        API["HTTP/WebSocket API"] --> DB["PostgreSQL operation log"]
+        DB --> SEQ["Server-assigned sequence"]
     end
 
-    subgraph FBAnswer["File-Based"]
-        direction TB
-        B1["The sync file<br/>(sync-data.json)"]
-        B2["Client increments<br/>syncVersion locally"]
-        B3["Client detects<br/>version mismatch"]
-        B4["Entire file<br/>(state + ops)"]
-        B5["Get state snapshot<br/>from file"]
+    subgraph FileBased["File-based providers"]
+        ADAPTER["FileBasedSyncAdapterService"] --> MODE{"Remote layout"}
+        MODE --> V2["v2 sync-data.json"]
+        MODE --> V3["v3 sync-ops.json<br/>+ sync-state.json"]
     end
 
-    C1 --> A1
-    C1 --> B1
-    C2 --> A2
-    C2 --> B2
-    C3 --> A3
-    C3 --> B3
-    C4 --> A4
-    C4 --> B4
-    C5 --> A5
-    C5 --> B5
-
-    style Concept fill:#f5f5f5,stroke:#333,stroke-width:2px
-    style SSAnswer fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    style FBAnswer fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    ORCH --> API
+    ORCH --> ADAPTER
 ```
 
-## Detailed Feature Comparison
+File-based providers are Dropbox, OneDrive, WebDAV/Nextcloud, and Local File.
+Version 2 is the default. Version 3 is the opt-in Surgical sync layout and is a
+one-way migration for a folder.
 
-| Aspect                   | SuperSync                     | File-Based                      | Winner     |
-| ------------------------ | ----------------------------- | ------------------------------- | ---------- |
-| **Bandwidth Efficiency** | Only transfers changed ops    | Transfers entire file each sync | SuperSync  |
-| **Setup Complexity**     | Requires account + server     | Use existing cloud storage      | File-Based |
-| **Offline Duration**     | Unlimited (server stores all) | Limited (only 200 ops retained) | SuperSync  |
-| **Self-Hosting**         | Need to run server            | Just need file storage          | File-Based |
-| **Late Joiner Speed**    | Slow (replay all ops)         | Fast (load snapshot)            | File-Based |
-| **Conflict Handling**    | Server-authoritative          | Client-side piggybacking        | Tie        |
-| **Real-time Sync**       | Yes (polling/webhooks)        | No (periodic sync)              | SuperSync  |
-| **Data Recovery**        | Full op history available     | Limited to snapshot + 200 ops   | SuperSync  |
+## Comparison
 
-## Trade-offs Visualization
+| Aspect | SuperSync | File based |
+| --- | --- | --- |
+| Remote source of truth | Server operation table and snapshots | Active remote commit file: v2 `sync-data.json` or v3 `sync-ops.json` |
+| Ordering | Server-assigned sequence | Client `syncVersion` plus retained compact operations |
+| Ordinary download | Paginated operations since cursor; optional WebSocket trigger | Read whole active commit file, filter retained ops locally |
+| Ordinary upload | POST operation batch | Download/merge/conditionally rewrite active commit file |
+| Snapshot | Server snapshot/import path | Embedded in v2; referenced `sync-state.json` in v3 |
+| Concurrency guard | Server transaction and conflict response | Provider-side revision precondition; retry after re-download |
+| Gap detection | Server cursor/snapshot protocol | Retained-op boundary, version reset/replacement, and v3 `snapshotRef` validation |
+| Storage efficiency | Operations plus server compaction | v2 rewrites snapshot each sync; v3 usually rewrites only the ops file |
+| Live trigger | WebSocket | Timer/manual/provider polling |
+| Self-hosting | Dedicated SuperSync service | Any compatible storage provider |
 
-```mermaid
-graph TB
-    subgraph Tradeoffs["TRADE-OFFS AT A GLANCE"]
-        direction TB
-
-        subgraph Bandwidth["Bandwidth"]
-            SS_BW["SuperSync: ✅ LOW<br/>Only delta ops transferred"]
-            FB_BW["File-Based: ⚠️ HIGH<br/>Full file each time"]
-        end
-
-        subgraph Setup["Setup Effort"]
-            SS_Setup["SuperSync: ⚠️ HIGH<br/>Account + server needed"]
-            FB_Setup["File-Based: ✅ LOW<br/>Use existing storage"]
-        end
-
-        subgraph History["Operation History"]
-            SS_Hist["SuperSync: ✅ FULL<br/>All ops stored forever"]
-            FB_Hist["File-Based: ⚠️ LIMITED<br/>Only last 200 ops"]
-        end
-
-        subgraph LateJoin["Late Joiner Experience"]
-            SS_Late["SuperSync: ⚠️ SLOW<br/>Must replay all ops"]
-            FB_Late["File-Based: ✅ FAST<br/>Just load snapshot"]
-        end
-
-        subgraph Complexity["Client Complexity"]
-            SS_Comp["SuperSync: ✅ SIMPLE<br/>Server handles sequences"]
-            FB_Comp["File-Based: ⚠️ COMPLEX<br/>Client manages versions"]
-        end
-    end
-
-    style SS_BW fill:#c8e6c9,stroke:#2e7d32
-    style FB_BW fill:#ffecb3,stroke:#ffa000
-    style SS_Setup fill:#ffecb3,stroke:#ffa000
-    style FB_Setup fill:#c8e6c9,stroke:#2e7d32
-    style SS_Hist fill:#c8e6c9,stroke:#2e7d32
-    style FB_Hist fill:#ffecb3,stroke:#ffa000
-    style SS_Late fill:#ffecb3,stroke:#ffa000
-    style FB_Late fill:#c8e6c9,stroke:#2e7d32
-    style SS_Comp fill:#c8e6c9,stroke:#2e7d32
-    style FB_Comp fill:#ffecb3,stroke:#ffa000
-```
-
-## Concurrent Edit Scenario Comparison
+## Upload Concurrency
 
 ```mermaid
 sequenceDiagram
     participant A as Client A
     participant B as Client B
-    participant SS as SuperSync Server
-    participant File as sync-data.json
-
-    Note over A,File: ═══ SUPERSYNC: Server Detects Gap ═══
+    participant S as SuperSync server
+    participant F as File provider
 
     rect rgb(227, 242, 253)
-        A->>SS: POST /ops [op1, op2]
-        SS->>SS: Assign seq 10, 11
-        SS-->>A: OK {seqs: [10, 11]}
-
-        B->>SS: POST /ops [op3] (lastKnown: 9)
-        SS->>SS: Gap! Client missing 10, 11
-        SS-->>B: 409 Conflict {missing: [op1, op2]}
-        B->>B: Process missing ops first
-        B->>SS: POST /ops [op3] (lastKnown: 11)
-        SS-->>B: OK {seqs: [12]}
-    end
-
-    Note over A,File: ═══ FILE-BASED: Piggybacking ═══
-
-    rect rgb(255, 243, 224)
-        A->>File: Download (v=5)
-        A->>A: Merge ops, set v=6
-        A->>File: Upload (v=6)
-
-        B->>File: Download (v=5, expects v=5)
-        Note over B: Version changed! (now v=6)
-        B->>B: Find A's ops in file (piggybacked)
-        B->>B: Merge A's ops + own ops
-        B->>B: Set v=7
-        B->>File: Upload (v=7)
-        B->>B: Process piggybacked ops locally
-    end
-```
-
-## Data Storage Comparison
-
-```mermaid
-flowchart TB
-    subgraph SuperSync["SuperSync Storage"]
-        direction TB
-        PG["PostgreSQL Database"]
-
-        subgraph Tables["Tables"]
-            OpsTable["operations<br/>━━━━━━━━━━━━━━━<br/>id, client_id, seq<br/>action_type, payload<br/>vector_clock, timestamp"]
-            ClientsTable["clients<br/>━━━━━━━━━━━━━━━<br/>client_id, last_seq<br/>created_at"]
-        end
-
-        PG --> Tables
-    end
-
-    subgraph FileBased["File-Based Storage"]
-        direction TB
-        SyncFile["sync-data.json"]
-
-        subgraph Contents["Contents"]
-            Meta["Metadata<br/>━━━━━━━━━━━━━━━<br/>version, syncVersion<br/>lastModified, checksum"]
-            State["State Snapshot<br/>━━━━━━━━━━━━━━━<br/>Full AppDataComplete"]
-            Archive["Archive Data<br/>━━━━━━━━━━━━━━━<br/>archiveYoung, archiveOld"]
-            RecentOps["Recent Ops (200)<br/>━━━━━━━━━━━━━━━<br/>CompactOperation[]"]
-        end
-
-        SyncFile --> Contents
-    end
-
-    style SuperSync fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    style FileBased fill:#fff3e0,stroke:#e65100,stroke-width:2px
-```
-
-## Sync Flow Comparison
-
-### Download Flow
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant SS as SuperSync Server
-    participant FB as File Provider
-
-    rect rgb(227, 242, 253)
-        Note over Client,SS: SuperSync Download
-        Client->>SS: GET /ops?since={lastSeq}
-        SS->>SS: Query ops WHERE seq > lastSeq
-        SS-->>Client: {ops: [...], lastSeq: N}
-        Note over Client: Only receives new ops<br/>Bandwidth efficient
+        Note over A,S: SuperSync
+        A->>S: POST ops
+        S-->>A: accepted + serverSeq
+        B->>S: POST concurrent ops
+        S-->>B: accepted, rejected, or missing-op response
+        B->>S: reconcile through server protocol
     end
 
     rect rgb(255, 243, 224)
-        Note over Client,FB: File-Based Download
-        Client->>FB: downloadFile("sync-data.json")
-        FB-->>Client: {state, recentOps, syncVersion}
-        Client->>Client: Filter ops by lastProcessedSeq
-        Note over Client: Downloads full file<br/>Filters locally
+        Note over A,F: File based
+        A->>F: read revision R1
+        B->>F: read revision R1
+        A->>F: conditional write R1
+        F-->>A: new revision R2
+        B->>F: conditional write R1
+        F-->>B: mismatch
+        B->>F: read R2, merge, retry
     end
 ```
 
-### Upload Flow
+File providers do not return piggybacked operations from an upload. The losing
+writer learns concurrent work by re-downloading after the revision mismatch.
 
-```mermaid
-sequenceDiagram
-    participant Client
-    participant SS as SuperSync Server
-    participant FB as File Provider
+## File-Provider Guarantees
 
-    rect rgb(227, 242, 253)
-        Note over Client,SS: SuperSync Upload
-        Client->>SS: POST /ops {ops: [...], lastKnownSeq}
-        SS->>SS: Validate sequence continuity
-        alt Gap detected
-            SS-->>Client: 409 Conflict + missing ops
-        else No gap
-            SS->>SS: Insert ops, assign seq numbers
-            SS-->>Client: 200 OK {assignedSeqs}
-        end
-    end
+`FileSyncProvider.uploadFile` defines:
 
-    rect rgb(255, 243, 224)
-        Note over Client,FB: File-Based Upload
-        Client->>FB: downloadFile (get current state)
-        FB-->>Client: {syncVersion: N, recentOps}
-        Client->>Client: Merge local ops + file ops
-        Client->>Client: Find piggybacked ops
-        Client->>Client: Set syncVersion = N+1
-        Client->>FB: uploadFile(merged data)
-        FB-->>Client: Success
-        Note over Client: Returns piggybacked ops<br/>for immediate processing
-    end
-```
+- string `revToMatch`: replace only that revision;
+- `null`: create only if absent;
+- force overwrite: intentional unconditional replacement.
 
-## Conflict Handling Comparison
+Dropbox and OneDrive offer atomic service-side preconditions. WebDAV is atomic
+when the server supplies strong ETags; weak/missing ETags use a best-effort
+content check. Local File is single-writer. The shared operation rules cannot
+compensate for a transport that permits two conditional writers to overwrite
+each other.
 
-```mermaid
-flowchart TB
-    subgraph SuperSync["SuperSync Conflict Handling"]
-        SS1["Client uploads ops"]
-        SS2{"Server checks<br/>sequence gap?"}
-        SS3["Gap: Return 409<br/>+ missing ops"]
-        SS4["No gap: Accept ops"]
-        SS5["Client downloads<br/>missing ops"]
-        SS6["LWW resolution<br/>on client"]
-
-        SS1 --> SS2
-        SS2 -->|Yes| SS3
-        SS2 -->|No| SS4
-        SS3 --> SS5
-        SS5 --> SS6
-    end
-
-    subgraph FileBased["File-Based Conflict Handling"]
-        FB1["Client downloads file"]
-        FB2{"syncVersion<br/>changed?"}
-        FB3["Version match:<br/>Clean upload"]
-        FB4["Version changed:<br/>Piggybacking"]
-        FB5["Merge all ops"]
-        FB6["Upload merged file"]
-        FB7["Return piggybacked ops"]
-        FB8["LWW resolution<br/>on client"]
-
-        FB1 --> FB2
-        FB2 -->|No| FB3
-        FB2 -->|Yes| FB4
-        FB4 --> FB5
-        FB5 --> FB6
-        FB6 --> FB7
-        FB7 --> FB8
-    end
-
-    style SuperSync fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    style FileBased fill:#fff3e0,stroke:#e65100,stroke-width:2px
-```
-
-## When to Use Each
+## Download and Snapshot Flow
 
 ```mermaid
 flowchart TD
-    Start["Choose Sync Provider"] --> Q1{Need real-time<br/>multi-device sync?}
+    START["Sync trigger"] --> KIND{"Provider mode"}
+    KIND -->|SuperSync| SS["GET ops since server cursor"]
+    KIND -->|File based| FB["Read active commit file"]
 
-    Q1 -->|Yes| Q2{Have SuperSync<br/>account?}
-    Q1 -->|No| FileBased
+    SS --> SS_GAP{"Server requests snapshot/rebase?"}
+    SS_GAP -->|No| APPLY["Apply unseen operations"]
+    SS_GAP -->|Yes| SNAPSHOT["Validate and apply snapshot"]
 
-    Q2 -->|Yes| SuperSync
-    Q2 -->|No| Q3{Have cloud<br/>storage?}
+    FB --> FB_GAP{"seq 0 or gap?"}
+    FB_GAP -->|No| APPLY
+    FB_GAP -->|Yes, v2| SNAPSHOT
+    FB_GAP -->|Yes, v3| REF["Load state matching snapshotRef"]
+    REF --> SNAPSHOT
 
-    Q3 -->|WebDAV/Dropbox| FileBased
-    Q3 -->|No| LocalFile
-
-    SuperSync["SuperSync<br/>━━━━━━━━━━━━━━━<br/>• Real-time sync<br/>• Efficient bandwidth<br/>• Server-managed gaps<br/>• Best for active teams"]
-
-    FileBased["File-Based Sync<br/>━━━━━━━━━━━━━━━<br/>• Uses existing storage<br/>• No additional account<br/>• Self-hosted option<br/>• Good for individuals"]
-
-    LocalFile["Local File<br/>━━━━━━━━━━━━━━━<br/>• Manual sync<br/>• Full control<br/>• Backup purposes"]
-
-    style SuperSync fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    style FileBased fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    style LocalFile fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    APPLY --> VALIDATE["Post-sync validation"]
+    SNAPSHOT --> VALIDATE
 ```
 
-## Implementation Details
+File snapshot hydration writes downloaded archives under `TASK_ARCHIVE`, saves
+the state cache and merged clock before `loadAllData`, then persists/replays
+local actions that were accepted during the hydration window.
 
-### Shared Infrastructure
+## Choosing a Transport
 
-Both providers implement `OperationSyncCapable` interface and use:
+This is a product/configuration decision, not a difference in local data
+ownership: every mode remains local-first and works offline.
 
-| Component                   | Purpose                               |
-| --------------------------- | ------------------------------------- |
-| `OperationLogSyncService`   | Orchestrates sync timing and triggers |
-| `ConflictResolutionService` | LWW resolution for concurrent edits   |
-| `VectorClockService`        | Causality tracking for all operations |
-| `OperationApplierService`   | Applies remote ops to NgRx state      |
-| `ArchiveOperationHandler`   | Handles archive side effects          |
-
-### Provider-Specific Components
-
-| SuperSync                       | File-Based                       |
-| ------------------------------- | -------------------------------- |
-| `SuperSyncProvider`             | `FileBasedSyncAdapter`           |
-| REST API client                 | File provider abstraction        |
-| Server-side sequence management | Client-side syncVersion tracking |
-| Gap detection via HTTP 409      | Piggybacking on version mismatch |
+- SuperSync is appropriate when real-time triggers, server-managed ordering,
+  and multi-device concurrency are worth operating or trusting a dedicated
+  service.
+- Dropbox/OneDrive are appropriate when a managed file API is preferred.
+- WebDAV/Nextcloud are appropriate for user-controlled storage; browser clients
+  additionally require complete CORS and ETag configuration.
+- Local File is for a single device or manual backup target, not a folder
+  mirrored concurrently by another sync tool.
 
 ## Key Files
 
-| File                                                 | Purpose                           |
-| ---------------------------------------------------- | --------------------------------- |
-| `src/app/op-log/sync-providers/super-sync/`          | SuperSync provider implementation |
-| `src/app/op-log/sync-providers/file-based/`          | File-based adapter and types      |
-| `src/app/op-log/sync/operation-log-sync.service.ts`  | Shared sync orchestration         |
-| `src/app/op-log/sync/conflict-resolution.service.ts` | LWW conflict resolution           |
+| Area | Files |
+| --- | --- |
+| Shared orchestration | `src/app/op-log/sync/operation-log-sync.service.ts`, `remote-ops-processing.service.ts` |
+| File adapter | `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts` |
+| Provider contract | `packages/sync-providers/src/provider-types.ts` |
+| SuperSync client | `packages/sync-providers/src/super-sync/` |
+| SuperSync server | `packages/super-sync-server/` |

--- a/docs/sync-and-op-log/diagrams/08-sync-flow-explained.md
+++ b/docs/sync-and-op-log/diagrams/08-sync-flow-explained.md
@@ -182,29 +182,25 @@ The change made later (by timestamp) wins:
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-### File-Based (Dropbox/WebDAV)
+### File-Based (Dropbox/OneDrive/WebDAV/Local File)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
 │                                                                      │
-│   Your Device              Cloud File          Other Device          │
-│   ┌────────┐              ┌────────┐           ┌────────┐           │
-│   │        │              │        │           │        │           │
-│   │Download│ ◄──────────  │ sync-  │ ──────►   │Download│           │
-│   │ whole  │              │ data.  │           │ whole  │           │
-│   │ file   │              │ json   │           │ file   │           │
-│   │        │ ──────────►  │        │ ◄──────   │        │           │
-│   │Upload  │              │(state +│           │Upload  │           │
-│   │ whole  │              │ ops)   │           │ whole  │           │
-│   │ file   │              │        │           │ file   │           │
-│   └────────┘              └────────┘           └────────┘           │
+│   Your Device             Remote commit        Other Device          │
+│   ┌────────┐              ┌────────────┐        ┌────────┐           │
+│   │Download│ ◄──────────  │ default v2 │ ─────► │Download│           │
+│   │+ merge │              │ sync-data  │        │+ merge │           │
+│   │        │              │            │        │        │           │
+│   │CAS     │ ──────────►  │ opt-in v3  │ ◄───── │CAS     │           │
+│   │upload  │              │ sync-ops   │        │upload  │           │
+│   └────────┘              └────────────┘        └────────┘           │
 │                                                                      │
-│   File contains EVERYTHING:                                          │
-│   - Current state (all your data)                                    │
-│   - Recent operations (last 200)                                     │
-│   - Vector clock (for conflict detection)                           │
+│   Default v2: snapshot + archives + up to 2,000 recent ops.          │
+│   Opt-in v3: sync-ops references a separate sync-state snapshot.     │
+│   A losing conditional upload re-downloads, merges, and retries.     │
 │                                                                      │
-│   Less efficient, but works with any storage                        │
+│   Strong provider revisions are required for concurrent writers.     │
 │                                                                      │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -261,7 +257,7 @@ The change made later (by timestamp) wins:
 | **Operation**    | A record of one change (create, update, delete)    |
 | **Vector Clock** | Tracks which device made changes when              |
 | **LWW**          | "Last Write Wins" - later timestamp wins conflicts |
-| **Piggybacking** | Getting other devices' changes during your upload  |
+| **Piggybacking** | SuperSync returning missing server ops with an upload response; file providers instead re-download after a revision mismatch |
 | **syncVersion**  | Counter that increases with each file update       |
 
 ## Key Files

--- a/docs/sync-and-op-log/diagrams/README.md
+++ b/docs/sync-and-op-log/diagrams/README.md
@@ -11,7 +11,7 @@ This directory contains visual diagrams explaining the Operation Log sync archit
 | [01-local-persistence.md](./01-local-persistence.md)             | Local IndexedDB persistence, hydration, compaction        | Implemented |
 | [02-server-sync.md](./02-server-sync.md)                         | SuperSync server API, PostgreSQL, upload/download flows   | Implemented |
 | [03-conflict-resolution.md](./03-conflict-resolution.md)         | LWW auto-resolution, SYNC_IMPORT filtering, vector clocks | Implemented |
-| [04-file-based-sync.md](./04-file-based-sync.md)                 | WebDAV/Dropbox/LocalFile sync via single sync-data.json   | Implemented |
+| [04-file-based-sync.md](./04-file-based-sync.md)                 | File-based v2 and opt-in v3 split sync                    | Implemented |
 | [05-meta-reducers.md](./05-meta-reducers.md)                     | Atomic multi-entity operations, state consistency         | Implemented |
 | [06-archive-operations.md](./06-archive-operations.md)           | Archive side effects, dual-database architecture          | Implemented |
 | [07-supersync-vs-file-based.md](./07-supersync-vs-file-based.md) | Comparison of SuperSync and file-based sync providers     | Implemented |

--- a/docs/sync-and-op-log/file-based-sync-flowchart.md
+++ b/docs/sync-and-op-log/file-based-sync-flowchart.md
@@ -1,12 +1,16 @@
 # File-Based Sync Flow — Mermaid Chart
 
-Visual overview of the sync decision tree for file-based providers (Dropbox, WebDAV, LocalFile). For the SuperSync equivalent see [supersync-scenarios-flowchart.md](./supersync-scenarios-flowchart.md).
+Visual overview of the sync decision tree for file-based providers (Dropbox, OneDrive, WebDAV/Nextcloud, and Local File). For the SuperSync equivalent see [supersync-scenarios-flowchart.md](./supersync-scenarios-flowchart.md).
 
 Both share the same op-log infrastructure (`OperationLogSyncService`, `RemoteOpsProcessingService`, conflict detection) but differ in the transport/adapter layer.
 
 ```mermaid
 flowchart TD
-    START([Sync Triggered]) --> DL[Download sync-data.json<br/>gap detection handled internally]
+    START([Sync Triggered]) --> MODE{Surgical sync<br/>enabled?}
+    MODE -->|No: v2| DL_V2[Download sync-data.json<br/>snapshot + recent ops]
+    MODE -->|Yes: v3| DL_V3[Download sync-ops.json<br/>commit point + recent ops]
+    DL_V2 --> DL[Validate envelope/revision<br/>recover .bak only if corrupt]
+    DL_V3 --> DL[Validate envelope/revision<br/>finish pending migration if present]
 
     %% ── SERVER MIGRATION (file-based specific) ──────────────────
     DL --> MIG_CHK{Server migration?<br/>gap + empty server}
@@ -42,7 +46,9 @@ flowchart TD
     SS_CONFLICT -->|Cancel| CANCELLED([Sync Cancelled])
     SS_CONFIRM -->|OK| HYDRATE[Hydrate from<br/>snapshotState]
     SS_CONFIRM -->|Cancel| CANCELLED
-    HYDRATE --> UPLOAD
+    HYDRATE --> ARCHIVE_LOCK[Replace/read archives<br/>under TASK_ARCHIVE lock]
+    ARCHIVE_LOCK --> DURABLE[Persist state cache + clock,<br/>then buffered local intents]
+    DURABLE --> UPLOAD
 
     %% ── INCREMENTAL OPS PATH (shared logic) ────────────────────
     HAS_OPS{Remote ops found?}
@@ -83,8 +89,8 @@ flowchart TD
     APPLY_IMPORT --> UPLOAD
 
     %% ── UPLOAD PHASE (file-based specific) ─────────────────────
-    APPLY --> UPLOAD[Upload: merge state<br/>into sync-data.json]
-    UPLOAD --> REV{Rev match<br/>on upload?}
+    APPLY --> UPLOAD[Merge local ops into active commit file:<br/>v2 sync-data.json or v3 sync-ops.json]
+    UPLOAD --> REV{Conditional remote<br/>revision matches?}
     REV -->|OK| IN_SYNC([IN_SYNC ✓])
     REV -->|Mismatch| RETRY[Exponential backoff:<br/>re-download, rebuild,<br/>re-upload]
     RETRY --> RETRY_CHK{Max retries?}
@@ -107,7 +113,7 @@ flowchart TD
     class ERROR error
     class CANCELLED cancel
     class SS_CONFIRM,CONFIRM,SS_CONFLICT,CONFLICT_DLG,IMPORT_DLG,NO_PWD_DLG,WRONG_PWD_DLG dialog
-    class APPLY,APPLY_IMPORT,FORCE_UP,FORCE_DL,MIGRATION,UPLOAD,SILENT_MIG,HYDRATE,RETRY action
+    class APPLY,APPLY_IMPORT,FORCE_UP,FORCE_DL,MIGRATION,UPLOAD,SILENT_MIG,HYDRATE,ARCHIVE_LOCK,DURABLE,RETRY action
 ```
 
 ## Error Handling (SyncWrapperService)
@@ -147,11 +153,11 @@ flowchart LR
 
 | Aspect                          | File-Based (Dropbox, WebDAV, LocalFile)                                                                 | SuperSync                                         |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| **Transport**                   | Downloads/uploads a single `sync-data.json` file                                                        | Paginated API (server-side op log)                |
+| **Transport**                   | Default v2 `sync-data.json`, or opt-in v3 `sync-ops.json` + `sync-state.json`                           | Paginated API (server-side op log)                |
 | **Snapshot path**               | Full `snapshotState` on seq 0 download, with its own conflict-checking flow                             | No snapshot concept — all ops are incremental     |
 | **Gap detection**               | Adapter detects syncVersion reset / snapshot replacement / partial trimming → re-download from seq 0    | Server handles gap detection internally           |
 | **Server migration**            | Gap on empty server → `needsFullStateUpload` → `handleServerMigration()`                                | Same concept but detected via different mechanism |
-| **Upload retry**                | Rev matching (ETag) + exponential backoff with jitter                                                   | Server rejection codes (`CONFLICT_CONCURRENT`)    |
+| **Upload retry**                | Provider-side revision matching + exponential backoff with jitter                                       | Server rejection codes (`CONFLICT_CONCURRENT`)    |
 | **Piggybacking**                | Not applicable — no server to piggyback. Concurrent changes are discovered on re-download during retry. | Server returns piggybacked ops in upload response |
 | **Post-sync encryption prompt** | Not applicable                                                                                          | Prompts user to set password or disable sync      |
 | **File-based error types**      | `PotentialCorsError`, `LegacySyncFormatDetectedError`, `SyncDataCorruptedError`                         | Not applicable                                    |
@@ -161,8 +167,10 @@ flowchart LR
 - The `Enter Password` and `Decrypt Error` dialogs correspond to `DecryptNoPasswordError` and `DecryptError` respectively — they are shared with SuperSync and are distinct components with different options.
 - `Encryption-only change` bypass: when an incoming SYNC_IMPORT has `syncImportReason === 'PASSWORD_CHANGED'` and there are no meaningful pending ops, the dialog is skipped (data is identical, only encryption changed).
 - LWW tie-breaking: on equal timestamps, remote wins (server-authoritative). `moveToArchive` operations always win regardless of timestamp.
-- Gap detection triggers: (1) syncVersion reset — another client uploaded a snapshot resetting the counter; (2) snapshot replacement — `recentOps` is empty but `state` exists and `clientId` differs; (3) partial trimming — `oldestOpSyncVersion > sinceSeq` and buffer is full.
+- Default v2 keeps at most 2,000 recent operations. Opt-in v3 compacts only after that cap is exceeded, writes `sync-state.json` first, and trims `sync-ops.json` to 1,000 operations.
+- Gap detection triggers include a syncVersion reset, snapshot replacement, and `oldestOpSyncVersion > sinceSeq`. A v3 seq-0/gap read also requires `sync-state.json` to match the ops file's `snapshotRef`.
 - Upload retry uses exponential backoff: `base × 2^(attempt-1) + random(0..50%)` with max retries defined by `FILE_BASED_SYNC_CONSTANTS.MAX_UPLOAD_RETRIES`.
+- `revToMatch: null` means create-if-absent; a string means replace that exact revision; force overwrite is reserved for explicit authoritative replacement.
 
 ## Key Source Files
 

--- a/docs/sync-and-op-log/operation-log-architecture.md
+++ b/docs/sync-and-op-log/operation-log-architecture.md
@@ -52,13 +52,17 @@ This is efficient and precise.
   - _Conflict:_ If Device B _also_ made a change and is at "Version 2", it knows "Wait, we both changed Version 1 at the same time!" -> **Conflict Detected**.
 - **Resolution:** The user is shown a dialog to pick the winner. The loser isn't deleted; it's marked as "Rejected" in the log but kept for history.
 
-**B. "File-Based Sync" (Dropbox, WebDAV, Local File)**
-This uses a single-file approach with embedded operations.
+**B. "File-Based Sync" (Dropbox, OneDrive, WebDAV/Nextcloud, Local File)**
 
-- File-based providers sync a single `sync-data.json` file containing: full state snapshot + recent operations buffer
-- When syncing, the system downloads the remote file, merges any new operations, and uploads the combined state
-- Conflict detection uses vector clocks - if two clients sync concurrently, the "piggybacking" mechanism ensures no operations are lost
-- This provides entity-level conflict resolution (vs old model-level "last write wins")
+- The default v2 layout stores the snapshot and recent operations in
+  `sync-data.json`.
+- Opt-in Surgical sync migrates the folder to a v3 `sync-ops.json` commit point
+  plus `sync-state.json`, so ordinary sync transfers only the smaller ops file.
+- Uploads conditionally match the revision returned by the read. A losing writer
+  re-downloads, merges the winner's operations, and retries; providers do not
+  piggyback operations in their upload response.
+- Vector clocks and the shared replay/conflict layer retain entity-level
+  conflict handling in either remote layout.
 
 ### 4. Safety & Self-Healing
 
@@ -215,28 +219,7 @@ Downloaded operations use a durable status transition so reducer state, archive 
 3. `failed` — an archive side-effect attempt failed. `retryCount` is charged only to the attempted row, so later rows in the same batch do not consume retry budget.
 4. `applied` — reducer and archive work both completed.
 
-Bulk replay isolates conversion/reducer exceptions per operation. The reducer-successful
-subsequence is checkpointed and receives archive side effects; ordinary reducer-failed remote
-rows are marked with terminal `rejectedAt` plus `reducerRejectedAt` metadata in the **same transaction**.
-`reducerRejectedAt` is distinct from an ordinary sync rejection: hydration excludes that row
-because its migrated reducer effect never entered state. Pending rows deliberately removed by a
-schema migration receive the same terminal marker. This prevents one malformed operation from
-terminating NgRx's state pipeline or receiving archive work, without creating a crash window
-where startup could mistake it for incomplete reducer work.
-
-Full-state and local operations are exceptions: a full-state failure discards the entire
-speculative bulk batch, while a local replay failure aborts hydration without rejecting the user
-intent. Neither case is terminally acknowledged when its state never entered NgRx.
-
-Startup recovery leaves surviving `pending` rows pending, then hydration replays them through the
-same per-operation reducer-failure collector. Successful rows and reducer failures are durably
-partitioned before archive retry or snapshot creation. A pending full-state operation never uses
-the direct-load shortcut. During live sync, a full-state reducer failure aborts before the reducer
-checkpoint and server cursor advance, so the pending row remains recoverable. Hydration retries
-`archive_pending`/`failed` rows with reducer dispatch disabled. Ordinary sync refuses to download,
-upload, or advance its cursor while any incomplete rows remain. Version 8 introduced a downgrade
-barrier for the reducer/archive checkpoint; version 9 similarly prevents older readers from replaying
-operations quarantined with `reducerRejectedAt`.
+Startup hydration replays persisted state history, quarantines surviving `pending` rows, and retries `archive_pending`/`failed` rows with reducer dispatch disabled. Ordinary sync refuses to download, upload, or advance its cursor while any incomplete rows remain. Database version 8 is a downgrade barrier: released readers that do not understand the distinct reducer checkpoint cannot open the newer store and silently overlook outstanding archive work.
 
 Local actions buffered during a remote-apply window stay ordered until each operation is durable. Transient persistence failures keep the failed suffix queued and block the current sync so a later sync can retry. A deterministically invalid buffered action also remains queued, but requires reload: its reducer already changed live state, so discarding it would let live state diverge from the durable operation log.
 
@@ -420,15 +403,12 @@ Without compaction, the op log grows unbounded. Compaction:
 
 ```typescript
 async compact(): Promise<void> {
-  // 1. Acquire the operation-log lock
-  await this.lockService.request('sp_op_log', async () => {
-    // 2. Never advance a snapshot past reducer-uncommitted remote rows
-    if ((await this.opLogStore.getPendingRemoteOps()).length > 0) return;
-
-    // 3. Read current state from NgRx (via delegate)
+  // 1. Acquire lock
+  await this.lockService.request('sp_op_log_compact', async () => {
+    // 2. Read current state from NgRx (via delegate)
     const currentState = await this.storeDelegate.getAllSyncModelDataFromStore();
 
-    // 4. Save new snapshot
+    // 3. Save new snapshot
     const lastSeq = await this.opLogStore.getLastSeq();
     await this.opLogStore.saveStateCache({
       state: currentState,
@@ -438,25 +418,16 @@ async compact(): Promise<void> {
       schemaVersion: CURRENT_SCHEMA_VERSION
     });
 
-    // 5. Delete old terminal ops only
+    // 4. Delete old ops (sync-aware)
+    // Only delete ops that have been synced AND are older than retention window
     const retentionWindowMs = 7 * 24 * 60 * 60 * 1000; // 7 days
     const cutoff = Date.now() - retentionWindowMs;
 
     await this.opLogStore.deleteOpsWhere(
-      (entry) => {
-        const rejected = entry.rejectedAt !== undefined;
-        const complete =
-          rejected ||
-          entry.applicationStatus === undefined ||
-          entry.applicationStatus === 'applied';
-        const terminalAt = entry.rejectedAt ?? entry.appliedAt;
-        return (
-          (!!entry.syncedAt || rejected) &&
-          complete &&
-          terminalAt < cutoff &&
-          entry.seq <= lastSeq
-        );
-      }
+      (entry) =>
+        !!entry.syncedAt && // never drop unsynced ops
+        entry.appliedAt < cutoff &&
+        entry.seq <= lastSeq
     );
   });
 }
@@ -471,9 +442,7 @@ async compact(): Promise<void> {
 | Emergency retention             | 1 day   | Shorter retention for quota exceeded           |
 | Compaction timeout              | 25 sec  | Abort if exceeds (prevents lock expiration)    |
 | Max compaction failures         | 3       | Failures before user notification              |
-| Unsynced non-rejected ops       | ∞       | Never delete unsynced active ops               |
-| Incomplete remote ops           | ∞       | Never delete pending/archive_pending/failed    |
-| Rejected ops retention          | 7 days  | Delete after terminal rejection retention      |
+| Unsynced ops                    | ∞       | Never delete unsynced ops                      |
 | Max download ops in memory      | 50,000  | Bounds memory during API download              |
 | Remote file retention           | 14 days | Server-side operation file retention           |
 | Max remote files to keep        | 100     | Minimum recent files on server                 |
@@ -601,18 +570,12 @@ export class MyEffects {
 
 ```
 1. Detect: Hydration fails or returns empty/invalid state
-2. Verify SUP_OPS has neither a snapshot nor any operation rows
-3. Only when SUP_OPS is provably empty, check legacy 'pf' database for data
-4. If found: Run recovery migration with that data
-5. Otherwise: restore through sync or a user-selected backup
+2. Check legacy 'pf' database for data
+3. If found: Run recovery migration with that data
+4. If not: Check remote sync for data
+5. If remote has data: Force sync download
+6. If all else fails: User must restore from backup
 ```
-
-Automatic legacy recovery runs the emptiness check and legacy write under the operation-log
-lock, and fails closed. A present snapshot, a non-empty operation log, or an inspection error
-prevents the legacy write and propagates the hydration failure. The generic hydration catch
-must never place an older `pf` copy at the current SUP_OPS sequence frontier. When recovery is
-allowed, the recovery operation, state-cache snapshot, and vector clock commit in one IndexedDB
-transaction; an interrupted write cannot leave a snapshot claiming an operation that rolled back.
 
 ### Implementation
 
@@ -621,12 +584,11 @@ async hydrateStore(): Promise<void> {
   try {
     const snapshot = await this.opLogStore.loadStateCache();
     if (!snapshot || !this.isValidSnapshot(snapshot)) {
-      // attemptRecovery() proceeds only if snapshot === null and lastSeq === 0
-      return await this.attemptRecovery();
+      await this.attemptRecovery();
+      return;
     }
     // Normal hydration...
   } catch (e) {
-    // This rethrows when SUP_OPS is non-empty or cannot be inspected.
     await this.attemptRecovery();
   }
 }
@@ -1094,147 +1056,139 @@ Before releasing any migration:
 
 # Part B: File-Based Sync
 
-File-based sync providers (WebDAV, Dropbox, LocalFile) use a single-file approach via the `FileBasedSyncAdapter`.
+File-based providers (Dropbox, OneDrive, WebDAV/Nextcloud, and Local File) use
+`FileBasedSyncAdapterService`. The adapter has two remote layouts:
+
+- **Version 2, default:** one `sync-data.json` containing the snapshot, archives,
+  vector clock, and recent operations.
+- **Version 3, opt-in “Surgical sync”:** a small `sync-ops.json` commit point plus
+  a `sync-state.json` snapshot. This reduces ordinary syncs to the operation file.
+
+The split layout is a one-way folder migration. Every client using that folder
+must be updated and have Surgical sync enabled before migration.
 
 ## B.1 How File-Based Sync Works
 
 ```
-Sync Triggered (WebDAV/Dropbox/LocalFile)
+Sync triggered
     │
     ▼
-FileBasedSyncAdapter.downloadOps()
+Download commit point
     │
-    └──► Downloads sync-data.json from remote
+    ├── v2: sync-data.json
+    └── v3: sync-ops.json
               │
-              ├──► Contains: state snapshot + recent ops buffer
-              │
-              └──► Compares vector clocks for conflict detection
-                        │
-                        ▼
-                   Process new ops, merge state
-                        │
-                        ▼
-                   FileBasedSyncAdapter.uploadOps()
-                        │
-                        └──► Upload merged state + ops
+              ├── Incremental: return unseen recent ops
+              └── seq 0 / gap: load and validate snapshot
+                    ├── v2: snapshot is in sync-data.json
+                    └── v3: snapshotRef must match sync-state.json
+                              │
+                              ▼
+                         Apply snapshot/ops
+                              │
+                              ▼
+                         Merge local ops
+                              │
+                              ▼
+                    Conditional upload against the
+                    revision returned by the read
+                              │
+                    mismatch ─┴─► re-download and retry
 ```
 
 **Key file:** `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts`
 
-## B.2 FileBasedSyncData Format
+## B.2 Remote Formats
+
+The provider package owns the transport envelopes in
+`packages/sync-providers/src/file-based-sync-data.ts`; the app binds its state,
+archive, and compact-operation types in `file-based-sync.types.ts`.
+
+### Default v2
 
 ```typescript
 interface FileBasedSyncData {
   version: 2;
   schemaVersion: number;
   vectorClock: VectorClock;
-  syncVersion: number; // Content-based optimistic locking
-  lastSeq: number;
+  syncVersion: number;
   lastModified: number;
-
-  // Full state snapshot (~95% of file size)
-  state: AppDataComplete;
-
-  // Recent operations for conflict detection (last 200, ~5% of file)
+  clientId: string;
+  state: unknown;
+  archiveYoung?: ArchiveModel;
+  archiveOld?: ArchiveModel;
   recentOps: CompactOperation[];
-
-  // Checksum for integrity verification
-  checksum?: string;
+  oldestOpSyncVersion?: number;
 }
 ```
 
-## B.3 Piggybacking Mechanism
+The recent-operation cap is `MAX_RECENT_OPS` (currently 2,000). A client that
+falls behind the retained window takes the snapshot/gap path.
 
-When two clients sync concurrently, the adapter uses "piggybacking" to ensure no operations are lost:
+### Opt-in v3
 
-1. Client A uploads state (syncVersion 1 → 2)
-2. Client B tries to upload, detects version mismatch
-3. Client B downloads A's changes, finds ops it hasn't seen
-4. Client B merges A's ops into its state, uploads (syncVersion 2 → 3)
-5. Both clients end up with all operations
+| File | Role |
+| --- | --- |
+| `sync-ops.json` | Small commit point read and conditionally rewritten on ordinary sync; contains vector clock, recent ops, and `snapshotRef`. |
+| `sync-state.json` | Full state and archives; rewritten for compaction, authoritative snapshots, migration, and repair. |
+| `sync-data.json` | Replaced by a v3 split tombstone after migration so clients with the setting off stop instead of recreating v2 data. |
+| `*.bak` | Recovery artifacts. A recovered split state is adopted only when it matches `snapshotRef`. |
 
-```typescript
-// In FileBasedSyncAdapter.uploadOps()
-const remote = await this._downloadRemoteData(provider);
-if (remote && remote.syncVersion !== expectedSyncVersion) {
-  // Another client synced - find ops we haven't processed
-  const newOps = remote.recentOps.filter((op) => op.seq > lastProcessedSeq);
-  // Return these as "piggybacked" ops for the caller to process
-  return { localOps, newOps };
-}
-```
+Compaction starts only when the operation buffer exceeds `MAX_RECENT_OPS`, then
+retains `SPLIT_COMPACTION_THRESHOLD` operations (currently 1,000). The state
+file is written before the ops commit point. A crash between those writes is
+recovered through the previous validated state backup.
 
-## B.4 Sync Download Persistence
+## B.3 Conditional Write Contract
 
-When remote data is downloaded, the sync system creates a SYNC_IMPORT operation:
+`FileSyncProvider.uploadFile(path, data, revToMatch, force)` has one shared
+meaning across providers:
 
-```typescript
-async hydrateFromRemoteSync(downloadedMainModelData?: Record<string, unknown>): Promise<void> {
-  // 1. Create SYNC_IMPORT operation with downloaded state
-  const op: Operation = {
-    id: uuidv7(),
-    opType: 'SYNC_IMPORT',
-    entityType: 'ALL',
-    payload: downloadedMainModelData,
-    // ...
-  };
-  await this.opLogStore.append(op, 'remote');
+- a string revision replaces only that exact remote revision;
+- `null` creates only when the target is absent;
+- `force: true` intentionally bypasses the precondition.
 
-  // 2. Force snapshot for crash safety
-  await this.opLogStore.saveStateCache({
-    state: downloadedMainModelData,
-    lastAppliedOpSeq: lastSeq,
-    // ...
-  });
+Dropbox uses its atomic update/add modes. OneDrive uses `If-Match` or
+`conflictBehavior=fail`. WebDAV uses strong ETags with `If-Match` and
+`If-None-Match`; servers without strong ETags fall back to a best-effort content
+hash check and are not safe for simultaneous writers. Local File is likewise a
+single-writer target.
 
-  // 3. Dispatch to NgRx
-  this.store.dispatch(loadAllData({ appDataComplete: downloadedMainModelData }));
-}
-```
+On a revision mismatch the adapter re-downloads, merges, and retries with
+bounded exponential backoff. There is no file-provider “piggyback” response;
+concurrent remote operations are learned from that re-download.
 
-### loadAllData Variants
+## B.4 Snapshot Hydration and Archives
 
-| Source               | Create Op?          | Force Snapshot? |
-| -------------------- | ------------------- | --------------- |
-| Hydration (startup)  | No                  | No              |
-| Remote sync download | Yes (SYNC_IMPORT)   | Yes             |
-| Backup file import   | Yes (BACKUP_IMPORT) | Yes             |
+File snapshots are applied without creating a `SYNC_IMPORT` operation. That
+preserves normal causality instead of giving a bootstrap download clean-slate
+semantics. Before `loadAllData` replaces NgRx state, hydration:
 
-## B.5 Archive Data Handling
+1. replaces downloaded archives and reads the resulting snapshot while holding
+   `TASK_ARCHIVE`;
+2. validates/repairs the snapshot;
+3. persists the state cache and merged vector clock;
+4. loads the snapshot into NgRx;
+5. persists local actions buffered during the hydration window with the fresh
+   clock, then replays only actions whose reducer result was overwritten.
 
-Archive data (`archiveYoung`, `archiveOld`) is included in the state snapshot for file-based sync.
-Archives are written directly to IndexedDB via `ArchiveDbAdapter` (bypassing the operation log for performance).
+Archive side effects for those local operations are replayed explicitly after
+the archive replacement. The archive lock is separate from the operation-log
+lock, avoiding re-entrant locking.
 
-Remote full-state replay holds the archive mutex while it loads, preflights, and writes both
-archive halves. When both halves are available, `archiveYoung` and `archiveOld` commit through
-one `saveArchivesAtomic()` transaction; a protected or omitted half is carried forward unchanged.
-`BACKUP_IMPORT` does not prompt on receiving clients: the originating restore was already an
-explicit user decision, so replay is deterministic across devices.
+## B.5 Migration and Recovery
 
-Archive compression uses the same `TASK_ARCHIVE` mutex for its entire read-compress-write cycle.
-This prevents compression from overwriting a concurrent full-state replacement with archives it
-read before the replacement. The final young/old pair is still committed atomically.
+Surgical-sync migration first writes a conditional pending marker to
+`sync-ops.json`, writes the state file, neutralizes the legacy backup, and
+conditionally tombstones the legacy primary. Only then is the ops marker
+finalized. A required migration backup is itself conditionally owned: a stale
+migrator cannot overwrite a causally newer or concurrent recovery artifact.
 
-### Why Archives Bypass Operation Log
-
-1. **Size**: Archived tasks can grow to tens of thousands of entries over years
-2. **Frequency**: Archive updates are rare (only when archiving tasks or flushing old data)
-3. **Sync needs**: Archives sync as part of the state snapshot, but don't need operation-level granularity
-
-### Archive Write Path
-
-```
-Archive Operation (e.g., archiving a completed task)
-    │
-    ├──► 1. Update archive directly via ArchiveDbAdapter
-    │
-    └──► 2. On next sync, archive is included in state snapshot
-```
-
-**Key files:**
-
-- `src/app/op-log/archive/archive-db-adapter.service.ts`
-- `src/app/op-log/archive/archive-operation-handler.service.ts`
+Primary files are backed up before ordinary replacement. Corrupt split-state
+primaries can be healed from a backup only when that backup matches the ops
+file’s `snapshotRef`; the heal conditionally matches the corrupt primary’s own
+revision. A newer but valid unreferenced state is never overwritten during
+recovery.
 
 ---
 
@@ -1244,13 +1198,13 @@ For server-based sync, the operation log IS the sync mechanism. Individual opera
 
 ## C.1 How Server Sync Differs from File-Based
 
-| Aspect              | File-Based Sync (Part B)     | Server Sync (Part C)  |
-| ------------------- | ---------------------------- | --------------------- |
-| What syncs          | State snapshot + recent ops  | Individual operations |
-| Conflict detection  | Vector clock on snapshot     | Entity-level per-op   |
-| Transport           | Single file (sync-data.json) | HTTP API              |
-| Op-log role         | Builds snapshot from ops     | IS the sync           |
-| `syncedAt` tracking | Not needed                   | Required              |
+| Aspect              | File-Based Sync (Part B)                               | Server Sync (Part C)  |
+| ------------------- | ------------------------------------------------------ | --------------------- |
+| What syncs          | State snapshot + recent ops                            | Individual operations |
+| Conflict detection  | Vector clock on snapshot                               | Entity-level per-op   |
+| Transport           | v2 single file or opt-in v3 split files on a provider | HTTP API              |
+| Op-log role         | Builds snapshot from ops                               | IS the sync           |
+| `syncedAt` tracking | Not needed                                             | Required              |
 
 ## C.2 Operation Sync Protocol
 
@@ -1458,12 +1412,27 @@ Conflicts are automatically resolved using Last-Write-Wins (LWW) strategy via `C
 2. **Newer wins**: The side with the newer timestamp wins
 3. **Tie-breaker**: When timestamps are equal, remote wins (server-authoritative)
 
-The selected operation or synthetic merge is persisted and applied before either original side
-is rejected. Only after reducer and archive work succeeds does the service finalize rejections
-and emit the conflict journal entry. A failed resolution therefore leaves the originals eligible
-for retry instead of recording a winner that never entered state. If a synthetic disjoint merge
-cannot pass reducer replay, that synthetic row is quarantined and the same conflict immediately
-falls back to ordinary LWW; a `merged` journal entry is emitted only when the merge itself succeeds.
+```typescript
+async autoResolveConflictsLWW(conflicts: EntityConflict[], nonConflictingOps: Operation[]): Promise<void> {
+  for (const conflict of conflicts) {
+    const localMaxTimestamp = Math.max(...conflict.localOps.map(op => op.timestamp));
+    const remoteMaxTimestamp = Math.max(...conflict.remoteOps.map(op => op.timestamp));
+
+    if (localMaxTimestamp > remoteMaxTimestamp) {
+      // Local wins - create new UPDATE op with current entity state
+      const localWinOp = await this._createLocalWinUpdateOp(conflict);
+      // Reject both old local and remote ops
+      await this.opLogStore.markRejected([...localOpIds, ...remoteOpIds]);
+      // New op will sync local state on next upload
+      await this.opLogStore.append(localWinOp, 'local');
+    } else {
+      // Remote wins (including tie)
+      await this.operationApplier.applyOperations(conflict.remoteOps);
+      await this.opLogStore.markRejected(localOpIds);
+    }
+  }
+}
+```
 
 ### When Local Wins
 
@@ -1645,7 +1614,6 @@ enum OpType {
 interface RepairPayload {
   appDataComplete: AppDataCompleteNew; // Full repaired state
   repairSummary: RepairSummary; // What was fixed
-  repairBaseServerSeq?: number; // Server cursor included in this repaired state
 }
 
 interface RepairSummary {
@@ -1661,8 +1629,6 @@ interface RepairSummary {
 ### REPAIR Operation Behavior
 
 - **During replay**: REPAIR operations load state directly (like SyncImport), skipping prior operations
-- **During sync**: REPAIR is narrower than an explicit import. Operations concurrent with it are replayed on top of the repaired snapshot (including a concurrent prefix that must move after the full-state boundary). On SuperSync, REPAIR never requests a clean slate; the server locks the user's sequence row and accepts the snapshot only when `repairBaseServerSeq` still equals the current server sequence. A stale repair is retired locally before the concurrent server suffix is downloaded.
-- **Upload ordering**: If a full-state upload fails, later regular operations stay pending. Permanent snapshot failures are classified by the central rejection handler after any remote work has been applied. A rejected local explicit import/restore remains a durable upload barrier across later sync cycles; incremental operations resume only after a newer full-state snapshot succeeds. Rejected remote imports are conflict-resolution history, and stale automatic REPAIR is excluded so its concurrent suffix can download and trigger a fresh repair if still necessary.
 - **User notification**: Shows snackbar with count of issues fixed
 - **Audit trail**: REPAIR operations are visible in the operation log for debugging
 
@@ -1911,12 +1877,9 @@ fresh id.
 
 **Status:** Handled via Locks
 
-- Compaction and sync serialize on the operation-log lock
-- Compaction aborts before snapshotting while any non-rejected `pending` remote row exists
-- Deletion requires terminal status: synced applied/legacy-complete rows or old rejected rows
-- `archive_pending` and `failed` quarantine rows survive regardless of age
-- Emergency compaction returns `false` when it skips for pending reducer work or an empty/degraded
-  live state; callers only treat an actually written snapshot/prune pass as success
+- Compaction acquires `sp_op_log_compact` lock
+- Sync operations use separate locks
+- **Verified safe**: Compaction only deletes ops with `syncedAt` set, so unsynced ops from active sync are preserved
 
 ---
 
@@ -2275,15 +2238,16 @@ When adding new entities or relationships:
 
 > **Note**: A.7.11 is required for cross-version sync. Currently safe because `CURRENT_SCHEMA_VERSION = 1` (all clients on same version). See [A.7.11 Interim Guardrails](#interim-guardrails-until-implementation) for pre-release checklist.
 
-## Part B: Legacy Sync Bridge
+## Part B: File-Based Sync
 
 ### Complete ✅
 
-- `PfapiStoreDelegateService` (reads all NgRx models for sync)
-- META_MODEL vector clock update (B.2)
-- Sync download persistence via `hydrateFromRemoteSync()` (B.3)
-- All models in NgRx (no hybrid persistence)
-- Skip META_MODEL update during sync (prevents lock errors)
+- Unified adapter for Dropbox, OneDrive, WebDAV/Nextcloud, and Local File
+- Default v2 `sync-data.json` layout with snapshot, archives, and recent ops
+- Opt-in v3 Surgical sync layout with a small ops commit file and referenced state file
+- Conditional provider revisions with re-download, merge, and retry on contention
+- Revision-owned backups, split-state validation, and crash-resumable v2-to-v3 migration
+- Snapshot/archive hydration with buffered-action persistence and replay across state replacement
 
 ## Part C: Server Sync
 
@@ -2437,6 +2401,7 @@ src/app/op-log/sync-providers/
 │   ├── file-based-sync.types.ts          # FileBasedSyncData types
 │   ├── webdav/                           # WebDAV provider
 │   ├── dropbox/                          # Dropbox provider
+│   ├── onedrive/                         # OneDrive provider
 │   └── local-file/                       # Local file sync provider
 ├── provider-manager.service.ts           # Provider activation/management
 ├── wrapped-provider.service.ts           # Provider wrapper with encryption

--- a/docs/sync-and-op-log/operation-log-architecture.md
+++ b/docs/sync-and-op-log/operation-log-architecture.md
@@ -219,7 +219,28 @@ Downloaded operations use a durable status transition so reducer state, archive 
 3. `failed` — an archive side-effect attempt failed. `retryCount` is charged only to the attempted row, so later rows in the same batch do not consume retry budget.
 4. `applied` — reducer and archive work both completed.
 
-Startup hydration replays persisted state history, quarantines surviving `pending` rows, and retries `archive_pending`/`failed` rows with reducer dispatch disabled. Ordinary sync refuses to download, upload, or advance its cursor while any incomplete rows remain. Database version 8 is a downgrade barrier: released readers that do not understand the distinct reducer checkpoint cannot open the newer store and silently overlook outstanding archive work.
+Bulk replay isolates conversion/reducer exceptions per operation. The reducer-successful
+subsequence is checkpointed and receives archive side effects; ordinary reducer-failed remote
+rows are marked with terminal `rejectedAt` plus `reducerRejectedAt` metadata in the **same transaction**.
+`reducerRejectedAt` is distinct from an ordinary sync rejection: hydration excludes that row
+because its migrated reducer effect never entered state. Pending rows deliberately removed by a
+schema migration receive the same terminal marker. This prevents one malformed operation from
+terminating NgRx's state pipeline or receiving archive work, without creating a crash window
+where startup could mistake it for incomplete reducer work.
+
+Full-state and local operations are exceptions: a full-state failure discards the entire
+speculative bulk batch, while a local replay failure aborts hydration without rejecting the user
+intent. Neither case is terminally acknowledged when its state never entered NgRx.
+
+Startup recovery leaves surviving `pending` rows pending, then hydration replays them through the
+same per-operation reducer-failure collector. Successful rows and reducer failures are durably
+partitioned before archive retry or snapshot creation. A pending full-state operation never uses
+the direct-load shortcut. During live sync, a full-state reducer failure aborts before the reducer
+checkpoint and server cursor advance, so the pending row remains recoverable. Hydration retries
+`archive_pending`/`failed` rows with reducer dispatch disabled. Ordinary sync refuses to download,
+upload, or advance its cursor while any incomplete rows remain. Version 8 introduced a downgrade
+barrier for the reducer/archive checkpoint; version 9 similarly prevents older readers from replaying
+operations quarantined with `reducerRejectedAt`.
 
 Local actions buffered during a remote-apply window stay ordered until each operation is durable. Transient persistence failures keep the failed suffix queued and block the current sync so a later sync can retry. A deterministically invalid buffered action also remains queued, but requires reload: its reducer already changed live state, so discarding it would let live state diverge from the durable operation log.
 
@@ -403,12 +424,15 @@ Without compaction, the op log grows unbounded. Compaction:
 
 ```typescript
 async compact(): Promise<void> {
-  // 1. Acquire lock
-  await this.lockService.request('sp_op_log_compact', async () => {
-    // 2. Read current state from NgRx (via delegate)
+  // 1. Acquire the operation-log lock
+  await this.lockService.request('sp_op_log', async () => {
+    // 2. Never advance a snapshot past reducer-uncommitted remote rows
+    if ((await this.opLogStore.getPendingRemoteOps()).length > 0) return;
+
+    // 3. Read current state from NgRx (via delegate)
     const currentState = await this.storeDelegate.getAllSyncModelDataFromStore();
 
-    // 3. Save new snapshot
+    // 4. Save new snapshot
     const lastSeq = await this.opLogStore.getLastSeq();
     await this.opLogStore.saveStateCache({
       state: currentState,
@@ -418,16 +442,25 @@ async compact(): Promise<void> {
       schemaVersion: CURRENT_SCHEMA_VERSION
     });
 
-    // 4. Delete old ops (sync-aware)
-    // Only delete ops that have been synced AND are older than retention window
+    // 5. Delete old terminal ops only
     const retentionWindowMs = 7 * 24 * 60 * 60 * 1000; // 7 days
     const cutoff = Date.now() - retentionWindowMs;
 
     await this.opLogStore.deleteOpsWhere(
-      (entry) =>
-        !!entry.syncedAt && // never drop unsynced ops
-        entry.appliedAt < cutoff &&
-        entry.seq <= lastSeq
+      (entry) => {
+        const rejected = entry.rejectedAt !== undefined;
+        const complete =
+          rejected ||
+          entry.applicationStatus === undefined ||
+          entry.applicationStatus === 'applied';
+        const terminalAt = entry.rejectedAt ?? entry.appliedAt;
+        return (
+          (!!entry.syncedAt || rejected) &&
+          complete &&
+          terminalAt < cutoff &&
+          entry.seq <= lastSeq
+        );
+      }
     );
   });
 }
@@ -442,7 +475,9 @@ async compact(): Promise<void> {
 | Emergency retention             | 1 day   | Shorter retention for quota exceeded           |
 | Compaction timeout              | 25 sec  | Abort if exceeds (prevents lock expiration)    |
 | Max compaction failures         | 3       | Failures before user notification              |
-| Unsynced ops                    | ∞       | Never delete unsynced ops                      |
+| Unsynced non-rejected ops       | ∞       | Never delete unsynced active ops               |
+| Incomplete remote ops           | ∞       | Never delete pending/archive_pending/failed    |
+| Rejected ops retention          | 7 days  | Delete after terminal rejection retention      |
 | Max download ops in memory      | 50,000  | Bounds memory during API download              |
 | Remote file retention           | 14 days | Server-side operation file retention           |
 | Max remote files to keep        | 100     | Minimum recent files on server                 |
@@ -570,12 +605,18 @@ export class MyEffects {
 
 ```
 1. Detect: Hydration fails or returns empty/invalid state
-2. Check legacy 'pf' database for data
-3. If found: Run recovery migration with that data
-4. If not: Check remote sync for data
-5. If remote has data: Force sync download
-6. If all else fails: User must restore from backup
+2. Verify SUP_OPS has neither a snapshot nor any operation rows
+3. Only when SUP_OPS is provably empty, check legacy 'pf' database for data
+4. If found: Run recovery migration with that data
+5. Otherwise: restore through sync or a user-selected backup
 ```
+
+Automatic legacy recovery runs the emptiness check and legacy write under the operation-log
+lock, and fails closed. A present snapshot, a non-empty operation log, or an inspection error
+prevents the legacy write and propagates the hydration failure. The generic hydration catch
+must never place an older `pf` copy at the current SUP_OPS sequence frontier. When recovery is
+allowed, the recovery operation, state-cache snapshot, and vector clock commit in one IndexedDB
+transaction; an interrupted write cannot leave a snapshot claiming an operation that rolled back.
 
 ### Implementation
 
@@ -584,11 +625,12 @@ async hydrateStore(): Promise<void> {
   try {
     const snapshot = await this.opLogStore.loadStateCache();
     if (!snapshot || !this.isValidSnapshot(snapshot)) {
-      await this.attemptRecovery();
-      return;
+      // attemptRecovery() proceeds only if snapshot === null and lastSeq === 0
+      return await this.attemptRecovery();
     }
     // Normal hydration...
   } catch (e) {
+    // This rethrows when SUP_OPS is non-empty or cannot be inspected.
     await this.attemptRecovery();
   }
 }
@@ -1185,6 +1227,18 @@ Archive side effects for those local operations are replayed explicitly after
 the archive replacement. The archive lock is separate from the operation-log
 lock, avoiding re-entrant locking.
 
+Remote full-state replay holds the archive mutex while it loads, preflights, and writes both
+archive halves. When both halves are available, `archiveYoung` and `archiveOld` commit through
+one `saveArchivesAtomic()` transaction; a protected or omitted half is carried forward unchanged.
+`BACKUP_IMPORT` does not prompt on receiving clients: the originating restore was already an
+explicit user decision, so replay is deterministic across devices.
+
+Archive compression uses the same `TASK_ARCHIVE` mutex for its entire read-compress-write cycle.
+This prevents compression from overwriting a concurrent full-state replacement with archives it
+read before the replacement. The final young/old pair is still committed atomically.
+
+### Why Archives Bypass Operation Log
+
 ## B.5 Migration and Recovery
 
 Surgical-sync migration first writes a conditional pending marker to
@@ -1421,27 +1475,12 @@ Conflicts are automatically resolved using Last-Write-Wins (LWW) strategy via `C
 2. **Newer wins**: The side with the newer timestamp wins
 3. **Tie-breaker**: When timestamps are equal, remote wins (server-authoritative)
 
-```typescript
-async autoResolveConflictsLWW(conflicts: EntityConflict[], nonConflictingOps: Operation[]): Promise<void> {
-  for (const conflict of conflicts) {
-    const localMaxTimestamp = Math.max(...conflict.localOps.map(op => op.timestamp));
-    const remoteMaxTimestamp = Math.max(...conflict.remoteOps.map(op => op.timestamp));
-
-    if (localMaxTimestamp > remoteMaxTimestamp) {
-      // Local wins - create new UPDATE op with current entity state
-      const localWinOp = await this._createLocalWinUpdateOp(conflict);
-      // Reject both old local and remote ops
-      await this.opLogStore.markRejected([...localOpIds, ...remoteOpIds]);
-      // New op will sync local state on next upload
-      await this.opLogStore.append(localWinOp, 'local');
-    } else {
-      // Remote wins (including tie)
-      await this.operationApplier.applyOperations(conflict.remoteOps);
-      await this.opLogStore.markRejected(localOpIds);
-    }
-  }
-}
-```
+The selected operation or synthetic merge is persisted and applied before either original side
+is rejected. Only after reducer and archive work succeeds does the service finalize rejections
+and emit the conflict journal entry. A failed resolution therefore leaves the originals eligible
+for retry instead of recording a winner that never entered state. If a synthetic disjoint merge
+cannot pass reducer replay, that synthetic row is quarantined and the same conflict immediately
+falls back to ordinary LWW; a `merged` journal entry is emitted only when the merge itself succeeds.
 
 ### When Local Wins
 
@@ -1623,6 +1662,7 @@ enum OpType {
 interface RepairPayload {
   appDataComplete: AppDataCompleteNew; // Full repaired state
   repairSummary: RepairSummary; // What was fixed
+  repairBaseServerSeq?: number; // Server cursor included in this repaired state
 }
 
 interface RepairSummary {
@@ -1638,6 +1678,8 @@ interface RepairSummary {
 ### REPAIR Operation Behavior
 
 - **During replay**: REPAIR operations load state directly (like SyncImport), skipping prior operations
+- **During sync**: REPAIR is narrower than an explicit import. Operations concurrent with it are replayed on top of the repaired snapshot (including a concurrent prefix that must move after the full-state boundary). On SuperSync, REPAIR never requests a clean slate; the server locks the user's sequence row and accepts the snapshot only when `repairBaseServerSeq` still equals the current server sequence. A stale repair is retired locally before the concurrent server suffix is downloaded.
+- **Upload ordering**: If a full-state upload fails, later regular operations stay pending. Permanent snapshot failures are classified by the central rejection handler after any remote work has been applied. A rejected local explicit import/restore remains a durable upload barrier across later sync cycles; incremental operations resume only after a newer full-state snapshot succeeds. Rejected remote imports are conflict-resolution history, and stale automatic REPAIR is excluded so its concurrent suffix can download and trigger a fresh repair if still necessary.
 - **User notification**: Shows snackbar with count of issues fixed
 - **Audit trail**: REPAIR operations are visible in the operation log for debugging
 
@@ -1886,9 +1928,12 @@ fresh id.
 
 **Status:** Handled via Locks
 
-- Compaction acquires `sp_op_log_compact` lock
-- Sync operations use separate locks
-- **Verified safe**: Compaction only deletes ops with `syncedAt` set, so unsynced ops from active sync are preserved
+- Compaction and sync serialize on the operation-log lock
+- Compaction aborts before snapshotting while any non-rejected `pending` remote row exists
+- Deletion requires terminal status: synced applied/legacy-complete rows or old rejected rows
+- `archive_pending` and `failed` quarantine rows survive regardless of age
+- Emergency compaction returns `false` when it skips for pending reducer work or an empty/degraded
+  live state; callers only treat an actually written snapshot/prune pass as success
 
 ---
 

--- a/docs/sync-and-op-log/operation-log-architecture.md
+++ b/docs/sync-and-op-log/operation-log-architecture.md
@@ -1093,7 +1093,8 @@ Download commit point
                     Conditional upload against the
                     revision returned by the read
                               │
-                    mismatch ─┴─► re-download and retry
+                    mismatch ─┴─► classify; genuine races
+                                  retry on the next sync cycle
 ```
 
 **Key file:** `src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts`
@@ -1125,14 +1126,21 @@ interface FileBasedSyncData {
 The recent-operation cap is `MAX_RECENT_OPS` (currently 2,000). A client that
 falls behind the retained window takes the snapshot/gap path.
 
+Authoritative replacements use `sync-data.snapshot-transaction.json` to bind a
+crash-recovery transaction to the exact encoded snapshot. A pending transaction
+is completed before ordinary sync can replace its backup or primary. The
+completed marker retains only SHA-256 payload bindings and authoritative file
+revisions so mixed-version clients cannot make a stale backup recoverable.
+
 ### Opt-in v3
 
-| File | Role |
-| --- | --- |
-| `sync-ops.json` | Small commit point read and conditionally rewritten on ordinary sync; contains vector clock, recent ops, and `snapshotRef`. |
-| `sync-state.json` | Full state and archives; rewritten for compaction, authoritative snapshots, migration, and repair. |
-| `sync-data.json` | Replaced by a v3 split tombstone after migration so clients with the setting off stop instead of recreating v2 data. |
-| `*.bak` | Recovery artifacts. A recovered split state is adopted only when it matches `snapshotRef`. |
+| File                                 | Role                                                                                                                        |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `sync-ops.json`                      | Small commit point read and conditionally rewritten on ordinary sync; contains vector clock, recent ops, and `snapshotRef`. |
+| `sync-state.json`                    | Full state and archives; rewritten for compaction, authoritative snapshots, migration, and repair.                          |
+| `sync-data.json`                     | Replaced by a v3 split tombstone after migration so clients with the setting off stop instead of recreating v2 data.        |
+| `*.bak`                              | Recovery artifacts. A recovered split state is adopted only when it matches `snapshotRef`.                                  |
+| `sync-ops.snapshot-transaction.json` | Durable pending/complete marker that binds an authoritative split state/ops pair to both exact encoded payloads.            |
 
 Compaction starts only when the operation buffer exceeds `MAX_RECENT_OPS`, then
 retains `SPLIT_COMPACTION_THRESHOLD` operations (currently 1,000). The state
@@ -1154,9 +1162,10 @@ Dropbox uses its atomic update/add modes. OneDrive uses `If-Match` or
 hash check and are not safe for simultaneous writers. Local File is likewise a
 single-writer target.
 
-On a revision mismatch the adapter re-downloads, merges, and retries with
-bounded exponential backoff. There is no file-provider “piggyback” response;
-concurrent remote operations are learned from that re-download.
+On a revision mismatch the adapter re-downloads to distinguish a transient
+provider mismatch from a genuine concurrent write. A genuine concurrent write
+ends the current attempt; the next sync cycle downloads and merges the remote
+operations before retrying. There is no file-provider “piggyback” response.
 
 ## B.4 Snapshot Hydration and Archives
 
@@ -1198,13 +1207,13 @@ For server-based sync, the operation log IS the sync mechanism. Individual opera
 
 ## C.1 How Server Sync Differs from File-Based
 
-| Aspect              | File-Based Sync (Part B)                               | Server Sync (Part C)  |
-| ------------------- | ------------------------------------------------------ | --------------------- |
-| What syncs          | State snapshot + recent ops                            | Individual operations |
-| Conflict detection  | Vector clock on snapshot                               | Entity-level per-op   |
+| Aspect              | File-Based Sync (Part B)                              | Server Sync (Part C)  |
+| ------------------- | ----------------------------------------------------- | --------------------- |
+| What syncs          | State snapshot + recent ops                           | Individual operations |
+| Conflict detection  | Vector clock on snapshot                              | Entity-level per-op   |
 | Transport           | v2 single file or opt-in v3 split files on a provider | HTTP API              |
-| Op-log role         | Builds snapshot from ops                               | IS the sync           |
-| `syncedAt` tracking | Not needed                                             | Required              |
+| Op-log role         | Builds snapshot from ops                              | IS the sync           |
+| `syncedAt` tracking | Not needed                                            | Required              |
 
 ## C.2 Operation Sync Protocol
 

--- a/docs/wiki/2.09-Configure-Sync-Backend.md
+++ b/docs/wiki/2.09-Configure-Sync-Backend.md
@@ -76,6 +76,16 @@ Then in Super Productivity:
 - **Sync Folder Path:** Path relative to the WebDAV server root where sync files are stored (e.g. `/super-productivity` or `/`). This is not your server’s internal filesystem path.
 - **Sync interval** and **Only sync manually** apply. **Encryption** is available under **Advanced** for file-based providers.
 
+For the **web app**, the WebDAV server or reverse proxy must answer browser
+preflight requests for the app's origin. Allow `GET`, `PUT`, `DELETE`, `MKCOL`,
+`PROPFIND`, and `OPTIONS`; allow the `Authorization`, `Cache-Control`,
+`Content-Type`, `Depth`, `If-Match`, and `If-None-Match` request headers; and
+expose the `ETag` response header. The conditional headers prevent one device
+from silently overwriting another device's update. A basic connection check can
+still succeed when these upload-specific headers are missing, so verify an
+actual sync after changing CORS configuration. Desktop and mobile builds use a
+native HTTP layer and do not need browser CORS configuration.
+
 ---
 
 ## Local File (experimental)
@@ -92,6 +102,7 @@ Available on **desktop (Electron)** and **Android** only; not in the web app.
 
 - **Sync interval:** How often the app syncs automatically. Hidden for SuperSync and when “Only sync manually” is on.
 - **Only sync manually (disable automatic sync):** When checked, sync runs only when you trigger it (e.g. via the sync button). Shown only for file-based providers (Dropbox, OneDrive, Nextcloud, WebDAV, Local file).
+- **Surgical sync:** Opt-in split-file storage for file-based providers. Ordinary sync uses the smaller `sync-ops.json`; the full snapshot stays in `sync-state.json` until compaction or recovery needs to replace it. Enabling this migrates the selected remote folder one way. Update every device first, then enable Surgical sync for that folder on every device; a device with the setting off will pause when it sees the migrated format.
 
 ---
 

--- a/docs/wiki/3.06-User-Data.md
+++ b/docs/wiki/3.06-User-Data.md
@@ -120,7 +120,13 @@ On mobile (Android/iOS), if the app launches with no local data but a usable on-
 
 **Strategy:** The app uses **local-first, operation-based sync**. The local device is the source of truth; sync exchanges **operations** (changes) rather than full state files each time. This reduces payload size and enables entity-level conflict detection.
 
-**Providers:** Four sync providers are supported: **SuperSync** (server-based operation sync; very new, still in beta), **WebDAV** (file-based), **Dropbox** (file-based), and **Local file** (file-based, Electron/Android). File-based providers store a single sync file (e.g. `sync-data.json`) containing a full state snapshot plus a buffer of recent operations and a vector clock for causality.
+**Providers:** SuperSync uses server-based operation sync. Dropbox, OneDrive,
+WebDAV/Nextcloud, and Local file use file-based sync. By default a file-based
+provider stores `sync-data.json`, containing a full snapshot, recent operations,
+and a vector clock. The opt-in **Surgical sync** layout instead stores the hot
+operation data in `sync-ops.json` and the full snapshot in `sync-state.json`.
+That folder migration is one-way, so every client for the folder must enable the
+setting.
 
 **Conflict resolution:** Conflicts are detected using vector clocks (same entity changed in two places before sync). Resolution is **last-write-wins (LWW)**: the operation with the **newer timestamp** wins; if timestamps are equal, the **remote** (server) side wins. When local wins, the app creates a new update operation so local state is propagated on the next sync. **Identical conflicts** (e.g. both sides deleted the same entity or made the same change) are auto-resolved without user action. In **first-sync** situations where both local and remote already have data, the app may show a dialog to choose **use local** or **use remote**. After resolution, state is validated and repaired as needed.
 

--- a/docs/wiki/4.23-Managing-Your-Data.md
+++ b/docs/wiki/4.23-Managing-Your-Data.md
@@ -44,7 +44,12 @@ So export = “save everything as it is right now”; import = “load everythin
 
 ## Sync: Local-First and Conflict Resolution
 
-The app uses **local-first, operation-based sync**: your device is the primary copy; sync sends **changes** (operations) to the remote side (or a single sync file) rather than uploading the entire dataset every time. That keeps sync fast and bandwidth low. Multiple **sync providers** are supported (e.g. SuperSync server (beta), WebDAV, Dropbox, local file); file-based providers typically use a single sync file that contains a state snapshot plus recent operations.
+The app uses **local-first, operation-based sync**: your device is the primary
+copy and sync exchanges operations with the remote side. SuperSync sends those
+operations to a server. File-based providers use either the default
+`sync-data.json` envelope or the opt-in Surgical sync pair (`sync-ops.json` plus
+`sync-state.json`), where ordinary sync usually transfers only the smaller ops
+file.
 
 **Conflicts** — When the same data is changed in two places (e.g. on two devices) before they sync, the app detects a conflict. It resolves most conflicts automatically using **last-write-wins**: the change with the **newer timestamp** is kept; if timestamps tie, the **remote** (server) side wins. When your local change wins, the app creates a new operation so your version is sent to the remote. In some cases (e.g. first sync when both local and remote already have data), the app may ask you to choose **use local** or **use remote** instead of applying automatic resolution. After resolution, the app validates and can repair state so references (e.g. tasks to projects) stay consistent.
 

--- a/packages/sync-providers/src/file-based-sync-data.ts
+++ b/packages/sync-providers/src/file-based-sync-data.ts
@@ -121,6 +121,11 @@ export interface FileBasedOpsFile<
    * retry the migration before treating this ops file as committed. Keeping
    * the complete candidate ops payload in the commit-point file makes recovery
    * possible after a crash on either side of the legacy tombstone write.
+   *
+   * On disk this file is stored with `version:
+   * SPLIT_MIGRATION_PENDING_OPS_VERSION` (not 3) so shipped split clients that
+   * predate the marker cannot mistake it for a committed ops file; readers
+   * normalize the version back to 3 in memory.
    */
   migration?: {
     status: 'pending';
@@ -184,6 +189,15 @@ export const FILE_BASED_SYNC_CONSTANTS = {
   STATE_BACKUP_FILE: 'sync-state.json.bak',
   OPS_SNAPSHOT_TRANSACTION_FILE: 'sync-ops.snapshot-transaction.json',
   SPLIT_FILE_VERSION: 3 as const,
+  // On-disk `version` of a mid-migration `sync-ops.json` (migration: pending).
+  // Deliberately NOT 3: already-shipped split clients validate only
+  // `version === 3` and would otherwise treat the pending marker file as a
+  // committed ops file — bootstrapping truncated state (no sync-state.json
+  // exists yet) or finalizing the migration implicitly by uploading over it.
+  // Unknown versions make them fail safe with a transient corruption error
+  // until the migration completes. Never reuse this value as a real format
+  // version. Readers normalize it back to SPLIT_FILE_VERSION in memory.
+  SPLIT_MIGRATION_PENDING_OPS_VERSION: 203 as const,
   // Post-compaction RETAINED size for the split ops file (≈ MAX_RECENT_OPS/2).
   // NOTE: this is the trim target, NOT the trigger — a recompaction fires when the
   // ops buffer exceeds MAX_RECENT_OPS, then trims sync-ops.json back to this many

--- a/packages/sync-providers/src/file-based-sync-data.ts
+++ b/packages/sync-providers/src/file-based-sync-data.ts
@@ -164,6 +164,7 @@ export interface FileBasedSplitTombstone {
 export const FILE_BASED_SYNC_CONSTANTS = {
   SYNC_FILE: 'sync-data.json',
   BACKUP_FILE: 'sync-data.json.bak',
+  SNAPSHOT_TRANSACTION_FILE: 'sync-data.snapshot-transaction.json',
   MIGRATION_LOCK_FILE: 'migration.lock',
   FILE_VERSION: 2 as const,
   // SPAP-9: raised 500 -> 2000 to shrink the gap window. A client that missed up
@@ -181,6 +182,7 @@ export const FILE_BASED_SYNC_CONSTANTS = {
   // old and new clients must agree on these names forever.
   OPS_BACKUP_FILE: 'sync-ops.json.bak',
   STATE_BACKUP_FILE: 'sync-state.json.bak',
+  OPS_SNAPSHOT_TRANSACTION_FILE: 'sync-ops.snapshot-transaction.json',
   SPLIT_FILE_VERSION: 3 as const,
   // Post-compaction RETAINED size for the split ops file (≈ MAX_RECENT_OPS/2).
   // NOTE: this is the trim target, NOT the trigger — a recompaction fires when the

--- a/packages/sync-providers/src/file-based/dropbox/dropbox.ts
+++ b/packages/sync-providers/src/file-based/dropbox/dropbox.ts
@@ -208,33 +208,13 @@ export class Dropbox implements FileSyncProvider<
     revToMatch: string | null,
     isForceOverwrite: boolean = false,
   ): Promise<{ rev: string }> {
-    let effectiveRev = revToMatch;
-
-    // If no rev provided and not force overwrite, get current rev first
-    if (!effectiveRev && !isForceOverwrite) {
-      try {
-        const current = await this.getFileRev(targetPath, '');
-        effectiveRev = current.rev;
-        this._deps.logger.normal(
-          `${Dropbox.L}.uploadFile got current rev for conditional upload`,
-          { targetPath, hasRev: !!effectiveRev },
-        );
-      } catch (e) {
-        if (!(e instanceof RemoteFileNotFoundAPIError)) {
-          throw e;
-        }
-        // File doesn't exist - proceed without rev (will create new)
-        this._deps.logger.normal(`${Dropbox.L}.uploadFile file does not exist`, {
-          targetPath,
-        });
-      }
-    }
-
     const r = await this._withTokenRefresh(() =>
       this._api.upload({
         path: this._getPath(targetPath),
         data: dataStr,
-        revToMatch: effectiveRev,
+        // null is an explicit create-if-absent precondition. DropboxApi maps it
+        // to atomic `add` mode, which fails if a concurrent creator won first.
+        revToMatch,
         isForceOverwrite,
         targetPath,
       }),

--- a/packages/sync-providers/src/file-based/webdav/webdav-base-provider.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-base-provider.ts
@@ -131,7 +131,7 @@ export abstract class WebdavBaseProvider<
   async uploadFile(
     targetPath: string,
     dataStr: string,
-    localRev: string,
+    localRev: string | null,
     isForceOverwrite: boolean = false,
   ): Promise<{ rev: string }> {
     this._logger.normal(`${this.logLabel}.uploadFile()`, {

--- a/packages/sync-providers/tests/file-based/dropbox/dropbox-auth-helper.spec.ts
+++ b/packages/sync-providers/tests/file-based/dropbox/dropbox-auth-helper.spec.ts
@@ -158,3 +158,26 @@ describe('Dropbox.getAuthHelper — PKCE lifecycle (issue #7139)', () => {
     expect(second.codeVerifier).not.toBe(first.codeVerifier);
   });
 });
+
+describe('Dropbox.uploadFile conditional semantics', () => {
+  it('preserves a null revision as atomic create-if-absent', async () => {
+    const dropbox = makeDropbox();
+    const api = (dropbox as unknown as { _api: DropboxApi })._api;
+    const getFileRevSpy = vi
+      .spyOn(dropbox, 'getFileRev')
+      .mockResolvedValue({ rev: 'concurrent-winner' });
+    const uploadSpy = vi.spyOn(api, 'upload').mockResolvedValue({
+      rev: 'created-rev',
+    } as Awaited<ReturnType<DropboxApi['upload']>>);
+
+    await dropbox.uploadFile('sync-ops.json', 'candidate', null, false);
+
+    expect(getFileRevSpy).not.toHaveBeenCalled();
+    expect(uploadSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        revToMatch: null,
+        isForceOverwrite: false,
+      }),
+    );
+  });
+});

--- a/packages/sync-providers/tests/provider-types.spec.ts
+++ b/packages/sync-providers/tests/provider-types.spec.ts
@@ -128,6 +128,12 @@ describe('sync provider contracts', () => {
 
     expect(data.recentOps[0].sv).toBe(7);
     expect(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE).toBe('sync-data.json');
+    expect(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE).toBe(
+      'sync-data.snapshot-transaction.json',
+    );
+    expect(FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE).toBe(
+      'sync-ops.snapshot-transaction.json',
+    );
   });
 
   // SPAP-9: shrink the gap window so slow-syncing clients that miss up to

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -1556,6 +1556,167 @@ describe('OperationLogStoreService', () => {
       const storedOps = await service.getOpsAfterSeq(0);
       expect(storedOps.length).toBe(1);
     });
+
+    it('should append snapshot-included ops and atomically advance the state-cache frontier', async () => {
+      const existingOp = createTestOperation({ id: 'snapshot-op-existing' });
+      const newOp = createTestOperation({ id: 'snapshot-op-new' });
+      await service.append(existingOp, 'remote');
+      await service.saveStateCache({
+        state: { task: { ids: ['task1'] } },
+        lastAppliedOpSeq: 1,
+        vectorClock: { testClient: 1 },
+        compactedAt: 1,
+      });
+
+      const result = await service.appendSnapshotIncludedOps([existingOp, newOp]);
+
+      expect(result.writtenOps).toEqual([newOp]);
+      expect(result.skippedCount).toBe(1);
+      expect((await service.loadStateCache())?.lastAppliedOpSeq).toBe(2);
+    });
+
+    it('should not append snapshot-included ops without an existing state cache', async () => {
+      const snapshotOp = createTestOperation({ id: 'snapshot-op-without-cache' });
+
+      await expectAsync(
+        service.appendSnapshotIncludedOps([snapshotOp]),
+      ).toBeRejectedWithError(
+        'Cannot append snapshot-included operations without an existing state cache',
+      );
+
+      expect(await service.getOpsAfterSeq(0)).toEqual([]);
+      expect(await service.loadStateCache()).toBeNull();
+    });
+
+    it('should reject a snapshot append when the state-cache frontier is behind the log tail', async () => {
+      const existingOp = createTestOperation({ id: 'existing-unmaterialized-op' });
+      const snapshotOp = createTestOperation({ id: 'snapshot-op-after-gap' });
+      await service.append(existingOp, 'remote');
+      await service.saveStateCache({
+        state: { task: { ids: [] } },
+        lastAppliedOpSeq: 0,
+        vectorClock: {},
+        compactedAt: 1,
+      });
+
+      await expectAsync(
+        service.appendSnapshotIncludedOps([snapshotOp]),
+      ).toBeRejectedWithError(
+        'Cannot append snapshot-included operations when the state-cache frontier does not match the operation-log tail',
+      );
+
+      expect((await service.getOpsAfterSeq(0)).map((entry) => entry.op.id)).toEqual([
+        existingOp.id,
+      ]);
+      expect((await service.loadStateCache())?.lastAppliedOpSeq).toBe(0);
+    });
+
+    it('should atomically commit file snapshot ops, cache, clock, and archives', async () => {
+      const existingOp = createTestOperation({ id: 'file-snapshot-existing' });
+      const includedOp = createTestOperation({ id: 'file-snapshot-new' });
+      const archiveYoung = {
+        task: { ids: [], entities: {} },
+        timeTracking: { project: {}, tag: {} },
+      } as unknown as ArchiveModel;
+      const archiveOld = {
+        task: { ids: [], entities: {} },
+        timeTracking: { project: {}, tag: {} },
+      } as unknown as ArchiveModel;
+      await service.append(existingOp, 'remote');
+
+      const result = await service.commitFileSnapshotBaseline({
+        state: { task: { ids: ['remote-task'] } },
+        lastAppliedOpSeq: 1,
+        vectorClock: { remote: 7 },
+        compactedAt: 123,
+        snapshotIncludedOps: [existingOp, includedOp],
+        archiveYoung,
+        archiveOld,
+      });
+
+      expect(result).toEqual({
+        seqs: [2],
+        writtenOps: [includedOp],
+        skippedCount: 1,
+      });
+      expect((await service.loadStateCache())?.lastAppliedOpSeq).toBe(2);
+      expect(await service.getVectorClock()).toEqual({ remote: 7 });
+      const db = (
+        service as unknown as {
+          db: IDBPDatabase<unknown>;
+        }
+      ).db;
+      expect((await db.get(STORE_NAMES.ARCHIVE_YOUNG, SINGLETON_KEY)).data).toEqual(
+        archiveYoung,
+      );
+      expect((await db.get(STORE_NAMES.ARCHIVE_OLD, SINGLETON_KEY)).data).toEqual(
+        archiveOld,
+      );
+    });
+
+    it('should roll back the whole file baseline when its vector-clock write fails', async () => {
+      const priorOp = createTestOperation({ id: 'file-snapshot-prior-op' });
+      const priorState = { sentinel: 'prior-state' };
+      await service.append(priorOp, 'remote');
+      await service.saveStateCache({
+        state: priorState,
+        lastAppliedOpSeq: 1,
+        vectorClock: { testClient: 1 },
+        compactedAt: 1,
+      });
+      await service.setVectorClock({ testClient: 1 });
+
+      const adapter = (
+        service as unknown as {
+          _adapter: OpLogDbAdapter;
+        }
+      )._adapter;
+      const originalTransaction = adapter.transaction.bind(adapter);
+      spyOn(adapter, 'transaction').and.callFake(async (stores, mode, callback) =>
+        originalTransaction(stores, mode, async (tx) => {
+          const failingTx = new Proxy(tx, {
+            get: (target, property): unknown => {
+              if (property === 'put') {
+                return async (
+                  storeName: Parameters<typeof tx.put>[0],
+                  ...args: unknown[]
+                ): Promise<unknown> => {
+                  if (storeName === STORE_NAMES.VECTOR_CLOCK) {
+                    throw new Error('injected vector-clock write failure');
+                  }
+                  return (target.put as (...putArgs: unknown[]) => Promise<unknown>).call(
+                    target,
+                    storeName,
+                    ...args,
+                  );
+                };
+              }
+              const value = Reflect.get(target, property);
+              return typeof value === 'function' ? value.bind(target) : value;
+            },
+          });
+          return callback(failingTx);
+        }),
+      );
+
+      await expectAsync(
+        service.commitFileSnapshotBaseline({
+          state: { sentinel: 'new-state' },
+          lastAppliedOpSeq: 1,
+          vectorClock: { remote: 2 },
+          compactedAt: 2,
+          snapshotIncludedOps: [
+            createTestOperation({ id: 'file-snapshot-rolled-back-op' }),
+          ],
+        }),
+      ).toBeRejectedWithError('injected vector-clock write failure');
+
+      expect((await service.getOpsAfterSeq(0)).map(({ op }) => op.id)).toEqual([
+        priorOp.id,
+      ]);
+      expect((await service.loadStateCache())?.state).toEqual(priorState);
+      expect(await service.getVectorClock()).toEqual({ testClient: 1 });
+    });
   });
 
   describe('appendMixedSourceBatchSkipDuplicates', () => {

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -781,6 +781,151 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     source: 'local' | 'remote' = 'local',
     options?: { pendingApply?: boolean },
   ): Promise<{ seqs: number[]; writtenOps: Operation[]; skippedCount: number }> {
+    return this._appendBatchSkipDuplicates(ops, source, options, false);
+  }
+
+  /**
+   * Records remote operations already materialized by the current state cache.
+   *
+   * The cache must be exactly at the pre-append operation-log tail. This keeps
+   * its contiguous replay frontier from skipping unrelated operations while
+   * still allowing the supplied snapshot operations to be appended and
+   * checkpointed atomically.
+   */
+  async appendSnapshotIncludedOps(
+    ops: Operation[],
+  ): Promise<{ seqs: number[]; writtenOps: Operation[]; skippedCount: number }> {
+    return this._appendBatchSkipDuplicates(ops, 'remote', undefined, true);
+  }
+
+  /**
+   * Atomically commits every durable part of a file-snapshot baseline.
+   *
+   * The downloaded state, its archives/vector clock, and the remote operations
+   * already represented by that state are one commit point. Keeping them in a
+   * single transaction means a failed write leaves the previous baseline fully
+   * intact, so local actions deferred during the download can safely be written
+   * against it instead of being stranded behind a partial snapshot.
+   */
+  async commitFileSnapshotBaseline(opts: {
+    state: unknown;
+    lastAppliedOpSeq: number;
+    vectorClock: VectorClock;
+    compactedAt: number;
+    snapshotIncludedOps: readonly Operation[];
+    archiveYoung?: ArchiveStoreEntry['data'];
+    archiveOld?: ArchiveStoreEntry['data'];
+  }): Promise<{ seqs: number[]; writtenOps: Operation[]; skippedCount: number }> {
+    await this._ensureInit();
+
+    const storeNames: OpLogStoreName[] = [
+      STORE_NAMES.OPS,
+      STORE_NAMES.STATE_CACHE,
+      STORE_NAMES.VECTOR_CLOCK,
+    ];
+    if (opts.snapshotIncludedOps.some((op) => isFullStateOpType(op.opType))) {
+      storeNames.push(STORE_NAMES.META);
+    }
+    if (opts.archiveYoung !== undefined) {
+      storeNames.push(STORE_NAMES.ARCHIVE_YOUNG);
+    }
+    if (opts.archiveOld !== undefined) {
+      storeNames.push(STORE_NAMES.ARCHIVE_OLD);
+    }
+
+    try {
+      const result = await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, () =>
+        this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
+          let preAppendLastSeq = 0;
+          await tx.iterate<StoredOperationLogEntry>(
+            STORE_NAMES.OPS,
+            { direction: 'prev' },
+            (_value, key) => {
+              if (typeof key !== 'number') {
+                throw new Error('Operation sequence key is not numeric');
+              }
+              preAppendLastSeq = key;
+              return 'stop';
+            },
+          );
+          if (preAppendLastSeq !== opts.lastAppliedOpSeq) {
+            throw new Error(
+              'Cannot commit a file snapshot after the operation-log tail changed',
+            );
+          }
+
+          const seqs: number[] = [];
+          const writtenOps: Operation[] = [];
+          let skippedCount = 0;
+          let snapshotFrontier = preAppendLastSeq;
+          for (const op of opts.snapshotIncludedOps) {
+            const existingKey = await tx.getKeyFromIndex(
+              STORE_NAMES.OPS,
+              OPS_INDEXES.BY_ID,
+              op.id,
+            );
+            if (existingKey !== undefined) {
+              if (typeof existingKey !== 'number') {
+                throw new Error('Operation sequence key is not numeric');
+              }
+              snapshotFrontier = Math.max(snapshotFrontier, existingKey);
+              skippedCount++;
+              continue;
+            }
+
+            const entry = this._buildStoredEntry(op, 'remote');
+            const seq = await tx.add(STORE_NAMES.OPS, entry);
+            await this._recordFullStateOpInTx(tx, entry.op, seq);
+            snapshotFrontier = Math.max(snapshotFrontier, seq);
+            seqs.push(seq);
+            writtenOps.push(op);
+          }
+
+          await tx.put(STORE_NAMES.STATE_CACHE, {
+            id: SINGLETON_KEY,
+            state: opts.state,
+            lastAppliedOpSeq: snapshotFrontier,
+            vectorClock: opts.vectorClock,
+            compactedAt: opts.compactedAt,
+          } satisfies StateCacheEntry);
+          await tx.put(
+            STORE_NAMES.VECTOR_CLOCK,
+            { clock: opts.vectorClock, lastUpdate: opts.compactedAt },
+            SINGLETON_KEY,
+          );
+          if (opts.archiveYoung !== undefined) {
+            await tx.put(STORE_NAMES.ARCHIVE_YOUNG, {
+              id: SINGLETON_KEY,
+              data: opts.archiveYoung,
+              lastModified: opts.compactedAt,
+            } satisfies ArchiveStoreEntry);
+          }
+          if (opts.archiveOld !== undefined) {
+            await tx.put(STORE_NAMES.ARCHIVE_OLD, {
+              id: SINGLETON_KEY,
+              data: opts.archiveOld,
+              lastModified: opts.compactedAt,
+            } satisfies ArchiveStoreEntry);
+          }
+
+          return { seqs, writtenOps, skippedCount };
+        }),
+      );
+
+      this._vectorClockCache = { ...opts.vectorClock };
+      this._invalidateAppliedAndUnsyncedCaches();
+      return result;
+    } catch (e) {
+      this._handleAppendError(e);
+    }
+  }
+
+  private async _appendBatchSkipDuplicates(
+    ops: Operation[],
+    source: 'local' | 'remote',
+    options: { pendingApply?: boolean } | undefined,
+    advanceSnapshotFrontier: boolean,
+  ): Promise<{ seqs: number[]; writtenOps: Operation[]; skippedCount: number }> {
     if (ops.length === 0) {
       return { seqs: [], writtenOps: [], skippedCount: 0 };
     }
@@ -792,11 +937,46 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       let skippedCount = 0;
 
       const storeNames: OpLogStoreName[] = [STORE_NAMES.OPS];
+      if (advanceSnapshotFrontier) {
+        storeNames.push(STORE_NAMES.STATE_CACHE);
+      }
       if (ops.some((op) => isFullStateOpType(op.opType))) {
         storeNames.push(STORE_NAMES.META);
       }
 
       await this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
+        let stateCache: StateCacheEntry | undefined;
+        if (advanceSnapshotFrontier) {
+          stateCache = await tx.get<StateCacheEntry>(
+            STORE_NAMES.STATE_CACHE,
+            SINGLETON_KEY,
+          );
+          if (!stateCache) {
+            throw new Error(
+              'Cannot append snapshot-included operations without an existing state cache',
+            );
+          }
+
+          let preAppendLastSeq = 0;
+          await tx.iterate<StoredOperationLogEntry>(
+            STORE_NAMES.OPS,
+            { direction: 'prev' },
+            (_value, key) => {
+              if (typeof key !== 'number') {
+                throw new Error('Operation sequence key is not numeric');
+              }
+              preAppendLastSeq = key;
+              return 'stop';
+            },
+          );
+          if (stateCache.lastAppliedOpSeq !== preAppendLastSeq) {
+            throw new Error(
+              'Cannot append snapshot-included operations when the state-cache frontier does not match the operation-log tail',
+            );
+          }
+        }
+
+        let lastIncludedSeq = 0;
         for (const op of ops) {
           // Check if op already exists in the same transaction (atomic)
           const existingKey = await tx.getKeyFromIndex(
@@ -805,6 +985,10 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
             op.id,
           );
           if (existingKey !== undefined) {
+            if (typeof existingKey !== 'number') {
+              throw new Error('Operation sequence key is not numeric');
+            }
+            lastIncludedSeq = Math.max(lastIncludedSeq, existingKey);
             skippedCount++;
             continue;
           }
@@ -812,8 +996,16 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
           const entry = this._buildStoredEntry(op, source, options);
           const seq = await tx.add(STORE_NAMES.OPS, entry);
           await this._recordFullStateOpInTx(tx, entry.op, seq);
+          lastIncludedSeq = Math.max(lastIncludedSeq, seq);
           seqs.push(seq);
           writtenOps.push(op);
+        }
+
+        if (stateCache) {
+          await tx.put(STORE_NAMES.STATE_CACHE, {
+            ...stateCache,
+            lastAppliedOpSeq: Math.max(stateCache.lastAppliedOpSeq, lastIncludedSeq),
+          });
         }
       });
 

--- a/src/app/op-log/persistence/sync-hydration.service.spec.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.spec.ts
@@ -8,7 +8,7 @@ import { ClientIdService } from '../../core/util/client-id.service';
 import { VectorClockService } from '../sync/vector-clock.service';
 import { ValidateStateService } from '../validation/validate-state.service';
 import { loadAllData } from '../../root-store/meta/load-all-data.action';
-import { ActionType, OpType } from '../core/operation.types';
+import { ActionType, OperationLogEntry, OpType } from '../core/operation.types';
 import { SyncProviderId } from '../sync-providers/provider.const';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 import { LOCAL_ONLY_SYNC_KEYS } from '../../features/config/local-only-sync-settings.util';
@@ -456,6 +456,46 @@ describe('SyncHydrationService', () => {
         expect(mockOpLogStore.append).not.toHaveBeenCalled();
       });
 
+      it('should reject only the pending ops captured before snapshot hydration starts', async () => {
+        const makeEntry = (id: string, seq: number): OperationLogEntry => ({
+          seq,
+          op: {
+            id,
+            clientId: 'localClient',
+            actionType: ActionType.TASK_SHARED_UPDATE,
+            opType: OpType.Update,
+            entityType: 'TASK',
+            entityId: `task-${seq}`,
+            payload: { title: id },
+            vectorClock: { localClient: seq },
+            timestamp: seq,
+            schemaVersion: 1,
+          },
+          appliedAt: seq,
+          source: 'local',
+        });
+        const pendingBeforeHydration = makeEntry('pending-before-hydration', 1);
+        const pendingDuringHydration = makeEntry('pending-during-hydration', 2);
+        let snapshotReadStarted = false;
+        mockOpLogStore.getUnsynced.and.callFake(async () =>
+          snapshotReadStarted
+            ? [pendingBeforeHydration, pendingDuringHydration]
+            : [pendingBeforeHydration],
+        );
+        mockStateSnapshotService.getAllSyncModelDataFromStoreAsync.and.callFake(
+          async () => {
+            snapshotReadStarted = true;
+            return {} as never;
+          },
+        );
+
+        await service.hydrateFromRemoteSync({ task: {} }, undefined, false);
+
+        expect(mockOpLogStore.markRejected).toHaveBeenCalledOnceWith([
+          pendingBeforeHydration.op.id,
+        ]);
+      });
+
       it('should still save state cache when createSyncImportOp is false', async () => {
         mockOpLogStore.getLastSeq.and.resolveTo(42);
 
@@ -488,6 +528,19 @@ describe('SyncHydrationService', () => {
             }) as any,
           }),
         );
+      });
+
+      it('should invoke beforeStateLoad immediately before replacing NgRx state', async () => {
+        let dispatchCountAtHook = -1;
+
+        await service.hydrateFromRemoteSync({}, undefined, false, undefined, {
+          beforeStateLoad: () => {
+            dispatchCountAtHook = mockStore.dispatch.calls.count();
+          },
+        });
+
+        expect(dispatchCountAtHook).toBe(0);
+        expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
       });
 
       it('should still merge remote vector clock when createSyncImportOp is false', async () => {

--- a/src/app/op-log/persistence/sync-hydration.service.spec.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.spec.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
 import { SyncHydrationService } from './sync-hydration.service';
 import { OperationLogStoreService } from './operation-log-store.service';
-import { StateSnapshotService } from '../backup/state-snapshot.service';
+import { AppStateSnapshot, StateSnapshotService } from '../backup/state-snapshot.service';
 import { ClientIdService } from '../../core/util/client-id.service';
 import { VectorClockService } from '../sync/vector-clock.service';
 import { ValidateStateService } from '../validation/validate-state.service';
@@ -13,6 +13,9 @@ import { SyncProviderId } from '../sync-providers/provider.const';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 import { LOCAL_ONLY_SYNC_KEYS } from '../../features/config/local-only-sync-settings.util';
 import { SnackService } from '../../core/snack/snack.service';
+import { ArchiveDbAdapter } from '../../core/persistence/archive-db-adapter.service';
+import { LockService } from '../sync/lock.service';
+import { LOCK_NAMES } from '../core/operation-log.const';
 
 describe('SyncHydrationService', () => {
   let service: SyncHydrationService;
@@ -23,6 +26,8 @@ describe('SyncHydrationService', () => {
   let mockVectorClockService: jasmine.SpyObj<VectorClockService>;
   let mockValidateStateService: jasmine.SpyObj<ValidateStateService>;
   let mockSnackService: jasmine.SpyObj<SnackService>;
+  let mockArchiveDbAdapter: jasmine.SpyObj<ArchiveDbAdapter>;
+  let mockLockService: jasmine.SpyObj<LockService>;
 
   // Default local sync config for tests
   const defaultLocalSyncConfig = {
@@ -66,6 +71,14 @@ describe('SyncHydrationService', () => {
       'validateAndRepair',
     ]);
     mockSnackService = jasmine.createSpyObj('SnackService', ['open']);
+    mockArchiveDbAdapter = jasmine.createSpyObj('ArchiveDbAdapter', [
+      'saveArchiveYoung',
+      'saveArchiveOld',
+    ]);
+    mockArchiveDbAdapter.saveArchiveYoung.and.resolveTo();
+    mockArchiveDbAdapter.saveArchiveOld.and.resolveTo();
+    mockLockService = jasmine.createSpyObj('LockService', ['request']);
+    mockLockService.request.and.callFake(async (_lockName, callback) => callback());
 
     TestBed.configureTestingModule({
       providers: [
@@ -77,6 +90,8 @@ describe('SyncHydrationService', () => {
         { provide: VectorClockService, useValue: mockVectorClockService },
         { provide: ValidateStateService, useValue: mockValidateStateService },
         { provide: SnackService, useValue: mockSnackService },
+        { provide: ArchiveDbAdapter, useValue: mockArchiveDbAdapter },
+        { provide: LockService, useValue: mockLockService },
       ],
     });
     service = TestBed.inject(SyncHydrationService);
@@ -98,6 +113,38 @@ describe('SyncHydrationService', () => {
 
   describe('hydrateFromRemoteSync', () => {
     beforeEach(setupDefaultMocks);
+
+    it('serializes archive replacement and its snapshot read', async () => {
+      let isArchiveLockHeld = false;
+      mockLockService.request.and.callFake(async (lockName, callback) => {
+        expect(lockName).toBe(LOCK_NAMES.TASK_ARCHIVE);
+        isArchiveLockHeld = true;
+        try {
+          return await callback();
+        } finally {
+          isArchiveLockHeld = false;
+        }
+      });
+      mockArchiveDbAdapter.saveArchiveYoung.and.callFake(async () => {
+        expect(isArchiveLockHeld).toBeTrue();
+      });
+      mockArchiveDbAdapter.saveArchiveOld.and.callFake(async () => {
+        expect(isArchiveLockHeld).toBeTrue();
+      });
+      mockStateSnapshotService.getAllSyncModelDataFromStoreAsync.and.callFake(
+        async () => {
+          expect(isArchiveLockHeld).toBeTrue();
+          return {} as AppStateSnapshot;
+        },
+      );
+
+      await service.hydrateFromRemoteSync({
+        archiveYoung: { task: { ids: [], entities: {} } },
+        archiveOld: { task: { ids: [], entities: {} } },
+      });
+
+      expect(mockLockService.request).toHaveBeenCalledTimes(1);
+    });
 
     it('should merge downloaded data with archive data from DB', async () => {
       const downloadedData = { task: { ids: ['t1'] }, project: { ids: ['p1'] } };

--- a/src/app/op-log/persistence/sync-hydration.service.spec.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.spec.ts
@@ -47,6 +47,7 @@ describe('SyncHydrationService', () => {
       'getLastSeq',
       'saveStateCache',
       'setVectorClock',
+      'commitFileSnapshotBaseline',
       'loadStateCache',
       'getUnsynced',
       'markRejected',
@@ -105,6 +106,11 @@ describe('SyncHydrationService', () => {
     mockOpLogStore.getLastSeq.and.resolveTo(10);
     mockOpLogStore.saveStateCache.and.resolveTo(undefined);
     mockOpLogStore.setVectorClock.and.resolveTo(undefined);
+    mockOpLogStore.commitFileSnapshotBaseline.and.resolveTo({
+      seqs: [],
+      writtenOps: [],
+      skippedCount: 0,
+    });
     mockValidateStateService.validateAndRepair.and.resolveTo({
       isValid: true,
       wasRepaired: false,
@@ -543,24 +549,30 @@ describe('SyncHydrationService', () => {
         ]);
       });
 
-      it('should still save state cache when createSyncImportOp is false', async () => {
+      it('should commit the file snapshot baseline when createSyncImportOp is false', async () => {
         mockOpLogStore.getLastSeq.and.resolveTo(42);
 
         await service.hydrateFromRemoteSync({ task: {} }, undefined, false);
 
-        expect(mockOpLogStore.saveStateCache).toHaveBeenCalled();
+        expect(mockOpLogStore.commitFileSnapshotBaseline).toHaveBeenCalledWith(
+          jasmine.objectContaining({ lastAppliedOpSeq: 42 }),
+        );
+        expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
       });
 
-      it('should still update vector clock when createSyncImportOp is false', async () => {
+      it('should include the vector clock in the atomic file baseline', async () => {
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({ localClient: 5 });
 
         await service.hydrateFromRemoteSync({ task: {} }, undefined, false);
 
-        expect(mockOpLogStore.setVectorClock).toHaveBeenCalledWith(
+        expect(mockOpLogStore.commitFileSnapshotBaseline).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            localClient: 6, // Should still increment
+            vectorClock: jasmine.objectContaining({
+              localClient: 6,
+            }),
           }),
         );
+        expect(mockOpLogStore.setVectorClock).not.toHaveBeenCalled();
       });
 
       it('should still dispatch loadAllData when createSyncImportOp is false', async () => {
@@ -590,16 +602,165 @@ describe('SyncHydrationService', () => {
         expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
       });
 
+      it('should invoke afterStateLoad only after loadAllData dispatch commits', async () => {
+        let dispatchCountBeforeStateLoad = -1;
+        let dispatchCountAfterStateLoad = -1;
+
+        await service.hydrateFromRemoteSync({}, undefined, false, undefined, {
+          beforeStateLoad: () => {
+            dispatchCountBeforeStateLoad = mockStore.dispatch.calls.count();
+          },
+          afterStateLoad: () => {
+            dispatchCountAfterStateLoad = mockStore.dispatch.calls.count();
+          },
+        });
+
+        expect(dispatchCountBeforeStateLoad).toBe(0);
+        expect(dispatchCountAfterStateLoad).toBe(1);
+      });
+
+      it('should not invoke afterStateLoad when loadAllData dispatch throws', async () => {
+        let didRunBeforeStateLoad = false;
+        let didRunAfterStateLoad = false;
+        mockStore.dispatch.and.throwError('state dispatch failed');
+
+        await expectAsync(
+          service.hydrateFromRemoteSync({}, undefined, false, undefined, {
+            beforeStateLoad: () => {
+              didRunBeforeStateLoad = true;
+            },
+            afterStateLoad: () => {
+              didRunAfterStateLoad = true;
+            },
+          }),
+        ).toBeRejectedWithError('state dispatch failed');
+
+        expect(didRunBeforeStateLoad).toBeTrue();
+        expect(didRunAfterStateLoad).toBeFalse();
+      });
+
+      it('should signal snapshot persistence only after cache and vector clock commit', async () => {
+        const callOrder: string[] = [];
+        mockOpLogStore.commitFileSnapshotBaseline.and.callFake(async () => {
+          callOrder.push('commit-snapshot-baseline');
+          return { seqs: [], writtenOps: [], skippedCount: 0 };
+        });
+
+        await service.hydrateFromRemoteSync({}, undefined, false, undefined, {
+          afterSnapshotCachePersisted: () => {
+            callOrder.push('after-snapshot-cache-persisted');
+          },
+          afterSnapshotPersisted: () => {
+            callOrder.push('after-snapshot-persisted');
+          },
+          beforeStateLoad: () => {
+            callOrder.push('before-state-load');
+          },
+        });
+
+        expect(callOrder).toEqual([
+          'commit-snapshot-baseline',
+          'after-snapshot-cache-persisted',
+          'after-snapshot-persisted',
+          'before-state-load',
+        ]);
+      });
+
+      it('should not signal or dispatch when the atomic snapshot baseline fails', async () => {
+        let didPersistSnapshotCache = false;
+        let didPersistSnapshot = false;
+        let didRunBeforeStateLoad = false;
+        let didRunAfterStateLoad = false;
+        mockOpLogStore.commitFileSnapshotBaseline.and.rejectWith(
+          new Error('snapshot baseline write failed'),
+        );
+
+        await expectAsync(
+          service.hydrateFromRemoteSync({}, undefined, false, undefined, {
+            afterSnapshotCachePersisted: () => {
+              didPersistSnapshotCache = true;
+            },
+            afterSnapshotPersisted: () => {
+              didPersistSnapshot = true;
+            },
+            beforeStateLoad: () => {
+              didRunBeforeStateLoad = true;
+            },
+            afterStateLoad: () => {
+              didRunAfterStateLoad = true;
+            },
+          }),
+        ).toBeRejectedWithError('snapshot baseline write failed');
+
+        expect(didPersistSnapshotCache).toBeFalse();
+        expect(didPersistSnapshot).toBeFalse();
+        expect(didRunBeforeStateLoad).toBeFalse();
+        expect(didRunAfterStateLoad).toBeFalse();
+        expect(mockStore.dispatch).not.toHaveBeenCalled();
+      });
+
+      it('should signal archive replacement after the atomic baseline commits', async () => {
+        const callOrder: string[] = [];
+        mockOpLogStore.commitFileSnapshotBaseline.and.callFake(async () => {
+          callOrder.push('commit-snapshot-baseline');
+          return { seqs: [], writtenOps: [], skippedCount: 0 };
+        });
+
+        await service.hydrateFromRemoteSync(
+          {
+            task: {},
+            archiveYoung: { task: { ids: [], entities: {} } },
+          },
+          undefined,
+          false,
+          undefined,
+          {
+            afterArchiveReplacement: () => callOrder.push('after-archive-replace'),
+          },
+        );
+
+        expect(callOrder).toEqual(['commit-snapshot-baseline', 'after-archive-replace']);
+        expect(mockArchiveDbAdapter.saveArchiveYoung).not.toHaveBeenCalled();
+      });
+
+      it('should not signal archive replacement when the atomic baseline fails', async () => {
+        let didReplaceArchive = false;
+        mockOpLogStore.commitFileSnapshotBaseline.and.rejectWith(
+          new Error('snapshot baseline write failed'),
+        );
+
+        await expectAsync(
+          service.hydrateFromRemoteSync(
+            {
+              task: {},
+              archiveYoung: { task: { ids: [], entities: {} } },
+            },
+            undefined,
+            false,
+            undefined,
+            {
+              afterArchiveReplacement: () => {
+                didReplaceArchive = true;
+              },
+            },
+          ),
+        ).toBeRejectedWithError('snapshot baseline write failed');
+
+        expect(didReplaceArchive).toBeFalse();
+      });
+
       it('should still merge remote vector clock when createSyncImportOp is false', async () => {
         const remoteVectorClock = { remoteClient: 100 };
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({ localClient: 5 });
 
         await service.hydrateFromRemoteSync({ task: {} }, remoteVectorClock, false);
 
-        expect(mockOpLogStore.setVectorClock).toHaveBeenCalledWith(
+        expect(mockOpLogStore.commitFileSnapshotBaseline).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            localClient: 6,
-            remoteClient: 100,
+            vectorClock: jasmine.objectContaining({
+              localClient: 6,
+              remoteClient: 100,
+            }),
           }),
         );
       });

--- a/src/app/op-log/persistence/sync-hydration.service.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.ts
@@ -29,6 +29,11 @@ import {
   stripLocalOnlySyncSettingsFromAppData,
 } from '../../features/config/local-only-sync-settings.util';
 
+interface SnapshotHydrationHooks {
+  /** Runs synchronously immediately before loadAllData replaces live NgRx state. */
+  beforeStateLoad?: () => void;
+}
+
 /**
  * Handles hydration after remote sync downloads.
  *
@@ -71,16 +76,27 @@ export class SyncHydrationService {
    *   for file-based sync bootstrap to avoid "clean slate" semantics that would filter
    *   concurrent ops from other clients. Default is true for backwards compatibility
    *   and for explicit "use local/remote" conflict resolution flows.
+   * @param hooks - Internal orchestration hooks around the final synchronous state load.
    */
   async hydrateFromRemoteSync(
     downloadedMainModelData?: Record<string, unknown>,
     remoteVectorClock?: Record<string, number>,
     createSyncImportOp: boolean = true,
     syncImportReason?: SyncImportReason,
+    hooks?: SnapshotHydrationHooks,
   ): Promise<void> {
     OpLog.normal('SyncHydrationService: Hydrating from remote sync...');
 
     try {
+      // Capture the exact pending set before any snapshot work can yield. The
+      // normal file-snapshot caller opens a remote-apply window around this
+      // method, so user actions arriving after this read are deferred and must
+      // be preserved on top of the downloaded snapshot rather than rejected as
+      // if they belonged to the superseded local baseline.
+      const unsyncedOpsToReject = createSyncImportOp
+        ? []
+        : await this.opLogStore.getUnsynced();
+
       // 0. Capture current local-only sync settings BEFORE overwriting
       // These settings should remain local to each client and not be overwritten by remote data.
       // FIX: isEnabled was not being preserved, causing sync to appear disabled after reload
@@ -207,12 +223,11 @@ export class SyncHydrationService {
         // CRITICAL: Reject any local pending ops since they're now based on superseded state.
         // Without SYNC_IMPORT, SyncImportFilterService won't automatically filter them.
         // These ops have superseded clocks and payloads that don't match the new snapshot.
-        const unsyncedOps = await this.opLogStore.getUnsynced();
-        if (unsyncedOps.length > 0) {
-          const opIds = unsyncedOps.map((entry) => entry.op.id);
+        if (unsyncedOpsToReject.length > 0) {
+          const opIds = unsyncedOpsToReject.map((entry) => entry.op.id);
           await this.opLogStore.markRejected(opIds);
           OpLog.normal(
-            `SyncHydrationService: Rejected ${unsyncedOps.length} local pending op(s) ` +
+            `SyncHydrationService: Rejected ${unsyncedOpsToReject.length} local pending op(s) ` +
               `(superseded after file-based sync snapshot)`,
           );
 
@@ -220,7 +235,7 @@ export class SyncHydrationService {
           this.snackService.open({
             msg: T.F.SYNC.S.LOCAL_CHANGES_DISCARDED_SNAPSHOT,
             translateParams: {
-              count: unsyncedOps.length,
+              count: unsyncedOpsToReject.length,
             },
           });
         }
@@ -298,6 +313,7 @@ export class SyncHydrationService {
       OpLog.normal('SyncHydrationService: Updated vector clock store after sync');
 
       // 11. Dispatch loadAllData to update NgRx
+      hooks?.beforeStateLoad?.();
       this.store.dispatch(loadAllData({ appDataComplete: dataToLoad }));
       OpLog.normal('SyncHydrationService: Dispatched loadAllData with synced data');
     } catch (e) {

--- a/src/app/op-log/persistence/sync-hydration.service.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.ts
@@ -32,8 +32,18 @@ import { LockService } from '../sync/lock.service';
 import { LOCK_NAMES } from '../core/operation-log.const';
 
 interface SnapshotHydrationHooks {
+  /** Remote operations already represented by a file-based snapshot. */
+  snapshotIncludedOps?: readonly Operation[];
+  /** Runs synchronously after downloaded archive replacement commits. */
+  afterArchiveReplacement?: () => void;
+  /** Runs synchronously after the snapshot baseline transaction commits. */
+  afterSnapshotCachePersisted?: () => void;
+  /** Runs synchronously after the complete snapshot baseline commits. */
+  afterSnapshotPersisted?: () => void;
   /** Runs synchronously immediately before loadAllData replaces live NgRx state. */
   beforeStateLoad?: () => void;
+  /** Runs synchronously after loadAllData has replaced live NgRx state. */
+  afterStateLoad?: () => void;
 }
 
 /**
@@ -79,7 +89,7 @@ export class SyncHydrationService {
    *   for file-based sync bootstrap to avoid "clean slate" semantics that would filter
    *   concurrent ops from other clients. Default is true for backwards compatibility
    *   and for explicit "use local/remote" conflict resolution flows.
-   * @param hooks - Internal orchestration hooks around the final synchronous state load.
+   * @param hooks - Internal orchestration hooks around archive and state replacement.
    */
   async hydrateFromRemoteSync(
     downloadedMainModelData?: Record<string, unknown>,
@@ -113,25 +123,35 @@ export class SyncHydrationService {
         isManualSyncOnly: currentSyncConfig.isManualSyncOnly,
       };
 
+      const typedDownloadedData = downloadedMainModelData as
+        | Record<string, unknown>
+        | undefined;
+      const downloadedArchiveYoung = typedDownloadedData?.['archiveYoung'] as
+        | ArchiveModel
+        | undefined;
+      const downloadedArchiveOld = typedDownloadedData?.['archiveOld'] as
+        | ArchiveModel
+        | undefined;
+
       // 1. Replace downloaded archives and read the resulting snapshot under one
       // archive lock. Otherwise a local archive read-modify-write can start from
       // the old archive, then save it after this replacement and silently erase
       // downloaded entries. TASK_ARCHIVE is independent from OPERATION_LOG.
       const dbData = await this.lockService.request(LOCK_NAMES.TASK_ARCHIVE, async () => {
-        if (downloadedMainModelData) {
-          const typedData = downloadedMainModelData as Record<string, unknown>;
-          if (typedData['archiveYoung']) {
-            await this.archiveDbAdapter.saveArchiveYoung(
-              typedData['archiveYoung'] as ArchiveModel,
-            );
+        // Full-state imports retain their existing archive write order. File
+        // snapshots defer these writes to commitFileSnapshotBaseline(), where
+        // archives, state, clock, and included operations commit atomically.
+        if (createSyncImportOp) {
+          if (downloadedArchiveYoung) {
+            await this.archiveDbAdapter.saveArchiveYoung(downloadedArchiveYoung);
+            hooks?.afterArchiveReplacement?.();
             OpLog.normal(
               'SyncHydrationService: Wrote archiveYoung to IndexedDB from sync',
             );
           }
-          if (typedData['archiveOld']) {
-            await this.archiveDbAdapter.saveArchiveOld(
-              typedData['archiveOld'] as ArchiveModel,
-            );
+          if (downloadedArchiveOld) {
+            await this.archiveDbAdapter.saveArchiveOld(downloadedArchiveOld);
+            hooks?.afterArchiveReplacement?.();
             OpLog.normal('SyncHydrationService: Wrote archiveOld to IndexedDB from sync');
           }
         }
@@ -302,26 +322,52 @@ export class SyncHydrationService {
         clockForStorage = newClock;
       }
 
-      // 9. Save new state cache (snapshot) for crash safety
-      await this.opLogStore.saveStateCache({
-        state: dataToLoad,
-        lastAppliedOpSeq: lastSeq,
-        vectorClock: clockForStorage,
-        compactedAt: Date.now(),
-      });
-      OpLog.normal('SyncHydrationService: Saved state cache after sync');
+      // 9. Commit the durable snapshot baseline before replacing live state.
+      // File snapshots include the downloaded archives and represented remote
+      // operations in this same transaction. If any write fails, the old
+      // baseline remains intact and mid-hydration local actions can safely drain
+      // against it; there is no cache-only or ops-only restart state.
+      if (createSyncImportOp) {
+        await this.opLogStore.saveStateCache({
+          state: dataToLoad,
+          lastAppliedOpSeq: lastSeq,
+          vectorClock: clockForStorage,
+          compactedAt: Date.now(),
+        });
+        hooks?.afterSnapshotCachePersisted?.();
 
-      // 10. Update vector clock store
-      // This is critical because:
-      // - The SYNC_IMPORT was appended with source='remote', so store wasn't updated
-      // - If user creates new ops in this session, incrementAndStoreVectorClock reads from store
-      // - Without this, new ops would have clocks missing entries from the SYNC_IMPORT
-      await this.opLogStore.setVectorClock(clockForStorage);
-      OpLog.normal('SyncHydrationService: Updated vector clock store after sync');
+        // The SYNC_IMPORT was appended with source='remote', so update the
+        // working clock separately on this legacy full-state-import path.
+        await this.opLogStore.setVectorClock(clockForStorage);
+      } else {
+        const appendResult = await this.opLogStore.commitFileSnapshotBaseline({
+          state: dataToLoad,
+          lastAppliedOpSeq: lastSeq,
+          vectorClock: clockForStorage,
+          compactedAt: Date.now(),
+          snapshotIncludedOps: hooks?.snapshotIncludedOps ?? [],
+          ...(downloadedArchiveYoung ? { archiveYoung: downloadedArchiveYoung } : {}),
+          ...(downloadedArchiveOld ? { archiveOld: downloadedArchiveOld } : {}),
+        });
+        if (downloadedArchiveYoung || downloadedArchiveOld) {
+          hooks?.afterArchiveReplacement?.();
+        }
+        hooks?.afterSnapshotCachePersisted?.();
+        OpLog.normal(
+          `SyncHydrationService: Atomically committed file snapshot and ` +
+            `${appendResult.writtenOps.length} included operation(s)` +
+            (appendResult.skippedCount > 0
+              ? `; skipped ${appendResult.skippedCount} duplicate(s)`
+              : ''),
+        );
+      }
+      hooks?.afterSnapshotPersisted?.();
+      OpLog.normal('SyncHydrationService: Committed snapshot persistence baseline');
 
-      // 11. Dispatch loadAllData to update NgRx
+      // 10. Dispatch loadAllData to update NgRx
       hooks?.beforeStateLoad?.();
       this.store.dispatch(loadAllData({ appDataComplete: dataToLoad }));
+      hooks?.afterStateLoad?.();
       OpLog.normal('SyncHydrationService: Dispatched loadAllData with synced data');
     } catch (e) {
       OpLog.err('SyncHydrationService: Error during hydrateFromRemoteSync', e);

--- a/src/app/op-log/persistence/sync-hydration.service.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.ts
@@ -28,6 +28,8 @@ import {
   applyLocalOnlySyncSettingsToAppData,
   stripLocalOnlySyncSettingsFromAppData,
 } from '../../features/config/local-only-sync-settings.util';
+import { LockService } from '../sync/lock.service';
+import { LOCK_NAMES } from '../core/operation-log.const';
 
 interface SnapshotHydrationHooks {
   /** Runs synchronously immediately before loadAllData replaces live NgRx state. */
@@ -57,6 +59,7 @@ export class SyncHydrationService {
   private sessionValidation = inject(SyncSessionValidationService);
   private snackService = inject(SnackService);
   private archiveDbAdapter = inject(ArchiveDbAdapter);
+  private lockService = inject(LockService);
 
   /**
    * Handles hydration after a remote sync download.
@@ -110,31 +113,35 @@ export class SyncHydrationService {
         isManualSyncOnly: currentSyncConfig.isManualSyncOnly,
       };
 
-      // 1. Write archives to IndexedDB if they were included in the downloaded data.
-      // This is critical for file-based sync where archives are bundled with the snapshot.
-      // Archives must be written BEFORE we read them back via getAllSyncModelDataFromStoreAsync().
-      // NOTE: This only happens when actually applying remote state (not during conflict
-      // detection - the downloadOps method no longer writes archives prematurely).
-      if (downloadedMainModelData) {
-        const typedData = downloadedMainModelData as Record<string, unknown>;
-        if (typedData['archiveYoung']) {
-          await this.archiveDbAdapter.saveArchiveYoung(
-            typedData['archiveYoung'] as ArchiveModel,
-          );
-          OpLog.normal('SyncHydrationService: Wrote archiveYoung to IndexedDB from sync');
+      // 1. Replace downloaded archives and read the resulting snapshot under one
+      // archive lock. Otherwise a local archive read-modify-write can start from
+      // the old archive, then save it after this replacement and silently erase
+      // downloaded entries. TASK_ARCHIVE is independent from OPERATION_LOG.
+      const dbData = await this.lockService.request(LOCK_NAMES.TASK_ARCHIVE, async () => {
+        if (downloadedMainModelData) {
+          const typedData = downloadedMainModelData as Record<string, unknown>;
+          if (typedData['archiveYoung']) {
+            await this.archiveDbAdapter.saveArchiveYoung(
+              typedData['archiveYoung'] as ArchiveModel,
+            );
+            OpLog.normal(
+              'SyncHydrationService: Wrote archiveYoung to IndexedDB from sync',
+            );
+          }
+          if (typedData['archiveOld']) {
+            await this.archiveDbAdapter.saveArchiveOld(
+              typedData['archiveOld'] as ArchiveModel,
+            );
+            OpLog.normal('SyncHydrationService: Wrote archiveOld to IndexedDB from sync');
+          }
         }
-        if (typedData['archiveOld']) {
-          await this.archiveDbAdapter.saveArchiveOld(
-            typedData['archiveOld'] as ArchiveModel,
-          );
-          OpLog.normal('SyncHydrationService: Wrote archiveOld to IndexedDB from sync');
-        }
-      }
 
-      // 2. Read archive data from IndexedDB and merge with passed entity data
-      // Entity models (task, tag, project, etc.) come from downloadedMainModelData
-      // Archive models (archiveYoung, archiveOld) come from IndexedDB (now with synced data)
-      const dbData = await this.stateSnapshotService.getAllSyncModelDataFromStoreAsync();
+        // Archives must be read after the optional replacement while the same
+        // lock is still held so the state cache and loadAllData use one view.
+        return this.stateSnapshotService.getAllSyncModelDataFromStoreAsync();
+      });
+
+      // 2. Merge the serialized archive data with passed entity data.
 
       const mergedData = downloadedMainModelData
         ? { ...dbData, ...downloadedMainModelData }

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -3446,6 +3446,53 @@ describe('FileBasedSyncAdapterService', () => {
       expect((res.snapshotState as { tasks: string[] }).tasks).toEqual(['from-bak']);
     });
 
+    it('(c2) heals a corrupt sync-state.json from its validated backup revision', async () => {
+      const snapshotClock = { client1: 1 };
+      const opsFile = makeOpsFile({
+        syncVersion: 5,
+        recentOps: [makeCompactOp()],
+        snapshotRef: { syncVersion: 1, vectorClock: snapshotClock },
+      });
+      const backup = makeStateFile({
+        syncVersion: 1,
+        vectorClock: snapshotClock,
+        state: { tasks: ['from-validated-backup'] },
+      });
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) {
+          return { dataStr: addPrefix(opsFile, 3), rev: 'ops-rev-5' };
+        }
+        if (path === C.STATE_FILE) {
+          return {
+            dataStr: addPrefix({ version: C.SPLIT_FILE_VERSION }, 3),
+            rev: 'corrupt-state-rev',
+          };
+        }
+        if (path === C.STATE_BACKUP_FILE) {
+          return { dataStr: addPrefix(backup, 3), rev: 'state-backup-rev' };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+
+      const result = await adapter.downloadOps(0, 'client2');
+
+      expect((result.snapshotState as { tasks: string[] }).tasks).toEqual([
+        'from-validated-backup',
+      ]);
+      const healCall = mockProvider.uploadFile.calls
+        .allArgs()
+        .find(([path]) => path === C.STATE_FILE);
+      expect(healCall).toBeDefined();
+      expect(healCall![2]).toBe('corrupt-state-rev');
+      expect(healCall![3]).toBeFalse();
+      const healedState = parseWithPrefix(
+        healCall![1] as string,
+      ) as unknown as FileBasedStateFile;
+      expect((healedState.state as { tasks: string[] }).tasks).toEqual([
+        'from-validated-backup',
+      ]);
+    });
+
     // (d) snapshotRef mismatch (and no usable backup) is treated as a gap.
     it('(d) snapshotRef mismatch with no backup signals a gap (full re-download)', async () => {
       const opsFile = makeOpsFile({
@@ -3984,6 +4031,63 @@ describe('FileBasedSyncAdapterService', () => {
 
       expect(stateData.syncVersion).toBe(8);
       expect((stateData.state as { tasks: string[] }).tasks).toEqual(['v8']);
+      expect((result.snapshotState as { tasks: string[] }).tasks).toEqual(['v8']);
+    });
+
+    it('(e4c) does not let a stale migration poison a newer ops backup', async () => {
+      const clock7 = { legacy: 7 };
+      const clock8 = { legacy: 8 };
+      const pendingV7 = makeOpsFile({
+        syncVersion: 7,
+        vectorClock: clock7,
+        snapshotRef: { syncVersion: 7, vectorClock: clock7 },
+        migration: { status: 'pending', legacyRev: 'legacy-rev-7' },
+      });
+      const finalizedV8 = makeOpsFile({
+        syncVersion: 8,
+        vectorClock: clock8,
+        snapshotRef: { syncVersion: 8, vectorClock: clock8 },
+      });
+      const stateV8 = makeStateFile({
+        syncVersion: 8,
+        vectorClock: clock8,
+        state: { tasks: ['v8'] },
+      });
+      const tombstone = {
+        version: C.SPLIT_FILE_VERSION,
+        format: C.SPLIT_TOMBSTONE_FORMAT,
+        migratedAt: Date.now(),
+        note: 'newer migration already committed',
+      };
+      let opsDownloads = 0;
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) {
+          opsDownloads++;
+          const data = opsDownloads === 1 ? pendingV7 : finalizedV8;
+          return {
+            dataStr: addPrefix(data, 3),
+            rev: opsDownloads === 1 ? 'ops-rev-7' : 'ops-rev-8',
+          };
+        }
+        if (path === C.OPS_BACKUP_FILE) {
+          return { dataStr: addPrefix(finalizedV8, 3), rev: 'ops-backup-rev-8' };
+        }
+        if (path === C.SYNC_FILE) {
+          return { dataStr: addPrefix(tombstone, 3), rev: 'legacy-tombstone-rev' };
+        }
+        if (path === C.STATE_FILE) {
+          return { dataStr: addPrefix(stateV8, 3), rev: 'state-rev-8' };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+
+      const result = await adapter.downloadOps(0, 'client2');
+
+      expect(
+        mockProvider.uploadFile.calls
+          .allArgs()
+          .some(([path]) => path === C.OPS_BACKUP_FILE),
+      ).toBeFalse();
       expect((result.snapshotState as { tasks: string[] }).tasks).toEqual(['v8']);
     });
 

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -804,6 +804,55 @@ describe('FileBasedSyncAdapterService', () => {
         jasmine.any(SyncDataCorruptedError),
       );
     });
+
+    it('should recover a structurally malformed v2 primary from its backup', async () => {
+      const backup = createMockSyncData({
+        syncVersion: 4,
+        recentOps: [
+          {
+            id: 'op-from-structural-backup',
+            c: 'client1',
+            a: 'HA',
+            o: 'ADD',
+            e: 'TASK',
+            d: 'task-1',
+            v: { client1: 4 },
+            t: Date.now(),
+            s: 1,
+            p: {},
+            sv: 4,
+          },
+        ],
+      });
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+          return { dataStr: addPrefix(backup), rev: 'backup-rev' };
+        }
+        return { dataStr: addPrefix({ version: 2 }), rev: 'malformed-primary-rev' };
+      });
+
+      const result = await adapter.downloadOps(0);
+
+      expect(result.ops.map(({ op }) => op.id)).toContain('op-from-structural-backup');
+    });
+
+    it('should keep reading legacy v2 files that predate schemaVersion', async () => {
+      const legacy = createMockSyncData({
+        syncVersion: 3,
+        state: { tasks: ['legacy-without-schema-version'] },
+      });
+      delete (legacy as Partial<FileBasedSyncData>).schemaVersion;
+      mockProvider.downloadFile.and.resolveTo({
+        dataStr: addPrefix(legacy),
+        rev: 'legacy-rev',
+      });
+
+      const result = await adapter.downloadOps(0);
+
+      expect(result.snapshotState).toEqual({
+        tasks: ['legacy-without-schema-version'],
+      });
+    });
   });
 
   describe('getLastServerSeq / setLastServerSeq', () => {
@@ -1010,7 +1059,7 @@ describe('FileBasedSyncAdapterService', () => {
         expect(result.gapDetected).toBe(true);
       });
 
-      it('does not commit reset metadata when snapshot application is cancelled', async () => {
+      it('keeps a cancelled reset unresolved after restart when the remote counter catches up', async () => {
         const compactOp = (
           id: string,
           clock: Record<string, number>,
@@ -1053,17 +1102,32 @@ describe('FileBasedSyncAdapterService', () => {
         await adapter.downloadOps(0, 'local-client');
         // No setLastServerSeq: the user cancelled applying the remote snapshot.
 
+        const freshService = TestBed.runInInjectionContext(
+          () => new FileBasedSyncAdapterService(),
+        );
+        const freshAdapter = freshService.createAdapter(
+          mockProvider,
+          mockCfg,
+          mockEncryptKey,
+        );
+
         const remoteAfterCancel = createMockSyncData({
-          syncVersion: 2,
-          vectorClock: { reset: 2 },
-          recentOps: [compactOp('op-after-reset', { reset: 2 }, 2)],
+          // The reset counter has caught back up to the committed cursor. None of
+          // the ordinary reset checks can distinguish this suffix from a
+          // continuous history, so the cancelled gap must remain latched.
+          syncVersion: 5,
+          vectorClock: { reset: 5 },
+          recentOps: [2, 3, 4, 5].map((version) =>
+            compactOp(`op-after-reset-${version}`, { reset: version }, version),
+          ),
+          oldestOpSyncVersion: 2,
           state: { tasks: [{ id: 'remote-reset' }] },
         });
         mockProvider.downloadFile.and.returnValue(
-          Promise.resolve({ dataStr: addPrefix(remoteAfterCancel), rev: 'rev-reset-2' }),
+          Promise.resolve({ dataStr: addPrefix(remoteAfterCancel), rev: 'rev-reset-5' }),
         );
 
-        const result = await adapter.downloadOps(5, 'local-client');
+        const result = await freshAdapter.downloadOps(5, 'local-client');
 
         expect(result.gapDetected).toBe(true);
       });
@@ -3207,7 +3271,7 @@ describe('FileBasedSyncAdapterService', () => {
       expect(result.snapshotState).toBeDefined();
     });
 
-    it('(a5) split download keeps reset metadata pending when snapshot application is cancelled', async () => {
+    it('(a5) split download keeps a cancelled reset unresolved after the counter catches up', async () => {
       routeDownloads({
         [C.OPS_FILE]: addPrefix(
           makeOpsFile({
@@ -3241,19 +3305,29 @@ describe('FileBasedSyncAdapterService', () => {
       await adapter.downloadOps(0, 'local-client');
       // No setLastServerSeq: the user cancelled applying the remote snapshot.
 
-      const advancedClock = { reset: 2 };
+      const freshService = TestBed.runInInjectionContext(
+        () => new FileBasedSyncAdapterService(),
+      );
+      const freshAdapter = freshService.createAdapter(
+        mockProvider,
+        mockCfg,
+        mockEncryptKey,
+      );
+
+      const advancedClock = { reset: 5 };
       routeDownloads({
         [C.OPS_FILE]: addPrefix(
           makeOpsFile({
-            syncVersion: 2,
+            syncVersion: 5,
             vectorClock: advancedClock,
-            recentOps: [
+            recentOps: [2, 3, 4, 5].map((version) =>
               makeCompactOp({
-                id: 'op-after-reset',
-                sv: 2,
-                v: advancedClock,
+                id: `op-after-reset-${version}`,
+                sv: version,
+                v: { reset: version },
               }),
-            ],
+            ),
+            oldestOpSyncVersion: 2,
             snapshotRef: { syncVersion: 1, vectorClock: resetClock },
           }),
           3,
@@ -3264,7 +3338,7 @@ describe('FileBasedSyncAdapterService', () => {
         ),
       });
 
-      const result = await adapter.downloadOps(5, 'local-client');
+      const result = await freshAdapter.downloadOps(5, 'local-client');
 
       expect(result.gapDetected).toBe(true);
     });
@@ -3272,7 +3346,9 @@ describe('FileBasedSyncAdapterService', () => {
     // (b) compaction triggers when the buffer exceeds MAX_RECENT_OPS, writing
     // state THEN ops.
     it('(b) compaction past MAX_RECENT_OPS writes sync-state.json BEFORE sync-ops.json', async () => {
-      const many = Array.from({ length: C.MAX_RECENT_OPS }, () => ({ sv: 1 }) as never);
+      const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
+        makeCompactOp({ id: `op-${index}`, sv: 1 }),
+      );
       const opsFile = makeOpsFile({ syncVersion: 5, recentOps: many });
       routeDownloads({
         [C.OPS_FILE]: addPrefix(opsFile, 3),
@@ -3290,6 +3366,15 @@ describe('FileBasedSyncAdapterService', () => {
       expect(opsIdx).toBeGreaterThanOrEqual(0);
       // sync-state.json is written before the ops file that references it.
       expect(stateIdx).toBeLessThan(opsIdx);
+
+      const stateUpload = mockProvider.uploadFile.calls
+        .allArgs()
+        .find((args) => args[0] === C.STATE_FILE);
+      expect(stateUpload).toBeDefined();
+      // A second compactor may have published a newer snapshot after this one
+      // read the old state. Replace only the exact revision that was backed up.
+      expect(stateUpload![2]).toBe(`${C.STATE_FILE}-rev`);
+      expect(stateUpload![3]).toBe(false);
     });
 
     // (b2) Review regression: once the folder is past SPLIT_COMPACTION_THRESHOLD but
@@ -3299,7 +3384,9 @@ describe('FileBasedSyncAdapterService', () => {
     it('(b2) does NOT recompact on every op-bearing sync between the threshold and the cap', async () => {
       // Buffer sits between the trim target (1000) and the trigger (2000).
       const between = C.SPLIT_COMPACTION_THRESHOLD + 200;
-      let recentOps = Array.from({ length: between }, () => ({ sv: 1 }) as never);
+      let recentOps = Array.from({ length: between }, (_, index) =>
+        makeCompactOp({ id: `op-${index}`, sv: 1 }),
+      );
 
       // Two consecutive op-bearing syncs, each appending one op (1201, then 1202) —
       // both still under MAX_RECENT_OPS, so neither may rebuild the snapshot.
@@ -3310,7 +3397,10 @@ describe('FileBasedSyncAdapterService', () => {
           [C.STATE_FILE]: addPrefix(makeStateFile({ syncVersion: 1 }), 3),
         });
         await adapter.uploadOps([createMockSyncOp()], 'client1');
-        recentOps = [...recentOps, { sv: 1 } as never];
+        recentOps = [
+          ...recentOps,
+          makeCompactOp({ id: `op-${recentOps.length}`, sv: 1 }),
+        ];
       }
 
       // At most one snapshot build across both syncs — ideally zero here.
@@ -3437,6 +3527,21 @@ describe('FileBasedSyncAdapterService', () => {
         version: number;
       };
       expect(bak.version).toBe(C.SPLIT_FILE_VERSION);
+
+      // Finalizing the marker rewrites the hot ops file after both legacy
+      // recovery files are tombstoned. Preserve the pending marker first so a
+      // torn final write can be recovered and resumed on the next sync.
+      const pendingRecoveryBakIdx = mockProvider.uploadFile.calls
+        .allArgs()
+        .findIndex((args) => {
+          if (args[0] !== C.OPS_BACKUP_FILE) return false;
+          const backup = parseWithPrefix(
+            args[1] as string,
+          ) as unknown as FileBasedOpsFile;
+          return backup.migration?.status === 'pending';
+        });
+      expect(pendingRecoveryBakIdx).toBeGreaterThan(tombIdx);
+      expect(pendingRecoveryBakIdx).toBeLessThan(finalizedOpsIdx);
     });
 
     it('(e2) resumes a pending migration marker after restart before appending ops', async () => {
@@ -3523,6 +3628,43 @@ describe('FileBasedSyncAdapterService', () => {
         .map((args) => parseWithPrefix(args[1] as string) as unknown as FileBasedOpsFile)
         .find((opsFile) => opsFile.migration === undefined);
       expect(finalizedMarker).toBeDefined();
+    });
+
+    it('(e2bb) aborts finalization when the last recoverable pending-marker backup fails', async () => {
+      const clock = { client1: 7 };
+      const pendingOps = makeOpsFile({
+        syncVersion: 7,
+        vectorClock: clock,
+        snapshotRef: { syncVersion: 7, vectorClock: clock },
+        migration: {
+          status: 'pending',
+          legacyRev: 'legacy-rev-7',
+        },
+      });
+      const tombstone = {
+        version: C.SPLIT_FILE_VERSION,
+        format: C.SPLIT_TOMBSTONE_FORMAT,
+        migratedAt: Date.now(),
+        note: 'migration already tombstoned legacy data',
+      };
+      routeDownloads({
+        [C.SYNC_FILE]: addPrefix(tombstone, 3),
+        [C.OPS_FILE]: addPrefix(pendingOps, 3),
+      });
+      mockProvider.uploadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_BACKUP_FILE) {
+          throw new Error('backup unavailable');
+        }
+        return { rev: `${path}-rev-new` };
+      });
+
+      await expectAsync(adapter.downloadOps(0, 'client2')).toBeRejectedWithError(
+        'backup unavailable',
+      );
+
+      expect(
+        mockProvider.uploadFile.calls.allArgs().some(([path]) => path === C.OPS_FILE),
+      ).toBeFalse();
     });
 
     it('(e2c) rebuilds a matching-revision pending marker from the legacy source before tombstoning', async () => {
@@ -3658,6 +3800,191 @@ describe('FileBasedSyncAdapterService', () => {
       expect(finalOps.migration).toBeUndefined();
       expect(finalOps.recentOps.some((op) => op.id === 'legacy-v8')).toBe(true);
       expect(finalOps.recentOps.some((op) => op.id === 'op-123')).toBe(true);
+    });
+
+    it('(e4) prevents a stale migrator from overwriting a newer committed snapshot', async () => {
+      const clock7 = { legacy: 7 };
+      const clock8 = { legacy: 8 };
+      const legacyV7 = createMockSyncData({
+        syncVersion: 7,
+        vectorClock: clock7,
+        state: { tasks: ['v7'] },
+      });
+      const pendingV7 = makeOpsFile({
+        syncVersion: 7,
+        vectorClock: clock7,
+        snapshotRef: { syncVersion: 7, vectorClock: clock7 },
+        migration: { status: 'pending', legacyRev: 'legacy-rev-7' },
+      });
+      const pendingV8 = makeOpsFile({
+        syncVersion: 8,
+        vectorClock: clock8,
+        snapshotRef: { syncVersion: 8, vectorClock: clock8 },
+        migration: { status: 'pending', legacyRev: 'legacy-rev-8' },
+      });
+      const stateV8 = makeStateFile({
+        syncVersion: 8,
+        vectorClock: clock8,
+        state: { tasks: ['v8'] },
+      });
+      const tombstone = {
+        version: C.SPLIT_FILE_VERSION,
+        format: C.SPLIT_TOMBSTONE_FORMAT,
+        migratedAt: Date.now(),
+        note: 'split migration complete',
+      };
+
+      let legacyData: unknown = legacyV7;
+      let legacyRev = 'legacy-rev-7';
+      let legacyIsTombstone = false;
+      let opsData: FileBasedOpsFile = pendingV7;
+      let opsRev = 'ops-rev-7';
+      let stateData = makeStateFile({
+        syncVersion: 6,
+        vectorClock: { legacy: 6 },
+        state: { tasks: ['v6'] },
+      });
+      let stateRev = 'state-rev-6';
+      let simulatedNewerMigrator = false;
+      let revCounter = 10;
+
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.SYNC_FILE) {
+          return {
+            dataStr: addPrefix(legacyData, legacyIsTombstone ? 3 : 2),
+            rev: legacyRev,
+          };
+        }
+        if (path === C.OPS_FILE) {
+          return { dataStr: addPrefix(opsData, 3), rev: opsRev };
+        }
+        if (path === C.STATE_FILE) {
+          return { dataStr: addPrefix(stateData, 3), rev: stateRev };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+      mockProvider.uploadFile.and.callFake(
+        async (
+          path: string,
+          dataStr: string,
+          revToMatch: string | null,
+          isForceOverwrite?: boolean,
+        ) => {
+          if (path === C.STATE_FILE) {
+            const incoming = parseWithPrefix(dataStr) as unknown as FileBasedStateFile;
+            if (incoming.syncVersion === 7 && !simulatedNewerMigrator) {
+              // Another client advances and completes migration after this stale
+              // client read v7 but before its state write reaches the provider.
+              simulatedNewerMigrator = true;
+              opsData = pendingV8;
+              opsRev = 'ops-rev-8';
+              stateData = stateV8;
+              stateRev = 'state-rev-8';
+              legacyData = tombstone;
+              legacyRev = 'legacy-tombstone-rev';
+              legacyIsTombstone = true;
+            }
+            if (!isForceOverwrite && revToMatch !== stateRev) {
+              throw new UploadRevToMatchMismatchAPIError();
+            }
+            stateData = incoming;
+            stateRev = `state-rev-${++revCounter}`;
+            return { rev: stateRev };
+          }
+          if (path === C.OPS_FILE) {
+            if (!isForceOverwrite && revToMatch !== opsRev) {
+              throw new UploadRevToMatchMismatchAPIError();
+            }
+            opsData = parseWithPrefix(dataStr) as unknown as FileBasedOpsFile;
+            opsRev = `ops-rev-${++revCounter}`;
+            return { rev: opsRev };
+          }
+          if (path === C.SYNC_FILE) {
+            if (!isForceOverwrite && revToMatch !== legacyRev) {
+              throw new UploadRevToMatchMismatchAPIError();
+            }
+            legacyData = parseWithPrefix(dataStr);
+            legacyRev = `legacy-rev-${++revCounter}`;
+            legacyIsTombstone = true;
+            return { rev: legacyRev };
+          }
+          return { rev: `${path}-rev-${++revCounter}` };
+        },
+      );
+
+      const result = await adapter.downloadOps(0, 'client2');
+
+      expect(stateData.syncVersion).toBe(8);
+      expect((stateData.state as { tasks: string[] }).tasks).toEqual(['v8']);
+      expect((result.snapshotState as { tasks: string[] }).tasks).toEqual(['v8']);
+    });
+
+    it('(e4b) rechecks the ops marker when a newer migration state already exists', async () => {
+      const clock7 = { legacy: 7 };
+      const clock8 = { legacy: 8 };
+      const legacyV7 = createMockSyncData({
+        syncVersion: 7,
+        vectorClock: clock7,
+        state: { tasks: ['v7'] },
+      });
+      const pendingV7 = makeOpsFile({
+        syncVersion: 7,
+        vectorClock: clock7,
+        snapshotRef: { syncVersion: 7, vectorClock: clock7 },
+        migration: { status: 'pending', legacyRev: 'legacy-rev-7' },
+      });
+      const pendingV8 = makeOpsFile({
+        syncVersion: 8,
+        vectorClock: clock8,
+        snapshotRef: { syncVersion: 8, vectorClock: clock8, rev: 'state-rev-8' },
+        migration: { status: 'pending', legacyRev: 'legacy-rev-8' },
+      });
+      const stateV8 = makeStateFile({
+        syncVersion: 8,
+        vectorClock: clock8,
+        state: { tasks: ['v8'] },
+      });
+      const tombstone = {
+        version: C.SPLIT_FILE_VERSION,
+        format: C.SPLIT_TOMBSTONE_FORMAT,
+        migratedAt: Date.now(),
+        note: 'newer migrator completed the legacy tombstone',
+      };
+      let opsDownloads = 0;
+      let syncDownloads = 0;
+      let stateData = stateV8;
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) {
+          opsDownloads++;
+          const data = opsDownloads === 1 ? pendingV7 : pendingV8;
+          return {
+            dataStr: addPrefix(data, 3),
+            rev: opsDownloads === 1 ? 'ops-rev-7' : 'ops-rev-8',
+          };
+        }
+        if (path === C.SYNC_FILE) {
+          syncDownloads++;
+          return syncDownloads === 1
+            ? { dataStr: addPrefix(legacyV7, 2), rev: 'legacy-rev-7' }
+            : { dataStr: addPrefix(tombstone, 3), rev: 'legacy-tombstone-rev' };
+        }
+        if (path === C.STATE_FILE) {
+          return { dataStr: addPrefix(stateData, 3), rev: 'state-rev-8' };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+      mockProvider.uploadFile.and.callFake(async (path: string, dataStr: string) => {
+        if (path === C.STATE_FILE) {
+          stateData = parseWithPrefix(dataStr) as unknown as FileBasedStateFile;
+        }
+        return { rev: `${path}-rev-new` };
+      });
+
+      const result = await adapter.downloadOps(0, 'client2');
+
+      expect(stateData.syncVersion).toBe(8);
+      expect((stateData.state as { tasks: string[] }).tasks).toEqual(['v8']);
+      expect((result.snapshotState as { tasks: string[] }).tasks).toEqual(['v8']);
     });
 
     // (f) setting-OFF client seeing the tombstone raises the actionable notice
@@ -3825,6 +4152,42 @@ describe('FileBasedSyncAdapterService', () => {
       await adapter.uploadOps([createMockSyncOp()], 'client1');
       expect(opsRevToMatch).toContain('corrupt-ops-rev');
       expect(opsRevToMatch).not.toContain('ops-bak-rev');
+    });
+
+    it('(i) recovers a structurally malformed sync-ops.json from .bak', async () => {
+      const backup = makeOpsFile({
+        syncVersion: 4,
+        recentOps: [makeCompactOp({ id: 'op-from-structural-backup', sv: 4 })],
+      });
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) {
+          return { dataStr: addPrefix({ version: 3 }, 3), rev: 'malformed-ops-rev' };
+        }
+        if (path === C.OPS_BACKUP_FILE) {
+          return { dataStr: addPrefix(backup, 3), rev: 'ops-backup-rev' };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+
+      const result = await adapter.downloadOps(1, 'client2');
+
+      expect(result.ops.map(({ op }) => op.id)).toContain('op-from-structural-backup');
+    });
+
+    it('(i) rejects a structurally malformed ops backup with the original corruption error', async () => {
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) {
+          return { dataStr: addPrefix({ version: 3 }, 3), rev: 'malformed-ops-rev' };
+        }
+        if (path === C.OPS_BACKUP_FILE) {
+          return { dataStr: addPrefix({ version: 3 }, 3), rev: 'malformed-bak-rev' };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+
+      await expectAsync(adapter.downloadOps(1, 'client2')).toBeRejectedWith(
+        jasmine.any(SyncDataCorruptedError),
+      );
     });
 
     it('(i) split .bak recovery never promotes the corrupt ops rev to last-seen (heal cannot wedge)', async () => {

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -1398,20 +1398,17 @@ describe('FileBasedSyncAdapterService', () => {
         ) as unknown as FileBasedSyncData;
         expect(primary.clientId).toBe('newClient');
         // Writes: 1 = pending marker, 2 = .bak, 3 = primary, 4 = complete marker.
-        // A crash BEFORE the primary write (1, 2) is recovered by promoting the
-        // pending payload (marker → complete). A crash AT/AFTER the primary
-        // write (3) leaves the primary already advanced past the marker's
-        // basePrimaryRev, so recovery must NOT re-promote (a marker-unaware
-        // client could have written in between) — the marker is abandoned while
-        // the already-committed primary stays authoritative. A crash after the
-        // complete write (4) needs no recovery.
+        // A crash before the primary write promotes the pending payload. A
+        // crash after it recognizes the exact encoded payload now at the new
+        // revision and completes the marker; a different payload would be
+        // abandoned as a concurrent commit.
         expect(
           JSON.parse(
             files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
           ),
         ).toEqual(
           jasmine.objectContaining({
-            status: crashAfterWrite === 3 ? 'aborted' : 'complete',
+            status: 'complete',
           }),
         );
 
@@ -1628,6 +1625,20 @@ describe('FileBasedSyncAdapterService', () => {
       return files;
     };
 
+    const createFreshAdapter = (): OperationSyncCapable => {
+      const freshService = TestBed.runInInjectionContext(
+        () => new FileBasedSyncAdapterService(),
+      );
+      return freshService.createAdapter(mockProvider, mockCfg, mockEncryptKey);
+    };
+
+    const digestEncodedPayload = async (encoded: string): Promise<string> =>
+      (
+        service as unknown as {
+          _digestEncodedPayload: (value: string) => Promise<string>;
+        }
+      )._digestEncodedPayload(encoded);
+
     it('abandons a stale pending snapshot instead of clobbering newer committed data', async () => {
       // Device A began a "Use Local" transaction at basePrimaryRev and crashed.
       // A marker-unaware client then committed days of work (primary advanced).
@@ -1679,6 +1690,325 @@ describe('FileBasedSyncAdapterService', () => {
         ),
       ).toEqual(
         jasmine.objectContaining({ status: 'aborted', transactionId: 'stale-tx' }),
+      );
+    });
+
+    it('abandons a pending snapshot when its primary was deleted', async () => {
+      const encodedPending = addPrefix(
+        createMockSyncData({
+          syncVersion: 2,
+          vectorClock: { pendingClient: 2 },
+          clientId: 'pendingClient',
+        }),
+      );
+      const files = installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'pending',
+              transactionId: 'deleted-primary',
+              basePrimaryRev: 'deleted-primary-rev',
+              encodedSnapshot: encodedPending,
+            }),
+            rev: 'marker-rev',
+          },
+        ],
+      ]);
+
+      const result = await adapter.downloadOps(0);
+
+      expect(result.latestSeq).toBe(0);
+      expect(
+        JSON.parse(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+        ),
+      ).toEqual(
+        jasmine.objectContaining({
+          status: 'aborted',
+          transactionId: 'deleted-primary',
+        }),
+      );
+    });
+
+    it('completes an already committed pending snapshot before a backup refresh failure', async () => {
+      const encodedPending = addPrefix(
+        createMockSyncData({
+          syncVersion: 2,
+          vectorClock: { pendingClient: 2 },
+          clientId: 'pendingClient',
+        }),
+      );
+      const files = installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          { dataStr: encodedPending, rev: 'committed-primary-rev' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'pending',
+              transactionId: 'already-committed',
+              basePrimaryRev: 'primary-at-begin',
+              encodedSnapshot: encodedPending,
+            }),
+            rev: 'marker-rev',
+          },
+        ],
+      ]);
+      let nextRev = 0;
+      mockProvider.uploadFile.and.callFake(
+        async (
+          path: string,
+          dataStr: string,
+          revToMatch: string | null,
+          isForceOverwrite = false,
+        ) => {
+          if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+            throw new Error('backup refresh unavailable');
+          }
+          const current = files.get(path);
+          if (
+            !isForceOverwrite &&
+            (revToMatch === null ? current !== undefined : current?.rev !== revToMatch)
+          ) {
+            throw new UploadRevToMatchMismatchAPIError();
+          }
+          const rev = `${path}-rev-${++nextRev}`;
+          files.set(path, { dataStr, rev });
+          return { rev };
+        },
+      );
+
+      const result = await adapter.downloadOps(0);
+
+      expect(result.latestSeq).toBe(2);
+      expect(
+        JSON.parse(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+        ),
+      ).toEqual(
+        jasmine.objectContaining({
+          status: 'complete',
+          transactionId: 'already-committed',
+        }),
+      );
+    });
+
+    it('inherits every rejected digest when an aborted snapshot is replaced', async () => {
+      const encodedA = addPrefix(
+        createMockSyncData({
+          syncVersion: 2,
+          vectorClock: { staleA: 2 },
+          clientId: 'staleA',
+        }),
+      );
+      const digestA = await digestEncodedPayload(encodedA);
+      const files = installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          { dataStr: addPrefix(createMockSyncData()), rev: 'primary-rev' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+          { dataStr: encodedA, rev: 'stale-a-backup-rev' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'aborted',
+              transactionId: 'aborted-a',
+              snapshotDigest: digestA,
+              stateDigest: 'state-a',
+              rejectedSnapshotDigests: ['snapshot-before-a'],
+              rejectedStateDigests: ['state-before-a'],
+            }),
+            rev: 'aborted-a-rev',
+          },
+        ],
+      ]);
+
+      await adapter.uploadSnapshot(
+        {},
+        'snapshot-b',
+        'recovery',
+        { snapshotB: 1 },
+        1,
+        undefined,
+        'snapshot-b-op',
+      );
+
+      const pendingB = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+        .map(([, dataStr]) => JSON.parse(dataStr as string) as Record<string, unknown>)
+        .find((marker) => marker['status'] === 'pending')!;
+      expect(pendingB['rejectedSnapshotDigests']).toEqual(['snapshot-before-a', digestA]);
+      expect(pendingB['rejectedStateDigests']).toEqual(['state-before-a', 'state-a']);
+      const completedB = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+        .map(([, dataStr]) => JSON.parse(dataStr as string) as Record<string, unknown>)
+        .find((marker) => marker['status'] === 'complete')!;
+      expect(completedB['rejectedSnapshotDigests']).toEqual([
+        'snapshot-before-a',
+        digestA,
+      ]);
+      expect(completedB['rejectedStateDigests']).toEqual(['state-before-a', 'state-a']);
+
+      files.set(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE, {
+        dataStr: JSON.stringify(pendingB),
+        rev: 'pending-b-rev',
+      });
+      files.set(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE, {
+        dataStr: addPrefix(
+          createMockSyncData({
+            syncVersion: 3,
+            vectorClock: { concurrentClient: 3 },
+            clientId: 'concurrentClient',
+          }),
+        ),
+        rev: 'concurrent-primary-rev',
+      });
+      mockProvider.uploadFile.calls.reset();
+
+      await createFreshAdapter().downloadOps(0);
+
+      const abortedB = JSON.parse(
+        files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+      ) as Record<string, unknown>;
+      expect(abortedB['status']).toBe('aborted');
+      expect(abortedB['rejectedSnapshotDigests']).toEqual(['snapshot-before-a', digestA]);
+      expect(abortedB['rejectedStateDigests']).toEqual(['state-before-a', 'state-a']);
+
+      files.set(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE, {
+        dataStr:
+          getSyncFilePrefix({
+            isCompress: true,
+            isEncrypt: false,
+            modelVersion: 2,
+          }) + 'not-valid-gzip',
+        rev: 'corrupt-primary-rev',
+      });
+
+      await expectAsync(createFreshAdapter().downloadOps(0)).toBeRejected();
+    });
+
+    it('does not abort a valid encrypted pending snapshot when the key is wrong', async () => {
+      const encryptedCfg: EncryptAndCompressCfg = {
+        isEncrypt: true,
+        isCompress: false,
+      };
+      const pendingData = createMockSyncData({
+        syncVersion: 1,
+        vectorClock: { pendingClient: 1 },
+        clientId: 'pendingClient',
+      });
+      const encodedPending = await (
+        service as unknown as {
+          _encryptAndCompressHandler: {
+            compressAndEncryptData: (
+              cfg: EncryptAndCompressCfg,
+              key: string,
+              data: unknown,
+              version: number,
+            ) => Promise<string>;
+          };
+        }
+      )._encryptAndCompressHandler.compressAndEncryptData(
+        encryptedCfg,
+        'correct-password',
+        pendingData,
+        FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+      );
+      const files = installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          { dataStr: addPrefix(createMockSyncData()), rev: 'primary-rev' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'pending',
+              transactionId: 'encrypted-pending',
+              basePrimaryRev: 'primary-rev',
+              encodedSnapshot: encodedPending,
+            }),
+            rev: 'marker-rev',
+          },
+        ],
+      ]);
+      const wrongKeyAdapter = service.createAdapter(
+        mockProvider,
+        encryptedCfg,
+        'wrong-password',
+      );
+
+      await expectAsync(wrongKeyAdapter.downloadOps(0)).toBeRejected();
+
+      expect(
+        JSON.parse(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+        ),
+      ).toEqual(jasmine.objectContaining({ status: 'pending' }));
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('refuses an abandoned snapshot payload left in the rolling backup', async () => {
+      const staleSnapshot = createMockSyncData({
+        syncVersion: 1,
+        vectorClock: { staleClient: 1 },
+        clientId: 'staleClient',
+      });
+      const encodedStale = addPrefix(staleSnapshot);
+      const corruptPrimary =
+        getSyncFilePrefix({ isCompress: true, isEncrypt: false, modelVersion: 2 }) +
+        'not-valid-gzip';
+      const files = installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          { dataStr: corruptPrimary, rev: 'newer-primary-rev' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+          { dataStr: encodedStale, rev: 'stale-backup-rev' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'pending',
+              transactionId: 'stale-pending',
+              basePrimaryRev: 'old-primary-rev',
+              encodedSnapshot: encodedStale,
+            }),
+            rev: 'marker-rev',
+          },
+        ],
+      ]);
+
+      await expectAsync(adapter.downloadOps(0)).toBeRejected();
+
+      expect(
+        JSON.parse(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+        ),
+      ).toEqual(
+        jasmine.objectContaining({
+          status: 'aborted',
+          snapshotDigest: jasmine.any(String),
+        }),
+      );
+      expect(files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.rev).toBe(
+        'newer-primary-rev',
       );
     });
 
@@ -3395,7 +3725,7 @@ describe('FileBasedSyncAdapterService', () => {
       expect(result.gapDetected).toBeFalsy();
     });
 
-    it('(a2) an unchanged-rev poll performs no snapshot-transaction marker request', async () => {
+    it('(a2) an unchanged-rev poll checks snapshot recovery before returning early', async () => {
       const syncData = createMockSyncData({ syncVersion: 2, recentOps: [] });
       mockProvider.downloadFile.and.returnValue(
         Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-1' }),
@@ -3413,11 +3743,11 @@ describe('FileBasedSyncAdapterService', () => {
 
       await adapter.downloadOps(2);
 
-      // The whole idle poll costs exactly ONE metadata request: the cheap rev
-      // pre-check runs BEFORE the marker read, so an unchanged remote skips the
-      // marker GET entirely (previously every poll paid 2+ round trips).
+      // Recovery intent cannot remain hidden behind an unchanged primary rev.
       expect(mockProvider.getFileRev.calls.count()).toBe(1);
-      expect(mockProvider.downloadFile.calls.count()).toBe(0);
+      expect(mockProvider.downloadFile).toHaveBeenCalledOnceWith(
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+      );
     });
 
     it('(b) proceeds with the full download when the remote rev changed', async () => {
@@ -3748,6 +4078,10 @@ describe('FileBasedSyncAdapterService', () => {
         throw new RemoteFileNotFoundAPIError(path);
       };
       mockProvider.downloadFile.and.callFake(downloadByPath);
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path in map) return { rev: `${path}-rev` };
+        throw new RemoteFileNotFoundAPIError(path);
+      });
       for (const markerPath of [
         C.SNAPSHOT_TRANSACTION_FILE,
         C.OPS_SNAPSHOT_TRANSACTION_FILE,
@@ -3845,6 +4179,13 @@ describe('FileBasedSyncAdapterService', () => {
       );
       return freshService.createAdapter(mockProvider, mockCfg, mockEncryptKey);
     };
+
+    const digestEncodedPayload = async (encoded: string): Promise<string> =>
+      (
+        service as unknown as {
+          _digestEncodedPayload: (value: string) => Promise<string>;
+        }
+      )._digestEncodedPayload(encoded);
 
     beforeEach(() => {
       splitSyncEnabled = true;
@@ -4146,6 +4487,137 @@ describe('FileBasedSyncAdapterService', () => {
       expect(stateUpload![3]).toBe(false);
     });
 
+    it('(b1) recovers transactional compaction after every publication write', async () => {
+      for (let crashAfterWrite = 1; crashAfterWrite <= 7; crashAfterWrite++) {
+        const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
+          makeCompactOp({ id: `op-${index}`, sv: 5 }),
+        );
+        const committedClock = { client1: 1 };
+        const remote = installStatefulCasRemote(createMockSyncData(), crashAfterWrite);
+        remote.files.delete(C.SYNC_FILE);
+        remote.files.set(C.OPS_FILE, {
+          dataStr: addPrefix(
+            makeOpsFile({
+              syncVersion: 5,
+              vectorClock: committedClock,
+              recentOps: many,
+              snapshotRef: { syncVersion: 1, vectorClock: committedClock },
+            }),
+            3,
+          ),
+          rev: 'ops-before-compaction',
+        });
+        remote.files.set(C.STATE_FILE, {
+          dataStr: addPrefix(
+            makeStateFile({ syncVersion: 1, vectorClock: committedClock }),
+            3,
+          ),
+          rev: 'state-before-compaction',
+        });
+
+        await expectAsync(
+          createFreshAdapter().uploadOps(
+            [
+              createMockSyncOp({
+                id: `compaction-op-${crashAfterWrite}`,
+                vectorClock: { client1: 2 },
+              }),
+            ],
+            'compactor-a',
+          ),
+        ).toBeRejectedWithError(
+          `simulated process crash after remote write ${crashAfterWrite}`,
+        );
+
+        remote.disableCrash();
+        const recovered = await createFreshAdapter().downloadOps(0);
+
+        expect(recovered.latestSeq).toBe(6);
+        expect(
+          JSON.parse(remote.files.get(C.OPS_SNAPSHOT_TRANSACTION_FILE)!.dataStr),
+        ).toEqual(jasmine.objectContaining({ status: 'complete' }));
+        const recoveredOps = parseWithPrefix(
+          remote.files.get(C.OPS_FILE)!.dataStr,
+        ) as unknown as FileBasedOpsFile;
+        const recoveredState = parseWithPrefix(
+          remote.files.get(C.STATE_FILE)!.dataStr,
+        ) as unknown as FileBasedStateFile;
+        expect(recoveredOps.syncVersion).toBe(6);
+        expect(recoveredState.syncVersion).toBe(6);
+
+        mockProvider.downloadFile.calls.reset();
+        mockProvider.uploadFile.calls.reset();
+      }
+    });
+
+    it('(b1) completes compactor A instead of letting compactor B replace its in-flight state', async () => {
+      const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
+        makeCompactOp({ id: `op-${index}`, sv: 5 }),
+      );
+      const committedClock = { client1: 1 };
+      const remote = installStatefulCasRemote(createMockSyncData(), 3);
+      remote.files.delete(C.SYNC_FILE);
+      remote.files.set(C.OPS_FILE, {
+        dataStr: addPrefix(
+          makeOpsFile({
+            syncVersion: 5,
+            vectorClock: committedClock,
+            recentOps: many,
+            snapshotRef: { syncVersion: 1, vectorClock: committedClock },
+          }),
+          3,
+        ),
+        rev: 'ops-before-compaction',
+      });
+      remote.files.set(C.STATE_FILE, {
+        dataStr: addPrefix(
+          makeStateFile({ syncVersion: 1, vectorClock: committedClock }),
+          3,
+        ),
+        rev: 'state-before-compaction',
+      });
+
+      await expectAsync(
+        createFreshAdapter().uploadOps(
+          [
+            createMockSyncOp({
+              id: 'compactor-a-op',
+              vectorClock: { client1: 2 },
+            }),
+          ],
+          'compactor-a',
+        ),
+      ).toBeRejectedWithError('simulated process crash after remote write 3');
+      const statePublishedByA = remote.files.get(C.STATE_FILE)!;
+      expect(
+        (parseWithPrefix(statePublishedByA.dataStr) as unknown as FileBasedStateFile)
+          .clientId,
+      ).toBe('compactor-a');
+
+      remote.disableCrash();
+      mockProvider.uploadFile.calls.reset();
+      await expectAsync(
+        createFreshAdapter().uploadOps(
+          [
+            createMockSyncOp({
+              id: 'compactor-b-op',
+              vectorClock: { client1: 3 },
+            }),
+          ],
+          'compactor-b',
+        ),
+      ).toBeRejectedWithError(UploadRevToMatchMismatchAPIError);
+
+      expect(remote.files.get(C.STATE_FILE)!.dataStr).toBe(statePublishedByA.dataStr);
+      expect(
+        mockProvider.uploadFile.calls.allArgs().some(([path]) => path === C.STATE_FILE),
+      ).toBeFalse();
+      const committedOps = parseWithPrefix(
+        remote.files.get(C.OPS_FILE)!.dataStr,
+      ) as unknown as FileBasedOpsFile;
+      expect(committedOps.clientId).toBe('compactor-a');
+    });
+
     // (b2) Review regression: once the folder is past SPLIT_COMPACTION_THRESHOLD but
     // still under MAX_RECENT_OPS, op-bearing syncs must stay cheap (no snapshot
     // rebuild). The old code triggered compaction at SPLIT_COMPACTION_THRESHOLD, so
@@ -4347,15 +4819,26 @@ describe('FileBasedSyncAdapterService', () => {
         vectorClock: { abandoned: 4 },
         state: { tasks: ['unreferenced'] },
       });
+      const encodedAbandonedPrimary = addPrefix(abandonedPrimary, 3);
       const files = new Map<string, { dataStr: string; rev: string }>([
         [C.OPS_FILE, { dataStr: addPrefix(opsFile, 3), rev: 'ops-rev-5' }],
-        [
-          C.STATE_FILE,
-          { dataStr: addPrefix(abandonedPrimary, 3), rev: 'state-abandoned-rev' },
-        ],
+        [C.STATE_FILE, { dataStr: encodedAbandonedPrimary, rev: 'state-abandoned-rev' }],
         [
           C.STATE_BACKUP_FILE,
           { dataStr: addPrefix(referencedBackup, 3), rev: 'state-backup-rev' },
+        ],
+        [
+          C.OPS_SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'aborted',
+              transactionId: 'abandoned-compaction',
+              snapshotDigest: 'abandoned-ops-digest',
+              stateDigest: await digestEncodedPayload(encodedAbandonedPrimary),
+            }),
+            rev: 'aborted-compaction-rev',
+          },
         ],
       ]);
       let revCounter = 0;
@@ -4363,6 +4846,20 @@ describe('FileBasedSyncAdapterService', () => {
         const file = files.get(path);
         if (!file) throw new RemoteFileNotFoundAPIError(path);
         return file;
+      });
+      mockProvider.downloadFile
+        .withArgs(C.OPS_SNAPSHOT_TRANSACTION_FILE)
+        .and.callFake(async () => {
+          const file = files.get(C.OPS_SNAPSHOT_TRANSACTION_FILE);
+          if (!file) {
+            throw new RemoteFileNotFoundAPIError(C.OPS_SNAPSHOT_TRANSACTION_FILE);
+          }
+          return file;
+        });
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return { rev: file.rev };
       });
       mockProvider.uploadFile.and.callFake(
         async (
@@ -4399,7 +4896,72 @@ describe('FileBasedSyncAdapterService', () => {
       expect((preserved.state as { tasks: string[] }).tasks).toEqual(['committed']);
     });
 
-    it('(d3) proceeds with compaction when the referenced-state backup cannot be written (non-fatal)', async () => {
+    it('(d2) replaces a rejected state backup with the state referenced by committed ops', async () => {
+      const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
+        makeCompactOp({ id: `op-${index}`, sv: 5 }),
+      );
+      const committedClock = { committed: 1 };
+      const committedState = makeStateFile({
+        syncVersion: 1,
+        vectorClock: committedClock,
+        state: { tasks: ['committed'] },
+      });
+      const rejectedState = makeStateFile({
+        syncVersion: 1,
+        vectorClock: committedClock,
+        state: { tasks: ['rejected-with-same-ref'] },
+      });
+      const encodedRejectedState = addPrefix(rejectedState, 3);
+      const remote = installStatefulCasRemote(createMockSyncData());
+      remote.files.delete(C.SYNC_FILE);
+      remote.files.set(C.OPS_FILE, {
+        dataStr: addPrefix(
+          makeOpsFile({
+            syncVersion: 5,
+            vectorClock: committedClock,
+            recentOps: many,
+            snapshotRef: { syncVersion: 1, vectorClock: committedClock },
+          }),
+          3,
+        ),
+        rev: 'committed-ops-rev',
+      });
+      remote.files.set(C.STATE_FILE, {
+        dataStr: addPrefix(committedState, 3),
+        rev: 'committed-state-rev',
+      });
+      remote.files.set(C.STATE_BACKUP_FILE, {
+        dataStr: encodedRejectedState,
+        rev: 'rejected-state-backup-rev',
+      });
+      remote.files.set(C.OPS_SNAPSHOT_TRANSACTION_FILE, {
+        dataStr: JSON.stringify({
+          version: 1,
+          status: 'aborted',
+          transactionId: 'rejected-state-backup',
+          snapshotDigest: 'rejected-ops-digest',
+          stateDigest: await digestEncodedPayload(encodedRejectedState),
+        }),
+        rev: 'aborted-marker-rev',
+      });
+      mockProvider.uploadFile.calls.reset();
+
+      const result = await createFreshAdapter().uploadOps(
+        [createMockSyncOp({ vectorClock: { committed: 2 } })],
+        'client1',
+      );
+
+      expect(result.results[0].accepted).toBeTrue();
+      const firstStateBackup = mockProvider.uploadFile.calls
+        .allArgs()
+        .find(([path]) => path === C.STATE_BACKUP_FILE)!;
+      const preserved = parseWithPrefix(
+        firstStateBackup[1] as string,
+      ) as unknown as FileBasedStateFile;
+      expect((preserved.state as { tasks: string[] }).tasks).toEqual(['committed']);
+    });
+
+    it('(d3) aborts compaction when the referenced-state backup cannot be written', async () => {
       const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
         makeCompactOp({ id: `op-${index}`, sv: 5 }),
       );
@@ -4421,16 +4983,16 @@ describe('FileBasedSyncAdapterService', () => {
         return { rev: `${path}-newrev` };
       });
 
-      // Backup writes are non-fatal by contract: a provider that cannot write
-      // the .bak (lock, quota, per-file permission) must still be able to sync.
-      // The compaction immediately rewrites a fresh sync-state.json and CAS-es
-      // the ops commit point, so the remote pair stays consistent.
-      const result = await adapter.uploadOps([createMockSyncOp()], 'client1');
+      // This backup is part of the split commit protocol, not an optional
+      // rolling recovery point. Replacing state without it would make the
+      // still-committed ops file unreadable after a crash or lost ops CAS.
+      await expectAsync(
+        adapter.uploadOps([createMockSyncOp()], 'client1'),
+      ).toBeRejectedWithError('backup unavailable');
 
-      expect(result.results[0].accepted).toBeTrue();
       const paths = uploadedPaths();
-      expect(paths).toContain(C.STATE_FILE);
-      expect(paths).toContain(C.OPS_FILE);
+      expect(paths).not.toContain(C.STATE_FILE);
+      expect(paths).not.toContain(C.OPS_FILE);
     });
 
     it('(d4) compaction self-heals when NO snapshot matches the committed snapshotRef', async () => {
@@ -4535,6 +5097,10 @@ describe('FileBasedSyncAdapterService', () => {
         });
       expect(pendingRecoveryBakIdx).toBeGreaterThan(tombIdx);
       expect(pendingRecoveryBakIdx).toBeLessThan(finalizedOpsIdx);
+      const pendingRecoveryBackup = parseWithPrefix(
+        mockProvider.uploadFile.calls.allArgs()[pendingRecoveryBakIdx][1] as string,
+      ) as unknown as { version: number };
+      expect(pendingRecoveryBackup.version).toBe(C.SPLIT_MIGRATION_PENDING_OPS_VERSION);
     });
 
     it('(e1b) writes the pending migration ops file with the sentinel version', async () => {
@@ -4569,6 +5135,42 @@ describe('FileBasedSyncAdapterService', () => {
       expect(pending!.version).toBe(C.SPLIT_MIGRATION_PENDING_OPS_VERSION);
       expect(finalized).toBeDefined();
       expect(finalized!.version).toBe(C.SPLIT_FILE_VERSION);
+    });
+
+    it('(e1c) rewrites a matching finalized v3 recovery backup to the pending sentinel', async () => {
+      const clock = { client1: 7 };
+      const legacy = createMockSyncData({
+        syncVersion: 7,
+        vectorClock: clock,
+        recentOps: [],
+        state: { tasks: ['legacy'] },
+      });
+      const matchingFinalizedBackup = makeOpsFile({
+        syncVersion: 7,
+        vectorClock: clock,
+        recentOps: [],
+        snapshotRef: { syncVersion: 7, vectorClock: clock },
+      });
+      routeDownloads({
+        [C.SYNC_FILE]: addPrefix(legacy, 2),
+        [C.OPS_BACKUP_FILE]: addPrefix(matchingFinalizedBackup, 3),
+      });
+
+      await adapter.uploadOps([createMockSyncOp()], 'client1');
+
+      const pendingRecoveryBackup = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === C.OPS_BACKUP_FILE)
+        .map(
+          ([, dataStr]) =>
+            parseWithPrefix(dataStr as string) as unknown as Omit<
+              FileBasedOpsFile,
+              'version'
+            > & { version: number },
+        )
+        .find((opsFile) => opsFile.migration?.status === 'pending');
+      expect(pendingRecoveryBackup).toBeDefined();
+      expect(pendingRecoveryBackup!.version).toBe(C.SPLIT_MIGRATION_PENDING_OPS_VERSION);
     });
 
     it('(e2) resumes a pending migration marker after restart before appending ops', async () => {
@@ -5520,6 +6122,10 @@ describe('FileBasedSyncAdapterService', () => {
           3,
         ),
       });
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) return { rev: `${C.OPS_FILE}-rev` };
+        throw new RemoteFileNotFoundAPIError(path);
+      });
 
       await adapter.uploadSnapshot(
         {},
@@ -5534,7 +6140,7 @@ describe('FileBasedSyncAdapterService', () => {
       const paths = uploadedPaths();
       const oBak = paths.indexOf(C.OPS_BACKUP_FILE);
       const oMain = paths.indexOf(C.OPS_FILE);
-      const sBak = paths.indexOf(C.STATE_BACKUP_FILE);
+      const sBak = paths.lastIndexOf(C.STATE_BACKUP_FILE);
       const sMain = paths.indexOf(C.STATE_FILE);
       const pending = paths.indexOf(C.OPS_SNAPSHOT_TRANSACTION_FILE);
       const complete = paths.lastIndexOf(C.OPS_SNAPSHOT_TRANSACTION_FILE);
@@ -5549,8 +6155,8 @@ describe('FileBasedSyncAdapterService', () => {
       expect(oMain).toBeLessThan(sBak);
       expect(sBak).toBeLessThan(complete);
       const stateUpload = mockProvider.uploadFile.calls.allArgs()[sMain];
-      expect(stateUpload[2]).toBeNull();
-      expect(stateUpload[3]).toBeTrue();
+      expect(stateUpload[2]).toBe(`${C.STATE_FILE}-rev`);
+      expect(stateUpload[3]).toBeFalse();
       // Both backups carry the fresh transaction payload, so no stale key or
       // pre-snapshot state remains recoverable after completion.
       const argAt = (i: number): string =>
@@ -5560,6 +6166,80 @@ describe('FileBasedSyncAdapterService', () => {
       const publishedState = parseWithPrefix(argAt(sBak));
       expect(publishedState.syncVersion).toBe(1);
       expect(publishedState.vectorClock).toEqual({ client1: 1 });
+    });
+
+    it('(i) refuses to overwrite a state candidate whose ops commit is still in flight', async () => {
+      const committedClock = { committedClient: 1 };
+      const pendingClock = { pendingClient: 2 };
+      const candidateClock = { candidateClient: 3 };
+      const pendingState = makeStateFile({
+        syncVersion: 2,
+        vectorClock: pendingClock,
+        clientId: 'pendingClient',
+      });
+      const pendingOps = makeOpsFile({
+        syncVersion: 2,
+        vectorClock: pendingClock,
+        clientId: 'pendingClient',
+        snapshotRef: { syncVersion: 2, vectorClock: pendingClock },
+      });
+      const inFlightCandidate = makeStateFile({
+        syncVersion: 3,
+        vectorClock: candidateClock,
+        clientId: 'candidateClient',
+      });
+      const remote = installStatefulCasRemote(createMockSyncData());
+      remote.files.delete(C.SYNC_FILE);
+      remote.files.set(C.OPS_FILE, {
+        dataStr: addPrefix(
+          makeOpsFile({
+            syncVersion: 1,
+            vectorClock: committedClock,
+            snapshotRef: { syncVersion: 1, vectorClock: committedClock },
+          }),
+          3,
+        ),
+        rev: 'committed-ops-rev',
+      });
+      remote.files.set(C.STATE_FILE, {
+        dataStr: addPrefix(inFlightCandidate, 3),
+        rev: 'in-flight-state-rev',
+      });
+      remote.files.set(C.STATE_BACKUP_FILE, {
+        dataStr: addPrefix(
+          makeStateFile({
+            syncVersion: 1,
+            vectorClock: committedClock,
+            clientId: 'committedClient',
+          }),
+          3,
+        ),
+        rev: 'committed-state-backup-rev',
+      });
+      remote.files.set(C.OPS_SNAPSHOT_TRANSACTION_FILE, {
+        dataStr: JSON.stringify({
+          version: 1,
+          status: 'pending',
+          transactionId: 'pending-split-snapshot',
+          basePrimaryRev: 'committed-ops-rev',
+          encodedSnapshot: addPrefix(pendingOps, 3),
+          encodedState: addPrefix(pendingState, 3),
+        }),
+        rev: 'pending-marker-rev',
+      });
+      mockProvider.uploadFile.calls.reset();
+
+      await expectAsync(createFreshAdapter().downloadOps(0)).toBeRejectedWithError(
+        UploadRevToMatchMismatchAPIError,
+      );
+
+      expect(remote.files.get(C.STATE_FILE)).toEqual({
+        dataStr: addPrefix(inFlightCandidate, 3),
+        rev: 'in-flight-state-rev',
+      });
+      expect(
+        mockProvider.uploadFile.calls.allArgs().some(([path]) => path === C.STATE_FILE),
+      ).toBeFalse();
     });
 
     it('(i) recovers a split snapshot after every transaction write', async () => {
@@ -5603,17 +6283,14 @@ describe('FileBasedSyncAdapterService', () => {
         expect(state.clientId).toBe('newClient');
         // Writes: 1 = pending marker, 2 = state, 3 = ops.bak, 4 = OPS (the
         // primary/commit point), 5 = state.bak, 6 = complete marker. A crash
-        // BEFORE the OPS write (1-3) is recovered by promoting the pending
-        // payload (marker → complete). A crash AT/AFTER the OPS write (4, 5)
-        // leaves the primary already advanced past the marker's basePrimaryRev,
-        // so recovery abandons the marker while the committed state/ops pair
-        // stays authoritative. After the complete write (6) nothing recovers.
+        // before the OPS write promotes the pending payload. A crash after the
+        // OPS commit recognizes the exact state/ops payloads and completes the
+        // marker; a different primary payload would be abandoned instead.
         expect(
           JSON.parse(remote.files.get(C.OPS_SNAPSHOT_TRANSACTION_FILE)!.dataStr),
         ).toEqual(
           jasmine.objectContaining({
-            status:
-              crashAfterWrite === 4 || crashAfterWrite === 5 ? 'aborted' : 'complete',
+            status: 'complete',
           }),
         );
 

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -3525,6 +3525,54 @@ describe('FileBasedSyncAdapterService', () => {
       expect(finalizedMarker).toBeDefined();
     });
 
+    it('(e2c) rebuilds a matching-revision pending marker from the legacy source before tombstoning', async () => {
+      const legacyOp = makeCompactOp({
+        id: 'legacy-authoritative-op',
+        sv: 7,
+        v: { client1: 7 },
+      });
+      const legacy = createMockSyncData({
+        syncVersion: 7,
+        vectorClock: { client1: 7 },
+        recentOps: [legacyOp],
+        state: { tasks: ['legacy-authoritative-state'] },
+      });
+      const malformedPending = makeOpsFile({
+        syncVersion: 99,
+        vectorClock: { stale: 99 },
+        recentOps: [makeCompactOp({ id: 'stale-op', sv: 99, v: { stale: 99 } })],
+        snapshotRef: { syncVersion: 99, vectorClock: { stale: 99 } },
+        migration: {
+          status: 'pending',
+          legacyRev: `${C.SYNC_FILE}-rev`,
+        },
+      });
+      routeDownloads({
+        [C.SYNC_FILE]: addPrefix(legacy, 2),
+        [C.OPS_FILE]: addPrefix(malformedPending, 3),
+      });
+
+      await adapter.downloadOps(0, 'client2');
+
+      const finalized = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter((args) => args[0] === C.OPS_FILE)
+        .map((args) => parseWithPrefix(args[1] as string) as unknown as FileBasedOpsFile)
+        .find((opsFile) => opsFile.migration === undefined);
+      expect(finalized).toBeDefined();
+      expect(finalized!.syncVersion).toBe(7);
+      expect(finalized!.vectorClock).toEqual({ client1: 7 });
+      expect(finalized!.snapshotRef).toEqual(
+        jasmine.objectContaining({
+          syncVersion: 7,
+          vectorClock: { client1: 7 },
+        }),
+      );
+      expect(finalized!.recentOps.map((op) => op.id)).toEqual([
+        'legacy-authoritative-op',
+      ]);
+    });
+
     it('(e3) retries migration from a newer legacy revision instead of tombstoning over it', async () => {
       const legacyV7 = createMockSyncData({
         syncVersion: 7,

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -1339,6 +1339,11 @@ describe('FileBasedSyncAdapterService', () => {
             if (!file) throw new RemoteFileNotFoundAPIError(path);
             return file;
           });
+        mockProvider.getFileRev.and.callFake(async (path: string) => {
+          const file = files.get(path);
+          if (!file) throw new RemoteFileNotFoundAPIError(path);
+          return { rev: file.rev };
+        });
         mockProvider.uploadFile.and.callFake(
           async (
             path: string,
@@ -1392,13 +1397,21 @@ describe('FileBasedSyncAdapterService', () => {
           files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.dataStr,
         ) as unknown as FileBasedSyncData;
         expect(primary.clientId).toBe('newClient');
+        // Writes: 1 = pending marker, 2 = .bak, 3 = primary, 4 = complete marker.
+        // A crash BEFORE the primary write (1, 2) is recovered by promoting the
+        // pending payload (marker → complete). A crash AT/AFTER the primary
+        // write (3) leaves the primary already advanced past the marker's
+        // basePrimaryRev, so recovery must NOT re-promote (a marker-unaware
+        // client could have written in between) — the marker is abandoned while
+        // the already-committed primary stays authoritative. A crash after the
+        // complete write (4) needs no recovery.
         expect(
           JSON.parse(
             files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
           ),
         ).toEqual(
           jasmine.objectContaining({
-            status: 'complete',
+            status: crashAfterWrite === 3 ? 'aborted' : 'complete',
           }),
         );
 
@@ -1500,6 +1513,11 @@ describe('FileBasedSyncAdapterService', () => {
         .and.callFake(() =>
           readFile(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE),
         );
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return { rev: file.rev };
+      });
       mockProvider.uploadFile.and.callFake(
         async (
           path: string,
@@ -1559,6 +1577,186 @@ describe('FileBasedSyncAdapterService', () => {
           files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.dataStr,
         ).recentOps.map((op) => op.id),
       ).toContain('op-after-poison');
+    });
+  });
+
+  describe('snapshot-transaction hardening', () => {
+    // Stateful CAS remote shared by the tests below: downloads/uploads/getFileRev
+    // all read and mutate one `files` map, mirroring a real provider.
+    const installCasRemote = (
+      seed: [string, { dataStr: string; rev: string }][],
+    ): Map<string, { dataStr: string; rev: string }> => {
+      const files = new Map(seed);
+      let nextRev = 0;
+      const readFile = async (
+        path: string,
+      ): Promise<{ dataStr: string; rev: string }> => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return file;
+      };
+      mockProvider.downloadFile.and.callFake(readFile);
+      mockProvider.downloadFile
+        .withArgs(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+        .and.callFake(() =>
+          readFile(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE),
+        );
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return { rev: file.rev };
+      });
+      mockProvider.uploadFile.and.callFake(
+        async (
+          path: string,
+          dataStr: string,
+          revToMatch: string | null,
+          isForceOverwrite = false,
+        ) => {
+          const current = files.get(path);
+          if (
+            !isForceOverwrite &&
+            (revToMatch === null ? current !== undefined : current?.rev !== revToMatch)
+          ) {
+            throw new UploadRevToMatchMismatchAPIError();
+          }
+          const rev = `${path}-rev-${++nextRev}`;
+          files.set(path, { dataStr, rev });
+          return { rev };
+        },
+      );
+      return files;
+    };
+
+    it('abandons a stale pending snapshot instead of clobbering newer committed data', async () => {
+      // Device A began a "Use Local" transaction at basePrimaryRev and crashed.
+      // A marker-unaware client then committed days of work (primary advanced).
+      const newerData = createMockSyncData({
+        syncVersion: 9,
+        vectorClock: { otherClient: 9 },
+        clientId: 'otherClient',
+      });
+      const staleSnapshot = createMockSyncData({
+        syncVersion: 1,
+        vectorClock: { useLocalClient: 1 },
+        clientId: 'useLocalClient',
+      });
+      const files = installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          { dataStr: addPrefix(newerData), rev: 'primary-after-marker' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'pending',
+              transactionId: 'stale-tx',
+              basePrimaryRev: 'primary-at-begin',
+              encodedSnapshot: addPrefix(staleSnapshot),
+            }),
+            rev: 'marker-rev',
+          },
+        ],
+      ]);
+
+      const result = await adapter.downloadOps(0);
+
+      // The newer committed data wins; the stale payload is NOT promoted.
+      expect(result.snapshotVectorClock).toEqual({ otherClient: 9 });
+      expect(
+        (
+          parseWithPrefix(
+            files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.dataStr,
+          ) as unknown as FileBasedSyncData
+        ).clientId,
+      ).toBe('otherClient');
+      // The marker is durably abandoned so later syncs and "Use Local" work.
+      expect(
+        JSON.parse(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+        ),
+      ).toEqual(
+        jasmine.objectContaining({ status: 'aborted', transactionId: 'stale-tx' }),
+      );
+    });
+
+    it('ignores a torn transaction marker and lets the next snapshot upload replace it', async () => {
+      const primary = createMockSyncData({
+        syncVersion: 3,
+        vectorClock: { client1: 3 },
+      });
+      const files = installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          { dataStr: addPrefix(primary), rev: 'primary-rev' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          // Torn mid-write: not valid JSON.
+          { dataStr: '{"version":1,"status":"pen', rev: 'torn-marker-rev' },
+        ],
+      ]);
+
+      // Downloads proceed despite the unreadable marker (previously every sync
+      // path threw SyncDataCorruptedError with no user remedy).
+      const result = await adapter.downloadOps(0);
+      expect(result.latestSeq).toBe(3);
+
+      // "Use Local" conditionally replaces the torn marker and completes.
+      await adapter.uploadSnapshot(
+        {},
+        'client1',
+        'recovery',
+        { client1: 4 },
+        1,
+        undefined,
+        'heal-after-torn-marker',
+      );
+      expect(
+        JSON.parse(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+        ),
+      ).toEqual(jasmine.objectContaining({ status: 'complete' }));
+      expect(
+        (
+          parseWithPrefix(
+            files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.dataStr,
+          ) as unknown as FileBasedSyncData
+        ).vectorClock,
+      ).toEqual({ client1: 4 });
+    });
+
+    it('reuses the cached backup rev instead of re-downloading the backup on every upload', async () => {
+      installCasRemote([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          {
+            dataStr: addPrefix(
+              createMockSyncData({ syncVersion: 2, vectorClock: { client1: 2 } }),
+            ),
+            rev: 'r1',
+          },
+        ],
+      ]);
+
+      await adapter.uploadOps([createMockSyncOp({ id: 'op-1' })], 'client1');
+      await adapter.uploadOps(
+        [createMockSyncOp({ id: 'op-2', vectorClock: { client1: 3 } })],
+        'client1',
+      );
+
+      const bakDownloadCount = mockProvider.downloadFile.calls
+        .allArgs()
+        .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE).length;
+      const bakUploadCount = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE).length;
+      // Both rotations wrote the backup, but only the FIRST needed to read it —
+      // the second used the cached rev with a single conditional PUT.
+      expect(bakUploadCount).toBe(2);
+      expect(bakDownloadCount).toBe(1);
     });
   });
 
@@ -3197,6 +3395,31 @@ describe('FileBasedSyncAdapterService', () => {
       expect(result.gapDetected).toBeFalsy();
     });
 
+    it('(a2) an unchanged-rev poll performs no snapshot-transaction marker request', async () => {
+      const syncData = createMockSyncData({ syncVersion: 2, recentOps: [] });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-1' }),
+      );
+      await adapter.downloadOps(0);
+      await adapter.setLastServerSeq(2);
+
+      crossPollBoundary();
+      mockProvider.downloadFile.calls.reset();
+      mockProvider.getFileRev.calls.reset();
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) return { rev: 'rev-1' };
+        throw new RemoteFileNotFoundAPIError('not found');
+      });
+
+      await adapter.downloadOps(2);
+
+      // The whole idle poll costs exactly ONE metadata request: the cheap rev
+      // pre-check runs BEFORE the marker read, so an unchanged remote skips the
+      // marker GET entirely (previously every poll paid 2+ round trips).
+      expect(mockProvider.getFileRev.calls.count()).toBe(1);
+      expect(mockProvider.downloadFile.calls.count()).toBe(0);
+    });
+
     it('(b) proceeds with the full download when the remote rev changed', async () => {
       const seed = createMockSyncData({ syncVersion: 2, recentOps: [] });
       mockProvider.downloadFile.and.returnValue(
@@ -4176,7 +4399,7 @@ describe('FileBasedSyncAdapterService', () => {
       expect((preserved.state as { tasks: string[] }).tasks).toEqual(['committed']);
     });
 
-    it('(d3) aborts compaction when the required referenced-state backup cannot be written', async () => {
+    it('(d3) proceeds with compaction when the referenced-state backup cannot be written (non-fatal)', async () => {
       const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
         makeCompactOp({ id: `op-${index}`, sv: 5 }),
       );
@@ -4198,13 +4421,42 @@ describe('FileBasedSyncAdapterService', () => {
         return { rev: `${path}-newrev` };
       });
 
-      await expectAsync(
-        adapter.uploadOps([createMockSyncOp()], 'client1'),
-      ).toBeRejectedWithError('backup unavailable');
+      // Backup writes are non-fatal by contract: a provider that cannot write
+      // the .bak (lock, quota, per-file permission) must still be able to sync.
+      // The compaction immediately rewrites a fresh sync-state.json and CAS-es
+      // the ops commit point, so the remote pair stays consistent.
+      const result = await adapter.uploadOps([createMockSyncOp()], 'client1');
 
+      expect(result.results[0].accepted).toBeTrue();
       const paths = uploadedPaths();
-      expect(paths).not.toContain(C.STATE_FILE);
-      expect(paths).not.toContain(C.OPS_FILE);
+      expect(paths).toContain(C.STATE_FILE);
+      expect(paths).toContain(C.OPS_FILE);
+    });
+
+    it('(d4) compaction self-heals when NO snapshot matches the committed snapshotRef', async () => {
+      // sync-state.json was deleted (cloud retention/manual cleanup) and no
+      // usable backup exists. The compaction must rewrite a fresh snapshot
+      // instead of wedging every future upload with a corruption error.
+      const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
+        makeCompactOp({ id: `op-${index}`, sv: 5 }),
+      );
+      const opsFile = makeOpsFile({
+        syncVersion: 5,
+        recentOps: many,
+        snapshotRef: { syncVersion: 1, vectorClock: { client1: 1 } },
+      });
+      routeDownloads({ [C.OPS_FILE]: addPrefix(opsFile, 3) });
+
+      const result = await adapter.uploadOps([createMockSyncOp()], 'client1');
+
+      expect(result.results[0].accepted).toBeTrue();
+      const stateUploads = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === C.STATE_FILE);
+      expect(stateUploads).toHaveSize(1);
+      // Written as create-if-absent against the missing file.
+      expect(stateUploads[0][2]).toBeNull();
+      expect(uploadedPaths()).toContain(C.OPS_FILE);
     });
 
     // (e) legacy v2 sync-data.json migrates in place: state+ops written, tombstone
@@ -4283,6 +4535,40 @@ describe('FileBasedSyncAdapterService', () => {
         });
       expect(pendingRecoveryBakIdx).toBeGreaterThan(tombIdx);
       expect(pendingRecoveryBakIdx).toBeLessThan(finalizedOpsIdx);
+    });
+
+    it('(e1b) writes the pending migration ops file with the sentinel version', async () => {
+      const legacy = createMockSyncData({
+        syncVersion: 7,
+        vectorClock: { client1: 7 },
+        recentOps: [],
+        state: { tasks: ['legacy'] },
+      });
+      routeDownloads({ [C.SYNC_FILE]: addPrefix(legacy, 2) });
+
+      await adapter.uploadOps([createMockSyncOp()], 'client1');
+
+      const opsUploads = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === C.OPS_FILE)
+        .map(
+          (args) =>
+            parseWithPrefix(args[1] as string) as unknown as Omit<
+              FileBasedOpsFile,
+              'version'
+            > & { version: number },
+        );
+      const pending = opsUploads.find((o) => o.migration?.status === 'pending');
+      const finalized = opsUploads.find((o) => o.migration === undefined);
+      // Shipped split clients validate ONLY `version === 3`, so a version-3
+      // pending file would be adopted as a committed ops file while
+      // sync-state.json does not exist yet (truncated bootstrap) or even be
+      // finalized implicitly by their next upload. The sentinel version makes
+      // them fail safe until the migration completes.
+      expect(pending).toBeDefined();
+      expect(pending!.version).toBe(C.SPLIT_MIGRATION_PENDING_OPS_VERSION);
+      expect(finalized).toBeDefined();
+      expect(finalized!.version).toBe(C.SPLIT_FILE_VERSION);
     });
 
     it('(e2) resumes a pending migration marker after restart before appending ops', async () => {
@@ -5074,9 +5360,16 @@ describe('FileBasedSyncAdapterService', () => {
           version: 1,
           status: 'pending',
           transactionId: 'pending-snapshot',
+          basePrimaryRev: `${C.OPS_FILE}-rev`,
           encodedSnapshot: encodedPendingSnapshot,
           encodedState: encodedPendingState,
         }),
+      });
+      // Recovery's freshness probe must observe the primary unchanged since the
+      // transaction began (routeDownloads revs are `${path}-rev`).
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) return { rev: `${C.OPS_FILE}-rev` };
+        throw new RemoteFileNotFoundAPIError(path);
       });
 
       await expectAsync(
@@ -5308,9 +5601,21 @@ describe('FileBasedSyncAdapterService', () => {
         ) as unknown as FileBasedStateFile;
         expect(ops.clientId).toBe('newClient');
         expect(state.clientId).toBe('newClient');
+        // Writes: 1 = pending marker, 2 = state, 3 = ops.bak, 4 = OPS (the
+        // primary/commit point), 5 = state.bak, 6 = complete marker. A crash
+        // BEFORE the OPS write (1-3) is recovered by promoting the pending
+        // payload (marker → complete). A crash AT/AFTER the OPS write (4, 5)
+        // leaves the primary already advanced past the marker's basePrimaryRev,
+        // so recovery abandons the marker while the committed state/ops pair
+        // stays authoritative. After the complete write (6) nothing recovers.
         expect(
           JSON.parse(remote.files.get(C.OPS_SNAPSHOT_TRANSACTION_FILE)!.dataStr),
-        ).toEqual(jasmine.objectContaining({ status: 'complete' }));
+        ).toEqual(
+          jasmine.objectContaining({
+            status:
+              crashAfterWrite === 4 || crashAfterWrite === 5 ? 'aborted' : 'complete',
+          }),
+        );
 
         mockProvider.downloadFile.calls.reset();
         mockProvider.uploadFile.calls.reset();

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -197,6 +197,23 @@ describe('FileBasedSyncAdapterService', () => {
       'getFileRev',
     ]);
     mockProvider.id = SyncProviderId.WebDAV;
+    // Transaction markers are separate files. Most tests model remotes that
+    // predate them, so keep marker probes path-specific instead of letting a
+    // path-agnostic primary-file response masquerade as marker JSON.
+    mockProvider.downloadFile
+      .withArgs(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+      .and.rejectWith(
+        new RemoteFileNotFoundAPIError(
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+        ),
+      );
+    mockProvider.downloadFile
+      .withArgs(FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE)
+      .and.rejectWith(
+        new RemoteFileNotFoundAPIError(
+          FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+        ),
+      );
     // Default: no legacy __meta_ file present → treat missing sync-data.json as fresh start
     mockProvider.getFileRev.and.callFake(async (_path: string) => {
       throw new RemoteFileNotFoundAPIError('not found');
@@ -340,8 +357,10 @@ describe('FileBasedSyncAdapterService', () => {
       );
 
       let uploadedDataStr: string = '';
-      mockProvider.uploadFile.and.callFake((_path: string, dataStr: string) => {
-        uploadedDataStr = dataStr;
+      mockProvider.uploadFile.and.callFake((path: string, dataStr: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+          uploadedDataStr = dataStr;
+        }
         return Promise.resolve({ rev: 'rev-1' });
       });
 
@@ -358,6 +377,87 @@ describe('FileBasedSyncAdapterService', () => {
 
       const uploadedData = parseWithPrefix(uploadedDataStr);
       expect(uploadedData.vectorClock).toEqual({ client1: 3, client2: 2, client3: 1 });
+    });
+
+    it('aborts before rotating the backup when a snapshot transaction changed', async () => {
+      const oldPrimary = createMockSyncData({
+        syncVersion: 10,
+        vectorClock: { oldClient: 10 },
+        clientId: 'oldClient',
+      });
+      const newSnapshot = createMockSyncData({
+        syncVersion: 1,
+        vectorClock: { newClient: 1 },
+        clientId: 'newClient',
+      });
+      const files = new Map<string, { dataStr: string; rev: string }>([
+        [
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          { dataStr: addPrefix(oldPrimary), rev: 'primary-old' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+          { dataStr: addPrefix(oldPrimary), rev: 'backup-old' },
+        ],
+        [
+          FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'complete',
+              transactionId: 'old-transaction',
+              primaryRev: 'primary-old',
+              snapshotDigest: '0'.repeat(64),
+            }),
+            rev: 'marker-old',
+          },
+        ],
+      ]);
+      const readFile = async (
+        path: string,
+      ): Promise<{ dataStr: string; rev: string }> => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+          // Complete an authoritative reset after the ordinary uploader read
+          // its primary, but before it can rotate the recovery artifact.
+          files.set(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE, {
+            dataStr: addPrefix(newSnapshot),
+            rev: 'primary-snapshot',
+          });
+          files.set(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE, {
+            dataStr: addPrefix(newSnapshot),
+            rev: 'backup-snapshot',
+          });
+          files.set(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE, {
+            dataStr: JSON.stringify({
+              version: 1,
+              status: 'complete',
+              transactionId: 'new-transaction',
+              primaryRev: 'primary-snapshot',
+              snapshotDigest: '1'.repeat(64),
+            }),
+            rev: 'marker-new',
+          });
+        }
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return file;
+      };
+      mockProvider.downloadFile.and.callFake(readFile);
+      mockProvider.downloadFile
+        .withArgs(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+        .and.callFake(() =>
+          readFile(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE),
+        );
+
+      await expectAsync(
+        adapter.uploadOps([createMockSyncOp()], 'oldClient'),
+      ).toBeRejectedWithError(UploadRevToMatchMismatchAPIError);
+
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+      expect(
+        parseWithPrefix(files.get(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE)!.dataStr)
+          .clientId,
+      ).toBe('newClient');
     });
 
     it('should use cached data from downloadOps when uploading (avoids redundant download)', async () => {
@@ -377,8 +477,13 @@ describe('FileBasedSyncAdapterService', () => {
       const op = createMockSyncOp();
       await adapter.uploadOps([op], 'client1');
 
-      // Download should NOT be called again during upload (cache hit)
-      expect(mockProvider.downloadFile).not.toHaveBeenCalled();
+      // The primary stays cached; the recovery artifact is inspected so a stale
+      // writer cannot roll it backward.
+      expect(
+        mockProvider.downloadFile.calls
+          .allArgs()
+          .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE),
+      ).toHaveSize(0);
     });
 
     it('should use conditional upload with revToMatch from cache', async () => {
@@ -407,15 +512,23 @@ describe('FileBasedSyncAdapterService', () => {
 
     it('should throw UploadRevToMatchMismatchAPIError on genuine concurrent upload (rev changed)', async () => {
       const syncData = createMockSyncData({ syncVersion: 1 });
-      // Initial download: rev-1
-      mockProvider.downloadFile.and.returnValues(
-        Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-1' }),
-        // Re-download after mismatch returns rev-2 (another client uploaded for real)
-        Promise.resolve({ dataStr: addPrefix(syncData), rev: 'rev-2' }),
-      );
-      // All upload attempts fail with rev mismatch
-      mockProvider.uploadFile.and.returnValue(
-        Promise.reject(new UploadRevToMatchMismatchAPIError('Rev mismatch')),
+      let primaryDownloads = 0;
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+          throw new RemoteFileNotFoundAPIError(path);
+        }
+        primaryDownloads++;
+        return {
+          dataStr: addPrefix(syncData),
+          // The mismatch re-download observes another client's newer revision.
+          rev: primaryDownloads === 1 ? 'rev-1' : 'rev-2',
+        };
+      });
+      mockProvider.uploadFile.and.callFake(
+        (path: string): Promise<{ rev: string }> =>
+          path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE
+            ? Promise.resolve({ rev: 'bak-1' })
+            : Promise.reject(new UploadRevToMatchMismatchAPIError('Rev mismatch')),
       );
 
       await adapter.downloadOps(0);
@@ -433,8 +546,8 @@ describe('FileBasedSyncAdapterService', () => {
         .filter((args) => args[0] === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE);
       expect(mainUploads.length).toBe(1);
       expect(mainUploads.every((args) => args[3] === false)).toBe(true);
-      // Download called twice: initial cache + re-download to check rev
-      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(2);
+      // Primary downloaded twice: initial cache + re-download to check rev.
+      expect(primaryDownloads).toBe(2);
     });
 
     it('retries CONDITIONALLY (never force) when freshRev equals original revToMatch (SPAP-8)', async () => {
@@ -497,8 +610,13 @@ describe('FileBasedSyncAdapterService', () => {
       const op2 = createMockSyncOp({ id: 'op-2' });
       await adapter.uploadOps([op2], 'client1');
 
-      // Download should be called because cache was cleared after first upload
-      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      // The primary is downloaded because the cache was cleared; additional
+      // calls may inspect the recovery artifact.
+      expect(
+        mockProvider.downloadFile.calls
+          .allArgs()
+          .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE),
+      ).toHaveSize(1);
     });
   });
 
@@ -875,8 +993,10 @@ describe('FileBasedSyncAdapterService', () => {
       );
 
       let uploadedDataStr: string = '';
-      mockProvider.uploadFile.and.callFake((_path: string, dataStr: string) => {
-        uploadedDataStr = dataStr;
+      mockProvider.uploadFile.and.callFake((path: string, dataStr: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+          uploadedDataStr = dataStr;
+        }
         return Promise.resolve({ rev: 'rev-1' });
       });
 
@@ -932,11 +1052,20 @@ describe('FileBasedSyncAdapterService', () => {
       mockProvider.downloadFile.and.throwError(
         new RemoteFileNotFoundAPIError('sync-data.json'),
       );
-      const uploads: { path: string; data: string }[] = [];
+      const uploads: {
+        path: string;
+        data: string;
+        revToMatch: string | null;
+        isForceOverwrite: boolean;
+      }[] = [];
       mockProvider.uploadFile.and.callFake(
-        async (path: string, data: string, _rev: string | null, force?: boolean) => {
-          uploads.push({ path, data });
-          expect(force).toBe(true);
+        async (
+          path: string,
+          data: string,
+          revToMatch: string | null,
+          isForceOverwrite = false,
+        ) => {
+          uploads.push({ path, data, revToMatch, isForceOverwrite });
           return { rev: `${path}-rev` };
         },
       );
@@ -952,16 +1081,33 @@ describe('FileBasedSyncAdapterService', () => {
       );
 
       const paths = uploads.map((u) => u.path);
+      const pendingIdx = paths.indexOf(
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+      );
       const bakIdx = paths.indexOf(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE);
       const mainIdx = paths.indexOf(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE);
+      const completeIdx = paths.lastIndexOf(
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+      );
+      expect(pendingIdx).toBeGreaterThanOrEqual(0);
       expect(bakIdx).toBeGreaterThanOrEqual(0);
       expect(mainIdx).toBeGreaterThanOrEqual(0);
+      expect(completeIdx).toBeGreaterThan(mainIdx);
+      expect(pendingIdx).toBeLessThan(bakIdx);
       // .bak first, then the primary — a crash in between leaves a valid old
       // primary + already-refreshed .bak (nothing recoverable, nothing stale).
       expect(bakIdx).toBeLessThan(mainIdx);
       // Identical payload: the .bak is the snapshot itself, not the pre-snapshot
       // remote it deliberately replaces.
       expect(uploads[bakIdx].data).toBe(uploads[mainIdx].data);
+      expect(uploads[pendingIdx].isForceOverwrite).toBeFalse();
+      expect(uploads[bakIdx].isForceOverwrite).toBeTrue();
+      expect(uploads[mainIdx].isForceOverwrite).toBeTrue();
+      expect(uploads[completeIdx].isForceOverwrite).toBeFalse();
+      expect(uploads[pendingIdx].revToMatch).toBeNull();
+      expect(uploads[completeIdx].revToMatch).toBe(
+        `${FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE}-rev`,
+      );
     });
 
     describe('uploadSnapshot gap detection', () => {
@@ -1158,6 +1304,262 @@ describe('FileBasedSyncAdapterService', () => {
       const seq = await adapter.getLastServerSeq();
       expect(seq).toBe(1);
     });
+
+    it('recovers an authoritative snapshot after every transaction write', async () => {
+      for (let crashAfterWrite = 1; crashAfterWrite <= 4; crashAfterWrite++) {
+        const files = new Map<string, { dataStr: string; rev: string }>([
+          [
+            FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+            {
+              dataStr: addPrefix(
+                createMockSyncData({
+                  syncVersion: 7,
+                  vectorClock: { oldClient: 7 },
+                  clientId: 'oldClient',
+                }),
+              ),
+              rev: 'primary-old',
+            },
+          ],
+        ]);
+        let writeCount = 0;
+        let nextRev = 0;
+        let activeCrashAfterWrite: number | undefined = crashAfterWrite;
+
+        mockProvider.downloadFile.and.callFake(async (path: string) => {
+          const file = files.get(path);
+          if (!file) throw new RemoteFileNotFoundAPIError(path);
+          return file;
+        });
+        mockProvider.downloadFile
+          .withArgs(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+          .and.callFake(async () => {
+            const path = FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE;
+            const file = files.get(path);
+            if (!file) throw new RemoteFileNotFoundAPIError(path);
+            return file;
+          });
+        mockProvider.uploadFile.and.callFake(
+          async (
+            path: string,
+            dataStr: string,
+            revToMatch: string | null,
+            isForceOverwrite = false,
+          ) => {
+            const current = files.get(path);
+            if (
+              !isForceOverwrite &&
+              (revToMatch === null ? current !== undefined : current?.rev !== revToMatch)
+            ) {
+              throw new UploadRevToMatchMismatchAPIError();
+            }
+            const rev = `${path}-rev-${++nextRev}`;
+            files.set(path, { dataStr, rev });
+            writeCount++;
+            if (writeCount === activeCrashAfterWrite) {
+              throw new Error(`simulated snapshot crash after write ${writeCount}`);
+            }
+            return { rev };
+          },
+        );
+
+        const snapshotAdapter = TestBed.runInInjectionContext(
+          () => new FileBasedSyncAdapterService(),
+        ).createAdapter(mockProvider, mockCfg, mockEncryptKey);
+        await expectAsync(
+          snapshotAdapter.uploadSnapshot(
+            {},
+            'newClient',
+            'recovery',
+            { newClient: 1 },
+            1,
+            undefined,
+            `snapshot-op-${crashAfterWrite}`,
+          ),
+        ).toBeRejectedWithError(
+          `simulated snapshot crash after write ${crashAfterWrite}`,
+        );
+
+        activeCrashAfterWrite = undefined;
+        const recoveryAdapter = TestBed.runInInjectionContext(
+          () => new FileBasedSyncAdapterService(),
+        ).createAdapter(mockProvider, mockCfg, mockEncryptKey);
+        const recovered = await recoveryAdapter.downloadOps(0);
+
+        expect(recovered.latestSeq).toBe(1);
+        expect(recovered.snapshotVectorClock).toEqual({ newClient: 1 });
+        const primary = parseWithPrefix(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.dataStr,
+        ) as unknown as FileBasedSyncData;
+        expect(primary.clientId).toBe('newClient');
+        expect(
+          JSON.parse(
+            files.get(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)!.dataStr,
+          ),
+        ).toEqual(
+          jasmine.objectContaining({
+            status: 'complete',
+          }),
+        );
+
+        mockProvider.downloadFile.calls.reset();
+        mockProvider.uploadFile.calls.reset();
+      }
+    });
+
+    it('rejects a poisoned backup while the authoritative snapshot revision is current', async () => {
+      const files = new Map<string, { dataStr: string; rev: string }>();
+      let nextRev = 0;
+      const readFile = async (
+        path: string,
+      ): Promise<{ dataStr: string; rev: string }> => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return file;
+      };
+      mockProvider.downloadFile.and.callFake(readFile);
+      mockProvider.downloadFile
+        .withArgs(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+        .and.callFake(() =>
+          readFile(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE),
+        );
+      mockProvider.uploadFile.and.callFake(
+        async (
+          path: string,
+          dataStr: string,
+          revToMatch: string | null,
+          isForceOverwrite = false,
+        ) => {
+          const current = files.get(path);
+          if (
+            !isForceOverwrite &&
+            (revToMatch === null ? current !== undefined : current?.rev !== revToMatch)
+          ) {
+            throw new UploadRevToMatchMismatchAPIError();
+          }
+          const rev = `${path}-rev-${++nextRev}`;
+          files.set(path, { dataStr, rev });
+          return { rev };
+        },
+      );
+
+      await adapter.uploadSnapshot(
+        {},
+        'newClient',
+        'recovery',
+        { newClient: 1 },
+        1,
+        undefined,
+        'snapshot-with-digest',
+      );
+
+      const authoritativeRev = files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.rev;
+      files.set(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE, {
+        dataStr:
+          getSyncFilePrefix({
+            isCompress: true,
+            isEncrypt: false,
+            modelVersion: 2,
+          }) + 'not-valid-gzip',
+        rev: authoritativeRev,
+      });
+      files.set(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE, {
+        dataStr: addPrefix(
+          createMockSyncData({
+            syncVersion: 10,
+            vectorClock: { oldClient: 10 },
+            clientId: 'oldClient',
+          }),
+        ),
+        rev: 'poisoned-backup-rev',
+      });
+      mockProvider.uploadFile.calls.reset();
+
+      await expectAsync(
+        TestBed.runInInjectionContext(() => new FileBasedSyncAdapterService())
+          .createAdapter(mockProvider, mockCfg, mockEncryptKey)
+          .downloadOps(0),
+      ).toBeRejected();
+
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('replaces a poisoned backup instead of promoting it during ordinary upload', async () => {
+      const files = new Map<string, { dataStr: string; rev: string }>();
+      let nextRev = 0;
+      const readFile = async (
+        path: string,
+      ): Promise<{ dataStr: string; rev: string }> => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return file;
+      };
+      mockProvider.downloadFile.and.callFake(readFile);
+      mockProvider.downloadFile
+        .withArgs(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+        .and.callFake(() =>
+          readFile(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE),
+        );
+      mockProvider.uploadFile.and.callFake(
+        async (
+          path: string,
+          dataStr: string,
+          revToMatch: string | null,
+          isForceOverwrite = false,
+        ) => {
+          const current = files.get(path);
+          if (
+            !isForceOverwrite &&
+            (revToMatch === null ? current !== undefined : current?.rev !== revToMatch)
+          ) {
+            throw new UploadRevToMatchMismatchAPIError();
+          }
+          const rev = `${path}-rev-${++nextRev}`;
+          files.set(path, { dataStr, rev });
+          return { rev };
+        },
+      );
+
+      await adapter.uploadSnapshot(
+        {},
+        'newClient',
+        'recovery',
+        { newClient: 1 },
+        1,
+        undefined,
+        'snapshot-before-poisoned-upload',
+      );
+      await adapter.uploadOps(
+        [createMockSyncOp({ id: 'op-after-snapshot' })],
+        'newClient',
+      );
+      files.set(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE, {
+        dataStr: addPrefix(
+          createMockSyncData({
+            syncVersion: 10,
+            vectorClock: { oldClient: 10 },
+            clientId: 'oldClient',
+          }),
+        ),
+        rev: 'poisoned-backup-rev',
+      });
+
+      const result = await adapter.uploadOps(
+        [createMockSyncOp({ id: 'op-after-poison' })],
+        'newClient',
+      );
+
+      expect(result.results[0].accepted).toBeTrue();
+      expect(
+        parseWithPrefix(files.get(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE)!.dataStr)
+          .clientId,
+      ).toBe('newClient');
+      expect(
+        parseWithPrefix(
+          files.get(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)!.dataStr,
+        ).recentOps.map((op) => op.id),
+      ).toContain('op-after-poison');
+    });
   });
 
   describe('deleteAllData', () => {
@@ -1172,6 +1574,12 @@ describe('FileBasedSyncAdapterService', () => {
       );
       expect(mockProvider.removeFile).toHaveBeenCalledWith(
         FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+      );
+      expect(mockProvider.removeFile).toHaveBeenCalledWith(
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+      );
+      expect(mockProvider.removeFile).toHaveBeenCalledWith(
+        FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
       );
       expect(mockProvider.removeFile).toHaveBeenCalledWith(
         FILE_BASED_SYNC_CONSTANTS.MIGRATION_LOCK_FILE,
@@ -1190,6 +1598,18 @@ describe('FileBasedSyncAdapterService', () => {
 
     it('should return failure when main sync file deletion fails with real error', async () => {
       mockProvider.removeFile.and.rejectWith(new Error('Permission denied'));
+
+      const result = await adapter.deleteAllData();
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should return failure when a user-data backup cannot be deleted', async () => {
+      mockProvider.removeFile.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+          throw new Error('Permission denied');
+        }
+      });
 
       const result = await adapter.deleteAllData();
 
@@ -1352,8 +1772,10 @@ describe('FileBasedSyncAdapterService', () => {
         );
 
         let uploadedDataStr: string = '';
-        mockProvider.uploadFile.and.callFake((_path: string, dataStr: string) => {
-          uploadedDataStr = dataStr;
+        mockProvider.uploadFile.and.callFake((path: string, dataStr: string) => {
+          if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+            uploadedDataStr = dataStr;
+          }
           return Promise.resolve({ rev: 'rev-1' });
         });
 
@@ -1376,8 +1798,10 @@ describe('FileBasedSyncAdapterService', () => {
         );
 
         let uploadedDataStr: string = '';
-        mockProvider.uploadFile.and.callFake((_path: string, dataStr: string) => {
-          uploadedDataStr = dataStr;
+        mockProvider.uploadFile.and.callFake((path: string, dataStr: string) => {
+          if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+            uploadedDataStr = dataStr;
+          }
           return Promise.resolve({ rev: 'rev-1' });
         });
 
@@ -1403,8 +1827,10 @@ describe('FileBasedSyncAdapterService', () => {
         );
 
         let uploadedDataStr: string = '';
-        mockProvider.uploadFile.and.callFake((_path: string, dataStr: string) => {
-          uploadedDataStr = dataStr;
+        mockProvider.uploadFile.and.callFake((path: string, dataStr: string) => {
+          if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+            uploadedDataStr = dataStr;
+          }
           return Promise.resolve({ rev: 'rev-1' });
         });
 
@@ -2132,8 +2558,10 @@ describe('FileBasedSyncAdapterService', () => {
       );
 
       let uploadedDataStr: string = '';
-      mockProvider.uploadFile.and.callFake((_path: string, dataStr: string) => {
-        uploadedDataStr = dataStr;
+      mockProvider.uploadFile.and.callFake((path: string, dataStr: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+          uploadedDataStr = dataStr;
+        }
         return Promise.resolve({ rev: 'rev-1' });
       });
 
@@ -2318,9 +2746,12 @@ describe('FileBasedSyncAdapterService', () => {
         clientId: 'prev-client',
         recentOps: [compactOp('prev-op') as never],
       });
-      mockProvider.downloadFile.and.returnValue(
-        Promise.resolve({ dataStr: addPrefix(prevData), rev: 'rev-1' }),
-      );
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+          return { dataStr: addPrefix(prevData), rev: 'rev-1' };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
 
       const uploadOrder: string[] = [];
       let backupDataStr = '';
@@ -2721,6 +3152,11 @@ describe('FileBasedSyncAdapterService', () => {
       )._syncCycleCache.clear();
     };
 
+    const syncFileDownloadCount = (): number =>
+      mockProvider.downloadFile.calls
+        .allArgs()
+        .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE).length;
+
     // The rev pre-check is enabled for providers with a cheap, content-stable rev.
     // WebDAV (the default mock) is deliberately NOT one of them, so exercise the
     // optimization on Dropbox. Re-create the adapter AFTER switching the id so the
@@ -2753,7 +3189,7 @@ describe('FileBasedSyncAdapterService', () => {
       const result = await adapter.downloadOps(2);
 
       // No full download happened.
-      expect(mockProvider.downloadFile).not.toHaveBeenCalled();
+      expect(syncFileDownloadCount()).toBe(0);
       // Empty, non-regressing "nothing new" response.
       expect(result.ops).toEqual([]);
       expect(result.hasMore).toBe(false);
@@ -2802,7 +3238,7 @@ describe('FileBasedSyncAdapterService', () => {
 
       const result = await adapter.downloadOps(2);
 
-      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(syncFileDownloadCount()).toBe(1);
       expect(result.ops.length).toBe(1);
       expect(result.latestSeq).toBe(3);
     });
@@ -2827,7 +3263,7 @@ describe('FileBasedSyncAdapterService', () => {
       const result = await adapter.downloadOps(2);
 
       // The cheap check failed but the sync did NOT fail — full download ran.
-      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(syncFileDownloadCount()).toBe(1);
       expect(result.latestSeq).toBe(2);
     });
 
@@ -2850,7 +3286,7 @@ describe('FileBasedSyncAdapterService', () => {
 
       const result = await adapter.downloadOps(2);
 
-      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(syncFileDownloadCount()).toBe(1);
       expect(result.latestSeq).toBe(2);
     });
 
@@ -2878,7 +3314,7 @@ describe('FileBasedSyncAdapterService', () => {
 
       const result = await adapter.downloadOps(2);
 
-      expect(mockProvider.downloadFile).not.toHaveBeenCalled();
+      expect(syncFileDownloadCount()).toBe(0);
       expect(result.ops).toEqual([]);
       // expected syncVersion after the upload was 2 → no seq regression.
       expect(result.latestSeq).toBe(2);
@@ -2910,7 +3346,7 @@ describe('FileBasedSyncAdapterService', () => {
 
       // The rev was never promoted, so there is no last-seen rev to match and the
       // full download runs — the un-applied ops are re-fetched, not skipped.
-      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(syncFileDownloadCount()).toBe(1);
       expect(result.latestSeq).toBe(2);
     });
 
@@ -2924,6 +3360,13 @@ describe('FileBasedSyncAdapterService', () => {
       localMock.downloadFile.and.returnValue(
         Promise.resolve({ dataStr: addPrefix(seed), rev: 'rev-1' }),
       );
+      localMock.downloadFile
+        .withArgs(FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE)
+        .and.rejectWith(
+          new RemoteFileNotFoundAPIError(
+            FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+          ),
+        );
       // No sync-ops.json on this single-file folder, so the SPAP-11 OFF-path probe
       // sees it absent; SYNC_FILE keeps a stable rev to exercise the SPAP-10 gating.
       localMock.getFileRev.and.callFake(async (path: string) => {
@@ -2944,7 +3387,11 @@ describe('FileBasedSyncAdapterService', () => {
       await localAdapter.downloadOps(2);
 
       // LocalFile is gated out → the full download still runs even though the rev matches.
-      expect(localMock.downloadFile).toHaveBeenCalledTimes(1);
+      expect(
+        localMock.downloadFile.calls
+          .allArgs()
+          .filter(([path]) => path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE).length,
+      ).toBe(1);
     });
 
     it('(f) forceFromSeq0 (sinceSeq=0) still full-downloads and returns snapshotState when the rev is unchanged', async () => {
@@ -2978,7 +3425,7 @@ describe('FileBasedSyncAdapterService', () => {
       const result = await adapter.downloadOps(0); // forceFromSeq0
 
       // Must perform the full download and return the snapshot used to rebuild local.
-      expect(mockProvider.downloadFile).toHaveBeenCalledTimes(1);
+      expect(syncFileDownloadCount()).toBe(1);
       expect(result.snapshotState).toBeDefined();
     });
 
@@ -3071,10 +3518,21 @@ describe('FileBasedSyncAdapterService', () => {
 
     // Routes downloadFile by path; unknown paths 404.
     const routeDownloads = (map: Record<string, string>): void => {
-      mockProvider.downloadFile.and.callFake(async (path: string) => {
+      const downloadByPath = async (
+        path: string,
+      ): Promise<{ dataStr: string; rev: string }> => {
         if (path in map) return { dataStr: map[path], rev: `${path}-rev` };
         throw new RemoteFileNotFoundAPIError(path);
-      });
+      };
+      mockProvider.downloadFile.and.callFake(downloadByPath);
+      for (const markerPath of [
+        C.SNAPSHOT_TRANSACTION_FILE,
+        C.OPS_SNAPSHOT_TRANSACTION_FILE,
+      ]) {
+        mockProvider.downloadFile
+          .withArgs(markerPath)
+          .and.callFake(() => downloadByPath(markerPath));
+      }
     };
 
     const recordUploads = (): void => {
@@ -3085,6 +3543,85 @@ describe('FileBasedSyncAdapterService', () => {
 
     const uploadedPaths = (): string[] =>
       mockProvider.uploadFile.calls.allArgs().map((args) => args[0] as string);
+
+    const installStatefulCasRemote = (
+      legacy: FileBasedSyncData,
+      crashAfterWrite?: number,
+    ): {
+      files: Map<string, { dataStr: string; rev: string }>;
+      disableCrash: () => void;
+      getWriteCount: () => number;
+    } => {
+      const files = new Map<string, { dataStr: string; rev: string }>([
+        [C.SYNC_FILE, { dataStr: addPrefix(legacy, 2), rev: 'legacy-seed-rev' }],
+      ]);
+      let nextRev = 0;
+      let writeCount = 0;
+      let activeCrashAfterWrite = crashAfterWrite;
+
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return file;
+      });
+      for (const markerPath of [
+        C.SNAPSHOT_TRANSACTION_FILE,
+        C.OPS_SNAPSHOT_TRANSACTION_FILE,
+      ]) {
+        mockProvider.downloadFile.withArgs(markerPath).and.callFake(async () => {
+          const file = files.get(markerPath);
+          if (!file) throw new RemoteFileNotFoundAPIError(markerPath);
+          return file;
+        });
+      }
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return { rev: file.rev };
+      });
+      mockProvider.uploadFile.and.callFake(
+        async (
+          path: string,
+          dataStr: string,
+          revToMatch: string | null,
+          isForceOverwrite = false,
+        ) => {
+          const current = files.get(path);
+          if (
+            !isForceOverwrite &&
+            (revToMatch === null ? current !== undefined : current?.rev !== revToMatch)
+          ) {
+            throw new UploadRevToMatchMismatchAPIError();
+          }
+
+          const rev = `${path}-rev-${++nextRev}`;
+          files.set(path, { dataStr, rev });
+          writeCount++;
+          if (writeCount === activeCrashAfterWrite) {
+            throw new Error(`simulated process crash after remote write ${writeCount}`);
+          }
+          return { rev };
+        },
+      );
+      mockProvider.removeFile.and.callFake(async (path: string) => {
+        files.delete(path);
+      });
+
+      return {
+        files,
+        disableCrash: () => {
+          activeCrashAfterWrite = undefined;
+        },
+        getWriteCount: () => writeCount,
+      };
+    };
+
+    const createFreshAdapter = (): OperationSyncCapable => {
+      const freshService = TestBed.runInInjectionContext(
+        () => new FileBasedSyncAdapterService(),
+      );
+      return freshService.createAdapter(mockProvider, mockCfg, mockEncryptKey);
+    };
 
     beforeEach(() => {
       splitSyncEnabled = true;
@@ -3109,9 +3646,13 @@ describe('FileBasedSyncAdapterService', () => {
       const paths = uploadedPaths();
       expect(paths).toContain(C.OPS_FILE);
       paths.forEach((p) => expect([C.OPS_FILE, C.OPS_BACKUP_FILE]).toContain(p as never));
-      // Only the ops file was downloaded.
+      // Only the ops commit point and its recovery artifact were downloaded.
       mockProvider.downloadFile.calls.allArgs().forEach((args) => {
-        expect(args[0]).toBe(C.OPS_FILE);
+        expect([
+          C.OPS_FILE,
+          C.OPS_BACKUP_FILE,
+          C.OPS_SNAPSHOT_TRANSACTION_FILE,
+        ]).toContain(args[0] as never);
       });
     });
 
@@ -3278,7 +3819,12 @@ describe('FileBasedSyncAdapterService', () => {
             syncVersion: 5,
             vectorClock: { original: 5 },
             recentOps: [makeCompactOp({ id: 'op-5', sv: 5, v: { original: 5 } })],
+            snapshotRef: { syncVersion: 1, vectorClock: { original: 5 } },
           }),
+          3,
+        ),
+        [C.STATE_FILE]: addPrefix(
+          makeStateFile({ syncVersion: 1, vectorClock: { original: 5 } }),
           3,
         ),
       });
@@ -3493,8 +4039,10 @@ describe('FileBasedSyncAdapterService', () => {
       ]);
     });
 
-    // (d) snapshotRef mismatch (and no usable backup) is treated as a gap.
-    it('(d) snapshotRef mismatch with no backup signals a gap (full re-download)', async () => {
+    // (d) A retained op tail is not a replacement for the snapshot base. If the
+    // referenced snapshot is unavailable, returning the tail with gapDetected
+    // would make the caller reset once and then accept incomplete remote state.
+    it('(d) snapshotRef mismatch with no backup fails closed', async () => {
       const opsFile = makeOpsFile({
         syncVersion: 5,
         recentOps: [makeCompactOp()],
@@ -3507,10 +4055,156 @@ describe('FileBasedSyncAdapterService', () => {
         // no .bak
       });
 
-      const res = await adapter.downloadOps(0, 'client2');
+      await expectAsync(adapter.downloadOps(0, 'client2')).toBeRejectedWith(
+        jasmine.any(SyncDataCorruptedError),
+      );
+    });
 
-      expect(res.gapDetected).toBe(true);
-      expect(res.snapshotState).toBeUndefined();
+    it('(d1) propagates a transient primary-state download failure unchanged', async () => {
+      const opsFile = makeOpsFile();
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) {
+          return { dataStr: addPrefix(opsFile, 3), rev: 'ops-rev-1' };
+        }
+        if (path === C.STATE_FILE) throw new Error('provider temporarily unavailable');
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+
+      await expectAsync(adapter.downloadOps(0, 'client2')).toBeRejectedWithError(
+        'provider temporarily unavailable',
+      );
+      expect(
+        mockProvider.downloadFile.calls
+          .allArgs()
+          .some(([path]) => path === C.STATE_BACKUP_FILE),
+      ).toBeFalse();
+    });
+
+    it('(d1) propagates a transient state-backup download failure unchanged', async () => {
+      const opsFile = makeOpsFile();
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) {
+          return { dataStr: addPrefix(opsFile, 3), rev: 'ops-rev-1' };
+        }
+        if (path === C.STATE_FILE) {
+          return {
+            dataStr: addPrefix(makeStateFile({ vectorClock: { stale: 1 } }), 3),
+            rev: 'state-stale-rev',
+          };
+        }
+        if (path === C.STATE_BACKUP_FILE) {
+          throw new Error('backup endpoint temporarily unavailable');
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+
+      await expectAsync(adapter.downloadOps(0, 'client2')).toBeRejectedWithError(
+        'backup endpoint temporarily unavailable',
+      );
+    });
+
+    it('(d2) preserves the snapshot referenced by committed ops across an abandoned compaction', async () => {
+      const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
+        makeCompactOp({ id: `op-${index}`, sv: 5 }),
+      );
+      const referencedClock = { committed: 1 };
+      const opsFile = makeOpsFile({
+        syncVersion: 5,
+        vectorClock: referencedClock,
+        recentOps: many,
+        snapshotRef: { syncVersion: 1, vectorClock: referencedClock },
+      });
+      const referencedBackup = makeStateFile({
+        syncVersion: 1,
+        vectorClock: referencedClock,
+        state: { tasks: ['committed'] },
+      });
+      const abandonedPrimary = makeStateFile({
+        syncVersion: 4,
+        vectorClock: { abandoned: 4 },
+        state: { tasks: ['unreferenced'] },
+      });
+      const files = new Map<string, { dataStr: string; rev: string }>([
+        [C.OPS_FILE, { dataStr: addPrefix(opsFile, 3), rev: 'ops-rev-5' }],
+        [
+          C.STATE_FILE,
+          { dataStr: addPrefix(abandonedPrimary, 3), rev: 'state-abandoned-rev' },
+        ],
+        [
+          C.STATE_BACKUP_FILE,
+          { dataStr: addPrefix(referencedBackup, 3), rev: 'state-backup-rev' },
+        ],
+      ]);
+      let revCounter = 0;
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        const file = files.get(path);
+        if (!file) throw new RemoteFileNotFoundAPIError(path);
+        return file;
+      });
+      mockProvider.uploadFile.and.callFake(
+        async (
+          path: string,
+          dataStr: string,
+          revToMatch: string | null,
+          isForceOverwrite = false,
+        ) => {
+          const current = files.get(path);
+          if (
+            !isForceOverwrite &&
+            (revToMatch === null ? current !== undefined : current?.rev !== revToMatch)
+          ) {
+            throw new UploadRevToMatchMismatchAPIError();
+          }
+          if (path === C.OPS_FILE) {
+            throw new Error('simulated crash before ops commit');
+          }
+          const rev = `${path}-new-${++revCounter}`;
+          files.set(path, { dataStr, rev });
+          return { rev };
+        },
+      );
+
+      await expectAsync(
+        adapter.uploadOps([createMockSyncOp()], 'client1'),
+      ).toBeRejectedWithError('simulated crash before ops commit');
+
+      const preserved = parseWithPrefix(
+        files.get(C.STATE_BACKUP_FILE)!.dataStr,
+      ) as unknown as FileBasedStateFile;
+      expect(preserved.syncVersion).toBe(1);
+      expect(preserved.vectorClock).toEqual(referencedClock);
+      expect((preserved.state as { tasks: string[] }).tasks).toEqual(['committed']);
+    });
+
+    it('(d3) aborts compaction when the required referenced-state backup cannot be written', async () => {
+      const many = Array.from({ length: C.MAX_RECENT_OPS }, (_, index) =>
+        makeCompactOp({ id: `op-${index}`, sv: 5 }),
+      );
+      const snapshotClock = { client1: 1 };
+      const opsFile = makeOpsFile({
+        syncVersion: 5,
+        recentOps: many,
+        snapshotRef: { syncVersion: 1, vectorClock: snapshotClock },
+      });
+      routeDownloads({
+        [C.OPS_FILE]: addPrefix(opsFile, 3),
+        [C.STATE_FILE]: addPrefix(
+          makeStateFile({ syncVersion: 1, vectorClock: snapshotClock }),
+          3,
+        ),
+      });
+      mockProvider.uploadFile.and.callFake(async (path: string) => {
+        if (path === C.STATE_BACKUP_FILE) throw new Error('backup unavailable');
+        return { rev: `${path}-newrev` };
+      });
+
+      await expectAsync(
+        adapter.uploadOps([createMockSyncOp()], 'client1'),
+      ).toBeRejectedWithError('backup unavailable');
+
+      const paths = uploadedPaths();
+      expect(paths).not.toContain(C.STATE_FILE);
+      expect(paths).not.toContain(C.OPS_FILE);
     });
 
     // (e) legacy v2 sync-data.json migrates in place: state+ops written, tombstone
@@ -3739,6 +4433,14 @@ describe('FileBasedSyncAdapterService', () => {
       routeDownloads({
         [C.SYNC_FILE]: addPrefix(legacy, 2),
         [C.OPS_FILE]: addPrefix(malformedPending, 3),
+        [C.STATE_FILE]: addPrefix(
+          makeStateFile({
+            syncVersion: 7,
+            vectorClock: { client1: 7 },
+            state: legacy.state,
+          }),
+          3,
+        ),
       });
 
       await adapter.downloadOps(0, 'client2');
@@ -4091,6 +4793,127 @@ describe('FileBasedSyncAdapterService', () => {
       expect((result.snapshotState as { tasks: string[] }).tasks).toEqual(['v8']);
     });
 
+    it('(e5) resumes safely after a process crash following every migration write', async () => {
+      const legacyOp = makeCompactOp({
+        id: 'legacy-op',
+        sv: 7,
+        v: { legacy: 7 },
+      });
+      const legacy = createMockSyncData({
+        syncVersion: 7,
+        vectorClock: { legacy: 7 },
+        recentOps: [legacyOp],
+        state: { tasks: ['legacy-state'] },
+      });
+      const newOp = createMockSyncOp({
+        id: 'new-op',
+        clientId: 'newClient',
+        vectorClock: { legacy: 7, newClient: 1 },
+      });
+
+      // Migration commits six remote writes before the ordinary op append:
+      // pending ops, state, legacy backup tombstone, legacy tombstone,
+      // pending recovery backup, and finalized ops.
+      for (let crashAfterWrite = 1; crashAfterWrite <= 6; crashAfterWrite++) {
+        localStorage.removeItem(C.SYNC_VERSION_STORAGE_KEY_PREFIX + 'versions');
+        localStorage.removeItem(C.SYNC_VERSION_STORAGE_KEY_PREFIX + 'seqCounters');
+        localStorage.removeItem(C.SYNC_VERSION_STORAGE_KEY_PREFIX + 'state');
+        const remote = installStatefulCasRemote(legacy, crashAfterWrite);
+
+        await expectAsync(
+          createFreshAdapter().uploadOps([newOp], 'newClient'),
+        ).toBeRejectedWithError(
+          `simulated process crash after remote write ${crashAfterWrite}`,
+        );
+        expect(remote.getWriteCount()).toBe(crashAfterWrite);
+
+        remote.disableCrash();
+        await createFreshAdapter().uploadOps([newOp], 'newClient');
+
+        const finalOps = parseWithPrefix(
+          remote.files.get(C.OPS_FILE)!.dataStr,
+        ) as unknown as FileBasedOpsFile;
+        const finalState = parseWithPrefix(
+          remote.files.get(C.STATE_FILE)!.dataStr,
+        ) as unknown as FileBasedStateFile;
+        const legacyTombstone = parseWithPrefix(
+          remote.files.get(C.SYNC_FILE)!.dataStr,
+        ) as unknown as { version: number; format: string };
+
+        expect(finalOps.migration).toBeUndefined();
+        expect(finalOps.recentOps.map((op) => op.id)).toContain('legacy-op');
+        expect(finalOps.recentOps.filter((op) => op.id === 'new-op').length).toBe(1);
+        expect((finalState.state as { tasks: string[] }).tasks).toEqual(['legacy-state']);
+        expect(legacyTombstone).toEqual(
+          jasmine.objectContaining({
+            version: C.SPLIT_FILE_VERSION,
+            format: C.SPLIT_TOMBSTONE_FORMAT,
+          }),
+        );
+      }
+    });
+
+    it('(e6) converges two concurrent migrators without losing either client operation', async () => {
+      const legacy = createMockSyncData({
+        syncVersion: 7,
+        vectorClock: { legacy: 7 },
+        recentOps: [makeCompactOp({ id: 'legacy-op', sv: 7, v: { legacy: 7 } })],
+        state: { tasks: ['legacy-state'] },
+      });
+      const remote = installStatefulCasRemote(legacy);
+      const clientOps = [
+        createMockSyncOp({
+          id: 'client-a-op',
+          clientId: 'clientA',
+          vectorClock: { legacy: 7, clientA: 1 },
+        }),
+        createMockSyncOp({
+          id: 'client-b-op',
+          clientId: 'clientB',
+          vectorClock: { legacy: 7, clientB: 1 },
+        }),
+      ];
+
+      const firstAttempts = await Promise.allSettled([
+        createFreshAdapter().uploadOps([clientOps[0]], 'clientA'),
+        createFreshAdapter().uploadOps([clientOps[1]], 'clientB'),
+      ]);
+      expect(firstAttempts.some((attempt) => attempt.status === 'fulfilled')).toBeTrue();
+
+      // A normal conditional-write loser retries on its next sync cycle.
+      for (let index = 0; index < firstAttempts.length; index++) {
+        const firstAttempt = firstAttempts[index];
+        if (firstAttempt.status === 'rejected') {
+          expect(firstAttempt.reason).toEqual(
+            jasmine.any(UploadRevToMatchMismatchAPIError),
+          );
+          await createFreshAdapter().uploadOps(
+            [clientOps[index]],
+            index === 0 ? 'clientA' : 'clientB',
+          );
+        }
+      }
+
+      const finalOps = parseWithPrefix(
+        remote.files.get(C.OPS_FILE)!.dataStr,
+      ) as unknown as FileBasedOpsFile;
+      const ids = finalOps.recentOps.map((op) => op.id);
+
+      expect(finalOps.migration).toBeUndefined();
+      expect(ids.filter((id) => id === 'legacy-op').length).toBe(1);
+      expect(ids.filter((id) => id === 'client-a-op').length).toBe(1);
+      expect(ids.filter((id) => id === 'client-b-op').length).toBe(1);
+      expect(finalOps.vectorClock).toEqual(
+        jasmine.objectContaining({ legacy: 7, clientA: 1, clientB: 1 }),
+      );
+      expect(parseWithPrefix(remote.files.get(C.SYNC_FILE)!.dataStr)).toEqual(
+        jasmine.objectContaining({
+          version: C.SPLIT_FILE_VERSION,
+          format: C.SPLIT_TOMBSTONE_FORMAT,
+        }),
+      );
+    });
+
     // (f) setting-OFF client seeing the tombstone raises the actionable notice
     // and does NOT upload/diverge.
     it('(f) OFF client hitting a split tombstone surfaces the enable-setting notice and does not upload', async () => {
@@ -4175,7 +4998,11 @@ describe('FileBasedSyncAdapterService', () => {
       // so a seq-0 split download must fetch ops AND state even when the rev matches.
       mockProvider.id = SyncProviderId.Dropbox;
       adapter = service.createAdapter(mockProvider, mockCfg, mockEncryptKey);
-      const opsFile = makeOpsFile({ syncVersion: 5, recentOps: [] });
+      const opsFile = makeOpsFile({
+        syncVersion: 5,
+        recentOps: [],
+        snapshotRef: { syncVersion: 5, vectorClock: { client1: 1 } },
+      });
       routeDownloads({
         [C.OPS_FILE]: addPrefix(opsFile, 3),
         [C.STATE_FILE]: addPrefix(
@@ -4223,6 +5050,64 @@ describe('FileBasedSyncAdapterService', () => {
       expect(bak.syncVersion).toBe(3);
     });
 
+    it('(i2) a stale uploader restores a newer ops backup and aborts its upload', async () => {
+      const stalePrimary = makeOpsFile({
+        syncVersion: 3,
+        vectorClock: { client1: 3 },
+        recentOps: [makeCompactOp({ id: 'op-stale', sv: 3 })],
+      });
+      const newerBackup = makeOpsFile({
+        syncVersion: 4,
+        vectorClock: { client1: 4 },
+        recentOps: [makeCompactOp({ id: 'op-newer', sv: 4 })],
+        snapshotRef: { syncVersion: 4, vectorClock: { client1: 4 } },
+      });
+      const encodedPendingSnapshot = addPrefix(newerBackup, 3);
+      const encodedPendingState = addPrefix(
+        makeStateFile({ syncVersion: 4, vectorClock: { client1: 4 } }),
+        3,
+      );
+      routeDownloads({
+        [C.OPS_FILE]: addPrefix(stalePrimary, 3),
+        [C.OPS_BACKUP_FILE]: addPrefix(newerBackup, 3),
+        [C.OPS_SNAPSHOT_TRANSACTION_FILE]: JSON.stringify({
+          version: 1,
+          status: 'pending',
+          transactionId: 'pending-snapshot',
+          encodedSnapshot: encodedPendingSnapshot,
+          encodedState: encodedPendingState,
+        }),
+      });
+
+      await expectAsync(
+        adapter.uploadOps([createMockSyncOp()], 'client1'),
+      ).toBeRejectedWithError(UploadRevToMatchMismatchAPIError);
+
+      expect(uploadedPaths()).toContain(C.OPS_BACKUP_FILE);
+      const primaryUploads = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === C.OPS_FILE);
+      expect(primaryUploads).toHaveSize(1);
+      const restored = parseWithPrefix(
+        primaryUploads[0][1] as string,
+      ) as unknown as FileBasedOpsFile;
+      expect(restored.syncVersion).toBe(4);
+      expect(restored.recentOps.map((op) => op.id)).toEqual(['op-newer']);
+      const transactionUploads = mockProvider.uploadFile.calls
+        .allArgs()
+        .filter(([path]) => path === C.OPS_SNAPSHOT_TRANSACTION_FILE);
+      const completedTransaction = JSON.parse(
+        transactionUploads[transactionUploads.length - 1][1] as string,
+      ) as { version: number; status: string; transactionId: string };
+      expect(completedTransaction).toEqual(
+        jasmine.objectContaining({
+          version: 1,
+          status: 'complete',
+          transactionId: 'pending-snapshot',
+        }),
+      );
+    });
+
     it('(i) recovers a corrupt sync-ops.json from .bak and heals it via ITS rev', async () => {
       const bakOps = makeOpsFile({
         syncVersion: 4,
@@ -4235,6 +5120,12 @@ describe('FileBasedSyncAdapterService', () => {
         if (path === C.OPS_FILE) return { dataStr: garbage, rev: 'corrupt-ops-rev' };
         if (path === C.OPS_BACKUP_FILE) {
           return { dataStr: addPrefix(bakOps, 3), rev: 'ops-bak-rev' };
+        }
+        if (path === C.STATE_FILE) {
+          return {
+            dataStr: addPrefix(makeStateFile(), 3),
+            rev: 'state-rev-1',
+          };
         }
         throw new RemoteFileNotFoundAPIError(path);
       });
@@ -4306,6 +5197,9 @@ describe('FileBasedSyncAdapterService', () => {
         if (path === C.OPS_BACKUP_FILE) {
           return { dataStr: addPrefix(bakOps, 3), rev: 'ops-bak-rev' };
         }
+        if (path === C.STATE_FILE) {
+          return { dataStr: addPrefix(makeStateFile(), 3), rev: 'state-rev-1' };
+        }
         throw new RemoteFileNotFoundAPIError(path);
       });
 
@@ -4317,13 +5211,22 @@ describe('FileBasedSyncAdapterService', () => {
       expect(lastSeen.get('Dropbox')).toBeUndefined();
     });
 
-    it('(i) snapshot upload refreshes the OPS .bak (not the ref-validated state .bak) before the primary', async () => {
-      // Rotation-safe replace: sync-ops.json.bak feeds UNVALIDATED recovery, so
-      // a pre-snapshot (possibly rotated-key) copy must not survive a snapshot
-      // upload. sync-state.json.bak is deliberately NOT refreshed — its adoption
-      // is ref-validated (EQUAL clock vs snapshotRef), so a stale copy is inert,
-      // and it must keep serving the compaction crash window it was made for.
-      routeDownloads({});
+    it('(i) snapshot transaction covers state and ops before publishing either file', async () => {
+      const committedClock = { committed: 1 };
+      routeDownloads({
+        [C.OPS_FILE]: addPrefix(
+          makeOpsFile({
+            syncVersion: 5,
+            vectorClock: committedClock,
+            snapshotRef: { syncVersion: 1, vectorClock: committedClock },
+          }),
+          3,
+        ),
+        [C.STATE_FILE]: addPrefix(
+          makeStateFile({ syncVersion: 1, vectorClock: committedClock }),
+          3,
+        ),
+      });
 
       await adapter.uploadSnapshot(
         {},
@@ -4338,16 +5241,123 @@ describe('FileBasedSyncAdapterService', () => {
       const paths = uploadedPaths();
       const oBak = paths.indexOf(C.OPS_BACKUP_FILE);
       const oMain = paths.indexOf(C.OPS_FILE);
+      const sBak = paths.indexOf(C.STATE_BACKUP_FILE);
+      const sMain = paths.indexOf(C.STATE_FILE);
+      const pending = paths.indexOf(C.OPS_SNAPSHOT_TRANSACTION_FILE);
+      const complete = paths.lastIndexOf(C.OPS_SNAPSHOT_TRANSACTION_FILE);
+      expect(pending).toBeGreaterThanOrEqual(0);
       expect(oBak).toBeGreaterThanOrEqual(0);
       expect(oMain).toBeGreaterThanOrEqual(0);
       expect(oBak).toBeLessThan(oMain);
-      // Identical payloads: the ops .bak IS the fresh snapshot-reset ops file.
+      expect(sBak).toBeGreaterThanOrEqual(0);
+      expect(sMain).toBeGreaterThanOrEqual(0);
+      expect(pending).toBeLessThan(sMain);
+      expect(sMain).toBeLessThan(oBak);
+      expect(oMain).toBeLessThan(sBak);
+      expect(sBak).toBeLessThan(complete);
+      const stateUpload = mockProvider.uploadFile.calls.allArgs()[sMain];
+      expect(stateUpload[2]).toBeNull();
+      expect(stateUpload[3]).toBeTrue();
+      // Both backups carry the fresh transaction payload, so no stale key or
+      // pre-snapshot state remains recoverable after completion.
       const argAt = (i: number): string =>
         mockProvider.uploadFile.calls.allArgs()[i][1] as string;
       expect(argAt(oBak)).toBe(argAt(oMain));
-      // State .bak untouched.
-      expect(paths).not.toContain(C.STATE_BACKUP_FILE);
-      expect(paths).toContain(C.STATE_FILE);
+      expect(argAt(sBak)).toBe(argAt(sMain));
+      const publishedState = parseWithPrefix(argAt(sBak));
+      expect(publishedState.syncVersion).toBe(1);
+      expect(publishedState.vectorClock).toEqual({ client1: 1 });
+    });
+
+    it('(i) recovers a split snapshot after every transaction write', async () => {
+      for (let crashAfterWrite = 1; crashAfterWrite <= 6; crashAfterWrite++) {
+        const remote = installStatefulCasRemote(
+          createMockSyncData({
+            syncVersion: 7,
+            vectorClock: { oldClient: 7 },
+            clientId: 'oldClient',
+          }),
+          crashAfterWrite,
+        );
+        const snapshotAdapter = createFreshAdapter();
+
+        await expectAsync(
+          snapshotAdapter.uploadSnapshot(
+            {},
+            'newClient',
+            'recovery',
+            { newClient: 1 },
+            1,
+            undefined,
+            `split-snapshot-${crashAfterWrite}`,
+          ),
+        ).toBeRejectedWithError(
+          `simulated process crash after remote write ${crashAfterWrite}`,
+        );
+
+        remote.disableCrash();
+        const recovered = await createFreshAdapter().downloadOps(0);
+
+        expect(recovered.latestSeq).toBe(1);
+        expect(recovered.snapshotVectorClock).toEqual({ newClient: 1 });
+        const ops = parseWithPrefix(
+          remote.files.get(C.OPS_FILE)!.dataStr,
+        ) as unknown as FileBasedOpsFile;
+        const state = parseWithPrefix(
+          remote.files.get(C.STATE_FILE)!.dataStr,
+        ) as unknown as FileBasedStateFile;
+        expect(ops.clientId).toBe('newClient');
+        expect(state.clientId).toBe('newClient');
+        expect(
+          JSON.parse(remote.files.get(C.OPS_SNAPSHOT_TRANSACTION_FILE)!.dataStr),
+        ).toEqual(jasmine.objectContaining({ status: 'complete' }));
+
+        mockProvider.downloadFile.calls.reset();
+        mockProvider.uploadFile.calls.reset();
+      }
+    });
+
+    it('(i) rejects a poisoned state backup when the bound state revision is current', async () => {
+      const remote = installStatefulCasRemote(createMockSyncData());
+      await createFreshAdapter().uploadSnapshot(
+        {},
+        'newClient',
+        'recovery',
+        { newClient: 1 },
+        1,
+        undefined,
+        'split-state-digest',
+      );
+
+      const stateRev = remote.files.get(C.STATE_FILE)!.rev;
+      remote.files.set(C.STATE_FILE, {
+        dataStr: addPrefix(
+          makeStateFile({
+            syncVersion: 2,
+            vectorClock: { otherClient: 2 },
+            clientId: 'otherClient',
+          }),
+          3,
+        ),
+        rev: stateRev,
+      });
+      remote.files.set(C.STATE_BACKUP_FILE, {
+        dataStr: addPrefix(
+          makeStateFile({
+            syncVersion: 1,
+            vectorClock: { newClient: 1 },
+            clientId: 'oldClient',
+            state: { tasks: ['poisoned'] },
+          }),
+          3,
+        ),
+        rev: 'poisoned-state-backup-rev',
+      });
+      mockProvider.uploadFile.calls.reset();
+
+      await expectAsync(createFreshAdapter().downloadOps(0)).toBeRejected();
+
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
     });
 
     it('(i) deleteAllData removes the split files (BEFORE the tombstone) and their .baks', async () => {

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -53,6 +53,39 @@ import {
   encodeOperation,
   decodeOperation,
 } from '../../persistence/compact/operation-codec.service';
+import { uuidv7 } from '../../../util/uuid-v7';
+
+interface PendingSnapshotTransaction {
+  version: 1;
+  status: 'pending';
+  transactionId: string;
+  encodedSnapshot: string;
+  encodedState?: string;
+}
+
+interface CompleteSnapshotTransaction {
+  version: 1;
+  status: 'complete';
+  transactionId: string;
+  primaryRev: string;
+  snapshotDigest: string;
+  statePrimaryRev?: string;
+  stateDigest?: string;
+}
+
+type SnapshotTransaction = PendingSnapshotTransaction | CompleteSnapshotTransaction;
+
+interface SnapshotTransactionObservation {
+  didRecover: boolean;
+  rev: string | null;
+  complete?: CompleteSnapshotTransaction;
+}
+
+interface SnapshotTransactionGuard {
+  path: string;
+  rev: string | null;
+  complete?: CompleteSnapshotTransaction;
+}
 
 /**
  * Adapter that enables file-based sync providers (WebDAV, Dropbox, LocalFile)
@@ -716,6 +749,25 @@ export class FileBasedSyncAdapterService {
       );
     }
 
+    const snapshotTransaction =
+      await this._recoverPendingSnapshotTransaction<FileBasedSyncData>(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+        (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
+      );
+    if (snapshotTransaction.didRecover) {
+      this._clearCachedSyncData(providerKey);
+      this._lastSeenRevs.delete(providerKey);
+      throw new UploadRevToMatchMismatchAPIError(
+        'FileBasedSyncAdapter: Recovered a pending snapshot; download it before retrying the upload.',
+      );
+    }
+
     // Step 1: Get current sync state
     const { currentData, currentSyncVersion, fileExists, revToMatch } =
       await this._getCurrentSyncState(provider, cfg, encryptKey, providerKey);
@@ -762,6 +814,18 @@ export class FileBasedSyncAdapterService {
         FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
         currentData,
         FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+        (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
+        {
+          primaryPath: FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          primaryRev: revToMatch,
+          snapshotTransaction: {
+            path: FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+            rev: snapshotTransaction.rev,
+            ...(snapshotTransaction.complete
+              ? { complete: snapshotTransaction.complete }
+              : {}),
+          },
+        },
       );
     }
 
@@ -837,6 +901,22 @@ export class FileBasedSyncAdapterService {
         limit,
         providerKey,
       );
+    }
+
+    const snapshotTransaction =
+      await this._recoverPendingSnapshotTransaction<FileBasedSyncData>(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+        (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
+      );
+    if (snapshotTransaction.didRecover) {
+      this._clearCachedSyncData(providerKey);
+      this._lastSeenRevs.delete(providerKey);
     }
 
     // SPAP-10: cheap remote-rev pre-check. If we already know the last-seen rev
@@ -923,6 +1003,12 @@ export class FileBasedSyncAdapterService {
       if (this._isRecoverableCorruption(e)) {
         // Primary sync-data.json is corrupt/empty/unparseable (e.g. interrupted
         // write). Try to recover from the .bak artifact before failing.
+        const annotatedPrimaryRev = (e as { primaryRev?: string } | null)?.primaryRev;
+        const completedSnapshot = snapshotTransaction.complete;
+        const expectedSnapshotDigest =
+          completedSnapshot && completedSnapshot.primaryRev === annotatedPrimaryRev
+            ? completedSnapshot.snapshotDigest
+            : undefined;
         const recovered = await this._readBakFile<FileBasedSyncData>(
           provider,
           cfg,
@@ -930,6 +1016,8 @@ export class FileBasedSyncAdapterService {
           FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
           FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
           (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
+          undefined,
+          expectedSnapshotDigest,
         );
         if (recovered) {
           recoveredFromBackup = true;
@@ -943,8 +1031,7 @@ export class FileBasedSyncAdapterService {
           // .bak rev would mismatch the primary on every upload, leaving sync stuck
           // in a re-recover/re-fail loop. Fall back to the .bak rev if the primary
           // rev is unavailable (a later mismatch just re-recovers — no data loss).
-          const primaryRev =
-            (e as { primaryRev?: string } | null)?.primaryRev ?? recovered.rev;
+          const primaryRev = annotatedPrimaryRev ?? recovered.rev;
           rev = primaryRev;
           this._setCachedSyncData(providerKey, syncData, rev);
           this._notifyRecoveredCorruptPrimaryOnce(providerKey, primaryRev);
@@ -1214,6 +1301,17 @@ export class FileBasedSyncAdapterService {
       );
     }
 
+    await this._recoverPendingSnapshotTransaction<FileBasedSyncData>(
+      provider,
+      cfg,
+      encryptKey,
+      FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+      FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+      FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+      FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+      (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
+    );
+
     // For snapshots, we start fresh with syncVersion = 1
     const newSyncVersion = 1;
 
@@ -1250,6 +1348,7 @@ export class FileBasedSyncAdapterService {
       provider,
       FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
       FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+      FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
       uploadData,
     );
 
@@ -1291,9 +1390,14 @@ export class FileBasedSyncAdapterService {
       // (an OFF client would then fresh-start a v2 file against it). "Not
       // found" is fine — most users are on the single-file format.
       for (const dataFile of [
+        FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
         FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
         FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
         FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
       ]) {
         try {
           await provider.removeFile(dataFile);
@@ -1304,14 +1408,9 @@ export class FileBasedSyncAdapterService {
         }
       }
 
-      // Disposable artifacts: best-effort — leaving one behind degrades nothing
-      // (recovery only triggers on a corrupt primary, never on a missing one).
-      for (const artifact of [
-        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
-        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
-        FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
-        FILE_BASED_SYNC_CONSTANTS.MIGRATION_LOCK_FILE,
-      ]) {
+      // The advisory migration lock contains no user data and is safe to leave
+      // behind if the provider rejects its best-effort cleanup.
+      for (const artifact of [FILE_BASED_SYNC_CONSTANTS.MIGRATION_LOCK_FILE]) {
         try {
           await provider.removeFile(artifact);
         } catch (e) {
@@ -1632,25 +1731,85 @@ export class FileBasedSyncAdapterService {
   }
 
   /**
-   * Copies the current `sync-state.json` to its `.bak` and returns the exact
-   * snapshot/rev that a subsequent conditional replacement must match. A missing
-   * state file is the first-compaction case and returns null; any other
-   * read/decode failure aborts rather than force-overwriting an unknown snapshot.
+   * Preserves the state referenced by the committed ops file before replacing
+   * `sync-state.json`, then returns the primary revision the replacement must
+   * match. If an abandoned replacement left an unreferenced primary, an already
+   * valid backup is retained instead of being rotated away.
    */
   private async _backupStateFile(
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
-  ): Promise<{ data: FileBasedStateFile; rev: string } | null> {
-    let current: { data: FileBasedStateFile; rev: string };
+    committedOpsFile?: FileBasedOpsFile,
+    snapshotTransaction?: SnapshotTransactionGuard,
+  ): Promise<{ data?: FileBasedStateFile; rev: string | null } | null> {
+    let current: { data: FileBasedStateFile; rev: string } | null = null;
+    let primaryRev: string | null = null;
     try {
       current = await this._downloadStateFile(provider, cfg, encryptKey);
+      primaryRev = current.rev;
     } catch (e) {
       if (e instanceof RemoteFileNotFoundAPIError) {
-        return null;
+        if (!committedOpsFile) return null;
+      } else if (this._isRecoverableCorruption(e)) {
+        const annotatedRev = (e as { primaryRev?: unknown } | null)?.primaryRev;
+        if (typeof annotatedRev !== 'string') throw e;
+        primaryRev = annotatedRev;
+      } else {
+        throw e;
       }
-      throw e;
     }
+
+    if (!committedOpsFile) {
+      if (snapshotTransaction) {
+        await this._assertSnapshotTransactionUnchanged(provider, snapshotTransaction);
+      }
+      if (!current) return primaryRev === null ? null : { rev: primaryRev };
+      await this._writeBakFile(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
+        current.data,
+        FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+        (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+        {
+          primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+          primaryRev,
+          snapshotTransaction,
+        },
+      );
+      return current;
+    }
+
+    const backup = await this._readBakFile<FileBasedStateFile>(
+      provider,
+      cfg,
+      encryptKey,
+      FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
+      FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+      (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+      undefined,
+      this._getSnapshotBoundBackupDigest(
+        snapshotTransaction,
+        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        primaryRev,
+      ),
+    );
+    if (snapshotTransaction) {
+      await this._assertSnapshotTransactionUnchanged(provider, snapshotTransaction);
+    }
+    if (backup && this._validateSnapshotRef(committedOpsFile, backup.data)) {
+      return current ?? { data: backup.data, rev: primaryRev };
+    }
+
+    if (!current || !this._validateSnapshotRef(committedOpsFile, current.data)) {
+      throw new SyncDataCorruptedError(
+        'Neither sync-state.json nor its backup matches the committed snapshotRef',
+        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+      );
+    }
+
     await this._writeBakFile(
       provider,
       cfg,
@@ -1658,6 +1817,13 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
       current.data,
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+      (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+      {
+        isRequired: true,
+        primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        primaryRev,
+        snapshotTransaction,
+      },
     );
     return current;
   }
@@ -1667,6 +1833,7 @@ export class FileBasedSyncAdapterService {
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
+    expectedDigest?: string,
   ): Promise<FileBasedStateFile | null> {
     const recovered = await this._readBakFile<FileBasedStateFile>(
       provider,
@@ -1675,6 +1842,8 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
       (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+      undefined,
+      expectedDigest,
     );
     return recovered?.data ?? null;
   }
@@ -1701,24 +1870,45 @@ export class FileBasedSyncAdapterService {
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
     opsFile: FileBasedOpsFile,
+    completeTransaction?: CompleteSnapshotTransaction,
   ): Promise<FileBasedStateFile | null> {
     let corruptPrimaryRev: string | undefined;
+    let observedPrimaryRev: string | undefined;
     try {
-      const { data } = await this._downloadStateFile(provider, cfg, encryptKey);
+      const { data, rev } = await this._downloadStateFile(provider, cfg, encryptKey);
+      observedPrimaryRev = rev;
       if (this._validateSnapshotRef(opsFile, data)) return data;
       OpLog.warn(
         'FileBasedSyncAdapter: sync-state.json does not match snapshotRef; trying .bak',
       );
     } catch (e) {
+      if (
+        !(e instanceof RemoteFileNotFoundAPIError) &&
+        !this._isRecoverableCorruption(e)
+      ) {
+        throw e;
+      }
       if (this._isRecoverableCorruption(e)) {
         const annotatedRev = (e as { primaryRev?: unknown } | null)?.primaryRev;
         if (typeof annotatedRev === 'string') {
           corruptPrimaryRev = annotatedRev;
+          observedPrimaryRev = annotatedRev;
         }
       }
       OpLog.warn('FileBasedSyncAdapter: sync-state.json unreadable; trying .bak', e);
     }
-    const bak = await this._recoverStateFromBackup(provider, cfg, encryptKey);
+    const completedStateSnapshot = completeTransaction;
+    const expectedStateDigest =
+      completedStateSnapshot &&
+      completedStateSnapshot.statePrimaryRev === observedPrimaryRev
+        ? completedStateSnapshot.stateDigest
+        : undefined;
+    const bak = await this._recoverStateFromBackup(
+      provider,
+      cfg,
+      encryptKey,
+      expectedStateDigest,
+    );
     if (bak && this._validateSnapshotRef(opsFile, bak)) {
       if (corruptPrimaryRev) {
         try {
@@ -2026,12 +2216,14 @@ export class FileBasedSyncAdapterService {
     encryptKey: string | undefined,
     initialPending: FileBasedOpsFile,
     initialPendingRev: string,
+    snapshotTransaction: SnapshotTransactionGuard,
   ): Promise<{ data: FileBasedOpsFile; rev: string }> {
     let current = { data: initialPending, rev: initialPendingRev };
     const maxAttempts = 1 + this._MAX_UPLOAD_RETRIES;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       if (!this._isPendingSplitMigration(current.data)) return current;
+      await this._assertSnapshotTransactionUnchanged(provider, snapshotTransaction);
 
       let legacy: { data: FileBasedSyncData; rev: string } | undefined;
       try {
@@ -2088,8 +2280,14 @@ export class FileBasedSyncAdapterService {
         legacy.data,
         current.data.clientId,
       );
-      const previousState = await this._backupStateFile(provider, cfg, encryptKey);
-      if (previousState) {
+      const previousState = await this._backupStateFile(
+        provider,
+        cfg,
+        encryptKey,
+        undefined,
+        snapshotTransaction,
+      );
+      if (previousState?.data) {
         const nextStateComparison = compareVectorClocks(
           nextState.vectorClock,
           previousState.data.vectorClock,
@@ -2170,6 +2368,7 @@ export class FileBasedSyncAdapterService {
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
     clientId: string,
+    snapshotTransaction: SnapshotTransactionGuard,
   ): Promise<{ data: FileBasedOpsFile; rev: string } | null> {
     let legacy: { data: FileBasedSyncData; rev: string };
     try {
@@ -2210,6 +2409,7 @@ export class FileBasedSyncAdapterService {
       encryptKey,
       pending.data,
       pending.rev,
+      snapshotTransaction,
     );
   }
 
@@ -2287,6 +2487,39 @@ export class FileBasedSyncAdapterService {
     providerKey: string,
     localStateSnapshot?: unknown,
   ): Promise<OpUploadResponse> {
+    const snapshotTransaction =
+      await this._recoverPendingSnapshotTransaction<FileBasedOpsFile>(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+        (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
+        {
+          primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+          bakPath: FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
+          expectedVersion: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+          isValid: (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+          matchesSnapshot: (snapshot, state) =>
+            this._isFileBasedStateFile(state) &&
+            this._validateSnapshotRef(snapshot, state),
+        },
+      );
+    if (snapshotTransaction.didRecover) {
+      this._clearCachedOpsData(providerKey);
+      this._lastSeenRevs.delete(providerKey);
+      throw new UploadRevToMatchMismatchAPIError(
+        'FileBasedSyncAdapter: Recovered a pending split snapshot; download it before retrying the upload.',
+      );
+    }
+    const snapshotTransactionGuard: SnapshotTransactionGuard = {
+      path: FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+      rev: snapshotTransaction.rev,
+      ...(snapshotTransaction.complete ? { complete: snapshotTransaction.complete } : {}),
+    };
+
     let opsFile: FileBasedOpsFile | null = null;
     let opsRev: string | null = null;
 
@@ -2307,6 +2540,7 @@ export class FileBasedSyncAdapterService {
             cfg,
             encryptKey,
             clientId,
+            snapshotTransactionGuard,
           );
           if (migrated) {
             opsFile = migrated.data;
@@ -2325,6 +2559,7 @@ export class FileBasedSyncAdapterService {
         encryptKey,
         opsFile,
         opsRev,
+        snapshotTransactionGuard,
       );
       opsFile = resumed.data;
       opsRev = resumed.rev;
@@ -2376,7 +2611,13 @@ export class FileBasedSyncAdapterService {
         localStateSnapshot,
       );
       // Preserve the pre-compaction snapshot for snapshotRef-mismatch recovery.
-      const previousState = await this._backupStateFile(provider, cfg, encryptKey);
+      const previousState = await this._backupStateFile(
+        provider,
+        cfg,
+        encryptKey,
+        opsFile ?? undefined,
+        snapshotTransactionGuard,
+      );
       // Atomicity: sync-state.json FIRST, then the ops file that references it.
       const stateRev = await this._writeStateFile(provider, cfg, encryptKey, stateData, {
         revToMatch: previousState?.rev ?? null,
@@ -2428,6 +2669,12 @@ export class FileBasedSyncAdapterService {
         FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
         opsFile,
         FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+        (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
+        {
+          primaryPath: FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+          primaryRev: opsRev,
+          snapshotTransaction: snapshotTransactionGuard,
+        },
       );
     }
 
@@ -2473,6 +2720,36 @@ export class FileBasedSyncAdapterService {
     limit: number,
     providerKey: string,
   ): Promise<FileSnapshotOpDownloadResponse> {
+    const snapshotTransaction =
+      await this._recoverPendingSnapshotTransaction<FileBasedOpsFile>(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+        (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
+        {
+          primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+          bakPath: FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
+          expectedVersion: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+          isValid: (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+          matchesSnapshot: (snapshot, state) =>
+            this._isFileBasedStateFile(state) &&
+            this._validateSnapshotRef(snapshot, state),
+        },
+      );
+    if (snapshotTransaction.didRecover) {
+      this._clearCachedOpsData(providerKey);
+      this._lastSeenRevs.delete(providerKey);
+    }
+    const snapshotTransactionGuard: SnapshotTransactionGuard = {
+      path: FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+      rev: snapshotTransaction.rev,
+      ...(snapshotTransaction.complete ? { complete: snapshotTransaction.complete } : {}),
+    };
+
     // SPAP-10 rev pre-check, extended to the ops file. Gated on `sinceSeq > 0`
     // (review follow-up): a forceFromSeq0 download (sinceSeq === 0) re-pulls the
     // full snapshot to REBUILD local state (e.g. USE_REMOTE), so it must never be
@@ -2523,6 +2800,12 @@ export class FileBasedSyncAdapterService {
         // sync): recover from .bak — same SPAP-8 semantics as the single-file
         // path, including seeding the heal cache with the CORRUPT primary's rev
         // so this cycle's upload conditionally matches and heals it.
+        const annotatedPrimaryRev = (e as { primaryRev?: string } | null)?.primaryRev;
+        const completedSnapshot = snapshotTransaction.complete;
+        const expectedSnapshotDigest =
+          completedSnapshot && completedSnapshot.primaryRev === annotatedPrimaryRev
+            ? completedSnapshot.snapshotDigest
+            : undefined;
         const recovered = await this._readBakFile<FileBasedOpsFile>(
           provider,
           cfg,
@@ -2530,6 +2813,8 @@ export class FileBasedSyncAdapterService {
           FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
           FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
           (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
+          undefined,
+          expectedSnapshotDigest,
         );
         if (!recovered) throw e;
         recoveredFromBackup = true;
@@ -2537,7 +2822,7 @@ export class FileBasedSyncAdapterService {
           'FileBasedSyncAdapter: Primary ops file unreadable; recovered from backup',
         );
         opsFile = recovered.data;
-        opsRev = (e as { primaryRev?: string } | null)?.primaryRev ?? recovered.rev;
+        opsRev = annotatedPrimaryRev ?? recovered.rev;
         this._setCachedOpsData(providerKey, opsFile, opsRev);
         this._notifyRecoveredCorruptPrimaryOnce(providerKey, opsRev);
       } else {
@@ -2552,6 +2837,7 @@ export class FileBasedSyncAdapterService {
         encryptKey,
         opsFile,
         opsRev,
+        snapshotTransactionGuard,
       );
       opsFile = resumed.data;
       opsRev = resumed.rev;
@@ -2591,7 +2877,7 @@ export class FileBasedSyncAdapterService {
       opsFile.oldestOpSyncVersion !== undefined &&
       opsFile.oldestOpSyncVersion > sinceSeq + 1;
     const gapWasAlreadyUnresolved = this._unresolvedGapProviderKeys.has(providerKey);
-    let needsGapDetection =
+    const needsGapDetection =
       gapWasAlreadyUnresolved || versionWasReset || snapshotReplacement || partialTrimGap;
 
     if (needsGapDetection && !gapWasAlreadyUnresolved) {
@@ -2631,7 +2917,13 @@ export class FileBasedSyncAdapterService {
     let snapshotStateWithArchives: Record<string, unknown> | undefined;
     let snapshot: FileBasedStateFile | undefined;
     if (isForceFromZero || needsGapDetection) {
-      const snap = await this._loadValidatedSnapshot(provider, cfg, encryptKey, opsFile);
+      const snap = await this._loadValidatedSnapshot(
+        provider,
+        cfg,
+        encryptKey,
+        opsFile,
+        snapshotTransaction.complete,
+      );
       if (snap) {
         snapshot = snap;
         snapshotStateWithArchives = {
@@ -2640,8 +2932,13 @@ export class FileBasedSyncAdapterService {
           ...(snap.archiveOld ? { archiveOld: snap.archiveOld } : {}),
         };
       } else {
-        // No snapshot validates the ref ⇒ treat as gap so the caller re-syncs.
-        needsGapDetection = true;
+        // A retained op tail cannot reconstruct data already compacted into the
+        // missing snapshot. Returning it with gapDetected would make the caller
+        // reset once and then accept incomplete state on the second response.
+        throw new SyncDataCorruptedError(
+          'No state snapshot matches the committed snapshotRef',
+          FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        );
       }
     }
 
@@ -2732,6 +3029,25 @@ export class FileBasedSyncAdapterService {
     providerKey: string,
     state: unknown,
   ): Promise<SnapshotUploadResponse> {
+    await this._recoverPendingSnapshotTransaction<FileBasedOpsFile>(
+      provider,
+      cfg,
+      encryptKey,
+      FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+      FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+      FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+      FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+      (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
+      {
+        primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        bakPath: FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
+        expectedVersion: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+        isValid: (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+        matchesSnapshot: (snapshot, state) =>
+          this._isFileBasedStateFile(state) && this._validateSnapshotRef(snapshot, state),
+      },
+    );
+
     const newSyncVersion = 1;
     const clock = vectorClock as VectorClock;
 
@@ -2742,12 +3058,16 @@ export class FileBasedSyncAdapterService {
       schemaVersion,
       state,
     );
-    // sync-state.json.bak is deliberately NOT refreshed here: its adoption is
-    // ref-validated (_loadValidatedSnapshot requires an EQUAL clock against the
-    // ops file's snapshotRef), so a stale — even rotated-key — state .bak is
-    // inert, and it must keep serving the COMPACTION crash window (state
-    // written, ops not yet) it was backed up for.
-    const stateRev = await this._writeStateFile(provider, cfg, encryptKey, stateData);
+    const stateEncoded = await this._encryptAndCompressHandler.compressAndEncryptData(
+      cfg,
+      encryptKey,
+      stateData,
+      FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+    );
+    this._assertUploadDataNotEmpty(
+      stateEncoded,
+      'FileBasedSyncAdapter._uploadSnapshotSplit state',
+    );
 
     const opsData: FileBasedOpsFile = {
       version: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
@@ -2757,7 +3077,7 @@ export class FileBasedSyncAdapterService {
       lastModified: Date.now(),
       clientId,
       recentOps: [],
-      snapshotRef: { syncVersion: newSyncVersion, vectorClock: clock, rev: stateRev },
+      snapshotRef: { syncVersion: newSyncVersion, vectorClock: clock },
     };
     const opsEncoded = await this._encryptAndCompressHandler.compressAndEncryptData(
       cfg,
@@ -2767,12 +3087,11 @@ export class FileBasedSyncAdapterService {
     );
     this._assertUploadDataNotEmpty(
       opsEncoded,
-      'FileBasedSyncAdapter._uploadSnapshotSplit',
+      'FileBasedSyncAdapter._uploadSnapshotSplit ops',
     );
-    const opsRes = await this._forceUploadWithBakFirst(
+    const opsRes = await this._forceUploadSplitSnapshot(
       provider,
-      FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
-      FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+      stateEncoded,
       opsEncoded,
     );
     await this._writeTombstoneAndNeutralizeBak(provider, cfg, encryptKey);
@@ -2801,27 +3120,104 @@ export class FileBasedSyncAdapterService {
     }
   }
 
-  /**
-   * Writes `data` to a `.bak` recovery artifact before its primary file is
-   * overwritten (two-phase write).
-   *
-   * MUST be non-fatal: a provider that cannot write the backup (e.g. no copy
-   * support, transient failure) must still be able to sync. The backup is a
-   * recovery artifact — losing it only degrades recoverability, never sync.
-   *
-   * Force-overwrite is used here because .bak is a disposable recovery artifact,
-   * NOT a source-of-truth sync file — the lost-update guarantee on the primary
-   * (conditional PUT) is unaffected.
-   */
-  private async _writeBakFile<T>(
+  private async _digestEncodedPayload(encoded: string): Promise<string> {
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(encoded),
+    );
+    return Array.from(new Uint8Array(digest), (byte) =>
+      byte.toString(16).padStart(2, '0'),
+    ).join('');
+  }
+
+  private _getSnapshotBoundBackupDigest(
+    guard: SnapshotTransactionGuard | undefined,
+    primaryPath: string | undefined,
+    primaryRev: string | null | undefined,
+  ): string | undefined {
+    const complete = guard?.complete;
+    if (!complete || primaryRev == null) return undefined;
+    if (
+      primaryPath === FILE_BASED_SYNC_CONSTANTS.STATE_FILE &&
+      complete.statePrimaryRev === primaryRev
+    ) {
+      return complete.stateDigest;
+    }
+    return complete.primaryRev === primaryRev ? complete.snapshotDigest : undefined;
+  }
+
+  /** Writes a recovery backup without replacing a causally newer artifact. */
+  private async _writeBakFile<
+    T extends { version: number; syncVersion: number; vectorClock: VectorClock },
+  >(
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
     bakPath: string,
     data: T,
     fileVersion: number,
+    isValid: (data: unknown) => data is T,
+    options: {
+      isRequired?: boolean;
+      primaryPath?: string;
+      primaryRev?: string | null;
+      snapshotTransaction?: SnapshotTransactionGuard;
+    } = {},
   ): Promise<void> {
     try {
+      let backupRev: string | null = null;
+      const expectedBackupDigest = this._getSnapshotBoundBackupDigest(
+        options.snapshotTransaction,
+        options.primaryPath,
+        options.primaryRev,
+      );
+      const existing = await this._readBakFile<T>(
+        provider,
+        cfg,
+        encryptKey,
+        bakPath,
+        fileVersion,
+        isValid,
+        (rev) => {
+          backupRev = rev;
+        },
+        expectedBackupDigest,
+      );
+      if (options.snapshotTransaction) {
+        await this._assertSnapshotTransactionUnchanged(
+          provider,
+          options.snapshotTransaction,
+        );
+      }
+      if (existing) {
+        const clockOrder = compareVectorClocks(
+          data.vectorClock,
+          existing.data.vectorClock,
+        );
+        const isSameRecoveryPoint =
+          clockOrder === 'EQUAL' && data.syncVersion === existing.data.syncVersion;
+        const isStrictlyNewer =
+          clockOrder === 'GREATER_THAN' ||
+          (clockOrder === 'EQUAL' && data.syncVersion > existing.data.syncVersion);
+        if (isSameRecoveryPoint) return;
+        if (!isStrictlyNewer) {
+          if (!options.primaryPath || options.primaryRev == null) {
+            throw new UploadRevToMatchMismatchAPIError(
+              `FileBasedSyncAdapter: ${bakPath} contains a newer or concurrent recovery point`,
+            );
+          }
+          const currentPrimary = await provider.downloadFile(options.primaryPath);
+          if (currentPrimary.rev !== options.primaryRev) {
+            throw new UploadRevToMatchMismatchAPIError(
+              `FileBasedSyncAdapter: ${options.primaryPath} changed while validating ${bakPath}`,
+            );
+          }
+          // A readable primary whose revision is still current is authoritative.
+          // Replace the anomalous recovery artifact; never promote a backup over
+          // it based on clocks alone (snapshot resets are intentionally non-monotonic).
+        }
+      }
+
       const backupData = await this._encryptAndCompressHandler.compressAndEncryptData(
         cfg,
         encryptKey,
@@ -2829,15 +3225,14 @@ export class FileBasedSyncAdapterService {
         fileVersion,
       );
       if (!backupData || backupData.trim().length === 0) {
-        OpLog.warn(
-          `FileBasedSyncAdapter: Skipping ${bakPath} — encoded backup data was empty`,
+        throw new InvalidDataSPError(
+          `FileBasedSyncAdapter: encoded ${bakPath} backup data was empty`,
         );
-        return;
       }
-      await provider.uploadFile(bakPath, backupData, null, true);
+      await provider.uploadFile(bakPath, backupData, backupRev, false);
       OpLog.normal(`FileBasedSyncAdapter: Wrote ${bakPath} before overwrite`);
     } catch (e) {
-      // Non-fatal by design — proceed with the primary upload regardless.
+      if (options.isRequired || e instanceof UploadRevToMatchMismatchAPIError) throw e;
       OpLog.warn(
         `FileBasedSyncAdapter: ${bakPath} write failed (non-fatal), proceeding`,
         e,
@@ -2857,9 +3252,21 @@ export class FileBasedSyncAdapterService {
     bakPath: string,
     expectedVersion: number,
     isValid: (data: unknown) => data is T,
+    onReadRev?: (rev: string) => void,
+    expectedDigest?: string,
   ): Promise<{ data: T; rev: string } | null> {
     try {
       const response = await provider.downloadFile(bakPath);
+      onReadRev?.(response.rev);
+      if (
+        expectedDigest !== undefined &&
+        (await this._digestEncodedPayload(response.dataStr)) !== expectedDigest
+      ) {
+        OpLog.warn(
+          `FileBasedSyncAdapter: ${bakPath} does not match the authoritative snapshot marker — refusing recovery`,
+        );
+        return null;
+      }
       // Security: when encryption is expected, refuse a PLAINTEXT .bak. Decoding
       // trusts the file's own prefix flags, so a plaintext .bak decodes even
       // under a wrong/rotated key — silently suppressing the wrong-password
@@ -2895,32 +3302,341 @@ export class FileBasedSyncAdapterService {
       }
       return { data, rev: response.rev };
     } catch (e) {
+      if (e instanceof RemoteFileNotFoundAPIError) return null;
+      if (!this._isRecoverableCorruption(e)) throw e;
       OpLog.warn(`FileBasedSyncAdapter: ${bakPath} recovery failed`, e);
       return null;
     }
   }
 
+  private async _readSnapshotTransaction(
+    provider: FileSyncProvider<SyncProviderId>,
+    transactionPath: string,
+  ): Promise<{ data: SnapshotTransaction; rev: string } | null> {
+    let response: { dataStr: string; rev: string };
+    try {
+      response = await provider.downloadFile(transactionPath);
+    } catch (e) {
+      if (e instanceof RemoteFileNotFoundAPIError) return null;
+      throw e;
+    }
+
+    let data: unknown;
+    try {
+      data = JSON.parse(response.dataStr);
+    } catch {
+      throw new SyncDataCorruptedError(
+        'Snapshot transaction marker is not valid JSON',
+        transactionPath,
+      );
+    }
+    if (
+      !this._isRecord(data) ||
+      data['version'] !== 1 ||
+      (data['status'] !== 'pending' && data['status'] !== 'complete') ||
+      typeof data['transactionId'] !== 'string' ||
+      (data['status'] === 'pending' &&
+        (typeof data['encodedSnapshot'] !== 'string' ||
+          (data['encodedState'] !== undefined &&
+            typeof data['encodedState'] !== 'string'))) ||
+      (data['status'] === 'complete' &&
+        (typeof data['primaryRev'] !== 'string' ||
+          typeof data['snapshotDigest'] !== 'string' ||
+          (data['statePrimaryRev'] === undefined) !==
+            (data['stateDigest'] === undefined) ||
+          (data['statePrimaryRev'] !== undefined &&
+            typeof data['statePrimaryRev'] !== 'string') ||
+          (data['stateDigest'] !== undefined && typeof data['stateDigest'] !== 'string')))
+    ) {
+      throw new SyncDataCorruptedError(
+        'Snapshot transaction marker has an invalid structure',
+        transactionPath,
+      );
+    }
+    return { data: data as unknown as SnapshotTransaction, rev: response.rev };
+  }
+
+  private async _assertSnapshotTransactionUnchanged(
+    provider: FileSyncProvider<SyncProviderId>,
+    guard: SnapshotTransactionGuard,
+  ): Promise<void> {
+    const current = await this._readSnapshotTransaction(provider, guard.path);
+    if (current?.data.status === 'pending' || (current?.rev ?? null) !== guard.rev) {
+      throw new UploadRevToMatchMismatchAPIError(
+        `FileBasedSyncAdapter: ${guard.path} changed while preparing the upload`,
+      );
+    }
+  }
+
+  /** Completes a crash-interrupted authoritative snapshot before normal sync. */
+  private async _recoverPendingSnapshotTransaction<T extends { version: number }>(
+    provider: FileSyncProvider<SyncProviderId>,
+    cfg: EncryptAndCompressCfg,
+    encryptKey: string | undefined,
+    primaryPath: string,
+    bakPath: string,
+    transactionPath: string,
+    expectedVersion: number,
+    isValid: (data: unknown) => data is T,
+    splitState?: {
+      primaryPath: string;
+      bakPath: string;
+      expectedVersion: number;
+      isValid: (data: unknown) => boolean;
+      matchesSnapshot: (snapshot: T, state: unknown) => boolean;
+    },
+  ): Promise<SnapshotTransactionObservation> {
+    const transaction = await this._readSnapshotTransaction(provider, transactionPath);
+    if (!transaction) {
+      return { didRecover: false, rev: null };
+    }
+    if (transaction.data.status === 'complete') {
+      return { didRecover: false, rev: transaction.rev, complete: transaction.data };
+    }
+
+    const encodedSnapshot = transaction.data.encodedSnapshot;
+    if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedSnapshot).isEncrypted) {
+      throw new SyncDataCorruptedError(
+        'Pending snapshot is plaintext but encryption is expected',
+        transactionPath,
+      );
+    }
+    const decoded =
+      await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
+        cfg,
+        encryptKey,
+        encodedSnapshot,
+      );
+    const version = this._isRecord(decoded) ? decoded['version'] : undefined;
+    if (version !== expectedVersion || !isValid(decoded)) {
+      throw new SyncDataCorruptedError(
+        'Pending snapshot transaction payload is invalid',
+        transactionPath,
+      );
+    }
+
+    const encodedState = transaction.data.encodedState;
+    if (splitState) {
+      if (typeof encodedState !== 'string') {
+        throw new SyncDataCorruptedError(
+          'Pending split snapshot transaction has no bound state payload',
+          transactionPath,
+        );
+      }
+      if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedState).isEncrypted) {
+        throw new SyncDataCorruptedError(
+          'Pending split state snapshot is plaintext but encryption is expected',
+          transactionPath,
+        );
+      }
+      const decodedState =
+        await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
+          cfg,
+          encryptKey,
+          encodedState,
+        );
+      const stateVersion = this._isRecord(decodedState)
+        ? decodedState['version']
+        : undefined;
+      if (
+        stateVersion !== splitState.expectedVersion ||
+        !splitState.isValid(decodedState) ||
+        !splitState.matchesSnapshot(decoded, decodedState)
+      ) {
+        throw new SyncDataCorruptedError(
+          'Pending split state transaction payload is invalid',
+          transactionPath,
+        );
+      }
+    } else if (encodedState !== undefined) {
+      throw new SyncDataCorruptedError(
+        'Single-file snapshot transaction unexpectedly contains split state',
+        transactionPath,
+      );
+    }
+
+    let primaryRev: string | null = null;
+    try {
+      primaryRev = (await provider.downloadFile(primaryPath)).rev;
+    } catch (e) {
+      if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
+    }
+
+    let statePrimaryRev: string | undefined;
+    if (splitState && encodedState) {
+      // The ops file remains the commit point. Publish state first; old ops can
+      // still use the retained state backup until the bound ops payload lands.
+      statePrimaryRev = (
+        await provider.uploadFile(splitState.primaryPath, encodedState, null, true)
+      ).rev;
+    }
+
+    // The pending marker owns this exact payload. Re-establish the recovery
+    // backup first, then conditionally promote the primary so an ordinary writer
+    // cannot be clobbered if it raced an older client that ignores the marker.
+    await provider.uploadFile(bakPath, encodedSnapshot, null, true);
+    const primaryResult = await provider.uploadFile(
+      primaryPath,
+      encodedSnapshot,
+      primaryRev,
+      false,
+    );
+    if (splitState && encodedState) {
+      await provider.uploadFile(splitState.bakPath, encodedState, null, true);
+    }
+    return this._completeSnapshotTransaction(
+      provider,
+      transactionPath,
+      transaction.data.transactionId,
+      transaction.rev,
+      encodedSnapshot,
+      primaryResult.rev,
+      encodedState && statePrimaryRev
+        ? { encodedState, primaryRev: statePrimaryRev }
+        : undefined,
+    );
+  }
+
+  private async _beginSnapshotTransaction(
+    provider: FileSyncProvider<SyncProviderId>,
+    transactionPath: string,
+    encodedSnapshot: string,
+    encodedState?: string,
+  ): Promise<{ transactionId: string; rev: string }> {
+    const priorTransaction = await this._readSnapshotTransaction(
+      provider,
+      transactionPath,
+    );
+    if (priorTransaction?.data.status === 'pending') {
+      throw new UploadRevToMatchMismatchAPIError(
+        `FileBasedSyncAdapter: ${transactionPath} already has a pending snapshot`,
+      );
+    }
+
+    const transactionId = uuidv7();
+    const pending = JSON.stringify({
+      version: 1,
+      status: 'pending',
+      transactionId,
+      encodedSnapshot,
+      ...(encodedState === undefined ? {} : { encodedState }),
+    } satisfies PendingSnapshotTransaction);
+    const result = await provider.uploadFile(
+      transactionPath,
+      pending,
+      priorTransaction?.rev ?? null,
+      false,
+    );
+    return { transactionId, rev: result.rev };
+  }
+
+  private async _completeSnapshotTransaction(
+    provider: FileSyncProvider<SyncProviderId>,
+    transactionPath: string,
+    transactionId: string,
+    pendingRev: string,
+    encodedSnapshot: string,
+    primaryRev: string,
+    state?: { encodedState: string; primaryRev: string },
+  ): Promise<SnapshotTransactionObservation> {
+    const complete: CompleteSnapshotTransaction = {
+      version: 1,
+      status: 'complete',
+      transactionId,
+      primaryRev,
+      snapshotDigest: await this._digestEncodedPayload(encodedSnapshot),
+      ...(state
+        ? {
+            statePrimaryRev: state.primaryRev,
+            stateDigest: await this._digestEncodedPayload(state.encodedState),
+          }
+        : {}),
+    };
+    const result = await provider.uploadFile(
+      transactionPath,
+      JSON.stringify(complete),
+      pendingRev,
+      false,
+    );
+    return { didRecover: true, rev: result.rev, complete };
+  }
+
   /**
-   * Force-writes the SAME payload to the `.bak` FIRST, then the primary. Used by
-   * snapshot uploads (force-upload / "Use Local" / E2EE re-encryption): a
-   * snapshot replaces the remote wholesale, so the pre-snapshot .bak must not
-   * survive it — a stale .bak encrypted with a ROTATED-AWAY key would otherwise
-   * be silently "recovered" by a still-old-key client (suppressing its
-   * wrong-password prompt) and heal-uploaded back over the new-key primary,
-   * reverting the rotation. Unlike the op-path backup, the .bak write here is
-   * deliberately FATAL: leaving the stale artifact behind breaks the snapshot's
-   * replace-everything contract, and aborting BEFORE the primary write leaves the
-   * remote fully consistent for a retry. (.bak-first also means a crash between
-   * the writes leaves a valid old primary + new .bak — nothing stale to recover.)
+   * Serializes and force-writes an authoritative snapshot. The durable pending
+   * transaction binds recovery to the exact payload, so a crash cannot make a
+   * later ordinary upload infer intent from non-monotonic snapshot clocks.
    */
   private async _forceUploadWithBakFirst(
     provider: FileSyncProvider<SyncProviderId>,
     primaryPath: string,
     bakPath: string,
+    transactionPath: string,
     encoded: string,
   ): Promise<{ rev: string }> {
+    const transaction = await this._beginSnapshotTransaction(
+      provider,
+      transactionPath,
+      encoded,
+    );
     await provider.uploadFile(bakPath, encoded, null, true);
-    return provider.uploadFile(primaryPath, encoded, null, true);
+    const primaryRes = await provider.uploadFile(primaryPath, encoded, null, true);
+    await this._completeSnapshotTransaction(
+      provider,
+      transactionPath,
+      transaction.transactionId,
+      transaction.rev,
+      encoded,
+      primaryRes.rev,
+    );
+    return primaryRes;
+  }
+
+  /** Atomically publishes the state/ops pair used by split authoritative snapshots. */
+  private async _forceUploadSplitSnapshot(
+    provider: FileSyncProvider<SyncProviderId>,
+    encodedState: string,
+    encodedOps: string,
+  ): Promise<{ rev: string }> {
+    const transaction = await this._beginSnapshotTransaction(
+      provider,
+      FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+      encodedOps,
+      encodedState,
+    );
+    const stateResult = await provider.uploadFile(
+      FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+      encodedState,
+      null,
+      true,
+    );
+    await provider.uploadFile(
+      FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+      encodedOps,
+      null,
+      true,
+    );
+    const opsResult = await provider.uploadFile(
+      FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+      encodedOps,
+      null,
+      true,
+    );
+    await provider.uploadFile(
+      FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
+      encodedState,
+      null,
+      true,
+    );
+    await this._completeSnapshotTransaction(
+      provider,
+      FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+      transaction.transactionId,
+      transaction.rev,
+      encodedOps,
+      opsResult.rev,
+      { encodedState, primaryRev: stateResult.rev },
+    );
+    return opsResult;
   }
 
   /**

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -106,6 +106,17 @@ export class FileBasedSyncAdapterService {
   private _pendingExpectedSyncVersions = new Map<string, number>();
 
   /**
+   * Providers with a detected gap whose replacement snapshot has not yet been
+   * durably applied. Persisted so cancelling the conflict dialog (or restarting
+   * the app afterward) cannot make the gap disappear once the remote
+   * syncVersion counter catches back up to the old cursor.
+   */
+  private _unresolvedGapProviderKeys = new Set<string>();
+
+  /** Snapshot-bearing downloads awaiting the caller's durable-apply acknowledgement. */
+  private _pendingGapResolutionProviderKeys = new Set<string>();
+
+  /**
    * SPAP-9: last-seen remote vector clock per provider+user. Used to tell a
    * benign (cosmetic) syncVersion reset apart from a genuine one: if the file's
    * causal clock did not regress, a lower syncVersion counter lost no data and
@@ -221,6 +232,14 @@ export class FileBasedSyncAdapterService {
         if (state.revs) {
           this._lastSeenRevs = new Map(Object.entries(state.revs));
         }
+        if (Array.isArray(state.unresolvedGaps)) {
+          this._unresolvedGapProviderKeys = new Set(
+            state.unresolvedGaps.filter(
+              (providerKey: unknown): providerKey is string =>
+                typeof providerKey === 'string',
+            ),
+          );
+        }
         this._persistedStateLoaded = true;
         return;
       }
@@ -274,6 +293,7 @@ export class FileBasedSyncAdapterService {
         seqCounters: Object.fromEntries(this._localSeqCounters),
         // SPAP-10: last-seen remote rev per provider, for the cheap download pre-check.
         revs: Object.fromEntries(this._lastSeenRevs),
+        unresolvedGaps: [...this._unresolvedGapProviderKeys],
       };
       localStorage.setItem(this._STORAGE_KEY, JSON.stringify(state));
     } catch (e) {
@@ -401,6 +421,9 @@ export class FileBasedSyncAdapterService {
         if (pendingRev !== undefined) {
           this._lastSeenRevs.set(providerKey, pendingRev);
           this._pendingRevs.delete(providerKey);
+        }
+        if (this._pendingGapResolutionProviderKeys.delete(providerKey)) {
+          this._unresolvedGapProviderKeys.delete(providerKey);
         }
         this._persistState();
       },
@@ -797,6 +820,11 @@ export class FileBasedSyncAdapterService {
   ): Promise<FileSnapshotOpDownloadResponse> {
     const providerKey = this._getProviderKey(provider);
 
+    // A cursor acknowledgement may only promote observations made by the
+    // response it acknowledges. Drop an abandoned/cancelled response before a
+    // later download stages its own baseline.
+    this._dropPendingRemoteObservations(providerKey);
+
     // SPAP-11: split-file ("Surgical sync") download path (opt-in). When OFF
     // (default) the single-file path below runs unchanged.
     if (this._isSplitSyncEnabled()) {
@@ -901,6 +929,7 @@ export class FileBasedSyncAdapterService {
           encryptKey,
           FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
           FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+          (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
         );
         if (recovered) {
           recoveredFromBackup = true;
@@ -1021,19 +1050,27 @@ export class FileBasedSyncAdapterService {
       syncData.oldestOpSyncVersion !== undefined &&
       syncData.oldestOpSyncVersion > sinceSeq + 1;
 
-    const needsGapDetection = versionWasReset || snapshotReplacement || partialTrimGap;
+    const gapWasAlreadyUnresolved = this._unresolvedGapProviderKeys.has(providerKey);
+    const needsGapDetection =
+      gapWasAlreadyUnresolved || versionWasReset || snapshotReplacement || partialTrimGap;
 
     if (needsGapDetection) {
-      const reason = versionWasReset
-        ? `sync version reset (${previousExpectedVersion} → ${syncData.syncVersion})`
-        : snapshotReplacement
-          ? `snapshot replacement (expected ops from seq ${sinceSeq}, but recentOps is empty)`
-          : `partial trimming (oldestOpSyncVersion=${syncData.oldestOpSyncVersion}, ` +
-            `sinceSeq=${sinceSeq}, recentOps=${syncData.recentOps.length})`;
+      const reason = gapWasAlreadyUnresolved
+        ? 'previously detected replacement snapshot is still unapplied'
+        : versionWasReset
+          ? `sync version reset (${previousExpectedVersion} → ${syncData.syncVersion})`
+          : snapshotReplacement
+            ? `snapshot replacement (expected ops from seq ${sinceSeq}, but recentOps is empty)`
+            : `partial trimming (oldestOpSyncVersion=${syncData.oldestOpSyncVersion}, ` +
+              `sinceSeq=${sinceSeq}, recentOps=${syncData.recentOps.length})`;
       OpLog.warn(
         `FileBasedSyncAdapter: Gap detected - ${reason}. ` +
           'Another client may have uploaded a snapshot. Signaling gap detection.',
       );
+      if (!gapWasAlreadyUnresolved) {
+        this._unresolvedGapProviderKeys.add(providerKey);
+        this._persistState();
+      }
     }
 
     // Stage the remote baseline until the caller confirms that the downloaded
@@ -1119,6 +1156,10 @@ export class FileBasedSyncAdapterService {
             ...(syncData.archiveOld ? { archiveOld: syncData.archiveOld } : {}),
           }
         : undefined;
+
+    if (snapshotStateWithArchives && this._unresolvedGapProviderKeys.has(providerKey)) {
+      this._pendingGapResolutionProviderKeys.add(providerKey);
+    }
 
     return {
       ops: limitedOps,
@@ -1215,6 +1256,7 @@ export class FileBasedSyncAdapterService {
     // Reset local state
     this._expectedSyncVersions.set(providerKey, newSyncVersion);
     this._localSeqCounters.set(providerKey, newSyncVersion);
+    this._markGapResolvedByAuthoritativeSnapshot(providerKey);
     // SPAP-10: record the rev of the snapshot we just wrote as the last-seen rev
     // so the next poll can skip a redundant full download.
     this._commitLastSeenRev(providerKey, snapshotUploadRes.rev);
@@ -1289,6 +1331,8 @@ export class FileBasedSyncAdapterService {
       this._lastSeenVectorClocks.delete(providerKey);
       this._pendingExpectedSyncVersions.delete(providerKey);
       this._pendingVectorClocks.delete(providerKey);
+      this._unresolvedGapProviderKeys.delete(providerKey);
+      this._pendingGapResolutionProviderKeys.delete(providerKey);
       this._clearCachedSyncData(providerKey);
       this._clearCachedOpsData(providerKey);
       this._persistState();
@@ -1321,6 +1365,115 @@ export class FileBasedSyncAdapterService {
       !!d &&
       d.version === FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION &&
       d.format === FILE_BASED_SYNC_CONSTANTS.SPLIT_TOMBSTONE_FORMAT
+    );
+  }
+
+  private _isRecord(data: unknown): data is Record<string, unknown> {
+    return typeof data === 'object' && data !== null && !Array.isArray(data);
+  }
+
+  private _isNonNegativeInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+  }
+
+  private _isNonNegativeFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+  }
+
+  private _isVectorClock(data: unknown): data is VectorClock {
+    return (
+      this._isRecord(data) &&
+      Object.values(data).every((value) => this._isNonNegativeInteger(value))
+    );
+  }
+
+  private _isCompactSyncOp(data: unknown): data is SyncFileCompactOp {
+    if (!this._isRecord(data)) return false;
+    return (
+      typeof data['id'] === 'string' &&
+      typeof data['a'] === 'string' &&
+      typeof data['o'] === 'string' &&
+      typeof data['e'] === 'string' &&
+      typeof data['c'] === 'string' &&
+      this._isVectorClock(data['v']) &&
+      this._isNonNegativeFiniteNumber(data['t']) &&
+      this._isNonNegativeInteger(data['s']) &&
+      (data['d'] === undefined || typeof data['d'] === 'string') &&
+      (data['ds'] === undefined ||
+        (Array.isArray(data['ds']) &&
+          data['ds'].every((entityId) => typeof entityId === 'string'))) &&
+      (data['r'] === undefined || typeof data['r'] === 'string') &&
+      (data['sv'] === undefined || this._isNonNegativeInteger(data['sv']))
+    );
+  }
+
+  private _hasValidSyncEnvelope(
+    data: Record<string, unknown>,
+    allowMissingSchemaVersion = false,
+  ): boolean {
+    return (
+      this._isNonNegativeInteger(data['syncVersion']) &&
+      (this._isNonNegativeInteger(data['schemaVersion']) ||
+        (allowMissingSchemaVersion && data['schemaVersion'] === undefined)) &&
+      this._isVectorClock(data['vectorClock']) &&
+      this._isNonNegativeFiniteNumber(data['lastModified']) &&
+      typeof data['clientId'] === 'string'
+    );
+  }
+
+  private _hasValidRecentOps(data: Record<string, unknown>): boolean {
+    return (
+      Array.isArray(data['recentOps']) &&
+      data['recentOps'].every((op) => this._isCompactSyncOp(op)) &&
+      (data['oldestOpSyncVersion'] === undefined ||
+        this._isNonNegativeInteger(data['oldestOpSyncVersion']))
+    );
+  }
+
+  private _isSnapshotRef(data: unknown): data is FileBasedOpsFile['snapshotRef'] {
+    return (
+      this._isRecord(data) &&
+      this._isNonNegativeInteger(data['syncVersion']) &&
+      this._isVectorClock(data['vectorClock']) &&
+      (data['rev'] === undefined || typeof data['rev'] === 'string')
+    );
+  }
+
+  private _isFileBasedSyncData(data: unknown): data is FileBasedSyncData {
+    return (
+      this._isRecord(data) &&
+      data['version'] === FILE_BASED_SYNC_CONSTANTS.FILE_VERSION &&
+      this._hasValidSyncEnvelope(data, true) &&
+      this._hasValidRecentOps(data) &&
+      this._isRecord(data['state'])
+    );
+  }
+
+  private _isFileBasedOpsFile(data: unknown): data is FileBasedOpsFile {
+    if (
+      !this._isRecord(data) ||
+      data['version'] !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION ||
+      !this._hasValidSyncEnvelope(data) ||
+      !this._hasValidRecentOps(data) ||
+      !this._isSnapshotRef(data['snapshotRef'])
+    ) {
+      return false;
+    }
+    const migration = data['migration'];
+    return (
+      migration === undefined ||
+      (this._isRecord(migration) &&
+        migration['status'] === 'pending' &&
+        typeof migration['legacyRev'] === 'string')
+    );
+  }
+
+  private _isFileBasedStateFile(data: unknown): data is FileBasedStateFile {
+    return (
+      this._isRecord(data) &&
+      data['version'] === FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION &&
+      this._hasValidSyncEnvelope(data) &&
+      this._isRecord(data['state'])
     );
   }
 
@@ -1386,14 +1539,24 @@ export class FileBasedSyncAdapterService {
     const response = await provider.downloadFile(FILE_BASED_SYNC_CONSTANTS.OPS_FILE);
     try {
       const data =
-        await this._encryptAndCompressHandler.decompressAndDecryptData<FileBasedOpsFile>(
+        await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
           cfg,
           encryptKey,
           response.dataStr,
         );
-      if (data.version !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION) {
+      if (
+        !this._isRecord(data) ||
+        data['version'] !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION
+      ) {
         throw new SyncDataCorruptedError(
-          `Unsupported ops-file version: ${data.version} (expected ${FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION})`,
+          `Unsupported ops-file version: ${String(this._isRecord(data) ? data['version'] : undefined)} ` +
+            `(expected ${FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION})`,
+          FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+        );
+      }
+      if (!this._isFileBasedOpsFile(data)) {
+        throw new SyncDataCorruptedError(
+          'Invalid ops-file structure',
           FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
         );
       }
@@ -1412,31 +1575,45 @@ export class FileBasedSyncAdapterService {
     encryptKey: string | undefined,
   ): Promise<{ data: FileBasedStateFile; rev: string }> {
     const response = await provider.downloadFile(FILE_BASED_SYNC_CONSTANTS.STATE_FILE);
-    const data =
-      await this._encryptAndCompressHandler.decompressAndDecryptData<FileBasedStateFile>(
-        cfg,
-        encryptKey,
-        response.dataStr,
-      );
-    if (data.version !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION) {
-      throw new SyncDataCorruptedError(
-        `Unsupported state-file version: ${data.version} (expected ${FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION})`,
-        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
-      );
+    try {
+      const data =
+        await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
+          cfg,
+          encryptKey,
+          response.dataStr,
+        );
+      if (
+        !this._isRecord(data) ||
+        data['version'] !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION
+      ) {
+        throw new SyncDataCorruptedError(
+          `Unsupported state-file version: ${String(this._isRecord(data) ? data['version'] : undefined)} ` +
+            `(expected ${FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION})`,
+          FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        );
+      }
+      if (!this._isFileBasedStateFile(data)) {
+        throw new SyncDataCorruptedError(
+          'Invalid state-file structure',
+          FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        );
+      }
+      return { data, rev: response.rev };
+    } catch (decodeErr) {
+      throw this._annotatePrimaryRev(decodeErr, response.rev);
     }
-    return { data, rev: response.rev };
   }
 
-  /**
-   * Writes `sync-state.json`. Force-overwrite: the ops file (commit point) is the
-   * concurrency gate, and readers only trust a snapshot the ops file's snapshotRef
-   * validates against. Returns the written rev for the snapshotRef pointer.
-   */
+  /** Writes `sync-state.json` and returns the rev used by snapshotRef. */
   private async _writeStateFile(
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
     data: FileBasedStateFile,
+    writeMode: {
+      revToMatch: string | null;
+      isForceOverwrite: boolean;
+    } = { revToMatch: null, isForceOverwrite: true },
   ): Promise<string> {
     const uploadData = await this._encryptAndCompressHandler.compressAndEncryptData(
       cfg,
@@ -1448,25 +1625,31 @@ export class FileBasedSyncAdapterService {
     const res = await provider.uploadFile(
       FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
       uploadData,
-      null,
-      true,
+      writeMode.revToMatch,
+      writeMode.isForceOverwrite,
     );
     return res.rev;
   }
 
-  /** Copies the current `sync-state.json` to its `.bak` (non-fatal). */
+  /**
+   * Copies the current `sync-state.json` to its `.bak` and returns the exact
+   * snapshot/rev that a subsequent conditional replacement must match. A missing
+   * state file is the first-compaction case and returns null; any other
+   * read/decode failure aborts rather than force-overwriting an unknown snapshot.
+   */
   private async _backupStateFile(
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
-  ): Promise<void> {
-    let current: { data: FileBasedStateFile };
+  ): Promise<{ data: FileBasedStateFile; rev: string } | null> {
+    let current: { data: FileBasedStateFile; rev: string };
     try {
       current = await this._downloadStateFile(provider, cfg, encryptKey);
     } catch (e) {
-      // Non-fatal — e.g. first compaction has no existing state file to back up.
-      OpLog.normal('FileBasedSyncAdapter: state-file backup skipped (non-fatal)', e);
-      return;
+      if (e instanceof RemoteFileNotFoundAPIError) {
+        return null;
+      }
+      throw e;
     }
     await this._writeBakFile(
       provider,
@@ -1476,6 +1659,7 @@ export class FileBasedSyncAdapterService {
       current.data,
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
     );
+    return current;
   }
 
   /** Recovers the snapshot from `sync-state.json.bak` (null if unusable). */
@@ -1490,6 +1674,7 @@ export class FileBasedSyncAdapterService {
       encryptKey,
       FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+      (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
     );
     return recovered?.data ?? null;
   }
@@ -1674,6 +1859,35 @@ export class FileBasedSyncAdapterService {
     };
   }
 
+  /**
+   * Writes a migration recovery marker that is required before the final ops
+   * rewrite. Unlike ordinary rolling backups, failure is fatal here because the
+   * legacy primary and backup have already been replaced by tombstones.
+   */
+  private async _writeRequiredMigrationOpsBackup(
+    provider: FileSyncProvider<SyncProviderId>,
+    cfg: EncryptAndCompressCfg,
+    encryptKey: string | undefined,
+    pending: FileBasedOpsFile,
+  ): Promise<void> {
+    const encoded = await this._encryptAndCompressHandler.compressAndEncryptData(
+      cfg,
+      encryptKey,
+      pending,
+      FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+    );
+    this._assertUploadDataNotEmpty(
+      encoded,
+      'FileBasedSyncAdapter._writeRequiredMigrationOpsBackup',
+    );
+    await provider.uploadFile(
+      FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+      encoded,
+      null,
+      true,
+    );
+  }
+
   private async _finalizeSplitMigrationMarker(
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
@@ -1681,6 +1895,10 @@ export class FileBasedSyncAdapterService {
     pending: FileBasedOpsFile,
     pendingRev: string,
   ): Promise<{ data: FileBasedOpsFile; rev: string }> {
+    // The legacy primary and backup have already become tombstones. Preserve the
+    // pending marker before this final rewrite so an interrupted/corrupt primary
+    // can recover the complete migration candidate and resume safely.
+    await this._writeRequiredMigrationOpsBackup(provider, cfg, encryptKey, pending);
     const finalized: FileBasedOpsFile = { ...pending };
     delete finalized.migration;
     const encoded = await this._encryptAndCompressHandler.compressAndEncryptData(
@@ -1768,17 +1986,43 @@ export class FileBasedSyncAdapterService {
         continue;
       }
 
-      // The pending marker is the write permission. Only after winning its
-      // conditional create/update may a migrator touch sync-state.json; this
-      // prevents a stale losing migrator from overwriting a newer state file.
-      // Rewriting here also repairs a crash after the marker write but before
-      // the state write. The final marker records the resulting snapshot rev.
-      const stateRev = await this._writeStateFile(
-        provider,
-        cfg,
-        encryptKey,
-        this._buildSplitMigrationState(legacy.data, current.data.clientId),
+      // The pending marker grants permission to attempt the snapshot write, but
+      // it is not a lock: a newer migrator may publish another marker and state
+      // between this read and our PUT. Match the exact state revision we just
+      // backed up so the stale writer loses instead of overwriting newer data.
+      const nextState = this._buildSplitMigrationState(
+        legacy.data,
+        current.data.clientId,
       );
+      const previousState = await this._backupStateFile(provider, cfg, encryptKey);
+      if (previousState) {
+        const nextStateComparison = compareVectorClocks(
+          nextState.vectorClock,
+          previousState.data.vectorClock,
+        );
+        if (nextStateComparison !== 'EQUAL' && nextStateComparison !== 'GREATER_THAN') {
+          // The state file already represents a migration newer than this
+          // cached pending marker (or one concurrent with it). Re-read the ops
+          // commit point rather than conditionally overwriting that snapshot.
+          // Deliberately use causality, not syncVersion: snapshot replacement
+          // can reset the cosmetic counter while advancing the vector clock.
+          current = await this._downloadOpsFile(provider, cfg, encryptKey);
+          continue;
+        }
+      }
+      let stateRev: string;
+      try {
+        stateRev = await this._writeStateFile(provider, cfg, encryptKey, nextState, {
+          revToMatch: previousState?.rev ?? null,
+          isForceOverwrite: false,
+        });
+      } catch (stateWriteError) {
+        if (!(stateWriteError instanceof UploadRevToMatchMismatchAPIError)) {
+          throw stateWriteError;
+        }
+        current = await this._downloadOpsFile(provider, cfg, encryptKey);
+        continue;
+      }
       current = {
         data: {
           ...current.data,
@@ -2038,9 +2282,12 @@ export class FileBasedSyncAdapterService {
         localStateSnapshot,
       );
       // Preserve the pre-compaction snapshot for snapshotRef-mismatch recovery.
-      await this._backupStateFile(provider, cfg, encryptKey);
+      const previousState = await this._backupStateFile(provider, cfg, encryptKey);
       // Atomicity: sync-state.json FIRST, then the ops file that references it.
-      const stateRev = await this._writeStateFile(provider, cfg, encryptKey, stateData);
+      const stateRev = await this._writeStateFile(provider, cfg, encryptKey, stateData, {
+        revToMatch: previousState?.rev ?? null,
+        isForceOverwrite: false,
+      });
       snapshotRef = {
         syncVersion: newSyncVersion,
         vectorClock: mergedClock,
@@ -2188,6 +2435,7 @@ export class FileBasedSyncAdapterService {
           encryptKey,
           FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
           FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+          (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
         );
         if (!recovered) throw e;
         recoveredFromBackup = true;
@@ -2248,7 +2496,14 @@ export class FileBasedSyncAdapterService {
       sinceSeq > 0 &&
       opsFile.oldestOpSyncVersion !== undefined &&
       opsFile.oldestOpSyncVersion > sinceSeq + 1;
-    let needsGapDetection = versionWasReset || snapshotReplacement || partialTrimGap;
+    const gapWasAlreadyUnresolved = this._unresolvedGapProviderKeys.has(providerKey);
+    let needsGapDetection =
+      gapWasAlreadyUnresolved || versionWasReset || snapshotReplacement || partialTrimGap;
+
+    if (needsGapDetection && !gapWasAlreadyUnresolved) {
+      this._unresolvedGapProviderKeys.add(providerKey);
+      this._persistState();
+    }
 
     this._pendingExpectedSyncVersions.set(providerKey, opsFile.syncVersion);
     this._pendingVectorClocks.set(providerKey, opsFile.vectorClock);
@@ -2294,6 +2549,10 @@ export class FileBasedSyncAdapterService {
         // No snapshot validates the ref ⇒ treat as gap so the caller re-syncs.
         needsGapDetection = true;
       }
+    }
+
+    if (snapshotStateWithArchives && this._unresolvedGapProviderKeys.has(providerKey)) {
+      this._pendingGapResolutionProviderKeys.add(providerKey);
     }
 
     return {
@@ -2426,6 +2685,7 @@ export class FileBasedSyncAdapterService {
 
     this._expectedSyncVersions.set(providerKey, newSyncVersion);
     this._localSeqCounters.set(providerKey, newSyncVersion);
+    this._markGapResolvedByAuthoritativeSnapshot(providerKey);
     this._commitLastSeenRev(providerKey, opsRes.rev);
     this._lastSeenVectorClocks.set(providerKey, clock);
     this._clearCachedOpsData(providerKey);
@@ -2502,6 +2762,7 @@ export class FileBasedSyncAdapterService {
     encryptKey: string | undefined,
     bakPath: string,
     expectedVersion: number,
+    isValid: (data: unknown) => data is T,
   ): Promise<{ data: T; rev: string } | null> {
     try {
       const response = await provider.downloadFile(bakPath);
@@ -2519,14 +2780,22 @@ export class FileBasedSyncAdapterService {
         );
         return null;
       }
-      const data = await this._encryptAndCompressHandler.decompressAndDecryptData<T>(
-        cfg,
-        encryptKey,
-        response.dataStr,
-      );
-      if (data.version !== expectedVersion) {
+      const data =
+        await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
+          cfg,
+          encryptKey,
+          response.dataStr,
+        );
+      const version = this._isRecord(data) ? data['version'] : undefined;
+      if (version !== expectedVersion) {
         OpLog.warn(
-          `FileBasedSyncAdapter: ${bakPath} has unsupported version ${data.version}; cannot recover`,
+          `FileBasedSyncAdapter: ${bakPath} has unsupported version ${String(version)}; cannot recover`,
+        );
+        return null;
+      }
+      if (!isValid(data)) {
+        OpLog.warn(
+          `FileBasedSyncAdapter: ${bakPath} has an invalid structure; cannot recover`,
         );
         return null;
       }
@@ -2574,6 +2843,18 @@ export class FileBasedSyncAdapterService {
     // cursor update cannot promote stale pre-write values over it.
     this._pendingExpectedSyncVersions.delete(providerKey);
     this._pendingVectorClocks.delete(providerKey);
+  }
+
+  private _dropPendingRemoteObservations(providerKey: string): void {
+    this._pendingExpectedSyncVersions.delete(providerKey);
+    this._pendingVectorClocks.delete(providerKey);
+    this._pendingRevs.delete(providerKey);
+    this._pendingGapResolutionProviderKeys.delete(providerKey);
+  }
+
+  private _markGapResolvedByAuthoritativeSnapshot(providerKey: string): void {
+    this._unresolvedGapProviderKeys.delete(providerKey);
+    this._pendingGapResolutionProviderKeys.delete(providerKey);
   }
 
   /**
@@ -2710,8 +2991,8 @@ export class FileBasedSyncAdapterService {
     }
     let data: FileBasedSyncData;
     try {
-      data =
-        await this._encryptAndCompressHandler.decompressAndDecryptData<FileBasedSyncData>(
+      const decoded =
+        await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
           cfg,
           encryptKey,
           response.dataStr,
@@ -2722,17 +3003,28 @@ export class FileBasedSyncAdapterService {
       // (distinct from generic corruption) so the caller can surface an actionable
       // "enable Surgical sync" notice and pause without re-creating a v2 file.
       // Checked before the version gate so a v3 tombstone doesn't read as corrupt.
-      if (this._isSplitTombstone(data)) {
+      if (this._isSplitTombstone(decoded)) {
         throw new SplitSyncFormatDetectedError();
       }
 
       // Validate file version
-      if (data.version !== FILE_BASED_SYNC_CONSTANTS.FILE_VERSION) {
+      if (
+        !this._isRecord(decoded) ||
+        decoded['version'] !== FILE_BASED_SYNC_CONSTANTS.FILE_VERSION
+      ) {
         throw new SyncDataCorruptedError(
-          `Unsupported file version: ${data.version} (expected ${FILE_BASED_SYNC_CONSTANTS.FILE_VERSION})`,
+          `Unsupported file version: ${String(this._isRecord(decoded) ? decoded['version'] : undefined)} ` +
+            `(expected ${FILE_BASED_SYNC_CONSTANTS.FILE_VERSION})`,
           FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
         );
       }
+      if (!this._isFileBasedSyncData(decoded)) {
+        throw new SyncDataCorruptedError(
+          'Invalid sync-file structure',
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+        );
+      }
+      data = decoded;
     } catch (decodeErr) {
       // A split tombstone is a valid signal, not corruption — let it propagate
       // by type without being annotated as a corrupt primary.

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -55,7 +55,12 @@ import {
 } from '../../persistence/compact/operation-codec.service';
 import { uuidv7 } from '../../../util/uuid-v7';
 
-interface PendingSnapshotTransaction {
+interface SnapshotRejectionHistory {
+  rejectedSnapshotDigests?: string[];
+  rejectedStateDigests?: string[];
+}
+
+interface PendingSnapshotTransaction extends SnapshotRejectionHistory {
   version: 1;
   status: 'pending';
   transactionId: string;
@@ -70,7 +75,7 @@ interface PendingSnapshotTransaction {
   encodedState?: string;
 }
 
-interface CompleteSnapshotTransaction {
+interface CompleteSnapshotTransaction extends SnapshotRejectionHistory {
   version: 1;
   status: 'complete';
   transactionId: string;
@@ -81,10 +86,12 @@ interface CompleteSnapshotTransaction {
 }
 
 /** A pending transaction that recovery gave up on (stale or undecodable). */
-interface AbortedSnapshotTransaction {
+interface AbortedSnapshotTransaction extends SnapshotRejectionHistory {
   version: 1;
   status: 'aborted';
   transactionId: string;
+  snapshotDigest: string;
+  stateDigest?: string;
 }
 
 type SnapshotTransaction =
@@ -96,12 +103,22 @@ interface SnapshotTransactionObservation {
   didRecover: boolean;
   rev: string | null;
   complete?: CompleteSnapshotTransaction;
+  aborted?: AbortedSnapshotTransaction;
 }
 
 interface SnapshotTransactionGuard {
   path: string;
   rev: string | null;
+  pending?: PendingSnapshotTransaction;
   complete?: CompleteSnapshotTransaction;
+  aborted?: AbortedSnapshotTransaction;
+}
+
+interface ReadBakFileOptions {
+  onReadRev?: (rev: string) => void;
+  expectedDigest?: string;
+  rejectedDigests?: readonly string[];
+  normalize?: (data: unknown) => unknown;
 }
 
 /**
@@ -930,6 +947,24 @@ export class FileBasedSyncAdapterService {
       );
     }
 
+    // A pending authoritative snapshot is user intent, not an optimization
+    // detail: recover it before an unchanged-primary early return can hide it.
+    const snapshotTransaction =
+      await this._recoverPendingSnapshotTransaction<FileBasedSyncData>(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+        (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
+      );
+    if (snapshotTransaction.didRecover) {
+      this._clearCachedSyncData(providerKey);
+      this._lastSeenRevs.delete(providerKey);
+    }
+
     // SPAP-10: cheap remote-rev pre-check. If we already know the last-seen rev
     // AND nothing in this cycle has cached a fresh download, ask the provider for
     // the current rev WITHOUT downloading the full file. An unchanged rev proves
@@ -939,12 +974,9 @@ export class FileBasedSyncAdapterService {
     // the file to have CHANGED, which an identical rev rules out. We therefore
     // safely bypass the gap-detection block below.
     //
-    // Runs BEFORE the snapshot-transaction marker check so an idle poll costs a
-    // single metadata request. Skipping the marker on the short-circuit is
-    // sound: an unchanged primary rev means either no transaction happened, or
-    // one is still pending with nothing promoted yet — completing it is a
-    // write-side concern handled by every upload and by the next changed-rev
-    // download.
+    // Runs after snapshot-transaction recovery. An idle poll pays the small
+    // marker read so a crash-before-primary transaction cannot remain hidden
+    // forever behind an unchanged primary revision.
     //
     // Gating on cache absence is a correctness guard, not just an optimization:
     // during multi-page pagination `_downloadOps` is called repeatedly with the
@@ -993,22 +1025,6 @@ export class FileBasedSyncAdapterService {
       }
     }
 
-    const snapshotTransaction =
-      await this._recoverPendingSnapshotTransaction<FileBasedSyncData>(
-        provider,
-        cfg,
-        encryptKey,
-        FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
-        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
-        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
-        FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
-        (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
-      );
-    if (snapshotTransaction.didRecover) {
-      this._clearCachedSyncData(providerKey);
-      this._lastSeenRevs.delete(providerKey);
-    }
-
     let syncData: FileBasedSyncData;
     let rev: string;
     let recoveredFromBackup = false;
@@ -1050,8 +1066,13 @@ export class FileBasedSyncAdapterService {
           FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
           FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
           (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
-          undefined,
-          expectedSnapshotDigest,
+          {
+            expectedDigest: expectedSnapshotDigest,
+            rejectedDigests: this._getRejectedBackupDigests(
+              snapshotTransaction.complete ?? snapshotTransaction.aborted,
+              FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+            ),
+          },
         );
         if (recovered) {
           recoveredFromBackup = true;
@@ -1510,6 +1531,10 @@ export class FileBasedSyncAdapterService {
     return typeof data === 'object' && data !== null && !Array.isArray(data);
   }
 
+  private _isStringArray(data: unknown): data is string[] {
+    return Array.isArray(data) && data.every((value) => typeof value === 'string');
+  }
+
   private _isNonNegativeInteger(value: unknown): value is number {
     return typeof value === 'number' && Number.isInteger(value) && value >= 0;
   }
@@ -1668,6 +1693,23 @@ export class FileBasedSyncAdapterService {
     this._splitOpsCache.delete(providerKey);
   }
 
+  private _normalizePendingMigrationOpsVersion(data: unknown): unknown {
+    if (
+      !this._isRecord(data) ||
+      data['version'] !== FILE_BASED_SYNC_CONSTANTS.SPLIT_MIGRATION_PENDING_OPS_VERSION
+    ) {
+      return data;
+    }
+    const normalized = {
+      ...data,
+      version: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+    };
+    return this._isFileBasedOpsFile(normalized) &&
+      this._isPendingSplitMigration(normalized)
+      ? normalized
+      : data;
+  }
+
   /** Downloads + decodes `sync-ops.json` and validates its version. */
   private async _downloadOpsFile(
     provider: FileSyncProvider<SyncProviderId>,
@@ -1690,9 +1732,7 @@ export class FileBasedSyncAdapterService {
         this._isRecord(decoded) &&
         decoded['version'] ===
           FILE_BASED_SYNC_CONSTANTS.SPLIT_MIGRATION_PENDING_OPS_VERSION;
-      const data = isPendingMigrationVersion
-        ? { ...decoded, version: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION }
-        : decoded;
+      const data = this._normalizePendingMigrationOpsVersion(decoded);
       if (
         !this._isRecord(data) ||
         data['version'] !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION
@@ -1817,7 +1857,7 @@ export class FileBasedSyncAdapterService {
     }
 
     if (!committedOpsFile) {
-      if (snapshotTransaction) {
+      if (snapshotTransaction && !snapshotTransaction.pending) {
         await this._assertSnapshotTransactionUnchanged(provider, snapshotTransaction);
       }
       if (!current) return primaryRev === null ? null : { rev: primaryRev };
@@ -1845,14 +1885,21 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
       (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
-      undefined,
-      this._getSnapshotBoundBackupDigest(
-        snapshotTransaction,
-        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
-        primaryRev,
-      ),
+      {
+        expectedDigest: this._getSnapshotBoundBackupDigest(
+          snapshotTransaction,
+          FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+          primaryRev,
+        ),
+        rejectedDigests: this._getRejectedBackupDigests(
+          snapshotTransaction?.pending ??
+            snapshotTransaction?.complete ??
+            snapshotTransaction?.aborted,
+          FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        ),
+      },
     );
-    if (snapshotTransaction) {
+    if (snapshotTransaction && !snapshotTransaction.pending) {
       await this._assertSnapshotTransactionUnchanged(provider, snapshotTransaction);
     }
     if (backup && this._validateSnapshotRef(committedOpsFile, backup.data)) {
@@ -1885,6 +1932,7 @@ export class FileBasedSyncAdapterService {
         primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
         primaryRev,
         snapshotTransaction,
+        isRequired: true,
       },
     );
     return current;
@@ -1896,6 +1944,7 @@ export class FileBasedSyncAdapterService {
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
     expectedDigest?: string,
+    rejectedDigests?: readonly string[],
   ): Promise<FileBasedStateFile | null> {
     const recovered = await this._readBakFile<FileBasedStateFile>(
       provider,
@@ -1904,8 +1953,7 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
       (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
-      undefined,
-      expectedDigest,
+      { expectedDigest, rejectedDigests },
     );
     return recovered?.data ?? null;
   }
@@ -1933,6 +1981,7 @@ export class FileBasedSyncAdapterService {
     encryptKey: string | undefined,
     opsFile: FileBasedOpsFile,
     completeTransaction?: CompleteSnapshotTransaction,
+    abortedTransaction?: AbortedSnapshotTransaction,
   ): Promise<FileBasedStateFile | null> {
     let corruptPrimaryRev: string | undefined;
     let observedPrimaryRev: string | undefined;
@@ -1970,6 +2019,10 @@ export class FileBasedSyncAdapterService {
       cfg,
       encryptKey,
       expectedStateDigest,
+      this._getRejectedBackupDigests(
+        completeTransaction ?? abortedTransaction,
+        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+      ),
     );
     if (bak && this._validateSnapshotRef(opsFile, bak)) {
       if (corruptPrimaryRev) {
@@ -2157,7 +2210,10 @@ export class FileBasedSyncAdapterService {
     const encoded = await this._encryptAndCompressHandler.compressAndEncryptData(
       cfg,
       encryptKey,
-      pending,
+      {
+        ...pending,
+        version: FILE_BASED_SYNC_CONSTANTS.SPLIT_MIGRATION_PENDING_OPS_VERSION,
+      },
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
     );
     this._assertUploadDataNotEmpty(
@@ -2173,13 +2229,19 @@ export class FileBasedSyncAdapterService {
       backupRev = response.rev;
 
       let existing: unknown;
+      let existingIsPendingSentinel = false;
       try {
-        existing =
+        const decoded =
           await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
             cfg,
             encryptKey,
             response.dataStr,
           );
+        existingIsPendingSentinel =
+          this._isRecord(decoded) &&
+          decoded['version'] ===
+            FILE_BASED_SYNC_CONSTANTS.SPLIT_MIGRATION_PENDING_OPS_VERSION;
+        existing = this._normalizePendingMigrationOpsVersion(decoded);
       } catch (e) {
         // A corrupt backup is replaceable, but only while its exact revision is
         // still current. The conditional write below owns that decision.
@@ -2215,13 +2277,16 @@ export class FileBasedSyncAdapterService {
           JSON.stringify(existing.recentOps) === JSON.stringify(pending.recentOps) &&
           (existing.migration === undefined ||
             existing.migration.legacyRev === pending.migration?.legacyRev);
-        if (sameRecoveryPayload) {
-          // A matching pending marker or its already-finalized form is at least
-          // as useful for recovery as rewriting the same backup again.
+        if (
+          sameRecoveryPayload &&
+          existingIsPendingSentinel &&
+          this._isPendingSplitMigration(existing)
+        ) {
+          // The required backup is already the same fail-closed pending marker.
           return;
         }
 
-        if (clockOrder === 'EQUAL') {
+        if (!sameRecoveryPayload && clockOrder === 'EQUAL') {
           // Equal clocks with different payloads are inconsistent; neither may
           // silently replace the other.
           throw new UploadRevToMatchMismatchAPIError();
@@ -2587,6 +2652,7 @@ export class FileBasedSyncAdapterService {
       path: FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
       rev: snapshotTransaction.rev,
       ...(snapshotTransaction.complete ? { complete: snapshotTransaction.complete } : {}),
+      ...(snapshotTransaction.aborted ? { aborted: snapshotTransaction.aborted } : {}),
     };
 
     let opsFile: FileBasedOpsFile | null = null;
@@ -2670,38 +2736,26 @@ export class FileBasedSyncAdapterService {
       !snapshotRef || combinedOps.length > FILE_BASED_SYNC_CONSTANTS.MAX_RECENT_OPS;
 
     let finalOps = combinedOps;
+    let compactionState: FileBasedStateFile | undefined;
     if (needsCompaction) {
       // The ONLY normal path that reads the full store snapshot.
-      const stateData = await this._buildStateFileData(
+      compactionState = await this._buildStateFileData(
         clientId,
         newSyncVersion,
         mergedClock,
         schemaVersion,
         localStateSnapshot,
       );
-      // Preserve the pre-compaction snapshot for snapshotRef-mismatch recovery.
-      const previousState = await this._backupStateFile(
-        provider,
-        cfg,
-        encryptKey,
-        opsFile ?? undefined,
-        snapshotTransactionGuard,
-      );
-      // Atomicity: sync-state.json FIRST, then the ops file that references it.
-      const stateRev = await this._writeStateFile(provider, cfg, encryptKey, stateData, {
-        revToMatch: previousState?.rev ?? null,
-        isForceOverwrite: false,
-      });
+      // `rev` is intentionally omitted. It is an optional best-effort hint;
+      // readers bind by syncVersion/vectorClock, while the durable transaction
+      // marker binds the exact encoded state and its published revision. This
+      // removes the state-rev/encoded-ops circularity so the transaction can be
+      // written before either split primary changes.
       snapshotRef = {
         syncVersion: newSyncVersion,
         vectorClock: mergedClock,
-        rev: stateRev,
       };
       finalOps = combinedOps.slice(-FILE_BASED_SYNC_CONSTANTS.SPLIT_COMPACTION_THRESHOLD);
-      OpLog.normal(
-        `FileBasedSyncAdapter: split compaction wrote sync-state.json (syncVersion=${newSyncVersion}), ` +
-          `trimmed recentOps ${combinedOps.length} → ${finalOps.length}`,
-      );
     } else {
       finalOps = combinedOps.slice(-FILE_BASED_SYNC_CONSTANTS.MAX_RECENT_OPS);
     }
@@ -2726,35 +2780,75 @@ export class FileBasedSyncAdapterService {
       snapshotRef,
     };
 
-    // Backup-before-overwrite (SPAP-8, same as the single-file path): preserve
-    // the CURRENT remote ops file in .bak so an interrupted/corrupt write of the
-    // hot file (rewritten on every op-bearing sync — the highest torn-write
-    // exposure of any sync file) can be recovered on the next download.
-    if (opsFile) {
-      await this._writeBakFile(
-        provider,
+    let finalRev: string;
+    if (compactionState) {
+      const stateEncoded = await this._encryptAndCompressHandler.compressAndEncryptData(
         cfg,
         encryptKey,
-        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
-        opsFile,
+        compactionState,
         FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
-        (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
-        {
-          primaryPath: FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
-          primaryRev: opsRev,
-          snapshotTransaction: snapshotTransactionGuard,
-        },
       );
-    }
+      const opsEncoded = await this._encryptAndCompressHandler.compressAndEncryptData(
+        cfg,
+        encryptKey,
+        newOpsFile,
+        FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+      );
+      this._assertUploadDataNotEmpty(
+        stateEncoded,
+        'FileBasedSyncAdapter._uploadOpsSplit compacted state',
+      );
+      this._assertUploadDataNotEmpty(
+        opsEncoded,
+        'FileBasedSyncAdapter._uploadOpsSplit compacted ops',
+      );
+      finalRev = (
+        await this._forceUploadSplitSnapshot(
+          provider,
+          cfg,
+          encryptKey,
+          stateEncoded,
+          opsEncoded,
+          opsRev,
+        )
+      ).rev;
+      OpLog.normal(
+        `FileBasedSyncAdapter: transactional compaction committed (syncVersion=${newSyncVersion}), ` +
+          `trimmed recentOps ${combinedOps.length} → ${finalOps.length}`,
+      );
+    } else {
+      // Backup-before-overwrite (SPAP-8, same as the single-file path): preserve
+      // the CURRENT remote ops file in .bak so an interrupted/corrupt write of the
+      // hot file (rewritten on every op-bearing sync — the highest torn-write
+      // exposure of any sync file) can be recovered on the next download.
+      if (opsFile) {
+        await this._writeBakFile(
+          provider,
+          cfg,
+          encryptKey,
+          FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+          opsFile,
+          FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+          (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
+          {
+            primaryPath: FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+            primaryRev: opsRev,
+            snapshotTransaction: snapshotTransactionGuard,
+          },
+        );
+      }
 
-    // Commit point.
-    const { finalRev } = await this._uploadOpsFileWithMismatchFallback(
-      provider,
-      cfg,
-      encryptKey,
-      newOpsFile,
-      opsRev,
-    );
+      // Commit point.
+      finalRev = (
+        await this._uploadOpsFileWithMismatchFallback(
+          provider,
+          cfg,
+          encryptKey,
+          newOpsFile,
+          opsRev,
+        )
+      ).finalRev;
+    }
 
     this._clearCachedOpsData(providerKey);
     this._expectedSyncVersions.set(providerKey, newSyncVersion);
@@ -2789,12 +2883,36 @@ export class FileBasedSyncAdapterService {
     limit: number,
     providerKey: string,
   ): Promise<FileSnapshotOpDownloadResponse> {
+    const snapshotTransaction =
+      await this._recoverPendingSnapshotTransaction<FileBasedOpsFile>(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+        (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
+        {
+          primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+          bakPath: FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
+          expectedVersion: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+          isValid: (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
+          matchesSnapshot: (snapshot, state) =>
+            this._isFileBasedStateFile(state) &&
+            this._validateSnapshotRef(snapshot, state),
+        },
+      );
+    if (snapshotTransaction.didRecover) {
+      this._clearCachedOpsData(providerKey);
+      this._lastSeenRevs.delete(providerKey);
+    }
+
     // SPAP-10 rev pre-check, extended to the ops file. Gated on `sinceSeq > 0`
     // (review follow-up): a forceFromSeq0 download (sinceSeq === 0) re-pulls the
     // full snapshot to REBUILD local state (e.g. USE_REMOTE), so it must never be
     // short-circuited by an unchanged rev — the same guard as the single-file path.
-    // Runs BEFORE the snapshot-transaction marker check so an idle poll costs a
-    // single metadata request (see the single-file path for why this is sound).
+    // Runs after snapshot-transaction recovery; see the single-file path.
     const lastSeenRev = this._lastSeenRevs.get(providerKey);
     if (
       sinceSeq > 0 &&
@@ -2822,34 +2940,11 @@ export class FileBasedSyncAdapterService {
       }
     }
 
-    const snapshotTransaction =
-      await this._recoverPendingSnapshotTransaction<FileBasedOpsFile>(
-        provider,
-        cfg,
-        encryptKey,
-        FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
-        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
-        FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
-        FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
-        (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
-        {
-          primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
-          bakPath: FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
-          expectedVersion: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
-          isValid: (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
-          matchesSnapshot: (snapshot, state) =>
-            this._isFileBasedStateFile(state) &&
-            this._validateSnapshotRef(snapshot, state),
-        },
-      );
-    if (snapshotTransaction.didRecover) {
-      this._clearCachedOpsData(providerKey);
-      this._lastSeenRevs.delete(providerKey);
-    }
     const snapshotTransactionGuard: SnapshotTransactionGuard = {
       path: FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
       rev: snapshotTransaction.rev,
       ...(snapshotTransaction.complete ? { complete: snapshotTransaction.complete } : {}),
+      ...(snapshotTransaction.aborted ? { aborted: snapshotTransaction.aborted } : {}),
     };
 
     let opsFile: FileBasedOpsFile;
@@ -2884,8 +2979,14 @@ export class FileBasedSyncAdapterService {
           FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
           FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
           (data): data is FileBasedOpsFile => this._isFileBasedOpsFile(data),
-          undefined,
-          expectedSnapshotDigest,
+          {
+            expectedDigest: expectedSnapshotDigest,
+            rejectedDigests: this._getRejectedBackupDigests(
+              snapshotTransaction.complete ?? snapshotTransaction.aborted,
+              FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+            ),
+            normalize: (data) => this._normalizePendingMigrationOpsVersion(data),
+          },
         );
         if (!recovered) throw e;
         recoveredFromBackup = true;
@@ -2994,6 +3095,7 @@ export class FileBasedSyncAdapterService {
         encryptKey,
         opsFile,
         snapshotTransaction.complete,
+        snapshotTransaction.aborted,
       );
       if (snap) {
         snapshot = snap;
@@ -3114,8 +3216,9 @@ export class FileBasedSyncAdapterService {
         bakPath: FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
         expectedVersion: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
         isValid: (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
-        matchesSnapshot: (snapshot, state) =>
-          this._isFileBasedStateFile(state) && this._validateSnapshotRef(snapshot, state),
+        matchesSnapshot: (snapshot, stateFile) =>
+          this._isFileBasedStateFile(stateFile) &&
+          this._validateSnapshotRef(snapshot, stateFile),
       },
     );
 
@@ -3162,6 +3265,8 @@ export class FileBasedSyncAdapterService {
     );
     const opsRes = await this._forceUploadSplitSnapshot(
       provider,
+      cfg,
+      encryptKey,
       stateEncoded,
       opsEncoded,
     );
@@ -3217,13 +3322,36 @@ export class FileBasedSyncAdapterService {
     return complete.primaryRev === primaryRev ? complete.snapshotDigest : undefined;
   }
 
+  private _getRejectedBackupDigests(
+    transaction: SnapshotTransaction | undefined,
+    primaryPath: string | undefined,
+  ): string[] {
+    if (!transaction) return [];
+    const isState = primaryPath === FILE_BASED_SYNC_CONSTANTS.STATE_FILE;
+    const inherited = isState
+      ? transaction.rejectedStateDigests
+      : transaction.rejectedSnapshotDigests;
+    const currentRejectedDigest =
+      transaction.status === 'aborted'
+        ? isState
+          ? transaction.stateDigest
+          : transaction.snapshotDigest
+        : undefined;
+    return [
+      ...new Set([
+        ...(inherited ?? []),
+        ...(currentRejectedDigest ? [currentRejectedDigest] : []),
+      ]),
+    ];
+  }
+
   /**
    * Writes a recovery backup without replacing a causally newer artifact.
    *
-   * Backup writes are non-fatal by contract: a provider that cannot write the
-   * backup must still be able to sync (only the semantic concurrency signal
-   * UploadRevToMatchMismatchAPIError is rethrown — it means the WORLD moved,
-   * not that the backup failed, and the caller must re-observe before writing).
+   * Rolling backup writes are normally non-fatal. Callers set `isRequired`
+   * when this copy preserves data still referenced by a commit point; those
+   * failures abort the replacement. A semantic revision mismatch is always
+   * rethrown because the caller must re-observe before writing.
    */
   private async _writeBakFile<
     T extends { version: number; syncVersion: number; vectorClock: VectorClock },
@@ -3239,6 +3367,7 @@ export class FileBasedSyncAdapterService {
       primaryPath?: string;
       primaryRev?: string | null;
       snapshotTransaction?: SnapshotTransactionGuard;
+      isRequired?: boolean;
     } = {},
   ): Promise<void> {
     const bakRevCacheKey = `${this._getProviderKey(provider)}:${bakPath}`;
@@ -3294,12 +3423,20 @@ export class FileBasedSyncAdapterService {
         bakPath,
         fileVersion,
         isValid,
-        (rev) => {
-          backupRev = rev;
+        {
+          onReadRev: (rev) => {
+            backupRev = rev;
+          },
+          expectedDigest: expectedBackupDigest,
+          rejectedDigests: this._getRejectedBackupDigests(
+            options.snapshotTransaction?.pending ??
+              options.snapshotTransaction?.complete ??
+              options.snapshotTransaction?.aborted,
+            options.primaryPath,
+          ),
         },
-        expectedBackupDigest,
       );
-      if (options.snapshotTransaction) {
+      if (options.snapshotTransaction && !options.snapshotTransaction.pending) {
         await this._assertSnapshotTransactionUnchanged(
           provider,
           options.snapshotTransaction,
@@ -3341,7 +3478,7 @@ export class FileBasedSyncAdapterService {
       this._bakRevCache.set(bakRevCacheKey, uploadRes.rev);
       OpLog.normal(`FileBasedSyncAdapter: Wrote ${bakPath} before overwrite`);
     } catch (e) {
-      if (e instanceof UploadRevToMatchMismatchAPIError) throw e;
+      if (options.isRequired || e instanceof UploadRevToMatchMismatchAPIError) throw e;
       OpLog.warn(
         `FileBasedSyncAdapter: ${bakPath} write failed (non-fatal), proceeding`,
         e,
@@ -3361,18 +3498,24 @@ export class FileBasedSyncAdapterService {
     bakPath: string,
     expectedVersion: number,
     isValid: (data: unknown) => data is T,
-    onReadRev?: (rev: string) => void,
-    expectedDigest?: string,
+    options: ReadBakFileOptions = {},
   ): Promise<{ data: T; rev: string } | null> {
     try {
       const response = await provider.downloadFile(bakPath);
-      onReadRev?.(response.rev);
-      if (
-        expectedDigest !== undefined &&
-        (await this._digestEncodedPayload(response.dataStr)) !== expectedDigest
-      ) {
+      options.onReadRev?.(response.rev);
+      const digest =
+        options.expectedDigest !== undefined || options.rejectedDigests?.length
+          ? await this._digestEncodedPayload(response.dataStr)
+          : undefined;
+      if (options.expectedDigest !== undefined && digest !== options.expectedDigest) {
         OpLog.warn(
           `FileBasedSyncAdapter: ${bakPath} does not match the authoritative snapshot marker — refusing recovery`,
+        );
+        return null;
+      }
+      if (digest !== undefined && options.rejectedDigests?.includes(digest)) {
+        OpLog.warn(
+          `FileBasedSyncAdapter: ${bakPath} belongs to an abandoned snapshot — refusing recovery`,
         );
         return null;
       }
@@ -3390,12 +3533,13 @@ export class FileBasedSyncAdapterService {
         );
         return null;
       }
-      const data =
+      const decoded =
         await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
           cfg,
           encryptKey,
           response.dataStr,
         );
+      const data = options.normalize ? options.normalize(decoded) : decoded;
       const version = this._isRecord(data) ? data['version'] : undefined;
       if (version !== expectedVersion) {
         OpLog.warn(
@@ -3455,6 +3599,10 @@ export class FileBasedSyncAdapterService {
         data['status'] !== 'complete' &&
         data['status'] !== 'aborted') ||
       typeof data['transactionId'] !== 'string' ||
+      (data['rejectedSnapshotDigests'] !== undefined &&
+        !this._isStringArray(data['rejectedSnapshotDigests'])) ||
+      (data['rejectedStateDigests'] !== undefined &&
+        !this._isStringArray(data['rejectedStateDigests'])) ||
       (data['status'] === 'pending' &&
         (typeof data['encodedSnapshot'] !== 'string' ||
           (data['basePrimaryRev'] !== null &&
@@ -3468,6 +3616,10 @@ export class FileBasedSyncAdapterService {
             (data['stateDigest'] === undefined) ||
           (data['statePrimaryRev'] !== undefined &&
             typeof data['statePrimaryRev'] !== 'string') ||
+          (data['stateDigest'] !== undefined &&
+            typeof data['stateDigest'] !== 'string'))) ||
+      (data['status'] === 'aborted' &&
+        (typeof data['snapshotDigest'] !== 'string' ||
           (data['stateDigest'] !== undefined && typeof data['stateDigest'] !== 'string')))
     ) {
       OpLog.warn(
@@ -3483,7 +3635,11 @@ export class FileBasedSyncAdapterService {
     guard: SnapshotTransactionGuard,
   ): Promise<void> {
     const current = await this._readSnapshotTransaction(provider, guard.path);
-    if (current?.data?.status === 'pending' || (current?.rev ?? null) !== guard.rev) {
+    const pendingChanged = guard.pending
+      ? current?.data?.status !== 'pending' ||
+        current.data.transactionId !== guard.pending.transactionId
+      : current?.data?.status === 'pending';
+    if (pendingChanged || (current?.rev ?? null) !== guard.rev) {
       throw new UploadRevToMatchMismatchAPIError(
         `FileBasedSyncAdapter: ${guard.path} changed while preparing the upload`,
       );
@@ -3505,18 +3661,112 @@ export class FileBasedSyncAdapterService {
     OpLog.warn(
       `FileBasedSyncAdapter: abandoning pending snapshot transaction (${reason})`,
     );
-    const aborted = JSON.stringify({
+    const abortedData: AbortedSnapshotTransaction = {
       version: 1,
       status: 'aborted',
       transactionId: transaction.data.transactionId,
-    } satisfies AbortedSnapshotTransaction);
+      snapshotDigest: await this._digestEncodedPayload(transaction.data.encodedSnapshot),
+      ...(transaction.data.rejectedSnapshotDigests?.length
+        ? { rejectedSnapshotDigests: transaction.data.rejectedSnapshotDigests }
+        : {}),
+      ...(transaction.data.rejectedStateDigests?.length
+        ? { rejectedStateDigests: transaction.data.rejectedStateDigests }
+        : {}),
+      ...(transaction.data.encodedState === undefined
+        ? {}
+        : {
+            stateDigest: await this._digestEncodedPayload(transaction.data.encodedState),
+          }),
+    };
+    const aborted = JSON.stringify(abortedData);
     const result = await provider.uploadFile(
       transactionPath,
       aborted,
       transaction.rev,
       false,
     );
-    return { didRecover: false, rev: result.rev };
+    return { didRecover: false, rev: result.rev, aborted: abortedData };
+  }
+
+  private async _prepareSplitStatePublication(
+    provider: FileSyncProvider<SyncProviderId>,
+    cfg: EncryptAndCompressCfg,
+    encryptKey: string | undefined,
+    baseOpsRev: string | null,
+    encodedState: string,
+    snapshotTransaction: SnapshotTransactionGuard,
+  ): Promise<{ revToMatch: string | null; publishedRev?: string }> {
+    let currentState:
+      | {
+          dataStr: string;
+          rev: string;
+        }
+      | undefined;
+    try {
+      currentState = await provider.downloadFile(FILE_BASED_SYNC_CONSTANTS.STATE_FILE);
+    } catch (e) {
+      if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
+    }
+    const currentStateDigest = currentState
+      ? await this._digestEncodedPayload(currentState.dataStr)
+      : undefined;
+    const isAlreadyPublished =
+      currentStateDigest !== undefined &&
+      currentStateDigest === (await this._digestEncodedPayload(encodedState));
+    const isKnownAbandoned =
+      currentStateDigest !== undefined &&
+      this._getRejectedBackupDigests(
+        snapshotTransaction.pending ??
+          snapshotTransaction.complete ??
+          snapshotTransaction.aborted,
+        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+      ).includes(currentStateDigest);
+
+    if (baseOpsRev === null) {
+      if (currentState && !isAlreadyPublished) {
+        throw new UploadRevToMatchMismatchAPIError(
+          'Split snapshot state appeared after an absent ops baseline',
+        );
+      }
+      return {
+        revToMatch: null,
+        ...(isAlreadyPublished ? { publishedRev: currentState?.rev } : {}),
+      };
+    }
+
+    const committed = await this._downloadOpsFile(provider, cfg, encryptKey);
+    if (committed.rev !== baseOpsRev) {
+      throw new UploadRevToMatchMismatchAPIError();
+    }
+    const preserved = await this._backupStateFile(
+      provider,
+      cfg,
+      encryptKey,
+      committed.data,
+      snapshotTransaction,
+    );
+    if (
+      !isAlreadyPublished &&
+      preserved?.data &&
+      !this._validateSnapshotRef(committed.data, preserved.data) &&
+      !isKnownAbandoned
+    ) {
+      // Another writer has published a candidate state but has not committed
+      // its ops file yet. Do not destroy that candidate; its CAS may still win.
+      throw new UploadRevToMatchMismatchAPIError(
+        'Split snapshot state is owned by an in-flight ops commit',
+      );
+    }
+    const currentOpsRev = (
+      await provider.getFileRev(FILE_BASED_SYNC_CONSTANTS.OPS_FILE, baseOpsRev)
+    ).rev;
+    if (currentOpsRev !== baseOpsRev) {
+      throw new UploadRevToMatchMismatchAPIError();
+    }
+    return {
+      revToMatch: preserved?.rev ?? null,
+      ...(isAlreadyPublished ? { publishedRev: currentState?.rev } : {}),
+    };
   }
 
   /** Completes a crash-interrupted authoritative snapshot before normal sync. */
@@ -3541,15 +3791,24 @@ export class FileBasedSyncAdapterService {
     if (!transaction) {
       return { didRecover: false, rev: null };
     }
-    if (!transaction.data || transaction.data.status === 'aborted') {
+    if (!transaction.data) {
       // Unusable (torn write) or explicitly abandoned marker: there is nothing
       // to recover; a later snapshot upload overwrites it conditionally by rev.
       return { didRecover: false, rev: transaction.rev };
+    }
+    if (transaction.data.status === 'aborted') {
+      return {
+        didRecover: false,
+        rev: transaction.rev,
+        aborted: transaction.data,
+      };
     }
     if (transaction.data.status === 'complete') {
       return { didRecover: false, rev: transaction.rev, complete: transaction.data };
     }
     const pending = { data: transaction.data, rev: transaction.rev };
+    const encodedSnapshot = pending.data.encodedSnapshot;
+    const encodedState = pending.data.encodedState;
 
     // Freshness guard BEFORE any decode or write: recovery may only promote the
     // pending payload while the primary still has the rev observed at begin
@@ -3565,6 +3824,56 @@ export class FileBasedSyncAdapterService {
       if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
     }
     if (currentPrimaryRev !== pending.data.basePrimaryRev) {
+      if (currentPrimaryRev === null) {
+        return this._abandonSnapshotTransaction(
+          provider,
+          transactionPath,
+          pending,
+          'primary was deleted after the transaction began',
+        );
+      }
+      const currentPrimary = await provider.downloadFile(primaryPath);
+      if (
+        currentPrimary.rev === currentPrimaryRev &&
+        (await this._digestEncodedPayload(currentPrimary.dataStr)) ===
+          (await this._digestEncodedPayload(encodedSnapshot))
+      ) {
+        let committedState: { encodedState: string; primaryRev: string } | undefined;
+        if (splitState && encodedState) {
+          const currentState = await provider.downloadFile(splitState.primaryPath);
+          if (
+            (await this._digestEncodedPayload(currentState.dataStr)) !==
+            (await this._digestEncodedPayload(encodedState))
+          ) {
+            throw new UploadRevToMatchMismatchAPIError(
+              'Pending split snapshot ops committed without their bound state',
+            );
+          }
+          committedState = { encodedState, primaryRev: currentState.rev };
+        }
+        const completed = await this._completeSnapshotTransaction(
+          provider,
+          transactionPath,
+          pending.data.transactionId,
+          pending.rev,
+          encodedSnapshot,
+          currentPrimary.rev,
+          committedState,
+          pending.data,
+        );
+        try {
+          await provider.uploadFile(bakPath, encodedSnapshot, null, true);
+          if (splitState && encodedState) {
+            await provider.uploadFile(splitState.bakPath, encodedState, null, true);
+          }
+        } catch (e) {
+          OpLog.warn(
+            'FileBasedSyncAdapter: committed snapshot backup refresh failed (non-fatal)',
+            e,
+          );
+        }
+        return completed;
+      }
       return this._abandonSnapshotTransaction(
         provider,
         transactionPath,
@@ -3573,15 +3882,23 @@ export class FileBasedSyncAdapterService {
       );
     }
 
-    const encodedSnapshot = pending.data.encodedSnapshot;
-    const encodedState = pending.data.encodedState;
+    if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedSnapshot).isEncrypted) {
+      throw new SyncDataCorruptedError(
+        'Pending snapshot is plaintext but encryption is expected',
+        transactionPath,
+      );
+    }
+    if (
+      cfg.isEncrypt &&
+      typeof encodedState === 'string' &&
+      !extractSyncFileStateFromPrefix(encodedState).isEncrypted
+    ) {
+      throw new SyncDataCorruptedError(
+        'Pending split state snapshot is plaintext but encryption is expected',
+        transactionPath,
+      );
+    }
     try {
-      if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedSnapshot).isEncrypted) {
-        throw new SyncDataCorruptedError(
-          'Pending snapshot is plaintext but encryption is expected',
-          transactionPath,
-        );
-      }
       const decoded =
         await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
           cfg,
@@ -3600,12 +3917,6 @@ export class FileBasedSyncAdapterService {
         if (typeof encodedState !== 'string') {
           throw new SyncDataCorruptedError(
             'Pending split snapshot transaction has no bound state payload',
-            transactionPath,
-          );
-        }
-        if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedState).isEncrypted) {
-          throw new SyncDataCorruptedError(
-            'Pending split state snapshot is plaintext but encryption is expected',
             transactionPath,
           );
         }
@@ -3635,10 +3946,11 @@ export class FileBasedSyncAdapterService {
         );
       }
     } catch (e) {
+      if (e instanceof DecryptError) throw e;
       if (!this._isRecoverableCorruption(e)) throw e;
-      // An unpromotable payload can never be recovered — a wrong/rotated key,
-      // a plaintext downgrade, or torn payload data. Keeping the marker would
-      // wedge every sync path (including "Use Local") on it forever.
+      // Structurally invalid payloads cannot be promoted. Authentication and
+      // encryption-mode failures return above without mutating the marker: the
+      // same payload may still be valid once the user supplies the right key.
       OpLog.warn('FileBasedSyncAdapter: pending snapshot payload is unusable', e);
       return this._abandonSnapshotTransaction(
         provider,
@@ -3650,11 +3962,32 @@ export class FileBasedSyncAdapterService {
 
     let statePrimaryRev: string | undefined;
     if (splitState && encodedState) {
-      // The ops file remains the commit point. Publish state first; old ops can
-      // still use the retained state backup until the bound ops payload lands.
-      statePrimaryRev = (
-        await provider.uploadFile(splitState.primaryPath, encodedState, null, true)
-      ).rev;
+      const statePublication = await this._prepareSplitStatePublication(
+        provider,
+        cfg,
+        encryptKey,
+        pending.data.basePrimaryRev,
+        encodedState,
+        {
+          path: transactionPath,
+          rev: pending.rev,
+          pending: pending.data,
+        },
+      );
+      statePrimaryRev = statePublication.publishedRev;
+      // The ops file remains the commit point. Publish state conditionally;
+      // the required backup above keeps the still-committed ops/state pair
+      // readable until the bound ops payload lands.
+      if (statePrimaryRev === undefined) {
+        statePrimaryRev = (
+          await provider.uploadFile(
+            splitState.primaryPath,
+            encodedState,
+            statePublication.revToMatch,
+            false,
+          )
+        ).rev;
+      }
     }
 
     // The pending marker owns this exact payload. Re-establish the recovery
@@ -3680,6 +4013,7 @@ export class FileBasedSyncAdapterService {
       encodedState && statePrimaryRev
         ? { encodedState, primaryRev: statePrimaryRev }
         : undefined,
+      pending.data,
     );
   }
 
@@ -3689,7 +4023,8 @@ export class FileBasedSyncAdapterService {
     primaryPath: string,
     encodedSnapshot: string,
     encodedState?: string,
-  ): Promise<{ transactionId: string; rev: string }> {
+    expectedBasePrimaryRev?: string | null,
+  ): Promise<{ data: PendingSnapshotTransaction; rev: string }> {
     const priorTransaction = await this._readSnapshotTransaction(
       provider,
       transactionPath,
@@ -3704,29 +4039,41 @@ export class FileBasedSyncAdapterService {
     // only promote the payload while this rev is still current (see
     // _recoverPendingSnapshotTransaction); the live flow force-writes and is
     // unaffected by a slightly stale probe.
-    let basePrimaryRev: string | null = null;
-    try {
-      basePrimaryRev = (await provider.getFileRev(primaryPath, null)).rev;
-    } catch (e) {
-      if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
+    let basePrimaryRev = expectedBasePrimaryRev ?? null;
+    if (expectedBasePrimaryRev === undefined) {
+      try {
+        basePrimaryRev = (await provider.getFileRev(primaryPath, null)).rev;
+      } catch (e) {
+        if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
+      }
     }
 
     const transactionId = uuidv7();
-    const pending = JSON.stringify({
+    const rejectedSnapshotDigests = this._getRejectedBackupDigests(
+      priorTransaction?.data ?? undefined,
+      primaryPath,
+    );
+    const rejectedStateDigests = this._getRejectedBackupDigests(
+      priorTransaction?.data ?? undefined,
+      FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+    );
+    const pendingData: PendingSnapshotTransaction = {
       version: 1,
       status: 'pending',
       transactionId,
       basePrimaryRev,
       encodedSnapshot,
       ...(encodedState === undefined ? {} : { encodedState }),
-    } satisfies PendingSnapshotTransaction);
+      ...(rejectedSnapshotDigests.length ? { rejectedSnapshotDigests } : {}),
+      ...(rejectedStateDigests.length ? { rejectedStateDigests } : {}),
+    };
     const result = await provider.uploadFile(
       transactionPath,
-      pending,
+      JSON.stringify(pendingData),
       priorTransaction?.rev ?? null,
       false,
     );
-    return { transactionId, rev: result.rev };
+    return { data: pendingData, rev: result.rev };
   }
 
   private async _completeSnapshotTransaction(
@@ -3737,6 +4084,7 @@ export class FileBasedSyncAdapterService {
     encodedSnapshot: string,
     primaryRev: string,
     state?: { encodedState: string; primaryRev: string },
+    rejectionHistory?: SnapshotRejectionHistory,
   ): Promise<SnapshotTransactionObservation> {
     const complete: CompleteSnapshotTransaction = {
       version: 1,
@@ -3744,6 +4092,14 @@ export class FileBasedSyncAdapterService {
       transactionId,
       primaryRev,
       snapshotDigest: await this._digestEncodedPayload(encodedSnapshot),
+      ...(rejectionHistory?.rejectedSnapshotDigests?.length
+        ? {
+            rejectedSnapshotDigests: rejectionHistory.rejectedSnapshotDigests,
+          }
+        : {}),
+      ...(rejectionHistory?.rejectedStateDigests?.length
+        ? { rejectedStateDigests: rejectionHistory.rejectedStateDigests }
+        : {}),
       ...(state
         ? {
             statePrimaryRev: state.primaryRev,
@@ -3783,19 +4139,24 @@ export class FileBasedSyncAdapterService {
     await this._completeSnapshotTransaction(
       provider,
       transactionPath,
-      transaction.transactionId,
+      transaction.data.transactionId,
       transaction.rev,
       encoded,
       primaryRes.rev,
+      undefined,
+      transaction.data,
     );
     return primaryRes;
   }
 
-  /** Atomically publishes the state/ops pair used by split authoritative snapshots. */
+  /** Publishes a transaction-bound split state/ops pair. */
   private async _forceUploadSplitSnapshot(
     provider: FileSyncProvider<SyncProviderId>,
+    cfg: EncryptAndCompressCfg,
+    encryptKey: string | undefined,
     encodedState: string,
     encodedOps: string,
+    expectedOpsRev?: string | null,
   ): Promise<{ rev: string }> {
     const transaction = await this._beginSnapshotTransaction(
       provider,
@@ -3803,13 +4164,28 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
       encodedOps,
       encodedState,
+      expectedOpsRev,
     );
-    const stateResult = await provider.uploadFile(
-      FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+    const statePublication = await this._prepareSplitStatePublication(
+      provider,
+      cfg,
+      encryptKey,
+      transaction.data.basePrimaryRev,
       encodedState,
-      null,
-      true,
+      {
+        path: FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+        rev: transaction.rev,
+        pending: transaction.data,
+      },
     );
+    const stateResult = statePublication.publishedRev
+      ? { rev: statePublication.publishedRev }
+      : await provider.uploadFile(
+          FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+          encodedState,
+          statePublication.revToMatch,
+          false,
+        );
     await provider.uploadFile(
       FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
       encodedOps,
@@ -3819,8 +4195,8 @@ export class FileBasedSyncAdapterService {
     const opsResult = await provider.uploadFile(
       FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
       encodedOps,
-      null,
-      true,
+      expectedOpsRev ?? null,
+      expectedOpsRev === undefined,
     );
     await provider.uploadFile(
       FILE_BASED_SYNC_CONSTANTS.STATE_BACKUP_FILE,
@@ -3831,11 +4207,12 @@ export class FileBasedSyncAdapterService {
     await this._completeSnapshotTransaction(
       provider,
       FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
-      transaction.transactionId,
+      transaction.data.transactionId,
       transaction.rev,
       encodedOps,
       opsResult.rev,
       { encodedState, primaryRev: stateResult.rev },
+      transaction.data,
     );
     return opsResult;
   }

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -1328,6 +1328,24 @@ export class FileBasedSyncAdapterService {
     return data.migration?.status === 'pending' && !!data.migration.legacyRev;
   }
 
+  private _pendingSplitMigrationMatchesLegacy(
+    pending: FileBasedOpsFile,
+    legacy: FileBasedSyncData,
+  ): boolean {
+    const legacySchemaVersion = legacy.schemaVersion ?? 1;
+    const legacyOps = legacy.recentOps ?? [];
+    return (
+      pending.syncVersion === legacy.syncVersion &&
+      pending.schemaVersion === legacySchemaVersion &&
+      compareVectorClocks(pending.vectorClock, legacy.vectorClock) === 'EQUAL' &&
+      pending.oldestOpSyncVersion === legacy.oldestOpSyncVersion &&
+      pending.snapshotRef.syncVersion === legacy.syncVersion &&
+      compareVectorClocks(pending.snapshotRef.vectorClock, legacy.vectorClock) ===
+        'EQUAL' &&
+      JSON.stringify(pending.recentOps) === JSON.stringify(legacyOps)
+    );
+  }
+
   /** Surfaces the actionable "turn on Surgical sync" notice (non-fatal if no snack). */
   private _notifySplitFormatDetected(): void {
     this._injector
@@ -1544,9 +1562,11 @@ export class FileBasedSyncAdapterService {
 
   /**
    * Neutralizes `sync-data.json.bak` and then overwrites `sync-data.json` with a
-   * v3 split tombstone (NEVER deletes it), so an old client's SPAP-8 `.bak`
-   * recovery cannot resurrect a v2 file and diverge. Order matters — see the
-   * inline comment.
+   * v3 split tombstone (NEVER deletes it), so compatible clients cannot recover
+   * a stale v2 backup after observing the migration. Order matters — see the
+   * inline comment. A pre-split binary already mid-upload cannot participate in
+   * this protocol, which is why the setting instructs users to stop and update
+   * every device before migration.
    */
   private async _writeTombstoneAndNeutralizeBak(
     provider: FileSyncProvider<SyncProviderId>,
@@ -1578,9 +1598,11 @@ export class FileBasedSyncAdapterService {
     // a tombstone with a resurrectable v2 .bak beside it.
     //
     // Migration passes the exact downloaded legacy rev, making the primary
-    // tombstone conditional. A mismatch leaves the pending ops marker intact;
-    // the recovery loop imports the newer v2 payload and retries. Explicit
-    // snapshot replacement omits the rev and intentionally force-overwrites.
+    // tombstone conditional when the provider offers atomic CAS. A mismatch
+    // leaves the pending marker intact; the recovery loop imports the newer v2
+    // payload and retries. Weak/no-ETag WebDAV and Local File retain their
+    // documented single-writer limitation. Explicit snapshot replacement omits
+    // the rev and intentionally force-overwrites.
     await provider.uploadFile(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE, encoded, null, true);
     // Overwrite the legacy single file in place (never remove it).
     await provider.uploadFile(
@@ -1723,7 +1745,10 @@ export class FileBasedSyncAdapterService {
         throw e;
       }
 
-      if (legacy.rev !== current.data.migration?.legacyRev) {
+      if (
+        legacy.rev !== current.data.migration?.legacyRev ||
+        !this._pendingSplitMigrationMatchesLegacy(current.data, legacy.data)
+      ) {
         try {
           current = await this._writePendingSplitMigration(
             provider,

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -59,6 +59,13 @@ interface PendingSnapshotTransaction {
   version: 1;
   status: 'pending';
   transactionId: string;
+  /**
+   * Primary rev observed when the transaction began (null = file absent).
+   * Recovery may only promote the pending payload while the primary still has
+   * this exact rev; any advance means a marker-unaware client committed data
+   * after the crash, and promoting the stale payload would clobber it.
+   */
+  basePrimaryRev: string | null;
   encodedSnapshot: string;
   encodedState?: string;
 }
@@ -73,7 +80,17 @@ interface CompleteSnapshotTransaction {
   stateDigest?: string;
 }
 
-type SnapshotTransaction = PendingSnapshotTransaction | CompleteSnapshotTransaction;
+/** A pending transaction that recovery gave up on (stale or undecodable). */
+interface AbortedSnapshotTransaction {
+  version: 1;
+  status: 'aborted';
+  transactionId: string;
+}
+
+type SnapshotTransaction =
+  | PendingSnapshotTransaction
+  | CompleteSnapshotTransaction
+  | AbortedSnapshotTransaction;
 
 interface SnapshotTransactionObservation {
   didRecover: boolean;
@@ -185,6 +202,16 @@ export class FileBasedSyncAdapterService {
    * ops and skip them on the next poll's pre-check.
    */
   private _pendingRevs = new Map<string, string>();
+
+  /**
+   * Rev of the `.bak` artifact WE last wrote, keyed by `providerKey:bakPath`.
+   * Lets the rolling backup rotation use a single conditional PUT instead of a
+   * full download + decrypt + validate of the existing backup on every upload
+   * cycle (the backup holds the whole dataset in single-file mode). In-memory
+   * only: a fresh session re-primes it with one guarded slow-path write. Never
+   * updated by snapshot force-writes, so those invalidate the fast path by rev.
+   */
+  private _bakRevCache = new Map<string, string>();
 
   /**
    * SPAP-10: providers whose `getFileRev` is BOTH cheap (a metadata-only call, so
@@ -903,22 +930,6 @@ export class FileBasedSyncAdapterService {
       );
     }
 
-    const snapshotTransaction =
-      await this._recoverPendingSnapshotTransaction<FileBasedSyncData>(
-        provider,
-        cfg,
-        encryptKey,
-        FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
-        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
-        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
-        FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
-        (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
-      );
-    if (snapshotTransaction.didRecover) {
-      this._clearCachedSyncData(providerKey);
-      this._lastSeenRevs.delete(providerKey);
-    }
-
     // SPAP-10: cheap remote-rev pre-check. If we already know the last-seen rev
     // AND nothing in this cycle has cached a fresh download, ask the provider for
     // the current rev WITHOUT downloading the full file. An unchanged rev proves
@@ -927,6 +938,13 @@ export class FileBasedSyncAdapterService {
     // signal (syncVersion reset, snapshot replacement, partial trimming) requires
     // the file to have CHANGED, which an identical rev rules out. We therefore
     // safely bypass the gap-detection block below.
+    //
+    // Runs BEFORE the snapshot-transaction marker check so an idle poll costs a
+    // single metadata request. Skipping the marker on the short-circuit is
+    // sound: an unchanged primary rev means either no transaction happened, or
+    // one is still pending with nothing promoted yet — completing it is a
+    // write-side concern handled by every upload and by the next changed-rev
+    // download.
     //
     // Gating on cache absence is a correctness guard, not just an optimization:
     // during multi-page pagination `_downloadOps` is called repeatedly with the
@@ -973,6 +991,22 @@ export class FileBasedSyncAdapterService {
           e,
         );
       }
+    }
+
+    const snapshotTransaction =
+      await this._recoverPendingSnapshotTransaction<FileBasedSyncData>(
+        provider,
+        cfg,
+        encryptKey,
+        FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+        FILE_BASED_SYNC_CONSTANTS.SNAPSHOT_TRANSACTION_FILE,
+        FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+        (data): data is FileBasedSyncData => this._isFileBasedSyncData(data),
+      );
+    if (snapshotTransaction.didRecover) {
+      this._clearCachedSyncData(providerKey);
+      this._lastSeenRevs.delete(providerKey);
     }
 
     let syncData: FileBasedSyncData;
@@ -1434,6 +1468,11 @@ export class FileBasedSyncAdapterService {
       this._pendingGapResolutionProviderKeys.delete(providerKey);
       this._clearCachedSyncData(providerKey);
       this._clearCachedOpsData(providerKey);
+      for (const cacheKey of this._bakRevCache.keys()) {
+        if (cacheKey.startsWith(`${providerKey}:`)) {
+          this._bakRevCache.delete(cacheKey);
+        }
+      }
       this._persistState();
 
       return { success: true };
@@ -1637,12 +1676,23 @@ export class FileBasedSyncAdapterService {
   ): Promise<{ data: FileBasedOpsFile; rev: string }> {
     const response = await provider.downloadFile(FILE_BASED_SYNC_CONSTANTS.OPS_FILE);
     try {
-      const data =
+      const decoded =
         await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
           cfg,
           encryptKey,
           response.dataStr,
         );
+      // A mid-migration pending marker is written with the sentinel version so
+      // OLD clients reject it (see _writePendingSplitMigration). Normalize it
+      // back for in-memory use; a sentinel-version file MUST carry the pending
+      // migration marker, otherwise it is corrupt.
+      const isPendingMigrationVersion =
+        this._isRecord(decoded) &&
+        decoded['version'] ===
+          FILE_BASED_SYNC_CONSTANTS.SPLIT_MIGRATION_PENDING_OPS_VERSION;
+      const data = isPendingMigrationVersion
+        ? { ...decoded, version: FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION }
+        : decoded;
       if (
         !this._isRecord(data) ||
         data['version'] !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION
@@ -1653,7 +1703,10 @@ export class FileBasedSyncAdapterService {
           FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
         );
       }
-      if (!this._isFileBasedOpsFile(data)) {
+      if (
+        !this._isFileBasedOpsFile(data) ||
+        (isPendingMigrationVersion && !this._isPendingSplitMigration(data))
+      ) {
         throw new SyncDataCorruptedError(
           'Invalid ops-file structure',
           FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
@@ -1734,7 +1787,10 @@ export class FileBasedSyncAdapterService {
    * Preserves the state referenced by the committed ops file before replacing
    * `sync-state.json`, then returns the primary revision the replacement must
    * match. If an abandoned replacement left an unreferenced primary, an already
-   * valid backup is retained instead of being rotated away.
+   * valid backup is retained instead of being rotated away. When NEITHER the
+   * primary nor the backup matches the committed snapshotRef, nothing is
+   * preserved and the compaction proceeds to rewrite a fresh snapshot
+   * (self-heal — the ops file CAS remains the concurrency gate).
    */
   private async _backupStateFile(
     provider: FileSyncProvider<SyncProviderId>,
@@ -1804,10 +1860,17 @@ export class FileBasedSyncAdapterService {
     }
 
     if (!current || !this._validateSnapshotRef(committedOpsFile, current.data)) {
-      throw new SyncDataCorruptedError(
-        'Neither sync-state.json nor its backup matches the committed snapshotRef',
-        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+      // Self-heal: NOTHING on the remote matches the committed snapshotRef any
+      // more (state file deleted by cloud cleanup, replaced without commit, or
+      // corrupt with no usable backup). There is nothing left to preserve, and
+      // the caller is about to write a fresh full snapshot and CAS the ops
+      // commit point — which restores a consistent pair. Failing here instead
+      // would wedge every future compaction with no user remedy.
+      OpLog.warn(
+        'FileBasedSyncAdapter: no snapshot matches the committed snapshotRef; ' +
+          'compaction will rewrite sync-state.json',
       );
+      return current ?? (primaryRev === null ? null : { rev: primaryRev });
     }
 
     await this._writeBakFile(
@@ -1819,7 +1882,6 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
       (data): data is FileBasedStateFile => this._isFileBasedStateFile(data),
       {
-        isRequired: true,
         primaryPath: FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
         primaryRev,
         snapshotTransaction,
@@ -2038,10 +2100,17 @@ export class FileBasedSyncAdapterService {
       },
       migration: { status: 'pending', legacyRev },
     };
+    // On disk the pending marker carries the sentinel version so already-shipped
+    // split clients (which know neither the `migration` field nor the fact that
+    // sync-state.json does not exist yet) fail safe on it instead of adopting or
+    // finalizing a half-done migration. See SPLIT_MIGRATION_PENDING_OPS_VERSION.
     const encoded = await this._encryptAndCompressHandler.compressAndEncryptData(
       cfg,
       encryptKey,
-      opsData,
+      {
+        ...opsData,
+        version: FILE_BASED_SYNC_CONSTANTS.SPLIT_MIGRATION_PENDING_OPS_VERSION,
+      },
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
     );
     this._assertUploadDataNotEmpty(
@@ -2720,6 +2789,39 @@ export class FileBasedSyncAdapterService {
     limit: number,
     providerKey: string,
   ): Promise<FileSnapshotOpDownloadResponse> {
+    // SPAP-10 rev pre-check, extended to the ops file. Gated on `sinceSeq > 0`
+    // (review follow-up): a forceFromSeq0 download (sinceSeq === 0) re-pulls the
+    // full snapshot to REBUILD local state (e.g. USE_REMOTE), so it must never be
+    // short-circuited by an unchanged rev — the same guard as the single-file path.
+    // Runs BEFORE the snapshot-transaction marker check so an idle poll costs a
+    // single metadata request (see the single-file path for why this is sound).
+    const lastSeenRev = this._lastSeenRevs.get(providerKey);
+    if (
+      sinceSeq > 0 &&
+      lastSeenRev &&
+      !this._getCachedOpsData(providerKey) &&
+      this._REV_PRECHECK_PROVIDERS.has(provider.id)
+    ) {
+      try {
+        const { rev: remoteRev } = await provider.getFileRev(
+          FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+          lastSeenRev,
+        );
+        if (remoteRev === lastSeenRev) {
+          const expectedVersion = this._expectedSyncVersions.get(providerKey) ?? 0;
+          OpLog.normal(
+            'FileBasedSyncAdapter: ops-file rev unchanged — skipping full download.',
+          );
+          return { ops: [], hasMore: false, latestSeq: expectedVersion };
+        }
+      } catch (e) {
+        OpLog.normal(
+          'FileBasedSyncAdapter: ops-file getFileRev pre-check failed; full download.',
+          e,
+        );
+      }
+    }
+
     const snapshotTransaction =
       await this._recoverPendingSnapshotTransaction<FileBasedOpsFile>(
         provider,
@@ -2749,37 +2851,6 @@ export class FileBasedSyncAdapterService {
       rev: snapshotTransaction.rev,
       ...(snapshotTransaction.complete ? { complete: snapshotTransaction.complete } : {}),
     };
-
-    // SPAP-10 rev pre-check, extended to the ops file. Gated on `sinceSeq > 0`
-    // (review follow-up): a forceFromSeq0 download (sinceSeq === 0) re-pulls the
-    // full snapshot to REBUILD local state (e.g. USE_REMOTE), so it must never be
-    // short-circuited by an unchanged rev — the same guard as the single-file path.
-    const lastSeenRev = this._lastSeenRevs.get(providerKey);
-    if (
-      sinceSeq > 0 &&
-      lastSeenRev &&
-      !this._getCachedOpsData(providerKey) &&
-      this._REV_PRECHECK_PROVIDERS.has(provider.id)
-    ) {
-      try {
-        const { rev: remoteRev } = await provider.getFileRev(
-          FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
-          lastSeenRev,
-        );
-        if (remoteRev === lastSeenRev) {
-          const expectedVersion = this._expectedSyncVersions.get(providerKey) ?? 0;
-          OpLog.normal(
-            'FileBasedSyncAdapter: ops-file rev unchanged — skipping full download.',
-          );
-          return { ops: [], hasMore: false, latestSeq: expectedVersion };
-        }
-      } catch (e) {
-        OpLog.normal(
-          'FileBasedSyncAdapter: ops-file getFileRev pre-check failed; full download.',
-          e,
-        );
-      }
-    }
 
     let opsFile: FileBasedOpsFile;
     let opsRev: string;
@@ -3146,7 +3217,14 @@ export class FileBasedSyncAdapterService {
     return complete.primaryRev === primaryRev ? complete.snapshotDigest : undefined;
   }
 
-  /** Writes a recovery backup without replacing a causally newer artifact. */
+  /**
+   * Writes a recovery backup without replacing a causally newer artifact.
+   *
+   * Backup writes are non-fatal by contract: a provider that cannot write the
+   * backup must still be able to sync (only the semantic concurrency signal
+   * UploadRevToMatchMismatchAPIError is rethrown — it means the WORLD moved,
+   * not that the backup failed, and the caller must re-observe before writing).
+   */
   private async _writeBakFile<
     T extends { version: number; syncVersion: number; vectorClock: VectorClock },
   >(
@@ -3158,13 +3236,51 @@ export class FileBasedSyncAdapterService {
     fileVersion: number,
     isValid: (data: unknown) => data is T,
     options: {
-      isRequired?: boolean;
       primaryPath?: string;
       primaryRev?: string | null;
       snapshotTransaction?: SnapshotTransactionGuard;
     } = {},
   ): Promise<void> {
+    const bakRevCacheKey = `${this._getProviderKey(provider)}:${bakPath}`;
     try {
+      const backupData = await this._encryptAndCompressHandler.compressAndEncryptData(
+        cfg,
+        encryptKey,
+        data,
+        fileVersion,
+      );
+      if (!backupData || backupData.trim().length === 0) {
+        throw new InvalidDataSPError(
+          `FileBasedSyncAdapter: encoded ${bakPath} backup data was empty`,
+        );
+      }
+
+      // Fast path: while the backup still has the rev WE last wrote, it is our
+      // own previous rotation and the newer-artifact/digest guards below cannot
+      // fire — a single conditional PUT replaces a full download + decrypt +
+      // validate of the entire backup on every upload cycle. Snapshot flows
+      // force-rewrite the backup (changing its rev, never this cache), so any
+      // externally replaced backup fails the CAS and falls back to the guarded
+      // slow path.
+      const cachedBakRev = this._bakRevCache.get(bakRevCacheKey);
+      if (cachedBakRev !== undefined) {
+        try {
+          const fastRes = await provider.uploadFile(
+            bakPath,
+            backupData,
+            cachedBakRev,
+            false,
+          );
+          this._bakRevCache.set(bakRevCacheKey, fastRes.rev);
+          OpLog.normal(`FileBasedSyncAdapter: Wrote ${bakPath} before overwrite`);
+          return;
+        } catch (e) {
+          this._bakRevCache.delete(bakRevCacheKey);
+          if (!(e instanceof UploadRevToMatchMismatchAPIError)) throw e;
+          // Backup changed since our last write: re-observe via the slow path.
+        }
+      }
+
       let backupRev: string | null = null;
       const expectedBackupDigest = this._getSnapshotBoundBackupDigest(
         options.snapshotTransaction,
@@ -3206,7 +3322,10 @@ export class FileBasedSyncAdapterService {
               `FileBasedSyncAdapter: ${bakPath} contains a newer or concurrent recovery point`,
             );
           }
-          const currentPrimary = await provider.downloadFile(options.primaryPath);
+          const currentPrimary = await provider.getFileRev(
+            options.primaryPath,
+            options.primaryRev,
+          );
           if (currentPrimary.rev !== options.primaryRev) {
             throw new UploadRevToMatchMismatchAPIError(
               `FileBasedSyncAdapter: ${options.primaryPath} changed while validating ${bakPath}`,
@@ -3218,21 +3337,11 @@ export class FileBasedSyncAdapterService {
         }
       }
 
-      const backupData = await this._encryptAndCompressHandler.compressAndEncryptData(
-        cfg,
-        encryptKey,
-        data,
-        fileVersion,
-      );
-      if (!backupData || backupData.trim().length === 0) {
-        throw new InvalidDataSPError(
-          `FileBasedSyncAdapter: encoded ${bakPath} backup data was empty`,
-        );
-      }
-      await provider.uploadFile(bakPath, backupData, backupRev, false);
+      const uploadRes = await provider.uploadFile(bakPath, backupData, backupRev, false);
+      this._bakRevCache.set(bakRevCacheKey, uploadRes.rev);
       OpLog.normal(`FileBasedSyncAdapter: Wrote ${bakPath} before overwrite`);
     } catch (e) {
-      if (options.isRequired || e instanceof UploadRevToMatchMismatchAPIError) throw e;
+      if (e instanceof UploadRevToMatchMismatchAPIError) throw e;
       OpLog.warn(
         `FileBasedSyncAdapter: ${bakPath} write failed (non-fatal), proceeding`,
         e,
@@ -3309,10 +3418,19 @@ export class FileBasedSyncAdapterService {
     }
   }
 
+  /**
+   * Reads the snapshot-transaction marker. Returns null when absent. A torn or
+   * structurally invalid marker returns `{ data: null, rev }` instead of
+   * throwing: the marker is always written FIRST (begin) or LAST (complete /
+   * abort), so an unreadable marker never hides committed work — but throwing
+   * here would wedge every sync path (including the "Use Local" repair) with no
+   * user remedy. Callers treat `data: null` like an aborted marker and may
+   * conditionally overwrite it via its rev.
+   */
   private async _readSnapshotTransaction(
     provider: FileSyncProvider<SyncProviderId>,
     transactionPath: string,
-  ): Promise<{ data: SnapshotTransaction; rev: string } | null> {
+  ): Promise<{ data: SnapshotTransaction | null; rev: string } | null> {
     let response: { dataStr: string; rev: string };
     try {
       response = await provider.downloadFile(transactionPath);
@@ -3325,18 +3443,22 @@ export class FileBasedSyncAdapterService {
     try {
       data = JSON.parse(response.dataStr);
     } catch {
-      throw new SyncDataCorruptedError(
-        'Snapshot transaction marker is not valid JSON',
-        transactionPath,
+      OpLog.warn(
+        `FileBasedSyncAdapter: ${transactionPath} is not valid JSON — treating as unusable marker`,
       );
+      return { data: null, rev: response.rev };
     }
     if (
       !this._isRecord(data) ||
       data['version'] !== 1 ||
-      (data['status'] !== 'pending' && data['status'] !== 'complete') ||
+      (data['status'] !== 'pending' &&
+        data['status'] !== 'complete' &&
+        data['status'] !== 'aborted') ||
       typeof data['transactionId'] !== 'string' ||
       (data['status'] === 'pending' &&
         (typeof data['encodedSnapshot'] !== 'string' ||
+          (data['basePrimaryRev'] !== null &&
+            typeof data['basePrimaryRev'] !== 'string') ||
           (data['encodedState'] !== undefined &&
             typeof data['encodedState'] !== 'string'))) ||
       (data['status'] === 'complete' &&
@@ -3348,10 +3470,10 @@ export class FileBasedSyncAdapterService {
             typeof data['statePrimaryRev'] !== 'string') ||
           (data['stateDigest'] !== undefined && typeof data['stateDigest'] !== 'string')))
     ) {
-      throw new SyncDataCorruptedError(
-        'Snapshot transaction marker has an invalid structure',
-        transactionPath,
+      OpLog.warn(
+        `FileBasedSyncAdapter: ${transactionPath} has an invalid structure — treating as unusable marker`,
       );
+      return { data: null, rev: response.rev };
     }
     return { data: data as unknown as SnapshotTransaction, rev: response.rev };
   }
@@ -3361,11 +3483,40 @@ export class FileBasedSyncAdapterService {
     guard: SnapshotTransactionGuard,
   ): Promise<void> {
     const current = await this._readSnapshotTransaction(provider, guard.path);
-    if (current?.data.status === 'pending' || (current?.rev ?? null) !== guard.rev) {
+    if (current?.data?.status === 'pending' || (current?.rev ?? null) !== guard.rev) {
       throw new UploadRevToMatchMismatchAPIError(
         `FileBasedSyncAdapter: ${guard.path} changed while preparing the upload`,
       );
     }
+  }
+
+  /**
+   * Replaces a pending marker that recovery cannot (or must not) promote with a
+   * durable `aborted` record, so ordinary sync and a later "Use Local" are not
+   * wedged by it. Conditional on the marker rev — losing the CAS means another
+   * client acted on the marker first, which the caller surfaces as retryable.
+   */
+  private async _abandonSnapshotTransaction(
+    provider: FileSyncProvider<SyncProviderId>,
+    transactionPath: string,
+    transaction: { data: PendingSnapshotTransaction; rev: string },
+    reason: string,
+  ): Promise<SnapshotTransactionObservation> {
+    OpLog.warn(
+      `FileBasedSyncAdapter: abandoning pending snapshot transaction (${reason})`,
+    );
+    const aborted = JSON.stringify({
+      version: 1,
+      status: 'aborted',
+      transactionId: transaction.data.transactionId,
+    } satisfies AbortedSnapshotTransaction);
+    const result = await provider.uploadFile(
+      transactionPath,
+      aborted,
+      transaction.rev,
+      false,
+    );
+    return { didRecover: false, rev: result.rev };
   }
 
   /** Completes a crash-interrupted authoritative snapshot before normal sync. */
@@ -3390,76 +3541,111 @@ export class FileBasedSyncAdapterService {
     if (!transaction) {
       return { didRecover: false, rev: null };
     }
+    if (!transaction.data || transaction.data.status === 'aborted') {
+      // Unusable (torn write) or explicitly abandoned marker: there is nothing
+      // to recover; a later snapshot upload overwrites it conditionally by rev.
+      return { didRecover: false, rev: transaction.rev };
+    }
     if (transaction.data.status === 'complete') {
       return { didRecover: false, rev: transaction.rev, complete: transaction.data };
     }
+    const pending = { data: transaction.data, rev: transaction.rev };
 
-    const encodedSnapshot = transaction.data.encodedSnapshot;
-    if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedSnapshot).isEncrypted) {
-      throw new SyncDataCorruptedError(
-        'Pending snapshot is plaintext but encryption is expected',
+    // Freshness guard BEFORE any decode or write: recovery may only promote the
+    // pending payload while the primary still has the rev observed at begin
+    // time. Any advance means another client (possibly a marker-unaware older
+    // release) committed data after the crash — promoting the stale snapshot
+    // would silently destroy that data on every device.
+    let currentPrimaryRev: string | null = null;
+    try {
+      currentPrimaryRev = (
+        await provider.getFileRev(primaryPath, pending.data.basePrimaryRev)
+      ).rev;
+    } catch (e) {
+      if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
+    }
+    if (currentPrimaryRev !== pending.data.basePrimaryRev) {
+      return this._abandonSnapshotTransaction(
+        provider,
         transactionPath,
+        pending,
+        'primary advanced past the transaction baseline',
       );
     }
-    const decoded =
-      await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
-        cfg,
-        encryptKey,
-        encodedSnapshot,
-      );
-    const version = this._isRecord(decoded) ? decoded['version'] : undefined;
-    if (version !== expectedVersion || !isValid(decoded)) {
-      throw new SyncDataCorruptedError(
-        'Pending snapshot transaction payload is invalid',
-        transactionPath,
-      );
-    }
 
-    const encodedState = transaction.data.encodedState;
-    if (splitState) {
-      if (typeof encodedState !== 'string') {
+    const encodedSnapshot = pending.data.encodedSnapshot;
+    const encodedState = pending.data.encodedState;
+    try {
+      if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedSnapshot).isEncrypted) {
         throw new SyncDataCorruptedError(
-          'Pending split snapshot transaction has no bound state payload',
+          'Pending snapshot is plaintext but encryption is expected',
           transactionPath,
         );
       }
-      if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedState).isEncrypted) {
-        throw new SyncDataCorruptedError(
-          'Pending split state snapshot is plaintext but encryption is expected',
-          transactionPath,
-        );
-      }
-      const decodedState =
+      const decoded =
         await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
           cfg,
           encryptKey,
-          encodedState,
+          encodedSnapshot,
         );
-      const stateVersion = this._isRecord(decodedState)
-        ? decodedState['version']
-        : undefined;
-      if (
-        stateVersion !== splitState.expectedVersion ||
-        !splitState.isValid(decodedState) ||
-        !splitState.matchesSnapshot(decoded, decodedState)
-      ) {
+      const version = this._isRecord(decoded) ? decoded['version'] : undefined;
+      if (version !== expectedVersion || !isValid(decoded)) {
         throw new SyncDataCorruptedError(
-          'Pending split state transaction payload is invalid',
+          'Pending snapshot transaction payload is invalid',
           transactionPath,
         );
       }
-    } else if (encodedState !== undefined) {
-      throw new SyncDataCorruptedError(
-        'Single-file snapshot transaction unexpectedly contains split state',
-        transactionPath,
-      );
-    }
 
-    let primaryRev: string | null = null;
-    try {
-      primaryRev = (await provider.downloadFile(primaryPath)).rev;
+      if (splitState) {
+        if (typeof encodedState !== 'string') {
+          throw new SyncDataCorruptedError(
+            'Pending split snapshot transaction has no bound state payload',
+            transactionPath,
+          );
+        }
+        if (cfg.isEncrypt && !extractSyncFileStateFromPrefix(encodedState).isEncrypted) {
+          throw new SyncDataCorruptedError(
+            'Pending split state snapshot is plaintext but encryption is expected',
+            transactionPath,
+          );
+        }
+        const decodedState =
+          await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
+            cfg,
+            encryptKey,
+            encodedState,
+          );
+        const stateVersion = this._isRecord(decodedState)
+          ? decodedState['version']
+          : undefined;
+        if (
+          stateVersion !== splitState.expectedVersion ||
+          !splitState.isValid(decodedState) ||
+          !splitState.matchesSnapshot(decoded, decodedState)
+        ) {
+          throw new SyncDataCorruptedError(
+            'Pending split state transaction payload is invalid',
+            transactionPath,
+          );
+        }
+      } else if (encodedState !== undefined) {
+        throw new SyncDataCorruptedError(
+          'Single-file snapshot transaction unexpectedly contains split state',
+          transactionPath,
+        );
+      }
     } catch (e) {
-      if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
+      if (!this._isRecoverableCorruption(e)) throw e;
+      // An unpromotable payload can never be recovered — a wrong/rotated key,
+      // a plaintext downgrade, or torn payload data. Keeping the marker would
+      // wedge every sync path (including "Use Local") on it forever.
+      OpLog.warn('FileBasedSyncAdapter: pending snapshot payload is unusable', e);
+      return this._abandonSnapshotTransaction(
+        provider,
+        transactionPath,
+        pending,
+        'pending payload is invalid or undecodable',
+      );
     }
 
     let statePrimaryRev: string | undefined;
@@ -3472,13 +3658,13 @@ export class FileBasedSyncAdapterService {
     }
 
     // The pending marker owns this exact payload. Re-establish the recovery
-    // backup first, then conditionally promote the primary so an ordinary writer
-    // cannot be clobbered if it raced an older client that ignores the marker.
+    // backup first, then promote the primary conditionally on the begin-time
+    // rev, so a writer that raced in after the freshness probe loses nothing.
     await provider.uploadFile(bakPath, encodedSnapshot, null, true);
     const primaryResult = await provider.uploadFile(
       primaryPath,
       encodedSnapshot,
-      primaryRev,
+      pending.data.basePrimaryRev,
       false,
     );
     if (splitState && encodedState) {
@@ -3487,8 +3673,8 @@ export class FileBasedSyncAdapterService {
     return this._completeSnapshotTransaction(
       provider,
       transactionPath,
-      transaction.data.transactionId,
-      transaction.rev,
+      pending.data.transactionId,
+      pending.rev,
       encodedSnapshot,
       primaryResult.rev,
       encodedState && statePrimaryRev
@@ -3500,6 +3686,7 @@ export class FileBasedSyncAdapterService {
   private async _beginSnapshotTransaction(
     provider: FileSyncProvider<SyncProviderId>,
     transactionPath: string,
+    primaryPath: string,
     encodedSnapshot: string,
     encodedState?: string,
   ): Promise<{ transactionId: string; rev: string }> {
@@ -3507,10 +3694,21 @@ export class FileBasedSyncAdapterService {
       provider,
       transactionPath,
     );
-    if (priorTransaction?.data.status === 'pending') {
+    if (priorTransaction?.data?.status === 'pending') {
       throw new UploadRevToMatchMismatchAPIError(
         `FileBasedSyncAdapter: ${transactionPath} already has a pending snapshot`,
       );
+    }
+
+    // Bind the transaction to the primary rev observed now. Crash recovery may
+    // only promote the payload while this rev is still current (see
+    // _recoverPendingSnapshotTransaction); the live flow force-writes and is
+    // unaffected by a slightly stale probe.
+    let basePrimaryRev: string | null = null;
+    try {
+      basePrimaryRev = (await provider.getFileRev(primaryPath, null)).rev;
+    } catch (e) {
+      if (!(e instanceof RemoteFileNotFoundAPIError)) throw e;
     }
 
     const transactionId = uuidv7();
@@ -3518,6 +3716,7 @@ export class FileBasedSyncAdapterService {
       version: 1,
       status: 'pending',
       transactionId,
+      basePrimaryRev,
       encodedSnapshot,
       ...(encodedState === undefined ? {} : { encodedState }),
     } satisfies PendingSnapshotTransaction);
@@ -3576,6 +3775,7 @@ export class FileBasedSyncAdapterService {
     const transaction = await this._beginSnapshotTransaction(
       provider,
       transactionPath,
+      primaryPath,
       encoded,
     );
     await provider.uploadFile(bakPath, encoded, null, true);
@@ -3600,6 +3800,7 @@ export class FileBasedSyncAdapterService {
     const transaction = await this._beginSnapshotTransaction(
       provider,
       FILE_BASED_SYNC_CONSTANTS.OPS_SNAPSHOT_TRANSACTION_FILE,
+      FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
       encodedOps,
       encodedState,
     );

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -1702,6 +1702,7 @@ export class FileBasedSyncAdapterService {
     encryptKey: string | undefined,
     opsFile: FileBasedOpsFile,
   ): Promise<FileBasedStateFile | null> {
+    let corruptPrimaryRev: string | undefined;
     try {
       const { data } = await this._downloadStateFile(provider, cfg, encryptKey);
       if (this._validateSnapshotRef(opsFile, data)) return data;
@@ -1709,10 +1710,34 @@ export class FileBasedSyncAdapterService {
         'FileBasedSyncAdapter: sync-state.json does not match snapshotRef; trying .bak',
       );
     } catch (e) {
+      if (this._isRecoverableCorruption(e)) {
+        const annotatedRev = (e as { primaryRev?: unknown } | null)?.primaryRev;
+        if (typeof annotatedRev === 'string') {
+          corruptPrimaryRev = annotatedRev;
+        }
+      }
       OpLog.warn('FileBasedSyncAdapter: sync-state.json unreadable; trying .bak', e);
     }
     const bak = await this._recoverStateFromBackup(provider, cfg, encryptKey);
-    if (bak && this._validateSnapshotRef(opsFile, bak)) return bak;
+    if (bak && this._validateSnapshotRef(opsFile, bak)) {
+      if (corruptPrimaryRev) {
+        try {
+          await this._writeStateFile(provider, cfg, encryptKey, bak, {
+            revToMatch: corruptPrimaryRev,
+            isForceOverwrite: false,
+          });
+        } catch (e) {
+          // Recovery remains usable even when this client is read-only or a
+          // concurrent writer already replaced the corrupt revision. A later
+          // sync can retry the conditional heal.
+          OpLog.warn(
+            'FileBasedSyncAdapter: recovered state backup but could not heal sync-state.json',
+            e,
+          );
+        }
+      }
+      return bak;
+    }
     OpLog.warn(
       'FileBasedSyncAdapter: no snapshot matching snapshotRef; signaling gap for full re-sync.',
     );
@@ -1880,11 +1905,80 @@ export class FileBasedSyncAdapterService {
       encoded,
       'FileBasedSyncAdapter._writeRequiredMigrationOpsBackup',
     );
+
+    let backupRev: string | null = null;
+    try {
+      const response = await provider.downloadFile(
+        FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+      );
+      backupRev = response.rev;
+
+      let existing: unknown;
+      try {
+        existing =
+          await this._encryptAndCompressHandler.decompressAndDecryptData<unknown>(
+            cfg,
+            encryptKey,
+            response.dataStr,
+          );
+      } catch (e) {
+        // A corrupt backup is replaceable, but only while its exact revision is
+        // still current. The conditional write below owns that decision.
+        OpLog.warn(
+          'FileBasedSyncAdapter: replacing unreadable migration ops backup conditionally',
+          e,
+        );
+      }
+
+      if (this._isFileBasedOpsFile(existing)) {
+        const clockOrder = compareVectorClocks(existing.vectorClock, pending.vectorClock);
+        const existingMayBeNewer =
+          existing.syncVersion > pending.syncVersion ||
+          clockOrder === 'GREATER_THAN' ||
+          clockOrder === 'CONCURRENT';
+        if (existingMayBeNewer) {
+          // Reuse the same retry signal as a primary CAS loss. The caller will
+          // re-download sync-ops.json instead of letting this stale migrator
+          // overwrite a newer recovery artifact.
+          throw new UploadRevToMatchMismatchAPIError();
+        }
+
+        const sameRecoveryPayload =
+          existing.syncVersion === pending.syncVersion &&
+          existing.schemaVersion === pending.schemaVersion &&
+          clockOrder === 'EQUAL' &&
+          existing.oldestOpSyncVersion === pending.oldestOpSyncVersion &&
+          existing.snapshotRef.syncVersion === pending.snapshotRef.syncVersion &&
+          compareVectorClocks(
+            existing.snapshotRef.vectorClock,
+            pending.snapshotRef.vectorClock,
+          ) === 'EQUAL' &&
+          JSON.stringify(existing.recentOps) === JSON.stringify(pending.recentOps) &&
+          (existing.migration === undefined ||
+            existing.migration.legacyRev === pending.migration?.legacyRev);
+        if (sameRecoveryPayload) {
+          // A matching pending marker or its already-finalized form is at least
+          // as useful for recovery as rewriting the same backup again.
+          return;
+        }
+
+        if (clockOrder === 'EQUAL') {
+          // Equal clocks with different payloads are inconsistent; neither may
+          // silently replace the other.
+          throw new UploadRevToMatchMismatchAPIError();
+        }
+      }
+    } catch (e) {
+      if (!(e instanceof RemoteFileNotFoundAPIError)) {
+        throw e;
+      }
+    }
+
     await provider.uploadFile(
       FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
       encoded,
-      null,
-      true,
+      backupRev,
+      false,
     );
   }
 

--- a/src/app/op-log/sync/operation-log-download.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-download.service.spec.ts
@@ -1172,6 +1172,26 @@ describe('OperationLogDownloadService', () => {
           }
         });
 
+        it('should omit a finite timestamp outside the JavaScript date range', async () => {
+          mockApiProvider.providerMode = 'fileSnapshotOps';
+          mockApiProvider.downloadOps.and.returnValue(
+            Promise.resolve({
+              ops: [],
+              hasMore: false,
+              latestSeq: 5,
+              snapshotState: { tasks: [] },
+              remoteLastModified: Number.MAX_SAFE_INTEGER,
+            }),
+          );
+
+          const result = await service.downloadRemoteOps(mockApiProvider);
+
+          expect(result.providerMode).toBe('fileSnapshotOps');
+          if (result.success && result.providerMode === 'fileSnapshotOps') {
+            expect(result.remoteLastModified).toBeUndefined();
+          }
+        });
+
         it('should return snapshotVectorClock even when no new ops', async () => {
           const snapshotClock = { clientA: 10, clientB: 5 };
           mockApiProvider.downloadOps.and.returnValue(

--- a/src/app/op-log/sync/operation-log-download.service.ts
+++ b/src/app/op-log/sync/operation-log-download.service.ts
@@ -214,7 +214,8 @@ export class OperationLogDownloadService implements OnDestroy {
           remoteLastModified =
             typeof receivedLastModified === 'number' &&
             Number.isFinite(receivedLastModified) &&
-            receivedLastModified >= 0
+            receivedLastModified >= 0 &&
+            Number.isFinite(new Date(receivedLastModified).getTime())
               ? receivedLastModified
               : undefined;
           OpLog.normal(

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -2330,6 +2330,7 @@ describe('OperationLogSyncService', () => {
           );
           expect(remoteOpsProcessingServiceSpy.processRemoteOps).toHaveBeenCalledOnceWith(
             [postSnapshotOp],
+            {},
           );
           expect(callOrder).toEqual(['processRemoteOps', 'setLastServerSeq']);
         });
@@ -2408,8 +2409,8 @@ describe('OperationLogSyncService', () => {
           expect(second.kind).toBe('ops_processed');
           expect(syncHydrationServiceSpy.hydrateFromRemoteSync).toHaveBeenCalledTimes(1);
           expect(remoteOpsProcessingServiceSpy.processRemoteOps.calls.allArgs()).toEqual([
-            [[op5, op6]],
-            [[op6]],
+            [[op5, op6], {}],
+            [[op6], {}],
           ]);
           expect(setLastServerSeqSpy).toHaveBeenCalledOnceWith(6);
         });
@@ -2820,6 +2821,7 @@ describe('OperationLogSyncService', () => {
           expect(syncHydrationServiceSpy.hydrateFromRemoteSync).not.toHaveBeenCalled();
           expect(remoteOpsProcessingServiceSpy.processRemoteOps).toHaveBeenCalledOnceWith(
             [suffixOp],
+            {},
           );
           expect(setLastServerSeqSpy).toHaveBeenCalledOnceWith(2);
         });

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -1976,6 +1976,108 @@ describe('OperationLogSyncService', () => {
           }
         });
 
+        it('should append snapshot-included remote ops BEFORE persisting deferred local intents', async () => {
+          clearDeferredActions();
+          const snapshotIncludedOp: Operation = {
+            id: 'snap-op-1',
+            clientId: 'client-B',
+            actionType: ActionType.TASK_SHARED_UPDATE,
+            opType: OpType.Update,
+            entityType: 'TASK',
+            entityId: 'task-x',
+            payload: { task: { id: 'task-x', changes: {} } },
+            vectorClock: { clientB: 4 },
+            timestamp: 1,
+            schemaVersion: 1,
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+            Promise.resolve([]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [snapshotIncludedOp],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            snapshotAppliedOpIds: ['snap-op-1'],
+            latestServerSeq: 1,
+          });
+          const callOrder: string[] = [];
+          opLogStoreSpy.appendBatchSkipDuplicates.and.callFake(async () => {
+            callOrder.push('append-snapshot-ops');
+            return { seqs: [10], writtenOps: [snapshotIncludedOp], skippedCount: 0 };
+          });
+          operationLogEffectsSpy.processDeferredActions.and.callFake(
+            async (options?: { callerHoldsOperationLogLock?: boolean }) => {
+              if (options?.callerHoldsOperationLogLock) {
+                callOrder.push('persist-deferred');
+              }
+            },
+          );
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          await service.downloadRemoteOps(mockProvider);
+
+          // Frontier ordering: getEntityFrontier() takes the LAST op per entity
+          // in seq order, so the snapshot's (older) remote ops must land at
+          // lower seqs than any local intents persisted during hydration —
+          // otherwise the frontier regresses and a later concurrent remote op
+          // is misclassified as non-conflicting.
+          expect(callOrder[0]).toBe('append-snapshot-ops');
+          expect(callOrder).toContain('persist-deferred');
+          expect(callOrder.indexOf('append-snapshot-ops')).toBeLessThan(
+            callOrder.indexOf('persist-deferred'),
+          );
+        });
+
+        it('should persist buffered local actions when snapshot hydration fails', async () => {
+          clearDeferredActions();
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.rejectWith(
+            new Error('hydration boom'),
+          );
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          await expectAsync(
+            service.downloadRemoteOps(mockProvider),
+          ).toBeRejectedWithError('hydration boom');
+
+          // The remote-apply window must be closed AND the deferred buffer
+          // persisted: edits made during the failed hydration are applied to
+          // live NgRx state but would otherwise be silently lost on app exit.
+          expect(hydrationStateServiceSpy.endApplyingRemoteOps).toHaveBeenCalled();
+          expect(operationLogEffectsSpy.processDeferredActions).toHaveBeenCalledWith({
+            callerHoldsOperationLogLock: true,
+          });
+          expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+        });
+
         it('should NOT throw LocalDataConflictError on normal incremental sync (no snapshotState)', async () => {
           // This tests the regression fix: normal incremental syncs should NOT throw
           // LocalDataConflictError, even if the client has unsynced ops.

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -12,6 +12,7 @@ import { OperationLogEffects } from '../capture/operation-log.effects';
 import {
   bufferDeferredAction,
   clearDeferredActions,
+  getDeferredActions,
 } from '../capture/operation-capture.meta-reducer';
 import { PersistentAction } from '../core/persistent-action.interface';
 import { ConflictResolutionService } from './conflict-resolution.service';
@@ -1891,6 +1892,33 @@ describe('OperationLogSyncService', () => {
           });
           const mockStore = TestBed.inject(MockStore);
           const dispatchSpy = spyOn(mockStore, 'dispatch').and.callThrough();
+          const durabilityOrder: string[] = [];
+          operationLogEffectsSpy.processDeferredActions.and.callFake(async () => {
+            if (
+              getDeferredActions().includes(localAction) &&
+              !durabilityOrder.includes('persist')
+            ) {
+              const wasAlreadyReplayed = dispatchSpy.calls
+                .allArgs()
+                .some(([dispatched]) => {
+                  const action = dispatched as unknown;
+                  return (
+                    typeof action === 'object' &&
+                    action !== null &&
+                    'type' in action &&
+                    action.type === localAction.type &&
+                    'meta' in action &&
+                    typeof action.meta === 'object' &&
+                    action.meta !== null &&
+                    'isRemote' in action.meta &&
+                    action.meta.isRemote === true
+                  );
+                });
+              durabilityOrder.push(
+                wasAlreadyReplayed ? 'replay-before-persist' : 'persist',
+              );
+            }
+          });
           const mockProvider = {
             supportsOperationSync: true,
             setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
@@ -1926,6 +1954,7 @@ describe('OperationLogSyncService', () => {
               .map((action) => action.task?.id);
             expect(remotelyReplayedTaskIds).toContain('task-local');
             expect(remotelyReplayedTaskIds).not.toContain('task-after-load');
+            expect(durabilityOrder).toEqual(['persist']);
             expect(operationLogEffectsSpy.processDeferredActions.calls.allArgs()).toEqual(
               [
                 [{ callerHoldsOperationLogLock: false }],

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -2112,6 +2112,86 @@ describe('OperationLogSyncService', () => {
           expect(callOrder).toEqual(['processRemoteOps', 'setLastServerSeq']);
         });
 
+        it('retries only the remaining split suffix after an incompatible op blocks a hydrated batch', async () => {
+          const op5: Operation = {
+            id: 'post-snapshot-op-5',
+            clientId: 'client-B',
+            actionType: 'test' as ActionType,
+            opType: OpType.Create,
+            entityType: 'TASK',
+            entityId: 'task-5',
+            payload: {},
+            vectorClock: { clientB: 5 },
+            timestamp: 5,
+            schemaVersion: 1,
+          };
+          const op6: Operation = {
+            ...op5,
+            id: 'post-snapshot-op-6',
+            entityId: 'task-6',
+            vectorClock: { clientB: 6 },
+            timestamp: 6,
+          };
+          const snapshotResult = (newOps: Operation[]): DownloadResult =>
+            ({
+              newOps,
+              needsFullStateUpload: false,
+              success: true,
+              providerMode: 'fileSnapshotOps',
+              failedFileCount: 0,
+              snapshotState: { task: { ids: ['snapshot-task'] } },
+              snapshotVectorClock: { clientB: 4 },
+              snapshotAppliedOpIds: [],
+              latestServerSeq: 6,
+            }) as DownloadResult;
+          downloadServiceSpy.downloadRemoteOps.and.returnValues(
+            Promise.resolve(snapshotResult([op5, op6])),
+            Promise.resolve(snapshotResult([op6])),
+          );
+          opLogStoreSpy.getVectorClock.and.returnValues(
+            Promise.resolve(null),
+            Promise.resolve({ clientB: 5 }),
+          );
+          remoteOpsProcessingServiceSpy.processRemoteOps.and.returnValues(
+            Promise.resolve({
+              localWinOpsCreated: 0,
+              allOpsFilteredBySyncImport: false,
+              filteredOpCount: 0,
+              isLocalUnsyncedImport: false,
+              blockedByIncompatibleOp: true,
+            }),
+            Promise.resolve({
+              localWinOpsCreated: 0,
+              allOpsFilteredBySyncImport: false,
+              filteredOpCount: 0,
+              isLocalUnsyncedImport: false,
+              blockedByIncompatibleOp: false,
+            }),
+          );
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          const setLastServerSeqSpy = jasmine
+            .createSpy('setLastServerSeq')
+            .and.resolveTo();
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: setLastServerSeqSpy,
+          } as unknown as OperationSyncCapable;
+
+          const first = await service.downloadRemoteOps(mockProvider);
+          const second = await service.downloadRemoteOps(mockProvider);
+
+          expect(first.kind).toBe('blocked_incompatible');
+          expect(second.kind).toBe('ops_processed');
+          expect(syncHydrationServiceSpy.hydrateFromRemoteSync).toHaveBeenCalledTimes(1);
+          expect(remoteOpsProcessingServiceSpy.processRemoteOps.calls.allArgs()).toEqual([
+            [[op5, op6]],
+            [[op6]],
+          ]);
+          expect(setLastServerSeqSpy).toHaveBeenCalledOnceWith(6);
+        });
+
         it('does NOT throw LocalDataConflictError when store + pending ops contain only example tasks (#7985)', async () => {
           opLogStoreSpy.getUnsynced.and.returnValue(
             Promise.resolve([exampleCreateEntry('ex-task-1')]),
@@ -2461,6 +2541,65 @@ describe('OperationLogSyncService', () => {
           expect(result.kind).toBe('no_new_ops');
           // lastServerSeq still advanced so future syncs use the right cursor.
           expect(setLastServerSeqSpy).toHaveBeenCalledWith(1);
+        });
+
+        it('should apply a split suffix before advancing when local dominates only the snapshot', async () => {
+          const suffixOp: Operation = {
+            id: 'post-snapshot-op',
+            clientId: 'windowsClient',
+            actionType: 'test' as ActionType,
+            opType: OpType.Create,
+            entityType: 'TASK',
+            entityId: 'remote-new-task',
+            payload: {},
+            vectorClock: { windowsClient: 2 },
+            timestamp: 2,
+            schemaVersion: 1,
+          };
+          opLogStoreSpy.getVectorClock.and.resolveTo({
+            windowsClient: 1,
+            iosClient: 5,
+          });
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [suffixOp],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { tasks: [{ id: 'snapshot-task' }] },
+            snapshotVectorClock: { windowsClient: 1 },
+            snapshotAppliedOpIds: [],
+            latestServerSeq: 2,
+          });
+          remoteOpsProcessingServiceSpy.processRemoteOps.and.resolveTo({
+            localWinOpsCreated: 2,
+            allOpsFilteredBySyncImport: false,
+            filteredOpCount: 0,
+            isLocalUnsyncedImport: false,
+            blockedByIncompatibleOp: false,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          const setLastServerSeqSpy = jasmine
+            .createSpy('setLastServerSeq')
+            .and.resolveTo();
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: setLastServerSeqSpy,
+          } as unknown as OperationSyncCapable;
+
+          const result = await service.downloadRemoteOps(mockProvider);
+
+          expect(result.kind).toBe('ops_processed');
+          if (result.kind === 'ops_processed') {
+            expect(result.localWinOpsCreated).toBe(2);
+          }
+          expect(syncHydrationServiceSpy.hydrateFromRemoteSync).not.toHaveBeenCalled();
+          expect(remoteOpsProcessingServiceSpy.processRemoteOps).toHaveBeenCalledOnceWith(
+            [suffixOp],
+          );
+          expect(setLastServerSeqSpy).toHaveBeenCalledOnceWith(2);
         });
 
         it('should NOT persist accompanying newOps on the dominate path — would corrupt per-entity frontiers (codex re-review)', async () => {
@@ -4113,6 +4252,44 @@ describe('OperationLogSyncService', () => {
       await service.forceDownloadRemoteState(mockProvider);
       expect(remoteOpsProcessingServiceSpy.processRemoteOps).toHaveBeenCalledWith(
         mockOps,
+        {
+          skipConflictDetection: true,
+          callerHoldsOperationLogLock: true,
+        },
+      );
+    });
+
+    it('hydrates a split snapshot and replays only its post-snapshot suffix', async () => {
+      const snapshotOp = makeRemoteOp('snapshot-op');
+      const suffixOp = {
+        ...makeRemoteOp('suffix-op'),
+        entityId: 'task-after-snapshot',
+        vectorClock: { remote: 2 },
+      };
+      downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+        newOps: [snapshotOp, suffixOp],
+        needsFullStateUpload: false,
+        success: true,
+        providerMode: 'fileSnapshotOps',
+        failedFileCount: 0,
+        snapshotState: { task: { ids: ['task1'] } },
+        snapshotVectorClock: { remote: 1 },
+        snapshotAppliedOpIds: [snapshotOp.id],
+        latestServerSeq: 2,
+      });
+      const mockProvider = {
+        supportsOperationSync: true,
+        setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+      } as unknown as OperationSyncCapable;
+
+      await service.forceDownloadRemoteState(mockProvider);
+
+      expect(opLogStoreSpy.appendBatchSkipDuplicates).toHaveBeenCalledOnceWith(
+        [snapshotOp],
+        'remote',
+      );
+      expect(remoteOpsProcessingServiceSpy.processRemoteOps).toHaveBeenCalledOnceWith(
+        [suffixOp],
         {
           skipConflictDetection: true,
           callerHoldsOperationLogLock: true,

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -7,7 +7,13 @@ import { SnackService } from '../../core/snack/snack.service';
 import { OperationLogStoreService } from '../persistence/operation-log-store.service';
 import { VectorClockService } from './vector-clock.service';
 import { OperationApplierService } from '../apply/operation-applier.service';
+import { HydrationStateService } from '../apply/hydration-state.service';
 import { OperationLogEffects } from '../capture/operation-log.effects';
+import {
+  bufferDeferredAction,
+  clearDeferredActions,
+} from '../capture/operation-capture.meta-reducer';
+import { PersistentAction } from '../core/persistent-action.interface';
 import { ConflictResolutionService } from './conflict-resolution.service';
 import { ValidateStateService } from '../validation/validate-state.service';
 import { SyncSessionValidationService } from './sync-session-validation.service';
@@ -73,6 +79,7 @@ describe('OperationLogSyncService', () => {
   let validateStateServiceSpy: jasmine.SpyObj<ValidateStateService>;
   let lockServiceSpy: jasmine.SpyObj<LockService>;
   let operationApplierSpy: jasmine.SpyObj<OperationApplierService>;
+  let hydrationStateServiceSpy: jasmine.SpyObj<HydrationStateService>;
   let operationLogEffectsSpy: jasmine.SpyObj<OperationLogEffects>;
   let hydratorServiceSpy: jasmine.SpyObj<OperationLogHydratorService>;
   const defaultBackupRef = { backupId: 'backup-1', savedAt: 1 };
@@ -244,6 +251,10 @@ describe('OperationLogSyncService', () => {
       'applyOperations',
     ]);
     operationApplierSpy.applyOperations.and.resolveTo({ appliedOps: [] });
+    hydrationStateServiceSpy = jasmine.createSpyObj('HydrationStateService', [
+      'startApplyingRemoteOps',
+      'endApplyingRemoteOps',
+    ]);
     operationLogEffectsSpy = jasmine.createSpyObj('OperationLogEffects', [
       'processDeferredActions',
     ]);
@@ -273,6 +284,7 @@ describe('OperationLogSyncService', () => {
           provide: OperationApplierService,
           useValue: operationApplierSpy,
         },
+        { provide: HydrationStateService, useValue: hydrationStateServiceSpy },
         { provide: OperationLogEffects, useValue: operationLogEffectsSpy },
         { provide: OperationLogHydratorService, useValue: hydratorServiceSpy },
         {
@@ -1754,6 +1766,187 @@ describe('OperationLogSyncService', () => {
       });
 
       describe('LocalDataConflictError for file-based sync', () => {
+        it('should abort snapshot hydration when a local op becomes durable after conflict detection', async () => {
+          const lateLocalEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'late-local-op',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-late',
+              payload: { task: { id: 'task-late', changes: { title: 'Keep me' } } },
+              vectorClock: { clientA: 2 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([lateLocalEntry]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          await expectAsync(
+            service.downloadRemoteOps(mockProvider),
+          ).toBeRejectedWithError(LocalDataConflictError);
+
+          expect(syncHydrationServiceSpy.hydrateFromRemoteSync).not.toHaveBeenCalled();
+          expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+        });
+
+        it('should restore and persist a local action buffered during snapshot hydration', async () => {
+          clearDeferredActions();
+          const localAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-local', changes: { title: 'Keep me' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              opType: OpType.Update,
+            },
+          };
+          const actionAfterStateLoad: PersistentAction = {
+            ...localAction,
+            task: { id: 'task-after-load', changes: { title: 'Already restored' } },
+            meta: { ...localAction.meta, entityId: 'task-after-load' },
+          };
+          const persistedEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'buffered-local-op',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              payload: { task: localAction.task },
+              vectorClock: { clientA: 2, clientB: 5 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          const persistedAfterLoadEntry: OperationLogEntry = {
+            ...persistedEntry,
+            seq: 3,
+            op: {
+              ...persistedEntry.op,
+              id: 'after-load-local-op',
+              entityId: 'task-after-load',
+              payload: { task: actionAfterStateLoad.task },
+              vectorClock: { clientA: 3, clientB: 5 },
+              timestamp: 3,
+            },
+            appliedAt: 3,
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+            Promise.resolve([persistedEntry, persistedAfterLoadEntry]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              bufferDeferredAction(localAction);
+              hooks?.beforeStateLoad?.();
+              bufferDeferredAction(actionAfterStateLoad);
+            },
+          );
+          operationApplierSpy.applyOperations.and.resolveTo({
+            appliedOps: [persistedEntry.op],
+          });
+          const mockStore = TestBed.inject(MockStore);
+          const dispatchSpy = spyOn(mockStore, 'dispatch').and.callThrough();
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await service.downloadRemoteOps(mockProvider);
+
+            expect(hydrationStateServiceSpy.startApplyingRemoteOps).toHaveBeenCalledTimes(
+              1,
+            );
+            expect(hydrationStateServiceSpy.endApplyingRemoteOps).toHaveBeenCalledTimes(
+              1,
+            );
+            expect(dispatchSpy).toHaveBeenCalledWith(
+              jasmine.objectContaining({
+                type: localAction.type,
+                meta: jasmine.objectContaining({ isRemote: true }),
+              }),
+            );
+            const remotelyReplayedTaskIds = dispatchSpy.calls
+              .allArgs()
+              .map(([action]) => action as unknown)
+              .filter(
+                (
+                  action,
+                ): action is {
+                  task?: { id?: string };
+                  meta?: { isRemote?: boolean };
+                } => typeof action === 'object' && action !== null,
+              )
+              .filter((action) => action.meta?.isRemote)
+              .map((action) => action.task?.id);
+            expect(remotelyReplayedTaskIds).toContain('task-local');
+            expect(remotelyReplayedTaskIds).not.toContain('task-after-load');
+            expect(operationLogEffectsSpy.processDeferredActions.calls.allArgs()).toEqual(
+              [
+                [{ callerHoldsOperationLogLock: false }],
+                [{ callerHoldsOperationLogLock: true }],
+                [{ callerHoldsOperationLogLock: true }],
+              ],
+            );
+            expect(operationApplierSpy.applyOperations).toHaveBeenCalledOnceWith(
+              [persistedEntry.op],
+              {
+                isLocalHydration: false,
+                skipDeferredLocalActions: true,
+                skipReducerDispatch: true,
+              },
+            );
+            expect(mockProvider.setLastServerSeq).toHaveBeenCalledOnceWith(1);
+          } finally {
+            clearDeferredActions();
+          }
+        });
+
         it('should NOT throw LocalDataConflictError on normal incremental sync (no snapshotState)', async () => {
           // This tests the regression fix: normal incremental syncs should NOT throw
           // LocalDataConflictError, even if the client has unsynced ops.
@@ -3760,7 +3953,7 @@ describe('OperationLogSyncService', () => {
       );
     });
 
-    it('should reset lastServerSeq to 0', async () => {
+    it('should acknowledge only the final cursor after a successful rebuild', async () => {
       downloadServiceSpy.downloadRemoteOps.and.resolveTo({
         newOps: [makeRemoteOp()],
         needsFullStateUpload: false,
@@ -3779,10 +3972,10 @@ describe('OperationLogSyncService', () => {
 
       await service.forceDownloadRemoteState(mockProvider);
 
-      expect(setLastServerSeqSpy).toHaveBeenCalledWith(0);
+      expect(setLastServerSeqSpy).toHaveBeenCalledOnceWith(1);
     });
 
-    it('should reset the external cursor before committing the local replacement', async () => {
+    it('should commit the local replacement before acknowledging the external cursor', async () => {
       const callOrder: string[] = [];
       downloadServiceSpy.downloadRemoteOps.and.resolveTo({
         newOps: [makeRemoteOp()],
@@ -3800,13 +3993,13 @@ describe('OperationLogSyncService', () => {
         setLastServerSeq: jasmine
           .createSpy('setLastServerSeq')
           .and.callFake(async (seq: number) => {
-            if (seq === 0) callOrder.push('cursor-zero');
+            callOrder.push(`cursor-${seq}`);
           }),
       } as unknown as OperationSyncCapable;
 
       await service.forceDownloadRemoteState(mockProvider);
 
-      expect(callOrder.slice(0, 2)).toEqual(['cursor-zero', 'replace']);
+      expect(callOrder).toEqual(['replace', 'cursor-1']);
     });
 
     it('should download raw history: forceFromSeq0 AND includeOwnAndAppliedOps', async () => {
@@ -4010,7 +4203,7 @@ describe('OperationLogSyncService', () => {
       );
     });
 
-    it('should NOT advance the cursor past 0 when replay blocks on a migration failure', async () => {
+    it('should not acknowledge the cursor when replay blocks on a migration failure', async () => {
       downloadServiceSpy.downloadRemoteOps.and.resolveTo({
         newOps: [makeRemoteOp()],
         needsFullStateUpload: false,
@@ -4036,8 +4229,7 @@ describe('OperationLogSyncService', () => {
       await expectAsync(
         service.forceDownloadRemoteState(mockProvider),
       ).toBeRejectedWithError(/USE_REMOTE incomplete/);
-      expect(setLastServerSeqSpy).toHaveBeenCalledWith(0);
-      expect(setLastServerSeqSpy).not.toHaveBeenCalledWith(50);
+      expect(setLastServerSeqSpy).not.toHaveBeenCalled();
     });
 
     it('should process downloaded ops without confirmation', async () => {
@@ -4113,9 +4305,7 @@ describe('OperationLogSyncService', () => {
 
       await service.forceDownloadRemoteState(mockProvider);
 
-      // First call is reset to 0, second call is update to latestServerSeq
-      expect(setLastServerSeqSpy).toHaveBeenCalledWith(0);
-      expect(setLastServerSeqSpy).toHaveBeenCalledWith(50);
+      expect(setLastServerSeqSpy).toHaveBeenCalledOnceWith(50);
     });
 
     it('should REJECT an empty remote instead of silently succeeding', async () => {
@@ -4201,14 +4391,19 @@ describe('OperationLogSyncService', () => {
         latestServerSeq: 1,
       });
 
+      const setLastServerSeqSpy = jasmine.createSpy('setLastServerSeq').and.resolveTo();
       const mockProvider = {
         supportsOperationSync: true,
-        setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+        setLastServerSeq: setLastServerSeqSpy,
       } as any;
 
       await expectAsync(service.forceDownloadRemoteState(mockProvider)).toBeRejectedWith(
         error,
       );
+      // A failed replacement must not acknowledge the staged download baseline.
+      // The raw-rebuild marker drives seq-0 recovery after a committed crash, so
+      // there is no need for an eager external cursor reset before the transaction.
+      expect(setLastServerSeqSpy).not.toHaveBeenCalled();
     });
 
     // Issue #7330: post-sync validation failure must be surfaced so

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -10,6 +10,7 @@ import { OperationApplierService } from '../apply/operation-applier.service';
 import { HydrationStateService } from '../apply/hydration-state.service';
 import { OperationLogEffects } from '../capture/operation-log.effects';
 import {
+  acknowledgeDeferredAction,
   bufferDeferredAction,
   clearDeferredActions,
   getDeferredActions,
@@ -125,6 +126,7 @@ describe('OperationLogSyncService', () => {
       'clearFullStateOps',
       'getVectorClock',
       'appendBatchSkipDuplicates',
+      'appendSnapshotIncludedOps',
       'hasSyncedOps',
       'runRemoteStateReplacement',
       'isRawRebuildIncomplete',
@@ -144,6 +146,11 @@ describe('OperationLogSyncService', () => {
     opLogStoreSpy.clearFullStateOps.and.resolveTo();
     opLogStoreSpy.getVectorClock.and.resolveTo(null);
     opLogStoreSpy.appendBatchSkipDuplicates.and.resolveTo({
+      seqs: [],
+      writtenOps: [],
+      skippedCount: 0,
+    });
+    opLogStoreSpy.appendSnapshotIncludedOps.and.resolveTo({
       seqs: [],
       writtenOps: [],
       skippedCount: 0,
@@ -259,7 +266,11 @@ describe('OperationLogSyncService', () => {
     operationLogEffectsSpy = jasmine.createSpyObj('OperationLogEffects', [
       'processDeferredActions',
     ]);
-    operationLogEffectsSpy.processDeferredActions.and.resolveTo();
+    operationLogEffectsSpy.processDeferredActions.and.callFake(async () => {
+      for (const action of getDeferredActions()) {
+        acknowledgeDeferredAction(action);
+      }
+    });
     hydratorServiceSpy = jasmine.createSpyObj('OperationLogHydratorService', [
       'retryFailedRemoteOps',
     ]);
@@ -1866,6 +1877,7 @@ describe('OperationLogSyncService', () => {
             Promise.resolve([]),
             Promise.resolve([]),
             Promise.resolve([persistedEntry, persistedAfterLoadEntry]),
+            Promise.resolve([persistedEntry, persistedAfterLoadEntry]),
           );
           downloadServiceSpy.downloadRemoteOps.and.resolveTo({
             newOps: [],
@@ -1883,12 +1895,14 @@ describe('OperationLogSyncService', () => {
           syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
             async (_state, _clock, _createImport, _reason, hooks) => {
               bufferDeferredAction(localAction);
+              hooks?.afterArchiveReplacement?.();
               hooks?.beforeStateLoad?.();
               bufferDeferredAction(actionAfterStateLoad);
+              hooks?.afterStateLoad?.();
             },
           );
           operationApplierSpy.applyOperations.and.resolveTo({
-            appliedOps: [persistedEntry.op],
+            appliedOps: [persistedEntry.op, persistedAfterLoadEntry.op],
           });
           const mockStore = TestBed.inject(MockStore);
           const dispatchSpy = spyOn(mockStore, 'dispatch').and.callThrough();
@@ -1917,6 +1931,9 @@ describe('OperationLogSyncService', () => {
               durabilityOrder.push(
                 wasAlreadyReplayed ? 'replay-before-persist' : 'persist',
               );
+            }
+            for (const action of getDeferredActions()) {
+              acknowledgeDeferredAction(action);
             }
           });
           const mockProvider = {
@@ -1959,15 +1976,15 @@ describe('OperationLogSyncService', () => {
               [
                 [{ callerHoldsOperationLogLock: false }],
                 [{ callerHoldsOperationLogLock: true }],
-                [{ callerHoldsOperationLogLock: true }],
               ],
             );
             expect(operationApplierSpy.applyOperations).toHaveBeenCalledOnceWith(
-              [persistedEntry.op],
+              [persistedEntry.op, persistedAfterLoadEntry.op],
               {
                 isLocalHydration: false,
                 skipDeferredLocalActions: true,
                 skipReducerDispatch: true,
+                remoteApplyWindowAlreadyOpen: true,
               },
             );
             expect(mockProvider.setLastServerSeq).toHaveBeenCalledOnceWith(1);
@@ -1976,7 +1993,117 @@ describe('OperationLogSyncService', () => {
           }
         });
 
-        it('should append snapshot-included remote ops BEFORE persisting deferred local intents', async () => {
+        it('should persist and restore an action that arrives during the final deferred drain', async () => {
+          clearDeferredActions();
+          const lateAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-late', changes: { title: 'Keep me too' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-late',
+              opType: OpType.Update,
+            },
+          };
+          const lateEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'late-during-final-drain',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-late',
+              payload: { task: lateAction.task },
+              vectorClock: { clientA: 2, clientB: 5 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          let hydrationFinished = false;
+          let lateActionPersisted = false;
+          opLogStoreSpy.getUnsynced.and.callFake(async () =>
+            hydrationFinished && lateActionPersisted ? [lateEntry] : [],
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              hooks?.afterArchiveReplacement?.();
+              hooks?.beforeStateLoad?.();
+              hooks?.afterStateLoad?.();
+              hydrationFinished = true;
+            },
+          );
+          const callOrder: string[] = [];
+          let heldLockDrainCount = 0;
+          operationLogEffectsSpy.processDeferredActions.and.callFake(async (options) => {
+            if (!options?.callerHoldsOperationLogLock) return;
+
+            heldLockDrainCount++;
+            if (heldLockDrainCount === 1) {
+              // processDeferredActions snapshots the queue before awaiting its
+              // writes. This action therefore belongs to the next drain.
+              bufferDeferredAction(lateAction);
+              callOrder.push('late-action-buffered');
+              return;
+            }
+
+            lateActionPersisted = true;
+            acknowledgeDeferredAction(lateAction);
+            callOrder.push('late-action-persisted');
+          });
+          operationApplierSpy.applyOperations.and.callFake(async (ops) => {
+            callOrder.push('late-archive-restored');
+            return { appliedOps: ops };
+          });
+          hydrationStateServiceSpy.endApplyingRemoteOps.and.callFake(() => {
+            callOrder.push('remote-window-closed');
+          });
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await service.downloadRemoteOps(mockProvider);
+
+            expect(heldLockDrainCount).toBe(2);
+            expect(getDeferredActions()).not.toContain(lateAction);
+            expect(operationApplierSpy.applyOperations).toHaveBeenCalledOnceWith(
+              [lateEntry.op],
+              {
+                isLocalHydration: false,
+                skipDeferredLocalActions: true,
+                skipReducerDispatch: true,
+                remoteApplyWindowAlreadyOpen: true,
+              },
+            );
+            expect(callOrder).toEqual([
+              'late-action-buffered',
+              'late-action-persisted',
+              'late-archive-restored',
+              'remote-window-closed',
+            ]);
+          } finally {
+            clearDeferredActions();
+          }
+        });
+
+        it('should commit snapshot-included remote ops BEFORE persisting deferred local intents', async () => {
           clearDeferredActions();
           const snapshotIncludedOp: Operation = {
             id: 'snap-op-1',
@@ -2007,10 +2134,15 @@ describe('OperationLogSyncService', () => {
             latestServerSeq: 1,
           });
           const callOrder: string[] = [];
-          opLogStoreSpy.appendBatchSkipDuplicates.and.callFake(async () => {
-            callOrder.push('append-snapshot-ops');
-            return { seqs: [10], writtenOps: [snapshotIncludedOp], skippedCount: 0 };
-          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              expect(hooks?.snapshotIncludedOps).toEqual([snapshotIncludedOp]);
+              callOrder.push('commit-snapshot-baseline');
+            },
+          );
           operationLogEffectsSpy.processDeferredActions.and.callFake(
             async (options?: { callerHoldsOperationLogLock?: boolean }) => {
               if (options?.callerHoldsOperationLogLock) {
@@ -2030,11 +2162,287 @@ describe('OperationLogSyncService', () => {
           // lower seqs than any local intents persisted during hydration —
           // otherwise the frontier regresses and a later concurrent remote op
           // is misclassified as non-conflicting.
-          expect(callOrder[0]).toBe('append-snapshot-ops');
+          expect(callOrder[0]).toBe('commit-snapshot-baseline');
           expect(callOrder).toContain('persist-deferred');
-          expect(callOrder.indexOf('append-snapshot-ops')).toBeLessThan(
+          expect(callOrder.indexOf('commit-snapshot-baseline')).toBeLessThan(
             callOrder.indexOf('persist-deferred'),
           );
+        });
+
+        it('should persist deferred local intents against the old baseline when the atomic snapshot commit fails', async () => {
+          clearDeferredActions();
+          const localAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-local', changes: { title: 'Keep me' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              opType: OpType.Update,
+            },
+          };
+          const snapshotIncludedOp: Operation = {
+            id: 'snap-op-append-failure',
+            clientId: 'client-B',
+            actionType: ActionType.TASK_SHARED_UPDATE,
+            opType: OpType.Update,
+            entityType: 'TASK',
+            entityId: 'task-x',
+            payload: { task: { id: 'task-x', changes: {} } },
+            vectorClock: { clientB: 4 },
+            timestamp: 1,
+            schemaVersion: 1,
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [snapshotIncludedOp],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            snapshotAppliedOpIds: [snapshotIncludedOp.id],
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              expect(hooks?.snapshotIncludedOps).toEqual([snapshotIncludedOp]);
+              bufferDeferredAction(localAction);
+              throw new Error('snapshot baseline write failed');
+            },
+          );
+          const callOrder: string[] = [];
+          hydrationStateServiceSpy.endApplyingRemoteOps.and.callFake(() => {
+            callOrder.push('end-remote-window');
+          });
+          operationLogEffectsSpy.processDeferredActions.and.callFake(async (options) => {
+            if (options?.callerHoldsOperationLogLock) {
+              callOrder.push('persist-deferred');
+              acknowledgeDeferredAction(localAction);
+            }
+          });
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await expectAsync(
+              service.downloadRemoteOps(mockProvider),
+            ).toBeRejectedWithError('snapshot baseline write failed');
+
+            expect(operationLogEffectsSpy.processDeferredActions.calls.allArgs()).toEqual(
+              [
+                [{ callerHoldsOperationLogLock: false }],
+                [{ callerHoldsOperationLogLock: true }],
+              ],
+            );
+            expect(callOrder).toEqual(['persist-deferred', 'end-remote-window']);
+            expect(getDeferredActions()).not.toContain(localAction);
+            expect(operationApplierSpy.applyOperations).not.toHaveBeenCalled();
+            expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+          } finally {
+            clearDeferredActions();
+          }
+        });
+
+        it('should append snapshot ops before recovery when persistence completes before state dispatch', async () => {
+          clearDeferredActions();
+          const localAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-local', changes: { title: 'Keep me' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              opType: OpType.Update,
+            },
+          };
+          const snapshotIncludedOp: Operation = {
+            id: 'snap-op-persisted-before-dispatch-failure',
+            clientId: 'client-B',
+            actionType: ActionType.TASK_SHARED_UPDATE,
+            opType: OpType.Update,
+            entityType: 'TASK',
+            entityId: 'task-x',
+            payload: { task: { id: 'task-x', changes: {} } },
+            vectorClock: { clientB: 4 },
+            timestamp: 1,
+            schemaVersion: 1,
+          };
+          const persistedEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'local-op-persisted-before-dispatch-failure',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              payload: { task: localAction.task },
+              vectorClock: { clientA: 2, clientB: 5 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+            Promise.resolve([persistedEntry]),
+            Promise.resolve([persistedEntry]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [snapshotIncludedOp],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            snapshotAppliedOpIds: [snapshotIncludedOp.id],
+            latestServerSeq: 1,
+          });
+          const callOrder: string[] = [];
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              bufferDeferredAction(localAction);
+              callOrder.push('commit-snapshot-baseline');
+              hooks?.afterArchiveReplacement?.();
+              hooks?.afterSnapshotCachePersisted?.();
+              hooks?.afterSnapshotPersisted?.();
+              hooks?.beforeStateLoad?.();
+              throw new Error('failed before state dispatch');
+            },
+          );
+          operationLogEffectsSpy.processDeferredActions.and.callFake(async (options) => {
+            if (options?.callerHoldsOperationLogLock) {
+              callOrder.push('persist-deferred');
+              acknowledgeDeferredAction(localAction);
+            }
+          });
+          operationApplierSpy.applyOperations.and.resolveTo({
+            appliedOps: [persistedEntry.op],
+          });
+          const dispatchSpy = spyOn(
+            TestBed.inject(MockStore),
+            'dispatch',
+          ).and.callThrough();
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await expectAsync(
+              service.downloadRemoteOps(mockProvider),
+            ).toBeRejectedWithError('failed before state dispatch');
+
+            expect(callOrder[0]).toBe('commit-snapshot-baseline');
+            expect(callOrder).toContain('persist-deferred');
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+              jasmine.objectContaining({
+                type: localAction.type,
+                meta: jasmine.objectContaining({ isRemote: true }),
+              }),
+            );
+            expect(operationApplierSpy.applyOperations).toHaveBeenCalledWith(
+              [persistedEntry.op],
+              jasmine.objectContaining({ skipReducerDispatch: true }),
+            );
+            expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+          } finally {
+            clearDeferredActions();
+          }
+        });
+
+        it('should persist deferred intents when a vector write aborts the atomic snapshot transaction', async () => {
+          clearDeferredActions();
+          const localAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-local', changes: { title: 'Keep me' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              opType: OpType.Update,
+            },
+          };
+          const snapshotIncludedOp: Operation = {
+            id: 'snap-op-partial-persistence',
+            clientId: 'client-B',
+            actionType: ActionType.TASK_SHARED_UPDATE,
+            opType: OpType.Update,
+            entityType: 'TASK',
+            entityId: 'task-x',
+            payload: { task: { id: 'task-x', changes: {} } },
+            vectorClock: { clientB: 4 },
+            timestamp: 1,
+            schemaVersion: 1,
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [snapshotIncludedOp],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            snapshotAppliedOpIds: [snapshotIncludedOp.id],
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              expect(hooks?.snapshotIncludedOps).toEqual([snapshotIncludedOp]);
+              bufferDeferredAction(localAction);
+              throw new Error('atomic vector clock write failed');
+            },
+          );
+          operationLogEffectsSpy.processDeferredActions.and.callFake(async (options) => {
+            if (options?.callerHoldsOperationLogLock) {
+              acknowledgeDeferredAction(localAction);
+            }
+          });
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await expectAsync(
+              service.downloadRemoteOps(mockProvider),
+            ).toBeRejectedWithError('atomic vector clock write failed');
+
+            expect(operationLogEffectsSpy.processDeferredActions.calls.allArgs()).toEqual(
+              [
+                [{ callerHoldsOperationLogLock: false }],
+                [{ callerHoldsOperationLogLock: true }],
+              ],
+            );
+            expect(operationApplierSpy.applyOperations).not.toHaveBeenCalled();
+            expect(getDeferredActions()).not.toContain(localAction);
+            expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+          } finally {
+            clearDeferredActions();
+          }
         });
 
         it('should persist buffered local actions when snapshot hydration fails', async () => {
@@ -2076,6 +2484,297 @@ describe('OperationLogSyncService', () => {
             callerHoldsOperationLogLock: true,
           });
           expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+        });
+
+        it('should restore overwritten reducers and archives when hydration fails after state load', async () => {
+          clearDeferredActions();
+          const localAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-local', changes: { title: 'Keep me' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              opType: OpType.Update,
+            },
+          };
+          const persistedEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'buffered-local-op-after-failure',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              payload: { task: localAction.task },
+              vectorClock: { clientA: 2, clientB: 5 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+            Promise.resolve([persistedEntry]),
+            Promise.resolve([persistedEntry]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              bufferDeferredAction(localAction);
+              hooks?.afterArchiveReplacement?.();
+              hooks?.beforeStateLoad?.();
+              hooks?.afterStateLoad?.();
+              throw new Error('state load failed');
+            },
+          );
+          operationApplierSpy.applyOperations.and.resolveTo({
+            appliedOps: [persistedEntry.op],
+          });
+          const dispatchSpy = spyOn(
+            TestBed.inject(MockStore),
+            'dispatch',
+          ).and.callThrough();
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await expectAsync(
+              service.downloadRemoteOps(mockProvider),
+            ).toBeRejectedWithError('state load failed');
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+              jasmine.objectContaining({
+                type: localAction.type,
+                meta: jasmine.objectContaining({ isRemote: true }),
+              }),
+            );
+            expect(operationApplierSpy.applyOperations).toHaveBeenCalledWith(
+              [persistedEntry.op],
+              jasmine.objectContaining({
+                skipReducerDispatch: true,
+                skipDeferredLocalActions: true,
+                remoteApplyWindowAlreadyOpen: true,
+              }),
+            );
+            expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+          } finally {
+            clearDeferredActions();
+          }
+        });
+
+        it('should restore archives without replaying reducers when state load does not commit', async () => {
+          clearDeferredActions();
+          const localAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-local', changes: { title: 'Keep me' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              opType: OpType.Update,
+            },
+          };
+          const persistedEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'buffered-local-op-after-archive-replacement',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              payload: { task: localAction.task },
+              vectorClock: { clientA: 2, clientB: 5 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+            Promise.resolve([persistedEntry]),
+            Promise.resolve([persistedEntry]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              bufferDeferredAction(localAction);
+              hooks?.afterArchiveReplacement?.();
+              hooks?.beforeStateLoad?.();
+              throw new Error('state load failed before commit');
+            },
+          );
+          operationApplierSpy.applyOperations.and.resolveTo({
+            appliedOps: [persistedEntry.op],
+          });
+          const dispatchSpy = spyOn(
+            TestBed.inject(MockStore),
+            'dispatch',
+          ).and.callThrough();
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await expectAsync(
+              service.downloadRemoteOps(mockProvider),
+            ).toBeRejectedWithError('state load failed before commit');
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+              jasmine.objectContaining({
+                type: localAction.type,
+                meta: jasmine.objectContaining({ isRemote: true }),
+              }),
+            );
+            expect(operationApplierSpy.applyOperations).toHaveBeenCalledWith(
+              [persistedEntry.op],
+              jasmine.objectContaining({
+                skipReducerDispatch: true,
+                skipDeferredLocalActions: true,
+                remoteApplyWindowAlreadyOpen: true,
+              }),
+            );
+            expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+          } finally {
+            clearDeferredActions();
+          }
+        });
+
+        it('should continue reducer and archive restoration after a transient deferred drain failure', async () => {
+          clearDeferredActions();
+          const localAction: PersistentAction = {
+            type: ActionType.TASK_SHARED_UPDATE,
+            task: { id: 'task-local', changes: { title: 'Keep me' } },
+            meta: {
+              isPersistent: true,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              opType: OpType.Update,
+            },
+          };
+          const persistedEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'buffered-local-op-after-drain-retry',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-local',
+              payload: { task: localAction.task },
+              vectorClock: { clientA: 2, clientB: 5 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([]),
+            Promise.resolve([persistedEntry]),
+            Promise.resolve([persistedEntry]),
+          );
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const syncHydrationServiceSpy = TestBed.inject(
+            SyncHydrationService,
+          ) as jasmine.SpyObj<SyncHydrationService>;
+          syncHydrationServiceSpy.hydrateFromRemoteSync.and.callFake(
+            async (_state, _clock, _createImport, _reason, hooks) => {
+              bufferDeferredAction(localAction);
+              hooks?.afterArchiveReplacement?.();
+              hooks?.beforeStateLoad?.();
+              hooks?.afterStateLoad?.();
+            },
+          );
+          let heldLockDrainCount = 0;
+          operationLogEffectsSpy.processDeferredActions.and.callFake(async (options) => {
+            if (options?.callerHoldsOperationLogLock) {
+              heldLockDrainCount++;
+              if (heldLockDrainCount === 1) {
+                throw new Error('transient deferred drain failure');
+              }
+              for (const action of getDeferredActions()) {
+                acknowledgeDeferredAction(action);
+              }
+            }
+          });
+          operationApplierSpy.applyOperations.and.resolveTo({
+            appliedOps: [persistedEntry.op],
+          });
+          const dispatchSpy = spyOn(
+            TestBed.inject(MockStore),
+            'dispatch',
+          ).and.callThrough();
+          const mockProvider = {
+            supportsOperationSync: true,
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await service.downloadRemoteOps(mockProvider);
+
+            expect(heldLockDrainCount).toBe(2);
+            expect(dispatchSpy).toHaveBeenCalledWith(
+              jasmine.objectContaining({
+                type: localAction.type,
+                meta: jasmine.objectContaining({ isRemote: true }),
+              }),
+            );
+            expect(operationApplierSpy.applyOperations).toHaveBeenCalledWith(
+              [persistedEntry.op],
+              jasmine.objectContaining({
+                skipReducerDispatch: true,
+                skipDeferredLocalActions: true,
+                remoteApplyWindowAlreadyOpen: true,
+              }),
+            );
+            expect(mockProvider.setLastServerSeq).toHaveBeenCalledOnceWith(1);
+          } finally {
+            clearDeferredActions();
+          }
         });
 
         it('should NOT throw LocalDataConflictError on normal incremental sync (no snapshotState)', async () => {
@@ -2426,10 +3125,10 @@ describe('OperationLogSyncService', () => {
 
           await service.downloadRemoteOps(mockProvider);
 
-          expect(opLogStoreSpy.appendBatchSkipDuplicates).toHaveBeenCalledWith(
-            [snapshotIncludedOp],
-            'remote',
-          );
+          expect(
+            syncHydrationServiceSpy.hydrateFromRemoteSync.calls.mostRecent().args[4]
+              ?.snapshotIncludedOps,
+          ).toEqual([snapshotIncludedOp]);
           expect(remoteOpsProcessingServiceSpy.processRemoteOps).toHaveBeenCalledOnceWith(
             [postSnapshotOp],
             {},
@@ -4612,10 +5311,9 @@ describe('OperationLogSyncService', () => {
 
       await service.forceDownloadRemoteState(mockProvider);
 
-      expect(opLogStoreSpy.appendBatchSkipDuplicates).toHaveBeenCalledOnceWith(
-        [snapshotOp],
-        'remote',
-      );
+      expect(opLogStoreSpy.appendSnapshotIncludedOps).toHaveBeenCalledOnceWith([
+        snapshotOp,
+      ]);
       expect(remoteOpsProcessingServiceSpy.processRemoteOps).toHaveBeenCalledOnceWith(
         [suffixOp],
         {

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -79,6 +79,8 @@ import {
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 import { OperationApplierService } from '../apply/operation-applier.service';
 import { processDeferredActions } from './process-deferred-actions-flush.util';
+import { HydrationStateService } from '../apply/hydration-state.service';
+import { getDeferredActions } from '../capture/operation-capture.meta-reducer';
 
 type RemoteOpsProcessingResult = Awaited<
   ReturnType<RemoteOpsProcessingService['processRemoteOps']>
@@ -179,6 +181,7 @@ export class OperationLogSyncService {
   private syncImportConflictCoordinator = inject(SyncImportConflictCoordinatorService);
   private providerManager = inject(SyncProviderManager);
   private operationApplier = inject(OperationApplierService);
+  private hydrationState = inject(HydrationStateService);
   private injector = inject(Injector);
 
   /**
@@ -861,15 +864,107 @@ export class OperationLogSyncService {
         }
       }
 
-      // Hydrate state from snapshot - DON'T create SYNC_IMPORT for file-based bootstrap.
-      // Creating SYNC_IMPORT would trigger "clean slate" semantics that filter concurrent
-      // ops from other clients (via SyncImportFilterService). For normal file-based sync,
-      // we want to merge concurrent work, not discard it.
-      await this.syncHydrationService.hydrateFromRemoteSync(
-        result.snapshotState as Record<string, unknown>,
-        result.snapshotVectorClock,
-        false, // Don't create SYNC_IMPORT for file-based bootstrap
-      );
+      const initialUnsyncedOpIds = new Set(unsyncedOps.map((entry) => entry.op.id));
+      await this.writeFlushService.flushThenRunExclusive(async () => {
+        let deferredActionsOverwrittenBySnapshot: ReturnType<typeof getDeferredActions> =
+          [];
+        // Keep capture in deferred mode from the last pre-hydration durability
+        // check through the snapshot dispatch. Otherwise an action can be
+        // persisted against the old state and then silently overwritten by
+        // loadAllData while this async hydration is in progress.
+        this.hydrationState.startApplyingRemoteOps();
+        try {
+          const pendingAtHydrationCutoff = await this.opLogStore.getUnsynced();
+          const lateDurableOps = pendingAtHydrationCutoff.filter(
+            (entry) => !initialUnsyncedOpIds.has(entry.op.id),
+          );
+          if (lateDurableOps.length > 0) {
+            const lastSyncedVectorClock =
+              (await this.vectorClockService.getSnapshotVectorClock()) ?? null;
+            throw new LocalDataConflictError(
+              pendingAtHydrationCutoff.length,
+              result.snapshotState as Record<string, unknown>,
+              result.snapshotVectorClock,
+              lastSyncedVectorClock,
+              result.remoteLastModified,
+            );
+          }
+
+          // Hydrate state from snapshot - DON'T create SYNC_IMPORT for file-based
+          // bootstrap. Creating it would trigger clean-slate filtering of concurrent
+          // ops from other clients.
+          await this.syncHydrationService.hydrateFromRemoteSync(
+            result.snapshotState as Record<string, unknown>,
+            result.snapshotVectorClock,
+            false,
+            undefined,
+            {
+              // Capture only actions that ran on the old state. Actions emitted
+              // by loadAllData effects run after the snapshot reducer and are
+              // already valid on top of the new state, so replaying those would
+              // double-apply additive reducers.
+              beforeStateLoad: () => {
+                deferredActionsOverwrittenBySnapshot = getDeferredActions();
+              },
+            },
+          );
+
+          // Persistent actions dispatched during hydration already ran once on
+          // the old NgRx state, then loadAllData replaced that state. Re-dispatch
+          // remote-marked clones synchronously on top of the snapshot. The
+          // originals stay in the deferred queue and are persisted below with
+          // clocks that include the remote snapshot.
+          for (const action of deferredActionsOverwrittenBySnapshot) {
+            this.store.dispatch({
+              ...action,
+              meta: {
+                ...action.meta,
+                isRemote: true,
+              },
+            });
+          }
+        } finally {
+          this.hydrationState.endApplyingRemoteOps();
+        }
+
+        await processDeferredActions(this.injector, true);
+
+        // Hydration also replaces archive stores. Re-run archive side effects
+        // for the just-persisted local intents without dispatching their reducers
+        // a third time. No other writer can enter while this lock is held.
+        const localOpsCreatedDuringHydration = (await this.opLogStore.getUnsynced())
+          .filter((entry) => !initialUnsyncedOpIds.has(entry.op.id))
+          .sort((a, b) => a.seq - b.seq);
+        const localOpsNeedingArchiveRestore = localOpsCreatedDuringHydration
+          // Deferred actions are persisted in queue order. Only the prefix
+          // captured before loadAllData had its earlier archive effects
+          // overwritten by the remote snapshot; post-load actions already ran
+          // against the new archive and must not be applied twice.
+          .slice(0, deferredActionsOverwrittenBySnapshot.length)
+          .map((entry) => entry.op);
+        if (localOpsNeedingArchiveRestore.length > 0) {
+          const applyResult = await this.operationApplier.applyOperations(
+            localOpsNeedingArchiveRestore,
+            {
+              isLocalHydration: false,
+              skipDeferredLocalActions: true,
+              skipReducerDispatch: true,
+            },
+          );
+          if (
+            applyResult.failedOp ||
+            applyResult.appliedOps.length !== localOpsNeedingArchiveRestore.length
+          ) {
+            throw new Error(
+              'Snapshot hydration incomplete: local archive changes could not be restored.',
+            );
+          }
+
+          // User actions arriving during archive replay remain valid atop the
+          // restored state; only their durable fresh-clock entries are pending.
+          await processDeferredActions(this.injector, true);
+        }
+      });
 
       // Now that the remote snapshot is applied, it's safe to drop the
       // startup ops we previously decided were obsolete. Doing this
@@ -1727,11 +1822,11 @@ export class OperationLogSyncService {
           }
 
           // The provider cursor lives outside SUP_OPS, so it cannot join the IDB
-          // transaction. Reset it first: a crash/failure before the transaction
-          // merely causes a safe re-download onto intact local state, while a
-          // commit can never become visible with a stale cursor that skips the
-          // remote history required to rebuild the baseline.
-          await syncProvider.setLastServerSeq(0);
+          // transaction. Do not reset it eagerly: for file adapters that call is
+          // also the durable-apply acknowledgement for the staged download. The
+          // transaction stores a raw-rebuild-incomplete marker atomically with
+          // the replacement, and crash recovery always re-downloads from seq 0;
+          // the cursor is therefore advanced only after replay/hydration succeeds.
           await this.opLogStore.runRemoteStateReplacement({
             baselineState,
             vectorClock: rebuiltClock,

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -610,7 +610,10 @@ export class OperationLogSyncService {
           `OperationLogSyncService: Local vector clock ${hydrationPlan.comparison} remote snapshot — ` +
             'skipping snapshot hydration (local already has all remote data).',
         );
-        // Deliberately do NOT call appendBatchSkipDuplicates(result.newOps).
+        // Deliberately do NOT append operations already represented by the
+        // snapshot. Split files can also return a newer suffix, however, and
+        // snapshot-clock dominance says nothing about that suffix. Apply it
+        // normally before advancing the cursor.
         // VectorClockService.getEntityFrontier() builds per-entity frontiers
         // by iterating the op log in seq order with last-write-wins semantics.
         // Appending historical remote ops at the current tail would regress
@@ -618,21 +621,44 @@ export class OperationLogSyncService {
         // which then lets future remote ops be classified as non-conflicting
         // and silently overwrite local changes.
         //
-        // The trade-off: those ops keep coming back in result.newOps on each
+        // The trade-off: snapshot-included ops keep coming back in result.newOps on each
         // sync until the file's snapshot advances or the user uploads their
         // own snapshot. They are never re-applied to state, because (a) the
         // dominate-check skips state mutation, and (b) the regular hydration
         // path replaces state wholesale from snapshotState, not by replaying
         // individual ops. So the cost is bounded re-download bandwidth, not
         // data corruption.
+        const { postSnapshotOps } = this._partitionSnapshotOps(
+          result.newOps,
+          result.snapshotAppliedOpIds,
+        );
+        let suffixProcessResult: RemoteOpsProcessingResult | undefined;
+        if (postSnapshotOps.length > 0) {
+          suffixProcessResult = await this._processRemoteOpsWithStartupCleanup(
+            postSnapshotOps,
+            undefined,
+            [],
+          );
+          if (suffixProcessResult.blockedByIncompatibleOp) {
+            return { kind: 'blocked_incompatible' };
+          }
+        }
         if (result.latestServerSeq !== undefined) {
           await syncProvider.setLastServerSeq(result.latestServerSeq);
         }
-        return {
-          kind: 'no_new_ops',
-          allOpClocks: result.allOpClocks,
-          snapshotVectorClock: result.snapshotVectorClock,
-        };
+        return suffixProcessResult
+          ? {
+              kind: 'ops_processed',
+              newOpsCount: postSnapshotOps.length,
+              localWinOpsCreated: suffixProcessResult.localWinOpsCreated,
+              allOpClocks: result.allOpClocks,
+              snapshotVectorClock: result.snapshotVectorClock,
+            }
+          : {
+              kind: 'no_new_ops',
+              allOpClocks: result.allOpClocks,
+              snapshotVectorClock: result.snapshotVectorClock,
+            };
       }
 
       OpLog.normal(
@@ -856,15 +882,10 @@ export class OperationLogSyncService {
       // snapshot ops may be recorded as already applied; the remaining suffix
       // must run through normal remote-op processing before the cursor advances.
       // An absent list keeps the legacy single-file contract (all ops included).
-      const snapshotAppliedOpIds = result.snapshotAppliedOpIds
-        ? new Set(result.snapshotAppliedOpIds)
-        : null;
-      const snapshotIncludedOps = snapshotAppliedOpIds
-        ? result.newOps.filter((op) => snapshotAppliedOpIds.has(op.id))
-        : result.newOps;
-      const postSnapshotOps = snapshotAppliedOpIds
-        ? result.newOps.filter((op) => !snapshotAppliedOpIds.has(op.id))
-        : [];
+      const { snapshotIncludedOps, postSnapshotOps } = this._partitionSnapshotOps(
+        result.newOps,
+        result.snapshotAppliedOpIds,
+      );
 
       // Record operations already represented by the snapshot so future whole-
       // file downloads deduplicate them without replaying their effects twice.
@@ -882,13 +903,14 @@ export class OperationLogSyncService {
         );
       }
 
+      let suffixProcessResult: RemoteOpsProcessingResult | undefined;
       if (postSnapshotOps.length > 0) {
-        const processResult = await this._processRemoteOpsWithStartupCleanup(
+        suffixProcessResult = await this._processRemoteOpsWithStartupCleanup(
           postSnapshotOps,
           undefined,
           [],
         );
-        if (processResult.blockedByIncompatibleOp) {
+        if (suffixProcessResult.blockedByIncompatibleOp) {
           return { kind: 'blocked_incompatible' };
         }
       }
@@ -900,11 +922,19 @@ export class OperationLogSyncService {
 
       OpLog.normal('OperationLogSyncService: Snapshot hydration complete.');
 
-      return {
-        kind: 'snapshot_hydrated',
-        allOpClocks: result.allOpClocks,
-        snapshotVectorClock: result.snapshotVectorClock,
-      };
+      return suffixProcessResult
+        ? {
+            kind: 'ops_processed',
+            newOpsCount: postSnapshotOps.length,
+            localWinOpsCreated: suffixProcessResult.localWinOpsCreated,
+            allOpClocks: result.allOpClocks,
+            snapshotVectorClock: result.snapshotVectorClock,
+          }
+        : {
+            kind: 'snapshot_hydrated',
+            allOpClocks: result.allOpClocks,
+            snapshotVectorClock: result.snapshotVectorClock,
+          };
     }
 
     if (result.newOps.length === 0) {
@@ -1249,6 +1279,20 @@ export class OperationLogSyncService {
     }
   }
 
+  private _partitionSnapshotOps(
+    ops: Operation[],
+    snapshotAppliedOpIds: string[] | undefined,
+  ): { snapshotIncludedOps: Operation[]; postSnapshotOps: Operation[] } {
+    if (snapshotAppliedOpIds === undefined) {
+      return { snapshotIncludedOps: ops, postSnapshotOps: [] };
+    }
+    const includedIds = new Set(snapshotAppliedOpIds);
+    return {
+      snapshotIncludedOps: ops.filter((op) => includedIds.has(op.id)),
+      postSnapshotOps: ops.filter((op) => !includedIds.has(op.id)),
+    };
+  }
+
   private async _discardStartupOpsIfFullStateCommitted(
     fullStateOpId: string | undefined,
     startupOpIds: string[],
@@ -1521,7 +1565,24 @@ export class OperationLogSyncService {
       throw new Error('USE_REMOTE aborted: remote returned no data to rebuild from.');
     }
 
-    const migratedRemoteOps = this._preflightRemoteOperations(result.newOps);
+    let migratedRemoteOps: Operation[];
+    let migratedSnapshotIncludedOps: Operation[] = [];
+    let migratedPostSnapshotOps: Operation[] = [];
+    if (hasSnapshotState && result.providerMode === 'fileSnapshotOps') {
+      const snapshotOps = this._partitionSnapshotOps(
+        result.newOps,
+        result.snapshotAppliedOpIds,
+      );
+      migratedSnapshotIncludedOps = this._preflightRemoteOperations(
+        snapshotOps.snapshotIncludedOps,
+      );
+      migratedPostSnapshotOps = this._preflightRemoteOperations(
+        snapshotOps.postSnapshotOps,
+      );
+      migratedRemoteOps = [...migratedSnapshotIncludedOps, ...migratedPostSnapshotOps];
+    } else {
+      migratedRemoteOps = this._preflightRemoteOperations(result.newOps);
+    }
 
     const currentSyncConfig = await firstValueFrom(this.store.select(selectSyncConfig));
     const localOnlySyncSettings: LocalOnlySyncSettings = {
@@ -1707,12 +1768,11 @@ export class OperationLogSyncService {
               false, // Don't create SYNC_IMPORT
             );
 
-            // CRITICAL FIX: Write recentOps to IndexedDB after snapshot hydration.
-            // Same rationale as downloadRemoteOps: file-based providers return ALL
-            // recentOps on every download and rely on getAppliedOpIds() to filter them.
-            if (migratedRemoteOps.length > 0) {
+            // Record only operations already represented by the snapshot. A
+            // split-file suffix must still be dispatched on top of that state.
+            if (migratedSnapshotIncludedOps.length > 0) {
               const appendResult = await this.opLogStore.appendBatchSkipDuplicates(
-                migratedRemoteOps,
+                migratedSnapshotIncludedOps,
                 'remote',
               );
               OpLog.normal(
@@ -1722,6 +1782,22 @@ export class OperationLogSyncService {
                     ? ` Skipped ${appendResult.skippedCount} duplicate(s).`
                     : ''),
               );
+            }
+
+            if (migratedPostSnapshotOps.length > 0) {
+              const processResult =
+                await this.remoteOpsProcessingService.processRemoteOps(
+                  migratedPostSnapshotOps,
+                  {
+                    skipConflictDetection: true,
+                    callerHoldsOperationLogLock: true,
+                  },
+                );
+              if (processResult.blockedByIncompatibleOp) {
+                throw new Error(
+                  'USE_REMOTE incomplete: a post-snapshot op failed schema migration during replay.',
+                );
+              }
             }
 
             await this._restorePreservedLocalOps(preservedLocalOps);

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -876,31 +876,9 @@ export class OperationLogSyncService {
         result.snapshotAppliedOpIds,
       );
 
-      await this.writeFlushService.flushThenRunExclusive(async () => {
-        try {
-          await this._hydrateSnapshotExclusive(
-            result,
-            initialUnsyncedOpIds,
-            snapshotIncludedOps,
-          );
-        } catch (e) {
-          // A throw anywhere above (validation failure, late-durable conflict,
-          // archive-restore failure) can leave user intents that were buffered
-          // during a remote-apply window applied to live NgRx state but not yet
-          // durable. Persist them before surfacing the error — otherwise
-          // closing the app afterwards silently drops those edits. (The apply
-          // window itself is already closed by the inner finally.)
-          try {
-            await processDeferredActions(this.injector, true);
-          } catch (drainError) {
-            OpLog.err(
-              'OperationLogSyncService: failed to persist deferred actions after hydration error',
-              drainError,
-            );
-          }
-          throw e;
-        }
-      });
+      await this.writeFlushService.flushThenRunExclusive(() =>
+        this._hydrateSnapshotExclusive(result, initialUnsyncedOpIds, snapshotIncludedOps),
+      );
 
       // Now that the remote snapshot is applied, it's safe to drop the
       // startup ops we previously decided were obsolete. Doing this
@@ -1315,135 +1293,153 @@ export class OperationLogSyncService {
     snapshotIncludedOps: Operation[],
   ): Promise<void> {
     let deferredActionsOverwrittenBySnapshot: ReturnType<typeof getDeferredActions> = [];
+    let didReplaceArchive = false;
+    let didCommitStateLoad = false;
+    let hydrationFailed = false;
+    let hydrationError: unknown;
+    let isRemoteApplyWindowOpen = true;
     // Keep capture in deferred mode from the last pre-hydration durability
     // check through the snapshot dispatch. Otherwise an action can be
     // persisted against the old state and then silently overwritten by
     // loadAllData while this async hydration is in progress.
     this.hydrationState.startApplyingRemoteOps();
-    let hasEndedRemoteApplyWindow = false;
     try {
-      const pendingAtHydrationCutoff = await this.opLogStore.getUnsynced();
-      const lateDurableOps = pendingAtHydrationCutoff.filter(
-        (entry) => !initialUnsyncedOpIds.has(entry.op.id),
-      );
-      if (lateDurableOps.length > 0) {
-        const lastSyncedVectorClock =
-          (await this.vectorClockService.getSnapshotVectorClock()) ?? null;
-        throw new LocalDataConflictError(
-          pendingAtHydrationCutoff.length,
+      try {
+        const pendingAtHydrationCutoff = await this.opLogStore.getUnsynced();
+        const lateDurableOps = pendingAtHydrationCutoff.filter(
+          (entry) => !initialUnsyncedOpIds.has(entry.op.id),
+        );
+        if (lateDurableOps.length > 0) {
+          const lastSyncedVectorClock =
+            (await this.vectorClockService.getSnapshotVectorClock()) ?? null;
+          throw new LocalDataConflictError(
+            pendingAtHydrationCutoff.length,
+            result.snapshotState as Record<string, unknown>,
+            result.snapshotVectorClock,
+            lastSyncedVectorClock,
+            result.remoteLastModified,
+          );
+        }
+
+        // Hydrate state from snapshot - DON'T create SYNC_IMPORT for file-based
+        // bootstrap. Creating it would trigger clean-slate filtering of concurrent
+        // ops from other clients.
+        await this.syncHydrationService.hydrateFromRemoteSync(
           result.snapshotState as Record<string, unknown>,
           result.snapshotVectorClock,
-          lastSyncedVectorClock,
-          result.remoteLastModified,
-        );
-      }
-
-      // Hydrate state from snapshot - DON'T create SYNC_IMPORT for file-based
-      // bootstrap. Creating it would trigger clean-slate filtering of concurrent
-      // ops from other clients.
-      await this.syncHydrationService.hydrateFromRemoteSync(
-        result.snapshotState as Record<string, unknown>,
-        result.snapshotVectorClock,
-        false,
-        undefined,
-        {
-          // Capture only actions that ran on the old state. Actions emitted
-          // by loadAllData effects run after the snapshot reducer and are
-          // already valid on top of the new state, so replaying those would
-          // double-apply additive reducers.
-          beforeStateLoad: () => {
-            deferredActionsOverwrittenBySnapshot = getDeferredActions();
+          false,
+          undefined,
+          {
+            snapshotIncludedOps,
+            // Capture only actions that ran on the old state. Actions emitted
+            // by loadAllData effects run after the snapshot reducer and are
+            // already valid on top of the new state, so replaying those would
+            // double-apply additive reducers.
+            beforeStateLoad: () => {
+              deferredActionsOverwrittenBySnapshot = getDeferredActions();
+            },
+            afterStateLoad: () => {
+              didCommitStateLoad = true;
+            },
+            afterArchiveReplacement: () => {
+              didReplaceArchive = true;
+            },
           },
-        },
-      );
-
-      // Record the remote ops the snapshot already represents BEFORE any
-      // mid-hydration local intents are persisted below.
-      // VectorClockService.getEntityFrontier() derives per-entity frontiers
-      // from the LAST op per entity in seq order; appending these older remote
-      // ops after the fresh-clock local intents would regress the frontier and
-      // let a later concurrent remote op be classified as non-conflicting,
-      // silently overwriting the user's mid-hydration edit. (Also prevents
-      // re-applying these ops on the next whole-file download.)
-      if (snapshotIncludedOps.length > 0) {
-        const appendResult = await this.opLogStore.appendBatchSkipDuplicates(
-          snapshotIncludedOps,
-          'remote',
         );
-        OpLog.normal(
-          `OperationLogSyncService: Wrote ${appendResult.writtenOps.length} snapshot ops to IndexedDB ` +
-            '(prevents duplication on next sync cycle).' +
-            (appendResult.skippedCount > 0
-              ? ` Skipped ${appendResult.skippedCount} duplicate(s).`
-              : ''),
-        );
+      } catch (error) {
+        hydrationFailed = true;
+        hydrationError = error;
       }
 
-      // The hydration service has durably stored the remote snapshot clock
-      // by this point. Persist buffered local intents with clocks based on
-      // that snapshot before making their replay visible again. This keeps
-      // a reducer replay failure from widening the non-durable window.
-      await processDeferredActions(this.injector, true);
+      // The file snapshot baseline transaction either committed state, clock,
+      // archives, and included remote ops together or left the old baseline
+      // intact. Deferred intents therefore always drain against a complete
+      // frontier, including when hydration failed before live-state dispatch.
+      await this._processSnapshotDeferredActionsWithRetry();
 
-      // loadAllData has committed the new baseline. Leave deferred mode
-      // before replaying remote-marked clones; subsequent user events now
-      // run on the new state and follow the normal persistence path.
-      this.hydrationState.endApplyingRemoteOps();
-      hasEndedRemoteApplyWindow = true;
-
-      // Persistent actions dispatched during hydration already ran once on
-      // the old NgRx state, then loadAllData replaced that state. Re-dispatch
-      // remote-marked clones synchronously on top of the snapshot. The
-      // originals were persisted above with clocks that include the remote
-      // snapshot.
-      for (const action of deferredActionsOverwrittenBySnapshot) {
-        this.store.dispatch({
-          ...action,
-          meta: {
-            ...action.meta,
-            isRemote: true,
-          },
-        });
+      if (didCommitStateLoad) {
+        // Persistent actions dispatched before loadAllData already ran once on
+        // the old NgRx state. Re-dispatch remote-marked clones synchronously on
+        // top of the snapshot without capturing a second operation.
+        for (const action of deferredActionsOverwrittenBySnapshot) {
+          this.store.dispatch({
+            ...action,
+            meta: {
+              ...action.meta,
+              isRemote: true,
+            },
+          });
+        }
       }
+
+      if (didReplaceArchive) {
+        // Hydration also replaces archive stores. Re-run archive side effects
+        // for every local intent created since the cutoff, in durable seq order.
+        // Keep looping until both the deferred queue and durable archive work
+        // are empty. The final queue check and remote-window close are
+        // synchronous, so an action cannot land in the handoff gap.
+        const restoredLocalOpIds = new Set(initialUnsyncedOpIds);
+        while (true) {
+          while (getDeferredActions().length > 0) {
+            await this._processSnapshotDeferredActionsWithRetry();
+          }
+
+          const localOpsNeedingArchiveRestore = (await this.opLogStore.getUnsynced())
+            .filter((entry) => !restoredLocalOpIds.has(entry.op.id))
+            .sort((a, b) => a.seq - b.seq)
+            .map((entry) => entry.op);
+          if (localOpsNeedingArchiveRestore.length === 0) {
+            if (getDeferredActions().length > 0) continue;
+            this.hydrationState.endApplyingRemoteOps();
+            isRemoteApplyWindowOpen = false;
+            break;
+          }
+
+          const applyResult = await this.operationApplier.applyOperations(
+            localOpsNeedingArchiveRestore,
+            {
+              isLocalHydration: false,
+              skipDeferredLocalActions: true,
+              skipReducerDispatch: true,
+              remoteApplyWindowAlreadyOpen: true,
+            },
+          );
+          if (
+            applyResult.failedOp ||
+            applyResult.appliedOps.length !== localOpsNeedingArchiveRestore.length
+          ) {
+            throw new Error(
+              'Snapshot hydration incomplete: local archive changes could not be restored.',
+            );
+          }
+          for (const op of localOpsNeedingArchiveRestore) {
+            restoredLocalOpIds.add(op.id);
+          }
+        }
+      } else {
+        while (getDeferredActions().length > 0) {
+          await this._processSnapshotDeferredActionsWithRetry();
+        }
+        this.hydrationState.endApplyingRemoteOps();
+        isRemoteApplyWindowOpen = false;
+      }
+
+      if (hydrationFailed) throw hydrationError;
     } finally {
-      if (!hasEndedRemoteApplyWindow) {
+      if (isRemoteApplyWindowOpen) {
         this.hydrationState.endApplyingRemoteOps();
       }
     }
+  }
 
-    // Hydration also replaces archive stores. Re-run archive side effects
-    // for the just-persisted local intents without dispatching their reducers
-    // a third time. No other writer can enter while this lock is held.
-    const localOpsCreatedDuringHydration = (await this.opLogStore.getUnsynced())
-      .filter((entry) => !initialUnsyncedOpIds.has(entry.op.id))
-      .sort((a, b) => a.seq - b.seq);
-    const localOpsNeedingArchiveRestore = localOpsCreatedDuringHydration
-      // Deferred actions are persisted in queue order. Only the prefix
-      // captured before loadAllData had its earlier archive effects
-      // overwritten by the remote snapshot; post-load actions already ran
-      // against the new archive and must not be applied twice.
-      .slice(0, deferredActionsOverwrittenBySnapshot.length)
-      .map((entry) => entry.op);
-    if (localOpsNeedingArchiveRestore.length > 0) {
-      const applyResult = await this.operationApplier.applyOperations(
-        localOpsNeedingArchiveRestore,
-        {
-          isLocalHydration: false,
-          skipDeferredLocalActions: true,
-          skipReducerDispatch: true,
-        },
+  private async _processSnapshotDeferredActionsWithRetry(): Promise<void> {
+    try {
+      await processDeferredActions(this.injector, true);
+    } catch (error) {
+      OpLog.warn(
+        'OperationLogSyncService: deferred snapshot action drain failed; retrying once',
+        { name: (error as Error | undefined)?.name },
       );
-      if (
-        applyResult.failedOp ||
-        applyResult.appliedOps.length !== localOpsNeedingArchiveRestore.length
-      ) {
-        throw new Error(
-          'Snapshot hydration incomplete: local archive changes could not be restored.',
-        );
-      }
-
-      // User actions arriving during archive replay remain valid atop the
-      // restored state; only their durable fresh-clock entries are pending.
       await processDeferredActions(this.injector, true);
     }
   }
@@ -1926,9 +1922,8 @@ export class OperationLogSyncService {
             // Record only operations already represented by the snapshot. A
             // split-file suffix must still be dispatched on top of that state.
             if (migratedSnapshotIncludedOps.length > 0) {
-              const appendResult = await this.opLogStore.appendBatchSkipDuplicates(
+              const appendResult = await this.opLogStore.appendSnapshotIncludedOps(
                 migratedSnapshotIncludedOps,
-                'remote',
               );
               OpLog.normal(
                 `OperationLogSyncService: Wrote ${appendResult.writtenOps.length} snapshot ops to IndexedDB ` +

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -873,6 +873,7 @@ export class OperationLogSyncService {
         // persisted against the old state and then silently overwritten by
         // loadAllData while this async hydration is in progress.
         this.hydrationState.startApplyingRemoteOps();
+        let hasEndedRemoteApplyWindow = false;
         try {
           const pendingAtHydrationCutoff = await this.opLogStore.getUnsynced();
           const lateDurableOps = pendingAtHydrationCutoff.filter(
@@ -909,11 +910,23 @@ export class OperationLogSyncService {
             },
           );
 
+          // The hydration service has durably stored the remote snapshot clock
+          // by this point. Persist buffered local intents with clocks based on
+          // that snapshot before making their replay visible again. This keeps
+          // a reducer replay failure from widening the non-durable window.
+          await processDeferredActions(this.injector, true);
+
+          // loadAllData has committed the new baseline. Leave deferred mode
+          // before replaying remote-marked clones; subsequent user events now
+          // run on the new state and follow the normal persistence path.
+          this.hydrationState.endApplyingRemoteOps();
+          hasEndedRemoteApplyWindow = true;
+
           // Persistent actions dispatched during hydration already ran once on
           // the old NgRx state, then loadAllData replaced that state. Re-dispatch
           // remote-marked clones synchronously on top of the snapshot. The
-          // originals stay in the deferred queue and are persisted below with
-          // clocks that include the remote snapshot.
+          // originals were persisted above with clocks that include the remote
+          // snapshot.
           for (const action of deferredActionsOverwrittenBySnapshot) {
             this.store.dispatch({
               ...action,
@@ -924,10 +937,10 @@ export class OperationLogSyncService {
             });
           }
         } finally {
-          this.hydrationState.endApplyingRemoteOps();
+          if (!hasEndedRemoteApplyWindow) {
+            this.hydrationState.endApplyingRemoteOps();
+          }
         }
-
-        await processDeferredActions(this.injector, true);
 
         // Hydration also replaces archive stores. Re-run archive side effects
         // for the just-persisted local intents without dispatching their reducers

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -865,125 +865,6 @@ export class OperationLogSyncService {
       }
 
       const initialUnsyncedOpIds = new Set(unsyncedOps.map((entry) => entry.op.id));
-      await this.writeFlushService.flushThenRunExclusive(async () => {
-        let deferredActionsOverwrittenBySnapshot: ReturnType<typeof getDeferredActions> =
-          [];
-        // Keep capture in deferred mode from the last pre-hydration durability
-        // check through the snapshot dispatch. Otherwise an action can be
-        // persisted against the old state and then silently overwritten by
-        // loadAllData while this async hydration is in progress.
-        this.hydrationState.startApplyingRemoteOps();
-        let hasEndedRemoteApplyWindow = false;
-        try {
-          const pendingAtHydrationCutoff = await this.opLogStore.getUnsynced();
-          const lateDurableOps = pendingAtHydrationCutoff.filter(
-            (entry) => !initialUnsyncedOpIds.has(entry.op.id),
-          );
-          if (lateDurableOps.length > 0) {
-            const lastSyncedVectorClock =
-              (await this.vectorClockService.getSnapshotVectorClock()) ?? null;
-            throw new LocalDataConflictError(
-              pendingAtHydrationCutoff.length,
-              result.snapshotState as Record<string, unknown>,
-              result.snapshotVectorClock,
-              lastSyncedVectorClock,
-              result.remoteLastModified,
-            );
-          }
-
-          // Hydrate state from snapshot - DON'T create SYNC_IMPORT for file-based
-          // bootstrap. Creating it would trigger clean-slate filtering of concurrent
-          // ops from other clients.
-          await this.syncHydrationService.hydrateFromRemoteSync(
-            result.snapshotState as Record<string, unknown>,
-            result.snapshotVectorClock,
-            false,
-            undefined,
-            {
-              // Capture only actions that ran on the old state. Actions emitted
-              // by loadAllData effects run after the snapshot reducer and are
-              // already valid on top of the new state, so replaying those would
-              // double-apply additive reducers.
-              beforeStateLoad: () => {
-                deferredActionsOverwrittenBySnapshot = getDeferredActions();
-              },
-            },
-          );
-
-          // The hydration service has durably stored the remote snapshot clock
-          // by this point. Persist buffered local intents with clocks based on
-          // that snapshot before making their replay visible again. This keeps
-          // a reducer replay failure from widening the non-durable window.
-          await processDeferredActions(this.injector, true);
-
-          // loadAllData has committed the new baseline. Leave deferred mode
-          // before replaying remote-marked clones; subsequent user events now
-          // run on the new state and follow the normal persistence path.
-          this.hydrationState.endApplyingRemoteOps();
-          hasEndedRemoteApplyWindow = true;
-
-          // Persistent actions dispatched during hydration already ran once on
-          // the old NgRx state, then loadAllData replaced that state. Re-dispatch
-          // remote-marked clones synchronously on top of the snapshot. The
-          // originals were persisted above with clocks that include the remote
-          // snapshot.
-          for (const action of deferredActionsOverwrittenBySnapshot) {
-            this.store.dispatch({
-              ...action,
-              meta: {
-                ...action.meta,
-                isRemote: true,
-              },
-            });
-          }
-        } finally {
-          if (!hasEndedRemoteApplyWindow) {
-            this.hydrationState.endApplyingRemoteOps();
-          }
-        }
-
-        // Hydration also replaces archive stores. Re-run archive side effects
-        // for the just-persisted local intents without dispatching their reducers
-        // a third time. No other writer can enter while this lock is held.
-        const localOpsCreatedDuringHydration = (await this.opLogStore.getUnsynced())
-          .filter((entry) => !initialUnsyncedOpIds.has(entry.op.id))
-          .sort((a, b) => a.seq - b.seq);
-        const localOpsNeedingArchiveRestore = localOpsCreatedDuringHydration
-          // Deferred actions are persisted in queue order. Only the prefix
-          // captured before loadAllData had its earlier archive effects
-          // overwritten by the remote snapshot; post-load actions already ran
-          // against the new archive and must not be applied twice.
-          .slice(0, deferredActionsOverwrittenBySnapshot.length)
-          .map((entry) => entry.op);
-        if (localOpsNeedingArchiveRestore.length > 0) {
-          const applyResult = await this.operationApplier.applyOperations(
-            localOpsNeedingArchiveRestore,
-            {
-              isLocalHydration: false,
-              skipDeferredLocalActions: true,
-              skipReducerDispatch: true,
-            },
-          );
-          if (
-            applyResult.failedOp ||
-            applyResult.appliedOps.length !== localOpsNeedingArchiveRestore.length
-          ) {
-            throw new Error(
-              'Snapshot hydration incomplete: local archive changes could not be restored.',
-            );
-          }
-
-          // User actions arriving during archive replay remain valid atop the
-          // restored state; only their durable fresh-clock entries are pending.
-          await processDeferredActions(this.injector, true);
-        }
-      });
-
-      // Now that the remote snapshot is applied, it's safe to drop the
-      // startup ops we previously decided were obsolete. Doing this
-      // after hydration ensures a hydration failure leaves the queue intact
-      // so the next attempt can retry.
-      await this._discardStartupOps(startupOpIdsToDiscard);
 
       // Single-file snapshots are current through every returned recent op. Split
       // snapshots can lag behind sync-ops.json, so only the explicitly-listed
@@ -995,21 +876,37 @@ export class OperationLogSyncService {
         result.snapshotAppliedOpIds,
       );
 
-      // Record operations already represented by the snapshot so future whole-
-      // file downloads deduplicate them without replaying their effects twice.
-      if (snapshotIncludedOps.length > 0) {
-        const appendResult = await this.opLogStore.appendBatchSkipDuplicates(
-          snapshotIncludedOps,
-          'remote',
-        );
-        OpLog.normal(
-          `OperationLogSyncService: Wrote ${appendResult.writtenOps.length} snapshot ops to IndexedDB ` +
-            '(prevents duplication on next sync cycle).' +
-            (appendResult.skippedCount > 0
-              ? ` Skipped ${appendResult.skippedCount} duplicate(s).`
-              : ''),
-        );
-      }
+      await this.writeFlushService.flushThenRunExclusive(async () => {
+        try {
+          await this._hydrateSnapshotExclusive(
+            result,
+            initialUnsyncedOpIds,
+            snapshotIncludedOps,
+          );
+        } catch (e) {
+          // A throw anywhere above (validation failure, late-durable conflict,
+          // archive-restore failure) can leave user intents that were buffered
+          // during a remote-apply window applied to live NgRx state but not yet
+          // durable. Persist them before surfacing the error — otherwise
+          // closing the app afterwards silently drops those edits. (The apply
+          // window itself is already closed by the inner finally.)
+          try {
+            await processDeferredActions(this.injector, true);
+          } catch (drainError) {
+            OpLog.err(
+              'OperationLogSyncService: failed to persist deferred actions after hydration error',
+              drainError,
+            );
+          }
+          throw e;
+        }
+      });
+
+      // Now that the remote snapshot is applied, it's safe to drop the
+      // startup ops we previously decided were obsolete. Doing this
+      // after hydration ensures a hydration failure leaves the queue intact
+      // so the next attempt can retry.
+      await this._discardStartupOps(startupOpIdsToDiscard);
 
       let suffixProcessResult: RemoteOpsProcessingResult | undefined;
       if (postSnapshotOps.length > 0) {
@@ -1399,6 +1296,156 @@ export class OperationLogSyncService {
       snapshotIncludedOps: ops.filter((op) => includedIds.has(op.id)),
       postSnapshotOps: ops.filter((op) => !includedIds.has(op.id)),
     };
+  }
+
+  /**
+   * Body of the exclusive file-snapshot hydration section: hydrates the remote
+   * snapshot while user actions are deferred, persists the buffered intents on
+   * top of it, and replays their archive side effects. Runs inside
+   * `writeFlushService.flushThenRunExclusive` — no other op-log writer can
+   * interleave.
+   */
+  private async _hydrateSnapshotExclusive(
+    result: {
+      snapshotState?: unknown;
+      snapshotVectorClock?: Record<string, number>;
+      remoteLastModified?: number;
+    },
+    initialUnsyncedOpIds: Set<string>,
+    snapshotIncludedOps: Operation[],
+  ): Promise<void> {
+    let deferredActionsOverwrittenBySnapshot: ReturnType<typeof getDeferredActions> = [];
+    // Keep capture in deferred mode from the last pre-hydration durability
+    // check through the snapshot dispatch. Otherwise an action can be
+    // persisted against the old state and then silently overwritten by
+    // loadAllData while this async hydration is in progress.
+    this.hydrationState.startApplyingRemoteOps();
+    let hasEndedRemoteApplyWindow = false;
+    try {
+      const pendingAtHydrationCutoff = await this.opLogStore.getUnsynced();
+      const lateDurableOps = pendingAtHydrationCutoff.filter(
+        (entry) => !initialUnsyncedOpIds.has(entry.op.id),
+      );
+      if (lateDurableOps.length > 0) {
+        const lastSyncedVectorClock =
+          (await this.vectorClockService.getSnapshotVectorClock()) ?? null;
+        throw new LocalDataConflictError(
+          pendingAtHydrationCutoff.length,
+          result.snapshotState as Record<string, unknown>,
+          result.snapshotVectorClock,
+          lastSyncedVectorClock,
+          result.remoteLastModified,
+        );
+      }
+
+      // Hydrate state from snapshot - DON'T create SYNC_IMPORT for file-based
+      // bootstrap. Creating it would trigger clean-slate filtering of concurrent
+      // ops from other clients.
+      await this.syncHydrationService.hydrateFromRemoteSync(
+        result.snapshotState as Record<string, unknown>,
+        result.snapshotVectorClock,
+        false,
+        undefined,
+        {
+          // Capture only actions that ran on the old state. Actions emitted
+          // by loadAllData effects run after the snapshot reducer and are
+          // already valid on top of the new state, so replaying those would
+          // double-apply additive reducers.
+          beforeStateLoad: () => {
+            deferredActionsOverwrittenBySnapshot = getDeferredActions();
+          },
+        },
+      );
+
+      // Record the remote ops the snapshot already represents BEFORE any
+      // mid-hydration local intents are persisted below.
+      // VectorClockService.getEntityFrontier() derives per-entity frontiers
+      // from the LAST op per entity in seq order; appending these older remote
+      // ops after the fresh-clock local intents would regress the frontier and
+      // let a later concurrent remote op be classified as non-conflicting,
+      // silently overwriting the user's mid-hydration edit. (Also prevents
+      // re-applying these ops on the next whole-file download.)
+      if (snapshotIncludedOps.length > 0) {
+        const appendResult = await this.opLogStore.appendBatchSkipDuplicates(
+          snapshotIncludedOps,
+          'remote',
+        );
+        OpLog.normal(
+          `OperationLogSyncService: Wrote ${appendResult.writtenOps.length} snapshot ops to IndexedDB ` +
+            '(prevents duplication on next sync cycle).' +
+            (appendResult.skippedCount > 0
+              ? ` Skipped ${appendResult.skippedCount} duplicate(s).`
+              : ''),
+        );
+      }
+
+      // The hydration service has durably stored the remote snapshot clock
+      // by this point. Persist buffered local intents with clocks based on
+      // that snapshot before making their replay visible again. This keeps
+      // a reducer replay failure from widening the non-durable window.
+      await processDeferredActions(this.injector, true);
+
+      // loadAllData has committed the new baseline. Leave deferred mode
+      // before replaying remote-marked clones; subsequent user events now
+      // run on the new state and follow the normal persistence path.
+      this.hydrationState.endApplyingRemoteOps();
+      hasEndedRemoteApplyWindow = true;
+
+      // Persistent actions dispatched during hydration already ran once on
+      // the old NgRx state, then loadAllData replaced that state. Re-dispatch
+      // remote-marked clones synchronously on top of the snapshot. The
+      // originals were persisted above with clocks that include the remote
+      // snapshot.
+      for (const action of deferredActionsOverwrittenBySnapshot) {
+        this.store.dispatch({
+          ...action,
+          meta: {
+            ...action.meta,
+            isRemote: true,
+          },
+        });
+      }
+    } finally {
+      if (!hasEndedRemoteApplyWindow) {
+        this.hydrationState.endApplyingRemoteOps();
+      }
+    }
+
+    // Hydration also replaces archive stores. Re-run archive side effects
+    // for the just-persisted local intents without dispatching their reducers
+    // a third time. No other writer can enter while this lock is held.
+    const localOpsCreatedDuringHydration = (await this.opLogStore.getUnsynced())
+      .filter((entry) => !initialUnsyncedOpIds.has(entry.op.id))
+      .sort((a, b) => a.seq - b.seq);
+    const localOpsNeedingArchiveRestore = localOpsCreatedDuringHydration
+      // Deferred actions are persisted in queue order. Only the prefix
+      // captured before loadAllData had its earlier archive effects
+      // overwritten by the remote snapshot; post-load actions already ran
+      // against the new archive and must not be applied twice.
+      .slice(0, deferredActionsOverwrittenBySnapshot.length)
+      .map((entry) => entry.op);
+    if (localOpsNeedingArchiveRestore.length > 0) {
+      const applyResult = await this.operationApplier.applyOperations(
+        localOpsNeedingArchiveRestore,
+        {
+          isLocalHydration: false,
+          skipDeferredLocalActions: true,
+          skipReducerDispatch: true,
+        },
+      );
+      if (
+        applyResult.failedOp ||
+        applyResult.appliedOps.length !== localOpsNeedingArchiveRestore.length
+      ) {
+        throw new Error(
+          'Snapshot hydration incomplete: local archive changes could not be restored.',
+        );
+      }
+
+      // User actions arriving during archive replay remain valid atop the
+      // restored state; only their durable fresh-clock entries are pending.
+      await processDeferredActions(this.injector, true);
+    }
   }
 
   private async _discardStartupOpsIfFullStateCommitted(

--- a/src/app/op-log/testing/integration/file-based-sync/conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/conflict-resolution.integration.spec.ts
@@ -77,9 +77,20 @@ describe('File-Based Sync Integration - Conflict Resolution', () => {
       // Client B downloads
       await clientB.downloadOps(0);
 
-      // Simulate race condition: inject rev mismatch error on first upload attempt
-      provider.injectNextError(
-        new UploadRevToMatchMismatchAPIError('Rev changed during upload'),
+      // Simulate a mismatch on the primary CAS, not on its preceding backup write.
+      const realUploadFile = provider.uploadFile.bind(provider);
+      let isFirstPrimaryUpload = true;
+      spyOn(provider, 'uploadFile').and.callFake(
+        async (targetPath, dataStr, revToMatch, isForceOverwrite) => {
+          if (
+            targetPath === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE &&
+            isFirstPrimaryUpload
+          ) {
+            isFirstPrimaryUpload = false;
+            throw new UploadRevToMatchMismatchAPIError('Rev changed during upload');
+          }
+          return realUploadFile(targetPath, dataStr, revToMatch, isForceOverwrite);
+        },
       );
 
       // Client B uploads - should handle the retry internally

--- a/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
@@ -83,6 +83,15 @@ describe('File-Based Sync Integration - Edge Cases', () => {
       expect(response.results).toEqual([]);
       expect(response.latestSeq).toBeGreaterThanOrEqual(0);
     });
+
+    it('should reject create-if-absent when the target already exists', async () => {
+      const provider = harness.getProvider();
+      provider.setFileContent(FILE_BASED_SYNC_CONSTANTS.OPS_FILE, 'winner');
+
+      await expectAsync(
+        provider.uploadFile(FILE_BASED_SYNC_CONSTANTS.OPS_FILE, 'loser', null, false),
+      ).toBeRejectedWith(jasmine.any(UploadRevToMatchMismatchAPIError));
+    });
   });
 
   describe('Provider Error Handling', () => {

--- a/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
@@ -478,9 +478,11 @@ describe('File-Based Sync Integration - Sync Cycle Cache', () => {
     // Client B downloads (caches the data)
     await clientB.downloadOps(0);
 
-    // Get download call count
-    const downloadCallsAfterDownload = provider.getCallsTo('downloadFile').length;
-    expect(downloadCallsAfterDownload).toBe(1);
+    const primaryDownloads = (): number =>
+      provider
+        .getCallsTo('downloadFile')
+        .filter(({ args }) => args[0] === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE).length;
+    expect(primaryDownloads()).toBe(1);
 
     // Client B immediately uploads (should use cached data)
     const opB = clientB.createOp('Task', 'task-b', 'CRT', 'TaskActionTypes.ADD_TASK', {
@@ -488,9 +490,14 @@ describe('File-Based Sync Integration - Sync Cycle Cache', () => {
     });
     await clientB.uploadOps([opB]);
 
-    // Should not have made another download call (cache was used)
-    const totalDownloadCalls = provider.getCallsTo('downloadFile').length;
-    expect(totalDownloadCalls).toBe(1); // Same as before, cache was used
+    // The source-of-truth file remains cached. The upload does inspect the
+    // recovery artifact so a stale writer cannot roll a newer backup backward.
+    expect(primaryDownloads()).toBe(1);
+    expect(
+      provider
+        .getCallsTo('downloadFile')
+        .filter(({ args }) => args[0] === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE),
+    ).toHaveSize(1);
   });
 
   it('should invalidate cache after upload', async () => {
@@ -518,8 +525,13 @@ describe('File-Based Sync Integration - Sync Cycle Cache', () => {
     // Client B downloads again (should fetch fresh, not use stale cache)
     await clientB.downloadOps(0);
 
-    // Should have made a new download call
-    expect(provider.getCallsTo('downloadFile').length).toBe(1);
+    // Should have fetched the primary again. The crash-recovery transaction
+    // marker is a separate lightweight probe and does not satisfy this check.
+    expect(
+      provider
+        .getCallsTo('downloadFile')
+        .filter(({ args }) => args[0] === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE),
+    ).toHaveSize(1);
   });
 });
 

--- a/src/app/op-log/testing/integration/helpers/mock-file-provider.helper.ts
+++ b/src/app/op-log/testing/integration/helpers/mock-file-provider.helper.ts
@@ -168,17 +168,22 @@ export class MockFileProvider implements FileSyncProvider<SyncProviderId> {
 
     const existingFile = this._files.get(targetPath);
 
-    // Check revision match (conditional upload) unless force overwrite
-    if (!isForceOverwrite && revToMatch !== null) {
-      if (!existingFile) {
-        // File doesn't exist but revToMatch was provided - mismatch
+    // Enforce the same conditional contract as real providers: null creates
+    // only when absent; a concrete revision replaces only that exact version.
+    if (!isForceOverwrite) {
+      if (revToMatch === null && existingFile) {
+        throw new UploadRevToMatchMismatchAPIError(
+          `File ${targetPath} already exists but create-if-absent was requested`,
+        );
+      }
+      if (revToMatch !== null && !existingFile) {
         throw new UploadRevToMatchMismatchAPIError(
           `File ${targetPath} does not exist but revToMatch was provided`,
         );
       }
-      if (existingFile.rev !== revToMatch) {
+      if (revToMatch !== null && existingFile?.rev !== revToMatch) {
         throw new UploadRevToMatchMismatchAPIError(
-          `Rev mismatch for ${targetPath}: expected ${revToMatch}, found ${existingFile.rev}`,
+          `Rev mismatch for ${targetPath}: expected ${revToMatch}, found ${existingFile?.rev ?? 'missing'}`,
         );
       }
     }

--- a/src/app/op-log/testing/integration/post-sync-validation.integration.spec.ts
+++ b/src/app/op-log/testing/integration/post-sync-validation.integration.spec.ts
@@ -186,12 +186,18 @@ describe('Post-sync validation latch (#7330) — integration', () => {
         'markRejected',
         'saveStateCache',
         'setVectorClock',
+        'commitFileSnapshotBaseline',
         'append',
         'loadStateCache',
       ]);
       opLogStoreHydrationSpy.getLastSeq.and.resolveTo(0);
       opLogStoreHydrationSpy.getUnsynced.and.resolveTo([]);
       opLogStoreHydrationSpy.loadStateCache.and.resolveTo(null);
+      opLogStoreHydrationSpy.commitFileSnapshotBaseline.and.resolveTo({
+        seqs: [],
+        writtenOps: [],
+        skippedCount: 0,
+      });
       const stateSnapshotSpy = jasmine.createSpyObj('StateSnapshotService', [
         'getStateSnapshot',
         'getAllSyncModelDataFromStoreAsync',

--- a/src/app/op-log/testing/integration/round-time-conflict-convergence.integration.spec.ts
+++ b/src/app/op-log/testing/integration/round-time-conflict-convergence.integration.spec.ts
@@ -16,6 +16,7 @@ import { Operation } from '../../core/operation.types';
 import { convertOpToAction } from '../../apply/operation-converter.util';
 import { roundTimeSpentForDay } from '../../../features/tasks/store/task.actions';
 import { taskReducer } from '../../../features/tasks/store/task.reducer';
+import { selectTaskById } from '../../../features/tasks/store/task.selectors';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { Task } from '../../../features/tasks/task.model';
 import { TASK_FEATURE_NAME } from '../../../features/tasks/store/task.reducer';
@@ -99,6 +100,10 @@ describe('round-time conflict convergence integration (#8944)', () => {
   };
 
   beforeEach(async () => {
+    // MockStore.overrideSelector() mutates the shared selector singleton. This
+    // integration invokes the real selector directly, so clear any result left
+    // by another spec in the same randomized Karma bundle.
+    selectTaskById.clearResult();
     resetTestUuidCounter();
 
     initialState = createStateWithExistingTasks([TASK_X, TASK_Y]);
@@ -196,6 +201,7 @@ describe('round-time conflict convergence integration (#8944)', () => {
   });
 
   afterEach(async () => {
+    selectTaskById.clearResult();
     await opLogStore._clearAllDataForTesting();
     await journal.clearAll();
     TestBed.resetTestingModule();

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1480,7 +1480,7 @@
         "L_MANUAL_SYNC_ONLY": "Only sync manually (disable automatic sync)",
         "L_SYNC_INTERVAL": "Sync interval",
         "L_SYNC_PROVIDER": "Sync provider",
-        "L_USE_SPLIT_SYNC_FILES": "Surgical sync (experimental) – Faster syncing using a split ops/snapshot file layout. Once enabled, all devices syncing this folder must also enable it.",
+        "L_USE_SPLIT_SYNC_FILES": "Surgical sync (experimental) – Faster syncing using a split ops/snapshot file layout. Before enabling it, stop sync on every other device. Then enable it on every device using this folder before resuming sync.",
         "LOCAL_FILE": {
           "INFO_TEXT": "<strong>Warning:</strong> Do <strong>not</strong> use file syncing tools like Syncthing, Resilio, or similar to sync this folder between devices — they <strong>will</strong> cause data corruption and conflicts. For multi-device sync, use SuperSync, Nextcloud, or Dropbox instead.",
           "L_SYNC_FILE_PATH_PERMISSION_VALIDATION": "Needs file access permission",


### PR DESCRIPTION
**Stacked on #9004** (the focused #8960 four-defect fix). Review #9004 first; this PR's base will retarget to master once #9004 merges.

This is the **orthogonal crash/corruption-hardening layer** that accumulated on the original `feat/issue-8960-5a4217` working branch. It is **not required to fix any of the four #8960 defects** — those are all in #9004. It's split out here so it can be evaluated on its own merits (or landed incrementally / deferred) rather than riding along under a bug fix.

## What's in here

- **Snapshot two-phase-commit subsystem** — wraps every *authoritative* snapshot force-write ("Use Local", E2EE re-encryption, force-upload, split-snapshot) in a durable pending→complete marker so a crash mid-write can be resumed/aborted and a later ordinary upload can't misread non-monotonic snapshot clocks. (~1,000 lines; the largest piece, and the one still settling — the recovery-call ordering was reworked twice during development.)
- **Structural-validation layer** — rejects parses-as-JSON-but-wrong-shape remote/`.bak` files (envelope / vector-clock / op type-guards).
- **Concurrent-hydration handling** — buffers local actions dispatched *during* async snapshot hydration and replays them onto the new baseline (`_hydrateSnapshotExclusive`, atomic `commitFileSnapshotBaseline`).
- **Split-migration crash-resume scaffolding**, `.bak` self-heal, backup-digest tracking, persisted unresolved-gap tracking.

## Scope notes / caveats

- **Not blocking for #8960.** These protect failure modes orthogonal to the four filed defects.
- **Excludes the #8941 archive serialization.** That work (`TASK_ARCHIVE` locks around archive read-modify-write) is entangled with newer `master` and belongs to #8941 — it will be rebased fresh on master as its own PR. One harmless remnant remains here: `cfac`'s hydration-side `TASK_ARCHIVE` lock (a no-op until the #8941 writer locks land) is kept, because separating it from `cfac`'s legitimate hydration-ordering change would need hunk surgery.
- Faithful reconstruction of the original branch's hardening commits, re-based onto current master (verified: adapter / hydration / sync-service byte-identical to the original branch; one cosmetic `no-shadow` merge artifact fixed).

## Verification

- ✅ eslint clean on all changed production files.
- ⚠️ Full unit (Karma) + SuperSync e2e suites not yet run locally (sandbox constraints) — relying on CI. Given the size and that this touches the highest-risk subsystem, wants a careful review + green CI before merge.
