### PR TITLE
docs(wiki): document F11 fullscreen shortcut

### DIFF
--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -38,6 +38,10 @@ These work everywhere in the app.
 
 The search bar searches open tasks by default. Enable **Include completed and archived tasks** in the search view to include older completed results.
 
+### Desktop Window (unconfigurable)
+
+- `F11`: Toggle full-screen mode. Available only in the Electron/desktop build.
+
 ### Add Task Bar (while the add bar input is focused)
 
 - `Ctrl+1`: Toggle issue-search mode
@@ -105,6 +109,7 @@ These shortcuts are **unconfigurable** and always available on group headers.
 
 - Global shortcuts (`globalShowHide`, `globalToggleTaskStart`, `globalAddNote`, `globalAddTask`) work system-wide when the app is running.
 - Window zoom controls (`zoomIn`, `zoomOut`, `zoomDefault`) are desktop-only.
+- `F11` toggles full-screen mode for the main window.
 
 **Linux (Wayland):**
 


### PR DESCRIPTION
## Summary

- document the existing desktop F11 full-screen shortcut in the keyboard shortcut reference
- clarify that the shortcut is desktop/Electron-only

Closes #5851

## Validation

- `git diff --check upstream/master...HEAD`

The implementation itself landed previously in #6183; this PR only documents the shortcut in the maintained wiki source.