### PR TITLE
perf(supersync): disable GIN fastupdate for conflict lookups

### DIFF
--- a/packages/super-sync-server/README.md
+++ b/packages/super-sync-server/README.md
@@ -77,7 +77,10 @@ Some migrations use `CREATE INDEX CONCURRENTLY`, which can block on long-running
 transactions on a busy database. Run deploys off-hours when applying schema
 changes, and raise `MIGRATION_TIMEOUT` (seconds, default `900`) if a large
 table requires more time. Exit code `124` from `deploy.sh` means the migration
-timed out — re-run after the blocking transaction clears.
+timed out — re-run after the blocking transaction clears. The
+`operations_entity_ids_gin` reloption migration instead has its own one-second
+index-lock timeout; if its one automatic retry also times out, clear the
+blocking transaction and re-run the deploy.
 
 If a deploy was interrupted after Prisma recorded a migration as failed, later
 deploys can stop with `P3009`. Prisma can also stop migrations with `P3018`
@@ -85,7 +88,21 @@ when they contain `CREATE/DROP INDEX CONCURRENTLY` statements, which cannot run
 in one transaction block. `scripts/migrate-deploy.sh` handles the safe
 drop-then-create concurrent-index case generically: it resolves the failed row
 when needed, applies the migration SQL outside Prisma migrate, marks the
-migration applied, and retries `migrate deploy`.
+migration applied, and retries `migrate deploy`. It also retries the exact
+lock-bounded `operations_entity_ids_gin` reloption migration natively; all
+other failed migration shapes stop for manual review.
+
+An application rollback does not require changing this index setting. If
+measured insert latency regresses after this rollout, restore PostgreSQL's
+default in a separately approved database change:
+
+```bash
+printf '%s\n' \
+  'BEGIN;' \
+  "SET LOCAL lock_timeout = '1s';" \
+  'ALTER INDEX "operations_entity_ids_gin" RESET (fastupdate);' \
+  'COMMIT;' | npx prisma db execute --schema prisma/schema.prisma --stdin
+```
 
 > **Existing databases created before the `0_init` baseline:** the migration
 > chain now begins with a `0_init` baseline that creates the base tables, so a
@@ -106,13 +123,29 @@ migration applied, and retries `migrate deploy`.
 >   ```
 >
 > - **Database created with `prisma db push`** (no migration history): its
->   schema already matches the latest `schema.prisma`, so baseline the whole
->   chain by marking every existing migration as applied.
+>   logical schema already matches the latest `schema.prisma`, but `db push`
+>   cannot represent the `operations_entity_ids_gin` storage reloption. Apply
+>   that database-only state and drain the old pending list before baselining
+>   the whole chain. The explicit transaction keeps `SET LOCAL` scoped to the
+>   `ALTER`; if its lock timeout fires, retry this off-hours.
 >
 >   ```bash
->   for m in prisma/migrations/*/; do
->     npx prisma migrate resolve --applied "$(basename "$m")"
->   done
+>   (
+>     set -e
+>     printf '%s\n' \
+>       'BEGIN;' \
+>       "SET LOCAL lock_timeout = '1s';" \
+>       'ALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);' \
+>       'COMMIT;' | npx prisma db execute --schema prisma/schema.prisma --stdin
+>     printf '%s\n' \
+>       'BEGIN;' \
+>       "SET LOCAL statement_timeout = '300s';" \
+>       "SELECT gin_clean_pending_list('operations_entity_ids_gin');" \
+>       'COMMIT;' | npx prisma db execute --schema prisma/schema.prisma --stdin
+>     for m in prisma/migrations/*/; do
+>       npx prisma migrate resolve --applied "$(basename "$m")"
+>     done
+>   )
 >   ```
 >
 > Fresh databases need none of this — `migrate deploy` applies `0_init` and the

--- a/packages/super-sync-server/prisma/migrations/20260720000000_disable_operation_entity_ids_gin_fastupdate/migration.sql
+++ b/packages/super-sync-server/prisma/migrations/20260720000000_disable_operation_entity_ids_gin_fastupdate/migration.sql
@@ -1,0 +1,4 @@
+-- Avoid accumulating a large pending list on an index dominated by empty arrays.
+-- The short timeout prevents the required index lock from queueing normal traffic.
+SET LOCAL lock_timeout = '1s';
+ALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);

--- a/packages/super-sync-server/prisma/migrations/20260720000001_clean_operation_entity_ids_gin_pending_list/migration.sql
+++ b/packages/super-sync-server/prisma/migrations/20260720000001_clean_operation_entity_ids_gin_pending_list/migration.sql
@@ -1,0 +1,3 @@
+-- Release the prior migration's index lock before draining existing entries.
+SET LOCAL statement_timeout = '300s';
+SELECT gin_clean_pending_list('operations_entity_ids_gin');

--- a/packages/super-sync-server/prisma/migrations/README.md
+++ b/packages/super-sync-server/prisma/migrations/README.md
@@ -8,10 +8,10 @@ block, so a CONCURRENTLY migration always fails the normal
 `scripts/migrate-deploy.sh` recovers from this generically: on that specific
 failure it reads the failing migration's name from Prisma's output, runs _that
 migration's own `migration.sql`_ out-of-band (no transaction,
-statement-by-statement), marks it applied, and retries. It hardcodes no
-migration names. Recovery is exercised by `tests/migrate-deploy-script.spec.ts`
-(behavioral, end-to-end) and `tests/migration-sql.spec.ts` (the migration SQL
-shapes the recovery relies on).
+statement-by-statement), marks it applied, and retries. The script also has one
+exact-shape recovery for the bounded `ALTER INDEX` described below. Recovery is
+exercised by `tests/migrate-deploy-script.spec.ts` (behavioral, end-to-end) and
+`tests/migration-sql.spec.ts` (the migration SQL shapes the recovery relies on).
 
 ## Prefer migrations that don't need recovery
 
@@ -27,6 +27,35 @@ Recovery is a safety net, not the happy path. Prefer, in order:
 Out-of-band recovery cost scales with the number of consecutive pending
 CONCURRENTLY migrations and the number of statements in each (one Prisma
 process per statement), so a large backlog deploy is intentionally slower.
+
+## Intentional exception: bounded `ALTER INDEX`
+
+`20260720000000_disable_operation_entity_ids_gin_fastupdate` has exactly two
+statements:
+
+```sql
+SET LOCAL lock_timeout = '1s';
+ALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);
+```
+
+The `ALTER INDEX` needs an `ACCESS EXCLUSIVE` lock on the GIN index. Without the
+short timeout, a waiting migration can queue new reads and writes behind it.
+`SET LOCAL` and the `ALTER` must stay in the same Prisma transaction, so this
+migration must never be split or executed out-of-band.
+
+A lock timeout leaves a failed Prisma migration record; a later deploy then
+sees only Prisma's cause-free `P3009`. Because the exact `ALTER` above is
+idempotent, the deploy script handles either state by marking the failed attempt
+rolled back and retrying it once through `prisma migrate deploy`. A repeated
+lock timeout or `P3009` is left rolled back; any different Prisma error fails
+loudly without being auto-resolved. The script never marks this migration
+applied itself.
+
+The following migration calls `gin_clean_pending_list` in a separate
+transaction, capped by a five-minute `statement_timeout`. Keep it separate so
+the index lock from the reloption change is released before cleanup starts. If
+cleanup times out, inspect database load, mark only that cleanup migration
+rolled back, and re-run the deploy; the cleanup call is safe to repeat.
 
 ## Rules for a recoverable CONCURRENTLY index migration
 

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -9,11 +9,18 @@ set -eu
 # transaction block"), and a later deploy then refuses with P3009 (the
 # migration is stuck in a failed state).
 #
-# This script applies migrations and, ONLY for that specific failure mode,
-# recovers by running the failing migration's own SQL out-of-band (no
-# transaction), then marks it applied and retries. It hardcodes no migration
-# names: the failing migration is read from Prisma's own output and its SQL is
-# read from prisma/migrations/<name>/migration.sql.
+# This script has two deliberately narrow recovery paths:
+#
+# 1. For the transaction-block failure above, it runs a migration with the safe
+#    DROP+CREATE CONCURRENTLY shape out-of-band, marks it applied, and retries.
+# 2. For the exact two-statement SET LOCAL lock_timeout + ALTER INDEX
+#    fastupdate=off shape, it rolls back Prisma's failed record and retries once
+#    through Prisma. It never splits or marks that transactional migration
+#    applied itself.
+#
+# Both paths discover the failing migration from Prisma's output and inspect
+# prisma/migrations/<name>/migration.sql. Anything matching neither guarded
+# recovery path fails loudly.
 #
 # A P1002 advisory-lock timeout (another session holds Prisma's migration lock,
 # usually a migrator container orphaned by a prior interrupted deploy) is NOT a
@@ -26,7 +33,7 @@ set -eu
 # invoke it, so it carries its own step timeout as defense-in-depth (deploy.sh
 # also wraps it; the CMD/initContainer paths have no outer timeout).
 #
-# RECOVERABLE shape (only this is auto-recovered): a migration whose SQL
+# OUT-OF-BAND RECOVERABLE shape: a migration whose SQL
 # contains BOTH a DROP INDEX CONCURRENTLY and a CREATE INDEX CONCURRENTLY, so
 # re-running it out-of-band is idempotent and clears a half-built INVALID index
 # first:
@@ -73,6 +80,7 @@ fi
 MIGRATE_LOG=""
 MIGRATE_STATUS=0
 LAST_RECOVERED=""
+LAST_NATIVE_RETRY=""
 
 STMT_FILE="$(mktemp "${TMPDIR:-/tmp}/supersync-stmts.XXXXXX")"
 cleanup() {
@@ -123,13 +131,24 @@ log_has() {
   grep -q "$1" "$MIGRATE_LOG"
 }
 
+log_has_line() {
+  grep -Eq "$1" "$MIGRATE_LOG"
+}
+
 is_transaction_block_failure() {
-  log_has 'P3018' &&
-    { log_has 'cannot run inside a transaction block' || log_has '25001'; }
+  log_has_line '^Error: P3018[[:space:]]*$' &&
+    { log_has_line '^ERROR: .*cannot run inside a transaction block[[:space:]]*$' ||
+      log_has_line '^Database error code: 25001[[:space:]]*$'; }
+}
+
+is_lock_timeout_failure() {
+  log_has_line '^Error: P3018[[:space:]]*$' &&
+    { log_has_line '^ERROR: canceling statement due to lock timeout[[:space:]]*$' ||
+      log_has_line '^Database error code: 55P03[[:space:]]*$'; }
 }
 
 is_stuck_failed_migration() {
-  log_has 'P3009'
+  log_has_line '^Error: P3009[[:space:]]*$'
 }
 
 # A P1002 whose message names the advisory lock: another DB session holds
@@ -178,6 +197,24 @@ split_statements() {
     }
     END { if (stmt != "") print stmt }
   ' "$1"
+}
+
+# This migration needs native Prisma transaction semantics: SET LOCAL must
+# apply to the ALTER, and a successful native retry must be what records the
+# migration as applied. Keep the gate exact so no unrelated failed migration is
+# ever rolled back automatically.
+is_retryable_fastupdate_migration() {
+  sql="$1"
+  [ -f "$sql" ] || return 1
+
+  split_statements "$sql" > "$STMT_FILE"
+  first_stmt="$(sed -n '1p' "$STMT_FILE")"
+  second_stmt="$(sed -n '2p' "$STMT_FILE")"
+  third_stmt="$(sed -n '3p' "$STMT_FILE")"
+
+  [ "$first_stmt" = "SET LOCAL lock_timeout = '1s';" ] &&
+    [ "$second_stmt" = 'ALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);' ] &&
+    [ -z "$third_stmt" ]
 }
 
 # Single-quote a value for safe shell paste (a'b -> 'a'\''b').
@@ -309,6 +346,20 @@ recover_migration() {
   echo "    $name applied out-of-band and marked applied."
 }
 
+rollback_for_native_retry() {
+  name="$1"
+
+  echo ""
+  echo "==> Rolling back failed migration record for bounded native retry: $name"
+  set +e
+  with_timeout npx prisma migrate resolve --rolled-back "$name"
+  resolve_status=$?
+  set -e
+  if [ "$resolve_status" -ne 0 ]; then
+    fail_loudly "could not mark $name rolled back; refusing to retry it." 1
+  fi
+}
+
 attempt=0
 while :; do
   run_migrate_deploy
@@ -325,12 +376,7 @@ while :; do
     fail_loudly "prisma migrate deploy timed out after ${STEP_TIMEOUT}s (a long-running transaction may be blocking CREATE/DROP INDEX CONCURRENTLY). Clear the blocker, then raise MIGRATION_TIMEOUT (it forwards to MIGRATE_STEP_TIMEOUT) and re-run." 1
   fi
 
-  attempt=$((attempt + 1))
-  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-    fail_loudly "prisma migrate deploy still failing after $attempt attempts."
-  fi
-
-  if ! is_transaction_block_failure && ! is_stuck_failed_migration; then
+  if ! is_transaction_block_failure && ! is_lock_timeout_failure && ! is_stuck_failed_migration; then
     if is_advisory_lock_timeout; then
       # Not a migration failure (nothing was applied) — print cleanup guidance
       # and fail loudly. Rationale is on is_advisory_lock_timeout / the emitter.
@@ -354,6 +400,34 @@ while :; do
   fi
 
   sql="$(migration_sql_path "$name")"
+
+  # ALTER INDEX ... fastupdate takes ACCESS EXCLUSIVE on the hot GIN index.
+  # Its 1s lock_timeout intentionally fails rather than queueing normal reads
+  # and writes behind a waiting DDL lock. Prisma records that timeout as a
+  # failed migration, so clear the failed row and retry the exact atomic,
+  # idempotent migration once using Prisma itself. Never split/execute it
+  # out-of-band: SET LOCAL would expire before the ALTER.
+  if is_retryable_fastupdate_migration "$sql" &&
+    { is_lock_timeout_failure || is_stuck_failed_migration; }; then
+    rollback_for_native_retry "$name"
+    if [ "$name" = "$LAST_NATIVE_RETRY" ]; then
+      fail_loudly "$name failed again after its bounded native retry and was left rolled back; inspect the Prisma error above, clear the blocker, and re-run the deploy." 1
+    fi
+    LAST_NATIVE_RETRY="$name"
+    echo ""
+    echo "==> Retrying prisma migrate deploy after bounded native recovery for $name..."
+    continue
+  fi
+
+  if is_lock_timeout_failure; then
+    fail_loudly "$name is not the exact bounded fastupdate migration; refusing to auto-resolve its lock timeout."
+  fi
+
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    fail_loudly "prisma migrate deploy still failing after $attempt attempts."
+  fi
+
   if ! is_recoverable_concurrently_migration "$sql"; then
     if is_bare_create_concurrently "$sql"; then
       print_bare_create_recovery "$name" "$sql"

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -12,8 +12,8 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-// Drives scripts/migrate-deploy.sh end-to-end with a fake `npx prisma` so the
-// generic CONCURRENTLY recovery logic is exercised without a real database.
+// Drives scripts/migrate-deploy.sh end-to-end with a fake `npx prisma` so its
+// guarded recovery paths are exercised without a real database.
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(currentDir, '../scripts/migrate-deploy.sh');
@@ -27,12 +27,19 @@ CREATE INDEX CONCURRENTLY "operations_user_id_server_seq_encrypted_idx"
 const PLAIN_MIGRATION = '20260601000000_add_plain_column';
 const PLAIN_SQL = `ALTER TABLE "operations" ADD COLUMN "foo" TEXT;`;
 
+const FASTUPDATE_MIGRATION = '20260720000000_disable_operation_entity_ids_gin_fastupdate';
+const FASTUPDATE_SQL = readFileSync(
+  join(currentDir, '../prisma/migrations', FASTUPDATE_MIGRATION, 'migration.sql'),
+  'utf8',
+);
+
 interface RunResult {
   status: number;
   stdout: string;
   executedSql: string;
   resolveApplied: string[];
   resolveRolledBack: string[];
+  deployAttempts: number;
 }
 
 let projectDir: string;
@@ -57,6 +64,7 @@ case "$sub" in
     action="$1"; shift
     case "$action" in
       deploy)
+        echo deploy >> "$state/deploy_attempts"
         for m in $FAKE_FAIL; do
           if [ ! -f "$state/applied_$m" ]; then
             case "$FAKE_CODE" in
@@ -69,7 +77,25 @@ case "$sub" in
                 echo "Database error:"
                 echo "ERROR: DROP INDEX CONCURRENTLY cannot run inside a transaction block"
                 ;;
+              LOCK_TIMEOUT)
+                if [ "\${FAKE_LOCK_TIMEOUT_ALWAYS:-0}" != "1" ] && [ -f "$state/lock_timeout_seen_$m" ]; then
+                  : > "$state/applied_$m"
+                  continue
+                fi
+                : > "$state/lock_timeout_seen_$m"
+                echo "Applying migration \\\`$m\\\`"
+                echo "Error: P3018"
+                echo "A migration failed to apply. New migrations cannot be applied before the error is recovered from."
+                echo "Migration name: $m"
+                echo "Database error code: 55P03"
+                echo "Database error:"
+                echo "ERROR: canceling statement due to lock timeout"
+                ;;
               P3009)
+                if [ -f "$state/rolledback_$m" ]; then
+                  : > "$state/applied_$m"
+                  continue
+                fi
                 echo "Error: P3009"
                 echo "migrate found failed migrations in the target database, new migrations will not be applied."
                 echo "The \\\`$m\\\` migration started at 2026-05-15 failed"
@@ -94,6 +120,11 @@ case "$sub" in
                 echo "The database server was reached but timed out."
                 echo "Context: Timed out trying to acquire a postgres advisory lock (SELECT pg_advisory_lock(72707369)). Elapsed: 10000ms."
                 ;;
+              DECOY_CODES)
+                echo "Applying migration \\\`$m\\\`"
+                echo "Error: P1001"
+                echo "Diagnostic context only: P3018 P3009 25001 55P03"
+                ;;
               *)
                 echo "Error: P1001"
                 echo "Can't reach database server"
@@ -109,7 +140,12 @@ case "$sub" in
         mode="$1"; name="$2"
         if [ "$mode" = "--rolled-back" ]; then
           echo "$name" >> "$state/rolledback"
-          exit "\${FAKE_ROLLEDBACK_EXIT:-0}"
+          rolledback_exit="\${FAKE_ROLLEDBACK_EXIT:-0}"
+          if [ "$rolledback_exit" -ne 0 ]; then
+            exit "$rolledback_exit"
+          fi
+          : > "$state/rolledback_$name"
+          exit 0
         fi
         echo "$name" >> "$state/applied_list"
         [ "\${FAKE_MARK:-1}" = "1" ] && : > "$state/applied_$name"
@@ -161,6 +197,7 @@ const run = (env: Record<string, string>): RunResult => {
     executedSql: read('executed_sql'),
     resolveApplied: read('applied_list').split('\n').filter(Boolean),
     resolveRolledBack: read('rolledback').split('\n').filter(Boolean),
+    deployAttempts: read('deploy_attempts').split('\n').filter(Boolean).length,
   };
 };
 
@@ -181,7 +218,7 @@ afterEach(() => {
   }
 });
 
-describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
+describe('migrate-deploy.sh recovery', () => {
   it('clean deploy with no failures exits 0 and runs no recovery', () => {
     const r = run({ FAKE_FAIL: '', FAKE_CODE: 'P3018' });
     expect(r.status).toBe(0);
@@ -224,6 +261,114 @@ describe('migrate-deploy.sh generic CONCURRENTLY recovery', () => {
     expect(r.status).not.toBe(0);
     expect(r.stdout).toContain('refusing to auto-resolve');
     expect(r.resolveApplied).toEqual([]);
+  });
+
+  it('rolls back and retries the bounded fastupdate migration natively after a lock timeout', () => {
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({ FAKE_FAIL: FASTUPDATE_MIGRATION, FAKE_CODE: 'LOCK_TIMEOUT' });
+
+    expect(r.status).toBe(0);
+    expect(r.deployAttempts).toBe(2);
+    expect(r.resolveRolledBack).toEqual([FASTUPDATE_MIGRATION]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+  });
+
+  it('clears the failed row and exits cleanly retryable after a repeated fastupdate lock timeout', () => {
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({
+      FAKE_FAIL: FASTUPDATE_MIGRATION,
+      FAKE_CODE: 'LOCK_TIMEOUT',
+      FAKE_LOCK_TIMEOUT_ALWAYS: '1',
+    });
+
+    expect(r.status).not.toBe(0);
+    expect(r.deployAttempts).toBe(2);
+    expect(r.resolveRolledBack).toEqual([FASTUPDATE_MIGRATION, FASTUPDATE_MIGRATION]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+    expect(r.stdout).toContain(
+      'failed again after its bounded native retry and was left rolled back',
+    );
+  });
+
+  it('recovers a pre-existing failed fastupdate migration and retries it natively', () => {
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({ FAKE_FAIL: FASTUPDATE_MIGRATION, FAKE_CODE: 'P3009' });
+
+    expect(r.status).toBe(0);
+    expect(r.deployAttempts).toBe(2);
+    expect(r.resolveRolledBack).toEqual([FASTUPDATE_MIGRATION]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+  });
+
+  it('stops without retrying when rollback resolution fails for fastupdate', () => {
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({
+      FAKE_FAIL: FASTUPDATE_MIGRATION,
+      FAKE_CODE: 'LOCK_TIMEOUT',
+      FAKE_ROLLEDBACK_EXIT: '1',
+    });
+
+    expect(r.status).not.toBe(0);
+    expect(r.deployAttempts).toBe(1);
+    expect(r.resolveRolledBack).toEqual([FASTUPDATE_MIGRATION]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+  });
+
+  it.each([
+    {
+      label: 'an extra statement',
+      sql: `${FASTUPDATE_SQL}\nSELECT 1;`,
+    },
+    {
+      label: 'another index',
+      sql: `SET LOCAL lock_timeout = '1s';\nALTER INDEX "another_gin" SET (fastupdate = off);`,
+    },
+    {
+      label: 'fastupdate enabled',
+      sql: `SET LOCAL lock_timeout = '1s';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = on);`,
+    },
+  ])('refuses lock-timeout recovery for $label', ({ sql }) => {
+    writeMigration(FASTUPDATE_MIGRATION, sql);
+
+    const r = run({ FAKE_FAIL: FASTUPDATE_MIGRATION, FAKE_CODE: 'LOCK_TIMEOUT' });
+
+    expect(r.status).not.toBe(0);
+    expect(r.deployAttempts).toBe(1);
+    expect(r.resolveRolledBack).toEqual([]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+  });
+
+  it('does not recover the fastupdate shape for a non-lock P3018 failure', () => {
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({ FAKE_FAIL: FASTUPDATE_MIGRATION, FAKE_CODE: 'P3018' });
+
+    expect(r.status).not.toBe(0);
+    expect(r.deployAttempts).toBe(1);
+    expect(r.resolveRolledBack).toEqual([]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+  });
+
+  it('does not treat diagnostic code substrings as a recoverable error', () => {
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({ FAKE_FAIL: FASTUPDATE_MIGRATION, FAKE_CODE: 'DECOY_CODES' });
+
+    expect(r.status).not.toBe(0);
+    expect(r.deployAttempts).toBe(1);
+    expect(r.resolveRolledBack).toEqual([]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
   });
 
   it('refuses a bare CREATE INDEX CONCURRENTLY (intentionally fail-loud, no DROP)', () => {

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -163,6 +163,60 @@ describe('performance migrations', () => {
     expect(migrationSql).not.toMatch(/\bALTER\s+TABLE\b/i);
     expect(migrationSql).not.toMatch(/\bDROP\s+TABLE\b/i);
     expect(migrationSql).not.toMatch(/\bBEGIN\b|\bCOMMIT\b/i);
+    // This migration is already applied in production. Changing it to set the
+    // reloption or clean the pending list would break its Prisma checksum.
+    expect(migrationSql).not.toMatch(/\bALTER\s+INDEX\b|\bfastupdate\b/i);
+    expect(migrationSql).not.toMatch(/\bgin_clean_pending_list\b/i);
+  });
+
+  it('disables entity_ids GIN fastupdate in a lock-bounded forward migration', () => {
+    const migrationSql = readMigration(
+      '20260720000000_disable_operation_entity_ids_gin_fastupdate',
+    );
+    const lockTimeout = migrationSql.match(
+      /\bSET\s+LOCAL\s+lock_timeout\s*=\s*'(\d+)(ms|s)'\s*;/i,
+    );
+    const alterIndex = migrationSql.match(
+      /\bALTER\s+INDEX\s+"operations_entity_ids_gin"\s+SET\s*\(\s*fastupdate\s*=\s*off\s*\)\s*;/i,
+    );
+    const lockTimeoutMs =
+      Number(lockTimeout?.[1]) * (lockTimeout?.[2].toLowerCase() === 's' ? 1000 : 1);
+
+    expect(lockTimeout).not.toBeNull();
+    expect(lockTimeoutMs).toBeGreaterThan(0);
+    expect(lockTimeoutMs).toBeLessThanOrEqual(5000);
+    expect(alterIndex).not.toBeNull();
+    expect(alterIndex?.index ?? -1).toBeGreaterThan(lockTimeout?.index ?? -1);
+    expect(migrationSql).not.toMatch(/\bgin_clean_pending_list\b|\bVACUUM\b/i);
+    expect(migrationSql).not.toMatch(/\bBEGIN\b|\bCOMMIT\b/i);
+  });
+
+  it('cleans the entity_ids GIN pending list only after the ALTER migration commits', () => {
+    const alterMigrationName =
+      '20260720000000_disable_operation_entity_ids_gin_fastupdate';
+    const cleanupMigrationName =
+      '20260720000001_clean_operation_entity_ids_gin_pending_list';
+    const cleanupSql = readMigration(cleanupMigrationName);
+    const statementTimeout = cleanupSql.match(
+      /\bSET\s+LOCAL\s+statement_timeout\s*=\s*'(\d+)(ms|s)'\s*;/i,
+    );
+    const statementTimeoutMs =
+      Number(statementTimeout?.[1]) *
+      (statementTimeout?.[2].toLowerCase() === 's' ? 1000 : 1);
+
+    // Prisma wraps each migration independently, so the consecutive directory
+    // is a separate transaction and cannot extend the ALTER's exclusive lock.
+    expect(cleanupMigrationName > alterMigrationName).toBe(true);
+    const cleanup = cleanupSql.match(
+      /\bSELECT\s+(?:pg_catalog\.)?gin_clean_pending_list\s*\([^)]*operations_entity_ids_gin[^)]*\)\s*;/i,
+    );
+    expect(statementTimeout).not.toBeNull();
+    expect(statementTimeoutMs).toBeGreaterThan(0);
+    expect(statementTimeoutMs).toBeLessThanOrEqual(300_000);
+    expect(cleanup).not.toBeNull();
+    expect(cleanup?.index ?? -1).toBeGreaterThan(statementTimeout?.index ?? -1);
+    expect(cleanupSql).not.toMatch(/\bALTER\s+INDEX\b|\bfastupdate\b|\bVACUUM\b/i);
+    expect(cleanupSql).not.toMatch(/\bBEGIN\b|\bCOMMIT\b/i);
   });
 
   it('runs migrations before replacing the app during compose deploys', () => {


### PR DESCRIPTION
## Summary

- disable `fastupdate` on `operations_entity_ids_gin` behind a one-second lock timeout
- drain the existing GIN pending list in a separate, statement-bounded migration
- recover only the exact Prisma lock-timeout/P3009 state by rolling back and retrying the migration natively once
- document `db push` baselining and emergency rollback

## Why

Production measurements in #9204 showed generic conflict probes spending about 315 ms scanning the GIN pending list. That lookup runs twice per default single-operation upload, so the pending-list cost was paid repeatedly.

## Safety and impact

The reloption migration fails quickly instead of waiting on a busy index. The deploy wrapper handles only the known failed-migration shape and otherwise fails closed. PostgreSQL 16 benchmarking showed single-write throughput within about 2% of `fastupdate=on`, with about 7% less WAL; batch behavior stayed stable once pending-list cleanup was removed from the write path.

## Validation

- `npm test` in `packages/super-sync-server` — 45 files and 928 tests passed
- `npm run build` in `packages/super-sync-server`
- required `npm run checkFile` checks for both modified TypeScript specs
- `sh -n packages/super-sync-server/scripts/migrate-deploy.sh`
- `git diff --check`
- PostgreSQL 16 lock-timeout, reloption, pending-list cleanup, rollback, and fresh 22-migration-chain verification
- repository pre-push gate: lint, package tests, 13,306 default-timezone browser tests, and 13,292 Los Angeles-timezone browser tests passed

Closes #9204
