### PR TITLE
test(schedule): stop the repeat projection spec depending on the wall clock

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
@@ -62,6 +62,11 @@ describe('createBlockedBlocksByDayMap()', () => {
       startDate: occurrenceDay,
       startTime: '23:00',
       defaultEstimate: h(2),
+      // DEFAULT_TASK_REPEAT_CFG anchors this to the real today at module load,
+      // and selectTaskRepeatCfgsForExactDay drops a day that equals the anchor —
+      // so leaving it defaulted made this spec pass only until the wall clock
+      // reached the hardcoded occurrence day.
+      lastTaskCreationDay: '1970-01-01',
     };
 
     const result = createBlockedBlocksByDayMap(


### PR DESCRIPTION
`master` is currently red, and it is a time bomb rather than a flake.

`createBlockedBlocksByDayMap() > keeps a repeat projection source day when a scheduled occurrence crosses midnight` fails on a clean checkout:

```
TypeError: Cannot read properties of undefined (reading 'sourceOccurrenceDate')
    at create-blocked-blocks-by-day-map.spec.ts:85:27
```

## Why it went red on its own

The spec spreads `DEFAULT_TASK_REPEAT_CFG` and overrides `startDate`, but leaves `lastTaskCreationDay` at the default. That default is evaluated at module load:

```ts
// task-repeat-cfg.model.ts:108-110
export const DEFAULT_TASK_REPEAT_CFG: Omit<TaskRepeatCfgCopy, 'id'> = {
  lastTaskCreation: Date.now(),
  lastTaskCreationDay: getDbDateStr(),   // <- the real today
```

and `selectTaskRepeatCfgsForExactDay` drops any day equal to that anchor:

```ts
// task-repeat-cfg.selectors.ts:106-113
const effectiveLastDay = getEffectiveLastTaskCreationDay(taskRepeatCfg);
if (effectiveLastDay === dateStr || (effectiveLastDay && effectiveLastDay > dateStr)) {
  return false;
}
```

The spec's occurrence day is hardcoded to `2026-07-30`. So it was green when it landed on 2026-07-29 (`a12a7a1e4`, #9314) and started failing the next day, when the wall clock reached the date it asserts on — no code change involved.

Verified red at `a12a7a1e4`, `46f1bb53e~1`, `46f1bb53e`, `d96109681` and `7b6a17047`, i.e. from the commit that introduced it onward; and shifting only the spec's two dates to 2028 turns it green, which isolates the cause to the anchor rather than anything in the projection code.

## Fix

Pin `lastTaskCreationDay` explicitly, which is what the sibling specs in the same area already do (`create-sorted-blocker-blocks.spec.ts:777` uses `'1970-01-01'`, `month-view-repeat-projection-day.spec.ts:19` uses an epoch-relative date). Test-only change; no production code touched.

Full `npm test` green in both timezones on this branch: 13705 passing / 16 skipped.

## One thing worth flagging beyond this diff

This failure mode is not specific to the one spec — any spec that spreads `DEFAULT_TASK_REPEAT_CFG` while asserting on a hardcoded date becomes a bomb dated to that day, and it lands on whoever pushes next rather than on the PR that introduced it. I did not audit the rest of the suite for it, so I can only say it is green today, not that no other spec detonates later. If you want, the sharper fix is to make the anchor non-defaulted for tests, or to have `DEFAULT_TASK_REPEAT_CFG` not bake a load-time timestamp at all — happy to look at either as a follow-up, but that is a wider change than unbreaking the suite.
