### PR TITLE
fix(tasks): replace mobile task action bar with a single overflow button

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.html
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.html
@@ -7,44 +7,16 @@
       class="task-title"
     ></task-title>
     @if (layoutService.isXs() && !isDialogMode()) {
-      <div class="mobile-task-actions">
-        <button
-          class="mobile-task-action --complete"
-          mat-button
-          (click)="toggleTaskDone()"
-          [attr.aria-label]="(task().isDone ? T.G.UNDO : T.G.COMPLETE) | translate"
-        >
-          <span>{{ (task().isDone ? T.G.UNDO : T.G.COMPLETE) | translate }}</span>
-        </button>
-
-        @if (isShowTrackingAction()) {
-          <button
-            class="mobile-task-action --tracking"
-            mat-button
-            (click)="togglePlayPause()"
-            [attr.aria-label]="
-              (isCurrent() ? T.F.TASK.CMP.TRACK_TIME_STOP : T.F.TASK.CMP.TRACK_TIME)
-                | translate
-            "
-          >
-            <span>{{
-              (isCurrent() ? T.F.FOCUS_MODE.B.PAUSE : T.F.TASK.D_REMINDER_VIEW.START)
-                | translate
-            }}</span>
-          </button>
-        }
-
-        <button
-          class="mobile-task-action --more"
-          mat-button
-          (click)="openTaskMenu($event)"
-          [attr.aria-label]="T.G.MORE_ACTIONS | translate"
-          aria-haspopup="menu"
-          [attr.aria-expanded]="taskContextMenu()?.isOpen() ?? false"
-        >
-          <span>{{ T.G.MORE_ACTIONS | translate }}</span>
-        </button>
-      </div>
+      <button
+        mat-icon-button
+        class="task-detail-more-btn"
+        (click)="openTaskMenu($event)"
+        [attr.aria-label]="T.G.MORE_ACTIONS | translate"
+        aria-haspopup="menu"
+        [attr.aria-expanded]="taskContextMenu()?.isOpen() ?? false"
+      >
+        <mat-icon>more_vert</mat-icon>
+      </button>
       <task-context-menu
         [isAdvancedControls]="true"
         [task]="task()"

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
@@ -47,27 +47,9 @@ progress-bar {
     color: var(--text-color);
   }
 
-  @include mq(xs, max) {
-    flex-wrap: wrap;
-
-    task-title {
-      flex-basis: 100%;
-      min-width: 0;
-    }
-  }
-}
-
-.mobile-task-actions {
-  display: flex;
-  gap: var(--s-half);
-  width: 100%;
-  padding: 0 var(--s-half) var(--s-half);
-  box-sizing: border-box;
-
-  .mobile-task-action {
-    flex: 1 1 0;
-    min-width: 0;
-    min-height: var(--s5);
+  .task-detail-more-btn {
+    flex: 0 0 auto;
+    margin-inline-end: var(--s-half);
   }
 }
 
@@ -77,6 +59,9 @@ progress-bar {
   padding: var(--s);
   margin: 0;
   flex-grow: 1;
+  // Keep the title shrinkable next to the trailing overflow button so a long
+  // unbroken title wraps/truncates instead of pushing the button off-row.
+  min-width: 0;
   margin-top: var(--s-half);
   line-height: 1.4;
   min-height: 40px;

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
@@ -36,11 +36,9 @@ describe('TaskDetailPanelComponent', () => {
   let mockAttachmentService: jasmine.SpyObj<TaskAttachmentService>;
   let mockTaskService: jasmine.SpyObj<TaskService>;
   let isXs: WritableSignal<boolean>;
-  let currentTaskId: WritableSignal<string | null>;
 
   beforeEach(async () => {
     isXs = signal(true);
-    currentTaskId = signal<string | null>(null);
     mockClipboardImageService = jasmine.createSpyObj('ClipboardImageService', [
       'handlePasteWithProgress',
     ]);
@@ -50,20 +48,10 @@ describe('TaskDetailPanelComponent', () => {
     ]);
     mockTaskService = jasmine.createSpyObj(
       'TaskService',
-      [
-        'update',
-        'setSelectedId',
-        'focusTaskIfPossible',
-        'addSubTaskTo',
-        'setCurrentId',
-        'pauseCurrent',
-        'setDone',
-        'setUnDone',
-      ],
+      ['update', 'setSelectedId', 'focusTaskIfPossible', 'addSubTaskTo'],
       {
         taskDetailPanelTargetPanel$: of(null),
         selectedTaskId: jasmine.createSpy().and.returnValue(null),
-        currentTaskId,
       },
     );
     const mockLayoutService = jasmine.createSpyObj('LayoutService', [], {
@@ -74,7 +62,6 @@ describe('TaskDetailPanelComponent', () => {
       cfg: jasmine.createSpy().and.returnValue({ keyboard: {} }),
       tasks: jasmine.createSpy().and.returnValue({}),
       clipboardImages: jasmine.createSpy().and.returnValue(null),
-      appFeatures: signal({ isTimeTrackingEnabled: true }),
     });
     const mockIssueService = jasmine.createSpyObj(
       'IssueService',
@@ -248,73 +235,18 @@ describe('TaskDetailPanelComponent', () => {
   });
 
   describe('mobile task actions', () => {
-    it('shows completion, time tracking, and more actions in the mobile header', () => {
-      const completeButton: HTMLButtonElement | null =
-        fixture.nativeElement.querySelector('.mobile-task-action.--complete');
-      const trackingButton: HTMLButtonElement | null =
-        fixture.nativeElement.querySelector('.mobile-task-action.--tracking');
+    it('shows a single more-actions button in the mobile header', () => {
       const moreButton: HTMLButtonElement | null = fixture.nativeElement.querySelector(
-        '.mobile-task-action.--more',
+        '.task-detail-more-btn',
       );
 
-      expect(completeButton).not.toBeNull();
-      expect(trackingButton).not.toBeNull();
       expect(moreButton).not.toBeNull();
-      expect(completeButton?.textContent?.trim()).toBeTruthy();
-      expect(trackingButton?.textContent?.trim()).toBeTruthy();
-      expect(moreButton?.textContent?.trim()).toBeTruthy();
-
-      completeButton?.click();
-      expect(mockTaskService.setDone).toHaveBeenCalledWith(MOCK_TASK.id);
-
-      trackingButton?.click();
-      expect(mockTaskService.setCurrentId).toHaveBeenCalledWith(MOCK_TASK.id);
+      expect(moreButton?.getAttribute('aria-label')).toBeTruthy();
+      expect(moreButton?.getAttribute('aria-haspopup')).toBe('menu');
+      expect(moreButton?.getAttribute('aria-expanded')).toBe('false');
     });
 
-    it('offers undo for an already completed task', () => {
-      componentRef.setInput('task', { ...MOCK_TASK, isDone: true });
-      fixture.detectChanges();
-
-      const completeButton: HTMLButtonElement | null =
-        fixture.nativeElement.querySelector('.mobile-task-action.--complete');
-      completeButton?.click();
-
-      expect(mockTaskService.setUnDone).toHaveBeenCalledWith(MOCK_TASK.id);
-      expect(mockTaskService.setDone).not.toHaveBeenCalled();
-    });
-
-    it('uses the visible completion text as its accessible name', () => {
-      const completeButton: HTMLButtonElement = fixture.nativeElement.querySelector(
-        '.mobile-task-action.--complete',
-      );
-
-      expect(completeButton.getAttribute('aria-label')).toBe(
-        completeButton.textContent?.trim(),
-      );
-
-      componentRef.setInput('task', { ...MOCK_TASK, isDone: true });
-      fixture.detectChanges();
-
-      const undoButton: HTMLButtonElement = fixture.nativeElement.querySelector(
-        '.mobile-task-action.--complete',
-      );
-      expect(undoButton.getAttribute('aria-label')).toBe(undoButton.textContent?.trim());
-    });
-
-    it('keeps every mobile action at least 40px high', () => {
-      const buttons: HTMLButtonElement[] = Array.from(
-        fixture.nativeElement.querySelectorAll('.mobile-task-action'),
-      );
-
-      expect(buttons.length).toBe(3);
-      buttons.forEach((button) => {
-        expect(
-          Number.parseFloat(getComputedStyle(button).minHeight),
-        ).toBeGreaterThanOrEqual(40);
-      });
-    });
-
-    it('opens More as a menu and reports keyboard activation through the view child', () => {
+    it('opens the actions menu and reports keyboard activation through the view child', () => {
       const taskContextMenu = component.taskContextMenu();
       expect(taskContextMenu).toBeDefined();
       const open = spyOn(taskContextMenu!, 'open').and.callFake(() =>
@@ -322,11 +254,8 @@ describe('TaskDetailPanelComponent', () => {
       );
 
       const moreButton: HTMLButtonElement = fixture.nativeElement.querySelector(
-        '.mobile-task-action.--more',
+        '.task-detail-more-btn',
       );
-
-      expect(moreButton.getAttribute('aria-haspopup')).toBe('menu');
-      expect(moreButton.getAttribute('aria-expanded')).toBe('false');
 
       moreButton.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 0 }));
       fixture.detectChanges();
@@ -335,23 +264,11 @@ describe('TaskDetailPanelComponent', () => {
       expect(moreButton.getAttribute('aria-expanded')).toBe('true');
     });
 
-    it('switches the tracking action to pause for the current task', () => {
-      currentTaskId.set(MOCK_TASK.id);
-      fixture.detectChanges();
-
-      const trackingButton: HTMLButtonElement | null =
-        fixture.nativeElement.querySelector('.mobile-task-action.--tracking');
-      trackingButton?.click();
-
-      expect(mockTaskService.pauseCurrent).toHaveBeenCalled();
-      expect(mockTaskService.setCurrentId).not.toHaveBeenCalled();
-    });
-
-    it('hides the mobile task actions above the mobile breakpoint', () => {
+    it('hides the mobile actions above the mobile breakpoint', () => {
       isXs.set(false);
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector('.mobile-task-actions')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.task-detail-more-btn')).toBeNull();
     });
 
     it('uses the responsive layout signal for mobile panel defaults', () => {

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -349,17 +349,6 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
       : !!task.notes || (!task.issueId && !task.attachments?.length);
   });
 
-  isCurrent = computed(() => this.taskService.currentTaskId() === this.task().id);
-
-  isShowTrackingAction = computed(() => {
-    const task = this.task();
-    return (
-      this._globalConfigService.appFeatures().isTimeTrackingEnabled &&
-      !task.isDone &&
-      !task.subTasks?.length
-    );
-  });
-
   // Task-based computed signals
   isMarkdownChecklist = computed(() => {
     const notes = this.task().notes;
@@ -624,23 +613,6 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
     const defaultNotes = this.defaultTaskNotes();
     if (!defaultNotes || !$event || $event.trim() !== defaultNotes.trim()) {
       this.taskService.update(this.task().id, { notes: $event });
-    }
-  }
-
-  toggleTaskDone(): void {
-    const task = this.task();
-    if (task.isDone) {
-      this.taskService.setUnDone(task.id);
-    } else {
-      this.taskService.setDone(task.id);
-    }
-  }
-
-  togglePlayPause(): void {
-    if (this.isCurrent()) {
-      this.taskService.pauseCurrent();
-    } else {
-      this.taskService.setCurrentId(this.task().id);
     }
   }
 


### PR DESCRIPTION
The mobile task detail panel rendered three equal-width text buttons
(Complete / Start / More actions) below the title. The row read like a
dialog action bar, gave the overflow menu the same weight as the primary
action, and had no visual hierarchy.

Replace it with a single more_vert icon button to the right of the title,
opening the existing advanced task context menu (which already offers
Mark Done/Undone and Track Time/Stop), so no action is lost. Drop the now
unused xs title-wrap override and the dead toggleTaskDone / togglePlayPause
/ isShowTrackingAction / isCurrent members, and update the spec.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017bGwytvG4zN6gvLbHf22q8