### PR TITLE
fix(project): keep taskIds unique on replayed move-to-done (#8469)

### DIFF
--- a/src/app/features/project/store/project.reducer.spec.ts
+++ b/src/app/features/project/store/project.reducer.spec.ts
@@ -383,6 +383,32 @@ describe('projectReducer', () => {
       // When target is DONE and afterTaskId is null, append to end
       expect((r.entities as any).P1.taskIds).toEqual(['T1', 'T2', 'B1']);
     });
+
+    it('should not duplicate the task id when re-replayed (DONE, null anchor) (#8469)', () => {
+      const s = fakeEntityStateFromArray([
+        {
+          id: 'P1',
+          taskIds: ['T1', 'T2'],
+          backlogTaskIds: ['B1', 'B2'],
+          isEnableBacklog: true,
+        },
+      ] as Partial<Project>[]);
+
+      const action = moveProjectTaskToRegularList({
+        taskId: 'B1',
+        afterTaskId: null,
+        workContextId: 'P1',
+        src: 'BACKLOG',
+        target: 'DONE',
+      }) as any;
+
+      // Re-applying the same op on top of already-applied state (snapshot
+      // re-replay window, #8469) must not append the id a second time.
+      const once = projectReducer(s as any, action);
+      const twice = projectReducer(once, action);
+      expect((twice.entities as any).P1.taskIds).toEqual(['T1', 'T2', 'B1']);
+      expect((twice.entities as any).P1.backlogTaskIds).toEqual(['B2']);
+    });
   });
 
   describe('moveTaskInTodayList (anchor-based)', () => {

--- a/src/app/features/project/store/project.reducer.ts
+++ b/src/app/features/project/store/project.reducer.ts
@@ -333,10 +333,12 @@ export const projectReducer = createReducer<ProjectState>(
 
       const filteredBacklog = backlogIdsBefore.filter(filterOutId(taskId));
       // When moving to DONE section with null anchor, append to end
-      // Otherwise use standard anchor-based positioning
+      // Otherwise use standard anchor-based positioning.
+      // Filter the id out before appending (like moveItemAfterAnchor does) so an
+      // op re-replayed on top of already-applied state can't duplicate it (#8469).
       const newTodaysTaskIds =
         afterTaskId === null && target === 'DONE'
-          ? [...todaysTaskIdsBefore, taskId]
+          ? [...todaysTaskIdsBefore.filter(filterOutId(taskId)), taskId]
           : moveItemAfterAnchor(taskId, afterTaskId, todaysTaskIdsBefore);
 
       return projectAdapter.updateOne(


### PR DESCRIPTION
## Summary

One branch of `moveProjectTaskToRegularList` — moving to the DONE section with a `null` anchor — appended the task id with a plain `[...taskIds, taskId]`, without filtering the id out first the way `moveItemAfterAnchor` does. If the op is re-applied on top of state that already contains its effect (the op-log snapshot/compaction re-replay window, #8469), the project's `taskIds` ordering ends up with a duplicated id that self-syncs to other devices and that `dataRepair` does not de-duplicate.

This makes the branch idempotent: filter the id out before appending, mirroring the anchor helper. In every live flow the action is dispatched with `src === 'BACKLOG'` (task not yet in `taskIds`), so the filter is a no-op there — behavior only changes on re-replay over already-applied state (no more duplicate) and on already-corrupted duplicate state (now self-heals on the next move).

Part of #8469 (one of the two reducer-level regression tests its fix plan calls for). Complementary to the planned `flushThenRunExclusive` quiesce fix at the state-cache writers: reducer idempotence also protects replay of ops produced by older clients, which the capture-site fix cannot.

## Test

- New regression test applies the same action twice through the real reducer and asserts no duplicated id (the double-apply failure mode).
- `project.reducer.spec.ts`: 36/36 green; `checkFile` clean on both files.