### PR TITLE
test: make date-based specs timezone-independent

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-schedule-days.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/create-schedule-days.spec.ts
@@ -43,19 +43,23 @@ describe('createScheduleDays - Task Filtering', () => {
     now = today.getTime();
     realNow = now;
 
-    todayStr = today.toISOString().split('T')[0];
+    // NOTE: date strings must be derived from the LOCAL date (getDbDateStr), not
+    // toISOString() (UTC) — otherwise they shift a day in timezones ahead of UTC
+    // (e.g. Australia/Sydney) and no longer match the local-midnight logic in
+    // createScheduleDays.
+    todayStr = getDbDateStr(today);
 
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrowStr = tomorrow.toISOString().split('T')[0];
+    tomorrowStr = getDbDateStr(tomorrow);
 
     const nextWeek = new Date(today);
     nextWeek.setDate(nextWeek.getDate() + 7);
-    nextWeekStr = nextWeek.toISOString().split('T')[0];
+    nextWeekStr = getDbDateStr(nextWeek);
 
     const futureWeek = new Date(today);
     futureWeek.setDate(futureWeek.getDate() + 14);
-    futureWeekStr = futureWeek.toISOString().split('T')[0];
+    futureWeekStr = getDbDateStr(futureWeek);
   });
 
   describe('Unscheduled tasks (no dueDay, no dueWithTime, no plannedForDay)', () => {
@@ -89,12 +93,7 @@ describe('createScheduleDays - Task Filtering', () => {
 
     it('should NOT appear when viewing next week (outside current week)', () => {
       // Arrange
-      const unscheduledTask: TaskWithoutReminder = {
-        id: 'task1',
-        title: 'Unscheduled Task',
-        timeEstimate: 3600000,
-        timeSpent: 0,
-      } as TaskWithoutReminder;
+      const unscheduledTask = createTestTask('task1', 'Unscheduled Task');
 
       // Viewing a week starting 7 days from now
       const dayDates = [nextWeekStr];
@@ -519,7 +518,7 @@ describe('createScheduleDays - Task Filtering', () => {
       // Viewing two days in next week
       const secondDayNextWeek = parseDbDateStr(nextWeekStr);
       secondDayNextWeek.setDate(secondDayNextWeek.getDate() + 1);
-      const secondDayStr = secondDayNextWeek.toISOString().split('T')[0];
+      const secondDayStr = getDbDateStr(secondDayNextWeek);
 
       const dayDates = [nextWeekStr, secondDayStr];
       const plannerDayMap: PlannerDayMap = {};

--- a/src/app/plugins/plugin-i18n-date.util.spec.ts
+++ b/src/app/plugins/plugin-i18n-date.util.spec.ts
@@ -1,9 +1,12 @@
 import { formatDateForPlugin } from './plugin-i18n-date.util';
 
 describe('formatDateForPlugin', () => {
-  const testDate = new Date('2026-01-16T14:30:00Z');
+  // NOTE: constructed in LOCAL time — formatDateForPlugin formats in the local
+  // timezone, so a fixed UTC instant would land on Jan 17 in timezones ahead of
+  // UTC (e.g. Australia/Sydney) and break the day-of-month assertions below.
+  const testDate = new Date(2026, 0, 16, 14, 30, 0);
   const testTimestamp = testDate.getTime();
-  const testISOString = '2026-01-16T14:30:00Z';
+  const testISOString = testDate.toISOString();
 
   describe('short format', () => {
     it('should format date with short format in English', () => {


### PR DESCRIPTION
## Problem

8 unit tests fail on a clean master checkout in timezones far enough ahead of UTC (e.g. `Australia/Sydney`, UTC+11). Reproducible on any OS with `npm run test:tz:sydney`.

- `create-schedule-days.spec.ts` (4 failures): the spec derives its day strings via `today.toISOString().split('T')[0]` — that's the **UTC** date, while `createScheduleDays` buckets days by **local** midnight. In Sydney, local `Jan 20 10:00` is UTC `Jan 19 23:00`, so `todayStr` lags a day, the week-boundary assertions flip, and one test crashes with `TypeError: Cannot read properties of undefined (reading 'length')` in `getTimeLeftForTask` — the shifted week boundary lets its raw task literal (built without `subTaskIds` instead of via `createTestTask`) reach the budget calculation.
- `plugin-i18n-date.util.spec.ts` (4 failures): the spec pins the UTC instant `2026-01-16T14:30:00Z` but `formatDateForPlugin` formats in the local timezone, so in Sydney the output is `Jan 17` and the `toContain('16')` assertions fail.

### Why this hits Windows contributors even with the `TZ=Europe/Berlin` pinning

The `cross-env TZ='Europe/Berlin'` in the test scripts only reaches the Node/Karma process. Chromium on Windows ignores the `TZ` environment variable and uses the OS timezone, so the browser the specs actually run in uses the machine's local timezone (verified with `Intl.DateTimeFormat().resolvedOptions().timeZone` inside a Karma spec). Any Windows contributor east of ~UTC+10 gets these 8 failures on untouched master.

## Fix

Make the specs timezone-independent, matching the intent of the `test:tz:*` scripts:

- derive day strings with `getDbDateStr()` (local date) instead of `toISOString()`
- construct the plugin spec's test date with the local-time `Date` constructor and derive the ISO-string input from it
- build the raw task literal with the file's `createTestTask` helper so the task shape matches the `Task` model (`subTaskIds` present)

~~The derived values are byte-identical in the timezones CI currently runs (`Europe/Berlin`, `America/Los_Angeles`, and the other `test:tz` targets `Asia/Tokyo`/`UTC`), so this changes nothing for existing green runs — it only removes the UTC/local mismatch.~~

**Correction** (from review — thanks @johannesjo for catching this): the byte-identical claim doesn't hold for `secondDayStr` in `create-schedule-days.spec.ts`. The old line went `parseDbDateStr` (local midnight) → `+1 day` → `.toISOString()` (UTC), and local midnight rolls back into the previous UTC day in any positive-offset timezone — including CI's primary `Europe/Berlin` and `Asia/Tokyo`. On master, `should filter tasks between days when viewing outside current week` was therefore arranging `dayDates` as the **same day twice** in those timezones instead of two consecutive days; only `America/Los_Angeles` and `UTC` produced the intended arrangement. This PR makes the arrangement correct in all timezones. No assertion outcome changes (the test only asserts on `result[0]`, which passed either way), but the description's "changes nothing for existing green runs" was wrong — it repairs a mis-arranged test in the timezones CI actually runs.

## Verification

- `npm run test:file src/app/features/schedule/map-schedule-data/create-schedule-days.spec.ts` → 18/18 (was 4 FAILED) on a Windows machine in `Australia/Sydney`
- `npm run test:file src/app/plugins/plugin-i18n-date.util.spec.ts` → 31/31 (was 4 FAILED)
- full `npm run lint && npm run test` (pre-push hook) green: 13162 SUCCESS