### PR TITLE
test(sync): reject opaque plugin data in frozen fixture

### DIFF
--- a/src/app/op-log/validation/frozen-state.spec.ts
+++ b/src/app/op-log/validation/frozen-state.spec.ts
@@ -53,6 +53,8 @@ describe('frozen prior-release state survives migrate -> validateFull', () => {
   const DO_NOT_EDIT =
     'FROZEN FIXTURE FAILED — do NOT add the field to the fixture. Type it ' +
     "optional (`?`) or backfill it in a migration. See this spec's docblock.\n";
+  const SECRET_KEY_RE =
+    /pass|token|api_?key|secret|encryptKey|clientId|userName|username|loginName/i;
 
   // structuredClone is load-bearing: migrateState returns `state` BY REFERENCE
   // when source === target, so without it every spec here shares one live
@@ -67,6 +69,27 @@ describe('frozen prior-release state survives migrate -> validateFull', () => {
       throw new Error(`migration of frozen fixture failed: ${migrated.error}`);
     }
     return migrated.data as AppDataComplete;
+  };
+
+  const findCredentialPaths = (state: typeof frozen.state): string[] => {
+    const found: string[] = [];
+    const walk = (value: unknown, path: string): void => {
+      if (!value || typeof value !== 'object') return;
+      Object.entries(value as Record<string, unknown>).forEach(([k, v]) => {
+        if (SECRET_KEY_RE.test(k) && typeof v === 'string' && v.length) {
+          found.push(`${path}.${k}`);
+        }
+        walk(v, `${path}.${k}`);
+      });
+    };
+    walk(state.globalConfig, 'globalConfig');
+    walk(state.issueProvider, 'issueProvider');
+    state.pluginUserData.forEach(({ id, data }) => {
+      // Plugin data is an opaque string, so nested credential keys cannot be
+      // inspected reliably. Keep the fixture's placeholder exact instead.
+      if (data !== '{}') found.push(`pluginUserData.${id}.data`);
+    });
+    return found;
   };
 
   it('validates after being migrated to the current schema version', () => {
@@ -174,23 +197,17 @@ describe('frozen prior-release state survives migrate -> validateFull', () => {
   // profile would commit live credentials, so fail loudly instead of relying on
   // the "do not regenerate" comment.
   it('carries no credentials', () => {
-    const SECRET_KEY_RE =
-      /pass|token|api_?key|secret|encryptKey|clientId|userName|username|loginName/i;
-    const found: string[] = [];
-    const walk = (value: unknown, path: string): void => {
-      if (!value || typeof value !== 'object') return;
-      Object.entries(value as Record<string, unknown>).forEach(([k, v]) => {
-        if (SECRET_KEY_RE.test(k) && typeof v === 'string' && v.length) {
-          found.push(`${path}.${k}`);
-        }
-        walk(v, `${path}.${k}`);
-      });
-    };
-    walk((frozen.state as { globalConfig: unknown }).globalConfig, 'globalConfig');
-    walk((frozen.state as { issueProvider: unknown }).issueProvider, 'issueProvider');
+    const found = findCredentialPaths(frozen.state);
 
     expect(found)
       .withContext(`non-empty credential-shaped fields: ${found.join(', ')}`)
       .toEqual([]);
+  });
+
+  it('detects credentials nested in serialized plugin data', () => {
+    const state = structuredClone(frozen.state);
+    state.pluginUserData[0].data = JSON.stringify({ token: 'secret' });
+
+    expect(findCredentialPaths(state)).toContain('pluginUserData.plugin-a.data');
   });
 });


### PR DESCRIPTION
## Summary

- prevent the frozen-state credential sentinel from overlooking opaque plugin persistence payloads
- require `pluginUserData.data` to keep the fixture's exact synthetic `"{}"` value
- add a regression test proving a serialized token-shaped payload is rejected

## Why

`pluginUserData.data` accepts arbitrary serialized strings, so recursively scanning object keys cannot reliably detect credentials stored inside it. The previous sentinel scanned `globalConfig` and `issueProvider` only, allowing real plugin profile data to pass unnoticed if the frozen fixture were regenerated.

Keeping the known synthetic placeholder exact is the smallest reliable guard and avoids coupling this validation fixture to plugin codecs.

## Verification

- `npm run checkFile src/app/op-log/validation/frozen-state.spec.ts`
- focused Karma spec: 7/7 passed, including a red-before-green regression
- full pre-push suite:
  - sync-core: 243 passed
  - sync-providers: 404 passed
  - release-note/tooling tests: 24 passed
  - Angular Berlin: 13,383 passed, 2 skipped
  - Angular Los Angeles: 13,369 passed, 16 skipped
  - lint and theme checks passed with existing unrelated warnings
- independent sub-agent review: approved with no findings
