### PR TITLE
fix(test): drop duplicate repeat-cfg keys that break the unit suite

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/create-blocked-blocks-by-day-map.spec.ts
@@ -70,12 +70,6 @@ describe('createBlockedBlocksByDayMap()', () => {
       startDate: occurrenceDay,
       startTime: '23:00',
       defaultEstimate: h(2),
-      // Pin the creation markers: DEFAULT_TASK_REPEAT_CFG seeds them from the REAL
-      // clock at module load, and the exact-day selector drops occurrences on or
-      // before lastTaskCreationDay — unpinned, this spec broke the day the real date
-      // reached its hardcoded 2026-07-30.
-      lastTaskCreation: new Date(2026, 6, 29).getTime(),
-      lastTaskCreationDay: '2026-07-29',
     };
 
     const result = createBlockedBlocksByDayMap(


### PR DESCRIPTION
`master`'s unit suite is red, and has been since #9390 merged: `create-blocked-blocks-by-day-map.spec.ts` declares `lastTaskCreation` / `lastTaskCreationDay` **twice** in the same object literal. `TS1117` aborts the Karma compile (`Found 1 load error`), so the entire `Tests` job fails — on master and on every PR branched from it, regardless of what the PR changes.

How it got there: `ba1e6e5292` ("stop the midnight projection spec depending on today") set both keys to `undefined`; #9390's squash then re-applied an independent pin (`+6` lines to this spec, its only change to it) for the same day-rollover problem. Two fixes, one literal, contradictory comments.

This keeps the `undefined` pair and drops the pinned one:

- it states what the case is actually about — a repeat cfg that has never created a task;
- it hardcodes no date, so it cannot rot the way the original fixture did (that fixture broke the day the wall clock reached its hardcoded `2026-07-30`).

**Verified:** the spec passes 5/5, and all 370 schedule specs pass. Removing the surviving pair as well makes 1/5 fail *today*, so the pin is load-bearing rather than decorative — which is why one of the two pairs had to stay.

Worth merging ahead of other PRs: while `Tests` is red at compile time, no spec in the repo actually runs in CI.
