### PR TITLE
fix(sync): resolve plan-for-today bulk conflicts instead of wedging sync

### DIFF
--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -631,6 +631,19 @@ describe('Task Reducer', () => {
       expect(state.entities).toBe(stateWithOrderedTasks.entities);
     });
 
+    it('must not handle moveTaskInTodayTagList at all (ordering-only invariant #9426)', () => {
+      // The task feature reducer currently has NO handler for this action; a
+      // future one that touches entities would invalidate the ordering-only
+      // rejection in conflict resolution. Same remediation as above.
+      const action = TaskSharedActions.moveTaskInTodayTagList({
+        toTaskId: 'task1',
+        fromTaskId: 'task2',
+      });
+      const state = taskReducer(stateWithTasks, action);
+
+      expect(state).toBe(stateWithTasks);
+    });
+
     it('should ignore all invalid IDs and leave state unchanged', () => {
       stubWindowConfirm(false);
       if (!jasmine.isSpy(window.alert)) {

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -623,6 +623,12 @@ describe('Task Reducer', () => {
 
       // The removed tasks should be moved to the beginning while maintaining their relative order
       expect(state.ids).toEqual(['task2', 'task4', 'task1', 'task3']);
+      // Ordering-only invariant (#9426): conflict resolution rejects
+      // conflicted rows of this action outright, which is lossless only while
+      // the handler never touches task entities. If this fails, remove the
+      // action from ORDERING_ONLY_MULTI_ACTIONS in conflict-resolution.service.ts
+      // (or give it a preserve path) BEFORE shipping the reducer change.
+      expect(state.entities).toBe(stateWithOrderedTasks.entities);
     });
 
     it('should ignore all invalid IDs and leave state unchanged', () => {

--- a/src/app/op-log/sync/conflict-disjoint-merge.util.ts
+++ b/src/app/op-log/sync/conflict-disjoint-merge.util.ts
@@ -185,7 +185,12 @@ export const noiseTiebreakSide = (
  *
  * Field-level conditions only (the caller separately excludes archive plans):
  *  - neither side contains a multi-entity op, because resolving one conflicted
- *    entity would reject the whole original op and drop its sibling updates;
+ *    entity would reject the whole original op and drop its sibling updates.
+ *    LOAD-BEARING beyond that rationale since #9426: for SCOPED_PLAN types the
+ *    sibling loss is now handled, but `_preservePartiallyRejectedLocalBulkPlanOps`
+ *    only sees conflicts routed to the plain-LWW `resolutions` list — a merged
+ *    conflict bypasses it and would starve the scoped replacement. Do not relax
+ *    this condition for those types without moving that grouping too;
  *  - neither side has a DELETE op;
  *  - BOTH sides changed at least one real (non-noise) field — if one side only
  *    bumped noise, nothing real is lost by LWW, so leave it to SPAP-13's `noise`

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -3676,6 +3676,64 @@ describe('ConflictResolutionService', () => {
         expect(mockOperationApplier.applyOperations).not.toHaveBeenCalled();
       });
 
+      it('keeps a locally deleted task deleted when a remote bulk plan op wins (#9426)', async () => {
+        // Pins the multi-entity skip in _convertToLWWUpdatesIfNeeded: with it,
+        // delete-vs-bulk-plan takes the documented stays-deleted degrade (no
+        // recreation row); without it, the conversion feeds the recreate path
+        // and a fresh recreatesEntityAfterDelete row for the deleted task
+        // rides the LOCAL batch. The bulk op itself must stay unmangled either
+        // way so its sibling still gets planned.
+        const remotePlanOp: Operation = {
+          ...createOpWithTimestamp(
+            'remote-bulk-plan',
+            'client-b',
+            2000,
+            OpType.Update,
+            'task-1',
+          ),
+          actionType: ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+          entityIds: ['task-1', 'task-2'],
+          payload: {
+            actionPayload: { taskIds: ['task-1', 'task-2'], today: '2026-07-30' },
+            entityChanges: [],
+          },
+        };
+        const localDelete: Operation = {
+          ...createOpWithTimestamp(
+            'local-delete',
+            'client-a',
+            1000,
+            OpType.Delete,
+            'task-1',
+          ),
+          actionType: ActionType.TASK_SHARED_DELETE,
+          payload: {
+            task: { id: 'task-1', title: 'Deleted locally' },
+          },
+        };
+
+        await service.autoResolveConflictsLWW([
+          createConflict('task-1', [localDelete], [remotePlanOp]),
+        ]);
+
+        // The original atomic row is queued unmangled on the remote side.
+        // With no local-win/recreation rows, it takes the plain remote append;
+        // without the conversion guard it instead rides the mixed batch with a
+        // same-id LOCAL rewrite row alongside it.
+        const plainRemoteAppends = mockOpLogStore.appendBatchSkipDuplicates.calls
+          .allArgs()
+          .flatMap(([ops]) => ops as Operation[]);
+        const appendedCopies = [...plainRemoteAppends, ...getMixedRemoteOps()].filter(
+          ({ id }) => id === remotePlanOp.id,
+        );
+        expect(appendedCopies.length).toBe(1);
+        expect(appendedCopies[0].actionType).toBe(ActionType.TASK_SHARED_PLAN_FOR_TODAY);
+        expect(appendedCopies[0].entityIds).toEqual(['task-1', 'task-2']);
+        // Stays-deleted degrade: NO local-source row touches the deleted task
+        // (a recreation row here means the conversion guard was bypassed).
+        expect(getMixedLocalOps().filter((op) => op.entityId === 'task-1')).toEqual([]);
+      });
+
       it('should extract entity from DELETE payload when UPDATE wins but entity not in store', () => {
         // This tests the helper method that extracts entity state from DELETE operations
         // Used when remote DELETE is applied first, then local UPDATE wins LWW

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -379,20 +379,26 @@ const INDEPENDENT_MULTI_DELETE_ACTIONS = new Set<ActionType>([
  * - ORDERING_ONLY rows touch nothing but `TODAY_TAG.taskIds` ordering — Today
  *   MEMBERSHIP is derived from `task.dueDay`/`dueWithTime` (ADR #2) — so
  *   rejecting such a row loses at most list ordering: cosmetic, self-healing,
- *   no replacement needed. Pinned by the entity-field-free invariant spec in
- *   `task-shared-scheduling.reducer.spec.ts`.
+ *   no replacement needed. Pinned by the entity-field-free invariant specs in
+ *   `task-shared-scheduling.reducer.spec.ts` AND `task.reducer.spec.ts`.
  *
  * Remote rows of these types replay as ordinary atomic actions (the reducers
  * skip unknown task ids); local winners are restored by the existing
- * mixed-winner compensation snapshots applied after the remote row.
+ * mixed-winner compensation snapshots applied after the remote row. Known
+ * bounded gap of that restore (also pre-existing for archive rows): the
+ * snapshot re-imposes TASK fields only, so cross-slice side effects of the
+ * applied remote row (e.g. `removeTasksFromPlannerDays` stripping a
+ * local-win task's planner-day placement) are not re-imposed; the entry
+ * reappears when the task's own dueDay comes around.
  */
 const ORDERING_ONLY_MULTI_ACTIONS = new Set<ActionType>([
   ActionType.TASK_SHARED_MOVE_IN_TODAY,
   ActionType.TASK_SHARED_REMOVE_FROM_TODAY,
 ]);
-const isResolvableTodayListMultiOp = (op: Operation): boolean =>
-  SCOPED_PLAN_MULTI_ACTIONS.has(op.actionType) ||
-  ORDERING_ONLY_MULTI_ACTIONS.has(op.actionType);
+/** NOTE: classifies by action type alone — callers gate on multi-entity-ness. */
+const isResolvableTodayListAction = (actionType: ActionType): boolean =>
+  SCOPED_PLAN_MULTI_ACTIONS.has(actionType) ||
+  ORDERING_ONLY_MULTI_ACTIONS.has(actionType);
 
 /**
  * Handles sync conflicts using Last-Write-Wins (LWW) automatic resolution.
@@ -1056,18 +1062,19 @@ export class ConflictResolutionService {
           remoteOp,
         );
         if (recreationOp === undefined) {
-          // The local DELETE carries no reconstructable base entity (e.g. a
-          // legacy bulk deleteTasks op stores only taskIds), so we cannot recreate
-          // the remote-winning entity. Degrade like the single-entity path
-          // (_convertToLWWUpdatesIfNeeded / onMissingBaseEntity) instead of
+          // No recreation available: the local DELETE carries no
+          // reconstructable base entity (e.g. a legacy bulk deleteTasks op
+          // stores only taskIds), or the winner is a multi-entity row that
+          // `_convertToLWWUpdatesIfNeeded` refuses to rewrite (#9426). Degrade
+          // like the single-entity path (onMissingBaseEntity) instead of
           // throwing: throwing here aborts autoResolveConflictsLWW without
           // advancing the cursor, so the same op re-downloads and wedges sync
           // forever. The entity stays locally deleted (a bounded divergence for
           // this one entity, logged below) while the rest of the batch resolves.
           OpLog.err(
             `ConflictResolutionService: Cannot recreate remote winner ${remoteOp.id} for ` +
-              `${resolution.conflict.entityType}:${resolution.conflict.entityId} — local delete ` +
-              `carried no base entity. Entity stays deleted on this client; skipping recreation.`,
+              `${resolution.conflict.entityType}:${resolution.conflict.entityId} — no base ` +
+              `entity or multi-entity conversion refused. Entity stays deleted on this client.`,
           );
           continue;
         }
@@ -1188,7 +1195,7 @@ export class ConflictResolutionService {
           )
         : [];
       if (uncoveredLocalWinnerKeys.length > 0) {
-        if (!isResolvableTodayListMultiOp(winners.op)) {
+        if (!isResolvableTodayListAction(winners.op.actionType)) {
           throw new Error(
             `ConflictResolutionService: Cannot safely compensate mixed multi-entity winners for ${remoteOp.id}`,
           );
@@ -1202,6 +1209,14 @@ export class ConflictResolutionService {
         // fall through: the compensated-remote-op flow below re-classifies the
         // row (partition booked it as a rejected loser) so its remote-win and
         // uncontested sibling entities still get it applied.
+        //
+        // KNOWN INACCURACY (bounded): the SPAP-13 journal emits from the
+        // untouched plans, so a degraded conflict is journaled winner=local
+        // although the row applied as a remote win. Confined to
+        // journal-enabled builds — the production entry point passes
+        // `disableConflictJournal: true` (producer freeze, see
+        // RemoteOpsProcessingService) — and fixing it means re-plumbing plan
+        // mutation; revisit when the journal producer is unfrozen.
         OpLog.err(
           `ConflictResolutionService: ${uncoveredLocalWinnerKeys.length} local winner(s) of ` +
             `Today-list op ${remoteOp.id} have no compensation snapshot; applying as remote win.`,
@@ -2351,7 +2366,7 @@ export class ConflictResolutionService {
    * The Today-list ops that used to make this reachable from ordinary use —
    * `planTasksForToday` (dispatched with every due task id by the automatic
    * day-rollover) and the ordering-only Today ops — now resolve via
-   * `isResolvableTodayListMultiOp` (#9426): scoped replacement for plan rows,
+   * `isResolvableTodayListAction` (#9426): scoped replacement for plan rows,
    * plain rejection for ordering rows, atomic replay for remote rows. The
    * remaining blocked set (updateTasks, legacy addTagToTask, …) is pinned in
    * `testing/integration/unsupported-multi-entity-conflict.integration.spec.ts`.
@@ -2365,7 +2380,7 @@ export class ConflictResolutionService {
           isMultiEntityOperation(op) &&
           op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
           !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType) &&
-          !isResolvableTodayListMultiOp(op),
+          !isResolvableTodayListAction(op.actionType),
       );
       if (unsafeRemoteOp) {
         throw new UnsupportedMultiEntityConflictError(
@@ -2388,7 +2403,7 @@ export class ConflictResolutionService {
             (op) =>
               !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType) &&
               !DECOMPOSABLE_MULTI_ACTION_FIELDS.has(op.actionType) &&
-              !isResolvableTodayListMultiOp(op),
+              !isResolvableTodayListAction(op.actionType),
           );
       if (unsafeLocalOp) {
         throw new UnsupportedMultiEntityConflictError(

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -79,6 +79,10 @@ import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service'
 import { SYNC_LOGGER } from '../core/sync-logger.adapter';
 import { processDeferredActionsAfterRemoteApply } from './process-deferred-actions-flush.util';
 import {
+  buildScopedBulkPlanReplacements,
+  SCOPED_PLAN_MULTI_ACTIONS,
+} from './preserve-partial-bulk-plan.util';
+import {
   IncompleteRemoteOperationsError,
   UnsupportedMultiEntityConflictError,
 } from '../core/errors/sync-errors';
@@ -362,6 +366,33 @@ const INDEPENDENT_MULTI_DELETE_ACTIONS = new Set<ActionType>([
   ActionType.REPEAT_CFG_DELETE_MULTIPLE,
   ActionType.COUNTER_DELETE_MULTIPLE,
 ]);
+
+/**
+ * Today-list multi-entity UPDATE actions that conflict resolution handles
+ * without splitting the atomic row (#9426, #9405 — the day-rollover
+ * `planTasksForToday` op carries EVERY due task id, so one concurrent remote
+ * edit of any of them used to stop sync entirely):
+ *
+ * - SCOPED_PLAN rows (see `preserve-partial-bulk-plan.util.ts`) are rejected
+ *   as a unit and replaced by ONE copy narrowed to the surviving task ids,
+ *   mirroring `_preservePartiallyRejectedLocalBulkDeletes`.
+ * - ORDERING_ONLY rows touch nothing but `TODAY_TAG.taskIds` ordering — Today
+ *   MEMBERSHIP is derived from `task.dueDay`/`dueWithTime` (ADR #2) — so
+ *   rejecting such a row loses at most list ordering: cosmetic, self-healing,
+ *   no replacement needed. Pinned by the entity-field-free invariant spec in
+ *   `task-shared-scheduling.reducer.spec.ts`.
+ *
+ * Remote rows of these types replay as ordinary atomic actions (the reducers
+ * skip unknown task ids); local winners are restored by the existing
+ * mixed-winner compensation snapshots applied after the remote row.
+ */
+const ORDERING_ONLY_MULTI_ACTIONS = new Set<ActionType>([
+  ActionType.TASK_SHARED_MOVE_IN_TODAY,
+  ActionType.TASK_SHARED_REMOVE_FROM_TODAY,
+]);
+const isResolvableTodayListMultiOp = (op: Operation): boolean =>
+  SCOPED_PLAN_MULTI_ACTIONS.has(op.actionType) ||
+  ORDERING_ONLY_MULTI_ACTIONS.has(op.actionType);
 
 /**
  * Handles sync conflicts using Last-Write-Wins (LWW) automatic resolution.
@@ -896,8 +927,10 @@ export class ConflictResolutionService {
       conflicts,
       options.disableDisjointMerge ?? false,
     );
-    const additionalLocalIntentOps =
-      await this._preservePartiallyRejectedLocalBulkDeletes(resolutions);
+    const additionalLocalIntentOps = [
+      ...(await this._preservePartiallyRejectedLocalBulkDeletes(resolutions)),
+      ...(await this._preservePartiallyRejectedLocalBulkPlanOps(resolutions)),
+    ];
 
     const allOpsToApply: Operation[] = [];
     const allStoredOps: Array<{ id: string; seq: number }> = [];
@@ -1149,15 +1182,33 @@ export class ConflictResolutionService {
           compensatedEntityKeys.add(toEntityKey(localWinOp.entityType, entityId));
         }
       }
-      if (
-        hasMixedWinners &&
-        [...winners.localWinnerKeys].some(
-          (entityKey) => !compensatedEntityKeys.has(entityKey),
-        )
-      ) {
-        throw new Error(
-          `ConflictResolutionService: Cannot safely compensate mixed multi-entity winners for ${remoteOp.id}`,
+      const uncoveredLocalWinnerKeys = hasMixedWinners
+        ? [...winners.localWinnerKeys].filter(
+            (entityKey) => !compensatedEntityKeys.has(entityKey),
+          )
+        : [];
+      if (uncoveredLocalWinnerKeys.length > 0) {
+        if (!isResolvableTodayListMultiOp(winners.op)) {
+          throw new Error(
+            `ConflictResolutionService: Cannot safely compensate mixed multi-entity winners for ${remoteOp.id}`,
+          );
+        }
+        // #9426: for the resolvable Today-list bulk types, a local winner
+        // without a covering snapshot means `_createLocalWinUpdateOp` found no
+        // live entity (e.g. archived meanwhile) — and the Today-list replays
+        // skip unknown task ids, so treating that entity as a plain remote win
+        // cannot overwrite live local state. Degrade (log, drop the winner
+        // key) instead of wedging the whole batch on the pre-#9426 throw, and
+        // fall through: the compensated-remote-op flow below re-classifies the
+        // row (partition booked it as a rejected loser) so its remote-win and
+        // uncontested sibling entities still get it applied.
+        OpLog.err(
+          `ConflictResolutionService: ${uncoveredLocalWinnerKeys.length} local winner(s) of ` +
+            `Today-list op ${remoteOp.id} have no compensation snapshot; applying as remote win.`,
         );
+        for (const entityKey of uncoveredLocalWinnerKeys) {
+          winners.localWinnerKeys.delete(entityKey);
+        }
       }
       if (remoteOp.opType === OpType.Delete) {
         for (const localWinOpId of winners.localWinOpIds) {
@@ -2297,15 +2348,13 @@ export class ConflictResolutionService {
    * a local archive is re-created as the same atomic action, or the local legacy
    * rounding action has an explicit per-entity reconciliation path above.
    *
-   * This is reachable from ordinary use, not only from bulk actions:
-   * `moveTaskInTodayTagList` (a planner drag inside Today) always carries two
-   * entity ids, and `planTasksForToday` is dispatched with every due task id by
-   * the automatic day-rollover paths. So a single pending local op plus one
-   * concurrent remote edit of the same task stops sync with no in-app recovery
-   * (#9405), without the user having done anything bulk. The thrown error names
-   * the blocked action without leaking ids; the reachable set is pinned in
-   * `testing/integration/unsupported-multi-entity-conflict.integration.spec.ts`
-   * so a future self-healing fix knows what it has to cover.
+   * The Today-list ops that used to make this reachable from ordinary use —
+   * `planTasksForToday` (dispatched with every due task id by the automatic
+   * day-rollover) and the ordering-only Today ops — now resolve via
+   * `isResolvableTodayListMultiOp` (#9426): scoped replacement for plan rows,
+   * plain rejection for ordering rows, atomic replay for remote rows. The
+   * remaining blocked set (updateTasks, legacy addTagToTask, …) is pinned in
+   * `testing/integration/unsupported-multi-entity-conflict.integration.spec.ts`.
    */
   private _assertMultiEntityPlansAreSafe(
     plans: LwwConflictResolutionPlan<EntityConflict>[],
@@ -2315,7 +2364,8 @@ export class ConflictResolutionService {
         (op) =>
           isMultiEntityOperation(op) &&
           op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
-          !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType),
+          !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType) &&
+          !isResolvableTodayListMultiOp(op),
       );
       if (unsafeRemoteOp) {
         throw new UnsupportedMultiEntityConflictError(
@@ -2337,7 +2387,8 @@ export class ConflictResolutionService {
         : localMultiOps.find(
             (op) =>
               !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType) &&
-              !DECOMPOSABLE_MULTI_ACTION_FIELDS.has(op.actionType),
+              !DECOMPOSABLE_MULTI_ACTION_FIELDS.has(op.actionType) &&
+              !isResolvableTodayListMultiOp(op),
           );
       if (unsafeLocalOp) {
         throw new UnsupportedMultiEntityConflictError(
@@ -2428,6 +2479,12 @@ export class ConflictResolutionService {
     if (conflict.remoteOps.some((op) => getOpEntityIds(op).length > 1)) {
       return undefined;
     }
+    // NOTE (#9426): conflicts carrying a now-resolvable Today-list bulk row
+    // never merge either — `isDisjointMergeEligible` below refuses ANY
+    // multi-entity op on either side. Load-bearing: a merged conflict bypasses
+    // `resolutions` and would starve the scoped-replacement grouping in
+    // `_preservePartiallyRejectedLocalBulkPlanOps` while still rejecting the
+    // bulk row.
     const payloadKey = this._resolvePayloadKey(conflict.entityType);
 
     // The merged op carries a PARTIAL delta. If it later has to RECREATE a
@@ -2888,6 +2945,34 @@ export class ConflictResolutionService {
       vectorClock: this.mergeAndIncrementClocks(allClocks, clientId),
       schemaVersion: CURRENT_SCHEMA_VERSION,
     };
+  }
+
+  /**
+   * #9426: preserves the surviving siblings of rejected `planTasksForToday`
+   * bulk rows as ONE scoped replacement per row. The mechanism lives in
+   * `preserve-partial-bulk-plan.util.ts` (pure); this wrapper only supplies
+   * the client id.
+   */
+  private async _preservePartiallyRejectedLocalBulkPlanOps(
+    resolutions: LWWResolution[],
+  ): Promise<Operation[]> {
+    if (
+      !resolutions.some((resolution) =>
+        resolution.conflict.localOps.some(
+          (op) =>
+            SCOPED_PLAN_MULTI_ACTIONS.has(op.actionType) && isMultiEntityOperation(op),
+        ),
+      )
+    ) {
+      return [];
+    }
+    const clientId = await this.clientIdProvider.loadClientId();
+    if (!clientId) {
+      throw new Error(
+        'ConflictResolutionService: Cannot preserve partial bulk plan - no client ID',
+      );
+    }
+    return buildScopedBulkPlanReplacements(resolutions, clientId);
   }
 
   /**
@@ -3591,7 +3676,18 @@ export class ConflictResolutionService {
     const convertibleRemoteOps = conflict.remoteOps.filter(
       (op) =>
         op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
-        op.actionType !== ActionType.TASK_SHARED_RESTORE,
+        op.actionType !== ActionType.TASK_SHARED_RESTORE &&
+        // A multi-entity row must never be rewritten into a single-entity LWW
+        // replace: it would drop the row's effect on every other entity, and
+        // the converted copy shares the original's op id across several
+        // conflicts. Today that mangling is MASKED downstream by accident (the
+        // recreate path re-routes the original op and the same-id copy dies in
+        // the append duplicate check) — this guard makes the invariant
+        // explicit instead. Consequence for multi-entity delete-vs-update:
+        // recreation finds no converted op, so the locally deleted entity
+        // stays deleted (the same logged degrade as the legacy bulk-delete
+        // case) while the bulk row still applies to its other entities.
+        getOpEntityIds(op).length <= 1,
     );
     if (convertibleRemoteOps.length === 0) {
       return conflict.remoteOps;

--- a/src/app/op-log/sync/preserve-partial-bulk-plan.util.spec.ts
+++ b/src/app/op-log/sync/preserve-partial-bulk-plan.util.spec.ts
@@ -1,0 +1,179 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { LwwResolvedConflict } from '@sp/sync-core';
+import { ActionType, EntityConflict, Operation, OpType } from '../core/operation.types';
+import { buildScopedBulkPlanReplacements } from './preserve-partial-bulk-plan.util';
+
+describe('buildScopedBulkPlanReplacements', () => {
+  const CLIENT_ID = 'local-client';
+
+  const planOp = (over: Partial<Operation> = {}): Operation => ({
+    id: 'plan-op-1',
+    actionType: ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+    opType: OpType.Update,
+    entityType: 'TASK',
+    entityId: 'task-a',
+    entityIds: ['task-a', 'task-b', 'task-c'],
+    payload: {
+      actionPayload: {
+        taskIds: ['task-a', 'task-b', 'task-c'],
+        today: '2026-07-30',
+        startOfNextDayDiffMs: 0,
+        parentTaskMap: { 'task-a': 'parent-x', 'task-b': undefined },
+      },
+      entityChanges: [],
+    },
+    clientId: CLIENT_ID,
+    vectorClock: { [CLIENT_ID]: 3 },
+    timestamp: 1000,
+    schemaVersion: 1,
+    ...over,
+  });
+
+  const remoteOp = (entityId: string, over: Partial<Operation> = {}): Operation => ({
+    id: `remote-${entityId}`,
+    actionType: '[Task Shared] updateTask' as ActionType,
+    opType: OpType.Update,
+    entityType: 'TASK',
+    entityId,
+    payload: { task: { id: entityId, changes: { title: 'remote' } } },
+    clientId: 'remote-client',
+    vectorClock: { 'remote-client': 7 },
+    timestamp: 2000,
+    schemaVersion: 1,
+    ...over,
+  });
+
+  const resolutionOf = (
+    localOps: Operation[],
+    entityId: string,
+    winner: 'local' | 'remote',
+    localWinOp?: Operation,
+  ): LwwResolvedConflict<Operation, EntityConflict> => ({
+    winner,
+    localWinOp,
+    conflict: {
+      entityType: 'TASK',
+      entityId,
+      localOps,
+      remoteOps: [remoteOp(entityId)],
+      suggestedResolution: 'manual',
+    },
+  });
+
+  it('narrows taskIds AND parentTaskMap to the surviving siblings', () => {
+    const op = planOp();
+    const replacements = buildScopedBulkPlanReplacements(
+      [resolutionOf([op], 'task-a', 'remote')],
+      CLIENT_ID,
+    );
+
+    expect(replacements.length).toBe(1);
+    const [replacement] = replacements;
+    expect(replacement.entityIds).toEqual(['task-b', 'task-c']);
+    expect(replacement.entityId).toBe('task-b');
+    const actionPayload = (
+      replacement.payload as { actionPayload: Record<string, unknown> }
+    ).actionPayload;
+    expect(actionPayload['taskIds']).toEqual(['task-b', 'task-c']);
+    // task-a's entry must not survive into the narrowed row.
+    expect(actionPayload['parentTaskMap']).toEqual({ 'task-b': undefined });
+    expect(actionPayload['today']).toBe('2026-07-30');
+    expect(replacement.timestamp).toBe(op.timestamp);
+    expect(replacement.id).not.toBe(op.id);
+    expect(replacement.clientId).toBe(CLIENT_ID);
+  });
+
+  it('retains an uncovered local-win target (no snapshot op) instead of dropping its intent', () => {
+    const op = planOp();
+    const replacements = buildScopedBulkPlanReplacements(
+      [resolutionOf([op], 'task-a', 'local', undefined)],
+      CLIENT_ID,
+    );
+
+    expect(replacements.length).toBe(1);
+    expect(replacements[0].entityIds).toEqual(['task-a', 'task-b', 'task-c']);
+  });
+
+  it('drops a covered local-win target (snapshot op exists)', () => {
+    const op = planOp();
+    const snapshot = remoteOp('task-a', { id: 'snapshot-a', clientId: CLIENT_ID });
+    const replacements = buildScopedBulkPlanReplacements(
+      [resolutionOf([op], 'task-a', 'local', snapshot)],
+      CLIENT_ID,
+    );
+
+    expect(replacements.length).toBe(1);
+    expect(replacements[0].entityIds).toEqual(['task-b', 'task-c']);
+  });
+
+  it('emits nothing when every id was a covered conflict target', () => {
+    const op = planOp({
+      entityIds: ['task-a'],
+      payload: {
+        actionPayload: { taskIds: ['task-a'], today: '2026-07-30' },
+        entityChanges: [],
+      },
+    });
+    expect(
+      buildScopedBulkPlanReplacements(
+        [resolutionOf([op], 'task-a', 'remote')],
+        CLIENT_ID,
+      ),
+    ).toEqual([]);
+  });
+
+  it('skips (never replays un-narrowed) a row whose payload carries no taskIds array', () => {
+    // Membership-contract violation: a future SCOPED_PLAN action whose payload
+    // names its ids differently must degrade to plain rejection, not silently
+    // re-impose the full id set on every client.
+    const op = planOp({
+      payload: {
+        actionPayload: { ids: ['task-a', 'task-b', 'task-c'] },
+        entityChanges: [],
+      },
+    });
+    expect(
+      buildScopedBulkPlanReplacements(
+        [resolutionOf([op], 'task-a', 'remote')],
+        CLIENT_ID,
+      ),
+    ).toEqual([]);
+  });
+
+  it('orders multiple groups deterministically by timestamp with op-id tie-break', () => {
+    const older = planOp({ id: 'op-bbb', timestamp: 1000 });
+    const tiedA = planOp({
+      id: 'op-aaa',
+      timestamp: 1000,
+      entityIds: ['task-a', 'task-b'],
+      payload: {
+        actionPayload: { taskIds: ['task-a', 'task-b'], today: '2026-07-31' },
+        entityChanges: [],
+      },
+    });
+    // One conflict pulls BOTH rows in (both touch task-a).
+    const resolution = resolutionOf([older, tiedA], 'task-a', 'remote');
+    const replacements = buildScopedBulkPlanReplacements([resolution], CLIENT_ID);
+
+    expect(replacements.length).toBe(2);
+    // Equal timestamps: op id decides — 'op-aaa' before 'op-bbb'.
+    expect(replacements[0].payload).toEqual(
+      jasmine.objectContaining({
+        actionPayload: jasmine.objectContaining({ today: '2026-07-31' }),
+      }),
+    );
+    expect(replacements[1].entityIds).toEqual(['task-b', 'task-c']);
+  });
+
+  it('dominates every clock of every conflict the row appears in', () => {
+    const op = planOp({ vectorClock: { [CLIENT_ID]: 3, other: 5 } });
+    const [replacement] = buildScopedBulkPlanReplacements(
+      [resolutionOf([op], 'task-a', 'remote')],
+      CLIENT_ID,
+    );
+
+    expect(replacement.vectorClock[CLIENT_ID]).toBe(4);
+    expect(replacement.vectorClock['other']).toBe(5);
+    expect(replacement.vectorClock['remote-client']).toBe(7);
+  });
+});

--- a/src/app/op-log/sync/preserve-partial-bulk-plan.util.ts
+++ b/src/app/op-log/sync/preserve-partial-bulk-plan.util.ts
@@ -1,0 +1,169 @@
+import { uuidv7 } from '../../util/uuid-v7';
+import {
+  incrementVectorClock,
+  mergeVectorClocks,
+  VectorClock,
+} from '../../core/util/vector-clock';
+import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
+import {
+  ActionType,
+  extractActionPayload,
+  isMultiEntityPayload,
+  Operation,
+} from '../core/operation.types';
+import { getOpEntityIds } from '../util/get-op-entity-ids.util';
+
+/**
+ * The multi-entity UPDATE actions whose atomic local rows are preserved by a
+ * scoped replacement when a conflict rejects them (#9426, #9405). Both are
+ * dispatched by the automatic day-rollover with every matching task id
+ * (`TaskDueEffects`), their reducers' per-task effect is a pure scheduling
+ * fold over `taskIds` (no cross-task invariant), and a narrowed row is a
+ * payload shape every released client replays natively — single-task
+ * `planTasksForToday` dispatchers ship in production (`TaskService.addToToday`,
+ * TaskComponent's add-to-my-day).
+ */
+export const SCOPED_PLAN_MULTI_ACTIONS: ReadonlySet<ActionType> = new Set<ActionType>([
+  ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+  ActionType.TASK_SHARED_PLAN_DEADLINE_FOR_TODAY,
+]);
+
+interface ConflictLike {
+  entityId: string;
+  localOps: Operation[];
+  remoteOps: Operation[];
+}
+
+interface ResolutionLike {
+  winner: 'local' | 'remote';
+  localWinOp?: Operation;
+  conflict: ConflictLike;
+}
+
+interface BulkPlanResolutionGroup {
+  planOp: Operation;
+  resolutions: ResolutionLike[];
+  decidedTargetIds: Set<string>;
+}
+
+const mergeAndIncrementClocks = (
+  clocks: VectorClock[],
+  clientId: string,
+): VectorClock => {
+  let merged: VectorClock = {};
+  for (const clock of clocks) {
+    merged = mergeVectorClocks(merged, clock);
+  }
+  return incrementVectorClock(merged, clientId);
+};
+
+/**
+ * #9426: a `planTasksForToday` bulk row is atomic, so any conflict rejects the
+ * whole row even though the surviving siblings' plan intent (dueDay set to the
+ * plan day, reminders cleared) is already applied locally and would otherwise
+ * never upload. Mirror of the bulk-delete preserve
+ * (`ConflictResolutionService._preservePartiallyRejectedLocalBulkDeletes`):
+ * replace each affected row with ONE narrowed copy that
+ *
+ * - drops every COVERED conflict target id — remote winners are owned by the
+ *   newer remote op, and local winners are carried by their whole-state
+ *   `localWinOp` snapshot (a second op would ride an equal clock). A local win
+ *   WITHOUT a covering snapshot (`localWinOp` undefined: the entity is absent
+ *   from the live store, e.g. archive-sibling shapes) keeps its id instead —
+ *   the reducers skip unknown task ids, so retaining it is at worst a replay
+ *   no-op and can never silently drop the target's plan intent,
+ * - keeps every other id with the original action payload and timestamp, and
+ * - dominates every conflict clock involving the original row.
+ *
+ * When several plan rows are grouped in one batch (the multi-day compounding
+ * case: a wedged client mints a new day-rollover op every day), replacements
+ * are emitted in ascending original-timestamp order. Their proposed clocks may
+ * be identical (same merge base), which would be CONCURRENT on the shared task
+ * ids — but every local append is rebased onto the durable running clock in
+ * `appendMixedSourceBatchSkipDuplicates` (#8939), so the WRITTEN rows are
+ * strictly ordered. Pinned by the multi-day case in
+ * `today-plan-conflict-resolution.integration.spec.ts`, which fails if that
+ * rebase is ever bypassed.
+ */
+export const buildScopedBulkPlanReplacements = (
+  resolutions: ResolutionLike[],
+  clientId: string,
+): Operation[] => {
+  const groups = new Map<string, BulkPlanResolutionGroup>();
+  for (const resolution of resolutions) {
+    for (const localOp of resolution.conflict.localOps) {
+      if (
+        !SCOPED_PLAN_MULTI_ACTIONS.has(localOp.actionType) ||
+        getOpEntityIds(localOp).length <= 1
+      ) {
+        continue;
+      }
+      const group = groups.get(localOp.id) ?? {
+        planOp: localOp,
+        resolutions: [],
+        decidedTargetIds: new Set<string>(),
+      };
+      group.resolutions.push(resolution);
+      const targetIsCovered =
+        resolution.winner === 'remote' || resolution.localWinOp !== undefined;
+      if (targetIsCovered) {
+        group.decidedTargetIds.add(resolution.conflict.entityId);
+      }
+      groups.set(localOp.id, group);
+    }
+  }
+
+  const orderedGroups = [...groups.values()].sort(
+    (a, b) => a.planOp.timestamp - b.planOp.timestamp,
+  );
+  const replacements: Operation[] = [];
+  for (const group of orderedGroups) {
+    const retainedEntityIds = getOpEntityIds(group.planOp).filter(
+      (entityId) => !group.decidedTargetIds.has(entityId),
+    );
+    if (retainedEntityIds.length === 0) {
+      continue;
+    }
+    const allClocks = group.resolutions.flatMap(({ conflict }) => [
+      ...conflict.localOps.map((op) => op.vectorClock),
+      ...conflict.remoteOps.map((op) => op.vectorClock),
+    ]);
+    const newClock = mergeAndIncrementClocks(allClocks, clientId);
+
+    const retainedSet = new Set(retainedEntityIds);
+    const originalActionPayload = extractActionPayload(group.planOp.payload);
+    const scopedActionPayload: Record<string, unknown> = {
+      ...originalActionPayload,
+      taskIds: retainedEntityIds,
+    };
+    const parentTaskMap = originalActionPayload['parentTaskMap'];
+    if (parentTaskMap && typeof parentTaskMap === 'object') {
+      scopedActionPayload['parentTaskMap'] = Object.fromEntries(
+        Object.entries(parentTaskMap as Record<string, unknown>).filter(([taskId]) =>
+          retainedSet.has(taskId),
+        ),
+      );
+    }
+    const scopedPayload = isMultiEntityPayload(group.planOp.payload)
+      ? {
+          ...group.planOp.payload,
+          actionPayload: scopedActionPayload,
+          entityChanges: group.planOp.payload.entityChanges.filter((change) =>
+            retainedSet.has(change.entityId),
+          ),
+        }
+      : scopedActionPayload;
+
+    replacements.push({
+      ...group.planOp,
+      id: uuidv7(),
+      entityId: retainedEntityIds[0],
+      entityIds: retainedEntityIds,
+      payload: scopedPayload,
+      clientId,
+      vectorClock: newClock,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    });
+  }
+  return replacements;
+};

--- a/src/app/op-log/sync/preserve-partial-bulk-plan.util.ts
+++ b/src/app/op-log/sync/preserve-partial-bulk-plan.util.ts
@@ -4,46 +4,51 @@ import {
   mergeVectorClocks,
   VectorClock,
 } from '../../core/util/vector-clock';
+import { OpLog } from '../../core/log';
 import { CURRENT_SCHEMA_VERSION } from '../persistence/schema-migration.service';
 import {
   ActionType,
+  EntityConflict,
   extractActionPayload,
   isMultiEntityPayload,
   Operation,
 } from '../core/operation.types';
+import type { LwwResolvedConflict } from '@sp/sync-core';
 import { getOpEntityIds } from '../util/get-op-entity-ids.util';
 
 /**
  * The multi-entity UPDATE actions whose atomic local rows are preserved by a
  * scoped replacement when a conflict rejects them (#9426, #9405). Both are
  * dispatched by the automatic day-rollover with every matching task id
- * (`TaskDueEffects`), their reducers' per-task effect is a pure scheduling
- * fold over `taskIds` (no cross-task invariant), and a narrowed row is a
- * payload shape every released client replays natively — single-task
- * `planTasksForToday` dispatchers ship in production (`TaskService.addToToday`,
- * TaskComponent's add-to-my-day).
+ * (`TaskDueEffects`), their reducers' per-task effect is a scheduling fold over
+ * `taskIds`, and a narrowed row is a payload shape every released client
+ * replays natively — single-task `planTasksForToday` dispatchers ship in
+ * production (`TaskService.addToToday`, TaskComponent's add-to-my-day).
+ *
+ * Known bounded coupling, accepted: a task's plan/skip decision is evaluated
+ * against RECEIVER state at replay time (e.g. the deadline fold skips a child
+ * whose parent is due today), so a narrowed row can plan a task the original
+ * atomic fold skipped, and vice versa. That state-dependence is inherent to
+ * action-replay ops — the un-narrowed row replayed on a peer has it too — and
+ * each client's own daily rollover re-derives the outcome.
+ *
+ * MEMBERSHIP CONTRACT: every action added here must carry its ids in
+ * `actionPayload.taskIds`; the builder below skips (and logs) rows that do
+ * not, so a mismatched future addition degrades to plain rejection instead of
+ * silently replaying the un-narrowed id set.
  */
 export const SCOPED_PLAN_MULTI_ACTIONS: ReadonlySet<ActionType> = new Set<ActionType>([
   ActionType.TASK_SHARED_PLAN_FOR_TODAY,
   ActionType.TASK_SHARED_PLAN_DEADLINE_FOR_TODAY,
 ]);
 
-interface ConflictLike {
-  entityId: string;
-  localOps: Operation[];
-  remoteOps: Operation[];
-}
-
-interface ResolutionLike {
-  winner: 'local' | 'remote';
-  localWinOp?: Operation;
-  conflict: ConflictLike;
-}
+type ResolutionLike = LwwResolvedConflict<Operation, EntityConflict>;
 
 interface BulkPlanResolutionGroup {
   planOp: Operation;
   resolutions: ResolutionLike[];
-  decidedTargetIds: Set<string>;
+  coveredTargetIds: Set<string>;
+  uncoveredTargetIds: Set<string>;
 }
 
 const mergeAndIncrementClocks = (
@@ -77,13 +82,21 @@ const mergeAndIncrementClocks = (
  *
  * When several plan rows are grouped in one batch (the multi-day compounding
  * case: a wedged client mints a new day-rollover op every day), replacements
- * are emitted in ascending original-timestamp order. Their proposed clocks may
- * be identical (same merge base), which would be CONCURRENT on the shared task
- * ids — but every local append is rebased onto the durable running clock in
- * `appendMixedSourceBatchSkipDuplicates` (#8939), so the WRITTEN rows are
- * strictly ordered. Pinned by the multi-day case in
+ * are emitted in ascending original-timestamp order (op id as a deterministic
+ * tie-break; the timestamp IS the LWW ordering the rest of resolution uses,
+ * so it is the consistent choice even though wall clocks can regress). Their
+ * proposed clocks may be identical (same merge base), which would be
+ * CONCURRENT on the shared task ids — but every local append is rebased onto
+ * the durable running clock in `appendMixedSourceBatchSkipDuplicates` (#8939),
+ * so the WRITTEN rows are strictly ordered. Pinned by the multi-day case in
  * `today-plan-conflict-resolution.integration.spec.ts`, which fails if that
  * rebase is ever bypassed.
+ *
+ * Crash window (same as the bulk-delete preserve): the replacement becomes
+ * durable in the atomic resolution batch, while the original row is only
+ * markRejected after the apply phase. A crash in between leaves both pending;
+ * the leaked original then re-plans its full id set on other clients — benign
+ * for scheduling ops, and superseded by the replacement's dominating clock.
  */
 export const buildScopedBulkPlanReplacements = (
   resolutions: ResolutionLike[],
@@ -101,29 +114,61 @@ export const buildScopedBulkPlanReplacements = (
       const group = groups.get(localOp.id) ?? {
         planOp: localOp,
         resolutions: [],
-        decidedTargetIds: new Set<string>(),
+        coveredTargetIds: new Set<string>(),
+        uncoveredTargetIds: new Set<string>(),
       };
       group.resolutions.push(resolution);
       const targetIsCovered =
         resolution.winner === 'remote' || resolution.localWinOp !== undefined;
       if (targetIsCovered) {
-        group.decidedTargetIds.add(resolution.conflict.entityId);
+        group.coveredTargetIds.add(resolution.conflict.entityId);
+      } else {
+        group.uncoveredTargetIds.add(resolution.conflict.entityId);
       }
       groups.set(localOp.id, group);
     }
   }
 
   const orderedGroups = [...groups.values()].sort(
-    (a, b) => a.planOp.timestamp - b.planOp.timestamp,
+    (a, b) =>
+      a.planOp.timestamp - b.planOp.timestamp || a.planOp.id.localeCompare(b.planOp.id),
   );
   const replacements: Operation[] = [];
   for (const group of orderedGroups) {
     const retainedEntityIds = getOpEntityIds(group.planOp).filter(
-      (entityId) => !group.decidedTargetIds.has(entityId),
+      (entityId) => !group.coveredTargetIds.has(entityId),
     );
     if (retainedEntityIds.length === 0) {
       continue;
     }
+    const originalActionPayload = extractActionPayload(group.planOp.payload);
+    if (
+      typeof originalActionPayload !== 'object' ||
+      originalActionPayload === null ||
+      !Array.isArray(originalActionPayload['taskIds'])
+    ) {
+      // Membership-contract violation (see SCOPED_PLAN_MULTI_ACTIONS doc) or a
+      // corrupt local row: emitting a replacement would replay the un-narrowed
+      // id set on every client. Degrade to plain rejection instead — bounded
+      // sibling-intent loss, never a wedge and never a resurrected winner.
+      OpLog.err(
+        `buildScopedBulkPlanReplacements: cannot scope ${group.planOp.actionType} ` +
+          `row ${group.planOp.id} (payload carries no taskIds array); ` +
+          `dropping its ${retainedEntityIds.length} surviving sibling(s).`,
+      );
+      continue;
+    }
+    if (group.uncoveredTargetIds.size > 0) {
+      // Deliberate cross-client effect from a snapshot-less local win (entity
+      // absent from the live store): the retained ids re-assert plan intent on
+      // receivers while this client's replay skips them. Logged because it is
+      // the one branch here whose effect is invisible locally.
+      OpLog.warn(
+        `buildScopedBulkPlanReplacements: retaining ${group.uncoveredTargetIds.size} ` +
+          `uncovered local-win target(s) of row ${group.planOp.id} in the replacement.`,
+      );
+    }
+
     const allClocks = group.resolutions.flatMap(({ conflict }) => [
       ...conflict.localOps.map((op) => op.vectorClock),
       ...conflict.remoteOps.map((op) => op.vectorClock),
@@ -131,7 +176,6 @@ export const buildScopedBulkPlanReplacements = (
     const newClock = mergeAndIncrementClocks(allClocks, clientId);
 
     const retainedSet = new Set(retainedEntityIds);
-    const originalActionPayload = extractActionPayload(group.planOp.payload);
     const scopedActionPayload: Record<string, unknown> = {
       ...originalActionPayload,
       taskIds: retainedEntityIds,

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.spec.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.spec.ts
@@ -4,6 +4,7 @@ import {
 } from './verify-decrypted-op-integrity';
 import { SyncOperation } from '../sync-providers/provider.interface';
 import { OperationIntegrityError } from '../core/errors/sync-errors';
+import { ActionType } from '../core/action-types.enum';
 import { toLwwUpdateActionType } from '../core/lww-update-action-types';
 import { SINGLETON_ENTITY_ID } from '../core/entity-registry';
 import { OpType } from '../core/operation.types';
@@ -219,6 +220,112 @@ describe('assertDecryptedOpMetadataIntegrity', () => {
       };
       expect(() =>
         assertDecryptedOpMetadataIntegrity(op, authenticatedPayload),
+      ).not.toThrow();
+    });
+  });
+
+  describe('Today-list bulk footprint binding (#9426, GHSA-8pxh)', () => {
+    const planOp = (over: Partial<SyncOperation>): SyncOperation =>
+      createOp({
+        actionType: ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+        entityId: 'task-1',
+        entityIds: ['task-1', 'task-2'],
+        ...over,
+      });
+    const planPayload = (taskIds: unknown): unknown => ({
+      actionPayload: { taskIds, today: '2026-07-30' },
+      entityChanges: [],
+    });
+
+    it('throws when op.entityIds injects a victim id absent from the authenticated taskIds', () => {
+      const op = planOp({ entityIds: ['task-1', 'task-2', 'victim-task'] });
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, planPayload(['task-1', 'task-2'])),
+      ).toThrowError(OperationIntegrityError);
+    });
+
+    it('throws when the envelope is stripped to look single-entity (undercount)', () => {
+      const op = planOp({ entityIds: undefined });
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, planPayload(['task-1', 'task-2'])),
+      ).toThrowError(OperationIntegrityError);
+    });
+
+    it('throws for a bulk unplan whose envelope diverges from the authenticated taskIds', () => {
+      const op = planOp({
+        actionType: ActionType.TASK_SHARED_REMOVE_FROM_TODAY,
+        entityIds: ['task-1', 'other-task'],
+      });
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, planPayload(['task-1', 'task-2'])),
+      ).toThrowError(OperationIntegrityError);
+    });
+
+    it('throws for a Today drag whose envelope diverges from the authenticated pair', () => {
+      const op = planOp({
+        actionType: ActionType.TASK_SHARED_MOVE_IN_TODAY,
+        entityIds: ['task-1', 'victim-task'],
+      });
+      const payload = {
+        actionPayload: { toTaskId: 'task-1', fromTaskId: 'task-2' },
+        entityChanges: [],
+      };
+      expect(() => assertDecryptedOpMetadataIntegrity(op, payload)).toThrowError(
+        OperationIntegrityError,
+      );
+    });
+
+    it('passes genuine bulk ops for all four action types', () => {
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(planOp({}), planPayload(['task-1', 'task-2'])),
+      ).not.toThrow();
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(
+          planOp({ actionType: ActionType.TASK_SHARED_PLAN_DEADLINE_FOR_TODAY }),
+          planPayload(['task-1', 'task-2']),
+        ),
+      ).not.toThrow();
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(
+          planOp({ actionType: ActionType.TASK_SHARED_REMOVE_FROM_TODAY }),
+          planPayload(['task-1', 'task-2']),
+        ),
+      ).not.toThrow();
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(
+          planOp({ actionType: ActionType.TASK_SHARED_MOVE_IN_TODAY }),
+          {
+            actionPayload: { toTaskId: 'task-1', fromTaskId: 'task-2' },
+            entityChanges: [],
+          },
+        ),
+      ).not.toThrow();
+    });
+
+    it('passes a genuine single-task plan op (entityIds = [id])', () => {
+      const op = planOp({ entityIds: ['task-1'] });
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, planPayload(['task-1'])),
+      ).not.toThrow();
+    });
+
+    it('leaves ops without an authenticated footprint shape untouched (interim tolerance)', () => {
+      const op = planOp({ entityIds: ['task-1', 'anything'] });
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, {
+          actionPayload: { someOtherShape: true },
+          entityChanges: [],
+        }),
+      ).not.toThrow();
+    });
+
+    it('ignores out-of-scope actions that also carry taskIds (e.g. round-time)', () => {
+      const op = planOp({
+        actionType: ActionType.TASK_ROUND_TIME_SPENT,
+        entityIds: ['task-1', 'mismatched-task'],
+      });
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, planPayload(['task-1', 'task-2'])),
       ).not.toThrow();
     });
   });

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.ts
@@ -4,6 +4,7 @@ import { getLwwEntityType } from '../core/lww-update-action-types';
 import { isLwwPayloadIdCanonical } from '../core/entity-registry';
 import { OperationIntegrityError } from '../core/errors/sync-errors';
 import { ACTION_TYPE_ALIASES } from '../apply/operation-converter.util';
+import { ActionType } from '../core/action-types.enum';
 import { SyncLog } from '../../core/log';
 import {
   extractFullStateFromPayload,
@@ -197,6 +198,12 @@ export const assertDecryptedOpMetadataIntegrity = (
   // would make this gate skip an op the converter still LWW-coerces, silently
   // reopening the retarget hole.
   const actionType = ACTION_TYPE_ALIASES[op.actionType] ?? op.actionType;
+
+  // Today-list bulk actions are validated BEFORE the LWW-only gate below —
+  // they are ordinary action replays, not LWW updates, but their envelope ids
+  // steer conflict detection and the #9426 resolvable-multi-op paths.
+  assertEncryptedTodayListFootprintIntegrity(op, actionType, decryptedPayload);
+
   const lwwEntityType = getLwwEntityType(actionType);
 
   // Derive the target from actionType because it chooses the reducer branch;
@@ -311,6 +318,109 @@ const assertEncryptedProjectMoveFootprintIntegrity = (
   throw new OperationIntegrityError(
     `Operation ${op.id} failed metadata integrity check: encrypted op entityIds do ` +
       `not match the authenticated project-move footprint (possible sync-server ` +
+      `tampering). GHSA-8pxh-mgc7-gp3g`,
+  );
+};
+
+/**
+ * The Today-list bulk actions whose authenticated payload carries the task
+ * footprint as `actionPayload.taskIds`.
+ */
+const TODAY_LIST_TASK_IDS_ACTIONS: ReadonlySet<string> = new Set<string>([
+  ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+  ActionType.TASK_SHARED_PLAN_DEADLINE_FOR_TODAY,
+  ActionType.TASK_SHARED_REMOVE_FROM_TODAY,
+]);
+
+/**
+ * Binds the plaintext envelope ids of a Today-list bulk op to its
+ * AES-GCM-authenticated payload footprint (#9426 hardening of the
+ * GHSA-8pxh-mgc7-gp3g class, mirroring the project-move footprint binding
+ * above).
+ *
+ * These ops replay via `actionPayload` (authenticated), so a tampered envelope
+ * cannot change WHAT is applied — but the envelope `entityId`/`entityIds`
+ * steer per-entity conflict DETECTION, the multi-entity resolvability
+ * classification, and the #9426 scoped-replacement narrowing. A compromised
+ * server could inflate a genuine encrypted plan op's `entityIds` with victim
+ * ids to manufacture conflicts (getting the victims' pending local ops
+ * LWW-rejected), or STRIP `entityIds` to make a bulk row look single-entity.
+ * Require exact-set equality between the declared envelope ids
+ * (`{entityId} ∪ entityIds`) and the authenticated footprint:
+ * `actionPayload.taskIds` for the plan/unplan actions, the
+ * `toTaskId`/`fromTaskId` pair for a Today drag.
+ *
+ * INTERIM hardening — enforceable only when the authenticated payload carries
+ * the expected footprint shape; unknown/legacy payload shapes are left
+ * untouched to avoid rejecting valid ops (same tolerance as the project-move
+ * binding). Every shipped producer of these four actions — capture from the
+ * action creators and the #9426 scoped replacements — writes the envelope ids
+ * verbatim from the payload footprint, so genuine ops always satisfy the
+ * exact-set check.
+ *
+ * @throws OperationIntegrityError when the declared envelope ids diverge from
+ *   the authenticated footprint.
+ */
+const assertEncryptedTodayListFootprintIntegrity = (
+  op: SyncOperation,
+  actionType: string,
+  decryptedPayload: unknown,
+): void => {
+  const isMoveAction = actionType === ActionType.TASK_SHARED_MOVE_IN_TODAY;
+  if (!isMoveAction && !TODAY_LIST_TASK_IDS_ACTIONS.has(actionType)) {
+    return;
+  }
+
+  const actionPayload = extractActionPayload(decryptedPayload);
+  let authenticatedIds: string[] | undefined;
+  if (isMoveAction) {
+    const toTaskId = actionPayload?.['toTaskId'];
+    const fromTaskId = actionPayload?.['fromTaskId'];
+    authenticatedIds =
+      typeof toTaskId === 'string' && typeof fromTaskId === 'string'
+        ? [toTaskId, fromTaskId]
+        : undefined;
+  } else {
+    const taskIds = actionPayload?.['taskIds'];
+    authenticatedIds = Array.isArray(taskIds)
+      ? taskIds.filter((id): id is string => typeof id === 'string')
+      : undefined;
+  }
+  if (authenticatedIds === undefined) {
+    // No authenticated footprint to bind against (unknown/legacy payload
+    // shape) — see the "INTERIM hardening" note above.
+    return;
+  }
+
+  const declaredIds = new Set<unknown>([
+    ...(op.entityId ? [op.entityId] : []),
+    ...(op.entityIds ?? []),
+  ]);
+  const authenticatedSet = new Set(authenticatedIds);
+  // Exact-set equality: no injected victim ids (inflation), no hidden ids
+  // (stripping/undercount), no non-strings.
+  const isExactSet =
+    declaredIds.size === authenticatedSet.size &&
+    [...declaredIds].every((id) => typeof id === 'string' && authenticatedSet.has(id));
+  if (isExactSet) {
+    return;
+  }
+
+  // Log ids/counts only — never payload content (op log is exportable). Rule 9.
+  SyncLog.err(
+    '[assertDecryptedOpMetadataIntegrity] encrypted op entityIds do not match the authenticated Today-list footprint — rejecting (possible sync-server tampering)',
+    {
+      opId: op.id,
+      entityType: op.entityType,
+      opEntityId: op.entityId,
+      declaredCount: declaredIds.size,
+      authenticatedCount: authenticatedSet.size,
+      actionType: op.actionType,
+    },
+  );
+  throw new OperationIntegrityError(
+    `Operation ${op.id} failed metadata integrity check: encrypted op entityIds do ` +
+      `not match the authenticated Today-list footprint (possible sync-server ` +
       `tampering). GHSA-8pxh-mgc7-gp3g`,
   );
 };

--- a/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
@@ -1,0 +1,518 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action, Store } from '@ngrx/store';
+import { of, Subject, Subscription } from 'rxjs';
+import { SnackService } from '../../../core/snack/snack.service';
+import { ClientIdService } from '../../../core/util/client-id.service';
+import { DEFAULT_TASK, Task } from '../../../features/tasks/task.model';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { OperationApplierService } from '../../apply/operation-applier.service';
+import { OperationCaptureService } from '../../capture/operation-capture.service';
+import { clearDeferredActions } from '../../capture/operation-capture.meta-reducer';
+import { OperationLogEffects } from '../../capture/operation-log.effects';
+import { buildEntityRegistry, ENTITY_REGISTRY } from '../../core/entity-registry';
+import { ActionType, Operation, OpType } from '../../core/operation.types';
+import {
+  isPersistentAction,
+  PersistentAction,
+} from '../../core/persistent-action.interface';
+import { OperationLogCompactionService } from '../../persistence/operation-log-compaction.service';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { ConflictJournalService } from '../../sync/conflict-journal.service';
+import { ConflictResolutionService } from '../../sync/conflict-resolution.service';
+import { ImmediateUploadService } from '../../sync/immediate-upload.service';
+import { OperationWriteFlushService } from '../../sync/operation-write-flush.service';
+import { CLIENT_ID_PROVIDER } from '../../util/client-id.provider';
+import { ValidateStateService } from '../../validation/validate-state.service';
+import { compareVectorClocks, VectorClockComparison } from '@sp/sync-core';
+import { EntityConflict } from '../../core/operation.types';
+import {
+  ApplyOperationsOptions,
+  ApplyOperationsResult,
+} from '../../core/types/apply.types';
+import { resetTestUuidCounter, TestClient } from './helpers/test-client.helper';
+
+/**
+ * #9426 / #9405: a pending local multi-entity Today-list op (the automatic
+ * day-rollover `planTasksForToday`, a Today drag, a bulk unplan) in ANY
+ * conflict must not wedge the whole batch. These specs pin the resolution
+ * behavior: the batch resolves, the atomic bulk row is rejected, and for
+ * `planTasksForToday` a scoped replacement re-emits the surviving siblings'
+ * intent (mirroring the bulk-delete preserve mechanism).
+ */
+describe('today-list multi-entity conflict resolution integration (#9426)', () => {
+  const LOCAL_CLIENT_ID = 'today-client';
+  const REMOTE_CLIENT_ID = 'remote-client';
+  const CONFLICT_TASK_ID = 'rpt_cfg-a_2026-07-28';
+  const SIBLING_1 = 'task-sibling-1';
+  const SIBLING_2 = 'task-sibling-2';
+  const TODAY = '2026-07-30';
+
+  let opLogStore: OperationLogStoreService;
+  let capture: OperationCaptureService;
+  let writeFlush: OperationWriteFlushService;
+  let resolver: ConflictResolutionService;
+  let journal: ConflictJournalService;
+  let operationApplier: jasmine.SpyObj<OperationApplierService>;
+  let store: jasmine.SpyObj<Store>;
+  let actions$: Subject<Action>;
+  let effectSubscription: Subscription;
+  let taskStateById: Record<string, Task | undefined>;
+
+  const liveTask = (id: string): Task => ({
+    ...DEFAULT_TASK,
+    id,
+    title: `Task ${id}`,
+    projectId: 'project1',
+    dueDay: TODAY,
+  });
+
+  beforeEach(async () => {
+    resetTestUuidCounter();
+    clearDeferredActions();
+    actions$ = new Subject<Action>();
+    store = jasmine.createSpyObj<Store>('Store', ['dispatch', 'select']);
+    taskStateById = {
+      [CONFLICT_TASK_ID]: liveTask(CONFLICT_TASK_ID),
+      [SIBLING_1]: liveTask(SIBLING_1),
+      [SIBLING_2]: liveTask(SIBLING_2),
+    };
+    // Serve current entity state for local-win snapshots from a plain map. The
+    // registry's TASK selectById is a props-based selector: (selector, {id}).
+    store.select.and.callFake(((_selector: unknown, props?: { id?: string }): unknown =>
+      of(props?.id ? taskStateById[props.id] : undefined)) as Store['select']);
+
+    operationApplier = jasmine.createSpyObj<OperationApplierService>(
+      'OperationApplierService',
+      ['applyOperations'],
+    );
+    // Mimic the real applier's contract: report every op as reducer-committed
+    // and applied, so the resolution's markApplied/checkpoint bookkeeping runs.
+    operationApplier.applyOperations.and.callFake((async (
+      ops: Operation[],
+      options: ApplyOperationsOptions = {},
+    ): Promise<ApplyOperationsResult> => {
+      await options.onReducersCommitted?.(ops, []);
+      return { appliedOps: ops };
+    }) as OperationApplierService['applyOperations']);
+    const validateState = jasmine.createSpyObj<ValidateStateService>(
+      'ValidateStateService',
+      ['validateAndRepairCurrentState'],
+    );
+    validateState.validateAndRepairCurrentState.and.resolveTo(true);
+    const compaction = jasmine.createSpyObj<OperationLogCompactionService>(
+      'OperationLogCompactionService',
+      ['compact', 'emergencyCompact'],
+    );
+    compaction.compact.and.resolveTo(true);
+    compaction.emergencyCompact.and.resolveTo(true);
+    const clientId = jasmine.createSpyObj<ClientIdService>('ClientIdService', [
+      'getOrGenerateClientId',
+    ]);
+    clientId.getOrGenerateClientId.and.resolveTo(LOCAL_CLIENT_ID);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ConflictResolutionService,
+        OperationLogEffects,
+        OperationLogStoreService,
+        OperationCaptureService,
+        provideMockActions(() => actions$),
+        { provide: Store, useValue: store },
+        { provide: OperationApplierService, useValue: operationApplier },
+        { provide: ValidateStateService, useValue: validateState },
+        { provide: OperationLogCompactionService, useValue: compaction },
+        {
+          provide: ImmediateUploadService,
+          useValue: jasmine.createSpyObj<ImmediateUploadService>(
+            'ImmediateUploadService',
+            ['trigger'],
+          ),
+        },
+        { provide: ClientIdService, useValue: clientId },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj<SnackService>('SnackService', ['open']),
+        },
+        {
+          provide: CLIENT_ID_PROVIDER,
+          useValue: {
+            loadClientId: () => Promise.resolve(LOCAL_CLIENT_ID),
+            getOrGenerateClientId: () => Promise.resolve(LOCAL_CLIENT_ID),
+            clearCache: () => {},
+          },
+        },
+        { provide: ENTITY_REGISTRY, useValue: buildEntityRegistry() },
+      ],
+    });
+
+    opLogStore = TestBed.inject(OperationLogStoreService);
+    capture = TestBed.inject(OperationCaptureService);
+    writeFlush = TestBed.inject(OperationWriteFlushService);
+    resolver = TestBed.inject(ConflictResolutionService);
+    journal = TestBed.inject(ConflictJournalService);
+    capture.clear();
+    store.dispatch.and.callFake(((action: Action): void => {
+      if (!isPersistentAction(action)) {
+        throw new Error('Expected a persistent action');
+      }
+      capture.incrementPending(action);
+      actions$.next(action);
+    }) as Store['dispatch']);
+
+    await opLogStore.init();
+    await opLogStore._clearAllDataForTesting();
+    await journal.clearAll();
+    effectSubscription =
+      TestBed.inject(OperationLogEffects).persistOperation$.subscribe();
+  });
+
+  afterEach(async () => {
+    await writeFlush.flushPendingWrites();
+    effectSubscription.unsubscribe();
+    actions$.complete();
+    capture.clear();
+    clearDeferredActions();
+    await opLogStore._clearAllDataForTesting();
+    await journal.clearAll();
+    TestBed.resetTestingModule();
+  });
+
+  const dispatchAndFlush = async (action: PersistentAction): Promise<Operation[]> => {
+    store.dispatch(action);
+    await writeFlush.flushPendingWrites();
+    return (await opLogStore.getUnsynced()).map(({ op }) => op);
+  };
+
+  const buildRemoteTaskUpdate = (targetTaskId: string, timestamp: number): Operation => {
+    const remoteAction = TaskSharedActions.updateTask({
+      task: { id: targetTaskId, changes: { title: 'Concurrent remote edit' } },
+    }) as PersistentAction;
+    const { type, meta, ...actionPayload } = remoteAction;
+    return {
+      ...new TestClient(REMOTE_CLIENT_ID).createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: targetTaskId,
+        payload: { actionPayload, entityChanges: [] },
+      }),
+      timestamp,
+    };
+  };
+
+  const detectConflictsFor = async (
+    remoteOperation: Operation,
+  ): Promise<EntityConflict[]> => {
+    const detection = await resolver.checkOpForConflicts(remoteOperation, {
+      localPendingOpsByEntity: await opLogStore.getUnsyncedByEntity(),
+      appliedFrontierByEntity: new Map(),
+      retainedOpsByEntity: new Map(),
+      snapshotVectorClock: undefined,
+      snapshotEntityKeys: undefined,
+      hasNoSnapshotClock: true,
+    });
+    expect(detection.conflicts.length).toBeGreaterThan(0);
+    return detection.conflicts;
+  };
+
+  const unsyncedOps = async (): Promise<Operation[]> =>
+    (await opLogStore.getUnsynced()).map(({ op }) => op);
+
+  const appliedOps = (): Operation[] =>
+    operationApplier.applyOperations.calls.allArgs().flatMap(([ops]) => ops);
+
+  const expectDominates = (dominating: Operation, dominated: Operation): void => {
+    expect(compareVectorClocks(dominating.vectorClock, dominated.vectorClock)).toBe(
+      VectorClockComparison.GREATER_THAN,
+    );
+  };
+
+  describe('local planTasksForToday bulk op in a conflict', () => {
+    const planAllThree = (): PersistentAction =>
+      TaskSharedActions.planTasksForToday({
+        taskIds: [CONFLICT_TASK_ID, SIBLING_1, SIBLING_2],
+        today: TODAY,
+        startOfNextDayDiffMs: 0,
+      }) as PersistentAction;
+
+    it('resolves a remote-win conflict and re-emits the surviving siblings as a scoped replacement', async () => {
+      const [bulkOp] = await dispatchAndFlush(planAllThree());
+      expect(bulkOp.actionType).toBe(ActionType.TASK_SHARED_PLAN_FOR_TODAY);
+
+      const remoteOp = buildRemoteTaskUpdate(CONFLICT_TASK_ID, bulkOp.timestamp + 1);
+      const conflicts = await detectConflictsFor(remoteOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      const pending = await unsyncedOps();
+      expect(pending.length).toBe(1);
+      const replacement = pending[0];
+      expect(replacement.id).not.toBe(bulkOp.id);
+      expect(replacement.actionType).toBe(ActionType.TASK_SHARED_PLAN_FOR_TODAY);
+      expect(replacement.entityIds).toEqual([SIBLING_1, SIBLING_2]);
+      const actionPayload = (
+        replacement.payload as { actionPayload: Record<string, unknown> }
+      ).actionPayload;
+      expect(actionPayload['taskIds']).toEqual([SIBLING_1, SIBLING_2]);
+      expect(actionPayload['today']).toBe(TODAY);
+      expect(replacement.timestamp).toBe(bulkOp.timestamp);
+      expectDominates(replacement, bulkOp);
+      expectDominates(replacement, remoteOp);
+
+      // The remote winner is queued for apply; the losing bulk row is rejected.
+      expect(operationApplier.applyOperations).toHaveBeenCalled();
+      expect(appliedOps().map(({ id }) => id)).toContain(remoteOp.id);
+    });
+
+    it('excludes a local-win conflict target from the replacement (covered by its snapshot op)', async () => {
+      const [bulkOp] = await dispatchAndFlush(planAllThree());
+
+      const remoteOp = buildRemoteTaskUpdate(CONFLICT_TASK_ID, bulkOp.timestamp - 1000);
+      const conflicts = await detectConflictsFor(remoteOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      const pending = await unsyncedOps();
+      const replacement = pending.find(
+        (op) => op.actionType === ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+      );
+      const snapshotOp = pending.find(
+        (op) => op.actionType !== ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+      );
+      expect(pending.length).toBe(2);
+      expect(replacement).toBeDefined();
+      expect(replacement!.entityIds).toEqual([SIBLING_1, SIBLING_2]);
+      // The local-win target is carried by its whole-state snapshot op instead.
+      expect(snapshotOp).toBeDefined();
+      expect(snapshotOp!.entityId).toBe(CONFLICT_TASK_ID);
+      expect(snapshotOp!.opType).toBe(OpType.Update);
+    });
+
+    it('retains a local-win target that has NO covering snapshot (entity absent from store)', async () => {
+      const [bulkOp] = await dispatchAndFlush(planAllThree());
+      // The conflict target vanished from the live store (e.g. archived
+      // meanwhile), so the local win cannot produce a whole-state snapshot.
+      taskStateById[CONFLICT_TASK_ID] = undefined;
+
+      const remoteOp = buildRemoteTaskUpdate(CONFLICT_TASK_ID, bulkOp.timestamp - 1000);
+      const conflicts = await detectConflictsFor(remoteOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      // No snapshot op exists, so the replacement must RETAIN the target id —
+      // dropping it would silently lose the plan intent with no covering op.
+      // Replaying it elsewhere is at worst a no-op (reducers skip unknown ids).
+      const pending = await unsyncedOps();
+      expect(pending.length).toBe(1);
+      expect(pending[0].entityIds).toEqual([CONFLICT_TASK_ID, SIBLING_1, SIBLING_2]);
+      expect(pending[0].id).not.toBe(bulkOp.id);
+    });
+
+    it('resolves a deadline auto-plan bulk op (planDeadlineTasksForToday) the same way', async () => {
+      // Dispatched by the SAME day-rollover effect as planTasksForToday, with
+      // every deadline-due task id — leaving it out would keep deadline users
+      // permanently wedged.
+      const [bulkOp] = await dispatchAndFlush(
+        TaskSharedActions.planDeadlineTasksForToday({
+          taskIds: [CONFLICT_TASK_ID, SIBLING_1],
+          today: TODAY,
+          startOfNextDayDiffMs: 0,
+        }) as PersistentAction,
+      );
+      expect(bulkOp.actionType).toBe(ActionType.TASK_SHARED_PLAN_DEADLINE_FOR_TODAY);
+
+      const remoteOp = buildRemoteTaskUpdate(CONFLICT_TASK_ID, bulkOp.timestamp + 1);
+      const conflicts = await detectConflictsFor(remoteOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      const pending = await unsyncedOps();
+      expect(pending.length).toBe(1);
+      expect(pending[0].actionType).toBe(ActionType.TASK_SHARED_PLAN_DEADLINE_FOR_TODAY);
+      expect(pending[0].entityIds).toEqual([SIBLING_1]);
+      expect(
+        (pending[0].payload as { actionPayload: Record<string, unknown> }).actionPayload[
+          'taskIds'
+        ],
+      ).toEqual([SIBLING_1]);
+    });
+
+    it('rejects all bulk rows and writes ordered replacement clocks for the multi-day compounding case', async () => {
+      const [dayOneOp] = await dispatchAndFlush(planAllThree());
+      const pendingAfterSecond = await dispatchAndFlush(
+        TaskSharedActions.planTasksForToday({
+          taskIds: [CONFLICT_TASK_ID, SIBLING_1],
+          today: '2026-07-31',
+          startOfNextDayDiffMs: 0,
+        }) as PersistentAction,
+      );
+      expect(pendingAfterSecond.length).toBe(2);
+      const dayTwoOp = pendingAfterSecond.find(({ id }) => id !== dayOneOp.id)!;
+
+      const remoteOp = buildRemoteTaskUpdate(CONFLICT_TASK_ID, dayTwoOp.timestamp + 1);
+      const conflicts = await detectConflictsFor(remoteOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      const pending = await unsyncedOps();
+      expect(pending.length).toBe(2);
+      // Same-millisecond timestamps are possible, so identify the replacements
+      // by their surviving id sets instead of by timestamp order.
+      const firstReplacement = pending.find((op) => op.entityIds?.length === 2)!;
+      const secondReplacement = pending.find((op) => op.entityIds?.length === 1)!;
+      expect(firstReplacement.entityIds).toEqual([SIBLING_1, SIBLING_2]);
+      expect(secondReplacement.entityIds).toEqual([SIBLING_1]);
+      // Ordered, not concurrent: the later WRITTEN replacement must dominate
+      // the earlier one so receiving clients never see two concurrent ops on
+      // SIBLING_1. Guaranteed by the local-append clock rebase in
+      // appendMixedSourceBatchSkipDuplicates (#8939), not by the builder —
+      // this case fails if that rebase is ever bypassed.
+      expectDominates(secondReplacement, firstReplacement);
+    });
+  });
+
+  describe('ordering-only Today-list ops in a conflict', () => {
+    it('resolves a Today drag (moveTaskInTodayTagList) by rejecting the row without a replacement', async () => {
+      const [moveOp] = await dispatchAndFlush(
+        TaskSharedActions.moveTaskInTodayTagList({
+          toTaskId: CONFLICT_TASK_ID,
+          fromTaskId: SIBLING_1,
+        }) as PersistentAction,
+      );
+      expect(moveOp.actionType).toBe(ActionType.TASK_SHARED_MOVE_IN_TODAY);
+
+      const remoteOp = buildRemoteTaskUpdate(CONFLICT_TASK_ID, moveOp.timestamp + 1);
+      const conflicts = await detectConflictsFor(remoteOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      // Ordering-only: rejecting the row loses at most Today-list ordering.
+      expect(await unsyncedOps()).toEqual([]);
+      expect(appliedOps().map(({ id }) => id)).toContain(remoteOp.id);
+    });
+
+    it('resolves a bulk unplan (removeTasksFromTodayTag) by rejecting the row without a replacement', async () => {
+      const [removeOp] = await dispatchAndFlush(
+        TaskSharedActions.removeTasksFromTodayTag({
+          taskIds: [CONFLICT_TASK_ID, SIBLING_1],
+        }) as PersistentAction,
+      );
+      expect(removeOp.actionType).toBe(ActionType.TASK_SHARED_REMOVE_FROM_TODAY);
+
+      const remoteOp = buildRemoteTaskUpdate(CONFLICT_TASK_ID, removeOp.timestamp + 1);
+      const conflicts = await detectConflictsFor(remoteOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      expect(await unsyncedOps()).toEqual([]);
+    });
+  });
+
+  describe('remote planTasksForToday bulk op in a conflict', () => {
+    const buildRemotePlanOp = (taskIds: string[], timestamp: number): Operation => {
+      const remoteAction = TaskSharedActions.planTasksForToday({
+        taskIds,
+        today: TODAY,
+        startOfNextDayDiffMs: 0,
+      }) as PersistentAction;
+      const { type, meta, ...actionPayload } = remoteAction;
+      return {
+        ...new TestClient(REMOTE_CLIENT_ID).createOperation({
+          actionType: type,
+          opType: meta.opType,
+          entityType: meta.entityType,
+          entityId: taskIds[0],
+          entityIds: taskIds,
+          payload: { actionPayload, entityChanges: [] },
+        }),
+        timestamp,
+      };
+    };
+
+    it('applies the original bulk op once and compensates a local winner after it', async () => {
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: CONFLICT_TASK_ID, changes: { title: 'Local newer edit' } },
+        }) as PersistentAction,
+      );
+
+      const remotePlanOp = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        localEditOp.timestamp - 1000,
+      );
+      const conflicts = await detectConflictsFor(remotePlanOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      const applied = appliedOps();
+      // The original atomic remote op is applied exactly once, unmangled...
+      const appliedPlanOps = applied.filter(({ id }) => id === remotePlanOp.id);
+      expect(appliedPlanOps.length).toBe(1);
+      expect(appliedPlanOps[0].actionType).toBe(ActionType.TASK_SHARED_PLAN_FOR_TODAY);
+      // ...and the local winner's compensation snapshot is applied AFTER it.
+      const planIndex = applied.findIndex(({ id }) => id === remotePlanOp.id);
+      const compensationIndex = applied.findIndex(
+        (op) => op.entityId === CONFLICT_TASK_ID && op.id !== remotePlanOp.id,
+      );
+      expect(compensationIndex).toBeGreaterThan(planIndex);
+    });
+
+    it('degrades to a plain remote win when a local winner has no compensation snapshot', async () => {
+      // Local pending edit on a task that is ABSENT from the live store (e.g.
+      // archived after the edit): the local win cannot build a snapshot, so
+      // the pre-#9426 mixed-winner throw would wedge the batch. The Today-list
+      // replay skips unknown ids, so applying the bulk op as a remote win is
+      // safe — resolution must complete.
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: CONFLICT_TASK_ID, changes: { title: 'Local newer edit' } },
+        }) as PersistentAction,
+      );
+      taskStateById[CONFLICT_TASK_ID] = undefined;
+
+      const remotePlanOp = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        localEditOp.timestamp - 1000,
+      );
+      const conflicts = await detectConflictsFor(remotePlanOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      const appliedPlanOps = appliedOps().filter(({ id }) => id === remotePlanOp.id);
+      expect(appliedPlanOps.length).toBe(1);
+      // The losing local edit is rejected; nothing is left pending.
+      expect(await unsyncedOps()).toEqual([]);
+    });
+
+    it('does not mangle the bulk op when a local delete loses to it', async () => {
+      const conflictTask = taskStateById[CONFLICT_TASK_ID]!;
+      const [deleteOp] = await dispatchAndFlush(
+        TaskSharedActions.deleteTask({
+          task: { ...conflictTask, subTaskIds: [], subTasks: [] },
+        }) as PersistentAction,
+      );
+      expect(deleteOp.opType).toBe(OpType.Delete);
+      // The task is gone locally after the optimistic delete.
+      taskStateById[CONFLICT_TASK_ID] = undefined;
+
+      const remotePlanOp = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        deleteOp.timestamp + 1,
+      );
+      const conflicts = await detectConflictsFor(remotePlanOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      const appliedPlanOp = appliedOps().find(({ id }) => id === remotePlanOp.id);
+      expect(appliedPlanOp).toBeDefined();
+      // NOT rewritten into a single-entity LWW replace: the op must keep its
+      // action type and full taskIds so SIBLING_1 still gets planned.
+      expect(appliedPlanOp!.actionType).toBe(ActionType.TASK_SHARED_PLAN_FOR_TODAY);
+      expect(
+        (appliedPlanOp!.payload as { actionPayload: { taskIds: string[] } }).actionPayload
+          .taskIds,
+      ).toEqual([CONFLICT_TASK_ID, SIBLING_1]);
+    });
+  });
+});

--- a/src/app/op-log/testing/integration/unsupported-multi-entity-conflict.integration.spec.ts
+++ b/src/app/op-log/testing/integration/unsupported-multi-entity-conflict.integration.spec.ts
@@ -251,42 +251,18 @@ describe('unsupported archive multi-entity conflict integration (#9405)', () => 
   });
 
   describe('reachability of the guard beyond bulk actions', () => {
-    // The report reads as a recurring-task problem, but the guard is not scoped
-    // to one. Every action below carries >1 entityId and is neither an
-    // independent multi-delete nor decomposable, so one pending local op plus
-    // one concurrent remote edit of the same task is enough to stop sync. This
-    // pins that surface so the self-healing follow-up knows what it must cover;
-    // moving any of these into a safe path is expected to flip its case here.
+    // The report reads as a recurring-task problem, but the guard is not
+    // scoped to one. Every action below carries >1 entityId and is neither an
+    // independent multi-delete, decomposable, nor a resolvable Today-list op,
+    // so one pending local op plus one concurrent remote edit of the same task
+    // is enough to stop sync. This pins the REMAINING blocked surface; the
+    // formerly-pinned Today-list cases (moveTaskInTodayTagList,
+    // planTasksForToday, removeTasksFromTodayTag) resolve since #9426 and are
+    // covered by today-plan-conflict-resolution.integration.spec.ts.
     //
     // Each case notes its production dispatcher, because "an action creator
     // exists" is not the same claim as "a user can trigger it".
     const CASES: { name: string; action: () => PersistentAction }[] = [
-      {
-        // planner-day.component.ts: a drag inside Today. Always exactly 2 ids.
-        name: 'reordering Today by drag and drop',
-        action: () =>
-          TaskSharedActions.moveTaskInTodayTagList({
-            toTaskId: YOUNG_TASK_ID,
-            fromTaskId: OLD_TASK_ID,
-          }) as PersistentAction,
-      },
-      {
-        // add-tasks-for-tomorrow.service.ts and task-due.effects.ts dispatch
-        // this with every due task id, automatically, on day rollover.
-        name: 'the automatic day-rollover plan-for-today',
-        action: () =>
-          TaskSharedActions.planTasksForToday({
-            taskIds: [YOUNG_TASK_ID, OLD_TASK_ID],
-          }) as PersistentAction,
-      },
-      {
-        // work-context-menu.component.ts: "unplan" the remaining Today tasks.
-        name: 'unplanning the remaining Today tasks',
-        action: () =>
-          TaskSharedActions.removeTasksFromTodayTag({
-            taskIds: [YOUNG_TASK_ID, OLD_TASK_ID],
-          }) as PersistentAction,
-      },
       {
         // No production dispatcher since 6bb0472549 (v18.14.0) removed the tag
         // dialog; tag edits now go through the single-entity updateTask. Kept

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-scheduling.reducer.spec.ts
@@ -1058,4 +1058,38 @@ describe('taskSharedSchedulingMetaReducer', () => {
       expect(mockReducer).toHaveBeenCalledWith(baseState, action);
     });
   });
+
+  describe('ordering-only invariant for conflict resolution (#9426)', () => {
+    // ConflictResolutionService rejects conflicted multi-entity rows of these
+    // actions outright (ORDERING_ONLY_MULTI_ACTIONS): lossless ONLY while
+    // their handlers never touch task-entity fields — Today MEMBERSHIP is
+    // derived from task.dueDay/dueWithTime (ADR #2), so dropping the row loses
+    // at most list ordering. If one of these cases fails, the action changed
+    // semantics: remove it from the allowlist in conflict-resolution.service.ts
+    // (or give it a preserve path) BEFORE shipping the reducer change.
+    it('moveTaskInTodayTagList must leave the task feature state untouched', () => {
+      const testState = createStateWithExistingTasks([], [], [], ['task1', 'task2']);
+      const action = TaskSharedActions.moveTaskInTodayTagList({
+        toTaskId: 'task1',
+        fromTaskId: 'task2',
+      });
+
+      metaReducer(testState, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0];
+      expect(updatedState[TASK_FEATURE_NAME]).toBe(testState[TASK_FEATURE_NAME]);
+    });
+
+    it('removeTasksFromTodayTag must leave the task feature state untouched', () => {
+      const testState = createStateWithExistingTasks([], [], [], ['task1', 'task2']);
+      const action = TaskSharedActions.removeTasksFromTodayTag({
+        taskIds: ['task1'],
+      });
+
+      metaReducer(testState, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0];
+      expect(updatedState[TASK_FEATURE_NAME]).toBe(testState[TASK_FEATURE_NAME]);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`_assertMultiEntityPlansAreSafe` is a deliberate fail-closed preflight (#8980, shipped since v18.15.0): it runs over ALL planned conflict resolutions before any mutation and throws for any multi-entity op that is neither archive-win, independent-multi-delete, nor decomposable. One such op in one conflict therefore aborts the entire batch, the server cursor never advances, and sync fails identically on every retry with no in-app recovery ("Review sync conflicts" stays empty because the stop is pre-resolution).

The dominant real-world trigger is `planTasksForToday`: the automatic day-rollover (`TaskDueEffects` -> `addAllDueToday()`) emits ONE op carrying EVERY due task id, so a single concurrent remote edit of any one of those tasks wedges the client. Confirmed twice in the field: the op-log extraction in #9405 (blocked action `TASK_SHARED_PLAN_FOR_TODAY`, entity counts 32/47/55/61) and the timing analysis of the logs attached to #9426. It compounds: a wedged client falls through `afterInitialSyncDoneStrict$` 8s after the failed sync and mints a NEW bulk op every day, growing the blocked set. The same rollover also dispatches `planDeadlineTasksForToday`, and every Today drag (`moveTaskInTodayTagList`, always 2 ids) and bulk unplan (`removeTasksFromTodayTag`) reach the same guard; #9412 pinned all of these as reachable.

#9412 (merged, unreleased) improved the diagnostics only and explicitly deferred this fix.

## Why the fix is resolution-side

A capture-side change (splitting the bulk op at dispatch) would not heal the clients wedged in the field today: their bulk rows are already captured and pending. This fix resolves at conflict-resolution time, so wedged clients heal on their first sync retry after updating. It also has to cover the REMOTE side in the same release: a healed client uploads a scoped replacement that is itself a multi-entity op, and a receiver with any pending edit on a retained id would otherwise hit the remote branch of the same guard, transplanting the wedge from device A to device B.

## What the fix does

1. **`planTasksForToday` / `planDeadlineTasksForToday` rows (local): scoped replacement.** The atomic row is rejected as a unit (all local ops of a conflict always are), and ONE narrowed copy re-emits the surviving siblings' intent, mirroring the existing `_preservePartiallyRejectedLocalBulkDeletes` mechanism. The mechanism lives in a new pure util (`preserve-partial-bulk-plan.util.ts`) rather than growing the grandfathered 4.2k-line service. Conflict targets are dropped from the copy when they are covered (remote win: the newer remote op owns the task; local win with a whole-state snapshot op). An uncovered local-win target (entity absent from the live store, so no snapshot could be built) is retained: the reducers skip unknown task ids, so retention is at worst a replay no-op and can never silently drop plan intent.
2. **Ordering-only rows (`moveTaskInTodayTagList`, `removeTasksFromTodayTag`): plain rejection.** Their reducers touch only `TODAY_TAG.taskIds` ordering and the task adapter's `ids` order; Today MEMBERSHIP is derived from `task.dueDay`/`dueWithTime` (ADR #2). New invariant specs pin the entity-field-free property so a future reducer change cannot silently invalidate the allowlist. Honest caveat: for `removeTasksFromTodayTag` a rejected row can leave a stale legacy list entry visible on other clients until their own rollover cleans it up. Bounded and self-healing, versus a full sync freeze.
3. **Remote rows of these types: atomic replay via the existing mixed-winner machinery** (apply the original op once, then local-win snapshots as compensations after it, in durable seq order). A local winner without a compensation snapshot degrades to a logged remote win for these types instead of throwing `Cannot safely compensate mixed multi-entity winners`; that shape is reachable only when the winning entity is absent from the live store, where the replay skips it anyway.
4. **`_convertToLWWUpdatesIfNeeded` no longer converts multi-entity remote ops.** Rewriting a bulk row into a single-entity LWW replace would drop its effect on every other entity. Today that mangling is masked downstream by two accidents (the recreate path re-routes the original op, and the same-id converted copy dies in the append duplicate check); the guard makes the invariant explicit. Consequence for multi-entity delete-vs-update: the locally deleted entity stays deleted (the same logged degrade the codebase already chose for legacy bulk deletes) while the row still applies to its other entities.

**What stays fail-closed, deliberately:** `updateTasks` (two producers with opposite entity locations, archive-resident targets, coupled projectId moves, per the #9412 findings), `updateTask` with `projectMoveSubTaskIds` (coupled structural move), and legacy `addTagToTask`. These keep the typed `SYNC_MULTI_ENTITY_UNSUPPORTED` diagnostic; the pinning spec now covers exactly that remaining set.

## Fleet / compatibility (rule 10)

No schema bump, no new wire shapes, no envelope changes. A narrowed plan op is a payload shape every released client already produces and replays natively (single-task `planTasksForToday` ships via `TaskService.addToToday` and the task context menu). Replacement clocks dominate every conflict clock involving the original row; per-client monotonic ordering of multiple replacements is guaranteed by the existing local-append clock rebase (#8939) and is now pinned by a test that fails if that rebase is ever bypassed.

## Verification

- New integration spec (`today-plan-conflict-resolution.integration.spec.ts`, 10 cases) drives the REAL capture -> persistence -> conflict-detection -> resolution path (real op-log store, real effects): remote-win scoping, local-win exclusion, uncovered-target retention, deadline variant, multi-day compounding with ordered written clocks, ordering-only rejection for both actions, remote bulk apply-once + compensation ordering, mixed-winner degrade, and the delete-vs-bulk no-mangling contract. All 10 failed with the exact production error before the fix.
- Sabotage-verified: allowlist off (10/10 fail), retained-ids filter off (4 fail), unconditional mixed-winner throw restored (exactly the degrade case fails), store clock rebase bypassed (exactly the compounding case fails). Two sabotages initially SURVIVED and were investigated rather than papered over: builder-side clock chaining turned out to be redundant (the store rebase is the real guarantor, so the chaining was removed and the store property pinned instead), and the conversion guard is currently masked downstream (kept, with the masking documented in the comment).
- Full `src/app/op-log/**` spec tree green (3772 specs), plus the touched reducer suites; `checkFile` clean on every modified file.

## Review notes

The plan behind this PR was reviewed by two independent adversarial passes before implementation; their findings shaped the final shape (deadline-op coverage, conditional target exclusion, the degrade path, util placement, the invariant specs). Two suggested amendments were deliberately NOT taken:

- Extracting a shared payload-narrowing helper out of the proven `_createScopedBulkDeleteReplacement`: declined to keep the shipped delete path untouched in this PR (DRY at two occurrences did not outweigh churn on hardened sync code).
- Skipping replacements for stale-day plan rows: declined because the replacement propagates this device's CURRENT task state; dropping it would reintroduce exactly the silent divergence the mechanism exists to prevent, and would make resolution outcomes wall-clock-dependent.

## Field guidance

Wedged clients (v18.15.0 to v18.16.0) heal automatically on their first successful sync attempt after updating; no migration or manual recovery needed. The re-baseline workaround from #9405 remains valid for anyone who cannot update.

Fixes #9426. Refs #9405 (the blocked action extracted there is exactly the one this makes resolvable; the two known non-Today shapes stay fail-closed with the #9412 diagnostic).
