### PR TITLE
ci(supersync): serialize image publishing

### DIFF
--- a/.github/workflows/supersync-docker.yml
+++ b/.github/workflows/supersync-docker.yml
@@ -20,6 +20,11 @@ on:
         type: boolean
         default: true
 
+# Every run publishes the same mutable `latest` tag, so only the newest may push.
+concurrency:
+  group: supersync-docker-publish
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     name: Build and Push to GHCR


### PR DESCRIPTION
## Summary

- serialize SuperSync GHCR publishing under one workflow concurrency group
- cancel superseded runs so older builds cannot overwrite the mutable `latest` tag
- prevent overlapping pushes from triggering GHCR authorization and blob-check failures

## Context

GitHub Actions run https://github.com/super-productivity/super-productivity/actions/runs/30894293990 overlapped with several other master builds. It pushed `latest`, then failed to publish its immutable SHA tag with a 403 response while another concurrent run failed OAuth authorization.

## Verification

- `npx prettier --check .github/workflows/supersync-docker.yml`
- `npm run lint` (passes with pre-existing warnings)
- `npm run packages:test`
- `npm run release-notes:test`
- `npx cross-env TZ='Europe/Berlin' ng test --watch=false`
- `npm run test:tz:ci`
