### PR TITLE
fix(schedule): keep the layout reference live instead of freezing at first render

### DIFF
--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -482,6 +482,50 @@ describe('ScheduleComponent', () => {
       expect(contextDate.getMonth()).toBe(0);
       expect(contextDate.getFullYear()).toBe(2026);
     });
+
+    it('should keep the reference live as time passes rather than freezing at first read', () => {
+      // The computed caches, and Date.now() is not reactive: without the refresh
+      // tick this pins the layout to whenever the view was first rendered.
+      let clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      // Round-trip through a date: the computed already ran against the real
+      // clock on init, and re-setting null over null would not invalidate it.
+      component['_selectedDate'].set(new Date(2026, 0, 21));
+      component['_selectedDate'].set(null);
+      expect(component['_contextNow']()).toBe(clock);
+
+      clock = new Date(2026, 0, 20, 17, 0, 0).getTime();
+      (mockScheduleService as any).scheduleRefreshTick.set(1);
+
+      expect(component['_contextNow']()).toBe(clock);
+    });
+
+    it('should keep using midnight when today sits later in the displayed week', () => {
+      // Week view can show a range that starts before today; day 0 is fully
+      // elapsed, so it stays the layout reference.
+      const clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+
+      component['_selectedDate'].set(new Date(2026, 0, 19));
+
+      expect(component['_contextNow']()).toBe(new Date(2026, 0, 19).setHours(0, 0, 0, 0));
+    });
+
+    it('should switch to the real now once the viewed day rolls over into today', () => {
+      // Viewing tomorrow at 22:00, then the app is left open past midnight. The
+      // view does not move, so the day it shows silently becomes today.
+      let clock = new Date(2026, 0, 20, 22, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      component['_selectedDate'].set(new Date(2026, 0, 21));
+      expect(component['_contextNow']()).toBe(new Date(2026, 0, 21).setHours(0, 0, 0, 0));
+
+      // Rollover happens at 00:00 and the user comes back at 09:00; only the
+      // refresh tick moves, exactly as in production.
+      clock = new Date(2026, 0, 21, 9, 0, 0).getTime();
+      (mockScheduleService as any).scheduleRefreshTick.set(1);
+
+      expect(component['_contextNow']()).toBe(clock);
+    });
   });
 
   describe('scheduleDays computed', () => {
@@ -524,10 +568,12 @@ describe('ScheduleComponent', () => {
     });
 
     it('should pass both contextNow and realNow when viewing a future date', () => {
-      // Arrange
-      const futureDate = new Date();
-      futureDate.setDate(futureDate.getDate() + 7);
-      component['_selectedDate'].set(futureDate);
+      // Arrange - a week past the mocked today (2026-01-20). The clock is pinned
+      // so both timestamps can be named exactly; asserting only that they differ
+      // would pass for arbitrary wrong values.
+      const clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      component['_selectedDate'].set(new Date(2026, 0, 27));
       mockScheduleService.createScheduleDaysWithContext.calls.reset();
 
       // Act
@@ -536,10 +582,8 @@ describe('ScheduleComponent', () => {
       // Assert
       const callArgs =
         mockScheduleService.createScheduleDaysWithContext.calls.mostRecent().args[0];
-      expect(callArgs.contextNow).toBeDefined();
-      expect(callArgs.realNow).toBeDefined();
-      // contextNow should be different from realNow when viewing future
-      expect(callArgs.contextNow).not.toBe(callArgs.realNow);
+      expect(callArgs.contextNow).toBe(new Date(2026, 0, 27).setHours(0, 0, 0, 0));
+      expect(callArgs.realNow).toBe(clock);
     });
   });
 

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -511,6 +511,23 @@ describe('ScheduleComponent', () => {
       expect(component['_contextNow']()).toBe(new Date(2026, 0, 19).setHours(0, 0, 0, 0));
     });
 
+    it('should never anchor day 0 with a now that falls outside it', () => {
+      // contextNow anchors dayDates[0], so a now past that day's end would push
+      // every day-0 entry over its boundary and empty the column. Reachable with
+      // a custom start-of-next-day, where the logical "today" is still Jan 20
+      // while the wall clock already reads 02:00 on Jan 21.
+      const clock = new Date(2026, 0, 21, 2, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+
+      component['_selectedDate'].set(new Date(2026, 0, 20));
+
+      const contextNow = component['_contextNow']();
+      expect(contextNow).toBeGreaterThanOrEqual(
+        new Date(2026, 0, 20).setHours(0, 0, 0, 0),
+      );
+      expect(contextNow).toBeLessThan(new Date(2026, 0, 21).setHours(0, 0, 0, 0));
+    });
+
     it('should switch to the real now once the viewed day rolls over into today', () => {
       // Viewing tomorrow at 22:00, then the app is left open past midnight. The
       // view does not move, so the day it shows silently becomes today.

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -225,15 +225,33 @@ export class ScheduleComponent {
   // Calculate context-aware "now" based on selected date
   // When viewing a future week, use the start of that week as reference time
   private _contextNow = computed(() => {
+    // Date.now() is not reactive and computeds cache, so without a time-varying
+    // dependency the reference would freeze at whatever instant this last ran.
+    // Same 2-min tick currentTimeRow and scheduleDays already refresh on.
+    this.scheduleService.scheduleRefreshTick();
+
     const selectedDate = this._selectedDate();
     if (selectedDate === null) {
       return Date.now();
     }
 
-    // Viewing a different date - use that date's midnight as reference
-    const contextDate = new Date(selectedDate);
-    contextDate.setHours(0, 0, 0, 0);
-    return contextDate.getTime();
+    // contextNow anchors dayDates[0] (`startTime = i == 0 ? now` in
+    // create-schedule-days), so it has to stay inside that day. Testing where the
+    // wall clock sits within the selected day - rather than comparing day strings -
+    // lets the view self-correct once it drifts under a midnight rollover (a day
+    // picked as "tomorrow" becomes today while the view stays put), and can never
+    // hand the mapper a now past day 0's end, which would push every entry out of
+    // the column.
+    const dayStart = new Date(selectedDate);
+    dayStart.setHours(0, 0, 0, 0);
+    // setDate rather than +24h: DST-safe day advancement.
+    const nextDayStart = new Date(dayStart);
+    nextDayStart.setDate(nextDayStart.getDate() + 1);
+
+    const now = Date.now();
+    return now >= dayStart.getTime() && now < nextDayStart.getTime()
+      ? now
+      : dayStart.getTime();
   });
 
   scheduleDays = computed(() => {


### PR DESCRIPTION
## Problem

`_contextNow` decides the reference time the Schedule lays events out against. It is a `computed` that returns `Date.now()` — but nothing it reads advances with the clock, so Angular caches the value until `_selectedDate` changes. The layout reference freezes at whatever instant the view was first rendered.

That is not an edge case. In the default state (`_selectedDate === null`) the computed reads one signal and returns early, so it never updates at all:

```ts
const selectedDate = this._selectedDate();
if (selectedDate === null) {
  return Date.now();   // cached from here on
}
```

Open the Schedule at 09:00 and look at it at 17:00: `msLeftToday()` still budgets 15h, and today's unscheduled tasks still lay out from 09:00 — above a now-line that has since marched down the grid. Verified with a spec against the real component: **8h of drift, no midnight or navigation involved.**

The irony is that the refresh machinery already runs. `scheduleDays` reads `scheduleRefreshTick()` (via `createScheduleDaysWithContext`, `schedule.service.ts:125`) and so re-runs the full layout every 2 minutes — all day, each time handed the same frozen reference. `currentTimeRow` rides that tick too. `_contextNow` was the one clock-reading computed that skipped it.

### The rollover case

The same freeze has a second face. The view does not move when the clock does: leave the app open past midnight and a day picked as "tomorrow" silently becomes today, while `_contextNow` still reports its `00:00`. `isViewingToday()` compares day *strings*, so it flips to `true` and the now-line is drawn — but the layout reference stays at midnight, so `msLeftToday(midnight)` reports a full 24h for a day already partly gone and today's tasks lay out from `00:00`.

## Fix

Read `scheduleRefreshTick()` in `_contextNow` — the same 2-minute cadence `currentTimeRow` and `scheduleDays` already use. Staleness drops from "forever" to 2 minutes, and both faces of the bug go with it.

**No added change-detection work:** `scheduleDays` already recomputes on that tick, so `_contextNow` re-running on it costs one array-free comparison. Measured against the repo's `@angular/core`: identical layout-recompute counts before and after.

Then decide the reference by **where the wall clock sits inside the selected day**, rather than by comparing day strings:

```ts
const now = Date.now();
return now >= dayStart.getTime() && now < nextDayStart.getTime()
  ? now
  : dayStart.getTime();
```

Deliberately **not** `daysToShow()[0] === this._todayDateStr()`. That mixes two notions of "today": `todayStr()` applies the start-of-next-day offset, `todayStr(date)` does not (`date.service.ts:64-74`, which documents exactly this). With a custom rollover configured the two disagree between midnight and the rollover hour, so the guard could return a `now` **outside day 0**. Since `create-schedule-days` anchors `dayDates[0]` with `startTime = i == 0 ? now`, that pushes every day-0 entry past its boundary and empties the first column. Making the reference live is what would have unmasked it.

Testing the clock's position makes that structural: the reference can never land outside day 0. It also drops `_todayDateStr` and `daysToShow` out of `_contextNow`, leaving `_selectedDate` as the single source — no dual-source divergence to reason about.

Behaviour preserved:

- **Week view, today later in the range** — day 0 is fully elapsed, so it stays the reference (the clock is outside it).
- **Month view** — unchanged. `getMonthDaysToShow` starts on a previous-month padding day, so `daysToShow()[0]` and `_selectedDate` disagree there; deriving midnight from `_selectedDate` keeps month view byte-identical. Its day-0 incoherence is pre-existing and left for its own change.
- **DST** — `setDate(+1)` rather than `+24h`, so the day window is correct across transitions.

The stale `_selectedDate` itself is left alone: after rollover it leaves Prev and Today disabled, which is correct — today really is in view.

## Testing

- New spec pins the reference staying live as time passes (fails without the tick: returns 09:00 at 17:00).
- Rollover spec moves **only the refresh tick**, as production does. The previous version set `Date.now()` to 09:00 and *then* emitted the day change, which models wake-from-sleep — it passed even while the value was frozen.
- New spec pins the invariant that day 0 is never anchored with a `now` outside it.
- The future-date spec asserted only `contextNow !== realNow`, which passes for arbitrary wrong values; it now names both timestamps exactly.
- Reverting `_contextNow` to the previous implementation fails 6 specs — the tests catch the bug rather than describe it.
- Full suite green on both TZ variants (12907 / 12893, 0 failures). `npm run checkFile` clean on both files.

Verified in the running app (`ng serve`, week view, one estimated task), not just in specs:

| | first shown event | grid row |
|---|---|---|
| 14:39:04 | top 511 | 177 |
| 14:45:24 | top 520 | 178 |

The reference tracks the clock live — the event steps down exactly one row over ~6 minutes. Because `FH = 12` quantises the grid to 5-minute rows (`startRow = Math.round(hoursToday * FH) + 1`), a single 2-minute tick rounds away: the layout settles by one ~9px step roughly every 5 minutes rather than re-flowing on every tick. No console or page errors.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)
