### PR TITLE
feat(sync): default superSync.baseUrl to window.location.origin when …

### DIFF
--- a/src/app/features/config/default-global-config.const.ts
+++ b/src/app/features/config/default-global-config.const.ts
@@ -10,6 +10,9 @@ import { INBOX_PROJECT } from '../project/project.const';
 import { DEFAULT_MAX_BACKUP_FILES } from '../../../../electron/shared-with-frontend/backup-file-cleanup.util';
 
 const minute = 60 * 1000;
+const isServedFromBundledSyncServer = (): boolean =>
+  typeof window !== 'undefined' && window.location.pathname.startsWith('/app/');
+
 const defaultTaskNotesTemplate = `**How can I best achieve it now?**
 
 **What do I want?**
@@ -251,9 +254,11 @@ export const DEFAULT_GLOBAL_CONFIG: GlobalConfigState = {
     },
 
     superSync: {
-      baseUrl: environment.production
-        ? 'https://sync.super-productivity.com'
-        : 'http://localhost:1901',
+      baseUrl: isServedFromBundledSyncServer()
+        ? window.location.origin
+        : environment.production
+          ? 'https://sync.super-productivity.com'
+          : 'http://localhost:1901',
       userName: null,
       password: null,
       accessToken: null,


### PR DESCRIPTION
…bundled #9400

## Problem

Self-hosting Super Productivity today requires the web client to load from
`app.super-productivity.com` even when running your own SuperSync server —
so self-hosters running the sync server still have to manually enter a
custom `superSync.baseUrl` to point the app at their own instance instead
of the hosted one.

## Solution

Adds a small detection helper, `isServedFromBundledSyncServer()`, that
checks whether the app is currently being served from a `/app/` path (the
path the bundled SuperSync server image will serve the static web app
from, per the design in #9400). When true, `superSync.baseUrl` now
defaults to `window.location.origin` — i.e. the same server the page is
already being served from — instead of the hardcoded hosted URL. This
requires zero configuration from the self-hoster: syncing "just works"
against their own server the moment the app loads under `/app/`.

Behavior is unchanged for the existing hosted web app, Electron, and
mobile builds, since none of those are served from a `/app/` path.

This addresses the first acceptance criterion in #9400 — "syncs against
the same origin with no manual URL entry" — and is scoped to just the
config-default piece of that issue; the Dockerfile build stage, static
serving, and landing-page link are separate, not part of this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)