### PR TITLE
fix(schedule): show the click affordance on continued repeat projections

### DIFF
--- a/src/app/features/schedule/schedule-event/schedule-event.component.scss
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.scss
@@ -197,10 +197,15 @@
 }
 
 :host-context(.is-not-dragging) {
+  // Keep in sync with the repeat-projection branch of clickHandler(): a segment
+  // that opens the edit dialog must also look like it does. The continued types
+  // became clickable in #9314 and were missing the affordance.
   :host.CalendarEvent,
   :host.RepeatProjection,
   :host.RepeatProjectionSplit,
-  :host.ScheduledRepeatProjection {
+  :host.ScheduledRepeatProjection,
+  :host.RepeatProjectionSplitContinued,
+  :host.RepeatProjectionSplitContinuedLast {
     cursor: pointer;
 
     &:hover {

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { TranslateModule } from '@ngx-translate/core';
@@ -197,6 +197,36 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
         matDialog.open.calls.reset();
       }
     });
+
+    // The spec above calls clickHandler() directly, so it cannot see the host
+    // '(click)' binding disappearing. This one goes through a real DOM event.
+    it('opens the dialog via the host click binding, not just the method', () => {
+      const repeatCfg = { id: 'repeat_cfg_with_underscores' } as TaskRepeatCfg;
+      const matDialog = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>;
+      fixture.componentRef.setInput('event', {
+        id: 'repeat_cfg_with_underscores_not-a-date',
+        type: SVEType.RepeatProjectionSplitContinuedLast,
+        style: '',
+        startHours: 10,
+        timeLeftInHours: 1,
+        plannedForDay: '2026-07-30',
+        sourceOccurrenceDate: '2026-07-29',
+        data: repeatCfg,
+      } as ScheduleEvent);
+      fixture.detectChanges();
+      matDialog.open.calls.reset();
+
+      (fixture.nativeElement as HTMLElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+
+      expect(matDialog.open).toHaveBeenCalledWith(
+        jasmine.anything(),
+        jasmine.objectContaining({
+          data: jasmine.objectContaining({ repeatCfg, targetDate: '2026-07-29' }),
+        }),
+      );
+    });
   });
 
   describe('resize handle', () => {
@@ -320,5 +350,86 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
       const c = await setupWith24h(false);
       expect(c.scheduledClockStr()).toBe('2:00');
     });
+  });
+});
+
+// Mirrors schedule-week.component.ts, which sets '[class.is-not-dragging]' on an
+// ancestor -- without it the :host-context() guard never matches and every
+// cursor below would read 'auto', making the assertions meaningless.
+@Component({
+  imports: [ScheduleEventComponent],
+  template: `<div class="is-not-dragging">
+    <schedule-event [event]="event"></schedule-event>
+  </div>`,
+})
+class AffordanceHostComponent {
+  event!: ScheduleEvent;
+}
+
+describe('ScheduleEventComponent – clickable affordance', () => {
+  const CLICKABLE_REPEAT_TYPES = [
+    SVEType.RepeatProjection,
+    SVEType.RepeatProjectionSplit,
+    SVEType.ScheduledRepeatProjection,
+    SVEType.RepeatProjectionSplitContinued,
+    SVEType.RepeatProjectionSplitContinuedLast,
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AffordanceHostComponent, DragDropModule, TranslateModule.forRoot()],
+      providers: [
+        provideMockStore(),
+        { provide: MatDialog, useValue: { open: jasmine.createSpy('open') } },
+        {
+          provide: TaskService,
+          useValue: { setSelectedId: jasmine.createSpy('setSelectedId') },
+        },
+        {
+          provide: CalendarEventActionsService,
+          useValue: {
+            hasEventUrl: () => false,
+            isPluginEvent: () => false,
+            canMoveEvent: () => false,
+          },
+        },
+        { provide: DateTimeFormatService, useValue: { is24HourFormat: () => true } },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  });
+
+  const cursorFor = (type: SVEType): string => {
+    const fixture = TestBed.createComponent(AffordanceHostComponent);
+    fixture.componentInstance.event = {
+      id: 'repeat_cfg_1_2026-07-30_0',
+      type,
+      style: '',
+      startHours: 10,
+      timeLeftInHours: 1,
+      plannedForDay: '2026-07-30',
+      data: { id: 'repeat_cfg_1', title: 'Repeat' },
+    } as ScheduleEvent;
+    fixture.detectChanges();
+    const host = fixture.nativeElement.querySelector('schedule-event') as HTMLElement;
+    return getComputedStyle(host).cursor;
+  };
+
+  // Every type clickHandler() opens the repeat dialog for must look clickable.
+  // The first three already did; the continued pair became clickable in #9314
+  // and read 'auto' until the selector list was extended -- so those three
+  // double as the positive control proving this assertion can fail.
+  it('shows a pointer cursor for every repeat projection the dialog opens for', () => {
+    const cursors = CLICKABLE_REPEAT_TYPES.map((type) => [type, cursorFor(type)]);
+
+    expect(cursors).toEqual(CLICKABLE_REPEAT_TYPES.map((type) => [type, 'pointer']));
+  });
+
+  // LunchBreak is the one type clickHandler() genuinely ignores -- note that
+  // SplitTaskContinued would be a wrong control here, since #9372 made it
+  // select its task. Asserted positively: `not.toBe('pointer')` would pass just
+  // as happily on '' -- a detached element, or styles that never applied.
+  it('leaves the inert lunch break alone', () => {
+    expect(cursorFor(SVEType.LunchBreak)).toBe('auto');
   });
 });


### PR DESCRIPTION
Follow-up to #9314, which made `RepeatProjectionSplitContinued` and
`RepeatProjectionSplitContinuedLast` open the repeat edit dialog. The cursor/hover rule in
`schedule-event.component.scss` still listed only the three originally clickable types, so in week
view a continued segment opened a dialog while looking completely inert — no pointer cursor, no hover
feedback, directly below a head segment that has both.

Clickability in the Schedule is gated in **two** places, and #9314 only touched the first:

1. the `else if` chain in `clickHandler()` — opens the dialog
2. the selector list under `:host-context(.is-not-dragging)` — `cursor: pointer` and the `:hover` feedback

The host `'(click)': 'clickHandler($event)'` binding is unconditional and `:host > * { pointer-events: none }`
applies only to children, so the clicks did work. Only the affordance was missing.

Week view only: month view sets `cursor: pointer` unconditionally for every event
(`schedule-month.component.scss:238`), so it was never affected.

## Verified by compiling the real pipeline, not by eyeballing the SCSS

Running the stylesheet through Angular's own emulated-encapsulation shim (`encapsulateStyle()`, i.e.
`ShadowCss().shimCssText()` — the exact AOT transform) emits, at the parent commit:

```css
.is-not-dragging .CalendarEvent[_nghost-x],
.is-not-dragging .RepeatProjection[_nghost-x],
.is-not-dragging .RepeatProjectionSplit[_nghost-x],
.is-not-dragging .ScheduledRepeatProjection[_nghost-x] { cursor: pointer; }
```

That matters because `:host-context(X) { :host.Y { … } }` is an unusual nesting and it would be
reasonable to assume it compiles to something dead. It doesn't — `_combineHostContextSelectors`
emits the ancestor form, and `.is-not-dragging` is emitted **unscoped**, so it correctly matches the
`schedule-week` host (`schedule-week.component.ts:72`). Measured cursor per type:

| type | before | after |
| --- | --- | --- |
| `RepeatProjection` | `pointer` | `pointer` |
| `RepeatProjectionSplit` | `pointer` | `pointer` |
| `ScheduledRepeatProjection` | `pointer` | `pointer` |
| `RepeatProjectionSplitContinued` | **`auto`** | `pointer` |
| `RepeatProjectionSplitContinuedLast` | **`auto`** | `pointer` |

No conflict with drag or resize: the new selector is specificity `(0,3,0)` vs `.draggable{cursor:grab}`
at `(0,2,0)`, and `canDragEvent()` is false for every repeat projection anyway. `isResizable()`
requires `!!task()`, never true for projections.

One deliberate side effect: `&:hover > * { opacity: 1 }` now also lifts the continued segment's
`.title { opacity: 0.4 }` marker to full opacity on hover, matching the other types.

## Tests

Three specs, each sabotage-verified:

- **Affordance.** Asserts the whole type list in one `toEqual`, so the three already-working types are
  a built-in positive control. Reverting the SCSS fails on exactly the two new indices while the other
  three pass. The test renders inside a wrapper carrying `.is-not-dragging` (mirroring
  `schedule-week.component.ts`) — without that ancestor the `:host-context()` guard never matches,
  every cursor reads `auto`, and the assertion would be meaningless.
- **Inert control.** `LunchBreak` must stay `auto`. Asserted positively — `not.toBe('pointer')` would
  pass just as happily on `''`. Adding `LunchBreak` to the selector list fails it.
  (`SplitTaskContinued` would be the wrong control here: #9372 made it select its task.)
- **Host click binding.** The existing repeat-projection spec calls `clickHandler()` directly, so it
  cannot see the host `(click)` binding disappear. This one dispatches a real DOM click: removing the
  binding fails only the new spec, while the old one still passes.

363 schedule specs green in `Europe/Berlin`, 349 in `America/Los_Angeles`. `checkFile` clean on both
changed files.

## Deliberately not in this PR

`SplitTaskContinued` / `SplitTaskContinuedLast` became clickable in #9372 and have no affordance
either — same bug class, but it belongs to that change rather than this one.
