### PR TITLE
refactor: remove brand color from sync progress state

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.scss
+++ b/src/app/core-ui/main-header/main-header.component.scss
@@ -348,9 +348,8 @@ page-title {
     color: var(--text-color);
   }
 
-  &.is-in-progress {
-    color: var(--brand);
-  }
+  // While syncing we intentionally keep the muted color: the spin animation
+  // already signals progress, and the brand color drew too much focus.
 
   &.is-error,
   &.is-offline {


### PR DESCRIPTION
## Problem

The brand color applied to the sync progress indicator was drawing too much visual focus, creating unnecessary noise during syncing operations. The spin animation already clearly signals that progress is occurring.

## Solution

Removed the `.is-in-progress` color rule that applied `var(--brand)` to the sync status indicator. The element now retains the muted text color during sync, allowing the animation itself to communicate progress without competing for user attention. This aligns with the project's "less noise, more depth" principle.

## Type of Change

- [x] Refactoring
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Test Plan

No testing needed — this is a styling refactor that removes a color rule. The spin animation continues to function as before, and the visual change is immediately apparent in the UI.

https://claude.ai/code/session_01LtKUYBFseDD4kAa31XuDa9