### PR TITLE
fix(electron): allow SiYuan deep links

### DIFF
--- a/electron/shared-with-frontend/is-external-url-allowed.ts
+++ b/electron/shared-with-frontend/is-external-url-allowed.ts
@@ -13,10 +13,11 @@
  * item) — a far narrower surface than the OS-level handlers this allowlist
  * exists to block. They are allow-listed because productivity users routinely
  * link tasks to such apps (#8429: obsidian:// links stopped opening after the
- * GHSA-hr87 fix; #8859: outlook: deep-links to mail items). The GHSA-hr87 fix
- * was a regression that silently broke every previously-working scheme at once,
- * so the popular note/task apps in this same low-risk class (notion:, things:,
- * omnifocus:, bear:, joplin:) are restored proactively alongside #8859.
+ * GHSA-hr87 fix; #8859: outlook: deep-links to mail items; #9292: siyuan://
+ * links to notes). The GHSA-hr87 fix was a regression that silently broke every
+ * previously-working scheme at once, so the popular note/task apps in this same
+ * low-risk class (notion:, things:, omnifocus:, bear:, joplin:) are restored
+ * proactively alongside #8859.
  * shortcut: a curated set — if a user needs a scheme that isn't here, the
  * upgrade path is a user-configurable allowlist in settings (MiscConfig).
  *
@@ -40,6 +41,7 @@ export const ALLOWED_EXTERNAL_URL_SCHEMES = [
   'omnifocus:',
   'bear:',
   'joplin:',
+  'siyuan:',
   'outlook:', // #8859 — Outlook desktop deep-links (outlook:<EntryID>)
   'webexteams:',
 ];

--- a/src/app/ui/is-external-url-allowed.spec.ts
+++ b/src/app/ui/is-external-url-allowed.spec.ts
@@ -29,6 +29,7 @@ describe('isExternalUrlSchemeAllowed', () => {
       'omnifocus:///task/abc123',
       'bear://x-callback-url/open-note?id=ABC123',
       'joplin://x-callback-url/openNote?id=abc123def456',
+      'siyuan://blocks/20240101000000-abcdefg',
       // #8859 — Outlook desktop deep-link: opaque EntryID, no `//` authority.
       'outlook:0000000067E6410516B83D47AC4C8EB786CE10920700A34574545A43BF41AC9C4F77801FE8E100000000010C0000A34574545A43BF41AC9C4F77801FE8E10009672045BC0000',
       'webexteams://im?space=ff135070-68f8-11f1-9229-c7e6cca7a7cd&message=f4f13440-6b50-11f1-8868-03e71232fa87',
@@ -57,6 +58,7 @@ describe('isExternalUrlSchemeAllowed', () => {
         'omnifocus:',
         'bear:',
         'joplin:',
+        'siyuan:',
         'outlook:',
         'webexteams:',
       ]);

--- a/src/app/ui/marked-options-factory.spec.ts
+++ b/src/app/ui/marked-options-factory.spec.ts
@@ -390,6 +390,7 @@ describe('markedOptionsFactory', () => {
           // #8429: app deep-links must stay clickable
           'obsidian://open?vault=Notes',
           'vscode://file/home/user/x.ts',
+          'siyuan://blocks/20240101000000-abcdefg',
           'webexteams://im?space=ff135070-68f8-11f1-9229-c7e6cca7a7cd&message=f4f13440-6b50-11f1-8868-03e71232fa87',
         ].forEach((href) => {
           const result = linkRenderer({


### PR DESCRIPTION
## Problem

Task-note links using the `siyuan://` protocol are rendered as inert text with the warning `Link blocked: unsafe URL scheme`.

This prevents users from opening SiYuan notes from their Super Productivity tasks.

Fixes #9292.

## Solution

- Add only the exact `siyuan:` protocol to the existing shared external URL allowlist.
- Add URL-policy regression coverage for a representative `siyuan://blocks/...` link.
- Verify that the Markdown renderer produces a clickable anchor for SiYuan links.
- Keep the existing blocking behavior for unsafe, malformed, and unapproved schemes unchanged.

### Before

The SiYuan link is rendered as blocked, inert text:

<img width="1280" height="720" alt="SiYuan link blocked before the change" src="https://github.com/user-attachments/assets/3f08d054-86b6-424f-a903-f912ddf58460" />

### After

The same note is rendered as a clickable `siyuan://` link:

<img width="1280" height="720" alt="SiYuan link allowed after the change" src="https://github.com/user-attachments/assets/12143db0-1b5e-4683-aca7-620c294e5b32" />

I verified the browser rendering locally. I did not test launching the SiYuan desktop application because SiYuan is not installed on the test machine.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] No wiki change is relevant for this narrowly scoped allowlist addition; the behavior is documented inline.
- [x] I have run `npm run checkFile` on all changed `.ts` files.
- [x] I have added tests for my changes.
- [x] Existing tests still pass.
- [x] My commit message follows the Angular format (`type(scope): description`).

## Validation

- URL-policy tests: 64/64 passed.
- Markdown-renderer tests: 71/71 passed.
- Full application suite: 13,590 passed, 2 skipped.
- Alternate-timezone suite: 13,576 passed, 16 skipped.
- Electron tests: 243/243 passed.
- Full lint pipeline completed with zero errors.
- Existing unsafe and malformed URL schemes remain blocked.
