### PR TITLE
fix(take-a-break): restore automatic break-timer reset and reminder teardown

### DIFF
--- a/e2e/tests/break/break-reminder-teardown.spec.ts
+++ b/e2e/tests/break/break-reminder-teardown.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import type { Page } from '@playwright/test';
+
+/**
+ * The break reminder's teardown used to hang off `_triggerReset$` only, while
+ * focus-mode breaks zeroed the counter through `otherNoBreakTIme$` and never
+ * reached it — so taking a break left the "you have been working for X" banner
+ * on screen (and, on Electron, left the lock-screen / fullscreen-blocker
+ * subjects latched at `true` for the rest of the session).
+ *
+ * The sibling spec in this folder only exercises settings navigation; its own
+ * header notes that timing tests "would require waiting for real time". The
+ * store bridge removes that constraint — the reminder threshold is shrunk to a
+ * couple of seconds so the real banner can be driven end to end.
+ *
+ * See #9305.
+ */
+
+const dispatch = async (page: Page, action: Record<string, unknown>): Promise<void> => {
+  await expect
+    .poll(
+      () =>
+        page.evaluate((a) => {
+          const store = (
+            window as unknown as {
+              __e2eTestHelpers?: { store?: { dispatch: (a: unknown) => void } };
+            }
+          ).__e2eTestHelpers?.store;
+          if (!store) return false;
+          store.dispatch(a);
+          return true;
+        }, action),
+      { timeout: 10000 },
+    )
+    .toBe(true);
+};
+
+test.describe('Break reminder teardown', () => {
+  test('dismisses the reminder banner when a focus-mode break starts', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    // remind after 2s of tracked work rather than the default hour
+    await dispatch(page, {
+      type: '[Global Config] Update Global Config Section',
+      sectionKey: 'takeABreak',
+      sectionCfg: { isTakeABreakEnabled: true, takeABreakMinWorkingTime: 2000 },
+      isSkipSnack: true,
+    });
+
+    await workViewPage.addTask('Break reminder task');
+    const task = taskPage.getTaskByText('Break reminder task');
+    await expect(task).toBeVisible();
+    const taskId = await task.getAttribute('data-task-id');
+    expect(taskId).toBeTruthy();
+
+    // start tracking via the store rather than the UI affordance: the play
+    // control lives behind a hover/context menu and is not what is under test
+    await dispatch(page, { type: '[Task] SetCurrentTask', id: taskId });
+
+    // NOTE: assert on DOM presence, not visibility. `startBreak` opens the
+    // focus-mode overlay, which would hide the banner without dismissing it —
+    // a visibility assertion would pass for the wrong reason.
+    const reminder = page.locator('banner mat-icon', { hasText: 'free_breakfast' });
+    await expect(reminder).toHaveCount(1, { timeout: 20000 });
+
+    // the reset path that used to zero the counter without tearing down the reminder
+    await dispatch(page, { type: '[FocusMode] Start Break' });
+
+    await expect(reminder).toHaveCount(0, { timeout: 10000 });
+  });
+});

--- a/src/app/features/focus-mode/store/focus-mode.bug-5875.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.bug-5875.spec.ts
@@ -93,6 +93,7 @@ describe('FocusMode Bug #5875: Pomodoro timer sync issues', () => {
 
     const takeABreakServiceMock = {
       otherNoBreakTIme$: new BehaviorSubject<number>(0),
+      resetTimer: jasmine.createSpy('resetTimer'),
     };
 
     TestBed.configureTestingModule({

--- a/src/app/features/focus-mode/store/focus-mode.bug-5995.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.bug-5995.spec.ts
@@ -90,6 +90,7 @@ describe('FocusMode Bug #5995: Resume paused break', () => {
 
     const takeABreakServiceMock = {
       otherNoBreakTIme$: new BehaviorSubject<number>(0),
+      resetTimer: jasmine.createSpy('resetTimer'),
     };
 
     TestBed.configureTestingModule({

--- a/src/app/features/focus-mode/store/focus-mode.bug-6064.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.bug-6064.spec.ts
@@ -141,9 +141,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       // Subscribe to the effect (non-dispatching effect, so we just need to subscribe)
       effects.resetBreakTimerOnBreakStart$.subscribe();
 
-      // Spy on the Subject's next method
-      spyOn(otherNoBreakTime$, 'next');
-
       // Dispatch startBreak action
       actions$.next(
         actions.startBreak({
@@ -153,7 +150,8 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       );
       tick(10);
 
-      // Verify: otherNoBreakTIme$.next(0) was called
+      // Verify: the reset went through resetTimer(), which also tears the
+      // reminder down (otherNoBreakTIme$.next(0) only zeroed the counter)
       expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
       expect(takeABreakServiceMock.resetTimer).toHaveBeenCalledTimes(1);
 
@@ -170,7 +168,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       store.refreshState();
 
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       // Dispatch startBreak action
       actions$.next(
@@ -197,7 +194,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       store.refreshState();
 
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       // Dispatch startBreak action
       actions$.next(
@@ -217,7 +213,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
 
     it('should reset break timer for short breaks', fakeAsync(() => {
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       // Dispatch short break (5 minutes)
       actions$.next(
@@ -235,7 +230,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
 
     it('should reset break timer for long breaks', fakeAsync(() => {
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       // Dispatch long break (15 minutes)
       actions$.next(
@@ -253,7 +247,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
 
     it('should reset break timer multiple times across multiple breaks', fakeAsync(() => {
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       // First break
       actions$.next(
@@ -292,7 +285,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
     it('should reset break timer for auto-started breaks', fakeAsync(() => {
       // Auto-started break (triggered by session completion)
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       // Dispatch startBreak from autoStartBreakOnSessionComplete$ effect
       actions$.next(
@@ -319,7 +311,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       store.refreshState();
 
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       // Dispatch startBreak from user action
       actions$.next(
@@ -341,7 +332,6 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       store.refreshState();
 
       effects.resetBreakTimerOnBreakStart$.subscribe();
-      spyOn(otherNoBreakTime$, 'next');
 
       actions$.next(
         actions.startBreak({

--- a/src/app/features/focus-mode/store/focus-mode.bug-6064.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.bug-6064.spec.ts
@@ -60,6 +60,9 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
 
     takeABreakServiceMock = {
       otherNoBreakTIme$: otherNoBreakTime$,
+      // #9305: the reset now goes through resetTimer() so it also tears the
+      // reminder down; otherNoBreakTIme$.next(0) only zeroed the counter
+      resetTimer: jasmine.createSpy('resetTimer'),
     };
 
     const strategyFactoryMock = {
@@ -151,8 +154,8 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       tick(10);
 
       // Verify: otherNoBreakTIme$.next(0) was called
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
-      expect(otherNoBreakTime$.next).toHaveBeenCalledTimes(1);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalledTimes(1);
 
       flush();
     }));
@@ -179,7 +182,7 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       tick(10);
 
       // Verify: Break timer still resets
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));
@@ -207,7 +210,7 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       tick(10);
 
       // Verify: Break timer still resets
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));
@@ -225,7 +228,7 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       );
       tick(10);
 
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));
@@ -243,7 +246,7 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       );
       tick(10);
 
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));
@@ -280,8 +283,8 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       tick(10);
 
       // Verify: Reset was called 3 times
-      expect(otherNoBreakTime$.next).toHaveBeenCalledTimes(3);
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalledTimes(3);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));
@@ -301,7 +304,7 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       );
       tick(10);
 
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));
@@ -327,7 +330,7 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       );
       tick(10);
 
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));
@@ -349,7 +352,7 @@ describe('FocusMode Bug #6064: Without break timer reset on break start', () => 
       tick(10);
 
       // Effect is unconditional - it always resets the break timer
-      expect(otherNoBreakTime$.next).toHaveBeenCalledWith(0);
+      expect(takeABreakServiceMock.resetTimer).toHaveBeenCalled();
 
       flush();
     }));

--- a/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
@@ -32,6 +32,10 @@ import { HydrationStateService } from '../../../op-log/apply/hydration-state.ser
 
 describe('FocusModeEffects', () => {
   let actions$: Observable<any>;
+  let takeABreakServiceMock: {
+    otherNoBreakTIme$: BehaviorSubject<number>;
+    resetTimer: jasmine.Spy;
+  };
   let effects: FocusModeEffects;
   let store: MockStore;
   let strategyFactoryMock: any;
@@ -100,8 +104,9 @@ describe('FocusModeEffects', () => {
         .and.returnValue(false),
     };
 
-    const takeABreakServiceMock = {
+    takeABreakServiceMock = {
       otherNoBreakTIme$: new BehaviorSubject<number>(0),
+      resetTimer: jasmine.createSpy('resetTimer'),
     };
 
     notifyServiceMock = {
@@ -163,6 +168,21 @@ describe('FocusModeEffects', () => {
 
   afterEach(() => {
     store.resetSelectors();
+  });
+
+  describe('resetBreakTimerOnBreakStart$', () => {
+    // #6064 / #9305: must go through resetTimer(), not otherNoBreakTIme$.next(0).
+    // The latter only zeroes the counter and skips the reminder teardown, so the
+    // "take a break" banner stays up and the lock-screen / fullscreen-blocker
+    // subjects stay latched at `true` for the rest of the session.
+    it('resets the break timer via resetTimer() when a break starts', (done) => {
+      actions$ = of(actions.startBreak({}));
+
+      effects.resetBreakTimerOnBreakStart$.subscribe(() => {
+        expect(takeABreakServiceMock.resetTimer).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
   });
 
   describe('syncDurationWithMode$', () => {
@@ -1219,7 +1239,10 @@ describe('FocusModeEffects', () => {
           },
           {
             provide: TakeABreakService,
-            useValue: { otherNoBreakTIme$: new BehaviorSubject<number>(0) },
+            useValue: {
+              otherNoBreakTIme$: new BehaviorSubject<number>(0),
+              resetTimer: jasmine.createSpy('resetTimer'),
+            },
           },
           { provide: NotifyService, useValue: { notify: androidNotify } },
           {

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -697,9 +697,10 @@ export class FocusModeEffects {
       this.actions$.pipe(
         ofType(actions.startBreak),
         tap(() => {
-          // Signal TakeABreakService to reset its timer
-          // otherNoBreakTIme$ feeds into the break timer's tick stream
-          this.takeABreakService.otherNoBreakTIme$.next(0);
+          // Signal TakeABreakService to reset its timer. Must be resetTimer()
+          // rather than otherNoBreakTIme$.next(0): the latter only zeroes the
+          // counter and skips the reminder teardown, leaving a stale banner up.
+          this.takeABreakService.resetTimer();
         }),
       ),
     { dispatch: false },

--- a/src/app/features/focus-mode/store/focus-mode.flowtime.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.flowtime.spec.ts
@@ -98,6 +98,7 @@ describe('FocusMode Flowtime behavior', () => {
     let effects: FocusModeEffects;
     const takeABreakServiceMock = {
       otherNoBreakTIme$: new BehaviorSubject<number>(0),
+      resetTimer: jasmine.createSpy('resetTimer'),
     };
 
     beforeEach(() => {
@@ -334,6 +335,7 @@ describe('FocusMode Flowtime behavior', () => {
     };
     const takeABreakServiceMock = {
       otherNoBreakTIme$: new BehaviorSubject<number>(0),
+      resetTimer: jasmine.createSpy('resetTimer'),
     };
 
     beforeEach(() => {
@@ -443,6 +445,7 @@ describe('FocusMode Flowtime behavior', () => {
     let getStrategySpy: jasmine.Spy;
     const takeABreakServiceMock = {
       otherNoBreakTIme$: new BehaviorSubject<number>(0),
+      resetTimer: jasmine.createSpy('resetTimer'),
     };
 
     beforeEach(() => {

--- a/src/app/features/idle/store/idle.actions.ts
+++ b/src/app/features/idle/store/idle.actions.ts
@@ -32,6 +32,3 @@ export const idleDialogResult = createAction(
     simpleCounterToggleBtnsWhenNoTrackItems?: SimpleCounterIdleBtn[];
   }>(),
 );
-
-// TODO better place would be the take a break module, if we ever add a store there
-export const triggerResetBreakTimer = createAction('[Idle] Reset break timer');

--- a/src/app/features/take-a-break/take-a-break.service.spec.ts
+++ b/src/app/features/take-a-break/take-a-break.service.spec.ts
@@ -10,11 +10,11 @@ import { IdleService } from '../idle/idle.service';
 import { GlobalConfigService } from '../config/global-config.service';
 import { NotifyService } from '../../core/notify/notify.service';
 import { BannerService } from '../../core/banner/banner.service';
-import { ChromeExtensionInterfaceService } from '../../core/chrome-extension-interface/chrome-extension-interface.service';
 import { UiHelperService } from '../ui-helper/ui-helper.service';
 import { SnackService } from '../../core/snack/snack.service';
 import { LOCAL_ACTIONS } from '../../util/local-actions.token';
 import { BannerId } from '../../core/banner/banner.model';
+import { Tick } from '../../core/global-tracking-interval/tick.model';
 import { T } from '../../t.const';
 
 describe('TakeABreakService', () => {
@@ -23,9 +23,11 @@ describe('TakeABreakService', () => {
   let snackService: jasmine.SpyObj<SnackService>;
   let bannerService: jasmine.SpyObj<BannerService>;
   let actions$: Subject<Action>;
+  let tick$: Subject<Tick>;
 
   beforeEach(() => {
     actions$ = new Subject<Action>();
+    tick$ = new Subject<Tick>();
     taskService = jasmine.createSpyObj<TaskService>('TaskService', [
       'pauseCurrent',
       'currentTaskId',
@@ -47,19 +49,23 @@ describe('TakeABreakService', () => {
         { provide: SnackService, useValue: snackService },
         { provide: BannerService, useValue: bannerService },
         { provide: LOCAL_ACTIONS, useValue: actions$ },
-        { provide: GlobalTrackingIntervalService, useValue: { tick$: new Subject() } },
+        { provide: GlobalTrackingIntervalService, useValue: { tick$: tick$ } },
         { provide: IdleService, useValue: { isIdle$: of(false) } },
         {
           provide: GlobalConfigService,
           useValue: {
-            cfg$: of({ takeABreak: { isTakeABreakEnabled: true } }),
+            cfg$: of({
+              takeABreak: { isTakeABreakEnabled: true },
+              // idle tracking on is the shipped default, and it used to be the
+              // configuration in which the automatic break-timer reset was dead
+              idle: { isEnableIdleTimeTracking: true },
+            }),
             takeABreak$: of({ isTakeABreakEnabled: true }),
-            idle$: of({ isEnableIdleTimeTracking: false }),
+            idle$: of({ isEnableIdleTimeTracking: true }),
             sound$: of({ breakReminderSound: null, volume: 0 }),
           },
         },
         { provide: NotifyService, useValue: { notifyDesktop: () => undefined } },
-        { provide: ChromeExtensionInterfaceService, useValue: { isReady$: of(false) } },
         {
           provide: UiHelperService,
           useValue: { focusAppAfterNotification: () => undefined },
@@ -71,12 +77,15 @@ describe('TakeABreakService', () => {
   });
 
   describe('idle dialog result', () => {
+    const IDLE_TIME = 5 * 60000;
     const BREAK_ITEM: IdleTrackItem = {
       type: 'BREAK',
       time: 'IDLE_TIME',
       simpleCounterToggleBtns: [],
     };
-    const TASK_ITEM: IdleTrackItem = {
+    // only SPLIT mode sends a resolved number; BREAK/TASK send the 'IDLE_TIME'
+    // placeholder with the duration in the action's separate idleTime field
+    const SPLIT_TASK_ITEM: IdleTrackItem = {
       type: 'TASK',
       time: 60000,
       title: 'Some task',
@@ -91,7 +100,7 @@ describe('TakeABreakService', () => {
         trackItems,
         isResetBreakTimer,
         wasFocusSessionRunning: false,
-        idleTime: 5 * 60000,
+        idleTime: IDLE_TIME,
       });
 
     let emitted: number[];
@@ -124,8 +133,30 @@ describe('TakeABreakService', () => {
     });
 
     it('adds tracked task time but not break time when not resetting', () => {
-      actions$.next(dialogResult([BREAK_ITEM, TASK_ITEM], false));
+      actions$.next(dialogResult([BREAK_ITEM, SPLIT_TASK_ITEM], false));
       expect(current()).toBe(10000 + 60000);
+    });
+
+    it('dismisses the reminder banner when the timer is reset', () => {
+      actions$.next(dialogResult([], true));
+
+      expect(bannerService.dismiss).toHaveBeenCalledTimes(1);
+      expect(bannerService.dismiss).toHaveBeenCalledWith(BannerId.TakeABreak);
+    });
+  });
+
+  describe('with idle tracking enabled', () => {
+    it('counts a long stretch without a tracked task as a break', () => {
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+      service.otherNoBreakTIme$.next(10000);
+      expect(emitted[emitted.length - 1]).toBe(10000);
+
+      // more than BREAK_TRIGGER_DURATION with no current task selected
+      tick$.next({ duration: 11 * 60000, date: '2026-07-28', timestamp: 0 });
+
+      expect(emitted[emitted.length - 1]).toBe(0);
+      sub.unsubscribe();
     });
   });
 

--- a/src/app/features/take-a-break/take-a-break.service.spec.ts
+++ b/src/app/features/take-a-break/take-a-break.service.spec.ts
@@ -158,6 +158,43 @@ describe('TakeABreakService', () => {
       expect(emitted[emitted.length - 1]).toBe(0);
       sub.unsubscribe();
     });
+
+    // Characterises the overlap between the two reset mechanisms: while the user
+    // is away, the current task is already deselected, so the "long stretch with
+    // no tracked task" reset fires during the absence -- before the idle dialog
+    // is ever answered. Answering it with the reset checkbox explicitly UNCHECKED
+    // therefore cannot preserve the pre-idle counter; it is already gone.
+    it('lets the untracked-stretch reset win over an explicit opt-out in the idle dialog', () => {
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+      service.otherNoBreakTIme$.next(89 * 60000);
+      expect(emitted[emitted.length - 1]).toBe(89 * 60000);
+
+      // user goes idle -> handleIdleInit$ deselects the task -> ticks accumulate
+      // as "no current task" for longer than BREAK_TRIGGER_DURATION
+      tick$.next({ duration: 11 * 60000, date: '2026-07-28', timestamp: 0 });
+      expect(emitted[emitted.length - 1]).toBe(0);
+
+      // user returns and says "that was work on a task, do NOT reset my timer"
+      actions$.next(
+        idleDialogResult({
+          trackItems: [
+            {
+              type: 'TASK',
+              time: 'IDLE_TIME',
+              title: 'Some task',
+              simpleCounterToggleBtns: [],
+            },
+          ],
+          isResetBreakTimer: false,
+          wasFocusSessionRunning: false,
+          idleTime: 11 * 60000,
+        }),
+      );
+
+      expect(emitted[emitted.length - 1]).toBe(0);
+      sub.unsubscribe();
+    });
   });
 
   describe('startBreak()', () => {

--- a/src/app/features/take-a-break/take-a-break.service.spec.ts
+++ b/src/app/features/take-a-break/take-a-break.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { of, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { TakeABreakService } from './take-a-break.service';
 import { idleDialogResult } from '../idle/store/idle.actions';
@@ -24,6 +24,7 @@ describe('TakeABreakService', () => {
   let bannerService: jasmine.SpyObj<BannerService>;
   let actions$: Subject<Action>;
   let tick$: Subject<Tick>;
+  let currentTaskId$: BehaviorSubject<string | null>;
 
   beforeEach(() => {
     actions$ = new Subject<Action>();
@@ -32,8 +33,12 @@ describe('TakeABreakService', () => {
       'pauseCurrent',
       'currentTaskId',
     ]);
-    // `currentTaskId$` is read as a property during construction.
-    (taskService as unknown as { currentTaskId$: unknown }).currentTaskId$ = of(null);
+    // `currentTaskId$` is read as a property during construction. It must be a
+    // live subject, not `of(null)`: `of` completes, which makes it impossible to
+    // exercise the untracked-stretch reset re-arming after a task is tracked.
+    currentTaskId$ = new BehaviorSubject<string | null>(null);
+    (taskService as unknown as { currentTaskId$: unknown }).currentTaskId$ =
+      currentTaskId$;
     taskService.currentTaskId.and.returnValue(null);
 
     snackService = jasmine.createSpyObj<SnackService>('SnackService', ['open']);
@@ -142,6 +147,67 @@ describe('TakeABreakService', () => {
 
       expect(bannerService.dismiss).toHaveBeenCalledTimes(1);
       expect(bannerService.dismiss).toHaveBeenCalledWith(BannerId.TakeABreak);
+    });
+  });
+
+  describe('reminder teardown', () => {
+    // The idle dialog used to reset the counter without reaching _triggerReset$,
+    // so the banner stayed up and the lock-screen / fullscreen-blocker subjects
+    // stayed latched at `true` for the rest of the session. (Focus-mode breaks
+    // had the same problem; that one is guarded in focus-mode.effects.spec.ts,
+    // since the routing lives in the effect.)
+    it('dismisses the reminder when the idle dialog requests a reset', () => {
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+      service.otherNoBreakTIme$.next(10000);
+
+      actions$.next(
+        idleDialogResult({
+          trackItems: [],
+          isResetBreakTimer: true,
+          wasFocusSessionRunning: false,
+          idleTime: 60000,
+        }),
+      );
+
+      expect(emitted[emitted.length - 1]).toBe(0);
+      expect(bannerService.dismiss).toHaveBeenCalledWith(BannerId.TakeABreak);
+      sub.unsubscribe();
+    });
+
+    it('tears down only once while nothing is being tracked', () => {
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+
+      // past BREAK_TRIGGER_DURATION, then many further ticks
+      for (let i = 0; i < 15; i++) {
+        tick$.next({ duration: 60000, date: '2026-07-28', timestamp: 0 });
+      }
+
+      expect(emitted[emitted.length - 1]).toBe(0);
+      expect(bannerService.dismiss).toHaveBeenCalledTimes(1);
+      sub.unsubscribe();
+    });
+
+    // The edge trigger must re-arm, or the automatic reset degrades to
+    // once-per-session — the same silent-death shape as the #9305 bug itself.
+    it('re-arms after a task is tracked and stopped again', () => {
+      const sub = service.timeWorkingWithoutABreak$.subscribe();
+      const untrackedStretch = (): void => {
+        for (let i = 0; i < 15; i++) {
+          tick$.next({ duration: 60000, date: '2026-07-28', timestamp: 0 });
+        }
+      };
+
+      untrackedStretch();
+      expect(bannerService.dismiss).toHaveBeenCalledTimes(1);
+
+      currentTaskId$.next('task-1');
+      currentTaskId$.next(null);
+      untrackedStretch();
+
+      expect(bannerService.dismiss).toHaveBeenCalledTimes(2);
+      sub.unsubscribe();
     });
   });
 

--- a/src/app/features/take-a-break/take-a-break.service.spec.ts
+++ b/src/app/features/take-a-break/take-a-break.service.spec.ts
@@ -26,7 +26,7 @@ describe('TakeABreakService', () => {
   let tick$: Subject<Tick>;
   let currentTaskId$: BehaviorSubject<string | null>;
 
-  beforeEach(() => {
+  const configure = (isTakeABreakEnabled = true): void => {
     actions$ = new Subject<Action>();
     tick$ = new Subject<Tick>();
     taskService = jasmine.createSpyObj<TaskService>('TaskService', [
@@ -60,12 +60,12 @@ describe('TakeABreakService', () => {
           provide: GlobalConfigService,
           useValue: {
             cfg$: of({
-              takeABreak: { isTakeABreakEnabled: true },
+              takeABreak: { isTakeABreakEnabled },
               // idle tracking on is the shipped default, and it used to be the
               // configuration in which the automatic break-timer reset was dead
               idle: { isEnableIdleTimeTracking: true },
             }),
-            takeABreak$: of({ isTakeABreakEnabled: true }),
+            takeABreak$: of({ isTakeABreakEnabled }),
             idle$: of({ isEnableIdleTimeTracking: true }),
             sound$: of({ breakReminderSound: null, volume: 0 }),
           },
@@ -79,7 +79,9 @@ describe('TakeABreakService', () => {
     });
 
     service = TestBed.inject(TakeABreakService);
-  });
+  };
+
+  beforeEach(() => configure());
 
   describe('idle dialog result', () => {
     const IDLE_TIME = 5 * 60000;
@@ -209,6 +211,80 @@ describe('TakeABreakService', () => {
       expect(bannerService.dismiss).toHaveBeenCalledTimes(2);
       sub.unsubscribe();
     });
+
+    // The teardown is deliberately NOT gated on isTakeABreakEnabled: gating it
+    // means toggling the feature off mid-session strands _triggerLockScreenCounter$
+    // and _triggerFullscreenBlocker$ at `true`, and because both are
+    // distinctUntilChanged() the later next(true) is swallowed — so re-enabling
+    // can never re-arm them. Dismissing a banner that cannot be open is a no-op.
+    it('still tears the reminder down when the feature is disabled', () => {
+      TestBed.resetTestingModule();
+      configure(false);
+
+      const sub = service.timeWorkingWithoutABreak$.subscribe();
+      service.resetTimer();
+
+      expect(bannerService.dismiss).toHaveBeenCalledWith(BannerId.TakeABreak);
+      sub.unsubscribe();
+    });
+  });
+
+  describe('counter arithmetic', () => {
+    const trackTask = (): void => {
+      taskService.currentTaskId.and.returnValue('task-1');
+      currentTaskId$.next('task-1');
+    };
+
+    // Only _triggerReset$ may zero the counter. The seedless scan treats any
+    // value <= 0 as a reset, and a 0 is a normal Android event: the focus-mode
+    // effects pass `cap = Math.max(0, timer.duration - timer.elapsed)` to
+    // triggerWakeUpTick, which is exactly 0 once a session reaches its duration.
+    // Zeroing through the tick branch skips the teardown, so the banner would
+    // keep claiming hours of work over a counter reading 0.
+    it('ignores a zero-duration tick rather than zeroing the counter', () => {
+      const twoHours = 2 * 60 * 60000;
+      const oneMinute = 60000;
+      trackTask();
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+      service.otherNoBreakTIme$.next(twoHours);
+
+      tick$.next({ duration: 0, date: '2026-07-28', timestamp: 0 });
+
+      expect(emitted[emitted.length - 1]).toBe(twoHours);
+      expect(bannerService.dismiss).not.toHaveBeenCalled();
+
+      // positive control: a real tick still accumulates, so the assertion above
+      // is not passing merely because the tick branch is wired up wrong
+      tick$.next({ duration: oneMinute, date: '2026-07-28', timestamp: 0 });
+      expect(emitted[emitted.length - 1]).toBe(twoHours + oneMinute);
+      sub.unsubscribe();
+    });
+
+    // consumeCurrentTick() is unclamped, so a backwards clock step goes negative
+    it('ignores a negative tick rather than zeroing the counter', () => {
+      trackTask();
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+      service.otherNoBreakTIme$.next(10000);
+
+      tick$.next({ duration: -5000, date: '2026-07-28', timestamp: 0 });
+
+      expect(emitted[emitted.length - 1]).toBe(10000);
+      sub.unsubscribe();
+    });
+
+    it('zeroes the counter on resetTimer()', () => {
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+      service.otherNoBreakTIme$.next(10000);
+      expect(emitted[emitted.length - 1]).toBe(10000);
+
+      service.resetTimer();
+
+      expect(emitted[emitted.length - 1]).toBe(0);
+      sub.unsubscribe();
+    });
   });
 
   describe('with idle tracking enabled', () => {
@@ -259,6 +335,41 @@ describe('TakeABreakService', () => {
       );
 
       expect(emitted[emitted.length - 1]).toBe(0);
+      sub.unsubscribe();
+    });
+
+    // The other half of the same overlap, and the reason the reset is edge- and
+    // not level-triggered: once it has fired, time added later in the SAME
+    // untracked stretch survives. With a level trigger the next tick wiped it
+    // again -- and every tick after -- so unchecking the dialog's reset box was
+    // inert for any absence over BREAK_TRIGGER_DURATION. SPLIT is the only mode
+    // that sends a resolved number, and handleIdleDialogResult$ re-selects a task
+    // only for a single task item, so with 2+ items the stretch keeps running.
+    it('keeps task time from an opt-out added after the untracked-stretch reset', () => {
+      const emitted: number[] = [];
+      const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
+
+      tick$.next({ duration: 11 * 60000, date: '2026-07-28', timestamp: 0 });
+      expect(emitted[emitted.length - 1]).toBe(0);
+
+      actions$.next(
+        idleDialogResult({
+          trackItems: [
+            { type: 'TASK', time: 6 * 60000, title: 'A', simpleCounterToggleBtns: [] },
+            { type: 'TASK', time: 5 * 60000, title: 'B', simpleCounterToggleBtns: [] },
+          ],
+          isResetBreakTimer: false,
+          wasFocusSessionRunning: false,
+          idleTime: 11 * 60000,
+        }),
+      );
+      expect(emitted[emitted.length - 1]).toBe(11 * 60000);
+
+      // still untracked: a level trigger would re-zero this on the next tick
+      tick$.next({ duration: 60000, date: '2026-07-28', timestamp: 0 });
+      tick$.next({ duration: 60000, date: '2026-07-28', timestamp: 0 });
+
+      expect(emitted[emitted.length - 1]).toBe(11 * 60000);
       sub.unsubscribe();
     });
   });

--- a/src/app/features/take-a-break/take-a-break.service.ts
+++ b/src/app/features/take-a-break/take-a-break.service.ts
@@ -73,9 +73,15 @@ export class TakeABreakService {
       shareReplay(1),
     );
 
+  // NOTE: edge-triggered on purpose. _timeWithNoCurrentTask$ grows monotonically
+  // while nothing is tracked, so a plain filter would re-fire on every 1s tick
+  // for as long as the app stays open — and timeWorkingWithoutABreak$ is bound
+  // via `| async` in the work view, so each one costs a change-detection pass.
   private _triggerSimpleBreakReset$: Observable<unknown> =
     this._timeWithNoCurrentTask$.pipe(
-      filter((timeWithNoTask) => timeWithNoTask > BREAK_TRIGGER_DURATION),
+      map((timeWithNoTask) => timeWithNoTask > BREAK_TRIGGER_DURATION),
+      distinctUntilChanged(),
+      filter(Boolean),
     );
 
   private _tick$: Observable<number> = merge(
@@ -85,11 +91,10 @@ export class TakeABreakService {
     ),
     this._actions$.pipe(ofType(idleDialogResult)).pipe(
       switchMap(({ trackItems, isResetBreakTimer }) => {
-        // the dialog checkbox is the single source of truth for resetting; it
-        // auto-defaults to checked when a break is tracked, so an unchecked
-        // value means the user explicitly opted out of the reset
+        // a requested reset is a reset event, not a measurement — it goes
+        // through _triggerReset$ so it also tears the reminder down
         if (isResetBreakTimer) {
-          return of(0);
+          return EMPTY;
         }
         // without a reset, time tracked to tasks still counts as work; break
         // items don't (but they don't reset the timer either).
@@ -102,6 +107,14 @@ export class TakeABreakService {
       }),
     ),
     this.otherNoBreakTIme$,
+  );
+
+  // the dialog checkbox is the single source of truth for resetting; it
+  // auto-defaults to checked when a break is tracked, so an unchecked value
+  // means the user explicitly opted out of the reset
+  private _triggerIdleDialogReset$: Observable<unknown> = this._actions$.pipe(
+    ofType(idleDialogResult),
+    filter(({ isResetBreakTimer }) => isResetBreakTimer),
   );
 
   private _triggerSnooze$: Subject<number> = new Subject();
@@ -126,9 +139,15 @@ export class TakeABreakService {
 
   private _triggerManualReset$: Subject<number> = new Subject<number>();
 
+  // Every reset path must land here: _triggerReset$ both zeroes the counter and
+  // drives the reminder teardown below, so a reset routed around it (as the idle
+  // dialog and focus-mode breaks used to be) leaves a stale banner up and leaves
+  // the lock-screen / fullscreen-blocker subjects latched at `true`, silently
+  // disabling both for the rest of the session. See #9305.
   private _triggerReset$: Observable<number> = merge(
     this._triggerProgrammaticReset$,
     this._triggerManualReset$,
+    this._triggerIdleDialogReset$,
   ).pipe(mapTo(0));
 
   timeWorkingWithoutABreak$: Observable<number> = merge(
@@ -202,23 +221,16 @@ export class TakeABreakService {
   > = this._triggerBanner$.pipe(throttleTime(DESKTOP_NOTIFICATION_THROTTLE));
 
   constructor() {
-    // Derive the reminder teardown from the counter itself rather than from
-    // _triggerReset$: the idle dialog and focus-mode breaks zero the counter
-    // through _tick$, which bypasses _triggerReset$ entirely. They therefore
-    // used to leave a stale banner up, and — because the lock-screen and
-    // fullscreen-blocker subjects are distinctUntilChanged() — left those
-    // latched at `true`, silently disabling both for the rest of the session.
-    this.timeWorkingWithoutABreak$
-      .pipe(
-        filter((timeWorkingWithoutABreak) => timeWorkingWithoutABreak === 0),
-        withLatestFrom(this._configService.takeABreak$),
-        filter(([, cfg]) => cfg && cfg.isTakeABreakEnabled),
-      )
-      .subscribe(() => {
-        this._triggerLockScreenCounter$.next(false);
-        this._triggerFullscreenBlocker$.next(false);
-        this._bannerService.dismiss(BANNER_ID);
-      });
+    // NOTE: deliberately not gated on isTakeABreakEnabled. Dismissing a banner
+    // that cannot be open and un-latching subjects that cannot be `true` are
+    // both no-ops, whereas skipping the teardown when the feature is toggled
+    // off mid-session strands those subjects at `true` for good — the exact
+    // state this is here to prevent.
+    this._triggerReset$.subscribe(() => {
+      this._triggerLockScreenCounter$.next(false);
+      this._triggerFullscreenBlocker$.next(false);
+      this._bannerService.dismiss(BANNER_ID);
+    });
 
     if (IS_ELECTRON) {
       this._triggerLockScreenThrottledAndDelayed$.subscribe(() => {

--- a/src/app/features/take-a-break/take-a-break.service.ts
+++ b/src/app/features/take-a-break/take-a-break.service.ts
@@ -17,7 +17,6 @@ import {
 } from 'rxjs/operators';
 import { GlobalConfigService } from '../config/global-config.service';
 import { msToString } from '../../ui/duration/ms-to-string.pipe';
-import { ChromeExtensionInterfaceService } from '../../core/chrome-extension-interface/chrome-extension-interface.service';
 import { IdleService } from '../idle/idle.service';
 import { IS_ELECTRON } from '../../app.constants';
 import { BannerService } from '../../core/banner/banner.service';
@@ -28,7 +27,7 @@ import { NotifyService } from '../../core/notify/notify.service';
 import { UiHelperService } from '../ui-helper/ui-helper.service';
 import { Tick } from '../../core/global-tracking-interval/tick.model';
 import { ofType } from '@ngrx/effects';
-import { idleDialogResult, triggerResetBreakTimer } from '../idle/store/idle.actions';
+import { idleDialogResult } from '../idle/store/idle.actions';
 import { playSound } from '../../util/play-sound';
 import { LOCAL_ACTIONS } from '../../util/local-actions.token';
 import { SnackService } from '../../core/snack/snack.service';
@@ -59,7 +58,6 @@ export class TakeABreakService {
   private _configService = inject(GlobalConfigService);
   private _notifyService = inject(NotifyService);
   private _bannerService = inject(BannerService);
-  private _chromeExtensionInterfaceService = inject(ChromeExtensionInterfaceService);
   private _uiHelperService = inject(UiHelperService);
   private _snackService = inject(SnackService);
 
@@ -75,24 +73,10 @@ export class TakeABreakService {
       shareReplay(1),
     );
 
-  private _isIdleResetEnabled$: Observable<boolean> = this._configService.idle$.pipe(
-    switchMap((idleCfg) => {
-      const isConfigured = idleCfg.isEnableIdleTimeTracking;
-      // return [true];
-      if (IS_ELECTRON) {
-        return [isConfigured];
-      } else if (isConfigured) {
-        return this._chromeExtensionInterfaceService.isReady$;
-      } else {
-        return [false];
-      }
-    }),
-    distinctUntilChanged(),
-  );
-
-  private _triggerSimpleBreakReset$: Observable<any> = this._timeWithNoCurrentTask$.pipe(
-    filter((timeWithNoTask) => timeWithNoTask > BREAK_TRIGGER_DURATION),
-  );
+  private _triggerSimpleBreakReset$: Observable<unknown> =
+    this._timeWithNoCurrentTask$.pipe(
+      filter((timeWithNoTask) => timeWithNoTask > BREAK_TRIGGER_DURATION),
+    );
 
   private _tick$: Observable<number> = merge(
     this._timeTrackingService.tick$.pipe(
@@ -108,7 +92,9 @@ export class TakeABreakService {
           return of(0);
         }
         // without a reset, time tracked to tasks still counts as work; break
-        // items don't (but they don't reset the timer either)
+        // items don't (but they don't reset the timer either).
+        // NOTE: only SPLIT mode sends numbers here — BREAK/TASK send the
+        // 'IDLE_TIME' placeholder, so this contributes 0 for them. See #9352.
         const noBreakTime = trackItems
           .filter((t) => t.type === 'TASK')
           .reduce((acc, t) => acc + (typeof t.time === 'number' ? t.time : 0), 0);
@@ -130,13 +116,13 @@ export class TakeABreakService {
     }),
   );
 
-  private _triggerProgrammaticReset$: Observable<any> = this._isIdleResetEnabled$.pipe(
-    switchMap((isIdleResetEnabled) => {
-      return isIdleResetEnabled
-        ? this._actions$.pipe(ofType(triggerResetBreakTimer))
-        : this._triggerSimpleBreakReset$;
-    }),
-  );
+  // NOTE: this used to be skipped whenever idle tracking was on, on the
+  // assumption that the idle path would reset the timer instead. It hasn't:
+  // the action it waited for lost its last dispatcher in v11.1.0, so for every
+  // Electron user (idle tracking defaults to on) the automatic reset was dead
+  // and only the idle dialog's checkbox could clear the timer. See #9305.
+  private _triggerProgrammaticReset$: Observable<unknown> =
+    this._triggerSimpleBreakReset$;
 
   private _triggerManualReset$: Subject<number> = new Subject<number>();
 
@@ -216,10 +202,17 @@ export class TakeABreakService {
   > = this._triggerBanner$.pipe(throttleTime(DESKTOP_NOTIFICATION_THROTTLE));
 
   constructor() {
-    this._triggerReset$
+    // Derive the reminder teardown from the counter itself rather than from
+    // _triggerReset$: the idle dialog and focus-mode breaks zero the counter
+    // through _tick$, which bypasses _triggerReset$ entirely. They therefore
+    // used to leave a stale banner up, and — because the lock-screen and
+    // fullscreen-blocker subjects are distinctUntilChanged() — left those
+    // latched at `true`, silently disabling both for the rest of the session.
+    this.timeWorkingWithoutABreak$
       .pipe(
+        filter((timeWorkingWithoutABreak) => timeWorkingWithoutABreak === 0),
         withLatestFrom(this._configService.takeABreak$),
-        filter(([reset, cfg]) => cfg && cfg.isTakeABreakEnabled),
+        filter(([, cfg]) => cfg && cfg.isTakeABreakEnabled),
       )
       .subscribe(() => {
         this._triggerLockScreenCounter$.next(false);

--- a/src/app/features/take-a-break/take-a-break.service.ts
+++ b/src/app/features/take-a-break/take-a-break.service.ts
@@ -73,10 +73,19 @@ export class TakeABreakService {
       shareReplay(1),
     );
 
-  // NOTE: edge-triggered on purpose. _timeWithNoCurrentTask$ grows monotonically
-  // while nothing is tracked, so a plain filter would re-fire on every 1s tick
-  // for as long as the app stays open — and timeWorkingWithoutABreak$ is bound
-  // via `| async` in the work view, so each one costs a change-detection pass.
+  // NOTE: edge-triggered on purpose, and this changes semantics, not just cost.
+  //
+  // Cost: _timeWithNoCurrentTask$ grows monotonically while nothing is tracked,
+  // so a plain filter re-fired on every 1s tick for as long as the app stayed
+  // open — and timeWorkingWithoutABreak$ is bound via `| async` in the work
+  // view, so each one cost a change-detection pass.
+  //
+  // Semantics: the reset now fires once per untracked stretch instead of pinning
+  // the counter to 0 for its whole duration, so time added LATER in the same
+  // stretch survives. That is the point — the idle dialog deselects the task
+  // (idle.effects.ts), so with a level trigger the dialog's "reset break timer"
+  // checkbox was inert for any absence over BREAK_TRIGGER_DURATION: unchecking
+  // it kept the tracked time for one tick before the next tick wiped it again.
   private _triggerSimpleBreakReset$: Observable<unknown> =
     this._timeWithNoCurrentTask$.pipe(
       map((timeWithNoTask) => timeWithNoTask > BREAK_TRIGGER_DURATION),
@@ -107,6 +116,17 @@ export class TakeABreakService {
       }),
     ),
     this.otherNoBreakTIme$,
+  ).pipe(
+    // Additions only. The seedless scan below treats any value <= 0 as a reset,
+    // so an out-of-band non-positive value used to zero the counter WITHOUT
+    // tearing the reminder down, leaving the banner claiming hours of work over
+    // a counter reading 0. That is not hypothetical: Android passes
+    // `cap = Math.max(0, timer.duration - timer.elapsed)` to
+    // `triggerWakeUpTick`, which is exactly 0 whenever a focus session sits at
+    // or over its duration (android-focus-mode.effects.ts), and
+    // `consumeCurrentTick()` is unclamped, so a backwards clock step goes
+    // negative. Resetting is `_triggerReset$`'s job alone.
+    filter((duration) => duration > 0),
   );
 
   // the dialog checkbox is the single source of truth for resetting; it
@@ -144,6 +164,13 @@ export class TakeABreakService {
   // dialog and focus-mode breaks used to be) leaves a stale banner up and leaves
   // the lock-screen / fullscreen-blocker subjects latched at `true`, silently
   // disabling both for the rest of the session. See #9305.
+  //
+  // Subscribed twice (the teardown below, and timeWorkingWithoutABreak$) and
+  // deliberately left cold: _timeWithNoCurrentTask$ is shareReplay(1), so the
+  // second subscriber is handed exactly the last value the first one saw and the
+  // two distinctUntilChanged instances cannot diverge. Do not "fix" this with
+  // share() — that would trade a state argument that holds unconditionally for
+  // one that depends on nothing emitting between the two subscribe calls.
   private _triggerReset$: Observable<number> = merge(
     this._triggerProgrammaticReset$,
     this._triggerManualReset$,


### PR DESCRIPTION
Two defects in `TakeABreakService`, both found while triaging #9305. Both are restorations of behaviour that was intended and silently lost — not new behaviour.

They are independent of that issue's main symptom (idle *detection* failing on the reporter's Ubuntu box — still awaiting logs), but they are the "going idle should also stop the break-reminder timer" half of it, and they affect everyone on Electron with default settings.

### 1. The automatic break-timer reset has been dead since v11.1.0

`_triggerProgrammaticReset$` branched on whether idle tracking was enabled:

```ts
isIdleResetEnabled
  ? this._actions$.pipe(ofType(triggerResetBreakTimer))
  : this._triggerSimpleBreakReset$;
```

`triggerResetBreakTimer` lost its last dispatcher in `aaca8d9657` (Jan 2025), which moved the reset into the idle-dialog result and left this waiting on an action nobody sends. Since `isEnableIdleTimeTracking` defaults to `true` on Electron, that silently disabled the `_triggerSimpleBreakReset$` fallback — "10 minutes with no tracked task counts as a break" — for essentially every desktop user, and for browser users once the extension connects. Turning idle tracking *off* was the only way to get it back, which is backwards.

This is also the unfixed half of #6064 ("Without break timer doesn't reset", expected *"should reset during breaks **and when no task is counting**"*), which was closed by a fix that only covered "during breaks".

Fix: drop the dead branch and the now-unreferenced action.

It is also now **edge-triggered**. `_timeWithNoCurrentTask$` grows monotonically, so a plain `filter` re-fired on every 1s tick for as long as the app stayed open — and `timeWorkingWithoutABreak$` is bound via `| async` at `work-view.component.html:65` behind an `@if` that is hardcoded true, so each emission cost a change-detection pass on the work view. Left open overnight with nothing tracked, that is ~28,800 wake-ups.

### 2. Two reset paths bypassed the reminder teardown

`_bannerService.dismiss(BANNER_ID)`, `_triggerLockScreenCounter$.next(false)` and `_triggerFullscreenBlocker$.next(false)` hung off `_triggerReset$`, but two real reset paths zeroed the counter through `_tick$` instead and never reached it:

- the idle dialog's "reset break reminder timer" / BREAK mode
- focus-mode breaks (`focus-mode.effects.ts`, `otherNoBreakTIme$.next(0)`)

So after taking a break through either, the stale "you have been working for X without one" banner stayed up. Worse: those two subjects are `distinctUntilChanged()`, so without the `next(false)` they stay latched at `true` — **lock screen and the timed fullscreen blocker go silently dead for the rest of the session** after the first break reminder, for users who have them enabled.

Fix: route every reset through `_triggerReset$`. Focus-mode calls `resetTimer()`; the idle dialog's reset request is forked out of `_tick$` into its own stream. The teardown is also no longer gated on `isTakeABreakEnabled` — dismissing a banner that cannot be open and un-latching subjects that cannot be `true` are both no-ops, whereas skipping the teardown when the feature is toggled off mid-session stranded those subjects at `true` for good, which is the exact state this code exists to prevent.

### Tests

The spec's `GlobalConfigService` stub used `isEnableIdleTimeTracking: false` — precisely the configuration in which defect 1 is invisible. Switched to the shipped default.

`resetBreakTimerOnBreakStart$` had **no coverage at all**, and four sibling focus-mode specs mocked `TakeABreakService` without `resetTimer`, so the routing change broke five tests in the #6064 spec. The edge trigger also needed a live `currentTaskId$` subject rather than `of(null)`, which completes — without that, a one-shot reset (`take(1)`) passes every test, which is the same silent-death shape as the bug being fixed.

Each guard was sabotage-verified individually:

| test | reverting the fix gives |
|---|---|
| counts a long stretch without a tracked task as a break | `Expected 10000 to be 0` |
| dismisses the reminder banner when the timer is reset | `dismiss` called 0 times |
| tears down only once while nothing is being tracked | `dismiss` called 5 times |
| re-arms after a task is tracked and stopped again | `dismiss` called 1 time, expected 2 |
| resets the break timer via resetTimer() when a break starts | `resetTimer` called 0 times |

Full local suite green (`npm test`, both TZ variants), `checkFile` clean on all touched files.

There is also now an **end-to-end test** (`e2e/tests/break/break-reminder-teardown.spec.ts`) covering the user-visible symptom: the reminder threshold is shrunk to 2s via the store bridge, a task is tracked until the real banner appears, a focus-mode break is started, and the banner must leave the DOM. Reverting focus-mode to `otherNoBreakTIme$.next(0)` fails it.

This is the feature's first real e2e coverage — the existing `tests/break/take-a-break.spec.ts` only walks settings pages, and its header explains why ("full break timing tests would require waiting for real time"). The assertion is on DOM presence rather than visibility on purpose: `startBreak` opens the focus-mode overlay, which would hide the banner without dismissing it, so a visibility assertion would pass even with the bug present.

Unrelated but worth knowing: `TaskPage.toggleTaskTimeTracking()` targets `.play-btn`, which no longer exists in the task template. It has no callers; the new test dispatches `[Task] SetCurrentTask` instead.

### Caveats worth knowing before merging

- **The lock-screen / fullscreen-blocker half of defect 2 is still unverified.** The banner half is now covered end to end, but `IS_ELECTRON` is a compile-time const (`app.constants.ts:5`), so both observables are `EMPTY` under Karma, `_triggerBanner$` guards the `next(true)` on it too, and the e2e suite runs the web build. The latching behaviour was checked with standalone rxjs harnesses only. Switching this service to the existing `IS_ELECTRON_TOKEN` would make it unit-testable; not done here to keep the diff contained. The direct manual check is: enable lock screen, set the reminder to 1 minute, track → banner + lock screen arms → "Pause & Break" → track again → confirm it arms a **second** time.
- **Defect 1 is a deliberate cadence change for every Electron user**: break reminders will fire less often, because pausing tracking for 10 minutes counts as a break again.
- **A non-positive tick still zeroes the counter** via the seedless `scan` — it just no longer tears the reminder down, so after a backwards clock step the banner can disagree with the counter. Pre-existing; needs a separate guard on the tick branch.
- **Open design question**: the untracked-stretch reset fires *during* an idle absence (the task is already deselected), so answering the idle dialog with "reset break reminder timer" explicitly unchecked no longer preserves the pre-idle counter. `1eace3799d` characterises this. Suppressing the reset while an idle absence is pending would keep that checkbox meaningful; not suppressing says "away 15+ minutes was a break regardless". Undecided.

### Deliberately not in this PR

- #9352 — the `idleDialogResult` branch computes `noBreakTime` with a `typeof t.time === 'number'` check that never matches the `'IDLE_TIME'` placeholder BREAK/TASK modes actually send, so it contributes `0`. Fixing it would switch on a path dormant for 18 months and interacts with a pre-existing double count, so it needs its own decision.
- #9356 — `LOCK_SCREEN_THROTTLE` / `FULLSCREEN_BLOCKER_THROTTLE` are dead code (the `throttleTime` sits inside a `switchMap` over a fresh single-value `of(v)`, so it never throttles).

Refs #9305
