### PR TITLE
fix(supersync): split the conflict entity lookup to avoid a full-history scan

### DIFF
--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -251,8 +251,11 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > The obvious escalations are broken too. Two ordered `LIMIT 1` lookups still leave the
   > array side unable to order on GIN. Measured under generic planning on a 40k-row seed, the
   > outage query, the naive array-only `LIMIT 1`, the flat `MAX`, Prisma's `aggregate({ _max })`
-  > and the CTE with `MATERIALIZED` dropped **all** read the user's whole entity-type slice —
-  > 816 blocks and 2500 rows discarded, against 143 blocks and 0 discarded for the shipped form.
+  > and the CTE with `MATERIALIZED` dropped **all** read the user's whole entity-type slice,
+  > against 143 blocks and 0 discarded for the shipped form. The **816 blocks / 2500 rows
+  > discarded** figure is the outage query specifically, and it is the only one still pinned
+  > by a test (the `CANARY` case in `conflict-entity-lookup-plan.pglite.spec.ts`); the other
+  > four were measured during the investigation but are not guarded against regression.
   >
   > Measure any change here with `SET plan_cache_mode = force_generic_plan`. Prisma sends
   > parameterized prepared statements; under `auto` Postgres plans the first ~5 executions as
@@ -276,7 +279,7 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > loss**. That was the #8334 bug; the divergent-scalar case is the decisive test in
   > `tests/integration/conflict-detection-sql.integration.spec.ts`.
 
-**Forward-only by design:** rows written before migration `20260613000000` have an empty `entity_ids` array and fall back to the scalar `entity_id` (= first entity) in the `CASE` expression / scalar branch above — there is no `UPDATE` backfill. Entities 2..n of already-stored multi-entity ops were never persisted and are unrecoverable, so they remain invisible to conflict detection until that entity gets a fresh write. This residual is bounded: client-side LWW is unaffected (the client persists the full op and `VectorClockService.getEntityFrontier()` fans each op out to **every** entity), and the server only builds an authoritative snapshot from non-encrypted ops (`replayOpsToState()` throws on encrypted ops), so the pre-fix gap could only surface a stale value to a fresh client on non-encrypted self-hosted servers.
+**Forward-only by design:** rows written before migration `20260613000000` have an empty `entity_ids` array, so they are reached only by their scalar `entity_id` (= first entity) — via the scalar arm of the batch union above, or the scalar branch of the single-entity lookup. (Not via the exclusive `CASE` form: that is the removed #8334 bug documented in the warning above, not the current shape.) There is no `UPDATE` backfill. Entities 2..n of already-stored multi-entity ops were never persisted and are unrecoverable, so they remain invisible to conflict detection until that entity gets a fresh write. This residual is bounded: client-side LWW is unaffected (the client persists the full op and `VectorClockService.getEntityFrontier()` fans each op out to **every** entity), and the server only builds an authoritative snapshot from non-encrypted ops (`replayOpsToState()` throws on encrypted ops), so the pre-fix gap could only surface a stale value to a fresh client on non-encrypted self-hosted servers.
 
 ### The `SyncImportFilterService` Algorithm
 

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -168,7 +168,7 @@ With MAX=20, a user needs 21+ unique client IDs before pruning triggers. Both si
 
 ### Server-Side Flow
 
-1. Server finds the latest operation for the same entity (`findFirst` by `entityType + entityId`, ordered by `serverSeq desc`)
+1. Server finds the latest operation for the same entity — **two separately-indexed lookups**, a scalar `findFirst` plus a raw-SQL `MATERIALIZED` CTE over `entity_ids`, taking whichever has the higher `serverSeq`. Deliberately NOT one combined filter; see the multi-entity section below for why that caused an outage.
 2. Compares incoming clock vs existing clock using the **full unpruned** incoming clock
 3. Possible outcomes:
    - `GREATER_THAN` → **accept** (incoming op causally succeeds existing)
@@ -255,9 +255,12 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > 816 blocks and 2500 rows discarded, against 143 blocks and 0 discarded for the shipped form.
   >
   > Measure any change here with `SET plan_cache_mode = force_generic_plan`. Prisma sends
-  > parameterized prepared statements, so Postgres settles on a **generic** plan after ~5
-  > executions, and `EXPLAIN` with literal constants builds a custom plan that makes every one
-  > of those broken shapes look perfect. See
+  > parameterized prepared statements; under `auto` Postgres plans the first ~5 executions as
+  > custom, then compares the generic cost against the average custom cost and **may** switch
+  > to a generic plan — a cost comparison, not an automatic switch, so some statements stay on
+  > custom plans indefinitely. This one was observed going generic on production, and a
+  > generic plan cannot see the parameter values. `EXPLAIN` with literal constants is
+  > different again and makes every one of those broken shapes look perfect. See
   > `packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts` and the note
   > at `detectConflictForEntity` in `packages/super-sync-server/src/sync/conflict.ts`.
 

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -237,7 +237,30 @@ To make that symmetric, the `operations` row stores:
 
 The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` **or** a member of `entity_ids`:
 
-- `detectConflictForEntity` (single) — Prisma `where: { OR: [{ entityId }, { entityIds: { has: entityId } }] }`, ordered by `server_seq`. The `OR` spans the `entity_id` btree and the `entity_ids` GIN, so the planner uses a `BitmapOr` + sort bounded by the entity's stored version depth (op-log pruning keeps that small). If a real-Postgres `EXPLAIN` on a deep-history entity ever shows this hot path is a problem, the escalation is two ordered `LIMIT 1` lookups (scalar btree + `entity_ids` GIN) taking the higher `server_seq` — the array side stays small because the column is multi-entity-only.
+- `detectConflictForEntity` (single) — **two separately-indexed lookups, never one combined filter.** A scalar `findFirst` on `{ userId, entityType, entityId }` ordered by `server_seq` (served end to end by the `(user_id, entity_type, entity_id, server_seq)` btree), plus a raw-SQL `MATERIALIZED` CTE taking `MAX(server_seq)` over `entity_ids @> ARRAY[id]`, with the winning row then fetched by the `(user_id, server_seq)` unique key.
+
+  > ⚠️ **Do not "simplify" this back into one query.** It used to be
+  > `where: { OR: [{ entityId }, { entityIds: { has: entityId } }] }` + `orderBy: { serverSeq: 'desc' }`,
+  > and on 2026-07-20 that caused a total sync outage — 47 stuck backends, longest 75 minutes,
+  > 61/66 connections consumed. The `OR` spans two different indexes and GIN cannot supply
+  > `server_seq` ordering, so the planner abandons **both** index paths and walks the user's
+  > history. Nothing bounds that walk when the entity has no matching rows — i.e. the
+  > first-ever op for a new task, the most common upload there is. Op-log pruning does **not**
+  > bound it; that assumption is what this paragraph used to assert, and it was wrong.
+  >
+  > The obvious escalations are broken too. Two ordered `LIMIT 1` lookups still leave the
+  > array side unable to order on GIN. Measured under generic planning on a 40k-row seed, the
+  > outage query, the naive array-only `LIMIT 1`, the flat `MAX`, Prisma's `aggregate({ _max })`
+  > and the CTE with `MATERIALIZED` dropped **all** read the user's whole entity-type slice —
+  > 816 blocks and 2500 rows discarded, against 143 blocks and 0 discarded for the shipped form.
+  >
+  > Measure any change here with `SET plan_cache_mode = force_generic_plan`. Prisma sends
+  > parameterized prepared statements, so Postgres settles on a **generic** plan after ~5
+  > executions, and `EXPLAIN` with literal constants builds a custom plan that makes every one
+  > of those broken shapes look perfect. See
+  > `packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts` and the note
+  > at `detectConflictForEntity` in `packages/super-sync-server/src/sync/conflict.ts`.
+
 - `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL unnesting `CASE WHEN cardinality(entity_ids) > 0 THEN entity_ids ELSE ARRAY[entity_id] END`, with a `entity_ids && ... OR entity_id = ANY(...)` prefilter so the `GIN(entity_ids)` index (migration `20260613000001`) and the existing `entity_id` btree stay usable.
 
 **Forward-only by design:** rows written before migration `20260613000000` have an empty `entity_ids` array and fall back to the scalar `entity_id` (= first entity) in the `CASE` expression / scalar branch above — there is no `UPDATE` backfill. Entities 2..n of already-stored multi-entity ops were never persisted and are unrecoverable, so they remain invisible to conflict detection until that entity gets a fresh write. This residual is bounded: client-side LWW is unaffected (the client persists the full op and `VectorClockService.getEntityFrontier()` fans each op out to **every** entity), and the server only builds an authoritative snapshot from non-encrypted ops (`replayOpsToState()` throws on encrypted ops), so the pre-fix gap could only surface a stale value to a fresh client on non-encrypted self-hosted servers.

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -253,9 +253,11 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > outage query, the naive array-only `LIMIT 1`, the flat `MAX`, Prisma's `aggregate({ _max })`
   > and the CTE with `MATERIALIZED` dropped **all** read the user's whole entity-type slice,
   > against 143 blocks and 0 discarded for the shipped form. The **816 blocks / 2500 rows
-  > discarded** figure is the outage query specifically, and it is the only one still pinned
-  > by a test (the `CANARY` case in `conflict-entity-lookup-plan.pglite.spec.ts`); the other
-  > four were measured during the investigation but are not guarded against regression.
+  > discarded** figure is the outage query specifically, pinned by the `CANARY` case in
+  > `conflict-entity-lookup-plan.pglite.spec.ts`. The other four are not unguarded: that
+  > spec rebuilds the array branch from the live tagged template, so dropping `MATERIALIZED`
+  > or flattening the `MAX` blows the block budget and fails there (verified by mutation).
+  > What is _not_ pinned is their individual historical block counts.
   >
   > Measure any change here with `SET plan_cache_mode = force_generic_plan`. Prisma sends
   > parameterized prepared statements; under `auto` Postgres plans the first ~5 executions as

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -261,7 +261,17 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > `packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts` and the note
   > at `detectConflictForEntity` in `packages/super-sync-server/src/sync/conflict.ts`.
 
-- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL unnesting `CASE WHEN cardinality(entity_ids) > 0 THEN entity_ids ELSE ARRAY[entity_id] END`, with a `entity_ids && ... OR entity_id = ANY(...)` prefilter so the `GIN(entity_ids)` index (migration `20260613000001`) and the existing `entity_id` btree stay usable.
+- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL unnesting the **union** of both columns, `entity_ids || CASE WHEN entity_id IS NULL THEN '{}' ELSE ARRAY[entity_id] END`, deduped by `DISTINCT ON`, with an `entity_ids && ... OR entity_id = ANY(...)` prefilter so the `GIN(entity_ids)` index (migration `20260613000001`) and the existing `entity_id` btree stay usable.
+
+  > ⚠️ It must be a **union**, not the mutually exclusive
+  > `CASE WHEN cardinality(entity_ids) > 0 THEN entity_ids ELSE ARRAY[entity_id] END`
+  > this section used to document. The server does **not** enforce
+  > `entity_id === entityIds[0]`, so a multi-entity op can carry a scalar that is not a
+  > member of its own `entity_ids` (see `getStoredEntityIds`). The exclusive form drops
+  > that scalar whenever the array is non-empty, making the entity invisible to conflict
+  > lookups — a later concurrent write to it is wrongly accepted, which is **silent data
+  > loss**. That was the #8334 bug; the divergent-scalar case is the decisive test in
+  > `tests/integration/conflict-detection-sql.integration.spec.ts`.
 
 **Forward-only by design:** rows written before migration `20260613000000` have an empty `entity_ids` array and fall back to the scalar `entity_id` (= first entity) in the `CASE` expression / scalar branch above — there is no `UPDATE` backfill. Entities 2..n of already-stored multi-entity ops were never persisted and are unrecoverable, so they remain invisible to conflict detection until that entity gets a fresh write. This residual is bounded: client-side LWW is unaffected (the client persists the full op and `VectorClockService.getEntityFrontier()` fans each op out to **every** entity), and the server only builds an authoritative snapshot from non-encrypted ops (`replayOpsToState()` throws on encrypted ops), so the pre-fix gap could only surface a stale value to a fresh client on non-encrypted self-hosted servers.
 

--- a/packages/super-sync-server/prisma/schema.prisma
+++ b/packages/super-sync-server/prisma/schema.prisma
@@ -11,31 +11,31 @@ datasource db {
 }
 
 model User {
-  id                              Int       @id @default(autoincrement())
-  email                           String    @unique
-  passwordHash                    String?   @map("password_hash") // Nullable for passkey-only users
-  isVerified                      Int       @default(0) @map("is_verified") // 0 or 1
-  verificationToken               String?   @map("verification_token")
-  verificationTokenExpiresAt      BigInt?   @map("verification_token_expires_at")
-  verificationResendCount         Int       @default(0) @map("verification_resend_count")
-  resetPasswordToken              String?   @map("reset_password_token")
-  resetPasswordTokenExpiresAt     BigInt?   @map("reset_password_token_expires_at")
-  passkeyRecoveryToken            String?   @map("passkey_recovery_token")
-  passkeyRecoveryTokenExpiresAt   BigInt?   @map("passkey_recovery_token_expires_at")
-  loginToken                      String?   @map("login_token")
-  loginTokenExpiresAt             BigInt?   @map("login_token_expires_at")
-  failedLoginAttempts             Int       @default(0) @map("failed_login_attempts")
-  lockedUntil                     BigInt?   @map("locked_until")
-  tokenVersion                    Int       @default(0) @map("token_version")
-  termsAcceptedAt                 BigInt?   @map("terms_accepted_at")
-  createdAt                       DateTime  @default(now()) @map("created_at")
-  storageQuotaBytes               BigInt    @default(104857600) @map("storage_quota_bytes")  // 100MB default
-  storageUsedBytes                BigInt    @default(0) @map("storage_used_bytes")
+  id                            Int      @id @default(autoincrement())
+  email                         String   @unique
+  passwordHash                  String?  @map("password_hash") // Nullable for passkey-only users
+  isVerified                    Int      @default(0) @map("is_verified") // 0 or 1
+  verificationToken             String?  @map("verification_token")
+  verificationTokenExpiresAt    BigInt?  @map("verification_token_expires_at")
+  verificationResendCount       Int      @default(0) @map("verification_resend_count")
+  resetPasswordToken            String?  @map("reset_password_token")
+  resetPasswordTokenExpiresAt   BigInt?  @map("reset_password_token_expires_at")
+  passkeyRecoveryToken          String?  @map("passkey_recovery_token")
+  passkeyRecoveryTokenExpiresAt BigInt?  @map("passkey_recovery_token_expires_at")
+  loginToken                    String?  @map("login_token")
+  loginTokenExpiresAt           BigInt?  @map("login_token_expires_at")
+  failedLoginAttempts           Int      @default(0) @map("failed_login_attempts")
+  lockedUntil                   BigInt?  @map("locked_until")
+  tokenVersion                  Int      @default(0) @map("token_version")
+  termsAcceptedAt               BigInt?  @map("terms_accepted_at")
+  createdAt                     DateTime @default(now()) @map("created_at")
+  storageQuotaBytes             BigInt   @default(104857600) @map("storage_quota_bytes") // 100MB default
+  storageUsedBytes              BigInt   @default(0) @map("storage_used_bytes")
 
-  operations                 Operation[]
-  syncState                  UserSyncState?
-  devices                    SyncDevice[]
-  passkeys                   Passkey[]
+  operations                  Operation[]
+  syncState                   UserSyncState?
+  devices                     SyncDevice[]
+  passkeys                    Passkey[]
   pendingPasskeyRegistrations PendingPasskeyRegistration[]
 
   @@index([verificationToken])
@@ -46,16 +46,16 @@ model User {
 }
 
 model Passkey {
-  id              String    @id @default(cuid())
-  credentialId    Bytes     @unique @map("credential_id")
-  publicKey       Bytes     @map("public_key")
-  counter         BigInt    @default(0)
-  transports      String?   // JSON array of transport types
-  createdAt       DateTime  @default(now()) @map("created_at")
-  lastUsedAt      DateTime? @map("last_used_at")
+  id           String    @id @default(cuid())
+  credentialId Bytes     @unique @map("credential_id")
+  publicKey    Bytes     @map("public_key")
+  counter      BigInt    @default(0)
+  transports   String? // JSON array of transport types
+  createdAt    DateTime  @default(now()) @map("created_at")
+  lastUsedAt   DateTime? @map("last_used_at")
 
-  userId          Int       @map("user_id")
-  user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId Int  @map("user_id")
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@map("passkeys")
@@ -79,14 +79,14 @@ model PendingPasskeyRegistration {
 }
 
 model Operation {
-  id                 String  @id
-  userId             Int     @map("user_id")
-  clientId           String  @map("client_id")
-  serverSeq          Int     @map("server_seq")
-  actionType         String  @map("action_type")
-  opType             String  @map("op_type")
-  entityType         String  @map("entity_type")
-  entityId           String? @map("entity_id")
+  id                  String   @id
+  userId              Int      @map("user_id")
+  clientId            String   @map("client_id")
+  serverSeq           Int      @map("server_seq")
+  actionType          String   @map("action_type")
+  opType              String   @map("op_type")
+  entityType          String   @map("entity_type")
+  entityId            String?  @map("entity_id")
   // Entity set for multi-entity (batch) ops only — single-entity ops store [] and
   // are matched via the scalar `entityId` (the client sets `entityId` to entityIds[0]
   // but the server does not enforce that). Conflict detection consults this array so
@@ -94,40 +94,48 @@ model Operation {
   // Pre-migration rows have an empty array and fall back to `entityId` in the
   // conflict lookups, so the backfill is forward-only (older entities 2..n are
   // unrecoverable — they were never persisted).
-  entityIds          String[] @default([]) @map("entity_ids")
-  payload            Json
-  payloadBytes       BigInt  @default(0) @map("payload_bytes")
-  vectorClock        Json    @map("vector_clock")
-  schemaVersion      Int     @map("schema_version")
-  clientTimestamp    BigInt  @map("client_timestamp")
-  receivedAt         BigInt  @map("received_at")
-  isPayloadEncrypted Boolean @default(false) @map("is_payload_encrypted")
-  syncImportReason   String? @map("sync_import_reason")
-  repairBaseServerSeq Int?   @map("repair_base_server_seq")
+  entityIds           String[] @default([]) @map("entity_ids")
+  payload             Json
+  payloadBytes        BigInt   @default(0) @map("payload_bytes")
+  vectorClock         Json     @map("vector_clock")
+  schemaVersion       Int      @map("schema_version")
+  clientTimestamp     BigInt   @map("client_timestamp")
+  receivedAt          BigInt   @map("received_at")
+  isPayloadEncrypted  Boolean  @default(false) @map("is_payload_encrypted")
+  syncImportReason    String?  @map("sync_import_reason")
+  repairBaseServerSeq Int?     @map("repair_base_server_seq")
 
-  user           User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, serverSeq])
   @@index([userId, entityType, entityId, serverSeq])
   @@index([userId, clientId])
   @@index([userId, receivedAt])
-  // Restore-point opType lookups use a raw partial index in the 20260512000000 migration.
-  // Multi-entity conflict lookups (#8334) use a raw GIN index on entity_ids in the
-  // 20260613000001 migration (Prisma does not model GIN array indexes here).
+  // Multi-entity conflict lookups (#8334) probe entity_ids with @> / &&. This MUST stay
+  // modelled here, not only in the 20260613000001 raw migration: `prisma db push` builds
+  // from this file alone, so while the GIN existed only as raw SQL the CI, E2E and
+  // documented manual-setup databases had NO index at all — and detectConflictForEntity's
+  // MATERIALIZED CTE carries no user_id predicate, so without it every probe Seq Scans
+  // EVERY tenant's rows, twice per accepted op. Worse than the outage this replaced.
+  // The map name matches the raw migration, so migrate-based deployments see no drift.
+  @@index([entityIds], type: Gin, map: "operations_entity_ids_gin")
+  // Restore-point opType lookups use a raw PARTIAL index (20260512000000). That one
+  // genuinely cannot be modelled — Prisma has no partial-index syntax — so db-push
+  // databases still lack it. Same trap, different index; tracked in #9192.
   @@map("operations")
 }
 
 model UserSyncState {
-  userId                Int     @id @map("user_id")
-  lastSeq               Int     @default(0) @map("last_seq")
-  lastSnapshotSeq       Int?    @map("last_snapshot_seq")
-  snapshotData          Bytes?  @map("snapshot_data")
-  snapshotAt            BigInt? @map("snapshot_at")
-  snapshotSchemaVersion Int?    @default(1) @map("snapshot_schema_version")
-  latestFullStateSeq         Int?   @map("latest_full_state_seq")
-  latestFullStateVectorClock Json?  @map("latest_full_state_vector_clock")
+  userId                     Int     @id @map("user_id")
+  lastSeq                    Int     @default(0) @map("last_seq")
+  lastSnapshotSeq            Int?    @map("last_snapshot_seq")
+  snapshotData               Bytes?  @map("snapshot_data")
+  snapshotAt                 BigInt? @map("snapshot_at")
+  snapshotSchemaVersion      Int?    @default(1) @map("snapshot_schema_version")
+  latestFullStateSeq         Int?    @map("latest_full_state_seq")
+  latestFullStateVectorClock Json?   @map("latest_full_state_vector_clock")
 
-  user                  User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("user_sync_state")
 }
@@ -141,7 +149,7 @@ model SyncDevice {
   lastAckedSeq Int     @default(0) @map("last_acked_seq")
   createdAt    BigInt  @map("created_at")
 
-  user         User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, clientId])
   @@map("sync_devices")

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -302,10 +302,20 @@ export const detectConflictForEntity = async (
   // (WHERE entity_ids <> '{}') and it covers only the multi-entity minority instead of
   // every row. That is lossless: a single-entity op stores '{}', so its indexed
   // expression is just ARRAY['u:<id>'] and can never contain the real entity id a probe
-  // carries. The catch is that the query must then carry a matching
-  // `AND entity_ids <> '{}'` predicate, or Postgres cannot prove the partial index
-  // applies and ignores it. The outer user_id predicate stays load-bearing either way —
-  // the 'u:' prefix is a namespace, not a security boundary.
+  // carries. That losslessness is a claim about the DATA and holds by inspection:
+  // getStoredEntityIds collapses single-entity sets to [], entity_ids is NOT NULL
+  // DEFAULT '{}', and '{}' @> ARRAY[<id>] is false.
+  //
+  // UNMEASURED, and do not build on it until you have: whether the PARTIAL form is
+  // usable at all is a claim about the PLANNER, and nobody has run it. The query would
+  // have to carry a matching `AND entity_ids <> '{}'` and Postgres would have to prove
+  // that implies the index predicate — for an array `<>`, which is not something this
+  // comment has any evidence about. EXPLAIN it under force_generic_plan first (see the
+  // plan-cache note above). A comment asserting unmeasured planner behaviour is what
+  // preceded the outage; this paragraph is a lead to chase, not a design to trust.
+  //
+  // The outer user_id predicate stays load-bearing either way — the 'u:' prefix is a
+  // namespace, not a security boundary.
   //
   // Sequential, never Promise.all: `tx` is a single-connection interactive transaction
   // client and concurrent queries on it are unsafe.

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -219,24 +219,116 @@ export const detectConflictForEntity = async (
   // member of entity_ids. Single-entity ops store an empty array and are matched
   // via the scalar; pre-migration rows likewise fall back to the scalar (#8334).
   //
-  // PERF: the OR spans the entity_id btree + the entity_ids GIN, so the planner
-  // uses a BitmapOr + sort rather than an ordered LIMIT-1 walk. Bounded by one
-  // entity's stored version depth (op-log pruning keeps that small, so the sort is
-  // sub-ms in practice). If a real-Postgres EXPLAIN on a deep-history entity ever
-  // shows this hot path (run per single-entity upload) is a problem, split into two
-  // ordered LIMIT-1 lookups (scalar btree + entity_ids GIN) and take the higher
-  // server_seq — the array branch stays small because entity_ids is multi-entity-only.
-  // The batch unnest paths (detectConflictForEntities / prefetchLatestEntityOpsForBatch)
-  // carry the larger sort, so EXPLAIN those first under heavy-user latency.
-  const existingOp = await tx.operation.findFirst({
-    where: {
-      userId,
-      entityType: op.entityType,
-      OR: [{ entityId }, { entityIds: { has: entityId } }],
-    },
+  // PERF — this must stay TWO separately-indexed lookups. It was one Prisma filter
+  // (`OR: [{ entityId }, { entityIds: { has: entityId } }]` +
+  // `orderBy: { serverSeq: 'desc' }`), and that took production down. The OR spans
+  // two different indexes — the (user_id, entity_type, entity_id, server_seq) btree
+  // and the entity_ids GIN — and GIN cannot supply server_seq ordering, so the
+  // planner abandons BOTH index paths and walks (user_id, server_seq) backwards
+  // applying the OR as a filter, betting `LIMIT 1` is satisfied early. For an entity
+  // with no matching rows — the first-ever op for a new task, the single most common
+  // upload there is — that bet loses and it scans the user's entire operation
+  // history, worst for the deepest histories.
+  //
+  // Live evidence (sync.super-productivity.com): 47 backends stuck on exactly this
+  // query, the longest running 75 MINUTES, wait_event=DataFileRead, 61 of 66
+  // connections active → Prisma pool exhaustion → every user's upload AND download
+  // failing with "Unable to start a transaction in the given time". Not a missing
+  // index: every index on `operations` was valid. The previous comment here asserted
+  // the planner would pick a BitmapOr + sort instead; production disproved that.
+  //
+  // Why it looked fine and then wasn't: the planner only takes the walk when it has
+  // NO array-element statistics for entity_ids. Without them it falls back to a
+  // default `@>` selectivity (0.5%) and estimates ~150 of 30k rows match, so LIMIT 1
+  // looks like it exits after ~200 rows. Populate entity_ids on even 6 rows in 30k
+  // and ANALYZE, and the estimate drops to ~1 row and BitmapOr wins. Empty is the
+  // DEPLOYED state: entity_ids was added by 20260613000000 with no backfill, and
+  // getStoredEntityIds stores [] for every single-entity op. Statistics are also
+  // table-wide, so if ANALYZE's sample holds no non-empty array, every user's
+  // uploads degenerate at once — a cliff, not a gradual slope. Re-EXPLAIN on a
+  // table with populated entity_ids and you will wrongly conclude this is fine;
+  // conflict-entity-lookup-plan.pglite.spec.ts pins the real conditions.
+  //
+  // Carried over from the comment this replaces: the batch unnest paths
+  // (detectConflictForEntities / prefetchLatestEntityOpsForBatch) rest on the same
+  // missing entity_ids statistics. They are NOT exposed to this trap — no LIMIT, and
+  // DISTINCT ON forces full evaluation of the matching set, so the "LIMIT 1 exits
+  // early" bet cannot be made — but EXPLAIN them first if heavy-user latency returns.
+  //
+  // Scalar branch: the (user_id, entity_type, entity_id, server_seq) btree covers all
+  // three equality columns PLUS the sort column, so this is a direct index seek and a
+  // one-step backward walk. No trap — the ORDER BY is served by the index itself.
+  const scalarOp = await tx.operation.findFirst({
+    where: { userId, entityType: op.entityType, entityId },
     select: { actionType: true, clientId: true, vectorClock: true, serverSeq: true },
     orderBy: { serverSeq: 'desc' },
   });
+
+  // Array branch — deliberately an aggregate, NOT
+  // `findFirst({ entityIds: { has: entityId }, orderBy: { serverSeq: 'desc' } })`.
+  // That naive form REINTRODUCES the incident above: GIN still cannot order, so the
+  // planner can still choose the LIMIT-driven backward walk (verified — it produces
+  // a byte-identical bad plan; pinned by conflict-entity-lookup-plan.pglite.spec.ts).
+  //
+  // Prisma compiles `aggregate` to `SELECT MAX(x) FROM (SELECT ... OFFSET 0) sub`,
+  // and that `OFFSET 0` is a Postgres planner optimization fence. Here the fence is
+  // exactly what we want: it FORBIDS the ordered LIMIT-1 walk and forces the GIN
+  // bitmap path, whose cost is bounded by actually-matching rows (zero, for a new
+  // entity). This is the SAME construct that caused a DIFFERENT incident in
+  // 410dac6785 (op-download minSeq), where a first-row index seek WAS wanted and the
+  // fence prevented it. Right here, wrong there — do not "optimize" this back into a
+  // findFirst. Sequential, never Promise.all: `tx` is a single-connection interactive
+  // transaction client and concurrent queries on it are unsafe.
+  //
+  // Verified against production Postgres (user with 88k ops, probing an entity id with
+  // zero matches — the pathological case): this branch plans as
+  // Aggregate → Bitmap Heap Scan → Bitmap Index Scan on operations_entity_ids_gin.
+  // Measured AFTER an ANALYZE and a GIN pending-list flush: old OR shape 12 buffers,
+  // this split 9 (scalar 4 + array 5). In that regime the two are COMPARABLE — the
+  // point of the split is not throughput, it is that neither branch offers the planner
+  // a LIMIT-driven early-exit bet, so it cannot degenerate into the backward walk no
+  // matter what the statistics say. (Wall-clock on a live server is too noisy to quote:
+  // the same old-shape query measured 255ms and 915ms on consecutive runs while its
+  // buffer count fell. Compare buffers, not milliseconds.)
+  //
+  // The old shape stays one autovacuum re-sample away from the incident plan: even
+  // post-ANALYZE the planner still estimates rows=96 for a zero-match `entity_ids @>`
+  // key, so the selectivity estimate is NOT fixed — the good plan is luck holding.
+  //
+  // LOAD-BEARING AND UNTESTED: the fence is a Prisma implementation detail. The PGlite
+  // spec hand-writes the SQL rather than invoking Prisma, so if a Prisma upgrade stops
+  // emitting `OFFSET 0`, the suite stays green while production silently regresses to
+  // the incident plan. On any Prisma major bump, re-run the EXPLAIN above before
+  // shipping.
+  const arrayBranchMax = await tx.operation.aggregate({
+    where: { userId, entityType: op.entityType, entityIds: { has: entityId } },
+    _max: { serverSeq: true },
+  });
+  const arrayBranchMaxSeq = arrayBranchMax._max.serverSeq ?? null;
+
+  // Fetch the array-branch row only when it actually beats the scalar branch.
+  // (user_id, server_seq) is UNIQUE, so this is a single indexed point lookup, and
+  // ties need no tie-break: an equal server_seq IS the same row.
+  //
+  // NEGATIVE_INFINITY, not -1: server_seq is >= 1 today, so -1 would work — but if a
+  // sentinel ever collided the array branch would lose to a non-existent scalar row
+  // and the op would be accepted as conflict-free, silently overwriting a remote edit.
+  // Sentinel-free comparison costs nothing and removes that failure mode entirely.
+  const arrayOp =
+    arrayBranchMaxSeq !== null &&
+    arrayBranchMaxSeq > (scalarOp?.serverSeq ?? Number.NEGATIVE_INFINITY)
+      ? await tx.operation.findUnique({
+          where: { userId_serverSeq: { userId, serverSeq: arrayBranchMaxSeq } },
+          select: {
+            actionType: true,
+            clientId: true,
+            vectorClock: true,
+            serverSeq: true,
+          },
+        })
+      : null;
+
+  const existingOp = arrayOp ?? scalarOp;
 
   // Histories written before schema v2 persist migrated task settings under
   // the raw `GLOBAL_CONFIG:misc` key. Consult that key as an alias when the

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -243,24 +243,19 @@ export const detectConflictForEntity = async (
 
   // Array branch — raw SQL, and the MATERIALIZED CTE is load-bearing.
   //
-  // MEASURE WITH `SET plan_cache_mode = force_generic_plan`, NEVER WITH LITERALS.
-  // Prisma sends parameterized prepared statements, so Postgres builds a GENERIC plan
-  // that cannot see the parameter values; EXPLAIN with literal constants yields a
-  // CUSTOM plan production never receives. Every simpler form measures perfect under
-  // literals and reads the whole (user_id, entity_type) slice under generic planning —
-  // the array-only `findFirst` + `orderBy` (the outage), Prisma's
-  // `aggregate({ _max })` (`MAX(...) FROM (... OFFSET 0)`), and the natural-looking
-  // flat `SELECT MAX(server_seq) ... WHERE user_id=$ AND entity_type=$ AND @>`. The
-  // last two drop LIMIT's early-exit bet but still get the composite btree with
-  // `entity_ids @> $` demoted to a Filter.
-  //
   // The CTE wins STRUCTURALLY, not on cost: inside it the only predicate is
-  // `entity_ids @> ...`, so the composite btree has no usable leading column and GIN
-  // is the only index available at ANY cost estimate. MATERIALIZED stops the outer
-  // user_id / entity_type predicates being pushed down, which would hand the btree
-  // back. All four forms are measured against this one in
-  // conflict-entity-lookup-plan.pglite.spec.ts, which fails on a block budget if any
-  // of them is reintroduced — including dropping the MATERIALIZED keyword alone.
+  // `entity_ids @> ...`, so the composite btree has no usable leading column and GIN is
+  // the only index available at ANY cost estimate. MATERIALIZED is what stops the outer
+  // user_id / entity_type predicates being pushed down, which would hand the btree back.
+  // Every simpler form reads the whole (user_id, entity_type) slice instead: the
+  // array-only `findFirst` + `orderBy` (the outage), Prisma's `aggregate({ _max })`, and
+  // the flat `SELECT MAX(server_seq) ... AND @>`.
+  //
+  // Do NOT "simplify" this without measuring under `plan_cache_mode =
+  // force_generic_plan` — Prisma sends parameterized prepared statements, so EXPLAIN
+  // with literal constants shows a custom plan production never gets, and every one of
+  // those forms looks perfect that way. conflict-entity-lookup-plan.pglite.spec.ts
+  // measures it correctly and fails on a block budget.
   //
   // Adding `server_seq > <scalar seq>` to narrow the CTE was evaluated and REJECTED:
   // under generic planning the bound is invisible, so it lands as a post-GIN Filter
@@ -269,18 +264,23 @@ export const detectConflictForEntity = async (
   // full-index scan across every user's history.
   //
   // Isolation: the CTE matches by entity id across ALL users and the outer WHERE
-  // enforces the user boundary, so this is CORRECT but NOT cost-bounded per user.
-  // Entity ids are not all client-generated nanoids — the client hard-codes globally
-  // shared ids that are byte-identical for every user on the server: 'TODAY',
-  // 'EM_URGENT', 'EM_IMPORTANT', 'KANBAN_IN_PROGRESS' (tag.const.ts), 'INBOX_PROJECT'
-  // (project.const.ts), 'EISENHOWER_MATRIX', 'KANBAN_DEFAULT' (boards.const.ts), plus
-  // the fixed GLOBAL_CONFIG keys. `updateBoard({ id: 'KANBAN_DEFAULT' })` is
-  // single-entity, so it routes here and probes that literal across every tenant. At
-  // 200k ops / 2000 tenants that measured 3885 blocks to reach the 10 rows belonging
-  // to the probing user, against 4 blocks for a genuinely unique id — it scales with
-  // total server population, bounded by nothing. The fix is a btree_gin composite
-  // index on (user_id, entity_ids); it needs a real-Postgres EXPLAIN to confirm, as
-  // PGlite has no btree_gin.
+  // enforces the user boundary, so this is CORRECT but NOT cost-bounded per user. Some
+  // entity ids are byte-identical across every tenant: the bulk `sortBoards` action
+  // (boards.actions.ts) stores the hard-coded 'EISENHOWER_MATRIX' / 'KANBAN_DEFAULT'
+  // ids (boards.const.ts) in entity_ids, so probing one walks every tenant's matching
+  // rows and the cost scales with total server population, bounded by nothing.
+  // Single-entity writes against a shared id — updateTag({ id: 'TODAY' }),
+  // updateBoard({ id: 'KANBAN_DEFAULT' }) — are NOT a vector: getStoredEntityIds
+  // persists '{}' for them, so they never enter the GIN under that id at all.
+  //
+  // The fix is a GIN index on the expression (ARRAY['u:' || user_id] || entity_ids),
+  // which makes the probe flat. It needs no btree_gin extension (the operand is text[],
+  // served by the built-in array_ops) and is measurable in PGlite. Not done here
+  // because it is a real tradeoff, not a free win: this predicate must be rewritten to
+  // match the expression or the index is simply ignored, and it indexes EVERY row
+  // rather than only the multi-entity minority, so every insert maintains it. The outer
+  // user_id predicate stays load-bearing either way — the 'u:' prefix is a namespace,
+  // not a security boundary.
   //
   // Sequential, never Promise.all: `tx` is a single-connection interactive transaction
   // client and concurrent queries on it are unsafe.

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -243,10 +243,19 @@ export const detectConflictForEntity = async (
 
   // Array branch — raw SQL, and the MATERIALIZED CTE is load-bearing.
   //
-  // The CTE wins STRUCTURALLY, not on cost: inside it the only predicate is
-  // `entity_ids @> ...`, so the composite btree has no usable leading column and GIN is
-  // the only index available at ANY cost estimate. MATERIALIZED is what stops the outer
-  // user_id / entity_type predicates being pushed down, which would hand the btree back.
+  // What the CTE removes structurally is the COMPETING BTREE: inside it the only
+  // predicate is `entity_ids @> ...`, so the composite btree has no usable leading
+  // column and GIN is the only INDEX available at any cost estimate. MATERIALIZED is
+  // what stops the outer user_id / entity_type predicates being pushed down, which
+  // would hand the btree back.
+  //
+  // That is NOT a guarantee that GIN is chosen. A sequential scan is always still
+  // available, and wins when the probed id is unselective — both plans have been
+  // reproduced on PG16 depending on row shape (see the cross-tenant note below, where a
+  // shared id produces a Seq Scan). GIN winning on production-shaped data is a MEASURED
+  // outcome, not a structural one. Re-measure after any change rather than trusting
+  // this paragraph; a confidently-worded comment asserting what the planner "will" do
+  // is what preceded the outage.
   // Every simpler form reads the whole (user_id, entity_type) slice instead: the
   // array-only `findFirst` + `orderBy` (the outage), Prisma's `aggregate({ _max })`, and
   // the flat `SELECT MAX(server_seq) ... AND @>`.

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -224,36 +224,13 @@ export const detectConflictForEntity = async (
   // `orderBy: { serverSeq: 'desc' }`), and that took production down. The OR spans
   // two different indexes — the (user_id, entity_type, entity_id, server_seq) btree
   // and the entity_ids GIN — and GIN cannot supply server_seq ordering, so the
-  // planner abandons BOTH index paths and walks (user_id, server_seq) backwards
-  // applying the OR as a filter, betting `LIMIT 1` is satisfied early. For an entity
-  // with no matching rows — the first-ever op for a new task, the single most common
-  // upload there is — that bet loses and it scans the user's entire operation
-  // history, worst for the deepest histories.
-  //
-  // Live evidence (sync.super-productivity.com): 47 backends stuck on exactly this
-  // query, the longest running 75 MINUTES, wait_event=DataFileRead, 61 of 66
-  // connections active → Prisma pool exhaustion → every user's upload AND download
-  // failing with "Unable to start a transaction in the given time". Not a missing
-  // index: every index on `operations` was valid. The previous comment here asserted
-  // the planner would pick a BitmapOr + sort instead; production disproved that.
-  //
-  // Why it looked fine and then wasn't: the planner only takes the walk when it has
-  // NO array-element statistics for entity_ids. Without them it falls back to a
-  // default `@>` selectivity (0.5%) and estimates ~150 of 30k rows match, so LIMIT 1
-  // looks like it exits after ~200 rows. Populate entity_ids on even 6 rows in 30k
-  // and ANALYZE, and the estimate drops to ~1 row and BitmapOr wins. Empty is the
-  // DEPLOYED state: entity_ids was added by 20260613000000 with no backfill, and
-  // getStoredEntityIds stores [] for every single-entity op. Statistics are also
-  // table-wide, so if ANALYZE's sample holds no non-empty array, every user's
-  // uploads degenerate at once — a cliff, not a gradual slope. Re-EXPLAIN on a
-  // table with populated entity_ids and you will wrongly conclude this is fine;
-  // conflict-entity-lookup-plan.pglite.spec.ts pins the real conditions.
-  //
-  // Carried over from the comment this replaces: the batch unnest paths
-  // (detectConflictForEntities / prefetchLatestEntityOpsForBatch) rest on the same
-  // missing entity_ids statistics. They are NOT exposed to this trap — no LIMIT, and
-  // DISTINCT ON forces full evaluation of the matching set, so the "LIMIT 1 exits
-  // early" bet cannot be made — but EXPLAIN them first if heavy-user latency returns.
+  // planner abandons BOTH index paths, filters the (user_id, entity_type) slice and
+  // sorts it (or walks (user_id, server_seq) backwards, betting `LIMIT 1` resolves
+  // early). For an entity with no matching rows — the first-ever op for a new task,
+  // the single most common upload there is — nothing bounds that work and it reads
+  // the user's whole slice. The batch unnest paths (detectConflictForEntities /
+  // prefetchLatestEntityOpsForBatch) are NOT exposed: no LIMIT, and DISTINCT ON
+  // forces full evaluation, so the early-exit bet cannot be made.
   //
   // Scalar branch: the (user_id, entity_type, entity_id, server_seq) btree covers all
   // three equality columns PLUS the sort column, so this is a direct index seek and a
@@ -264,69 +241,76 @@ export const detectConflictForEntity = async (
     orderBy: { serverSeq: 'desc' },
   });
 
-  // Array branch — deliberately an aggregate, NOT
-  // `findFirst({ entityIds: { has: entityId }, orderBy: { serverSeq: 'desc' } })`.
-  // That naive form REINTRODUCES the incident above: GIN still cannot order, so the
-  // planner can still choose the LIMIT-driven backward walk (verified — it produces
-  // a byte-identical bad plan; pinned by conflict-entity-lookup-plan.pglite.spec.ts).
+  // Array branch — raw SQL, and the MATERIALIZED CTE is load-bearing.
   //
-  // Prisma compiles `aggregate` to `SELECT MAX(x) FROM (SELECT ... OFFSET 0) sub`,
-  // and that `OFFSET 0` is a Postgres planner optimization fence. Here the fence is
-  // exactly what we want: it FORBIDS the ordered LIMIT-1 walk and forces the GIN
-  // bitmap path, whose cost is bounded by actually-matching rows (zero, for a new
-  // entity). This is the SAME construct that caused a DIFFERENT incident in
-  // 410dac6785 (op-download minSeq), where a first-row index seek WAS wanted and the
-  // fence prevented it. Right here, wrong there — do not "optimize" this back into a
-  // findFirst. Sequential, never Promise.all: `tx` is a single-connection interactive
-  // transaction client and concurrent queries on it are unsafe.
+  // MEASURE WITH `SET plan_cache_mode = force_generic_plan`, NEVER WITH LITERALS.
+  // Prisma sends parameterized prepared statements, so Postgres builds a GENERIC plan
+  // that cannot see the parameter values; EXPLAIN with literal constants yields a
+  // CUSTOM plan production never receives. Every simpler form measures perfect under
+  // literals and reads the whole (user_id, entity_type) slice under generic planning —
+  // the array-only `findFirst` + `orderBy` (the outage), Prisma's
+  // `aggregate({ _max })` (`MAX(...) FROM (... OFFSET 0)`), and the natural-looking
+  // flat `SELECT MAX(server_seq) ... WHERE user_id=$ AND entity_type=$ AND @>`. The
+  // last two drop LIMIT's early-exit bet but still get the composite btree with
+  // `entity_ids @> $` demoted to a Filter.
   //
-  // Verified against production Postgres (user with 88k ops, probing an entity id with
-  // zero matches — the pathological case): this branch plans as
-  // Aggregate → Bitmap Heap Scan → Bitmap Index Scan on operations_entity_ids_gin.
-  // Measured AFTER an ANALYZE and a GIN pending-list flush: old OR shape 12 buffers,
-  // this split 9 (scalar 4 + array 5). In that regime the two are COMPARABLE — the
-  // point of the split is not throughput, it is that neither branch offers the planner
-  // a LIMIT-driven early-exit bet, so it cannot degenerate into the backward walk no
-  // matter what the statistics say. (Wall-clock on a live server is too noisy to quote:
-  // the same old-shape query measured 255ms and 915ms on consecutive runs while its
-  // buffer count fell. Compare buffers, not milliseconds.)
+  // The CTE wins STRUCTURALLY, not on cost: inside it the only predicate is
+  // `entity_ids @> ...`, so the composite btree has no usable leading column and GIN
+  // is the only index available at ANY cost estimate. MATERIALIZED stops the outer
+  // user_id / entity_type predicates being pushed down, which would hand the btree
+  // back. All four forms are measured against this one in
+  // conflict-entity-lookup-plan.pglite.spec.ts, which fails on a block budget if any
+  // of them is reintroduced — including dropping the MATERIALIZED keyword alone.
   //
-  // The old shape stays one autovacuum re-sample away from the incident plan: even
-  // post-ANALYZE the planner still estimates rows=96 for a zero-match `entity_ids @>`
-  // key, so the selectivity estimate is NOT fixed — the good plan is luck holding.
+  // Adding `server_seq > <scalar seq>` to narrow the CTE was evaluated and REJECTED:
+  // under generic planning the bound is invisible, so it lands as a post-GIN Filter
+  // and buys nothing, and inside the CTE it lets a custom plan bitmap-scan
+  // (user_id, server_seq) on `server_seq > $4` with NO leading-column bound — a
+  // full-index scan across every user's history.
   //
-  // LOAD-BEARING AND UNTESTED: the fence is a Prisma implementation detail. The PGlite
-  // spec hand-writes the SQL rather than invoking Prisma, so if a Prisma upgrade stops
-  // emitting `OFFSET 0`, the suite stays green while production silently regresses to
-  // the incident plan. On any Prisma major bump, re-run the EXPLAIN above before
-  // shipping.
-  const arrayBranchMax = await tx.operation.aggregate({
-    where: { userId, entityType: op.entityType, entityIds: { has: entityId } },
-    _max: { serverSeq: true },
-  });
-  const arrayBranchMaxSeq = arrayBranchMax._max.serverSeq ?? null;
+  // Isolation: the CTE matches by entity id across ALL users and the outer WHERE
+  // enforces the user boundary, so this is CORRECT but NOT cost-bounded per user.
+  // Entity ids are not all client-generated nanoids — the client hard-codes globally
+  // shared ids that are byte-identical for every user on the server: 'TODAY',
+  // 'EM_URGENT', 'EM_IMPORTANT', 'KANBAN_IN_PROGRESS' (tag.const.ts), 'INBOX_PROJECT'
+  // (project.const.ts), 'EISENHOWER_MATRIX', 'KANBAN_DEFAULT' (boards.const.ts), plus
+  // the fixed GLOBAL_CONFIG keys. `updateBoard({ id: 'KANBAN_DEFAULT' })` is
+  // single-entity, so it routes here and probes that literal across every tenant —
+  // measured 3752 blocks to reach 20 relevant rows at 200k ops / 2000 tenants, scaling
+  // with total server population and bounded by nothing. The fix is a btree_gin
+  // composite index on (user_id, entity_ids); it needs a real-Postgres EXPLAIN to
+  // confirm, as PGlite has no btree_gin.
+  //
+  // Sequential, never Promise.all: `tx` is a single-connection interactive transaction
+  // client and concurrent queries on it are unsafe.
+  const arrayBranchRows = await tx.$queryRaw<Array<{ maxSeq: number | null }>>`
+    WITH cand AS MATERIALIZED (
+      SELECT user_id, entity_type, server_seq
+      FROM operations
+      WHERE entity_ids @> ARRAY[${entityId}]::text[]
+    )
+    SELECT MAX(server_seq)::int AS "maxSeq"
+    FROM cand
+    WHERE user_id = ${userId} AND entity_type = ${op.entityType}
+  `;
+  const arrayBranchMaxSeq = arrayBranchRows[0]?.maxSeq ?? null;
 
   // Fetch the array-branch row only when it actually beats the scalar branch.
   // (user_id, server_seq) is UNIQUE, so this is a single indexed point lookup, and
   // ties need no tie-break: an equal server_seq IS the same row.
-  //
-  // NEGATIVE_INFINITY, not -1: server_seq is >= 1 today, so -1 would work — but if a
-  // sentinel ever collided the array branch would lose to a non-existent scalar row
-  // and the op would be accepted as conflict-free, silently overwriting a remote edit.
-  // Sentinel-free comparison costs nothing and removes that failure mode entirely.
-  const arrayOp =
-    arrayBranchMaxSeq !== null &&
-    arrayBranchMaxSeq > (scalarOp?.serverSeq ?? Number.NEGATIVE_INFINITY)
-      ? await tx.operation.findUnique({
-          where: { userId_serverSeq: { userId, serverSeq: arrayBranchMaxSeq } },
-          select: {
-            actionType: true,
-            clientId: true,
-            vectorClock: true,
-            serverSeq: true,
-          },
-        })
-      : null;
+  const arrayWins =
+    arrayBranchMaxSeq !== null && (!scalarOp || arrayBranchMaxSeq > scalarOp.serverSeq);
+  const arrayOp = arrayWins
+    ? await tx.operation.findUnique({
+        where: { userId_serverSeq: { userId, serverSeq: arrayBranchMaxSeq } },
+        select: {
+          actionType: true,
+          clientId: true,
+          vectorClock: true,
+          serverSeq: true,
+        },
+      })
+    : null;
 
   const existingOp = arrayOp ?? scalarOp;
 
@@ -550,10 +534,15 @@ const isLegacyMiscConfigOperation = (op: Operation): boolean =>
 
 /**
  * The entity_ids array to persist with an op. Ops whose touched-entity set is
- * already covered by the scalar entity_id store an empty array, so single-entity
- * ops (the vast majority) stay out of the entity_ids GIN index — keeping it small
- * and off their insert write path (Postgres GIN indexes no keys for an empty
- * array). Any other set is stored in full.
+ * already covered by the scalar entity_id store an empty array; any other set is
+ * stored in full.
+ *
+ * This makes the entity_ids GIN index CHEAP, not absent. Postgres indexes an empty
+ * array as one degenerate GIN_CAT_EMPTY_ITEM key, so single-entity ops DO have index
+ * entries, the index grows with row count (measured on an all-empty column: 10k rows
+ * → 5 pages, 30k → 7, 60k → 11) and every insert still touches it. The win is one
+ * key per single-entity op instead of one key per member, which keeps
+ * `entity_ids @> ARRAY[id]` probes bounded by genuine multi-entity matches.
  *
  * The gate is "is the set exactly [entity_id]?", NOT "length > 1": a batch op
  * whose ids dedup to a single value that differs from entity_id (the server does

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -275,11 +275,12 @@ export const detectConflictForEntity = async (
   // 'EM_URGENT', 'EM_IMPORTANT', 'KANBAN_IN_PROGRESS' (tag.const.ts), 'INBOX_PROJECT'
   // (project.const.ts), 'EISENHOWER_MATRIX', 'KANBAN_DEFAULT' (boards.const.ts), plus
   // the fixed GLOBAL_CONFIG keys. `updateBoard({ id: 'KANBAN_DEFAULT' })` is
-  // single-entity, so it routes here and probes that literal across every tenant —
-  // measured 3752 blocks to reach 20 relevant rows at 200k ops / 2000 tenants, scaling
-  // with total server population and bounded by nothing. The fix is a btree_gin
-  // composite index on (user_id, entity_ids); it needs a real-Postgres EXPLAIN to
-  // confirm, as PGlite has no btree_gin.
+  // single-entity, so it routes here and probes that literal across every tenant. At
+  // 200k ops / 2000 tenants that measured 3885 blocks to reach the 10 rows belonging
+  // to the probing user, against 4 blocks for a genuinely unique id — it scales with
+  // total server population, bounded by nothing. The fix is a btree_gin composite
+  // index on (user_id, entity_ids); it needs a real-Postgres EXPLAIN to confirm, as
+  // PGlite has no btree_gin.
   //
   // Sequential, never Promise.all: `tx` is a single-connection interactive transaction
   // client and concurrent queries on it are unsafe.

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -231,8 +231,10 @@ export const detectConflictForEntity = async (
   // early). For an entity with no matching rows — the first-ever op for a new task,
   // the single most common upload there is — nothing bounds that work and it reads
   // the user's whole slice. The batch unnest paths (detectConflictForEntities /
-  // prefetchLatestEntityOpsForBatch) are NOT exposed: no LIMIT, and DISTINCT ON
-  // forces full evaluation, so the early-exit bet cannot be made.
+  // prefetchLatestEntityOpsForBatch) cannot make that EARLY-EXIT bet — no LIMIT, and
+  // DISTINCT ON forces full evaluation. They carry the same two-index OR, though, so
+  // the SLICE-SCAN degeneracy is not excluded for them, and nothing EXPLAINs either
+  // batch query today (#9205).
   //
   // Scalar branch: the (user_id, entity_type, entity_id, server_seq) btree covers all
   // three equality columns PLUS the sort column, so this is a direct index seek and a
@@ -253,14 +255,14 @@ export const detectConflictForEntity = async (
   //
   // That is NOT a guarantee that GIN is chosen. A sequential scan is always still
   // available, and wins when the probed id is unselective — both plans have been
-  // reproduced on PG16 depending on row shape (see the cross-tenant note below, where a
-  // shared id produces a Seq Scan). GIN winning on production-shaped data is a MEASURED
+  // reproduced on PG16 depending on row shape. GIN winning on production-shaped data is a MEASURED
   // outcome, not a structural one. Re-measure after any change rather than trusting
   // this paragraph; a confidently-worded comment asserting what the planner "will" do
   // is what preceded the outage.
   // Every simpler form reads the whole (user_id, entity_type) slice instead: the
-  // array-only `findFirst` + `orderBy` (the outage), Prisma's `aggregate({ _max })`, and
-  // the flat `SELECT MAX(server_seq) ... AND @>`.
+  // array-only `findFirst` + `orderBy`, Prisma's `aggregate({ _max })`, and the flat
+  // `SELECT MAX(server_seq) ... AND @>`. (The outage itself was the combined OR
+  // described above, not any of these.)
   //
   // Do NOT "simplify" this without measuring under `plan_cache_mode =
   // force_generic_plan`. Prisma sends parameterized prepared statements; under the
@@ -287,17 +289,23 @@ export const detectConflictForEntity = async (
   // ids (boards.const.ts) in entity_ids, so probing one walks every tenant's matching
   // rows and the cost scales with total server population, bounded by nothing.
   // Single-entity writes against a shared id — updateTag({ id: 'TODAY' }),
-  // updateBoard({ id: 'KANBAN_DEFAULT' }) — are NOT a vector: getStoredEntityIds
-  // persists '{}' for them, so they never enter the GIN under that id at all.
+  // updateBoard({ id: 'KANBAN_DEFAULT' }) — do not POPULATE the GIN under that id:
+  // getStoredEntityIds persists '{}' for them. They are still a PROBE vector, though.
+  // Each one routes through detectConflictForEntity and probes that shared literal, so
+  // it walks every tenant's matching rows without contributing any of its own.
   //
   // The fix is a GIN index on the expression (ARRAY['u:' || user_id] || entity_ids),
   // which makes the probe flat. It needs no btree_gin extension (the operand is text[],
   // served by the built-in array_ops) and is measurable in PGlite. Not done here
   // because it is a real tradeoff, not a free win: this predicate must be rewritten to
-  // match the expression or the index is simply ignored, and it indexes EVERY row
-  // rather than only the multi-entity minority, so every insert maintains it. The outer
-  // user_id predicate stays load-bearing either way — the 'u:' prefix is a namespace,
-  // not a security boundary.
+  // match the expression or the index is simply ignored. Make it PARTIAL
+  // (WHERE entity_ids <> '{}') and it covers only the multi-entity minority instead of
+  // every row. That is lossless: a single-entity op stores '{}', so its indexed
+  // expression is just ARRAY['u:<id>'] and can never contain the real entity id a probe
+  // carries. The catch is that the query must then carry a matching
+  // `AND entity_ids <> '{}'` predicate, or Postgres cannot prove the partial index
+  // applies and ignores it. The outer user_id predicate stays load-bearing either way —
+  // the 'u:' prefix is a namespace, not a security boundary.
   //
   // Sequential, never Promise.all: `tx` is a single-connection interactive transaction
   // client and concurrent queries on it are unsafe.
@@ -312,13 +320,15 @@ export const detectConflictForEntity = async (
     WHERE user_id = ${userId} AND entity_type = ${op.entityType}
   `;
   // INVARIANT: an aggregate with no GROUP BY returns exactly one row, so the `?.`
-  // fold below is unreachable and `maxSeq` is null only when nothing matched. Add a
-  // GROUP BY and zero rows becomes possible — at which point this reads as "no prior
-  // op" and the upload is ACCEPTED. (Prisma's bare `aggregate()` is NOT such a case:
-  // it returns one object with `_max.serverSeq: null`, so it fails differently. The
-  // failure mode is silent acceptance of a conflicting write, not an error.) No
-  // runtime guard here on purpose (it could never fire today); if you change the
-  // shape of this query, change this fold with it.
+  // fold below is unreachable and `maxSeq` is null only when nothing matched.
+  // `GROUP BY user_id` would NOT break that: zero groups arise only when zero rows
+  // matched, which folds to null and correctly reads as "no prior op" — the same
+  // outcome as `MAX` over no rows. What DOES break it is any grouping that can return
+  // more than one row (`GROUP BY server_seq`, say), because `[0]` then takes an
+  // arbitrary group instead of the maximum and can under-report the latest op — silent
+  // acceptance of a conflicting write, not an error. No runtime guard here on purpose
+  // (it could never fire today); if you change the shape of this query, change this
+  // fold with it.
   const arrayBranchMaxSeq = arrayBranchRows[0]?.maxSeq ?? null;
 
   // Fetch the array-branch row only when it actually beats the scalar branch.

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -204,9 +204,11 @@ export const resolveConflictForExistingOp = (
 };
 
 /**
- * Checks conflicts for the common single-entity upload path using Prisma's
- * typed model API. Multi-entity operations use the batched raw-SQL path above
- * to avoid one round trip per entity.
+ * Checks conflicts for the common single-entity upload path. TWO separately-indexed
+ * lookups: a typed `findFirst` on the scalar entity_id, plus a raw-SQL MATERIALIZED CTE
+ * over entity_ids — see the PERF note below, the combined filter caused an outage.
+ * Multi-entity operations use the batched raw-SQL path above instead, to avoid one round
+ * trip per entity.
  */
 export const detectConflictForEntity = async (
   userId: number,
@@ -261,10 +263,16 @@ export const detectConflictForEntity = async (
   // the flat `SELECT MAX(server_seq) ... AND @>`.
   //
   // Do NOT "simplify" this without measuring under `plan_cache_mode =
-  // force_generic_plan` — Prisma sends parameterized prepared statements, so EXPLAIN
-  // with literal constants shows a custom plan production never gets, and every one of
-  // those forms looks perfect that way. conflict-entity-lookup-plan.pglite.spec.ts
-  // measures it correctly and fails on a block budget.
+  // force_generic_plan`. Prisma sends parameterized prepared statements; under the
+  // default `auto` Postgres plans the first ~5 executions as CUSTOM, then compares the
+  // generic cost against the average custom cost and MAY switch to a generic plan. That
+  // is a cost comparison, not an automatic switch — a statement can stay on custom plans
+  // indefinitely. THIS statement was observed going generic on production
+  // (pg_prepared_statements: custom_plans=5, generic_plans=15), and a generic plan cannot
+  // see the parameter values. `EXPLAIN` with literal constants is different again, and
+  // every broken form above looks perfect that way.
+  // conflict-entity-lookup-plan.pglite.spec.ts measures the generic mode correctly and
+  // fails on a block budget; it does NOT cover custom plans.
   //
   // Adding `server_seq > <scalar seq>` to narrow the CTE was evaluated and REJECTED:
   // under generic planning the bound is invisible, so it lands as a post-GIN Filter
@@ -305,9 +313,10 @@ export const detectConflictForEntity = async (
   `;
   // INVARIANT: an aggregate with no GROUP BY returns exactly one row, so the `?.`
   // fold below is unreachable and `maxSeq` is null only when nothing matched. Add a
-  // GROUP BY, or go back to Prisma's aggregate(), and zero rows becomes possible —
-  // at which point this reads as "no prior op" and the upload is ACCEPTED. The
-  // failure mode is silent acceptance of a conflicting write, not an error. No
+  // GROUP BY and zero rows becomes possible — at which point this reads as "no prior
+  // op" and the upload is ACCEPTED. (Prisma's bare `aggregate()` is NOT such a case:
+  // it returns one object with `_max.serverSeq: null`, so it fails differently. The
+  // failure mode is silent acceptance of a conflicting write, not an error.) No
   // runtime guard here on purpose (it could never fire today); if you change the
   // shape of this query, change this fold with it.
   const arrayBranchMaxSeq = arrayBranchRows[0]?.maxSeq ?? null;

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -294,6 +294,13 @@ export const detectConflictForEntity = async (
     FROM cand
     WHERE user_id = ${userId} AND entity_type = ${op.entityType}
   `;
+  // INVARIANT: an aggregate with no GROUP BY returns exactly one row, so the `?.`
+  // fold below is unreachable and `maxSeq` is null only when nothing matched. Add a
+  // GROUP BY, or go back to Prisma's aggregate(), and zero rows becomes possible —
+  // at which point this reads as "no prior op" and the upload is ACCEPTED. The
+  // failure mode is silent acceptance of a conflicting write, not an error. No
+  // runtime guard here on purpose (it could never fire today); if you change the
+  // shape of this query, change this fold with it.
   const arrayBranchMaxSeq = arrayBranchRows[0]?.maxSeq ?? null;
 
   // Fetch the array-branch row only when it actually beats the scalar branch.
@@ -313,6 +320,13 @@ export const detectConflictForEntity = async (
       })
     : null;
 
+  // This `??` carries TWO meanings: "the array branch did not win" and "the array
+  // branch won but its row was not there". Only the first is reachable — the MAX came
+  // from a row in this transaction's snapshot and (user_id, server_seq) is unique, so
+  // at RepeatableRead the row cannot vanish under us. If the isolation level is ever
+  // lowered, the second case silently falls back to the STALE scalar row and accepts a
+  // write that should have conflicted. Retiring the separate findUnique (see the
+  // row-returning CTE, #9197) removes this ambiguity rather than guarding it.
   const existingOp = arrayOp ?? scalarOp;
 
   // Histories written before schema v2 persist migrated task settings under

--- a/packages/super-sync-server/tests/conflict-detection.spec.ts
+++ b/packages/super-sync-server/tests/conflict-detection.spec.ts
@@ -8,6 +8,8 @@ vi.mock('../src/db', async () => {
   const {
     applyOperationSelect,
     hasOperationUniqueConflict,
+    isEntityArrayBranchQuery,
+    entityArrayBranchRows,
     testState: state,
   } = await import('./sync.service.test-state');
   const { Prisma: PrismaModule } = await import('@prisma/client');
@@ -102,23 +104,7 @@ vi.mock('../src/db', async () => {
           .sort((a: any, b: any) => a.serverSeq - b.serverSeq)
           .slice(0, args.take || 500);
       }),
-      // Array branch of the single-entity conflict lookup: MAX(server_seq) over
-      // `entity_ids @> ARRAY[id]`, kept separate from the scalar findFirst above.
-      aggregate: vi.fn().mockImplementation(async (args: any) => {
-        const targetId = args.where?.entityIds?.has;
-        if (targetId === undefined || !args._max?.serverSeq) return { _max: {} };
-        state.entityConflictAggregateCount++;
-        const seqs = Array.from(state.operations.values())
-          .filter(
-            (op: any) =>
-              op.userId === args.where.userId &&
-              op.entityType === args.where.entityType &&
-              Array.isArray(op.entityIds) &&
-              op.entityIds.includes(targetId),
-          )
-          .map((op: any) => op.serverSeq);
-        return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
-      }),
+      aggregate: vi.fn().mockResolvedValue({ _max: {} }),
       findUnique: vi.fn().mockImplementation(async (args: any) => {
         // (user_id, server_seq) compound unique — fetches the array branch's winner.
         const compound = args.where?.userId_serverSeq;
@@ -196,6 +182,12 @@ vi.mock('../src/db', async () => {
     $executeRaw: vi.fn().mockResolvedValue(0),
     $queryRaw: vi.fn().mockImplementation(async (strings: any, ...params: unknown[]) => {
       const sql = Array.isArray(strings) ? strings.join('') : String(strings);
+      // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+      // `entity_ids @> ARRAY[id]`, kept separate from the scalar findFirst above.
+      if (isEntityArrayBranchQuery(strings)) {
+        state.entityConflictArrayQueryCount++;
+        return entityArrayBranchRows(state.operations, params);
+      }
       // Full-state op uploads aggregate prior vector clocks via $queryRaw.
       if (sql.includes('jsonb_each_text(vector_clock)')) {
         const [txUserId, beforeServerSeq] = params as [number, number];

--- a/packages/super-sync-server/tests/conflict-detection.spec.ts
+++ b/packages/super-sync-server/tests/conflict-detection.spec.ts
@@ -66,7 +66,7 @@ vi.mock('../src/db', async () => {
           );
         }
         // Single-entity conflict lookup, scalar branch: where { userId, entityType,
-        // entityId }. The entity_ids half is a separate aggregate() call below — the
+        // entityId }. The entity_ids half is a separate $queryRaw call below — the
         // two were one OR filter until it degenerated into a full history scan in
         // production (see the PERF note in conflict.ts detectConflictForEntity).
         // Scalar-only lookup (other callers): where { userId, entityType, entityId }.
@@ -104,7 +104,6 @@ vi.mock('../src/db', async () => {
           .sort((a: any, b: any) => a.serverSeq - b.serverSeq)
           .slice(0, args.take || 500);
       }),
-      aggregate: vi.fn().mockResolvedValue({ _max: {} }),
       findUnique: vi.fn().mockImplementation(async (args: any) => {
         // (user_id, server_seq) compound unique — fetches the array branch's winner.
         const compound = args.where?.userId_serverSeq;
@@ -216,6 +215,12 @@ vi.mock('../src/db', async () => {
         return [{ lastSeq: state.userSyncStates.get(txUserId)?.lastSeq ?? 0 }];
       }
 
+      // Anything left must be the batched multi-entity conflict lookup. Assert that
+      // rather than assuming it: falling through and reinterpreting an unrelated
+      // query as this one is how a mock silently answers a call it never modelled.
+      if (!sql.includes('DISTINCT ON')) {
+        throw new Error(`Unmocked raw query in tx: ${sql}`);
+      }
       const [userId, entityType, entityIdsSql] = params as [number, string, Prisma.Sql];
       state.batchConflictQueryCount++;
       if (!Array.isArray(entityIdsSql.values)) {

--- a/packages/super-sync-server/tests/conflict-detection.spec.ts
+++ b/packages/super-sync-server/tests/conflict-detection.spec.ts
@@ -63,27 +63,10 @@ vi.mock('../src/db', async () => {
             applyOperationSelect(state.operations.get(args.where.id), args.select) || null
           );
         }
-        // Single-entity conflict lookup: where { userId, entityType,
-        // OR: [{ entityId: X }, { entityIds: { has: X } }] } — match X as the
-        // scalar entity_id OR a member of the entity_ids array (#8334).
-        if (Array.isArray(args.where?.OR) && args.where?.entityType) {
-          state.entityConflictFindFirstCount++;
-          const scalarClause = args.where.OR.find((c: any) => 'entityId' in c);
-          const hasClause = args.where.OR.find(
-            (c: any) => c.entityIds?.has !== undefined,
-          );
-          const targetId = scalarClause?.entityId ?? hasClause?.entityIds?.has;
-          const ops = Array.from(state.operations.values())
-            .filter(
-              (op: any) =>
-                op.userId === args.where.userId &&
-                op.entityType === args.where.entityType &&
-                (op.entityId === targetId ||
-                  (Array.isArray(op.entityIds) && op.entityIds.includes(targetId))),
-            )
-            .sort((a: any, b: any) => b.serverSeq - a.serverSeq);
-          return applyOperationSelect(ops[0], args.select) || null;
-        }
+        // Single-entity conflict lookup, scalar branch: where { userId, entityType,
+        // entityId }. The entity_ids half is a separate aggregate() call below — the
+        // two were one OR filter until it degenerated into a full history scan in
+        // production (see the PERF note in conflict.ts detectConflictForEntity).
         // Scalar-only lookup (other callers): where { userId, entityType, entityId }.
         if (args.where?.entityId && args.where?.entityType) {
           state.entityConflictFindFirstCount++;
@@ -119,7 +102,33 @@ vi.mock('../src/db', async () => {
           .sort((a: any, b: any) => a.serverSeq - b.serverSeq)
           .slice(0, args.take || 500);
       }),
+      // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+      // `entity_ids @> ARRAY[id]`, kept separate from the scalar findFirst above.
+      aggregate: vi.fn().mockImplementation(async (args: any) => {
+        const targetId = args.where?.entityIds?.has;
+        if (targetId === undefined || !args._max?.serverSeq) return { _max: {} };
+        state.entityConflictAggregateCount++;
+        const seqs = Array.from(state.operations.values())
+          .filter(
+            (op: any) =>
+              op.userId === args.where.userId &&
+              op.entityType === args.where.entityType &&
+              Array.isArray(op.entityIds) &&
+              op.entityIds.includes(targetId),
+          )
+          .map((op: any) => op.serverSeq);
+        return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
+      }),
       findUnique: vi.fn().mockImplementation(async (args: any) => {
+        // (user_id, server_seq) compound unique — fetches the array branch's winner.
+        const compound = args.where?.userId_serverSeq;
+        if (compound) {
+          const match = Array.from(state.operations.values()).find(
+            (op: any) =>
+              op.userId === compound.userId && op.serverSeq === compound.serverSeq,
+          );
+          return applyOperationSelect(match, args.select) || null;
+        }
         if (args.where?.id) {
           return (
             applyOperationSelect(state.operations.get(args.where.id), args.select) || null

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { PGlite } from '@electric-sql/pglite';
 import { detectConflictForEntity } from '../src/sync/conflict';
+import { isEntityArrayBranchQuery } from './sync.service.test-state';
 import type { Operation } from '../src/sync/sync.types';
 
 /**
@@ -50,6 +51,30 @@ import type { Operation } from '../src/sync/sync.types';
  * call as the SQL Prisma emits, EXPLAIN (ANALYZE, BUFFERS)-ing every one and summing
  * what they touched. Reverting the split in conflict.ts makes the shim emit the old
  * OR query again and the row/block budgets below blow out by ~100x.
+ *
+ * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS. Prisma sends parameterized
+ * prepared statements, so production runs a GENERIC plan that cannot see parameter
+ * values; EXPLAIN with literal constants yields a CUSTOM plan nobody receives. This
+ * file used to test only with literals, and that blind spot passed two designs that
+ * were catastrophic in production. The raw-shape block below now uses explainGeneric
+ * throughout — keep it that way.
+ *
+ * KNOWN FIDELITY LIMITS — two things this spec CANNOT prove, so do not read a green
+ * run as covering them:
+ *
+ *  1. At this scale PGlite's planner does not reproduce the production mis-costing
+ *     that made the flat `MAX(...) FROM (... OFFSET 0)` form abandon GIN for the
+ *     entity btree (~80 vs ~875). The flat form is rejected on the production EXPLAIN
+ *     recorded in conflict.ts, not here.
+ *  2. `MATERIALIZED`'s EFFECT is unpinned. Dropping the keyword still plans as GIN in
+ *     PGlite at 30k rows, so no plan assertion here can detect its removal; the
+ *     'sends the array branch as a MATERIALIZED CTE' test guards the SQL TEXT only.
+ *     It is load-bearing on production, where inlining lets the outer user_id /
+ *     entity_type predicates push into the CTE and hand the composite btree a usable
+ *     leading column. Verify by EXPLAIN against real Postgres before touching it.
+ *
+ * The CTE is preferred precisely because its plan is forced STRUCTURALLY — inside the
+ * CTE no index has a usable leading column except GIN — rather than won on cost.
  */
 
 const SEEDED_OPS = 30_000;
@@ -85,15 +110,43 @@ const INSERT_COLS =
   'id,user_id,client_id,server_seq,action_type,entity_type,entity_id,entity_ids,' +
   'schema_version,vector_clock';
 
-type PlanStats = { blocks: number; rowsFiltered: number; sql: string[] };
+/**
+ * The array branch exactly as conflict.ts issues it, with positional params in
+ * tagged-template order. MATERIALIZED is load-bearing: it stops the outer user_id /
+ * entity_type predicates being pushed into the CTE, where they would give the
+ * (user_id, entity_type, entity_id, server_seq) btree a usable leading column and
+ * hand the planner back the scan this whole fix exists to prevent.
+ */
+const ARRAY_BRANCH_SQL = `
+  WITH cand AS MATERIALIZED (
+    SELECT user_id, entity_type, server_seq
+    FROM operations
+    WHERE entity_ids @> ARRAY[$1]::text[]
+  )
+  SELECT MAX(server_seq)::int AS "maxSeq"
+  FROM cand
+  WHERE user_id = $2 AND entity_type = $3`;
+
+type PlanStats = {
+  blocks: number;
+  rowsFiltered: number;
+  sql: string[];
+  rawSql: string[];
+};
 type PlanNode = Record<string, unknown>;
 
-const newStats = (): PlanStats => ({ blocks: 0, rowsFiltered: 0, sql: [] });
+const newStats = (): PlanStats => ({ blocks: 0, rowsFiltered: 0, sql: [], rawSql: [] });
 
+/**
+ * Walks the plan tree for node names and filtered-row counts.
+ *
+ * Blocks are deliberately NOT summed here: `Shared Hit/Read Blocks` are CUMULATIVE,
+ * so a parent already includes everything its children read. Summing every node
+ * double-counts the same buffers once per level of nesting, inflating deep plans
+ * (the CTE form nests one level deeper than the flat one) and biasing the budgets
+ * against the new code. The ROOT node's value is the true total — see explainOn.
+ */
 const accumulatePlan = (node: PlanNode, stats: PlanStats, nodes: string[]): void => {
-  stats.blocks +=
-    ((node['Shared Hit Blocks'] as number) ?? 0) +
-    ((node['Shared Read Blocks'] as number) ?? 0);
   stats.rowsFiltered += (node['Rows Removed by Filter'] as number) ?? 0;
   nodes.push(
     `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
@@ -103,6 +156,10 @@ const accumulatePlan = (node: PlanNode, stats: PlanStats, nodes: string[]): void
     accumulatePlan(child, stats, nodes);
   }
 };
+
+const rootBlocks = (node: PlanNode): number =>
+  ((node['Shared Hit Blocks'] as number) ?? 0) +
+  ((node['Shared Read Blocks'] as number) ?? 0);
 
 const explainOn = async (
   db: PGlite,
@@ -118,10 +175,46 @@ const explainOn = async (
   const nodes: string[] = [];
   accumulatePlan(plan, stats, nodes);
   return {
-    blocks: stats.blocks,
+    blocks: rootBlocks(plan),
     rowsFiltered: stats.rowsFiltered,
     nodes: nodes.join(' -> '),
   };
+};
+
+/**
+ * The same EXPLAIN, but through PREPARE/EXECUTE under `force_generic_plan` — the
+ * ONLY faithful way to see what production gets. Prisma sends parameterized
+ * prepared statements, so Postgres eventually builds a generic plan that cannot
+ * see parameter values; an EXPLAIN with literals yields a custom plan that
+ * production never receives, and two designs that looked perfect under literals
+ * were catastrophic under generic planning on the real table.
+ */
+let preparedCounterId = 0;
+const explainGeneric = async (
+  db: PGlite,
+  sql: string,
+  literalArgs: string,
+): Promise<{ blocks: number; rowsFiltered: number; nodes: string }> => {
+  const name = `plan_probe_${preparedCounterId++}`;
+  await db.exec(`SET plan_cache_mode = force_generic_plan`);
+  await db.exec(`PREPARE ${name} AS ${sql}`);
+  try {
+    const res = await db.query<Record<string, unknown>>(
+      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}(${literalArgs})`,
+    );
+    const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
+    const stats = newStats();
+    const nodes: string[] = [];
+    accumulatePlan(plan, stats, nodes);
+    return {
+      blocks: rootBlocks(plan),
+      rowsFiltered: stats.rowsFiltered,
+      nodes: nodes.join(' -> '),
+    };
+  } finally {
+    await db.exec(`DEALLOCATE ${name}`);
+    await db.exec(`SET plan_cache_mode = auto`);
+  }
 };
 
 const incomingOp = (
@@ -208,21 +301,6 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
         );
         return normalize(rows[0]);
       },
-      // Prisma compiles aggregate() to MAX() over a `SELECT ... OFFSET 0` subquery.
-      // That OFFSET is the planner fence that keeps this on the GIN bitmap path.
-      aggregate: async (args: Record<string, any>) => {
-        const params: unknown[] = [];
-        const conds = renderConditions(args.where, params);
-        const rows = await runMeasured(
-          `SELECT MAX(server_seq) AS max FROM (SELECT server_seq FROM operations ` +
-            `WHERE ${conds.join(' AND ')} OFFSET 0) sub`,
-          params,
-        );
-        const max = rows[0]?.max;
-        return {
-          _max: { serverSeq: max === null || max === undefined ? null : Number(max) },
-        };
-      },
       findUnique: async (args: Record<string, any>) => {
         const { userId, serverSeq } = args.where.userId_serverSeq;
         const rows = await runMeasured(
@@ -231,6 +309,20 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
         );
         return normalize(rows[0]);
       },
+    },
+    // Array branch. conflict.ts issues this as a Prisma tagged template; the shim
+    // rebuilds the identical SQL with positional params in template order
+    // (entityId, userId, entityType) so what is EXPLAINed is what production runs.
+    $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      if (!isEntityArrayBranchQuery(strings)) {
+        throw new Error(`Unexpected raw query: ${strings.join('?')}`);
+      }
+      // Record the REAL template text (not the reconstruction) so a test can assert
+      // on what conflict.ts actually sends.
+      stats.rawSql.push(strings.join('?'));
+      const rows = await runMeasured(ARRAY_BRANCH_SQL, values);
+      const max = rows[0]?.maxSeq;
+      return [{ maxSeq: max === null || max === undefined ? null : Number(max) }];
     },
   };
 };
@@ -292,6 +384,29 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
   });
 
+  it('sends the array branch as a MATERIALIZED CTE', async () => {
+    // A TEXT guard, not a plan guard, and deliberately so: PGlite at 30k rows plans
+    // `AS NOT MATERIALIZED` identically, so no behavioural assertion in this file
+    // fails if the keyword is dropped (see KNOWN FIDELITY LIMITS in the header). On
+    // production the keyword is what stops user_id / entity_type inlining into the
+    // CTE and handing the composite btree a usable leading column. Until that is
+    // reproducible in-process, pin the text so an accidental removal is not silent.
+    const stats = newStats();
+
+    await detectConflictForEntity(
+      USER_ID,
+      incomingOp('task-brand-new'),
+      'task-brand-new',
+      makeMeasuringTx(db, stats) as never,
+    );
+
+    expect(stats.rawSql).toHaveLength(1);
+    expect(stats.rawSql[0]).toContain('AS MATERIALIZED');
+    expect(stats.rawSql[0]).not.toContain('NOT MATERIALIZED');
+    // The outer user boundary must stay outside the CTE.
+    expect(stats.rawSql[0]).toMatch(/FROM cand\s+WHERE user_id =/);
+  });
+
   it('reads a bounded amount for an entity deep in the history', async () => {
     const stats = newStats();
 
@@ -306,17 +421,25 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
   });
 
-  describe('raw query shapes (the EXPLAIN recipe, runnable against real Postgres)', () => {
+  /**
+   * EVERY assertion here runs under `force_generic_plan`. Testing these shapes with
+   * literal constants — which this block used to do — is what let two broken designs
+   * through: both planned beautifully as custom plans and scanned the whole history
+   * as generic ones. Prisma only ever sends parameterized prepared statements, so the
+   * generic plan is the one that matters. If you add a shape, use explainGeneric.
+   */
+  describe('raw query shapes under force_generic_plan (what production actually gets)', () => {
     const MISSING = 'task-brand-new';
+    const ARGS = `${USER_ID}, 'TASK', '${MISSING}'`;
 
     it('OLD combined OR + LIMIT 1 degenerates into a full backward walk', async () => {
-      const old = await explainOn(
+      const old = await explainGeneric(
         db,
         `SELECT server_seq FROM operations
            WHERE user_id = $1 AND entity_type = $2
              AND (entity_id = $3 OR entity_ids @> ARRAY[$3]::text[])
            ORDER BY server_seq DESC LIMIT 1`,
-        [USER_ID, 'TASK', MISSING],
+        ARGS,
       );
 
       // The incident, reproduced: every row read and discarded.
@@ -326,14 +449,13 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
 
     it('the NAIVE array-only fix reintroduces the same walk (do not "simplify" to this)', async () => {
       // `findFirst({ entityIds: { has }, orderBy: { serverSeq: 'desc' } })`. GIN still
-      // cannot order, so the planner makes the same losing bet. This is why the array
-      // branch in conflict.ts is an aggregate and must stay one.
-      const naive = await explainOn(
+      // cannot order, so the planner makes the same losing bet.
+      const naive = await explainGeneric(
         db,
         `SELECT server_seq FROM operations
            WHERE user_id = $1 AND entity_type = $2 AND entity_ids @> ARRAY[$3]::text[]
            ORDER BY server_seq DESC LIMIT 1`,
-        [USER_ID, 'TASK', MISSING],
+        ARGS,
       );
 
       expect(naive.rowsFiltered).toBe(SEEDED_OPS);
@@ -341,25 +463,69 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     });
 
     it('the split lookups each stay bounded by actually-matching rows', async () => {
-      const scalar = await explainOn(
+      const scalar = await explainGeneric(
         db,
         `SELECT server_seq FROM operations
            WHERE user_id = $1 AND entity_type = $2 AND entity_id = $3
            ORDER BY server_seq DESC LIMIT 1`,
-        [USER_ID, 'TASK', MISSING],
+        ARGS,
       );
-      // The OFFSET 0 fence is deliberate — it forbids the LIMIT-driven walk.
-      const array = await explainOn(
+      const array = await explainGeneric(
         db,
-        `SELECT MAX(server_seq) FROM (SELECT server_seq FROM operations
-           WHERE user_id = $1 AND entity_type = $2 AND entity_ids @> ARRAY[$3]::text[]
-           OFFSET 0) sub`,
-        [USER_ID, 'TASK', MISSING],
+        // Same param order as conflict.ts: entityId first, inside the CTE.
+        ARRAY_BRANCH_SQL,
+        `'${MISSING}', ${USER_ID}, 'TASK'`,
       );
 
       expect(scalar.rowsFiltered).toBe(0);
       expect(array.rowsFiltered).toBe(0);
       expect(scalar.blocks + array.blocks).toBeLessThan(MAX_BLOCKS);
+    });
+
+    it('the array branch reaches the GIN index, never the entity btree', async () => {
+      // The load-bearing claim. Inside the CTE the only predicate is
+      // `entity_ids @> ...`, so the composite btree has no usable leading column and
+      // GIN is the only index available AT ANY COST ESTIMATE — this is structural,
+      // not a costing accident, which is why it survives generic planning.
+      const array = await explainGeneric(
+        db,
+        ARRAY_BRANCH_SQL,
+        `'${MISSING}', ${USER_ID}, 'TASK'`,
+      );
+
+      expect(array.nodes).toContain('operations_entity_ids_gin');
+      expect(array.nodes).not.toContain(
+        'operations_user_id_entity_type_entity_id_server_seq_idx',
+      );
+      expect(array.nodes).not.toContain('Backward');
+    });
+
+    it('adding a server_seq bound does NOT improve the generic plan (why there is none)', async () => {
+      // A review proposed bounding the array branch with `server_seq > <scalar seq>`,
+      // measured at 495 -> 9 buffers. That gain is a CUSTOM-plan artifact: with the
+      // value visible the planner knows the bound is selective. Under generic
+      // planning the value is invisible, so the bound cannot drive an index — it
+      // lands as a post-GIN Filter and buys nothing. Measured separately on a
+      // multi-user seed, inside the CTE it is actively harmful: with no user_id
+      // predicate available there, a custom plan bitmap-scans (user_id, server_seq)
+      // on `server_seq > $4` alone — no leading-column bound, i.e. a full index scan
+      // across EVERY user's history. Hence: no bound. Revisit only with a generic
+      // plan from production showing otherwise.
+      const bounded = await explainGeneric(
+        db,
+        `WITH cand AS MATERIALIZED (
+           SELECT user_id, entity_type, server_seq
+           FROM operations
+           WHERE entity_ids @> ARRAY[$1]::text[] AND server_seq > $4
+         )
+         SELECT MAX(server_seq)::int AS "maxSeq"
+         FROM cand
+         WHERE user_id = $2 AND entity_type = $3`,
+        `'${MISSING}', ${USER_ID}, 'TASK', 1`,
+      );
+
+      // Still GIN — the bound changed nothing the planner could act on.
+      expect(bounded.nodes).toContain('operations_entity_ids_gin');
     });
   });
 });
@@ -445,6 +611,36 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
 
     expect((await detect('divergent-scalar')).hasConflict).toBe(true);
     expect((await detect('divergent-member')).hasConflict).toBe(true);
+  });
+
+  it('does not re-fetch when both branches TIE on the same row', async () => {
+    // A multi-entity op whose scalar entity_id is also a member of its entity_ids —
+    // a real stored shape (getStoredEntityIds keeps the full set once length > 1).
+    // Both branches then return the SAME server_seq, and because
+    // @@unique([userId, serverSeq]) makes an equal server_seq the same row, the
+    // findUnique would be pure waste. Pins "fetch only when it BEATS the scalar":
+    // relaxing `>` to `>=` still returns the right answer, so only the round-trip
+    // count can catch it — and this lookup runs twice per uploaded op.
+    await seed({
+      id: 'op-tie',
+      serverSeq: 20,
+      clientId: 'other',
+      entityId: 'tie-entity',
+      entityIds: ['tie-entity', 'tie-sibling'],
+      vectorClock: { other: 1 },
+    });
+
+    const stats = newStats();
+    const result = await detectConflictForEntity(
+      USER_ID,
+      incomingOp('tie-entity'),
+      'tie-entity',
+      makeMeasuringTx(db, stats) as never,
+    );
+
+    expect(result.hasConflict).toBe(true);
+    // Scalar findFirst + array CTE. A third query means the tie triggered a fetch.
+    expect(stats.sql).toHaveLength(2);
   });
 
   it('picks the ARRAY row when it has the higher server_seq', async () => {

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -5,80 +5,62 @@ import { isEntityArrayBranchQuery } from './sync.service.test-state';
 import type { Operation } from '../src/sync/sync.types';
 
 /**
- * Production incident regression: the single-entity conflict lookup scanned a
- * user's ENTIRE operation history on every upload of a not-yet-seen entity.
- *
- * detectConflictForEntity used to match the entity with one Prisma filter —
- * `OR: [{ entityId }, { entityIds: { has: entityId } }]` + `orderBy serverSeq desc`
- * — which Postgres receives as
- *
- *   ... WHERE user_id=$1 AND entity_type=$2
- *         AND (entity_id=$3 OR entity_ids @> $4)
- *       ORDER BY server_seq DESC LIMIT 1
- *
- * The OR spans two different indexes (the (user_id, entity_type, entity_id,
- * server_seq) btree and the entity_ids GIN) and GIN cannot supply server_seq
- * ordering, so the planner may abandon both index paths and walk (user_id,
- * server_seq) BACKWARDS applying the OR as a filter, betting the LIMIT 1 resolves
- * early. For an entity with no matching rows — the first-ever op for a new task,
- * the single most common upload — the bet loses and it reads the whole history.
- *
- * Live evidence (sync.super-productivity.com): 47 backends stuck on exactly this
- * query, longest running 75 minutes, wait_event=DataFileRead, 61/66 connections
- * active → Prisma pool exhaustion → all uploads AND downloads failing. Every index
- * was valid; this was never a missing-index problem.
- *
- * WHAT DECIDES THE BET — READ THIS BEFORE RE-TESTING (measured below, and the
- * reason the previous "the planner uses a BitmapOr + sort" comment looked true):
- * the planner only takes the backward walk when it has NO array-element statistics
- * for entity_ids. With none it falls back to a default `@>` selectivity (0.5%) and
- * estimates ~150 of 30_000 rows match, so LIMIT 1 looks like it exits after ~200
- * rows. Populate entity_ids on even 6 rows in 30_000 and ANALYZE, and the estimate
- * drops to ~1 row, the walk prices itself out, and BitmapOr wins.
- *
- * That is not an exotic state — it is the deployed one. `entity_ids` was added by
- * migration 20260613000000 with NO backfill (forward-only, see schema.prisma), and
- * getStoredEntityIds stores [] for every single-entity op, i.e. the vast majority.
- * Statistics are also TABLE-wide, not per-user: if ANALYZE's sample happens to
- * contain no non-empty array, EVERY user's uploads degenerate at once, which is why
- * this detonates suddenly rather than degrading gradually.
- *
- * So the seed below leaves entity_ids empty on every row on purpose. Do not
- * "improve" it by populating the column — that silently disarms this regression.
+ * Production incident regression: the single-entity conflict lookup read a user's
+ * entire (user_id, entity_type) slice on every upload of a not-yet-seen entity.
+ * The mechanism, the rejected alternatives and the isolation caveat are documented
+ * once, at detectConflictForEntity in src/sync/conflict.ts — not repeated here.
  *
  * This spec runs the REAL detectConflictForEntity against in-process Postgres
  * (PGlite — no Docker, no DATABASE_URL) through a tx shim that renders each Prisma
- * call as the SQL Prisma emits, EXPLAIN (ANALYZE, BUFFERS)-ing every one and summing
- * what they touched. Reverting the split in conflict.ts makes the shim emit the old
- * OR query again and the row/block budgets below blow out by ~100x.
+ * call as the SQL Prisma emits and EXPLAINs it. The array branch is NOT rebuilt from
+ * a constant: the shim reconstructs it from the actual tagged-template text, so the
+ * SQL under test is byte-for-byte what conflict.ts sends. That is what lets a change
+ * to the aggregate (MAX -> MIN), the fence (dropping MATERIALIZED) or the CTE shape
+ * fail here instead of passing against a stale copy.
  *
  * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS. Prisma sends parameterized
  * prepared statements, so production runs a GENERIC plan that cannot see parameter
  * values; EXPLAIN with literal constants yields a CUSTOM plan nobody receives. This
- * file used to test only with literals, and that blind spot passed two designs that
- * were catastrophic in production. The raw-shape block below now uses explainGeneric
- * throughout — keep it that way.
+ * file once tested with literals and that blind spot passed two designs that were
+ * catastrophic in production. EVERYTHING here — including the shim — goes through
+ * explainGeneric. If you add a shape, use explainGeneric.
  *
- * KNOWN FIDELITY LIMITS — two things this spec CANNOT prove, so do not read a green
- * run as covering them:
+ * WHY THE SEED SHAPE IS WHAT IT IS — do not "simplify" it:
  *
- *  1. At this scale PGlite's planner does not reproduce the production mis-costing
- *     that made the flat `MAX(...) FROM (... OFFSET 0)` form abandon GIN for the
- *     entity btree (~80 vs ~875). The flat form is rejected on the production EXPLAIN
- *     recorded in conflict.ts, not here.
- *  2. `MATERIALIZED`'s EFFECT is unpinned. Dropping the keyword still plans as GIN in
- *     PGlite at 30k rows, so no plan assertion here can detect its removal; the
- *     'sends the array branch as a MATERIALIZED CTE' test guards the SQL TEXT only.
- *     It is load-bearing on production, where inlining lets the outer user_id /
- *     entity_type predicates push into the CTE and hand the composite btree a usable
- *     leading column. Verify by EXPLAIN against real Postgres before touching it.
+ *  - entity_ids stays '{}' on EVERY row. The planner only mis-plans when it has no
+ *    array-element statistics for entity_ids, falling back to a default `@>`
+ *    selectivity. That is the DEPLOYED state: entity_ids was added by migration
+ *    20260613000000 with no backfill, and getStoredEntityIds stores [] for every
+ *    single-entity op. Populating the column here silently disarms the regression.
+ *  - MANY users and MANY entity types. This is the load-bearing part. With one user
+ *    and one entity_type the GIN estimate (which scales with the whole table) and the
+ *    btree-slice estimate (N / (users x entity_types)) cover the SAME rows, so GIN
+ *    always wins on cost and no regression is detectable. That degenerate shape is
+ *    why this suite could not catch the outage. At 20k rows for the probed user plus
+ *    20k spread over ~20k other users across 8 entity types, PGlite reproduces the
+ *    production plan node-for-node and every regression below lands ~400x over budget.
  *
- * The CTE is preferred precisely because its plan is forced STRUCTURALLY — inside the
- * CTE no index has a usable leading column except GIN — rather than won on cost.
+ * REMAINING FIDELITY LIMIT: PGlite is not the production cluster. It has no btree_gin,
+ * so the composite (user_id, entity_ids) index proposed in conflict.ts as the fix for
+ * the shared-literal-id scan cannot be evaluated here at all.
  */
 
-const SEEDED_OPS = 30_000;
+const OWN_OPS = 20_000;
+const OTHER_OPS = 20_000;
 const USER_ID = 1;
+/** Entity types are spread across the seed so the btree slice is N/(users x types). */
+const ENTITY_TYPES = [
+  'TASK',
+  'PROJECT',
+  'TAG',
+  'NOTE',
+  'BOARD',
+  'GLOBAL_CONFIG',
+  'SIMPLE_COUNTER',
+  'TASK_REPEAT_CFG',
+];
+/** seq % ENTITY_TYPES.length === 0 => 'TASK', so this row is in the probed slice. */
+const DEEP_ENTITY_SEQ = 16;
 
 const CREATE_TABLE = `
   CREATE TABLE operations (
@@ -111,11 +93,9 @@ const INSERT_COLS =
   'schema_version,vector_clock';
 
 /**
- * The array branch exactly as conflict.ts issues it, with positional params in
- * tagged-template order. MATERIALIZED is load-bearing: it stops the outer user_id /
- * entity_type predicates being pushed into the CTE, where they would give the
- * (user_id, entity_type, entity_id, server_seq) btree a usable leading column and
- * hand the planner back the scan this whole fix exists to prevent.
+ * The array branch as conflict.ts issues it, with positional params in tagged-template
+ * order. Used only by the raw-shape comparisons below; the end-to-end tests reconstruct
+ * this from the real template instead, so the two are cross-checked against each other.
  */
 const ARRAY_BRANCH_SQL = `
   WITH cand AS MATERIALIZED (
@@ -134,6 +114,7 @@ type PlanStats = {
   rawSql: string[];
 };
 type PlanNode = Record<string, unknown>;
+type Measured = { blocks: number; rowsFiltered: number; nodes: string };
 
 const newStats = (): PlanStats => ({ blocks: 0, rowsFiltered: 0, sql: [], rawSql: [] });
 
@@ -144,7 +125,7 @@ const newStats = (): PlanStats => ({ blocks: 0, rowsFiltered: 0, sql: [], rawSql
  * so a parent already includes everything its children read. Summing every node
  * double-counts the same buffers once per level of nesting, inflating deep plans
  * (the CTE form nests one level deeper than the flat one) and biasing the budgets
- * against the new code. The ROOT node's value is the true total — see explainOn.
+ * against the new code. The ROOT node's value is the true total.
  */
 const accumulatePlan = (node: PlanNode, stats: PlanStats, nodes: string[]): void => {
   stats.rowsFiltered += (node['Rows Removed by Filter'] as number) ?? 0;
@@ -161,46 +142,34 @@ const rootBlocks = (node: PlanNode): number =>
   ((node['Shared Hit Blocks'] as number) ?? 0) +
   ((node['Shared Read Blocks'] as number) ?? 0);
 
-const explainOn = async (
-  db: PGlite,
-  sql: string,
-  params: unknown[],
-): Promise<{ blocks: number; rowsFiltered: number; nodes: string }> => {
-  const res = await db.query<Record<string, unknown>>(
-    `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`,
-    params,
-  );
-  const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
-  const stats = newStats();
-  const nodes: string[] = [];
-  accumulatePlan(plan, stats, nodes);
-  return {
-    blocks: rootBlocks(plan),
-    rowsFiltered: stats.rowsFiltered,
-    nodes: nodes.join(' -> '),
-  };
+const toSqlLiteral = (value: unknown): string => {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  if (Array.isArray(value)) {
+    return `ARRAY[${value.map(toSqlLiteral).join(',')}]::text[]`;
+  }
+  return `'${String(value).replace(/'/g, "''")}'`;
 };
 
 /**
- * The same EXPLAIN, but through PREPARE/EXECUTE under `force_generic_plan` — the
- * ONLY faithful way to see what production gets. Prisma sends parameterized
- * prepared statements, so Postgres eventually builds a generic plan that cannot
- * see parameter values; an EXPLAIN with literals yields a custom plan that
- * production never receives, and two designs that looked perfect under literals
- * were catastrophic under generic planning on the real table.
+ * EXPLAIN through PREPARE/EXECUTE under `force_generic_plan` — the ONLY faithful way
+ * to see what production gets. The params are rendered as literals for EXECUTE, but
+ * the PLAN is built at PREPARE time with the values invisible, which is exactly the
+ * situation Prisma puts Postgres in.
  */
 let preparedCounterId = 0;
 const explainGeneric = async (
   db: PGlite,
   sql: string,
-  literalArgs: string,
-): Promise<{ blocks: number; rowsFiltered: number; nodes: string }> => {
+  params: readonly unknown[],
+): Promise<Measured> => {
   const name = `plan_probe_${preparedCounterId++}`;
+  const args = params.map(toSqlLiteral).join(', ');
   await db.exec(`SET plan_cache_mode = force_generic_plan`);
   await db.exec(`PREPARE ${name} AS ${sql}`);
   try {
     const res = await db.query<Record<string, unknown>>(
-      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}(${literalArgs})`,
+      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
     );
     const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
     const stats = newStats();
@@ -234,17 +203,42 @@ const incomingOp = (
     ...overrides,
   }) as unknown as Operation;
 
+/** Column list per Prisma `select` key. An unmapped key must fail loudly, not vanish. */
+const COLUMN_SQL: Record<string, string> = {
+  actionType: 'action_type AS "actionType"',
+  clientId: 'client_id AS "clientId"',
+  vectorClock: 'vector_clock AS "vectorClock"',
+  serverSeq: 'server_seq AS "serverSeq"',
+  entityId: 'entity_id AS "entityId"',
+  entityType: 'entity_type AS "entityType"',
+};
+
+/**
+ * Honouring `select` is load-bearing, not cosmetic: conflict.ts reads
+ * existingOp.actionType to let concurrent time-tracking deltas merge. A shim that
+ * always returned every column would keep passing if actionType were dropped from
+ * the array-branch select, which is a silent rejection of tracked time.
+ */
+const selectCols = (select?: Record<string, boolean>): string => {
+  if (!select) return Object.values(COLUMN_SQL).join(', ');
+  const cols = Object.entries(select)
+    .filter(([, isSelected]) => isSelected)
+    .map(([key]) => {
+      const col = COLUMN_SQL[key];
+      if (!col) throw new Error(`Shim has no column mapping for select key "${key}"`);
+      return col;
+    });
+  if (cols.length === 0) throw new Error('Shim received an empty select');
+  return cols.join(', ');
+};
+
 /**
  * Renders the Prisma calls detectConflictForEntity makes as the SQL Prisma emits,
  * EXPLAIN-ing each one into `stats`. It deliberately also renders the OLD combined
- * OR filter: reverting the fix must fail this spec on the row/block BUDGET (proving
- * the plan degenerated), not on an unsupported-shape error.
+ * OR filter: reverting the fix must fail this spec on the BUDGET (proving the plan
+ * degenerated), not on an unsupported-shape error.
  */
 const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
-  const SELECT_COLS =
-    'action_type AS "actionType", client_id AS "clientId", ' +
-    'vector_clock AS "vectorClock", server_seq AS "serverSeq"';
-
   // Prisma renders `entityIds: { has: x }` as `entity_ids @> ARRAY[x]`.
   const renderConditions = (where: Record<string, any>, params: unknown[]): string[] => {
     const push = (value: unknown): string => `$${params.push(value)}`;
@@ -274,15 +268,17 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
     sql: string,
     params: unknown[],
   ): Promise<Record<string, unknown>[]> => {
-    const measured = await explainOn(db, sql, params);
+    const measured = await explainGeneric(db, sql, params);
     stats.blocks += measured.blocks;
     stats.rowsFiltered += measured.rowsFiltered;
     stats.sql.push(sql);
     return (await db.query<Record<string, unknown>>(sql, params)).rows;
   };
 
-  const normalize = (row?: Record<string, unknown>): Record<string, unknown> | null =>
-    row ? { ...row, serverSeq: Number(row.serverSeq) } : null;
+  const normalize = (row?: Record<string, unknown>): Record<string, unknown> | null => {
+    if (!row) return null;
+    return 'serverSeq' in row ? { ...row, serverSeq: Number(row.serverSeq) } : row;
+  };
 
   return {
     operation: {
@@ -296,7 +292,8 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
               ? 'ORDER BY server_seq ASC'
               : '';
         const rows = await runMeasured(
-          `SELECT ${SELECT_COLS} FROM operations WHERE ${conds.join(' AND ')} ${order} LIMIT 1`,
+          `SELECT ${selectCols(args.select)} FROM operations` +
+            ` WHERE ${conds.join(' AND ')} ${order} LIMIT 1`,
           params,
         );
         return normalize(rows[0]);
@@ -304,27 +301,44 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
       findUnique: async (args: Record<string, any>) => {
         const { userId, serverSeq } = args.where.userId_serverSeq;
         const rows = await runMeasured(
-          `SELECT ${SELECT_COLS} FROM operations WHERE user_id = $1 AND server_seq = $2 LIMIT 1`,
+          `SELECT ${selectCols(args.select)} FROM operations` +
+            ` WHERE user_id = $1 AND server_seq = $2 LIMIT 1`,
           [userId, serverSeq],
         );
         return normalize(rows[0]);
       },
     },
-    // Array branch. conflict.ts issues this as a Prisma tagged template; the shim
-    // rebuilds the identical SQL with positional params in template order
-    // (entityId, userId, entityType) so what is EXPLAINed is what production runs.
+    // Array branch. Rebuilt from the REAL tagged template — the literal text
+    // conflict.ts sends, with `$n` substituted in template order — so the aggregate,
+    // the MATERIALIZED fence and the CTE structure are all under test here rather
+    // than compared against a copy that can drift.
     $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
       if (!isEntityArrayBranchQuery(strings)) {
         throw new Error(`Unexpected raw query: ${strings.join('?')}`);
       }
-      // Record the REAL template text (not the reconstruction) so a test can assert
-      // on what conflict.ts actually sends.
-      stats.rawSql.push(strings.join('?'));
-      const rows = await runMeasured(ARRAY_BRANCH_SQL, values);
+      const sql = strings.reduce(
+        (acc, part, i) => acc + part + (i < values.length ? `$${i + 1}` : ''),
+        '',
+      );
+      stats.rawSql.push(sql);
+      const rows = await runMeasured(sql, values);
       const max = rows[0]?.maxSeq;
       return [{ maxSeq: max === null || max === undefined ? null : Number(max) }];
     },
   };
+};
+
+// Post-fix both branches are index lookups bounded by actually-matching rows.
+// Measured on this seed: the array branch reads 2 blocks and the scalar 3, filtering
+// nothing. Every regression form below reads 806 blocks and filters 2500 — the probed
+// user's whole TASK slice — so one budget separates them by ~400x. Budgets are the
+// metric, not plan names: plan shapes are row-count and version dependent, "how much
+// did it actually read" is not.
+const MAX_BLOCKS = 100;
+
+const expectWithinBudget = (measured: { blocks: number; rowsFiltered: number }): void => {
+  expect(measured.rowsFiltered).toBe(0);
+  expect(measured.blocks).toBeLessThan(MAX_BLOCKS);
 };
 
 describe('detectConflictForEntity does not scan the history (PGlite)', () => {
@@ -338,34 +352,40 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     // entity_ids stays '{}' on EVERY row — see the header note. Populating it here
     // gives the planner array statistics and disarms the regression.
     let rows: string[] = [];
-    for (let seq = 1; seq <= SEEDED_OPS; seq++) {
+    const flush = async (): Promise<void> => {
+      if (rows.length === 0) return;
+      await db.exec(`INSERT INTO operations (${INSERT_COLS}) VALUES ${rows.join(',')}`);
+      rows = [];
+    };
+    const entityTypeFor = (n: number): string => ENTITY_TYPES[n % ENTITY_TYPES.length];
+
+    for (let seq = 1; seq <= OWN_OPS; seq++) {
       rows.push(
-        `('op-${seq}', ${USER_ID}, 'seed-client', ${seq}, '[Task] Update', 'TASK',` +
-          ` 'task-${seq}', '{}', 1, '{"seed-client":${seq}}')`,
+        `('op-${seq}', ${USER_ID}, 'seed-client', ${seq}, '[Task] Update',` +
+          ` '${entityTypeFor(seq)}', 'task-${seq}', '{}', 1, '{"seed-client":${seq}}')`,
       );
-      if (rows.length === 1000) {
-        await db.exec(`INSERT INTO operations (${INSERT_COLS}) VALUES ${rows.join(',')}`);
-        rows = [];
-      }
+      if (rows.length === 1000) await flush();
     }
+    // A second population of comparable size spread over ~20k OTHER users, so the
+    // per-user btree slice is a small fraction of the table the GIN estimate sees.
+    for (let i = 1; i <= OTHER_OPS; i++) {
+      rows.push(
+        `('other-${i}', ${1000 + i}, 'seed-other', ${i}, '[Task] Update',` +
+          ` '${entityTypeFor(i)}', 'otask-${i}', '{}', 1, '{"seed-other":${i}}')`,
+      );
+      if (rows.length === 1000) await flush();
+    }
+    await flush();
 
     // Index after the bulk load, then ANALYZE so the planner works from real
     // statistics rather than defaults on an unanalyzed table.
     await db.exec(CREATE_INDEXES);
     await db.exec('ANALYZE operations');
-  }, 60_000);
+  }, 120_000);
 
   afterAll(async () => {
     await db.close();
   });
-
-  // Post-fix both branches are index lookups that match nothing: 0 rows filtered,
-  // ~12 blocks, flat in history size. The old single-OR query filters all 30_000
-  // rows across ~1366 blocks and grows linearly (measured 22x at 5k ops, 114x at
-  // 30k, 191x at 50k). Budgets are the metric, not plan names — plan shapes are
-  // row-count and version dependent, "how much did it actually read" is not.
-  const MAX_ROWS_FILTERED = SEEDED_OPS / 100;
-  const MAX_BLOCKS = 100;
 
   it('reads a bounded amount for a BRAND-NEW entity (the incident case)', async () => {
     const stats = newStats();
@@ -380,17 +400,26 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     );
 
     expect(result.hasConflict).toBe(false);
-    expect(stats.rowsFiltered).toBeLessThan(MAX_ROWS_FILTERED);
-    expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
+    expectWithinBudget(stats);
+  });
+
+  it('reads a bounded amount for an entity deep in the history', async () => {
+    const stats = newStats();
+
+    await detectConflictForEntity(
+      USER_ID,
+      incomingOp(`task-${DEEP_ENTITY_SEQ}`),
+      `task-${DEEP_ENTITY_SEQ}`,
+      makeMeasuringTx(db, stats) as never,
+    );
+
+    expectWithinBudget(stats);
   });
 
   it('sends the array branch as a MATERIALIZED CTE', async () => {
-    // A TEXT guard, not a plan guard, and deliberately so: PGlite at 30k rows plans
-    // `AS NOT MATERIALIZED` identically, so no behavioural assertion in this file
-    // fails if the keyword is dropped (see KNOWN FIDELITY LIMITS in the header). On
-    // production the keyword is what stops user_id / entity_type inlining into the
-    // CTE and handing the composite btree a usable leading column. Until that is
-    // reproducible in-process, pin the text so an accidental removal is not silent.
+    // A text guard on top of the behavioural budget test below: the budget proves the
+    // keyword's EFFECT, this pins its presence so a removal is never silent even if a
+    // future seed stops reproducing the mis-plan.
     const stats = newStats();
 
     await detectConflictForEntity(
@@ -407,92 +436,25 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     expect(stats.rawSql[0]).toMatch(/FROM cand\s+WHERE user_id =/);
   });
 
-  it('reads a bounded amount for an entity deep in the history', async () => {
-    const stats = newStats();
-
-    await detectConflictForEntity(
-      USER_ID,
-      incomingOp('task-17'),
-      'task-17',
-      makeMeasuringTx(db, stats) as never,
-    );
-
-    expect(stats.rowsFiltered).toBeLessThan(MAX_ROWS_FILTERED);
-    expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
-  });
-
   /**
    * EVERY assertion here runs under `force_generic_plan`. Testing these shapes with
    * literal constants — which this block used to do — is what let two broken designs
-   * through: both planned beautifully as custom plans and scanned the whole history
-   * as generic ones. Prisma only ever sends parameterized prepared statements, so the
-   * generic plan is the one that matters. If you add a shape, use explainGeneric.
+   * through: both planned beautifully as custom plans and read the whole slice as
+   * generic ones.
    */
   describe('raw query shapes under force_generic_plan (what production actually gets)', () => {
     const MISSING = 'task-brand-new';
-    const ARGS = `${USER_ID}, 'TASK', '${MISSING}'`;
+    const ARRAY_ARGS = [MISSING, USER_ID, 'TASK'];
+    const SLICE_ARGS = [USER_ID, 'TASK', MISSING];
 
-    it('OLD combined OR + LIMIT 1 degenerates into a full backward walk', async () => {
-      const old = await explainGeneric(
-        db,
-        `SELECT server_seq FROM operations
-           WHERE user_id = $1 AND entity_type = $2
-             AND (entity_id = $3 OR entity_ids @> ARRAY[$3]::text[])
-           ORDER BY server_seq DESC LIMIT 1`,
-        ARGS,
-      );
-
-      // The incident, reproduced: every row read and discarded.
-      expect(old.rowsFiltered).toBe(SEEDED_OPS);
-      expect(old.nodes).toContain('Backward');
-    });
-
-    it('the NAIVE array-only fix reintroduces the same walk (do not "simplify" to this)', async () => {
-      // `findFirst({ entityIds: { has }, orderBy: { serverSeq: 'desc' } })`. GIN still
-      // cannot order, so the planner makes the same losing bet.
-      const naive = await explainGeneric(
-        db,
-        `SELECT server_seq FROM operations
-           WHERE user_id = $1 AND entity_type = $2 AND entity_ids @> ARRAY[$3]::text[]
-           ORDER BY server_seq DESC LIMIT 1`,
-        ARGS,
-      );
-
-      expect(naive.rowsFiltered).toBe(SEEDED_OPS);
-      expect(naive.nodes).toContain('Backward');
-    });
-
-    it('the split lookups each stay bounded by actually-matching rows', async () => {
-      const scalar = await explainGeneric(
-        db,
-        `SELECT server_seq FROM operations
-           WHERE user_id = $1 AND entity_type = $2 AND entity_id = $3
-           ORDER BY server_seq DESC LIMIT 1`,
-        ARGS,
-      );
-      const array = await explainGeneric(
-        db,
-        // Same param order as conflict.ts: entityId first, inside the CTE.
-        ARRAY_BRANCH_SQL,
-        `'${MISSING}', ${USER_ID}, 'TASK'`,
-      );
-
-      expect(scalar.rowsFiltered).toBe(0);
-      expect(array.rowsFiltered).toBe(0);
-      expect(scalar.blocks + array.blocks).toBeLessThan(MAX_BLOCKS);
-    });
-
-    it('the array branch reaches the GIN index, never the entity btree', async () => {
+    it('the shipped CTE stays bounded and reaches GIN, never the entity btree', async () => {
       // The load-bearing claim. Inside the CTE the only predicate is
       // `entity_ids @> ...`, so the composite btree has no usable leading column and
       // GIN is the only index available AT ANY COST ESTIMATE — this is structural,
       // not a costing accident, which is why it survives generic planning.
-      const array = await explainGeneric(
-        db,
-        ARRAY_BRANCH_SQL,
-        `'${MISSING}', ${USER_ID}, 'TASK'`,
-      );
+      const array = await explainGeneric(db, ARRAY_BRANCH_SQL, ARRAY_ARGS);
 
+      expectWithinBudget(array);
       expect(array.nodes).toContain('operations_entity_ids_gin');
       expect(array.nodes).not.toContain(
         'operations_user_id_entity_type_entity_id_server_seq_idx',
@@ -500,38 +462,92 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
       expect(array.nodes).not.toContain('Backward');
     });
 
-    it('adding a server_seq bound does NOT improve the generic plan (why there is none)', async () => {
-      // A review proposed bounding the array branch with `server_seq > <scalar seq>`,
-      // measured at 495 -> 9 buffers. That gain is a CUSTOM-plan artifact: with the
-      // value visible the planner knows the bound is selective. Under generic
-      // planning the value is invisible, so the bound cannot drive an index — it
-      // lands as a post-GIN Filter and buys nothing. Measured separately on a
-      // multi-user seed, inside the CTE it is actively harmful: with no user_id
-      // predicate available there, a custom plan bitmap-scans (user_id, server_seq)
-      // on `server_seq > $4` alone — no leading-column bound, i.e. a full index scan
-      // across EVERY user's history. Hence: no bound. Revisit only with a generic
-      // plan from production showing otherwise.
-      const bounded = await explainGeneric(
+    it('the scalar branch stays bounded on its own composite btree', async () => {
+      const scalar = await explainGeneric(
         db,
-        `WITH cand AS MATERIALIZED (
-           SELECT user_id, entity_type, server_seq
-           FROM operations
-           WHERE entity_ids @> ARRAY[$1]::text[] AND server_seq > $4
-         )
-         SELECT MAX(server_seq)::int AS "maxSeq"
-         FROM cand
-         WHERE user_id = $2 AND entity_type = $3`,
-        `'${MISSING}', ${USER_ID}, 'TASK', 1`,
+        `SELECT server_seq FROM operations
+           WHERE user_id = $1 AND entity_type = $2 AND entity_id = $3
+           ORDER BY server_seq DESC LIMIT 1`,
+        SLICE_ARGS,
       );
 
-      // Still GIN — the bound changed nothing the planner could act on.
-      expect(bounded.nodes).toContain('operations_entity_ids_gin');
+      expectWithinBudget(scalar);
+    });
+
+    /**
+     * Every form that has been proposed, shipped or "simplified" into over the life of
+     * this query. All four abandon GIN under generic planning and read the probed
+     * user's whole entity_type slice; the budget catches each one.
+     */
+    const REGRESSION_SHAPES: Array<{ name: string; sql: string; args: unknown[] }> = [
+      {
+        name: 'the CTE with AS MATERIALIZED dropped (inlining hands back the btree)',
+        sql: `
+          WITH cand AS (
+            SELECT user_id, entity_type, server_seq
+            FROM operations
+            WHERE entity_ids @> ARRAY[$1]::text[]
+          )
+          SELECT MAX(server_seq)::int AS "maxSeq"
+          FROM cand
+          WHERE user_id = $2 AND entity_type = $3`,
+        args: ARRAY_ARGS,
+      },
+      {
+        name: 'the flat MAX form (the natural "why is there a CTE?" simplification)',
+        sql: `SELECT MAX(server_seq)::int AS "maxSeq" FROM operations
+              WHERE user_id = $1 AND entity_type = $2
+                AND entity_ids @> ARRAY[$3]::text[]`,
+        args: SLICE_ARGS,
+      },
+      {
+        name: "Prisma's aggregate({ _max }) form (MAX(...) FROM (... OFFSET 0))",
+        sql: `SELECT MAX(server_seq)::int AS "maxSeq" FROM (
+                SELECT server_seq FROM operations
+                WHERE user_id = $1 AND entity_type = $2
+                  AND entity_ids @> ARRAY[$3]::text[]
+                OFFSET 0
+              ) sub`,
+        args: SLICE_ARGS,
+      },
+      {
+        name: 'the OLD combined OR + LIMIT 1 (the outage)',
+        sql: `SELECT server_seq FROM operations
+              WHERE user_id = $1 AND entity_type = $2
+                AND (entity_id = $3 OR entity_ids @> ARRAY[$3]::text[])
+              ORDER BY server_seq DESC LIMIT 1`,
+        args: SLICE_ARGS,
+      },
+      {
+        name: 'the NAIVE array-only fix (GIN still cannot order)',
+        sql: `SELECT server_seq FROM operations
+              WHERE user_id = $1 AND entity_type = $2
+                AND entity_ids @> ARRAY[$3]::text[]
+              ORDER BY server_seq DESC LIMIT 1`,
+        args: SLICE_ARGS,
+      },
+    ];
+
+    it.each(REGRESSION_SHAPES)('blows the budget: $name', async ({ sql, args }) => {
+      const regressed = await explainGeneric(db, sql, args);
+
+      // Not "worse than the CTE" but "over the budget the shipped query is measured
+      // against", so this fails for the same reason the end-to-end tests would.
+      expect(regressed.blocks).toBeGreaterThan(MAX_BLOCKS);
+      // It read and discarded the probed user's whole entity_type slice.
+      expect(regressed.rowsFiltered).toBe(OWN_OPS / ENTITY_TYPES.length);
+      expect(regressed.nodes).toContain(
+        'operations_user_id_entity_type_entity_id_server_seq_idx',
+      );
     });
   });
 });
 
 describe('detectConflictForEntity behaviour is unchanged by the query split (PGlite)', () => {
   let db: PGlite;
+
+  const TIME_DELTA_ACTION = '[TimeTracking] Sync time spent';
+  const OTHER_USER_ID = 7;
 
   const seed = async (op: {
     id: string;
@@ -540,16 +556,20 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
     entityId: string | null;
     entityIds?: string[];
     entityType?: string;
+    actionType?: string;
     schemaVersion?: number;
+    userId?: number;
     vectorClock?: Record<string, number>;
   }): Promise<void> => {
     await db.query(
       `INSERT INTO operations (${INSERT_COLS})
-       VALUES ($1,${USER_ID},$2,$3,'[Task] Update',$4,$5,$6,$7,$8)`,
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
       [
         op.id,
+        op.userId ?? USER_ID,
         op.clientId,
         op.serverSeq,
+        op.actionType ?? '[Task] Update',
         op.entityType ?? 'TASK',
         op.entityId,
         op.entityIds ?? [],
@@ -562,9 +582,10 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
   const detect = (
     entityId: string,
     opOverrides: Partial<Record<string, unknown>> = {},
+    userId: number = USER_ID,
   ): Promise<{ hasConflict: boolean }> =>
     detectConflictForEntity(
-      USER_ID,
+      userId,
       incomingOp(entityId, opOverrides),
       entityId,
       makeMeasuringTx(db, newStats()) as never,
@@ -689,8 +710,77 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
     expect((await detect('reverse-entity')).hasConflict).toBe(false);
   });
 
+  it('takes the NEWEST of several array-branch matches, not the oldest', async () => {
+    // Two stored ops mention the same entity via entity_ids. The aggregate must be
+    // MAX: against the newer row the incoming clock is CONCURRENT (conflict), against
+    // the older one it is GREATER_THAN (clean successor). MIN therefore accepts an op
+    // that overwrites a concurrent remote edit — silently, with no error anywhere.
+    await seed({
+      id: 'op-max-older',
+      serverSeq: 12,
+      clientId: 'cB',
+      entityId: 'max-primary',
+      entityIds: ['max-primary', 'max-target'],
+      vectorClock: { cB: 1 },
+    });
+    await seed({
+      id: 'op-max-newer',
+      serverSeq: 13,
+      clientId: 'cC',
+      entityId: 'max-primary',
+      entityIds: ['max-primary', 'max-target'],
+      vectorClock: { cC: 7 },
+    });
+
+    expect(
+      (await detect('max-target', { vectorClock: { cA: 4, cB: 1 } })).hasConflict,
+    ).toBe(true);
+  });
+
+  it('carries actionType from the ARRAY branch so concurrent time deltas still merge', async () => {
+    // Timer deltas are additive and commute, so two CONCURRENT deltas must NOT be
+    // reported as a conflict — resolveConflictForExistingOp only reaches that rule if
+    // the stored row's actionType survives the array-branch select. Dropping
+    // actionType there silently rejects tracked time, and only a delta routed through
+    // the ARRAY branch (reachable via entity_ids, not the scalar) exercises it.
+    await seed({
+      id: 'op-delta-remote',
+      serverSeq: 14,
+      clientId: 'cB',
+      actionType: TIME_DELTA_ACTION,
+      entityId: 'delta-primary',
+      entityIds: ['delta-primary', 'delta-target'],
+      vectorClock: { cB: 5 },
+    });
+
+    const result = await detect('delta-target', {
+      actionType: TIME_DELTA_ACTION,
+      vectorClock: { cA: 3 },
+    });
+
+    expect(result.hasConflict).toBe(false);
+  });
+
+  it('scopes the array-branch row fetch to the REQUESTING user', async () => {
+    // Every other case here runs as user 1, so a findUnique that ignored its userId
+    // argument would be invisible. Under a different user the winning row is only
+    // reachable when the point lookup is scoped correctly; otherwise it returns null,
+    // the conflict disappears, and a concurrent remote edit is overwritten.
+    await seed({
+      userId: OTHER_USER_ID,
+      id: 'op-other-user',
+      serverSeq: 42,
+      clientId: 'other',
+      entityId: 'scoped-primary',
+      entityIds: ['scoped-primary', 'scoped-target'],
+      vectorClock: { other: 1 },
+    });
+
+    expect((await detect('scoped-target', {}, OTHER_USER_ID)).hasConflict).toBe(true);
+  });
+
   it('ignores a full-state op (entity_id NULL, entity_ids {}) without erroring', async () => {
-    await seed({ id: 'op-full', serverSeq: 7, clientId: 'other', entityId: null });
+    await seed({ id: 'op-full', serverSeq: 8, clientId: 'other', entityId: null });
 
     expect((await detect('some-entity-after-full-state')).hasConflict).toBe(false);
   });
@@ -700,7 +790,7 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
     // GLOBAL_CONFIG:tasks; that alias lookup must survive the query split.
     await seed({
       id: 'op-legacy-misc',
-      serverSeq: 8,
+      serverSeq: 10,
       clientId: 'other',
       entityId: 'misc',
       entityType: 'GLOBAL_CONFIG',
@@ -718,7 +808,7 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
     // disjoint from tasks and must not fabricate a conflict.
     await seed({
       id: 'op-modern-misc',
-      serverSeq: 9,
+      serverSeq: 11,
       clientId: 'other',
       entityId: 'misc',
       entityType: 'GLOBAL_CONFIG',

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -781,6 +781,53 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
     expect((await detect('scoped-target', {}, OTHER_USER_ID)).hasConflict).toBe(true);
   });
 
+  // The CTE matches entity_ids across ALL users and types; only the OUTER user_id /
+  // entity_type predicates restore isolation. Both were uncovered — replacing them with
+  // typed tautologies left all 915 tests green. The failure is silent rather than empty
+  // because server_seq is per-user: a leaked MAX still resolves to a REAL row of the
+  // requesting user through the (user_id, server_seq) point lookup, so an unrelated op
+  // becomes the conflict basis. Each case below seeds exactly that collision.
+  it('does not take the array-branch MAX from ANOTHER user', async () => {
+    await seed({
+      userId: OTHER_USER_ID,
+      id: 'op-cross-tenant',
+      serverSeq: 9001,
+      clientId: 'tenant-a',
+      entityId: 'tenant-a-primary',
+      entityIds: ['tenant-a-primary', 'cross-tenant-entity'],
+      vectorClock: { 'tenant-a': 1 },
+    });
+    // Same server_seq under the REQUESTING user, unrelated entity, concurrent clock.
+    // Reachable only if the CTE leaks the other tenant's sequence.
+    await seed({
+      id: 'op-decoy-same-seq',
+      serverSeq: 9001,
+      clientId: 'decoy',
+      entityId: 'unrelated-to-the-probe',
+      vectorClock: { decoy: 5 },
+    });
+
+    // USER_ID has never touched cross-tenant-entity, so nothing can conflict.
+    expect((await detect('cross-tenant-entity')).hasConflict).toBe(false);
+  });
+
+  it('does not take the array-branch MAX from another ENTITY TYPE', async () => {
+    // Same user and same entity id, but the only op carrying it is a PROJECT op while
+    // the incoming op is a TASK. Dropping the entity_type predicate fetches this very
+    // row (it belongs to USER_ID), and its concurrent clock invents a conflict.
+    await seed({
+      id: 'op-cross-type',
+      serverSeq: 9002,
+      clientId: 'other-type',
+      entityType: 'PROJECT',
+      entityId: 'proj-primary',
+      entityIds: ['proj-primary', 'cross-type-entity'],
+      vectorClock: { 'other-type': 9 },
+    });
+
+    expect((await detect('cross-type-entity')).hasConflict).toBe(false);
+  });
+
   it('ignores a full-state op (entity_id NULL, entity_ids {}) without erroring', async () => {
     await seed({ id: 'op-full', serverSeq: 8, clientId: 'other', entityId: null });
 

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -38,11 +38,23 @@ import type { Operation } from '../src/sync/sync.types';
  *    always wins on cost and no regression is detectable. That degenerate shape is
  *    why this suite could not catch the outage. At 20k rows for the probed user plus
  *    20k spread over ~20k other users across 8 entity types, PGlite reproduces the
- *    production plan node-for-node and every regression below lands ~400x over budget.
+ *    production plan node-for-node and every regression lands ~6x over budget.
+ *  - THE INDEXES ARE CREATED BEFORE THE ROWS. This is not cosmetic ordering. Building
+ *    the GIN after a bulk load produces a compact, pending-list-free index, and the
+ *    array branch then measures 2 blocks — a number production only sees right after a
+ *    vacuum. In production the index pre-exists and rows arrive one op at a time, so
+ *    inserts land in the GIN pending list (fastupdate defaults to on) which `@>` must
+ *    scan linearly: same data, same query, 140 blocks and a 14x larger index (1120 kB
+ *    vs 72 kB). VACUUM flushes the pending list and restores 2 blocks, so the real cost
+ *    OSCILLATES between the two across the autovacuum cycle, bounded above by
+ *    gin_pending_list_limit rather than by anything in this seed. This suite therefore
+ *    seeds in production order and never vacuums: it measures the WORST realistic
+ *    steady state, which is what a regression budget should sit above. Setting
+ *    fastupdate=off removes the oscillation and pins the array branch at 2 blocks.
  *
- * REMAINING FIDELITY LIMIT: PGlite is not the production cluster. It has no btree_gin,
- * so the composite (user_id, entity_ids) index proposed in conflict.ts as the fix for
- * the shared-literal-id scan cannot be evaluated here at all.
+ * REMAINING FIDELITY LIMIT: PGlite is not the production cluster — different major
+ * version, and it reports every block as a cache hit, so these counts cannot model
+ * cold-cache I/O.
  */
 
 const OWN_OPS = 20_000;
@@ -92,31 +104,24 @@ const INSERT_COLS =
   'id,user_id,client_id,server_seq,action_type,entity_type,entity_id,entity_ids,' +
   'schema_version,vector_clock';
 
-/**
- * The array branch as conflict.ts issues it, with positional params in tagged-template
- * order. Used only by the raw-shape comparisons below; the end-to-end tests reconstruct
- * this from the real template instead, so the two are cross-checked against each other.
- */
-const ARRAY_BRANCH_SQL = `
-  WITH cand AS MATERIALIZED (
-    SELECT user_id, entity_type, server_seq
-    FROM operations
-    WHERE entity_ids @> ARRAY[$1]::text[]
-  )
-  SELECT MAX(server_seq)::int AS "maxSeq"
-  FROM cand
-  WHERE user_id = $2 AND entity_type = $3`;
-
 type PlanStats = {
   blocks: number;
   rowsFiltered: number;
   sql: string[];
   rawSql: string[];
+  /** Plan node types + index names, per measured query, parallel to `sql`. */
+  nodes: string[];
 };
 type PlanNode = Record<string, unknown>;
 type Measured = { blocks: number; rowsFiltered: number; nodes: string };
 
-const newStats = (): PlanStats => ({ blocks: 0, rowsFiltered: 0, sql: [], rawSql: [] });
+const newStats = (): PlanStats => ({
+  blocks: 0,
+  rowsFiltered: 0,
+  sql: [],
+  rawSql: [],
+  nodes: [],
+});
 
 /**
  * Walks the plan tree for node names and filtered-row counts.
@@ -272,6 +277,7 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
     stats.blocks += measured.blocks;
     stats.rowsFiltered += measured.rowsFiltered;
     stats.sql.push(sql);
+    stats.nodes.push(measured.nodes);
     return (await db.query<Record<string, unknown>>(sql, params)).rows;
   };
 
@@ -329,12 +335,18 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
 };
 
 // Post-fix both branches are index lookups bounded by actually-matching rows.
-// Measured on this seed: the array branch reads 2 blocks and the scalar 3, filtering
-// nothing. Every regression form below reads 806 blocks and filters 2500 — the probed
-// user's whole TASK slice — so one budget separates them by ~400x. Budgets are the
-// metric, not plan names: plan shapes are row-count and version dependent, "how much
-// did it actually read" is not.
-const MAX_BLOCKS = 100;
+// Measured on this seed, seeded in production order: the array branch reads 140 blocks
+// (GIN pending list — see the header) and the scalar 3, both filtering NOTHING. Every
+// regression form reads 816 blocks and filters 2500, the probed user's whole TASK slice.
+//
+// `rowsFiltered === 0` is the load-bearing assertion; the budget is the backstop. The
+// filtered count is the regression's actual signature — "read the user's history and
+// threw it away" — and it is scale-free, so it keeps its meaning if the seed changes.
+// The block budget is NOT scale-free: it sits ~2x above the measured 143 and ~5.7x below
+// the regressions, a margin that only holds for THIS seed's user/entity-type ratio. If
+// you change the seed, re-derive it — and the canary test below exists to fail loudly if
+// the seed ever stops reproducing the mis-plan at all.
+const MAX_BLOCKS = 300;
 
 const expectWithinBudget = (measured: { blocks: number; rowsFiltered: number }): void => {
   expect(measured.rowsFiltered).toBe(0);
@@ -348,6 +360,9 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     db = new PGlite();
     await db.waitReady;
     await db.exec(CREATE_TABLE);
+    // BEFORE the rows, as in production — see the header note. Building the GIN after
+    // the load yields a pending-list-free index that measures 2 blocks instead of 140.
+    await db.exec(CREATE_INDEXES);
 
     // entity_ids stays '{}' on EVERY row — see the header note. Populating it here
     // gives the planner array statistics and disarms the regression.
@@ -377,9 +392,9 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     }
     await flush();
 
-    // Index after the bulk load, then ANALYZE so the planner works from real
-    // statistics rather than defaults on an unanalyzed table.
-    await db.exec(CREATE_INDEXES);
+    // ANALYZE so the planner works from real statistics rather than defaults on an
+    // unanalyzed table. Deliberately NOT VACUUM: that would flush the GIN pending list
+    // and measure the freshly-vacuumed best case instead of the steady state.
     await db.exec('ANALYZE operations');
   }, 120_000);
 
@@ -401,6 +416,20 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
 
     expect(result.hasConflict).toBe(false);
     expectWithinBudget(stats);
+
+    // Structural, and on the REAL template rather than a copy of it: inside the CTE the
+    // only predicate is `entity_ids @> ...`, so the composite btree has no usable
+    // leading column and GIN is the only index available AT ANY COST ESTIMATE. That is
+    // why the shape survives generic planning. Every regression form — inlining the
+    // CTE, flattening it, reinstating the OR — reaches the btree instead, so this
+    // catches them structurally even if a future seed stops blowing the budget.
+    expect(stats.rawSql).toHaveLength(1);
+    const arrayBranchPlan = stats.nodes[stats.sql.indexOf(stats.rawSql[0])];
+    expect(arrayBranchPlan).toContain('operations_entity_ids_gin');
+    expect(arrayBranchPlan).not.toContain(
+      'operations_user_id_entity_type_entity_id_server_seq_idx',
+    );
+    expect(arrayBranchPlan).not.toContain('Backward');
   });
 
   it('reads a bounded amount for an entity deep in the history', async () => {
@@ -416,130 +445,41 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     expectWithinBudget(stats);
   });
 
-  it('sends the array branch as a MATERIALIZED CTE', async () => {
-    // A text guard on top of the behavioural budget test below: the budget proves the
-    // keyword's EFFECT, this pins its presence so a removal is never silent even if a
-    // future seed stops reproducing the mis-plan.
-    const stats = newStats();
-
-    await detectConflictForEntity(
-      USER_ID,
-      incomingOp('task-brand-new'),
-      'task-brand-new',
-      makeMeasuringTx(db, stats) as never,
+  /**
+   * A CANARY, not a test of the source. It EXPLAINs a hardcoded copy of the OLD outage
+   * query — a string that exists only here — so it responds to no change in conflict.ts
+   * and proves nothing about the shipped code. Its one job is to prove that THIS SEED
+   * still reproduces the mis-plan, which is what gives the budget above its meaning.
+   *
+   * That job is real: the budget is an absolute, and its detection power depends on the
+   * seed's user/entity-type ratio. Shrink the seed, or collapse it toward one user and
+   * one entity type, and the regression's cost falls below MAX_BLOCKS while every other
+   * test in this file keeps passing — a suite that has silently stopped being able to
+   * fail. This fails instead.
+   *
+   * It replaced five near-identical shapes (the inlined CTE, the flat MAX, Prisma's
+   * aggregate form, the naive array-only fix, and this one). They were the same
+   * hardcoded-string assertion five times over and responded to no source mutation,
+   * while the shipped query's own budget and structural plan assertions above cover
+   * those regressions where it counts — on the real SQL. Verified by mutation: inlining
+   * the CTE in conflict.ts fails the two end-to-end budget tests, not this block.
+   */
+  it('CANARY: the seed still reproduces the mis-plan the budget is calibrated against', async () => {
+    const regressed = await explainGeneric(
+      db,
+      `SELECT server_seq FROM operations
+         WHERE user_id = $1 AND entity_type = $2
+           AND (entity_id = $3 OR entity_ids @> ARRAY[$3]::text[])
+         ORDER BY server_seq DESC LIMIT 1`,
+      [USER_ID, 'TASK', 'task-brand-new'],
     );
 
-    expect(stats.rawSql).toHaveLength(1);
-    expect(stats.rawSql[0]).toContain('AS MATERIALIZED');
-    expect(stats.rawSql[0]).not.toContain('NOT MATERIALIZED');
-    // The outer user boundary must stay outside the CTE.
-    expect(stats.rawSql[0]).toMatch(/FROM cand\s+WHERE user_id =/);
-  });
-
-  /**
-   * EVERY assertion here runs under `force_generic_plan`. Testing these shapes with
-   * literal constants — which this block used to do — is what let two broken designs
-   * through: both planned beautifully as custom plans and read the whole slice as
-   * generic ones.
-   */
-  describe('raw query shapes under force_generic_plan (what production actually gets)', () => {
-    const MISSING = 'task-brand-new';
-    const ARRAY_ARGS = [MISSING, USER_ID, 'TASK'];
-    const SLICE_ARGS = [USER_ID, 'TASK', MISSING];
-
-    it('the shipped CTE stays bounded and reaches GIN, never the entity btree', async () => {
-      // The load-bearing claim. Inside the CTE the only predicate is
-      // `entity_ids @> ...`, so the composite btree has no usable leading column and
-      // GIN is the only index available AT ANY COST ESTIMATE — this is structural,
-      // not a costing accident, which is why it survives generic planning.
-      const array = await explainGeneric(db, ARRAY_BRANCH_SQL, ARRAY_ARGS);
-
-      expectWithinBudget(array);
-      expect(array.nodes).toContain('operations_entity_ids_gin');
-      expect(array.nodes).not.toContain(
-        'operations_user_id_entity_type_entity_id_server_seq_idx',
-      );
-      expect(array.nodes).not.toContain('Backward');
-    });
-
-    it('the scalar branch stays bounded on its own composite btree', async () => {
-      const scalar = await explainGeneric(
-        db,
-        `SELECT server_seq FROM operations
-           WHERE user_id = $1 AND entity_type = $2 AND entity_id = $3
-           ORDER BY server_seq DESC LIMIT 1`,
-        SLICE_ARGS,
-      );
-
-      expectWithinBudget(scalar);
-    });
-
-    /**
-     * Every form that has been proposed, shipped or "simplified" into over the life of
-     * this query. All four abandon GIN under generic planning and read the probed
-     * user's whole entity_type slice; the budget catches each one.
-     */
-    const REGRESSION_SHAPES: Array<{ name: string; sql: string; args: unknown[] }> = [
-      {
-        name: 'the CTE with AS MATERIALIZED dropped (inlining hands back the btree)',
-        sql: `
-          WITH cand AS (
-            SELECT user_id, entity_type, server_seq
-            FROM operations
-            WHERE entity_ids @> ARRAY[$1]::text[]
-          )
-          SELECT MAX(server_seq)::int AS "maxSeq"
-          FROM cand
-          WHERE user_id = $2 AND entity_type = $3`,
-        args: ARRAY_ARGS,
-      },
-      {
-        name: 'the flat MAX form (the natural "why is there a CTE?" simplification)',
-        sql: `SELECT MAX(server_seq)::int AS "maxSeq" FROM operations
-              WHERE user_id = $1 AND entity_type = $2
-                AND entity_ids @> ARRAY[$3]::text[]`,
-        args: SLICE_ARGS,
-      },
-      {
-        name: "Prisma's aggregate({ _max }) form (MAX(...) FROM (... OFFSET 0))",
-        sql: `SELECT MAX(server_seq)::int AS "maxSeq" FROM (
-                SELECT server_seq FROM operations
-                WHERE user_id = $1 AND entity_type = $2
-                  AND entity_ids @> ARRAY[$3]::text[]
-                OFFSET 0
-              ) sub`,
-        args: SLICE_ARGS,
-      },
-      {
-        name: 'the OLD combined OR + LIMIT 1 (the outage)',
-        sql: `SELECT server_seq FROM operations
-              WHERE user_id = $1 AND entity_type = $2
-                AND (entity_id = $3 OR entity_ids @> ARRAY[$3]::text[])
-              ORDER BY server_seq DESC LIMIT 1`,
-        args: SLICE_ARGS,
-      },
-      {
-        name: 'the NAIVE array-only fix (GIN still cannot order)',
-        sql: `SELECT server_seq FROM operations
-              WHERE user_id = $1 AND entity_type = $2
-                AND entity_ids @> ARRAY[$3]::text[]
-              ORDER BY server_seq DESC LIMIT 1`,
-        args: SLICE_ARGS,
-      },
-    ];
-
-    it.each(REGRESSION_SHAPES)('blows the budget: $name', async ({ sql, args }) => {
-      const regressed = await explainGeneric(db, sql, args);
-
-      // Not "worse than the CTE" but "over the budget the shipped query is measured
-      // against", so this fails for the same reason the end-to-end tests would.
-      expect(regressed.blocks).toBeGreaterThan(MAX_BLOCKS);
-      // It read and discarded the probed user's whole entity_type slice.
-      expect(regressed.rowsFiltered).toBe(OWN_OPS / ENTITY_TYPES.length);
-      expect(regressed.nodes).toContain(
-        'operations_user_id_entity_type_entity_id_server_seq_idx',
-      );
-    });
+    expect(regressed.blocks).toBeGreaterThan(MAX_BLOCKS);
+    // It read and discarded the probed user's whole entity_type slice.
+    expect(regressed.rowsFiltered).toBe(OWN_OPS / ENTITY_TYPES.length);
+    expect(regressed.nodes).toContain(
+      'operations_user_id_entity_type_entity_id_server_seq_idx',
+    );
   });
 });
 

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -19,10 +19,12 @@ import type { Operation } from '../src/sync/sync.types';
  * fail here instead of passing against a stale copy.
  *
  * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS. Prisma sends parameterized
- * prepared statements, and under the default `auto` Postgres builds CUSTOM plans for the
- * first ~5 executions before settling on a GENERIC one that cannot see parameter values.
- * A hot path lives in that steady state, so generic is the mode that matters — but note
- * production does receive custom plans too, and this file does not cover them (a
+ * prepared statements; under the default `auto` Postgres plans the first ~5 executions as
+ * CUSTOM, then compares the generic cost against the average custom cost and MAY switch to
+ * a generic plan — a cost comparison, not an automatic switch, so a statement can stay on
+ * custom plans indefinitely. THIS one was observed going generic on production, and a
+ * generic plan cannot see parameter values, so that is the mode this file covers.
+ * Production also serves custom plans and this file does NOT cover them (a
  * custom-plan-only regression is possible; see the rejected `server_seq >` narrowing in
  * conflict.ts). `EXPLAIN` with literal constants is a third thing again, and is the trap:
  * this file once tested that way and the blind spot passed two designs that were
@@ -86,7 +88,10 @@ const CREATE_TABLE = `
     id             text PRIMARY KEY,
     user_id        integer NOT NULL,
     client_id      text NOT NULL,
-    server_seq     bigint NOT NULL,
+    -- integer, NOT bigint: production maps serverSeq as Prisma Int. Declaring bigint
+    -- here made MAX() return bigint, which the shim's Number() coercion then hid, so
+    -- dropping the ::int cast from the production SQL would have stayed green.
+    server_seq     integer NOT NULL,
     action_type    text NOT NULL,
     entity_type    text NOT NULL,
     entity_id      text,

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -46,11 +46,14 @@ import type { Operation } from '../src/sync/sync.types';
  *    inserts land in the GIN pending list (fastupdate defaults to on) which `@>` must
  *    scan linearly: same data, same query, 140 blocks and a 14x larger index (1120 kB
  *    vs 72 kB). VACUUM flushes the pending list and restores 2 blocks, so the real cost
- *    OSCILLATES between the two across the autovacuum cycle, bounded above by
- *    gin_pending_list_limit rather than by anything in this seed. This suite therefore
- *    seeds in production order and never vacuums: it measures the WORST realistic
- *    steady state, which is what a regression budget should sit above. Setting
- *    fastupdate=off removes the oscillation and pins the array branch at 2 blocks.
+ *    OSCILLATES across the autovacuum cycle. This suite therefore seeds in production
+ *    order and never vacuums, measuring the dirty end of that cycle rather than the
+ *    freshly-vacuumed end — but 140 is NOT a ceiling: the pending list is bounded by
+ *    gin_pending_list_limit (4MB default), not by anything in this seed, so a
+ *    production write burst can be worse. The budget below is calibrated to catch the
+ *    mis-plan, NOT to certify a maximum. Setting fastupdate=off stops new entries
+ *    queueing — it does not flush what is already pending, which still needs a VACUUM —
+ *    and so removes the oscillation going forward.
  *
  * REMAINING FIDELITY LIMIT: PGlite is not the production cluster — different major
  * version, and it reports every block as a cache hit, so these counts cannot model
@@ -488,6 +491,8 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
 
   const TIME_DELTA_ACTION = '[TimeTracking] Sync time spent';
   const OTHER_USER_ID = 7;
+  /** Own tenant, so the legacy-misc row seeded for USER_ID cannot mask the gate. */
+  const POST_SPLIT_USER_ID = 8;
 
   const seed = async (op: {
     id: string;
@@ -778,7 +783,16 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
   it('does not alias a POST-split misc write onto tasks', async () => {
     // The alias is gated on the fixed v1→v2 split boundary; a v2+ misc write is
     // disjoint from tasks and must not fabricate a conflict.
+    //
+    // MUST probe exactly 'tasks'. detectConflictForEntity enters the legacy-misc branch
+    // only for entityId === 'tasks', so probing any other id (this once read
+    // 'tasks-v2-only') never reaches the gate and passes no matter what the gate does —
+    // verified: breaking it to `lte` left all 915 tests green.
+    //
+    // Runs as its OWN user because the preceding test leaves a schema_version 1 misc row
+    // for USER_ID in the shared table, which would legitimately alias and mask this.
     await seed({
+      userId: POST_SPLIT_USER_ID,
       id: 'op-modern-misc',
       serverSeq: 11,
       clientId: 'other',
@@ -789,7 +803,8 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
     });
 
     expect(
-      (await detect('tasks-v2-only', { entityType: 'GLOBAL_CONFIG' })).hasConflict,
+      (await detect('tasks', { entityType: 'GLOBAL_CONFIG' }, POST_SPLIT_USER_ID))
+        .hasConflict,
     ).toBe(false);
   });
 });

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -44,7 +44,10 @@ import type { Operation } from '../src/sync/sync.types';
  *    always wins on cost and no regression is detectable. That degenerate shape is
  *    why this suite could not catch the outage. At 20k rows for the probed user plus
  *    20k spread over ~20k other users across 8 entity types, PGlite reproduces the
- *    production plan node-for-node and every regression lands ~6x over budget.
+ *    SHAPE of the production mis-plan (same nodes, same discarded-row signature) and
+ *    the regression lands ~2.7x over the block budget — 816 against MAX_BLOCKS 300.
+ *    Node-for-node identity with production is NOT claimed; see the fidelity limit
+ *    below.
  *  - THE INDEXES ARE CREATED BEFORE THE ROWS. This is not cosmetic ordering. Building
  *    the GIN after a bulk load produces a compact, pending-list-free index, and the
  *    array branch then measures 2 blocks — a number production only sees right after a
@@ -88,9 +91,10 @@ const CREATE_TABLE = `
     id             text PRIMARY KEY,
     user_id        integer NOT NULL,
     client_id      text NOT NULL,
-    -- integer, NOT bigint: production maps serverSeq as Prisma Int. Declaring bigint
-    -- here made MAX() return bigint, which the shim's Number() coercion then hid, so
-    -- dropping the ::int cast from the production SQL would have stayed green.
+    -- integer, NOT bigint: production maps serverSeq as Prisma Int, so this matches the
+    -- deployed column type. It is a FIDELITY fix and nothing more — it does not make
+    -- dropping the production ::int cast catchable, because over an integer column MAX()
+    -- already returns integer and the cast is a no-op either way.
     server_seq     integer NOT NULL,
     action_type    text NOT NULL,
     entity_type    text NOT NULL,
@@ -101,9 +105,12 @@ const CREATE_TABLE = `
   );
 `;
 
-// Index set mirrors prisma/schema.prisma + the migrations: 0_init (the
-// (user_id, server_seq) unique the backward walk rides on), 20260511000000 (the
-// entity btree) and 20260613000001 (the entity_ids GIN).
+// A deliberate SUBSET of prisma/schema.prisma + the migrations — the three indexes this
+// lookup can actually ride: 0_init (the (user_id, server_seq) unique the backward walk
+// rides on), 20260511000000 (the entity btree) and 20260613000001 (the entity_ids GIN).
+// Production also has a PK on id plus (user_id, client_id) and (user_id, received_at)
+// btrees; they are left out because no predicate here can use them. Add them if a new
+// shape could.
 const CREATE_INDEXES = `
   CREATE UNIQUE INDEX operations_user_id_server_seq_key
     ON operations (user_id, server_seq);
@@ -348,14 +355,19 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
 
 // Post-fix both branches are index lookups bounded by actually-matching rows.
 // Measured on this seed, seeded in production order: the array branch reads 140 blocks
-// (GIN pending list — see the header) and the scalar 3, both filtering NOTHING. Every
-// regression form reads 816 blocks and filters 2500, the probed user's whole TASK slice.
+// (GIN pending list — see the header) and the scalar 3, both filtering NOTHING. The
+// regression form pinned by the CANARY below — the combined OR that caused the outage —
+// reads 816 blocks and filters 2500, the probed user's whole TASK slice. (The other
+// broken shapes named in conflict.ts degrade the same way, but only this one is
+// measured here.)
 //
 // `rowsFiltered === 0` is the load-bearing assertion; the budget is the backstop. The
 // filtered count is the regression's actual signature — "read the user's history and
 // threw it away" — and it is scale-free, so it keeps its meaning if the seed changes.
-// The block budget is NOT scale-free: it sits ~2x above the measured 143 and ~5.7x below
-// the regressions, a margin that only holds for THIS seed's user/entity-type ratio. If
+// The block budget is NOT scale-free: it sits ~2x above the measured 143 and only ~2.7x
+// below the regression's 816, a margin that holds only for THIS seed's
+// user/entity-type ratio. (The wider ~5.7x is regression-to-measured, not
+// regression-to-budget — the real headroom is the smaller number.) If
 // you change the seed, re-derive it — and the canary test below exists to fail loudly if
 // the seed ever stops reproducing the mis-plan at all.
 const MAX_BLOCKS = 300;

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -19,9 +19,13 @@ import type { Operation } from '../src/sync/sync.types';
  * fail here instead of passing against a stale copy.
  *
  * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS. Prisma sends parameterized
- * prepared statements, so production runs a GENERIC plan that cannot see parameter
- * values; EXPLAIN with literal constants yields a CUSTOM plan nobody receives. This
- * file once tested with literals and that blind spot passed two designs that were
+ * prepared statements, and under the default `auto` Postgres builds CUSTOM plans for the
+ * first ~5 executions before settling on a GENERIC one that cannot see parameter values.
+ * A hot path lives in that steady state, so generic is the mode that matters — but note
+ * production does receive custom plans too, and this file does not cover them (a
+ * custom-plan-only regression is possible; see the rejected `server_seq >` narrowing in
+ * conflict.ts). `EXPLAIN` with literal constants is a third thing again, and is the trap:
+ * this file once tested that way and the blind spot passed two designs that were
  * catastrophic in production. EVERYTHING here — including the shim — goes through
  * explainGeneric. If you add a shape, use explainGeneric.
  *
@@ -420,12 +424,16 @@ describe('detectConflictForEntity does not scan the history (PGlite)', () => {
     expect(result.hasConflict).toBe(false);
     expectWithinBudget(stats);
 
-    // Structural, and on the REAL template rather than a copy of it: inside the CTE the
-    // only predicate is `entity_ids @> ...`, so the composite btree has no usable
-    // leading column and GIN is the only index available AT ANY COST ESTIMATE. That is
-    // why the shape survives generic planning. Every regression form — inlining the
-    // CTE, flattening it, reinstating the OR — reaches the btree instead, so this
-    // catches them structurally even if a future seed stops blowing the budget.
+    // Asserted on the REAL template rather than a copy of it. Inside the CTE the only
+    // predicate is `entity_ids @> ...`, so the composite btree has no usable leading
+    // column and GIN is the only INDEX available at any cost estimate — that much is
+    // structural, and it is why every regression form (inlining the CTE, flattening it,
+    // reinstating the OR) reaches the btree instead and is caught here even if a future
+    // seed stops blowing the budget.
+    //
+    // It does NOT prove GIN is forced: a sequential scan remains available at any time
+    // and wins for an unselective id (a globally shared entity id does exactly that).
+    // This pins the MEASURED plan for this seed, not a guarantee.
     expect(stats.rawSql).toHaveLength(1);
     const arrayBranchPlan = stats.nodes[stats.sql.indexOf(stats.rawSql[0])];
     expect(arrayBranchPlan).toContain('operations_entity_ids_gin');

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -1,0 +1,537 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { detectConflictForEntity } from '../src/sync/conflict';
+import type { Operation } from '../src/sync/sync.types';
+
+/**
+ * Production incident regression: the single-entity conflict lookup scanned a
+ * user's ENTIRE operation history on every upload of a not-yet-seen entity.
+ *
+ * detectConflictForEntity used to match the entity with one Prisma filter —
+ * `OR: [{ entityId }, { entityIds: { has: entityId } }]` + `orderBy serverSeq desc`
+ * — which Postgres receives as
+ *
+ *   ... WHERE user_id=$1 AND entity_type=$2
+ *         AND (entity_id=$3 OR entity_ids @> $4)
+ *       ORDER BY server_seq DESC LIMIT 1
+ *
+ * The OR spans two different indexes (the (user_id, entity_type, entity_id,
+ * server_seq) btree and the entity_ids GIN) and GIN cannot supply server_seq
+ * ordering, so the planner may abandon both index paths and walk (user_id,
+ * server_seq) BACKWARDS applying the OR as a filter, betting the LIMIT 1 resolves
+ * early. For an entity with no matching rows — the first-ever op for a new task,
+ * the single most common upload — the bet loses and it reads the whole history.
+ *
+ * Live evidence (sync.super-productivity.com): 47 backends stuck on exactly this
+ * query, longest running 75 minutes, wait_event=DataFileRead, 61/66 connections
+ * active → Prisma pool exhaustion → all uploads AND downloads failing. Every index
+ * was valid; this was never a missing-index problem.
+ *
+ * WHAT DECIDES THE BET — READ THIS BEFORE RE-TESTING (measured below, and the
+ * reason the previous "the planner uses a BitmapOr + sort" comment looked true):
+ * the planner only takes the backward walk when it has NO array-element statistics
+ * for entity_ids. With none it falls back to a default `@>` selectivity (0.5%) and
+ * estimates ~150 of 30_000 rows match, so LIMIT 1 looks like it exits after ~200
+ * rows. Populate entity_ids on even 6 rows in 30_000 and ANALYZE, and the estimate
+ * drops to ~1 row, the walk prices itself out, and BitmapOr wins.
+ *
+ * That is not an exotic state — it is the deployed one. `entity_ids` was added by
+ * migration 20260613000000 with NO backfill (forward-only, see schema.prisma), and
+ * getStoredEntityIds stores [] for every single-entity op, i.e. the vast majority.
+ * Statistics are also TABLE-wide, not per-user: if ANALYZE's sample happens to
+ * contain no non-empty array, EVERY user's uploads degenerate at once, which is why
+ * this detonates suddenly rather than degrading gradually.
+ *
+ * So the seed below leaves entity_ids empty on every row on purpose. Do not
+ * "improve" it by populating the column — that silently disarms this regression.
+ *
+ * This spec runs the REAL detectConflictForEntity against in-process Postgres
+ * (PGlite — no Docker, no DATABASE_URL) through a tx shim that renders each Prisma
+ * call as the SQL Prisma emits, EXPLAIN (ANALYZE, BUFFERS)-ing every one and summing
+ * what they touched. Reverting the split in conflict.ts makes the shim emit the old
+ * OR query again and the row/block budgets below blow out by ~100x.
+ */
+
+const SEEDED_OPS = 30_000;
+const USER_ID = 1;
+
+const CREATE_TABLE = `
+  CREATE TABLE operations (
+    id             text PRIMARY KEY,
+    user_id        integer NOT NULL,
+    client_id      text NOT NULL,
+    server_seq     bigint NOT NULL,
+    action_type    text NOT NULL,
+    entity_type    text NOT NULL,
+    entity_id      text,
+    entity_ids     text[] NOT NULL DEFAULT '{}',
+    schema_version integer NOT NULL DEFAULT 1,
+    vector_clock   jsonb NOT NULL
+  );
+`;
+
+// Index set mirrors prisma/schema.prisma + the migrations: 0_init (the
+// (user_id, server_seq) unique the backward walk rides on), 20260511000000 (the
+// entity btree) and 20260613000001 (the entity_ids GIN).
+const CREATE_INDEXES = `
+  CREATE UNIQUE INDEX operations_user_id_server_seq_key
+    ON operations (user_id, server_seq);
+  CREATE INDEX operations_user_id_entity_type_entity_id_server_seq_idx
+    ON operations (user_id, entity_type, entity_id, server_seq);
+  CREATE INDEX operations_entity_ids_gin ON operations USING GIN (entity_ids);
+`;
+
+const INSERT_COLS =
+  'id,user_id,client_id,server_seq,action_type,entity_type,entity_id,entity_ids,' +
+  'schema_version,vector_clock';
+
+type PlanStats = { blocks: number; rowsFiltered: number; sql: string[] };
+type PlanNode = Record<string, unknown>;
+
+const newStats = (): PlanStats => ({ blocks: 0, rowsFiltered: 0, sql: [] });
+
+const accumulatePlan = (node: PlanNode, stats: PlanStats, nodes: string[]): void => {
+  stats.blocks +=
+    ((node['Shared Hit Blocks'] as number) ?? 0) +
+    ((node['Shared Read Blocks'] as number) ?? 0);
+  stats.rowsFiltered += (node['Rows Removed by Filter'] as number) ?? 0;
+  nodes.push(
+    `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
+      `${node['Index Name'] ? ' on ' + node['Index Name'] : ''}`,
+  );
+  for (const child of (node.Plans as PlanNode[]) ?? []) {
+    accumulatePlan(child, stats, nodes);
+  }
+};
+
+const explainOn = async (
+  db: PGlite,
+  sql: string,
+  params: unknown[],
+): Promise<{ blocks: number; rowsFiltered: number; nodes: string }> => {
+  const res = await db.query<Record<string, unknown>>(
+    `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`,
+    params,
+  );
+  const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
+  const stats = newStats();
+  const nodes: string[] = [];
+  accumulatePlan(plan, stats, nodes);
+  return {
+    blocks: stats.blocks,
+    rowsFiltered: stats.rowsFiltered,
+    nodes: nodes.join(' -> '),
+  };
+};
+
+const incomingOp = (
+  entityId: string,
+  overrides: Partial<Record<string, unknown>> = {},
+): Operation =>
+  ({
+    id: 'op-incoming',
+    clientId: 'uploader',
+    actionType: '[Task] Update',
+    opType: 'UPD',
+    entityType: 'TASK',
+    entityId,
+    vectorClock: { uploader: 1 },
+    timestamp: 1,
+    schemaVersion: 1,
+    ...overrides,
+  }) as unknown as Operation;
+
+/**
+ * Renders the Prisma calls detectConflictForEntity makes as the SQL Prisma emits,
+ * EXPLAIN-ing each one into `stats`. It deliberately also renders the OLD combined
+ * OR filter: reverting the fix must fail this spec on the row/block BUDGET (proving
+ * the plan degenerated), not on an unsupported-shape error.
+ */
+const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
+  const SELECT_COLS =
+    'action_type AS "actionType", client_id AS "clientId", ' +
+    'vector_clock AS "vectorClock", server_seq AS "serverSeq"';
+
+  // Prisma renders `entityIds: { has: x }` as `entity_ids @> ARRAY[x]`.
+  const renderConditions = (where: Record<string, any>, params: unknown[]): string[] => {
+    const push = (value: unknown): string => `$${params.push(value)}`;
+    const conds: string[] = [];
+    if (where.userId !== undefined) conds.push(`user_id = ${push(where.userId)}`);
+    if (where.entityType !== undefined) {
+      conds.push(`entity_type = ${push(where.entityType)}`);
+    }
+    if (where.entityId !== undefined) conds.push(`entity_id = ${push(where.entityId)}`);
+    if (where.entityIds?.has !== undefined) {
+      conds.push(`entity_ids @> ARRAY[${push(where.entityIds.has)}]::text[]`);
+    }
+    if (where.schemaVersion?.lt !== undefined) {
+      conds.push(`schema_version < ${push(where.schemaVersion.lt)}`);
+    }
+    if (Array.isArray(where.OR)) {
+      const alternatives = where.OR.map(
+        (alt: Record<string, any>) =>
+          renderConditions(alt, params).join(' AND ') || 'TRUE',
+      );
+      conds.push(`(${alternatives.join(' OR ')})`);
+    }
+    return conds;
+  };
+
+  const runMeasured = async (
+    sql: string,
+    params: unknown[],
+  ): Promise<Record<string, unknown>[]> => {
+    const measured = await explainOn(db, sql, params);
+    stats.blocks += measured.blocks;
+    stats.rowsFiltered += measured.rowsFiltered;
+    stats.sql.push(sql);
+    return (await db.query<Record<string, unknown>>(sql, params)).rows;
+  };
+
+  const normalize = (row?: Record<string, unknown>): Record<string, unknown> | null =>
+    row ? { ...row, serverSeq: Number(row.serverSeq) } : null;
+
+  return {
+    operation: {
+      findFirst: async (args: Record<string, any>) => {
+        const params: unknown[] = [];
+        const conds = renderConditions(args.where, params);
+        const order =
+          args.orderBy?.serverSeq === 'desc'
+            ? 'ORDER BY server_seq DESC'
+            : args.orderBy?.serverSeq === 'asc'
+              ? 'ORDER BY server_seq ASC'
+              : '';
+        const rows = await runMeasured(
+          `SELECT ${SELECT_COLS} FROM operations WHERE ${conds.join(' AND ')} ${order} LIMIT 1`,
+          params,
+        );
+        return normalize(rows[0]);
+      },
+      // Prisma compiles aggregate() to MAX() over a `SELECT ... OFFSET 0` subquery.
+      // That OFFSET is the planner fence that keeps this on the GIN bitmap path.
+      aggregate: async (args: Record<string, any>) => {
+        const params: unknown[] = [];
+        const conds = renderConditions(args.where, params);
+        const rows = await runMeasured(
+          `SELECT MAX(server_seq) AS max FROM (SELECT server_seq FROM operations ` +
+            `WHERE ${conds.join(' AND ')} OFFSET 0) sub`,
+          params,
+        );
+        const max = rows[0]?.max;
+        return {
+          _max: { serverSeq: max === null || max === undefined ? null : Number(max) },
+        };
+      },
+      findUnique: async (args: Record<string, any>) => {
+        const { userId, serverSeq } = args.where.userId_serverSeq;
+        const rows = await runMeasured(
+          `SELECT ${SELECT_COLS} FROM operations WHERE user_id = $1 AND server_seq = $2 LIMIT 1`,
+          [userId, serverSeq],
+        );
+        return normalize(rows[0]);
+      },
+    },
+  };
+};
+
+describe('detectConflictForEntity does not scan the history (PGlite)', () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await db.exec(CREATE_TABLE);
+
+    // entity_ids stays '{}' on EVERY row — see the header note. Populating it here
+    // gives the planner array statistics and disarms the regression.
+    let rows: string[] = [];
+    for (let seq = 1; seq <= SEEDED_OPS; seq++) {
+      rows.push(
+        `('op-${seq}', ${USER_ID}, 'seed-client', ${seq}, '[Task] Update', 'TASK',` +
+          ` 'task-${seq}', '{}', 1, '{"seed-client":${seq}}')`,
+      );
+      if (rows.length === 1000) {
+        await db.exec(`INSERT INTO operations (${INSERT_COLS}) VALUES ${rows.join(',')}`);
+        rows = [];
+      }
+    }
+
+    // Index after the bulk load, then ANALYZE so the planner works from real
+    // statistics rather than defaults on an unanalyzed table.
+    await db.exec(CREATE_INDEXES);
+    await db.exec('ANALYZE operations');
+  }, 60_000);
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  // Post-fix both branches are index lookups that match nothing: 0 rows filtered,
+  // ~12 blocks, flat in history size. The old single-OR query filters all 30_000
+  // rows across ~1366 blocks and grows linearly (measured 22x at 5k ops, 114x at
+  // 30k, 191x at 50k). Budgets are the metric, not plan names — plan shapes are
+  // row-count and version dependent, "how much did it actually read" is not.
+  const MAX_ROWS_FILTERED = SEEDED_OPS / 100;
+  const MAX_BLOCKS = 100;
+
+  it('reads a bounded amount for a BRAND-NEW entity (the incident case)', async () => {
+    const stats = newStats();
+
+    // The worst case and the common case at once: the first-ever op for a new task.
+    // Nothing matches, so a LIMIT-1 backward walk never finds its early exit.
+    const result = await detectConflictForEntity(
+      USER_ID,
+      incomingOp('task-brand-new'),
+      'task-brand-new',
+      makeMeasuringTx(db, stats) as never,
+    );
+
+    expect(result.hasConflict).toBe(false);
+    expect(stats.rowsFiltered).toBeLessThan(MAX_ROWS_FILTERED);
+    expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
+  });
+
+  it('reads a bounded amount for an entity deep in the history', async () => {
+    const stats = newStats();
+
+    await detectConflictForEntity(
+      USER_ID,
+      incomingOp('task-17'),
+      'task-17',
+      makeMeasuringTx(db, stats) as never,
+    );
+
+    expect(stats.rowsFiltered).toBeLessThan(MAX_ROWS_FILTERED);
+    expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
+  });
+
+  describe('raw query shapes (the EXPLAIN recipe, runnable against real Postgres)', () => {
+    const MISSING = 'task-brand-new';
+
+    it('OLD combined OR + LIMIT 1 degenerates into a full backward walk', async () => {
+      const old = await explainOn(
+        db,
+        `SELECT server_seq FROM operations
+           WHERE user_id = $1 AND entity_type = $2
+             AND (entity_id = $3 OR entity_ids @> ARRAY[$3]::text[])
+           ORDER BY server_seq DESC LIMIT 1`,
+        [USER_ID, 'TASK', MISSING],
+      );
+
+      // The incident, reproduced: every row read and discarded.
+      expect(old.rowsFiltered).toBe(SEEDED_OPS);
+      expect(old.nodes).toContain('Backward');
+    });
+
+    it('the NAIVE array-only fix reintroduces the same walk (do not "simplify" to this)', async () => {
+      // `findFirst({ entityIds: { has }, orderBy: { serverSeq: 'desc' } })`. GIN still
+      // cannot order, so the planner makes the same losing bet. This is why the array
+      // branch in conflict.ts is an aggregate and must stay one.
+      const naive = await explainOn(
+        db,
+        `SELECT server_seq FROM operations
+           WHERE user_id = $1 AND entity_type = $2 AND entity_ids @> ARRAY[$3]::text[]
+           ORDER BY server_seq DESC LIMIT 1`,
+        [USER_ID, 'TASK', MISSING],
+      );
+
+      expect(naive.rowsFiltered).toBe(SEEDED_OPS);
+      expect(naive.nodes).toContain('Backward');
+    });
+
+    it('the split lookups each stay bounded by actually-matching rows', async () => {
+      const scalar = await explainOn(
+        db,
+        `SELECT server_seq FROM operations
+           WHERE user_id = $1 AND entity_type = $2 AND entity_id = $3
+           ORDER BY server_seq DESC LIMIT 1`,
+        [USER_ID, 'TASK', MISSING],
+      );
+      // The OFFSET 0 fence is deliberate — it forbids the LIMIT-driven walk.
+      const array = await explainOn(
+        db,
+        `SELECT MAX(server_seq) FROM (SELECT server_seq FROM operations
+           WHERE user_id = $1 AND entity_type = $2 AND entity_ids @> ARRAY[$3]::text[]
+           OFFSET 0) sub`,
+        [USER_ID, 'TASK', MISSING],
+      );
+
+      expect(scalar.rowsFiltered).toBe(0);
+      expect(array.rowsFiltered).toBe(0);
+      expect(scalar.blocks + array.blocks).toBeLessThan(MAX_BLOCKS);
+    });
+  });
+});
+
+describe('detectConflictForEntity behaviour is unchanged by the query split (PGlite)', () => {
+  let db: PGlite;
+
+  const seed = async (op: {
+    id: string;
+    serverSeq: number;
+    clientId: string;
+    entityId: string | null;
+    entityIds?: string[];
+    entityType?: string;
+    schemaVersion?: number;
+    vectorClock?: Record<string, number>;
+  }): Promise<void> => {
+    await db.query(
+      `INSERT INTO operations (${INSERT_COLS})
+       VALUES ($1,${USER_ID},$2,$3,'[Task] Update',$4,$5,$6,$7,$8)`,
+      [
+        op.id,
+        op.clientId,
+        op.serverSeq,
+        op.entityType ?? 'TASK',
+        op.entityId,
+        op.entityIds ?? [],
+        op.schemaVersion ?? 1,
+        JSON.stringify(op.vectorClock ?? { [op.clientId]: 1 }),
+      ],
+    );
+  };
+
+  const detect = (
+    entityId: string,
+    opOverrides: Partial<Record<string, unknown>> = {},
+  ): Promise<{ hasConflict: boolean }> =>
+    detectConflictForEntity(
+      USER_ID,
+      incomingOp(entityId, opOverrides),
+      entityId,
+      makeMeasuringTx(db, newStats()) as never,
+    );
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await db.exec(CREATE_TABLE);
+    await db.exec(CREATE_INDEXES);
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it('reports no conflict for an entity nothing has touched', async () => {
+    expect((await detect('never-seen-entity')).hasConflict).toBe(false);
+  });
+
+  it('finds a stored multi-entity op via its NON-FIRST entity (#8334)', async () => {
+    await seed({
+      id: 'op-multi',
+      serverSeq: 1,
+      clientId: 'other',
+      entityId: 'conflict-first',
+      entityIds: ['conflict-first', 'conflict-second'],
+    });
+
+    // Concurrent clocks ({other:1} vs {uploader:1}). conflict-second is reachable
+    // only through entity_ids, i.e. only via the array branch.
+    expect((await detect('conflict-second')).hasConflict).toBe(true);
+    expect((await detect('conflict-first')).hasConflict).toBe(true);
+  });
+
+  it('finds an op via its DIVERGENT scalar (not a member of its own entity_ids)', async () => {
+    await seed({
+      id: 'op-divergent',
+      serverSeq: 2,
+      clientId: 'other',
+      entityId: 'divergent-scalar',
+      entityIds: ['divergent-member'],
+    });
+
+    expect((await detect('divergent-scalar')).hasConflict).toBe(true);
+    expect((await detect('divergent-member')).hasConflict).toBe(true);
+  });
+
+  it('picks the ARRAY row when it has the higher server_seq', async () => {
+    // Scalar row first, then a NEWER multi-entity row covering the same entity.
+    // Pins the merge and the winning-row fetch: against the scalar row alone an
+    // incoming {uploader:1} is EQUAL from the SAME client (a retry, no conflict),
+    // so only picking the newer array row can produce a conflict here.
+    await seed({
+      id: 'op-older-scalar',
+      serverSeq: 3,
+      clientId: 'uploader',
+      entityId: 'merge-entity',
+      vectorClock: { uploader: 1 },
+    });
+    await seed({
+      id: 'op-newer-array',
+      serverSeq: 4,
+      clientId: 'other',
+      entityId: 'merge-other',
+      entityIds: ['merge-other', 'merge-entity'],
+      vectorClock: { other: 1 },
+    });
+
+    expect((await detect('merge-entity')).hasConflict).toBe(true);
+  });
+
+  it('keeps the SCALAR row when it has the higher server_seq', async () => {
+    await seed({
+      id: 'op-older-array',
+      serverSeq: 5,
+      clientId: 'other',
+      entityId: 'reverse-other',
+      entityIds: ['reverse-other', 'reverse-entity'],
+      vectorClock: { other: 1 },
+    });
+    await seed({
+      id: 'op-newer-scalar',
+      serverSeq: 6,
+      clientId: 'uploader',
+      entityId: 'reverse-entity',
+      vectorClock: { uploader: 1 },
+    });
+
+    // Newer scalar row is an EQUAL clock from the SAME client (a retry) → accepted.
+    // Picking the older array row instead would wrongly report a conflict.
+    expect((await detect('reverse-entity')).hasConflict).toBe(false);
+  });
+
+  it('ignores a full-state op (entity_id NULL, entity_ids {}) without erroring', async () => {
+    await seed({ id: 'op-full', serverSeq: 7, clientId: 'other', entityId: null });
+
+    expect((await detect('some-entity-after-full-state')).hasConflict).toBe(false);
+  });
+
+  it('still consults the legacy GLOBAL_CONFIG:misc alias for tasks', async () => {
+    // Pre-split (schema_version < 2) misc writes also carried what became
+    // GLOBAL_CONFIG:tasks; that alias lookup must survive the query split.
+    await seed({
+      id: 'op-legacy-misc',
+      serverSeq: 8,
+      clientId: 'other',
+      entityId: 'misc',
+      entityType: 'GLOBAL_CONFIG',
+      schemaVersion: 1,
+      vectorClock: { other: 1 },
+    });
+
+    expect((await detect('tasks', { entityType: 'GLOBAL_CONFIG' })).hasConflict).toBe(
+      true,
+    );
+  });
+
+  it('does not alias a POST-split misc write onto tasks', async () => {
+    // The alias is gated on the fixed v1→v2 split boundary; a v2+ misc write is
+    // disjoint from tasks and must not fabricate a conflict.
+    await seed({
+      id: 'op-modern-misc',
+      serverSeq: 9,
+      clientId: 'other',
+      entityId: 'misc',
+      entityType: 'GLOBAL_CONFIG',
+      schemaVersion: 2,
+      vectorClock: { other: 2 },
+    });
+
+    expect(
+      (await detect('tasks-v2-only', { entityType: 'GLOBAL_CONFIG' })).hasConflict,
+    ).toBe(false);
+  });
+});

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -650,6 +650,38 @@ describe('detectConflictForEntity behaviour is unchanged by the query split (PGl
     expect((await detect('reverse-entity')).hasConflict).toBe(false);
   });
 
+  it('takes the NEWEST of several SCALAR matches, not the oldest', async () => {
+    // Every other case here gives an entity at most one scalar row, which makes the
+    // scalar branch's `orderBy: { serverSeq: 'desc' }` unobservable: asc and desc return
+    // the same row. Flipping it to 'asc' passed the whole server suite. That is a silent
+    // data-loss bug, not a style issue — conflict detection would compare the incoming
+    // clock against a STALE one, so an op that is a clean successor of the OLD state but
+    // CONCURRENT with the current one is accepted and overwrites a remote edit.
+    //
+    // Two scalar rows for one entity, chosen so the verdict differs by row:
+    //   vs seq 31 {cC:5} -> CONCURRENT (incoming has cA/cB, stored has cC) -> conflict
+    //   vs seq 30 {cB:1} -> GREATER_THAN (incoming is a clean successor)   -> accepted
+    await seed({
+      id: 'op-scalar-older',
+      serverSeq: 30,
+      clientId: 'cB',
+      entityId: 'scalar-order-entity',
+      vectorClock: { cB: 1 },
+    });
+    await seed({
+      id: 'op-scalar-newer',
+      serverSeq: 31,
+      clientId: 'cC',
+      entityId: 'scalar-order-entity',
+      vectorClock: { cC: 5 },
+    });
+
+    expect(
+      (await detect('scalar-order-entity', { vectorClock: { cA: 1, cB: 1 } }))
+        .hasConflict,
+    ).toBe(true);
+  });
+
   it('takes the NEWEST of several array-branch matches, not the oldest', async () => {
     // Two stored ops mention the same entity via entity_ids. The aggregate must be
     // MAX: against the newer row the incoming clock is CONCURRENT (conflict), against

--- a/packages/super-sync-server/tests/duplicate-operation-precheck.spec.ts
+++ b/packages/super-sync-server/tests/duplicate-operation-precheck.spec.ts
@@ -430,6 +430,9 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
+          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
+          // no max — keeps the array branch from consuming a findUnique mock slot.
+          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi
             .fn()
             .mockResolvedValueOnce(null)
@@ -507,6 +510,9 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
+          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
+          // no max — keeps the array branch from consuming a findUnique mock slot.
+          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi
             .fn()
             .mockResolvedValueOnce(null)
@@ -575,6 +581,9 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
+          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
+          // no max — keeps the array branch from consuming a findUnique mock slot.
+          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi.fn().mockResolvedValue(null),
           findFirst: vi.fn().mockResolvedValue(null),
           createMany: vi.fn().mockResolvedValue({ count: 0 }),
@@ -632,6 +641,9 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
+          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
+          // no max — keeps the array branch from consuming a findUnique mock slot.
+          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi.fn().mockResolvedValue(null),
           findFirst: vi
             .fn()

--- a/packages/super-sync-server/tests/duplicate-operation-precheck.spec.ts
+++ b/packages/super-sync-server/tests/duplicate-operation-precheck.spec.ts
@@ -430,9 +430,6 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
-          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
-          // no max — keeps the array branch from consuming a findUnique mock slot.
-          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi
             .fn()
             .mockResolvedValueOnce(null)
@@ -471,6 +468,10 @@ describe('Duplicate Operation Pre-check', () => {
         user: {
           update: vi.fn(),
         },
+        // entity_ids branch of the conflict lookup (raw SQL): no multi-entity op
+        // stored, so no max — keeps the array branch from consuming a findUnique
+        // mock slot.
+        $queryRaw: vi.fn().mockResolvedValue([{ maxSeq: null }]),
       };
 
       vi.mocked(prisma.$transaction).mockImplementationOnce(async (callback: any) =>
@@ -510,9 +511,6 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
-          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
-          // no max — keeps the array branch from consuming a findUnique mock slot.
-          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi
             .fn()
             .mockResolvedValueOnce(null)
@@ -551,6 +549,10 @@ describe('Duplicate Operation Pre-check', () => {
         user: {
           update: vi.fn(),
         },
+        // entity_ids branch of the conflict lookup (raw SQL): no multi-entity op
+        // stored, so no max — keeps the array branch from consuming a findUnique
+        // mock slot.
+        $queryRaw: vi.fn().mockResolvedValue([{ maxSeq: null }]),
       };
 
       vi.mocked(prisma.$transaction).mockImplementationOnce(async (callback: any) =>
@@ -581,9 +583,6 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
-          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
-          // no max — keeps the array branch from consuming a findUnique mock slot.
-          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi.fn().mockResolvedValue(null),
           findFirst: vi.fn().mockResolvedValue(null),
           createMany: vi.fn().mockResolvedValue({ count: 0 }),
@@ -599,6 +598,10 @@ describe('Duplicate Operation Pre-check', () => {
         user: {
           update: vi.fn(),
         },
+        // entity_ids branch of the conflict lookup (raw SQL): no multi-entity op
+        // stored, so no max — keeps the array branch from consuming a findUnique
+        // mock slot.
+        $queryRaw: vi.fn().mockResolvedValue([{ maxSeq: null }]),
       };
 
       vi.mocked(prisma.$transaction).mockImplementationOnce(async (callback: any) =>
@@ -641,9 +644,6 @@ describe('Duplicate Operation Pre-check', () => {
       const tx = {
         operation: {
           deleteMany: vi.fn(),
-          // entity_ids branch of the conflict lookup: no multi-entity op stored, so
-          // no max — keeps the array branch from consuming a findUnique mock slot.
-          aggregate: vi.fn().mockResolvedValue({ _max: { serverSeq: null } }),
           findUnique: vi.fn().mockResolvedValue(null),
           findFirst: vi
             .fn()
@@ -668,6 +668,10 @@ describe('Duplicate Operation Pre-check', () => {
         user: {
           update: vi.fn(),
         },
+        // entity_ids branch of the conflict lookup (raw SQL): no multi-entity op
+        // stored, so no max — keeps the array branch from consuming a findUnique
+        // mock slot.
+        $queryRaw: vi.fn().mockResolvedValue([{ maxSeq: null }]),
       };
 
       vi.mocked(prisma.$transaction).mockImplementationOnce(async (callback: any) =>

--- a/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
+++ b/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
@@ -105,26 +105,46 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
     return res.rows;
   };
 
-  // detectConflictForEntity() — single entity, Prisma `OR: [{entityId}, {entityIds:{has}}]`
-  // which Prisma renders as `entity_id = $1 OR entity_ids @> ARRAY[$1]`.
+  // detectConflictForEntity() — single entity. The scalar and entity_ids halves are
+  // two separately-indexed queries whose higher server_seq wins; they were one OR +
+  // ORDER BY ... LIMIT 1 until that scanned whole histories in production (see the
+  // PERF note in conflict.ts and conflict-entity-lookup-plan.pglite.spec.ts). The
+  // union SEMANTICS asserted below are identical either way, which is the point.
   const detectForEntity = async (
     entityType: string,
     id: string,
   ): Promise<LatestRow | null> => {
-    const res = await db.query<LatestRow>(
-      `SELECT o.entity_id AS "entityId",
-              o.client_id AS "clientId",
-              o.server_seq AS "serverSeq",
-              o.vector_clock AS "vectorClock"
-       FROM operations o
-       WHERE o.user_id = 1
-         AND o.entity_type = $1
-         AND (o.entity_id = $2 OR o.entity_ids @> ARRAY[$2]::text[])
-       ORDER BY o.server_seq DESC
-       LIMIT 1`,
+    const cols = `o.entity_id AS "entityId",
+                  o.client_id AS "clientId",
+                  o.server_seq AS "serverSeq",
+                  o.vector_clock AS "vectorClock"`;
+    const scalar = await db.query<LatestRow>(
+      `SELECT ${cols} FROM operations o
+       WHERE o.user_id = 1 AND o.entity_type = $1 AND o.entity_id = $2
+       ORDER BY o.server_seq DESC LIMIT 1`,
       [entityType, id],
     );
-    return res.rows[0] ?? null;
+    // The OFFSET 0 fence is deliberate — it is what Prisma's aggregate() emits and
+    // what keeps this off an ordered LIMIT-1 backward walk.
+    const arrayMax = await db.query<{ max: number | null }>(
+      `SELECT MAX(o.server_seq) AS max FROM (
+         SELECT server_seq FROM operations
+         WHERE user_id = 1 AND entity_type = $1 AND entity_ids @> ARRAY[$2]::text[]
+         OFFSET 0
+       ) o`,
+      [entityType, id],
+    );
+
+    const scalarRow = scalar.rows[0] ?? null;
+    const maxSeq = arrayMax.rows[0]?.max ?? null;
+    if (maxSeq === null || Number(maxSeq) <= Number(scalarRow?.serverSeq ?? -1)) {
+      return scalarRow;
+    }
+    const winner = await db.query<LatestRow>(
+      `SELECT ${cols} FROM operations o WHERE o.user_id = 1 AND o.server_seq = $1`,
+      [maxSeq],
+    );
+    return winner.rows[0] ?? null;
   };
 
   // prefetchLatestEntityOpsForBatch() — multi-entity-TYPE batch via a JOIN over

--- a/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
+++ b/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
@@ -105,48 +105,6 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
     return res.rows;
   };
 
-  // detectConflictForEntity() — single entity. The scalar and entity_ids halves are
-  // two separately-indexed queries whose higher server_seq wins; they were one OR +
-  // ORDER BY ... LIMIT 1 until that scanned whole histories in production (see the
-  // PERF note in conflict.ts and conflict-entity-lookup-plan.pglite.spec.ts). The
-  // union SEMANTICS asserted below are identical either way, which is the point.
-  const detectForEntity = async (
-    entityType: string,
-    id: string,
-  ): Promise<LatestRow | null> => {
-    const cols = `o.entity_id AS "entityId",
-                  o.client_id AS "clientId",
-                  o.server_seq AS "serverSeq",
-                  o.vector_clock AS "vectorClock"`;
-    const scalar = await db.query<LatestRow>(
-      `SELECT ${cols} FROM operations o
-       WHERE o.user_id = 1 AND o.entity_type = $1 AND o.entity_id = $2
-       ORDER BY o.server_seq DESC LIMIT 1`,
-      [entityType, id],
-    );
-    // The OFFSET 0 fence is deliberate — it is what Prisma's aggregate() emits and
-    // what keeps this off an ordered LIMIT-1 backward walk.
-    const arrayMax = await db.query<{ max: number | null }>(
-      `SELECT MAX(o.server_seq) AS max FROM (
-         SELECT server_seq FROM operations
-         WHERE user_id = 1 AND entity_type = $1 AND entity_ids @> ARRAY[$2]::text[]
-         OFFSET 0
-       ) o`,
-      [entityType, id],
-    );
-
-    const scalarRow = scalar.rows[0] ?? null;
-    const maxSeq = arrayMax.rows[0]?.max ?? null;
-    if (maxSeq === null || Number(maxSeq) <= Number(scalarRow?.serverSeq ?? -1)) {
-      return scalarRow;
-    }
-    const winner = await db.query<LatestRow>(
-      `SELECT ${cols} FROM operations o WHERE o.user_id = 1 AND o.server_seq = $1`,
-      [maxSeq],
-    );
-    return winner.rows[0] ?? null;
-  };
-
   // prefetchLatestEntityOpsForBatch() — multi-entity-TYPE batch via a JOIN over
   // (entity_type, entity_id) pairs.
   const prefetchForPairs = async (
@@ -312,35 +270,6 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
       const byEntity = Object.fromEntries(rows.map((r) => [r.entityId, r.serverSeq]));
 
       expect(byEntity).toEqual({ 'task-1': 3, 'task-2': 1, 'task-3': 2 });
-    });
-  });
-
-  describe('detectConflictForEntity (Prisma OR / entity_ids @> ARRAY[id])', () => {
-    it('finds a multi-entity op via its non-first entity', async () => {
-      await insertOp({
-        id: 'opA',
-        serverSeq: 1,
-        clientId: 'A',
-        entityId: 'task-1',
-        entityIds: ['task-1', 'task-2'],
-      });
-
-      const row = await detectForEntity('TASK', 'task-2');
-
-      expect(row).not.toBeNull();
-      expect(row?.clientId).toBe('A');
-    });
-
-    it('returns null for an unrelated entity', async () => {
-      await insertOp({
-        id: 'opA',
-        serverSeq: 1,
-        clientId: 'A',
-        entityId: 'task-1',
-        entityIds: ['task-1', 'task-2'],
-      });
-
-      expect(await detectForEntity('TASK', 'task-9')).toBeNull();
     });
   });
 

--- a/packages/super-sync-server/tests/gap-detection.spec.ts
+++ b/packages/super-sync-server/tests/gap-detection.spec.ts
@@ -8,6 +8,8 @@ vi.mock('../src/db', async () => {
   const {
     applyOperationSelect,
     hasOperationUniqueConflict,
+    isEntityArrayBranchQuery,
+    entityArrayBranchRows,
     testState: state,
   } = await import('./sync.service.test-state');
   const { Prisma: PrismaModule } = await import('@prisma/client');
@@ -186,6 +188,14 @@ vi.mock('../src/db', async () => {
         return state.users.get(args.where.id) || null;
       }),
     },
+    // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+    // `entity_ids @> ARRAY[id]`, issued as raw SQL since the full-history-scan fix.
+    $queryRaw: vi.fn().mockImplementation(async (strings: any, ...params: unknown[]) => {
+      if (!isEntityArrayBranchQuery(strings)) {
+        throw new Error(`Unexpected raw query: ${String(strings)}`);
+      }
+      return entityArrayBranchRows(state.operations, params);
+    }),
     // Upload transaction writes the storage counter atomically via $executeRaw.
     $executeRaw: vi.fn().mockResolvedValue(0),
   });

--- a/packages/super-sync-server/tests/issue-8334-detect-conflict.spec.ts
+++ b/packages/super-sync-server/tests/issue-8334-detect-conflict.spec.ts
@@ -22,6 +22,15 @@ type StoredRow = {
   clientId: string;
   serverSeq: number;
   vectorClock: Record<string, number>;
+  /**
+   * REQUIRED, not optional, on purpose. detectConflictForEntity reads
+   * existingOp.actionType to let two CONCURRENT time-tracking deltas merge instead of
+   * conflicting. A row shape that can omit it makes actionType silently `undefined` on
+   * the array branch, which is exactly how that merge gets lost without a red test.
+   * The merge itself is covered against real Postgres in
+   * conflict-entity-lookup-plan.pglite.spec.ts; this only keeps the mock honest.
+   */
+  actionType: string;
 };
 
 // detectConflictForEntity issues the scalar and array halves as two separately
@@ -46,9 +55,23 @@ const makeTx = (rows: StoredRow[]): any => {
         );
       },
       // Winning array-branch row, fetched by the (user_id, server_seq) unique key.
-      findUnique: async ({ where }: any) => {
+      // Honours `select` so that dropping a column from the production query — most
+      // consequentially actionType, see StoredRow — actually changes what this returns.
+      findUnique: async ({ where, select }: any) => {
         const { userId, serverSeq } = where.userId_serverSeq;
-        return rows.find((r) => r.userId === userId && r.serverSeq === serverSeq) ?? null;
+        const row = rows.find((r) => r.userId === userId && r.serverSeq === serverSeq);
+        if (!row) return null;
+        if (!select) return row;
+        return Object.fromEntries(
+          Object.entries(select)
+            .filter(([, isSelected]) => isSelected)
+            .map(([key]) => {
+              if (!(key in row)) {
+                throw new Error(`Mock row has no column "${key}"`);
+              }
+              return [key, row[key as keyof StoredRow]];
+            }),
+        );
       },
     },
     // Array branch: MAX(server_seq) over `entity_ids @> ARRAY[id]`, issued as raw
@@ -87,6 +110,7 @@ const staleOp = (entityId: string): Operation =>
 const multiEntityRow: StoredRow = {
   userId: 1,
   entityType: 'TASK',
+  actionType: 'UPDATE_TASK',
   entityId: 'task-1',
   entityIds: ['task-1', 'task-2'],
   clientId: 'A',
@@ -109,6 +133,7 @@ describe('#8334 detectConflict single-entity path', () => {
     const oldRow: StoredRow = {
       userId: 1,
       entityType: 'TASK',
+      actionType: 'UPDATE_TASK',
       entityId: 'task-3',
       entityIds: [], // pre-migration: empty array, only scalar persisted
       clientId: 'A',

--- a/packages/super-sync-server/tests/issue-8334-detect-conflict.spec.ts
+++ b/packages/super-sync-server/tests/issue-8334-detect-conflict.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { detectConflict, getStoredEntityIds } from '../src/sync/conflict';
+import { isEntityArrayBranchQuery } from './sync.service.test-state';
 import type { Operation } from '../src/sync/sync.types';
 
 /**
@@ -7,8 +8,8 @@ import type { Operation } from '../src/sync/sync.types';
  * (detectConflict → detectConflictForEntity). It exercises the REAL function
  * against a tx mock modelling how production persists ops: multi-entity ops carry
  * the full entity_ids array, single-entity ops store []. detectConflictForEntity
- * matches an entity with a scalar `entityId` lookup plus a separate
- * `entityIds: { has }` max-serverSeq lookup, which the mock below reproduces.
+ * matches an entity with a scalar `entityId` lookup plus a separate raw-SQL
+ * max-serverSeq lookup over `entity_ids`, which the mock below reproduces.
  *
  * The batch lookup paths (raw unnest SQL) are validated separately against real
  * Postgres semantics and in conflict-detection.spec.ts.
@@ -44,18 +45,28 @@ const makeTx = (rows: StoredRow[]): any => {
             .sort((a, b) => b.serverSeq - a.serverSeq)[0] ?? null
         );
       },
-      // Array branch: MAX(server_seq) over entity_ids @> ARRAY[id].
-      aggregate: async ({ where }: any) => {
-        const seqs = scoped(where)
-          .filter((r) => r.entityIds.includes(where.entityIds.has))
-          .map((r) => r.serverSeq);
-        return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
-      },
       // Winning array-branch row, fetched by the (user_id, server_seq) unique key.
       findUnique: async ({ where }: any) => {
         const { userId, serverSeq } = where.userId_serverSeq;
         return rows.find((r) => r.userId === userId && r.serverSeq === serverSeq) ?? null;
       },
+    },
+    // Array branch: MAX(server_seq) over `entity_ids @> ARRAY[id]`, issued as raw
+    // SQL (a MATERIALIZED CTE) so the planner is forced onto the GIN index.
+    $queryRaw: async (strings: TemplateStringsArray, ...params: unknown[]) => {
+      if (!isEntityArrayBranchQuery(strings)) {
+        throw new Error(`Unexpected raw query: ${strings.join('?')}`);
+      }
+      const [entityId, userId, entityType] = params as [string, number, string];
+      const seqs = rows
+        .filter(
+          (r) =>
+            r.userId === userId &&
+            r.entityType === entityType &&
+            r.entityIds.includes(entityId),
+        )
+        .map((r) => r.serverSeq);
+      return [{ maxSeq: seqs.length ? Math.max(...seqs) : null }];
     },
   };
 };

--- a/packages/super-sync-server/tests/issue-8334-detect-conflict.spec.ts
+++ b/packages/super-sync-server/tests/issue-8334-detect-conflict.spec.ts
@@ -7,8 +7,8 @@ import type { Operation } from '../src/sync/sync.types';
  * (detectConflict → detectConflictForEntity). It exercises the REAL function
  * against a tx mock modelling how production persists ops: multi-entity ops carry
  * the full entity_ids array, single-entity ops store []. detectConflictForEntity
- * matches an entity via a Prisma `OR: [{entityId}, {entityIds:{has}}]` filter,
- * which the mock's findFirst reproduces.
+ * matches an entity with a scalar `entityId` lookup plus a separate
+ * `entityIds: { has }` max-serverSeq lookup, which the mock below reproduces.
  *
  * The batch lookup paths (raw unnest SQL) are validated separately against real
  * Postgres semantics and in conflict-detection.spec.ts.
@@ -23,26 +23,42 @@ type StoredRow = {
   vectorClock: Record<string, number>;
 };
 
-const makeTx = (rows: StoredRow[]): any => ({
-  operation: {
-    // Mirrors: where { userId, entityType, OR: [{entityId:X}, {entityIds:{has:X}}] }
-    findFirst: async ({ where }: any) => {
-      const target =
-        where.OR.find((c: any) => 'entityId' in c)?.entityId ??
-        where.OR.find((c: any) => c.entityIds?.has !== undefined)?.entityIds?.has;
-      return (
-        rows
-          .filter(
-            (r) =>
-              r.userId === where.userId &&
-              r.entityType === where.entityType &&
-              (r.entityId === target || r.entityIds.includes(target)),
-          )
-          .sort((a, b) => b.serverSeq - a.serverSeq)[0] ?? null
-      );
+// detectConflictForEntity issues the scalar and array halves as two separately
+// indexed queries (a single OR + ORDER BY ... LIMIT 1 degenerated into a full
+// history scan and took production down — see the PERF note in conflict.ts).
+// This mock mirrors that three-call shape and throws on the old OR filter so a
+// silent revert cannot pass here.
+const makeTx = (rows: StoredRow[]): any => {
+  const scoped = (where: any): StoredRow[] =>
+    rows.filter((r) => r.userId === where.userId && r.entityType === where.entityType);
+  return {
+    operation: {
+      // Scalar branch: where { userId, entityType, entityId }, orderBy serverSeq desc.
+      findFirst: async ({ where }: any) => {
+        if (where.OR) {
+          throw new Error('detectConflictForEntity must not use a combined OR filter');
+        }
+        return (
+          scoped(where)
+            .filter((r) => r.entityId === where.entityId)
+            .sort((a, b) => b.serverSeq - a.serverSeq)[0] ?? null
+        );
+      },
+      // Array branch: MAX(server_seq) over entity_ids @> ARRAY[id].
+      aggregate: async ({ where }: any) => {
+        const seqs = scoped(where)
+          .filter((r) => r.entityIds.includes(where.entityIds.has))
+          .map((r) => r.serverSeq);
+        return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
+      },
+      // Winning array-branch row, fetched by the (user_id, server_seq) unique key.
+      findUnique: async ({ where }: any) => {
+        const { userId, serverSeq } = where.userId_serverSeq;
+        return rows.find((r) => r.userId === userId && r.serverSeq === serverSeq) ?? null;
+      },
     },
-  },
-});
+  };
+};
 
 const staleOp = (entityId: string): Operation =>
   ({

--- a/packages/super-sync-server/tests/setup.ts
+++ b/packages/super-sync-server/tests/setup.ts
@@ -324,15 +324,21 @@ vi.mock('../src/db', () => {
           }),
           update: vi.fn().mockResolvedValue({}),
         },
+        // Every raw query issued inside the transaction must be recognised here and
+        // anything unknown must THROW. A tolerant default is how the array branch
+        // stayed silently stubbed out: conflict.ts reads an unrecognised row via
+        // `arrayBranchRows[0]?.maxSeq ?? null`, i.e. as "no match", so the branch
+        // disappears instead of failing.
         $queryRaw: vi
           .fn()
           .mockImplementation(async (strings: any, ...params: unknown[]) => {
             // Single-entity conflict lookup, array branch (raw SQL since the fix for
-            // the full-history scan). Everything else keeps the storage-total default.
+            // the full-history scan).
             if (isEntityArrayBranchQuery(strings)) {
               return entityArrayBranchRows(testData.operations, params);
             }
-            return [{ total: BigInt(0) }];
+            const sql = Array.isArray(strings) ? strings.join('') : String(strings);
+            throw new Error(`Unmocked raw query in tx: ${sql}`);
           }),
         // The upload transaction writes the storage counter atomically via
         // $executeRaw to keep the data write and the counter delta in a single

--- a/packages/super-sync-server/tests/setup.ts
+++ b/packages/super-sync-server/tests/setup.ts
@@ -119,6 +119,14 @@ vi.mock('../src/db', () => {
       return false;
     }
     if (where.entityId !== undefined && op.entityId !== where.entityId) return false;
+    // entity_ids @> ARRAY[id] — the array branch of the single-entity conflict
+    // lookup (#8334). Split out of the old OR filter; see conflict.ts detectConflictForEntity.
+    if (
+      where.entityIds?.has !== undefined &&
+      !(Array.isArray(op.entityIds) && op.entityIds.includes(where.entityIds.has))
+    ) {
+      return false;
+    }
     if (where.clientId !== undefined) {
       if (typeof where.clientId === 'object' && where.clientId !== null) {
         if (where.clientId.not !== undefined && op.clientId === where.clientId.not) {
@@ -221,6 +229,16 @@ vi.mock('../src/db', () => {
             return { count };
           }),
           findUnique: vi.fn().mockImplementation(async (args: any) => {
+            // (user_id, server_seq) compound unique — used by the conflict lookup's
+            // array branch to fetch the winning row once its max serverSeq is known.
+            const compound = args.where?.userId_serverSeq;
+            if (compound) {
+              const match = Array.from(testData.operations.values()).find(
+                (op: any) =>
+                  op.userId === compound.userId && op.serverSeq === compound.serverSeq,
+              );
+              return applySelect(match, args.select) || null;
+            }
             // Check if operation with given ID exists
             return (
               applySelect(testData.operations.get(args.where?.id), args.select) || null
@@ -248,7 +266,19 @@ vi.mock('../src/db', () => {
               matchesWhere(op, args.where),
             ).length;
           }),
-          aggregate: vi.fn().mockResolvedValue({ _min: { serverSeq: 1 } }),
+          aggregate: vi.fn().mockImplementation(async (args: any) => {
+            // The conflict lookup's array branch asks for _max.serverSeq over
+            // `entity_ids @> ARRAY[id]`; other callers still expect the _min default.
+            if (args?._max?.serverSeq) {
+              const seqs = Array.from(testData.operations.values())
+                .filter((op) => matchesWhere(op, args.where))
+                .map((op: any) => op.serverSeq);
+              return {
+                _max: { serverSeq: seqs.length ? Math.max(...seqs) : null },
+              };
+            }
+            return { _min: { serverSeq: 1 } };
+          }),
           deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
         },
         userSyncState: {

--- a/packages/super-sync-server/tests/setup.ts
+++ b/packages/super-sync-server/tests/setup.ts
@@ -5,6 +5,10 @@
  * test infrastructure after the migration to Prisma.
  */
 import { vi, beforeEach } from 'vitest';
+import {
+  isEntityArrayBranchQuery,
+  entityArrayBranchRows,
+} from './sync.service.test-state';
 
 // In-memory storage for test data
 interface TestData {
@@ -119,8 +123,10 @@ vi.mock('../src/db', () => {
       return false;
     }
     if (where.entityId !== undefined && op.entityId !== where.entityId) return false;
-    // entity_ids @> ARRAY[id] — the array branch of the single-entity conflict
-    // lookup (#8334). Split out of the old OR filter; see conflict.ts detectConflictForEntity.
+    // entity_ids @> ARRAY[id]. No production caller uses this via the typed API any
+    // more — detectConflictForEntity's array branch is raw SQL (see the $queryRaw
+    // mock below) — but keep the matcher generic so this shim stays a faithful
+    // stand-in for Prisma's filter semantics.
     if (
       where.entityIds?.has !== undefined &&
       !(Array.isArray(op.entityIds) && op.entityIds.includes(where.entityIds.has))
@@ -266,19 +272,7 @@ vi.mock('../src/db', () => {
               matchesWhere(op, args.where),
             ).length;
           }),
-          aggregate: vi.fn().mockImplementation(async (args: any) => {
-            // The conflict lookup's array branch asks for _max.serverSeq over
-            // `entity_ids @> ARRAY[id]`; other callers still expect the _min default.
-            if (args?._max?.serverSeq) {
-              const seqs = Array.from(testData.operations.values())
-                .filter((op) => matchesWhere(op, args.where))
-                .map((op: any) => op.serverSeq);
-              return {
-                _max: { serverSeq: seqs.length ? Math.max(...seqs) : null },
-              };
-            }
-            return { _min: { serverSeq: 1 } };
-          }),
+          aggregate: vi.fn().mockResolvedValue({ _min: { serverSeq: 1 } }),
           deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
         },
         userSyncState: {
@@ -330,7 +324,16 @@ vi.mock('../src/db', () => {
           }),
           update: vi.fn().mockResolvedValue({}),
         },
-        $queryRaw: vi.fn().mockResolvedValue([{ total: BigInt(0) }]),
+        $queryRaw: vi
+          .fn()
+          .mockImplementation(async (strings: any, ...params: unknown[]) => {
+            // Single-entity conflict lookup, array branch (raw SQL since the fix for
+            // the full-history scan). Everything else keeps the storage-total default.
+            if (isEntityArrayBranchQuery(strings)) {
+              return entityArrayBranchRows(testData.operations, params);
+            }
+            return [{ total: BigInt(0) }];
+          }),
         // The upload transaction writes the storage counter atomically via
         // $executeRaw to keep the data write and the counter delta in a single
         // commit. Default mock is a no-op; specs that care about counter

--- a/packages/super-sync-server/tests/sync-fixes.spec.ts
+++ b/packages/super-sync-server/tests/sync-fixes.spec.ts
@@ -144,8 +144,6 @@ vi.mock('../src/db', () => {
                 return true;
               }).length;
             }),
-            // _max mirrors the conflict lookup's entity_ids branch; null matches the
-            // findFirst above, which finds no prior op for an entity either.
             aggregate: vi
               .fn()
               .mockResolvedValue({ _min: { serverSeq: 1 }, _max: { serverSeq: null } }),
@@ -174,7 +172,9 @@ vi.mock('../src/db', () => {
             upsert: vi.fn().mockResolvedValue({}),
             count: vi.fn().mockResolvedValue(1),
           },
-          $queryRaw: vi.fn().mockResolvedValue([]),
+          // maxSeq null mirrors the conflict lookup's entity_ids branch, matching the
+          // findFirst above, which finds no prior op for an entity either.
+          $queryRaw: vi.fn().mockResolvedValue([{ maxSeq: null }]),
           // Upload transaction writes the storage counter atomically via $executeRaw.
           $executeRaw: vi.fn().mockResolvedValue(0),
         };

--- a/packages/super-sync-server/tests/sync-fixes.spec.ts
+++ b/packages/super-sync-server/tests/sync-fixes.spec.ts
@@ -144,9 +144,7 @@ vi.mock('../src/db', () => {
                 return true;
               }).length;
             }),
-            aggregate: vi
-              .fn()
-              .mockResolvedValue({ _min: { serverSeq: 1 }, _max: { serverSeq: null } }),
+            aggregate: vi.fn().mockResolvedValue({ _min: { serverSeq: 1 } }),
             findUnique: vi.fn().mockImplementation(async (args: any) => {
               if (args.where?.id) {
                 return (

--- a/packages/super-sync-server/tests/sync-fixes.spec.ts
+++ b/packages/super-sync-server/tests/sync-fixes.spec.ts
@@ -144,7 +144,11 @@ vi.mock('../src/db', () => {
                 return true;
               }).length;
             }),
-            aggregate: vi.fn().mockResolvedValue({ _min: { serverSeq: 1 } }),
+            // _max mirrors the conflict lookup's entity_ids branch; null matches the
+            // findFirst above, which finds no prior op for an entity either.
+            aggregate: vi
+              .fn()
+              .mockResolvedValue({ _min: { serverSeq: 1 }, _max: { serverSeq: null } }),
             findUnique: vi.fn().mockImplementation(async (args: any) => {
               if (args.where?.id) {
                 return (

--- a/packages/super-sync-server/tests/sync-operations.spec.ts
+++ b/packages/super-sync-server/tests/sync-operations.spec.ts
@@ -10,6 +10,8 @@ vi.mock('../src/db', async () => {
   const {
     applyOperationSelect,
     hasOperationUniqueConflict,
+    isEntityArrayBranchQuery,
+    entityArrayBranchRows,
     testState: state,
   } = await import('./sync.service.test-state');
   const { Prisma: PrismaModule } = await import('@prisma/client');
@@ -290,11 +292,19 @@ vi.mock('../src/db', async () => {
     },
     // Upload transaction writes the storage counter atomically via $executeRaw.
     $executeRaw: vi.fn().mockResolvedValue(0),
-    // Full-state op uploads aggregate prior vector clocks via $queryRaw inside
-    // the same transaction. Dispatch based on the SQL text so other $queryRaw
-    // callers (storage counter, etc.) keep working.
+    // Raw queries issued inside the upload transaction. Every shape must be
+    // recognised explicitly and anything else must THROW: this mock used to fall
+    // through to a `total` row, which conflict.ts reads via
+    // `arrayBranchRows[0]?.maxSeq ?? null` as "no array-branch match". That silently
+    // disabled the array branch for every conflict assertion in this file.
     $queryRaw: vi.fn().mockImplementation(async (strings: any, ...params: any[]) => {
       const sql = Array.isArray(strings) ? strings.join('') : String(strings);
+      // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+      // `entity_ids @> ARRAY[id]`, scoped to ONE entity.
+      if (isEntityArrayBranchQuery(strings)) {
+        return entityArrayBranchRows(state.operations, params);
+      }
+      // Full-state op uploads aggregate prior vector clocks in the same transaction.
       if (sql.includes('jsonb_each_text(vector_clock)')) {
         const [userId, beforeServerSeq] = params;
         const aggregate = new Map<string, number>();
@@ -316,7 +326,7 @@ vi.mock('../src/db', async () => {
           max_counter: BigInt(max_counter),
         }));
       }
-      return [{ total: BigInt(0) }];
+      throw new Error(`Unmocked raw query in upload tx: ${sql}`);
     }),
   });
 

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -144,7 +144,7 @@ vi.mock('../src/db', async () => {
           return applyOperationSelect(ops[0], args.select) || null;
         }
         // Scalar branch of the single-entity conflict lookup. The entity_ids half is
-        // a separate aggregate() call; the two were one OR + ORDER BY ... LIMIT 1
+        // a separate $queryRaw call; the two were one OR + ORDER BY ... LIMIT 1
         // until that degenerated into a full history scan in production (see the
         // PERF note in conflict.ts detectConflictForEntity).
         if (args.where?.entityId && args.where?.entityType) {
@@ -419,8 +419,8 @@ vi.mock('../src/db', async () => {
     $queryRaw: vi.fn().mockImplementation(async (strings: any, ...params: any[]) => {
       const sql = Array.isArray(strings) ? strings.join('') : String(strings);
       // Array branch of the single-entity conflict lookup: MAX(server_seq) over
-      // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max the
-      // aggregate() mock returns (see conflict.ts detectConflictForEntity).
+      // `entity_ids @> ARRAY[id]`, scoped to ONE entity — not a user-wide max
+      // (see conflict.ts detectConflictForEntity).
       if (isEntityArrayBranchQuery(strings)) {
         return entityArrayBranchRows(state.operations, params);
       }
@@ -502,7 +502,11 @@ vi.mock('../src/db', async () => {
           max_counter: BigInt(max_counter),
         }));
       }
-      return [{ total: BigInt(0) }];
+      // Unrecognised raw queries must THROW, never return a plausible-looking row.
+      // conflict.ts reads an unknown shape via `arrayBranchRows[0]?.maxSeq ?? null`
+      // as "no array-branch match", so a tolerant default silently deletes the
+      // branch under test instead of failing.
+      throw new Error(`Unmocked raw query in tx: ${sql}`);
     }),
   });
 

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -10,6 +10,8 @@ vi.mock('../src/db', async () => {
   const {
     applyOperationSelect,
     hasOperationUniqueConflict,
+    isEntityArrayBranchQuery,
+    entityArrayBranchRows,
     testState: state,
   } = await import('./sync.service.test-state');
   const { Prisma: PrismaModule } = await import('@prisma/client');
@@ -206,22 +208,6 @@ vi.mock('../src/db', async () => {
           .slice(0, args.take || 500);
       }),
       aggregate: vi.fn().mockImplementation(async (args: any) => {
-        // Array branch of the single-entity conflict lookup: MAX(server_seq) over
-        // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max
-        // the generic branch below returns (see conflict.ts detectConflictForEntity).
-        const conflictEntityId = args.where?.entityIds?.has;
-        if (conflictEntityId !== undefined) {
-          const seqs = Array.from(state.operations.values())
-            .filter(
-              (op: any) =>
-                op.userId === args.where.userId &&
-                op.entityType === args.where.entityType &&
-                Array.isArray(op.entityIds) &&
-                op.entityIds.includes(conflictEntityId),
-            )
-            .map((op: any) => op.serverSeq);
-          return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
-        }
         const ops = Array.from(state.operations.values()).filter(
           (op: any) => args.where?.userId === op.userId,
         );
@@ -432,6 +418,12 @@ vi.mock('../src/db', async () => {
     // returning their existing default shape.
     $queryRaw: vi.fn().mockImplementation(async (strings: any, ...params: any[]) => {
       const sql = Array.isArray(strings) ? strings.join('') : String(strings);
+      // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+      // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max the
+      // aggregate() mock returns (see conflict.ts detectConflictForEntity).
+      if (isEntityArrayBranchQuery(strings)) {
+        return entityArrayBranchRows(state.operations, params);
+      }
       if (sql.includes('FROM user_sync_state') && sql.includes('FOR UPDATE')) {
         const [txUserId] = params as [number];
         return [

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -141,23 +141,10 @@ vi.mock('../src/db', async () => {
             .sort((a: any, b: any) => b.serverSeq - a.serverSeq);
           return applyOperationSelect(ops[0], args.select) || null;
         }
-        if (args.where?.entityType && Array.isArray(args.where?.OR)) {
-          const targetEntityId =
-            args.where.OR.find((condition: any) => condition.entityId !== undefined)
-              ?.entityId ??
-            args.where.OR.find((condition: any) => condition.entityIds?.has !== undefined)
-              ?.entityIds.has;
-          const ops = Array.from(state.operations.values())
-            .filter(
-              (op: any) =>
-                op.userId === args.where.userId &&
-                op.entityType === args.where.entityType &&
-                (op.entityId === targetEntityId ||
-                  op.entityIds?.includes(targetEntityId)),
-            )
-            .sort((a: any, b: any) => b.serverSeq - a.serverSeq);
-          return applyOperationSelect(ops[0], args.select) || null;
-        }
+        // Scalar branch of the single-entity conflict lookup. The entity_ids half is
+        // a separate aggregate() call; the two were one OR + ORDER BY ... LIMIT 1
+        // until that degenerated into a full history scan in production (see the
+        // PERF note in conflict.ts detectConflictForEntity).
         if (args.where?.entityId && args.where?.entityType) {
           const ops = Array.from(state.operations.values())
             .filter(
@@ -219,6 +206,22 @@ vi.mock('../src/db', async () => {
           .slice(0, args.take || 500);
       }),
       aggregate: vi.fn().mockImplementation(async (args: any) => {
+        // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+        // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max
+        // the generic branch below returns (see conflict.ts detectConflictForEntity).
+        const conflictEntityId = args.where?.entityIds?.has;
+        if (conflictEntityId !== undefined) {
+          const seqs = Array.from(state.operations.values())
+            .filter(
+              (op: any) =>
+                op.userId === args.where.userId &&
+                op.entityType === args.where.entityType &&
+                Array.isArray(op.entityIds) &&
+                op.entityIds.includes(conflictEntityId),
+            )
+            .map((op: any) => op.serverSeq);
+          return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
+        }
         const ops = Array.from(state.operations.values()).filter(
           (op: any) => args.where?.userId === op.userId,
         );
@@ -281,6 +284,16 @@ vi.mock('../src/db', async () => {
         return count;
       }),
       findUnique: vi.fn().mockImplementation(async (args: any) => {
+        // (user_id, server_seq) compound unique — fetches the conflict lookup's
+        // array-branch winner once its max serverSeq is known.
+        const compound = args.where?.userId_serverSeq;
+        if (compound) {
+          const match = Array.from(state.operations.values()).find(
+            (op: any) =>
+              op.userId === compound.userId && op.serverSeq === compound.serverSeq,
+          );
+          return applyOperationSelect(match, args.select) || null;
+        }
         if (args.where?.id) {
           return (
             applyOperationSelect(state.operations.get(args.where.id), args.select) || null

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -12,6 +12,7 @@ export const testState = {
   serverSeqCounter: 0,
   batchConflictQueryCount: 0,
   entityConflictFindFirstCount: 0,
+  entityConflictAggregateCount: 0,
   fullStateAuthorLookupCount: 0,
 };
 
@@ -23,6 +24,7 @@ export function resetTestState(): void {
   testState.serverSeqCounter = 0;
   testState.batchConflictQueryCount = 0;
   testState.entityConflictFindFirstCount = 0;
+  testState.entityConflictAggregateCount = 0;
   testState.fullStateAuthorLookupCount = 0;
 }
 

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -1,5 +1,5 @@
 /**
- * Shared test state for sync.service.spec.ts
+ * Shared test state and Prisma-mock helpers for the sync service specs.
  *
  * Separated into its own file to avoid circular import issues with vitest mock hoisting.
  */
@@ -12,7 +12,7 @@ export const testState = {
   serverSeqCounter: 0,
   batchConflictQueryCount: 0,
   entityConflictFindFirstCount: 0,
-  entityConflictAggregateCount: 0,
+  entityConflictArrayQueryCount: 0,
   fullStateAuthorLookupCount: 0,
 };
 
@@ -24,8 +24,42 @@ export function resetTestState(): void {
   testState.serverSeqCounter = 0;
   testState.batchConflictQueryCount = 0;
   testState.entityConflictFindFirstCount = 0;
-  testState.entityConflictAggregateCount = 0;
+  testState.entityConflictArrayQueryCount = 0;
   testState.fullStateAuthorLookupCount = 0;
+}
+
+/**
+ * detectConflictForEntity's array branch is raw SQL — a MATERIALIZED CTE over the
+ * entity_ids GIN index — so every tx mock must answer it via $queryRaw rather than
+ * the typed model API. `AS "maxSeq"` is the discriminator: the only other raw query
+ * against `operations` (prefetchLatestEntityOpsForBatch) is a DISTINCT ON with no
+ * such alias, so the two never collide.
+ */
+export function isEntityArrayBranchQuery(strings: unknown): boolean {
+  const sql = Array.isArray(strings) ? strings.join('') : String(strings);
+  return sql.includes('AS "maxSeq"') && sql.includes('entity_ids @>');
+}
+
+/**
+ * Answers that query from in-memory ops. Parameter order follows the tagged
+ * template in conflict.ts: entityId (inside the CTE), then userId, then entityType.
+ * Returns the single-row shape the caller destructures.
+ */
+export function entityArrayBranchRows(
+  operations: Map<string, any>,
+  params: unknown[],
+): Array<{ maxSeq: number | null }> {
+  const [entityId, userId, entityType] = params as [string, number, string];
+  const seqs = Array.from(operations.values())
+    .filter(
+      (op: any) =>
+        op.userId === userId &&
+        op.entityType === entityType &&
+        Array.isArray(op.entityIds) &&
+        op.entityIds.includes(entityId),
+    )
+    .map((op: any) => op.serverSeq);
+  return [{ maxSeq: seqs.length ? Math.max(...seqs) : null }];
 }
 
 export function applyOperationSelect(op: any, select?: Record<string, boolean>): any {

--- a/packages/super-sync-server/tests/time-tracking-operations.spec.ts
+++ b/packages/super-sync-server/tests/time-tracking-operations.spec.ts
@@ -81,24 +81,10 @@ vi.mock('../src/db', async () => {
             applyOperationSelect(state.operations.get(args.where.id), args.select) || null
           );
         }
-        // Single-entity conflict lookup: where { userId, entityType,
-        // OR: [{ entityId: X }, { entityIds: { has: X } }] } (#8334).
-        if (Array.isArray(args.where?.OR) && args.where?.entityType) {
-          const targetId =
-            args.where.OR.find((c: any) => 'entityId' in c)?.entityId ??
-            args.where.OR.find((c: any) => c.entityIds?.has !== undefined)?.entityIds
-              ?.has;
-          const ops = Array.from(state.operations.values())
-            .filter(
-              (op: any) =>
-                op.userId === args.where.userId &&
-                op.entityType === args.where.entityType &&
-                (op.entityId === targetId ||
-                  (Array.isArray(op.entityIds) && op.entityIds.includes(targetId))),
-            )
-            .sort((a: any, b: any) => b.serverSeq - a.serverSeq);
-          return applyOperationSelect(ops[0], args.select) || null;
-        }
+        // Scalar branch of the single-entity conflict lookup (#8334). The entity_ids
+        // half is a separate aggregate() call; the two were one OR + ORDER BY ...
+        // LIMIT 1 until that degenerated into a full history scan in production
+        // (see the PERF note in conflict.ts detectConflictForEntity).
         if (args.where?.entityId && args.where?.entityType) {
           const ops = Array.from(state.operations.values())
             .filter(
@@ -181,6 +167,22 @@ vi.mock('../src/db', async () => {
         }).length;
       }),
       aggregate: vi.fn().mockImplementation(async (args: any) => {
+        // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+        // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max
+        // the generic branch below returns.
+        const conflictEntityId = args.where?.entityIds?.has;
+        if (conflictEntityId !== undefined) {
+          const seqs = Array.from(state.operations.values())
+            .filter(
+              (op: any) =>
+                op.userId === args.where.userId &&
+                op.entityType === args.where.entityType &&
+                Array.isArray(op.entityIds) &&
+                op.entityIds.includes(conflictEntityId),
+            )
+            .map((op: any) => op.serverSeq);
+          return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
+        }
         const ops = Array.from(state.operations.values()).filter(
           (op: any) => args.where?.userId === op.userId,
         );
@@ -194,6 +196,15 @@ vi.mock('../src/db', async () => {
       }),
       deleteMany: vi.fn().mockImplementation(async () => ({ count: 0 })),
       findUnique: vi.fn().mockImplementation(async (args: any) => {
+        // (user_id, server_seq) compound unique — fetches the array-branch winner.
+        const compound = args.where?.userId_serverSeq;
+        if (compound) {
+          const match = Array.from(state.operations.values()).find(
+            (op: any) =>
+              op.userId === compound.userId && op.serverSeq === compound.serverSeq,
+          );
+          return applyOperationSelect(match, args.select) || null;
+        }
         if (args.where?.id) {
           return (
             applyOperationSelect(state.operations.get(args.where.id), args.select) || null

--- a/packages/super-sync-server/tests/time-tracking-operations.spec.ts
+++ b/packages/super-sync-server/tests/time-tracking-operations.spec.ts
@@ -26,6 +26,8 @@ vi.mock('../src/db', async () => {
   const {
     applyOperationSelect,
     hasOperationUniqueConflict,
+    isEntityArrayBranchQuery,
+    entityArrayBranchRows,
     testState: state,
   } = await import('./sync.service.test-state');
   const { Prisma: PrismaModule } = await import('@prisma/client');
@@ -82,7 +84,7 @@ vi.mock('../src/db', async () => {
           );
         }
         // Scalar branch of the single-entity conflict lookup (#8334). The entity_ids
-        // half is a separate aggregate() call; the two were one OR + ORDER BY ...
+        // half is a separate $queryRaw call; the two were one OR + ORDER BY ...
         // LIMIT 1 until that degenerated into a full history scan in production
         // (see the PERF note in conflict.ts detectConflictForEntity).
         if (args.where?.entityId && args.where?.entityType) {
@@ -167,22 +169,6 @@ vi.mock('../src/db', async () => {
         }).length;
       }),
       aggregate: vi.fn().mockImplementation(async (args: any) => {
-        // Array branch of the single-entity conflict lookup: MAX(server_seq) over
-        // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max
-        // the generic branch below returns.
-        const conflictEntityId = args.where?.entityIds?.has;
-        if (conflictEntityId !== undefined) {
-          const seqs = Array.from(state.operations.values())
-            .filter(
-              (op: any) =>
-                op.userId === args.where.userId &&
-                op.entityType === args.where.entityType &&
-                Array.isArray(op.entityIds) &&
-                op.entityIds.includes(conflictEntityId),
-            )
-            .map((op: any) => op.serverSeq);
-          return { _max: { serverSeq: seqs.length ? Math.max(...seqs) : null } };
-        }
         const ops = Array.from(state.operations.values()).filter(
           (op: any) => args.where?.userId === op.userId,
         );
@@ -300,6 +286,15 @@ vi.mock('../src/db', async () => {
         return state.users.get(args.where.id) || null;
       }),
     },
+    // Array branch of the single-entity conflict lookup: MAX(server_seq) over
+    // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max the
+    // aggregate() mock above returns. Raw SQL since the full-history-scan fix.
+    $queryRaw: vi.fn().mockImplementation(async (strings: any, ...params: unknown[]) => {
+      if (!isEntityArrayBranchQuery(strings)) {
+        throw new Error(`Unexpected raw query: ${String(strings)}`);
+      }
+      return entityArrayBranchRows(state.operations, params);
+    }),
     // Upload transaction writes the storage counter atomically via $executeRaw.
     $executeRaw: vi.fn().mockResolvedValue(0),
   });

--- a/packages/super-sync-server/tests/time-tracking-operations.spec.ts
+++ b/packages/super-sync-server/tests/time-tracking-operations.spec.ts
@@ -287,8 +287,8 @@ vi.mock('../src/db', async () => {
       }),
     },
     // Array branch of the single-entity conflict lookup: MAX(server_seq) over
-    // `entity_ids @> ARRAY[id]`, scoped to one entity — NOT the user-wide max the
-    // aggregate() mock above returns. Raw SQL since the full-history-scan fix.
+    // `entity_ids @> ARRAY[id]`, scoped to ONE entity — not a user-wide max.
+    // Raw SQL since the full-history-scan fix.
     $queryRaw: vi.fn().mockImplementation(async (strings: any, ...params: unknown[]) => {
       if (!isEntityArrayBranchQuery(strings)) {
         throw new Error(`Unexpected raw query: ${String(strings)}`);


### PR DESCRIPTION
Fixes the query behind the 2026-07-20 SuperSync outage: 47 backends stuck on one statement, longest running 75 minutes, 61 of 66 connections consumed, every user's upload *and* download failing. No index was missing or invalid.

## What broke

`detectConflictForEntity` runs on **every** single-entity upload, twice per op. It combined an `OR` across two differently-indexed columns with an ordering GIN cannot supply:

```ts
findFirst({
  where: { userId, entityType, OR: [{ entityId }, { entityIds: { has: entityId } }] },
  orderBy: { serverSeq: 'desc' },
})
```

The `OR` spans the `(user_id, entity_type, entity_id, server_seq)` btree and the `entity_ids` GIN. GIN cannot order by `server_seq`, so the planner abandons **both** index paths and walks `server_seq` backwards applying the `OR` as a filter — betting `LIMIT 1` resolves early. For an entity with **zero** matching rows that bet loses and it reads the user's entire history. Zero matching rows is the first-ever op for a new task: the single most common upload on the server.

## The fix

Two separately-indexed lookups instead of one combined filter.

**Scalar branch** — unchanged shape, and never was the problem: the composite btree covers all three equality columns *plus* the sort column, so it is an index seek and a one-step backward walk.

**Array branch** — raw SQL, and the `MATERIALIZED` keyword is load-bearing:

```sql
WITH cand AS MATERIALIZED (
  SELECT user_id, entity_type, server_seq FROM operations
  WHERE entity_ids @> ARRAY[$1]::text[]
)
SELECT MAX(server_seq)::int AS "maxSeq" FROM cand
WHERE user_id = $2 AND entity_type = $3
```

Inside the CTE the only predicate is `entity_ids @>`, so the composite btree has no usable leading column and GIN is the only *index* available at any cost estimate. **That eliminates the btree structurally; it does not force GIN.** A sequential scan remains available and wins for an unselective id — reproduced on PG16, and exactly what a globally shared entity id produces (#9199). GIN winning on production-shaped data is a *measured* outcome, re-verified by the plan spec, not a guarantee. `MATERIALIZED` prevents the outer `user_id`/`entity_type` predicates being pushed down, which would hand the btree back. The winning row is then fetched by the `(user_id, server_seq)` unique key, and only when it actually beats the scalar branch.

## ⚠️ Measure with `force_generic_plan`, never with literals

The single most important thing for a reviewer to know. Prisma sends parameterized prepared statements; under the default `auto`, Postgres plans the first ~5 executions as custom, then compares the generic cost against the average custom cost and **may** switch to a generic plan — a cost comparison, not an automatic switch, so some statements stay on custom plans indefinitely. This one was **observed** going generic on production (`pg_prepared_statements`: `custom_plans=5, generic_plans=15`), and a generic plan cannot see parameter values. `EXPLAIN` with literal constants builds something different again — and under literals, **4 of 6 known-catastrophic shapes measure perfectly**. Three designs were approved on literal evidence during this incident and were catastrophic.

Measured under `SET plan_cache_mode = force_generic_plan` on a 40k-row seed (20k for the probed user, 20k across ~20k other users, 8 entity types):

| shape | blocks | rows discarded |
|---|---|---|
| **shipped: MATERIALIZED CTE + scalar** | **143** | **0** |
| the outage query (`OR` + `orderBy` + `LIMIT 1`) | 816 | 2500 |
| naive array-only `LIMIT 1` (GIN still cannot order) | 816 | 2500 |
| flat `SELECT MAX(...) WHERE user_id AND entity_type AND @>` | 816 | 2500 |
| Prisma `aggregate({ _max })` | 816 | 2500 |
| the same CTE with `MATERIALIZED` dropped | 816 | 2500 |

2500 is the probed user's whole `TASK` slice. Every alternative reads it and throws it away.

## Evidence

- **Correctness:** 73,000 randomised differential histories against the pre-change implementation, zero divergence — per-entity, top-level incl. legacy-misc, many-ops-sharing-an-entity, cross-tenant with colliding sequences, and equal-clock retries. *Caveat, stated plainly: that harness is not in this repo and so does not protect CI.* See #9194.
- **Mutation testing:** 10 of 10 sabotage mutations killed — CTE inlined, `MAX`→`MIN`, outer `user_id` dropped, outer `entity_type` dropped, `>`→`>=`, `actionType` dropped from the select, scalar `orderBy` flipped, plus three seed-degradation mutations.
- 915 server tests pass.

## Test changes worth reviewing

The plan spec is the regression guard, and two commits here exist because it was measuring the wrong thing:

- **Seeded in production order.** It built the GIN *after* the bulk load, which yields a compact pending-list-free index measuring 2 blocks — a state production only sees right after a vacuum. With the index pre-existing and rows arriving one at a time, the same query reads **140 blocks** against a 14× larger index, because entries queue in the GIN pending list. Budget re-derived accordingly.
- **Dropped 8 tests that could not fail** (five near-identical hardcoded regression shapes plus a redundant text guard), replaced with one canary whose stated job is proving the seed still reproduces the mis-plan — which is what gives an absolute block budget its meaning. Structural GIN-not-btree assertions moved onto the *real* tagged template rather than a copy that can drift.
- **Two genuine holes closed.** Flipping the scalar branch's `orderBy` to `'asc'` passed all 914 tests — silent data loss, since conflict detection would compare against a stale clock and accept an op that should conflict. And `does not alias a POST-split misc write onto tasks` probed the wrong entity id, so it never reached the gate it claimed to guard; breaking that gate also left the suite green. Both now verified red under the mutation they target.

## Docs

`docs/sync-and-op-log/vector-clocks.md` still documented the outage query *and vouched for it* — "a `BitmapOr` + sort bounded by the entity's stored version depth (op-log pruning keeps that small)". That is exactly the false assumption behind the incident, in the authoritative doc, and the escalation it recommended (two ordered `LIMIT 1` lookups) is itself one of the 816-block shapes above. Rewritten.

## Known limitations (not fixed here, tracked)

- **The CTE is correct but not cost-bounded per tenant → #9199.** It matches by entity id across all users and the outer `WHERE` enforces the boundary. Some entity ids are byte-identical across every tenant — bulk `sortBoards` stores the hard-coded `EISENHOWER_MATRIX`/`KANBAN_DEFAULT` ids in `entity_ids` — so probing one scales with total server population. Documented at `detectConflictForEntity`; an expression GIN would make it flat.
- **No PostgreSQL 16 planner gate.** The plan spec runs PGlite (18.3); the real-Prisma integration spec never reaches the rewritten single-entity path at all. → #9194.
- Prevention work (monitoring, lint rule, config guardrails) → #9191. Audit for other queries with this shape → #9192.

## Deploy notes

- **Zero pending migrations** — this is a code-only change.
- **Deploy via merge-to-master, not `deploy.sh --build`:** that script's revision check is tautological (it stamps the image with the value it compares against) and its `git pull --ff-only || warn` pulls whatever branch is checked out, so it can report success while shipping un-fixed code.
- Stale pre-fix backends do not die on their own — Postgres does not notice a vanished client mid-scan — so they may need clearing before the new container comes up. **Terminate by fingerprint, not indiscriminately:** match the old query text, require a minimum age, and exclude migration/maintenance sessions. Something like:

  ```sql
  SELECT pid, backend_type, application_name, age(clock_timestamp(), query_start) AS running_for, query
  FROM pg_stat_activity
  WHERE state = 'active'
    AND query ILIKE '%ORDER BY%server_seq%DESC%'
    AND query ILIKE '%entity_id%=%OR%entity_ids%'
    AND query NOT ILIKE '%CREATE INDEX%'
    AND query NOT ILIKE '%WITH cand AS MATERIALIZED%'
    AND backend_type = 'client backend'
    AND clock_timestamp() - query_start > interval '60 seconds'
    AND pid <> pg_backend_pid();
  ```

  Match the **old** shape specifically — a plain `%entity_ids%` filter also matches the new CTE and the batch queries — and print the **full** query text, not a truncation, so you can see which statement you are about to kill. Review that list, then `pg_terminate_backend(pid)` the rows you have actually inspected. A blanket terminate can kill an in-flight migration and leak its advisory lock (cf. #9126).
- Worth confirming `operations_entity_ids_gin` has `indisvalid = true` before concluding the deploy worked; an invalid GIN degrades to a sequential scan and would make this fix inert. (`ix_ops_plaintext` is currently invalid in production — see the note in #9191.)

`ghcr.io/super-productivity/supersync:latest` **is** master, so merging makes the fix available to self-hosters, who are all running this bug. It does not reach them automatically: operators still have to `docker compose pull` and redeploy, and any who pin a tag or run their own build will not pick it up at all.



---

### Review follow-ups applied

An external review found three claims that would have shipped as wrong. Fixed in `27d1baa9b7`:

- `vector-clocks.md` still documented the **batch** lookup as the mutually exclusive `CASE WHEN cardinality(entity_ids) > 0 ...`. Production unions the two columns, and the exclusive form *is* the #8334 silent-data-loss bug — it drops a scalar that is not a member of its own `entity_ids`. The section above it was rewritten in this PR and this one was missed.
- The "wins structurally, not on cost" framing overstated the guarantee (above).
- The plan spec claimed production receives "a CUSTOM plan nobody receives" — it receives custom plans for roughly the first 5 executions before settling generic, and this suite covers only the generic mode.

Newly tracked rather than left in a scratch file: **#9199** (cross-tenant scaling, with explicit risk acceptance for this merge), and the legacy `GLOBAL_CONFIG:misc` lookup attached to **#9192** (same failure shape, far lower exposure: 672 buffers / 50k rows discarded on PG16).


