### PR TITLE
fix(sync): accept legacy singleton LWW ops rejected as tampering (#9256)

### DIFF
--- a/docs/sync-and-op-log/supersync-encryption-architecture.md
+++ b/docs/sync-and-op-log/supersync-encryption-architecture.md
@@ -255,9 +255,12 @@ privateCfg: {
 >   rests on the server contract that `deleteAllData()` removes every downloadable
 >   plaintext op. This is the SuperSync op-level twin of the file-based GHSA-vrc7
 >   download guard and the GHSA-9544 _upload_ guard.
-> - **LWW `entityId` retarget:** the client rejects an _encrypted_ LWW-update op
->   whose authenticated `payload.id` does not equal `op.entityId`
->   (`verify-decrypted-op-integrity.ts`).
+> - **LWW `entityId` retarget:** for adapter-backed LWW updates, where
+>   `payload.id` selects the entity the reducer applies, the client rejects an
+>   _encrypted_ op whose authenticated `payload.id` does not equal
+>   `op.entityId` (`verify-decrypted-op-integrity.ts`). Singleton LWW actions
+>   target their registered feature state as a whole, so contextual conflict
+>   IDs such as TIME_TRACKING's composite key have no canonical payload `id`.
 > - **Full-state `opType` promotion:** after decrypting an operation tagged as
 >   `SYNC_IMPORT`, `BACKUP_IMPORT`, or `REPAIR`, the client structurally validates
 >   the authenticated payload as complete application data before the metadata can

--- a/e2e/tests/migration/legacy-themeless-tag-9139.spec.ts
+++ b/e2e/tests/migration/legacy-themeless-tag-9139.spec.ts
@@ -208,6 +208,12 @@ test.describe('@migration #9139 work context with no theme', () => {
       // would still pass with the on-disk corruption left in place. This is the
       // load-bearing assertion of this test (verified: disabling the heal fails
       // right here).
+      await expect
+        .poll(async () => (await readMigratedState(page)).tag?.entities?.TODAY != null, {
+          timeout: 30000,
+        })
+        .toBe(true);
+
       const state = await readMigratedState(page);
       const today = state.tag?.entities?.TODAY as
         | { theme?: Record<string, unknown> }
@@ -216,7 +222,7 @@ test.describe('@migration #9139 work context with no theme', () => {
       expect(today?.theme).toBeDefined();
       expect(typeof today?.theme?.primary).toBe('string');
 
-      // Checked LAST on purpose: the IndexedDB round trip above is a real
+      // Checked LAST on purpose: the IndexedDB poll above is a real
       // settle window, so a startup error has had time to surface. Asserting
       // this straight after the side nav appears would pass on timing alone.
       // (No task-content assertion here — TODAY membership is virtual, driven

--- a/packages/sync-core/src/conflict-resolution.ts
+++ b/packages/sync-core/src/conflict-resolution.ts
@@ -162,6 +162,14 @@ export const convertLocalDeleteRemoteUpdatesToLww = <
       const updateChanges = existingLwwPayload
         ? extractActionPayload(existingLwwPayload)
         : extractUpdateChanges(remoteOp.payload, remotePayloadKey, conflict.entityId);
+      // NOTE (#9256): this still classifies "is a singleton" by `entityId === '*'`,
+      // the same conflation the host fixed by switching to a storage-pattern check
+      // (see isLwwPayloadIdCanonical). A singleton with a COMPOSITE conflict id
+      // (e.g. TIME_TRACKING) would fall into the else branch and get `id` injected
+      // into its whole-slice payload. Latent only: this path is gated on a local
+      // DELETE op above, and singletons never emit per-entity deletes — so it is
+      // currently unreachable for them. Migrate to a storage-pattern predicate if
+      // a composite-id singleton ever gains a delete producer.
       const mergedEntity = options.isSingletonEntityId?.(conflict.entityId)
         ? { ...baseEntity, ...updateChanges }
         : { ...baseEntity, ...updateChanges, id: conflict.entityId };

--- a/packages/sync-core/src/conflict-resolution.ts
+++ b/packages/sync-core/src/conflict-resolution.ts
@@ -166,10 +166,17 @@ export const convertLocalDeleteRemoteUpdatesToLww = <
       // the same conflation the host fixed by switching to a storage-pattern check
       // (see isLwwPayloadIdCanonical). A singleton with a COMPOSITE conflict id
       // (e.g. TIME_TRACKING) would fall into the else branch and get `id` injected
-      // into its whole-slice payload. Latent only: this path is gated on a local
-      // DELETE op above, and singletons never emit per-entity deletes — so it is
-      // currently unreachable for them. Migrate to a storage-pattern predicate if
-      // a composite-id singleton ever gains a delete producer.
+      // into its whole-slice payload — and the host's LWW reducer would then
+      // replace the WHOLE feature slice with that merged shape.
+      //
+      // Unreachable today, but NOT because "singletons never emit deletes": they
+      // do — menuTreeDeleteFolder emits MENU_TREE + OpType.Delete with a folderId
+      // entityId. The actual guard is `baseEntity` above: extractEntityFromPayload
+      // finds nothing in that delete payload (no `menuTree` key, no id-matching
+      // array element, no top-level `id` — the field is named `folderId`), so this
+      // branch is skipped. That means renaming such a payload field to `id`, or
+      // adding a singleton delete that carries its entity, ARMS this line. Migrate
+      // to a storage-pattern predicate before either happens.
       const mergedEntity = options.isSingletonEntityId?.(conflict.entityId)
         ? { ...baseEntity, ...updateChanges }
         : { ...baseEntity, ...updateChanges, id: conflict.entityId };

--- a/src/app/op-log/apply/operation-converter.util.spec.ts
+++ b/src/app/op-log/apply/operation-converter.util.spec.ts
@@ -1040,6 +1040,28 @@ describe('operation-converter utility', () => {
         expect((action as { id?: unknown }).id).toBe('task-B');
       });
 
+      // Lockstep residual (#9256): the converter derives the LWW target from the
+      // action type — the SAME plaintext field the integrity gate skips on and
+      // the meta-reducer branches on. A compromised server that swaps a TASK op's
+      // actionType to a singleton type to skip the gate therefore lands it as a
+      // whole-slice singleton replace (id stripped), NOT an adapter retarget: the
+      // authenticated task id can never address a TASK entity here. This pins the
+      // documented, pre-existing actionType-swap residual so a future edit that
+      // decoupled the gate/reducer targets could not silently turn it into a
+      // TASK retarget. See verify-decrypted-op-integrity.ts (OPEN residual note).
+      it('treats an actionType swapped to a singleton as a singleton replace, never a TASK retarget (#9256)', () => {
+        const op = createMockOperation({
+          actionType: '[TIME_TRACKING] LWW Update' as ActionType,
+          entityType: 'TASK',
+          entityId: 'task-A',
+          payload: { id: 'task-A', title: 'Authenticated task' },
+        });
+        const action = convertOpToAction(op);
+
+        expect(action.type).toBe('[TIME_TRACKING] LWW Update');
+        expect((action as { id?: unknown }).id).toBeUndefined();
+      });
+
       it('does NOT inject id for non-LWW action types', () => {
         const op = createMockOperation({
           actionType: '[Task] Update Task' as ActionType,

--- a/src/app/op-log/apply/operation-converter.util.spec.ts
+++ b/src/app/op-log/apply/operation-converter.util.spec.ts
@@ -851,10 +851,9 @@ describe('operation-converter utility', () => {
       });
     });
 
-    // Issue #7330: LWW Update apply path requires payload.id to be set so
-    // lwwUpdateMetaReducer can write the entity. Producers force this on the
-    // on-disk shape, but as a universal safety net the converter backfills
-    // payload.id from op.entityId for any LWW Update op missing it.
+    // Issue #7330: adapter-backed LWW Update apply requires payload.id so the
+    // meta-reducer can address an entity. Producers force this on the on-disk
+    // shape, while the converter remains the apply-boundary safety net.
     describe('LWW Update id backfill (#7330)', () => {
       it('injects id from op.entityId into adapter LWW Update payloads when missing', () => {
         const op = createMockOperation({
@@ -946,6 +945,58 @@ describe('operation-converter utility', () => {
 
         expect((action as any).id).toBeUndefined();
         expect((action as any).theme).toBe('dark');
+      });
+
+      it('does NOT inject id for a TIME_TRACKING singleton with a composite conflict id (#9256)', () => {
+        const op = createMockOperation({
+          actionType: '[TIME_TRACKING] LWW Update' as ActionType,
+          entityType: 'TIME_TRACKING',
+          entityId: 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24',
+          payload: { project: {}, tag: {} },
+          timestamp: 1774332392933,
+        });
+        const action = convertOpToAction(op);
+
+        expect((action as { id?: unknown }).id).toBeUndefined();
+      });
+
+      it('strips an id injected by affected clients from TIME_TRACKING singleton state (#9256)', () => {
+        const op = createMockOperation({
+          actionType: '[TIME_TRACKING] LWW Update' as ActionType,
+          entityType: 'TIME_TRACKING',
+          entityId: 'PROJECT:new-context:2026-03-24',
+          payload: {
+            id: 'PROJECT:stale-or-retagged-context:2026-03-24',
+            project: {},
+            tag: {},
+          },
+        });
+        const action = convertOpToAction(op);
+
+        expect((action as { id?: unknown }).id).toBeUndefined();
+      });
+
+      it('does not throw for a malformed null singleton payload', () => {
+        const op = createMockOperation({
+          actionType: '[TIME_TRACKING] LWW Update' as ActionType,
+          entityType: 'TIME_TRACKING',
+          entityId: 'PROJECT:project-1:2026-03-24',
+          payload: null,
+        });
+
+        expect(() => convertOpToAction(op)).not.toThrow();
+      });
+
+      it('still enforces the TASK id when only the plaintext entityType says TIME_TRACKING', () => {
+        const op = createMockOperation({
+          actionType: '[TASK] LWW Update' as ActionType,
+          entityType: 'TIME_TRACKING',
+          entityId: 'task-B',
+          payload: { id: 'task-A', title: 'Authenticated task' },
+        });
+        const action = convertOpToAction(op);
+
+        expect((action as { id?: unknown }).id).toBe('task-B');
       });
 
       it('does NOT inject id for non-LWW action types', () => {

--- a/src/app/op-log/apply/operation-converter.util.spec.ts
+++ b/src/app/op-log/apply/operation-converter.util.spec.ts
@@ -869,6 +869,19 @@ describe('operation-converter utility', () => {
         expect((action as any).title).toBe('Recovered');
       });
 
+      it('does not throw for a wrapped adapter LWW payload without actionPayload', () => {
+        const op = createMockOperation({
+          actionType: '[TASK] LWW Update' as ActionType,
+          entityId: 'task-789',
+          payload: {
+            entityChanges: [],
+            lwwUpdateMode: 'replace',
+          },
+        });
+
+        expect(() => convertOpToAction(op)).not.toThrow();
+      });
+
       it('preserves payload id when it already matches op.entityId', () => {
         const op = createMockOperation({
           actionType: '[TASK] LWW Update' as ActionType,
@@ -922,6 +935,30 @@ describe('operation-converter utility', () => {
         expect(JSON.stringify(logCall.args)).not.toContain('should not leak');
       });
 
+      it('does not serialize a malformed non-string payload.id into the warning', () => {
+        const warnSpy = spyOn(SyncLog, 'warn');
+        const privatePayloadContent = 'private task title';
+        const op = createMockOperation({
+          actionType: '[TASK] LWW Update' as ActionType,
+          entityId: 'task-canonical',
+          payload: { id: [{ title: privatePayloadContent }] },
+        });
+
+        const action = convertOpToAction(op);
+
+        expect((action as { id?: unknown }).id).toBe('task-canonical');
+        expect(warnSpy).toHaveBeenCalledWith(
+          jasmine.stringMatching(/payload\.id mismatch/),
+          jasmine.objectContaining({
+            entityId: 'task-canonical',
+            payloadId: '<array>',
+          }),
+        );
+        expect(JSON.stringify(warnSpy.calls.mostRecent().args)).not.toContain(
+          privatePayloadContent,
+        );
+      });
+
       it('does not warn when payload.id already matches op.entityId', () => {
         const warnSpy = spyOn(SyncLog, 'warn');
         const op = createMockOperation({
@@ -948,16 +985,20 @@ describe('operation-converter utility', () => {
       });
 
       it('does NOT inject id for a TIME_TRACKING singleton with a composite conflict id (#9256)', () => {
+        const project = { project1: { day1: 120000 } };
+        const tag = { tag1: { day1: 30000 } };
         const op = createMockOperation({
           actionType: '[TIME_TRACKING] LWW Update' as ActionType,
           entityType: 'TIME_TRACKING',
           entityId: 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24',
-          payload: { project: {}, tag: {} },
+          payload: { project, tag },
           timestamp: 1774332392933,
         });
         const action = convertOpToAction(op);
 
         expect((action as { id?: unknown }).id).toBeUndefined();
+        expect((action as { project?: unknown }).project).toEqual(project);
+        expect((action as { tag?: unknown }).tag).toEqual(tag);
       });
 
       it('strips an id injected by affected clients from TIME_TRACKING singleton state (#9256)', () => {

--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -6,8 +6,8 @@ import {
   Operation,
   OpType,
 } from '../core/operation.types';
-import { isLwwUpdateActionType } from '../core/lww-update-action-types';
-import { isSingletonEntityId } from '../core/entity-registry';
+import { getLwwEntityType } from '../core/lww-update-action-types';
+import { getEntityConfig, isLwwPayloadIdCanonical } from '../core/entity-registry';
 import { PersistentAction } from '../core/persistent-action.interface';
 import { SyncLog } from '../../core/log';
 import { isValidDBDateStr } from '../../util/get-db-date-str';
@@ -255,6 +255,7 @@ const assertValidTaskTimeSyncPayload = (
 export const convertOpToAction = (op: Operation): PersistentAction => {
   // Resolve any aliased action types to their current names
   const actionType = ACTION_TYPE_ALIASES[op.actionType] ?? op.actionType;
+  const lwwEntityType = getLwwEntityType(actionType);
 
   // Handle full-state operations (SYNC_IMPORT, BACKUP_IMPORT, Repair) specially
   // These need their payload wrapped in appDataComplete for the loadAllData action
@@ -275,21 +276,35 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
   );
   assertValidTaskTimeSyncPayload(actionType, actionPayload, op);
 
-  // Force `payload.id = op.entityId` for non-singleton LWW Update ops. The
-  // op's `entityId` is the canonical identifier — producers also enforce
-  // this when creating ops, but a malformed/older remote op (or any path
-  // that ever drifts) could carry a payload.id that disagrees with
-  // op.entityId, in which case the consumer reducer at
-  // task-shared-meta-reducers/lww-update.meta-reducer.ts trusts payload.id
-  // and would update the WRONG entity. Forcing here makes "entityId is
-  // canonical" a hard invariant at the apply boundary regardless of
-  // producer or wire shape. Singletons use `SINGLETON_ENTITY_ID` and have
-  // no `id` field. Issue #7330.
+  // Affected #7330 clients injected conflict keys as `id` into singleton LWW
+  // payloads. Singleton models have no top-level id, so remove it based on the
+  // action-derived reducer target rather than comparing against unauthenticated
+  // envelope metadata. This also cleans stale ids already carried in state.
   if (
     !isFullStateOp &&
-    isLwwUpdateActionType(actionType) &&
+    lwwEntityType !== undefined &&
+    getEntityConfig(lwwEntityType)?.storagePattern === 'singleton' &&
+    actionPayload &&
+    typeof actionPayload === 'object' &&
+    Object.hasOwn(actionPayload, 'id')
+  ) {
+    actionPayload = { ...actionPayload };
+    delete actionPayload['id'];
+  }
+
+  // Force `payload.id = op.entityId` for adapter-backed LWW Update ops. The
+  // op's `entityId` is the canonical identifier for adapters — producers also
+  // enforce this when creating ops, but a malformed/older remote op (or any
+  // path that ever drifts) could carry a payload.id that disagrees with
+  // op.entityId, in which case the consumer reducer at
+  // task-shared-meta-reducers/lww-update.meta-reducer.ts trusts payload.id and
+  // would update the WRONG entity. Singleton LWW actions target their feature
+  // state as a whole; their conflict-routing entityId may be composite and must
+  // not be injected into that state. Issues #7330, #9256.
+  if (
+    !isFullStateOp &&
+    isLwwPayloadIdCanonical(lwwEntityType) &&
     op.entityId &&
-    !isSingletonEntityId(op.entityId) &&
     actionPayload &&
     typeof actionPayload === 'object' &&
     actionPayload['id'] !== op.entityId

--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -15,23 +15,6 @@ import { isValidDBDateStr } from '../../util/get-db-date-str';
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const MAX_ARRAY_INDEX = 4_294_967_294;
-
-const isCanonicalArrayIndexKey = (key: string): boolean => {
-  const index = Number(key);
-  return (
-    Number.isInteger(index) &&
-    index >= 0 &&
-    index <= MAX_ARRAY_INDEX &&
-    String(index) === key
-  );
-};
-
-const isLegacyArraySpreadRecord = (value: Record<string, unknown>): boolean => {
-  const stateKeys = Object.keys(value).filter((key) => key !== 'id');
-  return stateKeys.length > 0 && stateKeys.every(isCanonicalArrayIndexKey);
-};
-
 const getValueType = (value: unknown): string => {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'array';
@@ -295,21 +278,16 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
     ? extractFullStatePayload(op.payload)
     : (extractActionPayload(op.payload) as Record<string, unknown>);
 
-  // JSON primitives and arrays are object-spreadable at runtime. Legacy
-  // producers may already have serialized that spread as a numeric-key record.
-  // Without this guard, the LWW reducer mistakes either shape for non-empty
-  // singleton state and replaces the entire feature slice with it.
-  if (
-    isSingletonLww &&
-    (!isRecord(actionPayload) || isLegacyArraySpreadRecord(actionPayload))
-  ) {
+  // JSON primitives and arrays are object-spreadable at runtime: a non-record
+  // singleton payload such as "x" or ["x"] would spread into { 0: "x" }, which
+  // the LWW reducer mistakes for non-empty singleton state and uses to replace
+  // the entire feature slice. Normalize it to the reducer's empty-data no-op.
+  if (isSingletonLww && !isRecord(actionPayload)) {
     SyncLog.warn('[convertOpToAction] malformed singleton LWW payload — ignoring', {
       opId: op.id,
       actionType,
       entityType: lwwEntityType,
-      payloadType: isRecord(actionPayload)
-        ? 'legacy-array-spread-record'
-        : getValueType(actionPayload),
+      payloadType: getValueType(actionPayload),
     });
     actionPayload = {};
   }

--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -12,6 +12,9 @@ import { PersistentAction } from '../core/persistent-action.interface';
 import { SyncLog } from '../../core/log';
 import { isValidDBDateStr } from '../../util/get-db-date-str';
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
 const isValidDbDate = (value: unknown): value is string =>
   typeof value === 'string' && isValidDBDateStr(value);
 
@@ -260,10 +263,33 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
   // Handle full-state operations (SYNC_IMPORT, BACKUP_IMPORT, Repair) specially
   // These need their payload wrapped in appDataComplete for the loadAllData action
   const isFullStateOp = FULL_STATE_OP_TYPES.has(op.opType as OpType);
+  const isSingletonLww =
+    !isFullStateOp &&
+    lwwEntityType !== undefined &&
+    getEntityConfig(lwwEntityType)?.storagePattern === 'singleton';
   const replayActionType = isFullStateOp ? ActionType.LOAD_ALL_DATA : actionType;
   let actionPayload: Record<string, unknown> = isFullStateOp
     ? extractFullStatePayload(op.payload)
     : (extractActionPayload(op.payload) as Record<string, unknown>);
+
+  // JSON primitives and arrays are object-spreadable at runtime. Without this
+  // guard, a malformed singleton payload such as "x" becomes { 0: "x" }, which
+  // the LWW reducer mistakes for non-empty state and uses to replace the entire
+  // feature slice. Normalize it to the reducer's existing empty-data no-op.
+  if (isSingletonLww && !isRecord(actionPayload)) {
+    SyncLog.warn('[convertOpToAction] malformed singleton LWW payload — ignoring', {
+      opId: op.id,
+      actionType,
+      entityType: lwwEntityType,
+      payloadType:
+        actionPayload === null
+          ? 'null'
+          : Array.isArray(actionPayload)
+            ? 'array'
+            : typeof actionPayload,
+    });
+    actionPayload = {};
+  }
 
   actionPayload = addLegacyPlanForTodayDate(actionType, actionPayload, op);
   actionPayload = addLegacyConvertToMainTaskDates(actionType, actionPayload, op);
@@ -280,14 +306,7 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
   // payloads. Singleton models have no top-level id, so remove it based on the
   // action-derived reducer target rather than comparing against unauthenticated
   // envelope metadata. This also cleans stale ids already carried in state.
-  if (
-    !isFullStateOp &&
-    lwwEntityType !== undefined &&
-    getEntityConfig(lwwEntityType)?.storagePattern === 'singleton' &&
-    actionPayload &&
-    typeof actionPayload === 'object' &&
-    Object.hasOwn(actionPayload, 'id')
-  ) {
+  if (isSingletonLww && Object.hasOwn(actionPayload, 'id')) {
     actionPayload = { ...actionPayload };
     delete actionPayload['id'];
   }

--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -15,6 +15,23 @@ import { isValidDBDateStr } from '../../util/get-db-date-str';
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+const MAX_ARRAY_INDEX = 4_294_967_294;
+
+const isCanonicalArrayIndexKey = (key: string): boolean => {
+  const index = Number(key);
+  return (
+    Number.isInteger(index) &&
+    index >= 0 &&
+    index <= MAX_ARRAY_INDEX &&
+    String(index) === key
+  );
+};
+
+const isLegacyArraySpreadRecord = (value: Record<string, unknown>): boolean => {
+  const stateKeys = Object.keys(value).filter((key) => key !== 'id');
+  return stateKeys.length > 0 && stateKeys.every(isCanonicalArrayIndexKey);
+};
+
 const getValueType = (value: unknown): string => {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'array';
@@ -278,16 +295,21 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
     ? extractFullStatePayload(op.payload)
     : (extractActionPayload(op.payload) as Record<string, unknown>);
 
-  // JSON primitives and arrays are object-spreadable at runtime. Without this
-  // guard, a malformed singleton payload such as "x" becomes { 0: "x" }, which
-  // the LWW reducer mistakes for non-empty state and uses to replace the entire
-  // feature slice. Normalize it to the reducer's existing empty-data no-op.
-  if (isSingletonLww && !isRecord(actionPayload)) {
+  // JSON primitives and arrays are object-spreadable at runtime. Legacy
+  // producers may already have serialized that spread as a numeric-key record.
+  // Without this guard, the LWW reducer mistakes either shape for non-empty
+  // singleton state and replaces the entire feature slice with it.
+  if (
+    isSingletonLww &&
+    (!isRecord(actionPayload) || isLegacyArraySpreadRecord(actionPayload))
+  ) {
     SyncLog.warn('[convertOpToAction] malformed singleton LWW payload — ignoring', {
       opId: op.id,
       actionType,
       entityType: lwwEntityType,
-      payloadType: getValueType(actionPayload),
+      payloadType: isRecord(actionPayload)
+        ? 'legacy-array-spread-record'
+        : getValueType(actionPayload),
     });
     actionPayload = {};
   }

--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -15,6 +15,12 @@ import { isValidDBDateStr } from '../../util/get-db-date-str';
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+const getValueType = (value: unknown): string => {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+};
+
 const isValidDbDate = (value: unknown): value is string =>
   typeof value === 'string' && isValidDBDateStr(value);
 
@@ -281,12 +287,7 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
       opId: op.id,
       actionType,
       entityType: lwwEntityType,
-      payloadType:
-        actionPayload === null
-          ? 'null'
-          : Array.isArray(actionPayload)
-            ? 'array'
-            : typeof actionPayload,
+      payloadType: getValueType(actionPayload),
     });
     actionPayload = {};
   }
@@ -324,10 +325,10 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
     !isFullStateOp &&
     isLwwPayloadIdCanonical(lwwEntityType) &&
     op.entityId &&
-    actionPayload &&
-    typeof actionPayload === 'object' &&
+    isRecord(actionPayload) &&
     actionPayload['id'] !== op.entityId
   ) {
+    const payloadId = actionPayload['id'];
     // The hard rewrite is correct in direction (canonical entityId wins),
     // but it silently fixes a producer/wire bug. Surface it so we can
     // detect if the assumption ever breaks in production. Log only the
@@ -336,7 +337,8 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
       actionType,
       entityType: op.entityType,
       entityId: op.entityId,
-      payloadId: actionPayload['id'],
+      payloadId:
+        typeof payloadId === 'string' ? payloadId : `<${getValueType(payloadId)}>`,
     });
     actionPayload = { ...actionPayload, id: op.entityId };
   }

--- a/src/app/op-log/core/entity-registry.spec.ts
+++ b/src/app/op-log/core/entity-registry.spec.ts
@@ -8,6 +8,7 @@ import {
   isSingletonEntity,
   isMapEntity,
   isArrayEntity,
+  isLwwPayloadIdCanonical,
   EntityConfig,
 } from './entity-registry';
 
@@ -65,6 +66,17 @@ describe('entity-registry', () => {
     'PLUGIN_USER_DATA',
     'PLUGIN_METADATA',
   ];
+
+  describe('LWW payload id semantics', () => {
+    it('uses payload.id only for adapter-backed entities', () => {
+      expect(isLwwPayloadIdCanonical('TASK')).toBeTrue();
+      expect(isLwwPayloadIdCanonical('TIME_TRACKING')).toBeFalse();
+      expect(isLwwPayloadIdCanonical('PLANNER')).toBeFalse();
+      expect(isLwwPayloadIdCanonical('ALL')).toBeFalse();
+      expect(isLwwPayloadIdCanonical('UNKNOWN')).toBeFalse();
+      expect(isLwwPayloadIdCanonical(undefined)).toBeFalse();
+    });
+  });
 
   describe('ENTITY_CONFIGS completeness', () => {
     it('should have config for all regular entity types', () => {

--- a/src/app/op-log/core/entity-registry.spec.ts
+++ b/src/app/op-log/core/entity-registry.spec.ts
@@ -76,6 +76,29 @@ describe('entity-registry', () => {
       expect(isLwwPayloadIdCanonical('UNKNOWN')).toBeFalse();
       expect(isLwwPayloadIdCanonical(undefined)).toBeFalse();
     });
+
+    // #9256 was a MISCLASSIFICATION (a composite-id singleton mistaken for an
+    // adapter). Pin the payload-id verdict for EVERY entity so a future
+    // storagePattern change can't silently re-open the retarget gate for the
+    // wrong entity or slam it shut on a legitimate one. Table is exhaustive over
+    // ENTITY_CONFIGS via the categorized lists above.
+    it('is canonical for exactly the adapter entities and no others', () => {
+      for (const entityType of ADAPTER_ENTITIES) {
+        expect(isLwwPayloadIdCanonical(entityType))
+          .withContext(`adapter ${entityType} → canonical`)
+          .toBeTrue();
+      }
+      for (const entityType of [
+        ...SINGLETON_ENTITIES,
+        ...MAP_ENTITIES,
+        ...ARRAY_ENTITIES,
+        ...SPECIAL_OPERATION_TYPES,
+      ]) {
+        expect(isLwwPayloadIdCanonical(entityType))
+          .withContext(`non-adapter ${entityType} → not canonical`)
+          .toBeFalse();
+      }
+    });
   });
 
   describe('ENTITY_CONFIGS completeness', () => {

--- a/src/app/op-log/core/entity-registry.ts
+++ b/src/app/op-log/core/entity-registry.ts
@@ -368,12 +368,22 @@ export const getPayloadKey = (entityType: EntityType): string | undefined =>
   getPayloadKeyFromRegistry(ENTITY_CONFIGS, entityType);
 
 /**
+ * Whether an LWW action payload's top-level `id` selects the state that the
+ * LWW meta-reducer applies. Only adapter-backed entities are addressed by that
+ * field; singleton actions target their registered feature state as a whole.
+ */
+export const isLwwPayloadIdCanonical = (entityType: string | undefined): boolean =>
+  entityType !== undefined &&
+  ENTITY_CONFIGS[entityType as EntityType]?.storagePattern === 'adapter';
+
+/**
  * Sentinel `entityId` value used for singleton entities (`globalConfig`,
- * `metric`, etc.). These have no per-entity primary key, so the op-log
- * uses `'*'` to denote "the one and only" instance.
+ * `menuTree`, etc.). These have no per-entity primary key, so whole-state
+ * operations use `'*'` to denote "the one and only" instance.
  *
- * Used wherever singleton ops need to be distinguished from adapter ops,
- * e.g. when conditionally injecting `id` into LWW payloads.
+ * This is an operation-address sentinel, not a storage-pattern check:
+ * TIME_TRACKING uses contextual composite IDs for conflict routing even though
+ * its LWW reducer still targets singleton state as a whole.
  */
 export const SINGLETON_ENTITY_ID = '*' as const;
 

--- a/src/app/op-log/core/entity-registry.ts
+++ b/src/app/op-log/core/entity-registry.ts
@@ -377,13 +377,16 @@ export const isLwwPayloadIdCanonical = (entityType: string | undefined): boolean
   ENTITY_CONFIGS[entityType as EntityType]?.storagePattern === 'adapter';
 
 /**
- * Sentinel `entityId` value used for singleton entities (`globalConfig`,
- * `menuTree`, etc.). These have no per-entity primary key, so whole-state
- * operations use `'*'` to denote "the one and only" instance.
+ * Sentinel `entityId` value denoting "the one and only" instance of an entity
+ * that has no per-entity primary key.
  *
- * This is an operation-address sentinel, not a storage-pattern check:
- * TIME_TRACKING uses contextual composite IDs for conflict routing even though
- * its LWW reducer still targets singleton state as a whole.
+ * This is an operation-address sentinel, NOT a storage-pattern check — and in
+ * practice no shipped singleton producer emits it: GLOBAL_CONFIG addresses ops
+ * by section key (`'misc'`, `'sync'`, …), MENU_TREE by `'projectTree'` /
+ * `'tagTree'` / folderId, TIME_TRACKING by a composite `TYPE:id:date` conflict
+ * key. All of them still target their feature state as a whole in the LWW
+ * reducer. Use `isLwwPayloadIdCanonical` to ask "does payload.id address the
+ * state?"; use this only to recognize the whole-state address form.
  */
 export const SINGLETON_ENTITY_ID = '*' as const;
 

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -8349,40 +8349,5 @@ describe('ConflictResolutionService', () => {
       const updatedState = baseReducer.calls.mostRecent().args[0] as typeof state;
       expect(updatedState[TIME_TRACKING_FEATURE_KEY]).toEqual({ project, tag });
     });
-
-    it('preserves TIME_TRACKING state when malformed array state crosses the LWW pipeline (#9256)', () => {
-      const entityId = 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24';
-      const op = service.createLWWUpdateOp(
-        'TIME_TRACKING',
-        entityId,
-        ['private-time-entry'],
-        TEST_CLIENT_ID,
-        { [TEST_CLIENT_ID]: 1 },
-        1774332392933,
-      );
-      const existingTimeTracking = {
-        project: { project1: { day1: 120000 } },
-        tag: {},
-      };
-      const state = { [TIME_TRACKING_FEATURE_KEY]: existingTimeTracking };
-      const baseReducer = jasmine
-        .createSpy('baseReducer')
-        .and.callFake((currentState: unknown) => currentState);
-      const reducer = lwwUpdateMetaReducer(baseReducer);
-
-      if (!jasmine.isSpy(window.alert)) {
-        spyOn(window, 'alert');
-      }
-      if (!jasmine.isSpy(window.confirm)) {
-        spyOn(window, 'confirm').and.returnValue(false);
-      } else {
-        (window.confirm as jasmine.Spy).and.returnValue(false);
-      }
-
-      reducer(state, convertOpToAction(op));
-
-      const updatedState = baseReducer.calls.mostRecent().args[0] as typeof state;
-      expect(updatedState[TIME_TRACKING_FEATURE_KEY]).toBe(existingTimeTracking);
-    });
   });
 });

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -8391,9 +8391,13 @@ describe('ConflictResolutionService', () => {
       );
       const payload = extractActionPayload(op.payload);
 
-      // Old clients accept it BECAUSE of the compat id...
+      // LOAD-BEARING: this is what fails if the producer ever stops emitting the
+      // compat id — drop `|| !isSingletonEntityId(entityId)` from createLWWUpdateOp
+      // (the SUNSET cleanup, done too early) and old clients reject the op again.
       expect(acceptedByV1815Gate(op.actionType, entityId, payload)).toBeTrue();
-      // ...and non-vacuous: strip the compat id and old clients reproduce #9256.
+      // Guards the SIMULATION, not the producer: proves the copied v18.15.1
+      // predicate still discriminates, so the assertion above cannot pass because
+      // the helper degenerated into returning true for everything.
       const withoutCompatId = { ...payload };
       delete withoutCompatId['id'];
       expect(acceptedByV1815Gate(op.actionType, entityId, withoutCompatId)).toBeFalse();

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -36,6 +36,9 @@ import { OperationLogEffects } from '../capture/operation-log.effects';
 import { IncompleteRemoteOperationsError } from '../core/errors/sync-errors';
 import { ConflictJournalService } from './conflict-journal.service';
 import { toLwwUpdateActionType } from '../core/lww-update-action-types';
+import { convertOpToAction } from '../apply/operation-converter.util';
+import { TIME_TRACKING_FEATURE_KEY } from '../../features/time-tracking/store/time-tracking.reducer';
+import { lwwUpdateMetaReducer } from '../../root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer';
 
 describe('ConflictResolutionService', () => {
   let service: ConflictResolutionService;
@@ -8291,11 +8294,13 @@ describe('ConflictResolutionService', () => {
       expect(extractActionPayload(op.payload)).toEqual(singletonState);
     });
 
-    it('keeps a compatibility id for v18.15 TIME_TRACKING receivers (#9256)', () => {
+    it('keeps the compatibility id on wire and preserves TIME_TRACKING data on replay (#9256)', () => {
+      const project = { project1: { day1: 120000 } };
+      const tag = { tag1: { day1: 30000 } };
       const pollutedSingletonState = {
         id: 'PROJECT:stale-context:2026-03-23',
-        project: {},
-        tag: {},
+        project,
+        tag,
       };
       const entityId = 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24';
       const op = service.createLWWUpdateOp(
@@ -8312,9 +8317,56 @@ describe('ConflictResolutionService', () => {
       // this compatibility-only field before replacing singleton state.
       expect(extractActionPayload(op.payload)).toEqual({
         id: entityId,
-        project: {},
-        tag: {},
+        project,
+        tag,
       });
+
+      const existingTimeTracking = { project: {}, tag: {} };
+      const state = { [TIME_TRACKING_FEATURE_KEY]: existingTimeTracking };
+      const baseReducer = jasmine
+        .createSpy('baseReducer')
+        .and.callFake((currentState: unknown) => currentState);
+      const reducer = lwwUpdateMetaReducer(baseReducer);
+
+      reducer(state, convertOpToAction(op));
+
+      const updatedState = baseReducer.calls.mostRecent().args[0] as typeof state;
+      expect(updatedState[TIME_TRACKING_FEATURE_KEY]).toEqual({ project, tag });
+    });
+
+    it('preserves TIME_TRACKING state when malformed array state crosses the LWW pipeline (#9256)', () => {
+      const entityId = 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24';
+      const op = service.createLWWUpdateOp(
+        'TIME_TRACKING',
+        entityId,
+        ['private-time-entry'],
+        TEST_CLIENT_ID,
+        { [TEST_CLIENT_ID]: 1 },
+        1774332392933,
+      );
+      const existingTimeTracking = {
+        project: { project1: { day1: 120000 } },
+        tag: {},
+      };
+      const state = { [TIME_TRACKING_FEATURE_KEY]: existingTimeTracking };
+      const baseReducer = jasmine
+        .createSpy('baseReducer')
+        .and.callFake((currentState: unknown) => currentState);
+      const reducer = lwwUpdateMetaReducer(baseReducer);
+
+      if (!jasmine.isSpy(window.alert)) {
+        spyOn(window, 'alert');
+      }
+      if (!jasmine.isSpy(window.confirm)) {
+        spyOn(window, 'confirm').and.returnValue(false);
+      } else {
+        (window.confirm as jasmine.Spy).and.returnValue(false);
+      }
+
+      reducer(state, convertOpToAction(op));
+
+      const updatedState = baseReducer.calls.mostRecent().args[0] as typeof state;
+      expect(updatedState[TIME_TRACKING_FEATURE_KEY]).toBe(existingTimeTracking);
     });
   });
 });

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -8294,6 +8294,22 @@ describe('ConflictResolutionService', () => {
       expect(extractActionPayload(op.payload)).toEqual(singletonState);
     });
 
+    it('preserves a PLANNER day task-id array in the LWW payload', () => {
+      const day = '2026-03-24';
+      const op = service.createLWWUpdateOp(
+        'PLANNER',
+        day,
+        ['task-1', 'task-2'],
+        TEST_CLIENT_ID,
+        { [TEST_CLIENT_ID]: 1 },
+        1774332392933,
+      );
+
+      const actionPayload = extractActionPayload(op.payload);
+      expect(actionPayload['0']).toBe('task-1');
+      expect(actionPayload['1']).toBe('task-2');
+    });
+
     it('keeps the compatibility id on wire and preserves TIME_TRACKING data on replay (#9256)', () => {
       const project = { project1: { day1: 120000 } };
       const tag = { tag1: { day1: 30000 } };

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -30,12 +30,19 @@ import {
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
 import { MAX_VECTOR_CLOCK_SIZE } from '../core/operation-log.const';
-import { buildEntityRegistry, ENTITY_REGISTRY } from '../core/entity-registry';
+import {
+  buildEntityRegistry,
+  ENTITY_REGISTRY,
+  isSingletonEntityId,
+} from '../core/entity-registry';
 import { WorkContextType } from '../../features/work-context/work-context.model';
 import { OperationLogEffects } from '../capture/operation-log.effects';
 import { IncompleteRemoteOperationsError } from '../core/errors/sync-errors';
 import { ConflictJournalService } from './conflict-journal.service';
-import { toLwwUpdateActionType } from '../core/lww-update-action-types';
+import {
+  isLwwUpdateActionType,
+  toLwwUpdateActionType,
+} from '../core/lww-update-action-types';
 import { convertOpToAction } from '../apply/operation-converter.util';
 import { TIME_TRACKING_FEATURE_KEY } from '../../features/time-tracking/store/time-tracking.reducer';
 import { lwwUpdateMetaReducer } from '../../root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer';
@@ -8348,6 +8355,48 @@ describe('ConflictResolutionService', () => {
 
       const updatedState = baseReducer.calls.mostRecent().args[0] as typeof state;
       expect(updatedState[TIME_TRACKING_FEATURE_KEY]).toEqual({ project, tag });
+    });
+
+    it('produces TIME_TRACKING ops that shipped v18.15.0/v18.15.1 clients still accept (#9256)', () => {
+      // Faithful copy of the v18.15.1 metadata-integrity predicate
+      // (git show v18.15.1:src/app/op-log/sync/verify-decrypted-op-integrity.ts):
+      // a non-'*' LWW entityId demands payload.id === entityId, else it throws
+      // OperationIntegrityError (the #9256 rejection). This branch does NOT ship a
+      // schema bump, so those released clients run exactly this on our new ops —
+      // the compat id is what keeps a mixed fleet syncing (graceful degradation).
+      const acceptedByV1815Gate = (
+        actionType: string,
+        entityId: string,
+        payload: Record<string, unknown>,
+      ): boolean => {
+        if (
+          !isLwwUpdateActionType(actionType) ||
+          !entityId ||
+          isSingletonEntityId(entityId)
+        ) {
+          return true;
+        }
+        const payloadId = payload['id'];
+        return typeof payloadId === 'string' && payloadId === entityId;
+      };
+
+      const entityId = 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24';
+      const op = service.createLWWUpdateOp(
+        'TIME_TRACKING',
+        entityId,
+        { project: {}, tag: {} },
+        TEST_CLIENT_ID,
+        { [TEST_CLIENT_ID]: 1 },
+        1774332392933,
+      );
+      const payload = extractActionPayload(op.payload);
+
+      // Old clients accept it BECAUSE of the compat id...
+      expect(acceptedByV1815Gate(op.actionType, entityId, payload)).toBeTrue();
+      // ...and non-vacuous: strip the compat id and old clients reproduce #9256.
+      const withoutCompatId = { ...payload };
+      delete withoutCompatId['id'];
+      expect(acceptedByV1815Gate(op.actionType, entityId, withoutCompatId)).toBeFalse();
     });
   });
 });

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -8045,12 +8045,12 @@ describe('ConflictResolutionService', () => {
     });
   });
 
-  describe('LWW Update payload always has top-level id (#7330)', () => {
-    // The lwwUpdateMetaReducer bails with "Entity data has no id" when an LWW
-    // Update payload lacks a top-level id. createLWWUpdateOp is the choke point
-    // for two of three LWW Update producers (_createLocalWinUpdateOp and the
-    // superseded-operation-resolver). Both pass the canonical entityId — so the
-    // payload should always carry it, even when entityState was malformed.
+  describe('adapter LWW Update payload has a top-level id (#7330)', () => {
+    // The lwwUpdateMetaReducer bails with "Entity data has no id" when an
+    // adapter LWW Update payload lacks a top-level id. createLWWUpdateOp is the
+    // choke point for the local-win and superseded-operation producers. Both
+    // pass the canonical entityId, so adapter payloads must carry it even when
+    // entityState was malformed.
 
     it('should backfill payload.id from entityId when entityState lacks id', () => {
       const entityStateWithoutId = { title: 'Local winner', projectId: 'proj-1' };
@@ -8260,11 +8260,9 @@ describe('ConflictResolutionService', () => {
       expect(payload['projectId']).toBe('proj-1');
     });
 
-    // Singletons (GLOBAL_CONFIG, app-state, time-tracking) use entityId='*'
-    // as a sentinel. Injecting `id: '*'` into the payload would pollute the
-    // singleton feature state — which has no `id` field — when the consumer
-    // reducer spreads entityData into the feature state.
-    it('should NOT inject id when entityId is the singleton sentinel "*"', () => {
+    // Singleton LWW reducers target a whole feature slice, so neither the '*'
+    // sentinel nor a contextual conflict key belongs in payload state.
+    it('should NOT inject id for a GLOBAL_CONFIG singleton', () => {
       const singletonState = { sync: { syncProvider: null }, misc: { foo: 'bar' } };
       const op = service.createLWWUpdateOp(
         'GLOBAL_CONFIG',
@@ -8278,6 +8276,25 @@ describe('ConflictResolutionService', () => {
       expect(extractActionPayload(op.payload)['id']).toBeUndefined();
       // Original action payload shape is preserved (no synthetic field injected).
       expect(extractActionPayload(op.payload)).toEqual(singletonState);
+    });
+
+    it('should NOT inject id for a TIME_TRACKING singleton with a composite conflict id (#9256)', () => {
+      const pollutedSingletonState = {
+        id: 'PROJECT:stale-context:2026-03-23',
+        project: {},
+        tag: {},
+      };
+      const op = service.createLWWUpdateOp(
+        'TIME_TRACKING',
+        'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24',
+        pollutedSingletonState,
+        TEST_CLIENT_ID,
+        { [TEST_CLIENT_ID]: 1 },
+        1774332392933,
+      );
+
+      expect(extractActionPayload(op.payload)['id']).toBeUndefined();
+      expect(extractActionPayload(op.payload)).toEqual({ project: {}, tag: {} });
     });
   });
 });

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -8084,6 +8084,19 @@ describe('ConflictResolutionService', () => {
       expect(extractActionPayload(op.payload)['id']).toBe('task-canonical');
     });
 
+    it('should keep the canonical id when an adapter receives the singleton sentinel', () => {
+      const op = service.createLWWUpdateOp(
+        'TASK',
+        '*',
+        { id: 'wrong-id', title: 'Local winner' },
+        TEST_CLIENT_ID,
+        { [TEST_CLIENT_ID]: 1 },
+        Date.now(),
+      );
+
+      expect(extractActionPayload(op.payload)['id']).toBe('*');
+    });
+
     it('should handle non-object entityState by producing { id } payload', () => {
       // Defensive: producers should never pass non-objects, but if they do
       // we still want a usable payload rather than something the reducer rejects.
@@ -8278,23 +8291,30 @@ describe('ConflictResolutionService', () => {
       expect(extractActionPayload(op.payload)).toEqual(singletonState);
     });
 
-    it('should NOT inject id for a TIME_TRACKING singleton with a composite conflict id (#9256)', () => {
+    it('keeps a compatibility id for v18.15 TIME_TRACKING receivers (#9256)', () => {
       const pollutedSingletonState = {
         id: 'PROJECT:stale-context:2026-03-23',
         project: {},
         tag: {},
       };
+      const entityId = 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24';
       const op = service.createLWWUpdateOp(
         'TIME_TRACKING',
-        'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24',
+        entityId,
         pollutedSingletonState,
         TEST_CLIENT_ID,
         { [TEST_CLIENT_ID]: 1 },
         1774332392933,
       );
 
-      expect(extractActionPayload(op.payload)['id']).toBeUndefined();
-      expect(extractActionPayload(op.payload)).toEqual({ project: {}, tag: {} });
+      // v18.15.0/v18.15.1 treat every non-'*' LWW entityId as canonical and
+      // reject encrypted payloads without a matching id. New receivers strip
+      // this compatibility-only field before replacing singleton state.
+      expect(extractActionPayload(op.payload)).toEqual({
+        id: entityId,
+        project: {},
+        tag: {},
+      });
     });
   });
 });

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -69,7 +69,12 @@ import {
 } from '../../core/util/vector-clock';
 import { devError } from '../../util/dev-error';
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
-import { ENTITY_REGISTRY, isSingletonEntityId } from '../core/entity-registry';
+import {
+  ENTITY_REGISTRY,
+  getEntityConfig,
+  isLwwPayloadIdCanonical,
+  isSingletonEntityId,
+} from '../core/entity-registry';
 import { uuidv7 } from '../../util/uuid-v7';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
 import { SYNC_LOGGER } from '../core/sync-logger.adapter';
@@ -462,16 +467,20 @@ export class ConflictResolutionService {
     // lwwUpdateMetaReducer bails with "Entity data has no id" when an adapter
     // payload lacks a top-level id; a malformed/partial entityState (e.g. an
     // NgRx selector returning a stripped shape) would silently lose the LWW
-    // write on remote clients. Singletons use the '*' sentinel for entityId
-    // and have no `id` field — injecting `id: '*'` would pollute the singleton
-    // feature state when the consumer reducer spreads entityData. (#7330)
+    // write on remote clients. Singleton LWW actions have no canonical payload
+    // id; their conflict key may be '*' or a contextual composite ID, and
+    // injecting either would pollute the feature state. Remove stale synthetic
+    // ids that an affected client may already carry. (#7330, #9256)
     const basePayload =
       entityState && typeof entityState === 'object'
         ? (entityState as Record<string, unknown>)
         : {};
-    const actionPayload = isSingletonEntityId(entityId)
-      ? basePayload
-      : { ...basePayload, id: entityId };
+    const actionPayload = { ...basePayload };
+    if (isLwwPayloadIdCanonical(entityType)) {
+      actionPayload['id'] = entityId;
+    } else if (getEntityConfig(entityType)?.storagePattern === 'singleton') {
+      delete actionPayload['id'];
+    }
     // Compute the move footprint once and carry it BOTH in the plaintext
     // envelope (op.entityIds — the server needs it for its indexed conflict
     // detection and cannot read the encrypted payload) AND inside the

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -473,15 +473,16 @@ export class ConflictResolutionService {
     // composite conflict IDs; current receivers strip it before replacing the
     // singleton feature state. Whole-state '*' singletons still omit it.
     // (#7330, #9256)
-    const entityConfig = getEntityConfigFromRegistry(this.entityRegistry, entityType);
-    const isMalformedSingletonState =
-      Array.isArray(entityState) &&
-      entityConfig !== undefined &&
-      isSingletonEntity(entityConfig);
+    //
+    // SUNSET: this `id` is purely for shipped v18.15.0/v18.15.1 receivers, which
+    // reject composite-id singleton ops that lack it. It rides inside the
+    // AES-GCM payload (so those receivers see an authenticated, matching id) and
+    // never touches the plaintext `op.entityIds`/vector-clock footprint. Remove
+    // it (and the receiver-side strip in operation-converter.util.ts) once those
+    // two versions are no longer in the active fleet — there is no schema bump to
+    // gate on, so this is a manual, fleet-age-based cleanup, not automatic.
     const basePayload =
-      entityState !== null &&
-      typeof entityState === 'object' &&
-      !isMalformedSingletonState
+      entityState !== null && typeof entityState === 'object'
         ? (entityState as Record<string, unknown>)
         : {};
     const actionPayload = { ...basePayload };

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -474,7 +474,9 @@ export class ConflictResolutionService {
     // singleton feature state. Whole-state '*' singletons still omit it.
     // (#7330, #9256)
     const basePayload =
-      entityState && typeof entityState === 'object'
+      entityState !== null &&
+      typeof entityState === 'object' &&
+      !Array.isArray(entityState)
         ? (entityState as Record<string, unknown>)
         : {};
     const actionPayload = { ...basePayload };

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -469,10 +469,14 @@ export class ConflictResolutionService {
     // write on remote clients.
     //
     // v18.15.0/v18.15.1 also require a matching payload id whenever entityId is
-    // not '*'. Keep that compatibility-only wire field for TIME_TRACKING's
-    // composite conflict IDs; current receivers strip it before replacing the
-    // singleton feature state. Whole-state '*' singletons still omit it.
-    // (#7330, #9256)
+    // not '*'. Keep that compatibility-only wire field; current receivers strip
+    // it before replacing the singleton feature state. (#7330, #9256)
+    //
+    // This covers EVERY singleton, not just TIME_TRACKING: no shipped singleton
+    // producer emits the '*' sentinel (GLOBAL_CONFIG addresses ops by section
+    // key, MENU_TREE by tree name / folderId, TIME_TRACKING by a composite
+    // TYPE:id:date key), so the else branch below is unreachable in practice and
+    // kept only as a guard for a future whole-state '*' producer.
     //
     // SUNSET: this `id` is purely for shipped v18.15.0/v18.15.1 receivers, which
     // reject composite-id singleton ops that lack it. It rides inside the

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -71,7 +71,6 @@ import { devError } from '../../util/dev-error';
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
 import {
   ENTITY_REGISTRY,
-  getEntityConfig,
   isLwwPayloadIdCanonical,
   isSingletonEntityId,
 } from '../core/entity-registry';
@@ -467,18 +466,21 @@ export class ConflictResolutionService {
     // lwwUpdateMetaReducer bails with "Entity data has no id" when an adapter
     // payload lacks a top-level id; a malformed/partial entityState (e.g. an
     // NgRx selector returning a stripped shape) would silently lose the LWW
-    // write on remote clients. Singleton LWW actions have no canonical payload
-    // id; their conflict key may be '*' or a contextual composite ID, and
-    // injecting either would pollute the feature state. Remove stale synthetic
-    // ids that an affected client may already carry. (#7330, #9256)
+    // write on remote clients.
+    //
+    // v18.15.0/v18.15.1 also require a matching payload id whenever entityId is
+    // not '*'. Keep that compatibility-only wire field for TIME_TRACKING's
+    // composite conflict IDs; current receivers strip it before replacing the
+    // singleton feature state. Whole-state '*' singletons still omit it.
+    // (#7330, #9256)
     const basePayload =
       entityState && typeof entityState === 'object'
         ? (entityState as Record<string, unknown>)
         : {};
     const actionPayload = { ...basePayload };
-    if (isLwwPayloadIdCanonical(entityType)) {
+    if (isLwwPayloadIdCanonical(entityType) || !isSingletonEntityId(entityId)) {
       actionPayload['id'] = entityId;
-    } else if (getEntityConfig(entityType)?.storagePattern === 'singleton') {
+    } else {
       delete actionPayload['id'];
     }
     // Compute the move footprint once and carry it BOTH in the plaintext

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -473,10 +473,15 @@ export class ConflictResolutionService {
     // composite conflict IDs; current receivers strip it before replacing the
     // singleton feature state. Whole-state '*' singletons still omit it.
     // (#7330, #9256)
+    const entityConfig = getEntityConfigFromRegistry(this.entityRegistry, entityType);
+    const isMalformedSingletonState =
+      Array.isArray(entityState) &&
+      entityConfig !== undefined &&
+      isSingletonEntity(entityConfig);
     const basePayload =
       entityState !== null &&
       typeof entityState === 'object' &&
-      !Array.isArray(entityState)
+      !isMalformedSingletonState
         ? (entityState as Record<string, unknown>)
         : {};
     const actionPayload = { ...basePayload };

--- a/src/app/op-log/sync/operation-encryption.service.spec.ts
+++ b/src/app/op-log/sync/operation-encryption.service.spec.ts
@@ -2,8 +2,11 @@ import { TestBed } from '@angular/core/testing';
 import { OperationEncryptionService } from './operation-encryption.service';
 import { SyncOperation } from '../sync-providers/provider.interface';
 import { DecryptError, OperationIntegrityError } from '../core/errors/sync-errors';
-import { ActionType, OpType } from '../core/operation.types';
+import { ActionType, Operation, OpType } from '../core/operation.types';
 import { toLwwUpdateActionType } from '../core/lww-update-action-types';
+import { convertOpToAction } from '../apply/operation-converter.util';
+import { lwwUpdateMetaReducer } from '../../root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer';
+import { TIME_TRACKING_FEATURE_KEY } from '../../features/time-tracking/store/time-tracking.reducer';
 import { clearSessionKeyCache, setArgon2ParamsForTesting } from '@sp/sync-core';
 import { createValidAppData } from '../validation/state-validity-test-utils';
 import { stripLocalOnlySyncSettingsFromAppData } from '../../features/config/local-only-sync-settings.util';
@@ -319,6 +322,38 @@ describe('OperationEncryptionService', () => {
 
       expect(decrypted.payload).toEqual(legacyPayload);
       expect(decrypted.entityId).toBe(legacyOp.entityId);
+    });
+
+    it('recovers TIME_TRACKING data end-to-end: real decrypt → convert → reduce (#9256)', async () => {
+      // Welds the full seam the other specs leave un-joined: the reporter's op
+      // survives the REAL AES-GCM decrypt + integrity gate, the converter finds
+      // no id to inject, and the meta-reducer restores the singleton slice — i.e.
+      // the data actually comes back, not just "the op wasn't rejected".
+      const project = { project1: { day1: 120000 } };
+      const tag = { tag1: { day1: 30000 } };
+      const legacyOp: SyncOperation = {
+        ...createMockSyncOp({ project, tag }),
+        id: '019d1e73-b5e5-7790-a896-9f215331afe7',
+        actionType: toLwwUpdateActionType('TIME_TRACKING') as ActionType,
+        opType: 'UPDATE',
+        entityType: 'TIME_TRACKING',
+        entityId: 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24',
+        timestamp: 1774332392933,
+      };
+      const encrypted = await service.encryptOperation(legacyOp, TEST_PASSWORD);
+      const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+      const action = convertOpToAction(decrypted as unknown as Operation);
+      const baseReducer = jasmine
+        .createSpy('baseReducer')
+        .and.callFake((currentState: unknown) => currentState);
+      const reducer = lwwUpdateMetaReducer(baseReducer);
+      const state = { [TIME_TRACKING_FEATURE_KEY]: { project: {}, tag: {} } };
+
+      reducer(state, action);
+
+      const updated = baseReducer.calls.mostRecent().args[0] as typeof state;
+      expect(updated[TIME_TRACKING_FEATURE_KEY]).toEqual({ project, tag });
     });
 
     // --- project-move footprint (op.entityIds) across the real crypto flow ---

--- a/src/app/op-log/sync/operation-encryption.service.spec.ts
+++ b/src/app/op-log/sync/operation-encryption.service.spec.ts
@@ -273,6 +273,22 @@ describe('OperationEncryptionService', () => {
       ).toBeRejectedWithError(OperationIntegrityError);
     });
 
+    it('still rejects a retargeted TASK op when its plaintext entityType says TIME_TRACKING', async () => {
+      const encrypted = await service.encryptOperation(
+        createLwwOp('task-A'),
+        TEST_PASSWORD,
+      );
+      const tampered: SyncOperation = {
+        ...encrypted,
+        entityType: 'TIME_TRACKING',
+        entityId: 'task-B',
+      };
+
+      await expectAsync(
+        service.decryptOperation(tampered, TEST_PASSWORD),
+      ).toBeRejectedWithError(OperationIntegrityError);
+    });
+
     it('accepts a decrypted LWW op with untampered entityId', async () => {
       const encrypted = await service.encryptOperation(
         createLwwOp('task-123'),
@@ -284,6 +300,25 @@ describe('OperationEncryptionService', () => {
         id: 'task-123',
         changes: { title: 'legit change' },
       });
+    });
+
+    it('accepts the legacy encrypted TIME_TRACKING singleton op from #9256', async () => {
+      const legacyPayload = { project: {}, tag: {} };
+      const legacyOp: SyncOperation = {
+        ...createMockSyncOp(legacyPayload),
+        id: '019d1e73-b5e5-7790-a896-9f215331afe7',
+        actionType: toLwwUpdateActionType('TIME_TRACKING') as ActionType,
+        opType: 'UPDATE',
+        entityType: 'TIME_TRACKING',
+        entityId: 'PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24',
+        timestamp: 1774332392933,
+      };
+      const encrypted = await service.encryptOperation(legacyOp, TEST_PASSWORD);
+
+      const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+      expect(decrypted.payload).toEqual(legacyPayload);
+      expect(decrypted.entityId).toBe(legacyOp.entityId);
     });
 
     // --- project-move footprint (op.entityIds) across the real crypto flow ---

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.spec.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.spec.ts
@@ -11,6 +11,7 @@ import frozen from '../validation/test-fixtures/frozen-state-v18.15.json';
 
 describe('assertDecryptedOpMetadataIntegrity', () => {
   const LWW_TASK = toLwwUpdateActionType('TASK');
+  const LWW_TIME_TRACKING = toLwwUpdateActionType('TIME_TRACKING');
 
   const createOp = (over: Partial<SyncOperation>): SyncOperation => ({
     id: 'op-1',
@@ -87,8 +88,12 @@ describe('assertDecryptedOpMetadataIntegrity', () => {
       ).not.toThrow();
     });
 
-    it('ignores singleton entities (no payload.id to compare)', () => {
-      const op = createOp({ entityId: SINGLETON_ENTITY_ID });
+    it('ignores singleton LWW targets even when their conflict id is composite', () => {
+      const op = createOp({
+        actionType: LWW_TIME_TRACKING,
+        entityType: 'TIME_TRACKING',
+        entityId: 'PROJECT:project-1:2026-03-24',
+      });
       expect(() => assertDecryptedOpMetadataIntegrity(op, { foo: 'bar' })).not.toThrow();
     });
 

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.ts
@@ -201,6 +201,14 @@ export const assertDecryptedOpMetadataIntegrity = (
 
   // Derive the target from actionType because it chooses the reducer branch;
   // op.entityType is unauthenticated metadata and must not grant an exemption.
+  //
+  // Scope is adapter-only ON PURPOSE and stays tied to the reducer: only the
+  // adapter branch of lwwUpdateMetaReducer addresses an entity BY `payload.id`,
+  // so only adapters can be retargeted by a tampered id. Singleton LWW replaces a
+  // whole feature slice (id irrelevant) and map/array LWW ops are not applied by
+  // that reducer at all — none carry a canonical `payload.id` to protect. If the
+  // reducer ever learns to apply a map/array LWW update by payload identity, this
+  // gate must be widened in lockstep or the retarget defense would not cover it.
   if (!op.entityId || !isLwwPayloadIdCanonical(lwwEntityType)) {
     return;
   }

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.ts
@@ -1,7 +1,7 @@
 import { extractActionPayload } from '@sp/sync-core';
 import { SyncOperation } from '../sync-providers/provider.interface';
-import { isLwwUpdateActionType } from '../core/lww-update-action-types';
-import { isSingletonEntityId } from '../core/entity-registry';
+import { getLwwEntityType } from '../core/lww-update-action-types';
+import { isLwwPayloadIdCanonical } from '../core/entity-registry';
 import { OperationIntegrityError } from '../core/errors/sync-errors';
 import { ACTION_TYPE_ALIASES } from '../apply/operation-converter.util';
 import { SyncLog } from '../../core/log';
@@ -163,10 +163,12 @@ const _migrateFullStateForValidation = (
  * resolve the mismatch by trusting the tampered `op.entityId` over the
  * authenticated `payload.id` (it coerces `payload.id = op.entityId` — including
  * when `payload.id` is absent — and only warns). Here we treat the
- * authenticated `payload.id` as ground truth and fail CLOSED: an in-scope LWW op
- * whose authenticated payload does not carry a string `id` equal to
- * `op.entityId` is rejected. The gate mirrors `convertOpToAction`'s coercion
- * predicate exactly (same alias resolution, same singleton exclusion) so the two
+ * authenticated `payload.id` as ground truth for adapter-backed LWW actions and
+ * fail CLOSED: an in-scope adapter LWW op whose authenticated payload does not
+ * carry a string `id` equal to `op.entityId` is rejected. Singleton LWW actions
+ * target their registered feature state as a whole, so their contextual
+ * conflict IDs do not have a canonical payload `id`. The gate mirrors
+ * `convertOpToAction`'s action-derived storage-pattern check so the two
  * boundaries cannot drift and leave a hole.
  *
  * Scope: only encrypted ops reach this boundary (it is called from the decrypt
@@ -195,14 +197,11 @@ export const assertDecryptedOpMetadataIntegrity = (
   // would make this gate skip an op the converter still LWW-coerces, silently
   // reopening the retarget hole.
   const actionType = ACTION_TYPE_ALIASES[op.actionType] ?? op.actionType;
+  const lwwEntityType = getLwwEntityType(actionType);
 
-  // Only non-singleton LWW single-entity updates carry a canonical `payload.id`
-  // that must equal `op.entityId`. Singletons use SINGLETON_ENTITY_ID (no `id`).
-  if (
-    !isLwwUpdateActionType(actionType) ||
-    !op.entityId ||
-    isSingletonEntityId(op.entityId)
-  ) {
+  // Derive the target from actionType because it chooses the reducer branch;
+  // op.entityType is unauthenticated metadata and must not grant an exemption.
+  if (!op.entityId || !isLwwPayloadIdCanonical(lwwEntityType)) {
     return;
   }
 

--- a/src/app/op-log/validation/validate-operation-payload.ts
+++ b/src/app/op-log/validation/validate-operation-payload.ts
@@ -494,6 +494,12 @@ const validateEntityChanges = (
       }
       // Create should have an id in changes
       const changesObj = change.changes as Record<string, unknown>;
+      // NOTE (#9256): like sync-core's convertLocalDeleteRemoteUpdatesToLww, this
+      // still classifies "is a singleton" by `entityId === '*'` — a composite-id
+      // singleton (TIME_TRACKING, GLOBAL_CONFIG, MENU_TREE) would be treated as an
+      // adapter here. Harmless today: it only appends a warning string, and LWW ops
+      // always carry `entityChanges: []`. Switch to a storage-pattern check
+      // (isLwwPayloadIdCanonical) if this ever gates acceptance.
       if (!changesObj.id && !isSingletonEntityId(change.entityId)) {
         warnings.push(`EntityChange[${i}] CREATE changes missing 'id' field`);
       }

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -1742,6 +1742,7 @@ describe('lwwUpdateMetaReducer', () => {
         { label: 'null', value: null },
         { label: 'number', value: 1 },
         { label: 'boolean', value: true },
+        { label: 'undefined', value: undefined },
       ];
 
       spyOn(OpLog, 'warn');
@@ -1765,6 +1766,17 @@ describe('lwwUpdateMetaReducer', () => {
               lwwUpdateMode: 'replace',
             },
           },
+          ...(label === 'undefined'
+            ? [
+                {
+                  format: 'wrapped-missing',
+                  payload: {
+                    entityChanges: [],
+                    lwwUpdateMode: 'replace',
+                  },
+                },
+              ]
+            : []),
         ];
         for (const { format, payload } of payloads) {
           const clientId = 'remote-client';

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -1743,13 +1743,6 @@ describe('lwwUpdateMetaReducer', () => {
         { label: 'number', value: 1 },
         { label: 'boolean', value: true },
         { label: 'undefined', value: undefined },
-        {
-          label: 'legacy-array-spread-record',
-          value: {
-            ...['private-time-entry'],
-            id: 'PROJECT:project-1:2026-03-24',
-          },
-        },
       ];
 
       spyOn(OpLog, 'warn');

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -23,6 +23,8 @@ import {
   SimpleCounter,
   SimpleCounterType,
 } from '../../../features/simple-counter/simple-counter.model';
+import { convertOpToAction } from '../../../op-log/apply/operation-converter.util';
+import { ActionType, Operation, OpType } from '../../../op-log/core/operation.types';
 
 describe('lwwUpdateMetaReducer', () => {
   const mockReducer = jasmine.createSpy('reducer');
@@ -1726,6 +1728,67 @@ describe('lwwUpdateMetaReducer', () => {
       expect(timeTracking).toBeDefined();
       expect(timeTracking['currentSessionTime']).toBe(5000);
       expect(timeTracking['isTrackingReminder']).toBe(false);
+    });
+
+    it('should preserve timeTracking state for malformed non-record LWW payloads', () => {
+      const state = createMockStateWithSingletons();
+      const originalTimeTracking = state[TIME_TRACKING_FEATURE_KEY];
+      const malformedValues: ReadonlyArray<{
+        label: string;
+        value: unknown;
+      }> = [
+        { label: 'string', value: 'x' },
+        { label: 'array', value: ['x'] },
+        { label: 'null', value: null },
+        { label: 'number', value: 1 },
+        { label: 'boolean', value: true },
+      ];
+
+      spyOn(OpLog, 'warn');
+      if (!jasmine.isSpy(window.alert)) {
+        spyOn(window, 'alert');
+      }
+      if (!jasmine.isSpy(window.confirm)) {
+        spyOn(window, 'confirm').and.returnValue(false);
+      } else {
+        (window.confirm as jasmine.Spy).and.returnValue(false);
+      }
+
+      for (const { label, value } of malformedValues) {
+        const payloads = [
+          { format: 'flat', payload: value },
+          {
+            format: 'wrapped',
+            payload: {
+              actionPayload: value,
+              entityChanges: [],
+              lwwUpdateMode: 'replace',
+            },
+          },
+        ];
+        for (const { format, payload } of payloads) {
+          const clientId = 'remote-client';
+          const op: Operation = {
+            id: `malformed-${format}-${label}`,
+            actionType: '[TIME_TRACKING] LWW Update' as ActionType,
+            opType: OpType.Update,
+            entityType: 'TIME_TRACKING',
+            entityId: 'PROJECT:project-1:2026-03-24',
+            payload,
+            clientId,
+            vectorClock: { [clientId]: 1 },
+            timestamp: 1,
+            schemaVersion: 1,
+          };
+          const action = convertOpToAction(op);
+
+          const updatedState = reducer(state, action) as Partial<RootState>;
+
+          expect(updatedState[TIME_TRACKING_FEATURE_KEY])
+            .withContext(`${format} ${label}`)
+            .toBe(originalTimeTracking);
+        }
+      }
     });
 
     it('should not require id field for singleton entities', () => {

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -1730,7 +1730,7 @@ describe('lwwUpdateMetaReducer', () => {
       expect(timeTracking['isTrackingReminder']).toBe(false);
     });
 
-    it('should preserve timeTracking state for malformed non-record LWW payloads', () => {
+    it('should preserve timeTracking state for malformed singleton LWW payloads', () => {
       const state = createMockStateWithSingletons();
       const originalTimeTracking = state[TIME_TRACKING_FEATURE_KEY];
       const malformedValues: ReadonlyArray<{
@@ -1743,6 +1743,13 @@ describe('lwwUpdateMetaReducer', () => {
         { label: 'number', value: 1 },
         { label: 'boolean', value: true },
         { label: 'undefined', value: undefined },
+        {
+          label: 'legacy-array-spread-record',
+          value: {
+            ...['private-time-entry'],
+            id: 'PROJECT:project-1:2026-03-24',
+          },
+        },
       ];
 
       spyOn(OpLog, 'warn');


### PR DESCRIPTION
## What & why

Fixes the **second strand of #9256**. After the v18.15.0 boot-to-empty reinstall, E2EE SuperSync users cannot recover their data — sync aborts with *"server returned data that failed a security integrity check … possible tampered/misconfigured server."*

The first strand (a strict full-state schema check rejecting recoverable version-drift) was fixed in #9259. But the reporter's log from the #9259 preview build showed a **second** rejection right after:

```
[assertDecryptedOpMetadataIntegrity] encrypted op entityId does not match authenticated payload.id — rejecting
  entityType: TIME_TRACKING
  opEntityId: PROJECT:eP8tBLmm0tBgJThAZOxcT:2026-03-24
  payloadId:  <undefined>
  actionType: [TIME_TRACKING] LWW Update
Operation 019d1e73-… failed metadata integrity check (GHSA-8pxh-mgc7-gp3g)
```

### Root cause

`TIME_TRACKING` is a **singleton** entity (`storagePattern: 'singleton'`) whose LWW reducer replaces the whole feature slice. Unlike other singletons, its op `entityId` is a **composite conflict-routing key** (`PROJECT:…:date`), not the `'*'` singleton sentinel.

The op-integrity gate (and the converter) classified singletons purely by `isSingletonEntityId(op.entityId)` (i.e. `entityId === '*'`). Because TIME_TRACKING's entityId is composite, it was misclassified as **adapter-backed**, so the gate demanded a `payload.id === op.entityId`. Legacy time-tracking ops carry `{ project, tag }` with **no** `id` → rejected as tampering, aborting the whole sync. (The converter also injected the composite id into the singleton state.)

### Blast radius is wider than TIME_TRACKING

Review turned up that **no shipped singleton producer actually uses the `'*'` sentinel**:

| entity | real `entityId` | source |
| --- | --- | --- |
| `GLOBAL_CONFIG` | the section key (`'misc'`, `'sync'`, …) | `global-config.actions.ts:17` |
| `MENU_TREE` | `'projectTree'` / `'tagTree'` / folderId | `menu-tree.actions.ts:15,28,41` |
| `TIME_TRACKING` | `TYPE:id:date` composite key | `operation-capture.service.ts:287,303` |
| `WORK_CONTEXT` | emits no persistent ops | — |

So the misclassification was never TIME_TRACKING-specific: a legacy `[GLOBAL_CONFIG] LWW Update` without a payload `id` hits the same v18.15.1 rejection, and current clients inject `id: 'misc'` into the whole config slice. This branch fixes and cleans up both. TIME_TRACKING is simply what the reporter's log caught.

### Fix

Introduce `isLwwPayloadIdCanonical(entityType)` = `storagePattern === 'adapter'`, and route the converter's id-injection, the producer (`createLWWUpdateOp`), and the integrity gate through it — derived from the **actionType** (the field that selects the reducer branch):

- **Adapter LWW (e.g. TASK):** `payload.id` is canonical → force `payload.id = op.entityId`; the gate enforces the match. The GHSA-8pxh adapter-retarget defense is unchanged.
- **Singleton LWW (TIME_TRACKING, GLOBAL_CONFIG, …):** `payload.id` is not canonical → strip any `id`; the gate skips (a tampered entityId can't redirect a whole-slice replace anyway).

### Backward compatibility

New singleton ops keep a compatibility `id` **inside the AES-GCM payload** so shipped **v18.15.0 / v18.15.1** receivers (which still require a matching `payload.id`) accept them; new receivers strip it before replaying. No schema bump — degrades gracefully in a mixed fleet. The sunset condition is documented at the producer.

## Security note

Metadata (`actionType`/`entityType`/`entityId`) is **plaintext**, not AES-GCM-authenticated (documented in `verify-decrypted-op-integrity.ts`). This fix does **not** rely on authenticating actionType. It's safe because the gate, converter, and reducer all branch on the **same** actionType, in lockstep — flipping actionType to a singleton makes all three treat the op as a singleton (id stripped, whole-slice replace), never an adapter retarget. That "within-LWW actionType swap corrupts a singleton" residual is **pre-existing and documented** (the durable fix — binding metadata as GCM AAD — remains the tracked OPEN item); it is neither introduced nor worsened here. Verified against `master`.

**On the narrowed gate scope.** The gate no longer enforces `payload.id === op.entityId` for singleton ops that do carry a matching authenticated id (GLOBAL_CONFIG / MENU_TREE / TIME_TRACKING). This costs nothing: `master`'s gate returns early whenever `op.entityId === '*'` (`verify-decrypted-op-integrity.ts:201-207`), and `op.entityId` is plaintext and attacker-controlled — so an attacker targeting a singleton already got the same conflict-routing miss and the same whole-slice replace on `master` by writing `'*'` instead of a bogus key. Closing it for real needs the AAD work, not a predicate tweak. Map/array LWW ops lose gate coverage too, but `lwwUpdateMetaReducer` never applies them (`!isAdapterEntity` → warn + pass-through), and it is the only consumer of LWW action types.

## Notes / scope

- An earlier iteration added an `isLegacyArraySpreadRecord` guard (numeric-key singleton payloads). The #9256 repro contains no such shape — the failing payload is a well-formed record missing an `id` — so per "start from a reproducible problem" it was **removed**; the footgun-free `!isRecord` normalization stays (it only changes behavior for string/array payloads, and no singleton state is either).
- PLANNER (a `map` entity) is unaffected — its day-array payloads still spread correctly (covered by a regression test).
- The final commit is comment-only: it corrects a stale invariant in `sync-core`'s delete→LWW note (singletons *do* emit per-entity deletes — `menuTreeDeleteFolder` — that branch is unreachable for a different reason), the `SINGLETON_ENTITY_ID` docstring, and flags a third un-migrated `isSingletonEntityId` site that is inert today.

## Testing

- 533 unit specs green across converter, integrity gate, entity registry, LWW meta-reducer, encryption round-trip, and conflict resolution.
- The core fix is pinned by the reporter's exact op as a fixture; an end-to-end test welds real AES-GCM decrypt → convert → reduce and asserts `{ project, tag }` is actually restored.
- Sabotage-verified non-vacuous: reverting the gate predicate, dropping the producer's compat id, misclassifying the registry, disabling the singleton id-strip, and disabling the `!isRecord` normalization each kill exactly their intended test.

Closes #9256 (together with the already-merged #9259).
