### PR TITLE
fix(issue): show human-readable calendar names instead of hostnames

### DIFF
--- a/src/app/features/calendar-integration/calendar-integration.service.ts
+++ b/src/app/features/calendar-integration/calendar-integration.service.ts
@@ -9,6 +9,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 import { getRelevantEventsForCalendarIntegrationFromIcal } from '../schedule/ical/get-relevant-events-from-ical';
+import { getCalNameFromIcal } from '../schedule/ical/get-cal-name-from-ical';
 import {
   BehaviorSubject,
   combineLatest,
@@ -40,6 +41,7 @@ import {
 } from '../schedule/schedule.model';
 import { getDbDateStr } from '../../util/get-db-date-str';
 import { selectCalendarProviders } from '../issue/store/issue-provider.selectors';
+import { IssueProviderActions } from '../issue/store/issue-provider.actions';
 import {
   IssueProviderCalendar,
   IssueProviderPluginType,
@@ -441,15 +443,16 @@ export class CalendarIntegrationService {
         },
       })
       .pipe(
-        switchMap((icalStrData) =>
-          getRelevantEventsForCalendarIntegrationFromIcal(
+        switchMap((icalStrData) => {
+          this._updateCalNameIfChanged(calProvider, icalStrData);
+          return getRelevantEventsForCalendarIntegrationFromIcal(
             icalStrData,
             calProvider.id,
             start,
             end,
             calProvider.icalUrl,
-          ),
-        ),
+          );
+        }),
         map((events) =>
           events.map((ev) => ({
             ...ev,
@@ -508,6 +511,26 @@ export class CalendarIntegrationService {
       Date.now() + ONE_MONTHS,
       isForwardError,
     );
+  }
+
+  /**
+   * Persists the feed's own display name (X-WR-CALNAME) on the provider so
+   * lists and tooltips can show "Work" instead of "calendar.example.com"
+   * (#9144). Dispatches only when the name actually changed — i.e. at most
+   * once per calendar rename — so regular polling causes no store churn.
+   */
+  private _updateCalNameIfChanged(
+    calProvider: IssueProviderCalendar,
+    icalStrData: string,
+  ): void {
+    const calName = getCalNameFromIcal(icalStrData);
+    if (calName && calName !== calProvider.calName) {
+      this._store.dispatch(
+        IssueProviderActions.updateIssueProvider({
+          issueProvider: { id: calProvider.id, changes: { calName } },
+        }),
+      );
+    }
   }
 
   private _getCalProviderFromCache(): ScheduleCalendarMapEntry[] {

--- a/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.spec.ts
+++ b/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.spec.ts
@@ -1,4 +1,9 @@
-import { sanitizeIcalUrlForDisplay } from './get-issue-provider-tooltip';
+import {
+  getIssueProviderInitials,
+  getIssueProviderTooltip,
+  sanitizeIcalUrlForDisplay,
+} from './get-issue-provider-tooltip';
+import { IssueProvider } from '../issue.model';
 
 describe('sanitizeIcalUrlForDisplay', () => {
   it('returns hostname for https:// URLs', () => {
@@ -83,5 +88,89 @@ describe('sanitizeIcalUrlForDisplay', () => {
 
   it('returns iCal placeholder for undefined input', () => {
     expect(sanitizeIcalUrlForDisplay(undefined)).toBe('iCal');
+  });
+});
+
+describe('getIssueProviderTooltip', () => {
+  it('uses the configured calendar name for CALDAV providers (#9144)', () => {
+    const provider = {
+      issueProviderKey: 'CALDAV',
+      resourceName: 'Work Calendar',
+      caldavUrl: 'https://dav.example.com/calendars/work',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderTooltip(provider)).toBe('Work Calendar');
+  });
+
+  it('falls back to the URL for CALDAV providers without a calendar name', () => {
+    const provider = {
+      issueProviderKey: 'CALDAV',
+      resourceName: null,
+      caldavUrl: 'https://dav.example.com/calendars/work',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderTooltip(provider)).toBe(
+      'https://dav.example.com/calendars/work',
+    );
+  });
+
+  it('uses the feed calendar name for ICAL providers (#9144)', () => {
+    const provider = {
+      issueProviderKey: 'ICAL',
+      calName: 'Family',
+      icalUrl: 'https://calendar.example.com/family.ics',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderTooltip(provider)).toBe('Family');
+  });
+
+  it('falls back to the sanitized hostname for ICAL providers without a name', () => {
+    const provider = {
+      issueProviderKey: 'ICAL',
+      icalUrl: 'https://calendar.example.com/family.ics?token=SECRET',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderTooltip(provider)).toBe('calendar.example.com');
+  });
+});
+
+describe('getIssueProviderInitials', () => {
+  it('derives CALDAV initials from the configured calendar name (#9144)', () => {
+    const provider = {
+      issueProviderKey: 'CALDAV',
+      resourceName: 'Work Calendar',
+      caldavUrl: 'https://dav.example.com/calendars/work',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderInitials(provider)).toBe('WO');
+  });
+
+  it('falls back to the URL for CALDAV providers without a calendar name', () => {
+    const provider = {
+      issueProviderKey: 'CALDAV',
+      resourceName: null,
+      caldavUrl: 'https://dav.example.com/calendars/work',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderInitials(provider)).toBe('DA');
+  });
+
+  it('derives ICAL initials from the feed calendar name (#9144)', () => {
+    const provider = {
+      issueProviderKey: 'ICAL',
+      calName: 'Family',
+      icalUrl: 'https://calendar.google.com/family.ics',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderInitials(provider)).toBe('FA');
+  });
+
+  it('keeps the Google shortcut for ICAL providers without a name', () => {
+    const provider = {
+      issueProviderKey: 'ICAL',
+      icalUrl: 'https://calendar.google.com/family.ics',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderInitials(provider)).toBe('G');
+  });
+
+  it('falls back to sanitized hostname initials for other ICAL feeds', () => {
+    const provider = {
+      issueProviderKey: 'ICAL',
+      icalUrl: 'https://calendar.example.com/cal.ics',
+    } as Partial<IssueProvider> as IssueProvider;
+    expect(getIssueProviderInitials(provider)).toBe('CA');
   });
 });

--- a/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.ts
+++ b/src/app/features/issue/mapping-helper/get-issue-provider-tooltip.ts
@@ -56,9 +56,13 @@ export const getIssueProviderTooltip = (issueProvider: IssueProvider): string =>
       case 'GITLAB':
         return issueProvider.project;
       case 'CALDAV':
-        return issueProvider.caldavUrl;
+        // Prefer the human-readable calendar name the user is required to
+        // configure; the URL is only the fallback (#9144).
+        return issueProvider.resourceName || issueProvider.caldavUrl;
       case 'ICAL':
-        return sanitizeIcalUrlForDisplay(issueProvider.icalUrl);
+        // Prefer the calendar's own display name (X-WR-CALNAME, captured on
+        // fetch) over the bare hostname (#9144).
+        return issueProvider.calName || sanitizeIcalUrlForDisplay(issueProvider.icalUrl);
       case 'REDMINE':
         return issueProvider.projectId;
       case 'OPEN_PROJECT':
@@ -115,12 +119,18 @@ export const getIssueProviderInitials = (
         ?.substring(0, 2)
         ?.toUpperCase();
     case 'CALDAV':
+      if (issueProvider.resourceName) {
+        return issueProvider.resourceName.substring(0, 2).toUpperCase();
+      }
       return issueProvider.caldavUrl
         ?.replace('https://', '')
         ?.replace('http://', '')
         ?.substring(0, 2)
         ?.toUpperCase();
     case 'ICAL':
+      if (issueProvider.calName) {
+        return issueProvider.calName.substring(0, 2).toUpperCase();
+      }
       if (issueProvider.icalUrl?.includes('google')) return 'G';
       if (issueProvider.icalUrl?.includes('office365')) return 'MS';
       // Route through the sanitizer so credentials embedded in user/path/query

--- a/src/app/features/issue/providers/calendar/calendar.model.ts
+++ b/src/app/features/issue/providers/calendar/calendar.model.ts
@@ -4,6 +4,9 @@ import { CalendarIntegrationEvent } from '../../../calendar-integration/calendar
 
 export interface CalendarProviderCfg extends BaseIssueProviderCfg {
   icalUrl: string;
+  // Human-readable calendar name taken from the feed's X-WR-CALNAME property.
+  // Captured on fetch so lists/tooltips can show it instead of the hostname.
+  calName?: string;
   isAutoImportForCurrentDay: boolean;
   isReferenceCalendar?: boolean;
   color?: string;

--- a/src/app/features/schedule/ical/get-cal-name-from-ical.spec.ts
+++ b/src/app/features/schedule/ical/get-cal-name-from-ical.spec.ts
@@ -1,0 +1,64 @@
+import { getCalNameFromIcal } from './get-cal-name-from-ical';
+
+const wrapIcal = (lines: string[]): string =>
+  ['BEGIN:VCALENDAR', 'VERSION:2.0', ...lines, 'END:VCALENDAR'].join('\r\n');
+
+describe('getCalNameFromIcal', () => {
+  it('extracts the calendar name from X-WR-CALNAME', () => {
+    expect(getCalNameFromIcal(wrapIcal(['X-WR-CALNAME:Work Calendar']))).toBe(
+      'Work Calendar',
+    );
+  });
+
+  it('matches case-insensitively', () => {
+    expect(getCalNameFromIcal(wrapIcal(['x-wr-calname:Private']))).toBe('Private');
+  });
+
+  it('handles property parameters before the value', () => {
+    expect(getCalNameFromIcal(wrapIcal(['X-WR-CALNAME;VALUE=TEXT:Team Events']))).toBe(
+      'Team Events',
+    );
+  });
+
+  it('unfolds folded content lines (RFC 5545 §3.1)', () => {
+    expect(
+      getCalNameFromIcal(wrapIcal(['X-WR-CALNAME:A very long calen', ' dar name'])),
+    ).toBe('A very long calendar name');
+  });
+
+  it('unescapes TEXT values (RFC 5545 §3.3.11)', () => {
+    expect(getCalNameFromIcal(wrapIcal(['X-WR-CALNAME:Family\\, Friends\\; more']))).toBe(
+      'Family, Friends; more',
+    );
+  });
+
+  it('renders escaped newlines as a single-line label', () => {
+    expect(getCalNameFromIcal(wrapIcal(['X-WR-CALNAME:Line1\\nLine2']))).toBe(
+      'Line1 Line2',
+    );
+  });
+
+  it('handles LF-only line endings', () => {
+    expect(
+      getCalNameFromIcal('BEGIN:VCALENDAR\nX-WR-CALNAME:Unix Feed\nEND:VCALENDAR'),
+    ).toBe('Unix Feed');
+  });
+
+  it('returns undefined when the property is missing', () => {
+    expect(getCalNameFromIcal(wrapIcal(['X-WR-TIMEZONE:Europe/Berlin']))).toBeUndefined();
+  });
+
+  it('returns undefined for an empty value', () => {
+    expect(getCalNameFromIcal(wrapIcal(['X-WR-CALNAME:']))).toBeUndefined();
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(getCalNameFromIcal('')).toBeUndefined();
+  });
+
+  it('does NOT match a property whose name merely starts alike', () => {
+    expect(
+      getCalNameFromIcal(wrapIcal(['SUMMARY:X-WR-CALNAME:not a real one'])),
+    ).toBeUndefined();
+  });
+});

--- a/src/app/features/schedule/ical/get-cal-name-from-ical.ts
+++ b/src/app/features/schedule/ical/get-cal-name-from-ical.ts
@@ -1,0 +1,28 @@
+/**
+ * Extracts the human-readable calendar name from an iCal feed.
+ *
+ * X-WR-CALNAME is a de-facto standard property (Google, Outlook, Nextcloud,
+ * Apple all emit it) carrying the calendar's display name. It is matched with
+ * a small regex on the raw feed text instead of a full ICAL.parse so callers
+ * can use it before (and independently of) event parsing.
+ */
+export const getCalNameFromIcal = (icalData: string): string | undefined => {
+  if (!icalData) {
+    return undefined;
+  }
+  // Unfold folded content lines per RFC 5545 §3.1 (line break followed by
+  // a single space or tab continues the previous line).
+  const unfolded = icalData.replace(/\r?\n[ \t]/g, '');
+  // Allow property parameters between the name and the value separator,
+  // e.g. `X-WR-CALNAME;VALUE=TEXT:My Calendar`.
+  const match = unfolded.match(/^X-WR-CALNAME(?:;[^:\r\n]*)?:(.*)$/im);
+  if (!match) {
+    return undefined;
+  }
+  const value = match[1]
+    // Unescape TEXT values per RFC 5545 §3.3.11; escaped newlines become a
+    // plain space since the name is rendered as a single-line label.
+    .replace(/\\([\\;,nN])/g, (_, c: string) => (c === 'n' || c === 'N' ? ' ' : c))
+    .trim();
+  return value || undefined;
+};

--- a/src/app/imex/file-imex/privacy-export.ts
+++ b/src/app/imex/file-imex/privacy-export.ts
@@ -35,6 +35,7 @@ const KEY_TO_REPLACE = [
 
   // Issue #6020: Additional PII fields
   'resourceName',
+  'calName',
   'name',
   'description',
   'location',


### PR DESCRIPTION
## Problem

Synced calendars are listed by URL, not by name. The Issue Provider panel and its tooltips show the raw CalDAV URL even though CalDAV setup already requires a human-readable calendar name. iCal feeds are worse: they carry no name at all, so both the Issue Provider panel and Schedule's Calendar Visibility menu show bare hostnames — with several calendars on one host (e.g. Google), the entries are indistinguishable.

## Solution

- CALDAV: label the provider (and its chip initials) with the configured `resourceName`, falling back to the URL when it is missing.
- ICAL: capture the feed's `X-WR-CALNAME` (the de-facto standard display-name property emitted by Google, Outlook, Nextcloud, and Apple) when the feed is fetched, persist it on the provider only when it actually changed, and prefer it for the label and chip initials. The sanitized hostname stays as the fallback.
- Mask the new `calName` field in the privacy export, same as `resourceName`.

Extraction is a small unfold-and-match on the raw feed text (RFC 5545 line unfolding and TEXT unescaping) so it works before and independently of event parsing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Documentation/wiki changes (not applicable)
- [x] I have run `npm run checkFile` on changed `.ts` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit message follows the Angular format

## Testing

- New specs for `getCalNameFromIcal` (folding, parameters, escaping, LF-only feeds, missing/empty values)
- New specs for the CALDAV/ICAL branches of `getIssueProviderTooltip` and `getIssueProviderInitials`
- Full pre-push suite: 13737 passing; the single failure is `create-blocked-blocks-by-day-map.spec.ts`, which also fails on master (hardcoded date)

Fixes #9144