### PR TITLE
fix(plugins): sanitize plugin SVG icons at both HTML sinks

### DIFF
--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -219,3 +219,87 @@ describe('resolveBackground()', () => {
     });
   });
 });
+
+describe('GlobalThemeService.registerSvgIconFromContent()', () => {
+  interface IconRegistrationHarness {
+    registerSvgIconFromContent(iconName: string, svgContent: string): void;
+    _registeredPluginIcons: Set<string>;
+    _matIconRegistry: { addSvgIconLiteral: jasmine.Spy };
+    _domSanitizer: { bypassSecurityTrustHtml: (value: string) => string };
+  }
+
+  let harness: IconRegistrationHarness;
+
+  beforeEach(() => {
+    harness = Object.create(GlobalThemeService.prototype) as IconRegistrationHarness;
+    harness._registeredPluginIcons = new Set<string>();
+    harness._matIconRegistry = {
+      addSvgIconLiteral: jasmine.createSpy('addSvgIconLiteral'),
+    };
+    harness._domSanitizer = { bypassSecurityTrustHtml: (value: string) => value };
+  });
+
+  /** MatIconRegistry parses the registered literal with `div.innerHTML`. */
+  const renderRegisteredLiteral = (): HTMLDivElement => {
+    const div = document.createElement('div');
+    div.innerHTML = harness._matIconRegistry.addSvgIconLiteral.calls.mostRecent()
+      .args[1] as string;
+    return div;
+  };
+
+  it('registers a benign plugin icon', () => {
+    harness.registerSvgIconFromContent(
+      'plugin-a-icon',
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M1 2"></path></svg>',
+    );
+
+    expect(harness._matIconRegistry.addSvgIconLiteral).toHaveBeenCalledTimes(1);
+    expect(renderRegisteredLiteral().querySelector('path')?.getAttribute('d')).toBe(
+      'M1 2',
+    );
+    expect(harness._registeredPluginIcons.has('plugin-a-icon')).toBe(true);
+  });
+
+  it('does not register content that is not an SVG', () => {
+    harness.registerSvgIconFromContent('plugin-b-icon', '<div>nope</div>');
+
+    expect(harness._matIconRegistry.addSvgIconLiteral).not.toHaveBeenCalled();
+    expect(harness._registeredPluginIcons.has('plugin-b-icon')).toBe(false);
+  });
+
+  it('registers no live markup for a plugin icon that smuggles CDATA', () => {
+    harness.registerSvgIconFromContent(
+      'plugin-c-icon',
+      '<svg xmlns="http://www.w3.org/2000/svg"><desc><![CDATA[><img src=x onerror="window.alert(1)">]]></desc><circle r="4"></circle></svg>',
+    );
+
+    expect(harness._matIconRegistry.addSvgIconLiteral).toHaveBeenCalledTimes(1);
+    const rendered = renderRegisteredLiteral();
+    expect(rendered.querySelector('img')).toBeNull();
+    expect(rendered.querySelector('[onerror]')).toBeNull();
+    expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('4');
+  });
+
+  it('does not register an icon whose content is entirely stripped', () => {
+    harness.registerSvgIconFromContent(
+      'plugin-e-icon',
+      '<svg xmlns="http://www.w3.org/2000/svg"><desc><![CDATA[><img src=x onerror="window.alert(1)">]]></desc></svg>',
+    );
+
+    // Registering an empty literal would make `hasPluginIcon()` true, so callers would pick
+    // this icon name over their own fallback and render nothing.
+    expect(harness._matIconRegistry.addSvgIconLiteral).not.toHaveBeenCalled();
+    expect(harness._registeredPluginIcons.has('plugin-e-icon')).toBe(false);
+  });
+
+  it('strips an event handler from a plugin icon before registering it', () => {
+    harness.registerSvgIconFromContent(
+      'plugin-d-icon',
+      '<svg xmlns="http://www.w3.org/2000/svg" onload="window.alert(1)"><circle r="4"></circle></svg>',
+    );
+
+    const rendered = renderRegisteredLiteral();
+    expect(rendered.querySelector('svg')?.getAttribute('onload')).toBeNull();
+    expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('4');
+  });
+});

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -58,9 +58,10 @@ import { StatusBar, Style } from '@capacitor/status-bar';
 import { SafeArea } from 'capacitor-plugin-safe-area';
 import { patchCdkViewportForSafeArea } from './cdk-safe-area-viewport.util';
 import { LS } from '../persistence/storage-keys.const';
-import { Log } from '../log';
+import { Log, PluginLog } from '../log';
 import { LayoutService } from '../../core-ui/layout/layout.service';
 import { sanitizeIosKeyboardHeight } from './sanitize-ios-keyboard-height.util';
+import { sanitizeSvgIconContent } from '../../util/sanitize-svg-icon.util';
 import { CustomThemeService, getRequiredThemeMode } from './custom-theme.service';
 
 interface NavigationBarPlugin {
@@ -436,12 +437,21 @@ export class GlobalThemeService {
     return this._registeredPluginIcons.has(iconName);
   }
 
+  /**
+   * `svgContent` comes from a plugin, so it is untrusted. `MatIconRegistry` parses the
+   * literal with `div.innerHTML`, which makes this the trust boundary for that sink.
+   */
   registerSvgIconFromContent(iconName: string, svgContent: string): void {
     // Plugin icon is already registered, skip
     if (this._registeredPluginIcons.has(iconName)) return;
+    const safeSvgContent = sanitizeSvgIconContent(svgContent);
+    if (!safeSvgContent) {
+      PluginLog.warn(`Skipping unsafe or invalid SVG icon: ${iconName}`);
+      return;
+    }
     this._matIconRegistry.addSvgIconLiteral(
       iconName,
-      this._domSanitizer.bypassSecurityTrustHtml(svgContent),
+      this._domSanitizer.bypassSecurityTrustHtml(safeSvgContent),
     );
     this._registeredPluginIcons.add(iconName);
   }

--- a/src/app/plugins/plugin.service.ts
+++ b/src/app/plugins/plugin.service.ts
@@ -37,6 +37,7 @@ import { IssueSyncAdapterRegistryService } from '../features/issue/two-way-sync/
 import { SnackService } from '../core/snack/snack.service';
 import { pingWithRetry } from './util/ping-with-retry.util';
 import { PluginBridgeService } from './plugin-bridge.service';
+import { sanitizeSvgIconContent } from '../util/sanitize-svg-icon.util';
 
 // Each plugin's `id` (from its manifest.json, distinct from the asset path
 // here) becomes the entityId prefix for all data it persists via
@@ -1372,11 +1373,13 @@ export class PluginService implements OnDestroy {
             }),
           );
         }
-        iconContent = new TextDecoder().decode(iconBytes);
-        // Basic SVG validation
-        if (!iconContent.includes('<svg') || !iconContent.includes('</svg>')) {
-          PluginLog.err(`Plugin icon ${manifest.icon} does not appear to be a valid SVG`);
-          iconContent = null;
+        // Sanitize before caching, so anything installed from here on is stored clean.
+        // Icons cached before this existed are still raw, so both sinks sanitize as well.
+        iconContent = sanitizeSvgIconContent(new TextDecoder().decode(iconBytes));
+        if (!iconContent) {
+          PluginLog.err(
+            `Plugin icon ${manifest.icon} could not be sanitized into a renderable SVG icon`,
+          );
         }
       }
 

--- a/src/app/plugins/ui/plugin-icon/plugin-icon.component.spec.ts
+++ b/src/app/plugins/ui/plugin-icon/plugin-icon.component.spec.ts
@@ -1,0 +1,74 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PluginIconComponent } from './plugin-icon.component';
+import { PluginService } from '../../plugin.service';
+
+/**
+ * The component binds plugin supplied markup to `[innerHTML]`, so these specs assert on
+ * the DOM the browser actually builds from it rather than on the string itself.
+ */
+describe('PluginIconComponent', () => {
+  const PLUGIN_ID = 'test-plugin';
+
+  const renderIcon = (iconContent: string): ComponentFixture<PluginIconComponent> => {
+    const icons = signal<ReadonlyMap<string, string>>(
+      new Map([[PLUGIN_ID, iconContent]]),
+    );
+    TestBed.configureTestingModule({
+      imports: [PluginIconComponent],
+      providers: [
+        { provide: PluginService, useValue: { getPluginIconsSignal: () => icons } },
+      ],
+    });
+    const fixture = TestBed.createComponent(PluginIconComponent);
+    fixture.componentRef.setInput('pluginId', PLUGIN_ID);
+    fixture.detectChanges();
+    return fixture;
+  };
+
+  it('renders a benign plugin icon', () => {
+    const el: HTMLElement = renderIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M1 2"></path></svg>',
+    ).nativeElement;
+
+    expect(el.querySelector('svg')).not.toBeNull();
+    expect(el.querySelector('path')?.getAttribute('d')).toBe('M1 2');
+  });
+
+  it('falls back to the mat-icon when the content is not an SVG', () => {
+    const el: HTMLElement = renderIcon('<div>nope</div>').nativeElement;
+
+    expect(el.querySelector('.plugin-svg-icon')).toBeNull();
+    expect(el.querySelector('mat-icon')).not.toBeNull();
+  });
+
+  it('falls back to the mat-icon when nothing drawable survives sanitization', () => {
+    // `SafeHtml` is an object, so an empty-but-valid `<svg>` would satisfy the template's
+    // `@if` and paint a blank box instead of the fallback.
+    const el: HTMLElement = renderIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,iVBOR"></image></svg>',
+    ).nativeElement;
+
+    expect(el.querySelector('.plugin-svg-icon')).toBeNull();
+    expect(el.querySelector('mat-icon')).not.toBeNull();
+  });
+
+  it('does not render smuggled markup from a CDATA payload', () => {
+    const el: HTMLElement = renderIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg"><desc><![CDATA[><img src=x onerror="window.alert(1)">]]></desc></svg>',
+    ).nativeElement;
+
+    expect(el.querySelector('img')).toBeNull();
+    expect(el.querySelector('[onerror]')).toBeNull();
+  });
+
+  it('strips event handlers but keeps the drawable shapes', () => {
+    const el: HTMLElement = renderIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg" onload="window.alert(1)"><circle r="4" onclick="window.alert(1)"></circle></svg>',
+    ).nativeElement;
+
+    expect(el.querySelector('svg')?.getAttribute('onload')).toBeNull();
+    expect(el.querySelector('circle')?.getAttribute('onclick')).toBeNull();
+    expect(el.querySelector('circle')?.getAttribute('r')).toBe('4');
+  });
+});

--- a/src/app/plugins/ui/plugin-icon/plugin-icon.component.ts
+++ b/src/app/plugins/ui/plugin-icon/plugin-icon.component.ts
@@ -8,6 +8,7 @@ import {
 import { DomSanitizer } from '@angular/platform-browser';
 import { PluginService } from '../../plugin.service';
 import { MatIcon } from '@angular/material/icon';
+import { sanitizeSvgIconContent } from '../../../util/sanitize-svg-icon.util';
 
 @Component({
   selector: 'plugin-icon',
@@ -69,6 +70,9 @@ export class PluginIconComponent {
       return null;
     }
 
-    return this._sanitizer.bypassSecurityTrustHtml(iconContent);
+    // Plugin supplied markup lands in `[innerHTML]` below, so it has to be sanitized
+    // before it can be trusted.
+    const safeSvg = sanitizeSvgIconContent(iconContent);
+    return safeSvg ? this._sanitizer.bypassSecurityTrustHtml(safeSvg) : null;
   });
 }

--- a/src/app/util/sanitize-svg-icon.util.spec.ts
+++ b/src/app/util/sanitize-svg-icon.util.spec.ts
@@ -1,0 +1,385 @@
+import { sanitizeSvgIconContent } from './sanitize-svg-icon.util';
+
+/**
+ * The sanitizer output is only ever consumed by an HTML parser:
+ * `MatIconRegistry._svgElementFromString()` assigns it to `div.innerHTML` and
+ * `PluginIconComponent` binds it to `[innerHTML]`. Asserting on the returned *string*
+ * alone proves nothing about the tree those sinks build, so every payload below is
+ * re-parsed the same way the sink parses it before being inspected.
+ */
+const renderAtSink = (sanitized: string): HTMLDivElement => {
+  const div = document.createElement('div');
+  div.innerHTML = sanitized;
+  return div;
+};
+
+const sanitizeAndRender = (svg: string): HTMLDivElement =>
+  renderAtSink(sanitizeSvgIconContent(svg) ?? '');
+
+describe('sanitizeSvgIconContent', () => {
+  describe('rejects input that is not a single SVG root', () => {
+    it('returns null for non-svg markup', () => {
+      expect(sanitizeSvgIconContent('<div>not svg</div>')).toBeNull();
+    });
+
+    it('returns null for empty and blank input', () => {
+      expect(sanitizeSvgIconContent('')).toBeNull();
+      expect(sanitizeSvgIconContent('   \n ')).toBeNull();
+    });
+
+    it('returns null when the svg is not the first element', () => {
+      expect(
+        sanitizeSvgIconContent('<img src="x"><svg><circle r="1"></circle></svg>'),
+      ).toBeNull();
+    });
+
+    it('returns null when the svg is wrapped in another element', () => {
+      // Rejected because `firstElementChild` is the `<math>`, not the `<svg>`. Naming this
+      // after the namespace check would overstate it: that check is unreachable today.
+      expect(
+        sanitizeSvgIconContent('<math><svg><circle r="1"></circle></svg></math>'),
+      ).toBe(null);
+    });
+  });
+
+  describe('rejects an icon with nothing left to draw', () => {
+    // An empty `<svg>` is not the same as no icon: it paints a blank box and suppresses the
+    // caller's fallback, so it has to be reported as unusable.
+    it('returns null when an embedded <image> is the only content', () => {
+      expect(
+        sanitizeSvgIconContent(
+          '<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,iVBOR"></image></svg>',
+        ),
+      ).toBeNull();
+    });
+
+    it('returns null for an Illustrator <switch> wrapper', () => {
+      expect(
+        sanitizeSvgIconContent(
+          '<svg xmlns="http://www.w3.org/2000/svg"><switch><g><path d="M2 2h20v20H2z"></path></g></switch></svg>',
+        ),
+      ).toBeNull();
+    });
+
+    it('returns null when only bare text survives', () => {
+      expect(sanitizeSvgIconContent('<svg>hello</svg>')).toBeNull();
+    });
+
+    it('keeps an icon that still has one drawable child', () => {
+      expect(
+        sanitizeSvgIconContent(
+          '<svg xmlns="http://www.w3.org/2000/svg"><script>x</script><path d="M1 2"></path></svg>',
+        ),
+      ).toContain('<path d="M1 2">');
+    });
+  });
+
+  describe('keeps real icons intact', () => {
+    it('preserves shapes, presentation attributes and camelCase attribute names', () => {
+      const sanitized = sanitizeSvgIconContent(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">' +
+          '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>' +
+          '<line x1="16" y1="2" x2="16" y2="6"></line>' +
+          '<path d="M8 14h.01M12 14h.01"></path>' +
+          '</svg>',
+      );
+
+      expect(sanitized).not.toBeNull();
+      const svg = sanitizeAndRender(sanitized as string).querySelector('svg');
+      expect(svg).not.toBeNull();
+      expect(svg?.getAttribute('viewBox')).toBe('0 0 24 24');
+      expect(svg?.getAttribute('stroke')).toBe('currentColor');
+      expect(svg?.getAttribute('stroke-width')).toBe('2');
+      expect(svg?.querySelector('rect')?.getAttribute('rx')).toBe('2');
+      expect(svg?.querySelector('line')?.getAttribute('x1')).toBe('16');
+      expect(svg?.querySelector('path')?.getAttribute('d')).toBe('M8 14h.01M12 14h.01');
+    });
+
+    it('preserves a gradient referenced by a same-document fragment', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<defs><linearGradient id="g"><stop offset="0" stop-color="#f00"></stop></linearGradient></defs>' +
+          '<rect width="8" height="8" fill="url(#g)"></rect>' +
+          '</svg>',
+      );
+
+      expect(rendered.querySelector('linearGradient')?.getAttribute('id')).toBe('g');
+      expect(rendered.querySelector('stop')?.getAttribute('stop-color')).toBe('#f00');
+      expect(rendered.querySelector('rect')?.getAttribute('fill')).toBe('url(#g)');
+    });
+
+    it('preserves text content as text', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><text x="1" y="2">API</text></svg>',
+      );
+
+      expect(rendered.querySelector('text')?.textContent).toBe('API');
+    });
+  });
+
+  describe('strips script-bearing attributes', () => {
+    it('drops event handlers', () => {
+      const rendered = sanitizeAndRender(
+        '<svg onload="window.alert(1)"><circle cx="5" cy="5" r="4" onclick="window.alert(1)"></circle></svg>',
+      );
+
+      expect(rendered.querySelector('svg')?.getAttribute('onload')).toBeNull();
+      expect(rendered.querySelector('circle')?.getAttribute('onclick')).toBeNull();
+      expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('4');
+    });
+
+    it('drops style attributes', () => {
+      const rendered = sanitizeAndRender(
+        '<svg><circle r="4" style="background:url(https://evil.test/x)"></circle></svg>',
+      );
+
+      expect(rendered.querySelector('circle')?.getAttribute('style')).toBeNull();
+    });
+  });
+
+  describe('entity-encoded markup stays text', () => {
+    // The parser decodes `&lt;img ...&gt;` into a plain text node. Re-emitting that node
+    // verbatim would hand the sink live markup, so the value has to be encoded again on
+    // the way out.
+    it('does not release escaped markup from a text node', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><text>&lt;img src=x onerror=window.alert(1)&gt;</text></svg>',
+      );
+
+      expect(rendered.querySelector('img')).toBeNull();
+      expect(rendered.querySelector('text')?.textContent).toBe(
+        '<img src=x onerror=window.alert(1)>',
+      );
+    });
+
+    it('normalizes an attribute name that lowercases into the allowlist', () => {
+      // `'K'.toLowerCase()` is `k`, so `stroKe` passes an allowlist keyed on the
+      // lowercased name. Emitting the parsed spelling would put a name on the element that
+      // is not the one that was checked.
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect stroKe="red" width="1" height="1"></rect></svg>',
+      );
+      const rect = rendered.querySelector('rect');
+
+      expect(rect?.getAttribute('stroke')).toBe('red');
+      expect(rect?.getAttribute('stroKe')).toBeNull();
+    });
+
+    it('keeps camelCase svg attributes readable through the sink', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 4"><linearGradient id="g" gradientUnits="userSpaceOnUse"></linearGradient></svg>',
+      );
+
+      expect(rendered.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 4 4');
+      expect(
+        rendered.querySelector('linearGradient')?.getAttribute('gradientUnits'),
+      ).toBe('userSpaceOnUse');
+    });
+
+    it('does not let an attribute value break out of its quotes', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r=\'1" onload="window.alert(1)\'></circle></svg>',
+      );
+
+      expect(rendered.querySelector('circle')?.getAttribute('onload')).toBeNull();
+      expect(rendered.querySelector('[onload]')).toBeNull();
+    });
+  });
+
+  describe('mXSS: CDATA re-parsed as HTML at an SVG integration point', () => {
+    // `<desc>`, `<title>` and `<foreignObject>` are HTML integration points: inside them
+    // the HTML parser switches back to HTML content mode. An XML-based sanitizer re-emits
+    // `<![CDATA[..]]>` faithfully, and the HTML parser then reads it as a bogus comment
+    // that ends at the first `>`, releasing the rest as live markup.
+    (['desc', 'title', 'foreignObject'] as const).forEach((tag) => {
+      it(`does not smuggle live markup through <${tag}> CDATA`, () => {
+        const rendered = sanitizeAndRender(
+          `<svg xmlns="http://www.w3.org/2000/svg"><${tag}><![CDATA[><img src=x onerror="window.alert(1)">]]></${tag}><circle r="7"></circle></svg>`,
+        );
+
+        expect(rendered.querySelector('img')).toBeNull();
+        expect(rendered.querySelector('[onerror]')).toBeNull();
+        // Positive control: without it an always-empty sanitizer would pass the two above.
+        expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('7');
+      });
+    });
+  });
+
+  describe('case-folded tag names', () => {
+    // XML type selectors match case sensitively, so a denylist built on
+    // `querySelectorAll('foreignObject')` misses `<FOREIGNOBJECT>`. The HTML parser at the
+    // sink then applies its SVG tag-name adjustment table and resurrects the real element.
+    it('does not let <FOREIGNOBJECT> survive', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><FOREIGNOBJECT><![CDATA[><img src=x onerror="window.alert(1)">]]></FOREIGNOBJECT><circle r="7"></circle></svg>',
+      );
+
+      expect(rendered.querySelector('foreignObject')).toBeNull();
+      expect(rendered.querySelector('img')).toBeNull();
+      expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('7');
+    });
+
+    it('does not let <STYLE> survive', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><STYLE>*{color:red}</STYLE><circle r="7"></circle></svg>',
+      );
+
+      expect(rendered.querySelector('style')).toBeNull();
+      expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('7');
+    });
+
+    it('drops <SCRIPT> regardless of case', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><SCRIPT>window.alert(1)</SCRIPT><circle r="1"></circle></svg>',
+      );
+
+      expect(rendered.querySelector('script')).toBeNull();
+      expect(rendered.querySelector('circle')).not.toBeNull();
+    });
+  });
+
+  describe('SMIL animation retargeting an href attribute', () => {
+    // No parse trick needed: the animation element carries no href of its own, so an
+    // attribute-value check never inspects it. `<set>`/`<animate>` write the `javascript:`
+    // URL onto the parent `<a>` at runtime, after sanitization has finished.
+    it('strips <set> that retargets href to a javascript: URL', () => {
+      const sanitized = sanitizeSvgIconContent(
+        '<svg xmlns="http://www.w3.org/2000/svg"><a><set attributeName="href" to="javascript:window.alert(1)"></set><text>x</text></a><circle r="7"></circle></svg>',
+      );
+
+      // Asserting only `not.toContain('javascript:')` would be vacuous: `to` is not an
+      // allowlisted attribute, so the string disappears whether or not `<set>` survives.
+      // The load-bearing assertion is that the animation element and its `<a>` target are
+      // both gone from the tree the sink builds.
+      const rendered = renderAtSink(sanitized as string);
+      expect(rendered.querySelector('set')).toBeNull();
+      expect(rendered.querySelector('a')).toBeNull();
+      expect(rendered.querySelector('[attributeName]')).toBeNull();
+      expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('7');
+    });
+
+    it('strips <animate> that retargets xlink:href to a javascript: URL', () => {
+      const sanitized = sanitizeSvgIconContent(
+        '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><a><animate attributeName="xlink:href" values="javascript:window.alert(1)" begin="0s"></animate><text>x</text></a><circle r="7"></circle></svg>',
+      );
+
+      const rendered = renderAtSink(sanitized as string);
+      expect(rendered.querySelector('animate')).toBeNull();
+      expect(rendered.querySelector('a')).toBeNull();
+      expect(rendered.querySelector('[attributeName]')).toBeNull();
+      expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('7');
+    });
+  });
+
+  describe('references may not leave the document', () => {
+    // `<use>` and every `href` are out of the allowlist entirely: nested `<use>` expands
+    // exponentially at render time and wedges the renderer, and removing them takes the
+    // whole "is this reference same-document?" question with it.
+    it('drops <use> and its href outright', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<use href="https://evil.test/icon.svg#x"></use>' +
+          '<use href="#local"></use>' +
+          '<circle r="7"></circle>' +
+          '</svg>',
+      );
+
+      expect(rendered.querySelector('use')).toBeNull();
+      expect(rendered.querySelector('[href]')).toBeNull();
+      expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('7');
+    });
+
+    it('drops an href whose fragment hides behind non-ASCII whitespace', () => {
+      // `String.prototype.trim()` strips U+00A0, the URL parser does not, so a `trim()`-based
+      // fragment check would keep a value that resolves to a request off the document.
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><use href=" #x"></use><circle r="7"></circle></svg>',
+      );
+
+      expect(rendered.querySelector('[href]')).toBeNull();
+      expect(rendered.querySelector('[*|href]')).toBeNull();
+    });
+
+    it('drops a css identifier escape that spells url(', () => {
+      // `\75 rl(` is `url(` once the CSS parser resolves the escape, so a regex looking for
+      // the literal spelling never sees it and Chrome resolves the fetch for real.
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="9" height="9" fill="\\75 rl(https://evil.test/x.svg#g)"></rect></svg>',
+      );
+
+      expect(rendered.querySelector('rect')?.getAttribute('fill')).toBeNull();
+      expect(rendered.querySelector('rect')?.getAttribute('width')).toBe('9');
+    });
+
+    it('resolves no external paint server for an escaped url', () => {
+      const host = document.createElement('div');
+      host.innerHTML =
+        sanitizeSvgIconContent(
+          '<svg xmlns="http://www.w3.org/2000/svg"><rect width="9" height="9" fill="\\75 rl(https://evil.test/x.svg#g)"></rect></svg>',
+        ) ?? '';
+      document.body.appendChild(host);
+      try {
+        const rect = host.querySelector('rect');
+        expect(rect).not.toBeNull();
+        // The decisive assertion: before the escape was refused this read back as
+        // `url("https://evil.test/x.svg#g")`, i.e. a live cross-origin fetch.
+        expect(getComputedStyle(rect as Element).fill).not.toContain('evil.test');
+      } finally {
+        document.body.removeChild(host);
+      }
+    });
+
+    it('drops a paint reference to a remote document', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="8" height="8" fill="url(https://evil.test/x#g)"></rect></svg>',
+      );
+
+      expect(rendered.querySelector('rect')?.getAttribute('fill')).toBeNull();
+      expect(rendered.querySelector('rect')?.getAttribute('width')).toBe('8');
+    });
+
+    it('keeps a fragment paint reference written with whitespace or quotes', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<rect id="a" width="8" height="8" fill="url( #g )"></rect>' +
+          `<rect id="b" width="8" height="8" fill="url('#g')"></rect>` +
+          '</svg>',
+      );
+
+      expect(rendered.querySelector('#a')?.getAttribute('fill')).toBe('url( #g )');
+      expect(rendered.querySelector('#b')?.getAttribute('fill')).toBe(`url('#g')`);
+    });
+
+    it('drops the attribute when only one of several url() refs leaves the document', () => {
+      const rendered = sanitizeAndRender(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="8" height="8" fill="url(#g) url(https://evil.test/x)"></rect></svg>',
+      );
+
+      expect(rendered.querySelector('rect')?.getAttribute('fill')).toBeNull();
+    });
+  });
+
+  describe('output is stable under re-parsing', () => {
+    // The sinks parse whatever we return. If sanitizing our own output changed it, the tree
+    // the sink builds would differ from the tree we audited -- exactly the class of bug
+    // that made every payload above exploitable.
+    const PAYLOADS = [
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M1 2"></path></svg>',
+      // Each hostile payload keeps one drawable child, so sanitizing yields a real string
+      // to re-sanitize rather than the trivially stable `null`.
+      '<svg><desc><![CDATA[><img src=x onerror="window.alert(1)">]]></desc><circle r="1"></circle></svg>',
+      '<svg><FOREIGNOBJECT><![CDATA[><img src=x onerror="window.alert(1)">]]></FOREIGNOBJECT><circle r="1"></circle></svg>',
+      '<svg><a><set attributeName="href" to="javascript:window.alert(1)"></set></a><circle r="1"></circle></svg>',
+      '<svg><text>a &amp; b &lt;c&gt; "d" \'e\'</text></svg>',
+      '<svg><defs><linearGradient id="g"><stop offset="0" stop-color="#f00"></stop></linearGradient></defs><rect width="8" height="8" fill="url(#g)"></rect></svg>',
+    ];
+
+    PAYLOADS.forEach((payload, i) => {
+      it(`is idempotent for payload ${i}`, () => {
+        const once = sanitizeSvgIconContent(payload);
+        expect(once).not.toBeNull();
+        expect(sanitizeSvgIconContent(once as string)).toBe(once as string);
+      });
+    });
+  });
+});

--- a/src/app/util/sanitize-svg-icon.util.ts
+++ b/src/app/util/sanitize-svg-icon.util.ts
@@ -1,0 +1,264 @@
+/**
+ * Sanitizer for plugin supplied SVG icon markup.
+ *
+ * Every consumer hands the result to `bypassSecurityTrustHtml()`, and both sinks feed it
+ * to an *HTML* parser: `MatIconRegistry` assigns it to `div.innerHTML` and
+ * `PluginIconComponent` binds it to `[innerHTML]`. Angular's own HTML sanitizer cannot be
+ * used here because its element allowlist contains no SVG tags at all, so it strips the
+ * `<svg>` root and `mat-icon` then throws.
+ *
+ * Two properties keep this safe, and the second is the one carrying the weight:
+ *
+ * 1. The input is parsed as `text/html` rather than `image/svg+xml`. Auditing an XML tree
+ *    would audit a document that never ships: `<![CDATA[..]]>` becomes a bogus comment that
+ *    ends at the first `>` inside an HTML integration point, and XML type selectors are case
+ *    sensitive while the HTML parser case-folds tag names back into `<foreignObject>`. Both
+ *    turn a clean XML audit into live markup at the sink. `DOMParser` documents also have no
+ *    browsing context, so this parse runs no scripts and loads no sub-resources. It is not
+ *    quite the sinks' parse mode though: scripting is disabled here and enabled there, which
+ *    the parser does observe (`<noscript>` nests differently), so this alone is not a
+ *    guarantee that both sides build the same tree.
+ *
+ * 2. The output string is rebuilt from scratch rather than re-serialized, which is what
+ *    makes the remaining differential harmless. Only allowlisted SVG elements and attributes
+ *    are emitted, names are normalized to their allowlisted spelling, and every text and
+ *    attribute value is entity-encoded. Nothing the parser did not already recognise as a
+ *    safe SVG node can reach the string, so re-parsing the output yields the same tree again
+ *    and there is no mXSS instability left for a stabilization loop to catch.
+ *
+ * The allowlist is deliberately limited to what draws an icon. Notably absent:
+ * `script`, `style`, `foreignObject`, `title`, `desc`, `a`, the SMIL `animate`/`set` family
+ * and `filter`. Also absent are `use`/`symbol` and every `href` attribute: nested `<use>`
+ * expands exponentially at render time, and a 1KB icon built that way wedges the renderer
+ * for tens of seconds. Dropping them takes the whole reference-attribute class with it, so
+ * there is no same-document-fragment check left to get subtly wrong. Gradients still work,
+ * because those are reached through `fill="url(#id)"` rather than through `href`.
+ * Two more consequences worth knowing before widening it:
+ *
+ * - Dropping `<style>` and the `style` attribute means an icon exported from Illustrator's
+ *   default "style elements" mode, or saved in Inkscape's default format, loses its paint
+ *   and renders with SVG's default fill. Plugin icons should use presentation attributes.
+ * - Dropping `<title>` costs the accessible name. Re-adding it is safe (see
+ *   `serializeElement`), it just puts an HTML integration point back in the output for
+ *   something that draws nothing, so the host component's `aria-label` is preferred.
+ */
+
+import { escapeHtml } from './escape-html';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const ALLOWED_TAGS: ReadonlySet<string> = new Set([
+  'svg',
+  'g',
+  'defs',
+  'path',
+  'circle',
+  'ellipse',
+  'line',
+  'polyline',
+  'polygon',
+  'rect',
+  'text',
+  'tspan',
+  'linearGradient',
+  'radialGradient',
+  'stop',
+  'clipPath',
+  'mask',
+  'pattern',
+  'marker',
+]);
+
+const ALLOWED_ATTRS: ReadonlySet<string> = new Set([
+  // identity / grouping. `class` is deliberately absent: `<style>` is stripped, so a class
+  // can no longer style the icon and would only risk colliding with app CSS.
+  'id',
+  'xmlns',
+  'version',
+  // geometry
+  'd',
+  'cx',
+  'cy',
+  'r',
+  'rx',
+  'ry',
+  'x',
+  'y',
+  'x1',
+  'y1',
+  'x2',
+  'y2',
+  'dx',
+  'dy',
+  'width',
+  'height',
+  'points',
+  'transform',
+  'viewbox',
+  'preserveaspectratio',
+  'pathlength',
+  // painting
+  'fill',
+  'fill-opacity',
+  'fill-rule',
+  'stroke',
+  'stroke-width',
+  'stroke-linecap',
+  'stroke-linejoin',
+  'stroke-dasharray',
+  'stroke-dashoffset',
+  'stroke-opacity',
+  'stroke-miterlimit',
+  'opacity',
+  'color',
+  'display',
+  'visibility',
+  'paint-order',
+  'shape-rendering',
+  'vector-effect',
+  // gradients and paint servers
+  'offset',
+  'stop-color',
+  'stop-opacity',
+  'gradientunits',
+  'gradienttransform',
+  'spreadmethod',
+  'fx',
+  'fy',
+  // clipping and masking
+  'clip-path',
+  'clip-rule',
+  'mask',
+  'clippathunits',
+  'maskunits',
+  'maskcontentunits',
+  'patternunits',
+  'patterncontentunits',
+  'patterntransform',
+  'markerwidth',
+  'markerheight',
+  'marker-start',
+  'marker-mid',
+  'marker-end',
+  'markerunits',
+  'orient',
+  'refx',
+  'refy',
+  // text
+  'font-family',
+  'font-size',
+  'font-style',
+  'font-weight',
+  'letter-spacing',
+  'text-anchor',
+  'dominant-baseline',
+]);
+
+/**
+ * Paint and clipping attributes may point at a paint server via `url(...)`. Anything but a
+ * same-document fragment would let an icon pull in a remote resource, so it is dropped.
+ */
+const URL_REF = /url\(\s*(['"]?)([^'")]*)/gi;
+
+const hasOnlyFragmentUrlRefs = (value: string): boolean => {
+  for (const match of value.matchAll(URL_REF)) {
+    if (!match[2].trimStart().startsWith('#')) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const safeAttrValue = (attr: Attr): string | null => {
+  const name = attr.name.toLowerCase();
+  if (!ALLOWED_ATTRS.has(name)) {
+    return null;
+  }
+  const value = attr.value;
+  // Presentation attributes are CSS, and CSS resolves identifier escapes before deciding
+  // what a token is: `\75 rl(https://evil.test/x)` is `url(...)` to the parser but not to
+  // any regex looking for the literal spelling. Chrome resolves it all the way to a live
+  // cross-origin fetch. Nothing an icon legitimately needs contains a backslash, so the
+  // whole escape class is refused rather than decoded.
+  if (value.includes('\\')) {
+    return null;
+  }
+  return hasOnlyFragmentUrlRefs(value) ? value : null;
+};
+
+const serializeAttrs = (el: Element): string => {
+  let out = '';
+  for (const attr of Array.from(el.attributes)) {
+    const value = safeAttrValue(attr);
+    if (value !== null) {
+      // Emit the lowercased name, not the parsed one. They are not always the same string:
+      // `toLowerCase()` maps U+212A KELVIN SIGN onto `k`, so `stro<U+212A>e` passes the
+      // allowlist while the original spelling reaches the sink as a dead attribute. Writing
+      // the normalized form makes the emitted name an allowlist member by construction, so
+      // it provably cannot carry a quote or an angle bracket. The HTML parser restores the
+      // canonical camelCase for SVG attributes (`viewbox` reads back as `viewBox`).
+      out += ` ${attr.name.toLowerCase()}="${escapeHtml(value)}"`;
+    }
+  }
+  return out;
+};
+
+/**
+ * A disallowed element takes its whole subtree with it: an icon has no reason to nest
+ * drawable content inside something we refuse to render.
+ *
+ * The namespace test is a cheap invariant, not the defence that closes any known bypass, and
+ * it is worth being precise about that. What closes the CDATA class is parsing as HTML and
+ * rebuilding the output: the `<![CDATA[` becomes a comment node that this loop drops, and
+ * whatever text survives is escaped. Measured against Chrome's parser, a non-SVG element can
+ * only become a descendant of an `<svg>` through an HTML integration point (`foreignObject`,
+ * `desc`, `title`), and HTML breakout tags such as `<div>` eject the rest of the markup out
+ * of the `<svg>` altogether. So with the current allowlist this test is unreachable, and it
+ * only starts doing work if an integration point is ever allowlisted AND the smuggled
+ * element shares a name with an allowlisted one (an XHTML `<text>`, say). Kept because that
+ * is cheaper than re-deriving the reachability argument every time the allowlist changes.
+ */
+const serializeElement = (el: Element): string => {
+  if (el.namespaceURI !== SVG_NS || !ALLOWED_TAGS.has(el.localName)) {
+    return '';
+  }
+
+  let out = `<${el.localName}${serializeAttrs(el)}>`;
+  for (const node of Array.from(el.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += escapeHtml(node.nodeValue ?? '');
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      out += serializeElement(node as Element);
+    }
+    // comments, CDATA sections and processing instructions are dropped
+  }
+
+  return `${out}</${el.localName}>`;
+};
+
+const SVG_CLOSE_TAG = '</svg>';
+
+/**
+ * Returns SVG markup that is safe to pass to `bypassSecurityTrustHtml()`, or `null` when
+ * the input is not a single SVG root or nothing drawable survived sanitization.
+ */
+export const sanitizeSvgIconContent = (svgContent: string): string | null => {
+  if (!svgContent?.trim()) {
+    return null;
+  }
+
+  const doc = new DOMParser().parseFromString(svgContent, 'text/html');
+  const root = doc.body?.firstElementChild;
+  if (!root || root.namespaceURI !== SVG_NS || root.localName !== 'svg') {
+    return null;
+  }
+
+  const serialized = serializeElement(root);
+  // Rejecting outright and rendering an empty `<svg>` are not the same thing to a caller:
+  // an empty icon still reads as "I have an icon", so it paints a blank box and suppresses
+  // the fallback. Anything an editor wraps in something we drop (Illustrator's `<switch>`,
+  // an embedded `<image>`) lands here, so report it as unusable. Attribute values and text
+  // are escaped, so a `<` left in the body can only be a child element we emitted.
+  const body = serialized.slice(serialized.indexOf('>') + 1, -SVG_CLOSE_TAG.length);
+  return body.includes('<') ? serialized : null;
+};


### PR DESCRIPTION
## Problem

Plugin supplied SVG icons reached `bypassSecurityTrustHtml()` behind nothing but an `includes('<svg')` check, so a plugin could execute arbitrary JS in the renderer through its `icon.svg`.

Both consumers hand the markup to an HTML parser:

- `MatIconRegistry._svgElementFromString()` assigns it to `div.innerHTML`
- `PluginIconComponent` binds it to `[innerHTML]`

The detached div `MatIconRegistry` uses is never appended to the document, but `innerHTML` alone already starts the image load, so an `onerror` handler fires from it.

The sharp end is that `_discoverUploadedPlugins()` calls `_registerPluginIcon()` unconditionally whenever a cached icon exists, with no `isEnabled` gate and `status: 'not-loaded'`. A **disabled, never-loaded uploaded plugin therefore executes JS in the main renderer at app startup, with nothing rendered.**

For an *enabled* plugin this is not an escalation, since plugin code already runs via `new Function` in the same renderer and the CSP is `script-src *` with `unsafe-inline`/`unsafe-eval`. The disabled-plugin path is the reason this is worth fixing.

Reported by @ghostkeni in #9077. This PR supersedes it: the finding and the four trust boundaries are theirs, the implementation is different.

## Why not an existing sanitizer

- `DomSanitizer.sanitize(SecurityContext.HTML, ...)` cannot be used. Angular's `VALID_ELEMENTS` contains no SVG tags at all, so it strips the `<svg>` root and `mat-icon` then throws `<svg> tag not found`. The `bypassSecurityTrustHtml` calls are genuinely necessary.
- DOMPurify is out under the repo's no-new-dependencies rule.

So a hand rolled sanitizer is the constraint. What matters is that it is an allowlist, and that it audits the document that actually ships.

## Solution

`sanitizeSvgIconContent()` in `src/app/util/sanitize-svg-icon.util.ts`, called at both `bypassSecurityTrustHtml` sinks and at zip extraction so the persisted copy is already clean.

Two properties carry the safety, and the second is the one doing the work:

1. **Input is parsed as `text/html`**, not as XML. Auditing an `image/svg+xml` tree audits a document that never ships: `<![CDATA[..]]>` survives XML serialization and the HTML parser then reads it as a bogus comment ending at the first `>` inside an HTML integration point, and XML type selectors are case sensitive while the HTML parser folds `<FOREIGNOBJECT>` back into a real element. `DOMParser` documents also have no browsing context, so the parse runs no scripts and loads no sub-resources. This is close to, but not exactly, the sinks' parse mode: scripting is disabled here and enabled there, and the parser does observe that (`<noscript>` nests differently), so property 1 alone is not a guarantee that both sides build the same tree.
2. **Output is rebuilt from scratch**, not re-serialized, which is what makes the residual differential harmless. Only allowlisted SVG elements and attributes are emitted, names are normalized to their allowlisted spelling, and every text and attribute value is entity-encoded. Nothing the parser did not already recognise as a safe SVG node can reach the string.

Property 2 is also why there is no mXSS stability loop. Angular's `_sanitizeHtml` needs one because it re-reads `inertBodyElement.innerHTML`, which is the browser's serialization of an attacker controlled tree and can be unstable. This never round-trips through `innerHTML`, so the instability source is removed rather than iterated against, and the loop would be a branch that cannot fire. Idempotence is asserted in the specs instead.

`<a>` and the SMIL `animate`/`set` family are simply absent from the allowlist, which kills the "retarget `href` to `javascript:` at runtime" class without any SMIL-specific logic.

`<use>`, `<symbol>` and every `href` attribute are absent too. Nested `<use>` expands exponentially at render time, and a 1 KB icon built that way wedges the renderer for tens of seconds; dropping it also removes the whole reference-attribute class, so there is no same-document-fragment check left to get subtly wrong. Gradients are unaffected because they are reached through `fill="url(#id)"`.

Attribute values containing a backslash are refused rather than decoded. Presentation attributes are CSS, and CSS resolves identifier escapes before deciding token types, so `\75 rl(https://evil.test/x)` is `url(...)` to the parser but not to any regex looking for the literal spelling; Chrome resolves it into a real cross-origin fetch.

An icon that sanitizes down to an empty `<svg>` is reported as `null` rather than returned. An empty icon is not the same as no icon to a caller: `bypassSecurityTrustHtml` returns a truthy object, so `PluginIconComponent`'s `@if` would take the icon branch and paint a blank box instead of falling back, and `registerSvgIconFromContent` would register the empty literal and make `hasPluginIcon()` beat the caller's own fallback.

## Known compatibility costs

- `<style>` and the `style` attribute are dropped, so an icon from Illustrator's default "style elements" export or Inkscape's default save format renders with SVG's default fill. Plugin icons should use presentation attributes.
- `<title>` is dropped, costing the accessible name. Re-adding it would be safe (the CDATA defence is the rebuild, not the tag exclusion); it is left out because it puts an HTML integration point back into the output for something that draws nothing, and the host component's `aria-label` is the better place for the name.
- `<filter>` and SMIL animation are dropped, so drop shadows and spinner icons degrade to static shapes.
- `<use>`/`<symbol>` sprite-style icons are dropped, so a single-file icon built that way renders empty and falls back to the generic plugin icon.

All 19 icons currently under `packages/plugin-dev/` are unaffected, with zero tags and zero attributes dropped.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## Verification

Every payload is asserted against the DOM the sink actually builds, never the returned string. Asserting on the string is precisely what made the original specs structurally unable to observe this bug class.

- Run against #9077's sanitizer, 22 of the 74 specs across the three touched spec files fail, surfacing a live `<img src="x" onerror="window.alert(1)">` in the rendered DOM.
- Reverting the sanitize call in `PluginIconComponent` fails 3 of its 4 specs and renders a live `<img onerror>` inside the real component. Reverting it in `GlobalThemeService` fails 3 of its specs.
- Neutering the output encoding to the identity function produces a live `onload` attribute and a live `<img onerror>`; escaping is load bearing, since the parser hands back `&lt;img ...&gt;` already decoded into a text node.
- Every absence-only assertion carries a positive control, so a sanitizer returning an empty `<svg></svg>` for everything cannot pass. That mutation fails 24 of the sanitizer specs.
- All 19 real plugin icons under `packages/plugin-dev/` round-trip with zero drawable elements and zero attributes dropped. That oracle was checked by removing `viewBox` from the allowlist, which fails it.
- 1475 specs green across `src/app/plugins`, `src/app/core/theme` and `src/app/util`. Production AOT build clean. `npm run checkFile` clean on all 7 touched files.

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format
