### PR TITLE
fix(sync): detect Electron and iPad in client-ID platform prefix

### DIFF
--- a/electron/electronAPI.d.ts
+++ b/electron/electronAPI.d.ts
@@ -2,8 +2,8 @@
 // That program sets `types: []`, so it has no ambient Node globals of its own and
 // relied on the now-removed `import { IpcRendererEvent } from 'electron'` here to
 // transitively supply them. Several frontend/shared modules still probe Node globals
-// guarded at runtime (get-dist-channel's `process`/`NodeJS`, generate-client-id's
-// `process`, create-task-placeholder's `NodeJS.Timeout`, user-profile's `require`),
+// guarded at runtime (get-dist-channel's `process`/`NodeJS`,
+// create-task-placeholder's `NodeJS.Timeout`, user-profile's `require`),
 // so re-expose them explicitly instead of by accident.
 /// <reference types="node" />
 import {

--- a/src/app/core/util/generate-client-id.spec.ts
+++ b/src/app/core/util/generate-client-id.spec.ts
@@ -1,7 +1,40 @@
-import { generateClientId, isValidClientIdFormat } from './generate-client-id';
+import {
+  generateClientId,
+  getPlatformCode,
+  isValidClientIdFormat,
+} from './generate-client-id';
 
 describe('generate-client-id', () => {
+  describe('getPlatformCode()', () => {
+    const NONE = { isElectron: false, isAndroid: false, isIos: false };
+
+    it('maps each platform to its own character', () => {
+      expect(getPlatformCode({ ...NONE, isElectron: true })).toBe('E');
+      expect(getPlatformCode({ ...NONE, isAndroid: true })).toBe('A');
+      expect(getPlatformCode({ ...NONE, isIos: true })).toBe('I');
+      expect(getPlatformCode(NONE)).toBe('B');
+    });
+
+    it('resolves overlapping platforms as Electron > Android > iOS', () => {
+      // The predicates are independent, so the precedence is a real guard. The
+      // near case is macOS Electron, which already matches IS_IOS's `Mac`
+      // user-agent half — see the note on getPlatformCode. #9353.
+      expect(getPlatformCode({ isElectron: true, isAndroid: true, isIos: true })).toBe(
+        'E',
+      );
+      expect(getPlatformCode({ ...NONE, isAndroid: true, isIos: true })).toBe('A');
+    });
+  });
+
   describe('generateClientId()', () => {
+    it('uses the browser code in the Karma browser env', () => {
+      // IS_ELECTRON, IS_ANDROID_WEB_VIEW, IS_IOS_NATIVE and IS_IOS are all false
+      // here — same smoke-test shape as get-app-version-str.spec.ts. Per-branch
+      // assertions live on getPlatformCode(), since the constants behind them
+      // are frozen at module load and cannot be stubbed.
+      expect(generateClientId().charAt(0)).toBe('B');
+    });
+
     it('produces an id matching the new {platform}_{6-char} format', () => {
       expect(/^[BEAI]_[a-zA-Z0-9]{6}$/.test(generateClientId())).toBeTrue();
     });

--- a/src/app/core/util/generate-client-id.ts
+++ b/src/app/core/util/generate-client-id.ts
@@ -1,44 +1,71 @@
+import { IS_ELECTRON } from '../../app.constants';
+import { IS_IOS } from '../../util/is-ios';
+import { IS_IOS_NATIVE } from '../../util/is-native-platform';
+import { IS_ANDROID_WEB_VIEW } from '../../util/is-android-web-view';
+
 /**
- * Pure client-ID generation and format validation.
+ * Client-ID generation and format validation.
  *
  * Extracted from ClientIdService so destructive-flow callers (clean-slate,
  * backup-restore) can mint an id without going through the stateful service —
  * the new id is persisted only inside the atomic SUP_OPS transaction in
  * OperationLogStoreService.runDestructiveStateReplacement. See issue #7732.
  *
- * No DI, no I/O — directly unit-testable.
+ * No DI. Platform detection reuses the app-wide constants rather than
+ * re-deriving it here: local re-derivation is what broke in #9353. Those
+ * constants are frozen at module load and cannot be stubbed, so the mapping is
+ * split into a pure `getPlatformCode()` that a spec can drive directly — the
+ * same split `util/get-app-version-str.ts` uses for `distChannelSuffix()`.
  */
+
+type PlatformCode = 'B' | 'E' | 'A' | 'I';
+
+interface ClientPlatform {
+  isElectron: boolean;
+  isAndroid: boolean;
+  isIos: boolean;
+}
 
 /**
- * Returns a single-character platform identifier for compact client IDs.
+ * Maps a platform to the single character that prefixes a compact client ID.
  * B = Browser, E = Electron, A = Android, I = iOS.
+ *
+ * The three predicates are independent, so nothing structurally prevents an
+ * overlap and the order is a deliberate guard rather than an arbitrary one. The
+ * closest real case is macOS Electron, which already satisfies `IS_IOS`'s
+ * `Mac` user-agent half — only `'ontouchend' in document` (false on Macs today)
+ * keeps it from also reading as iOS. Electron therefore wins first.
  */
-const _getEnvironmentId = (): string => {
-  // Detect Electron
-  const isElectron =
-    typeof process !== 'undefined' &&
-    !!(process as { versions?: { electron?: string } }).versions?.electron;
-  if (isElectron) {
+export const getPlatformCode = (platform: ClientPlatform): PlatformCode => {
+  if (platform.isElectron) {
     return 'E';
   }
-
-  // Detect Android WebView
-  if (/Android/.test(navigator.userAgent) && /wv/.test(navigator.userAgent)) {
+  if (platform.isAndroid) {
     return 'A';
   }
-
-  // Detect iOS
-  if (
-    navigator.userAgent.includes('iOS') ||
-    navigator.userAgent.includes('iPhone') ||
-    navigator.userAgent.includes('iPad')
-  ) {
+  if (platform.isIos) {
     return 'I';
   }
-
-  // Default: Browser
   return 'B';
 };
+
+const _getEnvironmentId = (): PlatformCode =>
+  getPlatformCode({
+    isElectron: IS_ELECTRON,
+    // `window.SUPAndroid`, injected by both Android activities
+    // (CapacitorMainActivity and the legacy FullscreenActivity), so Play and
+    // F-Droid both stay 'A'. Deliberately narrower than the `Android`+`wv`
+    // user-agent test it replaces: our page inside some *other* app's WebView
+    // is a browser for forensic purposes, and now reports 'B'.
+    isAndroid: IS_ANDROID_WEB_VIEW,
+    // Capacitor first — it is authoritative for the native app, which is the
+    // case that actually broke, and cannot drift when Apple changes a UA. IS_IOS
+    // is the web fallback: it carries the iPadOS desktop-UA workaround and keeps
+    // mobile Safari on 'I'. IS_IOS_NATIVE alone would demote iPhone Safari to
+    // 'B'; IS_IOS alone would leave native detection resting on a deprecated
+    // `navigator.platform` heuristic — the same fragility as the original bug.
+    isIos: IS_IOS_NATIVE || IS_IOS,
+  });
 
 /**
  * Generates a random base62 string of the specified length.
@@ -65,6 +92,14 @@ export const generateClientId = (): string => {
  *
  * Used to narrow `unknown` values read from IndexedDB. An invalid format is
  * treated as "absent" rather than fatal — see issue #6197.
+ *
+ * The `[BEAI]` class is a compatibility contract with the installed fleet, not
+ * a local detail. "Invalid" means "absent" all the way down: a client that does
+ * not know a prefix reads null (`client-id.service.ts:165`) and then mints over
+ * the stored id (`:217`) — a silent vector-clock key rotation, one-time per
+ * install but permanent, the identity loss #7732 exists to prevent. So a fifth
+ * platform code may only ship once the receiving fleet already accepts it.
+ * Adding `E`/`I` here was safe precisely because every released client does.
  */
 export const isValidClientIdFormat = (id: unknown): id is string => {
   return (


### PR DESCRIPTION
Fixes #9353.

## Problem

`_getEnvironmentId()` re-derived platform detection locally instead of using the constants the app already has, and both of its checks were dead — so **Electron desktop and iPad both minted `B_` ids**:

- **Electron** tested `process.versions.electron`. The renderer runs with `contextIsolation: true` / `nodeIntegration: false` (fail-closed, enforced by `electron/web-preferences-guard.ts:60,65`), so `process` is never exposed to page scripts.
- **iOS** user-agent-matched `iOS|iPhone|iPad`, but iPadOS sends a desktop macOS UA. iPhone still matched via the `iPhone` clause, so this branch was half-dead rather than fully dead. Separately, the literal string `iOS` appears in **no** Apple user agent (Apple writes `iPhone OS` / `CPU OS`), and there is no `appendUserAgent` override in `capacitor.config.ts` or `ios/` — so that clause never fired on any device.

Client IDs are vector-clock keys and appear in most sync log lines. In #9332, attributing 25 operations to a device required subtracting three download responses precisely because a Windows desktop (`B_0oqz0T`, `B_XAqPeJ`) and an iPad (`B_6gFpTt`) were indistinguishable.

## Fix

Reuse the app-wide constants instead of re-deriving detection.

- **iOS = `IS_IOS_NATIVE || IS_IOS`.** Capacitor is authoritative for the native app — the case that actually broke — and can't drift when Apple changes a UA. `IS_IOS` is the web fallback: it carries the iPadOS desktop-UA workaround and keeps mobile Safari on `I`. `IS_IOS_NATIVE` alone would have *demoted* iPhone Safari from `I` to `B`.
- **Android = `IS_ANDROID_WEB_VIEW`** (`window.SUPAndroid`), injected by both activities (`CapacitorMainActivity.kt:185`, `FullscreenActivity.kt:218`), so Play and F-Droid both stay `A`.
- **Ordering is Electron > Android > iOS.** The predicates are independent, so overlap isn't structurally prevented; macOS Electron already satisfies `IS_IOS`'s `Mac` UA half, with only `'ontouchend' in document` (false on Macs today) between it and a wrong `I`.

The mapping is split into a pure `getPlatformCode()` returning a `'B' | 'E' | 'A' | 'I'` literal union, mirroring the `distChannelSuffix()` / `detectChannel()` split in `util/get-app-version-str.ts`. The union makes the `[BEAI]` contract compiler-enforced rather than only runtime-asserted.

## Behavior change per platform

| Platform | Before | After |
|---|---|---|
| Windows / Linux / macOS Electron | `B` | **`E`** ✅ |
| iPad, native app (iPadOS desktop UA) | `B` | **`I`** ✅ |
| Legacy Android activity (custom UA omits `wv`) | `B` | **`A`** ✅ |
| iPhone / iPad mobile Safari | `B`* | **`I`** |
| Our page inside another app's Android WebView | `A` | **`B`** |
| Capacitor Android (Play / F-Droid) | `A` | `A` |
| iPhone native / older iPad UA | `I` | `I` |
| Android Chrome / PWA, desktop browsers | `B` | `B` |

\* iPhone mobile Safari was already `I`; iPadOS mobile Safari was `B`.

The last two rows are deliberate and are called out because they go slightly beyond the reported bug: our page inside a *third-party* Android WebView is a browser for forensic purposes, and the legacy-activity row is a bonus fix that fell out of dropping the `wv` user-agent test.

## Scope and safety

- **Only newly minted ids change.** Existing ids are persisted vector-clock keys and are never rewritten. Verified all three `generateClientId()` call sites; `client-id.service.ts:217`'s CAS only mints when the stored value is absent or invalid.
- `isValidClientIdFormat` already accepts `^[BEAI]_[a-zA-Z0-9]{6}$`, so the format, the wire contract and the server are untouched. No schema bump.
- Nothing anywhere parses the prefix — only the `[BEAI]` char class plus display-only `slice()` in log lines. The sync server treats `clientId` as an opaque string.
- Existing installs keep their `B_` ids; the prefix self-corrects only on a future clean-slate or backup-restore, which already rotate the id today.

Also documents that `[BEAI]` is a **compatibility contract**, not a local detail: a client that doesn't know a prefix reads `null` (`client-id.service.ts:165`) and then mints over the stored id (`:217`) — a silent, permanent vector-clock key rotation. A fifth platform code may only ship once the receiving fleet already accepts it. Adding `E`/`I` was safe precisely because every released client already does.

## Testing

- `npm run lint` repo-wide: exit 0.
- `npx ng build` (AOT): exit 0.
- 84 specs green: `generate-client-id` 10, `client-id.service` 18, `clean-slate` 9, `backup` 29, `clean-slate-interrupt` 3, `get-app-version-str` 15.
- Sabotage-verified: reordering the ladder fails exactly one test (`Expected 'A' to be 'E'`); reinstating the original `process` check fails with `Expected 'B' to be 'E'`, the literal field symptom.

**Known limitation, stated deliberately:** the tests pin the *mapping*, not the *detection wiring*. `IS_ELECTRON` / `IS_IOS` / `IS_IOS_NATIVE` / `IS_ANDROID_WEB_VIEW` are frozen at module load and can't be stubbed, and all are `false` under Karma — so hardcoding `isIos: false` (i.e. reinstating the iPad bug) leaves all 10 specs green. I verified this rather than assuming it. Closing the gap would need module mocking or re-introducing the local detection that caused this bug in the first place; the per-platform behavior is covered by manual check only.

## Follow-up filed

#9355 — a separate, pre-existing regression found while reviewing this file: the `{4}`→`{6}` validator tightening in `ec16757c82` (v18.11.0) silently rotates client ids minted on v18.7.0–v18.10.0. One-character fix, not included here to keep this PR scoped.
