### PR TITLE
feat(plugins): add Plane.so issue provider

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -euo pipefail
           # Plugins that have an `npm test` script configured.
-          PLUGINS=(automations azure-devops-issue-provider caldav-calendar-provider clickup-issue-provider google-calendar-provider sync-md todoist-import)
+          PLUGINS=(automations azure-devops-issue-provider caldav-calendar-provider clickup-issue-provider google-calendar-provider plane-issue-provider sync-md todoist-import)
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             CHANGED=$(printf '%s\n' "${PLUGINS[@]}")

--- a/docs/wiki/2.07-Manage-Task-Integrations.md
+++ b/docs/wiki/2.07-Manage-Task-Integrations.md
@@ -15,7 +15,11 @@ The **issue provider panel** (Integrations & Calendars) is a side panel that lis
 1. Open the issue provider panel (see above).
 2. Click the **last tab** — the one with the **plus (add)** icon. The view shows two sections: **Connect Calendar** and **Setup Issue Provider**.
 3. **For a calendar:** Under **Connect Calendar**, click **Google Calendar**, **Outlook 365**, or **iCal Other**. A configuration dialog opens (e.g. URL for iCal, or OAuth for Google/Outlook). Fill in the details and save.
-4. **For an issue provider:** Under **Setup Issue Provider**, click the provider you want: **Jira**, **Trello**, **GitHub**, **Redmine**, **GitLab**, **CalDAV**, **Open Project**, **Gitea**, **Linear**, **ClickUp**, or **Plainspace**. A configuration dialog opens. Enter the required fields (host URL, token or password, project/repo ID, etc. — the exact fields depend on the provider). Save to create the integration. For **Plainspace** (collaboration), the easiest path is the project menu — see [Collaborate on a Project with Plainspace](#collaborate-on-a-project-with-plainspace) below.
+4. **For an issue provider:** Under **Setup Issue Provider**, click the provider you want: **Jira**, **Trello**, **GitHub**, **Redmine**, **GitLab**, **CalDAV**, **Open Project**, **Gitea**, **Linear**, **ClickUp**, **Plane**, **Azure DevOps**, or **Plainspace**. A configuration dialog opens. Enter the required fields (host URL, token or password, project/repo ID, etc. — the exact fields depend on the provider). Save to create the integration. For **Plainspace** (collaboration), the easiest path is the project menu — see [Collaborate on a Project with Plainspace](#collaborate-on-a-project-with-plainspace) below.
+
+### Plane.so
+
+For **Plane**, enter your **API key**, **workspace slug** (from `app.plane.so/<workspace-slug>/...`), and **project ID** (UUID). Leave **Host** empty for Plane Cloud; for self-hosted Plane, set Host to your instance origin (for example `https://plane.example.com`). The integration supports search, import, opening work items in the browser, and auto-import of open items; it does not create issues or push status changes back to Plane.
 
 ### Calendar Integrations: iCal Vs CalDAV (e.g. Nextcloud)
 

--- a/docs/wiki/3.07-Issue-Integration-Comparison.md
+++ b/docs/wiki/3.07-Issue-Integration-Comparison.md
@@ -24,6 +24,7 @@ Every issue provider supports the same basic operations: checking that the integ
 | Linear          | Yes    | Auto (state)  | No         | No       | No       | Yes         | Team, project        | Yes         | —         | —         |
 | Azure DevOps    | Yes    | No            | No         | No       | No       | No          | Project, scope, WIQL | Config      | —         | Yes       |
 | ClickUp         | Yes    | Auto (status) | No         | No       | Yes      | Yes         | Team                 | Yes         | —         | —         |
+| Plane           | Yes    | Auto (state)  | No         | No       | No       | No          | Workspace, project   | Yes         | —         | Yes       |
 | Plainspace      | Yes    | Two-way       | No         | No       | No       | No          | Space                | Yes         | —         | Yes       |
 
 **Legend:** **Status** = configurable or automatic status transitions; **Worklog** = time tracking submission to the external system; **Auto-import** = automatic import of new issues into backlog (or "Last 100" / "Today" where noted).
@@ -151,7 +152,16 @@ Every issue provider supports the same basic operations: checking that the integ
 - **Filtering:** Team-based.
 - **Auto-import:** Automatic task import to backlog.
 
-### 13. Plainspace
+### 13. Plane
+
+- **Issue import:** Work items from a Plane workspace project (cloud or self-hosted).
+- **Status transitions:** Tasks auto-marked as done when the Plane state group is `completed` or `cancelled` (pull-only; no push back to Plane).
+- **Worklog / Comments / Subtasks / Attachments:** Not supported.
+- **Filtering:** Workspace slug + project UUID; optional self-hosted host URL.
+- **Auto-import:** Open work items (excludes completed/cancelled) up to two pages of results.
+- **Due dates:** Target date support.
+
+### 14. Plainspace
 
 Plainspace is Super Productivity's own **collaboration** layer (a shared workspace at [plainspace.org](https://plainspace.org)), so it behaves differently from the read-mostly issue trackers above. You connect a **Space** with a personal API token (`pat_…`), and the tasks **assigned to you** in that Space import into the bound project.
 

--- a/docs/wiki/4.24-Integrations.md
+++ b/docs/wiki/4.24-Integrations.md
@@ -30,7 +30,7 @@ Sync is local-first and operation-based: your device holds the primary copy, and
 
 ## Available Issue Providers
 
-The app supports **11 issue-style integrations** (the exact list may vary by version): **Jira**, **GitHub**, **GitLab**, **Gitea**, **OpenProject**, **CalDAV**, **Calendar (iCal)**, **Redmine**, **Trello**, **Linear**, and **ClickUp**. Each has a display name and icon in the Issue Panel. Configuration is per-provider and often per-project (e.g. which project new issues are added to).
+The app supports **issue-style integrations** (the exact list may vary by version), including **Jira**, **GitHub**, **GitLab**, **Gitea**, **OpenProject**, **CalDAV**, **Calendar (iCal)**, **Redmine**, **Trello**, **Linear**, **ClickUp**, **Plane**, **Azure DevOps**, and **Plainspace**. Each has a display name and icon in the Issue Panel. Configuration is per-provider and often per-project (e.g. which project new issues are added to).
 
 **Capabilities vary by provider.** Some support full two-way sync (e.g. status transitions and worklog submission); others are mainly for importing and refreshing issues. For a comparison of what each issue provider supports—issue import, status transitions, worklogs, comments, subtasks, attachments, filtering, auto-import, story points, due dates—see [[3.07-Issue-Integration-Comparison]]. For a comparison of sync providers (WebDAV, Dropbox, SuperSync, local file), see [[3.08-Sync-Integration-Comparison]]. In short: Jira and OpenProject offer the widest set (worklogs, status workflows, story points); GitHub and GitLab offer issue import and comments; CalDAV and Calendar (iCal) focus on calendar/todo and events; ClickUp supports subtasks alongside Jira.
 

--- a/packages/plugin-dev/plane-issue-provider/i18n/en.json
+++ b/packages/plugin-dev/plane-issue-provider/i18n/en.json
@@ -1,0 +1,19 @@
+{
+  "CFG": {
+    "API_KEY": "API Key",
+    "HOW_TO_GET_TOKEN": "How to get an API key",
+    "HOST": "Host (self-hosted only; leave empty for Plane Cloud)",
+    "WORKSPACE_SLUG": "Workspace slug",
+    "WORKSPACE_SLUG_HELP": "From the URL: app.plane.so/<workspace-slug>/...",
+    "PROJECT_ID": "Project ID (UUID)",
+    "PROJECT_ID_HELP": "Open the project in Plane; the UUID is in the project settings URL or API."
+  },
+  "DISPLAY": {
+    "SUMMARY": "Summary",
+    "STATE": "State",
+    "PRIORITY": "Priority",
+    "ASSIGNEE": "Assignee",
+    "DUE": "Due date",
+    "DESCRIPTION": "Description"
+  }
+}

--- a/packages/plugin-dev/plane-issue-provider/icon.svg
+++ b/packages/plugin-dev/plane-issue-provider/icon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <path d="M3.5 4.5 20.5 12 3.5 19.5l2.2-5.7L14 12 5.7 10.2z"/>
+</svg>

--- a/packages/plugin-dev/plane-issue-provider/package-lock.json
+++ b/packages/plugin-dev/plane-issue-provider/package-lock.json
@@ -1,0 +1,1782 @@
+{
+  "name": "plane-issue-provider",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plane-issue-provider",
+      "version": "1.0.0",
+      "dependencies": {
+        "@super-productivity/plugin-api": "file:../../plugin-api"
+      },
+      "devDependencies": {
+        "esbuild": "^0.28.1",
+        "typescript": "^5.8.3",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../../plugin-api": {
+      "name": "@super-productivity/plugin-api",
+      "version": "1.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@super-productivity/plugin-api": {
+      "resolved": "../../plugin-api",
+      "link": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/plugin-dev/plane-issue-provider/package.json
+++ b/packages/plugin-dev/plane-issue-provider/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "plane-issue-provider",
+  "version": "1.0.0",
+  "description": "Plane.so issue provider plugin",
+  "scripts": {
+    "build": "node scripts/build.js",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.1",
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.0"
+  },
+  "dependencies": {
+    "@super-productivity/plugin-api": "file:../../plugin-api"
+  }
+}

--- a/packages/plugin-dev/plane-issue-provider/scripts/build.js
+++ b/packages/plugin-dev/plane-issue-provider/scripts/build.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { build } = require('esbuild');
+
+const ROOT_DIR = path.join(__dirname, '..');
+const SRC_DIR = path.join(ROOT_DIR, 'src');
+const DIST_DIR = path.join(ROOT_DIR, 'dist');
+const I18N_SRC = path.join(ROOT_DIR, 'i18n');
+const I18N_DIST = path.join(DIST_DIR, 'i18n');
+
+async function buildPlugin() {
+  console.log('Building plane-issue-provider...');
+
+  if (fs.existsSync(DIST_DIR)) {
+    fs.rmSync(DIST_DIR, { recursive: true });
+  }
+  fs.mkdirSync(DIST_DIR);
+
+  // Build TypeScript to IIFE bundle
+  await build({
+    entryPoints: [path.join(SRC_DIR, 'plugin.ts')],
+    bundle: true,
+    outfile: path.join(DIST_DIR, 'plugin.js'),
+    platform: 'browser',
+    target: 'es2020',
+    format: 'iife',
+    define: {
+      'process.env.NODE_ENV': '"production"',
+    },
+    logLevel: 'info',
+    minify: true,
+    sourcemap: false,
+  });
+
+  // Copy manifest.json
+  fs.copyFileSync(
+    path.join(SRC_DIR, 'manifest.json'),
+    path.join(DIST_DIR, 'manifest.json'),
+  );
+
+  // Copy icon.svg if present
+  const iconSrc = path.join(ROOT_DIR, 'icon.svg');
+  if (fs.existsSync(iconSrc)) {
+    fs.copyFileSync(iconSrc, path.join(DIST_DIR, 'icon.svg'));
+    console.log('Copied icon.svg');
+  }
+
+  // Copy i18n files
+  if (fs.existsSync(I18N_SRC)) {
+    fs.mkdirSync(I18N_DIST, { recursive: true });
+    for (const file of fs.readdirSync(I18N_SRC)) {
+      if (file.endsWith('.json')) {
+        fs.copyFileSync(path.join(I18N_SRC, file), path.join(I18N_DIST, file));
+      }
+    }
+    console.log('Copied i18n files');
+  }
+
+  console.log('Build complete!');
+}
+
+buildPlugin().catch((err) => {
+  console.error('Build failed:', err);
+  process.exit(1);
+});

--- a/packages/plugin-dev/plane-issue-provider/src/manifest.json
+++ b/packages/plugin-dev/plane-issue-provider/src/manifest.json
@@ -1,0 +1,28 @@
+{
+  "id": "plane-issue-provider",
+  "name": "Plane Issues",
+  "version": "1.0.0",
+  "manifestVersion": 1,
+  "minSupVersion": "13.0.0",
+  "description": "Plane.so issue provider plugin",
+  "author": "Super Productivity",
+  "type": "issueProvider",
+  "icon": "icon.svg",
+  "iFrame": false,
+  "permissions": [],
+  "hooks": [],
+  "i18n": {
+    "languages": ["en"]
+  },
+  "issueProvider": {
+    "pollIntervalMs": 300000,
+    "icon": "plane",
+    "humanReadableName": "Plane",
+    "issueProviderKey": "PLANE",
+    "allowPrivateNetwork": true,
+    "issueStrings": {
+      "singular": "Work item",
+      "plural": "Work items"
+    }
+  }
+}

--- a/packages/plugin-dev/plane-issue-provider/src/plane-helpers.ts
+++ b/packages/plugin-dev/plane-issue-provider/src/plane-helpers.ts
@@ -1,0 +1,183 @@
+import type { PluginIssue, PluginSearchResult } from '@super-productivity/plugin-api';
+
+export const CLOUD_API_BASE = 'https://api.plane.so';
+export const CLOUD_UI_BASE = 'https://app.plane.so';
+export const DONE_STATE_GROUPS = ['completed', 'cancelled'];
+
+export interface PlaneConfig {
+  apiKey?: string;
+  host?: string;
+  workspaceSlug?: string;
+  projectId?: string;
+}
+
+export interface PlaneState {
+  id?: string;
+  name?: string;
+  group?: string;
+}
+
+export interface PlaneUser {
+  id?: string;
+  display_name?: string;
+  first_name?: string;
+  email?: string;
+}
+
+export interface PlaneProject {
+  id?: string;
+  identifier?: string;
+  name?: string;
+}
+
+export interface PlaneSearchHit {
+  id: string;
+  name: string;
+  sequence_id: number;
+  project__identifier?: string;
+  project_id?: string;
+  workspace__slug?: string;
+}
+
+export interface PlaneWorkItem {
+  id: string;
+  name: string;
+  sequence_id: number;
+  description_stripped?: string;
+  priority?: string;
+  target_date?: string | null;
+  updated_at?: string;
+  project?: string | PlaneProject;
+  state?: string | PlaneState;
+  assignees?: Array<string | PlaneUser>;
+  labels?: unknown[];
+}
+
+/** API origin: configured host, or Plane Cloud. */
+export const getApiBase = (cfg: PlaneConfig): string => {
+  const host = (cfg.host || '').trim().replace(/\/+$/, '');
+  return host || CLOUD_API_BASE;
+};
+
+/** UI origin for browse links. */
+export const getUiBase = (cfg: PlaneConfig): string => {
+  const host = (cfg.host || '').trim().replace(/\/+$/, '');
+  return host || CLOUD_UI_BASE;
+};
+
+export const buildBrowseUrl = (
+  cfg: PlaneConfig,
+  projectIdentifier: string,
+  sequenceId: number,
+): string => {
+  const slug = (cfg.workspaceSlug || '').trim();
+  if (!slug || !projectIdentifier || !sequenceId) {
+    return '';
+  }
+  return `${getUiBase(cfg)}/${slug}/browse/${projectIdentifier}-${sequenceId}`;
+};
+
+export const displayKey = (projectIdentifier: string, sequenceId: number): string =>
+  `${projectIdentifier}-${sequenceId}`;
+
+export const isDoneStateGroup = (group: unknown): boolean =>
+  typeof group === 'string' && DONE_STATE_GROUPS.includes(group);
+
+export const stateOf = (item: PlaneWorkItem): PlaneState | null => {
+  if (item.state && typeof item.state === 'object') {
+    return item.state;
+  }
+  return null;
+};
+
+export const projectIdentifierOf = (item: PlaneWorkItem, fallback = ''): string => {
+  if (item.project && typeof item.project === 'object' && item.project.identifier) {
+    return item.project.identifier;
+  }
+  return fallback;
+};
+
+export const assigneeNames = (item: PlaneWorkItem): string[] =>
+  (item.assignees || [])
+    .map((a) => {
+      if (typeof a === 'string') {
+        return '';
+      }
+      return a.display_name || a.first_name || a.email || '';
+    })
+    .filter((name): name is string => !!name);
+
+export const mapSearchHit = (
+  hit: PlaneSearchHit,
+  cfg: PlaneConfig,
+): PluginSearchResult => {
+  const ident = hit.project__identifier || '';
+  const key = displayKey(ident, hit.sequence_id);
+  return {
+    id: hit.id,
+    title: `${key} ${hit.name}`,
+    url: buildBrowseUrl(cfg, ident, hit.sequence_id),
+    summary: `${key} ${hit.name}`,
+    identifier: key,
+    sequenceId: hit.sequence_id,
+    projectIdentifier: ident,
+  };
+};
+
+export const mapWorkItem = (
+  item: PlaneWorkItem,
+  cfg: PlaneConfig,
+  projectIdentifierFallback = '',
+): PluginIssue => {
+  const state = stateOf(item);
+  const ident = projectIdentifierOf(item, projectIdentifierFallback);
+  const key = displayKey(ident, item.sequence_id);
+  const assignees = assigneeNames(item);
+  return {
+    id: item.id,
+    title: item.name,
+    body: item.description_stripped || '',
+    url: buildBrowseUrl(cfg, ident, item.sequence_id),
+    state: state?.name || (typeof item.state === 'string' ? item.state : ''),
+    lastUpdated: item.updated_at ? new Date(item.updated_at).getTime() : 0,
+    assignee: assignees[0],
+    summary: `${key} ${item.name}`,
+    identifier: key,
+    sequenceId: item.sequence_id,
+    projectIdentifier: ident,
+    stateGroup: state?.group || '',
+    priority: item.priority || '',
+    due: item.target_date || '',
+    assignees,
+  };
+};
+
+export const mapWorkItemSearchResult = (
+  item: PlaneWorkItem,
+  cfg: PlaneConfig,
+  projectIdentifierFallback = '',
+): PluginSearchResult => {
+  const mapped = mapWorkItem(item, cfg, projectIdentifierFallback);
+  return {
+    id: mapped.id,
+    title: String(mapped.summary || mapped.title),
+    url: mapped.url,
+    status: mapped.state,
+    assignee: mapped.assignee,
+    summary: mapped.summary,
+    identifier: mapped.identifier,
+    stateGroup: mapped.stateGroup,
+    ...(mapped.due ? { due: mapped.due } : {}),
+  };
+};
+
+export const apiRoot = (cfg: PlaneConfig): string => {
+  const slug = (cfg.workspaceSlug || '').trim();
+  if (!slug) {
+    throw new Error('Plane workspace slug is not configured.');
+  }
+  if (!(cfg.projectId || '').trim()) {
+    throw new Error('Plane project ID is not configured.');
+  }
+  return `${getApiBase(cfg)}/api/v1/workspaces/${encodeURIComponent(slug)}`;
+};

--- a/packages/plugin-dev/plane-issue-provider/src/plugin.spec.ts
+++ b/packages/plugin-dev/plane-issue-provider/src/plugin.spec.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import type {
+  IssueProviderPluginDefinition,
+  PluginHttp,
+} from '@super-productivity/plugin-api';
+import {
+  buildBrowseUrl,
+  displayKey,
+  getApiBase,
+  getUiBase,
+  isDoneStateGroup,
+  mapSearchHit,
+  mapWorkItem,
+} from './plane-helpers';
+
+let definition: IssueProviderPluginDefinition;
+
+beforeAll(async () => {
+  (globalThis as unknown as { PluginAPI: unknown }).PluginAPI = {
+    registerIssueProvider: vi.fn((def: IssueProviderPluginDefinition) => {
+      definition = def;
+    }),
+    translate: (key: string) => key,
+  };
+  await import('./plugin');
+});
+
+describe('Plane URL helpers', () => {
+  it('defaults API and UI bases to Plane Cloud', () => {
+    expect(getApiBase({})).toBe('https://api.plane.so');
+    expect(getUiBase({})).toBe('https://app.plane.so');
+  });
+
+  it('uses custom host for self-hosted API and UI', () => {
+    const cfg = { host: 'https://plane.example.com/' };
+    expect(getApiBase(cfg)).toBe('https://plane.example.com');
+    expect(getUiBase(cfg)).toBe('https://plane.example.com');
+  });
+
+  it('builds browse URLs', () => {
+    expect(buildBrowseUrl({ workspaceSlug: 'acme', host: '' }, 'ENG', 42)).toBe(
+      'https://app.plane.so/acme/browse/ENG-42',
+    );
+    expect(buildBrowseUrl({ workspaceSlug: '' }, 'ENG', 42)).toBe('');
+  });
+
+  it('formats display keys', () => {
+    expect(displayKey('ENG', 7)).toBe('ENG-7');
+  });
+});
+
+describe('Plane mapping', () => {
+  it('maps search hits', () => {
+    const mapped = mapSearchHit(
+      {
+        id: 'uuid-1',
+        name: 'Fix login',
+        sequence_id: 12,
+        project__identifier: 'ENG',
+      },
+      { workspaceSlug: 'acme' },
+    );
+    expect(mapped.id).toBe('uuid-1');
+    expect(mapped.title).toBe('ENG-12 Fix login');
+    expect(mapped.url).toBe('https://app.plane.so/acme/browse/ENG-12');
+  });
+
+  it('maps work items with expanded state and assignees', () => {
+    const mapped = mapWorkItem(
+      {
+        id: 'uuid-2',
+        name: 'Ship it',
+        sequence_id: 3,
+        description_stripped: 'body',
+        priority: 'high',
+        target_date: '2026-08-01',
+        updated_at: '2026-07-01T00:00:00Z',
+        project: { identifier: 'ENG' },
+        state: { name: 'Done', group: 'completed' },
+        assignees: [{ display_name: 'Ada' }],
+      },
+      { workspaceSlug: 'acme' },
+    );
+    expect(mapped.summary).toBe('ENG-3 Ship it');
+    expect(mapped.state).toBe('Done');
+    expect(mapped.stateGroup).toBe('completed');
+    expect(mapped.assignee).toBe('Ada');
+    expect(mapped.due).toBe('2026-08-01');
+    expect(isDoneStateGroup(mapped.stateGroup)).toBe(true);
+  });
+
+  it('treats cancelled as done and unstarted as not done', () => {
+    expect(isDoneStateGroup('cancelled')).toBe(true);
+    expect(isDoneStateGroup('unstarted')).toBe(false);
+  });
+});
+
+describe('Plane plugin definition', () => {
+  it('sends X-API-Key header', () => {
+    expect(definition.getHeaders({ apiKey: 'plane_api_x' })).toEqual({
+      'X-API-Key': 'plane_api_x',
+      Accept: 'application/json',
+    });
+  });
+
+  it('getIssueLink returns empty so adapter can fall back to getById url', () => {
+    expect(definition.getIssueLink('uuid', {})).toBe('');
+  });
+
+  it('searchIssues calls the workspace search endpoint', async () => {
+    const http = {
+      get: vi.fn(async () => ({
+        issues: [
+          {
+            id: 'uuid-1',
+            name: 'Fix login',
+            sequence_id: 12,
+            project__identifier: 'ENG',
+          },
+        ],
+      })),
+    } as unknown as PluginHttp;
+
+    const results = await definition.searchIssues(
+      'login',
+      { workspaceSlug: 'acme', projectId: 'proj-1', apiKey: 'k' },
+      http,
+    );
+
+    expect(http.get).toHaveBeenCalledWith(
+      'https://api.plane.so/api/v1/workspaces/acme/work-items/search/',
+      {
+        params: {
+          search: 'login',
+          limit: '50',
+          project_id: 'proj-1',
+        },
+      },
+    );
+    expect(results[0]?.title).toBe('ENG-12 Fix login');
+  });
+
+  it('getNewIssuesForBacklog skips completed/cancelled state groups', async () => {
+    const http = {
+      get: vi.fn(async (url: string) => {
+        if (url.includes('/projects/proj-1/') && !url.includes('work-items')) {
+          return { identifier: 'ENG' };
+        }
+        return {
+          results: [
+            {
+              id: 'open-1',
+              name: 'Open',
+              sequence_id: 1,
+              state: { name: 'Todo', group: 'unstarted' },
+            },
+            {
+              id: 'done-1',
+              name: 'Done',
+              sequence_id: 2,
+              state: { name: 'Done', group: 'completed' },
+            },
+            {
+              id: 'cancel-1',
+              name: 'Cancelled',
+              sequence_id: 3,
+              state: { name: 'Cancelled', group: 'cancelled' },
+            },
+          ],
+          next_page_results: false,
+        };
+      }),
+    } as unknown as PluginHttp;
+
+    const results = await definition.getNewIssuesForBacklog!(
+      { workspaceSlug: 'acme', projectId: 'proj-1' },
+      http,
+    );
+
+    expect(results.map((r) => r.id)).toEqual(['open-1']);
+  });
+
+  it('testConnection probes /users/me/', async () => {
+    const http = {
+      get: vi.fn(async () => ({ id: 'me' })),
+    } as unknown as PluginHttp;
+    await expect(definition.testConnection!({ apiKey: 'k' }, http)).resolves.toBe(true);
+    expect(http.get).toHaveBeenCalledWith('https://api.plane.so/api/v1/users/me/');
+  });
+});

--- a/packages/plugin-dev/plane-issue-provider/src/plugin.ts
+++ b/packages/plugin-dev/plane-issue-provider/src/plugin.ts
@@ -1,0 +1,256 @@
+import type {
+  IssueProviderPluginDefinition,
+  PluginFieldMapping,
+  PluginHttp,
+  PluginIssue,
+  PluginSearchResult,
+} from '@super-productivity/plugin-api';
+import {
+  apiRoot,
+  getApiBase,
+  isDoneStateGroup,
+  mapSearchHit,
+  mapWorkItem,
+  mapWorkItemSearchResult,
+  PlaneConfig,
+  PlaneProject,
+  PlaneSearchHit,
+  PlaneWorkItem,
+  stateOf,
+} from './plane-helpers';
+
+declare const PluginAPI: {
+  registerIssueProvider(definition: IssueProviderPluginDefinition): void;
+  translate(key: string, params?: Record<string, string | number>): string;
+};
+
+const BACKLOG_PAGE_SIZE = 50;
+const BACKLOG_MAX_PAGES = 2;
+
+interface PlaneSearchResponse {
+  issues?: PlaneSearchHit[];
+}
+
+interface PlaneListResponse {
+  results?: PlaneWorkItem[];
+  next_cursor?: string;
+  next_page_results?: boolean;
+}
+
+const t = (key: string, fallback: string): string => {
+  try {
+    const translated = PluginAPI.translate(key);
+    // Uploaded zips historically skipped i18n load; fall back so labels aren't raw keys.
+    return !translated || translated === key ? fallback : translated;
+  } catch {
+    return fallback;
+  }
+};
+
+const asConfig = (config: Record<string, unknown>): PlaneConfig =>
+  config as unknown as PlaneConfig;
+
+const fetchProjectIdentifier = async (
+  cfg: PlaneConfig,
+  http: PluginHttp,
+): Promise<string> => {
+  const project = await http.get<PlaneProject>(
+    `${apiRoot(cfg)}/projects/${cfg.projectId}/`,
+  );
+  return project?.identifier || '';
+};
+
+const listOpenWorkItems = async (
+  cfg: PlaneConfig,
+  http: PluginHttp,
+): Promise<PluginSearchResult[]> => {
+  const projectIdentifier = await fetchProjectIdentifier(cfg, http);
+  const out: PluginSearchResult[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < BACKLOG_MAX_PAGES; page++) {
+    const params: Record<string, string> = {
+      per_page: String(BACKLOG_PAGE_SIZE),
+      expand: 'state,assignees,project',
+    };
+    if (cursor) {
+      params['cursor'] = cursor;
+    }
+    const res = await http.get<PlaneListResponse>(
+      `${apiRoot(cfg)}/projects/${cfg.projectId}/work-items/`,
+      { params },
+    );
+    const results = res?.results || [];
+    for (const item of results) {
+      const state = stateOf(item);
+      if (isDoneStateGroup(state?.group)) {
+        continue;
+      }
+      out.push(mapWorkItemSearchResult(item, cfg, projectIdentifier));
+    }
+    if (!res?.next_page_results || !res.next_cursor) {
+      break;
+    }
+    cursor = res.next_cursor;
+  }
+  return out;
+};
+
+PluginAPI.registerIssueProvider({
+  configFields: [
+    {
+      key: 'apiKey',
+      type: 'password',
+      label: t('CFG.API_KEY', 'API Key'),
+      required: true,
+    },
+    {
+      key: 'apiKeyHelp',
+      type: 'link',
+      label: t('CFG.HOW_TO_GET_TOKEN', 'How to get an API key'),
+      url: 'https://developers.plane.so/api-reference/introduction',
+    },
+    {
+      key: 'workspaceSlug',
+      type: 'input',
+      label: t('CFG.WORKSPACE_SLUG', 'Workspace slug'),
+      required: true,
+      description: t(
+        'CFG.WORKSPACE_SLUG_HELP',
+        'From the URL: app.plane.so/<workspace-slug>/...',
+      ),
+    },
+    {
+      key: 'projectId',
+      type: 'input',
+      label: t('CFG.PROJECT_ID', 'Project ID (UUID)'),
+      required: true,
+      description: t(
+        'CFG.PROJECT_ID_HELP',
+        'Open the project in Plane; the UUID is in the project settings URL or API.',
+      ),
+    },
+    {
+      key: 'host',
+      type: 'input',
+      label: t('CFG.HOST', 'Host (self-hosted only; leave empty for Plane Cloud)'),
+      advanced: true,
+    },
+  ],
+
+  getHeaders(config: Record<string, unknown>): Record<string, string> {
+    const cfg = asConfig(config);
+    return {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'X-API-Key': cfg.apiKey || '',
+      Accept: 'application/json',
+    };
+  },
+
+  async searchIssues(
+    searchTerm: string,
+    config: Record<string, unknown>,
+    http: PluginHttp,
+  ): Promise<PluginSearchResult[]> {
+    const cfg = asConfig(config);
+    const term = searchTerm.trim();
+    if (!term) {
+      return listOpenWorkItems(cfg, http);
+    }
+    const res = await http.get<PlaneSearchResponse>(
+      `${apiRoot(cfg)}/work-items/search/`,
+      {
+        params: {
+          search: term,
+          limit: '50',
+          project_id: (cfg.projectId || '').trim(),
+        },
+      },
+    );
+    return (res?.issues || []).map((hit) => mapSearchHit(hit, cfg));
+  },
+
+  async getById(
+    issueId: string,
+    config: Record<string, unknown>,
+    http: PluginHttp,
+  ): Promise<PluginIssue> {
+    const cfg = asConfig(config);
+    const item = await http.get<PlaneWorkItem>(
+      `${apiRoot(cfg)}/projects/${cfg.projectId}/work-items/${issueId}/`,
+      { params: { expand: 'state,assignees,project,labels' } },
+    );
+    return mapWorkItem(item, cfg);
+  },
+
+  // Browse URLs need project identifier + sequence; fall back to getById().url.
+  getIssueLink(): string {
+    return '';
+  },
+
+  async testConnection(
+    config: Record<string, unknown>,
+    http: PluginHttp,
+  ): Promise<boolean> {
+    const cfg = asConfig(config);
+    try {
+      await http.get(`${getApiBase(cfg)}/api/v1/users/me/`);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  getNewIssuesForBacklog(
+    config: Record<string, unknown>,
+    http: PluginHttp,
+  ): Promise<PluginSearchResult[]> {
+    return listOpenWorkItems(asConfig(config), http);
+  },
+
+  issueDisplay: [
+    {
+      field: 'summary',
+      label: t('DISPLAY.SUMMARY', 'Summary'),
+      type: 'link',
+      linkField: 'url',
+    },
+    { field: 'state', label: t('DISPLAY.STATE', 'State'), type: 'text', hideEmpty: true },
+    {
+      field: 'priority',
+      label: t('DISPLAY.PRIORITY', 'Priority'),
+      type: 'text',
+      hideEmpty: true,
+    },
+    {
+      field: 'assignee',
+      label: t('DISPLAY.ASSIGNEE', 'Assignee'),
+      type: 'text',
+      hideEmpty: true,
+    },
+    { field: 'due', label: t('DISPLAY.DUE', 'Due date'), type: 'date', hideEmpty: true },
+    {
+      field: 'body',
+      label: t('DISPLAY.DESCRIPTION', 'Description'),
+      type: 'markdown',
+    },
+  ],
+
+  fieldMappings: [
+    {
+      taskField: 'isDone',
+      issueField: 'stateGroup',
+      defaultDirection: 'pullOnly',
+      toIssueValue: (taskValue: unknown): string =>
+        taskValue ? 'completed' : 'unstarted',
+      toTaskValue: (issueValue: unknown): boolean => isDoneStateGroup(issueValue),
+    },
+  ] satisfies PluginFieldMapping[],
+
+  extractSyncValues(issue: PluginIssue): Record<string, unknown> {
+    return {
+      stateGroup: issue.stateGroup,
+      title: issue.title,
+      body: issue.body,
+    };
+  },
+});

--- a/packages/plugin-dev/plane-issue-provider/tsconfig.json
+++ b/packages/plugin-dev/plane-issue-provider/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/plugin-dev/plane-issue-provider/vitest.config.ts
+++ b/packages/plugin-dev/plane-issue-provider/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+    globals: true,
+  },
+});

--- a/packages/plugin-dev/scripts/build-all.js
+++ b/packages/plugin-dev/scripts/build-all.js
@@ -318,6 +318,32 @@ const plugins = [
     },
   },
   {
+    name: 'plane-issue-provider',
+    path: 'plane-issue-provider',
+    needsInstall: true,
+    copyToAssets: true,
+    buildCommand: async (pluginPath) => {
+      await execAsync(`cd ${pluginPath} && npm run build`);
+      const targetDir = path.join(
+        __dirname,
+        '../../../src/assets/bundled-plugins/plane-issue-provider',
+      );
+      if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+      }
+      const distPath = path.join(pluginPath, 'dist');
+      if (fs.existsSync(distPath)) {
+        const files = fs.readdirSync(distPath);
+        for (const file of files) {
+          const src = path.join(distPath, file);
+          const dest = path.join(targetDir, file);
+          copyRecursive(src, dest);
+        }
+      }
+      return 'Built and copied to assets';
+    },
+  },
+  {
     name: 'google-calendar-provider',
     path: 'google-calendar-provider',
     needsInstall: true,

--- a/src/app/plugins/plugin.service.load-from-zip.spec.ts
+++ b/src/app/plugins/plugin.service.load-from-zip.spec.ts
@@ -183,6 +183,53 @@ describe('PluginService loadPluginFromZip iframe-only plugins', () => {
     expect(service.getPluginIndexHtml(iframeManifest.id)).toBe(indexHtml);
   });
 
+  it('extracts i18n from zip, caches it, and loads it before plugin code runs', async () => {
+    const issueManifest: PluginManifest = {
+      id: 'i18n-upload-plugin',
+      name: 'I18n Upload',
+      manifestVersion: 1,
+      version: '1.0.0',
+      minSupVersion: '18.0.0',
+      hooks: [],
+      permissions: [],
+      iFrame: false,
+      i18n: { languages: ['en'] },
+      type: 'issueProvider',
+    };
+    const enJson = JSON.stringify({ CFG: { API_KEY: 'API Key' } });
+    const file = createZipFile({
+      'manifest.json': JSON.stringify(issueManifest),
+      'plugin.js': '/* plugin */',
+      'i18n/en.json': enJson,
+    });
+
+    const callOrder: string[] = [];
+    pluginI18n.loadPluginTranslationsFromContent.and.callFake(() => {
+      callOrder.push('i18n');
+    });
+    pluginRunner.loadPlugin.and.callFake(async (manifest, code, baseCfg, isEnabled) => {
+      callOrder.push('load');
+      return { manifest, loaded: true, isEnabled: isEnabled ?? true };
+    });
+
+    await service.loadPluginFromZip(file);
+
+    expect(pluginI18n.loadPluginTranslationsFromContent).toHaveBeenCalledWith(
+      issueManifest.id,
+      { en: enJson },
+    );
+    expect(pluginCache.storePlugin).toHaveBeenCalledWith(
+      issueManifest.id,
+      JSON.stringify(issueManifest),
+      '/* plugin */',
+      undefined,
+      undefined,
+      { en: enJson },
+      undefined,
+    );
+    expect(callOrder).toEqual(['i18n', 'load']);
+  });
+
   it('rejects a plugin zip without plugin.js when index.html is absent', async () => {
     const files: Record<string, string> = {};
     files['manifest.json'] = JSON.stringify(iframeManifest);

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -56,6 +56,7 @@ const BUNDLED_PLUGIN_PATHS = [
   'assets/bundled-plugins/linear-issue-provider',
   'assets/bundled-plugins/trello-issue-provider',
   'assets/bundled-plugins/azure-devops-issue-provider',
+  'assets/bundled-plugins/plane-issue-provider',
   'assets/bundled-plugins/brain-dump',
   'assets/bundled-plugins/voice-reminder',
   'assets/bundled-plugins/google-calendar-provider',
@@ -84,6 +85,7 @@ const BUNDLED_PLUGIN_IDS = new Set<string>([
   'github-issue-provider',
   'google-calendar-provider',
   'linear-issue-provider',
+  'plane-issue-provider',
   'procrastination-buster',
   'sync-md',
   'todoist-import',
@@ -1434,6 +1436,25 @@ export class PluginService implements OnDestroy {
         manifest.id,
       );
 
+      // Extract i18n/{lang}.json for languages listed in the manifest. Must be
+      // loaded before plugin.js runs — issue providers call translate() while
+      // registering configFields / issueDisplay labels.
+      const translations: Record<string, string> = {};
+      const i18nLanguages = manifest.i18n?.languages || [];
+      for (const lang of i18nLanguages) {
+        const i18nBytes = extractedFiles[`i18n/${lang}.json`];
+        if (!i18nBytes) {
+          continue;
+        }
+        if (i18nBytes.length > MAX_PLUGIN_MANIFEST_SIZE) {
+          PluginLog.err(
+            `Plugin i18n/${lang}.json is too large, skipping`,
+          );
+          continue;
+        }
+        translations[lang] = new TextDecoder().decode(i18nBytes);
+      }
+
       // Create a unique path identifier for uploaded plugins
       const uploadedPluginPath = `uploaded://${manifest.id}`;
 
@@ -1444,7 +1465,7 @@ export class PluginService implements OnDestroy {
         pluginCode,
         indexHtml || undefined,
         iconContent || undefined,
-        undefined,
+        Object.keys(translations).length > 0 ? translations : undefined,
         configSchema,
       );
 
@@ -1458,6 +1479,13 @@ export class PluginService implements OnDestroy {
         this._pluginIcons.set(manifest.id, iconContent);
         this._registerPluginIcon(manifest.id, iconContent);
         this._pluginIconsSignal.set(new Map(this._pluginIcons));
+      }
+
+      if (Object.keys(translations).length > 0) {
+        this._pluginI18nService.loadPluginTranslationsFromContent(
+          manifest.id,
+          translations,
+        );
       }
 
       // Check for dangerous permissions in web version


### PR DESCRIPTION
## Summary
- Add bundled `plane-issue-provider` plugin for Plane.so work items (search, import as tasks, open in browser, backlog poll, pull-only done sync from `completed`/`cancelled` state groups)
- Support cloud and self-hosted via API key, workspace slug, project UUID, and optional host
- Fix uploaded plugin zips so `i18n/*.json` is cached and loaded before plugin code runs (config labels no longer show raw `CFG.*` keys)
- Document Plane in the integrations wiki / comparison matrix

## Test plan
- [ ] `cd packages/plugin-dev/plane-issue-provider && npm test && npm run build`
- [ ] `npm run plugins:build` (or build plane plugin into `src/assets/bundled-plugins/plane-issue-provider/`)
- [ ] Enable Plane in the issue provider panel; configure API key, workspace slug, project UUID
- [ ] Test connection, search, add work item as task, open browse link
- [ ] Confirm completed/cancelled Plane items mark local tasks done on poll (pull-only)
- [ ] Optional: upload a plugin zip and confirm config labels are human-readable (not `CFG.API_KEY`)


Made with [Cursor](https://cursor.com)