### PR TITLE
fix(sync): accept legacy schema versions on download

### DIFF
--- a/packages/shared-schema/src/supersync-http-contract.ts
+++ b/packages/shared-schema/src/supersync-http-contract.ts
@@ -149,6 +149,18 @@ export const SuperSyncServerOperationSchema = z
   })
   .passthrough();
 
+// Legacy servers accepted finite numeric schema versions before integer
+// validation was added. Keep download parsing transport-compatible so the
+// client can classify unsupported versions per operation without rejecting
+// and permanently wedging the entire response page.
+const SuperSyncDownloadOperationSchema = SuperSyncOperationResponseSchema.extend({
+  schemaVersion: z.number(),
+});
+
+const SuperSyncDownloadServerOperationSchema = SuperSyncServerOperationSchema.extend({
+  op: SuperSyncDownloadOperationSchema,
+});
+
 export const SuperSyncUploadResultSchema = z
   .object({
     opId: z.string(),
@@ -171,7 +183,7 @@ export const SuperSyncUploadOpsResponseSchema = z
 
 export const SuperSyncDownloadOpsResponseSchema = z
   .object({
-    ops: z.array(SuperSyncServerOperationSchema),
+    ops: z.array(SuperSyncDownloadServerOperationSchema),
     hasMore: z.boolean(),
     latestSeq: z.number(),
     gapDetected: z.boolean().optional(),

--- a/packages/shared-schema/tests/supersync-http-contract.spec.ts
+++ b/packages/shared-schema/tests/supersync-http-contract.spec.ts
@@ -231,6 +231,27 @@ describe('SuperSync HTTP contract schemas', () => {
     expect(parsed.capabilities?.causalRepairSnapshots).toBe(true);
   });
 
+  it('accepts legacy fractional schema versions in download responses', () => {
+    const operation = {
+      ...createValidOperation(),
+      schemaVersion: 1.5,
+    };
+    const parsed = SuperSyncDownloadOpsResponseSchema.parse({
+      ops: [
+        {
+          serverSeq: 1,
+          op: operation,
+          receivedAt: 1234567890,
+        },
+      ],
+      hasMore: false,
+      latestSeq: 1,
+    });
+
+    expect(parsed.ops[0].op.schemaVersion).toBe(1.5);
+    expect(() => SuperSyncOperationSchema.parse(operation)).toThrow();
+  });
+
   it('requires an operation ID for destructive clean-slate snapshots', () => {
     expect(() =>
       SuperSyncUploadSnapshotRequestSchema.parse({


### PR DESCRIPTION
## Problem

Download responses are parsed with the strict operation schema. A legacy server operation containing a fractional numeric `schemaVersion` therefore rejects the entire response page before the existing per-operation version gate can classify and block it safely.

Closes #8923.

## Solution

Use a download-only operation schema that accepts numeric legacy schema versions while preserving every other operation constraint. The canonical operation schema remains strict, so upload/server validation still rejects non-integer versions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] Documentation changes are not required for this compatibility fix
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- Added a regression test that failed before the implementation at `ops[0].op.schemaVersion`
- Shared-schema suite: 86 tests passed
- Shared-schema build passed
- App-level SuperSync response-validator suite: 38 tests passed
