### PR TITLE
fix(ui): prevent calendar overlap for six-row months

### DIFF
--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -51,11 +51,10 @@
   }
 
   ::ng-deep {
-    // A 6-row month needs ~353px (40px header + ~313px month view); the previous
-    // 400px left ~47px of dead space between the grid and the time input. 360px
-    // fits the tallest month with a small buffer and no clipping.
+    // Reserve enough room for a 6-row month while keeping the dialog height stable
+    // as users navigate between months (#6556, #9397).
     mat-calendar {
-      height: 360px;
+      height: 416px;
     }
 
     .mat-calendar-header {

--- a/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
@@ -52,6 +52,24 @@ describe('DateTimePickerComponent', () => {
     expect(calendarEl).toBeTruthy();
   });
 
+  it('should keep a six-row month above the time controls', () => {
+    fixture.nativeElement.style.width = '400px';
+    fixture.componentRef.setInput('selectedDate', new Date(2026, 7, 4));
+    fixture.detectChanges();
+
+    const weekRows = fixture.nativeElement.querySelectorAll(
+      '.mat-calendar-body > tr',
+    ) as NodeListOf<HTMLElement>;
+    const formControls = fixture.nativeElement.querySelector(
+      '.form-ctrl-wrapper',
+    ) as HTMLElement;
+
+    expect(weekRows.length).toBe(6);
+    expect(weekRows[5].getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      formControls.getBoundingClientRect().top,
+    );
+  });
+
   it('should emit dateSelected when a date is selected on the calendar', () => {
     spyOn(component.dateSelected, 'emit');
     const testDate = new Date();


### PR DESCRIPTION
## Problem

Closes #9397.

Six-row months such as August 2026 overflowed the date-time picker's fixed 360px calendar box and overlapped the time field. The regression was introduced when the calendar height was reduced from 400px and the form's top margin was removed.

## Solution

Reserve 416px for the shared calendar. This accommodates all six date rows at the production 400px picker width while keeping the dialog height stable as users navigate between months, preserving the behavior from #6556.

Add a focused layout regression test that renders August 2026 and verifies the final week ends above the time controls. The shared fix covers both Schedule and Deadline dialogs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (Not applicable: localized layout correction.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Validation

- `npm run test:file src/app/ui/datetime-picker/datetime-picker.component.spec.ts -- --watch=false` — 23/23 passed
- `npm run checkFile` passed for both modified files
- Commit hook repository lint gate completed with zero errors
- Live browser verification: August 2026 rendered with approximately 8px clearance above the time field, stable dialog height between months, and no console warnings or errors
