### PR TITLE
fix(planner): keep lazy-loaded dates consecutive

### DIFF
--- a/src/app/features/planner/planner.component.spec.ts
+++ b/src/app/features/planner/planner.component.spec.ts
@@ -6,6 +6,7 @@ import { BehaviorSubject } from 'rxjs';
 import { DateService } from '../../core/date/date.service';
 import { LayoutService } from '../../core-ui/layout/layout.service';
 import { selectTaskFeatureState } from '../tasks/store/task.selectors';
+import { selectPlannerDayMap } from './store/planner.selectors';
 import { signal } from '@angular/core';
 import { PlannerDay } from './planner.model';
 
@@ -60,6 +61,10 @@ describe('PlannerComponent', () => {
             {
               selector: selectTaskFeatureState,
               value: { ids: ['task-1', 'task-2'], entities: {} },
+            },
+            {
+              selector: selectPlannerDayMap,
+              value: {},
             },
           ],
         }),
@@ -149,6 +154,24 @@ describe('PlannerComponent', () => {
       const result = component.daysWithTasks();
 
       expect(result.size).toBe(0);
+    });
+
+    it('should include persisted task dates outside the loaded render window', () => {
+      const outOfWindowDay = '2026-02-26';
+      days$.next([
+        makePlannerDay('2026-02-16', 0),
+        makePlannerDay('2026-02-17', 0),
+        makePlannerDay('2026-02-18', 0),
+        makePlannerDay('2026-02-19', 0),
+        makePlannerDay('2026-02-20', 0),
+      ]);
+      TestBed.inject(MockStore).overrideSelector(selectPlannerDayMap, {
+        [outOfWindowDay]: makePlannerDay(outOfWindowDay, 1).tasks,
+      });
+      TestBed.inject(MockStore).refreshState();
+      fixture.detectChanges();
+
+      expect(component.daysWithTasks().has(outOfWindowDay)).toBeTrue();
     });
   });
 });

--- a/src/app/features/planner/planner.component.ts
+++ b/src/app/features/planner/planner.component.ts
@@ -11,6 +11,7 @@ import { CdkScrollable } from '@angular/cdk/scrolling';
 import { PlannerCalendarNavComponent } from './planner-calendar-nav/planner-calendar-nav.component';
 import { PlannerService } from './planner.service';
 import { LayoutService } from '../../core-ui/layout/layout.service';
+import { selectPlannerDayMap } from './store/planner.selectors';
 
 @Component({
   selector: 'planner',
@@ -33,22 +34,31 @@ export class PlannerComponent {
   readonly T = T;
 
   private _days = toSignal(this._plannerService.days$, { initialValue: [] });
+  private _plannerDayMap = toSignal(this._store.select(selectPlannerDayMap), {
+    initialValue: {},
+  });
   private _prevDaysWithTasksKey = '';
   private _prevDaysWithTasks: ReadonlySet<string> = new Set();
   daysWithTasks = computed<ReadonlySet<string>>(() => {
     const days = this._days();
-    const dayDates: string[] = [];
+    const plannerDayMap = this._plannerDayMap();
+    const dayDates = new Set(
+      Object.entries(plannerDayMap)
+        .filter(([, tasks]) => tasks.length > 0)
+        .map(([dayDate]) => dayDate),
+    );
     for (const day of days) {
       if (day.tasks.length > 0) {
-        dayDates.push(day.dayDate);
+        dayDates.add(day.dayDate);
       }
     }
-    const key = dayDates.join(',');
+    const sortedDayDates = [...dayDates].sort();
+    const key = sortedDayDates.join(',');
     if (key === this._prevDaysWithTasksKey) {
       return this._prevDaysWithTasks;
     }
     this._prevDaysWithTasksKey = key;
-    this._prevDaysWithTasks = new Set(dayDates);
+    this._prevDaysWithTasks = new Set(sortedDayDates);
     return this._prevDaysWithTasks;
   });
 

--- a/src/app/features/planner/planner.service.spec.ts
+++ b/src/app/features/planner/planner.service.spec.ts
@@ -126,6 +126,7 @@ describe('PlannerService', () => {
 
   afterEach(() => {
     jasmine.clock().uninstall();
+    TestBed.inject(MockStore).resetSelectors();
   });
 
   describe('tomorrow$', () => {

--- a/src/app/features/planner/planner.service.spec.ts
+++ b/src/app/features/planner/planner.service.spec.ts
@@ -1,18 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 import { PlannerService } from './planner.service';
 import { DateService } from '../../core/date/date.service';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of, BehaviorSubject, ReplaySubject } from 'rxjs';
 import { CalendarIntegrationService } from '../calendar-integration/calendar-integration.service';
 import { GlobalTrackingIntervalService } from '../../core/global-tracking-interval/global-tracking-interval.service';
-import { selectAllTasksWithDueTime } from '../tasks/store/task.selectors';
-import { selectAllTaskRepeatCfgs } from '../task-repeat-cfg/store/task-repeat-cfg.selectors';
+import {
+  selectAllTasksWithDueTime,
+  selectMapOfAllTasksInActiveProjects,
+} from '../tasks/store/task.selectors';
+import { selectActiveTaskRepeatCfgs } from '../task-repeat-cfg/store/task-repeat-cfg.selectors';
 import { selectTodayTaskIds } from '../work-context/store/work-context.selectors';
 import { PlannerDay } from './planner.model';
 import { first, map, shareReplay } from 'rxjs/operators';
 import { getDbDateStr } from '../../util/get-db-date-str';
 import { signal, WritableSignal } from '@angular/core';
 import { LayoutService } from '../../core-ui/layout/layout.service';
+import { selectPlannerState } from './store/planner.selectors';
+import { selectTimelineConfig } from '../config/store/global-config.reducer';
+import { selectStartOfNextDayDiffMs } from '../../root-store/app-state/app-state.selectors';
 
 describe('PlannerService', () => {
   let service: PlannerService;
@@ -44,8 +50,25 @@ describe('PlannerService', () => {
         provideMockStore({
           selectors: [
             { selector: selectAllTasksWithDueTime, value: [] },
-            { selector: selectAllTaskRepeatCfgs, value: [] },
+            { selector: selectActiveTaskRepeatCfgs, value: [] },
             { selector: selectTodayTaskIds, value: [] },
+            { selector: selectMapOfAllTasksInActiveProjects, value: new Map() },
+            {
+              selector: selectPlannerState,
+              value: { days: {}, addPlannedTasksDialogLastShown: undefined },
+            },
+            {
+              selector: selectTimelineConfig,
+              value: {
+                isWorkStartEndEnabled: false,
+                workStart: '09:00',
+                workEnd: '17:00',
+                isLunchBreakEnabled: false,
+                lunchBreakStart: '12:00',
+                lunchBreakEnd: '13:00',
+              },
+            },
+            { selector: selectStartOfNextDayDiffMs, value: 0 },
           ],
         }),
         {
@@ -481,6 +504,49 @@ describe('PlannerService', () => {
           done();
         });
       });
+    });
+  });
+
+  describe('getSnackExtraStr', () => {
+    it('should include a stored task on a day outside the loaded render window', async () => {
+      const dayStr = '2026-01-24';
+      mockDaysSubject.next([
+        createMockPlannerDay('2026-01-14'),
+        createMockPlannerDay('2026-01-15'),
+        createMockPlannerDay('2026-01-16'),
+        createMockPlannerDay('2026-01-17'),
+        createMockPlannerDay('2026-01-18'),
+      ]);
+
+      const store = TestBed.inject(MockStore);
+      store.overrideSelector(
+        selectMapOfAllTasksInActiveProjects,
+        new Map([
+          [
+            'out-of-window-task',
+            {
+              id: 'out-of-window-task',
+              title: 'Later task',
+              projectId: 'project1',
+              created: 0,
+              isDone: false,
+              subTaskIds: [],
+              tagIds: [],
+              timeSpentOnDay: {},
+              timeEstimate: 0,
+              timeSpent: 0,
+              attachments: [],
+            } as any,
+          ],
+        ]),
+      );
+      store.overrideSelector(selectPlannerState, {
+        days: { [dayStr]: ['out-of-window-task'] },
+        addPlannedTasksDialogLastShown: undefined,
+      });
+      store.refreshState();
+
+      await expectAsync(service.getSnackExtraStr(dayStr)).toBeResolvedTo(' – ∑ 1');
     });
   });
 

--- a/src/app/features/planner/planner.service.ts
+++ b/src/app/features/planner/planner.service.ts
@@ -100,36 +100,43 @@ export class PlannerService {
   );
 
   // TODO this needs to be more performant
-  days$: Observable<PlannerDay[]> = this.daysToShow$.pipe(
-    switchMap((daysToShow) =>
-      combineLatest([
-        this._store.select(selectActiveTaskRepeatCfgs),
-        this._store.select(selectTodayTaskIds),
-        this._calendarIntegrationService.calendarEvents$,
-        this.allDueWithTimeTasks$,
-        this._globalTrackingIntervalService.todayDateStr$,
-      ]).pipe(
-        switchMap(
-          ([
-            taskRepeatCfgs,
-            todayListTaskIds,
-            calendarEvents,
-            allTasksPlanned,
-            todayStr,
-          ]) =>
-            this._store.select(
-              selectPlannerDays(
-                daysToShow,
-                taskRepeatCfgs,
-                todayListTaskIds,
-                calendarEvents,
-                allTasksPlanned,
-                todayStr,
+  private _selectPlannerDaysFor$(
+    dayDates$: Observable<string[]>,
+  ): Observable<PlannerDay[]> {
+    return dayDates$.pipe(
+      switchMap((daysToShow) =>
+        combineLatest([
+          this._store.select(selectActiveTaskRepeatCfgs),
+          this._store.select(selectTodayTaskIds),
+          this._calendarIntegrationService.calendarEvents$,
+          this.allDueWithTimeTasks$,
+          this._globalTrackingIntervalService.todayDateStr$,
+        ]).pipe(
+          switchMap(
+            ([
+              taskRepeatCfgs,
+              todayListTaskIds,
+              calendarEvents,
+              allTasksPlanned,
+              todayStr,
+            ]) =>
+              this._store.select(
+                selectPlannerDays(
+                  daysToShow,
+                  taskRepeatCfgs,
+                  todayListTaskIds,
+                  calendarEvents,
+                  allTasksPlanned,
+                  todayStr,
+                ),
               ),
-            ),
+          ),
         ),
       ),
-    ),
+    );
+  }
+
+  days$: Observable<PlannerDay[]> = this._selectPlannerDaysFor$(this.daysToShow$).pipe(
     // for better performance
     // TODO better solution, gets called very often
     // tap((val) => Log.log('days$', val)),
@@ -150,7 +157,7 @@ export class PlannerService {
   //   .pipe(shareReplay(1));
 
   getDayOnce$(dayStr: string): Observable<PlannerDay | undefined> {
-    return this.days$.pipe(
+    return this._selectPlannerDaysFor$(of([dayStr])).pipe(
       map((days) => days.find((d) => d.dayDate === dayStr)),
       first(),
     );

--- a/src/app/features/planner/store/planner.selectors.spec.ts
+++ b/src/app/features/planner/store/planner.selectors.spec.ts
@@ -449,6 +449,25 @@ describe('Planner Selectors - selectPlannerDays', () => {
     expect(dayDates).toContain(tomorrow);
   });
 
+  it('should keep dates consecutive when planner state extends the loaded range', () => {
+    const task = createMockTask({ id: 't1' });
+    const plannerState: PlannerState = {
+      ...emptyPlannerState,
+      days: { ['2026-07-28']: ['t1'] },
+    };
+
+    const selector = createPlannerDaysSelector(['2026-07-25', '2026-07-26']);
+    const tasks = createTasksMapFromTasksArray([task]);
+    const result = selector.projector(tasks, plannerState, defaultScheduleConfig, 0);
+
+    expect(result.map((day) => day.dayDate)).toEqual([
+      '2026-07-25',
+      '2026-07-26',
+      '2026-07-27',
+      '2026-07-28',
+    ]);
+  });
+
   it('should filter out deleted tasks from planner days', () => {
     const plannerState: PlannerState = {
       ...emptyPlannerState,

--- a/src/app/features/planner/store/planner.selectors.spec.ts
+++ b/src/app/features/planner/store/planner.selectors.spec.ts
@@ -430,42 +430,22 @@ describe('Planner Selectors - selectPlannerDays', () => {
     expect(result[0].progressPercentage).toBeUndefined();
   });
 
-  it('should include additional days from planner state not in dayDates', () => {
-    const tomorrow = getDbDateStr(new Date(Date.now() + 86400000));
-    const task = createMockTask({ id: 't1' });
+  it('should not expand the loaded range for a far-future planner day', () => {
+    const farFutureDay = '2099-12-31';
+    const task = createMockTask({ id: 'far-future-task' });
     const plannerState: PlannerState = {
       ...emptyPlannerState,
-      days: { [tomorrow]: ['t1'] },
+      days: { [farFutureDay]: ['far-future-task'] },
     };
 
-    const selector = createPlannerDaysSelector([today]);
-    const tasks = createTasksMapFromTasksArray([task]);
-    const result = selector.projector(tasks, plannerState, defaultScheduleConfig, 0);
-
-    // Should include both today (from dayDates) and tomorrow (from planner state)
-    expect(result.length).toBe(2);
-    const dayDates = result.map((d) => d.dayDate);
-    expect(dayDates).toContain(today);
-    expect(dayDates).toContain(tomorrow);
-  });
-
-  it('should keep dates consecutive when planner state extends the loaded range', () => {
-    const task = createMockTask({ id: 't1' });
-    const plannerState: PlannerState = {
-      ...emptyPlannerState,
-      days: { ['2026-07-28']: ['t1'] },
-    };
-
-    const selector = createPlannerDaysSelector(['2026-07-25', '2026-07-26']);
-    const tasks = createTasksMapFromTasksArray([task]);
-    const result = selector.projector(tasks, plannerState, defaultScheduleConfig, 0);
-
-    expect(result.map((day) => day.dayDate)).toEqual([
+    const selector = createPlannerDaysSelector(
+      ['2026-07-25', '2026-07-26'],
       '2026-07-25',
-      '2026-07-26',
-      '2026-07-27',
-      '2026-07-28',
-    ]);
+    );
+    const tasks = createTasksMapFromTasksArray([task]);
+    const result = selector.projector(tasks, plannerState, defaultScheduleConfig, 0);
+
+    expect(result.map((day) => day.dayDate)).toEqual(['2026-07-25', '2026-07-26']);
   });
 
   it('should filter out deleted tasks from planner days', () => {

--- a/src/app/features/planner/store/planner.selectors.ts
+++ b/src/app/features/planner/store/planner.selectors.ts
@@ -94,6 +94,37 @@ export const selectTasksForPlannerDay = (day: string) => {
   );
 };
 
+const appendConsecutivePlannerDates = (
+  dayDates: string[],
+  additionalDayDates: string[],
+): string[] => {
+  const result = [...dayDates];
+  const includedDates = new Set(dayDates);
+  let lastLoadedDate = dayDates.at(-1);
+
+  for (const additionalDayDate of additionalDayDates) {
+    if (!lastLoadedDate || additionalDayDate <= lastLoadedDate) {
+      if (!includedDates.has(additionalDayDate)) {
+        result.push(additionalDayDate);
+        includedDates.add(additionalDayDate);
+      }
+      continue;
+    }
+
+    const cursor = dateStrToUtcDate(lastLoadedDate);
+    while (lastLoadedDate < additionalDayDate) {
+      cursor.setDate(cursor.getDate() + 1);
+      lastLoadedDate = getDbDateStr(cursor);
+      if (!includedDates.has(lastLoadedDate)) {
+        result.push(lastLoadedDate);
+        includedDates.add(lastLoadedDate);
+      }
+    }
+  }
+
+  return result;
+};
+
 // Updated selectPlannerDays
 export const selectPlannerDays = (
   dayDates: string[],
@@ -115,12 +146,10 @@ export const selectPlannerDays = (
     selectStartOfNextDayDiffMs,
     (activeTasks, plannerState, scheduleConfig, startOfNextDayDiffMs): PlannerDay[] => {
       const allDatesWithData = Object.keys(plannerState.days);
-      const dayDatesToUse = [
-        ...dayDates,
-        ...allDatesWithData
-          .filter((d) => plannerState.days[d].length && !dayDates.includes(d))
-          .sort((a, b) => a.localeCompare(b)),
-      ];
+      const additionalDayDates = allDatesWithData
+        .filter((d) => plannerState.days[d].length && !dayDates.includes(d))
+        .sort((a, b) => a.localeCompare(b));
+      const dayDatesToUse = appendConsecutivePlannerDates(dayDates, additionalDayDates);
 
       // Pre-compute deadline tasks grouped by day (O(N) once, then O(1) per day)
       const deadlineMap = groupDeadlineTasksByDay(

--- a/src/app/features/planner/store/planner.selectors.ts
+++ b/src/app/features/planner/store/planner.selectors.ts
@@ -94,38 +94,6 @@ export const selectTasksForPlannerDay = (day: string) => {
   );
 };
 
-const appendConsecutivePlannerDates = (
-  dayDates: string[],
-  additionalDayDates: string[],
-): string[] => {
-  const result = [...dayDates];
-  const includedDates = new Set(dayDates);
-  let lastLoadedDate = dayDates.at(-1);
-
-  for (const additionalDayDate of additionalDayDates) {
-    if (!lastLoadedDate || additionalDayDate <= lastLoadedDate) {
-      if (!includedDates.has(additionalDayDate)) {
-        result.push(additionalDayDate);
-        includedDates.add(additionalDayDate);
-      }
-      continue;
-    }
-
-    const cursor = dateStrToUtcDate(lastLoadedDate);
-    while (lastLoadedDate < additionalDayDate) {
-      cursor.setDate(cursor.getDate() + 1);
-      lastLoadedDate = getDbDateStr(cursor);
-      if (!includedDates.has(lastLoadedDate)) {
-        result.push(lastLoadedDate);
-        includedDates.add(lastLoadedDate);
-      }
-    }
-  }
-
-  return result;
-};
-
-// Updated selectPlannerDays
 export const selectPlannerDays = (
   dayDates: string[],
   taskRepeatCfgs: TaskRepeatCfg[],
@@ -145,19 +113,13 @@ export const selectPlannerDays = (
     selectTimelineConfig,
     selectStartOfNextDayDiffMs,
     (activeTasks, plannerState, scheduleConfig, startOfNextDayDiffMs): PlannerDay[] => {
-      const allDatesWithData = Object.keys(plannerState.days);
-      const additionalDayDates = allDatesWithData
-        .filter((d) => plannerState.days[d].length && !dayDates.includes(d))
-        .sort((a, b) => a.localeCompare(b));
-      const dayDatesToUse = appendConsecutivePlannerDates(dayDates, additionalDayDates);
-
       // Pre-compute deadline tasks grouped by day (O(N) once, then O(1) per day)
       const deadlineMap = groupDeadlineTasksByDay(
         activeTasks.values(),
         startOfNextDayDiffMs,
       );
 
-      return dayDatesToUse.map((dayDate) =>
+      return dayDates.map((dayDate) =>
         getPlannerDay(
           dayDate,
           todayStr,


### PR DESCRIPTION
## Problem

When a populated planner date falls just beyond the initially loaded range, `selectPlannerDays()` appends that date directly. This can render a sequence such as July 25, July 26, July 28 and omit the empty boundary date.

Closes #8963.

## Solution

Keep the planner render selector bounded to its requested `dayDates`, so the rendered list remains a contiguous loaded window. Calendar markers instead combine persisted planner dates with tasks and the currently loaded planner-day projections, so dates outside that window still appear in mobile navigation.

For snackbar feedback, query the requested day directly instead of relying on the bounded render stream. This preserves the item/time suffix when a task is scheduled on an out-of-window day.

Regression tests cover both the out-of-window calendar marker and snackbar suffix.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki. (Not applicable: internal bug fix with no user-facing workflow change.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- `npm run test:file src/app/features/planner/planner.component.spec.ts` (7 passing)
- `npm run test:file src/app/features/planner/planner.service.spec.ts` (24 passing)
- `npm run test:file src/app/features/planner/store/planner.selectors.spec.ts`
- `npm run test:file src/app/features/config/store/global-config.start-of-next-day-hydration.spec.ts` (6 passing)
- `npm run checkFile` for all four changed TypeScript files
- `npm run lint`
