### PR TITLE
fix(sync): confirm first-sync overwrites

### DIFF
--- a/e2e/tests/sync/webdav-first-sync-conflict.spec.ts
+++ b/e2e/tests/sync/webdav-first-sync-conflict.spec.ts
@@ -107,18 +107,20 @@ test.describe('@webdav WebDAV First Sync Conflict', () => {
     await useLocalBtn.click();
     console.log('[Test] Clicked Use Local on Client B');
 
-    // Handle potential confirmation dialog (for overwrites with many changes)
+    // A first-sync overwrite must always require the count-free safety warning.
     const confirmDialog = pageB.locator('dialog-confirm');
-    try {
-      await confirmDialog.waitFor({ state: 'visible', timeout: 3000 });
-      // Click the confirm/OK button
-      await confirmDialog
-        .locator('button[color="warn"], button:has-text("OK")')
-        .first()
-        .click();
-    } catch {
-      // Confirmation might not appear - that's fine
-    }
+    await expect(confirmDialog).toBeVisible();
+    await expect(confirmDialog.locator('.content')).toHaveText(
+      'WARNING: This device cannot determine how many unsynced changes the remote data has (it has no record of a previous sync). Overwriting the remote data with the local version may discard changes. Are you sure?',
+    );
+    const snapshotUploadResponse = pageB.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        new URL(response.url()).pathname.endsWith('/sync-data.json'),
+      { timeout: 60000 },
+    );
+    await confirmDialog.locator('[e2e="confirmBtn"]').click();
+    expect((await snapshotUploadResponse).ok()).toBe(true);
 
     // Wait for sync to complete
     await waitForSyncComplete(pageB, syncPageB, 30000);
@@ -219,17 +221,13 @@ test.describe('@webdav WebDAV First Sync Conflict', () => {
     await useRemoteBtn.click();
     console.log('[Test] Clicked Use Remote');
 
-    // Handle potential confirmation dialog
+    // A first-sync overwrite must always require the count-free safety warning.
     const confirmDialog = pageB.locator('dialog-confirm');
-    try {
-      await confirmDialog.waitFor({ state: 'visible', timeout: 3000 });
-      await confirmDialog
-        .locator('button[color="warn"], button:has-text("OK")')
-        .first()
-        .click();
-    } catch {
-      // Confirmation might not appear
-    }
+    await expect(confirmDialog).toBeVisible();
+    await expect(confirmDialog.locator('.content')).toHaveText(
+      'WARNING: This device cannot determine how many unsynced changes the local data has (it has no record of a previous sync). Overwriting the local data with the remote version may discard changes. Are you sure?',
+    );
+    await confirmDialog.locator('[e2e="confirmBtn"]').click();
 
     await waitForSyncComplete(pageB, syncPageB, 30000);
     console.log('[Test] Sync completed');

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -3463,6 +3463,60 @@ describe('OperationLogSyncService', () => {
           }
         });
 
+        it('uses no last-synced baseline for a never-synced client with a local snapshot', async () => {
+          const unsyncedEntries: OperationLogEntry[] = [
+            {
+              seq: 1,
+              op: {
+                id: 'local-op-1',
+                clientId: 'client-A',
+                actionType: 'test' as ActionType,
+                opType: OpType.Update,
+                entityType: 'TASK',
+                entityId: 'task-1',
+                payload: {},
+                vectorClock: { clientA: 1 },
+                timestamp: Date.now(),
+                schemaVersion: 1,
+              },
+              appliedAt: Date.now(),
+              source: 'local',
+            },
+          ];
+          opLogStoreSpy.getUnsynced.and.resolveTo(unsyncedEntries);
+
+          const vectorClockService = TestBed.inject(
+            VectorClockService,
+          ) as jasmine.SpyObj<VectorClockService>;
+          vectorClockService.getSnapshotVectorClock.and.resolveTo({ clientA: 1 });
+
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { tasks: [{ id: 'remote-task' }] },
+            snapshotVectorClock: { clientB: 1 },
+            latestServerSeq: 0,
+          });
+
+          const mockProvider = {
+            isReady: () => Promise.resolve(true),
+            supportsOperationSync: true,
+          } as any;
+
+          try {
+            await service.downloadRemoteOps(mockProvider, { isNeverSynced: true });
+            fail('Expected LocalDataConflictError to be thrown');
+          } catch (error) {
+            expect(error).toBeInstanceOf(LocalDataConflictError);
+            const conflictError = error as LocalDataConflictError;
+            expect(conflictError.lastSyncedVectorClock).toBeNull();
+            expect(vectorClockService.getSnapshotVectorClock).not.toHaveBeenCalled();
+          }
+        });
+
         it('should NOT throw LocalDataConflictError when client has no unsynced ops', async () => {
           // No unsynced ops
           opLogStoreSpy.getUnsynced.and.returnValue(Promise.resolve([]));

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -1805,6 +1805,14 @@ describe('OperationLogSyncService', () => {
             Promise.resolve([]),
             Promise.resolve([lateLocalEntry]),
           );
+          // Established client (hasSyncedOps defaults to true): the late-op
+          // conflict must carry the baseline captured before the snapshot
+          // attempt, not a null one.
+          const lastSyncedClock = { clientA: 1, clientB: 4 };
+          const vectorClockService = TestBed.inject(
+            VectorClockService,
+          ) as jasmine.SpyObj<VectorClockService>;
+          vectorClockService.getSnapshotVectorClock.and.resolveTo(lastSyncedClock);
           downloadServiceSpy.downloadRemoteOps.and.resolveTo({
             newOps: [],
             needsFullStateUpload: false,
@@ -1823,12 +1831,74 @@ describe('OperationLogSyncService', () => {
             setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
           } as unknown as OperationSyncCapable;
 
-          await expectAsync(
-            service.downloadRemoteOps(mockProvider),
-          ).toBeRejectedWithError(LocalDataConflictError);
+          try {
+            await service.downloadRemoteOps(mockProvider);
+            fail('Expected LocalDataConflictError to be thrown');
+          } catch (error) {
+            expect(error).toBeInstanceOf(LocalDataConflictError);
+            const conflictError = error as LocalDataConflictError;
+            expect(conflictError.lastSyncedVectorClock).toEqual(lastSyncedClock);
+          }
 
           expect(syncHydrationServiceSpy.hydrateFromRemoteSync).not.toHaveBeenCalled();
           expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
+        });
+
+        it('uses no last-synced baseline when a late durable op aborts hydration on a never-synced client', async () => {
+          const lateLocalEntry: OperationLogEntry = {
+            seq: 2,
+            op: {
+              id: 'late-local-op',
+              clientId: 'client-A',
+              actionType: ActionType.TASK_SHARED_UPDATE,
+              opType: OpType.Update,
+              entityType: 'TASK',
+              entityId: 'task-late',
+              payload: { task: { id: 'task-late', changes: { title: 'Keep me' } } },
+              vectorClock: { clientA: 2 },
+              timestamp: 2,
+              schemaVersion: 1,
+            },
+            appliedAt: 2,
+            source: 'local',
+          };
+          opLogStoreSpy.getUnsynced.and.returnValues(
+            Promise.resolve([]),
+            Promise.resolve([lateLocalEntry]),
+          );
+          // Never synced, but a local state-cache snapshot already exists. The
+          // late-op conflict must use the captured null baseline instead of
+          // re-reading the snapshot clock inside the hydration section.
+          opLogStoreSpy.hasSyncedOps.and.resolveTo(false);
+          const vectorClockService = TestBed.inject(
+            VectorClockService,
+          ) as jasmine.SpyObj<VectorClockService>;
+          vectorClockService.getSnapshotVectorClock.and.resolveTo({ clientA: 1 });
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { task: { ids: ['remote-task'] } },
+            snapshotVectorClock: { clientB: 5 },
+            latestServerSeq: 1,
+          });
+          const mockProvider = {
+            supportsOperationSync: true,
+            getLastServerSeq: () => Promise.resolve(0),
+            setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+          } as unknown as OperationSyncCapable;
+
+          try {
+            await service.downloadRemoteOps(mockProvider);
+            fail('Expected LocalDataConflictError to be thrown');
+          } catch (error) {
+            expect(error).toBeInstanceOf(LocalDataConflictError);
+            const conflictError = error as LocalDataConflictError;
+            expect(conflictError.lastSyncedVectorClock).toBeNull();
+            expect(vectorClockService.getSnapshotVectorClock).not.toHaveBeenCalled();
+          }
         });
 
         it('should restore and persist a local action buffered during snapshot hydration', async () => {
@@ -3055,6 +3125,7 @@ describe('OperationLogSyncService', () => {
           const mockProvider = {
             isReady: () => Promise.resolve(true),
             supportsOperationSync: true,
+            getLastServerSeq: () => Promise.resolve(0),
             setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
           } as unknown as OperationSyncCapable;
 
@@ -3485,6 +3556,10 @@ describe('OperationLogSyncService', () => {
           ];
           opLogStoreSpy.getUnsynced.and.resolveTo(unsyncedEntries);
 
+          // Production classification, not an injected flag: no retained synced
+          // rows AND no persisted provider cursor means never synced.
+          opLogStoreSpy.hasSyncedOps.and.resolveTo(false);
+
           const vectorClockService = TestBed.inject(
             VectorClockService,
           ) as jasmine.SpyObj<VectorClockService>;
@@ -3504,16 +3579,78 @@ describe('OperationLogSyncService', () => {
           const mockProvider = {
             isReady: () => Promise.resolve(true),
             supportsOperationSync: true,
+            getLastServerSeq: () => Promise.resolve(0),
           } as any;
 
           try {
-            await service.downloadRemoteOps(mockProvider, { isNeverSynced: true });
+            await service.downloadRemoteOps(mockProvider);
             fail('Expected LocalDataConflictError to be thrown');
           } catch (error) {
             expect(error).toBeInstanceOf(LocalDataConflictError);
             const conflictError = error as LocalDataConflictError;
             expect(conflictError.lastSyncedVectorClock).toBeNull();
             expect(vectorClockService.getSnapshotVectorClock).not.toHaveBeenCalled();
+          }
+        });
+
+        it('keeps the snapshot-clock baseline when synced rows are gone but the provider cursor is set', async () => {
+          // Established client whose synced rows disappeared: a snapshot-only
+          // first sync commits zero synced rows, and compaction can prune them
+          // all later. The persisted per-provider cursor still proves the
+          // completed sync, so the measured-change threshold must keep working
+          // instead of forcing the count-free first-sync warning.
+          const unsyncedEntries: OperationLogEntry[] = [
+            {
+              seq: 1,
+              op: {
+                id: 'local-op-1',
+                clientId: 'client-A',
+                actionType: 'test' as ActionType,
+                opType: OpType.Update,
+                entityType: 'TASK',
+                entityId: 'task-1',
+                payload: {},
+                vectorClock: { clientA: 4 },
+                timestamp: Date.now(),
+                schemaVersion: 1,
+              },
+              appliedAt: Date.now(),
+              source: 'local',
+            },
+          ];
+          opLogStoreSpy.getUnsynced.and.resolveTo(unsyncedEntries);
+          opLogStoreSpy.hasSyncedOps.and.resolveTo(false);
+
+          const lastSyncedClock = { clientA: 3, clientB: 5 };
+          const vectorClockService = TestBed.inject(
+            VectorClockService,
+          ) as jasmine.SpyObj<VectorClockService>;
+          vectorClockService.getSnapshotVectorClock.and.resolveTo(lastSyncedClock);
+
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            needsFullStateUpload: false,
+            success: true,
+            providerMode: 'fileSnapshotOps',
+            failedFileCount: 0,
+            snapshotState: { tasks: [{ id: 'remote-task' }] },
+            snapshotVectorClock: { clientB: 6 },
+            latestServerSeq: 0,
+          });
+
+          const mockProvider = {
+            isReady: () => Promise.resolve(true),
+            supportsOperationSync: true,
+            getLastServerSeq: () => Promise.resolve(7),
+          } as any;
+
+          try {
+            await service.downloadRemoteOps(mockProvider);
+            fail('Expected LocalDataConflictError to be thrown');
+          } catch (error) {
+            expect(error).toBeInstanceOf(LocalDataConflictError);
+            const conflictError = error as LocalDataConflictError;
+            expect(conflictError.lastSyncedVectorClock).toEqual(lastSyncedClock);
           }
         });
 

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -771,12 +771,13 @@ export class OperationLogSyncService {
             FILE_BASED_SYNC_CONSTANTS.AUTO_MERGE_CONCURRENT_SNAPSHOT,
           );
 
-          // The local snapshot's vector clock is this client's last-synced
-          // baseline: unsynced ops sit on top of it, so the dialog can compute
-          // changes-since-last-sync as a per-client delta instead of summing
-          // the whole (lifetime) clock (SPAP-7). Undefined snapshot → null.
-          const lastSyncedVectorClock =
-            (await this.vectorClockService.getSnapshotVectorClock()) ?? null;
+          // A local state-cache snapshot is only a last-synced baseline after a
+          // completed sync. Fresh clients can already have a snapshot containing
+          // local changes, but using its clock here would hide the first-sync
+          // overwrite warning.
+          const lastSyncedVectorClock = isNeverSyncedAtSyncStart
+            ? null
+            : ((await this.vectorClockService.getSnapshotVectorClock()) ?? null);
 
           if (gate === 'keep-local') {
             // Local strictly dominates the snapshot: keep local, no dialog. The

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -712,6 +712,27 @@ export class OperationLogSyncService {
       const unsyncedOps = await this.opLogStore.getUnsynced();
       const hasLocalChanges = unsyncedOps.length > 0;
 
+      // Nothing from this sync is persisted yet, so these live reads reflect
+      // whether the client completed a prior sync cycle.
+      const isNeverSyncedAtSyncStart =
+        options?.isNeverSynced ?? !(await this.opLogStore.hasSyncedOps());
+      // A local state-cache snapshot is only a last-synced baseline after a
+      // completed sync: fresh clients can already have a snapshot containing
+      // local changes, and using its clock would suppress the count-free
+      // first-sync overwrite warning (#9166). Missing synced op rows cannot
+      // prove "never synced" either (a snapshot-only first sync commits zero
+      // synced rows, and compaction can prune them all later), so also consult
+      // the persisted per-provider cursor, which only advances after a
+      // completed, durably applied sync (setLastServerSeq below). Captured once
+      // here so every conflict surfaced during this snapshot attempt uses the
+      // same baseline decision, including the late-durable-op recheck inside
+      // _hydrateSnapshotExclusive().
+      const hasCompletedSyncBaseline =
+        !isNeverSyncedAtSyncStart || (await syncProvider.getLastServerSeq()) > 0;
+      const lastSyncedVectorClock = hasCompletedSyncBaseline
+        ? ((await this.vectorClockService.getSnapshotVectorClock()) ?? null)
+        : null;
+
       // Collected here, applied AFTER hydrateFromRemoteSync succeeds so a
       // hydration failure doesn't permanently drop discardable startup ops
       // while leaving the user without the remote snapshot.
@@ -739,10 +760,6 @@ export class OperationLogSyncService {
             .map((entry) => entry.op.entityId)
             .filter((id): id is string => id !== undefined),
         );
-        // Nothing from this sync is persisted yet, so this live read reflects
-        // whether the client completed a prior sync cycle.
-        const isNeverSyncedAtSyncStart =
-          options?.isNeverSynced ?? !(await this.opLogStore.hasSyncedOps());
         const pendingOpClassification = {
           hasCompletedInitialSync: !isNeverSyncedAtSyncStart,
         };
@@ -770,14 +787,6 @@ export class OperationLogSyncService {
             result.snapshotVectorClock,
             FILE_BASED_SYNC_CONSTANTS.AUTO_MERGE_CONCURRENT_SNAPSHOT,
           );
-
-          // A local state-cache snapshot is only a last-synced baseline after a
-          // completed sync. Fresh clients can already have a snapshot containing
-          // local changes, but using its clock here would hide the first-sync
-          // overwrite warning.
-          const lastSyncedVectorClock = isNeverSyncedAtSyncStart
-            ? null
-            : ((await this.vectorClockService.getSnapshotVectorClock()) ?? null);
 
           if (gate === 'keep-local') {
             // Local strictly dominates the snapshot: keep local, no dialog. The
@@ -925,7 +934,12 @@ export class OperationLogSyncService {
         'snapshot hydration',
       );
       await this.writeFlushService.flushThenRunExclusive(() =>
-        this._hydrateSnapshotExclusive(result, initialUnsyncedOpIds, snapshotIncludedOps),
+        this._hydrateSnapshotExclusive(
+          result,
+          initialUnsyncedOpIds,
+          snapshotIncludedOps,
+          lastSyncedVectorClock,
+        ),
       );
 
       // Now that the remote snapshot is applied, it's safe to drop the
@@ -1350,6 +1364,10 @@ export class OperationLogSyncService {
     },
     initialUnsyncedOpIds: Set<string>,
     snapshotIncludedOps: Operation[],
+    // Baseline decision captured by the caller before the snapshot attempt, so
+    // the late-durable-op conflict below classifies never-synced clients the
+    // same way as the pre-hydration conflict gate (#9166).
+    lastSyncedVectorClock: Record<string, number> | null,
   ): Promise<void> {
     let deferredActionsOverwrittenBySnapshot: ReturnType<typeof getDeferredActions> = [];
     let didReplaceArchive = false;
@@ -1369,8 +1387,6 @@ export class OperationLogSyncService {
           (entry) => !initialUnsyncedOpIds.has(entry.op.id),
         );
         if (lateDurableOps.length > 0) {
-          const lastSyncedVectorClock =
-            (await this.vectorClockService.getSnapshotVectorClock()) ?? null;
           throw new LocalDataConflictError(
             pendingAtHydrationCutoff.length,
             result.snapshotState as Record<string, unknown>,


### PR DESCRIPTION
## Problem

A fresh WebDAV client can already have a local state-cache snapshot before it has completed any provider sync. We were treating that snapshot clock as a last-synced baseline, so a small first-sync conflict could skip the secondary overwrite warning even while the conflict table showed `Never`.

Fixes #9166.

## Solution

Use the sync cycle's captured never-synced state when processing the conflict:

- fresh clients pass no last-synced baseline, so Keep local and Keep remote require the count-free safety warning
- established clients keep using the snapshot vector clock and the existing measured-change threshold
- a focused service test covers a never-synced client that already has a local snapshot
- the real WebDAV E2E scenarios now require the exact warning for both overwrite directions

## Verification

- `checkFile` passed for all three changed TypeScript files
- focused `OperationLogSyncService` suite: 153/153 passed
- first-sync WebDAV E2E scenarios: 2/2 passed

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] Documentation/wiki changes are not needed for this internal sync behavior fix.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Relevant existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
