### PR TITLE
fix(markdown): select exactly the url when wrapping selected text in a link

### DIFF
--- a/src/app/ui/inline-markdown/markdown-toolbar.util.spec.ts
+++ b/src/app/ui/inline-markdown/markdown-toolbar.util.spec.ts
@@ -316,8 +316,15 @@ describe('markdown-toolbar.util', () => {
     it('should use selection as link text', () => {
       const result = insertLink('hello world', 0, 5);
       expect(result.text).toBe('[hello](https://) world');
-      expect(result.selectionStart).toBe(9); // URL position
-      expect(result.selectionEnd).toBe(17); // URL selected
+      expect(result.selectionStart).toBe(8); // URL position
+      expect(result.selectionEnd).toBe(16); // URL selected
+    });
+
+    it('should select exactly the url placeholder', () => {
+      const result = insertLink('hello world', 0, 5);
+      expect(result.text.substring(result.selectionStart, result.selectionEnd)).toBe(
+        'https://',
+      );
     });
   });
 
@@ -332,8 +339,15 @@ describe('markdown-toolbar.util', () => {
     it('should use selection as alt text', () => {
       const result = insertImage('hello world', 0, 5);
       expect(result.text).toBe('![hello](https://) world');
-      expect(result.selectionStart).toBe(10); // URL position
-      expect(result.selectionEnd).toBe(18); // URL selected
+      expect(result.selectionStart).toBe(9); // URL position
+      expect(result.selectionEnd).toBe(17); // URL selected
+    });
+
+    it('should select exactly the url placeholder', () => {
+      const result = insertImage('hello world', 0, 5);
+      expect(result.text.substring(result.selectionStart, result.selectionEnd)).toBe(
+        'https://',
+      );
     });
   });
 

--- a/src/app/ui/inline-markdown/markdown-toolbar.util.ts
+++ b/src/app/ui/inline-markdown/markdown-toolbar.util.ts
@@ -488,10 +488,9 @@ export const insertLink = (
   const linkMarkdown = `[${selectedText}](${url})`;
   const newText =
     text.substring(0, selectionStart) + linkMarkdown + text.substring(selectionEnd);
-  // Place cursor at URL position: [ + text + ]( = 1 + text.length + 2 = text.length + 3
-  // But we want cursor AFTER the opening paren, which is at position: 1 + text.length + 2 = text.length + 3
-  // Test expects: for "hello" (5 chars), URL starts at 9 = 0 + 5 + 4
-  const urlStart = selectionStart + selectedText.length + 4; // After "[text]("
+  // Select the url so it is ready to be replaced. The url sits after "[text](",
+  // which is 1 ("[") + text.length + 2 ("](") = text.length + 3 characters.
+  const urlStart = selectionStart + selectedText.length + 3; // After "[text]("
   return {
     text: newText,
     selectionStart: urlStart,
@@ -523,9 +522,9 @@ export const insertImage = (
   const imageMarkdown = `![${selectedText}](${url})`;
   const newText =
     text.substring(0, selectionStart) + imageMarkdown + text.substring(selectionEnd);
-  // Place cursor at URL position: ![ + text + ]( = 2 + text.length + 2 = text.length + 4
-  // Test expects: for "hello" (5 chars), URL starts at 10 = 0 + 5 + 5
-  const urlStart = selectionStart + selectedText.length + 5; // After "![text]("
+  // Select the url so it is ready to be replaced. The url sits after "![text](",
+  // which is 2 ("![") + text.length + 2 ("](") = text.length + 4 characters.
+  const urlStart = selectionStart + selectedText.length + 4; // After "![text]("
   return {
     text: newText,
     selectionStart: urlStart,


### PR DESCRIPTION
## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

Fixes #9202. When you select text in a Project Note and insert a link (URL button or Ctrl+K), the wrong range gets highlighted: `[hello](https://) world` selects `ttps://)` instead of `https://`, so typing the URL leaves a stray `h` in front and overwrites the closing `)`.

The url offset in `insertLink` was one too high (`+ 4` instead of `+ 3`). `insertImage` had the same off-by-one (`+ 5` instead of `+ 4`). The two existing tests encoded the wrong positions, so they passed while the behaviour was broken.

## Solution

<!-- Describe your changes in detail. -->

Correct the url start offset in both `insertLink` and `insertImage`, update the two tests to the right positions, and add a small assertion in each that the resulting selection is exactly `https://`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)