### PR TITLE
fix(boards): add existing tasks to tagged columns

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,7 +41,10 @@ import { concatMap, first, take } from 'rxjs/operators';
 import { IS_MOBILE } from './util/is-mobile';
 import { recordSearchNavDebug } from './util/search-nav-debug';
 import { warpAnimation, warpInAnimation } from './ui/animations/warp.ani';
-import { AddTaskBarComponent } from './features/tasks/add-task-bar/add-task-bar.component';
+import {
+  AddTaskBarComponent,
+  TaskAddEvent,
+} from './features/tasks/add-task-bar/add-task-bar.component';
 import { Dir } from '@angular/cdk/bidi';
 import { MagicSideNavComponent } from './core-ui/magic-side-nav/magic-side-nav.component';
 import { MainHeaderComponent } from './core-ui/main-header/main-header.component';
@@ -426,7 +429,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     return this._activeWorkContextId() ?? null;
   }
 
-  onTaskAdded({ taskId }: { taskId: string; isAddToBottom: boolean }): void {
+  onTaskAdded({ taskId }: TaskAddEvent): void {
     this.layoutService.setPendingFocusTaskId(taskId);
     this.layoutService.scrollToNewTask(taskId);
     if (this.onboardingHintService.shouldAutoCloseFirstTaskComposer(taskId)) {

--- a/src/app/features/boards/board-panel/board-panel.component.spec.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.spec.ts
@@ -16,10 +16,14 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { PlannerTaskComponent } from '../../planner/planner-task/planner-task.component';
 import { AddTaskInlineComponent } from '../../planner/add-task-inline/add-task-inline.component';
 import { selectUnarchivedProjects } from '../../project/store/project.selectors';
-import { selectAllTasksInActiveProjects } from '../../tasks/store/task.selectors';
+import {
+  selectAllTasksInActiveProjects,
+  selectTaskById,
+} from '../../tasks/store/task.selectors';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { ProjectService } from '../../project/project.service';
 import { signal } from '@angular/core';
+import { TODAY_TAG } from '../../tag/tag.const';
 
 describe('BoardPanelComponent - Backlog Feature', () => {
   let component: BoardPanelComponent;
@@ -751,10 +755,12 @@ describe('BoardPanelComponent - drop()', () => {
     updateTagsSpy = jasmine.createSpy('updateTags');
 
     const storeMock = {
-      select: (selectorFn: any) => {
+      select: (selectorFn: any, props?: { id: string }) => {
         if (selectorFn === selectUnarchivedProjects)
           return of([{ id: 'p1', backlogTaskIds: [] }]);
         if (selectorFn === selectAllTasksInActiveProjects) return of(tasks);
+        if (selectorFn === selectTaskById)
+          return of(tasks.find((task) => task.id === props?.id));
         return of([]);
       },
       pipe: () => ({ toPromise: () => Promise.resolve(undefined) }),
@@ -888,5 +894,37 @@ describe('BoardPanelComponent - drop()', () => {
     const [taskArg, tagsArg] = updateTagsSpy.calls.mostRecent().args;
     expect(taskArg).toBe(task);
     expect(tagsArg).toEqual(['other', 'need']);
+  });
+
+  it('adds an existing task by rewriting real tags without updating board order', async () => {
+    const task = mkTask({
+      id: 't1',
+      tagIds: [TODAY_TAG.id, 'x', 'y', 'keep'],
+    });
+    await setup([task]);
+    const panelCfg = {
+      id: 'target',
+      title: 'Target',
+      taskIds: [],
+      includedTagIds: [TODAY_TAG.id, 'need'],
+      includedTagsMatch: 'any',
+      excludedTagIds: [TODAY_TAG.id, 'x', 'y'],
+      excludedTagsMatch: 'all',
+      taskDoneState: 1,
+      scheduledState: 3,
+      isParentTasksOnly: false,
+      projectIds: [''],
+    } as BoardPanelCfg;
+    fixture.componentRef.setInput('panelCfg', panelCfg);
+    fixture.detectChanges();
+
+    await component.afterTaskAdd({
+      taskId: task.id,
+      isAddToBottom: false,
+      isNewTask: false,
+    });
+
+    expect(updateTagsSpy).toHaveBeenCalledOnceWith(task, ['y', 'keep', 'need']);
+    expect(dispatchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/boards/board-panel/board-panel.component.spec.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.spec.ts
@@ -896,6 +896,41 @@ describe('BoardPanelComponent - drop()', () => {
     expect(tagsArg).toEqual(['other', 'need']);
   });
 
+  // TODAY_TAG is selectable in the board tag picker (isShowMyDayTag), but it is
+  // virtual — writing it to task.tagIds violates ARCHITECTURE-DECISIONS #2 and
+  // syncs the corruption to every device.
+  it('cross-panel drop never writes the virtual TODAY_TAG into the task', async () => {
+    // Arrange
+    await setup([]);
+    const panelCfg = {
+      id: 'target',
+      title: 'Target',
+      taskIds: [],
+      includedTagIds: [TODAY_TAG.id, 'need'],
+      excludedTagIds: [],
+      taskDoneState: 1,
+      scheduledState: 1,
+      isParentTasksOnly: false,
+      projectIds: [''],
+    } as BoardPanelCfg;
+    fixture.componentRef.setInput('panelCfg', panelCfg);
+    fixture.detectChanges();
+
+    const task = mkTask({ id: 't1', tagIds: ['other'] });
+
+    // Act
+    await component.drop(mkDropEvent({ panelCfg, task }));
+
+    // Assert — only the real required tag is applied
+    expect(updateTagsSpy).toHaveBeenCalledTimes(1);
+    const [, tagsArg] = updateTagsSpy.calls.mostRecent().args;
+    expect(tagsArg).toEqual(['other', 'need']);
+  });
+
+  // The AND-exclude list contains My Day, which `doesTaskMatchPanel` can never
+  // see on a task — so that exclusion is already inert and no real tag ('x'/'y')
+  // may be stripped to satisfy it. Only the legacy TODAY_TAG on the task itself
+  // and the missing required tag are rewritten.
   it('adds an existing task by rewriting real tags without updating board order', async () => {
     const task = mkTask({
       id: 't1',
@@ -924,7 +959,34 @@ describe('BoardPanelComponent - drop()', () => {
       isNewTask: false,
     });
 
-    expect(updateTagsSpy).toHaveBeenCalledOnceWith(task, ['y', 'keep', 'need']);
+    expect(updateTagsSpy).toHaveBeenCalledOnceWith(task, ['x', 'y', 'keep', 'need']);
     expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it('never writes the virtual TODAY_TAG into a task when the column requires My Day', async () => {
+    const task = mkTask({ id: 't1', tagIds: ['keep'] });
+    await setup([task]);
+    const panelCfg = {
+      id: 'target',
+      title: 'Target',
+      taskIds: [],
+      includedTagIds: [TODAY_TAG.id, 'need'],
+      includedTagsMatch: 'all',
+      excludedTagIds: [],
+      taskDoneState: 1,
+      scheduledState: 3,
+      isParentTasksOnly: false,
+      projectIds: [''],
+    } as BoardPanelCfg;
+    fixture.componentRef.setInput('panelCfg', panelCfg);
+    fixture.detectChanges();
+
+    await component.afterTaskAdd({
+      taskId: task.id,
+      isAddToBottom: false,
+      isNewTask: false,
+    });
+
+    expect(updateTagsSpy).toHaveBeenCalledOnceWith(task, ['keep', 'need']);
   });
 });

--- a/src/app/features/boards/board-panel/board-panel.component.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.ts
@@ -52,6 +52,8 @@ import {
   moveProjectTaskToBacklogListAuto,
   moveProjectTaskToRegularListAuto,
 } from '../../project/store/project.actions';
+import { TaskAddEvent } from '../../tasks/add-task-bar/add-task-bar.component';
+import { TODAY_TAG } from '../../tag/tag.const';
 
 @Component({
   selector: 'board-panel',
@@ -260,14 +262,33 @@ export class BoardPanelComponent {
     this._checkBacklogState(panelCfg, task.id);
   }
 
-  async afterTaskAdd({
-    taskId,
-    isAddToBottom,
-  }: {
-    taskId: string;
-    isAddToBottom: boolean;
-  }): Promise<void> {
+  async afterTaskAdd({ taskId, isAddToBottom, isNewTask }: TaskAddEvent): Promise<void> {
     const panelCfg = this.panelCfg();
+
+    if (!isNewTask) {
+      const task = await this.store
+        .select(selectTaskById, { id: taskId })
+        .pipe(first())
+        .toPromise();
+      if (!task) {
+        return;
+      }
+
+      const tagFilterCfg = {
+        includedTagIds: panelCfg.includedTagIds.filter((id) => id !== TODAY_TAG.id),
+        includedTagsMatch: panelCfg.includedTagsMatch,
+        excludedTagIds: panelCfg.excludedTagIds.filter((id) => id !== TODAY_TAG.id),
+        excludedTagsMatch: panelCfg.excludedTagsMatch,
+      };
+      const currentTagIds = (task.tagIds || []).filter((id) => id !== TODAY_TAG.id);
+      const newTagIds = unique(rewriteTagIdsForPanel(currentTagIds, tagFilterCfg));
+
+      if (!fastArrayCompare(task.tagIds || [], newTagIds)) {
+        this.taskService.updateTags(task, newTagIds);
+      }
+      return;
+    }
+
     this.store.dispatch(
       BoardsActions.updatePanelCfgTaskIds({
         panelId: panelCfg.id,

--- a/src/app/features/boards/board-panel/board-panel.component.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.ts
@@ -53,7 +53,6 @@ import {
   moveProjectTaskToRegularListAuto,
 } from '../../project/store/project.actions';
 import { TaskAddEvent } from '../../tasks/add-task-bar/add-task-bar.component';
-import { TODAY_TAG } from '../../tag/tag.const';
 
 @Component({
   selector: 'board-panel',
@@ -274,14 +273,7 @@ export class BoardPanelComponent {
         return;
       }
 
-      const tagFilterCfg = {
-        includedTagIds: panelCfg.includedTagIds.filter((id) => id !== TODAY_TAG.id),
-        includedTagsMatch: panelCfg.includedTagsMatch,
-        excludedTagIds: panelCfg.excludedTagIds.filter((id) => id !== TODAY_TAG.id),
-        excludedTagsMatch: panelCfg.excludedTagsMatch,
-      };
-      const currentTagIds = (task.tagIds || []).filter((id) => id !== TODAY_TAG.id);
-      const newTagIds = unique(rewriteTagIdsForPanel(currentTagIds, tagFilterCfg));
+      const newTagIds = unique(rewriteTagIdsForPanel(task.tagIds || [], panelCfg));
 
       if (!fastArrayCompare(task.tagIds || [], newTagIds)) {
         this.taskService.updateTags(task, newTagIds);

--- a/src/app/features/boards/boards.util.spec.ts
+++ b/src/app/features/boards/boards.util.spec.ts
@@ -11,6 +11,7 @@ import {
   BoardPanelCfgTaskTypeFilter,
 } from './boards.model';
 import { TaskCopy } from '../tasks/task.model';
+import { TODAY_TAG } from '../tag/tag.const';
 
 const basePanel: any = {
   id: 'p1',
@@ -332,6 +333,85 @@ describe('rewriteTagIdsForPanel', () => {
     // Act + Assert — would throw if mutated
     expect(() => rewriteTagIdsForPanel(tags, panel)).not.toThrow();
     expect(tags).toEqual(['x', 'y']);
+  });
+
+  // TODAY_TAG is virtual: membership derives from dueDay/dueWithTime and it must
+  // never land in task.tagIds (ARCHITECTURE-DECISIONS #2). The rewrite therefore
+  // has to agree with `doesTaskMatchPanel`, which can only ever see real tags.
+  describe('TODAY_TAG (virtual)', () => {
+    it('"all" include mode: appends the real required tags but never TODAY_TAG', () => {
+      // Arrange
+      const tags = ['keep'];
+      const panel = mkPanel({ includedTagIds: [TODAY_TAG.id, 'need'] });
+
+      // Act
+      const out = rewriteTagIdsForPanel(tags, panel);
+
+      // Assert
+      expect(out).toEqual(['keep', 'need']);
+    });
+
+    it('"any" include mode: appends the first REAL required tag, not TODAY_TAG', () => {
+      // Arrange
+      const tags = ['keep'];
+      const panel = mkPanel({
+        includedTagIds: [TODAY_TAG.id, 'need'],
+        includedTagsMatch: 'any',
+      });
+
+      // Act
+      const out = rewriteTagIdsForPanel(tags, panel);
+
+      // Assert
+      expect(out).toEqual(['keep', 'need']);
+    });
+
+    it('include mode: adds nothing when TODAY_TAG is the only required tag', () => {
+      // Arrange
+      const tags = ['keep'];
+      const panel = mkPanel({ includedTagIds: [TODAY_TAG.id] });
+
+      // Act
+      const out = rewriteTagIdsForPanel(tags, panel);
+
+      // Assert
+      expect(out).toEqual(['keep']);
+    });
+
+    it('"all" exclude mode: keeps every real tag, because the AND-exclude can never fire', () => {
+      // Arrange — `doesTaskMatchPanel` needs ALL of TODAY/x/y present to exclude,
+      // and TODAY can never be present, so nothing may be stripped here either.
+      const tags = ['x', 'y', 'keep'];
+      const panel = mkPanel({
+        excludedTagIds: [TODAY_TAG.id, 'x', 'y'],
+        excludedTagsMatch: 'all',
+      });
+
+      // Act
+      const out = rewriteTagIdsForPanel(tags, panel);
+
+      // Assert — rewrite agrees with the predicate: no change
+      expect(out).toEqual(['x', 'y', 'keep']);
+      expect(
+        doesTaskMatchPanel(
+          { id: 't', title: '', projectId: 'INBOX', tagIds: out } as TaskCopy,
+          { ...basePanel, ...panel } as BoardPanelCfg,
+          () => false,
+        ),
+      ).toBe(true);
+    });
+
+    it('strips a legacy TODAY_TAG carried in the task’s own tags', () => {
+      // Arrange — corrupt data written by an older build
+      const tags = [TODAY_TAG.id, 'keep'];
+      const panel = mkPanel();
+
+      // Act
+      const out = rewriteTagIdsForPanel(tags, panel);
+
+      // Assert
+      expect(out).toEqual(['keep']);
+    });
   });
 });
 

--- a/src/app/features/boards/boards.util.ts
+++ b/src/app/features/boards/boards.util.ts
@@ -7,6 +7,7 @@ import {
 } from './boards.model';
 import { TaskCopy } from '../tasks/task.model';
 import { dateStrToUtcDate } from '../../util/date-str-to-utc-date';
+import { TODAY_TAG } from '../tag/tag.const';
 
 const VALID_SORT_FIELDS: ReadonlySet<BoardSortField> = new Set([
   'dueDate',
@@ -117,6 +118,13 @@ const NO_OP_COMPARATOR = (): number => 0;
  *   - 'all': strip only the FIRST excluded tag when the task has ALL excluded
  *     tags (breaks the AND-exclude condition without over-removing).
  *
+ * TODAY_TAG is virtual: membership derives from dueDay/dueWithTime and it must
+ * never be written to `task.tagIds` (ARCHITECTURE-DECISIONS #2), so the result
+ * never contains it. Only the INCLUDE side ignores it — dropping it from the
+ * EXCLUDE side would let an AND-exclude fire here that `doesTaskMatchPanel` can
+ * never hit (it only ever sees real tags), stripping a real user tag to satisfy
+ * a filter that was already inert.
+ *
  * Duplicates are not de-duplicated here; callers that care should pass the
  * result through `unique()`.
  */
@@ -127,16 +135,18 @@ export const rewriteTagIdsForPanel = (
     'includedTagIds' | 'includedTagsMatch' | 'excludedTagIds' | 'excludedTagsMatch'
   >,
 ): string[] => {
-  let next: string[] = [...currentTagIds];
+  const includedTagIds = panelCfg.includedTagIds?.filter((id) => id !== TODAY_TAG.id);
+  // Also heals a legacy TODAY_TAG that an older build wrote into the task.
+  let next: string[] = currentTagIds.filter((id) => id !== TODAY_TAG.id);
 
-  if (panelCfg.includedTagIds?.length) {
+  if (includedTagIds?.length) {
     if (panelCfg.includedTagsMatch === 'any') {
-      const hasAny = panelCfg.includedTagIds.some((id) => next.includes(id));
+      const hasAny = includedTagIds.some((id) => next.includes(id));
       if (!hasAny) {
-        next = next.concat(panelCfg.includedTagIds[0]);
+        next = next.concat(includedTagIds[0]);
       }
     } else {
-      next = next.concat(panelCfg.includedTagIds);
+      next = next.concat(includedTagIds);
     }
   }
 

--- a/src/app/features/planner/add-task-inline/add-task-inline.component.ts
+++ b/src/app/features/planner/add-task-inline/add-task-inline.component.ts
@@ -1,7 +1,10 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
 import { T } from 'src/app/t.const';
-import { AddTaskBarComponent } from '../../tasks/add-task-bar/add-task-bar.component';
+import {
+  AddTaskBarComponent,
+  TaskAddEvent,
+} from '../../tasks/add-task-bar/add-task-bar.component';
 import { MatIcon } from '@angular/material/icon';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatButton } from '@angular/material/button';
@@ -22,7 +25,7 @@ export class AddTaskInlineComponent {
   readonly tagsToRemove = input<string[]>([]);
   readonly taskIdsToExclude = input<string[]>();
   readonly isNoDefaults = input<boolean>(false);
-  readonly afterTaskAdd = output<{ taskId: string; isAddToBottom: boolean }>();
+  readonly afterTaskAdd = output<TaskAddEvent>();
 
   isShowAddTask = false;
 }

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -381,6 +381,34 @@ describe('AddTaskBarComponent', () => {
   });
 
   describe('onTaskSuggestionSelected', () => {
+    it('leaves an existing task in place when defaults are disabled', async () => {
+      fixture.componentRef.setInput('isNoDefaults', true);
+      fixture.detectChanges();
+
+      const task = {
+        id: 'task-1',
+        title: 'Existing task',
+        subTaskIds: [],
+      } as Partial<TaskCopy> as TaskCopy;
+      const suggestion = {
+        title: task.title,
+        taskId: task.id,
+        projectId: 'project-1',
+      } as AddTaskSuggestion;
+      const emitSpy = spyOn(component.afterTaskAdd, 'emit');
+      mockTaskService.getByIdOnce$.and.returnValue(of(task));
+
+      await component.onTaskSuggestionSelected(suggestion);
+
+      expect(mockTaskService.moveToCurrentWorkContext).not.toHaveBeenCalled();
+      expect(mockSnackService.open).not.toHaveBeenCalled();
+      expect(emitSpy.calls.mostRecent().args[0] as unknown).toEqual({
+        taskId: task.id,
+        isAddToBottom: false,
+        isNewTask: false,
+      });
+    });
+
     it('plans existing tasks for the provided planner day instead of moving them to today', async () => {
       // Set component input using fixture.componentRef.setInput for planForDay
       fixture.componentRef.setInput('planForDay', '2024-05-20');

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -88,6 +88,12 @@ import { DateService } from '../../../core/date/date.service';
 import { MenuTreeService } from '../../menu-tree/menu-tree.service';
 import { SelectOptionRowComponent } from '../../../ui/select-option-row/select-option-row.component';
 
+export interface TaskAddEvent {
+  taskId: string;
+  isAddToBottom: boolean;
+  isNewTask: boolean;
+}
+
 @Component({
   selector: 'add-task-bar',
   templateUrl: './add-task-bar.component.html',
@@ -149,7 +155,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
   planForDay = input<string>();
 
   // Outputs
-  afterTaskAdd = output<{ taskId: string; isAddToBottom: boolean }>();
+  afterTaskAdd = output<TaskAddEvent>();
   closed = output<void>();
   done = output<void>();
 
@@ -620,7 +626,11 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
         }
       }
 
-      this.afterTaskAdd.emit({ taskId, isAddToBottom: this.isAddToBottom() });
+      this.afterTaskAdd.emit({
+        taskId,
+        isAddToBottom: this.isAddToBottom(),
+        isNewTask: true,
+      });
       this._resetAfterAdd();
     } finally {
       this._isAddingTask = false;
@@ -664,7 +674,9 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     const planForDay = this.planForDay();
     let didPlanForDay = false;
 
-    if (suggestion.taskId && suggestion.isFromOtherContextAndTagOnlySearch) {
+    if (suggestion.taskId && this.isNoDefaults() && !suggestion.isArchivedTask) {
+      taskId = suggestion.taskId;
+    } else if (suggestion.taskId && suggestion.isFromOtherContextAndTagOnlySearch) {
       if (planForDay) {
         await this._planTaskForCurrentDay(suggestion.taskId);
         didPlanForDay = true;
@@ -725,6 +737,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
       this.afterTaskAdd.emit({
         taskId,
         isAddToBottom: false,
+        isNewTask: !suggestion.taskId,
       });
     }
 


### PR DESCRIPTION
## Problem

Selecting an existing task suggestion from a tag-filtered board column's add bar did not make the task appear in that column.

Board membership is derived from `task.tagIds`, but the existing-task suggestion path never applied the destination panel's tag policy. It could also apply active work-context defaults and show a movement snackbar that did not describe the board operation.

## Solution

- Distinguish newly created tasks from selected existing suggestions in the add-task event.
- Keep the existing new-task ordering, schedule, and backlog behavior unchanged.
- For selected existing tasks, apply the destination column's tag policy with the established `rewriteTagIdsForPanel()` helper.
- Never persist the virtual `TODAY` tag.
- Persist at most one Task update and return before Boards ordering, scheduling, or backlog operations.
- Skip work-context defaults and movement snackbars for board add bars.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Verification

- `npm run checkFile` passed for all five changed TypeScript files.
- `add-task-bar.component.spec.ts`: 51/51 tests passed.
- `board-panel.component.spec.ts`: 24/24 tests passed.
- Angular production build passed.
- Repository-wide commit-hook lint, lint-rule tests, and theme-asset tests passed.

## Checklist

- [x] Documentation changes are not required for this focused bug fix.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
