### PR TITLE
fix(idle): defer the isIdle edge during sync instead of dropping it

### DIFF
--- a/eslint-local-rules/rules/require-hydration-guard.js
+++ b/eslint-local-rules/rules/require-hydration-guard.js
@@ -63,7 +63,7 @@ module.exports = {
     },
     messages: {
       missingHydrationGuard:
-        'Selector-based effect is missing hydration guard. Add skipWhileApplyingRemoteOps() or filter with isApplyingRemoteOps() to prevent duplicate operations during sync replay.',
+        'Selector-based effect is missing hydration guard. Add skipWhileApplyingRemoteOps(), or waitForSyncWindow() if the selector is edge-triggered (a value that flips once and stays — dropping that emission loses it forever, see #9348), or filter with isApplyingRemoteOps().',
     },
     schema: [],
   },

--- a/eslint-local-rules/rules/require-hydration-guard.js
+++ b/eslint-local-rules/rules/require-hydration-guard.js
@@ -15,6 +15,9 @@
  *
  * Effects that USE SELECTORS AS THE PRIMARY SOURCE should include one of:
  * - `skipWhileApplyingRemoteOps()` operator (preferred)
+ * - `waitForSyncWindow()` operator - defers instead of dropping. Required when the
+ *   selector is edge-triggered (a value that flips once and stays, e.g. behind
+ *   `distinctUntilChanged()`), since a dropped edge is never re-emitted (#9348)
  * - `skipDuringSync()` operator (deprecated alias)
  * - `filter(() => !this.hydrationState.isApplyingRemoteOps())`
  *
@@ -293,7 +296,10 @@ module.exports = {
       return (
         chainText.includes('skipWhileApplyingRemoteOps') ||
         chainText.includes('skipDuringSync') ||
-        chainText.includes('isApplyingRemoteOps')
+        chainText.includes('isApplyingRemoteOps') ||
+        // defers instead of dropping - required when the selector is
+        // edge-triggered, because a dropped edge can never be recovered (#9348)
+        chainText.includes('waitForSyncWindow')
       );
     };
 

--- a/eslint-local-rules/rules/require-hydration-guard.spec.js
+++ b/eslint-local-rules/rules/require-hydration-guard.spec.js
@@ -38,6 +38,20 @@ ruleTester.run('require-hydration-guard', rule, {
       `,
     },
 
+    // Selector with waitForSyncWindow guard (defers instead of dropping, #9348)
+    // - should NOT flag
+    {
+      code: `
+        createEffect(() =>
+          this._store$.select(mySelector).pipe(
+            distinctUntilChanged(),
+            waitForSyncWindow(this._hydrationStateService, 'myEffect$'),
+            tap(() => this.doSomething())
+          )
+        )
+      `,
+    },
+
     // Selector with skipDuringSync guard (deprecated alias) - should NOT flag
     {
       code: `

--- a/src/app/features/idle/store/idle.effects.spec.ts
+++ b/src/app/features/idle/store/idle.effects.spec.ts
@@ -29,6 +29,10 @@ describe('IdleEffects', () => {
     addEventListener: jasmine.Spy;
   };
   let idleCallback: ((ev: Event, data?: unknown) => void) | null;
+  let simpleCounterServiceMock: {
+    enabledSimpleStopWatchCounters$: BehaviorSubject<{ id: string; isOn: boolean }[]>;
+    decreaseCounterToday: jasmine.Spy;
+  };
 
   const setup = (overrides?: {
     isSuppressIdleDuringFocusMode?: boolean;
@@ -61,6 +65,13 @@ describe('IdleEffects', () => {
       setCurrentId: jasmine.createSpy('setCurrentId'),
     };
 
+    simpleCounterServiceMock = {
+      enabledSimpleStopWatchCounters$: new BehaviorSubject<
+        { id: string; isOn: boolean }[]
+      >([]),
+      decreaseCounterToday: jasmine.createSpy('decreaseCounterToday'),
+    };
+
     TestBed.configureTestingModule({
       providers: [
         IdleEffects,
@@ -88,10 +99,7 @@ describe('IdleEffects', () => {
         { provide: TaskService, useValue: taskServiceMock },
         { provide: MatDialog, useValue: {} as any },
         { provide: UiHelperService, useValue: {} as any },
-        {
-          provide: SimpleCounterService,
-          useValue: { enabledSimpleStopWatchCounters$: new BehaviorSubject([]) },
-        },
+        { provide: SimpleCounterService, useValue: simpleCounterServiceMock },
         {
           provide: DateService,
           useValue: { todayStr: () => '2026-07-13' },
@@ -287,6 +295,33 @@ describe('IdleEffects', () => {
       expect(taskSpies().removeTimeSpent).toHaveBeenCalledTimes(1);
       expect(taskSpies().removeTimeSpent.calls.mostRecent().args[0]).toBe('task-1');
       expect(taskSpies().setCurrentId).toHaveBeenCalledWith(null);
+    });
+
+    // Same hazard, other entity: a counter switched on during the wait never ran
+    // during the idle period, so decrementing it would delete recorded habit time.
+    it('decrements the counters running at the edge, not ones started during the wait', () => {
+      setup();
+      const hydrationState = TestBed.inject(HydrationStateService);
+      simpleCounterServiceMock.enabledSimpleStopWatchCounters$.next([
+        { id: 'counter-at-edge', isOn: true },
+      ]);
+      listen();
+
+      hydrationState.startApplyingRemoteOps();
+      goIdle();
+
+      // user comes back mid-window, stops that counter and starts another
+      simpleCounterServiceMock.enabledSimpleStopWatchCounters$.next([
+        { id: 'counter-started-later', isOn: true },
+      ]);
+
+      hydrationState.endApplyingRemoteOps();
+      TestBed.flushEffects();
+
+      expect(simpleCounterServiceMock.decreaseCounterToday).toHaveBeenCalledTimes(1);
+      expect(
+        simpleCounterServiceMock.decreaseCounterToday.calls.mostRecent().args[0],
+      ).toBe('counter-at-edge');
     });
   });
 });

--- a/src/app/features/idle/store/idle.effects.spec.ts
+++ b/src/app/features/idle/store/idle.effects.spec.ts
@@ -206,11 +206,32 @@ describe('IdleEffects', () => {
       TestBed.flushEffects();
     };
 
+    const taskSpies = (): {
+      currentTaskId: jasmine.Spy;
+      removeTimeSpent: jasmine.Spy;
+      setCurrentId: jasmine.Spy;
+    } =>
+      TestBed.inject(TaskService) as unknown as {
+        currentTaskId: jasmine.Spy;
+        removeTimeSpent: jasmine.Spy;
+        setCurrentId: jasmine.Spy;
+      };
+
     afterEach(() => {
       sub?.unsubscribe();
       // the effect starts a 1s poll interval; stop it so it cannot dispatch
       // into a torn-down TestBed
-      (effects as unknown as { _cancelIdlePoll: () => void })._cancelIdlePoll();
+      (
+        effects as unknown as { _cancelIdlePoll?: () => void } | undefined
+      )?._cancelIdlePoll?.();
+      // startApplyingRemoteOps() writes a MODULE-level flag that TestBed teardown
+      // does not reset, so a test that throws before its own endApplyingRemoteOps()
+      // would leave every later spec buffering its actions - invisible, and Karma
+      // randomises spec order. Same precaution as tag.effects.spec.ts.
+      const hydrationState = TestBed.inject(HydrationStateService);
+      hydrationState.endApplyingRemoteOps();
+      hydrationState.clearPostSyncCooldown();
+      hydrationState.closeSyncWindow();
     });
 
     it('opens the idle dialog when nothing is being applied', () => {
@@ -233,6 +254,8 @@ describe('IdleEffects', () => {
 
       // still held: the mutations must not run mid-apply
       expect(emitted.length).toBe(0);
+      expect(taskSpies().removeTimeSpent).not.toHaveBeenCalled();
+      expect(taskSpies().setCurrentId).not.toHaveBeenCalled();
 
       hydrationState.endApplyingRemoteOps();
       TestBed.flushEffects();
@@ -240,6 +263,30 @@ describe('IdleEffects', () => {
       // ...but they must not be lost either
       expect(emitted.length).toBe(1);
       expect(emitted[0].type).toBe(openIdleDialog.type);
+      expect(taskSpies().removeTimeSpent).toHaveBeenCalledTimes(1);
+    });
+
+    // The deferral can outlive the user's return. If the entity were re-read
+    // after the wait, the idle time would be subtracted from whatever task is
+    // current by then - deleting real tracked work from a task that never
+    // accrued it.
+    it('subtracts the idle time from the task running at the edge, not one started during the wait', () => {
+      setup();
+      const hydrationState = TestBed.inject(HydrationStateService);
+      listen();
+
+      hydrationState.startApplyingRemoteOps();
+      goIdle();
+
+      // user comes back mid-window and starts tracking something else
+      taskSpies().currentTaskId.and.returnValue('task-2');
+
+      hydrationState.endApplyingRemoteOps();
+      TestBed.flushEffects();
+
+      expect(taskSpies().removeTimeSpent).toHaveBeenCalledTimes(1);
+      expect(taskSpies().removeTimeSpent.calls.mostRecent().args[0]).toBe('task-1');
+      expect(taskSpies().setCurrentId).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/src/app/features/idle/store/idle.effects.spec.ts
+++ b/src/app/features/idle/store/idle.effects.spec.ts
@@ -16,8 +16,9 @@ import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
 import { IPC } from '../../../../../electron/shared-with-frontend/ipc-events.const';
 import { selectIdleConfig } from '../../config/store/global-config.reducer';
 import { selectIsSessionRunning } from '../../focus-mode/store/focus-mode.selectors';
-import { selectIsIdle } from './idle.selectors';
-import { triggerIdle } from './idle.actions';
+import { selectIdleTime, selectIsIdle } from './idle.selectors';
+import { openIdleDialog, triggerIdle } from './idle.actions';
+import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 
 describe('IdleEffects', () => {
   let effects: IdleEffects;
@@ -56,6 +57,8 @@ describe('IdleEffects', () => {
 
     const taskServiceMock = {
       currentTaskId: jasmine.createSpy('currentTaskId').and.returnValue('task-1'),
+      removeTimeSpent: jasmine.createSpy('removeTimeSpent'),
+      setCurrentId: jasmine.createSpy('setCurrentId'),
     };
 
     TestBed.configureTestingModule({
@@ -76,6 +79,7 @@ describe('IdleEffects', () => {
             },
             { selector: selectIsSessionRunning, value: isSessionRunning },
             { selector: selectIsIdle, value: false },
+            { selector: selectIdleTime, value: 0 },
           ],
         }),
         { provide: DataInitStateService, useValue: dataInitStateMock },
@@ -179,6 +183,63 @@ describe('IdleEffects', () => {
         expect(emitted[0]).toEqual(triggerIdle({ idleTime: 120000 }));
         done();
       }, 200);
+    });
+  });
+
+  describe('handleIdleInit$', () => {
+    // #9348: selectIsIdle emits `true` exactly once per idle episode. Dropping
+    // that single edge (rather than deferring it) loses the side effects for
+    // good AND leaves the store stuck at isIdle:true, which makes every later
+    // idle tick short-circuit on isAlreadyIdle - idle handling is then dead
+    // for the whole session.
+    let emitted: Action[];
+    let sub: { unsubscribe: () => void };
+
+    const listen = (): void => {
+      emitted = [];
+      sub = effects.handleIdleInit$.subscribe((a) => emitted.push(a));
+    };
+
+    const goIdle = (): void => {
+      store.overrideSelector(selectIsIdle, true);
+      store.refreshState();
+      TestBed.flushEffects();
+    };
+
+    afterEach(() => {
+      sub?.unsubscribe();
+      // the effect starts a 1s poll interval; stop it so it cannot dispatch
+      // into a torn-down TestBed
+      (effects as unknown as { _cancelIdlePoll: () => void })._cancelIdlePoll();
+    });
+
+    it('opens the idle dialog when nothing is being applied', () => {
+      setup();
+      listen();
+
+      goIdle();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].type).toBe(openIdleDialog.type);
+    });
+
+    it('defers - not drops - the idle side effects when the edge lands inside a sync apply window', () => {
+      setup();
+      const hydrationState = TestBed.inject(HydrationStateService);
+      listen();
+
+      hydrationState.startApplyingRemoteOps();
+      goIdle();
+
+      // still held: the mutations must not run mid-apply
+      expect(emitted.length).toBe(0);
+
+      hydrationState.endApplyingRemoteOps();
+      TestBed.flushEffects();
+
+      // ...but they must not be lost either
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].type).toBe(openIdleDialog.type);
     });
   });
 });

--- a/src/app/features/idle/store/idle.effects.ts
+++ b/src/app/features/idle/store/idle.effects.ts
@@ -164,61 +164,82 @@ export class IdleEffects {
   handleIdleInit$ = createEffect(() =>
     this._store.select(selectIsIdle).pipe(
       distinctUntilChanged(),
+      // Capture the task this idle period belongs to BEFORE the wait below. The
+      // deferral can outlive the user's return, and `currentTaskId()` read after
+      // it may already be a *different* task that never accrued this idle time —
+      // subtracting it there would silently delete real tracked work. #9348
+      map((isIdle) => [isIdle, this._taskService.currentTaskId()] as const),
       // Guard: defer idle state changes during sync - CRITICAL because this effect
       // has data mutations (removeTimeSpent, setCurrentId, decreaseCounterToday).
-      // NOTE: this must DEFER, not drop, and it must sit after
-      // distinctUntilChanged(): selectIsIdle emits `true` exactly once per idle
-      // episode, so a dropped edge is gone for good — and it leaves the store
-      // stuck at isIdle:true, which makes triggerIdleWhenEnabled$ short-circuit
-      // on isAlreadyIdle from then on, killing idle handling for the whole
-      // session. See #9348.
+      // NOTE: this must DEFER, not drop. selectIsIdle emits `true` exactly once
+      // per idle episode, so a dropped edge is gone for good — and it leaves the
+      // store stuck at isIdle:true, which makes triggerIdleWhenEnabled$
+      // short-circuit on isAlreadyIdle from then on, killing idle handling for
+      // the whole session. See #9348.
+      // It must also stay AHEAD of every distinctUntilChanged(): the operator is
+      // a switchMap, so a superseded edge is cancelled and never emitted. A dUC
+      // downstream would keep that cancelled value as its "last seen" and swallow
+      // the next identical one — re-creating the wedge this is here to prevent.
       waitForSyncWindow(this._hydrationStateService, 'IdleEffects.handleIdleInit$'),
-      switchMap((isIdle) => iif(() => isIdle, of(isIdle), EMPTY)),
+      switchMap(([isIdle, taskIdAtIdleStart]) =>
+        iif(() => isIdle, of(taskIdAtIdleStart), EMPTY),
+      ),
       withLatestFrom(
         this._store.select(selectIdleTime),
         this._simpleCounterService.enabledSimpleStopWatchCounters$,
         this._isFocusSessionRunning$,
       ),
-      map(([, idleTime, enabledSimpleStopWatchCounters, isFocusSessionRunning]) => {
-        // ALL IDLE SIDE EFFECTS
-        // ---------------------
-        if (IS_ELECTRON) {
-          this._uiHelperService.focusAppAfterNotification();
-        }
-
-        // untrack current task time und unselect
-        let lastCurrentTaskId: string | null;
-        const tid = this._taskService.currentTaskId();
-        if (tid) {
-          lastCurrentTaskId = tid;
-          // remove idle time already tracked
-          this._taskService.removeTimeSpent(tid, idleTime);
-          this._taskService.setCurrentId(null);
-        } else {
-          lastCurrentTaskId = null;
-        }
-
-        // untrack on simple counter time and turn off
-        if (enabledSimpleStopWatchCounters.length) {
-          enabledSimpleStopWatchCounters.forEach((simpleCounter) => {
-            if (simpleCounter.isOn) {
-              this._simpleCounterService.decreaseCounterToday(simpleCounter.id, idleTime);
-            }
-          });
-          this._store.dispatch(turnOffAllSimpleCounterCounters());
-        }
-
-        // NOTE: we need a new idleTimer since the other values are reset as soon as the user is active again
-        this._initIdlePoll(idleTime);
-
-        // this._openDialog(enabledSimpleStopWatchCounters, lastCurrentTaskId);
-        // finally open dialog
-        return openIdleDialog({
+      map(
+        ([
+          taskIdAtIdleStart,
+          idleTime,
           enabledSimpleStopWatchCounters,
-          lastCurrentTaskId,
-          wasFocusSessionRunning: isFocusSessionRunning,
-        });
-      }),
+          isFocusSessionRunning,
+        ]) => {
+          // ALL IDLE SIDE EFFECTS
+          // ---------------------
+          if (IS_ELECTRON) {
+            this._uiHelperService.focusAppAfterNotification();
+          }
+
+          // untrack current task time und unselect
+          let lastCurrentTaskId: string | null;
+          // snapshot from the idle edge, not a re-read — see the capture above
+          const tid = taskIdAtIdleStart;
+          if (tid) {
+            lastCurrentTaskId = tid;
+            // remove idle time already tracked
+            this._taskService.removeTimeSpent(tid, idleTime);
+            this._taskService.setCurrentId(null);
+          } else {
+            lastCurrentTaskId = null;
+          }
+
+          // untrack on simple counter time and turn off
+          if (enabledSimpleStopWatchCounters.length) {
+            enabledSimpleStopWatchCounters.forEach((simpleCounter) => {
+              if (simpleCounter.isOn) {
+                this._simpleCounterService.decreaseCounterToday(
+                  simpleCounter.id,
+                  idleTime,
+                );
+              }
+            });
+            this._store.dispatch(turnOffAllSimpleCounterCounters());
+          }
+
+          // NOTE: we need a new idleTimer since the other values are reset as soon as the user is active again
+          this._initIdlePoll(idleTime);
+
+          // this._openDialog(enabledSimpleStopWatchCounters, lastCurrentTaskId);
+          // finally open dialog
+          return openIdleDialog({
+            enabledSimpleStopWatchCounters,
+            lastCurrentTaskId,
+            wasFocusSessionRunning: isFocusSessionRunning,
+          });
+        },
+      ),
     ),
   );
 

--- a/src/app/features/idle/store/idle.effects.ts
+++ b/src/app/features/idle/store/idle.effects.ts
@@ -2,6 +2,8 @@ import { inject, Injectable } from '@angular/core';
 import { createEffect, ofType } from '@ngrx/effects';
 import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
 import { skipWhileApplyingRemoteOps } from '../../../util/skip-during-sync.operator';
+import { waitForSyncWindow } from '../../../util/wait-for-sync-window.operator';
+import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { DataInitStateService } from '../../../core/data-init/data-init-state.service';
 import { ChromeExtensionInterfaceService } from '../../../core/chrome-extension-interface/chrome-extension-interface.service';
 import { WorkContextService } from '../../work-context/work-context.service';
@@ -73,6 +75,7 @@ export class IdleEffects {
   private _dateService = inject(DateService);
 
   private _dataInitStateService = inject(DataInitStateService);
+  private _hydrationStateService = inject(HydrationStateService);
 
   private _clearIdlePollInterval?: () => void;
   private _isDialogOpen: boolean = false;
@@ -160,10 +163,16 @@ export class IdleEffects {
 
   handleIdleInit$ = createEffect(() =>
     this._store.select(selectIsIdle).pipe(
-      // Guard: skip idle state changes during sync - CRITICAL because this effect
-      // has data mutations (removeTimeSpent, setCurrentId, decreaseCounterToday)
-      skipWhileApplyingRemoteOps(),
       distinctUntilChanged(),
+      // Guard: defer idle state changes during sync - CRITICAL because this effect
+      // has data mutations (removeTimeSpent, setCurrentId, decreaseCounterToday).
+      // NOTE: this must DEFER, not drop, and it must sit after
+      // distinctUntilChanged(): selectIsIdle emits `true` exactly once per idle
+      // episode, so a dropped edge is gone for good — and it leaves the store
+      // stuck at isIdle:true, which makes triggerIdleWhenEnabled$ short-circuit
+      // on isAlreadyIdle from then on, killing idle handling for the whole
+      // session. See #9348.
+      waitForSyncWindow(this._hydrationStateService, 'IdleEffects.handleIdleInit$'),
       switchMap((isIdle) => iif(() => isIdle, of(isIdle), EMPTY)),
       withLatestFrom(
         this._store.select(selectIdleTime),

--- a/src/app/features/idle/store/idle.effects.ts
+++ b/src/app/features/idle/store/idle.effects.ts
@@ -164,11 +164,24 @@ export class IdleEffects {
   handleIdleInit$ = createEffect(() =>
     this._store.select(selectIsIdle).pipe(
       distinctUntilChanged(),
-      // Capture the task this idle period belongs to BEFORE the wait below. The
-      // deferral can outlive the user's return, and `currentTaskId()` read after
-      // it may already be a *different* task that never accrued this idle time —
+      // Snapshot EVERY entity this effect mutates BEFORE the wait below. The
+      // deferral can outlive the user's return, so anything re-read afterwards
+      // may be a *different* task or counter that never accrued this idle time —
       // subtracting it there would silently delete real tracked work. #9348
-      map((isIdle) => [isIdle, this._taskService.currentTaskId()] as const),
+      withLatestFrom(
+        this._store.select(selectIdleTime),
+        this._simpleCounterService.enabledSimpleStopWatchCounters$,
+        this._isFocusSessionRunning$,
+      ),
+      map(
+        ([isIdle, idleTime, enabledSimpleStopWatchCounters, isFocusSessionRunning]) => ({
+          isIdle,
+          idleTime,
+          enabledSimpleStopWatchCounters,
+          isFocusSessionRunning,
+          taskIdAtIdleStart: this._taskService.currentTaskId(),
+        }),
+      ),
       // Guard: defer idle state changes during sync - CRITICAL because this effect
       // has data mutations (removeTimeSpent, setCurrentId, decreaseCounterToday).
       // NOTE: this must DEFER, not drop. selectIsIdle emits `true` exactly once
@@ -181,21 +194,14 @@ export class IdleEffects {
       // downstream would keep that cancelled value as its "last seen" and swallow
       // the next identical one — re-creating the wedge this is here to prevent.
       waitForSyncWindow(this._hydrationStateService, 'IdleEffects.handleIdleInit$'),
-      switchMap(([isIdle, taskIdAtIdleStart]) =>
-        iif(() => isIdle, of(taskIdAtIdleStart), EMPTY),
-      ),
-      withLatestFrom(
-        this._store.select(selectIdleTime),
-        this._simpleCounterService.enabledSimpleStopWatchCounters$,
-        this._isFocusSessionRunning$,
-      ),
+      switchMap((snapshot) => iif(() => snapshot.isIdle, of(snapshot), EMPTY)),
       map(
-        ([
+        ({
           taskIdAtIdleStart,
           idleTime,
           enabledSimpleStopWatchCounters,
           isFocusSessionRunning,
-        ]) => {
+        }) => {
           // ALL IDLE SIDE EFFECTS
           // ---------------------
           if (IS_ELECTRON) {

--- a/src/app/util/wait-for-sync-window.operator.ts
+++ b/src/app/util/wait-for-sync-window.operator.ts
@@ -14,10 +14,18 @@ const SYNC_WINDOW_TIMEOUT_MS = 30000;
  * ## Why This Exists
  *
  * `skipDuringSyncWindow()` silently drops emissions during hydration/sync.
- * For frequently-emitting sources (e.g., store selectors), that's fine —
- * the next emission will retry. But for sparse, one-shot sources like
- * day-change observables, a dropped emission means the effect never runs
- * for that day (#6192).
+ * For sources that keep re-emitting the same state (a repeating timer tick),
+ * that's fine — the next emission retries. But for sparse or edge-triggered
+ * sources, a dropped emission means the effect never runs at all: for a
+ * day-change observable, not for that day (#6192); for `selectIsIdle`, not for
+ * that idle episode — and there the store stays latched at `isIdle: true`, so
+ * the producer short-circuits and idle handling dies for the session (#9348).
+ *
+ * ⚠️ Do not assume a store selector is safe to drop. `store.select()` ends in
+ * `distinctUntilChanged()`, so a dropped emission is NOT retried until the
+ * value changes again — and the emissions this guard drops are precisely the
+ * ones caused by remote ops, which have already settled by the time the window
+ * closes. Judge the source, not its type.
  *
  * This operator subscribes to `isInSyncWindow$` (a reactive observable
  * derived from Angular signals) and proceeds once the window closes.


### PR DESCRIPTION
## Problem

Closes #9348.

`IdleEffects.handleIdleInit$` guarded `selectIsIdle` with `skipWhileApplyingRemoteOps()` — which is `filter(() => !isApplyingRemoteOps())`, i.e. it **drops**, never defers — and it sat **before** `distinctUntilChanged()`.

`selectIsIdle` emits `true` exactly once per idle episode. If that single emission lands inside a sync apply window it is gone for good: no `setCurrentId(null)`, no `openIdleDialog` — **but the store stays `isIdle: true`**. Every later IPC tick then short-circuits on `isAlreadyIdle → EMPTY`, and the only `resetIdle()` comes from `idleDialogResult`, i.e. a dialog that never opened.

Result: idle detection is dead until restart, the current task keeps accruing time while the user is away, and the take-a-break banner stays permanently suppressed.

Moving the guard after `distinctUntilChanged()` alone does **not** fix it — the emission is still dropped, and `distinctUntilChanged` has latched `false`, so a later `true` cannot arrive.

## Solution

Swap in `waitForSyncWindow()` (`src/app/util/wait-for-sync-window.operator.ts`), the pre-existing defer-instead-of-drop counterpart whose docstring already cites #6192 for the identical "sparse source, dropped emission lost forever" shape, and place it **after** `distinctUntilChanged()` so the edge is captured first and then held.

Three things fell out of that, each its own commit:

**1. `e158f56242` — the operator swap.** The `require-hydration-guard` lint rule matched guard names textually and did not know `waitForSyncWindow`, so it **rejected the correct fix**. The rule and its docs were extended and a `valid:` case added.

**2. `1710546505` — snapshot the task at the edge.** Deferring means the effect body runs seconds after the edge, and it re-read `currentTaskId()` at that point. If the user came back and started a *different* task before the window closed, `removeTimeSpent()` subtracted the idle duration from that task — silently deleting real tracked work from a task that never accrued it. Reachable on the canonical idle path: waking from sleep opens a sync window and users typically start a task immediately.

**3. `da1e712d41` — snapshot the counters too.** Same hazard, other entity: `enabledSimpleStopWatchCounters$` was still read via `withLatestFrom` after the guard, so a counter switched on during the wait got `decreaseCounterToday()` applied to it. The whole `withLatestFrom` now sits ahead of the guard, so nothing in the body is a post-wait read.

Commit 2 also carries smaller corrections found in review: the lint rule's **error message** still told authors to add `skipWhileApplyingRemoteOps()` (the dropping guard that causes this bug); `waitForSyncWindow`'s docstring claimed dropping is fine for store selectors because "the next emission will retry" (false — `store.select()` ends in `distinctUntilChanged()`, so a dropped selector emission is not retried until the value changes); and the spec left a module-level applying-remote-ops flag set if a test threw, which would silently make later specs buffer their actions under Karma's randomised order.

### Note on scope

This is not a like-for-like swap: the guard predicate widens from `isApplyingRemoteOps()` (replay only) to `isInSyncWindow()` (window open ∨ applying ∨ 2s post-sync cooldown). The idle dialog can therefore appear slightly later when an idle edge coincides with a sync. That is the safe direction, but it is a real semantic change and no reviewer would catch it from the diff.

### Deliberately not in this PR

Three findings were raised in review and left as follow-ups rather than widening this fix:

- `waitForSyncWindow` **fails open** after `SYNC_WINDOW_TIMEOUT_MS = 30000` (`timeout` → `catchError` → emit anyway), and `sync-wrapper.service.ts:324` opens the window with `openSyncWindow(0)` (no failsafe), so a slow sync can exceed it. Shared operator, 4 call sites.
- `hasGuardInChain` substring-matches source text rather than inspecting pipe arguments, so a `waitForSyncWindow` in a *nested inner* pipe now satisfies the rule for an unguarded outer selector. Pre-existing in kind for the other three tokens; this PR adds a fourth. The structural fix should cover all four at once, with its own sabotage test.
- Several other call sites carry the same drop-an-unrecoverable-edge shape. The clearest is `idle.effects.ts:118` (`triggerIdleWhenEnabled$`, one effect above this fix): a remote idle-config change arrives *by definition* during an apply window, is dropped, and the memoized selector will not re-emit — so the device keeps running the old config, or never subscribes the IPC listener at all. Others: `reminder-countdown.effects.ts:60`, `android-sync-bridge.effects.ts:81`, `focus-mode.effects.ts:276`/`:930`, `task-ui.effects.ts:148`/`:181`/`:297`, `work-context.effects.ts:57`.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have included relevant changes to the documentation/wiki — n/a, no user-facing behaviour change (the lint rule's own docblock and the operator docstring are updated)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

### Verification

- `idle.effects.spec.ts` 7/7; `npm run test:lint-rules` green; **full suite 13602 passing, 0 failures**.
- The regression test asserts **both** halves — zero emissions while applying remote ops, then exactly one `openIdleDialog` once the window closes. Asserting only the second would also pass for an unguarded pass-through.
- Three sabotage runs, each killing exactly one test and nothing else:
  - break the rule's `waitForSyncWindow` support → the new `valid:` case fails ("Should have no errors but had 1")
  - revert the operator to `skipWhileApplyingRemoteOps()` → only `"defers - not drops - …"` fails ("Expected 0 to be 1")
  - re-read the counters after the wait → only `"decrements the counters running at the edge …"` fails ("Expected 'counter-started-later' to be 'counter-at-edge'")
