### PR TITLE
fix(backup): show the Windows Store backup path only when it exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ npm run prettier               # multi-file format
 npm run lint                   # multi-file lint
 npm test                       # all unit tests (Jasmine/Karma, .spec.ts co-located)
 npm run test:file <filepath>   # single spec
+npm run test:electron          # main-process tests — `electron/*.test.cjs`, NOT .spec.ts
+                               # (tsconfig.electron.json excludes *.spec.ts, so a spec
+                               #  placed under electron/ silently never runs)
 npm run e2e                    # all E2E (Playwright, slow)
 npm run e2e:file <path> -- --retries=0   # single E2E (~20s/test); add --grep "name" for one test
 npm start                      # Electron dev

--- a/docs/wiki/2.09-Configure-Sync-Backend.md
+++ b/docs/wiki/2.09-Configure-Sync-Backend.md
@@ -17,6 +17,7 @@ The rest of the form depends on the selected provider. Common options (sync inte
 - **Info:** The app shows a short note that SuperSync keeps your tasks in sync across devices in real time and that data is stored on the sync server. SuperSync is currently in Beta.
 - **Get a token:** Click **Open Server & Get Token** to open the server login page in your browser. After logging in, copy your access token.
 - **Access Token:** Paste the token into the **Access Token** field. Required for SuperSync.
+- **Multiple devices:** You can reuse the same access token on every device or sign in separately on each device to get another token. Both options connect to the same SuperSync account and synchronize the same data. Do not use **Revoke & Replace Token** when adding a device; it invalidates all existing tokens and disconnects every device.
 - **Advanced:** Under **Advanced**, you can set a custom **Server URL** (leave as-is for the official server). Here you can also **Enable Encryption** for end-to-end encryption; the app shows warnings about password loss and server data being replaced.
 - **Encryption:** If encryption is enabled, you can **Change Password** or **Disable Encryption** from the same form. These actions replace server data and require the same password on all devices (or re-upload with a new password).
 
@@ -42,6 +43,7 @@ OneDrive sync requires your own **Microsoft Entra** (Azure AD) app registration 
    - **Android / manual fallback:** `https://login.microsoftonline.com/common/oauth2/nativeclient`
 
    Do **not** register these under the **Web** or **Single-page application (SPA)** platforms — token redemption then fails with `HTTP 400` (e.g. `AADSTS9002327`).
+
 2. **Allow public client flows:** In **Authentication**, set **Allow public client flows** to **Yes**. Super Productivity authenticates with PKCE and sends no client secret; if this is **No**, sign-in appears to succeed but the token step fails with `HTTP 400 Bad Request` (`AADSTS7000218: ... 'client_assertion' or 'client_secret'`).
 3. **API permissions:** Under **API permissions**, add the Microsoft Graph **delegated** permissions `Files.ReadWrite.AppFolder` and `offline_access`.
 

--- a/docs/wiki/3.06-User-Data.md
+++ b/docs/wiki/3.06-User-Data.md
@@ -41,7 +41,7 @@ For Snap packages on Linux, the app uses the `SNAP_USER_COMMON` directory so tha
 
 ### Windows Store
 
-The Windows Store build uses a different path that includes the Windows Store package identifier (under `Local\Packages\...\LocalCache\Roaming` instead of `Roaming`).
+The Windows Store build may use a different path that includes the Windows Store package identifier (under `Local\Packages\...\LocalCache\Roaming` instead of `Roaming`). This depends on whether Windows virtualizes the package: virtualized packages have their `AppData` writes redirected into `LocalCache`, while full-trust ones write to the plain `Roaming` path. Settings shows whichever location actually exists on your machine, so check there rather than assuming either one.
 
 ## Directory Structure
 

--- a/electron/backup.test.cjs
+++ b/electron/backup.test.cjs
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+require('ts-node/register/transpile-only');
+
+const originalModuleLoad = Module._load;
+const backupModulePath = path.resolve(__dirname, 'backup.ts');
+
+// Windows-shaped so the `.replace('Roaming', ...)` derivation actually fires on
+// Linux/macOS CI too — otherwise BACKUP_DIR_WINSTORE would equal BACKUP_DIR and
+// every assertion below would pass vacuously.
+const USER_DATA = 'C:\\Users\\testuser\\AppData\\Roaming\\superProductivity';
+// path.join, like the module under test — the separator is the host's, not '\'.
+const BACKUP_DIR = path.join(USER_DATA, 'backups');
+const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace(
+  'Roaming',
+  'Local\\Packages\\53707johannesjo.SuperProductivity_ch45amy23cdv6\\LocalCache\\Roaming',
+);
+
+let existingPaths;
+
+const resetModule = () => {
+  delete require.cache[backupModulePath];
+};
+
+const installMocks = () => {
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        app: { getPath: () => USER_DATA },
+        ipcMain: { on: () => {}, handle: () => {} },
+      };
+    }
+
+    if (request === 'electron-log/main') {
+      return { log: () => {}, error: () => {} };
+    }
+
+    // Scoped to backup.ts so ts-node / node:test keep the real fs.
+    if (
+      request === 'fs' &&
+      parent &&
+      typeof parent.filename === 'string' &&
+      parent.filename.endsWith('backup.ts')
+    ) {
+      const realFs = originalModuleLoad.call(this, request, parent, isMain);
+      return { ...realFs, existsSync: (p) => existingPaths.has(p) };
+    }
+
+    return originalModuleLoad.call(this, request, parent, isMain);
+  };
+};
+
+const loadBackupModule = () => {
+  resetModule();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require(backupModulePath);
+};
+
+test.beforeEach(() => {
+  existingPaths = new Set();
+  installMocks();
+});
+
+test.afterEach(() => {
+  Module._load = originalModuleLoad;
+  delete process.windowsStore;
+  resetModule();
+});
+
+// Sanity check: without this the Windows-only branches below could never be
+// reached on a Linux CI runner and the suite would be green for the wrong reason.
+test('derives a distinct Windows Store path from the userData path', () => {
+  assert.notEqual(BACKUP_DIR_WINSTORE, BACKUP_DIR);
+  assert.match(BACKUP_DIR_WINSTORE, /LocalCache\\Roaming/);
+});
+
+test('non-Store builds always get the real backup dir', () => {
+  const { getBackupDirForDisplay } = loadBackupModule();
+
+  // Even if a LocalCache dir is left over from a previous Store install.
+  existingPaths.add(BACKUP_DIR_WINSTORE);
+
+  assert.equal(getBackupDirForDisplay(), BACKUP_DIR);
+});
+
+// Regression test for #995: a virtualized Store package redirects its writes
+// into LocalCache, so showing the plain Roaming path sends the user to a folder
+// their backups are not in.
+test('Store builds get the LocalCache path when it exists', () => {
+  process.windowsStore = true;
+  const { getBackupDirForDisplay } = loadBackupModule();
+
+  existingPaths.add(BACKUP_DIR_WINSTORE);
+
+  assert.equal(getBackupDirForDisplay(), BACKUP_DIR_WINSTORE);
+});
+
+// Regression test for #9209: a non-virtualized Store package writes to the real
+// AppData\Roaming, so the LocalCache path does not exist and must not be shown.
+test('Store builds fall back to the real backup dir when LocalCache is absent', () => {
+  process.windowsStore = true;
+  const { getBackupDirForDisplay } = loadBackupModule();
+
+  existingPaths.add(BACKUP_DIR);
+
+  assert.equal(getBackupDirForDisplay(), BACKUP_DIR);
+});

--- a/electron/backup.ts
+++ b/electron/backup.ts
@@ -24,21 +24,17 @@ import {
 export const BACKUP_DIR = path.join(app.getPath('userData'), `backups`);
 
 /**
- * Where a *virtualized* MSIX package's writes to BACKUP_DIR physically land, so
- * that Explorer (which runs outside the package and does not see the
- * redirection) can be pointed at them. We never write here, and never read
- * backup files from here on our own initiative — but `BACKUP_LOAD_DATA` below
- * does accept it as a second allow-listed read root, so it is not inert.
- * Only ever reached through `getBackupDirForDisplay()`, which verifies it.
+ * Where a virtualized MSIX package's writes to BACKUP_DIR physically land, so
+ * Explorer (which runs outside the package and sees no redirection) can be
+ * pointed at them. Display-oriented but not inert: `BACKUP_LOAD_DATA` below
+ * also accepts it as an allow-listed read root.
  *
- * shortcut: the package family name is hardcoded, and nothing in CI would
- * notice it drifting — the appx config lives in the WIN_STORE_ELECTRON_BUILDER_YML
- * secret. Drift degrades gracefully (the probe fails and we show BACKUP_DIR).
- * Verified against the shipped v18.15.1 appx on 2026-07-21: it is exactly
- * `<Identity Name>` + '_' + PublisherId, where PublisherId is the first 8 bytes
- * of SHA-256 over the UTF-16LE `<Identity Publisher>` in base32 (digits + a-z
- * minus i/l/o/u), so it can be re-checked from any release artifact without a
- * Windows machine.
+ * shortcut: the package family name is hardcoded and nothing in CI would notice
+ * it drifting (the appx config lives in the WIN_STORE_ELECTRON_BUILDER_YML
+ * secret); drift just fails the probe and we show BACKUP_DIR. Verified against
+ * the shipped v18.15.1 appx on 2026-07-21 — it is `<Identity Name>_<PublisherId>`,
+ * PublisherId being base32(SHA-256(UTF-16LE Publisher)[0..8]), so any release
+ * artifact re-checks it without a Windows machine.
  */
 const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace(
   'Roaming',
@@ -47,18 +43,15 @@ const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace(
 
 /**
  * The backup location to *show* the user, which is not always the one we write
- * to: a virtualized MSIX package has its AppData writes redirected into the
- * package's private LocalCache. That redirection applies only to virtualized
- * packages and, since Windows 10 1903, is decided per file — so it cannot be
- * known statically. Assuming it always applies is what made #9209 the mirror
- * image of #995.
+ * to. Redirection applies only to virtualized packages and, since Windows 10
+ * 1903, is decided per file — it cannot be known statically, and assuming it
+ * always applies is what made #9209 the mirror image of #995.
  *
  * shortcut: an install that flipped from virtualized to full-trust keeps a
- * stale LocalCache dir, which still wins the probe — the user would be shown
- * real but outdated backups. Accepted because restore reads BACKUP_DIR either
- * way, so only manual recovery is affected. Upgrade path if it gets reported:
- * probe for the newest filename in BACKUP_DIR (timestamps sort lexically)
- * rather than for the directory, which pins where the last write actually went.
+ * stale LocalCache dir that still wins the probe, showing real but outdated
+ * backups. Accepted — restore reads BACKUP_DIR either way, so only manual
+ * recovery is affected. Upgrade path: probe for the newest filename in
+ * BACKUP_DIR (timestamps sort lexically) instead of for the directory.
  */
 export const getBackupDirForDisplay = (): string =>
   process.windowsStore && existsSync(BACKUP_DIR_WINSTORE)

--- a/electron/backup.ts
+++ b/electron/backup.ts
@@ -31,11 +31,14 @@ export const BACKUP_DIR = path.join(app.getPath('userData'), `backups`);
  * does accept it as a second allow-listed read root, so it is not inert.
  * Only ever reached through `getBackupDirForDisplay()`, which verifies it.
  *
- * shortcut: the package family name is hardcoded and cannot be verified from
- * source — the appx config lives in the WIN_STORE_ELECTRON_BUILDER_YML secret,
- * so nothing in CI would notice it drifting. Drift degrades gracefully (the
- * probe fails and we show BACKUP_DIR). Upgrade path if it ever changes: derive
- * `<name>_<publisherHash>` from the WindowsApps segment of process.execPath.
+ * shortcut: the package family name is hardcoded, and nothing in CI would
+ * notice it drifting — the appx config lives in the WIN_STORE_ELECTRON_BUILDER_YML
+ * secret. Drift degrades gracefully (the probe fails and we show BACKUP_DIR).
+ * Verified against the shipped v18.15.1 appx on 2026-07-21: it is exactly
+ * `<Identity Name>` + '_' + PublisherId, where PublisherId is the first 8 bytes
+ * of SHA-256 over the UTF-16LE `<Identity Publisher>` in base32 (digits + a-z
+ * minus i/l/o/u), so it can be re-checked from any release artifact without a
+ * Windows machine.
  */
 const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace(
   'Roaming',

--- a/electron/backup.ts
+++ b/electron/backup.ts
@@ -22,16 +22,45 @@ import {
 } from './shared-with-frontend/backup-file-cleanup.util';
 
 export const BACKUP_DIR = path.join(app.getPath('userData'), `backups`);
+
 /**
- * Where the Windows Store build's backups end up on disk *if* the package is
- * virtualized — never a path we read or write ourselves, and not guaranteed to
- * exist. Only for showing the user a location they can open outside the package
- * sandbox; check `existsSync` before displaying it (#995, #9209).
+ * Where a *virtualized* MSIX package's writes to BACKUP_DIR physically land, so
+ * that Explorer (which runs outside the package and does not see the
+ * redirection) can be pointed at them. We never write here, and never read
+ * backup files from here on our own initiative — but `BACKUP_LOAD_DATA` below
+ * does accept it as a second allow-listed read root, so it is not inert.
+ * Only ever reached through `getBackupDirForDisplay()`, which verifies it.
+ *
+ * shortcut: the package family name is hardcoded and cannot be verified from
+ * source — the appx config lives in the WIN_STORE_ELECTRON_BUILDER_YML secret,
+ * so nothing in CI would notice it drifting. Drift degrades gracefully (the
+ * probe fails and we show BACKUP_DIR). Upgrade path if it ever changes: derive
+ * `<name>_<publisherHash>` from the WindowsApps segment of process.execPath.
  */
-export const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace(
+const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace(
   'Roaming',
   `Local\\Packages\\53707johannesjo.SuperProductivity_ch45amy23cdv6\\LocalCache\\Roaming`,
 );
+
+/**
+ * The backup location to *show* the user, which is not always the one we write
+ * to: a virtualized MSIX package has its AppData writes redirected into the
+ * package's private LocalCache. That redirection applies only to virtualized
+ * packages and, since Windows 10 1903, is decided per file — so it cannot be
+ * known statically. Assuming it always applies is what made #9209 the mirror
+ * image of #995.
+ *
+ * shortcut: an install that flipped from virtualized to full-trust keeps a
+ * stale LocalCache dir, which still wins the probe — the user would be shown
+ * real but outdated backups. Accepted because restore reads BACKUP_DIR either
+ * way, so only manual recovery is affected. Upgrade path if it gets reported:
+ * probe for the newest filename in BACKUP_DIR (timestamps sort lexically)
+ * rather than for the directory, which pins where the last write actually went.
+ */
+export const getBackupDirForDisplay = (): string =>
+  process.windowsStore && existsSync(BACKUP_DIR_WINSTORE)
+    ? BACKUP_DIR_WINSTORE
+    : BACKUP_DIR;
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function initBackupAdapter(): void {

--- a/electron/backup.ts
+++ b/electron/backup.ts
@@ -22,6 +22,12 @@ import {
 } from './shared-with-frontend/backup-file-cleanup.util';
 
 export const BACKUP_DIR = path.join(app.getPath('userData'), `backups`);
+/**
+ * Where the Windows Store build's backups end up on disk *if* the package is
+ * virtualized — never a path we read or write ourselves, and not guaranteed to
+ * exist. Only for showing the user a location they can open outside the package
+ * sandbox; check `existsSync` before displaying it (#995, #9209).
+ */
 export const BACKUP_DIR_WINSTORE = BACKUP_DIR.replace(
   'Roaming',
   `Local\\Packages\\53707johannesjo.SuperProductivity_ch45amy23cdv6\\LocalCache\\Roaming`,

--- a/electron/ipc-handlers/app-data.ts
+++ b/electron/ipc-handlers/app-data.ts
@@ -1,23 +1,11 @@
 import { app, ipcMain } from 'electron';
-import { existsSync } from 'fs';
 import { IPC } from '../shared-with-frontend/ipc-events.const';
-import { BACKUP_DIR, BACKUP_DIR_WINSTORE } from '../backup';
+import { getBackupDirForDisplay } from '../backup';
 
 export const initAppDataIpc = (): void => {
   ipcMain.handle(IPC.GET_PATH, (ev, name: string) => {
     return app.getPath(name as Parameters<typeof app.getPath>[0]);
   });
 
-  // The path shown in Settings is the one the user has to find in Explorer, which
-  // is not necessarily the one we write to: under MSIX virtualization writes to
-  // AppData\Roaming land in the package's private LocalCache instead. Whether that
-  // happens depends on the package's trust level and the Windows version (since
-  // Windows 10 1903 it is even decided per file), so we cannot know it statically —
-  // assuming it always applies is what made #9209 the mirror image of #995. Probe
-  // instead, and fall back to the path we actually write to.
-  ipcMain.handle(IPC.GET_BACKUP_PATH, () =>
-    process?.windowsStore && existsSync(BACKUP_DIR_WINSTORE)
-      ? BACKUP_DIR_WINSTORE
-      : BACKUP_DIR,
-  );
+  ipcMain.handle(IPC.GET_BACKUP_PATH, () => getBackupDirForDisplay());
 };

--- a/electron/ipc-handlers/app-data.ts
+++ b/electron/ipc-handlers/app-data.ts
@@ -1,4 +1,5 @@
 import { app, ipcMain } from 'electron';
+import { existsSync } from 'fs';
 import { IPC } from '../shared-with-frontend/ipc-events.const';
 import { BACKUP_DIR, BACKUP_DIR_WINSTORE } from '../backup';
 
@@ -7,11 +8,16 @@ export const initAppDataIpc = (): void => {
     return app.getPath(name as Parameters<typeof app.getPath>[0]);
   });
 
-  ipcMain.handle(IPC.GET_BACKUP_PATH, () => {
-    if (process?.windowsStore) {
-      return BACKUP_DIR_WINSTORE;
-    } else {
-      return BACKUP_DIR;
-    }
-  });
+  // The path shown in Settings is the one the user has to find in Explorer, which
+  // is not necessarily the one we write to: under MSIX virtualization writes to
+  // AppData\Roaming land in the package's private LocalCache instead. Whether that
+  // happens depends on the package's trust level and the Windows version (since
+  // Windows 10 1903 it is even decided per file), so we cannot know it statically —
+  // assuming it always applies is what made #9209 the mirror image of #995. Probe
+  // instead, and fall back to the path we actually write to.
+  ipcMain.handle(IPC.GET_BACKUP_PATH, () =>
+    process?.windowsStore && existsSync(BACKUP_DIR_WINSTORE)
+      ? BACKUP_DIR_WINSTORE
+      : BACKUP_DIR,
+  );
 };

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1492,7 +1492,7 @@
         },
         "PASSWORD_SET_INFO": "🔒 Encryption password is set.",
         "SUPER_SYNC": {
-          "ACCESS_TOKEN_DESCRIPTION": "Paste the token you copied from the server login page",
+          "ACCESS_TOKEN_DESCRIPTION": "Paste a token for your SuperSync account. On another device, reuse this token or sign in again to get another one.",
           "BTN_CHANGE_PASSWORD": "Change Password",
           "BTN_DISABLE_ENCRYPTION": "Disable Encryption",
           "BTN_ENABLE_ENCRYPTION": "Enable Encryption",


### PR DESCRIPTION
Fixes #9209.

> **Note:** this branch also carries one unrelated commit, `a3e1ab2f3d`
> *"docs(sync): clarify multi-device token usage"* — a wiki paragraph and one `en.json`
> string, riding along rather than getting its own PR. Everything below concerns the two
> backup commits.

## The bug

The Automatic Backups settings page told a Microsoft Store user their backups were in
`…\Local\Packages\53707johannesjo.SuperProductivity_…\LocalCache\Roaming\superProductivity\backups`.
That folder doesn't exist on their machine — the backups are in the plain
`…\AppData\Roaming\superProductivity\backups`. The rendered `file://` link goes nowhere.

No data is lost: `BACKUP_DIR` is the only path we ever read or write, so backups and
restore both work. But this is the *backup* feature, and the displayed path is what
someone follows during disaster recovery — which is exactly why #995 was filed.

## Why this keeps happening

This is the same bug as #995, inverted.

- **#995 (2021)**: Settings showed the plain `Roaming` path while the Store build actually
  wrote to the MSIX-virtualized `LocalCache\Roaming`.
- **`57a4e2839a` (Apr 2025)** closed it by hardcoding a string rewrite and returning it
  **unconditionally** whenever `process.windowsStore` is set. A contributor verified it
  correct on Store build 13.0.0 in May 2025.
- **#9209 (now)** reports the exact opposite on 18.14.0. Both reporters are right.

Per [Microsoft's MSIX docs](https://learn.microsoft.com/en-us/windows/msix/desktop/desktop-to-uwp-behind-the-scenes),
AppData redirection applies **only to virtualized packages**, and since **Windows 10 1903**
it is resolved **per file**:

> In response to a file open command, the OS will open the file from the per-user,
> per-package location first. If that location doesn't exist, then the OS will attempt to
> open the file from the real AppData location. If the file is opened from the real AppData
> location, then no virtualization for that file occurs.

So the physical location varies by package trust level, Windows build, and install history.
A hardcoded string cannot be right for everyone — it was always a guess that happened to hold.

## The fix

Probe for the directory instead of assuming it exists, and fall back to the path we actually
write to. Correct in both directions: virtualized installs still get the LocalCache path
(**#995 stays fixed**), non-virtualized installs get the real one (**#9209 fixed**). Worst
case it returns `BACKUP_DIR`, which is the pre-2025 behaviour — it cannot regress anyone who
already has backups.

The decision lives in `getBackupDirForDisplay()` next to the constants it reads, and
`BACKUP_DIR_WINSTORE` is no longer exported — so "verify before displaying" is enforced by
the only accessor rather than being an honour-system note in a comment, which is the shape
the 2025 fix got wrong. `backup.ts` already imported `existsSync`, so this costs no new
import, and it matches `getRelaunchExecPath` in `ipc-handlers/app-control.ts`.

## Tests

`electron/backup.test.cjs` pins **both** directions of the loop, so neither can be
"simplified" away again:

| case | expected |
|---|---|
| not a Store build (even with a leftover LocalCache dir) | `BACKUP_DIR` |
| Store + LocalCache present | `BACKUP_DIR_WINSTORE` — regression test for **#995** |
| Store + LocalCache absent | `BACKUP_DIR` — regression test for **#9209** |

Verified by sabotage, not just by passing:

- restoring the unconditional path → **only** the #9209 test fails
- deleting the probe entirely → **only** the #995 test fails

There's also an explicit assertion that the two derived paths differ, because `path.join`
uses `/` on Linux CI — without it the Windows-only branches would pass vacuously on the CI
runner. (That guard caught a real bug in the test on first run.)

Full `npm run test:electron`: **243/243**.

## Known residual, deliberately accepted

An install that flipped from virtualized to full-trust keeps a *stale* `LocalCache\…\backups`
directory, which still wins the probe — the user would be shown real but outdated backups.
Accepted because restore reads `BACKUP_DIR` either way, so only manual recovery is affected,
and the case is unobserved. The ceiling and the upgrade path (probe for the newest *filename*
rather than the directory — timestamps sort lexically) are documented in the code.

Also unverified: the LocalCache branch assumes `%LOCALAPPDATA%\Packages\<PFN>\LocalCache\`
is directly readable from inside the container. Structurally it must be — it *is* the
redirection target — but I have no Store install to confirm on. If that's wrong the branch
never fires and we fall back to `BACKUP_DIR`; the new test makes that a detectable mistake
rather than an invisible one. **A confirmation from a Store user would settle it.**

## Deliberately not in scope

- **`BACKUP_LOAD_DATA`'s second allow-listed read root** (`backup.ts`) is unreachable by any
  legitimate caller — `BACKUP_IS_AVAILABLE` builds every path from `BACKUP_DIR`. Narrowing a
  GHSA-x937-wf3j-88q3 guard doesn't belong in a display-path fix, and I can't test restore on
  Windows. The doc comment no longer claims the constant is inert, so it won't invite a blind
  deletion. Worth a follow-up with its own test.
- **The restore prompt** (`local-backup.service.ts`) shows raw `BACKUP_DIR`, so it can differ
  from Settings on a virtualized install. Pre-existing and strictly less divergent than before
  this PR; noting it so nobody "fixes" it by duplicating the probe.

## Unrelated, but worth flagging

The reporter's *original* complaint was **missing task notes**; they self-downgraded to a path
bug after finding the backups. They're on 18.14.0, and `e5a9ff7866` — the #9095 disjoint-merge
fix, *"a rename on one device is lost when another device marks the task done"* — is in
v18.15.0 and **not** in v18.14.0 (`git merge-base --is-ancestor`). If they sync across devices,
a vanished `notes` field is a textbook symptom, and it would explain why it's in no backup.
Worth asking before closing.

That also means the **Store build is lagging** (latest tag v18.15.1), so Store users are still
on a build with known shipped data loss.
