### PR TITLE
docs(idle): correct the minIdleTime floor's effect and flag its reuse

### DIFF
--- a/docs/wiki/3.02-Settings-and-Preferences.md
+++ b/docs/wiki/3.02-Settings-and-Preferences.md
@@ -49,9 +49,9 @@ Note: Differences between the Web app and the Desktop app are specified in [[3.0
   when you are away from the computer and show an idle dialog asking what you did.
 - **Minimum idle time** — The amount of time you need to be away before the idle
   dialog is shown. Must be at least **1 minute**: the desktop app never reports
-  shorter idle periods, so lower values would disable idle detection entirely.
-  Idle is sampled every 30 seconds, so the dialog can appear up to that much
-  after the threshold is reached.
+  shorter idle periods, so anything lower is rounded up to about a minute rather
+  than honoured. Idle is sampled every 30 seconds, so the dialog can appear up to
+  that much after the threshold is reached.
 - **Only show idle dialog when a task is active** — Only show the idle dialog when
   a task is currently being tracked.
 - **Suppress idle dialog during work sessions** — When enabled, the idle dialog

--- a/docs/wiki/4.17-Idle-Time.md
+++ b/docs/wiki/4.17-Idle-Time.md
@@ -22,7 +22,7 @@ The important point for you: when the app says you were “idle,” it means **t
 
 ## Thresholds and When the Dialog Appears
 
-- **Minimum idle time** — You must be idle for at least this long (default: 5 minutes) before the app triggers the idle flow. Shorter absences are not treated as idle.
+- **Minimum idle time** — You must be idle for at least this long (default: 5 minutes) before the app triggers the idle flow. Shorter absences are not treated as idle. The setting cannot go below **1 minute** — the desktop app never reports shorter idle periods. Idle is sampled every 30 seconds, so the dialog can appear up to that much after your threshold is reached.
 - **Only when a task is active** — An option (**only open idle when current task**) restricts the idle dialog to when a task is **currently being tracked**. If no task is active, the app may not show the dialog (or may handle idle differently), so you are not interrupted when you weren’t tracking anything.
 
 If idle detection is **disabled** in settings, the app does not run the idle flow; time is not removed or reassigned based on system idle.

--- a/electron/shared-with-frontend/idle.const.ts
+++ b/electron/shared-with-frontend/idle.const.ts
@@ -1,9 +1,14 @@
 /**
- * The Electron main process only forwards idle periods LONGER than this floor
- * (see `sendIdleMsgIfOverMin()` in start-app.ts), so a configured `minIdleTime`
- * below it can never trigger the idle dialog. Shared with the frontend so the
- * settings form validates against the very value the main process enforces
- * instead of a copy that can drift. See #9349.
+ * Floor the Electron main process enforces before forwarding an idle period
+ * (`sendIdleMsgIfOverMin()` in start-app.ts). On desktop a lower `minIdleTime`
+ * is not disabled, it is silently rounded up — the dialog opens at ~1–1.5 min
+ * regardless — which is what the settings bound exists to make visible. Shared
+ * with the frontend so that bound cannot drift from the enforced value. #9349
+ *
+ * ⚠️ Not only the forwarding floor: `IdleTimeHandler` reuses it as the Wayland
+ * helper's `--timeout-ms` and as the `_waylandIdleSinceMs` backfill offset, so
+ * lowering it to relax the settings bound would also retune Wayland idle
+ * detection.
  */
 export const IDLE_MIN_IDLE_TIME_MS = 60000;
 

--- a/src/app/features/config/form-cfgs/idle-form.const.spec.ts
+++ b/src/app/features/config/form-cfgs/idle-form.const.spec.ts
@@ -10,8 +10,9 @@ import EN_TRANSLATIONS from '../../../../assets/i18n/en.json';
 
 /**
  * #9349: the Electron main process never sends IPC.IDLE_TIME for idle periods
- * at or below `CONFIG.MIN_IDLE_TIME`, so any `minIdleTime` below that floor
- * silently disables idle detection entirely.
+ * at or below `CONFIG.MIN_IDLE_TIME`, so any `minIdleTime` below that floor is
+ * silently rounded up to it — the dialog opens at roughly 1–1.5 min however low
+ * the setting is. The bound makes that unhonourable range impossible to enter.
  *
  * These tests mount the REAL IDLE_FORM_CFG through the REAL ConfigFormComponent
  * and the REAL Formly `duration` type registration, because the fix is a single

--- a/src/app/features/config/form-cfgs/idle-form.const.ts
+++ b/src/app/features/config/form-cfgs/idle-form.const.ts
@@ -37,8 +37,6 @@ export const IDLE_FORM_CFG: ConfigFormSection<IdleConfig> = {
       hideExpression: '!model.isEnableIdleTimeTracking',
       templateOptions: {
         required: true,
-        // The main process drops anything at or below this, so a lower value
-        // would silently disable idle detection altogether (#9349).
         min: IDLE_MIN_IDLE_TIME_MS,
         label: T.GCF.IDLE.MIN_IDLE_TIME,
         description: T.GCF.IDLE.MIN_IDLE_TIME_DESCRIPTION,


### PR DESCRIPTION
## Problem

Refs #9349 / #9357.

#9357 added a `min: IDLE_MIN_IDLE_TIME_MS` (60000) bound to the **Minimum idle time** setting, and justified it — in four places — with the claim that a lower value *"silently disables idle detection entirely"*.

That justification is wrong, and it's wrong in a way that would mislead the next person to touch this code:

- `electron/start-app.ts:328` skips a sample only when `idleTime <= CONFIG.MIN_IDLE_TIME`.
- The poll (`start-app.ts:342-375`) runs every `IDLE_PING_INTERVAL` (30s) and reads the **current, still-growing** system idle time. All five `IdleTimeHandler` backends return elapsed ms — `powerMonitor.getSystemIdleTime() * 1000`, `Date.now() - _waylandIdleSinceMs`, and raw ms from gnomeDBus / xprintidle / loginctl.
- So while the user is away the samples climb 30s → 60s → 90s, and the ~90s sample **is** forwarded.
- The renderer then applies `idleTime >= minIdleTime` (`idle.effects.ts`), and `90000 >= 30000` is true.

⇒ A sub-minute `minIdleTime` **does** open the idle dialog, at roughly 1–1.5 min. The floor **rounds the threshold up**; it does not disable detection. Only the `en.json` hint got this right (*"shorter idle periods are never reported"*), which is why that string is left untouched.

Separately, #9357 updated `docs/wiki/3.02-Settings-and-Preferences.md` but not **`docs/wiki/4.17-Idle-Time.md`** — the *dedicated* idle note, which still described the threshold as freely tunable with no mention of the new bound or the 30s sampling lag.

## Solution

Correct the claim where it appears, and add the note that was missed.

The `min` bound itself is **unchanged and still correct** — it makes an unhonourable range impossible to enter. Only its stated reason changes: not *"otherwise detection is off"* but *"otherwise your setting is silently rounded up"*, which is the honest, user-visible consequence.

Also records a hazard that was previously undocumented: **`IDLE_MIN_IDLE_TIME_MS` is not only the forwarding floor.** `IdleTimeHandler` reuses it as `_waylandHelperTimeoutMs` — the `--timeout-ms` handed to the Wayland idle helper (`idle-time-handler.ts:408`) and the offset that backfills `_waylandIdleSinceMs` (`:455`). #9357 extracted the value into a shared const whose docblock described only the forwarding meaning, so someone lowering it to relax the settings bound would silently retune Wayland idle detection.

Deliberately **not** split into separate constants: the Wayland timeout and the forwarding floor genuinely want to move together (a helper timeout above the floor would backfill an idle-since already past it, and one below wakes the helper for nothing). A derived alias wouldn't prevent the stated hazard, and an independent literal would trade a documented coupling for a silent duplicate. Documenting is the right remedy here.

Kept deliberately terse. #9349's failure mode was *one fact stated in five places that then drifted*, so this states it once per audience — the const docblock for maintainers, `4.17` for users — and removes the inline comment in `idle-form.const.ts` that only restated the docblock of the symbol imported on the line above it.

No behaviour change: comments, a docblock and two wiki notes.

## Type of Change

- [x] Documentation

## Checklist

- [x] I have included relevant changes to the documentation/wiki
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable) — n/a, no behaviour change
- [x] Existing tests still pass (`idle-form.const.spec.ts` 9/9)
- [x] My commit messages follow the Angular format (`type(scope): description`)
