### PR TITLE
test(sync): cover production batch conflict queries

### DIFF
--- a/e2e/tests/work-view/sections.spec.ts
+++ b/e2e/tests/work-view/sections.spec.ts
@@ -46,7 +46,9 @@ test.describe('Sections', () => {
   const clickAddSection = async (
     page: import('@playwright/test').Page,
   ): Promise<void> => {
-    await page.getByRole('menuitem', { name: 'Add Section' }).click();
+    const menu = page.getByRole('menu');
+    await expect(menu).not.toHaveClass(/mat-menu-panel-animating/);
+    await menu.getByRole('menuitem', { name: 'Add Section' }).click();
   };
 
   /** Fill the dialog-prompt input and submit. */
@@ -221,7 +223,7 @@ test.describe('Sections', () => {
     await wrapper.waitFor({ state: 'visible', timeout: 5000 });
     await wrapper.dispatchEvent('contextmenu');
 
-    await page.getByRole('menuitem', { name: 'Add Section' }).click();
+    await clickAddSection(page);
     await submitPromptDialog(page, 'Right-Click Section');
 
     await expect(sectionByTitle(page, 'Right-Click Section')).toBeVisible();

--- a/packages/super-sync-server/tests/conflict.spec.ts
+++ b/packages/super-sync-server/tests/conflict.spec.ts
@@ -1,18 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { Prisma } from '@prisma/client';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  detectConflictForEntities,
   getConflictEntityIds,
+  getEntityConflictKey,
   isSameDuplicateOperation,
   isSameIncomingOperation,
   isSameDuplicateTimestamp,
+  prefetchLatestEntityOpsForBatch,
   pruneVectorClockForStorage,
   resolveConflictForExistingOp,
   stableJsonStringify,
 } from '../src/sync/conflict';
 import {
+  CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
   DuplicateOperationCandidate,
   MAX_VECTOR_CLOCK_SIZE,
   Operation,
 } from '../src/sync/sync.types';
+
+const TASK_TIME_DELTA_ACTION_TYPE = '[TimeTracking] Sync time spent';
 
 const op = (overrides: Partial<Operation> = {}): Operation => ({
   id: 'op-1',
@@ -69,10 +76,13 @@ describe('conflict helpers', () => {
     ).toBe(true);
   });
 
-  it('includes a divergent scalar entityId in the incoming conflict set', () => {
+  it('builds a deduplicated incoming conflict set that includes a divergent scalar', () => {
     expect(
       getConflictEntityIds(op({ entityId: 'task-scalar', entityIds: ['task-array'] })),
     ).toEqual(['task-scalar', 'task-array']);
+    expect(
+      getConflictEntityIds(op({ entityId: 'task-1', entityIds: ['task-1'] })),
+    ).toEqual(['task-1']);
   });
 
   it.each([false, true])(
@@ -122,6 +132,12 @@ describe('conflict helpers', () => {
     expect(isSameDuplicateOperation(duplicateCandidate(), 1, incoming, 60_000)).toBe(
       false,
     );
+  });
+
+  it('rejects an otherwise-identical duplicate operation from a different user', () => {
+    expect(
+      isSameDuplicateOperation(duplicateCandidate({ userId: 2 }), 1, op(), 60_000),
+    ).toBe(false);
   });
 
   it('accepts batch retries with identical entityIds', () => {
@@ -255,12 +271,12 @@ describe('conflict helpers', () => {
   it('accepts concurrent additive task-time deltas for the same task', () => {
     const result = resolveConflictForExistingOp(
       op({
-        actionType: '[TimeTracking] Sync time spent',
+        actionType: TASK_TIME_DELTA_ACTION_TYPE,
         vectorClock: { 'client-a': 1 },
       }),
       'task-1',
       {
-        actionType: '[TimeTracking] Sync time spent',
+        actionType: TASK_TIME_DELTA_ACTION_TYPE,
         clientId: 'client-b',
         vectorClock: { 'client-b': 1 },
       },
@@ -269,15 +285,42 @@ describe('conflict helpers', () => {
     expect(result).toEqual({ hasConflict: false });
   });
 
+  it.each([
+    ['incoming delta', TASK_TIME_DELTA_ACTION_TYPE, 'UPDATE_TASK'],
+    ['stored delta', 'UPDATE_TASK', TASK_TIME_DELTA_ACTION_TYPE],
+  ])(
+    'keeps a one-sided task-time delta conflicting (%s)',
+    (_label, incomingActionType, storedActionType) => {
+      const result = resolveConflictForExistingOp(
+        op({
+          actionType: incomingActionType,
+          vectorClock: { 'client-a': 1 },
+        }),
+        'task-1',
+        {
+          actionType: storedActionType,
+          clientId: 'client-b',
+          vectorClock: { 'client-b': 1 },
+        },
+      );
+
+      expect(result).toMatchObject({
+        hasConflict: true,
+        conflictType: 'concurrent',
+        existingClock: { 'client-b': 1 },
+      });
+    },
+  );
+
   it('still rejects a causally stale additive task-time delta', () => {
     const result = resolveConflictForExistingOp(
       op({
-        actionType: '[TimeTracking] Sync time spent',
+        actionType: TASK_TIME_DELTA_ACTION_TYPE,
         vectorClock: { 'client-a': 1 },
       }),
       'task-1',
       {
-        actionType: '[TimeTracking] Sync time spent',
+        actionType: TASK_TIME_DELTA_ACTION_TYPE,
         clientId: 'client-a',
         vectorClock: { 'client-a': 2 },
       },
@@ -285,6 +328,47 @@ describe('conflict helpers', () => {
 
     expect(result.hasConflict).toBe(true);
     expect(result.conflictType).toBe('superseded');
+  });
+
+  it('does not alias a post-split misc row during batch prefetch', async () => {
+    const storedSchemaVersion = 2;
+    const postSplitMiscRow = {
+      actionType: '[Global Config] Update',
+      clientId: 'client-b',
+      vectorClock: { 'client-b': 1 },
+      serverSeq: 1,
+    };
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([]),
+      operation: {
+        findFirst: vi
+          .fn()
+          .mockImplementation(
+            async (args: {
+              where: { schemaVersion?: { lt?: number; lte?: number } };
+            }) => {
+              const constraint = args.where.schemaVersion;
+              if (constraint?.lt !== undefined && storedSchemaVersion >= constraint.lt) {
+                return null;
+              }
+              if (constraint?.lte !== undefined && storedSchemaVersion > constraint.lte) {
+                return null;
+              }
+              return postSplitMiscRow;
+            },
+          ),
+      },
+    };
+
+    const latestByEntity = await prefetchLatestEntityOpsForBatch(
+      1,
+      [{ entityType: 'GLOBAL_CONFIG', entityId: 'tasks' }],
+      tx as unknown as Prisma.TransactionClient,
+    );
+
+    expect(latestByEntity.has(getEntityConflictKey('GLOBAL_CONFIG', 'tasks'))).toBe(
+      false,
+    );
   });
 
   it('classifies less-than vector clocks as superseded', () => {
@@ -300,6 +384,62 @@ describe('conflict helpers', () => {
       existingClock: { 'client-a': 2 },
     });
   });
+
+  it.each([
+    CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
+    CONFLICT_DETECTION_ENTITY_BATCH_SIZE + 1,
+  ])(
+    'handles the boundary row and chunks correctly for %i entities',
+    async (entityCount) => {
+      const crossesBatchBoundary = entityCount > CONFLICT_DETECTION_ENTITY_BATCH_SIZE;
+      const boundaryIndex = entityCount - 1;
+      const expectedBatchSizes = crossesBatchBoundary
+        ? [CONFLICT_DETECTION_ENTITY_BATCH_SIZE, 1]
+        : [CONFLICT_DETECTION_ENTITY_BATCH_SIZE];
+      const entityIds = Array.from(
+        { length: entityCount },
+        (_, index) => `task-${index}`,
+      );
+      const boundaryEntityId = entityIds[boundaryIndex];
+      const queriedBatchSizes: number[] = [];
+      const tx = {
+        $queryRaw: vi
+          .fn()
+          .mockImplementation(async (_strings: unknown, ...params: unknown[]) => {
+            const queriedEntityIds = (params[2] as Prisma.Sql).values;
+            queriedBatchSizes.push(queriedEntityIds.length);
+            if (!queriedEntityIds.includes(boundaryEntityId)) return [];
+
+            return [
+              {
+                entityId: boundaryEntityId,
+                clientId: crossesBatchBoundary ? 'client-b' : 'client-a',
+                actionType: 'UPDATE_TASK',
+                vectorClock: crossesBatchBoundary ? { 'client-b': 1 } : { 'client-a': 0 },
+              },
+            ];
+          }),
+      };
+
+      const result = await detectConflictForEntities(
+        1,
+        op({ vectorClock: { 'client-a': 1 } }),
+        entityIds,
+        tx as unknown as Prisma.TransactionClient,
+      );
+
+      expect(result).toMatchObject(
+        crossesBatchBoundary
+          ? {
+              hasConflict: true,
+              conflictType: 'concurrent',
+              existingClock: { 'client-b': 1 },
+            }
+          : { hasConflict: false },
+      );
+      expect(queriedBatchSizes).toEqual(expectedBatchSizes);
+    },
+  );
 
   it('stable-stringifies object keys recursively', () => {
     expect(stableJsonStringify({ z: 1, a: { b: 2, a: 1 } })).toBe(

--- a/packages/super-sync-server/tests/conflict.spec.ts
+++ b/packages/super-sync-server/tests/conflict.spec.ts
@@ -344,17 +344,12 @@ describe('conflict helpers', () => {
         findFirst: vi
           .fn()
           .mockImplementation(
-            async (args: {
-              where: { schemaVersion?: { lt?: number; lte?: number } };
-            }) => {
-              const constraint = args.where.schemaVersion;
-              if (constraint?.lt !== undefined && storedSchemaVersion >= constraint.lt) {
-                return null;
-              }
-              if (constraint?.lte !== undefined && storedSchemaVersion > constraint.lte) {
-                return null;
-              }
-              return postSplitMiscRow;
+            async (args: { where: { schemaVersion?: { lt?: number } } }) => {
+              const exclusiveUpperBound = args.where.schemaVersion?.lt;
+              return exclusiveUpperBound !== undefined &&
+                storedSchemaVersion >= exclusiveUpperBound
+                ? null
+                : postSplitMiscRow;
             },
           ),
       },
@@ -386,16 +381,28 @@ describe('conflict helpers', () => {
   });
 
   it.each([
-    CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
-    CONFLICT_DETECTION_ENTITY_BATCH_SIZE + 1,
+    [
+      'clean exact-size batch',
+      CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
+      false,
+      [CONFLICT_DETECTION_ENTITY_BATCH_SIZE],
+    ],
+    [
+      'conflicting exact-size batch',
+      CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
+      true,
+      [CONFLICT_DETECTION_ENTITY_BATCH_SIZE],
+    ],
+    [
+      'conflicting overflow batch',
+      CONFLICT_DETECTION_ENTITY_BATCH_SIZE + 1,
+      true,
+      [CONFLICT_DETECTION_ENTITY_BATCH_SIZE, 1],
+    ],
   ])(
-    'handles the boundary row and chunks correctly for %i entities',
-    async (entityCount) => {
-      const crossesBatchBoundary = entityCount > CONFLICT_DETECTION_ENTITY_BATCH_SIZE;
+    'handles the boundary row and chunks correctly for a %s (%i entities)',
+    async (_label, entityCount, boundaryHasConflict, expectedBatchSizes) => {
       const boundaryIndex = entityCount - 1;
-      const expectedBatchSizes = crossesBatchBoundary
-        ? [CONFLICT_DETECTION_ENTITY_BATCH_SIZE, 1]
-        : [CONFLICT_DETECTION_ENTITY_BATCH_SIZE];
       const entityIds = Array.from(
         { length: entityCount },
         (_, index) => `task-${index}`,
@@ -413,9 +420,9 @@ describe('conflict helpers', () => {
             return [
               {
                 entityId: boundaryEntityId,
-                clientId: crossesBatchBoundary ? 'client-b' : 'client-a',
+                clientId: boundaryHasConflict ? 'client-b' : 'client-a',
                 actionType: 'UPDATE_TASK',
-                vectorClock: crossesBatchBoundary ? { 'client-b': 1 } : { 'client-a': 0 },
+                vectorClock: boundaryHasConflict ? { 'client-b': 1 } : { 'client-a': 0 },
               },
             ];
           }),
@@ -429,7 +436,7 @@ describe('conflict helpers', () => {
       );
 
       expect(result).toMatchObject(
-        crossesBatchBoundary
+        boundaryHasConflict
           ? {
               hasConflict: true,
               conflictType: 'concurrent',

--- a/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
+++ b/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { PGlite } from '@electric-sql/pglite';
+import { Prisma } from '@prisma/client';
+import {
+  detectConflictForEntities,
+  getEntityConflictKey,
+  prefetchLatestEntityOpsForBatch,
+} from '../src/sync/conflict';
+import type { Operation, VectorClock } from '../src/sync/sync.types';
+
+const USER_ID = 1;
+const OTHER_USER_ID = 2;
+const TASK_UPDATE_ACTION = '[Task] Update';
+const TASK_TIME_DELTA_ACTION = '[TimeTracking] Sync time spent';
 
 /**
  * Real-Postgres regression for #8334's multi-entity conflict-detection SQL.
@@ -10,11 +22,9 @@ import { PGlite } from '@electric-sql/pglite';
  * actually send to Postgres. This spec runs that SQL against an in-process Postgres
  * (PGlite — no Docker, no DATABASE_URL) so it runs in the normal `npm test` CI job.
  *
- * The SQL below is copied verbatim from packages/super-sync-server/src/sync/conflict.ts
- * (only the Prisma.sql `${}` interpolations are rewritten as `$n` placeholders). If you
- * change the query shape there, update it here — the two are intentionally kept in sync
- * by hand (the source keeps the SQL inline so the conflict-detection.spec mock's
- * positional params stay stable).
+ * A small transaction adapter renders the production Prisma tagged template through
+ * Prisma.sql, including nested Prisma.Sql / Prisma.join fragments, then executes its
+ * PostgreSQL text and bound values in PGlite. There is no second copy of the query.
  *
  * Load-bearing detail: the unnest folds the scalar `entity_id` INTO the `entity_ids`
  * set with a UNION (`o.entity_ids || ...ARRAY[entity_id]`), NOT a mutually-exclusive
@@ -26,6 +36,38 @@ import { PGlite } from '@electric-sql/pglite';
  */
 describe('#8334 multi-entity conflict SQL (PGlite)', () => {
   let db: PGlite;
+  let transaction: Prisma.TransactionClient;
+
+  const createTransaction = (): Prisma.TransactionClient => {
+    const adapter = {
+      $queryRaw: async <T>(
+        strings: TemplateStringsArray,
+        ...values: Array<Prisma.Sql | Prisma.Sql['values'][number]>
+      ): Promise<T> => {
+        const query = Prisma.sql(strings, ...values);
+        return (await db.query(query.text, query.values)).rows as T;
+      },
+    };
+
+    return adapter as unknown as Prisma.TransactionClient;
+  };
+
+  const incomingOp = (
+    overrides: Partial<
+      Pick<Operation, 'clientId' | 'actionType' | 'entityType' | 'vectorClock'>
+    > = {},
+  ): Operation => ({
+    id: 'incoming',
+    clientId: 'B',
+    actionType: TASK_UPDATE_ACTION,
+    opType: 'UPD',
+    entityType: 'TASK',
+    payload: {},
+    vectorClock: { B: 1 },
+    timestamp: 1,
+    schemaVersion: 1,
+    ...overrides,
+  });
 
   // Mirrors the two migrations: the entity_ids text[] column + the GIN index, plus
   // the pre-existing btree that the scalar fallback relies on. Building the GIN index
@@ -36,7 +78,8 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
         id          text PRIMARY KEY,
         user_id     integer NOT NULL,
         client_id   text NOT NULL,
-        server_seq  bigint NOT NULL,
+        server_seq  integer NOT NULL,
+        action_type text NOT NULL,
         entity_type text NOT NULL,
         entity_id   text,
         entity_ids  text[] NOT NULL DEFAULT '{}',
@@ -52,19 +95,23 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
     id: string;
     serverSeq: number;
     clientId: string;
+    userId?: number;
+    actionType?: string;
     entityType?: string;
     entityId: string | null;
     entityIds?: string[];
-    vectorClock?: Record<string, number>;
+    vectorClock?: VectorClock;
   }): Promise<void> => {
     await db.query(
       `INSERT INTO operations
-         (id, user_id, client_id, server_seq, entity_type, entity_id, entity_ids, vector_clock)
-       VALUES ($1, 1, $2, $3, $4, $5, $6, $7)`,
+         (id, user_id, client_id, server_seq, action_type, entity_type, entity_id, entity_ids, vector_clock)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
       [
         op.id,
+        op.userId ?? USER_ID,
         op.clientId,
         op.serverSeq,
+        op.actionType ?? TASK_UPDATE_ACTION,
         op.entityType ?? 'TASK',
         op.entityId,
         op.entityIds ?? [],
@@ -73,75 +120,10 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
     );
   };
 
-  type LatestRow = {
-    entityId: string;
-    clientId: string;
-    serverSeq: number;
-    vectorClock: Record<string, number>;
-  };
-
-  // detectConflictForEntities() — single-entity-type batch lookup.
-  const detectForEntities = async (
-    entityType: string,
-    ids: string[],
-  ): Promise<LatestRow[]> => {
-    const res = await db.query<LatestRow>(
-      `SELECT DISTINCT ON (eid)
-          eid AS "entityId",
-          o.client_id AS "clientId",
-          o.server_seq AS "serverSeq",
-          o.vector_clock AS "vectorClock"
-       FROM operations o
-       CROSS JOIN LATERAL unnest(
-         o.entity_ids || CASE WHEN o.entity_id IS NULL THEN '{}'::text[] ELSE ARRAY[o.entity_id] END
-       ) AS eid
-       WHERE o.user_id = 1
-         AND o.entity_type = $1
-         AND (o.entity_ids && $2::text[] OR o.entity_id = ANY($2::text[]))
-         AND eid = ANY($2::text[])
-       ORDER BY eid, o.server_seq DESC`,
-      [entityType, ids],
-    );
-    return res.rows;
-  };
-
-  // prefetchLatestEntityOpsForBatch() — multi-entity-TYPE batch via a JOIN over
-  // (entity_type, entity_id) pairs.
-  const prefetchForPairs = async (
-    pairs: Array<{ entityType: string; entityId: string }>,
-  ): Promise<Array<LatestRow & { entityType: string }>> => {
-    const valuesSql = pairs.map((_p, i) => `($${i * 2 + 1}, $${i * 2 + 2})`).join(', ');
-    const idArrayParam = `$${pairs.length * 2 + 1}`;
-    const params: unknown[] = [];
-    for (const p of pairs) {
-      params.push(p.entityType, p.entityId);
-    }
-    params.push(pairs.map((p) => p.entityId));
-    const res = await db.query<LatestRow & { entityType: string }>(
-      `SELECT DISTINCT ON (o.entity_type, eid)
-          o.entity_type AS "entityType",
-          eid AS "entityId",
-          o.client_id AS "clientId",
-          o.server_seq AS "serverSeq",
-          o.vector_clock AS "vectorClock"
-       FROM operations o
-       CROSS JOIN LATERAL unnest(
-         o.entity_ids || CASE WHEN o.entity_id IS NULL THEN '{}'::text[] ELSE ARRAY[o.entity_id] END
-       ) AS eid
-       JOIN (VALUES ${valuesSql}) AS touched(entity_type, entity_id)
-         ON touched.entity_type = o.entity_type
-        AND touched.entity_id = eid
-       WHERE o.user_id = 1
-         AND (o.entity_ids && ${idArrayParam}::text[] OR o.entity_id = ANY(${idArrayParam}::text[]))
-       ORDER BY o.entity_type, eid, o.server_seq DESC`,
-      params,
-    );
-    return res.rows;
-  };
-
   beforeAll(async () => {
     db = new PGlite();
     await db.waitReady;
+    transaction = createTransaction();
   });
 
   afterAll(async () => {
@@ -162,126 +144,183 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
         clientId: 'A',
         entityId: 'task-1',
         entityIds: ['task-1', 'task-2'],
+        vectorClock: { A: 1 },
       });
 
-      const rows = await detectForEntities('TASK', ['task-2']);
+      const result = await detectConflictForEntities(
+        USER_ID,
+        incomingOp(),
+        ['task-2', 'task-unmatched'],
+        transaction,
+      );
 
       // Before the fix, task-2 was invisible (only the scalar task-1 was stored), so a
       // stale write to task-2 found no prior writer and was wrongly accepted.
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ entityId: 'task-2', clientId: 'A', serverSeq: 1 });
+      expect(result).toMatchObject({
+        hasConflict: true,
+        conflictType: 'concurrent',
+        existingClock: { A: 1 },
+      });
     });
 
-    it('returns the LATEST op per entity (DISTINCT ON ... ORDER BY server_seq DESC)', async () => {
+    it('skips a clean latest op and reports a later entity conflict', async () => {
+      // The old row conflicts with the incoming C clock; the latest row is its
+      // equal-clock retry from the same client. The second entity is concurrent,
+      // so omitting clientId, selecting the old task-1 row, or returning the clean
+      // task-1 result early changes the verdict.
       await insertOp({
-        id: 'opA',
+        id: 'old',
         serverSeq: 1,
         clientId: 'A',
         entityId: 'task-1',
-        entityIds: ['task-1', 'task-2'],
+        vectorClock: { A: 1 },
       });
-      // A newer single-entity write to task-1.
-      await insertOp({ id: 'opC', serverSeq: 3, clientId: 'A', entityId: 'task-1' });
+      await insertOp({
+        id: 'latest',
+        serverSeq: 3,
+        clientId: 'C',
+        entityId: 'task-1',
+        vectorClock: { C: 1 },
+      });
+      await insertOp({
+        id: 'later-conflict',
+        serverSeq: 4,
+        clientId: 'D',
+        entityId: 'task-2',
+        vectorClock: { D: 1 },
+      });
 
-      const rows = await detectForEntities('TASK', ['task-1']);
+      const result = await detectConflictForEntities(
+        USER_ID,
+        incomingOp({ clientId: 'C', vectorClock: { C: 1 } }),
+        ['task-1', 'task-2'],
+        transaction,
+      );
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0].serverSeq).toBe(3);
+      expect(result).toMatchObject({
+        hasConflict: true,
+        conflictType: 'concurrent',
+        existingClock: { D: 1 },
+      });
     });
 
     it('falls back to the scalar entity_id for a pre-migration row (entity_ids = {})', async () => {
-      await insertOp({ id: 'opB', serverSeq: 2, clientId: 'A', entityId: 'task-3' });
-
-      const rows = await detectForEntities('TASK', ['task-3']);
-
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ entityId: 'task-3', serverSeq: 2 });
-    });
-
-    it('does not match an unrelated entity', async () => {
       await insertOp({
-        id: 'opA',
-        serverSeq: 1,
+        id: 'opB',
+        serverSeq: 2,
         clientId: 'A',
-        entityId: 'task-1',
-        entityIds: ['task-1', 'task-2'],
+        entityId: 'task-3',
+        vectorClock: { A: 2 },
       });
 
-      expect(await detectForEntities('TASK', ['task-9'])).toHaveLength(0);
+      const result = await detectConflictForEntities(
+        USER_ID,
+        incomingOp(),
+        ['task-3', 'task-unmatched'],
+        transaction,
+      );
+
+      expect(result).toMatchObject({
+        hasConflict: true,
+        conflictType: 'concurrent',
+        existingClock: { A: 2 },
+      });
     });
 
-    it('ignores a full-state op (entity_id NULL, entity_ids {}) without erroring', async () => {
-      // SYNC_IMPORT / BACKUP_IMPORT / REPAIR ops have no entity. The unnest hits the
-      // ARRAY[entity_id] branch with a NULL element — it must yield no match, not throw.
-      await insertOp({ id: 'opFull', serverSeq: 1, clientId: 'A', entityId: null });
-
-      expect(await detectForEntities('TASK', ['task-1'])).toHaveLength(0);
-    });
-
-    it('matches an entity stored only in entity_ids when the scalar differs (dedup-off-scalar)', async () => {
-      // getStoredEntityIds persists [task-A] even though length === 1 because it differs
-      // from the scalar entity_id (task-Z). Without entity_ids, task-A would be invisible.
+    it('finds a DIVERGENT scalar entity_id not present in entity_ids', async () => {
+      // The old mutually-exclusive CASE unnested ['task-A'] and dropped task-Z.
       await insertOp({
         id: 'opD',
         serverSeq: 1,
         clientId: 'A',
         entityId: 'task-Z',
         entityIds: ['task-A'],
+        vectorClock: { A: 1 },
       });
 
-      const rows = await detectForEntities('TASK', ['task-A']);
+      const result = await detectConflictForEntities(
+        USER_ID,
+        incomingOp(),
+        ['task-Z', 'task-unmatched'],
+        transaction,
+      );
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0].entityId).toBe('task-A');
+      expect(result).toMatchObject({
+        hasConflict: true,
+        conflictType: 'concurrent',
+        existingClock: { A: 1 },
+      });
     });
 
-    it('finds the op via its DIVERGENT scalar entity_id (not a member of entity_ids) — the #8334 silent-data-loss case', async () => {
-      // Same dedup-off-scalar op as above, but now query for the SCALAR task-Z, which is
-      // NOT a member of entity_ids (['task-A']). The old mutually-exclusive CASE form used
-      // entity_ids alone (cardinality > 0) and dropped the scalar, so task-Z found no prior
-      // writer and a stale concurrent write to it was wrongly accepted. The UNION fold keeps
-      // the scalar visible. This is the case the dedup-off-scalar test above does NOT cover.
+    it('isolates rows by user and entity type', async () => {
       await insertOp({
-        id: 'opD',
-        serverSeq: 1,
+        id: 'other-user-task',
+        serverSeq: 10,
         clientId: 'A',
-        entityId: 'task-Z',
-        entityIds: ['task-A'],
+        userId: OTHER_USER_ID,
+        entityId: 'shared-id',
+        vectorClock: { A: 1 },
+      });
+      await insertOp({
+        id: 'same-user-project',
+        serverSeq: 11,
+        clientId: 'A',
+        entityType: 'PROJECT',
+        entityId: 'shared-id',
+        vectorClock: { A: 1 },
       });
 
-      const rows = await detectForEntities('TASK', ['task-Z']);
+      const result = await detectConflictForEntities(
+        USER_ID,
+        incomingOp(),
+        ['shared-id', 'task-unmatched'],
+        transaction,
+      );
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ entityId: 'task-Z', clientId: 'A', serverSeq: 1 });
+      expect(result).toEqual({ hasConflict: false });
     });
 
-    it('resolves every requested id to its own latest op in one batch', async () => {
+    it('uses the selected actionType when resolving concurrent timer deltas', async () => {
       await insertOp({
-        id: 'opA',
+        id: 'timer-delta',
         serverSeq: 1,
         clientId: 'A',
+        actionType: TASK_TIME_DELTA_ACTION,
         entityId: 'task-1',
-        entityIds: ['task-1', 'task-2'],
+        vectorClock: { A: 1 },
       });
-      await insertOp({ id: 'opB', serverSeq: 2, clientId: 'A', entityId: 'task-3' });
-      await insertOp({ id: 'opC', serverSeq: 3, clientId: 'A', entityId: 'task-1' });
 
-      const rows = await detectForEntities('TASK', ['task-1', 'task-2', 'task-3']);
-      const byEntity = Object.fromEntries(rows.map((r) => [r.entityId, r.serverSeq]));
+      const result = await detectConflictForEntities(
+        USER_ID,
+        incomingOp({ actionType: TASK_TIME_DELTA_ACTION }),
+        ['task-1', 'task-unmatched'],
+        transaction,
+      );
 
-      expect(byEntity).toEqual({ 'task-1': 3, 'task-2': 1, 'task-3': 2 });
+      expect(result).toEqual({ hasConflict: false });
     });
   });
 
   describe('prefetchLatestEntityOpsForBatch (JOIN-over-pairs unnest SQL)', () => {
-    it('matches each (type,id) pair against the op entity set without crossing types', async () => {
+    it('returns the latest same-user op for each (type,id) pair', async () => {
+      await insertOp({
+        id: 'opA-old',
+        serverSeq: 1,
+        clientId: 'A',
+        entityType: 'TASK',
+        entityId: 'task-2',
+        actionType: '[Task] Old Update',
+        vectorClock: { A: 1 },
+      });
       await insertOp({
         id: 'opA',
-        serverSeq: 1,
+        serverSeq: 3,
         clientId: 'A',
         entityType: 'TASK',
         entityId: 'task-1',
         entityIds: ['task-1', 'task-2'],
+        actionType: '[Task] Batch Update',
+        vectorClock: { A: 1 },
       });
       // Same id string but a different entity type must NOT match the TASK pair.
       await insertOp({
@@ -290,17 +329,47 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
         clientId: 'A',
         entityType: 'PROJECT',
         entityId: 'task-2',
+        actionType: '[Project] Update',
+        vectorClock: { A: 2 },
+      });
+      await insertOp({
+        id: 'other-user-task',
+        serverSeq: 10,
+        clientId: 'Z',
+        userId: OTHER_USER_ID,
+        entityType: 'TASK',
+        entityId: 'task-2',
+        actionType: '[Task] Other User Update',
+        vectorClock: { Z: 1 },
       });
 
-      const rows = await prefetchForPairs([
-        { entityType: 'TASK', entityId: 'task-2' },
-        { entityType: 'PROJECT', entityId: 'task-2' },
-      ]);
-
-      const byKey = Object.fromEntries(
-        rows.map((r) => [`${r.entityType}:${r.entityId}`, r.serverSeq]),
+      const latestByEntity = await prefetchLatestEntityOpsForBatch(
+        USER_ID,
+        [
+          { entityType: 'TASK', entityId: 'task-2' },
+          { entityType: 'PROJECT', entityId: 'task-2' },
+        ],
+        transaction,
       );
-      expect(byKey).toEqual({ 'TASK:task-2': 1, 'PROJECT:task-2': 2 });
+
+      expect(latestByEntity.get(getEntityConflictKey('TASK', 'task-2'))).toMatchObject({
+        entityType: 'TASK',
+        entityId: 'task-2',
+        clientId: 'A',
+        actionType: '[Task] Batch Update',
+        vectorClock: { A: 1 },
+        serverSeq: 3,
+      });
+      expect(latestByEntity.get(getEntityConflictKey('PROJECT', 'task-2'))).toMatchObject(
+        {
+          entityType: 'PROJECT',
+          entityId: 'task-2',
+          clientId: 'A',
+          actionType: '[Project] Update',
+          vectorClock: { A: 2 },
+          serverSeq: 2,
+        },
+      );
     });
 
     it('matches a (type, divergent-scalar) pair not present in entity_ids — the #8334 silent-data-loss case', async () => {
@@ -314,12 +383,16 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
         entityType: 'TASK',
         entityId: 'task-Z',
         entityIds: ['task-A'],
+        vectorClock: { A: 1 },
       });
 
-      const rows = await prefetchForPairs([{ entityType: 'TASK', entityId: 'task-Z' }]);
+      const latestByEntity = await prefetchLatestEntityOpsForBatch(
+        USER_ID,
+        [{ entityType: 'TASK', entityId: 'task-Z' }],
+        transaction,
+      );
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({
+      expect(latestByEntity.get(getEntityConflictKey('TASK', 'task-Z'))).toMatchObject({
         entityType: 'TASK',
         entityId: 'task-Z',
         serverSeq: 1,

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { uuidv7 } from 'uuidv7';
 import { Prisma } from '@prisma/client';
-import { prefetchLatestEntityOpsForBatch } from '../src/sync/conflict';
+import {
+  getEntityConflictKey,
+  prefetchLatestEntityOpsForBatch,
+} from '../src/sync/conflict';
 import { CONFLICT_DETECTION_ENTITY_BATCH_SIZE } from '../src/sync/sync.types';
 import { testState, resetTestState } from './sync.service.test-state';
 
@@ -1638,9 +1641,11 @@ describe('SyncService', () => {
           tx as unknown as Prisma.TransactionClient,
         );
 
-        expect(latestByEntity.get(`TASK\u0000${boundaryPair.entityId}`)).toEqual(
-          boundaryRow,
-        );
+        expect(
+          latestByEntity.get(
+            getEntityConflictKey(boundaryPair.entityType, boundaryPair.entityId),
+          ),
+        ).toEqual(boundaryRow);
         expect(queriedBatchSizes).toEqual(expectedBatchSizes);
       },
     );

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { uuidv7 } from 'uuidv7';
 import { Prisma } from '@prisma/client';
 import { prefetchLatestEntityOpsForBatch } from '../src/sync/conflict';
+import { CONFLICT_DETECTION_ENTITY_BATCH_SIZE } from '../src/sync/sync.types';
 import { testState, resetTestState } from './sync.service.test-state';
 
 // Mock the database module with Prisma mocks
@@ -1589,23 +1590,60 @@ describe('SyncService', () => {
       expect(testState.userSyncStates.get(userId)?.lastSeq).toBe(1);
     });
 
-    it('should chunk large batch entity prefetch queries', async () => {
-      const entityPairs = Array.from({ length: 250 }, (_, index) => ({
-        entityType: 'TASK',
-        entityId: `task-${index}`,
-      }));
-      const tx = {
-        $queryRaw: vi.fn().mockResolvedValue([]),
-      };
+    it.each([
+      CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
+      CONFLICT_DETECTION_ENTITY_BATCH_SIZE + 1,
+    ])(
+      'should include the boundary pair and chunk correctly for %i pairs',
+      async (pairCount) => {
+        const boundaryIndex = pairCount - 1;
+        const expectedBatchSizes =
+          pairCount > CONFLICT_DETECTION_ENTITY_BATCH_SIZE
+            ? [CONFLICT_DETECTION_ENTITY_BATCH_SIZE, 1]
+            : [CONFLICT_DETECTION_ENTITY_BATCH_SIZE];
+        const entityPairs = Array.from({ length: pairCount }, (_, index) => ({
+          entityType: 'TASK',
+          entityId: `task-${index}`,
+        }));
+        const boundaryPair = entityPairs[boundaryIndex];
+        const boundaryRow = {
+          ...boundaryPair,
+          clientId: 'other-client',
+          actionType: 'UPDATE_TASK',
+          vectorClock: { 'other-client': 1 },
+          serverSeq: 1,
+        };
+        const queriedBatchSizes: number[] = [];
+        const tx = {
+          $queryRaw: vi
+            .fn()
+            .mockImplementation(async (_strings: unknown, ...params: unknown[]) => {
+              const touchedPairValues = (params[0] as Prisma.Sql).values;
+              queriedBatchSizes.push(touchedPairValues.length / 2);
+              for (let index = 0; index < touchedPairValues.length; index += 2) {
+                if (
+                  touchedPairValues[index] === boundaryPair.entityType &&
+                  touchedPairValues[index + 1] === boundaryPair.entityId
+                ) {
+                  return [boundaryRow];
+                }
+              }
+              return [];
+            }),
+        };
 
-      await prefetchLatestEntityOpsForBatch(
-        userId,
-        entityPairs,
-        tx as unknown as Prisma.TransactionClient,
-      );
+        const latestByEntity = await prefetchLatestEntityOpsForBatch(
+          userId,
+          entityPairs,
+          tx as unknown as Prisma.TransactionClient,
+        );
 
-      expect(tx.$queryRaw).toHaveBeenCalledTimes(3);
-    });
+        expect(latestByEntity.get(`TASK\u0000${boundaryPair.entityId}`)).toEqual(
+          boundaryRow,
+        );
+        expect(queriedBatchSizes).toEqual(expectedBatchSizes);
+      },
+    );
 
     it('should create user sync state for first-time batch uploads', async () => {
       const service = new SyncService({ batchUpload: true });


### PR DESCRIPTION
## Summary

- execute the production `detectConflictForEntities` and `prefetchLatestEntityOpsForBatch` tagged SQL against PGlite in the default server suite
- cover required projections, latest-row selection, tenant/type isolation, scalar/array membership, conflict traversal, timer-delta asymmetry, duplicate ownership, legacy config boundaries, and exact 100/101-item chunking
- replace the copied SQL test helpers with a small Prisma tagged-template transaction adapter

## Why

The default SuperSync server suite stayed green when either production batch conflict query was disabled with `AND FALSE`. The tests exercised hand-copied SQL rather than the production templates, so critical conflict-detection regressions could bypass the default suite.

## Impact

This is test-only: there are no runtime, schema, API, or dependency changes. Regressions in the production batch queries now fail the normal server test run.

## Validation

- mandatory `checkFile` checks passed for all three modified test files
- SuperSync server TypeScript build passed
- SuperSync server suite: 45 files, 923 tests passed
- targeted mutation checks confirmed the exact-size boundary and `lt`/`lte` guards fail under their corresponding mutations
- pre-push repository lint completed with zero errors (10 unrelated existing warnings)
- pre-push root suites passed, including 13,306 Angular tests and 13,292 timezone tests

Closes #9205
