### PR TITLE
test: reset global dialog state between specs

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -25,6 +25,7 @@ import 'fake-indexeddb/auto';
 import { IDBFactory } from 'fake-indexeddb';
 import { asyncScheduler } from 'rxjs';
 import { clearDeferredActions } from './app/op-log/capture/operation-capture.meta-reducer';
+import { _resetDevErrorState } from './app/util/dev-error';
 
 import { getTestBed, TestBed } from '@angular/core/testing';
 import {
@@ -108,6 +109,18 @@ beforeEach(() => {
   // the phantom-change guard (#8751) reads it and silently skips compaction
   // and snapshot saves — an order-dependent failure that passes standalone.
   clearDeferredActions();
+
+  // The dialog spies below are created once at module load, so reset their
+  // call history before every spec to prevent assertions from passing on a
+  // stale call from an unrelated test. Re-arm devError's alert latch as well
+  // so legitimate alerts remain observable regardless of spec order.
+  if (jasmine.isSpy(window.alert)) {
+    (window.alert as jasmine.Spy).calls.reset();
+  }
+  if (jasmine.isSpy(window.confirm)) {
+    (window.confirm as jasmine.Spy).calls.reset();
+  }
+  _resetDevErrorState();
 });
 
 // Mock browser dialogs globally for tests


### PR DESCRIPTION
## Problem

The global `window.alert` and `window.confirm` spies keep their call history across specs. `devError` also keeps its one-alert latch across specs, so dialog assertions can pass because of an unrelated earlier call or become order-dependent.

Closes #9100.

## Solution

Reset both dialog spies and re-arm `devError` in the existing global `beforeEach`. Each spec now starts with clean dialog state while retaining the shared spy setup.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] Documentation changes are not required for this test-infrastructure fix
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing relevant tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- `npm run checkFile src/test.ts`
- Combined `task.reducer.spec.ts` and `task.reducer.util.spec.ts`: 75 tests passed
- Pre-push lint, lint-rule, theme, sync-core (243), sync-provider (404), and release-note (24) suites passed
- The full Angular bundle completed locally, but ChromeHeadless disconnected before executing the full browser suite; CI should provide the authoritative full-suite result
