### PR TITLE
fix(schedule): use UI locale for ISO headings

### DIFF
--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -18,6 +18,7 @@ import { ScheduleDay } from '../schedule.model';
 import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
 
 describe('ScheduleComponent', () => {
+  const mockLocalization = signal({ firstDayOfWeek: 1, dateTimeLocale: 'en-US' });
   let component: ScheduleComponent;
   let fixture: ComponentFixture<ScheduleComponent>;
   let mockTaskService: jasmine.SpyObj<TaskService>;
@@ -28,6 +29,7 @@ describe('ScheduleComponent', () => {
   let mockGlobalConfigService: jasmine.SpyObj<GlobalConfigService>;
   let mockCalendarEventActionsService: jasmine.SpyObj<CalendarEventActionsService>;
   beforeEach(async () => {
+    mockLocalization.set({ firstDayOfWeek: 1, dateTimeLocale: 'en-US' });
     // Create mock services
     mockTaskService = jasmine.createSpyObj('TaskService', ['currentTaskId']);
     (mockTaskService as any).currentTaskId = signal(null);
@@ -94,7 +96,7 @@ describe('ScheduleComponent', () => {
     mockGlobalConfigService = jasmine.createSpyObj('GlobalConfigService', [], {
       // Pin the date locale so Intl-formatted headers are deterministic across
       // runners (an en-GB runner would render "20 Jan", not "Jan 20").
-      localization: signal({ firstDayOfWeek: 1, dateTimeLocale: 'en-US' }),
+      localization: mockLocalization,
       cfg: signal(undefined),
     });
 
@@ -162,6 +164,49 @@ describe('ScheduleComponent', () => {
       mockScheduleService.getMonthDaysToShow.and.returnValue(days);
       fixture.detectChanges();
       expect(component.headerTitle()).toMatch(/April\s+2026/);
+    });
+
+    it('uses the UI language for ISO day, week, and month headings', () => {
+      const translate = TestBed.inject(TranslateService);
+      translate.setTranslation('en', {
+        F: { WORKLOG: { CMP: { WEEK_NR: 'Week {{nr}}' } } },
+      });
+      translate.use('en');
+      mockLocalization.set({ firstDayOfWeek: 1, dateTimeLocale: 'sv' });
+
+      mockLayoutService.selectedTimeView.set('day');
+      mockScheduleService.getDaysToShow.and.returnValue(['2026-07-19']);
+      component['_selectedDate'].set(new Date(2026, 6, 19));
+      fixture.detectChanges();
+      expect(component.headerTitle()).toContain('Jul');
+
+      mockLayoutService.selectedTimeView.set('week');
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-07-13',
+        '2026-07-14',
+        '2026-07-15',
+        '2026-07-16',
+        '2026-07-17',
+        '2026-07-18',
+        '2026-07-19',
+      ]);
+      component['_selectedDate'].set(new Date(2026, 6, 13));
+      fixture.detectChanges();
+      expect(component.headerTitle()).toContain('Jul');
+
+      mockLayoutService.selectedTimeView.set('month');
+      const monthDays = Array.from({ length: 35 }, (_, i) => {
+        const date = new Date(2026, 6, 1 + i);
+        return [
+          date.getFullYear(),
+          String(date.getMonth() + 1).padStart(2, '0'),
+          String(date.getDate()).padStart(2, '0'),
+        ].join('-');
+      });
+      mockScheduleService.getMonthDaysToShow.and.returnValue(monthDays);
+      component['_selectedDate'].set(new Date(2026, 6, 1));
+      fixture.detectChanges();
+      expect(component.headerTitle()).toContain('July');
     });
   });
 

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -16,6 +16,8 @@ import { SCHEDULE_CONSTANTS } from '../schedule.constants';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { ScheduleDay } from '../schedule.model';
 import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
+import { registerLocaleData } from '@angular/common';
+import localeSv from '@angular/common/locales/sv';
 
 describe('ScheduleComponent', () => {
   const mockLocalization = signal({ firstDayOfWeek: 1, dateTimeLocale: 'en-US' });
@@ -28,6 +30,9 @@ describe('ScheduleComponent', () => {
   let mockGlobalTrackingIntervalService: jasmine.SpyObj<GlobalTrackingIntervalService>;
   let mockGlobalConfigService: jasmine.SpyObj<GlobalConfigService>;
   let mockCalendarEventActionsService: jasmine.SpyObj<CalendarEventActionsService>;
+
+  beforeAll(() => registerLocaleData(localeSv, 'sv'));
+
   beforeEach(async () => {
     mockLocalization.set({ firstDayOfWeek: 1, dateTimeLocale: 'en-US' });
     // Create mock services
@@ -166,20 +171,27 @@ describe('ScheduleComponent', () => {
       expect(component.headerTitle()).toMatch(/April\s+2026/);
     });
 
-    it('uses the UI language for ISO day, week, and month headings', () => {
+    const useIsoDatesWithUiLanguage = (language: string): void => {
       const translate = TestBed.inject(TranslateService);
-      translate.setTranslation('en', {
+      translate.setTranslation(language, {
         F: { WORKLOG: { CMP: { WEEK_NR: 'Week {{nr}}' } } },
       });
-      translate.use('en');
+      translate.use(language);
       mockLocalization.set({ firstDayOfWeek: 1, dateTimeLocale: 'sv' });
+    };
 
+    it('uses the UI language for the ISO day heading', () => {
+      useIsoDatesWithUiLanguage('en');
       mockLayoutService.selectedTimeView.set('day');
       mockScheduleService.getDaysToShow.and.returnValue(['2026-07-19']);
       component['_selectedDate'].set(new Date(2026, 6, 19));
       fixture.detectChanges();
-      expect(component.headerTitle()).toContain('Jul');
 
+      expect(component.headerTitle()).toContain('Jul');
+    });
+
+    it('uses the UI language for the ISO week heading', () => {
+      useIsoDatesWithUiLanguage('en');
       mockLayoutService.selectedTimeView.set('week');
       mockScheduleService.getDaysToShow.and.returnValue([
         '2026-07-13',
@@ -192,8 +204,12 @@ describe('ScheduleComponent', () => {
       ]);
       component['_selectedDate'].set(new Date(2026, 6, 13));
       fixture.detectChanges();
-      expect(component.headerTitle()).toContain('Jul');
 
+      expect(component.headerTitle()).toContain('Jul');
+    });
+
+    it('uses the UI language for the ISO month heading', () => {
+      useIsoDatesWithUiLanguage('en');
       mockLayoutService.selectedTimeView.set('month');
       const monthDays = Array.from({ length: 35 }, (_, i) => {
         const date = new Date(2026, 6, 1 + i);
@@ -206,7 +222,19 @@ describe('ScheduleComponent', () => {
       mockScheduleService.getMonthDaysToShow.and.returnValue(monthDays);
       component['_selectedDate'].set(new Date(2026, 6, 1));
       fixture.detectChanges();
+
       expect(component.headerTitle()).toContain('July');
+    });
+
+    it('preserves Gregorian dates and Latin digits in Persian ISO day headings', () => {
+      useIsoDatesWithUiLanguage('fa');
+      mockLayoutService.selectedTimeView.set('day');
+      mockScheduleService.getDaysToShow.and.returnValue(['2026-07-19']);
+      component['_selectedDate'].set(new Date(2026, 6, 19));
+      fixture.detectChanges();
+
+      expect(component.headerTitle()).toContain('19');
+      expect(component.headerTitle()).not.toMatch(/[۰-۹]/);
     });
   });
 

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -200,7 +200,7 @@ export class ScheduleComponent {
   headerTitle = computed(() => {
     const days = this.daysToShow();
     if (!days.length) return '';
-    const locale = this._dateTimeFormatService.currentLocale();
+    const locale = this._dateTimeFormatService.textLocale();
 
     if (this.isDayView()) {
       // On tablet width and below the full date clips, so drop to month + day

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -201,6 +201,7 @@ export class ScheduleComponent {
     const days = this.daysToShow();
     if (!days.length) return '';
     const locale = this._dateTimeFormatService.textLocale();
+    const isIsoLocale = this._dateTimeFormatService.isoTextLocale() !== null;
 
     if (this.isDayView()) {
       // On tablet width and below the full date clips, so drop to month + day
@@ -208,6 +209,10 @@ export class ScheduleComponent {
       const dayOpts: Intl.DateTimeFormatOptions = this._isTablet()
         ? { month: 'short', day: 'numeric' }
         : { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' };
+      if (isIsoLocale) {
+        dayOpts.calendar = 'gregory';
+        dayOpts.numberingSystem = 'latn';
+      }
       return new Intl.DateTimeFormat(locale, dayOpts).format(parseDbDateStr(days[0]));
     }
 


### PR DESCRIPTION
## Problem

The ISO 8601 option uses `sv` to preserve year-first dates and 24-hour time. The Schedule header also used that locale for textual day and month names, so an English UI rendered Swedish headings.

Closes #9182.

## Solution

Use `DateTimeFormatService.textLocale()` for Schedule day, week, and month headings, with regression coverage for all three views.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Documentation/wiki changes (not applicable)
- [x] I have run `npm run checkFile` on changed `.ts` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit message follows the Angular format

## Testing

- 61 focused Schedule tests
- 165 adjacent locale and Schedule tests
- Full pre-push suite in Europe/Berlin and America/Los_Angeles

## Assistance

AI-assisted; reviewed and tested by the contributor.