### PR TITLE
test(tasks): create the notes-focus fixture inside fakeAsync

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
@@ -396,13 +396,23 @@ describe('TaskDetailPanelComponent notes target does not auto-edit', () => {
         set: { template: '', imports: [], schemas: [NO_ERRORS_SCHEMA] },
       })
       .compileComponents();
+  });
 
+  // The fixture is created INSIDE fakeAsync on purpose. The suite runs zoneless
+  // (src/test.ts provides provideZonelessChangeDetection globally), and
+  // ComponentFixture.autoDetectDefault is `true` whenever zoneless is enabled —
+  // so createComponent()/setInput() schedule an ApplicationRef tick. Created in
+  // the async beforeEach, that tick can fire before the spec body, running
+  // ngAfterViewInit outside the fake zone: its delay(50) then registers a REAL
+  // timer that tick() can never flush, and the focusItem spy is installed too
+  // late to observe the call. That is an order/load-dependent flake that fails
+  // roughly like "focusItem ... was never called" (it defeated an earlier
+  // tick(50) -> tick(100) fix, because the timer was never in the fake clock).
+  it('focuses the notes section without entering edit mode', fakeAsync(() => {
     fixture = TestBed.createComponent(TaskDetailPanelComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('task', fakeTask('B'));
-  });
 
-  it('focuses the notes section without entering edit mode', fakeAsync(() => {
     // Provide a notes wrapper so the real focus path (not the devError branch) runs.
     const noteItem = makeItem();
     (


### PR DESCRIPTION
## Problem

`TaskDetailPanelComponent notes target does not auto-edit > focuses the notes section without entering edit mode` fails intermittently in CI:

```
Expected spy focusItem to have been called with:
  [ Object({ elementRef: ... }) ]
but it was never called.
    at UserContext.apply (task-detail-panel.component.spec.ts:419:26)
```

Seen most recently on the `America/Los_Angeles` leg of #9132's run, while the `Europe/Berlin` leg of the same commit passed. It is not timezone-related — the timezone only shifts event-loop timing.

## Root cause

`src/test.ts` provides `provideZonelessChangeDetection()` for every TestBed, and Angular's `ComponentFixture` does:

```js
autoDetectDefault = this.zonelessEnabled ? true : false;   // → true for every fixture here
// constructor, when autoDetect:
this.scheduler?.notify(8); this.scheduler?.notify(0);      // schedules an ApplicationRef tick
```

So `TestBed.createComponent()` and `componentRef.setInput()` — both in the `async beforeEach` — schedule a change-detection tick. When that tick fires **before** the spec body, `ngAfterViewInit` runs **outside the fake zone**. Its `delay(50)` then registers a *real* timer that `tick(100)` can never flush, and `spyOn(component, 'focusItem')` is installed too late to observe the call. Whether the tick lands first depends on event-loop timing, so it is order/load dependent.

This also explains why c08832c9dc (`tick(50)` → `tick(100)`) did not help: the timer was never in the fake clock at all. **Raising `tick()` cannot fix this class of flake.**

## Fix

Create the fixture inside `fakeAsync`, so the scheduled tick lands on the fake clock.

I deliberately did *not* use `{ provide: ComponentFixtureAutoDetect, useValue: false }`: `autoDetectChanges(false)` throws under zoneless, so suppressing auto-detect via the token works against the framework and is fragile across Angular upgrades.

## Verification

Reproduced deterministically first — appending a single macrotask yield to the `beforeEach` lets the scheduled tick run and makes the spec fail **100%** of the time:

```js
await new Promise((r) => setTimeout(r, 0));
```

| | result |
| --- | --- |
| before fix + yield | **FAIL** — identical `focusItem … was never called` |
| after fix + yield | PASS |
| after fix, no yield | PASS |

Full suite green in both CI timezones on this branch: `Europe/Berlin` 13308 SUCCESS, `America/Los_Angeles` 13294 SUCCESS, 0 failures.

## Not addressed here

Four other specs share the same shape (fixture built in `beforeEach`, first `detectChanges()` inside a `fakeAsync` body) — `issue-panel-calendar-agenda`, `activity-heatmap`, `schedule-event`, `search-page`. None currently fails, and I have no reproduction for them, so they are left alone rather than changed blind.
