### PR TITLE
fix(date-time): fall back to default locale instead of blank dates; register English region locale data

### DIFF
--- a/docs/wiki/3.02-Settings-and-Preferences.md
+++ b/docs/wiki/3.02-Settings-and-Preferences.md
@@ -11,7 +11,9 @@ Note: Differences between the Web app and the Desktop app are specified in [[3.0
 - **Datetime format locale** — Controls numeric date formatting and the
   12/24-hour time format. The ISO 8601 option uses `YYYY-MM-DD` and a 24-hour
   clock. With ISO 8601 selected, weekday labels in Schedule, Habits, and Planner
-  follow the app language.
+  follow the app language. The System default option follows your browser or
+  operating system regional locale; when formatting data for a locale is not
+  available, dates fall back to British English (en-GB) formatting.
 
 #### global-settings.App-Features
 

--- a/src/app/core/locale-registration.spec.ts
+++ b/src/app/core/locale-registration.spec.ts
@@ -1,5 +1,6 @@
 import { formatDate, registerLocaleData } from '@angular/common';
 import localeEn from '@angular/common/locales/en';
+import localeEnAu from '@angular/common/locales/en-AU';
 import { TranslateService } from '@ngx-translate/core';
 import { registerDefaultLocale, registerNavigatorLocale } from './locale-registration';
 import { NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS } from './locale.constants';
@@ -27,19 +28,57 @@ describe('locale-registration', () => {
       expect(formatDate(onePm, 'shortDate', 'en')).toBe('15/01/2024');
       expect(formatDate(onePm, 'shortTime', 'en')).toBe('13:00');
     });
+
+    it('registers en-US under en-us so an explicit US locale is month-first/12h from first paint, not the en-GB seed', () => {
+      registerDefaultLocale();
+      // Without the explicit en-US registration, 'en-us' would resolve through
+      // the en-GB 'en' seed above and render '15/01/2024' / '13:00'.
+      expect(formatDate(onePm, 'shortDate', 'en-us')).toBe('1/15/24');
+      expect(formatDate(onePm, 'shortTime', 'en-us')).toMatch(/^1:00/);
+      // …and the en-GB seed under bare 'en' stays intact.
+      expect(formatDate(onePm, 'shortTime', 'en')).toBe('13:00');
+    });
   });
 
   describe('registerNavigatorLocale', () => {
+    // The real en-* variants leak into the process-global locale registry from
+    // locale.constants.spec (Angular has no unregister API), so asserting on
+    // them would pass on that leak alone — Jasmine randomises suite order, so
+    // whether the sibling suite ran first flips the result. Instead each spec
+    // registers a synthetic 12h locale (real en-AU data re-tagged under an id
+    // no other suite touches): a 12h render can then only mean *this* call
+    // registered it, and an unregistered synthetic falls through 'en' to the
+    // en-GB (24h) baseline below.
+    const syntheticMapKeys: string[] = [];
+    const addSynthetic12hLocale = (tag: string): string => {
+      // registerNavigatorLocale derives the map key from the (lower-cased,
+      // '_'-joined) nav language and registers keyless (by the data's self-id),
+      // so key and self-id are both derived from `tag`.
+      const mapKey = tag.toLowerCase().replace(/-/g, '_');
+      const data = [...(localeEnAu as unknown[])];
+      data[0] = tag.toLowerCase();
+      NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[mapKey] = () =>
+        Promise.resolve({ default: data });
+      syntheticMapKeys.push(mapKey);
+      return tag;
+    };
+
     beforeAll(() => {
       // Match prod ordering: the default locale is registered before the app
-      // initializer runs, so unregistered en-* resolves to en-GB (24h) — which
-      // is exactly what the 12h assertion below must flip.
+      // initializer runs, so an unregistered synthetic en-* resolves to en-GB
+      // (24h) — which is exactly what the 12h assertions below must flip.
       registerDefaultLocale();
     });
 
-    it('registers the data for a matched navigator.language (en-AU renders 12h, not the en-GB 24h fallback)', async () => {
-      await registerNavigatorLocale('en-AU');
-      expect(formatDate(onePm, 'shortTime', 'en-AU')).toMatch(/^1:00/);
+    afterEach(() => {
+      syntheticMapKeys.forEach((key) => delete NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[key]);
+      syntheticMapKeys.length = 0;
+    });
+
+    it('registers the data for a matched navigator.language (renders 12h, not the en-GB 24h fallback)', async () => {
+      const tag = addSynthetic12hLocale('en-XA');
+      await registerNavigatorLocale(tag);
+      expect(formatDate(onePm, 'shortTime', tag.toLowerCase())).toMatch(/^1:00/);
     });
 
     it('resolves without throwing for a locale outside the navigator-fallback map', async () => {
@@ -48,10 +87,13 @@ describe('locale-registration', () => {
 
     it('defaults to the same browser locale the date pipe resolves (getBrowserCultureLang, not navigator.language)', async () => {
       // Reading navigator.language instead would register data for a locale the
-      // pipe never asks for whenever the two disagree.
-      spyOn(TranslateService, 'getBrowserCultureLang').and.returnValue('en-NZ');
+      // pipe never asks for whenever the two disagree. The synthetic tag is not
+      // navigator.language, so the sabotage (default → navigator.language)
+      // leaves it unregistered and the 12h assertion fails.
+      const tag = addSynthetic12hLocale('en-XB');
+      spyOn(TranslateService, 'getBrowserCultureLang').and.returnValue(tag);
       await registerNavigatorLocale();
-      expect(formatDate(onePm, 'shortTime', 'en-NZ')).toMatch(/^1:00/);
+      expect(formatDate(onePm, 'shortTime', tag.toLowerCase())).toMatch(/^1:00/);
     });
 
     it('resolves without throwing when the browser reports no culture language', async () => {
@@ -59,21 +101,30 @@ describe('locale-registration', () => {
       await expectAsync(registerNavigatorLocale()).toBeResolved();
     });
 
-    it('gives up on a stalled chunk load instead of holding up bootstrap', async () => {
-      // en-IE is 12h; asserting the en-GB 24h fallback proves the stalled load
-      // was abandoned rather than awaited (and that we did not hang here).
-      const origLoad = NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS['en_ie'];
-      NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS['en_ie'] = () => new Promise(() => {});
-      jasmine.clock().install();
-      try {
-        const pending = registerNavigatorLocale('en-IE');
-        jasmine.clock().tick(1500);
+    describe('when the chunk load stalls', () => {
+      // Clock in before/afterEach, not a try/finally inside the spec: if the
+      // timeout ever regresses to a bare `await load()`, the assertion below
+      // never settles and a `finally` would never run — leaking jasmine.clock()
+      // and the mutated import map into every sibling suite for the rest of the
+      // run. afterEach still runs when the spec times out, containing the leak.
+      beforeEach(() => jasmine.clock().install());
+      afterEach(() => jasmine.clock().uninstall());
+
+      it('gives up on a stalled chunk load instead of holding up bootstrap', async () => {
+        // A synthetic 12h loader that never resolves. Giving up leaves the tag
+        // unregistered → it renders the en-GB 24h fallback; awaiting the stall
+        // would hang the spec. A real 24h locale (en-IE) cannot discriminate:
+        // its data is byte-identical to en-GB, so "loaded" and "abandoned"
+        // render the same 13:00.
+        const tag = 'en-XC';
+        const mapKey = 'en_xc';
+        syntheticMapKeys.push(mapKey);
+        NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[mapKey] = () => new Promise<never>(() => {});
+        const pending = registerNavigatorLocale(tag);
+        jasmine.clock().tick(2000);
         await expectAsync(pending).toBeResolved();
-        expect(formatDate(onePm, 'shortTime', 'en-IE')).toBe('13:00');
-      } finally {
-        jasmine.clock().uninstall();
-        NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS['en_ie'] = origLoad;
-      }
+        expect(formatDate(onePm, 'shortTime', tag.toLowerCase())).toMatch(/^13:00/);
+      });
     });
   });
 });

--- a/src/app/core/locale-registration.spec.ts
+++ b/src/app/core/locale-registration.spec.ts
@@ -1,6 +1,8 @@
 import { formatDate, registerLocaleData } from '@angular/common';
 import localeEn from '@angular/common/locales/en';
+import { TranslateService } from '@ngx-translate/core';
 import { registerDefaultLocale, registerNavigatorLocale } from './locale-registration';
+import { NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS } from './locale.constants';
 
 /**
  * Exercises the production registration path used by main.ts (module-scope
@@ -42,6 +44,36 @@ describe('locale-registration', () => {
 
     it('resolves without throwing for a locale outside the navigator-fallback map', async () => {
       await expectAsync(registerNavigatorLocale('th-TH')).toBeResolved();
+    });
+
+    it('defaults to the same browser locale the date pipe resolves (getBrowserCultureLang, not navigator.language)', async () => {
+      // Reading navigator.language instead would register data for a locale the
+      // pipe never asks for whenever the two disagree.
+      spyOn(TranslateService, 'getBrowserCultureLang').and.returnValue('en-NZ');
+      await registerNavigatorLocale();
+      expect(formatDate(onePm, 'shortTime', 'en-NZ')).toMatch(/^1:00/);
+    });
+
+    it('resolves without throwing when the browser reports no culture language', async () => {
+      spyOn(TranslateService, 'getBrowserCultureLang').and.returnValue(undefined);
+      await expectAsync(registerNavigatorLocale()).toBeResolved();
+    });
+
+    it('gives up on a stalled chunk load instead of holding up bootstrap', async () => {
+      // en-IE is 12h; asserting the en-GB 24h fallback proves the stalled load
+      // was abandoned rather than awaited (and that we did not hang here).
+      const origLoad = NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS['en_ie'];
+      NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS['en_ie'] = () => new Promise(() => {});
+      jasmine.clock().install();
+      try {
+        const pending = registerNavigatorLocale('en-IE');
+        jasmine.clock().tick(1500);
+        await expectAsync(pending).toBeResolved();
+        expect(formatDate(onePm, 'shortTime', 'en-IE')).toBe('13:00');
+      } finally {
+        jasmine.clock().uninstall();
+        NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS['en_ie'] = origLoad;
+      }
     });
   });
 });

--- a/src/app/core/locale-registration.spec.ts
+++ b/src/app/core/locale-registration.spec.ts
@@ -1,0 +1,47 @@
+import { formatDate, registerLocaleData } from '@angular/common';
+import localeEn from '@angular/common/locales/en';
+import { registerDefaultLocale, registerNavigatorLocale } from './locale-registration';
+
+/**
+ * Exercises the production registration path used by main.ts (module-scope
+ * registerDefaultLocale + app-initializer registerNavigatorLocale), asserting
+ * the user-visible formats rather than registry internals.
+ */
+describe('locale-registration', () => {
+  // 1pm discriminates 12h ("1:00 …") from 24h ("13:00"); Jan 15 discriminates
+  // day-first shortDate (en-GB "15/01/2024") from month-first (en-US "1/15/24").
+  const onePm = new Date(2024, 0, 15, 13, 0);
+
+  afterAll(() => {
+    // The locale registry is module-global across the Karma run. Restore 'en'
+    // to the baked-in en-US data, which is observably identical to the
+    // pristine unregistered state (Angular's parent-locale shortcut).
+    registerLocaleData(localeEn, 'en');
+  });
+
+  describe('registerDefaultLocale', () => {
+    it('registers en-GB data under the bare en id (day-first shortDate, 24h shortTime)', () => {
+      registerDefaultLocale();
+      expect(formatDate(onePm, 'shortDate', 'en')).toBe('15/01/2024');
+      expect(formatDate(onePm, 'shortTime', 'en')).toBe('13:00');
+    });
+  });
+
+  describe('registerNavigatorLocale', () => {
+    beforeAll(() => {
+      // Match prod ordering: the default locale is registered before the app
+      // initializer runs, so unregistered en-* resolves to en-GB (24h) — which
+      // is exactly what the 12h assertion below must flip.
+      registerDefaultLocale();
+    });
+
+    it('registers the data for a matched navigator.language (en-AU renders 12h, not the en-GB 24h fallback)', async () => {
+      await registerNavigatorLocale('en-AU');
+      expect(formatDate(onePm, 'shortTime', 'en-AU')).toMatch(/^1:00/);
+    });
+
+    it('resolves without throwing for a locale outside the navigator-fallback map', async () => {
+      await expectAsync(registerNavigatorLocale('th-TH')).toBeResolved();
+    });
+  });
+});

--- a/src/app/core/locale-registration.spec.ts
+++ b/src/app/core/locale-registration.spec.ts
@@ -85,6 +85,23 @@ describe('locale-registration', () => {
       await expectAsync(registerNavigatorLocale('th-TH')).toBeResolved();
     });
 
+    it('resolves without throwing when the matched chunk load rejects', async () => {
+      // The unmatched-key spec above returns before load() is ever called, so it
+      // cannot cover the catch. This one matches the map and rejects, which is
+      // the shape that matters: the promise is awaited by an app initializer, so
+      // an escaping rejection would reject bootstrap and block first render
+      // instead of degrading to the default locale.
+      const tag = 'en-XD';
+      const mapKey = 'en_xd';
+      syntheticMapKeys.push(mapKey);
+      NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[mapKey] = () =>
+        Promise.reject(new Error('chunk load failed'));
+      await expectAsync(registerNavigatorLocale(tag)).toBeResolved();
+      // …and the failed locale stays unregistered, so it renders the en-GB
+      // (24h) default rather than a half-applied state.
+      expect(formatDate(onePm, 'shortTime', tag.toLowerCase())).toMatch(/^13:00/);
+    });
+
     it('defaults to the same browser locale the date pipe resolves (getBrowserCultureLang, not navigator.language)', async () => {
       // Reading navigator.language instead would register data for a locale the
       // pipe never asks for whenever the two disagree. The synthetic tag is not

--- a/src/app/core/locale-registration.ts
+++ b/src/app/core/locale-registration.ts
@@ -1,0 +1,45 @@
+import { registerLocaleData } from '@angular/common';
+import { Log } from './log';
+import {
+  DEFAULT_LANGUAGE,
+  DEFAULT_LOCALE_DATA,
+  NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS,
+} from './locale.constants';
+
+/**
+ * Registers the statically imported default locale data (en-GB under the bare
+ * 'en' id). Must run before Angular's first render: LocaleDatePipe is pure, so
+ * a date rendered earlier would cache Angular's built-in en-US resolution for
+ * the session. main.ts calls this at module scope, before bootstrapApplication.
+ */
+export const registerDefaultLocale = (): void => {
+  registerLocaleData(DEFAULT_LOCALE_DATA, DEFAULT_LANGUAGE);
+};
+
+/**
+ * Loads and registers the regional locale data matching the browser's own
+ * locale, when it's one of the navigator-only variants (en-AU, en-CA, … — see
+ * NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS). Awaited by an app initializer so the
+ * data is registered before first render; otherwise a pure LocaleDatePipe
+ * caches the en-GB parent format for the session.
+ *
+ * Never rejects: a failed chunk load logs and falls back to default-locale
+ * rendering instead of blocking bootstrap.
+ */
+export const registerNavigatorLocale = async (
+  navLanguage: string = navigator.language,
+): Promise<void> => {
+  const key = navLanguage.toLowerCase().replace(/-/g, '_');
+  const load = NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[key];
+  if (!load) {
+    return;
+  }
+  try {
+    const m = await load();
+    // No explicit id: these data files self-report ids matching their keys
+    // (asserted in locale.constants.spec.ts), so the self-id is typo-proof.
+    registerLocaleData(m.default);
+  } catch (e) {
+    Log.err(`Failed to load locale ${key}`, e);
+  }
+};

--- a/src/app/core/locale-registration.ts
+++ b/src/app/core/locale-registration.ts
@@ -1,10 +1,18 @@
 import { registerLocaleData } from '@angular/common';
+import { TranslateService } from '@ngx-translate/core';
 import { Log } from './log';
 import {
   DEFAULT_LANGUAGE,
   DEFAULT_LOCALE_DATA,
   NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS,
 } from './locale.constants';
+
+/**
+ * Upper bound on how long bootstrap waits for the regional locale chunk. On
+ * timeout we render with the default locale — exactly the behavior before this
+ * registration existed — rather than hold up first render on a stalled network.
+ */
+const LOCALE_LOAD_TIMEOUT_MS = 1500;
 
 /**
  * Registers the statically imported default locale data (en-GB under the bare
@@ -23,23 +31,44 @@ export const registerDefaultLocale = (): void => {
  * data is registered before first render; otherwise a pure LocaleDatePipe
  * caches the en-GB parent format for the session.
  *
- * Never rejects: a failed chunk load logs and falls back to default-locale
- * rendering instead of blocking bootstrap.
+ * The default argument reads the browser locale through the exact same call
+ * `DateTimeFormatService` resolves the pipe's locale with
+ * (`getBrowserCultureLang()` → `navigator.languages[0]`). Reading
+ * `navigator.language` here instead would let the two disagree, and we would
+ * then register data for a locale the pipe never asks for.
+ *
+ * Never rejects and gives up after {@link LOCALE_LOAD_TIMEOUT_MS}: a failed or
+ * stalled chunk load degrades to default-locale rendering instead of failing or
+ * holding up bootstrap.
  */
 export const registerNavigatorLocale = async (
-  navLanguage: string = navigator.language,
+  navLanguage: string | undefined = TranslateService.getBrowserCultureLang(),
 ): Promise<void> => {
-  const key = navLanguage.toLowerCase().replace(/-/g, '_');
-  const load = NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[key];
+  const key = navLanguage?.toLowerCase().replace(/-/g, '_');
+  const load = key ? NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[key] : undefined;
   if (!load) {
     return;
   }
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
-    const m = await load();
+    // Promise.race consumes a late rejection from load(), so a chunk that fails
+    // after the timeout won this race cannot surface as an unhandled rejection.
+    const m = await Promise.race([
+      load(),
+      new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), LOCALE_LOAD_TIMEOUT_MS);
+      }),
+    ]);
+    if (!m) {
+      Log.err(`Timed out loading locale ${key}`);
+      return;
+    }
     // No explicit id: these data files self-report ids matching their keys
     // (asserted in locale.constants.spec.ts), so the self-id is typo-proof.
     registerLocaleData(m.default);
   } catch (e) {
     Log.err(`Failed to load locale ${key}`, e);
+  } finally {
+    clearTimeout(timeoutId);
   }
 };

--- a/src/app/core/locale-registration.ts
+++ b/src/app/core/locale-registration.ts
@@ -1,7 +1,9 @@
 import { registerLocaleData } from '@angular/common';
+import localeEnUs from '@angular/common/locales/en';
 import { TranslateService } from '@ngx-translate/core';
 import { Log } from './log';
 import {
+  DateTimeLocales,
   DEFAULT_LANGUAGE,
   DEFAULT_LOCALE_DATA,
   NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS,
@@ -19,9 +21,20 @@ const LOCALE_LOAD_TIMEOUT_MS = 1500;
  * 'en' id). Must run before Angular's first render: LocaleDatePipe is pure, so
  * a date rendered earlier would cache Angular's built-in en-US resolution for
  * the session. main.ts calls this at module scope, before bootstrapApplication.
+ *
+ * en-US is the one English region the en-GB-under-'en' seed above gets wrong:
+ * once 'en' is en-GB, an unregistered 'en-us' resolves through it and renders
+ * day-first/24h (frozen there by the pure pipe) until the idle loop registers
+ * en-US much later. On master, where 'en' was seeded only inside the bootstrap
+ * `.then`, the same lookup fell through to Angular's built-in en-US and was
+ * correct. So register en-US up front too, keeping an explicit "System default"
+ * or dropdown en-US choice month-first/12h from first paint. The data file
+ * self-reports 'en', so the explicit id is required — a keyless call would
+ * clobber the en-GB 'en' seed.
  */
 export const registerDefaultLocale = (): void => {
   registerLocaleData(DEFAULT_LOCALE_DATA, DEFAULT_LANGUAGE);
+  registerLocaleData(localeEnUs, DateTimeLocales.en_us);
 };
 
 /**

--- a/src/app/core/locale.constants.spec.ts
+++ b/src/app/core/locale.constants.spec.ts
@@ -1,6 +1,7 @@
-import { formatDate } from '@angular/common';
+import { formatDate, registerLocaleData } from '@angular/common';
+import localeEn from '@angular/common/locales/en';
 import { NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS } from './locale.constants';
-import { registerNavigatorLocale } from './locale-registration';
+import { registerDefaultLocale, registerNavigatorLocale } from './locale-registration';
 
 /**
  * Covers the registration half of the navigator-fallback fix: without their
@@ -28,6 +29,14 @@ describe('NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS', () => {
   };
 
   beforeAll(async () => {
+    // Register the en-GB baseline under the bare 'en' id first, matching prod
+    // (main.ts calls registerDefaultLocale before the app initializer). Without
+    // it, an unregistered en-* resolves through Angular's built-in en (=en-US,
+    // already 12h), so a 12h assertion would pass even if registration below
+    // were a no-op — vacuous for exactly the six 12h variants this fix exists
+    // for. With the en-GB (24h) baseline, "renders 12h" means the regional data
+    // genuinely won.
+    registerDefaultLocale();
     await Promise.all(
       Object.entries(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).map(async ([key, load]) => {
         const m = await load();
@@ -35,6 +44,13 @@ describe('NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS', () => {
         await registerNavigatorLocale(key.replace(/_/g, '-'));
       }),
     );
+  });
+
+  afterAll(() => {
+    // The locale registry is module-global across the Karma run. Restore 'en'
+    // to the baked-in en-US, matching locale-registration.spec's hygiene, so a
+    // sibling suite doesn't inherit this suite's en-GB baseline.
+    registerLocaleData(localeEn, 'en');
   });
 
   it('has a 12h/24h expectation for every registered variant', () => {

--- a/src/app/core/locale.constants.spec.ts
+++ b/src/app/core/locale.constants.spec.ts
@@ -1,13 +1,14 @@
-import { formatDate, registerLocaleData } from '@angular/common';
+import { formatDate } from '@angular/common';
 import { NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS } from './locale.constants';
+import { registerNavigatorLocale } from './locale-registration';
 
 /**
  * Covers the registration half of the navigator-fallback fix: without their
  * own locale data, en-AU/en-CA/… resolve through `en` (registered as en-GB in
- * prod) and render 24h time. These specs register the data exactly as main.ts
- * does — `registerLocaleData(m.default)` with no explicit id, relying on the
- * data's self-reported BCP-47 id — and assert the user-visible symptom:
- * 12h vs 24h `shortTime`.
+ * prod) and render 24h time. These specs register every variant through the
+ * production path (`registerNavigatorLocale`, keyless — relying on the data's
+ * self-reported BCP-47 id) and assert the user-visible symptom: 12h vs 24h
+ * `shortTime`.
  */
 describe('NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS', () => {
   // 1pm is the discriminating hour: 12h renders "1:00 …", 24h renders "13:00".
@@ -31,7 +32,7 @@ describe('NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS', () => {
       Object.entries(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).map(async ([key, load]) => {
         const m = await load();
         loadedById.set(key, m.default);
-        registerLocaleData(m.default);
+        await registerNavigatorLocale(key.replace(/_/g, '-'));
       }),
     );
   });

--- a/src/app/core/locale.constants.spec.ts
+++ b/src/app/core/locale.constants.spec.ts
@@ -1,0 +1,67 @@
+import { formatDate, registerLocaleData } from '@angular/common';
+import { NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS } from './locale.constants';
+
+/**
+ * Covers the registration half of the navigator-fallback fix: without their
+ * own locale data, en-AU/en-CA/… resolve through `en` (registered as en-GB in
+ * prod) and render 24h time. These specs register the data exactly as main.ts
+ * does — `registerLocaleData(m.default)` with no explicit id, relying on the
+ * data's self-reported BCP-47 id — and assert the user-visible symptom:
+ * 12h vs 24h `shortTime`.
+ */
+describe('NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS', () => {
+  // 1pm is the discriminating hour: 12h renders "1:00 …", 24h renders "13:00".
+  const onePm = new Date(2024, 0, 15, 13, 0);
+  const loadedById = new Map<string, unknown>();
+
+  // Which variants genuinely use 12h time; en-IE and en-ZA are 24h regions.
+  const IS_TWELVE_HOUR: Record<string, boolean> = {
+    en_au: true,
+    en_ca: true,
+    en_ie: false,
+    en_in: true,
+    en_nz: true,
+    en_ph: true,
+    en_sg: true,
+    en_za: false,
+  };
+
+  beforeAll(async () => {
+    await Promise.all(
+      Object.entries(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).map(async ([key, load]) => {
+        const m = await load();
+        loadedById.set(key, m.default);
+        registerLocaleData(m.default);
+      }),
+    );
+  });
+
+  it('has a 12h/24h expectation for every registered variant', () => {
+    expect(Object.keys(IS_TWELVE_HOUR).sort()).toEqual(
+      Object.keys(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).sort(),
+    );
+  });
+
+  it('each data file self-reports the BCP-47 id its map key promises (keyless registration is safe)', () => {
+    for (const [key, data] of loadedById) {
+      const selfReportedId = (data as unknown[])[0] as string;
+      expect(selfReportedId.toLowerCase()).toBe(key.replace(/_/g, '-'));
+    }
+  });
+
+  Object.keys(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).forEach((key) => {
+    const localeTag = key.replace(/_/g, '-');
+    const twelveHour = IS_TWELVE_HOUR[key];
+
+    it(`renders shortTime in ${twelveHour ? '12h' : '24h'} for ${localeTag}`, () => {
+      const result = formatDate(onePm, 'shortTime', localeTag);
+      if (twelveHour) {
+        // e.g. "1:00 pm" (en-AU), "1:00 p.m." (en-CA), "1:00 PM" (en-PH) —
+        // exact spacing/case varies per region, 12h is the invariant.
+        expect(result).toMatch(/^1:00/);
+      } else {
+        expect(result).toMatch(/^13:00/);
+      }
+    });
+  });
+});

--- a/src/app/core/locale.constants.ts
+++ b/src/app/core/locale.constants.ts
@@ -135,7 +135,7 @@ export const LocaleImportFns: Record<
 };
 
 /**
- * Angular locale data for common `navigator.language` region variants that
+ * Angular locale data for common browser-culture region variants that
  * are NOT user-selectable in the dropdown — they back the "System default"
  * option, which follows the browser's regional locale (see
  * `DateTimeFormatService`). English regions need their own data because
@@ -152,7 +152,8 @@ export const LocaleImportFns: Record<
  *
  * Keys are snake_case forms of the browser culture tag (`en-AU` -> `en_au`);
  * `registerNavigatorLocale` (locale-registration.ts, awaited by an app
- * initializer before first render) matches `navigator.language` against them.
+ * initializer before first render) matches the browser culture language against
+ * them — the same `getBrowserCultureLang()` value the pipe's locale resolves to.
  * Registration itself passes no id — each data file self-reports its BCP-47
  * id, which `registerLocaleData` normalizes to lowercase.
  */

--- a/src/app/core/locale.constants.ts
+++ b/src/app/core/locale.constants.ts
@@ -151,7 +151,8 @@ export const LocaleImportFns: Record<
  * region-correct, but out of scope here.
  *
  * Keys are snake_case forms of the browser culture tag (`en-AU` -> `en_au`);
- * main.ts matches `navigator.language` against them for eager loading.
+ * `registerNavigatorLocale` (locale-registration.ts, awaited by an app
+ * initializer before first render) matches `navigator.language` against them.
  * Registration itself passes no id — each data file self-reports its BCP-47
  * id, which `registerLocaleData` normalizes to lowercase.
  */

--- a/src/app/core/locale.constants.ts
+++ b/src/app/core/locale.constants.ts
@@ -150,8 +150,10 @@ export const LocaleImportFns: Record<
  * fr-CA, …) still fall back to their bare language code — not always
  * region-correct, but out of scope here.
  *
- * Keys are snake_case; `registerLocaleData` normalizes them to BCP-47
- * (`en_au` -> `en-au`), matching the lowercased browser culture language.
+ * Keys are snake_case forms of the browser culture tag (`en-AU` -> `en_au`);
+ * main.ts matches `navigator.language` against them for eager loading.
+ * Registration itself passes no id — each data file self-reports its BCP-47
+ * id, which `registerLocaleData` normalizes to lowercase.
  */
 export const NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS: Record<
   string,

--- a/src/app/core/locale.constants.ts
+++ b/src/app/core/locale.constants.ts
@@ -134,6 +134,39 @@ export const LocaleImportFns: Record<
   vi: () => import('@angular/common/locales/vi'),
 };
 
+/**
+ * Angular locale data for common `navigator.language` region variants that
+ * are NOT user-selectable in the dropdown — they back the "System default"
+ * option, which follows the browser's regional locale (see
+ * `DateTimeFormatService`). English regions need their own data because
+ * Angular's `DatePipe` would otherwise fall back through `en` (registered as
+ * en-GB) and render 24h time for en-AU/en-CA/en-NZ users, while the
+ * `Intl`-based code paths already render 12h for the same locale.
+ *
+ * Kept separate from {@link DateTimeLocales} so the `DateTimeLocale` union
+ * stays limited to genuinely selectable locales. Scope is English regions
+ * only: English is the most common navigator.language and the one language
+ * whose bare code is pinned to en-GB. Other regional variants (es-MX,
+ * fr-CA, …) still fall back to their bare language code — not always
+ * region-correct, but out of scope here.
+ *
+ * Keys are snake_case; `registerLocaleData` normalizes them to BCP-47
+ * (`en_au` -> `en-au`), matching the lowercased browser culture language.
+ */
+export const NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS: Record<
+  string,
+  () => Promise<{ default: unknown }>
+> = {
+  en_au: () => import('@angular/common/locales/en-AU'),
+  en_ca: () => import('@angular/common/locales/en-CA'),
+  en_ie: () => import('@angular/common/locales/en-IE'),
+  en_in: () => import('@angular/common/locales/en-IN'),
+  en_nz: () => import('@angular/common/locales/en-NZ'),
+  en_ph: () => import('@angular/common/locales/en-PH'),
+  en_sg: () => import('@angular/common/locales/en-SG'),
+  en_za: () => import('@angular/common/locales/en-ZA'),
+};
+
 /** Default locale data, statically imported for instant availability */
 export const DEFAULT_LOCALE_DATA = localeEnGB;
 

--- a/src/app/ui/pipes/locale-date.pipe.spec.ts
+++ b/src/app/ui/pipes/locale-date.pipe.spec.ts
@@ -1,8 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de';
+import localeEn from '@angular/common/locales/en';
+import localeEnGB from '@angular/common/locales/en-GB';
 import { LocaleDatePipe } from './locale-date.pipe';
 import { DateTimeFormatService } from '../../core/date-time-format/date-time-format.service';
+import { Log } from '../../core/log';
 
 describe('LocaleDatePipe', () => {
   let pipe: LocaleDatePipe;
@@ -11,6 +14,18 @@ describe('LocaleDatePipe', () => {
     // DatePipe needs locale data registered for non-default locales. In the app
     // this happens in main.ts; unit tests must register what they exercise.
     registerLocaleData(localeDe, 'de-DE');
+    // Match prod: main.ts registers en-GB data under the bare 'en' id, so the
+    // DEFAULT_LOCALE ('en-gb') fallback resolves to en-GB. Without this, Karma
+    // resolves it to Angular's baked-in en-US and the fallback specs would pin
+    // the wrong behavior.
+    registerLocaleData(localeEnGB, 'en');
+  });
+
+  afterAll(() => {
+    // The locale registry is module-global across the Karma run. Restore 'en'
+    // to the baked-in en-US data, which is observably identical to the
+    // pristine unregistered state (Angular's parent-locale shortcut).
+    registerLocaleData(localeEn, 'en');
   });
 
   beforeEach(() => {
@@ -78,13 +93,35 @@ describe('LocaleDatePipe', () => {
   it('should fall back to the default locale instead of rendering blank when locale data is unregistered (NG0701)', () => {
     const date = new Date(2024, 0, 15, 14, 30);
     // 'th-TH' is a valid BCP-47 tag, but neither 'th-TH' nor 'th' locale data
-    // is registered — pre-fallback this returned null (blank UI).
-    const result = pipe.transform(date, 'MMMM', undefined, 'th-TH');
-    expect(result).toBe('January');
+    // is registered — pre-fallback this returned null (blank UI). 'shortDate'
+    // is format-sensitive: en-GB (prod fallback) renders 15/01/2024, en-US
+    // would render 1/15/24, so this pins the actual fallback locale.
+    const result = pipe.transform(date, 'shortDate', undefined, 'th-TH');
+    expect(result).toBe('15/01/2024');
   });
 
-  it('should still return null when even the default-locale fallback cannot format the value', () => {
-    expect(pipe.transform('invalid-date-string', 'short', undefined, 'th-TH')).toBeNull();
+  it('should not warn for an unformattable value nor let it poison the per-locale warn dedup', () => {
+    // Uses a locale no other spec touches: the warn dedup set is module-scoped.
+    const warnSpy = spyOn(Log, 'warn');
+    // Bad value: both locales fail => silent null, no locale blamed.
+    expect(pipe.transform('invalid-date-string', 'short', undefined, 'el-GR')).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+    // The genuine NG0701 for the same locale must still be reported.
+    const result = pipe.transform(new Date(2024, 0, 15), 'MMMM', undefined, 'el-GR');
+    expect(result).toBe('January');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should warn once per locale across pipe instances, not once per instance', () => {
+    // Angular creates one pure-pipe instance per binding per embedded view
+    // (e.g. `| localeDate` inside @for), so per-instance dedup would flood
+    // the size-capped exportable log history with one warning per row.
+    const warnSpy = spyOn(Log, 'warn');
+    const date = new Date(2024, 0, 15, 14, 30);
+    const secondPipe = TestBed.runInInjectionContext(() => new LocaleDatePipe());
+    expect(pipe.transform(date, 'MMMM', undefined, 'da-DK')).toBe('January');
+    expect(secondPipe.transform(date, 'MMMM', undefined, 'da-DK')).toBe('January');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should react to a changed explicit locale arg (en-US vs de-DE)', () => {

--- a/src/app/ui/pipes/locale-date.pipe.spec.ts
+++ b/src/app/ui/pipes/locale-date.pipe.spec.ts
@@ -75,6 +75,18 @@ describe('LocaleDatePipe', () => {
     expect(a).toBe('January');
   });
 
+  it('should fall back to the default locale instead of rendering blank when locale data is unregistered (NG0701)', () => {
+    const date = new Date(2024, 0, 15, 14, 30);
+    // 'th-TH' is a valid BCP-47 tag, but neither 'th-TH' nor 'th' locale data
+    // is registered — pre-fallback this returned null (blank UI).
+    const result = pipe.transform(date, 'MMMM', undefined, 'th-TH');
+    expect(result).toBe('January');
+  });
+
+  it('should still return null when even the default-locale fallback cannot format the value', () => {
+    expect(pipe.transform('invalid-date-string', 'short', undefined, 'th-TH')).toBeNull();
+  });
+
   it('should react to a changed explicit locale arg (en-US vs de-DE)', () => {
     const date = new Date(2024, 0, 15, 14, 30);
     const en = pipe.transform(date, 'MMMM', undefined, 'en-US');

--- a/src/app/ui/pipes/locale-date.pipe.ts
+++ b/src/app/ui/pipes/locale-date.pipe.ts
@@ -4,6 +4,13 @@ import { DateTimeFormatService } from '../../core/date-time-format/date-time-for
 import { Log } from '../../core/log';
 import { DEFAULT_LOCALE } from '../../core/locale.constants';
 
+// Module-scoped: Angular creates one pure-pipe instance per binding per
+// embedded view, so per-instance state would warn once per row, not once.
+// DEFAULT_LOCALE ('en-gb') resolves to the 'en' data registered statically
+// at bootstrap, so the fallback pipe never depends on lazy locale registration.
+const FALLBACK_DATE_PIPE = new DatePipe(DEFAULT_LOCALE);
+const WARNED_LOCALES = new Set<string>();
+
 /**
  * Custom date pipe that respects the user's configured locale
  * Drop-in replacement for Angular's DatePipe
@@ -16,13 +23,6 @@ export class LocaleDatePipe implements PipeTransform {
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _datePipe: DatePipe | null = null;
   private _lastLocale: string | undefined;
-  // Fallback pipe, reused instead of re-allocated on every failed transform.
-  // DEFAULT_LOCALE ('en-gb') resolves to the 'en' data registered statically
-  // at bootstrap, so this path never depends on lazy locale registration.
-  private readonly _fallbackDatePipe = new DatePipe(DEFAULT_LOCALE);
-  // Many pipe instances render many dates per view; warn at most once per
-  // unregistered locale instead of flooding the console.
-  private readonly _warnedLocales = new Set<string>();
 
   transform(
     value: Date | string | number | null | undefined,
@@ -45,24 +45,33 @@ export class LocaleDatePipe implements PipeTransform {
 
     try {
       return this._datePipe.transform(value, format, timezone, effectiveLocale);
-    } catch (e) {
+    } catch {
       // Angular throws NG0701 when locale data for `effectiveLocale` isn't
       // registered — reachable since "System default" follows the browser's
       // regional locale, which can be any BCP-47 tag. Fall back to the
       // always-registered default locale so the date still renders.
-      if (!this._warnedLocales.has(effectiveLocale)) {
-        this._warnedLocales.add(effectiveLocale);
+      let fallback: string | null;
+      try {
+        fallback = FALLBACK_DATE_PIPE.transform(value, format, timezone, DEFAULT_LOCALE);
+      } catch {
+        // Both locales failed => the value itself is unformattable, not a
+        // locale problem. Stay silent (matching safeFormatDate) so a bad
+        // value cannot poison the per-locale warn set below.
+        return null;
+      }
+      // The fallback succeeding is the only prod-safe discriminant between
+      // "unregistered locale" and "bad value": DatePipe rewraps both as
+      // NG02100, and ngDevMode strips the messages in production builds.
+      // Deliberately not logging the error/value — the raw date is user
+      // content and log history is exportable (sync rule 9).
+      if (!WARNED_LOCALES.has(effectiveLocale)) {
+        WARNED_LOCALES.add(effectiveLocale);
         Log.warn(
           `LocaleDatePipe: cannot format with locale "${effectiveLocale}", ` +
             `using "${DEFAULT_LOCALE}"`,
-          e,
         );
       }
-      try {
-        return this._fallbackDatePipe.transform(value, format, timezone, DEFAULT_LOCALE);
-      } catch {
-        return null;
-      }
+      return fallback;
     }
   }
 }

--- a/src/app/ui/pipes/locale-date.pipe.ts
+++ b/src/app/ui/pipes/locale-date.pipe.ts
@@ -2,6 +2,7 @@ import { inject, Pipe, PipeTransform } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { DateTimeFormatService } from '../../core/date-time-format/date-time-format.service';
 import { Log } from '../../core/log';
+import { DEFAULT_LOCALE } from '../../core/locale.constants';
 
 /**
  * Custom date pipe that respects the user's configured locale
@@ -15,6 +16,13 @@ export class LocaleDatePipe implements PipeTransform {
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _datePipe: DatePipe | null = null;
   private _lastLocale: string | undefined;
+  // Fallback pipe, reused instead of re-allocated on every failed transform.
+  // DEFAULT_LOCALE ('en-gb') resolves to the 'en' data registered statically
+  // at bootstrap, so this path never depends on lazy locale registration.
+  private readonly _fallbackDatePipe = new DatePipe(DEFAULT_LOCALE);
+  // Many pipe instances render many dates per view; warn at most once per
+  // unregistered locale instead of flooding the console.
+  private readonly _warnedLocales = new Set<string>();
 
   transform(
     value: Date | string | number | null | undefined,
@@ -38,8 +46,23 @@ export class LocaleDatePipe implements PipeTransform {
     try {
       return this._datePipe.transform(value, format, timezone, effectiveLocale);
     } catch (e) {
-      Log.warn('LocaleDatePipe: failed to format value', value, e);
-      return null;
+      // Angular throws NG0701 when locale data for `effectiveLocale` isn't
+      // registered — reachable since "System default" follows the browser's
+      // regional locale, which can be any BCP-47 tag. Fall back to the
+      // always-registered default locale so the date still renders.
+      if (!this._warnedLocales.has(effectiveLocale)) {
+        this._warnedLocales.add(effectiveLocale);
+        Log.warn(
+          `LocaleDatePipe: cannot format with locale "${effectiveLocale}", ` +
+            `using "${DEFAULT_LOCALE}"`,
+          e,
+        );
+      }
+      try {
+        return this._fallbackDatePipe.transform(value, format, timezone, DEFAULT_LOCALE);
+      } catch {
+        return null;
+      }
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,7 +132,9 @@ bootstrapApplication(AppComponent, {
   providers: [
     // Await the browser's own regional locale (en-AU, en-CA, … — navigator-only
     // variants backing "System default") before first render, for the same
-    // pure-pipe reason as above. Never rejects, so it cannot block bootstrap.
+    // pure-pipe reason as above. Never rejects and self-limits to a short
+    // timeout, so a failed or stalled chunk load degrades to the default locale
+    // instead of failing bootstrap or holding up first render indefinitely.
     provideAppInitializer(() => registerNavigatorLocale()),
     // Provide configuration for TranslateHttpLoader
     {
@@ -365,9 +367,9 @@ bootstrapApplication(AppComponent, {
   initializeMatMenuTouchFix();
 
   // Lazily load and register remaining locales during idle time. The
-  // navigator-only regional variants are NOT loaded here — only the matched
-  // navigator.language entry is ever needed, and the app initializer above
-  // already registered it before first render.
+  // navigator-only regional variants are NOT loaded here — only the entry
+  // matching the browser culture language is ever needed, and the app
+  // initializer above already registered it before first render.
   const registerRemainingLocales = (): void => {
     Object.keys(LocaleImportFns).forEach((locale) => {
       if (locale !== DEFAULT_LANGUAGE) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import {
   APP_INITIALIZER,
+  provideAppInitializer,
   enableProdMode,
   EnvironmentInjector,
   ErrorHandler,
@@ -13,12 +14,11 @@ import { registerLocaleData } from '@angular/common';
 
 import { environment } from './environments/environment';
 import { IS_ELECTRON } from './app/app.constants';
+import { DEFAULT_LANGUAGE, LocaleImportFns } from './app/core/locale.constants';
 import {
-  DEFAULT_LANGUAGE,
-  DEFAULT_LOCALE_DATA,
-  LocaleImportFns,
-  NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS,
-} from './app/core/locale.constants';
+  registerDefaultLocale,
+  registerNavigatorLocale,
+} from './app/core/locale-registration';
 import { IS_ANDROID_WEB_VIEW } from './app/util/is-android-web-view';
 import { androidInterface } from './app/features/android/android-interface';
 import { AndroidBackButtonService } from './app/features/android/android-back-button.service';
@@ -122,8 +122,18 @@ setLegacyKdfWarningHandler(() => {
   );
 });
 
+// Register default locale data before bootstrap: LocaleDatePipe is pure, so a
+// date rendered before registration would cache Angular's built-in en-US
+// resolution for the session (bootstrapApplication's .then runs after first
+// render, which is too late).
+registerDefaultLocale();
+
 bootstrapApplication(AppComponent, {
   providers: [
+    // Await the browser's own regional locale (en-AU, en-CA, … — navigator-only
+    // variants backing "System default") before first render, for the same
+    // pure-pipe reason as above. Never rejects, so it cannot block bootstrap.
+    provideAppInitializer(() => registerNavigatorLocale()),
     // Provide configuration for TranslateHttpLoader
     {
       provide: TRANSLATE_HTTP_LOADER_CONFIG,
@@ -354,23 +364,10 @@ bootstrapApplication(AppComponent, {
   // Initialize touch fix for Material menus
   initializeMatMenuTouchFix();
 
-  // Register default locale immediately (statically imported, no network fetch)
-  registerLocaleData(DEFAULT_LOCALE_DATA, DEFAULT_LANGUAGE);
-
-  // Eagerly load the browser's own regional locale when it's one of the
-  // navigator-fallback variants: LocaleDatePipe is pure, so a date rendered
-  // before idle-time registration keeps its default-locale fallback until the
-  // binding changes. Loading now instead of at idle closes that window for
-  // exactly the users the fallback data exists for.
-  const navLocaleKey = navigator.language.toLowerCase().replace(/-/g, '_');
-  const eagerNavLocaleLoad = NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[navLocaleKey];
-  if (eagerNavLocaleLoad) {
-    eagerNavLocaleLoad()
-      .then((m) => registerLocaleData(m.default))
-      .catch((e) => Log.err(`Failed to load locale ${navLocaleKey}`, e));
-  }
-
-  // Lazily load and register remaining locales during idle time
+  // Lazily load and register remaining locales during idle time. The
+  // navigator-only regional variants are NOT loaded here — only the matched
+  // navigator.language entry is ever needed, and the app initializer above
+  // already registered it before first render.
   const registerRemainingLocales = (): void => {
     Object.keys(LocaleImportFns).forEach((locale) => {
       if (locale !== DEFAULT_LANGUAGE) {
@@ -380,15 +377,6 @@ bootstrapApplication(AppComponent, {
           })
           .catch((e) => Log.err(`Failed to load locale ${locale}`, e));
       }
-    });
-    // Region variants backing the "System default" browser-locale fallback —
-    // not user-selectable (see locale.constants.ts). No explicit id: unlike
-    // the aliasing loop above ('en'→en-GB, 'zh_tw'→zh), these data files
-    // self-report ids matching their keys, so the self-id is typo-proof.
-    Object.entries(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).forEach(([locale, load]) => {
-      load()
-        .then((m) => registerLocaleData(m.default))
-        .catch((e) => Log.err(`Failed to load locale ${locale}`, e));
     });
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -357,6 +357,19 @@ bootstrapApplication(AppComponent, {
   // Register default locale immediately (statically imported, no network fetch)
   registerLocaleData(DEFAULT_LOCALE_DATA, DEFAULT_LANGUAGE);
 
+  // Eagerly load the browser's own regional locale when it's one of the
+  // navigator-fallback variants: LocaleDatePipe is pure, so a date rendered
+  // before idle-time registration keeps its default-locale fallback until the
+  // binding changes. Loading now instead of at idle closes that window for
+  // exactly the users the fallback data exists for.
+  const navLocaleKey = navigator.language.toLowerCase().replace(/-/g, '_');
+  const eagerNavLocaleLoad = NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS[navLocaleKey];
+  if (eagerNavLocaleLoad) {
+    eagerNavLocaleLoad()
+      .then((m) => registerLocaleData(m.default))
+      .catch((e) => Log.err(`Failed to load locale ${navLocaleKey}`, e));
+  }
+
   // Lazily load and register remaining locales during idle time
   const registerRemainingLocales = (): void => {
     Object.keys(LocaleImportFns).forEach((locale) => {
@@ -369,10 +382,12 @@ bootstrapApplication(AppComponent, {
       }
     });
     // Region variants backing the "System default" browser-locale fallback —
-    // not user-selectable (see locale.constants.ts).
+    // not user-selectable (see locale.constants.ts). No explicit id: unlike
+    // the aliasing loop above ('en'→en-GB, 'zh_tw'→zh), these data files
+    // self-report ids matching their keys, so the self-id is typo-proof.
     Object.entries(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).forEach(([locale, load]) => {
       load()
-        .then((m) => registerLocaleData(m.default, locale))
+        .then((m) => registerLocaleData(m.default))
         .catch((e) => Log.err(`Failed to load locale ${locale}`, e));
     });
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_LOCALE_DATA,
   LocaleImportFns,
+  NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS,
 } from './app/core/locale.constants';
 import { IS_ANDROID_WEB_VIEW } from './app/util/is-android-web-view';
 import { androidInterface } from './app/features/android/android-interface';
@@ -366,6 +367,13 @@ bootstrapApplication(AppComponent, {
           })
           .catch((e) => Log.err(`Failed to load locale ${locale}`, e));
       }
+    });
+    // Region variants backing the "System default" browser-locale fallback —
+    // not user-selectable (see locale.constants.ts).
+    Object.entries(NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS).forEach(([locale, load]) => {
+      load()
+        .then((m) => registerLocaleData(m.default, locale))
+        .catch((e) => Log.err(`Failed to load locale ${locale}`, e));
     });
   };
 


### PR DESCRIPTION
## Summary

Focused follow-up to #7731, carrying over the two pieces @johannesjo suggested keeping after #8023 shipped the browser-locale resolution for "System default":

1. **`LocaleDatePipe`: fall back to `DEFAULT_LOCALE` instead of rendering blank.** Since #8023, `currentLocale()` for "System default" can be any browser locale (via `getBrowserCultureLang()`). `LocaleDatePipe` builds Angular's `DatePipe` from it, and Angular throws `NG0701` when locale data for that tag isn't registered — registration only covers the app's UI languages. The pipe's `catch` returned `null`, so users whose OS language is outside that set (Thai, Danish, Greek, Hebrew, …) get **blank date fields** on the default setting — in reminder toasts, planner, schedule, and sync-conflict UI (~15 templates + effects). The pipe now retries with `DEFAULT_LOCALE` (en-GB), mirroring the `safeFormatDate` pattern, so those users see en-GB-formatted dates instead of nothing.

2. **Register Angular locale data for eight English region variants** (en-AU, en-CA, en-IE, en-IN, en-NZ, en-PH, en-SG, en-ZA). Without registration, `DatePipe` falls back `en-au` → `en`, which is registered with **en-GB** data — so toast/snack messages show 24-hour `13:00` while the `Intl`-based paths (fixed by #8023) correctly show `1:00 PM` on the same machine. The variants live in a separate `NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS` registry so the `DateTimeLocale` union stays limited to dropdown-selectable locales. Because `LocaleDatePipe` is pure — the first render of a date caches its locale resolution for the session — registration must happen **before Angular's first render**, not at idle time: the en-GB default is registered at module scope and the browser's matching regional chunk is awaited by an app initializer. The registration is extracted into `src/app/core/locale-registration.ts` (unit-testable), with a bounded 1.5s `Promise.race` so a stalled chunk degrades to the default locale rather than holding up bootstrap.

3. **Register en-US up front too.** Seeding en-GB under the bare `en` id changes what an unregistered `en-us` lookup resolves to before the idle-time loop runs: it now falls through `en` (=en-GB) and renders day-first/24h, frozen there by the pure pipe. On master, where `en` was seeded only inside the bootstrap `.then`, the same first-paint lookup fell through to Angular's built-in en-US and was correct. So en-US is registered under `en-us` alongside the en-GB seed, keeping an explicit "System default" or dropdown en-US choice month-first/12h from first paint (the data file self-reports `en`, so an explicit id is required — a keyless call would clobber the en-GB seed).

Unlike #7731, this does **not** touch `DateTimeFormatService` or the `DateAdapter` — #8023's resolution logic is untouched.

## Changes

| File | Change |
| --- | --- |
| `src/app/ui/pipes/locale-date.pipe.ts` | Retry failed `transform` with a reused `DatePipe(DEFAULT_LOCALE)`; warn once per unregistered locale. Still returns `null` when the value itself is unformattable. |
| `src/app/core/locale.constants.ts` | Add `NAVIGATOR_FALLBACK_LOCALE_IMPORT_FNS` (8 English region variants, lazy imports, not dropdown-selectable). |
| `src/app/core/locale-registration.ts` | New. `registerDefaultLocale()` (module-scope: en-GB under `en`, en-US under `en-us`) and `registerNavigatorLocale()` (app-initializer: the browser's regional chunk, bounded 1.5s wait, never rejects). |
| `src/main.ts` | Call `registerDefaultLocale()` at module scope and await `registerNavigatorLocale()` via `provideAppInitializer` — both before first render. |
| `src/app/ui/pipes/locale-date.pipe.spec.ts` | Unregistered `th-TH` renders via en-GB fallback instead of `null`; unformattable value still returns `null` without poisoning the per-locale warn dedup. |
| `src/app/core/locale-registration.spec.ts` | New. en-GB seed under `en`, en-US under `en-us`, per-navigator registration (synthetic locales, pollution-proof), `getBrowserCultureLang` default, and the bounded stalled-load path. |
| `src/app/core/locale.constants.spec.ts` | New. Each of the 8 variants self-reports the BCP-47 id its map key promises (keyless registration is safe) and renders its expected 12h/24h `shortTime` against the en-GB baseline. |

## Test plan

- [x] `locale-date.pipe.spec.ts`, `locale-registration.spec.ts`, `locale.constants.spec.ts` — pass (31 specs). Each new assertion was sabotage-checked: reverting the fix it covers makes it fail (registration no-op → the six 12h variants fail; `.toLowerCase()`/default-arg regressions → the synthetic-locale specs fail; timeout regression → the stalled-load spec fails without leaking the mocked clock into sibling suites).
- [x] `npm run test:file src/app/core/date-time-format/date-time-format.service.spec.ts` — passes.
- [x] Full unit suite green (13314) and `checkFile` clean on all touched files.

Supersedes the salvageable part of #7731.

