### PR TITLE
fix(header): show add-task button before initial data load finishes

### DIFF
--- a/src/app/core-ui/main-header/main-header.component.html
+++ b/src/app/core-ui/main-header/main-header.component.html
@@ -1,34 +1,39 @@
 <div class="wrapper">
   @if (isDataLoaded()) {
     <page-title></page-title>
+  }
 
-    <nav class="action-nav-right">
-      <div class="header-action-group primary-action-group">
-        @if (isTimeTrackingEnabled()) {
-          <play-button
-            [currentTask]="currentTask()"
-            [currentTaskId]="currentTaskId()"
-            [currentTaskContext]="currentTaskContext()"
-            [hasTrackableTasks]="hasTrackableTasks()"
-          ></play-button>
-        }
+  <nav class="action-nav-right">
+    <div class="header-action-group primary-action-group">
+      @if (isDataLoaded() && isTimeTrackingEnabled()) {
+        <play-button
+          [currentTask]="currentTask()"
+          [currentTaskId]="currentTaskId()"
+          [currentTaskContext]="currentTaskContext()"
+          [hasTrackableTasks]="hasTrackableTasks()"
+        ></play-button>
+      }
 
-        @if (showDesktopButtons()) {
-          <button
-            emlDrop
-            (click)="layoutService.showAddTaskBar()"
-            matTooltip="{{ T.MH.ADD_NEW_TASK | translate }} {{
-              kb.addNewTask ? '[' + kb.addNewTask + ']' : ''
-            }}"
-            class="tour-addBtn"
-            color="primary"
-            mat-icon-button
-          >
-            <mat-icon>add</mat-icon>
-          </button>
-        }
-      </div>
+      <!-- Not gated on isDataLoaded: the shell paints before op-log hydration
+           finishes, and the primary quick-capture entry point must not be
+           missing for that window. -->
+      @if (showDesktopButtons()) {
+        <button
+          emlDrop
+          (click)="layoutService.showAddTaskBar()"
+          matTooltip="{{ T.MH.ADD_NEW_TASK | translate }} {{
+            kb.addNewTask ? '[' + kb.addNewTask + ']' : ''
+          }}"
+          class="tour-addBtn"
+          color="primary"
+          mat-icon-button
+        >
+          <mat-icon>add</mat-icon>
+        </button>
+      }
+    </div>
 
+    @if (isDataLoaded()) {
       <div class="header-action-group secondary-action-group counters-action-group">
         <!-- Focus button: keep the entry point discoverable on desktop and mobile. -->
         @if (isFocusButtonVisible()) {
@@ -166,6 +171,6 @@
           </div>
         }
       }
-    </nav>
-  }
+    }
+  </nav>
 </div>

--- a/src/app/core-ui/main-header/main-header.component.spec.ts
+++ b/src/app/core-ui/main-header/main-header.component.spec.ts
@@ -129,6 +129,7 @@ describe('MainHeaderComponent focus button visibility', () => {
   let isXxxs = signal(false);
   let appFeatures = signal(DEFAULT_GLOBAL_CONFIG.appFeatures);
   let enabledSimpleCounters: SimpleCounter[] = [];
+  let isAllDataLoaded = true;
 
   const configureTestBed = (): void => {
     const cfg = {
@@ -209,7 +210,7 @@ describe('MainHeaderComponent focus button visibility', () => {
         { provide: Store, useValue: { dispatch: jasmine.createSpy('dispatch') } },
         {
           provide: DataInitStateService,
-          useValue: { isAllDataLoadedInitially$: of(true) },
+          useValue: { isAllDataLoadedInitially$: isAllDataLoaded ? of(true) : EMPTY },
         },
         { provide: MetricService, useValue: { getFocusSummaryForDay: () => null } },
         { provide: DateService, useValue: { todayStr: () => '2026-06-09' } },
@@ -236,6 +237,7 @@ describe('MainHeaderComponent focus button visibility', () => {
     isXxxs = signal(false);
     appFeatures = signal(DEFAULT_GLOBAL_CONFIG.appFeatures);
     enabledSimpleCounters = [];
+    isAllDataLoaded = true;
   });
 
   afterEach(() => {
@@ -315,6 +317,21 @@ describe('MainHeaderComponent focus button visibility', () => {
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
     expect(menu.getAttribute('aria-hidden')).toBe('false');
     expect(menu.inert).toBe(false);
+  });
+
+  it('shows the add-task button before initial data load finishes', () => {
+    // The shell paints before op-log hydration completes; the quick-capture
+    // entry point must already be there in that window, while the
+    // data-dependent header parts still wait for the data-loaded signal.
+    isAllDataLoaded = false;
+
+    configureTestBed();
+    fixture = TestBed.createComponent(MainHeaderComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.tour-addBtn')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('page-title')).toBeFalsy();
+    expect(fixture.nativeElement.querySelector('.counters-action-group')).toBeFalsy();
   });
 
   it('keeps a persistent recovery action instead of showing routine sync success', async () => {

--- a/src/app/core-ui/main-header/main-header.component.ts
+++ b/src/app/core-ui/main-header/main-header.component.ts
@@ -234,8 +234,8 @@ export class MainHeaderComponent implements OnDestroy {
     // vertical strip escapes any ancestor containing-block
     // (transform/filter/contain) and reliably anchors to the viewport.
     // Reacts live to the config toggle and the desktop/mobile breakpoint;
-    // also re-runs once the nav enters the DOM (it sits behind
-    // @if(isDataLoaded())).
+    // also re-runs when data load fills in the nav's gated content (the nav
+    // shell itself renders from first paint).
     effect(() => {
       const enabled = this._isVerticalActionBar();
       this.isDataLoaded();


### PR DESCRIPTION
The whole header action nav (page-title, play button, add-task button,
sync icon, panel toggles) was deferred behind isDataLoaded(), added with
the onboarding entrance animations. Since the app shell paints before
op-log hydration completes, a fast UI load left the header without any
add-task button for the duration of hydration (a second or two).

Render the action nav shell and the add-task button immediately — it
only dispatches the layout action and has no data dependency — while
the data-dependent header parts (page title, play button, counters,
sync, panel buttons) keep waiting for the data-loaded signal.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XPNieHCttFpE3xaGNBx8U3