### PR TITLE
fix(scheduled-list): parse 'Last' repeat date as local day to fix off-by-one (#9127)

### DIFF
--- a/src/app/pages/scheduled-list-page/get-repeat-cfg-tooltip-text.util.spec.ts
+++ b/src/app/pages/scheduled-list-page/get-repeat-cfg-tooltip-text.util.spec.ts
@@ -1,0 +1,127 @@
+import { getRepeatCfgTooltipText } from './get-repeat-cfg-tooltip-text.util';
+import { DateTimeLocales } from '../../core/locale.constants';
+
+describe('getRepeatCfgTooltipText', () => {
+  // A stable local-noon timestamp for the 'Next' value so its rendered date
+  // does not cross a day boundary under any test timezone.
+  const nextTs = new Date(2025, 7, 15, 12, 0, 0).getTime(); // 2025-08-15, local
+
+  describe("'Last' date timezone handling (#9127)", () => {
+    it('renders the effective-last day string as its own calendar day, not the UTC-parsed previous day', () => {
+      // Regression: the old `new Date('2025-08-01')` parses as UTC midnight and
+      // formatMonthDay renders it in local time, so users west of UTC see
+      // "7/31". The util parses the string as a local day, so it stays "8/1".
+      // The repo's `test:tz:la` job runs this under America/Los_Angeles.
+      const result = getRepeatCfgTooltipText(
+        nextTs,
+        '2025-08-01',
+        DateTimeLocales.en_us,
+        'Next',
+        'Last',
+      );
+
+      expect(result).toBe('Next 8/15, Last 8/1');
+      expect(result).not.toContain('7/31');
+    });
+
+    it('does not drift across a month boundary', () => {
+      const result = getRepeatCfgTooltipText(
+        null,
+        '2025-12-31',
+        DateTimeLocales.en_us,
+        'Next',
+        'Last',
+      );
+
+      expect(result).toContain('Last 12/31');
+      expect(result).not.toContain('12/30');
+    });
+
+    it('does not drift across a year boundary', () => {
+      const result = getRepeatCfgTooltipText(
+        null,
+        '2026-01-01',
+        DateTimeLocales.en_us,
+        'Next',
+        'Last',
+      );
+
+      expect(result).toContain('Last 1/1');
+      expect(result).not.toContain('12/31');
+    });
+  });
+
+  describe('locale ordering', () => {
+    it('renders month-first for en-US', () => {
+      const result = getRepeatCfgTooltipText(
+        null,
+        '2025-08-01',
+        DateTimeLocales.en_us,
+        'Next',
+        'Last',
+      );
+      expect(result).toContain('Last 8/1');
+    });
+
+    it('renders day-first for en-GB', () => {
+      const result = getRepeatCfgTooltipText(
+        null,
+        '2025-08-01',
+        DateTimeLocales.en_gb,
+        'Next',
+        'Last',
+      );
+      expect(result).toContain('Last 1/8');
+    });
+
+    it('renders day-first for de-DE', () => {
+      const result = getRepeatCfgTooltipText(
+        null,
+        '2025-08-01',
+        DateTimeLocales.de_de,
+        'Next',
+        'Last',
+      );
+      expect(result).toContain('Last 1.8');
+    });
+  });
+
+  describe('missing values', () => {
+    it('yields an empty last segment (no "Invalid Date") when the last day is undefined', () => {
+      const result = getRepeatCfgTooltipText(
+        nextTs,
+        undefined,
+        DateTimeLocales.en_us,
+        'Next',
+        'Last',
+      );
+
+      expect(result).toBe('Next 8/15, Last ');
+      expect(result).not.toContain('Invalid');
+    });
+
+    it('yields an empty next segment when the next timestamp is null', () => {
+      const result = getRepeatCfgTooltipText(
+        null,
+        '2025-08-01',
+        DateTimeLocales.en_us,
+        'Next',
+        'Last',
+      );
+
+      expect(result).toBe('Next , Last 8/1');
+    });
+
+    it('still renders both labels when both values are missing', () => {
+      const result = getRepeatCfgTooltipText(
+        null,
+        undefined,
+        DateTimeLocales.en_us,
+        'Next',
+        'Last',
+      );
+
+      expect(result).toBe('Next , Last ');
+    });
+  });
+});

--- a/src/app/pages/scheduled-list-page/get-repeat-cfg-tooltip-text.util.ts
+++ b/src/app/pages/scheduled-list-page/get-repeat-cfg-tooltip-text.util.ts
@@ -1,0 +1,45 @@
+import { DateTimeLocale } from '../../core/locale.constants';
+import { formatMonthDay } from '../../util/format-month-day.util';
+import { dateStrToUtcDate } from '../../util/date-str-to-utc-date';
+
+/**
+ * Builds the "Next <date>, Last <date>" tooltip text for an "Every x days"
+ * repeat entry on the scheduled/upcoming list.
+ *
+ * Pure so it can be unit-tested without a component TestBed. The caller passes
+ * the already-computed next-occurrence timestamp, the effective last-creation
+ * day string, the locale, and the two already-translated labels.
+ *
+ * @param nextOccurrenceTimestamp Epoch ms of the next occurrence, or null/0 when
+ *   there is none. Rendered from a real timestamp, so it needs no tz handling.
+ * @param effectiveLastDay The effective last-creation day as a `YYYY-MM-DD`
+ *   string, or undefined when the repeat has never produced a task.
+ * @param locale The active date-time locale.
+ * @param nextLabel Translated label for the next occurrence (e.g. "Next").
+ * @param lastLabel Translated label for the last occurrence (e.g. "Last").
+ */
+export const getRepeatCfgTooltipText = (
+  nextOccurrenceTimestamp: number | null,
+  effectiveLastDay: string | undefined,
+  locale: DateTimeLocale,
+  nextLabel: string,
+  lastLabel: string,
+): string => {
+  const nextFormatted = nextOccurrenceTimestamp
+    ? formatMonthDay(new Date(nextOccurrenceTimestamp), locale)
+    : '';
+
+  // Parse the `YYYY-MM-DD` day string as a LOCAL start-of-day date.
+  // `new Date('2025-08-01')` parses a date-only string as UTC midnight, which
+  // formatMonthDay then renders in the system timezone — for any user west of
+  // UTC that instant falls on the previous local day, so "8/1" renders as
+  // "7/31" (the reported, persistent off-by-one). dateStrToUtcDate builds a
+  // local-midnight Date, matching how the rest of the app reads date strings.
+  // The 'Next' value is unaffected because it comes from a real epoch
+  // timestamp, not a date string. (#9127)
+  const lastFormatted = effectiveLastDay
+    ? formatMonthDay(dateStrToUtcDate(effectiveLastDay), locale)
+    : '';
+
+  return `${nextLabel} ${nextFormatted}, ${lastLabel} ${lastFormatted}`;
+};

--- a/src/app/pages/scheduled-list-page/scheduled-list-page.component.ts
+++ b/src/app/pages/scheduled-list-page/scheduled-list-page.component.ts
@@ -34,7 +34,7 @@ import { getNextRepeatOccurrence } from '../../features/task-repeat-cfg/store/ge
 import { getEffectiveLastTaskCreationDay } from '../../features/task-repeat-cfg/store/get-effective-last-task-creation-day.util';
 import { ShortTimePipe } from '../../ui/pipes/short-time.pipe';
 import { MatTooltip } from '@angular/material/tooltip';
-import { formatMonthDay } from '../../util/format-month-day.util';
+import { getRepeatCfgTooltipText } from './get-repeat-cfg-tooltip-text.util';
 
 @Component({
   selector: 'scheduled-list-page',
@@ -138,17 +138,12 @@ export class ScheduledListPageComponent {
   }
 
   getTooltipText(repeatCfg: TaskRepeatCfg): string {
-    const locale = this._dateTimeFormatService.currentLocale();
-    const nextDate = this.getNextOccurrence(repeatCfg);
-    const nextFormatted = nextDate ? formatMonthDay(new Date(nextDate), locale) : '';
-    const effectiveLastDay = getEffectiveLastTaskCreationDay(repeatCfg);
-    const lastFormatted = effectiveLastDay
-      ? formatMonthDay(new Date(effectiveLastDay), locale)
-      : '';
-
-    const next = this._translateService.instant(T.SCHEDULE.NEXT);
-    const last = this._translateService.instant(T.SCHEDULE.LAST);
-
-    return `${next} ${nextFormatted}, ${last} ${lastFormatted}`;
+    return getRepeatCfgTooltipText(
+      this.getNextOccurrence(repeatCfg),
+      getEffectiveLastTaskCreationDay(repeatCfg),
+      this._dateTimeFormatService.currentLocale(),
+      this._translateService.instant(T.SCHEDULE.NEXT),
+      this._translateService.instant(T.SCHEDULE.LAST),
+    );
   }
 }


### PR DESCRIPTION
## Problem

Fixes #9127.

On the Upcoming/Scheduled list, hovering an "Every x days" repeat shows a tooltip whose **'Last'** date is consistently off by one day for some users (the reporter is on v18.14.0; the error persists across restarts).

`ScheduledListPageComponent.getTooltipText()` rendered the 'Last' value from `getEffectiveLastTaskCreationDay(repeatCfg)`, which returns a `YYYY-MM-DD` string, via `formatMonthDay(new Date(effectiveLastDay), locale)`. `new Date('2025-08-01')` parses a **date-only** string as **UTC midnight**, while `formatMonthDay` → `Intl.DateTimeFormat` renders in the **system timezone**. For any user west of UTC (e.g. `America/Los_Angeles`), UTC-midnight falls on the previous local day, so "8/1" renders as "7/31". The 'Next' value is unaffected because it comes from a real epoch timestamp, not a date string.

Standalone repro of the exact date logic (`Intl` month/day numeric):

```
TZ=America/Los_Angeles   new Date('2025-08-01') -> "7/31"   dateStrToUtcDate('2025-08-01') -> "8/1"
                         new Date('2026-01-01') -> "12/31"  dateStrToUtcDate('2026-01-01') -> "1/1"
TZ=Europe/Berlin / UTC   both -> "8/1" / "1/1"   (east-of-UTC and UTC do not drift)
```

## Solution

Parse the day string with the codebase's canonical `dateStrToUtcDate` helper (`src/app/util/date-str-to-utc-date.ts`), which builds a **local start-of-day** `Date` and is already used elsewhere for exactly this. The rendered calendar day then matches the input string in every timezone.

To make the fix unit-testable without a heavy component TestBed, the tooltip-formatting logic is extracted into a pure `get-repeat-cfg-tooltip-text.util.ts` (takes the already-computed next timestamp, the effective-last-day string, the locale, and the two already-translated labels; formats `next` from the timestamp unchanged and `last` via `dateStrToUtcDate`), and `getTooltipText()` delegates to it. Output shape, labels, and empty-segment handling for `undefined`/`null` inputs are preserved.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki — not applicable (no documented behavior change).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files — the full Angular toolchain was not available in my environment; CI runs prettier/lint. The changes follow the surrounding 2-space/prettier style.
- [x] I have added tests for my changes (if applicable) — added `get-repeat-cfg-tooltip-text.util.spec.ts` covering the tz off-by-one (fails under `TZ=America/Los_Angeles` with the old `new Date(str)` path, which the repo's `test:tz:la` job exercises), month/year-boundary strings, locale ordering (en-US / en-GB / de-DE), and missing-value handling. The exact date logic was also verified with a standalone Node repro (above).
- [ ] Existing tests still pass — not run locally (toolchain unavailable); validated by CI.
- [x] My commit messages follow the Angular format (`type(scope): description`)
