### PR TITLE
fix(api): map plannedAt to dueWithTime

### DIFF
--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -311,7 +311,7 @@ curl -X POST http://127.0.0.1:3876/tasks/task-id/archive
 | `title` (required)   | Non-empty string                                                                                                                                                                                                                                                                                  |
 | `parentId`           | Create the task as a subtask of this top-level task. Returns 404 if parent missing, 400 if parent is itself a subtask. The new subtask inherits the parent's `projectId` and never has its own tags — supplying `projectId` or `tagIds` together with `parentId` returns 400 `UNSUPPORTED_FIELD`. |
 | `subTaskIds`         | Not supported on create — returns 400 `UNSUPPORTED_FIELD`. Create the parent first, then create each child with `parentId`.                                                                                                                                                                       |
-| other allowed fields | `notes`, `isDone`, `timeEstimate`, `timeSpent`, `projectId`, `tagIds`, `dueDay`, `dueWithTime`, `plannedAt`                                                                                                                                                                                       |
+| other allowed fields | `notes`, `isDone`, `timeEstimate`, `timeSpent`, `projectId`, `tagIds`, `dueDay`, `dueWithTime`; deprecated alias: `plannedAt` maps to `dueWithTime` when `dueWithTime` is not supplied.                                                                                                           |
 
 **PATCH /tasks/:id — restricted fields:**
 

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -585,6 +585,22 @@ describe('LocalRestApiHandlerService', () => {
         });
       });
 
+      it('should return 400 with plannedAt in the error path when legacy plannedAt has an invalid type', async () => {
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/tasks', {
+            body: { title: 'New Task', plannedAt: 'not-a-number' },
+          }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('INVALID_INPUT');
+        expect((response.body as any).error.details).toContain(
+          jasmine.objectContaining({ path: '$input.plannedAt' }),
+        );
+        expect(taskServiceMock.add).not.toHaveBeenCalled();
+      });
+
       it('should return 400 when an allowed field has an invalid type', async () => {
         const response = await sendRequestAndWait(
           createRequest('POST', '/tasks', {
@@ -824,6 +840,23 @@ describe('LocalRestApiHandlerService', () => {
         });
       });
 
+      it('should let dueWithTime override plannedAt when updating a task', async () => {
+        const mockTask = createMockTask('task-1');
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(mockTask),
+        });
+
+        await sendRequestAndWait(
+          createRequest('PATCH', '/tasks/task-1', {
+            body: { plannedAt: 1, dueWithTime: 2 },
+          }),
+        );
+
+        expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
+          dueWithTime: 2,
+        });
+      });
+
       it('should map null plannedAt to clearing dueWithTime when updating a task', async () => {
         const mockTask = createMockTask('task-1', { dueWithTime: 1 });
         Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
@@ -839,6 +872,27 @@ describe('LocalRestApiHandlerService', () => {
         expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
           dueWithTime: null,
         });
+      });
+
+      it('should return 400 with plannedAt in the error path when legacy plannedAt has an invalid type on PATCH', async () => {
+        const mockTask = createMockTask('task-1');
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(mockTask),
+        });
+
+        const response = await sendRequestAndWait(
+          createRequest('PATCH', '/tasks/task-1', {
+            body: { plannedAt: 'not-a-number' },
+          }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('INVALID_INPUT');
+        expect((response.body as any).error.details).toContain(
+          jasmine.objectContaining({ path: '$input.plannedAt' }),
+        );
+        expect(taskServiceMock.update).not.toHaveBeenCalled();
       });
 
       it('should reject parentId in PATCH body with 400', async () => {

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -543,6 +543,48 @@ describe('LocalRestApiHandlerService', () => {
         });
       });
 
+      it('should map plannedAt to dueWithTime when creating a task', async () => {
+        const plannedAt = new Date('2026-07-12T10:00:00Z').getTime();
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(createMockTask('new-task-id')),
+        });
+
+        await sendRequestAndWait(
+          createRequest('POST', '/tasks', {
+            body: {
+              title: 'New Task',
+              plannedAt,
+            },
+          }),
+        );
+
+        expect(taskServiceMock.add).toHaveBeenCalledWith('New Task', false, {
+          title: 'New Task',
+          dueWithTime: plannedAt,
+        });
+      });
+
+      it('should let dueWithTime override plannedAt when creating a task', async () => {
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(createMockTask('new-task-id')),
+        });
+
+        await sendRequestAndWait(
+          createRequest('POST', '/tasks', {
+            body: {
+              title: 'New Task',
+              plannedAt: 1,
+              dueWithTime: 2,
+            },
+          }),
+        );
+
+        expect(taskServiceMock.add).toHaveBeenCalledWith('New Task', false, {
+          title: 'New Task',
+          dueWithTime: 2,
+        });
+      });
+
       it('should return 400 when an allowed field has an invalid type', async () => {
         const response = await sendRequestAndWait(
           createRequest('POST', '/tasks', {
@@ -761,6 +803,41 @@ describe('LocalRestApiHandlerService', () => {
 
         expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
           title: 'Updated',
+        });
+      });
+
+      it('should map plannedAt to dueWithTime when updating a task', async () => {
+        const plannedAt = new Date('2026-07-13T09:30:00Z').getTime();
+        const mockTask = createMockTask('task-1');
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(mockTask),
+        });
+
+        await sendRequestAndWait(
+          createRequest('PATCH', '/tasks/task-1', {
+            body: { plannedAt },
+          }),
+        );
+
+        expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
+          dueWithTime: plannedAt,
+        });
+      });
+
+      it('should map null plannedAt to clearing dueWithTime when updating a task', async () => {
+        const mockTask = createMockTask('task-1', { dueWithTime: 1 });
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(mockTask),
+        });
+
+        await sendRequestAndWait(
+          createRequest('PATCH', '/tasks/task-1', {
+            body: { plannedAt: null },
+          }),
+        );
+
+        expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
+          dueWithTime: null,
         });
       });
 

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -47,7 +47,9 @@ const REJECTED_TASK_FIELDS = ['parentId', 'subTaskIds'] as const;
  */
 const SUBTASK_INHERITED_FIELDS = ['projectId', 'tagIds'] as const;
 
-const pickAllowedFields = (body: Record<string, unknown>): Partial<Task> => {
+const pickAllowedFields = (
+  body: Record<string, unknown>,
+): Partial<WritableTaskFields> => {
   const result: Record<string, unknown> = {};
   for (const key of Object.keys(body)) {
     if (ALLOWED_TASK_FIELDS.has(key)) {
@@ -55,6 +57,11 @@ const pickAllowedFields = (body: Record<string, unknown>): Partial<Task> => {
     }
   }
 
+  return result as Partial<WritableTaskFields>;
+};
+
+const mapLegacyPlannedAt = (fields: Partial<WritableTaskFields>): Partial<Task> => {
+  const result: Record<string, unknown> = { ...fields };
   if (
     Object.prototype.hasOwnProperty.call(result, 'plannedAt') &&
     !Object.prototype.hasOwnProperty.call(result, 'dueWithTime')
@@ -96,7 +103,7 @@ type FieldTypeError = { path: string; expected: string };
  * reject bad input with a clean 400 before anything is dispatched.
  */
 const validateWritableFields = (
-  fields: Partial<Task>,
+  fields: Partial<WritableTaskFields>,
 ): { ok: true } | { ok: false; errors: FieldTypeError[] } => {
   const result = typia.validate<WritableTaskFields>(fields);
   if (result.success) {
@@ -401,9 +408,9 @@ export class LocalRestApiHandlerService {
     }
 
     const title = body.title.trim();
-    const additionalFields = pickAllowedFields(body);
+    const writableFields = pickAllowedFields(body);
 
-    const validation = validateWritableFields(additionalFields);
+    const validation = validateWritableFields(writableFields);
     if (!validation.ok) {
       return createErrorResponse(
         requestId,
@@ -413,6 +420,8 @@ export class LocalRestApiHandlerService {
         validation.errors,
       );
     }
+
+    const additionalFields = mapLegacyPlannedAt(writableFields);
 
     if ('parentId' in body) {
       if (typeof body.parentId !== 'string' || !body.parentId) {
@@ -504,8 +513,8 @@ export class LocalRestApiHandlerService {
           );
         }
 
-        const changes = pickAllowedFields(body);
-        const validation = validateWritableFields(changes);
+        const writableFields = pickAllowedFields(body);
+        const validation = validateWritableFields(writableFields);
         if (!validation.ok) {
           return createErrorResponse(
             requestId,
@@ -515,6 +524,8 @@ export class LocalRestApiHandlerService {
             validation.errors,
           );
         }
+
+        const changes = mapLegacyPlannedAt(writableFields);
 
         const task = await this._getTaskById(taskId);
         if (!task) {

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -54,6 +54,15 @@ const pickAllowedFields = (body: Record<string, unknown>): Partial<Task> => {
       result[key] = body[key];
     }
   }
+
+  if (
+    Object.prototype.hasOwnProperty.call(result, 'plannedAt') &&
+    !Object.prototype.hasOwnProperty.call(result, 'dueWithTime')
+  ) {
+    result['dueWithTime'] = result['plannedAt'];
+  }
+  delete result['plannedAt'];
+
   return result as Partial<Task>;
 };
 
@@ -75,7 +84,7 @@ interface WritableTaskFields {
   tagIds?: string[];
   dueDay?: string | null;
   dueWithTime?: number | null;
-  plannedAt?: number;
+  plannedAt?: number | null;
 }
 
 type FieldTypeError = { path: string; expected: string };


### PR DESCRIPTION
## Problem

Fixes #8951.

The local REST API allowed `plannedAt`, but passed it through as a legacy field instead of scheduling tasks via `dueWithTime`.

## Solution

Map `plannedAt` to `dueWithTime` for task create/update requests, while preserving explicit `dueWithTime` when both fields are provided. `plannedAt: null` clears `dueWithTime` on updates.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Tests

- `NODE_OPTIONS=--max-old-space-size=4096 npm run test:file src/app/core/electron/local-rest-api-handler.service.spec.ts -- --watch=false --browsers=ChromeHeadless`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run checkFile src/app/core/electron/local-rest-api-handler.service.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run checkFile src/app/core/electron/local-rest-api-handler.service.spec.ts`
- `git diff --check`
