### PR TITLE
Update community-plugins.json - feat(community-plugins): add Goals Vision Board

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -126,5 +126,13 @@
     "author": "jloops412",
     "authorUrl": "https://github.com/jloops412",
     "stars": 0
+  },
+  {
+    "name": "Goals Vision Board",
+    "shortDescription": "A customizable two-page visual board for long-term goals, reminders, notes, images, tags, checklists, and metrics.",
+    "url": "https://github.com/CuriousChipmunk/vision-board-super-productivity",
+    "author": "CuriousChipmunk",
+    "authorUrl": "https://github.com/CuriousChipmunk",
+    "stars": 0
   }
 ]


### PR DESCRIPTION
## Problem

Goals Vision Board is not currently listed in the Super Productivity community plugin catalogue, so users cannot discover it through the app’s community plugin section.

## Solution

Adds Goals Vision Board to src/assets/community-plugins.json.

Plugin repository:

https://github.com/CuriousChipmunk/vision-board-super-productivity

Goals Vision Board is a customizable two-page visual board for long-term goals, reminders, notes, images, tags, checklists, and metrics.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)
