### PR TITLE
fix(monitoring): report analysis query failures

### DIFF
--- a/packages/super-sync-server/scripts/analyze-storage.ts
+++ b/packages/super-sync-server/scripts/analyze-storage.ts
@@ -782,9 +782,8 @@ const main = async (): Promise<void> => {
         showHelp();
     }
   } catch (error) {
-    if (reportMonitoringError('Error:', error)) {
-      process.exitCode = 1;
-    }
+    reportMonitoringError('Error:', error);
+    process.exitCode = 1;
   } finally {
     await disconnectDb();
   }

--- a/packages/super-sync-server/scripts/monitor.ts
+++ b/packages/super-sync-server/scripts/monitor.ts
@@ -186,9 +186,9 @@ const showStats = async (): Promise<void> => {
       tableSizes.forEach((t) => console.log(`  ${t.table}: ${t.size}`));
     }
   } catch (error) {
-    if (reportMonitoringError('Error:', error)) {
-      console.log('Status: Disconnected ❌');
-    }
+    reportMonitoringError('Error:', error);
+    console.log('Status: Disconnected ❌');
+    process.exitCode = 1;
   }
 
   // Disk space
@@ -304,6 +304,7 @@ const showUsage = async (saveHistory = true, showFullEmails = false): Promise<vo
     }
   } catch (error) {
     reportMonitoringError('Error fetching usage data:', error);
+    process.exitCode = 1;
   }
 };
 
@@ -612,6 +613,7 @@ const showOps = async (args: string[]): Promise<void> => {
     }
   } catch (error) {
     reportMonitoringError('Error fetching operations:', error);
+    process.exitCode = 1;
   }
 };
 
@@ -763,6 +765,7 @@ const showActiveUsers = async (args: string[]): Promise<void> => {
     );
   } catch (error) {
     reportMonitoringError('Error fetching active users:', error);
+    process.exitCode = 1;
   }
 };
 
@@ -824,6 +827,7 @@ const showActiveUsersQuick = async (args: string[]): Promise<void> => {
     );
   } catch (error) {
     reportMonitoringError('Error fetching active users (quick):', error);
+    process.exitCode = 1;
   }
 };
 
@@ -884,6 +888,7 @@ const main = async (): Promise<void> => {
     }
   } catch (err) {
     reportMonitoringError('Unexpected error:', err);
+    process.exitCode = 1;
   } finally {
     await disconnectDb();
   }

--- a/packages/super-sync-server/scripts/monitoring-db.ts
+++ b/packages/super-sync-server/scripts/monitoring-db.ts
@@ -27,12 +27,14 @@ export const isPrismaStatementTimeout = (error: unknown): boolean => {
 export const reportMonitoringError = (
   message: string,
   error: unknown,
-  logger: (message: string, error: unknown) => void = console.error,
-): boolean => {
+  logger: (message: string, error?: unknown) => void = console.error,
+): void => {
   if (isPrismaStatementTimeout(error)) {
-    return false;
+    logger(
+      `${message} PostgreSQL canceled this query because it exceeded statement_timeout.`,
+    );
+    return;
   }
 
   logger(message, error);
-  return true;
 };

--- a/packages/super-sync-server/scripts/run-all-monitoring.ts
+++ b/packages/super-sync-server/scripts/run-all-monitoring.ts
@@ -127,10 +127,15 @@ const runCommand = async (cmd: MonitoringCommand): Promise<string> => {
     console.log(stdout);
     return stdout;
   } catch (error: any) {
-    const errorMsg = `Error running ${cmd.name}: ${error.message}`;
+    process.exitCode = 1;
+    const stderr = typeof error.stderr === 'string' ? error.stderr.trim() : '';
+    const errorDetail =
+      stderr && !error.message.includes(stderr)
+        ? `${error.message}\n${stderr}`
+        : error.message;
+    const errorMsg = `Error running ${cmd.name}: ${errorDetail}`;
     console.error(errorMsg);
     if (error.stdout) console.log(error.stdout);
-    if (error.stderr) console.error(error.stderr);
     return errorMsg;
   }
 };
@@ -208,7 +213,11 @@ ${'='.repeat(80)}
     console.log(`Size: ${(fullReport.length / 1024).toFixed(1)} KB\n`);
   }
 
-  console.log('✅ Monitoring complete!\n');
+  console.log(
+    process.exitCode === 1
+      ? '⚠️ Monitoring completed with errors.\n'
+      : '✅ Monitoring complete!\n',
+  );
 };
 
 main().catch((error) => {

--- a/packages/super-sync-server/tests/monitoring-db.spec.ts
+++ b/packages/super-sync-server/tests/monitoring-db.spec.ts
@@ -45,7 +45,7 @@ describe('monitoring errors', () => {
     expect(isPrismaStatementTimeout(error)).toBe(false);
   });
 
-  it('does not report statement timeouts', () => {
+  it('reports statement timeouts without dumping the raw Prisma error', () => {
     const error = new Prisma.PrismaClientKnownRequestError('Raw query failed', {
       code: 'P2010',
       clientVersion: '5.22.0',
@@ -56,15 +56,18 @@ describe('monitoring errors', () => {
     });
     const logger = vi.fn();
 
-    expect(reportMonitoringError('Error:', error, logger)).toBe(false);
-    expect(logger).not.toHaveBeenCalled();
+    reportMonitoringError('Error:', error, logger);
+    expect(logger).toHaveBeenCalledWith(
+      'Error: PostgreSQL canceled this query because it exceeded statement_timeout.',
+    );
+    expect(logger).toHaveBeenCalledOnce();
   });
 
   it('continues to report genuine errors', () => {
     const error = new Error('permission denied');
     const logger = vi.fn();
 
-    expect(reportMonitoringError('Error:', error, logger)).toBe(true);
+    reportMonitoringError('Error:', error, logger);
     expect(logger).toHaveBeenCalledWith('Error:', error);
   });
 });

--- a/packages/super-sync-server/tests/monitoring-scripts.spec.ts
+++ b/packages/super-sync-server/tests/monitoring-scripts.spec.ts
@@ -11,12 +11,18 @@ const mocks = vi.hoisted(() => {
     PrismaClient: vi.fn(function () {
       return prisma;
     }),
+    exec: vi.fn<(...args: unknown[]) => unknown>(),
   };
 });
 
 vi.mock('@prisma/client', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@prisma/client')>()),
   PrismaClient: mocks.PrismaClient,
+}));
+
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
+  exec: mocks.exec,
 }));
 
 const statementTimeout = (): Prisma.PrismaClientKnownRequestError =>
@@ -32,6 +38,7 @@ const statementTimeout = (): Prisma.PrismaClientKnownRequestError =>
 describe('monitoring script error handling', () => {
   let previousExitCode: typeof process.exitCode;
   let previousArgv: string[];
+  let consoleLog: ReturnType<typeof vi.spyOn>;
   let consoleError: ReturnType<typeof vi.spyOn>;
   let exit: ReturnType<typeof vi.spyOn>;
 
@@ -43,7 +50,8 @@ describe('monitoring script error handling', () => {
     process.exitCode = undefined;
     mocks.prisma.$queryRaw.mockReset();
     mocks.prisma.$disconnect.mockReset().mockResolvedValue();
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    mocks.exec.mockReset();
+    consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     exit = vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new Error(`Unexpected process.exit(${code})`);
@@ -56,7 +64,7 @@ describe('monitoring script error handling', () => {
     vi.restoreAllMocks();
   });
 
-  it('silently completes and disconnects when the monitor query times out', async () => {
+  it('reports a monitor query timeout and exits unsuccessfully', async () => {
     mocks.prisma.$queryRaw.mockRejectedValue(statementTimeout());
     process.argv = ['node', 'monitor.ts', 'usage', '--no-save'];
 
@@ -64,8 +72,10 @@ describe('monitoring script error handling', () => {
     await vi.waitFor(() => expect(mocks.prisma.$disconnect).toHaveBeenCalledOnce());
 
     expect(mocks.PrismaClient).toHaveBeenCalledWith({ log: [] });
-    expect(consoleError).not.toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error fetching usage data: PostgreSQL canceled this query because it exceeded statement_timeout.',
+    );
+    expect(process.exitCode).toBe(1);
     expect(exit).not.toHaveBeenCalled();
   });
 
@@ -78,19 +88,21 @@ describe('monitoring script error handling', () => {
     await vi.waitFor(() => expect(mocks.prisma.$disconnect).toHaveBeenCalledOnce());
 
     expect(consoleError).toHaveBeenCalledWith('Error fetching usage data:', error);
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(1);
     expect(exit).not.toHaveBeenCalled();
   });
 
-  it('silently completes and disconnects when the analysis query times out', async () => {
+  it('reports an analysis query timeout and exits unsuccessfully', async () => {
     mocks.prisma.$queryRaw.mockRejectedValue(statementTimeout());
     process.argv = ['node', 'analyze-storage.ts', 'operation-sizes'];
 
     await import('../scripts/analyze-storage');
     await vi.waitFor(() => expect(mocks.prisma.$disconnect).toHaveBeenCalledOnce());
 
-    expect(consoleError).not.toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error: PostgreSQL canceled this query because it exceeded statement_timeout.',
+    );
+    expect(process.exitCode).toBe(1);
     expect(exit).not.toHaveBeenCalled();
   });
 
@@ -103,6 +115,49 @@ describe('monitoring script error handling', () => {
     await vi.waitFor(() => expect(mocks.prisma.$disconnect).toHaveBeenCalledOnce());
 
     expect(consoleError).toHaveBeenCalledWith('Error:', error);
+    expect(process.exitCode).toBe(1);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('continues the monitoring suite after child failures and exits unsuccessfully', async () => {
+    let invocation = 0;
+    mocks.exec.mockImplementation((...args: unknown[]) => {
+      const callback = args.at(-1);
+      if (typeof callback !== 'function') {
+        throw new Error('Expected exec callback');
+      }
+      invocation += 1;
+      const isMaxBufferFailure = invocation === 1;
+      const stderr = isMaxBufferFailure ? 'ExperimentalWarning' : 'query timed out';
+      callback(
+        Object.assign(
+          new Error(
+            isMaxBufferFailure
+              ? 'stdout maxBuffer length exceeded'
+              : 'Command failed: monitor\nquery timed out',
+          ),
+          {
+            stdout: 'partial output',
+            stderr,
+          },
+        ),
+      );
+    });
+    process.argv = ['node', 'run-all-monitoring.ts', '--quick'];
+
+    await import('../scripts/run-all-monitoring');
+    await vi.waitFor(() => expect(mocks.exec).toHaveBeenCalledTimes(8));
+
+    expect(consoleLog).toHaveBeenCalledWith('⚠️ Monitoring completed with errors.\n');
+    expect(consoleLog).not.toHaveBeenCalledWith('✅ Monitoring complete!\n');
+    expect(consoleError).toHaveBeenCalledTimes(8);
+    expect(String(consoleError.mock.calls[0][0])).toContain(
+      'stdout maxBuffer length exceeded',
+    );
+    expect(String(consoleError.mock.calls[0][0])).toContain('ExperimentalWarning');
+    for (const [message] of consoleError.mock.calls.slice(1)) {
+      expect(String(message).match(/query timed out/g)).toHaveLength(1);
+    }
     expect(process.exitCode).toBe(1);
     expect(exit).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- report PostgreSQL statement timeouts instead of silently printing empty monitoring sections
- make individual monitoring commands return a nonzero exit status after query failures
- let the aggregate monitoring runner continue remaining analyses while reporting an overall failure
- preserve execution-level child-process errors without duplicating stderr

## Root cause

The monitoring error helper treated Prisma statement-timeout errors as intentionally silent. Large exact-analysis queries could therefore be canceled by PostgreSQL while the scripts printed only their headings and exited successfully.

## Impact

Operators now receive a concise timeout explanation and a failing process status. Existing exact/all-history query semantics are unchanged.

## Validation

- `npm run checkFile` for all six modified TypeScript files
- `npm test -- tests/monitoring-db.spec.ts tests/monitoring-scripts.spec.ts` (10 tests)
- `npm run build` in `packages/super-sync-server`
- full `npm test` (package tests, 13,788 primary Angular tests, and 13,774 timezone tests)
- repository lint and commit hooks
- multi-agent review, including an exact-commit pass with no remaining findings
