### PR TITLE
fix(tags): make tag-input placeholder actually visible and translate it

### DIFF
--- a/src/app/features/tag/tag-edit/tag-edit.component.html
+++ b/src/app/features/tag/tag-edit/tag-edit.component.html
@@ -25,7 +25,7 @@
     [matChipInputFor]="chipListElRef"
     [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
     (keydown)="onKeydown($event)"
-    [placeholder]="'+ Add Tag'"
+    [placeholder]="T.F.TAG.D_EDIT.PLACEHOLDER | translate"
   />
 </mat-chip-grid>
 <mat-autocomplete

--- a/src/app/features/tag/tag-edit/tag-edit.component.scss
+++ b/src/app/features/tag/tag-edit/tag-edit.component.scss
@@ -29,6 +29,12 @@
       outline: none;
       border-bottom-color: var(--extra-border-color);
     }
+
+    // MDC hides the placeholder by default unless a mat-form-field adds its
+    // "no-label" modifier class, which this bare chip input never gets.
+    &::placeholder {
+      opacity: 1 !important;
+    }
   }
 }
 

--- a/src/app/features/tag/tag-edit/tag-edit.component.scss
+++ b/src/app/features/tag/tag-edit/tag-edit.component.scss
@@ -30,11 +30,14 @@
       border-bottom-color: var(--extra-border-color);
     }
 
-    // Material only sets opacity: 1 on .mat-mdc-chip-input placeholders inside
-    // a .mat-mdc-form-field ancestor; this bare chip input isn't wrapped in one,
-    // so it never gets that rule and falls back to the browser's low-contrast default.
+    // Material forces `.mdc-text-field__input::placeholder { opacity: 0 }` globally and
+    // only restores it inside a .mat-mdc-form-field ancestor. matChipInput puts that
+    // class on this input, which is deliberately not wrapped in a form field, so without
+    // this the placeholder is fully invisible. The color is set explicitly because the
+    // browser default is a fixed grey that ignores the theme (unreadable on dark).
     &::placeholder {
-      opacity: 1 !important;
+      color: var(--text-color-muted);
+      opacity: 1;
     }
   }
 }

--- a/src/app/features/tag/tag-edit/tag-edit.component.scss
+++ b/src/app/features/tag/tag-edit/tag-edit.component.scss
@@ -30,8 +30,9 @@
       border-bottom-color: var(--extra-border-color);
     }
 
-    // MDC hides the placeholder by default unless a mat-form-field adds its
-    // "no-label" modifier class, which this bare chip input never gets.
+    // Material only sets opacity: 1 on .mat-mdc-chip-input placeholders inside
+    // a .mat-mdc-form-field ancestor; this bare chip input isn't wrapped in one,
+    // so it never gets that rule and falls back to the browser's low-contrast default.
     &::placeholder {
       opacity: 1 !important;
     }

--- a/src/app/t.const.ts
+++ b/src/app/t.const.ts
@@ -1772,6 +1772,7 @@ const T = {
         ADD: 'F.TAG.D_EDIT.ADD',
         EDIT: 'F.TAG.D_EDIT.EDIT',
         LABEL: 'F.TAG.D_EDIT.LABEL',
+        PLACEHOLDER: 'F.TAG.D_EDIT.PLACEHOLDER',
       },
       FORM_BASIC: {
         D_COLOR: 'F.TAG.FORM_BASIC.D_COLOR',

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1722,7 +1722,8 @@
       "D_EDIT": {
         "ADD": "Add tags for \"{{title}}\"",
         "EDIT": "Edit tags for \"{{title}}\"",
-        "LABEL": "Tags"
+        "LABEL": "Tags",
+        "PLACEHOLDER": "+ Add Tag"
       },
       "FORM_BASIC": {
         "D_COLOR": "If not set, defaults to the Tag Color.",


### PR DESCRIPTION
## Problem

The tag input's `+ Add Tag` placeholder is hardcoded English (`[placeholder]="'+ Add Tag'"` in `tag-edit.component.html`), so it doesn't respect the selected locale. It's also invisible even in English: Material only sets `opacity: 1` on `.mat-mdc-chip-input` placeholders when the input is inside a `.mat-mdc-form-field` ancestor, and this chip input isn't wrapped in one — so it falls back to the browser's low-contrast default and renders as blank space. Fixes #9366.

## Solution

- Replaced the hardcoded string with `T.F.TAG.D_EDIT.PLACEHOLDER | translate`, added the key to `t.const.ts` and `en.json` (other locales fall back automatically).
- Added an `::placeholder` override in `tag-edit.component.scss` to restore visibility, since this input intentionally isn't wrapped in `mat-form-field` (it's used inline in two tight-layout contexts — the task-detail-panel row and the formly tag-selection field — where Material's default form-field chrome would conflict with the existing custom, borderless input styling).

## Screenshots

**Before** (placeholder invisible):
<img width="297" height="64" alt="Screenshot 2026-07-29 090947" src="https://github.com/user-attachments/assets/3940f270-6145-4812-a7b4-9bb8cde67ca7" />

**After** (placeholder visible):
<img width="263" height="60" alt="Screenshot 2026-07-29 091052" src="https://github.com/user-attachments/assets/152f77d4-498c-4aa0-8149-214a61b12200" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki. (n/a — no docs reference this string)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (n/a — no existing spec covers this component; this is a visual/CSS + i18n fix)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
