### PR TITLE
fix(sync): preserve planner placement during Today conflicts

### DIFF
--- a/e2e/tests/sync/supersync-today-plan-mixed-winner.spec.ts
+++ b/e2e/tests/sync/supersync-today-plan-mixed-winner.spec.ts
@@ -1,0 +1,283 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/supersync.fixture';
+import {
+  closeClient,
+  createSimulatedClient,
+  createTestUser,
+  getSuperSyncConfig,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+
+interface TaskRecord extends Record<string, unknown> {
+  id: string;
+  title: string;
+  dueDay?: string;
+}
+
+interface PlannerSnapshot {
+  plannerTaskIds: string[];
+  todayTaskIds: string[];
+  winner: { title: string; dueDay?: string };
+  remoteWinner: { title: string; dueDay?: string };
+}
+
+interface PersistentAction extends Record<string, unknown> {
+  type: string;
+  meta: Record<string, unknown>;
+}
+
+const dispatchPersistentAction = async (
+  page: Page,
+  action: PersistentAction,
+): Promise<void> => {
+  const dispatched = await page.evaluate((actionToDispatch) => {
+    type StoreLike = { dispatch: (value: unknown) => void };
+    const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+      .__e2eTestHelpers?.store;
+    if (!store) return false;
+    store.dispatch(actionToDispatch);
+    return true;
+  }, action);
+  expect(dispatched).toBe(true);
+};
+
+const getTasksByTitle = async (
+  page: Page,
+  titles: string[],
+): Promise<Record<string, TaskRecord>> =>
+  page.evaluate((requestedTitles) => {
+    type StoreState = {
+      tasks?: { entities?: Record<string, TaskRecord | undefined> };
+    };
+    type StoreLike = {
+      subscribe: (next: (state: StoreState) => void) => { unsubscribe: () => void };
+    };
+    const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+      .__e2eTestHelpers?.store;
+    if (!store) throw new Error('__e2eTestHelpers.store missing');
+
+    let state: StoreState | undefined;
+    const subscription = store.subscribe((value) => {
+      state = value;
+    });
+    subscription.unsubscribe();
+
+    const tasks = Object.values(state?.tasks?.entities ?? {});
+    return Object.fromEntries(
+      requestedTitles.map((title) => {
+        const task = tasks.find((candidate) => candidate?.title === title);
+        if (!task) throw new Error(`Task "${title}" was not found in the store`);
+        return [title, task];
+      }),
+    );
+  }, titles);
+
+const getPlannerSnapshot = async (
+  page: Page,
+  day: string,
+  winnerId: string,
+  remoteWinnerId: string,
+): Promise<PlannerSnapshot> =>
+  page.evaluate(
+    ({ plannerDay, localId, remoteId }) => {
+      type TaskLike = { title: string; dueDay?: string };
+      type StoreState = {
+        tasks?: { entities?: Record<string, TaskLike | undefined> };
+        planner?: { days?: Record<string, string[]> };
+        tag?: { entities?: Record<string, { taskIds?: string[] } | undefined> };
+      };
+      type StoreLike = {
+        subscribe: (next: (state: StoreState) => void) => {
+          unsubscribe: () => void;
+        };
+      };
+      const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+        .__e2eTestHelpers?.store;
+      if (!store) throw new Error('__e2eTestHelpers.store missing');
+
+      let state: StoreState | undefined;
+      const subscription = store.subscribe((value) => {
+        state = value;
+      });
+      subscription.unsubscribe();
+
+      const winner = state?.tasks?.entities?.[localId];
+      const remoteWinner = state?.tasks?.entities?.[remoteId];
+      if (!winner || !remoteWinner) throw new Error('Expected task state is missing');
+      return {
+        plannerTaskIds: state?.planner?.days?.[plannerDay] ?? [],
+        todayTaskIds: state?.tag?.entities?.TODAY?.taskIds ?? [],
+        winner: { title: winner.title, dueDay: winner.dueDay },
+        remoteWinner: {
+          title: remoteWinner.title,
+          dueDay: remoteWinner.dueDay,
+        },
+      };
+    },
+    { plannerDay: day, localId: winnerId, remoteId: remoteWinnerId },
+  );
+
+test.describe('@supersync Today-plan mixed-winner convergence', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('keeps the local winner in its future planner position across replay and a fresh client', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.setTimeout(180000);
+    const appUrl = baseURL || 'http://localhost:4242';
+    const today = '2026-08-04';
+    const futureDay = '2026-08-08';
+    const seedTime = new Date('2026-08-04T08:00:00');
+    const remotePlanTime = new Date('2026-08-04T09:00:00');
+    const localEditTime = new Date('2026-08-04T09:01:00');
+    const untouchedTitle = `A-${testRunId}-Untouched`;
+    const winnerTitle = `A-${testRunId}-Local winner`;
+    const renamedWinnerTitle = `${winnerTitle} renamed`;
+    const remoteWinnerTitle = `A-${testRunId}-Remote winner`;
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+    let clientC: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      clientA = await createSimulatedClient(browser, appUrl, 'A', testRunId);
+      await clientA.page.clock.setFixedTime(seedTime);
+      await clientA.page.reload();
+      await clientA.workView.waitForTaskList();
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      await clientA.workView.addTask('Untouched');
+      await clientA.workView.addTask('Local winner');
+      await clientA.workView.addTask('Remote winner');
+      const tasks = await getTasksByTitle(clientA.page, [
+        untouchedTitle,
+        winnerTitle,
+        remoteWinnerTitle,
+      ]);
+      for (const title of [untouchedTitle, winnerTitle, remoteWinnerTitle]) {
+        const task = tasks[title];
+        await dispatchPersistentAction(clientA.page, {
+          type: '[Planner] Plan Task for Day',
+          task,
+          day: futureDay,
+          meta: {
+            isPersistent: true,
+            entityType: 'PLANNER',
+            entityId: task.id,
+            opType: 'UPD',
+          },
+        });
+      }
+
+      const untouchedId = tasks[untouchedTitle].id;
+      const winnerId = tasks[winnerTitle].id;
+      const remoteWinnerId = tasks[remoteWinnerTitle].id;
+      const seededPlannerIds = [untouchedId, winnerId, remoteWinnerId];
+      await expect
+        .poll(
+          async () =>
+            (await getPlannerSnapshot(clientA!.page, futureDay, winnerId, remoteWinnerId))
+              .plannerTaskIds,
+        )
+        .toEqual(seededPlannerIds);
+
+      await clientA.sync.syncAndWait();
+      clientB = await createSimulatedClient(browser, appUrl, 'B', testRunId);
+      await clientB.page.clock.setFixedTime(seedTime);
+      await clientB.page.reload();
+      await clientB.workView.waitForTaskList();
+      await clientB.sync.setupSuperSync(syncConfig);
+      await clientB.sync.syncAndWait();
+
+      await clientB.page.clock.setFixedTime(remotePlanTime);
+      await dispatchPersistentAction(clientB.page, {
+        type: '[Task Shared] planTasksForToday',
+        taskIds: [winnerId, remoteWinnerId],
+        today,
+        startOfNextDayDiffMs: 0,
+        parentTaskMap: {},
+        meta: {
+          isPersistent: true,
+          entityType: 'TASK',
+          entityIds: [winnerId, remoteWinnerId],
+          opType: 'UPD',
+          isBulk: true,
+        },
+      });
+      await expect
+        .poll(
+          async () =>
+            (await getPlannerSnapshot(clientB!.page, futureDay, winnerId, remoteWinnerId))
+              .plannerTaskIds,
+        )
+        .toEqual([untouchedId]);
+
+      await clientA.page.clock.setFixedTime(localEditTime);
+      await dispatchPersistentAction(clientA.page, {
+        type: '[Task Shared] updateTask',
+        task: { id: winnerId, changes: { title: renamedWinnerTitle } },
+        meta: {
+          isPersistent: true,
+          entityType: 'TASK',
+          entityId: winnerId,
+          opType: 'UPD',
+        },
+      });
+      await expect
+        .poll(
+          async () =>
+            (await getPlannerSnapshot(clientA!.page, futureDay, winnerId, remoteWinnerId))
+              .winner.title,
+        )
+        .toBe(renamedWinnerTitle);
+
+      await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
+
+      const expectedSnapshot: PlannerSnapshot = {
+        plannerTaskIds: [untouchedId, winnerId],
+        todayTaskIds: [remoteWinnerId],
+        winner: { title: renamedWinnerTitle, dueDay: futureDay },
+        remoteWinner: { title: remoteWinnerTitle, dueDay: today },
+      };
+      expect(
+        await getPlannerSnapshot(clientA.page, futureDay, winnerId, remoteWinnerId),
+      ).toEqual(expectedSnapshot);
+      expect(
+        await getPlannerSnapshot(clientB.page, futureDay, winnerId, remoteWinnerId),
+      ).toEqual(expectedSnapshot);
+
+      await clientA.page.reload();
+      await clientA.workView.waitForTaskList();
+      await clientB.page.reload();
+      await clientB.workView.waitForTaskList();
+      expect(
+        await getPlannerSnapshot(clientA.page, futureDay, winnerId, remoteWinnerId),
+      ).toEqual(expectedSnapshot);
+      expect(
+        await getPlannerSnapshot(clientB.page, futureDay, winnerId, remoteWinnerId),
+      ).toEqual(expectedSnapshot);
+
+      clientC = await createSimulatedClient(browser, appUrl, 'C', testRunId);
+      await clientC.page.clock.setFixedTime(localEditTime);
+      await clientC.page.reload();
+      await clientC.workView.waitForTaskList();
+      await clientC.sync.setupSuperSync(syncConfig);
+      await clientC.sync.syncAndWait();
+      await clientC.sync.syncAndWait();
+      expect(
+        await getPlannerSnapshot(clientC.page, futureDay, winnerId, remoteWinnerId),
+      ).toEqual(expectedSnapshot);
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+      if (clientC) await closeClient(clientC);
+    }
+  });
+});

--- a/e2e/tests/sync/supersync-today-plan-mixed-winner.spec.ts
+++ b/e2e/tests/sync/supersync-today-plan-mixed-winner.spec.ts
@@ -136,6 +136,7 @@ test.describe('@supersync Today-plan mixed-winner convergence', () => {
     const winnerTitle = `A-${testRunId}-Local winner`;
     const renamedWinnerTitle = `${winnerTitle} renamed`;
     const remoteWinnerTitle = `A-${testRunId}-Remote winner`;
+    const concurrentTitle = `B-${testRunId}-Concurrent placement`;
     let clientA: SimulatedE2EClient | null = null;
     let clientB: SimulatedE2EClient | null = null;
     let clientC: SimulatedE2EClient | null = null;
@@ -216,6 +217,29 @@ test.describe('@supersync Today-plan mixed-winner convergence', () => {
         )
         .toEqual([untouchedId]);
 
+      await clientB.workView.addTask('Concurrent placement');
+      const concurrentTask = (await getTasksByTitle(clientB.page, [concurrentTitle]))[
+        concurrentTitle
+      ];
+      await dispatchPersistentAction(clientB.page, {
+        type: '[Planner] Plan Task for Day',
+        task: concurrentTask,
+        day: futureDay,
+        meta: {
+          isPersistent: true,
+          entityType: 'PLANNER',
+          entityId: concurrentTask.id,
+          opType: 'UPD',
+        },
+      });
+      await expect
+        .poll(
+          async () =>
+            (await getPlannerSnapshot(clientB!.page, futureDay, winnerId, remoteWinnerId))
+              .plannerTaskIds,
+        )
+        .toEqual([untouchedId, concurrentTask.id]);
+
       await clientA.page.clock.setFixedTime(localEditTime);
       await dispatchPersistentAction(clientA.page, {
         type: '[Task Shared] updateTask',
@@ -241,7 +265,7 @@ test.describe('@supersync Today-plan mixed-winner convergence', () => {
       await clientA.sync.syncAndWait();
 
       const expectedSnapshot: PlannerSnapshot = {
-        plannerTaskIds: [untouchedId, winnerId],
+        plannerTaskIds: [untouchedId, winnerId, concurrentTask.id],
         todayTaskIds: [remoteWinnerId],
         winner: { title: renamedWinnerTitle, dueDay: futureDay },
         remoteWinner: { title: remoteWinnerTitle, dueDay: today },

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -98,6 +98,7 @@ import {
 import { NOISE_FIELDS } from './conflict-journal.model';
 import { RECREATE_FALLBACK } from '../core/recreate-fallback.const';
 import { areCommutingSectionOperations } from './section-conflict-commutativity.util';
+import { selectPlannerState } from '../../features/planner/store/planner.selectors';
 
 /**
  * Represents the result of LWW (Last-Write-Wins) conflict resolution.
@@ -114,6 +115,16 @@ interface MergedResolution {
   mergedOp: Operation;
   /** Kept so the merge is journaled only after its reducer work succeeds. */
   plan: LwwConflictResolutionPlan<EntityConflict>;
+}
+
+interface MultiEntityRemoteOpWinners {
+  op: Operation;
+  hasLocalWinner: boolean;
+  hasRemoteWinner: boolean;
+  localWinnerKeys: Set<string>;
+  resolvedEntityKeys: Set<string>;
+  localWinOpIds: Set<string>;
+  remoteWinCompensationIds: Set<string>;
 }
 
 const taskRelationshipPatch = (
@@ -376,20 +387,19 @@ const INDEPENDENT_MULTI_DELETE_ACTIONS = new Set<ActionType>([
  * - SCOPED_PLAN rows (see `preserve-partial-bulk-plan.util.ts`) are rejected
  *   as a unit and replaced by ONE copy narrowed to the surviving task ids,
  *   mirroring `_preservePartiallyRejectedLocalBulkDeletes`.
- * - ORDERING_ONLY rows touch nothing but `TODAY_TAG.taskIds` ordering — Today
- *   MEMBERSHIP is derived from `task.dueDay`/`dueWithTime` (ADR #2) — so
- *   rejecting such a row loses at most list ordering: cosmetic, self-healing,
- *   no replacement needed. Pinned by the entity-field-free invariant specs in
- *   `task-shared-scheduling.reducer.spec.ts` AND `task.reducer.spec.ts`.
+ * - ORDERING_ONLY rows touch no task entity fields — Today MEMBERSHIP is
+ *   derived from `task.dueDay`/`dueWithTime` (ADR #2). Their reducers can
+ *   reorder `TODAY_TAG.taskIds` and persisted `TaskState.ids`, so rejecting
+ *   such a row loses ordering only: cosmetic, self-healing, no replacement
+ *   needed. Pinned by the entity-field-free and ordering specs in
+ *   `task-shared-scheduling.reducer.spec.ts` and `task.reducer.spec.ts`.
  *
  * Remote rows of these types replay as ordinary atomic actions (the reducers
- * skip unknown task ids); local winners are restored by the existing
- * mixed-winner compensation snapshots applied after the remote row. Known
- * bounded gap of that restore (also pre-existing for archive rows): the
- * snapshot re-imposes TASK fields only, so cross-slice side effects of the
- * applied remote row (e.g. `removeTasksFromPlannerDays` stripping a
- * local-win task's planner-day placement) are not re-imposed; the entry
- * reappears when the task's own dueDay comes around.
+ * skip unknown task ids); local winners are restored by mixed-winner
+ * compensation snapshots applied after the remote row. A remote
+ * `planTasksForToday` also removes every target from `planner.days`, so its
+ * local-winning targets receive an established `Upsert Planner Day` follow-up
+ * that restores their exact surviving placement on live apply and replay.
  */
 const ORDERING_ONLY_MULTI_ACTIONS = new Set<ActionType>([
   ActionType.TASK_SHARED_MOVE_IN_TODAY,
@@ -984,18 +994,7 @@ export class ConflictResolutionService {
     // local-win snapshots after it as compensations. The remote row stays pending
     // until reducer and archive application complete; status-blind hydration then
     // replays the same deterministic sequence after a crash.
-    const multiEntityRemoteOpWinners = new Map<
-      string,
-      {
-        op: Operation;
-        hasLocalWinner: boolean;
-        hasRemoteWinner: boolean;
-        localWinnerKeys: Set<string>;
-        resolvedEntityKeys: Set<string>;
-        localWinOpIds: Set<string>;
-        remoteWinCompensationIds: Set<string>;
-      }
-    >();
+    const multiEntityRemoteOpWinners = new Map<string, MultiEntityRemoteOpWinners>();
     const compensatedRemoteOps = new Map<string, Operation>();
     const compensationOpIdsToApply = new Set<string>();
     for (const resolution of resolutions) {
@@ -1278,6 +1277,17 @@ export class ConflictResolutionService {
           remoteWinnerAffectedEntityKeys.delete(localWinnerKey);
         }
       }
+    }
+
+    const plannerCompensationOps =
+      await this._createMixedRemoteTodayPlannerCompensationOps(
+        [...multiEntityRemoteOpWinners.values()],
+        newLocalWinOpsById,
+      );
+    for (const plannerCompensationOp of plannerCompensationOps) {
+      newLocalWinOps.push(plannerCompensationOp);
+      newLocalWinOpsById.set(plannerCompensationOp.id, plannerCompensationOp);
+      compensationOpIdsToApply.add(plannerCompensationOp.id);
     }
 
     // A remote DELETE that loses outright — single-entity, or a bulk delete
@@ -2782,6 +2792,102 @@ export class ConflictResolutionService {
       localWinOp = markLwwDeleteRecreation(localWinOp);
     }
     return localWinOp;
+  }
+
+  /**
+   * A mixed remote `planTasksForToday` must replay atomically so its remote
+   * winners keep their scheduling change. That same reducer removes every
+   * target from every planner day, including tasks whose newer local edit won.
+   * Re-emit the affected day snapshots after the TASK winner snapshots:
+   * remote-winning targets stay removed, while covered local winners retain
+   * their exact position among untouched tasks.
+   *
+   * `Upsert Planner Day` is an existing wire action understood by released
+   * clients, so this needs neither a schema bump nor a new payload contract.
+   */
+  private async _createMixedRemoteTodayPlannerCompensationOps(
+    winnerGroups: MultiEntityRemoteOpWinners[],
+    localWinOpsById: ReadonlyMap<string, Operation>,
+  ): Promise<Operation[]> {
+    const mixedPlanGroups = winnerGroups.filter(
+      ({ op, hasLocalWinner, hasRemoteWinner }) =>
+        op.actionType === ActionType.TASK_SHARED_PLAN_FOR_TODAY &&
+        hasLocalWinner &&
+        hasRemoteWinner,
+    );
+    if (mixedPlanGroups.length === 0) return [];
+
+    const localWinnerTaskIds = new Set<string>();
+    const localWinnerOps: Operation[] = [];
+    for (const group of mixedPlanGroups) {
+      for (const localWinOpId of group.localWinOpIds) {
+        const localWinOp = localWinOpsById.get(localWinOpId);
+        if (
+          localWinOp?.entityType !== 'TASK' ||
+          !localWinOp.entityId ||
+          localWinOp.opType === OpType.Delete ||
+          !group.localWinnerKeys.has(toEntityKey('TASK', localWinOp.entityId))
+        ) {
+          continue;
+        }
+        localWinnerTaskIds.add(localWinOp.entityId);
+        localWinnerOps.push(localWinOp);
+      }
+    }
+    if (localWinnerTaskIds.size === 0) return [];
+
+    const plannerState = await firstValueFrom(this.store.select(selectPlannerState));
+    if (!plannerState?.days) return [];
+
+    const remoteTargetIds = new Set(
+      mixedPlanGroups.flatMap(({ op }) => getOpEntityIds(op)),
+    );
+    const affectedDays = Object.entries(plannerState.days)
+      .filter(([, taskIds]) => taskIds.some((taskId) => localWinnerTaskIds.has(taskId)))
+      .map(([day, taskIds]) => ({
+        day,
+        taskIds: taskIds.filter(
+          (taskId) => !remoteTargetIds.has(taskId) || localWinnerTaskIds.has(taskId),
+        ),
+      }))
+      .sort((a, b) => a.day.localeCompare(b.day));
+    if (affectedDays.length === 0) return [];
+
+    const clientId = await this.clientIdProvider.loadClientId();
+    if (!clientId) {
+      throw new Error(
+        'ConflictResolutionService: Cannot preserve planner placement - no client ID',
+      );
+    }
+
+    let nextClock = this.mergeAndIncrementClocks(
+      [
+        (await this.opLogStore.getVectorClock()) ?? {},
+        ...mixedPlanGroups.map(({ op }) => op.vectorClock),
+        ...localWinnerOps.map((op) => op.vectorClock),
+      ],
+      clientId,
+    );
+    const timestamp = Math.max(...localWinnerOps.map((op) => op.timestamp));
+    return affectedDays.map(({ day, taskIds }) => {
+      const op: Operation = {
+        id: uuidv7(),
+        actionType: ActionType.PLANNER_UPSERT_DAY,
+        opType: OpType.Update,
+        entityType: 'PLANNER',
+        entityId: day,
+        payload: {
+          actionPayload: { day, taskIds },
+          entityChanges: [],
+        },
+        clientId,
+        vectorClock: nextClock,
+        timestamp,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      };
+      nextClock = this.mergeAndIncrementClocks([nextClock], clientId);
+      return op;
+    });
   }
 
   /**

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -2798,60 +2798,73 @@ export class ConflictResolutionService {
    * A mixed remote `planTasksForToday` must replay atomically so its remote
    * winners keep their scheduling change. That same reducer removes every
    * target from every planner day, including tasks whose newer local edit won.
-   * Re-emit the affected day snapshots after the TASK winner snapshots:
-   * remote-winning targets stay removed, while covered local winners retain
-   * their exact position among untouched tasks.
+   * Re-emit one task-scoped transfer per final local winner after the TASK
+   * snapshots. A whole-day snapshot is unsafe here: it can overwrite an
+   * unrelated placement that reached the server before this compensation.
    *
-   * `Upsert Planner Day` is an existing wire action understood by released
-   * clients, so this needs neither a schema bump nor a new payload contract.
+   * `Transfer Task` is an existing wire action understood by released clients,
+   * so this needs neither a schema bump nor a new payload contract.
    */
   private async _createMixedRemoteTodayPlannerCompensationOps(
     winnerGroups: MultiEntityRemoteOpWinners[],
     localWinOpsById: ReadonlyMap<string, Operation>,
   ): Promise<Operation[]> {
-    const mixedPlanGroups = winnerGroups.filter(
-      ({ op, hasLocalWinner, hasRemoteWinner }) =>
-        op.actionType === ActionType.TASK_SHARED_PLAN_FOR_TODAY &&
-        hasLocalWinner &&
-        hasRemoteWinner,
+    const appliedPlanGroups = winnerGroups.filter(
+      ({ op, hasRemoteWinner }) =>
+        op.actionType === ActionType.TASK_SHARED_PLAN_FOR_TODAY && hasRemoteWinner,
     );
-    if (mixedPlanGroups.length === 0) return [];
+    if (appliedPlanGroups.length === 0) return [];
 
-    const localWinnerTaskIds = new Set<string>();
-    const localWinnerOps: Operation[] = [];
-    for (const group of mixedPlanGroups) {
-      for (const localWinOpId of group.localWinOpIds) {
-        const localWinOp = localWinOpsById.get(localWinOpId);
-        if (
-          localWinOp?.entityType !== 'TASK' ||
-          !localWinOp.entityId ||
-          localWinOp.opType === OpType.Delete ||
-          !group.localWinnerKeys.has(toEntityKey('TASK', localWinOp.entityId))
-        ) {
+    const finalLocalWinners = new Map<
+      string,
+      { localWinOp: Operation; remotePlanOp: Operation }
+    >();
+    for (const group of appliedPlanGroups) {
+      for (const taskId of getOpEntityIds(group.op)) {
+        const taskKey = toEntityKey('TASK', taskId);
+        if (!group.localWinnerKeys.has(taskKey)) {
+          finalLocalWinners.delete(taskId);
           continue;
         }
-        localWinnerTaskIds.add(localWinOp.entityId);
-        localWinnerOps.push(localWinOp);
+        const localWinOp = [...group.localWinOpIds]
+          .map((opId) => localWinOpsById.get(opId))
+          .find(
+            (op): op is Operation =>
+              op?.entityType === 'TASK' &&
+              op.entityId === taskId &&
+              op.opType !== OpType.Delete,
+          );
+        if (localWinOp) {
+          finalLocalWinners.set(taskId, { localWinOp, remotePlanOp: group.op });
+        } else {
+          finalLocalWinners.delete(taskId);
+        }
       }
     }
-    if (localWinnerTaskIds.size === 0) return [];
+    if (finalLocalWinners.size === 0) return [];
 
     const plannerState = await firstValueFrom(this.store.select(selectPlannerState));
     if (!plannerState?.days) return [];
 
     const remoteTargetIds = new Set(
-      mixedPlanGroups.flatMap(({ op }) => getOpEntityIds(op)),
+      appliedPlanGroups.flatMap(({ op }) => getOpEntityIds(op)),
     );
-    const affectedDays = Object.entries(plannerState.days)
-      .filter(([, taskIds]) => taskIds.some((taskId) => localWinnerTaskIds.has(taskId)))
-      .map(([day, taskIds]) => ({
-        day,
-        taskIds: taskIds.filter(
-          (taskId) => !remoteTargetIds.has(taskId) || localWinnerTaskIds.has(taskId),
-        ),
-      }))
-      .sort((a, b) => a.day.localeCompare(b.day));
-    if (affectedDays.length === 0) return [];
+    const placements = Object.entries(plannerState.days)
+      .sort(([dayA], [dayB]) => dayA.localeCompare(dayB))
+      .flatMap(([day, taskIds]) => {
+        const postRemoteTaskIds = taskIds.filter(
+          (taskId) => !remoteTargetIds.has(taskId) || finalLocalWinners.has(taskId),
+        );
+        return postRemoteTaskIds.flatMap((taskId, targetIndex) => {
+          const winner = finalLocalWinners.get(taskId);
+          if (!winner) return [];
+          const today = extractActionPayload(winner.remotePlanOp.payload)['today'];
+          const task = extractActionPayload(winner.localWinOp.payload);
+          if (typeof today !== 'string' || task['id'] !== taskId) return [];
+          return [{ day, targetIndex, taskId, task, today, ...winner }];
+        });
+      });
+    if (placements.length === 0) return [];
 
     const clientId = await this.clientIdProvider.loadClientId();
     if (!clientId) {
@@ -2863,26 +2876,31 @@ export class ConflictResolutionService {
     let nextClock = this.mergeAndIncrementClocks(
       [
         (await this.opLogStore.getVectorClock()) ?? {},
-        ...mixedPlanGroups.map(({ op }) => op.vectorClock),
-        ...localWinnerOps.map((op) => op.vectorClock),
+        ...appliedPlanGroups.map(({ op }) => op.vectorClock),
+        ...placements.map(({ localWinOp }) => localWinOp.vectorClock),
       ],
       clientId,
     );
-    const timestamp = Math.max(...localWinnerOps.map((op) => op.timestamp));
-    return affectedDays.map(({ day, taskIds }) => {
+    return placements.map(({ day, targetIndex, taskId, task, today, localWinOp }) => {
       const op: Operation = {
         id: uuidv7(),
-        actionType: ActionType.PLANNER_UPSERT_DAY,
-        opType: OpType.Update,
+        actionType: ActionType.PLANNER_TRANSFER_TASK,
+        opType: OpType.Move,
         entityType: 'PLANNER',
-        entityId: day,
+        entityId: taskId,
         payload: {
-          actionPayload: { day, taskIds },
+          actionPayload: {
+            task,
+            prevDay: today,
+            newDay: day,
+            targetIndex,
+            today,
+          },
           entityChanges: [],
         },
         clientId,
         vectorClock: nextClock,
-        timestamp,
+        timestamp: localWinOp.timestamp,
         schemaVersion: CURRENT_SCHEMA_VERSION,
       };
       nextClock = this.mergeAndIncrementClocks([nextClock], clientId);

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -397,9 +397,11 @@ const INDEPENDENT_MULTI_DELETE_ACTIONS = new Set<ActionType>([
  * Remote rows of these types replay as ordinary atomic actions (the reducers
  * skip unknown task ids); local winners are restored by mixed-winner
  * compensation snapshots applied after the remote row. A remote
- * `planTasksForToday` also removes every target from `planner.days`, so its
- * local-winning targets receive an established `Upsert Planner Day` follow-up
- * that restores their exact surviving placement on live apply and replay.
+ * `planTasksForToday` also removes every target from `planner.days`, so each
+ * local-winning target whose snapshot still matches its surviving placement
+ * receives an established `Transfer Task` follow-up that restores that exact
+ * placement on live apply and replay
+ * (`_createMixedRemoteTodayPlannerCompensationOps`).
  */
 const ORDERING_ONLY_MULTI_ACTIONS = new Set<ActionType>([
   ActionType.TASK_SHARED_MOVE_IN_TODAY,
@@ -2802,6 +2804,10 @@ export class ConflictResolutionService {
    * snapshots. A whole-day snapshot is unsafe here: it can overwrite an
    * unrelated placement that reached the server before this compensation.
    *
+   * Each transfer must be a pure ordering restore — its replay force-writes
+   * `dueDay` and clears `dueWithTime` — so a placement whose day disagrees
+   * with the winning snapshot is skipped rather than re-imposed.
+   *
    * `Transfer Task` is an existing wire action understood by released clients,
    * so this needs neither a schema bump nor a new payload contract.
    */
@@ -2861,6 +2867,18 @@ export class ConflictResolutionService {
           const today = extractActionPayload(winner.remotePlanOp.payload)['today'];
           const task = extractActionPayload(winner.localWinOp.payload);
           if (typeof today !== 'string' || task['id'] !== taskId) return [];
+          // Ordering-only restore: the transfer replay force-writes dueDay and
+          // clears dueWithTime, so a stale planner.days entry that disagrees
+          // with the winning snapshot (e.g. left by an earlier LWW snapshot
+          // that moved scheduling without touching planner state) must not be
+          // re-imposed — it would revert the winner's schedule on every
+          // client. Skip it; that winner keeps the pre-existing bounded gap.
+          if (
+            task['dueDay'] !== day ||
+            (task['dueWithTime'] !== undefined && task['dueWithTime'] !== null)
+          ) {
+            return [];
+          }
           return [{ day, targetIndex, taskId, task, today, ...winner }];
         });
       });

--- a/src/app/op-log/sync/operation-encryption.service.spec.ts
+++ b/src/app/op-log/sync/operation-encryption.service.spec.ts
@@ -583,6 +583,69 @@ describe('OperationEncryptionService', () => {
       ).toBeResolved();
     });
 
+    // --- Today-list footprint across the real crypto flow ---
+    // The direct integrity-helper specs pin all supported action shapes. These
+    // cases prove the production decrypt entry points actually invoke that gate
+    // after AES-GCM authenticates actionPayload.taskIds.
+
+    const createTodayPlanOp = (): SyncOperation => ({
+      ...createMockSyncOp({
+        actionPayload: {
+          taskIds: ['task-1', 'task-2'],
+          today: '2026-07-30',
+          startOfNextDayDiffMs: 0,
+        },
+        entityChanges: [],
+      }),
+      actionType: ActionType.TASK_SHARED_PLAN_FOR_TODAY,
+      opType: 'UPDATE',
+      entityType: 'TASK',
+      entityId: 'task-1',
+      entityIds: ['task-1', 'task-2'],
+    });
+
+    it('round-trips a legitimate encrypted Today bulk plan', async () => {
+      const encrypted = await service.encryptOperation(
+        createTodayPlanOp(),
+        TEST_PASSWORD,
+      );
+
+      const decrypted = await service.decryptOperation(encrypted, TEST_PASSWORD);
+
+      expect(decrypted.entityIds).toEqual(['task-1', 'task-2']);
+      expect(
+        (decrypted.payload as { actionPayload: { taskIds: string[] } }).actionPayload
+          .taskIds,
+      ).toEqual(['task-1', 'task-2']);
+    });
+
+    it('rejects an encrypted Today plan whose plaintext footprint injects a victim', async () => {
+      const encrypted = await service.encryptOperation(
+        createTodayPlanOp(),
+        TEST_PASSWORD,
+      );
+      const tampered: SyncOperation = {
+        ...encrypted,
+        entityIds: [...(encrypted.entityIds as string[]), 'victim-task'],
+      };
+
+      await expectAsync(
+        service.decryptOperation(tampered, TEST_PASSWORD),
+      ).toBeRejectedWithError(OperationIntegrityError);
+    });
+
+    it('rejects a stripped Today bulk footprint through batch decrypt', async () => {
+      const [encrypted] = await service.encryptOperations(
+        [createTodayPlanOp()],
+        TEST_PASSWORD,
+      );
+      const tampered: SyncOperation = { ...encrypted, entityIds: undefined };
+
+      await expectAsync(
+        service.decryptOperations([tampered], TEST_PASSWORD),
+      ).toBeRejectedWithError(OperationIntegrityError);
+    });
+
     describe('full-state opType promotion', () => {
       const createFullStateOp = (
         opType: OpType.SyncImport | OpType.BackupImport | OpType.Repair,

--- a/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
@@ -579,6 +579,84 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
       ]);
     });
 
+    it('skips the placement compensation when a stale planner entry disagrees with the winner schedule', async () => {
+      // An earlier LWW TASK snapshot can move scheduling (here: dueWithTime)
+      // without touching planner state, leaving a stale planner.days entry.
+      // The transfer replay force-writes dueDay and clears dueWithTime, so
+      // re-imposing that entry would revert the winner's schedule on every
+      // client. The winner must keep its schedule; only the stale placement
+      // is lost (the pre-existing bounded gap).
+      const localWinner: Task = {
+        ...liveTask(CONFLICT_TASK_ID),
+        title: 'Local newer edit',
+        dueDay: undefined,
+        dueWithTime: Date.parse('2026-08-06T09:00:00Z'),
+      };
+      taskStateById[CONFLICT_TASK_ID] = localWinner;
+      plannerDaysByDay = { [FUTURE_DAY]: [CONFLICT_TASK_ID] };
+
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: CONFLICT_TASK_ID, changes: { title: localWinner.title } },
+        }) as PersistentAction,
+      );
+      const remotePlanOp = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        localEditOp.timestamp - 1000,
+      );
+
+      await resolver.autoResolveConflictsLWW(await detectConflictsFor(remotePlanOp));
+
+      expect((await unsyncedOps()).filter((op) => op.entityType === 'PLANNER')).toEqual(
+        [],
+      );
+
+      const baseState = createStateWithExistingTasks([
+        CONFLICT_TASK_ID,
+        SIBLING_1,
+        SIBLING_2,
+      ]);
+      const stateBeforeRemote: RootState = {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          entities: {
+            ...baseState[TASK_FEATURE_NAME].entities,
+            [CONFLICT_TASK_ID]: localWinner,
+          },
+        },
+        [plannerFeatureKey]: {
+          ...baseState[plannerFeatureKey],
+          days: plannerDaysByDay,
+        },
+      };
+      const baseReducer: ActionReducer<RootState, Action> = (state, action) => ({
+        ...(state as RootState),
+        [plannerFeatureKey]: plannerReducer(
+          (state as RootState)[plannerFeatureKey],
+          action,
+        ),
+      });
+      const replayReducer = bulkOperationsMetaReducer(
+        createCombinedTaskSharedMetaReducer(lwwUpdateMetaReducer(baseReducer)),
+      ) as ActionReducer<RootState, Action>;
+
+      const replayedState = replayReducer(
+        stateBeforeRemote,
+        bulkApplyOperations({
+          operations: appliedOps(),
+          localClientId: LOCAL_CLIENT_ID,
+        }),
+      );
+      const replayedWinner = replayedState[TASK_FEATURE_NAME].entities[
+        CONFLICT_TASK_ID
+      ] as Task;
+      expect(replayedWinner.title).toBe(localWinner.title);
+      expect(replayedWinner.dueWithTime).toBe(localWinner.dueWithTime);
+      expect(replayedWinner.dueDay).toBeUndefined();
+      expect(replayedState[plannerFeatureKey].days[FUTURE_DAY] ?? []).toEqual([]);
+    });
+
     it('preserves an unrelated placement that reaches the server before compensation', async () => {
       const localWinner = {
         ...liveTask(CONFLICT_TASK_ID),

--- a/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Action, Store } from '@ngrx/store';
+import { Action, ActionReducer, Store } from '@ngrx/store';
 import { of, Subject, Subscription } from 'rxjs';
 import { SnackService } from '../../../core/snack/snack.service';
 import { ClientIdService } from '../../../core/util/client-id.service';
 import { DEFAULT_TASK, Task } from '../../../features/tasks/task.model';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { OperationApplierService } from '../../apply/operation-applier.service';
+import { bulkApplyOperations } from '../../apply/bulk-hydration.action';
+import { bulkOperationsMetaReducer } from '../../apply/bulk-hydration.meta-reducer';
 import { OperationCaptureService } from '../../capture/operation-capture.service';
 import { clearDeferredActions } from '../../capture/operation-capture.meta-reducer';
 import { OperationLogEffects } from '../../capture/operation-log.effects';
@@ -31,6 +33,16 @@ import {
   ApplyOperationsResult,
 } from '../../core/types/apply.types';
 import { resetTestUuidCounter, TestClient } from './helpers/test-client.helper';
+import { RootState } from '../../../root-store/root-state';
+import { createStateWithExistingTasks } from '../../../root-store/meta/task-shared-meta-reducers/test-utils';
+import { createCombinedTaskSharedMetaReducer } from '../../../root-store/meta/task-shared-meta-reducers/test-helpers';
+import { lwwUpdateMetaReducer } from '../../../root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer';
+import {
+  plannerFeatureKey,
+  plannerReducer,
+} from '../../../features/planner/store/planner.reducer';
+import { PlannerActions } from '../../../features/planner/store/planner.actions';
+import { TASK_FEATURE_NAME } from '../../../features/tasks/store/task.reducer';
 
 /**
  * #9426 / #9405: a pending local multi-entity Today-list op (the automatic
@@ -47,6 +59,7 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
   const SIBLING_1 = 'task-sibling-1';
   const SIBLING_2 = 'task-sibling-2';
   const TODAY = '2026-07-30';
+  const FUTURE_DAY = '2026-08-03';
 
   let opLogStore: OperationLogStoreService;
   let capture: OperationCaptureService;
@@ -58,6 +71,7 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
   let actions$: Subject<Action>;
   let effectSubscription: Subscription;
   let taskStateById: Record<string, Task | undefined>;
+  let plannerDaysByDay: Record<string, string[]>;
 
   const liveTask = (id: string): Task => ({
     ...DEFAULT_TASK,
@@ -77,10 +91,18 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
       [SIBLING_1]: liveTask(SIBLING_1),
       [SIBLING_2]: liveTask(SIBLING_2),
     };
+    plannerDaysByDay = {};
     // Serve current entity state for local-win snapshots from a plain map. The
     // registry's TASK selectById is a props-based selector: (selector, {id}).
     store.select.and.callFake(((_selector: unknown, props?: { id?: string }): unknown =>
-      of(props?.id ? taskStateById[props.id] : undefined)) as Store['select']);
+      of(
+        props?.id
+          ? taskStateById[props.id]
+          : {
+              days: plannerDaysByDay,
+              addPlannedTasksDialogLastShown: undefined,
+            },
+      )) as Store['select']);
 
     operationApplier = jasmine.createSpyObj<OperationApplierService>(
       'OperationApplierService',
@@ -456,6 +478,92 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
         (op) => op.entityId === CONFLICT_TASK_ID && op.id !== remotePlanOp.id,
       );
       expect(compensationIndex).toBeGreaterThan(planIndex);
+    });
+
+    it('keeps a local winner in its future planner position after replay', async () => {
+      const localWinner = {
+        ...liveTask(CONFLICT_TASK_ID),
+        title: 'Local newer edit',
+        dueDay: FUTURE_DAY,
+      };
+      taskStateById[CONFLICT_TASK_ID] = localWinner;
+      taskStateById[SIBLING_1] = {
+        ...liveTask(SIBLING_1),
+        dueDay: FUTURE_DAY,
+      };
+      taskStateById[SIBLING_2] = {
+        ...liveTask(SIBLING_2),
+        dueDay: FUTURE_DAY,
+      };
+      plannerDaysByDay = {
+        [FUTURE_DAY]: [SIBLING_2, CONFLICT_TASK_ID, SIBLING_1],
+      };
+
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: CONFLICT_TASK_ID, changes: { title: localWinner.title } },
+        }) as PersistentAction,
+      );
+      const remotePlanOp = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        localEditOp.timestamp - 1000,
+      );
+
+      await resolver.autoResolveConflictsLWW(await detectConflictsFor(remotePlanOp));
+
+      const baseState = createStateWithExistingTasks([
+        CONFLICT_TASK_ID,
+        SIBLING_1,
+        SIBLING_2,
+      ]);
+      const stateBeforeRemote: RootState = {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          entities: {
+            ...baseState[TASK_FEATURE_NAME].entities,
+            [CONFLICT_TASK_ID]: localWinner,
+            [SIBLING_1]: taskStateById[SIBLING_1],
+            [SIBLING_2]: taskStateById[SIBLING_2],
+          },
+        },
+        [plannerFeatureKey]: {
+          ...baseState[plannerFeatureKey],
+          days: plannerDaysByDay,
+        },
+      };
+      const baseReducer: ActionReducer<RootState, Action> = (state, action) => {
+        if (action.type !== PlannerActions.upsertPlannerDay.type) {
+          return state as RootState;
+        }
+        return {
+          ...(state as RootState),
+          [plannerFeatureKey]: plannerReducer(
+            (state as RootState)[plannerFeatureKey],
+            action,
+          ),
+        };
+      };
+      const replayReducer = bulkOperationsMetaReducer(
+        createCombinedTaskSharedMetaReducer(lwwUpdateMetaReducer(baseReducer)),
+      ) as ActionReducer<RootState, Action>;
+
+      const replayedState = replayReducer(
+        stateBeforeRemote,
+        bulkApplyOperations({
+          operations: appliedOps(),
+          localClientId: LOCAL_CLIENT_ID,
+        }),
+      );
+      const replayedWinner = replayedState[TASK_FEATURE_NAME].entities[
+        CONFLICT_TASK_ID
+      ] as Task;
+      expect(replayedWinner.title).toBe(localWinner.title);
+      expect(replayedWinner.dueDay).toBe(FUTURE_DAY);
+      expect(replayedState[plannerFeatureKey].days[FUTURE_DAY]).toEqual([
+        SIBLING_2,
+        CONFLICT_TASK_ID,
+      ]);
     });
 
     it('degrades to a plain remote win when a local winner has no compensation snapshot', async () => {

--- a/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts
@@ -58,6 +58,7 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
   const CONFLICT_TASK_ID = 'rpt_cfg-a_2026-07-28';
   const SIBLING_1 = 'task-sibling-1';
   const SIBLING_2 = 'task-sibling-2';
+  const CONCURRENT_TASK_ID = 'task-concurrent-placement';
   const TODAY = '2026-07-30';
   const FUTURE_DAY = '2026-08-03';
 
@@ -90,6 +91,7 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
       [CONFLICT_TASK_ID]: liveTask(CONFLICT_TASK_ID),
       [SIBLING_1]: liveTask(SIBLING_1),
       [SIBLING_2]: liveTask(SIBLING_2),
+      [CONCURRENT_TASK_ID]: liveTask(CONCURRENT_TASK_ID),
     };
     plannerDaysByDay = {};
     // Serve current entity state for local-win snapshots from a plain map. The
@@ -432,7 +434,11 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
   });
 
   describe('remote planTasksForToday bulk op in a conflict', () => {
-    const buildRemotePlanOp = (taskIds: string[], timestamp: number): Operation => {
+    const buildRemotePlanOp = (
+      taskIds: string[],
+      timestamp: number,
+      remoteClient = new TestClient(REMOTE_CLIENT_ID),
+    ): Operation => {
       const remoteAction = TaskSharedActions.planTasksForToday({
         taskIds,
         today: TODAY,
@@ -440,7 +446,7 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
       }) as PersistentAction;
       const { type, meta, ...actionPayload } = remoteAction;
       return {
-        ...new TestClient(REMOTE_CLIENT_ID).createOperation({
+        ...remoteClient.createOperation({
           actionType: type,
           opType: meta.opType,
           entityType: meta.entityType,
@@ -495,8 +501,12 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
         ...liveTask(SIBLING_2),
         dueDay: FUTURE_DAY,
       };
+      taskStateById[CONCURRENT_TASK_ID] = {
+        ...liveTask(CONCURRENT_TASK_ID),
+        dueDay: FUTURE_DAY,
+      };
       plannerDaysByDay = {
-        [FUTURE_DAY]: [SIBLING_2, CONFLICT_TASK_ID, SIBLING_1],
+        [FUTURE_DAY]: [SIBLING_2, SIBLING_1, CONFLICT_TASK_ID, CONCURRENT_TASK_ID],
       };
 
       const [localEditOp] = await dispatchAndFlush(
@@ -515,6 +525,7 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
         CONFLICT_TASK_ID,
         SIBLING_1,
         SIBLING_2,
+        CONCURRENT_TASK_ID,
       ]);
       const stateBeforeRemote: RootState = {
         ...baseState,
@@ -525,6 +536,7 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
             [CONFLICT_TASK_ID]: localWinner,
             [SIBLING_1]: taskStateById[SIBLING_1],
             [SIBLING_2]: taskStateById[SIBLING_2],
+            [CONCURRENT_TASK_ID]: taskStateById[CONCURRENT_TASK_ID],
           },
         },
         [plannerFeatureKey]: {
@@ -563,7 +575,154 @@ describe('today-list multi-entity conflict resolution integration (#9426)', () =
       expect(replayedState[plannerFeatureKey].days[FUTURE_DAY]).toEqual([
         SIBLING_2,
         CONFLICT_TASK_ID,
+        CONCURRENT_TASK_ID,
       ]);
+    });
+
+    it('preserves an unrelated placement that reaches the server before compensation', async () => {
+      const localWinner = {
+        ...liveTask(CONFLICT_TASK_ID),
+        title: 'Local newer edit',
+        dueDay: FUTURE_DAY,
+      };
+      const concurrentTask = {
+        ...liveTask(CONCURRENT_TASK_ID),
+        dueDay: FUTURE_DAY,
+      };
+      taskStateById[CONFLICT_TASK_ID] = localWinner;
+      taskStateById[SIBLING_1] = {
+        ...liveTask(SIBLING_1),
+        dueDay: FUTURE_DAY,
+      };
+      taskStateById[SIBLING_2] = {
+        ...liveTask(SIBLING_2),
+        dueDay: FUTURE_DAY,
+      };
+      taskStateById[CONCURRENT_TASK_ID] = concurrentTask;
+      plannerDaysByDay = {
+        [FUTURE_DAY]: [SIBLING_2, CONFLICT_TASK_ID, SIBLING_1],
+      };
+
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: CONFLICT_TASK_ID, changes: { title: localWinner.title } },
+        }) as PersistentAction,
+      );
+      const remotePlanOp = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        localEditOp.timestamp - 1000,
+      );
+      const placementAction = PlannerActions.planTaskForDay({
+        task: concurrentTask,
+        day: FUTURE_DAY,
+      }) as PersistentAction;
+      const { type, meta, ...actionPayload } = placementAction;
+      const concurrentPlacementOp = new TestClient(
+        'concurrent-planner-client',
+      ).createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: CONCURRENT_TASK_ID,
+        payload: { actionPayload, entityChanges: [] },
+      });
+
+      await resolver.autoResolveConflictsLWW(await detectConflictsFor(remotePlanOp), [
+        concurrentPlacementOp,
+      ]);
+
+      const plannerCompensations = (await unsyncedOps()).filter(
+        (op) => op.entityType === 'PLANNER',
+      );
+      expect(plannerCompensations.length).toBe(1);
+      expect(plannerCompensations[0].actionType).toBe(ActionType.PLANNER_TRANSFER_TASK);
+      expect(plannerCompensations[0].entityId).toBe(CONFLICT_TASK_ID);
+
+      const baseState = createStateWithExistingTasks([
+        CONFLICT_TASK_ID,
+        SIBLING_1,
+        SIBLING_2,
+        CONCURRENT_TASK_ID,
+      ]);
+      const stateBeforeRemote: RootState = {
+        ...baseState,
+        [TASK_FEATURE_NAME]: {
+          ...baseState[TASK_FEATURE_NAME],
+          entities: {
+            ...baseState[TASK_FEATURE_NAME].entities,
+            [CONFLICT_TASK_ID]: localWinner,
+            [SIBLING_1]: taskStateById[SIBLING_1],
+            [SIBLING_2]: taskStateById[SIBLING_2],
+            [CONCURRENT_TASK_ID]: concurrentTask,
+          },
+        },
+        [plannerFeatureKey]: {
+          ...baseState[plannerFeatureKey],
+          days: plannerDaysByDay,
+        },
+      };
+      const baseReducer: ActionReducer<RootState, Action> = (state, action) => ({
+        ...(state as RootState),
+        [plannerFeatureKey]: plannerReducer(
+          (state as RootState)[plannerFeatureKey],
+          action,
+        ),
+      });
+      const replayReducer = bulkOperationsMetaReducer(
+        createCombinedTaskSharedMetaReducer(lwwUpdateMetaReducer(baseReducer)),
+      ) as ActionReducer<RootState, Action>;
+      const serverOrderedOps = [
+        remotePlanOp,
+        concurrentPlacementOp,
+        ...(await unsyncedOps()),
+      ];
+
+      const replayedState = replayReducer(
+        stateBeforeRemote,
+        bulkApplyOperations({
+          operations: serverOrderedOps,
+          localClientId: 'fresh-client',
+        }),
+      );
+
+      expect(replayedState[plannerFeatureKey].days[FUTURE_DAY]).toEqual([
+        SIBLING_2,
+        CONFLICT_TASK_ID,
+        CONCURRENT_TASK_ID,
+      ]);
+    });
+
+    it('does not compensate a task whose later remote Today operation wins', async () => {
+      taskStateById[CONFLICT_TASK_ID] = {
+        ...liveTask(CONFLICT_TASK_ID),
+        title: 'Local middle edit',
+        dueDay: FUTURE_DAY,
+      };
+      plannerDaysByDay = { [FUTURE_DAY]: [CONFLICT_TASK_ID] };
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: CONFLICT_TASK_ID, changes: { title: 'Local middle edit' } },
+        }) as PersistentAction,
+      );
+      const remoteClient = new TestClient(REMOTE_CLIENT_ID);
+      const earlierRemotePlan = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        localEditOp.timestamp - 1,
+        remoteClient,
+      );
+      const laterRemotePlan = buildRemotePlanOp(
+        [CONFLICT_TASK_ID, SIBLING_1],
+        localEditOp.timestamp + 1,
+        remoteClient,
+      );
+      const earlierConflicts = await detectConflictsFor(earlierRemotePlan);
+      const laterConflicts = await detectConflictsFor(laterRemotePlan);
+
+      await resolver.autoResolveConflictsLWW([...earlierConflicts, ...laterConflicts]);
+
+      expect((await unsyncedOps()).filter((op) => op.entityType === 'PLANNER')).toEqual(
+        [],
+      );
     });
 
     it('degrades to a plain remote win when a local winner has no compensation snapshot', async () => {


### PR DESCRIPTION
## Problem

Mixed-winner `planTasksForToday` conflicts replay the original remote bulk action atomically. That action removes every target from its planner day, including a task whose newer local edit wins. The earlier compensation restored task fields but not the task's future planner placement.

A whole-day planner snapshot is also unsafe as compensation: when replayed after another client has added an unrelated task to that day, it can overwrite the newer placement. Multiple remote Today operations in one batch can additionally leave a stale compensation for a task whose final winner is remote.

This is a follow-up to #9426 and #9442.

## Solution

- Track the final winner per task across all applied remote Today-plan operations.
- Restore each final local winner with the existing task-scoped `Transfer Task` wire action after the atomic remote action and task snapshot.
- Calculate target indexes after remote-winning targets are removed, preserving the surviving planner order without replacing the whole day.
- Preserve the local winner's timestamp and merge the relevant vector clocks; no schema bump or new wire contract is needed.
- Cover encrypted Today-plan footprints, reducer replay, a later remote winner, unrelated concurrent placement, and fresh-client SuperSync convergence.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Verification

- `npm test` — passed, including 14,042 Angular tests in Europe/Berlin and 14,028 in America/Los_Angeles
- `npm run test:file src/app/op-log/sync/conflict-resolution.service.spec.ts` — 237 passed
- `npm run test:file src/app/op-log/testing/integration/today-plan-conflict-resolution.integration.spec.ts` — 13 passed
- Focused three-client SuperSync Playwright regression — passed
- `npm run checkFile` — passed for every changed TypeScript file
- Pre-commit lint and repository checks — passed (existing warnings only)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (Not applicable: no user-facing workflow or setting changed.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
