### PR TITLE
fix(plugins): filter Linear auto-import by current cycle

### DIFF
--- a/packages/plugin-dev/linear-issue-provider/i18n/en.json
+++ b/packages/plugin-dev/linear-issue-provider/i18n/en.json
@@ -3,6 +3,7 @@
     "API_KEY": "API Key",
     "TEAM_ID": "Team ID (optional, filter to a specific team)",
     "PROJECT_ID": "Project ID (optional, filter to a specific project)",
+    "AUTO_IMPORT_CURRENT_CYCLE_ONLY": "Only auto-import issues from current cycle",
     "HOW_TO_GET_TOKEN": "Get your API key"
   },
   "DISPLAY": {

--- a/packages/plugin-dev/linear-issue-provider/src/plugin.ts
+++ b/packages/plugin-dev/linear-issue-provider/src/plugin.ts
@@ -20,6 +20,7 @@ interface LinearConfig {
   apiKey?: string;
   teamId?: string;
   projectId?: string;
+  isAutoImportCurrentCycleOnly?: boolean;
 }
 
 interface LinearGraphQLResponse<T = unknown> {
@@ -66,14 +67,15 @@ const t = (key: string): string => {
 };
 
 const SEARCH_ISSUES_QUERY = `
-  query SearchIssues($first: Int!, $team: TeamFilter, $project: NullableProjectFilter) {
+  query SearchIssues($first: Int!, $team: TeamFilter, $project: NullableProjectFilter, $cycle: NullableCycleFilter) {
     viewer {
       assignedIssues(
         first: $first,
         filter: {
           state: { type: { in: ["backlog", "unstarted", "started"] } },
           team: $team,
-          project: $project
+          project: $project,
+          cycle: $cycle
         }
       ) {
         nodes {
@@ -149,6 +151,9 @@ const searchAssignedIssues = async (
   if (cfg.projectId) {
     variables.project = { id: { eq: cfg.projectId } };
   }
+  if (cfg.isAutoImportCurrentCycleOnly) {
+    variables.cycle = { isActive: { eq: true } };
+  }
 
   const data = await graphql<{
     viewer: { assignedIssues: { nodes: LinearRawIssueReduced[] } };
@@ -190,6 +195,12 @@ PluginAPI.registerIssueProvider({
       key: 'projectId',
       type: 'input',
       label: t('CFG.PROJECT_ID'),
+      advanced: true,
+    },
+    {
+      key: 'isAutoImportCurrentCycleOnly',
+      type: 'checkbox' as const,
+      label: t('CFG.AUTO_IMPORT_CURRENT_CYCLE_ONLY'),
       advanced: true,
     },
   ],


### PR DESCRIPTION
## Problem

Linear auto-import currently imports all assigned open issues. Users who work primarily from Linear cycles need a way to limit auto-imported backlog items to issues from the current active cycle.

## Solution

Add an advanced Linear plugin checkbox: “Only auto-import issues from current cycle”.

When enabled, the Linear GraphQL search query includes:

`cycle: { isActive: { eq: true } }`

When disabled or unset, no cycle filter is sent, so existing behavior remains unchanged. The option is disabled by default via absent/falsy plugin config.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
For the unchecked items, keep them unchecked unless you also ran broader tests or decide docs/wiki updates are needed.
