### PR TITLE
fix(short-syntax): keep the typed time when the weekend skip crosses a DST change

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
@@ -62,6 +62,11 @@ describe('createBlockedBlocksByDayMap()', () => {
       startDate: occurrenceDay,
       startTime: '23:00',
       defaultEstimate: h(2),
+      // DEFAULT_TASK_REPEAT_CFG anchors this to the real today at module load,
+      // and selectTaskRepeatCfgsForExactDay drops a day that equals the anchor —
+      // so leaving it defaulted made this spec pass only until the wall clock
+      // reached the hardcoded occurrence day.
+      lastTaskCreationDay: '1970-01-01',
     };
 
     const result = createBlockedBlocksByDayMap(

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -2375,6 +2375,37 @@ describe('shortSyntax recurrence', () => {
   ): RepeatQuickSetting | null =>
     r?.repeat?.type === 'PRESET' ? r.repeat.quickSetting : null;
 
+  // The ambient timezone's spring-forward sunday and the hour it skips, derived
+  // rather than hardcoded so the DST case below is exercised in every zone the
+  // suite runs in (Berlin transitions in march, Los Angeles two weeks earlier,
+  // Sydney in october). Returns null where there is no transition.
+  const findSpringForwardSunday = (
+    year: number,
+  ): { sunday: Date; missingHour: number } | null => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    for (let month = 0; month < 12; month++) {
+      for (let day = 1; day <= 31; day++) {
+        const start = new Date(year, month, day, 0, 0, 0, 0);
+        if (start.getDate() !== day || start.getDay() !== 0) {
+          continue;
+        }
+        // A spring-forward day is shorter than 24h.
+        if (
+          new Date(year, month, day + 1, 0, 0, 0, 0).getTime() - start.getTime() >=
+          dayMs
+        ) {
+          continue;
+        }
+        for (let hour = 1; hour < 6; hour++) {
+          if (new Date(year, month, day, hour, 30, 0, 0).getHours() !== hour) {
+            return { sunday: start, missingHour: hour };
+          }
+        }
+      }
+    }
+    return null;
+  };
+
   it('should parse "@every friday" as weekly repeat anchored to next friday', async () => {
     const r = await parse('Water plants @every friday');
     expect(presetOf(r)).toBe('WEEKLY_CURRENT_WEEKDAY');
@@ -2592,6 +2623,28 @@ describe('shortSyntax recurrence', () => {
     expect(due.getDate()).toBe(22);
     expect(due.getDay()).toBe(1);
     expect(due.getHours()).toBe(6);
+  });
+
+  it('should keep the typed time when the skipped-over sunday springs forward', async () => {
+    // The weekend skip steps through Sunday, which is the day DST changes. If
+    // the typed time falls in the spring-forward gap, setDate normalizes it and
+    // the shift sticks — and this one is not preview-only: the time is read back
+    // off the parsed timestamp into the repeat config's startTime, so the task
+    // would recur an hour late every workday.
+    const gap = findSpringForwardSunday(2026);
+    if (!gap) {
+      // Timezone without a spring-forward transition (UTC, Tokyo).
+      return;
+    }
+    const friday = new Date(gap.sunday);
+    friday.setDate(friday.getDate() - 2);
+    friday.setHours(gap.missingHour + 6, 0);
+    const r = await parse(`Standup @every weekday ${gap.missingHour}:30am`, friday);
+    expect(presetOf(r)).toBe('MONDAY_TO_FRIDAY');
+    const due = new Date(r?.taskChanges.dueWithTime as number);
+    expect(due.getDay()).toBe(1);
+    expect(due.getHours()).toBe(gap.missingHour);
+    expect(due.getMinutes()).toBe(30);
   });
 
   it('should parse "@every 15th" as monthly on next 15th', async () => {

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -852,9 +852,15 @@ const anchorCycleOf = (repeat: ShortSyntaxRepeat): RepeatCycleOption | null => {
 // date in place would only make the add bar advertise a first occurrence the
 // task never gets. Mutates in place, like the roll-forward above.
 const skipExcludedWeekend = (date: Date): void => {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
   while (date.getDay() === 0 || date.getDay() === 6) {
     date.setDate(date.getDate() + 1);
   }
+  // A skipped-over day can be a DST spring-forward day whose 02:00-03:00 hour
+  // does not exist; stepping through it would silently shift the clock time,
+  // and that time is read back into the repeat config's startTime.
+  date.setHours(hours, minutes);
 };
 
 // Resolves a matched recurrence phrase into task changes: the parsed repeat


### PR DESCRIPTION
Closes the one finding in your approving review on #9370 — thanks for catching it. It landed as-is, so this is live in `master`.

> `skipExcludedWeekend` steps *through* Sunday, and Sunday is the day DST changes. If the typed time falls in the spring-forward gap, `setDate` normalizes it and the shift sticks.

Confirmed, with your numbers:

```
Europe/Berlin, spring-forward Sun 2026-03-29 (02:00 → 03:00)
"Standup @every weekday 2:30am" typed Fri 2026-03-27 08:00

master: preview Sat 03-28 02:30 → cfg.startDate 03-28, startTime "02:30" → SCHED Mon 03-30 02:30
  this: preview Mon 03-30 02:30 → cfg.startDate 03-30, startTime "02:30" → SCHED Mon 03-30 02:30
```

Sat 02:30 → `setDate(+1)` → Sun 02:30 does not exist → JS gives 03:30 → `setDate(+1)` → Mon 03:30. And as you noted this one is not preview-only: `state.time` is read back off the parsed timestamp (`add-task-bar-parser.service.ts:191-203`), so the shifted hour is written into the repeat config's `startTime` and the task then recurs at 03:30 every workday.

The fix is your patch — capture the clock time before the loop, restore it after.

## The spec is derived, not hardcoded

One deviation worth explaining. The convention in the repo for DST specs is to hardcode one zone's transition and note that it passes trivially elsewhere (`date.service.tz.spec.ts:105-108`). I did not follow it here, because a spec that cannot fail in `Europe/Berlin` would not have guarded this — and Berlin is where the suite runs by default.

So `findSpringForwardSunday(2026)` derives the transition from the ambient zone: it looks for a Sunday shorter than 24h, then for the hour where `getHours()` disagrees with the hour requested. Zones without a transition return `null` and the spec returns early.

Verified by breaking it — with the fix reverted, the spec fails in **both** timezones the suite runs in, not just one:

```
TZ=Europe/Berlin       Expected 3 to be 2.   TOTAL: 1 FAILED, 222 SUCCESS
TZ=America/Los_Angeles Expected 3 to be 2.   TOTAL: 1 FAILED, 222 SUCCESS
```

With the fix: 223 SUCCESS in `Europe/Berlin`, `America/Los_Angeles`, `Asia/Tokyo` and `Australia/Sydney`.

Full `npm test` green in both timezones: 13705 passing / 16 skipped.

## Note on the base

The first commit here is #9386, not part of this change. `master`'s suite is currently red on an unrelated spec that became date-dependent yesterday, so the pre-push hook cannot pass on a branch based directly on `master`. Once #9386 lands this rebases down to the single `short-syntax` commit — or just merge #9386 first and I will rebase.

## Your other two review items — deliberately not in here

- The date-picker + *Monday to Friday* pick divergence (`applyUserRepeatPick` not touching `state.date`) you marked "scope note, not a request", so I have left it out. Happy to do it separately if you want it.
- `@every weekday 2:30am` typed on **Sat** 2026-03-28 parsing to no date at all is pre-existing and untouched here.
