### PR TITLE
fix(add-task-bar): keep global bar above the keyboard on mobile web

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -31,7 +31,15 @@
   }
 }
 
-:host-context(.isTouchOnly).global {
+// Pin the floating bar to the bottom whenever touch is the primary input.
+// Keys on `.isTouchPrimary`, not `.isTouchOnly`: Android Chrome advertises a
+// fine pointer, so detect-it classifies phones as `hybrid` rather than
+// `touchOnly` and never sets `.isTouchOnly` on mobile web — which stranded the
+// bar at the top there while the native Android app (touch-only) got the
+// bottom layout. `.isTouchPrimary` covers pure-touch and hybrid-touch devices
+// alike (InputIntentService keeps it in sync with the active input) and matches
+// the autocomplete panel rule further down.
+:host-context(.isTouchPrimary).global {
   top: auto;
   // Extra gap above the keyboard so the bottom action buttons stay easy to
   // tap — `--s` alone leaves them flush against the IME's top edge.
@@ -42,7 +50,7 @@
 // Capacitor's native iOS mode shrinks the WebView around the keyboard. Only
 // apply an additional offset when the keyboard still overlays that viewport;
 // using its full height here would move the fixed bar twice (#8778).
-:host-context(.isTouchOnly.isIOS).global {
+:host-context(.isTouchPrimary.isIOS).global {
   bottom: calc(var(--keyboard-overlay-offset) + var(--s2));
 }
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -329,13 +329,13 @@ describe('AddTaskBarComponent', () => {
   });
 
   describe('mobile keyboard positioning', () => {
-    let hadTouchOnlyClass: boolean;
+    let hadTouchPrimaryClass: boolean;
     let hadIOSClass: boolean;
 
     beforeEach(() => {
-      hadTouchOnlyClass = document.body.classList.contains(BodyClass.isTouchOnly);
+      hadTouchPrimaryClass = document.body.classList.contains(BodyClass.isTouchPrimary);
       hadIOSClass = document.body.classList.contains(BodyClass.isIOS);
-      document.body.classList.add(BodyClass.isTouchOnly);
+      document.body.classList.add(BodyClass.isTouchPrimary);
       document.body.classList.remove(BodyClass.isIOS);
       fixture.nativeElement.classList.add('global');
       fixture.nativeElement.style.setProperty('--keyboard-height', '336px');
@@ -347,7 +347,7 @@ describe('AddTaskBarComponent', () => {
     });
 
     afterEach(() => {
-      document.body.classList.toggle(BodyClass.isTouchOnly, hadTouchOnlyClass);
+      document.body.classList.toggle(BodyClass.isTouchPrimary, hadTouchPrimaryClass);
       document.body.classList.toggle(BodyClass.isIOS, hadIOSClass);
     });
 
@@ -368,8 +368,8 @@ describe('AddTaskBarComponent', () => {
       expect(getComputedStyle(fixture.nativeElement).bottom).toBe('352px');
     });
 
-    it('keeps the top-positioned layout for hybrid iOS devices', () => {
-      document.body.classList.remove(BodyClass.isTouchOnly);
+    it('keeps the top-positioned layout for mouse-primary iOS devices', () => {
+      document.body.classList.remove(BodyClass.isTouchPrimary);
       const layoutBeforeIOSClass = fixture.nativeElement.getBoundingClientRect();
 
       document.body.classList.add(BodyClass.isIOS);

--- a/src/index.html
+++ b/src/index.html
@@ -4,8 +4,19 @@
     <meta charset="utf-8" />
     <title>Super Productivity</title>
 
+    <!--
+      interactive-widget=resizes-content makes the virtual keyboard shrink the
+      *layout* viewport on mobile web (Chrome/Android) instead of only the
+      visual viewport (the default `resizes-visual`). This mirrors what the
+      native builds already do — Android `adjustResize` and iOS Keyboard
+      `resize: 'native'` both resize the WebView — so the fixed global add-task
+      bar (position: fixed; bottom) re-anchors above the keyboard on the web app
+      the same way it does natively. Ignored where it doesn't apply: native
+      WebViews (keyboard handled natively), iOS Safari (unsupported → falls back
+      to the JS `--keyboard-height` visualViewport tracking), and desktop.
+    -->
     <meta
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
       name="viewport"
     />
     <link


### PR DESCRIPTION
The floating global add-task bar (position: fixed; bottom) sits nicely
above the on-screen keyboard on the native mobile builds but not on the
mobile web app.

Root cause is that the native builds resize the WebView when the keyboard
opens (Android `adjustResize`, iOS Keyboard `resize: 'native'`), so the
fixed bar re-anchors above the keyboard for free and `--keyboard-height`
stays ~0. On mobile web the default `interactive-widget=resizes-visual`
leaves the *layout* viewport full-height when the keyboard appears, so the
layout-viewport-anchored fixed bar depends entirely on the JS-computed
`--keyboard-height` offset, which is subject to visual-viewport panning
and cross-browser inconsistencies — hence the poor positioning.

Add `interactive-widget=resizes-content` to the viewport meta so the
virtual keyboard shrinks the layout viewport on mobile web too, matching
the native `adjustResize` behavior. Degrades gracefully everywhere it
doesn't apply: native WebViews handle the keyboard natively, iOS Safari
ignores the property and keeps the existing visualViewport tracking, and
desktop has no virtual keyboard.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CyqioXWJEgh5KSvsbj7P5N