### PR TITLE
test(project): guard project navigation route detection

### DIFF
--- a/e2e/pages/project.page.ts
+++ b/e2e/pages/project.page.ts
@@ -1,6 +1,9 @@
 import { expect, Locator, Page } from '@playwright/test';
 import { BasePage } from './base.page';
 
+export const isProjectTasksRoute = (url: string): boolean =>
+  /\/#\/project\/[^/]+\/tasks(?:[/?#]|$)/.test(url);
+
 export class ProjectPage extends BasePage {
   readonly sidenav: Locator;
   readonly createProjectBtn: Locator;
@@ -144,6 +147,10 @@ export class ProjectPage extends BasePage {
 
     // Helper function to check if we're already on the project
     const isAlreadyOnProject = async (): Promise<boolean> => {
+      if (!isProjectTasksRoute(this.page.url())) {
+        return false;
+      }
+
       try {
         // Use page.evaluate for direct DOM check (most reliable)
         return await this.page.evaluate((name) => {

--- a/e2e/tests/project/project-page-route.spec.ts
+++ b/e2e/tests/project/project-page-route.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { isProjectTasksRoute } from '../../pages/project.page';
+
+test.describe('Project page route detection', () => {
+  test('rejects the archived-projects route', () => {
+    expect(isProjectTasksRoute('http://localhost:4242/#/archived-projects')).toBe(false);
+  });
+
+  test('accepts a project tasks route', () => {
+    expect(isProjectTasksRoute('http://localhost:4242/#/project/project-id/tasks')).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- guard the project-navigation helper's early return with an actual project-tasks route check
- add focused coverage for archived-project and project-task URL classification

## Root cause

Scheduled E2E run [29551670184](https://github.com/super-productivity/super-productivity/actions/runs/29551670184) failed after reopening a completed project. The reopen itself succeeded, but `navigateToProjectByName()` saw stale project-title text in `<main>`, incorrectly assumed it was already on the project, and skipped the sidebar navigation while the URL remained `#/archived-projects`.

## Impact

This fixes the observed project-completion E2E false negative. The change is limited to Playwright test infrastructure and does not alter production behavior.

## Verification

- `npm run checkFile e2e/pages/project.page.ts`
- `npm run checkFile e2e/tests/project/project-page-route.spec.ts`
- route regression spec: 2 passed
- project completion E2E: 1 passed
- `git diff --check`

## Review notes

Independent review confirmed the reported archived-project failure is addressed. This remains a draft because the shared helper has broader pre-existing weaknesses worth resolving before merge:

- navigation success is not target-project-specific when switching between projects
- final navigation verification is currently swallowed instead of failing at the helper boundary
