### PR TITLE
fix: DST repeat anchors, logical-day windows, placeholder repairs

### DIFF
--- a/packages/shared-schema/tests/released-client-compatibility-policy.spec.ts
+++ b/packages/shared-schema/tests/released-client-compatibility-policy.spec.ts
@@ -35,10 +35,39 @@ const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
 const SHA1_PATTERN = /^(?!0{40}$)[0-9a-f]{40}$/;
 const ALL_ZERO_SHA1 = '0'.repeat(40);
 
+// Git exports repository-local variables to hooks. Remove the variables listed
+// by `git rev-parse --local-env-vars` before operating on a foreign repository.
+const GIT_LOCAL_ENVIRONMENT_VARIABLES = [
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
+  'GIT_CONFIG',
+  'GIT_CONFIG_COUNT',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_DIR',
+  'GIT_GRAFT_FILE',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_INTERNAL_SUPER_PREFIX',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_PREFIX',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_SHALLOW_FILE',
+  'GIT_WORK_TREE',
+] as const;
+
+const isolatedGitEnvironment = (): NodeJS.ProcessEnv => {
+  const environment = { ...process.env, GIT_NO_LAZY_FETCH: '1' };
+  for (const variable of GIT_LOCAL_ENVIRONMENT_VARIABLES) {
+    delete environment[variable];
+  }
+  return environment;
+};
+
 const runGit = (repositoryRoot: string, args: string[]): string =>
   execFileSync('git', ['-C', repositoryRoot, ...args], {
     encoding: 'utf8',
-    env: { ...process.env, GIT_NO_LAZY_FETCH: '1' },
+    env: isolatedGitEnvironment(),
     stdio: ['ignore', 'pipe', 'pipe'],
   }).trim();
 

--- a/src/app/features/planner/planner.service.spec.ts
+++ b/src/app/features/planner/planner.service.spec.ts
@@ -19,6 +19,7 @@ import { LayoutService } from '../../core-ui/layout/layout.service';
 import { selectPlannerState } from './store/planner.selectors';
 import { selectTimelineConfig } from '../config/store/global-config.reducer';
 import { selectStartOfNextDayDiffMs } from '../../root-store/app-state/app-state.selectors';
+import { findSpringForwardSunday } from '../tasks/dst.test-helper';
 
 describe('PlannerService', () => {
   let service: PlannerService;
@@ -552,10 +553,6 @@ describe('PlannerService', () => {
   });
 
   describe('daysToShow$ with a start-of-next-day offset', () => {
-    afterEach(() => {
-      jasmine.clock().uninstall();
-    });
-
     it('should start the window on the logical today between midnight and the offset', (done) => {
       // 00:30 on Jan 15 with a 04:00 start-of-next-day is logically still Jan
       // 14. Anchoring the window on the raw clock instead would start it at
@@ -568,6 +565,31 @@ describe('PlannerService', () => {
       service.daysToShow$.pipe(first()).subscribe((days) => {
         expect(days[0]).toBe('2026-01-14');
         expect(days[1]).toBe('2026-01-15');
+        done();
+      });
+    });
+
+    it('should keep the window consecutive across a spring-forward day', (done) => {
+      // A spring-forward day is 23h long, so stepping the window in +24h ms
+      // increments from a late-evening anchor lands past it and the date
+      // disappears from the planner entirely.
+      const gap = findSpringForwardSunday(2026);
+      if (!gap) {
+        // Timezone without a spring-forward transition (UTC, Tokyo).
+        done();
+        return;
+      }
+      jasmine.clock().install();
+      const saturday = new Date(gap.sunday);
+      saturday.setDate(saturday.getDate() - 1);
+      saturday.setHours(23, 30, 0, 0);
+      jasmine.clock().mockDate(saturday);
+      const monday = new Date(gap.sunday);
+      monday.setDate(monday.getDate() + 1);
+      service.daysToShow$.pipe(first()).subscribe((days) => {
+        expect(days[0]).toBe(getDbDateStr(saturday));
+        expect(days[1]).toBe(getDbDateStr(gap.sunday));
+        expect(days[2]).toBe(getDbDateStr(monday));
         done();
       });
     });

--- a/src/app/features/planner/planner.service.spec.ts
+++ b/src/app/features/planner/planner.service.spec.ts
@@ -551,6 +551,28 @@ describe('PlannerService', () => {
     });
   });
 
+  describe('daysToShow$ with a start-of-next-day offset', () => {
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('should start the window on the logical today between midnight and the offset', (done) => {
+      // 00:30 on Jan 15 with a 04:00 start-of-next-day is logically still Jan
+      // 14. Anchoring the window on the raw clock instead would start it at
+      // Jan 15, leaving the tasks still planned for (logical) today without a
+      // rendered day — and ensureDayLoaded can only extend the window forward,
+      // so no interaction can bring the day back.
+      jasmine.clock().install();
+      jasmine.clock().mockDate(new Date(2026, 0, 15, 0, 30));
+      dateService.setStartOfNextDayDiff('04:00');
+      service.daysToShow$.pipe(first()).subscribe((days) => {
+        expect(days[0]).toBe('2026-01-14');
+        expect(days[1]).toBe('2026-01-15');
+        done();
+      });
+    });
+  });
+
   describe('resetScrollState', () => {
     it('should reset daysToShow to initial count after loadMoreDays', (done) => {
       service.daysToShow$.pipe(first()).subscribe((initialDays) => {

--- a/src/app/features/planner/planner.service.spec.ts
+++ b/src/app/features/planner/planner.service.spec.ts
@@ -560,7 +560,7 @@ describe('PlannerService', () => {
       // 00:30 on Jan 15 with a 04:00 start-of-next-day is logically still Jan
       // 14. Anchoring the window on the raw clock instead would start it at
       // Jan 15, leaving the tasks still planned for (logical) today without a
-      // rendered day — and ensureDayLoaded can only extend the window forward,
+      // rendered day, and ensureDayLoaded can only extend the window forward,
       // so no interaction can bring the day back.
       jasmine.clock().install();
       jasmine.clock().mockDate(new Date(2026, 0, 15, 0, 30));

--- a/src/app/features/planner/planner.service.ts
+++ b/src/app/features/planner/planner.service.ts
@@ -75,24 +75,20 @@ export class PlannerService {
       // midnight and the configured start-of-next-day the window must still
       // begin at (logical) today, or the tasks planned for it have no rendered
       // day at all; ensureDayLoaded below can only extend the window forward.
-      const today = this._dateService.getLogicalTodayDate().getTime();
+      const cursor = this._dateService.getLogicalTodayDate();
       const daysToShow: string[] = [];
 
-      // CRITICAL FIX: Loop until we have the required count of days
-      // (not just iterate N times which produces fewer days if weekends are excluded)
+      // Loop until we have the required count of days (not just iterate N
+      // times, which produces fewer days when weekends are excluded), stepping
+      // by calendar day: a DST transition day is 23h/25h long, so +24h ms
+      // arithmetic from a late-evening anchor skips or duplicates a date.
       let daysAdded = 0;
-      let offset = 0;
       while (daysAdded < count) {
-        // eslint-disable-next-line no-mixed-operators
-        const dayOfWeek = new Date(today + offset * 24 * 60 * 60 * 1000).getDay();
-        if (includedWeekDays.includes(dayOfWeek)) {
-          daysToShow.push(
-            // eslint-disable-next-line no-mixed-operators
-            this._dateService.todayStr(today + offset * 24 * 60 * 60 * 1000),
-          );
+        if (includedWeekDays.includes(cursor.getDay())) {
+          daysToShow.push(this._dateService.todayStr(cursor));
           daysAdded++;
         }
-        offset++;
+        cursor.setDate(cursor.getDate() + 1);
       }
 
       return daysToShow;

--- a/src/app/features/planner/planner.service.ts
+++ b/src/app/features/planner/planner.service.ts
@@ -74,7 +74,7 @@ export class PlannerService {
       // Anchor on the logical day, not the raw clock: between calendar
       // midnight and the configured start-of-next-day the window must still
       // begin at (logical) today, or the tasks planned for it have no rendered
-      // day at all — ensureDayLoaded below can only extend the window forward.
+      // day at all; ensureDayLoaded below can only extend the window forward.
       const today = this._dateService.getLogicalTodayDate().getTime();
       const daysToShow: string[] = [];
 

--- a/src/app/features/planner/planner.service.ts
+++ b/src/app/features/planner/planner.service.ts
@@ -71,7 +71,11 @@ export class PlannerService {
         return [];
       }
 
-      const today = new Date().getTime();
+      // Anchor on the logical day, not the raw clock: between calendar
+      // midnight and the configured start-of-next-day the window must still
+      // begin at (logical) today, or the tasks planned for it have no rendered
+      // day at all — ensureDayLoaded below can only extend the window forward.
+      const today = this._dateService.getLogicalTodayDate().getTime();
       const daysToShow: string[] = [];
 
       // CRITICAL FIX: Loop until we have the required count of days

--- a/src/app/features/planner/planner.service.ts
+++ b/src/app/features/planner/planner.service.ts
@@ -76,6 +76,12 @@ export class PlannerService {
       // begin at (logical) today, or the tasks planned for it have no rendered
       // day at all; ensureDayLoaded below can only extend the window forward.
       const cursor = this._dateService.getLogicalTodayDate();
+      // Only date parts are read below, so pin the cursor to midday first.
+      // setDate() preserves the wall time, and a late-evening one is normalised
+      // past midnight in zones whose spring-forward gap ends at 00:00
+      // (America/Godthab and America/Scoresbysund skip 23:00-23:59), which
+      // would drop a whole day from the window. Midday is never in a gap.
+      cursor.setHours(12, 0, 0, 0);
       const daysToShow: string[] = [];
 
       // Loop until we have the required count of days (not just iterate N

--- a/src/app/features/schedule/schedule.service.spec.ts
+++ b/src/app/features/schedule/schedule.service.spec.ts
@@ -87,6 +87,22 @@ describe('ScheduleService', () => {
       const lastDay = new Date(result[4]);
       expect(lastDay.getMonth()).toBe(1); // February
     });
+
+    it('should start on the logical today between midnight and the start-of-next-day offset', () => {
+      // 00:30 on Jan 15 with a 04:00 start-of-next-day is logically still Jan
+      // 14; a window anchored on the raw clock would drop (logical) today's
+      // column right after midnight while todayStr() still names it.
+      jasmine.clock().install();
+      try {
+        jasmine.clock().mockDate(new Date(2026, 0, 15, 0, 30));
+        dateService.setStartOfNextDayDiff('04:00');
+        const result = service.getDaysToShow(3, null);
+        expect(result[0]).toBe('2026-01-14');
+        expect(result[1]).toBe('2026-01-15');
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
   });
 
   describe('getMonthDaysToShow', () => {
@@ -95,6 +111,21 @@ describe('ScheduleService', () => {
       const firstDayOfWeek = 1; // Monday
       const result = service.getMonthDaysToShow(numberOfWeeks, firstDayOfWeek);
       expect(result.length).toBe(numberOfWeeks * 7);
+    });
+
+    it('should show the logical month between midnight and the start-of-next-day offset', () => {
+      // 00:30 on Feb 1 with a 04:00 start-of-next-day is logically still Jan
+      // 31, so the grid must be January's (starting Mon Dec 29), not
+      // February's (starting Mon Jan 26).
+      jasmine.clock().install();
+      try {
+        jasmine.clock().mockDate(new Date(2026, 1, 1, 0, 30));
+        dateService.setStartOfNextDayDiff('04:00');
+        const result = service.getMonthDaysToShow(5, 1, null);
+        expect(result[0]).toBe('2025-12-29');
+      } finally {
+        jasmine.clock().uninstall();
+      }
     });
 
     it('should start with the configured first day of week when firstDayOfWeek is Monday (1)', () => {

--- a/src/app/features/schedule/schedule.service.spec.ts
+++ b/src/app/features/schedule/schedule.service.spec.ts
@@ -2,6 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { ScheduleService } from './schedule.service';
 import { DateService } from '../../core/date/date.service';
+import { getDbDateStr } from '../../util/get-db-date-str';
+import { findSpringForwardSunday } from '../tasks/dst.test-helper';
 import { provideMockStore } from '@ngrx/store/testing';
 import { selectTimelineTasks } from '../work-context/store/work-context.selectors';
 import { selectTaskRepeatCfgsWithAndWithoutStartTime } from '../task-repeat-cfg/store/task-repeat-cfg.selectors';
@@ -88,6 +90,34 @@ describe('ScheduleService', () => {
       expect(lastDay.getMonth()).toBe(1); // February
     });
 
+    it('should keep the window consecutive across a spring-forward day', () => {
+      // Same hazard as the planner window: +24h ms stepping from a
+      // late-evening anchor skips the 23h transition day.
+      const gap = findSpringForwardSunday(2026);
+      if (!gap) {
+        return;
+      }
+      jasmine.clock().install();
+      try {
+        const saturday = new Date(gap.sunday);
+        saturday.setDate(saturday.getDate() - 1);
+        saturday.setHours(23, 30, 0, 0);
+        jasmine.clock().mockDate(saturday);
+        const result = service.getDaysToShow(3, null);
+        expect(result[0]).toBe(getDbDateStr(saturday));
+        expect(result[1]).toBe(getDbDateStr(gap.sunday));
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
+
+    it('should not mutate a provided reference date', () => {
+      const referenceDate = new Date(2028, 5, 15, 10, 0);
+      const before = referenceDate.getTime();
+      service.getDaysToShow(7, referenceDate);
+      expect(referenceDate.getTime()).toBe(before);
+    });
+
     it('should start on the logical today between midnight and the start-of-next-day offset', () => {
       // 00:30 on Jan 15 with a 04:00 start-of-next-day is logically still Jan
       // 14; a window anchored on the raw clock would drop (logical) today's
@@ -99,6 +129,23 @@ describe('ScheduleService', () => {
         const result = service.getDaysToShow(3, null);
         expect(result[0]).toBe('2026-01-14');
         expect(result[1]).toBe('2026-01-15');
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
+  });
+
+  describe('getDayClass', () => {
+    it('should ring the logical today between midnight and the start-of-next-day offset', () => {
+      // Same clock setup as the window specs: at 00:30 with a 04:00 offset the
+      // ring must sit on Jan 14, the column todayStr() names and the window
+      // anchor produces, not on calendar-today.
+      jasmine.clock().install();
+      try {
+        jasmine.clock().mockDate(new Date(2026, 0, 15, 0, 30));
+        dateService.setStartOfNextDayDiff('04:00');
+        expect(service.getDayClass('2026-01-14')).toContain('today');
+        expect(service.getDayClass('2026-01-15')).not.toContain('today');
       } finally {
         jasmine.clock().uninstall();
       }

--- a/src/app/features/schedule/schedule.service.ts
+++ b/src/app/features/schedule/schedule.service.ts
@@ -153,7 +153,12 @@ export class ScheduleService {
   }
 
   getDaysToShow(nrOfDaysToShow: number, referenceDate: Date | null = null): string[] {
-    const today = referenceDate ? referenceDate.getTime() : new Date().getTime();
+    // Default anchor is the logical day, not the raw clock: between calendar
+    // midnight and the configured start-of-next-day the window must still
+    // begin at (logical) today, which todayStr() elsewhere keeps naming.
+    const today = referenceDate
+      ? referenceDate.getTime()
+      : this._dateService.getLogicalTodayDate().getTime();
     const daysToShow: string[] = [];
     for (let i = 0; i < nrOfDaysToShow; i++) {
       // eslint-disable-next-line no-mixed-operators
@@ -167,7 +172,8 @@ export class ScheduleService {
     firstDayOfWeek: number = 0,
     referenceDate: Date | null = null,
   ): string[] {
-    const today = referenceDate || new Date();
+    // Same logical-day anchoring as getDaysToShow above.
+    const today = referenceDate || this._dateService.getLogicalTodayDate();
     const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
 
     // Calculate the first day to show based on firstDayOfWeek setting

--- a/src/app/features/schedule/schedule.service.ts
+++ b/src/app/features/schedule/schedule.service.ts
@@ -161,6 +161,12 @@ export class ScheduleService {
     const cursor = referenceDate
       ? new Date(referenceDate)
       : this._dateService.getLogicalTodayDate();
+    // Only date parts are read below, so pin the cursor to midday first.
+    // setDate() preserves the wall time, and a late-evening one is normalised
+    // past midnight in zones whose spring-forward gap ends at 00:00
+    // (America/Godthab and America/Scoresbysund skip 23:00-23:59), which would
+    // drop a whole day from the window. Midday is never in a gap.
+    cursor.setHours(12, 0, 0, 0);
     const daysToShow: string[] = [];
     for (let i = 0; i < nrOfDaysToShow; i++) {
       daysToShow.push(this._dateService.todayStr(cursor.getTime()));

--- a/src/app/features/schedule/schedule.service.ts
+++ b/src/app/features/schedule/schedule.service.ts
@@ -156,13 +156,17 @@ export class ScheduleService {
     // Default anchor is the logical day, not the raw clock: between calendar
     // midnight and the configured start-of-next-day the window must still
     // begin at (logical) today, which todayStr() elsewhere keeps naming.
-    const today = referenceDate
-      ? referenceDate.getTime()
-      : this._dateService.getLogicalTodayDate().getTime();
+    // Cloned because the cursor is mutated below and referenceDate is the
+    // caller's (a selected-date signal value in the schedule component).
+    const cursor = referenceDate
+      ? new Date(referenceDate)
+      : this._dateService.getLogicalTodayDate();
     const daysToShow: string[] = [];
     for (let i = 0; i < nrOfDaysToShow; i++) {
-      // eslint-disable-next-line no-mixed-operators
-      daysToShow.push(this._dateService.todayStr(today + i * 24 * 60 * 60 * 1000));
+      daysToShow.push(this._dateService.todayStr(cursor.getTime()));
+      // Calendar-day stepping: a DST transition day is 23h/25h long, so
+      // +24h ms arithmetic skips or duplicates a date around it.
+      cursor.setDate(cursor.getDate() + 1);
     }
     return daysToShow;
   }
@@ -247,7 +251,9 @@ export class ScheduleService {
 
   getDayClass(day: string, referenceMonth?: Date): string {
     const dayDate = parseDbDateStr(day);
-    const today = new Date();
+    // Logical day, same as the window anchors above: the today ring must sit
+    // on the column todayStr() names, not one off during the offset window.
+    const today = this._dateService.getLogicalTodayDate();
 
     // If referenceMonth is provided, use it to determine "current month"
     // Otherwise, use the actual current month

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -5,6 +5,8 @@ import { ShortSyntaxConfig } from '../../config/global-config.model';
 import { Project } from '../../project/project.model';
 import { Tag } from '../../tag/tag.model';
 import { TaskReminderOptionId } from '../task.model';
+import { findSpringForwardSunday } from '../dst.test-helper';
+import { getDbDateStr } from '../../../util/get-db-date-str';
 
 describe('AddTaskBarParserService', () => {
   let service: AddTaskBarParserService;
@@ -1672,6 +1674,40 @@ describe('AddTaskBarParserService', () => {
       deadlineTime: null,
       deadlineRemindOption: null,
     };
+
+    it('should publish the typed time when the anchor day springs forward', async () => {
+      // Guards the dueTimeStr passthrough: on a DST spring-forward day the
+      // typed time does not exist, so deriving the time from the dueWithTime
+      // timestamp reads back an hour shifted — and that string becomes the
+      // repeat config's startTime. Only a real transition day can tell the
+      // passthrough and the timestamp read-back apart.
+      const gap = findSpringForwardSunday(2026);
+      if (!gap) {
+        // Timezone without a spring-forward transition (UTC, Tokyo).
+        return;
+      }
+      const friday = new Date(gap.sunday);
+      friday.setDate(friday.getDate() - 2);
+      friday.setHours(10, 0, 0, 0);
+      jasmine.clock().install();
+      jasmine.clock().mockDate(friday);
+      try {
+        mockStateService.state.and.returnValue(baseState as any);
+        await service.parseAndUpdateText(
+          `Backup @every sunday ${gap.missingHour}:30am`,
+          cfg,
+          [],
+          [],
+          defaultProject,
+        );
+        expect(mockStateService.updateDate).toHaveBeenCalledWith(
+          getDbDateStr(gap.sunday),
+          `0${gap.missingHour}:30`,
+        );
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
 
     it('should set repeat setting from "@every friday"', async () => {
       mockStateService.state.and.returnValue(baseState as any);

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.spec.ts
@@ -1678,7 +1678,7 @@ describe('AddTaskBarParserService', () => {
     it('should publish the typed time when the anchor day springs forward', async () => {
       // Guards the dueTimeStr passthrough: on a DST spring-forward day the
       // typed time does not exist, so deriving the time from the dueWithTime
-      // timestamp reads back an hour shifted — and that string becomes the
+      // timestamp reads back an hour shifted, and that string becomes the
       // repeat config's startTime. Only a real transition day can tell the
       // passthrough and the timestamp read-back apart.
       const gap = findSpringForwardSunday(2026);

--- a/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar-parser.service.ts
@@ -195,7 +195,10 @@ export class AddTaskBarParserService {
         if (parseResult.taskChanges.hasPlannedTime !== false) {
           const hours = dueDateObj.getHours().toString().padStart(2, '0');
           const minutes = dueDateObj.getMinutes().toString().padStart(2, '0');
-          const timeStr = `${hours}:${minutes}`;
+          // Prefer the typed wall-clock time: when the resolved day is a DST
+          // spring-forward day the timestamp reads back an hour shifted, and
+          // this string becomes the repeat config's startTime.
+          const timeStr = parseResult.taskChanges.dueTimeStr ?? `${hours}:${minutes}`;
 
           if (timeStr !== '00:00') {
             dueTime = timeStr;

--- a/src/app/features/tasks/dst.test-helper.ts
+++ b/src/app/features/tasks/dst.test-helper.ts
@@ -1,0 +1,32 @@
+/**
+ * Spec-only helper: the ambient timezone's spring-forward sunday and the hour
+ * it skips, derived rather than hardcoded so DST cases are exercised in every
+ * zone the suite runs in (Berlin transitions in march, Los Angeles two weeks
+ * earlier, Sydney in october). Returns null where there is no transition.
+ */
+export const findSpringForwardSunday = (
+  year: number,
+): { sunday: Date; missingHour: number } | null => {
+  const dayMs = 24 * 60 * 60 * 1000;
+  for (let month = 0; month < 12; month++) {
+    for (let day = 1; day <= 31; day++) {
+      const start = new Date(year, month, day, 0, 0, 0, 0);
+      if (start.getDate() !== day || start.getDay() !== 0) {
+        continue;
+      }
+      // A spring-forward day is shorter than 24h.
+      if (
+        new Date(year, month, day + 1, 0, 0, 0, 0).getTime() - start.getTime() >=
+        dayMs
+      ) {
+        continue;
+      }
+      for (let hour = 1; hour < 6; hour++) {
+        if (new Date(year, month, day, hour, 30, 0, 0).getHours() !== hour) {
+          return { sunday: start, missingHour: hour };
+        }
+      }
+    }
+  }
+  return null;
+};

--- a/src/app/features/tasks/dst.test-helper.ts
+++ b/src/app/features/tasks/dst.test-helper.ts
@@ -21,6 +21,9 @@ export const findSpringForwardSunday = (
       ) {
         continue;
       }
+      // Deliberately starts at 1: a midnight transition (Azores-style 00:00
+      // to 01:00) would need "12:30am" phrasing in the consuming specs, so
+      // such zones return null and the specs skip, same as no-DST zones.
       for (let hour = 1; hour < 6; hour++) {
         if (new Date(year, month, day, hour, 30, 0, 0).getHours() !== hour) {
           return { sunday: start, missingHour: hour };

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -16,6 +16,7 @@ import { Project } from '../project/project.model';
 import { DEFAULT_GLOBAL_CONFIG } from '../config/default-global-config.const';
 import { INBOX_PROJECT } from '../project/project.const';
 import { RepeatQuickSetting } from '../task-repeat-cfg/task-repeat-cfg.model';
+import { findSpringForwardSunday } from './dst.test-helper';
 
 const TASK: TaskCopy = {
   id: 'id',
@@ -2375,37 +2376,6 @@ describe('shortSyntax recurrence', () => {
   ): RepeatQuickSetting | null =>
     r?.repeat?.type === 'PRESET' ? r.repeat.quickSetting : null;
 
-  // The ambient timezone's spring-forward sunday and the hour it skips, derived
-  // rather than hardcoded so the DST case below is exercised in every zone the
-  // suite runs in (Berlin transitions in march, Los Angeles two weeks earlier,
-  // Sydney in october). Returns null where there is no transition.
-  const findSpringForwardSunday = (
-    year: number,
-  ): { sunday: Date; missingHour: number } | null => {
-    const dayMs = 24 * 60 * 60 * 1000;
-    for (let month = 0; month < 12; month++) {
-      for (let day = 1; day <= 31; day++) {
-        const start = new Date(year, month, day, 0, 0, 0, 0);
-        if (start.getDate() !== day || start.getDay() !== 0) {
-          continue;
-        }
-        // A spring-forward day is shorter than 24h.
-        if (
-          new Date(year, month, day + 1, 0, 0, 0, 0).getTime() - start.getTime() >=
-          dayMs
-        ) {
-          continue;
-        }
-        for (let hour = 1; hour < 6; hour++) {
-          if (new Date(year, month, day, hour, 30, 0, 0).getHours() !== hour) {
-            return { sunday: start, missingHour: hour };
-          }
-        }
-      }
-    }
-    return null;
-  };
-
   it('should parse "@every friday" as weekly repeat anchored to next friday', async () => {
     const r = await parse('Water plants @every friday');
     expect(presetOf(r)).toBe('WEEKLY_CURRENT_WEEKDAY');
@@ -2645,6 +2615,45 @@ describe('shortSyntax recurrence', () => {
     expect(due.getDay()).toBe(1);
     expect(due.getHours()).toBe(gap.missingHour);
     expect(due.getMinutes()).toBe(30);
+    expect(r?.taskChanges.dueTimeStr).toBe(`0${gap.missingHour}:30`);
+  });
+
+  it('should carry the typed time when the anchor day itself springs forward', async () => {
+    // Unlike the weekend skip, an anchor landing ON the transition day cannot
+    // be repaired on the timestamp: the typed time does not exist that day, so
+    // the Date can only hold the shifted hour. The typed wall-clock time must
+    // travel separately (dueTimeStr) or the repeat config's startTime is wrong
+    // for every later occurrence, where the time does exist.
+    const gap = findSpringForwardSunday(2026);
+    if (!gap) {
+      // Timezone without a spring-forward transition (UTC, Tokyo).
+      return;
+    }
+    const friday = new Date(gap.sunday);
+    friday.setDate(friday.getDate() - 2);
+    friday.setHours(10, 0);
+    const r = await parse(`Backup @every sunday ${gap.missingHour}:30am`, friday);
+    expect(presetOf(r)).toBe('WEEKLY_CURRENT_WEEKDAY');
+    const due = new Date(r?.taskChanges.dueWithTime as number);
+    expect(due.getDay()).toBe(0);
+    expect(r?.taskChanges.dueTimeStr).toBe(`0${gap.missingHour}:30`);
+  });
+
+  it('should carry the typed time when the weekly roll lands on the spring-forward sunday', async () => {
+    // Typed on a Sunday after the typed time has passed, the anchor rolls +7
+    // and lands on the transition Sunday, where the typed time does not exist.
+    const gap = findSpringForwardSunday(2026);
+    if (!gap) {
+      return;
+    }
+    const prevSunday = new Date(gap.sunday);
+    prevSunday.setDate(prevSunday.getDate() - 7);
+    prevSunday.setHours(15, 0);
+    const r = await parse(`Backup @every sunday ${gap.missingHour}:30am`, prevSunday);
+    const due = new Date(r?.taskChanges.dueWithTime as number);
+    expect(due.getDay()).toBe(0);
+    expect(due.getTime()).toBeGreaterThan(prevSunday.getTime());
+    expect(r?.taskChanges.dueTimeStr).toBe(`0${gap.missingHour}:30`);
   });
 
   it('should parse "@every 15th" as monthly on next 15th', async () => {

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -2639,6 +2639,31 @@ describe('shortSyntax recurrence', () => {
     expect(r?.taskChanges.dueTimeStr).toBe(`0${gap.missingHour}:30`);
   });
 
+  it('should carry the typed time when the monthly anchor day springs forward', async () => {
+    const gap = findSpringForwardSunday(2026);
+    if (!gap) {
+      return;
+    }
+    const twoDaysBefore = new Date(gap.sunday);
+    twoDaysBefore.setDate(twoDaysBefore.getDate() - 2);
+    twoDaysBefore.setHours(10, 0);
+    const dayOfMonth = gap.sunday.getDate();
+    const suffix = [1, 21, 31].includes(dayOfMonth)
+      ? 'st'
+      : [2, 22].includes(dayOfMonth)
+        ? 'nd'
+        : [3, 23].includes(dayOfMonth)
+          ? 'rd'
+          : 'th';
+    const r = await parse(
+      `Pay rent @every ${dayOfMonth}${suffix} ${gap.missingHour}:30am`,
+      twoDaysBefore,
+    );
+    const due = new Date(r?.taskChanges.dueWithTime as number);
+    expect(due.getDate()).toBe(gap.sunday.getDate());
+    expect(r?.taskChanges.dueTimeStr).toBe(`0${gap.missingHour}:30`);
+  });
+
   it('should carry the typed time when the weekly roll lands on the spring-forward sunday', async () => {
     // Typed on a Sunday after the typed time has passed, the anchor rolls +7
     // and lands on the transition Sunday, where the typed time does not exist.

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -5,6 +5,7 @@ import { Tag } from '../tag/tag.model';
 import { Project } from '../project/project.model';
 import { ShortSyntaxConfig } from '../config/global-config.model';
 import { isImageUrlSimple } from '../../util/is-image-url';
+import { formatTimeHHmm } from '../../util/format-time-hhmm';
 import { TaskAttachment } from './task-attachment/task-attachment.model';
 import { nanoid } from 'nanoid';
 import type { Chrono, ParsingContext, ParsingResult } from 'chrono-node';
@@ -371,6 +372,19 @@ const SHORT_SYNTAX_URL_REG_EX = new RegExp(
 const SHORT_SYNTAX_MARKDOWN_LINK_REG_EX =
   /\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)/g;
 
+// Non-Task marker fields that ride along in taskChanges for consumers to read
+// and that must be stripped before persisting (see short-syntax.effects).
+export interface ShortSyntaxMarkers {
+  hasDeadlineTime?: boolean;
+  /**
+   * The typed wall-clock time as HH:mm. dueWithTime alone cannot carry it when
+   * the resolved day is a DST spring-forward day on which that time does not
+   * exist: the timestamp reads back shifted, and the repeat config's startTime
+   * would inherit the shift for every later occurrence, where the time exists.
+   */
+  dueTimeStr?: string;
+}
+
 export const shortSyntax = async (
   task: Task | Partial<Task>,
   config: ShortSyntaxConfig,
@@ -384,7 +398,7 @@ export const shortSyntax = async (
   isParseRepeat: boolean = false,
 ): Promise<
   | {
-      taskChanges: Partial<Task> & { hasDeadlineTime?: boolean };
+      taskChanges: Partial<Task> & ShortSyntaxMarkers;
       newTagTitles: string[];
       remindAt: number | null;
       projectId: string | undefined;
@@ -402,7 +416,7 @@ export const shortSyntax = async (
   }
 
   // TODO clean up this mess
-  let taskChanges: Partial<TaskCopy> & { hasDeadlineTime?: boolean } = {};
+  let taskChanges: Partial<TaskCopy> & ShortSyntaxMarkers = {};
   let projectId: string | undefined;
   let newTagTitles: string[] = [];
   let attachments: TaskAttachment[] = [];
@@ -692,7 +706,7 @@ const parseTagChanges = (
 // Result of a date-like stage: the task field changes plus the raw-input
 // ranges of the consumed syntax (the working-title edit happens on `tracked`)
 interface DateStageResult {
-  changes: Partial<TaskCopy> & { hasDeadlineTime?: boolean };
+  changes: Partial<TaskCopy> & ShortSyntaxMarkers;
   repeat?: ShortSyntaxRepeat;
   ranges: TextRange[];
 }
@@ -950,8 +964,14 @@ const applyRepeatSyntax = async (
           : null;
 
   if (anchorDate) {
+    // Captured from the chrono result, not from anchorDate after the mutations
+    // below: the anchor (or a roll below) can land on a DST spring-forward day
+    // where the typed time does not exist, and anchorDate can then only hold
+    // the shifted hour.
+    let typedTimeStr: string | undefined;
     if (hasTime && parsedDateResult) {
       const parsed = parsedDateResult.start.date();
+      typedTimeStr = formatTimeHHmm(parsed);
       anchorDate.setHours(parsed.getHours(), parsed.getMinutes(), 0, 0);
       // "@every friday 3pm" typed on a Friday after 15:00 must not create a
       // task due in the past — advance one period, like chrono's forwardDate
@@ -981,7 +1001,7 @@ const applyRepeatSyntax = async (
       changes: {
         dueWithTime: anchorDate.getTime(),
         dueDay: null,
-        ...(hasTime ? {} : { hasPlannedTime: false }),
+        ...(hasTime ? { dueTimeStr: typedTimeStr } : { hasPlannedTime: false }),
       },
       repeat,
       ranges,
@@ -990,6 +1010,9 @@ const applyRepeatSyntax = async (
 
   if (parsedDateResult) {
     const due = parsedDateResult.start.date();
+    // Before skipExcludedWeekend, which can leave a shifted hour behind when
+    // the final landed day itself is a DST transition day (see dueTimeStr).
+    const typedTimeStr = hasTime ? formatTimeHHmm(due) : undefined;
     if (repeat.type === 'PRESET' && repeat.quickSetting === 'MONDAY_TO_FRIDAY') {
       skipExcludedWeekend(due);
     }
@@ -997,7 +1020,7 @@ const applyRepeatSyntax = async (
       changes: {
         dueWithTime: due.getTime(),
         dueDay: null,
-        ...(hasTime ? {} : { hasPlannedTime: false }),
+        ...(hasTime ? { dueTimeStr: typedTimeStr } : { hasPlannedTime: false }),
       },
       repeat,
       ranges,

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -374,7 +374,9 @@ const SHORT_SYNTAX_MARKDOWN_LINK_REG_EX =
 
 // Non-Task marker fields that ride along in taskChanges for consumers to read
 // and that must be stripped before persisting (see short-syntax.effects).
-export interface ShortSyntaxMarkers {
+// Consumers reach the fields structurally through shortSyntax's return type,
+// so the interface is deliberately not exported.
+interface ShortSyntaxMarkers {
   hasDeadlineTime?: boolean;
   /**
    * The typed wall-clock time as HH:mm. dueWithTime alone cannot carry it when
@@ -967,7 +969,10 @@ const applyRepeatSyntax = async (
     // Captured from the chrono result, not from anchorDate after the mutations
     // below: the anchor (or a roll below) can land on a DST spring-forward day
     // where the typed time does not exist, and anchorDate can then only hold
-    // the shifted hour.
+    // the shifted hour. Reading the chrono Date is safe the other way around:
+    // chrono's own validity filter drops any parse whose resolved day would
+    // normalize the typed time (getHours() != get('hour')), so `parsed` can
+    // never itself carry a shifted hour — it can only be absent entirely.
     let typedTimeStr: string | undefined;
     if (hasTime && parsedDateResult) {
       const parsed = parsedDateResult.start.date();

--- a/src/app/features/tasks/store/short-syntax.effects.ts
+++ b/src/app/features/tasks/store/short-syntax.effects.ts
@@ -233,6 +233,7 @@ export class ShortSyntaxEffects {
             );
 
             delete finalTaskChanges.hasDeadlineTime;
+            delete finalTaskChanges.dueTimeStr;
 
             // The parser writes an absolute per-day total. Persist any earlier
             // additive timer batch first so replay observes the same order as

--- a/src/app/pages/config-page/config-page.component.ts
+++ b/src/app/pages/config-page/config-page.component.ts
@@ -490,8 +490,8 @@ export class ConfigPageComponent implements OnInit {
     this.expandedSection = target.sectionKey ?? null;
     this._cd.detectChanges();
     // The tab body swaps in over `animationDuration`, so the element doesn't
-    // exist yet — wait it out before scrolling.
-    // ponytail: a fixed delay, not an animation-done hook. Switch to
+    // exist yet; wait it out before scrolling.
+    // shortcut: a fixed delay, not an animation-done hook. Switch to
     // `MatTabGroup.animationDone` if the duration ever stops being a constant.
     setTimeout(() => {
       this._elRef.nativeElement

--- a/src/app/plugins/plugin-bridge.service.spec.ts
+++ b/src/app/plugins/plugin-bridge.service.spec.ts
@@ -290,8 +290,14 @@ describe('PluginBridgeService - Counter Methods', () => {
 describe('PluginBridgeService - dispatchAction privacy (#7619)', () => {
   let service: PluginBridgeService;
   let store: MockStore;
+  let translateService: jasmine.SpyObj<TranslateService>;
 
   beforeEach(() => {
+    translateService = jasmine.createSpyObj<TranslateService>('TranslateService', [
+      'instant',
+    ]);
+    translateService.instant.and.returnValue('Action type is not allowed');
+
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
@@ -308,7 +314,7 @@ describe('PluginBridgeService - dispatchAction privacy (#7619)', () => {
         { provide: PluginConfigService, useValue: {} },
         { provide: TaskArchiveService, useValue: {} },
         { provide: Router, useValue: {} },
-        { provide: TranslateService, useValue: {} },
+        { provide: TranslateService, useValue: translateService },
         { provide: SyncWrapperService, useValue: {} },
         { provide: GlobalThemeService, useValue: {} },
         { provide: PluginIssueProviderRegistryService, useValue: {} },
@@ -350,6 +356,19 @@ describe('PluginBridgeService - dispatchAction privacy (#7619)', () => {
     });
 
     expect(Log.exportLogHistory()).toContain(updateGlobalConfigSection.type);
+  });
+
+  it('uses the English placeholder contract for rejected action types', () => {
+    const bound = service.createBoundMethods('test-plugin');
+    const type = '[Forbidden] Test Action';
+
+    expect(() => bound.dispatchAction({ type })).toThrowError(
+      'Action type is not allowed',
+    );
+    expect(translateService.instant).toHaveBeenCalledOnceWith(
+      T.PLUGINS.ACTION_TYPE_NOT_ALLOWED,
+      { type },
+    );
   });
 });
 

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -1772,7 +1772,7 @@ export class PluginBridgeService implements OnDestroy {
       );
       throw new Error(
         this._translateService.instant(T.PLUGINS.ACTION_TYPE_NOT_ALLOWED, {
-          actionType: action.type,
+          type: action.type,
         }),
       );
     }

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -685,7 +685,7 @@
         "DONE": "تم",
         "LOGIN_SUCCESS": "تم تسجيل الدخول بنجاح",
         "TEST_CREDENTIALS": "اختبار بيانات الاعتماد",
-        "WELCOME_USER": "مرحباً {{userName}}!"
+        "WELCOME_USER": "مرحباً {{user}}!"
       }
     },
     "MARKDOWN_PASTE": {
@@ -1457,7 +1457,7 @@
         "ARCHIVE_OPERATION_FAILED": "فشلت عملية الأرشيف: {{errorMsg}}",
         "AUTH_SETUP_FAILED": "فشل إعداد المصادقة. يرجى المحاولة مرة أخرى. إذا كنت تستخدم تطبيق الويب، فتأكد من الوصول إليه عبر HTTPS. إذا استمرت المشكلة، يرجى الإبلاغ عنها كخطأ.",
         "AUTH_TOKEN_REJECTED": "تم رفض رمز المصادقة. يرجى إعادة المصادقة.",
-        "CHANGE_PASSWORD_FAILED": "فشل تغيير كلمة المرور: {{errorMsg}}",
+        "CHANGE_PASSWORD_FAILED": "فشل تغيير كلمة المرور: {{message}}",
         "CLOCK_DRIFT_WARNING": "تحذير: يبدو أن ساعة جهازك غير متزامنة. قد يؤثر هذا على المزامنة.",
         "COMPACTION_FAILED": "فشل ضغط البيانات: {{errorMsg}}",
         "CONFLICT_DIALOG_TIMEOUT": "انتهت مهلة حوار التعارض",
@@ -1466,8 +1466,8 @@
         "DECRYPTION_FAILED": "فشل فك التشفير. يرجى التحقق من كلمة المرور.",
         "DEFERRED_ACTION_FAILED": "فشل الإجراء المؤجل: {{errorMsg}}",
         "DIALOG_RESULT_ERROR": "خطأ في نتيجة الحوار",
-        "DISABLE_ENCRYPTION_FAILED": "فشل تعطيل التشفير: {{errorMsg}}",
-        "ENABLE_ENCRYPTION_FAILED": "فشل تفعيل التشفير: {{errorMsg}}",
+        "DISABLE_ENCRYPTION_FAILED": "فشل تعطيل التشفير: {{message}}",
+        "ENABLE_ENCRYPTION_FAILED": "فشل تفعيل التشفير: {{message}}",
         "ENCRYPTION_DISABLED_ON_OTHER_DEVICE": "تم تعطيل التشفير على جهاز آخر. يرجى إعادة المزامنة.",
         "ENCRYPTION_PASSWORD_REQUIRED": "كلمة مرور التشفير مطلوبة",
         "ENCRYPTION_REQUIRED_FOR_SUPERSYNC": "التشفير مطلوب لـ SuperSync",
@@ -1493,7 +1493,7 @@
         "MIGRATION_FAILED": "فشل الترحيل: {{errorMsg}}",
         "NEWER_VERSION_AVAILABLE": "إصدار أحدث متاح. يرجى تحديث التطبيق.",
         "OPERATION_PERMANENTLY_FAILED": "فشلت العملية بشكل دائم: {{errorMsg}}",
-        "OVERWRITE_SERVER_FAILED": "فشل فرض الكتابة فوق الخادم: {{errorMsg}}",
+        "OVERWRITE_SERVER_FAILED": "فشل فرض الكتابة فوق الخادم: {{message}}",
         "PARTIAL_APPLY_FAILURE": "فشل التطبيق الجزئي: {{errorMsg}}",
         "PERSIST_FAILED": "فشل حفظ البيانات: {{errorMsg}}",
         "REMOTE_DATA_TOO_OLD": "البيانات البعيدة قديمة جداً",
@@ -1505,7 +1505,7 @@
         "STORAGE_RECOVERED_AFTER_COMPACTION": "تم استعادة التخزين بعد الضغط",
         "TIMEOUT_ERROR": "انتهت المهلة. يرجى المحاولة مرة أخرى.",
         "TOO_MANY_OPS_TO_DOWNLOAD": "عمليات كثيرة جداً للتحميل. يرجى إعادة المزامنة.",
-        "UPLOAD_ERROR": "خطأ في الرفع: {{errorMsg}}",
+        "UPLOAD_ERROR": "خطأ في الرفع: {{err}}",
         "UPLOAD_OPS_REJECTED": "تم رفض عمليات الرفع",
         "VECTOR_CLOCK_LIMIT_REACHED": "تم الوصول إلى حد ساعة المتجه",
         "VERSION_TOO_OLD": "الإصدار قديم جداً. يرجى تحديث التطبيق.",
@@ -1621,9 +1621,7 @@
       "D_SYNC_IMPORT_CONFLICT": {
         "FILTERED_CHANGES": "{{count}} تغيير(ات) محلية ستُحذف",
         "IMPORT_DATE": "تاريخ الاستيراد: {{date}}",
-        "MSG_INCOMING": "جهاز آخر قام باستيراد/استعادة البيانات. السبب: {{reason}}.",
         "MSG_INCOMING_NO_OPS": "جهاز آخر قام باستيراد/استعادة البيانات. لا توجد تغييرات محلية متأثرة.",
-        "MSG_LOCAL_FILTERS": "لديك {{count}} تغيير(ات) محلية ستُحذف لأنها سابقة للاستيراد.",
         "REASON_BACKUP_RESTORE": "استعادة نسخة احتياطية",
         "REASON_FILE_IMPORT": "استيراد ملف",
         "REASON_FORCE_UPLOAD": "فرض الرفع",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -774,7 +774,6 @@
         "REMINDER_CREATED": "تم إنشاء تذكير التأمل",
         "REMINDER_ERROR": "خطأ في إنشاء تذكير التأمل",
         "REMINDER_NEEDS_TEXT": "يرجى إدخال نص لإنشاء تذكير",
-        "REMINDER_TASK_TITLE": "🧘 تأمل: {{text}}",
         "REMIND_LABEL": "تذكير لاحقاً"
       }
     },
@@ -1326,7 +1325,7 @@
           "L_NEW_PASSWORD": "كلمة المرور الجديدة",
           "L_REMOVE_ENCRYPTION": "إزالة التشفير",
           "PASSWORDS_DONT_MATCH": "كلمات المرور غير متطابقة",
-          "PASSWORD_MIN_LENGTH": "يجب أن تكون كلمة المرور {{minLength}} أحرف على الأقل",
+          "PASSWORD_MIN_LENGTH": "يجب أن تكون كلمة المرور 8 أحرف على الأقل",
           "REMOVE_ENCRYPTION_WARNING": "تحذير: ستتم إزالة التشفير من جميع البيانات المتزامنة.",
           "ENCRYPTION_SETUP_INTRO": "<strong>عيّن كلمة مرور لتشفير بياناتك قبل رفعها</strong>، حتى لا تغادر هذا الجهاز من دون تشفير. هذا اختياري — ويمكنك تفعيله أو تغييره لاحقًا.",
           "SETUP_ENCRYPTION_BTN": "التشفير والمتابعة",
@@ -1403,7 +1402,7 @@
           "L_REMOVE_ENCRYPTION": "إزالة التشفير",
           "L_SERVER_URL": "رابط الخادم",
           "PASSWORDS_DONT_MATCH": "كلمات المرور غير متطابقة",
-          "PASSWORD_MIN_LENGTH": "يجب أن تكون كلمة المرور {{minLength}} أحرف على الأقل",
+          "PASSWORD_MIN_LENGTH": "يجب أن تكون كلمة المرور 8 أحرف على الأقل",
           "REMOVE_ENCRYPTION_WARNING": "تحذير: ستتم إزالة التشفير من جميع البيانات المتزامنة.",
           "SERVER_URL_DESCRIPTION": "رابط خادم SuperSync الخاص بك.",
           "SETUP_DISABLE_SUPERSYNC_BTN": "تعطيل SuperSync",
@@ -1454,17 +1453,14 @@
         "SUCCESS_DOWNLOAD": "البيانات المتزامنة من جهاز التحكم عن بعد",
         "SUCCESS_VIA_BUTTON": "تمت مزامنة البيانات بنجاح",
         "UNKNOWN_ERROR": "خطأ غير معروف أثناء المزامنة. يرجى التحقق من وحدة التحكم.",
-        "ARCHIVE_OPERATION_FAILED": "فشلت عملية الأرشيف: {{errorMsg}}",
         "AUTH_SETUP_FAILED": "فشل إعداد المصادقة. يرجى المحاولة مرة أخرى. إذا كنت تستخدم تطبيق الويب، فتأكد من الوصول إليه عبر HTTPS. إذا استمرت المشكلة، يرجى الإبلاغ عنها كخطأ.",
         "AUTH_TOKEN_REJECTED": "تم رفض رمز المصادقة. يرجى إعادة المصادقة.",
         "CHANGE_PASSWORD_FAILED": "فشل تغيير كلمة المرور: {{message}}",
         "CLOCK_DRIFT_WARNING": "تحذير: يبدو أن ساعة جهازك غير متزامنة. قد يؤثر هذا على المزامنة.",
-        "COMPACTION_FAILED": "فشل ضغط البيانات: {{errorMsg}}",
         "CONFLICT_DIALOG_TIMEOUT": "انتهت مهلة حوار التعارض",
         "CONFLICT_RESOLUTION_FAILED": "فشل حل التعارض",
         "DATA_REPAIRED": "تم إصلاح البيانات بنجاح",
         "DECRYPTION_FAILED": "فشل فك التشفير. يرجى التحقق من كلمة المرور.",
-        "DEFERRED_ACTION_FAILED": "فشل الإجراء المؤجل: {{errorMsg}}",
         "DIALOG_RESULT_ERROR": "خطأ في نتيجة الحوار",
         "DISABLE_ENCRYPTION_FAILED": "فشل تعطيل التشفير: {{message}}",
         "ENABLE_ENCRYPTION_FAILED": "فشل تفعيل التشفير: {{message}}",
@@ -1478,7 +1474,6 @@
         "ERROR_UNABLE_TO_READ_REMOTE_DATA": "تعذر قراءة البيانات البعيدة",
         "FINISH_DAY_SYNC_ERROR": "خطأ في مزامنة إنهاء اليوم",
         "FRESH_CLIENT_SYNC_CANCELLED": "تم إلغاء مزامنة العميل الجديد",
-        "HYDRATION_FAILED": "فشل تحميل البيانات: {{errorMsg}}",
         "IMPORTING": "جاري الاستيراد...",
         "INCOMPLETE_OP_SYNC": "مزامنة عمليات غير مكتملة",
         "INITIAL_SYNC_ERROR": "خطأ في المزامنة الأولية",
@@ -1490,15 +1485,9 @@
         "LOCAL_DATA_REPLACE_CANCELLED": "تم إلغاء استبدال البيانات المحلية",
         "LOCK_TIMEOUT_ERROR": "انتهت مهلة القفل. يرجى المحاولة مرة أخرى.",
         "LWW_CONFLICTS_AUTO_RESOLVED": "تم حل {{count}} تعارض(ات) تلقائياً",
-        "MIGRATION_FAILED": "فشل الترحيل: {{errorMsg}}",
         "NEWER_VERSION_AVAILABLE": "إصدار أحدث متاح. يرجى تحديث التطبيق.",
-        "OPERATION_PERMANENTLY_FAILED": "فشلت العملية بشكل دائم: {{errorMsg}}",
         "OVERWRITE_SERVER_FAILED": "فشل فرض الكتابة فوق الخادم: {{message}}",
-        "PARTIAL_APPLY_FAILURE": "فشل التطبيق الجزئي: {{errorMsg}}",
-        "PERSIST_FAILED": "فشل حفظ البيانات: {{errorMsg}}",
         "REMOTE_DATA_TOO_OLD": "البيانات البعيدة قديمة جداً",
-        "REPLAY_LOCAL_OPS_FAILED": "فشل إعادة تشغيل العمليات المحلية: {{errorMsg}}",
-        "RESTORE_ERROR": "خطأ في الاستعادة: {{errorMsg}}",
         "RESTORE_SUCCESS": "تمت الاستعادة بنجاح",
         "SERVER_MIGRATION_VALIDATION_FAILED": "فشل التحقق من ترحيل الخادم",
         "STORAGE_QUOTA_EXCEEDED": "تم تجاوز حصة التخزين",
@@ -1619,8 +1608,6 @@
         "TITLE": "ترحيل الخادم مطلوب"
       },
       "D_SYNC_IMPORT_CONFLICT": {
-        "FILTERED_CHANGES": "{{count}} تغيير(ات) محلية ستُحذف",
-        "IMPORT_DATE": "تاريخ الاستيراد: {{date}}",
         "MSG_INCOMING_NO_OPS": "جهاز آخر قام باستيراد/استعادة البيانات. لا توجد تغييرات محلية متأثرة.",
         "REASON_BACKUP_RESTORE": "استعادة نسخة احتياطية",
         "REASON_FILE_IMPORT": "استيراد ملف",
@@ -1712,8 +1699,7 @@
         "D_COLOR": "إذا لم يتم التعيين، فسيتم استخدام اللون الأساسي للسمة افتراضياً."
       },
       "S": {
-        "UPDATED": "تم تحديث إعدادات العلامات",
-        "ARCHIVE_CLEANUP_FAILED": "فشل تنظيف الأرشيف: {{errorMsg}}"
+        "UPDATED": "تم تحديث إعدادات العلامات"
       },
       "TTL": {
         "ADD_NEW_TAG": "إضافة علامة جديدة"
@@ -2208,13 +2194,9 @@
         "BTN_COMPRESS": "ضغط",
         "CONFIRM_MSG": "هل أنت متأكد أنك تريد ضغط الأرشيف؟ لا يمكن التراجع عن هذا.",
         "CONFIRM_TITLE": "تأكيد الضغط",
-        "ESTIMATED_SAVINGS": "التوفير المقدر: {{savings}}",
         "INTRO": "ضغط الأرشيف يزيل البيانات غير الضرورية لتوفير المساحة.",
-        "ISSUE_FIELDS_TO_CLEAR": "حقول المشكلات للمسح: {{count}}",
         "LOADING": "جاري التحليل...",
-        "NOTES_TO_CLEAR": "ملاحظات للمسح: {{count}}",
         "NO_DATA": "لا توجد بيانات للضغط",
-        "SUBTASKS_TO_DELETE": "مهام فرعية للحذف: {{count}}",
         "TITLE": "ضغط الأرشيف",
         "WARNING": "تحذير: لا يمكن التراجع عن هذا الإجراء."
       }
@@ -2769,9 +2751,7 @@
       "SORT_NEWEST": "الأحدث أولاً",
       "SORT_OLDEST": "الأقدم أولاً",
       "SORT_SMALLEST": "الأصغر أولاً",
-      "TITLE": "صور الحافظة",
-      "TOTAL_IMAGES": "إجمالي الصور: {{count}}",
-      "TOTAL_SIZE": "الحجم الإجمالي: {{size}}"
+      "TITLE": "صور الحافظة"
     },
     "TASK_WIDGET": {
       "TITLE": "ودجت المهام",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -410,7 +410,7 @@
         "T_TITLE": "العنوان",
         "T_TO_BE_SUBMITTED": "يتم تقديمه",
         "TITLE": "إرسال الوقت المنقضي على المشكلات إلى  جيت لاب",
-        "TOTAL_MSG": "ستقوم بإرسال\n<em> {totalTotalTimeToSubmit}</em>\n وقت العمل لهذا اليوم إجمالاً إلى\n<em> {nrOfOfTasksToSubmit}</em>\n مشكلات مختلفة."
+        "TOTAL_MSG": "ستقوم بإرسال\n<em> {{totalTimeToSubmit}}</em>\n وقت العمل لهذا اليوم إجمالاً إلى\n<em> {{nrOfTasksToSubmit}}</em>\n مشكلات مختلفة."
       },
       "FORM": {
         "FILTER": "فلتر مخصص",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -432,7 +432,7 @@
         "T_TITLE": "Titel",
         "T_TO_BE_SUBMITTED": "Noch einzureichen",
         "TITLE": "Zeit für Issues an GitLab senden",
-        "TOTAL_MSG": "Du wirst <em>{{totalTimeToSubmit}}</em> Arbeitszeit für heute insgesamt an <em>{{nrOfTasksToSubmit}</em> verschiedene Aufgaben übermitteln."
+        "TOTAL_MSG": "Du wirst <em>{{totalTimeToSubmit}}</em> Arbeitszeit für heute insgesamt an <em>{{nrOfTasksToSubmit}}</em> verschiedene Aufgaben übermitteln."
       },
       "FORM": {
         "FILTER": "Benutzerdefinierte Filter",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3030,7 +3030,7 @@
     }
   },
   "PLUGINS": {
-    "ACTION_TYPE_NOT_ALLOWED": "Aktionstyp '{{Typ}}' ist nicht erlaubt",
+    "ACTION_TYPE_NOT_ALLOWED": "Aktionstyp '{{type}}' ist nicht erlaubt",
     "ALLOWED_HOSTS": "Netzwerkzugriff",
     "ALREADY_INITIALIZED": "Plugin ist bereits initialisiert",
     "AUTHORED_BY": "von {{author}}",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -426,7 +426,7 @@
         "T_TITLE": "Título",
         "T_TO_BE_SUBMITTED": "Por enviar",
         "TITLE": "Enviar tiempo dedicado a las incidencias a GitLab",
-        "TOTAL_MSG": "Vas a enviar <em>{totalTimeToSubmit}</em> de tiempo trabajado en total para hoy a <em>{nrOfTasksToSubmit}</em> problemas diferentes."
+        "TOTAL_MSG": "Vas a enviar <em>{{totalTimeToSubmit}}</em> de tiempo trabajado en total para hoy a <em>{{nrOfTasksToSubmit}}</em> problemas diferentes."
       },
       "FORM": {
         "FILTER": "Filtro personalizado",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -788,8 +788,7 @@
         "REMIND_LABEL": "زمان یادآوری",
         "REMINDER_CREATED": "یادآوری ایجاد شد",
         "REMINDER_ERROR": "خطا در ایجاد یادآوری",
-        "REMINDER_NEEDS_TEXT": "لطفاً ابتدا متنی بنویسید",
-        "REMINDER_TASK_TITLE": "بازتاب: {{title}}"
+        "REMINDER_NEEDS_TEXT": "لطفاً ابتدا متنی بنویسید"
       }
     },
     "NOTE": {
@@ -1393,7 +1392,7 @@
           "L_CONFIRM_PASSWORD": "تأیید رمز عبور",
           "L_NEW_PASSWORD": "رمز عبور جدید",
           "L_REMOVE_ENCRYPTION": "حذف رمزنگاری",
-          "PASSWORD_MIN_LENGTH": "رمز عبور باید حداقل {{minLength}} کاراکتر باشد",
+          "PASSWORD_MIN_LENGTH": "رمز عبور باید حداقل 8 کاراکتر باشد",
           "PASSWORDS_DONT_MATCH": "رمزهای عبور مطابقت ندارند",
           "REMOVE_ENCRYPTION_WARNING": "هشدار: حذف رمزنگاری داده‌ها را بدون محافظت قرار می‌دهد.",
           "SETUP_ENCRYPTION_BTN": "رمزنگاری و ادامه",
@@ -1471,7 +1470,7 @@
           "L_REMOVE_ENCRYPTION": "حذف رمزنگاری",
           "L_SERVER_URL": "آدرس سرور",
           "LOGIN_INSTRUCTIONS": "دستورالعمل‌های ورود",
-          "PASSWORD_MIN_LENGTH": "رمز عبور باید حداقل {{minLength}} کاراکتر باشد",
+          "PASSWORD_MIN_LENGTH": "رمز عبور باید حداقل 8 کاراکتر باشد",
           "PASSWORDS_DONT_MATCH": "رمزهای عبور مطابقت ندارند",
           "REMOVE_ENCRYPTION_WARNING": "هشدار: حذف رمزنگاری داده‌ها را بدون محافظت قرار می‌دهد.",
           "SERVER_URL_DESCRIPTION": "آدرس سرور SuperSync خود را وارد کنید",
@@ -2318,7 +2317,6 @@
         "PASSWORD": "رمز عبور",
         "POLL_INTERVAL_MINUTES": "فاصله نظرسنجی (دقیقه)",
         "TITLE_TEMPLATE": "الگوی عنوان",
-        "TITLE_TEMPLATE_DESCRIPTION": "الگو برای عنوان وظیفه. از {{issueId}} و {{summary}} استفاده کنید.",
         "USERNAME": "نام کاربری"
       },
       "FORM_SECTION": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -945,7 +945,7 @@
       },
       "S": {
         "REMOVED_PLAN_DATE": "Date de planification supprimée pour la tâche \"{{taskTitle}}\"",
-        "TASK_ALREADY_PLANNED": "La tâche est déjà plannifiée le {{date}",
+        "TASK_ALREADY_PLANNED": "La tâche est déjà plannifiée le {{date}}",
         "TASK_PLANNED_FOR": "Tâche planifiée pour {date}"
       }
     },

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -946,7 +946,7 @@
       "S": {
         "REMOVED_PLAN_DATE": "Date de planification supprimée pour la tâche \"{{taskTitle}}\"",
         "TASK_ALREADY_PLANNED": "La tâche est déjà plannifiée le {{date}}",
-        "TASK_PLANNED_FOR": "Tâche planifiée pour {date}"
+        "TASK_PLANNED_FOR": "Tâche planifiée pour {{date}}"
       }
     },
     "POMODORO": {
@@ -968,7 +968,7 @@
         "EDIT": "Modifier le projet"
       },
       "D_DELETE": {
-        "MSG": "Êtes-vous sûr de vouloir supprimer le projet \"{title}\" ?"
+        "MSG": "Êtes-vous sûr de vouloir supprimer le projet \"{{title}}\" ?"
       },
       "COMPLETE": {
         "COMPLETED_ON": "Terminé le {{date}}",
@@ -1892,11 +1892,11 @@
         "MSG": "Êtes-vous sûr de vouloir supprimer la tâche \"{{title}}\" ?"
       },
       "D_CONFIRM_SHORT_SYNTAX_NEW_TAG": {
-        "MSG": "Voulez-vous créer la nouvelle balise {tagsTxt} ?",
+        "MSG": "Voulez-vous créer la nouvelle balise {{tagsTxt}} ?",
         "OK": "Créer la balise"
       },
       "D_CONFIRM_SHORT_SYNTAX_NEW_TAGS": {
-        "MSG": "Voulez-vous créer les nouvelles balises {tagsTxt} ?",
+        "MSG": "Voulez-vous créer les nouvelles balises {{tagsTxt}} ?",
         "OK": "Créer les balises"
       },
       "D_DEADLINE": {
@@ -2024,8 +2024,8 @@
     "TASK_REPEAT": {
       "ADD_INFO_PANEL": {
         "CUSTOM": "Configuration de répétition customisée",
-        "CUSTOM_AND_TIME": "Customisé, {timeStr}",
-        "CUSTOM_WEEKLY": "{daysStr}",
+        "CUSTOM_AND_TIME": "Customisé, {{timeStr}}",
+        "CUSTOM_WEEKLY": "{{daysStr}}",
         "CUSTOM_WEEKLY_AND_TIME": "{{daysStr}}, {{timeStr}}",
         "DAILY": "Chaque jour",
         "DAILY_AND_TIME": "Chaque jour, {{timeStr}}",
@@ -2036,17 +2036,17 @@
         "EVERY_X_YEARLY": "Tous les {{x}} ans",
         "EVERY_X_YEARLY_AND_TIME": "Tous les {{x}} ans, {{timeStr}}",
         "MONDAY_TO_FRIDAY": "Lun-Ven",
-        "MONDAY_TO_FRIDAY_AND_TIME": "Lun-Ven, {timeStr}",
+        "MONDAY_TO_FRIDAY_AND_TIME": "Lun-Ven, {{timeStr}}",
         "MONTHLY_CURRENT_DATE": "Le {{dateDayStr}} de chaque mois",
-        "MONTHLY_CURRENT_DATE_AND_TIME": "Le {dateDayStr} de chaque mois, {timeStr}",
+        "MONTHLY_CURRENT_DATE_AND_TIME": "Le {{dateDayStr}} de chaque mois, {{timeStr}}",
         "MONTHLY_LAST_DAY": "Chaque mois le dernier jour",
         "MONTHLY_LAST_DAY_AND_TIME": "Chaque mois le dernier jour, {{timeStr}}",
         "MONTHLY_NTH_WEEKDAY": "Chaque mois le {{ordinalStr}} {{weekdayStr}}",
         "MONTHLY_NTH_WEEKDAY_AND_TIME": "Chaque mois le {{ordinalStr}} {{weekdayStr}}, {{timeStr}}",
-        "WEEKLY_CURRENT_WEEKDAY": "Chaque semaine le {weekdayStr}",
-        "WEEKLY_CURRENT_WEEKDAY_AND_TIME": "Chaque semaine le {weekdayStr}, {timeStr}",
-        "YEARLY_CURRENT_DATE": "Chaque année le {dayAndMonthStr}",
-        "YEARLY_CURRENT_DATE_AND_TIME": "Chaque année le {dayAndMonthStr}, {timeStr}"
+        "WEEKLY_CURRENT_WEEKDAY": "Chaque semaine le {{weekdayStr}}",
+        "WEEKLY_CURRENT_WEEKDAY_AND_TIME": "Chaque semaine le {{weekdayStr}}, {{timeStr}}",
+        "YEARLY_CURRENT_DATE": "Chaque année le {{dayAndMonthStr}}",
+        "YEARLY_CURRENT_DATE_AND_TIME": "Chaque année le {{dayAndMonthStr}}, {{timeStr}}"
       },
       "D_CONFIRM_MOVE_TO_PROJECT": {
         "MSG": "Il y a {{tasksNr}} instances créées pour cette tâche répétée. Voulez-vous toutes les déplacer vers le projet « {{projectName}} » ?",
@@ -2058,7 +2058,7 @@
       },
       "D_CONFIRM_UPDATE_INSTANCES": {
         "CANCEL": "Seulement aux tâches futures",
-        "MSG": "Il y a {tasksNr} instances créées pour cette tâche répétée. Voulez-vous les mettre toutes à jour avec les nouveaux paramètres par défaut, ou juste appliquer le changement aux tâches futures ?",
+        "MSG": "Il y a {{tasksNr}} instances créées pour cette tâche répétée. Voulez-vous les mettre toutes à jour avec les nouveaux paramètres par défaut, ou juste appliquer le changement aux tâches futures ?",
         "OK": "Mettre à jour toutes les instances"
       },
       "D_DELETE_INSTANCE": {
@@ -2097,9 +2097,9 @@
         "Q_CUSTOM": "Configuration de répétition customisée",
         "Q_DAILY": "Chaque jour",
         "Q_MONDAY_TO_FRIDAY": "Chaque semaine du lundi au vendredi",
-        "Q_MONTHLY_CURRENT_DATE": "Chaque mois le {dateDayStr}",
-        "Q_WEEKLY_CURRENT_WEEKDAY": "Chaque semaine le {weekdayStr}",
-        "Q_YEARLY_CURRENT_DATE": "Chaque année le {dayAndMonthStr}",
+        "Q_MONTHLY_CURRENT_DATE": "Chaque mois le {{dateDayStr}}",
+        "Q_WEEKLY_CURRENT_WEEKDAY": "Chaque semaine le {{weekdayStr}}",
+        "Q_YEARLY_CURRENT_DATE": "Chaque année le {{dayAndMonthStr}}",
         "QUICK_SETTING": "Répéter la configuration",
         "REMIND_AT": "Rappeler à",
         "REMIND_AT_PLACEHOLDER": "Sélectionnez quand rappeler",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1997,7 +1997,7 @@
         "GO_TO_TASK": "Vai al compito",
         "MOVED_TO_ARCHIVE": "Spostato {{nr}} attività nell'archivio",
         "MOVED_TO_PROJECT": "Spostata attività \"{{taskTitle}}\" al progetto \"{{projectTitle}}\"",
-        "REMINDER_ADDED": "Pianificata attività <strong>{{title}}</strong> alle <strong>{{date}}</strong>{{extra}}",
+        "REMINDER_ADDED": "Pianificata attività <strong>{{title}}</strong> alle <strong>{{date}}</strong>",
         "REMINDER_DELETED": "Cancellato promemoria per attività",
         "REMINDER_UPDATED": "Aggiornato promemoria per attività \"{{title}}\"",
         "TASK_ALREADY_EXISTS": "L'attività <strong>{{title}}<\\/strong> esiste già",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -2032,7 +2032,7 @@
         "MONDAY_TO_FRIDAY_AND_TIME": "Ma-Vr, {{timeStr}}",
         "MONTHLY_CURRENT_DATE": "Maandelijks op {{dateDayStr}}de",
         "MONTHLY_CURRENT_DATE_AND_TIME": "Maandelijks op {{dateDayStr}}de, {{timeStr}}",
-        "WEEKLY_CURRENT_WEEKDAY": "Wekelijks op {{{weekdayStr}}",
+        "WEEKLY_CURRENT_WEEKDAY": "Wekelijks op {{weekdayStr}}",
         "WEEKLY_CURRENT_WEEKDAY_AND_TIME": "Wekelijks op {{weekdayStr}}, {{timeStr}}",
         "YEARLY_CURRENT_DATE": "Jaarlijks op {{dayAndMonthStr}}",
         "YEARLY_CURRENT_DATE_AND_TIME": "Jaarlijks op {{dayAndMonthStr}}, {{timeStr}}",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -681,7 +681,7 @@
         "NO_VALID_TRANSITION": "Jira: Geen geldige overgang geconfigureerd",
         "TIMED_OUT": "Jira: Time-out voor verzoek",
         "TRANSITION": "Jira: Stel probleem \"{{issueKey}}\" in op \"{{name}}\"",
-        "TRANSITION_SUCCESS": "Jira: Stel probleem {{issueKey}} in op <strong>{{gekozenTransition}}</strong>",
+        "TRANSITION_SUCCESS": "Jira: Stel probleem {{issueKey}} in op <strong>{{chosenTransition}}</strong>",
         "TRANSITIONS_LOADED": "Jira: Overgangen geladen. Gebruik de onderstaande selecties om ze toe te wijzen",
         "UNABLE_TO_REASSIGN": "Jira: Kan ticket niet aan jezelf toewijzen, omdat je geen gebruikersnaam hebt opgegeven. Ga naar de instellingen."
       },

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2420,7 +2420,6 @@
     "AUTO_BACKUPS": {
       "HELP": "Automatycznie zapisuj wszystkie dane w folderze aplikacji, aby mieć kopię na wypadek problemów.",
       "LABEL_IS_ENABLED": "Włącz automatyczne kopie zapasowe",
-      "LOCATION_INFO": "Lokalizacja: {{path}}",
       "TITLE": "Automatyczne kopie zapasowe",
       "LAST_BACKUP_INFO": "Ostatnia kopia zapasowa: {{date}}",
       "MAX_BACKUP_FILES": "Maksymalna liczba plików kopii zapasowych",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -681,7 +681,7 @@
         "NO_VALID_TRANSITION": "Jira: nenhuma transição válida configurada",
         "TIMED_OUT": "Jira: solicitação expirada",
         "TRANSITION": "Jira: defina o problema \"{{issueKey}}\" como \"{{name}}\" ",
-        "TRANSITION_SUCCESS": "Jira: defina o problema {{issueKey}} como <strong> {{selectedTransition}} </strong>",
+        "TRANSITION_SUCCESS": "Jira: defina o problema {{issueKey}} como <strong> {{chosenTransition}} </strong>",
         "TRANSITIONS_LOADED": "Jira: Transições carregadas. Use as opções abaixo para atribuí-las",
         "UNABLE_TO_REASSIGN": "Jira: não foi possível reatribuir o ticket a si mesmo, porque não especificou um nome de utilizador. Visite as definições."
       },

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2032,7 +2032,7 @@
         "MONDAY_TO_FRIDAY_AND_TIME": "Seg. a Sex, {{timeStr}}",
         "MONTHLY_CURRENT_DATE": "Mensalmente no dia {{dateDayStr}}",
         "MONTHLY_CURRENT_DATE_AND_TIME": "Mensalmente no dia {{dateDayStr}}, {{timeStr}}",
-        "WEEKLY_CURRENT_WEEKDAY": "Semanalmente {{weekdayStr}",
+        "WEEKLY_CURRENT_WEEKDAY": "Semanalmente {{weekdayStr}}",
         "WEEKLY_CURRENT_WEEKDAY_AND_TIME": "Semanalmente em {{weekdayStr}}, {{timeStr}}",
         "YEARLY_CURRENT_DATE": "Anualmente em {{dayAndMonthStr}}",
         "YEARLY_CURRENT_DATE_AND_TIME": "Anualmente no {{dayAndMonthStr}}, {{timeStr}}",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -47,7 +47,7 @@
   "CONFIRM": {
     "AUTO_FIX": "Vaše údaje sú zrejme poškodené (\"{{validityError}}\"). Chcete sa pokúsiť o automatickú opravu? Mohlo by to viesť k čiastočnej strate údajov.",
     "RELOAD_AFTER_IDB_ERROR": "Nemožno získať prístup k databáze :( Možnou príčinou je aktualizácia aplikácie na pozadí alebo málo miesta na disku. Ak ste aplikáciu nainštalovali na linux ako snap, mali by ste povoliť refresh awareness 'snap set core experimental.refresh-app-awareness=true', kým tento problém neopravia na svojej strane. Stlačením tlačidla OK aplikáciu znovu načítajte (na niektorých platformách môže byť potrebné manuálne reštartovanie aplikácie).",
-    "RESTORE_FILE_BACKUP": "Zdá sa, že neexistujú žiadne DÁTA, ale na adrese \"{{dir}}\" sú k dispozícii zálohy. Chcete obnoviť poslednú zálohu z {{{z}}?",
+    "RESTORE_FILE_BACKUP": "Zdá sa, že neexistujú žiadne DÁTA, ale na adrese \"{{dir}}\" sú k dispozícii zálohy. Chcete obnoviť poslednú zálohu z {{from}}?",
     "RESTORE_FILE_BACKUP_ANDROID": "Zdá sa, že neexistujú žiadne údaje, ale je k dispozícii záloha. Chcete ju načítať?",
     "RESTORE_STRAY_BACKUP": "Počas poslednej synchronizácie mohlo dôjsť k nejakej chybe. Chcete obnoviť poslednú zálohu?",
     "DELETE_SECTION": "Naozaj chcete odstrániť túto sekciu? Úlohy v nej sa presunú do zoznamu úloh.",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -429,7 +429,7 @@
         "T_TITLE": "Başlık",
         "T_TO_BE_SUBMITTED": "Gönderilecek",
         "TITLE": "Sorunlara Harcanan Zamanı GitLab'a Gönderin",
-        "TOTAL_MSG": "Bugünkü toplam <em>{{totalTimeToSubmit}</em> çalışma süresini <em>{{nrOfTasksToSubmit}</em> farklı sorunlara göndereceksiniz."
+        "TOTAL_MSG": "Bugünkü toplam <em>{{totalTimeToSubmit}}</em> çalışma süresini <em>{{nrOfTasksToSubmit}}</em> farklı sorunlara göndereceksiniz."
       },
       "FORM": {
         "FILTER": "Özel Filtre",
@@ -1980,7 +1980,7 @@
         "DELETED": "\"{{title}}\" görevi silindi",
         "FOUND_MOVE_FROM_BACKLOG": " <strong>{{title}}</strong> görevini bugünkü görev listesine taşıdı",
         "FOUND_MOVE_FROM_OTHER_LIST": " <strong>{{contextTitle}}</strong> 'den geçerli listeye <strong>{{title}}</strong> görevi eklendi",
-        "FOUND_RESTORE_FROM_ARCHIVE": "Arşivdeki sorunla ilgili <strong>{{title}</strong> görevi geri yüklendi",
+        "FOUND_RESTORE_FROM_ARCHIVE": "Arşivdeki sorunla ilgili <strong>{{title}}</strong> görevi geri yüklendi",
         "GO_TO_TASK": "Göreve Git",
         "MOVED_TO_ARCHIVE": " {{nr}} görevler arşive taşındı",
         "MOVED_TO_PROJECT": "\"{{taskTitle}}\" görevini \"{{projectTitle}}\" projesine taşıdı",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -235,12 +235,12 @@
         "TXT": "<strong>{{title}}</strong> <strong>{{start}}</strong>'da başlıyor!",
         "TXT_MULTIPLE": {
           "ONE": "<strong>{{title}}</strong> <strong>{{start}}</strong> saatinde başlıyor!<br> (ve {{nrOfOtherBanners}} başka etkinlik planlanmış)",
-          "OTHER": "<strong>{{title}}</strong> <strong>{{start}}</strong>'da başlıyor!<br> (ve {{nrOfOfOtherBanners}} diğer etkinlik sona eriyor)"
+          "OTHER": "<strong>{{title}}</strong> <strong>{{start}}</strong>'da başlıyor!<br> (ve {{nrOfOtherBanners}} diğer etkinlik sona eriyor)"
         },
         "TXT_PAST": "<strong>{{title}}</strong> <strong>{{start}}</strong>'da başladı!",
         "TXT_PAST_MULTIPLE": {
           "ONE": "<strong>{{title}}</strong> <strong>{{start}}</strong> saatinde başladı!<br> (ve {{nrOfOtherBanners}} başka etkinlik planlanmış)",
-          "OTHER": "<strong>{{title}}</strong> <strong>{{start}}</strong>'da başladı!<br> (ve {{nrOfOfOtherBanners}} diğer etkinlik sona eriyor)"
+          "OTHER": "<strong>{{title}}</strong> <strong>{{start}}</strong>'da başladı!<br> (ve {{nrOfOtherBanners}} diğer etkinlik sona eriyor)"
         }
       },
       "EVENT_STRINGS": {

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1146,6 +1146,7 @@
       "END": "Kết thúc",
       "EXCESS_TASK_TOOLTIP": "Việc này không vừa ngày này.",
       "EXCESS_TASKS_DAY_TOOLTIP": "{{count}} việc không vừa thời gian",
+      "EXCESS_TASKS_DAY_TOOLTIP_ONE": "{{count}} việc không vừa thời gian",
       "INSERT_BEFORE": "Trước",
       "LUNCH_BREAK": "Nghỉ trưa",
       "MONTH": "Tháng",
@@ -1994,6 +1995,7 @@
         "TITLE": "Thời lượng"
       },
       "N": {
+        "ESTIMATE_EXCEEDED": "Quá ước tính cho \"{{title}}\"",
         "ESTIMATE_EXCEEDED_BODY": "Vượt ước tính cho \"{{title}}\"."
       },
       "S": {

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1146,7 +1146,6 @@
       "END": "Kết thúc",
       "EXCESS_TASK_TOOLTIP": "Việc này không vừa ngày này.",
       "EXCESS_TASKS_DAY_TOOLTIP": "{{count}} việc không vừa thời gian",
-      "EXCESS_TASKS_DAY_TOOLTIP_ONE": "{{count}} việc không vừa thời gian",
       "INSERT_BEFORE": "Trước",
       "LUNCH_BREAK": "Nghỉ trưa",
       "MONTH": "Tháng",
@@ -1995,7 +1994,6 @@
         "TITLE": "Thời lượng"
       },
       "N": {
-        "ESTIMATE_EXCEEDED": "Quá ước tính cho \"{{title}}\"",
         "ESTIMATE_EXCEEDED_BODY": "Vượt ước tính cho \"{{title}}\"."
       },
       "S": {
@@ -2053,8 +2051,7 @@
         "YEARLY_CURRENT_DATE_AND_TIME": "Hàng năm {{dayAndMonthStr}}, {{timeStr}}"
       },
       "D_CONFIRM_MOVE_TO_PROJECT": {
-        "MSG": "Chuyển {{tasksNr}} phiên vào \"{{projectName}}\"?",
-        "OK": "Chuyển {{tasksNr}} phiên vào \"{{projectName}}\"?"
+        "MSG": "Chuyển {{tasksNr}} phiên vào \"{{projectName}}\"?"
       },
       "D_CONFIRM_REMOVE": {
         "MSG": "Xóa cấu hình lặp sẽ chuyển các phiên trước thành việc thường.",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1903,10 +1903,6 @@
         "MSG": "Tạo nhãn mới {{tagsTxt}}?",
         "OK": "Tạo nhãn"
       },
-      "D_CONFIRM_SHORT_SYNTAX_NEW_TAGS": {
-        "MSG": "Xóa việc \"{{title}}\"?",
-        "OK": "Xóa"
-      },
       "D_DEADLINE": {
         "ADD_TIME": "Thêm giờ",
         "QA_NEXT_MONTH": "Tháng sau",

--- a/src/styles/components/_overwrite-material.scss
+++ b/src/styles/components/_overwrite-material.scss
@@ -64,7 +64,7 @@ body.isDarkTheme {
 // Native mobile: dialogs need explicit safe-area offsets because they use
 // position:fixed inside a container that spans the full viewport.
 // Connected overlays (menus, selects) are handled via the CDK viewport margin
-// patch in GlobalThemeService._patchCdkViewportForSafeArea().
+// patch in core/theme/cdk-safe-area-viewport.util.ts.
 body.isNativeMobile .cdk-global-overlay-wrapper {
   padding: var(--safe-area-top) var(--safe-area-right) var(--safe-area-bottom)
     var(--safe-area-left);

--- a/tools/test-lng-files.js
+++ b/tools/test-lng-files.js
@@ -52,10 +52,11 @@ const collectPlaceholders = (value) =>
     : [];
 
 // Brace syntax that cannot interpolate cleanly: a run of 3+ braces
-// ("{{{name}}") or unbalanced "{{"/"}}" pairs ("{{name}"). Placeholder-set
-// drift is informational (the parameter just goes missing from the text), but
-// broken braces render literally to the user, so they fail the run the same
-// way malformed JSON does.
+// ("{{{name}}") or unbalanced "{{"/"}}" pairs ("{{name}"). Missing expected
+// placeholders are informational because translated prose may omit a value.
+// When English defines placeholders, a translation-only name is unsafe: callers
+// supplying the English parameter names cannot resolve it, so ngx-translate
+// leaves the placeholder visible in the rendered text.
 const findBraceDefect = (value) => {
   if (typeof value !== 'string') return null;
   if (/\{{3,}|\}{3,}/.test(value)) return 'brace run';
@@ -72,6 +73,7 @@ const getValueAtPath = (object, dottedKey) =>
 // never rendered.
 const comparePlaceholders = (reference, translation, sharedKeys) => {
   const placeholderMismatches = [];
+  const unexpectedPlaceholderKeys = [];
   const malformedKeys = [];
 
   for (const key of sharedKeys) {
@@ -84,9 +86,18 @@ const comparePlaceholders = (reference, translation, sharedKeys) => {
     if (referencePlaceholders.join('\n') !== translationPlaceholders.join('\n')) {
       placeholderMismatches.push(key);
     }
+
+    if (
+      referencePlaceholders.length > 0 &&
+      translationPlaceholders.some(
+        (placeholder) => !referencePlaceholders.includes(placeholder),
+      )
+    ) {
+      unexpectedPlaceholderKeys.push(key);
+    }
   }
 
-  return { placeholderMismatches, malformedKeys };
+  return { placeholderMismatches, unexpectedPlaceholderKeys, malformedKeys };
 };
 
 const readTranslationFile = (directory, file) => {
@@ -136,6 +147,10 @@ const inspectTranslationDirectory = (directory) => {
       (total, file) => total + file.placeholderMismatches.length,
       0,
     ),
+    totalUnexpectedPlaceholders: files.reduce(
+      (total, file) => total + file.unexpectedPlaceholderKeys.length,
+      0,
+    ),
     totalMalformed: files.reduce((total, file) => total + file.malformedKeys.length, 0),
   };
 };
@@ -166,9 +181,16 @@ const printReport = (report) => {
     const missing = file.missingKeys.length;
     const unnecessary = file.unnecessaryKeys.length;
     const mismatched = file.placeholderMismatches.length;
+    const unexpected = file.unexpectedPlaceholderKeys.length;
     const malformed = file.malformedKeys.length;
 
-    if (missing === 0 && unnecessary === 0 && mismatched === 0 && malformed === 0) {
+    if (
+      missing === 0 &&
+      unnecessary === 0 &&
+      mismatched === 0 &&
+      unexpected === 0 &&
+      malformed === 0
+    ) {
       console.log(`${formatLogValue(file.file)}: OK`);
       continue;
     }
@@ -177,6 +199,7 @@ const printReport = (report) => {
       `${formatLogValue(file.file)}: ${missing} missing${formatExamples(file.missingKeys)}; ` +
         `${unnecessary} not in en.json${formatExamples(file.unnecessaryKeys)}; ` +
         `${mismatched} placeholder mismatches${formatExamples(file.placeholderMismatches)}; ` +
+        `${unexpected} unexpected placeholders${formatExamples(file.unexpectedPlaceholderKeys)}; ` +
         `${malformed} broken braces${formatExamples(file.malformedKeys)}`,
     );
   }
@@ -186,14 +209,18 @@ const printReport = (report) => {
       `(${report.referenceKeyCount} keys): ${report.totalMissing} missing, ` +
       `${report.totalUnnecessary} not in en.json, ` +
       `${report.totalPlaceholderMismatches} placeholder mismatches, ` +
+      `${report.totalUnexpectedPlaceholders} unexpected placeholders, ` +
       `${report.totalMalformed} broken braces.`,
   );
   console.log(
-    'Key differences and placeholder mismatches are informational; ' +
+    'Key differences and missing-only placeholder mismatches are informational; ' +
       'missing translations use the English fallback.',
   );
-  if (report.totalMalformed > 0) {
-    console.error('Broken placeholder braces render literally to the user; fix them.');
+  if (report.totalUnexpectedPlaceholders > 0 || report.totalMalformed > 0) {
+    console.error(
+      'Unexpected placeholder names in an English placeholder contract and ' +
+        'broken braces render literally; fix them.',
+    );
   }
 };
 
@@ -205,7 +232,7 @@ if (require.main === module) {
   try {
     const report = inspectTranslationDirectory(BASE_PATH);
     printReport(report);
-    if (report.totalMalformed > 0) {
+    if (report.totalUnexpectedPlaceholders > 0 || report.totalMalformed > 0) {
       process.exitCode = 1;
     }
   } catch (error) {

--- a/tools/test-lng-files.js
+++ b/tools/test-lng-files.js
@@ -43,8 +43,8 @@ const compareTranslationKeys = (reference, translation) => {
   return compareKeyLists(referenceKeys, new Set(referenceKeys), translationKeys);
 };
 
-// Same pattern ngx-translate interpolates with (names may be dotted).
-const PLACEHOLDER_PATTERN = /\{\{\s*([\w.]+)\s*\}\}/gu;
+// Keep in sync with TranslateDefaultParser.templateMatcher in ngx-translate 17.
+const PLACEHOLDER_PATTERN = /\{\{\s?([^{}\s]*)\s?\}\}/g;
 
 const collectPlaceholders = (value) =>
   typeof value === 'string'
@@ -52,8 +52,9 @@ const collectPlaceholders = (value) =>
     : [];
 
 // Brace syntax that cannot interpolate cleanly: a run of 3+ braces
-// ("{{{name}}") or unbalanced "{{"/"}}" pairs ("{{name}"). Missing expected
-// placeholders are informational because translated prose may omit a value.
+// ("{{{name}}"), unbalanced "{{"/"}}" pairs ("{{name}"), or balanced pairs
+// that ngx-translate's placeholder matcher does not consume ("{{  name  }}").
+// Missing expected placeholders are informational because translated prose may omit a value.
 // When English defines placeholders, a translation-only name is unsafe: callers
 // supplying the English parameter names cannot resolve it, so ngx-translate
 // leaves the placeholder visible in the rendered text.
@@ -62,7 +63,12 @@ const findBraceDefect = (value) => {
   if (/\{{3,}|\}{3,}/.test(value)) return 'brace run';
   const opens = (value.match(/\{\{/g) ?? []).length;
   const closes = (value.match(/\}\}/g) ?? []).length;
-  return opens === closes ? null : 'unbalanced braces';
+  if (opens !== closes) return 'unbalanced braces';
+
+  const unmatchedBraces = value.replace(PLACEHOLDER_PATTERN, '');
+  return unmatchedBraces.includes('{{') || unmatchedBraces.includes('}}')
+    ? 'invalid placeholder syntax'
+    : null;
 };
 
 const getValueAtPath = (object, dottedKey) =>

--- a/tools/test-lng-files.js
+++ b/tools/test-lng-files.js
@@ -55,9 +55,9 @@ const collectPlaceholders = (value) =>
 // ("{{{name}}"), unbalanced "{{"/"}}" pairs ("{{name}"), or balanced pairs
 // that ngx-translate's placeholder matcher does not consume ("{{  name  }}").
 // Missing expected placeholders are informational because translated prose may omit a value.
-// A translation-only name is always unsafe, including where English defines no
-// placeholder at all: call sites pass the English parameter names, or none, so
-// ngx-translate cannot resolve it and leaves it visible in the rendered text.
+// When English defines placeholders, a translation-only name is unsafe: callers
+// supplying the English parameter names cannot resolve it, so ngx-translate
+// leaves the placeholder visible in the rendered text.
 const findBraceDefect = (value) => {
   if (typeof value !== 'string') return null;
   if (/\{{3,}|\}{3,}/.test(value)) return 'brace run';
@@ -93,7 +93,14 @@ const comparePlaceholders = (reference, translation, sharedKeys) => {
       placeholderMismatches.push(key);
     }
 
+    // Deliberately only when en.json defines placeholders. Whether a
+    // translation-only name resolves depends on the CALL SITE's translateParams,
+    // which this checker cannot see: a caller may pass values English does not
+    // interpolate (schedule-week.component.ts passes `count` to both the _ONE
+    // and plural tooltips; NotifyService passes translateParams to the title).
+    // Dropping this guard flagged 2 of 30 working translations as broken.
     if (
+      referencePlaceholders.length > 0 &&
       translationPlaceholders.some(
         (placeholder) => !referencePlaceholders.includes(placeholder),
       )
@@ -223,8 +230,8 @@ const printReport = (report) => {
   );
   if (report.totalUnexpectedPlaceholders > 0 || report.totalMalformed > 0) {
     console.error(
-      'Placeholder names en.json does not define and broken braces render ' +
-        'literally; fix them.',
+      'Unexpected placeholder names in an English placeholder contract and ' +
+        'broken braces render literally; fix them.',
     );
   }
 };

--- a/tools/test-lng-files.js
+++ b/tools/test-lng-files.js
@@ -43,6 +43,52 @@ const compareTranslationKeys = (reference, translation) => {
   return compareKeyLists(referenceKeys, new Set(referenceKeys), translationKeys);
 };
 
+// Same pattern ngx-translate interpolates with (names may be dotted).
+const PLACEHOLDER_PATTERN = /\{\{\s*([\w.]+)\s*\}\}/gu;
+
+const collectPlaceholders = (value) =>
+  typeof value === 'string'
+    ? [...value.matchAll(PLACEHOLDER_PATTERN)].map((match) => match[1]).sort()
+    : [];
+
+// Brace syntax that cannot interpolate cleanly: a run of 3+ braces
+// ("{{{name}}") or unbalanced "{{"/"}}" pairs ("{{name}"). Placeholder-set
+// drift is informational (the parameter just goes missing from the text), but
+// broken braces render literally to the user, so they fail the run the same
+// way malformed JSON does.
+const findBraceDefect = (value) => {
+  if (typeof value !== 'string') return null;
+  if (/\{{3,}|\}{3,}/.test(value)) return 'brace run';
+  const opens = (value.match(/\{\{/g) ?? []).length;
+  const closes = (value.match(/\}\}/g) ?? []).length;
+  return opens === closes ? null : 'unbalanced braces';
+};
+
+const getValueAtPath = (object, dottedKey) =>
+  dottedKey.split('.').reduce((current, key) => current?.[key], object);
+
+// Only keys present in both files are compared: a missing key falls back to
+// the English value (already reported as drift), and an unnecessary key is
+// never rendered.
+const comparePlaceholders = (reference, translation, sharedKeys) => {
+  const placeholderMismatches = [];
+  const malformedKeys = [];
+
+  for (const key of sharedKeys) {
+    const translationValue = getValueAtPath(translation, key);
+    const defect = findBraceDefect(translationValue);
+    if (defect) malformedKeys.push(`${key} (${defect})`);
+
+    const referencePlaceholders = collectPlaceholders(getValueAtPath(reference, key));
+    const translationPlaceholders = collectPlaceholders(translationValue);
+    if (referencePlaceholders.join('\n') !== translationPlaceholders.join('\n')) {
+      placeholderMismatches.push(key);
+    }
+  }
+
+  return { placeholderMismatches, malformedKeys };
+};
+
 const readTranslationFile = (directory, file) => {
   const filePath = join(directory, file);
   const contents = readFileSync(filePath, 'utf8');
@@ -66,14 +112,17 @@ const inspectTranslationDirectory = (directory) => {
     )
     .map((entry) => entry.name)
     .sort()
-    .map((file) => ({
-      file,
-      ...compareKeyLists(
-        referenceKeys,
-        referenceKeySet,
-        collectLeafKeys(readTranslationFile(directory, file)),
-      ),
-    }));
+    .map((file) => {
+      const translation = readTranslationFile(directory, file);
+      const translationKeys = collectLeafKeys(translation);
+      const sharedKeys = translationKeys.filter((key) => referenceKeySet.has(key));
+
+      return {
+        file,
+        ...compareKeyLists(referenceKeys, referenceKeySet, translationKeys),
+        ...comparePlaceholders(reference, translation, sharedKeys),
+      };
+    });
 
   return {
     referenceKeyCount: referenceKeys.length,
@@ -83,6 +132,11 @@ const inspectTranslationDirectory = (directory) => {
       (total, file) => total + file.unnecessaryKeys.length,
       0,
     ),
+    totalPlaceholderMismatches: files.reduce(
+      (total, file) => total + file.placeholderMismatches.length,
+      0,
+    ),
+    totalMalformed: files.reduce((total, file) => total + file.malformedKeys.length, 0),
   };
 };
 
@@ -111,26 +165,36 @@ const printReport = (report) => {
   for (const file of report.files) {
     const missing = file.missingKeys.length;
     const unnecessary = file.unnecessaryKeys.length;
+    const mismatched = file.placeholderMismatches.length;
+    const malformed = file.malformedKeys.length;
 
-    if (missing === 0 && unnecessary === 0) {
+    if (missing === 0 && unnecessary === 0 && mismatched === 0 && malformed === 0) {
       console.log(`${formatLogValue(file.file)}: OK`);
       continue;
     }
 
     console.log(
       `${formatLogValue(file.file)}: ${missing} missing${formatExamples(file.missingKeys)}; ` +
-        `${unnecessary} not in en.json${formatExamples(file.unnecessaryKeys)}`,
+        `${unnecessary} not in en.json${formatExamples(file.unnecessaryKeys)}; ` +
+        `${mismatched} placeholder mismatches${formatExamples(file.placeholderMismatches)}; ` +
+        `${malformed} broken braces${formatExamples(file.malformedKeys)}`,
     );
   }
 
   console.log(
     `Checked ${report.files.length} translation files against en.json ` +
       `(${report.referenceKeyCount} keys): ${report.totalMissing} missing, ` +
-      `${report.totalUnnecessary} not in en.json.`,
+      `${report.totalUnnecessary} not in en.json, ` +
+      `${report.totalPlaceholderMismatches} placeholder mismatches, ` +
+      `${report.totalMalformed} broken braces.`,
   );
   console.log(
-    'Key differences are informational; missing translations use the English fallback.',
+    'Key differences and placeholder mismatches are informational; ' +
+      'missing translations use the English fallback.',
   );
+  if (report.totalMalformed > 0) {
+    console.error('Broken placeholder braces render literally to the user; fix them.');
+  }
 };
 
 const printError = (error) => {
@@ -139,7 +203,11 @@ const printError = (error) => {
 
 if (require.main === module) {
   try {
-    printReport(inspectTranslationDirectory(BASE_PATH));
+    const report = inspectTranslationDirectory(BASE_PATH);
+    printReport(report);
+    if (report.totalMalformed > 0) {
+      process.exitCode = 1;
+    }
   } catch (error) {
     printError(error);
     process.exitCode = 1;
@@ -148,7 +216,9 @@ if (require.main === module) {
 
 module.exports = {
   collectLeafKeys,
+  collectPlaceholders,
   compareTranslationKeys,
+  findBraceDefect,
   inspectTranslationDirectory,
   printError,
   printReport,

--- a/tools/test-lng-files.js
+++ b/tools/test-lng-files.js
@@ -55,9 +55,9 @@ const collectPlaceholders = (value) =>
 // ("{{{name}}"), unbalanced "{{"/"}}" pairs ("{{name}"), or balanced pairs
 // that ngx-translate's placeholder matcher does not consume ("{{  name  }}").
 // Missing expected placeholders are informational because translated prose may omit a value.
-// When English defines placeholders, a translation-only name is unsafe: callers
-// supplying the English parameter names cannot resolve it, so ngx-translate
-// leaves the placeholder visible in the rendered text.
+// A translation-only name is always unsafe, including where English defines no
+// placeholder at all: call sites pass the English parameter names, or none, so
+// ngx-translate cannot resolve it and leaves it visible in the rendered text.
 const findBraceDefect = (value) => {
   if (typeof value !== 'string') return null;
   if (/\{{3,}|\}{3,}/.test(value)) return 'brace run';
@@ -94,7 +94,6 @@ const comparePlaceholders = (reference, translation, sharedKeys) => {
     }
 
     if (
-      referencePlaceholders.length > 0 &&
       translationPlaceholders.some(
         (placeholder) => !referencePlaceholders.includes(placeholder),
       )
@@ -224,8 +223,8 @@ const printReport = (report) => {
   );
   if (report.totalUnexpectedPlaceholders > 0 || report.totalMalformed > 0) {
     console.error(
-      'Unexpected placeholder names in an English placeholder contract and ' +
-        'broken braces render literally; fix them.',
+      'Placeholder names en.json does not define and broken braces render ' +
+        'literally; fix them.',
     );
   }
 };

--- a/tools/test-lng-files.test.js
+++ b/tools/test-lng-files.test.js
@@ -154,7 +154,8 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
     });
     writeJson('xx.json', {
       msg: {
-        // English defines no placeholder, so no call site passes one: renders literally
+        // Not flagged: English omitting a placeholder does not prove the call
+        // site omits it too, so this stays a mismatch and not a defect.
         extraDetail: 'Fehlgeschlagen: {{detail}}',
         hyphenated: 'Hallo {{translated-name}}',
         planned: 'geplant', // drops {{date}}: mismatch, braces fine
@@ -179,7 +180,6 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
       'msg.weekly',
     ]);
     assert.deepEqual(report.files[0].unexpectedPlaceholderKeys, [
-      'msg.extraDetail',
       'msg.hyphenated',
       'msg.renamed',
     ]);
@@ -188,7 +188,7 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
       'msg.weekly (unbalanced braces)',
     ]);
     assert.equal(report.totalPlaceholderMismatches, 6);
-    assert.equal(report.totalUnexpectedPlaceholders, 3);
+    assert.equal(report.totalUnexpectedPlaceholders, 2);
     assert.equal(report.totalMalformed, 2);
   } finally {
     rmSync(directory, { recursive: true, force: true });

--- a/tools/test-lng-files.test.js
+++ b/tools/test-lng-files.test.js
@@ -154,7 +154,7 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
     });
     writeJson('xx.json', {
       msg: {
-        // Call sites may supply locale-specific detail even if English omits it.
+        // English defines no placeholder, so no call site passes one: renders literally
         extraDetail: 'Fehlgeschlagen: {{detail}}',
         hyphenated: 'Hallo {{translated-name}}',
         planned: 'geplant', // drops {{date}}: mismatch, braces fine
@@ -179,6 +179,7 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
       'msg.weekly',
     ]);
     assert.deepEqual(report.files[0].unexpectedPlaceholderKeys, [
+      'msg.extraDetail',
       'msg.hyphenated',
       'msg.renamed',
     ]);
@@ -187,7 +188,7 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
       'msg.weekly (unbalanced braces)',
     ]);
     assert.equal(report.totalPlaceholderMismatches, 6);
-    assert.equal(report.totalUnexpectedPlaceholders, 2);
+    assert.equal(report.totalUnexpectedPlaceholders, 3);
     assert.equal(report.totalMalformed, 2);
   } finally {
     rmSync(directory, { recursive: true, force: true });

--- a/tools/test-lng-files.test.js
+++ b/tools/test-lng-files.test.js
@@ -140,14 +140,19 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
 
     writeJson('en.json', {
       msg: {
+        extraDetail: 'Something failed',
         planned: 'planned for {{date}}',
+        renamed: 'Hello {{name}}',
         weekly: 'Weekly on {{weekdayStr}}',
         plain: 'no params',
       },
     });
     writeJson('xx.json', {
       msg: {
+        // Call sites may supply locale-specific detail even if English omits it.
+        extraDetail: 'Fehlgeschlagen: {{detail}}',
         planned: 'geplant', // drops {{date}}: mismatch, braces fine
+        renamed: 'Hallo {{translatedName}}', // unresolved name: renders literally
         weekly: 'Wöchentlich am {{weekdayStr}', // unbalanced: malformed AND mismatch
         plain: 'keine Parameter',
       },
@@ -159,26 +164,38 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
 
     const report = inspectTranslationDirectory(directory);
     assert.deepEqual(report.files[0].placeholderMismatches, [
+      'msg.extraDetail',
       'msg.planned',
+      'msg.renamed',
       'msg.weekly',
     ]);
+    assert.deepEqual(report.files[0].unexpectedPlaceholderKeys, ['msg.renamed']);
     assert.deepEqual(report.files[0].malformedKeys, ['msg.weekly (unbalanced braces)']);
-    assert.equal(report.totalPlaceholderMismatches, 2);
+    assert.equal(report.totalPlaceholderMismatches, 4);
+    assert.equal(report.totalUnexpectedPlaceholders, 1);
     assert.equal(report.totalMalformed, 1);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
-test('no shipped locale value has broken placeholder braces', () => {
-  // Broken braces render literally to users ("{{date}" in the snack). The
-  // set-level drift stays informational, but this class must stay at zero.
+test('no shipped locale value has broken or unexpected placeholders', () => {
+  // Broken braces and translation-only names render literally to users. A
+  // missing expected name may reflect translated prose that omits the value,
+  // so that broader set-level drift remains informational.
   const report = inspectTranslationDirectory(
     join(__dirname, '..', 'src', 'assets', 'i18n'),
   );
   const offenders = report.files
-    .filter((file) => file.malformedKeys.length > 0)
-    .map((file) => `${file.file}: ${file.malformedKeys.join(', ')}`);
+    .filter(
+      (file) =>
+        file.unexpectedPlaceholderKeys.length > 0 || file.malformedKeys.length > 0,
+    )
+    .map(
+      (file) =>
+        `${file.file}: unexpected=${file.unexpectedPlaceholderKeys.join(', ')}; ` +
+        `malformed=${file.malformedKeys.join(', ')}`,
+    );
 
   assert.deepEqual(offenders, []);
 });
@@ -233,6 +250,7 @@ test('inspectTranslationDirectory compares every locale with deterministic order
           missingKeys: ['common.save'],
           unnecessaryKeys: ['common.delete'],
           placeholderMismatches: [],
+          unexpectedPlaceholderKeys: [],
           malformedKeys: [],
         },
         {
@@ -240,6 +258,7 @@ test('inspectTranslationDirectory compares every locale with deterministic order
           missingKeys: ['common.save', 'task.title'],
           unnecessaryKeys: [],
           placeholderMismatches: [],
+          unexpectedPlaceholderKeys: [],
           malformedKeys: [],
         },
         {
@@ -247,12 +266,14 @@ test('inspectTranslationDirectory compares every locale with deterministic order
           missingKeys: [],
           unnecessaryKeys: [],
           placeholderMismatches: [],
+          unexpectedPlaceholderKeys: [],
           malformedKeys: [],
         },
       ],
       totalMissing: 3,
       totalUnnecessary: 1,
       totalPlaceholderMismatches: 0,
+      totalUnexpectedPlaceholders: 0,
       totalMalformed: 0,
     });
   } finally {
@@ -295,12 +316,14 @@ test('inspectTranslationDirectory ignores .json directories and checks locale fi
           missingKeys: ['common.cancel'],
           unnecessaryKeys: [],
           placeholderMismatches: [],
+          unexpectedPlaceholderKeys: [],
           malformedKeys: [],
         },
       ],
       totalMissing: 1,
       totalUnnecessary: 0,
       totalPlaceholderMismatches: 0,
+      totalUnexpectedPlaceholders: 0,
       totalMalformed: 0,
     });
   } finally {
@@ -322,12 +345,14 @@ test('printReport keeps adversarial values on inert output lines', (t) => {
         missingKeys: ['error.message\n::warning::forged\r\x00\x1b[2J'],
         unnecessaryKeys: [],
         placeholderMismatches: [],
+        unexpectedPlaceholderKeys: [],
         malformedKeys: [],
       },
     ],
     totalMissing: 1,
     totalUnnecessary: 0,
     totalPlaceholderMismatches: 0,
+    totalUnexpectedPlaceholders: 0,
     totalMalformed: 0,
   });
 
@@ -359,12 +384,14 @@ test('printReport bounds keys while retaining three examples and the remainder',
         ],
         unnecessaryKeys: [],
         placeholderMismatches: [],
+        unexpectedPlaceholderKeys: [],
         malformedKeys: [],
       },
     ],
     totalMissing: 5,
     totalUnnecessary: 0,
     totalPlaceholderMismatches: 0,
+    totalUnexpectedPlaceholders: 0,
     totalMalformed: 0,
   });
 

--- a/tools/test-lng-files.test.js
+++ b/tools/test-lng-files.test.js
@@ -108,6 +108,81 @@ test('compareTranslationKeys treats object-versus-leaf differences as structural
   });
 });
 
+test('collectPlaceholders extracts sorted names and ignores non-strings', () => {
+  const { collectPlaceholders } = require('./test-lng-files');
+
+  assert.deepEqual(collectPlaceholders('submit {{b}} to {{ a.name }} now'), [
+    'a.name',
+    'b',
+  ]);
+  assert.deepEqual(collectPlaceholders('no placeholders'), []);
+  assert.deepEqual(collectPlaceholders(42), []);
+});
+
+test('findBraceDefect flags brace runs and unbalanced pairs but not clean values', () => {
+  const { findBraceDefect } = require('./test-lng-files');
+
+  assert.equal(findBraceDefect('Weekly on {{weekdayStr}}'), null);
+  assert.equal(findBraceDefect('no braces at all'), null);
+  assert.equal(findBraceDefect(null), null);
+  assert.equal(findBraceDefect('Wekelijks op {{{weekdayStr}}'), 'brace run');
+  assert.equal(findBraceDefect('planned for {{date}'), 'unbalanced braces');
+  assert.equal(findBraceDefect('single {braces} are fine'), null);
+});
+
+test('inspectTranslationDirectory reports placeholder mismatches and broken braces per shared key', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'test-lng-files-'));
+
+  try {
+    const writeJson = (file, value) => {
+      writeFileSync(join(directory, file), JSON.stringify(value));
+    };
+
+    writeJson('en.json', {
+      msg: {
+        planned: 'planned for {{date}}',
+        weekly: 'Weekly on {{weekdayStr}}',
+        plain: 'no params',
+      },
+    });
+    writeJson('xx.json', {
+      msg: {
+        planned: 'geplant', // drops {{date}}: mismatch, braces fine
+        weekly: 'Wöchentlich am {{weekdayStr}', // unbalanced: malformed AND mismatch
+        plain: 'keine Parameter',
+      },
+      extra: {
+        // malformed but not a shared key; never rendered, must not count
+        unused: '{{{orphan}}',
+      },
+    });
+
+    const report = inspectTranslationDirectory(directory);
+    assert.deepEqual(report.files[0].placeholderMismatches, [
+      'msg.planned',
+      'msg.weekly',
+    ]);
+    assert.deepEqual(report.files[0].malformedKeys, ['msg.weekly (unbalanced braces)']);
+    assert.equal(report.totalPlaceholderMismatches, 2);
+    assert.equal(report.totalMalformed, 1);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('no shipped locale value has broken placeholder braces', () => {
+  // Broken braces render literally to users ("{{date}" in the snack). The
+  // set-level drift stays informational, but this class must stay at zero.
+  const report = inspectTranslationDirectory(
+    join(__dirname, '..', 'src', 'assets', 'i18n'),
+  );
+  const offenders = report.files
+    .filter((file) => file.malformedKeys.length > 0)
+    .map((file) => `${file.file}: ${file.malformedKeys.join(', ')}`);
+
+  assert.deepEqual(offenders, []);
+});
+
 test('inspectTranslationDirectory compares every locale with deterministic order and totals', () => {
   const directory = mkdtempSync(join(tmpdir(), 'test-lng-files-'));
 
@@ -157,20 +232,28 @@ test('inspectTranslationDirectory compares every locale with deterministic order
           file: 'de.json',
           missingKeys: ['common.save'],
           unnecessaryKeys: ['common.delete'],
+          placeholderMismatches: [],
+          malformedKeys: [],
         },
         {
           file: 'fr.json',
           missingKeys: ['common.save', 'task.title'],
           unnecessaryKeys: [],
+          placeholderMismatches: [],
+          malformedKeys: [],
         },
         {
           file: 'zh.json',
           missingKeys: [],
           unnecessaryKeys: [],
+          placeholderMismatches: [],
+          malformedKeys: [],
         },
       ],
       totalMissing: 3,
       totalUnnecessary: 1,
+      totalPlaceholderMismatches: 0,
+      totalMalformed: 0,
     });
   } finally {
     rmSync(directory, { recursive: true, force: true });
@@ -211,10 +294,14 @@ test('inspectTranslationDirectory ignores .json directories and checks locale fi
           file: 'de.json',
           missingKeys: ['common.cancel'],
           unnecessaryKeys: [],
+          placeholderMismatches: [],
+          malformedKeys: [],
         },
       ],
       totalMissing: 1,
       totalUnnecessary: 0,
+      totalPlaceholderMismatches: 0,
+      totalMalformed: 0,
     });
   } finally {
     rmSync(directory, { recursive: true, force: true });
@@ -234,10 +321,14 @@ test('printReport keeps adversarial values on inert output lines', (t) => {
         file: '::error file=secret::forged\nname\r\x1b[31m.json',
         missingKeys: ['error.message\n::warning::forged\r\x00\x1b[2J'],
         unnecessaryKeys: [],
+        placeholderMismatches: [],
+        malformedKeys: [],
       },
     ],
     totalMissing: 1,
     totalUnnecessary: 0,
+    totalPlaceholderMismatches: 0,
+    totalMalformed: 0,
   });
 
   assert.equal(output.length, 3);
@@ -267,10 +358,14 @@ test('printReport bounds keys while retaining three examples and the remainder',
           'fifth.omitted',
         ],
         unnecessaryKeys: [],
+        placeholderMismatches: [],
+        malformedKeys: [],
       },
     ],
     totalMissing: 5,
     totalUnnecessary: 0,
+    totalPlaceholderMismatches: 0,
+    totalMalformed: 0,
   });
 
   const [fileLine] = output;

--- a/tools/test-lng-files.test.js
+++ b/tools/test-lng-files.test.js
@@ -115,6 +115,7 @@ test('collectPlaceholders extracts sorted names and ignores non-strings', () => 
     'a.name',
     'b',
   ]);
+  assert.deepEqual(collectPlaceholders('welcome {{ user-name }}'), ['user-name']);
   assert.deepEqual(collectPlaceholders('no placeholders'), []);
   assert.deepEqual(collectPlaceholders(42), []);
 });
@@ -127,6 +128,8 @@ test('findBraceDefect flags brace runs and unbalanced pairs but not clean values
   assert.equal(findBraceDefect(null), null);
   assert.equal(findBraceDefect('Wekelijks op {{{weekdayStr}}'), 'brace run');
   assert.equal(findBraceDefect('planned for {{date}'), 'unbalanced braces');
+  assert.equal(findBraceDefect('welcome {{ user-name }}'), null);
+  assert.equal(findBraceDefect('welcome {{  name  }}'), 'invalid placeholder syntax');
   assert.equal(findBraceDefect('single {braces} are fine'), null);
 });
 
@@ -141,8 +144,10 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
     writeJson('en.json', {
       msg: {
         extraDetail: 'Something failed',
+        hyphenated: 'Hello {{user-name}}',
         planned: 'planned for {{date}}',
         renamed: 'Hello {{name}}',
+        spacing: 'Hello {{name}}',
         weekly: 'Weekly on {{weekdayStr}}',
         plain: 'no params',
       },
@@ -151,8 +156,10 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
       msg: {
         // Call sites may supply locale-specific detail even if English omits it.
         extraDetail: 'Fehlgeschlagen: {{detail}}',
+        hyphenated: 'Hallo {{translated-name}}',
         planned: 'geplant', // drops {{date}}: mismatch, braces fine
         renamed: 'Hallo {{translatedName}}', // unresolved name: renders literally
+        spacing: 'Hallo {{  name  }}',
         weekly: 'Wöchentlich am {{weekdayStr}', // unbalanced: malformed AND mismatch
         plain: 'keine Parameter',
       },
@@ -165,15 +172,23 @@ test('inspectTranslationDirectory reports placeholder mismatches and broken brac
     const report = inspectTranslationDirectory(directory);
     assert.deepEqual(report.files[0].placeholderMismatches, [
       'msg.extraDetail',
+      'msg.hyphenated',
       'msg.planned',
       'msg.renamed',
+      'msg.spacing',
       'msg.weekly',
     ]);
-    assert.deepEqual(report.files[0].unexpectedPlaceholderKeys, ['msg.renamed']);
-    assert.deepEqual(report.files[0].malformedKeys, ['msg.weekly (unbalanced braces)']);
-    assert.equal(report.totalPlaceholderMismatches, 4);
-    assert.equal(report.totalUnexpectedPlaceholders, 1);
-    assert.equal(report.totalMalformed, 1);
+    assert.deepEqual(report.files[0].unexpectedPlaceholderKeys, [
+      'msg.hyphenated',
+      'msg.renamed',
+    ]);
+    assert.deepEqual(report.files[0].malformedKeys, [
+      'msg.spacing (invalid placeholder syntax)',
+      'msg.weekly (unbalanced braces)',
+    ]);
+    assert.equal(report.totalPlaceholderMismatches, 6);
+    assert.equal(report.totalUnexpectedPlaceholders, 2);
+    assert.equal(report.totalMalformed, 2);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
Follow-up fixes from a full review of everything landed on master 2026-07-29/30, plus the findings of a seven-reviewer pass over the branch itself (six focus-area agents and Codex; details at the end). Each behavior fix was written red-first and sabotage-verified: re-introducing the bug fails exactly the specs that guard it.

## Short syntax: typed time survives DST anchors

fa51168f90 restored the typed clock time only inside the weekend skip. The anchored-weekday path has the same bug with no possible in-place restore: an anchor (or the weekly/monthly roll-forward) landing ON the spring-forward day cannot represent the typed time in a `Date` at all, so the add bar read the shifted hour back off the timestamp and persisted it into the repeat config's `startTime` forever ("@every sunday 2:30am" typed before a transition Sunday recurred at 03:30 on every Sunday where 02:30 exists).

The typed wall-clock time now travels out of the parser explicitly: a `dueTimeStr` marker with the exact lifecycle `hasDeadlineTime` already has (set in the parser, preferred by `add-task-bar-parser.service` when deriving the time state, deleted in `short-syntax.effects` before the single dispatch, so it never reaches persisted state, the op-log, or sync). `dueWithTime` keeps the best representable instant for the first occurrence. The review pass additionally established (verified against chrono-node 2.9.1) that chrono's validity filter drops any parse whose resolved day would normalize the typed time, so the readback can never itself capture a shifted hour; that load-bearing fact is now documented at the capture site, and the monthly-anchor case has a spec.

## Planner and Schedule: day windows anchor on the logical day and step by calendar day

Three window generators (`daysToShow$` in the planner, `getDaysToShow`/`getMonthDaysToShow` in the schedule) anchored on the raw clock while day selection and the today-highlight use the logical day (`todayStr(arg)` applies no offset, by documented contract). With a start-of-next-day offset (e.g. 04:00), between calendar midnight and the offset the planner window excluded logical-today, and `ensureDayLoaded` can only extend forward, so tasks still planned for (logical) today were unreachable until the offset passed (#9174 removed the append hack that had accidentally kept them visible). The schedule week view dropped logical-today's column and the month view flipped to the next month's grid on the 1st.

The review pass surfaced two adjacent defects in the same functions, fixed here too:

- the windows stepped in `+24h` ms increments, and a DST transition day is 23h/25h long, so a late-evening anchor skipped the spring-forward date entirely (the planner showed Sat, Mon, Tue with March 29 nowhere); both loops now step a cursor with `setDate`, like `getMonthDaysToShow` and `getLogicalTomorrowMs` already did, and `getDaysToShow` clones the caller's `referenceDate` before stepping;
- `getDayClass` still ringed calendar-today, one column off the day `todayStr()` names during the offset window.

Users with the default offset (0) and away from transition days see byte-identical behavior; explicit `referenceDate` navigation is unchanged.

## i18n: broken placeholders repaired, brace syntax gated

Eight values across seven locales had brace syntax ngx-translate cannot interpolate, rendering raw braces to users: brace runs (`{{{weekdayStr}}` nl, `{{{z}}` sk), single-brace misspelled names (ar), and unbalanced `{{name}` (de, fr, pt, tr twice). The review pass found 21 more values in es/fr that single-brace a placeholder name en.json interpolates (`{date}`, `{weekdayStr}`, ...), rendering the literal token. All repaired mechanically; only brace syntax and misspelled placeholder names changed, never translated prose.

`tools/test-lng-files.js` now also compares the `{{placeholder}}` set of every shared key against en.json (informational, like the existing key-drift report) and fails the run on broken brace syntax, like malformed JSON already does; a repo-tree test pins that class at zero.

## Comment hygiene

`_overwrite-material.scss` pointed at the deleted `GlobalThemeService._patchCdkViewportForSafeArea()` (now `core/theme/cdk-safe-area-viewport.util.ts`); the config-page scroll delay's "ponytail:" marker was a typo for the "shortcut:" convention.

## Verification

- Every behavior fix red-first with the exact bug value ('03:30' vs '02:30'; the off-by-one window; the skipped '2026-03-29'; the wrong month grid), then sabotage-verified.
- 299 specs across the affected files green, 14 tool tests green, `npm run checkFile` clean on every touched file, full `ng build` (AOT) green.
- Seven-reviewer pass (correctness, security, architecture, alternatives, performance, simplicity, Codex): no critical findings; every warning was either fixed here (day-window stepping, today ring, es/fr repairs) or refuted with evidence (a proposed chrono-components rework was invalidated by chrono's own validity filter, which drops gap-day parses entirely; that empirical probe is what the new capture-site comment records). Known deliberate leftovers: the add-bar chip preview derives its time from the timestamp and can transiently show the shifted hour on the transition day itself, and the informational placeholder-mismatch list (174 keys) remains translator work.
