### PR TITLE
fix(electron): handle special characters in install paths

### DIFF
--- a/.github/workflows/electron-smoke.yml
+++ b/.github/workflows/electron-smoke.yml
@@ -93,6 +93,9 @@ jobs:
           fi
           node tools/verify-electron-requires.js "$ASAR"
 
+      - name: Move packaged app into special-character path
+        run: mv .tmp/app-builds/linux-unpacked '.tmp/app-builds/# packaged app'
+
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
@@ -104,7 +107,7 @@ jobs:
             --auto-servernum \
             --server-args="-screen 0 1280x720x24" \
             node e2e/electron/packaged-app-smoke.cjs \
-              .tmp/app-builds/linux-unpacked/superproductivity \
+              '.tmp/app-builds/# packaged app/superproductivity' \
             2>&1 | tee .tmp/smoke/launch.log
 
       - name: Upload logs on failure

--- a/e2e/electron/packaged-app-smoke.cjs
+++ b/e2e/electron/packaged-app-smoke.cjs
@@ -157,10 +157,28 @@ const run = async () => {
       timeout: 20_000,
     });
 
+    const overlayMessage = 'Packaged # path & fragment = decoded';
+    const overlayPagePromise = page.context().waitForEvent('page', {
+      timeout: 20_000,
+    });
+    await page.evaluate((msg) => {
+      window.ea.showFullScreenBlocker({
+        msg,
+        takeABreakCfg: {
+          motivationalImgs: [],
+          timedFullScreenBlockerDuration: 60_000,
+        },
+      });
+    }, overlayMessage);
+    const overlayPage = await overlayPagePromise;
+    await overlayPage.waitForLoadState('domcontentloaded');
+    await expect(overlayPage.locator('#msg')).toHaveText(overlayMessage);
+    expect(overlayPage.url()).toContain('%23%20packaged%20app');
+
     if (pageErrors.length) {
       throw new Error(`Renderer page errors:\n${pageErrors.join('\n')}`);
     }
-    console.log('Packaged Electron task-create-and-reload smoke passed.');
+    console.log('Packaged Electron task-create, reload, and overlay smoke passed.');
   } finally {
     await browser?.close().catch(() => undefined);
     await stopChild(child);

--- a/electron/full-screen-blocker.ts
+++ b/electron/full-screen-blocker.ts
@@ -1,7 +1,8 @@
 import { BrowserWindow, BrowserWindowConstructorOptions, ipcMain } from 'electron';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 import { TakeABreakConfig } from '../src/app/features/config/global-config.model';
-import { join, normalize } from 'path';
+import { join } from 'path';
+import { pathToFileURL } from 'node:url';
 import { assertSecureWebPreferences } from './web-preferences-guard';
 
 export const initFullScreenBlocker = (IS_DEV: boolean): void => {
@@ -44,15 +45,16 @@ export const initFullScreenBlocker = (IS_DEV: boolean): void => {
       win.setVisibleOnAllWorkspaces(true);
       win.setFullScreenable(false);
       isFullScreenWindowOpen = true;
+      const overlayUrl = pathToFileURL(
+        join(
+          __dirname,
+          IS_DEV
+            ? '../src/static/break-reminder-overlay.html'
+            : '../.tmp/angular-dist/browser/static/break-reminder-overlay.html',
+        ),
+      ).href;
       win.loadURL(
-        `file://${normalize(
-          join(
-            __dirname,
-            IS_DEV
-              ? '../src/static/break-reminder-overlay.html'
-              : '../dist/static/break-reminder-overlay.html',
-          ),
-        )}` +
+        overlayUrl +
           `#msg=${encodeURIComponent(msg)}&img=${encodeURIComponent(randomImgUrl ?? '')}&time=${
             takeABreakCfg.timedFullScreenBlockerDuration
           }`,

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -11,7 +11,7 @@ import {
 } from 'electron';
 import { errorHandlerWithFrontendInform } from './error-handler-with-frontend-inform';
 import * as path from 'path';
-import { join, normalize } from 'path';
+import { pathToFileURL } from 'node:url';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 import { isExternalUrlSchemeAllowed } from './shared-with-frontend/is-external-url-allowed';
 import { isLocalFileUrl, openLocalPath } from './open-url';
@@ -316,7 +316,8 @@ export const createWindow = async ({
     ? customUrl
     : IS_DEV
       ? 'http://localhost:4200'
-      : `file://${normalize(join(__dirname, '../.tmp/angular-dist/browser/index.html'))}`;
+      : pathToFileURL(path.join(__dirname, '../.tmp/angular-dist/browser/index.html'))
+          .href;
 
   // Capture the loaded URL so the navigation guard (initWinEventListeners →
   // will-navigate) can compare against the actual app origin, not a derived


### PR DESCRIPTION
## Problem

Closes #9172.

Packaged Electron builds manually constructed `file://` URLs from filesystem paths. Reserved characters such as `#` were therefore interpreted as URL fragments, truncating the renderer path and causing `ERR_FILE_NOT_FOUND` during startup.

The fullscreen blocker used the same URL construction and also referenced an asset path that is not present in the packaged ASAR.

## Solution

- Build the packaged renderer and fullscreen-overlay URLs with Node's `pathToFileURL()`.
- Resolve the overlay from its actual Angular build output.
- Move the Linux unpacked app into a directory containing `#` before the packaged smoke test.
- Verify startup, task persistence after reload, and overlay fragment decoding from that path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `npm run checkFile electron/main-window.ts`
- `npm run checkFile electron/full-screen-blocker.ts`
- `npm run electron:build`
- `npm run test:electron` (26 test files)
- Full packaged-app smoke from `# packaged app`, including create/reload persistence and the fullscreen overlay
- Pre-push `npm run lint` and `npm test`

## Checklist

- [x] Documentation is not required for this internal Electron path-handling fix
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
