### PR TITLE
fix(schedule): make split-task continued segments interactive

### DIFF
--- a/docs/wiki/4.04-Schedule-View.md
+++ b/docs/wiki/4.04-Schedule-View.md
@@ -29,7 +29,9 @@ Tasks are ordered by **start time**. When two or more tasks share the same start
 
 ## Blocked Time and Long-Running Tasks
 
-**Blocked periods** (for example lunch breaks) can be added to the Schedule. When a task would run through a blocked period, it is shown as **split**: one segment up to the block, then a continued segment after it. That keeps the timeline readable and shows when work resumes.
+**Blocked periods** can be added to the Schedule. Lunch breaks, scheduled tasks, and calendar events all block time. When a regular task would run through a blocked period, it is shown as **split**: one segment up to the block, then a continued segment after it. That keeps the timeline readable and shows when work resumes.
+
+All segments belong to the same task: clicking any of them opens it, and the last segment can be resized to change the estimate. Only the **first** segment can be dragged, since that is where the task starts.
 
 Tasks that run past midnight are continued on the next day, so you see the full span of the work.
 

--- a/docs/wiki/4.04-Schedule-View.md
+++ b/docs/wiki/4.04-Schedule-View.md
@@ -29,9 +29,9 @@ Tasks are ordered by **start time**. When two or more tasks share the same start
 
 ## Blocked Time and Long-Running Tasks
 
-**Blocked periods** can be added to the Schedule. Lunch breaks, scheduled tasks, and calendar events all block time. When a regular task would run through a blocked period, it is shown as **split**: one segment up to the block, then a continued segment after it. That keeps the timeline readable and shows when work resumes.
+**Blocked periods** are times a regular task cannot flow into. Scheduled tasks, calendar events, recurring task projections with a start time, your lunch break, and the hours outside your work start and end times all block time. When a regular task would run through a blocked period, it is shown as **split**: one segment up to the block, then a continued segment after it. That keeps the timeline readable and shows when work resumes.
 
-All segments belong to the same task: clicking any of them opens it, and the last segment can be resized to change the estimate. Only the **first** segment can be dragged, since that is where the task starts.
+All segments belong to the same task, so clicking any of them opens it. Only the **first** segment can be dragged, since that is where the task starts.
 
 Tasks that run past midnight are continued on the next day, so you see the full span of the work.
 

--- a/e2e/tests/schedule/schedule-split-segment.spec.ts
+++ b/e2e/tests/schedule/schedule-split-segment.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+test.describe('Schedule split segments', () => {
+  test.use({ viewport: DESKTOP_VIEWPORT });
+
+  test('should open the task when a continued segment is clicked', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await page.getByRole('menuitem', { name: 'Schedule' }).click();
+
+    // A 30h estimate crosses midnight no matter which hour the click lands on,
+    // so the split does not depend on the grid's scroll position or on the time
+    // of day the test runs at. Two later columns stay visible for the tails.
+    const dayCols = page.locator('schedule-week .col:not(.end-of-day)[data-day]');
+    const targetDay = dayCols.nth(2);
+    await targetDay.click({
+      position: {
+        x: await targetDay.evaluate((el) => el.clientWidth - 5),
+        y: await targetDay.evaluate((el) => el.clientHeight / 2),
+      },
+    });
+
+    const newTaskInput = page.getByRole('combobox', { name: 'Schedule task...' });
+    await newTaskInput.fill('Runs past midnight 30h');
+    await newTaskInput.press('Enter');
+
+    // The tail of a task crossing midnight renders as SplitTaskContinuedLast on
+    // the following day. It is the segment #9363 reported as dead.
+    const continuedSegment = page
+      .locator('schedule-event.SplitTaskContinuedLast')
+      .first();
+    await expect(continuedSegment).toBeVisible();
+
+    await continuedSegment.click({ position: { x: 0, y: 0 } });
+
+    await expect(
+      page.locator('task-detail-panel').filter({ hasText: 'Runs past midnight' }),
+    ).toBeVisible();
+  });
+});

--- a/src/app/features/schedule/schedule-event/schedule-event.component.scss
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.scss
@@ -443,6 +443,17 @@
   //}
 }
 
+// Not draggable (the head segment marks where the task starts), but clicking
+// still opens the task, so hint at it.
+:host.SplitTaskContinued,
+:host.SplitTaskContinuedLast {
+  cursor: pointer;
+
+  &::before {
+    cursor: pointer;
+  }
+}
+
 :host.draggable {
   cursor: grab;
 

--- a/src/app/features/schedule/schedule-event/schedule-event.component.scss
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.scss
@@ -448,10 +448,6 @@
 :host.SplitTaskContinued,
 :host.SplitTaskContinuedLast {
   cursor: pointer;
-
-  &::before {
-    cursor: pointer;
-  }
 }
 
 :host.draggable {

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -174,6 +174,44 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
     });
   });
 
+  describe('split-continued segments stay interactive (#9363)', () => {
+    const setEvent = (type: SVEType): void => {
+      fixture.componentRef.setInput('event', { ...makeTaskScheduleEvent(), type });
+      fixture.detectChanges();
+    };
+
+    it('should resolve the task for the continued segments of a split task', () => {
+      setEvent(SVEType.SplitTaskContinued);
+      expect(component.task()?.id).toBe('task-1');
+
+      setEvent(SVEType.SplitTaskContinuedLast);
+      expect(component.task()?.id).toBe('task-1');
+    });
+
+    it('should select the task when a continued segment is clicked', async () => {
+      const taskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
+      setEvent(SVEType.SplitTaskContinued);
+
+      await component.clickHandler(new MouseEvent('click'));
+
+      expect(taskService.setSelectedId).toHaveBeenCalledOnceWith('task-1');
+    });
+
+    it('should render the resize handle on the last segment of a split task', () => {
+      setEvent(SVEType.SplitTaskContinuedLast);
+
+      expect(component.isResizable()).toBe(true);
+      expect(fixture.nativeElement.querySelector('.resize-handle')).toBeTruthy();
+    });
+
+    it('should not offer resizing on non-final segments', () => {
+      setEvent(SVEType.SplitTaskContinued);
+
+      expect(component.isResizable()).toBe(false);
+      expect(fixture.nativeElement.querySelector('.resize-handle')).toBeNull();
+    });
+  });
+
   it('should delete scheduled tasks through TaskService cleanup', fakeAsync(() => {
     const task = {
       id: 'task-1',

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -197,16 +197,42 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
       expect(taskService.setSelectedId).toHaveBeenCalledOnceWith('task-1');
     });
 
-    it('should render the resize handle on the last segment of a split task', () => {
-      setEvent(SVEType.SplitTaskContinuedLast);
+    it('should keep continued segments undraggable', () => {
+      // elementId() is gated on isDraggableSE(), so an empty id also means no
+      // duplicate DOM ids across the segments of one task
+      setEvent(SVEType.Task);
+      expect(component.elementId()).toBe('t-task-1');
 
-      expect(component.isResizable()).toBe(true);
-      expect(fixture.nativeElement.querySelector('.resize-handle')).toBeTruthy();
+      setEvent(SVEType.SplitTaskContinued);
+      expect(component.elementId()).toBe('');
+
+      setEvent(SVEType.SplitTaskContinuedLast);
+      expect(component.elementId()).toBe('');
     });
 
-    it('should not offer resizing on non-final segments', () => {
-      setEvent(SVEType.SplitTaskContinued);
+    it('should open the task context menu on right-click of a continued segment', () => {
+      setEvent(SVEType.SplitTaskContinuedLast);
 
+      const menu = component.taskContextMenu();
+      expect(menu).toBeTruthy();
+      const openSpy = spyOn(menu!, 'open');
+
+      component.onContextMenu(new MouseEvent('contextmenu'));
+
+      expect(openSpy).toHaveBeenCalled();
+    });
+
+    it('should not offer resizing on any continued segment', () => {
+      // the head already carries the handle, and SplitTaskContinuedLast is not
+      // reliably the final segment of a multi-day scheduled task
+      setEvent(SVEType.Task);
+      expect(fixture.nativeElement.querySelector('.resize-handle')).toBeTruthy();
+
+      setEvent(SVEType.SplitTaskContinued);
+      expect(component.isResizable()).toBe(false);
+      expect(fixture.nativeElement.querySelector('.resize-handle')).toBeNull();
+
+      setEvent(SVEType.SplitTaskContinuedLast);
       expect(component.isResizable()).toBe(false);
       expect(fixture.nativeElement.querySelector('.resize-handle')).toBeNull();
     });

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -131,9 +131,9 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
       evt.type === SVEType.TaskPlannedForDay ||
       evt.type === SVEType.SplitTaskPlannedForDay ||
       evt.type === SVEType.ScheduledTask ||
-      // continued segments carry the same task, so selecting/context-menu/resize
-      // work on them too; dragging stays disabled via isDraggableSE() since only
-      // the head segment marks where the task starts
+      // continued segments carry the same task, so selecting and the context
+      // menu work on them too; dragging stays disabled via isDraggableSE()
+      // since only the head segment marks where the task starts
       evt.type === SVEType.SplitTaskContinued ||
       evt.type === SVEType.SplitTaskContinuedLast
     ) {
@@ -536,12 +536,15 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
 
     const t = this.task();
     const evt = this.se();
-    // Allow resizing for all task types with a time estimate
+    // Allow resizing for all task types with a time estimate.
+    // NOT for continued segments: a split task already has a handle on its head,
+    // and SplitTaskContinuedLast is not reliably the final segment — every day
+    // slice of a multi-day scheduled task carries that type (see
+    // create-view-entries-for-block.ts), so the middle ones cannot grow at all.
     return (
       !!t &&
       (evt.type === SVEType.ScheduledTask ||
         evt.type === SVEType.Task ||
-        evt.type === SVEType.SplitTaskContinuedLast ||
         evt.type === SVEType.TaskPlannedForDay ||
         evt.type === SVEType.SplitTaskPlannedForDay) &&
       t.timeEstimate > 0

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -130,7 +130,12 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
       evt.type === SVEType.SplitTask ||
       evt.type === SVEType.TaskPlannedForDay ||
       evt.type === SVEType.SplitTaskPlannedForDay ||
-      evt.type === SVEType.ScheduledTask
+      evt.type === SVEType.ScheduledTask ||
+      // continued segments carry the same task, so selecting/context-menu/resize
+      // work on them too; dragging stays disabled via isDraggableSE() since only
+      // the head segment marks where the task starts
+      evt.type === SVEType.SplitTaskContinued ||
+      evt.type === SVEType.SplitTaskContinuedLast
     ) {
       return evt.data as TaskCopy;
     }


### PR DESCRIPTION
Closes #9363.

## What was wrong

The "continued" segments of a split flowing task resolved to no task at all, so clicking one did nothing and right-click offered no context menu. The reporter read that as the task becoming an undraggable orphan.

It isn't — the **head** segment was always draggable and clickable, so the task was never stranded, and the split itself is intended (it's what the timeline is for). But the piece they were clicking on genuinely did nothing.

## What changed

`task()` in `schedule-event.component.ts` now resolves for `SplitTaskContinued` / `SplitTaskContinuedLast`. That single condition was gating click-to-select, the context menu, and the project-color left border — so continued segments now also share the head's project stripe instead of falling back to `--separator-color`, which makes it obvious they belong together.

Dragging deliberately stays on the head segment: a continuation has no start time of its own. `isDraggableSE()` is untouched.

## What I deliberately did *not* do

`isResizable()` has listed `SplitTaskContinuedLast` since 5bc531511a — dead code, because `task()` never resolved for it. Reviving it looked right and is wrong; I dropped the type instead. Verified against real `mapToScheduleDays` output:

- a planned-for-day task split by a lunch break renders `SplitTaskPlannedForDay` + `SplitTaskContinuedLast`, and **both** are resizable → two grips for one task
- `SplitTaskContinuedLast` is **not reliably last**: `create-view-entries-for-block.ts` gives every day slice of a multi-day scheduled task that type, so a 30h scheduled task renders `ScheduledTask:4h | SplitTaskContinuedLast:24h | SplitTaskContinuedLast:2h` — the 24h middle segment gets a grip that cannot change its own length

It also removes the handle's 12px hit area from a segment class with an 8px `min-height`, where mousedown starts a resize and `_justFinishedResizing` then blocks `clickHandler` for 200ms — i.e. it would have swallowed the very click this PR exists to enable.

Making resize correct here means teaching the split pipeline which segment is genuinely final. That's a separate change; this PR keeps the pre-existing one-handle-on-the-head behavior.

## Tests

Four specs in `schedule-event.component.spec.ts`, sabotage-verified in both directions:

| Sabotage | Specs failing |
|---|---|
| Revert the `task()` widening | 3 |
| Re-add `SplitTaskContinuedLast` to `isResizable()` | 1 |
| Add continued types to `isDraggableSE()` | 1 |

That last one had **zero** coverage anywhere before this PR — widening `isDraggableSE()` passed all 360 schedule specs. It matters beyond drag: `elementId()` is gated on it, so an over-reach would mint duplicate DOM ids across segments of one task.

361/361 schedule specs green.

## Docs

`docs/wiki/4.04-Schedule-View.md` named only lunch breaks as blocked time — probably why this read as a glitch. It now lists all five sources that `createSortedBlockerBlocks` actually builds from, and states which segment is draggable.

## Follow-ups (not in this PR)

- `RepeatProjectionSplitContinued(Last)` is inert for the same reason — being fixed in #9314
- resizing a split *head* grows the segment *after* the block, since both handles just do `timeEstimate += delta`
