### PR TITLE
feat(supersync): add database incident guardrails

### DIFF
--- a/packages/super-sync-server/docker-compose.build.yml
+++ b/packages/super-sync-server/docker-compose.build.yml
@@ -11,3 +11,5 @@ services:
       args:
         VCS_REF: ${SUPERSYNC_BUILD_SHA:-local}
     image: supersync:local
+    environment:
+      - MIGRATE_RECOVERY_BUILD_LOCAL=true

--- a/packages/super-sync-server/docker-compose.yml
+++ b/packages/super-sync-server/docker-compose.yml
@@ -32,11 +32,14 @@ services:
       - PORT=1900
       - HOST=${HOST:-0.0.0.0}
       # Prisma sizes its default pool from host CPUs, not the container limit.
-      # Overriding DATABASE_URL replaces these bounds; carry them across. A global
-      # statement_timeout remains opt-in because the legacy snapshot-clock scan
-      # can legitimately exceed 60s on upgraded histories. See env.example. (#9191)
+      # Overriding DATABASE_URL replaces these bounds; carry them across. The
+      # migrator rejects missing/invalid bounds before a production deploy. A
+      # global statement_timeout remains opt-in because the legacy snapshot-clock
+      # scan can legitimately exceed 60s on upgraded histories. See env.example.
+      # (#9191)
       - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-supersync}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-supersync}?connection_limit=60&pool_timeout=10}
       - RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}
+      - REQUIRE_DATABASE_POOL_LIMITS=true
       - MIGRATE_RECOVERY_RUNTIME=compose
       - JWT_SECRET=${JWT_SECRET}
       - PUBLIC_URL=${PUBLIC_URL:-http://localhost:1900}

--- a/packages/super-sync-server/docker-compose.yml
+++ b/packages/super-sync-server/docker-compose.yml
@@ -14,13 +14,8 @@ x-logging: &default-logging
     max-size: '10m'
     max-file: '3'
 
-# The app log is the only one that has to answer "what did load look like before
-# this started?" during an incident. At incident volume 3×10m is ~3 hours, which
-# in the 2026-07-20 outage had already rotated past the start of the pile-up by
-# the time anyone was looking — the daily traffic shape could not be
-# reconstructed at all. 30 files is ~days of history for ~300 MB. Deliberately
-# NOT applied to postgres/caddy via the shared anchor: that would be ~900 MB
-# against a disk alert that fires at 85%, for logs no incident needed. (#9191)
+# Preserve several days of app history at incident volume (~300 MB), without
+# applying the same 10x increase to Postgres and Caddy. (#9191)
 x-logging-app: &app-logging
   driver: 'json-file'
   options:
@@ -36,25 +31,13 @@ services:
       - NODE_ENV=${NODE_ENV:-production}
       - PORT=1900
       - HOST=${HOST:-0.0.0.0}
-      # The query params are load-bearing, not tuning (#9191):
-      #   statement_timeout - a degenerate query plan otherwise holds a pool
-      #     connection until someone kills it by hand (75 minutes, 2026-07-20).
-      #     Prisma's transaction timeout aborts only the client side, leaving the
-      #     backend running, so this is what makes pool exhaustion RECOVERABLE
-      #     rather than an absorbing state. It was absent in all three
-      #     operations-table pool incidents. Only the connection-string form
-      #     works — Prisma overrides role- and database-level settings.
-      #   connection_limit - Prisma otherwise defaults to host_cores * 2 + 1,
-      #     read from HOST cores, not the `cpus: '1.0'` limit below, so it
-      #     silently ignores the ceiling the postgres comment further down
-      #     assumes. max_connections is set well above this on purpose.
-      #   pool_timeout - fail a checkout fast instead of queueing behind an
-      #     already-saturated pool.
-      # Setting DATABASE_URL in .env REPLACES all of this. If you override it,
-      # carry these params across. scripts/migrate-deploy.sh deliberately resets
-      # statement_timeout to 0 for the migrator only.
-      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-supersync}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-supersync}?connection_limit=60&pool_timeout=20&options=-c%20statement_timeout%3D60000}
+      # Prisma sizes its default pool from host CPUs, not the container limit.
+      # Overriding DATABASE_URL replaces these bounds; carry them across. A global
+      # statement_timeout remains opt-in because the legacy snapshot-clock scan
+      # can legitimately exceed 60s on upgraded histories. See env.example. (#9191)
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-supersync}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-supersync}?connection_limit=60&pool_timeout=10}
       - RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}
+      - MIGRATE_RECOVERY_RUNTIME=compose
       - JWT_SECRET=${JWT_SECRET}
       - PUBLIC_URL=${PUBLIC_URL:-http://localhost:1900}
       - CORS_ORIGINS=${CORS_ORIGINS:-https://app.super-productivity.com}

--- a/packages/super-sync-server/docker-compose.yml
+++ b/packages/super-sync-server/docker-compose.yml
@@ -14,7 +14,7 @@ x-logging: &default-logging
     max-size: '10m'
     max-file: '3'
 
-# Preserve several days of app history at incident volume (~300 MB), without
+# Preserve about a day of app history at incident volume (~300 MB), without
 # applying the same 10x increase to Postgres and Caddy. (#9191)
 x-logging-app: &app-logging
   driver: 'json-file'

--- a/packages/super-sync-server/docker-compose.yml
+++ b/packages/super-sync-server/docker-compose.yml
@@ -14,6 +14,19 @@ x-logging: &default-logging
     max-size: '10m'
     max-file: '3'
 
+# The app log is the only one that has to answer "what did load look like before
+# this started?" during an incident. At incident volume 3×10m is ~3 hours, which
+# in the 2026-07-20 outage had already rotated past the start of the pile-up by
+# the time anyone was looking — the daily traffic shape could not be
+# reconstructed at all. 30 files is ~days of history for ~300 MB. Deliberately
+# NOT applied to postgres/caddy via the shared anchor: that would be ~900 MB
+# against a disk alert that fires at 85%, for logs no incident needed. (#9191)
+x-logging-app: &app-logging
+  driver: 'json-file'
+  options:
+    max-size: '10m'
+    max-file: '30'
+
 services:
   supersync:
     image: ${SUPERSYNC_IMAGE:-ghcr.io/super-productivity/supersync:latest}
@@ -23,7 +36,24 @@ services:
       - NODE_ENV=${NODE_ENV:-production}
       - PORT=1900
       - HOST=${HOST:-0.0.0.0}
-      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-supersync}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-supersync}}
+      # The query params are load-bearing, not tuning (#9191):
+      #   statement_timeout - a degenerate query plan otherwise holds a pool
+      #     connection until someone kills it by hand (75 minutes, 2026-07-20).
+      #     Prisma's transaction timeout aborts only the client side, leaving the
+      #     backend running, so this is what makes pool exhaustion RECOVERABLE
+      #     rather than an absorbing state. It was absent in all three
+      #     operations-table pool incidents. Only the connection-string form
+      #     works — Prisma overrides role- and database-level settings.
+      #   connection_limit - Prisma otherwise defaults to host_cores * 2 + 1,
+      #     read from HOST cores, not the `cpus: '1.0'` limit below, so it
+      #     silently ignores the ceiling the postgres comment further down
+      #     assumes. max_connections is set well above this on purpose.
+      #   pool_timeout - fail a checkout fast instead of queueing behind an
+      #     already-saturated pool.
+      # Setting DATABASE_URL in .env REPLACES all of this. If you override it,
+      # carry these params across. scripts/migrate-deploy.sh deliberately resets
+      # statement_timeout to 0 for the migrator only.
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-supersync}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-supersync}?connection_limit=60&pool_timeout=20&options=-c%20statement_timeout%3D60000}
       - RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}
       - JWT_SECRET=${JWT_SECRET}
       - PUBLIC_URL=${PUBLIC_URL:-http://localhost:1900}
@@ -76,7 +106,7 @@ services:
     cpus: '1.0'
     networks:
       - internal
-    logging: *default-logging
+    logging: *app-logging
 
   postgres:
     image: postgres:16-alpine
@@ -91,9 +121,11 @@ services:
     # well inside the 1.5g cap. Prisma's DEFAULT pool is ~(host_cpu_count × 2),
     # read from host cores NOT the container cpu limit — it is NOT single-digit
     # on this VPS and will silently consume the entire cap. The app MUST bound
-    # it via DATABASE_URL ?connection_limit=N (currently 60). max_connections
-    # stays well above N to reserve slots for migrations, psql, the old-ops
-    # cleanup job, and the reconnect stampede after an in-place crash recovery.
+    # it via DATABASE_URL ?connection_limit=N (60, set on the DATABASE_URL
+    # default above — this comment asserted it for months while the URL carried
+    # no such param, #9191). max_connections stays well above N to reserve slots
+    # for migrations, psql, the old-ops cleanup job, and the reconnect stampede
+    # after an in-place crash recovery.
     command:
       - postgres
       - -c

--- a/packages/super-sync-server/env.example
+++ b/packages/super-sync-server/env.example
@@ -40,7 +40,7 @@ HOST=0.0.0.0
 # is also kept as a compatibility alias for older .env files. If you point this
 # at an external host, also set POSTGRES_SERVICE= below.
 #
-# IMPORTANT: append ?connection_limit=N&pool_timeout=20 to bound Prisma's pool.
+# IMPORTANT: append ?connection_limit=N&pool_timeout=10 to bound Prisma's pool.
 # Prisma's DEFAULT pool size is ~(host_cpu_count * 2), read from HOST cores —
 # NOT the container cpu limit. On a many-core host an unbounded pool silently
 # consumes the entire postgres max_connections cap (compose: 120), leaving zero
@@ -48,19 +48,33 @@ HOST=0.0.0.0
 # stampede after a crash recovery -> "sorry, too many clients already" and a
 # fleet-wide WS reconnect storm. Keep N well below max_connections (e.g. 60).
 #
-# ALSO IMPORTANT: append options=-c%20statement_timeout%3D60000 (60s). Without
-# it a single degenerate query plan holds a pool connection until someone kills
-# it by hand — 75 minutes in the 2026-07-20 outage, which consumed the whole pool
-# and failed every user's sync, including requests unrelated to the bad query.
-# Prisma's transaction timeout only aborts the client side; the backend keeps
-# running. This is what makes pool exhaustion recoverable rather than a state the
-# server cannot exit on its own. Only the connection-string form works — Prisma
-# overrides both ALTER ROLE and ALTER DATABASE statement_timeout. Note %20 and
-# %3D must be percent-encoded; a literal space or `+` will not be decoded. (#9191)
-#
 # Setting DATABASE_URL here REPLACES the compose default wholesale, so these
 # params are not inherited — they must be carried across explicitly.
-# DATABASE_URL=postgresql://supersync:password@example.com:5432/supersync?connection_limit=60&pool_timeout=20&options=-c%20statement_timeout%3D60000
+# DATABASE_URL=postgresql://supersync:password@example.com:5432/supersync?connection_limit=60&pool_timeout=10
+#
+# OPTIONAL RECOVERY GUARDRAIL — enable only after checking legacy histories:
+#   ...&options=-c%20statement_timeout%3D60000
+# Without it a single degenerate query plan holds a pool connection until someone
+# kills it by hand: 75 minutes in the 2026-07-20 outage, which consumed the whole
+# pool and failed every user's sync, including requests unrelated to the bad
+# query. Prisma's transaction timeout only aborts the client side; the backend
+# keeps running. This is what makes pool exhaustion recoverable rather than a
+# state the server cannot exit on its own, and it was absent in all three
+# operations-table incidents. Only the connection-string form works — Prisma
+# overrides both ALTER ROLE and ALTER DATABASE statement_timeout. %20 and %3D
+# must stay percent-encoded; a literal space or `+` will not be decoded.
+#
+# NOT enabled by default because one legacy path legitimately exceeds 60s:
+# `_computeSnapshotVectorClock` (src/sync/services/operation-download.service.ts)
+# aggregates the vector clock across a user's whole history, and was moved out of
+# its transaction because large histories trip the 60s transaction budget. It
+# runs when persisted snapshot-clock metadata is missing, stale, or invalid. On
+# upgraded instances with long histories, a 60s cap can turn those downloads into
+# deterministic 500s. Either confirm that fallback no longer fires for your users,
+# or set a budget above its worst case. (#9191)
+#
+# scripts/migrate-deploy.sh resets statement_timeout to 0 for the migrator, so
+# CREATE INDEX CONCURRENTLY is never cancelled by this setting.
 
 # =============================================================================
 # CORS SETTINGS

--- a/packages/super-sync-server/env.example
+++ b/packages/super-sync-server/env.example
@@ -61,8 +61,8 @@ HOST=0.0.0.0
 # keeps running. This is what makes pool exhaustion recoverable rather than a
 # state the server cannot exit on its own, and it was absent in all three
 # operations-table incidents. Only the connection-string form works — Prisma
-# overrides both ALTER ROLE and ALTER DATABASE statement_timeout. %20 and %3D
-# must stay percent-encoded; a literal space or `+` will not be decoded.
+# overrides both ALTER ROLE and ALTER DATABASE statement_timeout. Keep the
+# shown %20 (space) and %3D (=) encoding for portability across URL tooling.
 #
 # NOT enabled by default because one legacy path legitimately exceeds 60s:
 # `_computeSnapshotVectorClock` (src/sync/services/operation-download.service.ts)
@@ -73,8 +73,9 @@ HOST=0.0.0.0
 # deterministic 500s. Either confirm that fallback no longer fires for your users,
 # or set a budget above its worst case. (#9191)
 #
-# scripts/migrate-deploy.sh resets statement_timeout to 0 for the migrator, so
-# CREATE INDEX CONCURRENTLY is never cancelled by this setting.
+# scripts/migrate-deploy.sh replaces this cap for the migrator with a finite
+# statement timeout five seconds below MIGRATE_STEP_TIMEOUT, allowing long
+# CREATE INDEX CONCURRENTLY work without leaving an unbounded backend query.
 
 # =============================================================================
 # CORS SETTINGS

--- a/packages/super-sync-server/env.example
+++ b/packages/super-sync-server/env.example
@@ -47,7 +47,20 @@ HOST=0.0.0.0
 # headroom for psql, migrations, the old-ops cleanup job, or the reconnect
 # stampede after a crash recovery -> "sorry, too many clients already" and a
 # fleet-wide WS reconnect storm. Keep N well below max_connections (e.g. 60).
-# DATABASE_URL=postgresql://supersync:password@example.com:5432/supersync?connection_limit=60&pool_timeout=20
+#
+# ALSO IMPORTANT: append options=-c%20statement_timeout%3D60000 (60s). Without
+# it a single degenerate query plan holds a pool connection until someone kills
+# it by hand — 75 minutes in the 2026-07-20 outage, which consumed the whole pool
+# and failed every user's sync, including requests unrelated to the bad query.
+# Prisma's transaction timeout only aborts the client side; the backend keeps
+# running. This is what makes pool exhaustion recoverable rather than a state the
+# server cannot exit on its own. Only the connection-string form works — Prisma
+# overrides both ALTER ROLE and ALTER DATABASE statement_timeout. Note %20 and
+# %3D must be percent-encoded; a literal space or `+` will not be decoded. (#9191)
+#
+# Setting DATABASE_URL here REPLACES the compose default wholesale, so these
+# params are not inherited — they must be carried across explicitly.
+# DATABASE_URL=postgresql://supersync:password@example.com:5432/supersync?connection_limit=60&pool_timeout=20&options=-c%20statement_timeout%3D60000
 
 # =============================================================================
 # CORS SETTINGS

--- a/packages/super-sync-server/helm/supersync/templates/_helpers.tpl
+++ b/packages/super-sync-server/helm/supersync/templates/_helpers.tpl
@@ -67,3 +67,13 @@ Create the fully qualified name for the PostgreSQL resources.
 {{- define "supersync.postgresql.fullname" -}}
 {{- printf "%s-postgresql" (include "supersync.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/* Validate and render the built-in database's Prisma connection limit. */}}
+{{- define "supersync.postgresqlConnectionLimit" -}}
+{{- $value := toString .Values.postgresql.connectionLimit -}}
+{{- $safeLength := or (lt (len $value) 16) (and (eq (len $value) 16) (le $value "9007199254740991")) -}}
+{{- if not (and (regexMatch "^[1-9][0-9]*$" $value) $safeLength) -}}
+{{- fail "postgresql.connectionLimit must be a positive integer" -}}
+{{- end -}}
+{{- $value -}}
+{{- end }}

--- a/packages/super-sync-server/helm/supersync/templates/database-url-check.yaml
+++ b/packages/super-sync-server/helm/supersync/templates/database-url-check.yaml
@@ -1,0 +1,62 @@
+{{- if not .Values.postgresql.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-database-url-check" (include "supersync.fullname" . | trunc 44 | trimSuffix "-") }}
+  labels:
+    {{- include "supersync.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: database-url-check
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: validate-database-url
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ['node', '-e']
+          args:
+            - |
+              try {
+                const url = new URL(process.env.DATABASE_URL);
+                const valid = ['connection_limit', 'pool_timeout'].every((name) => {
+                  const values = url.searchParams.getAll(name);
+                  const value = values[0];
+                  return values.length === 1 && /^[1-9][0-9]*$/.test(value) &&
+                    Number.isSafeInteger(Number(value));
+                });
+                if (!valid) throw new Error();
+              } catch {
+                console.error(
+                  'DATABASE_URL must include exactly one positive connection_limit and pool_timeout value each.',
+                );
+                process.exit(1);
+              }
+          env:
+            - name: DATABASE_URL
+              {{- if .Values.externalDatabase.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.existingSecret }}
+                  key: DATABASE_URL
+              {{- else }}
+              value: {{ .Values.externalDatabase.url | quote }}
+              {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+{{- end }}

--- a/packages/super-sync-server/helm/supersync/templates/deployment.yaml
+++ b/packages/super-sync-server/helm/supersync/templates/deployment.yaml
@@ -1,11 +1,6 @@
 {{- if gt (.Values.replicaCount | int) 1 }}
   {{- fail "replicaCount > 1 is not supported: WebSocket connection state is in-memory and not shared across replicas" }}
 {{- end }}
-{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) }}
-  {{- if or (not (regexMatch `[?&]connection_limit=[1-9][0-9]*([&#]|$)` .Values.externalDatabase.url)) (not (regexMatch `[?&]pool_timeout=[1-9][0-9]*([&#]|$)` .Values.externalDatabase.url)) }}
-    {{- fail "externalDatabase.url must include connection_limit and pool_timeout" }}
-  {{- end }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,6 +45,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['sh', '-c', 'sh scripts/migrate-deploy.sh']
           env:
+            - name: REQUIRE_DATABASE_POOL_LIMITS
+              value: "true"
             {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_USER
               value: {{ .Values.postgresql.username | quote }}
@@ -61,12 +58,8 @@ spec:
                   name: {{ .Values.postgresql.existingSecret | default (include "supersync.postgresql.fullname" .) }}
                   key: POSTGRES_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)?connection_limit=60&pool_timeout=10"
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)?connection_limit={{ include "supersync.postgresqlConnectionLimit" . }}&pool_timeout=10"
             {{- else }}
-            {{- if .Values.externalDatabase.existingSecret }}
-            - name: REQUIRE_DATABASE_POOL_LIMITS
-              value: "true"
-            {{- end }}
             - name: DATABASE_URL
               {{- if .Values.externalDatabase.existingSecret }}
               valueFrom:
@@ -118,7 +111,7 @@ spec:
                   name: {{ .Values.postgresql.existingSecret | default (include "supersync.postgresql.fullname" .) }}
                   key: POSTGRES_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)?connection_limit=60&pool_timeout=10"
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)?connection_limit={{ include "supersync.postgresqlConnectionLimit" . }}&pool_timeout=10"
             {{- else }}
             - name: DATABASE_URL
               {{- if .Values.externalDatabase.existingSecret }}

--- a/packages/super-sync-server/helm/supersync/templates/deployment.yaml
+++ b/packages/super-sync-server/helm/supersync/templates/deployment.yaml
@@ -1,6 +1,11 @@
 {{- if gt (.Values.replicaCount | int) 1 }}
   {{- fail "replicaCount > 1 is not supported: WebSocket connection state is in-memory and not shared across replicas" }}
 {{- end }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) }}
+  {{- if or (not (regexMatch `[?&]connection_limit=[1-9][0-9]*([&#]|$)` .Values.externalDatabase.url)) (not (regexMatch `[?&]pool_timeout=[1-9][0-9]*([&#]|$)` .Values.externalDatabase.url)) }}
+    {{- fail "externalDatabase.url must include connection_limit and pool_timeout" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,8 +61,12 @@ spec:
                   name: {{ .Values.postgresql.existingSecret | default (include "supersync.postgresql.fullname" .) }}
                   key: POSTGRES_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)"
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)?connection_limit=60&pool_timeout=10"
             {{- else }}
+            {{- if .Values.externalDatabase.existingSecret }}
+            - name: REQUIRE_DATABASE_POOL_LIMITS
+              value: "true"
+            {{- end }}
             - name: DATABASE_URL
               {{- if .Values.externalDatabase.existingSecret }}
               valueFrom:
@@ -109,7 +118,7 @@ spec:
                   name: {{ .Values.postgresql.existingSecret | default (include "supersync.postgresql.fullname" .) }}
                   key: POSTGRES_PASSWORD
             - name: DATABASE_URL
-              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)"
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "supersync.postgresql.fullname" . }}:5432/$(POSTGRES_DB)?connection_limit=60&pool_timeout=10"
             {{- else }}
             - name: DATABASE_URL
               {{- if .Values.externalDatabase.existingSecret }}

--- a/packages/super-sync-server/helm/supersync/values.yaml
+++ b/packages/super-sync-server/helm/supersync/values.yaml
@@ -144,10 +144,12 @@ postgresql:
 
 # -- External database configuration (used when postgresql.enabled is false)
 externalDatabase:
-  # -- Full PostgreSQL connection URL (e.g. postgresql://user:pass@host:5432/dbname)
+  # -- Full PostgreSQL URL. Must include connection_limit and pool_timeout, e.g.
+  # postgresql://user:pass@host:5432/dbname?connection_limit=60&pool_timeout=10
   url: ""
   # -- Use an existing Kubernetes secret for the database URL.
-  # The secret must contain a DATABASE_URL key.
+  # The secret must contain a DATABASE_URL key with the same pool parameters;
+  # the migration init container fails fast when either parameter is absent.
   existingSecret: ""
 
 # -- Ingress configuration

--- a/packages/super-sync-server/helm/supersync/values.yaml
+++ b/packages/super-sync-server/helm/supersync/values.yaml
@@ -108,6 +108,8 @@ postgresql:
   # -- Deploy a PostgreSQL instance alongside SuperSync.
   # Set to false and configure externalDatabase to use an external PostgreSQL.
   enabled: true
+  # -- Maximum Prisma connections when using the bundled 512Mi PostgreSQL.
+  connectionLimit: 20
   image:
     # -- PostgreSQL image repository
     repository: postgres
@@ -144,12 +146,13 @@ postgresql:
 
 # -- External database configuration (used when postgresql.enabled is false)
 externalDatabase:
-  # -- Full PostgreSQL URL. Must include connection_limit and pool_timeout, e.g.
+  # -- Full PostgreSQL URL. Must include exactly one positive connection_limit
+  # and pool_timeout value. A pre-upgrade hook validates both before replacing
+  # a running pod, and the migration init container rechecks them, e.g.
   # postgresql://user:pass@host:5432/dbname?connection_limit=60&pool_timeout=10
   url: ""
   # -- Use an existing Kubernetes secret for the database URL.
-  # The secret must contain a DATABASE_URL key with the same pool parameters;
-  # the migration init container fails fast when either parameter is absent.
+  # The secret must contain a DATABASE_URL key with the same pool parameters.
   existingSecret: ""
 
 # -- Ingress configuration

--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
     "pretest": "prisma generate",
     "test": "vitest run",
-    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts",
+    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts",
     "docker:build": "./scripts/build-and-push.sh",
     "docker:deploy": "./scripts/deploy.sh",
     "docker:deploy:build": "./scripts/deploy.sh --build",

--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
     "pretest": "prisma generate",
     "test": "vitest run",
-    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts",
+    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts",
     "docker:build": "./scripts/build-and-push.sh",
     "docker:deploy": "./scripts/deploy.sh",
     "docker:deploy:build": "./scripts/deploy.sh --build",

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -239,14 +239,14 @@ If it says the cron is missing, nothing is watching the server.
 
 ### What it checks
 
-| #   | Check                                                            | Fires when                                                            |
-| --- | ---------------------------------------------------------------- | --------------------------------------------------------------------- |
-| 0–3 | Docker daemon, container state/health, OOM kills, restart counts | a container is down, unhealthy, OOM-killed, or crash-looping          |
-| 4   | `/health` endpoint                                               | HTTP != 200                                                           |
-| 5   | Disk usage                                                       | > 85%                                                                 |
-| 6   | Long-running queries                                             | any query `active` > `MAX_QUERY_SECONDS` (default 120)                |
-| 7   | Pool saturation                                                  | active backends ≥ `POOL_WARN_PCT`% (default 75) of `connection_limit` |
-| 8   | Invalid operations indexes                                       | a non-building index is not valid/ready/live                          |
+| #   | Check                                                            | Fires when                                                               |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| 0–3 | Docker daemon, container state/health, OOM kills, restart counts | a container is down, unhealthy, OOM-killed, or crash-looping             |
+| 4   | `/health` endpoint                                               | HTTP != 200                                                              |
+| 5   | Disk usage                                                       | > 85%                                                                    |
+| 6   | Long-running queries                                             | any query `active` > `MAX_QUERY_SECONDS` (default 120)                   |
+| 7   | Pool saturation                                                  | connections in use ≥ `POOL_WARN_PCT`% (default 75) of `connection_limit` |
+| 8   | Invalid operations indexes                                       | a non-building index is not valid/ready/live                             |
 
 Checks 0–5 detect the outage once containers or `/health` fail. Checks 6–8 inspect
 the database through the app container and catch the precursor while the server
@@ -266,12 +266,12 @@ lookup would silently degrade to a sequential scan on every upload, permanently,
 and nothing else in the codebase would report it.
 
 The known migrator is excluded from the long-query check. Indexes currently
-listed in `pg_stat_progress_create_index`, and invalid indexes observed while the
-migrator is active, are excluded from check 8. The latter also covers
-`DROP INDEX CONCURRENTLY`, which has no progress-view entry. Each migration run
-has a unique database application id; its finite database/client timeouts and
-targeted backend cleanup bound interrupted DDL without generating
-incident/recovery noise.
+listed in `pg_stat_progress_create_index`, and invalid indexes carrying the
+exact DDL lock held by an active migrator, are excluded from check 8. The latter
+also covers `DROP INDEX CONCURRENTLY`, which has no progress-view entry, without
+hiding unrelated invalid indexes. Each migration run has a unique database
+application id; its finite database/client timeouts and targeted backend cleanup
+bound interrupted DDL without generating incident/recovery noise.
 
 Repeat alerts for the same problem are suppressed by a content hash, so counts
 and durations are normalised out — you get one mail per distinct problem, plus a

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -265,10 +265,13 @@ insert**. If `operations_entity_ids_gin` were the invalid one, the conflict
 lookup would silently degrade to a sequential scan on every upload, permanently,
 and nothing else in the codebase would report it.
 
-The known migrator is excluded from the long-query check, and indexes currently
-listed in `pg_stat_progress_create_index` are excluded from check 8. Its own
-`MIGRATE_STEP_TIMEOUT` and deploy exit status monitor intentional long-running DDL
-without generating incident/recovery noise.
+The known migrator is excluded from the long-query check. Indexes currently
+listed in `pg_stat_progress_create_index`, and invalid indexes observed while the
+migrator is active, are excluded from check 8. The latter also covers
+`DROP INDEX CONCURRENTLY`, which has no progress-view entry. Each migration run
+has a unique database application id; its finite database/client timeouts and
+targeted backend cleanup bound interrupted DDL without generating
+incident/recovery noise.
 
 Repeat alerts for the same problem are suppressed by a content hash, so counts
 and durations are normalised out — you get one mail per distinct problem, plus a

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -232,9 +232,10 @@ is not started by `deploy.sh` and nothing else runs it:
 (crontab -l 2>/dev/null; echo "*/5 * * * * ALERT_EMAIL=you@example.com /path/to/super-sync-server/scripts/health-alert.sh") | crontab -
 ```
 
-`deploy.sh` reports at the end of every deploy whether this cron exists, whether
-it is still completing, and whether alert email is being delivered. If it says
-the cron is missing, nothing is watching the server.
+`deploy.sh` reports at the end of every deploy whether this exact cron exists,
+whether it is still completing, and whether the last attempted email failed. It
+cannot prove delivery while the system is healthy because no email is sent then.
+If it says the cron is missing, nothing is watching the server.
 
 ### What it checks
 
@@ -245,14 +246,13 @@ the cron is missing, nothing is watching the server.
 | 5   | Disk usage                                                       | > 85%                                                                 |
 | 6   | Long-running queries                                             | any query `active` > `MAX_QUERY_SECONDS` (default 120)                |
 | 7   | Pool saturation                                                  | active backends ≥ `POOL_WARN_PCT`% (default 75) of `connection_limit` |
-| 8   | Invalid indexes                                                  | any index in `public` is not valid/ready/live                         |
+| 8   | Invalid operations indexes                                       | a non-building index is not valid/ready/live                          |
 
-Checks 6–8 exist because 0–5 are all **liveness** checks and cannot see the
-failure mode that has now caused three `operations`-table incidents: every
-container stays running and healthy while a degenerate query plan holds
-connections until the pool is empty. That failure is bistable — below the
-capacity ceiling nothing looks wrong, above it everything fails at once — so
-there is no gradual phase for a liveness check to notice.
+Checks 0–5 detect the outage once containers or `/health` fail. Checks 6–8 inspect
+the database through the app container and catch the precursor while the server
+can still answer. This also works when `POSTGRES_SERVICE=` selects an external
+database. A failed/malformed probe and a missing `connection_limit` are themselves
+alertable problems, so the new checks cannot silently become inert.
 
 Check 7 is deliberately a **ratio** against `connection_limit`, not a fixed
 number: measured steady state sits the same order of magnitude below the
@@ -264,6 +264,11 @@ leaves an index that is **unusable for reads but still maintained on every
 insert**. If `operations_entity_ids_gin` were the invalid one, the conflict
 lookup would silently degrade to a sequential scan on every upload, permanently,
 and nothing else in the codebase would report it.
+
+The known migrator is excluded from the long-query check, and indexes currently
+listed in `pg_stat_progress_create_index` are excluded from check 8. Its own
+`MIGRATE_STEP_TIMEOUT` and deploy exit status monitor intentional long-running DDL
+without generating incident/recovery noise.
 
 Repeat alerts for the same problem are suppressed by a content hash, so counts
 and durations are normalised out — you get one mail per distinct problem, plus a

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -222,6 +222,53 @@ Possible causes:
 
 **Investigate**: `snapshot-analysis`, correlation with op count
 
+## Alerting (health-alert.sh)
+
+The reports above are things you go and read. `health-alert.sh` is the only thing
+that comes and finds you, and it is **the piece that has to be installed** — it
+is not started by `deploy.sh` and nothing else runs it:
+
+```bash
+(crontab -l 2>/dev/null; echo "*/5 * * * * ALERT_EMAIL=you@example.com /path/to/super-sync-server/scripts/health-alert.sh") | crontab -
+```
+
+`deploy.sh` reports at the end of every deploy whether this cron exists, whether
+it is still completing, and whether alert email is being delivered. If it says
+the cron is missing, nothing is watching the server.
+
+### What it checks
+
+| #   | Check                                                            | Fires when                                                            |
+| --- | ---------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 0–3 | Docker daemon, container state/health, OOM kills, restart counts | a container is down, unhealthy, OOM-killed, or crash-looping          |
+| 4   | `/health` endpoint                                               | HTTP != 200                                                           |
+| 5   | Disk usage                                                       | > 85%                                                                 |
+| 6   | Long-running queries                                             | any query `active` > `MAX_QUERY_SECONDS` (default 120)                |
+| 7   | Pool saturation                                                  | active backends ≥ `POOL_WARN_PCT`% (default 75) of `connection_limit` |
+| 8   | Invalid indexes                                                  | any index in `public` is not valid/ready/live                         |
+
+Checks 6–8 exist because 0–5 are all **liveness** checks and cannot see the
+failure mode that has now caused three `operations`-table incidents: every
+container stays running and healthy while a degenerate query plan holds
+connections until the pool is empty. That failure is bistable — below the
+capacity ceiling nothing looks wrong, above it everything fails at once — so
+there is no gradual phase for a liveness check to notice.
+
+Check 7 is deliberately a **ratio** against `connection_limit`, not a fixed
+number: measured steady state sits the same order of magnitude below the
+pathological-query ceiling (pool size ÷ worst-case query duration), so the
+absolute margin is thin and a fixed threshold would not survive a pool resize.
+
+Check 8 matters more than it looks. An interrupted `CREATE INDEX CONCURRENTLY`
+leaves an index that is **unusable for reads but still maintained on every
+insert**. If `operations_entity_ids_gin` were the invalid one, the conflict
+lookup would silently degrade to a sequential scan on every upload, permanently,
+and nothing else in the codebase would report it.
+
+Repeat alerts for the same problem are suppressed by a content hash, so counts
+and durations are normalised out — you get one mail per distinct problem, plus a
+recovery mail when it clears.
+
 ## Automation
 
 You can set up cron jobs for regular monitoring:

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -427,6 +427,8 @@ echo ""
 report_monitoring_status() {
     local state_dir="$SERVER_DIR/.health-alert"
     local script_path="$SERVER_DIR/scripts/health-alert.sh"
+    local cron_installed=true
+    local recent_run=false
 
     echo ""
     echo "==> Monitoring status"
@@ -442,26 +444,35 @@ report_monitoring_status() {
         }
         END { exit(found ? 0 : 1) }
     '; then
+        cron_installed=false
         echo "    WARNING: health-alert.sh is not in this user's crontab."
-        echo "             Pool saturation and long-running queries will go unnoticed."
-        echo "             Install with:"
-        echo "               (crontab -l 2>/dev/null; echo \"*/5 * * * * ALERT_EMAIL=you@example.com $script_path\") | crontab -"
-        return
+    else
+        echo "    health-alert.sh: cron installed"
     fi
-    echo "    health-alert.sh: cron installed"
 
-    # A stale last-run means the cron is present but not completing.
+    # A fresh heartbeat is authoritative even when another user or scheduler
+    # runs the script and the current user's crontab has no matching entry.
     if [ -f "$state_dir/last-run" ]; then
         local last_run age
         last_run=$(cat "$state_dir/last-run" 2>/dev/null || true)
         age=$(( $(date -u +%s) - $(date -u -d "$last_run" +%s 2>/dev/null || echo 0) ))
         if [ "$age" -gt 1800 ]; then
-            echo "    WARNING: last completed run was $last_run (>30m ago) — cron is not completing."
+            echo "    WARNING: last completed run was $last_run (>30m ago) — health-alert.sh is not completing."
         else
+            recent_run=true
             echo "    last run: $last_run"
         fi
     else
-        echo "    WARNING: cron has no completed run recorded yet (expected within 5 minutes)."
+        echo "    WARNING: health-alert.sh has no completed run recorded yet (expected within 5 minutes)."
+    fi
+
+    if ! $cron_installed; then
+        if $recent_run; then
+            echo "    health-alert.sh: recent completed run found outside this user's crontab"
+        else
+            echo "             Monitoring is not confirmed active. Install with:"
+            echo "               (crontab -l 2>/dev/null; echo \"*/5 * * * * ALERT_EMAIL=you@example.com $script_path\") | crontab -"
+        fi
     fi
 
     if [ -f "$state_dir/mail-failed" ]; then

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -422,16 +422,8 @@ echo "    All containers healthy"
 
 # Verify HTTPS health check
 echo ""
-# Report on the alerting path itself (#9191).
-#
-# All three operations-table pool incidents were found by users reporting
-# problems, never by monitoring — and health-alert.sh has had checks that should
-# have caught at least the last one. The gap is that nothing installs it and
-# nothing notices when it stops working: the cron line lives only in a comment in
-# that script, and its stderr goes to the local mail spool, which is exactly what
-# is broken when mail is broken. So report, every deploy, whether the alerting is
-# actually running. Advisory only — never fail a deploy over it, and never edit
-# the operator's crontab from here.
+# Report whether the separately-installed alert cron is active and completing.
+# Advisory only: deploys never edit the operator's crontab. (#9191)
 report_monitoring_status() {
     local state_dir="$SERVER_DIR/.health-alert"
     local script_path="$SERVER_DIR/scripts/health-alert.sh"
@@ -439,7 +431,17 @@ report_monitoring_status() {
     echo ""
     echo "==> Monitoring status"
 
-    if ! crontab -l 2>/dev/null | grep -q 'health-alert\.sh'; then
+    if ! crontab -l 2>/dev/null | awk -v script="$script_path" '
+        NF >= 6 && $1 !~ /^#/ {
+            command_index = 6
+            while (command_index <= NF &&
+                   $command_index ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+                command_index++
+            }
+            if ($command_index == script) found = 1
+        }
+        END { exit(found ? 0 : 1) }
+    '; then
         echo "    WARNING: health-alert.sh is not in this user's crontab."
         echo "             Pool saturation and long-running queries will go unnoticed."
         echo "             Install with:"
@@ -448,24 +450,25 @@ report_monitoring_status() {
     fi
     echo "    health-alert.sh: cron installed"
 
-    # A stale last-run means the cron is present but not completing — a silent
-    # failure that looks identical to a healthy system from the outside.
+    # A stale last-run means the cron is present but not completing.
     if [ -f "$state_dir/last-run" ]; then
         local last_run age
         last_run=$(cat "$state_dir/last-run" 2>/dev/null || true)
         age=$(( $(date -u +%s) - $(date -u -d "$last_run" +%s 2>/dev/null || echo 0) ))
         if [ "$age" -gt 1800 ]; then
-            echo "    WARNING: last successful run was $last_run (>30m ago) — cron is not completing."
+            echo "    WARNING: last completed run was $last_run (>30m ago) — cron is not completing."
         else
             echo "    last run: $last_run"
         fi
     else
-        echo "    NOTE: no run recorded yet (expected within 5 minutes)."
+        echo "    WARNING: cron has no completed run recorded yet (expected within 5 minutes)."
     fi
 
     if [ -f "$state_dir/mail-failed" ]; then
         echo "    WARNING: alert email delivery FAILED at $(cat "$state_dir/mail-failed" 2>/dev/null)."
         echo "             Checks are running but nobody is being told. Verify \`mail\` works."
+    else
+        echo "    alert email: no recorded failure (verified only when mail is attempted)"
     fi
 }
 

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -422,12 +422,60 @@ echo "    All containers healthy"
 
 # Verify HTTPS health check
 echo ""
+# Report on the alerting path itself (#9191).
+#
+# All three operations-table pool incidents were found by users reporting
+# problems, never by monitoring — and health-alert.sh has had checks that should
+# have caught at least the last one. The gap is that nothing installs it and
+# nothing notices when it stops working: the cron line lives only in a comment in
+# that script, and its stderr goes to the local mail spool, which is exactly what
+# is broken when mail is broken. So report, every deploy, whether the alerting is
+# actually running. Advisory only — never fail a deploy over it, and never edit
+# the operator's crontab from here.
+report_monitoring_status() {
+    local state_dir="$SERVER_DIR/.health-alert"
+    local script_path="$SERVER_DIR/scripts/health-alert.sh"
+
+    echo ""
+    echo "==> Monitoring status"
+
+    if ! crontab -l 2>/dev/null | grep -q 'health-alert\.sh'; then
+        echo "    WARNING: health-alert.sh is not in this user's crontab."
+        echo "             Pool saturation and long-running queries will go unnoticed."
+        echo "             Install with:"
+        echo "               (crontab -l 2>/dev/null; echo \"*/5 * * * * ALERT_EMAIL=you@example.com $script_path\") | crontab -"
+        return
+    fi
+    echo "    health-alert.sh: cron installed"
+
+    # A stale last-run means the cron is present but not completing — a silent
+    # failure that looks identical to a healthy system from the outside.
+    if [ -f "$state_dir/last-run" ]; then
+        local last_run age
+        last_run=$(cat "$state_dir/last-run" 2>/dev/null || true)
+        age=$(( $(date -u +%s) - $(date -u -d "$last_run" +%s 2>/dev/null || echo 0) ))
+        if [ "$age" -gt 1800 ]; then
+            echo "    WARNING: last successful run was $last_run (>30m ago) — cron is not completing."
+        else
+            echo "    last run: $last_run"
+        fi
+    else
+        echo "    NOTE: no run recorded yet (expected within 5 minutes)."
+    fi
+
+    if [ -f "$state_dir/mail-failed" ]; then
+        echo "    WARNING: alert email delivery FAILED at $(cat "$state_dir/mail-failed" 2>/dev/null)."
+        echo "             Checks are running but nobody is being told. Verify \`mail\` works."
+    fi
+}
+
 echo "==> Verifying HTTPS health check..."
 for i in {1..6}; do
     if curl -sf "$HEALTH_URL" > /dev/null 2>&1; then
         echo ""
         echo "==> Deployment successful!"
         echo "    Service is healthy at $HEALTH_URL"
+        report_monitoring_status
         exit 0
     fi
     echo "    Waiting... (attempt $i/6)"

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -13,6 +13,8 @@
 #   ALERT_EMAIL    - Email address to receive alerts (required)
 #   COMPOSE_DIR    - Path to docker-compose.yml directory (default: script directory's parent)
 #   HEALTH_URL     - Health endpoint URL (default: read from .env DOMAIN)
+#   MAX_QUERY_SECONDS  - Alert if any query has been active longer (default: 120)
+#   POOL_WARN_PCT      - Alert if active backends exceed this % of the pool (default: 75)
 
 # Do NOT use set -e — a monitoring script must never silently abort.
 set -uo pipefail
@@ -21,6 +23,8 @@ umask 077
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_DIR="${COMPOSE_DIR:-$(dirname "$SCRIPT_DIR")}"
 ALERT_EMAIL="${ALERT_EMAIL:-contact@super-productivity.com}"
+MAX_QUERY_SECONDS="${MAX_QUERY_SECONDS:-120}"
+POOL_WARN_PCT="${POOL_WARN_PCT:-75}"
 
 if [ ! -f "$COMPOSE_DIR/docker-compose.yml" ]; then
   echo "ERROR: $COMPOSE_DIR does not contain docker-compose.yml" >&2
@@ -93,6 +97,100 @@ if $DOCKER_OK; then
       fi
     fi
   done
+
+  # --- Database-level checks (#9191) ---------------------------------------
+  #
+  # Checks 1-5 are all liveness: is the process up, is the endpoint answering.
+  # They cannot see the failure mode that caused the 2026-07-20 outage and the
+  # two operations-table pool incidents before it, where every container stayed
+  # "running" and healthy while a degenerate query plan held connections until
+  # the pool was empty. That failure is bistable — below the capacity line
+  # nothing is visibly wrong, above it everything fails at once — so there is no
+  # gradual phase to notice. These three checks look at the pool directly.
+  #
+  # Best-effort by design: a failed psql must never mask checks 0-5, so every
+  # query falls back to empty and is skipped rather than alerting.
+  PG_ID=$(docker compose ps -q postgres 2>/dev/null | head -1 || true)
+  if [ -n "$PG_ID" ]; then
+    DB_USER=$(grep -E '^POSTGRES_USER=' ".env" 2>/dev/null | cut -d'=' -f2 | tr -d "\"' " || true)
+    DB_NAME=$(grep -E '^POSTGRES_DB=' ".env" 2>/dev/null | cut -d'=' -f2 | tr -d "\"' " || true)
+    DB_USER="${DB_USER:-supersync}"
+    DB_NAME="${DB_NAME:-supersync}"
+
+    pg_query() {
+      timeout 15 docker exec "$PG_ID" \
+        psql -U "$DB_USER" -d "$DB_NAME" -tAX -c "$1" 2>/dev/null | tr -d ' ' || true
+    }
+
+    # 6. Long-running queries. statement_timeout should cap these at 60s, so
+    # anything past MAX_QUERY_SECONDS means the guardrail is absent, overridden,
+    # or the session is exempt (the migrator legitimately is). Excludes idle
+    # backends and this script's own query.
+    LONG_Q=$(pg_query "
+      SELECT count(*) FROM pg_stat_activity
+      WHERE state = 'active' AND pid <> pg_backend_pid()
+        AND backend_type = 'client backend'
+        AND now() - query_start > interval '${MAX_QUERY_SECONDS} seconds';")
+    if [[ "$LONG_Q" =~ ^[0-9]+$ ]] && [ "$LONG_Q" -gt 0 ]; then
+      LONGEST=$(pg_query "
+        SELECT round(extract(epoch FROM max(now() - query_start)))
+        FROM pg_stat_activity
+        WHERE state = 'active' AND pid <> pg_backend_pid()
+          AND backend_type = 'client backend';")
+      PROBLEMS="${PROBLEMS}${LONG_Q} query(s) active longer than ${MAX_QUERY_SECONDS}s (longest: ${LONGEST:-?}s)\n"
+    fi
+
+    # 7. Pool saturation, as a RATIO against the app's connection_limit rather
+    # than a fixed number: measured steady state (~0.75 downloads/sec) sits the
+    # same order of magnitude below the pathological-query ceiling (pool size ÷
+    # worst-case query duration), so the absolute margin is thin and a fixed
+    # threshold would not survive a pool resize.
+    #
+    # Read connection_limit from the RUNNING container's env, not from .env: the
+    # limit may come from the compose default instead, and .env may hold a stale
+    # value the container was not recreated for. Falling back to max_connections
+    # would silently under-report — with a pool of 60 against max_connections
+    # 120, a fully exhausted pool measures 50% and never alerts.
+    APP_ID=$(docker compose ps -q supersync 2>/dev/null | head -1 || true)
+    POOL_LIMIT=""
+    if [ -n "$APP_ID" ]; then
+      POOL_LIMIT=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$APP_ID" 2>/dev/null |
+        grep -m1 '^DATABASE_URL=' | grep -oE 'connection_limit=[0-9]+' | cut -d'=' -f2 || true)
+    fi
+    if ! [[ "${POOL_LIMIT:-}" =~ ^[0-9]+$ ]]; then
+      # No explicit limit: Prisma defaults to host_cores * 2 + 1 (read from HOST
+      # cores, not the container cpu limit), which is unknowable from here. Report
+      # against max_connections and say so, rather than skipping the check.
+      POOL_LIMIT=$(pg_query "SHOW max_connections;")
+      POOL_LIMIT_NOTE=" — no connection_limit set, measured against max_connections"
+    fi
+    ACTIVE=$(pg_query "
+      SELECT count(*) FROM pg_stat_activity
+      WHERE state = 'active' AND pid <> pg_backend_pid()
+        AND backend_type = 'client backend';")
+    if [[ "${ACTIVE:-}" =~ ^[0-9]+$ ]] && [[ "${POOL_LIMIT:-}" =~ ^[0-9]+$ ]] && [ "$POOL_LIMIT" -gt 0 ]; then
+      PCT=$(( ACTIVE * 100 / POOL_LIMIT ))
+      if [ "$PCT" -ge "$POOL_WARN_PCT" ]; then
+        PROBLEMS="${PROBLEMS}Connection pool ${PCT}% saturated (${ACTIVE} active / ${POOL_LIMIT} limit)${POOL_LIMIT_NOTE:-}\n"
+      fi
+    fi
+
+    # 8. Invalid indexes. An interrupted CREATE INDEX CONCURRENTLY leaves an
+    # index that is unusable for reads but STILL maintained on every insert, and
+    # nothing else in the codebase reports it. If operations_entity_ids_gin were
+    # the invalid one, the conflict lookup's array branch would silently degrade
+    # to a sequential scan on every upload — worse than the outage this check
+    # exists to catch, and permanent until someone reindexes. indisready and
+    # indislive are the other two partial states the same interruption leaves.
+    BAD_IDX=$(pg_query "
+      SELECT string_agg(indexrelid::regclass::text, ', ')
+      FROM pg_index
+      WHERE (NOT indisvalid OR NOT indisready OR NOT indislive)
+        AND indrelid IN (SELECT oid FROM pg_class WHERE relnamespace = 'public'::regnamespace);")
+    if [ -n "${BAD_IDX:-}" ]; then
+      PROBLEMS="${PROBLEMS}Invalid/unusable index(es) present: ${BAD_IDX}\n"
+    fi
+  fi
 fi
 
 # 4. Check health endpoint (runs even if Docker is down — tests from outside)
@@ -116,7 +214,9 @@ HASH_INPUT=$(printf '%s' "$PROBLEMS" | sed \
   's/restarted [0-9]* times/restarted N times/g
    s/([0-9]* entries/(N entries/g
    s/at [0-9]*% on/at N% on/g
-   s/HTTP [0-9]*/HTTP NNN/g')
+   s/HTTP [0-9]*/HTTP NNN/g
+   s/[0-9]* query(s) active longer than [0-9]*s (longest: [0-9]*s)/N query(s) active longer than Ns (longest: Ns)/g
+   s/pool [0-9]*% saturated ([0-9]* active \/ [0-9]* limit)/pool N% saturated (N active \/ N limit)/g')
 CURRENT_HASH=$(printf '%s' "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
 PREVIOUS_HASH=$(cat "$ALERT_STATE_FILE" 2>/dev/null || echo "none")
 
@@ -127,8 +227,13 @@ if [ -n "$PROBLEMS" ]; then
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROBLEMS" "$(hostname)" \
         | timeout 30 mail -s "SuperSync Alert: Health Check Failed" "$ALERT_EMAIL" 2>/dev/null; then
       echo "$CURRENT_HASH" > "$ALERT_STATE_FILE"
+      rm -f "$ALERT_STATE_DIR/mail-failed"
     else
+      # A failing alert path is indistinguishable from a healthy system: stderr
+      # from cron goes to the local mail spool, which is exactly what is broken
+      # when mail is broken. Leave a marker deploy.sh can surface instead. (#9191)
       echo "ERROR: Failed to send alert email" >&2
+      date -u +%Y-%m-%dT%H:%M:%SZ > "$ALERT_STATE_DIR/mail-failed"
     fi
   fi
 else

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -15,6 +15,8 @@
 #   HEALTH_URL     - Health endpoint URL (default: read from .env DOMAIN)
 #   MAX_QUERY_SECONDS  - Alert if any query has been active longer (default: 120)
 #   POOL_WARN_PCT      - Alert if active backends exceed this % of the pool (default: 75)
+#   POSTGRES_SERVICE   - Bundled database service to health-check
+#                        (default: postgres; empty: none)
 
 # Do NOT use set -e — a monitoring script must never silently abort.
 set -uo pipefail
@@ -25,6 +27,17 @@ COMPOSE_DIR="${COMPOSE_DIR:-$(dirname "$SCRIPT_DIR")}"
 ALERT_EMAIL="${ALERT_EMAIL:-contact@super-productivity.com}"
 MAX_QUERY_SECONDS="${MAX_QUERY_SECONDS:-120}"
 POOL_WARN_PCT="${POOL_WARN_PCT:-75}"
+
+CONFIG_PROBLEMS=""
+DB_CONFIG_OK=true
+if ! [[ "$MAX_QUERY_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  CONFIG_PROBLEMS="${CONFIG_PROBLEMS}MAX_QUERY_SECONDS must be a positive integer\n"
+  DB_CONFIG_OK=false
+fi
+if ! [[ "$POOL_WARN_PCT" =~ ^([1-9]|[1-9][0-9]|100)$ ]]; then
+  CONFIG_PROBLEMS="${CONFIG_PROBLEMS}POOL_WARN_PCT must be an integer from 1 to 100\n"
+  DB_CONFIG_OK=false
+fi
 
 if [ ! -f "$COMPOSE_DIR/docker-compose.yml" ]; then
   echo "ERROR: $COMPOSE_DIR does not contain docker-compose.yml" >&2
@@ -52,7 +65,17 @@ if [ -f ".env" ]; then
 fi
 HEALTH_URL="${HEALTH_URL:-https://${DOMAIN:-localhost}/health}"
 
-PROBLEMS=""
+# An explicitly empty value means the deployment uses an external database.
+if [ "${POSTGRES_SERVICE+x}" != "x" ]; then
+  if grep -qE '^POSTGRES_SERVICE=' ".env" 2>/dev/null; then
+    POSTGRES_SERVICE=$(grep -m1 -E '^POSTGRES_SERVICE=' ".env" 2>/dev/null |
+      cut -d'=' -f2- | tr -d "\"' " || true)
+  else
+    POSTGRES_SERVICE="postgres"
+  fi
+fi
+
+PROBLEMS="$CONFIG_PROBLEMS"
 DOCKER_OK=true
 
 # 0. Check Docker daemon is accessible
@@ -63,7 +86,11 @@ fi
 
 if $DOCKER_OK; then
   # 1. Check if all containers are running and healthy
-  SERVICES=(supersync postgres caddy)
+  SERVICES=(supersync)
+  if [ -n "$POSTGRES_SERVICE" ]; then
+    SERVICES+=("$POSTGRES_SERVICE")
+  fi
+  SERVICES+=(caddy)
   for svc in "${SERVICES[@]}"; do
     STATE=$(docker compose ps --format '{{.State}}' "$svc" 2>/dev/null || echo "missing")
     HEALTH=$(docker compose ps --format '{{.Health}}' "$svc" 2>/dev/null || echo "")
@@ -98,97 +125,149 @@ if $DOCKER_OK; then
     fi
   done
 
-  # --- Database-level checks (#9191) ---------------------------------------
-  #
-  # Checks 1-5 are all liveness: is the process up, is the endpoint answering.
-  # They cannot see the failure mode that caused the 2026-07-20 outage and the
-  # two operations-table pool incidents before it, where every container stayed
-  # "running" and healthy while a degenerate query plan held connections until
-  # the pool was empty. That failure is bistable — below the capacity line
-  # nothing is visibly wrong, above it everything fails at once — so there is no
-  # gradual phase to notice. These three checks look at the pool directly.
-  #
-  # Best-effort by design: a failed psql must never mask checks 0-5, so every
-  # query falls back to empty and is skipped rather than alerting.
-  PG_ID=$(docker compose ps -q postgres 2>/dev/null | head -1 || true)
-  if [ -n "$PG_ID" ]; then
-    DB_USER=$(grep -E '^POSTGRES_USER=' ".env" 2>/dev/null | cut -d'=' -f2 | tr -d "\"' " || true)
-    DB_NAME=$(grep -E '^POSTGRES_DB=' ".env" 2>/dev/null | cut -d'=' -f2 | tr -d "\"' " || true)
-    DB_USER="${DB_USER:-supersync}"
-    DB_NAME="${DB_NAME:-supersync}"
+  # 6-8. Query the configured database from the app container so external
+  # PostgreSQL deployments use the same DATABASE_URL and Prisma client as the app.
+  if $DB_CONFIG_OK; then
+    DB_PROBE_JS=$(cat <<'NODE'
+const { PrismaClient } = require('@prisma/client');
 
-    pg_query() {
-      timeout 15 docker exec "$PG_ID" \
-        psql -U "$DB_USER" -d "$DB_NAME" -tAX -c "$1" 2>/dev/null | tr -d ' ' || true
-    }
+const prisma = new PrismaClient();
+const maxQuerySeconds = Number(process.env.HEALTH_MAX_QUERY_SECONDS);
 
-    # 6. Long-running queries. statement_timeout should cap these at 60s, so
-    # anything past MAX_QUERY_SECONDS means the guardrail is absent, overridden,
-    # or the session is exempt (the migrator legitimately is). Excludes idle
-    # backends and this script's own query.
-    LONG_Q=$(pg_query "
-      SELECT count(*) FROM pg_stat_activity
-      WHERE state = 'active' AND pid <> pg_backend_pid()
-        AND backend_type = 'client backend'
-        AND now() - query_start > interval '${MAX_QUERY_SECONDS} seconds';")
-    if [[ "$LONG_Q" =~ ^[0-9]+$ ]] && [ "$LONG_Q" -gt 0 ]; then
-      LONGEST=$(pg_query "
-        SELECT round(extract(epoch FROM max(now() - query_start)))
-        FROM pg_stat_activity
-        WHERE state = 'active' AND pid <> pg_backend_pid()
-          AND backend_type = 'client backend';")
-      PROBLEMS="${PROBLEMS}${LONG_Q} query(s) active longer than ${MAX_QUERY_SECONDS}s (longest: ${LONGEST:-?}s)\n"
-    fi
+const readPoolLimit = () => {
+  try {
+    const value = new URL(process.env.DATABASE_URL ?? '').searchParams.get(
+      'connection_limit',
+    );
+    const numericValue = Number(value);
+    return value && /^\d+$/.test(value) && numericValue > 0 && Number.isSafeInteger(numericValue)
+      ? String(numericValue)
+      : '';
+  } catch {
+    return '';
+  }
+};
 
-    # 7. Pool saturation, as a RATIO against the app's connection_limit rather
-    # than a fixed number: measured steady state (~0.75 downloads/sec) sits the
-    # same order of magnitude below the pathological-query ceiling (pool size ÷
-    # worst-case query duration), so the absolute margin is thin and a fixed
-    # threshold would not survive a pool resize.
-    #
-    # Read connection_limit from the RUNNING container's env, not from .env: the
-    # limit may come from the compose default instead, and .env may hold a stale
-    # value the container was not recreated for. Falling back to max_connections
-    # would silently under-report — with a pool of 60 against max_connections
-    # 120, a fully exhausted pool measures 50% and never alerts.
-    APP_ID=$(docker compose ps -q supersync 2>/dev/null | head -1 || true)
+const main = async () => {
+  console.log(`POOL_LIMIT=${readPoolLimit()}`);
+
+  const { activity, indexes } = await prisma.$transaction(
+    async (tx) => {
+      await tx.$executeRawUnsafe('SET LOCAL statement_timeout = 10000');
+      const [activity] = await tx.$queryRawUnsafe(
+        `WITH active AS (
+       SELECT now() - query_start AS age
+       FROM pg_stat_activity
+       WHERE state = 'active'
+         AND pid <> pg_backend_pid()
+         AND backend_type = 'client backend'
+         AND datname = current_database()
+         AND usename = current_user
+         AND application_name IS DISTINCT FROM 'supersync-migrator'
+     )
+     SELECT
+       count(*) FILTER (
+         WHERE age > $1::integer * interval '1 second'
+       )::integer AS "longQueryCount",
+       COALESCE(round(extract(epoch FROM max(age))), 0)::integer AS "longest",
+       count(*)::integer AS "active"
+     FROM active`,
+        maxQuerySeconds,
+      );
+
+      const [indexes] = await tx.$queryRawUnsafe(
+        `SELECT COALESCE(
+       string_agg(i.indexrelid::regclass::text, ', ' ORDER BY i.indexrelid),
+       ''
+     ) AS "badIndex"
+     FROM pg_index i
+     WHERE i.indrelid = 'public.operations'::regclass
+       AND (NOT i.indisvalid OR NOT i.indisready OR NOT i.indislive)
+       AND NOT EXISTS (
+         SELECT 1
+         FROM pg_stat_progress_create_index p
+          WHERE p.index_relid = i.indexrelid
+       )`,
+      );
+
+      return { activity, indexes };
+    },
+    { maxWait: 5000, timeout: 12000 },
+  );
+
+  console.log(`LONG_Q=${activity.longQueryCount}`);
+  console.log(`LONGEST=${activity.longest}`);
+  console.log(`ACTIVE=${activity.active}`);
+  console.log(`BAD_INDEX=${indexes.badIndex}`);
+};
+
+main()
+  .catch((error) => {
+    console.error(
+      'Database probe failed:',
+      error instanceof Error ? error.message : String(error),
+    );
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());
+NODE
+)
+
+    # Allow Prisma's 5s pool wait plus its 12s transaction bound to finish.
+    DB_OUTPUT=$(timeout 20 docker compose exec -T \
+      -e "HEALTH_MAX_QUERY_SECONDS=$MAX_QUERY_SECONDS" \
+      supersync node -e "$DB_PROBE_JS" 2>/dev/null)
+    DB_STATUS=$?
+
+    LONG_Q=""
+    LONGEST=""
+    ACTIVE=""
     POOL_LIMIT=""
-    if [ -n "$APP_ID" ]; then
-      POOL_LIMIT=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$APP_ID" 2>/dev/null |
-        grep -m1 '^DATABASE_URL=' | grep -oE 'connection_limit=[0-9]+' | cut -d'=' -f2 || true)
-    fi
-    if ! [[ "${POOL_LIMIT:-}" =~ ^[0-9]+$ ]]; then
-      # No explicit limit: Prisma defaults to host_cores * 2 + 1 (read from HOST
-      # cores, not the container cpu limit), which is unknowable from here. Report
-      # against max_connections and say so, rather than skipping the check.
-      POOL_LIMIT=$(pg_query "SHOW max_connections;")
-      POOL_LIMIT_NOTE=" — no connection_limit set, measured against max_connections"
-    fi
-    ACTIVE=$(pg_query "
-      SELECT count(*) FROM pg_stat_activity
-      WHERE state = 'active' AND pid <> pg_backend_pid()
-        AND backend_type = 'client backend';")
-    if [[ "${ACTIVE:-}" =~ ^[0-9]+$ ]] && [[ "${POOL_LIMIT:-}" =~ ^[0-9]+$ ]] && [ "$POOL_LIMIT" -gt 0 ]; then
-      PCT=$(( ACTIVE * 100 / POOL_LIMIT ))
-      if [ "$PCT" -ge "$POOL_WARN_PCT" ]; then
-        PROBLEMS="${PROBLEMS}Connection pool ${PCT}% saturated (${ACTIVE} active / ${POOL_LIMIT} limit)${POOL_LIMIT_NOTE:-}\n"
-      fi
+    BAD_IDX=""
+    HAVE_LONG_Q=false
+    HAVE_LONGEST=false
+    HAVE_ACTIVE=false
+    HAVE_POOL_LIMIT=false
+    HAVE_BAD_IDX=false
+    while IFS='=' read -r KEY VALUE; do
+      case "$KEY" in
+        LONG_Q) LONG_Q="$VALUE"; HAVE_LONG_Q=true ;;
+        LONGEST) LONGEST="$VALUE"; HAVE_LONGEST=true ;;
+        ACTIVE) ACTIVE="$VALUE"; HAVE_ACTIVE=true ;;
+        POOL_LIMIT) POOL_LIMIT="$VALUE"; HAVE_POOL_LIMIT=true ;;
+        BAD_INDEX) BAD_IDX="$VALUE"; HAVE_BAD_IDX=true ;;
+      esac
+    done <<< "$DB_OUTPUT"
+
+    if $HAVE_POOL_LIMIT && ! [[ "$POOL_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+      PROBLEMS="${PROBLEMS}DATABASE_URL has no valid connection_limit\n"
     fi
 
-    # 8. Invalid indexes. An interrupted CREATE INDEX CONCURRENTLY leaves an
-    # index that is unusable for reads but STILL maintained on every insert, and
-    # nothing else in the codebase reports it. If operations_entity_ids_gin were
-    # the invalid one, the conflict lookup's array branch would silently degrade
-    # to a sequential scan on every upload — worse than the outage this check
-    # exists to catch, and permanent until someone reindexes. indisready and
-    # indislive are the other two partial states the same interruption leaves.
-    BAD_IDX=$(pg_query "
-      SELECT string_agg(indexrelid::regclass::text, ', ')
-      FROM pg_index
-      WHERE (NOT indisvalid OR NOT indisready OR NOT indislive)
-        AND indrelid IN (SELECT oid FROM pg_class WHERE relnamespace = 'public'::regnamespace);")
-    if [ -n "${BAD_IDX:-}" ]; then
-      PROBLEMS="${PROBLEMS}Invalid/unusable index(es) present: ${BAD_IDX}\n"
+    DB_RESULTS_OK=true
+    if [ "$DB_STATUS" -ne 0 ] || ! $HAVE_LONG_Q || ! $HAVE_LONGEST ||
+      ! $HAVE_ACTIVE || ! $HAVE_POOL_LIMIT || ! $HAVE_BAD_IDX ||
+      ! [[ "$LONG_Q" =~ ^[0-9]+$ ]] ||
+      ! [[ "$LONGEST" =~ ^[0-9]*$ ]] ||
+      ! [[ "$ACTIVE" =~ ^[0-9]+$ ]]; then
+      DB_RESULTS_OK=false
+      PROBLEMS="${PROBLEMS}Database monitoring checks failed\n"
+    fi
+
+    if $DB_RESULTS_OK; then
+      if [ "$LONG_Q" -gt 0 ]; then
+        PROBLEMS="${PROBLEMS}${LONG_Q} query(s) active longer than ${MAX_QUERY_SECONDS}s (longest: ${LONGEST:-?}s)\n"
+      fi
+
+      if [[ "$POOL_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+        PCT=$(( ACTIVE * 100 / POOL_LIMIT ))
+        if [ "$PCT" -ge "$POOL_WARN_PCT" ]; then
+          PROBLEMS="${PROBLEMS}Connection pool ${PCT}% saturated (${ACTIVE} active / ${POOL_LIMIT} limit)\n"
+        fi
+      fi
+
+      if [ -n "$BAD_IDX" ]; then
+        PROBLEMS="${PROBLEMS}Invalid/unusable index(es) present: ${BAD_IDX}\n"
+      fi
     fi
   fi
 fi
@@ -229,19 +308,13 @@ if [ -n "$PROBLEMS" ]; then
       echo "$CURRENT_HASH" > "$ALERT_STATE_FILE"
       rm -f "$ALERT_STATE_DIR/mail-failed"
     else
-      # A failing alert path is indistinguishable from a healthy system: stderr
-      # from cron goes to the local mail spool, which is exactly what is broken
-      # when mail is broken. Leave a marker deploy.sh can surface instead. (#9191)
+      # Leave a marker deploy.sh can surface when cron cannot deliver mail.
       echo "ERROR: Failed to send alert email" >&2
       date -u +%Y-%m-%dT%H:%M:%SZ > "$ALERT_STATE_DIR/mail-failed"
     fi
   fi
 else
-  # All clear — send recovery notification, only delete state if mail succeeds.
-  # Also runs when only the mail-failed marker is present: a failed alert send
-  # leaves no state file, so without this the marker (and deploy.sh's warning)
-  # would survive every later healthy run and never clear. Retrying here doubles
-  # as the proof that delivery works again.
+  # A healthy retry also proves mail works again and clears a sticky failure marker.
   if [ -f "$ALERT_STATE_FILE" ] || [ -f "$ALERT_STATE_DIR/mail-failed" ]; then
     if printf 'SuperSync health check recovered at %s\n\nAll checks passing.\nServer: %s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname)" \
@@ -255,5 +328,5 @@ else
   fi
 fi
 
-# Record last successful run for monitoring verification
+# Record the last completed run for deploy-time monitoring verification.
 date -u +%Y-%m-%dT%H:%M:%SZ > "$ALERT_STATE_DIR/last-run"

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -14,7 +14,7 @@
 #   COMPOSE_DIR    - Path to docker-compose.yml directory (default: script directory's parent)
 #   HEALTH_URL     - Health endpoint URL (default: read from .env DOMAIN)
 #   MAX_QUERY_SECONDS  - Alert if any query has been active longer (default: 120)
-#   POOL_WARN_PCT      - Alert if active backends exceed this % of the pool (default: 75)
+#   POOL_WARN_PCT      - Alert if connections in use exceed this % of the pool (default: 75)
 #   POSTGRES_SERVICE   - Bundled database service to health-check
 #                        (default: postgres; empty: none)
 
@@ -159,10 +159,16 @@ const main = async () => {
     async (tx) => {
       await tx.$executeRawUnsafe('SET LOCAL statement_timeout = 10000');
       const [activity] = await tx.$queryRawUnsafe(
-        `WITH active AS (
-       SELECT now() - query_start AS age
+        `WITH pool_sessions AS (
+       SELECT CASE
+         WHEN state = 'active' THEN now() - query_start
+       END AS active_age
        FROM pg_stat_activity
-       WHERE state = 'active'
+       WHERE state IN (
+         'active',
+         'idle in transaction',
+         'idle in transaction (aborted)'
+       )
          AND pid <> pg_backend_pid()
          AND backend_type = 'client backend'
          AND datname = current_database()
@@ -171,11 +177,11 @@ const main = async () => {
      )
      SELECT
        count(*) FILTER (
-         WHERE age > $1::integer * interval '1 second'
+         WHERE active_age > $1::integer * interval '1 second'
        )::integer AS "longQueryCount",
-       COALESCE(round(extract(epoch FROM max(age))), 0)::integer AS "longest",
-       count(*)::integer AS "active"
-     FROM active`,
+       COALESCE(round(extract(epoch FROM max(active_age))), 0)::integer AS "longest",
+       count(*)::integer AS "poolInUse"
+     FROM pool_sessions`,
         maxQuerySeconds,
       );
 
@@ -195,6 +201,11 @@ const main = async () => {
        AND NOT EXISTS (
          SELECT 1
          FROM pg_stat_activity m
+         JOIN pg_locks l
+           ON l.pid = m.pid
+          AND l.locktype = 'relation'
+          AND l.relation = i.indexrelid
+          AND l.mode = 'ShareUpdateExclusiveLock'
          WHERE m.datname = current_database()
            AND m.usename = current_user
            AND m.state = 'active'
@@ -209,7 +220,7 @@ const main = async () => {
 
   console.log(`LONG_Q=${activity.longQueryCount}`);
   console.log(`LONGEST=${activity.longest}`);
-  console.log(`ACTIVE=${activity.active}`);
+  console.log(`POOL_IN_USE=${activity.poolInUse}`);
   console.log(`BAD_INDEX=${indexes.badIndex}`);
 };
 
@@ -233,19 +244,19 @@ NODE
 
     LONG_Q=""
     LONGEST=""
-    ACTIVE=""
+    POOL_IN_USE=""
     POOL_LIMIT=""
     BAD_IDX=""
     HAVE_LONG_Q=false
     HAVE_LONGEST=false
-    HAVE_ACTIVE=false
+    HAVE_POOL_IN_USE=false
     HAVE_POOL_LIMIT=false
     HAVE_BAD_IDX=false
     while IFS='=' read -r KEY VALUE; do
       case "$KEY" in
         LONG_Q) LONG_Q="$VALUE"; HAVE_LONG_Q=true ;;
         LONGEST) LONGEST="$VALUE"; HAVE_LONGEST=true ;;
-        ACTIVE) ACTIVE="$VALUE"; HAVE_ACTIVE=true ;;
+        POOL_IN_USE) POOL_IN_USE="$VALUE"; HAVE_POOL_IN_USE=true ;;
         POOL_LIMIT) POOL_LIMIT="$VALUE"; HAVE_POOL_LIMIT=true ;;
         BAD_INDEX) BAD_IDX="$VALUE"; HAVE_BAD_IDX=true ;;
       esac
@@ -257,10 +268,10 @@ NODE
 
     DB_RESULTS_OK=true
     if [ "$DB_STATUS" -ne 0 ] || ! $HAVE_LONG_Q || ! $HAVE_LONGEST ||
-      ! $HAVE_ACTIVE || ! $HAVE_POOL_LIMIT || ! $HAVE_BAD_IDX ||
+      ! $HAVE_POOL_IN_USE || ! $HAVE_POOL_LIMIT || ! $HAVE_BAD_IDX ||
       ! [[ "$LONG_Q" =~ ^[0-9]+$ ]] ||
       ! [[ "$LONGEST" =~ ^[0-9]+$ ]] ||
-      ! [[ "$ACTIVE" =~ ^[0-9]+$ ]]; then
+      ! [[ "$POOL_IN_USE" =~ ^[0-9]+$ ]]; then
       DB_RESULTS_OK=false
       PROBLEMS="${PROBLEMS}Database monitoring checks failed\n"
     fi
@@ -271,9 +282,9 @@ NODE
       fi
 
       if [[ "$POOL_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
-        PCT=$(( ACTIVE * 100 / POOL_LIMIT ))
+        PCT=$(( POOL_IN_USE * 100 / POOL_LIMIT ))
         if [ "$PCT" -ge "$POOL_WARN_PCT" ]; then
-          PROBLEMS="${PROBLEMS}Connection pool ${PCT}% saturated (${ACTIVE} active / ${POOL_LIMIT} limit)\n"
+          PROBLEMS="${PROBLEMS}Connection pool ${PCT}% saturated (${POOL_IN_USE} in use / ${POOL_LIMIT} limit)\n"
         fi
       fi
 
@@ -307,7 +318,7 @@ HASH_INPUT=$(printf '%s' "$PROBLEMS" | sed \
    s/at [0-9]*% on/at N% on/g
    s/HTTP [0-9]*/HTTP NNN/g
    s/[0-9]* query(s) active longer than [0-9]*s (longest: [0-9]*s)/N query(s) active longer than Ns (longest: Ns)/g
-   s/pool [0-9]*% saturated ([0-9]* active \/ [0-9]* limit)/pool N% saturated (N active \/ N limit)/g')
+   s/pool [0-9]*% saturated ([0-9]* in use \/ [0-9]* limit)/pool N% saturated (N in use \/ N limit)/g')
 CURRENT_HASH=$(printf '%s' "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
 PREVIOUS_HASH=$(cat "$ALERT_STATE_FILE" 2>/dev/null || echo "none")
 

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -215,7 +215,7 @@ HASH_INPUT=$(printf '%s' "$PROBLEMS" | sed \
    s/([0-9]* entries/(N entries/g
    s/at [0-9]*% on/at N% on/g
    s/HTTP [0-9]*/HTTP NNN/g
-   s/[0-9]* query(s) active longer than [0-9]*s (longest: [0-9]*s)/N query(s) active longer than Ns (longest: Ns)/g
+   s/[0-9]* query(s) active longer than [0-9]*s (longest: [0-9?]*s)/N query(s) active longer than Ns (longest: Ns)/g
    s/pool [0-9]*% saturated ([0-9]* active \/ [0-9]* limit)/pool N% saturated (N active \/ N limit)/g')
 CURRENT_HASH=$(printf '%s' "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
 PREVIOUS_HASH=$(cat "$ALERT_STATE_FILE" 2>/dev/null || echo "none")
@@ -237,14 +237,20 @@ if [ -n "$PROBLEMS" ]; then
     fi
   fi
 else
-  # All clear — send recovery notification, only delete state if mail succeeds
-  if [ -f "$ALERT_STATE_FILE" ]; then
+  # All clear — send recovery notification, only delete state if mail succeeds.
+  # Also runs when only the mail-failed marker is present: a failed alert send
+  # leaves no state file, so without this the marker (and deploy.sh's warning)
+  # would survive every later healthy run and never clear. Retrying here doubles
+  # as the proof that delivery works again.
+  if [ -f "$ALERT_STATE_FILE" ] || [ -f "$ALERT_STATE_DIR/mail-failed" ]; then
     if printf 'SuperSync health check recovered at %s\n\nAll checks passing.\nServer: %s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname)" \
         | timeout 30 mail -s "SuperSync OK: Health Check Recovered" "$ALERT_EMAIL" 2>/dev/null; then
       rm -f "$ALERT_STATE_FILE"
+      rm -f "$ALERT_STATE_DIR/mail-failed"
     else
       echo "ERROR: Failed to send recovery email" >&2
+      date -u +%Y-%m-%dT%H:%M:%SZ > "$ALERT_STATE_DIR/mail-failed"
     fi
   fi
 fi

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -30,8 +30,10 @@ POOL_WARN_PCT="${POOL_WARN_PCT:-75}"
 
 CONFIG_PROBLEMS=""
 DB_CONFIG_OK=true
-if ! [[ "$MAX_QUERY_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
-  CONFIG_PROBLEMS="${CONFIG_PROBLEMS}MAX_QUERY_SECONDS must be a positive integer\n"
+if ! [[ "$MAX_QUERY_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+  [ "${#MAX_QUERY_SECONDS}" -gt 10 ] ||
+  [ "$MAX_QUERY_SECONDS" -gt 2147483647 ]; then
+  CONFIG_PROBLEMS="${CONFIG_PROBLEMS}MAX_QUERY_SECONDS must be an integer from 1 to 2147483647\n"
   DB_CONFIG_OK=false
 fi
 if ! [[ "$POOL_WARN_PCT" =~ ^([1-9]|[1-9][0-9]|100)$ ]]; then
@@ -136,9 +138,11 @@ const maxQuerySeconds = Number(process.env.HEALTH_MAX_QUERY_SECONDS);
 
 const readPoolLimit = () => {
   try {
-    const value = new URL(process.env.DATABASE_URL ?? '').searchParams.get(
+    const values = new URL(process.env.DATABASE_URL ?? '').searchParams.getAll(
       'connection_limit',
     );
+    if (values.length !== 1) return '';
+    const [value] = values;
     const numericValue = Number(value);
     return value && /^\d+$/.test(value) && numericValue > 0 && Number.isSafeInteger(numericValue)
       ? String(numericValue)
@@ -163,7 +167,7 @@ const main = async () => {
          AND backend_type = 'client backend'
          AND datname = current_database()
          AND usename = current_user
-         AND application_name IS DISTINCT FROM 'supersync-migrator'
+         AND application_name NOT LIKE 'supersync-migrator-%'
      )
      SELECT
        count(*) FILTER (
@@ -181,12 +185,20 @@ const main = async () => {
        ''
      ) AS "badIndex"
      FROM pg_index i
-     WHERE i.indrelid = 'public.operations'::regclass
+     WHERE i.indrelid = 'operations'::regclass
        AND (NOT i.indisvalid OR NOT i.indisready OR NOT i.indislive)
        AND NOT EXISTS (
          SELECT 1
          FROM pg_stat_progress_create_index p
           WHERE p.index_relid = i.indexrelid
+       )
+       AND NOT EXISTS (
+         SELECT 1
+         FROM pg_stat_activity m
+         WHERE m.datname = current_database()
+           AND m.usename = current_user
+           AND m.state = 'active'
+           AND m.application_name LIKE 'supersync-migrator-%'
        )`,
       );
 
@@ -214,9 +226,9 @@ NODE
 )
 
     # Allow Prisma's 5s pool wait plus its 12s transaction bound to finish.
-    DB_OUTPUT=$(timeout 20 docker compose exec -T \
+    DB_OUTPUT=$(timeout -k 5 20 docker compose exec -T \
       -e "HEALTH_MAX_QUERY_SECONDS=$MAX_QUERY_SECONDS" \
-      supersync node -e "$DB_PROBE_JS" 2>/dev/null)
+      supersync timeout 18 node -e "$DB_PROBE_JS" 2>/dev/null)
     DB_STATUS=$?
 
     LONG_Q=""
@@ -247,7 +259,7 @@ NODE
     if [ "$DB_STATUS" -ne 0 ] || ! $HAVE_LONG_Q || ! $HAVE_LONGEST ||
       ! $HAVE_ACTIVE || ! $HAVE_POOL_LIMIT || ! $HAVE_BAD_IDX ||
       ! [[ "$LONG_Q" =~ ^[0-9]+$ ]] ||
-      ! [[ "$LONGEST" =~ ^[0-9]*$ ]] ||
+      ! [[ "$LONGEST" =~ ^[0-9]+$ ]] ||
       ! [[ "$ACTIVE" =~ ^[0-9]+$ ]]; then
       DB_RESULTS_OK=false
       PROBLEMS="${PROBLEMS}Database monitoring checks failed\n"
@@ -255,7 +267,7 @@ NODE
 
     if $DB_RESULTS_OK; then
       if [ "$LONG_Q" -gt 0 ]; then
-        PROBLEMS="${PROBLEMS}${LONG_Q} query(s) active longer than ${MAX_QUERY_SECONDS}s (longest: ${LONGEST:-?}s)\n"
+        PROBLEMS="${PROBLEMS}${LONG_Q} query(s) active longer than ${MAX_QUERY_SECONDS}s (longest: ${LONGEST}s)\n"
       fi
 
       if [[ "$POOL_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
@@ -294,13 +306,13 @@ HASH_INPUT=$(printf '%s' "$PROBLEMS" | sed \
    s/([0-9]* entries/(N entries/g
    s/at [0-9]*% on/at N% on/g
    s/HTTP [0-9]*/HTTP NNN/g
-   s/[0-9]* query(s) active longer than [0-9]*s (longest: [0-9?]*s)/N query(s) active longer than Ns (longest: Ns)/g
+   s/[0-9]* query(s) active longer than [0-9]*s (longest: [0-9]*s)/N query(s) active longer than Ns (longest: Ns)/g
    s/pool [0-9]*% saturated ([0-9]* active \/ [0-9]* limit)/pool N% saturated (N active \/ N limit)/g')
 CURRENT_HASH=$(printf '%s' "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
 PREVIOUS_HASH=$(cat "$ALERT_STATE_FILE" 2>/dev/null || echo "none")
 
 if [ -n "$PROBLEMS" ]; then
-  if [ "$CURRENT_HASH" != "$PREVIOUS_HASH" ]; then
+  if [ "$CURRENT_HASH" != "$PREVIOUS_HASH" ] || [ -f "$ALERT_STATE_DIR/mail-failed" ]; then
     # New or changed problem — send alert, only write state if mail succeeds
     if printf 'SuperSync health check failed at %s\n\nProblems found:\n%b\nServer: %s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROBLEMS" "$(hostname)" \

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -52,38 +52,73 @@ MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
 # can hang forever; without this the CMD/initContainer paths never fail.
 STEP_TIMEOUT="${MIGRATE_STEP_TIMEOUT:-1800}"
 
-# Exempt the migrator from the production statement_timeout guardrail (#9191).
-#
-# DATABASE_URL carries `options=-c statement_timeout=60000` so a degenerate query
-# plan cannot hold a pool connection indefinitely (the 2026-07-20 outage held one
-# for 75 minutes). That cap rides into the migrator, where it is not merely
-# unhelpful but a dead end: a CREATE INDEX CONCURRENTLY on a large `operations`
-# table runs well past 60s and gets cancelled mid-build, leaving an INVALID index
-# — and every recovery path below inherits the same URL, so `prisma db execute`
-# fails identically, as do the by-hand statements print_manual_recovery tells the
-# operator to run. Nothing in the loop can succeed.
-#
-# STEP_TIMEOUT is the correct bound for migrations instead: it kills the client,
-# and it is the signal the CONCURRENTLY recovery logic already understands.
-#
-# Four cases, in order: an existing statement_timeout is rewritten to 0; an
-# existing `options` value is extended (never duplicated as a second `options`
-# param, which Prisma would silently resolve to one of the two); otherwise the
-# param is appended with the right separator.
+# Helm cannot inspect a DATABASE_URL stored in an existing Kubernetes Secret.
+# Its init container opts into this runtime check before migrations or the app
+# can start. Literal chart values are also rejected during template rendering.
+if [ "${REQUIRE_DATABASE_POOL_LIMITS:-false}" = "true" ]; then
+  if ! node -e '
+    try {
+      const url = new URL(process.env.DATABASE_URL);
+      const valid = ["connection_limit", "pool_timeout"].every((name) =>
+        /^[1-9][0-9]*$/.test(url.searchParams.get(name) ?? ""),
+      );
+      process.exit(valid ? 0 : 1);
+    } catch {
+      process.exit(1);
+    }
+  '; then
+    echo "ERROR: DATABASE_URL must include positive connection_limit and pool_timeout values." >&2
+    exit 1
+  fi
+fi
+
+# DATABASE_URL may cap application statements. Migrations use STEP_TIMEOUT
+# instead: a shorter statement_timeout can cancel CREATE INDEX CONCURRENTLY and
+# leave an INVALID index that every automated recovery step inherits. Append our
+# settings to the real `options` query parameter so they override earlier `-c`
+# values without mistaking credentials or another URL component for an option.
+# The application_name lets health-alert.sh ignore expected long-running DDL.
+# Connection option format: https://www.postgresql.org/docs/16/libpq-connect.html
 if [ -n "${DATABASE_URL:-}" ]; then
+  MIGRATOR_OPTIONS="-c%20statement_timeout%3D0"
   case "$DATABASE_URL" in
-    *statement_timeout*)
+    *\?options=*|*\&options=*)
       DATABASE_URL=$(printf '%s' "$DATABASE_URL" |
-        sed -E 's/(statement_timeout(%3[Dd]|=))[0-9]+/\10/g')
+        sed -E "s/([?&]options=[^&]*)/\1%20${MIGRATOR_OPTIONS}/")
       ;;
-    *options=*)
+    *\?*) DATABASE_URL="${DATABASE_URL}&options=${MIGRATOR_OPTIONS}" ;;
+    *) DATABASE_URL="${DATABASE_URL}?options=${MIGRATOR_OPTIONS}" ;;
+  esac
+
+  # application_name is a first-class libpq connection parameter. Set that
+  # parameter directly: an existing value overrides a conflicting `options`
+  # setting regardless of their textual order in the URL.
+  case "$DATABASE_URL" in
+    *\?application_name=*|*\&application_name=*)
       DATABASE_URL=$(printf '%s' "$DATABASE_URL" |
-        sed -E 's/(options=[^&]*)/\1%20-c%20statement_timeout%3D0/')
+        sed -E 's/([?&]application_name=)[^&#]*/\1supersync-migrator/')
       ;;
-    *\?*) DATABASE_URL="${DATABASE_URL}&options=-c%20statement_timeout%3D0" ;;
-    *) DATABASE_URL="${DATABASE_URL}?options=-c%20statement_timeout%3D0" ;;
+    *) DATABASE_URL="${DATABASE_URL}&application_name=supersync-migrator" ;;
   esac
   export DATABASE_URL
+fi
+
+# Printed manual-recovery commands re-enter through this narrow wrapper so
+# they receive the same timeout exemption without printing database secrets.
+if [ "${1:-}" = "--prisma" ]; then
+  shift
+  [ "$#" -gt 0 ] || { echo "ERROR: --prisma requires Prisma arguments." >&2; exit 2; }
+  exec npx prisma "$@"
+fi
+
+PRISMA_RECOVERY_CMD="sh scripts/migrate-deploy.sh --prisma"
+if [ "${MIGRATE_RECOVERY_RUNTIME:-}" = "compose" ]; then
+  # Keep DATABASE_URL (and its credentials) inside Compose. The host command
+  # works even when the URL comes entirely from compose defaults.
+  PRISMA_RECOVERY_CMD="docker compose run --rm --no-deps -T supersync sh scripts/migrate-deploy.sh --prisma"
+  if [ "${MIGRATE_RECOVERY_BUILD_LOCAL:-false}" = "true" ]; then
+    PRISMA_RECOVERY_CMD="docker compose -f docker-compose.yml -f docker-compose.build.yml run --rm --no-deps -T supersync sh scripts/migrate-deploy.sh --prisma"
+  fi
 fi
 
 if command -v timeout >/dev/null 2>&1; then
@@ -224,13 +259,13 @@ print_manual_recovery() {
   sql="$2"
   echo ""
   echo "Manual recovery for $name (copy-paste):"
-  echo "  npx prisma migrate resolve --rolled-back $(shell_quote "$name")"
+  echo "  $PRISMA_RECOVERY_CMD migrate resolve --rolled-back $(shell_quote "$name")"
   split_statements "$sql" > "$STMT_FILE"
   while IFS= read -r stmt; do
     [ -n "$stmt" ] || continue
-    echo "  printf '%s\\n' $(shell_quote "$stmt") | npx prisma db execute --schema $SCHEMA --stdin"
+    echo "  printf '%s\\n' $(shell_quote "$stmt") | $PRISMA_RECOVERY_CMD db execute --schema $SCHEMA --stdin"
   done < "$STMT_FILE"
-  echo "  npx prisma migrate resolve --applied $(shell_quote "$name")   # only after every statement above succeeds"
+  echo "  $PRISMA_RECOVERY_CMD migrate resolve --applied $(shell_quote "$name")   # only after every statement above succeeds"
 }
 
 # Copy-paste recovery for an interrupted bare CREATE INDEX CONCURRENTLY. An
@@ -246,12 +281,12 @@ print_bare_create_recovery() {
   echo ""
   echo "Manual recovery for $name (interrupted bare CREATE INDEX CONCURRENTLY, copy-paste):"
   if [ -n "$idx" ]; then
-    echo "  printf '%s\\n' $(shell_quote "DROP INDEX CONCURRENTLY IF EXISTS \"$idx\";") | npx prisma db execute --schema $SCHEMA --stdin"
+    echo "  printf '%s\\n' $(shell_quote "DROP INDEX CONCURRENTLY IF EXISTS \"$idx\";") | $PRISMA_RECOVERY_CMD db execute --schema $SCHEMA --stdin"
   else
     echo "  # Drop any INVALID index left by the interrupted build (see $sql), e.g.:"
     echo "  #   DROP INDEX CONCURRENTLY IF EXISTS \"<index_name>\";"
   fi
-  echo "  npx prisma migrate resolve --rolled-back $(shell_quote "$name")"
+  echo "  $PRISMA_RECOVERY_CMD migrate resolve --rolled-back $(shell_quote "$name")"
   echo "  # Then re-run the deploy; $name re-applies natively."
 }
 

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -48,95 +48,170 @@ MIGRATIONS_DIR="prisma/migrations"
 # The real infinite-loop backstop is the LAST_RECOVERED guard below; this is
 # just a tight upper bound. Overridable for emergencies.
 MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
-# Per-step timeout. A CONCURRENTLY build blocked by a long-running transaction
-# can hang forever; without this the CMD/initContainer paths never fail.
+# Per-step client timeout. PostgreSQL also receives a per-statement timeout five
+# seconds shorter. If cumulative work still reaches the client deadline, the
+# wrapper terminates only the backend carrying this run's unique application id.
 STEP_TIMEOUT="${MIGRATE_STEP_TIMEOUT:-1800}"
+case "$STEP_TIMEOUT" in
+  ''|0*|*[!0-9]*)
+    echo "ERROR: MIGRATE_STEP_TIMEOUT must be an integer from 1 to 2147483 seconds." >&2
+    exit 2
+    ;;
+esac
+if [ "${#STEP_TIMEOUT}" -gt 7 ] || [ "$STEP_TIMEOUT" -gt 2147483 ]; then
+  echo "ERROR: MIGRATE_STEP_TIMEOUT must be an integer from 1 to 2147483 seconds." >&2
+  exit 2
+fi
+if [ "$STEP_TIMEOUT" -gt 5 ]; then
+  STATEMENT_TIMEOUT_SECONDS=$((STEP_TIMEOUT - 5))
+else
+  STATEMENT_TIMEOUT_SECONDS=1
+fi
+STATEMENT_TIMEOUT_MS=$((STATEMENT_TIMEOUT_SECONDS * 1000))
 
-# Helm cannot inspect a DATABASE_URL stored in an existing Kubernetes Secret.
-# Its init container opts into this runtime check before migrations or the app
-# can start. Literal chart values are also rejected during template rendering.
+# Helm cannot inspect a DATABASE_URL stored in an existing Kubernetes Secret,
+# so its migration init container requests the same check at runtime.
 if [ "${REQUIRE_DATABASE_POOL_LIMITS:-false}" = "true" ]; then
   if ! node -e '
     try {
       const url = new URL(process.env.DATABASE_URL);
-      const valid = ["connection_limit", "pool_timeout"].every((name) =>
-        /^[1-9][0-9]*$/.test(url.searchParams.get(name) ?? ""),
-      );
+      const valid = ["connection_limit", "pool_timeout"].every((name) => {
+        const values = url.searchParams.getAll(name);
+        const value = values[0];
+        return values.length === 1 && /^[1-9][0-9]*$/.test(value) &&
+          Number.isSafeInteger(Number(value));
+      });
       process.exit(valid ? 0 : 1);
     } catch {
       process.exit(1);
     }
   '; then
-    echo "ERROR: DATABASE_URL must include positive connection_limit and pool_timeout values." >&2
+    echo "ERROR: DATABASE_URL must include exactly one positive connection_limit and pool_timeout value each." >&2
     exit 1
   fi
 fi
 
-# DATABASE_URL may cap application statements. Migrations use STEP_TIMEOUT
-# instead: a shorter statement_timeout can cancel CREATE INDEX CONCURRENTLY and
-# leave an INVALID index that every automated recovery step inherits. Append our
-# settings to the real `options` query parameter so they override earlier `-c`
-# values without mistaking credentials or another URL component for an option.
-# The application_name lets health-alert.sh ignore expected long-running DDL.
+# DATABASE_URL may cap application statements. Migrations use a statement
+# timeout just below STEP_TIMEOUT instead: a shorter application cap can cancel
+# CREATE INDEX CONCURRENTLY and leave an INVALID index, while an unlimited cap
+# can leave PostgreSQL working after a killed client. Collapse protected query
+# parameters so a duplicate cannot override the final settings. The
+# application_name lets health-alert.sh ignore expected long-running DDL.
 # Connection option format: https://www.postgresql.org/docs/16/libpq-connect.html
 if [ -n "${DATABASE_URL:-}" ]; then
-  MIGRATOR_OPTIONS="-c%20statement_timeout%3D0"
-  case "$DATABASE_URL" in
-    *\?options=*|*\&options=*)
-      DATABASE_URL=$(printf '%s' "$DATABASE_URL" |
-        sed -E "s/([?&]options=[^&]*)/\1%20${MIGRATOR_OPTIONS}/")
-      ;;
-    *\?*) DATABASE_URL="${DATABASE_URL}&options=${MIGRATOR_OPTIONS}" ;;
-    *) DATABASE_URL="${DATABASE_URL}?options=${MIGRATOR_OPTIONS}" ;;
-  esac
+  if ! MIGRATOR_APPLICATION_NAME=$(node -e \
+    "process.stdout.write('supersync-migrator-' + require('node:crypto').randomUUID())"); then
+    echo "ERROR: could not generate a unique database migrator identifier." >&2
+    exit 1
+  fi
+  export MIGRATOR_APPLICATION_NAME
+  if ! MIGRATOR_DATABASE_URL=$(
+    MIGRATOR_SOURCE_DATABASE_URL="$DATABASE_URL" \
+      MIGRATOR_STATEMENT_TIMEOUT_MS="$STATEMENT_TIMEOUT_MS" \
+      MIGRATOR_APPLICATION_NAME="$MIGRATOR_APPLICATION_NAME" \
+      node <<'NODE'
+try {
+  const url = new URL(process.env.MIGRATOR_SOURCE_DATABASE_URL);
+  const options = url.searchParams.getAll('options').filter(Boolean);
+  options.push(
+    `-c statement_timeout=${process.env.MIGRATOR_STATEMENT_TIMEOUT_MS}`,
+  );
 
-  # application_name is a first-class libpq connection parameter. Set that
-  # parameter directly: an existing value overrides a conflicting `options`
-  # setting regardless of their textual order in the URL.
-  case "$DATABASE_URL" in
-    *\?application_name=*|*\&application_name=*)
-      DATABASE_URL=$(printf '%s' "$DATABASE_URL" |
-        sed -E 's/([?&]application_name=)[^&#]*/\1supersync-migrator/')
-      ;;
-    *) DATABASE_URL="${DATABASE_URL}&application_name=supersync-migrator" ;;
-  esac
+  url.searchParams.delete('options');
+  url.searchParams.append('options', options.join(' '));
+  url.searchParams.delete('application_name');
+  url.searchParams.append(
+    'application_name',
+    process.env.MIGRATOR_APPLICATION_NAME,
+  );
+  url.search = url.searchParams.toString().replace(/\+/g, '%20');
+  process.stdout.write(url.toString());
+} catch {
+  process.exit(1);
+}
+NODE
+  ); then
+    echo "ERROR: DATABASE_URL is not a valid PostgreSQL URL." >&2
+    exit 1
+  fi
+  DATABASE_URL="$MIGRATOR_DATABASE_URL"
   export DATABASE_URL
 fi
 
-# Printed manual-recovery commands re-enter through this narrow wrapper so
-# they receive the same timeout exemption without printing database secrets.
-if [ "${1:-}" = "--prisma" ]; then
-  shift
-  [ "$#" -gt 0 ] || { echo "ERROR: --prisma requires Prisma arguments." >&2; exit 2; }
-  exec npx prisma "$@"
-fi
-
-PRISMA_RECOVERY_CMD="sh scripts/migrate-deploy.sh --prisma"
+PRISMA_RECOVERY_CMD="MIGRATE_STEP_TIMEOUT=$STEP_TIMEOUT sh scripts/migrate-deploy.sh --prisma"
 if [ "${MIGRATE_RECOVERY_RUNTIME:-}" = "compose" ]; then
   # Keep DATABASE_URL (and its credentials) inside Compose. The host command
   # works even when the URL comes entirely from compose defaults.
-  PRISMA_RECOVERY_CMD="docker compose run --rm --no-deps -T supersync sh scripts/migrate-deploy.sh --prisma"
+  PRISMA_RECOVERY_CMD="docker compose run --rm --no-deps -T -e \"MIGRATE_STEP_TIMEOUT=$STEP_TIMEOUT\" supersync sh scripts/migrate-deploy.sh --prisma"
   if [ "${MIGRATE_RECOVERY_BUILD_LOCAL:-false}" = "true" ]; then
-    PRISMA_RECOVERY_CMD="docker compose -f docker-compose.yml -f docker-compose.build.yml run --rm --no-deps -T supersync sh scripts/migrate-deploy.sh --prisma"
+    PRISMA_RECOVERY_CMD="docker compose -f docker-compose.yml -f docker-compose.build.yml run --rm --no-deps -T -e \"MIGRATE_STEP_TIMEOUT=$STEP_TIMEOUT\" supersync sh scripts/migrate-deploy.sh --prisma"
   fi
 fi
 
-if command -v timeout >/dev/null 2>&1; then
-  with_timeout() {
-    wt_rc=0
-    timeout "$STEP_TIMEOUT" "$@" || wt_rc=$?
-    # GNU coreutils `timeout` exits 124 on expiry; BusyBox `timeout` (shipped by
-    # the node:*-alpine runtime image) instead lets the child die from the
-    # default SIGTERM and returns 128+15=143. Normalize so the single 124
-    # timeout branch is reached on both. Under this wrapper a 143 is timeout's
-    # own SIGTERM, not an unrelated external kill.
-    if [ "$wt_rc" -eq 143 ]; then
-      wt_rc=124
-    fi
-    return "$wt_rc"
-  }
-else
-  with_timeout() { "$@"; }
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "ERROR: timeout is required to bound database migration steps." >&2
+  exit 1
+fi
+
+terminate_migrator_backends() {
+  [ -n "${DATABASE_URL:-}" ] && [ -n "${MIGRATOR_APPLICATION_NAME:-}" ] || return 0
+
+  cleanup_status=0
+  MIGRATOR_TARGET_APPLICATION_NAME="$MIGRATOR_APPLICATION_NAME" \
+    timeout -k 2 10 node <<'NODE' || cleanup_status=$?
+const { PrismaClient } = require('@prisma/client');
+
+const target = process.env.MIGRATOR_TARGET_APPLICATION_NAME;
+const url = new URL(process.env.DATABASE_URL);
+url.searchParams.set('application_name', `${target}-cleanup`);
+const prisma = new PrismaClient({ datasources: { db: { url: url.toString() } } });
+
+prisma
+  .$queryRawUnsafe(
+    `SELECT pg_terminate_backend(pid)
+       FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND usename = current_user
+        AND application_name = $1
+        AND pid <> pg_backend_pid()`,
+    target,
+  )
+  .catch(() => {
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());
+NODE
+  if [ "$cleanup_status" -ne 0 ]; then
+    echo "WARNING: could not terminate the interrupted migrator database session." >&2
+  fi
+  return 0
+}
+
+with_timeout() {
+  wt_rc=0
+  timeout -k 5 "$STEP_TIMEOUT" "$@" || wt_rc=$?
+  case "$wt_rc" in
+    124|137|143) terminate_migrator_backends ;;
+  esac
+  # GNU coreutils `timeout` exits 124 on expiry; BusyBox `timeout` (shipped by
+  # the node:*-alpine runtime image) instead lets the child die from the
+  # default SIGTERM and returns 128+15=143. Normalize so the single 124 timeout
+  # branch is reached on both. Under this wrapper a 143 is timeout's own
+  # SIGTERM, not an unrelated external kill.
+  if [ "$wt_rc" -eq 143 ]; then
+    wt_rc=124
+  fi
+  return "$wt_rc"
+}
+
+# Printed manual-recovery commands re-enter through this narrow wrapper so
+# they receive the same finite bounds without printing database secrets.
+if [ "${1:-}" = "--prisma" ]; then
+  shift
+  [ "$#" -gt 0 ] || { echo "ERROR: --prisma requires Prisma arguments." >&2; exit 2; }
+  prisma_status=0
+  with_timeout npx prisma "$@" || prisma_status=$?
+  exit "$prisma_status"
 fi
 
 MIGRATE_LOG=""

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -52,6 +52,40 @@ MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
 # can hang forever; without this the CMD/initContainer paths never fail.
 STEP_TIMEOUT="${MIGRATE_STEP_TIMEOUT:-1800}"
 
+# Exempt the migrator from the production statement_timeout guardrail (#9191).
+#
+# DATABASE_URL carries `options=-c statement_timeout=60000` so a degenerate query
+# plan cannot hold a pool connection indefinitely (the 2026-07-20 outage held one
+# for 75 minutes). That cap rides into the migrator, where it is not merely
+# unhelpful but a dead end: a CREATE INDEX CONCURRENTLY on a large `operations`
+# table runs well past 60s and gets cancelled mid-build, leaving an INVALID index
+# — and every recovery path below inherits the same URL, so `prisma db execute`
+# fails identically, as do the by-hand statements print_manual_recovery tells the
+# operator to run. Nothing in the loop can succeed.
+#
+# STEP_TIMEOUT is the correct bound for migrations instead: it kills the client,
+# and it is the signal the CONCURRENTLY recovery logic already understands.
+#
+# Four cases, in order: an existing statement_timeout is rewritten to 0; an
+# existing `options` value is extended (never duplicated as a second `options`
+# param, which Prisma would silently resolve to one of the two); otherwise the
+# param is appended with the right separator.
+if [ -n "${DATABASE_URL:-}" ]; then
+  case "$DATABASE_URL" in
+    *statement_timeout*)
+      DATABASE_URL=$(printf '%s' "$DATABASE_URL" |
+        sed -E 's/(statement_timeout(%3[Dd]|=))[0-9]+/\10/g')
+      ;;
+    *options=*)
+      DATABASE_URL=$(printf '%s' "$DATABASE_URL" |
+        sed -E 's/(options=[^&]*)/\1%20-c%20statement_timeout%3D0/')
+      ;;
+    *\?*) DATABASE_URL="${DATABASE_URL}&options=-c%20statement_timeout%3D0" ;;
+    *) DATABASE_URL="${DATABASE_URL}?options=-c%20statement_timeout%3D0" ;;
+  esac
+  export DATABASE_URL
+fi
+
 if command -v timeout >/dev/null 2>&1; then
   with_timeout() {
     wt_rc=0

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import {
   chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -14,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(currentDir, '../scripts/health-alert.sh');
+const DEPLOY_SCRIPT = join(currentDir, '../scripts/deploy.sh');
 
 const FAKE_DOCKER = `#!/bin/sh
 set -u
@@ -49,7 +51,7 @@ if [ "\${1:-}" = "exec" ]; then
     exit 0
   fi
   printf 'LONG_Q=%s\n' "\${FAKE_LONG_Q:-0}"
-  printf 'LONGEST=%s\n' "\${FAKE_LONGEST-}"
+  printf 'LONGEST=%s\n' "\${FAKE_LONGEST-0}"
   printf 'ACTIVE=%s\n' "\${FAKE_ACTIVE:-0}"
   printf 'POOL_LIMIT=%s\n' "\${FAKE_POOL_LIMIT-60}"
   printf 'BAD_INDEX=%s\n' "\${FAKE_BAD_INDEX-}"
@@ -129,6 +131,28 @@ const run = (env: Record<string, string> = {}): RunResult => {
   };
 };
 
+const runDeployMonitoringStatus = (): string => {
+  const deployScript = readFileSync(DEPLOY_SCRIPT, 'utf8');
+  const match = deployScript.match(/report_monitoring_status\(\) \{[\s\S]*?\n\}/);
+  expect(match).not.toBeNull();
+
+  const runner = join(projectDir, 'report-monitoring-status.sh');
+  writeFileSync(runner, `${match?.[0] ?? ''}\nreport_monitoring_status\n`);
+  writeExecutable('crontab', '#!/bin/sh\nexit 1\n');
+
+  const result = spawnSync('bash', [runner], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+      SERVER_DIR: projectDir,
+    },
+  });
+
+  expect(result.status).toBe(0);
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+};
+
 beforeEach(() => {
   projectDir = mkdtempSync(join(tmpdir(), 'sup-health-project-'));
   binDir = mkdtempSync(join(tmpdir(), 'sup-health-bin-'));
@@ -148,16 +172,25 @@ afterEach(() => {
 });
 
 describe('health-alert.sh configuration', () => {
-  it.each(['0', '-1', '1.5', 'abc'])(
+  it.each(['0', '-1', '1.5', 'abc', '2147483648', '99999999999999999999'])(
     'alerts without probing the database for invalid MAX_QUERY_SECONDS=%s',
     (value) => {
       const result = run({ MAX_QUERY_SECONDS: value });
 
-      expect(result.mailLog).toContain('MAX_QUERY_SECONDS must be a positive integer');
+      expect(result.mailLog).toContain(
+        'MAX_QUERY_SECONDS must be an integer from 1 to 2147483647',
+      );
       expect(result.dockerLog).not.toContain(' psql ');
       expect(result.dockerLog).not.toContain(' node -e ');
     },
   );
+
+  it('accepts the PostgreSQL integer upper bound for MAX_QUERY_SECONDS', () => {
+    const result = run({ MAX_QUERY_SECONDS: '2147483647' });
+
+    expect(result.output).not.toContain('MAX_QUERY_SECONDS must be');
+    expect(result.dockerLog).toContain(' node -e ');
+  });
 
   it.each(['0', '101', '75.5', 'abc'])(
     'alerts without probing the database for invalid POOL_WARN_PCT=%s',
@@ -210,10 +243,13 @@ describe('health-alert.sh service and database monitoring', () => {
 
   it('runs probes with Prisma inside the supersync container', () => {
     const result = run({ POSTGRES_SERVICE: '' });
+    const script = readFileSync(SCRIPT, 'utf8');
 
     expect(result.dockerLog).toContain('compose exec -T');
-    expect(result.dockerLog).toContain('supersync node -e');
+    expect(result.dockerLog).toContain('supersync timeout 18 node -e');
+    expect(script).toMatch(/DB_OUTPUT=\$\(timeout -k 5 20 docker compose exec/);
     expect(result.dockerLog).toContain("require('@prisma/client')");
+    expect(result.dockerLog).toContain('searchParams.getAll(');
     expect(result.dockerLog).not.toContain(' psql ');
   });
 
@@ -260,20 +296,22 @@ describe('health-alert.sh service and database monitoring', () => {
     );
   });
 
-  it('scopes SQL away from migrators and in-progress or non-operations indexes', () => {
+  it('scopes SQL away from migrators and transient or non-operations indexes', () => {
     const result = run();
 
     expect(result.status).toBe(0);
     expect(result.dockerLog).toContain('SET LOCAL statement_timeout');
     expect(result.dockerLog).toContain('timeout: 12000');
     expect(result.dockerLog).toContain(
-      "application_name IS DISTINCT FROM 'supersync-migrator'",
+      "application_name NOT LIKE 'supersync-migrator-%'",
     );
     expect(result.dockerLog).toContain('datname = current_database()');
     expect(result.dockerLog).toContain('usename = current_user');
     expect(result.dockerLog).toContain('pg_stat_progress_create_index');
-    expect(result.dockerLog).toContain("'public.operations'::regclass");
+    expect(result.dockerLog).toContain("'operations'::regclass");
+    expect(result.dockerLog).not.toContain("'public.operations'::regclass");
     expect(result.dockerLog).toContain('p.index_relid = i.indexrelid');
+    expect(result.dockerLog).toContain("application_name LIKE 'supersync-migrator-%'");
   });
 
   it('reports invalid operations indexes returned by the probe', () => {
@@ -283,15 +321,21 @@ describe('health-alert.sh service and database monitoring', () => {
       'Invalid/unusable index(es) present: operations_entity_ids_gin',
     );
   });
+
+  it('treats an empty longest-query duration as malformed probe output', () => {
+    const result = run({ FAKE_LONGEST: '' });
+
+    expect(result.mailLog).toContain('Database monitoring checks failed');
+  });
 });
 
 describe('health-alert.sh state handling', () => {
-  it('deduplicates volatile long-query alerts when the longest duration is unknown', () => {
-    run({ FAKE_LONG_Q: '1', FAKE_LONGEST: '' });
-    const second = run({ FAKE_LONG_Q: '27', FAKE_LONGEST: '' });
+  it('deduplicates volatile long-query counts and durations', () => {
+    run({ FAKE_LONG_Q: '1', FAKE_LONGEST: '130' });
+    const second = run({ FAKE_LONG_Q: '27', FAKE_LONGEST: '240' });
 
     expect(second.mailLog.match(/SuperSync health check failed/g)).toHaveLength(1);
-    expect(second.mailLog).toContain('longest: ?s');
+    expect(second.mailLog).toContain('longest: 130s');
   });
 
   it('sends recovery after mail failure and clears the sticky marker', () => {
@@ -306,5 +350,37 @@ describe('health-alert.sh state handling', () => {
     const recovered = run();
     expect(recovered.mailLog).toContain('All checks passing.');
     expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(false);
+  });
+
+  it('retries failed delivery when an earlier problem remains active', () => {
+    run({ FAKE_BAD_INDEX: 'index-a' });
+    run({
+      FAKE_BAD_INDEX: 'index-a',
+      FAKE_LONG_Q: '1',
+      FAKE_LONGEST: '130',
+      FAKE_MAIL_EXIT: '1',
+    });
+    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(true);
+
+    const retried = run({ FAKE_BAD_INDEX: 'index-a' });
+    expect(retried.mailLog.match(/SuperSync health check failed/g)).toHaveLength(3);
+    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(false);
+
+    const deduplicated = run({ FAKE_BAD_INDEX: 'index-a' });
+    expect(deduplicated.mailLog.match(/SuperSync health check failed/g)).toHaveLength(3);
+  });
+
+  it('reports heartbeat and mail failure even without a current-user cron entry', () => {
+    const stateDir = join(projectDir, '.health-alert');
+    mkdirSync(stateDir);
+    writeFileSync(join(stateDir, 'last-run'), new Date().toISOString());
+    writeFileSync(join(stateDir, 'mail-failed'), '2026-07-20T12:00:00Z\n');
+
+    const output = runDeployMonitoringStatus();
+
+    expect(output).toContain("not in this user's crontab");
+    expect(output).toContain('recent completed run');
+    expect(output).toContain('alert email delivery FAILED');
+    expect(output).not.toContain('will go unnoticed');
   });
 });

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -52,7 +52,7 @@ if [ "\${1:-}" = "exec" ]; then
   fi
   printf 'LONG_Q=%s\n' "\${FAKE_LONG_Q:-0}"
   printf 'LONGEST=%s\n' "\${FAKE_LONGEST-0}"
-  printf 'ACTIVE=%s\n' "\${FAKE_ACTIVE:-0}"
+  printf 'POOL_IN_USE=%s\n' "\${FAKE_POOL_IN_USE:-0}"
   printf 'POOL_LIMIT=%s\n' "\${FAKE_POOL_LIMIT-60}"
   printf 'BAD_INDEX=%s\n' "\${FAKE_BAD_INDEX-}"
   exit 0
@@ -275,7 +275,7 @@ describe('health-alert.sh service and database monitoring', () => {
   it.each(['', 'not-a-number', '0'])(
     'alerts when the running DATABASE_URL connection_limit is %j',
     (poolLimit) => {
-      const result = run({ FAKE_ACTIVE: '120', FAKE_POOL_LIMIT: poolLimit });
+      const result = run({ FAKE_POOL_IN_USE: '120', FAKE_POOL_LIMIT: poolLimit });
 
       expect(result.mailLog).toContain('DATABASE_URL has no valid connection_limit');
       expect(result.mailLog).not.toContain('Connection pool');
@@ -284,15 +284,15 @@ describe('health-alert.sh service and database monitoring', () => {
     },
   );
 
-  it('alerts when active connections reach the configured pool percentage', () => {
+  it('alerts when connections in use reach the configured pool percentage', () => {
     const result = run({
-      FAKE_ACTIVE: '45',
+      FAKE_POOL_IN_USE: '45',
       FAKE_POOL_LIMIT: '60',
       POOL_WARN_PCT: '75',
     });
 
     expect(result.mailLog).toContain(
-      'Connection pool 75% saturated (45 active / 60 limit)',
+      'Connection pool 75% saturated (45 in use / 60 limit)',
     );
   });
 
@@ -308,9 +308,12 @@ describe('health-alert.sh service and database monitoring', () => {
     expect(result.dockerLog).toContain('datname = current_database()');
     expect(result.dockerLog).toContain('usename = current_user');
     expect(result.dockerLog).toContain('pg_stat_progress_create_index');
+    expect(result.dockerLog).toContain('JOIN pg_locks l');
     expect(result.dockerLog).toContain("'operations'::regclass");
     expect(result.dockerLog).not.toContain("'public.operations'::regclass");
     expect(result.dockerLog).toContain('p.index_relid = i.indexrelid');
+    expect(result.dockerLog).toContain('l.relation = i.indexrelid');
+    expect(result.dockerLog).toContain("l.mode = 'ShareUpdateExclusiveLock'");
     expect(result.dockerLog).toContain("application_name LIKE 'supersync-migrator-%'");
   });
 

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -1,0 +1,310 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(currentDir, '../scripts/health-alert.sh');
+
+const FAKE_DOCKER = `#!/bin/sh
+set -u
+printf '%s\n' "$*" >> "$FAKE_STATE/docker.log"
+
+if [ "\${1:-}" = "info" ]; then
+  exit "\${FAKE_DOCKER_INFO_EXIT:-0}"
+fi
+
+if [ "\${1:-}" = "inspect" ]; then
+  printf '0\n'
+  exit 0
+fi
+
+if [ "\${1:-}" != "compose" ]; then
+  exit 99
+fi
+shift
+
+if [ "\${1:-}" = "ps" ]; then
+  case "$*" in
+    *"{{.State}}"*) printf 'running\n' ;;
+    *"{{.Health}}"*) printf 'healthy\n' ;;
+    *" -q "*|"ps -q "*) printf 'id-%s\n' "\${3:-\${2:-unknown}}" ;;
+  esac
+  exit 0
+fi
+
+if [ "\${1:-}" = "exec" ]; then
+  [ "\${FAKE_DB_EXIT:-0}" = "0" ] || exit "$FAKE_DB_EXIT"
+  if [ "\${FAKE_DB_MALFORMED:-0}" = "1" ]; then
+    printf 'not monitor data\n'
+    exit 0
+  fi
+  printf 'LONG_Q=%s\n' "\${FAKE_LONG_Q:-0}"
+  printf 'LONGEST=%s\n' "\${FAKE_LONGEST-}"
+  printf 'ACTIVE=%s\n' "\${FAKE_ACTIVE:-0}"
+  printf 'POOL_LIMIT=%s\n' "\${FAKE_POOL_LIMIT-60}"
+  printf 'BAD_INDEX=%s\n' "\${FAKE_BAD_INDEX-}"
+  exit 0
+fi
+
+exit 99
+`;
+
+const FAKE_CURL = `#!/bin/sh
+printf '%s' "\${FAKE_HTTP_CODE:-200}"
+`;
+
+const FAKE_DF = `#!/bin/sh
+printf 'Use%%\n%s%%\n' "\${FAKE_DISK_PCT:-10}"
+`;
+
+const FAKE_MAIL = `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_STATE/mail.args"
+printf '%s\n' '---MAIL---' >> "$FAKE_STATE/mail.log"
+cat >> "$FAKE_STATE/mail.log"
+exit "\${FAKE_MAIL_EXIT:-0}"
+`;
+
+interface RunResult {
+  status: number;
+  output: string;
+  dockerLog: string;
+  mailLog: string;
+}
+
+let projectDir: string;
+let binDir: string;
+
+const readStateFile = (name: string): string => {
+  try {
+    return readFileSync(join(projectDir, '.health-alert', name), 'utf8');
+  } catch {
+    return '';
+  }
+};
+
+const writeExecutable = (name: string, contents: string): void => {
+  const path = join(binDir, name);
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+};
+
+const run = (env: Record<string, string> = {}): RunResult => {
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    COMPOSE_DIR: projectDir,
+    HEALTH_URL: 'https://health.test/health',
+    ALERT_EMAIL: 'ops@example.test',
+    FAKE_STATE: join(projectDir, '.health-alert'),
+    ...env,
+  };
+
+  for (const name of ['POSTGRES_SERVICE', 'MAX_QUERY_SECONDS', 'POOL_WARN_PCT']) {
+    if (!(name in env)) {
+      delete childEnv[name];
+    }
+  }
+
+  const result = spawnSync('bash', [SCRIPT], {
+    encoding: 'utf8',
+    env: childEnv,
+    timeout: 10_000,
+  });
+
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+    dockerLog: readStateFile('docker.log'),
+    mailLog: readStateFile('mail.log'),
+  };
+};
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'sup-health-project-'));
+  binDir = mkdtempSync(join(tmpdir(), 'sup-health-bin-'));
+  writeFileSync(join(projectDir, 'docker-compose.yml'), 'services: {}\n');
+  writeFileSync(join(projectDir, '.env'), 'DOMAIN=sync.example.test\n');
+  writeExecutable('docker', FAKE_DOCKER);
+  writeExecutable('curl', FAKE_CURL);
+  writeExecutable('df', FAKE_DF);
+  writeExecutable('mail', FAKE_MAIL);
+  writeExecutable('journalctl', '#!/bin/sh\nexit 0\n');
+  writeExecutable('mountpoint', '#!/bin/sh\nexit 1\n');
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  rmSync(binDir, { recursive: true, force: true });
+});
+
+describe('health-alert.sh configuration', () => {
+  it.each(['0', '-1', '1.5', 'abc'])(
+    'alerts without probing the database for invalid MAX_QUERY_SECONDS=%s',
+    (value) => {
+      const result = run({ MAX_QUERY_SECONDS: value });
+
+      expect(result.mailLog).toContain('MAX_QUERY_SECONDS must be a positive integer');
+      expect(result.dockerLog).not.toContain(' psql ');
+      expect(result.dockerLog).not.toContain(' node -e ');
+    },
+  );
+
+  it.each(['0', '101', '75.5', 'abc'])(
+    'alerts without probing the database for invalid POOL_WARN_PCT=%s',
+    (value) => {
+      const result = run({ POOL_WARN_PCT: value });
+
+      expect(result.mailLog).toContain('POOL_WARN_PCT must be an integer from 1 to 100');
+      expect(result.dockerLog).not.toContain(' psql ');
+      expect(result.dockerLog).not.toContain(' node -e ');
+    },
+  );
+});
+
+describe('health-alert.sh service and database monitoring', () => {
+  it('keeps the embedded Node probe syntactically valid', () => {
+    const script = readFileSync(SCRIPT, 'utf8');
+    const match = script.match(/DB_PROBE_JS=\$\(cat <<'NODE'\n([\s\S]*?)\nNODE\n\)/);
+
+    expect(match).not.toBeNull();
+    const result = spawnSync(process.execPath, ['--check', '-'], {
+      input: match?.[1] ?? '',
+      encoding: 'utf8',
+    });
+    expect(`${result.stdout}${result.stderr}`).toBe('');
+    expect(result.status).toBe(0);
+  });
+
+  it('checks the bundled postgres service by default', () => {
+    const result = run();
+
+    expect(result.dockerLog).toContain('compose ps --format {{.State}} postgres');
+  });
+
+  it('honors an explicitly empty POSTGRES_SERVICE for an external database', () => {
+    const result = run({ POSTGRES_SERVICE: '' });
+
+    expect(result.dockerLog).not.toContain('compose ps --format {{.State}} postgres');
+  });
+
+  it('honors POSTGRES_SERVICE= from .env', () => {
+    writeFileSync(
+      join(projectDir, '.env'),
+      'DOMAIN=sync.example.test\nPOSTGRES_SERVICE=\n',
+    );
+
+    const result = run();
+
+    expect(result.dockerLog).not.toContain('compose ps --format {{.State}} postgres');
+  });
+
+  it('runs probes with Prisma inside the supersync container', () => {
+    const result = run({ POSTGRES_SERVICE: '' });
+
+    expect(result.dockerLog).toContain('compose exec -T');
+    expect(result.dockerLog).toContain('supersync node -e');
+    expect(result.dockerLog).toContain("require('@prisma/client')");
+    expect(result.dockerLog).not.toContain(' psql ');
+  });
+
+  it('alerts once when the database probe fails and still runs checks 4 and 5', () => {
+    const result = run({
+      FAKE_DB_EXIT: '1',
+      FAKE_HTTP_CODE: '503',
+      FAKE_DISK_PCT: '90',
+    });
+
+    expect(result.mailLog).toContain('Database monitoring checks failed');
+    expect(result.mailLog.match(/Database monitoring checks failed/g)).toHaveLength(1);
+    expect(result.mailLog).toContain('Health endpoint returned HTTP 503');
+    expect(result.mailLog).toContain('Disk usage at 90% on /');
+  });
+
+  it('treats malformed probe output as a database monitoring failure', () => {
+    const result = run({ FAKE_DB_MALFORMED: '1' });
+
+    expect(result.mailLog).toContain('Database monitoring checks failed');
+  });
+
+  it.each(['', 'not-a-number', '0'])(
+    'alerts when the running DATABASE_URL connection_limit is %j',
+    (poolLimit) => {
+      const result = run({ FAKE_ACTIVE: '120', FAKE_POOL_LIMIT: poolLimit });
+
+      expect(result.mailLog).toContain('DATABASE_URL has no valid connection_limit');
+      expect(result.mailLog).not.toContain('Connection pool');
+      expect(result.mailLog).not.toContain('measured against max_connections');
+      expect(result.dockerLog).not.toContain('max_connections');
+    },
+  );
+
+  it('alerts when active connections reach the configured pool percentage', () => {
+    const result = run({
+      FAKE_ACTIVE: '45',
+      FAKE_POOL_LIMIT: '60',
+      POOL_WARN_PCT: '75',
+    });
+
+    expect(result.mailLog).toContain(
+      'Connection pool 75% saturated (45 active / 60 limit)',
+    );
+  });
+
+  it('scopes SQL away from migrators and in-progress or non-operations indexes', () => {
+    const result = run();
+
+    expect(result.status).toBe(0);
+    expect(result.dockerLog).toContain('SET LOCAL statement_timeout');
+    expect(result.dockerLog).toContain('timeout: 12000');
+    expect(result.dockerLog).toContain(
+      "application_name IS DISTINCT FROM 'supersync-migrator'",
+    );
+    expect(result.dockerLog).toContain('datname = current_database()');
+    expect(result.dockerLog).toContain('usename = current_user');
+    expect(result.dockerLog).toContain('pg_stat_progress_create_index');
+    expect(result.dockerLog).toContain("'public.operations'::regclass");
+    expect(result.dockerLog).toContain('p.index_relid = i.indexrelid');
+  });
+
+  it('reports invalid operations indexes returned by the probe', () => {
+    const result = run({ FAKE_BAD_INDEX: 'operations_entity_ids_gin' });
+
+    expect(result.mailLog).toContain(
+      'Invalid/unusable index(es) present: operations_entity_ids_gin',
+    );
+  });
+});
+
+describe('health-alert.sh state handling', () => {
+  it('deduplicates volatile long-query alerts when the longest duration is unknown', () => {
+    run({ FAKE_LONG_Q: '1', FAKE_LONGEST: '' });
+    const second = run({ FAKE_LONG_Q: '27', FAKE_LONGEST: '' });
+
+    expect(second.mailLog.match(/SuperSync health check failed/g)).toHaveLength(1);
+    expect(second.mailLog).toContain('longest: ?s');
+  });
+
+  it('sends recovery after mail failure and clears the sticky marker', () => {
+    const failed = run({
+      FAKE_LONG_Q: '1',
+      FAKE_LONGEST: '130',
+      FAKE_MAIL_EXIT: '1',
+    });
+    expect(failed.output).toContain('Failed to send alert email');
+    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(true);
+
+    const recovered = run();
+    expect(recovered.mailLog).toContain('All checks passing.');
+    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(false);
+  });
+});

--- a/packages/super-sync-server/tests/integration/health-alert-db-probe.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/health-alert-db-probe.integration.spec.ts
@@ -22,7 +22,7 @@ const embeddedProbe = (): string => {
   return match?.[1] ?? '';
 };
 
-const runProbe = (databaseUrl: string) =>
+const runProbe = (databaseUrl: string, maxQuerySeconds = 120) =>
   spawnSync(process.execPath, ['-e', embeddedProbe()], {
     cwd: packageDir,
     encoding: 'utf8',
@@ -30,9 +30,57 @@ const runProbe = (databaseUrl: string) =>
     env: {
       ...process.env,
       DATABASE_URL: databaseUrl,
-      HEALTH_MAX_QUERY_SECONDS: '120',
+      HEALTH_MAX_QUERY_SECONDS: String(maxQuerySeconds),
     },
   });
+
+const readNumericMetric = (stdout: string, name: string): number => {
+  const match = stdout.match(new RegExp(`^${name}=(\\d+)$`, 'm'));
+  if (!match) throw new Error(`Missing ${name} in probe output:\n${stdout}`);
+  return Number(match[1]);
+};
+
+const waitForBackend = async (
+  prisma: PrismaClient,
+  applicationName: string,
+  expectedState: string,
+): Promise<number> => {
+  const deadline = Date.now() + 5_000;
+
+  while (Date.now() < deadline) {
+    const rows = await prisma.$queryRawUnsafe<Array<{ pid: number; state: string }>>(
+      `SELECT pid, state
+       FROM pg_stat_activity
+       WHERE application_name = $1`,
+      applicationName,
+    );
+    const backend = rows.find(({ state }) => state === expectedState);
+    if (backend) return backend.pid;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`Timed out waiting for ${applicationName} to become ${expectedState}`);
+};
+
+const waitForInvalidIndex = async (
+  prisma: PrismaClient,
+  qualifiedIndexName: string,
+): Promise<void> => {
+  const deadline = Date.now() + 5_000;
+
+  while (Date.now() < deadline) {
+    const rows = await prisma.$queryRawUnsafe<Array<{ invalid: boolean }>>(
+      `SELECT NOT indisvalid AS invalid
+       FROM pg_index
+       WHERE indexrelid = to_regclass($1)`,
+      qualifiedIndexName,
+    );
+    if (rows.some(({ invalid }) => invalid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`Timed out waiting for ${qualifiedIndexName} to become invalid`);
+};
 
 describeWithDb('health-alert.sh PostgreSQL probe', () => {
   it('executes through Prisma and returns the complete monitor result', () => {
@@ -46,17 +94,26 @@ describeWithDb('health-alert.sh PostgreSQL probe', () => {
     expect(result.stdout).toMatch(/^POOL_LIMIT=4$/m);
     expect(result.stdout).toMatch(/^LONG_Q=\d+$/m);
     expect(result.stdout).toMatch(/^LONGEST=\d+$/m);
-    expect(result.stdout).toMatch(/^ACTIVE=\d+$/m);
+    expect(result.stdout).toMatch(/^POOL_IN_USE=\d+$/m);
     expect(result.stdout).toMatch(/^BAD_INDEX=.*$/m);
   });
 
-  it('checks the operations table selected by the Prisma schema parameter', async () => {
+  it('reports a schema-scoped invalid index during an unrelated migration', async () => {
     const suffix = `${process.pid}_${Date.now()}`;
     const schema = `health_probe_${suffix}`;
     const index = `health_probe_invalid_${suffix}`;
+    const applicationName = `supersync-migrator-test-${suffix}`;
+    const migratorUrl = new URL(DATABASE_URL as string);
+    migratorUrl.searchParams.set('application_name', applicationName);
+    migratorUrl.searchParams.set('connection_limit', '1');
     const admin = new PrismaClient({
       datasources: { db: { url: DATABASE_URL as string } },
     });
+    const migrator = new PrismaClient({
+      datasources: { db: { url: migratorUrl.toString() } },
+    });
+    let migratorPid: number | undefined;
+    let sleepQuery: Promise<unknown> | undefined;
 
     try {
       await admin.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`);
@@ -72,6 +129,9 @@ describeWithDb('health-alert.sh PostgreSQL probe', () => {
         ),
       ).rejects.toThrow();
 
+      sleepQuery = migrator.$queryRawUnsafe('SELECT pg_sleep(30)').catch(() => undefined);
+      migratorPid = await waitForBackend(admin, applicationName, 'active');
+
       const url = new URL(DATABASE_URL as string);
       url.searchParams.set('schema', schema);
       url.searchParams.set('connection_limit', '4');
@@ -82,8 +142,173 @@ describeWithDb('health-alert.sh PostgreSQL probe', () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toMatch(new RegExp(`^BAD_INDEX=.*${index}.*$`, 'm'));
     } finally {
+      if (migratorPid !== undefined) {
+        await admin.$queryRawUnsafe('SELECT pg_cancel_backend($1::integer)', migratorPid);
+      }
+      await sleepQuery;
       await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await migrator.$disconnect();
       await admin.$disconnect();
     }
   });
+
+  it.each([
+    { expectedState: 'idle in transaction', abortTransaction: false },
+    { expectedState: 'idle in transaction (aborted)', abortTransaction: true },
+  ])(
+    'counts a connection in $expectedState as pool usage without reporting a long query',
+    async ({ expectedState, abortTransaction }) => {
+      const suffix = `${process.pid}_${Date.now()}`;
+      const applicationName = `health-probe-idle-${suffix}`;
+      const holderUrl = new URL(DATABASE_URL as string);
+      holderUrl.searchParams.set('application_name', applicationName);
+      holderUrl.searchParams.set('connection_limit', '1');
+      const holder = new PrismaClient({
+        datasources: { db: { url: holderUrl.toString() } },
+      });
+      const observer = new PrismaClient({
+        datasources: { db: { url: DATABASE_URL as string } },
+      });
+      const probeUrl = new URL(DATABASE_URL as string);
+      probeUrl.searchParams.set('connection_limit', '4');
+      const baseline = runProbe(probeUrl.toString(), 1);
+      let releaseTransaction: () => void = () => undefined;
+      let signalTransactionReady: () => void = () => undefined;
+      const release = new Promise<void>((resolve) => {
+        releaseTransaction = resolve;
+      });
+      const transactionReady = new Promise<void>((resolve) => {
+        signalTransactionReady = resolve;
+      });
+      const transaction = holder.$transaction(
+        async (tx) => {
+          await tx.$queryRawUnsafe('SELECT 1');
+          if (abortTransaction) {
+            await tx.$queryRawUnsafe('SELECT 1 / 0').catch(() => undefined);
+          }
+          signalTransactionReady();
+          await release;
+        },
+        { timeout: 20_000 },
+      );
+
+      try {
+        await Promise.race([
+          transactionReady,
+          transaction.then(() => {
+            throw new Error('Transaction completed before it became idle');
+          }),
+        ]);
+        await waitForBackend(observer, applicationName, expectedState);
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+        const result = runProbe(probeUrl.toString(), 1);
+
+        expect(result.error).toBeUndefined();
+        expect(result.stderr).toBe('');
+        expect(result.status).toBe(0);
+        expect(readNumericMetric(result.stdout, 'POOL_IN_USE')).toBe(
+          readNumericMetric(baseline.stdout, 'POOL_IN_USE') + 1,
+        );
+        expect(readNumericMetric(result.stdout, 'LONG_Q')).toBe(
+          readNumericMetric(baseline.stdout, 'LONG_Q'),
+        );
+      } finally {
+        releaseTransaction();
+        await Promise.allSettled([transaction]);
+        await Promise.allSettled([holder.$disconnect(), observer.$disconnect()]);
+      }
+    },
+    15_000,
+  );
+
+  it('ignores only the invalid index being dropped by a migrator', async () => {
+    const suffix = `${process.pid}_${Date.now()}`;
+    const schema = `health_probe_${suffix}`;
+    const index = `health_probe_drop_${suffix}`;
+    const qualifiedIndex = `"${schema}"."${index}"`;
+    const applicationName = `supersync-migrator-test-${suffix}`;
+    const migratorUrl = new URL(DATABASE_URL as string);
+    migratorUrl.searchParams.set('application_name', applicationName);
+    migratorUrl.searchParams.set('connection_limit', '1');
+    const admin = new PrismaClient({
+      datasources: { db: { url: DATABASE_URL as string } },
+    });
+    const blocker = new PrismaClient({
+      datasources: { db: { url: DATABASE_URL as string } },
+    });
+    const migrator = new PrismaClient({
+      datasources: { db: { url: migratorUrl.toString() } },
+    });
+    let releaseBlocker: () => void = () => undefined;
+    let signalBlockerReady: () => void = () => undefined;
+    const release = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    const blockerReady = new Promise<void>((resolve) => {
+      signalBlockerReady = resolve;
+    });
+    let blockingTransaction: Promise<unknown> | undefined;
+    let droppingIndex: Promise<unknown> | undefined;
+
+    try {
+      await admin.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`);
+      await admin.$executeRawUnsafe(
+        `CREATE TABLE "${schema}"."operations" ("id" integer NOT NULL)`,
+      );
+      await admin.$executeRawUnsafe(
+        `INSERT INTO "${schema}"."operations" ("id") SELECT generate_series(1, 100)`,
+      );
+      await admin.$executeRawUnsafe(
+        `CREATE INDEX "${index}" ON "${schema}"."operations" ("id")`,
+      );
+
+      blockingTransaction = blocker.$transaction(
+        async (tx) => {
+          await tx.$executeRawUnsafe('SET LOCAL enable_seqscan = off');
+          await tx.$queryRawUnsafe(
+            `SELECT "id" FROM "${schema}"."operations" WHERE "id" = 1`,
+          );
+          signalBlockerReady();
+          await release;
+        },
+        { timeout: 20_000 },
+      );
+      await blockerReady;
+
+      droppingIndex = migrator.$executeRawUnsafe(
+        `DROP INDEX CONCURRENTLY ${qualifiedIndex}`,
+      );
+      await Promise.race([
+        waitForBackend(admin, applicationName, 'active'),
+        droppingIndex.then(() => {
+          throw new Error('DROP INDEX CONCURRENTLY completed before it was observed');
+        }),
+      ]);
+      await waitForInvalidIndex(admin, qualifiedIndex);
+
+      const url = new URL(DATABASE_URL as string);
+      url.searchParams.set('schema', schema);
+      url.searchParams.set('connection_limit', '4');
+      const result = runProbe(url.toString());
+
+      expect(result.error).toBeUndefined();
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+      expect(result.stdout).not.toMatch(new RegExp(`^BAD_INDEX=.*${index}.*$`, 'm'));
+
+      releaseBlocker();
+      await blockingTransaction;
+      await droppingIndex;
+      blockingTransaction = undefined;
+      droppingIndex = undefined;
+    } finally {
+      releaseBlocker();
+      await Promise.allSettled([blockingTransaction, droppingIndex]);
+      await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await blocker.$disconnect();
+      await migrator.$disconnect();
+      await admin.$disconnect();
+    }
+  }, 20_000);
 });

--- a/packages/super-sync-server/tests/integration/health-alert-db-probe.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/health-alert-db-probe.integration.spec.ts
@@ -4,6 +4,7 @@
  * and the two monitoring queries without duplicating their SQL in the test.
  */
 import { spawnSync } from 'node:child_process';
+import { PrismaClient } from '@prisma/client';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,25 +15,30 @@ const describeWithDb = DATABASE_URL ? describe : describe.skip;
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(currentDir, '../..');
 const healthScript = join(packageDir, 'scripts/health-alert.sh');
+const embeddedProbe = (): string => {
+  const script = readFileSync(healthScript, 'utf8');
+  const match = script.match(/DB_PROBE_JS=\$\(cat <<'NODE'\n([\s\S]*?)\nNODE\n\)/);
+  expect(match).not.toBeNull();
+  return match?.[1] ?? '';
+};
+
+const runProbe = (databaseUrl: string) =>
+  spawnSync(process.execPath, ['-e', embeddedProbe()], {
+    cwd: packageDir,
+    encoding: 'utf8',
+    timeout: 20_000,
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      HEALTH_MAX_QUERY_SECONDS: '120',
+    },
+  });
 
 describeWithDb('health-alert.sh PostgreSQL probe', () => {
   it('executes through Prisma and returns the complete monitor result', () => {
-    const script = readFileSync(healthScript, 'utf8');
-    const match = script.match(/DB_PROBE_JS=\$\(cat <<'NODE'\n([\s\S]*?)\nNODE\n\)/);
-    expect(match).not.toBeNull();
-
     const url = new URL(DATABASE_URL as string);
     url.searchParams.set('connection_limit', '4');
-    const result = spawnSync(process.execPath, ['-e', match?.[1] ?? ''], {
-      cwd: packageDir,
-      encoding: 'utf8',
-      timeout: 20_000,
-      env: {
-        ...process.env,
-        DATABASE_URL: url.toString(),
-        HEALTH_MAX_QUERY_SECONDS: '120',
-      },
-    });
+    const result = runProbe(url.toString());
 
     expect(result.error).toBeUndefined();
     expect(result.stderr).toBe('');
@@ -42,5 +48,42 @@ describeWithDb('health-alert.sh PostgreSQL probe', () => {
     expect(result.stdout).toMatch(/^LONGEST=\d+$/m);
     expect(result.stdout).toMatch(/^ACTIVE=\d+$/m);
     expect(result.stdout).toMatch(/^BAD_INDEX=.*$/m);
+  });
+
+  it('checks the operations table selected by the Prisma schema parameter', async () => {
+    const suffix = `${process.pid}_${Date.now()}`;
+    const schema = `health_probe_${suffix}`;
+    const index = `health_probe_invalid_${suffix}`;
+    const admin = new PrismaClient({
+      datasources: { db: { url: DATABASE_URL as string } },
+    });
+
+    try {
+      await admin.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`);
+      await admin.$executeRawUnsafe(
+        `CREATE TABLE "${schema}"."operations" ("id" integer NOT NULL)`,
+      );
+      await admin.$executeRawUnsafe(
+        `INSERT INTO "${schema}"."operations" ("id") VALUES (1), (1)`,
+      );
+      await expect(
+        admin.$executeRawUnsafe(
+          `CREATE UNIQUE INDEX CONCURRENTLY "${index}" ON "${schema}"."operations" ("id")`,
+        ),
+      ).rejects.toThrow();
+
+      const url = new URL(DATABASE_URL as string);
+      url.searchParams.set('schema', schema);
+      url.searchParams.set('connection_limit', '4');
+      const result = runProbe(url.toString());
+
+      expect(result.error).toBeUndefined();
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(new RegExp(`^BAD_INDEX=.*${index}.*$`, 'm'));
+    } finally {
+      await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await admin.$disconnect();
+    }
   });
 });

--- a/packages/super-sync-server/tests/integration/health-alert-db-probe.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/health-alert-db-probe.integration.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Runs the exact JavaScript embedded in health-alert.sh against PostgreSQL.
+ * This preserves coverage for Prisma result conversion, catalog permissions,
+ * and the two monitoring queries without duplicating their SQL in the test.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = join(currentDir, '../..');
+const healthScript = join(packageDir, 'scripts/health-alert.sh');
+
+describeWithDb('health-alert.sh PostgreSQL probe', () => {
+  it('executes through Prisma and returns the complete monitor result', () => {
+    const script = readFileSync(healthScript, 'utf8');
+    const match = script.match(/DB_PROBE_JS=\$\(cat <<'NODE'\n([\s\S]*?)\nNODE\n\)/);
+    expect(match).not.toBeNull();
+
+    const url = new URL(DATABASE_URL as string);
+    url.searchParams.set('connection_limit', '4');
+    const result = spawnSync(process.execPath, ['-e', match?.[1] ?? ''], {
+      cwd: packageDir,
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        ...process.env,
+        DATABASE_URL: url.toString(),
+        HEALTH_MAX_QUERY_SECONDS: '120',
+      },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/^POOL_LIMIT=4$/m);
+    expect(result.stdout).toMatch(/^LONG_Q=\d+$/m);
+    expect(result.stdout).toMatch(/^LONGEST=\d+$/m);
+    expect(result.stdout).toMatch(/^ACTIVE=\d+$/m);
+    expect(result.stdout).toMatch(/^BAD_INDEX=.*$/m);
+  });
+});

--- a/packages/super-sync-server/tests/integration/migrate-deploy-db-timeout.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/migrate-deploy-db-timeout.integration.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Proves the migration wrapper cancels work in PostgreSQL itself and cleans up
+ * a late statement when the whole Prisma process reaches its deadline.
+ */
+import { PrismaClient } from '@prisma/client';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = join(currentDir, '../..');
+const migrateScript = join(packageDir, 'scripts/migrate-deploy.sh');
+
+const createAdmin = (): PrismaClient => {
+  const url = new URL(DATABASE_URL as string);
+  url.searchParams.set('application_name', 'supersync-timeout-test');
+  return new PrismaClient({ datasources: { db: { url: url.toString() } } });
+};
+
+const runPrismaSql = (sql: string, stepTimeout: number, timeout: number) => {
+  const url = new URL(DATABASE_URL as string);
+  url.searchParams.append('options', '-c statement_timeout=60000');
+  url.searchParams.append('application_name', 'must-not-win');
+  const startedAt = Date.now();
+  const result = spawnSync(
+    'sh',
+    [
+      migrateScript,
+      '--prisma',
+      'db',
+      'execute',
+      '--schema',
+      'prisma/schema.prisma',
+      '--stdin',
+    ],
+    {
+      cwd: packageDir,
+      encoding: 'utf8',
+      input: sql,
+      timeout,
+      env: {
+        ...process.env,
+        DATABASE_URL: url.toString(),
+        MIGRATE_STEP_TIMEOUT: String(stepTimeout),
+      },
+    },
+  );
+  return { elapsedMs: Date.now() - startedAt, result };
+};
+
+const countActiveTestBackends = async (
+  admin: PrismaClient,
+  marker: string,
+): Promise<number> => {
+  const [activity] = await admin.$queryRawUnsafe<Array<{ count: number }>>(
+    `SELECT count(*)::integer AS count
+       FROM pg_stat_activity
+      WHERE application_name LIKE 'supersync-migrator%'
+        AND state = 'active'
+        AND query LIKE $1`,
+    `%${marker}%`,
+  );
+  return activity.count;
+};
+
+const terminateTestBackends = async (
+  admin: PrismaClient,
+  marker: string,
+): Promise<void> => {
+  await admin.$queryRawUnsafe(
+    `SELECT pg_terminate_backend(pid)
+       FROM pg_stat_activity
+      WHERE application_name LIKE 'supersync-migrator%'
+        AND pid <> pg_backend_pid()
+        AND query LIKE $1`,
+    `%${marker}%`,
+  );
+};
+
+describeWithDb('migrate-deploy.sh PostgreSQL timeout', () => {
+  it('overrides an existing cap and cancels a long statement on the server', async () => {
+    const marker = 'supersync_statement_timeout_test';
+    const admin = createAdmin();
+    const { elapsedMs, result } = runPrismaSql(
+      `/* ${marker} */ SELECT pg_sleep(60);\n`,
+      7,
+      5_000,
+    );
+
+    let lingeringBackends = -1;
+    try {
+      lingeringBackends = await countActiveTestBackends(admin, marker);
+    } finally {
+      await terminateTestBackends(admin, marker);
+      await admin.$disconnect();
+    }
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      'canceling statement due to statement timeout',
+    );
+    expect(elapsedMs).toBeLessThan(5_000);
+    expect(lingeringBackends).toBe(0);
+  }, 10_000);
+
+  it('terminates a late statement when earlier work consumes the client budget', async () => {
+    const marker = 'supersync_cumulative_timeout_test';
+    const admin = createAdmin();
+    const { elapsedMs, result } = runPrismaSql(
+      `/* ${marker} */
+SELECT pg_sleep(3);
+SELECT pg_sleep(3);
+SELECT pg_sleep(60);\n`,
+      10,
+      15_000,
+    );
+
+    let lingeringBackends = -1;
+    try {
+      lingeringBackends = await countActiveTestBackends(admin, marker);
+    } finally {
+      await terminateTestBackends(admin, marker);
+      await admin.$disconnect();
+    }
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).not.toContain(
+      'canceling statement due to statement timeout',
+    );
+    expect(elapsedMs).toBeGreaterThanOrEqual(9_000);
+    expect(elapsedMs).toBeLessThan(15_000);
+    expect(lingeringBackends).toBe(0);
+  }, 20_000);
+});

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -35,6 +35,7 @@ interface RunResult {
   resolveRolledBack: string[];
   databaseUrls: string[];
   prismaCommands: string[];
+  timeoutCommands: string[];
 }
 
 let projectDir: string;
@@ -56,7 +57,7 @@ shift # drop "prisma"
 sub="$1"; shift
 state="$FAKE_STATE"
 # Record the URL every prisma invocation actually receives, so the migrator's
-# statement_timeout exemption can be asserted on the recovery paths too.
+# statement_timeout guardrail can be asserted on the recovery paths too.
 printf '%s\\n' "\${DATABASE_URL:-<unset>}" >> "$state/database_urls"
 case "$sub" in
   migrate)
@@ -169,6 +170,7 @@ const run = (env: Record<string, string>, args: string[] = []): RunResult => {
     resolveRolledBack: read('rolledback').split('\n').filter(Boolean),
     databaseUrls: read('database_urls').split('\n').filter(Boolean),
     prismaCommands: read('prisma_commands').split('\n').filter(Boolean),
+    timeoutCommands: read('timeout_commands').split('\n').filter(Boolean),
   };
 };
 
@@ -270,7 +272,7 @@ describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
     );
     expect(r.stdout).toContain(`migrate resolve --rolled-back '${bare}'`);
     expect(r.stdout).toContain(
-      'docker compose run --rm --no-deps -T supersync sh scripts/migrate-deploy.sh --prisma',
+      'docker compose run --rm --no-deps -T -e "MIGRATE_STEP_TIMEOUT=1800" supersync sh scripts/migrate-deploy.sh --prisma',
     );
     expect(r.resolveApplied).toEqual([]);
     expect(r.resolveRolledBack).toEqual([]);
@@ -282,7 +284,7 @@ describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
     // that: run the wrapped command, then exit 143 as if the step was TERMed.
     // migrate-deploy.sh must normalize this to its timeout branch.
     const fakeTimeout = join(binDir, 'timeout');
-    writeFileSync(fakeTimeout, '#!/bin/sh\nshift\n"$@"\nexit 143\n');
+    writeFileSync(fakeTimeout, '#!/bin/sh\nshift 3\n"$@"\nexit 143\n');
     chmodSync(fakeTimeout, 0o755);
 
     const r = run({ FAKE_FAIL: '', FAKE_CODE: 'P3018' });
@@ -299,7 +301,7 @@ describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
     // recovery, because raising the timeout alone cannot rebuild an INVALID
     // index left by the aborted build.
     const fakeTimeout = join(binDir, 'timeout');
-    writeFileSync(fakeTimeout, '#!/bin/sh\nshift\n"$@"\nexit 143\n');
+    writeFileSync(fakeTimeout, '#!/bin/sh\nshift 3\n"$@"\nexit 143\n');
     chmodSync(fakeTimeout, 0o755);
     const bare = '20260701000000_add_bare_concurrent_index';
     const bareSql = `CREATE INDEX CONCURRENTLY "operations_bare_idx"
@@ -433,24 +435,25 @@ CREATE INDEX CONCURRENTLY "operations_payload_bytes_unbackfilled_idx"
   });
 });
 
-// #9191: operators may cap application statements through DATABASE_URL. That cap
-// must not reach CREATE INDEX CONCURRENTLY or its automated recovery steps;
-// migrations are bounded by STEP_TIMEOUT instead.
-describe('migrate-deploy.sh statement_timeout exemption', () => {
+// #9191: operators may cap application statements through DATABASE_URL. Migrations
+// use the larger, finite MIGRATE_STEP_TIMEOUT budget instead so PostgreSQL cannot
+// keep running a query after its Prisma client has been terminated.
+describe('migrate-deploy.sh statement_timeout guardrail', () => {
   const BASE = 'postgresql://u:p@postgres:5432/supersync';
 
-  it('overrides an existing statement_timeout with a final zero value', () => {
+  it('overrides an existing statement_timeout with the finite migration budget', () => {
     const r = run({
       FAKE_FAIL: '',
       FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '7',
       DATABASE_URL: `${BASE}?connection_limit=60&pool_timeout=20&options=-c%20statement_timeout%3D60000`,
     });
 
     expect(r.status).toBe(0);
     expect(r.databaseUrls).not.toHaveLength(0);
     for (const url of r.databaseUrls) {
-      expect(url).toContain('statement_timeout%3D0');
-      expect(url).toMatch(/statement_timeout%3D60000.*statement_timeout%3D0/);
+      expect(url).toContain('statement_timeout%3D2000');
+      expect(url).toMatch(/statement_timeout%3D60000.*statement_timeout%3D2000/);
       // The pool settings are not ours to touch.
       expect(url).toContain('connection_limit=60');
       expect(url).toContain('pool_timeout=20');
@@ -467,7 +470,27 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
 
     expect(r.status).not.toBe(0);
     expect(r.stdout).toContain(
-      'DATABASE_URL must include positive connection_limit and pool_timeout values',
+      'DATABASE_URL must include exactly one positive connection_limit and pool_timeout value each',
+    );
+    expect(r.prismaCommands).toEqual([]);
+  });
+
+  it.each([
+    'connection_limit=60&connection_limit=0&pool_timeout=10',
+    'connection_limit=60&pool_timeout=10&pool_timeout=0',
+    'connection_limit=9007199254740992&pool_timeout=10',
+    'connection_limit=60&pool_timeout=9007199254740992',
+  ])('rejects invalid pool guardrails in %s', (query) => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?${query}`,
+      REQUIRE_DATABASE_POOL_LIMITS: 'true',
+    });
+
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toContain(
+      'DATABASE_URL must include exactly one positive connection_limit and pool_timeout value each',
     );
     expect(r.prismaCommands).toEqual([]);
   });
@@ -477,6 +500,7 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
       {
         FAKE_FAIL: '',
         FAKE_CODE: 'P3018',
+        MIGRATE_STEP_TIMEOUT: '7',
         DATABASE_URL: `${BASE}?connection_limit=60&pool_timeout=10&options=-c%20statement_timeout%3D60000`,
         REQUIRE_DATABASE_POOL_LIMITS: 'true',
       },
@@ -487,17 +511,44 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
     expect(r.prismaCommands).toEqual([
       `prisma migrate resolve --rolled-back ${ENCRYPTED_OPS}`,
     ]);
-    expect(r.databaseUrls[0]).toMatch(/statement_timeout%3D60000.*statement_timeout%3D0/);
-    expect(new URL(r.databaseUrls[0]).searchParams.get('application_name')).toBe(
-      'supersync-migrator',
+    expect(r.databaseUrls[0]).toMatch(
+      /statement_timeout%3D60000.*statement_timeout%3D2000/,
+    );
+    expect(new URL(r.databaseUrls[0]).searchParams.get('application_name')).toMatch(
+      /^supersync-migrator-[0-9a-f-]{36}$/,
     );
   });
 
-  it('keeps the exemption on the recovery paths, not just the first deploy', () => {
+  it('bounds manual recovery commands with the same client timeout wrapper', () => {
+    const timeoutPath = join(binDir, 'timeout');
+    writeFileSync(
+      timeoutPath,
+      '#!/bin/sh\ncase "$*" in *"npx prisma"*) printf \'%s\\n\' "$*" >> "$FAKE_STATE/timeout_commands" ;; esac\nexit 124\n',
+    );
+    chmodSync(timeoutPath, 0o755);
+
+    const r = run(
+      {
+        FAKE_FAIL: '',
+        FAKE_CODE: 'P3018',
+        MIGRATE_STEP_TIMEOUT: '7',
+      },
+      ['--prisma', 'migrate', 'resolve', '--rolled-back', ENCRYPTED_OPS],
+    );
+
+    expect(r.status).toBe(124);
+    expect(r.timeoutCommands).toEqual([
+      `-k 5 7 npx prisma migrate resolve --rolled-back ${ENCRYPTED_OPS}`,
+    ]);
+    expect(r.prismaCommands).toEqual([]);
+  });
+
+  it('keeps the guardrail on the recovery paths, not just the first deploy', () => {
     writeMigration(ENCRYPTED_OPS, ENCRYPTED_OPS_SQL);
     const r = run({
       FAKE_FAIL: ENCRYPTED_OPS,
       FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '7',
       DATABASE_URL: `${BASE}?options=-c%20statement_timeout%3D60000`,
     });
 
@@ -505,20 +556,23 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
     // deploy → resolve → db execute → resolve → deploy: several invocations, and
     // the out-of-band `db execute` is the one that actually builds the index.
     expect(r.databaseUrls.length).toBeGreaterThan(1);
-    expect(r.databaseUrls.every((u) => u.includes('statement_timeout%3D0'))).toBe(true);
+    expect(r.databaseUrls.every((u) => u.includes('statement_timeout%3D2000'))).toBe(
+      true,
+    );
   });
 
   it('extends an existing options value instead of adding a second options param', () => {
     const r = run({
       FAKE_FAIL: '',
       FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '7',
       DATABASE_URL: `${BASE}?options=-c%20lock_timeout%3D5000&connection_limit=60`,
     });
 
     const url = r.databaseUrls[0];
-    expect(url).toContain('statement_timeout%3D0');
+    expect(url).toContain('statement_timeout%3D2000');
     // Prisma resolves a duplicated param to one of the two — silently dropping
-    // either the pre-existing setting or our exemption.
+    // either the pre-existing setting or our guardrail.
     expect(url.match(/options=/g)).toHaveLength(1);
     expect(url).toContain('lock_timeout%3D5000');
     expect(url).toContain('connection_limit=60');
@@ -528,10 +582,11 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
     const r = run({
       FAKE_FAIL: '',
       FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '7',
       DATABASE_URL: `postgresql://statement_timeout:p@postgres:5432/supersync?connection_limit=60`,
     });
 
-    expect(r.databaseUrls[0]).toContain('options=-c%20statement_timeout%3D0');
+    expect(r.databaseUrls[0]).toContain('options=-c%20statement_timeout%3D2000');
   });
 
   it('identifies every Prisma migration connection to monitoring', () => {
@@ -543,11 +598,17 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
 
     expect(r.databaseUrls).not.toHaveLength(0);
     expect(
-      r.databaseUrls.every(
-        (url) =>
-          new URL(url).searchParams.get('application_name') === 'supersync-migrator',
+      r.databaseUrls.every((url) =>
+        /^supersync-migrator-[0-9a-f-]{36}$/.test(
+          new URL(url).searchParams.get('application_name') ?? '',
+        ),
       ),
     ).toBe(true);
+    expect(
+      new Set(
+        r.databaseUrls.map((url) => new URL(url).searchParams.get('application_name')),
+      ).size,
+    ).toBe(1);
   });
 
   it('replaces an existing application_name query parameter', () => {
@@ -557,29 +618,84 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
       DATABASE_URL: `${BASE}?application_name=existing-app`,
     });
 
-    expect(new URL(r.databaseUrls[0]).searchParams.get('application_name')).toBe(
-      'supersync-migrator',
+    expect(new URL(r.databaseUrls[0]).searchParams.get('application_name')).toMatch(
+      /^supersync-migrator-[0-9a-f-]{36}$/,
     );
+  });
+
+  it('collapses duplicate protected parameters so later values cannot override them', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '7',
+      DATABASE_URL: `${BASE}?options=-c%20lock_timeout%3D5000&options=-c%20statement_timeout%3D60000&application_name=first&application_name=last`,
+    });
+
+    const url = new URL(r.databaseUrls[0]);
+    const options = url.searchParams.getAll('options');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toBe(
+      '-c lock_timeout=5000 -c statement_timeout=60000 -c statement_timeout=2000',
+    );
+    expect(url.searchParams.getAll('application_name')).toEqual([
+      expect.stringMatching(/^supersync-migrator-[0-9a-f-]{36}$/),
+    ]);
   });
 
   it('appends with & when the URL already has a query string', () => {
     const r = run({
       FAKE_FAIL: '',
       FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '7',
       DATABASE_URL: `${BASE}?connection_limit=60`,
     });
 
-    expect(r.databaseUrls[0]).toBe(
-      `${BASE}?connection_limit=60&options=-c%20statement_timeout%3D0&application_name=supersync-migrator`,
+    expect(r.databaseUrls[0]).toContain(
+      `${BASE}?connection_limit=60&options=-c%20statement_timeout%3D2000&application_name=supersync-migrator-`,
     );
   });
 
   it('appends with ? when the URL has no query string', () => {
-    const r = run({ FAKE_FAIL: '', FAKE_CODE: 'P3018', DATABASE_URL: BASE });
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '7',
+      DATABASE_URL: BASE,
+    });
 
-    expect(r.databaseUrls[0]).toBe(
-      `${BASE}?options=-c%20statement_timeout%3D0&application_name=supersync-migrator`,
+    expect(r.databaseUrls[0]).toContain(
+      `${BASE}?options=-c%20statement_timeout%3D2000&application_name=supersync-migrator-`,
     );
+  });
+
+  it.each(['0', '01', '-1', '1.5', 'abc', '2147484', '99999999999999999999'])(
+    'rejects invalid MIGRATE_STEP_TIMEOUT=%s before invoking Prisma',
+    (timeout) => {
+      const r = run({
+        FAKE_FAIL: '',
+        FAKE_CODE: 'P3018',
+        MIGRATE_STEP_TIMEOUT: timeout,
+        DATABASE_URL: BASE,
+      });
+
+      expect(r.status).not.toBe(0);
+      expect(r.stdout).toContain(
+        'MIGRATE_STEP_TIMEOUT must be an integer from 1 to 2147483 seconds',
+      );
+      expect(r.prismaCommands).toEqual([]);
+    },
+  );
+
+  it('clamps the database timeout to one second for a short client budget', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      MIGRATE_STEP_TIMEOUT: '3',
+      DATABASE_URL: BASE,
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.databaseUrls[0]).toContain('statement_timeout%3D1000');
   });
 
   it('does nothing when DATABASE_URL is unset', () => {

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -33,6 +33,7 @@ interface RunResult {
   executedSql: string;
   resolveApplied: string[];
   resolveRolledBack: string[];
+  databaseUrls: string[];
 }
 
 let projectDir: string;
@@ -52,6 +53,9 @@ set -eu
 shift # drop "prisma"
 sub="$1"; shift
 state="$FAKE_STATE"
+# Record the URL every prisma invocation actually receives, so the migrator's
+# statement_timeout exemption can be asserted on the recovery paths too.
+printf '%s\\n' "\${DATABASE_URL:-<unset>}" >> "$state/database_urls"
 case "$sub" in
   migrate)
     action="$1"; shift
@@ -161,6 +165,7 @@ const run = (env: Record<string, string>): RunResult => {
     executedSql: read('executed_sql'),
     resolveApplied: read('applied_list').split('\n').filter(Boolean),
     resolveRolledBack: read('rolledback').split('\n').filter(Boolean),
+    databaseUrls: read('database_urls').split('\n').filter(Boolean),
   };
 };
 
@@ -415,5 +420,88 @@ CREATE INDEX CONCURRENTLY "operations_payload_bytes_unbackfilled_idx"
 
     expect(r.status).toBe(0);
     expect(r.resolveApplied).toEqual(expect.arrayContaining([ENCRYPTED_OPS, second]));
+  });
+});
+
+// #9191: production caps statement_timeout at 60s via DATABASE_URL so a bad query
+// plan cannot hold a pool connection forever. That cap must NOT reach the migrator
+// — a CREATE INDEX CONCURRENTLY runs far longer than 60s, and because every
+// recovery path inherits the same URL, a cancelled build cannot be recovered
+// either, by the script or by hand. Migrations are bounded by STEP_TIMEOUT.
+describe('migrate-deploy.sh statement_timeout exemption', () => {
+  const BASE = 'postgresql://u:p@postgres:5432/supersync';
+
+  it('rewrites an existing statement_timeout to 0', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?connection_limit=60&pool_timeout=20&options=-c%20statement_timeout%3D60000`,
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.databaseUrls).not.toHaveLength(0);
+    for (const url of r.databaseUrls) {
+      expect(url).toContain('statement_timeout%3D0');
+      expect(url).not.toContain('60000');
+      // The pool settings are not ours to touch.
+      expect(url).toContain('connection_limit=60');
+      expect(url).toContain('pool_timeout=20');
+    }
+  });
+
+  it('keeps the exemption on the recovery paths, not just the first deploy', () => {
+    writeMigration(ENCRYPTED_OPS, ENCRYPTED_OPS_SQL);
+    const r = run({
+      FAKE_FAIL: ENCRYPTED_OPS,
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?options=-c%20statement_timeout%3D60000`,
+    });
+
+    expect(r.status).toBe(0);
+    // deploy → resolve → db execute → resolve → deploy: several invocations, and
+    // the out-of-band `db execute` is the one that actually builds the index.
+    expect(r.databaseUrls.length).toBeGreaterThan(1);
+    expect(r.databaseUrls.every((u) => u.includes('statement_timeout%3D0'))).toBe(true);
+  });
+
+  it('extends an existing options value instead of adding a second options param', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?options=-c%20lock_timeout%3D5000&connection_limit=60`,
+    });
+
+    const url = r.databaseUrls[0];
+    expect(url).toContain('statement_timeout%3D0');
+    // Prisma resolves a duplicated param to one of the two — silently dropping
+    // either the pre-existing setting or our exemption.
+    expect(url.match(/options=/g)).toHaveLength(1);
+    expect(url).toContain('lock_timeout%3D5000');
+    expect(url).toContain('connection_limit=60');
+  });
+
+  it('appends with & when the URL already has a query string', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?connection_limit=60`,
+    });
+
+    expect(r.databaseUrls[0]).toBe(
+      `${BASE}?connection_limit=60&options=-c%20statement_timeout%3D0`,
+    );
+  });
+
+  it('appends with ? when the URL has no query string', () => {
+    const r = run({ FAKE_FAIL: '', FAKE_CODE: 'P3018', DATABASE_URL: BASE });
+
+    expect(r.databaseUrls[0]).toBe(`${BASE}?options=-c%20statement_timeout%3D0`);
+  });
+
+  it('does nothing when DATABASE_URL is unset', () => {
+    const r = run({ FAKE_FAIL: '', FAKE_CODE: 'P3018' });
+
+    expect(r.status).toBe(0);
+    expect(r.databaseUrls).toEqual(['<unset>']);
   });
 });

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -34,6 +34,7 @@ interface RunResult {
   resolveApplied: string[];
   resolveRolledBack: string[];
   databaseUrls: string[];
+  prismaCommands: string[];
 }
 
 let projectDir: string;
@@ -50,6 +51,7 @@ const writeMigration = (name: string, sql: string): void => {
 // marker files under $FAKE_STATE so the deploy→recover→retry cycle is modelled.
 const FAKE_NPX = `#!/bin/sh
 set -eu
+printf '%s\\n' "$*" >> "$FAKE_STATE/prisma_commands"
 shift # drop "prisma"
 sub="$1"; shift
 state="$FAKE_STATE"
@@ -133,11 +135,11 @@ echo "fake npx: unhandled args" >&2
 exit 99
 `;
 
-const run = (env: Record<string, string>): RunResult => {
+const run = (env: Record<string, string>, args: string[] = []): RunResult => {
   let status = 0;
   let stdout = '';
   try {
-    stdout = execFileSync('sh', [SCRIPT], {
+    stdout = execFileSync('sh', [SCRIPT, ...args], {
       cwd: projectDir,
       encoding: 'utf8',
       env: {
@@ -166,6 +168,7 @@ const run = (env: Record<string, string>): RunResult => {
     resolveApplied: read('applied_list').split('\n').filter(Boolean),
     resolveRolledBack: read('rolledback').split('\n').filter(Boolean),
     databaseUrls: read('database_urls').split('\n').filter(Boolean),
+    prismaCommands: read('prisma_commands').split('\n').filter(Boolean),
   };
 };
 
@@ -254,7 +257,11 @@ describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
     const bareSql = `CREATE INDEX CONCURRENTLY "operations_bare_idx"
   ON "operations"("user_id", "server_seq");`;
     writeMigration(bare, bareSql);
-    const r = run({ FAKE_FAIL: bare, FAKE_CODE: 'P3009' });
+    const r = run({
+      FAKE_FAIL: bare,
+      FAKE_CODE: 'P3009',
+      MIGRATE_RECOVERY_RUNTIME: 'compose',
+    });
 
     expect(r.status).not.toBe(0);
     expect(r.stdout).toContain('not a recoverable drop-then-create');
@@ -262,6 +269,9 @@ describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
       'DROP INDEX CONCURRENTLY IF EXISTS "operations_bare_idx";',
     );
     expect(r.stdout).toContain(`migrate resolve --rolled-back '${bare}'`);
+    expect(r.stdout).toContain(
+      'docker compose run --rm --no-deps -T supersync sh scripts/migrate-deploy.sh --prisma',
+    );
     expect(r.resolveApplied).toEqual([]);
     expect(r.resolveRolledBack).toEqual([]);
   });
@@ -423,15 +433,13 @@ CREATE INDEX CONCURRENTLY "operations_payload_bytes_unbackfilled_idx"
   });
 });
 
-// #9191: production caps statement_timeout at 60s via DATABASE_URL so a bad query
-// plan cannot hold a pool connection forever. That cap must NOT reach the migrator
-// — a CREATE INDEX CONCURRENTLY runs far longer than 60s, and because every
-// recovery path inherits the same URL, a cancelled build cannot be recovered
-// either, by the script or by hand. Migrations are bounded by STEP_TIMEOUT.
+// #9191: operators may cap application statements through DATABASE_URL. That cap
+// must not reach CREATE INDEX CONCURRENTLY or its automated recovery steps;
+// migrations are bounded by STEP_TIMEOUT instead.
 describe('migrate-deploy.sh statement_timeout exemption', () => {
   const BASE = 'postgresql://u:p@postgres:5432/supersync';
 
-  it('rewrites an existing statement_timeout to 0', () => {
+  it('overrides an existing statement_timeout with a final zero value', () => {
     const r = run({
       FAKE_FAIL: '',
       FAKE_CODE: 'P3018',
@@ -442,11 +450,47 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
     expect(r.databaseUrls).not.toHaveLength(0);
     for (const url of r.databaseUrls) {
       expect(url).toContain('statement_timeout%3D0');
-      expect(url).not.toContain('60000');
+      expect(url).toMatch(/statement_timeout%3D60000.*statement_timeout%3D0/);
       // The pool settings are not ours to touch.
       expect(url).toContain('connection_limit=60');
       expect(url).toContain('pool_timeout=20');
     }
+  });
+
+  it('rejects a secret-backed URL without explicit pool guardrails', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?connection_limit=60`,
+      REQUIRE_DATABASE_POOL_LIMITS: 'true',
+    });
+
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toContain(
+      'DATABASE_URL must include positive connection_limit and pool_timeout values',
+    );
+    expect(r.prismaCommands).toEqual([]);
+  });
+
+  it('runs manual recovery commands through the protected Prisma wrapper', () => {
+    const r = run(
+      {
+        FAKE_FAIL: '',
+        FAKE_CODE: 'P3018',
+        DATABASE_URL: `${BASE}?connection_limit=60&pool_timeout=10&options=-c%20statement_timeout%3D60000`,
+        REQUIRE_DATABASE_POOL_LIMITS: 'true',
+      },
+      ['--prisma', 'migrate', 'resolve', '--rolled-back', ENCRYPTED_OPS],
+    );
+
+    expect(r.status).toBe(0);
+    expect(r.prismaCommands).toEqual([
+      `prisma migrate resolve --rolled-back ${ENCRYPTED_OPS}`,
+    ]);
+    expect(r.databaseUrls[0]).toMatch(/statement_timeout%3D60000.*statement_timeout%3D0/);
+    expect(new URL(r.databaseUrls[0]).searchParams.get('application_name')).toBe(
+      'supersync-migrator',
+    );
   });
 
   it('keeps the exemption on the recovery paths, not just the first deploy', () => {
@@ -480,6 +524,44 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
     expect(url).toContain('connection_limit=60');
   });
 
+  it('does not mistake a URL component for the statement_timeout option', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `postgresql://statement_timeout:p@postgres:5432/supersync?connection_limit=60`,
+    });
+
+    expect(r.databaseUrls[0]).toContain('options=-c%20statement_timeout%3D0');
+  });
+
+  it('identifies every Prisma migration connection to monitoring', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?options=-c%20lock_timeout%3D5000`,
+    });
+
+    expect(r.databaseUrls).not.toHaveLength(0);
+    expect(
+      r.databaseUrls.every(
+        (url) =>
+          new URL(url).searchParams.get('application_name') === 'supersync-migrator',
+      ),
+    ).toBe(true);
+  });
+
+  it('replaces an existing application_name query parameter', () => {
+    const r = run({
+      FAKE_FAIL: '',
+      FAKE_CODE: 'P3018',
+      DATABASE_URL: `${BASE}?application_name=existing-app`,
+    });
+
+    expect(new URL(r.databaseUrls[0]).searchParams.get('application_name')).toBe(
+      'supersync-migrator',
+    );
+  });
+
   it('appends with & when the URL already has a query string', () => {
     const r = run({
       FAKE_FAIL: '',
@@ -488,14 +570,16 @@ describe('migrate-deploy.sh statement_timeout exemption', () => {
     });
 
     expect(r.databaseUrls[0]).toBe(
-      `${BASE}?connection_limit=60&options=-c%20statement_timeout%3D0`,
+      `${BASE}?connection_limit=60&options=-c%20statement_timeout%3D0&application_name=supersync-migrator`,
     );
   });
 
   it('appends with ? when the URL has no query string', () => {
     const r = run({ FAKE_FAIL: '', FAKE_CODE: 'P3018', DATABASE_URL: BASE });
 
-    expect(r.databaseUrls[0]).toBe(`${BASE}?options=-c%20statement_timeout%3D0`);
+    expect(r.databaseUrls[0]).toBe(
+      `${BASE}?options=-c%20statement_timeout%3D0&application_name=supersync-migrator`,
+    );
   });
 
   it('does nothing when DATABASE_URL is unset', () => {

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -255,6 +255,8 @@ describe('performance migrations', () => {
     expect(deployScript).toContain('prisma migrate deploy timed out');
     expect(deployScript).toContain('database migrations failed (exit $MIGRATE_STATUS)');
     expect(deployScript).toContain(externalDbStartCommand);
+    expect(deployScript).toContain('awk -v script="$script_path"');
+    expect(deployScript).toContain('$command_index == script');
     expect(deployScript).toContain('RUN_MIGRATIONS_ON_STARTUP');
     expect(deployScript.indexOf(migrationCommand)).toBeLessThan(
       deployScript.indexOf(startCommand),
@@ -265,6 +267,7 @@ describe('performance migrations', () => {
     expect(dockerfile).toContain('sh scripts/migrate-deploy.sh');
     expect(dockerfile).toContain('NODE_OPTIONS=--max-old-space-size=576');
     expect(composeBuildFile).toContain('VCS_REF: ${SUPERSYNC_BUILD_SHA:-local}');
+    expect(composeBuildFile).toContain('MIGRATE_RECOVERY_BUILD_LOCAL=true');
     expect(buildAndPushScript).toContain('supersync_image_source_revision()');
     expect(buildAndPushScript).toContain('assert_clean_supersync_image_inputs');
     expect(buildAndPushScript).toContain('git -C "$REPO_ROOT" log -1 --format=%H');
@@ -283,6 +286,17 @@ describe('performance migrations', () => {
     expect(dockerWorkflow).toContain('VCS_REF=${{ steps.source-ref.outputs.revision }}');
     expect(dockerWorkflow).not.toContain('labels: ${{ steps.meta.outputs.labels }}');
     expect(helmDeployment).toContain('sh scripts/migrate-deploy.sh');
+    expect(helmDeployment).toContain('connection_limit=60&pool_timeout=10');
+    expect(helmDeployment).toContain(
+      'externalDatabase.url must include connection_limit and pool_timeout',
+    );
+    expect(helmDeployment).toContain('REQUIRE_DATABASE_POOL_LIMITS');
+    expect(runtimeMigrateScript).toContain(
+      'DATABASE_URL must include positive connection_limit and pool_timeout values',
+    );
+    expect(runtimeMigrateScript).toContain(
+      '-f docker-compose.yml -f docker-compose.build.yml',
+    );
     // Architectural invariant (the actual bug class): the generic runtime
     // script must NOT hardcode any migration name or index DDL — that lockstep
     // coupling is what went stale and broke the production deploy. Behavioral
@@ -301,9 +315,11 @@ describe('performance migrations', () => {
     expect(composeFile).toContain(
       'RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}',
     );
+    expect(composeFile).toContain('MIGRATE_RECOVERY_RUNTIME=compose');
     expect(composeFile).toContain(
       'SUPERSYNC_PAYLOAD_BYTES_BACKFILL_COMPLETE=${SUPERSYNC_PAYLOAD_BYTES_BACKFILL_COMPLETE:-false}',
     );
+    expect(composeFile).toContain('connection_limit=60&pool_timeout=10');
     expect(composeFile).toContain(
       'psql -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" -c "SELECT 1"',
     );

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -185,6 +185,18 @@ describe('performance migrations', () => {
       join(currentDir, '../helm/supersync/templates/deployment.yaml'),
       'utf8',
     );
+    const helmValues = readFileSync(
+      join(currentDir, '../helm/supersync/values.yaml'),
+      'utf8',
+    );
+    const helmHelpers = readFileSync(
+      join(currentDir, '../helm/supersync/templates/_helpers.tpl'),
+      'utf8',
+    );
+    const helmDatabaseUrlCheck = readFileSync(
+      join(currentDir, '../helm/supersync/templates/database-url-check.yaml'),
+      'utf8',
+    );
     const dockerWorkflow = readFileSync(
       join(currentDir, '../../../.github/workflows/supersync-docker.yml'),
       'utf8',
@@ -286,17 +298,40 @@ describe('performance migrations', () => {
     expect(dockerWorkflow).toContain('VCS_REF=${{ steps.source-ref.outputs.revision }}');
     expect(dockerWorkflow).not.toContain('labels: ${{ steps.meta.outputs.labels }}');
     expect(helmDeployment).toContain('sh scripts/migrate-deploy.sh');
-    expect(helmDeployment).toContain('connection_limit=60&pool_timeout=10');
-    expect(helmDeployment).toContain(
-      'externalDatabase.url must include connection_limit and pool_timeout',
+    expect(
+      helmDeployment.match(/include "supersync\.postgresqlConnectionLimit" \./g),
+    ).toHaveLength(2);
+    expect(helmHelpers).toContain(
+      'postgresql.connectionLimit must be a positive integer',
     );
-    expect(helmDeployment).toContain('REQUIRE_DATABASE_POOL_LIMITS');
+    expect(helmValues).toContain('connectionLimit: 20');
+    expect(helmDeployment).not.toContain('regexMatch');
+    expect(helmDeployment.match(/REQUIRE_DATABASE_POOL_LIMITS/g)).toHaveLength(1);
+    expect(helmDeployment.indexOf('REQUIRE_DATABASE_POOL_LIMITS')).toBeLessThan(
+      helmDeployment.indexOf('{{- if .Values.postgresql.enabled }}'),
+    );
+    expect(helmDatabaseUrlCheck).toContain('"helm.sh/hook": pre-upgrade');
+    expect(helmDatabaseUrlCheck).toContain("command: ['node', '-e']");
+    expect(helmDatabaseUrlCheck).toContain('Number.isSafeInteger');
+    expect(helmDatabaseUrlCheck).not.toContain('migrate-deploy.sh');
+    expect(helmDatabaseUrlCheck).not.toContain('activeDeadlineSeconds');
+    expect(helmDatabaseUrlCheck).toContain('.Values.externalDatabase.existingSecret');
+    expect(helmDatabaseUrlCheck).toContain(
+      'include "supersync.fullname" . | trunc 44 | trimSuffix "-"',
+    );
+    expect(helmDatabaseUrlCheck).toContain(
+      'app.kubernetes.io/component: database-url-check',
+    );
+    expect(helmDatabaseUrlCheck).not.toContain('supersync.selectorLabels');
     expect(runtimeMigrateScript).toContain(
-      'DATABASE_URL must include positive connection_limit and pool_timeout values',
+      'DATABASE_URL must include exactly one positive connection_limit and pool_timeout value each',
     );
     expect(runtimeMigrateScript).toContain(
       '-f docker-compose.yml -f docker-compose.build.yml',
     );
+    expect(
+      runtimeMigrateScript.match(/MIGRATE_STEP_TIMEOUT=\$STEP_TIMEOUT/g),
+    ).toHaveLength(3);
     // Architectural invariant (the actual bug class): the generic runtime
     // script must NOT hardcode any migration name or index DDL — that lockstep
     // coupling is what went stale and broke the production deploy. Behavioral

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -350,6 +350,7 @@ describe('performance migrations', () => {
     expect(composeFile).toContain(
       'RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}',
     );
+    expect(composeFile).toContain('REQUIRE_DATABASE_POOL_LIMITS=true');
     expect(composeFile).toContain('MIGRATE_RECOVERY_RUNTIME=compose');
     expect(composeFile).toContain(
       'SUPERSYNC_PAYLOAD_BYTES_BACKFILL_COMPLETE=${SUPERSYNC_PAYLOAD_BYTES_BACKFILL_COMPLETE:-false}',

--- a/packages/super-sync-server/vitest.config.ts
+++ b/packages/super-sync-server/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       'tests/integration/conflict-detection-sql.integration.spec.ts',
       'tests/integration/repair-causality.integration.spec.ts',
       'tests/integration/health-alert-db-probe.integration.spec.ts',
+      'tests/integration/migrate-deploy-db-timeout.integration.spec.ts',
       // Tests password reset routes that don't exist - server uses passkey/magic link auth
       'tests/password-reset-api.spec.ts',
     ],

--- a/packages/super-sync-server/vitest.config.ts
+++ b/packages/super-sync-server/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       'tests/integration/snapshot-vector-clock-sql.integration.spec.ts',
       'tests/integration/conflict-detection-sql.integration.spec.ts',
       'tests/integration/repair-causality.integration.spec.ts',
+      'tests/integration/health-alert-db-probe.integration.spec.ts',
       // Tests password reset routes that don't exist - server uses passkey/magic link auth
       'tests/password-reset-api.spec.ts',
     ],


### PR DESCRIPTION
## Summary

- monitor long-running queries, application-pool saturation, and unusable `operations` indexes from the running SuperSync container
- make monitoring installation, heartbeat, and mail-delivery failures visible during deploys
- make Prisma pool limits durable in Compose and Helm, and retain about a day of application logs without increasing PostgreSQL/Caddy retention
- bound migration work on both the client and PostgreSQL sides, tag each run uniquely, and terminate only its backend after a client timeout
- validate Helm database pool settings before a Recreate upgrade can stop the running application

## Why

During the 2026-07-20 outage, a degenerate query plan held most PostgreSQL connections for up to 75 minutes while the containers remained healthy. Existing liveness checks could not identify long-running work, saturation, or an invalid concurrent index, and the available logs had rotated before the incident could be reconstructed.

This change adds generic operational guardrails for the next query-plan or migration failure rather than encoding knowledge of one query.

## Root cause and safety details

Prisma's client-side transaction timeout does not guarantee that PostgreSQL has stopped executing a statement. A global application `statement_timeout` would bound that work, but it remains opt-in here because the legacy snapshot-clock fallback can legitimately exceed 60 seconds on upgraded histories. This PR instead makes pool bounds durable and alerts on long-running work; operators can enable the documented application timeout after validating their histories.

Migrations must remain compatible with an operator-configured application timeout. The migration wrapper applies a larger but finite per-statement budget below its client deadline, assigns a unique `application_name`, and terminates only the matching database/user/backend after timeout.

For Helm external-database upgrades, an inline pre-upgrade validator checks secret-backed pool settings before the default Recreate strategy can replace the live pod. The migration init container rechecks the same contract at runtime.

## Deliberate limitation

The application `statement_timeout` is not enabled by default. Without it, these changes detect long-running work and contain the application's connection usage, but they do not guarantee that PostgreSQL cancels an abandoned ordinary application statement. Enabling a default safely requires first reproducing and bounding the legacy snapshot-clock fallback against realistic PostgreSQL histories.

## Scope decision

The proposed Prisma AST lint rule is intentionally not included. The SuperSync package is excluded from the root ESLint configuration, its only matching call site is removed by the query-fix change, and the relevant hot paths now use raw SQL that such a rule cannot inspect. Adding permanent lint machinery here would provide no effective coverage.

This PR links to issue #9191 because that issue also discusses the rejected lint proposal and live operational follow-up.

Refs #9191

## Validation

- push hook: full repository lint (0 errors; 10 pre-existing warnings) and complete test suite
  - sync-core: 243 tests
  - sync-providers: 404 tests
  - release tooling: 24 tests
  - Angular/Karma: 13,294 tests, plus 13,280 in the alternate-timezone run
- SuperSync unit suite: 954 tests
- real PostgreSQL integration suite: 31 tests, including server-side statement cancellation and targeted timeout cleanup
- SuperSync TypeScript build
- required `checkFile` validation for every changed TypeScript file
- shell syntax and staged-diff checks
- Helm lint/render for bundled PostgreSQL, external literal URL, and external Secret configurations, including invalid boundary cases
- both production and local-build Docker Compose configurations
- independent multi-review plus a final post-fix review wave with no remaining actionable findings

Not exercised: a live Kubernetes hook lifecycle or production-scale saturation load test.
