### PR TITLE
docs(wiki): document F11 fullscreen shortcut

### DIFF
--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -38,6 +38,10 @@ These work everywhere in the app.
 
 The search bar searches open tasks by default. Enable **Include completed and archived tasks** in the search view to include older completed results.
 
+### Desktop Window (unconfigurable)
+
+- `F11`: Toggle full-screen mode. Available only in the Electron/desktop build.
+
 ### Add Task Bar (while the add bar input is focused)
 
 - `Ctrl+1`: Toggle issue-search mode
@@ -105,6 +109,7 @@ These shortcuts are **unconfigurable** and always available on group headers.
 
 - Global shortcuts (`globalShowHide`, `globalToggleTaskStart`, `globalAddNote`, `globalAddTask`) work system-wide when the app is running.
 - Window zoom controls (`zoomIn`, `zoomOut`, `zoomDefault`) are desktop-only.
+- `F11` toggles full-screen mode for the main window.
 
 **Linux (Wayland):**
 


### PR DESCRIPTION
## Problem

F11 fullscreen support was implemented in #6183 for #5851, but the shortcut is still absent from the official keyboard shortcut reference. Users cannot discover that the existing behavior is desktop-only and unconfigurable.

## Solution

- add an unconfigurable Desktop Window section documenting F11 fullscreen
- include F11 in the Electron/desktop platform-specific summary
- leave the existing Electron implementation unchanged

Documents the completed behavior requested in #5851.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Validation

- `pymarkdownlnt --disable-rules line-length,no-inline-html scan docs/wiki/3.03-Keyboard-Shortcuts.md`
- `git diff --check`

## Checklist

- [x] I have included relevant changes to the documentation/wiki.
- [x] `npm run checkFile` is not applicable because no `.ts` or `.scss` files changed.
- [x] Tests are not applicable to this documentation-only change.
- [x] The changed wiki file passes the same markdown lint rules used by CI.
- [x] My commit message follows the Angular format (`type(scope): description`).