### PR TITLE
fix(sync): preserve section semantics during conflict replay

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -126,9 +126,11 @@ dependencies {
     // WidgetDataTest to lock the widget_data blob contract.
     testImplementation "org.json:json:20240303"
 
+    androidTestImplementation "androidx.test:core:1.6.1"
     androidTestImplementation "androidx.test:rules:1.6.1"
     androidTestImplementation "com.android.support.test:runner:1.0.2"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/CapacitorLifecycleBridgeInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/CapacitorLifecycleBridgeInstrumentedTest.kt
@@ -1,0 +1,266 @@
+package com.superproductivity.superproductivity
+
+import android.os.SystemClock
+import android.webkit.WebView
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import com.capacitorjs.plugins.app.AppPlugin
+import com.superproductivity.plugins.webdavhttp.WebDavHttpPlugin
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.json.JSONArray
+import org.json.JSONObject
+import org.json.JSONTokener
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Native smoke for the Capacitor shell.
+ *
+ * The test serves controlled HTML through Capacitor's real local server so the
+ * production JavaScript injection, plugin bridge, activity lifecycle, and
+ * WebDavHttp transport all participate. It deliberately stops at that native
+ * boundary; configured-provider background sync is covered separately by #9152.
+ */
+@RunWith(AndroidJUnit4::class)
+class CapacitorLifecycleBridgeInstrumentedTest {
+
+    @Test
+    fun bridgeAndWebDavRequestSurviveBackgroundResume() {
+        val responseGate = CountDownLatch(1)
+        val requestStarted = CountDownLatch(1)
+        val recordedRequest = AtomicReference<RecordedRequest>()
+        val server = MockWebServer()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                recordedRequest.set(request)
+                requestStarted.countDown()
+                return if (responseGate.await(20, TimeUnit.SECONDS)) {
+                    MockResponse()
+                        .setResponseCode(201)
+                        .setBody("stored-after-resume")
+                } else {
+                    MockResponse().setResponseCode(504)
+                }
+            }
+        }
+        server.start()
+
+        val scenario = ActivityScenario.launch(CapacitorMainActivity::class.java)
+        lateinit var webView: WebView
+        var webRoot: File? = null
+
+        try {
+            scenario.onActivity { activity ->
+                val bridge = activity.bridge
+                assertNotNull("Capacitor bridge should be created", bridge)
+                assertNotNull("Capacitor WebView should be created", bridge.webView)
+                assertEquals(AppPlugin::class.java, bridge.getPlugin("App").pluginClass)
+                assertEquals(
+                    WebDavHttpPlugin::class.java,
+                    bridge.getPlugin("WebDavHttp").pluginClass,
+                )
+
+                webView = bridge.webView
+                val testWebRoot = File(activity.cacheDir, "capacitor-lifecycle-bridge-smoke")
+                check(testWebRoot.mkdirs() || testWebRoot.isDirectory)
+                File(testWebRoot, "index.html").writeText(TEST_PAGE)
+                webRoot = testWebRoot
+                bridge.setServerBasePath(testWebRoot.absolutePath)
+            }
+
+            awaitJavaScript(webView, "window.__capacitorSmoke?.ready === true")
+            val readyState = readSmokeState(webView)
+            assertEquals("android", readyState.getString("platform"))
+            assertTrue(readyState.getBoolean("hasAndroidBridge"))
+            assertTrue(readyState.getBoolean("hasSupAndroid"))
+            assertTrue(readyState.getBoolean("hasAppPlugin"))
+            assertTrue(readyState.getBoolean("hasWebDavPlugin"))
+
+            evaluateJavaScript(
+                webView,
+                "window.startWebDavPut(${JSONObject.quote(server.url("/native-smoke.txt").toString())})",
+            )
+            assertTrue(
+                "WebDavHttp should start the PUT before backgrounding",
+                requestStarted.await(10, TimeUnit.SECONDS),
+            )
+            assertEquals("pending", readSmokeState(webView).getString("putState"))
+
+            scenario.moveToState(Lifecycle.State.CREATED)
+            assertEquals(Lifecycle.State.CREATED, scenario.state)
+            assertEquals(
+                "The server response must still be held while the activity is backgrounded",
+                1L,
+                responseGate.count,
+            )
+
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            assertEquals(Lifecycle.State.RESUMED, scenario.state)
+            awaitJavaScript(
+                webView,
+                """
+                    window.__capacitorSmoke?.supPause >= 1 &&
+                    window.__capacitorSmoke?.supResume >= 1 &&
+                    window.__capacitorSmoke?.appStates.includes(false) &&
+                    window.__capacitorSmoke?.appStates.includes(true)
+                """.trimIndent(),
+            )
+
+            val resumedState = readSmokeState(webView)
+            assertEquals("pending", resumedState.getString("putState"))
+            assertTrue(resumedState.getInt("supPause") >= 1)
+            assertTrue(resumedState.getInt("supResume") >= 1)
+            assertInactiveThenActive(resumedState.getJSONArray("appStates"))
+
+            responseGate.countDown()
+            awaitJavaScript(webView, "window.__capacitorSmoke?.putState === 'resolved'")
+
+            val completedState = readSmokeState(webView)
+            assertEquals(201, completedState.getInt("putStatus"))
+            assertEquals("stored-after-resume", completedState.getString("putData"))
+
+            val request = recordedRequest.get()
+            assertNotNull("Mock server should record the WebDavHttp request", request)
+            assertEquals("PUT", request.method)
+            assertEquals("/native-smoke.txt", request.path)
+            assertEquals("Basic native-smoke-token", request.getHeader("Authorization"))
+            assertEquals("lifecycle-body", request.body.readUtf8())
+        } finally {
+            responseGate.countDown()
+            scenario.close()
+            server.shutdown()
+            webRoot?.deleteRecursively()
+        }
+    }
+
+    private fun awaitJavaScript(
+        webView: WebView,
+        predicate: String,
+        timeoutSeconds: Long = 10,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(timeoutSeconds)
+        var lastResult = "not evaluated"
+        while (SystemClock.elapsedRealtime() < deadline) {
+            lastResult = evaluateJavaScript(webView, "Boolean($predicate)")
+            if (lastResult == "true") {
+                return
+            }
+            SystemClock.sleep(50)
+        }
+        fail("Timed out waiting for JavaScript predicate `$predicate`; last result: $lastResult")
+    }
+
+    private fun evaluateJavaScript(webView: WebView, script: String): String {
+        val completed = CountDownLatch(1)
+        val result = AtomicReference<String>()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            webView.evaluateJavascript(script) {
+                result.set(it)
+                completed.countDown()
+            }
+        }
+        assertTrue(
+            "JavaScript evaluation should complete",
+            completed.await(10, TimeUnit.SECONDS),
+        )
+        return requireNotNull(result.get())
+    }
+
+    private fun readSmokeState(webView: WebView): JSONObject {
+        val encoded = evaluateJavaScript(
+            webView,
+            "JSON.stringify(window.__capacitorSmoke)",
+        )
+        val json = JSONTokener(encoded).nextValue() as String
+        return JSONObject(json)
+    }
+
+    private fun assertInactiveThenActive(appStates: JSONArray) {
+        val values = (0 until appStates.length()).map(appStates::getBoolean)
+        val inactiveIndex = values.indexOf(false)
+        assertTrue("Capacitor App should report the background state", inactiveIndex >= 0)
+        assertTrue(
+            "Capacitor App should report active after the background state",
+            values.drop(inactiveIndex + 1).contains(true),
+        )
+    }
+
+    private companion object {
+        val TEST_PAGE = """
+            <!doctype html>
+            <html>
+              <head><meta charset="utf-8"></head>
+              <body>
+                <script>
+                  const smoke = window.__capacitorSmoke = {
+                    ready: false,
+                    platform: window.Capacitor?.getPlatform?.(),
+                    hasAndroidBridge: typeof window.androidBridge !== 'undefined',
+                    hasSupAndroid:
+                      typeof window.SUPAndroid !== 'undefined' &&
+                      typeof window.SUPAndroid.getVersion === 'function',
+                    hasAppPlugin:
+                      typeof window.Capacitor?.Plugins?.App?.addListener === 'function',
+                    hasWebDavPlugin:
+                      typeof window.Capacitor?.Plugins?.WebDavHttp?.request === 'function',
+                    supPause: 0,
+                    supResume: 0,
+                    appStates: [],
+                    putState: 'not-started',
+                  };
+
+                  window.SUPAndroid['onPause$'] = {
+                    next: () => smoke.supPause++,
+                  };
+                  window.SUPAndroid['onResume$'] = {
+                    next: () => smoke.supResume++,
+                  };
+                  window.Capacitor.Plugins.App.addListener(
+                    'appStateChange',
+                    ({ isActive }) => smoke.appStates.push(isActive),
+                  );
+
+                  window.startWebDavPut = (url) => {
+                    smoke.putState = 'pending';
+                    window.Capacitor.Plugins.WebDavHttp.request({
+                      url,
+                      method: 'PUT',
+                      headers: {
+                        Authorization: 'Basic native-smoke-token',
+                        'Content-Type': 'text/plain; charset=utf-8',
+                      },
+                      data: 'lifecycle-body',
+                    }).then((response) => {
+                      smoke.putStatus = response.status;
+                      smoke.putData = response.data;
+                      smoke.putState = 'resolved';
+                    }).catch((error) => {
+                      smoke.putError = String(error?.message || error);
+                      smoke.putState = 'rejected';
+                    });
+                  };
+
+                  window.Capacitor.Plugins.App.getState()
+                    .then(() => smoke.ready = true)
+                    .catch((error) => {
+                      smoke.readyError = String(error?.message || error);
+                    });
+                </script>
+              </body>
+            </html>
+        """.trimIndent()
+    }
+}

--- a/e2e/tests/sync/supersync-rejected-ops-transient-download-8331.spec.ts
+++ b/e2e/tests/sync/supersync-rejected-ops-transient-download-8331.spec.ts
@@ -257,7 +257,7 @@ test.describe('@supersync Rejected-ops transient download (#8331)', () => {
       // 7. Remove the fault and let B sync cleanly — the still-pending edit
       //    resolves and its local-win replacement is uploaded in the same sync.
       await clientB.page.unroute('**/api/sync/ops*');
-      await clientB.sync.syncAndWait();
+      await clientB.sync.triggerSync();
 
       // 8. End-to-end recovery proof: after pulling B's now-uploaded edit, both
       //    clients converge to the SAME title. With the bug, B's edit was

--- a/e2e/tests/sync/supersync-rejected-ops-transient-download-8331.spec.ts
+++ b/e2e/tests/sync/supersync-rejected-ops-transient-download-8331.spec.ts
@@ -255,9 +255,8 @@ test.describe('@supersync Rejected-ops transient download (#8331)', () => {
       expect(await isOpPending(clientB.page, concurrentRejectedOpId)).toBe(true);
 
       // 7. Remove the fault and let B sync cleanly — the still-pending edit
-      //    resolves and uploads (the merged op may need a second flush).
+      //    resolves and its local-win replacement is uploaded in the same sync.
       await clientB.page.unroute('**/api/sync/ops*');
-      await clientB.sync.syncAndWait();
       await clientB.sync.syncAndWait();
 
       // 8. End-to-end recovery proof: after pulling B's now-uploaded edit, both

--- a/e2e/tests/sync/supersync-repair-lifecycle.spec.ts
+++ b/e2e/tests/sync/supersync-repair-lifecycle.spec.ts
@@ -1,0 +1,510 @@
+import { expect, test } from '../../fixtures/supersync.fixture';
+import type { Page, Response, Route } from '@playwright/test';
+import { SuperSyncPage } from '../../pages/supersync.page';
+import { WorkViewPage } from '../../pages/work-view.page';
+import {
+  closeClient,
+  createSimulatedClient,
+  createTestUser,
+  getSuperSyncConfig,
+  parseSuperSyncRequestBody,
+  renameTask,
+  SUPERSYNC_BASE_URL,
+  type SimulatedE2EClient,
+  waitForTask,
+} from '../../utils/supersync-helpers';
+import { waitForAppReady } from '../../utils/waits';
+
+interface SnapshotUploadRequest {
+  opId?: string;
+  repairBaseServerSeq?: number;
+  snapshotOpType?: string;
+}
+
+interface SnapshotUploadResponse {
+  accepted?: boolean;
+  errorCode?: string;
+  serverSeq?: number;
+}
+
+interface StoredRepairOperation {
+  baseServerSeq?: number;
+  id: string;
+  rejectedAt?: number;
+  source: 'local' | 'remote';
+  syncedAt?: number;
+}
+
+interface ServerOperation {
+  id: string;
+  opType: string;
+  serverSeq: number;
+}
+
+interface TaskSnapshot {
+  id: string;
+  tagIds: string[];
+  title: string;
+}
+
+const getServerOperations = async (userId: number): Promise<ServerOperation[]> => {
+  const response = await fetch(
+    `${SUPERSYNC_BASE_URL}/api/test/user/${userId}/ops?limit=100`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to inspect server operations: ${response.status} ${await response.text()}`,
+    );
+  }
+  const body = (await response.json()) as { ops: ServerOperation[] };
+  return body.ops;
+};
+
+const getLatestServerSeq = async (userId: number): Promise<number> => {
+  const operations = await getServerOperations(userId);
+  return Math.max(0, ...operations.map(({ serverSeq }) => serverSeq));
+};
+
+const getTaskSnapshots = async (
+  page: Page,
+  exactTitle: string,
+): Promise<TaskSnapshot[]> =>
+  page.evaluate((title) => {
+    type TaskLike = {
+      id?: string;
+      tagIds?: unknown;
+      title?: string;
+    };
+    type StoreState = {
+      task?: { entities?: Record<string, TaskLike | undefined> };
+      tasks?: { entities?: Record<string, TaskLike | undefined> };
+    };
+    type StoreLike = {
+      subscribe: (next: (state: StoreState) => void) => { unsubscribe: () => void };
+    };
+
+    const store = (
+      window as unknown as {
+        __e2eTestHelpers?: { store?: StoreLike };
+      }
+    ).__e2eTestHelpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+
+    let latestState: StoreState | undefined;
+    const subscription = store.subscribe((state) => {
+      latestState = state;
+    });
+    subscription.unsubscribe();
+
+    const taskState = latestState?.tasks ?? latestState?.task;
+    return Object.values(taskState?.entities ?? {}).flatMap((task) => {
+      if (
+        task?.title !== title ||
+        typeof task.id !== 'string' ||
+        !Array.isArray(task.tagIds) ||
+        !task.tagIds.every((tagId) => typeof tagId === 'string')
+      ) {
+        return [];
+      }
+      return [
+        {
+          id: task.id,
+          tagIds: task.tagIds as string[],
+          title: task.title,
+        },
+      ];
+    });
+  }, exactTitle);
+
+const addGhostTagReference = async (
+  page: Page,
+  taskTitle: string,
+  ghostTagId: string,
+): Promise<void> => {
+  await page.evaluate(
+    ({ title, tagId }) => {
+      type TaskLike = {
+        id?: string;
+        tagIds?: string[];
+        title?: string;
+      };
+      type StoreState = {
+        task?: { entities?: Record<string, TaskLike | undefined> };
+        tasks?: { entities?: Record<string, TaskLike | undefined> };
+      };
+      type StoreLike = {
+        dispatch: (action: unknown) => void;
+        subscribe: (next: (state: StoreState) => void) => { unsubscribe: () => void };
+      };
+
+      const store = (
+        window as unknown as {
+          __e2eTestHelpers?: { store?: StoreLike };
+        }
+      ).__e2eTestHelpers?.store;
+      if (!store) {
+        throw new Error('__e2eTestHelpers.store missing');
+      }
+
+      let latestState: StoreState | undefined;
+      const subscription = store.subscribe((state) => {
+        latestState = state;
+      });
+      subscription.unsubscribe();
+
+      const taskState = latestState?.tasks ?? latestState?.task;
+      const task = Object.values(taskState?.entities ?? {}).find(
+        (candidate) => candidate?.title === title,
+      );
+      if (!task || typeof task.id !== 'string') {
+        throw new Error(`Task not found: ${title}`);
+      }
+
+      store.dispatch({
+        type: '[Task Shared] updateTask',
+        task: {
+          id: task.id,
+          changes: {
+            tagIds: [...(task.tagIds ?? []), tagId],
+          },
+        },
+        isIgnoreShortSyntax: true,
+        meta: {
+          isPersistent: true,
+          entityType: 'TASK',
+          entityId: task.id,
+          opType: 'UPD',
+        },
+      });
+    },
+    { title: taskTitle, tagId: ghostTagId },
+  );
+
+  await expect
+    .poll(async () => (await getTaskSnapshots(page, taskTitle))[0]?.tagIds ?? [])
+    .toContain(ghostTagId);
+};
+
+const getStoredRepairOperations = async (page: Page): Promise<StoredRepairOperation[]> =>
+  page.evaluate(async () => {
+    type CompactRepairEntry = {
+      op?: {
+        b?: number;
+        id?: string;
+        o?: string;
+      };
+      rejectedAt?: number;
+      source?: 'local' | 'remote';
+      syncedAt?: number;
+    };
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('SUP_OPS');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+
+    try {
+      if (!db.objectStoreNames.contains('ops')) {
+        return [];
+      }
+      const entries = await new Promise<CompactRepairEntry[]>((resolve, reject) => {
+        const transaction = db.transaction('ops', 'readonly');
+        const request = transaction.objectStore('ops').getAll();
+        request.onsuccess = () => resolve(request.result as CompactRepairEntry[]);
+        request.onerror = () => reject(request.error);
+      });
+
+      return entries.flatMap((entry) => {
+        if (
+          entry.op?.o !== 'REPAIR' ||
+          typeof entry.op.id !== 'string' ||
+          (entry.source !== 'local' && entry.source !== 'remote')
+        ) {
+          return [];
+        }
+        return [
+          {
+            id: entry.op.id,
+            source: entry.source,
+            ...(entry.op.b !== undefined ? { baseServerSeq: entry.op.b } : {}),
+            ...(entry.syncedAt !== undefined ? { syncedAt: entry.syncedAt } : {}),
+            ...(entry.rejectedAt !== undefined ? { rejectedAt: entry.rejectedAt } : {}),
+          },
+        ];
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+const forwardResponse = async (
+  route: Route,
+  response: Response,
+): Promise<SnapshotUploadResponse> => {
+  const body = await response.body();
+  const decoded = JSON.parse(body.toString('utf8')) as SnapshotUploadResponse;
+  await route.fulfill({ response, body });
+  return decoded;
+};
+
+const expectConvergedTask = async (
+  client: SimulatedE2EClient,
+  taskTitle: string,
+  ghostTagId: string,
+): Promise<void> => {
+  await waitForTask(client.page, taskTitle);
+  await expect
+    .poll(() => getTaskSnapshots(client.page, taskTitle), {
+      message: `${client.clientName} did not converge to exactly one repaired task`,
+    })
+    .toHaveLength(1);
+  expect((await getTaskSnapshots(client.page, taskTitle))[0].tagIds).not.toContain(
+    ghostTagId,
+  );
+};
+
+test.describe('@supersync REPAIR lifecycle', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('rebases a stale repair, retries it after reload, and converges all clients', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.setTimeout(240000);
+
+    const appUrl = baseURL || 'http://localhost:4242';
+    const taskTitle = `A-${testRunId}-RepairLifecycle`;
+    const renamedTaskTitle = `${taskTitle}-RenamedByB`;
+    const ghostTagId = `ghost-tag-${testRunId}`;
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+    let clientC: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      clientA = await createSimulatedClient(browser, appUrl, 'A', testRunId);
+      await clientA.workView.waitForTaskList();
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      clientB = await createSimulatedClient(browser, appUrl, 'B', testRunId);
+      await clientB.workView.waitForTaskList();
+      await clientB.sync.setupSuperSync(syncConfig);
+
+      await clientA.workView.addTask(taskTitle);
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await waitForTask(clientB.page, taskTitle);
+
+      await addGhostTagReference(clientB.page, taskTitle, ghostTagId);
+      const serverSeqBeforeCorruption = await getLatestServerSeq(user.userId);
+      await clientB.sync.syncAndWait();
+      const corruptionServerSeq = await getLatestServerSeq(user.userId);
+      expect(corruptionServerSeq).toBeGreaterThan(serverSeqBeforeCorruption);
+
+      let firstRepairRequest: SnapshotUploadRequest | undefined;
+      let firstRepairResponse: SnapshotUploadResponse | undefined;
+      let replacementRepairRequest: SnapshotUploadRequest | undefined;
+      let replacementAcceptedResponse: SnapshotUploadResponse | undefined;
+      let replacementAbortCount = 0;
+      let replacementRetryCount = 0;
+      let allowReplacementCommit = false;
+
+      let markFirstRepairSeen!: () => void;
+      const firstRepairSeen = new Promise<void>((resolve) => {
+        markFirstRepairSeen = resolve;
+      });
+      let releaseFirstRepair!: () => void;
+      const firstRepairRelease = new Promise<void>((resolve) => {
+        releaseFirstRepair = resolve;
+      });
+      let markReplacementAborted!: () => void;
+      const replacementAborted = new Promise<void>((resolve) => {
+        markReplacementAborted = resolve;
+      });
+      let markReplacementAccepted!: () => void;
+      const replacementAccepted = new Promise<void>((resolve) => {
+        markReplacementAccepted = resolve;
+      });
+
+      await clientA.page.route('**/api/sync/snapshot', async (route) => {
+        const request = parseSuperSyncRequestBody<SnapshotUploadRequest>(route.request());
+        if (request.snapshotOpType !== 'REPAIR' || !request.opId) {
+          await route.continue();
+          return;
+        }
+
+        if (!firstRepairRequest) {
+          firstRepairRequest = request;
+          markFirstRepairSeen();
+          await firstRepairRelease;
+          const response = await route.fetch();
+          firstRepairResponse = await forwardResponse(route, response);
+          return;
+        }
+
+        if (request.opId === firstRepairRequest.opId) {
+          throw new Error(`Stale REPAIR ${request.opId} was uploaded more than once`);
+        }
+
+        if (!replacementRepairRequest) {
+          replacementRepairRequest = request;
+        } else {
+          expect(request.opId).toBe(replacementRepairRequest.opId);
+          expect(request.repairBaseServerSeq).toBe(
+            replacementRepairRequest.repairBaseServerSeq,
+          );
+        }
+
+        if (!allowReplacementCommit) {
+          if (replacementAbortCount === 0) {
+            replacementAbortCount++;
+            await route.abort('failed');
+            markReplacementAborted();
+            return;
+          }
+          // The provider retries one transport failure itself. Keep that retry
+          // away from the server with a retryable HTTP response so the one
+          // explicit abort still leaves the replacement pending for reload.
+          await route.fulfill({
+            status: 503,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'Temporary test outage' }),
+          });
+          return;
+        }
+
+        replacementRetryCount++;
+        const response = await route.fetch();
+        replacementAcceptedResponse = await forwardResponse(route, response);
+        markReplacementAccepted();
+      });
+
+      await clientA.sync.syncBtn.click();
+      await firstRepairSeen;
+      await expect(clientA.sync.syncSpinner).toBeVisible();
+      expect(firstRepairRequest?.repairBaseServerSeq).toBe(corruptionServerSeq);
+
+      await renameTask(clientB, taskTitle, renamedTaskTitle);
+      await clientB.sync.syncAndWait();
+      const concurrentServerSeq = await getLatestServerSeq(user.userId);
+      expect(concurrentServerSeq).toBeGreaterThan(corruptionServerSeq);
+
+      releaseFirstRepair();
+      await replacementAborted;
+      await clientA.sync.syncSpinner.waitFor({ state: 'hidden', timeout: 30000 });
+
+      expect(firstRepairResponse).toMatchObject({
+        accepted: false,
+        errorCode: 'REPAIR_STALE',
+      });
+      expect(replacementAbortCount).toBe(1);
+      expect(replacementRepairRequest?.opId).not.toBe(firstRepairRequest?.opId);
+      expect(replacementRepairRequest?.repairBaseServerSeq).toBe(concurrentServerSeq);
+
+      const repairsBeforeReload = await getStoredRepairOperations(clientA.page);
+      const staleRepairBeforeReload = repairsBeforeReload.find(
+        ({ id }) => id === firstRepairRequest?.opId,
+      );
+      const replacementBeforeReload = repairsBeforeReload.find(
+        ({ id }) => id === replacementRepairRequest?.opId,
+      );
+      expect(staleRepairBeforeReload).toMatchObject({
+        source: 'local',
+        baseServerSeq: corruptionServerSeq,
+      });
+      expect(staleRepairBeforeReload?.rejectedAt).toBeDefined();
+      expect(staleRepairBeforeReload?.syncedAt).toBeUndefined();
+      expect(replacementBeforeReload).toMatchObject({
+        source: 'local',
+        baseServerSeq: concurrentServerSeq,
+      });
+      expect(replacementBeforeReload?.rejectedAt).toBeUndefined();
+      expect(replacementBeforeReload?.syncedAt).toBeUndefined();
+
+      await clientA.page.addInitScript(() => {
+        const e2eGlobal = globalThis as typeof globalThis & {
+          __SP_E2E_BLOCK_AUTO_SYNC?: boolean;
+          __SP_E2E_BLOCK_IMMEDIATE_UPLOAD?: boolean;
+          __SP_E2E_BLOCK_WS_DOWNLOAD?: boolean;
+        };
+        e2eGlobal.__SP_E2E_BLOCK_AUTO_SYNC = true;
+        e2eGlobal.__SP_E2E_BLOCK_IMMEDIATE_UPLOAD = true;
+        e2eGlobal.__SP_E2E_BLOCK_WS_DOWNLOAD = true;
+      });
+      await clientA.page.reload({ waitUntil: 'domcontentloaded', timeout: 30000 });
+      clientA.workView = new WorkViewPage(clientA.page, `A-${testRunId}`);
+      clientA.sync = new SuperSyncPage(clientA.page);
+      await waitForAppReady(clientA.page);
+      await clientA.workView.waitForTaskList();
+
+      allowReplacementCommit = true;
+      await clientA.sync.syncAndWait({ timeout: 60000 });
+      await replacementAccepted;
+      expect(replacementRetryCount).toBe(1);
+      expect(replacementAcceptedResponse?.accepted).toBe(true);
+      expect(replacementAcceptedResponse?.serverSeq).toBeGreaterThan(concurrentServerSeq);
+
+      const repairsAfterRetry = await getStoredRepairOperations(clientA.page);
+      expect(repairsAfterRetry).toHaveLength(2);
+      const retriedReplacement = repairsAfterRetry.find(
+        ({ id }) => id === replacementRepairRequest?.opId,
+      );
+      expect(retriedReplacement?.syncedAt).toBeDefined();
+      expect(retriedReplacement?.rejectedAt).toBeUndefined();
+
+      const repairRequestCountBeforeNoop =
+        1 + replacementAbortCount + replacementRetryCount;
+      await clientA.sync.syncAndWait();
+      expect(1 + replacementAbortCount + replacementRetryCount).toBe(
+        repairRequestCountBeforeNoop,
+      );
+      expect(await getStoredRepairOperations(clientA.page)).toHaveLength(2);
+
+      const serverRepairOperations = (await getServerOperations(user.userId)).filter(
+        ({ opType }) => opType === 'REPAIR',
+      );
+      expect(serverRepairOperations).toHaveLength(1);
+      expect(serverRepairOperations[0].id).toBe(replacementRepairRequest?.opId);
+      expect(
+        serverRepairOperations.some(({ id }) => id === firstRepairRequest?.opId),
+      ).toBe(false);
+
+      await clientB.sync.syncAndWait();
+      await expectConvergedTask(clientA, renamedTaskTitle, ghostTagId);
+      await expectConvergedTask(clientB, renamedTaskTitle, ghostTagId);
+
+      let clientCRepairUploads = 0;
+      clientC = await createSimulatedClient(browser, appUrl, 'C', testRunId);
+      await clientC.workView.waitForTaskList();
+      await clientC.page.route('**/api/sync/snapshot', async (route) => {
+        const request = parseSuperSyncRequestBody<SnapshotUploadRequest>(route.request());
+        if (request.snapshotOpType === 'REPAIR') {
+          clientCRepairUploads++;
+        }
+        await route.continue();
+      });
+      await clientC.sync.setupSuperSync(syncConfig);
+      await clientC.sync.syncAndWait();
+      await expectConvergedTask(clientC, renamedTaskTitle, ghostTagId);
+      expect(clientCRepairUploads).toBe(0);
+
+      for (const client of [clientA, clientB, clientC]) {
+        const pendingLocalRepairs = (await getStoredRepairOperations(client.page)).filter(
+          ({ rejectedAt, source, syncedAt }) =>
+            source === 'local' && rejectedAt === undefined && syncedAt === undefined,
+        );
+        expect(pendingLocalRepairs).toEqual([]);
+      }
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+      if (clientC) await closeClient(clientC);
+    }
+  });
+});

--- a/e2e/tests/sync/supersync-section-convergence.spec.ts
+++ b/e2e/tests/sync/supersync-section-convergence.spec.ts
@@ -1,0 +1,400 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/supersync.fixture';
+import {
+  closeClient,
+  createSimulatedClient,
+  createTestUser,
+  getSuperSyncConfig,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+
+interface SectionSnapshot {
+  leftTitles: string[];
+  rightTitles: string[];
+  noSectionTitles: string[];
+  todayTitles: string[];
+  todaySectionIds: string[];
+  movingSectionMemberships: number;
+  movingTodayOccurrences: number;
+}
+
+interface PersistentAction extends Record<string, unknown> {
+  type: string;
+  meta: Record<string, unknown>;
+}
+
+const dispatchPersistentAction = async (
+  page: Page,
+  action: PersistentAction,
+): Promise<void> => {
+  const wasDispatched = await page.evaluate((actionToDispatch) => {
+    type StoreLike = { dispatch: (action: unknown) => void };
+    const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+      .__e2eTestHelpers?.store;
+    if (!store) return false;
+    store.dispatch(actionToDispatch);
+    return true;
+  }, action);
+
+  expect(wasDispatched).toBe(true);
+};
+
+const getTaskIdsByTitle = async (
+  page: Page,
+  titles: string[],
+): Promise<Record<string, string | null>> =>
+  page.evaluate((taskTitles) => {
+    type TaskLike = { id: string; title: string };
+    type StoreState = {
+      tasks?: { entities?: Record<string, TaskLike | undefined> };
+    };
+    type StoreLike = {
+      subscribe: (next: (state: StoreState) => void) => { unsubscribe: () => void };
+    };
+    const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+      .__e2eTestHelpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+
+    let state: StoreState | undefined;
+    const subscription = store.subscribe((value) => {
+      state = value;
+    });
+    subscription.unsubscribe();
+
+    const tasks = Object.values(state?.tasks?.entities ?? {});
+    return Object.fromEntries(
+      taskTitles.map((title) => [
+        title,
+        tasks.find((task) => task?.title === title)?.id ?? null,
+      ]),
+    );
+  }, titles);
+
+const requireTaskId = (
+  taskIdsByTitle: Record<string, string | null>,
+  title: string,
+): string => {
+  const id = taskIdsByTitle[title];
+  if (!id) throw new Error(`Task "${title}" was not found in the store`);
+  return id;
+};
+
+const getSectionSnapshot = async (
+  page: Page,
+  leftSectionId: string,
+  rightSectionId: string,
+  movingTaskId: string,
+): Promise<SectionSnapshot> =>
+  page.evaluate(
+    ({ leftId, rightId, movingId }) => {
+      type TaskLike = { id: string; title: string };
+      type SectionLike = { id: string; contextId: string; taskIds: string[] };
+      type TagLike = { taskIds: string[] };
+      type StoreState = {
+        tasks?: { entities?: Record<string, TaskLike | undefined> };
+        section?: {
+          ids?: Array<string | number>;
+          entities?: Record<string, SectionLike | undefined>;
+        };
+        tag?: { entities?: Record<string, TagLike | undefined> };
+      };
+      type StoreLike = {
+        subscribe: (next: (state: StoreState) => void) => {
+          unsubscribe: () => void;
+        };
+      };
+      const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+        .__e2eTestHelpers?.store;
+      if (!store) {
+        throw new Error('__e2eTestHelpers.store missing');
+      }
+
+      let state: StoreState | undefined;
+      const subscription = store.subscribe((value) => {
+        state = value;
+      });
+      subscription.unsubscribe();
+
+      const tasks = state?.tasks?.entities ?? {};
+      const sections = state?.section?.entities ?? {};
+      const todayTaskIds = state?.tag?.entities?.TODAY?.taskIds ?? [];
+      const todaySections = Object.values(sections).filter(
+        (section): section is SectionLike => section?.contextId === 'TODAY',
+      );
+      const todaySectionIds = (state?.section?.ids ?? [])
+        .map(String)
+        .filter((id) => sections[id]?.contextId === 'TODAY');
+      const sectionedTaskIds = new Set(
+        todaySections.flatMap((section) => section.taskIds),
+      );
+      const titlesFor = (ids: string[]): string[] =>
+        ids.map((id) => tasks[id]?.title ?? `[missing:${id}]`);
+
+      return {
+        leftTitles: titlesFor(sections[leftId]?.taskIds ?? []),
+        rightTitles: titlesFor(sections[rightId]?.taskIds ?? []),
+        noSectionTitles: titlesFor(
+          todayTaskIds.filter((id) => !sectionedTaskIds.has(id)),
+        ),
+        todayTitles: titlesFor(todayTaskIds),
+        todaySectionIds,
+        movingSectionMemberships: todaySections.filter((section) =>
+          section.taskIds.includes(movingId),
+        ).length,
+        movingTodayOccurrences: todayTaskIds.filter((id) => id === movingId).length,
+      };
+    },
+    {
+      leftId: leftSectionId,
+      rightId: rightSectionId,
+      movingId: movingTaskId,
+    },
+  );
+
+test.describe('@supersync Section cross-client convergence', () => {
+  test('concurrent move, removal, and reorder converge once and persist', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.setTimeout(180000);
+    const appUrl = baseURL || 'http://localhost:4242';
+    const leftSectionId = `section-left-${testRunId}`;
+    const rightSectionId = `section-right-${testRunId}`;
+    const movingTitle = `A-${testRunId}-Moving`;
+    const leftAnchorTitle = `A-${testRunId}-Left anchor`;
+    const rightAnchorTitle = `A-${testRunId}-Right anchor`;
+    const mainAnchorTitle = `A-${testRunId}-Main anchor`;
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+    let clientC: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      clientA = await createSimulatedClient(browser, appUrl, 'A', testRunId);
+      await clientA.workView.waitForTaskList();
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      await clientA.workView.addTask('Main anchor');
+      await clientA.workView.addTask('Left anchor');
+      await clientA.workView.addTask('Moving');
+      await clientA.workView.addTask('Right anchor');
+
+      const taskIdsByTitle = await getTaskIdsByTitle(clientA.page, [
+        mainAnchorTitle,
+        leftAnchorTitle,
+        movingTitle,
+        rightAnchorTitle,
+      ]);
+      const mainAnchorId = requireTaskId(taskIdsByTitle, mainAnchorTitle);
+      const leftAnchorId = requireTaskId(taskIdsByTitle, leftAnchorTitle);
+      const movingTaskId = requireTaskId(taskIdsByTitle, movingTitle);
+      const rightAnchorId = requireTaskId(taskIdsByTitle, rightAnchorTitle);
+
+      for (const [id, title] of [
+        [leftSectionId, 'Left'],
+        [rightSectionId, 'Right'],
+      ]) {
+        await dispatchPersistentAction(clientA.page, {
+          type: '[Section] Add Section',
+          section: {
+            id,
+            contextId: 'TODAY',
+            contextType: 'TAG',
+            title,
+            isExpanded: true,
+            taskIds: [],
+          },
+          meta: {
+            isPersistent: true,
+            entityType: 'SECTION',
+            entityId: id,
+            opType: 'CRT',
+          },
+        });
+      }
+
+      for (const [sectionId, taskId, afterTaskId] of [
+        [leftSectionId, leftAnchorId, null],
+        [leftSectionId, movingTaskId, leftAnchorId],
+        [rightSectionId, rightAnchorId, null],
+      ]) {
+        await dispatchPersistentAction(clientA.page, {
+          type: '[Section] Add Task to Section',
+          sectionId,
+          taskId,
+          afterTaskId,
+          sourceSectionId: null,
+          meta: {
+            isPersistent: true,
+            entityType: 'SECTION',
+            entityId: sectionId,
+            opType: 'MOV',
+          },
+        });
+      }
+
+      await clientA.sync.syncAndWait();
+
+      clientB = await createSimulatedClient(browser, appUrl, 'B', testRunId);
+      await clientB.workView.waitForTaskList();
+      await clientB.sync.setupSuperSync(syncConfig);
+      await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+
+      const seededSnapshot: SectionSnapshot = {
+        leftTitles: [leftAnchorTitle, movingTitle],
+        rightTitles: [rightAnchorTitle],
+        noSectionTitles: [mainAnchorTitle],
+        todayTitles: [rightAnchorTitle, movingTitle, leftAnchorTitle, mainAnchorTitle],
+        todaySectionIds: [leftSectionId, rightSectionId],
+        movingSectionMemberships: 1,
+        movingTodayOccurrences: 1,
+      };
+      expect(
+        await getSectionSnapshot(
+          clientA.page,
+          leftSectionId,
+          rightSectionId,
+          movingTaskId,
+        ),
+      ).toEqual(seededSnapshot);
+      expect(
+        await getSectionSnapshot(
+          clientB.page,
+          leftSectionId,
+          rightSectionId,
+          movingTaskId,
+        ),
+      ).toEqual(seededSnapshot);
+
+      await dispatchPersistentAction(clientA.page, {
+        type: '[Section] Add Task to Section',
+        sectionId: rightSectionId,
+        taskId: movingTaskId,
+        afterTaskId: rightAnchorId,
+        sourceSectionId: leftSectionId,
+        meta: {
+          isPersistent: true,
+          entityType: 'SECTION',
+          entityIds: [leftSectionId, rightSectionId],
+          opType: 'MOV',
+        },
+      });
+
+      await dispatchPersistentAction(clientB.page, {
+        type: '[Section] Remove Task from Section',
+        sectionId: leftSectionId,
+        taskId: movingTaskId,
+        workContextId: 'TODAY',
+        workContextType: 'TAG',
+        workContextAfterTaskId: mainAnchorId,
+        meta: {
+          isPersistent: true,
+          entityType: 'SECTION',
+          entityId: leftSectionId,
+          opType: 'UPD',
+        },
+      });
+      await dispatchPersistentAction(clientB.page, {
+        type: '[Section] Update Section Order',
+        contextId: 'TODAY',
+        ids: [rightSectionId, leftSectionId],
+        meta: {
+          isPersistent: true,
+          entityType: 'SECTION',
+          entityIds: [rightSectionId, leftSectionId],
+          opType: 'MOV',
+          isBulk: true,
+        },
+      });
+
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+
+      const convergedSnapshot: SectionSnapshot = {
+        leftTitles: [leftAnchorTitle],
+        rightTitles: [rightAnchorTitle, movingTitle],
+        noSectionTitles: [mainAnchorTitle],
+        todayTitles: [rightAnchorTitle, leftAnchorTitle, mainAnchorTitle, movingTitle],
+        todaySectionIds: [rightSectionId, leftSectionId],
+        movingSectionMemberships: 1,
+        movingTodayOccurrences: 1,
+      };
+      const convergedClientASnapshot = await getSectionSnapshot(
+        clientA.page,
+        leftSectionId,
+        rightSectionId,
+        movingTaskId,
+      );
+      const convergedClientBSnapshot = await getSectionSnapshot(
+        clientB.page,
+        leftSectionId,
+        rightSectionId,
+        movingTaskId,
+      );
+      expect({
+        clientA: convergedClientASnapshot,
+        clientB: convergedClientBSnapshot,
+      }).toEqual({
+        clientA: convergedSnapshot,
+        clientB: convergedSnapshot,
+      });
+      await expect(
+        clientA.page.locator('task').filter({ hasText: movingTitle }),
+      ).toHaveCount(1);
+      await expect(
+        clientB.page.locator('task').filter({ hasText: movingTitle }),
+      ).toHaveCount(1);
+
+      await clientA.page.reload();
+      await clientA.workView.waitForTaskList();
+      await clientB.page.reload();
+      await clientB.workView.waitForTaskList();
+      expect(
+        await getSectionSnapshot(
+          clientA.page,
+          leftSectionId,
+          rightSectionId,
+          movingTaskId,
+        ),
+      ).toEqual(convergedSnapshot);
+      expect(
+        await getSectionSnapshot(
+          clientB.page,
+          leftSectionId,
+          rightSectionId,
+          movingTaskId,
+        ),
+      ).toEqual(convergedSnapshot);
+
+      clientC = await createSimulatedClient(browser, appUrl, 'C', testRunId);
+      await clientC.workView.waitForTaskList();
+      await clientC.sync.setupSuperSync(syncConfig);
+      await clientC.sync.syncAndWait();
+      await clientC.sync.syncAndWait();
+      expect(
+        await getSectionSnapshot(
+          clientC.page,
+          leftSectionId,
+          rightSectionId,
+          movingTaskId,
+        ),
+      ).toEqual(convergedSnapshot);
+      await expect(
+        clientC.page.locator('task').filter({ hasText: movingTitle }),
+      ).toHaveCount(1);
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+      if (clientC) await closeClient(clientC);
+    }
+  });
+});

--- a/e2e/tests/sync/supersync-section-convergence.spec.ts
+++ b/e2e/tests/sync/supersync-section-convergence.spec.ts
@@ -166,7 +166,7 @@ const getSectionSnapshot = async (
   );
 
 test.describe('@supersync Section cross-client convergence', () => {
-  test('concurrent move, removal, and reorder converge once and persist', async ({
+  test('concurrent move, removal, reorder, and dependent placements converge and persist', async ({
     browser,
     baseURL,
     testRunId,
@@ -177,7 +177,9 @@ test.describe('@supersync Section cross-client convergence', () => {
     const rightSectionId = `section-right-${testRunId}`;
     const thirdSectionId = `section-third-${testRunId}`;
     const movingTitle = `A-${testRunId}-Moving`;
-    const placementTitle = `A-${testRunId}-Placement`;
+    const placementTitle = `A-${testRunId}-Placement C`;
+    const placementBTitle = `A-${testRunId}-Placement B`;
+    const placementATitle = `A-${testRunId}-Placement A`;
     const leftAnchorTitle = `A-${testRunId}-Left anchor`;
     const rightAnchorTitle = `A-${testRunId}-Right anchor`;
     const mainAnchorTitle = `A-${testRunId}-Main anchor`;
@@ -197,7 +199,9 @@ test.describe('@supersync Section cross-client convergence', () => {
       await clientA.workView.addTask('Left anchor');
       await clientA.workView.addTask('Moving');
       await clientA.workView.addTask('Right anchor');
-      await clientA.workView.addTask('Placement');
+      await clientA.workView.addTask('Placement C');
+      await clientA.workView.addTask('Placement B');
+      await clientA.workView.addTask('Placement A');
 
       const taskIdsByTitle = await getTaskIdsByTitle(clientA.page, [
         mainAnchorTitle,
@@ -205,12 +209,16 @@ test.describe('@supersync Section cross-client convergence', () => {
         movingTitle,
         rightAnchorTitle,
         placementTitle,
+        placementBTitle,
+        placementATitle,
       ]);
       const mainAnchorId = requireTaskId(taskIdsByTitle, mainAnchorTitle);
       const leftAnchorId = requireTaskId(taskIdsByTitle, leftAnchorTitle);
       const movingTaskId = requireTaskId(taskIdsByTitle, movingTitle);
       const rightAnchorId = requireTaskId(taskIdsByTitle, rightAnchorTitle);
       const placementTaskId = requireTaskId(taskIdsByTitle, placementTitle);
+      const placementBTaskId = requireTaskId(taskIdsByTitle, placementBTitle);
+      const placementATaskId = requireTaskId(taskIdsByTitle, placementATitle);
 
       for (const [id, title] of [
         [leftSectionId, 'Left'],
@@ -269,8 +277,15 @@ test.describe('@supersync Section cross-client convergence', () => {
         leftTitles: [leftAnchorTitle, movingTitle],
         rightTitles: [rightAnchorTitle],
         thirdTitles: [],
-        noSectionTitles: [placementTitle, mainAnchorTitle],
+        noSectionTitles: [
+          placementATitle,
+          placementBTitle,
+          placementTitle,
+          mainAnchorTitle,
+        ],
         todayTitles: [
+          placementATitle,
+          placementBTitle,
           placementTitle,
           rightAnchorTitle,
           movingTitle,
@@ -317,19 +332,21 @@ test.describe('@supersync Section cross-client convergence', () => {
           opType: 'MOV',
         },
       });
-      await dispatchPersistentAction(clientA.page, {
-        type: '[Section] Add Task to Section',
-        sectionId: thirdSectionId,
-        taskId: placementTaskId,
-        afterTaskId: null,
-        sourceSectionId: null,
-        meta: {
-          isPersistent: true,
-          entityType: 'SECTION',
-          entityId: thirdSectionId,
-          opType: 'MOV',
-        },
-      });
+      for (const taskId of [placementTaskId, placementBTaskId, placementATaskId]) {
+        await dispatchPersistentAction(clientA.page, {
+          type: '[Section] Add Task to Section',
+          sectionId: thirdSectionId,
+          taskId,
+          afterTaskId: null,
+          sourceSectionId: null,
+          meta: {
+            isPersistent: true,
+            entityType: 'SECTION',
+            entityId: thirdSectionId,
+            opType: 'MOV',
+          },
+        });
+      }
 
       await dispatchPersistentAction(clientB.page, {
         type: '[Section] Remove Task from Section',
@@ -358,17 +375,19 @@ test.describe('@supersync Section cross-client convergence', () => {
         },
       });
 
-      await clientA.sync.syncAndWait();
       await clientB.sync.syncAndWait();
       await clientA.sync.syncAndWait();
       await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
 
       const convergedSnapshot: SectionSnapshot = {
         leftTitles: [leftAnchorTitle],
         rightTitles: [rightAnchorTitle, movingTitle],
-        thirdTitles: [placementTitle],
+        thirdTitles: [placementATitle, placementBTitle, placementTitle],
         noSectionTitles: [mainAnchorTitle],
         todayTitles: [
+          placementATitle,
+          placementBTitle,
           placementTitle,
           rightAnchorTitle,
           leftAnchorTitle,

--- a/e2e/tests/sync/supersync-section-convergence.spec.ts
+++ b/e2e/tests/sync/supersync-section-convergence.spec.ts
@@ -11,11 +11,14 @@ import {
 interface SectionSnapshot {
   leftTitles: string[];
   rightTitles: string[];
+  thirdTitles: string[];
   noSectionTitles: string[];
   todayTitles: string[];
   todaySectionIds: string[];
   movingSectionMemberships: number;
   movingTodayOccurrences: number;
+  placementSectionMemberships: number;
+  placementTodayOccurrences: number;
 }
 
 interface PersistentAction extends Record<string, unknown> {
@@ -85,10 +88,12 @@ const getSectionSnapshot = async (
   page: Page,
   leftSectionId: string,
   rightSectionId: string,
+  thirdSectionId: string,
   movingTaskId: string,
+  placementTaskId: string,
 ): Promise<SectionSnapshot> =>
   page.evaluate(
-    ({ leftId, rightId, movingId }) => {
+    ({ leftId, rightId, thirdId, movingId, placementId }) => {
       type TaskLike = { id: string; title: string };
       type SectionLike = { id: string; contextId: string; taskIds: string[] };
       type TagLike = { taskIds: string[] };
@@ -135,6 +140,7 @@ const getSectionSnapshot = async (
       return {
         leftTitles: titlesFor(sections[leftId]?.taskIds ?? []),
         rightTitles: titlesFor(sections[rightId]?.taskIds ?? []),
+        thirdTitles: titlesFor(sections[thirdId]?.taskIds ?? []),
         noSectionTitles: titlesFor(
           todayTaskIds.filter((id) => !sectionedTaskIds.has(id)),
         ),
@@ -144,12 +150,18 @@ const getSectionSnapshot = async (
           section.taskIds.includes(movingId),
         ).length,
         movingTodayOccurrences: todayTaskIds.filter((id) => id === movingId).length,
+        placementSectionMemberships: todaySections.filter((section) =>
+          section.taskIds.includes(placementId),
+        ).length,
+        placementTodayOccurrences: todayTaskIds.filter((id) => id === placementId).length,
       };
     },
     {
       leftId: leftSectionId,
       rightId: rightSectionId,
+      thirdId: thirdSectionId,
       movingId: movingTaskId,
+      placementId: placementTaskId,
     },
   );
 
@@ -163,7 +175,9 @@ test.describe('@supersync Section cross-client convergence', () => {
     const appUrl = baseURL || 'http://localhost:4242';
     const leftSectionId = `section-left-${testRunId}`;
     const rightSectionId = `section-right-${testRunId}`;
+    const thirdSectionId = `section-third-${testRunId}`;
     const movingTitle = `A-${testRunId}-Moving`;
+    const placementTitle = `A-${testRunId}-Placement`;
     const leftAnchorTitle = `A-${testRunId}-Left anchor`;
     const rightAnchorTitle = `A-${testRunId}-Right anchor`;
     const mainAnchorTitle = `A-${testRunId}-Main anchor`;
@@ -183,21 +197,25 @@ test.describe('@supersync Section cross-client convergence', () => {
       await clientA.workView.addTask('Left anchor');
       await clientA.workView.addTask('Moving');
       await clientA.workView.addTask('Right anchor');
+      await clientA.workView.addTask('Placement');
 
       const taskIdsByTitle = await getTaskIdsByTitle(clientA.page, [
         mainAnchorTitle,
         leftAnchorTitle,
         movingTitle,
         rightAnchorTitle,
+        placementTitle,
       ]);
       const mainAnchorId = requireTaskId(taskIdsByTitle, mainAnchorTitle);
       const leftAnchorId = requireTaskId(taskIdsByTitle, leftAnchorTitle);
       const movingTaskId = requireTaskId(taskIdsByTitle, movingTitle);
       const rightAnchorId = requireTaskId(taskIdsByTitle, rightAnchorTitle);
+      const placementTaskId = requireTaskId(taskIdsByTitle, placementTitle);
 
       for (const [id, title] of [
         [leftSectionId, 'Left'],
         [rightSectionId, 'Right'],
+        [thirdSectionId, 'Third'],
       ]) {
         await dispatchPersistentAction(clientA.page, {
           type: '[Section] Add Section',
@@ -250,18 +268,29 @@ test.describe('@supersync Section cross-client convergence', () => {
       const seededSnapshot: SectionSnapshot = {
         leftTitles: [leftAnchorTitle, movingTitle],
         rightTitles: [rightAnchorTitle],
-        noSectionTitles: [mainAnchorTitle],
-        todayTitles: [rightAnchorTitle, movingTitle, leftAnchorTitle, mainAnchorTitle],
-        todaySectionIds: [leftSectionId, rightSectionId],
+        thirdTitles: [],
+        noSectionTitles: [placementTitle, mainAnchorTitle],
+        todayTitles: [
+          placementTitle,
+          rightAnchorTitle,
+          movingTitle,
+          leftAnchorTitle,
+          mainAnchorTitle,
+        ],
+        todaySectionIds: [leftSectionId, rightSectionId, thirdSectionId],
         movingSectionMemberships: 1,
         movingTodayOccurrences: 1,
+        placementSectionMemberships: 0,
+        placementTodayOccurrences: 1,
       };
       expect(
         await getSectionSnapshot(
           clientA.page,
           leftSectionId,
           rightSectionId,
+          thirdSectionId,
           movingTaskId,
+          placementTaskId,
         ),
       ).toEqual(seededSnapshot);
       expect(
@@ -269,7 +298,9 @@ test.describe('@supersync Section cross-client convergence', () => {
           clientB.page,
           leftSectionId,
           rightSectionId,
+          thirdSectionId,
           movingTaskId,
+          placementTaskId,
         ),
       ).toEqual(seededSnapshot);
 
@@ -283,6 +314,19 @@ test.describe('@supersync Section cross-client convergence', () => {
           isPersistent: true,
           entityType: 'SECTION',
           entityIds: [leftSectionId, rightSectionId],
+          opType: 'MOV',
+        },
+      });
+      await dispatchPersistentAction(clientA.page, {
+        type: '[Section] Add Task to Section',
+        sectionId: thirdSectionId,
+        taskId: placementTaskId,
+        afterTaskId: null,
+        sourceSectionId: null,
+        meta: {
+          isPersistent: true,
+          entityType: 'SECTION',
+          entityId: thirdSectionId,
           opType: 'MOV',
         },
       });
@@ -304,11 +348,11 @@ test.describe('@supersync Section cross-client convergence', () => {
       await dispatchPersistentAction(clientB.page, {
         type: '[Section] Update Section Order',
         contextId: 'TODAY',
-        ids: [rightSectionId, leftSectionId],
+        ids: [rightSectionId, thirdSectionId, leftSectionId],
         meta: {
           isPersistent: true,
           entityType: 'SECTION',
-          entityIds: [rightSectionId, leftSectionId],
+          entityIds: [rightSectionId, thirdSectionId, leftSectionId],
           opType: 'MOV',
           isBulk: true,
         },
@@ -322,23 +366,36 @@ test.describe('@supersync Section cross-client convergence', () => {
       const convergedSnapshot: SectionSnapshot = {
         leftTitles: [leftAnchorTitle],
         rightTitles: [rightAnchorTitle, movingTitle],
+        thirdTitles: [placementTitle],
         noSectionTitles: [mainAnchorTitle],
-        todayTitles: [rightAnchorTitle, leftAnchorTitle, mainAnchorTitle, movingTitle],
-        todaySectionIds: [rightSectionId, leftSectionId],
+        todayTitles: [
+          placementTitle,
+          rightAnchorTitle,
+          leftAnchorTitle,
+          mainAnchorTitle,
+          movingTitle,
+        ],
+        todaySectionIds: [rightSectionId, thirdSectionId, leftSectionId],
         movingSectionMemberships: 1,
         movingTodayOccurrences: 1,
+        placementSectionMemberships: 1,
+        placementTodayOccurrences: 1,
       };
       const convergedClientASnapshot = await getSectionSnapshot(
         clientA.page,
         leftSectionId,
         rightSectionId,
+        thirdSectionId,
         movingTaskId,
+        placementTaskId,
       );
       const convergedClientBSnapshot = await getSectionSnapshot(
         clientB.page,
         leftSectionId,
         rightSectionId,
+        thirdSectionId,
         movingTaskId,
+        placementTaskId,
       );
       expect({
         clientA: convergedClientASnapshot,
@@ -363,7 +420,9 @@ test.describe('@supersync Section cross-client convergence', () => {
           clientA.page,
           leftSectionId,
           rightSectionId,
+          thirdSectionId,
           movingTaskId,
+          placementTaskId,
         ),
       ).toEqual(convergedSnapshot);
       expect(
@@ -371,7 +430,9 @@ test.describe('@supersync Section cross-client convergence', () => {
           clientB.page,
           leftSectionId,
           rightSectionId,
+          thirdSectionId,
           movingTaskId,
+          placementTaskId,
         ),
       ).toEqual(convergedSnapshot);
 
@@ -385,7 +446,9 @@ test.describe('@supersync Section cross-client convergence', () => {
           clientC.page,
           leftSectionId,
           rightSectionId,
+          thirdSectionId,
           movingTaskId,
+          placementTaskId,
         ),
       ).toEqual(convergedSnapshot);
       await expect(

--- a/e2e/tests/sync/webdav-surgical-sync.spec.ts
+++ b/e2e/tests/sync/webdav-surgical-sync.spec.ts
@@ -15,7 +15,16 @@ import { waitForAppReady, waitForStatePersistence } from '../../utils/waits';
 interface SurgicalOpsFile {
   version: number;
   syncVersion: number;
-  recentOps: Array<{ id: string }>;
+  recentOps: Array<{
+    id: string;
+    p?: {
+      actionPayload?: {
+        task?: {
+          title?: string | null;
+        };
+      };
+    };
+  }>;
   snapshotRef: {
     rev?: string;
   };
@@ -301,6 +310,7 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
 
     let migratingClient: Awaited<ReturnType<typeof setupSyncClient>> | null = null;
     let legacyClient: Awaited<ReturnType<typeof setupSyncClient>> | null = null;
+    let freshSplitClient: Awaited<ReturnType<typeof setupSyncClient>> | null = null;
     let legacyRequestListener: ((webDavRequest: Request) => void) | null = null;
     const migrationRoute = `**/${folderName}/DEV/**`;
 
@@ -552,9 +562,17 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
       expect(recoveredBackup).toMatchObject({ version: 3, format: 'split' });
       expect(recoveredOps.migration).toBeUndefined();
       expect(recoveredOps.syncVersion).toBeGreaterThan(legacySyncVersion);
-      expect(
-        recoveredOps.recentOps.filter((operation) => operation.id === pendingOperationId),
-      ).toHaveLength(1);
+      const recoveredPendingOperations = recoveredOps.recentOps.filter(
+        (operation) => operation.id === pendingOperationId,
+      );
+      expect(recoveredPendingOperations).toHaveLength(1);
+      expect(recoveredPendingOperations[0]?.p).toMatchObject({
+        actionPayload: {
+          task: {
+            title: pendingTask,
+          },
+        },
+      });
       const recoveredLocalOperation = await getLocalOperationState(
         migratingClient.page,
         pendingOperationId,
@@ -568,6 +586,23 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
       });
       expect(JSON.stringify(recoveredState.state)).toContain(firstLegacyTask);
       expect(JSON.stringify(recoveredState.state)).toContain(secondLegacyTask);
+      expect(JSON.stringify(recoveredState.state)).not.toContain(pendingTask);
+
+      // Every fault stage reaches the same healed split files. Exercise a fresh
+      // baseline-plus-tail download once without multiplying this slow setup by five.
+      if (scenario.stage === 'final-marker') {
+        freshSplitClient = await setupSyncClient(browser, appUrl);
+        const freshSync = new SyncPage(freshSplitClient.page);
+        await freshSync.setupWebdavSync(splitConfig);
+        await freshSync.triggerSync();
+        await waitForSyncComplete(freshSplitClient.page, freshSync);
+
+        for (const taskTitle of [firstLegacyTask, secondLegacyTask, pendingTask]) {
+          await expect(
+            freshSplitClient.page.locator('task', { hasText: taskTitle }),
+          ).toHaveCount(1);
+        }
+      }
     } finally {
       if (migratingClient) {
         await migratingClient.page.unroute(migrationRoute).catch(() => {});
@@ -575,7 +610,11 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
       if (legacyClient && legacyRequestListener) {
         legacyClient.page.off('request', legacyRequestListener);
       }
-      await closeContextsSafely(migratingClient?.context, legacyClient?.context);
+      await closeContextsSafely(
+        migratingClient?.context,
+        legacyClient?.context,
+        freshSplitClient?.context,
+      );
     }
   };
 

--- a/e2e/tests/sync/webdav-surgical-sync.spec.ts
+++ b/e2e/tests/sync/webdav-surgical-sync.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures/webdav.fixture';
-import type { APIRequestContext, Page, Request } from '@playwright/test';
+import type { APIRequestContext, Browser, Page, Request } from '@playwright/test';
 import { SyncPage } from '../../pages/sync.page';
 import { WorkViewPage } from '../../pages/work-view.page';
 import {
@@ -13,7 +13,12 @@ import {
 import { waitForAppReady, waitForStatePersistence } from '../../utils/waits';
 
 interface SurgicalOpsFile {
+  version: number;
+  syncVersion: number;
   recentOps: Array<{ id: string }>;
+  snapshotRef: {
+    rev?: string;
+  };
   migration?: {
     status: string;
     legacyRev: string;
@@ -24,6 +29,97 @@ interface SplitTombstone {
   version: number;
   format: string;
 }
+
+interface SplitStateFile {
+  version: number;
+  syncVersion: number;
+  state: unknown;
+}
+
+interface RemoteSyncFile {
+  version: number;
+  syncVersion?: number;
+  format?: string;
+  state?: unknown;
+}
+
+type MigrationResponseLossStage =
+  | 'pending-marker'
+  | 'state'
+  | 'backup-tombstone'
+  | 'primary-tombstone'
+  | 'final-marker';
+
+interface MigrationResponseLossScenario {
+  stage: MigrationResponseLossStage;
+  title: string;
+  stateCommitted: boolean;
+  backupTombstoned: boolean;
+  primaryTombstoned: boolean;
+  markerPending: boolean;
+}
+
+interface MigrationUploadBody {
+  version?: number;
+  syncVersion?: number;
+  format?: string;
+  state?: unknown;
+  recentOps?: Array<{ id?: string }>;
+  snapshotRef?: {
+    rev?: string;
+    syncVersion?: number;
+  };
+  migration?: {
+    status?: string;
+    legacyRev?: string;
+  };
+}
+
+const MIGRATION_RESPONSE_LOSS_SCENARIOS: readonly MigrationResponseLossScenario[] = [
+  {
+    stage: 'pending-marker',
+    title:
+      'recovers when the pending sync-ops migration marker commits but its response is lost',
+    stateCommitted: false,
+    backupTombstoned: false,
+    primaryTombstoned: false,
+    markerPending: true,
+  },
+  {
+    stage: 'state',
+    title: 'recovers when sync-state commits during migration but its response is lost',
+    stateCommitted: true,
+    backupTombstoned: false,
+    primaryTombstoned: false,
+    markerPending: true,
+  },
+  {
+    stage: 'backup-tombstone',
+    title:
+      'recovers when backup neutralization commits during migration but its response is lost',
+    stateCommitted: true,
+    backupTombstoned: true,
+    primaryTombstoned: false,
+    markerPending: true,
+  },
+  {
+    stage: 'primary-tombstone',
+    title: 'recovers a v2 migration after the tombstone response is lost',
+    stateCommitted: true,
+    backupTombstoned: true,
+    primaryTombstoned: true,
+    markerPending: true,
+  },
+  {
+    stage: 'final-marker',
+    title:
+      'recovers when the final sync-ops marker clear commits but its response is lost',
+    stateCommitted: true,
+    backupTombstoned: true,
+    primaryTombstoned: true,
+    markerPending: false,
+  },
+];
 
 const readPrefixedFile = async <T>(
   request: APIRequestContext,
@@ -48,6 +144,103 @@ const readSurgicalOpsFile = (
   authorization: string,
 ): Promise<SurgicalOpsFile> =>
   readPrefixedFile<SurgicalOpsFile>(request, url, authorization);
+
+const decodeMigrationUpload = (request: Request): MigrationUploadBody | undefined => {
+  const body = request.postData();
+  if (!body) {
+    return undefined;
+  }
+  const prefixEnd = body.indexOf('__');
+  if (prefixEnd < 0) {
+    return undefined;
+  }
+  return JSON.parse(body.slice(prefixEnd + 2)) as MigrationUploadBody;
+};
+
+const isScenarioUpload = (
+  request: Request,
+  scenario: MigrationResponseLossScenario,
+  legacySyncVersion: number,
+  pendingOperationId: string,
+): boolean => {
+  if (request.method() !== 'PUT') {
+    return false;
+  }
+
+  const path = new URL(request.url()).pathname;
+  const uploaded = decodeMigrationUpload(request);
+  if (!uploaded || uploaded.version !== 3) {
+    return false;
+  }
+
+  switch (scenario.stage) {
+    case 'pending-marker':
+      return (
+        path.endsWith('/sync-ops.json') &&
+        uploaded.syncVersion === legacySyncVersion &&
+        uploaded.migration?.status === 'pending' &&
+        !!uploaded.migration.legacyRev &&
+        uploaded.snapshotRef?.syncVersion === legacySyncVersion &&
+        uploaded.snapshotRef.rev === undefined &&
+        uploaded.recentOps?.every((operation) => operation.id !== pendingOperationId) ===
+          true
+      );
+    case 'state':
+      return (
+        path.endsWith('/sync-state.json') &&
+        uploaded.syncVersion === legacySyncVersion &&
+        uploaded.state !== undefined
+      );
+    case 'backup-tombstone':
+      return path.endsWith('/sync-data.json.bak') && uploaded.format === 'split';
+    case 'primary-tombstone':
+      return path.endsWith('/sync-data.json') && uploaded.format === 'split';
+    case 'final-marker':
+      return (
+        path.endsWith('/sync-ops.json') &&
+        uploaded.syncVersion === legacySyncVersion &&
+        uploaded.migration === undefined &&
+        !!uploaded.snapshotRef?.rev &&
+        uploaded.recentOps?.every((operation) => operation.id !== pendingOperationId) ===
+          true
+      );
+  }
+};
+
+const getLocalPendingOperationIds = async (page: Page): Promise<string[]> =>
+  page.evaluate(async () => {
+    interface StoredOperation {
+      op?: {
+        id?: string;
+      };
+      syncedAt?: number;
+      rejectedAt?: number;
+    }
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const openRequest = indexedDB.open('SUP_OPS');
+      openRequest.onsuccess = (): void => resolve(openRequest.result);
+      openRequest.onerror = (): void => reject(openRequest.error);
+    });
+    try {
+      const entries = await new Promise<StoredOperation[]>((resolve, reject) => {
+        const tx = db.transaction('ops', 'readonly');
+        const getRequest = tx.objectStore('ops').getAll();
+        getRequest.onsuccess = (): void =>
+          resolve(getRequest.result as StoredOperation[]);
+        getRequest.onerror = (): void => reject(getRequest.error);
+      });
+      return entries.flatMap((entry) =>
+        entry.syncedAt === undefined &&
+        entry.rejectedAt === undefined &&
+        typeof entry.op?.id === 'string'
+          ? [entry.op.id]
+          : [],
+      );
+    } finally {
+      db.close();
+    }
+  });
 
 const getLocalOperationState = async (
   page: Page,
@@ -80,14 +273,14 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
   // Each case drives multiple app contexts through faulted WebDAV requests.
   test.describe.configure({ mode: 'serial' });
 
-  test('recovers a v2 migration after the tombstone response is lost', async ({
-    browser,
-    baseURL,
-    request,
-  }) => {
-    test.slow();
+  const runMigrationResponseLossScenario = async (
+    browser: Browser,
+    baseURL: string | undefined,
+    request: APIRequestContext,
+    scenario: MigrationResponseLossScenario,
+  ): Promise<void> => {
     const appUrl = baseURL || 'http://localhost:4242';
-    const folderName = generateSyncFolderName('e2e-surgical-v2');
+    const folderName = generateSyncFolderName(`e2e-surgical-v2-${scenario.stage}`);
     const folderUrl = `${WEBDAV_CONFIG_TEMPLATE.baseUrl}${folderName}/DEV/`;
     const legacyConfig = {
       ...WEBDAV_CONFIG_TEMPLATE,
@@ -109,11 +302,13 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
     let migratingClient: Awaited<ReturnType<typeof setupSyncClient>> | null = null;
     let legacyClient: Awaited<ReturnType<typeof setupSyncClient>> | null = null;
     let legacyRequestListener: ((webDavRequest: Request) => void) | null = null;
+    const migrationRoute = `**/${folderName}/DEV/**`;
 
     try {
       migratingClient = await setupSyncClient(browser, appUrl);
       const sync = new SyncPage(migratingClient.page);
       const workView = new WorkViewPage(migratingClient.page);
+      await workView.waitForTaskList();
 
       await sync.setupWebdavSync(legacyConfig);
 
@@ -123,117 +318,152 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
       await sync.triggerSync();
       await waitForSyncComplete(migratingClient.page, sync);
 
-      // A second v2 upload rotates the first primary into sync-data.json.bak,
-      // giving the migration a real stale backup that must be neutralized.
+      // The second v2 upload creates a populated legacy backup so every
+      // interruption proves that stale recovery data is neutralized safely.
       const secondLegacyTask = `Legacy-second-${folderName}`;
       await workView.addTask(secondLegacyTask);
       await waitForStatePersistence(migratingClient.page);
       await sync.triggerSync();
       await waitForSyncComplete(migratingClient.page, sync);
 
-      const legacyPrimary = await readPrefixedFile<{ version: number }>(
+      const legacyPrimary = await readPrefixedFile<RemoteSyncFile>(
         request,
         `${folderUrl}sync-data.json`,
         authorization,
       );
-      const legacyBackup = await readPrefixedFile<{ version: number }>(
+      const legacyBackup = await readPrefixedFile<RemoteSyncFile>(
         request,
         `${folderUrl}sync-data.json.bak`,
         authorization,
       );
       expect(legacyPrimary.version).toBe(2);
       expect(legacyBackup.version).toBe(2);
+      const legacyPrimaryState = JSON.stringify(legacyPrimary.state);
+      const legacyBackupState = JSON.stringify(legacyBackup.state);
+      expect(legacyPrimaryState).toContain(firstLegacyTask);
+      expect(legacyPrimaryState).toContain(secondLegacyTask);
+      expect(legacyBackupState).toContain(firstLegacyTask);
+      expect(legacyBackupState).not.toContain(secondLegacyTask);
+      const legacySyncVersion = legacyPrimary.syncVersion;
+      if (legacySyncVersion === undefined) {
+        throw new Error('Legacy primary is missing its syncVersion');
+      }
 
+      const pendingIdsBefore = new Set(
+        await getLocalPendingOperationIds(migratingClient.page),
+      );
       const pendingTask = `Pending-during-migration-${folderName}`;
       await workView.addTask(pendingTask);
       await waitForStatePersistence(migratingClient.page);
+      const newPendingIds = (
+        await getLocalPendingOperationIds(migratingClient.page)
+      ).filter((id) => !pendingIdsBefore.has(id));
+      expect(newPendingIds).toHaveLength(1);
+      const pendingOperationId = newPendingIds[0];
 
       let faultActive = true;
-      let tombstoneCommitted = false;
-      let tombstoneResponseDropped = false;
-      await migratingClient.page.route('**/sync-data.json', async (route) => {
-        const body = route.request().postData() ?? '';
-        const prefixEnd = body.indexOf('__');
-        const uploaded =
-          prefixEnd >= 0
-            ? (JSON.parse(body.slice(prefixEnd + 2)) as Partial<SplitTombstone>)
-            : null;
-        const isSplitTombstone = uploaded?.version === 3 && uploaded.format === 'split';
-
-        if (route.request().method() === 'PUT' && faultActive && isSplitTombstone) {
-          if (!tombstoneCommitted) {
-            const response = await route.fetch();
-            expect(response.ok()).toBe(true);
-            tombstoneCommitted = true;
-          }
-          tombstoneResponseDropped = true;
+      let stageCommitted = false;
+      await migratingClient.page.route(migrationRoute, async (route) => {
+        const webDavRequest = route.request();
+        if (faultActive && stageCommitted && webDavRequest.method() === 'PUT') {
+          await route.abort('failed');
+          return;
+        }
+        if (
+          faultActive &&
+          isScenarioUpload(webDavRequest, scenario, legacySyncVersion, pendingOperationId)
+        ) {
+          const response = await route.fetch();
+          expect(response.ok()).toBe(true);
+          stageCommitted = true;
           await route.abort('failed');
           return;
         }
         await route.continue();
       });
 
-      // Reconfiguration can schedule its own first sync, so fault interception
-      // must already be active before the setting flips.
+      // Reconfiguration may schedule the migration immediately, so interception
+      // is installed before Surgical sync is enabled.
       await sync.setupWebdavSync(splitConfig, { isReconfigure: true });
-      await expect.poll(() => tombstoneResponseDropped).toBe(true);
+      await expect.poll(() => stageCommitted).toBe(true);
       await sync.syncSpinner.waitFor({ state: 'hidden', timeout: 20000 });
-      expect(tombstoneCommitted).toBe(true);
 
-      // The remote commit happened even though the client saw a network error.
-      const committedPrimary = await readPrefixedFile<SplitTombstone>(
-        request,
-        `${folderUrl}sync-data.json`,
-        authorization,
-      );
-      const pendingMigrationOps = await readSurgicalOpsFile(
+      // Read the exact durable boundary before reload. Later PUTs remain blocked,
+      // so these assertions cannot accidentally observe an in-memory retry.
+      const interruptedOps = await readSurgicalOpsFile(
         request,
         `${folderUrl}sync-ops.json`,
         authorization,
       );
-      expect(committedPrimary).toMatchObject({ version: 3, format: 'split' });
-      expect(pendingMigrationOps.migration).toMatchObject({ status: 'pending' });
-      expect(pendingMigrationOps.migration?.legacyRev).toBeTruthy();
+      if (scenario.markerPending) {
+        expect(interruptedOps.migration).toMatchObject({ status: 'pending' });
+        expect(interruptedOps.migration?.legacyRev).toBeTruthy();
+      } else {
+        expect(interruptedOps.migration).toBeUndefined();
+      }
+      expect(interruptedOps.syncVersion).toBe(legacySyncVersion);
+      if (scenario.markerPending) {
+        expect(interruptedOps.snapshotRef.rev).toBeUndefined();
+      } else {
+        expect(interruptedOps.snapshotRef.rev).toBeTruthy();
+      }
+      expect(
+        interruptedOps.recentOps.filter(
+          (operation) => operation.id === pendingOperationId,
+        ),
+      ).toHaveLength(0);
+      const pendingLocalOperation = await getLocalOperationState(
+        migratingClient.page,
+        pendingOperationId,
+      );
+      expect(pendingLocalOperation).toBeDefined();
+      expect(pendingLocalOperation?.syncedAt).toBeUndefined();
+      expect(pendingLocalOperation?.rejectedAt).toBeUndefined();
 
-      // Restart before allowing another write so recovery comes from the
-      // persisted migration marker rather than the failed call's memory.
-      faultActive = false;
-      await migratingClient.page.reload({ waitUntil: 'domcontentloaded' });
-      await waitForAppReady(migratingClient.page);
-      await sync.triggerSync();
-      await waitForSyncComplete(migratingClient.page, sync);
+      const stateUrl = `${folderUrl}sync-state.json`;
+      if (scenario.stateCommitted) {
+        const interruptedState = await readPrefixedFile<SplitStateFile>(
+          request,
+          stateUrl,
+          authorization,
+        );
+        expect(interruptedState).toMatchObject({
+          version: 3,
+          syncVersion: legacySyncVersion,
+        });
+        expect(JSON.stringify(interruptedState.state)).toContain(firstLegacyTask);
+        expect(JSON.stringify(interruptedState.state)).toContain(secondLegacyTask);
+        expect(JSON.stringify(interruptedState.state)).not.toContain(pendingTask);
+      } else {
+        const missingState = await request.get(stateUrl, {
+          headers: { Authorization: authorization },
+        });
+        expect(missingState.status()).toBe(404);
+      }
 
-      await expect(
-        migratingClient.page.locator('task', { hasText: firstLegacyTask }),
-      ).toBeVisible();
-      await expect(
-        migratingClient.page.locator('task', { hasText: secondLegacyTask }),
-      ).toBeVisible();
-      await expect(
-        migratingClient.page.locator('task', { hasText: pendingTask }),
-      ).toHaveCount(1);
-
-      const recoveredPrimary = await readPrefixedFile<SplitTombstone>(
+      const interruptedPrimary = await readPrefixedFile<RemoteSyncFile>(
         request,
         `${folderUrl}sync-data.json`,
         authorization,
       );
-      const recoveredBackup = await readPrefixedFile<SplitTombstone>(
+      const interruptedBackup = await readPrefixedFile<RemoteSyncFile>(
         request,
         `${folderUrl}sync-data.json.bak`,
         authorization,
       );
-      const recoveredOps = await readSurgicalOpsFile(
-        request,
-        `${folderUrl}sync-ops.json`,
-        authorization,
-      );
-      expect(recoveredPrimary).toMatchObject({ version: 3, format: 'split' });
-      expect(recoveredBackup).toMatchObject({ version: 3, format: 'split' });
-      expect(recoveredOps.migration).toBeUndefined();
+      if (scenario.primaryTombstoned) {
+        expect(interruptedPrimary).toMatchObject({ version: 3, format: 'split' });
+      } else {
+        expect(interruptedPrimary).toEqual(legacyPrimary);
+      }
+      if (scenario.backupTombstoned) {
+        expect(interruptedBackup).toMatchObject({ version: 3, format: 'split' });
+      } else {
+        expect(interruptedBackup).toEqual(legacyBackup);
+      }
 
-      // A client that has not opted into split files must remain in the
-      // persistent error state without writing v2 back over the tombstone.
+      // Before the primary tombstone, sync-ops fences split-disabled clients;
+      // afterward, the tombstone does.
       legacyClient = await setupSyncClient(browser, appUrl);
       const legacySync = new SyncPage(legacyClient.page);
       let legacyPutCount = 0;
@@ -252,17 +482,16 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
         { timeout: 20000 },
       );
 
-      // Retry once explicitly to prove the guard is stable beyond setup's
-      // automatic first sync.
-      const tombstoneDownload = legacyClient.page.waitForResponse(
+      const guardFile = scenario.primaryTombstoned ? 'sync-data.json' : 'sync-ops.json';
+      const guardedFormatDownload = legacyClient.page.waitForResponse(
         (response) =>
           response.request().method() === 'GET' &&
-          response.url() === `${folderUrl}sync-data.json` &&
+          response.url() === `${folderUrl}${guardFile}` &&
           response.ok(),
         { timeout: 20000 },
       );
       await legacySync.syncBtn.click({ noWaitAfter: true });
-      await tombstoneDownload;
+      await guardedFormatDownload;
       await expect(legacyClient.page.locator('snack-custom .message')).toContainText(
         /split-file format.*(?:Enable|Turn on).*Surgical sync.*Sync settings/i,
         { timeout: 20000 },
@@ -272,25 +501,90 @@ test.describe('@webdav @surgical WebDAV Surgical sync', () => {
       );
       expect(legacyPutCount).toBe(0);
 
-      const primaryAfterLegacyAttempt = await readPrefixedFile<SplitTombstone>(
+      const opsAfterLegacyAttempt = await readSurgicalOpsFile(
+        request,
+        `${folderUrl}sync-ops.json`,
+        authorization,
+      );
+      const primaryAfterLegacyAttempt = await readPrefixedFile<RemoteSyncFile>(
         request,
         `${folderUrl}sync-data.json`,
         authorization,
       );
-      expect(primaryAfterLegacyAttempt).toMatchObject({
+      expect(opsAfterLegacyAttempt).toEqual(interruptedOps);
+      expect(primaryAfterLegacyAttempt).toEqual(interruptedPrimary);
+
+      // Release the fault at the reload boundary so the new document recovers
+      // from the remote marker and the locally persisted pending operation.
+      faultActive = false;
+      await migratingClient.page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForAppReady(migratingClient.page);
+      await sync.triggerSync();
+      await waitForSyncComplete(migratingClient.page, sync);
+
+      for (const taskTitle of [firstLegacyTask, secondLegacyTask, pendingTask]) {
+        await expect(
+          migratingClient.page.locator('task', { hasText: taskTitle }),
+        ).toHaveCount(1);
+      }
+
+      const recoveredPrimary = await readPrefixedFile<SplitTombstone>(
+        request,
+        `${folderUrl}sync-data.json`,
+        authorization,
+      );
+      const recoveredBackup = await readPrefixedFile<SplitTombstone>(
+        request,
+        `${folderUrl}sync-data.json.bak`,
+        authorization,
+      );
+      const recoveredOps = await readSurgicalOpsFile(
+        request,
+        `${folderUrl}sync-ops.json`,
+        authorization,
+      );
+      const recoveredState = await readPrefixedFile<SplitStateFile>(
+        request,
+        `${folderUrl}sync-state.json`,
+        authorization,
+      );
+      expect(recoveredPrimary).toMatchObject({ version: 3, format: 'split' });
+      expect(recoveredBackup).toMatchObject({ version: 3, format: 'split' });
+      expect(recoveredOps.migration).toBeUndefined();
+      expect(recoveredOps.syncVersion).toBeGreaterThan(legacySyncVersion);
+      expect(
+        recoveredOps.recentOps.filter((operation) => operation.id === pendingOperationId),
+      ).toHaveLength(1);
+      const recoveredLocalOperation = await getLocalOperationState(
+        migratingClient.page,
+        pendingOperationId,
+      );
+      expect(recoveredLocalOperation).toBeDefined();
+      expect(recoveredLocalOperation?.syncedAt).toBeDefined();
+      expect(recoveredLocalOperation?.rejectedAt).toBeUndefined();
+      expect(recoveredState).toMatchObject({
         version: 3,
-        format: 'split',
+        syncVersion: legacySyncVersion,
       });
+      expect(JSON.stringify(recoveredState.state)).toContain(firstLegacyTask);
+      expect(JSON.stringify(recoveredState.state)).toContain(secondLegacyTask);
     } finally {
       if (migratingClient) {
-        await migratingClient.page.unroute('**/sync-data.json').catch(() => {});
+        await migratingClient.page.unroute(migrationRoute).catch(() => {});
       }
       if (legacyClient && legacyRequestListener) {
         legacyClient.page.off('request', legacyRequestListener);
       }
       await closeContextsSafely(migratingClient?.context, legacyClient?.context);
     }
-  });
+  };
+
+  for (const scenario of MIGRATION_RESPONSE_LOSS_SCENARIOS) {
+    test(scenario.title, async ({ browser, baseURL, request }) => {
+      test.slow();
+      await runMigrationResponseLossScenario(browser, baseURL, request, scenario);
+    });
+  }
 
   test('survives a committed ops response loss and restart', async ({
     browser,

--- a/packages/shared-schema/tests/released-client-compatibility-policy.spec.ts
+++ b/packages/shared-schema/tests/released-client-compatibility-policy.spec.ts
@@ -1,0 +1,95 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { validateMigrationRegistry } from '../src/migrate';
+import { MIGRATIONS } from '../src/migrations';
+import { CURRENT_SCHEMA_VERSION } from '../src/schema-version';
+
+type RuntimeSurface = 'reducer' | 'persistence' | 'cursor';
+
+interface SharedSchemaEvidence {
+  kind: 'shared-schema-spec';
+  specPath: `tests/${string}.spec.ts`;
+}
+
+interface ReleasedOracleEvidence {
+  kind: 'pinned-released-oracle';
+  oracleSpecPath: `tests/released-client-oracles/${string}.spec.ts`;
+  cohorts: readonly {
+    releaseTag: `v${string}`;
+    commitSha: string;
+    sourcePath: string;
+    sourceBlobSha: string;
+  }[];
+}
+
+interface CompatibilityAssessment {
+  toVersion: number;
+  runtimeSurfaces: readonly RuntimeSurface[];
+  evidence: SharedSchemaEvidence | ReleasedOracleEvidence;
+}
+
+/**
+ * Schemas through v4 were reviewed historically, before this evidence gate.
+ * This does not claim that the current-client forward-schema E2E exercises a
+ * released legacy receiver.
+ *
+ * Do not add a generic old-app bundle here. Add one assessment per future
+ * migration. A package-only migration may cite a shared-schema spec; behavior
+ * reaching reducers, persistence, or cursor acknowledgement needs a small,
+ * deterministic oracle pinned to the affected released cohort.
+ */
+const POLICY_BASELINE_SCHEMA_VERSION = 4;
+const COMPATIBILITY_ASSESSMENTS: readonly CompatibilityAssessment[] = [];
+
+const expectExistingSpec = (specPath: string): void => {
+  expect(
+    existsSync(resolve(process.cwd(), specPath)),
+    `Compatibility evidence does not exist: ${specPath}`,
+  ).toBe(true);
+};
+
+describe('released-client compatibility policy', () => {
+  it('requires an explicit assessment for every schema after the audited baseline', () => {
+    expect(validateMigrationRegistry()).toEqual([]);
+    expect(CURRENT_SCHEMA_VERSION).toBe(MIGRATIONS.at(-1)?.toVersion);
+
+    const migrationVersions = MIGRATIONS.filter(
+      ({ toVersion }) => toVersion > POLICY_BASELINE_SCHEMA_VERSION,
+    )
+      .map(({ toVersion }) => toVersion)
+      .sort((a, b) => a - b);
+    const assessmentVersions = COMPATIBILITY_ASSESSMENTS.map(
+      ({ toVersion }) => toVersion,
+    ).sort((a, b) => a - b);
+
+    expect(new Set(assessmentVersions).size).toBe(assessmentVersions.length);
+    expect(assessmentVersions).toEqual(migrationVersions);
+  });
+
+  it('requires a pinned released oracle for runtime-visible migration semantics', () => {
+    for (const assessment of COMPATIBILITY_ASSESSMENTS) {
+      if (assessment.runtimeSurfaces.length === 0) {
+        expect(assessment.evidence.kind).toBe('shared-schema-spec');
+        if (assessment.evidence.kind === 'shared-schema-spec') {
+          expectExistingSpec(assessment.evidence.specPath);
+        }
+        continue;
+      }
+
+      expect(assessment.evidence.kind).toBe('pinned-released-oracle');
+      if (assessment.evidence.kind !== 'pinned-released-oracle') {
+        continue;
+      }
+
+      expectExistingSpec(assessment.evidence.oracleSpecPath);
+      expect(assessment.evidence.cohorts.length).toBeGreaterThan(0);
+      for (const cohort of assessment.evidence.cohorts) {
+        expect(cohort.releaseTag).toMatch(/^v\d+\.\d+\.\d+/);
+        expect(cohort.commitSha).toMatch(/^[0-9a-f]{40}$/);
+        expect(cohort.sourcePath.length).toBeGreaterThan(0);
+        expect(cohort.sourceBlobSha).toMatch(/^[0-9a-f]{40}$/);
+      }
+    }
+  });
+});

--- a/packages/shared-schema/tests/released-client-compatibility-policy.spec.ts
+++ b/packages/shared-schema/tests/released-client-compatibility-policy.spec.ts
@@ -1,5 +1,7 @@
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { validateMigrationRegistry } from '../src/migrate';
 import { MIGRATIONS } from '../src/migrations';
@@ -29,6 +31,115 @@ interface CompatibilityAssessment {
   evidence: SharedSchemaEvidence | ReleasedOracleEvidence;
 }
 
+const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+const SHA1_PATTERN = /^(?!0{40}$)[0-9a-f]{40}$/;
+const ALL_ZERO_SHA1 = '0'.repeat(40);
+
+const runGit = (repositoryRoot: string, args: string[]): string =>
+  execFileSync('git', ['-C', repositoryRoot, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, GIT_NO_LAZY_FETCH: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+
+const tryGit = (repositoryRoot: string, args: string[]): string | undefined => {
+  try {
+    return runGit(repositoryRoot, args);
+  } catch {
+    return undefined;
+  }
+};
+
+const validateReleasedOracleProvenance = (
+  cohort: ReleasedOracleEvidence['cohorts'][number],
+  repositoryRoot: string,
+): string[] => {
+  const errors: string[] = [];
+  const isShallow =
+    tryGit(repositoryRoot, ['rev-parse', '--is-shallow-repository']) === 'true';
+  const unavailableHint = isShallow
+    ? ' (the shallow checkout does not contain the pinned provenance)'
+    : '';
+  const tagCommit = RELEASE_TAG_PATTERN.test(cohort.releaseTag)
+    ? tryGit(repositoryRoot, [
+        'rev-parse',
+        '--verify',
+        `refs/tags/${cohort.releaseTag}^{commit}`,
+      ])
+    : undefined;
+  const commitType = SHA1_PATTERN.test(cohort.commitSha)
+    ? tryGit(repositoryRoot, ['cat-file', '-t', cohort.commitSha])
+    : undefined;
+  const sourceBlob =
+    SHA1_PATTERN.test(cohort.commitSha) && cohort.sourcePath.length > 0
+      ? tryGit(repositoryRoot, [
+          'rev-parse',
+          '--verify',
+          `${cohort.commitSha}:${cohort.sourcePath}`,
+        ])
+      : undefined;
+  const sourceBlobType = sourceBlob
+    ? tryGit(repositoryRoot, ['cat-file', '-t', sourceBlob])
+    : undefined;
+
+  if (tagCommit !== cohort.commitSha) {
+    errors.push(
+      `Invalid or unavailable release tag pin: ${cohort.releaseTag}${unavailableHint}`,
+    );
+  }
+  if (commitType !== 'commit') {
+    errors.push(
+      `Invalid or unavailable commit pin: ${cohort.commitSha}${unavailableHint}`,
+    );
+  }
+  if (
+    !SHA1_PATTERN.test(cohort.sourceBlobSha) ||
+    sourceBlob !== cohort.sourceBlobSha ||
+    sourceBlobType !== 'blob'
+  ) {
+    errors.push(
+      `Invalid or unavailable source blob pin: ${cohort.sourceBlobSha}${unavailableHint}`,
+    );
+  }
+
+  return errors;
+};
+
+const withTestGitRepository = (
+  assertion: (
+    repositoryRoot: string,
+    cohort: ReleasedOracleEvidence['cohorts'][number],
+  ) => void,
+): void => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'released-oracle-provenance-'));
+  try {
+    runGit(repositoryRoot, ['init', '--quiet']);
+    runGit(repositoryRoot, ['config', 'user.name', 'Compatibility Test']);
+    runGit(repositoryRoot, ['config', 'user.email', 'compatibility@test.invalid']);
+    writeFileSync(
+      join(repositoryRoot, 'released-source.ts'),
+      'export const value = 1;\n',
+    );
+    runGit(repositoryRoot, ['add', 'released-source.ts']);
+    runGit(repositoryRoot, ['commit', '--quiet', '-m', 'released source']);
+    runGit(repositoryRoot, ['tag', '-a', 'v1.2.3', '-m', 'v1.2.3']);
+
+    const commitSha = runGit(repositoryRoot, ['rev-parse', 'HEAD']);
+    const sourceBlobSha = runGit(repositoryRoot, [
+      'rev-parse',
+      `${commitSha}:released-source.ts`,
+    ]);
+    assertion(repositoryRoot, {
+      releaseTag: 'v1.2.3',
+      commitSha,
+      sourcePath: 'released-source.ts',
+      sourceBlobSha,
+    });
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+};
+
 /**
  * Schemas through v4 were reviewed historically, before this evidence gate.
  * This does not claim that the current-client forward-schema E2E exercises a
@@ -50,6 +161,44 @@ const expectExistingSpec = (specPath: string): void => {
 };
 
 describe('released-client compatibility policy', () => {
+  it('accepts a tag, commit, source path, and blob from one real Git provenance chain', () => {
+    withTestGitRepository((repositoryRoot, cohort) => {
+      expect(validateReleasedOracleProvenance(cohort, repositoryRoot)).toEqual([]);
+    });
+  });
+
+  it('rejects fake and all-zero release provenance pins', () => {
+    withTestGitRepository((repositoryRoot, cohort) => {
+      const tamperedPins: readonly [ReleasedOracleEvidence['cohorts'][number], string][] =
+        [
+          [{ ...cohort, releaseTag: 'v9.9.9' }, 'release tag'],
+          [{ ...cohort, commitSha: '1'.repeat(40) }, 'commit'],
+          [{ ...cohort, sourceBlobSha: '2'.repeat(40) }, 'source blob'],
+        ];
+
+      for (const [pins, expectedError] of tamperedPins) {
+        expect(validateReleasedOracleProvenance(pins, repositoryRoot)).toEqual(
+          expect.arrayContaining([expect.stringContaining(expectedError)]),
+        );
+      }
+
+      const allZeroErrors = validateReleasedOracleProvenance(
+        {
+          ...cohort,
+          commitSha: ALL_ZERO_SHA1,
+          sourceBlobSha: ALL_ZERO_SHA1,
+        },
+        repositoryRoot,
+      );
+      expect(allZeroErrors).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('commit'),
+          expect.stringContaining('source blob'),
+        ]),
+      );
+    });
+  });
+
   it('requires an explicit assessment for every schema after the audited baseline', () => {
     expect(validateMigrationRegistry()).toEqual([]);
     expect(CURRENT_SCHEMA_VERSION).toBe(MIGRATIONS.at(-1)?.toVersion);
@@ -84,11 +233,9 @@ describe('released-client compatibility policy', () => {
 
       expectExistingSpec(assessment.evidence.oracleSpecPath);
       expect(assessment.evidence.cohorts.length).toBeGreaterThan(0);
+      const repositoryRoot = runGit(process.cwd(), ['rev-parse', '--show-toplevel']);
       for (const cohort of assessment.evidence.cohorts) {
-        expect(cohort.releaseTag).toMatch(/^v\d+\.\d+\.\d+/);
-        expect(cohort.commitSha).toMatch(/^[0-9a-f]{40}$/);
-        expect(cohort.sourcePath.length).toBeGreaterThan(0);
-        expect(cohort.sourceBlobSha).toMatch(/^[0-9a-f]{40}$/);
+        expect(validateReleasedOracleProvenance(cohort, repositoryRoot)).toEqual([]);
       }
     }
   });

--- a/src/app/op-log/core/types/sync-results.types.ts
+++ b/src/app/op-log/core/types/sync-results.types.ts
@@ -242,6 +242,8 @@ export type DownloadResultForRejection =
   | {
       kind: 'completed';
       newOpsCount: number;
+      /** Local-win operations created while applying this nested download. */
+      localWinOpsCreated?: number;
       allOpClocks?: VectorClock[];
       snapshotVectorClock?: VectorClock;
       /** Server cursor after the downloaded operations were durably applied. */

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -1831,6 +1831,147 @@ describe('OperationLogStoreService', () => {
   });
 
   describe('appendMixedSourceBatchSkipDuplicates', () => {
+    it('should atomically append a replacement and reject its predecessors with one timestamp', async () => {
+      const firstPredecessor = createTestOperation({ id: 'first-predecessor' });
+      const secondPredecessor = createTestOperation({ id: 'second-predecessor' });
+      const replacement = createTestOperation({ id: 'replacement' });
+      await service.appendBatch([firstPredecessor, secondPredecessor], 'local');
+
+      // Populate the unsynced cache before the atomic transition.
+      expect((await service.getUnsynced()).map(({ op }) => op.id)).toEqual([
+        'first-predecessor',
+        'second-predecessor',
+      ]);
+
+      const result = await service.appendMixedSourceBatchSkipDuplicates(
+        [{ ops: [replacement], source: 'local' }],
+        { rejectOpIds: [firstPredecessor.id, secondPredecessor.id] },
+      );
+
+      expect(result.written.map(({ op }) => op.id)).toEqual(['replacement']);
+      const stored = await service.getOpsAfterSeq(0);
+      const rejectedAt = stored
+        .filter(({ op }) => op.id !== replacement.id)
+        .map((entry) => entry.rejectedAt);
+      expect(rejectedAt[0]).toBeDefined();
+      expect(rejectedAt[1]).toBe(rejectedAt[0]);
+      expect(
+        stored.find(({ op }) => op.id === replacement.id)?.rejectedAt,
+      ).toBeUndefined();
+      expect((await service.getUnsynced()).map(({ op }) => op.id)).toEqual([
+        'replacement',
+      ]);
+    });
+
+    it('should roll back replacement and predecessor rejection when the clock write fails', async () => {
+      await service.setVectorClock({ testClient: 4 });
+      const predecessor = createTestOperation({ id: 'rollback-predecessor' });
+      await service.append(predecessor, 'local');
+      expect((await service.getUnsynced()).map(({ op }) => op.id)).toEqual([
+        predecessor.id,
+      ]);
+
+      const adapter = (
+        service as unknown as {
+          _adapter: OpLogDbAdapter;
+        }
+      )._adapter;
+      const originalTransaction = adapter.transaction.bind(adapter);
+      spyOn(adapter, 'transaction').and.callFake(async (stores, mode, callback) =>
+        originalTransaction(stores, mode, async (tx) => {
+          const failingTx = new Proxy(tx, {
+            get: (target, property): unknown => {
+              if (property === 'put') {
+                return async (store: string, value: unknown, key?: string | number) => {
+                  if (store === STORE_NAMES.VECTOR_CLOCK) {
+                    throw new Error('injected atomic replacement clock failure');
+                  }
+                  return target.put(store, value, key);
+                };
+              }
+              const value = Reflect.get(target, property);
+              return typeof value === 'function' ? value.bind(target) : value;
+            },
+          });
+          return callback(failingTx);
+        }),
+      );
+
+      await expectAsync(
+        service.appendMixedSourceBatchSkipDuplicates(
+          [
+            {
+              ops: [createTestOperation({ id: 'rolled-back-replacement' })],
+              source: 'local',
+            },
+          ],
+          { rejectOpIds: [predecessor.id] },
+        ),
+      ).toBeRejectedWithError('injected atomic replacement clock failure');
+
+      const stored = await service.getOpsAfterSeq(0);
+      expect(stored.map(({ op }) => op.id)).toEqual([predecessor.id]);
+      expect(stored[0].rejectedAt).toBeUndefined();
+      expect((await service.getUnsynced()).map(({ op }) => op.id)).toEqual([
+        predecessor.id,
+      ]);
+      service.clearVectorClockCache();
+      expect(await service.getVectorClock()).toEqual({ testClient: 4 });
+    });
+
+    it('should support atomically rejecting predecessors without appending a replacement', async () => {
+      const predecessor = createTestOperation({ id: 'rejection-only-predecessor' });
+      await service.append(predecessor, 'local');
+      expect((await service.getUnsynced()).map(({ op }) => op.id)).toEqual([
+        predecessor.id,
+      ]);
+
+      const result = await service.appendMixedSourceBatchSkipDuplicates([], {
+        rejectOpIds: [predecessor.id],
+      });
+
+      expect(result).toEqual({ written: [], skippedCount: 0 });
+      expect((await service.getOpById(predecessor.id))?.rejectedAt).toBeDefined();
+      expect(await service.getUnsynced()).toEqual([]);
+    });
+
+    it('should abort atomically when a predecessor to reject is missing', async () => {
+      const replacement = createTestOperation({ id: 'orphaned-replacement' });
+
+      await expectAsync(
+        service.appendMixedSourceBatchSkipDuplicates(
+          [{ ops: [replacement], source: 'local' }],
+          { rejectOpIds: ['missing-predecessor'] },
+        ),
+      ).toBeRejectedWithError(
+        'Cannot atomically reject missing operation missing-predecessor',
+      );
+
+      expect(await service.getOpsAfterSeq(0)).toEqual([]);
+    });
+
+    it('should abort atomically when a predecessor is already inactive', async () => {
+      const predecessor = createTestOperation({ id: 'inactive-predecessor' });
+      const replacement = createTestOperation({
+        id: 'replacement-for-inactive-predecessor',
+      });
+      await service.append(predecessor, 'local');
+      await service.markRejected([predecessor.id]);
+
+      await expectAsync(
+        service.appendMixedSourceBatchSkipDuplicates(
+          [{ ops: [replacement], source: 'local' }],
+          { rejectOpIds: [predecessor.id] },
+        ),
+      ).toBeRejectedWithError(
+        'Cannot atomically reject operation inactive-predecessor because it is not an active pending local operation',
+      );
+
+      expect((await service.getOpsAfterSeq(0)).map(({ op }) => op.id)).toEqual([
+        predecessor.id,
+      ]);
+    });
+
     it('should atomically order remote losers before monotonically clocked local compensations', async () => {
       await service.setVectorClock({ testClient: 5, existingClient: 2 });
       const remoteLoser = createTestOperation({

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -1136,13 +1136,18 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
    *
    * Batch order is durable sequence order. Conflict resolution relies on this
    * to persist remote loser rows before the local compensations that supersede
-   * them, without exposing a crash point between the two groups.
+   * them, without exposing a crash point between the two groups. Superseded
+   * predecessor IDs can be rejected in that same transaction. Missing or
+   * inactive IDs abort the commit so callers cannot mistake a partial recovery
+   * for success.
    */
   async appendMixedSourceBatchSkipDuplicates(
     batches: readonly MixedSourceOperationBatch[],
+    options?: { rejectOpIds?: readonly string[] },
   ): Promise<{ written: MixedSourceWrittenOperation[]; skippedCount: number }> {
     const nonEmptyBatches = batches.filter((batch) => batch.ops.length > 0);
-    if (nonEmptyBatches.length === 0) {
+    const rejectOpIds = [...new Set(options?.rejectOpIds ?? [])];
+    if (nonEmptyBatches.length === 0 && rejectOpIds.length === 0) {
       return { written: [], skippedCount: 0 };
     }
 
@@ -1167,9 +1172,37 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     const written: MixedSourceWrittenOperation[] = [];
     let skippedCount = 0;
     let committedClock: VectorClock | undefined;
+    const committedAt = Date.now();
 
     try {
       await this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
+        const entriesToReject: StoredOperationLogEntry[] = [];
+        for (const opId of rejectOpIds) {
+          const entry = await tx.getFromIndex<StoredOperationLogEntry>(
+            STORE_NAMES.OPS,
+            OPS_INDEXES.BY_ID,
+            opId,
+          );
+          if (!entry) {
+            throw new Error(`Cannot atomically reject missing operation ${opId}`);
+          }
+          if (
+            entry.source !== 'local' ||
+            entry.syncedAt !== undefined ||
+            entry.rejectedAt !== undefined ||
+            entry.reducerRejectedAt !== undefined
+          ) {
+            throw new Error(
+              `Cannot atomically reject operation ${opId} because it is not an active pending local operation`,
+            );
+          }
+          entriesToReject.push(entry);
+        }
+        for (const entry of entriesToReject) {
+          entry.rejectedAt = committedAt;
+          await tx.put(STORE_NAMES.OPS, entry);
+        }
+
         const currentClockEntry = hasLocalOps
           ? await tx.get<VectorClockEntry>(STORE_NAMES.VECTOR_CLOCK, SINGLETON_KEY)
           : undefined;
@@ -1216,7 +1249,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
           committedClock = runningClock;
           await tx.put(
             STORE_NAMES.VECTOR_CLOCK,
-            { clock: runningClock, lastUpdate: Date.now() } satisfies VectorClockEntry,
+            { clock: runningClock, lastUpdate: committedAt } satisfies VectorClockEntry,
             SINGLETON_KEY,
           );
         }
@@ -1227,6 +1260,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
 
     if (committedClock) {
       this._vectorClockCache = { ...committedClock };
+    }
+    if (rejectOpIds.length > 0) {
+      this._invalidateUnsyncedCache();
     }
     return { written, skippedCount };
   }

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -6339,18 +6339,25 @@ describe('ConflictResolutionService', () => {
     const createSectionMoveOp = (
       id: string,
       clientId: string,
-      sourceSectionId = 'section-left',
+      sourceSectionId: string | null = 'section-left',
       taskId = 'task-1',
+      destinationSectionId = 'section-right',
     ): Operation => ({
       ...createMockOp(id, clientId),
       actionType: ActionType.SECTION_ADD_TASK,
       opType: OpType.Move,
       entityType: 'SECTION',
-      entityId: sourceSectionId,
-      entityIds: [sourceSectionId, 'section-right'],
+      entityId:
+        sourceSectionId && sourceSectionId !== destinationSectionId
+          ? sourceSectionId
+          : destinationSectionId,
+      entityIds:
+        sourceSectionId && sourceSectionId !== destinationSectionId
+          ? [sourceSectionId, destinationSectionId]
+          : [destinationSectionId],
       payload: {
         actionPayload: {
-          sectionId: 'section-right',
+          sectionId: destinationSectionId,
           taskId,
           afterTaskId: 'right-anchor',
           sourceSectionId,
@@ -6670,6 +6677,58 @@ describe('ConflictResolutionService', () => {
       it(`should keep commuting ${description} non-conflicting`, async () => {
         const localPendingOpsByEntity = new Map<string, Operation[]>([
           ['SECTION:section-left', [localOp]],
+        ]);
+
+        const result = await service.checkOpForConflicts(
+          remoteOp,
+          buildCtx({ localPendingOpsByEntity }),
+        );
+
+        expect(result).toEqual({ isSupersededOrDuplicate: false, conflicts: [] });
+      });
+    });
+
+    [
+      {
+        description: 'null-source placement against remote order',
+        remoteOp: createSectionOrderOp('remote-order-null-source', 'clientB'),
+        localOp: createSectionMoveOp('local-placement-null-source', 'clientA', null),
+        entityKey: 'SECTION:section-right',
+      },
+      {
+        description: 'remote null-source placement against local order',
+        remoteOp: createSectionMoveOp('remote-placement-null-source', 'clientB', null),
+        localOp: createSectionOrderOp('local-order-null-source', 'clientA'),
+        entityKey: 'SECTION:section-right',
+      },
+      {
+        description: 'same-section placement against remote order',
+        remoteOp: createSectionOrderOp('remote-order-same-section', 'clientB'),
+        localOp: createSectionMoveOp(
+          'local-placement-same-section',
+          'clientA',
+          'section-left',
+          'task-1',
+          'section-left',
+        ),
+        entityKey: 'SECTION:section-left',
+      },
+      {
+        description: 'remote same-section placement against local order',
+        remoteOp: createSectionMoveOp(
+          'remote-placement-same-section',
+          'clientB',
+          'section-left',
+          'task-1',
+          'section-left',
+        ),
+        localOp: createSectionOrderOp('local-order-same-section', 'clientA'),
+        entityKey: 'SECTION:section-left',
+      },
+    ].forEach(({ description, remoteOp, localOp, entityKey }) => {
+      it(`should keep commuting ${description} non-conflicting`, async () => {
+        const localPendingOpsByEntity = new Map<string, Operation[]>([
+          [entityKey, [localOp]],
         ]);
 
         const result = await service.checkOpForConflicts(

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -6336,6 +6336,69 @@ describe('ConflictResolutionService', () => {
       hasNoSnapshotClock: overrides.hasNoSnapshotClock ?? true,
     });
 
+    const createSectionMoveOp = (
+      id: string,
+      clientId: string,
+      sourceSectionId = 'section-left',
+      taskId = 'task-1',
+    ): Operation => ({
+      ...createMockOp(id, clientId),
+      actionType: ActionType.SECTION_ADD_TASK,
+      opType: OpType.Move,
+      entityType: 'SECTION',
+      entityId: sourceSectionId,
+      entityIds: [sourceSectionId, 'section-right'],
+      payload: {
+        actionPayload: {
+          sectionId: 'section-right',
+          taskId,
+          afterTaskId: 'right-anchor',
+          sourceSectionId,
+        },
+        entityChanges: [],
+      },
+    });
+
+    const createSectionRemoveOp = (
+      id: string,
+      clientId: string,
+      sectionId = 'section-left',
+      taskId = 'task-1',
+    ): Operation => ({
+      ...createMockOp(id, clientId),
+      actionType: ActionType.SECTION_REMOVE_TASK,
+      opType: OpType.Update,
+      entityType: 'SECTION',
+      entityId: sectionId,
+      payload: {
+        actionPayload: {
+          sectionId,
+          taskId,
+          workContextId: 'TODAY',
+          workContextType: WorkContextType.TAG,
+          workContextAfterTaskId: 'main-anchor',
+        },
+        entityChanges: [],
+      },
+    });
+
+    const createSectionOrderOp = (
+      id: string,
+      clientId: string,
+      ids = ['section-right', 'section-left'],
+    ): Operation => ({
+      ...createMockOp(id, clientId),
+      actionType: ActionType.SECTION_UPDATE_ORDER,
+      opType: OpType.Move,
+      entityType: 'SECTION',
+      entityId: ids[0],
+      entityIds: ids,
+      payload: {
+        actionPayload: { contextId: 'TODAY', ids },
+        entityChanges: [],
+      },
+    });
+
     it('should mark CONCURRENT remote op as superseded when entity no longer in state', async () => {
       // Scenario: Client A archived a task (already synced), Client B sends a
       // concurrent update. Client A has no pending ops, but local frontier
@@ -6590,6 +6653,113 @@ describe('ConflictResolutionService', () => {
       );
 
       expect(result).toEqual({ isSupersededOrDuplicate: false, conflicts: [] });
+    });
+
+    [
+      {
+        description: 'remote cross-section move and local source removal',
+        remoteOp: createSectionMoveOp('remote-move', 'clientB'),
+        localOp: createSectionRemoveOp('local-remove', 'clientA'),
+      },
+      {
+        description: 'remote source removal and local cross-section move',
+        remoteOp: createSectionRemoveOp('remote-remove', 'clientB'),
+        localOp: createSectionMoveOp('local-move', 'clientA'),
+      },
+    ].forEach(({ description, remoteOp, localOp }) => {
+      it(`should keep commuting ${description} non-conflicting`, async () => {
+        const localPendingOpsByEntity = new Map<string, Operation[]>([
+          ['SECTION:section-left', [localOp]],
+        ]);
+
+        const result = await service.checkOpForConflicts(
+          remoteOp,
+          buildCtx({ localPendingOpsByEntity }),
+        );
+
+        expect(result).toEqual({ isSupersededOrDuplicate: false, conflicts: [] });
+      });
+    });
+
+    it('should still conflict when a section move and removal target different tasks', async () => {
+      const remoteOp = createSectionMoveOp(
+        'remote-move',
+        'clientB',
+        'section-left',
+        'task-1',
+      );
+      const localOp = createSectionRemoveOp(
+        'local-remove',
+        'clientA',
+        'section-left',
+        'task-2',
+      );
+      const localPendingOpsByEntity = new Map<string, Operation[]>([
+        ['SECTION:section-left', [localOp]],
+      ]);
+
+      const result = await service.checkOpForConflicts(
+        remoteOp,
+        buildCtx({ localPendingOpsByEntity }),
+      );
+
+      expect(result.conflicts).toHaveSize(1);
+      expect(result.conflicts[0].entityId).toBe('section-left');
+    });
+
+    it('should still conflict when section payload and entity metadata disagree', async () => {
+      const remoteOp = {
+        ...createSectionMoveOp('remote-move', 'clientB'),
+        entityIds: ['section-left'],
+      };
+      const localOp = createSectionRemoveOp('local-remove', 'clientA');
+      const localPendingOpsByEntity = new Map<string, Operation[]>([
+        ['SECTION:section-left', [localOp]],
+      ]);
+
+      const result = await service.checkOpForConflicts(
+        remoteOp,
+        buildCtx({ localPendingOpsByEntity }),
+      );
+
+      expect(result.conflicts).toHaveSize(1);
+      expect(result.conflicts[0].entityId).toBe('section-left');
+    });
+
+    it('should keep a move non-conflicting with a causal local removal and section reorder', async () => {
+      const remoteMove = createSectionMoveOp('remote-move', 'clientB');
+      const localRemove = createSectionRemoveOp('local-remove', 'clientA');
+      const localOrder = createSectionOrderOp('local-order', 'clientA');
+      const localPendingOpsByEntity = new Map<string, Operation[]>([
+        ['SECTION:section-left', [localRemove, localOrder]],
+        ['SECTION:section-right', [localOrder]],
+      ]);
+
+      const result = await service.checkOpForConflicts(
+        remoteMove,
+        buildCtx({ localPendingOpsByEntity }),
+      );
+
+      expect(result).toEqual({ isSupersededOrDuplicate: false, conflicts: [] });
+    });
+
+    it('should keep concurrent section-order replacements on the conflict path', async () => {
+      const remoteOrder = createSectionOrderOp('remote-order', 'clientB', [
+        'section-left',
+        'section-right',
+      ]);
+      const localOrder = createSectionOrderOp('local-order', 'clientA');
+      const localPendingOpsByEntity = new Map<string, Operation[]>([
+        ['SECTION:section-left', [localOrder]],
+        ['SECTION:section-right', [localOrder]],
+      ]);
+
+      const result = await service.checkOpForConflicts(
+        remoteOrder,
+        buildCtx({ localPendingOpsByEntity }),
+      );
+
+      expect(result.conflicts).toHaveSize(2);
     });
 
     it('should use entityId fallback when entityIds is an empty array', async () => {

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -90,6 +90,7 @@ import {
 } from './conflict-disjoint-merge.util';
 import { NOISE_FIELDS } from './conflict-journal.model';
 import { RECREATE_FALLBACK } from '../core/recreate-fallback.const';
+import { areCommutingSectionOperations } from './section-conflict-commutativity.util';
 
 /**
  * Represents the result of LWW (Last-Write-Wins) conflict resolution.
@@ -3886,6 +3887,18 @@ export class ConflictResolutionService {
 
     // CONCURRENT = true conflict
     if (vcComparison === VectorClockComparison.CONCURRENT) {
+      // The no-pending side already applies these exact crossings as-is because
+      // generic multi-entity LWW cannot split them safely. Applying every pair
+      // is lossless and commutative, so the pending side must do the same to
+      // converge. Any differently shaped local op keeps the conflict path.
+      if (
+        ctx.localOpsForEntity.every((localOp) =>
+          areCommutingSectionOperations(remoteOp, localOp),
+        )
+      ) {
+        return { isSupersededOrDuplicate: false, conflict: null };
+      }
+
       // Task-time sync operations are positive deltas, so two concurrent timer
       // batches commute. Sending them through entity-level LWW would discard one
       // user's tracked time even though both can be applied safely.

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -844,7 +844,9 @@ describe('OperationLogSyncService', () => {
 
           const downloadSpy = spyOn(service, 'downloadRemoteOps').and.returnValue(
             Promise.resolve({
-              kind: 'no_new_ops' as const,
+              kind: 'ops_processed' as const,
+              newOpsCount: 1,
+              localWinOpsCreated: 2,
             }),
           );
 
@@ -874,6 +876,7 @@ describe('OperationLogSyncService', () => {
             isNeverSynced: true,
           });
           expect(recoveryResult.latestServerSeq).toBe(12);
+          expect(recoveryResult.localWinOpsCreated).toBe(2);
         });
 
         it('should propagate nested download cancellation as a cancelled upload', async () => {

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -467,6 +467,7 @@ export class OperationLogSyncService {
           return {
             kind: 'completed',
             newOpsCount: outcome.newOpsCount,
+            localWinOpsCreated: outcome.localWinOpsCreated,
             allOpClocks: outcome.allOpClocks,
             snapshotVectorClock: outcome.snapshotVectorClock,
             latestServerSeq,

--- a/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
@@ -106,6 +106,17 @@ describe('RejectedOpsHandlerService', () => {
       expect(opLogStoreSpy.markRejected).not.toHaveBeenCalled();
     });
 
+    it('should skip reducer-rejected ops', async () => {
+      const op = createOp({ id: 'op-1' });
+      opLogStoreSpy.getOpById.and.returnValue(
+        Promise.resolve({ ...mockEntry(op), reducerRejectedAt: Date.now() }),
+      );
+
+      await service.handleRejectedOps([{ opId: 'op-1', error: 'test error' }]);
+
+      expect(opLogStoreSpy.markRejected).not.toHaveBeenCalled();
+    });
+
     it('should skip ops that no longer exist', async () => {
       opLogStoreSpy.getOpById.and.returnValue(Promise.resolve(undefined));
 
@@ -795,6 +806,90 @@ describe('RejectedOpsHandlerService', () => {
         // Should have called twice: normal then forced
         expect(downloadCallback).toHaveBeenCalledTimes(2);
         expect(downloadCallback).toHaveBeenCalledWith({ forceFromSeq0: true });
+      });
+
+      it('should not resolve an op already retired by the forced download', async () => {
+        const op = createOp({ id: 'op-1' });
+        let rejectedAt: number | undefined;
+        opLogStoreSpy.getOpById.and.callFake(async () => ({
+          ...mockEntry(op),
+          rejectedAt,
+        }));
+        downloadCallback.and.callFake(async (options) => {
+          if (options?.forceFromSeq0) {
+            rejectedAt = Date.now();
+            return {
+              kind: 'completed',
+              newOpsCount: 1,
+              localWinOpsCreated: 1,
+              allOpClocks: [{ remoteClient: 2 }],
+            };
+          }
+          return { kind: 'completed', newOpsCount: 0 };
+        });
+
+        const result = await service.handleRejectedOps(
+          [{ opId: 'op-1', error: 'concurrent', errorCode: 'CONFLICT_CONCURRENT' }],
+          downloadCallback,
+        );
+
+        expect(
+          supersededOperationResolverSpy.resolveSupersededLocalOps,
+        ).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          kind: 'completed',
+          mergedOpsCreated: 1,
+          permanentRejectionCount: 0,
+        });
+      });
+
+      it('should resolve only ops that remain pending after the forced download', async () => {
+        const resolvedOp = createOp({ id: 'op-1', entityId: 'resolved-entity' });
+        const pendingOp = createOp({ id: 'op-2', entityId: 'pending-entity' });
+        let resolvedRejectedAt: number | undefined;
+        opLogStoreSpy.getOpById.and.callFake(async (opId: string) => {
+          if (opId === resolvedOp.id) {
+            return { ...mockEntry(resolvedOp), rejectedAt: resolvedRejectedAt };
+          }
+          if (opId === pendingOp.id) {
+            return mockEntry(pendingOp);
+          }
+          return undefined;
+        });
+        downloadCallback.and.callFake(async (options) => {
+          if (options?.forceFromSeq0) {
+            resolvedRejectedAt = Date.now();
+            return {
+              kind: 'completed',
+              newOpsCount: 1,
+              allOpClocks: [{ remoteClient: 2 }],
+            };
+          }
+          return { kind: 'completed', newOpsCount: 0 };
+        });
+        supersededOperationResolverSpy.resolveSupersededLocalOps.and.resolveTo(1);
+
+        const result = await service.handleRejectedOps(
+          [resolvedOp, pendingOp].map((op) => ({
+            opId: op.id,
+            error: 'concurrent',
+            errorCode: 'CONFLICT_CONCURRENT',
+          })),
+          downloadCallback,
+        );
+
+        expect(
+          supersededOperationResolverSpy.resolveSupersededLocalOps,
+        ).toHaveBeenCalledOnceWith(
+          [{ opId: pendingOp.id, op: pendingOp, existingClock: undefined }],
+          [{ remoteClient: 2 }],
+          undefined,
+        );
+        expect(result).toEqual({
+          kind: 'completed',
+          mergedOpsCreated: 1,
+          permanentRejectionCount: 0,
+        });
       });
 
       it('should use superseded operation resolver when force download returns clocks', async () => {

--- a/src/app/op-log/sync/rejected-ops-handler.service.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.ts
@@ -208,7 +208,13 @@ export class RejectedOpsHandlerService {
       // - Op doesn't exist (was somehow removed)
       // - Op is already synced (was accepted after all)
       // - Op is already rejected (conflict resolution already handled it)
-      if (!entry || entry.syncedAt || entry.rejectedAt) {
+      if (
+        !entry ||
+        entry.source !== 'local' ||
+        entry.syncedAt !== undefined ||
+        entry.rejectedAt !== undefined ||
+        entry.reducerRejectedAt !== undefined
+      ) {
         continue;
       }
 
@@ -423,6 +429,7 @@ export class RejectedOpsHandlerService {
         this._rollbackResolutionAttempts(opsToResolve);
         return { kind: 'cancelled' };
       }
+      mergedOpsCreated += downloadResult.localWinOpsCreated ?? 0;
 
       // Helper to check which ops are still pending, preserving existingClock from rejection
       const getStillPendingOps = async (): Promise<
@@ -435,7 +442,12 @@ export class RejectedOpsHandlerService {
         }> = [];
         for (const { opId, op, existingClock } of opsToResolve) {
           const entry = await this.opLogStore.getOpById(opId);
-          if (entry && !entry.syncedAt && !entry.rejectedAt) {
+          if (
+            entry?.source === 'local' &&
+            entry.syncedAt === undefined &&
+            entry.rejectedAt === undefined &&
+            entry.reducerRejectedAt === undefined
+          ) {
             pending.push({ opId, op, existingClock });
           }
         }
@@ -454,7 +466,7 @@ export class RejectedOpsHandlerService {
       // If download got new ops, conflict detection already happened in _processRemoteOps
       // If download got nothing (newOpsCount === 0), we need to resolve locally
       if (downloadResult.newOpsCount === 0) {
-        const stillPendingOps = await getStillPendingOps();
+        let stillPendingOps = await getStillPendingOps();
 
         if (stillPendingOps.length > 0) {
           // Normal download returned 0 ops but concurrent ops still pending.
@@ -469,6 +481,18 @@ export class RejectedOpsHandlerService {
           if (forceDownloadResult.kind === 'cancelled') {
             this._rollbackResolutionAttempts(opsToResolve);
             return { kind: 'cancelled' };
+          }
+          mergedOpsCreated += forceDownloadResult.localWinOpsCreated ?? 0;
+
+          // The forced download can itself resolve the conflict and retire the
+          // original op. Never pass the stale pre-download list to the resolver.
+          stillPendingOps = await getStillPendingOps();
+          if (stillPendingOps.length === 0) {
+            return {
+              kind: 'completed',
+              mergedOpsCreated,
+              retryExceededCount: opsExceededRetries.length,
+            };
           }
 
           // Use the clocks from force download to resolve superseded ops

--- a/src/app/op-log/sync/section-conflict-commutativity.util.ts
+++ b/src/app/op-log/sync/section-conflict-commutativity.util.ts
@@ -1,17 +1,21 @@
 import {
   ActionType,
   extractActionPayload,
-  isFullStateOpType,
+  isMultiEntityPayload,
   Operation,
   OpType,
 } from '../core/operation.types';
 import { WorkContextType } from '../../features/work-context/work-context.model';
 import { getOpEntityIds } from '../util/get-op-entity-ids.util';
+import { Section, SectionState } from '../../features/section/section.model';
+import { ProjectState } from '../../features/project/project.model';
+import { TagState } from '../../features/tag/tag.model';
 
 interface SectionPlacement {
   sourceSectionId: string | null;
   destinationSectionId: string;
   taskId: string;
+  afterTaskId: string | null;
 }
 
 interface SectionMove extends SectionPlacement {
@@ -23,6 +27,7 @@ interface SectionRemoval {
   taskId: string;
   workContextId: string;
   workContextType: WorkContextType;
+  workContextAfterTaskId: string | null;
 }
 
 interface SectionOrder {
@@ -30,21 +35,16 @@ interface SectionOrder {
   sectionIds: string[];
 }
 
-interface SectionSemanticFootprint {
-  writeKeys: readonly string[];
-  sectionIds: readonly string[];
-  taskIds: readonly string[];
-  workContexts: readonly {
-    id: string;
-    type: WorkContextType;
-  }[];
+export interface SectionReplaySnapshot {
+  section: SectionState;
+  project: ProjectState;
+  tag: TagState;
 }
 
-const SECTION_ACTIONS = new Set<ActionType>([
-  ActionType.SECTION_UPDATE_ORDER,
-  ActionType.SECTION_ADD_TASK,
-  ActionType.SECTION_REMOVE_TASK,
-]);
+export type SectionReplayProjection =
+  | { kind: 'replay'; operation: Operation }
+  | { kind: 'superseded' }
+  | { kind: 'blocked'; reason: string };
 
 const isStringOrNull = (value: unknown): value is string | null =>
   value === null || typeof value === 'string';
@@ -79,11 +79,12 @@ const getSectionPlacement = (operation: Operation): SectionPlacement | undefined
   const sourceSectionId = payload?.['sourceSectionId'];
   const destinationSectionId = payload?.['sectionId'];
   const taskId = payload?.['taskId'];
+  const afterTaskId = payload?.['afterTaskId'];
   if (
     !isStringOrNull(sourceSectionId) ||
     typeof destinationSectionId !== 'string' ||
     typeof taskId !== 'string' ||
-    !isStringOrNull(payload?.['afterTaskId'])
+    !isStringOrNull(afterTaskId)
   ) {
     return undefined;
   }
@@ -98,7 +99,7 @@ const getSectionPlacement = (operation: Operation): SectionPlacement | undefined
   ) {
     return undefined;
   }
-  return { sourceSectionId, destinationSectionId, taskId };
+  return { sourceSectionId, destinationSectionId, taskId, afterTaskId };
 };
 
 const getSectionMove = (operation: Operation): SectionMove | undefined => {
@@ -129,19 +130,26 @@ const getSectionRemoval = (operation: Operation): SectionRemoval | undefined => 
   const taskId = payload?.['taskId'];
   const workContextId = payload?.['workContextId'];
   const workContextType = payload?.['workContextType'];
+  const workContextAfterTaskId = payload?.['workContextAfterTaskId'];
   if (
     typeof sectionId !== 'string' ||
     typeof taskId !== 'string' ||
     typeof workContextId !== 'string' ||
     (workContextType !== WorkContextType.PROJECT &&
       workContextType !== WorkContextType.TAG) ||
-    !isStringOrNull(payload?.['workContextAfterTaskId']) ||
+    !isStringOrNull(workContextAfterTaskId) ||
     operation.entityId !== sectionId ||
     !hasExactEntityIds(operation, [sectionId])
   ) {
     return undefined;
   }
-  return { sectionId, taskId, workContextId, workContextType };
+  return {
+    sectionId,
+    taskId,
+    workContextId,
+    workContextType,
+    workContextAfterTaskId,
+  };
 };
 
 const getSectionOrder = (operation: Operation): SectionOrder | undefined => {
@@ -182,62 +190,6 @@ const isSectionOrderAndPlacementPair = (
   return getOpEntityIds(placementOperation).some((id) => order.sectionIds.includes(id));
 };
 
-const getSectionSemanticFootprint = (
-  operation: Operation,
-): SectionSemanticFootprint | undefined => {
-  const order = getSectionOrder(operation);
-  if (order) {
-    return {
-      writeKeys: [`section-order:${order.contextId}`],
-      sectionIds: order.sectionIds,
-      taskIds: [],
-      workContexts: [],
-    };
-  }
-
-  const placement = getSectionPlacement(operation);
-  if (placement) {
-    const sectionIds =
-      placement.sourceSectionId &&
-      placement.sourceSectionId !== placement.destinationSectionId
-        ? [placement.sourceSectionId, placement.destinationSectionId]
-        : [placement.destinationSectionId];
-    return {
-      writeKeys: [
-        `task-placement:${placement.taskId}`,
-        ...sectionIds.map((id) => `section-tasks:${id}`),
-      ],
-      sectionIds,
-      taskIds: [placement.taskId],
-      workContexts: [],
-    };
-  }
-
-  const removal = getSectionRemoval(operation);
-  if (removal) {
-    return {
-      writeKeys: [
-        `task-placement:${removal.taskId}`,
-        `section-tasks:${removal.sectionId}`,
-        `work-context-tasks:${removal.workContextType}:${removal.workContextId}`,
-      ],
-      sectionIds: [removal.sectionId],
-      taskIds: [removal.taskId],
-      workContexts: [{ id: removal.workContextId, type: removal.workContextType }],
-    };
-  }
-
-  return undefined;
-};
-
-const hasIntersection = (
-  first: readonly string[],
-  second: readonly string[],
-): boolean => {
-  const secondSet = new Set(second);
-  return first.some((value) => secondSet.has(value));
-};
-
 /**
  * Recognizes the narrow SECTION operation pairs whose reducer effects commute.
  * Metadata must exactly match the authenticated action payload before a pair is
@@ -275,95 +227,216 @@ export const areCommutingSectionOperations = (
   );
 };
 
-/**
- * Returns stable lookup keys for operations that can affect a SECTION semantic
- * transition. `undefined` means the operation cannot be scoped safely and must
- * be treated as globally relevant; an empty array is provably unrelated.
- */
-export const getSectionReplayScopeKeys = (
+const withActionPayload = (
   operation: Operation,
-): readonly string[] | undefined => {
-  if (isFullStateOpType(operation.opType)) {
-    return undefined;
-  }
+  actionPayload: Record<string, unknown>,
+): Operation => ({
+  ...operation,
+  payload: isMultiEntityPayload(operation.payload)
+    ? { ...operation.payload, actionPayload, entityChanges: [] }
+    : actionPayload,
+});
 
-  const footprint = getSectionSemanticFootprint(operation);
-  if (footprint) {
-    return Array.from(
-      new Set([
-        ...footprint.writeKeys,
-        ...footprint.sectionIds.map((id) => `section-entity:${id}`),
-        ...footprint.taskIds.map((id) => `task-placement:${id}`),
-        ...footprint.workContexts.map(
-          ({ type, id }) => `work-context-tasks:${type}:${id}`,
-        ),
-      ]),
-    );
+const withEntityFootprint = (
+  operation: Operation,
+  entityIds: readonly string[],
+): Operation => {
+  const next = {
+    ...operation,
+    entityId: entityIds[0],
+  };
+  if (entityIds.length > 1) {
+    next.entityIds = [...entityIds];
+  } else {
+    delete next.entityIds;
   }
-
-  if (SECTION_ACTIONS.has(operation.actionType)) {
-    return undefined;
-  }
-
-  const entityIds = getOpEntityIds(operation);
-  if (entityIds.length === 0) {
-    return operation.entityType === 'SECTION' ? undefined : [];
-  }
-  switch (operation.entityType) {
-    case 'SECTION':
-      return entityIds.flatMap((id) => [`section-entity:${id}`, `section-tasks:${id}`]);
-    case 'TASK':
-      return entityIds.map((id) => `task-placement:${id}`);
-    case 'PROJECT':
-    case 'TAG':
-      return entityIds.map((id) => `work-context-tasks:${operation.entityType}:${id}`);
-    default:
-      return [];
-  }
+  return next;
 };
 
+const getCurrentAnchor = (
+  taskId: string,
+  taskIds: readonly string[],
+): { afterTaskId: string | null } | undefined => {
+  const index = taskIds.indexOf(taskId);
+  if (index === -1 || taskIds.lastIndexOf(taskId) !== index) {
+    return undefined;
+  }
+  return { afterTaskId: index === 0 ? null : taskIds[index - 1] };
+};
+
+const getCurrentSectionsForTask = (state: SectionState, taskId: string): Section[] =>
+  Object.values(state.entities).filter(
+    (section): section is Section => !!section && section.taskIds.includes(taskId),
+  );
+
+const getWorkContextTaskIds = (
+  snapshot: SectionReplaySnapshot,
+  type: WorkContextType,
+  id: string,
+): readonly string[] | undefined =>
+  type === WorkContextType.TAG
+    ? snapshot.tag.entities[id]?.taskIds
+    : snapshot.project.entities[id]?.taskIds;
+
+const createPlacementReplay = (
+  operation: Operation,
+  placement: SectionPlacement,
+  destination: Section,
+): Operation => {
+  const currentAnchor = getCurrentAnchor(placement.taskId, destination.taskIds);
+  if (!currentAnchor) {
+    return operation;
+  }
+  const entityIds =
+    placement.sourceSectionId && placement.sourceSectionId !== destination.id
+      ? [placement.sourceSectionId, destination.id]
+      : [destination.id];
+  return withEntityFootprint(
+    withActionPayload(operation, {
+      sectionId: destination.id,
+      taskId: placement.taskId,
+      afterTaskId: currentAnchor.afterTaskId,
+      sourceSectionId: placement.sourceSectionId,
+    }),
+    entityIds,
+  );
+};
+
+const createRemovalReplay = (
+  operation: Operation,
+  removal: SectionRemoval,
+  afterTaskId: string | null,
+): Operation =>
+  withEntityFootprint(
+    withActionPayload(
+      {
+        ...operation,
+        actionType: ActionType.SECTION_REMOVE_TASK,
+        opType: OpType.Update,
+      },
+      {
+        sectionId: removal.sectionId,
+        taskId: removal.taskId,
+        workContextId: removal.workContextId,
+        workContextType: removal.workContextType,
+        workContextAfterTaskId: afterTaskId,
+      },
+    ),
+    [removal.sectionId],
+  );
+
 /**
- * Whether applying `candidate` before versus after a valid SECTION transition
- * can change the result. Unknown operations fail closed only when their entity
- * footprint can touch the transition.
+ * Projects a causally accepted SECTION intent onto the current, stable NgRx
+ * frontier. The replacement is built from current ordering rather than a stale
+ * anchor, so every already-applied local successor is represented without
+ * action-family whitelists. A replay result must be a local no-op.
  */
-export const canReorderSectionTransition = (
-  sectionOperation: Operation,
-  candidate: Operation,
-): boolean => {
-  const sectionFootprint = getSectionSemanticFootprint(sectionOperation);
-  if (!sectionFootprint || isFullStateOpType(candidate.opType)) {
-    return true;
-  }
-
-  const candidateFootprint = getSectionSemanticFootprint(candidate);
-  if (candidateFootprint) {
-    return (
-      !areCommutingSectionOperations(sectionOperation, candidate) &&
-      hasIntersection(sectionFootprint.writeKeys, candidateFootprint.writeKeys)
+export const projectSectionReplayAgainstState = (
+  operation: Operation,
+  snapshot: SectionReplaySnapshot,
+): SectionReplayProjection => {
+  const order = getSectionOrder(operation);
+  if (order) {
+    const currentIds = snapshot.section.ids.filter(
+      (id) => snapshot.section.entities[id]?.contextId === order.contextId,
     );
+    if (currentIds.length === 0) {
+      return { kind: 'superseded' };
+    }
+    return {
+      kind: 'replay',
+      operation: withEntityFootprint(
+        withActionPayload(operation, {
+          contextId: order.contextId,
+          ids: currentIds,
+        }),
+        currentIds,
+      ),
+    };
   }
 
-  if (SECTION_ACTIONS.has(candidate.actionType)) {
-    return true;
+  const placement = getSectionPlacement(operation);
+  if (placement) {
+    const currentSections = getCurrentSectionsForTask(snapshot.section, placement.taskId);
+    if (currentSections.length > 1) {
+      return {
+        kind: 'blocked',
+        reason: `task ${placement.taskId} belongs to multiple sections`,
+      };
+    }
+    if (currentSections.length === 1) {
+      const destination = currentSections[0];
+      const currentAnchor = getCurrentAnchor(placement.taskId, destination.taskIds);
+      if (!currentAnchor) {
+        return {
+          kind: 'blocked',
+          reason: `task ${placement.taskId} has ambiguous section ordering`,
+        };
+      }
+      return {
+        kind: 'replay',
+        operation: createPlacementReplay(operation, placement, destination),
+      };
+    }
+
+    const contextSection =
+      (placement.sourceSectionId
+        ? snapshot.section.entities[placement.sourceSectionId]
+        : undefined) ?? snapshot.section.entities[placement.destinationSectionId];
+    if (!contextSection) {
+      return { kind: 'superseded' };
+    }
+    const contextTaskIds = getWorkContextTaskIds(
+      snapshot,
+      contextSection.contextType,
+      contextSection.contextId,
+    );
+    const currentAnchor = contextTaskIds
+      ? getCurrentAnchor(placement.taskId, contextTaskIds)
+      : undefined;
+    if (!currentAnchor) {
+      return { kind: 'superseded' };
+    }
+    return {
+      kind: 'replay',
+      operation: createRemovalReplay(
+        operation,
+        {
+          sectionId: placement.sourceSectionId ?? placement.destinationSectionId,
+          taskId: placement.taskId,
+          workContextId: contextSection.contextId,
+          workContextType: contextSection.contextType,
+          workContextAfterTaskId: currentAnchor.afterTaskId,
+        },
+        currentAnchor.afterTaskId,
+      ),
+    };
   }
 
-  const candidateEntityIds = getOpEntityIds(candidate);
-  switch (candidate.entityType) {
-    case 'SECTION':
-      return (
-        candidateEntityIds.length === 0 ||
-        hasIntersection(sectionFootprint.sectionIds, candidateEntityIds)
-      );
-    case 'TASK':
-      return hasIntersection(sectionFootprint.taskIds, candidateEntityIds);
-    case 'PROJECT':
-    case 'TAG':
-      return sectionFootprint.workContexts.some(
-        ({ id, type }) =>
-          type === candidate.entityType && candidateEntityIds.includes(id),
-      );
-    default:
-      return false;
+  const removal = getSectionRemoval(operation);
+  if (removal) {
+    if (snapshot.section.entities[removal.sectionId]?.taskIds.includes(removal.taskId)) {
+      return {
+        kind: 'blocked',
+        reason: `section ${removal.sectionId} still contains task ${removal.taskId}`,
+      };
+    }
+    const contextTaskIds = getWorkContextTaskIds(
+      snapshot,
+      removal.workContextType,
+      removal.workContextId,
+    );
+    const currentAnchor = contextTaskIds
+      ? getCurrentAnchor(removal.taskId, contextTaskIds)
+      : undefined;
+    if (!currentAnchor) {
+      return { kind: 'superseded' };
+    }
+    return {
+      kind: 'replay',
+      operation: createRemovalReplay(operation, removal, currentAnchor.afterTaskId),
+    };
   }
+
+  return { kind: 'blocked', reason: 'operation is not a valid SECTION transition' };
 };

--- a/src/app/op-log/sync/section-conflict-commutativity.util.ts
+++ b/src/app/op-log/sync/section-conflict-commutativity.util.ts
@@ -1,0 +1,166 @@
+import {
+  ActionType,
+  extractActionPayload,
+  Operation,
+  OpType,
+} from '../core/operation.types';
+import { WorkContextType } from '../../features/work-context/work-context.model';
+import { getOpEntityIds } from '../util/get-op-entity-ids.util';
+
+interface SectionMove {
+  sourceSectionId: string;
+  destinationSectionId: string;
+  taskId: string;
+}
+
+interface SectionRemoval {
+  sectionId: string;
+  taskId: string;
+}
+
+const isStringOrNull = (value: unknown): value is string | null =>
+  value === null || typeof value === 'string';
+
+const getActionPayload = (operation: Operation): Record<string, unknown> | undefined => {
+  if (!operation.payload || typeof operation.payload !== 'object') {
+    return undefined;
+  }
+  const payload = extractActionPayload(operation.payload);
+  return payload && typeof payload === 'object' ? payload : undefined;
+};
+
+const hasExactEntityIds = (operation: Operation, expectedIds: string[]): boolean => {
+  const uniqueExpectedIds = Array.from(new Set(expectedIds));
+  const declaredIds = getOpEntityIds(operation);
+  return (
+    uniqueExpectedIds.length === expectedIds.length &&
+    declaredIds.length === uniqueExpectedIds.length &&
+    uniqueExpectedIds.every((id) => declaredIds.includes(id))
+  );
+};
+
+const getSectionMove = (operation: Operation): SectionMove | undefined => {
+  if (
+    operation.actionType !== ActionType.SECTION_ADD_TASK ||
+    operation.entityType !== 'SECTION' ||
+    operation.opType !== OpType.Move
+  ) {
+    return undefined;
+  }
+  const payload = getActionPayload(operation);
+  const sourceSectionId = payload?.['sourceSectionId'];
+  const destinationSectionId = payload?.['sectionId'];
+  const taskId = payload?.['taskId'];
+  if (
+    typeof sourceSectionId !== 'string' ||
+    typeof destinationSectionId !== 'string' ||
+    sourceSectionId === destinationSectionId ||
+    typeof taskId !== 'string' ||
+    !isStringOrNull(payload?.['afterTaskId']) ||
+    operation.entityId !== sourceSectionId ||
+    !hasExactEntityIds(operation, [sourceSectionId, destinationSectionId])
+  ) {
+    return undefined;
+  }
+  return { sourceSectionId, destinationSectionId, taskId };
+};
+
+const getSectionRemoval = (operation: Operation): SectionRemoval | undefined => {
+  if (
+    operation.actionType !== ActionType.SECTION_REMOVE_TASK ||
+    operation.entityType !== 'SECTION' ||
+    operation.opType !== OpType.Update
+  ) {
+    return undefined;
+  }
+  const payload = getActionPayload(operation);
+  const sectionId = payload?.['sectionId'];
+  const taskId = payload?.['taskId'];
+  if (
+    typeof sectionId !== 'string' ||
+    typeof taskId !== 'string' ||
+    typeof payload?.['workContextId'] !== 'string' ||
+    (payload?.['workContextType'] !== WorkContextType.PROJECT &&
+      payload?.['workContextType'] !== WorkContextType.TAG) ||
+    !isStringOrNull(payload?.['workContextAfterTaskId']) ||
+    operation.entityId !== sectionId ||
+    !hasExactEntityIds(operation, [sectionId])
+  ) {
+    return undefined;
+  }
+  return { sectionId, taskId };
+};
+
+const getSectionOrderIds = (operation: Operation): string[] | undefined => {
+  if (
+    operation.actionType !== ActionType.SECTION_UPDATE_ORDER ||
+    operation.entityType !== 'SECTION' ||
+    operation.opType !== OpType.Move
+  ) {
+    return undefined;
+  }
+  const payload = getActionPayload(operation);
+  const ids = payload?.['ids'];
+  if (
+    typeof payload?.['contextId'] !== 'string' ||
+    !Array.isArray(ids) ||
+    ids.length === 0 ||
+    !ids.every((id): id is string => typeof id === 'string') ||
+    operation.entityId !== ids[0] ||
+    !hasExactEntityIds(operation, ids)
+  ) {
+    return undefined;
+  }
+  return ids;
+};
+
+const isSectionOrderAndPlacementPair = (
+  orderOperation: Operation,
+  placementOperation: Operation,
+): boolean => {
+  const orderIds = getSectionOrderIds(orderOperation);
+  if (
+    !orderIds ||
+    (!getSectionMove(placementOperation) && !getSectionRemoval(placementOperation))
+  ) {
+    return false;
+  }
+  return getOpEntityIds(placementOperation).some((id) => orderIds.includes(id));
+};
+
+/**
+ * Recognizes the narrow SECTION operation pairs whose reducer effects commute.
+ * Metadata must exactly match the authenticated action payload before a pair is
+ * allowed to bypass entity-level LWW.
+ */
+export const areCommutingSectionOperations = (
+  first: Operation,
+  second: Operation,
+): boolean => {
+  const firstMove = getSectionMove(first);
+  const secondMove = getSectionMove(second);
+  const firstRemoval = getSectionRemoval(first);
+  const secondRemoval = getSectionRemoval(second);
+
+  if (
+    firstMove &&
+    secondRemoval &&
+    firstMove.sourceSectionId === secondRemoval.sectionId &&
+    firstMove.taskId === secondRemoval.taskId
+  ) {
+    return true;
+  }
+  if (
+    secondMove &&
+    firstRemoval &&
+    secondMove.sourceSectionId === firstRemoval.sectionId &&
+    secondMove.taskId === firstRemoval.taskId
+  ) {
+    return true;
+  }
+
+  return (
+    isSectionOrderAndPlacementPair(first, second) ||
+    isSectionOrderAndPlacementPair(second, first)
+  );
+};

--- a/src/app/op-log/sync/section-conflict-commutativity.util.ts
+++ b/src/app/op-log/sync/section-conflict-commutativity.util.ts
@@ -46,15 +46,21 @@ export interface SectionReplayOrder {
   position: number;
 }
 
+export interface SectionReplayStateCompensation {
+  entityType: WorkContextType;
+  entityId: string;
+  entityState: Project | Tag;
+  order: SectionReplayOrder;
+}
+
 export type SectionReplayProjection =
-  | { kind: 'replay'; operation: Operation; order: SectionReplayOrder }
   | {
-      kind: 'work-context-state';
-      entityType: WorkContextType;
-      entityId: string;
-      entityState: Project | Tag;
+      kind: 'replay';
+      operation: Operation;
       order: SectionReplayOrder;
+      stateCompensation?: SectionReplayStateCompensation;
     }
+  | ({ kind: 'work-context-state' } & SectionReplayStateCompensation)
   | { kind: 'superseded' }
   | { kind: 'blocked'; reason: string };
 
@@ -305,6 +311,26 @@ const getWorkContextEntity = (
     ? snapshot.tag.entities[id]
     : snapshot.project.entities[id];
 
+const createStateCompensation = (
+  entityType: WorkContextType,
+  entityId: string,
+  entityState: Project | Tag,
+): SectionReplayStateCompensation => {
+  // Wire compatibility: v18.4.0-v18.4.3 accept schema-4 S6 rows but only
+  // remove section membership; they ignore the later work-context anchor fields.
+  // Their existing Project/Tag LWW reducer does understand this complete entity
+  // snapshot, so persist it after semantic removals to converge taskIds ordering.
+  return {
+    entityType,
+    entityId,
+    entityState,
+    order: {
+      scope: getReplayScope('work-context-tasks', entityType, entityId),
+      position: Number.MAX_SAFE_INTEGER,
+    },
+  };
+};
+
 const createPlacementReplay = (
   operation: Operation,
   placement: SectionPlacement,
@@ -488,6 +514,11 @@ export const projectSectionReplayAgainstState = (
         ),
         position: contextEntity.taskIds.indexOf(placement.taskId),
       },
+      stateCompensation: createStateCompensation(
+        contextSection.contextType,
+        contextSection.contextId,
+        contextEntity,
+      ),
     };
   }
 
@@ -543,17 +574,11 @@ export const projectSectionReplayAgainstState = (
       }
       return {
         kind: 'work-context-state',
-        entityType: removal.workContextType,
-        entityId: removal.workContextId,
-        entityState: contextEntity,
-        order: {
-          scope: getReplayScope(
-            'work-context-tasks',
-            removal.workContextType,
-            removal.workContextId,
-          ),
-          position: Number.MAX_SAFE_INTEGER,
-        },
+        ...createStateCompensation(
+          removal.workContextType,
+          removal.workContextId,
+          contextEntity,
+        ),
       };
     }
     if (!currentAnchor) {
@@ -570,6 +595,11 @@ export const projectSectionReplayAgainstState = (
         ),
         position: contextEntity.taskIds.indexOf(removal.taskId),
       },
+      stateCompensation: createStateCompensation(
+        removal.workContextType,
+        removal.workContextId,
+        contextEntity,
+      ),
     };
   }
 

--- a/src/app/op-log/sync/section-conflict-commutativity.util.ts
+++ b/src/app/op-log/sync/section-conflict-commutativity.util.ts
@@ -1,22 +1,50 @@
 import {
   ActionType,
   extractActionPayload,
+  isFullStateOpType,
   Operation,
   OpType,
 } from '../core/operation.types';
 import { WorkContextType } from '../../features/work-context/work-context.model';
 import { getOpEntityIds } from '../util/get-op-entity-ids.util';
 
-interface SectionMove {
-  sourceSectionId: string;
+interface SectionPlacement {
+  sourceSectionId: string | null;
   destinationSectionId: string;
   taskId: string;
+}
+
+interface SectionMove extends SectionPlacement {
+  sourceSectionId: string;
 }
 
 interface SectionRemoval {
   sectionId: string;
   taskId: string;
+  workContextId: string;
+  workContextType: WorkContextType;
 }
+
+interface SectionOrder {
+  contextId: string;
+  sectionIds: string[];
+}
+
+interface SectionSemanticFootprint {
+  writeKeys: readonly string[];
+  sectionIds: readonly string[];
+  taskIds: readonly string[];
+  workContexts: readonly {
+    id: string;
+    type: WorkContextType;
+  }[];
+}
+
+const SECTION_ACTIONS = new Set<ActionType>([
+  ActionType.SECTION_UPDATE_ORDER,
+  ActionType.SECTION_ADD_TASK,
+  ActionType.SECTION_REMOVE_TASK,
+]);
 
 const isStringOrNull = (value: unknown): value is string | null =>
   value === null || typeof value === 'string';
@@ -39,7 +67,7 @@ const hasExactEntityIds = (operation: Operation, expectedIds: string[]): boolean
   );
 };
 
-const getSectionMove = (operation: Operation): SectionMove | undefined => {
+const getSectionPlacement = (operation: Operation): SectionPlacement | undefined => {
   if (
     operation.actionType !== ActionType.SECTION_ADD_TASK ||
     operation.entityType !== 'SECTION' ||
@@ -52,17 +80,40 @@ const getSectionMove = (operation: Operation): SectionMove | undefined => {
   const destinationSectionId = payload?.['sectionId'];
   const taskId = payload?.['taskId'];
   if (
-    typeof sourceSectionId !== 'string' ||
+    !isStringOrNull(sourceSectionId) ||
     typeof destinationSectionId !== 'string' ||
-    sourceSectionId === destinationSectionId ||
     typeof taskId !== 'string' ||
-    !isStringOrNull(payload?.['afterTaskId']) ||
-    operation.entityId !== sourceSectionId ||
-    !hasExactEntityIds(operation, [sourceSectionId, destinationSectionId])
+    !isStringOrNull(payload?.['afterTaskId'])
+  ) {
+    return undefined;
+  }
+  const isCrossSectionMove =
+    sourceSectionId !== null && sourceSectionId !== destinationSectionId;
+  const expectedEntityIds = isCrossSectionMove
+    ? [sourceSectionId, destinationSectionId]
+    : [destinationSectionId];
+  if (
+    operation.entityId !== expectedEntityIds[0] ||
+    !hasExactEntityIds(operation, expectedEntityIds)
   ) {
     return undefined;
   }
   return { sourceSectionId, destinationSectionId, taskId };
+};
+
+const getSectionMove = (operation: Operation): SectionMove | undefined => {
+  const placement = getSectionPlacement(operation);
+  if (
+    !placement ||
+    typeof placement.sourceSectionId !== 'string' ||
+    placement.sourceSectionId === placement.destinationSectionId
+  ) {
+    return undefined;
+  }
+  return {
+    ...placement,
+    sourceSectionId: placement.sourceSectionId,
+  };
 };
 
 const getSectionRemoval = (operation: Operation): SectionRemoval | undefined => {
@@ -76,22 +127,24 @@ const getSectionRemoval = (operation: Operation): SectionRemoval | undefined => 
   const payload = getActionPayload(operation);
   const sectionId = payload?.['sectionId'];
   const taskId = payload?.['taskId'];
+  const workContextId = payload?.['workContextId'];
+  const workContextType = payload?.['workContextType'];
   if (
     typeof sectionId !== 'string' ||
     typeof taskId !== 'string' ||
-    typeof payload?.['workContextId'] !== 'string' ||
-    (payload?.['workContextType'] !== WorkContextType.PROJECT &&
-      payload?.['workContextType'] !== WorkContextType.TAG) ||
+    typeof workContextId !== 'string' ||
+    (workContextType !== WorkContextType.PROJECT &&
+      workContextType !== WorkContextType.TAG) ||
     !isStringOrNull(payload?.['workContextAfterTaskId']) ||
     operation.entityId !== sectionId ||
     !hasExactEntityIds(operation, [sectionId])
   ) {
     return undefined;
   }
-  return { sectionId, taskId };
+  return { sectionId, taskId, workContextId, workContextType };
 };
 
-const getSectionOrderIds = (operation: Operation): string[] | undefined => {
+const getSectionOrder = (operation: Operation): SectionOrder | undefined => {
   if (
     operation.actionType !== ActionType.SECTION_UPDATE_ORDER ||
     operation.entityType !== 'SECTION' ||
@@ -100,9 +153,10 @@ const getSectionOrderIds = (operation: Operation): string[] | undefined => {
     return undefined;
   }
   const payload = getActionPayload(operation);
+  const contextId = payload?.['contextId'];
   const ids = payload?.['ids'];
   if (
-    typeof payload?.['contextId'] !== 'string' ||
+    typeof contextId !== 'string' ||
     !Array.isArray(ids) ||
     ids.length === 0 ||
     !ids.every((id): id is string => typeof id === 'string') ||
@@ -111,21 +165,77 @@ const getSectionOrderIds = (operation: Operation): string[] | undefined => {
   ) {
     return undefined;
   }
-  return ids;
+  return { contextId, sectionIds: ids };
 };
 
 const isSectionOrderAndPlacementPair = (
   orderOperation: Operation,
   placementOperation: Operation,
 ): boolean => {
-  const orderIds = getSectionOrderIds(orderOperation);
+  const order = getSectionOrder(orderOperation);
   if (
-    !orderIds ||
-    (!getSectionMove(placementOperation) && !getSectionRemoval(placementOperation))
+    !order ||
+    (!getSectionPlacement(placementOperation) && !getSectionRemoval(placementOperation))
   ) {
     return false;
   }
-  return getOpEntityIds(placementOperation).some((id) => orderIds.includes(id));
+  return getOpEntityIds(placementOperation).some((id) => order.sectionIds.includes(id));
+};
+
+const getSectionSemanticFootprint = (
+  operation: Operation,
+): SectionSemanticFootprint | undefined => {
+  const order = getSectionOrder(operation);
+  if (order) {
+    return {
+      writeKeys: [`section-order:${order.contextId}`],
+      sectionIds: order.sectionIds,
+      taskIds: [],
+      workContexts: [],
+    };
+  }
+
+  const placement = getSectionPlacement(operation);
+  if (placement) {
+    const sectionIds =
+      placement.sourceSectionId &&
+      placement.sourceSectionId !== placement.destinationSectionId
+        ? [placement.sourceSectionId, placement.destinationSectionId]
+        : [placement.destinationSectionId];
+    return {
+      writeKeys: [
+        `task-placement:${placement.taskId}`,
+        ...sectionIds.map((id) => `section-tasks:${id}`),
+      ],
+      sectionIds,
+      taskIds: [placement.taskId],
+      workContexts: [],
+    };
+  }
+
+  const removal = getSectionRemoval(operation);
+  if (removal) {
+    return {
+      writeKeys: [
+        `task-placement:${removal.taskId}`,
+        `section-tasks:${removal.sectionId}`,
+        `work-context-tasks:${removal.workContextType}:${removal.workContextId}`,
+      ],
+      sectionIds: [removal.sectionId],
+      taskIds: [removal.taskId],
+      workContexts: [{ id: removal.workContextId, type: removal.workContextType }],
+    };
+  }
+
+  return undefined;
+};
+
+const hasIntersection = (
+  first: readonly string[],
+  second: readonly string[],
+): boolean => {
+  const secondSet = new Set(second);
+  return first.some((value) => secondSet.has(value));
 };
 
 /**
@@ -163,4 +273,97 @@ export const areCommutingSectionOperations = (
     isSectionOrderAndPlacementPair(first, second) ||
     isSectionOrderAndPlacementPair(second, first)
   );
+};
+
+/**
+ * Returns stable lookup keys for operations that can affect a SECTION semantic
+ * transition. `undefined` means the operation cannot be scoped safely and must
+ * be treated as globally relevant; an empty array is provably unrelated.
+ */
+export const getSectionReplayScopeKeys = (
+  operation: Operation,
+): readonly string[] | undefined => {
+  if (isFullStateOpType(operation.opType)) {
+    return undefined;
+  }
+
+  const footprint = getSectionSemanticFootprint(operation);
+  if (footprint) {
+    return Array.from(
+      new Set([
+        ...footprint.writeKeys,
+        ...footprint.sectionIds.map((id) => `section-entity:${id}`),
+        ...footprint.taskIds.map((id) => `task-placement:${id}`),
+        ...footprint.workContexts.map(
+          ({ type, id }) => `work-context-tasks:${type}:${id}`,
+        ),
+      ]),
+    );
+  }
+
+  if (SECTION_ACTIONS.has(operation.actionType)) {
+    return undefined;
+  }
+
+  const entityIds = getOpEntityIds(operation);
+  if (entityIds.length === 0) {
+    return operation.entityType === 'SECTION' ? undefined : [];
+  }
+  switch (operation.entityType) {
+    case 'SECTION':
+      return entityIds.flatMap((id) => [`section-entity:${id}`, `section-tasks:${id}`]);
+    case 'TASK':
+      return entityIds.map((id) => `task-placement:${id}`);
+    case 'PROJECT':
+    case 'TAG':
+      return entityIds.map((id) => `work-context-tasks:${operation.entityType}:${id}`);
+    default:
+      return [];
+  }
+};
+
+/**
+ * Whether applying `candidate` before versus after a valid SECTION transition
+ * can change the result. Unknown operations fail closed only when their entity
+ * footprint can touch the transition.
+ */
+export const canReorderSectionTransition = (
+  sectionOperation: Operation,
+  candidate: Operation,
+): boolean => {
+  const sectionFootprint = getSectionSemanticFootprint(sectionOperation);
+  if (!sectionFootprint || isFullStateOpType(candidate.opType)) {
+    return true;
+  }
+
+  const candidateFootprint = getSectionSemanticFootprint(candidate);
+  if (candidateFootprint) {
+    return (
+      !areCommutingSectionOperations(sectionOperation, candidate) &&
+      hasIntersection(sectionFootprint.writeKeys, candidateFootprint.writeKeys)
+    );
+  }
+
+  if (SECTION_ACTIONS.has(candidate.actionType)) {
+    return true;
+  }
+
+  const candidateEntityIds = getOpEntityIds(candidate);
+  switch (candidate.entityType) {
+    case 'SECTION':
+      return (
+        candidateEntityIds.length === 0 ||
+        hasIntersection(sectionFootprint.sectionIds, candidateEntityIds)
+      );
+    case 'TASK':
+      return hasIntersection(sectionFootprint.taskIds, candidateEntityIds);
+    case 'PROJECT':
+    case 'TAG':
+      return sectionFootprint.workContexts.some(
+        ({ id, type }) =>
+          type === candidate.entityType && candidateEntityIds.includes(id),
+      );
+    default:
+      return false;
+  }
 };

--- a/src/app/op-log/sync/section-conflict-commutativity.util.ts
+++ b/src/app/op-log/sync/section-conflict-commutativity.util.ts
@@ -8,8 +8,8 @@ import {
 import { WorkContextType } from '../../features/work-context/work-context.model';
 import { getOpEntityIds } from '../util/get-op-entity-ids.util';
 import { Section, SectionState } from '../../features/section/section.model';
-import { ProjectState } from '../../features/project/project.model';
-import { TagState } from '../../features/tag/tag.model';
+import { Project, ProjectState } from '../../features/project/project.model';
+import { Tag, TagState } from '../../features/tag/tag.model';
 
 interface SectionPlacement {
   sourceSectionId: string | null;
@@ -41,13 +41,27 @@ export interface SectionReplaySnapshot {
   tag: TagState;
 }
 
+export interface SectionReplayOrder {
+  scope: string;
+  position: number;
+}
+
 export type SectionReplayProjection =
-  | { kind: 'replay'; operation: Operation }
+  | { kind: 'replay'; operation: Operation; order: SectionReplayOrder }
+  | {
+      kind: 'work-context-state';
+      entityType: WorkContextType;
+      entityId: string;
+      entityState: Project | Tag;
+      order: SectionReplayOrder;
+    }
   | { kind: 'superseded' }
   | { kind: 'blocked'; reason: string };
 
 const isStringOrNull = (value: unknown): value is string | null =>
   value === null || typeof value === 'string';
+
+const getReplayScope = (...parts: string[]): string => JSON.stringify(parts);
 
 const getActionPayload = (operation: Operation): Record<string, unknown> | undefined => {
   if (!operation.payload || typeof operation.payload !== 'object') {
@@ -269,14 +283,27 @@ const getCurrentSectionsForTask = (state: SectionState, taskId: string): Section
     (section): section is Section => !!section && section.taskIds.includes(taskId),
   );
 
-const getWorkContextTaskIds = (
+const isSameWorkContext = (first: Section, second: Section): boolean =>
+  first.contextId === second.contextId && first.contextType === second.contextType;
+
+const getCurrentSectionsForTaskInContext = (
+  state: SectionState,
+  taskId: string,
+  contextId: string,
+  contextType: WorkContextType,
+): Section[] =>
+  getCurrentSectionsForTask(state, taskId).filter(
+    (section) => section.contextId === contextId && section.contextType === contextType,
+  );
+
+const getWorkContextEntity = (
   snapshot: SectionReplaySnapshot,
   type: WorkContextType,
   id: string,
-): readonly string[] | undefined =>
+): Project | Tag | undefined =>
   type === WorkContextType.TAG
-    ? snapshot.tag.entities[id]?.taskIds
-    : snapshot.project.entities[id]?.taskIds;
+    ? snapshot.tag.entities[id]
+    : snapshot.project.entities[id];
 
 const createPlacementReplay = (
   operation: Operation,
@@ -352,16 +379,45 @@ export const projectSectionReplayAgainstState = (
         }),
         currentIds,
       ),
+      order: {
+        scope: getReplayScope('section-order', order.contextId),
+        position: 0,
+      },
     };
   }
 
   const placement = getSectionPlacement(operation);
   if (placement) {
-    const currentSections = getCurrentSectionsForTask(snapshot.section, placement.taskId);
+    const sourceSection = placement.sourceSectionId
+      ? snapshot.section.entities[placement.sourceSectionId]
+      : undefined;
+    const destinationSection = snapshot.section.entities[placement.destinationSectionId];
+    if (
+      sourceSection &&
+      destinationSection &&
+      !isSameWorkContext(sourceSection, destinationSection)
+    ) {
+      return {
+        kind: 'blocked',
+        reason: 'source and destination sections belong to different work contexts',
+      };
+    }
+    const contextSection = sourceSection ?? destinationSection;
+    if (!contextSection) {
+      return { kind: 'superseded' };
+    }
+    const currentSections = getCurrentSectionsForTaskInContext(
+      snapshot.section,
+      placement.taskId,
+      contextSection.contextId,
+      contextSection.contextType,
+    );
     if (currentSections.length > 1) {
       return {
         kind: 'blocked',
-        reason: `task ${placement.taskId} belongs to multiple sections`,
+        reason:
+          `task ${placement.taskId} belongs to multiple sections in ` +
+          `${contextSection.contextType}:${contextSection.contextId}`,
       };
     }
     if (currentSections.length === 1) {
@@ -376,24 +432,38 @@ export const projectSectionReplayAgainstState = (
       return {
         kind: 'replay',
         operation: createPlacementReplay(operation, placement, destination),
+        order: {
+          scope: getReplayScope(
+            'section-tasks',
+            destination.contextType,
+            destination.contextId,
+            destination.id,
+          ),
+          position: destination.taskIds.indexOf(placement.taskId),
+        },
       };
     }
 
-    const contextSection =
-      (placement.sourceSectionId
-        ? snapshot.section.entities[placement.sourceSectionId]
-        : undefined) ?? snapshot.section.entities[placement.destinationSectionId];
-    if (!contextSection) {
-      return { kind: 'superseded' };
-    }
-    const contextTaskIds = getWorkContextTaskIds(
+    const contextEntity = getWorkContextEntity(
       snapshot,
       contextSection.contextType,
       contextSection.contextId,
     );
-    const currentAnchor = contextTaskIds
-      ? getCurrentAnchor(placement.taskId, contextTaskIds)
-      : undefined;
+    if (!contextEntity) {
+      return { kind: 'superseded' };
+    }
+    const taskOccurrences = contextEntity.taskIds.filter(
+      (id) => id === placement.taskId,
+    ).length;
+    if (taskOccurrences > 1) {
+      return {
+        kind: 'blocked',
+        reason:
+          `task ${placement.taskId} has ambiguous ordering in ` +
+          `${contextSection.contextType}:${contextSection.contextId}`,
+      };
+    }
+    const currentAnchor = getCurrentAnchor(placement.taskId, contextEntity.taskIds);
     if (!currentAnchor) {
       return { kind: 'superseded' };
     }
@@ -410,31 +480,96 @@ export const projectSectionReplayAgainstState = (
         },
         currentAnchor.afterTaskId,
       ),
+      order: {
+        scope: getReplayScope(
+          'work-context-tasks',
+          contextSection.contextType,
+          contextSection.contextId,
+        ),
+        position: contextEntity.taskIds.indexOf(placement.taskId),
+      },
     };
   }
 
   const removal = getSectionRemoval(operation);
   if (removal) {
-    if (snapshot.section.entities[removal.sectionId]?.taskIds.includes(removal.taskId)) {
+    const sourceSection = snapshot.section.entities[removal.sectionId];
+    if (
+      sourceSection &&
+      (sourceSection.contextId !== removal.workContextId ||
+        sourceSection.contextType !== removal.workContextType)
+    ) {
       return {
         kind: 'blocked',
-        reason: `section ${removal.sectionId} still contains task ${removal.taskId}`,
+        reason: `section ${removal.sectionId} does not belong to the declared work context`,
       };
     }
-    const contextTaskIds = getWorkContextTaskIds(
+    const contextEntity = getWorkContextEntity(
       snapshot,
       removal.workContextType,
       removal.workContextId,
     );
-    const currentAnchor = contextTaskIds
-      ? getCurrentAnchor(removal.taskId, contextTaskIds)
-      : undefined;
+    const sourceContainsTask = sourceSection?.taskIds.includes(removal.taskId) === true;
+    if (!contextEntity) {
+      return sourceContainsTask
+        ? {
+            kind: 'blocked',
+            reason:
+              `task ${removal.taskId} is sectioned but its declared work context ` +
+              `${removal.workContextType}:${removal.workContextId} is missing`,
+          }
+        : { kind: 'superseded' };
+    }
+    const taskOccurrences = contextEntity.taskIds.filter(
+      (id) => id === removal.taskId,
+    ).length;
+    if (taskOccurrences > 1) {
+      return {
+        kind: 'blocked',
+        reason:
+          `task ${removal.taskId} has ambiguous ordering in ` +
+          `${removal.workContextType}:${removal.workContextId}`,
+      };
+    }
+    const currentAnchor = getCurrentAnchor(removal.taskId, contextEntity.taskIds);
+    if (sourceContainsTask) {
+      if (!currentAnchor) {
+        return {
+          kind: 'blocked',
+          reason:
+            `task ${removal.taskId} is sectioned but missing from ` +
+            `${removal.workContextType}:${removal.workContextId}`,
+        };
+      }
+      return {
+        kind: 'work-context-state',
+        entityType: removal.workContextType,
+        entityId: removal.workContextId,
+        entityState: contextEntity,
+        order: {
+          scope: getReplayScope(
+            'work-context-tasks',
+            removal.workContextType,
+            removal.workContextId,
+          ),
+          position: Number.MAX_SAFE_INTEGER,
+        },
+      };
+    }
     if (!currentAnchor) {
       return { kind: 'superseded' };
     }
     return {
       kind: 'replay',
       operation: createRemovalReplay(operation, removal, currentAnchor.afterTaskId),
+      order: {
+        scope: getReplayScope(
+          'work-context-tasks',
+          removal.workContextType,
+          removal.workContextId,
+        ),
+        position: contextEntity.taskIds.indexOf(removal.taskId),
+      },
     };
   }
 

--- a/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
@@ -25,6 +25,7 @@ import { MAX_VECTOR_CLOCK_SIZE } from '../core/operation-log.const';
 import { StateSnapshotService } from '../backup/state-snapshot.service';
 import { OperationCaptureService } from '../capture/operation-capture.service';
 import { AppStateSnapshot } from '../core/types/backup.types';
+import { TODAY_TAG } from '../../features/tag/tag.const';
 
 describe('SupersededOperationResolverService', () => {
   let service: SupersededOperationResolverService;
@@ -1058,8 +1059,7 @@ describe('SupersededOperationResolverService', () => {
               ids: ['TODAY'],
               entities: {
                 TODAY: {
-                  id: 'TODAY',
-                  title: 'Today',
+                  ...TODAY_TAG,
                   taskIds: ['main-anchor', 'task-1'],
                 },
               },
@@ -1087,7 +1087,9 @@ describe('SupersededOperationResolverService', () => {
             { opId: op.id, op, existingClock: remoteOp.vectorClock },
           ]);
 
-          expect(result).toBe(1);
+          const needsLegacyWorkContextCompensation =
+            op.actionType === ActionType.SECTION_REMOVE_TASK;
+          expect(result).toBe(needsLegacyWorkContextCompensation ? 2 : 1);
           expectAtomicRejection([op.id]);
           expect(
             mockConflictResolutionService.getCurrentEntityState,
@@ -1122,6 +1124,20 @@ describe('SupersededOperationResolverService', () => {
             expect(replacement.payload).toEqual(op.payload);
           }
           expect(replacement.id).not.toBe(op.id);
+          if (needsLegacyWorkContextCompensation) {
+            expect(
+              mockOpLogStore.appendWithVectorClockOverwrite.calls.allArgs()[1][0],
+            ).toEqual(
+              jasmine.objectContaining({
+                actionType: '[TAG] LWW Update',
+                entityType: 'TAG',
+                entityId: 'TODAY',
+                payload: jasmine.objectContaining({
+                  taskIds: ['main-anchor', 'task-1'],
+                }),
+              }),
+            );
+          }
         });
       });
 
@@ -1414,8 +1430,12 @@ describe('SupersededOperationResolverService', () => {
         expect(replacementTaskIds).toEqual(['task-a', 'task-b', 'task-c']);
       });
 
-      it('should compose a later removal into one no-section replacement', async () => {
+      it('should compose a later removal into a fleet-compatible replacement pair', async () => {
         const localMoveOp = sectionOps[0].op;
+        const currentToday = {
+          ...TODAY_TAG,
+          taskIds: ['current-main-anchor', 'task-1'],
+        };
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
         mockOpLogStore.getOpsAfterSeq.and.resolveTo([
           {
@@ -1451,17 +1471,13 @@ describe('SupersededOperationResolverService', () => {
             tag: {
               ids: ['TODAY'],
               entities: {
-                TODAY: {
-                  id: 'TODAY',
-                  title: 'Today',
-                  taskIds: ['current-main-anchor', 'task-1'],
-                },
+                TODAY: currentToday,
               },
             },
           }),
         );
 
-        await service.resolveSupersededLocalOps([
+        const result = await service.resolveSupersededLocalOps([
           {
             opId: localMoveOp.id,
             op: localMoveOp,
@@ -1469,14 +1485,16 @@ describe('SupersededOperationResolverService', () => {
           },
         ]);
 
-        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
-          .args[0] as Operation;
-        expect(replacement.actionType).toBe(ActionType.SECTION_REMOVE_TASK);
-        expect(replacement.opType).toBe(OpType.Update);
-        expect(replacement.entityId).toBe('section-left');
-        expect(replacement.entityIds).toBeUndefined();
+        expect(result).toBe(2);
+        const replacements =
+          mockOpLogStore.appendWithVectorClockOverwrite.calls.allArgs();
+        const sectionReplacement = replacements[0][0] as Operation;
+        expect(sectionReplacement.actionType).toBe(ActionType.SECTION_REMOVE_TASK);
+        expect(sectionReplacement.opType).toBe(OpType.Update);
+        expect(sectionReplacement.entityId).toBe('section-left');
+        expect(sectionReplacement.entityIds).toBeUndefined();
         expect(
-          (replacement.payload as { actionPayload: Record<string, unknown> })
+          (sectionReplacement.payload as { actionPayload: Record<string, unknown> })
             .actionPayload,
         ).toEqual({
           sectionId: 'section-left',
@@ -1485,6 +1503,14 @@ describe('SupersededOperationResolverService', () => {
           workContextType: 'TAG',
           workContextAfterTaskId: 'current-main-anchor',
         });
+        expect(replacements[1][0]).toEqual(
+          jasmine.objectContaining({
+            actionType: '[TAG] LWW Update',
+            entityType: 'TAG',
+            entityId: 'TODAY',
+            payload: currentToday,
+          }),
+        );
       });
 
       it('should ignore an unrelated retained non-SECTION op for safe replay', async () => {
@@ -1661,8 +1687,7 @@ describe('SupersededOperationResolverService', () => {
           timestamp: 2500,
         };
         const currentToday = {
-          id: 'TODAY',
-          title: 'Today',
+          ...TODAY_TAG,
           taskIds: ['new-main-predecessor', 'task-1', 'main-anchor'],
         };
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({

--- a/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
@@ -12,7 +12,13 @@ import {
 import { LockService } from './lock.service';
 import { SnackService } from '../../core/snack/snack.service';
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
-import { ActionType, Operation, OpType, EntityType } from '../core/operation.types';
+import {
+  ActionType,
+  Operation,
+  OperationLogEntry,
+  OpType,
+  EntityType,
+} from '../core/operation.types';
 import { VectorClock } from '../../core/util/vector-clock';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
 import { MAX_VECTOR_CLOCK_SIZE } from '../core/operation-log.const';
@@ -52,6 +58,8 @@ describe('SupersededOperationResolverService', () => {
       'markRejected',
       'appendMixedSourceBatchSkipDuplicates',
       'appendWithVectorClockOverwrite',
+      'getOpsAfterSeq',
+      'getUnsynced',
     ]);
     mockVectorClockService = jasmine.createSpyObj('VectorClockService', [
       'getCurrentVectorClock',
@@ -72,6 +80,8 @@ describe('SupersededOperationResolverService', () => {
 
     // Default mocks
     mockVectorClockService.getCurrentVectorClock.and.returnValue(Promise.resolve({}));
+    mockOpLogStore.getOpsAfterSeq.and.resolveTo([]);
+    mockOpLogStore.getUnsynced.and.resolveTo([]);
     mockOpLogStore.markRejected.and.returnValue(Promise.resolve());
     mockOpLogStore.appendWithVectorClockOverwrite.and.returnValue(Promise.resolve(1));
     mockOpLogStore.appendMixedSourceBatchSkipDuplicates.and.callFake(async (batches) => {
@@ -799,6 +809,458 @@ describe('SupersededOperationResolverService', () => {
       expect(op1.id).not.toBe(op2.id);
       expect(op1.id).not.toBe('op-1'); // New ID, not reusing original
       expect(op2.id).not.toBe('op-2');
+    });
+
+    describe('section placement operation handling', () => {
+      const remoteMoveOp: Operation = {
+        id: 'remote-section-move',
+        actionType: ActionType.SECTION_ADD_TASK,
+        opType: OpType.Move,
+        entityType: 'SECTION',
+        entityId: 'section-left',
+        entityIds: ['section-left', 'section-right'],
+        payload: {
+          actionPayload: {
+            sectionId: 'section-right',
+            taskId: 'task-1',
+            afterTaskId: 'right-anchor',
+            sourceSectionId: 'section-left',
+          },
+          entityChanges: [],
+        },
+        clientId: 'remote-client',
+        vectorClock: { remote: 4 },
+        timestamp: 900,
+        schemaVersion: 1,
+      };
+      const remoteRemoveOp: Operation = {
+        id: 'remote-section-remove',
+        actionType: ActionType.SECTION_REMOVE_TASK,
+        opType: OpType.Update,
+        entityType: 'SECTION',
+        entityId: 'section-left',
+        payload: {
+          actionPayload: {
+            sectionId: 'section-left',
+            taskId: 'task-1',
+            workContextId: 'TODAY',
+            workContextType: 'TAG',
+            workContextAfterTaskId: 'main-anchor',
+          },
+          entityChanges: [],
+        },
+        clientId: 'remote-client',
+        vectorClock: { remote: 4 },
+        timestamp: 900,
+        schemaVersion: 1,
+      };
+      const remoteOrderOp: Operation = {
+        id: 'remote-section-order',
+        actionType: ActionType.SECTION_UPDATE_ORDER,
+        opType: OpType.Move,
+        entityType: 'SECTION',
+        entityId: 'section-right',
+        entityIds: ['section-right', 'section-left'],
+        payload: {
+          actionPayload: {
+            contextId: 'TODAY',
+            ids: ['section-right', 'section-left'],
+          },
+          entityChanges: [],
+        },
+        clientId: 'remote-client',
+        vectorClock: { remote: 4 },
+        timestamp: 900,
+        schemaVersion: 1,
+      };
+      const asPendingEntries = (...ops: Operation[]): OperationLogEntry[] =>
+        ops.map((op, index) => ({
+          seq: index + 1,
+          op,
+          appliedAt: index + 1,
+          source: 'local',
+        }));
+      const sectionOps: Array<{
+        description: string;
+        op: Operation;
+        remoteOp: Operation;
+      }> = [
+        {
+          description: 'cross-section move',
+          op: {
+            id: 'op-section-move',
+            actionType: ActionType.SECTION_ADD_TASK,
+            opType: OpType.Move,
+            entityType: 'SECTION',
+            entityId: 'section-left',
+            entityIds: ['section-left', 'section-right'],
+            payload: {
+              actionPayload: {
+                sectionId: 'section-right',
+                taskId: 'task-1',
+                afterTaskId: 'right-anchor',
+                sourceSectionId: 'section-left',
+              },
+              entityChanges: [],
+            },
+            clientId: 'original-client',
+            vectorClock: { original: 3 },
+            timestamp: 1000,
+            schemaVersion: 1,
+          },
+          remoteOp: remoteRemoveOp,
+        },
+        {
+          description: 'section removal with work-context reorder',
+          op: {
+            id: 'op-section-remove',
+            actionType: ActionType.SECTION_REMOVE_TASK,
+            opType: OpType.Update,
+            entityType: 'SECTION',
+            entityId: 'section-left',
+            payload: {
+              actionPayload: {
+                sectionId: 'section-left',
+                taskId: 'task-1',
+                workContextId: 'TODAY',
+                workContextType: 'TAG',
+                workContextAfterTaskId: 'main-anchor',
+              },
+              entityChanges: [],
+            },
+            clientId: 'original-client',
+            vectorClock: { original: 3 },
+            timestamp: 2000,
+            schemaVersion: 1,
+          },
+          remoteOp: remoteMoveOp,
+        },
+        {
+          description: 'section order',
+          op: {
+            id: 'op-section-order',
+            actionType: ActionType.SECTION_UPDATE_ORDER,
+            opType: OpType.Move,
+            entityType: 'SECTION',
+            entityId: 'section-right',
+            entityIds: ['section-right', 'section-left'],
+            payload: {
+              actionPayload: {
+                contextId: 'TODAY',
+                ids: ['section-right', 'section-left'],
+              },
+              entityChanges: [],
+            },
+            clientId: 'original-client',
+            vectorClock: { original: 4 },
+            timestamp: 3000,
+            schemaVersion: 1,
+          },
+          remoteOp: remoteMoveOp,
+        },
+        {
+          description: 'cross-section move rejected behind section order',
+          op: {
+            ...remoteMoveOp,
+            id: 'op-section-move-behind-order',
+            clientId: 'original-client',
+            vectorClock: { original: 3 },
+            timestamp: 4000,
+          },
+          remoteOp: remoteOrderOp,
+        },
+      ];
+      const newPendingRemoveOp: Operation = {
+        ...remoteRemoveOp,
+        id: 'new-pending-section-remove',
+        entityId: 'section-other',
+        payload: {
+          actionPayload: {
+            sectionId: 'section-other',
+            taskId: 'task-2',
+            workContextId: 'TODAY',
+            workContextType: 'TAG',
+            workContextAfterTaskId: 'main-anchor',
+          },
+          entityChanges: [],
+        },
+        clientId: 'original-client',
+        vectorClock: { original: 4 },
+        timestamp: 5000,
+      };
+
+      sectionOps.forEach(({ description, op, remoteOp }) => {
+        it(`should causally re-create a superseded ${description}`, async () => {
+          mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+          mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+            {
+              seq: 1,
+              op: remoteOp,
+              appliedAt: 1,
+              source: 'remote',
+              syncedAt: 1,
+              applicationStatus: 'applied',
+            },
+          ]);
+          mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(op));
+
+          const result = await service.resolveSupersededLocalOps([
+            { opId: op.id, op, existingClock: remoteOp.vectorClock },
+          ]);
+
+          expect(result).toBe(1);
+          expect(mockOpLogStore.markRejected).toHaveBeenCalledWith([op.id]);
+          expect(
+            mockConflictResolutionService.getCurrentEntityState,
+          ).not.toHaveBeenCalled();
+          const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+            .args[0] as Operation;
+          expect(replacement).toEqual({
+            ...op,
+            id: jasmine.any(String),
+            clientId: TEST_CLIENT_ID,
+            entityIds: op.entityIds,
+            vectorClock: {
+              ...op.vectorClock,
+              remote: 4,
+              [TEST_CLIENT_ID]: 1,
+            },
+            schemaVersion: CURRENT_SCHEMA_VERSION,
+          });
+          expect(replacement.id).not.toBe(op.id);
+        });
+      });
+
+      it('should keep the LWW fallback when the retained SECTION op does not commute', async () => {
+        const localRemoveOp = sectionOps[1].op;
+        const nonCommutingMove: Operation = {
+          ...remoteMoveOp,
+          payload: {
+            actionPayload: {
+              sectionId: 'section-right',
+              taskId: 'different-task',
+              afterTaskId: 'right-anchor',
+              sourceSectionId: 'section-left',
+            },
+            entityChanges: [],
+          },
+        };
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(localRemoveOp));
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: nonCommutingMove,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockConflictResolutionService.getCurrentEntityState.and.resolveTo({
+          id: 'section-left',
+          taskIds: [],
+        });
+
+        await service.resolveSupersededLocalOps([
+          {
+            opId: localRemoveOp.id,
+            op: localRemoveOp,
+            existingClock: nonCommutingMove.vectorClock,
+          },
+        ]);
+
+        expect(mockConflictResolutionService.getCurrentEntityState).toHaveBeenCalled();
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).not.toBe(ActionType.SECTION_REMOVE_TASK);
+      });
+
+      it('should keep the LWW fallback when multiple retained ops share the conflict clock', async () => {
+        const localMoveOp = sectionOps[0].op;
+        const ambiguousRemoteOp: Operation = {
+          ...remoteRemoveOp,
+          id: 'ambiguous-remote-section-remove',
+          payload: {
+            actionPayload: {
+              sectionId: 'section-left',
+              taskId: 'different-task',
+              workContextId: 'TODAY',
+              workContextType: 'TAG',
+              workContextAfterTaskId: 'main-anchor',
+            },
+            entityChanges: [],
+          },
+        };
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(localMoveOp));
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteRemoveOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+          {
+            seq: 2,
+            op: ambiguousRemoteOp,
+            appliedAt: 2,
+            source: 'local',
+            syncedAt: 2,
+            rejectedAt: 3,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockConflictResolutionService.getCurrentEntityState.and.resolveTo({
+          id: 'section-left',
+          taskIds: [],
+        });
+
+        await service.resolveSupersededLocalOps([
+          {
+            opId: localMoveOp.id,
+            op: localMoveOp,
+            existingClock: remoteRemoveOp.vectorClock,
+          },
+        ]);
+
+        expect(mockConflictResolutionService.getCurrentEntityState).toHaveBeenCalled();
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).not.toBe(ActionType.SECTION_ADD_TASK);
+      });
+
+      it('should defer instead of using LWW when a new pending op appeared before resolution', async () => {
+        const localMoveOp = sectionOps[0].op;
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getUnsynced.and.resolveTo(
+          asPendingEntries(localMoveOp, newPendingRemoveOp),
+        );
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteRemoveOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockConflictResolutionService.getCurrentEntityState.and.resolveTo({
+          id: 'section-left',
+          taskIds: [],
+        });
+
+        const supersededMove = {
+          opId: localMoveOp.id,
+          op: localMoveOp,
+          existingClock: remoteRemoveOp.vectorClock,
+        };
+        await expectAsync(
+          service.resolveSupersededLocalOps([supersededMove]),
+        ).toBeRejectedWithError(/Deferring causal SECTION replay/);
+        expect(mockOpLogStore.markRejected).not.toHaveBeenCalled();
+        expect(mockOpLogStore.appendWithVectorClockOverwrite).not.toHaveBeenCalled();
+
+        mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(localMoveOp));
+        const result = await service.resolveSupersededLocalOps([supersededMove]);
+
+        expect(result).toBe(1);
+        expect(
+          mockConflictResolutionService.getCurrentEntityState,
+        ).not.toHaveBeenCalled();
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).toBe(ActionType.SECTION_ADD_TASK);
+      });
+
+      it('should resolve another rejected op before deferring the SECTION replay', async () => {
+        const localMoveOp = sectionOps[0].op;
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getUnsynced.and.resolveTo(
+          asPendingEntries(localMoveOp, newPendingRemoveOp),
+        );
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteRemoveOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockConflictResolutionService.getCurrentEntityState.and.resolveTo({
+          id: 'section-other',
+          taskIds: [],
+        });
+
+        await expectAsync(
+          service.resolveSupersededLocalOps([
+            {
+              opId: localMoveOp.id,
+              op: localMoveOp,
+              existingClock: remoteRemoveOp.vectorClock,
+            },
+            {
+              opId: newPendingRemoveOp.id,
+              op: newPendingRemoveOp,
+              existingClock: remoteRemoveOp.vectorClock,
+            },
+          ]),
+        ).toBeRejectedWithError(/Deferring causal SECTION replay/);
+
+        expect(mockOpLogStore.markRejected).toHaveBeenCalledOnceWith([
+          newPendingRemoveOp.id,
+        ]);
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).not.toBe(ActionType.SECTION_REMOVE_TASK);
+      });
+
+      [
+        { description: 'causally older', vectorClock: { remote: 3 } },
+        { description: 'equal-clock', vectorClock: { remote: 4 } },
+      ].forEach(({ description, vectorClock }) => {
+        it(`should keep the LWW fallback for a ${description} SECTION op`, async () => {
+          const localMoveOp: Operation = {
+            ...sectionOps[0].op,
+            id: `op-section-move-${description}`,
+            vectorClock,
+          };
+          mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+          mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(localMoveOp));
+          mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+            {
+              seq: 1,
+              op: remoteRemoveOp,
+              appliedAt: 1,
+              source: 'remote',
+              syncedAt: 1,
+              applicationStatus: 'applied',
+            },
+          ]);
+          mockConflictResolutionService.getCurrentEntityState.and.resolveTo({
+            id: 'section-left',
+            taskIds: [],
+          });
+
+          await service.resolveSupersededLocalOps([
+            {
+              opId: localMoveOp.id,
+              op: localMoveOp,
+              existingClock: remoteRemoveOp.vectorClock,
+            },
+          ]);
+
+          expect(mockConflictResolutionService.getCurrentEntityState).toHaveBeenCalled();
+          const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+            .args[0] as Operation;
+          expect(replacement.actionType).not.toBe(ActionType.SECTION_ADD_TASK);
+        });
+      });
     });
 
     describe('moveToArchive operation handling', () => {

--- a/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
@@ -22,6 +22,9 @@ import {
 import { VectorClock } from '../../core/util/vector-clock';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
 import { MAX_VECTOR_CLOCK_SIZE } from '../core/operation-log.const';
+import { StateSnapshotService } from '../backup/state-snapshot.service';
+import { OperationCaptureService } from '../capture/operation-capture.service';
+import { AppStateSnapshot } from '../core/types/backup.types';
 
 describe('SupersededOperationResolverService', () => {
   let service: SupersededOperationResolverService;
@@ -31,8 +34,27 @@ describe('SupersededOperationResolverService', () => {
   let mockLockService: jasmine.SpyObj<LockService>;
   let mockSnackService: jasmine.SpyObj<SnackService>;
   let mockClientIdProvider: { loadClientId: jasmine.Spy };
+  let mockStateSnapshotService: jasmine.SpyObj<StateSnapshotService>;
+  let mockOperationCapture: jasmine.SpyObj<OperationCaptureService>;
 
   const TEST_CLIENT_ID = 'test-client-123';
+
+  const createReplaySnapshot = (
+    overrides: Partial<AppStateSnapshot> = {},
+  ): AppStateSnapshot =>
+    ({
+      section: { ids: [], entities: {} },
+      project: { ids: [], entities: {} },
+      tag: { ids: [], entities: {} },
+      ...overrides,
+    }) as AppStateSnapshot;
+
+  const expectAtomicRejection = (opIds: readonly string[]): void => {
+    expect(
+      mockOpLogStore.appendMixedSourceBatchSkipDuplicates.calls.mostRecent().args[1],
+    ).toEqual({ rejectOpIds: opIds });
+    expect(mockOpLogStore.markRejected).not.toHaveBeenCalled();
+  };
 
   const createMockOperation = (
     id: string,
@@ -77,12 +99,24 @@ describe('SupersededOperationResolverService', () => {
         .createSpy('loadClientId')
         .and.returnValue(Promise.resolve(TEST_CLIENT_ID)),
     };
+    mockStateSnapshotService = jasmine.createSpyObj('StateSnapshotService', [
+      'getStateSnapshotForOperationLog',
+    ]);
+    mockOperationCapture = jasmine.createSpyObj('OperationCaptureService', [
+      'hasUnrecoveredPersistFailure',
+      'getPendingCount',
+    ]);
 
     // Default mocks
     mockVectorClockService.getCurrentVectorClock.and.returnValue(Promise.resolve({}));
     mockOpLogStore.getOpsAfterSeq.and.resolveTo([]);
     mockOpLogStore.getUnsynced.and.resolveTo([]);
     mockOpLogStore.markRejected.and.returnValue(Promise.resolve());
+    mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+      createReplaySnapshot(),
+    );
+    mockOperationCapture.hasUnrecoveredPersistFailure.and.returnValue(false);
+    mockOperationCapture.getPendingCount.and.returnValue(0);
     mockOpLogStore.appendWithVectorClockOverwrite.and.returnValue(Promise.resolve(1));
     mockOpLogStore.appendMixedSourceBatchSkipDuplicates.and.callFake(async (batches) => {
       const written: MixedSourceWrittenOperation[] = [];
@@ -147,6 +181,8 @@ describe('SupersededOperationResolverService', () => {
         { provide: LockService, useValue: mockLockService },
         { provide: SnackService, useValue: mockSnackService },
         { provide: CLIENT_ID_PROVIDER, useValue: mockClientIdProvider },
+        { provide: StateSnapshotService, useValue: mockStateSnapshotService },
+        { provide: OperationCaptureService, useValue: mockOperationCapture },
       ],
     });
 
@@ -191,13 +227,23 @@ describe('SupersededOperationResolverService', () => {
           return result;
         },
       );
-      mockOpLogStore.markRejected.and.callFake(async () => {
-        callOrder.push('markRejected');
-      });
       mockOpLogStore.appendWithVectorClockOverwrite.and.callFake(async () => {
         callOrder.push('appendWithVectorClockOverwrite');
         return 1;
       });
+      mockOpLogStore.appendMixedSourceBatchSkipDuplicates.and.callFake(
+        async (batches) => {
+          const written: MixedSourceWrittenOperation[] = [];
+          for (const batch of batches) {
+            for (const op of batch.ops) {
+              await mockOpLogStore.appendWithVectorClockOverwrite(op, batch.source);
+              written.push({ seq: written.length + 1, op, source: batch.source });
+            }
+          }
+          callOrder.push('atomicCommit');
+          return { written, skippedCount: 0 };
+        },
+      );
 
       await service.resolveSupersededLocalOps([{ opId: 'op-1', op: supersededOp }]);
 
@@ -205,9 +251,10 @@ describe('SupersededOperationResolverService', () => {
       expect(callOrder).toEqual([
         'lock-start',
         'appendWithVectorClockOverwrite',
-        'markRejected',
+        'atomicCommit',
         'lock-end',
       ]);
+      expectAtomicRejection(['op-1']);
     });
 
     it('keeps superseded rows retryable when the replacement batch fails', async () => {
@@ -295,7 +342,7 @@ describe('SupersededOperationResolverService', () => {
       ]);
 
       expect(result).toBe(1);
-      expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1']);
+      expectAtomicRejection(['op-1']);
       expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(1);
 
       const appendedOp = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
@@ -521,7 +568,7 @@ describe('SupersededOperationResolverService', () => {
       ]);
 
       expect(result).toBe(1); // Only ONE new op for all 3 superseded ops
-      expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1', 'op-2', 'op-3']);
+      expectAtomicRejection(['op-1', 'op-2', 'op-3']);
       expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(1);
 
       const appendedOp = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
@@ -560,7 +607,7 @@ describe('SupersededOperationResolverService', () => {
       ]);
 
       expect(result).toBe(2);
-      expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1', 'op-2']);
+      expectAtomicRejection(['op-1', 'op-2']);
       expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(2);
     });
 
@@ -579,7 +626,7 @@ describe('SupersededOperationResolverService', () => {
       ]);
 
       expect(result).toBe(0);
-      expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1']);
+      expectAtomicRejection(['op-1']);
       expect(mockOpLogStore.appendWithVectorClockOverwrite).not.toHaveBeenCalled();
       // Should notify user that local changes were discarded
       expect(mockSnackService.open).toHaveBeenCalledOnceWith(
@@ -767,7 +814,7 @@ describe('SupersededOperationResolverService', () => {
       ]);
 
       expect(result).toBe(2); // Only 2 new ops (for existing entities)
-      expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1', 'op-2', 'op-3']); // All 3 rejected
+      expectAtomicRejection(['op-1', 'op-2', 'op-3']); // All 3 rejected
       expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(2);
     });
 
@@ -970,24 +1017,6 @@ describe('SupersededOperationResolverService', () => {
           remoteOp: remoteOrderOp,
         },
       ];
-      const newPendingRemoveOp: Operation = {
-        ...remoteRemoveOp,
-        id: 'new-pending-section-remove',
-        entityId: 'section-other',
-        payload: {
-          actionPayload: {
-            sectionId: 'section-other',
-            taskId: 'task-2',
-            workContextId: 'TODAY',
-            workContextType: 'TAG',
-            workContextAfterTaskId: 'main-anchor',
-          },
-          entityChanges: [],
-        },
-        clientId: 'original-client',
-        vectorClock: { original: 4 },
-        timestamp: 5000,
-      };
       const unrelatedPendingTaskOp = createMockOperation(
         'unrelated-pending-task',
         'TASK',
@@ -995,6 +1024,49 @@ describe('SupersededOperationResolverService', () => {
         { original: 4 },
         5000,
       );
+
+      beforeEach(() => {
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-right', 'section-left', 'section-third'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['right-anchor', 'task-1'],
+                },
+                ['section-third']: {
+                  id: 'section-third',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Third',
+                  taskIds: [],
+                },
+              },
+            },
+            tag: {
+              ids: ['TODAY'],
+              entities: {
+                TODAY: {
+                  id: 'TODAY',
+                  title: 'Today',
+                  taskIds: ['main-anchor', 'task-1'],
+                },
+              },
+            },
+          }),
+        );
+      });
 
       sectionOps.forEach(({ description, op, remoteOp }) => {
         it(`should causally re-create a superseded ${description}`, async () => {
@@ -1016,24 +1088,39 @@ describe('SupersededOperationResolverService', () => {
           ]);
 
           expect(result).toBe(1);
-          expect(mockOpLogStore.markRejected).toHaveBeenCalledWith([op.id]);
+          expectAtomicRejection([op.id]);
           expect(
             mockConflictResolutionService.getCurrentEntityState,
           ).not.toHaveBeenCalled();
           const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
             .args[0] as Operation;
-          expect(replacement).toEqual({
-            ...op,
-            id: jasmine.any(String),
-            clientId: TEST_CLIENT_ID,
-            entityIds: op.entityIds,
-            vectorClock: {
-              ...op.vectorClock,
-              remote: 4,
-              [TEST_CLIENT_ID]: 1,
-            },
-            schemaVersion: CURRENT_SCHEMA_VERSION,
-          });
+          expect(replacement).toEqual(
+            jasmine.objectContaining({
+              actionType: op.actionType,
+              id: jasmine.any(String),
+              clientId: TEST_CLIENT_ID,
+              vectorClock: {
+                ...op.vectorClock,
+                remote: 4,
+                [TEST_CLIENT_ID]: 1,
+              },
+              schemaVersion: CURRENT_SCHEMA_VERSION,
+            }),
+          );
+          if (op.actionType === ActionType.SECTION_UPDATE_ORDER) {
+            expect(replacement.entityIds).toEqual([
+              'section-right',
+              'section-left',
+              'section-third',
+            ]);
+            expect(
+              (replacement.payload as { actionPayload: Record<string, unknown> })
+                .actionPayload['ids'],
+            ).toEqual(['section-right', 'section-left', 'section-third']);
+          } else {
+            expect(replacement.entityIds).toEqual(op.entityIds);
+            expect(replacement.payload).toEqual(op.payload);
+          }
           expect(replacement.id).not.toBe(op.id);
         });
       });
@@ -1139,7 +1226,7 @@ describe('SupersededOperationResolverService', () => {
         expect(replacement.actionType).not.toBe(ActionType.SECTION_ADD_TASK);
       });
 
-      it('should defer an older move when a later overlapping move is already synced', async () => {
+      it('should compose an older move with a later synced move instead of deferring forever', async () => {
         const localMoveOp = sectionOps[0].op;
         const laterOverlappingMoveOp: Operation = {
           ...localMoveOp,
@@ -1162,7 +1249,6 @@ describe('SupersededOperationResolverService', () => {
           original: 4,
           remote: 4,
         });
-        mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(localMoveOp));
         mockOpLogStore.getOpsAfterSeq.and.resolveTo([
           {
             seq: 1,
@@ -1186,26 +1272,138 @@ describe('SupersededOperationResolverService', () => {
             applicationStatus: 'applied',
           },
         ]);
-
-        await expectAsync(
-          service.resolveSupersededLocalOps([
-            {
-              opId: localMoveOp.id,
-              op: localMoveOp,
-              existingClock: remoteRemoveOp.vectorClock,
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-right', 'section-left', 'section-third'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['right-anchor'],
+                },
+                ['section-third']: {
+                  id: 'section-third',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Third',
+                  taskIds: ['third-anchor', 'task-1'],
+                },
+              },
             },
-          ]),
-        ).toBeRejectedWithError(/Deferring causal SECTION replay/);
-        expect(mockOpLogStore.markRejected).not.toHaveBeenCalled();
-        expect(mockOpLogStore.appendWithVectorClockOverwrite).not.toHaveBeenCalled();
+          }),
+        );
+
+        const result = await service.resolveSupersededLocalOps([
+          {
+            opId: localMoveOp.id,
+            op: localMoveOp,
+            existingClock: remoteRemoveOp.vectorClock,
+          },
+        ]);
+
+        expect(result).toBe(1);
+        expectAtomicRejection([localMoveOp.id]);
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.entityId).toBe('section-left');
+        expect(replacement.entityIds).toEqual(['section-left', 'section-third']);
+        expect(
+          (replacement.payload as { actionPayload: Record<string, unknown> })
+            .actionPayload,
+        ).toEqual({
+          sectionId: 'section-third',
+          taskId: 'task-1',
+          afterTaskId: 'third-anchor',
+          sourceSectionId: 'section-left',
+        });
       });
 
-      it('should ignore an unrelated pending non-SECTION op for safe replay', async () => {
+      it('should compose a later removal into one no-section replacement', async () => {
         const localMoveOp = sectionOps[0].op;
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
-        mockOpLogStore.getUnsynced.and.resolveTo(
-          asPendingEntries(localMoveOp, unrelatedPendingTaskOp),
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteOrderOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-left', 'section-right'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['right-anchor'],
+                },
+              },
+            },
+            tag: {
+              ids: ['TODAY'],
+              entities: {
+                TODAY: {
+                  id: 'TODAY',
+                  title: 'Today',
+                  taskIds: ['current-main-anchor', 'task-1'],
+                },
+              },
+            },
+          }),
         );
+
+        await service.resolveSupersededLocalOps([
+          {
+            opId: localMoveOp.id,
+            op: localMoveOp,
+            existingClock: remoteOrderOp.vectorClock,
+          },
+        ]);
+
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).toBe(ActionType.SECTION_REMOVE_TASK);
+        expect(replacement.opType).toBe(OpType.Update);
+        expect(replacement.entityId).toBe('section-left');
+        expect(replacement.entityIds).toBeUndefined();
+        expect(
+          (replacement.payload as { actionPayload: Record<string, unknown> })
+            .actionPayload,
+        ).toEqual({
+          sectionId: 'section-left',
+          taskId: 'task-1',
+          workContextId: 'TODAY',
+          workContextType: 'TAG',
+          workContextAfterTaskId: 'current-main-anchor',
+        });
+      });
+
+      it('should ignore an unrelated retained non-SECTION op for safe replay', async () => {
+        const localMoveOp = sectionOps[0].op;
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
         mockOpLogStore.getOpsAfterSeq.and.resolveTo([
           {
             seq: 1,
@@ -1213,6 +1411,14 @@ describe('SupersededOperationResolverService', () => {
             appliedAt: 1,
             source: 'remote',
             syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+          {
+            seq: 2,
+            op: unrelatedPendingTaskOp,
+            appliedAt: 2,
+            source: 'local',
+            syncedAt: 2,
             applicationStatus: 'applied',
           },
         ]);
@@ -1226,18 +1432,15 @@ describe('SupersededOperationResolverService', () => {
         ]);
 
         expect(result).toBe(1);
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledOnceWith([localMoveOp.id]);
+        expectAtomicRejection([localMoveOp.id]);
         const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
           .args[0] as Operation;
         expect(replacement.actionType).toBe(ActionType.SECTION_ADD_TASK);
       });
 
-      it('should defer instead of using LWW when a new pending op appeared before resolution', async () => {
+      it('should replace a deleted section anchor with the current predecessor', async () => {
         const localMoveOp = sectionOps[0].op;
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
-        mockOpLogStore.getUnsynced.and.resolveTo(
-          asPendingEntries(localMoveOp, newPendingRemoveOp),
-        );
         mockOpLogStore.getOpsAfterSeq.and.resolveTo([
           {
             seq: 1,
@@ -1248,40 +1451,113 @@ describe('SupersededOperationResolverService', () => {
             applicationStatus: 'applied',
           },
         ]);
-        mockConflictResolutionService.getCurrentEntityState.and.resolveTo({
-          id: 'section-left',
-          taskIds: [],
-        });
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-left', 'section-right'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['new-predecessor', 'task-1', 'tail'],
+                },
+              },
+            },
+          }),
+        );
 
-        const supersededMove = {
-          opId: localMoveOp.id,
-          op: localMoveOp,
-          existingClock: remoteRemoveOp.vectorClock,
-        };
-        await expectAsync(
-          service.resolveSupersededLocalOps([supersededMove]),
-        ).toBeRejectedWithError(/Deferring causal SECTION replay/);
-        expect(mockOpLogStore.markRejected).not.toHaveBeenCalled();
-        expect(mockOpLogStore.appendWithVectorClockOverwrite).not.toHaveBeenCalled();
-
-        mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(localMoveOp));
-        const result = await service.resolveSupersededLocalOps([supersededMove]);
+        const result = await service.resolveSupersededLocalOps([
+          {
+            opId: localMoveOp.id,
+            op: localMoveOp,
+            existingClock: remoteRemoveOp.vectorClock,
+          },
+        ]);
 
         expect(result).toBe(1);
-        expect(
-          mockConflictResolutionService.getCurrentEntityState,
-        ).not.toHaveBeenCalled();
         const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
           .args[0] as Operation;
-        expect(replacement.actionType).toBe(ActionType.SECTION_ADD_TASK);
+        expect(
+          (replacement.payload as { actionPayload: Record<string, unknown> })
+            .actionPayload['afterTaskId'],
+        ).toBe('new-predecessor');
       });
 
-      it('should resolve another rejected op before deferring the SECTION replay', async () => {
+      it('should replace a moved work-context anchor with the current predecessor', async () => {
+        const localRemoveOp = sectionOps[1].op;
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteMoveOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-left', 'section-right'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['right-anchor', 'task-1'],
+                },
+              },
+            },
+            tag: {
+              ids: ['TODAY'],
+              entities: {
+                TODAY: {
+                  id: 'TODAY',
+                  title: 'Today',
+                  taskIds: ['new-main-predecessor', 'task-1', 'main-anchor'],
+                },
+              },
+            },
+          }),
+        );
+
+        await service.resolveSupersededLocalOps([
+          {
+            opId: localRemoveOp.id,
+            op: localRemoveOp,
+            existingClock: remoteMoveOp.vectorClock,
+          },
+        ]);
+
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(
+          (replacement.payload as { actionPayload: Record<string, unknown> })
+            .actionPayload['workContextAfterTaskId'],
+        ).toBe('new-main-predecessor');
+      });
+
+      it('should leave the predecessor retryable when live state is ahead of durable capture', async () => {
         const localMoveOp = sectionOps[0].op;
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
-        mockOpLogStore.getUnsynced.and.resolveTo(
-          asPendingEntries(localMoveOp, newPendingRemoveOp),
-        );
         mockOpLogStore.getOpsAfterSeq.and.resolveTo([
           {
             seq: 1,
@@ -1292,10 +1568,7 @@ describe('SupersededOperationResolverService', () => {
             applicationStatus: 'applied',
           },
         ]);
-        mockConflictResolutionService.getCurrentEntityState.and.resolveTo({
-          id: 'section-other',
-          taskIds: [],
-        });
+        mockOperationCapture.getPendingCount.and.returnValue(1);
 
         await expectAsync(
           service.resolveSupersededLocalOps([
@@ -1304,20 +1577,15 @@ describe('SupersededOperationResolverService', () => {
               op: localMoveOp,
               existingClock: remoteRemoveOp.vectorClock,
             },
-            {
-              opId: newPendingRemoveOp.id,
-              op: newPendingRemoveOp,
-              existingClock: remoteRemoveOp.vectorClock,
-            },
           ]),
-        ).toBeRejectedWithError(/Deferring causal SECTION replay/);
+        ).toBeRejectedWithError(/captured actions are still awaiting persistence/);
 
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledOnceWith([
-          newPendingRemoveOp.id,
-        ]);
-        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
-          .args[0] as Operation;
-        expect(replacement.actionType).not.toBe(ActionType.SECTION_REMOVE_TASK);
+        expect(
+          mockStateSnapshotService.getStateSnapshotForOperationLog,
+        ).not.toHaveBeenCalled();
+        expect(
+          mockOpLogStore.appendMixedSourceBatchSkipDuplicates,
+        ).not.toHaveBeenCalled();
       });
 
       [
@@ -1405,7 +1673,7 @@ describe('SupersededOperationResolverService', () => {
         ]);
 
         expect(result).toBe(1);
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-archive-1']);
+        expectAtomicRejection(['op-archive-1']);
         expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(1);
 
         const appendedOp = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
@@ -1539,10 +1807,7 @@ describe('SupersededOperationResolverService', () => {
         ]);
 
         expect(result).toBe(2);
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledWith([
-          'op-archive',
-          'op-regular',
-        ]);
+        expectAtomicRejection(['op-archive', 'op-regular']);
         expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(2);
 
         const calls = mockOpLogStore.appendWithVectorClockOverwrite.calls.all();
@@ -1648,10 +1913,7 @@ describe('SupersededOperationResolverService', () => {
         ]);
 
         expect(result).toBe(2);
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledWith([
-          'op-archive-1',
-          'op-archive-2',
-        ]);
+        expectAtomicRejection(['op-archive-1', 'op-archive-2']);
         expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(2);
 
         const calls = mockOpLogStore.appendWithVectorClockOverwrite.calls.all();
@@ -1707,7 +1969,7 @@ describe('SupersededOperationResolverService', () => {
         ]);
 
         expect(result).toBe(1);
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1']);
+        expectAtomicRejection(['op-1']);
         expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(1);
 
         const appendedOp = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
@@ -1751,7 +2013,7 @@ describe('SupersededOperationResolverService', () => {
         ]);
 
         expect(result).toBe(1); // Only ONE new op for both superseded DELETE ops
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1', 'op-2']);
+        expectAtomicRejection(['op-1', 'op-2']);
         expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(1);
 
         const appendedOp = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
@@ -1842,7 +2104,7 @@ describe('SupersededOperationResolverService', () => {
         ]);
 
         expect(result).toBe(2); // One DELETE op + one UPDATE op
-        expect(mockOpLogStore.markRejected).toHaveBeenCalledWith(['op-1', 'op-2']);
+        expectAtomicRejection(['op-1', 'op-2']);
         expect(mockOpLogStore.appendWithVectorClockOverwrite).toHaveBeenCalledTimes(2);
 
         const calls = mockOpLogStore.appendWithVectorClockOverwrite.calls.all();

--- a/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
@@ -1328,6 +1328,92 @@ describe('SupersededOperationResolverService', () => {
         });
       });
 
+      it('should persist projected placements in current predecessor order', async () => {
+        const createPlacement = (
+          taskId: string,
+          afterTaskId: string,
+          counter: number,
+        ): Operation => ({
+          ...sectionOps[0].op,
+          id: `place-${taskId}`,
+          entityId: 'section-right',
+          entityIds: undefined,
+          payload: {
+            actionPayload: {
+              sectionId: 'section-right',
+              taskId,
+              afterTaskId,
+              sourceSectionId: null,
+            },
+            entityChanges: [],
+          },
+          vectorClock: { original: counter },
+          timestamp: 1000 + counter,
+        });
+        const placeC = createPlacement('task-c', 'base-task', 1);
+        const placeB = createPlacement('task-b', 'base-task', 2);
+        const placeA = createPlacement('task-a', 'base-task', 3);
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({
+          original: 3,
+          remote: 4,
+        });
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteOrderOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-right', 'section-left'],
+              entities: {
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['base-task', 'task-a', 'task-b', 'task-c'],
+                },
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: [],
+                },
+              },
+            },
+          }),
+        );
+
+        const result = await service.resolveSupersededLocalOps(
+          [placeC, placeB, placeA].map((op) => ({
+            opId: op.id,
+            op,
+            existingClock: remoteOrderOp.vectorClock,
+          })),
+        );
+
+        expect(result).toBe(3);
+        expectAtomicRejection([placeC.id, placeB.id, placeA.id]);
+        const replacementTaskIds = mockOpLogStore.appendWithVectorClockOverwrite.calls
+          .all()
+          .map(
+            ({ args }) =>
+              (
+                args[0].payload as {
+                  actionPayload: { taskId: string };
+                }
+              ).actionPayload.taskId,
+          );
+        expect(replacementTaskIds).toEqual(['task-a', 'task-b', 'task-c']);
+      });
+
       it('should compose a later removal into one no-section replacement', async () => {
         const localMoveOp = sectionOps[0].op;
         mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
@@ -1553,6 +1639,261 @@ describe('SupersededOperationResolverService', () => {
           (replacement.payload as { actionPayload: Record<string, unknown> })
             .actionPayload['workContextAfterTaskId'],
         ).toBe('new-main-predecessor');
+      });
+
+      it('should preserve the work-context reorder when a later action re-adds the task to its source section', async () => {
+        const localRemoveOp = sectionOps[1].op;
+        const laterReAddOp: Operation = {
+          ...sectionOps[0].op,
+          id: 'later-re-add-to-source',
+          entityId: 'section-left',
+          entityIds: undefined,
+          payload: {
+            actionPayload: {
+              sectionId: 'section-left',
+              taskId: 'task-1',
+              afterTaskId: 'left-anchor',
+              sourceSectionId: null,
+            },
+            entityChanges: [],
+          },
+          vectorClock: { original: 4 },
+          timestamp: 2500,
+        };
+        const currentToday = {
+          id: 'TODAY',
+          title: 'Today',
+          taskIds: ['new-main-predecessor', 'task-1', 'main-anchor'],
+        };
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({
+          original: 4,
+          remote: 4,
+        });
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteOrderOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+          {
+            seq: 2,
+            op: laterReAddOp,
+            appliedAt: 2,
+            source: 'local',
+            syncedAt: 2,
+          },
+        ]);
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-left', 'section-right'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor', 'task-1'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['right-anchor'],
+                },
+              },
+            },
+            tag: {
+              ids: ['TODAY'],
+              entities: { TODAY: currentToday },
+            },
+          }),
+        );
+
+        const result = await service.resolveSupersededLocalOps([
+          {
+            opId: localRemoveOp.id,
+            op: localRemoveOp,
+            existingClock: remoteOrderOp.vectorClock,
+          },
+        ]);
+
+        expect(result).toBe(1);
+        expectAtomicRejection([localRemoveOp.id]);
+        expect(mockConflictResolutionService.createLWWUpdateOp).toHaveBeenCalledWith(
+          'TAG',
+          'TODAY',
+          currentToday,
+          TEST_CLIENT_ID,
+          {
+            original: 4,
+            remote: 4,
+            [TEST_CLIENT_ID]: 1,
+          },
+          localRemoveOp.timestamp,
+          'replace',
+        );
+        expect(
+          mockOpLogStore.appendWithVectorClockOverwrite.calls.first().args[0],
+        ).toEqual(
+          jasmine.objectContaining({
+            entityType: 'TAG',
+            entityId: 'TODAY',
+            actionType: '[TAG] LWW Update',
+          }),
+        );
+      });
+
+      it('should scope placement projection to its work context when the task belongs to sections in two contexts', async () => {
+        const localMoveOp = sectionOps[0].op;
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteOrderOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-left', 'project-section', 'section-right'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor'],
+                },
+                ['project-section']: {
+                  id: 'project-section',
+                  contextId: 'project-1',
+                  contextType: 'PROJECT',
+                  title: 'Project',
+                  taskIds: ['task-1'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['right-anchor', 'task-1'],
+                },
+              },
+            },
+          }),
+        );
+
+        await service.resolveSupersededLocalOps([
+          {
+            opId: localMoveOp.id,
+            op: localMoveOp,
+            existingClock: remoteOrderOp.vectorClock,
+          },
+        ]);
+
+        expect(
+          mockConflictResolutionService.getCurrentEntityState,
+        ).not.toHaveBeenCalled();
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).toBe(ActionType.SECTION_ADD_TASK);
+        expect(replacement.entityIds).toEqual(['section-left', 'section-right']);
+        expect(
+          (replacement.payload as { actionPayload: Record<string, unknown> })
+            .actionPayload,
+        ).toEqual({
+          sectionId: 'section-right',
+          taskId: 'task-1',
+          afterTaskId: 'right-anchor',
+          sourceSectionId: 'section-left',
+        });
+      });
+
+      it('should not retarget a no-section placement replay into another work context', async () => {
+        const localMoveOp = sectionOps[0].op;
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteOrderOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+        mockStateSnapshotService.getStateSnapshotForOperationLog.and.returnValue(
+          createReplaySnapshot({
+            section: {
+              ids: ['section-left', 'project-section', 'section-right'],
+              entities: {
+                ['section-left']: {
+                  id: 'section-left',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Left',
+                  taskIds: ['left-anchor'],
+                },
+                ['project-section']: {
+                  id: 'project-section',
+                  contextId: 'project-1',
+                  contextType: 'PROJECT',
+                  title: 'Project',
+                  taskIds: ['task-1'],
+                },
+                ['section-right']: {
+                  id: 'section-right',
+                  contextId: 'TODAY',
+                  contextType: 'TAG',
+                  title: 'Right',
+                  taskIds: ['right-anchor'],
+                },
+              },
+            },
+            tag: {
+              ids: ['TODAY'],
+              entities: {
+                TODAY: {
+                  id: 'TODAY',
+                  title: 'Today',
+                  taskIds: ['current-main-anchor', 'task-1'],
+                },
+              },
+            },
+          }),
+        );
+
+        await service.resolveSupersededLocalOps([
+          {
+            opId: localMoveOp.id,
+            op: localMoveOp,
+            existingClock: remoteOrderOp.vectorClock,
+          },
+        ]);
+
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).toBe(ActionType.SECTION_REMOVE_TASK);
+        expect(replacement.entityId).toBe('section-left');
+        expect(
+          (replacement.payload as { actionPayload: Record<string, unknown> })
+            .actionPayload,
+        ).toEqual({
+          sectionId: 'section-left',
+          taskId: 'task-1',
+          workContextId: 'TODAY',
+          workContextType: 'TAG',
+          workContextAfterTaskId: 'current-main-anchor',
+        });
       });
 
       it('should leave the predecessor retryable when live state is ahead of durable capture', async () => {

--- a/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
@@ -988,6 +988,13 @@ describe('SupersededOperationResolverService', () => {
         vectorClock: { original: 4 },
         timestamp: 5000,
       };
+      const unrelatedPendingTaskOp = createMockOperation(
+        'unrelated-pending-task',
+        'TASK',
+        'task-unrelated',
+        { original: 4 },
+        5000,
+      );
 
       sectionOps.forEach(({ description, op, remoteOp }) => {
         it(`should causally re-create a superseded ${description}`, async () => {
@@ -1130,6 +1137,99 @@ describe('SupersededOperationResolverService', () => {
         const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
           .args[0] as Operation;
         expect(replacement.actionType).not.toBe(ActionType.SECTION_ADD_TASK);
+      });
+
+      it('should defer an older move when a later overlapping move is already synced', async () => {
+        const localMoveOp = sectionOps[0].op;
+        const laterOverlappingMoveOp: Operation = {
+          ...localMoveOp,
+          id: 'later-synced-section-move',
+          entityId: 'section-right',
+          entityIds: ['section-right', 'section-third'],
+          payload: {
+            actionPayload: {
+              sectionId: 'section-third',
+              taskId: 'task-1',
+              afterTaskId: 'third-anchor',
+              sourceSectionId: 'section-right',
+            },
+            entityChanges: [],
+          },
+          vectorClock: { original: 4 },
+          timestamp: 1500,
+        };
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({
+          original: 4,
+          remote: 4,
+        });
+        mockOpLogStore.getUnsynced.and.resolveTo(asPendingEntries(localMoveOp));
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: localMoveOp,
+            appliedAt: 1,
+            source: 'local',
+          },
+          {
+            seq: 2,
+            op: laterOverlappingMoveOp,
+            appliedAt: 2,
+            source: 'local',
+            syncedAt: 2,
+          },
+          {
+            seq: 3,
+            op: remoteRemoveOp,
+            appliedAt: 3,
+            source: 'remote',
+            syncedAt: 3,
+            applicationStatus: 'applied',
+          },
+        ]);
+
+        await expectAsync(
+          service.resolveSupersededLocalOps([
+            {
+              opId: localMoveOp.id,
+              op: localMoveOp,
+              existingClock: remoteRemoveOp.vectorClock,
+            },
+          ]),
+        ).toBeRejectedWithError(/Deferring causal SECTION replay/);
+        expect(mockOpLogStore.markRejected).not.toHaveBeenCalled();
+        expect(mockOpLogStore.appendWithVectorClockOverwrite).not.toHaveBeenCalled();
+      });
+
+      it('should ignore an unrelated pending non-SECTION op for safe replay', async () => {
+        const localMoveOp = sectionOps[0].op;
+        mockVectorClockService.getCurrentVectorClock.and.resolveTo({ remote: 4 });
+        mockOpLogStore.getUnsynced.and.resolveTo(
+          asPendingEntries(localMoveOp, unrelatedPendingTaskOp),
+        );
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          {
+            seq: 1,
+            op: remoteRemoveOp,
+            appliedAt: 1,
+            source: 'remote',
+            syncedAt: 1,
+            applicationStatus: 'applied',
+          },
+        ]);
+
+        const result = await service.resolveSupersededLocalOps([
+          {
+            opId: localMoveOp.id,
+            op: localMoveOp,
+            existingClock: remoteRemoveOp.vectorClock,
+          },
+        ]);
+
+        expect(result).toBe(1);
+        expect(mockOpLogStore.markRejected).toHaveBeenCalledOnceWith([localMoveOp.id]);
+        const replacement = mockOpLogStore.appendWithVectorClockOverwrite.calls.first()
+          .args[0] as Operation;
+        expect(replacement.actionType).toBe(ActionType.SECTION_ADD_TASK);
       });
 
       it('should defer instead of using LWW when a new pending op appeared before resolution', async () => {

--- a/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.spec.ts
@@ -1132,9 +1132,10 @@ describe('SupersededOperationResolverService', () => {
                 actionType: '[TAG] LWW Update',
                 entityType: 'TAG',
                 entityId: 'TODAY',
-                payload: jasmine.objectContaining({
+                payload: {
+                  ...TODAY_TAG,
                   taskIds: ['main-anchor', 'task-1'],
-                }),
+                },
               }),
             );
           }

--- a/src/app/op-log/sync/superseded-operation-resolver.service.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.ts
@@ -32,8 +32,8 @@ import {
   areCommutingSectionOperations,
   projectSectionReplayAgainstState,
   SectionReplayOrder,
-  SectionReplayProjection,
   SectionReplaySnapshot,
+  SectionReplayStateCompensation,
 } from './section-conflict-commutativity.util';
 import { getOpEntityIds } from '../util/get-op-entity-ids.util';
 import { StateSnapshotService } from '../backup/state-snapshot.service';
@@ -50,10 +50,7 @@ type SupersededOperation = {
 };
 
 type SectionCausalReplayDecision = 'replay' | 'fallback';
-type WorkContextStateProjection = Extract<
-  SectionReplayProjection,
-  { kind: 'work-context-state' }
->;
+type WorkContextStateProjection = SectionReplayStateCompensation;
 interface OrderedSectionReplacement {
   operation: Operation;
   order: SectionReplayOrder;
@@ -342,10 +339,10 @@ export class SupersededOperationResolverService {
               );
             } else if (projection.kind === 'work-context-state') {
               projectedWorkContextState = projection;
-              projectedOrder = projection.order;
             } else {
               projectedSectionOp = projection.operation;
               projectedOrder = projection.order;
+              projectedWorkContextState = projection.stateCompensation;
             }
           }
         }
@@ -355,7 +352,6 @@ export class SupersededOperationResolverService {
           projectedSectionOp ||
           projectedWorkContextState
         ) {
-          const sourceOp = projectedSectionOp ?? item.op;
           const clocksToMerge = [globalClock, item.op.vectorClock];
           if ((projectedSectionOp || projectedWorkContextState) && item.existingClock) {
             clocksToMerge.push(item.existingClock);
@@ -368,8 +364,24 @@ export class SupersededOperationResolverService {
           // Client-side pruning would drop entity clock IDs when the merged clock exceeds
           // MAX_VECTOR_CLOCK_SIZE, causing the comparison to return CONCURRENT instead of
           // GREATER_THAN → infinite rejection loop.
-          const newOp = projectedWorkContextState
-            ? this.conflictResolutionService.createLWWUpdateOp(
+          const replacements: Array<{
+            operation: Operation;
+            order: SectionReplayOrder | undefined;
+          }> = [];
+          if (projectedSectionOp) {
+            replacements.push({
+              operation: this._recreateOpWithMergedClock(
+                projectedSectionOp,
+                mergedClock,
+                clientId,
+                item.op.timestamp,
+              ),
+              order: projectedOrder,
+            });
+          }
+          if (projectedWorkContextState) {
+            replacements.push({
+              operation: this.conflictResolutionService.createLWWUpdateOp(
                 projectedWorkContextState.entityType,
                 projectedWorkContextState.entityId,
                 projectedWorkContextState.entityState,
@@ -377,27 +389,37 @@ export class SupersededOperationResolverService {
                 mergedClock,
                 item.op.timestamp,
                 'replace',
-              )
-            : this._recreateOpWithMergedClock(
-                sourceOp,
+              ),
+              order: projectedWorkContextState.order,
+            });
+          }
+          if (replacements.length === 0) {
+            replacements.push({
+              operation: this._recreateOpWithMergedClock(
+                item.op,
                 mergedClock,
                 clientId,
                 item.op.timestamp,
-              );
-          if (projectedOrder) {
-            orderedSectionReplacements.push({
-              operation: newOp,
-              order: projectedOrder,
-              originalIndex: itemIndex,
+              ),
+              order: undefined,
             });
-          } else {
-            newOpsCreated.push(newOp);
+          }
+          for (const { operation, order } of replacements) {
+            if (order) {
+              orderedSectionReplacements.push({
+                operation,
+                order,
+                originalIndex: itemIndex,
+              });
+            } else {
+              newOpsCreated.push(operation);
+            }
+            OpLog.normal(
+              `SupersededOperationResolverService: Created causal replacement ` +
+                `${operation.actionType} op ${operation.id}, replacing superseded op ${item.opId}`,
+            );
           }
           opsToReject.push(item.opId);
-          OpLog.normal(
-            `SupersededOperationResolverService: Created causal replacement ` +
-              `${item.op.actionType} op ${newOp.id}, replacing superseded op ${item.opId}`,
-          );
         } else {
           regularSupersededOps.push(item);
         }

--- a/src/app/op-log/sync/superseded-operation-resolver.service.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.ts
@@ -4,10 +4,15 @@ import {
   ActionType,
   isLwwUpdatePayload,
   Operation,
+  OperationLogEntry,
   OpType,
   VectorClock,
 } from '../core/operation.types';
-import { mergeVectorClocks } from '../../core/util/vector-clock';
+import {
+  compareVectorClocks,
+  mergeVectorClocks,
+  VectorClockComparison,
+} from '../../core/util/vector-clock';
 import { OpLog } from '../../core/log';
 import {
   ConflictResolutionService,
@@ -23,6 +28,32 @@ import { T } from '../../t.const';
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
 import { uuidv7 } from '../../util/uuid-v7';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
+import { areCommutingSectionOperations } from './section-conflict-commutativity.util';
+
+type SupersededOperation = {
+  opId: string;
+  op: Operation;
+  existingClock?: VectorClock;
+};
+
+type SectionCausalReplayDecision = 'replay' | 'fallback' | 'defer';
+
+const CAUSALLY_REPLAYABLE_SECTION_ACTIONS = new Set<ActionType>([
+  ActionType.SECTION_UPDATE_ORDER,
+  ActionType.SECTION_ADD_TASK,
+  ActionType.SECTION_REMOVE_TASK,
+]);
+
+const haveStructurallyEqualClocks = (
+  first: VectorClock,
+  second: VectorClock,
+): boolean => {
+  const firstEntries = Object.entries(first);
+  return (
+    firstEntries.length === Object.keys(second).length &&
+    firstEntries.every(([clientId, counter]) => second[clientId] === counter)
+  );
+};
 
 /**
  * Resolves superseded local operations that were rejected due to concurrent modification.
@@ -78,6 +109,54 @@ export class SupersededOperationResolverService {
     };
   }
 
+  private _getSectionCausalReplayDecision(
+    item: SupersededOperation,
+    retainedEntries: OperationLogEntry[],
+    pendingOps: Operation[],
+    rejectedGroupIds: Set<string>,
+  ): SectionCausalReplayDecision {
+    const existingClock = item.existingClock;
+    if (
+      !CAUSALLY_REPLAYABLE_SECTION_ACTIONS.has(item.op.actionType) ||
+      !existingClock ||
+      compareVectorClocks(item.op.vectorClock, existingClock) !==
+        VectorClockComparison.CONCURRENT
+    ) {
+      return 'fallback';
+    }
+
+    const matchingRetainedEntries = retainedEntries.filter(
+      (entry) =>
+        entry.op.id !== item.op.id &&
+        entry.op.entityType === item.op.entityType &&
+        haveStructurallyEqualClocks(entry.op.vectorClock, existingClock),
+    );
+    if (matchingRetainedEntries.length !== 1) {
+      return 'fallback';
+    }
+    const retainedConflictEntry = matchingRetainedEntries[0];
+    if (
+      retainedConflictEntry.source !== 'remote' ||
+      retainedConflictEntry.syncedAt === undefined ||
+      retainedConflictEntry.applicationStatus !== 'applied' ||
+      retainedConflictEntry.rejectedAt !== undefined ||
+      retainedConflictEntry.reducerRejectedAt !== undefined ||
+      !areCommutingSectionOperations(item.op, retainedConflictEntry.op)
+    ) {
+      return 'fallback';
+    }
+    const retainedConflictOp = retainedConflictEntry.op;
+
+    const canReplayWholePendingGroup =
+      pendingOps.some((pendingOp) => pendingOp.id === item.op.id) &&
+      pendingOps.every(
+        (pendingOp) =>
+          rejectedGroupIds.has(pendingOp.id) &&
+          areCommutingSectionOperations(retainedConflictOp, pendingOp),
+      );
+    return canReplayWholePendingGroup ? 'replay' : 'defer';
+  }
+
   /**
    * Resolves superseded local operations by creating new LWW Update operations.
    *
@@ -87,7 +166,7 @@ export class SupersededOperationResolverService {
    * @returns Number of merged ops created
    */
   async resolveSupersededLocalOps(
-    supersededOps: Array<{ opId: string; op: Operation; existingClock?: VectorClock }>,
+    supersededOps: SupersededOperation[],
     extraClocks?: VectorClock[],
     snapshotVectorClock?: VectorClock,
   ): Promise<number> {
@@ -131,26 +210,57 @@ export class SupersededOperationResolverService {
       const opsToReject: string[] = [];
       const newOpsCreated: Operation[] = [];
       const auxiliaryOpIds = new Set<string>();
+      const deferredSectionOpIds: string[] = [];
 
-      // Handle bulk semantic operations BEFORE entity-by-entity grouping.
+      // Handle irreducible semantic operations BEFORE entity-by-entity grouping.
       // moveToArchive uses OpType.Update but its reducer removes entities from the NgRx store
       // (via deleteTaskHelper). This is the ONLY action with this pattern — all other entity
       // removals use OpType.Delete (handled below). The normal resolution path would call
       // getCurrentEntityState() → undefined → discard, permanently losing the archive.
       // Instead, re-create the operation with a merged clock preserving the original payload.
-      // NOTE: If a future action type also removes entities with OpType.Update, add it here.
-      const regularSupersededOps: Array<{
-        opId: string;
-        op: Operation;
-        existingClock?: VectorClock;
-      }> = [];
+      //
+      // SECTION order/placement operations also carry reducer semantics that an
+      // entity snapshot cannot represent. Re-create one only when the exact
+      // applied server row and the entire pending set prove one commuting
+      // rejected group. If another pending op could be reordered, leave the
+      // SECTION row pending and fail this cycle after resolving the other rows.
+      // Any other ambiguity retains the generic LWW fallback.
+      const regularSupersededOps: SupersededOperation[] = [];
+      const rejectedGroupIds = new Set(supersededOps.map(({ opId }) => opId));
+      let retainedEntries: OperationLogEntry[] | undefined;
+      let pendingOps: Operation[] | undefined;
       for (const item of supersededOps) {
-        if (item.op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE) {
-          // Re-create the archive operation with a merged vector clock.
-          // The original payload is preserved exactly (MultiEntityPayload format with
-          // actionPayload.tasks containing full task data for remote archive writes).
+        let canCausallyReplaySectionOperation = false;
+        if (
+          CAUSALLY_REPLAYABLE_SECTION_ACTIONS.has(item.op.actionType) &&
+          item.existingClock
+        ) {
+          retainedEntries ??= await this.opLogStore.getOpsAfterSeq(0);
+          pendingOps ??= (await this.opLogStore.getUnsynced()).map(({ op }) => op);
+          const replayDecision = this._getSectionCausalReplayDecision(
+            item,
+            retainedEntries,
+            pendingOps,
+            rejectedGroupIds,
+          );
+          if (replayDecision === 'defer') {
+            deferredSectionOpIds.push(item.opId);
+            continue;
+          }
+          canCausallyReplaySectionOperation = replayDecision === 'replay';
+        }
+
+        if (
+          item.op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE ||
+          canCausallyReplaySectionOperation
+        ) {
+          // Preserve the original authenticated action payload and footprint.
+          const clocksToMerge = [globalClock, item.op.vectorClock];
+          if (canCausallyReplaySectionOperation && item.existingClock) {
+            clocksToMerge.push(item.existingClock);
+          }
           const mergedClock = this.conflictResolutionService.mergeAndIncrementClocks(
-            [globalClock, item.op.vectorClock],
+            clocksToMerge,
             clientId,
           );
           // Don't prune here — the server prunes AFTER conflict detection (before storage).
@@ -166,8 +276,8 @@ export class SupersededOperationResolverService {
           newOpsCreated.push(newOp);
           opsToReject.push(item.opId);
           OpLog.normal(
-            `SupersededOperationResolverService: Created replacement moveToArchive op ${newOp.id} ` +
-              `with ${item.op.entityIds?.length ?? 0} tasks, replacing superseded op ${item.opId}`,
+            `SupersededOperationResolverService: Created causal replacement ` +
+              `${item.op.actionType} op ${newOp.id}, replacing superseded op ${item.opId}`,
           );
         } else {
           regularSupersededOps.push(item);
@@ -175,10 +285,7 @@ export class SupersededOperationResolverService {
       }
 
       // Group remaining ops by entity to handle multiple ops for the same entity
-      const opsByEntity = new Map<
-        string,
-        Array<{ opId: string; op: Operation; existingClock?: VectorClock }>
-      >();
+      const opsByEntity = new Map<string, SupersededOperation[]>();
       for (const item of regularSupersededOps) {
         // Skip ops without entityId (shouldn't happen for entity-level ops)
         if (!item.op.entityId) {
@@ -345,6 +452,12 @@ export class SupersededOperationResolverService {
       }
 
       result = newOpsCreated.length - auxiliaryOpIds.size;
+      if (deferredSectionOpIds.length > 0) {
+        throw new Error(
+          `Deferring causal SECTION replay for ${deferredSectionOpIds.length} ` +
+            'operation(s) until the pending operation set is stable.',
+        );
+      }
     });
     return result;
   }

--- a/src/app/op-log/sync/superseded-operation-resolver.service.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.ts
@@ -31,6 +31,8 @@ import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service'
 import {
   areCommutingSectionOperations,
   projectSectionReplayAgainstState,
+  SectionReplayOrder,
+  SectionReplayProjection,
   SectionReplaySnapshot,
 } from './section-conflict-commutativity.util';
 import { getOpEntityIds } from '../util/get-op-entity-ids.util';
@@ -48,6 +50,15 @@ type SupersededOperation = {
 };
 
 type SectionCausalReplayDecision = 'replay' | 'fallback';
+type WorkContextStateProjection = Extract<
+  SectionReplayProjection,
+  { kind: 'work-context-state' }
+>;
+interface OrderedSectionReplacement {
+  operation: Operation;
+  order: SectionReplayOrder;
+  originalIndex: number;
+}
 
 interface SectionCausalReplayContext {
   retainedByEntityClock: Map<string, OperationLogEntry[]>;
@@ -276,6 +287,7 @@ export class SupersededOperationResolverService {
       const opsToReject: string[] = [];
       const newOpsCreated: Operation[] = [];
       const auxiliaryOpIds = new Set<string>();
+      const orderedSectionReplacements: OrderedSectionReplacement[] = [];
 
       // Handle irreducible semantic operations BEFORE entity-by-entity grouping.
       // moveToArchive uses OpType.Update but its reducer removes entities from the NgRx store
@@ -293,8 +305,10 @@ export class SupersededOperationResolverService {
       const regularSupersededOps: SupersededOperation[] = [];
       let sectionReplayContext: SectionCausalReplayContext | undefined;
       let sectionReplaySnapshot: SectionReplaySnapshot | undefined;
-      for (const item of supersededOps) {
+      for (const [itemIndex, item] of supersededOps.entries()) {
         let projectedSectionOp: Operation | undefined;
+        let projectedWorkContextState: WorkContextStateProjection | undefined;
+        let projectedOrder: SectionReplayOrder | undefined;
         if (
           CAUSALLY_REPLAYABLE_SECTION_ACTIONS.has(item.op.actionType) &&
           item.existingClock
@@ -326,19 +340,24 @@ export class SupersededOperationResolverService {
                 `SupersededOperationResolverService: Cannot safely project SECTION ` +
                   `intent ${item.opId}: ${projection.reason}. Falling back to LWW.`,
               );
+            } else if (projection.kind === 'work-context-state') {
+              projectedWorkContextState = projection;
+              projectedOrder = projection.order;
             } else {
               projectedSectionOp = projection.operation;
+              projectedOrder = projection.order;
             }
           }
         }
 
         if (
           item.op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE ||
-          projectedSectionOp
+          projectedSectionOp ||
+          projectedWorkContextState
         ) {
           const sourceOp = projectedSectionOp ?? item.op;
           const clocksToMerge = [globalClock, item.op.vectorClock];
-          if (projectedSectionOp && item.existingClock) {
+          if ((projectedSectionOp || projectedWorkContextState) && item.existingClock) {
             clocksToMerge.push(item.existingClock);
           }
           const mergedClock = this.conflictResolutionService.mergeAndIncrementClocks(
@@ -349,13 +368,31 @@ export class SupersededOperationResolverService {
           // Client-side pruning would drop entity clock IDs when the merged clock exceeds
           // MAX_VECTOR_CLOCK_SIZE, causing the comparison to return CONCURRENT instead of
           // GREATER_THAN → infinite rejection loop.
-          const newOp = this._recreateOpWithMergedClock(
-            sourceOp,
-            mergedClock,
-            clientId,
-            item.op.timestamp,
-          );
-          newOpsCreated.push(newOp);
+          const newOp = projectedWorkContextState
+            ? this.conflictResolutionService.createLWWUpdateOp(
+                projectedWorkContextState.entityType,
+                projectedWorkContextState.entityId,
+                projectedWorkContextState.entityState,
+                clientId,
+                mergedClock,
+                item.op.timestamp,
+                'replace',
+              )
+            : this._recreateOpWithMergedClock(
+                sourceOp,
+                mergedClock,
+                clientId,
+                item.op.timestamp,
+              );
+          if (projectedOrder) {
+            orderedSectionReplacements.push({
+              operation: newOp,
+              order: projectedOrder,
+              originalIndex: itemIndex,
+            });
+          } else {
+            newOpsCreated.push(newOp);
+          }
           opsToReject.push(item.opId);
           OpLog.normal(
             `SupersededOperationResolverService: Created causal replacement ` +
@@ -365,6 +402,13 @@ export class SupersededOperationResolverService {
           regularSupersededOps.push(item);
         }
       }
+      orderedSectionReplacements.sort(
+        (first, second) =>
+          first.order.scope.localeCompare(second.order.scope) ||
+          first.order.position - second.order.position ||
+          first.originalIndex - second.originalIndex,
+      );
+      newOpsCreated.push(...orderedSectionReplacements.map(({ operation }) => operation));
 
       // Group remaining ops by entity to handle multiple ops for the same entity
       const opsByEntity = new Map<string, SupersededOperation[]>();

--- a/src/app/op-log/sync/superseded-operation-resolver.service.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.ts
@@ -30,10 +30,16 @@ import { uuidv7 } from '../../util/uuid-v7';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
 import {
   areCommutingSectionOperations,
-  canReorderSectionTransition,
-  getSectionReplayScopeKeys,
+  projectSectionReplayAgainstState,
+  SectionReplaySnapshot,
 } from './section-conflict-commutativity.util';
 import { getOpEntityIds } from '../util/get-op-entity-ids.util';
+import { StateSnapshotService } from '../backup/state-snapshot.service';
+import { OperationCaptureService } from '../capture/operation-capture.service';
+import { getPhantomChangeRisk } from '../capture/phantom-change-guard.util';
+import { SectionState } from '../../features/section/section.model';
+import { ProjectState } from '../../features/project/project.model';
+import { TagState } from '../../features/tag/tag.model';
 
 type SupersededOperation = {
   opId: string;
@@ -41,14 +47,10 @@ type SupersededOperation = {
   existingClock?: VectorClock;
 };
 
-type SectionCausalReplayDecision = 'replay' | 'fallback' | 'defer';
+type SectionCausalReplayDecision = 'replay' | 'fallback';
 
 interface SectionCausalReplayContext {
   retainedByEntityClock: Map<string, OperationLogEntry[]>;
-  syncedLocalByScope: Map<string, OperationLogEntry[]>;
-  unscopedSyncedLocal: OperationLogEntry[];
-  pendingEntries: OperationLogEntry[];
-  pendingById: Map<string, OperationLogEntry>;
 }
 
 const CAUSALLY_REPLAYABLE_SECTION_ACTIONS = new Set<ActionType>([
@@ -83,11 +85,8 @@ const addToIndex = (
 
 const buildSectionCausalReplayContext = (
   retainedEntries: OperationLogEntry[],
-  pendingEntries: OperationLogEntry[],
 ): SectionCausalReplayContext => {
   const retainedByEntityClock = new Map<string, OperationLogEntry[]>();
-  const syncedLocalByScope = new Map<string, OperationLogEntry[]>();
-  const unscopedSyncedLocal: OperationLogEntry[] = [];
 
   for (const entry of retainedEntries) {
     for (const entityId of getOpEntityIds(entry.op)) {
@@ -97,32 +96,9 @@ const buildSectionCausalReplayContext = (
         entry,
       );
     }
-
-    if (
-      entry.source !== 'local' ||
-      entry.syncedAt === undefined ||
-      entry.rejectedAt !== undefined ||
-      entry.reducerRejectedAt !== undefined
-    ) {
-      continue;
-    }
-    const scopeKeys = getSectionReplayScopeKeys(entry.op);
-    if (scopeKeys === undefined) {
-      unscopedSyncedLocal.push(entry);
-      continue;
-    }
-    for (const scopeKey of scopeKeys) {
-      addToIndex(syncedLocalByScope, scopeKey, entry);
-    }
   }
 
-  return {
-    retainedByEntityClock,
-    syncedLocalByScope,
-    unscopedSyncedLocal,
-    pendingEntries,
-    pendingById: new Map(pendingEntries.map((entry) => [entry.op.id, entry])),
-  };
+  return { retainedByEntityClock };
 };
 
 /**
@@ -153,6 +129,8 @@ export class SupersededOperationResolverService {
   private snackService = inject(SnackService);
   private syncConflictBanner = inject(SyncConflictBannerService);
   private clientIdProvider = inject(CLIENT_ID_PROVIDER);
+  private stateSnapshotService = inject(StateSnapshotService);
+  private operationCapture = inject(OperationCaptureService);
 
   /**
    * Re-creates an operation with a merged vector clock, preserving its original payload.
@@ -222,56 +200,27 @@ export class SupersededOperationResolverService {
     ) {
       return 'fallback';
     }
-    const retainedConflictOp = retainedConflictEntry.op;
-    const pendingItemEntry = context.pendingById.get(item.op.id);
-    const itemScopeKeys = getSectionReplayScopeKeys(item.op);
-    const conflictScopeKeys = getSectionReplayScopeKeys(retainedConflictOp);
-    if (
-      !pendingItemEntry ||
-      itemScopeKeys === undefined ||
-      conflictScopeKeys === undefined
-    ) {
-      return 'defer';
-    }
-
-    const scopedSuccessors = new Map<string, OperationLogEntry>();
-    for (const entry of context.unscopedSyncedLocal) {
-      scopedSuccessors.set(entry.op.id, entry);
-    }
-    for (const scopeKey of new Set([...itemScopeKeys, ...conflictScopeKeys])) {
-      for (const entry of context.syncedLocalByScope.get(scopeKey) ?? []) {
-        scopedSuccessors.set(entry.op.id, entry);
-      }
-    }
-    for (const successor of scopedSuccessors.values()) {
-      if (
-        successor.seq <= pendingItemEntry.seq ||
-        compareVectorClocks(item.op.vectorClock, successor.op.vectorClock) !==
-          VectorClockComparison.LESS_THAN
-      ) {
-        continue;
-      }
-      if (
-        canReorderSectionTransition(item.op, successor.op) ||
-        canReorderSectionTransition(retainedConflictOp, successor.op)
-      ) {
-        return 'defer';
-      }
-    }
-
-    for (const pendingEntry of context.pendingEntries) {
-      if (pendingEntry.op.id === item.op.id) {
-        continue;
-      }
-      if (
-        canReorderSectionTransition(item.op, pendingEntry.op) ||
-        canReorderSectionTransition(retainedConflictOp, pendingEntry.op)
-      ) {
-        return 'defer';
-      }
-    }
 
     return 'replay';
+  }
+
+  /**
+   * Reads a reducer-state frontier that is fully represented by durable ops.
+   * This check and the synchronous snapshot read deliberately have no await
+   * between them. Later user actions wait behind the operation-log lock for
+   * persistence and therefore follow the compensation in durable order.
+   */
+  private _getStableSectionReplaySnapshot(): SectionReplaySnapshot {
+    const phantomRisk = getPhantomChangeRisk(this.operationCapture);
+    if (phantomRisk) {
+      throw new Error(`Cannot project SECTION conflict recovery while ${phantomRisk}.`);
+    }
+    const snapshot = this.stateSnapshotService.getStateSnapshotForOperationLog();
+    return {
+      section: snapshot.section as SectionState,
+      project: snapshot.project as ProjectState,
+      tag: snapshot.tag as TagState,
+    };
   }
 
   /**
@@ -327,7 +276,6 @@ export class SupersededOperationResolverService {
       const opsToReject: string[] = [];
       const newOpsCreated: Operation[] = [];
       const auxiliaryOpIds = new Set<string>();
-      const deferredSectionOpIds: string[] = [];
 
       // Handle irreducible semantic operations BEFORE entity-by-entity grouping.
       // moveToArchive uses OpType.Update but its reducer removes entities from the NgRx store
@@ -338,45 +286,59 @@ export class SupersededOperationResolverService {
       //
       // SECTION order/placement operations also carry reducer semantics that an
       // entity snapshot cannot represent. Re-create one only when the exact
-      // applied server row proves a commuting crossing and neither pending work
-      // nor an already-accepted causal successor could be reordered around the
-      // replacement. Otherwise leave the SECTION row pending and fail this cycle
-      // after resolving unrelated rejected rows. Any malformed or ambiguous
-      // crossing retains the generic LWW fallback.
+      // applied server row proves a commuting crossing. Project its payload
+      // against one stable live-state frontier so anchors and every later local
+      // successor are represented without an action-family allowlist. Malformed
+      // or unrepresentable crossings retain the generic LWW fallback.
       const regularSupersededOps: SupersededOperation[] = [];
       let sectionReplayContext: SectionCausalReplayContext | undefined;
+      let sectionReplaySnapshot: SectionReplaySnapshot | undefined;
       for (const item of supersededOps) {
-        let canCausallyReplaySectionOperation = false;
+        let projectedSectionOp: Operation | undefined;
         if (
           CAUSALLY_REPLAYABLE_SECTION_ACTIONS.has(item.op.actionType) &&
           item.existingClock
         ) {
           if (!sectionReplayContext) {
             const retainedEntries = await this.opLogStore.getOpsAfterSeq(0);
-            const pendingEntries = await this.opLogStore.getUnsynced();
-            sectionReplayContext = buildSectionCausalReplayContext(
-              retainedEntries,
-              pendingEntries,
-            );
+            sectionReplayContext = buildSectionCausalReplayContext(retainedEntries);
           }
           const replayDecision = this._getSectionCausalReplayDecision(
             item,
             sectionReplayContext,
           );
-          if (replayDecision === 'defer') {
-            deferredSectionOpIds.push(item.opId);
-            continue;
+          if (replayDecision === 'replay') {
+            sectionReplaySnapshot ??= this._getStableSectionReplaySnapshot();
+            const projection = projectSectionReplayAgainstState(
+              item.op,
+              sectionReplaySnapshot,
+            );
+            if (projection.kind === 'superseded') {
+              opsToReject.push(item.opId);
+              OpLog.normal(
+                `SupersededOperationResolverService: SECTION intent ${item.opId} ` +
+                  'was superseded by the current durable state.',
+              );
+              continue;
+            }
+            if (projection.kind === 'blocked') {
+              OpLog.warn(
+                `SupersededOperationResolverService: Cannot safely project SECTION ` +
+                  `intent ${item.opId}: ${projection.reason}. Falling back to LWW.`,
+              );
+            } else {
+              projectedSectionOp = projection.operation;
+            }
           }
-          canCausallyReplaySectionOperation = replayDecision === 'replay';
         }
 
         if (
           item.op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE ||
-          canCausallyReplaySectionOperation
+          projectedSectionOp
         ) {
-          // Preserve the original authenticated action payload and footprint.
+          const sourceOp = projectedSectionOp ?? item.op;
           const clocksToMerge = [globalClock, item.op.vectorClock];
-          if (canCausallyReplaySectionOperation && item.existingClock) {
+          if (projectedSectionOp && item.existingClock) {
             clocksToMerge.push(item.existingClock);
           }
           const mergedClock = this.conflictResolutionService.mergeAndIncrementClocks(
@@ -388,7 +350,7 @@ export class SupersededOperationResolverService {
           // MAX_VECTOR_CLOCK_SIZE, causing the comparison to return CONCURRENT instead of
           // GREATER_THAN → infinite rejection loop.
           const newOp = this._recreateOpWithMergedClock(
-            item.op,
+            sourceOp,
             mergedClock,
             clientId,
             item.op.timestamp,
@@ -533,23 +495,19 @@ export class SupersededOperationResolverService {
         );
       }
 
-      // Persist every replacement group atomically and rebase its clocks in
-      // durable sequence order. Retire the stale rows only afterwards: if the
-      // batch fails, the originals remain retryable; if rejection fails, the
-      // complete replacement group is already durable.
-      if (newOpsCreated.length > 0) {
-        const { written } = await this.opLogStore.appendMixedSourceBatchSkipDuplicates([
-          { ops: newOpsCreated, source: 'local' },
-        ]);
+      // Persist replacements, rebase their clocks, and retire their stale
+      // predecessors in one transaction. A crash can therefore expose neither
+      // half of the recovery on its own.
+      if (newOpsCreated.length > 0 || opsToReject.length > 0) {
+        const { written } = await this.opLogStore.appendMixedSourceBatchSkipDuplicates(
+          [{ ops: newOpsCreated, source: 'local' }],
+          { rejectOpIds: opsToReject },
+        );
         for (const { op } of written) {
           OpLog.normal(
             `SupersededOperationResolverService: Appended LWW update op ${op.id} for ${op.entityType}:${op.entityId}`,
           );
         }
-      }
-
-      if (opsToReject.length > 0) {
-        await this.opLogStore.markRejected(opsToReject);
         OpLog.normal(
           `SupersededOperationResolverService: Marked ${opsToReject.length} superseded ops as rejected`,
         );
@@ -572,12 +530,6 @@ export class SupersededOperationResolverService {
       }
 
       result = newOpsCreated.length - auxiliaryOpIds.size;
-      if (deferredSectionOpIds.length > 0) {
-        throw new Error(
-          `Deferring causal SECTION replay for ${deferredSectionOpIds.length} ` +
-            'operation(s) until the pending operation set is stable.',
-        );
-      }
     });
     return result;
   }

--- a/src/app/op-log/sync/superseded-operation-resolver.service.ts
+++ b/src/app/op-log/sync/superseded-operation-resolver.service.ts
@@ -28,7 +28,12 @@ import { T } from '../../t.const';
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
 import { uuidv7 } from '../../util/uuid-v7';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
-import { areCommutingSectionOperations } from './section-conflict-commutativity.util';
+import {
+  areCommutingSectionOperations,
+  canReorderSectionTransition,
+  getSectionReplayScopeKeys,
+} from './section-conflict-commutativity.util';
+import { getOpEntityIds } from '../util/get-op-entity-ids.util';
 
 type SupersededOperation = {
   opId: string;
@@ -38,21 +43,86 @@ type SupersededOperation = {
 
 type SectionCausalReplayDecision = 'replay' | 'fallback' | 'defer';
 
+interface SectionCausalReplayContext {
+  retainedByEntityClock: Map<string, OperationLogEntry[]>;
+  syncedLocalByScope: Map<string, OperationLogEntry[]>;
+  unscopedSyncedLocal: OperationLogEntry[];
+  pendingEntries: OperationLogEntry[];
+  pendingById: Map<string, OperationLogEntry>;
+}
+
 const CAUSALLY_REPLAYABLE_SECTION_ACTIONS = new Set<ActionType>([
   ActionType.SECTION_UPDATE_ORDER,
   ActionType.SECTION_ADD_TASK,
   ActionType.SECTION_REMOVE_TASK,
 ]);
 
-const haveStructurallyEqualClocks = (
-  first: VectorClock,
-  second: VectorClock,
-): boolean => {
-  const firstEntries = Object.entries(first);
-  return (
-    firstEntries.length === Object.keys(second).length &&
-    firstEntries.every(([clientId, counter]) => second[clientId] === counter)
-  );
+const getEntityClockIndexKey = (
+  entityType: Operation['entityType'],
+  entityId: string,
+  vectorClock: VectorClock,
+): string =>
+  JSON.stringify([
+    entityType,
+    entityId,
+    Object.entries(vectorClock).sort(([first], [second]) => first.localeCompare(second)),
+  ]);
+
+const addToIndex = (
+  index: Map<string, OperationLogEntry[]>,
+  key: string,
+  entry: OperationLogEntry,
+): void => {
+  const entries = index.get(key);
+  if (entries) {
+    entries.push(entry);
+  } else {
+    index.set(key, [entry]);
+  }
+};
+
+const buildSectionCausalReplayContext = (
+  retainedEntries: OperationLogEntry[],
+  pendingEntries: OperationLogEntry[],
+): SectionCausalReplayContext => {
+  const retainedByEntityClock = new Map<string, OperationLogEntry[]>();
+  const syncedLocalByScope = new Map<string, OperationLogEntry[]>();
+  const unscopedSyncedLocal: OperationLogEntry[] = [];
+
+  for (const entry of retainedEntries) {
+    for (const entityId of getOpEntityIds(entry.op)) {
+      addToIndex(
+        retainedByEntityClock,
+        getEntityClockIndexKey(entry.op.entityType, entityId, entry.op.vectorClock),
+        entry,
+      );
+    }
+
+    if (
+      entry.source !== 'local' ||
+      entry.syncedAt === undefined ||
+      entry.rejectedAt !== undefined ||
+      entry.reducerRejectedAt !== undefined
+    ) {
+      continue;
+    }
+    const scopeKeys = getSectionReplayScopeKeys(entry.op);
+    if (scopeKeys === undefined) {
+      unscopedSyncedLocal.push(entry);
+      continue;
+    }
+    for (const scopeKey of scopeKeys) {
+      addToIndex(syncedLocalByScope, scopeKey, entry);
+    }
+  }
+
+  return {
+    retainedByEntityClock,
+    syncedLocalByScope,
+    unscopedSyncedLocal,
+    pendingEntries,
+    pendingById: new Map(pendingEntries.map((entry) => [entry.op.id, entry])),
+  };
 };
 
 /**
@@ -111,9 +181,7 @@ export class SupersededOperationResolverService {
 
   private _getSectionCausalReplayDecision(
     item: SupersededOperation,
-    retainedEntries: OperationLogEntry[],
-    pendingOps: Operation[],
-    rejectedGroupIds: Set<string>,
+    context: SectionCausalReplayContext,
   ): SectionCausalReplayDecision {
     const existingClock = item.existingClock;
     if (
@@ -125,12 +193,21 @@ export class SupersededOperationResolverService {
       return 'fallback';
     }
 
-    const matchingRetainedEntries = retainedEntries.filter(
-      (entry) =>
-        entry.op.id !== item.op.id &&
-        entry.op.entityType === item.op.entityType &&
-        haveStructurallyEqualClocks(entry.op.vectorClock, existingClock),
-    );
+    const itemEntityIds = getOpEntityIds(item.op);
+    const matchingRetainedEntriesById = new Map<string, OperationLogEntry>();
+    for (const entityId of itemEntityIds) {
+      const indexKey = getEntityClockIndexKey(
+        item.op.entityType,
+        entityId,
+        existingClock,
+      );
+      for (const entry of context.retainedByEntityClock.get(indexKey) ?? []) {
+        if (entry.op.id !== item.op.id) {
+          matchingRetainedEntriesById.set(entry.op.id, entry);
+        }
+      }
+    }
+    const matchingRetainedEntries = Array.from(matchingRetainedEntriesById.values());
     if (matchingRetainedEntries.length !== 1) {
       return 'fallback';
     }
@@ -146,15 +223,55 @@ export class SupersededOperationResolverService {
       return 'fallback';
     }
     const retainedConflictOp = retainedConflictEntry.op;
+    const pendingItemEntry = context.pendingById.get(item.op.id);
+    const itemScopeKeys = getSectionReplayScopeKeys(item.op);
+    const conflictScopeKeys = getSectionReplayScopeKeys(retainedConflictOp);
+    if (
+      !pendingItemEntry ||
+      itemScopeKeys === undefined ||
+      conflictScopeKeys === undefined
+    ) {
+      return 'defer';
+    }
 
-    const canReplayWholePendingGroup =
-      pendingOps.some((pendingOp) => pendingOp.id === item.op.id) &&
-      pendingOps.every(
-        (pendingOp) =>
-          rejectedGroupIds.has(pendingOp.id) &&
-          areCommutingSectionOperations(retainedConflictOp, pendingOp),
-      );
-    return canReplayWholePendingGroup ? 'replay' : 'defer';
+    const scopedSuccessors = new Map<string, OperationLogEntry>();
+    for (const entry of context.unscopedSyncedLocal) {
+      scopedSuccessors.set(entry.op.id, entry);
+    }
+    for (const scopeKey of new Set([...itemScopeKeys, ...conflictScopeKeys])) {
+      for (const entry of context.syncedLocalByScope.get(scopeKey) ?? []) {
+        scopedSuccessors.set(entry.op.id, entry);
+      }
+    }
+    for (const successor of scopedSuccessors.values()) {
+      if (
+        successor.seq <= pendingItemEntry.seq ||
+        compareVectorClocks(item.op.vectorClock, successor.op.vectorClock) !==
+          VectorClockComparison.LESS_THAN
+      ) {
+        continue;
+      }
+      if (
+        canReorderSectionTransition(item.op, successor.op) ||
+        canReorderSectionTransition(retainedConflictOp, successor.op)
+      ) {
+        return 'defer';
+      }
+    }
+
+    for (const pendingEntry of context.pendingEntries) {
+      if (pendingEntry.op.id === item.op.id) {
+        continue;
+      }
+      if (
+        canReorderSectionTransition(item.op, pendingEntry.op) ||
+        canReorderSectionTransition(retainedConflictOp, pendingEntry.op)
+      ) {
+        return 'defer';
+      }
+    }
+
+    return 'replay';
   }
 
   /**
@@ -221,27 +338,30 @@ export class SupersededOperationResolverService {
       //
       // SECTION order/placement operations also carry reducer semantics that an
       // entity snapshot cannot represent. Re-create one only when the exact
-      // applied server row and the entire pending set prove one commuting
-      // rejected group. If another pending op could be reordered, leave the
-      // SECTION row pending and fail this cycle after resolving the other rows.
-      // Any other ambiguity retains the generic LWW fallback.
+      // applied server row proves a commuting crossing and neither pending work
+      // nor an already-accepted causal successor could be reordered around the
+      // replacement. Otherwise leave the SECTION row pending and fail this cycle
+      // after resolving unrelated rejected rows. Any malformed or ambiguous
+      // crossing retains the generic LWW fallback.
       const regularSupersededOps: SupersededOperation[] = [];
-      const rejectedGroupIds = new Set(supersededOps.map(({ opId }) => opId));
-      let retainedEntries: OperationLogEntry[] | undefined;
-      let pendingOps: Operation[] | undefined;
+      let sectionReplayContext: SectionCausalReplayContext | undefined;
       for (const item of supersededOps) {
         let canCausallyReplaySectionOperation = false;
         if (
           CAUSALLY_REPLAYABLE_SECTION_ACTIONS.has(item.op.actionType) &&
           item.existingClock
         ) {
-          retainedEntries ??= await this.opLogStore.getOpsAfterSeq(0);
-          pendingOps ??= (await this.opLogStore.getUnsynced()).map(({ op }) => op);
+          if (!sectionReplayContext) {
+            const retainedEntries = await this.opLogStore.getOpsAfterSeq(0);
+            const pendingEntries = await this.opLogStore.getUnsynced();
+            sectionReplayContext = buildSectionCausalReplayContext(
+              retainedEntries,
+              pendingEntries,
+            );
+          }
           const replayDecision = this._getSectionCausalReplayDecision(
             item,
-            retainedEntries,
-            pendingOps,
-            rejectedGroupIds,
+            sectionReplayContext,
           );
           if (replayDecision === 'defer') {
             deferredSectionOpIds.push(item.opId);


### PR DESCRIPTION
## Summary

- adds real E2E coverage for encrypted SuperSync REPAIR and SECTION convergence, every WebDAV v2→v3 response-loss stage, Capacitor lifecycle/native-transport continuity, and transient rejected-op recovery
- preserves SECTION ordering and placement semantics when encrypted SuperSync rejects concurrent operations, using current-state semantic compensation
- scopes membership recovery to the original work context and replays dependent anchors in current predecessor order
- persists replacement operations and predecessor rejection atomically, with stable snapshot/provenance guards
- pairs projected SECTION removals with complete Project/Tag LWW state so v18.4.0–v18.4.3 retain work-context ordering
- re-reads durable pending state after a forced conflict download and carries nested LWW replacements into the same sync cycle for immediate re-upload
- adds a released-client compatibility policy gate backed by real tag → commit → blob provenance

## Root cause

Encrypted SuperSync can reject multi-entity SECTION operations from their plaintext footprints, but it cannot inspect encrypted action semantics. Generic entity-level LWW compensation cannot represent section order, task placement, or cross-feature work-context ordering. Replaying stale anchors, dependency chains in input order, or membership from another context can therefore leave clients diverged after a rejected operation.

The recovery path also needs to account for v18.4.0–v18.4.3: those clients accept schema-4 S6 rows but consume only section membership fields, ignoring the later work-context anchor fields. Projecting a removal now emits the semantic S6 operation followed by an exact Project/Tag state operation that their established LWW reducer understands.

The full E2E matrix exposed a second rejected-op failure: after a transient download error, a retry's forced-from-zero download could resolve and retire the original local operation, but the handler reused its stale pre-download pending list and attempted a duplicate replacement. The forced-download result's nested `localWinOpsCreated` count was also not propagated, so a successfully created replacement was not guaranteed to upload in the same sync cycle. The handler now re-reads the durable operation state, resolves only surviving active local operations, and threads that count back to the wrapper.

## Compatibility boundary

The state companion closes the projected/recovery removal path for v18.4.0–v18.4.3. Ordinary directly accepted S6 operations retain the pre-existing historical ordering limitation on that cohort; this PR does not claim to repair that separate path. Released behavior was source-audited and policy-tested rather than executed through a pinned old-client binary.

## Validation

- `npm test`
  - sync-core: 243/243
  - shared-schema: 89/89
  - sync providers: 416/416
  - release tooling: 24/24
  - Angular Europe/Berlin: 13,551 passed, 2 skipped
  - Angular Los Angeles: 13,537 passed, 16 skipped
- focused sync suites: rejected-op handler 42/42, operation-log sync 152/152, sync wrapper 153/153, resolver 65/65, conflict resolution 236/236, operation store 241/241, compatibility policy 4/4
- real rejected-op transient-download E2E: 1/1 with retries disabled; one `triggerSync()` engine cycle forced the download, created and uploaded one LWW replacement, and converged A/B
- real encrypted SuperSync SECTION E2E: 1/1, exercising four server rejections plus reload and fresh-client A/B/C convergence
- real SuperSync REPAIR lifecycle E2E: 1/1
- real WebDAV migration interruption matrix: 6/6
- finish-day hierarchy E2E: 1/1
- Android instrumentation: 1/1 plus `assemblePlayDebugAndroidTest`
- mandatory `checkFile` passed for every modified TypeScript file; `git diff --check` clean
- rebased onto `master` at `c31718cf12`; all eight commits remained patch-identical in `git range-diff`
- two independent final reviewers approved exact SHA `e28f6b91af` with no findings
- [scheduled full E2E matrix](https://github.com/super-productivity/super-productivity/actions/runs/30269419457) on exact SHA `e28f6b91af`: all six SuperSync shards, WebDAV, regular E2E, server unit tests, and frontend build passed
- all 22 reported PR checks passed, including the standard test/PWA job, CodeQL, Android native tests, and packaged Electron validation

The large diff is primarily the new real-provider E2E matrices and fixtures; production changes remain scoped to conflict recovery and atomic persistence.

Closes #9273
Refs #9262
Refs #9152
