### PR TITLE
fix(sync): stop rejecting clientIds minted by older releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@
   - **Collect personal metrics** to see, which of your work routines need adjustments.
 - Integrate with **Jira**, **Trello**, **GitHub**, **GitLab**, **Gitea**, **OpenProject**, **Linear**, **ClickUp** and **Azure DevOps**. Auto import tasks assigned to you, plan the details locally, automatically create work logs, and get notified immediately, when something changes.
 - Basic **CalDAV** integration.
-- Back up and synchronize your data across multiple devices with **Dropbox** and **WebDAV** support
+- Back up and synchronize your data across multiple devices with **SuperSync**, **Dropbox** and **WebDAV** support. SuperSync is our own end-to-end encrypted sync service, which you can also [host yourself](https://github.com/super-productivity/super-productivity/tree/master/packages/super-sync-server).
 - Attach context information to tasks and projects. Create **notes**, attach **files** or create **project-level bookmarks** for links, files, and even commands.
-- Super Productivity **respects your privacy** and **does NOT collect any data** and there are no user accounts or registration. **You decide where you store your data!**
+- Super Productivity **respects your privacy** and **does NOT collect any data**. No account or registration is required. **You decide where you store your data!**
 - It's **free** and **open source** and always will be.
 
 And much more!

--- a/src/app/core/util/client-id.service.spec.ts
+++ b/src/app/core/util/client-id.service.spec.ts
@@ -130,6 +130,42 @@ describe('ClientIdService', () => {
     });
   });
 
+  /**
+   * #9336. v17.0.0–v18.10.0 minted a 4-char random suffix ('B_H8AR', taken
+   * verbatim from #6197); ec16757c82 then widened the generator to 6 AND
+   * narrowed the matching check, so those stored ids read as absent and were
+   * minted over — a silent, permanent vector-clock key rotation (#7732).
+   *
+   * The two sub-windows differ in WHERE the id lives: SUP_OPS gained its
+   * client_id store in v18.7.0, so v17.0.0–v18.6.x devices hold it only in pf.
+   */
+  describe('a clientId minted by an older release (#9336)', () => {
+    const SHIPPED_COMPACT_ID = 'B_H8AR';
+
+    it('resolves it from pf instead of reporting absence', async () => {
+      await seedPf(PF_CLIENT_ID_KEY, SHIPPED_COMPACT_ID);
+
+      expect(await service.loadClientId()).toBe(SHIPPED_COMPACT_ID);
+    });
+
+    it('copies it forward to SUP_OPS rather than minting a replacement', async () => {
+      await seedPf(PF_CLIENT_ID_KEY, SHIPPED_COMPACT_ID);
+
+      expect(await service.getOrGenerateClientId()).toBe(SHIPPED_COMPACT_ID);
+      expect(await readSupOps()).toBe(SHIPPED_COMPACT_ID);
+    });
+
+    // v18.7.0–v18.10.0: the id lives only in SUP_OPS. Asserting the STORED
+    // value is what proves the identity survived — _putClientIdIfAbsent used
+    // to overwrite it in place, which the return value alone would not reveal.
+    it('never overwrites one already stored in SUP_OPS', async () => {
+      await seedSupOps(SHIPPED_COMPACT_ID);
+
+      expect(await service.getOrGenerateClientId()).toBe(SHIPPED_COMPACT_ID);
+      expect(await readSupOps()).toBe(SHIPPED_COMPACT_ID);
+    });
+  });
+
   describe('nothing stored anywhere', () => {
     it('loadClientId() resolves to null', async () => {
       expect(await service.loadClientId()).toBeNull();

--- a/src/app/core/util/generate-client-id.spec.ts
+++ b/src/app/core/util/generate-client-id.spec.ts
@@ -1,3 +1,5 @@
+import { SUPER_SYNC_CLIENT_ID_REGEX } from '@sp/shared-schema';
+import { MIN_CLIENT_ID_LENGTH } from '../../op-log/core/operation-log.const';
 import {
   generateClientId,
   getPlatformCode,
@@ -64,11 +66,50 @@ describe('generate-client-id', () => {
       expect(isValidClientIdFormat('0123456789')).toBeTrue();
     });
 
-    it('rejects short, non-conforming strings', () => {
-      expect(isValidClientIdFormat('BAD')).toBeFalse();
+    // #9336: these shipped and are still on disk. Rejecting one silently
+    // rotates that device's vector-clock key.
+    it('accepts every compact shape this app has ever minted', () => {
+      expect(isValidClientIdFormat('B_H8AR')).toBeTrue(); // 4-char era, from #6197
+      expect(isValidClientIdFormat('B_2Oke')).toBeTrue(); // 4-char era, from #6142
+      expect(isValidClientIdFormat('BCL_1736251234567')).toBeTrue(); // legacy PFAPI
+      expect(isValidClientIdFormat('AND_1736251234567')).toBeTrue(); // legacy PFAPI
+    });
+
+    // Forward compatibility: a future entropy bump or platform code must not
+    // require editing this predicate again — that edit is what broke #9336.
+    it('accepts shapes this build cannot mint', () => {
+      expect(isValidClientIdFormat('B_a7Kx9')).toBeTrue(); // 5-char suffix
+      expect(isValidClientIdFormat('X_a7Kx9Z')).toBeTrue(); // unknown platform
+      expect(isValidClientIdFormat('E_a7Kx9Z1234')).toBeTrue(); // longer entropy
+    });
+
+    it('rejects only ids the system genuinely cannot use', () => {
       expect(isValidClientIdFormat('')).toBeFalse();
-      expect(isValidClientIdFormat('B_a7Kx9')).toBeFalse(); // 5-char suffix
-      expect(isValidClientIdFormat('X_a7Kx9Z')).toBeFalse(); // unknown platform
+      expect(isValidClientIdFormat('BAD')).toBeFalse(); // < MIN_CLIENT_ID_LENGTH
+      expect(isValidClientIdFormat('B_a7')).toBeFalse(); // incrementVectorClock throws
+      expect(isValidClientIdFormat('B_a7Kx/9')).toBeFalse(); // fails wire charset
+    });
+
+    // Anti-drift guard. Deliberately one-directional: the predicate is allowed
+    // to be LOOSER than the wire contract (the `>= 10` branch keeps legacy ids
+    // whatever they contain), but never tighter — narrowing it is what shipped
+    // #9336. Any id SuperSync would carry must be accepted here.
+    it('never rejects an id SuperSync would accept', () => {
+      const shapes = [
+        'B_H8AR',
+        'B_2Oke',
+        'B_a7Kx9Z',
+        'BCL_1736251234567',
+        'X_a7Kx9Z',
+        'E_a7Kx9Z1234',
+        'zz_future_scheme',
+      ];
+      for (const id of shapes) {
+        expect(SUPER_SYNC_CLIENT_ID_REGEX.test(id) && id.length >= MIN_CLIENT_ID_LENGTH)
+          .withContext(`fixture unusable on the wire: ${id}`)
+          .toBeTrue();
+        expect(isValidClientIdFormat(id)).withContext(id).toBeTrue();
+      }
     });
 
     it('rejects non-string values', () => {

--- a/src/app/core/util/generate-client-id.ts
+++ b/src/app/core/util/generate-client-id.ts
@@ -2,6 +2,7 @@ import { IS_ELECTRON } from '../../app.constants';
 import { IS_IOS } from '../../util/is-ios';
 import { IS_IOS_NATIVE } from '../../util/is-native-platform';
 import { IS_ANDROID_WEB_VIEW } from '../../util/is-android-web-view';
+import { MIN_CLIENT_ID_LENGTH } from '../../op-log/core/operation-log.const';
 
 /**
  * Client-ID generation and format validation.
@@ -86,23 +87,43 @@ export const generateClientId = (): string => {
 };
 
 /**
- * Type guard: true if `id` matches a known valid client-ID format.
- * - Legacy format: any string of length >= 10 (legacy IDs).
- * - New format: {platform}_{6-char-base62}, e.g. "B_a7Kx9Z".
+ * Charset every clientId must satisfy to survive a round trip to SuperSync
+ * (`SUPER_SYNC_CLIENT_ID_REGEX` in `@sp/shared-schema`). Inlined rather than
+ * imported because that module pulls in zod and this file sits on the boot
+ * path with no dependencies by design. `generate-client-id.spec.ts` pins the
+ * coupling in the direction that matters: every id SuperSync would carry must
+ * pass this predicate.
+ */
+const USABLE_CLIENT_ID_CHARSET = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Type guard: true if `id` is a clientId this app can actually USE.
  *
- * Used to narrow `unknown` values read from IndexedDB. An invalid format is
- * treated as "absent" rather than fatal — see issue #6197.
+ * ⚠️ This asks "can the system use this id?", never "did THIS build mint it?".
+ * The distinction is the whole bug in #9336 and #6197/#6142: an id is a
+ * persisted, non-regenerable vector-clock key, so this predicate is applied to
+ * whatever any past build wrote to disk — not to freshly generated values.
  *
- * The `[BEAI]` class is a compatibility contract with the installed fleet, not
- * a local detail. "Invalid" means "absent" all the way down: a client that does
- * not know a prefix reads null (`client-id.service.ts:165`) and then mints over
- * the stored id (`:217`) — a silent vector-clock key rotation, one-time per
- * install but permanent, the identity loss #7732 exists to prevent. So a fifth
- * platform code may only ship once the receiving fleet already accepts it.
- * Adding `E`/`I` here was safe precisely because every released client does.
+ * "Invalid" means "absent" all the way down: a rejected id reads as null
+ * (`client-id.service.ts:165`) and is then minted over (`:217`) — a silent,
+ * permanent identity rotation, the loss #7732 exists to prevent. So:
+ *
+ * **NEVER narrow this predicate.** Widening the generator (4→6 random chars in
+ * ec16757c82, shipped v18.11.0) while narrowing the matching check orphaned
+ * every id minted by v17.0.0–v18.10.0. The same mistake in the other direction
+ * (emitting a new shape before readers accept it) caused #6142/#6197/#6274/
+ * #6588/#6793. Both halves of that contract now live here, so the accepted set
+ * is deliberately looser than anything we mint: the `>= 10` branch keeps every
+ * legacy PFAPI id (`getEnvironmentId() + '_' + Date.now()`), and the charset
+ * branch accepts any future prefix or entropy bump without another edit.
+ *
+ * The floor is `MIN_CLIENT_ID_LENGTH` because `incrementVectorClock` throws
+ * below it — that, and the SuperSync charset, are the only real constraints.
  */
 export const isValidClientIdFormat = (id: unknown): id is string => {
   return (
-    typeof id === 'string' && (id.length >= 10 || /^[BEAI]_[a-zA-Z0-9]{6}$/.test(id))
+    typeof id === 'string' &&
+    (id.length >= 10 ||
+      (id.length >= MIN_CLIENT_ID_LENGTH && USABLE_CLIENT_ID_CHARSET.test(id)))
   );
 };


### PR DESCRIPTION
Fixes the silent client-ID rotation behind #9336.

## The bug

`isValidClientIdFormat` gates client IDs **already persisted on disk**, not just freshly
generated ones. `ec16757c82` widened the generator's random suffix from 4 to 6 characters and
narrowed the matching regex to `{6}` in the same commit — so from **v18.11.0** onward, every ID
minted by v17.0.0–v18.10.0 (e.g. `B_H8AR`) reads as absent: `length >= 10` fails at 6
characters, and the `{6}` regex wants a 6-character suffix, not 4.

An unrecognised ID is treated as absent all the way down, so an affected device did not merely
ignore its identity — `_putClientIdIfAbsent` minted over it, silently and permanently rotating
the vector-clock key that #7732 exists to protect.

Affected: installs whose first launch fell in that window, plus **any install of any age that
ran clean-slate, backup-restore, or an E2EE password change** during it, since those mint
directly too.

That commit reached master inside a squashed macOS keyboard-shortcut PR (#8381), which is why a
sync-identity change received no sync review.

## The fix

Make the predicate ask *"can the system use this ID?"* instead of *"did this build mint it?"*.
The only real constraints are `MIN_CLIENT_ID_LENGTH` (below it `incrementVectorClock` throws)
and the SuperSync charset (outside it every upload 400s), so accept anything satisfying both.

The `>= 10` branch is deliberately left untouched — narrowing an accept side against data
already on disk is the bug itself, and legacy PFAPI IDs pass it whatever they contain. A
400k-sample fuzz confirms the new predicate is a **strict superset** of the old one: zero inputs
accepted before are rejected now.

## What this does not do

It prevents further rotations; it cannot undo one. A device that already rotated holds a valid
ID in `SUP_OPS`, which wins over `pf`, and restoring the original would resume a possibly-pruned
clock component from zero — the recovery would itself break causality. So this is prophylaxis
for devices still on ≤ v18.10.0, not a repair.

## Prior art

The same class shipped once before in the opposite direction (emitting a new shape before
readers accepted it): #6142, #6197, #6274, #6588, #6793 — all *"Invalid clientId loaded:
B_…"*, two still open. The JSDoc now states the rule in both directions, and the spec pins it:
any ID SuperSync would carry must pass this predicate.

## Testing

- Full unit suite green in both timezone variants: `Europe/Berlin` 13653/13655, `America/Los_Angeles` 13639/13655, zero failures
- `ng build --configuration production` exit 0 — the new `core/util` → `op-log/core` import creates no cycle
- Sabotage (revert the predicate alone) kills exactly the 6 new tests; all 28 pre-existing ones stay green
- Also verified against the destructive-rotation flows: `clean-slate` 9, `backup` 29, `clean-slate-interrupt` 3

## Follow-up

#9371 — spun off from this investigation. Upload derives one request `clientId` from
`pendingOps[0]` for a batch that isn't guaranteed homogeneous, so **any** rotation with a
non-empty outbox permanently strands the non-matching ops. Independent of this fix, and it
affects clean-slate / backup-restore / E2EE password change on their own.
