### PR TITLE
fix(tasks): honor auto-add setting for started tasks

### DIFF
--- a/src/app/features/tasks/store/task-internal.effects.spec.ts
+++ b/src/app/features/tasks/store/task-internal.effects.spec.ts
@@ -368,6 +368,67 @@ describe('TaskInternalEffects', () => {
       actions$.next(setCurrentTask({ id: 'task1' }));
     });
 
+    it('should not plan the started task when auto-add worked-on tasks is disabled', () => {
+      const task = createTask('task1', { isDone: false });
+
+      store.overrideSelector(
+        selectTasksConfig,
+        createTasksConfig({ isAutoAddWorkedOnToToday: false }),
+      );
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], 'task1'));
+      store.overrideSelector(selectTodayTaskIds, []);
+      store.refreshState();
+
+      let emitted = false;
+      effects.planStartedTaskForToday$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(setCurrentTask({ id: 'task1' }));
+
+      expect(emitted).toBe(false);
+    });
+
+    it('should not move a task with an existing due day to today when started', () => {
+      const task = createTask('task1', {
+        isDone: false,
+        dueDay: '2026-01-06',
+      });
+
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], 'task1'));
+      store.overrideSelector(selectTodayTaskIds, []);
+      store.refreshState();
+
+      let emitted = false;
+      effects.planStartedTaskForToday$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(setCurrentTask({ id: 'task1' }));
+
+      expect(emitted).toBe(false);
+    });
+
+    it('should not move a task with a scheduled time to today when started', () => {
+      const task = createTask('task1', {
+        isDone: false,
+        dueWithTime: new Date('2026-01-06T09:00:00Z').getTime(),
+      });
+
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], 'task1'));
+      store.overrideSelector(selectTodayTaskIds, []);
+      store.refreshState();
+
+      let emitted = false;
+      effects.planStartedTaskForToday$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(setCurrentTask({ id: 'task1' }));
+
+      expect(emitted).toBe(false);
+    });
+
     it('should not plan the started task again when it is already in today', (done) => {
       const task = createTask('task1', { isDone: false, dueDay: '2026-01-05' });
 

--- a/src/app/features/tasks/store/task-internal.effects.ts
+++ b/src/app/features/tasks/store/task-internal.effects.ts
@@ -100,8 +100,9 @@ export class TaskInternalEffects {
       withLatestFrom(
         this._store$.pipe(select(selectTaskFeatureState)),
         this._store$.pipe(select(selectTodayTaskIds)),
+        this._store$.pipe(select(selectTasksConfig)),
       ),
-      mergeMap(([, state, todayTaskIds]) => {
+      mergeMap(([, state, todayTaskIds, tasksCfg]) => {
         const currentTaskId = state.currentTaskId;
         if (!currentTaskId) {
           return EMPTY;
@@ -109,7 +110,10 @@ export class TaskInternalEffects {
 
         const currentTask = state.entities[currentTaskId] as Task | undefined;
         if (
+          !tasksCfg.isAutoAddWorkedOnToToday ||
           !currentTask ||
+          !!currentTask.dueDay ||
+          typeof currentTask.dueWithTime === 'number' ||
           todayTaskIds.includes(currentTaskId) ||
           (!!currentTask.parentId && todayTaskIds.includes(currentTask.parentId))
         ) {


### PR DESCRIPTION
## Summary

- honor “Automatically add worked-on tasks to today” when a task starts
- preserve tasks that already have a due day or scheduled time
- add regression coverage for the disabled setting and existing schedules

Closes #9180.

## Root cause

The immediate `setCurrentTask` effect added for #8031 planned every started task for today without consulting `isAutoAddWorkedOnToToday`. It also lacked the schedule-preservation guards already used by the time-tracking fallback.

## Impact

Users who disable automatic planning can track ongoing activities without those tasks appearing in Today or the Planner. Starting a previously scheduled task no longer overwrites its existing schedule.

## Validation

- `npm run checkFile src/app/features/tasks/store/task-internal.effects.ts`
- `npm run checkFile src/app/features/tasks/store/task-internal.effects.spec.ts`
- `npm run test:file src/app/features/tasks/store/task-internal.effects.spec.ts` — 17 passed
- `npm run test:file src/app/features/tasks/store/task-related-model.effects.spec.ts` — 8 passed
- pre-push lint and complete test suites — 13,396 primary Angular tests and 13,382 timezone tests passed, plus package and tooling suites
- six-perspective multi-review — APPROVE
