### PR TITLE
fix(sync): serialize archive read-modify-write vs remote replacement (#8941)

### DIFF
--- a/docs/plans/2026-07-14-ios-testflight-master-builds.md
+++ b/docs/plans/2026-07-14-ios-testflight-master-builds.md
@@ -1,0 +1,206 @@
+# Implementation plan: Internal TestFlight builds from `master`
+
+**Status:** Plan only · **Date:** 2026-07-14
+**Difficulty:** Moderate. Allow about one engineering day split across two small
+changes, plus Apple processing and tester verification time.
+
+## Outcome and scope
+
+Use the existing iOS signing/archive workflow to send the newest eligible `master`
+state to an internal TestFlight group. Rapid pushes are coalesced: one beta may run
+and only the newest superseding beta waits. This intentionally does not produce one
+TestFlight build for every intermediate SHA.
+
+Production behavior stays event-based: final `v*` tag pushes submit the existing iOS
+release for review, prerelease tag pushes remain upload-only, and manual dispatch can
+never submit to production. Master builds are marked **TestFlight Internal Only**, so
+Apple cannot offer them to external testers or customers.
+
+Out of scope: external TestFlight, app changes, new dependencies, and the existing
+iOS/macOS App Store review-submission race. There is no new app-wide upload queue;
+the internal-only beta path neither edits App Store metadata nor opens a review.
+
+## Routing contract
+
+| Event                                  | Export                   | Fastlane lane | Production submit |
+| -------------------------------------- | ------------------------ | ------------- | ----------------- |
+| Push to `master`                       | TestFlight Internal Only | `ios beta`    | Never             |
+| Push of final `v*` tag                 | App Store Connect        | `ios release` | Yes               |
+| Push of prerelease `v*` tag            | App Store Connect        | `ios release` | No                |
+| Manual dispatch, default `beta` mode   | TestFlight Internal Only | `ios beta`    | Never             |
+| Manual dispatch, `release-upload-only` | App Store Connect        | `ios release` | Never             |
+
+The production guard must include the event type, not only the ref:
+
+```yaml
+SUBMIT_FOR_REVIEW: >-
+  ${{ github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !contains(github.ref, '-') }}
+```
+
+Manual beta dispatch is allowed only from `master`. The explicit
+`release-upload-only` mode preserves the workflow's current manual upload capability
+without inheriting its final-tag submission footgun.
+
+## Phase 0: Apple and version prerequisites
+
+- Create one internal tester group, add the intended App Store Connect users, and
+  enable automatic distribution. Accept that eligible tag uploads will also reach
+  this group because automatic distribution is app/group configuration, not
+  Git-ref-aware.
+- Create a dedicated App Store Connect **team** API key with the Developer role for
+  beta uploads. Store it as `ASC_*` secrets in an `internal-testflight` GitHub
+  environment restricted to `master`, with no reviewer gate. A team key cannot be
+  app-scoped; the separate lower-role key reduces privilege and credential reuse but
+  still has team-wide upload access.
+- Keep the existing App Manager key on the release route. Record secret names, roles,
+  and certificate/profile expiry only—never key or tester content.
+- On the pinned Xcode 26.2 runner, confirm `xcodebuild -help` supports the
+  `testFlightInternalTestingOnly` export option and that the current provisioning
+  profile can export that distribution type.
+- Validate the build-number examples below with `agvtool`, the archived IPA, and
+  Apple before enabling unattended builds.
+
+## Increment A: Add a safe manual beta path
+
+Do not add the `master` push trigger yet.
+
+### Fastlane
+
+Add `ios beta` to `fastlane/Fastfile`. It requires `IPA_PATH` and the existing
+`ASC_*` contract, calls `upload_to_testflight`, and sets these options explicitly:
+
+```ruby
+skip_submission: true
+skip_waiting_for_build_processing: false
+distribute_external: false
+submit_beta_review: false
+wait_processing_timeout_duration: 1800
+```
+
+Do not pass tester groups, changelog, or notification options. App Store Connect's
+automatic group owns internal distribution. A processing timeout means “upload
+succeeded, processing unknown”; inspect App Store Connect before retrying. Never
+re-upload the same IPA blindly.
+
+### Workflow and versioning
+
+Refactor `.github/workflows/build-ios.yml` into one build job and conditional beta
+and release upload jobs:
+
+- Add `workflow_dispatch.mode` with `beta` as the safe default and
+  `release-upload-only` as the other choice.
+- Set top-level `permissions: contents: read`.
+- Export beta runs with `testFlightInternalTestingOnly: true`; tag and manual release
+  uploads keep the current App Store Connect export.
+- Preserve the exact stripped `package.json` marketing version on release routes.
+- For betas, set `CFBundleShortVersionString` to
+  `incrementPatch(max(stripPrerelease(package.version), highest stable vX.Y.Z tag))`.
+  Fetch tags and implement the strict three-integer comparison without a dependency.
+  This future train must be greater than the latest approved iOS version, including
+  immediately after a release.
+- Set `CFBundleVersion` exactly to
+  `$(date -u +%Y%m%d%H%M).${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}` on every route.
+  This remains above the old timestamp values and separates same-minute runs and
+  reruns.
+- Verify both values in every relevant target and in the exported IPA. Also confirm
+  whether `VERSIONING_SYSTEM = apple-generic` must be added for reliable `agvtool`
+  behavior.
+- Move certificate/profile installation to immediately before export; the archive is
+  already unsigned. Reuse of the shared Apple Distribution certificate remains an
+  accepted residual risk on every master build.
+- Pass exactly one IPA between jobs using pinned artifact actions, a run/attempt-
+  specific name, `if-no-files-found: error`, a clean download directory, and one-day
+  retention for beta artifacts. The upload jobs must fail unless exactly one regular
+  `.ipa` exists.
+- Bind only the beta upload job to `internal-testflight`; keep release credentials on
+  the existing release path. Never enable verbose fastlane output.
+
+Add workflow-level concurrency for the complete beta build/upload lifecycle: beta
+runs share a fixed group with `cancel-in-progress: false` and `queue: single`, keeping
+the running run and only the newest pending run. Tag and manual release runs use a
+run/attempt-specific group, so a master push cannot coalesce them.
+
+### Static verification
+
+- `ruby -c fastlane/Fastfile`
+- `bundle exec fastlane lanes` on the macOS runner
+- `npx prettier --check .github/workflows/build-ios.yml`
+- `git diff --check`
+- Exercise the version calculation with an old timestamp build, two same-minute
+  runs, a rerun, prerelease package versions, and a stable tag newer than the package.
+- Review every routing-table case and confirm the `master` push trigger is absent.
+- Confirm no dependency or secret content was added.
+
+## Live gate between increments
+
+Merge Increment A, then manually dispatch `beta` from `master` once. Do not proceed
+until all of the following are true:
+
+- Apple accepts and finishes processing the expected version/build pair.
+- App Store Connect shows the **Internal** indicator and does not allow external or
+  customer distribution.
+- The automatic internal group receives it and one tester can install and launch it.
+- No external Beta App Review, App Review submission, App Store version, or release
+  metadata is created or changed.
+- Logs and artifacts expose no signing or API-key material.
+
+Record only the Actions URL, non-sensitive version/build pair, duration, and result.
+
+## Increment B: Enable `master` and document operations
+
+Add the branch trigger while retaining the existing tag trigger:
+
+```yaml
+push:
+  branches: [master]
+  tags: ['v*']
+```
+
+Update `docs/build-and-publish-notes.md`, `docs/apple-release-automation.md`, and
+`.github/SECURITY-SETUP.md` with the routing table, internal-only boundary,
+credentials, version/build formulas, coalescing, timeout recovery, and rollback.
+
+After merge, confirm one normal `master` push uploads successfully. Start three beta
+dispatches close together and verify the active run completes, the middle pending
+run is superseded, and the newest pending run proceeds. A failed Apple
+upload/processing result must leave Actions red.
+
+The next tagged release is a follow-up observation, not an activation blocker:
+
+- verify the release lane and submission behavior are unchanged;
+- expect the automatic internal group to receive the eligible release build; and
+- after it reaches Ready for Distribution, verify the next master beta advances to
+  the following patch train and Apple accepts it.
+
+## Cost, rollback, and risks
+
+Each beta that survives coalescing consumes roughly 10–15 macOS runner minutes plus
+one signed IPA upload. Track `accepted beta runs × duration` and artifact storage for
+the first week. Keep one-day beta artifact retention; consider a proven-safe
+docs-only path filter later only if cost/noise is material.
+
+Rollback is to remove the `master` branch trigger while retaining manual beta mode.
+If a distributed build must stop, use App Store Connect **Expire Build**; disabling
+automatic group distribution affects future assignment but does not retract an
+installed build. Keep the new version/build scheme after Apple has accepted it.
+
+| Risk                                                  | Mitigation                                                                                  |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Beta reaches external testing or production           | Internal-only export plus fail-closed beta lane                                             |
+| Post-release betas are rejected as an old version     | Future patch train based on package and stable tags; mandatory post-release check           |
+| Rapid pushes create cost and TestFlight noise         | Workflow-wide beta coalescing and one-day artifacts                                         |
+| Manual/tag routing submits the wrong build            | Explicit modes, event-type production guard, routing-table review                           |
+| Production credentials gain exposure                  | Dedicated Developer beta key; release key stays on release job; protected master/CODEOWNERS |
+| Signing identity gains exposure on every master build | Install only at export, restrict workflow changes, accept and document certificate reuse    |
+| Apple processing times out after upload               | Inspect App Store Connect first; rebuild with a new number only when retry is required      |
+
+## References to recheck when implementing
+
+- [Apple: Distributing beta builds](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases)
+- [Apple: Internal testers and internal-only builds](https://developer.apple.com/help/app-store-connect/test-a-beta-version/add-internal-testers)
+- [Apple: Build/version identifiers](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleversion)
+- [Apple: Marketing-version identifiers](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleshortversionstring)
+- [fastlane: `upload_to_testflight`](https://docs.fastlane.tools/actions/upload_to_testflight/)
+- [GitHub Actions: concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)

--- a/docs/plans/2026-07-14-microsoft-365-calendar-provider.md
+++ b/docs/plans/2026-07-14-microsoft-365-calendar-provider.md
@@ -1,0 +1,703 @@
+# Microsoft 365 Calendar provider (Outlook without an iCal URL)
+
+Status: **proposed, revised after repository audit and adversarial Codex review** ·
+2026-07-14
+
+## Decision summary
+
+This is feasible, but it is not a mechanical rename of the Google Calendar plugin.
+Microsoft Graph event mapping is the easy half. The harder half is operating a
+multitenant Microsoft Entra application reliably in university tenants and closing
+several generic plugin-host gaps around OAuth, polling, throttling, all-day dates, and
+device-local credentials.
+
+The smallest responsible product is a bundled, **read-only, Electron-only Microsoft
+365 Calendar provider for work/school accounts**. It should let a user authenticate
+without an iCal URL, select their own calendars, see events in Schedule/Planner,
+manually turn an event into a task, and open the original event in Outlook.
+
+Do not begin the production implementation until the Phase 0 tenant gate succeeds.
+Code cannot bypass a university's consent, Conditional Access, or enterprise-app
+policy.
+
+### Difficulty and estimate
+
+| Outcome                                                     |                                  Estimate | Confidence                        |
+| ----------------------------------------------------------- | ----------------------------------------: | --------------------------------- |
+| Disposable Graph/tenant feasibility spike                   |                      1–2 engineering days | Medium; tenant policy is external |
+| Production Electron MVP, including host hardening and tests | 17–26 additional focused engineering days | Medium                            |
+| Total engineering effort                                    |          About 4–6 weeks for one engineer | Medium                            |
+| Microsoft publisher/admin approval                          |                              Not included | Unbounded external elapsed time   |
+
+A demo that only logs in and lists events could be built in a few days. Calling that
+production-ready would hide the main risks found in review: unsupported mobile flows
+currently start OAuth, all calendar providers can be polled at the fastest provider's
+cadence, linked tasks cause per-task Graph requests, refresh-token persistence is not
+transactional, and synced calendar IDs can meet credentials for a different local
+account.
+
+## User problem
+
+Some universities require Outlook/Microsoft 365 but disable calendar publication, so
+the existing URL-based iCal integration cannot be used. The requested workflow is
+personal planning, not team calendar management:
+
+1. Sign in with a university Microsoft 365 account.
+2. Select one or more personal calendars.
+3. See upcoming events beside tasks when planning a realistic day.
+4. Convert an event into a task when useful.
+5. Open the source event in Outlook.
+
+This fits Super Productivity's deep-work scope as an optional integration. It must be
+quiet by default, read-only, least-privilege, and safe when offline or disconnected.
+
+## What can be reused
+
+The repository already has most of the structural pieces:
+
+- `packages/plugin-dev/google-calendar-provider/` demonstrates a bundled OAuth
+  agenda provider, dynamic calendar selection, recurrence expansion through a remote
+  API, event-to-task mapping, and provider-local tests.
+- `src/app/plugins/oauth/` supplies authorization-code + PKCE flows, Electron
+  loopback callbacks, token refresh, and local IndexedDB token storage.
+- `packages/plugin-api/src/issue-provider-types.ts` already represents agenda events
+  with start, duration, all-day, due-time, and source URL fields.
+- `src/app/features/calendar-integration/` already combines plugin events with iCal
+  events and exposes task creation and source-link actions.
+- `packages/plugin-dev/scripts/build-all.js`, `src/app/plugins/plugin.service.ts`, and
+  `electron/bundled-plugin-ids.test.cjs` define the bundled-plugin build and reserved-ID
+  path.
+
+The provider should extend these building blocks. It should not introduce a second
+calendar framework, a Microsoft SDK, a backend token broker, or a new root dependency.
+
+## Corrections made during the double-check
+
+The initial outline was too optimistic in the following ways. These are requirements,
+not optional polish:
+
+- Missing mobile client IDs do **not** currently disable native OAuth. The host needs
+  an explicit additive platform-capability contract.
+- Agenda refresh currently uses the minimum interval across all calendar providers.
+  A one-minute Google provider can therefore make a five-minute Microsoft provider
+  call Graph every minute.
+- Agenda-view configurations hide the auto-poll setting while the default remains on.
+  Imported plugin-calendar tasks can consequently generate one `getById` request per
+  task on every issue-poll cycle.
+- `/me/calendars` can expose locally represented shared/delegated calendars. The MVP
+  must filter to calendars owned by the signed-in mailbox instead of merely hiding a
+  label in the UI.
+- Agenda loading and issue search are independent host paths. A claim of “local
+  search” requires an explicitly keyed provider cache and in-flight deduplication.
+- Refreshed token persistence must finish before a new access token is returned, and
+  a late refresh must not resurrect credentials after disconnect or overwrite a newer
+  login.
+- Transient refresh failures and terminal reauthentication failures need different
+  state transitions. A 429, timeout, offline error, or 5xx must not delete a usable
+  refresh token.
+- Microsoft requires clients to respect `Retry-After`. A small typed error extension
+  is preferable to blind sleeps or exposing every response header as a permanent
+  plugin API.
+- Calendar selection is synced, while OAuth credentials are local and keyed once per
+  plugin. The provider must detect calendar IDs from a different account and explain
+  that all configurations on one device share one Microsoft login.
+- An all-day event needs an explicit `dueDay` date string. Reconstructing it from a
+  UTC millisecond timestamp can shift it by a day when mailbox and device time zones
+  differ.
+- Event metadata is cached unencrypted in local storage. Authentication changes must
+  purge the affected provider's cache, while transient offline failures may retain it.
+- Plugin translations require `i18n.languages: ["en"]`, `i18n/en.json`, build copying,
+  and `PluginAPI.translate`; copying the current Google scaffold literally would miss
+  those requirements.
+
+## MVP scope
+
+### Included
+
+- Microsoft 365 work/school accounts in the global Microsoft cloud.
+- Super Productivity Electron builds on Windows, macOS, and Linux.
+- One Microsoft account per plugin per device.
+- Up to 10 calendars owned by the signed-in mailbox.
+- A fixed event window from 7 days before local today through 28 days after local
+  today.
+- Single events, recurring occurrences/exceptions, and multi-day/all-day events.
+- Schedule/Planner display, bounded title search over the provider cache, manual task
+  creation, and opening the Outlook web link.
+- Read-only delegated permission `Calendars.ReadBasic` plus `offline_access`.
+- Stale cached agenda data during transient offline/server failures, clearly
+  distinguishable from a reconnect-required state.
+
+### Explicitly excluded
+
+- Creating, editing, moving, completing, or deleting Outlook events.
+- Time-block write-back and Google feature parity.
+- Event bodies/notes, attachments, extensions, attendees, or meeting chat data.
+- Shared, delegated, group, room, or resource calendars.
+- Personal Outlook.com accounts, guest-only accounts, and national/sovereign clouds.
+- Web, Android, and iOS support.
+- Multiple Microsoft accounts on one device.
+- Automatic backlog import.
+- Automatic refresh of imported tasks. The task is a manually created planning
+  snapshot with a source link; this avoids an unbounded per-task Graph polling path.
+
+The exclusions should appear in the setup copy and documentation, not only in code
+comments.
+
+## Architecture
+
+```text
+Microsoft Entra authorization (system browser + PKCE)
+        |
+        v
+device-local OAuth token store (one account per plugin, never synced)
+        |
+        v
+Microsoft provider -> validated Graph client -> bounded in-memory event cache
+        |                                      |
+        |                                      +-> local title search / getById reuse
+        v
+existing issue-provider agenda contract
+        |
+        v
+calendar integration cache -> Schedule/Planner -> manual task snapshot
+```
+
+Provider configuration, including selected calendar IDs, remains part of synced issue
+provider state. Tokens and the provider's event cache remain device-local. On each
+device, the selected IDs must be reconciled against the calendars returned for that
+device's connected account before Graph event calls begin.
+
+## Fixed contracts and limits
+
+These values make “bounded” testable and avoid adding settings before a real workflow
+requires them:
+
+| Concern                      | MVP rule                                                                                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tenant endpoint              | `organizations` authorization/token endpoints                                                                                                                 |
+| Delegated scopes             | `offline_access https://graph.microsoft.com/Calendars.ReadBasic`                                                                                              |
+| Calendar ownership           | Compare each calendar owner to the default calendar's owner; if ownership is missing/ambiguous, expose only the default calendar and fail closed for the rest |
+| Selected calendars           | 1 required, 10 maximum                                                                                                                                        |
+| Event window                 | Local start-of-day −7 days through local start-of-day +28 days, sent as explicit-offset instants                                                              |
+| Graph page size              | `$top=100`                                                                                                                                                    |
+| Pagination                   | At most 5 pages per calendar and 2,000 mapped events total                                                                                                    |
+| Calendar request concurrency | 2                                                                                                                                                             |
+| Request timeout              | 30 seconds                                                                                                                                                    |
+| Agenda cadence               | 5 minutes per Microsoft provider; manual refresh may bypass the due time                                                                                      |
+| Overlap                      | One in-flight fetch per account/config cache key; later automatic ticks reuse it                                                                              |
+| Search                       | Case-insensitive title search, 50 results maximum, over the same bounded cache                                                                                |
+| Retry without `Retry-After`  | At most 2 retries using approximately 1 s and 2 s exponential delay plus jitter                                                                               |
+| Retry with `Retry-After`     | Do not retry before the supplied time; retry once only when the wait is at most 30 s, otherwise stop and retain stale data                                    |
+| Timed event identity         | Composite, reversible encoding of case-sensitive calendar ID + immutable event ID                                                                             |
+| All-day identity/date        | Preserve `YYYY-MM-DD` start and exclusive end dates separately from numeric schedule instants                                                                 |
+| Content limits               | Validate response shapes; cap IDs/URLs/titles to documented local constants before mapping                                                                    |
+
+If a cap is reached, fail that refresh with a safe localized “calendar result limit
+reached” error and keep the last complete provider snapshot. Do not silently replace a
+complete cache with a truncated one.
+
+### Failure semantics
+
+- **Offline, timeout, 429, or 5xx:** keep tokens and the last complete agenda cache;
+  retry only within the table's budget.
+- **One selected calendar returns 403/404:** fail the refresh and retain the last
+  complete snapshot; setup/test-connection identifies the inaccessible calendar and
+  requires reselection. This is intentionally all-or-nothing for the MVP because the
+  host cache is provider-wide, not per remote calendar.
+- **401:** force-refresh the access token once and retry the Graph request once. A
+  second 401, `invalid_grant`, `interaction_required`, or a claims challenge becomes
+  reconnect-required and purges the affected provider's cached event metadata.
+- **Malformed Graph data:** reject the malformed item. If rejected items or paging
+  limits make the result incomplete, reject the refresh and keep the prior complete
+  snapshot.
+- **No previous cache:** show no events and a localized actionable error; never invent
+  an empty successful result for an authentication or completeness failure.
+- **Account/config mismatch:** make no `calendarView` calls. Ask the user to reselect
+  calendars for the locally connected account.
+
+## External feasibility gate (Phase 0)
+
+This phase deliberately precedes repo implementation.
+
+1. Create a Super Productivity-owned, multitenant public-client Entra registration
+   limited to accounts in organizational directories. Do not add a client secret.
+2. Register the Electron loopback redirect
+   `http://127.0.0.1:<fixed-high-port>/<fixed-callback-path>` through the Entra
+   application manifest. Microsoft does not treat a literal `127.0.0.1` port as
+   interchangeable, so the exact URI matters.
+3. Configure only `Calendars.ReadBasic`; request `offline_access` in the OAuth flow.
+4. Record whether the project can satisfy Microsoft publisher-verification
+   prerequisites. Many education tenants restrict unverified multitenant apps even
+   when a delegated permission is normally user-consentable.
+5. Prove authorization, PKCE token exchange, refresh, `/me/calendars`, and one
+   `calendarView` call with:
+   - an ordinary Microsoft 365 tenant;
+   - a representative restrictive university tenant, ideally the reporting user's;
+   - consent denied and admin-approval-required paths.
+6. Verify the chosen fixed port on all three desktop OSes. Confirm that a port
+   collision produces a clear actionable failure rather than a timeout.
+7. Verify that Graph responses expose the fields required under
+   `Calendars.ReadBasic`: calendar owner/default flags, event subject/start/end,
+   `isAllDay`, cancellation/response status, immutable ID, and `webLink`.
+
+**Go:** at least one representative university user can consent, or the university has
+a realistic documented admin-approval route; the app registration can be operated and
+published by the project; all required fields are available at read-basic scope.
+
+**No-go:** representative tenants categorically block the app with no workable approval
+path, publisher requirements cannot be met, or required event/ownership fields demand
+a broader permission the project is unwilling to request. In that case, answer the
+user honestly; no client implementation can override the policy.
+
+The spike should leave a short evidence note with tenant type, requested scopes,
+redirect used, success/failure category, and redacted screenshots/errors. Never commit
+tokens, tenant IDs, user addresses, authorization codes, or client secrets.
+
+## Dependency order
+
+```text
+Phase 0 tenant gate
+  -> host OAuth safety
+  -> host HTTP/polling/calendar contracts
+  -> provider Graph slices
+  -> cross-tenant/manual verification
+  -> docs and pilot
+```
+
+Stop at each checkpoint if the preceding contract cannot be made reliable without a
+larger architectural change.
+
+## Ordered implementation tasks
+
+Each task is intentionally reviewable on its own. File lists are expected touch points,
+not permission to broaden the task.
+
+### 1. Add an explicit OAuth platform-capability contract
+
+**Depends on:** Phase 0 green.
+
+Add an optional, backward-compatible `supportedPlatforms` field to
+`OAuthFlowConfig`. Existing plugins that omit it keep current behavior; the Microsoft
+provider declares Electron only. Enforce the field before preparing a redirect server
+or opening a browser.
+
+Likely files:
+
+- `packages/plugin-api/src/types.ts`
+- `src/app/plugins/oauth/resolve-effective-oauth-config.util.ts`
+- `src/app/plugins/oauth/resolve-effective-oauth-config.util.spec.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts`
+
+Acceptance: web/native attempts fail before any OAuth side effect; Google behavior is
+unchanged. Verify with targeted specs and `npm run checkFile` for every changed TypeScript
+file. Estimate: 0.5 day.
+
+### 2. Make unsupported-platform UX generic
+
+**Depends on:** Task 1.
+
+Replace the web-only availability check in the provider dialog with the new platform
+contract and a localized desktop-only explanation.
+
+Likely files:
+
+- `src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts`
+- `src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.html`
+- `src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.spec.ts`
+- `src/assets/i18n/en.json`
+
+Acceptance: unsupported builds show a disabled connect action and never start OAuth;
+Electron remains connectable. Estimate: 0.5 day.
+
+### 3. Make token refresh an awaited, generation-guarded transaction
+
+**Depends on:** Task 1.
+
+Define internal refresh outcomes for success, transient failure, and terminal
+reauthentication. On success, replace a rotated refresh token (or retain the old one if
+none is returned), persist the full new token set, and only then return the access
+token. Increment a per-plugin generation on connect/disconnect; a late refresh from an
+older generation must be discarded and must not write to memory or IndexedDB. Deduplicate
+concurrent refreshes within the same generation.
+
+Expose an additive force-refresh option for the one-retry-on-401 path and emit a
+plugin-session-changed event after connect, disconnect, or terminal invalidation.
+Transient network/429/5xx errors retain credentials.
+
+Likely files:
+
+- `src/app/plugins/oauth/plugin-oauth.model.ts`
+- `src/app/plugins/oauth/plugin-oauth.service.ts`
+- `src/app/plugins/oauth/plugin-oauth.service.spec.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts`
+
+Acceptance: tests cover rotation, no rotation, persistence failure, refresh
+deduplication, disconnect during refresh, reconnect/account switch during refresh,
+restart restoration, transient failure, terminal failure, and forced refresh. No token
+or response body is logged. Estimate: 2–3 days.
+
+### 4. Harden the Electron loopback callback
+
+**Depends on:** Phase 0's exact redirect.
+
+At `PLUGIN_OAUTH_START`, extract the expected state and callback path from the validated
+authorization URL. The loopback server must ignore unrelated paths and wrong-state
+requests without marking the flow handled or closing. Close only after a matching
+callback, timeout, explicit cancellation, or startup error. Keep the existing clear
+`EADDRINUSE` error for the fixed port.
+
+Likely files:
+
+- `electron/plugin-oauth.ts`
+- a small pure callback-validation helper and focused test beside it
+
+Acceptance: wrong path/state cannot consume the real callback; correct error and code
+callbacks complete once; collision and timeout clean up. Estimate: 0.5–1 day.
+
+### 5. Add a narrow typed plugin HTTP error contract
+
+**Depends on:** none after Phase 0; land before Graph retry logic.
+
+Add an optional typed error shape containing only normalized `status`,
+`retryAfterMs`, and a stable error category. Parse both seconds and HTTP-date forms of
+`Retry-After`. Do not expose arbitrary headers and do not change successful response
+shapes. Keep the addition backward-compatible for existing plugins.
+
+Likely files:
+
+- `packages/plugin-api/src/issue-provider-types.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider.model.ts`
+- `src/app/plugins/issue-provider/plugin-http.service.ts`
+- `src/app/plugins/issue-provider/plugin-http.service.spec.ts`
+
+Acceptance: Electron and supported native paths produce the same safe error fields for
+401/403/404/429/5xx/timeout; existing consumers still receive their expected data.
+Estimate: 1–1.5 days.
+
+### 6. Enforce per-provider agenda cadence and no overlap
+
+**Depends on:** none; required before enabling the provider.
+
+The combined calendar timer may continue waking at the smallest configured interval,
+but it must call only providers that are due. Track last attempt/success and an in-flight
+promise per provider ID. A manual refresh marks providers due; an automatic tick never
+starts a second request for a provider already in flight.
+
+Likely files:
+
+- `src/app/features/calendar-integration/calendar-integration.service.ts`
+- `src/app/features/calendar-integration/calendar-integration.service.spec.ts`
+
+Acceptance: with Google at one minute and Microsoft at five, Microsoft is called once
+per five minutes; slow requests never overlap; enable/disable and provider removal clear
+cadence state. Estimate: 1–1.5 days.
+
+### 7. Add a default-auto-poll capability for agenda providers
+
+**Depends on:** none; additive public contract.
+
+Add `defaultAutoPoll?: boolean` to the issue-provider manifest plumbing. Preserve the
+current default for existing plugins; Microsoft sets it to false. This prevents hidden
+agenda-view defaults from starting per-linked-task Graph polling.
+
+Likely contract/plumbing files:
+
+- `packages/plugin-api/src/issue-provider-types.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider.model.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider-registry.service.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider-registry.service.spec.ts`
+- `src/app/plugins/plugin-bridge.service.ts`
+
+Then apply it in the provider setup model and cover it in the dialog spec. Acceptance:
+new Microsoft configurations store `isAutoPoll: false`; Google and existing providers
+retain current defaults. Estimate: 0.5–1 day.
+
+### 8. Preserve date-only due dates and canonical URLs through the agenda contract
+
+**Depends on:** contract review checkpoint.
+
+Add optional `dueDay?: string` to `PluginSearchResult` and
+`CalendarIntegrationEvent`. Preserve `dueDay` and `url` when mapping plugin agenda
+results. Validate `dueDay` as `YYYY-MM-DD`; the issue adapter must prefer it over
+deriving a date from `start` milliseconds. Event opening prefers the canonical HTTPS
+URL and falls back to `getIssueLink`.
+
+Likely files, split into two small commits if needed:
+
+- `packages/plugin-api/src/issue-provider-types.ts`
+- `src/app/features/calendar-integration/calendar-integration.model.ts`
+- `src/app/features/calendar-integration/calendar-integration.service.ts` and spec
+- `src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts` and spec
+- `src/app/features/calendar-integration/calendar-event-actions.service.ts` and spec
+
+Acceptance: mailbox/device timezone differences never shift all-day task dates;
+canonical URL, fallback URL, malformed URL, and ordinary iCal behavior are covered.
+Estimate: 1–2 days.
+
+### 9. Purge only authentication-invalid calendar cache entries
+
+**Depends on:** Tasks 3 and 8.
+
+Consume the OAuth session-change event in calendar integration. Remove in-memory and
+local-storage entries belonging to provider configurations registered by that plugin
+on disconnect, account replacement, or terminal invalidation. Retain the last complete
+snapshot for transient offline/429/5xx failures.
+
+Likely files:
+
+- `src/app/features/calendar-integration/calendar-integration.service.ts`
+- `src/app/features/calendar-integration/calendar-integration.service.spec.ts`
+- OAuth event definitions/specs from Task 3 if not already complete
+
+Acceptance: old account titles/links are not visible after disconnect or reconnect;
+offline startup can still show the prior account's cache only while that same OAuth
+session remains valid. Estimate: 1 day.
+
+**Checkpoint A:** run all targeted OAuth, plugin HTTP, calendar integration, issue
+adapter, provider-dialog, and Google Calendar tests. Review every additive public type
+before starting the Microsoft package. If these changes need a breaking plugin API,
+stop and write an architecture decision instead.
+
+### 10. Scaffold the provider with real i18n
+
+**Depends on:** Checkpoint A.
+
+Create `packages/plugin-dev/microsoft-calendar-provider/` with the Google provider's
+Vitest/esbuild shape, but follow the current plugin i18n contract rather than copying
+Google's hard-coded labels.
+
+Required assets:
+
+- permanent manifest ID `microsoft-calendar-provider`;
+- `i18n.languages: ["en"]` and `i18n/en.json`;
+- a build script that copies manifest, icon, and English translations;
+- `PluginAPI.translate` for every user-facing provider string;
+- OAuth and HTTP permissions only; no node execution;
+- `useAgendaView: true`, five-minute agenda interval,
+  `defaultAutoAddToBacklog: false`, and `defaultAutoPoll: false`;
+- no web/mobile client IDs and `supportedPlatforms: ["electron"]`.
+
+Likely package/tooling files: `package.json`, `package-lock.json`, `tsconfig.json`,
+`vitest.config.ts`, and `scripts/build.js`. Keep runtime code dependency-free; scoped
+build/test packages mirror the existing plugin. Estimate: 1 day.
+
+### 11. Implement pure Graph boundary parsing and mapping
+
+**Depends on:** Task 10.
+
+Create small typed modules for config validation, Graph response validation, composite
+IDs, URL allowlisting, and date mapping. Treat every Graph response and `nextLink` as
+untrusted. Every bearer-authenticated absolute URL must be HTTPS with hostname exactly
+`graph.microsoft.com`; reject credentials, alternate ports, lookalike suffixes, and
+redirect-derived hosts.
+
+Mapping rules:
+
+- request `Prefer: IdType="ImmutableId"` on every event request;
+- use a reversible calendar-ID + event-ID composite key and preserve case;
+- filter cancelled events and, by calm default, events the user declined;
+- use a localized “Untitled event” fallback for an empty subject;
+- timed values become real instants using the supplied Graph timezone/offset;
+- all-day start/end retain date strings, with end exclusive; numeric schedule instants
+  are constructed from local date boundaries solely for display;
+- multi-day duration uses local date boundaries so 23/25-hour DST days still occupy the
+  correct calendar days;
+- accept only safe HTTPS Outlook `webLink` values.
+
+Acceptance: pure tests cover invalid shapes, oversized fields, hostile `nextLink`, ID
+case, recurrence instances/exceptions, missing titles, timed timezone offsets, mailbox
+timezone different from device timezone, travel, DST, and multi-day all-day events.
+Estimate: 2 days.
+
+### 12. Connect OAuth and load only owned calendars
+
+**Depends on:** Tasks 3, 4, 10, and 11.
+
+Configure authorization-code + PKCE against the `organizations` endpoints with the
+Phase 0 client ID and redirect. Load `/me/calendars` after connection. Establish the
+mailbox owner from the default calendar, filter calendars to the same normalized owner,
+and fail closed as specified when owner data is absent. Do not persist or log the owner
+address.
+
+The multi-select is required and capped at 10. Before saving/testing, reconcile synced
+selected IDs with the locally returned owned-calendar IDs. If none or only some match,
+show an account-mismatch/reselection error and make no event calls. Setup copy must say
+that disconnect/reconnect affects every Microsoft Calendar configuration on the device.
+
+Acceptance: ordinary own calendars appear; shared/delegated calendars do not; a config
+synced from the same account works; a config synced from a different account fails
+safely. Estimate: 1–1.5 days.
+
+### 13. Implement the bounded event fetch and provider cache
+
+**Depends on:** Tasks 5, 6, 11, and 12.
+
+Fetch each selected calendar's `calendarView` using the fixed window and numeric limits.
+Follow only validated `@odata.nextLink` values. Limit concurrency, enforce one in-flight
+promise per cache key, and implement the fixed failure/retry semantics above.
+
+Use a session-memory cache keyed by a one-way in-memory account-owner fingerprint plus
+the sorted selected calendar IDs and window. Never persist the fingerprint. Before the
+first agenda load, search may populate the same cache once; afterward `searchIssues`
+filters it locally. Clear it on connect, disconnect, selection change, or OAuth terminal
+invalidation.
+
+Acceptance: tests prove pagination caps, total-event cap, 429 with both Retry-After
+forms, long Retry-After abort, 5xx backoff, timeout, 401 force-refresh-once, terminal
+reconnect, no overlapping fetches, cache isolation, and all-or-nothing retention of the
+last complete snapshot. Estimate: 2–3 days.
+
+### 14. Register the read-only provider definition
+
+**Depends on:** Task 13.
+
+Implement the mandatory issue-provider methods:
+
+- `getHeaders` obtains the current OAuth access token;
+- `testConnection` validates account, selection, and one bounded Graph call;
+- `getNewIssuesForBacklog` returns the agenda window;
+- `searchIssues` searches the same cache, fetching once only if needed;
+- `getById` reuses a fresh cache entry or performs one bounded direct lookup;
+- `getIssueLink` uses a cached canonical link with a documented work/school fallback;
+- `issueDisplay` shows only non-sensitive basic fields.
+
+Do not register `createIssue`, `updateIssue`, `deleteIssue`, comments, time-block
+methods, or push field mappings. Do not include Graph event bodies in mapped objects.
+
+Acceptance: a static/spy test proves no write HTTP method or write provider hook exists;
+task creation gets title, `dueWithTime` or `dueDay`, duration/time estimate, and source
+link as appropriate. Estimate: 1–1.5 days.
+
+### 15. Bundle and reserve the permanent plugin ID
+
+**Depends on:** Tasks 10 and 14.
+
+Register build/copy and discovery atomically:
+
+- `packages/plugin-dev/scripts/build-all.js`
+- `src/app/plugins/plugin.service.ts`
+- `electron/bundled-plugin-ids.test.cjs` (verification; change only if the test itself
+  needs no new behavior)
+
+Acceptance: built assets include `manifest.json`, `plugin.js`, `icon.svg`, and
+`i18n/en.json`; the asset path and reserved manifest ID cannot drift. Estimate: 0.5 day.
+
+### 16. Document privacy, platform, and tenant limitations
+
+**Depends on:** working implementation.
+
+Update user documentation in the same feature PR:
+
+- `docs/wiki/3.07-Issue-Integration-Comparison.md`
+- `docs/wiki/4.24-Integrations.md`
+- `docs/wiki/3.05-Web-App-vs-Desktop.md`
+- `docs/wiki/3.06-User-Data.md`
+
+Document exact scopes, read-only behavior, Electron-only support, one local account,
+synced selection versus unsynced credentials, university admin approval, and storage:
+OAuth tokens in local-only IndexedDB plus basic event metadata/source URLs in the
+existing unencrypted calendar local-storage cache. State when each cache is retained or
+purged. Estimate: 0.5–1 day.
+
+### 17. End-to-end verification and pilot
+
+**Depends on:** all implementation tasks.
+
+Run:
+
+- `npm run checkFile <filepath>` for every changed `.ts` or `.scss` file;
+- targeted root specs for OAuth, plugin HTTP, calendar integration, provider dialog,
+  issue adapter, and Google Calendar regression;
+- Microsoft plugin `npm test`, `npm run typecheck`, and `npm run build`;
+- `node --test electron/bundled-plugin-ids.test.cjs`;
+- `npm run plugins:build` and a production build appropriate to the release branch.
+
+Manual matrix:
+
+- Windows, macOS, and Linux Electron;
+- ordinary tenant and representative university tenant;
+- first consent, denied consent, admin approval required, expired access token, rotated
+  refresh token, offline refresh, revoked grant, and reconnect to another account;
+- one and ten calendars, same-account synced config, different-account synced config;
+- timed, recurring, exception, cancelled, declined, all-day, multi-day, DST, and
+  mailbox/device timezone mismatch;
+- one-minute Google plus five-minute Microsoft cadence;
+- disconnect/account switch cache purge and offline stale-cache retention;
+- port collision and wrong-path/state loopback requests.
+
+Pilot with the reporting user before general release. A successful pilot means they can
+connect without an iCal URL, select their university calendars, plan from the agenda,
+create a task snapshot, and open the Outlook event without broader permissions.
+Estimate: 1.5–2 days plus user availability.
+
+## Security and privacy acceptance criteria
+
+- No client secret or tenant-specific identifier is committed.
+- Only `offline_access` and delegated `Calendars.ReadBasic` are requested.
+- Every OAuth flow uses PKCE and state; the loopback listener accepts only the expected
+  path/state on `127.0.0.1`.
+- Bearer tokens are sent only to exact HTTPS Microsoft Graph hosts.
+- Redirects and `nextLink` values cannot move a bearer request to another host.
+- Graph response values are shape/length validated at the boundary and rendered only
+  through normal escaped Angular/plugin form paths.
+- Logs contain only safe categories/status/counts and opaque internal provider IDs;
+  never tokens, codes, email addresses, tenant IDs, titles, bodies, event URLs, or raw
+  Graph error payloads.
+- OAuth credentials are local-only and never enter synced `pluginConfig`.
+- Event bodies, attendees, and attachments are neither requested nor cached.
+- Account replacement, disconnect, and terminal authentication failure purge affected
+  cached event metadata.
+- Automatic and manual request paths share concurrency, pagination, retry, and timeout
+  bounds.
+- No new root dependency is introduced.
+
+## Release criteria
+
+Ship only when all are true:
+
+- Phase 0 passed for a representative education tenant.
+- The Entra app registration has a named long-term owner and publisher-verification
+  decision.
+- Unsupported platforms cannot start OAuth.
+- Refresh rotation survives restart and cannot race disconnect/reconnect.
+- Microsoft calls remain on their own cadence even beside faster providers.
+- Imported tasks do not trigger automatic per-task Graph polling.
+- Shared/delegated calendars are absent from selection.
+- All-day dates remain stable across mailbox/device timezone differences.
+- Throttling honors Retry-After and all request/page/event limits are tested.
+- Cache retention/purge behavior is tested and documented.
+- Existing Google Calendar behavior remains green.
+- The university pilot succeeds without broader scopes.
+
+## Deferred follow-ups
+
+Consider these only after real demand and a separate design review:
+
+- Android/iOS support with dedicated Entra redirect/client configuration.
+- Web support, including the 24-hour SPA refresh-token lifetime and CORS/reauth design.
+- Outlook.com consumer accounts and sovereign-cloud endpoint sets.
+- Shared/delegated calendars with explicit permission and ownership UX.
+- Multiple accounts per device, which requires changing plugin-global OAuth storage.
+- Event write operations and time-block synchronization, which require
+  `Calendars.ReadWrite`, conflict semantics, and a much larger trust surface.
+- Delta queries or change notifications if measured Graph volume justifies the added
+  state and lifecycle complexity.
+
+## Official references checked
+
+- [Microsoft identity platform authorization-code flow with PKCE](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow)
+- [Redirect URI restrictions and loopback rules](https://learn.microsoft.com/en-us/entra/identity-platform/reply-url)
+- [Refresh-token replacement and lifetimes](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)
+- [`Calendars.ReadBasic` delegated permission](https://learn.microsoft.com/en-us/graph/permissions-reference#calendarsreadbasic)
+- [Tenant user-consent configuration](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent)
+- [Publisher verification](https://learn.microsoft.com/en-us/entra/identity-platform/publisher-verification-overview)
+- [List calendars](https://learn.microsoft.com/en-us/graph/api/user-list-calendars?view=graph-rest-1.0)
+- [Shared and delegated Outlook calendars](https://learn.microsoft.com/en-us/graph/outlook-get-shared-events-calendars)
+- [Calendar view and recurrence expansion](https://learn.microsoft.com/en-us/graph/api/calendar-list-calendarview?view=graph-rest-1.0)
+- [Outlook immutable IDs](https://learn.microsoft.com/en-us/graph/outlook-immutable-id)
+- [Microsoft Graph event resource and `webLink`](https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0)
+- [Get an event](https://learn.microsoft.com/en-us/graph/api/event-get?view=graph-rest-1.0)
+- [Microsoft Graph throttling and Retry-After](https://learn.microsoft.com/en-us/graph/throttling)
+- [Claims challenges and Conditional Access](https://learn.microsoft.com/en-us/entra/identity-platform/claims-challenge)

--- a/src/app/features/archive/archive-compression.service.spec.ts
+++ b/src/app/features/archive/archive-compression.service.spec.ts
@@ -30,7 +30,9 @@ describe('ArchiveCompressionService', () => {
     archiveDbAdapterMock.saveArchiveOld.and.resolveTo(undefined);
     archiveDbAdapterMock.saveArchivesAtomic.and.resolveTo(undefined);
     lockServiceMock = jasmine.createSpyObj<LockService>('LockService', ['request']);
-    lockServiceMock.request.and.callFake(async (_name, callback) => callback());
+    lockServiceMock.request.and.callFake(
+      <T>(_lockName: string, callback: () => Promise<T>): Promise<T> => callback(),
+    );
 
     TestBed.configureTestingModule({
       providers: [

--- a/src/app/features/archive/task-archive.service.ts
+++ b/src/app/features/archive/task-archive.service.ts
@@ -118,10 +118,9 @@ export class TaskArchiveService {
    * mutex; a bypassed remote mutation could interleave with a locked local one
    * and silently drop one side's archive write.
    *
-   * Known paths still OUTSIDE the lock (tracked in #8941):
-   * TimeTrackingService's project/tag archive cleanups. Compression and remote
-   * full-state archive replacement use the same lock for their complete
-   * read-modify-write cycles.
+   * ArchiveCompressionService, TimeTrackingService, snapshot hydration/import,
+   * remote full-state replay, and authoritative op-log state replacements use
+   * the same mutex.
    */
   private _runTaskArchiveMutation(mutation: () => Promise<void>): Promise<void> {
     return this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, mutation);

--- a/src/app/features/time-tracking/time-tracking.service.spec.ts
+++ b/src/app/features/time-tracking/time-tracking.service.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { of } from 'rxjs';
+import { ArchiveDbAdapter } from '../../core/persistence/archive-db-adapter.service';
+import { LOCK_NAMES } from '../../op-log/core/operation-log.const';
+import { LockService } from '../../op-log/sync/lock.service';
+import { ArchiveModel } from '../archive/archive.model';
+import { initialTimeTrackingState } from './store/time-tracking.reducer';
+import { TimeTrackingService } from './time-tracking.service';
+
+const archiveWithTimeTracking = (): ArchiveModel => ({
+  task: { ids: [], entities: {} },
+  timeTracking: {
+    project: { project1: {} },
+    tag: { tag1: {} },
+  },
+  lastTimeTrackingFlush: 0,
+});
+
+describe('TimeTrackingService archive cleanup', () => {
+  let service: TimeTrackingService;
+  let storeMock: jasmine.SpyObj<Store>;
+  let archiveDbAdapterMock: jasmine.SpyObj<ArchiveDbAdapter>;
+  let lockServiceMock: jasmine.SpyObj<LockService>;
+
+  beforeEach(() => {
+    storeMock = jasmine.createSpyObj<Store>('Store', ['select', 'dispatch']);
+    storeMock.select.and.returnValue(of(initialTimeTrackingState));
+    archiveDbAdapterMock = jasmine.createSpyObj<ArchiveDbAdapter>('ArchiveDbAdapter', [
+      'loadArchiveYoung',
+      'loadArchiveOld',
+      'saveArchiveYoung',
+      'saveArchiveOld',
+    ]);
+    archiveDbAdapterMock.loadArchiveYoung.and.callFake(async () =>
+      archiveWithTimeTracking(),
+    );
+    archiveDbAdapterMock.loadArchiveOld.and.callFake(async () =>
+      archiveWithTimeTracking(),
+    );
+    archiveDbAdapterMock.saveArchiveYoung.and.resolveTo(undefined);
+    archiveDbAdapterMock.saveArchiveOld.and.resolveTo(undefined);
+    lockServiceMock = jasmine.createSpyObj<LockService>('LockService', ['request']);
+    lockServiceMock.request.and.callFake(
+      <T>(_lockName: string, callback: () => Promise<T>): Promise<T> => callback(),
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        TimeTrackingService,
+        { provide: Store, useValue: storeMock },
+        { provide: ArchiveDbAdapter, useValue: archiveDbAdapterMock },
+        { provide: LockService, useValue: lockServiceMock },
+      ],
+    });
+    service = TestBed.inject(TimeTrackingService);
+  });
+
+  it('serializes project cleanup behind the archive mutex', async () => {
+    await service.cleanupDataEverywhereForProject('project1');
+
+    expect(lockServiceMock.request).toHaveBeenCalledOnceWith(
+      LOCK_NAMES.TASK_ARCHIVE,
+      jasmine.any(Function),
+    );
+    expect(archiveDbAdapterMock.saveArchiveYoung).toHaveBeenCalled();
+    expect(archiveDbAdapterMock.saveArchiveOld).toHaveBeenCalled();
+  });
+
+  it('serializes tag cleanup behind the archive mutex', async () => {
+    await service.cleanupArchiveDataForTag('tag1');
+
+    expect(lockServiceMock.request).toHaveBeenCalledOnceWith(
+      LOCK_NAMES.TASK_ARCHIVE,
+      jasmine.any(Function),
+    );
+    expect(archiveDbAdapterMock.saveArchiveYoung).toHaveBeenCalled();
+    expect(archiveDbAdapterMock.saveArchiveOld).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/time-tracking/time-tracking.service.ts
+++ b/src/app/features/time-tracking/time-tracking.service.ts
@@ -10,8 +10,9 @@ import { WorkContextType, WorkStartEnd } from '../work-context/work-context.mode
 import { ImpossibleError } from '../../op-log/sync-exports';
 import { toLegacyWorkStartEndMaps } from './to-legacy-work-start-end-maps';
 import { TimeTrackingActions } from './store/time-tracking.actions';
-import { Log } from '../../core/log';
 import { initialTimeTrackingState } from './store/time-tracking.reducer';
+import { LockService } from '../../op-log/sync/lock.service';
+import { LOCK_NAMES } from '../../op-log/core/operation-log.const';
 
 @Injectable({
   providedIn: 'root',
@@ -19,6 +20,7 @@ import { initialTimeTrackingState } from './store/time-tracking.reducer';
 export class TimeTrackingService {
   private _store = inject(Store);
   private _archiveDbAdapter = inject(ArchiveDbAdapter);
+  private _lockService = inject(LockService);
 
   private _archiveYoungUpdateTrigger$ = new Subject();
   private _archiveOldUpdateTrigger$ = new Subject();
@@ -72,35 +74,35 @@ export class TimeTrackingService {
   }
 
   async cleanupDataEverywhereForProject(projectId: string): Promise<void> {
-    const current = await firstValueFrom(this.current$);
-    const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
-    const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
+    await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, async () => {
+      const current = await firstValueFrom(this.current$);
+      const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
+      const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
 
-    Log.log({ current, archiveYoung, archiveOld });
+      if (projectId in current.project) {
+        const newProject = { ...current.project };
+        delete newProject[projectId];
+        this._store.dispatch(
+          TimeTrackingActions.updateWholeState({
+            newState: {
+              ...current,
+              project: { ...newProject },
+            },
+          }),
+        );
+      }
+      if (archiveYoung && projectId in archiveYoung.timeTracking.project) {
+        delete archiveYoung.timeTracking.project[projectId];
+        await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
+        this._archiveYoungUpdateTrigger$.next(undefined);
+      }
 
-    if (projectId in current.project) {
-      const newProject = { ...current.project };
-      delete newProject[projectId];
-      this._store.dispatch(
-        TimeTrackingActions.updateWholeState({
-          newState: {
-            ...current,
-            project: { ...newProject },
-          },
-        }),
-      );
-    }
-    if (archiveYoung && projectId in archiveYoung.timeTracking.project) {
-      delete archiveYoung.timeTracking.project[projectId];
-      await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
-      this._archiveYoungUpdateTrigger$.next(undefined);
-    }
-
-    if (archiveOld && projectId in archiveOld.timeTracking.project) {
-      delete archiveOld.timeTracking.project[projectId];
-      await this._archiveDbAdapter.saveArchiveOld(archiveOld);
-      this._archiveOldUpdateTrigger$.next(undefined);
-    }
+      if (archiveOld && projectId in archiveOld.timeTracking.project) {
+        delete archiveOld.timeTracking.project[projectId];
+        await this._archiveDbAdapter.saveArchiveOld(archiveOld);
+        this._archiveOldUpdateTrigger$.next(undefined);
+      }
+    });
   }
 
   /**
@@ -108,34 +110,36 @@ export class TimeTrackingService {
    * Current state cleanup is now handled atomically in tag-shared.reducer.ts.
    */
   async cleanupDataEverywhereForTag(tagId: string): Promise<void> {
-    const current = await firstValueFrom(this.current$);
-    const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
-    const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
+    await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, async () => {
+      const current = await firstValueFrom(this.current$);
+      const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
+      const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
 
-    if (tagId in current.tag) {
-      const newTag = { ...current.tag };
-      delete newTag[tagId];
-      this._store.dispatch(
-        TimeTrackingActions.updateWholeState({
-          newState: {
-            ...current,
-            tag: { ...newTag },
-          },
-        }),
-      );
-    }
+      if (tagId in current.tag) {
+        const newTag = { ...current.tag };
+        delete newTag[tagId];
+        this._store.dispatch(
+          TimeTrackingActions.updateWholeState({
+            newState: {
+              ...current,
+              tag: { ...newTag },
+            },
+          }),
+        );
+      }
 
-    if (archiveYoung && tagId in archiveYoung.timeTracking.tag) {
-      delete archiveYoung.timeTracking.tag[tagId];
-      await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
-      this._archiveYoungUpdateTrigger$.next(undefined);
-    }
+      if (archiveYoung && tagId in archiveYoung.timeTracking.tag) {
+        delete archiveYoung.timeTracking.tag[tagId];
+        await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
+        this._archiveYoungUpdateTrigger$.next(undefined);
+      }
 
-    if (archiveOld && tagId in archiveOld.timeTracking.tag) {
-      delete archiveOld.timeTracking.tag[tagId];
-      await this._archiveDbAdapter.saveArchiveOld(archiveOld);
-      this._archiveOldUpdateTrigger$.next(undefined);
-    }
+      if (archiveOld && tagId in archiveOld.timeTracking.tag) {
+        delete archiveOld.timeTracking.tag[tagId];
+        await this._archiveDbAdapter.saveArchiveOld(archiveOld);
+        this._archiveOldUpdateTrigger$.next(undefined);
+      }
+    });
   }
 
   /**
@@ -143,20 +147,22 @@ export class TimeTrackingService {
    * Current state cleanup is handled atomically in tag-shared.reducer.ts.
    */
   async cleanupArchiveDataForTag(tagId: string): Promise<void> {
-    const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
-    const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
+    await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, async () => {
+      const archiveYoung = await this._archiveDbAdapter.loadArchiveYoung();
+      const archiveOld = await this._archiveDbAdapter.loadArchiveOld();
 
-    if (archiveYoung && tagId in archiveYoung.timeTracking.tag) {
-      delete archiveYoung.timeTracking.tag[tagId];
-      await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
-      this._archiveYoungUpdateTrigger$.next(undefined);
-    }
+      if (archiveYoung && tagId in archiveYoung.timeTracking.tag) {
+        delete archiveYoung.timeTracking.tag[tagId];
+        await this._archiveDbAdapter.saveArchiveYoung(archiveYoung);
+        this._archiveYoungUpdateTrigger$.next(undefined);
+      }
 
-    if (archiveOld && tagId in archiveOld.timeTracking.tag) {
-      delete archiveOld.timeTracking.tag[tagId];
-      await this._archiveDbAdapter.saveArchiveOld(archiveOld);
-      this._archiveOldUpdateTrigger$.next(undefined);
-    }
+      if (archiveOld && tagId in archiveOld.timeTracking.tag) {
+        delete archiveOld.timeTracking.tag[tagId];
+        await this._archiveDbAdapter.saveArchiveOld(archiveOld);
+        this._archiveOldUpdateTrigger$.next(undefined);
+      }
+    });
   }
 
   async getWorkStartEndForWorkContext(ctx: {

--- a/src/app/op-log/apply/archive-operation-handler.service.spec.ts
+++ b/src/app/op-log/apply/archive-operation-handler.service.spec.ts
@@ -144,7 +144,9 @@ describe('ArchiveOperationHandler', () => {
       'cleanupArchiveDataForTag',
     ]);
     mockLockService = jasmine.createSpyObj('LockService', ['request']);
-    mockLockService.request.and.callFake(async (_lockName, callback) => callback());
+    mockLockService.request.and.callFake(
+      <T>(_lockName: string, callback: () => Promise<T>): Promise<T> => callback(),
+    );
     mockArchiveDbAdapter = jasmine.createSpyObj('ArchiveDbAdapter', [
       'loadArchiveYoung',
       'loadArchiveOld',
@@ -883,6 +885,10 @@ describe('ArchiveOperationHandler', () => {
           mockArchiveDbAdapter.saveArchivesAtomic.calls.mostRecent().args;
         expect(savedYoung).toBe(archiveYoungData);
         expect(savedOld.task.ids).toEqual([]);
+        expect(mockLockService.request).toHaveBeenCalledOnceWith(
+          LOCK_NAMES.TASK_ARCHIVE,
+          jasmine.any(Function),
+        );
       });
 
       it('should write archiveOld to IndexedDB for remote operations', async () => {
@@ -956,6 +962,7 @@ describe('ArchiveOperationHandler', () => {
 
         expect(mockArchiveDbAdapter.saveArchiveYoung).not.toHaveBeenCalled();
         expect(mockArchiveDbAdapter.saveArchiveOld).not.toHaveBeenCalled();
+        expect(mockLockService.request).not.toHaveBeenCalled();
         expect(mockArchiveDbAdapter.saveArchivesAtomic).not.toHaveBeenCalled();
       });
 
@@ -1236,6 +1243,10 @@ describe('ArchiveOperationHandler', () => {
             expect(mockArchiveDbAdapter.saveArchivesAtomic).toHaveBeenCalledOnceWith(
               emptyArchive,
               emptyArchive,
+            );
+            expect(mockLockService.request).toHaveBeenCalledOnceWith(
+              LOCK_NAMES.TASK_ARCHIVE,
+              jasmine.any(Function),
             );
           });
 

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -27,6 +27,7 @@ import {
   IDB_OPEN_RETRIES,
   IDB_OPEN_RETRIES_NON_LOCK,
   IDB_OPEN_RETRY_BASE_DELAY_MS,
+  LOCK_NAMES,
   MAX_VECTOR_CLOCK_SIZE,
 } from '../core/operation-log.const';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
@@ -37,10 +38,12 @@ import {
   STORE_NAMES,
 } from './db-keys.const';
 import { ArchiveModel } from '../../features/time-tracking/time-tracking.model';
+import { LockService } from '../sync/lock.service';
 
 describe('OperationLogStoreService', () => {
   let service: OperationLogStoreService;
   let vectorClockService: VectorClockService;
+  let lockService: LockService;
   const mockClientIdProvider: ClientIdProvider = {
     loadClientId: () => Promise.resolve('testClient'),
     getOrGenerateClientId: () => Promise.resolve('testClient'),
@@ -72,6 +75,7 @@ describe('OperationLogStoreService', () => {
     });
     service = TestBed.inject(OperationLogStoreService);
     vectorClockService = TestBed.inject(VectorClockService);
+    lockService = TestBed.inject(LockService);
     await service.init();
     // Clear all data from previous tests to ensure test isolation
     await service._clearAllDataForTesting();
@@ -2671,6 +2675,7 @@ describe('OperationLogStoreService', () => {
     it('should write archives in the same destructive replacement', async () => {
       const archiveYoung = createArchive('young-task');
       const archiveOld = createArchive('old-task');
+      const lockRequestSpy = spyOn(lockService, 'request').and.callThrough();
 
       await service.runDestructiveStateReplacement({
         syncImportOp: createTestOperation({
@@ -2689,6 +2694,10 @@ describe('OperationLogStoreService', () => {
       const oldEntry = await db.get(STORE_NAMES.ARCHIVE_OLD, SINGLETON_KEY);
       expect(youngEntry.data).toEqual(archiveYoung);
       expect(oldEntry.data).toEqual(archiveOld);
+      expect(lockRequestSpy).toHaveBeenCalledOnceWith(
+        LOCK_NAMES.TASK_ARCHIVE,
+        jasmine.any(Function),
+      );
     });
 
     it('should roll back ops, state_cache, vector_clock, and archives when an archive write fails', async () => {

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -44,6 +44,7 @@ import {
   IDB_OPEN_RETRIES,
   IDB_OPEN_RETRIES_NON_LOCK,
   IDB_OPEN_RETRY_BASE_DELAY_MS,
+  LOCK_NAMES,
 } from '../core/operation-log.const';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 import { limitVectorClockSize, vectorClockToString } from '../../core/util/vector-clock';
@@ -55,6 +56,7 @@ import {
   encodeOperation,
 } from './compact/operation-codec.service';
 import { uuidv7 } from '../../util/uuid-v7';
+import { LockService } from '../sync/lock.service';
 
 /**
  * Vector clock entry stored in the vector_clock object store.
@@ -322,6 +324,7 @@ type OpLogStoreName = (typeof STORE_NAMES)[keyof typeof STORE_NAMES];
 })
 export class OperationLogStoreService implements RemoteOperationApplyStorePort<Operation> {
   private clientIdProvider: ClientIdProvider = inject(CLIENT_ID_PROVIDER);
+  private readonly _lockService = inject(LockService);
   private _db?: IDBPDatabase<OpLogDB>;
   private _initPromise?: Promise<void>;
   // Phase A migration seam: methods migrated off direct `idb` route through
@@ -2003,77 +2006,79 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
 
     const now = Date.now();
     try {
-      await this._adapter.transaction(
-        [
-          STORE_NAMES.OPS,
-          STORE_NAMES.META,
-          STORE_NAMES.STATE_CACHE,
-          STORE_NAMES.VECTOR_CLOCK,
-          STORE_NAMES.ARCHIVE_YOUNG,
-          STORE_NAMES.ARCHIVE_OLD,
-          STORE_NAMES.IMPORT_BACKUP,
-        ],
-        'readwrite',
-        async (tx) => {
-          if (opts.backupRef) {
-            const currentBackup = await tx.get<{ backupId?: string }>(
-              STORE_NAMES.IMPORT_BACKUP,
+      await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, () =>
+        this._adapter.transaction(
+          [
+            STORE_NAMES.OPS,
+            STORE_NAMES.META,
+            STORE_NAMES.STATE_CACHE,
+            STORE_NAMES.VECTOR_CLOCK,
+            STORE_NAMES.ARCHIVE_YOUNG,
+            STORE_NAMES.ARCHIVE_OLD,
+            STORE_NAMES.IMPORT_BACKUP,
+          ],
+          'readwrite',
+          async (tx) => {
+            if (opts.backupRef) {
+              const currentBackup = await tx.get<{ backupId?: string }>(
+                STORE_NAMES.IMPORT_BACKUP,
+                SINGLETON_KEY,
+              );
+              if (currentBackup?.backupId !== opts.backupRef.backupId) {
+                throw new Error(
+                  'Pre-replace backup was superseded before remote replacement.',
+                );
+              }
+            }
+            await tx.clear(STORE_NAMES.OPS);
+            await tx.put(
+              STORE_NAMES.META,
+              buildFullStateOpsMeta([]),
+              FULL_STATE_OPS_META_KEY,
+            );
+            // Set atomically with the replacement; the caller clears it after
+            // the post-replacement replay commits. A crash in between leaves the
+            // marker set so the next sync redoes the raw rebuild instead of a
+            // normal download (which excludes this client's own ops).
+            await tx.put(
+              STORE_NAMES.META,
+              {
+                incomplete: true,
+                startedAt: now,
+                preservedLocalOps: opts.preservedLocalOps ?? [],
+                backupRef: opts.backupRef,
+              } satisfies RawRebuildIncompleteEntry,
+              RAW_REBUILD_INCOMPLETE_META_KEY,
+            );
+            // A new replacement supersedes any earlier completed-rebuild Undo.
+            // The new backup token becomes authoritative only on completion.
+            await tx.delete(STORE_NAMES.META, RAW_REBUILD_RECOVERY_META_KEY);
+            await tx.put(STORE_NAMES.STATE_CACHE, {
+              id: SINGLETON_KEY,
+              state: opts.baselineState,
+              lastAppliedOpSeq: 0,
+              vectorClock: opts.vectorClock,
+              compactedAt: now,
+              schemaVersion: opts.schemaVersion,
+              snapshotEntityKeys: opts.snapshotEntityKeys,
+            });
+            await tx.put(
+              STORE_NAMES.VECTOR_CLOCK,
+              { clock: opts.vectorClock, lastUpdate: now },
               SINGLETON_KEY,
             );
-            if (currentBackup?.backupId !== opts.backupRef.backupId) {
-              throw new Error(
-                'Pre-replace backup was superseded before remote replacement.',
-              );
-            }
-          }
-          await tx.clear(STORE_NAMES.OPS);
-          await tx.put(
-            STORE_NAMES.META,
-            buildFullStateOpsMeta([]),
-            FULL_STATE_OPS_META_KEY,
-          );
-          // Set atomically with the replacement; the caller clears it after
-          // the post-replacement replay commits. A crash in between leaves the
-          // marker set so the next sync redoes the raw rebuild instead of a
-          // normal download (which excludes this client's own ops).
-          await tx.put(
-            STORE_NAMES.META,
-            {
-              incomplete: true,
-              startedAt: now,
-              preservedLocalOps: opts.preservedLocalOps ?? [],
-              backupRef: opts.backupRef,
-            } satisfies RawRebuildIncompleteEntry,
-            RAW_REBUILD_INCOMPLETE_META_KEY,
-          );
-          // A new replacement supersedes any earlier completed-rebuild Undo.
-          // The new backup token becomes authoritative only on completion.
-          await tx.delete(STORE_NAMES.META, RAW_REBUILD_RECOVERY_META_KEY);
-          await tx.put(STORE_NAMES.STATE_CACHE, {
-            id: SINGLETON_KEY,
-            state: opts.baselineState,
-            lastAppliedOpSeq: 0,
-            vectorClock: opts.vectorClock,
-            compactedAt: now,
-            schemaVersion: opts.schemaVersion,
-            snapshotEntityKeys: opts.snapshotEntityKeys,
-          });
-          await tx.put(
-            STORE_NAMES.VECTOR_CLOCK,
-            { clock: opts.vectorClock, lastUpdate: now },
-            SINGLETON_KEY,
-          );
-          await tx.put(STORE_NAMES.ARCHIVE_YOUNG, {
-            id: SINGLETON_KEY,
-            data: opts.archiveYoung,
-            lastModified: now,
-          });
-          await tx.put(STORE_NAMES.ARCHIVE_OLD, {
-            id: SINGLETON_KEY,
-            data: opts.archiveOld,
-            lastModified: now,
-          });
-        },
+            await tx.put(STORE_NAMES.ARCHIVE_YOUNG, {
+              id: SINGLETON_KEY,
+              data: opts.archiveYoung,
+              lastModified: now,
+            });
+            await tx.put(STORE_NAMES.ARCHIVE_OLD, {
+              id: SINGLETON_KEY,
+              data: opts.archiveOld,
+              lastModified: now,
+            });
+          },
+        ),
       );
 
       this._invalidateAppliedAndUnsyncedCaches();
@@ -2560,76 +2565,80 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       // tests (#7709) spy on the shared connection's `transaction` and poison
       // `opsStore.add`; that still fires here because the adapter operates on
       // that same adopted connection.
-      await this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
-        if (opts.requiredImportBackupId !== undefined) {
-          const currentBackup = await tx.get<{ backupId?: string }>(
-            STORE_NAMES.IMPORT_BACKUP,
+      await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, () =>
+        this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
+          if (opts.requiredImportBackupId !== undefined) {
+            const currentBackup = await tx.get<{ backupId?: string }>(
+              STORE_NAMES.IMPORT_BACKUP,
+              SINGLETON_KEY,
+            );
+            if (currentBackup?.backupId !== opts.requiredImportBackupId) {
+              throw new Error(
+                'Recovery backup was superseded before destructive restore.',
+              );
+            }
+          }
+          // Rotate the clientId first, inside this same atomic transaction.
+          // Writing it before the OPS clear means an interrupt injected into a
+          // later step still aborts this queued put — exercising the genuine
+          // "queued -> tx aborts -> client_id unchanged" path. Atomicity itself
+          // is order-independent.
+          await tx.put(STORE_NAMES.CLIENT_ID, syncImportOp.clientId, SINGLETON_KEY);
+
+          await tx.clear(STORE_NAMES.OPS);
+
+          const seq = await tx.add(
+            STORE_NAMES.OPS,
+            this._buildStoredEntry(syncImportOp, 'local'),
+          );
+          // syncImportOp is always a full-state op (both callers pass SYNC_IMPORT);
+          // OPS was just cleared, so the pointer is exactly this one op. Use the
+          // shared builder so `latest` is derived, never hand-asserted.
+          await tx.put(
+            STORE_NAMES.META,
+            buildFullStateOpsMeta([{ opId: syncImportOp.id, seq }]),
+            FULL_STATE_OPS_META_KEY,
+          );
+
+          // This replacement supersedes any interrupted USE_REMOTE rebuild. Clear
+          // the marker in the same transaction as the restored/clean-slate
+          // baseline so a successful Undo cannot immediately re-enter recovery.
+          await tx.delete(STORE_NAMES.META, RAW_REBUILD_INCOMPLETE_META_KEY);
+          await tx.delete(STORE_NAMES.META, RAW_REBUILD_RECOVERY_META_KEY);
+
+          await tx.put(
+            STORE_NAMES.VECTOR_CLOCK,
+            { clock: newVectorClock, lastUpdate: Date.now() },
             SINGLETON_KEY,
           );
-          if (currentBackup?.backupId !== opts.requiredImportBackupId) {
-            throw new Error('Recovery backup was superseded before destructive restore.');
+
+          await tx.put(STORE_NAMES.STATE_CACHE, {
+            id: SINGLETON_KEY,
+            state: newState,
+            lastAppliedOpSeq: seq,
+            vectorClock: newVectorClock,
+            compactedAt,
+            schemaVersion: syncImportOp.schemaVersion,
+            snapshotEntityKeys,
+          });
+
+          if (archiveYoung != null) {
+            await tx.put(STORE_NAMES.ARCHIVE_YOUNG, {
+              id: SINGLETON_KEY,
+              data: archiveYoung,
+              lastModified: compactedAt,
+            });
           }
-        }
-        // Rotate the clientId first, inside this same atomic transaction.
-        // Writing it before the OPS clear means an interrupt injected into a
-        // later step still aborts this queued put — exercising the genuine
-        // "queued -> tx aborts -> client_id unchanged" path. Atomicity itself
-        // is order-independent.
-        await tx.put(STORE_NAMES.CLIENT_ID, syncImportOp.clientId, SINGLETON_KEY);
 
-        await tx.clear(STORE_NAMES.OPS);
-
-        const seq = await tx.add(
-          STORE_NAMES.OPS,
-          this._buildStoredEntry(syncImportOp, 'local'),
-        );
-        // syncImportOp is always a full-state op (both callers pass SYNC_IMPORT);
-        // OPS was just cleared, so the pointer is exactly this one op. Use the
-        // shared builder so `latest` is derived, never hand-asserted.
-        await tx.put(
-          STORE_NAMES.META,
-          buildFullStateOpsMeta([{ opId: syncImportOp.id, seq }]),
-          FULL_STATE_OPS_META_KEY,
-        );
-
-        // This replacement supersedes any interrupted USE_REMOTE rebuild. Clear
-        // the marker in the same transaction as the restored/clean-slate
-        // baseline so a successful Undo cannot immediately re-enter recovery.
-        await tx.delete(STORE_NAMES.META, RAW_REBUILD_INCOMPLETE_META_KEY);
-        await tx.delete(STORE_NAMES.META, RAW_REBUILD_RECOVERY_META_KEY);
-
-        await tx.put(
-          STORE_NAMES.VECTOR_CLOCK,
-          { clock: newVectorClock, lastUpdate: Date.now() },
-          SINGLETON_KEY,
-        );
-
-        await tx.put(STORE_NAMES.STATE_CACHE, {
-          id: SINGLETON_KEY,
-          state: newState,
-          lastAppliedOpSeq: seq,
-          vectorClock: newVectorClock,
-          compactedAt,
-          schemaVersion: syncImportOp.schemaVersion,
-          snapshotEntityKeys,
-        });
-
-        if (archiveYoung != null) {
-          await tx.put(STORE_NAMES.ARCHIVE_YOUNG, {
-            id: SINGLETON_KEY,
-            data: archiveYoung,
-            lastModified: compactedAt,
-          });
-        }
-
-        if (archiveOld != null) {
-          await tx.put(STORE_NAMES.ARCHIVE_OLD, {
-            id: SINGLETON_KEY,
-            data: archiveOld,
-            lastModified: compactedAt,
-          });
-        }
-      });
+          if (archiveOld != null) {
+            await tx.put(STORE_NAMES.ARCHIVE_OLD, {
+              id: SINGLETON_KEY,
+              data: archiveOld,
+              lastModified: compactedAt,
+            });
+          }
+        }),
+      );
 
       // Reached only on a committed transaction.
       this._invalidateAppliedAndUnsyncedCaches();

--- a/src/app/op-log/testing/integration/sync-hydration-archive-race.integration.spec.ts
+++ b/src/app/op-log/testing/integration/sync-hydration-archive-race.integration.spec.ts
@@ -1,22 +1,24 @@
 import { TestBed } from '@angular/core/testing';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { SyncHydrationService } from '../../persistence/sync-hydration.service';
+import { provideMockStore } from '@ngrx/store/testing';
 import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
-import { StateSnapshotService } from '../../backup/state-snapshot.service';
 import { ArchiveDbAdapter } from '../../../core/persistence/archive-db-adapter.service';
 import { LockService } from '../../sync/lock.service';
 import { LOCK_NAMES } from '../../core/operation-log.const';
 import { ClientIdService } from '../../../core/util/client-id.service';
-import { VectorClockService } from '../../sync/vector-clock.service';
-import { ValidateStateService } from '../../validation/validate-state.service';
-import { SnackService } from '../../../core/snack/snack.service';
-import { selectSyncConfig } from '../../../features/config/store/global-config.reducer';
 import { DEFAULT_GLOBAL_CONFIG } from '../../../features/config/default-global-config.const';
 import { ArchiveModel } from '../../../features/time-tracking/time-tracking.model';
 import { ArchiveCompressionService } from '../../../features/archive/archive-compression.service';
 
-describe('Sync hydration archive race integration', () => {
-  let hydration: SyncHydrationService;
+/**
+ * Guards this PR's fix: archive read-modify-write (compression) must serialize
+ * against the op-log full-state replacement writer via LOCK_NAMES.TASK_ARCHIVE,
+ * so a stale local read can never save over a downloaded/replaced archive.
+ *
+ * The sibling race on the SyncHydrationService.hydrateFromRemoteSync path is
+ * fixed and covered separately in PR #9010 (fix/8960-hydration-race), which adds
+ * the hydration-side TASK_ARCHIVE lock and its own sync-hydration.service.spec.
+ */
+describe('Archive compression vs op-log state replacement race', () => {
   let lockService: LockService;
   let archiveDb: ArchiveDbAdapter;
   let opLogStore: OperationLogStoreService;
@@ -36,48 +38,24 @@ describe('Sync hydration archive race integration', () => {
 
   beforeEach(async () => {
     const clientIdService = jasmine.createSpyObj<ClientIdService>('ClientIdService', [
+      'loadClientId',
       'getOrGenerateClientId',
+      'clearCache',
     ]);
+    clientIdService.loadClientId.and.resolveTo('localClient');
     clientIdService.getOrGenerateClientId.and.resolveTo('localClient');
-    const vectorClockService = jasmine.createSpyObj<VectorClockService>(
-      'VectorClockService',
-      ['getCurrentVectorClock'],
-    );
-    vectorClockService.getCurrentVectorClock.and.resolveTo({ localClient: 1 });
-    const validateStateService = jasmine.createSpyObj<ValidateStateService>(
-      'ValidateStateService',
-      ['validateAndRepair'],
-    );
-    validateStateService.validateAndRepair.and.resolveTo({
-      isValid: true,
-      wasRepaired: false,
-    });
 
     TestBed.configureTestingModule({
       providers: [
         provideMockStore(),
-        SyncHydrationService,
         OperationLogStoreService,
-        StateSnapshotService,
         ArchiveDbAdapter,
         ArchiveCompressionService,
         LockService,
         { provide: ClientIdService, useValue: clientIdService },
-        { provide: VectorClockService, useValue: vectorClockService },
-        { provide: ValidateStateService, useValue: validateStateService },
-        {
-          provide: SnackService,
-          useValue: jasmine.createSpyObj('SnackService', ['open']),
-        },
       ],
     });
 
-    const store = TestBed.inject(MockStore);
-    store.overrideSelector(selectSyncConfig, {
-      ...DEFAULT_GLOBAL_CONFIG.sync,
-      isEnabled: true,
-    });
-    hydration = TestBed.inject(SyncHydrationService);
     lockService = TestBed.inject(LockService);
     archiveDb = TestBed.inject(ArchiveDbAdapter);
     opLogStore = TestBed.inject(OperationLogStoreService);
@@ -87,73 +65,6 @@ describe('Sync hydration archive race integration', () => {
     await opLogStore._clearAllDataForTesting();
     await archiveDb.saveArchiveYoung(archiveModel(['initial']));
     await archiveDb.saveArchiveOld(archiveModel([]));
-  });
-
-  it('prevents archive compression from overwriting downloaded archives with a stale read', async () => {
-    let signalLocalRead!: () => void;
-    const localRead = new Promise<void>((resolve) => {
-      signalLocalRead = resolve;
-    });
-    let releaseLocalSave!: () => void;
-    const localSaveMayContinue = new Promise<void>((resolve) => {
-      releaseLocalSave = resolve;
-    });
-
-    const realSaveArchivesAtomic = archiveDb.saveArchivesAtomic.bind(archiveDb);
-    spyOn(archiveDb, 'saveArchivesAtomic').and.callFake(async (young, old) => {
-      signalLocalRead();
-      await localSaveMayContinue;
-      await realSaveArchivesAtomic(young, old);
-    });
-
-    const localMutation = archiveCompression.compressArchive(Date.now());
-    await localRead;
-
-    const realSaveArchiveYoung = archiveDb.saveArchiveYoung.bind(archiveDb);
-    let remoteWriteStarted = false;
-    spyOn(archiveDb, 'saveArchiveYoung').and.callFake(async (archive) => {
-      if (archive.task.ids.includes('remote')) remoteWriteStarted = true;
-      await realSaveArchiveYoung(archive);
-    });
-
-    const realLockRequest = lockService.request.bind(lockService);
-    let signalHydrationLockRequest!: () => void;
-    const hydrationLockRequested = new Promise<void>((resolve) => {
-      signalHydrationLockRequest = resolve;
-    });
-    spyOn(lockService, 'request').and.callFake(
-      <T>(
-        lockName: string,
-        callback: () => Promise<T>,
-        timeoutMs?: number,
-      ): Promise<T> => {
-        if (lockName === LOCK_NAMES.TASK_ARCHIVE) signalHydrationLockRequest();
-        return realLockRequest(lockName, callback, timeoutMs);
-      },
-    );
-
-    const remoteArchive = archiveModel(['remote']);
-    const hydrationPromise = hydration.hydrateFromRemoteSync(
-      {
-        globalConfig: DEFAULT_GLOBAL_CONFIG,
-        archiveYoung: remoteArchive,
-        archiveOld: archiveModel([]),
-      },
-      { remote: 1 },
-      false,
-    );
-
-    await hydrationLockRequested;
-    expect(remoteWriteStarted).toBeFalse();
-
-    releaseLocalSave();
-    await Promise.all([localMutation, hydrationPromise]);
-
-    expect(remoteWriteStarted).toBeTrue();
-    expect((await archiveDb.loadArchiveYoung())!.task.ids).toEqual(['remote']);
-    const stateCache = await opLogStore.loadStateCache();
-    const cachedState = stateCache?.state as { archiveYoung: ArchiveModel } | undefined;
-    expect(cachedState?.archiveYoung.task.ids).toEqual(['remote']);
   });
 
   it('prevents archive compression from overwriting an op-log state replacement', async () => {

--- a/src/app/op-log/testing/integration/sync-hydration-archive-race.integration.spec.ts
+++ b/src/app/op-log/testing/integration/sync-hydration-archive-race.integration.spec.ts
@@ -1,0 +1,220 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { SyncHydrationService } from '../../persistence/sync-hydration.service';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { StateSnapshotService } from '../../backup/state-snapshot.service';
+import { ArchiveDbAdapter } from '../../../core/persistence/archive-db-adapter.service';
+import { LockService } from '../../sync/lock.service';
+import { LOCK_NAMES } from '../../core/operation-log.const';
+import { ClientIdService } from '../../../core/util/client-id.service';
+import { VectorClockService } from '../../sync/vector-clock.service';
+import { ValidateStateService } from '../../validation/validate-state.service';
+import { SnackService } from '../../../core/snack/snack.service';
+import { selectSyncConfig } from '../../../features/config/store/global-config.reducer';
+import { DEFAULT_GLOBAL_CONFIG } from '../../../features/config/default-global-config.const';
+import { ArchiveModel } from '../../../features/time-tracking/time-tracking.model';
+import { ArchiveCompressionService } from '../../../features/archive/archive-compression.service';
+
+describe('Sync hydration archive race integration', () => {
+  let hydration: SyncHydrationService;
+  let lockService: LockService;
+  let archiveDb: ArchiveDbAdapter;
+  let opLogStore: OperationLogStoreService;
+  let archiveCompression: ArchiveCompressionService;
+
+  const archiveModel = (taskIds: string[]): ArchiveModel =>
+    ({
+      task: {
+        ids: taskIds,
+        entities: Object.fromEntries(
+          taskIds.map((id) => [id, { id, title: `Archived ${id}`, isDone: true }]),
+        ),
+      },
+      timeTracking: { project: {}, tag: {} },
+      lastTimeTrackingFlush: 0,
+    }) as unknown as ArchiveModel;
+
+  beforeEach(async () => {
+    const clientIdService = jasmine.createSpyObj<ClientIdService>('ClientIdService', [
+      'getOrGenerateClientId',
+    ]);
+    clientIdService.getOrGenerateClientId.and.resolveTo('localClient');
+    const vectorClockService = jasmine.createSpyObj<VectorClockService>(
+      'VectorClockService',
+      ['getCurrentVectorClock'],
+    );
+    vectorClockService.getCurrentVectorClock.and.resolveTo({ localClient: 1 });
+    const validateStateService = jasmine.createSpyObj<ValidateStateService>(
+      'ValidateStateService',
+      ['validateAndRepair'],
+    );
+    validateStateService.validateAndRepair.and.resolveTo({
+      isValid: true,
+      wasRepaired: false,
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore(),
+        SyncHydrationService,
+        OperationLogStoreService,
+        StateSnapshotService,
+        ArchiveDbAdapter,
+        ArchiveCompressionService,
+        LockService,
+        { provide: ClientIdService, useValue: clientIdService },
+        { provide: VectorClockService, useValue: vectorClockService },
+        { provide: ValidateStateService, useValue: validateStateService },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', ['open']),
+        },
+      ],
+    });
+
+    const store = TestBed.inject(MockStore);
+    store.overrideSelector(selectSyncConfig, {
+      ...DEFAULT_GLOBAL_CONFIG.sync,
+      isEnabled: true,
+    });
+    hydration = TestBed.inject(SyncHydrationService);
+    lockService = TestBed.inject(LockService);
+    archiveDb = TestBed.inject(ArchiveDbAdapter);
+    opLogStore = TestBed.inject(OperationLogStoreService);
+    archiveCompression = TestBed.inject(ArchiveCompressionService);
+
+    await opLogStore.init();
+    await opLogStore._clearAllDataForTesting();
+    await archiveDb.saveArchiveYoung(archiveModel(['initial']));
+    await archiveDb.saveArchiveOld(archiveModel([]));
+  });
+
+  it('prevents archive compression from overwriting downloaded archives with a stale read', async () => {
+    let signalLocalRead!: () => void;
+    const localRead = new Promise<void>((resolve) => {
+      signalLocalRead = resolve;
+    });
+    let releaseLocalSave!: () => void;
+    const localSaveMayContinue = new Promise<void>((resolve) => {
+      releaseLocalSave = resolve;
+    });
+
+    const realSaveArchivesAtomic = archiveDb.saveArchivesAtomic.bind(archiveDb);
+    spyOn(archiveDb, 'saveArchivesAtomic').and.callFake(async (young, old) => {
+      signalLocalRead();
+      await localSaveMayContinue;
+      await realSaveArchivesAtomic(young, old);
+    });
+
+    const localMutation = archiveCompression.compressArchive(Date.now());
+    await localRead;
+
+    const realSaveArchiveYoung = archiveDb.saveArchiveYoung.bind(archiveDb);
+    let remoteWriteStarted = false;
+    spyOn(archiveDb, 'saveArchiveYoung').and.callFake(async (archive) => {
+      if (archive.task.ids.includes('remote')) remoteWriteStarted = true;
+      await realSaveArchiveYoung(archive);
+    });
+
+    const realLockRequest = lockService.request.bind(lockService);
+    let signalHydrationLockRequest!: () => void;
+    const hydrationLockRequested = new Promise<void>((resolve) => {
+      signalHydrationLockRequest = resolve;
+    });
+    spyOn(lockService, 'request').and.callFake(
+      <T>(
+        lockName: string,
+        callback: () => Promise<T>,
+        timeoutMs?: number,
+      ): Promise<T> => {
+        if (lockName === LOCK_NAMES.TASK_ARCHIVE) signalHydrationLockRequest();
+        return realLockRequest(lockName, callback, timeoutMs);
+      },
+    );
+
+    const remoteArchive = archiveModel(['remote']);
+    const hydrationPromise = hydration.hydrateFromRemoteSync(
+      {
+        globalConfig: DEFAULT_GLOBAL_CONFIG,
+        archiveYoung: remoteArchive,
+        archiveOld: archiveModel([]),
+      },
+      { remote: 1 },
+      false,
+    );
+
+    await hydrationLockRequested;
+    expect(remoteWriteStarted).toBeFalse();
+
+    releaseLocalSave();
+    await Promise.all([localMutation, hydrationPromise]);
+
+    expect(remoteWriteStarted).toBeTrue();
+    expect((await archiveDb.loadArchiveYoung())!.task.ids).toEqual(['remote']);
+    const stateCache = await opLogStore.loadStateCache();
+    const cachedState = stateCache?.state as { archiveYoung: ArchiveModel } | undefined;
+    expect(cachedState?.archiveYoung.task.ids).toEqual(['remote']);
+  });
+
+  it('prevents archive compression from overwriting an op-log state replacement', async () => {
+    let signalLocalRead!: () => void;
+    const localRead = new Promise<void>((resolve) => {
+      signalLocalRead = resolve;
+    });
+    let releaseLocalSave!: () => void;
+    const localSaveMayContinue = new Promise<void>((resolve) => {
+      releaseLocalSave = resolve;
+    });
+
+    const realSaveArchivesAtomic = archiveDb.saveArchivesAtomic.bind(archiveDb);
+    spyOn(archiveDb, 'saveArchivesAtomic').and.callFake(async (young, old) => {
+      signalLocalRead();
+      await localSaveMayContinue;
+      await realSaveArchivesAtomic(young, old);
+    });
+
+    const localMutation = archiveCompression.compressArchive(Date.now());
+    await localRead;
+
+    const realLockRequest = lockService.request.bind(lockService);
+    let signalReplacementLockRequest!: () => void;
+    const replacementLockRequested = new Promise<void>((resolve) => {
+      signalReplacementLockRequest = resolve;
+    });
+    spyOn(lockService, 'request').and.callFake(
+      <T>(
+        lockName: string,
+        callback: () => Promise<T>,
+        timeoutMs?: number,
+      ): Promise<T> => {
+        if (lockName === LOCK_NAMES.TASK_ARCHIVE) signalReplacementLockRequest();
+        return realLockRequest(lockName, callback, timeoutMs);
+      },
+    );
+
+    const remoteArchive = archiveModel(['replacement']);
+    const replacement = opLogStore.runRemoteStateReplacement({
+      baselineState: {
+        globalConfig: DEFAULT_GLOBAL_CONFIG,
+        archiveYoung: remoteArchive,
+        archiveOld: archiveModel([]),
+      },
+      vectorClock: { remote: 2 },
+      schemaVersion: 1,
+      snapshotEntityKeys: [],
+      archiveYoung: remoteArchive,
+      archiveOld: archiveModel([]),
+    });
+
+    await replacementLockRequested;
+    expect((await archiveDb.loadArchiveYoung())!.task.ids).toEqual(['initial']);
+
+    releaseLocalSave();
+    await Promise.all([localMutation, replacement]);
+
+    expect((await archiveDb.loadArchiveYoung())!.task.ids).toEqual(['replacement']);
+    const stateCache = await opLogStore.loadStateCache();
+    const cachedState = stateCache?.state as { archiveYoung: ArchiveModel } | undefined;
+    expect(cachedState?.archiveYoung.task.ids).toEqual(['replacement']);
+  });
+});


### PR DESCRIPTION
Completes the archive read-modify-write serialization started by `982f2916ca` ("serialize archive mutations"), which introduced the `TASK_ARCHIVE` lock but explicitly left `compressArchive`, the `TimeTrackingService` cleanups, and the remote-replacement writers unlocked — tracked as this issue (#8941).

This surfaced during the #8960 sync review (it had accumulated on that working branch), but it is **independent of #8960** — the race exists on `master` today, affects all sync providers, and touches none of the file-based-provider defects. It targets `master` directly.

## The race

A local archive **read-modify-write** (`compressArchive`, tag/project cleanups: load young+old → mutate → save) can start from the old archive and then save it *after* a remote replacement (`runRemoteStateReplacement` / `SYNC_IMPORT` restore) lands, silently erasing the downloaded/replaced archive entries.

## Fix

Wrap all remaining archive writers behind the existing `LOCK_NAMES.TASK_ARCHIVE` lock:
- `ArchiveCompressionService.compressArchive`
- the three `TimeTrackingService` cleanups
- the SYNC_IMPORT / BACKUP_IMPORT writer in `ArchiveOperationHandler`
- the two destructive op-log-store transactions (`runRemoteStateReplacement`, SYNC_IMPORT restore)

Also drops the BACKUP_IMPORT `confirmDialog` (can't block on user input while the lock / `OPERATION_LOG` is held) and removes a `Log.log({...})` that logged user content.

## Cross-PR note

The hydration-side `TASK_ARCHIVE` lock (from the `harden snapshot hydration ordering` change) currently rides in the sync-hardening follow-up (#9005) because it's entangled with a legitimate hydration-ordering change there. It's a no-op until this PR's writer locks land; full serialization is in place once both merge. The two are independent and can merge in either order.

## Verification

- ✅ eslint clean on all changed production files.
- ⚠️ Full unit (Karma) + SuperSync e2e suites not yet run locally (sandbox constraints) — relying on CI. Includes a `sync-hydration-archive-race.integration.spec.ts` demonstrating both races.

Closes #8941
