### PR TITLE
feat(work-view): show custom section task counts

### DIFF
--- a/e2e/tests/work-view/sections.spec.ts
+++ b/e2e/tests/work-view/sections.spec.ts
@@ -304,7 +304,7 @@ test.describe('Sections', () => {
     await expect(sectionByTitle(page, 'Doomed')).toHaveCount(0);
   });
 
-  test('drops a task into a section via drag and drop', async ({
+  test('drops a task into a section and updates its task count', async ({
     page,
     workViewPage,
     projectPage,
@@ -322,6 +322,8 @@ test.describe('Sections', () => {
 
     const section = sectionByTitle(page, 'Target');
     await expect(section).toBeVisible();
+    const sectionTitle = section.locator('.collapsible-title');
+    await expect(sectionTitle).toHaveText('Target (0)');
     // The section's inner task-list is the drop target.
     const sectionTaskList = section.locator('task-list').first();
     const noSectionTaskList = page.locator('.no-section task-list').first();
@@ -336,6 +338,7 @@ test.describe('Sections', () => {
     await expect(section.locator('task').filter({ hasText: 'Movable' })).toBeVisible({
       timeout: 5000,
     });
+    await expect(sectionTitle).toHaveText('Target (1)');
     await expect(
       noSectionTaskList.locator('task').filter({ hasText: 'Movable' }),
     ).toHaveCount(0);

--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -187,7 +187,9 @@
                     [cdkDragLockAxis]="'y'"
                   >
                     <collapsible
-                      [title]="section.title"
+                      [title]="
+                        section.title + ' (' + bySection.dict[section.id].length + ')'
+                      "
                       [isIconBefore]="true"
                       [isExpanded]="section.isExpanded"
                       (isExpandedChange)="


### PR DESCRIPTION
AI-assisted: OpenAI Codex implemented and validated this contribution under the `coyaSONG` account.

## Problem

Custom sections show their names but not task totals, unlike Later Today, Completed Tasks, Recurring Tasks, and other built-in sections.

Fixes #9068.

## Solution

Reuse the existing `undoneTasksBySection()` result to append the current task-list length to every custom-section title. The count updates reactively when tasks move into or out of a section.

The existing Sections Playwright coverage now verifies that the title changes from `Target (0)` to `Target (1)` after a task is dropped into the section.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/wiki. (No existing custom-section documentation required an update.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Validation

- Red-first focused E2E reproduced the missing count (`Target` instead of `Target (0)`)
- Focused Sections E2E: 1/1 passed
- Complete Sections E2E file: 10/10 passed
- WorkView unit spec: 15/15 passed
- Full pre-push unit suite: 13,160 passed, 2 skipped
- Package tests: 647 passed
- Release-note tests: 24 passed
- `npm run checkFile` passed for both changed files
- Full lint passed with 0 errors (9 pre-existing warnings)
- Production frontend build passed; all 23 packages built
- `git diff --check` passed
