### PR TITLE
fix(plugins): sanitize dialog html with an allowlist

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -414,6 +414,18 @@ the dialog without clicking a button, it resolves with `undefined`. The legacy
 `content`, `okBtnLabel`, and `cancelBtnLabel` fields are still accepted, but new
 plugins should use `htmlContent` and `buttons`.
 
+The host sanitizes `htmlContent` before rendering it, rebuilding the markup from
+an allowlist. Semantic HTML, native form controls (including their `id`s and
+values), `class`, `data-*`, `aria-*`, and inline layout styles are preserved.
+Removed are scripts, event-handler attributes, unsafe URLs, inline `<svg>`, and
+any `style` attribute containing `url(`, since dialog layout never needs to load
+a resource. Elements outside the allowlist are unwrapped, so their text stays
+visible while the tag itself is dropped.
+
+Escape untrusted values before interpolating them into the HTML string: the
+sanitizer is a safety net for the host, not a substitute for escaping in your
+plugin. Use `content` when plain text is sufficient.
+
 ### Registration Methods (plugin.js only)
 
 #### Header Button

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -77,7 +77,7 @@ development guide live in `packages/plugin-api/src/types.ts` and
 **UI:**
 
 - `showSnack(snackCfg)`, `notify(notifyCfg)` — Notifications.
-- `openDialog(dialogCfg)` — Opens a plugin dialog and resolves to the clicked button label, or `undefined` if the dialog is dismissed.
+- `openDialog(dialogCfg)` — Opens a plugin dialog and resolves to the clicked button label, or `undefined` if the dialog is dismissed. The host sanitizes `htmlContent` against an allowlist, keeping semantic HTML, form controls and layout styles while removing scripts, event handlers, unsafe URLs, inline `<svg>`, and styles containing `url(`.
 - `showIndexHtmlAsView()` — Shows plugin UI.
 
 **Registration (main plugin context only; not in iframe):**

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -54,6 +54,12 @@ export type DialogResult = string | undefined;
 
 export interface DialogCfg {
   title?: string;
+  /**
+   * Rich HTML sanitized by the host before rendering, rebuilt from an allowlist.
+   * Semantic HTML, native form controls and inline layout styles are preserved;
+   * scripts, event-handler attributes, unsafe URLs, inline `<svg>` and `style`
+   * values containing `url(` are removed. Escape untrusted values yourself.
+   */
   htmlContent?: string;
   content?: string;
   okBtnLabel?: string;

--- a/src/app/plugins/plugin-security.spec.ts
+++ b/src/app/plugins/plugin-security.spec.ts
@@ -1,0 +1,185 @@
+import { TestBed } from '@angular/core/testing';
+import { PluginSecurityService } from './plugin-security';
+
+describe('PluginSecurityService', () => {
+  let service: PluginSecurityService;
+
+  beforeEach(() => {
+    service = TestBed.inject(PluginSecurityService);
+  });
+
+  describe('sanitizeHtml', () => {
+    it('removes executable elements, attributes, styles, and URLs', () => {
+      const sanitized = service.sanitizeHtml(`
+        <script>alert('script')</script>
+        <iframe srcdoc="<script>alert('iframe')</script>"></iframe>
+        <svg onload="alert('svg')"><circle></circle></svg>
+        <img src="javascript:alert('url')" onerror="alert('event')" style="background:url(https://evil.test/x.png)">
+        <img src="data:image/svg+xml,<svg onload=alert('data')></svg>">
+        <a href="&#x6a;avascript:alert('link')" onmouseover="alert('hover')">Link</a>
+        <button formaction="javascript:alert('submit')" onclick="alert('click')">
+          Submit
+        </button>
+      `);
+
+      expect(sanitized).not.toContain('<script');
+      expect(sanitized).not.toContain('<iframe');
+      expect(sanitized).not.toContain('<svg');
+      expect(sanitized).not.toContain('javascript:');
+      expect(sanitized).not.toContain('onerror');
+      expect(sanitized).not.toContain('onmouseover');
+      expect(sanitized).not.toContain('onclick');
+      expect(sanitized).not.toContain('formaction');
+      expect(sanitized).not.toContain('image/svg+xml');
+      expect(sanitized).not.toContain('style=');
+    });
+
+    it('preserves supported semantic markup and form controls', () => {
+      const sanitized = service.sanitizeHtml(`
+        <section id="settings" data-state="ready" aria-label="Plugin settings">
+          <h2>Settings</h2>
+          <label for="name">Name</label>
+          <input id="name" type="text" value="Example" required>
+          <select id="choice"><option value="a" selected>A</option></select>
+          <textarea id="notes" rows="3" placeholder="Notes">Hello</textarea>
+        </section>
+      `);
+      const container = document.createElement('div');
+      container.innerHTML = sanitized;
+
+      const section = container.querySelector('section');
+      const input = container.querySelector('input');
+      const option = container.querySelector('option');
+      const textarea = container.querySelector('textarea');
+
+      expect(section?.id).toBe('settings');
+      expect(section?.getAttribute('data-state')).toBe('ready');
+      expect(section?.getAttribute('aria-label')).toBe('Plugin settings');
+      expect(input?.value).toBe('Example');
+      expect(input?.required).toBeTrue();
+      expect(option?.selected).toBeTrue();
+      expect(textarea?.rows).toBe(3);
+      expect(textarea?.textContent).toBe('Hello');
+    });
+
+    it('keeps safe links and raster image sources', () => {
+      const sanitized = service.sanitizeHtml(`
+        <a href="https://example.com/path" target="_blank">Example</a>
+        <a href="#settings">Settings</a>
+        <img src="data:image/png;base64,iVBORw0KGgo=" alt="Preview">
+      `);
+
+      expect(sanitized).toContain('href="https://example.com/path"');
+      expect(sanitized).toContain('href="#settings"');
+      expect(sanitized).toContain('rel="noopener noreferrer"');
+      expect(sanitized).toContain('src="data:image/png;base64,iVBORw0KGgo="');
+    });
+
+    it('rejects URLs that would resolve relative to the host application', () => {
+      const sanitized = service.sanitizeHtml(`
+        <a id="absolute-path" href="/etc/passwd">Absolute path</a>
+        <a id="protocol-relative" href="//example.com/path">Protocol relative</a>
+        <img id="relative-image" src="assets/example.png">
+      `);
+      const container = document.createElement('div');
+      container.innerHTML = sanitized;
+
+      expect(container.querySelector('#absolute-path')?.getAttribute('href')).toBeNull();
+      expect(
+        container.querySelector('#protocol-relative')?.getAttribute('href'),
+      ).toBeNull();
+      expect(container.querySelector('#relative-image')?.getAttribute('src')).toBeNull();
+    });
+
+    it('emits the same URL string it validated', () => {
+      // `trim()` strips U+00A0 but the URL parser does not, so emitting the raw
+      // value would turn a validated https link into a relative path.
+      const sanitized = service.sanitizeHtml(
+        `<a id="padded" href="\u00A0https://example.com/ok">Padded</a>` +
+          `<img id="padded-image" src="\u00A0data:image/png;base64,iVBORw0KGgo=" alt="p">`,
+      );
+      const container = document.createElement('div');
+      container.innerHTML = sanitized;
+
+      const link = container.querySelector('#padded') as HTMLAnchorElement;
+      const image = container.querySelector('#padded-image') as HTMLImageElement;
+
+      expect(link.getAttribute('href')).toBe('https://example.com/ok');
+      expect(link.protocol).toBe('https:');
+      expect(image.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=');
+    });
+
+    it('drops elements whose content must not become visible text', () => {
+      // The leading <p> matters: a <style>/<script>/<title> before any body
+      // content is routed into <head> by the parser, and only <body> is walked,
+      // so such a payload would never reach the drop check at all.
+      const sanitized = service.sanitizeHtml(
+        `<p>keep</p><style>p{color:red}</style><script>alert('x')</script><title>t</title>`,
+      );
+
+      expect(sanitized).toBe('<p>keep</p>');
+    });
+
+    it('keeps layout styles but drops declarations that can fetch', () => {
+      const sanitized = service.sanitizeHtml(
+        `<div id="layout" style="display:flex;gap:12px;width:100%;height:3px">a</div>`,
+      );
+      const container = document.createElement('div');
+      container.innerHTML = sanitized;
+      const style = (container.querySelector('#layout') as HTMLElement).style;
+
+      expect(style.display).toBe('flex');
+      expect(style.gap).toBe('12px');
+      expect(style.width).toBe('100%');
+      expect(style.height).toBe('3px');
+    });
+
+    it('drops url() from styles however it is spelled', () => {
+      // CSS resolves identifier escapes while tokenizing, so each of these is a
+      // real url() to the browser and only the normalized value reveals it.
+      const sanitized = service.sanitizeHtml(
+        `<div id="a" style="background:url(https://evil.test/a.png)">a</div>` +
+          `<div id="b" style="background:\\75 rl(https://evil.test/b.png)">b</div>` +
+          `<div id="c" style="background:\\75\\72\\6c(https://evil.test/c.png)">c</div>` +
+          `<div id="d" style="background:image-set('https://evil.test/d.png' 1x)">d</div>` +
+          `<div id="e" style="cursor:url(https://evil.test/e.cur),pointer">e</div>` +
+          `<div id="f" style="--x:\\75 rl(https://evil.test/f.png);background:var(--x)">f</div>`,
+      );
+
+      const container = document.createElement('div');
+      container.innerHTML = sanitized;
+
+      expect(sanitized).not.toContain('url(');
+      expect(sanitized).not.toContain('evil.test');
+      for (const id of ['a', 'b', 'c', 'd', 'e']) {
+        expect(container.querySelector(`#${id}`)?.getAttribute('style')).toBeNull();
+      }
+      // The var() indirection must not survive either: the custom property that
+      // held the escaped url() is gone, so nothing can substitute it back in.
+      const indirect = container.querySelector('#f') as HTMLElement;
+      expect(indirect.style.getPropertyValue('--x')).toBe('');
+    });
+
+    it('preserves the markup bundled plugin dialogs are built from', () => {
+      const sanitized = service.sanitizeHtml(
+        `<div style="display:flex;gap:12px">` +
+          `<div id="bd-color-bar" style="height:3px;border-radius:2px"></div>` +
+          `<textarea id="bd-input" rows="10" style="width:100%">saved</textarea>` +
+          `<input type="range" id="vr-volume" min="0" max="100" value="50" style="flex:1">` +
+          `</div>`,
+      );
+      const container = document.createElement('div');
+      container.innerHTML = sanitized;
+
+      const colorBar = container.querySelector('#bd-color-bar') as HTMLElement;
+      const textarea = container.querySelector('#bd-input') as HTMLTextAreaElement;
+      const slider = container.querySelector('#vr-volume') as HTMLInputElement;
+
+      expect(colorBar.style.height).toBe('3px');
+      expect(textarea.style.width).toBe('100%');
+      expect(textarea.value).toBe('saved');
+      expect(slider.style.flexGrow).toBe('1');
+      expect(slider.value).toBe('50');
+    });
+  });
+});

--- a/src/app/plugins/plugin-security.ts
+++ b/src/app/plugins/plugin-security.ts
@@ -2,9 +2,200 @@ import { Injectable } from '@angular/core';
 import { PluginManifest } from './plugin-api.model';
 
 /**
- * Simplified plugin security service following KISS principles.
- * Focuses on user awareness rather than restrictive validation.
+ * Elements that may appear in the output.
+ *
+ * SECURITY INVARIANT: no raw-text element may ever be added here. The HTML
+ * serializer emits the text of `style`, `script`, `xmp`, `iframe`, `noembed`,
+ * `noframes`, `plaintext` and `noscript` UNESCAPED, so an allowlisted raw-text
+ * element would let `output.innerHTML` produce markup that re-parses into new
+ * elements at the sink (the mutation-XSS class). Because none of them can be
+ * created, every text node in the output is entity-escaped and the sanitized
+ * string re-parses to the same tree. Re-adding `title` for accessibility, or
+ * `xmp`/`noembed` because they "cannot run scripts", would silently reopen it.
  */
+const SAFE_HTML_ELEMENTS: ReadonlySet<string> = new Set([
+  'a',
+  'abbr',
+  'address',
+  'article',
+  'aside',
+  'b',
+  'blockquote',
+  'br',
+  'button',
+  'caption',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hr',
+  'i',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'main',
+  'mark',
+  'meter',
+  'nav',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'pre',
+  'progress',
+  'q',
+  's',
+  'section',
+  'select',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'tr',
+  'u',
+  'ul',
+  'wbr',
+]);
+
+/**
+ * Dropped together with their content. Unwrapping these would be safe (their
+ * text ends up entity-escaped like any other), but it would render a stylesheet
+ * or a script body as visible garbage inside the dialog.
+ */
+const DROP_WITH_CONTENT_ELEMENTS: ReadonlySet<string> = new Set([
+  'base',
+  'embed',
+  'iframe',
+  'link',
+  'math',
+  'meta',
+  'noscript',
+  'object',
+  'script',
+  'style',
+  'svg',
+  'template',
+  'title',
+]);
+
+const GLOBAL_SAFE_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'class',
+  'dir',
+  'id',
+  'lang',
+  'role',
+  'style',
+  'title',
+]);
+
+const SAFE_ATTRIBUTES_BY_ELEMENT: Readonly<Record<string, ReadonlySet<string>>> = {
+  a: new Set(['href', 'rel', 'target']),
+  button: new Set(['disabled', 'name', 'type', 'value']),
+  col: new Set(['span']),
+  colgroup: new Set(['span']),
+  del: new Set(['datetime']),
+  details: new Set(['open']),
+  fieldset: new Set(['disabled', 'name']),
+  img: new Set(['alt', 'height', 'src', 'width']),
+  ins: new Set(['datetime']),
+  input: new Set([
+    'accept',
+    'autocomplete',
+    'checked',
+    'disabled',
+    'max',
+    'maxlength',
+    'min',
+    'minlength',
+    'multiple',
+    'name',
+    'pattern',
+    'placeholder',
+    'readonly',
+    'required',
+    'step',
+    'type',
+    'value',
+  ]),
+  label: new Set(['for']),
+  li: new Set(['value']),
+  meter: new Set(['high', 'low', 'max', 'min', 'optimum', 'value']),
+  ol: new Set(['reversed', 'start', 'type']),
+  optgroup: new Set(['disabled', 'label']),
+  option: new Set(['disabled', 'label', 'selected', 'value']),
+  output: new Set(['for', 'name']),
+  progress: new Set(['max', 'value']),
+  select: new Set(['disabled', 'multiple', 'name', 'required', 'size']),
+  td: new Set(['colspan', 'headers', 'rowspan']),
+  textarea: new Set([
+    'autocomplete',
+    'cols',
+    'disabled',
+    'maxlength',
+    'minlength',
+    'name',
+    'placeholder',
+    'readonly',
+    'required',
+    'rows',
+    'wrap',
+  ]),
+  th: new Set(['colspan', 'headers', 'rowspan', 'scope']),
+  time: new Set(['datetime']),
+};
+
+const SAFE_LINK_PROTOCOLS: ReadonlySet<string> = new Set([
+  'http:',
+  'https:',
+  'mailto:',
+  'tel:',
+]);
+const SAFE_IMAGE_PROTOCOLS: ReadonlySet<string> = new Set(['http:', 'https:']);
+const SAFE_RASTER_DATA_URL = /^data:image\/(?:avif|gif|jpeg|png|webp);base64,/i;
+
+/**
+ * Output is built here rather than in the live document: `document.createElement`
+ * + `setAttribute('src', …)` starts the image load immediately, so sanitizing
+ * would fetch every image before the dialog is even rendered. An inert document
+ * has no browsing context, so building the tree has no side effects at all.
+ */
+const BUILD_DOCUMENT = document.implementation.createHTMLDocument('plugin-sanitizer');
+
+/** Security checks and HTML sanitization for installed plugins. */
 @Injectable({
   providedIn: 'root',
 })
@@ -90,14 +281,174 @@ export class PluginSecurityService {
   }
 
   /**
-   * Minimal HTML sanitization - just prevent the worst attacks.
-   * Trust the browser's built-in protections for most things.
+   * Rebuild plugin-provided markup from an explicit allowlist before it is
+   * passed to Angular as trusted HTML. Unknown elements are unwrapped so their
+   * text remains visible; elements whose content can execute are dropped.
+   *
+   * This is NOT plugin containment: `plugin.js` runs through `new Function` in
+   * this renderer realm and plugin iframes are same-origin on purpose, so a
+   * hostile plugin never needed this sink. What it protects against is a
+   * well-meaning plugin interpolating untrusted data (a task title, a synced
+   * note, an API response) into its dialog markup.
+   *
+   * Hand-rolled on purpose, so please do not "simplify" it: Angular's own
+   * sanitizer deletes every form control (`input`, `select`, `textarea`,
+   * `button`), which bundled plugins build their dialogs from and read back by
+   * id, and DOMPurify would be a new runtime dependency. See #7869.
    */
   sanitizeHtml(html: string): string {
-    // Only remove truly dangerous elements
-    return html
-      .replace(/<script[^>]*>.*?<\/script>/gis, '') // No inline scripts
-      .replace(/<iframe[^>]*>.*?<\/iframe>/gis, '') // No nested iframes
-      .replace(/javascript:/gi, '#'); // No javascript: URLs
+    const sourceDocument = new DOMParser().parseFromString(html, 'text/html');
+    const output = BUILD_DOCUMENT.createElement('div');
+
+    for (const child of Array.from(sourceDocument.body.childNodes)) {
+      const sanitizedChild = this._sanitizeNode(child);
+      if (sanitizedChild) {
+        output.appendChild(sanitizedChild);
+      }
+    }
+
+    return output.innerHTML;
+  }
+
+  private _sanitizeNode(source: Node): Node | null {
+    if (source.nodeType === Node.TEXT_NODE) {
+      return BUILD_DOCUMENT.createTextNode(source.textContent ?? '');
+    }
+
+    if (source.nodeType !== Node.ELEMENT_NODE) {
+      return null;
+    }
+
+    const sourceElement = source as Element;
+    const tagName = sourceElement.tagName.toLowerCase();
+
+    if (DROP_WITH_CONTENT_ELEMENTS.has(tagName)) {
+      return null;
+    }
+
+    const output: Node = SAFE_HTML_ELEMENTS.has(tagName)
+      ? BUILD_DOCUMENT.createElement(tagName)
+      : BUILD_DOCUMENT.createDocumentFragment();
+
+    if (output.nodeType === Node.ELEMENT_NODE) {
+      this._copySafeAttributes(sourceElement, output as HTMLElement, tagName);
+    }
+
+    for (const child of Array.from(sourceElement.childNodes)) {
+      const sanitizedChild = this._sanitizeNode(child);
+      if (sanitizedChild) {
+        output.appendChild(sanitizedChild);
+      }
+    }
+
+    return output;
+  }
+
+  private _copySafeAttributes(
+    source: Element,
+    output: HTMLElement,
+    tagName: string,
+  ): void {
+    for (const attribute of Array.from(source.attributes)) {
+      const name = attribute.name.toLowerCase();
+
+      if (!this._isSafeAttribute(tagName, name)) {
+        continue;
+      }
+
+      if (name === 'style') {
+        const style = this._sanitizeStyle(attribute.value);
+        if (style) {
+          output.setAttribute(name, style);
+        }
+        continue;
+      }
+
+      if (name === 'href' || name === 'src') {
+        // Emit exactly the string that was validated. `trim()` strips more than
+        // the URL parser does (U+00A0, U+FEFF, …), so emitting the raw value
+        // would let a validated `https://…` resolve as a relative path instead.
+        const url = attribute.value.trim();
+        if (this._isSafeUrl(name, url)) {
+          output.setAttribute(name, url);
+        }
+        continue;
+      }
+
+      if (
+        name === 'target' &&
+        attribute.value !== '_blank' &&
+        attribute.value !== '_self'
+      ) {
+        continue;
+      }
+
+      output.setAttribute(name, attribute.value);
+    }
+
+    if (tagName === 'a' && output.getAttribute('target') === '_blank') {
+      output.setAttribute('rel', 'noopener noreferrer');
+    }
+  }
+
+  private _isSafeAttribute(tagName: string, attributeName: string): boolean {
+    return (
+      GLOBAL_SAFE_ATTRIBUTES.has(attributeName) ||
+      attributeName.startsWith('aria-') ||
+      attributeName.startsWith('data-') ||
+      SAFE_ATTRIBUTES_BY_ELEMENT[tagName]?.has(attributeName) === true
+    );
+  }
+
+  /**
+   * Keep declarations a plugin needs for layout, drop the ones that can fetch.
+   *
+   * The check runs on the value the CSS parser gives BACK, never on the raw
+   * attribute: CSS resolves identifier escapes while tokenizing, so `\75 rl(…)`
+   * is a url() to the browser and plain text to any regex. Re-serializing
+   * normalizes every spelling to a literal `url(`, which makes this check
+   * escape-proof. Custom properties are dropped outright because their value is
+   * an unparsed token stream (no normalization happens), so an escaped url()
+   * could hide in one and only materialize when a var() reference substitutes it.
+   */
+  private _sanitizeStyle(value: string): string | null {
+    const probe = BUILD_DOCUMENT.createElement('div');
+    probe.style.cssText = value;
+
+    // Refuse the whole attribute rather than a single declaration: dropping one
+    // longhand out of a shorthand leaves the siblings behind as `initial`, and
+    // no dialog layout needs url() in the first place.
+    if (probe.style.cssText.includes('url(')) {
+      return null;
+    }
+
+    for (const property of Array.from(probe.style)) {
+      if (property.startsWith('--')) {
+        probe.style.removeProperty(property);
+      }
+    }
+
+    return probe.style.cssText || null;
+  }
+
+  private _isSafeUrl(attributeName: 'href' | 'src', trimmedValue: string): boolean {
+    if (attributeName === 'href' && trimmedValue.startsWith('#')) {
+      return true;
+    }
+
+    if (attributeName === 'src' && SAFE_RASTER_DATA_URL.test(trimmedValue)) {
+      return true;
+    }
+
+    try {
+      // Require an explicit scheme. A relative URL validated against an HTTPS
+      // placeholder could later resolve as file:// in the packaged app.
+      const protocol = new URL(trimmedValue).protocol;
+      return (attributeName === 'href' ? SAFE_LINK_PROTOCOLS : SAFE_IMAGE_PROTOCOLS).has(
+        protocol,
+      );
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/app/plugins/ui/plugin-dialog/plugin-dialog.component.spec.ts
+++ b/src/app/plugins/ui/plugin-dialog/plugin-dialog.component.spec.ts
@@ -56,6 +56,40 @@ describe('PluginDialogComponent', () => {
     ]);
   });
 
+  it('removes executable attributes from plugin HTML', async () => {
+    await createComponent({
+      htmlContent: `
+        <img id="plugin-dialog-img" onerror="alert(document.domain)">
+        <a id="plugin-dialog-link" href="#" onmouseover="alert(document.domain)">
+          Link
+        </a>
+      `,
+    });
+
+    const img = fixture.nativeElement.querySelector('mat-dialog-content img');
+    const link = fixture.nativeElement.querySelector('mat-dialog-content a');
+
+    expect(img.getAttribute('onerror')).toBeNull();
+    expect(link.getAttribute('onmouseover')).toBeNull();
+  });
+
+  it('preserves safe rich HTML and form controls', async () => {
+    await createComponent({
+      htmlContent: `
+        <h2>Plugin settings</h2>
+        <label for="plugin-dialog-input">Name</label>
+        <input id="plugin-dialog-input" value="Example">
+        <p><strong>Ready</strong></p>
+      `,
+    });
+
+    const input = fixture.nativeElement.querySelector('mat-dialog-content input');
+
+    expect(fixture.nativeElement.querySelector('h2').textContent).toBe('Plugin settings');
+    expect(input.value).toBe('Example');
+    expect(fixture.nativeElement.querySelector('strong').textContent).toBe('Ready');
+  });
+
   it('closes with the clicked custom button label', async () => {
     const onClick = jasmine.createSpy('onClick').and.resolveTo();
     const component = await createComponent({


### PR DESCRIPTION
Replaces the regex-based sanitization of plugin dialog `htmlContent` with an allowlist rebuild, closing item 4 of #7869.

## The problem

`PluginDialogComponent` passes `htmlContent` to `bypassSecurityTrustHtml` and binds it with `[innerHTML]`, so whatever the sanitizer returns is rendered as trusted HTML. The old sanitizer stripped `<script>`, `<iframe>` and the literal string `javascript:` with three regexes, which meant an `<img onerror>` or `<svg onload>` reached the sink untouched.

The new implementation parses the input, rebuilds it from an explicit element and attribute allowlist, and returns the serialized result. Elements outside the allowlist are unwrapped so their text stays visible, and elements whose body would otherwise render as visible garbage (`<style>`, `<script>`, `<title>`) are dropped with their content.

## What this is, and what it is not

This is **not** plugin containment. `plugin.js` runs through `new Function` in the host renderer realm, and plugin iframes are same-origin by deliberate design (see the comment on `PLUGIN_IFRAME_SANDBOX`), so a hostile plugin never needed this sink to reach the page. What it protects against is a well-meaning plugin interpolating untrusted data, such as a task title, a synced note, or an API response, into its dialog markup. Every bundled plugin hand-rolls an `escapeHtml` for exactly that reason. The doc comment says this so nobody over-trusts the boundary later.

## Why hand-rolled rather than Angular's sanitizer or DOMPurify

Issue #7869 suggested both alternatives. Neither works here:

- Angular's own sanitizer deletes every form control. Measured against a real bundled dialog fixture, `<select>`, `<input>`, `<textarea>` and `<button>` all vanish and only their text survives. Bundled plugins build their dialogs from those controls and read them back by `id`, so this would break them functionally, not cosmetically.
- DOMPurify would be a new runtime dependency, which the project's dependency rule excludes.

Both findings are recorded in the file so the decision is not silently reverted later.

## Inline styles are preserved

An earlier iteration of this change dropped the `style` attribute outright. That broke real UI: brain-dump's project color bar is an empty `<div>` whose only geometry came from `style="height:3px"`, so it became permanently invisible, and both it and voice-reminder lost their layout entirely.

Styles are now kept, minus any declaration that can fetch. The check runs on the value the CSS parser gives back rather than on the raw attribute, because CSS resolves identifier escapes while tokenizing: `\75 rl(...)` is a real `url()` to the browser and plain text to any regex. Re-serialization normalizes every spelling back to a literal `url(`, which makes the check escape-proof. Custom properties are removed as well, since their value is never normalized and could otherwise smuggle an escaped `url()` in through a `var()` reference.

## Other fixes in this change

- Output is built in an inert document. Previously the sanitizer created nodes in the live document, so `setAttribute('src', ...)` started an image load at sanitize time, before anything was rendered.
- URLs are emitted exactly as validated. `trim()` strips characters the URL parser keeps (U+00A0, U+FEFF), so emitting the raw value let a validated `https://` link resolve as a same-origin relative path instead.
- Added the missing `ins`, `dl`, `dt`, `dd`, `caption`, `col`, `colgroup`, `q`, `cite`, `address` and `wbr` elements.

## Testing

Nine sanitizer specs plus two dialog component specs, covering event handlers, unsafe URLs, `<svg>`, script URLs, style handling and the markup bundled dialogs are built from. 591 plugin specs, `ng build` and lint are green.

Each guard is sabotage-tested: neutering the style filter fails two specs, keeping custom properties fails one, emitting the untrimmed URL fails one, and neutering the drop list fails one.

One note for future editors, written into the spec as a comment: a `<style>` or `<script>` before any body content is routed into `<head>` by the parser, and only `<body>` is walked, so a drop-list test without preceding body content passes no matter what the code does.

## Compatibility

Plugin-visible behavior changes, so the contract is documented in `DialogCfg`, `docs/plugin-development.md` and the wiki API page. Inline `<svg>` in dialog markup is dropped and is the most likely thing a third-party plugin would miss.

## Security invariant

No raw-text element may ever be added to the allowlist. The serializer emits the text of `style`, `script`, `xmp`, `iframe`, `noembed`, `noframes`, `plaintext` and `noscript` unescaped, so allowlisting one would let the output re-parse into new elements at the sink. Because none can be created, every text node is entity-escaped and the sanitized string re-parses to the same tree. This is written above the allowlist, since re-adding `<title>` for accessibility is a plausible future change that would silently reopen it.
