### PR TITLE
Add tests for critical task, note, and OAuth paths

### DIFF
--- a/src/app/features/note/store/note.reducer.spec.ts
+++ b/src/app/features/note/store/note.reducer.spec.ts
@@ -1,0 +1,171 @@
+import { loadAllData } from '../../../root-store/meta/load-all-data.action';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { WorkContextType } from '../../work-context/work-context.model';
+import { Note, NoteState } from '../note.model';
+import {
+  initialNoteState,
+  noteReducer,
+  selectNoteById,
+  selectNotesById,
+} from './note.reducer';
+import {
+  addNote,
+  deleteNote,
+  moveNoteToOtherProject,
+  updateNote,
+  updateNoteOrder,
+} from './note.actions';
+
+const createNote = (id: string, partial: Partial<Note> = {}): Note => ({
+  id,
+  projectId: 'projectA',
+  isPinnedToToday: false,
+  content: `note-${id}`,
+  created: 1,
+  modified: 1,
+  ...partial,
+});
+
+const createState = (notes: Note[], todayOrder: string[] = []): NoteState => ({
+  ids: notes.map((note) => note.id),
+  entities: notes.reduce(
+    (acc, note) => {
+      acc[note.id] = note;
+      return acc;
+    },
+    {} as Record<string, Note>,
+  ),
+  todayOrder,
+});
+
+describe('note.reducer', () => {
+  it('should add a note to the top and pin it to today order when applicable', () => {
+    const existing = createNote('n1');
+    const state = createState([existing], []);
+    const newPinned = createNote('n2', { isPinnedToToday: true });
+
+    const result = noteReducer(state, addNote({ note: newPinned }));
+
+    expect(result.ids).toEqual(['n2', 'n1']);
+    expect(result.entities['n2']).toEqual(newPinned);
+    expect(result.todayOrder).toEqual(['n2']);
+  });
+
+  it('should update pinning and keep today order in sync', () => {
+    const note = createNote('n1', { isPinnedToToday: false });
+    const state = createState([note], []);
+
+    const pinned = noteReducer(
+      state,
+      updateNote({ note: { id: 'n1', changes: { isPinnedToToday: true } } }),
+    );
+    expect(pinned.todayOrder).toEqual(['n1']);
+
+    const unpinned = noteReducer(
+      pinned,
+      updateNote({ note: { id: 'n1', changes: { isPinnedToToday: false } } }),
+    );
+    expect(unpinned.todayOrder).toEqual([]);
+  });
+
+  it('should update note order only for non-project contexts', () => {
+    const n1 = createNote('n1');
+    const n2 = createNote('n2');
+    const state = createState([n1, n2], ['n1', 'n2']);
+
+    const forTag = noteReducer(
+      state,
+      updateNoteOrder({
+        ids: ['n2', 'n1'],
+        activeContextType: WorkContextType.TAG,
+        activeContextId: 'TODAY',
+      }),
+    );
+    expect(forTag.todayOrder).toEqual(['n2', 'n1']);
+
+    const forProject = noteReducer(
+      forTag,
+      updateNoteOrder({
+        ids: ['n1', 'n2'],
+        activeContextType: WorkContextType.PROJECT,
+        activeContextId: 'projectA',
+      }),
+    );
+    expect(forProject.todayOrder).toEqual(['n2', 'n1']);
+  });
+
+  it('should remove note and today order entry when deleting', () => {
+    const n1 = createNote('n1', { isPinnedToToday: true });
+    const n2 = createNote('n2');
+    const state = createState([n1, n2], ['n1']);
+
+    const result = noteReducer(
+      state,
+      deleteNote({ id: 'n1', projectId: 'projectA', isPinnedToToday: true }),
+    );
+
+    expect(result.entities['n1']).toBeUndefined();
+    expect(result.ids).toEqual(['n2']);
+    expect(result.todayOrder).toEqual([]);
+  });
+
+  it('should move note to another project', () => {
+    const note = createNote('n1', { projectId: 'p1' });
+    const state = createState([note]);
+
+    const result = noteReducer(
+      state,
+      moveNoteToOtherProject({ note, targetProjectId: 'p2' }),
+    );
+
+    expect(result.entities['n1']?.projectId).toBe('p2');
+  });
+
+  it('should remove project notes via shared deleteProject action', () => {
+    const keep = createNote('n1');
+    const remove = createNote('n2', { isPinnedToToday: true });
+    const state = createState([keep, remove], ['n2']);
+
+    const result = noteReducer(
+      state,
+      TaskSharedActions.deleteProject({
+        projectId: 'projectA',
+        noteIds: ['n2'],
+        allTaskIds: [],
+      }),
+    );
+
+    expect(result.entities['n1']).toBeDefined();
+    expect(result.entities['n2']).toBeUndefined();
+    expect(result.todayOrder).toEqual([]);
+  });
+
+  it('should replace note state on loadAllData when note payload exists', () => {
+    const loadedState = createState([createNote('loaded')], ['loaded']);
+
+    const result = noteReducer(
+      initialNoteState,
+      loadAllData({ appDataComplete: { note: loadedState } as never }),
+    );
+
+    expect(result).toEqual(loadedState);
+  });
+
+  it('should throw from selectNoteById when note does not exist', () => {
+    const state = createState([createNote('n1')]);
+
+    expect(() => selectNoteById.projector(state, { id: 'missing' })).toThrowError(
+      'No note',
+    );
+  });
+
+  it('should select notes by id in input order', () => {
+    const n1 = createNote('n1');
+    const n2 = createNote('n2');
+    const state = createState([n1, n2]);
+
+    const result = selectNotesById.projector(state, { ids: ['n2', 'n1'] });
+
+    expect(result).toEqual([n2, n1]);
+  });
+});

--- a/src/app/features/tasks/store/task.reducer.util.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.util.spec.ts
@@ -1,0 +1,209 @@
+import { Update } from '@ngrx/entity';
+import { INBOX_PROJECT } from '../../project/project.const';
+import { _resetDevErrorState } from '../../../util/dev-error';
+import { DEFAULT_TASK, Task, TaskState } from '../task.model';
+import {
+  deleteTaskHelper,
+  getTaskById,
+  removeTaskFromParentSideEffects,
+  updateDoneOnForTask,
+  updateTimeEstimateForTask,
+  updateTimeSpentForTask,
+} from './task.reducer.util';
+
+const createTask = (id: string, partial: Partial<Task> = {}): Task => ({
+  ...DEFAULT_TASK,
+  id,
+  title: `Task ${id}`,
+  created: 1,
+  projectId: INBOX_PROJECT.id,
+  ...partial,
+});
+
+const createState = (tasks: Task[], currentTaskId: string | null = null): TaskState => ({
+  ids: tasks.map((task) => task.id),
+  entities: tasks.reduce(
+    (acc, task) => {
+      acc[task.id] = task;
+      return acc;
+    },
+    {} as Record<string, Task>,
+  ),
+  currentTaskId,
+  selectedTaskId: null,
+  taskDetailTargetPanel: null,
+  lastCurrentTaskId: null,
+  isDataLoaded: true,
+});
+
+describe('task.reducer.util', () => {
+  const DAY_1 = '2025-01-01';
+  const DAY_2 = '2025-01-02';
+  const DAY_3 = '2025-01-03';
+
+  describe('getTaskById', () => {
+    it('should return task when id exists', () => {
+      const task = createTask('t1');
+      const state = createState([task]);
+
+      expect(getTaskById('t1', state)).toEqual(task);
+    });
+
+    it('should throw when id does not exist', () => {
+      const state = createState([]);
+
+      expect(() => getTaskById('missing', state)).toThrowError('Task not found: missing');
+    });
+  });
+
+  describe('updateDoneOnForTask', () => {
+    it('should set doneOn using explicit payload timestamp when task is completed', () => {
+      const task = createTask('t1', { isDone: false, doneOn: undefined });
+      const state = createState([task]);
+      const upd: Update<Task> = {
+        id: 't1',
+        changes: { isDone: true, doneOn: 123456789 },
+      };
+
+      const result = updateDoneOnForTask(upd, state);
+
+      expect(result.entities['t1']?.doneOn).toBe(123456789);
+    });
+
+    it('should clear doneOn when task is marked undone', () => {
+      const task = createTask('t1', { isDone: true, doneOn: 5555 });
+      const state = createState([task]);
+      const upd: Update<Task> = { id: 't1', changes: { isDone: false } };
+
+      const result = updateDoneOnForTask(upd, state);
+
+      expect(result.entities['t1']?.doneOn).toBeUndefined();
+    });
+
+    it('should keep state unchanged when update does not toggle done state', () => {
+      const task = createTask('t1', { title: 'Before' });
+      const state = createState([task]);
+      const upd: Update<Task> = { id: 't1', changes: { title: 'After' } };
+
+      const result = updateDoneOnForTask(upd, state);
+
+      expect(result).toBe(state);
+    });
+  });
+
+  describe('updateTimeSpentForTask', () => {
+    it('should update child and incrementally roll up parent times', () => {
+      const parent = createTask('parent', {
+        subTaskIds: ['child'],
+        timeSpentOnDay: { [DAY_1]: 30, [DAY_2]: 5 },
+        timeSpent: 35,
+      });
+      const child = createTask('child', {
+        parentId: 'parent',
+        timeSpentOnDay: { [DAY_1]: 30, [DAY_2]: 5 },
+        timeSpent: 35,
+      });
+      const state = createState([parent, child]);
+
+      const result = updateTimeSpentForTask('child', { [DAY_1]: 10, [DAY_3]: 20 }, state);
+
+      expect(result.entities['child']?.timeSpent).toBe(30);
+      expect(result.entities['child']?.timeSpentOnDay).toEqual({
+        [DAY_1]: 10,
+        [DAY_3]: 20,
+      });
+      expect(result.entities['parent']?.timeSpent).toBe(30);
+      expect(result.entities['parent']?.timeSpentOnDay).toEqual({
+        [DAY_1]: 10,
+        [DAY_3]: 20,
+      });
+    });
+  });
+
+  describe('updateTimeEstimateForTask', () => {
+    it('should recalculate parent estimate when subtask done state changes', () => {
+      const parent = createTask('parent', { subTaskIds: ['child'], timeEstimate: 70 });
+      const child = createTask('child', {
+        parentId: 'parent',
+        isDone: false,
+        timeEstimate: 100,
+        timeSpent: 30,
+      });
+      const state = createState([parent, child]);
+      const upd: Update<Task> = { id: 'child', changes: { isDone: true } };
+
+      const result = updateTimeEstimateForTask(upd, null, state);
+
+      expect(result.entities['parent']?.timeEstimate).toBe(0);
+    });
+
+    it('should update estimate and include it in parent recalculation', () => {
+      const parent = createTask('parent', { subTaskIds: ['child'], timeEstimate: 10 });
+      const child = createTask('child', {
+        parentId: 'parent',
+        isDone: false,
+        timeEstimate: 10,
+        timeSpent: 0,
+      });
+      const state = createState([parent, child]);
+      const upd: Update<Task> = { id: 'child', changes: {} };
+
+      const result = updateTimeEstimateForTask(upd, 90, state);
+
+      expect(result.entities['child']?.timeEstimate).toBe(90);
+      expect(result.entities['parent']?.timeEstimate).toBe(90);
+    });
+  });
+
+  describe('deleteTaskHelper', () => {
+    beforeEach(() => {
+      _resetDevErrorState();
+      if (jasmine.isSpy(window.alert)) {
+        (window.alert as jasmine.Spy).and.stub();
+      } else {
+        spyOn(window, 'alert').and.stub();
+      }
+      if (jasmine.isSpy(window.confirm)) {
+        (window.confirm as jasmine.Spy).and.returnValue(false);
+      } else {
+        spyOn(window, 'confirm').and.returnValue(false);
+      }
+    });
+
+    it('should delete payload and orphan subtasks and clear current selection', () => {
+      const parent = createTask('parent', { subTaskIds: ['sub1'] });
+      const payloadSubTask = createTask('sub1', { parentId: 'parent' });
+      const orphanSubTask = createTask('sub2', { parentId: 'parent' });
+      const state = createState([parent, payloadSubTask, orphanSubTask], 'sub2');
+
+      const result = deleteTaskHelper(state, parent);
+
+      expect(result.entities['parent']).toBeUndefined();
+      expect(result.entities['sub1']).toBeUndefined();
+      expect(result.entities['sub2']).toBeUndefined();
+      expect(result.currentTaskId).toBeNull();
+    });
+  });
+
+  describe('removeTaskFromParentSideEffects', () => {
+    it('should copy subtask times to parent when last subtask is removed', () => {
+      const parent = createTask('parent', {
+        subTaskIds: ['sub1'],
+        timeSpentOnDay: {},
+        timeEstimate: 0,
+      });
+      const subTask = createTask('sub1', {
+        parentId: 'parent',
+        timeSpentOnDay: { [DAY_1]: 42 },
+        timeEstimate: 123,
+      });
+      const state = createState([parent, subTask]);
+
+      const result = removeTaskFromParentSideEffects(state, subTask, true);
+
+      expect(result.entities['parent']?.subTaskIds).toEqual([]);
+      expect(result.entities['parent']?.timeSpentOnDay).toEqual({ [DAY_1]: 42 });
+      expect(result.entities['parent']?.timeEstimate).toBe(123);
+    });
+  });
+});

--- a/src/app/plugins/oauth/plugin-oauth-redirect.handler.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth-redirect.handler.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import { PluginOAuthRedirectHandler } from './plugin-oauth-redirect.handler';
+import { PluginOAuthService } from './plugin-oauth.service';
+
+describe('PluginOAuthRedirectHandler', () => {
+  let serviceSpy: jasmine.SpyObj<PluginOAuthService>;
+  let handler: PluginOAuthRedirectHandler;
+
+  beforeEach(() => {
+    serviceSpy = jasmine.createSpyObj<PluginOAuthService>('PluginOAuthService', [
+      'handleRedirectCode',
+      'handleRedirectError',
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        PluginOAuthRedirectHandler,
+        { provide: PluginOAuthService, useValue: serviceSpy },
+      ],
+    });
+
+    handler = TestBed.inject(PluginOAuthRedirectHandler);
+  });
+
+  afterEach(() => {
+    handler.ngOnDestroy();
+  });
+
+  it('should forward OAuth code callbacks from same-origin postMessage', () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        data: {
+          type: 'SP_OAUTH_CALLBACK',
+          code: 'oauth-code',
+          state: 'state-1',
+        },
+      }),
+    );
+
+    expect(serviceSpy.handleRedirectCode).toHaveBeenCalledWith('oauth-code', 'state-1');
+    expect(serviceSpy.handleRedirectError).not.toHaveBeenCalled();
+  });
+
+  it('should forward OAuth error callbacks from same-origin postMessage', () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        data: {
+          type: 'SP_OAUTH_CALLBACK',
+          error: 'access_denied',
+          state: 'state-2',
+        },
+      }),
+    );
+
+    expect(serviceSpy.handleRedirectError).toHaveBeenCalledWith(
+      'access_denied',
+      'state-2',
+    );
+    expect(serviceSpy.handleRedirectCode).not.toHaveBeenCalled();
+  });
+
+  it('should ignore events from a different origin', () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://evil.example.com',
+        data: {
+          type: 'SP_OAUTH_CALLBACK',
+          code: 'oauth-code',
+          state: 'state-1',
+        },
+      }),
+    );
+
+    expect(serviceSpy.handleRedirectCode).not.toHaveBeenCalled();
+    expect(serviceSpy.handleRedirectError).not.toHaveBeenCalled();
+  });
+
+  it('should ignore non-oauth message types', () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        data: {
+          type: 'OTHER_EVENT',
+          code: 'oauth-code',
+        },
+      }),
+    );
+
+    expect(serviceSpy.handleRedirectCode).not.toHaveBeenCalled();
+    expect(serviceSpy.handleRedirectError).not.toHaveBeenCalled();
+  });
+
+  it('should remove window message listener on destroy', () => {
+    const removeSpy = spyOn(window, 'removeEventListener').and.callThrough();
+
+    handler.ngOnDestroy();
+
+    expect(removeSpy).toHaveBeenCalledWith('message', jasmine.any(Function));
+  });
+});


### PR DESCRIPTION
## Problem

Critical business-logic and auth paths had no direct unit coverage, especially around task mutation helpers, note state mutation logic, and OAuth redirect callback handling. These are high-risk paths because they update persisted state and auth flow behavior.

## Solution

Added targeted unit specs for the most critical uncovered code paths:

- `task.reducer.util.spec.ts` covers key mutation helpers, including parent-child time rollups, done-state timestamp behavior, parent estimate recalculation, delete/orphan-subtask cleanup, and parent side effects.
- `note.reducer.spec.ts` covers note add/update/delete/order/move mutations, shared `deleteProject` handling, load hydration behavior, and selector edge cases.
- `plugin-oauth-redirect.handler.spec.ts` covers same-origin OAuth callback handling, message filtering for security, and listener cleanup behavior.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (please describe)

Test coverage for critical mutation/auth paths.

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)