### PR TITLE
fix(sync): write split-compaction snapshots to immutable files (#9040)

### DIFF
--- a/packages/sync-providers/src/file-based-sync-data.ts
+++ b/packages/sync-providers/src/file-based-sync-data.ts
@@ -97,6 +97,16 @@ export interface FileBasedSnapshotRef {
   vectorClock: VectorClock;
   /** Optional provider rev of the referenced snapshot file (best-effort). */
   rev?: string;
+  /**
+   * #9040: generation+client-unique, immutable snapshot filename this ops file
+   * was built against (e.g. `sync-state__7__clientA.json`). Present on ops files
+   * written by post-#9040 clients. Readers MUST prefer it over the fixed
+   * `sync-state.json`: a concurrent compactor force-writes its own snapshot to a
+   * DIFFERENT immutable file, so the winning ops pointer can never be stranded by
+   * a clobbered `sync-state.json`. Optional for backward compatibility — when
+   * absent (older ops files), readers fall back to `sync-state.json`/`.bak`.
+   */
+  file?: string;
 }
 
 /**
@@ -181,6 +191,11 @@ export const FILE_BASED_SYNC_CONSTANTS = {
   // old and new clients must agree on these names forever.
   OPS_BACKUP_FILE: 'sync-ops.json.bak',
   STATE_BACKUP_FILE: 'sync-state.json.bak',
+  // #9040: prefix for the generation+client-unique immutable snapshot files
+  // (`sync-state__<syncVersion>__<clientId>.json`). Distinct from the fixed
+  // `sync-state.json` (no `__`) so the two never collide. Remote-format surface:
+  // old and new clients must keep this stable forever.
+  STATE_GEN_FILE_PREFIX: 'sync-state__',
   SPLIT_FILE_VERSION: 3 as const,
   // Post-compaction RETAINED size for the split ops file (≈ MAX_RECENT_OPS/2).
   // NOTE: this is the trim target, NOT the trigger — a recompaction fires when the

--- a/packages/sync-providers/src/file-based-sync-data.ts
+++ b/packages/sync-providers/src/file-based-sync-data.ts
@@ -98,13 +98,13 @@ export interface FileBasedSnapshotRef {
   /** Optional provider rev of the referenced snapshot file (best-effort). */
   rev?: string;
   /**
-   * #9040: generation+client-unique, immutable snapshot filename this ops file
-   * was built against (e.g. `sync-state__7__clientA.json`). Present on ops files
-   * written by post-#9040 clients. Readers MUST prefer it over the fixed
-   * `sync-state.json`: a concurrent compactor force-writes its own snapshot to a
-   * DIFFERENT immutable file, so the winning ops pointer can never be stranded by
-   * a clobbered `sync-state.json`. Optional for backward compatibility — when
-   * absent (older ops files), readers fall back to `sync-state.json`/`.bak`.
+   * #9040: immutable, per-compaction snapshot filename this ops file was built
+   * against (e.g. `sync-state__7__9f3a1c8b0d2e4f6a.json` — `<syncVersion>__<random>`).
+   * Present on ops files written by post-#9040 clients. Readers MUST prefer it over
+   * the fixed `sync-state.json`: a concurrent compactor force-writes its own
+   * snapshot to a DIFFERENT immutable file, so the winning ops pointer can never be
+   * stranded by a clobbered `sync-state.json`. Optional for backward compatibility
+   * — when absent (older ops files), readers fall back to `sync-state.json`/`.bak`.
    */
   file?: string;
 }
@@ -191,8 +191,8 @@ export const FILE_BASED_SYNC_CONSTANTS = {
   // old and new clients must agree on these names forever.
   OPS_BACKUP_FILE: 'sync-ops.json.bak',
   STATE_BACKUP_FILE: 'sync-state.json.bak',
-  // #9040: prefix for the generation+client-unique immutable snapshot files
-  // (`sync-state__<syncVersion>__<clientId>.json`). Distinct from the fixed
+  // #9040: prefix for the immutable per-compaction snapshot files
+  // (`sync-state__<syncVersion>__<random>.json`). Distinct from the fixed
   // `sync-state.json` (no `__`) so the two never collide. Remote-format surface:
   // old and new clients must keep this stable forever.
   STATE_GEN_FILE_PREFIX: 'sync-state__',

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -3376,6 +3376,83 @@ describe('FileBasedSyncAdapterService', () => {
       expect(res.snapshotState).toBeUndefined();
     });
 
+    // #9040: an ops file with snapshotRef.file reads the immutable snapshot in
+    // PREFERENCE to the fixed sync-state.json (which a concurrent compactor may
+    // have clobbered with a different generation).
+    it('#9040 prefers the immutable snapshotRef.file over the fixed sync-state.json', async () => {
+      const clock = { client1: 5 };
+      const opsFile = makeOpsFile({
+        syncVersion: 5,
+        recentOps: [makeCompactOp()],
+        snapshotRef: {
+          syncVersion: 5,
+          vectorClock: clock,
+          rev: 'sr5',
+          file: 'sync-state__5__client1.json',
+        },
+      });
+      routeDownloads({
+        [C.OPS_FILE]: addPrefix(opsFile, 3),
+        ['sync-state__5__client1.json']: addPrefix(
+          makeStateFile({
+            syncVersion: 5,
+            vectorClock: clock,
+            state: { tasks: ['from-immutable'] },
+          }),
+          3,
+        ),
+        // A concurrent compactor clobbered the fixed file with another generation.
+        [C.STATE_FILE]: addPrefix(
+          makeStateFile({
+            syncVersion: 5,
+            vectorClock: { client2: 5 },
+            state: { tasks: ['clobbered'] },
+          }),
+          3,
+        ),
+      });
+
+      const res = await adapter.downloadOps(0, 'client2');
+
+      expect(res.gapDetected).toBeFalsy();
+      expect((res.snapshotState as { tasks: string[] }).tasks).toEqual([
+        'from-immutable',
+      ]);
+    });
+
+    // #9040: when the immutable snapshot is missing (e.g. an over-eager GC or a
+    // provider hiccup), fall back to the dual-written fixed sync-state.json.
+    it('#9040 falls back to sync-state.json when the immutable snapshot is missing', async () => {
+      const clock = { client1: 5 };
+      const opsFile = makeOpsFile({
+        syncVersion: 5,
+        recentOps: [makeCompactOp()],
+        snapshotRef: {
+          syncVersion: 5,
+          vectorClock: clock,
+          rev: 'sr5',
+          file: 'sync-state__5__client1.json',
+        },
+      });
+      routeDownloads({
+        [C.OPS_FILE]: addPrefix(opsFile, 3),
+        // Immutable file absent (404) → fall back to the fixed compat snapshot.
+        [C.STATE_FILE]: addPrefix(
+          makeStateFile({
+            syncVersion: 5,
+            vectorClock: clock,
+            state: { tasks: ['from-compat'] },
+          }),
+          3,
+        ),
+      });
+
+      const res = await adapter.downloadOps(0, 'client2');
+
+      expect(res.gapDetected).toBeFalsy();
+      expect((res.snapshotState as { tasks: string[] }).tasks).toEqual(['from-compat']);
+    });
+
     // (e) legacy v2 sync-data.json migrates in place: state+ops written, tombstone
     // over sync-data.json, .bak neutralized, sync-data.json NOT removed.
     it('(e) migrates legacy v2 sync-data.json to split format with a v3 tombstone', async () => {

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -2163,12 +2163,18 @@ export class FileBasedSyncAdapterService {
         opsRev,
       ));
     } catch (e) {
-      // #9040: our ops never committed — a concurrent compactor won the ops race.
-      // The immutable snapshot we wrote this compaction is now an orphan no
-      // committed ops file references, so reclaim it before bubbling up. (Only
-      // when we compacted; otherwise snapshotRef.file is the still-referenced
-      // predecessor and must NOT be deleted.)
-      if (needsCompaction && snapshotRef.file) {
+      // #9040: reclaim the immutable snapshot we just wrote — but ONLY on a
+      // confirmed rev-mismatch rejection, which proves the server refused our ops
+      // PUT, so a concurrent compactor won and our snapshot is a true orphan. Any
+      // other error (network/5xx) is AMBIGUOUS: the PUT may have landed and
+      // committed, in which case the snapshot is still referenced and MUST survive
+      // (readers would otherwise strand on it). Deleting only applies when we
+      // compacted; otherwise snapshotRef.file is the still-referenced predecessor.
+      if (
+        e instanceof UploadRevToMatchMismatchAPIError &&
+        needsCompaction &&
+        snapshotRef.file
+      ) {
         await this._removeGenStateFile(provider, snapshotRef.file);
       }
       throw e;

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -1445,13 +1445,21 @@ export class FileBasedSyncAdapterService {
   }
 
   /**
-   * Builds the generation+client-unique immutable snapshot filename (#9040).
-   * `clientId` is sanitized to path-safe characters; `syncVersion` + `clientId`
-   * together guarantee two concurrent compactors never target the same file.
+   * Builds the immutable snapshot filename for a compaction (#9040):
+   * `sync-state__<syncVersion>__<random>.json`. The random suffix (not the
+   * clientId) makes two concurrent compactors target different files without
+   * leaking device identity — filenames are NOT encrypted, so an opaque suffix
+   * keeps device count/platform private from the remote for E2EE users. A
+   * collision is astronomically unlikely and self-heals anyway: the reader
+   * validates loaded content against `snapshotRef` (clock EQUAL), so a wrong
+   * file fails validation and falls back to `sync-state.json`/`.bak`. `syncVersion`
+   * stays in the name for legible ordering and a future `listFiles`-prune.
    */
-  private _genStateFileName(syncVersion: number, clientId: string): string {
-    const safeClientId = clientId.replace(/[^A-Za-z0-9_-]/g, '_');
-    return `${FILE_BASED_SYNC_CONSTANTS.STATE_GEN_FILE_PREFIX}${syncVersion}__${safeClientId}.json`;
+  private _genStateFileName(syncVersion: number): string {
+    const bytes = new Uint8Array(8);
+    crypto.getRandomValues(bytes);
+    const random = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${FILE_BASED_SYNC_CONSTANTS.STATE_GEN_FILE_PREFIX}${syncVersion}__${random}.json`;
   }
 
   /**
@@ -2083,12 +2091,11 @@ export class FileBasedSyncAdapterService {
         schemaVersion,
         localStateSnapshot,
       );
-      // #9040: write the snapshot to a generation+client-unique IMMUTABLE file
-      // first. This is the snapshot the ops pointer references; because its name
-      // is unique per (syncVersion, clientId), a concurrent compactor writes a
-      // DIFFERENT file and can never clobber it, so the winning ops pointer can
-      // never be stranded.
-      const genStateFile = this._genStateFileName(newSyncVersion, clientId);
+      // #9040: write the snapshot to an IMMUTABLE, per-compaction file first. This
+      // is the snapshot the ops pointer references; because its name carries a
+      // random suffix, a concurrent compactor writes a DIFFERENT file and can never
+      // clobber it, so the winning ops pointer can never be stranded.
+      const genStateFile = this._genStateFileName(newSyncVersion);
       const stateRev = await this._writeStateFile(
         provider,
         cfg,

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -1455,31 +1455,28 @@ export class FileBasedSyncAdapterService {
   }
 
   /**
-   * Best-effort deletion of the immutable snapshot the PRE-compaction ops file
-   * referenced (#9040). Keeps the steady state at ~one immutable snapshot: every
-   * successful compaction supersedes the previous one, deleted here in O(1).
+   * Best-effort deletion of a generation-specific immutable snapshot file (#9040).
+   * Non-fatal — an undeleted snapshot only wastes remote space. Two call sites:
+   *   - after a successful compaction: reclaim the PREVIOUS generation's snapshot
+   *     (keeps the steady state at ~one immutable file), and
+   *   - when a compaction fails to commit: reclaim the snapshot THIS compaction
+   *     just wrote, which is now an orphan no committed ops file references (the
+   *     concurrent-compaction case that would otherwise leak).
    *
-   * shortcut: a losing concurrent compactor's same-generation snapshot is an
-   * orphan no committed ops file ever references, so it is never a future
-   * predecessor and leaks. That only happens on the rare concurrent-compaction
-   * race; upgrade path if it ever matters — an opportunistic `listFiles` prune of
-   * `STATE_GEN_FILE_PREFIX` files with a stale syncVersion (listFiles is optional
-   * on the provider interface, so it must stay capability-gated).
+   * Residual: a crash between the snapshot write and either commit or this cleanup
+   * still leaks (rare crash window). Upgrade path if it ever matters — an
+   * opportunistic `listFiles` prune of `STATE_GEN_FILE_PREFIX` files with a stale
+   * syncVersion (listFiles is optional on the provider interface, so it must stay
+   * capability-gated).
    */
-  private async _gcSupersededGenStateFile(
+  private async _removeGenStateFile(
     provider: FileSyncProvider<SyncProviderId>,
-    previousFile: string | undefined,
-    newFile: string,
+    file: string,
   ): Promise<void> {
-    if (!previousFile || previousFile === newFile) return;
     try {
-      await provider.removeFile(previousFile);
+      await provider.removeFile(file);
     } catch (e) {
-      // Non-fatal: an orphaned snapshot only wastes remote space.
-      OpLog.normal(
-        `FileBasedSyncAdapter: superseded snapshot cleanup skipped (non-fatal)`,
-        e,
-      );
+      OpLog.normal('FileBasedSyncAdapter: snapshot cleanup skipped (non-fatal)', e);
     }
   }
 
@@ -2156,24 +2153,38 @@ export class FileBasedSyncAdapterService {
     }
 
     // Commit point.
-    const { finalRev } = await this._uploadOpsFileWithMismatchFallback(
-      provider,
-      cfg,
-      encryptKey,
-      newOpsFile,
-      opsRev,
-    );
+    let finalRev: string;
+    try {
+      ({ finalRev } = await this._uploadOpsFileWithMismatchFallback(
+        provider,
+        cfg,
+        encryptKey,
+        newOpsFile,
+        opsRev,
+      ));
+    } catch (e) {
+      // #9040: our ops never committed — a concurrent compactor won the ops race.
+      // The immutable snapshot we wrote this compaction is now an orphan no
+      // committed ops file references, so reclaim it before bubbling up. (Only
+      // when we compacted; otherwise snapshotRef.file is the still-referenced
+      // predecessor and must NOT be deleted.)
+      if (needsCompaction && snapshotRef.file) {
+        await this._removeGenStateFile(provider, snapshotRef.file);
+      }
+      throw e;
+    }
 
     // #9040: after the commit succeeds, reclaim the immutable snapshot the
     // superseded ops file referenced (no-op unless this sync compacted). Runs
     // post-commit so a concurrent reader of the OLD ops file still finds its
     // snapshot until it too advances.
-    if (needsCompaction) {
-      await this._gcSupersededGenStateFile(
-        provider,
-        opsFile?.snapshotRef?.file,
-        snapshotRef.file as string,
-      );
+    const previousGenStateFile = opsFile?.snapshotRef?.file;
+    if (
+      needsCompaction &&
+      previousGenStateFile &&
+      previousGenStateFile !== snapshotRef.file
+    ) {
+      await this._removeGenStateFile(provider, previousGenStateFile);
     }
 
     this._clearCachedOpsData(providerKey);

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -1387,13 +1387,18 @@ export class FileBasedSyncAdapterService {
     }
   }
 
-  /** Downloads + decodes `sync-state.json` and validates its version. */
+  /**
+   * Downloads + decodes a snapshot file and validates its version. Defaults to
+   * the fixed `sync-state.json`; pass a generation-specific name (#9040) to read
+   * the immutable snapshot referenced by an ops file's `snapshotRef.file`.
+   */
   private async _downloadStateFile(
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
+    path: string = FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
   ): Promise<{ data: FileBasedStateFile; rev: string }> {
-    const response = await provider.downloadFile(FILE_BASED_SYNC_CONSTANTS.STATE_FILE);
+    const response = await provider.downloadFile(path);
     const data =
       await this._encryptAndCompressHandler.decompressAndDecryptData<FileBasedStateFile>(
         cfg,
@@ -1403,22 +1408,30 @@ export class FileBasedSyncAdapterService {
     if (data.version !== FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION) {
       throw new SyncDataCorruptedError(
         `Unsupported state-file version: ${data.version} (expected ${FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION})`,
-        FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
+        path,
       );
     }
     return { data, rev: response.rev };
   }
 
   /**
-   * Writes `sync-state.json`. Force-overwrite: the ops file (commit point) is the
-   * concurrency gate, and readers only trust a snapshot the ops file's snapshotRef
-   * validates against. Returns the written rev for the snapshotRef pointer.
+   * Writes a snapshot file (default `sync-state.json`). Force-overwrite: the ops
+   * file (commit point) is the concurrency gate, and readers only trust a snapshot
+   * the ops file's snapshotRef validates against. Returns the written rev for the
+   * snapshotRef pointer.
+   *
+   * #9040: pass a generation+client-unique `path` to write the immutable snapshot.
+   * Force-overwrite is safe there because the name is unique per (syncVersion,
+   * clientId) — no concurrent compactor targets the same file, so nothing clobbers
+   * it. The fixed `sync-state.json` remains clobberable and is written only for
+   * pre-#9040 clients that don't read `snapshotRef.file`.
    */
   private async _writeStateFile(
     provider: FileSyncProvider<SyncProviderId>,
     cfg: EncryptAndCompressCfg,
     encryptKey: string | undefined,
     data: FileBasedStateFile,
+    path: string = FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
   ): Promise<string> {
     const uploadData = await this._encryptAndCompressHandler.compressAndEncryptData(
       cfg,
@@ -1427,13 +1440,47 @@ export class FileBasedSyncAdapterService {
       FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
     );
     this._assertUploadDataNotEmpty(uploadData, 'FileBasedSyncAdapter._writeStateFile');
-    const res = await provider.uploadFile(
-      FILE_BASED_SYNC_CONSTANTS.STATE_FILE,
-      uploadData,
-      null,
-      true,
-    );
+    const res = await provider.uploadFile(path, uploadData, null, true);
     return res.rev;
+  }
+
+  /**
+   * Builds the generation+client-unique immutable snapshot filename (#9040).
+   * `clientId` is sanitized to path-safe characters; `syncVersion` + `clientId`
+   * together guarantee two concurrent compactors never target the same file.
+   */
+  private _genStateFileName(syncVersion: number, clientId: string): string {
+    const safeClientId = clientId.replace(/[^A-Za-z0-9_-]/g, '_');
+    return `${FILE_BASED_SYNC_CONSTANTS.STATE_GEN_FILE_PREFIX}${syncVersion}__${safeClientId}.json`;
+  }
+
+  /**
+   * Best-effort deletion of the immutable snapshot the PRE-compaction ops file
+   * referenced (#9040). Keeps the steady state at ~one immutable snapshot: every
+   * successful compaction supersedes the previous one, deleted here in O(1).
+   *
+   * shortcut: a losing concurrent compactor's same-generation snapshot is an
+   * orphan no committed ops file ever references, so it is never a future
+   * predecessor and leaks. That only happens on the rare concurrent-compaction
+   * race; upgrade path if it ever matters — an opportunistic `listFiles` prune of
+   * `STATE_GEN_FILE_PREFIX` files with a stale syncVersion (listFiles is optional
+   * on the provider interface, so it must stay capability-gated).
+   */
+  private async _gcSupersededGenStateFile(
+    provider: FileSyncProvider<SyncProviderId>,
+    previousFile: string | undefined,
+    newFile: string,
+  ): Promise<void> {
+    if (!previousFile || previousFile === newFile) return;
+    try {
+      await provider.removeFile(previousFile);
+    } catch (e) {
+      // Non-fatal: an orphaned snapshot only wastes remote space.
+      OpLog.normal(
+        `FileBasedSyncAdapter: superseded snapshot cleanup skipped (non-fatal)`,
+        e,
+      );
+    }
   }
 
   /** Copies the current `sync-state.json` to its `.bak` (non-fatal). */
@@ -1489,8 +1536,15 @@ export class FileBasedSyncAdapterService {
 
   /**
    * Loads the snapshot referenced by `opsFile.snapshotRef`, validating it against
-   * the ref. On mismatch (e.g. a crash between the state and ops writes left a
-   * newer, unreferenced `sync-state.json`), falls back to `sync-state.json.bak`.
+   * the ref. Resolution order:
+   *   1. #9040: `snapshotRef.file` — the immutable, generation+client-unique
+   *      snapshot. A committed ops file's referenced immutable file is never
+   *      clobbered by a concurrent compactor, so this is the authoritative source
+   *      for post-#9040 ops files.
+   *   2. `sync-state.json` — the fixed compat snapshot (older ops files with no
+   *      `snapshotRef.file`, or defensive fallback).
+   *   3. `sync-state.json.bak` — the crash-window backup (e.g. a crash between the
+   *      state and ops writes left a newer, unreferenced `sync-state.json`).
    * Returns null when no snapshot validates the ref (caller signals a gap).
    */
   private async _loadValidatedSnapshot(
@@ -1499,6 +1553,26 @@ export class FileBasedSyncAdapterService {
     encryptKey: string | undefined,
     opsFile: FileBasedOpsFile,
   ): Promise<FileBasedStateFile | null> {
+    const genFile = opsFile.snapshotRef.file;
+    if (genFile) {
+      try {
+        const { data } = await this._downloadStateFile(
+          provider,
+          cfg,
+          encryptKey,
+          genFile,
+        );
+        if (this._validateSnapshotRef(opsFile, data)) return data;
+        OpLog.warn(
+          'FileBasedSyncAdapter: immutable snapshot does not match snapshotRef; trying sync-state.json',
+        );
+      } catch (e) {
+        OpLog.warn(
+          'FileBasedSyncAdapter: immutable snapshot unreadable; trying sync-state.json',
+          e,
+        );
+      }
+    }
     try {
       const { data } = await this._downloadStateFile(provider, cfg, encryptKey);
       if (this._validateSnapshotRef(opsFile, data)) return data;
@@ -2012,14 +2086,30 @@ export class FileBasedSyncAdapterService {
         schemaVersion,
         localStateSnapshot,
       );
-      // Preserve the pre-compaction snapshot for snapshotRef-mismatch recovery.
+      // #9040: write the snapshot to a generation+client-unique IMMUTABLE file
+      // first. This is the snapshot the ops pointer references; because its name
+      // is unique per (syncVersion, clientId), a concurrent compactor writes a
+      // DIFFERENT file and can never clobber it, so the winning ops pointer can
+      // never be stranded.
+      const genStateFile = this._genStateFileName(newSyncVersion, clientId);
+      const stateRev = await this._writeStateFile(
+        provider,
+        cfg,
+        encryptKey,
+        stateData,
+        genStateFile,
+      );
+      // Compat: also refresh the fixed sync-state.json (+ its .bak) so pre-#9040
+      // split clients — which don't read snapshotRef.file — can still hydrate.
+      // This copy stays clobberable, but pre-#9040 clients already carried that
+      // exposure, so it is no regression; post-#9040 clients use snapshotRef.file.
       await this._backupStateFile(provider, cfg, encryptKey);
-      // Atomicity: sync-state.json FIRST, then the ops file that references it.
-      const stateRev = await this._writeStateFile(provider, cfg, encryptKey, stateData);
+      await this._writeStateFile(provider, cfg, encryptKey, stateData);
       snapshotRef = {
         syncVersion: newSyncVersion,
         vectorClock: mergedClock,
         rev: stateRev,
+        file: genStateFile,
       };
       finalOps = combinedOps.slice(-FILE_BASED_SYNC_CONSTANTS.SPLIT_COMPACTION_THRESHOLD);
       OpLog.normal(
@@ -2073,6 +2163,18 @@ export class FileBasedSyncAdapterService {
       newOpsFile,
       opsRev,
     );
+
+    // #9040: after the commit succeeds, reclaim the immutable snapshot the
+    // superseded ops file referenced (no-op unless this sync compacted). Runs
+    // post-commit so a concurrent reader of the OLD ops file still finds its
+    // snapshot until it too advances.
+    if (needsCompaction) {
+      await this._gcSupersededGenStateFile(
+        provider,
+        opsFile?.snapshotRef?.file,
+        snapshotRef.file as string,
+      );
+    }
 
     this._clearCachedOpsData(providerKey);
     this._expectedSyncVersions.set(providerKey, newSyncVersion);

--- a/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
@@ -125,9 +125,11 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
     );
 
     // The winner's immutable snapshot (syncVersion 3) survives the loser's clobber,
-    // and the superseded predecessor (seed's syncVersion 1) was garbage-collected.
+    // the superseded predecessor (seed's syncVersion 1) was garbage-collected, and
+    // the loser cleaned up its own orphaned snapshot on its failed commit.
     expect(provider.hasFile('sync-state__3__winner-client.json')).toBe(true);
     expect(provider.hasFile('sync-state__1__seed-client.json')).toBe(false);
+    expect(provider.hasFile('sync-state__3__loser-client.json')).toBe(false);
 
     const download = await downloadFresh();
     expect(download.gapDetected).toBeFalsy();
@@ -176,7 +178,9 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
     const download = await downloadFresh();
     expect(download.gapDetected).toBeFalsy();
     expect(download.snapshotState).toBeDefined();
-    // The winner's immutable snapshot (syncVersion 1) survives the loser's clobber.
+    // The winner's immutable snapshot (syncVersion 1) survives the loser's clobber,
+    // and the loser cleaned up its own orphan on its failed commit.
     expect(provider.hasFile('sync-state__1__winner-client.json')).toBe(true);
+    expect(provider.hasFile('sync-state__1__loser-client.json')).toBe(false);
   });
 });

--- a/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
@@ -1,42 +1,34 @@
-import { FileBasedSyncTestHarness } from '../helpers/file-based-sync-test-harness';
+import {
+  FileBasedSyncTestHarness,
+  HarnessClient,
+} from '../helpers/file-based-sync-test-harness';
 import { FILE_BASED_SYNC_CONSTANTS } from '../../../sync-providers/file-based/file-based-sync.types';
 import {
-  FileRevResponse,
   FileSnapshotOpDownloadResponse,
   SyncOperation,
 } from '../../../sync-providers/provider.interface';
 import { UploadRevToMatchMismatchAPIError } from '../../../core/errors/sync-errors';
 
 /**
- * Regression coverage for issue #9040: split-file compaction can strand the ops
- * pointer at a snapshot that survives in neither the primary snapshot file nor
- * its backup.
+ * Regression coverage for issue #9040: split-file compaction must not strand the
+ * ops pointer at a snapshot that no concurrent-safe file preserves.
  *
  * ## The race (file-based providers have NO cross-device lock)
  *
- * `_uploadOpsSplit` commits a compaction in three provider writes:
- *   1. `sync-state.json.bak`  ← copy of the CURRENT snapshot (reads live state)
- *   2. `sync-state.json`      ← the NEW snapshot, FORCE-written (revToMatch=null)
- *   3. `sync-ops.json`        ← the commit point, CONDITIONAL on the ops rev
+ * `_uploadOpsSplit` writes the snapshot, then commits `sync-ops.json` conditionally
+ * (the single-winner gate). Before #9040 the snapshot went to the FIXED
+ * `sync-state.json` via an unconditional force-write, so the LOSER of the ops race
+ * could still clobber the WINNER's snapshot, leaving the winning ops pointer
+ * referencing a snapshot absent from both `sync-state.json` and its `.bak` → an
+ * unrecoverable gap for a fresh client.
  *
- * Only write 3 is gated, so the ops file has a single winner. But write 2 is an
- * unconditional last-writer-wins force-write, so the LOSER of the ops race can
- * still clobber the WINNER's snapshot. When the loser's backup (write 1) ran
- * before the winner's snapshot write, `.bak` holds an older, unrelated snapshot
- * — so the winning ops file ends up referencing a snapshot present in neither
- * `sync-state.json` nor `sync-state.json.bak`.
+ * ## The fix
  *
- * Interleave reproduced below (winner A, loser B; initial snapshot S0, ops rev R0):
- *   B.bak(read S0 → write S0)  →  A.state(SA)  →  A.ops(commit, R0→RA)
- *     →  B.state(SB, clobbers SA)  →  B.ops(PUT vs R0 → mismatch, B aborts)
- *   Final: sync-state.json = SB, .bak = S0, sync-ops.json → SA (in neither).
- *
- * A fresh client that then hydrates from seq 0 cannot validate the referenced
- * snapshot against `sync-state.json` (SB) or `.bak` (S0), so it reports an
- * unrecoverable gap. This test asserts the fresh client CAN still hydrate — it
- * FAILS today (stranded pointer) and should PASS once the snapshot is written
- * under a generation-unique, immutable name that a concurrent compaction cannot
- * clobber.
+ * The snapshot is now written to a generation+client-unique IMMUTABLE file
+ * (`sync-state__<syncVersion>__<clientId>.json`) recorded in `snapshotRef.file`. A
+ * concurrent compactor writes a DIFFERENT immutable file, so it can never clobber
+ * the winner's referenced snapshot. These tests assert a fresh client always
+ * hydrates the committed generation regardless of interleave.
  */
 describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', () => {
   const C = FILE_BASED_SYNC_CONSTANTS;
@@ -50,110 +42,141 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
     harness.reset();
   });
 
-  it('a losing concurrent compaction must not strand the winner’s ops pointer', async () => {
-    const provider = harness.getProvider();
+  const addTaskOp = (client: HarnessClient, id: string): SyncOperation =>
+    client.createOp('Task', id, 'CRT', 'TaskActionTypes.ADD_TASK', { title: id });
 
-    // --- Arrange: a compacted folder whose ops buffer sits EXACTLY at the cap,
-    // so the next single-op sync from any client triggers a fresh compaction
-    // (needsCompaction = combinedOps.length > MAX_RECENT_OPS). This is the only
-    // path where the conditional ops PUT uses a real rev, giving a single winner
-    // — the fresh/first-sync path uses revToMatch=null and has no gate. ---
+  /**
+   * Seeds a compacted folder whose ops buffer sits EXACTLY at the cap, so the next
+   * single-op sync from any client triggers a fresh compaction
+   * (needsCompaction = combinedOps.length > MAX_RECENT_OPS) using a real ops rev —
+   * the only path where the conditional ops PUT yields a single winner.
+   */
+  const seedFolderAtCap = async (): Promise<void> => {
     const seed = harness.createClient('seed-client');
-    await seed.uploadOps([
-      seed.createOp('Task', 'seed-0', 'CRT', 'TaskActionTypes.ADD_TASK', {
-        title: 'seed',
-      }),
-    ]);
+    await seed.uploadOps([addTaskOp(seed, 'seed-0')]);
     const fill: SyncOperation[] = [];
     for (let i = 0; i < C.MAX_RECENT_OPS - 1; i++) {
-      fill.push(
-        seed.createOp('Task', `fill-${i}`, 'CRT', 'TaskActionTypes.ADD_TASK', {
-          title: `fill-${i}`,
-        }),
-      );
+      fill.push(addTaskOp(seed, `fill-${i}`));
     }
     // Op-only sync (combined = 1 + (MAX_RECENT_OPS - 1) = MAX_RECENT_OPS, NOT
     // greater, so no compaction): the buffer now sits precisely at the cap.
     await seed.uploadOps(fill);
+  };
 
-    // Control: the seeded folder is healthy and fully hydratable BEFORE the race,
-    // so a gap after it is attributable to the concurrent compaction, not setup.
-    const probe = harness.createClient('probe-client');
-    const probeDownload = (await probe.downloadOps(0)) as FileSnapshotOpDownloadResponse;
-    expect(probeDownload.gapDetected).toBeFalsy();
-    expect(probeDownload.snapshotState).toBeDefined();
+  /**
+   * Spies the shared provider so the FIRST `uploadFile` whose (path, isForce)
+   * matches `match` parks BEFORE executing, until the returned `release` fires.
+   * Lets a test drive a deterministic interleave of two concurrent compactions.
+   */
+  const gateFirstUpload = (
+    match: (path: string, isForce: boolean) => boolean,
+  ): { atGate: Promise<void>; release: () => void } => {
+    let release: () => void = () => {};
+    const released = new Promise<void>((r) => (release = r));
+    let reached: () => void = () => {};
+    const atGate = new Promise<void>((r) => (reached = r));
+    let armed = true;
 
-    // --- Deterministically interleave two concurrent compactions via a gate on
-    // the FIRST sync-state.json.bak write (the loser B's backup). B parks there,
-    // A runs to completion, then B resumes to clobber + lose the ops race. ---
-    let releaseLoser: () => void = () => {};
-    const loserReleased = new Promise<void>((r) => (releaseLoser = r));
-    let loserAtGate: () => void = () => {};
-    const loserReachedGate = new Promise<void>((r) => (loserAtGate = r));
-    let stateBakWrites = 0;
-
+    const provider = harness.getProvider();
     const realUploadFile = provider.uploadFile.bind(provider);
     spyOn(provider, 'uploadFile').and.callFake(
-      async (
-        path: string,
-        data: string,
-        revToMatch: string | null,
-        isForceOverwrite?: boolean,
-      ): Promise<FileRevResponse> => {
-        const res = await realUploadFile(path, data, revToMatch, isForceOverwrite);
-        if (path === C.STATE_BACKUP_FILE) {
-          stateBakWrites += 1;
-          // Pause the loser after its backup captured the OLD snapshot (S0),
-          // before it (or the winner) writes a new sync-state.json.
-          if (stateBakWrites === 1) {
-            loserAtGate();
-            await loserReleased;
-          }
+      async (path: string, data: string, rev: string | null, isForce?: boolean) => {
+        if (armed && match(path, !!isForce)) {
+          armed = false;
+          reached();
+          await released;
         }
-        return res;
+        return realUploadFile(path, data, rev, isForce);
       },
     );
+    return { atGate, release };
+  };
 
+  const downloadFresh = async (): Promise<FileSnapshotOpDownloadResponse> => {
+    const fresh = harness.createClient('fresh-client');
+    return (await fresh.downloadOps(0)) as FileSnapshotOpDownloadResponse;
+  };
+
+  it('harmful interleave: loser clobbers sync-state.json but cannot strand the immutable snapshot', async () => {
+    const provider = harness.getProvider();
+    await seedFolderAtCap();
+
+    // Control: the seeded folder is healthy and fully hydratable BEFORE the race,
+    // so any later gap is attributable to the concurrent compaction, not setup.
+    const probe = (await harness
+      .createClient('probe-client')
+      .downloadOps(0)) as FileSnapshotOpDownloadResponse;
+    expect(probe.gapDetected).toBeFalsy();
+    expect(probe.snapshotState).toBeDefined();
+
+    // Park the loser at its sync-state.json.bak write — its backup has already read
+    // the OLD snapshot, so `.bak` will hold a stale generation. Then run the winner
+    // to completion and resume the loser to clobber + lose the ops race.
+    const { atGate, release } = gateFirstUpload((path) => path === C.STATE_BACKUP_FILE);
     const winner = harness.createClient('winner-client');
     const loser = harness.createClient('loser-client');
 
-    // Start the loser first; it parks after backing up the current snapshot.
-    const loserPromise = loser.uploadOps([
-      loser.createOp('Task', 'loser-op', 'CRT', 'TaskActionTypes.ADD_TASK', {
-        title: 'loser',
-      }),
-    ]);
-    await loserReachedGate;
-
-    // Winner compacts fully while the loser is parked: writes its snapshot and
-    // wins the conditional ops commit (loser has not touched the ops file yet).
-    await winner.uploadOps([
-      winner.createOp('Task', 'winner-op', 'CRT', 'TaskActionTypes.ADD_TASK', {
-        title: 'winner',
-      }),
-    ]);
-
-    // Resume the loser: it force-overwrites sync-state.json (clobbering the
-    // winner's snapshot), then loses the conditional ops PUT and aborts.
-    releaseLoser();
+    const loserPromise = loser.uploadOps([addTaskOp(loser, 'loser-op')]);
+    await atGate;
+    await winner.uploadOps([addTaskOp(winner, 'winner-op')]);
+    release();
     await expectAsync(loserPromise).toBeRejectedWithError(
       UploadRevToMatchMismatchAPIError,
     );
 
-    // Sanity: the interleave really occurred — the winner's snapshot generation
-    // is the one referenced by the committed ops file, and the loser clobbered
-    // sync-state.json with a DIFFERENT generation.
-    expect(provider.hasFile(C.OPS_FILE)).toBe(true);
-    expect(provider.hasFile(C.STATE_FILE)).toBe(true);
+    // The winner's immutable snapshot (syncVersion 3) survives the loser's clobber,
+    // and the superseded predecessor (seed's syncVersion 1) was garbage-collected.
+    expect(provider.hasFile('sync-state__3__winner-client.json')).toBe(true);
+    expect(provider.hasFile('sync-state__1__seed-client.json')).toBe(false);
 
-    // --- Assert: a fresh client can still hydrate the committed generation. ---
-    const fresh = harness.createClient('fresh-client');
-    const download = (await fresh.downloadOps(0)) as FileSnapshotOpDownloadResponse;
-
-    // FAILS today: sync-state.json holds the loser's snapshot and .bak holds the
-    // pre-compaction snapshot, so the winning ops pointer matches neither and the
-    // client reports an unrecoverable gap requiring a full re-sync.
+    const download = await downloadFresh();
     expect(download.gapDetected).toBeFalsy();
     expect(download.snapshotState).toBeDefined();
+  });
+
+  it('benign interleave: loser holding a stale rev loses the ops race, fresh client still hydrates', async () => {
+    await seedFolderAtCap();
+    const winner = harness.createClient('winner-client');
+    const loser = harness.createClient('loser-client');
+
+    // Loser downloads (caching the pre-compaction ops rev), then the winner
+    // compacts + commits. The loser's later compaction backs up the winner's
+    // snapshot and loses the conditional ops PUT — order-independence guard.
+    await loser.downloadOps(0);
+    await winner.uploadOps([addTaskOp(winner, 'winner-op')]);
+    await expectAsync(
+      loser.uploadOps([addTaskOp(loser, 'loser-op')]),
+    ).toBeRejectedWithError(UploadRevToMatchMismatchAPIError);
+
+    const download = await downloadFresh();
+    expect(download.gapDetected).toBeFalsy();
+    expect(download.snapshotState).toBeDefined();
+  });
+
+  it('fresh-folder concurrent compaction: create-if-absent picks one winner, no strand', async () => {
+    const provider = harness.getProvider();
+
+    // Both clients compact a fresh folder (no snapshot yet). Park the loser just
+    // before it creates sync-ops.json; the winner then creates it first and wins
+    // the create-if-absent gate, so the loser's create fails.
+    const { atGate, release } = gateFirstUpload(
+      (path, isForce) => path === C.OPS_FILE && !isForce,
+    );
+    const winner = harness.createClient('winner-client');
+    const loser = harness.createClient('loser-client');
+
+    const loserPromise = loser.uploadOps([addTaskOp(loser, 'loser-op')]);
+    await atGate;
+    await winner.uploadOps([addTaskOp(winner, 'winner-op')]);
+    release();
+    await expectAsync(loserPromise).toBeRejectedWithError(
+      UploadRevToMatchMismatchAPIError,
+    );
+
+    const download = await downloadFresh();
+    expect(download.gapDetected).toBeFalsy();
+    expect(download.snapshotState).toBeDefined();
+    // The winner's immutable snapshot (syncVersion 1) survives the loser's clobber.
+    expect(provider.hasFile('sync-state__1__winner-client.json')).toBe(true);
   });
 });

--- a/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
@@ -1,0 +1,159 @@
+import { FileBasedSyncTestHarness } from '../helpers/file-based-sync-test-harness';
+import { FILE_BASED_SYNC_CONSTANTS } from '../../../sync-providers/file-based/file-based-sync.types';
+import {
+  FileRevResponse,
+  FileSnapshotOpDownloadResponse,
+  SyncOperation,
+} from '../../../sync-providers/provider.interface';
+import { UploadRevToMatchMismatchAPIError } from '../../../core/errors/sync-errors';
+
+/**
+ * Regression coverage for issue #9040: split-file compaction can strand the ops
+ * pointer at a snapshot that survives in neither the primary snapshot file nor
+ * its backup.
+ *
+ * ## The race (file-based providers have NO cross-device lock)
+ *
+ * `_uploadOpsSplit` commits a compaction in three provider writes:
+ *   1. `sync-state.json.bak`  ← copy of the CURRENT snapshot (reads live state)
+ *   2. `sync-state.json`      ← the NEW snapshot, FORCE-written (revToMatch=null)
+ *   3. `sync-ops.json`        ← the commit point, CONDITIONAL on the ops rev
+ *
+ * Only write 3 is gated, so the ops file has a single winner. But write 2 is an
+ * unconditional last-writer-wins force-write, so the LOSER of the ops race can
+ * still clobber the WINNER's snapshot. When the loser's backup (write 1) ran
+ * before the winner's snapshot write, `.bak` holds an older, unrelated snapshot
+ * — so the winning ops file ends up referencing a snapshot present in neither
+ * `sync-state.json` nor `sync-state.json.bak`.
+ *
+ * Interleave reproduced below (winner A, loser B; initial snapshot S0, ops rev R0):
+ *   B.bak(read S0 → write S0)  →  A.state(SA)  →  A.ops(commit, R0→RA)
+ *     →  B.state(SB, clobbers SA)  →  B.ops(PUT vs R0 → mismatch, B aborts)
+ *   Final: sync-state.json = SB, .bak = S0, sync-ops.json → SA (in neither).
+ *
+ * A fresh client that then hydrates from seq 0 cannot validate the referenced
+ * snapshot against `sync-state.json` (SB) or `.bak` (S0), so it reports an
+ * unrecoverable gap. This test asserts the fresh client CAN still hydrate — it
+ * FAILS today (stranded pointer) and should PASS once the snapshot is written
+ * under a generation-unique, immutable name that a concurrent compaction cannot
+ * clobber.
+ */
+describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', () => {
+  const C = FILE_BASED_SYNC_CONSTANTS;
+  let harness: FileBasedSyncTestHarness;
+
+  beforeEach(() => {
+    harness = FileBasedSyncTestHarness.create({ isUseSplitSyncFiles: true });
+  });
+
+  afterEach(() => {
+    harness.reset();
+  });
+
+  it('a losing concurrent compaction must not strand the winner’s ops pointer', async () => {
+    const provider = harness.getProvider();
+
+    // --- Arrange: a compacted folder whose ops buffer sits EXACTLY at the cap,
+    // so the next single-op sync from any client triggers a fresh compaction
+    // (needsCompaction = combinedOps.length > MAX_RECENT_OPS). This is the only
+    // path where the conditional ops PUT uses a real rev, giving a single winner
+    // — the fresh/first-sync path uses revToMatch=null and has no gate. ---
+    const seed = harness.createClient('seed-client');
+    await seed.uploadOps([
+      seed.createOp('Task', 'seed-0', 'CRT', 'TaskActionTypes.ADD_TASK', {
+        title: 'seed',
+      }),
+    ]);
+    const fill: SyncOperation[] = [];
+    for (let i = 0; i < C.MAX_RECENT_OPS - 1; i++) {
+      fill.push(
+        seed.createOp('Task', `fill-${i}`, 'CRT', 'TaskActionTypes.ADD_TASK', {
+          title: `fill-${i}`,
+        }),
+      );
+    }
+    // Op-only sync (combined = 1 + (MAX_RECENT_OPS - 1) = MAX_RECENT_OPS, NOT
+    // greater, so no compaction): the buffer now sits precisely at the cap.
+    await seed.uploadOps(fill);
+
+    // Control: the seeded folder is healthy and fully hydratable BEFORE the race,
+    // so a gap after it is attributable to the concurrent compaction, not setup.
+    const probe = harness.createClient('probe-client');
+    const probeDownload = (await probe.downloadOps(0)) as FileSnapshotOpDownloadResponse;
+    expect(probeDownload.gapDetected).toBeFalsy();
+    expect(probeDownload.snapshotState).toBeDefined();
+
+    // --- Deterministically interleave two concurrent compactions via a gate on
+    // the FIRST sync-state.json.bak write (the loser B's backup). B parks there,
+    // A runs to completion, then B resumes to clobber + lose the ops race. ---
+    let releaseLoser: () => void = () => {};
+    const loserReleased = new Promise<void>((r) => (releaseLoser = r));
+    let loserAtGate: () => void = () => {};
+    const loserReachedGate = new Promise<void>((r) => (loserAtGate = r));
+    let stateBakWrites = 0;
+
+    const realUploadFile = provider.uploadFile.bind(provider);
+    spyOn(provider, 'uploadFile').and.callFake(
+      async (
+        path: string,
+        data: string,
+        revToMatch: string | null,
+        isForceOverwrite?: boolean,
+      ): Promise<FileRevResponse> => {
+        const res = await realUploadFile(path, data, revToMatch, isForceOverwrite);
+        if (path === C.STATE_BACKUP_FILE) {
+          stateBakWrites += 1;
+          // Pause the loser after its backup captured the OLD snapshot (S0),
+          // before it (or the winner) writes a new sync-state.json.
+          if (stateBakWrites === 1) {
+            loserAtGate();
+            await loserReleased;
+          }
+        }
+        return res;
+      },
+    );
+
+    const winner = harness.createClient('winner-client');
+    const loser = harness.createClient('loser-client');
+
+    // Start the loser first; it parks after backing up the current snapshot.
+    const loserPromise = loser.uploadOps([
+      loser.createOp('Task', 'loser-op', 'CRT', 'TaskActionTypes.ADD_TASK', {
+        title: 'loser',
+      }),
+    ]);
+    await loserReachedGate;
+
+    // Winner compacts fully while the loser is parked: writes its snapshot and
+    // wins the conditional ops commit (loser has not touched the ops file yet).
+    await winner.uploadOps([
+      winner.createOp('Task', 'winner-op', 'CRT', 'TaskActionTypes.ADD_TASK', {
+        title: 'winner',
+      }),
+    ]);
+
+    // Resume the loser: it force-overwrites sync-state.json (clobbering the
+    // winner's snapshot), then loses the conditional ops PUT and aborts.
+    releaseLoser();
+    await expectAsync(loserPromise).toBeRejectedWithError(
+      UploadRevToMatchMismatchAPIError,
+    );
+
+    // Sanity: the interleave really occurred — the winner's snapshot generation
+    // is the one referenced by the committed ops file, and the loser clobbered
+    // sync-state.json with a DIFFERENT generation.
+    expect(provider.hasFile(C.OPS_FILE)).toBe(true);
+    expect(provider.hasFile(C.STATE_FILE)).toBe(true);
+
+    // --- Assert: a fresh client can still hydrate the committed generation. ---
+    const fresh = harness.createClient('fresh-client');
+    const download = (await fresh.downloadOps(0)) as FileSnapshotOpDownloadResponse;
+
+    // FAILS today: sync-state.json holds the loser's snapshot and .bak holds the
+    // pre-compaction snapshot, so the winning ops pointer matches neither and the
+    // client reports an unrecoverable gap requiring a full re-sync.
+    expect(download.gapDetected).toBeFalsy();
+    expect(download.snapshotState).toBeDefined();
+  });
+});

--- a/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
@@ -97,8 +97,16 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
     return (await fresh.downloadOps(0)) as FileSnapshotOpDownloadResponse;
   };
 
+  // The immutable per-compaction snapshot files currently on the remote. Their
+  // names carry a random suffix (#9040 keeps the clientId out of plaintext file
+  // names), so tests assert on their COUNT rather than exact names.
+  const genStateFiles = (): string[] =>
+    harness
+      .getProvider()
+      .getFilePaths()
+      .filter((p) => p.startsWith(C.STATE_GEN_FILE_PREFIX));
+
   it('harmful interleave: loser clobbers sync-state.json but cannot strand the immutable snapshot', async () => {
-    const provider = harness.getProvider();
     await seedFolderAtCap();
 
     // Control: the seeded folder is healthy and fully hydratable BEFORE the race,
@@ -124,12 +132,11 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
       UploadRevToMatchMismatchAPIError,
     );
 
-    // The winner's immutable snapshot (syncVersion 3) survives the loser's clobber,
-    // the superseded predecessor (seed's syncVersion 1) was garbage-collected, and
-    // the loser cleaned up its own orphaned snapshot on its failed commit.
-    expect(provider.hasFile('sync-state__3__winner-client.json')).toBe(true);
-    expect(provider.hasFile('sync-state__1__seed-client.json')).toBe(false);
-    expect(provider.hasFile('sync-state__3__loser-client.json')).toBe(false);
+    // Exactly one immutable snapshot remains: the winner's. The seed's predecessor
+    // was GC'd on the winner's commit, and the loser cleaned up its own orphaned
+    // snapshot on its failed commit. A fresh client hydrating without a gap proves
+    // the survivor is the one the committed ops file references (the winner's).
+    expect(genStateFiles().length).toBe(1);
 
     const download = await downloadFresh();
     expect(download.gapDetected).toBeFalsy();
@@ -156,8 +163,6 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
   });
 
   it('fresh-folder concurrent compaction: create-if-absent picks one winner, no strand', async () => {
-    const provider = harness.getProvider();
-
     // Both clients compact a fresh folder (no snapshot yet). Park the loser just
     // before it creates sync-ops.json; the winner then creates it first and wins
     // the create-if-absent gate, so the loser's create fails.
@@ -178,10 +183,9 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
     const download = await downloadFresh();
     expect(download.gapDetected).toBeFalsy();
     expect(download.snapshotState).toBeDefined();
-    // The winner's immutable snapshot (syncVersion 1) survives the loser's clobber,
-    // and the loser cleaned up its own orphan on its failed commit.
-    expect(provider.hasFile('sync-state__1__winner-client.json')).toBe(true);
-    expect(provider.hasFile('sync-state__1__loser-client.json')).toBe(false);
+    // Only the winner's immutable snapshot remains — the loser cleaned up its own
+    // orphan on its failed commit (no predecessor exists on a fresh folder).
+    expect(genStateFiles().length).toBe(1);
   });
 
   it('ambiguous (non-mismatch) commit failure keeps the immutable snapshot', async () => {
@@ -194,8 +198,10 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
     // reader of the committed ops file would strand on it.
     const client = harness.createClient('netfail-client');
     const realUploadFile = provider.uploadFile.bind(provider);
+    let writtenGenFile: string | undefined;
     spyOn(provider, 'uploadFile').and.callFake(
       async (path: string, data: string, rev: string | null, isForce?: boolean) => {
+        if (path.startsWith(C.STATE_GEN_FILE_PREFIX)) writtenGenFile = path;
         if (path === C.OPS_FILE) throw new Error('simulated network failure');
         return realUploadFile(path, data, rev, isForce);
       },
@@ -203,7 +209,8 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
 
     await expectAsync(client.uploadOps([addTaskOp(client, 'netfail-op')])).toBeRejected();
 
-    // syncVersion 3 (seed 1 → fill 2 → this compaction 3): snapshot must remain.
-    expect(provider.hasFile('sync-state__3__netfail-client.json')).toBe(true);
+    // The immutable snapshot this compaction wrote must NOT have been reclaimed.
+    expect(writtenGenFile).toBeDefined();
+    expect(provider.hasFile(writtenGenFile as string)).toBe(true);
   });
 });

--- a/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/concurrent-compaction.integration.spec.ts
@@ -183,4 +183,27 @@ describe('File-Based Sync Integration - Concurrent Split Compaction (#9040)', ()
     expect(provider.hasFile('sync-state__1__winner-client.json')).toBe(true);
     expect(provider.hasFile('sync-state__1__loser-client.json')).toBe(false);
   });
+
+  it('ambiguous (non-mismatch) commit failure keeps the immutable snapshot', async () => {
+    const provider = harness.getProvider();
+    await seedFolderAtCap();
+
+    // A compactor writes its immutable snapshot, then its ops commit fails with a
+    // NON-mismatch error (e.g. a dropped connection). That is ambiguous — the PUT
+    // may have landed and committed — so the snapshot MUST NOT be reclaimed, or a
+    // reader of the committed ops file would strand on it.
+    const client = harness.createClient('netfail-client');
+    const realUploadFile = provider.uploadFile.bind(provider);
+    spyOn(provider, 'uploadFile').and.callFake(
+      async (path: string, data: string, rev: string | null, isForce?: boolean) => {
+        if (path === C.OPS_FILE) throw new Error('simulated network failure');
+        return realUploadFile(path, data, rev, isForce);
+      },
+    );
+
+    await expectAsync(client.uploadOps([addTaskOp(client, 'netfail-op')])).toBeRejected();
+
+    // syncVersion 3 (seed 1 → fill 2 → this compaction 3): snapshot must remain.
+    expect(provider.hasFile('sync-state__3__netfail-client.json')).toBe(true);
+  });
 });

--- a/src/app/op-log/testing/integration/helpers/mock-file-provider.helper.ts
+++ b/src/app/op-log/testing/integration/helpers/mock-file-provider.helper.ts
@@ -168,15 +168,25 @@ export class MockFileProvider implements FileSyncProvider<SyncProviderId> {
 
     const existingFile = this._files.get(targetPath);
 
-    // Check revision match (conditional upload) unless force overwrite
-    if (!isForceOverwrite && revToMatch !== null) {
-      if (!existingFile) {
+    // Conditional-upload semantics (skipped entirely on force overwrite):
+    // - revToMatch === null  → create-if-absent (WebDAV `If-None-Match: *`): the
+    //   PUT only succeeds when the file does not yet exist. This gates concurrent
+    //   first-writers so exactly one wins, matching real providers.
+    // - revToMatch !== null  → If-Match: the PUT only succeeds when the current
+    //   rev equals revToMatch.
+    if (!isForceOverwrite) {
+      if (revToMatch === null) {
+        if (existingFile) {
+          throw new UploadRevToMatchMismatchAPIError(
+            `File ${targetPath} already exists (create-if-absent write)`,
+          );
+        }
+      } else if (!existingFile) {
         // File doesn't exist but revToMatch was provided - mismatch
         throw new UploadRevToMatchMismatchAPIError(
           `File ${targetPath} does not exist but revToMatch was provided`,
         );
-      }
-      if (existingFile.rev !== revToMatch) {
+      } else if (existingFile.rev !== revToMatch) {
         throw new UploadRevToMatchMismatchAPIError(
           `Rev mismatch for ${targetPath}: expected ${revToMatch}, found ${existingFile.rev}`,
         );


### PR DESCRIPTION
Fixes #9040.

Concurrent split-file compactions could strand the winning ops pointer: the snapshot was force-written to the fixed `sync-state.json`, so the loser of the conditional ops-commit race could clobber the winner's snapshot — leaving the committed `sync-ops.json` referencing a snapshot absent from both `sync-state.json` and its `.bak` (an unrecoverable gap for a fresh client). Opt-in split format only; self-heals on the next compaction, but the window can persist ~1000 ops.

## Fix

Write the compaction snapshot to a generation+client-unique **immutable file** `sync-state__<syncVersion>__<clientId>.json`, recorded in a new optional `snapshotRef.file`. A concurrent compactor writes a *different* file, so the winning pointer can never be clobbered. Readers prefer `snapshotRef.file` and fall back to `sync-state.json` → `.bak` (both kept dual-written for pre-#9040 clients — adding an optional field is forward-compatible, so no regression). The superseded snapshot is GC'd O(1) via `removeFile` after commit; a losing compactor's same-generation orphan is a rare, bounded, documented leak (upgrade path: `listFiles` prune).

Rejected the leaner "conditional state write" alternative — it has a liveness hole (a compactor that writes state but loses the ops commit poisons `sync-state.json`'s rev and dead-locks all future compactions). Immutable filenames preserve both safety and liveness.

Also fixes `MockFileProvider` to model create-if-absent (`If-None-Match: *`), matching real WebDAV — this faithfully gates the fresh-folder concurrent-compaction path, which had the same stranding exposure on real providers.

## Tests

- 3 concurrent-compaction integration scenarios (harmful interleave + GC assertion, benign interleave, fresh-folder race)
- 2 unit tests pinning the snapshot resolution order (immutable preferred; fallback when immutable missing)
- Full op-log suite (3427) and sync-providers package (404) green

## Sync-correctness notes

Every char of a real `clientId` (`{platform}_{6-base62}`) is path-safe, so the immutable filename is collision-free in practice. Downstream user-visible handling of `gapDetected` is unchanged and out of scope here.