### PR TITLE
fix(schedule): project untimed repeats on the day they are due in month view

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
+++ b/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
@@ -97,10 +97,15 @@ export const createScheduleDays = (
       }
     }
 
+    // Which cfgs are due is a property of the calendar day, not of where the
+    // clock happens to sit. Anchoring this on startTime (which is `now` for
+    // i === 0) only agrees with dayDate while day 0 contains now -- an
+    // invariant month view breaks, since its day 0 is the first grid cell and
+    // usually lands in the previous month.
     const nonScheduledRepeatCfgsDueOnDay = selectTaskRepeatCfgsForExactDay.projector(
       unScheduledTaskRepeatCfgs,
       {
-        dayDate: startTime,
+        dayDate: dayStartTime,
       },
     );
 

--- a/src/app/features/schedule/map-schedule-data/month-view-repeat-projection-day.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/month-view-repeat-projection-day.spec.ts
@@ -1,0 +1,75 @@
+import { mapToScheduleDays } from './map-to-schedule-days';
+import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+
+const H = 60 * 60 * 1000;
+const h = (hr: number): number => hr * H;
+
+// Mid-day on the 1st. Month view's daysToShow[0] is the first *grid* cell --
+// the start of the week containing the 1st -- so day 0 sits in the previous
+// month while contextNow stays on the selected date. Week view has no such gap.
+const NOW = new Date(1970, 0, 1, 9, 0, 0, 0).getTime();
+const MONTH_GRID = ['1969-12-30', '1969-12-31', '1970-01-01', '1970-01-02'];
+
+const repeatCfg = (add?: Partial<TaskRepeatCfg>): TaskRepeatCfg =>
+  ({
+    id: 'R_MONTHLY',
+    startDate: '1969-01-01',
+    startTime: undefined,
+    lastTaskCreationDay: getDbDateStr(new Date(1969, 11, 31).getTime()),
+    monday: true,
+    tuesday: true,
+    wednesday: true,
+    thursday: true,
+    friday: true,
+    saturday: true,
+    sunday: true,
+    repeatCycle: 'MONTHLY',
+    repeatEvery: 1,
+    defaultEstimate: h(1),
+    ...add,
+  }) as Partial<TaskRepeatCfg> as TaskRepeatCfg;
+
+const projectionDays = (cfg: TaskRepeatCfg, dayDates: string[]): (string | undefined)[] =>
+  mapToScheduleDays(
+    NOW,
+    dayDates,
+    [],
+    [],
+    [],
+    [cfg],
+    [],
+    null,
+    {},
+    undefined,
+    undefined,
+    NOW,
+  )
+    .flatMap((d) => d.entries)
+    .filter((e) => e.type.startsWith('RepeatProjection'))
+    .map((e) => e.plannedForDay);
+
+describe('untimed repeat projections resolve to the day they are due', () => {
+  // createScheduleDays looked up "which cfgs are due" with `startTime`, which is
+  // `now` for day 0. That only equals day 0 while day 0 contains now -- true in
+  // week view, false in month view. The monthly occurrence therefore also
+  // rendered on grid cell 0, stamped plannedForDay of that cell, and the repeat
+  // dialog resolves targetDate from plannedForDay -- so "skip instance" wrote
+  // the grid cell's date into the synced deletedInstanceDates and left the real
+  // occurrence in place.
+  it('does not project a monthly occurrence onto month view grid cell 0', () => {
+    expect(projectionDays(repeatCfg(), MONTH_GRID)).toEqual(['1970-01-01']);
+  });
+
+  // Guards the fix against being "corrected" back: week view's day 0 IS now's
+  // day, and every other spec uses a midnight `now`, where the two anchors
+  // coincide and the difference is invisible.
+  it('still projects on week view day 0 when now is mid-day', () => {
+    expect(
+      projectionDays(repeatCfg({ id: 'R_DAILY', repeatCycle: 'DAILY' }), [
+        '1970-01-01',
+        '1970-01-02',
+      ]),
+    ).toEqual(['1970-01-01', '1970-01-02']);
+  });
+});


### PR DESCRIPTION
In month view, an untimed repeat projection is rendered **twice**: once on the day it is due, and once
on the first cell of the grid — where it is not due. Clicking the ghost opens the repeat dialog for
the wrong occurrence, and "skip instance" then writes the grid cell's date into `deletedInstanceDates`
while leaving the real occurrence in place.

## Root cause

`createScheduleDays` asks which cfgs are due using `startTime`:

```ts
let startTime = i == 0 ? now : dayStartTime;
...
selectTaskRepeatCfgsForExactDay.projector(unScheduledTaskRepeatCfgs, { dayDate: startTime });
```

while the entry it produces is stamped `plannedForDay: dayDate` (`create-view-entries-for-day.ts`).
Those two agree only while day 0 contains `now`. `_contextNow` is written to guarantee exactly that,
and says so:

> `contextNow` anchors `dayDates[0]` (`startTime = i == 0 ? now` in create-schedule-days), so it has
> to stay inside that day.

But it clamps to `_selectedDate`, and **month view's day 0 is not the selected date** —
`getMonthDaysToShow` starts at the first grid cell, i.e. the beginning of the week containing the 1st,
which normally lands in the previous month. So day 0 looks up "cfgs due on the 1st" and labels the
result with the grid cell's date.

Which cfgs are due is a property of the calendar day, not of where the clock happens to sit, so the
lookup is now anchored on `dayStartTime`. The layout start time is deliberately unchanged.

## Why it matters more since #9314

Before #9314 the dialog derived `targetDate` from `evt.id.split('_')[1]`, which produced garbage on
this path — the Skip button was effectively inert. #9314 made it resolve from `plannedForDay`, so the
button now works and faithfully skips the **wrong** day. `deletedInstanceDates` is `isPersistent: true`,
`OpType.Update` on `TASK_REPEAT_CFG`, appended monotonically, and no template renders it — there is no
UI to inspect or undo an entry.

The bug itself predates #9314.

## Tests

`month-view-repeat-projection-day.spec.ts`, driving the real `mapToScheduleDays`:

| spec | without the fix |
| --- | --- |
| monthly occurrence is not projected onto grid cell 0 | **fails** — `['1969-12-30', '1970-01-01']` instead of `['1970-01-01']` |
| week view day 0 still projects when `now` is mid-day | passes |

The second one is the point of the pair. **Every pre-existing spec uses a midnight `now`**, where
`startTime` and `dayStartTime` coincide and this distinction is invisible — so a green suite proved
nothing about week view. That case pins the behaviour the fix must not change, and stops the change
being "corrected" back.

367 schedule specs green in `Europe/Berlin`, 353 in `America/Los_Angeles`; 612 task-repeat-cfg specs
green. `checkFile` clean.

## Not addressed here

Day 0's `startTime` is also the flow **layout** start, so month view grid cell 0 still lays tasks out
from a `now` in a different month. Same underlying confusion, but fixing it means deciding what "now"
should mean for a month grid — a larger change, and not the part that produces the bad synced write.
