### PR TITLE
test(sync): wait for log export before parsing

### DIFF
--- a/e2e/tests/sync/supersync-final-page-decrypt-failure-9256.spec.ts
+++ b/e2e/tests/sync/supersync-final-page-decrypt-failure-9256.spec.ts
@@ -337,9 +337,9 @@ test.describe('@supersync @encryption #9256 final-page decrypt failure', () => {
       const settingsPage = new SettingsPage(clientB.page);
       await settingsPage.navigateToSettings();
       await clientB.page.getByRole('link', { name: 'Logs', exact: true }).click();
-      const exportedLogsText = await clientB.page
-        .locator('dialog-logs textarea.logs-textarea')
-        .inputValue();
+      const logsTextarea = clientB.page.locator('dialog-logs textarea.logs-textarea');
+      await expect(logsTextarea).toHaveValue(/^\s*\[[\s\S]*\]\s*$/);
+      const exportedLogsText = await logsTextarea.inputValue();
       const exportedLogs: unknown = JSON.parse(exportedLogsText);
 
       // One diagnostic entry per failed run: the initial download plus the


### PR DESCRIPTION
## Summary

- wait for the Logs dialog textarea to contain a complete JSON array before reading it
- prevent a timing-dependent failure in the final-page decrypt recovery E2E

## Root cause

[Scheduled E2E run 30452872330](https://github.com/super-productivity/super-productivity/actions/runs/30452872330) failed because the test clicked **Logs** and immediately called `inputValue()`. The dialog textarea already existed but its Angular value binding had not populated yet, so Playwright returned an empty string and `JSON.parse` failed. The uploaded trace showed the complete, valid JSON value appearing about 23 ms later with both expected diagnostic records.

This is a test-only synchronization fix; product behavior is unchanged.

## Validation

- `npm run checkFile e2e/tests/sync/supersync-final-page-decrypt-failure-9256.spec.ts`
- targeted SuperSync E2E with one worker and `--retries=0`: 1 passed
- `HUSKY=0 npm run shared-schema:test`: 89 passed
- commit hooks: lint completed with no errors; lint-rule, theme-asset, and macOS-icon tests passed
