### PR TITLE
fix(plugin): dispatch FINISH_DAY action so the finishDay plugin hook fires

### DIFF
--- a/src/app/pages/daily-summary/daily-summary.component.ts
+++ b/src/app/pages/daily-summary/daily-summary.component.ts
@@ -37,7 +37,7 @@ import {
 import { DateService } from 'src/app/core/date/date.service';
 
 import { EntityState } from '@ngrx/entity';
-import { Action } from '@ngrx/store';
+import { Action, Store } from '@ngrx/store';
 import { TranslatePipe, TranslateService, TranslateStore } from '@ngx-translate/core';
 
 import { IS_ELECTRON } from '../../app.constants';
@@ -126,6 +126,7 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
   private readonly _syncWrapperService = inject(SyncWrapperService);
   private readonly _operationWriteFlushService = inject(OperationWriteFlushService);
   private readonly _beforeFinishDayService = inject(BeforeFinishDayService);
+  private readonly _store = inject(Store);
   private readonly _simpleCounterService = inject(SimpleCounterService);
   private readonly _dateService = inject(DateService);
   private readonly _metricService = inject(MetricService);
@@ -341,6 +342,11 @@ export class DailySummaryComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   async finishDay(): Promise<void> {
+    // Notify plugins (finishDay hook) before the day is wrapped up and tasks are
+    // archived — the plugin-hooks effect listens for the FINISH_DAY action.
+    this.actionsToExecuteBeforeFinishDay.forEach((action) =>
+      this._store.dispatch(action),
+    );
     try {
       await this._beforeFinishDayService.executeActions();
       // Wait for any ongoing sync to complete before archiving to avoid DB lock errors.


### PR DESCRIPTION
## Problem

The `finishDay` plugin hook (`PluginHooks.FINISH_DAY`) can be registered successfully, but it **never fires** — the NgRx action it listens for is never dispatched anywhere in the app.

There are exactly two references to the `FINISH_DAY` action type in `src/`:

1. The effect that forwards it to plugins ([`plugin-hooks.effects.ts`](https://github.com/johannesjo/super-productivity/blob/master/src/app/plugins/plugin-hooks.effects.ts#L249-L257)):

   ```ts
   finishDay$ = createEffect(
     () =>
       this.actions$.pipe(
         filter((action) => action.type === 'FINISH_DAY'),
         tap(() => {
           this.pluginService.dispatchHook(PluginHooks.FINISH_DAY);
         }),
       ),
     { dispatch: false },
   );
   ```

2. The `actionsToExecuteBeforeFinishDay` field in `daily-summary.component.ts`, which defines `[{ type: 'FINISH_DAY' }]` but was never referenced anywhere — dead code.

Since nothing dispatches the action, the effect's filter never matches and `dispatchHook(PluginHooks.FINISH_DAY)` is never called — for any plugin, web or desktop. (The built-in issue-provider integrations are unaffected because they use the internal `BeforeFinishDayService.addAction()`, which is not reachable from the plugin API.)

### Steps to reproduce

1. Install a plugin that declares `"hooks": ["finishDay"]` and calls `api.registerHook('finishDay', () => console.log('finishDay fired'))`.
2. The console confirms registration: `Plugin <id> registered hook: finishDay`.
3. Go to the daily summary and click *Finish day* — the callback is never invoked.

## Fix

Dispatch the actions from the existing `actionsToExecuteBeforeFinishDay` field at the start of `DailySummaryComponent.finishDay()`, so plugins are notified before the day is wrapped up and done tasks are archived. This wires up the field as originally intended and keeps the hook's fire-and-forget semantics (the effect uses `tap`, archiving is not blocked on plugin handlers).

## Verification

Diagnosed and verified with a live plugin (an issue-provider plugin that books tracked time to GitLab on finish day) against v18.15.1: hook registration succeeds but the handler never runs when finishing the day; after dispatching `FINISH_DAY` the handler runs as expected. Also verified via source search that no other dispatcher of this action exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
