### PR TITLE
fix(color): render the color picker panel in a CDK overlay

### DIFF
--- a/e2e/pages/tag.page.ts
+++ b/e2e/pages/tag.page.ts
@@ -18,9 +18,9 @@ export class TagPage extends BasePage {
   }
 
   /**
-   * Creates a new tag via the sidebar
+   * Opens the create tag dialog via the sidebar and returns its name input.
    */
-  async createTag(tagName: string): Promise<void> {
+  async openCreateTagDialog(): Promise<Locator> {
     // Find the Tags group header button
     const tagsGroupBtn = this.tagsGroup
       .locator('.g-multi-btn-wrapper nav-item button')
@@ -56,6 +56,15 @@ export class TagPage extends BasePage {
 
     // Add a small delay for Angular form initialization
     await this.page.waitForTimeout(500);
+
+    return tagNameInput;
+  }
+
+  /**
+   * Creates a new tag via the sidebar
+   */
+  async createTag(tagName: string): Promise<void> {
+    const tagNameInput = await this.openCreateTagDialog();
 
     await tagNameInput.fill(tagName);
 

--- a/e2e/tests/tags/tag-color-picker-9423.spec.ts
+++ b/e2e/tests/tags/tag-color-picker-9423.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '../../fixtures/test.fixture';
+import { waitForAppReady } from '../../utils/waits';
+
+/**
+ * Issue #9423: the tag color picker rendered half off-screen on macOS.
+ *
+ * `backdrop-filter` makes an element the containing block for fixed-position
+ * descendants, and three built-in themes apply it to `.mat-mdc-dialog-surface`.
+ * The picker positioned its panel with `position: fixed` plus viewport
+ * coordinates read from the trigger, so under those themes the offsets resolved
+ * against the dialog surface instead of the viewport and the panel was
+ * displaced by the dialog's own origin.
+ *
+ * The unit spec pins the same behavior against a synthetic wrapper. Only this
+ * test runs the real `liquid-glass.css` against the real dialog, which is the
+ * exact combination the bug needed — so it asserts the theme is actually in
+ * effect before it asserts anything about the panel.
+ *
+ * Liquid Glass is the default on Apple Silicon Macs (`pickInitialActiveRef`),
+ * which is why the report came from macOS.
+ *
+ * Run: npm run e2e:file e2e/tests/tags/tag-color-picker-9423.spec.ts -- --retries=0
+ */
+test.describe('Tag color picker positioning', () => {
+  test('should keep the panel on screen and anchored under a glass-surface theme', async ({
+    page,
+    workViewPage,
+    tagPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    await page.evaluate(() =>
+      localStorage.setItem('CUSTOM_THEME', 'builtin:liquid-glass'),
+    );
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForAppReady(page);
+
+    await tagPage.openCreateTagDialog();
+
+    // Precondition: without the theme's backdrop-filter there is no containing
+    // block and the assertions below would pass on the broken code too.
+    const surfaceFilter = await page
+      .locator('.mat-mdc-dialog-surface')
+      .evaluate((el) => getComputedStyle(el).backdropFilter);
+    expect(surfaceFilter).not.toBe('none');
+
+    const trigger = page.locator('input-color-picker .color-trigger');
+    await trigger.click();
+
+    const panel = page.locator('.color-panel');
+    await expect(panel).toBeVisible();
+
+    const triggerBox = (await trigger.boundingBox())!;
+    const panelBox = (await panel.boundingBox())!;
+    const viewport = page.viewportSize()!;
+
+    // Anchored to the trigger, directly above or below it.
+    expect(Math.abs(panelBox.x - triggerBox.x)).toBeLessThanOrEqual(8);
+    const isBelow = Math.abs(panelBox.y - (triggerBox.y + triggerBox.height)) <= 8;
+    const isAbove = Math.abs(panelBox.y + panelBox.height - triggerBox.y) <= 8;
+    expect(isBelow || isAbove).toBe(true);
+
+    // Fully on screen.
+    expect(panelBox.y).toBeGreaterThanOrEqual(0);
+    expect(panelBox.x).toBeGreaterThanOrEqual(0);
+    expect(panelBox.y + panelBox.height).toBeLessThanOrEqual(viewport.height);
+    expect(panelBox.x + panelBox.width).toBeLessThanOrEqual(viewport.width);
+  });
+});

--- a/src/app/ui/input-color-picker/input-color-picker.component.html
+++ b/src/app/ui/input-color-picker/input-color-picker.component.html
@@ -3,24 +3,27 @@
 }
 
 <button
-  #trigger
+  #triggerOrigin="cdkOverlayOrigin"
+  cdkOverlayOrigin
   type="button"
   class="color-trigger"
   [style.background-color]="value()"
   (click)="toggle()"
 ></button>
 
-@if (isOpen()) {
-  <div
-    class="backdrop"
-    (click)="isOpen.set(false)"
-  ></div>
-  <div
-    class="color-panel"
-    [style.position]="'fixed'"
-    [style.top]="panelTop"
-    [style.left]="panelLeft"
-  >
+<ng-template
+  cdkConnectedOverlay
+  [cdkConnectedOverlayOrigin]="triggerOrigin"
+  [cdkConnectedOverlayOpen]="isOpen()"
+  [cdkConnectedOverlayPositions]="panelPositions"
+  [cdkConnectedOverlayViewportMargin]="viewportMargin"
+  [cdkConnectedOverlayPush]="true"
+  [cdkConnectedOverlayHasBackdrop]="true"
+  cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+  (backdropClick)="isOpen.set(false)"
+  (detach)="isOpen.set(false)"
+>
+  <div class="color-panel">
     <div class="color-grid">
       @for (color of presetColors; track color) {
         <button
@@ -50,7 +53,7 @@
       </button>
     </div>
   </div>
-}
+</ng-template>
 
 <input
   #nativeInput

--- a/src/app/ui/input-color-picker/input-color-picker.component.scss
+++ b/src/app/ui/input-color-picker/input-color-picker.component.scss
@@ -25,18 +25,11 @@
   }
 }
 
-.backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: calc(var(--z-backdrop) - 1);
-}
-
 .color-panel {
   padding: var(--s);
   background: var(--card-bg);
   border-radius: 8px;
   box-shadow: var(--whiteframe-shadow-8dp);
-  z-index: var(--z-backdrop);
 }
 
 .color-grid {

--- a/src/app/ui/input-color-picker/input-color-picker.component.spec.ts
+++ b/src/app/ui/input-color-picker/input-color-picker.component.spec.ts
@@ -1,0 +1,148 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { InputColorPickerComponent } from './input-color-picker.component';
+import { PRESET_COLORS } from '../../features/work-context/work-context-color';
+
+/**
+ * The wrapper mimics the themed dialog surface from #9423: `backdrop-filter`
+ * makes an element the containing block for fixed-position descendants, so a
+ * panel positioned with viewport coordinates lands offset by the wrapper's own
+ * origin. Three built-in themes do exactly this to `.mat-mdc-dialog-surface`.
+ */
+@Component({
+  template: `
+    <div class="offset-container">
+      <input-color-picker
+        [value]="color()"
+        (valueChange)="color.set($event)"
+      />
+    </div>
+  `,
+  styles: [
+    `
+      /* Fixed, not absolute: the trigger's viewport rect must not depend on
+         how far the Karma page happens to be scrolled in a full-suite run. */
+      .offset-container {
+        position: fixed;
+        top: 220px;
+        left: 260px;
+        backdrop-filter: blur(20px);
+      }
+    `,
+  ],
+  imports: [InputColorPickerComponent],
+})
+class TestHostComponent {
+  readonly color = signal(PRESET_COLORS[0]);
+}
+
+describe('InputColorPickerComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let picker: InputColorPickerComponent;
+
+  const trigger = (): HTMLButtonElement =>
+    fixture.nativeElement.querySelector('.color-trigger');
+  const panel = (): HTMLElement | null => document.querySelector('.color-panel');
+  const swatches = (): HTMLButtonElement[] =>
+    Array.from(document.querySelectorAll('.color-panel .color-swatch'));
+
+  const open = (): void => {
+    trigger().click();
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    picker = fixture.debugElement.children[0].children[0]
+      .componentInstance as InputColorPickerComponent;
+  });
+
+  it('should not render the panel until opened', () => {
+    expect(panel()).toBeNull();
+  });
+
+  it('should render the panel in the CDK overlay container, not inside the component', () => {
+    open();
+
+    const el = panel();
+    expect(el).not.toBeNull();
+    expect(el!.closest('.cdk-overlay-container')).not.toBeNull();
+    expect(fixture.nativeElement.contains(el)).toBe(false);
+  });
+
+  // Regression test for #9423.
+  it('should position the panel against the trigger when an ancestor establishes a containing block', () => {
+    open();
+
+    const triggerRect = trigger().getBoundingClientRect();
+    const panelRect = panel()!.getBoundingClientRect();
+
+    expect(panelRect.left).toBeCloseTo(triggerRect.left, 0);
+
+    const isBelow = Math.abs(panelRect.top - triggerRect.bottom) <= 8;
+    const isAbove = Math.abs(panelRect.bottom - triggerRect.top) <= 8;
+    expect(isBelow || isAbove).toBe(true);
+
+    expect(panelRect.top).toBeGreaterThanOrEqual(0);
+    expect(panelRect.bottom).toBeLessThanOrEqual(window.innerHeight);
+    expect(panelRect.right).toBeLessThanOrEqual(window.innerWidth);
+  });
+
+  it('should toggle closed when the trigger is clicked again', () => {
+    open();
+    expect(picker.isOpen()).toBe(true);
+
+    open();
+
+    expect(picker.isOpen()).toBe(false);
+    expect(panel()).toBeNull();
+  });
+
+  it('should emit the picked preset and close', () => {
+    open();
+    const target = PRESET_COLORS[3];
+
+    swatches()[3].click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.color()).toBe(target);
+    expect(picker.isOpen()).toBe(false);
+  });
+
+  it('should close on escape without needing focus inside the panel', () => {
+    open();
+
+    // CDK's overlay keyboard dispatcher listens on `body` and reads `keyCode`.
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        keyCode: 27,
+        bubbles: true,
+        cancelable: true,
+      } as KeyboardEventInit & { keyCode: number }),
+    );
+    fixture.detectChanges();
+
+    expect(picker.isOpen()).toBe(false);
+    expect(panel()).toBeNull();
+  });
+
+  it('should close the panel and delegate to the native input for a custom color', () => {
+    open();
+    const nativeInput = picker.nativeInput()!.nativeElement;
+    const clickSpy = spyOn(nativeInput, 'click');
+
+    swatches()[swatches().length - 1].click();
+    fixture.detectChanges();
+
+    expect(clickSpy).toHaveBeenCalled();
+    expect(picker.isOpen()).toBe(false);
+  });
+});

--- a/src/app/ui/input-color-picker/input-color-picker.component.ts
+++ b/src/app/ui/input-color-picker/input-color-picker.component.ts
@@ -3,21 +3,28 @@ import {
   Component,
   computed,
   ElementRef,
-  HostListener,
   input,
   output,
   signal,
   viewChild,
 } from '@angular/core';
+import {
+  CdkConnectedOverlay,
+  CdkOverlayOrigin,
+  ConnectedPosition,
+} from '@angular/cdk/overlay';
 import { PRESET_COLORS } from '../../features/work-context/work-context-color';
 import { MatIcon } from '@angular/material/icon';
+
+const PANEL_GAP = 4;
+const VIEWPORT_MARGIN = 8;
 
 @Component({
   selector: 'input-color-picker',
   templateUrl: './input-color-picker.component.html',
   styleUrls: ['./input-color-picker.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatIcon],
+  imports: [MatIcon, CdkOverlayOrigin, CdkConnectedOverlay],
 })
 export class InputColorPickerComponent {
   readonly value = input<string>('#000000');
@@ -26,24 +33,30 @@ export class InputColorPickerComponent {
 
   readonly presetColors = PRESET_COLORS;
   readonly nativeInput = viewChild<ElementRef<HTMLInputElement>>('nativeInput');
-  readonly trigger = viewChild<ElementRef<HTMLButtonElement>>('trigger');
   readonly isOpen = signal(false);
   readonly isPresetColor = computed(() => this.presetColors.includes(this.value()));
 
-  panelTop = '';
-  panelLeft = '';
+  readonly viewportMargin = VIEWPORT_MARGIN;
 
-  @HostListener('document:keydown.escape')
-  onEscape(): void {
-    if (this.isOpen()) {
-      this.isOpen.set(false);
-    }
-  }
+  // Below the trigger, flipping above when there is no room.
+  readonly panelPositions: ConnectedPosition[] = [
+    {
+      originX: 'start',
+      originY: 'bottom',
+      overlayX: 'start',
+      overlayY: 'top',
+      offsetY: PANEL_GAP,
+    },
+    {
+      originX: 'start',
+      originY: 'top',
+      overlayX: 'start',
+      overlayY: 'bottom',
+      offsetY: -PANEL_GAP,
+    },
+  ];
 
   toggle(): void {
-    if (!this.isOpen()) {
-      this._updatePanelPosition();
-    }
     this.isOpen.update((v) => !v);
   }
 
@@ -60,25 +73,5 @@ export class InputColorPickerComponent {
   onNativeChange(event: Event): void {
     const el = event.target as HTMLInputElement;
     this.valueChange.emit(el.value);
-  }
-
-  private _updatePanelPosition(): void {
-    const rect = this.trigger()?.nativeElement.getBoundingClientRect();
-    if (!rect) return;
-
-    const panelWidth = 196;
-    const panelHeight = 160;
-    const gap = 4;
-
-    const spaceRight = window.innerWidth - rect.left;
-    const left =
-      spaceRight >= panelWidth ? rect.left : window.innerWidth - panelWidth - 8;
-
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const top =
-      spaceBelow >= panelHeight + gap ? rect.bottom + gap : rect.top - panelHeight - gap;
-
-    this.panelTop = `${top}px`;
-    this.panelLeft = `${left}px`;
   }
 }


### PR DESCRIPTION
## Problem

Fixes #9423. The tag color picker panel renders half off-screen on macOS.

`InputColorPickerComponent` positioned its panel by hand: it read the trigger's `getBoundingClientRect()` (viewport coordinates) and applied them as `position: fixed; top/left` on a panel that lives inside the component's own DOM.

`backdrop-filter` makes an element the containing block for fixed-position descendants, and three built-in themes apply it to `.mat-mdc-dialog-surface`: `liquid-glass.css` (Tier B), plus `velvet.css` and `rainbow.css` in dark mode. Under those themes the panel's offsets resolve against the dialog surface instead of the viewport, so the panel is displaced by the dialog's own origin and falls off the viewport edge.

Liquid Glass is the auto-selected default on Apple Silicon Macs (`pickInitialActiveRef` in `custom-theme.service.ts`), which is why this is a macOS report and why it does not reproduce under the default theme.

Measured in the real Electron app, Create Tag dialog, Liquid Glass, 1200x400 content size:

| | before | after |
|---|---|---|
| trigger rect | `top 235.9, left 438` | `top 234.1, left 436.2` |
| panel inline style | `top: 71.9px; left: 438px` | none (overlay-positioned) |
| panel painted at | `top 115.4, left 852` | `top 75.9, left 438` |
| result | 414px right of the dialog, clipped | anchored above the trigger, fully on screen |

The reporter's "extend the window to reveal the bottom half" matches the same cause: the panel is placed past the viewport edge and never repositions.

| before | after |
|---|---|
| <img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/b579abff-3d94-4c2c-a3b8-15f1dd4d9f19" /> | <img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/ddbbc832-d650-4fde-9c88-64a003e0b5b0" /> |

## Solution

Move the panel into a CDK connected overlay anchored to the trigger. The overlay pane is a child of the overlay container, so no ancestor can become its containing block.

This removes rather than adds: `panelTop`, `panelLeft`, `_updatePanelPosition()`, the hardcoded `panelWidth = 196` / `panelHeight = 160` guesses (the panel actually measures 192x156), the hand-rolled `.backdrop` element and its SCSS, and the `document:keydown.escape` `HostListener`.

Four things the hand-rolled positioning could not do come along with it:

- viewport clamping via `withPush`, where the old flip-above branch could produce a negative `top` with no clamp
- reposition on scroll (CDK's default reposition strategy)
- outside-click and Escape handled by the overlay itself
- the app's global safe-area patch on `FlexibleConnectedPositionStrategy` (`cdk-safe-area-viewport.util.ts`), which the old code bypassed entirely

One deliberate behavior change: Escape now closes only the picker. Previously, the `document` listener closed the picker while the same event also reached `MatDialog` and closed the dialog. CDK's keyboard dispatcher routes the key to the top-most overlay, which matches how `mat-menu` and `mat-select` behave inside a dialog.

Panel styles stay in the component SCSS. Template-projected content keeps its `_ngcontent-*` attribute, so class selectors still apply once the panel is portaled; verified in the running app (`--card-bg`, padding, radius and elevation all resolve).

Both call sites are covered by the one change: `dialog-create-tag` and the formly `color` field used by the tag/project settings dialog.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Nothing to document in the wiki: this is a positioning fix with no user-facing behavior to describe.

## Testing

Unit suite: 14029 passing (baseline on `master` was 14022; the 7 new specs are the difference). Lint clean, 0 errors, the 10 remaining warnings are pre-existing in untouched files.

New `input-color-picker.component.spec.ts` (7 specs). Two of them are the regression guard: the panel must render in the overlay container rather than inside the component, and it must stay anchored to the trigger and inside the viewport when mounted inside a wrapper that carries `backdrop-filter`. Sabotage-verified by restoring the old component: **2 FAILED, 5 SUCCESS**.

New `e2e/tests/tags/tag-color-picker-9423.spec.ts`. The unit spec can only simulate the containing block with a synthetic wrapper, so this one activates the real `liquid-glass.css`, opens the real Create Tag dialog, and asserts the panel is anchored and on screen. It asserts the theme is in effect first (`backdrop-filter !== 'none'` on the surface), so it cannot pass vacuously if the theme fails to load. Sabotage-verified against the old component: **1 failed**, on the anchoring assertion.

`e2e/tests/tags/tag-crud.spec.ts`: 5 passing, confirming the `TagPage.openCreateTagDialog()` extraction (pulled out of `createTag()`, which now calls it) did not change existing behavior.

Manual verification in the real Electron app on macOS, driven through Playwright's `_electron`, under both Liquid Glass and the default theme, in the Create Tag dialog and the tag settings dialog. Panel measures 192x156, sits 4px from the trigger, flips above when there is no room below, and stays inside the viewport in every case.

## Notes for reviewers

The theme side is intentional and I did not touch it. `tools/theme-assets.test.js` already guards `.main-content` against creating a containing block ("Liquid Glass keeps routed overlays and mobile safe-area math intact") and `liquid-glass.css` comments on the hazard directly, while Tier B applies the effect to dialog and menu surfaces on purpose. `magic-side-nav.component.scss` carries the same warning to theme authors. So the component was the layer relying on an assumption the themes are allowed to break.

Alternative considered and rejected: keep the hand-rolled `position: fixed` and subtract the nearest containing block's rect. It needs the panel measured before it is rendered, and it would still leave the missing viewport clamp, the missing reposition-on-scroll, and the bypassed safe-area handling.

No new dependencies (`@angular/cdk` is already a dependency), no translations, and nothing in the sync, op-log or persisted-model surface is touched.
