### PR TITLE
fix(habit-tracker): roll the 7-day strip over on day change

### DIFF
--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.spec.ts
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { signal, WritableSignal } from '@angular/core';
 import { registerLocaleData } from '@angular/common';
 import localeSv from '@angular/common/locales/sv';
 import { HabitTrackerComponent } from './habit-tracker.component';
@@ -10,12 +11,16 @@ import { SimpleCounter, SimpleCounterType } from '../simple-counter.model';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { EMPTY_SIMPLE_COUNTER } from '../simple-counter.const';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+import { getDbDateStr } from '../../../util/get-db-date-str';
 
 describe('HabitTrackerComponent', () => {
   let component: HabitTrackerComponent;
   let fixture: ComponentFixture<HabitTrackerComponent>;
   let simpleCounterService: jasmine.SpyObj<SimpleCounterService>;
   let matDialog: jasmine.SpyObj<MatDialog>;
+  let logicalToday: Date;
+  let todayDateStr: WritableSignal<string>;
 
   const mockCounter: SimpleCounter = {
     ...EMPTY_SIMPLE_COUNTER,
@@ -39,13 +44,22 @@ describe('HabitTrackerComponent', () => {
       'deleteSimpleCounter',
     ]);
     matDialog = jasmine.createSpyObj('MatDialog', ['open']);
+    logicalToday = new Date('2026-05-18T10:00:00');
+    todayDateStr = signal(getDbDateStr(logicalToday));
 
     await TestBed.configureTestingModule({
       imports: [HabitTrackerComponent, NoopAnimationsModule, TranslateModule.forRoot()],
       providers: [
         { provide: SimpleCounterService, useValue: simpleCounterService },
         { provide: MatDialog, useValue: matDialog },
-        { provide: DateService, useValue: { todayStr: () => '2026-05-18' } },
+        {
+          provide: DateService,
+          useValue: {
+            todayStr: (date?: Date | number) => getDbDateStr(date ?? logicalToday),
+            getLogicalTodayDate: () => new Date(logicalToday),
+          },
+        },
+        { provide: GlobalTrackingIntervalService, useValue: { todayDateStr } },
         {
           provide: DateTimeFormatService,
           useValue: {
@@ -138,6 +152,32 @@ describe('HabitTrackerComponent', () => {
     } finally {
       document.body.removeChild(mobileLayout);
     }
+  });
+
+  it('rolls the 7 day window over when the day changes', () => {
+    expect(component.days().map((d) => d.str)).toEqual([
+      '2026-05-12',
+      '2026-05-13',
+      '2026-05-14',
+      '2026-05-15',
+      '2026-05-16',
+      '2026-05-17',
+      '2026-05-18',
+    ]);
+
+    // midnight passes while the app stays open
+    logicalToday = new Date('2026-05-19T00:30:00');
+    todayDateStr.set(getDbDateStr(logicalToday));
+
+    expect(component.days().map((d) => d.str)).toEqual([
+      '2026-05-13',
+      '2026-05-14',
+      '2026-05-15',
+      '2026-05-16',
+      '2026-05-17',
+      '2026-05-18',
+      '2026-05-19',
+    ]);
   });
 
   it('should not open edit dialog on long-press if day is disabled', fakeAsync(() => {

--- a/src/app/features/simple-counter/habit-tracker/habit-tracker.component.ts
+++ b/src/app/features/simple-counter/habit-tracker/habit-tracker.component.ts
@@ -11,6 +11,7 @@ import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
 import { SimpleCounter, SimpleCounterType } from '../simple-counter.model';
 import { SimpleCounterService } from '../simple-counter.service';
 import { DateService } from '../../../core/date/date.service';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { T } from '../../../t.const';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -57,6 +58,7 @@ export class HabitTrackerComponent {
   private _simpleCounterService = inject(SimpleCounterService);
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _dateService = inject(DateService);
+  private _globalTrackingIntervalService = inject(GlobalTrackingIntervalService);
   private _matDialog = inject(MatDialog);
 
   // Exposed so templates can pass the reactive locale to the now-pure
@@ -77,10 +79,13 @@ export class HabitTrackerComponent {
     const weekdayFormatter = isoTextLocale
       ? new Intl.DateTimeFormat(isoTextLocale, { weekday: 'short' })
       : null;
-    const today = new Date();
+    // Day-change dependency, so the window rolls over instead of freezing at first
+    // render (#9072). Also covers sleep and tab throttling, via #5464.
+    this._globalTrackingIntervalService.todayDateStr();
+    const today = this._dateService.getLogicalTodayDate();
     const offset = this.dayOffset();
     for (let i = 6; i >= 0; i--) {
-      const d = new Date();
+      const d = new Date(today);
       d.setDate(today.getDate() - i + offset);
       days.push({
         str: this._dateService.todayStr(d),


### PR DESCRIPTION
## Problem

Closes #9072. The 7 day strip is built in a `computed` whose dates come from `new Date()`, which is not reactive, so it renders once and never updates. Leave the app open past midnight and the strip still shows yesterday as the rightmost column, and clicking a cell writes the count to yesterday's date.

Using `new Date()` also ignored the start of next day setting, so the strip could disagree with the rest of the app about which day is today.

## Solution

Read `GlobalTrackingIntervalService.todayDateStr()` inside the computed and take the base date from `DateService.getLogicalTodayDate()`. That signal is the day change source the rest of the app already uses, so the strip also rolls over after sleep or tab throttling. No new timer, no new service.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/wiki.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
