### PR TITLE
fix(ui): improve responsive dialog actions

### DIFF
--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.html
@@ -37,51 +37,50 @@
       </div>
     }
 
-    <mat-dialog-actions align="start">
-      <div class="schedule-actions">
-        @if (
-          !data.isSelectDueOnly &&
-          data.task &&
-          (data.task.dueWithTime || plannedDayForTask)
-        ) {
-          <button
-            (click)="remove()"
-            color="warn"
-            mat-stroked-button
-            type="button"
-          >
-            @if (selectedTime) {
-              <mat-icon>alarm_off</mat-icon>
-            } @else {
-              <mat-icon>event_busy</mat-icon>
-            }
-            {{ T.F.TASK.D_SCHEDULE_TASK.UNSCHEDULE | translate }}
-          </button>
-        }
-        <button
-          color="primary"
-          mat-flat-button
-          [disabled]="!selectedDate"
-          (click)="submit()"
-          type="button"
-          data-test-id="schedule-submit-btn"
-        >
-          @if (selectedTime) {
-            <mat-icon>alarm</mat-icon>
-          } @else {
-            <mat-icon>today</mat-icon>
-          }
-          {{ T.F.TASK.D_SCHEDULE_TASK.SCHEDULE | translate }}
-        </button>
-      </div>
+    <mat-dialog-actions align="end">
       <button
-        class="dialog-cancel-btn"
         mat-button
         (click)="close()"
         type="button"
         data-test-id="schedule-cancel-btn"
       >
-        {{ T.G.CANCEL | translate }}
+        <span class="action-label">{{ T.G.CANCEL | translate }}</span>
+      </button>
+      @if (
+        !data.isSelectDueOnly && data.task && (data.task.dueWithTime || plannedDayForTask)
+      ) {
+        <button
+          (click)="remove()"
+          color="warn"
+          mat-stroked-button
+          type="button"
+        >
+          @if (selectedTime) {
+            <mat-icon>alarm_off</mat-icon>
+          } @else {
+            <mat-icon>event_busy</mat-icon>
+          }
+          <span class="action-label">
+            {{ T.F.TASK.D_SCHEDULE_TASK.UNSCHEDULE | translate }}
+          </span>
+        </button>
+      }
+      <button
+        color="primary"
+        mat-flat-button
+        [disabled]="!selectedDate"
+        (click)="submit()"
+        type="button"
+        data-test-id="schedule-submit-btn"
+      >
+        @if (selectedTime) {
+          <mat-icon>alarm</mat-icon>
+        } @else {
+          <mat-icon>today</mat-icon>
+        }
+        <span class="action-label">
+          {{ T.F.TASK.D_SCHEDULE_TASK.SCHEDULE | translate }}
+        </span>
       </button>
     </mat-dialog-actions>
   </div>

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
@@ -10,8 +10,9 @@
   justify-content: stretch;
   align-items: stretch;
   user-select: none;
-  width: 400px;
-  max-width: 100%;
+  width: max-content;
+  min-width: min(400px, calc(100vw - var(--s4)));
+  max-width: min(560px, 100%);
   display: block;
 
   :host-context([dir='rtl']) {
@@ -34,48 +35,17 @@ mat-dialog-content {
   ) !important;
 }
 
-:host ::ng-deep mat-dialog-actions {
+mat-dialog-actions {
   padding: 0 0 var(--s2) 0 !important;
+  row-gap: calc(var(--s) + var(--s-half));
 }
 
 .dialog-actions-and-warnings {
   margin: 0 var(--s2) var(--s2);
 }
 
-.schedule-actions {
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
-  width: 100%;
-  margin: 0 auto;
-  padding-bottom: var(--s);
-}
-
-.schedule-actions button {
-  flex: 1 1 0;
-  min-width: 0;
-  max-width: 100%;
-  height: auto;
-  min-height: 38px;
-  white-space: normal;
-  overflow-wrap: anywhere;
-  text-align: center;
-}
-
-.schedule-actions button:not(:last-child) {
-  margin-right: var(--s-quarter);
-}
-
-.dialog-cancel-btn {
-  display: block;
-  width: 100%;
-}
-
-.schedule-actions button,
-.dialog-cancel-btn {
-  white-space: normal;
-  overflow-wrap: anywhere;
-  text-align: center;
+.action-label {
+  white-space: nowrap;
 }
 
 .schedule-info {

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
@@ -163,6 +163,51 @@ describe('DialogScheduleTaskComponent', () => {
     expect(dialogRefSpy.close).toHaveBeenCalledWith(true);
   });
 
+  it('should reflow three intact action buttons without horizontal overflow', () => {
+    component.plannedDayForTask = '2026-07-24';
+    fixture.detectChanges();
+
+    const actions: HTMLElement | null =
+      fixture.nativeElement.querySelector('mat-dialog-actions');
+    expect(actions).not.toBeNull();
+    if (!actions) {
+      return;
+    }
+
+    const actionButtons: HTMLElement[] = Array.from(
+      actions.querySelectorAll<HTMLElement>('button'),
+    );
+    const actionLabels = actions.querySelectorAll<HTMLElement>('.action-label');
+
+    expect(actionButtons.length).toBe(3);
+    expect(actionButtons[0].dataset.testId).toBe('schedule-cancel-btn');
+    expect(actionButtons[1].getAttribute('color')).toBe('warn');
+    expect(actionButtons[2].dataset.testId).toBe('schedule-submit-btn');
+    actionButtons.forEach((button) => {
+      expect(button.parentElement).toBe(actions);
+    });
+    expect(actionLabels.length).toBe(3);
+    actionLabels.forEach((label) => {
+      expect(getComputedStyle(label).whiteSpace).toBe('nowrap');
+    });
+
+    // Karma doesn't load the app-level Material layout styles. Reproduce the
+    // dialog action container's production flex rules to exercise this markup.
+    actions.style.display = 'flex';
+    actions.style.flexWrap = 'wrap';
+    actions.style.justifyContent = 'flex-end';
+    actions.style.width = '280px';
+    const actionsRect = actions.getBoundingClientRect();
+    const buttonRects = actionButtons.map((button) => button.getBoundingClientRect());
+
+    expect(new Set(buttonRects.map(({ top }) => top)).size).toBeGreaterThan(1);
+    buttonRects.forEach(({ left, right }) => {
+      expect(left).toBeGreaterThanOrEqual(actionsRect.left);
+      expect(right).toBeLessThanOrEqual(actionsRect.right);
+    });
+    expect(getComputedStyle(actions).rowGap).toBe('12px');
+  });
+
   describe('schedule hints', () => {
     it('should show an inline info hint when the selected time overlaps another task', () => {
       const selectedDate = new Date(2026, 3, 15);

--- a/src/app/features/tasks/dialog-deadline/dialog-deadline.component.html
+++ b/src/app/features/tasks/dialog-deadline/dialog-deadline.component.html
@@ -17,8 +17,15 @@
     ></datetime-picker>
   }
 
-  <mat-dialog-actions align="start">
-    <div class="deadline-actions">
+  <div class="dialog-actions-and-warnings">
+    <mat-dialog-actions align="end">
+      <button
+        mat-button
+        (click)="close()"
+        type="button"
+      >
+        <span class="action-label">{{ T.G.CANCEL | translate }}</span>
+      </button>
       @if (hasExistingDeadline && !data.isSelectDeadlineOnly) {
         <button
           (click)="remove()"
@@ -27,7 +34,9 @@
           type="button"
         >
           <mat-icon>event_busy</mat-icon>
-          {{ T.F.TASK.D_DEADLINE.REMOVE_DEADLINE | translate }}
+          <span class="action-label">
+            {{ T.F.TASK.D_DEADLINE.REMOVE_DEADLINE | translate }}
+          </span>
         </button>
       }
       <button
@@ -38,16 +47,10 @@
         type="button"
       >
         <mat-icon>event_available</mat-icon>
-        {{ T.F.TASK.D_DEADLINE.SET_DEADLINE | translate }}
+        <span class="action-label">
+          {{ T.F.TASK.D_DEADLINE.SET_DEADLINE | translate }}
+        </span>
       </button>
-    </div>
-    <button
-      class="dialog-cancel-btn"
-      mat-button
-      (click)="close()"
-      type="button"
-    >
-      {{ T.G.CANCEL | translate }}
-    </button>
-  </mat-dialog-actions>
+    </mat-dialog-actions>
+  </div>
 </mat-dialog-content>

--- a/src/app/features/tasks/dialog-deadline/dialog-deadline.component.scss
+++ b/src/app/features/tasks/dialog-deadline/dialog-deadline.component.scss
@@ -10,8 +10,9 @@
   justify-content: stretch;
   align-items: stretch;
   user-select: none;
-  width: 400px;
-  max-width: 100%;
+  width: max-content;
+  min-width: min(400px, calc(100vw - var(--s4)));
+  max-width: min(560px, 100%);
   display: block;
 
   :host-context([dir='rtl']) {
@@ -27,46 +28,15 @@ mat-dialog-content {
   ) !important;
 }
 
-:host ::ng-deep mat-dialog-actions {
+mat-dialog-actions {
   padding: 0 0 var(--s2) 0 !important;
+  row-gap: calc(var(--s) + var(--s-half));
 }
 
 .dialog-actions-and-warnings {
   margin: 0 var(--s2) var(--s2);
 }
 
-.deadline-actions {
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
-  width: 100%;
-  margin: 0 auto;
-  padding-bottom: var(--s);
-}
-
-.deadline-actions button {
-  flex: 1 1 0;
-  min-width: 0;
-  max-width: 100%;
-  height: auto;
-  min-height: 38px;
-  white-space: normal;
-  overflow-wrap: anywhere;
-  text-align: center;
-}
-
-.deadline-actions button:not(:last-child) {
-  margin-right: var(--s-quarter);
-}
-
-.dialog-cancel-btn {
-  display: block;
-  width: 100%;
-}
-
-.deadline-actions button,
-.dialog-cancel-btn {
-  white-space: normal;
-  overflow-wrap: anywhere;
-  text-align: center;
+.action-label {
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

- replace the fixed two-tier action layouts in the Schedule and Deadline dialogs with native Material dialog actions that wrap as whole buttons
- use the logical action order Cancel → Unschedule/Remove → primary, preserving keyboard order and automatic RTL mirroring
- let the dialogs grow responsively before wrapping, keep translated labels intact, and align the Deadline footer inset with Schedule
- add a regression test for action order, intact labels, wrapping, and horizontal overflow

## Why

The previous nested equal-width button rows forced longer translated labels to break inside buttons and placed Cancel on a separate full-width row. This produced an awkward layout and differed from the action order used by other dialogs.

The new layout keeps Material's end-aligned action behavior while allowing complete buttons to reflow when three translated actions cannot fit safely on one row.

## Validation

- `npm run checkFile` passed for all five changed HTML, SCSS, and TypeScript files
- Schedule dialog focused tests: 14/14 passed
- Deadline dialog focused tests: 10/10 passed
- Angular development build completed successfully
- manually verified at 320px and 768px in LTR and Arabic RTL: no clipping, horizontal overflow, or action overlap; labels remain on one line and whole buttons wrap with consistent spacing
