### PR TITLE
feat(sync): guide recovery from plaintext-op integrity stops (#9439)

### DIFF
--- a/docs/sync-and-op-log/supersync-encryption-architecture.md
+++ b/docs/sync-and-op-log/supersync-encryption-architecture.md
@@ -312,7 +312,14 @@ instead of copying the private-config shape into new code.
 >
 > Known limitation: a peer running an app version that predates the GHSA-9544
 > _upload_ guard can still push plaintext ops; a keyed client then fails closed
-> here with the tamper message. Recovery is to update the old peer.
+> here with the tamper message. Keep older peers offline and update them before
+> they sync again. If an updated client has a verified complete copy, export a
+> backup and use its explicit **Force Overwrite** action to replace the mixed
+> history with an encrypted clean-slate full state. Never run that action from a
+> fresh or incomplete client. If no verified complete client remains, preserve
+> the database and clients for incident recovery; do not skip the row or advance
+> a cursor past it. See
+> [`backup-and-recovery.md`](../../packages/super-sync-server/docs/backup-and-recovery.md#recovering-a-mixed-encryptedplaintext-history).
 >
 > Full protection — binding the metadata (and the encryption flag) as GCM AAD
 > behind an envelope-version migration, with a monotonic "encryption floor" to

--- a/docs/wiki/2.02-Restore-Data-From-Backup.md
+++ b/docs/wiki/2.02-Restore-Data-From-Backup.md
@@ -22,6 +22,19 @@ On Android, automatic backups are stored inside the app data instead of as visib
 
 Use this only as a recovery action. If sync is configured, the restored data is treated like a backup import and can overwrite other synced devices on the next sync.
 
+## SuperSync Security Integrity Error
+
+Use this recovery only when an updated device still shows the complete, current data. **Force Overwrite replaces the SuperSync server copy and propagates that device's data to every other device. Never run it from a blank, newly installed, incomplete, or stale device.**
+
+1. Keep every other device offline. Do not clear or uninstall the device with the complete data.
+2. On the complete device, update Super Productivity and verify that recent tasks, projects, and archives are present.
+3. Go to **Settings → Sync & Backup → Import/Export**, export the data, and store that plaintext backup securely.
+4. In **Settings → Sync & Backup → Sync**, open **Advanced**, choose **Force Overwrite**, and confirm the replacement.
+5. Wait for sync to finish successfully before reconnecting another device.
+6. Update the other devices before reconnecting them, sync one at a time, and verify the restored data. Keep the backup until every device is correct.
+
+If no device has a verified complete copy, do not use Force Overwrite and do not reset the server account. Keep the remaining devices unchanged and contact support so the retained history can be inspected.
+
 ## Alternative Method: Clear App Data First, then Import
 
 If the app does not start properly (e.g. [inconsistent task state](https://github.com/super-productivity/super-productivity/issues/3052)), clear local data and then import a backup:

--- a/e2e/tests/sync/supersync-plaintext-history-recovery-9439.spec.ts
+++ b/e2e/tests/sync/supersync-plaintext-history-recovery-9439.spec.ts
@@ -1,0 +1,327 @@
+import {
+  SuperSyncDownloadOpsResponseSchema,
+  SuperSyncUploadOpsRequestSchema,
+  SuperSyncUploadOpsResponseSchema,
+  type SuperSyncOperation,
+} from '@sp/shared-schema';
+import { decrypt } from '@sp/sync-core';
+import { expect, test } from '../../fixtures/supersync.fixture';
+import {
+  closeClient,
+  createSimulatedClient,
+  createTestUser,
+  getSuperSyncConfig,
+  routeSuperSyncOps,
+  SUPERSYNC_BASE_URL,
+  type SimulatedE2EClient,
+  waitForTask,
+} from '../../utils/supersync-helpers';
+
+type DownloadHistory = ReturnType<typeof SuperSyncDownloadOpsResponseSchema.parse>;
+
+interface SeededPlaintextOperation {
+  id: string;
+  serverSeq: number;
+}
+
+interface RawServerOperation {
+  id: string;
+  opType: string;
+  serverSeq: number;
+}
+
+interface CapturedSnack {
+  actionLabels: string[];
+  message: string;
+}
+
+const authHeaders = (token: string): Headers => {
+  const headers = new Headers();
+  headers.set('Authorization', `Bearer ${token}`);
+  headers.set('Content-Type', 'application/json');
+  return headers;
+};
+
+const downloadServerHistory = async (token: string): Promise<DownloadHistory> => {
+  const response = await fetch(
+    `${SUPERSYNC_BASE_URL}/api/sync/ops?sinceSeq=0&limit=1000`,
+    { headers: authHeaders(token) },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to inspect SuperSync history: ${response.status} ${await response.text()}`,
+    );
+  }
+  return SuperSyncDownloadOpsResponseSchema.parse(await response.json());
+};
+
+const downloadRawServerOps = async (userId: number): Promise<RawServerOperation[]> => {
+  const response = await fetch(
+    `${SUPERSYNC_BASE_URL}/api/test/user/${userId}/ops?limit=100`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to inspect raw server operations: ${response.status} ${await response.text()}`,
+    );
+  }
+  return ((await response.json()) as { ops: RawServerOperation[] }).ops;
+};
+
+const mergeHistoryClock = (history: DownloadHistory): Record<string, number> => {
+  const merged: Record<string, number> = {};
+  for (const { op } of history.ops) {
+    for (const [clientId, counter] of Object.entries(op.vectorClock)) {
+      merged[clientId] = Math.max(merged[clientId] ?? 0, counter);
+    }
+  }
+  return merged;
+};
+
+/**
+ * Reuses a genuine app-created encrypted TASK operation, decrypts its payload,
+ * and uploads the same wire shape as plaintext. This models the historical
+ * pre-upload-guard leak without mocking the client or server sync seams.
+ */
+const uploadPlaintextClone = async (
+  token: string,
+  password: string,
+  testRunId: string,
+  history: DownloadHistory,
+): Promise<SeededPlaintextOperation> => {
+  const source = history.ops.find(
+    ({ op }) =>
+      op.entityType === 'TASK' &&
+      op.isPayloadEncrypted === true &&
+      typeof op.payload === 'string',
+  )?.op;
+  if (!source || typeof source.payload !== 'string') {
+    throw new Error('No encrypted TASK operation available for the plaintext seed');
+  }
+
+  const clientId = `issue-9439-seed-${testRunId}`;
+  const plaintextOp: SuperSyncOperation = {
+    ...source,
+    id: crypto.randomUUID(),
+    clientId,
+    payload: JSON.parse(await decrypt(source.payload, password)),
+    vectorClock: { ...mergeHistoryClock(history), [clientId]: 1 },
+    timestamp: Date.now(),
+    isPayloadEncrypted: false,
+  };
+  const requestBody = SuperSyncUploadOpsRequestSchema.parse({
+    clientId,
+    ops: [plaintextOp],
+  });
+  const response = await fetch(`${SUPERSYNC_BASE_URL}/api/sync/ops`, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify(requestBody),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to seed plaintext operation: ${response.status} ${await response.text()}`,
+    );
+  }
+
+  const result = SuperSyncUploadOpsResponseSchema.parse(await response.json());
+  const upload = result.results[0];
+  if (result.results.length !== 1 || upload.accepted !== true || !upload.serverSeq) {
+    throw new Error(`Server rejected plaintext fixture: ${JSON.stringify(result)}`);
+  }
+  return { id: plaintextOp.id, serverSeq: upload.serverSeq };
+};
+
+const forceOverwriteFromTrustedClient = async (
+  client: SimulatedE2EClient,
+): Promise<void> => {
+  await client.sync.syncBtn.click({ button: 'right', noWaitAfter: true });
+  await client.sync.providerSelect.waitFor({ state: 'visible', timeout: 10000 });
+
+  const forceOverwriteButton = client.page.getByRole('button', {
+    name: 'Force Overwrite',
+    exact: true,
+  });
+  if (!(await forceOverwriteButton.isVisible().catch(() => false))) {
+    await client.page
+      .locator('.collapsible-header')
+      .filter({ hasText: 'Advanced' })
+      .click();
+  }
+  await expect(forceOverwriteButton).toBeVisible();
+
+  client.page.once('dialog', async (dialog) => {
+    expect(dialog.type()).toBe('confirm');
+    expect(dialog.message()).toContain('REPLACE all data on the server');
+    try {
+      await dialog.accept();
+    } catch {
+      // setupSuperSync also guards native confirmations and may win this race.
+    }
+  });
+  await forceOverwriteButton.click();
+};
+
+test.describe('@supersync @encryption #9439 plaintext history recovery', () => {
+  test('trusted-client force overwrite restores a fresh client without accepting plaintext', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.setTimeout(180000);
+    let trustedClient: SimulatedE2EClient | null = null;
+    let freshClient: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const password = `issue-9439-${testRunId}`;
+      const syncConfig = {
+        ...getSuperSyncConfig(user),
+        isEncryptionEnabled: true,
+        password,
+      };
+      const preservedTask = `Preserved-${testRunId}`;
+
+      trustedClient = await createSimulatedClient(
+        browser,
+        baseURL!,
+        'trusted',
+        testRunId,
+      );
+      await trustedClient.sync.setupSuperSync(syncConfig);
+      await trustedClient.workView.addTask(preservedTask);
+      await trustedClient.sync.syncAndWait();
+
+      const validHistory = await downloadServerHistory(user.token);
+      const plaintextOp = await uploadPlaintextClone(
+        user.token,
+        password,
+        testRunId,
+        validHistory,
+      );
+
+      freshClient = await createSimulatedClient(browser, baseURL!, 'fresh', testRunId);
+      await freshClient.page.evaluate(() => {
+        const capturedSnacks: CapturedSnack[] = [];
+        const observer = new MutationObserver(() => {
+          document.querySelectorAll('snack-custom').forEach((element) => {
+            const message = element.querySelector('.message')?.textContent?.trim();
+            if (!message) return;
+            const actionLabels = Array.from(
+              element.querySelectorAll<HTMLButtonElement>('button.action'),
+            ).flatMap((button) => {
+              const label = button.textContent?.trim();
+              return label ? [label] : [];
+            });
+            const signature = JSON.stringify({ message, actionLabels });
+            if (!capturedSnacks.some((snack) => JSON.stringify(snack) === signature)) {
+              capturedSnacks.push({ message, actionLabels });
+            }
+          });
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        (
+          globalThis as unknown as {
+            __issue9439Snacks?: CapturedSnack[];
+          }
+        ).__issue9439Snacks = capturedSnacks;
+      });
+      const requestedSinceSeqs: number[] = [];
+      await routeSuperSyncOps(freshClient.page, async (route) => {
+        if (route.request().method() === 'GET') {
+          const url = new URL(route.request().url());
+          requestedSinceSeqs.push(Number(url.searchParams.get('sinceSeq') ?? 0));
+          url.searchParams.set('limit', '1');
+          await route.continue({ url: url.toString() });
+          return;
+        }
+        await route.continue();
+      });
+
+      await freshClient.sync.setupSuperSync({
+        ...syncConfig,
+        waitForInitialSync: false,
+      });
+
+      await expect(freshClient.sync.syncErrorIcon).toBeVisible({ timeout: 30000 });
+      await expect(
+        freshClient.page.locator(`task:has-text("${preservedTask}")`),
+      ).not.toBeVisible();
+      expect(requestedSinceSeqs).toContain(plaintextOp.serverSeq - 1);
+      const zeroRequestsBeforeExplicitRetry = requestedSinceSeqs.filter(
+        (sinceSeq) => sinceSeq === 0,
+      ).length;
+      await freshClient.sync.syncBtn.click();
+      await expect
+        .poll(() => requestedSinceSeqs.filter((sinceSeq) => sinceSeq === 0).length, {
+          timeout: 30000,
+        })
+        .toBeGreaterThan(zeroRequestsBeforeExplicitRetry);
+      await expect(
+        freshClient.page.locator(`task:has-text("${preservedTask}")`),
+      ).not.toBeVisible();
+      expect(
+        (await downloadRawServerOps(user.userId)).some(({ id }) => id === plaintextOp.id),
+      ).toBe(true);
+
+      const capturedSnacks = await freshClient.page.evaluate(
+        () =>
+          (
+            globalThis as unknown as {
+              __issue9439Snacks?: CapturedSnack[];
+            }
+          ).__issue9439Snacks ?? [],
+      );
+      const integritySnacks = capturedSnacks.filter(({ message }) =>
+        message.includes('security integrity check'),
+      );
+      expect(integritySnacks.length).toBeGreaterThan(0);
+      expect(integritySnacks.every(({ actionLabels }) => actionLabels.length === 0)).toBe(
+        true,
+      );
+      expect(integritySnacks.map(({ message }) => message).join('\n')).toContain(
+        'export a backup',
+      );
+      expect(integritySnacks.map(({ message }) => message).join('\n')).toContain(
+        'Force Overwrite',
+      );
+
+      await forceOverwriteFromTrustedClient(trustedClient);
+      await expect
+        .poll(
+          async () => {
+            const [history, rawOps] = await Promise.all([
+              downloadServerHistory(user.token),
+              downloadRawServerOps(user.userId),
+            ]);
+            return (
+              !rawOps.some(({ id }) => id === plaintextOp.id) &&
+              history.latestSeq > plaintextOp.serverSeq &&
+              history.ops.every(({ op }) => op.isPayloadEncrypted === true) &&
+              history.ops.some(
+                ({ op, serverSeq }) =>
+                  op.opType === 'SYNC_IMPORT' &&
+                  op.isPayloadEncrypted === true &&
+                  serverSeq > plaintextOp.serverSeq,
+              )
+            );
+          },
+          { timeout: 60000 },
+        )
+        .toBe(true);
+
+      const recoveredHistory = await downloadServerHistory(user.token);
+      expect(recoveredHistory.ops.every(({ op }) => op.isPayloadEncrypted === true)).toBe(
+        true,
+      );
+      expect(recoveredHistory.latestSeq).toBeGreaterThan(plaintextOp.serverSeq);
+
+      await trustedClient.page.keyboard.press('Escape');
+      await freshClient.sync.syncAndWait();
+      await waitForTask(freshClient.page, preservedTask);
+      await expect(freshClient.sync.syncErrorIcon).not.toBeVisible();
+    } finally {
+      if (trustedClient) await closeClient(trustedClient);
+      if (freshClient) await closeClient(freshClient);
+    }
+  });
+});

--- a/packages/super-sync-server/docs/backup-and-recovery.md
+++ b/packages/super-sync-server/docs/backup-and-recovery.md
@@ -159,6 +159,40 @@ authentication failure as a bare `Error` (fallback crypto).
 ciphertext, and `WebCryptoNotAvailableError` is an environment failure —
 neither is password evidence.
 
+### Recovering a mixed encrypted/plaintext history
+
+An encryption-enabled client that logs
+`received a plaintext op while encryption is mandatory` is not reporting a
+wrong passphrase. It has found a plaintext row in an account that is expected
+to contain only encrypted payloads. The client rejects the complete download
+without applying its valid prefix or advancing its durable cursor.
+
+If an **updated** client still has a verified complete, current copy of the
+account, use the supported client recovery:
+
+1. Keep every other client offline and preserve the complete client unchanged.
+2. Export a full backup from that client and protect it as plaintext user data.
+3. In its sync settings, open **Advanced** and choose **Force Overwrite**.
+4. Wait for the encrypted clean-slate upload to finish before updating and
+   reconnecting the other clients one at a time.
+5. Verify the reconstructed data on a fresh client before deleting the backup.
+
+Force Overwrite deletes the mixed operation dataset and uploads the selected
+client's state as an encrypted full-state operation while preserving server
+sequence monotonicity. Do not run it from a fresh, incomplete, stale, or
+pre-fix client.
+
+Do **not** recover by changing `isPayloadEncrypted`, applying or skipping the
+plaintext row, deleting that row alone, or advancing a client cursor past it.
+The flag and surrounding envelope are unauthenticated, so those shortcuts can
+apply forged data or silently construct an incomplete state. If no client has
+a verified complete copy, preserve the clients and database, inspect only safe
+row metadata first, and treat any server-side reconstruction as an incident
+recovery against an isolated database restore rather than a normal sync path.
+
+The real-shape recovery regression is
+`e2e/tests/sync/supersync-plaintext-history-recovery-9439.spec.ts`.
+
 `scripts/recover-user.ts` fills the encrypted-recovery gap. It replays the user's operation log up
 to a chosen `serverSeq`, decrypting encrypted payloads with the user's
 passphrase, and writes an importable `AppDataComplete` JSON file. It is
@@ -228,3 +262,4 @@ The backup recovery scenarios are covered by automated tests in `e2e/tests/sync/
 1. **Complete data loss** — server wiped, single client recovers all data
 2. **Partial revert** — server reverted to older state, client preserves local data
 3. **Accounts-only restore** — recommended recovery path with multi-client convergence
+4. **Mixed encrypted/plaintext history** — fail closed, then recover through an encrypted trusted-client Force Overwrite

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -1223,6 +1223,12 @@ describe('SyncWrapperService', () => {
       expect(mockSnackService.open).not.toHaveBeenCalledWith(
         jasmine.objectContaining({ msg: jasmine.stringMatching(/GHSA-/) }),
       );
+      const openedSnack = mockSnackService.open.calls.mostRecent().args[0];
+      expect(typeof openedSnack).not.toBe('string');
+      if (typeof openedSnack !== 'string') {
+        expect(openedSnack.actionStr).toBeUndefined();
+        expect(openedSnack.actionFn).toBeUndefined();
+      }
     });
 
     it('should handle NetworkUnavailableSPError with WARNING snackbar when user-triggered', async () => {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1641,7 +1641,7 @@
         "INCOMPLETE_REMOTE_OPERATIONS": "Downloaded changes could not finish applying. Sync is paused to protect your data. Restart the app to retry. If this keeps happening, restore a backup.",
         "INITIAL_SYNC_ERROR": "Initial Sync failed",
         "INTEGRITY_CHECK_FAILED": "Data integrity issue detected. Auto-repair attempted. If you experience issues, please reload the app.",
-        "INTEGRITY_TAMPER_DETECTED": "Sync stopped: the server returned data that failed a security integrity check. Your local data is safe. This can indicate a tampered or misconfigured sync server.",
+        "INTEGRITY_TAMPER_DETECTED": "Sync stopped: the server returned data that failed a security integrity check. Your local data is safe. On an updated device that you have verified contains the complete, current data, export a backup, then use Force Overwrite in Sync settings under Advanced. Keep other devices offline until it finishes. Otherwise, stop and contact support.",
         "INVALID_AUTH_CODE": "The authorization code was rejected. Please try authenticating again and make sure to copy the code exactly.",
         "INVALID_OPERATION_PAYLOAD": "Invalid operation detected. Changes may not be saved - please reload.",
         "LEGACY_FORMAT_DETECTED": "Sync format mismatch: the remote storage was last written by an older app version (v16.x or earlier) that uses a different sync format. Please update all your devices to the same app version. \"Force overwrite\" unblocks this device by writing the new format alongside the legacy files; only use it if no older device will sync to this remote anymore, otherwise they will silently diverge from this device.",


### PR DESCRIPTION
Closes #9439

## Problem

A fresh encrypted client cannot recover a SuperSync account whose history contains a plaintext operation. The client correctly fails closed (`assertOpsEncryptedWhenExpected`, GHSA-8pxh-mgc7-gp3g): the `isPayloadEncrypted` flag is unauthenticated, so accepting plaintext would allow forged operations to bypass decryption and every post-decrypt integrity check. But the user was left with a dead end: the snackbar explained nothing actionable, and no supported recovery path was documented anywhere.

## Approach

No sync behavior changes. Default sync keeps rejecting plaintext atomically (no partial apply, no cursor advance). This PR documents and pins the already-supported recovery, an explicit trusted-client **Force Overwrite**, and makes the in-app message point to it:

- **`en.json`** (English only, per translation policy): `INTEGRITY_TAMPER_DETECTED` now states the precondition (an updated device verified to contain the complete, current data), the steps (export a backup, then Advanced -> Force Overwrite, other devices offline), and the fallback (stop and contact support).
- **Unit assertion** (`sync-wrapper.service.spec.ts`): the integrity snack must carry no `actionStr`/`actionFn`. Recovery must never be one click away from the incomplete client; sabotage-verified (adding an action makes exactly these assertions fail).
- **E2E regression** (`supersync-plaintext-history-recovery-9439.spec.ts`, real server and wire shapes, no mocked seams):
  1. Seeds the failure by decrypting a genuine app-created encrypted TASK op and re-uploading the same wire shape as plaintext (models the historical pre-upload-guard leak from #8670).
  2. Forces one-op download pages via route interception to prove atomicity across pagination: the fresh client walks to the bad row (`sinceSeq` assertions), rejects the complete download, applies nothing, and an explicit retry restarts from `sinceSeq=0` (durable cursor untouched).
  3. Asserts the integrity snack appears with zero action buttons and contains the recovery guidance.
  4. Runs Force Overwrite through the actual UI on the trusted client and verifies server-side: plaintext row deleted, sequence numbers stay monotonic, the surviving history is all-encrypted with a newer `SYNC_IMPORT`, and the previously wedged fresh client then syncs and recovers the data.
- **Docs**: recovery section in `packages/super-sync-server/docs/backup-and-recovery.md` (including what NOT to do: no flag flips, no row deletion, no cursor skips, since the envelope is unauthenticated), a pointer from the known-limitation note in `supersync-encryption-architecture.md`, and a user-facing procedure in the wiki restore How-To.

## Reviewer notes

- **Wiki How-To edit (2.02)**: per `docs/documentation-guide.md`, prose changes to How-To notes should get human review. The new "SuperSync Security Integrity Error" section is new scope in that note; please check tone/voice.
- The e2e intentionally asserts on user-facing copy fragments ("security integrity check", "export a backup", "Force Overwrite") and on the native confirm text. Future copy edits will need to touch the test; that coupling is the point of the guidance regression.
- The snack keeps `duration: 15000`. A sticky variant (`duration: 0`, precedent: `INCOMPLETE_REMOTE_OPERATIONS`) was considered; the message reappears on every sync attempt and the sync-problem icon persists, so the shorter duration was kept. Open to changing this.
- Force Overwrite remains reachable on the failing fresh client (edit mode). The message precondition and the native "REPLACE all data on the server" confirm are the guards; the docs warn in bold never to run it from a blank or incomplete device.

## Verification

- Focused SuperSync Playwright regression: 1 passed against a real local server (see the verification comment on #9439).
- `SyncWrapperService` unit suite: 153/153; the new assertions were sabotage-verified (mutated snack -> exactly those two expectations fail).
- `checkFile` clean on both TS files; new spec has zero type errors under `e2e/tsconfig.json`.
- Doc link checker green in both CI modes (`--docs-only` on the three touched docs, `--sources-only`); cross-doc anchor verified.
- UI labels in docs/message verified against the live form config ("Sync & Backup" tab, "Import/Export" section, "Advanced Config" collapsible, "Force Overwrite" button).

No schema bump, no new dependencies, no behavior change for old clients.
