### PR TITLE
fix(task-widget): apply saved opacity after renderer loads on Windows/Linux

### DIFF
--- a/electron/task-widget.test.cjs
+++ b/electron/task-widget.test.cjs
@@ -24,6 +24,7 @@ const createDeferred = () => {
 
 class FakeWebContents {
   on() {}
+  once() {}
   send() {}
   focus() {}
   isDestroyed() {

--- a/electron/task-widget.test.cjs
+++ b/electron/task-widget.test.cjs
@@ -23,9 +23,23 @@ const createDeferred = () => {
 };
 
 class FakeWebContents {
-  on() {}
-  once() {}
-  send() {}
+  constructor() {
+    this.sent = [];
+    this._handlers = new Map();
+  }
+  on(eventName, handler) {
+    this._handlers.set(eventName, handler);
+  }
+  once(eventName, handler) {
+    this._handlers.set(eventName, handler);
+  }
+  emitOnce(eventName) {
+    const handler = this._handlers.get(eventName);
+    if (handler) handler();
+  }
+  send(channel, payload) {
+    this.sent.push({ channel, payload });
+  }
   focus() {}
   isDestroyed() {
     return false;
@@ -294,5 +308,29 @@ test('the closed event clears the sticky flag so it does not outlive the window'
     mod.getIsTaskWidgetUserForcedVisible(),
     false,
     'closing the window clears the sticky flag',
+  );
+});
+
+test('the opacity in effect at load time reaches the widget renderer once it finished loading', async () => {
+  const mod = loadModule();
+
+  mod.updateTaskWidgetEnabled(true);
+  await flush();
+
+  const { webContents } = createdWindows[0];
+
+  // The user's saved opacity arrives while the widget page is still loading.
+  // Sending it now is useless: the renderer only registers its `update-opacity`
+  // listener when task-widget-renderer.js runs, and ipcRenderer does not replay.
+  mod.updateTaskWidgetOpacity(5);
+  webContents.sent.length = 0;
+
+  webContents.emitOnce('did-finish-load');
+
+  assert.deepEqual(
+    webContents.sent.filter((m) => m.channel === 'update-opacity'),
+    // 5 % is below the 10 % floor, so the renderer must get the clamped value.
+    [{ channel: 'update-opacity', payload: 0.1 }],
+    'the opacity current at load time must reach the renderer exactly once, clamped',
   );
 });

--- a/electron/task-widget/task-widget.ts
+++ b/electron/task-widget/task-widget.ts
@@ -252,6 +252,13 @@ const createTaskWidgetWindowForGeneration = async (
 
   taskWidgetWin.loadFile(join(__dirname, 'task-widget.html'));
 
+  // Re-apply opacity once the renderer is ready to receive IPC (Windows only; macOS uses setOpacity()).
+  taskWidgetWin.webContents.once('did-finish-load', () => {
+    if (taskWidgetWin && !taskWidgetWin.isDestroyed()) {
+      updateTaskWidgetOpacity(currentOpacity);
+    }
+  });
+
   // Set visible on all workspaces immediately after creation
   taskWidgetWin.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 
@@ -304,6 +311,7 @@ const createTaskWidgetWindowForGeneration = async (
   // Update initial state
   updateTaskWidgetContent();
 
+  // macOS: setOpacity() works immediately; Windows: did-finish-load handler above handles it.
   updateTaskWidgetOpacity(currentOpacity);
 
   if (pendingShowAfterCreate) {

--- a/electron/task-widget/task-widget.ts
+++ b/electron/task-widget/task-widget.ts
@@ -252,11 +252,11 @@ const createTaskWidgetWindowForGeneration = async (
 
   taskWidgetWin.loadFile(join(__dirname, 'task-widget.html'));
 
-  // Re-apply opacity once the renderer is ready to receive IPC (Windows only; macOS uses setOpacity()).
-  taskWidgetWin.webContents.once('did-finish-load', () => {
-    if (taskWidgetWin && !taskWidgetWin.isDestroyed()) {
-      updateTaskWidgetOpacity(currentOpacity);
-    }
+  // Re-apply opacity once the page loads. On Windows/Linux opacity is a CSS variable driven
+  // by IPC; sends before did-finish-load are dropped. Uses 'on' (not 'once') so a DevTools
+  // reload also restores the correct opacity. macOS re-calls setOpacity() idempotently.
+  taskWidgetWin.webContents.on('did-finish-load', () => {
+    updateTaskWidgetOpacity(currentOpacity);
   });
 
   // Set visible on all workspaces immediately after creation
@@ -311,7 +311,8 @@ const createTaskWidgetWindowForGeneration = async (
   // Update initial state
   updateTaskWidgetContent();
 
-  // macOS: setOpacity() works immediately; Windows: did-finish-load handler above handles it.
+  // macOS: setOpacity() works immediately. Windows/Linux: IPC send is dropped before the
+  // page loads; the did-finish-load handler above re-delivers it reliably.
   updateTaskWidgetOpacity(currentOpacity);
 
   if (pendingShowAfterCreate) {


### PR DESCRIPTION
## Problem

Closes #9368

On Windows and Linux, the Task Widget floating window ignores the saved opacity setting on app startup. The opacity slider in Settings correctly shows the saved value (e.g. 50%), but the widget always appears fully opaque visually. Adjusting the slider restores the correct opacity, confirming the value is saved — it just isn't applied on launch.

macOS is unaffected because it applies opacity via `BrowserWindow.setOpacity()`, a native OS-level call independent of the renderer.

## Solution

On Windows/Linux, the widget's opacity is driven by a CSS custom property (`--opacity`) updated via an IPC `update-opacity` message sent from the Electron main process to the widget renderer. The two existing calls to `updateTaskWidgetOpacity()` both fire during window creation — before the renderer page has finished loading and registered its `onUpdateOpacity` IPC listener in `task-widget-renderer.js`. Since `ipcRenderer` is a plain `EventEmitter` with no message replay, those sends are silently dropped, leaving the widget at the CSS default of `0.95` (fully opaque).

**The fix** adds a `webContents.on('did-finish-load', ...)` listener immediately after `loadFile()`. This is the earliest point at which the renderer's listener is guaranteed to be active, so the opacity IPC message is reliably received. `on` is used instead of `once` so that a DevTools-triggered page reload (F12 while the widget is focused) also correctly restores the opacity.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes — regression test in `task-widget.test.cjs` that fails without the fix, verifies the clamped opacity value is delivered to the renderer after `did-finish-load`
- [x] Existing tests still pass (`npm run test:electron` — 230/231, the 1 failure is a pre-existing unrelated `jira.test.cjs` failure)
- [x] My commit messages follow the Angular format (`type(scope): description`)