### PR TITLE
test(planner): use distinct dates in subtask visibility spec

### DIFF
--- a/e2e/tests/planner/planner-subtask-scheduled-visibility.spec.ts
+++ b/e2e/tests/planner/planner-subtask-scheduled-visibility.spec.ts
@@ -1,24 +1,19 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect, test } from '../../fixtures/test.fixture';
 
-const QUICK_ACCESS_BUTTON = '.quick-access button';
-
 /**
- * Schedule a task for a quick-access day (day-only, no time) via the keyboard
- * shortcut ('S' opens the schedule dialog for the focused task) and the
- * dialog's quick-access buttons (Today=0, Tomorrow=1, Next Week=2, Next
- * Month=3). onQuickAccessClick auto-submits, so clicking a day both sets the
- * due day and closes the dialog.
+ * Schedule a task for an exact day (day-only, no time) via the keyboard
+ * shortcut ('S' opens the schedule dialog) and calendar.
  *
  * The keyboard path is used deliberately: it is independent of whether the task
  * is already scheduled (a scheduled task's detail item shows a "Reschedule"
  * control instead of "Schedule Task") and of task height (hovering a parent
  * with sub-tasks lands on a sub-task row).
  */
-const scheduleTaskForQuickDay = async (
+const scheduleTaskForDay = async (
   page: Page,
   task: Locator,
-  quickAccessIndex: number,
+  targetDate: Date,
 ): Promise<void> => {
   await task.scrollIntoViewIfNeeded();
   await task.focus();
@@ -31,17 +26,34 @@ const scheduleTaskForQuickDay = async (
   // No time set -> this creates a date-only dueDay, not a timed dueWithTime.
   await expect(scheduleDialog.locator('input[type="time"]')).toHaveValue('');
 
-  await scheduleDialog.locator(QUICK_ACCESS_BUTTON).nth(quickAccessIndex).click();
+  const today = new Date();
+  if (
+    targetDate.getMonth() !== today.getMonth() ||
+    targetDate.getFullYear() !== today.getFullYear()
+  ) {
+    await scheduleDialog.getByRole('button', { name: /next month/i }).click();
+  }
+
+  const targetDay = scheduleDialog
+    .locator('.mat-calendar-body-cell:not(.mat-calendar-body-disabled)')
+    .filter({ hasText: new RegExp(`^\\s*${targetDate.getDate()}\\s*$`) })
+    .first();
+  await expect(targetDay).toBeVisible();
+  await targetDay.click();
+  await scheduleDialog.locator('[data-test-id="schedule-submit-btn"]').click();
   await scheduleDialog.waitFor({ state: 'hidden', timeout: 10000 });
 };
 
-const getTomorrowDateString = (): string => {
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
+const getDateWithDayOffset = (dayOffset: number): Date => {
+  const date = new Date();
+  date.setDate(date.getDate() + dayOffset);
+  return date;
+};
 
-  const year = tomorrow.getFullYear();
-  const month = String(tomorrow.getMonth() + 1).padStart(2, '0');
-  const day = String(tomorrow.getDate()).padStart(2, '0');
+const getDateString = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 };
 
@@ -52,6 +64,9 @@ test.describe('Planner: scheduled subtask visibility (#9019)', () => {
     taskPage,
     workViewPage,
   }) => {
+    const subTaskDate = getDateWithDayOffset(1);
+    const parentDate = getDateWithDayOffset(2);
+
     await workViewPage.waitForTaskList();
     await workViewPage.addTask('Parent 9019');
 
@@ -66,16 +81,18 @@ test.describe('Planner: scheduled subtask visibility (#9019)', () => {
     await expect(subTask).toBeVisible();
 
     // Schedule the SUBTASK for tomorrow (day-only).
-    await scheduleTaskForQuickDay(page, subTask, 1);
+    await scheduleTaskForDay(page, subTask, subTaskDate);
 
-    // Plan the PARENT for a different day (next week). Before #9019 this removed
-    // the subtask from EVERY planner day, so it vanished from the planner.
-    await scheduleTaskForQuickDay(page, parentTask, 2);
+    // Plan the PARENT for the following day. Before #9019 this removed the
+    // subtask from EVERY planner day, so it vanished from the planner.
+    await scheduleTaskForDay(page, parentTask, parentDate);
 
     await plannerPage.navigateToPlanner();
     await plannerPage.waitForPlannerView();
 
-    const subTaskDay = page.locator(`planner-day[data-day="${getTomorrowDateString()}"]`);
+    const subTaskDay = page.locator(
+      `planner-day[data-day="${getDateString(subTaskDate)}"]`,
+    );
     await expect(subTaskDay).toBeVisible({ timeout: 15000 });
     await expect(
       subTaskDay.locator('planner-task').filter({ hasText: 'Sub 9019' }),


### PR DESCRIPTION
## Summary

- replace relative “Tomorrow”/“Next Week” choices with explicit consecutive future dates
- keep the #9019 scheduled-subtask regression scenario valid on every weekday
- navigate the calendar when the selected dates cross a month or year boundary

## Root cause

The [scheduled E2E run](https://github.com/super-productivity/super-productivity/actions/runs/29671322533) ran on Sunday, July 19, 2026. With Monday as the first day of the week, both “Tomorrow” and “Next Week” resolved to Monday, July 20. The application correctly folded the same-day subtask under its parent, but the test incorrectly expected it as a separate planner item.

## Impact

Test-only change. Production behavior is unchanged. This prevents a deterministic false failure on Sundays while preserving the original regression coverage.

## Verification

- `npm run checkFile e2e/tests/planner/planner-subtask-scheduled-visibility.spec.ts`
- `npm run e2e:file e2e/tests/planner/planner-subtask-scheduled-visibility.spec.ts -- --retries=0`
- `git diff --check`
- pre-push lint and full unit test suites, including Europe/Berlin and America/Los_Angeles runs
- independent sub-agent review: no findings
