### PR TITLE
fix(ui): prevent wide calendar overlap

### DIFF
--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -51,10 +51,13 @@
   }
 
   ::ng-deep {
-    // Reserve enough room for a 6-row month while keeping the dialog height stable
-    // as users navigate between months (#6556, #9397).
+    // Reserve enough room for a 6-row month at every supported picker width while
+    // keeping the dialog height stable as users navigate between months (#6556,
+    // #9397, #9452). Material calendar rows grow with the picker's width.
     mat-calendar {
-      height: 416px;
+      height: auto;
+      min-height: 416px;
+      aspect-ratio: 25 / 26;
     }
 
     .mat-calendar-header {

--- a/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
+++ b/src/app/ui/datetime-picker/datetime-picker.component.spec.ts
@@ -52,22 +52,25 @@ describe('DateTimePickerComponent', () => {
     expect(calendarEl).toBeTruthy();
   });
 
-  it('should keep a six-row month above the time controls', () => {
-    fixture.nativeElement.style.width = '400px';
+  it('should keep a six-row month above the time controls at supported widths', () => {
     fixture.componentRef.setInput('selectedDate', new Date(2026, 7, 4));
     fixture.detectChanges();
 
-    const weekRows = fixture.nativeElement.querySelectorAll(
-      '.mat-calendar-body > tr',
-    ) as NodeListOf<HTMLElement>;
-    const formControls = fixture.nativeElement.querySelector(
-      '.form-ctrl-wrapper',
-    ) as HTMLElement;
+    [400, 560].forEach((pickerWidth) => {
+      fixture.nativeElement.style.width = `${pickerWidth}px`;
 
-    expect(weekRows.length).toBe(6);
-    expect(weekRows[5].getBoundingClientRect().bottom).toBeLessThanOrEqual(
-      formControls.getBoundingClientRect().top,
-    );
+      const weekRows = fixture.nativeElement.querySelectorAll(
+        '.mat-calendar-body > tr',
+      ) as NodeListOf<HTMLElement>;
+      const formControls = fixture.nativeElement.querySelector(
+        '.form-ctrl-wrapper',
+      ) as HTMLElement;
+
+      expect(weekRows.length).withContext(`${pickerWidth}px picker`).toBe(6);
+      expect(weekRows[5].getBoundingClientRect().bottom)
+        .withContext(`${pickerWidth}px picker`)
+        .toBeLessThanOrEqual(formControls.getBoundingClientRect().top);
+    });
   });
 
   it('should emit dateSelected when a date is selected on the calendar', () => {


### PR DESCRIPTION
## Problem

At wider scheduling-dialog widths, Angular Material calendar rows scale with the calendar width while the calendar host remained fixed at 416px high. Six-row months could therefore overlap the time controls, particularly with longer translations such as Russian.

Fixes #9452.

## Solution

- Scale the reserved calendar height with the picker width while retaining the existing 416px minimum for narrow layouts.
- Keep the calendar height deterministic when navigating between months.
- Cover both the standard 400px width and the maximum supported 560px width with the existing geometry regression test.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (Not applicable: layout-only bug fix.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- `npm run test:file src/app/ui/datetime-picker/datetime-picker.component.spec.ts` — 23 tests passed
- `npm run checkFile src/app/ui/datetime-picker/datetime-picker.component.scss`
- `npm run checkFile src/app/ui/datetime-picker/datetime-picker.component.spec.ts`
- Reproduced the reported Russian dialog layout at 591×682 and verified the time controls remain below the six-row calendar.
