### PR TITLE
fix(sync): preserve forced-download conflict recovery

### DIFF
--- a/src/app/op-log/core/types/sync-results.types.ts
+++ b/src/app/op-log/core/types/sync-results.types.ts
@@ -242,6 +242,8 @@ export type DownloadResultForRejection =
   | {
       kind: 'completed';
       newOpsCount: number;
+      /** Local-win operations created while applying the nested download. */
+      localWinOpsCreated?: number;
       allOpClocks?: VectorClock[];
       snapshotVectorClock?: VectorClock;
       /** Server cursor after the downloaded operations were durably applied. */

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -844,7 +844,9 @@ describe('OperationLogSyncService', () => {
 
           const downloadSpy = spyOn(service, 'downloadRemoteOps').and.returnValue(
             Promise.resolve({
-              kind: 'no_new_ops' as const,
+              kind: 'ops_processed' as const,
+              newOpsCount: 1,
+              localWinOpsCreated: 2,
             }),
           );
 
@@ -874,6 +876,7 @@ describe('OperationLogSyncService', () => {
             isNeverSynced: true,
           });
           expect(recoveryResult.latestServerSeq).toBe(12);
+          expect(recoveryResult.localWinOpsCreated).toBe(2);
         });
 
         it('should propagate nested download cancellation as a cancelled upload', async () => {

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -467,6 +467,7 @@ export class OperationLogSyncService {
           return {
             kind: 'completed',
             newOpsCount: outcome.newOpsCount,
+            localWinOpsCreated: outcome.localWinOpsCreated,
             allOpClocks: outcome.allOpClocks,
             snapshotVectorClock: outcome.snapshotVectorClock,
             latestServerSeq,

--- a/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
@@ -797,6 +797,102 @@ describe('RejectedOpsHandlerService', () => {
         expect(downloadCallback).toHaveBeenCalledWith({ forceFromSeq0: true });
       });
 
+      it('should not resolve an op retired by the forced download', async () => {
+        const op = createOp({ id: 'op-1' });
+        let wasRetired = false;
+        opLogStoreSpy.getOpById.and.callFake(async () =>
+          wasRetired ? { ...mockEntry(op), rejectedAt: Date.now() } : mockEntry(op),
+        );
+        downloadCallback.and.callFake(async (options) => {
+          if (options?.forceFromSeq0) {
+            wasRetired = true;
+            return {
+              kind: 'completed',
+              newOpsCount: 1,
+              localWinOpsCreated: 1,
+              allOpClocks: [{ remoteClient: 2 }],
+            } as DownloadResultForRejection;
+          }
+          return { kind: 'completed', newOpsCount: 0 };
+        });
+
+        const result = await service.handleRejectedOps(
+          [{ opId: op.id, error: 'concurrent', errorCode: 'CONFLICT_CONCURRENT' }],
+          downloadCallback,
+        );
+
+        expect(opLogStoreSpy.getOpById).toHaveBeenCalledTimes(3);
+        expect(
+          supersededOperationResolverSpy.resolveSupersededLocalOps,
+        ).not.toHaveBeenCalled();
+        expect(opLogStoreSpy.markRejected).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          kind: 'completed',
+          mergedOpsCreated: 1,
+          permanentRejectionCount: 0,
+        });
+      });
+
+      it('should resolve only ops still pending after the forced download', async () => {
+        const retiredOp = createOp({ id: 'retired-op', entityId: 'retired-entity' });
+        const pendingOp = createOp({ id: 'pending-op', entityId: 'pending-entity' });
+        const opsById = new Map([
+          [retiredOp.id, retiredOp],
+          [pendingOp.id, pendingOp],
+        ]);
+        let forceDownloadCompleted = false;
+        opLogStoreSpy.getOpById.and.callFake(async (opId) => {
+          const op = opsById.get(opId);
+          if (!op) {
+            return undefined;
+          }
+          return forceDownloadCompleted && opId === retiredOp.id
+            ? { ...mockEntry(op), rejectedAt: Date.now() }
+            : mockEntry(op);
+        });
+        const forceClock = { remoteClient: 2 };
+        const retiredClock = { retiredClient: 1 };
+        const pendingClock = { pendingClient: 1 };
+        downloadCallback.and.callFake(async (options) => {
+          if (options?.forceFromSeq0) {
+            forceDownloadCompleted = true;
+            return {
+              kind: 'completed',
+              newOpsCount: 1,
+              allOpClocks: [forceClock],
+            } as DownloadResultForRejection;
+          }
+          return { kind: 'completed', newOpsCount: 0 };
+        });
+        supersededOperationResolverSpy.resolveSupersededLocalOps.and.resolveTo(1);
+
+        await service.handleRejectedOps(
+          [
+            {
+              opId: retiredOp.id,
+              error: 'concurrent',
+              errorCode: 'CONFLICT_CONCURRENT',
+              existingClock: retiredClock,
+            },
+            {
+              opId: pendingOp.id,
+              error: 'concurrent',
+              errorCode: 'CONFLICT_CONCURRENT',
+              existingClock: pendingClock,
+            },
+          ],
+          downloadCallback,
+        );
+
+        expect(
+          supersededOperationResolverSpy.resolveSupersededLocalOps,
+        ).toHaveBeenCalledOnceWith(
+          [{ opId: pendingOp.id, op: pendingOp, existingClock: pendingClock }],
+          [forceClock, pendingClock],
+          undefined,
+        );
+      });
+
       it('should use superseded operation resolver when force download returns clocks', async () => {
         const op = createOp({ id: 'op-1' });
         opLogStoreSpy.getOpById.and.returnValue(Promise.resolve(mockEntry(op)));

--- a/src/app/op-log/sync/rejected-ops-handler.service.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.ts
@@ -423,6 +423,7 @@ export class RejectedOpsHandlerService {
         this._rollbackResolutionAttempts(opsToResolve);
         return { kind: 'cancelled' };
       }
+      mergedOpsCreated += downloadResult.localWinOpsCreated ?? 0;
 
       // Helper to check which ops are still pending, preserving existingClock from rejection
       const getStillPendingOps = async (): Promise<
@@ -454,7 +455,7 @@ export class RejectedOpsHandlerService {
       // If download got new ops, conflict detection already happened in _processRemoteOps
       // If download got nothing (newOpsCount === 0), we need to resolve locally
       if (downloadResult.newOpsCount === 0) {
-        const stillPendingOps = await getStillPendingOps();
+        let stillPendingOps = await getStillPendingOps();
 
         if (stillPendingOps.length > 0) {
           // Normal download returned 0 ops but concurrent ops still pending.
@@ -469,6 +470,17 @@ export class RejectedOpsHandlerService {
           if (forceDownloadResult.kind === 'cancelled') {
             this._rollbackResolutionAttempts(opsToResolve);
             return { kind: 'cancelled' };
+          }
+          mergedOpsCreated += forceDownloadResult.localWinOpsCreated ?? 0;
+
+          // The forced download can resolve and retire the same local ops.
+          stillPendingOps = await getStillPendingOps();
+          if (stillPendingOps.length === 0) {
+            return {
+              kind: 'completed',
+              mergedOpsCreated,
+              retryExceededCount: opsExceededRetries.length,
+            };
           }
 
           // Use the clocks from force download to resolve superseded ops


### PR DESCRIPTION
## Summary

- re-read rejected operations after a forced-from-sequence-zero download before resolving superseded local operations
- stop recovery when that download already retired every rejected operation, and resolve only the operations that remain pending
- propagate local-win operation counts from nested downloads so replacement operations are uploaded in the same sync cycle
- add regression coverage for complete and partial retirement, operation-count propagation, cancellation, and retry behavior

## Root cause

The rejection handler retained its pre-download pending-operation list across forced recovery. When that download applied remote conflicts and retired some or all of those local operations, the handler could continue resolving stale entries a second time. It also omitted local-win operations created by nested downloads from the count returned to the outer sync loop.

## Impact

Conflict recovery no longer resolves already-retired operations twice, and any replacement operations created during nested downloads are uploaded without waiting for another sync cycle.

## Validation

- `rejected-ops-handler.service.spec.ts`: 41 tests passed
- `operation-log-sync.service.spec.ts`: 152 tests passed
- exact retries-disabled SuperSync regression E2E: passed
- scheduled E2E run 30263635451: all six SuperSync shards, WebDAV, and workflow gates passed
- `npm run checkFile` passed for all five modified TypeScript files
- six-perspective multi-review verdict: APPROVE (high confidence)
