### PR TITLE
docs: Add sync.md Multi plugin to community plugins list #5747

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -134,5 +134,13 @@
     "author": "CuriousChipmunk",
     "authorUrl": "https://github.com/CuriousChipmunk",
     "stars": 0
+  },
+  {
+    "name": "sync.md Multi",
+    "shortDescription": "Sync multiple SuperProductivity projects with their own markdown files (bidirectional).",
+    "url": "https://codeberg.org/fpindado/sync-md-multi",
+    "author": "Fernando Pindado",
+    "authorUrl": "https://codeberg.org/fpindado",
+    "stars": 0
   }
 ]


### PR DESCRIPTION
## Problem

Super Productivity's built-in sync.md syncs a single project with one Markdown file. There is no built-in way to sync multiple projects, each with its own `.md` file — the request in #5747.

## Solution

Lists **sync.md Multi** in the community plugins so users can find and install it. It's an external plugin that bidirectionally syncs multiple SP projects with their own Markdown files (each project maps to its own `.md`), extending the built-in single-project sync.md.

- Source & README (EN/ES): https://codeberg.org/fpindado/sync-md-multi
- Latest release (installable ZIP): https://codeberg.org/fpindado/sync-md-multi/releases/tag/v0.4.0
- Verified working on Super Productivity 18.13.1–18.16 (macOS) as an uploaded plugin (nodeExecution consent).

Refs #5747 for users today, with no change to Super Productivity itself.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki) — this PR *is* a docs/listing change (`community-plugins.json`); no wiki changes needed.
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files — N/A, no `.ts`/`.scss` changed (data-only JSON entry).
- [ ] I have added tests for my changes (if applicable) — N/A, data-only change.
- [x] Existing tests still pass — unaffected (no code changed).
- [x] My commit messages follow the Angular format (`type(scope): description`)

