### PR TITLE
fix(sync): hide inactive encryption actions

### DIFF
--- a/src/app/features/config/form-cfgs/sync-form.const.spec.ts
+++ b/src/app/features/config/form-cfgs/sync-form.const.spec.ts
@@ -144,3 +144,98 @@ describe('SYNC_FORM Android SAF pick → form value (#9075)', () => {
     expect(logErrSpy).toHaveBeenCalled();
   });
 });
+
+describe('SYNC_FORM encryption action visibility (#9268)', () => {
+  type EncryptionVisibilityModel = {
+    syncProvider: SyncProviderId;
+    isEncryptionEnabled: boolean;
+    _isInitialSetup: boolean;
+    _activeProviderId: SyncProviderId | null;
+  };
+
+  const findFieldPath = (
+    fields: FormlyFieldConfig[],
+    className: string,
+  ): FormlyFieldConfig[] | undefined => {
+    for (const field of fields) {
+      if (field.className === className) {
+        return [field];
+      }
+      const childPath = field.fieldGroup
+        ? findFieldPath(field.fieldGroup, className)
+        : undefined;
+      if (childPath) {
+        return [field, ...childPath];
+      }
+    }
+    return undefined;
+  };
+
+  const isFieldHidden = (
+    className: string,
+    model: EncryptionVisibilityModel,
+  ): boolean => {
+    const path = findFieldPath(SYNC_FORM.items as FormlyFieldConfig[], className);
+    if (!path) {
+      throw new Error(`${className} not found in SYNC_FORM`);
+    }
+
+    let field: FormlyFieldConfig = { model };
+    for (const fieldConfig of path) {
+      field = { ...fieldConfig, model, parent: field };
+    }
+    if (typeof field.hideExpression !== 'function') {
+      throw new Error(`${className} has no hide expression`);
+    }
+
+    return field.hideExpression(model, {}, field);
+  };
+
+  it('hides the action during initial file-based sync setup', () => {
+    expect(
+      isFieldHidden('e2e-file-based-enable-encryption-btn', {
+        syncProvider: SyncProviderId.Dropbox,
+        isEncryptionEnabled: false,
+        _isInitialSetup: true,
+        _activeProviderId: null,
+      }),
+    ).toBeTrue();
+  });
+
+  it('shows the action for an established unencrypted file-based provider', () => {
+    expect(
+      isFieldHidden('e2e-file-based-enable-encryption-btn', {
+        syncProvider: SyncProviderId.Dropbox,
+        isEncryptionEnabled: false,
+        _isInitialSetup: false,
+        _activeProviderId: SyncProviderId.Dropbox,
+      }),
+    ).toBeFalse();
+  });
+
+  it('hides active-provider encryption actions during an unsaved switch', () => {
+    const switchedFileProvider: EncryptionVisibilityModel = {
+      syncProvider: SyncProviderId.Dropbox,
+      isEncryptionEnabled: false,
+      _isInitialSetup: false,
+      _activeProviderId: SyncProviderId.WebDAV,
+    };
+    expect(
+      isFieldHidden('e2e-file-based-enable-encryption-btn', switchedFileProvider),
+    ).toBeTrue();
+    expect(
+      isFieldHidden('e2e-enable-encryption-btn', {
+        syncProvider: SyncProviderId.SuperSync,
+        isEncryptionEnabled: false,
+        _isInitialSetup: false,
+        _activeProviderId: SyncProviderId.WebDAV,
+      }),
+    ).toBeTrue();
+    expect(
+      isFieldHidden('encryption-status-box', {
+        ...switchedFileProvider,
+        isEncryptionEnabled: true,
+      }),
+    ).toBeTrue();
+  });
+});

--- a/src/app/features/config/form-cfgs/sync-form.const.ts
+++ b/src/app/features/config/form-cfgs/sync-form.const.ts
@@ -151,6 +151,15 @@ const isNotSyncProvider = (
   providerId: SyncProviderId | null,
 ): boolean => rootSyncProvider(field, depth) !== providerId;
 
+const hasUnsavedProviderSwitch = (
+  field: FormlyFieldConfig | undefined,
+  depth: 1 | 2,
+): boolean => {
+  const root = depth === 1 ? field?.parent : field?.parent?.parent;
+  const activeProviderId = root?.model?._activeProviderId;
+  return activeProviderId !== undefined && activeProviderId !== root?.model?.syncProvider;
+};
+
 const isOneDriveClientIdRequired = (field: FormlyFieldConfig): boolean => {
   if (!isSyncProvider(field, 2, SyncProviderId.OneDrive)) {
     return false;
@@ -477,10 +486,11 @@ export const SYNC_FORM: ConfigFormSection<SyncConfig> = {
       ],
     },
 
-    // Encryption status box - shown when encryption is enabled (for any provider)
+    // Encryption status box - shown when encryption is enabled for the active provider.
     {
       hideExpression: (m: any, v: any, field?: FormlyFieldConfig) =>
-        !(field?.parent?.model?.isEncryptionEnabled ?? false),
+        !(field?.parent?.model?.isEncryptionEnabled ?? false) ||
+        hasUnsavedProviderSwitch(field, 1),
       className: 'encryption-status-box',
       fieldGroup: [
         {
@@ -588,10 +598,15 @@ export const SYNC_FORM: ConfigFormSection<SyncConfig> = {
             label: T.F.SYNC.FORM.L_USE_SPLIT_SYNC_FILES,
           },
         },
-        // Enable encryption button for file-based providers (shown when encryption is disabled)
+        // Established file-based providers can enable encryption here.
+        // Setup and provider switches expose this only after Save, when the
+        // selected provider is active.
         {
           hideExpression: (m: any, v: any, field?: FormlyFieldConfig) =>
-            isSyncProvider(field, 2, SyncProviderId.SuperSync) || m.isEncryptionEnabled,
+            isSyncProvider(field, 2, SyncProviderId.SuperSync) ||
+            m.isEncryptionEnabled ||
+            field?.parent?.parent?.model?._isInitialSetup === true ||
+            hasUnsavedProviderSwitch(field, 2),
           type: 'btn',
           className: 'e2e-file-based-enable-encryption-btn',
           templateOptions: {
@@ -681,12 +696,14 @@ export const SYNC_FORM: ConfigFormSection<SyncConfig> = {
           },
         },
         // Enable encryption button for SuperSync (shown when encryption is disabled)
-        // Hidden during initial setup (encryption dialog opens automatically after save)
+        // Hidden during initial setup and provider switches because the
+        // encryption dialog always acts on the active, persisted provider.
         {
           hideExpression: (m: any, v: any, field?: FormlyFieldConfig) =>
             isNotSyncProvider(field, 2, SyncProviderId.SuperSync) ||
             (field?.parent?.parent?.model?.isEncryptionEnabled ?? false) ||
-            field?.parent?.parent?.model?._isInitialSetup === true,
+            field?.parent?.parent?.model?._isInitialSetup === true ||
+            hasUnsavedProviderSwitch(field, 2),
           type: 'btn',
           className: 'e2e-enable-encryption-btn',
           templateOptions: {

--- a/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.spec.ts
+++ b/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.spec.ts
@@ -651,6 +651,22 @@ describe('DialogSyncCfgComponent', () => {
       expect((component as any)._tmpUpdatedCfg.isEncryptionEnabled).toBeFalse();
     }));
 
+    it('records the provider active when the dialog opens', () => {
+      fixture.destroy();
+      (mockSyncConfigService as any).syncSettingsForm$ = of({
+        ...baseSyncConfig,
+        isEnabled: true,
+        syncProvider: SyncProviderId.WebDAV,
+      });
+
+      fixture = TestBed.createComponent(DialogSyncCfgComponent);
+      component = fixture.componentInstance;
+
+      expect((component as any)._tmpUpdatedCfg._activeProviderId).toBe(
+        SyncProviderId.WebDAV,
+      );
+    });
+
     it('waits for the selected provider config before saving', fakeAsync(() => {
       let resolvePrivateCfg: (value: null) => void = () => undefined;
       const privateCfgPromise = new Promise<null>((resolve) => {

--- a/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.ts
+++ b/src/app/imex/sync/dialog-sync-cfg/dialog-sync-cfg.component.ts
@@ -60,6 +60,11 @@ import type { SuperSyncPrivateCfg } from '@sp/sync-providers/super-sync';
 // the app, so the discriminator value is named locally instead of inlined.
 const HTTP_NOT_FOUND = 404;
 
+type SyncFormModel = SyncConfig & {
+  _isInitialSetup?: boolean;
+  _activeProviderId?: SyncProviderId | null;
+};
+
 @Component({
   selector: 'dialog-sync-cfg',
   templateUrl: './dialog-sync-cfg.component.html',
@@ -398,9 +403,9 @@ export class DialogSyncCfgComponent implements AfterViewInit {
       });
     }
   }
-  // Note: _isInitialSetup flag is checked by sync-form.const.ts hideExpressions
-  // to hide the encryption button/warning (encryption is handled by _promptSuperSyncEncryptionIfNeeded after sync)
-  _tmpUpdatedCfg: SyncConfig & { _isInitialSetup?: boolean } = {
+  // Form-only flags are checked by sync-form.const.ts hideExpressions.
+  // Encryption actions must target only the active, persisted provider.
+  _tmpUpdatedCfg: SyncFormModel = {
     isEnabled: true,
     syncProvider: SyncProviderId.SuperSync,
     syncInterval: 300000,
@@ -411,6 +416,7 @@ export class DialogSyncCfgComponent implements AfterViewInit {
     nextcloud: {},
     superSync: {},
     _isInitialSetup: true,
+    _activeProviderId: null,
   };
 
   private _matDialogRef = inject<MatDialogRef<DialogSyncCfgComponent>>(MatDialogRef);
@@ -441,6 +447,7 @@ export class DialogSyncCfgComponent implements AfterViewInit {
           ...v,
           isEnabled: true,
           _isInitialSetup: !v.isEnabled,
+          _activeProviderId: this._initialProviderId,
         });
       });
   }
@@ -650,20 +657,21 @@ export class DialogSyncCfgComponent implements AfterViewInit {
       ...this.form.value,
     };
 
-    // Strip _isInitialSetup before saving — it's only for form hideExpressions
-    // and the fresh-setup encryption-prompt decision below.
-    const { _isInitialSetup, ...cfgWithoutFlag } = this._tmpUpdatedCfg;
+    const isInitialSetup = this._tmpUpdatedCfg._isInitialSetup;
     const configToSave = {
-      ...cfgWithoutFlag,
+      ...this._tmpUpdatedCfg,
       isEnabled: this._tmpUpdatedCfg.isEnabled || !this.isWasEnabled(),
     };
+    // These flags drive only the form UI and setup decision.
+    delete configToSave._isInitialSetup;
+    delete configToSave._activeProviderId;
 
     const providerId = toSyncProviderId(this._tmpUpdatedCfg.syncProvider);
     // Switching providers is a first setup only when the target has no stored
     // private config. Returning providers must keep their existing encryption
     // contract instead of being offered a new, incompatible key.
     const isProviderSetup =
-      _isInitialSetup ||
+      isInitialSetup ||
       (providerId !== this._initialProviderId && !this._selectedProviderWasConfigured);
     let selectedProvider: Awaited<ReturnType<SyncProviderManager['getProviderById']>> =
       undefined;
@@ -837,7 +845,7 @@ export class DialogSyncCfgComponent implements AfterViewInit {
     return result?.success && result.password ? result.password : null;
   }
 
-  updateTmpCfg(cfg: SyncConfig & { _isInitialSetup?: boolean }): void {
+  updateTmpCfg(cfg: SyncFormModel): void {
     // Use Object.assign to preserve the object reference for Formly
     // This ensures Formly detects changes to the model
     Object.assign(this._tmpUpdatedCfg, cfg);


### PR DESCRIPTION
## Problem

Closes #9268.

During initial file-based sync setup, Advanced Configuration exposed the established-provider **Enable Encryption** action. That dialog requires an active persisted provider, so on a fresh setup it could only fail while the supported setup flow offered encryption again after Save.

The same selected-versus-active mismatch could occur while switching providers in an already-enabled configuration, allowing encryption controls to act on the previously active provider.

## Solution

- Hide file-based and SuperSync enable-encryption actions during initial setup.
- Record the provider that was active when the form opened and hide active-provider encryption controls whenever it differs from the currently selected provider.
- Keep the existing setup-specific post-Save encryption flow unchanged, so an optional file-provider key is still persisted before the first upload.
- Strip both form-only markers before saving; this adds no persisted field or schema change.
- Add regression coverage for fresh setup, established providers, unsaved provider switches, and active-provider initialization.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Verification

- `npm run checkFile` passed for all four changed TypeScript files.
- Focused specs passed: `sync-form.const.spec.ts` (7/7) and `dialog-sync-cfg.component.spec.ts` (40/40).
- Full `npm test -- --watch=false` passed, including package tests, release-note tests, and both timezone Angular suites (13,465 Berlin / 13,451 Los Angeles; only the existing skips).
- Live browser verification confirmed the action is hidden for fresh setup and disappears immediately on an unsaved WebDAV → Dropbox/SuperSync switch, while remaining available for the active established provider.
- Independent final review found no blocking issues and confirmed the selected-versus-active provider risk is resolved.

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — No documentation change is required; the documented post-Save setup flow remains unchanged.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
