### PR TITLE
fix(locale): localize ISO 8601 recurring-task start date & weekday labels (#8987)

### DIFF
--- a/src/app/core/date-time-format/date-time-format.service.spec.ts
+++ b/src/app/core/date-time-format/date-time-format.service.spec.ts
@@ -305,6 +305,17 @@ describe('DateTimeFormatService', () => {
       expect(service.dateFormat().raw).toBe('yyyy-MM-dd');
       expect(service.is24HourFormat()).toBe(true);
     });
+
+    it('exposes the UI language as textLocale, tracking language changes', () => {
+      // Spelled-out weekday/month names must not render in Swedish under the
+      // sv sentinel (#8987 follow-up); textLocale resolves to the UI language.
+      expect(service.textLocale()).toBe('en');
+
+      service.setUiLanguage('de');
+      TestBed.flushEffects();
+
+      expect(service.textLocale()).toBe('de');
+    });
   });
 
   describe('dateTimeLocale config fallback', () => {
@@ -411,6 +422,9 @@ describe('DateTimeFormatService', () => {
 
       expect(service.currentLocale()).toBe(DateTimeLocales.ja_jp);
       expect(service.isoTextLocale()).toBeNull();
+      // Non-ISO options keep spelled-out names on the configured locale, so
+      // ja/ar/etc. still render their native month/weekday names.
+      expect(service.textLocale()).toBe(DateTimeLocales.ja_jp);
       expect(dateAdapter.format(testDate, TIME_FORMAT)).toBe('14:00');
     });
 

--- a/src/app/core/date-time-format/date-time-format.service.ts
+++ b/src/app/core/date-time-format/date-time-format.service.ts
@@ -47,6 +47,17 @@ export class DateTimeFormatService {
     );
   });
 
+  /**
+   * Locale for spelled-out weekday/month names (e.g. "Wed", "July"). Under the
+   * ISO 8601 option this resolves to the UI language, so names aren't shown in
+   * Swedish (the `sv` sync sentinel) — mirrors the calendar fix in `CustomDateAdapter`.
+   * Numeric dates and clock times must keep `currentLocale()` instead, so ISO
+   * stays YYYY-MM-DD and the 24h clock is preserved (#8987 follow-up).
+   */
+  readonly textLocale = computed<string>(
+    () => this.isoTextLocale() ?? this.currentLocale(),
+  );
+
   /** Test formats to detect locale-specific time and date formats (e.g., 24h vs 12h, DD/MM vs MM/DD) */
   private readonly _testFormats = computed(() => {
     const locale = this.currentLocale();

--- a/src/app/features/tag/tag-list/tag-list.component.spec.ts
+++ b/src/app/features/tag/tag-list/tag-list.component.spec.ts
@@ -92,6 +92,7 @@ describe('TagListComponent', () => {
 
     const dateTimeFormatServiceMock = {
       currentLocale: () => 'en',
+      textLocale: () => 'en',
     };
 
     const pluginRegistryMock = {

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.spec.ts
@@ -67,4 +67,43 @@ describe('buildRepeatQuickSettingOptions', () => {
     expect(options.length).toBe(9);
     options.forEach((o) => expect(o.label).toBeTruthy());
   });
+
+  // #8987 follow-up: under the ISO 8601 option the numeric locale is the `sv`
+  // sentinel; the spelled-out weekday must follow the UI language instead, while
+  // numeric day/month keep the sv (day-first) ordering.
+  it('should use weekdayLocale for the spelled-out weekday, keeping locale for numeric parts', () => {
+    // 2026-07-15 is a Wednesday.
+    const weekdayCalls: { key: string; params: any }[] = [];
+    spyOn(translateService, 'instant').and.callFake((key: any, params?: any) => {
+      weekdayCalls.push({ key, params });
+      return key;
+    });
+
+    buildRepeatQuickSettingOptions(new Date(2026, 6, 15), 'sv', translateService, 'en');
+
+    const weeklyCall = weekdayCalls.find(
+      (c) => c.params?.weekdayStr !== undefined && c.params?.ordinalStr === undefined,
+    );
+    const yearlyCall = weekdayCalls.find((c) => c.params?.dayAndMonthStr !== undefined);
+
+    // Weekday follows the UI language ('en' → "Wednesday"), not sv ("onsdag").
+    expect(weeklyCall!.params.weekdayStr).toBe('Wednesday');
+    // Numeric day/month keeps the sv locale → day-first "15/7".
+    expect(yearlyCall!.params.dayAndMonthStr).toBe('15/7');
+  });
+
+  it('should default weekdayLocale to locale when omitted', () => {
+    const weekdayCalls: { key: string; params: any }[] = [];
+    spyOn(translateService, 'instant').and.callFake((key: any, params?: any) => {
+      weekdayCalls.push({ key, params });
+      return key;
+    });
+
+    buildRepeatQuickSettingOptions(new Date(2026, 6, 15), 'sv', translateService);
+
+    const weeklyCall = weekdayCalls.find(
+      (c) => c.params?.weekdayStr !== undefined && c.params?.ordinalStr === undefined,
+    );
+    expect(weeklyCall!.params.weekdayStr).toBe('onsdag');
+  });
 });

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.spec.ts
@@ -27,6 +27,7 @@ describe('buildRepeatQuickSettingOptions', () => {
       new Date(2026, 5, 2),
       'en-US',
       translateService,
+      'en-US',
     );
     expect(options.map((o) => o.value)).toEqual([
       'DAILY',
@@ -54,7 +55,12 @@ describe('buildRepeatQuickSettingOptions', () => {
   // and `ORDINAL_KEYS[NaN-1]` → undefined → instant(undefined) threw.
   it('should not throw when given an invalid date', () => {
     expect(() =>
-      buildRepeatQuickSettingOptions(new Date('Invalid Date'), 'en-US', translateService),
+      buildRepeatQuickSettingOptions(
+        new Date('Invalid Date'),
+        'en-US',
+        translateService,
+        'en-US',
+      ),
     ).not.toThrow();
   });
 
@@ -63,6 +69,7 @@ describe('buildRepeatQuickSettingOptions', () => {
       new Date('Invalid Date'),
       'en-US',
       translateService,
+      'en-US',
     );
     expect(options.length).toBe(9);
     options.forEach((o) => expect(o.label).toBeTruthy());
@@ -92,14 +99,14 @@ describe('buildRepeatQuickSettingOptions', () => {
     expect(yearlyCall!.params.dayAndMonthStr).toBe('15/7');
   });
 
-  it('should default weekdayLocale to locale when omitted', () => {
+  it('should use locale for the weekday when both locales match (non-ISO)', () => {
     const weekdayCalls: { key: string; params: any }[] = [];
     spyOn(translateService, 'instant').and.callFake((key: any, params?: any) => {
       weekdayCalls.push({ key, params });
       return key;
     });
 
-    buildRepeatQuickSettingOptions(new Date(2026, 6, 15), 'sv', translateService);
+    buildRepeatQuickSettingOptions(new Date(2026, 6, 15), 'sv', translateService, 'sv');
 
     const weeklyCall = weekdayCalls.find(
       (c) => c.params?.weekdayStr !== undefined && c.params?.ordinalStr === undefined,

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.ts
@@ -13,13 +13,20 @@ export const buildRepeatQuickSettingOptions = (
   refDate: Date,
   locale: string,
   translateService: TranslateService,
+  // Locale for the spelled-out weekday name. Defaults to `locale`; under the
+  // ISO 8601 option the caller passes the UI language so the weekday isn't shown
+  // in Swedish (the `sv` sentinel). Numeric day/month below keep `locale` so ISO
+  // day-first ordering is preserved (#8987 follow-up).
+  weekdayLocale: string = locale,
 ): { value: RepeatQuickSetting; label: string }[] => {
   // Guard against an invalid Date slipping through (e.g. a non-DB date string).
   // An invalid date makes the weekOfMonth math NaN, so ORDINAL_KEYS[NaN-1] is
   // undefined and translate's `instant(undefined)` throws, crashing the whole
   // dialog (#7945). Fall back to "today" so options still render.
   const safeRefDate = isNaN(refDate.getTime()) ? new Date() : refDate;
-  const refWeekdayStr = safeRefDate.toLocaleDateString(locale, { weekday: 'long' });
+  const refWeekdayStr = safeRefDate.toLocaleDateString(weekdayLocale, {
+    weekday: 'long',
+  });
   const refDayStr = safeRefDate.toLocaleDateString(locale, { day: 'numeric' });
   const refDayAndMonthStr = safeRefDate.toLocaleDateString(locale, {
     day: 'numeric',

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/build-repeat-quick-setting-options.ts
@@ -13,11 +13,12 @@ export const buildRepeatQuickSettingOptions = (
   refDate: Date,
   locale: string,
   translateService: TranslateService,
-  // Locale for the spelled-out weekday name. Defaults to `locale`; under the
-  // ISO 8601 option the caller passes the UI language so the weekday isn't shown
-  // in Swedish (the `sv` sentinel). Numeric day/month below keep `locale` so ISO
-  // day-first ordering is preserved (#8987 follow-up).
-  weekdayLocale: string = locale,
+  // Locale for the spelled-out weekday name — pass DateTimeFormatService.textLocale().
+  // Required (no default) so a new caller has to make the choice consciously:
+  // under the ISO 8601 option `locale` is the `sv` sentinel, and silently reusing
+  // it here renders the weekday in Swedish (#8987). Numeric day/month below keep
+  // `locale` so ISO day-first ordering is preserved.
+  weekdayLocale: string,
 ): { value: RepeatQuickSetting; label: string }[] => {
   // Guard against an invalid Date slipping through (e.g. a non-DB date string).
   // An invalid date makes the weekOfMonth math NaN, so ORDINAL_KEYS[NaN-1] is

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -40,6 +40,12 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
   let mockDateTimeFormatService: jasmine.SpyObj<DateTimeFormatService>;
   let mockDateService: jasmine.SpyObj<DateService>;
 
+  // Mutable locale backing the DateTimeFormatService mock, so a test can
+  // simulate the ISO 8601 option (numeric locale = sv sentinel, spelled-out
+  // names = UI language). Reset in setupTestBed.
+  let mockCurrentLocale = 'en-US';
+  let mockTextLocale = 'en-US';
+
   // DateService is mocked to this fixed day; assertions about "today" must
   // derive from these consts, never from the real clock (see #8017 CI breakage).
   const MOCK_TODAY = new Date(2026, 5, 9, 0, 0, 0, 0);
@@ -112,8 +118,13 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
     mockGlobalConfigService = jasmine.createSpyObj('GlobalConfigService', [], {
       cfg: () => ({ reminder: { defaultTaskRemindOption: null } }),
     });
+    mockCurrentLocale = 'en-US';
+    mockTextLocale = 'en-US';
     mockDateTimeFormatService = jasmine.createSpyObj('DateTimeFormatService', [], {
-      currentLocale: () => 'en-US',
+      currentLocale: () => mockCurrentLocale,
+      // Mirrors the real service: spelled-out names follow this locale (equals
+      // currentLocale() unless the ISO option remaps it to the UI language).
+      textLocale: () => mockTextLocale,
       dateFormat: () => ({
         parse: 'MM/dd/yyyy',
         display: { dateInput: 'MM/dd/yyyy' },
@@ -340,6 +351,42 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       const component = fixture.componentInstance;
 
       expect(component.isEdit()).toBe(false);
+    });
+  });
+
+  describe('plannedStartDateStr localization (#8987 follow-up)', () => {
+    it('renders the start-date value in the UI language under the ISO option, not sv', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      // ISO 8601 option: numeric locale is the sv sentinel, but spelled-out
+      // names must follow the UI language ('en').
+      mockCurrentLocale = 'sv';
+      mockTextLocale = 'en';
+
+      fixture.componentInstance.repeatCfg.set({
+        ...DEFAULT_TASK_REPEAT_CFG,
+        startDate: '2026-07-15',
+      });
+
+      const label = fixture.componentInstance.plannedStartDateStr();
+      // English spelled-out names ("Wed, Jul 15, 2026"), not Swedish
+      // ("ons 15 juli 2026").
+      expect(label).toContain('Jul');
+      expect(label).not.toContain('juli');
+      expect(label).not.toContain('ons');
+    });
+
+    it('keeps the configured locale for spelled-out names when not the ISO option', async () => {
+      const fixture = await setupTestBed({ task: mockTask });
+      // de-DE renders its own spelled-out names; textLocale equals currentLocale.
+      mockCurrentLocale = 'de-DE';
+      mockTextLocale = 'de-DE';
+
+      fixture.componentInstance.repeatCfg.set({
+        ...DEFAULT_TASK_REPEAT_CFG,
+        startDate: '2026-07-15',
+      });
+
+      expect(fixture.componentInstance.plannedStartDateStr()).toContain('Juli');
     });
   });
 

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -393,15 +393,16 @@ export class DialogEditTaskRepeatCfgComponent {
 
     // Memoize to avoid rebuilding options on every formly change cycle
     let lastStartDate: string | undefined;
-    let lastLocale: string | undefined;
+    let lastLocaleKey: string | undefined;
     let cachedOptions: { value: string; label: string }[];
 
-    // Update options when startDate or locale changes. The cache key tracks
-    // textLocale too because buildOptions now depends on it — under the ISO
-    // option currentLocale() stays 'sv' while textLocale() carries the UI
-    // language for the weekday label. (This modal dialog can't have its UI
-    // language changed mid-life, so the first build already reads the right
-    // textLocale; the composite key just keeps the memo honest.)
+    // Update options when startDate or either locale changes. The key must track
+    // textLocale, not just currentLocale: under the ISO option currentLocale()
+    // stays 'sv' while textLocale() carries the UI language for the weekday
+    // label. Those move independently — applyLanguageFromState$ deliberately
+    // applies the UI language from remote sync too, so lng can change while this
+    // dialog is open, shifting textLocale() with currentLocale() frozen at 'sv'.
+    // A currentLocale-only key would serve a stale weekday label there.
     quickSettingField.expressionProperties = {
       ...quickSettingField.expressionProperties,
       ['templateOptions.options']: (model: Record<string, unknown>) => {
@@ -409,9 +410,9 @@ export class DialogEditTaskRepeatCfgComponent {
         const currentLocale = this._dateTimeFormatService.currentLocale();
         const textLocale = this._dateTimeFormatService.textLocale();
         const localeKey = `${currentLocale}|${textLocale}`;
-        if (sd !== lastStartDate || localeKey !== lastLocale || !cachedOptions) {
+        if (sd !== lastStartDate || localeKey !== lastLocaleKey || !cachedOptions) {
           lastStartDate = sd;
-          lastLocale = localeKey;
+          lastLocaleKey = localeKey;
           const refDate = sd ? dateStrToUtcDate(sd) : this._getReferenceDate();
           cachedOptions = buildOptions(refDate);
         }

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -117,10 +117,13 @@ export class DialogEditTaskRepeatCfgComponent {
     const d = this.repeatCfg().startDate;
     if (!d) return this._translateService.instant(T.F.TASK_REPEAT.F.START_DATE);
     const date = dateStrToUtcDate(d);
-    const locale = this._dateTimeFormatService.currentLocale();
+    // Spelled-out weekday/month names follow the UI language under the ISO 8601
+    // option (the `sv` sentinel would otherwise leak Swedish, e.g. "ons 15 juli
+    // 2026"). The clock time below keeps currentLocale() so 24h is preserved.
+    const textLocale = this._dateTimeFormatService.textLocale();
     const time = this.repeatCfg().startTime;
     if (time && isValidSplitTime(time)) {
-      const formattedDate = date.toLocaleDateString(locale, {
+      const formattedDate = date.toLocaleDateString(textLocale, {
         weekday: 'short',
         year: 'numeric',
         month: 'short',
@@ -130,11 +133,11 @@ export class DialogEditTaskRepeatCfgComponent {
       const safeTimeDate = new Date(2000, 0, 1, hours, minutes, 0, 0);
       const formattedTime = this._dateTimeFormatService.formatTime(
         safeTimeDate.getTime(),
-        locale,
+        this._dateTimeFormatService.currentLocale(),
       );
       return `${formattedDate}, ${formattedTime}`;
     }
-    return date.toLocaleDateString(locale, {
+    return date.toLocaleDateString(textLocale, {
       weekday: 'short',
       year: 'numeric',
       month: 'short',
@@ -360,10 +363,13 @@ export class DialogEditTaskRepeatCfgComponent {
       // Read currentLocale() reactively each time options are built so the
       // correct locale is used even when the config store hasn't emitted yet
       // at construction time (previously captured once as a const → en-GB).
+      // textLocale() localizes the spelled-out weekday name (UI language under
+      // the ISO option), while numeric day/month keep currentLocale().
       buildRepeatQuickSettingOptions(
         refDate,
         this._dateTimeFormatService.currentLocale(),
         translateService,
+        this._dateTimeFormatService.textLocale(),
       );
 
     const formConfig = TASK_REPEAT_CFG_ESSENTIAL_FORM_CFG.map((field) => ({
@@ -393,15 +399,19 @@ export class DialogEditTaskRepeatCfgComponent {
     let lastLocale: string | undefined;
     let cachedOptions: { value: string; label: string }[];
 
-    // Update options reactively when startDate or locale changes
+    // Update options reactively when startDate or locale changes. The cache key
+    // tracks textLocale too: under the ISO option a UI-language switch leaves
+    // currentLocale() at 'sv', but the spelled-out weekday label must rebuild.
     quickSettingField.expressionProperties = {
       ...quickSettingField.expressionProperties,
       ['templateOptions.options']: (model: Record<string, unknown>) => {
         const sd = model['startDate'] as string | undefined;
         const currentLocale = this._dateTimeFormatService.currentLocale();
-        if (sd !== lastStartDate || currentLocale !== lastLocale || !cachedOptions) {
+        const textLocale = this._dateTimeFormatService.textLocale();
+        const localeKey = `${currentLocale}|${textLocale}`;
+        if (sd !== lastStartDate || localeKey !== lastLocale || !cachedOptions) {
           lastStartDate = sd;
-          lastLocale = currentLocale;
+          lastLocale = localeKey;
           const refDate = sd ? dateStrToUtcDate(sd) : this._getReferenceDate();
           cachedOptions = buildOptions(refDate);
         }

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -120,15 +120,17 @@ export class DialogEditTaskRepeatCfgComponent {
     // Spelled-out weekday/month names follow the UI language under the ISO 8601
     // option (the `sv` sentinel would otherwise leak Swedish, e.g. "ons 15 juli
     // 2026"). The clock time below keeps currentLocale() so 24h is preserved.
-    const textLocale = this._dateTimeFormatService.textLocale();
-    const time = this.repeatCfg().startTime;
-    if (time && isValidSplitTime(time)) {
-      const formattedDate = date.toLocaleDateString(textLocale, {
+    const formattedDate = date.toLocaleDateString(
+      this._dateTimeFormatService.textLocale(),
+      {
         weekday: 'short',
         year: 'numeric',
         month: 'short',
         day: 'numeric',
-      });
+      },
+    );
+    const time = this.repeatCfg().startTime;
+    if (time && isValidSplitTime(time)) {
       const [hours, minutes] = time.split(':').map(Number);
       const safeTimeDate = new Date(2000, 0, 1, hours, minutes, 0, 0);
       const formattedTime = this._dateTimeFormatService.formatTime(
@@ -137,12 +139,7 @@ export class DialogEditTaskRepeatCfgComponent {
       );
       return `${formattedDate}, ${formattedTime}`;
     }
-    return date.toLocaleDateString(textLocale, {
-      weekday: 'short',
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
+    return formattedDate;
   });
 
   openScheduleDialog(): void {
@@ -399,9 +396,12 @@ export class DialogEditTaskRepeatCfgComponent {
     let lastLocale: string | undefined;
     let cachedOptions: { value: string; label: string }[];
 
-    // Update options reactively when startDate or locale changes. The cache key
-    // tracks textLocale too: under the ISO option a UI-language switch leaves
-    // currentLocale() at 'sv', but the spelled-out weekday label must rebuild.
+    // Update options when startDate or locale changes. The cache key tracks
+    // textLocale too because buildOptions now depends on it — under the ISO
+    // option currentLocale() stays 'sv' while textLocale() carries the UI
+    // language for the weekday label. (This modal dialog can't have its UI
+    // language changed mid-life, so the first build already reads the right
+    // textLocale; the composite key just keeps the memo honest.)
     quickSettingField.expressionProperties = {
       ...quickSettingField.expressionProperties,
       ['templateOptions.options']: (model: Record<string, unknown>) => {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
@@ -89,6 +89,7 @@ describe('AddTaskBarActionsComponent', () => {
     ['formatTime'],
     {
       currentLocale: () => 'en-US',
+      textLocale: () => 'en-US',
     },
   );
   mockDateTimeFormatService.formatTime.and.callFake((timestamp: number) =>
@@ -495,6 +496,7 @@ describe('AddTaskBarActionsComponent', () => {
             provide: DateTimeFormatService,
             useValue: jasmine.createSpyObj('DateTimeFormatService', ['-'], {
               currentLocale: () => 'de-de',
+              textLocale: () => 'de-de',
             }),
           },
           { provide: DateService, useValue: mockDateService },

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.spec.ts
@@ -84,12 +84,17 @@ describe('AddTaskBarActionsComponent', () => {
       localization: () => ({ timeLocale: locale }),
     });
   };
+  // Mutable locales backing the mock so a test can simulate the ISO 8601 option
+  // (numeric locale = sv sentinel, spelled-out names = UI language). Reset in
+  // beforeEach.
+  let mockCurrentLocale = 'en-US';
+  let mockTextLocale = 'en-US';
   const mockDateTimeFormatService = jasmine.createSpyObj(
     'DateTimeFormatService',
     ['formatTime'],
     {
-      currentLocale: () => 'en-US',
-      textLocale: () => 'en-US',
+      currentLocale: () => mockCurrentLocale,
+      textLocale: () => mockTextLocale,
     },
   );
   mockDateTimeFormatService.formatTime.and.callFake((timestamp: number) =>
@@ -100,6 +105,8 @@ describe('AddTaskBarActionsComponent', () => {
   );
 
   beforeEach(async () => {
+    mockCurrentLocale = 'en-US';
+    mockTextLocale = 'en-US';
     // Create proper signal mocks
     const mockStateSignal = signal(mockState);
     const mockAutoDetectedSignal = signal(false);
@@ -392,6 +399,25 @@ describe('AddTaskBarActionsComponent', () => {
       const result = component.dateDisplay();
       // Check that result contains the day
       expect(result).toContain(futureDate.getDate().toString());
+    });
+
+    it('should render dateDisplay month name in the UI language under the ISO option (#8987)', () => {
+      // ISO 8601 option: numeric locale is the sv sentinel, spelled-out month
+      // name must follow the UI language ('en').
+      mockCurrentLocale = 'sv';
+      mockTextLocale = 'en';
+      mockDateService.getLogicalTodayDate.and.returnValue(new Date(2020, 0, 1));
+      (mockStateService as any)._mockStateSignal.set({
+        ...mockState,
+        date: '2026-07-15',
+        time: null,
+      });
+
+      fixture.detectChanges();
+      const result = component.dateDisplay();
+      // English 'Jul 15', not Swedish '15 juli'.
+      expect(result).toContain('Jul');
+      expect(result).not.toContain('juli');
     });
 
     it('should compute estimateDisplay correctly', () => {

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
@@ -136,7 +136,9 @@ export class AddTaskBarActionsComponent {
     if (!state.time && this.isSameDate(date, tomorrow)) {
       return this._translateService.instant(T.F.TASK.ADD_TASK_BAR.TOMORROW);
     }
-    const dateStr = date.toLocaleDateString(this._dateTimeFormatService.currentLocale(), {
+    // Spelled-out `month: 'short'` name follows the UI language under the ISO
+    // option, so it isn't shown in Swedish (the `sv` sentinel); #8987 follow-up.
+    const dateStr = date.toLocaleDateString(this._dateTimeFormatService.textLocale(), {
       month: 'short',
       day: 'numeric',
     });
@@ -159,7 +161,9 @@ export class AddTaskBarActionsComponent {
     if (!state.deadlineTime && this.isSameDate(date, tomorrow)) {
       return this._translateService.instant(T.F.TASK.ADD_TASK_BAR.TOMORROW);
     }
-    const dateStr = date.toLocaleDateString(this._dateTimeFormatService.currentLocale(), {
+    // Spelled-out `month: 'short'` name follows the UI language under the ISO
+    // option, so it isn't shown in Swedish (the `sv` sentinel); #8987 follow-up.
+    const dateStr = date.toLocaleDateString(this._dateTimeFormatService.textLocale(), {
       month: 'short',
       day: 'numeric',
     });

--- a/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-actions/add-task-bar-actions.component.ts
@@ -191,6 +191,9 @@ export class AddTaskBarActionsComponent {
       refDate,
       this._dateTimeFormatService.currentLocale(),
       this._translateService,
+      // Spelled-out weekday follows the UI language under the ISO option, so it
+      // isn't shown in Swedish (the `sv` sentinel); #8987 follow-up.
+      this._dateTimeFormatService.textLocale(),
     );
   });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar-mentions.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-mentions.spec.ts
@@ -125,7 +125,7 @@ describe('AddTaskBarComponent Mentions Integration', () => {
     storeSpy.select.and.returnValue(of([]));
     const dateTimeFormatServiceSpy = jasmine.createSpyObj(
       'DateTimeFormatService',
-      ['currentLocale'],
+      ['currentLocale', 'textLocale'],
       {
         dateFormat: () => ({
           parse: 'MM/dd/yyyy',
@@ -134,6 +134,7 @@ describe('AddTaskBarComponent Mentions Integration', () => {
       },
     );
     dateTimeFormatServiceSpy.currentLocale.and.returnValue('en-US');
+    dateTimeFormatServiceSpy.textLocale.and.returnValue('en-US');
     const dateAdapter = jasmine.createSpyObj<DateAdapter<Date>>('DateAdapter', [], {
       getFirstDayOfWeek: () => DEFAULT_FIRST_DAY_OF_WEEK,
       setLocale: () => {},

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -163,8 +163,10 @@ describe('AddTaskBarComponent', () => {
 
   const mockDateTimeFormatService = jasmine.createSpyObj('DateTimeFormatService', [
     'currentLocale',
+    'textLocale',
   ]);
   mockDateTimeFormatService.currentLocale.and.returnValue('en-US');
+  mockDateTimeFormatService.textLocale.and.returnValue('en-US');
 
   beforeEach(async () => {
     // The state service seeds its note draft (and thus isNoteExpanded) from

--- a/src/app/features/tasks/task-detail-panel/get-task-repeat-info-text.util.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/get-task-repeat-info-text.util.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../../task-repeat-cfg/task-repeat-cfg.model';
 import { T } from '../../../t.const';
 import { TranslateService } from '@ngx-translate/core';
+import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 
 const mockTranslateService = {
   instant: (key: string) => {
@@ -275,6 +276,57 @@ describe('getTaskRepeatInfoText()', () => {
           mockTranslateService,
         ),
       ).toEqual([translationKey, translateParams]);
+    });
+  });
+
+  // #8987 follow-up: under the ISO 8601 option the numeric locale is the `sv`
+  // sentinel; spelled-out weekday names must follow the UI language (from
+  // DateTimeFormatService.textLocale), while numeric day/month keep `locale`.
+  describe('ISO 8601 option (sv sentinel) weekday localization', () => {
+    const isoDateTimeFormatService = {
+      textLocale: () => 'en',
+    } as unknown as DateTimeFormatService;
+
+    it('renders the single-weekday name in the UI language, not Swedish', () => {
+      const [, params] = getTaskRepeatInfoText(
+        {
+          ...DEFAULT_TASK_REPEAT_CFG,
+          id: 'IDDD',
+          repeatEvery: 1,
+          repeatCycle: 'WEEKLY',
+          // DEFAULT has Mon–Fri true; zero them so only Monday is enabled and
+          // the single-weekday branch is exercised.
+          monday: true,
+          tuesday: false,
+          wednesday: false,
+          thursday: false,
+          friday: false,
+          saturday: false,
+          sunday: false,
+        },
+        'sv',
+        isoDateTimeFormatService,
+        mockTranslateService,
+      );
+      // English 'Mon', not Swedish 'mån'.
+      expect(params.weekdayStr).toBe('Mon');
+    });
+
+    it('keeps numeric day/month on the configured (sv, day-first) locale', () => {
+      const [, params] = getTaskRepeatInfoText(
+        {
+          ...DEFAULT_TASK_REPEAT_CFG,
+          id: 'IDDD',
+          repeatEvery: 1,
+          repeatCycle: 'YEARLY',
+          startDate: '2022-02-24',
+        },
+        'sv',
+        isoDateTimeFormatService,
+        mockTranslateService,
+      );
+      // sv keeps day-first ordering '24/2' (would be '2/24' under en).
+      expect(params.dayAndMonthStr).toBe('24/2');
     });
   });
 

--- a/src/app/features/tasks/task-detail-panel/get-task-repeat-info-text.util.ts
+++ b/src/app/features/tasks/task-detail-panel/get-task-repeat-info-text.util.ts
@@ -18,6 +18,10 @@ export const getTaskRepeatInfoText = (
   dateTimeFormatService: DateTimeFormatService | undefined,
   translateService: TranslateService,
 ): [string, { [key: string]: string | number }] => {
+  // Spelled-out weekday names follow the UI language under the ISO 8601 option
+  // (the `sv` sentinel would otherwise leak Swedish, e.g. "mån"); numeric day/
+  // month below stay on `locale` so ISO day-first ordering is kept. #8987 f/u.
+  const weekdayLocale = dateTimeFormatService?.textLocale() ?? locale;
   const timeStr =
     repeatCfg.startTime && isValidSplitTime(repeatCfg.startTime)
       ? dateTimeFormatService
@@ -82,7 +86,7 @@ export const getTaskRepeatInfoText = (
       ];
 
     case 'WEEKLY':
-      const localWeekDays = getWeekdaysMin(locale);
+      const localWeekDays = getWeekdaysMin(weekdayLocale);
       const enabledDays = TASK_REPEAT_WEEKDAY_MAP.filter((day) => repeatCfg[day]);
 
       if (enabledDays.length === 1) {
@@ -90,7 +94,7 @@ export const getTaskRepeatInfoText = (
           (day) => repeatCfg[day],
         );
         const weekDayDate = new Date(Date.UTC(2026, 0, 4 + enabledDayIndex));
-        const weekdayStr = weekDayDate.toLocaleDateString(locale, {
+        const weekdayStr = weekDayDate.toLocaleDateString(weekdayLocale, {
           weekday: 'short',
           timeZone: 'UTC',
         });
@@ -134,7 +138,7 @@ export const getTaskRepeatInfoText = (
     case 'MONTHLY':
       if (hasNthWeekdayAnchor(repeatCfg)) {
         const weekDayDate = new Date(Date.UTC(2026, 0, 4 + repeatCfg.monthlyWeekday));
-        const weekdayStr = weekDayDate.toLocaleDateString(locale, {
+        const weekdayStr = weekDayDate.toLocaleDateString(weekdayLocale, {
           weekday: 'long',
           timeZone: 'UTC',
         });

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
@@ -79,6 +79,7 @@ describe('TaskDetailPanelComponent paste handler', () => {
       ['formatDateTime'],
       {
         currentLocale: jasmine.createSpy().and.returnValue('en'),
+        textLocale: jasmine.createSpy().and.returnValue('en'),
       },
     );
     const mockStore = jasmine.createSpyObj('Store', ['select', 'dispatch', 'pipe']);


### PR DESCRIPTION
## Problem

Follow-up to #9013 (now merged; fixes #8987). That PR localized ISO 8601 spelled-out weekday/month names inside `CustomDateAdapter`, fixing every `<mat-calendar>`. But some components format dates **directly** via `toLocaleDateString(currentLocale(), …)`, bypassing the adapter — so they still leaked Swedish under the ISO option.

Reported by @cdnia on #9013: in the **Add Recurring Task Config** dialog (task detail → Recur → `+`), the **"Start date" value** renders in Swedish (e.g. `ons 15 juli 2026`) and ignores the UI language — the *label* translates but the *value* doesn't.

**Root cause:** the ISO 8601 option stores `dateTimeLocale = 'sv'` (the sentinel that yields `YYYY-MM-DD` + a 24h clock). `plannedStartDateStr` formats the value with `toLocaleDateString(currentLocale(), { weekday: 'short', month: 'short', … })`, so the spelled-out names come out Swedish. Same class of bug also affects the dialog's **quick-setting labels** (`Weekly on onsdag`, `On the first onsdag …`), which build the weekday via `buildRepeatQuickSettingOptions` — shared with the add-task-bar.

## Solution

Mirror #9013's principle at the one shared boundary: **spelled-out names follow the UI language; numeric dates and clock times keep the configured locale** (so ISO stays `YYYY-MM-DD` and 24h is preserved).

- Add `DateTimeFormatService.textLocale` = `isoTextLocale() ?? currentLocale()` — the canonical locale for spelled-out names.
- `plannedStartDateStr`: format the spelled-out date with `textLocale()`; keep the clock time on `currentLocale()`.
- `buildRepeatQuickSettingOptions`: new `weekdayLocale` param used only for the spelled-out weekday; numeric day/month keep `locale` so ISO day-first ordering (`15/7`) is preserved. The dialog and `add-task-bar-actions` pass `textLocale()`. The dialog's formly options memo key now tracks `textLocale`.

## Type of Change

- [x] Bug fix

## Validation

- `date-time-format.service.spec.ts` — `textLocale` resolves to the UI language under the ISO option (tracking language switches) and to the configured locale otherwise.
- `build-repeat-quick-setting-options.spec.ts` — `weekdayLocale` localizes the weekday while numeric day/month stay on `locale`; defaults to `locale` when omitted.
- `dialog-edit-task-repeat-cfg.component.spec.ts` — start-date value renders in the UI language (not `sv`) under the ISO option, and keeps native spelled-out names for non-ISO locales.
- All 6 affected spec files green; `npm run checkFile` clean on every modified file.
