### PR TITLE
fix(sync): use canonical Nextcloud ETags for uploads

### DIFF
--- a/packages/sync-providers/src/file-based/webdav/nextcloud.ts
+++ b/packages/sync-providers/src/file-based/webdav/nextcloud.ts
@@ -30,7 +30,7 @@ export class NextcloudProvider extends WebdavBaseProvider<
   readonly id = PROVIDER_ID_NEXTCLOUD;
 
   constructor(deps: NextcloudDeps, extraPath?: string) {
-    super(deps, extraPath);
+    super(deps, extraPath, { useCanonicalOcEtag: true });
   }
 
   protected override get logLabel(): string {

--- a/packages/sync-providers/src/file-based/webdav/webdav-api.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-api.ts
@@ -24,15 +24,6 @@ import type { WebdavPrivateCfg } from './webdav.model';
  */
 const STRONG_ETAG_RE = /^"[\x21\x23-\x7e\x80-\xff]*"$/;
 
-/**
- * Content-coding suffixes Apache appends to the ETag it SERVES on a compressed
- * response — `mod_deflate` under its default `DeflateAlterETag AddSuffix`, and
- * `mod_brotli` likewise. The origin keeps comparing `If-Match` against the bare
- * tag, so a client that echoes back what it was served can never satisfy the
- * precondition (#9154, #9196).
- */
-const CONTENT_CODING_ETAG_SUFFIX_RE = /-(?:gzip|br|deflate)"$/;
-
 export interface WebdavApiDeps {
   logger: SyncLogger;
   /**
@@ -42,6 +33,8 @@ export interface WebdavApiDeps {
    */
   getCfg: () => Promise<WebdavPrivateCfg>;
   httpAdapter: WebDavHttpAdapter;
+  /** Nextcloud's DAV layer exposes its canonical validator in `OC-ETag`. */
+  useCanonicalOcEtag?: boolean;
 }
 
 export class WebdavApi {
@@ -62,35 +55,38 @@ export class WebdavApi {
    * malformed values cannot safely drive `If-Match`, so callers fall back to a
    * content hash and the legacy best-effort check instead.
    */
-  private _readStrongEtag(headers: Record<string, string>): string | undefined {
-    const entry = Object.entries(headers).find(([name]) => name.toLowerCase() === 'etag');
+  private _readStrongEtag(
+    headers: Record<string, string>,
+    headerName: string,
+  ): string | undefined {
+    const entry = Object.entries(headers).find(
+      ([name]) => name.toLowerCase() === headerName,
+    );
     const etag = entry?.[1]?.trim();
     return etag && STRONG_ETAG_RE.test(etag) ? etag : undefined;
   }
 
-  private _isStrongEtag(value: string): boolean {
-    return STRONG_ETAG_RE.test(value);
+  /**
+   * Returns a strong validator that can be echoed back exactly in `If-Match`.
+   *
+   * Nextcloud exposes its canonical validator as `OC-ETag`, specifically so it
+   * survives HTTP-server rewrites such as Apache's content-coding suffix
+   * (#9154, #9196). Only the dedicated Nextcloud provider enables that
+   * extension; generic WebDAV entity tags are opaque and must never be
+   * rewritten. If browser CORS hides `OC-ETag`, Nextcloud falls back to the
+   * existing content-hash check instead of trusting a potentially rewritten
+   * HTTP `ETag`.
+   */
+  private _readStrongRevision(headers: Record<string, string>): string | undefined {
+    if (this._deps.useCanonicalOcEtag) {
+      return this._readStrongEtag(headers, 'oc-etag');
+    }
+
+    return this._readStrongEtag(headers, 'etag');
   }
 
-  /**
-   * `If-Match` value for a rev, offering the bare tag alongside the served one
-   * whenever the served tag carries a content-coding suffix.
-   *
-   * RFC 7232 lets `If-Match` carry a list and the precondition passes if ANY
-   * member matches, so we let the server pick whichever form it actually
-   * compares. This keeps the write atomic — no precondition is ever dropped —
-   * and costs no extra round trip. A genuine concurrent write still matches
-   * neither candidate and is rejected as before.
-   *
-   * Verified against Apache 2.4 + mod_dav + mod_deflate (list → 204, stale list
-   * → 412); sabre/dav, which evaluates `If-Match` for Nextcloud, splits the list
-   * the same way.
-   */
-  private _ifMatchValue(rev: string): string {
-    const bare = rev.replace(CONTENT_CODING_ETAG_SUFFIX_RE, '"');
-    // `""` would be a degenerate tag: a rev of `"-gzip"` is a tag in its own
-    // right, not a suffixed one.
-    return bare === rev || bare === '""' ? rev : `${rev}, ${bare}`;
+  private _isStrongEtag(value: string): boolean {
+    return STRONG_ETAG_RE.test(value);
   }
 
   private _isHttpStatus(error: unknown, status: number): boolean {
@@ -219,7 +215,7 @@ export class WebdavApi {
 
       const hash = await this._computeContentHash(response.data);
       return {
-        rev: this._readStrongEtag(response.headers) ?? hash,
+        rev: this._readStrongRevision(response.headers) ?? hash,
         dataStr: response.data,
       };
     } catch (e) {
@@ -285,7 +281,7 @@ export class WebdavApi {
         [WebDavHttpHeader.CONTENT_TYPE]: 'application/octet-stream',
       };
       if (!isForceOverwrite && strongExpectedRev) {
-        headers[WebDavHttpHeader.IF_MATCH] = this._ifMatchValue(strongExpectedRev);
+        headers[WebDavHttpHeader.IF_MATCH] = strongExpectedRev;
       } else if (!isForceOverwrite && expectedRev === null) {
         headers[WebDavHttpHeader.IF_NONE_MATCH] = '*';
       }
@@ -414,7 +410,7 @@ export class WebdavApi {
           `sync cycle will re-download and reconcile.`,
       );
     }
-    return this._readStrongEtag(remoteResponse.headers) ?? remoteHash;
+    return this._readStrongRevision(remoteResponse.headers) ?? remoteHash;
   }
 
   async remove(path: string): Promise<void> {

--- a/packages/sync-providers/src/file-based/webdav/webdav-base-provider.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-base-provider.ts
@@ -63,6 +63,10 @@ type WebdavCredentialsLike = {
   syncFolderPath?: string;
 };
 
+interface WebdavBaseOptions {
+  useCanonicalOcEtag?: boolean;
+}
+
 export abstract class WebdavBaseProvider<
   T extends WebdavProviderId,
   TPrivateCfg extends WebdavCredentialsLike = WebdavPrivateCfg,
@@ -76,7 +80,11 @@ export abstract class WebdavBaseProvider<
   protected readonly _logger: SyncLogger;
   protected readonly _extraPath?: string;
 
-  constructor(deps: WebdavBaseDeps<T, TPrivateCfg>, extraPath?: string) {
+  constructor(
+    deps: WebdavBaseDeps<T, TPrivateCfg>,
+    extraPath?: string,
+    options: WebdavBaseOptions = {},
+  ) {
     this.privateCfg = deps.credentialStore;
     this._logger = deps.logger;
     this._extraPath = extraPath;
@@ -91,6 +99,7 @@ export abstract class WebdavBaseProvider<
       logger: deps.logger,
       getCfg: () => this._cfgOrError(),
       httpAdapter,
+      useCanonicalOcEtag: options.useCanonicalOcEtag,
     });
   }
 

--- a/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
@@ -65,12 +65,17 @@ const makeApi = (
   adapter: MockAdapter,
   logger: SyncLogger = NOOP_SYNC_LOGGER,
   overrideCfg: WebdavPrivateCfg = cfg,
+  useCanonicalOcEtag = false,
 ): WebdavApi =>
   new WebdavApi({
     logger,
     getCfg: async () => overrideCfg,
     httpAdapter: adapter as unknown as WebDavHttpAdapter,
+    useCanonicalOcEtag,
   });
+
+const makeNextcloudApi = (adapter: MockAdapter): WebdavApi =>
+  makeApi(adapter, NOOP_SYNC_LOGGER, cfg, true);
 
 const okResponse = (
   data: string,
@@ -110,7 +115,10 @@ interface FakeDavFile {
  */
 const makeFakeDavServer = (
   file: FakeDavFile,
-  { etagSuffix = '' }: { etagSuffix?: string } = {},
+  {
+    etagSuffix = '',
+    exposeOcEtag = false,
+  }: { etagSuffix?: string; exposeOcEtag?: boolean } = {},
 ): MockAdapter => {
   const adapter = makeAdapter();
   let writes = 0;
@@ -121,7 +129,10 @@ const makeFakeDavServer = (
     const { method, headers, body } = raw as DavRequest;
 
     if (method === 'GET') {
-      return okResponse(file.body, 200, { etag: servedTag() });
+      return okResponse(file.body, 200, {
+        etag: servedTag(),
+        ...(exposeOcEtag ? { ['OC-ETag']: comparedTag() } : {}),
+      });
     }
     if (method === 'PUT') {
       const ifMatch = headers?.[WebDavHttpHeader.IF_MATCH];
@@ -189,6 +200,56 @@ describe('WebdavApi', () => {
       const result = await makeApi(adapter).download({ path: 'op-1.json' });
 
       expect(result.rev).toBe('"strong-rev"');
+    });
+
+    it('uses the canonical OC-ETag when Nextcloud HTTP ETag was rewritten', async () => {
+      const adapter = makeAdapter();
+      adapter.request.mockResolvedValue(
+        okResponse('hello world', 200, {
+          ETag: '"strong-rev-gzip"',
+          ['OC-ETag']: '"different-rev"',
+        }),
+      );
+
+      const result = await makeNextcloudApi(adapter).download({ path: 'op-1.json' });
+
+      expect(result.rev).toBe('"different-rev"');
+    });
+
+    it('ignores a matching OC-ETag for a generic WebDAV origin', async () => {
+      const adapter = makeAdapter();
+      adapter.request.mockResolvedValue(
+        okResponse('hello world', 200, {
+          ETag: '"strong-rev-gzip"',
+          ['OC-ETag']: '"strong-rev"',
+        }),
+      );
+
+      const result = await makeApi(adapter).download({ path: 'op-1.json' });
+
+      expect(result.rev).toBe('"strong-rev-gzip"');
+    });
+
+    it('uses a canonical OC-ETag when the HTTP ETag is not exposed', async () => {
+      const adapter = makeAdapter();
+      adapter.request.mockResolvedValue(
+        okResponse('hello world', 200, { ['OC-ETag']: '"strong-rev"' }),
+      );
+
+      const result = await makeNextcloudApi(adapter).download({ path: 'op-1.json' });
+
+      expect(result.rev).toBe('"strong-rev"');
+    });
+
+    it('uses the content hash when Nextcloud OC-ETag is not exposed', async () => {
+      const adapter = makeAdapter();
+      adapter.request.mockResolvedValue(
+        okResponse('hello world', 200, { ETag: '"strong-rev-gzip"' }),
+      );
+
+      const result = await makeNextcloudApi(adapter).download({ path: 'op-1.json' });
+
+      expect(result.rev).toBe(await md5HashWasm('hello world'));
     });
 
     it('does not trust a weak ETag as an atomic revision', async () => {
@@ -313,32 +374,56 @@ describe('WebdavApi', () => {
     describe('servers that rewrite the ETag they serve (#9154 / #9196)', () => {
       it("completes the upload when the served ETag carries mod_deflate's -gzip suffix", async () => {
         const file: FakeDavFile = { body: 'remote body', tag: 'abc' };
-        const adapter = makeFakeDavServer(file, { etagSuffix: '-gzip' });
-        const api = makeApi(adapter);
+        const adapter = makeFakeDavServer(file, {
+          etagSuffix: '-gzip',
+          exposeOcEtag: true,
+        });
+        const api = makeNextcloudApi(adapter);
 
-        // The rev the rest of the app is handed is the mangled tag.
+        // Nextcloud supplies the canonical validator explicitly. The app must
+        // not reconstruct it from the opaque, content-coded HTTP ETag.
         const { rev } = await api.download({ path: 'op-1.json' });
-        expect(rev).toBe('"abc-gzip"');
+        expect(rev).toBe('"abc"');
 
         await api.upload({ path: 'op-1.json', data: 'my new body', expectedRev: rev });
 
         expect(file.body).toBe('my new body');
-        // The write stays atomic and costs no retry: one conditional PUT that
-        // offers the server both spellings of the tag.
+        // The write stays atomic and costs no retry: one exact conditional PUT
+        // using the validator that Nextcloud itself supplied.
         const puts = putsOf(adapter);
         expect(puts).toHaveLength(1);
-        expect(puts[0]?.headers?.[WebDavHttpHeader.IF_MATCH]).toBe('"abc-gzip", "abc"');
+        expect(puts[0]?.headers?.[WebDavHttpHeader.IF_MATCH]).toBe('"abc"');
       });
 
       it('still refuses to overwrite a genuine concurrent write', async () => {
         const file: FakeDavFile = { body: 'remote body', tag: 'abc' };
-        const adapter = makeFakeDavServer(file, { etagSuffix: '-gzip' });
-        const api = makeApi(adapter);
+        const adapter = makeFakeDavServer(file, {
+          etagSuffix: '-gzip',
+          exposeOcEtag: true,
+        });
+        const api = makeNextcloudApi(adapter);
         const { rev } = await api.download({ path: 'op-1.json' });
 
         // Another client writes between our download and our upload.
         file.body = 'their body';
         file.tag = 'xyz';
+
+        await expect(
+          api.upload({ path: 'op-1.json', data: 'my new body', expectedRev: rev }),
+        ).rejects.toBeInstanceOf(RemoteFileChangedUnexpectedly);
+        expect(file.body).toBe('their body');
+      });
+
+      it('does not treat a derived bare tag as the revision that was downloaded', async () => {
+        const file: FakeDavFile = { body: 'remote body', tag: 'abc-gzip' };
+        const adapter = makeFakeDavServer(file);
+        const api = makeNextcloudApi(adapter);
+        const { rev } = await api.download({ path: 'op-1.json' });
+
+        // Entity tags are opaque. `"abc"` is a distinct, newer revision — it
+        // must not match merely because the downloaded tag ended in `-gzip`.
+        file.body = 'their body';
+        file.tag = 'abc';
 
         await expect(
           api.upload({ path: 'op-1.json', data: 'my new body', expectedRev: rev }),
@@ -363,8 +448,11 @@ describe('WebdavApi', () => {
         // The rev handed back after an upload is mangled too, so a fix that only
         // recovered once would 412 forever from the second upload on.
         const file: FakeDavFile = { body: 'remote body', tag: 'abc' };
-        const adapter = makeFakeDavServer(file, { etagSuffix: '-gzip' });
-        const api = makeApi(adapter);
+        const adapter = makeFakeDavServer(file, {
+          etagSuffix: '-gzip',
+          exposeOcEtag: true,
+        });
+        const api = makeNextcloudApi(adapter);
 
         const first = await api.download({ path: 'op-1.json' });
         const { rev } = await api.upload({

--- a/packages/sync-providers/tests/file-based/webdav/webdav-base-provider.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-base-provider.spec.ts
@@ -296,6 +296,34 @@ describe('NextcloudProvider', () => {
     );
   });
 
+  it('uses Nextcloud canonical OC-ETag revisions', async () => {
+    const nativeHttp = vi.fn().mockResolvedValue({
+      status: 200,
+      headers: {
+        ETag: '"strong-rev-gzip"',
+        ['OC-ETag']: '"strong-rev"',
+      },
+      data: 'real-payload',
+    });
+    const provider = new NextcloudProvider({
+      logger: NOOP_SYNC_LOGGER,
+      platformInfo: {
+        isNativePlatform: true,
+        isAndroidWebView: false,
+        isIosNative: false,
+      },
+      webFetch: () => globalThis.fetch as typeof fetch,
+      nativeHttp,
+      credentialStore: fakeStore<typeof PROVIDER_ID_NEXTCLOUD, NextcloudPrivateCfg>(
+        validNextcloudCfg,
+      ),
+    });
+
+    const result = await provider.downloadFile('op-1.json');
+
+    expect(result.rev).toBe('"strong-rev"');
+  });
+
   it('_cfgOrError rejects missing serverUrl', async () => {
     const provider = new NextcloudProvider({
       logger: NOOP_SYNC_LOGGER,


### PR DESCRIPTION
Closes #9154. Also addresses the duplicate report in #9196 and corrects the unsafe compatibility behavior merged in #9240.

## Root cause

Apache may rewrite the HTTP `ETag` of a compressed Nextcloud response from `"abc"` to `"abc-gzip"`, while Nextcloud evaluates `If-Match` against its canonical `OC-ETag`.

The first fix sent both spellings:

```http
If-Match: "abc-gzip", "abc"
```

That is not safe. Entity tags are opaque and an `If-Match` list succeeds when any member matches. If a genuine downloaded revision is `"abc-gzip"` and a concurrent write changes it to `"abc"`, the derived candidate matches and the stale upload overwrites the concurrent write.

## Fix

- The dedicated Nextcloud provider opts into canonical `OC-ETag` handling.
- Nextcloud downloads and post-upload verification use a valid strong `OC-ETag` as the revision.
- Uploads echo exactly one validator in `If-Match`; no alternative tag is derived.
- If browser CORS hides `OC-ETag`, Nextcloud uses the existing content-hash fallback instead of trusting a potentially rewritten HTTP `ETag`.
- Generic WebDAV continues to treat the standard `ETag` as opaque and sends it unchanged.

The CORS fallback remains best-effort across the GET-to-PUT window, matching the established behavior for weak or missing validators. A generic WebDAV server that rewrites ETags can still reject a write rather than being normalized unsafely.

## Regression coverage

Tests cover:

- rewritten Nextcloud ETags succeeding with one canonical validator;
- genuine concurrent writes still being rejected;
- the opaque-tag overwrite counterexample;
- generic WebDAV ignoring `OC-ETag`;
- CORS exposing only one of the two headers;
- steady-state revisions after post-upload verification;
- provider-level Nextcloud option wiring.

## Verification

- Full pre-push `npm test`: 13,393 default-timezone tests and 13,379 Los Angeles-timezone tests passed.
- `@sp/sync-core`: 243 tests passed.
- `@sp/sync-providers`: 416 tests passed with typecheck.
- Package CJS, ESM, and declaration build passed.
- All five changed TypeScript files passed `npm run checkFile`.
- Repository lint, lint-rule tests, and 18 theme-asset tests passed; only pre-existing warnings outside this change remain.
- Six-perspective read-only multi-review: APPROVE, high confidence, no findings.
