### PR TITLE
fix(mobile): keep bottom-anchored overlays out of the safe area (#8792)

### DIFF
--- a/src/app/core/theme/cdk-safe-area-viewport.util.spec.ts
+++ b/src/app/core/theme/cdk-safe-area-viewport.util.spec.ts
@@ -1,0 +1,158 @@
+import { Component, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FlexibleConnectedPositionStrategy } from '@angular/cdk/overlay';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { patchCdkViewportForSafeArea } from './cdk-safe-area-viewport.util';
+
+const SAFE_BOTTOM = 48;
+const SAFE_TOP = 48;
+const NAV_HEIGHT = 56;
+
+/**
+ * Mirrors the mobile bottom nav (#8792): a bar pinned to the viewport bottom
+ * that reserves the bottom inset as padding, with a menu trigger in its button
+ * row, i.e. a trigger whose bottom edge sits exactly at the top of the
+ * reserved system-bar strip.
+ */
+@Component({
+  selector: 'safe-area-menu-host',
+  imports: [MatMenuModule],
+  template: `
+    <nav
+      [style.position]="'fixed'"
+      [style.left.px]="0"
+      [style.right.px]="0"
+      [style.bottom.px]="0"
+      [style.height.px]="navHeight + safeBottom"
+      [style.padding-bottom.px]="safeBottom"
+      [style.box-sizing]="'border-box'"
+    >
+      <button
+        [style.height.px]="navHeight"
+        [matMenuTriggerFor]="panelsMenu"
+      >
+        panels
+      </button>
+    </nav>
+    <mat-menu #panelsMenu="matMenu">
+      @for (label of itemLabels; track label) {
+        <button mat-menu-item>{{ label }}</button>
+      }
+    </mat-menu>
+  `,
+})
+class SafeAreaMenuHostComponent {
+  safeBottom = SAFE_BOTTOM;
+  navHeight = NAV_HEIGHT;
+  itemLabels = ['Project notes'];
+  trigger = viewChild.required(MatMenuTrigger);
+}
+
+describe('patchCdkViewportForSafeArea', () => {
+  const proto = FlexibleConnectedPositionStrategy.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  let originalMarginTop: unknown;
+  let originalMarginBottom: unknown;
+
+  const openMenuAndMeasure = async (
+    itemLabels?: string[],
+  ): Promise<{
+    panelBottom: number;
+    triggerTop: number;
+    safeAreaTopEdge: number;
+  }> => {
+    const fixture = TestBed.createComponent(SafeAreaMenuHostComponent);
+    if (itemLabels) {
+      fixture.componentInstance.itemLabels = itemLabels;
+    }
+    fixture.detectChanges();
+    const triggerEl = fixture.nativeElement.querySelector('button') as HTMLElement;
+    const triggerTop = triggerEl.getBoundingClientRect().top;
+
+    fixture.componentInstance.trigger().openMenu();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const panel = document.querySelector('.mat-mdc-menu-panel') as HTMLElement;
+    return {
+      panelBottom: panel.getBoundingClientRect().bottom,
+      triggerTop,
+      safeAreaTopEdge: document.documentElement.clientHeight - SAFE_BOTTOM,
+    };
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [provideNoopAnimations()] });
+    originalMarginTop = proto['_getViewportMarginTop'];
+    originalMarginBottom = proto['_getViewportMarginBottom'];
+    patchCdkViewportForSafeArea(document);
+  });
+
+  afterEach(() => {
+    // The patch mutates a shared CDK prototype; leave it as we found it.
+    proto['_getViewportMarginTop'] = originalMarginTop;
+    proto['_getViewportMarginBottom'] = originalMarginBottom;
+    proto['_spSafeAreaPatched'] = false;
+    document.documentElement.style.removeProperty('--safe-area-bottom');
+    document.documentElement.style.removeProperty('--safe-area-top');
+    document.documentElement.style.removeProperty('--safe-area-inset-bottom');
+    document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+  });
+
+  // Android WebView >= 140: Capacitor SystemBars passes the native insets
+  // through instead of injecting the vars, so only env() carries the value.
+  it('keeps a bottom-anchored menu out of the inset when it comes from env() only', async () => {
+    document.documentElement.style.setProperty('--safe-area-bottom', `${SAFE_BOTTOM}px`);
+
+    const { panelBottom, triggerTop, safeAreaTopEdge } = await openMenuAndMeasure();
+
+    expect(panelBottom).toBeLessThanOrEqual(safeAreaTopEdge);
+    // Exactly above the trigger: narrowing CDK's viewport rect instead of its
+    // viewport margins shifts this down by the inset, whatever the geometry.
+    expect(panelBottom).toBeCloseTo(triggerTop, 0);
+  });
+
+  // iOS (and the Android bands that do inject) feed --safe-area-inset-*.
+  it('keeps a bottom-anchored menu out of the inset when it comes from the injected var', async () => {
+    document.documentElement.style.setProperty(
+      '--safe-area-inset-bottom',
+      `${SAFE_BOTTOM}px`,
+    );
+
+    const { panelBottom, triggerTop, safeAreaTopEdge } = await openMenuAndMeasure();
+
+    expect(panelBottom).toBeLessThanOrEqual(safeAreaTopEdge);
+    expect(panelBottom).toBeCloseTo(triggerTop, 0);
+  });
+
+  // The reporter's device (#8792, Android 16): a status bar *and* a navigation
+  // bar, so both insets are non-zero. Both came off `viewport.height`, so the
+  // shipped code understated the bounding box's `bottom` by their sum and
+  // pinned the panel's bottom edge there regardless of how tall the panel was,
+  // which is why enabling a second menu entry did not move it out of the strip.
+  it('places a two-item menu at its trigger, not lower, when both insets are set', async () => {
+    document.documentElement.style.setProperty('--safe-area-top', `${SAFE_TOP}px`);
+    document.documentElement.style.setProperty('--safe-area-bottom', `${SAFE_BOTTOM}px`);
+
+    const twoItems = await openMenuAndMeasure(['Issue provider panel', 'Project notes']);
+    const oneItem = await openMenuAndMeasure(['Project notes']);
+
+    expect(twoItems.panelBottom).toBeLessThanOrEqual(twoItems.safeAreaTopEdge);
+    expect(twoItems.panelBottom).toBeCloseTo(twoItems.triggerTop, 0);
+    // Same bottom edge for both: the placement must not depend on panel height.
+    expect(twoItems.panelBottom).toBeCloseTo(oneItem.panelBottom, 0);
+  });
+
+  it('does not stack insets when applied more than once', async () => {
+    document.documentElement.style.setProperty('--safe-area-bottom', `${SAFE_BOTTOM}px`);
+    patchCdkViewportForSafeArea(document);
+    patchCdkViewportForSafeArea(document);
+
+    const { panelBottom, triggerTop } = await openMenuAndMeasure();
+
+    expect(panelBottom).toBeCloseTo(triggerTop, 0);
+  });
+});

--- a/src/app/core/theme/cdk-safe-area-viewport.util.ts
+++ b/src/app/core/theme/cdk-safe-area-viewport.util.ts
@@ -1,0 +1,76 @@
+import { FlexibleConnectedPositionStrategy } from '@angular/cdk/overlay';
+import { BodyClass } from '../../app.constants';
+
+/**
+ * Resolved inset tokens from `_css-variables.scss`:
+ * `var(--safe-area-inset-*, env(safe-area-inset-*))`.
+ *
+ * Always read these, never the raw `--safe-area-inset-*`: on Android the
+ * effective inset can come from `env()` alone (Capacitor SystemBars passes the
+ * native insets through instead of injecting the vars), in which case reading
+ * the injected var yields 0 (#8792).
+ */
+const CSS_VAR_RESOLVED_SAFE_AREA_TOP = '--safe-area-top';
+const CSS_VAR_RESOLVED_SAFE_AREA_BOTTOM = '--safe-area-bottom';
+const CSS_VAR_KEYBOARD_OVERLAY_OFFSET = '--keyboard-overlay-offset';
+
+const readPx = (doc: Document, name: string): number =>
+  parseInt(getComputedStyle(doc.documentElement).getPropertyValue(name), 10) || 0;
+
+/**
+ * Teach CDK about the native mobile insets, so connected overlays (menus,
+ * selects, autocomplete panels) stay clear of the system bars and of the iOS
+ * keyboard when the WebView does not shrink.
+ *
+ * Hooks the per-side *viewport margin* getters, CDK's own mechanism for
+ * "keep overlays this far from the viewport edge" (`withViewportMargin`), and
+ * not the viewport rect (`_getNarrowedViewportRect`). CDK derives the
+ * container-relative CSS `bottom` of a bottom-anchored bounding box as
+ * `viewport.height - origin.y + marginTop + marginBottom`, i.e. it adds the
+ * margins back to return to full-viewport coordinates. Shrinking the rect
+ * without declaring margins understates that `bottom` by `top + bottom` (both
+ * insets, since both came off `viewport.height`), which pins an
+ * 'above'-anchored panel's bottom edge that far *below* its trigger, i.e. down
+ * into the very strip being reserved (#8792).
+ *
+ * The pin is independent of panel height, so a taller menu grows upward and
+ * overlaps by exactly as much: with a 48px status bar and a 48px navigation
+ * bar, measured on the real app, the panel's bottom sat ~3px above the screen
+ * edge whether the menu had one item or two.
+ *
+ * Declaring margins instead makes the two terms cancel
+ * (`(height - top - bottom) - origin.y + top + bottom`), which is why the
+ * placement is then correct for any inset combination.
+ *
+ * Idempotent: patching twice would add the inset twice.
+ */
+export const patchCdkViewportForSafeArea = (doc: Document): void => {
+  const proto = FlexibleConnectedPositionStrategy.prototype as unknown as {
+    _getViewportMarginTop: () => number;
+    _getViewportMarginBottom: () => number;
+    _spSafeAreaPatched?: boolean;
+  };
+  if (proto._spSafeAreaPatched) {
+    return;
+  }
+  proto._spSafeAreaPatched = true;
+
+  const originalTop = proto._getViewportMarginTop;
+  const originalBottom = proto._getViewportMarginBottom;
+
+  proto._getViewportMarginTop = function (this: unknown): number {
+    return originalTop.call(this) + readPx(doc, CSS_VAR_RESOLVED_SAFE_AREA_TOP);
+  };
+  proto._getViewportMarginBottom = function (this: unknown): number {
+    const keyboardOverlayOffset =
+      doc.body.classList.contains(BodyClass.isIOS) &&
+      doc.body.classList.contains(BodyClass.isKeyboardVisible)
+        ? readPx(doc, CSS_VAR_KEYBOARD_OVERLAY_OFFSET)
+        : 0;
+    return (
+      originalBottom.call(this) +
+      readPx(doc, CSS_VAR_RESOLVED_SAFE_AREA_BOTTOM) +
+      keyboardOverlayOffset
+    );
+  };
+};

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -56,7 +56,7 @@ import { Keyboard, KeyboardInfo } from '@capacitor/keyboard';
 import { PluginListenerHandle, registerPlugin } from '@capacitor/core';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { SafeArea } from 'capacitor-plugin-safe-area';
-import { FlexibleConnectedPositionStrategy } from '@angular/cdk/overlay';
+import { patchCdkViewportForSafeArea } from './cdk-safe-area-viewport.util';
 import { LS } from '../persistence/storage-keys.const';
 import { Log } from '../log';
 import { LayoutService } from '../../core-ui/layout/layout.service';
@@ -980,44 +980,7 @@ export class GlobalThemeService {
       SafeArea.getSafeAreaInsets().then(({ insets }) => applyInsets(insets));
       SafeArea.addListener('safeAreaChanged', ({ insets }) => applyInsets(insets));
     }
-    this._patchCdkViewportForSafeArea();
-  }
-
-  /**
-   * Monkey-patch CDK's viewport rect calculation to include native mobile insets.
-   * This keeps connected overlays (menus, selects, autocomplete panels) above
-   * the safe areas and the iOS keyboard when the WebView does not shrink.
-   */
-  private _patchCdkViewportForSafeArea(): void {
-    const proto = FlexibleConnectedPositionStrategy.prototype as any;
-    const original = proto._getNarrowedViewportRect;
-    const doc = this.document;
-    proto._getNarrowedViewportRect = function (): {
-      top: number;
-      left: number;
-      right: number;
-      bottom: number;
-      width: number;
-      height: number;
-    } {
-      const rect = original.call(this);
-      const style = getComputedStyle(doc.documentElement);
-      const safeTop = parseInt(style.getPropertyValue(CSS_VAR_SAFE_AREA_TOP), 10) || 0;
-      const safeBottom =
-        parseInt(style.getPropertyValue(CSS_VAR_SAFE_AREA_BOTTOM), 10) || 0;
-      const keyboardOverlayOffset =
-        doc.body.classList.contains(BodyClass.isIOS) &&
-        doc.body.classList.contains(BodyClass.isKeyboardVisible)
-          ? parseInt(style.getPropertyValue(CSS_VAR_KEYBOARD_OVERLAY_OFFSET), 10) || 0
-          : 0;
-      const bottomInset = safeBottom + keyboardOverlayOffset;
-      return {
-        ...rect,
-        top: rect.top + safeTop,
-        bottom: rect.bottom - bottomInset,
-        height: rect.height - safeTop - bottomInset,
-      };
-    };
+    patchCdkViewportForSafeArea(this.document);
   }
 
   private _initMobileStatusBar(): void {


### PR DESCRIPTION
Reported on #8792 by @persy (v18.16.0, Android 16, 3-button nav): the bottom-nav panels menu opens *into* the system-bar strip. The `--bottom-nav-safe-area` fix from #8799 is intact, this is a separate defect in the CDK safe-area patch, and it had two independent causes:

1. **It narrowed CDK's viewport rect instead of declaring viewport margins.** CDK derives a bottom-anchored bounding box's container-relative `bottom` as `viewport.height - origin.y + marginTop + marginBottom`, adding the margins back to reach full-viewport coordinates. Shrinking the height without declaring margins understates that `bottom` by **the top and bottom insets summed** (both came off `viewport.height`, and the compensation term stays 0), pinning an 'above'-anchored panel's bottom edge that far below its trigger, inside the reserved strip. The shift comes from `_calculateBoundingBoxRect`, which all `FlexibleConnectedPositionStrategy` consumers share, so it applies to any bottom-anchored connected overlay (menus, selects, autocompletes) on any platform with an inset, **iOS included**.

   The pin is **independent of panel height**: a taller menu grows upward and overlaps by just as much. That is why the reporter's menu looked identical with one and with two entries, and it is what refuted my first reading of their screenshot.

2. **It read the injection-only `--safe-area-inset-*`.** Where the inset comes from `env()` alone (Capacitor SystemBars passes native insets through on WebView >= 140 rather than injecting them), `parseInt('') || 0` yielded 0 and nothing was reserved.

Fix: hook the per-side viewport-margin getters (CDK's own `withViewportMargin` plumbing, so its compensation math applies) and read the resolved `--safe-area-top` / `--safe-area-bottom` tokens. Declaring margins makes the two terms cancel, `(height - top - bottom) - origin.y + top + bottom`, which is why the placement is then correct for any inset combination. Extracted to a util so the product code itself is under test.

**Verification.** Reproduced on the running app (Playwright, native mode faked, both insets injected as SystemBars does on API >= 35) before claiming a cause:

| top inset | bottom inset | shipped code | with this fix |
| --- | --- | --- | --- |
| 24px | 48px | panel bottom 894.5, **28.5px into the strip** | 822.5 = trigger top |
| 32px | 48px | panel bottom 902.5, **36.5px into the strip** | 822.5 = trigger top |
| 40px | 48px | panel bottom 910.5, **44.5px into the strip** | 822.5 = trigger top |

Identical numbers for a one-item and a two-item menu in every row, which is the reporter's signature and matches their screenshots to about a pixel.

Note the earlier sweep in this PR's first revision only varied the *bottom* inset and only used a one-item menu, which put it on the "pushed" side of a knife edge (CDK's push path clamps to `viewport.height` and so fails safe, producing a gap rather than an overlap). That is why it looked clean. The table above is the corrected sweep.

Unit spec: drives a real `MatMenu` from a bottom-pinned trigger in real Chrome and asserts the panel sits exactly at the trigger's top edge, an invariant that catches a shift of any size, unlike a viewport-budget assertion that a small inset slips under. Now includes the reporter's configuration (both insets set, two items) asserting the bottom edge is the same as for one item. Sabotage-checked: restoring the shipped rect-narrowing fails 4/4; reverting to the injected var fails the two env-only cases.

**Not verified on hardware:** no KVM for an emulator and no device attached here. A debug APK was built locally if someone wants to confirm on a real edge-to-edge WebView. Reporter confirmation requested on #8792 for the next release.
