### PR TITLE
fix(tasks): restore archived tasks to Today (#9263)

### DIFF
--- a/e2e/tests/task-list-basic/finish-day-quick-history-with-subtasks.spec.ts
+++ b/e2e/tests/task-list-basic/finish-day-quick-history-with-subtasks.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../fixtures/test.fixture';
 import type { Locator } from '@playwright/test';
+import { waitForStatePersistence } from '../../utils/waits';
 
 const TASK_SEL = 'task';
 const TASK_TITLE = 'task task-title';
@@ -18,10 +19,12 @@ const markTaskAsDone = async (task: Locator): Promise<void> => {
 test.describe('Finish Day Quick History With Subtasks', () => {
   test('should complete full finish day flow with subtasks', async ({
     page,
+    dialogPage,
+    taskPage,
     workViewPage,
     testPrefix,
   }) => {
-    test.setTimeout(60000); // Increase timeout for this long flow
+    test.setTimeout(90000); // Increase timeout for this long flow
     // Wait for work view to be ready
     await workViewPage.waitForTaskList();
 
@@ -94,5 +97,33 @@ test.describe('Finish Day Quick History With Subtasks', () => {
     await expect(rows.nth(0)).toContainText(parentTitle);
     await expect(rows.nth(1)).toContainText(firstSubtaskTitle);
     await expect(rows.nth(2)).toContainText(secondSubtaskTitle);
+
+    // Step 9: Restore the parent through the real History action
+    await page.getByRole('button', { name: 'Restore task from archive' }).first().click();
+    await dialogPage.waitForDialog();
+    await Promise.all([
+      page.waitForURL(/#\/tag\/TODAY\/tasks/, { timeout: 15000 }),
+      dialogPage.clickDialogButton('Do it!'),
+    ]);
+
+    const expectRestoredHierarchy = async (): Promise<void> => {
+      const restoredParent = taskPage.getTaskByText(parentTitle).first();
+      await expect(restoredParent).toBeVisible();
+      const restoredSubTasks = taskPage.getSubTasks(restoredParent);
+      await expect(restoredSubTasks).toHaveCount(2);
+      await expect(
+        restoredSubTasks.locator('task-title').filter({ hasText: firstSubtaskTitle }),
+      ).toBeVisible();
+      await expect(
+        restoredSubTasks.locator('task-title').filter({ hasText: secondSubtaskTitle }),
+      ).toBeVisible();
+    };
+
+    // Step 10: Today placement and hierarchy survive persistence + reload
+    await expectRestoredHierarchy();
+    await waitForStatePersistence(page);
+    await page.reload();
+    await workViewPage.waitForTaskList();
+    await expectRestoredHierarchy();
   });
 });

--- a/src/app/features/history/history.component.spec.ts
+++ b/src/app/features/history/history.component.spec.ts
@@ -34,6 +34,7 @@ describe('HistoryComponent', () => {
   let matDialogSpy: jasmine.SpyObj<MatDialog>;
   let routerSpy: jasmine.SpyObj<Router>;
   let taskArchiveServiceSpy: jasmine.SpyObj<TaskArchiveService>;
+  let dateServiceSpy: jasmine.SpyObj<DateService>;
   let store: Store;
 
   const worklogData$ = new BehaviorSubject({
@@ -79,7 +80,7 @@ describe('HistoryComponent', () => {
       'TaskArchiveService',
       ['load'],
     );
-    const dateServiceSpy = jasmine.createSpyObj<DateService>('DateService', [
+    dateServiceSpy = jasmine.createSpyObj<DateService>('DateService', [
       'todayStr',
       'getStartOfNextDayDiffMs',
     ]);
@@ -260,5 +261,48 @@ describe('HistoryComponent', () => {
       startOfNextDayDiffMs: 0,
     });
     expect(routerSpy.navigate).toHaveBeenCalledOnceWith(['/active/tasks']);
+  }));
+
+  it('captures the logical Today after the archive load finishes', fakeAsync(() => {
+    const subTask = {
+      ...createTaskForDate('2026-01-05', 60000, true, 'subtask'),
+      parentId: 'parent',
+    };
+    const parent = {
+      ...createTaskForDate('2026-01-05', 60000, true, 'parent'),
+      subTaskIds: [subTask.id],
+    };
+    let resolveArchiveLoad!: (
+      archive: Awaited<ReturnType<TaskArchiveService['load']>>,
+    ) => void;
+    taskArchiveServiceSpy.load.and.returnValue(
+      new Promise((resolve) => {
+        resolveArchiveLoad = resolve;
+      }),
+    );
+    matDialogSpy.open.and.returnValue({
+      afterClosed: () => of(true),
+    } as ReturnType<MatDialog['open']>);
+
+    fixture.componentInstance.restoreTask(parent);
+    flushMicrotasks();
+
+    dateServiceSpy.todayStr.and.returnValue('2026-01-06');
+    dateServiceSpy.getStartOfNextDayDiffMs.and.returnValue(60 * 60 * 1000);
+    resolveArchiveLoad({
+      ids: [parent.id, subTask.id],
+      entities: {
+        [parent.id]: parent,
+        [subTask.id]: subTask,
+      },
+    });
+    flushMicrotasks();
+
+    const action = (store.dispatch as jasmine.Spy).calls.mostRecent()
+      .args[0] as ReturnType<typeof TaskSharedActions.restoreTask>;
+    expect(action.restoreToToday).toEqual({
+      today: '2026-01-06',
+      startOfNextDayDiffMs: 60 * 60 * 1000,
+    });
   }));
 });

--- a/src/app/features/history/history.component.spec.ts
+++ b/src/app/features/history/history.component.spec.ts
@@ -1,12 +1,19 @@
 import { ChangeDetectorRef } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flushMicrotasks,
+  TestBed,
+} from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
+import { MatDialog } from '@angular/material/dialog';
 
 import { TranslateModule } from '@ngx-translate/core';
 import { provideMockStore } from '@ngrx/store/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
+import { Store } from '@ngrx/store';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { Worklog } from '../worklog/worklog.model';
@@ -19,9 +26,15 @@ import { TaskService } from '../tasks/task.service';
 import { Task } from '../tasks/task.model';
 import { selectAllProjectColorsAndTitles } from '../project/store/project.selectors';
 import { mapArchiveToWorklog } from '../worklog/util/map-archive-to-worklog';
+import { DateService } from '../../core/date/date.service';
+import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 
 describe('HistoryComponent', () => {
   let fixture: ComponentFixture<HistoryComponent>;
+  let matDialogSpy: jasmine.SpyObj<MatDialog>;
+  let routerSpy: jasmine.SpyObj<Router>;
+  let taskArchiveServiceSpy: jasmine.SpyObj<TaskArchiveService>;
+  let store: Store;
 
   const worklogData$ = new BehaviorSubject({
     worklog: {} as Worklog,
@@ -60,6 +73,18 @@ describe('HistoryComponent', () => {
     const worklogServiceSpy = jasmine.createSpyObj<WorklogService>('WorklogService', [], {
       worklogData$,
     });
+    matDialogSpy = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    taskArchiveServiceSpy = jasmine.createSpyObj<TaskArchiveService>(
+      'TaskArchiveService',
+      ['load'],
+    );
+    const dateServiceSpy = jasmine.createSpyObj<DateService>('DateService', [
+      'todayStr',
+      'getStartOfNextDayDiffMs',
+    ]);
+    dateServiceSpy.todayStr.and.returnValue('2026-01-05');
+    dateServiceSpy.getStartOfNextDayDiffMs.and.returnValue(0);
     worklogData$.next({
       worklog: {} as Worklog,
       totalTimeSpent: 0,
@@ -80,8 +105,11 @@ describe('HistoryComponent', () => {
         provideMockActions(of()),
         provideNoopAnimations(),
         { provide: ActivatedRoute, useValue: activatedRouteSpy },
-        { provide: TaskArchiveService, useValue: {} },
+        { provide: MatDialog, useValue: matDialogSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: TaskArchiveService, useValue: taskArchiveServiceSpy },
         { provide: TaskService, useValue: {} },
+        { provide: DateService, useValue: dateServiceSpy },
         { provide: WorkContextService, useValue: {} },
         { provide: SimpleCounterService, useValue: { enabledSimpleCounters$: of([]) } },
         { provide: WorklogService, useValue: worklogServiceSpy },
@@ -89,6 +117,8 @@ describe('HistoryComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(HistoryComponent);
+    store = TestBed.inject(Store);
+    spyOn(store, 'dispatch');
     fixture.detectChanges();
   });
 
@@ -168,4 +198,67 @@ describe('HistoryComponent', () => {
 
     expect(dayLabels).toEqual(['Wed 1.', 'Thu 2.', 'Fri 3.']);
   });
+
+  it('explicitly restores the archived hierarchy to Today once', fakeAsync(() => {
+    const subTask1 = {
+      ...createTaskForDate('2026-01-05', 60000, true, 'subtask1'),
+      parentId: 'parent',
+      dueDay: '2025-12-30',
+      dueWithTime: new Date('2025-12-30T10:00:00Z').getTime(),
+      remindAt: new Date('2025-12-30T09:55:00Z').getTime(),
+    };
+    const subTask2 = {
+      ...createTaskForDate('2026-01-05', 60000, true, 'subtask2'),
+      parentId: 'parent',
+    };
+    const parent = {
+      ...createTaskForDate('2026-01-05', 60000, true, 'parent'),
+      dueWithTime: new Date('2025-12-30T12:00:00Z').getTime(),
+      remindAt: new Date('2025-12-30T12:00:00Z').getTime(),
+      subTaskIds: [subTask1.id, subTask2.id],
+    };
+    matDialogSpy.open.and.returnValue({
+      afterClosed: () => of(true),
+    } as ReturnType<MatDialog['open']>);
+    taskArchiveServiceSpy.load.and.resolveTo({
+      ids: [parent.id, subTask1.id, subTask2.id],
+      entities: {
+        [parent.id]: parent,
+        [subTask1.id]: subTask1,
+        [subTask2.id]: subTask2,
+      },
+    });
+
+    fixture.componentInstance.restoreTask(parent);
+    flushMicrotasks();
+
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+    const action = (store.dispatch as jasmine.Spy).calls.mostRecent()
+      .args[0] as ReturnType<typeof TaskSharedActions.restoreTask>;
+    expect(action.task).toEqual({
+      ...parent,
+      dueDay: '2026-01-05',
+      dueWithTime: undefined,
+      remindAt: undefined,
+    });
+    expect(action.subTasks).toEqual([
+      {
+        ...subTask1,
+        dueDay: undefined,
+        dueWithTime: undefined,
+        remindAt: undefined,
+      },
+      {
+        ...subTask2,
+        dueDay: undefined,
+        dueWithTime: undefined,
+        remindAt: undefined,
+      },
+    ]);
+    expect(action.restoreToToday).toEqual({
+      today: '2026-01-05',
+      startOfNextDayDiffMs: 0,
+    });
+    expect(routerSpy.navigate).toHaveBeenCalledOnceWith(['/active/tasks']);
+  }));
 });

--- a/src/app/features/history/history.component.ts
+++ b/src/app/features/history/history.component.ts
@@ -33,6 +33,8 @@ import { Log } from '../../core/log';
 import { DialogViewArchivedTaskComponent } from '../tasks/dialog-view-archived-task/dialog-view-archived-task.component';
 import { WorklogTaskRowComponent } from '../worklog/worklog-task-row/worklog-task-row.component';
 import { HistoryDayMetaComponent } from './history-day-meta/history-day-meta.component';
+import { DateService } from '../../core/date/date.service';
+import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 
 @Component({
   selector: 'history',
@@ -65,6 +67,7 @@ export class HistoryComponent {
   private readonly _route = inject(ActivatedRoute);
   private readonly _store = inject(Store);
   private readonly _taskArchiveService = inject(TaskArchiveService);
+  private readonly _dateService = inject(DateService);
   private readonly _queryParams = toSignal(this._route.queryParams, {
     initialValue: this._route.snapshot.queryParams,
   });
@@ -146,6 +149,10 @@ export class HistoryComponent {
       .subscribe(async (isConfirm: boolean) => {
         // because we navigate away we don't need to worry about updating the worklog itself
         if (isConfirm) {
+          const restoreToToday = {
+            today: this._dateService.todayStr(),
+            startOfNextDayDiffMs: this._dateService.getStartOfNextDayDiffMs(),
+          };
           let subTasks: Task[] | undefined;
           if (task.subTaskIds && task.subTaskIds.length) {
             const archiveState = await this._taskArchiveService.load();
@@ -155,7 +162,13 @@ export class HistoryComponent {
           }
 
           Log.log('RESTORE', { taskId: task.id, subTaskCount: subTasks?.length });
-          this._taskService.restoreTask(task, subTasks || []);
+          this._store.dispatch(
+            TaskSharedActions.restoreTask({
+              task,
+              subTasks: subTasks || [],
+              restoreToToday,
+            }),
+          );
           this._router.navigate(['/active/tasks']);
         }
       });

--- a/src/app/features/history/history.component.ts
+++ b/src/app/features/history/history.component.ts
@@ -149,10 +149,6 @@ export class HistoryComponent {
       .subscribe(async (isConfirm: boolean) => {
         // because we navigate away we don't need to worry about updating the worklog itself
         if (isConfirm) {
-          const restoreToToday = {
-            today: this._dateService.todayStr(),
-            startOfNextDayDiffMs: this._dateService.getStartOfNextDayDiffMs(),
-          };
           let subTasks: Task[] | undefined;
           if (task.subTaskIds && task.subTaskIds.length) {
             const archiveState = await this._taskArchiveService.load();
@@ -160,6 +156,10 @@ export class HistoryComponent {
               .map((id) => archiveState.entities[id])
               .filter((t): t is Task => !!t);
           }
+          const restoreToToday = {
+            today: this._dateService.todayStr(),
+            startOfNextDayDiffMs: this._dateService.getStartOfNextDayDiffMs(),
+          };
 
           Log.log('RESTORE', { taskId: task.id, subTaskCount: subTasks?.length });
           this._store.dispatch(

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -7252,6 +7252,47 @@ describe('ConflictResolutionService', () => {
       expect(result[0].payload).toBe(archivePayload);
     });
 
+    it('should not convert a winning remote restore when local DELETE exists', () => {
+      const restorePayload = {
+        actionPayload: {
+          task: {
+            id: 'task-1',
+            title: 'Restored task',
+            subTaskIds: ['subtask-1'],
+          },
+          subTasks: [
+            {
+              id: 'subtask-1',
+              title: 'Restored subtask',
+              parentId: 'task-1',
+            },
+          ],
+        },
+        entityChanges: [],
+      };
+      const remoteRestore = {
+        ...createOpWithTimestamp('remote-restore', 'client-b', Date.now()),
+        actionType: ActionType.TASK_SHARED_RESTORE,
+        opType: OpType.Update,
+        payload: restorePayload,
+      };
+      const conflict = createConflict(
+        'task-1',
+        [
+          {
+            ...createOpWithTimestamp('local-del', 'client-a', Date.now() - 1000),
+            opType: OpType.Delete,
+            payload: { task: { id: 'task-1', title: 'Deleted task' } },
+          },
+        ],
+        [remoteRestore],
+      );
+
+      const result = (service as any)._convertToLWWUpdatesIfNeeded(conflict);
+
+      expect(result).toEqual([remoteRestore]);
+    });
+
     it('should return remote op unchanged when base entity cannot be extracted', () => {
       // Rewriting actionType to LWW Update with an unmerged NgRx UPDATE payload
       // would no-op at the consumer (lwwUpdateMetaReducer bails when entityData

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -2523,11 +2523,12 @@ export class ConflictResolutionService {
   }
 
   /**
-   * Creates a new UPDATE operation to sync local state when local wins LWW.
+   * Creates a replacement operation to sync local state when local wins LWW.
    *
    * The new operation has:
    * - Fresh UUIDv7 ID
-   * - Current entity state from NgRx store
+   * - The original semantic restore payload for the exact restore-vs-delete case,
+   *   otherwise the current entity state from NgRx store
    * - Merged vector clock (local + remote) + increment
    * - Preserved maximum timestamp from local ops (for correct LWW semantics)
    *
@@ -2537,6 +2538,53 @@ export class ConflictResolutionService {
   private async _createLocalWinUpdateOp(
     conflict: EntityConflict,
   ): Promise<Operation | undefined> {
+    const [semanticRestoreOp] = conflict.localOps;
+    const [remoteDeleteOp] = conflict.remoteOps;
+    const remoteDeleteIds = remoteDeleteOp ? getOpEntityIds(remoteDeleteOp) : [];
+    // Mixed histories need the generic snapshot path so a stale restore payload
+    // cannot overwrite a later local edit or compensate for unrelated deletes.
+    if (
+      conflict.entityType === 'TASK' &&
+      conflict.localOps.length === 1 &&
+      conflict.remoteOps.length === 1 &&
+      semanticRestoreOp?.actionType === ActionType.TASK_SHARED_RESTORE &&
+      semanticRestoreOp.opType === OpType.Update &&
+      semanticRestoreOp.entityType === 'TASK' &&
+      semanticRestoreOp.entityId === conflict.entityId &&
+      remoteDeleteOp?.opType === OpType.Delete &&
+      remoteDeleteOp.entityType === 'TASK' &&
+      remoteDeleteIds.length === 1 &&
+      remoteDeleteIds[0] === conflict.entityId
+    ) {
+      const clientId = await this.clientIdProvider.loadClientId();
+      if (!clientId) {
+        OpLog.err(
+          'ConflictResolutionService: Cannot create restore-win op - no client ID',
+        );
+        return undefined;
+      }
+
+      return {
+        id: uuidv7(),
+        actionType: semanticRestoreOp.actionType,
+        opType: semanticRestoreOp.opType,
+        entityType: semanticRestoreOp.entityType,
+        entityId: semanticRestoreOp.entityId,
+        entityIds: semanticRestoreOp.entityIds,
+        payload: semanticRestoreOp.payload,
+        clientId,
+        vectorClock: this.mergeAndIncrementClocks(
+          [
+            ...conflict.localOps.map((op) => op.vectorClock),
+            ...conflict.remoteOps.map((op) => op.vectorClock),
+          ],
+          clientId,
+        ),
+        timestamp: semanticRestoreOp.timestamp,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      };
+    }
+
     // Get current entity state from store
     let entityState = await this.getCurrentEntityState(
       conflict.entityType,

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -3479,17 +3479,10 @@ export class ConflictResolutionService {
   }
 
   /**
-   * Converts remote UPDATE operations to LWW Update format when entity was deleted locally.
+   * Makes winning remote updates recreate entities deleted locally.
    *
-   * When a local DELETE loses to a remote UPDATE via LWW, the entity is already deleted
-   * from the local store. Regular UPDATE operations can't recreate deleted entities -
-   * only LWW Update operations can (via lwwUpdateMetaReducer).
-   *
-   * This method detects DELETE vs UPDATE conflicts and converts the winning remote UPDATE
-   * to LWW Update format by changing its actionType to '[ENTITY_TYPE] LWW Update'.
-   *
-   * @param conflict - The entity conflict being resolved
-   * @returns Remote operations, with UPDATEs converted to LWW Updates if needed
+   * Generic updates become LWW snapshots. Archive/restore actions already recreate
+   * state and retain their type so archive side effects receive the semantic payload.
    */
   private _convertToLWWUpdatesIfNeeded(conflict: EntityConflict): Operation[] {
     // Check if local side has a DELETE operation
@@ -3501,7 +3494,9 @@ export class ConflictResolutionService {
     }
 
     const convertibleRemoteOps = conflict.remoteOps.filter(
-      (op) => op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+      (op) =>
+        op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
+        op.actionType !== ActionType.TASK_SHARED_RESTORE,
     );
     if (convertibleRemoteOps.length === 0) {
       return conflict.remoteOps;

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -2541,8 +2541,18 @@ export class ConflictResolutionService {
     const [semanticRestoreOp] = conflict.localOps;
     const [remoteDeleteOp] = conflict.remoteOps;
     const remoteDeleteIds = remoteDeleteOp ? getOpEntityIds(remoteDeleteOp) : [];
-    // Mixed histories need the generic snapshot path so a stale restore payload
-    // cannot overwrite a later local edit or compensate for unrelated deletes.
+    // Only re-emit the semantic restore for the exact 1-restore-vs-1-single-entity-
+    // delete shape. Mixed histories need the generic snapshot path so a stale restore
+    // payload cannot overwrite a later local edit or compensate for unrelated deletes.
+    //
+    // Consequence, scoped to #9290: for a bulk `deleteTasks` (multi-`entityIds`) or any
+    // multi-op history the guard fails, and the generic path below emits a `[TASK] LWW
+    // Update` rather than a `restoreTask` action. That still recreates the active entity,
+    // but receivers won't run archive cleanup (dispatched only by the semantic restore
+    // action, see ArchiveOperationHandler), so a stale archived copy can survive next to
+    // the active task. This matches the pre-existing behavior for those shapes — this fix
+    // deliberately covers only the common single-op path; broadening it (and the
+    // dependency that `deleteTask` stays single-entity) is tracked in #9290.
     if (
       conflict.entityType === 'TASK' &&
       conflict.localOps.length === 1 &&

--- a/src/app/op-log/testing/integration/restore-task-conflict.integration.spec.ts
+++ b/src/app/op-log/testing/integration/restore-task-conflict.integration.spec.ts
@@ -375,34 +375,89 @@ describe('restoreTask delete-conflict integration (#9263)', () => {
 
     const deleteClientProjection = restoredProjection(localState);
     expect(restoredProjection(restartedState)).toEqual(deleteClientProjection);
+  });
 
-    // Reverse delivery: the restore author receives the losing delete and
-    // persists the reconciliation operations needed for status-blind restart.
+  it('re-emits a winning local restore after a remote delete for replay and archive convergence', async () => {
     currentClientId = REMOTE_CLIENT_ID;
-    await opLogStore._clearAllDataForTesting();
-    await archiveDb.saveArchiveYoung(archiveModel([deletedParent, subtask]));
-    await archiveDb.saveArchiveOld(archiveModel([]));
-    localState = reducer(reducer(initialState, deleteAction), restoreAction);
+
+    const deleteClient = new TestClient(LOCAL_CLIENT_ID);
+    const restoreClient = new TestClient(REMOTE_CLIENT_ID);
+    const deleteAction = TaskSharedActions.deleteTask({
+      task: deletedParentWithSubtasks,
+    }) as PersistentAction;
+    const restoreAction = TaskSharedActions.restoreTask({
+      task: deletedParent,
+      subTasks: [subtask],
+      restoreToToday: {
+        today: RESTORE_DAY,
+        startOfNextDayDiffMs: 0,
+      },
+    }) as PersistentAction;
+    const remoteDelete = captureOperation(deleteAction, deleteClient, 1_000);
+    const localRestore = captureOperation(restoreAction, restoreClient, 2_000);
+
+    localState = reducer(localState, restoreAction);
     await archiveHandler.handleOperation(restoreAction);
-    await opLogStore.append(remoteRestore, 'local');
+    await opLogStore.append(localRestore, 'local');
 
     await resolver.autoResolveConflictsLWW([
       {
         entityType: 'TASK',
         entityId: PARENT_ID,
-        localOps: [remoteRestore],
-        remoteOps: [localDelete],
+        localOps: [localRestore],
+        remoteOps: [remoteDelete],
         suggestedResolution: 'manual',
       },
     ]);
 
-    expect(restoredProjection(localState)).toEqual(deleteClientProjection);
     const restoreClientOperations = (await opLogStore.getOpsAfterSeq(0)).map(
       ({ op }) => op,
     );
-    expect(restoredProjection(replay(initialState, restoreClientOperations))).toEqual(
-      deleteClientProjection,
+    const replacementRestore = restoreClientOperations.find(
+      (operation) =>
+        operation.id !== localRestore.id &&
+        operation.actionType === TaskSharedActions.restoreTask.type,
     );
+
+    if (!replacementRestore) {
+      throw new Error('Semantic replacement restore was not persisted');
+    }
+    expect(replacementRestore.payload).toEqual(localRestore.payload);
+    const remoteDeleteIndex = restoreClientOperations.findIndex(
+      ({ id }) => id === remoteDelete.id,
+    );
+    const replacementRestoreIndex = restoreClientOperations.findIndex(
+      ({ id }) => id === replacementRestore.id,
+    );
+    expect(remoteDeleteIndex).toBeGreaterThan(-1);
+    expect(remoteDeleteIndex).toBeLessThan(replacementRestoreIndex);
+
+    const replacementRestoreAction = convertOpToAction(replacementRestore) as ReturnType<
+      typeof TaskSharedActions.restoreTask
+    >;
+    expect(replacementRestoreAction.type).toBe(TaskSharedActions.restoreTask.type);
+    expect(replacementRestoreAction.restoreToToday).toEqual({
+      today: RESTORE_DAY,
+      startOfNextDayDiffMs: 0,
+    });
+    expect(replacementRestoreAction.subTasks.map(({ id }) => id)).toEqual([SUBTASK_ID]);
+
+    const restartedState = replay(initialState, restoreClientOperations);
+    expect(restoredProjection(restartedState)).toEqual(restoredProjection(localState));
+    expect(restartedState.tasks.entities[PARENT_ID]?.subTaskIds).toEqual([SUBTASK_ID]);
+    expect(restartedState.tasks.entities[SUBTASK_ID]?.parentId).toBe(PARENT_ID);
+    expect(restartedState[TAG_FEATURE_NAME].entities[TODAY_TAG.id]?.taskIds).toEqual([
+      PARENT_ID,
+    ]);
+
+    const receivingState = replay(reducer(initialState, deleteAction), [
+      replacementRestore,
+    ]);
+    expect(restoredProjection(receivingState)).toEqual(restoredProjection(localState));
+
+    await archiveDb.saveArchiveYoung(archiveModel([deletedParent]));
+    await archiveDb.saveArchiveOld(archiveModel([subtask]));
+    await archiveHandler.handleOperation(replacementRestoreAction);
     expect((await archiveDb.loadArchiveYoung())?.task.ids).toEqual([]);
     expect((await archiveDb.loadArchiveOld())?.task.ids).toEqual([]);
   });

--- a/src/app/op-log/testing/integration/restore-task-conflict.integration.spec.ts
+++ b/src/app/op-log/testing/integration/restore-task-conflict.integration.spec.ts
@@ -1,0 +1,409 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Action, ActionReducer, createSelector, Store } from '@ngrx/store';
+import { of } from 'rxjs';
+import { BannerService } from '../../../core/banner/banner.service';
+import { ArchiveDbAdapter } from '../../../core/persistence/archive-db-adapter.service';
+import { SnackService } from '../../../core/snack/snack.service';
+import { ArchiveModel } from '../../../features/archive/archive.model';
+import { ArchiveService } from '../../../features/archive/archive.service';
+import { TaskArchiveService } from '../../../features/archive/task-archive.service';
+import { TAG_FEATURE_NAME } from '../../../features/tag/store/tag.reducer';
+import { TODAY_TAG } from '../../../features/tag/tag.const';
+import { DEFAULT_TASK, Task, TaskWithSubTasks } from '../../../features/tasks/task.model';
+import {
+  TASK_FEATURE_NAME,
+  taskReducer,
+} from '../../../features/tasks/store/task.reducer';
+import { TimeTrackingService } from '../../../features/time-tracking/time-tracking.service';
+import { createCombinedTaskSharedMetaReducer } from '../../../root-store/meta/task-shared-meta-reducers/test-helpers';
+import { createBaseState } from '../../../root-store/meta/task-shared-meta-reducers/test-utils';
+import { lwwUpdateMetaReducer } from '../../../root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { RootState } from '../../../root-store/root-state';
+import { ArchiveOperationHandler } from '../../apply/archive-operation-handler.service';
+import { OperationApplierService } from '../../apply/operation-applier.service';
+import { convertOpToAction } from '../../apply/operation-converter.util';
+import { OperationCaptureService } from '../../capture/operation-capture.service';
+import { OperationLogEffects } from '../../capture/operation-log.effects';
+import { buildEntityRegistry, ENTITY_REGISTRY } from '../../core/entity-registry';
+import { EntityConflict, Operation } from '../../core/operation.types';
+import { PersistentAction } from '../../core/persistent-action.interface';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { ConflictJournalService } from '../../sync/conflict-journal.service';
+import { ConflictResolutionService } from '../../sync/conflict-resolution.service';
+import { SyncConflictBannerService } from '../../sync/sync-conflict-banner.service';
+import { SyncSessionValidationService } from '../../sync/sync-session-validation.service';
+import { CLIENT_ID_PROVIDER } from '../../util/client-id.provider';
+import { ValidateStateService } from '../../validation/validate-state.service';
+import { resetTestUuidCounter, TestClient } from './helpers/test-client.helper';
+
+describe('restoreTask delete-conflict integration (#9263)', () => {
+  const LOCAL_CLIENT_ID = 'delete-client';
+  const REMOTE_CLIENT_ID = 'restore-client';
+  const PARENT_ID = 'archived-parent';
+  const SUBTASK_ID = 'archived-subtask';
+  const RESTORE_DAY = '2026-07-23';
+
+  let resolver: ConflictResolutionService;
+  let opLogStore: OperationLogStoreService;
+  let capture: OperationCaptureService;
+  let archiveDb: ArchiveDbAdapter;
+  let archiveHandler: ArchiveOperationHandler;
+  let reducer: ActionReducer<RootState, Action>;
+  let initialState: RootState;
+  let localState: RootState;
+  let currentClientId: string;
+
+  const subtask: Task = {
+    ...DEFAULT_TASK,
+    id: SUBTASK_ID,
+    title: 'Archived subtask',
+    projectId: 'project1',
+    parentId: PARENT_ID,
+  };
+  const deletedParent: Task = {
+    ...DEFAULT_TASK,
+    id: PARENT_ID,
+    title: 'Archived parent',
+    projectId: 'project1',
+    subTaskIds: [SUBTASK_ID],
+  };
+  const deletedParentWithSubtasks: TaskWithSubTasks = {
+    ...deletedParent,
+    subTasks: [subtask],
+  };
+
+  const archiveModel = (tasks: Task[]): ArchiveModel =>
+    ({
+      task: {
+        ids: tasks.map(({ id }) => id),
+        entities: Object.fromEntries(tasks.map((task) => [task.id, task])),
+      },
+      timeTracking: { project: {}, tag: {} },
+      lastTimeTrackingFlush: 0,
+    }) as ArchiveModel;
+
+  const captureOperation = (
+    action: PersistentAction,
+    client: TestClient,
+    timestamp: number,
+  ): Operation => {
+    const { type, meta, ...actionPayload } = action;
+    const entityIds = meta.entityIds ?? (meta.entityId ? [meta.entityId] : undefined);
+    const entityId = meta.entityId ?? entityIds?.[0];
+    if (!entityId) {
+      throw new Error('Persistent test action has no entity id');
+    }
+
+    return {
+      ...client.createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId,
+        entityIds,
+        payload: {
+          actionPayload,
+          entityChanges: capture.extractEntityChanges(action),
+        },
+      }),
+      timestamp,
+    };
+  };
+
+  const replay = (state: RootState, operations: Operation[]): RootState =>
+    operations.reduce(
+      (currentState, operation) => reducer(currentState, convertOpToAction(operation)),
+      state,
+    );
+
+  const restoredProjection = (state: RootState): object => {
+    const parent = state.tasks.entities[PARENT_ID];
+    const restoredSubtask = state.tasks.entities[SUBTASK_ID];
+    return {
+      parent: {
+        id: parent?.id,
+        projectId: parent?.projectId,
+        subTaskIds: parent?.subTaskIds,
+        dueDay: parent?.dueDay,
+        dueWithTime: parent?.dueWithTime,
+        remindAt: parent?.remindAt,
+        isDone: parent?.isDone,
+      },
+      subtask: {
+        id: restoredSubtask?.id,
+        parentId: restoredSubtask?.parentId,
+        projectId: restoredSubtask?.projectId,
+        dueDay: restoredSubtask?.dueDay,
+        dueWithTime: restoredSubtask?.dueWithTime,
+        remindAt: restoredSubtask?.remindAt,
+      },
+      projectTaskIds: state.projects.entities.project1?.taskIds,
+      todayTaskIds: state[TAG_FEATURE_NAME].entities[TODAY_TAG.id]?.taskIds,
+    };
+  };
+
+  beforeEach(async () => {
+    resetTestUuidCounter();
+    currentClientId = LOCAL_CLIENT_ID;
+
+    const baseState = createBaseState();
+    const project = baseState.projects.entities.project1;
+    if (!project) {
+      throw new Error('Test fixture project1 is missing');
+    }
+    initialState = {
+      ...baseState,
+      tasks: {
+        ...baseState.tasks,
+        ids: [PARENT_ID, SUBTASK_ID],
+        entities: {
+          [PARENT_ID]: deletedParent,
+          [SUBTASK_ID]: subtask,
+        },
+      },
+      projects: {
+        ...baseState.projects,
+        entities: {
+          ...baseState.projects.entities,
+          project1: {
+            ...project,
+            taskIds: [PARENT_ID],
+          },
+        },
+      },
+    };
+
+    const rootReducer: ActionReducer<RootState, Action> = (
+      state = initialState,
+      action,
+    ) => ({
+      ...state,
+      [TASK_FEATURE_NAME]: taskReducer(state[TASK_FEATURE_NAME], action),
+    });
+    reducer = createCombinedTaskSharedMetaReducer(
+      lwwUpdateMetaReducer(rootReducer),
+    ) as ActionReducer<RootState, Action>;
+
+    const deleteAction = TaskSharedActions.deleteTask({
+      task: deletedParentWithSubtasks,
+    }) as PersistentAction;
+    localState = reducer(initialState, deleteAction);
+
+    const store = jasmine.createSpyObj<Store>('Store', ['select']);
+    store.select.and.callFake((selector: unknown, props?: unknown) => {
+      if (typeof selector !== 'function') {
+        return of(undefined) as ReturnType<Store['select']>;
+      }
+      return of(
+        (selector as (state: RootState, selectorProps?: unknown) => unknown)(
+          localState,
+          props,
+        ),
+      ) as ReturnType<Store['select']>;
+    });
+
+    const operationApplier = jasmine.createSpyObj<OperationApplierService>(
+      'OperationApplierService',
+      ['applyOperations'],
+    );
+    operationApplier.applyOperations.and.callFake(async (operations, options) => {
+      localState = replay(localState, operations);
+      await options?.onReducersCommitted?.(operations);
+      return { appliedOps: operations };
+    });
+
+    const validateState = jasmine.createSpyObj<ValidateStateService>(
+      'ValidateStateService',
+      ['validateAndRepairCurrentState'],
+    );
+    validateState.validateAndRepairCurrentState.and.resolveTo(true);
+    const operationLogEffects = jasmine.createSpyObj<OperationLogEffects>(
+      'OperationLogEffects',
+      ['processDeferredActions'],
+    );
+    operationLogEffects.processDeferredActions.and.resolveTo();
+    const conflictJournal = jasmine.createSpyObj<ConflictJournalService>(
+      'ConflictJournalService',
+      ['record'],
+      { unreviewedCount: signal(0) },
+    );
+    conflictJournal.record.and.resolveTo();
+    const syncConflictBanner = jasmine.createSpyObj<SyncConflictBannerService>(
+      'SyncConflictBannerService',
+      ['maybeShowSummaryBanner', 'navigateToReview'],
+    );
+    syncConflictBanner.maybeShowSummaryBanner.and.resolveTo();
+    const snack = jasmine.createSpyObj<SnackService>('SnackService', [
+      'open',
+      'hasPendingPersistentAction',
+    ]);
+    snack.hasPendingPersistentAction.and.returnValue(false);
+
+    const entityRegistry = buildEntityRegistry();
+    const taskConfig = entityRegistry.TASK;
+    if (!taskConfig) {
+      throw new Error('TASK entity config is required');
+    }
+    taskConfig.selectById = createSelector(
+      (state: RootState) => state[TASK_FEATURE_NAME],
+      (state, props: { id: string }) => state.entities[props.id] as Task | undefined,
+    ) as NonNullable<typeof taskConfig.selectById>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        ConflictResolutionService,
+        OperationLogStoreService,
+        OperationCaptureService,
+        ArchiveDbAdapter,
+        ArchiveOperationHandler,
+        TaskArchiveService,
+        { provide: Store, useValue: store },
+        { provide: OperationApplierService, useValue: operationApplier },
+        { provide: ValidateStateService, useValue: validateState },
+        { provide: OperationLogEffects, useValue: operationLogEffects },
+        { provide: ConflictJournalService, useValue: conflictJournal },
+        { provide: SyncConflictBannerService, useValue: syncConflictBanner },
+        { provide: SnackService, useValue: snack },
+        {
+          provide: BannerService,
+          useValue: jasmine.createSpyObj<BannerService>('BannerService', ['open']),
+        },
+        {
+          provide: SyncSessionValidationService,
+          useValue: jasmine.createSpyObj<SyncSessionValidationService>(
+            'SyncSessionValidationService',
+            ['setFailed'],
+          ),
+        },
+        {
+          provide: CLIENT_ID_PROVIDER,
+          useValue: {
+            loadClientId: () => Promise.resolve(currentClientId),
+            getOrGenerateClientId: () => Promise.resolve(currentClientId),
+            clearCache: () => {},
+          },
+        },
+        { provide: ENTITY_REGISTRY, useValue: entityRegistry },
+        { provide: ArchiveService, useValue: {} },
+        { provide: TimeTrackingService, useValue: {} },
+      ],
+    });
+
+    resolver = TestBed.inject(ConflictResolutionService);
+    opLogStore = TestBed.inject(OperationLogStoreService);
+    capture = TestBed.inject(OperationCaptureService);
+    archiveDb = TestBed.inject(ArchiveDbAdapter);
+    archiveHandler = TestBed.inject(ArchiveOperationHandler);
+
+    await opLogStore.init();
+    await opLogStore._clearAllDataForTesting();
+    await archiveDb.saveArchiveYoung(archiveModel([deletedParent, subtask]));
+    await archiveDb.saveArchiveOld(archiveModel([]));
+  });
+
+  afterEach(async () => {
+    await archiveDb.saveArchiveYoung(archiveModel([]));
+    await archiveDb.saveArchiveOld(archiveModel([]));
+    await opLogStore._clearAllDataForTesting();
+    TestBed.resetTestingModule();
+  });
+
+  it('replays a winning remote restore after a local delete without leaving archived copies', async () => {
+    const localClient = new TestClient(LOCAL_CLIENT_ID);
+    const remoteClient = new TestClient(REMOTE_CLIENT_ID);
+    const deleteAction = TaskSharedActions.deleteTask({
+      task: deletedParentWithSubtasks,
+    }) as PersistentAction;
+    const restoreAction = TaskSharedActions.restoreTask({
+      task: deletedParent,
+      subTasks: [subtask],
+      restoreToToday: {
+        today: RESTORE_DAY,
+        startOfNextDayDiffMs: 0,
+      },
+    }) as PersistentAction;
+    const localDelete = captureOperation(deleteAction, localClient, 1_000);
+    const remoteRestore = captureOperation(restoreAction, remoteClient, 2_000);
+    const conflict: EntityConflict = {
+      entityType: 'TASK',
+      entityId: PARENT_ID,
+      localOps: [localDelete],
+      remoteOps: [remoteRestore],
+      suggestedResolution: 'manual',
+    };
+
+    await opLogStore.append(localDelete, 'local');
+    await resolver.autoResolveConflictsLWW([conflict]);
+
+    const storedOperations = (await opLogStore.getOpsAfterSeq(0)).map(({ op }) => op);
+    const storedRestore = storedOperations.find(({ id }) => id === remoteRestore.id);
+    if (!storedRestore) {
+      throw new Error('Resolved restore operation was not persisted');
+    }
+    const storedRestoreAction = convertOpToAction(storedRestore) as ReturnType<
+      typeof TaskSharedActions.restoreTask
+    >;
+    expect(storedRestoreAction.type).toBe(TaskSharedActions.restoreTask.type);
+    expect(storedRestoreAction.restoreToToday).toEqual({
+      today: RESTORE_DAY,
+      startOfNextDayDiffMs: 0,
+    });
+    expect(storedRestoreAction.subTasks.map(({ id }) => id)).toEqual([SUBTASK_ID]);
+
+    const restartedState = replay(initialState, storedOperations);
+
+    expect(restartedState.tasks.ids).toContain(PARENT_ID);
+    expect(restartedState.tasks.ids).toContain(SUBTASK_ID);
+    expect(restartedState.tasks.entities[PARENT_ID]?.subTaskIds).toEqual([SUBTASK_ID]);
+    expect(restartedState.tasks.entities[SUBTASK_ID]?.parentId).toBe(PARENT_ID);
+    expect(restartedState.tasks.entities[PARENT_ID]?.dueDay).toBe(RESTORE_DAY);
+    expect(restartedState.tasks.entities[SUBTASK_ID]?.dueDay).toBeUndefined();
+    expect(restartedState.tasks.entities[PARENT_ID]?.tagIds).not.toContain(TODAY_TAG.id);
+    expect(restartedState.tasks.entities[SUBTASK_ID]?.tagIds).not.toContain(TODAY_TAG.id);
+    expect(restartedState[TAG_FEATURE_NAME].entities[TODAY_TAG.id]?.taskIds).toEqual([
+      PARENT_ID,
+    ]);
+
+    for (const operation of storedOperations) {
+      await archiveHandler.handleOperation(convertOpToAction(operation));
+    }
+
+    expect((await archiveDb.loadArchiveYoung())?.task.ids).toEqual([]);
+    expect((await archiveDb.loadArchiveOld())?.task.ids).toEqual([]);
+
+    const deleteClientProjection = restoredProjection(localState);
+    expect(restoredProjection(restartedState)).toEqual(deleteClientProjection);
+
+    // Reverse delivery: the restore author receives the losing delete and
+    // persists the reconciliation operations needed for status-blind restart.
+    currentClientId = REMOTE_CLIENT_ID;
+    await opLogStore._clearAllDataForTesting();
+    await archiveDb.saveArchiveYoung(archiveModel([deletedParent, subtask]));
+    await archiveDb.saveArchiveOld(archiveModel([]));
+    localState = reducer(reducer(initialState, deleteAction), restoreAction);
+    await archiveHandler.handleOperation(restoreAction);
+    await opLogStore.append(remoteRestore, 'local');
+
+    await resolver.autoResolveConflictsLWW([
+      {
+        entityType: 'TASK',
+        entityId: PARENT_ID,
+        localOps: [remoteRestore],
+        remoteOps: [localDelete],
+        suggestedResolution: 'manual',
+      },
+    ]);
+
+    expect(restoredProjection(localState)).toEqual(deleteClientProjection);
+    const restoreClientOperations = (await opLogStore.getOpsAfterSeq(0)).map(
+      ({ op }) => op,
+    );
+    expect(restoredProjection(replay(initialState, restoreClientOperations))).toEqual(
+      deleteClientProjection,
+    );
+    expect((await archiveDb.loadArchiveYoung())?.task.ids).toEqual([]);
+    expect((await archiveDb.loadArchiveOld())?.task.ids).toEqual([]);
+  });
+});

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.ts
@@ -360,6 +360,21 @@ const createActionHandlers = (state: RootState, action: Action): ActionHandlerMa
       isClearScheduledTime,
     );
   },
+  [TaskSharedActions.restoreTask.type]: () => {
+    const { task, restoreToToday } = action as ReturnType<
+      typeof TaskSharedActions.restoreTask
+    >;
+    if (!restoreToToday) {
+      return state;
+    }
+    return handlePlanTasksForToday(
+      state,
+      [task.id],
+      {},
+      restoreToToday.today,
+      restoreToToday.startOfNextDayDiffMs,
+    );
+  },
   [TaskSharedActions.removeTasksFromTodayTag.type]: () => {
     const { taskIds } = action as ReturnType<
       typeof TaskSharedActions.removeTasksFromTodayTag

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.ts
@@ -9,7 +9,10 @@ import {
 import { Task } from '../../../features/tasks/task.model';
 import { TODAY_TAG } from '../../../features/tag/tag.const';
 import { unique } from '../../../util/unique';
-import { isTodayWithOffset } from '../../../util/is-today.util';
+import {
+  isTodayWithOffset,
+  shouldClearDueTimeForToday,
+} from '../../../util/is-today.util';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { appStateFeatureKey } from '../../app-state/app-state.reducer';
 import { moveItemBeforeItem } from '../../../util/move-item-before-item';
@@ -235,7 +238,7 @@ const handlePlanTasksForToday = (
     // However, if isClearScheduledTime is true (from reminder dialog), always clear the time
     const shouldClearTime = isClearScheduledTime
       ? !!task?.dueWithTime
-      : task?.dueWithTime && !isTodayWithOffset(task.dueWithTime, today, offsetMs);
+      : shouldClearDueTimeForToday(task?.dueWithTime, today, offsetMs);
 
     return {
       id: taskId,

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -6,6 +6,7 @@ import { WorkContextType } from '../../features/work-context/work-context.model'
 import { BatchOperation } from '@super-productivity/plugin-api';
 import { PersistentActionMeta } from '../../op-log/core/persistent-action.interface';
 import { OpType } from '../../op-log/core/operation.types';
+import { isTodayWithOffset } from '../../util/is-today.util';
 
 /**
  * Payload marker stamped on every new `deleteProject` operation so the LWW
@@ -117,15 +118,57 @@ export const TaskSharedActions = createActionGroup({
       } satisfies PersistentActionMeta,
     }),
 
-    restoreTask: (taskProps: { task: Task | TaskWithSubTasks; subTasks: Task[] }) => ({
-      ...taskProps,
-      meta: {
-        isPersistent: true,
-        entityType: 'TASK',
-        entityId: taskProps.task.id,
-        opType: OpType.Update,
-      } satisfies PersistentActionMeta,
-    }),
+    restoreTask: (taskProps: {
+      task: Task | TaskWithSubTasks;
+      subTasks: Task[];
+      restoreToToday?: {
+        today: string;
+        startOfNextDayDiffMs: number;
+      };
+    }) => {
+      const { restoreToToday } = taskProps;
+      const dueWithTime = taskProps.task.dueWithTime;
+      const hasValidDueWithTime =
+        typeof dueWithTime === 'number' &&
+        Number.isFinite(dueWithTime) &&
+        dueWithTime > 0;
+      const shouldClearTime =
+        restoreToToday &&
+        dueWithTime !== undefined &&
+        (!hasValidDueWithTime ||
+          !isTodayWithOffset(
+            dueWithTime,
+            restoreToToday.today,
+            restoreToToday.startOfNextDayDiffMs,
+          ));
+      const task = restoreToToday
+        ? {
+            ...taskProps.task,
+            dueDay: restoreToToday.today,
+            remindAt: undefined,
+            ...(shouldClearTime ? { dueWithTime: undefined } : {}),
+          }
+        : taskProps.task;
+      const subTasks = restoreToToday
+        ? taskProps.subTasks.map((subTask) => ({
+            ...subTask,
+            dueDay: undefined,
+            dueWithTime: undefined,
+            remindAt: undefined,
+          }))
+        : taskProps.subTasks;
+      return {
+        ...taskProps,
+        task,
+        subTasks,
+        meta: {
+          isPersistent: true,
+          entityType: 'TASK',
+          entityId: task.id,
+          opType: OpType.Update,
+        } satisfies PersistentActionMeta,
+      };
+    },
 
     // Restore a deleted task (undo delete) - syncs across devices
     restoreDeletedTask: (payload: {

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -6,7 +6,7 @@ import { WorkContextType } from '../../features/work-context/work-context.model'
 import { BatchOperation } from '@super-productivity/plugin-api';
 import { PersistentActionMeta } from '../../op-log/core/persistent-action.interface';
 import { OpType } from '../../op-log/core/operation.types';
-import { isTodayWithOffset } from '../../util/is-today.util';
+import { shouldClearDueTimeForToday } from '../../util/is-today.util';
 
 /**
  * Payload marker stamped on every new `deleteProject` operation so the LWW
@@ -127,20 +127,16 @@ export const TaskSharedActions = createActionGroup({
       };
     }) => {
       const { restoreToToday } = taskProps;
-      const dueWithTime = taskProps.task.dueWithTime;
-      const hasValidDueWithTime =
-        typeof dueWithTime === 'number' &&
-        Number.isFinite(dueWithTime) &&
-        dueWithTime > 0;
+      // Materialize Today placement into the snapshot fields so a released
+      // conflict converter degrades to visible-but-unordered Today membership
+      // instead of losing the restore. Clearing rules match handlePlanTasksForToday.
       const shouldClearTime =
-        restoreToToday &&
-        dueWithTime !== undefined &&
-        (!hasValidDueWithTime ||
-          !isTodayWithOffset(
-            dueWithTime,
-            restoreToToday.today,
-            restoreToToday.startOfNextDayDiffMs,
-          ));
+        !!restoreToToday &&
+        shouldClearDueTimeForToday(
+          taskProps.task.dueWithTime,
+          restoreToToday.today,
+          restoreToToday.startOfNextDayDiffMs,
+        );
       const task = restoreToToday
         ? {
             ...taskProps.task,

--- a/src/app/root-store/meta/task-shared.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared.reducer.spec.ts
@@ -19,6 +19,7 @@ import {
   plannerInitialState,
 } from '../../features/planner/store/planner.reducer';
 import { appStateFeatureKey } from '../app-state/app-state.reducer';
+import { TODAY_TAG } from '../../features/tag/tag.const';
 
 describe('taskSharedMetaReducer', () => {
   let mockReducer: jasmine.Spy;
@@ -1221,6 +1222,84 @@ describe('taskSharedMetaReducer', () => {
         },
         action,
       );
+    });
+
+    it('should atomically restore only the parent into captured Today', () => {
+      const today = '2026-01-05';
+      const subTasks = [
+        createMockTask({
+          id: 'subtask1',
+          parentId: 'task1',
+          dueDay: '2025-12-30',
+          dueWithTime: new Date('2025-12-30T10:00:00Z').getTime(),
+          remindAt: new Date('2025-12-30T09:55:00Z').getTime(),
+          tagIds: [TODAY_TAG.id],
+        }),
+        createMockTask({
+          id: 'subtask2',
+          parentId: 'task1',
+          dueDay: '2025-12-31',
+          dueWithTime: new Date('2025-12-31T10:00:00Z').getTime(),
+          remindAt: new Date('2025-12-31T09:55:00Z').getTime(),
+          tagIds: [TODAY_TAG.id],
+        }),
+      ];
+      const action = TaskSharedActions.restoreTask({
+        task: createMockTask({
+          dueDay: today,
+          dueWithTime: Number.NaN,
+          remindAt: new Date('2025-12-30T09:55:00Z').getTime(),
+          subTaskIds: ['subtask1', 'subtask2'],
+          tagIds: ['tag1', TODAY_TAG.id],
+        }),
+        subTasks,
+        restoreToToday: {
+          today,
+          startOfNextDayDiffMs: 0,
+        },
+      });
+      const replayState = {
+        ...baseState,
+        [appStateFeatureKey]: {
+          todayStr: '2026-01-06',
+          startOfNextDayDiffMs: 0,
+        },
+      } as RootState;
+
+      metaReducer(replayState, action);
+
+      const restoredState = mockReducer.calls.mostRecent().args[0] as RootState;
+      const restoredParent = restoredState[TASK_FEATURE_NAME].entities.task1;
+      const restoredSubTask1 = restoredState[TASK_FEATURE_NAME].entities.subtask1;
+      const restoredSubTask2 = restoredState[TASK_FEATURE_NAME].entities.subtask2;
+      expect(restoredParent?.dueDay).toBe(today);
+      expect(restoredParent?.dueWithTime).toBeUndefined();
+      expect(restoredParent?.remindAt).toBeUndefined();
+      expect(restoredParent?.subTaskIds).toEqual(['subtask1', 'subtask2']);
+      expect(restoredParent?.tagIds).not.toContain(TODAY_TAG.id);
+      expect(restoredSubTask1?.parentId).toBe('task1');
+      expect(restoredSubTask1?.dueDay).toBeUndefined();
+      expect(restoredSubTask1?.dueWithTime).toBeUndefined();
+      expect(restoredSubTask1?.remindAt).toBeUndefined();
+      expect(restoredSubTask1?.tagIds).not.toContain(TODAY_TAG.id);
+      expect(restoredSubTask2?.parentId).toBe('task1');
+      expect(restoredSubTask2?.dueDay).toBeUndefined();
+      expect(restoredSubTask2?.dueWithTime).toBeUndefined();
+      expect(restoredSubTask2?.remindAt).toBeUndefined();
+      expect(restoredSubTask2?.tagIds).not.toContain(TODAY_TAG.id);
+      expect(restoredState[TAG_FEATURE_NAME].entities[TODAY_TAG.id]?.taskIds).toEqual([
+        'task1',
+      ]);
+    });
+
+    it('should keep markerless restore out of Today', () => {
+      const action = createRestoreAction();
+
+      metaReducer(baseState, action);
+
+      const restoredState = mockReducer.calls.mostRecent().args[0] as RootState;
+      expect(restoredState[TASK_FEATURE_NAME].entities.task1?.dueDay).toBeUndefined();
+      expect(restoredState[TAG_FEATURE_NAME].entities[TODAY_TAG.id]?.taskIds).toEqual([]);
     });
 
     it('should add tasks to existing taskIds', () => {

--- a/src/app/util/is-today.util.spec.ts
+++ b/src/app/util/is-today.util.spec.ts
@@ -1,4 +1,4 @@
-import { isTodayWithOffset } from './is-today.util';
+import { isTodayWithOffset, shouldClearDueTimeForToday } from './is-today.util';
 import { getDbDateStr } from './get-db-date-str';
 
 describe('isTodayWithOffset', () => {
@@ -116,5 +116,49 @@ describe('isTodayWithOffset', () => {
         'Invalid date passed',
       );
     });
+  });
+});
+
+describe('shouldClearDueTimeForToday', () => {
+  const todayStr = '2026-02-15';
+
+  it('keeps (returns false) when there is no time set', () => {
+    expect(shouldClearDueTimeForToday(undefined, todayStr, 0)).toBe(false);
+    expect(shouldClearDueTimeForToday(null, todayStr, 0)).toBe(false);
+  });
+
+  it('keeps (returns false) a valid time that falls on today', () => {
+    const todayTime = new Date(2026, 1, 15, 12, 0, 0).getTime();
+
+    expect(shouldClearDueTimeForToday(todayTime, todayStr, 0)).toBe(false);
+  });
+
+  it('clears (returns true) a valid time that falls on another day', () => {
+    const yesterdayTime = new Date(2026, 1, 14, 12, 0, 0).getTime();
+
+    expect(shouldClearDueTimeForToday(yesterdayTime, todayStr, 0)).toBe(true);
+  });
+
+  it('clears (returns true) a non-positive or non-finite timestamp', () => {
+    expect(shouldClearDueTimeForToday(0, todayStr, 0)).toBe(true);
+    expect(shouldClearDueTimeForToday(-1, todayStr, 0)).toBe(true);
+    expect(shouldClearDueTimeForToday(NaN, todayStr, 0)).toBe(true);
+  });
+
+  it('clears (returns true) instead of throwing on an out-of-range timestamp', () => {
+    // 1e20 ms is a finite, positive number but outside the valid JS Date range,
+    // so a bare isTodayWithOffset(1e20, ...) would throw. The helper must not.
+    expect(() => shouldClearDueTimeForToday(1e20, todayStr, 0)).not.toThrow();
+    expect(shouldClearDueTimeForToday(1e20, todayStr, 0)).toBe(true);
+  });
+
+  it('honors the start-of-next-day offset like isTodayWithOffset', () => {
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+    // 2 AM Feb 16 belongs to Feb 15 with a 4h offset → keep.
+    const earlyNextMorning = new Date(2026, 1, 16, 2, 0, 0).getTime();
+
+    expect(shouldClearDueTimeForToday(earlyNextMorning, todayStr, fourHoursMs)).toBe(
+      false,
+    );
   });
 });

--- a/src/app/util/is-today.util.ts
+++ b/src/app/util/is-today.util.ts
@@ -12,6 +12,32 @@ export const isTodayWithOffset = (
   return getDbDateStr(new Date(d.getTime() - startOfNextDayDiffMs)) === todayStr;
 };
 
+/**
+ * Decides whether a task's `dueWithTime` should be dropped when (re)scheduling
+ * the task onto `todayStr`: `true` = clear the time, `false` = keep it.
+ *
+ * Clears when the timestamp is missing-as-invalid (non-finite, non-positive, or
+ * outside the JS `Date` range) or falls on a different logical day; keeps it only
+ * for a valid timestamp that lands on today. `undefined`/`null` (no time set)
+ * returns `false` so callers don't spuriously flag a change.
+ *
+ * Unlike a bare `isTodayWithOffset` call this never throws: the range is guarded
+ * here before delegating, so a corrupt timestamp is cleared instead of blowing up.
+ */
+export const shouldClearDueTimeForToday = (
+  dueWithTime: number | null | undefined,
+  todayStr: string,
+  startOfNextDayDiffMs: number,
+): boolean => {
+  if (dueWithTime === undefined || dueWithTime === null) {
+    return false;
+  }
+  if (!(new Date(dueWithTime).getTime() > 0)) {
+    return true;
+  }
+  return !isTodayWithOffset(dueWithTime, todayStr, startOfNextDayDiffMs);
+};
+
 /** @deprecated Use `DateService.isToday()` or `isTodayWithOffset()` instead for offset-aware comparison. */
 export const isToday = (date: number | Date): boolean => {
   const d = new Date(date);


### PR DESCRIPTION
## What & why

Fixes #9263. Restoring an archived task hierarchy from **History** and confirming the "move the task into your Today task list" dialog navigated to Today but did **not** place the task there — it only regained project/Inbox membership. Archived snapshots have `dueDay`/`dueWithTime` cleared, so the generic restore path could not make the task a Today member.

## How

- **History opts into restore-to-Today** via a new optional `restoreToToday` field on `TaskSharedActions.restoreTask`. Markerless/legacy and generic/API restore callers keep their current project-only behavior.
- Restore + hierarchy repair + Today placement + archive removal stay **one replay-atomic op** (lifecycle meta-reducer recreates the entity, then the scheduling meta-reducer adds only the parent to `TODAY_TAG.taskIds` ordering).
- The logical day is captured at **dispatch time** (after the archive load resolves) via `DateService`; replay never reads wall-clock time.
- Final scheduling state is materialized into the existing `task.dueDay` / `dueWithTime` / `remindAt` snapshot fields, so released conflict converters degrade to **visible-but-unordered** Today membership rather than losing the restore. **No schema bump; the new field is optional.**
- **Sync fix:** a delete-vs-restore conflict previously converted the winning restore into a `[TASK] LWW Update`, dropping the subtask/`restoreToToday` payload and skipping archive cleanup. `TASK_SHARED_RESTORE` is now exempt from `_convertToLWWUpdatesIfNeeded` (recreated by its own reducer via `addMany`), and a local-win restore re-emits the original semantic payload (fresh UUIDv7, merged clock) instead of a generic snapshot — so both clients converge on the restored hierarchy **and** purge the archived copies.
- Preserves the virtual Today invariant: `TODAY_TAG` is never added to any task's `tagIds`; subtasks are scheduled-cleared so they never become independent Today roots.

## Invariants / correctness

- Follows sync-model rules: multi-entity change via meta-reducer (one reducer pass = one op), `LOCAL_ACTIONS` in effects, logical-clock via `DateService` with `startOfNextDayDiffMs` threaded for replay determinism, `TODAY_TAG` virtual, no schema bump, new field optional.
- Started from a **reproducible failure**: a real-operation integration spec using captured `deleteTask`/`restoreTask` payloads + IndexedDB archive persistence (`restore-task-conflict.integration.spec.ts`) that fails without the fix.

## Tests

- New integration regression proving both clients converge and archived copies are purged after conflict resolution (remote-restore-wins and local-restore-wins).
- Composed lifecycle+scheduling reducer regression (parent gets captured `dueDay`, only the parent enters `TODAY_TAG.taskIds`, subtasks stay nested and unscheduled, no `TODAY_TAG.id` in any `tagIds`, replay after the logical day advances is stable).
- History component spec: exactly one persistent restore carrying the captured logical day, captured after the archive load.
- Conflict-resolution unit spec for the `TASK_SHARED_RESTORE` exemption.
- Extended E2E through the real History restore → persistence → reload → full hierarchy assertion.
- Shared `dueWithTime`-for-today normalization helper with its own unit tests (incl. an out-of-range timestamp that would otherwise throw).

## Scope

Deliberately the **minimal** fix. Restore-dependency ordering, compensation barriers, remote-page segmentation, and a general coordinator are intentionally parked in **#9290** (reject-and-close unless independently reproduced). The one conflict-resolution edge left to #9290 — bulk/multi-op delete-vs-restore forgoing archive cleanup on the local-win path — is pre-existing (it is not a regression) and documented in-code at the guard.
