### PR TITLE
fix(util): client-ID validator regression: {4}→{6} tightening silently

### DIFF
--- a/src/app/core/util/generate-client-id.spec.ts
+++ b/src/app/core/util/generate-client-id.spec.ts
@@ -59,6 +59,14 @@ describe('generate-client-id', () => {
       expect(isValidClientIdFormat('I_ZzZzZz')).toBeTrue();
     });
 
+    it('accepts the 4-char compact format minted by v18.7.0 - v18.10.0', () => {
+      // Those ids are still on disk. Rejecting one reads as "absent", which
+      // mints a new id over it — a silent vector-clock key rotation. #9355.
+      expect(isValidClientIdFormat('B_FXMz')).toBeTrue();
+      expect(isValidClientIdFormat('A_1ile')).toBeTrue();
+      expect(isValidClientIdFormat('E_0000')).toBeTrue();
+    });
+
     it('accepts legacy ids of length >= 10', () => {
       expect(isValidClientIdFormat('LongClientId123')).toBeTrue();
       expect(isValidClientIdFormat('0123456789')).toBeTrue();

--- a/src/app/core/util/generate-client-id.ts
+++ b/src/app/core/util/generate-client-id.ts
@@ -89,6 +89,8 @@ export const generateClientId = (): string => {
  * Type guard: true if `id` matches a known valid client-ID format.
  * - Legacy format: any string of length >= 10 (legacy IDs).
  * - New format: {platform}_{6-char-base62}, e.g. "B_a7Kx9Z".
+ * - The 4-char suffix v18.7.0 - v18.10.0 minted, e.g. "B_FXMz". Only the
+ *   generator moved to 6 chars; those ids are still on disk and stay valid.
  *
  * Used to narrow `unknown` values read from IndexedDB. An invalid format is
  * treated as "absent" rather than fatal — see issue #6197.
@@ -103,6 +105,7 @@ export const generateClientId = (): string => {
  */
 export const isValidClientIdFormat = (id: unknown): id is string => {
   return (
-    typeof id === 'string' && (id.length >= 10 || /^[BEAI]_[a-zA-Z0-9]{6}$/.test(id))
+    typeof id === 'string' &&
+    (id.length >= 10 || /^[BEAI]_([a-zA-Z0-9]{4}|[a-zA-Z0-9]{6})$/.test(id))
   );
 };


### PR DESCRIPTION
This is a small, targeted change to src/app/core/util/generate-client-id.spec.ts, src/app/core/util/generate-client-id.ts that resolves the reported issue without touching anything unrelated.

Fixes #9355.

The repo's own CI runs green on this branch; I ran it on my fork before opening this.
