### PR TITLE
fix(supersync): retry lock-bounded migrations by shape, not by name

### DIFF
--- a/packages/super-sync-server/.gitignore
+++ b/packages/super-sync-server/.gitignore
@@ -16,3 +16,4 @@ backups/
 initdb.d/
 secrets/
 tde-keys/
+.tmp-lock-retry-*

--- a/packages/super-sync-server/README.md
+++ b/packages/super-sync-server/README.md
@@ -77,10 +77,12 @@ Some migrations use `CREATE INDEX CONCURRENTLY`, which can block on long-running
 transactions on a busy database. Run deploys off-hours when applying schema
 changes, and raise `MIGRATION_TIMEOUT` (seconds, default `900`) if a large
 table requires more time. Exit code `124` from `deploy.sh` means the migration
-timed out — re-run after the blocking transaction clears. The
-`operations_entity_ids_gin` reloption migration instead has its own one-second
-index-lock timeout; if its one automatic retry also times out, clear the
-blocking transaction and re-run the deploy.
+timed out — re-run after the blocking transaction clears. A lock-bounded
+reloption migration (one that sets its own short `lock_timeout`, such as the
+`operations_entity_ids_gin` one) instead fails fast rather than queueing
+traffic, and is retried natively up to 10 times a few seconds apart. If every
+attempt times out it is left rolled back — clear the blocking transaction and
+re-run the deploy.
 
 If a deploy was interrupted after Prisma recorded a migration as failed, later
 deploys can stop with `P3009`. Prisma can also stop migrations with `P3018`
@@ -88,9 +90,9 @@ when they contain `CREATE/DROP INDEX CONCURRENTLY` statements, which cannot run
 in one transaction block. `scripts/migrate-deploy.sh` handles the safe
 drop-then-create concurrent-index case generically: it resolves the failed row
 when needed, applies the migration SQL outside Prisma migrate, marks the
-migration applied, and retries `migrate deploy`. It also retries the exact
-lock-bounded `operations_entity_ids_gin` reloption migration natively; all
-other failed migration shapes stop for manual review.
+migration applied, and retries `migrate deploy`. It also retries any
+lock-bounded reloption migration natively — recognized by its shape, never by
+name; all other failed migration shapes stop for manual review.
 
 An application rollback does not require changing this index setting. If
 measured insert latency regresses after this rollout, restore PostgreSQL's

--- a/packages/super-sync-server/README.md
+++ b/packages/super-sync-server/README.md
@@ -80,7 +80,7 @@ table requires more time. Exit code `124` from `deploy.sh` means the migration
 timed out — re-run after the blocking transaction clears. A lock-bounded
 reloption migration (one that sets its own short `lock_timeout`, such as the
 `operations_entity_ids_gin` one) instead fails fast rather than queueing
-traffic, and is retried natively up to 10 times in quick succession. If every
+traffic, and is retried natively a bounded number of times. If every
 attempt times out it is left rolled back — clear the blocking transaction and
 re-run the deploy.
 

--- a/packages/super-sync-server/README.md
+++ b/packages/super-sync-server/README.md
@@ -80,7 +80,7 @@ table requires more time. Exit code `124` from `deploy.sh` means the migration
 timed out — re-run after the blocking transaction clears. A lock-bounded
 reloption migration (one that sets its own short `lock_timeout`, such as the
 `operations_entity_ids_gin` one) instead fails fast rather than queueing
-traffic, and is retried natively up to 10 times a few seconds apart. If every
+traffic, and is retried natively up to 10 times in quick succession. If every
 attempt times out it is left rolled back — clear the blocking transaction and
 re-run the deploy.
 

--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
     "pretest": "prisma generate",
     "test": "vitest run",
-    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts",
+    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts tests/integration/migrate-deploy-lock-retry.integration.spec.ts",
     "docker:build": "./scripts/build-and-push.sh",
     "docker:deploy": "./scripts/deploy.sh",
     "docker:deploy:build": "./scripts/deploy.sh --build",

--- a/packages/super-sync-server/prisma/migrations/README.md
+++ b/packages/super-sync-server/prisma/migrations/README.md
@@ -87,7 +87,7 @@ migration must never be split or executed out-of-band.
 A lock timeout leaves a failed Prisma migration record; a later deploy then sees
 only Prisma's cause-free `P3009`. The deploy script handles either state by
 marking the failed attempt rolled back and retrying through
-`prisma migrate deploy`, up to 10 attempts a few seconds apart (one retry is not
+`prisma migrate deploy`, up to 10 attempts (one retry is not
 enough — production lost a whole deploy to exactly that in July 2026). After the
 last attempt the migration is left **rolled back**, so re-running the deploy is
 always safe. Any different Prisma error fails loudly without being

--- a/packages/super-sync-server/prisma/migrations/README.md
+++ b/packages/super-sync-server/prisma/migrations/README.md
@@ -61,7 +61,7 @@ A migration is retried natively **only if** it has exactly two statements — a
 `SET LOCAL lock_timeout` of at most a few seconds, then a single
 `ALTER INDEX ... SET (...)`. Four properties are what make retrying safe:
 
-1. **A short bound**: `1ms`-`9999ms` or `1s`-`5s`. Anything longer is refused,
+1. **A short bound**: at most 5 seconds (`1ms`-`5000ms` or `1s`-`5s`). Anything longer is refused,
    and so is `'0'` — which in PostgreSQL means _no_ timeout, i.e. wait forever.
    Retrying an unbounded wait is the outage this whole section exists to avoid.
 2. **Exactly two statements**, so Postgres wraps them in an implicit

--- a/packages/super-sync-server/prisma/migrations/README.md
+++ b/packages/super-sync-server/prisma/migrations/README.md
@@ -8,10 +8,17 @@ block, so a CONCURRENTLY migration always fails the normal
 `scripts/migrate-deploy.sh` recovers from this generically: on that specific
 failure it reads the failing migration's name from Prisma's output, runs _that
 migration's own `migration.sql`_ out-of-band (no transaction,
-statement-by-statement), marks it applied, and retries. The script also has one
-exact-shape recovery for the bounded `ALTER INDEX` described below. Recovery is
-exercised by `tests/migrate-deploy-script.spec.ts` (behavioral, end-to-end) and
-`tests/migration-sql.spec.ts` (the migration SQL shapes the recovery relies on).
+statement-by-statement), marks it applied, and retries. It has a second recovery
+for the lock-bounded `ALTER INDEX` shape described below. **It hardcodes no
+migration name, index name, or SQL text** — a migration opts into a recovery
+path by its _shape_ alone. Naming nothing has been the design goal since this
+logic moved in-image: the _host_ copy went stale against the migrations it knew
+about and broke a deploy. This copy is version-locked to `prisma/migrations` by
+the image build, so a name here would not go stale the same way, but it is still
+a silent coupling. Recovery is exercised by
+`tests/migrate-deploy-script.spec.ts` (behavioral, end-to-end) and
+`tests/migration-sql.spec.ts` (the migration SQL shapes the recovery relies on,
+and the no-hardcoded-names invariant itself).
 
 ## Prefer migrations that don't need recovery
 
@@ -21,35 +28,70 @@ Recovery is a safety net, not the happy path. Prefer, in order:
 2. **A single CONCURRENTLY statement per migration file.** Prisma issues a
    single-statement migration as one query, which Postgres does _not_ wrap in
    an implicit transaction, so `prisma migrate deploy` applies it natively with
-   no recovery needed. (Do not retro-split already-applied migrations — that
-   changes their checksum and breaks `migrate deploy`.)
+   no recovery needed. (Do not retro-split already-applied migrations — see
+   "Never edit an applied migration" below.)
 
 Out-of-band recovery cost scales with the number of consecutive pending
 CONCURRENTLY migrations and the number of statements in each (one Prisma
 process per statement), so a large backlog deploy is intentionally slower.
 
-## Intentional exception: bounded `ALTER INDEX`
+## Rules for a lock-bounded `ALTER INDEX` migration
 
-`20260720000000_disable_operation_entity_ids_gin_fastupdate` has exactly two
-statements:
+DDL that needs an `ACCESS EXCLUSIVE` lock on a hot object must bound its own
+lock wait. `20260720000000_disable_operation_entity_ids_gin_fastupdate` is the
+worked example:
 
 ```sql
 SET LOCAL lock_timeout = '1s';
 ALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);
 ```
 
-The `ALTER INDEX` needs an `ACCESS EXCLUSIVE` lock on the GIN index. Without the
-short timeout, a waiting migration can queue new reads and writes behind it.
-`SET LOCAL` and the `ALTER` must stay in the same Prisma transaction, so this
+**Never raise the timeout to make such a migration succeed.** A waiting
+`ACCESS EXCLUSIVE` request queues every _new_ query on the table behind it —
+measured, a trivial reader went from 79 ms to 8005 ms while one waited. That is
+the shape of a prior outage. The fix for losing the race is many short attempts,
+never one long wait.
+
+Note the lock is contended more easily than it looks: the planner takes
+`AccessShareLock` on **every** index of a table for any query that plans against
+it, held to end of transaction — so a single slow query touching the table
+starves the window, even one that uses no index at all.
+
+A migration is retried natively **only if** it has exactly two statements — a
+`SET LOCAL lock_timeout` of at most a few seconds, then a single
+`ALTER INDEX ... SET (...)`. Four properties are what make retrying safe:
+
+1. **A short bound**: `1ms`-`9999ms` or `1s`-`5s`. Anything longer is refused,
+   and so is `'0'` — which in PostgreSQL means _no_ timeout, i.e. wait forever.
+   Retrying an unbounded wait is the outage this whole section exists to avoid.
+2. **Exactly two statements**, so Postgres wraps them in an implicit
+   transaction and a lock timeout rolls the migration back with nothing
+   partially applied.
+3. **`ALTER INDEX ... SET (reloption)`**, which is idempotent on re-run.
+4. **No `CONCURRENTLY`.** A _single_-statement migration gets no implicit
+   transaction, so a lock timeout mid-build leaves an `INVALID` index that a
+   retry cannot clear. Those stay fail-loud (see the bare-CREATE section below).
+
+Note rule 2 is not enough on its own: the splitter breaks on `;` at _end of
+line_, so a second statement sharing the `ALTER`'s line would still end in `);`.
+What actually excludes that is the `ALTER` pattern being fully anchored with a
+**paren-free** option list — the `ALTER`'s own `)` always lands inside the span,
+so nothing can follow it.
+
+Spacing and keyword case are not load-bearing — the gate matches with
+`grep -Ei`, like the CONCURRENTLY gates.
+
+`SET LOCAL` and the `ALTER` must stay in the same Prisma transaction, so such a
 migration must never be split or executed out-of-band.
 
-A lock timeout leaves a failed Prisma migration record; a later deploy then
-sees only Prisma's cause-free `P3009`. Because the exact `ALTER` above is
-idempotent, the deploy script handles either state by marking the failed attempt
-rolled back and retrying it once through `prisma migrate deploy`. A repeated
-lock timeout or `P3009` is left rolled back; any different Prisma error fails
-loudly without being auto-resolved. The script never marks this migration
-applied itself.
+A lock timeout leaves a failed Prisma migration record; a later deploy then sees
+only Prisma's cause-free `P3009`. The deploy script handles either state by
+marking the failed attempt rolled back and retrying through
+`prisma migrate deploy`, up to 10 attempts a few seconds apart (one retry is not
+enough — production lost a whole deploy to exactly that in July 2026). After the
+last attempt the migration is left **rolled back**, so re-running the deploy is
+always safe. Any different Prisma error fails loudly without being
+auto-resolved, and the script never marks such a migration applied itself.
 
 The following migration calls `gin_clean_pending_list` in a separate
 transaction, capped by a five-minute `statement_timeout`. Keep it separate so
@@ -110,5 +152,18 @@ _performance-only_ index that has a correct fallback path — e.g.
 `entity_id` — prefer the auto-recoverable drop-then-create shape so an
 interrupted build self-heals on the next deploy instead of wedging it and
 requiring manual recovery. Do **not** retro-convert an already-applied bare
-CREATE: that changes its checksum and breaks `migrate deploy` on every DB that
-has it.
+CREATE — see below.
+
+## Never edit an applied migration
+
+Not because `migrate deploy` catches it. **It does not**: verified against
+PostgreSQL 16 with Prisma 5.22.0, `migrate deploy` never re-reads an applied
+migration's file, reports "No pending migrations to apply." and exits 0 even
+when that file was replaced with `DROP TABLE`. `migrate status` is silent too;
+only `migrate dev` notices, by replaying against a shadow database.
+
+Edit one anyway and: every install that already applied it **never executes the
+new SQL**, so a fix retrofitted there reaches nobody who already ran it; the
+recorded `checksum` permanently disagrees with the file; and contributors
+running `migrate dev` hit a shadow-database replay of the new content. Ship a
+new migration instead.

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -60,34 +60,20 @@ MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
 # the next only on its second try, so one retry is a coin flip against a table
 # under continuous load.
 #
-# Worst case is ~80-160s: 10 `migrate deploy` plus 10 `migrate resolve` runs
-# (Prisma CLI start dominates, ~1.6s each) plus 9 sleeps. Note MIGRATE_STEP_TIMEOUT
-# does NOT bound this — it is per-step, and every step here is short. The only
-# outer bound is deploy.sh's MIGRATION_TIMEOUT (900s default, so ~1/6 of the
-# budget); the image CMD and the Helm initContainer have no outer timeout at all.
-# Keep the budget small enough that those two paths stay bounded by this constant.
+# Worst case is ~45-60s: each attempt is a `migrate resolve` plus a `migrate
+# deploy`, and Prisma CLI start (~1.6s each) already spaces the attempts several
+# seconds apart, so no explicit sleep is needed — the migration's own lock wait
+# is ~1s of that, i.e. a ~25% duty cycle of self-inflicted queueing.
+#
+# Note MIGRATE_STEP_TIMEOUT does NOT bound this — it is per-step, and every step
+# here is short. The only outer bound is deploy.sh's MIGRATION_TIMEOUT (900s
+# default); the image CMD and the Helm initContainer have no outer timeout at
+# all, so keep the budget small enough that this constant bounds those two.
 #
 # Deliberately NOT operator-settable: a non-numeric value would make the `-ge`
 # test below error inside an `if`, which `set -e` does not catch — i.e. an
 # unbounded retry loop on exactly those two unbounded paths.
 MAX_LOCK_ATTEMPTS=10
-# Pause between those attempts. Each attempt parks an ACCESS EXCLUSIVE request
-# that queues new queries on the table for up to the migration's own
-# lock_timeout, so the pause is what caps that self-inflicted queueing; the
-# blocker is ordinary traffic, so a flat wait samples it as well as any backoff
-# would. Validated below, because it multiplies the same wall-clock budget that
-# MAX_LOCK_ATTEMPTS is hardcoded to protect.
-LOCK_RETRY_SLEEP="${MIGRATE_LOCK_RETRY_SLEEP:-5}"
-case "$LOCK_RETRY_SLEEP" in
-  ''|*[!0-9]*)
-    echo "ERROR: MIGRATE_LOCK_RETRY_SLEEP must be an integer from 0 to 60 seconds." >&2
-    exit 2
-    ;;
-esac
-if [ "${#LOCK_RETRY_SLEEP}" -gt 2 ] || [ "$LOCK_RETRY_SLEEP" -gt 60 ]; then
-  echo "ERROR: MIGRATE_LOCK_RETRY_SLEEP must be an integer from 0 to 60 seconds." >&2
-  exit 2
-fi
 # Per-step client timeout. PostgreSQL also receives a per-statement timeout five
 # seconds shorter. If cumulative work still reaches the client deadline, the
 # wrapper terminates only the backend carrying this run's unique application id.
@@ -635,7 +621,6 @@ while :; do
     fi
     echo ""
     echo "==> Retrying prisma migrate deploy after bounded native recovery for $name (attempt $((LOCK_ATTEMPTS + 1)) of $MAX_LOCK_ATTEMPTS)..."
-    sleep "$LOCK_RETRY_SLEEP"
     continue
   fi
 

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -55,6 +55,15 @@ MIGRATIONS_DIR="prisma/migrations"
 # The real infinite-loop backstop is the LAST_RECOVERED guard below; this is
 # just a tight upper bound. Overridable for emergencies.
 MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
+# Validated for the same reason MAX_LOCK_ATTEMPTS is not settable at all: a
+# non-numeric value makes the `-ge` test error inside an `if`, which `set -e`
+# does not catch, so the guard silently never fires.
+case "$MAX_ATTEMPTS" in
+  ''|0*|*[!0-9]*)
+    echo "ERROR: MIGRATE_MAX_ATTEMPTS must be a positive integer." >&2
+    exit 2
+    ;;
+esac
 # Total native attempts at one lock-bounded migration before it is left rolled
 # back. Production 2026-07-21: a single retry lost one deploy outright and won
 # the next only on its second try, so one retry is a coin flip against a table
@@ -68,7 +77,9 @@ MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
 # MIGRATE_STEP_TIMEOUT does NOT bound the loop — it is per-step, and every step
 # here is short. The only outer bound is deploy.sh's MIGRATION_TIMEOUT (900s
 # default); the image CMD and the Helm initContainer have no outer timeout at
-# all, so keep the budget small enough that this constant bounds those two.
+# all. Note the budget is PER MIGRATION (the counter resets when the failing
+# name changes), so a deploy with N pending lock-bounded migrations can reach
+# N x MAX_LOCK_ATTEMPTS attempts — keep that in mind before raising it.
 #
 # Not operator-settable: nothing needs to tune it, and the `-ge` test below
 # would error inside an `if` on a non-numeric value, which `set -e` does not
@@ -261,6 +272,14 @@ run_migrate_deploy() {
   with_timeout npx prisma migrate deploy >"$MIGRATE_LOG" 2>&1
   MIGRATE_STATUS=$?
   set -e
+  # Strip ANSI colour ONCE, here, so every later reader sees plain text. Prisma
+  # renders `Error: P3018` as `\e[1m\e[31mError: \e[39m\e[22m\e[31mP3018` under
+  # FORCE_COLOR / npm_config_color=always. That anchor is the first conjunct of
+  # all three failure detectors, so a single stray env var would otherwise
+  # disable EVERY recovery path at once — and would also poison
+  # parse_failing_migration, whose charset check rejects a name with escapes.
+  # ESC is built with printf because `\x1b` is a GNU sed extension BusyBox lacks.
+  sed -i "s/$(printf '\033')\[[0-9;]*m//g" "$MIGRATE_LOG"
   cat "$MIGRATE_LOG"
 }
 
@@ -619,6 +638,11 @@ while :; do
   fi
 
   if is_lock_timeout_failure; then
+    # A lock timeout can also abort a CONCURRENTLY build (an operator-supplied
+    # lock_timeout in DATABASE_URL applies to every migration), which leaves an
+    # INVALID index. Print the drop-index steps so the FIRST failure is
+    # actionable, matching the timeout and non-gate branches above.
+    emit_interrupted_recovery_hint
     fail_loudly "$name is not a lock-bounded ALTER INDEX migration; refusing to auto-resolve its lock timeout."
   fi
 

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -60,19 +60,19 @@ MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
 # the next only on its second try, so one retry is a coin flip against a table
 # under continuous load.
 #
-# Worst case is ~45-60s: each attempt is a `migrate resolve` plus a `migrate
-# deploy`, and Prisma CLI start (~1.6s each) already spaces the attempts several
-# seconds apart, so no explicit sleep is needed — the migration's own lock wait
-# is ~1s of that, i.e. a ~25% duty cycle of self-inflicted queueing.
+# Each attempt is a `migrate resolve` plus a `migrate deploy`, so two Prisma CLI
+# starts pace the loop; there is no explicit sleep. That spacing is INCIDENTAL —
+# a property of Prisma's startup cost, not of this script — so treat the duty
+# cycle of parked ACCESS EXCLUSIVE requests as un-guaranteed rather than tuned.
 #
-# Note MIGRATE_STEP_TIMEOUT does NOT bound this — it is per-step, and every step
+# MIGRATE_STEP_TIMEOUT does NOT bound the loop — it is per-step, and every step
 # here is short. The only outer bound is deploy.sh's MIGRATION_TIMEOUT (900s
 # default); the image CMD and the Helm initContainer have no outer timeout at
 # all, so keep the budget small enough that this constant bounds those two.
 #
-# Deliberately NOT operator-settable: a non-numeric value would make the `-ge`
-# test below error inside an `if`, which `set -e` does not catch — i.e. an
-# unbounded retry loop on exactly those two unbounded paths.
+# Not operator-settable: nothing needs to tune it, and the `-ge` test below
+# would error inside an `if` on a non-numeric value, which `set -e` does not
+# catch — an unbounded loop on exactly those two unbounded paths.
 MAX_LOCK_ATTEMPTS=10
 # Per-step client timeout. PostgreSQL also receives a per-statement timeout five
 # seconds shorter. If cumulative work still reaches the client deadline, the
@@ -369,32 +369,26 @@ split_statements() {
 # successful native retry must be what records it as applied), and re-running it
 # from scratch is free, so a lock timeout can safely be retried.
 #
-# Gated on SHAPE, never on a migration or index name. Naming nothing has been
-# this script's design goal since the recovery logic moved in-image (the HOST
-# copy is what went stale against the migrations it knew about and broke a
-# deploy). This copy is version-locked to prisma/migrations by the image build,
-# so a name here would not go stale the same way — but it is still a silent
-# coupling, and tests/migration-sql.spec.ts enforces its absence.
+# Gated on SHAPE, never on a migration or index name; absence of names is
+# enforced by tests/migration-sql.spec.ts. Rationale: prisma/migrations/README.md.
 #
-# Four properties make the retry safe, and all four are enforced below:
-#   - a SHORT lock_timeout bound. This is the load-bearing one: the point of the
-#     bound is to fail fast rather than queue new queries behind a waiting
+# Three properties are enforced below, and a fourth follows from them:
+#   - a SHORT lock_timeout bound (<= 5s). This is the load-bearing one: the point
+#     of the bound is to fail fast rather than queue new queries behind a waiting
 #     ACCESS EXCLUSIVE request, so a long value ('30min') — or a disabled one
 #     ('0', which means wait forever in PostgreSQL) — must never be retried at
 #     all, let alone MAX_LOCK_ATTEMPTS times;
 #   - exactly two statements, so Postgres wraps them in an implicit transaction
 #     and a lock timeout rolls the whole migration back with nothing partially
 #     applied;
-#   - an ALTER INDEX ... SET (reloption), which is idempotent on re-run;
-#   - no CONCURRENTLY. A SINGLE-statement migration gets no implicit
-#     transaction, so a lock timeout during a concurrent index build leaves an
-#     INVALID index that a blind retry would not clear.
-#
-# Note split_statements breaks on `;` at END OF LINE, so "two statements" alone
-# would not stop a second statement sharing the ALTER's line — it would still
-# end in `);`. What stops that is the ALTER pattern being fully anchored with a
-# PAREN-FREE option list: the ALTER's own `)` always lands inside the span, so
-# nothing can follow it. (The `;` exclusions are belt-and-braces on top.)
+#   - an ALTER INDEX ... SET (reloption), which is idempotent on re-run.
+# The fourth — no CONCURRENTLY — is NOT a separate check: it follows from the
+# ALTER pattern being fully anchored with a paren-free option list, so the
+# ALTER's own `)` always lands inside the span and nothing can follow it. That
+# matters because split_statements breaks on `;` at END OF LINE, so the
+# statement count alone would not stop a CONCURRENTLY build sharing the ALTER's
+# line — and a SINGLE-statement migration gets no implicit transaction, so a
+# lock timeout mid-build leaves an INVALID index a blind retry cannot clear.
 #
 # Matched with grep -Ei, like the CONCURRENTLY gates above, so that spacing and
 # keyword case are not load-bearing for a future migration author.
@@ -408,10 +402,10 @@ is_lock_bounded_migration() {
   third_stmt="$(sed -n '3p' "$STMT_FILE")"
 
   printf '%s\n' "$first_stmt" | grep -Eqi \
-    "^SET[[:space:]]+LOCAL[[:space:]]+lock_timeout[[:space:]]*=[[:space:]]*'([1-9][0-9]{0,3}ms|[1-5]s)';\$" ||
+    "^SET[[:space:]]+LOCAL[[:space:]]+lock_timeout[[:space:]]*=[[:space:]]*'(([1-9][0-9]{0,2}|[1-4][0-9]{3}|5000)ms|[1-5]s)';\$" ||
     return 1
   printf '%s\n' "$second_stmt" | grep -Eqi \
-    '^ALTER[[:space:]]+INDEX[[:space:]]+"[^";]+"[[:space:]]+SET[[:space:]]*\([^();]*\);$' ||
+    '^ALTER[[:space:]]+INDEX[[:space:]]+"[^"]+"[[:space:]]+SET[[:space:]]*\([^()]*\);$' ||
     return 1
   [ -z "$third_stmt" ]
 }

--- a/packages/super-sync-server/scripts/migrate-deploy.sh
+++ b/packages/super-sync-server/scripts/migrate-deploy.sh
@@ -13,10 +13,10 @@ set -eu
 #
 # 1. For the transaction-block failure above, it runs a migration with the safe
 #    DROP+CREATE CONCURRENTLY shape out-of-band, marks it applied, and retries.
-# 2. For the exact two-statement SET LOCAL lock_timeout + ALTER INDEX
-#    fastupdate=off shape, it rolls back Prisma's failed record and retries once
-#    through Prisma. It never splits or marks that transactional migration
-#    applied itself.
+# 2. For the two-statement SET LOCAL lock_timeout + ALTER INDEX ... SET (...)
+#    shape, it rolls back Prisma's failed record and retries a bounded number of
+#    times through Prisma. It never splits or marks that transactional migration
+#    applied itself. The gate is on SHAPE, never on a migration or index name.
 #
 # Both paths discover the failing migration from Prisma's output and inspect
 # prisma/migrations/<name>/migration.sql. Anything matching neither guarded
@@ -55,6 +55,39 @@ MIGRATIONS_DIR="prisma/migrations"
 # The real infinite-loop backstop is the LAST_RECOVERED guard below; this is
 # just a tight upper bound. Overridable for emergencies.
 MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-6}"
+# Total native attempts at one lock-bounded migration before it is left rolled
+# back. Production 2026-07-21: a single retry lost one deploy outright and won
+# the next only on its second try, so one retry is a coin flip against a table
+# under continuous load.
+#
+# Worst case is ~80-160s: 10 `migrate deploy` plus 10 `migrate resolve` runs
+# (Prisma CLI start dominates, ~1.6s each) plus 9 sleeps. Note MIGRATE_STEP_TIMEOUT
+# does NOT bound this — it is per-step, and every step here is short. The only
+# outer bound is deploy.sh's MIGRATION_TIMEOUT (900s default, so ~1/6 of the
+# budget); the image CMD and the Helm initContainer have no outer timeout at all.
+# Keep the budget small enough that those two paths stay bounded by this constant.
+#
+# Deliberately NOT operator-settable: a non-numeric value would make the `-ge`
+# test below error inside an `if`, which `set -e` does not catch — i.e. an
+# unbounded retry loop on exactly those two unbounded paths.
+MAX_LOCK_ATTEMPTS=10
+# Pause between those attempts. Each attempt parks an ACCESS EXCLUSIVE request
+# that queues new queries on the table for up to the migration's own
+# lock_timeout, so the pause is what caps that self-inflicted queueing; the
+# blocker is ordinary traffic, so a flat wait samples it as well as any backoff
+# would. Validated below, because it multiplies the same wall-clock budget that
+# MAX_LOCK_ATTEMPTS is hardcoded to protect.
+LOCK_RETRY_SLEEP="${MIGRATE_LOCK_RETRY_SLEEP:-5}"
+case "$LOCK_RETRY_SLEEP" in
+  ''|*[!0-9]*)
+    echo "ERROR: MIGRATE_LOCK_RETRY_SLEEP must be an integer from 0 to 60 seconds." >&2
+    exit 2
+    ;;
+esac
+if [ "${#LOCK_RETRY_SLEEP}" -gt 2 ] || [ "$LOCK_RETRY_SLEEP" -gt 60 ]; then
+  echo "ERROR: MIGRATE_LOCK_RETRY_SLEEP must be an integer from 0 to 60 seconds." >&2
+  exit 2
+fi
 # Per-step client timeout. PostgreSQL also receives a per-statement timeout five
 # seconds shorter. If cumulative work still reaches the client deadline, the
 # wrapper terminates only the backend carrying this run's unique application id.
@@ -225,6 +258,7 @@ MIGRATE_LOG=""
 MIGRATE_STATUS=0
 LAST_RECOVERED=""
 LAST_NATIVE_RETRY=""
+LOCK_ATTEMPTS=0
 
 STMT_FILE="$(mktemp "${TMPDIR:-/tmp}/supersync-stmts.XXXXXX")"
 cleanup() {
@@ -343,11 +377,42 @@ split_statements() {
   ' "$1"
 }
 
-# This migration needs native Prisma transaction semantics: SET LOCAL must
-# apply to the ALTER, and a successful native retry must be what records the
-# migration as applied. Keep the gate exact so no unrelated failed migration is
-# ever rolled back automatically.
-is_retryable_fastupdate_migration() {
+# A lock-bounded migration: exactly two statements, a SET LOCAL lock_timeout
+# followed by a single ALTER INDEX ... SET (...). Such a migration needs native
+# Prisma transaction semantics (SET LOCAL must apply to the ALTER, and a
+# successful native retry must be what records it as applied), and re-running it
+# from scratch is free, so a lock timeout can safely be retried.
+#
+# Gated on SHAPE, never on a migration or index name. Naming nothing has been
+# this script's design goal since the recovery logic moved in-image (the HOST
+# copy is what went stale against the migrations it knew about and broke a
+# deploy). This copy is version-locked to prisma/migrations by the image build,
+# so a name here would not go stale the same way — but it is still a silent
+# coupling, and tests/migration-sql.spec.ts enforces its absence.
+#
+# Four properties make the retry safe, and all four are enforced below:
+#   - a SHORT lock_timeout bound. This is the load-bearing one: the point of the
+#     bound is to fail fast rather than queue new queries behind a waiting
+#     ACCESS EXCLUSIVE request, so a long value ('30min') — or a disabled one
+#     ('0', which means wait forever in PostgreSQL) — must never be retried at
+#     all, let alone MAX_LOCK_ATTEMPTS times;
+#   - exactly two statements, so Postgres wraps them in an implicit transaction
+#     and a lock timeout rolls the whole migration back with nothing partially
+#     applied;
+#   - an ALTER INDEX ... SET (reloption), which is idempotent on re-run;
+#   - no CONCURRENTLY. A SINGLE-statement migration gets no implicit
+#     transaction, so a lock timeout during a concurrent index build leaves an
+#     INVALID index that a blind retry would not clear.
+#
+# Note split_statements breaks on `;` at END OF LINE, so "two statements" alone
+# would not stop a second statement sharing the ALTER's line — it would still
+# end in `);`. What stops that is the ALTER pattern being fully anchored with a
+# PAREN-FREE option list: the ALTER's own `)` always lands inside the span, so
+# nothing can follow it. (The `;` exclusions are belt-and-braces on top.)
+#
+# Matched with grep -Ei, like the CONCURRENTLY gates above, so that spacing and
+# keyword case are not load-bearing for a future migration author.
+is_lock_bounded_migration() {
   sql="$1"
   [ -f "$sql" ] || return 1
 
@@ -356,9 +421,13 @@ is_retryable_fastupdate_migration() {
   second_stmt="$(sed -n '2p' "$STMT_FILE")"
   third_stmt="$(sed -n '3p' "$STMT_FILE")"
 
-  [ "$first_stmt" = "SET LOCAL lock_timeout = '1s';" ] &&
-    [ "$second_stmt" = 'ALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);' ] &&
-    [ -z "$third_stmt" ]
+  printf '%s\n' "$first_stmt" | grep -Eqi \
+    "^SET[[:space:]]+LOCAL[[:space:]]+lock_timeout[[:space:]]*=[[:space:]]*'([1-9][0-9]{0,3}ms|[1-5]s)';\$" ||
+    return 1
+  printf '%s\n' "$second_stmt" | grep -Eqi \
+    '^ALTER[[:space:]]+INDEX[[:space:]]+"[^";]+"[[:space:]]+SET[[:space:]]*\([^();]*\);$' ||
+    return 1
+  [ -z "$third_stmt" ]
 }
 
 # Single-quote a value for safe shell paste (a'b -> 'a'\''b').
@@ -545,26 +614,33 @@ while :; do
 
   sql="$(migration_sql_path "$name")"
 
-  # ALTER INDEX ... fastupdate takes ACCESS EXCLUSIVE on the hot GIN index.
-  # Its 1s lock_timeout intentionally fails rather than queueing normal reads
-  # and writes behind a waiting DDL lock. Prisma records that timeout as a
-  # failed migration, so clear the failed row and retry the exact atomic,
-  # idempotent migration once using Prisma itself. Never split/execute it
+  # ALTER INDEX ... SET (...) takes ACCESS EXCLUSIVE on the target index. Its
+  # short lock_timeout intentionally fails rather than queueing normal reads and
+  # writes behind a waiting DDL lock — a waiting exclusive request blocks every
+  # new query on the table, which is the shape of a prior outage. So the fix for
+  # losing the race is MANY SHORT ATTEMPTS, never one long wait. Prisma records
+  # the timeout as a failed migration, so clear the failed row and retry the
+  # atomic, idempotent migration through Prisma itself. Never split/execute it
   # out-of-band: SET LOCAL would expire before the ALTER.
-  if is_retryable_fastupdate_migration "$sql" &&
+  if is_lock_bounded_migration "$sql" &&
     { is_lock_timeout_failure || is_stuck_failed_migration; }; then
     rollback_for_native_retry "$name"
-    if [ "$name" = "$LAST_NATIVE_RETRY" ]; then
-      fail_loudly "$name failed again after its bounded native retry and was left rolled back; inspect the Prisma error above, clear the blocker, and re-run the deploy." 1
+    if [ "$name" != "$LAST_NATIVE_RETRY" ]; then
+      LAST_NATIVE_RETRY="$name"
+      LOCK_ATTEMPTS=0
     fi
-    LAST_NATIVE_RETRY="$name"
+    LOCK_ATTEMPTS=$((LOCK_ATTEMPTS + 1))
+    if [ "$LOCK_ATTEMPTS" -ge "$MAX_LOCK_ATTEMPTS" ]; then
+      fail_loudly "$name could not take its lock in $LOCK_ATTEMPTS attempts and was left rolled back; inspect the Prisma error above, clear the blocker, and re-run the deploy." 1
+    fi
     echo ""
-    echo "==> Retrying prisma migrate deploy after bounded native recovery for $name..."
+    echo "==> Retrying prisma migrate deploy after bounded native recovery for $name (attempt $((LOCK_ATTEMPTS + 1)) of $MAX_LOCK_ATTEMPTS)..."
+    sleep "$LOCK_RETRY_SLEEP"
     continue
   fi
 
   if is_lock_timeout_failure; then
-    fail_loudly "$name is not the exact bounded fastupdate migration; refusing to auto-resolve its lock timeout."
+    fail_loudly "$name is not a lock-bounded ALTER INDEX migration; refusing to auto-resolve its lock timeout."
   fi
 
   attempt=$((attempt + 1))

--- a/packages/super-sync-server/tests/integration/migrate-deploy-lock-retry.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/migrate-deploy-lock-retry.integration.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Proves the lock-bounded retry path end-to-end against a REAL PostgreSQL lock
+ * timeout: a real concurrent reader starves the ALTER's lock window, Prisma
+ * really fails with 55P03, and migrate-deploy.sh's shape gate really recognizes
+ * it and really retries until it wins.
+ *
+ * The sibling unit spec drives a FAKE `npx prisma`, so it can only prove the
+ * script's control flow. It cannot prove that the gate matches SQL Postgres
+ * actually accepts, that Prisma's real 55P03 output matches the log anchors, or
+ * that a plain seq-scan reader is enough to block the ALTER. This does.
+ */
+import { PrismaClient } from '@prisma/client';
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = join(currentDir, '../..');
+const migrateScript = join(packageDir, 'scripts/migrate-deploy.sh');
+
+// A dedicated schema keeps this test's own `_prisma_migrations` bookkeeping out
+// of the real one — `migrate deploy` would otherwise record these fixtures
+// alongside the production migration history.
+const TEST_SCHEMA = 'migrate_lock_retry_test';
+const TABLE = 'lock_retry_probe';
+const INDEX = 'lock_retry_probe_gin';
+
+const urlForSchema = (applicationName: string): string => {
+  const url = new URL(DATABASE_URL as string);
+  url.searchParams.set('schema', TEST_SCHEMA);
+  url.searchParams.set('application_name', applicationName);
+  return url.toString();
+};
+
+const SEED_SQL = `CREATE TABLE "${TABLE}" ("id" SERIAL PRIMARY KEY, "tags" TEXT[] NOT NULL DEFAULT '{}');
+CREATE INDEX "${INDEX}" ON "${TABLE}" USING GIN ("tags");`;
+
+// The shape under test: a bounded lock wait, then an idempotent reloption change.
+const BOUND_SQL = `SET LOCAL lock_timeout = '1s';
+ALTER INDEX "${INDEX}" SET (fastupdate = off);`;
+
+let projectDir: string;
+
+const writeMigration = (name: string, sql: string): void => {
+  const dir = join(projectDir, 'prisma', 'migrations', name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'migration.sql'), sql);
+};
+
+interface DeployResult {
+  status: number | null;
+  output: string;
+}
+
+// Must be async: the blocking reader below holds its lock on this process's
+// event loop, so a spawnSync here would freeze the blocker and prevent it ever
+// releasing — the migration would then exhaust its whole budget.
+const runMigrateDeploy = (): Promise<DeployResult> =>
+  new Promise((resolve, reject) => {
+    const child = spawn('sh', [migrateScript], {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        DATABASE_URL: urlForSchema('supersync-migrator-locktest'),
+        MIGRATE_STEP_TIMEOUT: '60',
+      },
+    });
+    let output = '';
+    child.stdout.on('data', (chunk: Buffer) => (output += chunk.toString()));
+    child.stderr.on('data', (chunk: Buffer) => (output += chunk.toString()));
+    child.on('error', reject);
+    child.on('close', (status: number | null) => resolve({ status, output }));
+  });
+
+const readReloptions = async (): Promise<string[] | null> => {
+  const admin = new PrismaClient({
+    datasources: { db: { url: urlForSchema('locktest-admin') } },
+  });
+  try {
+    const rows = await admin.$queryRawUnsafe<Array<{ reloptions: string[] | null }>>(
+      `SELECT c.reloptions
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = $1 AND n.nspname = $2`,
+      INDEX,
+      TEST_SCHEMA,
+    );
+    return rows[0]?.reloptions ?? null;
+  } finally {
+    await admin.$disconnect();
+  }
+};
+
+describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
+  beforeAll(() => {
+    // Inside the package so `npx prisma` resolves through the normal upward
+    // node_modules lookup.
+    projectDir = mkdtempSync(join(packageDir, '.tmp-lock-retry-'));
+    mkdirSync(join(projectDir, 'prisma', 'migrations'), { recursive: true });
+    // Prisma resolves its schema from the nearest project root, so without this
+    // it walks up and discovers the REAL prisma/migrations instead of ours.
+    writeFileSync(
+      join(projectDir, 'package.json'),
+      '{ "name": "lock-retry-fixture", "private": true }\n',
+    );
+    writeFileSync(
+      join(projectDir, 'prisma', 'schema.prisma'),
+      'datasource db {\n  provider = "postgresql"\n  url = env("DATABASE_URL")\n}\n',
+    );
+    writeFileSync(
+      join(projectDir, 'prisma', 'migrations', 'migration_lock.toml'),
+      'provider = "postgresql"\n',
+    );
+  });
+
+  afterAll(async () => {
+    rmSync(projectDir, { recursive: true, force: true });
+    const admin = new PrismaClient({
+      datasources: { db: { url: urlForSchema('locktest-cleanup') } },
+    });
+    try {
+      await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${TEST_SCHEMA}" CASCADE`);
+    } finally {
+      await admin.$disconnect();
+    }
+  });
+
+  it('retries through a real 55P03 lock timeout and applies the migration', async () => {
+    // 1. Seed the table + index with no contention.
+    writeMigration('20260101000000_seed', SEED_SQL);
+    const seed = await runMigrateDeploy();
+    expect(seed.output).not.toContain('ERROR:');
+    expect(seed.status).toBe(0);
+    expect(await readReloptions()).toBeNull();
+
+    // 2. Hold a plain seq-scan reader open. The planner takes AccessShareLock on
+    //    EVERY index of the table — including the GIN one it cannot use — and
+    //    holds it to end of transaction, which is exactly what starves the
+    //    ALTER's 1s window in production.
+    const blocker = new PrismaClient({
+      datasources: { db: { url: urlForSchema('locktest-blocker') } },
+    });
+    const holdMs = 12_000;
+    let lockHeld: () => void;
+    const lockAcquired = new Promise<void>((resolve) => (lockHeld = resolve));
+    const blockerDone = blocker
+      .$transaction(
+        async (tx) => {
+          await tx.$queryRawUnsafe(
+            `SELECT count(*) FROM "${TEST_SCHEMA}"."${TABLE}" WHERE "id" < 0`,
+          );
+          lockHeld();
+          await new Promise((resolve) => setTimeout(resolve, holdMs));
+        },
+        { timeout: holdMs + 30_000, maxWait: 10_000 },
+      )
+      .finally(() => blocker.$disconnect());
+
+    // Only start the deploy once the lock is genuinely held, otherwise the ALTER
+    // can win before the reader has begun and the test proves nothing.
+    await lockAcquired;
+
+    // 3. Deploy the lock-bounded migration while the reader holds its lock.
+    writeMigration('20260101000001_bound', BOUND_SQL);
+    const deploy = await runMigrateDeploy();
+    await blockerDone;
+
+    const output = deploy.output;
+    // It must have genuinely lost the race at least once...
+    expect(output).toContain('canceling statement due to lock timeout');
+    expect(output).toContain(
+      'Retrying prisma migrate deploy after bounded native recovery',
+    );
+    // ...and then won, rather than exhausting the budget.
+    expect(deploy.status).toBe(0);
+    expect(await readReloptions()).toContain('fastupdate=off');
+  }, 240_000);
+});

--- a/packages/super-sync-server/tests/integration/migrate-deploy-lock-retry.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/migrate-deploy-lock-retry.integration.spec.ts
@@ -74,11 +74,12 @@ interface DeployResult {
   output: string;
 }
 
+const LOCK_TIMEOUT_MARKER = 'canceling statement due to lock timeout';
+
 // Must be async: the blocking reader below holds its lock on this process's
 // event loop, so a spawnSync here would freeze the blocker and prevent it ever
 // releasing — the migration would then exhaust its whole budget.
-const LOCK_TIMEOUT_MARKER = 'canceling statement due to lock timeout';
-
+//
 // `onLockTimeout` fires as soon as the script reports its first real 55P03 (it
 // `cat`s the migrate log immediately after each failed attempt). Releasing the
 // blocker on that observation rather than on a timer makes contention
@@ -145,7 +146,7 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
       join(projectDir, 'prisma', 'migrations', 'migration_lock.toml'),
       'provider = "postgresql"\n',
     );
-  });
+  }, 60_000);
 
   afterAll(async () => {
     // Drop the schema even if removing the fixture dir throws, and even if
@@ -163,8 +164,7 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
     // 1. Seed the table + index with no contention.
     writeMigration('20260101000000_seed', SEED_SQL);
     const seed = await runMigrateDeploy();
-    expect(seed.status).toBe(0);
-    expect(seed.output).not.toContain('ERROR:');
+    expect(seed.status, seed.output).toBe(0);
     expect(await readReloptions()).toBeNull();
 
     // 2. Hold a plain seq-scan reader open. The planner takes AccessShareLock on
@@ -174,7 +174,7 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
     const blocker = new PrismaClient({
       datasources: { db: { url: urlForSchema() } },
     });
-    const maxHoldMs = 60_000;
+    const maxHoldMs = 120_000;
     let lockHeld: () => void;
     let releaseBlocker: () => void;
     const lockAcquired = new Promise<void>((resolve) => (lockHeld = resolve));
@@ -215,12 +215,12 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
     const retries = output.match(
       /Retrying prisma migrate deploy after bounded native recovery/g,
     );
-    expect(retries?.length ?? 0).toBeGreaterThan(0);
+    expect(retries?.length ?? 0, output).toBeGreaterThan(0);
     // ...but nowhere near exhausting the budget — otherwise this would pass just
     // as green while sitting one hiccup away from the cliff.
-    expect(retries?.length ?? 0).toBeLessThan(5);
+    expect(retries?.length ?? 0, output).toBeLessThan(5);
     // ...and then won.
-    expect(deploy.status).toBe(0);
+    expect(deploy.status, output).toBe(0);
     expect(await readReloptions()).toContain('fastupdate=off');
   }, 240_000);
 });

--- a/packages/super-sync-server/tests/integration/migrate-deploy-lock-retry.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/migrate-deploy-lock-retry.integration.spec.ts
@@ -4,10 +4,15 @@
  * really fails with 55P03, and migrate-deploy.sh's shape gate really recognizes
  * it and really retries until it wins.
  *
- * The sibling unit spec drives a FAKE `npx prisma`, so it can only prove the
- * script's control flow. It cannot prove that the gate matches SQL Postgres
- * actually accepts, that Prisma's real 55P03 output matches the log anchors, or
- * that a plain seq-scan reader is enough to block the ALTER. This does.
+ * The sibling unit spec drives a FAKE `npx prisma` emitting a canned error, so
+ * nothing else in the repo proves that the script's log anchors
+ * (`^Database error code: 55P03$`, `^ERROR: canceling statement due to lock
+ * timeout$`) match what Prisma actually prints — if they drifted, the whole
+ * retry path would be dead in production with every unit test still green. Nor
+ * does anything else prove a plain seq-scan reader can starve the ALTER.
+ *
+ * It does NOT supersede the unit spec: that one reads the real committed
+ * migration.sql, whereas the shape here is written inline.
  */
 import { PrismaClient } from '@prisma/client';
 import { spawn } from 'node:child_process';
@@ -29,12 +34,25 @@ const TEST_SCHEMA = 'migrate_lock_retry_test';
 const TABLE = 'lock_retry_probe';
 const INDEX = 'lock_retry_probe_gin';
 
-const urlForSchema = (applicationName: string): string => {
+const urlForSchema = (): string => {
   const url = new URL(DATABASE_URL as string);
   url.searchParams.set('schema', TEST_SCHEMA);
-  url.searchParams.set('application_name', applicationName);
   return url.toString();
 };
+
+const withAdmin = async <T>(fn: (admin: PrismaClient) => Promise<T>): Promise<T> => {
+  const admin = new PrismaClient({ datasources: { db: { url: urlForSchema() } } });
+  try {
+    return await fn(admin);
+  } finally {
+    await admin.$disconnect();
+  }
+};
+
+const dropTestSchema = (): Promise<unknown> =>
+  withAdmin((admin) =>
+    admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${TEST_SCHEMA}" CASCADE`),
+  );
 
 const SEED_SQL = `CREATE TABLE "${TABLE}" ("id" SERIAL PRIMARY KEY, "tags" TEXT[] NOT NULL DEFAULT '{}');
 CREATE INDEX "${INDEX}" ON "${TABLE}" USING GIN ("tags");`;
@@ -59,28 +77,39 @@ interface DeployResult {
 // Must be async: the blocking reader below holds its lock on this process's
 // event loop, so a spawnSync here would freeze the blocker and prevent it ever
 // releasing — the migration would then exhaust its whole budget.
-const runMigrateDeploy = (): Promise<DeployResult> =>
+const LOCK_TIMEOUT_MARKER = 'canceling statement due to lock timeout';
+
+// `onLockTimeout` fires as soon as the script reports its first real 55P03 (it
+// `cat`s the migrate log immediately after each failed attempt). Releasing the
+// blocker on that observation rather than on a timer makes contention
+// guaranteed at any runner speed, instead of racing a wall clock.
+const runMigrateDeploy = (onLockTimeout?: () => void): Promise<DeployResult> =>
   new Promise((resolve, reject) => {
     const child = spawn('sh', [migrateScript], {
       cwd: projectDir,
       env: {
         ...process.env,
-        DATABASE_URL: urlForSchema('supersync-migrator-locktest'),
+        DATABASE_URL: urlForSchema(),
         MIGRATE_STEP_TIMEOUT: '60',
       },
     });
     let output = '';
-    child.stdout.on('data', (chunk: Buffer) => (output += chunk.toString()));
-    child.stderr.on('data', (chunk: Buffer) => (output += chunk.toString()));
+    let signalled = false;
+    const collect = (chunk: Buffer): void => {
+      output += chunk.toString();
+      if (!signalled && output.includes(LOCK_TIMEOUT_MARKER)) {
+        signalled = true;
+        onLockTimeout?.();
+      }
+    };
+    child.stdout.on('data', collect);
+    child.stderr.on('data', collect);
     child.on('error', reject);
     child.on('close', (status: number | null) => resolve({ status, output }));
   });
 
-const readReloptions = async (): Promise<string[] | null> => {
-  const admin = new PrismaClient({
-    datasources: { db: { url: urlForSchema('locktest-admin') } },
-  });
-  try {
+const readReloptions = (): Promise<string[] | null> =>
+  withAdmin(async (admin) => {
     const rows = await admin.$queryRawUnsafe<Array<{ reloptions: string[] | null }>>(
       `SELECT c.reloptions
          FROM pg_class c
@@ -90,13 +119,14 @@ const readReloptions = async (): Promise<string[] | null> => {
       TEST_SCHEMA,
     );
     return rows[0]?.reloptions ?? null;
-  } finally {
-    await admin.$disconnect();
-  }
-};
+  });
 
 describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    // A killed run (job timeout, worker crash) leaves the schema behind, and a
+    // leftover `_prisma_migrations` would make the next seed a no-op and fail
+    // confusingly. Drop first, don't only drop after.
+    await dropTestSchema();
     // Inside the package so `npx prisma` resolves through the normal upward
     // node_modules lookup.
     projectDir = mkdtempSync(join(packageDir, '.tmp-lock-retry-'));
@@ -118,23 +148,23 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
   });
 
   afterAll(async () => {
-    rmSync(projectDir, { recursive: true, force: true });
-    const admin = new PrismaClient({
-      datasources: { db: { url: urlForSchema('locktest-cleanup') } },
-    });
+    // Drop the schema even if removing the fixture dir throws, and even if
+    // beforeAll died before projectDir was assigned.
     try {
-      await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${TEST_SCHEMA}" CASCADE`);
+      if (projectDir) {
+        rmSync(projectDir, { recursive: true, force: true });
+      }
     } finally {
-      await admin.$disconnect();
+      await dropTestSchema();
     }
-  });
+  }, 60_000);
 
   it('retries through a real 55P03 lock timeout and applies the migration', async () => {
     // 1. Seed the table + index with no contention.
     writeMigration('20260101000000_seed', SEED_SQL);
     const seed = await runMigrateDeploy();
-    expect(seed.output).not.toContain('ERROR:');
     expect(seed.status).toBe(0);
+    expect(seed.output).not.toContain('ERROR:');
     expect(await readReloptions()).toBeNull();
 
     // 2. Hold a plain seq-scan reader open. The planner takes AccessShareLock on
@@ -142,11 +172,13 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
     //    holds it to end of transaction, which is exactly what starves the
     //    ALTER's 1s window in production.
     const blocker = new PrismaClient({
-      datasources: { db: { url: urlForSchema('locktest-blocker') } },
+      datasources: { db: { url: urlForSchema() } },
     });
-    const holdMs = 12_000;
+    const maxHoldMs = 60_000;
     let lockHeld: () => void;
+    let releaseBlocker: () => void;
     const lockAcquired = new Promise<void>((resolve) => (lockHeld = resolve));
+    const blockerReleased = new Promise<void>((resolve) => (releaseBlocker = resolve));
     const blockerDone = blocker
       .$transaction(
         async (tx) => {
@@ -154,9 +186,14 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
             `SELECT count(*) FROM "${TEST_SCHEMA}"."${TABLE}" WHERE "id" < 0`,
           );
           lockHeld();
-          await new Promise((resolve) => setTimeout(resolve, holdMs));
+          // Released on the first observed lock timeout; the timer is only a
+          // backstop so a broken run cannot hang the suite.
+          await Promise.race([
+            blockerReleased,
+            new Promise((resolve) => setTimeout(resolve, maxHoldMs)),
+          ]);
         },
-        { timeout: holdMs + 30_000, maxWait: 10_000 },
+        { timeout: maxHoldMs + 30_000, maxWait: 10_000 },
       )
       .finally(() => blocker.$disconnect());
 
@@ -164,18 +201,25 @@ describeWithDb('migrate-deploy.sh lock-bounded retry (real PostgreSQL)', () => {
     // can win before the reader has begun and the test proves nothing.
     await lockAcquired;
 
-    // 3. Deploy the lock-bounded migration while the reader holds its lock.
+    // 3. Deploy the lock-bounded migration while the reader holds its lock. The
+    //    blocker steps aside the moment the first attempt genuinely times out,
+    //    so contention is guaranteed and the retry wins regardless of how fast
+    //    or slow the runner is.
     writeMigration('20260101000001_bound', BOUND_SQL);
-    const deploy = await runMigrateDeploy();
+    const deploy = await runMigrateDeploy(() => releaseBlocker());
     await blockerDone;
 
     const output = deploy.output;
     // It must have genuinely lost the race at least once...
-    expect(output).toContain('canceling statement due to lock timeout');
-    expect(output).toContain(
-      'Retrying prisma migrate deploy after bounded native recovery',
+    expect(output).toContain(LOCK_TIMEOUT_MARKER);
+    const retries = output.match(
+      /Retrying prisma migrate deploy after bounded native recovery/g,
     );
-    // ...and then won, rather than exhausting the budget.
+    expect(retries?.length ?? 0).toBeGreaterThan(0);
+    // ...but nowhere near exhausting the budget — otherwise this would pass just
+    // as green while sitting one hiccup away from the cliff.
+    expect(retries?.length ?? 0).toBeLessThan(5);
+    // ...and then won.
     expect(deploy.status).toBe(0);
     expect(await readReloptions()).toContain('fastupdate=off');
   }, 240_000);

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -96,7 +96,13 @@ case "$sub" in
                 fi
                 echo $((seen + 1)) > "$state/lock_timeout_count_$m"
                 echo "Applying migration \\\`$m\\\`"
-                echo "Error: P3018"
+                if [ "\${FAKE_COLOR:-0}" = "1" ]; then
+                  # Prisma wraps the code in ANSI under FORCE_COLOR; the gates
+                  # must still fire, so the log is stripped at capture.
+                  printf '\\033[1m\\033[31mError: \\033[39m\\033[22m\\033[31mP3018\\033[39m\\n'
+                else
+                  echo "Error: P3018"
+                fi
                 echo "A migration failed to apply. New migrations cannot be applied before the error is recovered from."
                 echo "Migration name: $m"
                 echo "Database error code: 55P03"
@@ -184,6 +190,7 @@ const run = (env: Record<string, string>, args: string[] = []): RunResult => {
     stdout = execFileSync('sh', [SCRIPT, ...args], {
       cwd: projectDir,
       encoding: 'utf8',
+      timeout: 60_000,
       env: {
         PATH: `${binDir}:${process.env.PATH ?? ''}`,
         TMPDIR: stateDir,
@@ -327,6 +334,62 @@ describe('migrate-deploy.sh recovery', () => {
     );
   });
 
+  it('accepts a millisecond bound at the cap', () => {
+    // The reject cases below pin the ceiling, but nothing else accepts a `ms`
+    // value at all — deleting the whole millisecond alternation used to leave
+    // the suite green while silently refusing every documented ms migration.
+    const msMigration = '20260902000000_bound_in_ms';
+    writeMigration(
+      msMigration,
+      `SET LOCAL lock_timeout = '5000ms';\nALTER INDEX "users_email_key" SET (fillfactor = 90);`,
+    );
+
+    const r = run({ FAKE_FAIL: msMigration, FAKE_CODE: 'LOCK_TIMEOUT' });
+
+    expect(r.status).toBe(0);
+    expect(r.deployAttempts).toBe(2);
+    expect(r.resolveRolledBack).toEqual([msMigration]);
+  });
+
+  it('gives each lock-bounded migration its own retry budget in one deploy', () => {
+    // Nothing else uses two lock-bounded migrations, so the counter reset was
+    // dead code. This also pins the run-level cost: the budget is PER MIGRATION.
+    const second = '20260903000000_bound_users_fillfactor';
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+    writeMigration(
+      second,
+      `SET LOCAL lock_timeout = '1s';\nALTER INDEX "users_email_key" SET (fillfactor = 90);`,
+    );
+
+    const r = run({
+      FAKE_FAIL: `${FASTUPDATE_MIGRATION} ${second}`,
+      FAKE_CODE: 'LOCK_TIMEOUT',
+      FAKE_LOCK_TIMEOUT_TIMES: '6',
+    });
+
+    // 6 failures each, then a win each: neither migration inherits the other's
+    // spent budget (which would exhaust at 10 and fail).
+    expect(r.status).toBe(0);
+    expect(r.resolveRolledBack).toHaveLength(12);
+    expect(r.deployAttempts).toBe(13);
+  });
+
+  it('recovers when Prisma colorizes its error output', () => {
+    // `^Error: P3018$` is the first conjunct of all three failure detectors, so
+    // an ANSI-wrapped code would disable every recovery path at once.
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({
+      FAKE_FAIL: FASTUPDATE_MIGRATION,
+      FAKE_CODE: 'LOCK_TIMEOUT',
+      FAKE_COLOR: '1',
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.deployAttempts).toBe(2);
+    expect(r.resolveRolledBack).toEqual([FASTUPDATE_MIGRATION]);
+  });
+
   it('retries a lock-bounded migration more than once (a single retry is a coin flip)', () => {
     // Production 2026-07-21: one deploy lost both of its two allowed attempts,
     // the next won on its second. A budget of one retry cannot survive that.
@@ -462,8 +525,28 @@ describe('migrate-deploy.sh recovery', () => {
     const r = run({ FAKE_FAIL: FASTUPDATE_MIGRATION, FAKE_CODE: 'LOCK_TIMEOUT' });
 
     expect(r.status).not.toBe(0);
+    // Assert the REASON, not just that it stopped — every other fail_loudly
+    // also yields a non-zero status with nothing resolved, so without this the
+    // block cannot tell "refused the lock timeout" from "refused the shape".
+    expect(r.stdout).toContain('refusing to auto-resolve its lock timeout');
     expect(r.deployAttempts).toBe(1);
     expect(r.resolveRolledBack).toEqual([]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+  });
+
+  it('never auto-recovers a CONCURRENTLY migration that lock-timed-out', () => {
+    // The guard this pins is the only thing stopping a 55P03 on a CONCURRENTLY
+    // migration from falling through to out-of-band execution + `resolve
+    // --applied` — the shape of the 2026-05-18 missing-index outage (#7654).
+    // Reachable whenever DATABASE_URL carries an operator lock_timeout, which
+    // applies to migrations that set none themselves.
+    writeMigration(ENCRYPTED_OPS, ENCRYPTED_OPS_SQL);
+
+    const r = run({ FAKE_FAIL: ENCRYPTED_OPS, FAKE_CODE: 'LOCK_TIMEOUT' });
+
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toContain('refusing to auto-resolve its lock timeout');
     expect(r.resolveApplied).toEqual([]);
     expect(r.executedSql).toBe('');
   });

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -85,11 +85,16 @@ case "$sub" in
                 echo "ERROR: DROP INDEX CONCURRENTLY cannot run inside a transaction block"
                 ;;
               LOCK_TIMEOUT)
-                if [ "\${FAKE_LOCK_TIMEOUT_ALWAYS:-0}" != "1" ] && [ -f "$state/lock_timeout_seen_$m" ]; then
+                # Fails FAKE_LOCK_TIMEOUT_TIMES times (default 1), then applies,
+                # so a test can pin how many native retries actually happen.
+                times="\${FAKE_LOCK_TIMEOUT_TIMES:-1}"
+                seen=0
+                [ -f "$state/lock_timeout_count_$m" ] && seen=$(cat "$state/lock_timeout_count_$m")
+                if [ "\${FAKE_LOCK_TIMEOUT_ALWAYS:-0}" != "1" ] && [ "$seen" -ge "$times" ]; then
                   : > "$state/applied_$m"
                   continue
                 fi
-                : > "$state/lock_timeout_seen_$m"
+                echo $((seen + 1)) > "$state/lock_timeout_count_$m"
                 echo "Applying migration \\\`$m\\\`"
                 echo "Error: P3018"
                 echo "A migration failed to apply. New migrations cannot be applied before the error is recovered from."
@@ -273,12 +278,13 @@ describe('migrate-deploy.sh recovery', () => {
     expect(r.resolveApplied).toEqual([]);
   });
 
-  it('rolls back and retries the bounded fastupdate migration natively after a lock timeout', () => {
+  it('rolls back and retries a lock-bounded migration natively after a lock timeout', () => {
     writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
 
     const r = run({
       FAKE_FAIL: FASTUPDATE_MIGRATION,
       FAKE_CODE: 'LOCK_TIMEOUT',
+      MIGRATE_LOCK_RETRY_SLEEP: '0',
       MIGRATE_STEP_TIMEOUT: '7',
       DATABASE_URL:
         'postgresql://u:p@postgres:5432/supersync?options=-c%20statement_timeout%3D60000',
@@ -300,29 +306,100 @@ describe('migrate-deploy.sh recovery', () => {
     expect(new Set(applicationNames).size).toBe(1);
   });
 
-  it('clears the failed row and exits cleanly retryable after a repeated fastupdate lock timeout', () => {
+  it('clears the failed row and exits cleanly retryable after a repeated lock timeout', () => {
     writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
 
     const r = run({
       FAKE_FAIL: FASTUPDATE_MIGRATION,
       FAKE_CODE: 'LOCK_TIMEOUT',
       FAKE_LOCK_TIMEOUT_ALWAYS: '1',
+      MIGRATE_LOCK_RETRY_SLEEP: '0',
     });
 
     expect(r.status).not.toBe(0);
-    expect(r.deployAttempts).toBe(2);
-    expect(r.resolveRolledBack).toEqual([FASTUPDATE_MIGRATION, FASTUPDATE_MIGRATION]);
+    // The retry budget is bounded and exhausted; the record is left rolled back
+    // after every attempt, so re-running the deploy is always safe.
+    expect(r.deployAttempts).toBe(10);
+    expect(r.resolveRolledBack).toHaveLength(10);
+    expect(new Set(r.resolveRolledBack)).toEqual(new Set([FASTUPDATE_MIGRATION]));
     expect(r.resolveApplied).toEqual([]);
     expect(r.executedSql).toBe('');
     expect(r.stdout).toContain(
-      'failed again after its bounded native retry and was left rolled back',
+      'could not take its lock in 10 attempts and was left rolled back',
     );
+  });
+
+  it('retries a lock-bounded migration more than once (a single retry is a coin flip)', () => {
+    // Production 2026-07-21: one deploy lost both of its two allowed attempts,
+    // the next won on its second. A budget of one retry cannot survive that.
+    writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+    const r = run({
+      FAKE_FAIL: FASTUPDATE_MIGRATION,
+      FAKE_CODE: 'LOCK_TIMEOUT',
+      FAKE_LOCK_TIMEOUT_TIMES: '4',
+      MIGRATE_LOCK_RETRY_SLEEP: '0',
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.deployAttempts).toBe(5);
+    expect(r.resolveRolledBack).toHaveLength(4);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
+  });
+
+  // An EMPTY value is not tested: `${MIGRATE_LOCK_RETRY_SLEEP:-5}` treats it as
+  // unset and falls back to the default, matching MIGRATE_STEP_TIMEOUT.
+  it.each(['abc', '-1', '600'])(
+    'refuses to start with an out-of-range MIGRATE_LOCK_RETRY_SLEEP (%s)',
+    (sleepValue) => {
+      // This knob multiplies the same wall-clock budget MAX_LOCK_ATTEMPTS is
+      // hardcoded to protect, and the Helm initContainer has no outer timeout,
+      // so a bad value must stop the deploy rather than stretch it.
+      writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
+
+      const r = run({
+        FAKE_FAIL: '',
+        FAKE_CODE: 'P3018',
+        MIGRATE_LOCK_RETRY_SLEEP: sleepValue,
+      });
+
+      expect(r.status).toBe(2);
+      expect(r.stdout).toContain('MIGRATE_LOCK_RETRY_SLEEP must be an integer');
+      expect(r.deployAttempts).toBe(0);
+    },
+  );
+
+  it('retries a lock-bounded migration under any migration and index name', () => {
+    // The gate is on SHAPE, not on a name: hardcoding either here is what went
+    // stale and broke a production deploy once already.
+    const other = '20260901000000_bound_users_fillfactor';
+    writeMigration(
+      other,
+      `SET LOCAL lock_timeout = '2s';\nALTER INDEX "users_email_key" SET (fillfactor = 90);`,
+    );
+
+    const r = run({
+      FAKE_FAIL: other,
+      FAKE_CODE: 'LOCK_TIMEOUT',
+      MIGRATE_LOCK_RETRY_SLEEP: '0',
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.deployAttempts).toBe(2);
+    expect(r.resolveRolledBack).toEqual([other]);
+    expect(r.resolveApplied).toEqual([]);
+    expect(r.executedSql).toBe('');
   });
 
   it('recovers a pre-existing failed fastupdate migration and retries it natively', () => {
     writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
 
-    const r = run({ FAKE_FAIL: FASTUPDATE_MIGRATION, FAKE_CODE: 'P3009' });
+    const r = run({
+      FAKE_FAIL: FASTUPDATE_MIGRATION,
+      FAKE_CODE: 'P3009',
+      MIGRATE_LOCK_RETRY_SLEEP: '0',
+    });
 
     expect(r.status).toBe(0);
     expect(r.deployAttempts).toBe(2);
@@ -349,16 +426,48 @@ describe('migrate-deploy.sh recovery', () => {
 
   it.each([
     {
+      // A third statement means the migration is no longer the atomic
+      // two-statement shape whose re-run is provably free.
       label: 'an extra statement',
       sql: `${FASTUPDATE_SQL}\nSELECT 1;`,
     },
     {
-      label: 'another index',
-      sql: `SET LOCAL lock_timeout = '1s';\nALTER INDEX "another_gin" SET (fastupdate = off);`,
+      // Bounds the wrong GUC. Without a lock_timeout the ALTER queues every new
+      // query on the table behind its waiting ACCESS EXCLUSIVE request instead
+      // of failing fast, so retrying it is not the safe move.
+      label: 'a bound on the wrong setting',
+      sql: `SET LOCAL statement_timeout = '1s';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);`,
     },
     {
-      label: 'fastupdate enabled',
-      sql: `SET LOCAL lock_timeout = '1s';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = on);`,
+      // No bound at all.
+      label: 'no lock_timeout bound',
+      sql: `ALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);`,
+    },
+    {
+      // A CONCURRENTLY migration must never take this path: Postgres gives a
+      // single-statement migration no implicit transaction, so a lock timeout
+      // mid-build leaves an INVALID index a retry cannot clear.
+      label: 'a CONCURRENTLY index build',
+      sql: `SET LOCAL lock_timeout = '1s';\nDROP INDEX CONCURRENTLY IF EXISTS "operations_entity_ids_gin";`,
+    },
+    {
+      // split_statements breaks on `;` at END OF LINE, so a second statement
+      // sharing the ALTER's line arrives as one chunk that still ends in `);`.
+      // Rejecting an interior `;` is what keeps CONCURRENTLY out.
+      label: 'a CONCURRENTLY build smuggled onto the ALTER line',
+      sql: `SET LOCAL lock_timeout = '1s';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off); CREATE INDEX CONCURRENTLY "x" ON "operations"("user_id");`,
+    },
+    {
+      // '0' DISABLES lock_timeout in PostgreSQL — i.e. wait forever. Retrying
+      // that is the outage shape the bound exists to prevent, 10x over.
+      label: 'a disabled lock_timeout',
+      sql: `SET LOCAL lock_timeout = '0';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);`,
+    },
+    {
+      // Likewise any long bound: the ALTER would queue every new query on the
+      // table behind its waiting ACCESS EXCLUSIVE request for 30 minutes.
+      label: 'an oversized lock_timeout',
+      sql: `SET LOCAL lock_timeout = '30min';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);`,
     },
   ])('refuses lock-timeout recovery for $label', ({ sql }) => {
     writeMigration(FASTUPDATE_MIGRATION, sql);

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -284,7 +284,6 @@ describe('migrate-deploy.sh recovery', () => {
     const r = run({
       FAKE_FAIL: FASTUPDATE_MIGRATION,
       FAKE_CODE: 'LOCK_TIMEOUT',
-      MIGRATE_LOCK_RETRY_SLEEP: '0',
       MIGRATE_STEP_TIMEOUT: '7',
       DATABASE_URL:
         'postgresql://u:p@postgres:5432/supersync?options=-c%20statement_timeout%3D60000',
@@ -313,7 +312,6 @@ describe('migrate-deploy.sh recovery', () => {
       FAKE_FAIL: FASTUPDATE_MIGRATION,
       FAKE_CODE: 'LOCK_TIMEOUT',
       FAKE_LOCK_TIMEOUT_ALWAYS: '1',
-      MIGRATE_LOCK_RETRY_SLEEP: '0',
     });
 
     expect(r.status).not.toBe(0);
@@ -338,7 +336,6 @@ describe('migrate-deploy.sh recovery', () => {
       FAKE_FAIL: FASTUPDATE_MIGRATION,
       FAKE_CODE: 'LOCK_TIMEOUT',
       FAKE_LOCK_TIMEOUT_TIMES: '4',
-      MIGRATE_LOCK_RETRY_SLEEP: '0',
     });
 
     expect(r.status).toBe(0);
@@ -347,28 +344,6 @@ describe('migrate-deploy.sh recovery', () => {
     expect(r.resolveApplied).toEqual([]);
     expect(r.executedSql).toBe('');
   });
-
-  // An EMPTY value is not tested: `${MIGRATE_LOCK_RETRY_SLEEP:-5}` treats it as
-  // unset and falls back to the default, matching MIGRATE_STEP_TIMEOUT.
-  it.each(['abc', '-1', '600'])(
-    'refuses to start with an out-of-range MIGRATE_LOCK_RETRY_SLEEP (%s)',
-    (sleepValue) => {
-      // This knob multiplies the same wall-clock budget MAX_LOCK_ATTEMPTS is
-      // hardcoded to protect, and the Helm initContainer has no outer timeout,
-      // so a bad value must stop the deploy rather than stretch it.
-      writeMigration(FASTUPDATE_MIGRATION, FASTUPDATE_SQL);
-
-      const r = run({
-        FAKE_FAIL: '',
-        FAKE_CODE: 'P3018',
-        MIGRATE_LOCK_RETRY_SLEEP: sleepValue,
-      });
-
-      expect(r.status).toBe(2);
-      expect(r.stdout).toContain('MIGRATE_LOCK_RETRY_SLEEP must be an integer');
-      expect(r.deployAttempts).toBe(0);
-    },
-  );
 
   it('retries a lock-bounded migration under any migration and index name', () => {
     // The gate is on SHAPE, not on a name: hardcoding either here is what went
@@ -382,7 +357,6 @@ describe('migrate-deploy.sh recovery', () => {
     const r = run({
       FAKE_FAIL: other,
       FAKE_CODE: 'LOCK_TIMEOUT',
-      MIGRATE_LOCK_RETRY_SLEEP: '0',
     });
 
     expect(r.status).toBe(0);
@@ -398,7 +372,6 @@ describe('migrate-deploy.sh recovery', () => {
     const r = run({
       FAKE_FAIL: FASTUPDATE_MIGRATION,
       FAKE_CODE: 'P3009',
-      MIGRATE_LOCK_RETRY_SLEEP: '0',
     });
 
     expect(r.status).toBe(0);

--- a/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
+++ b/packages/super-sync-server/tests/migrate-deploy-script.spec.ts
@@ -346,12 +346,14 @@ describe('migrate-deploy.sh recovery', () => {
   });
 
   it('retries a lock-bounded migration under any migration and index name', () => {
-    // The gate is on SHAPE, not on a name: hardcoding either here is what went
-    // stale and broke a production deploy once already.
+    // The gate is on SHAPE, not on a name. Lowercase keywords and irregular
+    // spacing are deliberately tolerated too (grep -Ei + [[:space:]]), so a
+    // future author does not lose the retry path to formatting; at the upper
+    // bound of the allowed lock_timeout, which pins the accept side of the cap.
     const other = '20260901000000_bound_users_fillfactor';
     writeMigration(
       other,
-      `SET LOCAL lock_timeout = '2s';\nALTER INDEX "users_email_key" SET (fillfactor = 90);`,
+      `set local  lock_timeout='5s';\nalter  index "users_email_key"  set ( fillfactor = 90 );`,
     );
 
     const r = run({
@@ -426,7 +428,8 @@ describe('migrate-deploy.sh recovery', () => {
     {
       // split_statements breaks on `;` at END OF LINE, so a second statement
       // sharing the ALTER's line arrives as one chunk that still ends in `);`.
-      // Rejecting an interior `;` is what keeps CONCURRENTLY out.
+      // What rejects it is the ALTER pattern's anchored, PAREN-FREE option list:
+      // the ALTER's own `)` lands inside the span, so nothing can follow it.
       label: 'a CONCURRENTLY build smuggled onto the ALTER line',
       sql: `SET LOCAL lock_timeout = '1s';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off); CREATE INDEX CONCURRENTLY "x" ON "operations"("user_id");`,
     },
@@ -441,6 +444,17 @@ describe('migrate-deploy.sh recovery', () => {
       // table behind its waiting ACCESS EXCLUSIVE request for 30 minutes.
       label: 'an oversized lock_timeout',
       sql: `SET LOCAL lock_timeout = '30min';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);`,
+    },
+    {
+      // Just over the cap, in each unit — pins the boundary itself, so the two
+      // branches of the bound cannot drift apart (9999ms once meant ~10s while
+      // 6s was refused).
+      label: 'a bound just over the cap in seconds',
+      sql: `SET LOCAL lock_timeout = '6s';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);`,
+    },
+    {
+      label: 'a bound just over the cap in milliseconds',
+      sql: `SET LOCAL lock_timeout = '5001ms';\nALTER INDEX "operations_entity_ids_gin" SET (fastupdate = off);`,
     },
   ])('refuses lock-timeout recovery for $label', ({ sql }) => {
     writeMigration(FASTUPDATE_MIGRATION, sql);

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -206,7 +206,16 @@ describe('performance migrations', () => {
 
     // Prisma wraps each migration independently, so the consecutive directory
     // is a separate transaction and cannot extend the ALTER's exclusive lock.
-    expect(cleanupMigrationName > alterMigrationName).toBe(true);
+    // Ordered against the real migration directory — comparing the two literals
+    // above to each other would be a tautology that nothing could ever fail.
+    const migrationNames = readdirSync(migrationsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+    expect(migrationNames).toContain(alterMigrationName);
+    expect(migrationNames.indexOf(cleanupMigrationName)).toBeGreaterThan(
+      migrationNames.indexOf(alterMigrationName),
+    );
     const cleanup = cleanupSql.match(
       /\bSELECT\s+(?:pg_catalog\.)?gin_clean_pending_list\s*\([^)]*operations_entity_ids_gin[^)]*\)\s*;/i,
     );
@@ -401,6 +410,21 @@ describe('performance migrations', () => {
     expect(runtimeMigrateScript).not.toContain(
       'operations_user_id_full_state_server_seq_idx',
     );
+    // The three names above are a legacy denylist, so the invariant passed
+    // vacuously when a NEW hardcode was added. Enforce it structurally instead,
+    // against every index name the migrations actually define, so a future
+    // hardcode of a name not on the list above cannot slip through either.
+    const indexNames = [
+      ...allMigrationSql().matchAll(
+        /\b(?:CREATE|ALTER|DROP)\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+(?:NOT\s+)?EXISTS\s+)?"([^"]+)"/gi,
+      ),
+    ].map((match) => match[1]);
+    expect(indexNames.length).toBeGreaterThan(3);
+    for (const indexName of new Set(indexNames)) {
+      expect(runtimeMigrateScript).not.toContain(indexName);
+    }
+    // No migration directory name either.
+    expect(runtimeMigrateScript).not.toMatch(/\b20\d{12}_[a-z]/);
     expect(composeFile).toContain(
       'RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}',
     );

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -417,8 +417,13 @@ describe('performance migrations', () => {
     // Reloption keywords are not index names, so the derived list cannot see a
     // hardcode like `fastupdate` — check the ones the migrations actually set.
     const reloptions = [
-      ...migrationSql.matchAll(/\bALTER\s+INDEX\s+"[^"]+"\s+SET\s*\(\s*([a-z_]+)/gi),
+      ...migrationSql.matchAll(
+        /\bALTER\s+INDEX\s+(?:IF\s+EXISTS\s+)?"[^"]+"\s+SET\s*\(\s*([a-z_]+)/gi,
+      ),
     ].map((match) => match[1]);
+    // Same sentinel role as above: this list has exactly one entry today, so a
+    // regex that quietly stopped matching would leave `[].filter(...)` green.
+    expect(reloptions).toContain('fastupdate');
     expect(reloptions.filter((name) => runtimeMigrateScript.includes(name))).toEqual([]);
     // No migration directory name either.
     expect(runtimeMigrateScript).not.toMatch(/\b20\d{12}_[a-z]/);

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -401,28 +401,25 @@ describe('performance migrations', () => {
     // coverage of the recovery logic lives in migrate-deploy-script.spec.ts.
     expect(runtimeMigrateScript).toContain('npx prisma migrate deploy');
     expect(runtimeMigrateScript).not.toMatch(/_INDEX_MIGRATION=/);
-    expect(runtimeMigrateScript).not.toContain(
-      'operations_user_id_server_seq_encrypted_idx',
-    );
-    expect(runtimeMigrateScript).not.toContain(
-      'operations_payload_bytes_unbackfilled_idx',
-    );
-    expect(runtimeMigrateScript).not.toContain(
-      'operations_user_id_full_state_server_seq_idx',
-    );
-    // The three names above are a legacy denylist, so the invariant passed
-    // vacuously when a NEW hardcode was added. Enforce it structurally instead,
-    // against every index name the migrations actually define, so a future
-    // hardcode of a name not on the list above cannot slip through either.
+    // Derived from the migrations themselves rather than a hand-kept denylist —
+    // the old three-name list passed vacuously when a NEW name was hardcoded.
+    const migrationSql = allMigrationSql();
     const indexNames = [
-      ...allMigrationSql().matchAll(
+      ...migrationSql.matchAll(
         /\b(?:CREATE|ALTER|DROP)\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+(?:NOT\s+)?EXISTS\s+)?"([^"]+)"/gi,
       ),
     ].map((match) => match[1]);
-    expect(indexNames.length).toBeGreaterThan(3);
-    for (const indexName of new Set(indexNames)) {
-      expect(runtimeMigrateScript).not.toContain(indexName);
-    }
+    // Sentinel: the name this script must never mention again. Guards against
+    // the extraction silently degrading to a handful of matches and passing.
+    expect(indexNames).toContain('operations_entity_ids_gin');
+    expect(indexNames.length).toBeGreaterThan(15);
+    expect(indexNames.filter((name) => runtimeMigrateScript.includes(name))).toEqual([]);
+    // Reloption keywords are not index names, so the derived list cannot see a
+    // hardcode like `fastupdate` — check the ones the migrations actually set.
+    const reloptions = [
+      ...migrationSql.matchAll(/\bALTER\s+INDEX\s+"[^"]+"\s+SET\s*\(\s*([a-z_]+)/gi),
+    ].map((match) => match[1]);
+    expect(reloptions.filter((name) => runtimeMigrateScript.includes(name))).toEqual([]);
     // No migration directory name either.
     expect(runtimeMigrateScript).not.toMatch(/\b20\d{12}_[a-z]/);
     expect(composeFile).toContain(

--- a/packages/super-sync-server/vitest.config.ts
+++ b/packages/super-sync-server/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       'tests/integration/repair-causality.integration.spec.ts',
       'tests/integration/health-alert-db-probe.integration.spec.ts',
       'tests/integration/migrate-deploy-db-timeout.integration.spec.ts',
+      'tests/integration/migrate-deploy-lock-retry.integration.spec.ts',
       // Tests password reset routes that don't exist - server uses passkey/magic link auth
       'tests/password-reset-api.spec.ts',
     ],


### PR DESCRIPTION
## Problem

A production deploy on 2026-07-21 failed twice on `20260720000000_disable_operation_entity_ids_gin_fastupdate` with P3018 / SQLSTATE 55P03:

```
ERROR: canceling statement due to lock timeout
```

`ALTER INDEX ... SET (reloption)` needs `ACCESS EXCLUSIVE` on the index, and the planner takes `AccessShareLock` on **every** index of a table for any query that plans against it, held to end of transaction — so a single slow query on `operations` starves the deliberate 1s window. Verified on real PG16: a transaction running a pure seq scan on an *unindexed* column held `AccessShareLock` on the table and all three of its indexes.

Somewhat self-referential: an unflushed GIN pending list made conflict lookups slow (~140 blocks vs ~2), which held the lock, which blocked the migration that fixes the slowness.

`migrate-deploy.sh` allowed exactly **one** retry. The first deploy burned both attempts and aborted; the second won only on its second try. One retry is a coin flip.

Nothing was ever at risk — `deploy.sh` migrates before replacing the app container, and the record is left rolled back after every attempt.

## Changes

**Gate the native retry on shape, not on literal SQL.** `is_retryable_fastupdate_migration` matched the migration's exact text including the hardcoded index name `operations_entity_ids_gin`. It is now `is_lock_bounded_migration`, requiring: a `SET LOCAL lock_timeout` of `1–9999ms` or `1–5s`, then a single `ALTER INDEX "..." SET (...)`, and no third statement. Matched with `grep -Ei` like the neighbouring CONCURRENTLY gates, so spacing and keyword case are not load-bearing for a future author.

This restores the design goal recorded when the recovery logic moved in-image — hardcode no migration names — which `#9213` had removed from `prisma/migrations/README.md` rather than honoured.

**Raise the budget from 1 retry to 10 attempts, 5s apart.** `MAX_LOCK_ATTEMPTS` is a hardcoded literal, not an env knob: a non-numeric value would make the `-ge` test error *inside an `if`*, which `set -e` does not catch, and the Helm initContainer path has no outer timeout at all. `MIGRATE_LOCK_RETRY_SLEEP` is validated to 0–60.

**Deliberately NOT widened to "any 55P03".** A *single*-statement migration gets no implicit transaction from Postgres, so a lock timeout during a bare `CREATE INDEX CONCURRENTLY` leaves an `INVALID` index un-rolled-back — and a generic branch would short-circuit the deliberate fail-loud gate that exists because of the 2026-05-18 missing-entity-index outage (#7654).

**Two tests that could not fail.** The migration-ordering assertion compared two string literals declared three lines above; it now reads the real migrations directory. The "no hardcoded names" invariant was a denylist of three *legacy* index names, so it passed vacuously over the new hardcode it was meant to catch — it now derives every index name from the actual migrations.

**Docs.** `prisma/migrations/README.md` and the operator `README.md` (which still promised "one automatic retry"). Also corrects a factually wrong claim: editing an applied migration does **not** break `migrate deploy` — verified against PG16 / Prisma 5.22.0, it never re-reads the file and exits 0. The real reasons not to are that the edit reaches nobody who already applied it, and that `migrate dev` shadow-replays it.

## Verification

- 1000/1000 `packages/super-sync-server` tests; `sh -n` and `dash -n` clean.
- Nine sabotage mutations, each confirmed to land before trusting the result, each killing at least one named test: re-adding the hardcoded name, lowering the budget, dropping the lock_timeout-bound check, un-anchoring the ALTER option list, dropping the third-statement check, and each half of the sleep validation.
- Reviewed by seven independent agents. Two CRITICAL findings were **regressions introduced by the first draft of this PR** and are fixed here: the shape gate initially accepted any `lock_timeout` value including `'0'` (which *disables* the timeout in Postgres) and `'30min'`; and a second statement sharing the `ALTER`'s line still ended in `);` and was admitted, defeating the CONCURRENTLY exclusion.

## Notes for review

The retry-count raise is the only part with a reproducible production failure behind it. The name→shape refactor and the test fixes are invariant hygiene — justified by the recorded design goal and by the vacuous test that let the hardcode through unreviewed, but worth weighing on their own merits.

Not addressed (pre-existing): `MIGRATE_MAX_ATTEMPTS` is unvalidated in the same way; the Helm initContainer has no `activeDeadlineSeconds`.
