### PR TITLE
test(tasks): harden date-time clearing E2E

### DIFF
--- a/e2e/tests/task-detail/task-detail.spec.ts
+++ b/e2e/tests/task-detail/task-detail.spec.ts
@@ -90,11 +90,16 @@ test.describe('Task detail', () => {
 
     const dateInput = page.getByRole('textbox', { name: 'Date' });
     const timeInput = page.getByRole('combobox', { name: 'Time' });
+    // Let Angular's deferred initial ngModel writes settle before editing.
+    await expect(dateInput).toHaveValue(/\S/);
+    await expect(timeInput).toHaveValue(/\S/);
     await dateInput.fill('');
     // Blur to trigger form update (ngModelOptions: updateOn: 'blur')
     await dateInput.press('Tab');
     await timeInput.fill('');
     await timeInput.press('Tab');
+    await expect(dateInput).toHaveValue('');
+    await expect(timeInput).toHaveValue('');
 
     await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
@@ -109,11 +114,16 @@ test.describe('Task detail', () => {
 
     const dateInput = page.getByRole('textbox', { name: 'Date' });
     const timeInput = page.getByRole('combobox', { name: 'Time' });
+    // Let Angular's deferred initial ngModel writes settle before editing.
+    await expect(dateInput).toHaveValue(/\S/);
+    await expect(timeInput).toHaveValue(/\S/);
     await dateInput.fill('');
     // Blur to trigger form update (ngModelOptions: updateOn: 'blur')
     await dateInput.press('Tab');
     await timeInput.fill('');
     await timeInput.press('Tab');
+    await expect(dateInput).toHaveValue('');
+    await expect(timeInput).toHaveValue('');
 
     await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
   });

--- a/e2e/tests/task-detail/task-detail.spec.ts
+++ b/e2e/tests/task-detail/task-detail.spec.ts
@@ -30,6 +30,21 @@ test.describe('Task detail', () => {
   const findDateInfo = (page: Page, infoPrefix: string): Locator =>
     page.locator('.edit-date-info').filter({ hasText: new RegExp(infoPrefix) });
 
+  const clearDateTimeInputs = async (page: Page): Promise<void> => {
+    const dateInput = page.getByRole('textbox', { name: 'Date' });
+    const timeInput = page.getByRole('combobox', { name: 'Time' });
+    // Let Angular's deferred initial ngModel writes settle before editing.
+    await expect(dateInput).toHaveValue(/\S/);
+    await expect(timeInput).toHaveValue(/\S/);
+    await dateInput.fill('');
+    // Blur to trigger form update (ngModelOptions: updateOn: 'blur')
+    await dateInput.press('Tab');
+    await timeInput.fill('');
+    await timeInput.press('Tab');
+    await expect(dateInput).toHaveValue('');
+    await expect(timeInput).toHaveValue('');
+  };
+
   test('should update created with a time change', async ({ page, workViewPage }) => {
     await addAndOpenIncompleteTask(workViewPage, page);
 
@@ -87,19 +102,7 @@ test.describe('Task detail', () => {
     await addAndOpenIncompleteTask(workViewPage, page);
 
     await findDateInfo(page, 'Created').click();
-
-    const dateInput = page.getByRole('textbox', { name: 'Date' });
-    const timeInput = page.getByRole('combobox', { name: 'Time' });
-    // Let Angular's deferred initial ngModel writes settle before editing.
-    await expect(dateInput).toHaveValue(/\S/);
-    await expect(timeInput).toHaveValue(/\S/);
-    await dateInput.fill('');
-    // Blur to trigger form update (ngModelOptions: updateOn: 'blur')
-    await dateInput.press('Tab');
-    await timeInput.fill('');
-    await timeInput.press('Tab');
-    await expect(dateInput).toHaveValue('');
-    await expect(timeInput).toHaveValue('');
+    await clearDateTimeInputs(page);
 
     await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
@@ -111,19 +114,7 @@ test.describe('Task detail', () => {
     await addAndOpenCompleteTask(workViewPage, page);
 
     await findDateInfo(page, 'Completed').click();
-
-    const dateInput = page.getByRole('textbox', { name: 'Date' });
-    const timeInput = page.getByRole('combobox', { name: 'Time' });
-    // Let Angular's deferred initial ngModel writes settle before editing.
-    await expect(dateInput).toHaveValue(/\S/);
-    await expect(timeInput).toHaveValue(/\S/);
-    await dateInput.fill('');
-    // Blur to trigger form update (ngModelOptions: updateOn: 'blur')
-    await dateInput.press('Tab');
-    await timeInput.fill('');
-    await timeInput.press('Tab');
-    await expect(dateInput).toHaveValue('');
-    await expect(timeInput).toHaveValue('');
+    await clearDateTimeInputs(page);
 
     await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
   });


### PR DESCRIPTION
## Summary

- Wait for the date and time controls to receive Angular's deferred initial `ngModel` values before clearing them.
- Assert that both clears persist before checking that Save is disabled.
- Share the race-sensitive interaction between the created/completed cases so future hardening cannot drift.

## Root cause

[Scheduled E2E run 30624729960](https://github.com/super-productivity/super-productivity/actions/runs/30624729960) failed once in the Task Detail no-datetime case even though the exact source tree passed the same test minutes earlier.

The failure trace showed that both early `fill('')` operations were overwritten by the controls' deferred initial model writes. The tests now synchronize on those initial values, then prove the fields remain empty after the blur-driven updates.

## Verification

- `npm run checkFile e2e/tests/task-detail/task-detail.spec.ts`
- `CI=true npm run e2e:file -- e2e/tests/task-detail/task-detail.spec.ts --retries=0 --workers=3` — 5 passed
- 40/40 parallel repetitions of the two affected cases passed against the failed-run frontend artifact
- Full lint hook — 0 errors (10 existing warnings)
- Full `npm test` suite with nested temporary Git hooks isolated — package/release tests passed; 13,788 browser tests passed in Europe/Berlin and 13,774 in America/Los_Angeles
