### PR TITLE
fix(focus-mode): defer task tracking until session starts

### DIFF
--- a/docs/wiki/4.14-How-Time-Is-Logged.md
+++ b/docs/wiki/4.14-How-Time-Is-Logged.md
@@ -64,7 +64,7 @@ Because time spent is updated in real time as the timer runs, the progress value
 
 - [[4.21-Worklog]] — How “time spent per day” is turned into the date-organized History view
 - [[4.20-Task-Archiving]] — How completed tasks and their time move into the archive (recent and old tiers)
-- [[4.15-Timers-and-Focus-Mode]] — How Focus Mode timers sync with task tracking (when enabled)
+- [[4.15-Timers-and-Focus-Mode]] — How Focus Mode timers sync with task tracking
 - [[4.08-Time-Estimates]] — How estimates and the comparison with actual time support planning and review
 - [[4.09-Task-Attributes]] — How time spent and time-per-day fit into the task model
 - [[3.02-Settings-and-Preferences]] — Idle handling, reminders, and time-tracking options

--- a/docs/wiki/4.15-Timers-and-Focus-Mode.md
+++ b/docs/wiki/4.15-Timers-and-Focus-Mode.md
@@ -4,7 +4,7 @@ Focus Mode in Super Productivity addresses a central challenge of task-based wor
 
 You can enter Focus Mode from the focus button in the main header on both desktop and mobile layouts. The keyboard shortcut is listed in [[3.03-Keyboard-Shortcuts]].
 
-For how time is logged when you track a task, see [[4.14-How-Time-Is-Logged]]. Focus Mode settings (sync with task tracking, tick sound, preparation screen, breaks, etc.) are in [[3.02-Settings-and-Preferences]].
+For how time is logged when you track a task, see [[4.14-How-Time-Is-Logged]]. Focus Mode settings (automatic start from task tracking, tick sound, preparation screen, breaks, etc.) are in [[3.02-Settings-and-Preferences]].
 
 ## What Problem Does Focus Mode Solve?
 
@@ -13,7 +13,7 @@ Productivity loss from **distractions and context switching** is something the a
 - **Structured work sessions** — A timer and clear “work” vs “break” phases so you can commit to a block of time instead of working in an unstructured way.
 - **Timeboxing** — Fixed or flexible time boxes so you can plan how long you work and when you rest.
 - **Awareness** — Optional tick sounds and session-completion notifications so you stay present and know when a block has ended.
-- **Integration with task tracking** — When enabled, focus sessions can start and pause in sync with the task you’re tracking, so “focus time” and “task time” stay aligned.
+- **Integration with task tracking** — Focus sessions start and pause in sync with the task you’re tracking, so “focus time” and “task time” stay aligned.
 
 The app’s **metrics** also reflect this. They can classify your day into states that include an ideal **deep-flow** state (high productivity and high sustainability) and a **drift** state (low productivity and low sustainability—often indicating attention or focus problems). That encourages you to reflect not only on _how much_ you worked but on _how_ you worked: sustained focus vs fragmented attention.
 
@@ -102,10 +102,10 @@ That multi-channel feedback makes it clear when to switch from work to break or 
 
 ### Deep Integration with Task Tracking
 
-When **“sync session with task tracking”** is enabled, Focus Mode and time tracking work together in **both directions**:
+Focus Mode and time tracking work together in **both directions**. Before a session starts, choosing a task in the Focus Mode overlay only prepares that task for the session; it does not begin logging task time. Pressing **Start** activates the selected task and the Focus timer together. Closing the overlay before pressing Start leaves any existing task tracking unchanged.
 
-- **Task tracking → Focus** — When you **start** tracking a task, the app can start or resume a focus session (if you’re on the main focus screen and no session is active, or if a work session was paused). When you’re on a break and you start tracking a task, the app can skip the break and start work so the session aligns with the task.
-- **Focus → Task tracking** — Focus sessions run while you have an active task; when you pause the session (e.g. for a break), the app can pause task tracking too, so time isn’t logged during the break. When you resume, both resume.
+- **Task tracking → Focus** — When you **start** tracking a task, the app resumes a paused focus session. If **Start a focus session when I start tracking a task** is enabled, tracking a task can also start a new focus session. When you’re on a break and you start tracking a task, the app can skip the break and start work so the session aligns with the task.
+- **Focus → Task tracking** — Starting a Focus session starts tracking its selected task. When you pause the session (e.g. for a break), the app can pause task tracking too, so time isn’t logged during the break. When you resume, both resume.
 
 That creates a **bidirectional link**: starting or pausing the task affects the focus session, and starting or ending a focus session (or break) can affect what’s being tracked. The result is that “focus time” and “logged task time” stay in sync when you want them to.
 
@@ -127,7 +127,7 @@ Each mode (**Pomodoro**, **Flowtime**, **Countdown**) has **defined behavior**: 
 
 ### Configuration and Integration
 
-Focus Mode has **multiple dedicated settings** (e.g. sync with task tracking, show preparation screen, play tick sound, pause task tracking during break, enable Pomodoro overtime). Those options show that focus is meant to be **configurable** to your workflow. The feature is also **woven into the app**: session lifecycle (start, tick, complete), break handling, task-tracking sync, and metrics all depend on focus state. So focus is **central to the workflow**, not a side panel you can ignore.
+Focus Mode has **multiple dedicated settings** (e.g. automatically start Focus when task tracking begins, show the preparation screen, play ambient sound, pause task tracking during breaks, and enable Pomodoro overtime). Those options show that focus is meant to be **configurable** to your workflow. The feature is also **woven into the app**: session lifecycle (start, tick, complete), break handling, task-tracking sync, and metrics all depend on focus state. So focus is **central to the workflow**, not a side panel you can ignore.
 
 ### Sustainable Productivity as a Goal
 
@@ -145,7 +145,7 @@ The 4-hour optimal focus target and the penalty for excessive focus reinforce th
 - **Three modes**: **Pomodoro** (fixed work/break/cycles), **Flowtime** (open-ended, no auto-completion), **Countdown** (custom duration per session).
 - **Session completion**: For Pomodoro and Countdown, a work session completes when elapsed ≥ duration and the timer stops; **Flowtime never auto-completes**.
 - **Focus balance**: Metrics assume an **optimal focus target** (e.g. 4 h/day) and **penalize excessive focus** to support sustainability.
-- **Behavior**: Tick sounds, session-done notifications, and **sync with task tracking** (when enabled) tie focus to how you actually work.
+- **Behavior**: Ambient sounds, session-done notifications, and synchronized task tracking tie focus to how you actually work; automatically starting Focus from task tracking is optional.
 - **Quality**: Productivity score weights **impact** more than **focus time**, so you’re encouraged to reflect on value, not only on time.
 
 ## Related

--- a/docs/wiki/4.15-Timers-and-Focus-Mode.md
+++ b/docs/wiki/4.15-Timers-and-Focus-Mode.md
@@ -102,12 +102,14 @@ That multi-channel feedback makes it clear when to switch from work to break or 
 
 ### Deep Integration with Task Tracking
 
-Focus Mode and time tracking work together in **both directions**. Before a session starts, choosing a task in the Focus Mode overlay only prepares that task for the session; it does not begin logging task time. Pressing **Start** activates the selected task and the Focus timer together. Closing the overlay before pressing Start leaves any existing task tracking unchanged.
+Focus Mode and time tracking work together in **both directions**:
 
 - **Task tracking → Focus** — When you **start** tracking a task, the app resumes a paused focus session. If **Start a focus session when I start tracking a task** is enabled, tracking a task can also start a new focus session. When you’re on a break and you start tracking a task, the app can skip the break and start work so the session aligns with the task.
 - **Focus → Task tracking** — Starting a Focus session starts tracking its selected task. When you pause the session (e.g. for a break), the app can pause task tracking too, so time isn’t logged during the break. When you resume, both resume.
 
-That creates a **bidirectional link**: starting or pausing the task affects the focus session, and starting or ending a focus session (or break) can affect what’s being tracked. The result is that “focus time” and “logged task time” stay in sync when you want them to.
+Before a session starts, choosing a task in the Focus Mode overlay only prepares that task for the session; it does not begin logging task time. Pressing **Start** activates the selected task and the Focus timer together. Closing the overlay before pressing Start leaves any existing task tracking unchanged.
+
+That creates a **bidirectional link**: starting or pausing the task affects the focus session, and starting or ending a focus session (or break) can affect what’s being tracked. The result is that “focus time” and “logged task time” stay in sync.
 
 ### Quality Metrics and the Role of Focus
 

--- a/src/app/features/android/store/android-focus-mode.effects.spec.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.spec.ts
@@ -109,6 +109,42 @@ describe('hasFocusNotificationStateChanged (notification reconciliation, #7856)'
   });
 });
 
+describe('hasFocusNotificationStateChanged (task reconciliation, #9399)', () => {
+  it('pushes immediately when the current task changes without a timer change', () => {
+    const timer = workTimer(0);
+
+    expect(
+      hasFocusNotificationStateChanged(
+        timer,
+        timer,
+        { id: 'task-a', title: 'Task A' },
+        { id: 'task-b', title: 'Task B' },
+      ),
+    ).toBe(true);
+  });
+
+  it('pushes immediately when the current task title changes', () => {
+    const timer = workTimer(0);
+
+    expect(
+      hasFocusNotificationStateChanged(
+        timer,
+        timer,
+        { id: 'task-a', title: 'Old title' },
+        { id: 'task-a', title: 'New title' },
+      ),
+    ).toBe(true);
+  });
+
+  it('still throttles a normal tick when the current task is unchanged', () => {
+    const task = { id: 'task-a', title: 'Task A' };
+
+    expect(
+      hasFocusNotificationStateChanged(workTimer(60_000), workTimer(61_000), task, task),
+    ).toBe(false);
+  });
+});
+
 // handleNativeTimerComplete$ acts on a native completion only while the matching
 // session is still active. The work-session guard is what prevents a double
 // completion when a resume tick (#7856) already finished the session before the

--- a/src/app/features/android/store/android-focus-mode.effects.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.ts
@@ -24,6 +24,9 @@ import { DroidLog } from '../../../core/log';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
+import { Task } from '../../tasks/task.model';
+
+type FocusNotificationTask = Pick<Task, 'id' | 'title'> | null | undefined;
 
 /**
  * On app resume, fire a single `tick()` so the wall-clock-based focus reducer
@@ -40,9 +43,9 @@ export const createFocusResumeTick$ = (onResume$: Observable<void>): Observable<
  * changes need no push at all — and since prev/curr are consecutive per-tick
  * emissions (~1s apart), the 5s gate suppresses them entirely (#8243). Do not
  * weaken it: every push re-runs startForeground + a notification rebuild.
- * Pause/purpose changes — and the large elapsed jump a resume `tick()`
- * produces (#7856) — must propagate immediately so the notification
- * reconciles with the corrected in-app countdown. (The 5000 here and
+ * Pause/purpose and displayed-task changes — and the large elapsed jump a
+ * resume `tick()` produces (#7856) — must propagate immediately so the
+ * notification reconciles with the corrected in-app state. (The 5000 here and
  * TIME_SPENT_JUMP_THRESHOLD_MS in android-foreground-tracking.effects.ts
  * encode the same "larger than any tick" idea but differ in semantics —
  * abs() vs decrease-always-passes — so they are deliberately not shared.)
@@ -50,8 +53,13 @@ export const createFocusResumeTick$ = (onResume$: Observable<void>): Observable<
 export const hasFocusNotificationStateChanged = (
   prevTimer: TimerState | undefined,
   currTimer: TimerState,
+  prevTask?: FocusNotificationTask,
+  currTask?: FocusNotificationTask,
 ): boolean => {
   if (!prevTimer) return true;
+  // The task title is part of the native notification payload, even though the
+  // focus timer itself is unchanged when tracking switches to another task.
+  if (prevTask?.id !== currTask?.id || prevTask?.title !== currTask?.title) return true;
   // Pause state changed
   if (prevTimer.isRunning !== currTimer.isRunning) return true;
   // Purpose changed (work -> break or vice versa)
@@ -253,7 +261,14 @@ export class AndroidFocusModeEffects {
                   'Failed to start focus mode notification',
                   true,
                 );
-              } else if (hasFocusNotificationStateChanged(prev?.timer, timer)) {
+              } else if (
+                hasFocusNotificationStateChanged(
+                  prev?.timer,
+                  timer,
+                  prev?.currentTask,
+                  currentTask,
+                )
+              ) {
                 // Only update if something significant changed
                 DroidLog.log('AndroidFocusModeEffects: Updating focus mode service', {
                   title,

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
@@ -66,6 +66,7 @@ describe('FocusModeMainComponent', () => {
   let mockIssueService: jasmine.SpyObj<IssueService>;
   let focusModeServiceSpy: jasmine.SpyObj<FocusModeService>;
   let currentTaskSubject: BehaviorSubject<TaskCopy | null>;
+  let mainStateSignal: WritableSignal<FocusMainUIState>;
   let mockMatDialog: jasmine.SpyObj<MatDialog>;
 
   const mockTask: TaskCopy = {
@@ -87,6 +88,7 @@ describe('FocusModeMainComponent', () => {
   } as TaskCopy;
 
   beforeEach(async () => {
+    mainStateSignal = signal(FocusMainUIState.Preparation);
     const globalConfigServiceSpy = jasmine.createSpyObj('GlobalConfigService', [], {
       tasks: jasmine.createSpy().and.returnValue({
         notesTemplate: 'Default task notes template',
@@ -129,7 +131,7 @@ describe('FocusModeMainComponent', () => {
       currentCycle: jasmine.createSpy().and.returnValue(1),
       sessionDuration: jasmine.createSpy().and.returnValue(0),
       mode: jasmine.createSpy().and.returnValue(FocusModeMode.Pomodoro),
-      mainState: jasmine.createSpy().and.returnValue(FocusMainUIState.Preparation),
+      mainState: mainStateSignal,
       focusModeConfig: jasmine.createSpy().and.returnValue({
         isSkipPreparation: false,
       }),
@@ -440,7 +442,7 @@ describe('FocusModeMainComponent', () => {
     });
 
     it('should open task selector and NOT dispatch selectFocusTask when session is running', () => {
-      focusModeServiceSpy.mainState.and.returnValue(FocusMainUIState.InProgress);
+      mainStateSignal.set(FocusMainUIState.InProgress);
       focusModeServiceSpy.isSessionRunning.and.returnValue(true);
       component.finishCurrentTask();
 
@@ -461,7 +463,7 @@ describe('FocusModeMainComponent', () => {
     });
 
     it('should preserve a paused session while choosing the next task', () => {
-      focusModeServiceSpy.mainState.and.returnValue(FocusMainUIState.InProgress);
+      mainStateSignal.set(FocusMainUIState.InProgress);
       focusModeServiceSpy.isSessionRunning.and.returnValue(false);
       focusModeServiceSpy.isSessionPaused.and.returnValue(true);
 

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
@@ -1271,6 +1271,40 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
       );
     }));
 
+    it('returns to task selection if the passive task disappears during inline launch', fakeAsync(() => {
+      spyOn(globalThis, 'matchMedia').and.callFake(matchMediaFake(false));
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      component.startSession();
+      selectedTaskSubject.next(undefined as unknown as TaskCopy);
+      fixture.detectChanges();
+      tick(800);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(actions.selectFocusTask());
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ type: actions.startFocusSession.type }),
+      );
+      expect(component.isTaskSelectorOpen()).toBe(true);
+    }));
+
+    it('does not retarget an inline launch after finishing the passive task', fakeAsync(() => {
+      spyOn(globalThis, 'matchMedia').and.callFake(matchMediaFake(false));
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      component.startSession();
+      component.finishCurrentTask();
+      component.onTaskSelected(mockTask.id);
+      tick(800);
+
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ type: actions.startFocusSession.type }),
+      );
+      expect(component.displayedTask()).toBe(mockTask);
+      expect(component.isTaskSelectorOpen()).toBe(false);
+    }));
+
     it('carries a valid passive selection through the full preparation countdown', () => {
       currentTaskSubject.next(null);
       focusModeConfigSignal.set({
@@ -1347,6 +1381,8 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
           },
         }),
       );
+      expect(mockTaskService.setCurrentId).not.toHaveBeenCalled();
+      expect(component.isTaskSelectorOpen()).toBe(true);
     });
 
     it('returns to task selection if the passive task disappears before countdown completion', () => {

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
@@ -1252,6 +1252,49 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
       expect(component.displayedTask()).toBe(mockTask);
     });
 
+    it('does not cancel a session started for another task during inline launch', fakeAsync(() => {
+      spyOn(globalThis, 'matchMedia').and.callFake(matchMediaFake(false));
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+      component.startSession();
+
+      mainStateSignal.set(FocusMainUIState.InProgress);
+      currentTaskSubject.next(mockTask);
+      fixture.detectChanges();
+      mockStore.dispatch.calls.reset();
+      tick(800);
+
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(actions.selectFocusTask());
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ type: actions.startFocusSession.type }),
+      );
+      expect(component.isTaskSelectorOpen()).toBe(false);
+
+      mainStateSignal.set(FocusMainUIState.Preparation);
+      currentTaskSubject.next(null);
+      fixture.detectChanges();
+      expect(component.displayedTask()).toBeNull();
+    }));
+
+    it('does not restart a session started for the staged task during inline launch', fakeAsync(() => {
+      spyOn(globalThis, 'matchMedia').and.callFake(matchMediaFake(false));
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+      component.startSession();
+
+      mainStateSignal.set(FocusMainUIState.InProgress);
+      currentTaskSubject.next(selectedTask);
+      fixture.detectChanges();
+      mockStore.dispatch.calls.reset();
+      tick(800);
+
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(actions.selectFocusTask());
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ type: actions.startFocusSession.type }),
+      );
+      expect(component.isTaskSelectorOpen()).toBe(false);
+    }));
+
     it('passes the passive task selection to the focus-session start', fakeAsync(() => {
       currentTaskSubject.next(null);
       component.displayDuration.set(1500000);

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
@@ -1398,6 +1398,26 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
       expect(component.isTaskSelectorOpen()).toBe(true);
     });
 
+    it('disables the play button when the staged task is completed elsewhere', () => {
+      currentTaskSubject.next(null);
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+      expect(component.isPlayButtonDisabled()).toBe(false);
+
+      // e.g. a remote op (or the task list) marks the staged task done while it
+      // still sits in preparation waiting for Start.
+      selectedTaskSubject.next({ ...selectedTask, isDone: true });
+      fixture.detectChanges();
+
+      // Assert the staged task is still displayed, so that a null displayedTask
+      // cannot satisfy the isPlayButtonDisabled expectation below — only the
+      // isDone check can. Without this, dropping that check keeps the spec green.
+      expect(component.displayedTask()).toEqual(
+        jasmine.objectContaining({ id: selectedTask.id, isDone: true }),
+      );
+      expect(component.isPlayButtonDisabled()).toBe(true);
+    });
+
     it('edits the passively selected task rather than an already tracked task', () => {
       component.onTaskSelected(selectedTask.id);
       fixture.detectChanges();

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
@@ -440,6 +440,7 @@ describe('FocusModeMainComponent', () => {
     });
 
     it('should open task selector and NOT dispatch selectFocusTask when session is running', () => {
+      focusModeServiceSpy.mainState.and.returnValue(FocusMainUIState.InProgress);
       focusModeServiceSpy.isSessionRunning.and.returnValue(true);
       component.finishCurrentTask();
 
@@ -457,6 +458,18 @@ describe('FocusModeMainComponent', () => {
           },
         }),
       );
+    });
+
+    it('should preserve a paused session while choosing the next task', () => {
+      focusModeServiceSpy.mainState.and.returnValue(FocusMainUIState.InProgress);
+      focusModeServiceSpy.isSessionRunning.and.returnValue(false);
+      focusModeServiceSpy.isSessionPaused.and.returnValue(true);
+
+      component.finishCurrentTask();
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(actions.completeTask());
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(actions.selectFocusTask());
+      expect(component.isTaskSelectorOpen()).toBe(true);
     });
   });
 
@@ -503,7 +516,7 @@ describe('FocusModeMainComponent', () => {
 
       expect(component.isLaunching()).toBe(false);
       expect(mockStore.dispatch).toHaveBeenCalledWith(
-        actions.startFocusSession({ duration: 900000 }),
+        actions.startFocusSession({ duration: 900000, taskId: mockTask.id }),
       );
     }));
 
@@ -519,7 +532,7 @@ describe('FocusModeMainComponent', () => {
       // No animation delay: the session starts synchronously.
       expect(component.isLaunching()).toBe(false);
       expect(mockStore.dispatch).toHaveBeenCalledWith(
-        actions.startFocusSession({ duration: 900000 }),
+        actions.startFocusSession({ duration: 900000, taskId: mockTask.id }),
       );
     }));
 
@@ -557,7 +570,7 @@ describe('FocusModeMainComponent', () => {
       tick(800);
 
       expect(mockStore.dispatch).toHaveBeenCalledWith(
-        actions.startFocusSession({ duration: 0 }),
+        actions.startFocusSession({ duration: 0, taskId: mockTask.id }),
       );
     }));
 
@@ -1050,8 +1063,12 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
   let component: FocusModeMainComponent;
   let fixture: ComponentFixture<FocusModeMainComponent>;
   let mockStore: jasmine.SpyObj<Store>;
+  let mockTaskService: jasmine.SpyObj<TaskService>;
   let currentTaskSubject: BehaviorSubject<TaskCopy | null>;
+  let selectedTaskSubject: BehaviorSubject<TaskCopy>;
   let focusModeConfigSignal: WritableSignal<any>;
+  let mainStateSignal: WritableSignal<FocusMainUIState>;
+  let isSessionPausedSignal: WritableSignal<boolean>;
 
   const mockTask: TaskCopy = {
     id: 'task-1',
@@ -1068,11 +1085,19 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
     tagIds: [],
   } as TaskCopy;
 
+  const selectedTask: TaskCopy = {
+    ...mockTask,
+    id: 'task-2',
+    title: 'Selected Focus Task',
+  };
+
   beforeEach(async () => {
     // Create writable signal for focusModeConfig to test computed signals
     focusModeConfigSignal = signal({
       isSkipPreparation: false,
     });
+    mainStateSignal = signal(FocusMainUIState.Preparation);
+    isSessionPausedSignal = signal(false);
 
     const storeSpy = jasmine.createSpyObj('Store', [
       'dispatch',
@@ -1089,13 +1114,17 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
     });
 
     currentTaskSubject = new BehaviorSubject<TaskCopy | null>(mockTask);
+    selectedTaskSubject = new BehaviorSubject<TaskCopy>(selectedTask);
     const taskServiceSpy = jasmine.createSpyObj(
       'TaskService',
-      ['update', 'setCurrentId'],
+      ['getByIdLive$', 'update', 'setCurrentId'],
       {
         currentTask$: currentTaskSubject.asObservable(),
         currentTaskId: jasmine.createSpy().and.returnValue(null),
       },
+    );
+    taskServiceSpy.getByIdLive$.and.callFake((taskId: string) =>
+      taskId === selectedTask.id ? selectedTaskSubject : of(mockTask),
     );
 
     const taskAttachmentServiceSpy = jasmine.createSpyObj('TaskAttachmentService', [
@@ -1121,12 +1150,12 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
       progress: signal(0),
       timeRemaining: signal(1500000),
       isSessionRunning: signal(false),
-      isSessionPaused: signal(false),
+      isSessionPaused: isSessionPausedSignal,
       isBreakActive: signal(false),
       currentCycle: signal(1),
       sessionDuration: signal(0),
       mode: signal(FocusModeMode.Pomodoro),
-      mainState: signal(FocusMainUIState.Preparation),
+      mainState: mainStateSignal,
       focusModeConfig: focusModeConfigSignal,
       pomodoroConfig: signal(undefined),
       isInOvertime: signal(false),
@@ -1162,8 +1191,177 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
     fixture = TestBed.createComponent(FocusModeMainComponent);
     component = fixture.componentInstance;
     mockStore = TestBed.inject(Store) as jasmine.SpyObj<Store>;
+    mockTaskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
     fixture.detectChanges();
     mockStore.dispatch.calls.reset();
+  });
+
+  describe('task selection (issue #9399)', () => {
+    it('keeps a preparation selection passive while displaying it as the focus task', () => {
+      currentTaskSubject.next(null);
+      fixture.detectChanges();
+
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      expect(mockTaskService.setCurrentId).not.toHaveBeenCalled();
+      expect(component.displayedTask()).toBe(selectedTask);
+      expect(component.isPlayButtonDisabled()).toBe(false);
+    });
+
+    it('does not replace an already tracked task until the focus session starts', () => {
+      currentTaskSubject.next(mockTask);
+      fixture.detectChanges();
+
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      expect(mockTaskService.setCurrentId).not.toHaveBeenCalled();
+      expect(component.currentTask()).toBe(mockTask);
+      expect(component.displayedTask()).toBe(selectedTask);
+    });
+
+    it('switches tasks immediately when a focus session is already in progress', () => {
+      mainStateSignal.set(FocusMainUIState.InProgress);
+      fixture.detectChanges();
+
+      component.onTaskSelected(selectedTask.id);
+
+      expect(mockTaskService.setCurrentId).toHaveBeenCalledOnceWith(selectedTask.id);
+    });
+
+    it('switches tasks immediately when a focus session is paused', () => {
+      mainStateSignal.set(FocusMainUIState.InProgress);
+      isSessionPausedSignal.set(true);
+      currentTaskSubject.next(null);
+      fixture.detectChanges();
+
+      component.onTaskSelected(selectedTask.id);
+
+      expect(mockTaskService.setCurrentId).toHaveBeenCalledOnceWith(selectedTask.id);
+    });
+
+    it('ignores a stale passive selection after another path starts a session', () => {
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      mainStateSignal.set(FocusMainUIState.InProgress);
+      currentTaskSubject.next(mockTask);
+      fixture.detectChanges();
+
+      expect(component.displayedTask()).toBe(mockTask);
+    });
+
+    it('passes the passive task selection to the focus-session start', fakeAsync(() => {
+      currentTaskSubject.next(null);
+      component.displayDuration.set(1500000);
+      fixture.detectChanges();
+
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+      component.startSession();
+      tick(800);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          type: actions.startFocusSession.type,
+          duration: 1500000,
+          taskId: selectedTask.id,
+        }),
+      );
+    }));
+
+    it('carries a valid passive selection through the full preparation countdown', () => {
+      currentTaskSubject.next(null);
+      focusModeConfigSignal.set({
+        ...focusModeConfigSignal(),
+        isShowPreparation: true,
+      });
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      component.startSession();
+      expect(mockStore.dispatch).toHaveBeenCalledWith(actions.startFocusPreparation());
+
+      mainStateSignal.set(FocusMainUIState.Countdown);
+      mockStore.dispatch.calls.reset();
+      component.onCountdownComplete();
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(
+        actions.startFocusSession({
+          duration: component.displayDuration(),
+          taskId: selectedTask.id,
+        }),
+      );
+    });
+
+    it('returns to task selection if the passive task is completed during countdown', () => {
+      currentTaskSubject.next(null);
+      focusModeConfigSignal.set({
+        ...focusModeConfigSignal(),
+        isShowPreparation: true,
+      });
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+      component.startSession();
+
+      mainStateSignal.set(FocusMainUIState.Countdown);
+      selectedTaskSubject.next({ ...selectedTask, isDone: true });
+      fixture.detectChanges();
+      mockStore.dispatch.calls.reset();
+      component.onCountdownComplete();
+
+      expect(component.isPlayButtonDisabled()).toBe(true);
+      expect(mockStore.dispatch).toHaveBeenCalledWith(actions.selectFocusTask());
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ type: actions.startFocusSession.type }),
+      );
+      expect(component.isTaskSelectorOpen()).toBe(true);
+    });
+
+    it('edits the passively selected task rather than an already tracked task', () => {
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      component.updateTaskTitleIfChanged(true, 'Updated Focus Task');
+
+      expect(mockTaskService.update).toHaveBeenCalledWith(selectedTask.id, {
+        title: 'Updated Focus Task',
+      });
+    });
+
+    it('completes the passively selected task rather than an already tracked task', () => {
+      component.onTaskSelected(selectedTask.id);
+      fixture.detectChanges();
+
+      component.finishCurrentTask();
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.updateTask({
+          task: {
+            id: selectedTask.id,
+            changes: {
+              isDone: true,
+              doneOn: jasmine.any(Number) as unknown as number,
+            },
+          },
+        }),
+      );
+    });
+
+    it('returns to task selection if the passive task disappears before countdown completion', () => {
+      mockTaskService.getByIdLive$.and.returnValue(of(undefined as unknown as TaskCopy));
+
+      component.onTaskSelected('deleted-task');
+      fixture.detectChanges();
+      component.onCountdownComplete();
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(actions.selectFocusTask());
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({ type: actions.startFocusSession.type }),
+      );
+      expect(component.isTaskSelectorOpen()).toBe(true);
+    });
   });
 
   describe('isPlayButtonDisabled', () => {
@@ -1264,6 +1462,7 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
       expect(mockStore.dispatch).toHaveBeenCalledWith(
         actions.startFocusSession({
           duration: 1500000,
+          taskId: mockTask.id,
         }),
       );
     }));

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
@@ -173,7 +173,20 @@ export class FocusModeMainComponent {
     ),
   );
 
+  // Picking a task during preparation only stages it for the upcoming Focus
+  // session. Activating it here would start global task tracking before the
+  // user presses Start (#9399).
+  private readonly _pendingTaskId = signal<string | null>(null);
+  private readonly _pendingTask = toSignal(
+    toObservable(this._pendingTaskId).pipe(
+      switchMap((id) => (id ? this.taskService.getByIdLive$(id) : of(null))),
+    ),
+  );
+
   readonly displayedTask = computed(() => {
+    if (this.mainState() !== FocusMainUIState.InProgress && this._pendingTaskId()) {
+      return this._pendingTask() ?? null;
+    }
     const tracked = this.currentTask();
     if (tracked) return tracked;
     if (this.focusModeService.isSessionPaused()) {
@@ -252,7 +265,10 @@ export class FocusModeMainComponent {
   // Play button should be disabled when no task is selected.
   // Sync between focus session and tracking is always on, so starting a session
   // without a task would leave tracking with nothing to bind to.
-  isPlayButtonDisabled = computed(() => !this.currentTask());
+  isPlayButtonDisabled = computed(() => {
+    const task = this.displayedTask();
+    return !task || task.isDone;
+  });
 
   // Mode selector options
   readonly modeOptions = computed<ReadonlyArray<SegmentedButtonOption>>(() => {
@@ -408,12 +424,13 @@ export class FocusModeMainComponent {
   }
 
   finishCurrentTask(): void {
-    const sessionRunning = this.isSessionRunning();
+    const isSessionInProgress =
+      this.mainState() === FocusMainUIState.InProgress || this.isSessionRunning();
+    const task = this.displayedTask();
 
     this._store.dispatch(completeTask());
 
-    const t = this.currentTask();
-    const id = t && t.id;
+    const id = task?.id;
     if (id) {
       this._store.dispatch(
         TaskSharedActions.updateTask({
@@ -428,9 +445,10 @@ export class FocusModeMainComponent {
       );
     }
 
-    if (sessionRunning) {
+    if (isSessionInProgress) {
       this.openTaskSelector();
     } else {
+      this._pendingTaskId.set(null);
       this._store.dispatch(selectFocusTask());
     }
   }
@@ -441,9 +459,9 @@ export class FocusModeMainComponent {
 
   updateTaskTitleIfChanged(isChanged: boolean, newTitle: string): void {
     if (isChanged) {
-      const t = this.currentTask();
+      const t = this.displayedTask();
       if (!t) {
-        Log.warn('updateTaskTitleIfChanged: currentTask is null, skipping update');
+        Log.warn('updateTaskTitleIfChanged: displayedTask is null, skipping update');
         return;
       }
       this.taskService.update(t.id, { title: newTitle });
@@ -489,7 +507,8 @@ export class FocusModeMainComponent {
 
     // Sync between focus session and tracking is always on — require a task
     // before starting so tracking has something to bind to.
-    if (!this.currentTask()) {
+    const task = this.displayedTask();
+    if (!task || task.isDone) {
       this.openTaskSelector();
       return;
     }
@@ -525,7 +544,7 @@ export class FocusModeMainComponent {
       .subscribe(() => {
         this.isLaunching.set(false);
         // The task could have been deselected during the brief launch window.
-        if (!this.currentTask()) {
+        if (!this.displayedTask()) {
           return;
         }
         this._dispatchStartSession();
@@ -537,9 +556,17 @@ export class FocusModeMainComponent {
   }
 
   private _dispatchStartSession(): void {
+    const task = this.displayedTask();
+    if (!task || task.isDone) {
+      this._store.dispatch(selectFocusTask());
+      this.openTaskSelector();
+      return;
+    }
+
     // For Flowtime mode, duration must be 0 to count indefinitely
     const duration = this.mode() === FocusModeMode.Flowtime ? 0 : this.displayDuration();
-    this._store.dispatch(startFocusSession({ duration }));
+    this._store.dispatch(startFocusSession({ duration, taskId: task.id }));
+    this._pendingTaskId.set(null);
   }
 
   pauseSession(): void {
@@ -611,7 +638,11 @@ export class FocusModeMainComponent {
   }
 
   onTaskSelected(taskId: string): void {
-    this.switchToTask(taskId);
+    if (this._isInProgress()) {
+      this.switchToTask(taskId);
+    } else {
+      this._pendingTaskId.set(taskId);
+    }
     this.closeTaskSelector();
   }
 

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
@@ -10,7 +10,7 @@ import {
   signal,
 } from '@angular/core';
 import { Log } from '../../../core/log';
-import { from, Observable, of, Subject, timer } from 'rxjs';
+import { from, Observable, of, Subject, Subscription, timer } from 'rxjs';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { TaskService } from '../../tasks/task.service';
 import { debounceTime, switchMap, take } from 'rxjs/operators';
@@ -146,6 +146,7 @@ export class FocusModeMainComponent {
   private readonly _LAUNCH_DURATION_MS = 800;
   // True while the brief inline rocket launch plays (default, prep screen off).
   readonly isLaunching = signal(false);
+  private _launchSubscription: Subscription | null = null;
 
   readonly simpleCounterService = inject(SimpleCounterService);
   readonly taskService = inject(TaskService);
@@ -450,6 +451,7 @@ export class FocusModeMainComponent {
     } else {
       this._pendingTaskId.set(null);
       this._store.dispatch(selectFocusTask());
+      this.openTaskSelector();
     }
   }
 
@@ -520,7 +522,7 @@ export class FocusModeMainComponent {
     }
 
     // Default: play a quick inline rocket launch from the play button, then start.
-    this._launchThenStart();
+    this._launchThenStart(task.id);
   }
 
   onCountdownComplete(): void {
@@ -529,25 +531,22 @@ export class FocusModeMainComponent {
     // Main UI state transitions are now handled by the store
   }
 
-  private _launchThenStart(): void {
+  private _launchThenStart(taskId: string): void {
     // Honor "reduce motion": skip the rocket flourish and its timed delay,
     // starting immediately. Otherwise a motion-sensitive user would just wait
     // out an 800ms delay for an animation they never see.
     if (this._prefersReducedMotion()) {
-      this._dispatchStartSession();
+      this._dispatchStartSession(taskId);
       return;
     }
 
     this.isLaunching.set(true);
-    timer(this._LAUNCH_DURATION_MS)
+    this._launchSubscription = timer(this._LAUNCH_DURATION_MS)
       .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(() => {
+        this._launchSubscription = null;
         this.isLaunching.set(false);
-        // The task could have been deselected during the brief launch window.
-        if (!this.displayedTask()) {
-          return;
-        }
-        this._dispatchStartSession();
+        this._dispatchStartSession(taskId);
       });
   }
 
@@ -555,9 +554,10 @@ export class FocusModeMainComponent {
     return !!globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
   }
 
-  private _dispatchStartSession(): void {
+  private _dispatchStartSession(expectedTaskId?: string): void {
     const task = this.displayedTask();
-    if (!task || task.isDone) {
+    if (!task || task.isDone || (expectedTaskId && task.id !== expectedTaskId)) {
+      this._pendingTaskId.set(null);
       this._store.dispatch(selectFocusTask());
       this.openTaskSelector();
       return;
@@ -630,7 +630,14 @@ export class FocusModeMainComponent {
   }
 
   openTaskSelector(): void {
+    this._cancelInlineLaunch();
     this.isTaskSelectorOpen.set(true);
+  }
+
+  private _cancelInlineLaunch(): void {
+    this._launchSubscription?.unsubscribe();
+    this._launchSubscription = null;
+    this.isLaunching.set(false);
   }
 
   closeTaskSelector(): void {

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
@@ -396,8 +396,7 @@ export class FocusModeMainComponent {
   }
 
   @HostListener('drop', ['$event']) onDrop(ev: DragEvent): void {
-    // Drop attaches to the displayedTask (= currentTask, or the paused task
-    // during a paused session) so drops still work mid-pause.
+    // Drop attaches to the tracked, paused, or staged preparation task.
     const t = this.displayedTask();
     if (!t) {
       return;
@@ -425,8 +424,7 @@ export class FocusModeMainComponent {
   }
 
   finishCurrentTask(): void {
-    const isSessionInProgress =
-      this.mainState() === FocusMainUIState.InProgress || this.isSessionRunning();
+    const isSessionInProgress = this._isInProgress() || this.isSessionRunning();
     const task = this.displayedTask();
 
     this._store.dispatch(completeTask());

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
@@ -546,6 +546,10 @@ export class FocusModeMainComponent {
       .subscribe(() => {
         this._launchSubscription = null;
         this.isLaunching.set(false);
+        if (!this._isPreparation()) {
+          this._pendingTaskId.set(null);
+          return;
+        }
         this._dispatchStartSession(taskId);
       });
   }

--- a/src/app/features/focus-mode/store/focus-mode.actions.ts
+++ b/src/app/features/focus-mode/store/focus-mode.actions.ts
@@ -21,7 +21,7 @@ export const startFocusPreparation = createAction('[FocusMode] Start Preparation
 
 export const startFocusSession = createAction(
   '[FocusMode] Start Session',
-  props<{ duration?: number }>(),
+  props<{ duration?: number; taskId?: string }>(),
 );
 
 export const navigateToMainScreen = createAction('[FocusMode] Navigate To Main Screen');

--- a/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
@@ -2278,10 +2278,7 @@ describe('FocusModeEffects', () => {
 
         effects.syncSessionStartToTracking$.pipe(toArray()).subscribe((emitted) => {
           const emittedTypes: string[] = emitted.map((action) => action.type);
-          expect(emittedTypes).toEqual([
-            actions.selectFocusTask.type,
-            actions.showFocusOverlay.type,
-          ]);
+          expect(emittedTypes).toEqual([actions.selectFocusTask.type]);
           done();
         });
       });

--- a/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
@@ -29,6 +29,7 @@ import {
 import { updateGlobalConfigSection } from '../../config/store/global-config.actions';
 import { take, toArray } from 'rxjs/operators';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
+import { DEFAULT_TASK } from '../../tasks/task.model';
 
 describe('FocusModeEffects', () => {
   let actions$: Observable<any>;
@@ -2226,6 +2227,66 @@ describe('FocusModeEffects', () => {
   });
 
   describe('syncSessionStartToTracking$', () => {
+    it('should switch tracking to the explicitly selected focus task when the session starts', (done) => {
+      store.overrideSelector(selectors.selectPausedTaskId, 'paused-task');
+      store.overrideSelector(selectLastCurrentTask, null);
+      store.overrideSelector(selectTaskById, {
+        ...DEFAULT_TASK,
+        id: 'selected-task',
+        title: 'Selected Focus Task',
+        isDone: false,
+        projectId: '',
+      });
+      currentTaskId$.next('previously-tracked-task');
+      store.refreshState();
+
+      actions$ = of(
+        actions.startFocusSession({
+          duration: 25 * 60 * 1000,
+          taskId: 'selected-task',
+        }),
+      );
+
+      effects.syncSessionStartToTracking$.pipe(toArray()).subscribe((emitted) => {
+        expect(emitted).toEqual([setCurrentTask({ id: 'selected-task' })]);
+        done();
+      });
+    });
+
+    [null, 'previously-tracked-task'].forEach((currentTaskId) => {
+      it(`should reject an explicitly selected done task without changing ${
+        currentTaskId ? 'different' : 'empty'
+      } tracking`, (done) => {
+        store.overrideSelector(selectors.selectPausedTaskId, null);
+        store.overrideSelector(selectLastCurrentTask, null);
+        store.overrideSelector(selectTaskById, {
+          ...DEFAULT_TASK,
+          id: 'done-selected-task',
+          title: 'Done Selected Focus Task',
+          isDone: true,
+          projectId: '',
+        });
+        currentTaskId$.next(currentTaskId);
+        store.refreshState();
+
+        actions$ = of(
+          actions.startFocusSession({
+            duration: 25 * 60 * 1000,
+            taskId: 'done-selected-task',
+          }),
+        );
+
+        effects.syncSessionStartToTracking$.pipe(toArray()).subscribe((emitted) => {
+          const emittedTypes: string[] = emitted.map((action) => action.type);
+          expect(emittedTypes).toEqual([
+            actions.selectFocusTask.type,
+            actions.showFocusOverlay.type,
+          ]);
+          done();
+        });
+      });
+    });
+
     it('should dispatch setCurrentTask when session starts with pausedTaskId and no current task', (done) => {
       store.overrideSelector(selectFocusModeConfig, {
         isSkipPreparation: false,

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -234,7 +234,8 @@ export class FocusModeEffects {
     ),
   );
 
-  // Sync: When focus session starts → start tracking (if not already tracking)
+  // Sync: When focus session starts → start or switch tracking
+  // An explicitly selected task takes precedence over existing and resumable tasks.
   // Checks that the paused task still exists before starting tracking
   // Bug #5954 fix: Falls back to lastCurrentTask if no pausedTaskId (e.g., after app restart)
   // Bug #5954 fix: Shows focus overlay if no valid (undone) task is available
@@ -246,21 +247,24 @@ export class FocusModeEffects {
         this.taskService.currentTaskId$,
         this.store.select(selectLastCurrentTask),
       ),
-      filter(
-        ([_action, pausedTaskId, currentTaskId, lastCurrentTask]) =>
-          !currentTaskId && (!!pausedTaskId || !!lastCurrentTask),
+      filter(([action, pausedTaskId, currentTaskId, lastCurrentTask]) =>
+        action.taskId
+          ? action.taskId !== currentTaskId
+          : !currentTaskId && (!!pausedTaskId || !!lastCurrentTask),
       ),
-      switchMap(([_action, pausedTaskId, _currentTaskId, lastCurrentTask]) => {
-        // Prefer pausedTaskId, fall back to lastCurrentTask
-        const taskIdToResume = pausedTaskId || lastCurrentTask?.id;
+      switchMap(([action, pausedTaskId, _currentTaskId, lastCurrentTask]) => {
+        // Prefer an explicit selection, then pausedTaskId, then lastCurrentTask.
+        const taskIdToResume = action.taskId || pausedTaskId || lastCurrentTask?.id;
         if (!taskIdToResume) return EMPTY;
 
         return this.store.select(selectTaskById, { id: taskIdToResume }).pipe(
           take(1),
-          map((task) =>
+          switchMap((task) =>
             task && !task.isDone
-              ? setCurrentTask({ id: taskIdToResume })
-              : actions.showFocusOverlay(),
+              ? of(setCurrentTask({ id: taskIdToResume }))
+              : action.taskId
+                ? of(actions.selectFocusTask(), actions.showFocusOverlay())
+                : of(actions.showFocusOverlay()),
           ),
         );
       }),
@@ -866,6 +870,7 @@ export class FocusModeEffects {
             actions.completeBreak,
             actions.completeFocusSession,
             actions.cancelFocusSession,
+            actions.selectFocusTask,
           ),
           // Throttle to prevent excessive IPC calls (timer ticks every 1s)
           // Use leading + trailing to ensure immediate feedback and final state

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -263,7 +263,7 @@ export class FocusModeEffects {
             task && !task.isDone
               ? of(setCurrentTask({ id: taskIdToResume }))
               : action.taskId
-                ? of(actions.selectFocusTask(), actions.showFocusOverlay())
+                ? of(actions.selectFocusTask())
                 : of(actions.showFocusOverlay()),
           ),
         );

--- a/src/app/features/focus-mode/store/focus-mode.reducer.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.reducer.spec.ts
@@ -110,16 +110,33 @@ describe('FocusModeReducer', () => {
 
       expect(result.isOverlayShown).toBe(false);
     });
+
+    it('should cancel an unstarted preparation countdown when the overlay closes', () => {
+      const state = {
+        ...initialState,
+        isOverlayShown: true,
+        mainState: FocusMainUIState.Countdown,
+      };
+
+      const result = focusModeReducer(state, a.hideFocusOverlay());
+
+      expect(result.mainState).toBe(FocusMainUIState.Preparation);
+    });
   });
 
   describe('screen navigation actions', () => {
     it('should reset to preparation state on task selection', () => {
-      const state = { ...initialState, currentScreen: FocusScreen.Main };
+      const runningState = focusModeReducer(
+        { ...initialState, currentScreen: FocusScreen.Main },
+        a.startFocusSession({ duration: 25 * 60 * 1000 }),
+      );
       const action = a.selectFocusTask();
-      const result = focusModeReducer(state, action);
+      const result = focusModeReducer(runningState, action);
 
       expect(result.currentScreen).toBe(FocusScreen.Main);
       expect(result.mainState).toBe(FocusMainUIState.Preparation);
+      expect(result.timer.purpose).toBeNull();
+      expect(result.timer.isRunning).toBe(false);
     });
 
     it('should stay on main screen for duration selection', () => {

--- a/src/app/features/focus-mode/store/focus-mode.reducer.ts
+++ b/src/app/features/focus-mode/store/focus-mode.reducer.ts
@@ -91,13 +91,21 @@ export const focusModeReducer = createReducer(
   on(a.hideFocusOverlay, (state) => ({
     ...state,
     isOverlayShown: false,
+    // The preparation task is local to the overlay. Closing before the session
+    // starts cancels the countdown so reopening cannot continue without it.
+    mainState:
+      state.mainState === FocusMainUIState.Countdown && state.timer.purpose === null
+        ? FocusMainUIState.Preparation
+        : state.mainState,
   })),
 
   // Screen navigation
   on(a.selectFocusTask, (state) => ({
     ...state,
+    timer: createIdleTimer(),
     currentScreen: FocusScreen.Main,
     mainState: FocusMainUIState.Preparation,
+    _isOvertimeEnabled: false,
   })),
 
   on(a.selectFocusDuration, (state) => ({


### PR DESCRIPTION
## Summary

- Stage Focus Mode task selections during preparation instead of starting global task tracking immediately.
- Activate the selected task together with the Focus session and guard delayed preparation/inline-launch handoffs against stale, deleted, completed, or superseded tasks.
- Keep task editing, completion, attachments, and display behavior aligned with the staged or paused task.
- Update the Focus Mode concepts documentation to describe the synchronized lifecycle accurately.

Fixes #9399.

## Root cause

Selecting a task in the Focus Mode overlay called the global task-tracking path immediately. That started logging time before the user pressed **Start**, and time continued to accrue if the overlay was closed during preparation. Deferring activation is necessary because merely clearing the task when the overlay closes would still log time while the selector or preparation countdown is open.

## Additional fixes included

- Android's ongoing Focus notification now refreshes when the task changes. Previously, the five-second elapsed-time gate could never pass for a title-only update, so switching tasks mid-session left the old title in the notification.
- Completing the displayed task during a paused session now marks that paused task done; previously the live current task was null and the button silently left it incomplete.
- Completing a task outside an in-progress session now opens the task selector after returning to task selection.
- Opening the task selector cancels any pending inline launch so a session cannot start behind it.

These are defensible pre-existing behavior fixes discovered while implementing #9399, rather than direct parts of the reported reproduction.

## Documentation scope

The Concepts notes were changed only where current code provides strong evidence: task selection is staged until session start, and Focus/task tracking are synchronized without the removed opt-in setting. The corrected setting labels and stale opt-in wording repair pre-existing documentation drift unrelated to #9399 and should receive an explicit prose review.

## Validation

- `npm run test:file src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts` — 82 tests passed
- `npm run shared-schema:test` — 89 tests passed
- `npm run checkFile` passed for both modified TypeScript files
- `npm run docs:check-links` passed
- Repository lint/pre-commit checks passed with zero errors (existing warnings only)
