### PR TITLE
fix(ios): play bundled sounds from status-zero responses

### DIFF
--- a/src/app/util/audio-context.spec.ts
+++ b/src/app/util/audio-context.spec.ts
@@ -188,6 +188,21 @@ describe('audio-context', () => {
         /Failed to fetch audio file.*404/,
       );
     });
+
+    it('should decode readable custom-scheme responses with status 0', async () => {
+      fetchSpy.and.returnValue(
+        Promise.resolve({
+          ok: false,
+          status: 0,
+          arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+        } as Response),
+      );
+
+      const buffer = await getAudioBuffer('./assets/snd/done1.mp3');
+
+      expect(mockContext.decodeAudioData).toHaveBeenCalledWith(mockArrayBuffer);
+      expect(buffer).toBe(mockAudioBuffer);
+    });
   });
 
   describe('playBuffer', () => {

--- a/src/app/util/audio-context.ts
+++ b/src/app/util/audio-context.ts
@@ -49,7 +49,9 @@ export const getAudioBuffer = async (filePath: string): Promise<AudioBuffer> => 
 
   const ctx = getAudioContext();
   const response = await fetch(filePath);
-  if (!response.ok) {
+  // Capacitor's iOS asset scheme can return a readable response with status 0.
+  // Network failures still reject fetch(), and decodeAudioData validates the body.
+  if (!response.ok && response.status !== 0) {
     throw new Error(`Failed to fetch audio file ${filePath}: ${response.status}`);
   }
   const arrayBuffer = await response.arrayBuffer();


### PR DESCRIPTION
## Problem

On iOS, Capacitor can return readable bundled audio assets with response status `0` and `ok=false`. `getAudioBuffer()` rejected those responses before reading the body, so task-completion and other configured sounds failed to play.

Closes #8880.

## Solution

Allow status-zero responses to proceed to `arrayBuffer()` and `decodeAudioData()`. Normal non-success HTTP statuses still raise, while fetch and decode failures continue to surface through their existing error paths.

Add a regression test that verifies a status-zero response is decoded successfully.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki. (Not applicable: platform-specific bug fix with no workflow change.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- `npm run checkFile src/app/util/audio-context.ts`
- `npm run checkFile src/app/util/audio-context.spec.ts`
- `npm run test:file src/app/util/audio-context.spec.ts`: 26 tests passed