### PR TITLE
feat(add-task-bar): file tasks into project sections via short syntax (+Project/Section and /Section)

### DIFF
--- a/docs/wiki/3.04-Short-Syntax.md
+++ b/docs/wiki/3.04-Short-Syntax.md
@@ -1,6 +1,6 @@
 # Short Syntax
 
-Super Productivity supports five main short syntax forms for quickly adding metadata to tasks: tags (`#`), projects (`+`), time estimates (`m`/`h`), due dates (`@`), and deadlines (`!`). The due date form also accepts recurrence phrases (`@every friday`, `@daily`) in the Add Task Bar. The forms are controlled in [[3.02-Settings-and-Preferences#global-settings.Short-Syntax]], with a separate opt-in setting for deadline syntax.
+Super Productivity supports six main short syntax forms for quickly adding metadata to tasks: tags (`#`), projects (`+`), project sections (`/`), time estimates (`m`/`h`), due dates (`@`), and deadlines (`!`). The due date form also accepts recurrence phrases (`@every friday`, `@daily`) in the Add Task Bar. The forms are controlled in [[3.02-Settings-and-Preferences#global-settings.Short-Syntax]], with a separate opt-in setting for deadline syntax.
 
 ## Supported Syntax Forms
 
@@ -21,6 +21,17 @@ Super Productivity supports five main short syntax forms for quickly adding meta
 - **Parameters:** Project title or partial title; minimum 3 characters. Matching is prefix-based, case-insensitive, with spaces removed for comparison. The shortest matching project title is preferred when several match.
 - **Valid:** `"Task +Important Project"`, `"Task +Project"` (partial match). Project names containing `+`, `#`, `@`, or similar are supported; the parser uses lookahead so these characters inside the name do not end the token.
 - **Invalid:** `"Task+Project"` (no space before `+`) — no project is applied.
+- **With a section:** `+<project-name>/<section-name>` files the task into a section of the matched project (see Section Syntax below). A project whose title itself contains `/` (e.g. `A/B Testing`) is always tried first and keeps matching as a plain project — which also means a `/` in a project title disables section syntax for that project.
+
+### Section Syntax (`/`)
+
+- **Symbol:** `/`
+- **Purpose:** Place the task inside a section of a project.
+- **Grammar:** either `+<project-name>/<section-name>` (explicit project) or a standalone `/<section-name>`, which resolves against the project the task will land in (the active work context or the project selected in the Add Task Bar). An explicit `+Project/Section` wins over the context. For the standalone form, `/` must start a word (space or start of title before it) and must not be followed by a space.
+- **Parameters:** Section title or partial title. Matching is prefix-based, case-insensitive, with spaces removed for comparison; when trailing words follow, the longest leading word span that still matches a section is used (so `"/Design Reviews finish draft"` matches `Design Reviews` and keeps `finish draft` in the title). Only sections belonging to the resolved project are considered.
+- **Valid:** `"Task +Work/Design"`, `"Task +Work/des"` (prefix), `"Task /Design"` (section of the current project), `"Task /des fix login"` (prefix with trailing text; the unmatched words stay in the title).
+- **Invalid / inert:** `"either/or"`, `"w/ milk"` (no word boundary before `/` or no match) — nothing is stripped from the title unless a section actually matches. `"Task / Design"` (space after `/`) is not parsed. `"+/..."` (nothing before the slash) is plain text, so notation like `+/-` stays untouched. Time forms like `1h/2h` are parsed as time before section parsing runs.
+- **Enabled by:** the project Short Syntax setting (there is no separate section toggle).
 
 ### Time Estimate Syntax
 
@@ -61,7 +72,7 @@ Super Productivity supports five main short syntax forms for quickly adding meta
 
 ## Formal Grammar and Regex Patterns
 
-The parser uses regular expressions for each syntax form. Time: optional `t` prefix, digits and decimal with `m`/`h`, optional `/` for spent/estimate. Project: `+` with lookahead so delimiters (`#`, `@`, time-like tokens) inside the project name do not terminate the match. Tag: `#` followed by characters until a special character or whitespace. Due: `@` followed by characters until a special character. Deadline: `!` followed by characters until a special character. Exact patterns are defined in `short-syntax.ts` (e.g. `SHORT_SYNTAX_TIME_REG_EX`, `SHORT_SYNTAX_PROJECT_REG_EX`, `SHORT_SYNTAX_TAGS_REG_EX`, `SHORT_SYNTAX_DUE_REG_EX`, `SHORT_SYNTAX_DEADLINE_REG_EX`).
+The parser uses regular expressions for each syntax form. Time: optional `t` prefix, digits and decimal with `m`/`h`, optional `/` for spent/estimate. Project: `+` with lookahead so delimiters (`#`, `@`, time-like tokens) inside the project name do not terminate the match. Tag: `#` followed by characters until a special character or whitespace. Due: `@` followed by characters until a special character. Deadline: `!` followed by characters until a special character. Section (standalone): `/` at a word boundary, not followed by whitespace or another `/`. Exact patterns are defined in `short-syntax.ts` (e.g. `SHORT_SYNTAX_TIME_REG_EX`, `SHORT_SYNTAX_PROJECT_REG_EX`, `SHORT_SYNTAX_STANDALONE_SECTION_REG_EX`, `SHORT_SYNTAX_TAGS_REG_EX`, `SHORT_SYNTAX_DUE_REG_EX`, `SHORT_SYNTAX_DEADLINE_REG_EX`).
 
 ## Default Values and Behavior
 
@@ -88,10 +99,10 @@ The parser uses regular expressions for each syntax form. Time: optional `t` pre
 
 ## Parsing and Evaluation Rules
 
-1. **Order of processing:** Due/deadline/time → Project → Tag.
+1. **Order of processing:** Due/deadline/time → Project (including sections) → Tag.
 2. **Title cleanup:** Parsed syntax is removed from the task title after processing.
 3. **Tag creation:** Tags that do not exist yet are collected in a `newTagTitles` array for creation.
-4. **Return value:** The `shortSyntax()` function returns an object with task changes (and `newTagTitles`, `remindAt`, `projectId`, `repeatQuickSetting`) or `undefined` if nothing was parsed or syntax is disabled.
+4. **Return value:** The `shortSyntax()` function returns an object with task changes (and `newTagTitles`, `remindAt`, `projectId`, `sectionId`, `repeatQuickSetting`) or `undefined` if nothing was parsed or syntax is disabled.
 
 ## Error Handling
 
@@ -110,7 +121,7 @@ The parser uses regular expressions for each syntax form. Time: optional `t` pre
 ## Add Task Bar Behavior
 
 - **Toggle new task position:** A toggle in the Add Task Bar controls whether the new task is added at the top or the bottom of the list.
-- **Autocomplete:** The Add Task Bar can suggest tags, projects, and date expressions while typing.
+- **Autocomplete:** The Add Task Bar can suggest tags, projects, date expressions, and — after `/` — the sections of the effective project while typing.
 - **Inline highlighting:** Detected short syntax (tags, project, estimate, due/deadline dates, recurrence, extracted URLs) is highlighted directly in the input while typing, showing which characters will be stripped from the title before the task is created.
 
 ## Notes

--- a/docs/wiki/3.04-Short-Syntax.md
+++ b/docs/wiki/3.04-Short-Syntax.md
@@ -31,7 +31,8 @@ Super Productivity supports six main short syntax forms for quickly adding metad
 - **Parameters:** Section title or partial title. Matching is prefix-based, case-insensitive, with spaces removed for comparison; when trailing words follow, the longest leading word span that still matches a section is used (so `"/Design Reviews finish draft"` matches `Design Reviews` and keeps `finish draft` in the title). Only sections belonging to the resolved project are considered.
 - **Valid:** `"Task +Work/Design"`, `"Task +Work/des"` (prefix), `"Task /Design"` (section of the current project), `"Task /des fix login"` (prefix with trailing text; the unmatched words stay in the title).
 - **Invalid / inert:** `"either/or"`, `"w/ milk"` (no word boundary before `/` or no match) — nothing is stripped from the title unless a section actually matches. `"Task / Design"` (space after `/`) is not parsed. `"+/..."` (nothing before the slash) is plain text, so notation like `+/-` stays untouched. Time forms like `1h/2h` are parsed as time before section parsing runs.
-- **Enabled by:** the project Short Syntax setting (there is no separate section toggle).
+- **Enabled by:** the project Short Syntax setting (there is no separate section toggle). The `/` autocomplete dropdown follows the same setting.
+- **Backlog adds:** when the Add Task Bar is set to add into the project backlog, a parsed section is ignored — sections only group the main task list, so a backlogged task never carries an invisible section membership.
 
 ### Time Estimate Syntax
 

--- a/docs/wiki/3.04-Short-Syntax.md
+++ b/docs/wiki/3.04-Short-Syntax.md
@@ -1,6 +1,6 @@
 # Short Syntax
 
-Super Productivity supports five main short syntax forms for quickly adding metadata to tasks: tags (`#`), projects (`+`), time estimates (`m`/`h`), due dates (`@`), and deadlines (`!`). The due date form also accepts recurrence phrases (`@every friday`, `@daily`) in the Add Task Bar. The forms are controlled in [[3.02-Settings-and-Preferences#short-syntax]], with a separate opt-in setting for deadline syntax.
+Super Productivity supports six main short syntax forms for quickly adding metadata to tasks: tags (`#`), projects (`+`), project sections (`/`), time estimates (`m`/`h`), due dates (`@`), and deadlines (`!`). The due date form also accepts recurrence phrases (`@every friday`, `@daily`) in the Add Task Bar. The forms are controlled in [[3.02-Settings-and-Preferences#short-syntax]], with a separate opt-in setting for deadline syntax.
 
 ## Supported Syntax Forms
 
@@ -21,6 +21,17 @@ Super Productivity supports five main short syntax forms for quickly adding meta
 - **Parameters:** Project title or partial title; minimum 3 characters. Matching is prefix-based, case-insensitive, with spaces removed for comparison. The shortest matching project title is preferred when several match.
 - **Valid:** `"Task +Important Project"`, `"Task +Project"` (partial match). Project names containing `+`, `#`, `@`, or similar are supported; the parser uses lookahead so these characters inside the name do not end the token.
 - **Invalid:** `"Task+Project"` (no space before `+`) — no project is applied.
+- **With a section:** `+<project-name>/<section-name>` files the task into a section of the matched project (see Section Syntax below). A project whose title itself contains `/` (e.g. `A/B Testing`) is always tried first and keeps matching as a plain project — which also means a `/` in a project title disables section syntax for that project.
+
+### Section Syntax (`/`)
+
+- **Symbol:** `/`
+- **Purpose:** Place the task inside a section of a project.
+- **Grammar:** either `+<project-name>/<section-name>` (explicit project) or a standalone `/<section-name>`, which resolves against the project the task will land in (the active work context or the project selected in the Add Task Bar). An explicit `+Project/Section` wins over the context. For the standalone form, `/` must start a word (space or start of title before it) and must not be followed by a space.
+- **Parameters:** Section title or partial title. Matching is prefix-based, case-insensitive, with spaces removed for comparison; when trailing words follow, the longest leading word span that still matches a section is used (so `"/Design Reviews finish draft"` matches `Design Reviews` and keeps `finish draft` in the title). Only sections belonging to the resolved project are considered.
+- **Valid:** `"Task +Work/Design"`, `"Task +Work/des"` (prefix), `"Task /Design"` (section of the current project), `"Task /des fix login"` (prefix with trailing text; the unmatched words stay in the title).
+- **Invalid / inert:** `"either/or"`, `"w/ milk"` (no word boundary before `/` or no match) — nothing is stripped from the title unless a section actually matches. `"Task / Design"` (space after `/`) is not parsed. `"+/..."` (nothing before the slash) is plain text, so notation like `+/-` stays untouched. Time forms like `1h/2h` are parsed as time before section parsing runs.
+- **Enabled by:** the project Short Syntax setting (there is no separate section toggle).
 
 ### Time Estimate Syntax
 
@@ -62,7 +73,7 @@ Super Productivity supports five main short syntax forms for quickly adding meta
 
 ## Formal Grammar and Regex Patterns
 
-The parser uses regular expressions for each syntax form. Time: optional `t` prefix, digits and decimal with `m`/`h`, optional `/` for spent/estimate. Project: `+` with lookahead so delimiters (`#`, `@`, time-like tokens) inside the project name do not terminate the match. Tag: `#` followed by characters until a special character or whitespace. Due: `@` followed by characters until a special character. Deadline: `!` followed by characters until a special character. Exact patterns are defined in `short-syntax.ts` (e.g. `SHORT_SYNTAX_TIME_REG_EX`, `SHORT_SYNTAX_PROJECT_REG_EX`, `SHORT_SYNTAX_TAGS_REG_EX`, `SHORT_SYNTAX_DUE_REG_EX`, `SHORT_SYNTAX_DEADLINE_REG_EX`).
+The parser uses regular expressions for each syntax form. Time: optional `t` prefix, digits and decimal with `m`/`h`, optional `/` for spent/estimate. Project: `+` with lookahead so delimiters (`#`, `@`, time-like tokens) inside the project name do not terminate the match. Tag: `#` followed by characters until a special character or whitespace. Due: `@` followed by characters until a special character. Deadline: `!` followed by characters until a special character. Section (standalone): `/` at a word boundary, not followed by whitespace or another `/`. Exact patterns are defined in `short-syntax.ts` (e.g. `SHORT_SYNTAX_TIME_REG_EX`, `SHORT_SYNTAX_PROJECT_REG_EX`, `SHORT_SYNTAX_STANDALONE_SECTION_REG_EX`, `SHORT_SYNTAX_TAGS_REG_EX`, `SHORT_SYNTAX_DUE_REG_EX`, `SHORT_SYNTAX_DEADLINE_REG_EX`).
 
 ## Default Values and Behavior
 
@@ -89,10 +100,10 @@ The parser uses regular expressions for each syntax form. Time: optional `t` pre
 
 ## Parsing and Evaluation Rules
 
-1. **Order of processing:** Due/deadline/time → Project → Tag.
+1. **Order of processing:** Due/deadline/time → Project (including sections) → Tag.
 2. **Title cleanup:** Parsed syntax is removed from the task title after processing.
 3. **Tag creation:** Tags that do not exist yet are collected in a `newTagTitles` array for creation.
-4. **Return value:** The `shortSyntax()` function returns an object with task changes (and `newTagTitles`, `remindAt`, `projectId`, `repeat`) or `undefined` if nothing was parsed or syntax is disabled.
+4. **Return value:** The `shortSyntax()` function returns an object with task changes (and `newTagTitles`, `remindAt`, `projectId`, `sectionId`, `repeat`) or `undefined` if nothing was parsed or syntax is disabled.
 5. **Buttons win over text:** picking a date, deadline, estimate or recurrence in the Add Task Bar's buttons removes the matching syntax from the input, the same way the buttons' clear (`x`) does, so the text stops advertising a value the task will not get. Changing the date of a task whose recurrence came from syntax keeps the recurrence and re-anchors it to the new date.
 
 ## Error Handling
@@ -112,7 +123,7 @@ The parser uses regular expressions for each syntax form. Time: optional `t` pre
 ## Add Task Bar Behavior
 
 - **Toggle new task position:** A toggle in the Add Task Bar controls whether the new task is added at the top or the bottom of the list.
-- **Autocomplete:** The Add Task Bar can suggest tags, projects, and date expressions while typing.
+- **Autocomplete:** The Add Task Bar can suggest tags, projects, date expressions, and — after `/` — the sections of the effective project while typing.
 - **Inline highlighting:** Detected short syntax (tags, project, estimate, due/deadline dates, recurrence, extracted URLs) is highlighted directly in the input while typing, showing which characters will be stripped from the title before the task is created.
 
 ## Notes

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { AddTaskBarParserService } from './add-task-bar-parser.service';
 import { AddTaskBarStateService } from './add-task-bar-state.service';
 import { selectAllSections } from '../../section/store/section.selectors';
@@ -1724,6 +1724,121 @@ describe('AddTaskBarParserService', () => {
       mockStateService.state.and.returnValue(baseState as any);
       await service.parseAndUpdateText('', cfg, [], [], defaultProject);
       expect(mockStateService.updateSyntaxHighlight).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('section validation against the final project (round-3 review, PR #9014)', () => {
+    const cfg = {
+      isEnableProject: true,
+      isEnableDue: true,
+      isEnableTag: true,
+    } as ShortSyntaxConfig;
+    const defaultProject = { id: 'default-project', title: 'Default Project' } as Project;
+    const workProject = { id: 'work', title: 'Work' } as Project;
+    const designSection = {
+      id: 'sec-design',
+      contextId: 'work',
+      contextType: 'PROJECT',
+      title: 'Design',
+      taskIds: [],
+    };
+    const makeState = (projectId: string): unknown => ({
+      projectId,
+      sectionId: null,
+      tagIds: [],
+      tagIdsFromTxt: [],
+      newTagTitles: [],
+      date: null,
+      time: null,
+      spent: null,
+      estimate: null,
+      cleanText: null,
+      remindOption: null,
+      attachments: [],
+      repeatQuickSetting: null,
+      deadlineDate: null,
+      deadlineTime: null,
+      deadlineRemindOption: null,
+    });
+
+    // Mirror the real state service closely enough for the two-step
+    // sequence: project updates clear the section, every update lands in
+    // `liveState` so the service's own `state()` reads see it.
+    let liveState: { projectId: string; sectionId: string | null };
+    beforeEach(() => {
+      const store = TestBed.inject(MockStore);
+      store.overrideSelector(selectAllSections, [designSection] as never[]);
+      liveState = makeState(defaultProject.id) as typeof liveState;
+      mockStateService.state.and.callFake((() => liveState) as any);
+      mockStateService.isAutoDetected.and.returnValue(true);
+      mockStateService.setAutoDetectedProjectId.and.callFake((id: string) => {
+        liveState = { ...liveState, projectId: id, sectionId: null };
+      });
+      mockStateService.updateProjectId.and.callFake((id: string) => {
+        liveState = { ...liveState, projectId: id, sectionId: null };
+      });
+      mockStateService.updateSectionId.and.callFake((id: string | null) => {
+        liveState = { ...liveState, sectionId: id };
+      });
+    });
+
+    it('should resolve "+Work/Design" to Work + its section', async () => {
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+      expect(liveState.projectId).toBe('work');
+      expect(liveState.sectionId).toBe('sec-design');
+    });
+
+    it('should clear a stale section from another project when the +Project token is deleted', async () => {
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+
+      // Deleting just "+Work" falls the task back to the default project;
+      // the leftover "/Design" must NOT keep pointing at Work's section.
+      await service.parseAndUpdateText(
+        'buy milk /Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+      expect(liveState.projectId).toBe(defaultProject.id);
+      expect(liveState.sectionId).toBeNull();
+    });
+
+    it('should clear the section when the user manually picks another project', async () => {
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+
+      // Manual selection: the state service clears the section and the
+      // auto-detected flag; a re-parse of the unchanged text must not
+      // re-apply Work's section to the manually chosen project.
+      liveState = { ...liveState, projectId: defaultProject.id, sectionId: null };
+      mockStateService.isAutoDetected.and.returnValue(false);
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+      expect(liveState.projectId).toBe(defaultProject.id);
+      expect(liveState.sectionId).toBeNull();
     });
   });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { AddTaskBarParserService } from './add-task-bar-parser.service';
 import { AddTaskBarStateService } from './add-task-bar-state.service';
+import { selectAllSections } from '../../section/store/section.selectors';
 import { ShortSyntaxConfig } from '../../config/global-config.model';
 import { Project } from '../../project/project.model';
 import { Tag } from '../../tag/tag.model';
@@ -26,6 +28,7 @@ describe('AddTaskBarParserService', () => {
       'updateRepeatSetting',
       'clearRepeatSetting',
       'updateSyntaxHighlight',
+      'updateSectionId',
       'isAutoDetected',
       'state',
     ]);
@@ -52,6 +55,9 @@ describe('AddTaskBarParserService', () => {
       providers: [
         AddTaskBarParserService,
         { provide: AddTaskBarStateService, useValue: mockStateServiceSpy },
+        provideMockStore({
+          selectors: [{ selector: selectAllSections, value: [] }],
+        }),
       ],
     });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -150,6 +150,7 @@ describe('AddTaskBarParserService', () => {
         // Mock state to return no current date/time
         const mockState = {
           projectId: mockDefaultProject.id,
+          sectionId: null,
           tagIds: [],
           tagIdsFromTxt: [],
           newTagTitles: [],
@@ -188,6 +189,7 @@ describe('AddTaskBarParserService', () => {
         // Mock state to return current user-selected values
         const mockState = {
           projectId: mockDefaultProject.id,
+          sectionId: null,
           tagIds: [],
           tagIdsFromTxt: [],
           newTagTitles: [],
@@ -223,6 +225,7 @@ describe('AddTaskBarParserService', () => {
         // Mock state with date but no time
         const mockState = {
           projectId: mockDefaultProject.id,
+          sectionId: null,
           tagIds: [],
           tagIdsFromTxt: [],
           newTagTitles: [],
@@ -309,6 +312,7 @@ describe('AddTaskBarParserService', () => {
 
         mockStateService.state.and.returnValue({
           projectId: mockDefaultProject.id,
+          sectionId: null,
           tagIds: [],
           tagIdsFromTxt: [],
           newTagTitles: [],
@@ -341,6 +345,7 @@ describe('AddTaskBarParserService', () => {
 
         mockStateService.state.and.returnValue({
           projectId: mockDefaultProject.id,
+          sectionId: null,
           tagIds: [],
           tagIdsFromTxt: [],
           newTagTitles: [],
@@ -1072,6 +1077,7 @@ describe('AddTaskBarParserService', () => {
       // Mock state to return the date and time
       const mockState = {
         projectId: mockDefaultProject.id,
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1107,6 +1113,7 @@ describe('AddTaskBarParserService', () => {
 
       const mockState = {
         projectId: mockDefaultProject.id,
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1144,6 +1151,7 @@ describe('AddTaskBarParserService', () => {
 
       const mockState = {
         projectId: mockDefaultProject.id,
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1179,6 +1187,7 @@ describe('AddTaskBarParserService', () => {
 
       const mockState = {
         projectId: mockDefaultProject.id,
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1213,6 +1222,7 @@ describe('AddTaskBarParserService', () => {
 
       const mockState = {
         projectId: mockDefaultProject.id,
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1331,6 +1341,7 @@ describe('AddTaskBarParserService', () => {
     it('should extract single HTTPS URL and update state', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1365,6 +1376,7 @@ describe('AddTaskBarParserService', () => {
     it('should extract file:// URL with FILE type', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1399,6 +1411,7 @@ describe('AddTaskBarParserService', () => {
     it('should detect image URLs as IMG type', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1431,6 +1444,7 @@ describe('AddTaskBarParserService', () => {
     it('should extract multiple URLs', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1464,6 +1478,7 @@ describe('AddTaskBarParserService', () => {
     it('should work with combined short syntax (URL + date + tag + estimate)', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1507,6 +1522,7 @@ describe('AddTaskBarParserService', () => {
     it('should not extract URLs from empty text', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1535,6 +1551,7 @@ describe('AddTaskBarParserService', () => {
     it('should update attachments when URL changes', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1583,6 +1600,7 @@ describe('AddTaskBarParserService', () => {
     it('should clear attachments when URL removed from text', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1625,6 +1643,7 @@ describe('AddTaskBarParserService', () => {
     it('should handle www URLs correctly', async () => {
       const mockState = {
         projectId: 'default-project',
+        sectionId: null,
         tagIds: [],
         tagIdsFromTxt: [],
         newTagTitles: [],
@@ -1665,6 +1684,7 @@ describe('AddTaskBarParserService', () => {
     const defaultProject = { id: 'default-project', title: 'Default Project' } as Project;
     const baseState = {
       projectId: 'default-project',
+      sectionId: null,
       tagIds: [],
       tagIdsFromTxt: [],
       newTagTitles: [],
@@ -2036,7 +2056,13 @@ describe('AddTaskBarParserService', () => {
     beforeEach(() => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        providers: [AddTaskBarParserService, AddTaskBarStateService],
+        providers: [
+          AddTaskBarParserService,
+          AddTaskBarStateService,
+          provideMockStore({
+            selectors: [{ selector: selectAllSections, value: [] }],
+          }),
+        ],
       });
       service = TestBed.inject(AddTaskBarParserService);
       realState = TestBed.inject(AddTaskBarStateService);
@@ -2086,6 +2112,7 @@ describe('AddTaskBarParserService', () => {
     const defaultProject = { id: 'default-project', title: 'Default Project' } as Project;
     const baseState = {
       projectId: 'default-project',
+      sectionId: null,
       tagIds: [],
       tagIdsFromTxt: [],
       newTagTitles: [],

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { AddTaskBarParserService } from './add-task-bar-parser.service';
 import { AddTaskBarStateService } from './add-task-bar-state.service';
 import { selectAllSections } from '../../section/store/section.selectors';
@@ -2145,6 +2145,121 @@ describe('AddTaskBarParserService', () => {
       mockStateService.state.and.returnValue(baseState as any);
       await service.parseAndUpdateText('', cfg, [], [], defaultProject);
       expect(mockStateService.updateSyntaxHighlight).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('section validation against the final project (round-3 review, PR #9014)', () => {
+    const cfg = {
+      isEnableProject: true,
+      isEnableDue: true,
+      isEnableTag: true,
+    } as ShortSyntaxConfig;
+    const defaultProject = { id: 'default-project', title: 'Default Project' } as Project;
+    const workProject = { id: 'work', title: 'Work' } as Project;
+    const designSection = {
+      id: 'sec-design',
+      contextId: 'work',
+      contextType: 'PROJECT',
+      title: 'Design',
+      taskIds: [],
+    };
+    const makeState = (projectId: string): unknown => ({
+      projectId,
+      sectionId: null,
+      tagIds: [],
+      tagIdsFromTxt: [],
+      newTagTitles: [],
+      date: null,
+      time: null,
+      spent: null,
+      estimate: null,
+      cleanText: null,
+      remindOption: null,
+      attachments: [],
+      repeatQuickSetting: null,
+      deadlineDate: null,
+      deadlineTime: null,
+      deadlineRemindOption: null,
+    });
+
+    // Mirror the real state service closely enough for the two-step
+    // sequence: project updates clear the section, every update lands in
+    // `liveState` so the service's own `state()` reads see it.
+    let liveState: { projectId: string; sectionId: string | null };
+    beforeEach(() => {
+      const store = TestBed.inject(MockStore);
+      store.overrideSelector(selectAllSections, [designSection] as never[]);
+      liveState = makeState(defaultProject.id) as typeof liveState;
+      mockStateService.state.and.callFake((() => liveState) as any);
+      mockStateService.isAutoDetected.and.returnValue(true);
+      mockStateService.setAutoDetectedProjectId.and.callFake((id: string) => {
+        liveState = { ...liveState, projectId: id, sectionId: null };
+      });
+      mockStateService.updateProjectId.and.callFake((id: string) => {
+        liveState = { ...liveState, projectId: id, sectionId: null };
+      });
+      mockStateService.updateSectionId.and.callFake((id: string | null) => {
+        liveState = { ...liveState, sectionId: id };
+      });
+    });
+
+    it('should resolve "+Work/Design" to Work + its section', async () => {
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+      expect(liveState.projectId).toBe('work');
+      expect(liveState.sectionId).toBe('sec-design');
+    });
+
+    it('should clear a stale section from another project when the +Project token is deleted', async () => {
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+
+      // Deleting just "+Work" falls the task back to the default project;
+      // the leftover "/Design" must NOT keep pointing at Work's section.
+      await service.parseAndUpdateText(
+        'buy milk /Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+      expect(liveState.projectId).toBe(defaultProject.id);
+      expect(liveState.sectionId).toBeNull();
+    });
+
+    it('should clear the section when the user manually picks another project', async () => {
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+
+      // Manual selection: the state service clears the section and the
+      // auto-detected flag; a re-parse of the unchanged text must not
+      // re-apply Work's section to the manually chosen project.
+      liveState = { ...liveState, projectId: defaultProject.id, sectionId: null };
+      mockStateService.isAutoDetected.and.returnValue(false);
+      await service.parseAndUpdateText(
+        'buy milk +Work/Design',
+        cfg,
+        [defaultProject, workProject],
+        [],
+        defaultProject,
+      );
+      expect(liveState.projectId).toBe(defaultProject.id);
+      expect(liveState.sectionId).toBeNull();
     });
   });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { AddTaskBarParserService } from './add-task-bar-parser.service';
 import { AddTaskBarStateService } from './add-task-bar-state.service';
+import { selectAllSections } from '../../section/store/section.selectors';
 import { ShortSyntaxConfig } from '../../config/global-config.model';
 import { Project } from '../../project/project.model';
 import { Tag } from '../../tag/tag.model';
@@ -29,6 +31,7 @@ describe('AddTaskBarParserService', () => {
       'clearRepeatSetting',
       'updateSyntaxHighlight',
       'updateRemindOption',
+      'updateSectionId',
       'isAutoDetected',
       'state',
       'inputTxt',
@@ -57,6 +60,9 @@ describe('AddTaskBarParserService', () => {
       providers: [
         AddTaskBarParserService,
         { provide: AddTaskBarStateService, useValue: mockStateServiceSpy },
+        provideMockStore({
+          selectors: [{ selector: selectAllSections, value: [] }],
+        }),
       ],
     });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -1,6 +1,9 @@
 import { inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { firstValueFrom } from 'rxjs';
 import { Project } from '../../project/project.model';
 import { Tag } from '../../tag/tag.model';
+import { selectAllSections } from '../../section/store/section.selectors';
 import { AddTaskBarStateService } from './add-task-bar-state.service';
 import {
   SHORT_SYNTAX_REPEAT_REMOVAL_REG_EX,
@@ -17,6 +20,7 @@ import { millisecondsDiffToRemindOption } from '../util/remind-option-to-millise
 interface PreviousParseResult {
   cleanText: string | null;
   projectId: string | null;
+  sectionId: string | null;
   tagIds: string[];
   newTagTitles: string[];
   timeSpentOnDay: TimeSpentOnDay | null;
@@ -35,6 +39,7 @@ interface PreviousParseResult {
 @Injectable()
 export class AddTaskBarParserService {
   private readonly _stateService = inject(AddTaskBarStateService);
+  private readonly _store = inject(Store);
   private _previousParseResult: PreviousParseResult | null = null;
   private _parseRunId = 0;
 
@@ -80,6 +85,7 @@ export class AddTaskBarParserService {
 
     // Get current tags from state to preserve pre-selected tags
     const currentState = this._stateService.state();
+    const allSections = await firstValueFrom(this._store.select(selectAllSections));
     const parseResult = await shortSyntax(
       { title: text, tagIds: currentState.tagIdsFromTxt },
       config,
@@ -88,6 +94,9 @@ export class AddTaskBarParserService {
       undefined,
       'replace',
       true,
+      allSections,
+      // Context for a standalone "/Section" token (no "+Project" typed)
+      currentState.projectId || defaultProject?.id,
     );
 
     if (parseRunId !== this._parseRunId) {
@@ -130,6 +139,7 @@ export class AddTaskBarParserService {
         projectId: this._stateService.isAutoDetected()
           ? defaultProject?.id || null
           : null,
+        sectionId: null,
         tagIds: currentState.tagIdsFromTxt, // Preserve pre-selected tags
         newTagTitles: [],
         timeSpentOnDay: null,
@@ -223,6 +233,7 @@ export class AddTaskBarParserService {
       currentResult = {
         cleanText: parseResult.taskChanges.title || text,
         projectId: parseResult.projectId || null,
+        sectionId: parseResult.sectionId || null,
         tagIds: tagIds,
         newTagTitles: newTagTitles,
         timeSpentOnDay: parseResult.taskChanges.timeSpentOnDay || null,
@@ -261,6 +272,15 @@ export class AddTaskBarParserService {
           this._stateService.updateProjectId(defaultProject.id);
         }
       }
+    }
+
+    // After the project (updateProjectId resets the section to null)
+    if (
+      !this._previousParseResult ||
+      this._previousParseResult.sectionId !== currentResult.sectionId ||
+      this._stateService.state().sectionId !== currentResult.sectionId
+    ) {
+      this._stateService.updateSectionId(currentResult.sectionId);
     }
 
     if (

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -274,7 +274,20 @@ export class AddTaskBarParserService {
       }
     }
 
-    // After the project (updateProjectId resets the section to null)
+    // After the project (updateProjectId resets the section to null). A
+    // parsed section must belong to the project the task will actually land
+    // in: the standalone-"/Section" context handed to the parser can be one
+    // edit stale (deleting "+Work" still resolves "/Design" against Work), so
+    // validate against the CURRENT project — the block above has already
+    // updated it (round-3 review finding on PR #9014).
+    const finalProjectId = this._stateService.state().projectId;
+    currentResult.sectionId =
+      currentResult.sectionId &&
+      allSections.some(
+        (s) => s.id === currentResult.sectionId && s.contextId === finalProjectId,
+      )
+        ? currentResult.sectionId
+        : null;
     if (
       !this._previousParseResult ||
       this._previousParseResult.sectionId !== currentResult.sectionId ||

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -316,7 +316,20 @@ export class AddTaskBarParserService {
       }
     }
 
-    // After the project (updateProjectId resets the section to null)
+    // After the project (updateProjectId resets the section to null). A
+    // parsed section must belong to the project the task will actually land
+    // in: the standalone-"/Section" context handed to the parser can be one
+    // edit stale (deleting "+Work" still resolves "/Design" against Work), so
+    // validate against the CURRENT project — the block above has already
+    // updated it (round-3 review finding on PR #9014).
+    const finalProjectId = this._stateService.state().projectId;
+    currentResult.sectionId =
+      currentResult.sectionId &&
+      allSections.some(
+        (s) => s.id === currentResult.sectionId && s.contextId === finalProjectId,
+      )
+        ? currentResult.sectionId
+        : null;
     if (
       !this._previousParseResult ||
       this._previousParseResult.sectionId !== currentResult.sectionId ||

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -1,6 +1,9 @@
 import { inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { firstValueFrom } from 'rxjs';
 import { Project } from '../../project/project.model';
 import { Tag } from '../../tag/tag.model';
+import { selectAllSections } from '../../section/store/section.selectors';
 import { AddTaskBarStateService } from './add-task-bar-state.service';
 import { AddTaskBarRepeat } from './add-task-bar.const';
 import {
@@ -19,6 +22,7 @@ import { millisecondsDiffToRemindOption } from '../util/remind-option-to-millise
 interface PreviousParseResult {
   cleanText: string | null;
   projectId: string | null;
+  sectionId: string | null;
   tagIds: string[];
   newTagTitles: string[];
   timeSpentOnDay: TimeSpentOnDay | null;
@@ -57,6 +61,7 @@ const isSameRepeat = (
 @Injectable()
 export class AddTaskBarParserService {
   private readonly _stateService = inject(AddTaskBarStateService);
+  private readonly _store = inject(Store);
   private _previousParseResult: PreviousParseResult | null = null;
   private _parseRunId = 0;
   // Exactly which characters of which input the parser last consumed, so a
@@ -108,7 +113,12 @@ export class AddTaskBarParserService {
       return;
     }
 
-    // Get current tags from state to preserve pre-selected tags
+    const allSections = await firstValueFrom(this._store.select(selectAllSections));
+    // Context for a standalone "/Section" token (no "+Project" typed) — read
+    // BEFORE the parse so it reflects the selection the text was typed against
+    // (the parsed section is re-validated against the final project below).
+    const sectionContextProjectId =
+      this._stateService.state().projectId || defaultProject?.id;
     const parseResult = await shortSyntax(
       { title: text, tagIds: this._stateService.state().tagIdsFromTxt },
       config,
@@ -117,6 +127,8 @@ export class AddTaskBarParserService {
       undefined,
       'replace',
       true,
+      allSections,
+      sectionContextProjectId,
     );
 
     if (parseRunId !== this._parseRunId) {
@@ -168,6 +180,7 @@ export class AddTaskBarParserService {
         projectId: this._stateService.isAutoDetected()
           ? defaultProject?.id || null
           : null,
+        sectionId: null,
         tagIds: currentState.tagIdsFromTxt, // Preserve pre-selected tags
         newTagTitles: [],
         timeSpentOnDay: null,
@@ -262,6 +275,7 @@ export class AddTaskBarParserService {
       currentResult = {
         cleanText: parseResult.taskChanges.title || text,
         projectId: parseResult.projectId || null,
+        sectionId: parseResult.sectionId || null,
         tagIds: tagIds,
         newTagTitles: newTagTitles,
         timeSpentOnDay: parseResult.taskChanges.timeSpentOnDay || null,
@@ -300,6 +314,15 @@ export class AddTaskBarParserService {
           this._stateService.updateProjectId(defaultProject.id);
         }
       }
+    }
+
+    // After the project (updateProjectId resets the section to null)
+    if (
+      !this._previousParseResult ||
+      this._previousParseResult.sectionId !== currentResult.sectionId ||
+      this._stateService.state().sectionId !== currentResult.sectionId
+    ) {
+      this._stateService.updateSectionId(currentResult.sectionId);
     }
 
     if (

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -54,9 +54,18 @@ export class AddTaskBarStateService {
   }
 
   updateProjectId(projectId: string): void {
-    this._taskInputState.update((state) => ({ ...state, projectId }));
+    this._taskInputState.update((state) => ({
+      ...state,
+      projectId,
+      // A section only makes sense within its project
+      sectionId: null,
+    }));
     // Clear auto-detected flag when manually changing project
     this.isAutoDetected.set(false);
+  }
+
+  updateSectionId(sectionId: string | null): void {
+    this._taskInputState.update((state) => ({ ...state, sectionId }));
   }
 
   updateDate(date: string | null, time?: string | null): void {
@@ -208,6 +217,10 @@ export class AddTaskBarStateService {
     // Only clear input text and tags, preserve project, date, and estimate
     this._taskInputState.update((state) => ({
       ...state,
+      // Unlike the project, the section came from the (now cleared) input
+      // text and has no visible UI element — keeping it would silently file
+      // follow-up tasks into it.
+      sectionId: null,
       tagIds: [],
       tagIdsFromTxt: [],
       newTagTitles: [],

--- a/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-state.service.ts
@@ -57,9 +57,18 @@ export class AddTaskBarStateService {
   }
 
   updateProjectId(projectId: string): void {
-    this._taskInputState.update((state) => ({ ...state, projectId }));
+    this._taskInputState.update((state) => ({
+      ...state,
+      projectId,
+      // A section only makes sense within its project
+      sectionId: null,
+    }));
     // Clear auto-detected flag when manually changing project
     this.isAutoDetected.set(false);
+  }
+
+  updateSectionId(sectionId: string | null): void {
+    this._taskInputState.update((state) => ({ ...state, sectionId }));
   }
 
   updateDate(date: string | null, time?: string | null, cleanedInputTxt?: string): void {
@@ -227,6 +236,10 @@ export class AddTaskBarStateService {
     // Only clear input text and tags, preserve project, date, and estimate
     this._taskInputState.update((state) => ({
       ...state,
+      // Unlike the project, the section came from the (now cleared) input
+      // text and has no visible UI element — keeping it would silently file
+      // follow-up tasks into it.
+      sectionId: null,
       tagIds: [],
       tagIdsFromTxt: [],
       newTagTitles: [],

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AddTaskBarComponent } from './add-task-bar.component';
 import { TaskService } from '../task.service';
+import { SectionService } from '../../section/section.service';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { ProjectService } from '../../project/project.service';
 import { TagService } from '../../tag/tag.service';
@@ -460,6 +461,75 @@ describe('AddTaskBarComponent', () => {
         }),
       );
       expect(mockTaskService.moveToCurrentWorkContext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addTask → section placement (PR #9014)', () => {
+    const designSection = {
+      id: 'sec-1',
+      contextId: 'project-1',
+      contextType: 'PROJECT',
+      title: 'Design',
+      taskIds: [],
+    };
+    let addToSectionSpy: jasmine.Spy;
+
+    const setupSectionAdd = (sections: unknown[]): void => {
+      mockStore.select.and.returnValue(of(sections));
+      mockTaskService.add.and.returnValue('task-1');
+      addToSectionSpy = spyOn(TestBed.inject(SectionService), 'addTaskToSection');
+      component.stateService.updateInputTxt('New task');
+      component.stateService.updateCleanText('New task');
+      // updateProjectId clears the section, so set the project first
+      component.stateService.updateProjectId('project-1');
+      component.stateService.updateSectionId('sec-1');
+    };
+
+    it('should file the new task into the parsed section of its project', async () => {
+      setupSectionAdd([designSection]);
+
+      await component.addTask();
+
+      expect(addToSectionSpy).toHaveBeenCalledWith('sec-1', 'task-1', null, null);
+    });
+
+    it('should respect add-to-bottom inside the section', async () => {
+      setupSectionAdd([{ ...designSection, taskIds: ['t-a', 't-b'] }]);
+      component.isAddToBottom.set(true);
+
+      await component.addTask();
+
+      expect(addToSectionSpy).toHaveBeenCalledWith('sec-1', 'task-1', 't-b', null);
+    });
+
+    it('should NOT file the task when the section belongs to another project (write-site guard)', async () => {
+      // Round-3 review finding on PR #9014: a stale sectionId must never put
+      // a task id into another project's section.taskIds.
+      setupSectionAdd([{ ...designSection, contextId: 'project-2' }]);
+
+      await component.addTask();
+
+      expect(mockTaskService.add).toHaveBeenCalled();
+      expect(addToSectionSpy).not.toHaveBeenCalled();
+    });
+
+    it('should NOT file the task when the section no longer exists', async () => {
+      setupSectionAdd([]);
+
+      await component.addTask();
+
+      expect(mockTaskService.add).toHaveBeenCalled();
+      expect(addToSectionSpy).not.toHaveBeenCalled();
+    });
+
+    it('should skip section placement for backlog adds', async () => {
+      setupSectionAdd([designSection]);
+      component.isAddToBacklog.set(true);
+
+      await component.addTask();
+
+      expect(mockTaskService.add).toHaveBeenCalled();
+      expect(addToSectionSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -624,7 +624,11 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
             first(),
           ),
         );
-        if (targetSection) {
+        // Write-site guard in lock-step with the reducer's own checks: the
+        // section must still exist AND belong to the project the task was
+        // just created in — a stale sectionId must never file a task into
+        // another project's section (round-3 review finding on PR #9014).
+        if (targetSection && targetSection.contextId === state.projectId) {
           // Respect the add-to-bottom toggle within the section, too
           const afterTaskId = this.isAddToBottom()
             ? targetSection.taskIds[targetSection.taskIds.length - 1] || null

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -28,6 +28,8 @@ import { blendInOutAnimation } from 'src/app/ui/animations/blend-in-out.ani';
 import { expandFadeAnimation } from '../../../ui/animations/expand.ani';
 import { TaskCopy, TaskReminderOptionId } from '../task.model';
 import { TaskService } from '../task.service';
+import { SectionService } from '../../section/section.service';
+import { selectAllSections } from '../../section/store/section.selectors';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { WorkContext, WorkContextType } from '../../work-context/work-context.model';
 import { ProjectService } from '../../project/project.service';
@@ -46,7 +48,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
-import { BehaviorSubject, combineLatest, from, Observable } from 'rxjs';
+import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
 import {
@@ -124,6 +126,7 @@ export interface TaskAddEvent {
 })
 export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
   private readonly _taskService = inject(TaskService);
+  private readonly _sectionService = inject(SectionService);
   private readonly _workContextService = inject(WorkContextService);
   private readonly _projectService = inject(ProjectService);
   private readonly _tagService = inject(TagService);
@@ -271,7 +274,43 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     startWith([]),
   );
 
-  mentionCfg$ = inject(MentionConfigService).mentionConfig$;
+  // The project a "/" section suggestion would apply to: the typed
+  // "+Project" token when present, else the project the task will land in
+  // (work context / manual selection) — mirroring how the parser resolves a
+  // standalone "/Section" token.
+  private readonly _sectionMentionProjectId = computed(
+    () => this.stateService.state().projectId,
+  );
+
+  mentionCfg$ = combineLatest([
+    inject(MentionConfigService).mentionConfig$,
+    toObservable(this._sectionMentionProjectId),
+    this._store.select(selectAllSections),
+  ]).pipe(
+    map(([cfg, sectionProjectId, allSections]) => {
+      const sections = sectionProjectId
+        ? allSections.filter((s) => s.contextId === sectionProjectId)
+        : [];
+      if (!sections.length) {
+        return cfg;
+      }
+      return {
+        ...cfg,
+        mentions: [
+          ...(cfg.mentions || []),
+          {
+            items: sections.map((s) => ({
+              title: s.title,
+              id: s.id,
+              icon: 'view_agenda',
+            })),
+            labelKey: 'title',
+            triggerChar: '/',
+          },
+        ],
+      };
+    }),
+  );
 
   // View children
   inputEl = viewChild<ElementRef<HTMLTextAreaElement>>('inputEl');
@@ -568,6 +607,36 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
         taskData,
         this.isAddToBottom(),
       );
+
+      // Section membership lives on the section (taskIds), not the task —
+      // place the new task into the "+Project/Section" target if one parsed.
+      // Two dispatches for one gesture is the established pattern here: it
+      // mirrors drag-into-section (task-list.component), both ops replay
+      // deterministically, and the section reducer no-ops defensively if the
+      // section vanished concurrently.
+      // Skipped for backlog adds: sections only group the main list
+      // (undoneTasksBySection), so a backlogged task would carry an invisible
+      // section membership.
+      if (state.sectionId && state.projectId && !this.isAddToBacklog()) {
+        const targetSection = await firstValueFrom(
+          this._store.select(selectAllSections).pipe(
+            map((all) => all.find((s) => s.id === state.sectionId)),
+            first(),
+          ),
+        );
+        if (targetSection) {
+          // Respect the add-to-bottom toggle within the section, too
+          const afterTaskId = this.isAddToBottom()
+            ? targetSection.taskIds[targetSection.taskIds.length - 1] || null
+            : null;
+          this._sectionService.addTaskToSection(
+            state.sectionId,
+            taskId,
+            afterTaskId,
+            null,
+          );
+        }
+      }
 
       // Resolve remind option once for both scheduleTask and repeat config paths
       const resolvedRemindOption =

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -645,7 +645,11 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
             first(),
           ),
         );
-        if (targetSection) {
+        // Write-site guard in lock-step with the reducer's own checks: the
+        // section must still exist AND belong to the project the task was
+        // just created in — a stale sectionId must never file a task into
+        // another project's section (round-3 review finding on PR #9014).
+        if (targetSection && targetSection.contextId === state.projectId) {
           // Respect the add-to-bottom toggle within the section, too
           const afterTaskId = this.isAddToBottom()
             ? targetSection.taskIds[targetSection.taskIds.length - 1] || null

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -28,6 +28,8 @@ import { blendInOutAnimation } from 'src/app/ui/animations/blend-in-out.ani';
 import { expandFadeAnimation } from '../../../ui/animations/expand.ani';
 import { TaskCopy, TaskReminderOptionId } from '../task.model';
 import { TaskService } from '../task.service';
+import { SectionService } from '../../section/section.service';
+import { selectAllSections } from '../../section/store/section.selectors';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { WorkContext, WorkContextType } from '../../work-context/work-context.model';
 import { ProjectService } from '../../project/project.service';
@@ -46,7 +48,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
-import { BehaviorSubject, combineLatest, from, Observable } from 'rxjs';
+import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
 import {
@@ -126,6 +128,7 @@ export interface TaskAddEvent {
 })
 export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
   private readonly _taskService = inject(TaskService);
+  private readonly _sectionService = inject(SectionService);
   private readonly _workContextService = inject(WorkContextService);
   private readonly _projectService = inject(ProjectService);
   private readonly _tagService = inject(TagService);
@@ -273,7 +276,43 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     startWith([]),
   );
 
-  mentionCfg$ = inject(MentionConfigService).mentionConfig$;
+  // The project a "/" section suggestion would apply to: the typed
+  // "+Project" token when present, else the project the task will land in
+  // (work context / manual selection) — mirroring how the parser resolves a
+  // standalone "/Section" token.
+  private readonly _sectionMentionProjectId = computed(
+    () => this.stateService.state().projectId,
+  );
+
+  mentionCfg$ = combineLatest([
+    inject(MentionConfigService).mentionConfig$,
+    toObservable(this._sectionMentionProjectId),
+    this._store.select(selectAllSections),
+  ]).pipe(
+    map(([cfg, sectionProjectId, allSections]) => {
+      const sections = sectionProjectId
+        ? allSections.filter((s) => s.contextId === sectionProjectId)
+        : [];
+      if (!sections.length) {
+        return cfg;
+      }
+      return {
+        ...cfg,
+        mentions: [
+          ...(cfg.mentions || []),
+          {
+            items: sections.map((s) => ({
+              title: s.title,
+              id: s.id,
+              icon: 'view_agenda',
+            })),
+            labelKey: 'title',
+            triggerChar: '/',
+          },
+        ],
+      };
+    }),
+  );
 
   // View children
   inputEl = viewChild<ElementRef<HTMLTextAreaElement>>('inputEl');
@@ -589,6 +628,36 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
         taskData,
         this.isAddToBottom(),
       );
+
+      // Section membership lives on the section (taskIds), not the task —
+      // place the new task into the "+Project/Section" target if one parsed.
+      // Two dispatches for one gesture is the established pattern here: it
+      // mirrors drag-into-section (task-list.component), both ops replay
+      // deterministically, and the section reducer no-ops defensively if the
+      // section vanished concurrently.
+      // Skipped for backlog adds: sections only group the main list
+      // (undoneTasksBySection), so a backlogged task would carry an invisible
+      // section membership.
+      if (state.sectionId && state.projectId && !this.isAddToBacklog()) {
+        const targetSection = await firstValueFrom(
+          this._store.select(selectAllSections).pipe(
+            map((all) => all.find((s) => s.id === state.sectionId)),
+            first(),
+          ),
+        );
+        if (targetSection) {
+          // Respect the add-to-bottom toggle within the section, too
+          const afterTaskId = this.isAddToBottom()
+            ? targetSection.taskIds[targetSection.taskIds.length - 1] || null
+            : null;
+          this._sectionService.addTaskToSection(
+            state.sectionId,
+            taskId,
+            afterTaskId,
+            null,
+          );
+        }
+      }
 
       // Resolve remind option once for both scheduleTask and repeat config paths
       const resolvedRemindOption =

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -288,11 +288,17 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     inject(MentionConfigService).mentionConfig$,
     toObservable(this._sectionMentionProjectId),
     this._store.select(selectAllSections),
+    this._globalConfigService.shortSyntax$,
   ]).pipe(
-    map(([cfg, sectionProjectId, allSections]) => {
-      const sections = sectionProjectId
-        ? allSections.filter((s) => s.contextId === sectionProjectId)
-        : [];
+    map(([cfg, sectionProjectId, allSections, shortSyntaxCfg]) => {
+      // The "/" mention rides the project short-syntax toggle, exactly like
+      // the parser paths it feeds — with project syntax off, a picked item
+      // would just leave "/Design" sitting in the title (round-4 review
+      // finding on PR #9014).
+      const sections =
+        sectionProjectId && shortSyntaxCfg?.isEnableProject
+          ? allSections.filter((s) => s.contextId === sectionProjectId)
+          : [];
       if (!sections.length) {
         return cfg;
       }
@@ -640,10 +646,9 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
       // section membership.
       if (state.sectionId && state.projectId && !this.isAddToBacklog()) {
         const targetSection = await firstValueFrom(
-          this._store.select(selectAllSections).pipe(
-            map((all) => all.find((s) => s.id === state.sectionId)),
-            first(),
-          ),
+          this._store
+            .select(selectAllSections)
+            .pipe(map((all) => all.find((s) => s.id === state.sectionId))),
         );
         // Write-site guard in lock-step with the reducer's own checks: the
         // section must still exist AND belong to the project the task was

--- a/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
@@ -5,6 +5,9 @@ import { RepeatQuickSetting } from '../../task-repeat-cfg/task-repeat-cfg.model'
 
 export interface AddTaskBarState {
   projectId: string;
+  // Section within the project (from "+Project/Section" syntax); the task is
+  // added to it after creation (section membership is not a task field).
+  sectionId?: string | null;
   tagIds: string[];
   tagIdsFromTxt: string[];
   date: string | null;
@@ -37,6 +40,7 @@ export const ESTIMATE_OPTIONS = [
 
 export const INITIAL_ADD_TASK_BAR_STATE: AddTaskBarState = {
   projectId: INBOX_PROJECT.id,
+  sectionId: null,
   tagIds: [],
   tagIdsFromTxt: [],
   date: null,

--- a/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
@@ -12,6 +12,9 @@ export type AddTaskBarRepeat = ShortSyntaxRepeat | { type: 'DIALOG' };
 
 export interface AddTaskBarState {
   projectId: string;
+  // Section within the project (from "+Project/Section" syntax); the task is
+  // added to it after creation (section membership is not a task field).
+  sectionId?: string | null;
   tagIds: string[];
   tagIdsFromTxt: string[];
   date: string | null;
@@ -44,6 +47,7 @@ export const ESTIMATE_OPTIONS = [
 
 export const INITIAL_ADD_TASK_BAR_STATE: AddTaskBarState = {
   projectId: INBOX_PROJECT.id,
+  sectionId: null,
   tagIds: [],
   tagIdsFromTxt: [],
   date: null,

--- a/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.const.ts
@@ -14,7 +14,7 @@ export interface AddTaskBarState {
   projectId: string;
   // Section within the project (from "+Project/Section" syntax); the task is
   // added to it after creation (section membership is not a task field).
-  sectionId?: string | null;
+  sectionId: string | null;
   tagIds: string[];
   tagIdsFromTxt: string[];
   date: string | null;

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1891,6 +1891,216 @@ describe('shortSyntax', () => {
         expect(r?.taskChanges.timeEstimate).toBe(2 * 60 * 60 * 1000);
       });
     });
+
+    describe('round-3 review regressions (PR #9014)', () => {
+      it('should not treat "+/" as a project token — "+/-" is ordinary text', async () => {
+        for (const title of [
+          'temp +/- 5 degrees',
+          'budget +/-10% ok',
+          'review PR +/- comments',
+        ]) {
+          const r = await shortSyntax(
+            { ...TASK, title },
+            CONFIG,
+            [],
+            projects,
+            undefined,
+            'combine',
+            false,
+            sections,
+            'WorkID',
+          );
+          expect(r?.projectId)
+            .withContext(`"${title}" must not match a project`)
+            .toBeUndefined();
+          expect(r?.taskChanges?.title)
+            .withContext(`"${title}" must keep its title`)
+            .toBeUndefined();
+        }
+      });
+
+      it('should not match a half-deleted "+/Section" against any project', async () => {
+        // Backspacing the project name out of "+Work/Design" passes through
+        // this state; it must stay inert instead of jumping to the
+        // shortest-titled project.
+        const r = await shortSyntax(
+          { ...TASK, title: 'buy milk +/Design' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r).toBeUndefined();
+      });
+
+      it('should not let the shortest project title win for an empty left side', async () => {
+        // The project picked used to depend on title length — assert no
+        // match for several project sets instead of a lucky fixture.
+        const projectSets = [
+          [
+            { title: 'Work', id: 'WorkID' },
+            { title: 'Personal Stuff', id: 'PersonalID' },
+          ],
+          [
+            { title: 'Work', id: 'WorkID' },
+            { title: 'Zoo', id: 'ZooID' },
+          ],
+          [
+            { title: 'Work', id: 'WorkID' },
+            { title: 'Ab', id: 'AbID' },
+          ],
+        ] as any[];
+        for (const set of projectSets) {
+          const r = await shortSyntax(
+            { ...TASK, title: 'temp +/- 5 degrees' },
+            CONFIG,
+            [],
+            set,
+            undefined,
+            'combine',
+            false,
+            sections,
+          );
+          expect(r).withContext(set.map((p: Project) => p.title).join(',')).toBeUndefined();
+        }
+      });
+
+      it('should strip a multi-word section fully with trailing task text (+Project form)', async () => {
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Design Reviews finish draft' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.title).toBe('Task finish draft');
+      });
+
+      it('should strip a multi-word section fully with trailing task text (standalone form)', async () => {
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task /Design Reviews finish draft' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.title).toBe('Task finish draft');
+      });
+
+      it('should consume the longest matching word span, not the whole remainder', async () => {
+        const roadMapSections = [
+          ...sections,
+          {
+            id: 'RoadMapID',
+            contextId: 'WorkID',
+            contextType: 'PROJECT',
+            title: 'Road Map',
+            taskIds: [],
+          },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Road Map finish draft' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          roadMapSections,
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('RoadMapID');
+        expect(r?.taskChanges.title).toBe('Task finish draft');
+      });
+
+      it('should rank a full project+section match above the first-word project fallback', async () => {
+        // "+Work/Design fix login": "Work/Design" is also a prefix of the
+        // project "Work/Design Archive", but a whole-token match is strong
+        // evidence while a first-word prefix match is weak — the resolved
+        // project+section wins.
+        const archiveProjects = [
+          ...projects,
+          { title: 'Work/Design Archive', id: 'ArchiveID' },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Design fix login' },
+          CONFIG,
+          [],
+          archiveProjects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.title).toBe('Task fix login');
+      });
+
+      it('should not read a section out of a slash-titled project token', async () => {
+        // "+A/B Testing extra words": the left side "A" and the first word
+        // "A/B" both prefix the project "A/B Testing" — the "/" belongs to
+        // the project's own title, so its right side must never be matched
+        // as a section ("B" would prefix-match "Backlog").
+        const abSections = [
+          ...sections,
+          {
+            id: 'AbBacklogID',
+            contextId: 'SlashProjectID',
+            contextType: 'PROJECT',
+            title: 'Backlog',
+            taskIds: [],
+          },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +A/B Testing extra words' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          abSections,
+        );
+        expect(r?.projectId).toBe('SlashProjectID');
+        expect(r?.sectionId).toBeUndefined();
+        expect(r?.taskChanges.title).toBe('Task Testing extra words');
+      });
+
+      it('should still prefer an exact whole-token project over a section interpretation', async () => {
+        const archiveProjects = [
+          ...projects,
+          { title: 'Work/Design Archive', id: 'ArchiveID' },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Design Archive' },
+          CONFIG,
+          [],
+          archiveProjects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.projectId).toBe('ArchiveID');
+        expect(r?.sectionId).toBeUndefined();
+        expect(r?.taskChanges.title).toBe('Task');
+      });
+    });
   });
 
   // This group of tests address Chrono's parsing the format "<date> <month> <yy}>" as year

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -13,6 +13,7 @@ import {
 import { Tag } from '../tag/tag.model';
 import { DEFAULT_TAG } from '../tag/tag.const';
 import { Project } from '../project/project.model';
+import { Section } from '../section/section.model';
 import { DEFAULT_GLOBAL_CONFIG } from '../config/default-global-config.const';
 import { INBOX_PROJECT } from '../project/project.const';
 
@@ -1510,6 +1511,386 @@ describe('shortSyntax', () => {
         });
       }
     }
+  });
+
+  describe('project sections (+Project/Section)', () => {
+    let projects: Project[];
+    let sections: Section[];
+    beforeEach(() => {
+      projects = [
+        {
+          title: 'Work',
+          id: 'WorkID',
+        },
+        {
+          title: 'A/B Testing',
+          id: 'SlashProjectID',
+        },
+      ] as any;
+      sections = [
+        {
+          id: 'DesignSectionID',
+          contextId: 'WorkID',
+          contextType: 'PROJECT',
+          title: 'Design Reviews',
+          taskIds: [],
+        },
+        {
+          id: 'OtherProjectSectionID',
+          contextId: 'OtherProjectID',
+          contextType: 'PROJECT',
+          title: 'Design Reviews',
+          taskIds: [],
+        },
+      ] as any;
+    });
+
+    it('should match a section within the matched project', async () => {
+      const t = {
+        ...TASK,
+        title: 'Review mockups +Work/Design Reviews',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.taskChanges.title).toBe('Review mockups');
+    });
+
+    it('should match a section by prefix', async () => {
+      const t = {
+        ...TASK,
+        title: 'Review mockups +Work/des',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.taskChanges.title).toBe('Review mockups');
+    });
+
+    it('should match section by first word with trailing text kept in title', async () => {
+      const t = {
+        ...TASK,
+        title: '+Work/design fix the login flow',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.taskChanges.title).toBe('fix the login flow');
+    });
+
+    it('should only match sections belonging to the matched project', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +Work/Design',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.sectionId).not.toBe('OtherProjectSectionID');
+    });
+
+    it('should prefer a project whose title contains "/" over section syntax', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +A/B Testing',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('SlashProjectID');
+      expect(r?.sectionId).toBeUndefined();
+      expect(r?.taskChanges.title).toBe('Task');
+    });
+
+    it('should prefer a project whose title contains "/" with trailing words', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +A/B Testing extra words',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('SlashProjectID');
+      expect(r?.sectionId).toBeUndefined();
+      // Regression (PR #9014 review): matches master's first-word fallback —
+      // strip "+A/B", not "+A/", so no orphaned "B" remains.
+      expect(r?.taskChanges.title).toBe('Task Testing extra words');
+    });
+
+    it('should match the project without a section when the section part matches nothing', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +Work/nonexistent',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBeUndefined();
+      // Regression (PR #9014 review): the whole "+Work/" must be stripped —
+      // leaving "/nonexistent" in the title orphans a stray slash.
+      expect(r?.taskChanges.title).toBe('Task nonexistent');
+    });
+
+    it('should not leave a slash residue for an unmatched section mid-title', async () => {
+      const t = {
+        ...TASK,
+        title: 'buy milk +Work/grocer',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBeUndefined();
+      expect(r?.taskChanges.title).toBe('buy milk grocer');
+    });
+
+    it('should not leave a slash residue when the token leads the title', async () => {
+      const t = {
+        ...TASK,
+        title: '+Work/review the Q3 numbers',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.taskChanges.title).toBe('review the Q3 numbers');
+    });
+
+    it('should clean the full token for a multi-word project with a section', async () => {
+      const multiProjects = [
+        ...projects,
+        { title: 'Work Space', id: 'WorkSpaceID' },
+      ] as any;
+      const multiSections = [
+        ...sections,
+        {
+          id: 'WsDesignID',
+          contextId: 'WorkSpaceID',
+          contextType: 'PROJECT',
+          title: 'Design',
+          taskIds: [],
+        },
+      ] as any;
+      const t = {
+        ...TASK,
+        title: 'Task +Work Space/Design',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        multiProjects,
+        undefined,
+        'combine',
+        false,
+        multiSections,
+      );
+      expect(r?.projectId).toBe('WorkSpaceID');
+      expect(r?.sectionId).toBe('WsDesignID');
+      expect(r?.taskChanges.title).toBe('Task');
+    });
+
+    it('should not return a section when no sections are passed', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +Work/Design',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBeUndefined();
+    });
+
+    describe('standalone /Section (context project)', () => {
+      it('should match a section of the context project without a + token', async () => {
+        const t = {
+          ...TASK,
+          title: 'Review mockups /Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.projectId).toBeUndefined();
+        expect(r?.taskChanges.title).toBe('Review mockups');
+      });
+
+      it('should let an explicit +Project/Section win over the context project', async () => {
+        const t = {
+          ...TASK,
+          title: 'Task +Work/Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'OtherProjectID',
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('DesignSectionID');
+      });
+
+      it('should leave the title untouched when nothing matches', async () => {
+        const t = {
+          ...TASK,
+          title: 'Deploy w/ care /nonexistent',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBeUndefined();
+        expect(r?.taskChanges.title ?? t.title).toBe('Deploy w/ care /nonexistent');
+      });
+
+      it('should ignore slashes inside words and after spaces', async () => {
+        const t = {
+          ...TASK,
+          title: 'either/or / Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBeUndefined();
+      });
+
+      it('should do nothing without a context project', async () => {
+        const t = {
+          ...TASK,
+          title: 'Task /Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.sectionId).toBeUndefined();
+      });
+
+      it('should not break time estimate syntax with slashes', async () => {
+        const t = {
+          ...TASK,
+          title: 'Task 1h/2h /Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.timeSpentOnDay).toBeDefined();
+        expect(r?.taskChanges.timeEstimate).toBe(2 * 60 * 60 * 1000);
+      });
+    });
   });
 
   // This group of tests address Chrono's parsing the format "<date> <month> <yy}>" as year

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1856,9 +1856,9 @@ describe('shortSyntax', () => {
       );
       expect(r?.projectId).toBe('SlashProjectID');
       expect(r?.sectionId).toBeUndefined();
-      // Regression (PR #9014 review): matches master's first-word fallback —
-      // strip "+A/B", not "+A/", so no orphaned "B" remains.
-      expect(r?.taskChanges.title).toBe('Task Testing extra words');
+      // The word-wise matcher (#9679) consumes the fully typed project title
+      // "+A/B Testing", so only the actual task content remains.
+      expect(r?.taskChanges.title).toBe('Task extra words');
     });
 
     it('should match the project without a section when the section part matches nothing', async () => {
@@ -2160,7 +2160,9 @@ describe('shortSyntax', () => {
             false,
             sections,
           );
-          expect(r).withContext(set.map((p: Project) => p.title).join(',')).toBeUndefined();
+          expect(r)
+            .withContext(set.map((p: Project) => p.title).join(','))
+            .toBeUndefined();
         }
       });
 
@@ -2222,11 +2224,12 @@ describe('shortSyntax', () => {
         expect(r?.taskChanges.title).toBe('Task finish draft');
       });
 
-      it('should rank a full project+section match above the first-word project fallback', async () => {
-        // "+Work/Design fix login": "Work/Design" is also a prefix of the
-        // project "Work/Design Archive", but a whole-token match is strong
-        // evidence while a first-word prefix match is weak — the resolved
-        // project+section wins.
+      it('should let a slash-titled project claim its slash over a section reading', async () => {
+        // "+Work/Design fix login" with a project literally titled
+        // "Work/Design Archive": the first word including the slash prefixes
+        // that project, so it wins — reading Work + section "Design Reviews"
+        // instead would silently change which PROJECT the task lands in
+        // (round-4 review finding on PR #9014).
         const archiveProjects = [
           ...projects,
           { title: 'Work/Design Archive', id: 'ArchiveID' },
@@ -2241,9 +2244,129 @@ describe('shortSyntax', () => {
           false,
           sections,
         );
-        expect(r?.projectId).toBe('WorkID');
-        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.projectId).toBe('ArchiveID');
+        expect(r?.sectionId).toBeUndefined();
         expect(r?.taskChanges.title).toBe('Task fix login');
+      });
+
+      it('should never flip the project when a trailing word is added (+Dev/Ops fix)', async () => {
+        // Round-4 repro: projects Dev + Dev/Ops, section "Ops" inside Dev.
+        // "+Dev/Ops" and "+Dev/Ops fix" must both resolve to the Dev/Ops
+        // PROJECT — never to Dev + section Ops.
+        const devProjects = [
+          { title: 'Dev', id: 'DevID' },
+          { title: 'Dev/Ops', id: 'DevOpsID' },
+        ] as any;
+        const devSections = [
+          {
+            id: 'OpsSectionID',
+            contextId: 'DevID',
+            contextType: 'PROJECT',
+            title: 'Ops',
+            taskIds: [],
+          },
+        ] as any;
+        for (const [title, expectedTitle] of [
+          ['deploy +Dev/Ops', 'deploy'],
+          ['deploy +Dev/Ops fix', 'deploy fix'],
+        ]) {
+          const r = await shortSyntax(
+            { ...TASK, title },
+            CONFIG,
+            [],
+            devProjects,
+            undefined,
+            'combine',
+            false,
+            devSections,
+          );
+          expect(r?.projectId).withContext(title).toBe('DevOpsID');
+          expect(r?.sectionId).withContext(title).toBeUndefined();
+          expect(r?.taskChanges.title).withContext(title).toBe(expectedTitle);
+        }
+      });
+
+      it('should not change the project when the slash resolves no section', async () => {
+        // "+Work Inbox/whatever": the left side matches project "Work Inbox"
+        // but "whatever" is no section — the slash reading explained nothing,
+        // so the plain word-wise match ("Work") must win exactly like master
+        // (round-4 rule: section syntax never changes project resolution).
+        const inboxProjects = [
+          ...projects,
+          { title: 'Work Inbox', id: 'WorkInboxID' },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work Inbox/whatever y' },
+          CONFIG,
+          [],
+          inboxProjects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBeUndefined();
+        expect(r?.taskChanges.title).toBe('Task Inbox/whatever y');
+      });
+
+      it('should still pick the multi-word left project when its section matches', async () => {
+        const inboxProjects = [
+          ...projects,
+          { title: 'Work Inbox', id: 'WorkInboxID' },
+        ] as any;
+        const inboxSections = [
+          ...sections,
+          {
+            id: 'TriageID',
+            contextId: 'WorkInboxID',
+            contextType: 'PROJECT',
+            title: 'Triage',
+            taskIds: [],
+          },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work Inbox/Triage y' },
+          CONFIG,
+          [],
+          inboxProjects,
+          undefined,
+          'combine',
+          false,
+          inboxSections,
+        );
+        expect(r?.projectId).toBe('WorkInboxID');
+        expect(r?.sectionId).toBe('TriageID');
+        expect(r?.taskChanges.title).toBe('Task y');
+      });
+
+      it('should strip a section containing non-space whitespace fully', async () => {
+        // Same class as the multi-word residue bug, with a tab instead of a
+        // space (round-4 review note): "/Road\tMap" must match "Road Map"
+        // and strip both words.
+        const roadMapSections = [
+          ...sections,
+          {
+            id: 'RoadMapID',
+            contextId: 'WorkID',
+            contextType: 'PROJECT',
+            title: 'Road Map',
+            taskIds: [],
+          },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'x /Road\tMap y' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          roadMapSections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBe('RoadMapID');
+        expect(r?.taskChanges.title).toBe('x y');
       });
 
       it('should not read a section out of a slash-titled project token', async () => {
@@ -2273,7 +2396,8 @@ describe('shortSyntax', () => {
         );
         expect(r?.projectId).toBe('SlashProjectID');
         expect(r?.sectionId).toBeUndefined();
-        expect(r?.taskChanges.title).toBe('Task Testing extra words');
+        // Full project title consumed by the word-wise matcher (#9679)
+        expect(r?.taskChanges.title).toBe('Task extra words');
       });
 
       it('should still prefer an exact whole-token project over a section interpretation', async () => {

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -2086,6 +2086,216 @@ describe('shortSyntax', () => {
         expect(r?.taskChanges.timeEstimate).toBe(2 * 60 * 60 * 1000);
       });
     });
+
+    describe('round-3 review regressions (PR #9014)', () => {
+      it('should not treat "+/" as a project token — "+/-" is ordinary text', async () => {
+        for (const title of [
+          'temp +/- 5 degrees',
+          'budget +/-10% ok',
+          'review PR +/- comments',
+        ]) {
+          const r = await shortSyntax(
+            { ...TASK, title },
+            CONFIG,
+            [],
+            projects,
+            undefined,
+            'combine',
+            false,
+            sections,
+            'WorkID',
+          );
+          expect(r?.projectId)
+            .withContext(`"${title}" must not match a project`)
+            .toBeUndefined();
+          expect(r?.taskChanges?.title)
+            .withContext(`"${title}" must keep its title`)
+            .toBeUndefined();
+        }
+      });
+
+      it('should not match a half-deleted "+/Section" against any project', async () => {
+        // Backspacing the project name out of "+Work/Design" passes through
+        // this state; it must stay inert instead of jumping to the
+        // shortest-titled project.
+        const r = await shortSyntax(
+          { ...TASK, title: 'buy milk +/Design' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r).toBeUndefined();
+      });
+
+      it('should not let the shortest project title win for an empty left side', async () => {
+        // The project picked used to depend on title length — assert no
+        // match for several project sets instead of a lucky fixture.
+        const projectSets = [
+          [
+            { title: 'Work', id: 'WorkID' },
+            { title: 'Personal Stuff', id: 'PersonalID' },
+          ],
+          [
+            { title: 'Work', id: 'WorkID' },
+            { title: 'Zoo', id: 'ZooID' },
+          ],
+          [
+            { title: 'Work', id: 'WorkID' },
+            { title: 'Ab', id: 'AbID' },
+          ],
+        ] as any[];
+        for (const set of projectSets) {
+          const r = await shortSyntax(
+            { ...TASK, title: 'temp +/- 5 degrees' },
+            CONFIG,
+            [],
+            set,
+            undefined,
+            'combine',
+            false,
+            sections,
+          );
+          expect(r).withContext(set.map((p: Project) => p.title).join(',')).toBeUndefined();
+        }
+      });
+
+      it('should strip a multi-word section fully with trailing task text (+Project form)', async () => {
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Design Reviews finish draft' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.title).toBe('Task finish draft');
+      });
+
+      it('should strip a multi-word section fully with trailing task text (standalone form)', async () => {
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task /Design Reviews finish draft' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.title).toBe('Task finish draft');
+      });
+
+      it('should consume the longest matching word span, not the whole remainder', async () => {
+        const roadMapSections = [
+          ...sections,
+          {
+            id: 'RoadMapID',
+            contextId: 'WorkID',
+            contextType: 'PROJECT',
+            title: 'Road Map',
+            taskIds: [],
+          },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Road Map finish draft' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          roadMapSections,
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('RoadMapID');
+        expect(r?.taskChanges.title).toBe('Task finish draft');
+      });
+
+      it('should rank a full project+section match above the first-word project fallback', async () => {
+        // "+Work/Design fix login": "Work/Design" is also a prefix of the
+        // project "Work/Design Archive", but a whole-token match is strong
+        // evidence while a first-word prefix match is weak — the resolved
+        // project+section wins.
+        const archiveProjects = [
+          ...projects,
+          { title: 'Work/Design Archive', id: 'ArchiveID' },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Design fix login' },
+          CONFIG,
+          [],
+          archiveProjects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.title).toBe('Task fix login');
+      });
+
+      it('should not read a section out of a slash-titled project token', async () => {
+        // "+A/B Testing extra words": the left side "A" and the first word
+        // "A/B" both prefix the project "A/B Testing" — the "/" belongs to
+        // the project's own title, so its right side must never be matched
+        // as a section ("B" would prefix-match "Backlog").
+        const abSections = [
+          ...sections,
+          {
+            id: 'AbBacklogID',
+            contextId: 'SlashProjectID',
+            contextType: 'PROJECT',
+            title: 'Backlog',
+            taskIds: [],
+          },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +A/B Testing extra words' },
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          abSections,
+        );
+        expect(r?.projectId).toBe('SlashProjectID');
+        expect(r?.sectionId).toBeUndefined();
+        expect(r?.taskChanges.title).toBe('Task Testing extra words');
+      });
+
+      it('should still prefer an exact whole-token project over a section interpretation', async () => {
+        const archiveProjects = [
+          ...projects,
+          { title: 'Work/Design Archive', id: 'ArchiveID' },
+        ] as any;
+        const r = await shortSyntax(
+          { ...TASK, title: 'Task +Work/Design Archive' },
+          CONFIG,
+          [],
+          archiveProjects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.projectId).toBe('ArchiveID');
+        expect(r?.sectionId).toBeUndefined();
+        expect(r?.taskChanges.title).toBe('Task');
+      });
+    });
   });
 
   // This group of tests address Chrono's parsing the format "<date> <month> <yy}>" as year

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -13,6 +13,7 @@ import {
 import { Tag } from '../tag/tag.model';
 import { DEFAULT_TAG } from '../tag/tag.const';
 import { Project } from '../project/project.model';
+import { Section } from '../section/section.model';
 import { DEFAULT_GLOBAL_CONFIG } from '../config/default-global-config.const';
 import { INBOX_PROJECT } from '../project/project.const';
 import { RepeatQuickSetting } from '../task-repeat-cfg/task-repeat-cfg.model';
@@ -1705,6 +1706,386 @@ describe('shortSyntax', () => {
         });
       }
     }
+  });
+
+  describe('project sections (+Project/Section)', () => {
+    let projects: Project[];
+    let sections: Section[];
+    beforeEach(() => {
+      projects = [
+        {
+          title: 'Work',
+          id: 'WorkID',
+        },
+        {
+          title: 'A/B Testing',
+          id: 'SlashProjectID',
+        },
+      ] as any;
+      sections = [
+        {
+          id: 'DesignSectionID',
+          contextId: 'WorkID',
+          contextType: 'PROJECT',
+          title: 'Design Reviews',
+          taskIds: [],
+        },
+        {
+          id: 'OtherProjectSectionID',
+          contextId: 'OtherProjectID',
+          contextType: 'PROJECT',
+          title: 'Design Reviews',
+          taskIds: [],
+        },
+      ] as any;
+    });
+
+    it('should match a section within the matched project', async () => {
+      const t = {
+        ...TASK,
+        title: 'Review mockups +Work/Design Reviews',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.taskChanges.title).toBe('Review mockups');
+    });
+
+    it('should match a section by prefix', async () => {
+      const t = {
+        ...TASK,
+        title: 'Review mockups +Work/des',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.taskChanges.title).toBe('Review mockups');
+    });
+
+    it('should match section by first word with trailing text kept in title', async () => {
+      const t = {
+        ...TASK,
+        title: '+Work/design fix the login flow',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.taskChanges.title).toBe('fix the login flow');
+    });
+
+    it('should only match sections belonging to the matched project', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +Work/Design',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.sectionId).toBe('DesignSectionID');
+      expect(r?.sectionId).not.toBe('OtherProjectSectionID');
+    });
+
+    it('should prefer a project whose title contains "/" over section syntax', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +A/B Testing',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('SlashProjectID');
+      expect(r?.sectionId).toBeUndefined();
+      expect(r?.taskChanges.title).toBe('Task');
+    });
+
+    it('should prefer a project whose title contains "/" with trailing words', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +A/B Testing extra words',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('SlashProjectID');
+      expect(r?.sectionId).toBeUndefined();
+      // Regression (PR #9014 review): matches master's first-word fallback —
+      // strip "+A/B", not "+A/", so no orphaned "B" remains.
+      expect(r?.taskChanges.title).toBe('Task Testing extra words');
+    });
+
+    it('should match the project without a section when the section part matches nothing', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +Work/nonexistent',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBeUndefined();
+      // Regression (PR #9014 review): the whole "+Work/" must be stripped —
+      // leaving "/nonexistent" in the title orphans a stray slash.
+      expect(r?.taskChanges.title).toBe('Task nonexistent');
+    });
+
+    it('should not leave a slash residue for an unmatched section mid-title', async () => {
+      const t = {
+        ...TASK,
+        title: 'buy milk +Work/grocer',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBeUndefined();
+      expect(r?.taskChanges.title).toBe('buy milk grocer');
+    });
+
+    it('should not leave a slash residue when the token leads the title', async () => {
+      const t = {
+        ...TASK,
+        title: '+Work/review the Q3 numbers',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        projects,
+        undefined,
+        'combine',
+        false,
+        sections,
+      );
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.taskChanges.title).toBe('review the Q3 numbers');
+    });
+
+    it('should clean the full token for a multi-word project with a section', async () => {
+      const multiProjects = [
+        ...projects,
+        { title: 'Work Space', id: 'WorkSpaceID' },
+      ] as any;
+      const multiSections = [
+        ...sections,
+        {
+          id: 'WsDesignID',
+          contextId: 'WorkSpaceID',
+          contextType: 'PROJECT',
+          title: 'Design',
+          taskIds: [],
+        },
+      ] as any;
+      const t = {
+        ...TASK,
+        title: 'Task +Work Space/Design',
+      };
+      const r = await shortSyntax(
+        t,
+        CONFIG,
+        [],
+        multiProjects,
+        undefined,
+        'combine',
+        false,
+        multiSections,
+      );
+      expect(r?.projectId).toBe('WorkSpaceID');
+      expect(r?.sectionId).toBe('WsDesignID');
+      expect(r?.taskChanges.title).toBe('Task');
+    });
+
+    it('should not return a section when no sections are passed', async () => {
+      const t = {
+        ...TASK,
+        title: 'Task +Work/Design',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r?.projectId).toBe('WorkID');
+      expect(r?.sectionId).toBeUndefined();
+    });
+
+    describe('standalone /Section (context project)', () => {
+      it('should match a section of the context project without a + token', async () => {
+        const t = {
+          ...TASK,
+          title: 'Review mockups /Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.projectId).toBeUndefined();
+        expect(r?.taskChanges.title).toBe('Review mockups');
+      });
+
+      it('should let an explicit +Project/Section win over the context project', async () => {
+        const t = {
+          ...TASK,
+          title: 'Task +Work/Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'OtherProjectID',
+        );
+        expect(r?.projectId).toBe('WorkID');
+        expect(r?.sectionId).toBe('DesignSectionID');
+      });
+
+      it('should leave the title untouched when nothing matches', async () => {
+        const t = {
+          ...TASK,
+          title: 'Deploy w/ care /nonexistent',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBeUndefined();
+        expect(r?.taskChanges.title ?? t.title).toBe('Deploy w/ care /nonexistent');
+      });
+
+      it('should ignore slashes inside words and after spaces', async () => {
+        const t = {
+          ...TASK,
+          title: 'either/or / Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBeUndefined();
+      });
+
+      it('should do nothing without a context project', async () => {
+        const t = {
+          ...TASK,
+          title: 'Task /Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+        );
+        expect(r?.sectionId).toBeUndefined();
+      });
+
+      it('should not break time estimate syntax with slashes', async () => {
+        const t = {
+          ...TASK,
+          title: 'Task 1h/2h /Design',
+        };
+        const r = await shortSyntax(
+          t,
+          CONFIG,
+          [],
+          projects,
+          undefined,
+          'combine',
+          false,
+          sections,
+          'WorkID',
+        );
+        expect(r?.sectionId).toBe('DesignSectionID');
+        expect(r?.taskChanges.timeSpentOnDay).toBeDefined();
+        expect(r?.taskChanges.timeEstimate).toBe(2 * 60 * 60 * 1000);
+      });
+    });
   });
 
   // This group of tests address Chrono's parsing the format "<date> <month> <yy}>" as year

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -3,6 +3,7 @@ import { getDbDateStr } from '../../util/get-db-date-str';
 import { stringToMs } from '../../ui/duration/string-to-ms.pipe';
 import { Tag } from '../tag/tag.model';
 import { Project } from '../project/project.model';
+import { Section } from '../section/section.model';
 import { ShortSyntaxConfig } from '../config/global-config.model';
 import { isImageUrlSimple } from '../../util/is-image-url';
 import { TaskAttachment } from './task-attachment/task-attachment.model';
@@ -54,6 +55,10 @@ const CH_PRO = '+';
 const CH_TAG = '#';
 const CH_DUE = '@';
 const CH_DEADLINE = '!';
+// Separates the section part inside a "+Project/Section" token and triggers a
+// standalone "/Section" token. Not a global special char: bare slashes in
+// ordinary text stay untouched unless a section actually matches.
+const CH_SECTION = '/';
 const ALL_SPECIAL = `(\\${CH_PRO}|\\${CH_TAG}|\\${CH_DUE}|\\${CH_DEADLINE})`;
 
 let customDateParserPromise: Promise<Chrono> | null = null;
@@ -303,12 +308,17 @@ export const shortSyntax = async (
   // can be created for the result — the add-task bar. Title edits of existing
   // tasks keep parsing it as a plain date.
   isParseRepeat: boolean = false,
+  allSections?: Section[],
+  // The project the task will land in when no "+Project" token is typed —
+  // the context a standalone "/Section" token resolves against.
+  contextProjectId?: string,
 ): Promise<
   | {
       taskChanges: Partial<Task> & { hasDeadlineTime?: boolean };
       newTagTitles: string[];
       remindAt: number | null;
       projectId: string | undefined;
+      sectionId?: string;
       attachments: TaskAttachment[];
       repeatQuickSetting: RepeatQuickSetting | null;
       parsedRanges: ShortSyntaxRange[];
@@ -325,6 +335,7 @@ export const shortSyntax = async (
   // TODO clean up this mess
   let taskChanges: Partial<TaskCopy> & { hasDeadlineTime?: boolean } = {};
   let projectId: string | undefined;
+  let sectionId: string | undefined;
   let newTagTitles: string[] = [];
   let attachments: TaskAttachment[] = [];
   let repeatQuickSetting: RepeatQuickSetting | null = null;
@@ -367,11 +378,31 @@ export const shortSyntax = async (
       task,
       tracked,
       allProjects?.filter((p) => !p.isArchived && !p.isHiddenFromMenu),
+      allSections,
     );
     if (projectResult) {
       projectId = projectResult.projectId;
+      sectionId = projectResult.sectionId;
       pushRanges('project', projectResult.ranges);
       isTitleChanged = true;
+    }
+
+    // Standalone "/Section" (no "+Project/Section" resolved): resolve against
+    // the project the task is being added to (an explicit "+Project" wins).
+    if (!sectionId) {
+      const sectionContextProjectId = projectResult?.projectId || contextProjectId;
+      if (sectionContextProjectId) {
+        const standaloneResult = parseStandaloneSectionTracked(
+          tracked,
+          sectionContextProjectId,
+          allSections,
+        );
+        if (standaloneResult) {
+          sectionId = standaloneResult.sectionId;
+          pushRanges('project', standaloneResult.ranges);
+          isTitleChanged = true;
+        }
+      }
     }
   }
 
@@ -413,6 +444,7 @@ export const shortSyntax = async (
     newTagTitles,
     remindAt: null,
     projectId,
+    ...(sectionId ? { sectionId } : {}),
     attachments,
     repeatQuickSetting,
     parsedRanges,
@@ -431,11 +463,80 @@ export const parseProjectChanges = (
   return result ? { title: tracked.text, projectId: result.projectId } : {};
 };
 
+// Prefix-match typed text against a project's sections; falls back to first
+// word only (like project matching). Returns the exact typed text to strip
+// from the title alongside the id.
+const matchSectionByTypedText = (
+  typed: string,
+  projectId: string,
+  allSections?: Section[],
+): { sectionId: string; typedText: string } | undefined => {
+  if (!typed.trim() || !Array.isArray(allSections) || !allSections.length) {
+    return undefined;
+  }
+  const projectSections = allSections
+    .filter((s) => s.contextId === projectId)
+    .sort((s1, s2) => s1.title.length - s2.title.length);
+  const attempts = [typed.trim(), typed.trim().split(' ')[0]];
+  for (const typedText of attempts) {
+    const toMatch = typedText.replaceAll(' ', '').toLowerCase();
+    const existing = projectSections.find(
+      (s) => s.title.replaceAll(' ', '').toLowerCase().indexOf(toMatch) === 0,
+    );
+    if (existing) {
+      return { sectionId: existing.id, typedText };
+    }
+  }
+  return undefined;
+};
+
+// Standalone "/Section" token (word boundary before "/", no space after it) —
+// only meaningful when a context project is known. Nothing is stripped from
+// the title unless a section actually matches, so slashes in ordinary prose
+// ("either/or", "w/ milk") and URLs stay untouched.
+const SHORT_SYNTAX_STANDALONE_SECTION_REG_EX = new RegExp(
+  `(?:^|\\s)\\${CH_SECTION}(?!\\s|\\${CH_SECTION})([^${ALL_SPECIAL}]+)`,
+);
+
+const parseStandaloneSectionTracked = (
+  tracked: TrackedTitle,
+  contextProjectId: string,
+  allSections?: Section[],
+): { sectionId: string; ranges: TextRange[] } | null => {
+  if (!tracked.text || !contextProjectId) {
+    return null;
+  }
+  const rr = tracked.text.match(SHORT_SYNTAX_STANDALONE_SECTION_REG_EX);
+  if (!rr || !rr[1]) {
+    return null;
+  }
+  const section = matchSectionByTypedText(rr[1], contextProjectId, allSections);
+  if (!section) {
+    return null;
+  }
+  // Positional strip of exactly the matched "/<typed>" span. "(?:^|\s)"
+  // consumes at most one leading whitespace char, so the slash sits at index
+  // 0 or 1 of the match; the section text follows it directly (the lookahead
+  // forbids whitespace after the slash).
+  const slashPos = (rr.index as number) + (rr[0].startsWith(CH_SECTION) ? 0 : 1);
+  const stripEnd = slashPos + 1 + section.typedText.length;
+  const ranges = tracked.rawRanges(slashPos, stripEnd);
+  tracked.remove(slashPos, stripEnd);
+  tracked.trim();
+  // get rid of excess whitespace a mid-title removal leaves behind
+  const doubleSpaceIdx = tracked.text.indexOf('  ');
+  if (doubleSpaceIdx !== -1) {
+    tracked.remove(doubleSpaceIdx, doubleSpaceIdx + 1);
+  }
+  return { sectionId: section.sectionId, ranges };
+};
+
 const parseProjectTracked = (
   task: Partial<TaskCopy>,
   tracked: TrackedTitle,
   allProjects?: Project[],
-): { projectId: string; ranges: TextRange[] } | null => {
+  allSections?: Section[],
+): { projectId: string; sectionId?: string; ranges: TextRange[] } | null => {
   if (
     task.issueId || // don't allow for issue tasks
     !tracked.text ||
@@ -448,7 +549,13 @@ const parseProjectTracked = (
   const rr = tracked.text.match(SHORT_SYNTAX_PROJECT_REG_EX);
 
   if (rr && rr[0]) {
-    const projectTitle: string = rr[0].trim().replace(CH_PRO, '');
+    const rawToken: string = rr[0].trim().replace(CH_PRO, '');
+    // "+Project/Section" targets a section within the matched project;
+    // everything after the first "/" is the section part.
+    const slashIndex = rawToken.indexOf(CH_SECTION);
+    const projectTitle = slashIndex === -1 ? rawToken : rawToken.slice(0, slashIndex);
+    const sectionPart = slashIndex === -1 ? '' : rawToken.slice(slashIndex + 1);
+
     const projectTitleToMatch = projectTitle.replaceAll(' ', '').toLowerCase();
     const indexBeforePlus =
       tracked.text.toLowerCase().lastIndexOf(CH_PRO + projectTitleToMatch) - 1;
@@ -459,13 +566,14 @@ const parseProjectTracked = (
       return null;
     }
 
-    const consume = (matchedText: string): TextRange[] => {
-      const start = tracked.text.indexOf(matchedText);
-      if (start === -1) {
-        return [];
-      }
-      const ranges = tracked.rawRanges(start, start + matchedText.length);
-      tracked.remove(start, start + matchedText.length);
+    // Positional strip: remove exactly `len` chars of the matched token
+    // starting at the "+" — never re-find the typed text by string search
+    // (a search on a reconstructed string silently no-ops or hits an earlier
+    // lookalike occurrence, orphaning syntax in the title).
+    const tokenStart = rr.index as number;
+    const consumeAt = (len: number): TextRange[] => {
+      const ranges = tracked.rawRanges(tokenStart, tokenStart + len);
+      tracked.remove(tokenStart, tokenStart + len);
       tracked.trim();
       // get rid of excess whitespace a mid-title removal leaves behind
       const doubleSpaceIdx = tracked.text.indexOf('  ');
@@ -480,33 +588,84 @@ const parseProjectTracked = (
       .slice()
       .sort((p1, p2) => p1.title.length - p2.title.length);
 
-    const existingProject = sortedAllProjects.find(
-      (project) =>
-        project.title.replaceAll(' ', '').toLowerCase().indexOf(projectTitleToMatch) ===
-        0,
-    );
+    const matchProject = (titleToMatch: string): Project | undefined =>
+      sortedAllProjects.find(
+        (project) =>
+          project.title.replaceAll(' ', '').toLowerCase().indexOf(titleToMatch) === 0,
+      );
+
+    const buildResult = (
+      project: Project,
+      typedProjectText: string,
+    ): { projectId: string; sectionId?: string; ranges: TextRange[] } => {
+      // Sections are only resolved when the FULL left side matched the
+      // project — after a first-word-only match the leftover words sit
+      // between the project and the "/", so a contiguous strip is impossible.
+      const isFullLeftMatch = typedProjectText === projectTitle;
+      const section =
+        slashIndex !== -1 && isFullLeftMatch
+          ? matchSectionByTypedText(sectionPart, project.id, allSections)
+          : undefined;
+
+      let stripLen: number;
+      if (section) {
+        // "+Work/Design …" → strip through the matched section text
+        const leadingWs = sectionPart.length - sectionPart.trimStart().length;
+        stripLen = 1 + projectTitle.length + 1 + leadingWs + section.typedText.length;
+      } else if (slashIndex !== -1 && isFullLeftMatch) {
+        // "+Work/grocer" with no matching section: strip through the slash so
+        // the leftover ("grocer") rejoins the title instead of keeping a
+        // stray "/" (review finding on PR #9014).
+        stripLen = 1 + projectTitle.length + 1;
+      } else {
+        stripLen = 1 + typedProjectText.length;
+      }
+
+      return {
+        projectId: project.id,
+        ...(section ? { sectionId: section.sectionId } : {}),
+        ranges: consumeAt(stripLen),
+      };
+    };
+
+    // Legacy first: the whole token as a project title, so projects whose
+    // titles themselves contain "/" (e.g. "A/B Testing") keep matching and
+    // never get misread as project/section.
+    if (slashIndex !== -1) {
+      const wholeTokenProject = matchProject(rawToken.replaceAll(' ', '').toLowerCase());
+      if (wholeTokenProject) {
+        return {
+          projectId: wholeTokenProject.id,
+          ranges: consumeAt(1 + rawToken.length),
+        };
+      }
+      // Same legacy fallback with trailing words ("+A/B Testing extra words"):
+      // the first word alone, slash included, as a project title prefix.
+      const firstWord = rawToken.split(' ')[0];
+      if (firstWord.includes(CH_SECTION)) {
+        const firstWordProject = matchProject(firstWord.toLowerCase());
+        if (firstWordProject) {
+          return {
+            projectId: firstWordProject.id,
+            ranges: consumeAt(1 + firstWord.length),
+          };
+        }
+      }
+    }
+
+    const existingProject = matchProject(projectTitleToMatch);
 
     if (existingProject) {
-      return {
-        projectId: existingProject.id,
-        ranges: consume(`${CH_PRO}${projectTitle}`),
-      };
+      return buildResult(existingProject, projectTitle);
     }
 
     // also try only first word after special char
     const projectTitleFirstWordOnly = projectTitle.split(' ')[0];
     const projectTitleToMatch2 = projectTitleFirstWordOnly.replace(' ', '').toLowerCase();
-    const existingProjectForFirstWordOnly = sortedAllProjects.find(
-      (project) =>
-        project.title.replaceAll(' ', '').toLowerCase().indexOf(projectTitleToMatch2) ===
-        0,
-    );
+    const existingProjectForFirstWordOnly = matchProject(projectTitleToMatch2);
 
     if (existingProjectForFirstWordOnly) {
-      return {
-        projectId: existingProjectForFirstWordOnly.id,
-        ranges: consume(`${CH_PRO}${projectTitleFirstWordOnly}`),
-      };
+      return buildResult(existingProjectForFirstWordOnly, projectTitleFirstWordOnly);
     }
   }
 

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -463,9 +463,13 @@ export const parseProjectChanges = (
   return result ? { title: tracked.text, projectId: result.projectId } : {};
 };
 
-// Prefix-match typed text against a project's sections; falls back to first
-// word only (like project matching). Returns the exact typed text to strip
-// from the title alongside the id.
+// Prefix-match typed text against a project's sections. Tries decreasing
+// leading word spans ("Design Reviews finish draft" → "Design Reviews
+// finish", "Design Reviews", "Design") and consumes the LONGEST one that
+// matches, so multi-word section names don't orphan their later words into
+// the title (round-3 review finding on PR #9014 — a first-word-only fallback
+// turned "+Work/Design Reviews finish draft" into "Task Reviews finish
+// draft"). Returns the exact typed text to strip alongside the id.
 const matchSectionByTypedText = (
   typed: string,
   projectId: string,
@@ -477,8 +481,18 @@ const matchSectionByTypedText = (
   const projectSections = allSections
     .filter((s) => s.contextId === projectId)
     .sort((s1, s2) => s1.title.length - s2.title.length);
-  const attempts = [typed.trim(), typed.trim().split(' ')[0]];
-  for (const typedText of attempts) {
+  // End offsets of every leading word span. Internal spacing is preserved so
+  // the returned typedText is always a literal slice of the typed text
+  // (leading whitespace is the caller's to account for).
+  const body = typed.trimStart();
+  const wordEnds: number[] = [];
+  const wordRegEx = /\S+/g;
+  let wordMatch: RegExpExecArray | null;
+  while ((wordMatch = wordRegEx.exec(body)) !== null) {
+    wordEnds.push(wordMatch.index + wordMatch[0].length);
+  }
+  for (let i = wordEnds.length - 1; i >= 0; i--) {
+    const typedText = body.slice(0, wordEnds[i]);
     const toMatch = typedText.replaceAll(' ', '').toLowerCase();
     const existing = projectSections.find(
       (s) => s.title.replaceAll(' ', '').toLowerCase().indexOf(toMatch) === 0,
@@ -553,6 +567,14 @@ const parseProjectTracked = (
     // "+Project/Section" targets a section within the matched project;
     // everything after the first "/" is the section part.
     const slashIndex = rawToken.indexOf(CH_SECTION);
+    // A token that STARTS with "/" has no project part. Bail out entirely:
+    // matching an empty string against project titles would prefix-match
+    // every project (round-3 review finding on PR #9014 — "+/-" in ordinary
+    // text, or a half-deleted "+Work/…", silently picked the shortest-titled
+    // project and mangled the title).
+    if (slashIndex === 0) {
+      return null;
+    }
     const projectTitle = slashIndex === -1 ? rawToken : rawToken.slice(0, slashIndex);
     const sectionPart = slashIndex === -1 ? '' : rawToken.slice(slashIndex + 1);
 
@@ -589,44 +611,13 @@ const parseProjectTracked = (
       .sort((p1, p2) => p1.title.length - p2.title.length);
 
     const matchProject = (titleToMatch: string): Project | undefined =>
-      sortedAllProjects.find(
-        (project) =>
-          project.title.replaceAll(' ', '').toLowerCase().indexOf(titleToMatch) === 0,
-      );
-
-    const buildResult = (
-      project: Project,
-      typedProjectText: string,
-    ): { projectId: string; sectionId?: string; ranges: TextRange[] } => {
-      // Sections are only resolved when the FULL left side matched the
-      // project — after a first-word-only match the leftover words sit
-      // between the project and the "/", so a contiguous strip is impossible.
-      const isFullLeftMatch = typedProjectText === projectTitle;
-      const section =
-        slashIndex !== -1 && isFullLeftMatch
-          ? matchSectionByTypedText(sectionPart, project.id, allSections)
-          : undefined;
-
-      let stripLen: number;
-      if (section) {
-        // "+Work/Design …" → strip through the matched section text
-        const leadingWs = sectionPart.length - sectionPart.trimStart().length;
-        stripLen = 1 + projectTitle.length + 1 + leadingWs + section.typedText.length;
-      } else if (slashIndex !== -1 && isFullLeftMatch) {
-        // "+Work/grocer" with no matching section: strip through the slash so
-        // the leftover ("grocer") rejoins the title instead of keeping a
-        // stray "/" (review finding on PR #9014).
-        stripLen = 1 + projectTitle.length + 1;
-      } else {
-        stripLen = 1 + typedProjectText.length;
-      }
-
-      return {
-        projectId: project.id,
-        ...(section ? { sectionId: section.sectionId } : {}),
-        ranges: consumeAt(stripLen),
-      };
-    };
+      titleToMatch
+        ? sortedAllProjects.find(
+            (project) =>
+              project.title.replaceAll(' ', '').toLowerCase().indexOf(titleToMatch) === 0,
+          )
+        : // an empty string would prefix-match every project
+          undefined;
 
     // Legacy first: the whole token as a project title, so projects whose
     // titles themselves contain "/" (e.g. "A/B Testing") keep matching and
@@ -639,33 +630,95 @@ const parseProjectTracked = (
           ranges: consumeAt(1 + rawToken.length),
         };
       }
-      // Same legacy fallback with trailing words ("+A/B Testing extra words"):
-      // the first word alone, slash included, as a project title prefix.
-      const firstWord = rawToken.split(' ')[0];
-      if (firstWord.includes(CH_SECTION)) {
-        const firstWordProject = matchProject(firstWord.toLowerCase());
-        if (firstWordProject) {
-          return {
-            projectId: firstWordProject.id,
-            ranges: consumeAt(1 + firstWord.length),
-          };
-        }
-      }
     }
 
     const existingProject = matchProject(projectTitleToMatch);
 
-    if (existingProject) {
-      return buildResult(existingProject, projectTitle);
+    // Candidate for the legacy first-word fallback ("+A/B Testing extra
+    // words" → first word "A/B", slash included, as a project title prefix).
+    // Computed early: it decides section eligibility below AND serves as the
+    // fallback match itself.
+    let firstWordSlashProject: Project | undefined;
+    if (slashIndex !== -1) {
+      const firstWord = rawToken.split(' ')[0];
+      if (firstWord.includes(CH_SECTION)) {
+        firstWordSlashProject = matchProject(firstWord.toLowerCase());
+      }
     }
 
-    // also try only first word after special char
+    // Full left-side project match WITH a matching section is the strongest
+    // remaining interpretation — a whole-token match above is exact evidence,
+    // but the first-word fallback below is only a prefix guess, so a resolved
+    // project+section outranks it (round-3 review note on PR #9014: with
+    // projects "Work" + "Work/Design Archive" and section "Design Reviews",
+    // "+Work/Design fix login" means Work → Design Reviews).
+    // EXCEPT when the first word including the slash prefixes the SAME
+    // project ("+A/B Testing…"): then the "/" is part of the project's own
+    // title, not a section separator, and reading a section out of its right
+    // side ("B" → "Backlog") would file the task somewhere the user never
+    // pointed at.
+    if (
+      existingProject &&
+      slashIndex !== -1 &&
+      (!firstWordSlashProject || firstWordSlashProject.id !== existingProject.id)
+    ) {
+      const section = matchSectionByTypedText(
+        sectionPart,
+        existingProject.id,
+        allSections,
+      );
+      if (section) {
+        // "+Work/Design …" → strip through the matched section text
+        const leadingWs = sectionPart.length - sectionPart.trimStart().length;
+        return {
+          projectId: existingProject.id,
+          sectionId: section.sectionId,
+          ranges: consumeAt(
+            1 + projectTitle.length + 1 + leadingWs + section.typedText.length,
+          ),
+        };
+      }
+    }
+
+    // Legacy fallback with trailing words ("+A/B Testing extra words"): the
+    // first word alone, slash included, as a project title prefix. Ranked
+    // above the strip-through-slash path so master's stripping behavior is
+    // preserved whenever the section part matches nothing.
+    if (firstWordSlashProject) {
+      return {
+        projectId: firstWordSlashProject.id,
+        ranges: consumeAt(1 + rawToken.split(' ')[0].length),
+      };
+    }
+
+    if (existingProject) {
+      if (slashIndex !== -1) {
+        // "+Work/grocer" with no matching section: strip through the slash so
+        // the leftover ("grocer") rejoins the title instead of keeping a
+        // stray "/" (round-1 review finding on PR #9014).
+        return {
+          projectId: existingProject.id,
+          ranges: consumeAt(1 + projectTitle.length + 1),
+        };
+      }
+      return {
+        projectId: existingProject.id,
+        ranges: consumeAt(1 + projectTitle.length),
+      };
+    }
+
+    // also try only first word after special char. Sections are not resolved
+    // here: after a first-word-only match the leftover words sit between the
+    // project and the "/", so a contiguous strip is impossible.
     const projectTitleFirstWordOnly = projectTitle.split(' ')[0];
     const projectTitleToMatch2 = projectTitleFirstWordOnly.replace(' ', '').toLowerCase();
     const existingProjectForFirstWordOnly = matchProject(projectTitleToMatch2);
 
     if (existingProjectForFirstWordOnly) {
-      return buildResult(existingProjectForFirstWordOnly, projectTitleFirstWordOnly);
+      return {
+        projectId: existingProjectForFirstWordOnly.id,
+        ranges: consumeAt(1 + projectTitleFirstWordOnly.length),
+      };
     }
   }
 

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -804,11 +804,7 @@ const parseProjectTracked = (
           )
         : undefined;
       if (leftProject) {
-        const section = matchSectionByTypedText(
-          sectionPart,
-          leftProject.id,
-          allSections,
-        );
+        const section = matchSectionByTypedText(sectionPart, leftProject.id, allSections);
         if (section) {
           // "+Work/Design …" → strip through the matched section text
           const leadingWs = sectionPart.length - sectionPart.trimStart().length;
@@ -820,13 +816,19 @@ const parseProjectTracked = (
             ),
           };
         }
-        // "+Work/grocer" with no matching section: strip through the slash so
-        // the leftover ("grocer") rejoins the title instead of keeping a
-        // stray "/" (round-1 review finding on PR #9014).
-        return {
-          projectId: leftProject.id,
-          ranges: consumeAt(1 + projectTitle.length + 1),
-        };
+        // No matching section: the slash reading explained nothing extra, so
+        // it must not change which project the task lands in — fall through
+        // to the plain word-wise match when one exists ("+Work Inbox/x" with
+        // projects Work + "Work Inbox" stays in Work, like master; round-4
+        // rule on PR #9014). Only without any plain match does the left side
+        // claim the token: "+Work/grocer" strips through the slash so the
+        // leftover rejoins the title (round-1 review finding).
+        if (!match) {
+          return {
+            projectId: leftProject.id,
+            ranges: consumeAt(1 + projectTitle.length + 1),
+          };
+        }
       }
     }
 

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -3,6 +3,7 @@ import { getDbDateStr } from '../../util/get-db-date-str';
 import { stringToMs } from '../../ui/duration/string-to-ms.pipe';
 import { Tag } from '../tag/tag.model';
 import { Project } from '../project/project.model';
+import { Section } from '../section/section.model';
 import { ShortSyntaxConfig } from '../config/global-config.model';
 import { isImageUrlSimple } from '../../util/is-image-url';
 import { formatTimeHHmm } from '../../util/format-time-hhmm';
@@ -67,6 +68,10 @@ const CH_PRO = '+';
 const CH_TAG = '#';
 const CH_DUE = '@';
 const CH_DEADLINE = '!';
+// Separates the section part inside a "+Project/Section" token and triggers a
+// standalone "/Section" token. Not a global special char: bare slashes in
+// ordinary text stay untouched unless a section actually matches.
+const CH_SECTION = '/';
 const ALL_SPECIAL = `(\\${CH_PRO}|\\${CH_TAG}|\\${CH_DUE}|\\${CH_DEADLINE})`;
 
 let customDateParserPromise: Promise<Chrono> | null = null;
@@ -398,12 +403,17 @@ export const shortSyntax = async (
   // can be created for the result — the add-task bar. Title edits of existing
   // tasks keep parsing it as a plain date.
   isParseRepeat: boolean = false,
+  allSections?: Section[],
+  // The project the task will land in when no "+Project" token is typed —
+  // the context a standalone "/Section" token resolves against.
+  contextProjectId?: string,
 ): Promise<
   | {
       taskChanges: Partial<Task> & ShortSyntaxMarkers;
       newTagTitles: string[];
       remindAt: number | null;
       projectId: string | undefined;
+      sectionId?: string;
       attachments: TaskAttachment[];
       repeat: ShortSyntaxRepeat | null;
       parsedRanges: ShortSyntaxRange[];
@@ -420,6 +430,7 @@ export const shortSyntax = async (
   // TODO clean up this mess
   let taskChanges: Partial<TaskCopy> & ShortSyntaxMarkers = {};
   let projectId: string | undefined;
+  let sectionId: string | undefined;
   let newTagTitles: string[] = [];
   let attachments: TaskAttachment[] = [];
   let repeat: ShortSyntaxRepeat | null = null;
@@ -462,11 +473,31 @@ export const shortSyntax = async (
       task,
       tracked,
       allProjects?.filter((p) => !p.isArchived && !p.isHiddenFromMenu),
+      allSections,
     );
     if (projectResult) {
       projectId = projectResult.projectId;
+      sectionId = projectResult.sectionId;
       pushRanges('project', projectResult.ranges);
       isTitleChanged = true;
+    }
+
+    // Standalone "/Section" (no "+Project/Section" resolved): resolve against
+    // the project the task is being added to (an explicit "+Project" wins).
+    if (!sectionId) {
+      const sectionContextProjectId = projectResult?.projectId || contextProjectId;
+      if (sectionContextProjectId) {
+        const standaloneResult = parseStandaloneSectionTracked(
+          tracked,
+          sectionContextProjectId,
+          allSections,
+        );
+        if (standaloneResult) {
+          sectionId = standaloneResult.sectionId;
+          pushRanges('project', standaloneResult.ranges);
+          isTitleChanged = true;
+        }
+      }
     }
   }
 
@@ -508,6 +539,7 @@ export const shortSyntax = async (
     newTagTitles,
     remindAt: null,
     projectId,
+    ...(sectionId ? { sectionId } : {}),
     attachments,
     repeat,
     parsedRanges,
@@ -567,11 +599,100 @@ const isPartiallyTypedProjectTitle = (
           : project.words[i] === word,
       );
 
+// Tidy the working title after a token removal: trim, then collapse the one
+// double space a mid-title strip can leave behind.
+const tidyAfterRemoval = (tracked: TrackedTitle): void => {
+  tracked.trim();
+  const doubleSpaceIdx = tracked.text.indexOf('  ');
+  if (doubleSpaceIdx !== -1) {
+    tracked.remove(doubleSpaceIdx, doubleSpaceIdx + 1);
+  }
+};
+
+// Prefix-match typed text against a project's sections. Tries decreasing
+// leading word spans ("Design Reviews finish draft" → "Design Reviews
+// finish", "Design Reviews", "Design") and consumes the LONGEST one that
+// matches, so multi-word section names don't orphan their later words into
+// the title (round-3 review finding on PR #9014). Returns the exact typed
+// text to strip alongside the id.
+const matchSectionByTypedText = (
+  typed: string,
+  projectId: string,
+  allSections?: Section[],
+): { sectionId: string; typedText: string } | undefined => {
+  if (!typed.trim() || !Array.isArray(allSections) || !allSections.length) {
+    return undefined;
+  }
+  const projectSections = allSections
+    .filter((s) => s.contextId === projectId)
+    .sort((s1, s2) => s1.title.length - s2.title.length);
+  // End offsets of every leading word span. Internal spacing is preserved so
+  // the returned typedText is always a literal slice of the typed text
+  // (leading whitespace is the caller's to account for).
+  const body = typed.trimStart();
+  const wordEnds: number[] = [];
+  const wordRegEx = /\S+/g;
+  let wordMatch: RegExpExecArray | null;
+  while ((wordMatch = wordRegEx.exec(body)) !== null) {
+    wordEnds.push(wordMatch.index + wordMatch[0].length);
+  }
+  for (let i = wordEnds.length - 1; i >= 0; i--) {
+    const typedText = body.slice(0, wordEnds[i]);
+    // \s+ (not just spaces): tabs or NBSPs inside a section name must not
+    // leave residue either (round-4 review note on PR #9014)
+    const toMatch = typedText.replace(/\s+/g, '').toLowerCase();
+    const existing = projectSections.find(
+      (s) => s.title.replace(/\s+/g, '').toLowerCase().indexOf(toMatch) === 0,
+    );
+    if (existing) {
+      return { sectionId: existing.id, typedText };
+    }
+  }
+  return undefined;
+};
+
+// Standalone "/Section" token (word boundary before "/", no space after it) —
+// only meaningful when a context project is known. Nothing is stripped from
+// the title unless a section actually matches, so slashes in ordinary prose
+// ("either/or", "w/ milk") and URLs stay untouched.
+const SHORT_SYNTAX_STANDALONE_SECTION_REG_EX = new RegExp(
+  `(?:^|\\s)\\${CH_SECTION}(?!\\s|\\${CH_SECTION})([^${ALL_SPECIAL}]+)`,
+);
+
+const parseStandaloneSectionTracked = (
+  tracked: TrackedTitle,
+  contextProjectId: string,
+  allSections?: Section[],
+): { sectionId: string; ranges: TextRange[] } | null => {
+  if (!tracked.text || !contextProjectId) {
+    return null;
+  }
+  const rr = tracked.text.match(SHORT_SYNTAX_STANDALONE_SECTION_REG_EX);
+  if (!rr || !rr[1]) {
+    return null;
+  }
+  const section = matchSectionByTypedText(rr[1], contextProjectId, allSections);
+  if (!section) {
+    return null;
+  }
+  // Positional strip of exactly the matched "/<typed>" span. "(?:^|\s)"
+  // consumes at most one leading whitespace char, so the slash sits at index
+  // 0 or 1 of the match; the section text follows it directly (the lookahead
+  // forbids whitespace after the slash).
+  const slashPos = (rr.index as number) + (rr[0].startsWith(CH_SECTION) ? 0 : 1);
+  const stripEnd = slashPos + 1 + section.typedText.length;
+  const ranges = tracked.rawRanges(slashPos, stripEnd);
+  tracked.remove(slashPos, stripEnd);
+  tidyAfterRemoval(tracked);
+  return { sectionId: section.sectionId, ranges };
+};
+
 const parseProjectTracked = (
   task: Partial<TaskCopy>,
   tracked: TrackedTitle,
   allProjects?: Project[],
-): { projectId: string; ranges: TextRange[] } | null => {
+  allSections?: Section[],
+): { projectId: string; sectionId?: string; ranges: TextRange[] } | null => {
   if (
     task.issueId || // don't allow for issue tasks
     !tracked.text ||
@@ -584,7 +705,13 @@ const parseProjectTracked = (
   const rr = tracked.text.match(SHORT_SYNTAX_PROJECT_REG_EX);
 
   if (rr && rr[0]) {
-    const projectTitle: string = rr[0].trim().replace(CH_PRO, '');
+    const rawToken: string = rr[0].trim().replace(CH_PRO, '');
+    // "+Project/Section" targets a section within the matched project;
+    // everything after the first "/" is the section part.
+    const slashIndex = rawToken.indexOf(CH_SECTION);
+    const projectTitle = slashIndex === -1 ? rawToken : rawToken.slice(0, slashIndex);
+    const sectionPart = slashIndex === -1 ? '' : rawToken.slice(slashIndex + 1);
+
     const projectTitleToMatch = projectTitle.replaceAll(' ', '').toLowerCase();
     const indexBeforePlus =
       tracked.text.toLowerCase().lastIndexOf(CH_PRO + projectTitleToMatch) - 1;
@@ -595,19 +722,15 @@ const parseProjectTracked = (
       return null;
     }
 
-    const consume = (matchedText: string): TextRange[] => {
-      const start = tracked.text.indexOf(matchedText);
-      if (start === -1) {
-        return [];
-      }
-      const ranges = tracked.rawRanges(start, start + matchedText.length);
-      tracked.remove(start, start + matchedText.length);
-      tracked.trim();
-      // get rid of excess whitespace a mid-title removal leaves behind
-      const doubleSpaceIdx = tracked.text.indexOf('  ');
-      if (doubleSpaceIdx !== -1) {
-        tracked.remove(doubleSpaceIdx, doubleSpaceIdx + 1);
-      }
+    // Positional strip: remove exactly `len` chars of the matched token
+    // starting at the "+" — never re-find the typed text by string search
+    // (a search on a reconstructed string silently no-ops or hits an earlier
+    // lookalike occurrence, orphaning syntax in the title).
+    const tokenStart = rr.index as number;
+    const consumeAt = (len: number): TextRange[] => {
+      const ranges = tracked.rawRanges(tokenStart, tokenStart + len);
+      tracked.remove(tokenStart, tokenStart + len);
+      tidyAfterRemoval(tracked);
       return ranges;
     };
 
@@ -625,7 +748,7 @@ const parseProjectTracked = (
       (max, project) => Math.max(max, project.words.length),
       0,
     );
-    const candidateWordEnds = [...projectTitle.matchAll(/\S+/g)].map(
+    const candidateWordEnds = [...rawToken.matchAll(/\S+/g)].map(
       (match) => (match.index ?? 0) + match[0].length,
     );
 
@@ -637,7 +760,7 @@ const parseProjectTracked = (
         nrOfWords > 0;
         nrOfWords--
       ) {
-        const typedTitle = projectTitle.slice(0, candidateWordEnds[nrOfWords - 1]);
+        const typedTitle = rawToken.slice(0, candidateWordEnds[nrOfWords - 1]);
         const typedWords = toWords(typedTitle);
         const project = matchableProjects.find((p) => isMatch(p, typedWords));
         if (project) {
@@ -653,10 +776,66 @@ const parseProjectTracked = (
       findLongestTypedPrefix(isFullyTypedProjectTitle) ||
       findLongestTypedPrefix(isPartiallyTypedProjectTitle);
 
+    // A match whose typed title reaches PAST the first slash means the "/"
+    // belongs to the project's own title ("+Dev/Ops fix", "+A/B Testing…") —
+    // the project claims its slash and no section is ever read out of it
+    // (round-4 review finding on PR #9014: a section reading here silently
+    // changed which PROJECT the task lands in).
+    if (match && (slashIndex === -1 || match.typedTitle.length > slashIndex)) {
+      return {
+        projectId: match.projectId,
+        ranges: consumeAt(1 + match.typedTitle.length),
+      };
+    }
+
+    // A token that STARTS with "/" has no project part: "+/-" in ordinary
+    // text, or a half-deleted "+Work/…", must stay inert (round-3 review
+    // finding on PR #9014).
+    if (slashIndex !== 0 && slashIndex !== -1) {
+      // "+Project/Section": the left side of the slash was typed entirely as
+      // a project reference, so match it with the same word-wise rules (the
+      // last word may be a prefix), then resolve the section on the right.
+      const leftWords = toWords(projectTitle);
+      const leftProject = projectTitle.trim()
+        ? matchableProjects.find(
+            (p) =>
+              isFullyTypedProjectTitle(p, leftWords) ||
+              isPartiallyTypedProjectTitle(p, leftWords),
+          )
+        : undefined;
+      if (leftProject) {
+        const section = matchSectionByTypedText(
+          sectionPart,
+          leftProject.id,
+          allSections,
+        );
+        if (section) {
+          // "+Work/Design …" → strip through the matched section text
+          const leadingWs = sectionPart.length - sectionPart.trimStart().length;
+          return {
+            projectId: leftProject.id,
+            sectionId: section.sectionId,
+            ranges: consumeAt(
+              1 + projectTitle.length + 1 + leadingWs + section.typedText.length,
+            ),
+          };
+        }
+        // "+Work/grocer" with no matching section: strip through the slash so
+        // the leftover ("grocer") rejoins the title instead of keeping a
+        // stray "/" (round-1 review finding on PR #9014).
+        return {
+          projectId: leftProject.id,
+          ranges: consumeAt(1 + projectTitle.length + 1),
+        };
+      }
+    }
+
+    // Slash present but neither reading explained it: fall back to the plain
+    // word-wise match, if any ("+Work in progress/x" → project "Work").
     if (match) {
       return {
         projectId: match.projectId,
-        ranges: consume(`${CH_PRO}${match.typedTitle}`),
+        ranges: consumeAt(1 + match.typedTitle.length),
       };
     }
   }


### PR DESCRIPTION
## Problem

Sections exist as a first-class way to organize a project's task list, but the quick-add bar can't target them — a task added via `+Project` always lands outside any section and has to be dragged in afterwards. For section-heavy projects this makes the add-task bar a two-step flow.

## Solution

Extends the `+` short syntax so quick-add can file a task directly into a section, plus autocomplete:

- `Task +Work/Design` — matches project *Work*, then prefix-matches *Design* against that project's sections (longest leading word span wins, so multi-word section names strip cleanly)
- `Task /Design` — a standalone `/Section` resolves against the project the task will land in (active work context or the bar's selected project); an explicit `+Project/Section` wins
- Typing `/` opens a mention dropdown with the effective project's sections (same UX as the existing `+`/`#`/`@` triggers)
- Placement reuses the existing `addTaskToSection` action right after creation; the parsed section lives in `AddTaskBarState.sectionId` and is cleared on project change and after each add

**Design notes:**

- `/` follows Todoist's quick-add convention (`#Project /Section`), so it matches arriving muscle memory
- Sections ride the existing project short-syntax toggle — no new setting, per the manifesto's "one calm default" guidance; independent gating would be a trivial follow-up if workflows diverge
- **Backward compatibility:** projects whose titles contain `/` (e.g. "A/B Testing") keep matching as plain projects — the whole token is tried first, covered by a test. Standalone `/` requires a word boundary with no trailing space, and nothing is stripped from the title unless a section actually matches, so `either/or`, `w/ milk`, `1h/2h` estimates, and URLs stay untouched (all covered by tests). With no sections passed, `shortSyntax()` output is unchanged.

**One point I want to flag for review** rather than have you find: creation into a section is two ops (task creation, then `addTaskToSection`) from one user gesture. Both replay deterministically and it mirrors how drag-into-section works today, but if you'd rather have a combined action/meta-reducer per the contributor sync model, I'm happy to rework it that way.

**To try it:** create a project with a couple of sections → quick-add → `something +ProjectName/` (dropdown appears) or, inside the project, just `something /sec`.

**Scope note:** this PR now covers the add-task bar only. Section syntax while editing existing task titles (+ inline autocomplete) was split into a follow-up PR per review.

## Type of Change

- [x] New feature

## Checklist

- [x] I have included relevant changes to the documentation/wiki (`3.04-Short-Syntax.md`)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (26 new specs: matching, fallbacks, collision/compat cases, round-3 review regressions)
- [x] Existing tests still pass (232 short-syntax / 95 parser service / full 13.6k-spec suite green locally)
- [x] My commit messages follow the Angular format

