### PR TITLE
fix(supersync): prevent migrator advisory-lock leak on deploy timeout

### DIFF
--- a/packages/super-sync-server/env.example
+++ b/packages/super-sync-server/env.example
@@ -115,7 +115,14 @@ SMTP_FROM="Super Productivity Sync" <noreply@your-domain.com>
 
 # Timeout in seconds for `prisma migrate deploy` during ./scripts/deploy.sh.
 # Online index builds (CREATE INDEX CONCURRENTLY) can block on long-running
-# transactions; raise this for very large tables. Exit code 124 = timed out.
+# transactions; raise this for very large tables (3600 is a safe starting point
+# for a large operations table — the 900 default can SIGTERM a slow index build
+# part-way through). A timed-out migrator container is now force-removed, so a
+# too-low value no longer wedges the NEXT deploy with a leaked advisory lock
+# (P1002); the deploy fails loudly with copy-paste recovery steps instead. Note
+# an interrupted CREATE INDEX CONCURRENTLY can still need a one-time INVALID-index
+# drop (the failure output prints the exact steps) before the re-run succeeds.
+# Exit code 124 = timed out.
 # MIGRATION_TIMEOUT=900
 
 # Per-migration-step timeout (seconds) enforced inside the image. deploy.sh

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -297,11 +297,46 @@ if [ "$MIGRATION_TIMEOUT" -gt 90 ]; then
 else
     MIGRATE_STEP_TIMEOUT="${MIGRATE_STEP_TIMEOUT:-$MIGRATION_TIMEOUT}"
 fi
-MIGRATOR_RUN="docker compose $COMPOSE_FILES run --rm --no-deps --interactive=false -T -e MIGRATE_STEP_TIMEOUT=$MIGRATE_STEP_TIMEOUT supersync"
+# One-off migrator containers run under `timeout`. A timed-out `docker compose
+# run` SIGTERMs the compose CLI but can leave the container (and its DB
+# connection) running detached, which keeps Prisma's session-level migration
+# advisory lock held and wedges the NEXT deploy with P1002. Give every run
+# container a per-deploy name and force-remove it after each run — plus an EXIT
+# sweep — so the connection and lock are always released with this deploy.
+#
+# Single source of truth for the names: used to BOTH name each container and
+# sweep them, so the two must stay in lockstep. $$-scoped so the sweep can never
+# touch a concurrent deploy's (or a live build's) container.
+MIGRATOR_NAME_PREFIX="supersync-migrator-$$"
+
+cleanup_migrator_containers() {
+    local ids
+    ids="$(docker ps -aq --filter "name=${MIGRATOR_NAME_PREFIX}-" 2>/dev/null || true)"
+    if [ -n "$ids" ]; then
+        docker rm -f $ids >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup_migrator_containers EXIT
+
+run_migrator() {
+    local run_timeout="$1"
+    shift
+    local name="${MIGRATOR_NAME_PREFIX}-$RANDOM"
+    local rc=0
+    # -k gives the host timeout its own SIGKILL escalation, so a `docker compose
+    # run` that ignores SIGTERM cannot hang the deploy past its budget; the
+    # unconditional `docker rm -f` below then releases the container either way.
+    timeout -k 30 "$run_timeout" \
+        docker compose $COMPOSE_FILES run --rm --no-deps --interactive=false -T \
+        --name "$name" -e "MIGRATE_STEP_TIMEOUT=$MIGRATE_STEP_TIMEOUT" \
+        supersync "$@" || rc=$?
+    docker rm -f "$name" >/dev/null 2>&1 || true
+    return "$rc"
+}
+
 echo "==> Verifying database connectivity from the supersync image..."
 set +e
-timeout "$POSTGRES_WAIT_TIMEOUT" \
-    $MIGRATOR_RUN sh -ec 'printf "SELECT 1;" | npx prisma db execute --schema prisma/schema.prisma --stdin > /dev/null'
+run_migrator "$POSTGRES_WAIT_TIMEOUT" sh -ec 'printf "SELECT 1;" | npx prisma db execute --schema prisma/schema.prisma --stdin > /dev/null'
 DB_CHECK_STATUS=$?
 set -e
 if [ "$DB_CHECK_STATUS" -eq 124 ]; then
@@ -326,8 +361,7 @@ echo "==> Applying database migrations before app restart (timeout: ${MIGRATION_
 # recovery). The host only owns the timeout + exit-code policy here.
 MIGRATE_STATUS=0
 set +e
-timeout "$MIGRATION_TIMEOUT" \
-    $MIGRATOR_RUN sh -ec 'echo "    Migrator container started"; sh scripts/migrate-deploy.sh'
+run_migrator "$MIGRATION_TIMEOUT" sh -ec 'echo "    Migrator container started"; sh scripts/migrate-deploy.sh'
 MIGRATE_STATUS=$?
 set -e
 

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -15,6 +15,11 @@ set -eu
 # names: the failing migration is read from Prisma's own output and its SQL is
 # read from prisma/migrations/<name>/migration.sql.
 #
+# A P1002 advisory-lock timeout (another session holds Prisma's migration lock,
+# usually a migrator container orphaned by a prior interrupted deploy) is NOT a
+# migration failure: it is detected separately and printed with cleanup steps,
+# never auto-resolved.
+#
 # This script is COPYed into the image next to prisma/migrations in the same
 # build, so it is always version-locked to the migrations it must handle. All
 # three call sites (host deploy.sh, image startup CMD, helm initContainer)
@@ -127,6 +132,14 @@ is_stuck_failed_migration() {
   log_has 'P3009'
 }
 
+# A P1002 whose message names the advisory lock: another DB session holds
+# Prisma's migration advisory lock, so `migrate deploy` never began applying
+# migrations. Distinct from every migration-level failure below — nothing was
+# applied, so there is no failing migration to recover; only the holder to clear.
+is_advisory_lock_timeout() {
+  log_has 'P1002' && log_has 'advisory lock'
+}
+
 migration_sql_path() {
   printf '%s/%s/migration.sql' "$MIGRATIONS_DIR" "$1"
 }
@@ -226,6 +239,31 @@ emit_interrupted_recovery_hint() {
   fi
 }
 
+# Copy-paste diagnosis + cleanup for a P1002 advisory-lock timeout. Another DB
+# session holds Prisma's migration advisory lock — almost always a one-off
+# migrator container orphaned by a previous interrupted deploy (a timed-out
+# `docker compose run` can leave its container, and thus its DB connection,
+# alive). This only ever prints guidance; it NEVER terminates a backend, because
+# an active CREATE INDEX CONCURRENTLY build legitimately holds the lock and must
+# not be killed. The operator decides.
+emit_advisory_lock_recovery() {
+  echo ""
+  echo "Another database session holds Prisma's migration advisory lock, so"
+  echo "migrate deploy could not start. This is usually a migrator container"
+  echo "orphaned by a previous interrupted deploy. Diagnose and clear it:"
+  echo ""
+  echo "  1. Remove any orphaned one-off migrator containers:"
+  echo "       docker ps -aq --filter name=supersync-migrator | xargs -r docker rm -f"
+  echo "       docker ps -aq --filter name=supersync-run       | xargs -r docker rm -f"
+  echo "  2. If the lock is still held, find who holds it (against your Postgres):"
+  echo "       SELECT a.pid, a.state, now() - a.state_change AS idle_for, left(a.query, 80)"
+  echo "         FROM pg_locks l JOIN pg_stat_activity a ON a.pid = l.pid"
+  echo "        WHERE l.locktype = 'advisory' AND l.granted;"
+  echo "  3. If that session is idle (NOT actively building an index), release it:"
+  echo "       SELECT pg_terminate_backend(<pid>);"
+  echo "  4. Re-run the deploy. Never terminate a live CREATE INDEX CONCURRENTLY build."
+}
+
 fail_loudly() {
   echo ""
   echo "ERROR: $1"
@@ -293,6 +331,12 @@ while :; do
   fi
 
   if ! is_transaction_block_failure && ! is_stuck_failed_migration; then
+    if is_advisory_lock_timeout; then
+      # Not a migration failure (nothing was applied) — print cleanup guidance
+      # and fail loudly. Rationale is on is_advisory_lock_timeout / the emitter.
+      emit_advisory_lock_recovery
+      fail_loudly "prisma migrate deploy could not acquire the migration advisory lock (P1002) within 10s; another migrator session holds it." 1
+    fi
     # A non-P3018/P3009 exit is usually a genuine error (bad SQL, unreachable
     # DB), but OOM (137) or another non-timeout kill can also abort an in-flight
     # CONCURRENTLY build before Prisma records the failure. (A timeout SIGTERM is

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -85,6 +85,15 @@ case "$sub" in
                 echo "Terminated"
                 exit 137
                 ;;
+              P1002)
+                # Another session holds Prisma's migration advisory lock, so
+                # deploy times out before applying anything. No migration name
+                # or gate marker is emitted — the script must recognize this
+                # from the P1002 + advisory-lock text, not a failing migration.
+                echo "Error: P1002"
+                echo "The database server was reached but timed out."
+                echo "Context: Timed out trying to acquire a postgres advisory lock (SELECT pg_advisory_lock(72707369)). Elapsed: 10000ms."
+                ;;
               *)
                 echo "Error: P1001"
                 echo "Can't reach database server"
@@ -356,6 +365,23 @@ describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
     expect(r.status).not.toBe(0);
     expect(r.stdout).toContain('Not auto-recovered');
     expect(r.resolveApplied).toEqual([]);
+  });
+
+  it('prints advisory-lock recovery on a P1002 lock timeout, without resolving anything', () => {
+    // Another session holds Prisma's migration advisory lock (e.g. a migrator
+    // container orphaned by a prior interrupted deploy), so migrate deploy
+    // times out before applying anything. This is NOT a migration failure:
+    // print cleanup guidance, never mark a migration applied or rolled-back.
+    writeMigration(ENCRYPTED_OPS, ENCRYPTED_OPS_SQL);
+    const r = run({ FAKE_FAIL: ENCRYPTED_OPS, FAKE_CODE: 'P1002' });
+
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toContain('advisory lock');
+    expect(r.stdout).toContain('supersync-migrator');
+    expect(r.stdout).toContain('pg_terminate_backend');
+    // The lock timeout is not a failing migration — nothing gets resolved.
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.resolveRolledBack).toEqual([]);
   });
 
   it('targets the failed migration in a P3009 log that also backticks others', () => {

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -217,9 +217,20 @@ describe('performance migrations', () => {
     expect(deployScript).toContain('jq is required');
     expect(deployScript).toContain('docker compose config --format json failed');
     expect(deployScript).toContain('docker image inspect');
-    expect(deployScript).toContain(
-      'run --rm --no-deps --interactive=false -T -e MIGRATE_STEP_TIMEOUT=$MIGRATE_STEP_TIMEOUT supersync',
-    );
+    expect(deployScript).toContain('run --rm --no-deps --interactive=false -T');
+    expect(deployScript).toContain('-e "MIGRATE_STEP_TIMEOUT=$MIGRATE_STEP_TIMEOUT"');
+    // One-off migrator containers are named per-deploy and force-removed (inline
+    // + an EXIT trap) so a timed-out `docker compose run` cannot orphan the
+    // container and leak Prisma's advisory lock into the next deploy (P1002).
+    expect(deployScript).toContain('run_migrator()');
+    expect(deployScript).toContain('--name "$name"');
+    // Container name and EXIT-sweep filter must derive from ONE prefix, else a
+    // rename in one spot silently breaks the sweep backstop this PR relies on.
+    expect(deployScript).toContain('MIGRATOR_NAME_PREFIX="supersync-migrator-$$"');
+    expect(deployScript).toContain('local name="${MIGRATOR_NAME_PREFIX}-$RANDOM"');
+    expect(deployScript).toContain('--filter "name=${MIGRATOR_NAME_PREFIX}-"');
+    expect(deployScript).toContain('docker rm -f "$name"');
+    expect(deployScript).toContain('trap cleanup_migrator_containers EXIT');
     // The host forwards its migration budget into the image so the in-image
     // per-step timeout can't silently cap a large MIGRATION_TIMEOUT at the
     // image default (1800s) and kill a slow CREATE INDEX CONCURRENTLY early.
@@ -236,8 +247,11 @@ describe('performance migrations', () => {
     expect(deployScript).not.toMatch(/_INDEX_MIGRATION=/);
     expect(deployScript).not.toContain('run_concurrent_index_sql');
     expect(deployScript).not.toContain('CREATE INDEX CONCURRENTLY "operations');
-    // Host still owns the timeout + exit-code policy around the migrator.
-    expect(deployScript).toContain('timeout "$MIGRATION_TIMEOUT"');
+    // Host still owns the timeout + exit-code policy around the migrator: it
+    // passes MIGRATION_TIMEOUT into run_migrator, which wraps the container run
+    // in `timeout` and force-removes the container afterward.
+    expect(deployScript).toContain('run_migrator "$MIGRATION_TIMEOUT"');
+    expect(deployScript).toContain('timeout -k 30 "$run_timeout"');
     expect(deployScript).toContain('prisma migrate deploy timed out');
     expect(deployScript).toContain('database migrations failed (exit $MIGRATE_STATUS)');
     expect(deployScript).toContain(externalDbStartCommand);


### PR DESCRIPTION
## Problem

A SuperSync production deploy failed with **P1002** — Prisma timed out (10s) acquiring its migration advisory lock `pg_advisory_lock(72707369)` — so `migrate deploy` never even began applying migrations.

Root cause: `deploy.sh` runs the migrator as `timeout $MIGRATION_TIMEOUT docker compose run --rm ... supersync`. When a slow `CREATE INDEX CONCURRENTLY` build overran the timeout, `timeout` SIGTERM'd the compose **CLI** but left the container (and its DB connection) running detached. That container kept Prisma's **session-level** advisory lock held, so the *next* deploy attempt was wedged with P1002. `migrate-deploy.sh` had no branch for P1002 and printed a generic, unactionable `exit 1`.

The failure was recovered manually (the leaked sessions had self-released; the GIN index was already valid, so `migrate resolve --applied` closed the stuck record). This PR prevents recurrence.

## Fix

**`scripts/deploy.sh` (root cause):**
- New `run_migrator()` helper names every one-off migrator container from a single `MIGRATOR_NAME_PREFIX` (`supersync-migrator-$$`) and force-removes it — inline after each run **plus** a `$$`-scoped `EXIT`-trap sweep — so a timed-out `docker compose run` can never orphan the container and leak the lock into the next deploy.
- `timeout -k 30` so a compose CLI that ignores SIGTERM can't hang the deploy past its budget.
- The two migrator invocations (connectivity check + migration) refactored onto the helper; exit-code semantics (incl. the `-eq 124` timeout branch) preserved.

**`scripts/migrate-deploy.sh` (diagnosability):**
- `is_advisory_lock_timeout()` (matches `P1002` + `advisory lock`) → `emit_advisory_lock_recovery()` prints copy-paste `pg_locks` diagnosis + orphan-container / idle-backend cleanup steps. It **never** auto-terminates a backend — an active `CREATE INDEX CONCURRENTLY` build legitimately holds the lock and must not be killed. Placed before any recovery path, so it never marks a migration applied.

**Scope note:** only the `deploy.sh` path has the CLI-orphan indirection. The image `CMD` and helm `initContainer` run `migrate-deploy.sh` in-process, so a kill closes the connection and releases the session lock — those paths are not exposed to the leak. Detection lives in the shared in-image script; the docker-orphan fix is host-side.

**Tests / docs:**
- `migrate-deploy-script.spec.ts`: P1002 case added to the fake `npx`; a new test asserts the guidance prints and nothing is resolved (sabotage-verified — fails without the fix).
- `migration-sql.spec.ts`: assertions updated to the new structure and now pin the name/sweep-filter prefix single-source-of-truth invariant.
- `env.example`: documents the recommended higher `MIGRATION_TIMEOUT` and the new force-remove-on-timeout behavior.

All 901 server tests pass; both scripts syntax-checked; lint clean.

## Review

Multi-agent review (correctness, security, architecture, alternatives, performance, simplicity): **no CRITICAL/WARNING findings** — unanimous. Suggestions applied: DRY the container-name prefix, `timeout -k`, honest `env.example` caveat. (Codex reviewer was unavailable — usage limit.)

## Operator action (independent of this PR)

Set `MIGRATION_TIMEOUT=3600` in the server `.env`. This alone stops the premature-kill that starts the cascade, and takes effect on the next deploy without waiting for this PR to ship. Full P1002 guidance from the in-image script lands once a new `supersync:latest` image is built from `master`.
