### PR TITLE
fix(supersync): preserve Helm reuse-values upgrades

### DIFF
--- a/.github/workflows/supersync-server-tests.yml
+++ b/.github/workflows/supersync-server-tests.yml
@@ -55,6 +55,22 @@ jobs:
           ssh://git@github.com/
       - name: Install npm Packages
         run: npm i
+      - name: Verify Helm upgrade value compatibility
+        working-directory: packages/super-sync-server
+        run: |
+          set -euo pipefail
+          chart_args=(
+            supersync helm/supersync
+            --show-only templates/deployment.yaml
+            --set postgresql.password=test
+            --set supersync.secret.jwtSecret=01234567890123456789012345678901
+          )
+          helm template "${chart_args[@]}" --set postgresql.connectionLimit=null |
+            grep -Fq 'connection_limit=20&pool_timeout=10'
+          if helm template "${chart_args[@]}" --set postgresql.connectionLimit=0 >/dev/null 2>&1; then
+            echo 'connectionLimit=0 unexpectedly passed Helm validation' >&2
+            exit 1
+          fi
       - name: Run SuperSync Server Tests
         run: cd packages/super-sync-server && npm test
       - name: Apply PostgreSQL Test Schema

--- a/packages/super-sync-server/helm/supersync/templates/_helpers.tpl
+++ b/packages/super-sync-server/helm/supersync/templates/_helpers.tpl
@@ -68,9 +68,17 @@ Create the fully qualified name for the PostgreSQL resources.
 {{- printf "%s-postgresql" (include "supersync.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/* Validate and render the built-in database's Prisma connection limit. */}}
+{{/*
+Validate and render the built-in database's Prisma connection limit.
+`--reuse-values` can omit new chart defaults; fall back only when the key is
+absent so an explicitly invalid zero still fails validation.
+*/}}
 {{- define "supersync.postgresqlConnectionLimit" -}}
-{{- $value := toString .Values.postgresql.connectionLimit -}}
+{{- $postgresql := default (dict) .Values.postgresql -}}
+{{- $value := "20" -}}
+{{- if hasKey $postgresql "connectionLimit" -}}
+{{- $value = toString $postgresql.connectionLimit -}}
+{{- end -}}
 {{- $safeLength := or (lt (len $value) 16) (and (eq (len $value) 16) (le $value "9007199254740991")) -}}
 {{- if not (and (regexMatch "^[1-9][0-9]*$" $value) $safeLength) -}}
 {{- fail "postgresql.connectionLimit must be a positive integer" -}}


### PR DESCRIPTION
## Summary

- preserve the built-in PostgreSQL connection limit when a Helm upgrade reuses values from an older release
- continue rejecting explicit invalid limits such as `0` and unsafe integers
- add a real Helm render regression check to the SuperSync PR workflow

## Root cause

#9212 introduced `postgresql.connectionLimit` with a chart default of `20`. Helm's `--reuse-values` mode reuses the prior release values instead of adding newly introduced chart defaults, so an upgrade from the previous chart could leave the key absent and fail validation before deployment.

The helper now falls back to `20` only when the key is absent. It deliberately uses key-presence detection rather than Sprig's `default`, because `default` also treats an explicit numeric zero as empty and would bypass the intended validation.

## Impact

Helm users with bundled PostgreSQL can upgrade older releases using `--reuse-values` without manually adding the new setting. Explicit invalid configuration still fails loudly. Docker Compose and external-database behavior are unchanged.

Follow-up to #9212.

## Validation

- real Helm render: absent key renders `connection_limit=20`
- real Helm render: explicit `connectionLimit=0` remains rejected
- Helm lint
- migration/deployment specification: 14/14 tests
- SuperSync suite: 989/989 tests on the identical relevant tree
- full pre-push gate: lint, package tests, release tooling, and both Angular timezone suites passed (13,308 + 13,294 tests)
