### PR TITLE
fix(backup): prevent overlapping automatic backups

### DIFF
--- a/src/app/imex/local-backup/local-backup.service.spec.ts
+++ b/src/app/imex/local-backup/local-backup.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { LocalBackupService } from './local-backup.service';
 import { GlobalConfigService } from '../../features/config/global-config.service';
@@ -15,6 +15,7 @@ import { LOCAL_ACTIONS } from '../../util/local-actions.token';
 import { Action } from '@ngrx/store';
 import { DEFAULT_MAX_BACKUP_FILES } from '../../../../electron/shared-with-frontend/backup-file-cleanup.util';
 import { LS } from '../../core/persistence/storage-keys.const';
+import { Log } from '../../core/log';
 
 const BACKUP_INTERVAL = 5 * 60 * 1000;
 const DATA_CHANGE_DEBOUNCE = 30 * 1000;
@@ -704,6 +705,57 @@ describe('LocalBackupService', () => {
       tick(BACKUP_INTERVAL);
 
       expect(backupSpy).not.toHaveBeenCalled();
+    }));
+
+    it('contains a failed backup and handles a later trigger', fakeAsync(() => {
+      const { actions$, backupSpy } = setup(true);
+      const error = new DOMException(
+        'An internal error was encountered in the Indexed Database server',
+        'UnknownError',
+      );
+      const logSpy = spyOn(Log, 'err');
+      backupSpy.and.rejectWith(error);
+
+      actions$.next({ type: 'FirstAction' });
+      tick(DATA_CHANGE_DEBOUNCE);
+      flushMicrotasks();
+
+      expect(logSpy).toHaveBeenCalledWith('LocalBackupService: Backup failed', error);
+
+      backupSpy.and.resolveTo();
+      actions$.next({ type: 'SecondAction' });
+      tick(DATA_CHANGE_DEBOUNCE);
+      flushMicrotasks();
+
+      expect(backupSpy).toHaveBeenCalledTimes(2);
+    }));
+
+    it('drops an overlapping trigger and handles one after completion', fakeAsync(() => {
+      const { actions$, backupSpy } = setup(true);
+      let resolveFirstBackup: (() => void) | undefined;
+      backupSpy.and.returnValue(
+        new Promise<void>((resolve) => {
+          resolveFirstBackup = resolve;
+        }),
+      );
+
+      actions$.next({ type: 'FirstAction' });
+      tick(DATA_CHANGE_DEBOUNCE);
+      expect(backupSpy).toHaveBeenCalledTimes(1);
+
+      actions$.next({ type: 'OverlappingAction' });
+      tick(DATA_CHANGE_DEBOUNCE);
+      expect(backupSpy).toHaveBeenCalledTimes(1);
+
+      resolveFirstBackup?.();
+      flushMicrotasks();
+
+      backupSpy.and.resolveTo();
+      actions$.next({ type: 'LaterAction' });
+      tick(DATA_CHANGE_DEBOUNCE);
+      flushMicrotasks();
+
+      expect(backupSpy).toHaveBeenCalledTimes(2);
     }));
   });
 

--- a/src/app/imex/local-backup/local-backup.service.ts
+++ b/src/app/imex/local-backup/local-backup.service.ts
@@ -1,9 +1,9 @@
 import { DestroyRef, inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GlobalConfigService } from '../../features/config/global-config.service';
-import { EMPTY, firstValueFrom, interval, merge, Observable } from 'rxjs';
+import { EMPTY, firstValueFrom, from, interval, merge, Observable } from 'rxjs';
 import { LocalBackupConfig } from '../../features/config/global-config.model';
-import { debounceTime, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, debounceTime, exhaustMap, map, switchMap } from 'rxjs/operators';
 import { LOCAL_ACTIONS } from '../../util/local-actions.token';
 import { LocalBackupMeta } from './local-backup.model';
 import { IS_ANDROID_WEB_VIEW_TOKEN } from '../../util/is-android-web-view';
@@ -76,7 +76,14 @@ export class LocalBackupService {
           )
         : EMPTY,
     ),
-    tap(() => this._backup()),
+    exhaustMap(() =>
+      from(this._backup()).pipe(
+        catchError((error) => {
+          Log.err('LocalBackupService: Backup failed', error);
+          return EMPTY;
+        }),
+      ),
+    ),
   );
 
   init(): void {


### PR DESCRIPTION
## Problem

The automatic local-backup stream invoked the asynchronous backup method from `tap()` without owning its promise. If backup creation rejected, the failure surfaced as an unhandled rejection; a later timer or data-change trigger could also start another backup while the first one was still active.

This hardens the scheduler around the failure reported in #9299. It does not claim to resolve the underlying iOS/WebKit IndexedDB `UnknownError`, whose root cause is still unconfirmed.

## Solution

- Run automatic backups through `exhaustMap()` so triggers are dropped while a backup is active.
- Convert the backup promise to an observable and contain/log rejections, keeping the scheduler alive for later triggers.
- Add regression tests for rejection recovery and overlapping-trigger behavior.

## User impact

A failed automatic backup no longer becomes an unhandled promise rejection, and concurrent automatic backup attempts no longer compete for the same persistence resources. A later trigger can retry after the current attempt settles.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] Documentation reviewed; no user-facing documentation change is needed for this internal reliability fix.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files.
- [x] I have added tests for my changes.
- [x] Existing tests still pass.
- [x] My commit messages follow the Angular format (`type(scope): description`).

## Validation

- Focused `LocalBackupService` suite: 51/51 passed.
- Full `npm test`: passed, including both timezone runs.
- `npm run checkFile` passed for both modified TypeScript files.
- Six-perspective static multi-review: approved with no findings.

Related to #9299.
