### PR TITLE
test(sync): stabilize conflict recovery e2e tests

### DIFF
--- a/e2e/tests/sync/supersync-plaintext-history-recovery-9439.spec.ts
+++ b/e2e/tests/sync/supersync-plaintext-history-recovery-9439.spec.ts
@@ -30,11 +30,6 @@ interface RawServerOperation {
   serverSeq: number;
 }
 
-interface CapturedSnack {
-  actionLabels: string[];
-  message: string;
-}
-
 const authHeaders = (token: string): Headers => {
   const headers = new Headers();
   headers.set('Authorization', `Bearer ${token}`);
@@ -200,31 +195,6 @@ test.describe('@supersync @encryption #9439 plaintext history recovery', () => {
       );
 
       freshClient = await createSimulatedClient(browser, baseURL!, 'fresh', testRunId);
-      await freshClient.page.evaluate(() => {
-        const capturedSnacks: CapturedSnack[] = [];
-        const observer = new MutationObserver(() => {
-          document.querySelectorAll('snack-custom').forEach((element) => {
-            const message = element.querySelector('.message')?.textContent?.trim();
-            if (!message) return;
-            const actionLabels = Array.from(
-              element.querySelectorAll<HTMLButtonElement>('button.action'),
-            ).flatMap((button) => {
-              const label = button.textContent?.trim();
-              return label ? [label] : [];
-            });
-            const signature = JSON.stringify({ message, actionLabels });
-            if (!capturedSnacks.some((snack) => JSON.stringify(snack) === signature)) {
-              capturedSnacks.push({ message, actionLabels });
-            }
-          });
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-        (
-          globalThis as unknown as {
-            __issue9439Snacks?: CapturedSnack[];
-          }
-        ).__issue9439Snacks = capturedSnacks;
-      });
       const requestedSinceSeqs: number[] = [];
       await routeSuperSyncOps(freshClient.page, async (route) => {
         if (route.request().method() === 'GET') {
@@ -263,27 +233,13 @@ test.describe('@supersync @encryption #9439 plaintext history recovery', () => {
         (await downloadRawServerOps(user.userId)).some(({ id }) => id === plaintextOp.id),
       ).toBe(true);
 
-      const capturedSnacks = await freshClient.page.evaluate(
-        () =>
-          (
-            globalThis as unknown as {
-              __issue9439Snacks?: CapturedSnack[];
-            }
-          ).__issue9439Snacks ?? [],
-      );
-      const integritySnacks = capturedSnacks.filter(({ message }) =>
-        message.includes('security integrity check'),
-      );
-      expect(integritySnacks.length).toBeGreaterThan(0);
-      expect(integritySnacks.every(({ actionLabels }) => actionLabels.length === 0)).toBe(
-        true,
-      );
-      expect(integritySnacks.map(({ message }) => message).join('\n')).toContain(
-        'export a backup',
-      );
-      expect(integritySnacks.map(({ message }) => message).join('\n')).toContain(
-        'Force Overwrite',
-      );
+      const integritySnack = freshClient.page.locator('snack-custom', {
+        hasText: 'security integrity check',
+      });
+      await expect(integritySnack).toBeVisible({ timeout: 30000 });
+      await expect(integritySnack.locator('button.action')).toHaveCount(0);
+      await expect(integritySnack).toContainText('export a backup');
+      await expect(integritySnack).toContainText('Force Overwrite');
 
       await forceOverwriteFromTrustedClient(trustedClient);
       await expect

--- a/e2e/tests/sync/webdav-first-sync-conflict.spec.ts
+++ b/e2e/tests/sync/webdav-first-sync-conflict.spec.ts
@@ -472,6 +472,12 @@ test.describe('@webdav WebDAV First Sync Conflict', () => {
     console.log('[Test] Client C conflict dialog appeared');
 
     const useLocalBtnC = conflictDialogC.locator('button', { hasText: /Keep local/i });
+    const snapshotUploadResponse = pageC.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        new URL(response.url()).pathname.endsWith('/sync-data.json'),
+      { timeout: 60000 },
+    );
     await useLocalBtnC.click();
     console.log('[Test] Client C clicked Use Local (uploads snapshot)');
 
@@ -487,6 +493,7 @@ test.describe('@webdav WebDAV First Sync Conflict', () => {
       // Confirmation might not appear
     }
 
+    expect((await snapshotUploadResponse).ok()).toBe(true);
     await waitForSyncComplete(pageC, syncPageC, 30000);
     console.log('[Test] Client C sync completed (snapshot uploaded)');
 


### PR DESCRIPTION
## Problem

Two sync E2E jobs failed because their assertions could run before the state they were checking became observable:

- [WebDAV E2E run 30911181829](https://github.com/super-productivity/super-productivity/actions/runs/30911181829) treated an existing success icon as completion and let Client B sync before Client C's replacement snapshot upload finished.
- [SuperSync E2E run 30911190100](https://github.com/super-productivity/super-productivity/actions/runs/30911190100) read a custom `MutationObserver` capture before the integrity snackbar was mounted, even though the expected snackbar appeared immediately afterward.

## Solution

- Wait for the WebDAV replacement snapshot's successful `PUT` response before triggering the next client.
- Assert the live SuperSync integrity snackbar with Playwright's retrying locator assertions instead of maintaining a custom observer.
- Keep the change limited to the two affected E2E specs; production sync behavior is unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (E2E test reliability)

## Verification

- `npm run checkFile e2e/tests/sync/webdav-first-sync-conflict.spec.ts`
- `npm run checkFile e2e/tests/sync/supersync-plaintext-history-recovery-9439.spec.ts`
- Focused WebDAV snapshot-replacement scenario: 1 passed
- Focused SuperSync plaintext-history recovery scenario: 1 passed

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (Not applicable: test-only change.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
