### PR TITLE
fix(tasks): delete sub-tasks via keyboard shortcut (#9280)

### DIFF
--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -333,6 +333,21 @@ describe('TaskService', () => {
       expect(clearOneSpy).toHaveBeenCalledWith('task-1');
       expect(clearOneSpy).toHaveBeenCalledWith('subtask-1');
     });
+
+    // Regression: deleting a sub-task via keyboard shortcut (Backspace) passes the
+    // raw Task entity, which has no `subTasks` array — remove() must not throw. #9280
+    it('should still dispatch when removing a sub-task without a subTasks array', () => {
+      const clearOneSpy = spyOn(taskTimeSync, 'clearOne');
+      const subTask = createMockTask('subtask-1', {
+        parentId: 'task-1',
+      }) as TaskWithSubTasks;
+
+      expect(() => service.remove(subTask)).not.toThrow();
+      expect(store.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.deleteTask({ task: subTask }),
+      );
+      expect(clearOneSpy).toHaveBeenCalledWith('subtask-1');
+    });
   });
 
   describe('removeMultipleTasks', () => {

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -477,7 +477,9 @@ export class TaskService {
 
   remove(task: TaskWithSubTasks): void {
     this._taskTimeSync.clearOne(task.id);
-    task.subTasks.forEach((subTask) => this._taskTimeSync.clearOne(subTask.id));
+    // Clear via subTaskIds (always present) not subTasks: the keyboard-delete path
+    // passes a raw Task entity whose subTasks array is undefined (see #9280).
+    task.subTaskIds.forEach((id) => this._taskTimeSync.clearOne(id));
     this._store.dispatch(TaskSharedActions.deleteTask({ task }));
   }
 


### PR DESCRIPTION
Fixes #9280

## Problem

Deleting a **sub-task** with the <kbd>Backspace</kbd> keyboard shortcut did nothing: the confirm dialog appeared, focus moved away, and the prompt stopped re-appearing — but the sub-task was never removed and reappeared after navigating away and back. Deleting the same sub-task via the right-click context menu worked fine.

## Root cause

`TaskService.remove()` was changed in #8979 (shipped in v18.15.0 / v18.15.1) to clear pending time-sync buffers for the task and its sub-tasks:

```ts
task.subTasks.forEach((subTask) => this._taskTimeSync.clearOne(subTask.id));
```

This assumes `task.subTasks` is always defined. On the keyboard path (`task-shortcut.service` → `TaskComponent.deleteTask()` → `_performDelete()` → `remove(this.task())`), a sub-task is a **raw `Task` entity** produced by `mapSubTasksToTask` (which pushes bare `s.entities[id]` objects). A plain `Task` has no `subTasks` field — only `TaskWithSubTasks` adds it — so `task.subTasks.forEach` threw `TypeError: Cannot read properties of undefined (reading 'forEach')` **before** `this._store.dispatch(deleteTask(...))`, so the delete never dispatched.

The context-menu path works because it first re-maps to a full `TaskWithSubTasks` via `selectTaskByIdWithSubTaskData`, so `subTasks` is `[]`, not `undefined`. `_performDelete()` also sets `_isTaskDeleteTriggered = true` and calls `focusNext()` before `remove()`, which is why the prompt stopped re-appearing and focus moved despite nothing being deleted.

## Fix

Clear pending time via **`subTaskIds`** — a required base-`Task` field (`DEFAULT_TASK.subTaskIds: []`, always present) — instead of the runtime-optional `subTasks` array:

```ts
task.subTaskIds.forEach((id) => this._taskTimeSync.clearOne(id));
```

This structurally avoids the crash (the boundary no longer depends on the field that isn't reliably present) rather than merely guarding it, and matches how the downstream reducer (`deleteTaskHelper` / `handleDeleteTask`) already sources its removal set. `clearOne` is a `Map.delete`, so it's a safe no-op for any orphan IDs. The dispatched payload is unchanged, so there is no sync/op-log impact and no schema bump.

## Test

Adds a regression unit test that deletes a sub-task with no `subTasks` array — it throws the `TypeError` without the fix and passes with it. Full `task.service.spec.ts` suite green (72/72).
