### PR TITLE
fix(onboarding): improve productivity preset and mobile first-task flow

### DIFF
--- a/e2e/fixtures/test.fixture.ts
+++ b/e2e/fixtures/test.fixture.ts
@@ -38,12 +38,12 @@ export const test = base.extend<TestFixtures>({
   // We use Playwright's merged `contextOptions` fixture so future option additions
   // propagate automatically instead of requiring this list to stay in sync by hand.
   isolatedContext: async (
-    { browser, contextOptions, baseURL, actionTimeout, navigationTimeout },
+    { browser, contextOptions, userAgent, baseURL, actionTimeout, navigationTimeout },
     use,
     testInfo,
   ) => {
     const url = baseURL || testInfo.project.use.baseURL || 'http://localhost:4242';
-    const baseUserAgent = contextOptions.userAgent ?? 'PLAYWRIGHT';
+    const baseUserAgent = userAgent ?? contextOptions.userAgent ?? 'PLAYWRIGHT';
 
     const context = await browser.newContext({
       ...contextOptions,

--- a/e2e/tests/onboarding/onboarding-preset.spec.ts
+++ b/e2e/tests/onboarding/onboarding-preset.spec.ts
@@ -1,17 +1,18 @@
 import { expect, test } from '../../fixtures/test.fixture';
+import { devices } from '@playwright/test';
 import {
   assertNoRuntimeBrowserErrors,
   attachPageErrorCollector,
   installDevErrorDialogHandler,
 } from '../../utils/runtime-errors';
 import { waitForStatePersistence } from '../../utils/waits';
-import { WorkViewPage } from '../../pages/work-view.page';
 
 test.describe('First-run onboarding', () => {
   test('applies a preset and does not show onboarding again after reload', async ({
     isolatedContext,
   }) => {
     const page = await isolatedContext.newPage();
+    await page.setViewportSize({ width: 599, height: 800 });
     const runtimeErrors = attachPageErrorCollector(page, 'onboarding');
     installDevErrorDialogHandler(page, 'onboarding');
 
@@ -30,7 +31,14 @@ test.describe('First-run onboarding', () => {
     ).toBe('true');
 
     const taskTitle = `Simple Todo preset ${Date.now()}`;
-    await new WorkViewPage(page).addTask(taskTitle);
+    await page.getByRole('button', { name: 'Add new task' }).click();
+    const input = page.locator('add-task-bar.global .main-input');
+    await input.fill(taskTitle);
+    await input.press('Enter');
+    await expect(page.locator('add-task-bar.global')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('add-task-bar.global')).toBeHidden();
+    await page.setViewportSize({ width: 1280, height: 720 });
     const task = page.locator('task').filter({ hasText: taskTitle }).first();
     await expect(task).toBeVisible();
     await task.hover();
@@ -47,5 +55,47 @@ test.describe('First-run onboarding', () => {
     await expect(reloadedTask.locator('.start-task-btn')).toHaveCount(0);
     assertNoRuntimeBrowserErrors(runtimeErrors, 'onboarding');
     await page.close();
+  });
+
+  test('closes the mobile composer after the first onboarding task', async ({
+    baseURL,
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      ...devices['Pixel 5'],
+      baseURL: baseURL ?? 'http://localhost:4242',
+      storageState: undefined,
+    });
+    const page = await context.newPage();
+    const runtimeErrors = attachPageErrorCollector(page, 'mobile onboarding');
+    installDevErrorDialogHandler(page, 'mobile onboarding');
+
+    await page.addInitScript(() => {
+      localStorage.setItem('SUP_EXAMPLE_TASKS_CREATED', 'true');
+    });
+
+    try {
+      await page.goto('/');
+
+      const onboarding = page.locator('onboarding-preset-selection');
+      await onboarding.getByRole('button', { name: /Simple Todo/ }).tap();
+      await expect(onboarding).toBeHidden();
+      await expect(page.locator('onboarding-hint')).toContainText(
+        'Tap + to add your first task',
+      );
+
+      await page.getByRole('button', { name: 'Add new task' }).tap();
+      const input = page.locator('add-task-bar.global .main-input');
+      await input.fill('My first mobile task');
+      await input.press('Enter');
+
+      await expect(page.locator('add-task-bar.global')).toBeHidden();
+      await expect(page.locator('onboarding-hint')).toContainText(
+        'Tap a task to open its details.',
+      );
+      assertNoRuntimeBrowserErrors(runtimeErrors, 'mobile onboarding');
+    } finally {
+      await context.close();
+    }
   });
 });

--- a/e2e/tests/onboarding/onboarding-preset.spec.ts
+++ b/e2e/tests/onboarding/onboarding-preset.spec.ts
@@ -7,6 +7,10 @@ import {
 } from '../../utils/runtime-errors';
 import { waitForStatePersistence } from '../../utils/waits';
 
+const pixel5TestOptions = { ...devices['Pixel 5'] };
+// Browser type is worker-scoped and cannot be overridden inside a describe block.
+Reflect.deleteProperty(pixel5TestOptions, 'defaultBrowserType');
+
 test.describe('First-run onboarding', () => {
   test('applies a preset and does not show onboarding again after reload', async ({
     isolatedContext,
@@ -57,25 +61,24 @@ test.describe('First-run onboarding', () => {
     await page.close();
   });
 
-  test('closes the mobile composer after the first onboarding task', async ({
-    baseURL,
-    browser,
-  }) => {
-    const context = await browser.newContext({
-      ...devices['Pixel 5'],
-      baseURL: baseURL ?? 'http://localhost:4242',
-      storageState: undefined,
-    });
-    const page = await context.newPage();
-    const runtimeErrors = attachPageErrorCollector(page, 'mobile onboarding');
-    installDevErrorDialogHandler(page, 'mobile onboarding');
+  test.describe('mobile', () => {
+    test.use(pixel5TestOptions);
 
-    await page.addInitScript(() => {
-      localStorage.setItem('SUP_EXAMPLE_TASKS_CREATED', 'true');
-    });
+    test('closes the composer after the first onboarding task', async ({
+      isolatedContext,
+    }) => {
+      const page = await isolatedContext.newPage();
+      const runtimeErrors = attachPageErrorCollector(page, 'mobile onboarding');
+      installDevErrorDialogHandler(page, 'mobile onboarding');
 
-    try {
+      await page.addInitScript(() => {
+        localStorage.setItem('SUP_EXAMPLE_TASKS_CREATED', 'true');
+      });
+
       await page.goto('/');
+      const userAgent = await page.evaluate(() => navigator.userAgent);
+      expect(userAgent).toContain('Pixel 5');
+      expect(userAgent).toContain('PLAYWRIGHT-WORKER-');
 
       const onboarding = page.locator('onboarding-preset-selection');
       await onboarding.getByRole('button', { name: /Simple Todo/ }).tap();
@@ -94,8 +97,54 @@ test.describe('First-run onboarding', () => {
         'Tap a task to open its details.',
       );
       assertNoRuntimeBrowserErrors(runtimeErrors, 'mobile onboarding');
-    } finally {
-      await context.close();
-    }
+      await page.close();
+    });
+
+    test('keeps the composer open after a later touch task', async ({
+      isolatedContext,
+    }) => {
+      const page = await isolatedContext.newPage();
+      const runtimeErrors = attachPageErrorCollector(page, 'hybrid onboarding');
+      installDevErrorDialogHandler(page, 'hybrid onboarding');
+
+      await page.addInitScript(() => {
+        localStorage.setItem('SUP_EXAMPLE_TASKS_CREATED', 'true');
+      });
+
+      await page.goto('/');
+
+      const onboarding = page.locator('onboarding-preset-selection');
+      await onboarding.getByRole('button', { name: /Simple Todo/ }).tap();
+      await expect(onboarding).toBeHidden();
+      await expect(page.locator('onboarding-hint')).toContainText(
+        'Tap + to add your first task',
+      );
+
+      await page.mouse.move(10, 10);
+      await expect(page.locator('body')).toHaveClass(/isMousePrimary/);
+      await page.getByRole('button', { name: 'Add new task' }).click();
+
+      const composer = page.locator('add-task-bar.global');
+      const input = composer.locator('.main-input');
+      await input.fill('First hybrid task');
+      await input.press('Enter');
+      await expect(composer).toBeVisible();
+
+      // Switch intent before the real submit tap so the touch layout has settled.
+      await page.locator('body').dispatchEvent('pointerdown', {
+        pointerType: 'touch',
+      });
+      await expect(page.locator('body')).toHaveClass(/isTouchPrimary/);
+      await expect(composer).toBeVisible();
+
+      await input.fill('Second hybrid task');
+      await composer.locator('.e2e-add-task-submit').tap();
+      await expect(composer).toBeVisible();
+
+      await input.press('Escape');
+      await expect(composer).toBeHidden();
+      assertNoRuntimeBrowserErrors(runtimeErrors, 'hybrid onboarding');
+      await page.close();
+    });
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -429,6 +429,9 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   onTaskAdded({ taskId }: { taskId: string; isAddToBottom: boolean }): void {
     this.layoutService.setPendingFocusTaskId(taskId);
     this.layoutService.scrollToNewTask(taskId);
+    if (this.onboardingHintService.shouldAutoCloseFirstTaskComposer()) {
+      this.layoutService.hideAddTaskBar(taskId);
+    }
   }
 
   // Opacity + blur follow the resolved background source (per-context image or

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -429,7 +429,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   onTaskAdded({ taskId }: { taskId: string; isAddToBottom: boolean }): void {
     this.layoutService.setPendingFocusTaskId(taskId);
     this.layoutService.scrollToNewTask(taskId);
-    if (this.onboardingHintService.shouldAutoCloseFirstTaskComposer()) {
+    if (this.onboardingHintService.shouldAutoCloseFirstTaskComposer(taskId)) {
       this.layoutService.hideAddTaskBar(taskId);
     }
   }

--- a/src/app/features/onboarding/onboarding-hint.service.ts
+++ b/src/app/features/onboarding/onboarding-hint.service.ts
@@ -39,6 +39,7 @@ export class OnboardingHintService {
   private _taskFocusService = inject(TaskFocusService);
   private _store = inject(Store);
   private _isStarted = false;
+  private _firstTaskIdForComposerAutoClose: string | null = null;
   private _waitingForBarClose = false;
   private _waitingForTaskPanelClose = false;
   private _waitingForTaskContextMenuClose = false;
@@ -126,17 +127,20 @@ export class OnboardingHintService {
     this._startOnboarding();
   }
 
-  shouldAutoCloseFirstTaskComposer(): boolean {
-    return (
+  shouldAutoCloseFirstTaskComposer(taskId: string): boolean {
+    const shouldAutoClose =
+      taskId === this._firstTaskIdForComposerAutoClose &&
       this._waitingForBarClose &&
       isTouchActive() &&
-      this._layoutService.isShowMobileBottomNav()
-    );
+      this._layoutService.isShowMobileBottomNav();
+    this._firstTaskIdForComposerAutoClose = null;
+    return shouldAutoClose;
   }
 
   skip(): void {
     localStorage.setItem(LS.ONBOARDING_HINTS_DONE, 'true');
     this.currentStep.set(null);
+    this._firstTaskIdForComposerAutoClose = null;
     this._waitingForBarClose = false;
     this._waitingForTaskPanelClose = false;
     this._waitingForTaskContextMenuClose = false;
@@ -172,8 +176,9 @@ export class OnboardingHintService {
   private _listenForTaskCreation(): void {
     this._listenSub = this._actions$
       .pipe(ofType(TaskSharedActions.addTask), first())
-      .subscribe(() => {
+      .subscribe(({ task }) => {
         this._listenSub?.unsubscribe();
+        this._firstTaskIdForComposerAutoClose = task.id;
         this._waitingForBarClose = true;
         // If the bar is already closed (e.g. keyboard shortcut), start the delay now
         if (!this._layoutService.isShowAddTaskBar()) {

--- a/src/app/features/onboarding/onboarding-hint.service.ts
+++ b/src/app/features/onboarding/onboarding-hint.service.ts
@@ -126,6 +126,14 @@ export class OnboardingHintService {
     this._startOnboarding();
   }
 
+  shouldAutoCloseFirstTaskComposer(): boolean {
+    return (
+      this._waitingForBarClose &&
+      isTouchActive() &&
+      this._layoutService.isShowMobileBottomNav()
+    );
+  }
+
   skip(): void {
     localStorage.setItem(LS.ONBOARDING_HINTS_DONE, 'true');
     this.currentStep.set(null);

--- a/src/app/features/onboarding/onboarding-presets.const.spec.ts
+++ b/src/app/features/onboarding/onboarding-presets.const.spec.ts
@@ -1,0 +1,11 @@
+import { ONBOARDING_PRESETS } from './onboarding-presets.const';
+
+describe('ONBOARDING_PRESETS', () => {
+  it('enables Finish Day for the Productivity Suite preset', () => {
+    const productivitySuite = ONBOARDING_PRESETS.find(
+      (preset) => preset.id === 'productivity-pro',
+    );
+
+    expect(productivitySuite?.features.isFinishDayEnabled).toBeTrue();
+  });
+});

--- a/src/app/features/onboarding/onboarding-presets.const.ts
+++ b/src/app/features/onboarding/onboarding-presets.const.ts
@@ -67,6 +67,7 @@ export const ONBOARDING_PRESETS: OnboardingPreset[] = [
       isIssuesPanelEnabled: true,
       isProjectNotesEnabled: true,
       isHabitsEnabled: true,
+      isFinishDayEnabled: true,
     },
   },
 ];


### PR DESCRIPTION
## Summary

- enable **Finish Day** for the Productivity Suite onboarding preset
- close the mobile task composer after the first onboarding task so the tour can advance
- scope that auto-close to the captured first task, preserving the composer for later tasks and hybrid mouse/touch input
- add focused unit and mobile E2E coverage, including correct mobile user-agent handling in isolated contexts

## Root cause

The Productivity Suite preset did not opt into `isFinishDayEnabled`, so applying the preset disabled Finish Day. On mobile, onboarding waited for the task composer to close before showing the next hint but did not close it after the first task. The close decision also needs to be tied to the exact first task so a later touch-created task cannot be mistaken for it after input intent changes.

## User impact

New users choosing Productivity Suite keep access to Finish Day. On touch/mobile devices, creating the first task now reveals the next onboarding step immediately, while subsequent task creation keeps the composer open as expected.

## Validation

- `npm run test:file src/app/features/onboarding/onboarding-presets.const.spec.ts` — 1 passed
- `npm run e2e:file e2e/tests/onboarding/onboarding-preset.spec.ts -- --retries=0` — 3 passed
- `npm run checkFile -- <modified TypeScript file>` — passed for all modified TypeScript files
- `git diff --check` — passed
- independent review — no findings
