### PR TITLE
Point Dashboard plugin to maintained fork (original archived)

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -66,9 +66,9 @@
   {
     "name": "Dashboard",
     "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
-    "url": "https://github.com/dougcooper/sp-dashboard",
-    "author": "dougcooper",
-    "authorUrl": "https://github.com/dougcooper",
+    "url": "https://github.com/ahanel13/sp-dashboard",
+    "author": "ahanel13",
+    "authorUrl": "https://github.com/ahanel13",
     "stars": 43
   },
   {

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -65,11 +65,11 @@
   },
   {
     "name": "Dashboard",
-    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project breakdowns within a user‑defined date range. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
+    "shortDescription": "A lightweight dashboard plugin that visualizes time tracked, completed tasks, overdue items, and project/tag breakdowns within a user‑defined date range, with live time tracking and chart share/export. It ships as a self-contained HTML/JavaScript widget with no external dependencies and is styled to support light/dark themes.",
     "url": "https://github.com/ahanel13/sp-dashboard",
     "author": "ahanel13",
     "authorUrl": "https://github.com/ahanel13",
-    "stars": 43
+    "stars": 9
   },
   {
     "name": "Invoicer",


### PR DESCRIPTION
## What

Updates the **Dashboard** entry in `src/assets/community-plugins.json` to point at the actively maintained fork at [ahanel13/sp-dashboard](https://github.com/ahanel13/sp-dashboard).

## Why

The original repository, `dougcooper/sp-dashboard`, has been **archived** by its author and is no longer maintained (last activity around February). I have been maintaining a fork that is currently at v1.5.0 with a number of fixes and features on top of the original, including timezone/date handling fixes, chart improvements, live time tracking, and share/export.

The original author has given their blessing for this move: they archived the upstream repo, added me as a collaborator, and agreed to point users to the fork. See dougcooper/sp-dashboard#18 for the full discussion.

## Changes

The Dashboard entry now reads:

- `url`: `https://github.com/ahanel13/sp-dashboard`
- `author`: `ahanel13`
- `authorUrl`: `https://github.com/ahanel13`

## Note on stars

I left the `stars` count at its existing value of 43 (from the original repo). The fork itself currently shows a lower count since it is a separate repository. Happy to adjust this to whatever value you prefer.
