### PR TITLE
fix(calendar): avoid duplicate time blocks for imported events

### DIFF
--- a/src/app/features/calendar-integration/time-block/time-block-sync.effects.spec.ts
+++ b/src/app/features/calendar-integration/time-block/time-block-sync.effects.spec.ts
@@ -136,6 +136,69 @@ describe('TimeBlockSyncEffects', () => {
     flush();
   }));
 
+  it('does not create a time-block mirror for a task imported from the same provider (#9206)', fakeAsync(() => {
+    const task = createTask('task-1', {
+      issueId: 'primary::event-1',
+      issueProviderId: provider.id,
+      issueType: 'plugin:google-calendar',
+    });
+    getByIdOnce$Spy.and.returnValue(of(task));
+
+    actions$.next(
+      TaskSharedActions.scheduleTaskWithTime({
+        task,
+        dueWithTime: task.dueWithTime!,
+        isMoveToBacklog: false,
+      }),
+    );
+    tick(COALESCE_MS);
+
+    expect(upsertEventSpy).not.toHaveBeenCalled();
+    expect(deleteEventSpy).not.toHaveBeenCalled();
+    flush();
+  }));
+
+  it('still creates a time block for a task imported from a different provider', fakeAsync(() => {
+    const task = createTask('task-1', {
+      issueId: 'other-calendar::event-1',
+      issueProviderId: 'ip-2',
+      issueType: 'plugin:google-calendar',
+    });
+    getByIdOnce$Spy.and.returnValue(of(task));
+
+    actions$.next(
+      TaskSharedActions.scheduleTaskWithTime({
+        task,
+        dueWithTime: task.dueWithTime!,
+        isMoveToBacklog: false,
+      }),
+    );
+    tick(COALESCE_MS);
+
+    expect(upsertEventSpy).toHaveBeenCalledTimes(1);
+    flush();
+  }));
+
+  it('still deletes a legacy mirror when a same-provider task is deleted', fakeAsync(() => {
+    const deleteSub = effects.deleteOnTaskDelete$.subscribe();
+    const task = {
+      ...createTask('task-1', {
+        issueId: 'primary::event-1',
+        issueProviderId: provider.id,
+        issueType: 'plugin:google-calendar',
+      }),
+      subTasks: [],
+    };
+
+    actions$.next(TaskSharedActions.deleteTask({ task }));
+    flushMicrotasks();
+
+    expect(deleteEventSpy).toHaveBeenCalledTimes(1);
+    expect(deleteEventSpy.calls.mostRecent().args[0]).toBe(task.id);
+    deleteSub.unsubscribe();
+    flush();
+  }));
+
   it('coalesces independently per task', fakeAsync(() => {
     actions$.next(
       TaskSharedActions.updateTask({ task: { id: 'task-1', changes: { title: 'A' } } }),
@@ -375,6 +438,36 @@ describe('TimeBlockSyncEffects', () => {
     expect(deleteEventSpy).toHaveBeenCalledTimes(1);
     backfillSub.unsubscribe();
     deleteSub.unsubscribe();
+    flush();
+  }));
+
+  it('does not backfill a time-block mirror for a same-provider task', fakeAsync(() => {
+    const backfillSub = effects.backfillOnAutoTimeBlockEnabled$.subscribe();
+    const oneHourMs = 60 * 60 * 1000;
+    const dueWithTime = Date.now() + oneHourMs;
+    const task = createTask('task-1', {
+      dueWithTime,
+      issueId: 'primary::event-1',
+      issueProviderId: provider.id,
+      issueType: 'plugin:google-calendar',
+    }) as TaskWithDueTime;
+    store.overrideSelector(selectAllTasksWithDueTimeSorted, [task]);
+    store.refreshState();
+    getByIdOnce$Spy.and.returnValue(of(task));
+
+    actions$.next(
+      IssueProviderActions.updateIssueProvider({
+        issueProvider: {
+          id: provider.id,
+          changes: { pluginConfig: { isAutoTimeBlock: true } },
+        },
+      }),
+    );
+    flushMicrotasks();
+
+    expect(getByIdOnce$Spy).toHaveBeenCalledWith(task.id);
+    expect(upsertEventSpy).not.toHaveBeenCalled();
+    backfillSub.unsubscribe();
     flush();
   }));
 

--- a/src/app/features/calendar-integration/time-block/time-block-sync.effects.ts
+++ b/src/app/features/calendar-integration/time-block/time-block-sync.effects.ts
@@ -435,6 +435,12 @@ export class TimeBlockSyncEffects {
     task: Task,
     dueWithTime: number,
   ): Promise<void> {
+    // An imported task is already represented by its source calendar event.
+    // Writing a second, task-id-based time block to the same provider duplicates it.
+    if (task.issueId && task.issueProviderId === ctx.providerId) {
+      return;
+    }
+
     const durationMs = this._calcDurationMs(task);
     await ctx.definition.timeBlock!.upsertEvent(
       task.id,

--- a/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.spec.ts
+++ b/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.spec.ts
@@ -91,7 +91,10 @@ describe('PluginIssueProviderAdapterService', () => {
     storeSpy = jasmine.createSpyObj('Store', ['select', 'pipe']);
 
     snackSpy = jasmine.createSpyObj('SnackService', ['open']);
-    taskServiceSpy = jasmine.createSpyObj('TaskService', ['removeMultipleTasks']);
+    taskServiceSpy = jasmine.createSpyObj('TaskService', [
+      'removeMultipleTasks',
+      'getByIdOnce$',
+    ]);
     tagServiceSpy = jasmine.createSpyObj('TagService', [
       'tagsNoMyDayAndNoList',
       'addTag',
@@ -997,7 +1000,11 @@ describe('PluginIssueProviderAdapterService', () => {
     });
 
     describe('remote deletion handling', () => {
-      it('should auto-delete local task when getById returns 404 and no time tracked', async () => {
+      const mockCurrentTask = (task: Task | undefined): void => {
+        taskServiceSpy.getByIdOnce$.and.returnValue(of(task as Task));
+      };
+
+      it('should use current tracked time instead of the stale request snapshot', async () => {
         const provider = createMockProvider({
           getById: jasmine
             .createSpy('getById')
@@ -1011,18 +1018,34 @@ describe('PluginIssueProviderAdapterService', () => {
           issueId: 'ISS-5',
           issueProviderId: PROVIDER_ID,
           timeSpent: 0,
+          title: 'Old title',
         } as unknown as Task;
+        mockCurrentTask({
+          ...task,
+          timeSpent: 1000,
+          title: 'Current title',
+        });
 
         const result = await service.getFreshDataForIssueTask(task);
 
         expect(result).toBeNull();
-        expect(taskServiceSpy.removeMultipleTasks).toHaveBeenCalledWith(['task-1']);
+        expect(taskServiceSpy.removeMultipleTasks).not.toHaveBeenCalled();
         expect(snackSpy.open).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            type: 'CUSTOM',
-            ico: 'delete_forever',
+            type: 'WARNING',
+            translateParams: { taskTitle: 'Current title' },
           }),
         );
+
+        const snackParams = snackSpy.open.calls.mostRecent().args[0];
+        if (typeof snackParams === 'string') {
+          fail('Expected an actionable warning');
+          return;
+        }
+        const actionFn = snackParams.actionFn;
+        expect(actionFn).toBeDefined();
+        actionFn?.();
+        expect(taskServiceSpy.removeMultipleTasks).toHaveBeenCalledOnceWith(['task-1']);
       });
 
       it('should auto-delete local task when getById returns 410 and no time tracked', async () => {
@@ -1040,6 +1063,7 @@ describe('PluginIssueProviderAdapterService', () => {
           issueProviderId: PROVIDER_ID,
           timeSpent: 0,
         } as unknown as Task;
+        mockCurrentTask(task);
 
         const result = await service.getFreshDataForIssueTask(task);
 
@@ -1053,7 +1077,37 @@ describe('PluginIssueProviderAdapterService', () => {
         );
       });
 
-      it('should not auto-delete task with time tracking on 404 but offer action', async () => {
+      it('should not auto-delete an untracked task after it was relinked', async () => {
+        const provider = createMockProvider({
+          getById: jasmine
+            .createSpy('getById')
+            .and.rejectWith(new HttpErrorResponse({ status: 404 })),
+        });
+        registrySpy.getProvider.and.returnValue(provider);
+        spyOn(console, 'log');
+
+        const task = {
+          id: 'task-1',
+          issueId: 'ISS-5',
+          issueProviderId: PROVIDER_ID,
+          timeSpent: 0,
+        } as unknown as Task;
+        const relinkedTasks = [
+          { ...task, issueId: 'ISS-6' },
+          { ...task, issueProviderId: 'replacement-provider' },
+        ];
+        for (const relinkedTask of relinkedTasks) {
+          mockCurrentTask(relinkedTask);
+
+          const result = await service.getFreshDataForIssueTask(task);
+
+          expect(result).toBeNull();
+          expect(taskServiceSpy.removeMultipleTasks).not.toHaveBeenCalled();
+          expect(snackSpy.open).not.toHaveBeenCalled();
+        }
+      });
+
+      it('should not delete a retained task from an old warning after it was relinked', async () => {
         const provider = createMockProvider({
           getById: jasmine
             .createSpy('getById')
@@ -1069,17 +1123,25 @@ describe('PluginIssueProviderAdapterService', () => {
           timeSpent: 3600000,
           title: 'Tracked Task',
         } as unknown as Task;
+        mockCurrentTask(task);
+        await service.getFreshDataForIssueTask(task);
 
-        const result = await service.getFreshDataForIssueTask(task);
+        const snackParams = snackSpy.open.calls.mostRecent().args[0];
+        if (typeof snackParams === 'string') {
+          fail('Expected an actionable warning');
+          return;
+        }
+        const relinkedTasks = [
+          { ...task, issueId: 'ISS-6' },
+          { ...task, issueProviderId: 'replacement-provider' },
+        ];
+        for (const relinkedTask of relinkedTasks) {
+          mockCurrentTask(relinkedTask);
 
-        expect(result).toBeNull();
-        expect(taskServiceSpy.removeMultipleTasks).not.toHaveBeenCalled();
-        expect(snackSpy.open).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            type: 'WARNING',
-            actionStr: T.G.DELETE,
-          }),
-        );
+          snackParams.actionFn?.();
+
+          expect(taskServiceSpy.removeMultipleTasks).not.toHaveBeenCalled();
+        }
       });
 
       it('should not delete task on non-404 errors', async () => {
@@ -1121,6 +1183,7 @@ describe('PluginIssueProviderAdapterService', () => {
           issueProviderId: PROVIDER_ID,
           timeSpent: 0,
         } as unknown as Task;
+        mockCurrentTask(task);
 
         const result = await service.getFreshDataForIssueTask(task);
 
@@ -1134,7 +1197,7 @@ describe('PluginIssueProviderAdapterService', () => {
         );
       });
 
-      it('should offer delete action when issue state matches deletedStates with time tracked', async () => {
+      it('should retain and offer delete when deletedStates matches with time tracked', async () => {
         const provider = createMockProvider({
           getById: jasmine.createSpy('getById').and.resolveTo({
             id: 'ISS-5',
@@ -1153,6 +1216,7 @@ describe('PluginIssueProviderAdapterService', () => {
           timeSpent: 3600000,
           title: 'Tracked Task',
         } as unknown as Task;
+        mockCurrentTask(task);
 
         const result = await service.getFreshDataForIssueTask(task);
 
@@ -1209,6 +1273,7 @@ describe('PluginIssueProviderAdapterService', () => {
           issueProviderId: PROVIDER_ID,
           timeSpent: 0,
         } as unknown as Task;
+        mockCurrentTask(task);
 
         const result = await service.getFreshDataForIssueTask(task);
 

--- a/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts
+++ b/src/app/plugins/issue-provider/plugin-issue-provider-adapter.service.ts
@@ -472,26 +472,49 @@ export class PluginIssueProviderAdapterService implements IssueServiceInterface 
     return ['closed', 'done', 'completed', 'resolved'].includes(state);
   }
 
-  private _handleRemoteDeletion(task: Task): void {
-    const hasTimeTracking = task.timeSpent > 0;
-    if (hasTimeTracking) {
-      this._snackService.open({
-        type: 'WARNING',
-        msg: T.F.ISSUE.S.REMOTE_ISSUE_DELETED_WITH_TIME,
-        translateParams: { taskTitle: task.title },
-        ico: 'delete_forever',
-        actionStr: T.G.DELETE,
-        actionFn: () => this._taskService.removeMultipleTasks([task.id]),
-      });
-    } else {
-      this._taskService.removeMultipleTasks([task.id]);
-      this._snackService.open({
-        type: 'CUSTOM',
-        msg: T.F.ISSUE.S.REMOTE_ISSUE_DELETED,
-        translateParams: { taskTitle: task.title },
-        ico: 'delete_forever',
-      });
-    }
+  private _handleRemoteDeletion(requestedTask: Task): void {
+    // Re-read synchronously from NgRx so a delayed response cannot delete or
+    // warn about a task that was relinked while the provider request was in flight.
+    this._taskService.getByIdOnce$(requestedTask.id).subscribe((currentTask) => {
+      if (
+        !currentTask ||
+        currentTask.issueId !== requestedTask.issueId ||
+        currentTask.issueProviderId !== requestedTask.issueProviderId
+      ) {
+        return;
+      }
+
+      const hasTimeTracking = currentTask.timeSpent > 0;
+      if (hasTimeTracking) {
+        this._snackService.open({
+          type: 'WARNING',
+          msg: T.F.ISSUE.S.REMOTE_ISSUE_DELETED_WITH_TIME,
+          translateParams: { taskTitle: currentTask.title },
+          ico: 'delete_forever',
+          actionStr: T.G.DELETE,
+          actionFn: () => this._removeIfIssueStillMatches(currentTask),
+        });
+      } else {
+        this._taskService.removeMultipleTasks([currentTask.id]);
+        this._snackService.open({
+          type: 'CUSTOM',
+          msg: T.F.ISSUE.S.REMOTE_ISSUE_DELETED,
+          translateParams: { taskTitle: currentTask.title },
+          ico: 'delete_forever',
+        });
+      }
+    });
+  }
+
+  private _removeIfIssueStillMatches(requestedTask: Task): void {
+    this._taskService.getByIdOnce$(requestedTask.id).subscribe((currentTask) => {
+      if (
+        currentTask?.issueId === requestedTask.issueId &&
+        currentTask.issueProviderId === requestedTask.issueProviderId
+      ) {
+        this._taskService.removeMultipleTasks([currentTask.id]);
+      }
+    });
   }
 
   private _mapLabelsToTagIds(labels: string[], shouldCreate: boolean): string[] {


### PR DESCRIPTION
## Summary

- Avoid creating a second calendar event when an imported issue already belongs to the same provider as the TimeBlock mirror.
- Re-read current task state before handling delayed remote-deletion responses.
- Revalidate the issue linkage before executing a retained task's delayed Delete action.
- Add regression coverage for matching providers, relinked tasks, current tracked time, and existing deletion behavior.

## Root cause

Imported calendar tasks retain their issue-provider linkage, but TimeBlock sync treated every scheduled task as an independent local block and mirrored it back to the same provider. This created a duplicate of the source event. Remote-deletion handling also relied on the task snapshot from before the provider request, allowing a delayed response or snackbar action to act after the task had been relinked.

## User impact

Tasks imported from Google Calendar with Auto Time Block enabled remain associated with their source event without creating a duplicate. Delayed provider responses no longer remove or warn about tasks whose issue linkage changed in the meantime.

Fixes #9206

## Validation

- `npm run checkFile` passed for all four changed TypeScript files.
- TimeBlock sync focused spec: 21/21 passed.
- Plugin issue-provider adapter focused spec: 58/58 passed.
- Full `npm test` passed before the history cleanup; `git range-diff` confirmed both rebased patches are unchanged.
- Six-perspective multi-review verdict: APPROVE, with no critical issues or warnings.
