### PR TITLE
fix(theme): tolerate work contexts persisted without a theme (#9139)

### DIFF
--- a/e2e/tests/migration/legacy-themeless-tag-9139.spec.ts
+++ b/e2e/tests/migration/legacy-themeless-tag-9139.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect, Page } from '@playwright/test';
+import legacyData from '../../fixtures/legacy-full-migration-backup.json';
+import { MIGRATION_BACKUP_PREFIX } from '../../../electron/shared-with-frontend/get-backup-timestamp';
+import { skipOnboardingForE2E } from '../../utils/waits';
+
+/**
+ * Issue #9139: a tag persisted with no `theme` at all crashed the app on
+ * EVERY launch — `resolveBackground()` dereferenced `theme.backgroundImageDark`
+ * on undefined, and the reported entity was TODAY, the active context at
+ * startup.
+ *
+ * The unit tests pin the pieces (the fallback, the heal, the `currentTheme$`
+ * wiring). None of them can show that the app actually STARTS with this data
+ * on disk, which is the only claim the bug report makes. That is what this
+ * test is for, so it deliberately asserts boot-and-render rather than any
+ * particular colour.
+ *
+ * SCOPE: this covers the on-disk heal. With the heal in place the data is
+ * repaired during migration, so the read-side fallback in `resolveContextTheme`
+ * is never reached here — verified by removing it and watching this test stay
+ * green. That path is covered by the `currentTheme$` unit test instead; an
+ * end-to-end version needs to corrupt an already-migrated store, which fights
+ * the running app's own IndexedDB connection and is not worth the flake.
+ *
+ * Run: npm run e2e:file e2e/tests/migration/legacy-themeless-tag-9139.spec.ts -- --retries=0
+ */
+
+/** Read the migrated store back out of SUP_OPS. */
+const readMigratedState = async (
+  page: Page,
+): Promise<{ tag?: { ids: string[]; entities: Record<string, unknown> } }> =>
+  page.evaluate(
+    async () =>
+      new Promise((resolve, reject) => {
+        const request = indexedDB.open('SUP_OPS');
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction('state_cache', 'readonly');
+          const getReq = tx.objectStore('state_cache').get('current');
+          getReq.onsuccess = () => {
+            db.close();
+            resolve(getReq.result?.state || {});
+          };
+          getReq.onerror = () => {
+            db.close();
+            reject(getReq.error);
+          };
+        };
+        request.onerror = () => reject(request.error);
+      }),
+  );
+
+const seedLegacyDatabase = async (
+  page: Page,
+  data: Record<string, unknown>,
+): Promise<void> => {
+  await page.evaluate(
+    async (entityData) =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('pf', 1);
+        request.onupgradeneeded = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          if (!db.objectStoreNames.contains('main')) {
+            db.createObjectStore('main');
+          }
+        };
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction('main', 'readwrite');
+          const store = tx.objectStore('main');
+          for (const [key, value] of Object.entries(entityData)) {
+            store.put(value, key);
+          }
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+          };
+        };
+        request.onerror = () => reject(request.error);
+      }),
+    data,
+  );
+};
+
+test.describe('@migration #9139 work context with no theme', () => {
+  test('app starts and migrates when the TODAY tag has no theme', async ({
+    browser,
+    baseURL,
+  }) => {
+    // Mutate the shared fixture in-code rather than committing a near-duplicate
+    // copy of it: the single deleted key IS the bug, and this way it stays
+    // visible in the diff instead of buried in ~100KB of JSON.
+    const themelessData = JSON.parse(JSON.stringify(legacyData.data)) as Record<
+      string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      any
+    >;
+    delete themelessData.tag.entities.TODAY.theme;
+    expect('theme' in themelessData.tag.entities.TODAY).toBe(false);
+
+    const context = await browser.newContext({
+      storageState: undefined,
+      baseURL: baseURL || 'http://localhost:4242',
+      acceptDownloads: true,
+    });
+    const page = await context.newPage();
+    await page.addInitScript(skipOnboardingForE2E);
+
+    // The pre-fix failure is an uncaught TypeError during startup, so collect
+    // page errors and assert on them explicitly — a blank-but-quiet page and a
+    // crashed page must not look the same to this test.
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    try {
+      await page.route('**/*.js', async (route) => route.abort());
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await seedLegacyDatabase(page, themelessData);
+      await page.unroute('**/*.js');
+
+      const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
+      await page.reload({ waitUntil: 'domcontentloaded' });
+
+      // Migration ran at all (its backup download is the reliable signal —
+      // the dialog can come and go faster than we can observe it).
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toContain(MIGRATION_BACKUP_PREFIX);
+
+      // The actual regression: the app renders instead of dying at startup.
+      await page.waitForSelector('magic-side-nav', { state: 'visible', timeout: 30000 });
+      await expect(page.locator('magic-side-nav')).toBeVisible();
+
+      // TODAY is the context the crash was reported on, so make sure we
+      // actually landed on it rather than passing on some other route.
+      await page.goto('/#/tag/TODAY/tasks');
+      await page.waitForSelector('magic-side-nav', { state: 'visible', timeout: 30000 });
+
+      expect(
+        pageErrors.filter((m) => /backgroundImage|theme|undefined/i.test(m)),
+      ).toEqual([]);
+
+      // And the data was healed, not merely tolerated at read time — otherwise
+      // this would still pass with the on-disk corruption left in place.
+      const state = await readMigratedState(page);
+      const today = state.tag?.entities?.TODAY as
+        | { theme?: Record<string, unknown> }
+        | undefined;
+      expect(today).toBeDefined();
+      expect(today?.theme).toBeDefined();
+      expect(typeof today?.theme?.primary).toBe('string');
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/e2e/tests/migration/legacy-themeless-tag-9139.spec.ts
+++ b/e2e/tests/migration/legacy-themeless-tag-9139.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, Page } from '@playwright/test';
 import legacyData from '../../fixtures/legacy-full-migration-backup.json';
 import { MIGRATION_BACKUP_PREFIX } from '../../../electron/shared-with-frontend/get-backup-timestamp';
 import { skipOnboardingForE2E } from '../../utils/waits';
+import { cssSelectors } from '../../constants/selectors';
 
 /**
  * Issue #9139: a tag persisted with no `theme` at all crashed the app on
@@ -15,12 +16,12 @@ import { skipOnboardingForE2E } from '../../utils/waits';
  * test is for, so it deliberately asserts boot-and-render rather than any
  * particular colour.
  *
- * SCOPE: this covers the on-disk heal. With the heal in place the data is
- * repaired during migration, so the read-side fallback in `resolveContextTheme`
- * is never reached here — verified by removing it and watching this test stay
- * green. That path is covered by the `currentTheme$` unit test instead; an
- * end-to-end version needs to corrupt an already-migrated store, which fights
- * the running app's own IndexedDB connection and is not worth the flake.
+ * There are two independent defenses and they cover different paths, so there
+ * is a test for each:
+ *  1. the on-disk heal, which repairs the data during migration;
+ *  2. the read-side fallback in `resolveContextTheme`, which is what saves an
+ *     ALREADY-migrated store whose theme goes missing later — hydration
+ *     validates but does not repair, so nothing heals that before render.
  *
  * Run: npm run e2e:file e2e/tests/migration/legacy-themeless-tag-9139.spec.ts -- --retries=0
  */
@@ -86,6 +87,70 @@ const seedLegacyDatabase = async (
   );
 };
 
+/**
+ * Delete `theme` from the TODAY tag of an already-migrated store, and report
+ * what happened rather than failing silently.
+ *
+ * Corrupting a store the app itself produced beats hand-building one: the
+ * surrounding schema is guaranteed real, so the only variable is the missing
+ * key.
+ */
+const stripThemeFromMigratedToday = async (page: Page): Promise<string> =>
+  page.evaluate(
+    async () =>
+      new Promise<string>((resolve) => {
+        // Resolve on every branch — an IndexedDB request that neither succeeds
+        // nor errors (a blocked upgrade, say) would otherwise hang the evaluate
+        // until the whole test times out with a misleading message.
+        const timer = setTimeout(() => resolve('TIMEOUT'), 10000);
+        const done = (msg: string): void => {
+          clearTimeout(timer);
+          resolve(msg);
+        };
+        const req = indexedDB.open('SUP_OPS');
+        req.onblocked = () => done('BLOCKED');
+        req.onerror = () => done('OPEN-ERROR');
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction('state_cache', 'readwrite');
+          tx.onabort = () => done('TX-ABORT');
+          const store = tx.objectStore('state_cache');
+          const getReq = store.get('current');
+          getReq.onsuccess = () => {
+            const row = getReq.result;
+            const today = row?.state?.tag?.entities?.TODAY;
+            if (!today) {
+              db.close();
+              done('NO-TODAY');
+              return;
+            }
+            delete today.theme;
+            // `state_cache` uses an in-line key (the row carries its own id),
+            // and passing an explicit key to put() on such a store raises
+            // DataError, which aborts the transaction rather than surfacing as
+            // a request error. Let the store take the key from the row.
+            let putReq: IDBRequest;
+            try {
+              putReq = store.keyPath ? store.put(row) : store.put(row, 'current');
+            } catch (e) {
+              db.close();
+              done('PUT-THREW:' + String(e));
+              return;
+            }
+            putReq.onsuccess = () => {
+              db.close();
+              done('OK');
+            };
+            putReq.onerror = () => {
+              db.close();
+              done('PUT-ERROR:' + String(putReq.error));
+            };
+          };
+          getReq.onerror = () => done('GET-ERROR');
+        };
+      }),
+  );
+
 test.describe('@migration #9139 work context with no theme', () => {
   test('app starts and migrates when the TODAY tag has no theme', async ({
     browser,
@@ -139,12 +204,10 @@ test.describe('@migration #9139 work context with no theme', () => {
       await page.goto('/#/tag/TODAY/tasks');
       await page.waitForSelector('magic-side-nav', { state: 'visible', timeout: 30000 });
 
-      expect(
-        pageErrors.filter((m) => /backgroundImage|theme|undefined/i.test(m)),
-      ).toEqual([]);
-
-      // And the data was healed, not merely tolerated at read time — otherwise
-      // this would still pass with the on-disk corruption left in place.
+      // The data was healed, not merely tolerated at read time — otherwise this
+      // would still pass with the on-disk corruption left in place. This is the
+      // load-bearing assertion of this test (verified: disabling the heal fails
+      // right here).
       const state = await readMigratedState(page);
       const today = state.tag?.entities?.TODAY as
         | { theme?: Record<string, unknown> }
@@ -152,6 +215,113 @@ test.describe('@migration #9139 work context with no theme', () => {
       expect(today).toBeDefined();
       expect(today?.theme).toBeDefined();
       expect(typeof today?.theme?.primary).toBe('string');
+
+      // Checked LAST on purpose: the IndexedDB round trip above is a real
+      // settle window, so a startup error has had time to surface. Asserting
+      // this straight after the side nav appears would pass on timing alone.
+      // (No task-content assertion here — TODAY membership is virtual, driven
+      // by dueDay rather than the tag's taskIds, so the list can legitimately
+      // be empty for this fixture.)
+      expect(
+        pageErrors.filter((m) => /backgroundImage|theme|undefined/i.test(m)),
+      ).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
+
+  // The test above only exercises the on-disk heal: it repairs the data during
+  // migration, so the read-side fallback is never reached (verified — removing
+  // it leaves that test green). But the crash in #9139 was an ordinary launch,
+  // not a migration. This covers that: an already-migrated store that loses its
+  // theme afterwards. Hydration validates without repairing, so nothing heals
+  // this before render and `resolveContextTheme` is the only thing standing
+  // between the user and the startup crash.
+  test('app starts when an already-migrated TODAY tag loses its theme', async ({
+    browser,
+    baseURL,
+  }) => {
+    const context = await browser.newContext({
+      storageState: undefined,
+      baseURL: baseURL || 'http://localhost:4242',
+      acceptDownloads: true,
+    });
+
+    try {
+      // Phase 1 — let the app build a real, valid store for itself.
+      const appPage = await context.newPage();
+      await appPage.addInitScript(skipOnboardingForE2E);
+      await appPage.route('**/*.js', async (route) => route.abort());
+      await appPage.goto('/', { waitUntil: 'domcontentloaded' });
+      await seedLegacyDatabase(appPage, legacyData.data as Record<string, unknown>);
+      await appPage.unroute('**/*.js');
+
+      const downloadPromise = appPage.waitForEvent('download', { timeout: 60000 });
+      await appPage.reload({ waitUntil: 'domcontentloaded' });
+      await downloadPromise;
+      await appPage.waitForSelector('magic-side-nav', {
+        state: 'visible',
+        timeout: 30000,
+      });
+
+      // Phase 2 — corrupt the store from a second, script-free page.
+      //
+      // Order matters and is load-bearing: this page is opened BEFORE the app
+      // page closes. Opening it afterwards produced an evaluate that never
+      // settled and surfaced as a misleading "execution context was destroyed".
+      // Reading from the app's own page is no good either — the state_cache
+      // write is async and lands after `magic-side-nav` is already visible, so
+      // it reads back empty.
+      const dbPage = await context.newPage();
+      await dbPage.route('**/*.js', async (route) => route.abort());
+      await dbPage.goto('/', { waitUntil: 'domcontentloaded' });
+
+      // Wait for the row to actually exist before touching it, so a corruption
+      // that silently no-ops cannot masquerade as a pass.
+      await expect
+        .poll(
+          async () => (await readMigratedState(dbPage)).tag?.entities?.TODAY != null,
+          {
+            timeout: 30000,
+          },
+        )
+        .toBe(true);
+
+      await appPage.close();
+      expect(await stripThemeFromMigratedToday(dbPage)).toBe('OK');
+
+      // Confirm the corruption is really on disk before relying on it.
+      const corrupted = (await readMigratedState(dbPage)).tag?.entities?.TODAY as
+        | Record<string, unknown>
+        | undefined;
+      expect(corrupted).toBeDefined();
+      expect('theme' in (corrupted as Record<string, unknown>)).toBe(false);
+      await dbPage.close();
+
+      // Phase 3 — the launch that used to die in resolveBackground().
+      const page = await context.newPage();
+      await page.addInitScript(skipOnboardingForE2E);
+      const pageErrors: string[] = [];
+      page.on('pageerror', (error) => pageErrors.push(error.message));
+
+      await page.goto('/#/tag/TODAY/tasks', { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('magic-side-nav', { state: 'visible', timeout: 30000 });
+      await expect(page.locator('magic-side-nav')).toBeVisible();
+
+      // "No error happened" is meaningless without waiting for something real
+      // first. The side nav renders BEFORE the theme pipeline throws, so
+      // asserting straight after it is a race — verified the hard way: with the
+      // fallback removed this test failed alongside its sibling but PASSED when
+      // run alone, purely because the faster solo run checked before the error
+      // arrived. Waiting on a rendered task is both the stronger assertion and
+      // the settle window, without a bare timeout.
+      await expect(page.locator(cssSelectors.TASK).first()).toBeVisible({
+        timeout: 30000,
+      });
+
+      expect(
+        pageErrors.filter((m) => /backgroundImage|theme|undefined/i.test(m)),
+      ).toEqual([]);
     } finally {
       await context.close();
     }

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts
@@ -44,4 +44,16 @@ describe('getProjectVisibilityIconColor', () => {
 
     expect(getProjectVisibilityIconColor(project)).toBe('#abcdef');
   });
+
+  it('does not throw for a project persisted without a theme (#9139)', () => {
+    // A project entity can reach the store with no `theme` at all. This helper
+    // renders once per project in the side nav on every launch, and because
+    // DEFAULT_PROJECT_ICON is not an emoji the theme branch is the DEFAULT
+    // path — so an unguarded deref crashed the app at startup.
+    const project = createProject({ icon: 'work' });
+    delete (project as unknown as Record<string, unknown>).theme;
+
+    expect(() => getProjectVisibilityIconColor(project)).not.toThrow();
+    expect(getProjectVisibilityIconColor(project)).toBeNull();
+  });
 });

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.spec.ts
@@ -50,10 +50,11 @@ describe('getProjectVisibilityIconColor', () => {
     // renders once per project in the side nav on every launch, and because
     // DEFAULT_PROJECT_ICON is not an emoji the theme branch is the DEFAULT
     // path — so an unguarded deref crashed the app at startup.
-    const project = createProject({ icon: 'work' });
+    // No `icon` here on purpose: that is the fall-through the comment
+    // describes, so the fixture exercises the path it claims to.
+    const project = createProject({});
     delete (project as unknown as Record<string, unknown>).theme;
 
-    expect(() => getProjectVisibilityIconColor(project)).not.toThrow();
     expect(getProjectVisibilityIconColor(project)).toBeNull();
   });
 });

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.ts
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.ts
@@ -44,7 +44,7 @@ const EXPAND_ANIMATION_RESET_DELAY_MS = 250;
 export const getProjectVisibilityIconColor = (project: Project): string | null =>
   isSingleEmoji(project.icon || DEFAULT_PROJECT_ICON)
     ? null
-    : (project.theme.primary ?? null);
+    : (project.theme?.primary ?? null);
 
 @Component({
   selector: 'nav-list-tree',

--- a/src/app/features/note/note/note.component.html
+++ b/src/app/features/note/note/note.component.html
@@ -119,7 +119,7 @@
             mat-menu-item
           >
             <mat-icon
-              [style.color]="project.theme.primary"
+              [style.color]="project.theme?.primary"
               class="tag-ico"
               >{{ project.icon || DEFAULT_PROJECT_ICON }}</mat-icon
             >

--- a/src/app/features/work-context/work-context-default-theme.util.ts
+++ b/src/app/features/work-context/work-context-default-theme.util.ts
@@ -1,0 +1,45 @@
+import { WorkContextThemeCfg } from './work-context.model';
+import { DEFAULT_TAG, IMPORTANT_TAG, TODAY_TAG, URGENT_TAG } from '../tag/tag.const';
+import { DEFAULT_PROJECT, INBOX_PROJECT } from '../project/project.const';
+
+/**
+ * System entities ship a *distinct* theme, so falling back to the generic
+ * default would silently restyle them — and where `auto-fix-typia-errors`
+ * persists the value, permanently.
+ *
+ * A Map, not an object literal: a hostile entity id of `__proto__` resolves to
+ * `Object.prototype` on a plain-object lookup, which is non-nullish and would
+ * therefore be spread into an empty theme instead of falling through.
+ *
+ * IN_PROGRESS_TAG is deliberately absent: its theme differs from DEFAULT_TAG's
+ * only in `backgroundImageDark` ('' vs null), and `isBackgroundImageSet` treats
+ * both as unset — so a row for it could not change any rendered output.
+ */
+const SYSTEM_ENTITY_THEMES: ReadonlyMap<string, WorkContextThemeCfg> = new Map(
+  [TODAY_TAG, URGENT_TAG, IMPORTANT_TAG, INBOX_PROJECT].map(
+    (e) => [e.id, e.theme] as const,
+  ),
+);
+
+/**
+ * The theme a work context should fall back to when it has none.
+ *
+ * Shared by the read side (`resolveContextTheme`) and the on-disk heal in
+ * `auto-fix-typia-errors`. Those two must not diverge: hydration validates
+ * without repairing, so a local-only user can render the read-side value for
+ * many sessions before a repair ever runs — and TODAY is the active context at
+ * startup (#9139).
+ *
+ * KNOWN RESIDUAL: `lwwUpdateMetaReducer`'s recreate branch is a third writer
+ * and does NOT route through here — it spreads `RECREATE_FALLBACK[type].defaults`,
+ * which is id-blind, so a system entity recreated from a partial LWW update
+ * still gets the generic theme persisted. Narrow (needs a delete-vs-update race
+ * on a system entity) and left alone deliberately: that file is sync-critical
+ * and deserves its own change with its own convergence analysis.
+ */
+export const getDefaultWorkContextTheme = (
+  isTag: boolean,
+  entityId: string,
+): WorkContextThemeCfg =>
+  SYSTEM_ENTITY_THEMES.get(entityId) ??
+  (isTag ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme);

--- a/src/app/features/work-context/work-context-default-theme.util.ts
+++ b/src/app/features/work-context/work-context-default-theme.util.ts
@@ -1,4 +1,4 @@
-import { WorkContextThemeCfg } from './work-context.model';
+import { WorkContextThemeCfg, WorkContextType } from './work-context.model';
 import { DEFAULT_TAG, IMPORTANT_TAG, TODAY_TAG, URGENT_TAG } from '../tag/tag.const';
 import { DEFAULT_PROJECT, INBOX_PROJECT } from '../project/project.const';
 
@@ -15,7 +15,7 @@ import { DEFAULT_PROJECT, INBOX_PROJECT } from '../project/project.const';
  * only in `backgroundImageDark` ('' vs null), and `isBackgroundImageSet` treats
  * both as unset — so a row for it could not change any rendered output.
  */
-const SYSTEM_ENTITY_THEMES: ReadonlyMap<string, WorkContextThemeCfg> = new Map(
+export const SYSTEM_ENTITY_THEMES: ReadonlyMap<string, WorkContextThemeCfg> = new Map(
   [TODAY_TAG, URGENT_TAG, IMPORTANT_TAG, INBOX_PROJECT].map(
     (e) => [e.id, e.theme] as const,
   ),
@@ -38,8 +38,8 @@ const SYSTEM_ENTITY_THEMES: ReadonlyMap<string, WorkContextThemeCfg> = new Map(
  * and deserves its own change with its own convergence analysis.
  */
 export const getDefaultWorkContextTheme = (
-  isTag: boolean,
+  type: WorkContextType,
   entityId: string,
 ): WorkContextThemeCfg =>
   SYSTEM_ENTITY_THEMES.get(entityId) ??
-  (isTag ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme);
+  (type === WorkContextType.TAG ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme);

--- a/src/app/features/work-context/work-context.service.spec.ts
+++ b/src/app/features/work-context/work-context.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { resolveContextTheme, WorkContextService } from './work-context.service';
 import { DEFAULT_TAG_COLOR, WORK_CONTEXT_DEFAULT_THEME } from './work-context.const';
-import { DEFAULT_PROJECT } from '../project/project.const';
+import { DEFAULT_PROJECT, INBOX_PROJECT } from '../project/project.const';
 import { TaskWithSubTasks } from '../tasks/task.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
@@ -13,7 +13,7 @@ import { GlobalTrackingIntervalService } from '../../core/global-tracking-interv
 import { DateService } from '../../core/date/date.service';
 import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { TaskArchiveService } from '../archive/task-archive.service';
-import { DEFAULT_TAG, TODAY_TAG } from '../tag/tag.const';
+import { DEFAULT_TAG, IMPORTANT_TAG, TODAY_TAG, URGENT_TAG } from '../tag/tag.const';
 import { WorkContext, WorkContextType } from './work-context.model';
 import {
   selectActiveContextId,
@@ -748,12 +748,15 @@ describe('WorkContextService - isTodayListSignal reactivity', () => {
 });
 
 describe('resolveContextTheme()', () => {
+  // NOTE: a plain USER tag id by default. System entities (TODAY, INBOX, …)
+  // resolve to their own themes, so a system id here would silently stop these
+  // cases from exercising the generic default.
   const buildCtx = (over: Record<string, unknown> = {}): WorkContext =>
     ({
-      id: 'TODAY',
-      title: 'Today',
+      id: 'user-tag-1',
+      title: 'User tag',
       type: WorkContextType.TAG,
-      routerLink: 'tag/TODAY',
+      routerLink: 'tag/user-tag-1',
       taskIds: [],
       noteIds: [],
       color: null,
@@ -770,9 +773,10 @@ describe('resolveContextTheme()', () => {
       const ctx = buildCtx();
       delete (ctx as unknown as Record<string, unknown>).theme;
 
-      // Returns the shared constant by reference — deliberate: both consumers
-      // only read, and a stable identity helps the downstream
-      // distinctUntilChanged. `toBe` pins that decision.
+      // Returns the shared constant by reference. Deliberate, but note the
+      // reason is only that both consumers are read-only — NOT emission
+      // dedup: currentTheme$ uses distinctUntilChanged(isShallowEqual), which
+      // compares key-by-key with no reference short-circuit.
       expect(resolveContextTheme(ctx)).toBe(DEFAULT_TAG.theme);
     });
 
@@ -789,6 +793,39 @@ describe('resolveContextTheme()', () => {
       const ctx = buildCtx({ theme: null });
 
       expect(resolveContextTheme(ctx)).toBe(DEFAULT_TAG.theme);
+    });
+
+    // Regression: the read side was only type-aware while the on-disk heal was
+    // id-aware, so a theme-less TODAY — the active context at startup —
+    // rendered purple/tinted indefinitely (hydration validates but never
+    // repairs) and then flipped once a sync repair landed. Both sides now
+    // resolve through getDefaultWorkContextTheme.
+    //
+    // Table-driven on purpose: asserting the property that makes each row
+    // exist (its theme is DISTINGUISHABLE from the generic default) means a
+    // row that is actually inert fails here rather than sitting unnoticed.
+    (
+      [
+        [TODAY_TAG, true],
+        [URGENT_TAG, true],
+        [IMPORTANT_TAG, true],
+        [INBOX_PROJECT, false],
+      ] as const
+    ).forEach(([entity, isTag]) => {
+      it(`gives ${entity.id} its own theme, not the generic default`, () => {
+        const ctx = buildCtx({
+          id: entity.id,
+          type: isTag ? WorkContextType.TAG : WorkContextType.PROJECT,
+        });
+        delete (ctx as unknown as Record<string, unknown>).theme;
+
+        const res = resolveContextTheme(ctx);
+        const generic = isTag ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme;
+
+        expect(res).toBe(entity.theme);
+        // If this fails the row is inert and should be deleted, not kept.
+        expect(res.primary).not.toBe(generic.primary);
+      });
     });
 
     it('yields a COMPLETE theme when the tag-color fallback applies', () => {

--- a/src/app/features/work-context/work-context.service.spec.ts
+++ b/src/app/features/work-context/work-context.service.spec.ts
@@ -884,11 +884,13 @@ describe('resolveContextTheme()', () => {
       const ctx = buildCtx();
       delete (ctx as unknown as Record<string, unknown>).theme;
 
-      // Returns the shared constant by reference. Deliberate, but note the
-      // reason is only that both consumers are read-only — NOT emission
-      // dedup: currentTheme$ uses distinctUntilChanged(isShallowEqual), which
-      // compares key-by-key with no reference short-circuit.
-      expect(resolveContextTheme(ctx)).toBe(DEFAULT_TAG.theme);
+      expect(resolveContextTheme(ctx)).toEqual(DEFAULT_TAG.theme);
+      // A COPY, never the module constant itself — a consumer mutating what it
+      // was handed would otherwise corrupt DEFAULT_TAG app-wide. Nothing
+      // freezes these constants, so this is the only thing enforcing it.
+      // (Safe for the stream: currentTheme$ dedups with isShallowEqual, which
+      // compares key-by-key and does not short-circuit on reference.)
+      expect(resolveContextTheme(ctx)).not.toBe(DEFAULT_TAG.theme);
     });
 
     it('returns the PROJECT default for a theme-less project', () => {
@@ -897,13 +899,14 @@ describe('resolveContextTheme()', () => {
       const ctx = buildCtx({ type: WorkContextType.PROJECT });
       delete (ctx as unknown as Record<string, unknown>).theme;
 
-      expect(resolveContextTheme(ctx)).toBe(DEFAULT_PROJECT.theme);
+      expect(resolveContextTheme(ctx)).toEqual(DEFAULT_PROJECT.theme);
+      expect(resolveContextTheme(ctx)).not.toBe(DEFAULT_PROJECT.theme);
     });
 
     it('handles an explicit null theme, not just a missing one', () => {
       const ctx = buildCtx({ theme: null });
 
-      expect(resolveContextTheme(ctx)).toBe(DEFAULT_TAG.theme);
+      expect(resolveContextTheme(ctx)).toEqual(DEFAULT_TAG.theme);
     });
 
     // Regression: the read side was only type-aware while the on-disk heal was
@@ -934,7 +937,9 @@ describe('resolveContextTheme()', () => {
         });
         delete (ctx as unknown as Record<string, unknown>).theme;
 
-        expect(resolveContextTheme(ctx)).toBe(theme);
+        expect(resolveContextTheme(ctx)).toEqual(theme);
+        // System themes are module constants too — same aliasing hazard.
+        expect(resolveContextTheme(ctx)).not.toBe(theme);
       });
 
       it(`${entityId} has a theme that renders differently from the generic default`, () => {

--- a/src/app/features/work-context/work-context.service.spec.ts
+++ b/src/app/features/work-context/work-context.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { resolveContextTheme, WorkContextService } from './work-context.service';
 import { DEFAULT_TAG_COLOR, WORK_CONTEXT_DEFAULT_THEME } from './work-context.const';
+import { DEFAULT_PROJECT } from '../project/project.const';
 import { TaskWithSubTasks } from '../tasks/task.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
@@ -12,7 +13,7 @@ import { GlobalTrackingIntervalService } from '../../core/global-tracking-interv
 import { DateService } from '../../core/date/date.service';
 import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { TaskArchiveService } from '../archive/task-archive.service';
-import { TODAY_TAG } from '../tag/tag.const';
+import { DEFAULT_TAG, TODAY_TAG } from '../tag/tag.const';
 import { WorkContext, WorkContextType } from './work-context.model';
 import {
   selectActiveContextId,
@@ -763,25 +764,31 @@ describe('resolveContextTheme()', () => {
   describe('regression #9139: work context persisted with no theme', () => {
     // A tag/project entity stored without `theme` propagated `undefined` into
     // resolveBackground() and _setColorTheme(), crashing on every launch.
-    it('returns the default theme instead of undefined', () => {
+    // The crashing consumers were resolveBackground() (reads backgroundImage*)
+    // and _setColorTheme() (reads isAutoContrast); both need a real object.
+    it('returns the default tag theme instead of undefined', () => {
       const ctx = buildCtx();
       delete (ctx as unknown as Record<string, unknown>).theme;
 
-      expect(resolveContextTheme(ctx)).toEqual(WORK_CONTEXT_DEFAULT_THEME);
+      // Returns the shared constant by reference — deliberate: both consumers
+      // only read, and a stable identity helps the downstream
+      // distinctUntilChanged. `toBe` pins that decision.
+      expect(resolveContextTheme(ctx)).toBe(DEFAULT_TAG.theme);
     });
 
-    it('returns a theme the crashing consumers can dereference', () => {
-      const ctx = buildCtx();
+    it('returns the PROJECT default for a theme-less project', () => {
+      // Must match what auto-fix-typia-errors would later persist, else a
+      // theme-less project renders tag-purple then flips to project-teal.
+      const ctx = buildCtx({ type: WorkContextType.PROJECT });
       delete (ctx as unknown as Record<string, unknown>).theme;
 
-      const res = resolveContextTheme(ctx);
+      expect(resolveContextTheme(ctx)).toBe(DEFAULT_PROJECT.theme);
+    });
 
-      // The exact fields whose unguarded deref produced the reported crashes:
-      // resolveBackground() reads backgroundImage*, _setColorTheme() reads
-      // isAutoContrast.
-      expect(res.backgroundImageDark).toBeDefined();
-      expect(res.backgroundImageLight).toBeDefined();
-      expect(res.isAutoContrast).toBeDefined();
+    it('handles an explicit null theme, not just a missing one', () => {
+      const ctx = buildCtx({ theme: null });
+
+      expect(resolveContextTheme(ctx)).toBe(DEFAULT_TAG.theme);
     });
 
     it('yields a COMPLETE theme when the tag-color fallback applies', () => {

--- a/src/app/features/work-context/work-context.service.spec.ts
+++ b/src/app/features/work-context/work-context.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { WorkContextService } from './work-context.service';
+import { resolveContextTheme, WorkContextService } from './work-context.service';
+import { DEFAULT_TAG_COLOR, WORK_CONTEXT_DEFAULT_THEME } from './work-context.const';
 import { TaskWithSubTasks } from '../tasks/task.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
@@ -742,5 +743,90 @@ describe('WorkContextService - isTodayListSignal reactivity', () => {
     store.refreshState();
 
     expect(service.isTodayListSignal()).toBe(false);
+  });
+});
+
+describe('resolveContextTheme()', () => {
+  const buildCtx = (over: Record<string, unknown> = {}): WorkContext =>
+    ({
+      id: 'TODAY',
+      title: 'Today',
+      type: WorkContextType.TAG,
+      routerLink: 'tag/TODAY',
+      taskIds: [],
+      noteIds: [],
+      color: null,
+      theme: { ...WORK_CONTEXT_DEFAULT_THEME, primary: '#123456' },
+      ...over,
+    }) as unknown as WorkContext;
+
+  describe('regression #9139: work context persisted with no theme', () => {
+    // A tag/project entity stored without `theme` propagated `undefined` into
+    // resolveBackground() and _setColorTheme(), crashing on every launch.
+    it('returns the default theme instead of undefined', () => {
+      const ctx = buildCtx();
+      delete (ctx as unknown as Record<string, unknown>).theme;
+
+      expect(resolveContextTheme(ctx)).toEqual(WORK_CONTEXT_DEFAULT_THEME);
+    });
+
+    it('returns a theme the crashing consumers can dereference', () => {
+      const ctx = buildCtx();
+      delete (ctx as unknown as Record<string, unknown>).theme;
+
+      const res = resolveContextTheme(ctx);
+
+      // The exact fields whose unguarded deref produced the reported crashes:
+      // resolveBackground() reads backgroundImage*, _setColorTheme() reads
+      // isAutoContrast.
+      expect(res.backgroundImageDark).toBeDefined();
+      expect(res.backgroundImageLight).toBeDefined();
+      expect(res.isAutoContrast).toBeDefined();
+    });
+
+    it('yields a COMPLETE theme when the tag-color fallback applies', () => {
+      const ctx = buildCtx({ color: '#abcdef' });
+      delete (ctx as unknown as Record<string, unknown>).theme;
+
+      const res = resolveContextTheme(ctx);
+
+      // Spreading an undefined theme would have produced just `{ primary }`.
+      expect(res.primary).toBe('#abcdef');
+      expect(res.accent).toBe(WORK_CONTEXT_DEFAULT_THEME.accent);
+      expect(res.huePrimary).toBe(WORK_CONTEXT_DEFAULT_THEME.huePrimary);
+    });
+  });
+
+  describe('existing behaviour is preserved', () => {
+    it('keeps an explicit primary override over tag.color', () => {
+      const res = resolveContextTheme(
+        buildCtx({
+          theme: { ...WORK_CONTEXT_DEFAULT_THEME, primary: '#explicit' },
+          color: '#tagcolor',
+        }),
+      );
+      expect(res.primary).toBe('#explicit');
+    });
+
+    it('falls back to tag.color when primary is still the auto-default', () => {
+      const res = resolveContextTheme(
+        buildCtx({
+          theme: { ...WORK_CONTEXT_DEFAULT_THEME, primary: DEFAULT_TAG_COLOR },
+          color: '#tagcolor',
+        }),
+      );
+      expect(res.primary).toBe('#tagcolor');
+    });
+
+    it('does not apply the tag-color fallback for projects', () => {
+      const res = resolveContextTheme(
+        buildCtx({
+          type: WorkContextType.PROJECT,
+          theme: { ...WORK_CONTEXT_DEFAULT_THEME, primary: DEFAULT_TAG_COLOR },
+          color: '#tagcolor',
+        }),
+      );
+      expect(res.primary).toBe(DEFAULT_TAG_COLOR);
+    });
   });
 });

--- a/src/app/features/work-context/work-context.service.spec.ts
+++ b/src/app/features/work-context/work-context.service.spec.ts
@@ -18,7 +18,7 @@ import { GlobalTrackingIntervalService } from '../../core/global-tracking-interv
 import { DateService } from '../../core/date/date.service';
 import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { TaskArchiveService } from '../archive/task-archive.service';
-import { DEFAULT_TAG, TODAY_TAG } from '../tag/tag.const';
+import { DEFAULT_TAG, IMPORTANT_TAG, TODAY_TAG, URGENT_TAG } from '../tag/tag.const';
 import { WorkContext, WorkContextThemeCfg, WorkContextType } from './work-context.model';
 import {
   selectActiveContextId,
@@ -752,6 +752,112 @@ describe('WorkContextService - isTodayListSignal reactivity', () => {
   });
 });
 
+// The #9139 fix lives in `resolveContextTheme`, but `currentTheme$` is the only
+// thing in production that CALLS it — every crashing consumer (resolveBackground,
+// _setColorTheme) reads this stream, not the function. Without this block the
+// whole fix could be reverted at the `map()` and the suite stayed green: the
+// unit tests below pass a themeless context in by hand, so they never observe
+// the wiring. Tests the seam, deliberately, not the logic.
+describe('WorkContextService - currentTheme$ wiring (#9139)', () => {
+  let store: MockStore;
+  let service: WorkContextService;
+
+  // TODAY, with no `theme` at all — the exact entity and shape from the report,
+  // and the active context at startup.
+  const themelessToday = (): WorkContext => {
+    const ctx = {
+      id: TODAY_TAG.id,
+      type: WorkContextType.TAG,
+      title: 'Today',
+      icon: null,
+      routerLink: `tag/${TODAY_TAG.id}`,
+      advancedCfg: {},
+      taskIds: [],
+      backlogTaskIds: [],
+      noteIds: [],
+    } as unknown as WorkContext;
+    // Assert the premise rather than trusting it: if `theme` were somehow
+    // present the test would pass for the wrong reason.
+    expect('theme' in ctx).toBe(false);
+    return ctx;
+  };
+
+  beforeEach(() => {
+    const tagServiceMock = jasmine.createSpyObj('TagService', ['getTagById$']);
+    tagServiceMock.getTagById$.and.returnValue(of(TODAY_TAG));
+
+    const globalTrackingIntervalServiceMock = jasmine.createSpyObj(
+      'GlobalTrackingIntervalService',
+      [],
+      { todayDateStr$: of('2026-04-06') },
+    );
+
+    const dateServiceMock = jasmine.createSpyObj('DateService', ['todayStr']);
+    dateServiceMock.todayStr.and.returnValue('2026-04-06');
+
+    const timeTrackingServiceMock = jasmine.createSpyObj('TimeTrackingService', [
+      'getWorkStartEndForWorkContext$',
+    ]);
+    timeTrackingServiceMock.getWorkStartEndForWorkContext$.and.returnValue(of({}));
+
+    const taskArchiveServiceMock = jasmine.createSpyObj('TaskArchiveService', [
+      'loadYoung',
+    ]);
+    taskArchiveServiceMock.loadYoung.and.returnValue(
+      Promise.resolve({ ids: [], entities: {} }),
+    );
+
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideMockStore({
+          initialState: {
+            workContext: { activeId: TODAY_TAG.id, activeType: 'TAG' },
+            tag: { entities: {}, ids: [] },
+            project: { entities: {}, ids: [] },
+            task: { entities: {}, ids: [] },
+          },
+        }),
+        // activeWorkContext$ is gated behind _afterDataLoadedOnce$, which only
+        // fires after the allDataWasLoaded action.
+        provideMockActions(() => of(allDataWasLoaded())),
+        { provide: Router, useValue: { events: of(), url: '/' } },
+        { provide: TagService, useValue: tagServiceMock },
+        {
+          provide: GlobalTrackingIntervalService,
+          useValue: globalTrackingIntervalServiceMock,
+        },
+        { provide: DateService, useValue: dateServiceMock },
+        { provide: TimeTrackingService, useValue: timeTrackingServiceMock },
+        { provide: TaskArchiveService, useValue: taskArchiveServiceMock },
+        WorkContextService,
+      ],
+    });
+
+    store = TestBed.inject(MockStore);
+    store.overrideSelector(selectActiveWorkContext, themelessToday());
+    store.refreshState();
+
+    service = TestBed.inject(WorkContextService);
+  });
+
+  it('emits a real theme for a themeless active context instead of undefined', () => {
+    const emitted: (WorkContextThemeCfg | undefined)[] = [];
+    const sub = service.currentTheme$.subscribe((v) => emitted.push(v));
+
+    expect(emitted.length).toBe(1);
+    // The crash itself: consumers deref `.backgroundImageDark` / `.isAutoContrast`
+    // on whatever this emits, so `undefined` here IS the bug.
+    expect(emitted[0]).toBeDefined();
+    // TODAY's OWN theme, not the generic tag default — proves the stream routes
+    // through the id-aware fallback and not merely some non-null object.
+    expect(emitted[0]).toEqual(TODAY_TAG.theme);
+    expect(emitted[0]!.primary).not.toBe(DEFAULT_TAG.theme.primary);
+
+    sub.unsubscribe();
+  });
+});
+
 describe('resolveContextTheme()', () => {
   // NOTE: a plain USER tag id by default. System entities (TODAY, INBOX, …)
   // resolve to their own themes, so a system id here would silently stop these
@@ -806,9 +912,18 @@ describe('resolveContextTheme()', () => {
     // repairs) and then flipped once a sync repair landed. Both sides now
     // resolve through getDefaultWorkContextTheme.
     //
-    // Driven from SYSTEM_ENTITY_THEMES itself, NOT a hand-written copy: a
-    // duplicated table only catches rows REMOVED from the Map, never rows
-    // ADDED to it, so an inert row could be introduced and sit unnoticed.
+    // The loop below is driven from SYSTEM_ENTITY_THEMES itself so that a row
+    // ADDED to the Map is automatically covered. The cost is that it is blind in
+    // the other direction: deleting a row deletes its tests too, so they VANISH
+    // (silently, 32 -> 28) rather than fail. This assertion is the other half —
+    // it pins the roster so a removal is loud. Both halves are needed; neither
+    // catches what the other does.
+    it('covers exactly the known system entities', () => {
+      expect([...SYSTEM_ENTITY_THEMES.keys()].sort()).toEqual(
+        [TODAY_TAG.id, URGENT_TAG.id, IMPORTANT_TAG.id, INBOX_PROJECT.id].sort(),
+      );
+    });
+
     [...SYSTEM_ENTITY_THEMES.entries()].forEach(([entityId, theme]) => {
       const isTag = entityId !== INBOX_PROJECT.id;
 

--- a/src/app/features/work-context/work-context.service.spec.ts
+++ b/src/app/features/work-context/work-context.service.spec.ts
@@ -1,7 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { resolveContextTheme, WorkContextService } from './work-context.service';
-import { DEFAULT_TAG_COLOR, WORK_CONTEXT_DEFAULT_THEME } from './work-context.const';
+import { SYSTEM_ENTITY_THEMES } from './work-context-default-theme.util';
+import {
+  DEFAULT_TAG_COLOR,
+  isBackgroundImageSet,
+  WORK_CONTEXT_DEFAULT_THEME,
+} from './work-context.const';
 import { DEFAULT_PROJECT, INBOX_PROJECT } from '../project/project.const';
 import { TaskWithSubTasks } from '../tasks/task.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
@@ -13,8 +18,8 @@ import { GlobalTrackingIntervalService } from '../../core/global-tracking-interv
 import { DateService } from '../../core/date/date.service';
 import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { TaskArchiveService } from '../archive/task-archive.service';
-import { DEFAULT_TAG, IMPORTANT_TAG, TODAY_TAG, URGENT_TAG } from '../tag/tag.const';
-import { WorkContext, WorkContextType } from './work-context.model';
+import { DEFAULT_TAG, TODAY_TAG } from '../tag/tag.const';
+import { WorkContext, WorkContextThemeCfg, WorkContextType } from './work-context.model';
 import {
   selectActiveContextId,
   selectActiveWorkContext,
@@ -801,30 +806,39 @@ describe('resolveContextTheme()', () => {
     // repairs) and then flipped once a sync repair landed. Both sides now
     // resolve through getDefaultWorkContextTheme.
     //
-    // Table-driven on purpose: asserting the property that makes each row
-    // exist (its theme is DISTINGUISHABLE from the generic default) means a
-    // row that is actually inert fails here rather than sitting unnoticed.
-    (
-      [
-        [TODAY_TAG, true],
-        [URGENT_TAG, true],
-        [IMPORTANT_TAG, true],
-        [INBOX_PROJECT, false],
-      ] as const
-    ).forEach(([entity, isTag]) => {
-      it(`gives ${entity.id} its own theme, not the generic default`, () => {
+    // Driven from SYSTEM_ENTITY_THEMES itself, NOT a hand-written copy: a
+    // duplicated table only catches rows REMOVED from the Map, never rows
+    // ADDED to it, so an inert row could be introduced and sit unnoticed.
+    [...SYSTEM_ENTITY_THEMES.entries()].forEach(([entityId, theme]) => {
+      const isTag = entityId !== INBOX_PROJECT.id;
+
+      it(`gives ${entityId} its own theme, not the generic default`, () => {
         const ctx = buildCtx({
-          id: entity.id,
+          id: entityId,
           type: isTag ? WorkContextType.TAG : WorkContextType.PROJECT,
         });
         delete (ctx as unknown as Record<string, unknown>).theme;
 
-        const res = resolveContextTheme(ctx);
-        const generic = isTag ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme;
+        expect(resolveContextTheme(ctx)).toBe(theme);
+      });
 
-        expect(res).toBe(entity.theme);
-        // If this fails the row is inert and should be deleted, not kept.
-        expect(res.primary).not.toBe(generic.primary);
+      it(`${entityId} has a theme that renders differently from the generic default`, () => {
+        const generic = isTag ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme;
+        // OBSERVABLE difference, not raw field inequality: the background-image
+        // fields reach the UI only through isBackgroundImageSet, so '' and null
+        // are the same thing. Comparing raw values would call IN_PROGRESS_TAG
+        // ('' vs null, nothing else) "different" and let an inert row back in.
+        const observable = (t: WorkContextThemeCfg): Record<string, unknown> => ({
+          ...t,
+          backgroundImageDark: isBackgroundImageSet(t.backgroundImageDark),
+          backgroundImageLight: isBackgroundImageSet(t.backgroundImageLight),
+        });
+        const a = observable(generic);
+        const b = observable(theme);
+
+        // If this fails the row is inert and should be DELETED, not kept —
+        // IN_PROGRESS_TAG was removed for exactly this reason.
+        expect(Object.keys({ ...a, ...b }).some((k) => a[k] !== b[k])).toBe(true);
       });
     });
 

--- a/src/app/features/work-context/work-context.service.ts
+++ b/src/app/features/work-context/work-context.service.ts
@@ -28,7 +28,7 @@ import {
 } from 'rxjs/operators';
 import { TODAY_TAG } from '../tag/tag.const';
 import { Tag } from '../tag/tag.model';
-import { DEFAULT_TAG_COLOR } from './work-context.const';
+import { DEFAULT_TAG_COLOR, WORK_CONTEXT_DEFAULT_THEME } from './work-context.const';
 import { TagService } from '../tag/tag.service';
 import { ArchiveTask, Task, TaskWithSubTasks } from '../tasks/task.model';
 import {
@@ -75,6 +75,31 @@ import { selectProjectById } from '../project/store/project.selectors';
 import { Project } from '../project/project.model';
 import { Log } from '../../core/log';
 import { LOCAL_ACTIONS } from '../../util/local-actions.token';
+
+/**
+ * Resolve the theme to apply for a work context.
+ *
+ * `WorkContextCommon.theme` is declared required, but persisted data can lack
+ * it: validation at hydration is non-fatal, so a snapshot holding a theme-less
+ * tag loads anyway and every consumer then dereferences `undefined` (#9139 —
+ * this crashed both `resolveBackground` and `_setColorTheme` on every launch).
+ * Defaulting here gives the theme pipeline a single choke point.
+ */
+export const resolveContextTheme = (awc: WorkContext): WorkContextThemeCfg => {
+  const theme = awc.theme ?? WORK_CONTEXT_DEFAULT_THEME;
+  // For tags: theme.primary is the explicit override. If it's still at
+  // the auto-default (or unset) and tag.color is set, fall back to
+  // tag.color so newly created tags drive Material theming with their
+  // randomized color while still letting users override explicitly.
+  if (awc.type === WorkContextType.TAG) {
+    const tagColor = (awc as unknown as Tag).color;
+    const primary = theme.primary;
+    if (tagColor && (!primary || primary === DEFAULT_TAG_COLOR)) {
+      return { ...theme, primary: tagColor };
+    }
+  }
+  return theme;
+};
 
 @Injectable({
   providedIn: 'root',
@@ -230,20 +255,7 @@ export class WorkContextService {
   );
 
   currentTheme$: Observable<WorkContextThemeCfg> = this.activeWorkContext$.pipe(
-    map((awc) => {
-      // For tags: theme.primary is the explicit override. If it's still at
-      // the auto-default (or unset) and tag.color is set, fall back to
-      // tag.color so newly created tags drive Material theming with their
-      // randomized color while still letting users override explicitly.
-      if (awc.type === WorkContextType.TAG) {
-        const tagColor = (awc as unknown as Tag).color;
-        const primary = awc.theme?.primary;
-        if (tagColor && (!primary || primary === DEFAULT_TAG_COLOR)) {
-          return { ...awc.theme, primary: tagColor };
-        }
-      }
-      return awc.theme;
-    }),
+    map(resolveContextTheme),
     distinctUntilChanged<WorkContextThemeCfg>(isShallowEqual),
   );
 

--- a/src/app/features/work-context/work-context.service.ts
+++ b/src/app/features/work-context/work-context.service.ts
@@ -89,12 +89,14 @@ import { LOCAL_ACTIONS } from '../../util/local-actions.token';
  * work context. It is NOT an app-wide guarantee — code that iterates over all
  * projects/tags reads the raw entity and must still guard `theme?.` itself.
  *
- * The fallback comes from `getDefaultWorkContextTheme`, shared with the on-disk
- * heal, so what is rendered now and what a later repair persists cannot differ.
+ * The FALLBACK comes from `getDefaultWorkContextTheme`, shared with the on-disk
+ * heal, so the theme rendered for a theme-less context and the one a later
+ * repair persists cannot differ. The tag-color override below sits on top and
+ * is read-side only — it is re-applied after any repair, so it does not flip.
  */
 export const resolveContextTheme = (awc: WorkContext): WorkContextThemeCfg => {
   const isTag = awc.type === WorkContextType.TAG;
-  const theme = awc.theme ?? getDefaultWorkContextTheme(isTag, awc.id);
+  const theme = awc.theme ?? getDefaultWorkContextTheme(awc.type, awc.id);
   // For tags: theme.primary is the explicit override. If it's still at
   // the auto-default (or unset) and tag.color is set, fall back to
   // tag.color so newly created tags drive Material theming with their

--- a/src/app/features/work-context/work-context.service.ts
+++ b/src/app/features/work-context/work-context.service.ts
@@ -26,9 +26,10 @@ import {
   take,
   withLatestFrom,
 } from 'rxjs/operators';
-import { DEFAULT_TAG, TODAY_TAG } from '../tag/tag.const';
+import { TODAY_TAG } from '../tag/tag.const';
 import { Tag } from '../tag/tag.model';
 import { DEFAULT_TAG_COLOR } from './work-context.const';
+import { getDefaultWorkContextTheme } from './work-context-default-theme.util';
 import { TagService } from '../tag/tag.service';
 import { ArchiveTask, Task, TaskWithSubTasks } from '../tasks/task.model';
 import {
@@ -70,7 +71,7 @@ import { getTimeSpentForDay } from './get-time-spent-for-day.util';
 import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { updateWorkContextData } from '../time-tracking/store/time-tracking.actions';
 import { TaskArchiveService } from '../archive/task-archive.service';
-import { DEFAULT_PROJECT, INBOX_PROJECT } from '../project/project.const';
+import { INBOX_PROJECT } from '../project/project.const';
 import { selectProjectById } from '../project/store/project.selectors';
 import { Project } from '../project/project.model';
 import { Log } from '../../core/log';
@@ -88,19 +89,17 @@ import { LOCAL_ACTIONS } from '../../util/local-actions.token';
  * work context. It is NOT an app-wide guarantee — code that iterates over all
  * projects/tags reads the raw entity and must still guard `theme?.` itself.
  *
- * The default is type-aware so it matches what `auto-fix-typia-errors` would
- * later persist for the same entity; otherwise a theme-less project rendered
- * tag-purple until a repair ran and then flipped to project-teal.
+ * The fallback comes from `getDefaultWorkContextTheme`, shared with the on-disk
+ * heal, so what is rendered now and what a later repair persists cannot differ.
  */
 export const resolveContextTheme = (awc: WorkContext): WorkContextThemeCfg => {
-  const theme =
-    awc.theme ??
-    (awc.type === WorkContextType.TAG ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme);
+  const isTag = awc.type === WorkContextType.TAG;
+  const theme = awc.theme ?? getDefaultWorkContextTheme(isTag, awc.id);
   // For tags: theme.primary is the explicit override. If it's still at
   // the auto-default (or unset) and tag.color is set, fall back to
   // tag.color so newly created tags drive Material theming with their
   // randomized color while still letting users override explicitly.
-  if (awc.type === WorkContextType.TAG) {
+  if (isTag) {
     const tagColor = (awc as unknown as Tag).color;
     const primary = theme.primary;
     if (tagColor && (!primary || primary === DEFAULT_TAG_COLOR)) {

--- a/src/app/features/work-context/work-context.service.ts
+++ b/src/app/features/work-context/work-context.service.ts
@@ -26,9 +26,9 @@ import {
   take,
   withLatestFrom,
 } from 'rxjs/operators';
-import { TODAY_TAG } from '../tag/tag.const';
+import { DEFAULT_TAG, TODAY_TAG } from '../tag/tag.const';
 import { Tag } from '../tag/tag.model';
-import { DEFAULT_TAG_COLOR, WORK_CONTEXT_DEFAULT_THEME } from './work-context.const';
+import { DEFAULT_TAG_COLOR } from './work-context.const';
 import { TagService } from '../tag/tag.service';
 import { ArchiveTask, Task, TaskWithSubTasks } from '../tasks/task.model';
 import {
@@ -70,7 +70,7 @@ import { getTimeSpentForDay } from './get-time-spent-for-day.util';
 import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { updateWorkContextData } from '../time-tracking/store/time-tracking.actions';
 import { TaskArchiveService } from '../archive/task-archive.service';
-import { INBOX_PROJECT } from '../project/project.const';
+import { DEFAULT_PROJECT, INBOX_PROJECT } from '../project/project.const';
 import { selectProjectById } from '../project/store/project.selectors';
 import { Project } from '../project/project.model';
 import { Log } from '../../core/log';
@@ -83,10 +83,19 @@ import { LOCAL_ACTIONS } from '../../util/local-actions.token';
  * it: validation at hydration is non-fatal, so a snapshot holding a theme-less
  * tag loads anyway and every consumer then dereferences `undefined` (#9139 —
  * this crashed both `resolveBackground` and `_setColorTheme` on every launch).
- * Defaulting here gives the theme pipeline a single choke point.
+ *
+ * Scope: this covers every consumer of `currentTheme$`, i.e. the *active*
+ * work context. It is NOT an app-wide guarantee — code that iterates over all
+ * projects/tags reads the raw entity and must still guard `theme?.` itself.
+ *
+ * The default is type-aware so it matches what `auto-fix-typia-errors` would
+ * later persist for the same entity; otherwise a theme-less project rendered
+ * tag-purple until a repair ran and then flipped to project-teal.
  */
 export const resolveContextTheme = (awc: WorkContext): WorkContextThemeCfg => {
-  const theme = awc.theme ?? WORK_CONTEXT_DEFAULT_THEME;
+  const theme =
+    awc.theme ??
+    (awc.type === WorkContextType.TAG ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme);
   // For tags: theme.primary is the explicit override. If it's still at
   // the auto-default (or unset) and tag.color is set, fall back to
   // tag.color so newly created tags drive Material theming with their

--- a/src/app/features/work-context/work-context.service.ts
+++ b/src/app/features/work-context/work-context.service.ts
@@ -96,7 +96,15 @@ import { LOCAL_ACTIONS } from '../../util/local-actions.token';
  */
 export const resolveContextTheme = (awc: WorkContext): WorkContextThemeCfg => {
   const isTag = awc.type === WorkContextType.TAG;
-  const theme = awc.theme ?? getDefaultWorkContextTheme(awc.type, awc.id);
+  // COPY the fallback, never hand out the module constant itself: a consumer
+  // that mutated what this returns would write straight through into
+  // DEFAULT_TAG / TODAY_TAG for the whole app, and those are plain object
+  // literals with nothing freezing them. The on-disk heal already spreads for
+  // the same reason; keeping only one side aliased is the asymmetry that turns
+  // into a bug the first time someone writes to a theme they were handed.
+  // Cheap: `distinctUntilChanged(isShallowEqual)` on currentTheme$ compares
+  // key-by-key, so a fresh object per emission causes no extra emissions.
+  const theme = awc.theme ?? { ...getDefaultWorkContextTheme(awc.type, awc.id) };
   // For tags: theme.primary is the explicit override. If it's still at
   // the auto-default (or unset) and tag.color is set, fall back to
   // tag.color so newly created tags drive Material theming with their

--- a/src/app/op-log/core/recreate-fallback.const.ts
+++ b/src/app/op-log/core/recreate-fallback.const.ts
@@ -19,9 +19,11 @@ import { EMPTY_SIMPLE_COUNTER } from '../../features/simple-counter/simple-count
  *   `requiredKeys`.
  * - `requiredKeys` drives only (a) the meta-reducer's diagnostic warn (which
  *   missing schema-required fields to name in the log) and (b) the per-type
- *   on-disk heal branch in `auto-fix-typia-errors.ts`. Only TASK and
- *   SIMPLE_COUNTER have such a branch today; PROJECT/TAG rely on the generic
- *   recreate backfill alone, so their `requiredKeys` feed only the warn.
+ *   on-disk heal branch in `auto-fix-typia-errors.ts`. TASK and SIMPLE_COUNTER
+ *   have a `requiredKeys`-driven branch. TAG/PROJECT have a narrower one
+ *   covering `theme` only (#9139), which reads its defaults directly rather
+ *   than through this table, so for them `requiredKeys` still feeds only the
+ *   warn — `theme` is listed below so the warn names it.
  *   List the schema-required fields that are NOT already coerced by an
  *   earlier generic branch in `autoFixTypiaErrors` (booleans → false,
  *   nullable → null) — mirroring TASK's curated list.
@@ -73,8 +75,8 @@ export const RECREATE_FALLBACK: Partial<Record<EntityType, RecreateFallback>> = 
       'projectId',
     ],
   },
-  PROJECT: { defaults: DEFAULT_PROJECT, requiredKeys: ['title', 'taskIds'] },
-  TAG: { defaults: DEFAULT_TAG, requiredKeys: ['title', 'taskIds'] },
+  PROJECT: { defaults: DEFAULT_PROJECT, requiredKeys: ['title', 'taskIds', 'theme'] },
+  TAG: { defaults: DEFAULT_TAG, requiredKeys: ['title', 'taskIds', 'theme'] },
   SIMPLE_COUNTER: {
     defaults: EMPTY_SIMPLE_COUNTER,
     // Curated like TASK: omit `icon` (nullable, healed by the undefined→null

--- a/src/app/op-log/core/recreate-fallback.const.ts
+++ b/src/app/op-log/core/recreate-fallback.const.ts
@@ -23,6 +23,12 @@ import { EMPTY_SIMPLE_COUNTER } from '../../features/simple-counter/simple-count
  *   SIMPLE_COUNTER have a `requiredKeys`-driven branch; TAG/PROJECT have a
  *   `theme`-specific one (#9139) that reads its defaults directly, not through
  *   this table, so their `requiredKeys` feed only the warn.
+ *   `theme` is listed for TAG/PROJECT deliberately: the warn is gated on
+ *   `partialKeys.length > 0`, so omitting it would silence the diagnostic
+ *   ENTIRELY for a payload carrying title+taskIds but no theme — which is
+ *   exactly the #9139 corruption shape, on the one writer that still bypasses
+ *   `getDefaultWorkContextTheme`. With provenance still unknown, that is the
+ *   last signal that this path touched a themeless entity; do not remove it.
  *   List the schema-required fields that are NOT already coerced by an
  *   earlier generic branch in `autoFixTypiaErrors` (booleans → false,
  *   nullable → null) — mirroring TASK's curated list.
@@ -74,8 +80,8 @@ export const RECREATE_FALLBACK: Partial<Record<EntityType, RecreateFallback>> = 
       'projectId',
     ],
   },
-  PROJECT: { defaults: DEFAULT_PROJECT, requiredKeys: ['title', 'taskIds'] },
-  TAG: { defaults: DEFAULT_TAG, requiredKeys: ['title', 'taskIds'] },
+  PROJECT: { defaults: DEFAULT_PROJECT, requiredKeys: ['title', 'taskIds', 'theme'] },
+  TAG: { defaults: DEFAULT_TAG, requiredKeys: ['title', 'taskIds', 'theme'] },
   SIMPLE_COUNTER: {
     defaults: EMPTY_SIMPLE_COUNTER,
     // Curated like TASK: omit `icon` (nullable, healed by the undefined→null

--- a/src/app/op-log/core/recreate-fallback.const.ts
+++ b/src/app/op-log/core/recreate-fallback.const.ts
@@ -19,11 +19,10 @@ import { EMPTY_SIMPLE_COUNTER } from '../../features/simple-counter/simple-count
  *   `requiredKeys`.
  * - `requiredKeys` drives only (a) the meta-reducer's diagnostic warn (which
  *   missing schema-required fields to name in the log) and (b) the per-type
- *   on-disk heal branch in `auto-fix-typia-errors.ts`. TASK and SIMPLE_COUNTER
- *   have a `requiredKeys`-driven branch. TAG/PROJECT have a narrower one
- *   covering `theme` only (#9139), which reads its defaults directly rather
- *   than through this table, so for them `requiredKeys` still feeds only the
- *   warn — `theme` is listed below so the warn names it.
+ *   on-disk heal branch in `auto-fix-typia-errors.ts`. Only TASK and
+ *   SIMPLE_COUNTER have a `requiredKeys`-driven branch; TAG/PROJECT have a
+ *   `theme`-specific one (#9139) that reads its defaults directly, not through
+ *   this table, so their `requiredKeys` feed only the warn.
  *   List the schema-required fields that are NOT already coerced by an
  *   earlier generic branch in `autoFixTypiaErrors` (booleans → false,
  *   nullable → null) — mirroring TASK's curated list.
@@ -75,8 +74,8 @@ export const RECREATE_FALLBACK: Partial<Record<EntityType, RecreateFallback>> = 
       'projectId',
     ],
   },
-  PROJECT: { defaults: DEFAULT_PROJECT, requiredKeys: ['title', 'taskIds', 'theme'] },
-  TAG: { defaults: DEFAULT_TAG, requiredKeys: ['title', 'taskIds', 'theme'] },
+  PROJECT: { defaults: DEFAULT_PROJECT, requiredKeys: ['title', 'taskIds'] },
+  TAG: { defaults: DEFAULT_TAG, requiredKeys: ['title', 'taskIds'] },
   SIMPLE_COUNTER: {
     defaults: EMPTY_SIMPLE_COUNTER,
     // Curated like TASK: omit `icon` (nullable, healed by the undefined→null

--- a/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
@@ -4,8 +4,8 @@ import type { IValidation } from 'typia';
 import { initialTaskState } from '../../features/tasks/store/task.reducer';
 import { DEFAULT_TASK } from '../../features/tasks/task.model';
 import { OP_LOG_SYNC_LOGGER } from '../core/sync-logger.adapter';
-import { DEFAULT_TAG } from '../../features/tag/tag.const';
-import { DEFAULT_PROJECT } from '../../features/project/project.const';
+import { DEFAULT_TAG, TODAY_TAG } from '../../features/tag/tag.const';
+import { DEFAULT_PROJECT, INBOX_PROJECT } from '../../features/project/project.const';
 
 const createTypiaError = (
   path: string,
@@ -493,16 +493,26 @@ describe('autoFixTypiaErrors', () => {
     it('should backfill a missing tag.theme with the default tag theme', () => {
       const mockData = createAppDataCompleteMock();
       (mockData as any).tag = {
-        ids: ['TODAY'],
-        entities: { TODAY: { id: 'TODAY', title: 'Today', taskIds: [] } },
+        ids: ['t1', 't2'],
+        entities: {
+          t1: { id: 't1', title: 'User tag', taskIds: [] },
+          t2: { id: 't2', title: 'Other', taskIds: [] },
+        },
       };
       const errors = [
-        createTypiaError('$input.tag.entities.TODAY.theme', REAL_EXPECTED, undefined),
+        createTypiaError('$input.tag.entities.t1.theme', REAL_EXPECTED, undefined),
+        createTypiaError('$input.tag.entities.t2.theme', REAL_EXPECTED, undefined),
       ];
 
       const result = autoFixTypiaErrors(mockData, errors);
 
-      expect((result as any).tag.entities.TODAY.theme).toEqual(DEFAULT_TAG.theme);
+      const a = (result as any).tag.entities.t1.theme;
+      const b = (result as any).tag.entities.t2.theme;
+      expect(a).toEqual(DEFAULT_TAG.theme);
+      // Backfill a COPY: aliasing the constant across entities would let any
+      // later mutation write through into DEFAULT_TAG for the whole app.
+      expect(a).not.toBe(DEFAULT_TAG.theme);
+      expect(a).not.toBe(b);
       expect(errSpy).toHaveBeenCalledWith(
         '[auto-fix-typia-errors] Applied validation auto-fix',
         undefined,
@@ -535,12 +545,12 @@ describe('autoFixTypiaErrors', () => {
       // not change the outcome.
       const mockData = createAppDataCompleteMock();
       (mockData as any).tag = {
-        ids: ['TODAY'],
-        entities: { TODAY: { id: 'TODAY', title: 'Today', taskIds: [] } },
+        ids: ['t1'],
+        entities: { t1: { id: 't1', title: 'User tag', taskIds: [] } },
       };
       const errors = [
         createTypiaError(
-          '$input.tag.entities.TODAY.theme',
+          '$input.tag.entities.t1.theme',
           'Readonly<__type>.o99999',
           undefined,
         ),
@@ -548,54 +558,94 @@ describe('autoFixTypiaErrors', () => {
 
       const result = autoFixTypiaErrors(mockData, errors);
 
-      expect((result as any).tag.entities.TODAY.theme).toEqual(DEFAULT_TAG.theme);
+      expect((result as any).tag.entities.t1.theme).toEqual(DEFAULT_TAG.theme);
     });
 
-    it('should backfill a COPY, never the shared default constant', () => {
-      // Aliasing DEFAULT_TAG.theme across entities would let any later
-      // mutation write through into the app-wide constant.
+    it('should repair an explicit null theme, not just a missing one', () => {
+      // The `setOne` 'replace' branch applies a remote entity verbatim, so
+      // `theme: null` is reachable and typia reports it at the same path with
+      // `value: null`. Gating on `undefined` alone left this dead-ending the
+      // repair pipeline ("state still invalid after repair").
       const mockData = createAppDataCompleteMock();
       (mockData as any).tag = {
-        ids: ['TODAY', 't2'],
-        entities: {
-          TODAY: { id: 'TODAY', title: 'Today', taskIds: [] },
-          t2: { id: 't2', title: 'Other', taskIds: [] },
-        },
+        ids: ['t1'],
+        entities: { t1: { id: 't1', title: 'Other', taskIds: [], theme: null } },
+      };
+      const errors = [
+        createTypiaError('$input.tag.entities.t1.theme', REAL_EXPECTED, null),
+      ];
+
+      const result = autoFixTypiaErrors(mockData, errors);
+
+      expect((result as any).tag.entities.t1.theme).toEqual(DEFAULT_TAG.theme);
+    });
+
+    it('should restore the TODAY tag its own theme, not the generic tag default', () => {
+      // TODAY is the entity from the #9139 report and ships a distinct theme.
+      // The repair is written to disk, so a generic default would permanently
+      // restyle it (cornflower + tint-disabled -> purple + tint-enabled).
+      const mockData = createAppDataCompleteMock();
+      (mockData as any).tag = {
+        ids: ['TODAY'],
+        entities: { TODAY: { id: 'TODAY', title: 'Today', taskIds: [] } },
       };
       const errors = [
         createTypiaError('$input.tag.entities.TODAY.theme', REAL_EXPECTED, undefined),
-        createTypiaError('$input.tag.entities.t2.theme', REAL_EXPECTED, undefined),
       ];
 
       const result = autoFixTypiaErrors(mockData, errors);
 
-      const a = (result as any).tag.entities.TODAY.theme;
-      const b = (result as any).tag.entities.t2.theme;
-      expect(a).not.toBe(DEFAULT_TAG.theme);
-      expect(b).not.toBe(DEFAULT_TAG.theme);
-      expect(a).not.toBe(b);
-      expect(a).toEqual(DEFAULT_TAG.theme);
+      const healed = (result as any).tag.entities.TODAY.theme;
+      expect(healed).toEqual(TODAY_TAG.theme);
+      expect(healed.primary).toBe(TODAY_TAG.theme.primary);
+      expect(healed.isDisableBackgroundTint).toBe(true);
+      expect(healed.huePrimary).toBe('400');
+      // Guards the regression this test was written for.
+      expect(healed.primary).not.toBe(DEFAULT_TAG.theme.primary);
     });
 
-    it('should NOT overwrite a theme that is present but merely invalid', () => {
-      // `value === undefined` scopes this to a genuinely absent field; a
-      // present-but-wrong theme is a different problem and must not be
-      // silently replaced (that would discard user styling).
+    it('should restore the INBOX project its own theme', () => {
       const mockData = createAppDataCompleteMock();
-      const existingTheme = { primary: '#user-picked' };
-      (mockData as any).tag = {
-        ids: ['TODAY'],
+      (mockData as any).project = {
+        ids: [INBOX_PROJECT.id],
         entities: {
-          TODAY: { id: 'TODAY', title: 'Today', taskIds: [], theme: existingTheme },
+          [INBOX_PROJECT.id]: { id: INBOX_PROJECT.id, title: 'Inbox', taskIds: [] },
         },
       };
       const errors = [
-        createTypiaError('$input.tag.entities.TODAY.theme', REAL_EXPECTED, existingTheme),
+        createTypiaError(
+          `$input.project.entities.${INBOX_PROJECT.id}.theme`,
+          REAL_EXPECTED,
+          undefined,
+        ),
       ];
 
       const result = autoFixTypiaErrors(mockData, errors);
 
-      expect((result as any).tag.entities.TODAY.theme).toEqual(existingTheme);
+      const healed = (result as any).project.entities[INBOX_PROJECT.id].theme;
+      expect(healed).toEqual(INBOX_PROJECT.theme);
+      expect(healed.primary).not.toBe(DEFAULT_PROJECT.theme.primary);
+    });
+
+    it('should not treat a hostile "__proto__" entity id as a system theme', () => {
+      // The system-theme lookup is a Map precisely so this returns undefined
+      // rather than Object.prototype.
+      const mockData = createAppDataCompleteMock();
+      (mockData as any).tag = {
+        ids: ['t1'],
+        entities: { t1: { id: 't1', title: 'x', taskIds: [] } },
+      };
+      const errors = [
+        createTypiaError('$input.tag.entities.t1.theme', REAL_EXPECTED, undefined),
+      ];
+
+      const result = autoFixTypiaErrors(mockData, errors);
+
+      expect((result as any).tag.entities.t1.theme).toEqual(DEFAULT_TAG.theme);
+      expect(
+        (result as any).tag.entities.t1.theme instanceof Object &&
+          Object.getPrototypeOf((result as any).tag.entities.t1.theme),
+      ).toBe(Object.prototype);
     });
   });
 });

--- a/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
@@ -640,10 +640,17 @@ describe('autoFixTypiaErrors', () => {
       // Object.prototype here, which is non-nullish, so the `??` would not fall
       // through and the entity would be healed to an empty theme.
       const mockData = createAppDataCompleteMock();
-      const entities: Record<string, unknown> = {};
-      // Computed key => a genuine OWN property named __proto__, not a set prototype.
-      entities['__proto__'] = { id: '__proto__', title: 'x', taskIds: [] };
-      (mockData as any).tag = { ids: ['__proto__'], entities };
+      // Built via JSON.parse because that is what a hostile payload actually
+      // arrives as, and it is the ONLY construction that yields a genuine own
+      // "__proto__" key. `obj['__proto__'] = x` invokes the inherited setter
+      // and sets the prototype instead, creating no own property.
+      const tagState = JSON.parse(
+        '{"ids":["__proto__"],"entities":{"__proto__":{"id":"__proto__","title":"x","taskIds":[]}}}',
+      );
+      expect(Object.prototype.hasOwnProperty.call(tagState.entities, '__proto__')).toBe(
+        true,
+      );
+      (mockData as any).tag = tagState;
       const errors = [
         createTypiaError('$input.tag.entities.__proto__.theme', REAL_EXPECTED, undefined),
       ];

--- a/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
@@ -578,6 +578,14 @@ describe('autoFixTypiaErrors', () => {
       const result = autoFixTypiaErrors(mockData, errors);
 
       expect((result as any).tag.entities.t1.theme).toEqual(DEFAULT_TAG.theme);
+      // Pins the branch's POSITION in the else-if chain: one of the earlier
+      // `expected.includes('null'|'undefined')` branches swallowing this error
+      // would still leave state changed, but under a different fix label.
+      expect(errSpy).toHaveBeenCalledWith(
+        '[auto-fix-typia-errors] Applied validation auto-fix',
+        undefined,
+        jasmine.objectContaining({ fix: 'work-context-theme-undefined-to-default' }),
+      );
     });
 
     it('should restore the TODAY tag its own theme, not the generic tag default', () => {
@@ -627,25 +635,22 @@ describe('autoFixTypiaErrors', () => {
       expect(healed.primary).not.toBe(DEFAULT_PROJECT.theme.primary);
     });
 
-    it('should not treat a hostile "__proto__" entity id as a system theme', () => {
-      // The system-theme lookup is a Map precisely so this returns undefined
-      // rather than Object.prototype.
+    it('should not resolve a hostile "__proto__" entity id to a system theme', () => {
+      // The lookup is a Map for exactly this: an object literal would return
+      // Object.prototype here, which is non-nullish, so the `??` would not fall
+      // through and the entity would be healed to an empty theme.
       const mockData = createAppDataCompleteMock();
-      (mockData as any).tag = {
-        ids: ['t1'],
-        entities: { t1: { id: 't1', title: 'x', taskIds: [] } },
-      };
+      const entities: Record<string, unknown> = {};
+      // Computed key => a genuine OWN property named __proto__, not a set prototype.
+      entities['__proto__'] = { id: '__proto__', title: 'x', taskIds: [] };
+      (mockData as any).tag = { ids: ['__proto__'], entities };
       const errors = [
-        createTypiaError('$input.tag.entities.t1.theme', REAL_EXPECTED, undefined),
+        createTypiaError('$input.tag.entities.__proto__.theme', REAL_EXPECTED, undefined),
       ];
 
       const result = autoFixTypiaErrors(mockData, errors);
 
-      expect((result as any).tag.entities.t1.theme).toEqual(DEFAULT_TAG.theme);
-      expect(
-        (result as any).tag.entities.t1.theme instanceof Object &&
-          Object.getPrototypeOf((result as any).tag.entities.t1.theme),
-      ).toBe(Object.prototype);
+      expect((result as any).tag.entities['__proto__'].theme).toEqual(DEFAULT_TAG.theme);
     });
   });
 });

--- a/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
@@ -1,5 +1,7 @@
 import { autoFixTypiaErrors } from './auto-fix-typia-errors';
 import { createAppDataCompleteMock } from '../../util/app-data-mock';
+import { validateAllData } from './validation-fn';
+import type { AppDataComplete } from '../model/model-config';
 import type { IValidation } from 'typia';
 import { initialTaskState } from '../../features/tasks/store/task.reducer';
 import { DEFAULT_TASK } from '../../features/tasks/task.model';
@@ -659,5 +661,125 @@ describe('autoFixTypiaErrors', () => {
 
       expect((result as any).tag.entities['__proto__'].theme).toEqual(DEFAULT_TAG.theme);
     });
+  });
+});
+
+// Every test above hand-builds its typia errors, so all of them would still
+// pass if REAL typia reported a themeless entity somewhere else entirely and
+// the fix's branch never fired on real data. That is not hypothetical here:
+// #9045 shipped a check that was fully tested and never once ran in
+// production. These tests close that loop by driving the actual validator.
+describe('autoFixTypiaErrors — against REAL typia validation (#9139)', () => {
+  beforeEach(() => {
+    spyOn(OP_LOG_SYNC_LOGGER, 'err').and.stub();
+    spyOn(OP_LOG_SYNC_LOGGER, 'warn').and.stub();
+  });
+
+  // A tag/project that is valid in every respect except what each test does to
+  // `theme`, so nothing unrelated pollutes the error list.
+  const buildTag = (mutate: (t: Record<string, unknown>) => void): AppDataComplete => {
+    const d = createAppDataCompleteMock() as unknown as Record<string, unknown>;
+    const tag = {
+      ...DEFAULT_TAG,
+      id: 't1',
+      title: 'Probe',
+      created: Date.now(),
+    } as unknown as Record<string, unknown>;
+    mutate(tag);
+    d.tag = { ids: ['t1'], entities: { t1: tag } };
+    return d as unknown as AppDataComplete;
+  };
+
+  const buildProject = (
+    mutate: (p: Record<string, unknown>) => void,
+  ): AppDataComplete => {
+    const d = createAppDataCompleteMock() as unknown as Record<string, unknown>;
+    const project = { ...DEFAULT_PROJECT, id: 'p1', title: 'Probe' } as unknown as Record<
+      string,
+      unknown
+    >;
+    mutate(project);
+    d.project = { ids: ['p1'], entities: { p1: project } };
+    return d as unknown as AppDataComplete;
+  };
+
+  const errorsOf = (d: AppDataComplete): IValidation.IError[] => {
+    const res = validateAllData(d) as { success: boolean; errors?: IValidation.IError[] };
+    return res.errors ?? [];
+  };
+  const isValid = (d: AppDataComplete): boolean =>
+    (validateAllData(d) as { success: boolean }).success;
+
+  it('the unmodified mock is fully valid, so any error below is caused by the test', () => {
+    // Without this the round-trips further down could pass or fail for reasons
+    // that have nothing to do with `theme`.
+    expect(isValid(createAppDataCompleteMock())).toBe(true);
+  });
+
+  (
+    [
+      ['tag', (): AppDataComplete => buildTag((t) => delete t.theme), 't1'],
+      ['project', (): AppDataComplete => buildProject((p) => delete p.theme), 'p1'],
+    ] as const
+  ).forEach(([root, build, entityId]) => {
+    it(`real typia reports a missing ${root} theme at the exact path the fix matches`, () => {
+      const errors = errorsOf(build());
+
+      // The branch keys on: keys[0] in {tag,project}, keys[1] === 'entities',
+      // keys.length === 4, keys[3] === 'theme'. If typia ever reported this
+      // per-member (deeper) or on the entity (shallower), the fix would go
+      // silently dead — so pin the shape, not just "some error exists".
+      expect(errors.length).toBe(1);
+      expect(errors[0].path).toBe(`$input.${root}.entities.${entityId}.theme`);
+      expect(errors[0].path.split('.').length - 1).toBe(4);
+      expect(errors[0].value).toBeUndefined();
+    });
+
+    it(`repairing the real errors makes the ${root} data validate clean`, () => {
+      const data = build();
+      expect(isValid(data)).toBe(false);
+
+      const repaired = autoFixTypiaErrors(data, errorsOf(data)) as AppDataComplete;
+
+      // The round trip is the point: the fix does not merely write *a* value,
+      // it writes one the validator accepts.
+      expect(isValid(repaired)).toBe(true);
+    });
+  });
+
+  it('real typia reports an explicit null theme at the same path', () => {
+    // Justifies the `value == null` gate rather than `=== undefined`: null is
+    // reachable via the setOne 'replace' branch and reported identically.
+    const errors = errorsOf(buildTag((t) => (t.theme = null)));
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].path).toBe('$input.tag.entities.t1.theme');
+    expect(errors[0].value).toBeNull();
+  });
+
+  // KNOWN GAP (#9156), pinned deliberately as characterization, NOT approval.
+  //
+  // Every member of WorkContextThemeCfg is optional; only `theme` itself is
+  // required. So typia accepts `{}` and even a theme missing `primary` — no
+  // error is produced, which means the heal above can never see them and the
+  // read-side `??` never fires either (both are nullish-gated).
+  //
+  // This is why an empty theme is STICKIER than a missing one: a missing theme
+  // self-heals on the next validation pass, `{}` is invisible to validation
+  // forever. The settings dialog persists exactly `{}` (see #9156).
+  //
+  // When #9156 is fixed these expectations SHOULD flip — that is the signal,
+  // not a regression.
+  it('DOCUMENTS #9156: an empty or partial theme is invisible to validation', () => {
+    expect(isValid(buildTag((t) => (t.theme = {})))).toBe(true);
+    expect(
+      isValid(
+        buildTag((t) => {
+          const theme = { ...DEFAULT_TAG.theme } as Record<string, unknown>;
+          delete theme.primary;
+          t.theme = theme;
+        }),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.spec.ts
@@ -4,6 +4,8 @@ import type { IValidation } from 'typia';
 import { initialTaskState } from '../../features/tasks/store/task.reducer';
 import { DEFAULT_TASK } from '../../features/tasks/task.model';
 import { OP_LOG_SYNC_LOGGER } from '../core/sync-logger.adapter';
+import { DEFAULT_TAG } from '../../features/tag/tag.const';
+import { DEFAULT_PROJECT } from '../../features/project/project.const';
 
 const createTypiaError = (
   path: string,
@@ -478,6 +480,122 @@ describe('autoFixTypiaErrors', () => {
           pathRoot: 'tag',
         }),
       );
+    });
+  });
+
+  describe('issue #9139 — tag/project entities missing `theme` entirely', () => {
+    // The `expected` string typia ACTUALLY emits for this error, captured by
+    // running the real validator. It is a generated anonymous type name whose
+    // ordinal suffix moves whenever the type graph changes — which is exactly
+    // why the fix must not key on it. See the no-longer-brittle test below.
+    const REAL_EXPECTED = 'Readonly<__type>.o26';
+
+    it('should backfill a missing tag.theme with the default tag theme', () => {
+      const mockData = createAppDataCompleteMock();
+      (mockData as any).tag = {
+        ids: ['TODAY'],
+        entities: { TODAY: { id: 'TODAY', title: 'Today', taskIds: [] } },
+      };
+      const errors = [
+        createTypiaError('$input.tag.entities.TODAY.theme', REAL_EXPECTED, undefined),
+      ];
+
+      const result = autoFixTypiaErrors(mockData, errors);
+
+      expect((result as any).tag.entities.TODAY.theme).toEqual(DEFAULT_TAG.theme);
+      expect(errSpy).toHaveBeenCalledWith(
+        '[auto-fix-typia-errors] Applied validation auto-fix',
+        undefined,
+        jasmine.objectContaining({
+          fix: 'work-context-theme-undefined-to-default',
+          pathRoot: 'tag',
+        }),
+      );
+    });
+
+    it('should backfill a missing project.theme with the default project theme', () => {
+      const mockData = createAppDataCompleteMock();
+      (mockData as any).project = {
+        ids: ['p1'],
+        entities: { p1: { id: 'p1', title: 'Proj', taskIds: [] } },
+      };
+      const errors = [
+        createTypiaError('$input.project.entities.p1.theme', REAL_EXPECTED, undefined),
+      ];
+
+      const result = autoFixTypiaErrors(mockData, errors);
+
+      expect((result as any).project.entities.p1.theme).toEqual(DEFAULT_PROJECT.theme);
+    });
+
+    it('should still fire when typia renames the generated `expected` type', () => {
+      // Guards the #9045 failure mode: a branch keyed on `error.expected`
+      // would silently stop firing the moment the ordinal shifts. This fix
+      // matches on path + `value === undefined` only, so a renamed type must
+      // not change the outcome.
+      const mockData = createAppDataCompleteMock();
+      (mockData as any).tag = {
+        ids: ['TODAY'],
+        entities: { TODAY: { id: 'TODAY', title: 'Today', taskIds: [] } },
+      };
+      const errors = [
+        createTypiaError(
+          '$input.tag.entities.TODAY.theme',
+          'Readonly<__type>.o99999',
+          undefined,
+        ),
+      ];
+
+      const result = autoFixTypiaErrors(mockData, errors);
+
+      expect((result as any).tag.entities.TODAY.theme).toEqual(DEFAULT_TAG.theme);
+    });
+
+    it('should backfill a COPY, never the shared default constant', () => {
+      // Aliasing DEFAULT_TAG.theme across entities would let any later
+      // mutation write through into the app-wide constant.
+      const mockData = createAppDataCompleteMock();
+      (mockData as any).tag = {
+        ids: ['TODAY', 't2'],
+        entities: {
+          TODAY: { id: 'TODAY', title: 'Today', taskIds: [] },
+          t2: { id: 't2', title: 'Other', taskIds: [] },
+        },
+      };
+      const errors = [
+        createTypiaError('$input.tag.entities.TODAY.theme', REAL_EXPECTED, undefined),
+        createTypiaError('$input.tag.entities.t2.theme', REAL_EXPECTED, undefined),
+      ];
+
+      const result = autoFixTypiaErrors(mockData, errors);
+
+      const a = (result as any).tag.entities.TODAY.theme;
+      const b = (result as any).tag.entities.t2.theme;
+      expect(a).not.toBe(DEFAULT_TAG.theme);
+      expect(b).not.toBe(DEFAULT_TAG.theme);
+      expect(a).not.toBe(b);
+      expect(a).toEqual(DEFAULT_TAG.theme);
+    });
+
+    it('should NOT overwrite a theme that is present but merely invalid', () => {
+      // `value === undefined` scopes this to a genuinely absent field; a
+      // present-but-wrong theme is a different problem and must not be
+      // silently replaced (that would discard user styling).
+      const mockData = createAppDataCompleteMock();
+      const existingTheme = { primary: '#user-picked' };
+      (mockData as any).tag = {
+        ids: ['TODAY'],
+        entities: {
+          TODAY: { id: 'TODAY', title: 'Today', taskIds: [], theme: existingTheme },
+        },
+      };
+      const errors = [
+        createTypiaError('$input.tag.entities.TODAY.theme', REAL_EXPECTED, existingTheme),
+      ];
+
+      const result = autoFixTypiaErrors(mockData, errors);
+
+      expect((result as any).tag.entities.TODAY.theme).toEqual(existingTheme);
     });
   });
 });

--- a/src/app/op-log/validation/auto-fix-typia-errors.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.ts
@@ -4,6 +4,7 @@ import type { SyncLogMeta } from '@sp/sync-core';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 import { INBOX_PROJECT } from '../../features/project/project.const';
 import { getDefaultWorkContextTheme } from '../../features/work-context/work-context-default-theme.util';
+import { WorkContextType } from '../../features/work-context/work-context.model';
 import { RECREATE_FALLBACK } from '../core/recreate-fallback.const';
 import { OP_LOG_SYNC_LOGGER } from '../core/sync-logger.adapter';
 import { devError } from '../../util/dev-error';
@@ -294,7 +295,10 @@ export const autoFixTypiaErrors = (
         // whenever the type graph changes. Keying on it would make this branch
         // silently stop firing. Path + nullish value is stable.
         const theme = {
-          ...getDefaultWorkContextTheme(keys[0] === 'tag', String(keys[2])),
+          ...getDefaultWorkContextTheme(
+            keys[0] === 'tag' ? WorkContextType.TAG : WorkContextType.PROJECT,
+            String(keys[2]),
+          ),
         };
         setValueByPath(data, keys, theme);
         logAutoFixApplied(

--- a/src/app/op-log/validation/auto-fix-typia-errors.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.ts
@@ -2,7 +2,8 @@ import { AppDataComplete } from '../model/model-config';
 import { IValidation } from 'typia';
 import type { SyncLogMeta } from '@sp/sync-core';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
-import { INBOX_PROJECT } from '../../features/project/project.const';
+import { DEFAULT_PROJECT, INBOX_PROJECT } from '../../features/project/project.const';
+import { DEFAULT_TAG } from '../../features/tag/tag.const';
 import { RECREATE_FALLBACK } from '../core/recreate-fallback.const';
 import { OP_LOG_SYNC_LOGGER } from '../core/sync-logger.adapter';
 import { devError } from '../../util/dev-error';
@@ -271,6 +272,36 @@ export const autoFixTypiaErrors = (
         const created = Date.now();
         setValueByPath(data, keys, created);
         logAutoFixApplied(path, keys, 'tag-created-undefined-to-now', value, created);
+      } else if (
+        (keys[0] === 'tag' || keys[0] === 'project') &&
+        keys[1] === 'entities' &&
+        keys.length === 4 &&
+        keys[3] === 'theme' &&
+        value === undefined
+      ) {
+        // A tag/project entity can be persisted with no `theme` at all (#9139).
+        // Left unrepaired it either dead-ends legacy migration ("Migration
+        // failed") or, on the hydration paths where validation is non-fatal,
+        // loads and crashes the theme pipeline on every launch.
+        //
+        // Deliberately NOT matched on `error.expected`: typia reports this as
+        // the generated name `Readonly<__type>.oNN`, whose ordinal shifts
+        // whenever the type graph changes. Keying on it would make this branch
+        // silently stop firing. Path + `value === undefined` is stable.
+        // Copy, never share the constant by reference: two theme-less entities
+        // would otherwise alias one object, and any later mutation would write
+        // straight through into DEFAULT_TAG/DEFAULT_PROJECT for the whole app.
+        const theme = {
+          ...(keys[0] === 'tag' ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme),
+        };
+        setValueByPath(data, keys, theme);
+        logAutoFixApplied(
+          path,
+          keys,
+          'work-context-theme-undefined-to-default',
+          value,
+          theme,
+        );
       } else if (
         keys[0] === 'metric' &&
         keys[1] === 'entities' &&

--- a/src/app/op-log/validation/auto-fix-typia-errors.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.ts
@@ -2,45 +2,13 @@ import { AppDataComplete } from '../model/model-config';
 import { IValidation } from 'typia';
 import type { SyncLogMeta } from '@sp/sync-core';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
-import { DEFAULT_PROJECT, INBOX_PROJECT } from '../../features/project/project.const';
-import {
-  DEFAULT_TAG,
-  IMPORTANT_TAG,
-  IN_PROGRESS_TAG,
-  TODAY_TAG,
-  URGENT_TAG,
-} from '../../features/tag/tag.const';
-import { WorkContextThemeCfg } from '../../features/work-context/work-context.model';
+import { INBOX_PROJECT } from '../../features/project/project.const';
+import { getDefaultWorkContextTheme } from '../../features/work-context/work-context-default-theme.util';
 import { RECREATE_FALLBACK } from '../core/recreate-fallback.const';
 import { OP_LOG_SYNC_LOGGER } from '../core/sync-logger.adapter';
 import { devError } from '../../util/dev-error';
 
 const LOG_PREFIX = '[auto-fix-typia-errors]';
-
-/**
- * System tags/projects ship a *distinct* theme, so healing them from the
- * generic default would silently restyle them — and because the repair is
- * written to disk, permanently. TODAY in particular is the entity from the
- * #9139 report: it is cornflower with `huePrimary: '400'` and background tint
- * disabled, where DEFAULT_TAG is purple with tint on.
- *
- * A Map, not an object literal: a hostile entity id of `__proto__` would hit
- * `Object.prototype` on a plain-object lookup and be treated as a theme.
- */
-const SYSTEM_ENTITY_THEMES: ReadonlyMap<string, WorkContextThemeCfg> = new Map([
-  [TODAY_TAG.id, TODAY_TAG.theme],
-  [URGENT_TAG.id, URGENT_TAG.theme],
-  [IMPORTANT_TAG.id, IMPORTANT_TAG.theme],
-  [IN_PROGRESS_TAG.id, IN_PROGRESS_TAG.theme],
-  [INBOX_PROJECT.id, INBOX_PROJECT.theme],
-]);
-
-const getWorkContextDefaultTheme = (
-  pathRoot: string | number,
-  entityId: string | number,
-): WorkContextThemeCfg =>
-  SYSTEM_ENTITY_THEMES.get(String(entityId)) ??
-  (pathRoot === 'tag' ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme);
 
 const getValueType = (value: unknown): string => {
   if (value === null) return 'null';
@@ -325,7 +293,9 @@ export const autoFixTypiaErrors = (
         // the generated name `Readonly<__type>.oNN`, whose ordinal shifts
         // whenever the type graph changes. Keying on it would make this branch
         // silently stop firing. Path + nullish value is stable.
-        const theme = { ...getWorkContextDefaultTheme(keys[0], keys[2]) };
+        const theme = {
+          ...getDefaultWorkContextTheme(keys[0] === 'tag', String(keys[2])),
+        };
         setValueByPath(data, keys, theme);
         logAutoFixApplied(
           path,

--- a/src/app/op-log/validation/auto-fix-typia-errors.ts
+++ b/src/app/op-log/validation/auto-fix-typia-errors.ts
@@ -3,12 +3,44 @@ import { IValidation } from 'typia';
 import type { SyncLogMeta } from '@sp/sync-core';
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 import { DEFAULT_PROJECT, INBOX_PROJECT } from '../../features/project/project.const';
-import { DEFAULT_TAG } from '../../features/tag/tag.const';
+import {
+  DEFAULT_TAG,
+  IMPORTANT_TAG,
+  IN_PROGRESS_TAG,
+  TODAY_TAG,
+  URGENT_TAG,
+} from '../../features/tag/tag.const';
+import { WorkContextThemeCfg } from '../../features/work-context/work-context.model';
 import { RECREATE_FALLBACK } from '../core/recreate-fallback.const';
 import { OP_LOG_SYNC_LOGGER } from '../core/sync-logger.adapter';
 import { devError } from '../../util/dev-error';
 
 const LOG_PREFIX = '[auto-fix-typia-errors]';
+
+/**
+ * System tags/projects ship a *distinct* theme, so healing them from the
+ * generic default would silently restyle them — and because the repair is
+ * written to disk, permanently. TODAY in particular is the entity from the
+ * #9139 report: it is cornflower with `huePrimary: '400'` and background tint
+ * disabled, where DEFAULT_TAG is purple with tint on.
+ *
+ * A Map, not an object literal: a hostile entity id of `__proto__` would hit
+ * `Object.prototype` on a plain-object lookup and be treated as a theme.
+ */
+const SYSTEM_ENTITY_THEMES: ReadonlyMap<string, WorkContextThemeCfg> = new Map([
+  [TODAY_TAG.id, TODAY_TAG.theme],
+  [URGENT_TAG.id, URGENT_TAG.theme],
+  [IMPORTANT_TAG.id, IMPORTANT_TAG.theme],
+  [IN_PROGRESS_TAG.id, IN_PROGRESS_TAG.theme],
+  [INBOX_PROJECT.id, INBOX_PROJECT.theme],
+]);
+
+const getWorkContextDefaultTheme = (
+  pathRoot: string | number,
+  entityId: string | number,
+): WorkContextThemeCfg =>
+  SYSTEM_ENTITY_THEMES.get(String(entityId)) ??
+  (pathRoot === 'tag' ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme);
 
 const getValueType = (value: unknown): string => {
   if (value === null) return 'null';
@@ -277,23 +309,23 @@ export const autoFixTypiaErrors = (
         keys[1] === 'entities' &&
         keys.length === 4 &&
         keys[3] === 'theme' &&
-        value === undefined
+        value == null
       ) {
         // A tag/project entity can be persisted with no `theme` at all (#9139).
         // Left unrepaired it either dead-ends legacy migration ("Migration
         // failed") or, on the hydration paths where validation is non-fatal,
         // loads and crashes the theme pipeline on every launch.
         //
+        // `== null` covers both undefined and an explicit null: the `setOne`
+        // 'replace' branch (lww-update.meta-reducer.ts) applies a remote entity
+        // verbatim, so a null theme is reachable, and typia reports it at this
+        // same path. Gating on `undefined` alone left it dead-ending migration.
+        //
         // Deliberately NOT matched on `error.expected`: typia reports this as
         // the generated name `Readonly<__type>.oNN`, whose ordinal shifts
         // whenever the type graph changes. Keying on it would make this branch
-        // silently stop firing. Path + `value === undefined` is stable.
-        // Copy, never share the constant by reference: two theme-less entities
-        // would otherwise alias one object, and any later mutation would write
-        // straight through into DEFAULT_TAG/DEFAULT_PROJECT for the whole app.
-        const theme = {
-          ...(keys[0] === 'tag' ? DEFAULT_TAG.theme : DEFAULT_PROJECT.theme),
-        };
+        // silently stop firing. Path + nullish value is stable.
+        const theme = { ...getWorkContextDefaultTheme(keys[0], keys[2]) };
         setValueByPath(data, keys, theme);
         logAutoFixApplied(
           path,

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -953,34 +953,45 @@ describe('lwwUpdateMetaReducer', () => {
       expect(recreated.taskIds).toEqual([]);
     });
 
-    it('warns when a recreate payload is missing ONLY `theme` (#9139)', () => {
-      // Pins `theme` in RECREATE_FALLBACK.TAG.requiredKeys. That entry looks
-      // removable — it drives no backfill, since `defaults` is spread wholesale
-      // — but the warn is gated on `partialKeys.length > 0`, so dropping it
-      // silences the diagnostic ENTIRELY for a payload carrying title+taskIds
-      // and no theme. That is exactly the #9139 corruption shape, on the one
-      // writer that still bypasses getDefaultWorkContextTheme, and provenance
-      // is still unknown — so this is the last signal that path ran.
-      const warnSpy = spyOn(OpLog, 'warn').and.stub();
-      const state = createMockState();
-      const action = {
-        type: '[TAG] LWW Update',
-        id: 'themeless-tag',
-        title: 'Themeless Tag',
-        taskIds: [],
-        meta: {
-          isPersistent: true,
-          entityType: 'TAG',
-          entityId: 'themeless-tag',
-        },
-      };
+    // Pins `theme` in RECREATE_FALLBACK.{TAG,PROJECT}.requiredKeys. Those
+    // entries look removable — they drive no backfill, since `defaults` is
+    // spread wholesale — but the warn is gated on `partialKeys.length > 0`, so
+    // dropping one silences the diagnostic ENTIRELY for a payload carrying
+    // title+taskIds and no theme. That is exactly the #9139 corruption shape,
+    // on the one writer that still bypasses getDefaultWorkContextTheme, and
+    // provenance is still unknown — so this is the last signal that path ran.
+    //
+    // Runs for BOTH types on purpose: covering only TAG left PROJECT's entry
+    // dead (dropping it passed 133/133), i.e. a diagnostic that could be lost
+    // without a single test going red.
+    (
+      [
+        ['TAG', 'themeless-tag', 'Themeless Tag'],
+        ['PROJECT', 'themeless-project', 'Themeless Project'],
+      ] as const
+    ).forEach(([entityType, entityId, title]) => {
+      it(`warns when a recreate payload for ${entityType} is missing ONLY \`theme\` (#9139)`, () => {
+        const warnSpy = spyOn(OpLog, 'warn').and.stub();
+        const state = createMockState();
+        const action = {
+          type: `[${entityType}] LWW Update`,
+          id: entityId,
+          title,
+          taskIds: [],
+          meta: {
+            isPersistent: true,
+            entityType,
+            entityId,
+          },
+        };
 
-      reducer(state, action);
+        reducer(state, action);
 
-      expect(warnSpy).toHaveBeenCalled();
-      const warned = warnSpy.calls.allArgs().flat().join(' ');
-      expect(warned).toContain('missing required');
-      expect(warned).toContain('theme');
+        expect(warnSpy).toHaveBeenCalled();
+        const warned = warnSpy.calls.allArgs().flat().join(' ');
+        expect(warned).toContain('missing required');
+        expect(warned).toContain('theme');
+      });
     });
   });
 

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -952,6 +952,36 @@ describe('lwwUpdateMetaReducer', () => {
       // Backfilled from DEFAULT_TAG
       expect(recreated.taskIds).toEqual([]);
     });
+
+    it('warns when a recreate payload is missing ONLY `theme` (#9139)', () => {
+      // Pins `theme` in RECREATE_FALLBACK.TAG.requiredKeys. That entry looks
+      // removable — it drives no backfill, since `defaults` is spread wholesale
+      // — but the warn is gated on `partialKeys.length > 0`, so dropping it
+      // silences the diagnostic ENTIRELY for a payload carrying title+taskIds
+      // and no theme. That is exactly the #9139 corruption shape, on the one
+      // writer that still bypasses getDefaultWorkContextTheme, and provenance
+      // is still unknown — so this is the last signal that path ran.
+      const warnSpy = spyOn(OpLog, 'warn').and.stub();
+      const state = createMockState();
+      const action = {
+        type: '[TAG] LWW Update',
+        id: 'themeless-tag',
+        title: 'Themeless Tag',
+        taskIds: [],
+        meta: {
+          isPersistent: true,
+          entityType: 'TAG',
+          entityId: 'themeless-tag',
+        },
+      };
+
+      reducer(state, action);
+
+      expect(warnSpy).toHaveBeenCalled();
+      const warned = warnSpy.calls.allArgs().flat().join(' ');
+      expect(warned).toContain('missing required');
+      expect(warned).toContain('theme');
+    });
   });
 
   // Issue #7330 recurred on SIMPLE_COUNTER (ruckusvol's logs, both clients


### PR DESCRIPTION
Fixes #9139

## The crash

A tag/project entity can reach the store with **no `theme` at all**. `WorkContextCommon.theme` is declared required, but validation at hydration is non-fatal — a snapshot holding a theme-less tag loads anyway, and every consumer then dereferences `undefined`:

```
backgroundImageDark (global-theme.service.ts:129)
resolveBackground   (global-theme.service.ts:234)
```

The reported entity is **TODAY**, which is the active work context at startup — so this crashes the app on *every launch*, not just on some navigation. Reported on 18.14.0 (Electron/Linux).

## The fix

Four writers/readers touch a work-context theme. Three now share one source of truth, `getDefaultWorkContextTheme(type, entityId)`:

| Site | Change |
| --- | --- |
| `resolveContextTheme` (read side, `currentTheme$`) | extracted from the inline `map()`, now falls back instead of passing `undefined` through |
| `autoFixTypiaErrors` (on-disk heal) | new branch backfills a nullish `theme` |
| `getProjectVisibilityIconColor` + `note.component.html` | `theme?.primary` — these iterate *all* projects, so `currentTheme$` never covers them |

The read side and the heal **must not diverge**: hydration validates without repairing, so a local-only user can render the read-side value for many sessions before a repair ever runs. If the two disagreed, a theme-less context would render one color and then silently flip once a sync repair landed.

`getDefaultWorkContextTheme` is **id-aware, not just type-aware**. System entities (TODAY, URGENT, IMPORTANT, INBOX) ship distinct themes, so healing TODAY to the generic tag default would permanently restyle it (cornflower + tint-disabled → purple + tint-enabled) — and the heal is written to disk. The lookup is a `Map` rather than an object literal because an entity id of `__proto__` resolves to `Object.prototype` on a plain-object lookup, which is non-nullish and would defeat the `??` fall-through.

## Deliberate non-changes

- **`lwwUpdateMetaReducer`'s recreate branch is a fourth writer and is NOT routed through the shared helper.** It spreads `RECREATE_FALLBACK[type].defaults`, which is id-blind, so a system entity recreated from a partial LWW update still gets the generic theme persisted. It needs a delete-vs-update race on a system entity to hit, and that file is sync-critical — it deserves its own change with its own convergence analysis. Documented as a KNOWN RESIDUAL in the helper.
- **`theme` added to `RECREATE_FALLBACK.{TAG,PROJECT}.requiredKeys`** even though it drives no backfill there. The diagnostic warn is gated on `partialKeys.length > 0`, so omitting it would silence the warn *entirely* for a payload carrying `title`+`taskIds` but no theme — exactly the #9139 corruption shape, on the one writer that still bypasses the shared helper. **Provenance of the corruption is still unknown**, so this is the last signal that path touched a theme-less entity.
- **`IN_PROGRESS_TAG` is absent from `SYSTEM_ENTITY_THEMES`.** Its theme differs from `DEFAULT_TAG`'s only in `backgroundImageDark` (`''` vs `null`), and `isBackgroundImageSet` treats both as unset — the row could not change any rendered output, so it would be inert. A test enforces that every row in the map *is* observably different, so an inert row can't be added back unnoticed.

## Sync-correctness notes

- No schema bump, no new op semantics, no wire-format change. The heal is a client-local repair of already-invalid data.
- The heal is **idempotent and convergent**: the value written depends only on `(entityType, entityId)`, both of which are stable, so two clients repairing the same theme-less entity independently write byte-identical themes. No new conflict surface.
- The read-side tag-color override sits *on top of* the fallback and is read-side only, so it is re-applied after any repair and does not flip.

## Tests

31 assertions added across 4 spec files. Notable:

- The heal branch matches on **path + nullish value only, never `error.expected`** — typia reports this as the generated name `Readonly<__type>.oNN`, whose ordinal shifts whenever the type graph changes. A test asserts the fix still fires under a renamed type, guarding the #9045 failure mode (a check that shipped and never fired).
- The `null`-theme case is covered separately from `undefined`: the `setOne` `'replace'` branch applies a remote entity verbatim, so `theme: null` is reachable, and gating on `undefined` alone dead-ended the repair pipeline ("state still invalid after repair").
- The system-entity cases are **driven from `SYSTEM_ENTITY_THEMES` itself**, not a hand-written copy — a duplicated table only catches rows *removed* from the map, never rows *added* to it.
- The `__proto__` fixture is built via `JSON.parse`, the only construction that yields a genuine own `__proto__` key (`obj['__proto__'] = x` invokes the inherited setter and sets the prototype instead, creating no own property).

All green: `work-context.service.spec.ts` 32/32, `auto-fix-typia-errors.spec.ts` 24/24, `lww-update.meta-reducer.spec.ts` 133/133.

## Known gap

The **root cause — how an entity loses its `theme` in the first place — is still unknown.** This PR stops the crash and heals the data; it does not close the hole that produces it. The `requiredKeys` warn above is the deliberate breadcrumb for that follow-up.
