### PR TITLE
fix(task): make move-to-backlog shortcut leave the Today view

### DIFF
--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -1,4 +1,4 @@
-import { signal } from '@angular/core';
+import { signal, WritableSignal } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Location } from '@angular/common';
 import { MatDialog, MatDialogState } from '@angular/material/dialog';
@@ -12,6 +12,7 @@ import { DateService } from '../../../core/date/date.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
 import { GlobalConfigService } from '../../config/global-config.service';
+import { Project } from '../../project/project.model';
 import { ProjectService } from '../../project/project.service';
 import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { TaskAttachmentService } from '../task-attachment/task-attachment.service';
@@ -32,6 +33,7 @@ describe('TaskComponent shortcut handling', () => {
   let taskServiceSpy: jasmine.SpyObj<TaskService>;
   let addSubtaskInputServiceSpy: jasmine.SpyObj<AddSubtaskInputService>;
   let storeSpy: jasmine.SpyObj<Store>;
+  let isTodayListSignal: WritableSignal<boolean>;
 
   const createSubTask = (title: string): TaskWithSubTasks =>
     ({
@@ -105,6 +107,7 @@ describe('TaskComponent shortcut handling', () => {
     );
     storeSpy = jasmine.createSpyObj<Store>('Store', ['dispatch', 'select']);
     storeSpy.select.and.returnValue(of(new Set<string>()));
+    isTodayListSignal = signal(false);
 
     await TestBed.configureTestingModule({
       imports: [TaskComponent],
@@ -191,6 +194,7 @@ describe('TaskComponent shortcut handling', () => {
           provide: WorkContextService,
           useValue: {
             isTodayList: signal(false),
+            isTodayListSignal,
           },
         },
         {
@@ -633,6 +637,66 @@ describe('TaskComponent shortcut handling', () => {
       expect(document.activeElement).toBe(lastSubtask);
       detailPanel.remove();
     }));
+  });
+
+  describe('moveToBacklogWithFocus from Today view (#9374)', () => {
+    let projectService: jasmine.SpyObj<ProjectService>;
+
+    beforeEach(() => {
+      projectService = TestBed.inject(ProjectService) as jasmine.SpyObj<ProjectService>;
+      fixture.componentRef.setInput('task', createTopLevelTask('Scheduled for today'));
+      storeSpy.dispatch.calls.reset();
+    });
+
+    it('keeps the position-only move outside of the Today list (#8592)', () => {
+      component.moveToBacklogWithFocus();
+
+      expect(projectService.moveTaskToBacklog).toHaveBeenCalledWith('top-1', 'project-1');
+      expect(projectService.getByIdOnce$).not.toHaveBeenCalled();
+      expect(storeSpy.dispatch).not.toHaveBeenCalledWith(
+        TaskSharedActions.unscheduleTask({ id: 'top-1' }),
+      );
+    });
+
+    it('also unschedules on the Today list so the task actually leaves it', () => {
+      isTodayListSignal.set(true);
+      projectService.getByIdOnce$.and.returnValue(
+        of({ isEnableBacklog: true } as Project),
+      );
+
+      component.moveToBacklogWithFocus();
+
+      expect(projectService.moveTaskToBacklog).toHaveBeenCalledWith('top-1', 'project-1');
+      expect(storeSpy.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.unscheduleTask({ id: 'top-1' }),
+      );
+    });
+
+    it('no-ops on the Today list when the project backlog is disabled', () => {
+      isTodayListSignal.set(true);
+      projectService.getByIdOnce$.and.returnValue(
+        of({ isEnableBacklog: false } as Project),
+      );
+
+      component.moveToBacklogWithFocus();
+
+      expect(projectService.moveTaskToBacklog).not.toHaveBeenCalled();
+      expect(storeSpy.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('no-ops for a task without a project', () => {
+      isTodayListSignal.set(true);
+      fixture.componentRef.setInput('task', {
+        ...createTopLevelTask('No project'),
+        projectId: undefined,
+      } as unknown as TaskWithSubTasks);
+
+      component.moveToBacklogWithFocus();
+
+      expect(projectService.moveTaskToBacklog).not.toHaveBeenCalled();
+      expect(projectService.getByIdOnce$).not.toHaveBeenCalled();
+      expect(storeSpy.dispatch).not.toHaveBeenCalled();
+    });
   });
 
   describe('moveToToday overdue branch (#8851)', () => {

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -812,10 +812,28 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
 
   moveToBacklogWithFocus(): void {
     const t = this.task();
-    if (t.projectId && !t.parentId) {
+    if (!t.projectId || t.parentId) {
+      return;
+    }
+    if (!this.isTodayListActive()) {
       this.focusPrevious(true);
       this.moveToBacklog();
+      return;
     }
+    // Membership in the Today view is schedule-based, so from there the
+    // position-only backlog move alone is invisible: the task would stay on
+    // the list and only the focus would jump to the previous task (#9374).
+    // Unschedule the task as well so it actually disappears from Today. If
+    // the project's backlog is disabled the move would be dropped by the
+    // reducer, so no-op entirely instead of silently unscheduling.
+    this._projectService.getByIdOnce$(t.projectId).subscribe((project) => {
+      if (!project?.isEnableBacklog) {
+        return;
+      }
+      this.focusPrevious(true);
+      this.moveToBacklog();
+      this.unschedule();
+    });
   }
 
   moveToTodayWithFocus(): void {


### PR DESCRIPTION
## Problem

Pressing the move-to-backlog shortcut on a task in the Today view only moved focus to the previous task; the task itself stayed put. The dispatch actually ran, but it only moves the id between `project.taskIds` and `project.backlogTaskIds`, and Today membership is schedule-based (`dueDay`/`dueWithTime`), so the position-only move is invisible there.

Fixes #9374.

## Solution

When the shortcut fires on the Today list, unschedule the task in addition to the backlog move so it actually leaves the view. If the project's backlog is disabled the reducer drops the move, so the shortcut now no-ops entirely there instead of shifting focus (or silently unscheduling). Project-view behavior is unchanged and stays schedule-preserving (#8592).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Documentation/wiki changes (not applicable)
- [x] I have run `npm run checkFile` on changed `.ts` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit message follows the Angular format
