### PR TITLE
fix(sync): offer both ETag spellings on conditional WebDAV uploads

### DIFF
--- a/packages/sync-providers/src/file-based/webdav/webdav-api.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-api.ts
@@ -24,6 +24,15 @@ import type { WebdavPrivateCfg } from './webdav.model';
  */
 const STRONG_ETAG_RE = /^"[\x21\x23-\x7e\x80-\xff]*"$/;
 
+/**
+ * Content-coding suffixes Apache appends to the ETag it SERVES on a compressed
+ * response — `mod_deflate` under its default `DeflateAlterETag AddSuffix`, and
+ * `mod_brotli` likewise. The origin keeps comparing `If-Match` against the bare
+ * tag, so a client that echoes back what it was served can never satisfy the
+ * precondition (#9154, #9196).
+ */
+const CONTENT_CODING_ETAG_SUFFIX_RE = /-(?:gzip|br|deflate)"$/;
+
 export interface WebdavApiDeps {
   logger: SyncLogger;
   /**
@@ -61,6 +70,27 @@ export class WebdavApi {
 
   private _isStrongEtag(value: string): boolean {
     return STRONG_ETAG_RE.test(value);
+  }
+
+  /**
+   * `If-Match` value for a rev, offering the bare tag alongside the served one
+   * whenever the served tag carries a content-coding suffix.
+   *
+   * RFC 7232 lets `If-Match` carry a list and the precondition passes if ANY
+   * member matches, so we let the server pick whichever form it actually
+   * compares. This keeps the write atomic — no precondition is ever dropped —
+   * and costs no extra round trip. A genuine concurrent write still matches
+   * neither candidate and is rejected as before.
+   *
+   * Verified against Apache 2.4 + mod_dav + mod_deflate (list → 204, stale list
+   * → 412); sabre/dav, which evaluates `If-Match` for Nextcloud, splits the list
+   * the same way.
+   */
+  private _ifMatchValue(rev: string): string {
+    const bare = rev.replace(CONTENT_CODING_ETAG_SUFFIX_RE, '"');
+    // `""` would be a degenerate tag: a rev of `"-gzip"` is a tag in its own
+    // right, not a suffixed one.
+    return bare === rev || bare === '""' ? rev : `${rev}, ${bare}`;
   }
 
   private _isHttpStatus(error: unknown, status: number): boolean {
@@ -255,7 +285,7 @@ export class WebdavApi {
         [WebDavHttpHeader.CONTENT_TYPE]: 'application/octet-stream',
       };
       if (!isForceOverwrite && strongExpectedRev) {
-        headers[WebDavHttpHeader.IF_MATCH] = strongExpectedRev;
+        headers[WebDavHttpHeader.IF_MATCH] = this._ifMatchValue(strongExpectedRev);
       } else if (!isForceOverwrite && expectedRev === null) {
         headers[WebDavHttpHeader.IF_NONE_MATCH] = '*';
       }

--- a/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
@@ -82,6 +82,68 @@ const okResponse = (
   data,
 });
 
+interface DavRequest {
+  method: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+}
+
+interface FakeDavFile {
+  body: string;
+  tag: string;
+}
+
+/**
+ * Minimal stateful WebDAV origin: a single file that honours `If-Match` and
+ * bumps its entity tag on every write.
+ *
+ * `etagSuffix` reproduces Apache `mod_deflate` under its default
+ * `DeflateAlterETag AddSuffix`: a compressed GET advertises `"<tag>-gzip"`
+ * while `If-Match` is still compared against the bare `"<tag>"`. A client that
+ * echoes back the tag it was served therefore can never satisfy the
+ * precondition — see #9154 / #9196.
+ *
+ * `If-Match` is evaluated as the RFC 7232 list it is: split on `,`, trimmed,
+ * and satisfied if ANY member matches. That mirrors both evaluators that matter
+ * — Apache's `ap_find_list_item` (verified live against 2.4 + mod_dav) and
+ * sabre/dav's `explode(',', $ifMatch)`, which is what Nextcloud runs.
+ */
+const makeFakeDavServer = (
+  file: FakeDavFile,
+  { etagSuffix = '' }: { etagSuffix?: string } = {},
+): MockAdapter => {
+  const adapter = makeAdapter();
+  let writes = 0;
+  const servedTag = (): string => `"${file.tag}${etagSuffix}"`;
+  const comparedTag = (): string => `"${file.tag}"`;
+
+  adapter.request.mockImplementation(async (raw: unknown) => {
+    const { method, headers, body } = raw as DavRequest;
+
+    if (method === 'GET') {
+      return okResponse(file.body, 200, { etag: servedTag() });
+    }
+    if (method === 'PUT') {
+      const ifMatch = headers?.[WebDavHttpHeader.IF_MATCH];
+      const candidates = ifMatch?.split(',').map((t) => t.trim());
+      if (candidates !== undefined && !candidates.includes(comparedTag())) {
+        throw new HttpNotOkAPIError(new Response('', { status: 412 }));
+      }
+      file.body = body ?? '';
+      file.tag = `tag-${(writes += 1)}`;
+      return okResponse('', 204, { etag: comparedTag() });
+    }
+    throw new Error(`FakeDavServer: unexpected ${method}`);
+  });
+
+  return adapter;
+};
+
+const putsOf = (adapter: MockAdapter): DavRequest[] =>
+  adapter.request.mock.calls
+    .map((call: unknown[]) => call[0] as DavRequest)
+    .filter((req) => req.method === 'PUT');
+
 describe('WebdavApi', () => {
   describe('listFiles', () => {
     it('returns file paths from PROPFIND multistatus, filtering folder itself', async () => {
@@ -245,6 +307,105 @@ describe('WebdavApi', () => {
           expectedRev: '"stale-rev"',
         }),
       ).rejects.toBeInstanceOf(RemoteFileChangedUnexpectedly);
+      expect(putsOf(adapter)).toHaveLength(1);
+    });
+
+    describe('servers that rewrite the ETag they serve (#9154 / #9196)', () => {
+      it("completes the upload when the served ETag carries mod_deflate's -gzip suffix", async () => {
+        const file: FakeDavFile = { body: 'remote body', tag: 'abc' };
+        const adapter = makeFakeDavServer(file, { etagSuffix: '-gzip' });
+        const api = makeApi(adapter);
+
+        // The rev the rest of the app is handed is the mangled tag.
+        const { rev } = await api.download({ path: 'op-1.json' });
+        expect(rev).toBe('"abc-gzip"');
+
+        await api.upload({ path: 'op-1.json', data: 'my new body', expectedRev: rev });
+
+        expect(file.body).toBe('my new body');
+        // The write stays atomic and costs no retry: one conditional PUT that
+        // offers the server both spellings of the tag.
+        const puts = putsOf(adapter);
+        expect(puts).toHaveLength(1);
+        expect(puts[0]?.headers?.[WebDavHttpHeader.IF_MATCH]).toBe('"abc-gzip", "abc"');
+      });
+
+      it('still refuses to overwrite a genuine concurrent write', async () => {
+        const file: FakeDavFile = { body: 'remote body', tag: 'abc' };
+        const adapter = makeFakeDavServer(file, { etagSuffix: '-gzip' });
+        const api = makeApi(adapter);
+        const { rev } = await api.download({ path: 'op-1.json' });
+
+        // Another client writes between our download and our upload.
+        file.body = 'their body';
+        file.tag = 'xyz';
+
+        await expect(
+          api.upload({ path: 'op-1.json', data: 'my new body', expectedRev: rev }),
+        ).rejects.toBeInstanceOf(RemoteFileChangedUnexpectedly);
+        expect(file.body).toBe('their body');
+      });
+
+      it('sends a single unexpanded tag to a compliant server', async () => {
+        const file: FakeDavFile = { body: 'remote body', tag: 'abc' };
+        const adapter = makeFakeDavServer(file);
+        const api = makeApi(adapter);
+        const { rev } = await api.download({ path: 'op-1.json' });
+
+        await api.upload({ path: 'op-1.json', data: 'my new body', expectedRev: rev });
+
+        const puts = putsOf(adapter);
+        expect(puts).toHaveLength(1);
+        expect(puts[0]?.headers?.[WebDavHttpHeader.IF_MATCH]).toBe('"abc"');
+      });
+
+      it('keeps working once the server re-mangles the tag it just returned', async () => {
+        // The rev handed back after an upload is mangled too, so a fix that only
+        // recovered once would 412 forever from the second upload on.
+        const file: FakeDavFile = { body: 'remote body', tag: 'abc' };
+        const adapter = makeFakeDavServer(file, { etagSuffix: '-gzip' });
+        const api = makeApi(adapter);
+
+        const first = await api.download({ path: 'op-1.json' });
+        const { rev } = await api.upload({
+          path: 'op-1.json',
+          data: 'body two',
+          expectedRev: first.rev,
+        });
+        await api.upload({ path: 'op-1.json', data: 'body three', expectedRev: rev });
+
+        expect(file.body).toBe('body three');
+        expect(putsOf(adapter)).toHaveLength(2);
+      });
+
+      it('does not expand a tag that is only the suffix', async () => {
+        // `"-gzip"` is a tag in its own right; expanding it would offer the
+        // degenerate `""` alongside it.
+        const file: FakeDavFile = { body: 'remote body', tag: '' };
+        const adapter = makeFakeDavServer(file, { etagSuffix: '-gzip' });
+        const api = makeApi(adapter);
+        const { rev } = await api.download({ path: 'op-1.json' });
+        expect(rev).toBe('"-gzip"');
+
+        await expect(
+          api.upload({ path: 'op-1.json', data: 'mine', expectedRev: rev }),
+        ).rejects.toBeInstanceOf(RemoteFileChangedUnexpectedly);
+        expect(putsOf(adapter)[0]?.headers?.[WebDavHttpHeader.IF_MATCH]).toBe('"-gzip"');
+      });
+
+      it('treats a 412 on an atomic create as a conflict, never a retry', async () => {
+        // `expectedRev: null` sends `If-None-Match: *` — a 412 there means the
+        // file EXISTS, which must never be resolved by overwriting it.
+        const adapter = makeAdapter();
+        adapter.request.mockRejectedValueOnce(
+          new HttpNotOkAPIError(new Response('', { status: 412 })),
+        );
+
+        await expect(
+          makeApi(adapter).upload({ path: 'op-1.json', data: 'mine', expectedRev: null }),
+        ).rejects.toBeInstanceOf(RemoteFileChangedUnexpectedly);
+        expect(putsOf(adapter)).toHaveLength(1);
+      });
     });
 
     it('throws RemoteFileChangedUnexpectedly when remote hash drift detected', async () => {


### PR DESCRIPTION
Fixes the WebDAV/Nextcloud upload failure reported in #9154 and, independently, in #9196 — the two are the same bug.

## The bug

Apache's `mod_deflate`, under its default `DeflateAlterETag AddSuffix`, appends `-gzip` to the ETag it **serves** on a compressed GET, while still evaluating `If-Match` against the **bare** tag. Since v18.15.0 the WebDAV provider takes the served tag as the file revision and echoes it back as a conditional PUT precondition. Against such a server:

```
GET  → ETag: "71705e…-gzip"
PUT  → If-Match: "71705e…-gzip" → 412   (server compares against "71705e…")   ×3
     → Ops-file upload retries exhausted → "Concurrent upload detected, will retry next cycle"
```

The adapter's mismatch branch re-downloads and, finding the rev unchanged, retries the **identical** doomed request until retries are exhausted. The resulting error is treated as benign concurrency, so there is no snackbar: sync goes **permanently one-way, silently**. Nextcloud's official Docker image ships `mod_deflate` enabled.

`"<md5>-gzip"` passes `STRONG_ETAG_RE` (`-` is `0x2D`), so it is accepted as a strong ETag and the legacy GET-and-compare pre-check is skipped.

**Not iOS-specific,** despite #9154's title. `webdav-http-adapter.ts` has no iOS branch and both native plugins return all headers, so iOS *and* Android are exposed; browser/PWA is exposed whenever the server sends `Access-Control-Expose-Headers: ETag`, which the #9196 reporter's Nextcloud does. Desktop is immune only incidentally: Electron strips `accept-encoding` from renderer requests, so Apache never compresses and the tag stays clean — which is what explains desktop working against the very same server that fails from the PWA.

Introduced by `2864a39c85` (#9004); shipped in **v18.15.0 and v18.15.1**.

## The fix

RFC 7232 allows `If-Match` to carry a **list** of entity tags, and the precondition passes if **any** member matches. So when the rev carries a content-coding suffix, we offer the bare tag alongside the served one and let the server pick whichever it actually compares:

```
If-Match: "71705e…-gzip", "71705e…"
```

- The write **stays conditional** — no precondition is ever dropped, so compare-and-swap is preserved for every server.
- **No extra round trip**, and no extra body transfer.
- A genuine concurrent write matches **neither** candidate and is still rejected with `RemoteFileChangedUnexpectedly`.
- Servers that never mangle see exactly the single tag they always did — the expansion only triggers on a recognised suffix.
- The rev format is unchanged, so nothing that persists or compares a rev is affected.

Net production change: **+31 / −1**, one line of which is the call site. The `upload()` catch block is byte-identical to master.

## Verification against a real server

Not a mocked seam. Apache 2.4.68 with `mod_dav` + `mod_deflate` and `DeflateAlterETag AddSuffix`:

| request | result |
|---|---|
| `GET` (no `accept-encoding`) | `"76d-65733840297fa"` |
| `GET` (`accept-encoding: gzip`) | `"76d-65733840297fa-gzip"` ← mangled |
| `PUT If-Match: "<served -gzip>"` | **412** ← the reported bug, reproduced |
| `PUT If-Match: "<bare>"` | **204** |
| `PUT If-Match: "<served>", "<bare>"` | **204** ✅ this fix |
| `PUT If-Match: "stale-gzip", "stale"` | **412** ✅ conflict still detected |

For Nextcloud the precondition is evaluated by **sabre/dav**, not Apache, so that was checked too: `lib/DAV/Server.php` does `explode(',', $ifMatch)` and compares each trimmed member, so it honours the list form identically.

(Worth noting for anyone reproducing this: Apache serves a **weak** `W/"…"` ETag while the file's mtime is in the current second, and weak tags never satisfy `If-Match`. Without a settle delay every variant returns 412 and you conclude the list form fails.)

## Testing

Six tests against a stateful fake DAV origin that reproduces the mangling and evaluates `If-Match` as an RFC 7232 list, matching both real evaluators. They cover: the `-gzip` upload succeeding in a single conditional PUT carrying both tags; a genuine concurrent write still being refused; a compliant server still receiving a single unexpanded tag; the **steady state** (a second upload after the server re-mangles the tag it just returned); a tag that is *only* the suffix not being expanded to a degenerate `""`; and a 412 on an atomic create (`If-None-Match: *`) being treated as a conflict rather than a retry.

Every one of these was mutation-tested — five independent sabotages of the production code (disable the expansion, drop the degenerate-tag guard, send only the bare tag, stop mapping 412 to a conflict, neuter the suffix pattern) and each is caught by the corresponding test, with no survivors.

- `sync-providers` vitest: 410/410 across 18 files
- full `npm test`: green in both timezone variants
- package `tsc --noEmit` and `checkFile` clean on both changed files

## Follow-up, intentionally not in this PR

The UX half is untouched: `sync-wrapper.service.ts` still swallows `UploadRevToMatchMismatchAPIError` as benign concurrency. That reasoning is right for real concurrency but backwards for a permanent, unrecoverable condition. Separate change.

Closes #9154
