### PR TITLE
fix(sync): isolate provider encryption settings + enforce critical e2e coverage

### DIFF
--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -151,16 +151,16 @@ jobs:
           E2E_REQUIRE_WEBDAV: 'true'
         run: npm run e2e:all -- --grep "${{ inputs.webdav_grep || '@webdav' }}"
 
-      - name: Stop Docker Services
-        if: always()
-        run: |
-          docker compose down
-
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
           echo "=== WebDAV Logs ==="
           docker compose logs webdav
+
+      - name: Stop Docker Services
+        if: always()
+        run: |
+          docker compose down
 
       - name: Upload E2E Results on Failure
         if: ${{ failure() }}
@@ -170,7 +170,8 @@ jobs:
           path: .tmp/e2e-test-results/**/*.*
           retention-days: 30
 
-  # Job 3: SuperSync E2E tests (sharded)
+  # Job 3: SuperSync E2E tests (sharded). WebDAV runs in every shard as well so
+  # the provider-switch scenarios are part of the suite rather than skipped.
   e2e-supersync:
     name: E2E Tests (SuperSync ${{ matrix.shard }}/6)
     needs: [build]
@@ -203,7 +204,7 @@ jobs:
         run: |
           cp .env.example .env
 
-      - name: Start SuperSync Docker Service
+      - name: Start Sync Docker Services
         # Retry to survive transient Docker Hub pull timeouts / rate limits;
         # timeout_minutes also bounds the otherwise-unbounded health-wait loop
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
@@ -212,26 +213,29 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 20
           command: |
-            docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml up -d --build supersync
+            docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml up -d --build supersync webdav
             echo "⏳ Waiting for SuperSync server..."
             until curl -s http://localhost:1901/health > /dev/null 2>&1; do sleep 1; done
             echo "✓ SuperSync server ready!"
+            chmod +x ./scripts/wait-for-webdav.sh
+            ./scripts/wait-for-webdav.sh
 
       - name: Run SuperSync E2E Tests
         env:
           E2E_REQUIRE_SUPERSYNC: 'true'
+          E2E_REQUIRE_WEBDAV: 'true'
         run: npm run e2e:all -- --grep "${{ inputs.grep || '@supersync' }}" --shard=${{ matrix.shard }}/6
-
-      - name: Stop Docker Services
-        if: always()
-        run: |
-          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml down supersync
 
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
           echo "=== SuperSync Logs ==="
-          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs supersync
+          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs supersync webdav
+
+      - name: Stop Docker Services
+        if: always()
+        run: |
+          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml down
 
       - name: Upload E2E Results on Failure
         if: ${{ failure() }}

--- a/.github/workflows/e2e-sync-pr.yml
+++ b/.github/workflows/e2e-sync-pr.yml
@@ -130,7 +130,8 @@ jobs:
           path: .tmp/angular-dist
           retention-days: 1
 
-  # Job 2: SuperSync E2E tests (sharded), each shard spins up its own server.
+  # Job 2: SuperSync E2E tests (sharded), each shard spins up SuperSync and
+  # WebDAV so the provider-switch scenarios are exercised instead of skipped.
   e2e-supersync:
     name: SuperSync E2E ${{ matrix.shard }}/6
     needs: [detect, build]
@@ -162,7 +163,7 @@ jobs:
       - name: Create .env file for Docker Compose
         run: cp .env.example .env
 
-      - name: Start SuperSync Docker Service
+      - name: Start Sync Docker Services
         # Retry to survive transient Docker Hub pull timeouts / rate limits;
         # timeout_minutes also bounds the otherwise-unbounded health-wait loop.
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
@@ -171,25 +172,28 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 20
           command: |
-            docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml up -d --build supersync
+            docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml up -d --build supersync webdav
             echo "⏳ Waiting for SuperSync server..."
             until curl -s http://localhost:1901/health > /dev/null 2>&1; do sleep 1; done
             echo "✓ SuperSync server ready!"
+            chmod +x ./scripts/wait-for-webdav.sh
+            ./scripts/wait-for-webdav.sh
 
       - name: Run SuperSync E2E Tests
         env:
           E2E_REQUIRE_SUPERSYNC: 'true'
+          E2E_REQUIRE_WEBDAV: 'true'
         run: npm run e2e:all -- --grep "@supersync" --shard=${{ matrix.shard }}/6
-
-      - name: Stop Docker Services
-        if: always()
-        run: docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml down supersync
 
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
           echo "=== SuperSync Logs ==="
-          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs supersync
+          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs supersync webdav
+
+      - name: Stop Docker Services
+        if: always()
+        run: docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml down
 
       - name: Upload E2E Results on Failure
         if: ${{ failure() }}
@@ -244,15 +248,15 @@ jobs:
           E2E_REQUIRE_WEBDAV: 'true'
         run: npm run e2e:all -- --grep "@webdav"
 
-      - name: Stop Docker Services
-        if: always()
-        run: docker compose down
-
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
           echo "=== WebDAV Logs ==="
           docker compose logs webdav
+
+      - name: Stop Docker Services
+        if: always()
+        run: docker compose down
 
       - name: Upload E2E Results on Failure
         if: ${{ failure() }}

--- a/.github/workflows/electron-smoke.yml
+++ b/.github/workflows/electron-smoke.yml
@@ -9,11 +9,9 @@ name: Electron Packaging Smoke Test
 # and the compiled dep was omitted from the electron-builder files glob,
 # so every 18.2.7 binary crashed on launch.
 #
-# PRs run the cheap static check (~10s after the build) — paths filter
-# excludes docs, translations, and platform-specific trees but still covers
-# src/**, because #7320's root cause lived under src/app/util/. The full
-# launch-under-xvfb smoke test runs on merge to master, release tags, and
-# manual dispatch — stronger signal but needs xvfb setup + ~30s of wait.
+# The static check catches missing require() targets. The packaged renderer
+# also runs a task-create-and-reload flow under xvfb on every invocation, so
+# pull requests prove the native shell can perform and persist a core action.
 
 on:
   pull_request:
@@ -96,99 +94,18 @@ jobs:
           node tools/verify-electron-requires.js "$ASAR"
 
       - name: Install xvfb
-        if: github.event_name != 'pull_request'
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
-      - name: Smoke test — launch packaged app
-        if: github.event_name != 'pull_request'
+      - name: Smoke test packaged app task flow
         run: |
-          set -uo pipefail
-
-          UNPACKED=.tmp/app-builds/linux-unpacked
-          # afterPack.js renames the real binary to superproductivity-bin and
-          # installs a shell wrapper at superproductivity. Launch the wrapper
-          # so the smoke test exercises the exact entry path users hit.
-          BIN="$UNPACKED/superproductivity"
-          if [ ! -x "$BIN" ]; then
-            echo "::error::Expected launcher at $BIN not found or not executable"
-            ls -la "$UNPACKED" || true
-            exit 1
-          fi
-
-          # Keep the log inside the workspace so upload-artifact can find it
-          # when a step fails. /tmp is accessible but fragile across runner
-          # images and upload-artifact glob evaluation.
+          set -o pipefail
           mkdir -p .tmp/smoke
-          LOG=.tmp/smoke/launch.log
-          : > "$LOG"
-
-          echo "Launching $BIN under xvfb (log: $LOG)"
-          # Electron flags:
-          #   --no-sandbox: chrome-sandbox needs setuid root, not set on runners
-          #   --disable-gpu: no GPU on the runner
-          #   --disable-dev-shm-usage: /dev/shm is small in GH-hosted containers,
-          #     and Chromium/Electron can die with shared-memory errors without it
-          # Xvfb flags:
-          #   --server-args: explicit screen geometry; Xvfb's 640x480x8 default
-          #     trips some Chromium color-depth assertions
           xvfb-run \
             --auto-servernum \
             --server-args="-screen 0 1280x720x24" \
-            "$BIN" \
-              --no-sandbox \
-              --disable-gpu \
-              --disable-dev-shm-usage \
-            > "$LOG" 2>&1 &
-          WRAPPER_PID=$!
-
-          # Wait up to 30s for the app to crash. The #7320 crash surfaces
-          # within ~100ms — 30s is generous headroom for Angular bootstrap
-          # in CI. xvfb-run exits when its child exits, so the wrapper PID
-          # going away is a reliable crash signal. We also scan stderr for
-          # known failure markers as a belt-and-suspenders backstop: some
-          # main-process exceptions log without killing the process.
-          CRASH_RE='(Uncaught Exception|Cannot find module|A JavaScript error occurred in the main process|Segmentation fault|SIGSEGV|SIGABRT|TypeError:|ReferenceError:|FATAL ERROR|Check failed)'
-          for i in $(seq 1 30); do
-            if ! kill -0 $WRAPPER_PID 2>/dev/null; then
-              echo "::error::xvfb-run/Electron exited after ${i}s — likely crash."
-              echo "----8<---- launch log"
-              cat "$LOG" || true
-              echo "---->8----"
-              exit 1
-            fi
-            if grep -E -q "$CRASH_RE" "$LOG" 2>/dev/null; then
-              echo "::error::Crash marker detected in log after ${i}s:"
-              grep -E "$CRASH_RE" "$LOG" || true
-              echo "----8<---- launch log"
-              cat "$LOG" || true
-              echo "---->8----"
-              kill -9 $WRAPPER_PID 2>/dev/null || true
-              exit 1
-            fi
-            sleep 1
-          done
-
-          echo "App still alive after 30s — startup OK. Terminating."
-          kill $WRAPPER_PID 2>/dev/null || true
-          # xvfb-run forwards SIGTERM to its child; give them 5s to exit
-          # cleanly before SIGKILL. Also sweep any stray electron workers.
-          for i in 1 2 3 4 5; do
-            if ! kill -0 $WRAPPER_PID 2>/dev/null; then break; fi
-            sleep 1
-          done
-          kill -9 $WRAPPER_PID 2>/dev/null || true
-          pkill -9 -f "$UNPACKED/superproductivity" 2>/dev/null || true
-          wait $WRAPPER_PID 2>/dev/null || true
-
-          # Final scan for errors that didn't crash the main process but
-          # would still indicate a broken build.
-          if grep -E -q "$CRASH_RE" "$LOG" 2>/dev/null; then
-            echo "::error::Crash marker detected in final log scan:"
-            grep -E "$CRASH_RE" "$LOG" || true
-            exit 1
-          fi
-
-          echo "Smoke test passed."
+            node e2e/electron/packaged-app-smoke.cjs \
+              .tmp/app-builds/linux-unpacked/superproductivity \
+            2>&1 | tee .tmp/smoke/launch.log
 
       - name: Upload logs on failure
         if: failure()

--- a/docs/plans/2026-07-14-ios-testflight-master-builds.md
+++ b/docs/plans/2026-07-14-ios-testflight-master-builds.md
@@ -1,0 +1,206 @@
+# Implementation plan: Internal TestFlight builds from `master`
+
+**Status:** Plan only · **Date:** 2026-07-14
+**Difficulty:** Moderate. Allow about one engineering day split across two small
+changes, plus Apple processing and tester verification time.
+
+## Outcome and scope
+
+Use the existing iOS signing/archive workflow to send the newest eligible `master`
+state to an internal TestFlight group. Rapid pushes are coalesced: one beta may run
+and only the newest superseding beta waits. This intentionally does not produce one
+TestFlight build for every intermediate SHA.
+
+Production behavior stays event-based: final `v*` tag pushes submit the existing iOS
+release for review, prerelease tag pushes remain upload-only, and manual dispatch can
+never submit to production. Master builds are marked **TestFlight Internal Only**, so
+Apple cannot offer them to external testers or customers.
+
+Out of scope: external TestFlight, app changes, new dependencies, and the existing
+iOS/macOS App Store review-submission race. There is no new app-wide upload queue;
+the internal-only beta path neither edits App Store metadata nor opens a review.
+
+## Routing contract
+
+| Event                                  | Export                   | Fastlane lane | Production submit |
+| -------------------------------------- | ------------------------ | ------------- | ----------------- |
+| Push to `master`                       | TestFlight Internal Only | `ios beta`    | Never             |
+| Push of final `v*` tag                 | App Store Connect        | `ios release` | Yes               |
+| Push of prerelease `v*` tag            | App Store Connect        | `ios release` | No                |
+| Manual dispatch, default `beta` mode   | TestFlight Internal Only | `ios beta`    | Never             |
+| Manual dispatch, `release-upload-only` | App Store Connect        | `ios release` | Never             |
+
+The production guard must include the event type, not only the ref:
+
+```yaml
+SUBMIT_FOR_REVIEW: >-
+  ${{ github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !contains(github.ref, '-') }}
+```
+
+Manual beta dispatch is allowed only from `master`. The explicit
+`release-upload-only` mode preserves the workflow's current manual upload capability
+without inheriting its final-tag submission footgun.
+
+## Phase 0: Apple and version prerequisites
+
+- Create one internal tester group, add the intended App Store Connect users, and
+  enable automatic distribution. Accept that eligible tag uploads will also reach
+  this group because automatic distribution is app/group configuration, not
+  Git-ref-aware.
+- Create a dedicated App Store Connect **team** API key with the Developer role for
+  beta uploads. Store it as `ASC_*` secrets in an `internal-testflight` GitHub
+  environment restricted to `master`, with no reviewer gate. A team key cannot be
+  app-scoped; the separate lower-role key reduces privilege and credential reuse but
+  still has team-wide upload access.
+- Keep the existing App Manager key on the release route. Record secret names, roles,
+  and certificate/profile expiry only—never key or tester content.
+- On the pinned Xcode 26.2 runner, confirm `xcodebuild -help` supports the
+  `testFlightInternalTestingOnly` export option and that the current provisioning
+  profile can export that distribution type.
+- Validate the build-number examples below with `agvtool`, the archived IPA, and
+  Apple before enabling unattended builds.
+
+## Increment A: Add a safe manual beta path
+
+Do not add the `master` push trigger yet.
+
+### Fastlane
+
+Add `ios beta` to `fastlane/Fastfile`. It requires `IPA_PATH` and the existing
+`ASC_*` contract, calls `upload_to_testflight`, and sets these options explicitly:
+
+```ruby
+skip_submission: true
+skip_waiting_for_build_processing: false
+distribute_external: false
+submit_beta_review: false
+wait_processing_timeout_duration: 1800
+```
+
+Do not pass tester groups, changelog, or notification options. App Store Connect's
+automatic group owns internal distribution. A processing timeout means “upload
+succeeded, processing unknown”; inspect App Store Connect before retrying. Never
+re-upload the same IPA blindly.
+
+### Workflow and versioning
+
+Refactor `.github/workflows/build-ios.yml` into one build job and conditional beta
+and release upload jobs:
+
+- Add `workflow_dispatch.mode` with `beta` as the safe default and
+  `release-upload-only` as the other choice.
+- Set top-level `permissions: contents: read`.
+- Export beta runs with `testFlightInternalTestingOnly: true`; tag and manual release
+  uploads keep the current App Store Connect export.
+- Preserve the exact stripped `package.json` marketing version on release routes.
+- For betas, set `CFBundleShortVersionString` to
+  `incrementPatch(max(stripPrerelease(package.version), highest stable vX.Y.Z tag))`.
+  Fetch tags and implement the strict three-integer comparison without a dependency.
+  This future train must be greater than the latest approved iOS version, including
+  immediately after a release.
+- Set `CFBundleVersion` exactly to
+  `$(date -u +%Y%m%d%H%M).${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}` on every route.
+  This remains above the old timestamp values and separates same-minute runs and
+  reruns.
+- Verify both values in every relevant target and in the exported IPA. Also confirm
+  whether `VERSIONING_SYSTEM = apple-generic` must be added for reliable `agvtool`
+  behavior.
+- Move certificate/profile installation to immediately before export; the archive is
+  already unsigned. Reuse of the shared Apple Distribution certificate remains an
+  accepted residual risk on every master build.
+- Pass exactly one IPA between jobs using pinned artifact actions, a run/attempt-
+  specific name, `if-no-files-found: error`, a clean download directory, and one-day
+  retention for beta artifacts. The upload jobs must fail unless exactly one regular
+  `.ipa` exists.
+- Bind only the beta upload job to `internal-testflight`; keep release credentials on
+  the existing release path. Never enable verbose fastlane output.
+
+Add workflow-level concurrency for the complete beta build/upload lifecycle: beta
+runs share a fixed group with `cancel-in-progress: false` and `queue: single`, keeping
+the running run and only the newest pending run. Tag and manual release runs use a
+run/attempt-specific group, so a master push cannot coalesce them.
+
+### Static verification
+
+- `ruby -c fastlane/Fastfile`
+- `bundle exec fastlane lanes` on the macOS runner
+- `npx prettier --check .github/workflows/build-ios.yml`
+- `git diff --check`
+- Exercise the version calculation with an old timestamp build, two same-minute
+  runs, a rerun, prerelease package versions, and a stable tag newer than the package.
+- Review every routing-table case and confirm the `master` push trigger is absent.
+- Confirm no dependency or secret content was added.
+
+## Live gate between increments
+
+Merge Increment A, then manually dispatch `beta` from `master` once. Do not proceed
+until all of the following are true:
+
+- Apple accepts and finishes processing the expected version/build pair.
+- App Store Connect shows the **Internal** indicator and does not allow external or
+  customer distribution.
+- The automatic internal group receives it and one tester can install and launch it.
+- No external Beta App Review, App Review submission, App Store version, or release
+  metadata is created or changed.
+- Logs and artifacts expose no signing or API-key material.
+
+Record only the Actions URL, non-sensitive version/build pair, duration, and result.
+
+## Increment B: Enable `master` and document operations
+
+Add the branch trigger while retaining the existing tag trigger:
+
+```yaml
+push:
+  branches: [master]
+  tags: ['v*']
+```
+
+Update `docs/build-and-publish-notes.md`, `docs/apple-release-automation.md`, and
+`.github/SECURITY-SETUP.md` with the routing table, internal-only boundary,
+credentials, version/build formulas, coalescing, timeout recovery, and rollback.
+
+After merge, confirm one normal `master` push uploads successfully. Start three beta
+dispatches close together and verify the active run completes, the middle pending
+run is superseded, and the newest pending run proceeds. A failed Apple
+upload/processing result must leave Actions red.
+
+The next tagged release is a follow-up observation, not an activation blocker:
+
+- verify the release lane and submission behavior are unchanged;
+- expect the automatic internal group to receive the eligible release build; and
+- after it reaches Ready for Distribution, verify the next master beta advances to
+  the following patch train and Apple accepts it.
+
+## Cost, rollback, and risks
+
+Each beta that survives coalescing consumes roughly 10–15 macOS runner minutes plus
+one signed IPA upload. Track `accepted beta runs × duration` and artifact storage for
+the first week. Keep one-day beta artifact retention; consider a proven-safe
+docs-only path filter later only if cost/noise is material.
+
+Rollback is to remove the `master` branch trigger while retaining manual beta mode.
+If a distributed build must stop, use App Store Connect **Expire Build**; disabling
+automatic group distribution affects future assignment but does not retract an
+installed build. Keep the new version/build scheme after Apple has accepted it.
+
+| Risk                                                  | Mitigation                                                                                  |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Beta reaches external testing or production           | Internal-only export plus fail-closed beta lane                                             |
+| Post-release betas are rejected as an old version     | Future patch train based on package and stable tags; mandatory post-release check           |
+| Rapid pushes create cost and TestFlight noise         | Workflow-wide beta coalescing and one-day artifacts                                         |
+| Manual/tag routing submits the wrong build            | Explicit modes, event-type production guard, routing-table review                           |
+| Production credentials gain exposure                  | Dedicated Developer beta key; release key stays on release job; protected master/CODEOWNERS |
+| Signing identity gains exposure on every master build | Install only at export, restrict workflow changes, accept and document certificate reuse    |
+| Apple processing times out after upload               | Inspect App Store Connect first; rebuild with a new number only when retry is required      |
+
+## References to recheck when implementing
+
+- [Apple: Distributing beta builds](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases)
+- [Apple: Internal testers and internal-only builds](https://developer.apple.com/help/app-store-connect/test-a-beta-version/add-internal-testers)
+- [Apple: Build/version identifiers](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleversion)
+- [Apple: Marketing-version identifiers](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleshortversionstring)
+- [fastlane: `upload_to_testflight`](https://docs.fastlane.tools/actions/upload_to_testflight/)
+- [GitHub Actions: concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)

--- a/docs/plans/2026-07-14-microsoft-365-calendar-provider.md
+++ b/docs/plans/2026-07-14-microsoft-365-calendar-provider.md
@@ -1,0 +1,703 @@
+# Microsoft 365 Calendar provider (Outlook without an iCal URL)
+
+Status: **proposed, revised after repository audit and adversarial Codex review** ·
+2026-07-14
+
+## Decision summary
+
+This is feasible, but it is not a mechanical rename of the Google Calendar plugin.
+Microsoft Graph event mapping is the easy half. The harder half is operating a
+multitenant Microsoft Entra application reliably in university tenants and closing
+several generic plugin-host gaps around OAuth, polling, throttling, all-day dates, and
+device-local credentials.
+
+The smallest responsible product is a bundled, **read-only, Electron-only Microsoft
+365 Calendar provider for work/school accounts**. It should let a user authenticate
+without an iCal URL, select their own calendars, see events in Schedule/Planner,
+manually turn an event into a task, and open the original event in Outlook.
+
+Do not begin the production implementation until the Phase 0 tenant gate succeeds.
+Code cannot bypass a university's consent, Conditional Access, or enterprise-app
+policy.
+
+### Difficulty and estimate
+
+| Outcome                                                     |                                  Estimate | Confidence                        |
+| ----------------------------------------------------------- | ----------------------------------------: | --------------------------------- |
+| Disposable Graph/tenant feasibility spike                   |                      1–2 engineering days | Medium; tenant policy is external |
+| Production Electron MVP, including host hardening and tests | 17–26 additional focused engineering days | Medium                            |
+| Total engineering effort                                    |          About 4–6 weeks for one engineer | Medium                            |
+| Microsoft publisher/admin approval                          |                              Not included | Unbounded external elapsed time   |
+
+A demo that only logs in and lists events could be built in a few days. Calling that
+production-ready would hide the main risks found in review: unsupported mobile flows
+currently start OAuth, all calendar providers can be polled at the fastest provider's
+cadence, linked tasks cause per-task Graph requests, refresh-token persistence is not
+transactional, and synced calendar IDs can meet credentials for a different local
+account.
+
+## User problem
+
+Some universities require Outlook/Microsoft 365 but disable calendar publication, so
+the existing URL-based iCal integration cannot be used. The requested workflow is
+personal planning, not team calendar management:
+
+1. Sign in with a university Microsoft 365 account.
+2. Select one or more personal calendars.
+3. See upcoming events beside tasks when planning a realistic day.
+4. Convert an event into a task when useful.
+5. Open the source event in Outlook.
+
+This fits Super Productivity's deep-work scope as an optional integration. It must be
+quiet by default, read-only, least-privilege, and safe when offline or disconnected.
+
+## What can be reused
+
+The repository already has most of the structural pieces:
+
+- `packages/plugin-dev/google-calendar-provider/` demonstrates a bundled OAuth
+  agenda provider, dynamic calendar selection, recurrence expansion through a remote
+  API, event-to-task mapping, and provider-local tests.
+- `src/app/plugins/oauth/` supplies authorization-code + PKCE flows, Electron
+  loopback callbacks, token refresh, and local IndexedDB token storage.
+- `packages/plugin-api/src/issue-provider-types.ts` already represents agenda events
+  with start, duration, all-day, due-time, and source URL fields.
+- `src/app/features/calendar-integration/` already combines plugin events with iCal
+  events and exposes task creation and source-link actions.
+- `packages/plugin-dev/scripts/build-all.js`, `src/app/plugins/plugin.service.ts`, and
+  `electron/bundled-plugin-ids.test.cjs` define the bundled-plugin build and reserved-ID
+  path.
+
+The provider should extend these building blocks. It should not introduce a second
+calendar framework, a Microsoft SDK, a backend token broker, or a new root dependency.
+
+## Corrections made during the double-check
+
+The initial outline was too optimistic in the following ways. These are requirements,
+not optional polish:
+
+- Missing mobile client IDs do **not** currently disable native OAuth. The host needs
+  an explicit additive platform-capability contract.
+- Agenda refresh currently uses the minimum interval across all calendar providers.
+  A one-minute Google provider can therefore make a five-minute Microsoft provider
+  call Graph every minute.
+- Agenda-view configurations hide the auto-poll setting while the default remains on.
+  Imported plugin-calendar tasks can consequently generate one `getById` request per
+  task on every issue-poll cycle.
+- `/me/calendars` can expose locally represented shared/delegated calendars. The MVP
+  must filter to calendars owned by the signed-in mailbox instead of merely hiding a
+  label in the UI.
+- Agenda loading and issue search are independent host paths. A claim of “local
+  search” requires an explicitly keyed provider cache and in-flight deduplication.
+- Refreshed token persistence must finish before a new access token is returned, and
+  a late refresh must not resurrect credentials after disconnect or overwrite a newer
+  login.
+- Transient refresh failures and terminal reauthentication failures need different
+  state transitions. A 429, timeout, offline error, or 5xx must not delete a usable
+  refresh token.
+- Microsoft requires clients to respect `Retry-After`. A small typed error extension
+  is preferable to blind sleeps or exposing every response header as a permanent
+  plugin API.
+- Calendar selection is synced, while OAuth credentials are local and keyed once per
+  plugin. The provider must detect calendar IDs from a different account and explain
+  that all configurations on one device share one Microsoft login.
+- An all-day event needs an explicit `dueDay` date string. Reconstructing it from a
+  UTC millisecond timestamp can shift it by a day when mailbox and device time zones
+  differ.
+- Event metadata is cached unencrypted in local storage. Authentication changes must
+  purge the affected provider's cache, while transient offline failures may retain it.
+- Plugin translations require `i18n.languages: ["en"]`, `i18n/en.json`, build copying,
+  and `PluginAPI.translate`; copying the current Google scaffold literally would miss
+  those requirements.
+
+## MVP scope
+
+### Included
+
+- Microsoft 365 work/school accounts in the global Microsoft cloud.
+- Super Productivity Electron builds on Windows, macOS, and Linux.
+- One Microsoft account per plugin per device.
+- Up to 10 calendars owned by the signed-in mailbox.
+- A fixed event window from 7 days before local today through 28 days after local
+  today.
+- Single events, recurring occurrences/exceptions, and multi-day/all-day events.
+- Schedule/Planner display, bounded title search over the provider cache, manual task
+  creation, and opening the Outlook web link.
+- Read-only delegated permission `Calendars.ReadBasic` plus `offline_access`.
+- Stale cached agenda data during transient offline/server failures, clearly
+  distinguishable from a reconnect-required state.
+
+### Explicitly excluded
+
+- Creating, editing, moving, completing, or deleting Outlook events.
+- Time-block write-back and Google feature parity.
+- Event bodies/notes, attachments, extensions, attendees, or meeting chat data.
+- Shared, delegated, group, room, or resource calendars.
+- Personal Outlook.com accounts, guest-only accounts, and national/sovereign clouds.
+- Web, Android, and iOS support.
+- Multiple Microsoft accounts on one device.
+- Automatic backlog import.
+- Automatic refresh of imported tasks. The task is a manually created planning
+  snapshot with a source link; this avoids an unbounded per-task Graph polling path.
+
+The exclusions should appear in the setup copy and documentation, not only in code
+comments.
+
+## Architecture
+
+```text
+Microsoft Entra authorization (system browser + PKCE)
+        |
+        v
+device-local OAuth token store (one account per plugin, never synced)
+        |
+        v
+Microsoft provider -> validated Graph client -> bounded in-memory event cache
+        |                                      |
+        |                                      +-> local title search / getById reuse
+        v
+existing issue-provider agenda contract
+        |
+        v
+calendar integration cache -> Schedule/Planner -> manual task snapshot
+```
+
+Provider configuration, including selected calendar IDs, remains part of synced issue
+provider state. Tokens and the provider's event cache remain device-local. On each
+device, the selected IDs must be reconciled against the calendars returned for that
+device's connected account before Graph event calls begin.
+
+## Fixed contracts and limits
+
+These values make “bounded” testable and avoid adding settings before a real workflow
+requires them:
+
+| Concern                      | MVP rule                                                                                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tenant endpoint              | `organizations` authorization/token endpoints                                                                                                                 |
+| Delegated scopes             | `offline_access https://graph.microsoft.com/Calendars.ReadBasic`                                                                                              |
+| Calendar ownership           | Compare each calendar owner to the default calendar's owner; if ownership is missing/ambiguous, expose only the default calendar and fail closed for the rest |
+| Selected calendars           | 1 required, 10 maximum                                                                                                                                        |
+| Event window                 | Local start-of-day −7 days through local start-of-day +28 days, sent as explicit-offset instants                                                              |
+| Graph page size              | `$top=100`                                                                                                                                                    |
+| Pagination                   | At most 5 pages per calendar and 2,000 mapped events total                                                                                                    |
+| Calendar request concurrency | 2                                                                                                                                                             |
+| Request timeout              | 30 seconds                                                                                                                                                    |
+| Agenda cadence               | 5 minutes per Microsoft provider; manual refresh may bypass the due time                                                                                      |
+| Overlap                      | One in-flight fetch per account/config cache key; later automatic ticks reuse it                                                                              |
+| Search                       | Case-insensitive title search, 50 results maximum, over the same bounded cache                                                                                |
+| Retry without `Retry-After`  | At most 2 retries using approximately 1 s and 2 s exponential delay plus jitter                                                                               |
+| Retry with `Retry-After`     | Do not retry before the supplied time; retry once only when the wait is at most 30 s, otherwise stop and retain stale data                                    |
+| Timed event identity         | Composite, reversible encoding of case-sensitive calendar ID + immutable event ID                                                                             |
+| All-day identity/date        | Preserve `YYYY-MM-DD` start and exclusive end dates separately from numeric schedule instants                                                                 |
+| Content limits               | Validate response shapes; cap IDs/URLs/titles to documented local constants before mapping                                                                    |
+
+If a cap is reached, fail that refresh with a safe localized “calendar result limit
+reached” error and keep the last complete provider snapshot. Do not silently replace a
+complete cache with a truncated one.
+
+### Failure semantics
+
+- **Offline, timeout, 429, or 5xx:** keep tokens and the last complete agenda cache;
+  retry only within the table's budget.
+- **One selected calendar returns 403/404:** fail the refresh and retain the last
+  complete snapshot; setup/test-connection identifies the inaccessible calendar and
+  requires reselection. This is intentionally all-or-nothing for the MVP because the
+  host cache is provider-wide, not per remote calendar.
+- **401:** force-refresh the access token once and retry the Graph request once. A
+  second 401, `invalid_grant`, `interaction_required`, or a claims challenge becomes
+  reconnect-required and purges the affected provider's cached event metadata.
+- **Malformed Graph data:** reject the malformed item. If rejected items or paging
+  limits make the result incomplete, reject the refresh and keep the prior complete
+  snapshot.
+- **No previous cache:** show no events and a localized actionable error; never invent
+  an empty successful result for an authentication or completeness failure.
+- **Account/config mismatch:** make no `calendarView` calls. Ask the user to reselect
+  calendars for the locally connected account.
+
+## External feasibility gate (Phase 0)
+
+This phase deliberately precedes repo implementation.
+
+1. Create a Super Productivity-owned, multitenant public-client Entra registration
+   limited to accounts in organizational directories. Do not add a client secret.
+2. Register the Electron loopback redirect
+   `http://127.0.0.1:<fixed-high-port>/<fixed-callback-path>` through the Entra
+   application manifest. Microsoft does not treat a literal `127.0.0.1` port as
+   interchangeable, so the exact URI matters.
+3. Configure only `Calendars.ReadBasic`; request `offline_access` in the OAuth flow.
+4. Record whether the project can satisfy Microsoft publisher-verification
+   prerequisites. Many education tenants restrict unverified multitenant apps even
+   when a delegated permission is normally user-consentable.
+5. Prove authorization, PKCE token exchange, refresh, `/me/calendars`, and one
+   `calendarView` call with:
+   - an ordinary Microsoft 365 tenant;
+   - a representative restrictive university tenant, ideally the reporting user's;
+   - consent denied and admin-approval-required paths.
+6. Verify the chosen fixed port on all three desktop OSes. Confirm that a port
+   collision produces a clear actionable failure rather than a timeout.
+7. Verify that Graph responses expose the fields required under
+   `Calendars.ReadBasic`: calendar owner/default flags, event subject/start/end,
+   `isAllDay`, cancellation/response status, immutable ID, and `webLink`.
+
+**Go:** at least one representative university user can consent, or the university has
+a realistic documented admin-approval route; the app registration can be operated and
+published by the project; all required fields are available at read-basic scope.
+
+**No-go:** representative tenants categorically block the app with no workable approval
+path, publisher requirements cannot be met, or required event/ownership fields demand
+a broader permission the project is unwilling to request. In that case, answer the
+user honestly; no client implementation can override the policy.
+
+The spike should leave a short evidence note with tenant type, requested scopes,
+redirect used, success/failure category, and redacted screenshots/errors. Never commit
+tokens, tenant IDs, user addresses, authorization codes, or client secrets.
+
+## Dependency order
+
+```text
+Phase 0 tenant gate
+  -> host OAuth safety
+  -> host HTTP/polling/calendar contracts
+  -> provider Graph slices
+  -> cross-tenant/manual verification
+  -> docs and pilot
+```
+
+Stop at each checkpoint if the preceding contract cannot be made reliable without a
+larger architectural change.
+
+## Ordered implementation tasks
+
+Each task is intentionally reviewable on its own. File lists are expected touch points,
+not permission to broaden the task.
+
+### 1. Add an explicit OAuth platform-capability contract
+
+**Depends on:** Phase 0 green.
+
+Add an optional, backward-compatible `supportedPlatforms` field to
+`OAuthFlowConfig`. Existing plugins that omit it keep current behavior; the Microsoft
+provider declares Electron only. Enforce the field before preparing a redirect server
+or opening a browser.
+
+Likely files:
+
+- `packages/plugin-api/src/types.ts`
+- `src/app/plugins/oauth/resolve-effective-oauth-config.util.ts`
+- `src/app/plugins/oauth/resolve-effective-oauth-config.util.spec.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts`
+
+Acceptance: web/native attempts fail before any OAuth side effect; Google behavior is
+unchanged. Verify with targeted specs and `npm run checkFile` for every changed TypeScript
+file. Estimate: 0.5 day.
+
+### 2. Make unsupported-platform UX generic
+
+**Depends on:** Task 1.
+
+Replace the web-only availability check in the provider dialog with the new platform
+contract and a localized desktop-only explanation.
+
+Likely files:
+
+- `src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts`
+- `src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.html`
+- `src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.spec.ts`
+- `src/assets/i18n/en.json`
+
+Acceptance: unsupported builds show a disabled connect action and never start OAuth;
+Electron remains connectable. Estimate: 0.5 day.
+
+### 3. Make token refresh an awaited, generation-guarded transaction
+
+**Depends on:** Task 1.
+
+Define internal refresh outcomes for success, transient failure, and terminal
+reauthentication. On success, replace a rotated refresh token (or retain the old one if
+none is returned), persist the full new token set, and only then return the access
+token. Increment a per-plugin generation on connect/disconnect; a late refresh from an
+older generation must be discarded and must not write to memory or IndexedDB. Deduplicate
+concurrent refreshes within the same generation.
+
+Expose an additive force-refresh option for the one-retry-on-401 path and emit a
+plugin-session-changed event after connect, disconnect, or terminal invalidation.
+Transient network/429/5xx errors retain credentials.
+
+Likely files:
+
+- `src/app/plugins/oauth/plugin-oauth.model.ts`
+- `src/app/plugins/oauth/plugin-oauth.service.ts`
+- `src/app/plugins/oauth/plugin-oauth.service.spec.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.ts`
+- `src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts`
+
+Acceptance: tests cover rotation, no rotation, persistence failure, refresh
+deduplication, disconnect during refresh, reconnect/account switch during refresh,
+restart restoration, transient failure, terminal failure, and forced refresh. No token
+or response body is logged. Estimate: 2–3 days.
+
+### 4. Harden the Electron loopback callback
+
+**Depends on:** Phase 0's exact redirect.
+
+At `PLUGIN_OAUTH_START`, extract the expected state and callback path from the validated
+authorization URL. The loopback server must ignore unrelated paths and wrong-state
+requests without marking the flow handled or closing. Close only after a matching
+callback, timeout, explicit cancellation, or startup error. Keep the existing clear
+`EADDRINUSE` error for the fixed port.
+
+Likely files:
+
+- `electron/plugin-oauth.ts`
+- a small pure callback-validation helper and focused test beside it
+
+Acceptance: wrong path/state cannot consume the real callback; correct error and code
+callbacks complete once; collision and timeout clean up. Estimate: 0.5–1 day.
+
+### 5. Add a narrow typed plugin HTTP error contract
+
+**Depends on:** none after Phase 0; land before Graph retry logic.
+
+Add an optional typed error shape containing only normalized `status`,
+`retryAfterMs`, and a stable error category. Parse both seconds and HTTP-date forms of
+`Retry-After`. Do not expose arbitrary headers and do not change successful response
+shapes. Keep the addition backward-compatible for existing plugins.
+
+Likely files:
+
+- `packages/plugin-api/src/issue-provider-types.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider.model.ts`
+- `src/app/plugins/issue-provider/plugin-http.service.ts`
+- `src/app/plugins/issue-provider/plugin-http.service.spec.ts`
+
+Acceptance: Electron and supported native paths produce the same safe error fields for
+401/403/404/429/5xx/timeout; existing consumers still receive their expected data.
+Estimate: 1–1.5 days.
+
+### 6. Enforce per-provider agenda cadence and no overlap
+
+**Depends on:** none; required before enabling the provider.
+
+The combined calendar timer may continue waking at the smallest configured interval,
+but it must call only providers that are due. Track last attempt/success and an in-flight
+promise per provider ID. A manual refresh marks providers due; an automatic tick never
+starts a second request for a provider already in flight.
+
+Likely files:
+
+- `src/app/features/calendar-integration/calendar-integration.service.ts`
+- `src/app/features/calendar-integration/calendar-integration.service.spec.ts`
+
+Acceptance: with Google at one minute and Microsoft at five, Microsoft is called once
+per five minutes; slow requests never overlap; enable/disable and provider removal clear
+cadence state. Estimate: 1–1.5 days.
+
+### 7. Add a default-auto-poll capability for agenda providers
+
+**Depends on:** none; additive public contract.
+
+Add `defaultAutoPoll?: boolean` to the issue-provider manifest plumbing. Preserve the
+current default for existing plugins; Microsoft sets it to false. This prevents hidden
+agenda-view defaults from starting per-linked-task Graph polling.
+
+Likely contract/plumbing files:
+
+- `packages/plugin-api/src/issue-provider-types.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider.model.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider-registry.service.ts`
+- `src/app/plugins/issue-provider/plugin-issue-provider-registry.service.spec.ts`
+- `src/app/plugins/plugin-bridge.service.ts`
+
+Then apply it in the provider setup model and cover it in the dialog spec. Acceptance:
+new Microsoft configurations store `isAutoPoll: false`; Google and existing providers
+retain current defaults. Estimate: 0.5–1 day.
+
+### 8. Preserve date-only due dates and canonical URLs through the agenda contract
+
+**Depends on:** contract review checkpoint.
+
+Add optional `dueDay?: string` to `PluginSearchResult` and
+`CalendarIntegrationEvent`. Preserve `dueDay` and `url` when mapping plugin agenda
+results. Validate `dueDay` as `YYYY-MM-DD`; the issue adapter must prefer it over
+deriving a date from `start` milliseconds. Event opening prefers the canonical HTTPS
+URL and falls back to `getIssueLink`.
+
+Likely files, split into two small commits if needed:
+
+- `packages/plugin-api/src/issue-provider-types.ts`
+- `src/app/features/calendar-integration/calendar-integration.model.ts`
+- `src/app/features/calendar-integration/calendar-integration.service.ts` and spec
+- `src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts` and spec
+- `src/app/features/calendar-integration/calendar-event-actions.service.ts` and spec
+
+Acceptance: mailbox/device timezone differences never shift all-day task dates;
+canonical URL, fallback URL, malformed URL, and ordinary iCal behavior are covered.
+Estimate: 1–2 days.
+
+### 9. Purge only authentication-invalid calendar cache entries
+
+**Depends on:** Tasks 3 and 8.
+
+Consume the OAuth session-change event in calendar integration. Remove in-memory and
+local-storage entries belonging to provider configurations registered by that plugin
+on disconnect, account replacement, or terminal invalidation. Retain the last complete
+snapshot for transient offline/429/5xx failures.
+
+Likely files:
+
+- `src/app/features/calendar-integration/calendar-integration.service.ts`
+- `src/app/features/calendar-integration/calendar-integration.service.spec.ts`
+- OAuth event definitions/specs from Task 3 if not already complete
+
+Acceptance: old account titles/links are not visible after disconnect or reconnect;
+offline startup can still show the prior account's cache only while that same OAuth
+session remains valid. Estimate: 1 day.
+
+**Checkpoint A:** run all targeted OAuth, plugin HTTP, calendar integration, issue
+adapter, provider-dialog, and Google Calendar tests. Review every additive public type
+before starting the Microsoft package. If these changes need a breaking plugin API,
+stop and write an architecture decision instead.
+
+### 10. Scaffold the provider with real i18n
+
+**Depends on:** Checkpoint A.
+
+Create `packages/plugin-dev/microsoft-calendar-provider/` with the Google provider's
+Vitest/esbuild shape, but follow the current plugin i18n contract rather than copying
+Google's hard-coded labels.
+
+Required assets:
+
+- permanent manifest ID `microsoft-calendar-provider`;
+- `i18n.languages: ["en"]` and `i18n/en.json`;
+- a build script that copies manifest, icon, and English translations;
+- `PluginAPI.translate` for every user-facing provider string;
+- OAuth and HTTP permissions only; no node execution;
+- `useAgendaView: true`, five-minute agenda interval,
+  `defaultAutoAddToBacklog: false`, and `defaultAutoPoll: false`;
+- no web/mobile client IDs and `supportedPlatforms: ["electron"]`.
+
+Likely package/tooling files: `package.json`, `package-lock.json`, `tsconfig.json`,
+`vitest.config.ts`, and `scripts/build.js`. Keep runtime code dependency-free; scoped
+build/test packages mirror the existing plugin. Estimate: 1 day.
+
+### 11. Implement pure Graph boundary parsing and mapping
+
+**Depends on:** Task 10.
+
+Create small typed modules for config validation, Graph response validation, composite
+IDs, URL allowlisting, and date mapping. Treat every Graph response and `nextLink` as
+untrusted. Every bearer-authenticated absolute URL must be HTTPS with hostname exactly
+`graph.microsoft.com`; reject credentials, alternate ports, lookalike suffixes, and
+redirect-derived hosts.
+
+Mapping rules:
+
+- request `Prefer: IdType="ImmutableId"` on every event request;
+- use a reversible calendar-ID + event-ID composite key and preserve case;
+- filter cancelled events and, by calm default, events the user declined;
+- use a localized “Untitled event” fallback for an empty subject;
+- timed values become real instants using the supplied Graph timezone/offset;
+- all-day start/end retain date strings, with end exclusive; numeric schedule instants
+  are constructed from local date boundaries solely for display;
+- multi-day duration uses local date boundaries so 23/25-hour DST days still occupy the
+  correct calendar days;
+- accept only safe HTTPS Outlook `webLink` values.
+
+Acceptance: pure tests cover invalid shapes, oversized fields, hostile `nextLink`, ID
+case, recurrence instances/exceptions, missing titles, timed timezone offsets, mailbox
+timezone different from device timezone, travel, DST, and multi-day all-day events.
+Estimate: 2 days.
+
+### 12. Connect OAuth and load only owned calendars
+
+**Depends on:** Tasks 3, 4, 10, and 11.
+
+Configure authorization-code + PKCE against the `organizations` endpoints with the
+Phase 0 client ID and redirect. Load `/me/calendars` after connection. Establish the
+mailbox owner from the default calendar, filter calendars to the same normalized owner,
+and fail closed as specified when owner data is absent. Do not persist or log the owner
+address.
+
+The multi-select is required and capped at 10. Before saving/testing, reconcile synced
+selected IDs with the locally returned owned-calendar IDs. If none or only some match,
+show an account-mismatch/reselection error and make no event calls. Setup copy must say
+that disconnect/reconnect affects every Microsoft Calendar configuration on the device.
+
+Acceptance: ordinary own calendars appear; shared/delegated calendars do not; a config
+synced from the same account works; a config synced from a different account fails
+safely. Estimate: 1–1.5 days.
+
+### 13. Implement the bounded event fetch and provider cache
+
+**Depends on:** Tasks 5, 6, 11, and 12.
+
+Fetch each selected calendar's `calendarView` using the fixed window and numeric limits.
+Follow only validated `@odata.nextLink` values. Limit concurrency, enforce one in-flight
+promise per cache key, and implement the fixed failure/retry semantics above.
+
+Use a session-memory cache keyed by a one-way in-memory account-owner fingerprint plus
+the sorted selected calendar IDs and window. Never persist the fingerprint. Before the
+first agenda load, search may populate the same cache once; afterward `searchIssues`
+filters it locally. Clear it on connect, disconnect, selection change, or OAuth terminal
+invalidation.
+
+Acceptance: tests prove pagination caps, total-event cap, 429 with both Retry-After
+forms, long Retry-After abort, 5xx backoff, timeout, 401 force-refresh-once, terminal
+reconnect, no overlapping fetches, cache isolation, and all-or-nothing retention of the
+last complete snapshot. Estimate: 2–3 days.
+
+### 14. Register the read-only provider definition
+
+**Depends on:** Task 13.
+
+Implement the mandatory issue-provider methods:
+
+- `getHeaders` obtains the current OAuth access token;
+- `testConnection` validates account, selection, and one bounded Graph call;
+- `getNewIssuesForBacklog` returns the agenda window;
+- `searchIssues` searches the same cache, fetching once only if needed;
+- `getById` reuses a fresh cache entry or performs one bounded direct lookup;
+- `getIssueLink` uses a cached canonical link with a documented work/school fallback;
+- `issueDisplay` shows only non-sensitive basic fields.
+
+Do not register `createIssue`, `updateIssue`, `deleteIssue`, comments, time-block
+methods, or push field mappings. Do not include Graph event bodies in mapped objects.
+
+Acceptance: a static/spy test proves no write HTTP method or write provider hook exists;
+task creation gets title, `dueWithTime` or `dueDay`, duration/time estimate, and source
+link as appropriate. Estimate: 1–1.5 days.
+
+### 15. Bundle and reserve the permanent plugin ID
+
+**Depends on:** Tasks 10 and 14.
+
+Register build/copy and discovery atomically:
+
+- `packages/plugin-dev/scripts/build-all.js`
+- `src/app/plugins/plugin.service.ts`
+- `electron/bundled-plugin-ids.test.cjs` (verification; change only if the test itself
+  needs no new behavior)
+
+Acceptance: built assets include `manifest.json`, `plugin.js`, `icon.svg`, and
+`i18n/en.json`; the asset path and reserved manifest ID cannot drift. Estimate: 0.5 day.
+
+### 16. Document privacy, platform, and tenant limitations
+
+**Depends on:** working implementation.
+
+Update user documentation in the same feature PR:
+
+- `docs/wiki/3.07-Issue-Integration-Comparison.md`
+- `docs/wiki/4.24-Integrations.md`
+- `docs/wiki/3.05-Web-App-vs-Desktop.md`
+- `docs/wiki/3.06-User-Data.md`
+
+Document exact scopes, read-only behavior, Electron-only support, one local account,
+synced selection versus unsynced credentials, university admin approval, and storage:
+OAuth tokens in local-only IndexedDB plus basic event metadata/source URLs in the
+existing unencrypted calendar local-storage cache. State when each cache is retained or
+purged. Estimate: 0.5–1 day.
+
+### 17. End-to-end verification and pilot
+
+**Depends on:** all implementation tasks.
+
+Run:
+
+- `npm run checkFile <filepath>` for every changed `.ts` or `.scss` file;
+- targeted root specs for OAuth, plugin HTTP, calendar integration, provider dialog,
+  issue adapter, and Google Calendar regression;
+- Microsoft plugin `npm test`, `npm run typecheck`, and `npm run build`;
+- `node --test electron/bundled-plugin-ids.test.cjs`;
+- `npm run plugins:build` and a production build appropriate to the release branch.
+
+Manual matrix:
+
+- Windows, macOS, and Linux Electron;
+- ordinary tenant and representative university tenant;
+- first consent, denied consent, admin approval required, expired access token, rotated
+  refresh token, offline refresh, revoked grant, and reconnect to another account;
+- one and ten calendars, same-account synced config, different-account synced config;
+- timed, recurring, exception, cancelled, declined, all-day, multi-day, DST, and
+  mailbox/device timezone mismatch;
+- one-minute Google plus five-minute Microsoft cadence;
+- disconnect/account switch cache purge and offline stale-cache retention;
+- port collision and wrong-path/state loopback requests.
+
+Pilot with the reporting user before general release. A successful pilot means they can
+connect without an iCal URL, select their university calendars, plan from the agenda,
+create a task snapshot, and open the Outlook event without broader permissions.
+Estimate: 1.5–2 days plus user availability.
+
+## Security and privacy acceptance criteria
+
+- No client secret or tenant-specific identifier is committed.
+- Only `offline_access` and delegated `Calendars.ReadBasic` are requested.
+- Every OAuth flow uses PKCE and state; the loopback listener accepts only the expected
+  path/state on `127.0.0.1`.
+- Bearer tokens are sent only to exact HTTPS Microsoft Graph hosts.
+- Redirects and `nextLink` values cannot move a bearer request to another host.
+- Graph response values are shape/length validated at the boundary and rendered only
+  through normal escaped Angular/plugin form paths.
+- Logs contain only safe categories/status/counts and opaque internal provider IDs;
+  never tokens, codes, email addresses, tenant IDs, titles, bodies, event URLs, or raw
+  Graph error payloads.
+- OAuth credentials are local-only and never enter synced `pluginConfig`.
+- Event bodies, attendees, and attachments are neither requested nor cached.
+- Account replacement, disconnect, and terminal authentication failure purge affected
+  cached event metadata.
+- Automatic and manual request paths share concurrency, pagination, retry, and timeout
+  bounds.
+- No new root dependency is introduced.
+
+## Release criteria
+
+Ship only when all are true:
+
+- Phase 0 passed for a representative education tenant.
+- The Entra app registration has a named long-term owner and publisher-verification
+  decision.
+- Unsupported platforms cannot start OAuth.
+- Refresh rotation survives restart and cannot race disconnect/reconnect.
+- Microsoft calls remain on their own cadence even beside faster providers.
+- Imported tasks do not trigger automatic per-task Graph polling.
+- Shared/delegated calendars are absent from selection.
+- All-day dates remain stable across mailbox/device timezone differences.
+- Throttling honors Retry-After and all request/page/event limits are tested.
+- Cache retention/purge behavior is tested and documented.
+- Existing Google Calendar behavior remains green.
+- The university pilot succeeds without broader scopes.
+
+## Deferred follow-ups
+
+Consider these only after real demand and a separate design review:
+
+- Android/iOS support with dedicated Entra redirect/client configuration.
+- Web support, including the 24-hour SPA refresh-token lifetime and CORS/reauth design.
+- Outlook.com consumer accounts and sovereign-cloud endpoint sets.
+- Shared/delegated calendars with explicit permission and ownership UX.
+- Multiple accounts per device, which requires changing plugin-global OAuth storage.
+- Event write operations and time-block synchronization, which require
+  `Calendars.ReadWrite`, conflict semantics, and a much larger trust surface.
+- Delta queries or change notifications if measured Graph volume justifies the added
+  state and lifecycle complexity.
+
+## Official references checked
+
+- [Microsoft identity platform authorization-code flow with PKCE](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow)
+- [Redirect URI restrictions and loopback rules](https://learn.microsoft.com/en-us/entra/identity-platform/reply-url)
+- [Refresh-token replacement and lifetimes](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)
+- [`Calendars.ReadBasic` delegated permission](https://learn.microsoft.com/en-us/graph/permissions-reference#calendarsreadbasic)
+- [Tenant user-consent configuration](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent)
+- [Publisher verification](https://learn.microsoft.com/en-us/entra/identity-platform/publisher-verification-overview)
+- [List calendars](https://learn.microsoft.com/en-us/graph/api/user-list-calendars?view=graph-rest-1.0)
+- [Shared and delegated Outlook calendars](https://learn.microsoft.com/en-us/graph/outlook-get-shared-events-calendars)
+- [Calendar view and recurrence expansion](https://learn.microsoft.com/en-us/graph/api/calendar-list-calendarview?view=graph-rest-1.0)
+- [Outlook immutable IDs](https://learn.microsoft.com/en-us/graph/outlook-immutable-id)
+- [Microsoft Graph event resource and `webLink`](https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0)
+- [Get an event](https://learn.microsoft.com/en-us/graph/api/event-get?view=graph-rest-1.0)
+- [Microsoft Graph throttling and Retry-After](https://learn.microsoft.com/en-us/graph/throttling)
+- [Claims challenges and Conditional Access](https://learn.microsoft.com/en-us/entra/identity-platform/claims-challenge)

--- a/e2e/electron/packaged-app-smoke.cjs
+++ b/e2e/electron/packaged-app-smoke.cjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { chromium, expect } = require('@playwright/test');
+
+const executablePath = process.argv[2];
+if (!executablePath || !fs.existsSync(executablePath)) {
+  throw new Error(
+    `Packaged Electron executable not found: ${executablePath || '<none>'}`,
+  );
+}
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sp-electron-smoke-'));
+const xdgDir = path.join(userDataDir, 'xdg');
+fs.mkdirSync(xdgDir, { recursive: true });
+
+const getFreePort = async () =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Could not allocate a local debugging port'));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+
+const waitForCdp = async (endpoint, child, timeoutMs = 60_000) => {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `Packaged Electron exited before opening CDP (${child.exitCode ?? child.signalCode})`,
+      );
+    }
+    try {
+      const response = await fetch(`${endpoint}/json/version`);
+      if (response.ok) return;
+      lastError = new Error(`CDP returned HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for packaged Electron CDP: ${lastError}`);
+};
+
+const waitForMainPage = async (browser, timeoutMs = 30_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const page = browser
+      .contexts()
+      .flatMap((context) => context.pages())
+      .find((candidate) => !candidate.url().startsWith('devtools://'));
+    if (page) return page;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('Packaged Electron did not create a renderer window');
+};
+
+const stopChild = async (child) => {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 8_000)),
+  ]);
+  if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+};
+
+const run = async () => {
+  const debuggingPort = await getFreePort();
+  const endpoint = `http://127.0.0.1:${debuggingPort}`;
+  const child = spawn(
+    executablePath,
+    [
+      `--remote-debugging-port=${debuggingPort}`,
+      `--user-data-dir=${userDataDir}`,
+      '--no-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+    ],
+    {
+      env: {
+        ...process.env,
+        ELECTRON_ENABLE_LOGGING: '1',
+        XDG_CONFIG_HOME: xdgDir,
+        XDG_CACHE_HOME: xdgDir,
+        XDG_DATA_HOME: xdgDir,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+
+  let browser;
+  try {
+    await waitForCdp(endpoint, child);
+    browser = await chromium.connectOverCDP(endpoint);
+    const pageErrors = [];
+    const observedPages = new WeakSet();
+    const observePageErrors = (candidate) => {
+      if (observedPages.has(candidate)) return;
+      observedPages.add(candidate);
+      candidate.on('pageerror', (error) => pageErrors.push(error.message));
+    };
+    for (const context of browser.contexts()) {
+      context.on('page', observePageErrors);
+      context.pages().forEach(observePageErrors);
+    }
+    const page = await waitForMainPage(browser);
+
+    await page.waitForLoadState('domcontentloaded');
+    await page.evaluate(() => {
+      localStorage.setItem('SUP_ONBOARDING_PRESET_DONE', 'true');
+      localStorage.setItem('SUP_ONBOARDING_HINTS_DONE', 'true');
+      localStorage.setItem('SUP_IS_SHOW_TOUR', 'true');
+      localStorage.setItem('SUP_EXAMPLE_TASKS_CREATED', 'true');
+    });
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.locator('.route-wrapper').first().waitFor({ state: 'visible' });
+
+    const taskTitle = `Packaged Electron smoke ${Date.now()}`;
+    const addTaskInput = page.locator('add-task-bar.global .main-input').first();
+    if (!(await addTaskInput.isVisible())) {
+      await page.locator('.tour-addBtn').waitFor({ state: 'visible', timeout: 20_000 });
+      await page.locator('.tour-addBtn').click();
+    }
+    await addTaskInput.waitFor({ state: 'visible', timeout: 10_000 });
+    await addTaskInput.fill(taskTitle);
+    const operationProcessed = page.waitForEvent('console', {
+      predicate: (message) =>
+        message.text().includes('OperationCaptureService: Processed action'),
+      timeout: 20_000,
+    });
+    await addTaskInput.press('Enter');
+    await expect(page.locator('task').filter({ hasText: taskTitle })).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Reload proves the renderer can also persist and hydrate the core task.
+    // This completion log fires after either the IndexedDB or Electron SQLite
+    // backend has finished the operation write and released its lock.
+    await operationProcessed;
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.locator('task').filter({ hasText: taskTitle })).toBeVisible({
+      timeout: 20_000,
+    });
+
+    if (pageErrors.length) {
+      throw new Error(`Renderer page errors:\n${pageErrors.join('\n')}`);
+    }
+    console.log('Packaged Electron task-create-and-reload smoke passed.');
+  } finally {
+    await browser?.close().catch(() => undefined);
+    await stopChild(child);
+  }
+};
+
+run()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });

--- a/e2e/helpers/plugin-test.helpers.ts
+++ b/e2e/helpers/plugin-test.helpers.ts
@@ -68,11 +68,6 @@ export const waitForPluginAssets = async (
 
   console.error('[Plugin Test] Failed to load plugin assets after all retries');
 
-  // In CI, this might be expected if assets aren't built properly
-  if (process.env.CI) {
-    console.warn('[Plugin Test] Plugin assets unavailable; skipping in CI');
-  }
-
   return false;
 };
 

--- a/e2e/pages/sync.page.ts
+++ b/e2e/pages/sync.page.ts
@@ -39,20 +39,23 @@ export class SyncPage extends BasePage {
     this.disableEncryptionBtn = page.locator('.e2e-disable-encryption-btn button');
   }
 
-  async setupWebdavSync(config: {
-    baseUrl: string;
-    username: string;
-    password: string;
-    syncFolderPath: string;
-    isEncryptionEnabled?: boolean;
-    encryptionPassword?: string;
-    /**
-     * Set the encryption password in the setup-time "Encrypt before first
-     * upload?" dialog (instead of the post-setup Enable Encryption button), so
-     * the very first sync is encrypted. Requires `encryptionPassword`.
-     */
-    encryptAtSetup?: boolean;
-  }): Promise<void> {
+  async setupWebdavSync(
+    config: {
+      baseUrl: string;
+      username: string;
+      password: string;
+      syncFolderPath: string;
+      isEncryptionEnabled?: boolean;
+      encryptionPassword?: string;
+      /**
+       * Set the encryption password in the setup-time "Encrypt before first
+       * upload?" dialog (instead of the post-setup Enable Encryption button), so
+       * the very first sync is encrypted. Requires `encryptionPassword`.
+       */
+      encryptAtSetup?: boolean;
+    },
+    options: { isReconfigure?: boolean } = {},
+  ): Promise<void> {
     // Try entire setup flow up to 2 times (dialog-level retry)
     for (let dialogAttempt = 0; dialogAttempt < 2; dialogAttempt++) {
       if (dialogAttempt > 0) {
@@ -83,7 +86,11 @@ export class SyncPage extends BasePage {
 
       // Click sync button to open settings dialog
       // Use noWaitAfter to prevent blocking on Angular hash navigation
-      await this.syncBtn.click({ timeout: 5000, noWaitAfter: true });
+      await this.syncBtn.click({
+        button: options.isReconfigure ? 'right' : 'left',
+        timeout: 5000,
+        noWaitAfter: true,
+      });
 
       // Wait for dialog to appear
       const dialog = this.page.locator('mat-dialog-container, .mat-mdc-dialog-container');
@@ -95,7 +102,11 @@ export class SyncPage extends BasePage {
       // If dialog didn't open, try clicking again
       if (!dialogVisible) {
         await this.page.waitForTimeout(500);
-        await this.syncBtn.click({ force: true, noWaitAfter: true });
+        await this.syncBtn.click({
+          button: options.isReconfigure ? 'right' : 'left',
+          force: true,
+          noWaitAfter: true,
+        });
         await dialog.waitFor({ state: 'visible', timeout: 5000 });
       }
 

--- a/e2e/tests/onboarding/onboarding-preset.spec.ts
+++ b/e2e/tests/onboarding/onboarding-preset.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import {
+  assertNoRuntimeBrowserErrors,
+  attachPageErrorCollector,
+  installDevErrorDialogHandler,
+} from '../../utils/runtime-errors';
+import { waitForStatePersistence } from '../../utils/waits';
+import { WorkViewPage } from '../../pages/work-view.page';
+
+test.describe('First-run onboarding', () => {
+  test('applies a preset and does not show onboarding again after reload', async ({
+    isolatedContext,
+  }) => {
+    const page = await isolatedContext.newPage();
+    const runtimeErrors = attachPageErrorCollector(page, 'onboarding');
+    installDevErrorDialogHandler(page, 'onboarding');
+
+    await page.goto('/');
+
+    const onboarding = page.locator('onboarding-preset-selection');
+    await expect(onboarding).toBeVisible();
+    await expect(onboarding.locator('.preset-card')).toHaveCount(3);
+
+    await onboarding.getByRole('button', { name: /Simple Todo/ }).click();
+
+    await expect(onboarding).toBeHidden();
+    await expect(page.locator('task-list').first()).toBeVisible();
+    expect(
+      await page.evaluate(() => localStorage.getItem('SUP_ONBOARDING_PRESET_DONE')),
+    ).toBe('true');
+
+    const taskTitle = `Simple Todo preset ${Date.now()}`;
+    await new WorkViewPage(page).addTask(taskTitle);
+    const task = page.locator('task').filter({ hasText: taskTitle }).first();
+    await expect(task).toBeVisible();
+    await task.hover();
+    await expect(task.locator('.start-task-btn')).toHaveCount(0);
+    await waitForStatePersistence(page);
+
+    await page.reload();
+
+    await expect(page.locator('task-list').first()).toBeVisible();
+    await expect(onboarding).toHaveCount(0);
+    const reloadedTask = page.locator('task').filter({ hasText: taskTitle }).first();
+    await expect(reloadedTask).toBeVisible();
+    await reloadedTask.hover();
+    await expect(reloadedTask.locator('.start-task-btn')).toHaveCount(0);
+    assertNoRuntimeBrowserErrors(runtimeErrors, 'onboarding');
+    await page.close();
+  });
+});

--- a/e2e/tests/plugins/doc-mode-bundled.spec.ts
+++ b/e2e/tests/plugins/doc-mode-bundled.spec.ts
@@ -13,11 +13,6 @@ test.describe('Doc Mode bundled plugin', () => {
 
     const assetsAvailable = await waitForPluginAssets(page);
     if (!assetsAvailable) {
-      if (process.env.CI) {
-        // Mirrors plugin-loading.spec.ts: assets may not be built in CI.
-        test.skip(true, 'Plugin assets not available in CI');
-        return;
-      }
       throw new Error('Plugin assets not available — run `npm run prebuild`');
     }
 

--- a/e2e/tests/plugins/doc-mode-migration.spec.ts
+++ b/e2e/tests/plugins/doc-mode-migration.spec.ts
@@ -85,10 +85,6 @@ test.describe('Doc Mode Stage A migration', () => {
 
     const assetsAvailable = await waitForPluginAssets(page);
     if (!assetsAvailable) {
-      if (process.env.CI) {
-        test.skip(true, 'Plugin assets not available in CI');
-        return;
-      }
       throw new Error('Plugin assets not available — run `npm run prebuild`');
     }
 
@@ -126,10 +122,6 @@ test.describe('Doc Mode Stage A migration', () => {
 
     const assetsAvailable = await waitForPluginAssets(page);
     if (!assetsAvailable) {
-      if (process.env.CI) {
-        test.skip(true, 'Plugin assets not available in CI');
-        return;
-      }
       throw new Error('Plugin assets not available — run `npm run prebuild`');
     }
 

--- a/e2e/tests/project/project-completion.spec.ts
+++ b/e2e/tests/project/project-completion.spec.ts
@@ -13,7 +13,7 @@ test.describe('Project completion', () => {
     await workViewPage.waitForTaskList();
   });
 
-  test('complete a project and see the celebration', async ({ page }) => {
+  test('complete a project and reopen it from archived projects', async ({ page }) => {
     // Arrange: a project with one done and one unfinished task
     await projectPage.createProject('Test Project');
     await projectPage.navigateToProjectByName('Test Project');
@@ -56,10 +56,21 @@ test.describe('Project completion', () => {
     await expect(celebration.getByText(/project complete/i)).toBeVisible();
     await expect(celebration.getByText('Test Project')).toBeVisible();
 
-    // Close the celebration. There is no reopen/undo here — completion resolves
-    // tasks irreversibly; reactivation lives on the archived-projects page.
+    // Close the celebration and exercise the reactivation path.
     await celebration.locator('.actions button').click();
     await expect(celebration).toBeHidden();
+
+    await page.goto('/#/archived-projects');
+    const archivedProject = page
+      .locator('archived-projects-page .project-row')
+      .filter({ hasText: 'Test Project' });
+    await expect(archivedProject).toBeVisible();
+
+    await archivedProject.getByRole('button', { name: 'Reopen' }).click();
+
+    await expect(archivedProject).toHaveCount(0);
+    await projectPage.navigateToProjectByName('Test Project');
+    await expect(page).toHaveURL(/\/#\/project\/.+\/tasks/);
 
     await expectNoGlobalError(page);
   });

--- a/e2e/tests/search/global-search.spec.ts
+++ b/e2e/tests/search/global-search.spec.ts
@@ -1,126 +1,43 @@
 import { expect, test } from '../../fixtures/test.fixture';
-import { ensureGlobalAddTaskBarOpen } from '../../utils/element-helpers';
 
-/**
- * Global Search E2E Tests
- *
- * Tests the search functionality:
- * - Open search
- * - Search for tasks
- * - Navigate to search results
- */
+const openGlobalSearch = async (page: import('@playwright/test').Page): Promise<void> => {
+  await page.keyboard.press('Shift+F');
+  await expect(page).toHaveURL(/\/#\/search$/);
+  await expect(page.locator('search-page')).toBeVisible();
+};
 
 test.describe('Global Search', () => {
-  test.describe.configure({ timeout: 30000 });
-
-  test('should open search with keyboard shortcut', async ({
+  test('opens from the configured keyboard shortcut and focuses the search field', async ({
     page,
     workViewPage,
-    testPrefix,
   }) => {
     await workViewPage.waitForTaskList();
 
-    // Create some tasks to search for
-    await workViewPage.addTask(`${testPrefix}-Searchable Task 1`);
-    await workViewPage.addTask(`${testPrefix}-Searchable Task 2`);
+    await openGlobalSearch(page);
 
-    // Use Ctrl+Shift+F or similar shortcut to open global search
-    await page.keyboard.press('Control+Shift+f');
-    await page.waitForTimeout(500);
-
-    // Just verify the app is still responsive (search shortcut may vary)
-    await expect(page.locator('task-list').first()).toBeVisible();
+    await expect(page.locator('search-page .search-field input')).toBeFocused();
   });
 
-  test('should search for existing tasks', async ({ page, workViewPage, testPrefix }) => {
-    await workViewPage.waitForTaskList();
-
-    // Create a task with a unique name
-    const uniqueName = `${testPrefix}-UniqueSearchTerm`;
-    await workViewPage.addTask(uniqueName);
-
-    await expect(page.locator('task').filter({ hasText: uniqueName })).toBeVisible();
-
-    // Try to open search
-    await page.keyboard.press('Control+Shift+f');
-    await page.waitForTimeout(500);
-
-    const searchInput = page.locator('input[type="search"], command-bar input').first();
-    const isSearchOpen = await searchInput
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    if (isSearchOpen) {
-      // Type the search term
-      await searchInput.fill(uniqueName);
-      await page.waitForTimeout(500);
-
-      // Results should appear
-      const results = page.locator('.search-result, .autocomplete-option');
-      const hasResults = await results
-        .first()
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
-
-      if (hasResults) {
-        await expect(results.first()).toContainText(uniqueName);
-      }
-    }
-  });
-
-  test('should use autocomplete in add task bar', async ({
+  test('finds an existing task and navigates to it', async ({
     page,
     workViewPage,
+    taskPage,
     testPrefix,
   }) => {
     await workViewPage.waitForTaskList();
-
-    // Create an initial task
-    const taskName = `${testPrefix}-AutoComplete Target`;
+    const taskName = `${testPrefix}-UniqueSearchResult`;
     await workViewPage.addTask(taskName);
-    await expect(page.locator('task').filter({ hasText: taskName })).toBeVisible();
 
-    // Ensure the add task bar is open and get the input
-    const addTaskInput = await ensureGlobalAddTaskBarOpen(page);
+    await openGlobalSearch(page);
+    await page.locator('search-page .search-field input').fill(taskName);
 
-    // Type part of the task name
-    await addTaskInput.fill(testPrefix);
-    await page.waitForTimeout(500);
+    const result = page
+      .locator('search-page mat-list-item')
+      .filter({ hasText: taskName });
+    await expect(result).toHaveCount(1);
+    await result.click();
 
-    // Clear the input
-    await addTaskInput.clear();
-
-    await page.keyboard.press('Escape');
-
-    // Verify app is responsive
-    await expect(page.locator('task-list').first()).toBeVisible();
-  });
-
-  test('should filter tasks in current view', async ({
-    page,
-    workViewPage,
-    testPrefix,
-  }) => {
-    await workViewPage.waitForTaskList();
-
-    // Create multiple tasks
-    await workViewPage.addTask(`${testPrefix}-Alpha Task`);
-    await workViewPage.addTask(`${testPrefix}-Beta Task`);
-    await workViewPage.addTask(`${testPrefix}-Gamma Task`);
-
-    // All tasks should be visible
-    await expect(
-      page.locator('task').filter({ hasText: `${testPrefix}-Alpha` }),
-    ).toBeVisible();
-    await expect(
-      page.locator('task').filter({ hasText: `${testPrefix}-Beta` }),
-    ).toBeVisible();
-    await expect(
-      page.locator('task').filter({ hasText: `${testPrefix}-Gamma` }),
-    ).toBeVisible();
-
-    // Verify task count
-    const taskCount = await page.locator('task').count();
-    expect(taskCount).toBeGreaterThanOrEqual(3);
+    await expect(page).toHaveURL(/\/#\/tag\/TODAY\/tasks/);
+    await expect(taskPage.getTaskByText(taskName)).toBeVisible();
   });
 });

--- a/e2e/tests/sync/import-sync.spec.ts
+++ b/e2e/tests/sync/import-sync.spec.ts
@@ -1,11 +1,10 @@
-import { test as base, expect } from '@playwright/test';
+import { test as base, expect } from '../../fixtures/supersync.fixture';
 import {
   createTestUser,
   getSuperSyncConfig,
   createSimulatedClient,
   closeClient,
   waitForTask,
-  isServerHealthy,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
 import { ImportPage } from '../../pages/import.page';
@@ -15,7 +14,7 @@ import { waitForAppReady } from '../../utils/waits';
  * Import + Sync E2E Tests
  *
  * These tests verify that imported backup data syncs correctly between clients.
- * This includes active tasks, archived tasks (worklog), and projects.
+ * This includes active tasks, subtasks, and replacement of existing state.
  *
  * Prerequisites:
  * - super-sync-server running on localhost:1901 with TEST_MODE=true
@@ -24,56 +23,30 @@ import { waitForAppReady } from '../../utils/waits';
  * Run with: npm run e2e:playwright -- --grep @importsync
  */
 
-const generateTestRunId = (workerIndex: number): string => {
-  return `${Date.now()}-${workerIndex}`;
-};
-
 /** Default encryption password used by setupSuperSync's mandatory encryption dialog */
 const ENCRYPTION_PASSWORD = 'e2e-default-encryption-pw';
 
 base.describe('@importsync @supersync Import + Sync E2E', () => {
-  let serverHealthy: boolean | null = null;
-
-  base.beforeEach(async ({}, testInfo) => {
-    if (serverHealthy === null) {
-      serverHealthy = await isServerHealthy();
-      if (!serverHealthy) {
-        console.warn(
-          'SuperSync server not healthy at http://localhost:1901 - skipping tests',
-        );
-      }
-    }
-    testInfo.skip(!serverHealthy, 'SuperSync server not running');
-  });
-
   /**
    * Scenario: Import backup file and sync to second client
    *
    * This test verifies that importing a backup file creates sync operations
-   * that propagate all data (including archives) to other clients.
+   * that propagate the imported active data to other clients.
    *
    * Setup: Client A and B with shared SuperSync account, empty server
    *
    * Actions:
    * 1. Client A imports JSON backup file containing:
-   *    - Active tasks (with subtasks)
-   *    - Archived tasks in archiveYoung/archiveOld
-   *    - Projects and tags
+   *    - Active tasks with a parent/subtask relationship
    * 2. Client A syncs
    * 3. Client B syncs
    *
    * Verify:
-   * - Client B has all active tasks
-   * - Client B has archived tasks in worklog view
-   * - Projects and tags match
+   * - Client B has all active tasks and the imported subtask relationship
    */
-  // SKIPPED: Pre-existing issue. After configuring sync and then importing a backup,
-  // the imported state doesn't persist - likely overwritten by sync activity.
-  // The import+sync interaction needs investigation in the app code itself.
-  base.skip(
+  base(
     'Import backup file on Client A, sync to Client B',
-    async ({ browser, baseURL }, testInfo) => {
-      const testRunId = generateTestRunId(testInfo.workerIndex);
+    async ({ browser, baseURL, testRunId }) => {
       let clientA: SimulatedE2EClient | null = null;
       let clientB: SimulatedE2EClient | null = null;
 
@@ -85,7 +58,11 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
         // ============ PHASE 1: Client A Sets Up Sync and Imports Backup ============
         console.log('[Import Test] Phase 1: Client A importing backup');
         clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
-        await clientA.sync.setupSuperSync(syncConfig);
+        await clientA.sync.setupSuperSync({
+          ...syncConfig,
+          isEncryptionEnabled: true,
+          password: ENCRYPTION_PASSWORD,
+        });
 
         // Navigate to import page
         const importPage = new ImportPage(clientA.page);
@@ -114,7 +91,12 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
 
         // Re-enable sync after import (import overwrites globalConfig including sync settings)
         console.log('[Import Test] Re-enabling sync after import');
-        await clientA.sync.setupSuperSync(syncConfig);
+        await clientA.sync.setupSuperSync({
+          ...syncConfig,
+          isEncryptionEnabled: true,
+          password: ENCRYPTION_PASSWORD,
+          syncImportChoice: 'local',
+        });
 
         // ============ PHASE 2: Client A Syncs to Server ============
         console.log('[Import Test] Phase 2: Client A syncing to server');
@@ -149,63 +131,33 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
         await waitForTask(clientB.page, 'E2E Import Test - Simple Active Task');
 
         // Verify both active tasks are visible
-        const activeTask1 = clientB.page.locator(
-          'task:has-text("E2E Import Test - Active Task With Subtask")',
-        );
-        const activeTask2 = clientB.page.locator(
-          'task:has-text("E2E Import Test - Simple Active Task")',
-        );
+        const activeTask1 = clientB.page
+          .locator('task:has-text("E2E Import Test - Active Task With Subtask")')
+          .first();
+        const activeTask2 = clientB.page
+          .locator('task:has-text("E2E Import Test - Simple Active Task")')
+          .first();
         await expect(activeTask1).toBeVisible({ timeout: 10000 });
         await expect(activeTask2).toBeVisible({ timeout: 10000 });
         console.log('[Import Test] Client B has both active tasks');
 
-        // Expand parent task to see subtask
-        const expandBtn = activeTask1.locator('.expand-btn');
-        if (await expandBtn.isVisible()) {
-          await expandBtn.click();
-          await waitForTask(clientB.page, 'E2E Import Test - Subtask of Active Task');
-          console.log('[Import Test] Client B has subtask visible');
-        }
+        // The imported subtask is nested under its parent and follows the
+        // parent's visibility toggle, proving the relationship survived sync.
+        const subTask = activeTask1
+          .locator('task')
+          .filter({ hasText: 'E2E Import Test - Subtask of Active Task' })
+          .first();
+        const toggleSubTasksBtn = activeTask1.locator('.toggle-sub-tasks-btn');
+        await expect(toggleSubTasksBtn).toBeVisible();
+        await expect(subTask).toBeVisible();
+        await toggleSubTasksBtn.click();
+        await expect(subTask).toBeHidden();
+        await toggleSubTasksBtn.click();
+        await expect(subTask).toBeVisible();
+        console.log('[Import Test] Client B has subtask visible');
 
-        // ============ PHASE 5: Verify Archived Tasks in Worklog ============
-        console.log('[Import Test] Phase 5: Verifying archived tasks in worklog');
-
-        // Navigate to worklog on Client B
-        await clientB.page.goto('/#/tag/TODAY/history');
-        await clientB.page.waitForLoadState('networkidle');
-        await clientB.page.waitForSelector('history', { timeout: 10000 });
-
-        // Expand worklog to see archived tasks
-        const weekRow = clientB.page.locator('.week-row').first();
-        if (await weekRow.isVisible()) {
-          await weekRow.click();
-          await clientB.page.waitForTimeout(500);
-        }
-
-        // Archived tasks should appear in the worklog
-        // The test backup has archived tasks with titles containing "E2E Import Test - Archived"
-        // Note: Archived tasks appear in worklog if they have timeSpentOnDay entries
-        // Our test backup has archived tasks with time entries
-        console.log('[Import Test] Checking for archived tasks in worklog...');
-
-        // Try to find archived task entries - they appear under the dates they were worked on
-        const hasArchivedTasks =
-          (await clientB.page
-            .locator('.task-summary-table .task-title')
-            .count()
-            .catch(() => 0)) > 0;
-
-        if (hasArchivedTasks) {
-          console.log('[Import Test] Client B worklog has archived task entries');
-        } else {
-          // Archive data may not show in TODAY tag worklog - navigate to project worklog
-          await clientB.page.goto('/#/project/test-project-1/history');
-          await clientB.page.waitForLoadState('networkidle');
-          console.log('[Import Test] Checking project worklog for archived tasks');
-        }
-
-        // ============ PHASE 6: Final Verification ============
-        console.log('[Import Test] Phase 6: Final state verification');
+        // ============ PHASE 5: Final Verification ============
+        console.log('[Import Test] Phase 5: Final state verification');
 
         // Go back to project view on both clients and wait for app to be ready
         await clientA.page.goto('/#/project/INBOX_PROJECT/tasks');
@@ -237,10 +189,10 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
   );
 
   /**
-   * Scenario: Import with existing data (merge scenario)
+   * Scenario: Import with existing data (replacement scenario)
    *
-   * Tests that importing a backup on one client merges with
-   * existing data on another client after sync.
+   * Tests that importing a backup on one client replaces the old baseline on
+   * every client after sync.
    *
    * Actions:
    * 1. Client A creates a task "Existing Task A"
@@ -252,17 +204,12 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
    * 7. Client B syncs
    *
    * Verify:
-   * - Client A has: imported tasks + Existing Task A + Existing Task B
-   * - Client B has: imported tasks + Existing Task A + Existing Task B
+   * - Both clients have the imported tasks
+   * - Neither client keeps Existing Task A or Existing Task B
    */
-  // SKIPPED: Pre-existing issue. After backup import on Client A with existing synced data,
-  // the imported tasks don't appear in the TODAY view. The BACKUP_IMPORT operation's
-  // interaction with pre-existing server operations needs investigation.
-  // The simpler "Import backup file" test (above) verifies import+sync on a clean server.
-  base.skip(
-    'Import merges with existing synced data',
-    async ({ browser, baseURL }, testInfo) => {
-      const testRunId = generateTestRunId(testInfo.workerIndex);
+  base(
+    'Import replaces existing synced data on all clients',
+    async ({ browser, baseURL, testRunId }) => {
       const uniqueId = Date.now();
       let clientA: SimulatedE2EClient | null = null;
       let clientB: SimulatedE2EClient | null = null;
@@ -275,7 +222,11 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
         console.log('[Merge Test] Phase 1: Creating initial tasks');
 
         clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
-        await clientA.sync.setupSuperSync(syncConfig);
+        await clientA.sync.setupSuperSync({
+          ...syncConfig,
+          isEncryptionEnabled: true,
+          password: ENCRYPTION_PASSWORD,
+        });
 
         // Client A creates a task
         const existingTaskA = `ExistingA-${uniqueId}`;
@@ -328,7 +279,12 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
 
         // Re-enable sync after import (import overwrites globalConfig including sync settings)
         console.log('[Merge Test] Re-enabling sync after import');
-        await clientA.sync.setupSuperSync(syncConfig);
+        await clientA.sync.setupSuperSync({
+          ...syncConfig,
+          isEncryptionEnabled: true,
+          password: ENCRYPTION_PASSWORD,
+          syncImportChoice: 'local',
+        });
 
         // ============ PHASE 3: Sync After Import ============
         console.log('[Merge Test] Phase 3: Syncing after import');
@@ -344,6 +300,14 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
         });
         await waitForAppReady(clientB.page);
 
+        for (const client of [clientA, clientB]) {
+          await client.page.goto('/#/project/INBOX_PROJECT/tasks', {
+            waitUntil: 'domcontentloaded',
+            timeout: 30000,
+          });
+          await waitForAppReady(client.page);
+        }
+
         // ============ PHASE 4: Verify Merged Data ============
         console.log('[Merge Test] Phase 4: Verifying merged data');
 
@@ -355,11 +319,16 @@ base.describe('@importsync @supersync Import + Sync E2E', () => {
         await waitForTask(clientB.page, 'E2E Import Test - Active Task With Subtask');
         console.log('[Merge Test] Client B received imported tasks via sync');
 
-        // Note: The import replaces state rather than merging, so existing tasks
-        // may be gone after import. This test documents the actual behavior.
-        // If merge behavior is desired, the app would need to implement it differently.
+        for (const client of [clientA, clientB]) {
+          await expect(
+            client.page.locator(`task:has-text("${existingTaskA}")`),
+          ).not.toBeVisible();
+          await expect(
+            client.page.locator(`task:has-text("${existingTaskB}")`),
+          ).not.toBeVisible();
+        }
 
-        console.log('[Merge Test] ✓ Import merge test passed!');
+        console.log('[Merge Test] ✓ Import replacement test passed!');
       } finally {
         if (clientA) await closeClient(clientA);
         if (clientB) await closeClient(clientB);

--- a/e2e/tests/sync/supersync-backup-import-id-mismatch.spec.ts
+++ b/e2e/tests/sync/supersync-backup-import-id-mismatch.spec.ts
@@ -14,21 +14,13 @@ import * as path from 'path';
 import * as os from 'os';
 
 /**
- * SuperSync Backup Import ID Mismatch Bug Reproduction Test
+ * SuperSync Backup Import Replay Regression Tests
  *
- * BUG: When a backup is imported and synced, the client creates a BACKUP_IMPORT
- * operation with a local ID. However, uploadSnapshot() does NOT send this ID to
- * the server - the server generates its own ID. When the client later downloads
- * operations, it doesn't recognize the server's BACKUP_IMPORT (different ID) as
- * a duplicate, so it RE-APPLIES the old backup state, overwriting any tasks
- * created after the import.
- *
- * ROOT CAUSE: Missing op.id parameter in uploadSnapshot() interface at
- * src/app/op-log/sync-providers/provider.interface.ts:277-284
- *
- * EXPECTED: Tasks created after backup import should survive subsequent syncs.
- * ACTUAL (BUG): Tasks created after backup import are LOST because the old
- * BACKUP_IMPORT state is re-applied.
+ * The user-facing invariant is that tasks created after a backup import survive
+ * later syncs, including concurrent sync and repeated download cycles. The exact
+ * snapshot-operation ID forwarding is covered at the upload-service boundary;
+ * mandatory SuperSync encryption replaces the initial snapshot before a browser
+ * test can observe that transport-level detail directly.
  *
  * Run with: npm run e2e:supersync:file e2e/tests/sync/supersync-backup-import-id-mismatch.spec.ts
  */
@@ -149,186 +141,7 @@ const importBackup = async (
   return !importFailed;
 };
 
-test.describe('@supersync Backup Import ID Mismatch Bug', () => {
-  /**
-   * Verifies that BACKUP_IMPORT operation IDs match between client and server.
-   *
-   * KNOWN LIMITATION: SuperSync's mandatory encryption creates a clean-slate
-   * SYNC_IMPORT that overwrites the initial BACKUP_IMPORT on the server.
-   * The upload code correctly sends op.id and snapshotOpType, but the
-   * encryption setup always creates a replacement SYNC_IMPORT with a new ID.
-   * This test cannot pass until encryption setup preserves the original op ID.
-   *
-   * The user-facing behavior (tasks surviving after backup import) is verified
-   * by the other tests in this file ('Tasks should survive...' and 'Multiple syncs...').
-   */
-  test.fixme('Server stores BACKUP_IMPORT with matching client ID', async ({
-    browser,
-    baseURL,
-    testRunId,
-  }) => {
-    let clientA: SimulatedE2EClient | null = null;
-    let backupPath: string | null = null;
-
-    try {
-      const user = await createTestUser(testRunId + '-idmismatch');
-      const syncConfig = getSuperSyncConfig(user);
-
-      // ============ PHASE 1: Create task and export backup (no sync yet) ============
-      console.log('[ID Mismatch Test] Phase 1: Create task and export backup');
-
-      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
-
-      // Create initial task that will be in the backup
-      const initialTaskName = `InitialTask-${testRunId}`;
-      await clientA.workView.addTask(initialTaskName);
-      await waitForTask(clientA.page, initialTaskName);
-
-      backupPath = await exportBackup(clientA.page);
-      console.log(`[ID Mismatch Test] Exported backup`);
-
-      // ============ PHASE 2: Import backup (creates BACKUP_IMPORT locally) ============
-      console.log('[ID Mismatch Test] Phase 2: Import backup');
-
-      const importSuccess = await importBackup(clientA.page, backupPath);
-      if (!importSuccess) {
-        throw new Error('Backup import failed');
-      }
-      console.log(
-        '[ID Mismatch Test] Backup imported (BACKUP_IMPORT created with local ID)',
-      );
-
-      // ============ PHASE 3: Get local BACKUP_IMPORT op ID from IndexedDB ============
-      console.log('[ID Mismatch Test] Phase 3: Getting local BACKUP_IMPORT op ID');
-
-      // Wait for IndexedDB writes to complete
-      await clientA.page.waitForTimeout(1000);
-
-      const localOpData = await clientA.page.evaluate(async () => {
-        const db = await new Promise<IDBDatabase>((resolve, reject) => {
-          const request = indexedDB.open('SUP_OPS');
-          request.onsuccess = () => resolve(request.result);
-          request.onerror = () => reject(request.error);
-        });
-
-        interface CompactOp {
-          id: string;
-          o: string; // opType
-          a: string; // actionType short code
-          e: string; // entityType
-        }
-
-        const ops = await new Promise<Array<{ seq: number; op: CompactOp }>>(
-          (resolve, reject) => {
-            const tx = db.transaction('ops', 'readonly');
-            const store = tx.objectStore('ops');
-            const request = store.getAll();
-            request.onsuccess = () => resolve(request.result || []);
-            request.onerror = () => reject(request.error);
-          },
-        );
-
-        db.close();
-
-        const debugInfo = ops.map((entry) => ({
-          seq: entry.seq,
-          opType: entry.op?.o,
-          entityType: entry.op?.e,
-          id: entry.op?.id?.substring(0, 20),
-        }));
-
-        const backupImportOp = ops.find((entry) => entry.op?.o === 'BACKUP_IMPORT');
-
-        return {
-          opId: backupImportOp?.op.id || null,
-          debugInfo,
-          totalOps: ops.length,
-        };
-      });
-
-      console.log(
-        `[ID Mismatch Test] Debug: Found ${localOpData.totalOps} ops:`,
-        JSON.stringify(localOpData.debugInfo),
-      );
-      const localOpId = localOpData.opId;
-
-      console.log(`[ID Mismatch Test] Local BACKUP_IMPORT op ID: ${localOpId}`);
-      expect(localOpId).toBeTruthy();
-
-      // ============ PHASE 4: Enable sync for the FIRST time (server is empty) ============
-      // IMPORTANT: By enabling sync on a fresh server, the pending BACKUP_IMPORT
-      // gets uploaded directly as a snapshot (no existing server data to conflict with).
-      console.log('[ID Mismatch Test] Phase 4: Enabling sync (server is empty)');
-
-      await clientA.sync.setupSuperSync(syncConfig);
-      await clientA.sync.syncAndWait();
-      console.log('[ID Mismatch Test] Sync completed - BACKUP_IMPORT uploaded to server');
-
-      // ============ PHASE 5: Query server for the operation ID it stored ============
-      console.log('[ID Mismatch Test] Phase 5: Querying server for stored operation ID');
-
-      // Query for BACKUP_IMPORT first, fall back to any snapshot op
-      let serverOpId: string | null = null;
-      let serverOpType: string | null = null;
-      try {
-        // Try BACKUP_IMPORT first
-        let opsResponse = await fetch(
-          `http://localhost:1901/api/test/user/${user.userId}/ops?opType=BACKUP_IMPORT&limit=1`,
-        );
-        if (opsResponse.ok) {
-          const opsData = (await opsResponse.json()) as {
-            ops: Array<{ id: string; opType: string }>;
-          };
-          console.log(`[ID Mismatch Test] BACKUP_IMPORT ops:`, JSON.stringify(opsData));
-          if (opsData.ops.length > 0) {
-            serverOpId = opsData.ops[0].id;
-            serverOpType = opsData.ops[0].opType;
-          }
-        }
-
-        // If no BACKUP_IMPORT found, check for SYNC_IMPORT (in case opType mapping differs)
-        if (!serverOpId) {
-          opsResponse = await fetch(
-            `http://localhost:1901/api/test/user/${user.userId}/ops?opType=SYNC_IMPORT&limit=1`,
-          );
-          if (opsResponse.ok) {
-            const opsData = (await opsResponse.json()) as {
-              ops: Array<{ id: string; opType: string }>;
-            };
-            console.log(`[ID Mismatch Test] SYNC_IMPORT ops:`, JSON.stringify(opsData));
-            if (opsData.ops.length > 0) {
-              serverOpId = opsData.ops[0].id;
-              serverOpType = opsData.ops[0].opType;
-            }
-          }
-        }
-      } catch (err) {
-        console.error(`[ID Mismatch Test] Server ops query failed:`, err);
-      }
-
-      console.log(`[ID Mismatch Test] Server op: type=${serverOpType}, id=${serverOpId}`);
-
-      // ============ PHASE 6: CRITICAL ASSERTION - IDs should match ============
-      console.log('[ID Mismatch Test] Phase 6: Comparing local and server op IDs');
-      console.log(`[ID Mismatch Test]   Local ID:  ${localOpId}`);
-      console.log(`[ID Mismatch Test]   Server ID: ${serverOpId}`);
-
-      expect(serverOpId).toBeTruthy();
-      expect(
-        localOpId,
-        'Local BACKUP_IMPORT op ID should match server op ID. ' +
-          `Local: ${localOpId}, Server: ${serverOpId} (type: ${serverOpType})`,
-      ).toBe(serverOpId);
-
-      console.log('[ID Mismatch Test] ✓ IDs MATCH!');
-    } finally {
-      if (clientA) await closeClient(clientA);
-      if (backupPath && fs.existsSync(backupPath)) {
-        fs.unlinkSync(backupPath);
-      }
-    }
-  });
-
+test.describe('@supersync Backup Import Replay Regression', () => {
   /**
    * CRITICAL BUG REPRODUCTION TEST - With concurrent client causing rejection
    *

--- a/e2e/tests/sync/supersync-import-clean-server-state.spec.ts
+++ b/e2e/tests/sync/supersync-import-clean-server-state.spec.ts
@@ -51,10 +51,7 @@ test.describe('@supersync @import SYNC_IMPORT Clean Server State', () => {
    * - Client B does NOT have the old data (Task-OLD)
    * - Client B does NOT have old archived tasks in worklog
    */
-  // TODO: Skipped — BACKUP_IMPORT with isCleanSlate=true is not clearing old archived data on the server.
-  // The server receives the clean slate flag but Client B still sees old archived tasks.
-  // Needs server-side investigation.
-  test.skip('SYNC_IMPORT clears server state for fresh client joining later', async ({
+  test('SYNC_IMPORT clears server state for fresh client joining later', async ({
     browser,
     baseURL,
     testRunId,
@@ -194,10 +191,7 @@ test.describe('@supersync @import SYNC_IMPORT Clean Server State', () => {
    * - Client C has ONLY Backup-2 data
    * - Client C does NOT have Backup-1 remnants
    */
-  // TODO: Skipped — BACKUP_IMPORT with isCleanSlate=true is not clearing old data on the server.
-  // The second import's clean slate doesn't remove marker tasks from the first import.
-  // Needs server-side investigation.
-  test.skip('Multiple SYNC_IMPORTs overwrite each other cleanly', async ({
+  test('Multiple SYNC_IMPORTs overwrite each other cleanly', async ({
     browser,
     baseURL,
     testRunId,
@@ -322,10 +316,7 @@ test.describe('@supersync @import SYNC_IMPORT Clean Server State', () => {
    * Verify:
    * - Client B does NOT have OLD archived task
    */
-  // TODO: Skipped — BACKUP_IMPORT with isCleanSlate=true is not clearing old archived data on the server.
-  // Client B still receives old archived tasks despite the clean slate flag.
-  // Needs server-side investigation.
-  test.skip('SYNC_IMPORT properly clears old archived data from server', async ({
+  test('SYNC_IMPORT properly clears old archived data from server', async ({
     browser,
     baseURL,
     testRunId,

--- a/e2e/tests/sync/supersync-import-encryption-change.spec.ts
+++ b/e2e/tests/sync/supersync-import-encryption-change.spec.ts
@@ -10,60 +10,24 @@ import {
 import { ImportPage } from '../../pages/import.page';
 
 /**
- * SuperSync Import with Encryption State Change E2E Tests
- *
- * These tests verify that importing data with different encryption settings
- * properly handles the encryption state change:
- * - Server data is wiped (encrypted ops can't mix with unencrypted)
- * - A fresh snapshot is uploaded with correct encryption settings
- * - Other clients can sync with the new encryption state
- *
- * This is the "tabula rasa" behavior for encryption state changes during import.
- *
- * Run with: npm run e2e:supersync:file e2e/tests/sync/supersync-import-encryption-change.spec.ts
+ * SuperSync requires encryption. Importing an older backup whose global sync
+ * config says encryption was disabled must not disable it or mix the old server
+ * history with the imported state.
  */
-
-test.describe('@supersync @encryption Import with Encryption State Change', () => {
-  /**
-   * Scenario: Import unencrypted backup while encrypted sync is active
-   *
-   * This tests the critical case where:
-   * - Client has encryption enabled with existing encrypted data on server
-   * - Client imports a backup that doesn't have encryption enabled
-   * - Server should be wiped and fresh unencrypted snapshot uploaded
-   * - New clients should sync without encryption
-   *
-   * Setup: Client A with encryption enabled
-   *
-   * Actions:
-   * 1. Client A sets up SuperSync with encryption enabled
-   * 2. Client A creates task "EncryptedTask" and syncs (encrypted)
-   * 3. Client A imports backup (has encryption disabled)
-   * 4. Server data should be wiped and unencrypted snapshot uploaded
-   * 5. Client B sets up SuperSync WITHOUT encryption
-   * 6. Client B syncs and should get imported data
-   *
-   * Verify:
-   * - Client A has imported tasks (not EncryptedTask)
-   * - Client B can sync WITHOUT encryption and has imported tasks
-   * - No encryption errors occur
-   */
-  test('Import unencrypted backup while encrypted sync is active', async ({
+test.describe('@supersync @encryption Import preserves mandatory encryption', () => {
+  test('legacy unencrypted backup keeps SuperSync encrypted and replaces server state', async ({
     browser,
     baseURL,
     testRunId,
   }) => {
     const uniqueId = Date.now();
+    const encryptionPassword = `pass-${testRunId}`;
     let clientA: SimulatedE2EClient | null = null;
     let clientB: SimulatedE2EClient | null = null;
 
     try {
       const user = await createTestUser(testRunId);
       const baseConfig = getSuperSyncConfig(user);
-      const encryptionPassword = `pass-${testRunId}`;
-
-      // ============ PHASE 1: Setup Client A with Encryption ============
-      console.log('[EncryptionChange] Phase 1: Setting up Client A with encryption');
 
       clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
       await clientA.sync.setupSuperSync({
@@ -72,472 +36,55 @@ test.describe('@supersync @encryption Import with Encryption State Change', () =
         password: encryptionPassword,
       });
 
-      // Create and sync encrypted task
-      const encryptedTask = `EncryptedTask-${uniqueId}`;
-      await clientA.workView.addTask(encryptedTask);
+      const taskBeforeImport = `BeforeImport-${uniqueId}`;
+      await clientA.workView.addTask(taskBeforeImport);
       await clientA.sync.syncAndWait();
-      console.log(`[EncryptionChange] Client A created encrypted: ${encryptedTask}`);
 
-      // Verify task exists
-      await waitForTask(clientA.page, encryptedTask);
-
-      // ============ PHASE 2: Import Unencrypted Backup ============
-      console.log('[EncryptionChange] Phase 2: Client A importing unencrypted backup');
-
-      // Navigate to import page
       const importPage = new ImportPage(clientA.page);
       await importPage.navigateToImportPage();
-
-      // Import the backup file (has encryption disabled)
-      const backupPath = ImportPage.getFixturePath('test-backup.json');
-
-      // Set file on input (this triggers the import flow)
-      const fileInput = clientA.page.locator('file-imex input[type="file"]');
-
-      // Start listening for import completion BEFORE triggering the import
       const importCompletePromise = clientA.page.waitForEvent('console', {
         predicate: (msg) => msg.text().includes('Load(import) all data'),
         timeout: 60000,
       });
 
-      await fileInput.setInputFiles(backupPath);
-
-      // Handle "Encryption Settings Will Change" dialog that appears when
-      // importing a backup with different encryption settings
-      const encryptionChangeDialog = clientA.page.locator(
-        'mat-dialog-container:has-text("Encryption Settings Will Change")',
-      );
-      await encryptionChangeDialog.waitFor({ state: 'visible', timeout: 10000 });
-      console.log('[EncryptionChange] Encryption change dialog appeared');
-
-      const importAndChangeBtn = encryptionChangeDialog.locator(
-        'button:has-text("Import and Change Encryption")',
-      );
-      await importAndChangeBtn.click();
-      console.log('[EncryptionChange] Clicked Import and Change Encryption');
-
-      // Wait for dialog to close and import to complete
-      await encryptionChangeDialog.waitFor({ state: 'hidden', timeout: 15000 });
-
-      // Wait for import to complete
+      await clientA.page
+        .locator('file-imex input[type="file"]')
+        .setInputFiles(ImportPage.getFixturePath('test-backup.json'));
       await importCompletePromise;
-      console.log('[EncryptionChange] Client A imported unencrypted backup');
 
-      // Navigate to work view
-      await clientA.page.goto('/#/work-view');
-      await clientA.page.waitForLoadState('networkidle');
+      await expect(
+        clientA.page.locator(
+          'mat-dialog-container:has-text("Encryption Settings Will Change")',
+        ),
+      ).toHaveCount(0);
 
-      // Wait for imported tasks to be visible
-      await waitForTask(clientA.page, 'E2E Import Test - Active Task With Subtask');
-      console.log('[EncryptionChange] Client A has imported tasks visible after import');
-
-      // Re-setup sync after import (import overwrites globalConfig)
-      // Use encryption disabled since the imported backup has encryption disabled
       await clientA.sync.setupSuperSync({
         ...baseConfig,
-        isEncryptionEnabled: false,
         syncImportChoice: 'local',
       });
-      console.log('[EncryptionChange] Client A re-enabled sync without encryption');
-
-      // ============ PHASE 3: Sync After Import ============
-      console.log('[EncryptionChange] Phase 3: Client A syncing after import');
-
       await clientA.sync.syncAndWait();
-      console.log('[EncryptionChange] Client A synced successfully');
-
-      // ============ PHASE 4: Client B Syncs Without Encryption ============
-      console.log('[EncryptionChange] Phase 4: Client B syncing without encryption');
 
       clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
-      // Setup WITHOUT encryption - should work since import disabled encryption.
-      // Pass decryptionFailedPassword so the "Decryption Failed" dialog (caused by
-      // old encrypted ops still on the server) can be handled by entering the old password.
       await clientB.sync.setupSuperSync({
         ...baseConfig,
-        isEncryptionEnabled: false,
-        decryptionFailedPassword: encryptionPassword,
+        isEncryptionEnabled: true,
+        password: encryptionPassword,
       });
-
       await clientB.sync.syncAndWait();
-      console.log('[EncryptionChange] Client B synced successfully');
 
-      // ============ PHASE 5: Verify Clean Slate ============
-      console.log('[EncryptionChange] Phase 5: Verifying encryption state change');
-
-      // Navigate to work view on both clients
-      await clientA.page.goto('/#/work-view');
-      await clientA.page.waitForLoadState('networkidle');
       await clientB.page.goto('/#/work-view');
       await clientB.page.waitForLoadState('networkidle');
-
-      // Wait for imported task to appear on both
-      await waitForTask(clientA.page, 'E2E Import Test - Active Task With Subtask');
       await waitForTask(clientB.page, 'E2E Import Test - Active Task With Subtask');
 
-      // CRITICAL: Original encrypted task should be GONE
-      const encryptedTaskOnA = clientA.page.locator(`task:has-text("${encryptedTask}")`);
-      const encryptedTaskOnB = clientB.page.locator(`task:has-text("${encryptedTask}")`);
-
-      await expect(encryptedTaskOnA).not.toBeVisible({ timeout: 5000 });
-      await expect(encryptedTaskOnB).not.toBeVisible({ timeout: 5000 });
-      console.log('[EncryptionChange] ✓ Original encrypted task is GONE');
-
-      // Verify imported tasks are present on both clients
-      // Use .first() because the project page may show the task in both backlog and active sections
-      const importedTaskOnA = clientA.page
-        .locator('task:has-text("E2E Import Test - Active Task With Subtask")')
-        .first();
-      const importedTaskOnB = clientB.page
-        .locator('task:has-text("E2E Import Test - Active Task With Subtask")')
-        .first();
-
-      await expect(importedTaskOnA).toBeVisible({ timeout: 5000 });
-      await expect(importedTaskOnB).toBeVisible({ timeout: 5000 });
-      console.log('[EncryptionChange] ✓ Both clients have imported tasks');
-
-      // Verify no encryption errors on Client B (would indicate encrypted data leaked)
-      const hasError = await clientB.sync.hasSyncError();
-      expect(hasError).toBe(false);
-      console.log('[EncryptionChange] ✓ No encryption errors on Client B');
-
-      console.log('[EncryptionChange] ✓ Import encryption change test PASSED!');
-    } finally {
-      if (clientA) await closeClient(clientA);
-      if (clientB) await closeClient(clientB);
-    }
-  });
-
-  /**
-   * Scenario: Import encrypted backup while unencrypted sync is active
-   *
-   * Tests the reverse scenario where:
-   * - Client has unencrypted sync active
-   * - Client imports a backup that has encryption enabled
-   * - Server should be wiped and encrypted snapshot uploaded
-   *
-   * Setup: Client A with unencrypted sync
-   *
-   * Actions:
-   * 1. Client A sets up SuperSync without encryption
-   * 2. Client A creates task "UnencryptedTask" and syncs
-   * 3. Client A imports backup (has encryption enabled in globalConfig.sync)
-   * 4. After import, user must provide encryption password for sync
-   * 5. Server data should be wiped and encrypted snapshot uploaded
-   * 6. Client B sets up SuperSync WITH encryption using same password
-   * 7. Client B syncs and should get imported data
-   *
-   * Verify:
-   * - Client A has imported tasks (not UnencryptedTask)
-   * - Client B can sync WITH encryption and has imported tasks
-   * - No encryption errors occur
-   */
-  // TODO: Skip — server keeps old unencrypted ops after SYNC_IMPORT (isCleanSlate=true
-  // doesn't clear server data). Client B with encryption enabled can't decrypt old
-  // unencrypted ops — no password works. Needs server-side fix to wipe old data on SYNC_IMPORT.
-  test.skip('Import encrypted backup while unencrypted sync is active', async ({
-    browser,
-    baseURL,
-    testRunId,
-  }) => {
-    const uniqueId = Date.now();
-    let clientA: SimulatedE2EClient | null = null;
-    let clientB: SimulatedE2EClient | null = null;
-
-    try {
-      const user = await createTestUser(testRunId);
-      const baseConfig = getSuperSyncConfig(user);
-      const encryptionPassword = `pass-${testRunId}`;
-
-      // ============ PHASE 1: Setup Client A WITHOUT Encryption ============
-      console.log(
-        '[EncryptionChange-Reverse] Phase 1: Setting up Client A without encryption',
-      );
-
-      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
-      await clientA.sync.setupSuperSync({
-        ...baseConfig,
-        isEncryptionEnabled: false,
-      });
-
-      // Create and sync unencrypted task
-      const unencryptedTask = `UnencryptedTask-${uniqueId}`;
-      await clientA.workView.addTask(unencryptedTask);
-      await clientA.sync.syncAndWait();
-      console.log(
-        `[EncryptionChange-Reverse] Client A created unencrypted: ${unencryptedTask}`,
-      );
-
-      // Verify task exists
-      await waitForTask(clientA.page, unencryptedTask);
-
-      // ============ PHASE 2: Import Encrypted Backup ============
-      console.log(
-        '[EncryptionChange-Reverse] Phase 2: Client A importing encrypted backup',
-      );
-
-      // Navigate to import page
-      const importPage = new ImportPage(clientA.page);
-      await importPage.navigateToImportPage();
-
-      // Import the encrypted backup file (has encryption enabled in globalConfig.sync)
-      const backupPath = ImportPage.getFixturePath('test-backup-encrypted.json');
-
-      // Set file on input (this triggers the import flow)
-      const fileInput = clientA.page.locator('file-imex input[type="file"]');
-
-      // Start listening for import completion BEFORE triggering the import
-      const importCompletePromise = clientA.page.waitForEvent('console', {
-        predicate: (msg) => msg.text().includes('Load(import) all data'),
-        timeout: 60000,
-      });
-
-      await fileInput.setInputFiles(backupPath);
-
-      // The "Encryption Settings Will Change" dialog may or may not appear.
-      // It depends on whether the app detects the encryption mismatch.
-      // Wait to see if either the dialog appears or the import completes directly.
-      const encryptionChangeDialog = clientA.page.locator(
-        'mat-dialog-container:has-text("Encryption Settings Will Change")',
-      );
-
-      const importOutcome = await Promise.race([
-        encryptionChangeDialog
-          .waitFor({ state: 'visible', timeout: 10000 })
-          .then(() => 'encryption_dialog' as const),
-        importCompletePromise.then(() => 'import_completed' as const),
-      ]).catch(() => 'timeout' as const);
-
-      if (importOutcome === 'encryption_dialog') {
-        console.log('[EncryptionChange-Reverse] Encryption change dialog appeared');
-        const importAndChangeBtn = encryptionChangeDialog.locator(
-          'button:has-text("Import and Change Encryption")',
-        );
-        await importAndChangeBtn.click();
-        console.log('[EncryptionChange-Reverse] Clicked Import and Change Encryption');
-        await encryptionChangeDialog.waitFor({ state: 'hidden', timeout: 15000 });
-        await importCompletePromise;
-      } else if (importOutcome === 'import_completed') {
-        console.log(
-          '[EncryptionChange-Reverse] Import completed without encryption dialog',
-        );
-      } else {
-        throw new Error('Import timed out waiting for completion');
-      }
-      console.log('[EncryptionChange-Reverse] Client A imported encrypted backup');
-
-      // Navigate to work view
-      await clientA.page.goto('/#/work-view');
-      await clientA.page.waitForLoadState('networkidle');
-
-      // Wait for imported tasks to be visible
-      await waitForTask(clientA.page, 'E2E Import Test - Encrypted Task With Subtask');
-      console.log(
-        '[EncryptionChange-Reverse] Client A has imported tasks visible after import',
-      );
-
-      // Re-setup sync after import with encryption enabled
-      // The backup had isEncryptionEnabled: true, so we need to provide a password
-      await clientA.sync.setupSuperSync({
-        ...baseConfig,
-        isEncryptionEnabled: true,
-        password: encryptionPassword,
-        syncImportChoice: 'local',
-      });
-      console.log('[EncryptionChange-Reverse] Client A re-enabled sync with encryption');
-
-      // ============ PHASE 3: Sync After Import ============
-      console.log('[EncryptionChange-Reverse] Phase 3: Client A syncing after import');
-
-      await clientA.sync.syncAndWait();
-      console.log('[EncryptionChange-Reverse] Client A synced successfully');
-
-      // ============ PHASE 4: Client B Syncs With Encryption ============
-      console.log('[EncryptionChange-Reverse] Phase 4: Client B syncing with encryption');
-
-      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
-      // Setup WITH encryption - should work since import enabled encryption
-      await clientB.sync.setupSuperSync({
-        ...baseConfig,
-        isEncryptionEnabled: true,
-        password: encryptionPassword,
-      });
-
-      await clientB.sync.syncAndWait();
-      console.log('[EncryptionChange-Reverse] Client B synced successfully');
-
-      // ============ PHASE 5: Verify Clean Slate ============
-      console.log(
-        '[EncryptionChange-Reverse] Phase 5: Verifying encryption state change',
-      );
-
-      // Navigate to work view on both clients
-      await clientA.page.goto('/#/work-view');
-      await clientA.page.waitForLoadState('networkidle');
-      await clientB.page.goto('/#/work-view');
-      await clientB.page.waitForLoadState('networkidle');
-
-      // Wait for imported task to appear on both
-      await waitForTask(clientA.page, 'E2E Import Test - Encrypted Task With Subtask');
-      await waitForTask(clientB.page, 'E2E Import Test - Encrypted Task With Subtask');
-
-      // CRITICAL: Original unencrypted task should be GONE
-      const unencryptedTaskOnA = clientA.page.locator(
-        `task:has-text("${unencryptedTask}")`,
-      );
-      const unencryptedTaskOnB = clientB.page.locator(
-        `task:has-text("${unencryptedTask}")`,
-      );
-
-      await expect(unencryptedTaskOnA).not.toBeVisible({ timeout: 5000 });
-      await expect(unencryptedTaskOnB).not.toBeVisible({ timeout: 5000 });
-      console.log('[EncryptionChange-Reverse] Original unencrypted task is GONE');
-
-      // Verify imported tasks are present on both clients
-      // Use .first() because the project page may show the task in both backlog and active sections
-      const importedTaskOnA = clientA.page
-        .locator('task:has-text("E2E Import Test - Encrypted Task With Subtask")')
-        .first();
-      const importedTaskOnB = clientB.page
-        .locator('task:has-text("E2E Import Test - Encrypted Task With Subtask")')
-        .first();
-
-      await expect(importedTaskOnA).toBeVisible({ timeout: 5000 });
-      await expect(importedTaskOnB).toBeVisible({ timeout: 5000 });
-      console.log('[EncryptionChange-Reverse] Both clients have imported tasks');
-
-      // Verify no encryption errors on Client B
-      const hasError = await clientB.sync.hasSyncError();
-      expect(hasError).toBe(false);
-      console.log('[EncryptionChange-Reverse] No encryption errors on Client B');
-
-      console.log('[EncryptionChange-Reverse] Import encrypted backup test PASSED!');
-    } finally {
-      if (clientA) await closeClient(clientA);
-      if (clientB) await closeClient(clientB);
-    }
-  });
-
-  /**
-   * Scenario: Bidirectional sync works after encryption state change via import
-   *
-   * After importing with encryption change, verify that:
-   * - Both clients can create new tasks
-   * - Tasks sync correctly in both directions
-   * - No encryption mismatches occur
-   */
-  test('Bidirectional sync works after encryption change via import', async ({
-    browser,
-    baseURL,
-    testRunId,
-  }) => {
-    const uniqueId = Date.now();
-    let clientA: SimulatedE2EClient | null = null;
-    let clientB: SimulatedE2EClient | null = null;
-
-    try {
-      const user = await createTestUser(testRunId);
-      const baseConfig = getSuperSyncConfig(user);
-      const encryptionPassword = `pass-${testRunId}`;
-
-      // ============ Setup with encryption, then import unencrypted ============
-      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
-      await clientA.sync.setupSuperSync({
-        ...baseConfig,
-        isEncryptionEnabled: true,
-        password: encryptionPassword,
-      });
-
-      // Initial sync to establish account
-      await clientA.sync.syncAndWait();
-
-      // Import unencrypted backup
-      const importPage = new ImportPage(clientA.page);
-      await importPage.navigateToImportPage();
-      const backupPath = ImportPage.getFixturePath('test-backup.json');
-
-      // Set file on input (this triggers the import flow)
-      const fileInput = clientA.page.locator('file-imex input[type="file"]');
-
-      // Start listening for import completion BEFORE triggering the import
-      const importCompletePromise = clientA.page.waitForEvent('console', {
-        predicate: (msg) => msg.text().includes('Load(import) all data'),
-        timeout: 60000,
-      });
-
-      await fileInput.setInputFiles(backupPath);
-
-      // Handle "Encryption Settings Will Change" dialog
-      const encryptionChangeDialog = clientA.page.locator(
-        'mat-dialog-container:has-text("Encryption Settings Will Change")',
-      );
-      await encryptionChangeDialog.waitFor({ state: 'visible', timeout: 10000 });
-      const importAndChangeBtn = encryptionChangeDialog.locator(
-        'button:has-text("Import and Change Encryption")',
-      );
-      await importAndChangeBtn.click();
-      await encryptionChangeDialog.waitFor({ state: 'hidden', timeout: 15000 });
-
-      // Wait for import to complete
-      await importCompletePromise;
-      await clientA.page.goto('/#/work-view');
-      await clientA.page.waitForLoadState('networkidle');
-
-      // Wait for imported tasks BEFORE re-configuring sync
-      await waitForTask(clientA.page, 'E2E Import Test - Active Task With Subtask');
-
-      // Re-configure without encryption and sync
-      await clientA.sync.setupSuperSync({
-        ...baseConfig,
-        isEncryptionEnabled: false,
-        syncImportChoice: 'local',
-      });
-      await clientA.sync.syncAndWait();
-
-      // ============ Setup Client B without encryption ============
-      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
-      // Pass decryptionFailedPassword so the "Decryption Failed" dialog (caused by
-      // old encrypted ops still on the server) can be handled by entering the old password.
-      await clientB.sync.setupSuperSync({
-        ...baseConfig,
-        isEncryptionEnabled: false,
-        decryptionFailedPassword: encryptionPassword,
-      });
-      await clientB.sync.syncAndWait();
-
-      // Navigate to work view after setup
-      await clientB.page.goto('/#/work-view');
-      await clientB.page.waitForLoadState('networkidle');
-
-      // Wait for Client B to have imported data
-      await waitForTask(clientB.page, 'E2E Import Test - Active Task With Subtask');
-
-      // ============ Bidirectional sync test ============
-      // Client A creates a task
-      const taskFromA = `FromA-${uniqueId}`;
-      await clientA.workView.addTask(taskFromA);
-      await clientA.sync.syncAndWait();
-
-      // Client B syncs and should see A's task
-      await clientB.sync.syncAndWait();
-      await waitForTask(clientB.page, taskFromA);
-
-      // Client B creates a task
-      const taskFromB = `FromB-${uniqueId}`;
-      await clientB.workView.addTask(taskFromB);
-      await clientB.sync.syncAndWait();
-
-      // Client A syncs and should see B's task
-      await clientA.sync.syncAndWait();
-      await waitForTask(clientA.page, taskFromB);
-
-      // Verify both clients have both tasks
-      await expect(clientA.page.locator(`task:has-text("${taskFromA}")`)).toBeVisible();
-      await expect(clientA.page.locator(`task:has-text("${taskFromB}")`)).toBeVisible();
-      await expect(clientB.page.locator(`task:has-text("${taskFromA}")`)).toBeVisible();
-      await expect(clientB.page.locator(`task:has-text("${taskFromB}")`)).toBeVisible();
-
-      console.log('[BidiSync] ✓ Bidirectional sync works after encryption change!');
+      await expect(
+        clientB.page.locator(`task:has-text("${taskBeforeImport}")`),
+      ).not.toBeVisible();
+      await expect(
+        clientB.page
+          .locator('task:has-text("E2E Import Test - Active Task With Subtask")')
+          .first(),
+      ).toBeVisible();
+      await expect(clientB.sync.hasSyncError()).resolves.toBe(false);
     } finally {
       if (clientA) await closeClient(clientA);
       if (clientB) await closeClient(clientB);

--- a/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
+++ b/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
@@ -3,9 +3,11 @@ import { SuperSyncPage } from '../../pages/supersync.page';
 import { WorkViewPage } from '../../pages/work-view.page';
 import { waitForStatePersistence } from '../../utils/waits';
 import {
+  closeClient,
+  createSimulatedClient,
   createTestUser,
   getSuperSyncConfig,
-  isServerHealthy,
+  type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
 import {
   createLegacyMigratedClient,
@@ -31,14 +33,6 @@ import legacyDataCollisionB from '../../fixtures/legacy-migration-collision-b.js
  */
 test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
   test.describe.configure({ mode: 'serial' });
-
-  test.beforeAll(async () => {
-    const healthy = await isServerHealthy();
-    if (!healthy) {
-      console.warn('SuperSync server not healthy. Skipping SuperSync tests.');
-      test.skip(true, 'SuperSync server not healthy');
-    }
-  });
 
   /**
    * Test: Both clients migrated from legacy - Keep local resolution
@@ -480,12 +474,8 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
    * Verifies that archived tasks from legacy data survive the migration
    * process and can be synced to other clients.
    *
-   * Note: This test is skipped because the fresh client sync flow has
-   * timing issues with the setupSuperSync method. Archive sync is already
-   * covered by other SuperSync tests. The core legacy migration scenarios
-   * (tests 1-3) demonstrate the main functionality.
    */
-  test.skip('verify archive data is preserved after migration + sync', async ({
+  test('verify archive data is preserved after migration + sync', async ({
     browser,
     baseURL,
     testRunId,
@@ -500,10 +490,7 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
       context: Awaited<ReturnType<typeof browser.newContext>>;
       page: Awaited<ReturnType<typeof browser.newPage>>;
     } | null = null;
-    let clientB: {
-      context: Awaited<ReturnType<typeof browser.newContext>>;
-      page: Awaited<ReturnType<typeof browser.newPage>>;
-    } | null = null;
+    let clientB: SimulatedE2EClient | null = null;
 
     try {
       // === Client A: Legacy migration with archived task ===
@@ -538,27 +525,10 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
       // === Client B: Fresh client (no legacy data), syncs ===
       // We use a fresh client to verify archive data transfers correctly
       console.log('[Test] Creating fresh Client B...');
-      const contextB = await browser.newContext({
-        baseURL: url,
-        acceptDownloads: true,
-      });
-      const pageB = await contextB.newPage();
-
-      // Auto-accept dialogs for fresh client
-      pageB.on('dialog', async (dialog) => {
-        if (dialog.type() === 'confirm') {
-          await dialog.accept();
-        }
-      });
-
-      await pageB.goto('/');
-      // Wait for app to be ready
-      await pageB.waitForSelector('magic-side-nav', { state: 'visible', timeout: 30000 });
-
-      clientB = { context: contextB, page: pageB };
-      const syncPageB = new SuperSyncPage(pageB);
-      const workViewB = new WorkViewPage(pageB);
-      await workViewB.waitForTaskList();
+      clientB = await createSimulatedClient(browser, url, 'B', testRunId);
+      const pageB = clientB.page;
+      const syncPageB = clientB.sync;
+      const workViewB = clientB.workView;
 
       // Setup sync - fresh client downloads data
       await syncPageB.setupSuperSync({ ...syncConfig, waitForInitialSync: false });
@@ -616,7 +586,7 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
       console.log('[Test] SUCCESS: Archive data preserved after migration + sync');
     } finally {
       if (clientA) await closeLegacyClient(clientA).catch(() => {});
-      if (clientB) await closeLegacyClient(clientB).catch(() => {});
+      if (clientB) await closeClient(clientB).catch(() => {});
     }
   });
 });

--- a/e2e/tests/sync/supersync-provider-switch-to-supersync.spec.ts
+++ b/e2e/tests/sync/supersync-provider-switch-to-supersync.spec.ts
@@ -19,6 +19,7 @@ import { SyncPage } from '../../pages/sync.page';
 import { SuperSyncPage } from '../../pages/supersync.page';
 import { WorkViewPage } from '../../pages/work-view.page';
 import { waitForStatePersistence } from '../../utils/waits';
+import { isWebDavServerUp } from '../../utils/check-webdav';
 
 /**
  * SuperSync Provider Switch (WebDAV → SuperSync) E2E Tests
@@ -37,21 +38,6 @@ import { waitForStatePersistence } from '../../utils/waits';
  *
  * Run with: npm run e2e:supersync:file e2e/tests/sync/supersync-provider-switch-to-supersync.spec.ts
  */
-
-/**
- * Check if the WebDAV server is available.
- */
-const isWebDAVAvailable = async (): Promise<boolean> => {
-  try {
-    const response = await fetch('http://localhost:2345', {
-      method: 'OPTIONS',
-      signal: AbortSignal.timeout(3000),
-    });
-    return response.ok || response.status === 200 || response.status === 207;
-  } catch {
-    return false;
-  }
-};
 
 test.describe('@supersync Provider Switch WebDAV to SuperSync', () => {
   /**
@@ -74,7 +60,10 @@ test.describe('@supersync Provider Switch WebDAV to SuperSync', () => {
     test.setTimeout(180000);
 
     // Skip if WebDAV server is not available
-    const webdavAvailable = await isWebDAVAvailable();
+    const webdavAvailable = await isWebDavServerUp();
+    if (!webdavAvailable && process.env.E2E_REQUIRE_WEBDAV === 'true') {
+      throw new Error('WebDAV is required for provider-switch coverage.');
+    }
     testInfo.skip(!webdavAvailable, 'WebDAV server not running on localhost:2345');
 
     const appUrl = baseURL || 'http://localhost:4242';

--- a/e2e/tests/sync/supersync-provider-switch.spec.ts
+++ b/e2e/tests/sync/supersync-provider-switch.spec.ts
@@ -11,8 +11,11 @@ import {
   WEBDAV_CONFIG_TEMPLATE,
   createSyncFolder,
   generateSyncFolderName,
+  setupSyncClient,
+  waitForSyncComplete,
 } from '../../utils/sync-helpers';
 import { SyncPage } from '../../pages/sync.page';
+import { isWebDavServerUp } from '../../utils/check-webdav';
 
 /**
  * SuperSync Provider Switch E2E Tests
@@ -29,21 +32,6 @@ import { SyncPage } from '../../pages/sync.page';
  *
  * Run with: npm run e2e:supersync:file e2e/tests/sync/supersync-provider-switch.spec.ts
  */
-
-/**
- * Check if the WebDAV server is available.
- */
-const isWebDAVAvailable = async (): Promise<boolean> => {
-  try {
-    const response = await fetch('http://localhost:2345', {
-      method: 'OPTIONS',
-      signal: AbortSignal.timeout(3000),
-    });
-    return response.ok || response.status === 200 || response.status === 207;
-  } catch {
-    return false;
-  }
-};
 
 test.describe('@supersync Provider Switch (WebDAV ↔ SuperSync)', () => {
   /**
@@ -67,7 +55,10 @@ test.describe('@supersync Provider Switch (WebDAV ↔ SuperSync)', () => {
     test.setTimeout(180000);
 
     // Skip if WebDAV server is not available
-    const webdavAvailable = await isWebDAVAvailable();
+    const webdavAvailable = await isWebDavServerUp();
+    if (!webdavAvailable && process.env.E2E_REQUIRE_WEBDAV === 'true') {
+      throw new Error('WebDAV is required for provider-switch coverage.');
+    }
     testInfo.skip(!webdavAvailable, 'WebDAV server not running on localhost:2345');
 
     const appUrl = baseURL || 'http://localhost:4242';
@@ -105,14 +96,17 @@ test.describe('@supersync Provider Switch (WebDAV ↔ SuperSync)', () => {
 
       // Disable SuperSync and set up WebDAV
       const syncPageA = new SyncPage(clientA.page);
-      await syncPageA.configureSyncProvider({
-        ...WEBDAV_CONFIG_TEMPLATE,
-        syncFolderPath: `/${syncFolderName}`,
-      });
+      await syncPageA.setupWebdavSync(
+        {
+          ...WEBDAV_CONFIG_TEMPLATE,
+          syncFolderPath: `/${syncFolderName}`,
+        },
+        { isReconfigure: true },
+      );
       console.log('[ProviderSwitch] Switched to WebDAV');
 
-      // Wait for WebDAV sync
-      await clientA.page.waitForTimeout(3000);
+      await syncPageA.triggerSync();
+      await waitForSyncComplete(clientA.page, syncPageA);
 
       // Verify tasks still exist on Client A
       await waitForTask(clientA.page, task1);
@@ -122,24 +116,19 @@ test.describe('@supersync Provider Switch (WebDAV ↔ SuperSync)', () => {
       // ============ PHASE 3: New client joins via WebDAV ============
       console.log('[ProviderSwitch] Phase 3: New client joins via WebDAV');
 
-      contextB = await browser.newContext({
-        storageState: undefined,
-        viewport: { width: 1920, height: 1080 },
-      });
-      const pageB = await contextB.newPage();
-      await pageB.goto(appUrl);
-      await pageB.waitForLoadState('networkidle');
-      await pageB.waitForTimeout(2000);
+      const clientB = await setupSyncClient(browser, appUrl);
+      contextB = clientB.context;
+      const pageB = clientB.page;
 
       const syncPageB = new SyncPage(pageB);
-      await syncPageB.configureSyncProvider({
+      await syncPageB.setupWebdavSync({
         ...WEBDAV_CONFIG_TEMPLATE,
         syncFolderPath: `/${syncFolderName}`,
       });
       console.log('[ProviderSwitch] Client B joined via WebDAV');
 
-      // Wait for sync
-      await pageB.waitForTimeout(5000);
+      await syncPageB.triggerSync();
+      await waitForSyncComplete(pageB, syncPageB);
 
       // Verify tasks on Client B
       await waitForTask(pageB, task1);

--- a/e2e/tests/work-view/sections.spec.ts
+++ b/e2e/tests/work-view/sections.spec.ts
@@ -77,9 +77,9 @@ test.describe('Sections', () => {
    * `@for track` reorders nodes) and freshly-dropped tasks run an
    * `expandInOnly` enter animation that holds them at `height: 0`. Wait
    * for the element to be visible, then poll until it reports a real box
-   * so the read can't race the re-render. This is the failure the two
-   * `test.fixme`s below hit; keeping the guard here lets the active tests
-   * stay reliable instead of throwing "no bounding box".
+   * so the read can't race the re-render. This was the failure the former
+   * disabled cross-list scenarios hit; keeping the guard here prevents the
+   * active tests from throwing "no bounding box".
    *
    * The box captured *inside* the poll is the one returned — re-reading
    * after the poll reopens the very race the poll closes (the list can
@@ -143,18 +143,18 @@ test.describe('Sections', () => {
    * `expandInOnly` animation (`height: 0 -> *`, expand.ani.ts) and has a
    * zero-height layout box mid-animation. `boundingBox()` returns `null` for
    * that, which is the root cause of the "drag source/target has no bounding
-   * box" flake (and why the cross-section tests below are fixme'd).
+   * box" flake in the former disabled cross-section scenarios.
    *
    * Flipping the app's own `isDisableAnimations` config toggles the
    * `@HostBinding('@.disabled')` on the root component (app.component.ts),
    * which disables every `@trigger` including `expandInOnly` — so dropped
    * tasks render at full height instantly and their box never collapses.
    *
-   * NOTE: only the intra-section reorder test uses this. The "drops a task
-   * into a section" test intentionally keeps animations on: it drags out of
-   * the no-section list into an *empty* section, and with animations off the
-   * source-removal reflow is instant, so the empty drop target can jump out
-   * from under the in-flight pointer and the drop misses.
+   * NOTE: the "drops a task into a section" test intentionally keeps
+   * animations on: it drags out of the no-section list into an *empty*
+   * section, and with animations off the source-removal reflow is instant,
+   * so the empty drop target can jump out from under the in-flight pointer
+   * and the drop misses. Reorder and cross-list scenarios disable them.
    */
   const disableAnimations = async (
     page: import('@playwright/test').Page,
@@ -399,18 +399,13 @@ test.describe('Sections', () => {
     await expect.poll(async () => (await sectionTaskTitles()).length).toBe(3);
   });
 
-  // FIXME: cross-section drag is flaky in headless CDK for the same
-  // pointer-event reason as the section→no-section round-trip below — the
-  // source task's bounding box can collapse mid-gesture when the source
-  // section re-renders without it. Behavior is covered by section.reducer
-  // unit tests (cross-section moves via `addTaskToSection`) and by the
-  // component-level `undoneTasksBySection` spec.
-  test.fixme('moves a task from one section to a specific slot in another', async ({
+  test('moves a task from one section to another', async ({
     page,
     workViewPage,
     projectPage,
   }) => {
     await setupTestProject(workViewPage, projectPage);
+    await disableAnimations(page);
 
     await openProjectContextMenu(page);
     await clickAddSection(page);
@@ -442,10 +437,14 @@ test.describe('Sections', () => {
       });
     }
 
-    // Drag Zulu from Left onto Yankee in Right.
+    // Drag Zulu into Right's actual CDK drop list. Targeting a task row can
+    // race the row transform while CDK makes room for the incoming item.
     const taskZulu = left.locator('task').filter({ hasText: 'Zulu' }).first();
-    const taskYankee = right.locator('task').filter({ hasText: 'Yankee' }).first();
-    await cdkDragTo(page, taskZulu.locator('done-toggle').first(), taskYankee);
+    await cdkDragTo(
+      page,
+      taskZulu.locator('done-toggle').first(),
+      right.locator('.task-list-inner').first(),
+    );
 
     // Behavioral invariant: Zulu has crossed sections. Exact slot is
     // CDK-cursor dependent, so we don't pin it.
@@ -456,13 +455,7 @@ test.describe('Sections', () => {
     await expect(right.locator('task')).toHaveCount(3);
   });
 
-  // FIXME: round-trip drag (section → no-section) is flaky in headless CDK.
-  // The forward "into section" drag passes; the reverse fails to register the
-  // drop on the empty `.no-section` task-list whose bounding box collapses
-  // to its hint-message. Driving CDK pointer events deterministically here
-  // is non-trivial — track as a follow-up and exercise reverse moves via
-  // unit tests in section.reducer.spec.ts (`removeTaskFromSection`).
-  test.fixme('drags a task back out of a section into the main list', async ({
+  test('drags a task back out of a section into the main list', async ({
     page,
     workViewPage,
     projectPage,
@@ -478,9 +471,6 @@ test.describe('Sections', () => {
 
     const section = sectionByTitle(page, 'Holding');
     const sectionTaskList = section.locator('task-list').first();
-    // Target the wrapper `.no-section` div, not the inner task-list — when
-    // the no-section bucket is empty the task-list collapses to its hint
-    // text and may have a too-small bounding box for a stable drop.
     const noSection = page.locator('.no-section').first();
 
     const task = page.locator('task').filter({ hasText: 'Roundtrip' }).first();
@@ -494,9 +484,16 @@ test.describe('Sections', () => {
       .first();
     await expect(taskInSection).toBeVisible();
 
+    // Give the no-section CDK list a stable row target. Its empty-state text
+    // is a sibling that overlaps the otherwise-empty drop rect, so a row is
+    // the deterministic equivalent of a user dropping beside another task.
+    await workViewPage.addTask('Main anchor');
+    const mainAnchor = noSection.locator('task').filter({ hasText: 'Main anchor' });
+    await expect(mainAnchor).toBeVisible();
+
     // Move back out — re-acquire handle from the new DOM location.
     dragHandle = taskInSection.locator('done-toggle').first();
-    await cdkDragTo(page, dragHandle, noSection);
+    await cdkDragTo(page, dragHandle, mainAnchor);
 
     await expect(noSection.locator('task').filter({ hasText: 'Roundtrip' })).toBeVisible({
       timeout: 5000,

--- a/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.spec.ts
+++ b/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.spec.ts
@@ -1,4 +1,10 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flushMicrotasks,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { FormControl, FormGroup } from '@angular/forms';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -245,7 +251,46 @@ describe('DialogSyncCfgComponent', () => {
     it('does NOT flag when re-saving an already-established SuperSync config', async () => {
       forceOnline();
       mockProviderManager.getProviderById.and.resolveTo(superSyncProvider as any);
+      (component as any)._initialProviderId = SyncProviderId.SuperSync;
 
+      (component as any)._tmpUpdatedCfg = {
+        ...(component as any)._tmpUpdatedCfg,
+        syncProvider: SyncProviderId.SuperSync,
+        isEnabled: true,
+        _isInitialSetup: false,
+      };
+
+      await component.save();
+
+      expect(
+        mockSyncWrapperService.markPromptEncryptionAfterSetupSync,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('flags setup sync when switching to an unconfigured SuperSync provider', async () => {
+      forceOnline();
+      mockProviderManager.getProviderById.and.resolveTo(superSyncProvider as any);
+      (component as any)._initialProviderId = SyncProviderId.WebDAV;
+      (component as any)._selectedProviderWasConfigured = false;
+      (component as any)._tmpUpdatedCfg = {
+        ...(component as any)._tmpUpdatedCfg,
+        syncProvider: SyncProviderId.SuperSync,
+        isEnabled: true,
+        _isInitialSetup: false,
+      };
+
+      await component.save();
+
+      expect(
+        mockSyncWrapperService.markPromptEncryptionAfterSetupSync,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT flag setup when returning to an already-configured SuperSync provider', async () => {
+      forceOnline();
+      mockProviderManager.getProviderById.and.resolveTo(superSyncProvider as any);
+      (component as any)._initialProviderId = SyncProviderId.WebDAV;
+      (component as any)._selectedProviderWasConfigured = true;
       (component as any)._tmpUpdatedCfg = {
         ...(component as any)._tmpUpdatedCfg,
         syncProvider: SyncProviderId.SuperSync,
@@ -327,6 +372,7 @@ describe('DialogSyncCfgComponent', () => {
     it('does NOT prompt when re-saving an already-configured provider (not a fresh setup)', async () => {
       setOnline(true);
       mockDialogResult({ success: true, password: 'unused' });
+      (component as any)._initialProviderId = SyncProviderId.WebDAV;
       setFreshWebdavCfg({ _isInitialSetup: false } as any);
 
       await component.save();
@@ -335,14 +381,54 @@ describe('DialogSyncCfgComponent', () => {
       expect(savedConfig().isEncryptionEnabled).toBeFalse();
     });
 
+    it('offers encryption setup when switching to an unconfigured WebDAV provider', async () => {
+      setOnline(true);
+      mockDialogResult({ success: true, password: 'provider-switch-password' });
+      (component as any)._initialProviderId = SyncProviderId.SuperSync;
+      (component as any)._selectedProviderWasConfigured = false;
+      setFreshWebdavCfg({ _isInitialSetup: false } as any);
+
+      await component.save();
+
+      expect(mockMatDialog.open).toHaveBeenCalledTimes(1);
+      expect(savedConfig().encryptKey).toBe('provider-switch-password');
+      expect(savedConfig().isEncryptionEnabled).toBeTrue();
+    });
+
+    it('does NOT offer a new key when returning to a configured WebDAV provider', async () => {
+      setOnline(true);
+      mockDialogResult({ success: true, password: 'incompatible-new-password' });
+      (component as any)._initialProviderId = SyncProviderId.SuperSync;
+      (component as any)._selectedProviderWasConfigured = true;
+      setFreshWebdavCfg({ _isInitialSetup: false } as any);
+
+      await component.save();
+
+      expect(mockMatDialog.open).not.toHaveBeenCalled();
+      expect(savedConfig().encryptKey).toBe('');
+      expect(savedConfig().isEncryptionEnabled).toBeFalse();
+    });
+
     it('does NOT prompt when encryption is already enabled', async () => {
       setOnline(true);
       mockDialogResult({ success: true, password: 'unused' });
+      mockProviderManager.getProviderById.and.resolveTo({
+        id: SyncProviderId.WebDAV,
+        privateCfg: {
+          load: jasmine.createSpy('load').and.resolveTo({
+            encryptKey: 'stored-webdav-key',
+            isEncryptionEnabled: true,
+          }),
+        },
+        isReady: jasmine.createSpy('isReady').and.resolveTo(true),
+      } as any);
       setFreshWebdavCfg({ isEncryptionEnabled: true });
 
       await component.save();
 
       expect(mockMatDialog.open).not.toHaveBeenCalled();
+      expect(savedConfig().encryptKey).toBe('stored-webdav-key');
+      expect(savedConfig().isEncryptionEnabled).toBeTrue();
     });
 
     it('does NOT prompt for a non-file-based provider (SuperSync)', async () => {
@@ -402,6 +488,138 @@ describe('DialogSyncCfgComponent', () => {
       expect(mockSyncConfigService.updateSettingsFromForm).toHaveBeenCalled();
       expect(mockDialogRef.close).toHaveBeenCalled();
     });
+  });
+
+  describe('provider changes', () => {
+    it('clears the previous provider encryption when the new provider has none', fakeAsync(() => {
+      const syncProviderControl = new FormControl<SyncProviderId | null>(null);
+      component.form = new FormGroup({
+        syncProvider: syncProviderControl,
+      }) as unknown as typeof component.form;
+      mockProviderManager.getProviderById.and.resolveTo({
+        privateCfg: {
+          load: jasmine.createSpy('load').and.resolveTo(null),
+        },
+      } as any);
+      (component as any)._tmpUpdatedCfg = {
+        ...(component as any)._tmpUpdatedCfg,
+        syncProvider: SyncProviderId.SuperSync,
+        encryptKey: 'super-sync-secret',
+        isEncryptionEnabled: true,
+      };
+
+      component.ngAfterViewInit();
+      tick();
+      syncProviderControl.setValue(SyncProviderId.WebDAV);
+      flushMicrotasks();
+
+      expect((component as any)._tmpUpdatedCfg.encryptKey).toBe('');
+      expect((component as any)._tmpUpdatedCfg.isEncryptionEnabled).toBeFalse();
+    }));
+
+    it('waits for the selected provider config before saving', fakeAsync(() => {
+      let resolvePrivateCfg: (value: null) => void = () => undefined;
+      const privateCfgPromise = new Promise<null>((resolve) => {
+        resolvePrivateCfg = resolve;
+      });
+      const syncProviderControl = new FormControl<SyncProviderId | null>(null);
+      component.form = new FormGroup({
+        syncProvider: syncProviderControl,
+        encryptKey: new FormControl('stale-super-sync-key'),
+        isEncryptionEnabled: new FormControl(true),
+      }) as unknown as typeof component.form;
+      mockProviderManager.getProviderById.and.resolveTo({
+        privateCfg: {
+          load: jasmine.createSpy('load').and.returnValue(privateCfgPromise),
+        },
+      } as any);
+      mockSyncWrapperService.configuredAuthForSyncProviderIfNecessary.and.resolveTo({
+        wasConfigured: false,
+      });
+      (component as any)._tmpUpdatedCfg = {
+        ...(component as any)._tmpUpdatedCfg,
+        encryptKey: 'stale-super-sync-key',
+        isEncryptionEnabled: true,
+      };
+
+      component.ngAfterViewInit();
+      tick();
+      syncProviderControl.setValue(SyncProviderId.WebDAV);
+      void component.save();
+      flushMicrotasks();
+
+      expect(mockSyncConfigService.updateSettingsFromForm).not.toHaveBeenCalled();
+
+      resolvePrivateCfg(null);
+      flushMicrotasks();
+
+      expect(mockSyncConfigService.updateSettingsFromForm).toHaveBeenCalled();
+      expect(
+        (
+          mockSyncConfigService.updateSettingsFromForm.calls.mostRecent()
+            .args[0] as SyncConfig
+        ).encryptKey,
+      ).toBe('');
+      expect(
+        (
+          mockSyncConfigService.updateSettingsFromForm.calls.mostRecent()
+            .args[0] as SyncConfig
+        ).isEncryptionEnabled,
+      ).toBeFalse();
+    }));
+
+    it('ignores an older provider load that resolves after the current one', fakeAsync(() => {
+      let resolveWebDav: (value: { encryptKey: string }) => void = () => undefined;
+      let resolveSuperSync: (value: {
+        encryptKey: string;
+        isEncryptionEnabled: boolean;
+      }) => void = () => undefined;
+      const webDavCfg = new Promise<{ encryptKey: string }>((resolve) => {
+        resolveWebDav = resolve;
+      });
+      const superSyncCfg = new Promise<{
+        encryptKey: string;
+        isEncryptionEnabled: boolean;
+      }>((resolve) => {
+        resolveSuperSync = resolve;
+      });
+      const syncProviderControl = new FormControl<SyncProviderId | null>(null);
+      component.form = new FormGroup({
+        syncProvider: syncProviderControl,
+      }) as unknown as typeof component.form;
+      mockProviderManager.getProviderById.and.callFake(
+        async (providerId) =>
+          ({
+            privateCfg: {
+              load: jasmine
+                .createSpy('load')
+                .and.returnValue(
+                  providerId === SyncProviderId.WebDAV ? webDavCfg : superSyncCfg,
+                ),
+            },
+          }) as any,
+      );
+
+      component.ngAfterViewInit();
+      tick();
+      syncProviderControl.setValue(SyncProviderId.WebDAV);
+      syncProviderControl.setValue(SyncProviderId.SuperSync);
+      flushMicrotasks();
+
+      resolveSuperSync({
+        encryptKey: 'current-super-sync-key',
+        isEncryptionEnabled: true,
+      });
+      flushMicrotasks();
+      resolveWebDav({ encryptKey: 'stale-webdav-key' });
+      flushMicrotasks();
+
+      expect((component as any)._tmpUpdatedCfg.syncProvider).toBe(
+        SyncProviderId.SuperSync,
+      );
+      expect((component as any)._tmpUpdatedCfg.encryptKey).toBe('current-super-sync-key');
+      expect((component as any)._tmpUpdatedCfg.isEncryptionEnabled).toBeTrue();
+    }));
   });
 
   describe('Nextcloud connection test', () => {

--- a/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.ts
+++ b/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.ts
@@ -33,7 +33,7 @@ import {
 import { SyncConfigService } from '../sync-config.service';
 import { SyncWrapperService } from '../sync-wrapper.service';
 import { firstValueFrom } from 'rxjs';
-import { first, skip } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { toSyncProviderId } from '../../../op-log/sync-exports';
 import { isFileBasedProviderId } from '../../../op-log/sync/operation-sync.util';
 import { SyncLog } from '../../../core/log';
@@ -51,6 +51,8 @@ import {
 import { testWebdavConnection } from '../../../op-log/sync-providers/file-based/webdav/test-webdav-connection';
 import { discoverNextcloudUserId } from '../../../op-log/sync-providers/file-based/webdav/discover-nextcloud-user-id';
 import type { OneDrivePrivateCfg } from '../../../op-log/sync-providers/file-based/onedrive/onedrive.model';
+import type { LocalFileSyncPrivateCfg } from '@sp/sync-providers/local-file';
+import type { SuperSyncPrivateCfg } from '@sp/sync-providers/super-sync';
 
 // `testWebdavConnection` reports a 404 (auth ok, wrong DAV path) via this
 // HTTP status; the package-side `WebDavHttpStatus` enum is not exported to
@@ -411,11 +413,17 @@ export class DialogSyncCfgComponent implements AfterViewInit {
   };
 
   private _matDialogRef = inject<MatDialogRef<DialogSyncCfgComponent>>(MatDialogRef);
+  private _initialProviderId: SyncProviderId | null = null;
+  private _providerConfigLoad: Promise<void> = Promise.resolve();
+  private _providerConfigLoadId = 0;
+  private _selectedProviderWasConfigured = false;
 
   constructor() {
     this.syncConfigService.syncSettingsForm$
       .pipe(first(), takeUntilDestroyed(this._destroyRef))
       .subscribe((v) => {
+        this._initialProviderId = toSyncProviderId(v.syncProvider);
+        this._selectedProviderWasConfigured = v.isEnabled;
         if (v.isEnabled) {
           this.isWasEnabled.set(true);
         }
@@ -442,8 +450,8 @@ export class DialogSyncCfgComponent implements AfterViewInit {
 
       // Listen for provider changes and reload provider-specific configuration
       syncProviderControl.valueChanges
-        .pipe(skip(1), takeUntilDestroyed(this._destroyRef))
-        .subscribe(async (newProvider: SyncProviderId | null) => {
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe((newProvider: SyncProviderId | null) => {
           if (!newProvider) {
             return;
           }
@@ -454,77 +462,93 @@ export class DialogSyncCfgComponent implements AfterViewInit {
             return;
           }
 
-          // Load the provider's stored configuration
-          const provider = await this._providerManager.getProviderById(providerId);
-          if (!provider) {
-            // Provider not yet configured, keep current form state
-            return;
-          }
-
-          const privateCfg = await provider.privateCfg.load();
-          const globalCfg = await this._globalConfigService.sync$
-            .pipe(first())
-            .toPromise();
-
-          // Create provider-specific config based on provider type
-          let providerSpecificUpdate: Partial<SyncConfig> = {};
-
-          if (newProvider === SyncProviderId.SuperSync && privateCfg) {
-            providerSpecificUpdate = {
-              superSync: privateCfg as any,
-              encryptKey: privateCfg.encryptKey || '',
-              // SuperSync stores isEncryptionEnabled in privateCfg, not globalCfg
-              isEncryptionEnabled: (privateCfg as any).isEncryptionEnabled || false,
-            };
-          } else if (newProvider === SyncProviderId.WebDAV && privateCfg) {
-            providerSpecificUpdate = {
-              webDav: privateCfg as any,
-              encryptKey: privateCfg.encryptKey || '',
-            };
-          } else if (newProvider === SyncProviderId.LocalFile && privateCfg) {
-            providerSpecificUpdate = {
-              localFileSync: privateCfg as any,
-              encryptKey: privateCfg.encryptKey || '',
-            };
-          } else if (newProvider === SyncProviderId.Nextcloud && privateCfg) {
-            providerSpecificUpdate = {
-              nextcloud: privateCfg as any,
-              encryptKey: privateCfg.encryptKey || '',
-            };
-          } else if (newProvider === SyncProviderId.Dropbox && privateCfg) {
-            providerSpecificUpdate = {
-              encryptKey: privateCfg.encryptKey || '',
-            };
-          } else if (newProvider === SyncProviderId.OneDrive && privateCfg) {
-            providerSpecificUpdate = {
-              oneDrive: privateCfg as any,
-              encryptKey: privateCfg.encryptKey || '',
-            };
-          }
-
-          // Update the model, preserving non-provider-specific fields
-          this._tmpUpdatedCfg = {
-            ...this._tmpUpdatedCfg,
-            ...providerSpecificUpdate,
-            syncProvider: newProvider,
-            // Preserve global settings (?? not || so explicit `false` is honoured)
-            isEnabled: this._tmpUpdatedCfg.isEnabled,
-            syncInterval: globalCfg?.syncInterval ?? this._tmpUpdatedCfg.syncInterval,
-            isManualSyncOnly:
-              globalCfg?.isManualSyncOnly ?? this._tmpUpdatedCfg.isManualSyncOnly,
-            isCompressionEnabled:
-              globalCfg?.isCompressionEnabled ?? this._tmpUpdatedCfg.isCompressionEnabled,
-          };
-
-          // For non-SuperSync providers, update encryption from global config
-          if (newProvider !== SyncProviderId.SuperSync) {
-            this._tmpUpdatedCfg = {
-              ...this._tmpUpdatedCfg,
-              isEncryptionEnabled: globalCfg?.isEncryptionEnabled ?? false,
-            };
-          }
+          this._providerConfigLoad = this._loadProviderConfig(providerId);
         });
     }, 0);
+  }
+
+  private async _loadProviderConfig(providerId: SyncProviderId): Promise<void> {
+    const loadId = ++this._providerConfigLoadId;
+    this._selectedProviderWasConfigured = false;
+
+    // Clear provider-owned encryption synchronously. Save waits for this load,
+    // but the immediate reset also prevents the previous provider's key from
+    // remaining in the Formly model while the new private config is loading.
+    Object.assign(this._tmpUpdatedCfg, {
+      syncProvider: providerId,
+      encryptKey: '',
+      isEncryptionEnabled: false,
+    });
+
+    const provider = await this._providerManager.getProviderById(providerId);
+    const privateCfg = provider ? await provider.privateCfg.load() : null;
+    const globalCfg = await firstValueFrom(this._globalConfigService.sync$);
+
+    // A later provider selection owns the form now. Never let an older async
+    // load restore stale credentials or encryption state.
+    if (loadId !== this._providerConfigLoadId) {
+      return;
+    }
+
+    this._selectedProviderWasConfigured = privateCfg !== null;
+    const encryptionCfg = privateCfg as {
+      encryptKey?: string;
+      isEncryptionEnabled?: boolean;
+    } | null;
+    const encryptKey = encryptionCfg?.encryptKey ?? '';
+    let providerSpecificUpdate: Partial<SyncConfig> = {
+      encryptKey,
+      isEncryptionEnabled:
+        providerId === SyncProviderId.SuperSync
+          ? (encryptionCfg?.isEncryptionEnabled ?? false)
+          : (encryptionCfg?.isEncryptionEnabled ?? !!encryptKey),
+    };
+
+    if (providerId === SyncProviderId.SuperSync && privateCfg) {
+      providerSpecificUpdate = {
+        ...providerSpecificUpdate,
+        superSync: privateCfg as SuperSyncPrivateCfg,
+      };
+    } else if (providerId === SyncProviderId.WebDAV && privateCfg) {
+      providerSpecificUpdate = {
+        ...providerSpecificUpdate,
+        webDav: privateCfg as WebdavPrivateCfg,
+      };
+    } else if (providerId === SyncProviderId.LocalFile && privateCfg) {
+      providerSpecificUpdate = {
+        ...providerSpecificUpdate,
+        localFileSync: privateCfg as LocalFileSyncPrivateCfg,
+      };
+    } else if (providerId === SyncProviderId.Nextcloud && privateCfg) {
+      providerSpecificUpdate = {
+        ...providerSpecificUpdate,
+        nextcloud: privateCfg as NextcloudPrivateCfg,
+      };
+    } else if (providerId === SyncProviderId.OneDrive && privateCfg) {
+      providerSpecificUpdate = {
+        ...providerSpecificUpdate,
+        oneDrive: privateCfg as OneDrivePrivateCfg,
+      };
+    }
+
+    Object.assign(this._tmpUpdatedCfg, providerSpecificUpdate, {
+      syncProvider: providerId,
+      // Preserve global settings (?? not || so explicit `false` is honoured)
+      isEnabled: this._tmpUpdatedCfg.isEnabled,
+      syncInterval: globalCfg.syncInterval ?? this._tmpUpdatedCfg.syncInterval,
+      isManualSyncOnly:
+        globalCfg.isManualSyncOnly ?? this._tmpUpdatedCfg.isManualSyncOnly,
+      isCompressionEnabled:
+        globalCfg.isCompressionEnabled ?? this._tmpUpdatedCfg.isCompressionEnabled,
+    });
+  }
+
+  private async _waitForCurrentProviderConfig(): Promise<void> {
+    let pendingLoad: Promise<void>;
+    do {
+      pendingLoad = this._providerConfigLoad;
+      await pendingLoad;
+    } while (pendingLoad !== this._providerConfigLoad);
   }
 
   close(): void {
@@ -599,6 +623,8 @@ export class DialogSyncCfgComponent implements AfterViewInit {
       return;
     }
 
+    await this._waitForCurrentProviderConfig();
+
     // Explicitly sync form values to _tmpUpdatedCfg in case modelChange didn't fire
     // This is especially important on Android WebView where change detection can be unreliable
     this._tmpUpdatedCfg = {
@@ -615,6 +641,14 @@ export class DialogSyncCfgComponent implements AfterViewInit {
     };
 
     const providerId = toSyncProviderId(this._tmpUpdatedCfg.syncProvider);
+    // Switching providers is a first setup only when the target has no stored
+    // private config. Returning providers must keep their existing encryption
+    // contract instead of being offered a new, incompatible key.
+    const isProviderSetup =
+      _isInitialSetup ||
+      (providerId !== this._initialProviderId && !this._selectedProviderWasConfigured);
+    let selectedProvider: Awaited<ReturnType<SyncProviderManager['getProviderById']>> =
+      undefined;
     if (providerId && this._tmpUpdatedCfg.isEnabled) {
       if (providerId === SyncProviderId.OneDrive) {
         await this._persistOneDriveFormCfgBeforeAuth(providerId);
@@ -626,10 +660,31 @@ export class DialogSyncCfgComponent implements AfterViewInit {
       // the auth dialog was cancelled or failed. Keep the dialog open so the
       // user can retry, and do not persist isEnabled:true with missing credentials
       // (which would trigger the "Sync credentials are missing" snack loop — issue #7131).
-      const provider = await this._providerManager.getProviderById(providerId);
-      if (provider?.getAuthHelper && !(await provider.isReady())) {
+      selectedProvider = await this._providerManager.getProviderById(providerId);
+      if (selectedProvider?.getAuthHelper && !(await selectedProvider.isReady())) {
         return;
       }
+    }
+
+    // The Formly value can briefly retain the previous provider's root-level
+    // encryption fields during a provider switch. The selected provider's
+    // private config is the authority, so re-derive both fields at the save
+    // boundary before any setup prompt or persistence occurs.
+    if (providerId) {
+      selectedProvider ??= await this._providerManager.getProviderById(providerId);
+      const privateCfg = selectedProvider?.privateCfg
+        ? await selectedProvider.privateCfg.load()
+        : null;
+      const encryptionCfg = privateCfg as {
+        encryptKey?: string;
+        isEncryptionEnabled?: boolean;
+      } | null;
+      const encryptKey = encryptionCfg?.encryptKey ?? '';
+      configToSave.encryptKey = encryptKey;
+      configToSave.isEncryptionEnabled =
+        providerId === SyncProviderId.SuperSync
+          ? (encryptionCfg?.isEncryptionEnabled ?? false)
+          : (encryptionCfg?.isEncryptionEnabled ?? !!encryptKey);
     }
 
     // File-based providers support OPTIONAL E2EE but (unlike SuperSync) have no
@@ -642,7 +697,7 @@ export class DialogSyncCfgComponent implements AfterViewInit {
     // snapshot-overwrite, no plaintext-upload window. Skipping keeps today's
     // unencrypted behavior. No network needed, so this also covers offline setup.
     if (
-      _isInitialSetup &&
+      isProviderSetup &&
       providerId &&
       isFileBasedProviderId(providerId) &&
       !configToSave.isEncryptionEnabled
@@ -662,7 +717,7 @@ export class DialogSyncCfgComponent implements AfterViewInit {
     // an offline save still needs the flag armed for whenever the setup sync finally
     // runs (else the prompt is silently skipped and the account syncs unencrypted).
     // Established/returning accounts are nudged by the calm migration banner instead.
-    if (_isInitialSetup && providerId === SyncProviderId.SuperSync) {
+    if (isProviderSetup && providerId === SyncProviderId.SuperSync) {
       this.syncWrapperService.markPromptEncryptionAfterSetupSync();
     }
 

--- a/src/app/imex/sync/import-encryption-handler.service.spec.ts
+++ b/src/app/imex/sync/import-encryption-handler.service.spec.ts
@@ -106,7 +106,7 @@ describe('ImportEncryptionHandlerService', () => {
       expect(result.importedEnabled).toBeTrue();
     });
 
-    it('should detect change from encrypted to unencrypted', async () => {
+    it('should not report disabling encryption because SuperSync requires it', async () => {
       // Current: encrypted
       (mockSyncProvider.privateCfg.load as jasmine.Spy).and.resolveTo({
         ...mockExistingCfg,
@@ -117,7 +117,7 @@ describe('ImportEncryptionHandlerService', () => {
 
       const result = await service.checkEncryptionStateChange(importedData);
 
-      expect(result.willChange).toBeTrue();
+      expect(result.willChange).toBeFalse();
       expect(result.currentEnabled).toBeTrue();
       expect(result.importedEnabled).toBeFalse();
     });

--- a/src/app/imex/sync/import-encryption-handler.service.ts
+++ b/src/app/imex/sync/import-encryption-handler.service.ts
@@ -92,8 +92,10 @@ export class ImportEncryptionHandlerService {
     const importedEnabled = importedSuperSync?.isEncryptionEnabled ?? false;
     const importedHasKey = !!importedSuperSync?.encryptKey;
 
-    // Encryption state changes if enabled state differs
-    const willChange = currentEnabled !== importedEnabled;
+    // SuperSync encryption is mandatory, so an import can enable encryption but
+    // can never disable it. Do not warn that encryption "will change" for a
+    // transition this service intentionally ignores below.
+    const willChange = !currentEnabled && importedEnabled;
 
     return {
       willChange,


### PR DESCRIPTION
## Summary

Two substantive changes (plus planning docs carried on the branch):

### 1. `fix(sync): isolate provider encryption settings`
Makes the selected provider's `privateCfg` the single authority for `encryptKey` / `isEncryptionEnabled`, re-derived on every provider switch (with a `loadId` race guard) and again at the save boundary. Prevents one provider's encryption key/state from leaking into another during a switch in the sync-config dialog.
- `willChange` narrowed to `!currentEnabled && importedEnabled` so the import warning is accurate (SuperSync encryption is mandatory; the disable path is already ignored downstream).
- Unit-verified: dialog spec 30/30, handler spec 15/15; both files lint-clean.

### 2. `test: enforce critical end-to-end coverage`
- Replaced vacuous global-search tests (assertions gated behind `if (isSearchOpen)`, wrong shortcut) with real ones using the correct `Shift+F`.
- New packaged-Electron **functional** smoke (task create + reload persistence) under xvfb, now on every PR.
- Un-skipped several SuperSync tests whose blockers are believed resolved (clean-server-state, import-sync, legacy-migration archive).
- CI: WebDAV now starts in every SuperSync shard so provider-switch scenarios run instead of skipping; `E2E_REQUIRE_WEBDAV` gate throws instead of skipping; deterministic sync waits replace `waitForTimeout`.
- Fixed a real CI bug: `Stop Docker Services` (`always()`) ran **before** `Print Docker Logs on Failure`, so failure logs were captured after teardown.

## Validation
- Full SuperSync+WebDAV suite dispatched via `E2E Tests (Scheduled)` (`grep=@import`) to confirm the un-skipped clean-server-state + import-sync tests are green.
- ⚠️ The `@import` grep does **not** cover the `legacy-migration` archive un-skip — run `grep=@supersync` before merge to validate that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)