### PR TITLE
fix(tasks): preserve notes in recurring task presets

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -490,6 +490,24 @@ describe('AddTaskBarComponent', () => {
       expect(repeatCfg.startDate).toBe('2024-05-19');
     });
 
+    it('should copy entered notes to an inline repeat preset config (discussion #937)', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const addRepeatCfgSpy = spyOn(
+        TestBed.inject(TaskRepeatCfgService),
+        'addTaskRepeatCfgToTask',
+      );
+
+      component.stateService.updateInputTxt('Daily standup');
+      component.stateService.updateCleanText('Daily standup');
+      component.stateService.updateRepeatSetting('DAILY');
+      component.stateService.noteTxt.set('  Join from the meeting room  ');
+
+      await component.addTask();
+
+      const repeatCfg = addRepeatCfgSpy.calls.mostRecent().args[2];
+      expect(repeatCfg.notes).toBe('Join from the meeting room');
+    });
+
     it('seeds skipOverdue ON for an inline Daily repeat (#8644)', async () => {
       mockTaskService.add.and.returnValue('task-1');
       const addRepeatCfgSpy = spyOn(

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -605,6 +605,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
             ...quickSettingUpdates,
             title,
             quickSetting: state.repeatQuickSetting,
+            notes: taskData.notes,
             tagIds: taskData.tagIds ?? [],
             defaultEstimate: state.estimate || 0,
             startTime: state.time || undefined,


### PR DESCRIPTION
## Problem

Creating a task from the add-task bar with notes and an inline recurrence preset (for example, **Every day**) kept the notes on the first task but omitted them from the recurring template. Later generated instances therefore lost the notes.

Reported in [Discussion #937](https://github.com/super-productivity/super-productivity/discussions/937#discussioncomment-17688899).

## Solution

Copy the already-trimmed task notes into the inline repeat configuration and add a regression test covering the preset creation path.

This restores the existing **Default notes** behavior without adding settings, UI, dependencies, or sync-format changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Verification

- Focused regression test: 46/46 passed
- Runtime browser check: notes populate **Recur → Advanced configuration → Default notes**
- Full `npm test`: passed
- `npm run checkFile` passed for both changed TypeScript files
- Six-perspective multi-review: approved with no findings

## Checklist

- [x] Documentation reviewed; no changes required because this restores documented behavior
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
