### PR TITLE
fix(sync): guard file-based recovery snapshot vs concurrent ops (#9023)

### DIFF
--- a/src/app/op-log/core/operation-log.const.ts
+++ b/src/app/op-log/core/operation-log.const.ts
@@ -80,6 +80,19 @@ export const LOCK_NAMES = {
 } as const;
 
 /**
+ * Error code a REPAIR recovery snapshot upload returns when it is based on a
+ * remote the client has not fully merged (#9023). Shared as a single symbol so
+ * the producer (`FileBasedSyncAdapterService`) and the consumer
+ * (`RejectedOpsHandlerService`, which routes it to a rebase) cannot drift apart.
+ *
+ * The value MUST equal the server's `SYNC_ERROR_CODES.REPAIR_STALE` — the same
+ * code arrives over the wire from SuperSync, so this is also the wire contract.
+ * (Server-originated codes like CONFLICT_CONCURRENT stay as string matches: the
+ * server owns those; this one has a client-side producer that must agree.)
+ */
+export const REPAIR_STALE_ERROR_CODE = 'REPAIR_STALE';
+
+/**
  * Maximum time to wait for lock acquisition before throwing (milliseconds).
  * If a lock holder crashes or stalls, waiters would hang indefinitely without this.
  * Default: 30 seconds - long enough for legitimate operations (compaction can take ~5s),

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -1096,6 +1096,147 @@ describe('FileBasedSyncAdapterService', () => {
     });
   });
 
+  describe('uploadSnapshot REPAIR concurrency guard (#9023)', () => {
+    // An automatic REPAIR recovery snapshot must never blindly overwrite a remote
+    // that advanced since this client last synced: if another device uploaded ops
+    // this client never merged, the snapshot yields (REPAIR_STALE) so the shared
+    // rebase path pulls those ops in first. Mirrors the SuperSync
+    // repairBaseServerSeq guard, but keyed on the remote REV — a vector clock can
+    // compare CONCURRENT under pruning and wedge the repair forever.
+
+    // Seeds `_lastSeenRevs` = `rev` exactly as a real sync cycle does: download
+    // the file (stages the rev) then setLastServerSeq (promotes it after apply).
+    const seedBaseRev = async (rev: string): Promise<void> => {
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({
+          dataStr: addPrefix(createMockSyncData({ syncVersion: 2, recentOps: [] })),
+          rev,
+        }),
+      );
+      await adapter.downloadOps(0);
+      await adapter.setLastServerSeq(2);
+      mockProvider.downloadFile.calls.reset();
+    };
+
+    const uploadRepair = (): Promise<{
+      accepted: boolean;
+      errorCode?: string;
+      serverSeq?: number;
+    }> =>
+      adapter.uploadSnapshot(
+        { tasks: [] },
+        'client1',
+        'recovery',
+        { client1: 2 },
+        1,
+        undefined, // isPayloadEncrypted
+        'repair-op-id',
+        false, // isCleanSlate
+        'REPAIR', // snapshotOpType — triggers the guard
+      );
+
+    // Records every write (path, rev-to-match, force) in call order.
+    const captureWrites = (): { path: string; rev: string | null; force?: boolean }[] => {
+      const writes: { path: string; rev: string | null; force?: boolean }[] = [];
+      mockProvider.uploadFile.and.callFake(
+        async (path: string, _data: string, rev: string | null, force?: boolean) => {
+          writes.push({ path, rev, force });
+          return { rev: 'new-rev' };
+        },
+      );
+      return writes;
+    };
+    const primaryOf = (
+      writes: { path: string; rev: string | null; force?: boolean }[],
+    ): { path: string; rev: string | null; force?: boolean }[] =>
+      writes.filter((w) => w.path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE);
+
+    it('writes CONDITIONALLY on the base rev — primary before .bak — when the remote is unchanged', async () => {
+      await seedBaseRev('rev-1');
+      const writes = captureWrites();
+      const result = await uploadRepair();
+
+      expect(result.accepted).toBe(true);
+      const primary = primaryOf(writes);
+      expect(primary.length).toBe(1);
+      // Conditional on the rev we last synced, NOT a force overwrite.
+      expect(primary[0].rev).toBe('rev-1');
+      expect(primary[0].force).toBe(false);
+      // .bak is refreshed only AFTER the primary conditional write wins.
+      const order = writes.map((w) => w.path);
+      expect(order.indexOf(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE)).toBeLessThan(
+        order.indexOf(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE),
+      );
+    });
+
+    it('rejects as REPAIR_STALE — leaving .bak untouched — when the conditional write loses to a concurrent upload', async () => {
+      await seedBaseRev('rev-1');
+      const writes: { path: string }[] = [];
+      mockProvider.uploadFile.and.callFake(
+        async (path: string, _data: string, _rev: string | null, force?: boolean) => {
+          // The remote advanced past 'rev-1' → provider rejects the conditional
+          // primary write.
+          if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE && force === false) {
+            throw new UploadRevToMatchMismatchAPIError('rev changed');
+          }
+          writes.push({ path });
+          return { rev: 'x' };
+        },
+      );
+
+      const result = await uploadRepair();
+      expect(result.accepted).toBe(false);
+      expect(result.errorCode).toBe('REPAIR_STALE');
+      // The concurrent writer's data survives, AND the stale repair never reaches
+      // .bak (where a later corrupt-primary recovery could resurrect it).
+      expect(writes.some((w) => w.path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE)).toBe(
+        false,
+      );
+    });
+
+    it('writes with a null rev-to-match ("expect absent") when this client has no last-seen rev', async () => {
+      // No seedBaseRev → _lastSeenRevs is empty.
+      const writes = captureWrites();
+      const result = await uploadRepair();
+      expect(result.accepted).toBe(true);
+      expect(primaryOf(writes)[0].rev).toBeNull();
+      expect(primaryOf(writes)[0].force).toBe(false);
+    });
+
+    it('does NOT guard BACKUP_IMPORT — an explicit restore still force-overwrites', async () => {
+      await seedBaseRev('rev-1');
+      const writes = captureWrites();
+      const result = await adapter.uploadSnapshot(
+        { tasks: [] },
+        'client1',
+        'recovery',
+        { client1: 2 },
+        1,
+        undefined,
+        'backup-op-id',
+        false,
+        'BACKUP_IMPORT',
+      );
+      expect(result.accepted).toBe(true);
+      // Forced overwrite (not conditional) — the guard is REPAIR-only.
+      expect(primaryOf(writes)[0].force).toBe(true);
+    });
+
+    it('split format: rejects as REPAIR_STALE when the remote ops-file rev advanced past our base', async () => {
+      await seedBaseRev('rev-1'); // seed via the single-file path, then switch
+      splitSyncEnabled = true;
+      mockProvider.getFileRev.and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.OPS_FILE) return { rev: 'rev-2' };
+        throw new RemoteFileNotFoundAPIError('not found');
+      });
+      const result = await uploadRepair();
+      expect(result.accepted).toBe(false);
+      expect(result.errorCode).toBe('REPAIR_STALE');
+      // Gated before any write — the concurrent ops survive.
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+    });
+  });
+
   describe('deleteAllData', () => {
     it('should delete sync file and backup', async () => {
       mockProvider.removeFile.and.returnValue(Promise.resolve());

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -414,7 +414,7 @@ export class FileBasedSyncAdapterService {
         isPayloadEncrypted: boolean | undefined,
         _opId: string, // Not used in file-based sync (operation IDs are client-local)
         _isCleanSlate?: boolean, // Not used - file-based sync replaces entire file
-        _snapshotOpType?: RestorePointType, // Not used - file-based sync has no server-side op log
+        snapshotOpType?: RestorePointType, // REPAIR triggers a rev-based concurrency guard; see _uploadSnapshot
         _syncImportReason?: string, // Not used - file-based sync has no server-side conflict dialog
       ): Promise<SnapshotUploadResponse> => {
         return this._uploadSnapshot(
@@ -426,6 +426,7 @@ export class FileBasedSyncAdapterService {
           reason,
           vectorClock,
           schemaVersion,
+          snapshotOpType,
         );
       },
 
@@ -1152,6 +1153,7 @@ export class FileBasedSyncAdapterService {
     reason: 'initial' | 'recovery' | 'migration',
     vectorClock: Record<string, number>,
     schemaVersion: number,
+    snapshotOpType?: RestorePointType,
   ): Promise<SnapshotUploadResponse> {
     const providerKey = this._getProviderKey(provider);
 
@@ -1170,6 +1172,7 @@ export class FileBasedSyncAdapterService {
         schemaVersion,
         providerKey,
         state,
+        snapshotOpType,
       );
     }
 
@@ -1205,12 +1208,51 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
     );
     this._assertUploadDataNotEmpty(uploadData, 'FileBasedSyncAdapter._uploadSnapshot');
-    const snapshotUploadRes = await this._forceUploadWithBakFirst(
-      provider,
-      FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
-      FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
-      uploadData,
-    );
+    let snapshotUploadRes: { rev: string };
+    if (snapshotOpType === 'REPAIR') {
+      // #9023: an automatic REPAIR recovery snapshot must never overwrite a remote
+      // that advanced since this client last synced — otherwise a concurrent edit
+      // from another device (uploaded after our last download) is silently dropped.
+      // Mirror the SuperSync repairBaseServerSeq guard by writing CONDITIONALLY on
+      // the rev we last downloaded+applied (`_lastSeenRevs` — the repair's base).
+      // A rev, not a vector clock, is used deliberately: two independently-pruned
+      // clocks (MAX_VECTOR_CLOCK_SIZE) can compare CONCURRENT even when one
+      // dominates, which would wedge the repair forever. On a rev mismatch we
+      // signal REPAIR_STALE so the shared rebase path (RejectedOpsHandlerService)
+      // downloads the concurrent ops and rebuilds the repair; that download
+      // promotes `_lastSeenRevs`, so the retry converges. BACKUP_IMPORT / initial /
+      // migration keep force-overwrite: explicit restores or first-time uploads.
+      const baseRev = this._lastSeenRevs.get(providerKey) ?? null;
+      try {
+        snapshotUploadRes = await this._conditionalUploadRepairSnapshot(
+          provider,
+          FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+          FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+          uploadData,
+          baseRev,
+        );
+      } catch (e) {
+        if (e instanceof UploadRevToMatchMismatchAPIError) {
+          OpLog.warn(
+            'FileBasedSyncAdapter: REPAIR snapshot is stale (remote advanced since ' +
+              'our last sync); requesting rebase instead of overwriting.',
+          );
+          return {
+            accepted: false,
+            error: 'REPAIR snapshot does not include current remote state',
+            errorCode: 'REPAIR_STALE',
+          };
+        }
+        throw e;
+      }
+    } else {
+      snapshotUploadRes = await this._forceUploadWithBakFirst(
+        provider,
+        FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+        FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+        uploadData,
+      );
+    }
 
     // Reset local state
     this._expectedSyncVersions.set(providerKey, newSyncVersion);
@@ -2361,9 +2403,45 @@ export class FileBasedSyncAdapterService {
     schemaVersion: number,
     providerKey: string,
     state: unknown,
+    snapshotOpType?: RestorePointType,
   ): Promise<SnapshotUploadResponse> {
     const newSyncVersion = 1;
     const clock = vectorClock as VectorClock;
+
+    // #9023: same concurrency guard as the single-file path — a REPAIR recovery
+    // snapshot must not overwrite a remote that advanced since our last sync.
+    // The commit-point sync-ops.json is what other clients read, so gate on ITS
+    // rev vs the rev we last downloaded+applied (`_lastSeenRevs`). A rev, not a
+    // vector clock, is used deliberately (see _uploadSnapshot). `getFileRev`
+    // reads metadata only — no decode — so a torn/undecryptable remote does not
+    // block the repair. Missing ops file → no history to clobber, safe.
+    // NOTE: this pre-check closes the concurrent *merge* window; a conditional
+    // (rev-matched) write across the two-file (state + ops) protocol to close the
+    // residual sub-second check→write race is tracked as a follow-up.
+    if (snapshotOpType === 'REPAIR') {
+      const baseRev = this._lastSeenRevs.get(providerKey) ?? null;
+      let remoteOpsRev: string | null = null;
+      try {
+        remoteOpsRev = (
+          await provider.getFileRev(FILE_BASED_SYNC_CONSTANTS.OPS_FILE, null)
+        ).rev;
+      } catch (e) {
+        if (!(e instanceof RemoteFileNotFoundAPIError)) {
+          throw e;
+        }
+      }
+      if (remoteOpsRev !== null && remoteOpsRev !== baseRev) {
+        OpLog.warn(
+          'FileBasedSyncAdapter: REPAIR split snapshot is stale (remote advanced ' +
+            'since our last sync); requesting rebase instead of overwriting.',
+        );
+        return {
+          accepted: false,
+          error: 'REPAIR snapshot does not include current remote state',
+          errorCode: 'REPAIR_STALE',
+        };
+      }
+    }
 
     const stateData = await this._buildStateFileData(
       clientId,
@@ -2541,6 +2619,29 @@ export class FileBasedSyncAdapterService {
   ): Promise<{ rev: string }> {
     await provider.uploadFile(bakPath, encoded, null, true);
     return provider.uploadFile(primaryPath, encoded, null, true);
+  }
+
+  /**
+   * #9023: writes the primary sync file CONDITIONALLY on `revToMatch`, then (only
+   * once the primary write wins) refreshes the .bak with the same payload. Used
+   * for automatic REPAIR recovery snapshots so a concurrent write that landed
+   * since our last sync throws UploadRevToMatchMismatchAPIError instead of being
+   * silently overwritten. Primary-first (unlike `_forceUploadWithBakFirst`) so a
+   * lost race leaves the .bak untouched — a stale repair payload must never
+   * survive in .bak where a later corrupt-primary recovery could resurrect it and
+   * re-drop the concurrent ops. A null `revToMatch` means "expect the file
+   * absent" — the provider rejects the write if another client created it.
+   */
+  private async _conditionalUploadRepairSnapshot(
+    provider: FileSyncProvider<SyncProviderId>,
+    primaryPath: string,
+    bakPath: string,
+    encoded: string,
+    revToMatch: string | null,
+  ): Promise<{ rev: string }> {
+    const res = await provider.uploadFile(primaryPath, encoded, revToMatch, false);
+    await provider.uploadFile(bakPath, encoded, null, true);
+    return res;
   }
 
   /**

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -13,6 +13,7 @@ import {
 import { EncryptAndCompressHandlerService } from '../../encryption/encrypt-and-compress-handler.service';
 import { extractSyncFileStateFromPrefix } from '../../util/sync-file-prefix';
 import { EncryptAndCompressCfg } from '../../core/types/sync.types';
+import { REPAIR_STALE_ERROR_CODE } from '../../core/operation-log.const';
 import {
   Operation,
   VectorClock,
@@ -1240,7 +1241,7 @@ export class FileBasedSyncAdapterService {
           return {
             accepted: false,
             error: 'REPAIR snapshot does not include current remote state',
-            errorCode: 'REPAIR_STALE',
+            errorCode: REPAIR_STALE_ERROR_CODE,
           };
         }
         throw e;
@@ -2438,7 +2439,7 @@ export class FileBasedSyncAdapterService {
         return {
           accepted: false,
           error: 'REPAIR snapshot does not include current remote state',
-          errorCode: 'REPAIR_STALE',
+          errorCode: REPAIR_STALE_ERROR_CODE,
         };
       }
     }

--- a/src/app/op-log/sync/rejected-ops-handler.service.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.ts
@@ -7,7 +7,10 @@ import { T } from '../../t.const';
 import { SupersededOperationResolverService } from './superseded-operation-resolver.service';
 import { DownloadCallback, RejectedOpInfo } from '../core/types/sync-results.types';
 import { handleStorageQuotaError } from './sync-error-utils';
-import { MAX_CONCURRENT_RESOLUTION_ATTEMPTS } from '../core/operation-log.const';
+import {
+  MAX_CONCURRENT_RESOLUTION_ATTEMPTS,
+  REPAIR_STALE_ERROR_CODE,
+} from '../core/operation-log.const';
 import { toEntityKey } from '../util/entity-key.util';
 import { RepairOperationService } from '../validation/repair-operation.service';
 
@@ -209,7 +212,10 @@ export class RejectedOpsHandlerService {
         continue;
       }
 
-      if (rejected.errorCode === 'REPAIR_STALE' && entry.op.opType === OpType.Repair) {
+      if (
+        rejected.errorCode === REPAIR_STALE_ERROR_CODE &&
+        entry.op.opType === OpType.Repair
+      ) {
         const repairSummary = getRepairSummary(entry.op.payload);
         if (!repairSummary) {
           throw new Error(

--- a/src/app/op-log/testing/integration/file-based-sync/multi-client-convergence.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/multi-client-convergence.integration.spec.ts
@@ -1,4 +1,9 @@
-import { FileBasedSyncTestHarness } from '../helpers/file-based-sync-test-harness';
+import {
+  FileBasedSyncTestHarness,
+  HarnessClient,
+} from '../helpers/file-based-sync-test-harness';
+import { OpDownloadResponse } from '../../../sync-providers/provider.interface';
+import { uuidv7 } from 'uuidv7';
 
 describe('File-Based Sync Integration - Multi-Client Convergence', () => {
   let harness: FileBasedSyncTestHarness;
@@ -327,6 +332,103 @@ describe('File-Based Sync Integration - Multi-Client Convergence', () => {
       const entityIds = download.ops.map((o) => o.op.entityId);
       expect(entityIds).toContain('task-new');
       expect(entityIds).not.toContain('task-1');
+    });
+  });
+
+  describe('REPAIR recovery snapshot concurrency (#9023)', () => {
+    // A REPAIR recovery snapshot force-replaces the whole shared file. Before the
+    // guard it did so unconditionally, so a concurrent op another device had
+    // uploaded — but this client had not yet merged — was silently dropped. The
+    // guard makes the REPAIR yield (REPAIR_STALE) until that op is pulled in, then
+    // converge. This drives the full loop across two clients on one shared remote.
+
+    // The harness downloadOps() does NOT promote the last-seen rev (the real sync
+    // service does that via setLastServerSeq after the ops are applied). Do it
+    // explicitly so the client's REPAIR is based on the rev it actually saw, and
+    // merge the downloaded clock so the client's later ops are causally correct.
+    const applyDownload = async (
+      client: HarnessClient,
+      download: OpDownloadResponse,
+    ): Promise<void> => {
+      for (const serverOp of download.ops) {
+        client.mergeRemoteClock(serverOp.op.vectorClock);
+      }
+      await client.adapter.setLastServerSeq(download.latestSeq);
+    };
+
+    const repair = (
+      client: HarnessClient,
+      state: unknown,
+    ): Promise<{ accepted: boolean; errorCode?: string }> =>
+      client.adapter.uploadSnapshot(
+        state,
+        client.clientId,
+        'recovery',
+        client.getCurrentClock(),
+        1,
+        undefined, // isPayloadEncrypted
+        uuidv7(), // opId
+        false, // isCleanSlate
+        'REPAIR', // snapshotOpType — engages the concurrency guard
+      );
+
+    const taskState = (...ids: string[]): unknown => ({
+      task: {
+        ids,
+        entities: Object.fromEntries(ids.map((id) => [id, { id }])),
+      },
+    });
+
+    it('does not clobber a concurrent op, then converges after rebasing on it', async () => {
+      const a = harness.createClient('client-a');
+      const b = harness.createClient('client-b');
+
+      // A and B both start synced on A's first op.
+      await a.uploadOps([
+        a.createOp('Task', 'task-a', 'CRT', 'TaskActionTypes.ADD_TASK', { title: 'A' }),
+      ]);
+      await applyDownload(b, await b.downloadOps(0));
+
+      // B uploads a concurrent op that A never downloads.
+      await b.uploadOps([
+        b.createOp('Task', 'task-b', 'CRT', 'TaskActionTypes.ADD_TASK', { title: 'B' }),
+      ]);
+
+      // A tries to publish a REPAIR snapshot from its now-stale view of the remote.
+      const stale = await repair(a, taskState('task-a'));
+
+      // The guard fires: A yields instead of force-overwriting.
+      expect(stale.accepted).toBe(false);
+      expect(stale.errorCode).toBe('REPAIR_STALE');
+
+      // Critically — B's op is still on the remote. Nothing was clobbered.
+      const afterStale = await harness.createClient('observer-1').downloadOps(0);
+      expect(afterStale.ops.map((o) => o.op.entityId)).toContain('task-b');
+
+      // Rebase: A pulls in B's op, then re-publishes a merged REPAIR snapshot.
+      await applyDownload(a, await a.downloadOps(0));
+      const merged = await repair(a, taskState('task-a', 'task-b'));
+
+      // The retry converges (no wedge) — the rebased base rev now matches the remote.
+      expect(merged.accepted).toBe(true);
+
+      // A fresh client bootstraps to the merged state: B's data survived the repair.
+      const finalState = (await harness.createClient('observer-2').downloadOps(0))
+        .snapshotState as { task: { ids: string[] } };
+      expect(finalState.task.ids).toContain('task-a');
+      expect(finalState.task.ids).toContain('task-b');
+    });
+
+    it('publishes a REPAIR snapshot when the remote has not advanced (no false stale)', async () => {
+      const a = harness.createClient('client-a');
+      await a.uploadOps([
+        a.createOp('Task', 'task-a', 'CRT', 'TaskActionTypes.ADD_TASK', { title: 'A' }),
+      ]);
+
+      // No other client wrote since A's upload → the repair's base rev matches the
+      // remote → it publishes rather than needlessly rebasing.
+      const result = await repair(a, taskState('task-a'));
+      expect(result.accepted).toBe(true);
     });
   });
 


### PR DESCRIPTION
Closes #9023.

## Problem

An automatic REPAIR recovery snapshot on a **file-based** provider (Dropbox / WebDAV / local) force-overwrote the entire shared sync file **unconditionally**. If another device had uploaded a concurrent op this client hadn't yet merged, that op was silently dropped. SuperSync guards this via a server-side `repairBaseServerSeq` check; the file-based path had no equivalent (it dropped the arg and force-wrote). Reported in #9023 with a full console log confirming a `reason=recovery` snapshot resetting the Dropbox history to `syncVersion=1`.

## Fix

For a `REPAIR` snapshot (not `BACKUP_IMPORT` / `initial` / `migration`, which are explicit restores or first-time uploads), the adapter now writes the primary sync file **conditionally on the rev it last downloaded+applied** (`_lastSeenRevs` — the repair's base). On a rev mismatch it returns `REPAIR_STALE`, which routes into the **existing, provider-agnostic** rebase path (`RejectedOpsHandlerService` → `rebaseStaleRepair`): download the concurrent ops, rebuild the repair, retry. That download promotes `_lastSeenRevs`, so the retry converges. No shared-code changes — the adapter just *emits* the signal SuperSync already handles.

A **rev, not a vector clock**, is used deliberately: two independently-pruned clocks (`MAX_VECTOR_CLOCK_SIZE`) can compare `CONCURRENT` even when one dominates, and since the rebase rebuilds the same clock, that would wedge the repair forever (this was caught in an adversarial review of an earlier clock-based draft). The split-file path applies the same guard via a `getFileRev` pre-check (metadata only, so a torn/undecryptable remote can't block it). `_conditionalUploadRepairSnapshot` writes primary-before-`.bak` so a lost race leaves the stale repair out of `.bak`.

## Tests

- **Unit** (`file-based-sync-adapter.service.spec.ts`): conditional-on-base-rev; stale → `REPAIR_STALE` with `.bak` untouched; null-rev "expect absent"; `BACKUP_IMPORT` still force-overwrites; split-path stale pre-check.
- **Integration** (`multi-client-convergence.integration.spec.ts`): two clients on one shared provider — A's REPAIR yields when B has a concurrent unmerged op, **B's op survives** (no clobber), then A rebases and the retry **converges** with both clients' data present; plus a no-false-stale case.

All `checkFile` clean; related file-based specs green.

## Notes / scope

- Separate, compounding bug — the repair `confirm()` holding the `sp_op_log` lock during background sync (the reporter's 30s timeout + what widened the clobber window) — is tracked in **#9026**.
- Residual split-file force-write TOCTOU tracked in **#9042**.
- The underlying trigger (a cross-device merge leaving `task.projectId` inconsistent with project membership) overlaps **#9025 / #8749**.

⚠️ Sync-correctness change — please run the **WebDAV** job of `E2E Tests (Scheduled)` on this branch before merge (the closest multi-device coverage of the file-based path).
