### PR TITLE
fix(op-log): explain the IndexedDB downgrade barrier instead of blaming corruption

### DIFF
--- a/e2e/tests/migration/idb-downgrade-barrier-9187.spec.ts
+++ b/e2e/tests/migration/idb-downgrade-barrier-9187.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect, Page } from '@playwright/test';
+import { skipOnboardingForE2E } from '../../utils/waits';
+
+/**
+ * Issue #9187: launching an older build against a database a newer build has
+ * already upgraded produces an IndexedDB `VersionError`. `DB_VERSION` 8-10 are
+ * deliberate downgrade barriers, so this is a supported rejection of INTACT
+ * data — but it was reported through the generic dialog, which blames low disk
+ * space and storage corruption and ends with "your browser storage may need to
+ * be cleared". Following that advice deletes every task and still does not let
+ * the old build open the data.
+ *
+ * The unit specs pin the classifier and the wording; none of them can show that
+ * a real boot against a real downgraded database reaches the dialog at all.
+ * That is this test's only job, and it is worth its runtime because the failure
+ * mode it guards is silent: if the dialog were bypassed (an unwrapped
+ * `VersionError` escaping from some other `SUP_OPS` opener, say) the app would
+ * simply show its blank shell and the user would get no message whatsoever.
+ *
+ * Direction note: we cannot run a v18.14 binary here, so the downgrade is
+ * staged from the other side — the on-disk version is pushed one above whatever
+ * this build requests, which is the identical `VersionError` the reporter hit,
+ * just with the numbers shifted.
+ *
+ * Run: npm run e2e:file e2e/tests/migration/idb-downgrade-barrier-9187.spec.ts -- --retries=0
+ */
+
+/**
+ * Push `SUP_OPS` one version above the running build's `DB_VERSION`.
+ *
+ * Reads the current version rather than hardcoding it, so the test keeps
+ * meaning the same thing after the next barrier bump.
+ *
+ * Every branch resolves with a tag: an IndexedDB request that neither succeeds
+ * nor errors (a blocked upgrade) would otherwise hang the evaluate until the
+ * test times out with a misleading message.
+ */
+const bumpDbOneVersionAhead = async (page: Page): Promise<string> =>
+  page.evaluate(
+    async () =>
+      new Promise<string>((resolve) => {
+        const timer = setTimeout(() => resolve('TIMEOUT'), 15000);
+        const done = (msg: string): void => {
+          clearTimeout(timer);
+          resolve(msg);
+        };
+
+        const probe = indexedDB.open('SUP_OPS');
+        probe.onerror = () => done('PROBE-ERROR');
+        probe.onblocked = () => done('PROBE-BLOCKED');
+        probe.onsuccess = () => {
+          const current = probe.result.version;
+          probe.result.close();
+
+          const upgrade = indexedDB.open('SUP_OPS', current + 1);
+          upgrade.onerror = () => done('UPGRADE-ERROR');
+          upgrade.onblocked = () => done('UPGRADE-BLOCKED');
+          // No schema change needed — the version number itself is the barrier.
+          upgrade.onupgradeneeded = () => {};
+          upgrade.onsuccess = () => {
+            const bumped = upgrade.result.version;
+            upgrade.result.close();
+            done(`OK:${current}->${bumped}`);
+          };
+        };
+      }),
+  );
+
+test.describe('@migration #9187 IndexedDB downgrade barrier', () => {
+  test('explains the too-old build instead of advising a storage wipe', async ({
+    browser,
+    baseURL,
+  }) => {
+    const context = await browser.newContext({
+      storageState: undefined,
+      baseURL: baseURL || 'http://localhost:4242',
+    });
+
+    try {
+      // Phase 1 — let the app create a real SUP_OPS at its own DB_VERSION.
+      // Corrupting a store the app itself produced beats hand-building one:
+      // the surrounding schema is guaranteed real, so the only variable is the
+      // version number.
+      const appPage = await context.newPage();
+      await appPage.addInitScript(skipOnboardingForE2E);
+      await appPage.goto('/', { waitUntil: 'domcontentloaded' });
+      await appPage.waitForSelector('magic-side-nav', {
+        state: 'visible',
+        timeout: 30000,
+      });
+
+      // Phase 2 — open the mutation page while the app page is still open.
+      // Opening it afterwards makes the evaluate below fail to settle (see the
+      // #9139 spec, which learned this the expensive way). `**/*.js` is aborted
+      // so no second app instance races us for the connection.
+      const mutationPage = await context.newPage();
+      await mutationPage.route('**/*.js', async (route) => route.abort());
+      await mutationPage.goto('/', { waitUntil: 'domcontentloaded' });
+
+      // Phase 3 — close the app so its open connection cannot block the upgrade.
+      await appPage.close();
+
+      const bumpResult = await bumpDbOneVersionAhead(mutationPage);
+      expect(bumpResult).toMatch(/^OK:\d+->\d+$/);
+      await mutationPage.close();
+
+      // Phase 4 — boot again. This build now requests a LOWER version than the
+      // one on disk, exactly as an outdated copy would.
+      const relaunchPage = await context.newPage();
+      await relaunchPage.addInitScript(skipOnboardingForE2E);
+
+      // Register before navigating: the dialog fires during hydration, and
+      // Playwright auto-dismisses dialogs when nothing is listening — the
+      // message would be gone before we could read it.
+      const dialogs: string[] = [];
+      relaunchPage.on('dialog', async (dialog) => {
+        dialogs.push(dialog.message());
+        await dialog.dismiss();
+      });
+
+      await relaunchPage.goto('/', { waitUntil: 'domcontentloaded' });
+      await expect
+        .poll(() => dialogs.length, {
+          message: 'no dialog appeared — the downgrade failed silently',
+          timeout: 45000,
+        })
+        .toBeGreaterThan(0);
+
+      // Select by the technical detail, which BOTH the old and new wording
+      // carry. Selecting by the new title instead would make a regression fail
+      // as "no matching dialog" rather than naming the advice that came back.
+      const barrierDialog = dialogs.find((m) =>
+        m.includes('is less than the existing version'),
+      );
+      expect(
+        barrierDialog,
+        `no downgrade dialog; dialogs seen: ${JSON.stringify(dialogs)}`,
+      ).toBeDefined();
+      const msg = barrierDialog as string;
+
+      // The regression this guards: the destructive advice must be gone.
+      // Sabotaging the fix brings back the verbatim #9187 text and fails here.
+      expect(msg).not.toContain('storage may need to be cleared');
+      expect(msg).not.toContain('Storage corruption');
+      expect(msg).not.toContain('Low disk space');
+
+      // And the user is told what actually happened, plus a way out that does
+      // not destroy data.
+      expect(msg).toContain('This Version Is Too Old');
+      expect(msg).toContain('Do NOT clear your storage');
+      expect(msg).toContain('make a copy of your Super Productivity');
+      // The raw browser detail still reaches bug reports.
+      expect(msg).toContain('is less than the existing version');
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/e2e/tests/migration/idb-downgrade-barrier-9187.spec.ts
+++ b/e2e/tests/migration/idb-downgrade-barrier-9187.spec.ts
@@ -39,22 +39,44 @@ const bumpDbOneVersionAhead = async (page: Page): Promise<string> =>
   page.evaluate(
     async () =>
       new Promise<string>((resolve) => {
-        const timer = setTimeout(() => resolve('TIMEOUT'), 15000);
+        let wasBlocked = false;
+        const timer = setTimeout(
+          () => resolve(wasBlocked ? 'STUCK-BLOCKED' : 'TIMEOUT'),
+          15000,
+        );
         const done = (msg: string): void => {
           clearTimeout(timer);
           resolve(msg);
         };
 
+        // A versionless open never triggers an upgrade, so it cannot be blocked.
         const probe = indexedDB.open('SUP_OPS');
         probe.onerror = () => done('PROBE-ERROR');
-        probe.onblocked = () => done('PROBE-BLOCKED');
         probe.onsuccess = () => {
           const current = probe.result.version;
+          // A versionless open CREATES the database at version 1 if it is
+          // missing. Without this guard that silently yields a valid-looking
+          // `OK:1->2`, the relaunch upgrades 2->10 cleanly, and the real
+          // failure surfaces 45s later as "no dialog appeared" — a
+          // misdiagnosis. Fail here, where the cause is obvious.
+          if (!probe.result.objectStoreNames.contains('ops')) {
+            probe.result.close();
+            done('EMPTY-DB');
+            return;
+          }
           probe.result.close();
 
           const upgrade = indexedDB.open('SUP_OPS', current + 1);
           upgrade.onerror = () => done('UPGRADE-ERROR');
-          upgrade.onblocked = () => done('UPGRADE-BLOCKED');
+          // `blocked` is an INTERMEDIATE event, not a failure: it means another
+          // connection is still open, and the request proceeds to `success` on
+          // its own once that closes. Resolving here would abort a bump that was
+          // about to work — a live flake on slower CI, where the closed app
+          // page's connection can outlive `close()` by a moment. Record it and
+          // let the timer surface it only if it never clears.
+          upgrade.onblocked = () => {
+            wasBlocked = true;
+          };
           // No schema change needed — the version number itself is the barrier.
           upgrade.onupgradeneeded = () => {};
           upgrade.onsuccess = () => {
@@ -119,12 +141,21 @@ test.describe('@migration #9187 IndexedDB downgrade barrier', () => {
       });
 
       await relaunchPage.goto('/', { waitUntil: 'domcontentloaded' });
+
+      // Poll for OUR dialog, not merely for any dialog. This is a dev build
+      // (`angular.json` sets no defaultConfiguration, so `environment.production`
+      // is false), which arms `devError()` to fire its own alert — that would
+      // satisfy a bare `length > 0` and leave the find below empty on a single
+      // non-retried pass.
       await expect
-        .poll(() => dialogs.length, {
-          message: 'no dialog appeared — the downgrade failed silently',
-          timeout: 45000,
-        })
-        .toBeGreaterThan(0);
+        .poll(
+          () => dialogs.some((m) => m.includes('is less than the existing version')),
+          {
+            message: 'no downgrade dialog appeared — the barrier failed silently',
+            timeout: 45000,
+          },
+        )
+        .toBe(true);
 
       // Select by the technical detail, which BOTH the old and new wording
       // carry. Selecting by the new title instead would make a regression fail
@@ -148,7 +179,10 @@ test.describe('@migration #9187 IndexedDB downgrade barrier', () => {
       // not destroy data.
       expect(msg).toContain('This Version Is Too Old');
       expect(msg).toContain('Do NOT clear your storage');
-      expect(msg).toContain('make a copy of your Super Productivity');
+      // This harness is a browser, so the message takes the `web` branch. The
+      // desktop "copy your data folder first" variant has no meaning here (no
+      // folder to copy) and is covered by idb-open-error-message.spec.ts.
+      expect(msg).toContain('no copy to fall back on');
       // The raw browser detail still reaches bug reports.
       expect(msg).toContain('is less than the existing version');
     } finally {

--- a/e2e/tests/migration/idb-downgrade-barrier-9187.spec.ts
+++ b/e2e/tests/migration/idb-downgrade-barrier-9187.spec.ts
@@ -179,10 +179,12 @@ test.describe('@migration #9187 IndexedDB downgrade barrier', () => {
       // not destroy data.
       expect(msg).toContain('This Version Is Too Old');
       expect(msg).toContain('Do NOT clear your storage');
-      // This harness is a browser, so the message takes the `web` branch. The
-      // desktop "copy your data folder first" variant has no meaning here (no
-      // folder to copy) and is covered by idb-open-error-message.spec.ts.
-      expect(msg).toContain('no copy to fall back on');
+      // The escape hatch that keeps the message from dead-ending. It is now
+      // channel-independent (see idb-open-error-message.ts), so this harness
+      // being a browser does not change which variant is asserted.
+      expect(msg).toContain('makes the loss permanent');
+      // The second-copy diagnosis — the sentence that actually explains #9187.
+      expect(msg).toContain('second, older copy');
       // The raw browser detail still reaches bug reports.
       expect(msg).toContain('is less than the existing version');
     } finally {

--- a/src/app/op-log/core/errors/indexed-db-open.error.spec.ts
+++ b/src/app/op-log/core/errors/indexed-db-open.error.spec.ts
@@ -1,5 +1,8 @@
 import { IndexedDBOpenError } from './indexed-db-open.error';
-import { IDB_OPEN_ERROR_MSG } from '../../persistence/op-log-errors.const';
+import {
+  IDB_OPEN_ERROR_MSG,
+  IDB_OPEN_VERSION_BARRIER_MSG,
+} from '../../persistence/op-log-errors.const';
 import { HANDLED_ERROR_PROP_STR } from '../../../app.constants';
 
 describe('IndexedDBOpenError', () => {
@@ -139,6 +142,34 @@ describe('IndexedDBOpenError', () => {
       // NOTE: deliberately no `isBackingStoreError` assertion here. It is false
       // with or without this change (the message has no "backing store"), so it
       // would pass against the unfixed code — a vacuous assertion.
+    });
+
+    // The wrapper's own message — not just the Log.err prefix — is what reaches
+    // HANDLED_ERROR_PROP_STR, getErrorTxt and the exported log history, i.e.
+    // what a user pastes into a bug report. Claiming retries there would send
+    // #9187 triage looking for a 7s window that never happened.
+    it('should not claim retries in the message when no retry ran', () => {
+      const error = new IndexedDBOpenError(
+        new DOMException(
+          'The requested version (7) is less than the existing version (10).',
+          'VersionError',
+        ),
+      );
+
+      expect(error.message).toContain(IDB_OPEN_VERSION_BARRIER_MSG);
+      expect(error.message).not.toContain('after multiple retries');
+      expect(error.message).toContain('The requested version (7) is less than');
+      // ...and the marker must carry the same corrected text.
+      expect((error as unknown as Record<string, unknown>)[HANDLED_ERROR_PROP_STR]).toBe(
+        error.message,
+      );
+    });
+
+    it('should keep the retry wording for failures that really did retry', () => {
+      const error = new IndexedDBOpenError(new Error('QuotaExceededError'));
+
+      expect(error.message).toContain(IDB_OPEN_ERROR_MSG);
+      expect(error.message).not.toContain(IDB_OPEN_VERSION_BARRIER_MSG);
     });
 
     it('should be false for other IndexedDB open failures', () => {

--- a/src/app/op-log/core/errors/indexed-db-open.error.spec.ts
+++ b/src/app/op-log/core/errors/indexed-db-open.error.spec.ts
@@ -126,6 +126,37 @@ describe('IndexedDBOpenError', () => {
     });
   });
 
+  describe('isVersionError (#9187)', () => {
+    it('should be true for a downgrade-barrier VersionError', () => {
+      const error = new IndexedDBOpenError(
+        new DOMException(
+          'The requested version (7) is less than the existing version (10).',
+          'VersionError',
+        ),
+      );
+
+      expect(error.isVersionError).toBe(true);
+      // Not storage damage — must not be conflated with the backing-store path.
+      expect(error.isBackingStoreError).toBe(false);
+    });
+
+    it('should be false for other IndexedDB open failures', () => {
+      expect(new IndexedDBOpenError(new Error('QuotaExceededError')).isVersionError).toBe(
+        false,
+      );
+      expect(
+        new IndexedDBOpenError(new DOMException('nope', 'InvalidStateError'))
+          .isVersionError,
+      ).toBe(false);
+      expect(new IndexedDBOpenError(undefined).isVersionError).toBe(false);
+      // A message that merely mentions the words must not trigger it.
+      expect(
+        new IndexedDBOpenError(new Error('VersionError happened somewhere'))
+          .isVersionError,
+      ).toBe(false);
+    });
+  });
+
   describe('inheritance', () => {
     it('should be an instance of Error', () => {
       const error = new IndexedDBOpenError(new Error('test'));

--- a/src/app/op-log/core/errors/indexed-db-open.error.spec.ts
+++ b/src/app/op-log/core/errors/indexed-db-open.error.spec.ts
@@ -136,8 +136,9 @@ describe('IndexedDBOpenError', () => {
       );
 
       expect(error.isVersionError).toBe(true);
-      // Not storage damage — must not be conflated with the backing-store path.
-      expect(error.isBackingStoreError).toBe(false);
+      // NOTE: deliberately no `isBackingStoreError` assertion here. It is false
+      // with or without this change (the message has no "backing store"), so it
+      // would pass against the unfixed code — a vacuous assertion.
     });
 
     it('should be false for other IndexedDB open failures', () => {

--- a/src/app/op-log/core/errors/indexed-db-open.error.ts
+++ b/src/app/op-log/core/errors/indexed-db-open.error.ts
@@ -1,5 +1,6 @@
 import {
   IDB_OPEN_ERROR_MSG,
+  IDB_OPEN_VERSION_BARRIER_MSG,
   IDB_BACKING_STORE_PATTERN,
   isIdbVersionError,
 } from '../../persistence/op-log-errors.const';
@@ -55,10 +56,18 @@ export class IndexedDBOpenError extends Error {
    * Includes the original error's name and message so bug reports can
    * distinguish Chromium LevelDB locks, WebKit's "Connection to Indexed
    * Database server lost", quota errors, etc.
+   *
+   * The base string is chosen from the same classification the constructor
+   * records, so every consumer of the wrapper — console, `HANDLED_ERROR_PROP_STR`,
+   * exported logs — describes the barrier consistently. Classifying here rather
+   * than at each `Log.err` call site keeps that to one decision point.
    */
   private static _buildMessage(originalError: unknown): string {
+    const base = isIdbVersionError(originalError)
+      ? IDB_OPEN_VERSION_BARRIER_MSG
+      : IDB_OPEN_ERROR_MSG;
     const detail = IndexedDBOpenError._formatOriginal(originalError);
-    return detail ? `${IDB_OPEN_ERROR_MSG} | original: ${detail}` : IDB_OPEN_ERROR_MSG;
+    return detail ? `${base} | original: ${detail}` : base;
   }
 
   private static _formatOriginal(err: unknown): string {

--- a/src/app/op-log/core/errors/indexed-db-open.error.ts
+++ b/src/app/op-log/core/errors/indexed-db-open.error.ts
@@ -1,6 +1,7 @@
 import {
   IDB_OPEN_ERROR_MSG,
   IDB_BACKING_STORE_PATTERN,
+  isIdbVersionError,
 } from '../../persistence/op-log-errors.const';
 import { HANDLED_ERROR_PROP_STR } from '../../../app.constants';
 
@@ -23,6 +24,15 @@ export class IndexedDBOpenError extends Error {
   /** True if the original error message contains "backing store" (Chromium LevelDB signal). */
   readonly isBackingStoreError: boolean;
 
+  /**
+   * True if an older app build tried to open a database a newer build already
+   * upgraded (the `DB_VERSION` downgrade barrier). The data is intact; only
+   * this build is too old to read it.
+   *
+   * @see https://github.com/super-productivity/super-productivity/issues/9187
+   */
+  readonly isVersionError: boolean;
+
   /** The original error that caused IndexedDB to fail. */
   readonly originalError: unknown;
 
@@ -38,6 +48,7 @@ export class IndexedDBOpenError extends Error {
     this[HANDLED_ERROR_PROP_STR] = this.message;
     this.originalError = originalError;
     this.isBackingStoreError = IndexedDBOpenError._checkBackingStoreError(originalError);
+    this.isVersionError = isIdbVersionError(originalError);
   }
 
   /**

--- a/src/app/op-log/persistence/archive-store.service.spec.ts
+++ b/src/app/op-log/persistence/archive-store.service.spec.ts
@@ -2,7 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import { IDBPDatabase, unwrap } from 'idb';
 import { forceCloseDatabase } from 'fake-indexeddb';
 import { ArchiveStoreService } from './archive-store.service';
-import { STORE_NAMES } from './db-keys.const';
+import { DB_NAME, DB_VERSION, STORE_NAMES } from './db-keys.const';
+import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 
 describe('ArchiveStoreService', () => {
   let service: ArchiveStoreService;
@@ -76,6 +77,47 @@ describe('ArchiveStoreService', () => {
       expect((service as any)._db).toBeUndefined();
       expect((service as any)._initPromise).toBeUndefined();
       await expectAsync(service.loadArchiveYoung()).toBeResolved();
+    });
+  });
+
+  // #9187: ArchiveStoreService keeps its own copy of the open-with-retry loop,
+  // and it is a live path (both consumers only skip it for a self-managing
+  // adapter). Driving a REAL downgrade beats spying a seam here — this service
+  // inlines `openDB`, and the actual browser rejection is the better oracle.
+  describe('downgrade barrier', () => {
+    it('fails fast with a classified error when the DB is newer than this build', async () => {
+      // Drop the connection opened by the beforeEach so it cannot block the
+      // upgrade below.
+      ((service as any)._db as IDBPDatabase | undefined)?.close();
+      (service as any)._db = undefined;
+      (service as any)._initPromise = undefined;
+
+      // Push the on-disk version above what the service asks for.
+      await new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, DB_VERSION + 1);
+        req.onupgradeneeded = () => {};
+        req.onsuccess = () => {
+          req.result.close();
+          resolve();
+        };
+        req.onerror = () => reject(req.error);
+      });
+
+      const startedAt = Date.now();
+      let caught: unknown;
+      try {
+        await service.loadArchiveYoung();
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toEqual(jasmine.any(IndexedDBOpenError));
+      expect((caught as IndexedDBOpenError).isVersionError).toBe(true);
+      // Without the fail-fast break this burns the non-lock budget
+      // (1s+2s+4s) and dies on jasmine's 2s timeout before reaching here — so
+      // the elapsed check is a second signal, not the only one. Do NOT
+      // "repair" a slow run by raising DEFAULT_TIMEOUT_INTERVAL.
+      expect(Date.now() - startedAt).toBeLessThan(1500);
     });
   });
 });

--- a/src/app/op-log/persistence/archive-store.service.spec.ts
+++ b/src/app/op-log/persistence/archive-store.service.spec.ts
@@ -117,7 +117,11 @@ describe('ArchiveStoreService', () => {
       // (1s+2s+4s) and dies on jasmine's 2s timeout before reaching here — so
       // the elapsed check is a second signal, not the only one. Do NOT
       // "repair" a slow run by raising DEFAULT_TIMEOUT_INTERVAL.
-      expect(Date.now() - startedAt).toBeLessThan(1500);
+      //
+      // 500ms, not 1500ms: the real path is ~1-20ms, and a PARTIAL regression
+      // (break moved one iteration late = one 1000ms backoff) would clear a
+      // 1500ms bound and the 2s timeout both, passing green.
+      expect(Date.now() - startedAt).toBeLessThan(500);
     });
   });
 });

--- a/src/app/op-log/persistence/archive-store.service.ts
+++ b/src/app/op-log/persistence/archive-store.service.ts
@@ -169,12 +169,7 @@ export class ArchiveStoreService {
     // from WebKit's iOS "Connection to Indexed Database server lost", #7415).
     const err = new IndexedDBOpenError(lastError);
     // See OperationLogStoreService: zero retries ran on the barrier path (#9187).
-    Log.err(
-      err.isVersionError
-        ? '[ArchiveStore] IndexedDB open rejected by the downgrade barrier (no retry).'
-        : '[ArchiveStore] IndexedDB open failed after all retries.',
-      err,
-    );
+    Log.err('[ArchiveStore] IndexedDB open failed.', err);
     throw err;
   }
 

--- a/src/app/op-log/persistence/archive-store.service.ts
+++ b/src/app/op-log/persistence/archive-store.service.ts
@@ -168,7 +168,13 @@ export class ArchiveStoreService {
     // cause needed for diagnostics (e.g. distinguishing Chromium LevelDB locks
     // from WebKit's iOS "Connection to Indexed Database server lost", #7415).
     const err = new IndexedDBOpenError(lastError);
-    Log.err('[ArchiveStore] IndexedDB open failed after all retries.', err);
+    // See OperationLogStoreService: zero retries ran on the barrier path (#9187).
+    Log.err(
+      err.isVersionError
+        ? '[ArchiveStore] IndexedDB open rejected by the downgrade barrier (no retry).'
+        : '[ArchiveStore] IndexedDB open failed after all retries.',
+      err,
+    );
     throw err;
   }
 

--- a/src/app/op-log/persistence/archive-store.service.ts
+++ b/src/app/op-log/persistence/archive-store.service.ts
@@ -13,6 +13,7 @@ import { OpLogDbAdapter } from './op-log-db-adapter';
 import { OP_LOG_DB_ADAPTER_FACTORY } from './op-log-db-adapter.token';
 import {
   isConnectionClosingError,
+  isIdbVersionError,
   isLockRelatedIdbOpenError,
 } from './op-log-errors.const';
 import { Log } from '../../core/log';
@@ -131,6 +132,11 @@ export class ArchiveStoreService {
         });
       } catch (e) {
         lastError = e;
+
+        // Downgrade barrier: retrying can't change the on-disk version (#9187).
+        if (isIdbVersionError(e)) {
+          break;
+        }
 
         // Non-lock errors fall back to a short retry budget so we don't block
         // the op-log subsystem for 31s before surfacing the error to the user.

--- a/src/app/op-log/persistence/archive-store.service.ts
+++ b/src/app/op-log/persistence/archive-store.service.ts
@@ -168,7 +168,7 @@ export class ArchiveStoreService {
     // cause needed for diagnostics (e.g. distinguishing Chromium LevelDB locks
     // from WebKit's iOS "Connection to Indexed Database server lost", #7415).
     const err = new IndexedDBOpenError(lastError);
-    // See OperationLogStoreService: zero retries ran on the barrier path (#9187).
+    // See OperationLogStoreService: the barrier path stops retrying (#9187).
     Log.err('[ArchiveStore] IndexedDB open failed.', err);
     throw err;
   }

--- a/src/app/op-log/persistence/db-upgrade.spec.ts
+++ b/src/app/op-log/persistence/db-upgrade.spec.ts
@@ -6,6 +6,7 @@ import {
   OPS_INDEXES,
 } from './db-keys.const';
 import { deleteDB, openDB } from 'idb';
+import { isIdbVersionError } from './op-log-errors.const';
 import { OpType } from '../core/operation.types';
 
 describe('runDbUpgrade', () => {
@@ -316,6 +317,13 @@ describe('runDbUpgrade', () => {
         await expectAsync(openDB(dbName, 9)).toBeRejectedWith(
           jasmine.objectContaining({ name: 'VersionError' }),
         );
+
+        // #9187: the rejection an old reader actually gets must be the one the
+        // user-facing classifier recognises. Asserting it here — on a real
+        // downgrade rather than a hand-built DOMException — is what keeps the
+        // dialog from falling back to "your storage may need to be cleared".
+        const rejection = await openDB(dbName, 9).catch((e: unknown) => e);
+        expect(isIdbVersionError(rejection)).toBe(true);
       } finally {
         await deleteDB(dbName);
       }

--- a/src/app/op-log/persistence/db-upgrade.spec.ts
+++ b/src/app/op-log/persistence/db-upgrade.spec.ts
@@ -314,15 +314,23 @@ describe('runDbUpgrade', () => {
         });
         currentDb.close();
 
-        await expectAsync(openDB(dbName, 9)).toBeRejectedWith(
-          jasmine.objectContaining({ name: 'VersionError' }),
+        // One open, both assertions. On the success path the connection is
+        // closed before being discarded, so a regression that lets the
+        // downgrade through fails on the expectation rather than hanging the
+        // `finally`'s deleteDB on an open handle.
+        const rejection = await openDB(dbName, 9).then(
+          (db) => {
+            db.close();
+            return null;
+          },
+          (e: unknown) => e,
         );
 
+        expect(rejection).toEqual(jasmine.objectContaining({ name: 'VersionError' }));
         // #9187: the rejection an old reader actually gets must be the one the
         // user-facing classifier recognises. Asserting it here — on a real
         // downgrade rather than a hand-built DOMException — is what keeps the
         // dialog from falling back to "your storage may need to be cleared".
-        const rejection = await openDB(dbName, 9).catch((e: unknown) => e);
         expect(isIdbVersionError(rejection)).toBe(true);
       } finally {
         await deleteDB(dbName);

--- a/src/app/op-log/persistence/db-upgrade.spec.ts
+++ b/src/app/op-log/persistence/db-upgrade.spec.ts
@@ -328,9 +328,15 @@ describe('runDbUpgrade', () => {
 
         expect(rejection).toEqual(jasmine.objectContaining({ name: 'VersionError' }));
         // #9187: the rejection an old reader actually gets must be the one the
-        // user-facing classifier recognises. Asserting it here — on a real
-        // downgrade rather than a hand-built DOMException — is what keeps the
-        // dialog from falling back to "your storage may need to be cleared".
+        // user-facing classifier recognises, or the dialog falls back to
+        // "your storage may need to be cleared".
+        //
+        // Scope of this oracle: a real downgrade through `openDB`, but on the
+        // fake-indexeddb engine `src/test.ts` installs — NOT Blink. Verified
+        // separately against Chromium 149, which returns
+        //   name: 'VersionError', instanceof DOMException && instanceof Error,
+        //   message: 'The requested version (7) is less than the existing version (10).'
+        // — byte-identical to the message in the #9187 report.
         expect(isIdbVersionError(rejection)).toBe(true);
       } finally {
         await deleteDB(dbName);

--- a/src/app/op-log/persistence/idb-open-error-message.spec.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.spec.ts
@@ -1,11 +1,13 @@
-import { buildIdbOpenErrorMessage, IdbOpenErrorContext } from './idb-open-error-message';
+import {
+  buildIdbOpenErrorMessage,
+  IdbOpenErrorContext,
+  IdbOpenPlatform,
+} from './idb-open-error-message';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 
 describe('buildIdbOpenErrorMessage', () => {
   const ctx = (overrides: Partial<IdbOpenErrorContext> = {}): IdbOpenErrorContext => ({
-    isElectron: true,
-    isFlatpak: false,
-    isSnap: false,
+    platform: 'electron',
     appVersion: '18.14.0',
     ...overrides,
   });
@@ -19,36 +21,45 @@ describe('buildIdbOpenErrorMessage', () => {
     );
 
   describe('downgrade barrier (#9187)', () => {
-    it('never repeats the destructive generic advice on any platform', () => {
-      const platforms: IdbOpenErrorContext[] = [
-        ctx(),
-        ctx({ isSnap: true }),
-        ctx({ isFlatpak: true }),
-        ctx({ isElectron: false }),
-      ];
+    // Swept across every platform because this is the actual bug: whichever
+    // branch a locked-out user lands in, none of them may repeat the advice
+    // that would destroy the intact data.
+    const ALL_PLATFORMS: IdbOpenPlatform[] = ['electron', 'snap', 'flatpak', 'web'];
 
-      platforms.forEach((platform) => {
-        const msg = buildIdbOpenErrorMessage(versionError(), platform);
-        expect(msg).not.toContain('storage may need to be cleared');
-        expect(msg).not.toContain('Storage corruption');
-        expect(msg).not.toContain('Low disk space');
-        expect(msg).toContain('Do NOT clear your storage');
+    it('never repeats the destructive generic advice on any platform', () => {
+      ALL_PLATFORMS.forEach((platform) => {
+        const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform }));
+
+        expect(msg).withContext(platform).not.toContain('storage may need to be cleared');
+        expect(msg).withContext(platform).not.toContain('Storage corruption');
+        expect(msg).withContext(platform).not.toContain('Low disk space');
+        expect(msg).withContext(platform).toContain('Do NOT clear your storage');
         // The running version is what tells the user which copy is stale.
-        expect(msg).toContain('18.14.0');
+        expect(msg).withContext(platform).toContain('18.14.0');
+        // Every platform must offer a way out that does not destroy data.
+        expect(msg)
+          .withContext(platform)
+          .toContain('make a copy of your Super Productivity');
       });
     });
 
+    // The package ids are asserted in FULL on purpose. A partial match (e.g.
+    // just 'flatpak update') passes with a wrong id, and a wrong id makes the
+    // single command we hand a locked-out user fail. Sources of truth are the
+    // store links in README.md; note they differ from the mac/Capacitor appId
+    // `com.super-productivity.app`, which is what a careless grep turns up.
     it('points Snap users at their own update channel, not the website', () => {
-      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ isSnap: true }));
+      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform: 'snap' }));
 
-      expect(msg).toContain('snap refresh super-productivity');
+      expect(msg).toContain('snap refresh superproductivity');
       expect(msg).not.toContain('super-productivity.com');
     });
 
-    it('points Flatpak users at flatpak update', () => {
-      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ isFlatpak: true }));
+    it('points Flatpak users at flatpak update with the real Flathub id', () => {
+      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform: 'flatpak' }));
 
-      expect(msg).toContain('flatpak update');
+      expect(msg).toContain('flatpak update com.super_productivity.SuperProductivity');
+      expect(msg).not.toContain('com.super-productivity.app');
       expect(msg).not.toContain('super-productivity.com');
     });
 
@@ -61,32 +72,43 @@ describe('buildIdbOpenErrorMessage', () => {
     });
 
     it('qualifies the reload hint so it stays true on mobile', () => {
-      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ isElectron: false }));
+      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform: 'web' }));
 
       // Android/iOS WebViews have no tabs and no Ctrl+Shift+R — the hint must
-      // not be stated as an unconditional instruction there.
+      // be qualified, not stated as an unconditional instruction.
       expect(msg).toContain('In a web browser:');
-      expect(msg).not.toContain('1. Reload the page');
     });
   });
 
   describe('other open failures keep the existing guidance', () => {
-    it('still shows the generic causes and the clear-storage fallback', () => {
+    // Asserted in FULL, not by fragments. Extracting this text out of
+    // OperationLogHydratorService was required by the 1200-line service cap,
+    // and "the wording is unchanged" was the whole safety argument for that
+    // move — a fragment match would not have detected a dropped line or a
+    // mangled blank line. If this fails, confirm the change to user-facing
+    // copy is intentional before updating the expectation.
+    it('reproduces the pre-extraction generic message exactly', () => {
       const msg = buildIdbOpenErrorMessage(
         new IndexedDBOpenError(new Error('QuotaExceededError')),
         ctx(),
       );
 
-      expect(msg).toContain('Database Error - Cannot Load Data');
-      expect(msg).toContain('- Low disk space');
-      expect(msg).toContain('storage may need to be cleared');
-      expect(msg).toContain('Technical details: QuotaExceededError');
+      expect(msg).toBe(
+        'Database Error - Cannot Load Data\n\n' +
+          'Super Productivity cannot open its database. This may be caused by:\n\n' +
+          '- Low disk space\n' +
+          '- Temporary file lock (try closing other tabs)\n' +
+          '- Storage corruption\n\n' +
+          'If the problem continues after restart, your browser storage may need to be cleared.\n\n' +
+          'Technical details: QuotaExceededError\n\n' +
+          '(Check browser console for full error details)',
+      );
     });
 
     it('adds Snap-specific recovery steps for backing-store errors', () => {
       const msg = buildIdbOpenErrorMessage(
         new IndexedDBOpenError(new Error('Internal error opening backing store')),
-        ctx({ isSnap: true }),
+        ctx({ platform: 'snap' }),
       );
 
       expect(msg).toContain('Recovery steps:');

--- a/src/app/op-log/persistence/idb-open-error-message.spec.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.spec.ts
@@ -21,8 +21,8 @@ describe('buildIdbOpenErrorMessage', () => {
     // Swept across EVERY channel because this is the actual bug: whichever
     // branch a locked-out user lands in, none of them may repeat the advice
     // that would destroy the intact data. Listed exhaustively rather than
-    // sampled — a channel added to DistChannel without recovery text here is
-    // precisely the regression this guards.
+    // sampled so that a channel added to DistChannel is a visible diff here,
+    // even though the builder's `default` arm means it cannot go untexted.
     const ALL_CHANNELS: DistChannel[] = [
       'win-nsis',
       'win-portable',
@@ -49,12 +49,10 @@ describe('buildIdbOpenErrorMessage', () => {
         expect(msg).withContext(channel).toContain('Do NOT clear your storage');
         // The running version is what tells the user which copy is stale.
         expect(msg).withContext(channel).toContain('18.14.0W');
-        // Every channel must offer a way out that does not destroy data — copy
-        // the folder where one exists, and where none does (web/mobile) say
-        // plainly that clearing the data is unrecoverable.
-        expect(msg)
-          .withContext(channel)
-          .toMatch(/make a copy of your Super Productivity|no copy to fall back on/);
+        // Every channel must offer a way out that does not destroy data. This
+        // sentence is deliberately NOT forked per channel — it guards the
+        // anti-data-loss advice, so a mis-detected channel must not flip it.
+        expect(msg).withContext(channel).toContain('makes the loss permanent');
         // ...and every channel must actually name a way to get the newer build,
         // so no channel can fall through to a bare "What to do:" heading.
         expect(msg)
@@ -63,55 +61,55 @@ describe('buildIdbOpenErrorMessage', () => {
       });
     });
 
-    // The whole point of branching on DistChannel: a managed-store or
-    // sandboxed build keeps its data where a website download cannot see it,
-    // so pointing these users at super-productivity.com is wrong advice.
-    it('never sends store-managed or sandboxed builds to the website download', () => {
-      const MANAGED: DistChannel[] = [
-        'win-store',
-        'mac-store',
-        'ios',
-        'android-play',
-        'android-fdroid',
-        'linux-snap',
-        'linux-flatpak',
-      ];
+    // Snap and Flatpak keep the database inside the package sandbox, so a
+    // website download would not even see this data — those two are the only
+    // channels where a specific instruction beats the universal one.
+    it('sends only Snap and Flatpak down a channel-specific path', () => {
+      const specific = ALL_CHANNELS.filter(
+        (c) => c === 'linux-snap' || c === 'linux-flatpak',
+      );
+      const universal = ALL_CHANNELS.filter(
+        (c) => c !== 'linux-snap' && c !== 'linux-flatpak',
+      );
 
-      MANAGED.forEach((channel) => {
+      // Every other channel gets byte-identical text. This is the property that
+      // makes a mis-detected channel harmless: DistChannel's remaining
+      // detectors are UA sniffs and the unreliable process.mas/windowsStore
+      // flags, so being wrong must not change what the user is told.
+      const texts = new Set(
+        universal.map((channel) =>
+          buildIdbOpenErrorMessage(versionError(), ctx({ channel })),
+        ),
+      );
+      expect(texts.size).toBe(1);
+
+      specific.forEach((channel) => {
         const msg = buildIdbOpenErrorMessage(versionError(), ctx({ channel }));
 
-        expect(msg).withContext(channel).not.toContain('super-productivity.com');
+        expect(msg)
+          .withContext(channel)
+          .not.toBe([...texts][0]);
       });
     });
 
-    it('names the right store for each managed channel', () => {
-      const expected: [DistChannel, string][] = [
-        ['win-store', 'the Microsoft Store'],
-        ['mac-store', 'the App Store'],
-        ['ios', 'the App Store'],
-        ['android-play', 'Google Play'],
-        ['android-fdroid', 'F-Droid'],
-      ];
-
-      expected.forEach(([channel, storeName]) => {
-        const msg = buildIdbOpenErrorMessage(versionError(), ctx({ channel }));
-
-        expect(msg).withContext(channel).toContain(`through ${storeName}`);
-      });
-    });
-
-    // The package ids are asserted in FULL on purpose. A partial match (e.g.
-    // just 'flatpak update') passes with a wrong id, and a wrong id makes the
-    // single command we hand a locked-out user fail. Sources of truth are the
-    // store links in README.md; note they differ from the mac/Capacitor appId
-    // `com.super-productivity.app`, which is what a careless grep turns up.
-    it('points Snap users at their own update channel', () => {
+    // These two commands are the only channel-specific instructions left, so
+    // they carry the whole risk of being wrong. Asserted in FULL: a partial
+    // match (e.g. just 'flatpak update') passes with a wrong id, and a wrong id
+    // makes the single command we hand a locked-out user fail. Sources of truth
+    // are the store links in README.md; they differ from the mac/Capacitor
+    // appId `com.super-productivity.app`, which is what a careless grep finds.
+    //
+    // The sudo asymmetry is deliberate and verified against polkit policy:
+    // snapd's io.snapcraft.snapd.manage is `auth_admin_keep` (bare command dies
+    // with "access denied"), while org.freedesktop.Flatpak.app-update is
+    // `allow_active=yes` — adding sudo there would break --user installs.
+    it('points Snap users at their own update channel, with sudo', () => {
       const msg = buildIdbOpenErrorMessage(
         versionError(),
         ctx({ channel: 'linux-snap' }),
       );
 
-      expect(msg).toContain('snap refresh superproductivity');
+      expect(msg).toContain('sudo snap refresh superproductivity');
     });
 
     it('points Flatpak users at flatpak update with the real Flathub id', () => {
@@ -122,34 +120,22 @@ describe('buildIdbOpenErrorMessage', () => {
 
       expect(msg).toContain('flatpak update com.super_productivity.SuperProductivity');
       expect(msg).not.toContain('com.super-productivity.app');
+      expect(msg).not.toContain('sudo flatpak');
     });
 
-    it('tells self-installed desktop users to look for a second copy', () => {
-      const msg = buildIdbOpenErrorMessage(versionError(), ctx());
-
-      expect(msg).toContain('portable');
-      expect(msg).toContain('super-productivity.com');
-      expect(msg).not.toContain('snap refresh');
-    });
-
-    it('does not offer a data-folder copy where the user cannot reach one', () => {
-      (['web', 'ios', 'android-play', 'android-fdroid'] as DistChannel[]).forEach(
+    // The line that actually resolved #9187 (a stale desktop shortcut). It now
+    // reaches every channel rather than only the self-installed desktop ones,
+    // because the detector that used to gate it is not reliable enough to
+    // withhold the most useful sentence in the message.
+    it('offers the second-copy diagnosis on every channel', () => {
+      ALL_CHANNELS.filter((c) => c !== 'linux-snap' && c !== 'linux-flatpak').forEach(
         (channel) => {
           const msg = buildIdbOpenErrorMessage(versionError(), ctx({ channel }));
 
-          expect(msg).withContext(channel).not.toContain('data folder');
+          expect(msg).withContext(channel).toContain('second, older copy');
+          expect(msg).withContext(channel).toContain('portable executable');
         },
       );
-    });
-
-    it('gives browsers the reload hint and mobile the store instead', () => {
-      const web = buildIdbOpenErrorMessage(versionError(), ctx({ channel: 'web' }));
-      const ios = buildIdbOpenErrorMessage(versionError(), ctx({ channel: 'ios' }));
-
-      expect(web).toContain('Ctrl+Shift+R');
-      // Mobile WebViews have no tabs and no Ctrl+Shift+R, so the reload hint
-      // must not leak into their branch.
-      expect(ios).not.toContain('Ctrl+Shift+R');
     });
   });
 

--- a/src/app/op-log/persistence/idb-open-error-message.spec.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.spec.ts
@@ -1,0 +1,96 @@
+import { buildIdbOpenErrorMessage, IdbOpenErrorContext } from './idb-open-error-message';
+import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
+
+describe('buildIdbOpenErrorMessage', () => {
+  const ctx = (overrides: Partial<IdbOpenErrorContext> = {}): IdbOpenErrorContext => ({
+    isElectron: true,
+    isFlatpak: false,
+    isSnap: false,
+    appVersion: '18.14.0',
+    ...overrides,
+  });
+
+  const versionError = (): IndexedDBOpenError =>
+    new IndexedDBOpenError(
+      new DOMException(
+        'The requested version (7) is less than the existing version (10).',
+        'VersionError',
+      ),
+    );
+
+  describe('downgrade barrier (#9187)', () => {
+    it('never repeats the destructive generic advice on any platform', () => {
+      const platforms: IdbOpenErrorContext[] = [
+        ctx(),
+        ctx({ isSnap: true }),
+        ctx({ isFlatpak: true }),
+        ctx({ isElectron: false }),
+      ];
+
+      platforms.forEach((platform) => {
+        const msg = buildIdbOpenErrorMessage(versionError(), platform);
+        expect(msg).not.toContain('storage may need to be cleared');
+        expect(msg).not.toContain('Storage corruption');
+        expect(msg).not.toContain('Low disk space');
+        expect(msg).toContain('Do NOT clear your storage');
+        // The running version is what tells the user which copy is stale.
+        expect(msg).toContain('18.14.0');
+      });
+    });
+
+    it('points Snap users at their own update channel, not the website', () => {
+      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ isSnap: true }));
+
+      expect(msg).toContain('snap refresh super-productivity');
+      expect(msg).not.toContain('super-productivity.com');
+    });
+
+    it('points Flatpak users at flatpak update', () => {
+      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ isFlatpak: true }));
+
+      expect(msg).toContain('flatpak update');
+      expect(msg).not.toContain('super-productivity.com');
+    });
+
+    it('tells plain desktop users to look for a second copy', () => {
+      const msg = buildIdbOpenErrorMessage(versionError(), ctx());
+
+      expect(msg).toContain('portable');
+      expect(msg).toContain('super-productivity.com');
+      expect(msg).not.toContain('snap refresh');
+    });
+
+    it('qualifies the reload hint so it stays true on mobile', () => {
+      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ isElectron: false }));
+
+      // Android/iOS WebViews have no tabs and no Ctrl+Shift+R — the hint must
+      // not be stated as an unconditional instruction there.
+      expect(msg).toContain('In a web browser:');
+      expect(msg).not.toContain('1. Reload the page');
+    });
+  });
+
+  describe('other open failures keep the existing guidance', () => {
+    it('still shows the generic causes and the clear-storage fallback', () => {
+      const msg = buildIdbOpenErrorMessage(
+        new IndexedDBOpenError(new Error('QuotaExceededError')),
+        ctx(),
+      );
+
+      expect(msg).toContain('Database Error - Cannot Load Data');
+      expect(msg).toContain('- Low disk space');
+      expect(msg).toContain('storage may need to be cleared');
+      expect(msg).toContain('Technical details: QuotaExceededError');
+    });
+
+    it('adds Snap-specific recovery steps for backing-store errors', () => {
+      const msg = buildIdbOpenErrorMessage(
+        new IndexedDBOpenError(new Error('Internal error opening backing store')),
+        ctx({ isSnap: true }),
+      );
+
+      expect(msg).toContain('Recovery steps:');
+      expect(msg).toContain('snap set core experimental.refresh-app-awareness=true');
+    });
+  });
+});

--- a/src/app/op-log/persistence/idb-open-error-message.spec.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.spec.ts
@@ -1,14 +1,11 @@
-import {
-  buildIdbOpenErrorMessage,
-  IdbOpenErrorContext,
-  IdbOpenPlatform,
-} from './idb-open-error-message';
+import { buildIdbOpenErrorMessage, IdbOpenErrorContext } from './idb-open-error-message';
+import { DistChannel } from '../../util/get-app-version-str';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 
 describe('buildIdbOpenErrorMessage', () => {
   const ctx = (overrides: Partial<IdbOpenErrorContext> = {}): IdbOpenErrorContext => ({
-    platform: 'electron',
-    appVersion: '18.14.0',
+    channel: 'win-nsis',
+    appVersion: '18.14.0W',
     ...overrides,
   });
 
@@ -21,27 +18,85 @@ describe('buildIdbOpenErrorMessage', () => {
     );
 
   describe('downgrade barrier (#9187)', () => {
-    // Swept across every platform because this is the actual bug: whichever
+    // Swept across EVERY channel because this is the actual bug: whichever
     // branch a locked-out user lands in, none of them may repeat the advice
-    // that would destroy the intact data.
-    const ALL_PLATFORMS: IdbOpenPlatform[] = ['electron', 'snap', 'flatpak', 'web'];
+    // that would destroy the intact data. Listed exhaustively rather than
+    // sampled — a channel added to DistChannel without recovery text here is
+    // precisely the regression this guards.
+    const ALL_CHANNELS: DistChannel[] = [
+      'win-nsis',
+      'win-portable',
+      'win-store',
+      'mac-dmg',
+      'mac-store',
+      'linux-appimage',
+      'linux-snap',
+      'linux-flatpak',
+      'linux-native',
+      'android-play',
+      'android-fdroid',
+      'ios',
+      'web',
+    ];
 
-    it('never repeats the destructive generic advice on any platform', () => {
-      ALL_PLATFORMS.forEach((platform) => {
-        const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform }));
+    it('never repeats the destructive generic advice on any channel', () => {
+      ALL_CHANNELS.forEach((channel) => {
+        const msg = buildIdbOpenErrorMessage(versionError(), ctx({ channel }));
 
-        expect(msg).withContext(platform).not.toContain('storage may need to be cleared');
-        expect(msg).withContext(platform).not.toContain('Storage corruption');
-        expect(msg).withContext(platform).not.toContain('Low disk space');
-        expect(msg).withContext(platform).toContain('Do NOT clear your storage');
+        expect(msg).withContext(channel).not.toContain('storage may need to be cleared');
+        expect(msg).withContext(channel).not.toContain('Storage corruption');
+        expect(msg).withContext(channel).not.toContain('Low disk space');
+        expect(msg).withContext(channel).toContain('Do NOT clear your storage');
         // The running version is what tells the user which copy is stale.
-        expect(msg).withContext(platform).toContain('18.14.0');
-        // Every platform must offer a way out that does not destroy data —
-        // copy the folder on desktop, and on web (no folder to copy) at least
-        // say plainly that clearing site data is unrecoverable.
+        expect(msg).withContext(channel).toContain('18.14.0W');
+        // Every channel must offer a way out that does not destroy data — copy
+        // the folder where one exists, and where none does (web/mobile) say
+        // plainly that clearing the data is unrecoverable.
         expect(msg)
-          .withContext(platform)
+          .withContext(channel)
           .toMatch(/make a copy of your Super Productivity|no copy to fall back on/);
+        // ...and every channel must actually name a way to get the newer build,
+        // so no channel can fall through to a bare "What to do:" heading.
+        expect(msg)
+          .withContext(channel)
+          .toMatch(/\n1\. /);
+      });
+    });
+
+    // The whole point of branching on DistChannel: a managed-store or
+    // sandboxed build keeps its data where a website download cannot see it,
+    // so pointing these users at super-productivity.com is wrong advice.
+    it('never sends store-managed or sandboxed builds to the website download', () => {
+      const MANAGED: DistChannel[] = [
+        'win-store',
+        'mac-store',
+        'ios',
+        'android-play',
+        'android-fdroid',
+        'linux-snap',
+        'linux-flatpak',
+      ];
+
+      MANAGED.forEach((channel) => {
+        const msg = buildIdbOpenErrorMessage(versionError(), ctx({ channel }));
+
+        expect(msg).withContext(channel).not.toContain('super-productivity.com');
+      });
+    });
+
+    it('names the right store for each managed channel', () => {
+      const expected: [DistChannel, string][] = [
+        ['win-store', 'the Microsoft Store'],
+        ['mac-store', 'the App Store'],
+        ['ios', 'the App Store'],
+        ['android-play', 'Google Play'],
+        ['android-fdroid', 'F-Droid'],
+      ];
+
+      expected.forEach(([channel, storeName]) => {
+        const msg = buildIdbOpenErrorMessage(versionError(), ctx({ channel }));
+
+        expect(msg).withContext(channel).toContain(`through ${storeName}`);
       });
     });
 
@@ -50,22 +105,26 @@ describe('buildIdbOpenErrorMessage', () => {
     // single command we hand a locked-out user fail. Sources of truth are the
     // store links in README.md; note they differ from the mac/Capacitor appId
     // `com.super-productivity.app`, which is what a careless grep turns up.
-    it('points Snap users at their own update channel, not the website', () => {
-      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform: 'snap' }));
+    it('points Snap users at their own update channel', () => {
+      const msg = buildIdbOpenErrorMessage(
+        versionError(),
+        ctx({ channel: 'linux-snap' }),
+      );
 
       expect(msg).toContain('snap refresh superproductivity');
-      expect(msg).not.toContain('super-productivity.com');
     });
 
     it('points Flatpak users at flatpak update with the real Flathub id', () => {
-      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform: 'flatpak' }));
+      const msg = buildIdbOpenErrorMessage(
+        versionError(),
+        ctx({ channel: 'linux-flatpak' }),
+      );
 
       expect(msg).toContain('flatpak update com.super_productivity.SuperProductivity');
       expect(msg).not.toContain('com.super-productivity.app');
-      expect(msg).not.toContain('super-productivity.com');
     });
 
-    it('tells plain desktop users to look for a second copy', () => {
+    it('tells self-installed desktop users to look for a second copy', () => {
       const msg = buildIdbOpenErrorMessage(versionError(), ctx());
 
       expect(msg).toContain('portable');
@@ -73,15 +132,24 @@ describe('buildIdbOpenErrorMessage', () => {
       expect(msg).not.toContain('snap refresh');
     });
 
-    it('qualifies the reload hint so it stays true on mobile', () => {
-      const msg = buildIdbOpenErrorMessage(versionError(), ctx({ platform: 'web' }));
+    it('does not offer a data-folder copy where the user cannot reach one', () => {
+      (['web', 'ios', 'android-play', 'android-fdroid'] as DistChannel[]).forEach(
+        (channel) => {
+          const msg = buildIdbOpenErrorMessage(versionError(), ctx({ channel }));
 
-      // Android/iOS WebViews have no tabs and no Ctrl+Shift+R — the hint must
-      // be qualified, not stated as an unconditional instruction.
-      expect(msg).toContain('In a web browser:');
-      // ...and there is no data folder to copy in a browser or WebView, so the
-      // desktop escape hatch must not be handed to them as an instruction.
-      expect(msg).not.toContain('data folder');
+          expect(msg).withContext(channel).not.toContain('data folder');
+        },
+      );
+    });
+
+    it('gives browsers the reload hint and mobile the store instead', () => {
+      const web = buildIdbOpenErrorMessage(versionError(), ctx({ channel: 'web' }));
+      const ios = buildIdbOpenErrorMessage(versionError(), ctx({ channel: 'ios' }));
+
+      expect(web).toContain('Ctrl+Shift+R');
+      // Mobile WebViews have no tabs and no Ctrl+Shift+R, so the reload hint
+      // must not leak into their branch.
+      expect(ios).not.toContain('Ctrl+Shift+R');
     });
   });
 
@@ -113,7 +181,7 @@ describe('buildIdbOpenErrorMessage', () => {
     it('adds Snap-specific recovery steps for backing-store errors', () => {
       const msg = buildIdbOpenErrorMessage(
         new IndexedDBOpenError(new Error('Internal error opening backing store')),
-        ctx({ platform: 'snap' }),
+        ctx({ channel: 'linux-snap' }),
       );
 
       expect(msg).toContain('Recovery steps:');

--- a/src/app/op-log/persistence/idb-open-error-message.spec.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.spec.ts
@@ -36,10 +36,12 @@ describe('buildIdbOpenErrorMessage', () => {
         expect(msg).withContext(platform).toContain('Do NOT clear your storage');
         // The running version is what tells the user which copy is stale.
         expect(msg).withContext(platform).toContain('18.14.0');
-        // Every platform must offer a way out that does not destroy data.
+        // Every platform must offer a way out that does not destroy data —
+        // copy the folder on desktop, and on web (no folder to copy) at least
+        // say plainly that clearing site data is unrecoverable.
         expect(msg)
           .withContext(platform)
-          .toContain('make a copy of your Super Productivity');
+          .toMatch(/make a copy of your Super Productivity|no copy to fall back on/);
       });
     });
 
@@ -77,6 +79,9 @@ describe('buildIdbOpenErrorMessage', () => {
       // Android/iOS WebViews have no tabs and no Ctrl+Shift+R — the hint must
       // be qualified, not stated as an unconditional instruction.
       expect(msg).toContain('In a web browser:');
+      // ...and there is no data folder to copy in a browser or WebView, so the
+      // desktop escape hatch must not be handed to them as an instruction.
+      expect(msg).not.toContain('data folder');
     });
   });
 

--- a/src/app/op-log/persistence/idb-open-error-message.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.ts
@@ -1,13 +1,22 @@
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 
 /**
+ * Which packaging the running build came from. One resolved value rather than
+ * independent `isSnap`/`isFlatpak`/`isElectron` booleans: those can express
+ * states that cannot exist (snap *and* flatpak), which left the mutual
+ * exclusion living in the caller while two branch chains here disagreed on
+ * precedence. A single discriminator makes that unrepresentable.
+ *
+ * `'web'` covers browsers AND the mobile WebViews — see the reload wording.
+ */
+export type IdbOpenPlatform = 'flatpak' | 'snap' | 'electron' | 'web';
+
+/**
  * Platform facts the recovery text depends on. Passed in rather than probed
  * here so the builder stays pure and directly testable.
  */
 export interface IdbOpenErrorContext {
-  isElectron: boolean;
-  isFlatpak: boolean;
-  isSnap: boolean;
+  platform: IdbOpenPlatform;
   /** Version of the build showing the dialog (`environment.version`). */
   appVersion: string;
 }
@@ -32,36 +41,45 @@ const versionErrorRecoverySteps = (ctx: IdbOpenErrorContext): string => {
   // roll back with a single command (`snap revert`), and Snap `edge` tracks
   // every master push. Sending those users to the website download would be
   // wrong — they need their own update channel.
-  if (ctx.isSnap) {
-    return (
-      '1. Close this window.\n' +
-      '2. Update to the newest version: snap refresh super-productivity\n' +
-      '3. If you ran `snap revert` recently, that is what caused this.\n\n'
-    );
+  // Package identifiers per the store links in README.md — snapcraft.io/superproductivity
+  // and flathub.org/apps/com.super_productivity.SuperProductivity. They differ from
+  // both the top-level `appId` and the mac/Capacitor `com.super-productivity.app`;
+  // a wrong id here makes the one command we give the user fail outright.
+  switch (ctx.platform) {
+    case 'flatpak':
+      return (
+        '1. Close this window.\n' +
+        '2. Update to the newest version:\n' +
+        '   flatpak update com.super_productivity.SuperProductivity\n\n'
+      );
+    case 'snap':
+      return (
+        '1. Close this window.\n' +
+        '2. Update to the newest version: snap refresh superproductivity\n' +
+        '3. If you ran `snap revert` recently, that is what caused this.\n\n'
+      );
+    case 'electron':
+      // Snap and Flatpak get their own branch above because this text is
+      // actively wrong for them: their data lives inside the package sandbox
+      // (`SNAP_USER_COMMON`, see electron/start-app.ts), so a second copy
+      // installed from the website would not even share the database.
+      return (
+        '1. Close this window.\n' +
+        '2. Start the newest version you have installed. If this keeps happening, ' +
+        'you likely have a second copy: an outdated desktop shortcut, a portable ' +
+        'executable, or an older install folder.\n' +
+        '3. Otherwise install the latest release from https://super-productivity.com ' +
+        'and launch it from there.\n\n'
+      );
+    case 'web':
+      // Browsers and the mobile WebViews share this branch, so the reload hint
+      // is qualified — Android/iOS have no tabs and no Ctrl+Shift+R.
+      return (
+        '1. Make sure you are running the newest version of Super Productivity.\n' +
+        '2. In a web browser: reload with Ctrl+Shift+R (Cmd+Shift+R on Mac) and ' +
+        'close any other tabs running Super Productivity.\n\n'
+      );
   }
-  if (ctx.isFlatpak) {
-    return (
-      '1. Close this window.\n' +
-      '2. Update to the newest version: flatpak update com.super-productivity.app\n\n'
-    );
-  }
-  if (ctx.isElectron) {
-    return (
-      '1. Close this window.\n' +
-      '2. Start the newest version you have installed. If this keeps happening, ' +
-      'you likely have a second copy: an outdated desktop shortcut, a portable ' +
-      'executable, or an older install folder.\n' +
-      '3. Otherwise install the latest release from https://super-productivity.com ' +
-      'and launch it from there.\n\n'
-    );
-  }
-  // Web and mobile WebView share a branch: the reload hint is qualified so it
-  // stays true on Android/iOS, where there are no tabs and no Ctrl+Shift+R.
-  return (
-    '1. Make sure you are running the newest version of Super Productivity.\n' +
-    '2. In a web browser: reload with Ctrl+Shift+R (Cmd+Shift+R on Mac) and ' +
-    'close any other tabs running Super Productivity.\n\n'
-  );
 };
 
 const buildVersionErrorMessage = (
@@ -71,9 +89,20 @@ const buildVersionErrorMessage = (
   'Cannot Open Data - This Version Is Too Old\n\n' +
   `You are running Super Productivity ${ctx.appVersion}, but your data was ` +
   'last used by a newer version. Older versions cannot read it.\n\n' +
-  'Your data is safe. Do NOT clear your storage — that would delete it.\n\n' +
+  // Deliberately factual rather than "your data is safe": all we know is that
+  // this failure touched nothing. The app never opened the database, so it has
+  // not read the contents and cannot vouch for them.
+  'Nothing was changed or deleted. Do NOT clear your storage — that would ' +
+  'erase the data this build simply cannot read.\n\n' +
   'What to do:\n' +
   versionErrorRecoverySteps(ctx) +
+  // Without this line the message dead-ends: a user whose newer build is gone
+  // (reinstall, replaced machine, restored profile) is told what NOT to do and
+  // given no way forward, so they search the web, find "clear IndexedDB" and
+  // destroy recoverable data. One sentence turns that into a copy-first.
+  'If you cannot run a newer version, make a copy of your Super Productivity ' +
+  'data folder before resetting anything. That copy is what makes recovery ' +
+  'possible.\n\n' +
   `Technical details: ${originalMessageOf(error)}`;
 
 /**
@@ -99,9 +128,9 @@ const buildGenericErrorMessage = (
       'Recovery steps:\n' +
       '1. Close ALL browser tabs and windows\n' +
       '2. Restart the app\n' +
-      (ctx.isFlatpak
+      (ctx.platform === 'flatpak'
         ? '3. If using Linux Flatpak with autostart, try disabling autostart and launching manually\n'
-        : ctx.isSnap
+        : ctx.platform === 'snap'
           ? '3. If using Linux Snap, try: snap set core experimental.refresh-app-awareness=true\n'
           : '3. If using Linux with autostart, try disabling autostart and launching manually\n') +
       '4. If issue persists, check available disk space\n\n';

--- a/src/app/op-log/persistence/idb-open-error-message.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.ts
@@ -96,13 +96,17 @@ const buildVersionErrorMessage = (
   'erase the data this build simply cannot read.\n\n' +
   'What to do:\n' +
   versionErrorRecoverySteps(ctx) +
-  // Without this line the message dead-ends: a user whose newer build is gone
+  // Without this the message dead-ends: a user whose newer build is gone
   // (reinstall, replaced machine, restored profile) is told what NOT to do and
   // given no way forward, so they search the web, find "clear IndexedDB" and
-  // destroy recoverable data. One sentence turns that into a copy-first.
-  'If you cannot run a newer version, make a copy of your Super Productivity ' +
-  'data folder before resetting anything. That copy is what makes recovery ' +
-  'possible.\n\n' +
+  // destroy recoverable data. Browsers and mobile WebViews get the warning
+  // rather than the copy instruction — there is no data folder to copy there.
+  (ctx.platform === 'web'
+    ? 'If you cannot get back to a newer version, do not clear this site’s ' +
+      'data — in the browser there is no copy to fall back on.\n\n'
+    : 'If you cannot run a newer version, make a copy of your Super Productivity ' +
+      'data folder before resetting anything. That copy is what makes recovery ' +
+      'possible.\n\n') +
   `Technical details: ${originalMessageOf(error)}`;
 
 /**

--- a/src/app/op-log/persistence/idb-open-error-message.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.ts
@@ -27,6 +27,43 @@ const originalMessageOf = (error: IndexedDBOpenError): string =>
  *
  * @see https://github.com/super-productivity/super-productivity/issues/9187
  */
+const versionErrorRecoverySteps = (ctx: IdbOpenErrorContext): string => {
+  // Snap and Flatpak are the likeliest way to end up here deliberately: both
+  // roll back with a single command (`snap revert`), and Snap `edge` tracks
+  // every master push. Sending those users to the website download would be
+  // wrong — they need their own update channel.
+  if (ctx.isSnap) {
+    return (
+      '1. Close this window.\n' +
+      '2. Update to the newest version: snap refresh super-productivity\n' +
+      '3. If you ran `snap revert` recently, that is what caused this.\n\n'
+    );
+  }
+  if (ctx.isFlatpak) {
+    return (
+      '1. Close this window.\n' +
+      '2. Update to the newest version: flatpak update com.super-productivity.app\n\n'
+    );
+  }
+  if (ctx.isElectron) {
+    return (
+      '1. Close this window.\n' +
+      '2. Start the newest version you have installed. If this keeps happening, ' +
+      'you likely have a second copy: an outdated desktop shortcut, a portable ' +
+      'executable, or an older install folder.\n' +
+      '3. Otherwise install the latest release from https://super-productivity.com ' +
+      'and launch it from there.\n\n'
+    );
+  }
+  // Web and mobile WebView share a branch: the reload hint is qualified so it
+  // stays true on Android/iOS, where there are no tabs and no Ctrl+Shift+R.
+  return (
+    '1. Make sure you are running the newest version of Super Productivity.\n' +
+    '2. In a web browser: reload with Ctrl+Shift+R (Cmd+Shift+R on Mac) and ' +
+    'close any other tabs running Super Productivity.\n\n'
+  );
+};
+
 const buildVersionErrorMessage = (
   error: IndexedDBOpenError,
   ctx: IdbOpenErrorContext,
@@ -36,17 +73,7 @@ const buildVersionErrorMessage = (
   'last used by a newer version. Older versions cannot read it.\n\n' +
   'Your data is safe. Do NOT clear your storage — that would delete it.\n\n' +
   'What to do:\n' +
-  (ctx.isElectron
-    ? '1. Close this window.\n' +
-      '2. Start the newest version you have installed. If this keeps happening, ' +
-      'you likely have a second copy: an outdated desktop shortcut, a portable ' +
-      'executable, or an older install folder.\n' +
-      '3. Otherwise install the latest release from https://super-productivity.com ' +
-      'and launch it from there.\n\n'
-    : '1. Reload the page with Ctrl+Shift+R (Cmd+Shift+R on Mac) to pick up the ' +
-      'newest version.\n' +
-      '2. If that does not help, close every other tab running Super Productivity ' +
-      'and reload again.\n\n') +
+  versionErrorRecoverySteps(ctx) +
   `Technical details: ${originalMessageOf(error)}`;
 
 /**

--- a/src/app/op-log/persistence/idb-open-error-message.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.ts
@@ -1,0 +1,103 @@
+import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
+
+/**
+ * Platform facts the recovery text depends on. Passed in rather than probed
+ * here so the builder stays pure and directly testable.
+ */
+export interface IdbOpenErrorContext {
+  isElectron: boolean;
+  isFlatpak: boolean;
+  isSnap: boolean;
+  /** Version of the build showing the dialog (`environment.version`). */
+  appVersion: string;
+}
+
+const originalMessageOf = (error: IndexedDBOpenError): string =>
+  error.originalError instanceof Error
+    ? error.originalError.message
+    : String(error.originalError);
+
+/**
+ * The downgrade barrier rejected an intact database: `DB_VERSION` 8-10 exist
+ * precisely to stop an older build from reading newer data (see
+ * `db-keys.const.ts`). The generic text must never be shown here — it blames
+ * disk space and corruption and ends with "your browser storage may need to be
+ * cleared", advice that would destroy perfectly good data and still not let
+ * this build open it. The only fix is to run the newer build.
+ *
+ * @see https://github.com/super-productivity/super-productivity/issues/9187
+ */
+const buildVersionErrorMessage = (
+  error: IndexedDBOpenError,
+  ctx: IdbOpenErrorContext,
+): string =>
+  'Cannot Open Data - This Version Is Too Old\n\n' +
+  `You are running Super Productivity ${ctx.appVersion}, but your data was ` +
+  'last used by a newer version. Older versions cannot read it.\n\n' +
+  'Your data is safe. Do NOT clear your storage — that would delete it.\n\n' +
+  'What to do:\n' +
+  (ctx.isElectron
+    ? '1. Close this window.\n' +
+      '2. Start the newest version you have installed. If this keeps happening, ' +
+      'you likely have a second copy: an outdated desktop shortcut, a portable ' +
+      'executable, or an older install folder.\n' +
+      '3. Otherwise install the latest release from https://super-productivity.com ' +
+      'and launch it from there.\n\n'
+    : '1. Reload the page with Ctrl+Shift+R (Cmd+Shift+R on Mac) to pick up the ' +
+      'newest version.\n' +
+      '2. If that does not help, close every other tab running Super Productivity ' +
+      'and reload again.\n\n') +
+  `Technical details: ${originalMessageOf(error)}`;
+
+/**
+ * Generic "cannot open the database" guidance, with extra recovery steps for
+ * backing-store errors (stale LevelDB lock, sandbox not ready yet).
+ *
+ * @see https://github.com/johannesjo/super-productivity/issues/6255
+ */
+const buildGenericErrorMessage = (
+  error: IndexedDBOpenError,
+  ctx: IdbOpenErrorContext,
+): string => {
+  let message =
+    'Database Error - Cannot Load Data\n\n' +
+    'Super Productivity cannot open its database. ' +
+    'This may be caused by:\n\n' +
+    '- Low disk space\n' +
+    '- Temporary file lock (try closing other tabs)\n' +
+    '- Storage corruption\n\n';
+
+  if (error.isBackingStoreError) {
+    message +=
+      'Recovery steps:\n' +
+      '1. Close ALL browser tabs and windows\n' +
+      '2. Restart the app\n' +
+      (ctx.isFlatpak
+        ? '3. If using Linux Flatpak with autostart, try disabling autostart and launching manually\n'
+        : ctx.isSnap
+          ? '3. If using Linux Snap, try: snap set core experimental.refresh-app-awareness=true\n'
+          : '3. If using Linux with autostart, try disabling autostart and launching manually\n') +
+      '4. If issue persists, check available disk space\n\n';
+  }
+
+  return (
+    message +
+    'If the problem continues after restart, your browser storage may need to be cleared.\n\n' +
+    `Technical details: ${originalMessageOf(error)}\n\n` +
+    '(Check browser console for full error details)'
+  );
+};
+
+/**
+ * Builds the user-facing recovery text for a failed IndexedDB open.
+ *
+ * Extracted from `OperationLogHydratorService` so the wording is pure logic and
+ * the service stays under the 1200-line cap.
+ */
+export const buildIdbOpenErrorMessage = (
+  error: IndexedDBOpenError,
+  ctx: IdbOpenErrorContext,
+): string =>
+  error.isVersionError
+    ? buildVersionErrorMessage(error, ctx)
+    : buildGenericErrorMessage(error, ctx);

--- a/src/app/op-log/persistence/idb-open-error-message.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.ts
@@ -17,16 +17,21 @@ const originalMessageOf = (error: IndexedDBOpenError): string =>
     ? error.originalError.message
     : String(error.originalError);
 
-/** Channels whose data lives in a user-reachable folder that can be copied. */
-const hasLocalDataFolder = (channel: DistChannel): boolean =>
-  channel !== 'web' &&
-  channel !== 'ios' &&
-  channel !== 'android-play' &&
-  channel !== 'android-fdroid';
-
-const storeSteps = (storeName: string): string =>
+/**
+ * Recovery text that is true on every channel. Each sentence self-qualifies
+ * ("If you run it in a browser…"), so a sentence that does not apply reads as
+ * skippable rather than wrong — which is what makes this safe to hand to a
+ * mis-detected user.
+ */
+const UNIVERSAL_RECOVERY_STEPS =
   '1. Close this window.\n' +
-  `2. Update Super Productivity through ${storeName}, then open it again.\n\n`;
+  '2. Start the newest version of Super Productivity you have installed. If this ' +
+  'keeps happening, you likely have a second, older copy: an outdated shortcut, ' +
+  'a portable executable, or an old install folder.\n' +
+  '3. If you cannot find it, update the way you installed it — your app store, ' +
+  'package manager, or https://super-productivity.com\n' +
+  '4. If you run it in a browser: reload with Ctrl+Shift+R (Cmd+Shift+R on Mac) ' +
+  'and close any other tabs running Super Productivity.\n\n';
 
 /**
  * The downgrade barrier rejected an intact database: `DB_VERSION` 8-10 exist
@@ -36,11 +41,16 @@ const storeSteps = (storeName: string): string =>
  * cleared", advice that would destroy perfectly good data and still not let
  * this build open it. The only fix is to run the newer build.
  *
- * Branching on `DistChannel` rather than a local flavour of it matters for
- * correctness, not tidiness: managed-store and sandboxed builds keep their data
- * where a website download cannot see it, so "install the latest release from
- * super-productivity.com" is actively wrong for them. No `default` arm — with
- * `noImplicitReturns` a new channel is then a compile error here.
+ * Only Snap and Flatpak get their own text, and the reason is data location,
+ * not politeness: both keep the database inside the package sandbox, so
+ * "download it from the website" is actively WRONG there — a second install
+ * would not even see this data. Everywhere else the universal block is true,
+ * so it wins: `DistChannel`'s remaining detectors are UA sniffs and
+ * `process.mas`/`process.windowsStore` (the repo already records the former as
+ * unreliable), and a confident wrong instruction is worse than a general right
+ * one. `default` rather than an exhaustive switch for the same reason — an
+ * unknown or future channel must inherit safe text at RUNTIME, which matters
+ * more here than a compile error would.
  *
  * Package identifiers per the store links in README.md — snapcraft.io/superproductivity
  * and flathub.org/apps/com.super_productivity.SuperProductivity. They differ from
@@ -52,47 +62,23 @@ const storeSteps = (storeName: string): string =>
 const versionErrorRecoverySteps = (channel: DistChannel): string => {
   switch (channel) {
     case 'linux-flatpak':
+      // No sudo: polkit's org.freedesktop.Flatpak.app-update is
+      // `allow_active=yes`, and adding sudo would break --user installs.
       return (
         '1. Close this window.\n' +
         '2. Update to the newest version:\n' +
         '   flatpak update com.super_productivity.SuperProductivity\n\n'
       );
     case 'linux-snap':
+      // sudo IS required: snapd's io.snapcraft.snapd.manage is
+      // `auth_admin_keep`, so the bare command dies with "access denied".
       return (
         '1. Close this window.\n' +
-        '2. Update to the newest version: snap refresh superproductivity\n' +
+        '2. Update to the newest version: sudo snap refresh superproductivity\n' +
         '3. If you ran `snap revert` recently, that is what caused this.\n\n'
       );
-    case 'win-store':
-      return storeSteps('the Microsoft Store');
-    case 'mac-store':
-    case 'ios':
-      return storeSteps('the App Store');
-    case 'android-play':
-      return storeSteps('Google Play');
-    case 'android-fdroid':
-      return storeSteps('F-Droid');
-    case 'win-nsis':
-    case 'win-portable':
-    case 'mac-dmg':
-    case 'linux-appimage':
-    case 'linux-native':
-      // Only these channels can have a second, stale copy sitting next to the
-      // current one — which is exactly how #9187 was reported (an old shortcut).
-      return (
-        '1. Close this window.\n' +
-        '2. Start the newest version you have installed. If this keeps happening, ' +
-        'you likely have a second copy: an outdated desktop shortcut, a portable ' +
-        'executable, or an older install folder.\n' +
-        '3. Otherwise install the latest release from https://super-productivity.com ' +
-        'and launch it from there.\n\n'
-      );
-    case 'web':
-      return (
-        '1. Make sure you are running the newest version of Super Productivity.\n' +
-        '2. Reload with Ctrl+Shift+R (Cmd+Shift+R on Mac) and close any other tabs ' +
-        'running Super Productivity.\n\n'
-      );
+    default:
+      return UNIVERSAL_RECOVERY_STEPS;
   }
 };
 
@@ -113,15 +99,16 @@ const buildVersionErrorMessage = (
   // Without this the message dead-ends: a user whose newer build is gone
   // (reinstall, replaced machine, restored profile) is told what NOT to do and
   // given no way forward, so they search the web, find "clear IndexedDB" and
-  // destroy recoverable data.
-  (hasLocalDataFolder(ctx.channel)
-    ? 'If you cannot run a newer version, make a copy of your Super Productivity ' +
-      'data folder before resetting anything. That copy is what makes recovery ' +
-      'possible.\n\n'
-    : 'If you cannot get back to a newer version, do not clear this app’s ' +
-      'data — there is no copy to fall back on here.\n\n') +
-  `Technical details: ${originalMessageOf(error)}\n\n` +
-  '(Check browser console for full error details)';
+  // destroy recoverable data. Not forked per channel — this guards the
+  // anti-data-loss advice, so a mis-detected channel must not be able to flip
+  // it. The desktop half self-qualifies instead.
+  'If you cannot run a newer version, do NOT clear this app data — that is what ' +
+  'makes the loss permanent. On desktop, copy your Super Productivity data ' +
+  'folder somewhere safe before changing anything.\n\n' +
+  // No "check the console" pointer here: `Technical details` above already
+  // carries the whole error, and 5 of the 13 channels have no console a user
+  // can open. It stays in the generic branch, where it is true.
+  `Technical details: ${originalMessageOf(error)}`;
 
 /**
  * Generic "cannot open the database" guidance, with extra recovery steps for

--- a/src/app/op-log/persistence/idb-open-error-message.ts
+++ b/src/app/op-log/persistence/idb-open-error-message.ts
@@ -1,23 +1,14 @@
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
-
-/**
- * Which packaging the running build came from. One resolved value rather than
- * independent `isSnap`/`isFlatpak`/`isElectron` booleans: those can express
- * states that cannot exist (snap *and* flatpak), which left the mutual
- * exclusion living in the caller while two branch chains here disagreed on
- * precedence. A single discriminator makes that unrepresentable.
- *
- * `'web'` covers browsers AND the mobile WebViews — see the reload wording.
- */
-export type IdbOpenPlatform = 'flatpak' | 'snap' | 'electron' | 'web';
+import { DistChannel } from '../../util/get-app-version-str';
 
 /**
  * Platform facts the recovery text depends on. Passed in rather than probed
  * here so the builder stays pure and directly testable.
  */
 export interface IdbOpenErrorContext {
-  platform: IdbOpenPlatform;
-  /** Version of the build showing the dialog (`environment.version`). */
+  /** How this build was distributed — decides where "get the newer one" points. */
+  channel: DistChannel;
+  /** Version of the build showing the dialog (`getAppVersionStr()`). */
   appVersion: string;
 }
 
@@ -25,6 +16,17 @@ const originalMessageOf = (error: IndexedDBOpenError): string =>
   error.originalError instanceof Error
     ? error.originalError.message
     : String(error.originalError);
+
+/** Channels whose data lives in a user-reachable folder that can be copied. */
+const hasLocalDataFolder = (channel: DistChannel): boolean =>
+  channel !== 'web' &&
+  channel !== 'ios' &&
+  channel !== 'android-play' &&
+  channel !== 'android-fdroid';
+
+const storeSteps = (storeName: string): string =>
+  '1. Close this window.\n' +
+  `2. Update Super Productivity through ${storeName}, then open it again.\n\n`;
 
 /**
  * The downgrade barrier rejected an intact database: `DB_VERSION` 8-10 exist
@@ -34,35 +36,49 @@ const originalMessageOf = (error: IndexedDBOpenError): string =>
  * cleared", advice that would destroy perfectly good data and still not let
  * this build open it. The only fix is to run the newer build.
  *
+ * Branching on `DistChannel` rather than a local flavour of it matters for
+ * correctness, not tidiness: managed-store and sandboxed builds keep their data
+ * where a website download cannot see it, so "install the latest release from
+ * super-productivity.com" is actively wrong for them. No `default` arm — with
+ * `noImplicitReturns` a new channel is then a compile error here.
+ *
+ * Package identifiers per the store links in README.md — snapcraft.io/superproductivity
+ * and flathub.org/apps/com.super_productivity.SuperProductivity. They differ from
+ * both the top-level `appId` and the mac/Capacitor `com.super-productivity.app`;
+ * a wrong id here makes the one command we give the user fail outright.
+ *
  * @see https://github.com/super-productivity/super-productivity/issues/9187
  */
-const versionErrorRecoverySteps = (ctx: IdbOpenErrorContext): string => {
-  // Snap and Flatpak are the likeliest way to end up here deliberately: both
-  // roll back with a single command (`snap revert`), and Snap `edge` tracks
-  // every master push. Sending those users to the website download would be
-  // wrong — they need their own update channel.
-  // Package identifiers per the store links in README.md — snapcraft.io/superproductivity
-  // and flathub.org/apps/com.super_productivity.SuperProductivity. They differ from
-  // both the top-level `appId` and the mac/Capacitor `com.super-productivity.app`;
-  // a wrong id here makes the one command we give the user fail outright.
-  switch (ctx.platform) {
-    case 'flatpak':
+const versionErrorRecoverySteps = (channel: DistChannel): string => {
+  switch (channel) {
+    case 'linux-flatpak':
       return (
         '1. Close this window.\n' +
         '2. Update to the newest version:\n' +
         '   flatpak update com.super_productivity.SuperProductivity\n\n'
       );
-    case 'snap':
+    case 'linux-snap':
       return (
         '1. Close this window.\n' +
         '2. Update to the newest version: snap refresh superproductivity\n' +
         '3. If you ran `snap revert` recently, that is what caused this.\n\n'
       );
-    case 'electron':
-      // Snap and Flatpak get their own branch above because this text is
-      // actively wrong for them: their data lives inside the package sandbox
-      // (`SNAP_USER_COMMON`, see electron/start-app.ts), so a second copy
-      // installed from the website would not even share the database.
+    case 'win-store':
+      return storeSteps('the Microsoft Store');
+    case 'mac-store':
+    case 'ios':
+      return storeSteps('the App Store');
+    case 'android-play':
+      return storeSteps('Google Play');
+    case 'android-fdroid':
+      return storeSteps('F-Droid');
+    case 'win-nsis':
+    case 'win-portable':
+    case 'mac-dmg':
+    case 'linux-appimage':
+    case 'linux-native':
+      // Only these channels can have a second, stale copy sitting next to the
+      // current one — which is exactly how #9187 was reported (an old shortcut).
       return (
         '1. Close this window.\n' +
         '2. Start the newest version you have installed. If this keeps happening, ' +
@@ -72,12 +88,10 @@ const versionErrorRecoverySteps = (ctx: IdbOpenErrorContext): string => {
         'and launch it from there.\n\n'
       );
     case 'web':
-      // Browsers and the mobile WebViews share this branch, so the reload hint
-      // is qualified — Android/iOS have no tabs and no Ctrl+Shift+R.
       return (
         '1. Make sure you are running the newest version of Super Productivity.\n' +
-        '2. In a web browser: reload with Ctrl+Shift+R (Cmd+Shift+R on Mac) and ' +
-        'close any other tabs running Super Productivity.\n\n'
+        '2. Reload with Ctrl+Shift+R (Cmd+Shift+R on Mac) and close any other tabs ' +
+        'running Super Productivity.\n\n'
       );
   }
 };
@@ -95,19 +109,19 @@ const buildVersionErrorMessage = (
   'Nothing was changed or deleted. Do NOT clear your storage — that would ' +
   'erase the data this build simply cannot read.\n\n' +
   'What to do:\n' +
-  versionErrorRecoverySteps(ctx) +
+  versionErrorRecoverySteps(ctx.channel) +
   // Without this the message dead-ends: a user whose newer build is gone
   // (reinstall, replaced machine, restored profile) is told what NOT to do and
   // given no way forward, so they search the web, find "clear IndexedDB" and
-  // destroy recoverable data. Browsers and mobile WebViews get the warning
-  // rather than the copy instruction — there is no data folder to copy there.
-  (ctx.platform === 'web'
-    ? 'If you cannot get back to a newer version, do not clear this site’s ' +
-      'data — in the browser there is no copy to fall back on.\n\n'
-    : 'If you cannot run a newer version, make a copy of your Super Productivity ' +
+  // destroy recoverable data.
+  (hasLocalDataFolder(ctx.channel)
+    ? 'If you cannot run a newer version, make a copy of your Super Productivity ' +
       'data folder before resetting anything. That copy is what makes recovery ' +
-      'possible.\n\n') +
-  `Technical details: ${originalMessageOf(error)}`;
+      'possible.\n\n'
+    : 'If you cannot get back to a newer version, do not clear this app’s ' +
+      'data — there is no copy to fall back on here.\n\n') +
+  `Technical details: ${originalMessageOf(error)}\n\n` +
+  '(Check browser console for full error details)';
 
 /**
  * Generic "cannot open the database" guidance, with extra recovery steps for
@@ -132,9 +146,9 @@ const buildGenericErrorMessage = (
       'Recovery steps:\n' +
       '1. Close ALL browser tabs and windows\n' +
       '2. Restart the app\n' +
-      (ctx.platform === 'flatpak'
+      (ctx.channel === 'linux-flatpak'
         ? '3. If using Linux Flatpak with autostart, try disabling autostart and launching manually\n'
-        : ctx.platform === 'snap'
+        : ctx.channel === 'linux-snap'
           ? '3. If using Linux Snap, try: snap set core experimental.refresh-app-awareness=true\n'
           : '3. If using Linux with autostart, try disabling autostart and launching manually\n') +
       '4. If issue persists, check available disk space\n\n';

--- a/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
+++ b/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
@@ -32,7 +32,7 @@ import {
   IDB_OPEN_RETRY_BASE_DELAY_MS,
 } from '../core/operation-log.const';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
-import { isLockRelatedIdbOpenError } from './op-log-errors.const';
+import { isIdbVersionError, isLockRelatedIdbOpenError } from './op-log-errors.const';
 
 const ADAPTER_NOT_INITIALIZED =
   'IndexedDbOpLogAdapter not initialized. Ensure init() is called.';
@@ -214,6 +214,10 @@ export class IndexedDbOpLogAdapter implements OpLogDbAdapter {
         return await this._openDbOnce();
       } catch (e) {
         lastError = e;
+        // Downgrade barrier: retrying can't change the on-disk version (#9187).
+        if (isIdbVersionError(e)) {
+          break;
+        }
         if (attempt === 1 && !isLockRelatedIdbOpenError(e)) {
           maxRetries = IDB_OPEN_RETRIES_NON_LOCK;
         }

--- a/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
+++ b/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
@@ -203,6 +203,13 @@ export class IndexedDbOpLogAdapter implements OpLogDbAdapter {
    * Open with exponential backoff. Lock-related errors get the full retry
    * window (they may clear); other errors fail faster so the hydrator can
    * surface the problem. Preserves the budgets/semantics of the existing store.
+   *
+   * NOTE: dormant in production today. Both stores call `_adapter.init()` only
+   * behind `if (!this._adapter.adoptConnection)`, and this adapter defines
+   * `adoptConnection` — so it runs on the connection the store hands it and
+   * never opens the database itself. Kept in step with the two live loops
+   * (`OperationLogStoreService`, `ArchiveStoreService`) so the path is already
+   * correct if the adapter ever takes ownership of the open.
    */
   private async _openDbWithRetry(): Promise<IDBPDatabase> {
     let maxRetries = IDB_OPEN_RETRIES;
@@ -236,12 +243,7 @@ export class IndexedDbOpLogAdapter implements OpLogDbAdapter {
 
     const err = new IndexedDBOpenError(lastError);
     // See OperationLogStoreService: zero retries ran on the barrier path (#9187).
-    Log.err(
-      err.isVersionError
-        ? '[OpLogAdapter] IndexedDB open rejected by the downgrade barrier (no retry).'
-        : '[OpLogAdapter] IndexedDB open failed after all retries.',
-      err,
-    );
+    Log.err('[OpLogAdapter] IndexedDB open failed.', err);
     throw err;
   }
 

--- a/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
+++ b/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
@@ -242,7 +242,7 @@ export class IndexedDbOpLogAdapter implements OpLogDbAdapter {
     }
 
     const err = new IndexedDBOpenError(lastError);
-    // See OperationLogStoreService: zero retries ran on the barrier path (#9187).
+    // See OperationLogStoreService: the barrier path stops retrying (#9187).
     Log.err('[OpLogAdapter] IndexedDB open failed.', err);
     throw err;
   }

--- a/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
+++ b/src/app/op-log/persistence/indexed-db-op-log-adapter.ts
@@ -235,7 +235,13 @@ export class IndexedDbOpLogAdapter implements OpLogDbAdapter {
     }
 
     const err = new IndexedDBOpenError(lastError);
-    Log.err('[OpLogAdapter] IndexedDB open failed after all retries.', err);
+    // See OperationLogStoreService: zero retries ran on the barrier path (#9187).
+    Log.err(
+      err.isVersionError
+        ? '[OpLogAdapter] IndexedDB open rejected by the downgrade barrier (no retry).'
+        : '[OpLogAdapter] IndexedDB open failed after all retries.',
+      err,
+    );
     throw err;
   }
 

--- a/src/app/op-log/persistence/op-log-errors.const.ts
+++ b/src/app/op-log/persistence/op-log-errors.const.ts
@@ -91,6 +91,30 @@ export const isLockRelatedIdbOpenError = (err: unknown): boolean => {
   return false;
 };
 
+/**
+ * Is this open error the downgrade barrier firing? The browser throws
+ * `VersionError` when the requested `DB_VERSION` is lower than the version
+ * already on disk, i.e. an older app build is opening a database that a newer
+ * build upgraded. `DB_VERSION` 8-10 exist purely as such barriers (see
+ * `db-keys.const.ts`), so this is a supported, deliberate rejection — not
+ * storage damage.
+ *
+ * Two consequences, both handled by callers:
+ * - Retrying is pointless: the version numbers cannot change while the app
+ *   runs, so every attempt fails identically. The open loops break out
+ *   immediately instead of burning the ~7s non-lock budget on a white screen.
+ * - The recovery advice must differ: the generic dialog blames disk space and
+ *   corruption and suggests clearing storage, which here would destroy intact
+ *   data and still not let the old build open it.
+ *
+ * `DOMException` is checked alongside `Error` for the same reason as in
+ * `isLockRelatedIdbOpenError` above.
+ *
+ * @see https://github.com/super-productivity/super-productivity/issues/9187
+ */
+export const isIdbVersionError = (err: unknown): boolean =>
+  (err instanceof DOMException || err instanceof Error) && err.name === 'VersionError';
+
 // ============================================================================
 // Connection Closing Errors (Issue #6643)
 // ============================================================================

--- a/src/app/op-log/persistence/op-log-errors.const.ts
+++ b/src/app/op-log/persistence/op-log-errors.const.ts
@@ -48,6 +48,19 @@ export const IDB_OPEN_ERROR_MSG =
   '[OpLogStore] Failed to open IndexedDB after multiple retries. See #6255.';
 
 /**
+ * Base message for the downgrade barrier. `IDB_OPEN_ERROR_MSG` must not be
+ * reused there: it claims retries that never ran, and the wrapper's `message`
+ * is the string that reaches `HANDLED_ERROR_PROP_STR`, `getErrorTxt` and the
+ * exported log history — i.e. exactly what a user pastes into a bug report.
+ * Correcting only the `Log.err` prefixes would leave the false claim in the
+ * copy most likely to be read.
+ *
+ * @see https://github.com/super-productivity/super-productivity/issues/9187
+ */
+export const IDB_OPEN_VERSION_BARRIER_MSG =
+  'Failed to open IndexedDB: rejected by the downgrade barrier, no retry attempted. See #9187.';
+
+/**
  * Pattern to detect "backing store" errors from the browser.
  * These errors indicate storage-level issues (disk I/O, file locks, corruption).
  * Used for heuristic error detection to show platform-specific guidance.

--- a/src/app/op-log/persistence/op-log-errors.const.ts
+++ b/src/app/op-log/persistence/op-log-errors.const.ts
@@ -48,8 +48,11 @@ export const IDB_OPEN_ERROR_MSG =
   '[OpLogStore] Failed to open IndexedDB after multiple retries. See #6255.';
 
 /**
- * Base message for the downgrade barrier. `IDB_OPEN_ERROR_MSG` must not be
- * reused there: it claims retries that never ran, and the wrapper's `message`
+ * Base message for the downgrade barrier. Says "further retries skipped" rather
+ * than "no retry ran", because attempts CAN precede it: a transient failure may
+ * burn an attempt, then another process commits the upgrade during the backoff,
+ * and the next attempt hits the barrier. `IDB_OPEN_ERROR_MSG` must not be
+ * reused here either: it claims a full retry budget, and the wrapper's `message`
  * is the string that reaches `HANDLED_ERROR_PROP_STR`, `getErrorTxt` and the
  * exported log history — i.e. exactly what a user pastes into a bug report.
  * Correcting only the `Log.err` prefixes would leave the false claim in the
@@ -58,7 +61,7 @@ export const IDB_OPEN_ERROR_MSG =
  * @see https://github.com/super-productivity/super-productivity/issues/9187
  */
 export const IDB_OPEN_VERSION_BARRIER_MSG =
-  'Failed to open IndexedDB: rejected by the downgrade barrier, no retry attempted. See #9187.';
+  'Failed to open IndexedDB: rejected by the downgrade barrier, further retries skipped. See #9187.';
 
 /**
  * Pattern to detect "backing store" errors from the browser.

--- a/src/app/op-log/persistence/op-log-errors.const.ts
+++ b/src/app/op-log/persistence/op-log-errors.const.ts
@@ -110,6 +110,11 @@ export const isLockRelatedIdbOpenError = (err: unknown): boolean => {
  * `DOMException` is checked alongside `Error` for the same reason as in
  * `isLockRelatedIdbOpenError` above.
  *
+ * Pass the ORIGINAL browser error. An already-wrapped `IndexedDBOpenError`
+ * overrides `name`, so it returns `false` here — read `.isVersionError` on the
+ * wrapper instead, or the caller silently falls back to the generic
+ * clear-your-storage dialog.
+ *
  * @see https://github.com/super-productivity/super-productivity/issues/9187
  */
 export const isIdbVersionError = (err: unknown): boolean =>

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -29,6 +29,7 @@ import { bulkApplyHydrationOperations } from '../apply/bulk-hydration.action';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 import { MAX_VECTOR_CLOCK_SIZE } from '../core/operation-log.const';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
+import { environment } from '../../../environments/environment';
 import { IDB_OPEN_ERROR_RELOAD_KEY } from './operation-log-hydrator.service';
 import { SyncProviderId } from '../sync-providers/provider.const';
 import { OperationLogEffects } from '../capture/operation-log.effects';
@@ -2324,6 +2325,55 @@ describe('OperationLogHydratorService', () => {
       await expectAsync(service.hydrateStore()).toBeRejected();
 
       expect(reloadSpy).not.toHaveBeenCalled();
+    });
+
+    // #9187: DB_VERSION 8-10 are deliberate downgrade barriers, so a
+    // VersionError means an old build is looking at an intact database. The
+    // generic dialog's "your browser storage may need to be cleared" would
+    // destroy that data and still not let this build open it.
+    describe('downgrade barrier (VersionError)', () => {
+      const arrangeVersionError = (): void => {
+        mockRecoveryService.recoverPendingRemoteOps.and.rejectWith(
+          new IndexedDBOpenError(
+            new DOMException(
+              'The requested version (7) is less than the existing version (10).',
+              'VersionError',
+            ),
+          ),
+        );
+      };
+
+      const shownMessage = (): string =>
+        (window.alert as jasmine.Spy).calls.mostRecent().args[0] as string;
+
+      it('never tells the user to clear storage or blames corruption', async () => {
+        arrangeVersionError();
+
+        await expectAsync(service.hydrateStore()).toBeRejected();
+
+        expect(window.alert).toHaveBeenCalledTimes(1);
+        const msg = shownMessage();
+        expect(msg).not.toContain('storage may need to be cleared');
+        expect(msg).not.toContain('Storage corruption');
+        expect(msg).not.toContain('Low disk space');
+        expect(msg).toContain('Do NOT clear your storage');
+      });
+
+      it('names the running version and keeps the technical detail', async () => {
+        arrangeVersionError();
+
+        await expectAsync(service.hydrateStore()).toBeRejected();
+
+        const msg = shownMessage();
+        expect(msg).toContain(environment.version);
+        expect(msg).toContain('newer version');
+        // The raw browser text still reaches bug reports.
+        expect(msg).toContain('The requested version (7) is less than');
+      });
+
+      // No auto-reload assertion here: a VersionError is not a backing-store
+      // error, so the existing non-backing-store test above already covers it.
+      // Asserting it again passes with this branch deleted — a vacuous test.
     });
 
     it('should clear the reload key after successful hydration', async () => {

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -30,6 +30,7 @@ import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider
 import { MAX_VECTOR_CLOCK_SIZE } from '../core/operation-log.const';
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 import { environment } from '../../../environments/environment';
+import { getAppVersionStr } from '../../util/get-app-version-str';
 import { IDB_OPEN_ERROR_RELOAD_KEY } from './operation-log-hydrator.service';
 import { SyncProviderId } from '../sync-providers/provider.const';
 import { OperationLogEffects } from '../capture/operation-log.effects';
@@ -2365,7 +2366,10 @@ describe('OperationLogHydratorService', () => {
         await expectAsync(service.hydrateStore()).toBeRejected();
 
         const msg = shownMessage();
-        expect(msg).toContain(environment.version);
+        // The channel-suffixed string, not the bare version: the suffix is what
+        // distinguishes two installed copies from each other (#9187).
+        expect(msg).toContain(getAppVersionStr());
+        expect(getAppVersionStr()).not.toBe(environment.version);
         expect(msg).toContain('newer version');
         // The raw browser text still reaches bug reports.
         expect(msg).toContain('The requested version (7) is less than');

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -34,7 +34,7 @@ import { AppDataComplete } from '../model/model-config';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 import { IS_ELECTRON } from '../../app.constants';
 import { environment } from '../../../environments/environment';
-import { buildIdbOpenErrorMessage } from './idb-open-error-message';
+import { buildIdbOpenErrorMessage, IdbOpenPlatform } from './idb-open-error-message';
 import {
   BulkReplayReducerFailure,
   runWithBulkReplayFailureCollector,
@@ -1128,8 +1128,16 @@ export class OperationLogHydratorService {
       error.originalError,
     );
 
-    const isFlatpak = !!(IS_ELECTRON && window.ea?.isFlatpak?.());
-    const isSnap = !isFlatpak && !!(IS_ELECTRON && window.ea?.isSnap?.());
+    // Resolved once, here, so the mutual exclusion cannot be expressed wrongly
+    // downstream. Flatpak wins over Snap, preserving the long-standing
+    // precedence of the generic message's recovery-steps ternary.
+    const platform: IdbOpenPlatform = !IS_ELECTRON
+      ? 'web'
+      : window.ea?.isFlatpak?.()
+        ? 'flatpak'
+        : window.ea?.isSnap?.()
+          ? 'snap'
+          : 'electron';
 
     // For backing-store errors (common during Linux session startup with autostart),
     // auto-reload once after the user dismisses the dialog. By the time the dialog
@@ -1153,12 +1161,7 @@ export class OperationLogHydratorService {
     }
 
     alertDialog(
-      buildIdbOpenErrorMessage(error, {
-        isElectron: IS_ELECTRON,
-        isFlatpak,
-        isSnap,
-        appVersion: environment.version,
-      }),
+      buildIdbOpenErrorMessage(error, { platform, appVersion: environment.version }),
     );
   }
 

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -1122,9 +1122,15 @@ export class OperationLogHydratorService {
    * @see https://github.com/johannesjo/super-productivity/issues/6255
    */
   private _showIndexedDBOpenError(error: IndexedDBOpenError): void {
-    // Log full error details to console for debugging (can be copied by users)
+    // Log full error details to console for debugging (can be copied by users).
+    // The barrier path breaks out after ONE attempt, and this is the log line
+    // that accompanies the dialog a user is about to screenshot — claiming
+    // retries here would misdirect #9187 triage more than the three store-side
+    // copies of the same sentence.
     OpLog.err(
-      'IndexedDB open failed after all retries. Original error:',
+      error.isVersionError
+        ? 'IndexedDB open rejected by the downgrade barrier (no retry). Original error:'
+        : 'IndexedDB open failed after all retries. Original error:',
       error.originalError,
     );
 

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -33,6 +33,8 @@ import { bulkApplyOperations } from '../apply/bulk-hydration.action';
 import { AppDataComplete } from '../model/model-config';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 import { IS_ELECTRON } from '../../app.constants';
+import { environment } from '../../../environments/environment';
+import { buildIdbOpenErrorMessage } from './idb-open-error-message';
 import {
   BulkReplayReducerFailure,
   runWithBulkReplayFailureCollector,
@@ -1126,14 +1128,8 @@ export class OperationLogHydratorService {
       error.originalError,
     );
 
-    const originalMsg =
-      error.originalError instanceof Error
-        ? error.originalError.message
-        : String(error.originalError);
-
-    // Hoist platform detection — used in both branches below to avoid computing twice
-    const isFlatpak = IS_ELECTRON && window.ea?.isFlatpak?.();
-    const isSnap = !isFlatpak && IS_ELECTRON && window.ea?.isSnap?.();
+    const isFlatpak = !!(IS_ELECTRON && window.ea?.isFlatpak?.());
+    const isSnap = !isFlatpak && !!(IS_ELECTRON && window.ea?.isSnap?.());
 
     // For backing-store errors (common during Linux session startup with autostart),
     // auto-reload once after the user dismisses the dialog. By the time the dialog
@@ -1156,34 +1152,14 @@ export class OperationLogHydratorService {
       }
     }
 
-    // Second failure, or non-backing-store error: show full manual recovery instructions.
-    let message =
-      'Database Error - Cannot Load Data\n\n' +
-      'Super Productivity cannot open its database. ' +
-      'This may be caused by:\n\n' +
-      '- Low disk space\n' +
-      '- Temporary file lock (try closing other tabs)\n' +
-      '- Storage corruption\n\n';
-
-    if (error.isBackingStoreError) {
-      message +=
-        'Recovery steps:\n' +
-        '1. Close ALL browser tabs and windows\n' +
-        '2. Restart the app\n' +
-        (isFlatpak
-          ? '3. If using Linux Flatpak with autostart, try disabling autostart and launching manually\n'
-          : isSnap
-            ? '3. If using Linux Snap, try: snap set core experimental.refresh-app-awareness=true\n'
-            : '3. If using Linux with autostart, try disabling autostart and launching manually\n') +
-        '4. If issue persists, check available disk space\n\n';
-    }
-
-    message +=
-      'If the problem continues after restart, your browser storage may need to be cleared.\n\n' +
-      `Technical details: ${originalMsg}\n\n` +
-      '(Check browser console for full error details)';
-
-    alertDialog(message);
+    alertDialog(
+      buildIdbOpenErrorMessage(error, {
+        isElectron: IS_ELECTRON,
+        isFlatpak,
+        isSnap,
+        appVersion: environment.version,
+      }),
+    );
   }
 
   /**

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -33,8 +33,8 @@ import { bulkApplyOperations } from '../apply/bulk-hydration.action';
 import { AppDataComplete } from '../model/model-config';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
 import { IS_ELECTRON } from '../../app.constants';
-import { environment } from '../../../environments/environment';
-import { buildIdbOpenErrorMessage, IdbOpenPlatform } from './idb-open-error-message';
+import { detectChannel, getAppVersionStr } from '../../util/get-app-version-str';
+import { buildIdbOpenErrorMessage } from './idb-open-error-message';
 import {
   BulkReplayReducerFailure,
   runWithBulkReplayFailureCollector,
@@ -1123,27 +1123,9 @@ export class OperationLogHydratorService {
    */
   private _showIndexedDBOpenError(error: IndexedDBOpenError): void {
     // Log full error details to console for debugging (can be copied by users).
-    // The barrier path breaks out after ONE attempt, and this is the log line
-    // that accompanies the dialog a user is about to screenshot — claiming
-    // retries here would misdirect #9187 triage more than the three store-side
-    // copies of the same sentence.
-    OpLog.err(
-      error.isVersionError
-        ? 'IndexedDB open rejected by the downgrade barrier (no retry). Original error:'
-        : 'IndexedDB open failed after all retries. Original error:',
-      error.originalError,
-    );
-
-    // Resolved once, here, so the mutual exclusion cannot be expressed wrongly
-    // downstream. Flatpak wins over Snap, preserving the long-standing
-    // precedence of the generic message's recovery-steps ternary.
-    const platform: IdbOpenPlatform = !IS_ELECTRON
-      ? 'web'
-      : window.ea?.isFlatpak?.()
-        ? 'flatpak'
-        : window.ea?.isSnap?.()
-          ? 'snap'
-          : 'electron';
+    // Deliberately does not mention retries — the barrier path breaks out after
+    // ONE attempt (#9187); `error.message` names which case this is.
+    OpLog.err('IndexedDB open failed. Original error:', error.originalError);
 
     // For backing-store errors (common during Linux session startup with autostart),
     // auto-reload once after the user dismisses the dialog. By the time the dialog
@@ -1166,8 +1148,14 @@ export class OperationLogHydratorService {
       }
     }
 
+    // `getAppVersionStr()` rather than the bare version: its channel suffix
+    // (e.g. `18.15.1P` vs `18.15.1W`) is what tells a user WHICH of two copies
+    // they just launched — the central question in a downgrade (#9187).
     alertDialog(
-      buildIdbOpenErrorMessage(error, { platform, appVersion: environment.version }),
+      buildIdbOpenErrorMessage(error, {
+        channel: detectChannel(),
+        appVersion: getAppVersionStr(),
+      }),
     );
   }
 

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -1123,8 +1123,8 @@ export class OperationLogHydratorService {
    */
   private _showIndexedDBOpenError(error: IndexedDBOpenError): void {
     // Log full error details to console for debugging (can be copied by users).
-    // Deliberately does not mention retries — the barrier path breaks out after
-    // ONE attempt (#9187); `error.message` names which case this is.
+    // Deliberately does not mention retries — the barrier path stops as soon as
+    // it is hit (#9187); `error.message` names which case this is.
     OpLog.err('IndexedDB open failed. Original error:', error.originalError);
 
     // For backing-store errors (common during Linux session startup with autostart),

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -192,6 +192,31 @@ describe('OperationLogStoreService', () => {
       expect(initSpy).not.toHaveBeenCalled();
       expect((svc as unknown as { _db: unknown })._db).toBe(fakeDb);
     });
+
+    // #9187: an older build opening a database a newer build upgraded gets a
+    // VersionError. The version numbers can't change while we run, so the
+    // retry budget only delays the explanation behind a white screen.
+    it('fails fast without retrying when the downgrade barrier rejects the open', async () => {
+      const adapter = {
+        init: jasmine.createSpy('init').and.resolveTo(undefined),
+        adoptConnection: jasmine.createSpy('adoptConnection'),
+      } as unknown as OpLogDbAdapter;
+      const svc = freshServiceWith(adapter);
+      const openSpy = spyOn(
+        svc as unknown as { _openDbOnce: () => Promise<unknown> },
+        '_openDbOnce',
+      ).and.rejectWith(
+        new DOMException(
+          'The requested version (7) is less than the existing version (10).',
+          'VersionError',
+        ),
+      );
+
+      await expectAsync(svc.init()).toBeRejectedWithError(/Failed to open IndexedDB/);
+
+      // Exactly one attempt — no exponential-backoff budget burned.
+      expect(openSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('connection lifecycle handlers', () => {

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -216,6 +216,11 @@ describe('OperationLogStoreService', () => {
 
       // Exactly one attempt — no exponential-backoff budget burned.
       expect(openSpy).toHaveBeenCalledTimes(1);
+      // NOTE: without the fail-fast break this spec dies on the 2s jasmine
+      // timeout (src/test.ts) rather than on the assertion above, because the
+      // non-lock budget sleeps 1s+2s+4s. Do NOT "repair" a slow run here by
+      // raising DEFAULT_TIMEOUT_INTERVAL — that would turn this into a
+      // 7-second passing test that no longer guards anything.
     });
   });
 

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -502,7 +502,15 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     // carries the formatted original detail, so logging the wrapper exposes
     // everything we need.
     const err = new IndexedDBOpenError(lastError);
-    Log.err('[OpLogStore] IndexedDB open failed after all retries.', err);
+    // The barrier path breaks out after ONE attempt — saying "after all
+    // retries" there would send #9187 triage looking for a 7s window that
+    // never happened. Log output is what bug reports carry.
+    Log.err(
+      err.isVersionError
+        ? '[OpLogStore] IndexedDB open rejected by the downgrade barrier (no retry).'
+        : '[OpLogStore] IndexedDB open failed after all retries.',
+      err,
+    );
     throw err;
   }
 

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -502,8 +502,8 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     // carries the formatted original detail, so logging the wrapper exposes
     // everything we need.
     const err = new IndexedDBOpenError(lastError);
-    // Deliberately does not mention retries: the barrier path breaks out after
-    // ONE attempt. `err.message` already names which case this is (#9187).
+    // Deliberately does not mention retries: the barrier path stops as soon as
+    // it is hit. `err.message` already names which case this is (#9187).
     Log.err('[OpLogStore] IndexedDB open failed.', err);
     throw err;
   }

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -34,6 +34,7 @@ import {
 import {
   DUPLICATE_OPERATION_ERROR_MSG,
   OPERATION_LOG_STORE_NOT_INITIALIZED,
+  isIdbVersionError,
   isLockRelatedIdbOpenError,
 } from './op-log-errors.const';
 import { runDbUpgrade } from './db-upgrade';
@@ -462,6 +463,12 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         return await this._openDbOnce();
       } catch (e) {
         lastError = e;
+
+        // Downgrade barrier: the on-disk version can't change while we run, so
+        // every retry fails identically. Surface it now (#9187).
+        if (isIdbVersionError(e)) {
+          break;
+        }
 
         // Classify the error on the first failure. If it doesn't look
         // lock-related, shrink the retry budget so we fail fast and let the

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -502,15 +502,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     // carries the formatted original detail, so logging the wrapper exposes
     // everything we need.
     const err = new IndexedDBOpenError(lastError);
-    // The barrier path breaks out after ONE attempt — saying "after all
-    // retries" there would send #9187 triage looking for a 7s window that
-    // never happened. Log output is what bug reports carry.
-    Log.err(
-      err.isVersionError
-        ? '[OpLogStore] IndexedDB open rejected by the downgrade barrier (no retry).'
-        : '[OpLogStore] IndexedDB open failed after all retries.',
-      err,
-    );
+    // Deliberately does not mention retries: the barrier path breaks out after
+    // ONE attempt. `err.message` already names which case this is (#9187).
+    Log.err('[OpLogStore] IndexedDB open failed.', err);
     throw err;
   }
 

--- a/src/app/util/get-app-version-str.ts
+++ b/src/app/util/get-app-version-str.ts
@@ -61,7 +61,13 @@ export const distChannelSuffix = (channel: DistChannel | null | undefined): stri
   }
 };
 
-const detectChannel = (): DistChannel => {
+/**
+ * Resolves the running build's distribution channel. Exported because recovery
+ * advice has to differ per channel too (see `idb-open-error-message.ts`), not
+ * just the version suffix — telling a Microsoft Store or Flatpak user to
+ * download from the website points them at a build that cannot see their data.
+ */
+export const detectChannel = (): DistChannel => {
   if (IS_IOS) {
     return 'ios';
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1619,7 +1619,7 @@
         "ERROR_PAYLOAD_TOO_LARGE": "Sync Error: Your data is too large to upload.\n\nThis happens when you have many archived tasks. Your data was NOT synced!\n\nPlease contact support for assistance.",
         "ERROR_PERMISSION": "File access denied. Please check your filesystem permissions.",
         "ERROR_PERMISSION_FLATPAK": "File access denied. Grant filesystem permission via Flatseal or use a path inside ~/.var/app/",
-        "ERROR_PERMISSION_SNAP": "File access denied. Run 'snap connect super-productivity:home' or use a path inside ~/snap/super-productivity/common/",
+        "ERROR_PERMISSION_SNAP": "File access denied. Run 'snap connect superproductivity:home' or use a path inside ~/snap/superproductivity/common/",
         "ERROR_REMOTE_FILE_CORRUPTED": "Remote sync data is unreadable (possibly truncated or corrupted). Your local data is safe. You can overwrite the remote with your local data.",
         "ERROR_REMOTE_FILE_EMPTY": "Remote sync file is empty. This can happen after an interrupted sync. Overwrite remote with your local data?",
         "ERROR_REMOTE_FILE_LOCKED": "Remote sync file is locked by the server. This may resolve on the next sync attempt.",


### PR DESCRIPTION
Rewrites the dialog reported in #9187, where an IndexedDB `VersionError` was presented as storage corruption.

## What this fixes — and what it does not

**It does not help the reporter of #9187, or anyone currently locked out.** The dialog is rendered by the *old* binary (v18.11.0–v18.14.0, `DB_VERSION 7`), and that binary already shipped with the bad text. Nothing merged here can change what an already-installed old build says.

This only takes effect once a build containing it becomes the *stale* one — i.e. on the next `DB_VERSION` bump. Given 7→8→9→10 happened in three commits over four days, that is likely soon, but the value here is forward-looking. Anyone stuck today needs to find and run their newer install; that is a support answer, not a code fix.

## The bug

`DB_VERSION` is **7** in v18.11.0–v18.14.0 and **10** in v18.15.0/v18.15.1. When an older build opens a database a newer build already upgraded, the browser throws `VersionError` — and versions 8/9/10 add no object stores, so they exist *purely* as downgrade barriers (`db-upgrade.ts` has no branch above `oldVersion < 7`).

That deliberate rejection of **intact** data was reported through the generic dialog, which blames low disk space and storage corruption and ends with:

> If the problem continues after restart, your browser storage may need to be cleared.

For this failure that advice destroys the user's tasks and still does not let the old build open the data. The barrier is not the bug; the message is.

The failure path itself was already non-destructive — `IndexedDBOpenError` short-circuits before `recoveryService.attemptRecovery()`, and there is no `deleteDB` in production code — so only the advice was dangerous.

## The change

- **Classify it once.** `isIdbVersionError()` feeds `IndexedDBOpenError.isVersionError`, and `_buildMessage` picks the base string from that same classification. This matters because the wrapper's `message` — not the `Log.err` prefix — is what reaches `HANDLED_ERROR_PROP_STR`, `getErrorTxt` and the exported log history, i.e. what a user actually pastes into a bug report.
- **Say what happened.** "This copy is too old, nothing was changed or deleted, do NOT clear your storage."
- **Channel-specific advice only where it must be.** Snap and Flatpak keep exact commands, because both store the database inside the package sandbox — "download it from the website" is *actively wrong* there, since a second install would not even see the data. Every other channel gets one universal block whose sentences self-qualify ("If you run it in a browser: …"), so an inapplicable line reads as skippable rather than false.

  This is deliberate: `DistChannel`'s other detectors are not reliable enough to act on. `IS_IOS` is a `navigator.platform` sniff, so every iOS *browser* user resolves to `ios`; `process.mas`/`process.windowsStore` are the signals `app.constants.ts` already records as unreliable. A mis-detected Mac App Store user sent to the website download would open a build reading a different container — an *empty* app, which is exactly how someone talks themselves into clearing storage. A `default` arm rather than an exhaustive switch, so an unknown or future channel inherits safe text at runtime.
- **Reuse the existing channel vocabulary.** `detectChannel()` / `getAppVersionStr()` from `util/get-app-version-str.ts` instead of a local re-derivation. The channel suffix (`18.15.1P` vs `18.15.1W`) is what tells a user *which* of two copies they just launched — the central question in a downgrade.
- **Stop retrying.** The on-disk version cannot change while the app runs, so the ~7s non-lock budget (1+3 attempts, 1s+2s+4s) only delayed the explanation behind a white screen — exactly the "after a few sec" in the report.
- **Extraction was forced, not cosmetic.** `operation-log-hydrator.service.ts` was at **exactly** 1200 lines, the lint-enforced `max-lines` cap, and is not in the grandfathered warn-list — it could not absorb one added line. Now 1173, with the message building as a pure, directly testable function.

Also included, found while verifying the snap identifier: `ERROR_PERMISSION_SNAP` in `en.json` shipped `snap connect super-productivity:home` and `~/snap/super-productivity/common/`. The snap is `superproductivity` (README, `linux.executableName`, `build.yml`), so both failed as printed. One-line fix, unrelated to #9187.

## Verification

- Real **Chromium 149** probe confirms the contract and the diagnosis: `name: 'VersionError'`, `instanceof DOMException && instanceof Error`, message **byte-identical** to the screenshot in #9187. (The Karma suite installs `fake-indexeddb`, so IDB specs agree with the spec but do not prove Blink — the E2E does.)
- The generic non-`VersionError` message is preserved **byte-for-byte** and pinned by a full-string assertion.
- A spec asserts the universal recovery text is **byte-identical across all 11** non-sandboxed channels — that invariant is what makes a mis-detected channel harmless.
- `sudo` on the snap command and its *absence* on flatpak are both verified against polkit policy: `io.snapcraft.snapd.manage` is `auth_admin_keep` (the bare command dies with "access denied"), `org.freedesktop.Flatpak.app-update` is `allow_active=yes` (adding sudo would break `--user` installs).
- Every new test sabotage-verified: reverting the corresponding production change makes it fail. Assertions that could not fail were removed rather than kept.
- Pre-existing exact-attempt guards for the lock (`1 + IDB_OPEN_RETRIES`) and non-lock (`1 + IDB_OPEN_RETRIES_NON_LOCK`) budgets are untouched and green, which is what proves the early exit did not shrink the retry machinery that #6255/#7191 depend on.

## Review notes

This went through a 7-way review plus two independent scoping reviews and a Codex safety pass, which caught real defects in earlier revisions of this branch:

- Two **non-existent package identifiers** (`super-productivity` is not the snap; `com.super-productivity.app` is the *macOS* bundle id), whose specs pinned the wrong strings.
- Log lines corrected to stop claiming retries, while the wrapper's own message still said "after multiple retries" — the correction that mattered least, in the string that mattered most.
- An earlier 13-channel switch that gave *confident wrong* advice on mis-detected channels.
- The barrier message then claiming "no retry attempted", which is untrue when a transient failure burns an attempt and another process commits the upgrade during the backoff. Now "further retries skipped", true in both orderings.

Known gaps, deliberately out of scope:

- A `versionchange`-triggered re-open at **runtime** throws from a runtime caller, which by design only logs — no dialog. Pre-existing.
- After dismissing the alert the app shows an empty shell, because the route guards await `isAllDataLoadedInitially$`, which never emits. Pre-existing for every branch of this dialog; a persistent in-app error screen would be the better fix.
- The three `_openDbWithRetry` copies should collapse into one shared helper — that duplication is why this one behavioural change needed three edits. `ArchiveStoreService` is also the only one of the three without exact-attempt budget tests, because it inlines `openDB` rather than exposing an `_openDbOnce` seam.

The dialog stays hardcoded English: it runs before the user's language is loaded (`setLng` happens post-hydration via `global-config.effects.ts`), and rendering raw translation keys in the one dialog whose job is to stop someone wiping their data would be worse than English.
