### PR TITLE
fix(i18n): correct shortcut key assignments and parentheses in zh.json

### DIFF
--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -1766,17 +1766,17 @@
         "TOMORROW": "明天",
         "TOOLTIP_ADD_TASK": "添加任务",
         "TOOLTIP_ADD_TO_BACKLOG": "添加至待办事项",
-        "TOOLTIP_ADD_TO_BOTTOM": "添加至底部 (Ctrl+1)",
+        "TOOLTIP_ADD_TO_BOTTOM": "添加至底部 (Ctrl+3)",
         "TOOLTIP_ADD_TO_TODAY": "添加至今天",
-        "TOOLTIP_ADD_TO_TOP": "添加至顶部 (Ctrl+1)",
+        "TOOLTIP_ADD_TO_TOP": "添加至顶部 (Ctrl+3)",
         "TOOLTIP_CLEAR_DATE": "清除日期",
         "TOOLTIP_CLEAR_DEADLINE": "清除截止日期",
         "TOOLTIP_CLEAR_ESTIMATE": "清除估算",
         "TOOLTIP_CLEAR_REPEAT": "清除重复设置",
         "TOOLTIP_CLEAR_TAGS": "清除标签",
-        "TOOLTIP_DISABLE_SEARCH": "禁用问题搜索 (Ctrl+2)",
-        "TOOLTIP_ENABLE_SEARCH": "启用问题搜索 (Ctrl+2)",
-        "TOOLTIP_NOTE": "笔记（Ctrl+2）"
+        "TOOLTIP_DISABLE_SEARCH": "禁用问题搜索 (Ctrl+1)",
+        "TOOLTIP_ENABLE_SEARCH": "启用问题搜索 (Ctrl+1)",
+        "TOOLTIP_NOTE": "笔记 (Ctrl+2)"
       },
       "ADDITIONAL_INFO": {
         "ADD_ATTACHMENT": "添加附件",


### PR DESCRIPTION
Closes #9300

## Problem

The Simplified Chinese (zh.json) tooltips for the three feature buttons in the task bar (`Shift+A`) have **incorrect shortcut key mappings** and **inconsistent parenthesis usage**:

- `启用/禁用问题搜索` currently displays `(Ctrl+2)` but the actual key binding is `Ctrl+1`
- `笔记` displays `（Ctrl+2）` (full-width parentheses) – the key is correct but the format is inconsistent
- `添加至底部/顶部` currently displays `(Ctrl+1)` but the actual key binding is `Ctrl+3`

This creates confusion for users relying on tooltips to learn keyboard shortcuts, and the mixed use of full-width vs. half-width parentheses violates our UI localization standards.

Reported in #9300.

## Solution

- Corrected the shortcut key numbers in `zh.json` for all three affected tooltips to match the actual key bindings:
  - `启用/禁用问题搜索 (Ctrl+1)`
  - `笔记 (Ctrl+2)`
  - `添加至底部/顶部 (Ctrl+3)`
- Standardized the above shortcut display format to use **half-width parentheses with a preceding space** (` (Ctrl+X)`), following industry best practices for Chinese UI localization.
- Affected scope: `F.TASK.ADD_TASK_BAR` tooltips.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (N/A - localization only)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files (N/A)
- [ ] I have added tests for my changes (if applicable) (N/A)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)