### PR TITLE
fix: open recurring Schedule projections reliably

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
@@ -1,5 +1,11 @@
 import { createBlockedBlocksByDayMap } from './create-blocked-blocks-by-day-map';
 import { TaskCopy, TaskWithDueTime } from '../../tasks/task.model';
+import {
+  DEFAULT_TASK_REPEAT_CFG,
+  TaskRepeatCfg,
+} from '../../task-repeat-cfg/task-repeat-cfg.model';
+import { BlockedBlockType } from '../schedule.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
 
 const NDS = '1970-01-01';
 const H = 60 * 60 * 1000;
@@ -42,6 +48,41 @@ describe('createBlockedBlocksByDayMap()', () => {
   it('should work for empty case', () => {
     const r = createBlockedBlocksByDayMap([], [], [], undefined, undefined, 0);
     expect(r).toEqual({});
+  });
+
+  it('keeps a repeat projection source day when a scheduled occurrence crosses midnight', () => {
+    const occurrenceDate = new Date(2026, 6, 30, 12).getTime();
+    const occurrenceDay = getDbDateStr(occurrenceDate);
+    const continuedDay = getDbDateStr(new Date(2026, 6, 31, 12));
+    const repeatCfg: TaskRepeatCfg = {
+      ...DEFAULT_TASK_REPEAT_CFG,
+      id: 'daily-across-midnight',
+      quickSetting: 'DAILY',
+      repeatCycle: 'DAILY',
+      startDate: occurrenceDay,
+      startTime: '23:00',
+      defaultEstimate: h(2),
+    };
+
+    const result = createBlockedBlocksByDayMap(
+      [],
+      [repeatCfg],
+      [],
+      undefined,
+      undefined,
+      occurrenceDate,
+      2,
+      new Date(2026, 6, 31, 12).getTime(),
+    );
+    const continuedEntry = result[continuedDay]
+      .flatMap((block) => block.entries)
+      .find(
+        (entry) => entry.type === BlockedBlockType.ScheduledRepeatProjectionSplit,
+      ) as {
+      sourceOccurrenceDate?: string;
+    };
+
+    expect(continuedEntry.sourceOccurrenceDate).toBe(occurrenceDay);
   });
 
   it('should work for basic case', () => {

--- a/src/app/features/schedule/map-schedule-data/create-sorted-blocker-blocks.ts
+++ b/src/app/features/schedule/map-schedule-data/create-sorted-blocker-blocks.ts
@@ -118,6 +118,7 @@ const createBlockerBlocksForScheduledRepeatProjections = (
             data: repeatCfg,
             start,
             end,
+            sourceOccurrenceDate: currentDayStr,
           },
         ],
       });

--- a/src/app/features/schedule/map-schedule-data/create-view-entries-for-block.ts
+++ b/src/app/features/schedule/map-schedule-data/create-view-entries-for-block.ts
@@ -27,7 +27,9 @@ export const createViewEntriesForBlock = (
         data: repeatCfg,
         duration: repeatCfg.defaultEstimate || 0,
         plannedForDay: dayDate,
-        sourceOccurrenceDate: entry.sourceOccurrenceDate,
+        ...(entry.sourceOccurrenceDate
+          ? { sourceOccurrenceDate: entry.sourceOccurrenceDate }
+          : {}),
       });
     } else if (entry.type === BlockedBlockType.CalendarEvent) {
       const calendarEvent = entry.data;
@@ -68,7 +70,9 @@ export const createViewEntriesForBlock = (
         data: repeatCfg,
         duration: entry.end - entry.start,
         plannedForDay: dayDate,
-        sourceOccurrenceDate: entry.sourceOccurrenceDate,
+        ...(entry.sourceOccurrenceDate
+          ? { sourceOccurrenceDate: entry.sourceOccurrenceDate }
+          : {}),
       });
     }
   });

--- a/src/app/features/schedule/map-schedule-data/create-view-entries-for-block.ts
+++ b/src/app/features/schedule/map-schedule-data/create-view-entries-for-block.ts
@@ -27,6 +27,7 @@ export const createViewEntriesForBlock = (
         data: repeatCfg,
         duration: repeatCfg.defaultEstimate || 0,
         plannedForDay: dayDate,
+        sourceOccurrenceDate: entry.sourceOccurrenceDate,
       });
     } else if (entry.type === BlockedBlockType.CalendarEvent) {
       const calendarEvent = entry.data;
@@ -67,6 +68,7 @@ export const createViewEntriesForBlock = (
         data: repeatCfg,
         duration: entry.end - entry.start,
         plannedForDay: dayDate,
+        sourceOccurrenceDate: entry.sourceOccurrenceDate,
       });
     }
   });

--- a/src/app/features/schedule/map-schedule-data/insert-blocked-blocks-view-entries-for-schedule.ts
+++ b/src/app/features/schedule/map-schedule-data/insert-blocked-blocks-view-entries-for-schedule.ts
@@ -211,6 +211,8 @@ export const insertBlockedBlocksViewEntriesForSchedule = (
               taskRepeatCfg,
               duration: timePlannedForSplitContinued,
               splitIndex: 0,
+              sourceOccurrenceDate:
+                currentVE.sourceOccurrenceDate ?? currentVE.plannedForDay,
             });
 
             // move entries
@@ -258,6 +260,8 @@ export const insertBlockedBlocksViewEntriesForSchedule = (
               taskRepeatCfg: currentVE.data,
               duration: timePlannedForSplitRepeatCfgProjectionContinued,
               splitIndex,
+              sourceOccurrenceDate:
+                currentVE.sourceOccurrenceDate ?? currentVE.plannedForDay,
             });
 
             // move entries
@@ -370,12 +374,16 @@ export const createSplitRepeat = ({
   taskRepeatCfg,
   splitIndex,
   duration,
+  sourceOccurrenceDate,
 }: {
   start: number;
   dayDate: string;
   taskRepeatCfg: TaskRepeatCfg;
   splitIndex: number;
   duration: number;
+  // the day the occurrence belongs to, which is not dayDate once a segment has
+  // been pushed across midnight -- without it a tail resolves to its render day
+  sourceOccurrenceDate?: string;
 }): SVERepeatProjectionSplitContinued => {
   return {
     id: `${taskRepeatCfg.id}_${dayDate}_${splitIndex}`,
@@ -385,5 +393,6 @@ export const createSplitRepeat = ({
     splitIndex,
     data: taskRepeatCfg,
     plannedForDay: dayDate,
+    ...(sourceOccurrenceDate ? { sourceOccurrenceDate } : {}),
   };
 };

--- a/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.spec.ts
@@ -137,6 +137,20 @@ describe('mapScheduleDaysToScheduleEvents()', () => {
     expect(res.eventsFlat[0].isBeyondBudget).toBe(true);
   });
 
+  it('preserves the source occurrence date of a continued repeat projection', () => {
+    const entry = {
+      ...fakeTaskEntry('CONTINUED', {
+        plannedForDay: '2026-07-31',
+        start: new Date(2026, 6, 31, 0, 0).getTime(),
+      }),
+      sourceOccurrenceDate: '2026-07-30',
+    };
+
+    const res = mapScheduleDaysToScheduleEvents([fakeDay({ entries: [entry] })], FH);
+
+    expect(res.eventsFlat[0].sourceOccurrenceDate).toBe('2026-07-30');
+  });
+
   it('should set calendar badge day for beyond budget planned tasks', () => {
     const res = mapScheduleDaysToScheduleEvents(
       [

--- a/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.ts
+++ b/src/app/features/schedule/map-schedule-data/map-schedule-days-to-schedule-events.ts
@@ -68,6 +68,9 @@ export const mapScheduleDaysToScheduleEvents = (
           style: `grid-column: ${dayIndex + 2};  grid-row: ${startRow} / span ${rowSpan}`,
           data: entry.data,
           plannedForDay: entry.plannedForDay,
+          ...(entry.sourceOccurrenceDate
+            ? { sourceOccurrenceDate: entry.sourceOccurrenceDate }
+            : {}),
           isBeyondBudget: entry.isBeyondBudget,
         });
 

--- a/src/app/features/schedule/map-schedule-data/map-to-schedule-days-extended.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/map-to-schedule-days-extended.spec.ts
@@ -156,6 +156,7 @@ describe('mapToScheduleDays()', () => {
           start: 1722841200000,
           type: 'ScheduledRepeatProjection',
           plannedForDay: '2024-08-05',
+          sourceOccurrenceDate: '2024-08-05',
         },
         {
           data: {

--- a/src/app/features/schedule/map-schedule-data/map-to-schedule-days.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/map-to-schedule-days.spec.ts
@@ -781,6 +781,7 @@ describe('mapToScheduleDays()', () => {
             type: 'RepeatProjectionSplitContinuedLast',
             splitIndex: 0,
             plannedForDay: '1970-01-01',
+            sourceOccurrenceDate: '1970-01-01',
           },
         ],
         isToday: true,
@@ -827,6 +828,7 @@ describe('mapToScheduleDays()', () => {
             start: 129600000,
             type: 'RepeatProjectionSplitContinuedLast',
             plannedForDay: '1970-01-02',
+            sourceOccurrenceDate: '1970-01-02',
           },
         ],
         isToday: false,
@@ -948,6 +950,7 @@ describe('mapToScheduleDays()', () => {
           type: 'RepeatProjectionSplitContinuedLast',
           splitIndex: 0,
           plannedForDay: '1970-01-02',
+          sourceOccurrenceDate: '1970-01-02',
         },
         {
           data: jasmine.any(Object),
@@ -1274,4 +1277,46 @@ describe('mapToScheduleDays()', () => {
   //     isToday: false,
   //   } as any);
   // });
+  it('should keep every segment of a flow projection pointing at its own occurrence day', () => {
+    // a 26h untimed projection starts on day 1, is pushed over midnight, and is
+    // then split again by a scheduled task on day 2 -> all four segments still
+    // belong to the day-1 occurrence
+    const r = mapToScheduleDays(
+      N,
+      [NDS, '1970-01-02', '1970-01-03'],
+      [],
+      [
+        fakePlannedTaskEntry('S2', new Date(1970, 0, 2, 1, 0, 0, 0), {
+          timeEstimate: h(0.5),
+        }),
+      ],
+      [],
+      [
+        fakeRepeatCfg('R2', undefined, {
+          defaultEstimate: h(26),
+          // monthly so exactly one occurrence falls into the 3 day window
+          repeatCycle: 'MONTHLY',
+        }),
+      ],
+      [],
+      null,
+      {},
+      undefined,
+      undefined,
+    );
+
+    const projectionSegments = r
+      .flatMap((d) => d.entries)
+      .filter((e) => e.type.startsWith('RepeatProjection'));
+
+    expect(projectionSegments.length).toBe(3);
+    // this is what the schedule event click handler resolves the target date to
+    expect(
+      projectionSegments.map(
+        (e) =>
+          (e as { sourceOccurrenceDate?: string }).sourceOccurrenceDate ??
+          e.plannedForDay,
+      ),
+    ).toEqual([NDS, NDS, NDS]);
+  });
 });

--- a/src/app/features/schedule/map-schedule-data/map-to-schedule-days.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/map-to-schedule-days.spec.ts
@@ -361,6 +361,7 @@ describe('mapToScheduleDays()', () => {
             duration: h(1),
             type: 'ScheduledRepeatProjection',
             plannedForDay: '1970-01-02',
+            sourceOccurrenceDate: '1970-01-02',
           },
         ],
         isToday: false,
@@ -431,6 +432,7 @@ describe('mapToScheduleDays()', () => {
             duration: h(1),
             type: 'ScheduledRepeatProjection',
             plannedForDay: '1970-01-02',
+            sourceOccurrenceDate: '1970-01-02',
           },
           {
             data: jasmine.any(Object),
@@ -571,6 +573,7 @@ describe('mapToScheduleDays()', () => {
           start: dhTz(1, 9),
           type: 'ScheduledRepeatProjection',
           plannedForDay: '1970-01-02',
+          sourceOccurrenceDate: '1970-01-02',
         },
         {
           data: jasmine.any(Object),
@@ -594,6 +597,7 @@ describe('mapToScheduleDays()', () => {
           start: dhTz(2, 9),
           type: 'ScheduledRepeatProjection',
           plannedForDay: '1970-01-03',
+          sourceOccurrenceDate: '1970-01-03',
         },
         {
           data: jasmine.any(Object),
@@ -919,6 +923,7 @@ describe('mapToScheduleDays()', () => {
           start: dhTz(1, 1),
           type: 'ScheduledRepeatProjection',
           plannedForDay: '1970-01-02',
+          sourceOccurrenceDate: '1970-01-02',
         },
         {
           data: jasmine.any(Object),
@@ -1003,6 +1008,7 @@ describe('mapToScheduleDays()', () => {
           start: dhTz(2, 1),
           type: 'ScheduledRepeatProjection',
           plannedForDay: '1970-01-03',
+          sourceOccurrenceDate: '1970-01-03',
         },
         {
           data: {

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -157,6 +157,7 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
     it('opens every repeat projection variant for its planned calendar day', async () => {
       const repeatCfg = { id: 'repeat_cfg_with_underscores' } as TaskRepeatCfg;
       const plannedForDay = '2026-07-30';
+      const sourceOccurrenceDate = '2026-07-29';
       const projectionTypes = [
         SVEType.RepeatProjection,
         SVEType.RepeatProjectionSplit,
@@ -167,6 +168,9 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
       const matDialog = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>;
 
       for (const type of projectionTypes) {
+        const isContinuedProjection =
+          type === SVEType.RepeatProjectionSplitContinued ||
+          type === SVEType.RepeatProjectionSplitContinuedLast;
         fixture.componentRef.setInput('event', {
           id: 'repeat_cfg_with_underscores_not-a-date',
           type,
@@ -174,6 +178,7 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
           startHours: 10,
           timeLeftInHours: 1,
           plannedForDay,
+          sourceOccurrenceDate: isContinuedProjection ? sourceOccurrenceDate : undefined,
           data: repeatCfg,
         } as ScheduleEvent);
         fixture.detectChanges();
@@ -183,7 +188,10 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
         expect(matDialog.open).toHaveBeenCalledWith(
           jasmine.anything(),
           jasmine.objectContaining({
-            data: jasmine.objectContaining({ repeatCfg, targetDate: plannedForDay }),
+            data: jasmine.objectContaining({
+              repeatCfg,
+              targetDate: isContinuedProjection ? sourceOccurrenceDate : plannedForDay,
+            }),
           }),
         );
         matDialog.open.calls.reset();

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -11,6 +11,7 @@ import { TaskService } from '../../tasks/task.service';
 import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { selectTaskByIdWithSubTaskData } from '../../tasks/store/task.selectors';
+import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
 
 const makeCalendarScheduleEvent = (isReferenceCalendar: boolean): ScheduleEvent => ({
   id: 'cal-1',
@@ -148,6 +149,44 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
       } else {
         // calMenuTrigger is undefined when MatMenuTrigger is not resolved – openMenu was never called
         expect(trigger).toBeUndefined();
+      }
+    });
+  });
+
+  describe('clickHandler – repeat projections', () => {
+    it('opens every repeat projection variant for its planned calendar day', async () => {
+      const repeatCfg = { id: 'repeat_cfg_with_underscores' } as TaskRepeatCfg;
+      const plannedForDay = '2026-07-30';
+      const projectionTypes = [
+        SVEType.RepeatProjection,
+        SVEType.RepeatProjectionSplit,
+        SVEType.ScheduledRepeatProjection,
+        SVEType.RepeatProjectionSplitContinued,
+        SVEType.RepeatProjectionSplitContinuedLast,
+      ];
+      const matDialog = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>;
+
+      for (const type of projectionTypes) {
+        fixture.componentRef.setInput('event', {
+          id: 'repeat_cfg_with_underscores_not-a-date',
+          type,
+          style: '',
+          startHours: 10,
+          timeLeftInHours: 1,
+          plannedForDay,
+          data: repeatCfg,
+        } as ScheduleEvent);
+        fixture.detectChanges();
+
+        await component.clickHandler(new MouseEvent('click'));
+
+        expect(matDialog.open).toHaveBeenCalledWith(
+          jasmine.anything(),
+          jasmine.objectContaining({
+            data: jasmine.objectContaining({ repeatCfg, targetDate: plannedForDay }),
+          }),
+        );
+        matDialog.open.calls.reset();
       }
     });
   });

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -382,13 +382,15 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
     } else if (
       evt.type === SVEType.RepeatProjection ||
       evt.type === SVEType.RepeatProjectionSplit ||
-      evt.type === SVEType.ScheduledRepeatProjection
+      evt.type === SVEType.ScheduledRepeatProjection ||
+      evt.type === SVEType.RepeatProjectionSplitContinued ||
+      evt.type === SVEType.RepeatProjectionSplitContinuedLast
     ) {
       const repeatCfg: TaskRepeatCfg = evt.data as TaskRepeatCfg;
       this._matDialog.open(DialogEditTaskRepeatCfgComponent, {
         data: {
           repeatCfg,
-          targetDate: (evt.id.includes('_') && evt.id.split('_')[1]) || undefined,
+          targetDate: evt.plannedForDay,
         },
       });
     } else if (evt.type === SVEType.CalendarEvent) {

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -390,7 +390,7 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
       this._matDialog.open(DialogEditTaskRepeatCfgComponent, {
         data: {
           repeatCfg,
-          targetDate: evt.plannedForDay,
+          targetDate: evt.sourceOccurrenceDate ?? evt.plannedForDay,
         },
       });
     } else if (evt.type === SVEType.CalendarEvent) {

--- a/src/app/features/schedule/schedule.model.ts
+++ b/src/app/features/schedule/schedule.model.ts
@@ -12,6 +12,7 @@ export interface ScheduleEvent {
   timeLeftInHours: number;
   dayOfMonth?: number;
   plannedForDay?: string;
+  sourceOccurrenceDate?: string;
   data?: SVE['data'];
   overlap?: { count: number; offset: number };
   isBeyondBudget?: boolean;
@@ -30,6 +31,7 @@ interface SVEBase {
   start: number;
   duration: number;
   plannedForDay?: string;
+  sourceOccurrenceDate?: string;
   isBeyondBudget?: boolean;
 }
 
@@ -177,6 +179,7 @@ export interface BlockedBlockEntryScheduledRepeatProjection {
     | BlockedBlockType.ScheduledRepeatProjection
     | BlockedBlockType.ScheduledRepeatProjectionSplit;
   data: TaskRepeatCfg;
+  sourceOccurrenceDate?: string;
 }
 
 export interface BlockedBlockEntryCalendarEvent {

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -357,6 +357,34 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
     });
   });
 
+  describe('deleteInstance', () => {
+    it('formats a date-only target date at local midnight in the skip confirmation', async () => {
+      const fixture = await setupTestBed({
+        repeatCfg: mockRepeatCfg,
+        targetDate: '2026-06-10',
+      });
+      const component = fixture.componentInstance;
+      component.canRemoveInstance.set(true);
+      const toLocaleDateStringSpy = spyOn(
+        Date.prototype,
+        'toLocaleDateString',
+      ).and.callFake(function (this: Date): string {
+        return String(this.getHours());
+      });
+      spyOn(TestBed.inject(TranslateService), 'instant').and.callFake(
+        (_key: string, params?: { date?: string }) => params?.date || '',
+      );
+
+      component.deleteInstance();
+
+      expect(toLocaleDateStringSpy).toHaveBeenCalled();
+      expect(mockMatDialog.open).toHaveBeenCalledWith(
+        jasmine.anything(),
+        jasmine.objectContaining({ data: jasmine.objectContaining({ message: '0' }) }),
+      );
+    });
+  });
+
   describe('new config initialization', () => {
     it('uses the explicit initial start date from the schedule dialog', async () => {
       const taskWithStoredDueDate = {

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts
@@ -552,13 +552,16 @@ export class DialogEditTaskRepeatCfgComponent {
 
     const currentRepeatCfg = this.repeatCfg() as TaskRepeatCfg;
     const targetDate = this._data.targetDate;
+    const confirmationDate = isDBDateStr(targetDate)
+      ? dateStrToUtcDate(targetDate)
+      : new Date(targetDate);
 
     this._matDialog
       .open(DialogConfirmComponent, {
         restoreFocus: true,
         data: {
           message: this._translateService.instant(T.F.TASK_REPEAT.D_SKIP_INSTANCE.MSG, {
-            date: new Date(targetDate).toLocaleDateString(
+            date: confirmationDate.toLocaleDateString(
               this._dateTimeFormatService.currentLocale(),
             ),
           }),


### PR DESCRIPTION
## Summary
- pass the projection's authoritative `plannedForDay` to the recurrence dialog instead of parsing generated IDs
- allow both continued split-projection event variants to open the dialog
- format date-only skip confirmations without UTC date parsing

Fixes #9270

## Verification
- `npm run test:file src/app/features/schedule/schedule-event/schedule-event.component.spec.ts` (15 passed)
- `npm run test:file src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts` (40 passed)
- `npm run checkFile src/app/features/schedule/schedule-event/schedule-event.component.ts`
- `npm run checkFile src/app/features/schedule/schedule-event/schedule-event.component.spec.ts`
- `npm run checkFile src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.ts`
- `npm run checkFile src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts`
- `git diff --check`

The repository-wide lint command exits non-zero for existing, unrelated warnings; this change adds none.