### PR TITLE
fix(mobile): keep backlog add button round

### DIFF
--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
@@ -96,6 +96,8 @@
     }
 
     &.smaller {
+      flex-basis: var(--bottom-nav-height);
+      width: var(--bottom-nav-height);
       height: var(--bottom-nav-height);
       margin-left: var(--s);
       margin-right: var(--s);


### PR DESCRIPTION
## Problem

When project backlog is enabled, the mobile add-task FAB uses the compact height (`var(--bottom-nav-height)`, currently `44px`) but retains the normal `56px` flex basis and width, rendering it as an oval.

Fixes #8647.

## Solution

Set the compact FAB's flex basis and width to the same `--bottom-nav-height` token already used for its height. This keeps the button square as the layout tokens evolve and avoids restoring the old hardcoded `40px` value.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (not applicable to this two-property layout fix)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Validation

Validation on the rebased `master` head:

- `npm run checkFile src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss`
- full pre-push lint, including SCSS lint, lint-rule specs, and theme-asset tests
- main browser suite: 13,411 passed, 2 skipped
- Los Angeles timezone suite: 13,397 passed, 16 skipped

## AI assistance

AI-assisted coding tools were used to help inspect the upstream conflict and validate the updated flex behavior. I reviewed the final two-line SCSS diff against the current layout tokens and ran the repository-required checks above.
