### PR TITLE
test(e2e): accept beforeunload prompt in shared dialog fallback

### DIFF
--- a/e2e/tests/sync/supersync-use-remote-crash-resume.spec.ts
+++ b/e2e/tests/sync/supersync-use-remote-crash-resume.spec.ts
@@ -97,11 +97,8 @@ test.describe('@supersync USE_REMOTE interrupted rebuild recovery', () => {
           rebuildCommittedLog: REBUILD_COMMITTED_LOG,
         },
       );
-      // Wait only for `domcontentloaded`, not the default `load`: an active
-      // SuperSync WebSocket/sync connection can keep the page "loading" so the
-      // `load` event never fires and `reload()` times out (flaky). `reload()`
-      // preserves sessionStorage (unlike close()+newPage()), which this test
-      // needs, and `waitForAppReady` below is the real readiness gate.
+      // `reload()` preserves sessionStorage (unlike close()+newPage()), which
+      // this test needs; `waitForAppReady` below is the real readiness gate.
       await clientB.page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
       await waitForAppReady(clientB.page);
 
@@ -136,10 +133,12 @@ test.describe('@supersync USE_REMOTE interrupted rebuild recovery', () => {
 
       await clientB.sync.syncImportUseRemoteBtn.click();
       await crashObserved;
-      // domcontentloaded (not the default `load`) — see the note on the first
-      // reload above: an active sync connection can block `load` and hang
-      // `reload()`. sessionStorage survives the reload; the assertion below
-      // depends on it.
+      // This reload races the crashed sync's unwind: while `isSyncInProgress` is
+      // still set, startup.service's beforeunload handler prevents the unload and
+      // Chrome prompts (the click above supplies the required user activation).
+      // installDevErrorDialogHandler accepts that prompt — without it the
+      // navigation never starts and this hangs. sessionStorage survives the
+      // reload; the assertion below depends on it.
       await clientB.page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
       await waitForAppReady(clientB.page);
       expect(

--- a/e2e/utils/runtime-errors.ts
+++ b/e2e/utils/runtime-errors.ts
@@ -37,6 +37,21 @@ export const attachPageErrorCollector = (
 // explicitly, or it will be vulnerable to the same hang.
 export const installDevErrorDialogHandler = (page: Page, label: string): void => {
   page.on('dialog', async (dialog) => {
+    // Registering ANY 'dialog' listener switches off Playwright's built-in
+    // handling (accept for beforeunload, dismiss for everything else). This
+    // fallback is installed on every page, so it must restore that default for
+    // beforeunload: startup.service raises one whenever a sync is in flight, and
+    // an unanswered prompt blocks the navigation before it starts — reload()
+    // then times out on any waitUntil, however early.
+    if (dialog.type() === 'beforeunload') {
+      try {
+        await dialog.accept();
+      } catch {
+        // Already handled by another listener — ignore.
+      }
+      return;
+    }
+
     const message = dialog.message();
     const isDevErrorAlert = dialog.type() === 'alert' && message.startsWith('devERR:');
     const isDevErrorConfirm =


### PR DESCRIPTION
## What

Fixes the flaky `supersync-use-remote-crash-resume` spec that failed the scheduled E2E run ([SuperSync shard 6/6](https://github.com/super-productivity/super-productivity/actions/runs/29586179514)) with:

```
TimeoutError: page.reload: Timeout 60000ms exceeded.
  - waiting for navigation until "domcontentloaded"
```

This is a harness bug, not a product bug.

## Root cause

The failure trace shows an unanswered `beforeunload` dialog at the exact moment `reload()` hangs:

```
click "Use Server"          ← grants Chrome sticky user activation
DIALOG confirm "This replaces…"  → accepted
reload() starts
DIALOG beforeunload ''      ← never accepted, never dismissed → 60s hang
```

The chain:

1. `startup.service.ts` registers a `beforeunload` handler that calls `preventDefault()` while a sync is in progress. This test reloads Client B *mid-sync*, so it fires.
2. The preceding button click supplies the user activation Chrome requires before it will actually raise the prompt.
3. Playwright auto-accepts `beforeunload` **only when no `'dialog'` listener is registered**. `installDevErrorDialogHandler` registers one on every page and early-returned on `beforeunload`, so the built-in auto-accept was suppressed and nothing answered the prompt.
4. Navigation never starts → `reload()` times out.

This also explains why the earlier `load` → `domcontentloaded` de-flake ([#9028](https://github.com/super-productivity/super-productivity/pull/9028)) couldn't help: the navigation is blocked *before* any lifecycle event, so waiting for an earlier one just changes which timeout fires.

## Fix

Accept `beforeunload` in the shared dialog fallback, restoring Playwright's default. Every other dialog type still flows to the existing devError logic and to any spec-specific handlers. No E2E spec observes `beforeunload` (the only reference in the tree is `startup.service.ts`), so this cannot steal a dialog a test wants.

Also corrects the two crash-resume comments that had blamed the WebSocket keeping the page "loading".

## Verification

Opening this PR runs the `E2E Sync (PR Gate)` workflow (6 SuperSync shards + WebDAV), which re-runs the previously-failing spec. Note the hang is a race, so a green run is strong corroboration rather than proof — the definitive evidence is the trace above plus Playwright's confirmed auto-accept suppression.