### PR TITLE
fix(schedule): span the whole month in the month grid

### DIFF
--- a/e2e/tests/schedule/schedule-month-scroll-reset.spec.ts
+++ b/e2e/tests/schedule/schedule-month-scroll-reset.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Review of #9463: with the month grid fixed at six rows it overflows the
+ * scroll wrapper on a short window, so the scroll position carried over from
+ * week view clamped to the bottom and the month opened with its first row
+ * above the viewport (scrollTop 121 of a 121px maximum, reproduced here).
+ *
+ * The unit spec asserts the reset call fires; only this test runs it at a real
+ * constrained height with a real overflowing month grid, which is the
+ * combination the bug needed.
+ *
+ * Run: npm run e2e:file e2e/tests/schedule/schedule-month-scroll-reset.spec.ts -- --retries=0
+ */
+const SHORT_DESKTOP_VIEWPORT = { width: 1280, height: 500 };
+
+test.describe('Schedule month view scroll position', () => {
+  test.use({ viewport: SHORT_DESKTOP_VIEWPORT });
+
+  test('should open month view at the top after scrolling week view', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await page.getByRole('menuitem', { name: 'Schedule' }).click();
+
+    const wrapper = page.locator('schedule .scroll-wrapper');
+    await expect(wrapper).toBeVisible();
+    await page.getByRole('button', { name: 'View Week' }).click();
+    await expect(page.locator('schedule-week')).toBeVisible();
+
+    // Week view is a full day timeline, so it always overflows this height.
+    const scrolled = await wrapper.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+      return el.scrollTop;
+    });
+    expect(scrolled).toBeGreaterThan(0);
+
+    await page.getByRole('button', { name: 'View Month' }).click();
+    await expect(page.locator('schedule-month')).toBeVisible();
+
+    // Precondition: without overflow there would be nothing to clamp to and
+    // this would pass on the unfixed code too.
+    const overflow = await wrapper.evaluate((el) => el.scrollHeight - el.clientHeight);
+    expect(overflow).toBeGreaterThan(0);
+
+    await expect
+      .poll(async () => wrapper.evaluate((el) => el.scrollTop), { timeout: 5000 })
+      .toBe(0);
+  });
+});

--- a/e2e/tests/schedule/schedule-month-scroll-reset.spec.ts
+++ b/e2e/tests/schedule/schedule-month-scroll-reset.spec.ts
@@ -1,18 +1,27 @@
 import { expect, test } from '../../fixtures/test.fixture';
 
 /**
- * Review of #9463: with the month grid fixed at six rows it overflows the
- * scroll wrapper on a short window, so the scroll position carried over from
- * week view clamped to the bottom and the month opened with its first row
- * above the viewport (scrollTop 121 of a 121px maximum, reproduced here).
+ * Review of #9463: a month grid that overflows the scroll wrapper on a short
+ * window kept the scroll position carried over from week view, so the month
+ * opened with its first row above the viewport (scrollTop 121 of a 121px
+ * maximum, reproduced here).
  *
  * The unit spec asserts the reset call fires; only this test runs it at a real
  * constrained height with a real overflowing month grid, which is the
  * combination the bug needed.
  *
+ * The month is navigated to rather than taken from the clock. Rows follow the
+ * displayed month (4-6), and `.month-day-cell` has `min-height: 80px`, so the
+ * track minimum sets the grid height once the rows stop fitting: at this
+ * viewport six rows overflow by 121px, five by 40, and four not at all. Taking
+ * whatever month today happens to be would make the precondition below fail
+ * for the 28 days of a non-leap February starting on the week's first day.
+ *
  * Run: npm run e2e:file e2e/tests/schedule/schedule-month-scroll-reset.spec.ts -- --retries=0
  */
 const SHORT_DESKTOP_VIEWPORT = { width: 1280, height: 500 };
+/** Rows the grid must show for the wrapper to overflow at this viewport. */
+const ROWS_THAT_OVERFLOW = 6;
 
 test.describe('Schedule month view scroll position', () => {
   test.use({ viewport: SHORT_DESKTOP_VIEWPORT });
@@ -26,6 +35,29 @@ test.describe('Schedule month view scroll position', () => {
 
     const wrapper = page.locator('schedule .scroll-wrapper');
     await expect(wrapper).toBeVisible();
+
+    // Land on a month that actually overflows, before the scroll position that
+    // the reset has to clear is set up. The view switch below keeps it: only
+    // `selectedTimeView` changes, never the selected date.
+    await page.getByRole('button', { name: 'View Month' }).click();
+    await expect(page.locator('schedule-month')).toBeVisible();
+    const monthRows = (): Promise<number> =>
+      page
+        .locator('schedule-month')
+        .evaluate((el) =>
+          Number(getComputedStyle(el).getPropertyValue('--nr-of-weeks').trim()),
+        );
+    const firstDay = (): Promise<string | null> =>
+      page.locator('.month-day-cell[data-day]').first().getAttribute('data-day');
+    // Wait for the grid to actually advance rather than re-reading the row
+    // count before Angular has re-rendered. Six rows is at most 11 months away.
+    for (let i = 0; i < 12 && (await monthRows()) !== ROWS_THAT_OVERFLOW; i++) {
+      const before = await firstDay();
+      await page.getByRole('button', { name: 'Next Month' }).click();
+      await expect.poll(firstDay).not.toBe(before);
+    }
+    expect(await monthRows()).toBe(ROWS_THAT_OVERFLOW);
+
     await page.getByRole('button', { name: 'View Week' }).click();
     await expect(page.locator('schedule-week')).toBeVisible();
 
@@ -40,7 +72,8 @@ test.describe('Schedule month view scroll position', () => {
     await expect(page.locator('schedule-month')).toBeVisible();
 
     // Precondition: without overflow there would be nothing to clamp to and
-    // this would pass on the unfixed code too.
+    // this would pass on the unfixed code too. Pinned to six rows above, so it
+    // does not depend on the month the suite happens to run in.
     const overflow = await wrapper.evaluate((el) => el.scrollHeight - el.clientHeight);
     expect(overflow).toBeGreaterThan(0);
 

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
@@ -526,13 +526,18 @@ describe('CalendarGestureHandler', () => {
       cb.getIsExpanded.and.returnValue(false);
       cb.getActiveWeekIndex.and.returnValue(0);
 
+      // Derived, not a literal: the midpoint sits halfway between MIN_HEIGHT
+      // and MAX_HEIGHT, so a fixed pixel delta silently stops clearing it when
+      // the expanded height changes (it did when the grid went to six rows).
+      const pastMidpoint = Math.ceil((MAX_HEIGHT - MIN_HEIGHT) * 0.75);
+
       handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
       // Move more than 5px to trigger drag mode, then advance time to keep
       // velocity low so the midpoint check is used rather than velocity
-      handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 200));
+      handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 100 + pastMidpoint));
       jasmine.clock().tick(1000);
       // End drag with enough delta to be past midpoint
-      handleEl.dispatchEvent(makeTouchEvent('touchend', 100, 200));
+      handleEl.dispatchEvent(makeTouchEvent('touchend', 100, 100 + pastMidpoint));
 
       jasmine.clock().tick(SNAP_DURATION + 15);
 

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
@@ -551,5 +551,95 @@ describe('CalendarGestureHandler', () => {
 
       expect(cb.onExpandChanged).toHaveBeenCalledWith(true);
     });
+
+    // Review round 2 of #9463: with room for a single row there is nothing to
+    // expand into, so the interpolation range is 0 and the ratio would be NaN.
+    describe('at a one-row viewport', () => {
+      beforeEach(() => {
+        cb.getExpandedHeight.and.returnValue(MIN_HEIGHT);
+      });
+
+      // Asserting the exact offset, not merely the absence of 'NaN': the
+      // browser rejects translateY(NaNpx) outright, so the unguarded code
+      // leaves the transform empty and a not-toContain check passes on it.
+      it('should still write a usable transform while dragging', () => {
+        cb.getActiveWeekIndex.and.returnValue(2);
+
+        handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
+        handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 200));
+
+        const innerEl = weeksEl.firstElementChild as HTMLElement;
+        expect(innerEl.style.transform).toBe(`translateY(${-2 * ROW_HEIGHT}px)`);
+        expect(weeksEl.style.maxHeight).toBe(MIN_HEIGHT + 'px');
+      });
+
+      it('should stay collapsed rather than report an expansion it cannot render', () => {
+        handler.snapTo(true);
+        jasmine.clock().tick(SNAP_DURATION + 20);
+
+        expect(cb.onExpandChanged).toHaveBeenCalledWith(false);
+        expect(cb.onExpandChanged).not.toHaveBeenCalledWith(true);
+        expect(weeksEl.style.maxHeight).toBe(MIN_HEIGHT + 'px');
+      });
+    });
+
+    // The component re-measures on every getExpandedHeight() call, so reading it
+    // per touchmove interleaves layout reads with the style writes below it.
+    it('should measure the expanded height once per drag, not per touchmove', () => {
+      handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
+      cb.getExpandedHeight.calls.reset();
+
+      handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 120));
+      handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 140));
+      handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 160));
+
+      // Once for _startDrag, on the first move that crosses the threshold.
+      expect(cb.getExpandedHeight).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // Review round 2 of #9463: the zero-duration branch cleared the inline styles
+  // and relied on Angular re-applying them, but onExpandChanged may write an
+  // unchanged signal value, in which case Angular skips the DOM write and the
+  // element is left with no max-height at all — dropping the responsive clamp.
+  describe('reduced motion', () => {
+    let reducedHandler: CalendarGestureHandler;
+    let reducedWeeksEl: HTMLElement;
+
+    beforeEach(() => {
+      (window.matchMedia as jasmine.Spy).and.returnValue({
+        matches: true,
+      } as MediaQueryList);
+      reducedWeeksEl = createMockWeeksEl();
+      reducedHandler = new CalendarGestureHandler(
+        document.createElement('div'),
+        () => reducedWeeksEl,
+        cb,
+      );
+    });
+
+    afterEach(() => reducedHandler.destroy());
+
+    it('should keep the clamped height when snapping to the state it is already in', () => {
+      cb.getIsExpanded.and.returnValue(true);
+
+      reducedHandler.snapTo(true);
+
+      expect(reducedWeeksEl.style.maxHeight).toBe(MAX_HEIGHT + 'px');
+      expect((reducedWeeksEl.firstElementChild as HTMLElement).style.transform).toBe(
+        'translateY(0px)',
+      );
+    });
+
+    it('should keep the collapsed geometry when a drag is cancelled', () => {
+      cb.getActiveWeekIndex.and.returnValue(2);
+
+      reducedHandler.snapTo(false, 2);
+
+      expect(reducedWeeksEl.style.maxHeight).toBe(MIN_HEIGHT + 'px');
+      expect((reducedWeeksEl.firstElementChild as HTMLElement).style.transform).toBe(
+        `translateY(${-2 * ROW_HEIGHT}px)`,
+      );
+    });
   });
 });

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
@@ -50,6 +50,8 @@ const createMockCallbacks = (): jasmine.SpyObj<CalendarGestureCallbacks> =>
   jasmine.createSpyObj<CalendarGestureCallbacks>('callbacks', [
     'getActiveWeekIndex',
     'getIsExpanded',
+    'getExpandedHeight',
+    'getWeekOffset',
     'onExpandChanged',
     'onVerticalSwipe',
     'onHorizontalSwipe',
@@ -78,6 +80,12 @@ describe('CalendarGestureHandler', () => {
     cb = createMockCallbacks();
     cb.getActiveWeekIndex.and.returnValue(0);
     cb.getIsExpanded.and.returnValue(false);
+    // Unclamped geometry: what the component reports on any viewport tall
+    // enough for all six rows. The clamped case is covered in the component spec.
+    cb.getExpandedHeight.and.returnValue(MAX_HEIGHT);
+    cb.getWeekOffset.and.callFake((expanded: boolean, activeIdx: number) =>
+      expanded ? 0 : -activeIdx * ROW_HEIGHT,
+    );
 
     handler = new CalendarGestureHandler(el, () => weeksEl, cb);
   });

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
@@ -57,6 +57,7 @@ const createMockCallbacks = (): jasmine.SpyObj<CalendarGestureCallbacks> =>
     'getIsExpanded',
     'measure',
     'getExpandedHeight',
+    'getRowHeight',
     'canExpand',
     'onExpandChanged',
     'onVerticalSwipe',
@@ -87,6 +88,7 @@ describe('CalendarGestureHandler', () => {
     cb.getActiveWeekIndex.and.returnValue(0);
     cb.getIsExpanded.and.returnValue(false);
     cb.getExpandedHeight.and.returnValue(MAX_HEIGHT);
+    cb.getRowHeight.and.returnValue(ROW_HEIGHT);
     cb.canExpand.and.returnValue(true);
 
     handler = new CalendarGestureHandler(el, () => weeksEl, cb);
@@ -571,6 +573,35 @@ describe('CalendarGestureHandler', () => {
         // dropped-rows clamp this was -4 rows and weeks 5 and 6 were unreachable.
         const innerEl = weeksEl.firstElementChild as HTMLElement;
         expect(innerEl.style.transform).toBe('translateY(0px)');
+      });
+
+      // The offset counts in whole rows, so the rows on screen have to be the
+      // height that offset assumes for the whole animation, not only after the
+      // flag flips at snapDur + 10. Collapsing from index 2 with 29px rows
+      // travelled to -80px and put week 3 in the window before jumping back.
+      it('should give the rows their post-snap height when the animation starts', () => {
+        cb.getExpandedHeight.and.returnValue(MIN_ROW_HEIGHT * WEEKS_SHOWN);
+        cb.getRowHeight.and.returnValue(MIN_ROW_HEIGHT);
+        cb.getIsExpanded.and.returnValue(true);
+
+        handler.snapTo(false, 2);
+
+        // Before the animation has finished, and before onExpandChanged fires.
+        expect(weeksEl.style.getPropertyValue('--row-height')).toBe(`${ROW_HEIGHT}px`);
+        const innerEl = weeksEl.firstElementChild as HTMLElement;
+        expect(innerEl.style.transform).toBe(`translateY(${-2 * ROW_HEIGHT}px)`);
+        expect(cb.onExpandChanged).not.toHaveBeenCalled();
+      });
+
+      it('should give the rows the shrunken height when expanding', () => {
+        cb.getExpandedHeight.and.returnValue(MIN_ROW_HEIGHT * WEEKS_SHOWN);
+        cb.getRowHeight.and.returnValue(MIN_ROW_HEIGHT);
+
+        handler.snapTo(true, 2);
+
+        expect(weeksEl.style.getPropertyValue('--row-height')).toBe(
+          `${MIN_ROW_HEIGHT}px`,
+        );
       });
 
       it('should collapse to a full-size row, never a shrunken one', () => {

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
@@ -56,7 +56,7 @@ const createMockCallbacks = (): jasmine.SpyObj<CalendarGestureCallbacks> =>
     'getActiveWeekIndex',
     'getIsExpanded',
     'measure',
-    'getRowHeight',
+    'getExpandedHeight',
     'canExpand',
     'onExpandChanged',
     'onVerticalSwipe',
@@ -86,7 +86,7 @@ describe('CalendarGestureHandler', () => {
     cb = createMockCallbacks();
     cb.getActiveWeekIndex.and.returnValue(0);
     cb.getIsExpanded.and.returnValue(false);
-    cb.getRowHeight.and.returnValue(ROW_HEIGHT);
+    cb.getExpandedHeight.and.returnValue(MAX_HEIGHT);
     cb.canExpand.and.returnValue(true);
 
     handler = new CalendarGestureHandler(el, () => weeksEl, cb);
@@ -555,11 +555,11 @@ describe('CalendarGestureHandler', () => {
     });
 
     // Rows shrink instead of being dropped, so every geometry the handler sees
-    // still spans six rows. A viewport too short even for MIN_ROW_HEIGHT rows
-    // reports canExpand false rather than a degenerate height (#9463 review).
+    // still spans six rows. The collapsed height is always ROW_HEIGHT; only the
+    // expanded height moves, and it arrives already clamped (#9463 review).
     describe('on a shrunken grid', () => {
       it('should snap to six shrunken rows with no offset', () => {
-        cb.getRowHeight.and.returnValue(MIN_ROW_HEIGHT);
+        cb.getExpandedHeight.and.returnValue(MIN_ROW_HEIGHT * WEEKS_SHOWN);
         cb.getActiveWeekIndex.and.returnValue(4);
 
         handler.snapTo(true);
@@ -573,9 +573,23 @@ describe('CalendarGestureHandler', () => {
         expect(innerEl.style.transform).toBe('translateY(0px)');
       });
 
-      describe('too short even for that', () => {
+      it('should collapse to a full-size row, never a shrunken one', () => {
+        cb.getExpandedHeight.and.returnValue(MIN_ROW_HEIGHT * WEEKS_SHOWN);
+
+        handler.snapTo(false);
+        jasmine.clock().tick(SNAP_DURATION + 20);
+
+        // The collapsed strip is one row in a viewport with room for one, so it
+        // does not shrink with the grid: shrinking it would give every user
+        // 25px tap targets whether or not they ever expand.
+        expect(weeksEl.style.maxHeight).toBe(`${ROW_HEIGHT}px`);
+      });
+
+      describe('too short to expand at all', () => {
         beforeEach(() => {
-          cb.getRowHeight.and.returnValue(MIN_ROW_HEIGHT);
+          // What the component reports once the room is gone: the clamped
+          // expanded height has collapsed onto the collapsed height.
+          cb.getExpandedHeight.and.returnValue(ROW_HEIGHT);
           cb.canExpand.and.returnValue(false);
         });
 
@@ -585,38 +599,41 @@ describe('CalendarGestureHandler', () => {
 
           expect(cb.onExpandChanged).toHaveBeenCalledWith(false);
           expect(cb.onExpandChanged).not.toHaveBeenCalledWith(true);
-          expect(weeksEl.style.maxHeight).toBe(MIN_ROW_HEIGHT + 'px');
+          expect(weeksEl.style.maxHeight).toBe(`${ROW_HEIGHT}px`);
         });
 
-        // Asserting the exact offset, not merely the absence of 'NaN': the
-        // browser rejects translateY(NaNpx) outright, so code that produced one
-        // would leave the transform empty and a not-toContain check would pass.
-        it('should still write a usable transform while dragging', () => {
+        // The drag ceiling is the clamped expanded height, so a rubber-band
+        // cannot open the grid into room that is not there. Previously a 100px
+        // drag opened it to 124px in a viewport with 42px to spare.
+        it('should not open past the room available while dragging', () => {
           cb.getActiveWeekIndex.and.returnValue(2);
 
           handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
           handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 200));
 
-          // 100px of a 120px range leaves a sixth of the collapsed offset.
+          expect(weeksEl.style.maxHeight).toBe(`${ROW_HEIGHT}px`);
+          // Asserting the exact offset, not merely the absence of 'NaN': the
+          // browser rejects translateY(NaNpx) outright, so code that produced
+          // one would leave the transform empty and a not-toContain check would
+          // pass. The range is 0 here, which is what the guard is for.
           const innerEl = weeksEl.firstElementChild as HTMLElement;
-          expect(innerEl.style.transform).toBe('translateY(-8px)');
-          expect(weeksEl.style.maxHeight).toBe(`${MIN_ROW_HEIGHT + 100}px`);
+          expect(innerEl.style.transform).toBe(`translateY(${-2 * ROW_HEIGHT}px)`);
         });
       });
     });
 
     // The component measures layout to answer this, so reading it per touchmove
     // would interleave layout reads with the style writes below it.
-    it('should read the row height once per drag, not per touchmove', () => {
+    it('should read the expanded height once per drag, not per touchmove', () => {
       handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
-      cb.getRowHeight.calls.reset();
+      cb.getExpandedHeight.calls.reset();
 
       handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 120));
       handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 140));
       handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 160));
 
       // Once for _startDrag, on the first move that crosses the threshold.
-      expect(cb.getRowHeight).toHaveBeenCalledTimes(1);
+      expect(cb.getExpandedHeight).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
@@ -1,10 +1,15 @@
 import {
   CalendarGestureHandler,
   CalendarGestureCallbacks,
+  MIN_ROW_HEIGHT,
   ROW_HEIGHT,
-  MAX_HEIGHT,
-  MIN_HEIGHT,
+  WEEKS_SHOWN,
 } from './planner-calendar-gesture-handler';
+
+// Geometry on a viewport tall enough for six full-size rows. Shrunken rows are
+// covered by the row-height cases below and in the component spec.
+const MAX_HEIGHT = ROW_HEIGHT * WEEKS_SHOWN;
+const MIN_HEIGHT = ROW_HEIGHT;
 
 // Snap/slide durations must match the source constants
 const SNAP_DURATION = 200;
@@ -50,8 +55,9 @@ const createMockCallbacks = (): jasmine.SpyObj<CalendarGestureCallbacks> =>
   jasmine.createSpyObj<CalendarGestureCallbacks>('callbacks', [
     'getActiveWeekIndex',
     'getIsExpanded',
-    'getExpandedHeight',
-    'getWeekOffset',
+    'measure',
+    'getRowHeight',
+    'canExpand',
     'onExpandChanged',
     'onVerticalSwipe',
     'onHorizontalSwipe',
@@ -80,12 +86,8 @@ describe('CalendarGestureHandler', () => {
     cb = createMockCallbacks();
     cb.getActiveWeekIndex.and.returnValue(0);
     cb.getIsExpanded.and.returnValue(false);
-    // Unclamped geometry: what the component reports on any viewport tall
-    // enough for all six rows. The clamped case is covered in the component spec.
-    cb.getExpandedHeight.and.returnValue(MAX_HEIGHT);
-    cb.getWeekOffset.and.callFake((expanded: boolean, activeIdx: number) =>
-      expanded ? 0 : -activeIdx * ROW_HEIGHT,
-    );
+    cb.getRowHeight.and.returnValue(ROW_HEIGHT);
+    cb.canExpand.and.returnValue(true);
 
     handler = new CalendarGestureHandler(el, () => weeksEl, cb);
   });
@@ -552,49 +554,69 @@ describe('CalendarGestureHandler', () => {
       expect(cb.onExpandChanged).toHaveBeenCalledWith(true);
     });
 
-    // Review round 2 of #9463: with room for a single row there is nothing to
-    // expand into, so the interpolation range is 0 and the ratio would be NaN.
-    describe('at a one-row viewport', () => {
-      beforeEach(() => {
-        cb.getExpandedHeight.and.returnValue(MIN_HEIGHT);
-      });
+    // Rows shrink instead of being dropped, so every geometry the handler sees
+    // still spans six rows. A viewport too short even for MIN_ROW_HEIGHT rows
+    // reports canExpand false rather than a degenerate height (#9463 review).
+    describe('on a shrunken grid', () => {
+      it('should snap to six shrunken rows with no offset', () => {
+        cb.getRowHeight.and.returnValue(MIN_ROW_HEIGHT);
+        cb.getActiveWeekIndex.and.returnValue(4);
 
-      // Asserting the exact offset, not merely the absence of 'NaN': the
-      // browser rejects translateY(NaNpx) outright, so the unguarded code
-      // leaves the transform empty and a not-toContain check passes on it.
-      it('should still write a usable transform while dragging', () => {
-        cb.getActiveWeekIndex.and.returnValue(2);
-
-        handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
-        handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 200));
-
-        const innerEl = weeksEl.firstElementChild as HTMLElement;
-        expect(innerEl.style.transform).toBe(`translateY(${-2 * ROW_HEIGHT}px)`);
-        expect(weeksEl.style.maxHeight).toBe(MIN_HEIGHT + 'px');
-      });
-
-      it('should stay collapsed rather than report an expansion it cannot render', () => {
         handler.snapTo(true);
         jasmine.clock().tick(SNAP_DURATION + 20);
 
-        expect(cb.onExpandChanged).toHaveBeenCalledWith(false);
-        expect(cb.onExpandChanged).not.toHaveBeenCalledWith(true);
-        expect(weeksEl.style.maxHeight).toBe(MIN_HEIGHT + 'px');
+        expect(cb.onExpandChanged).toHaveBeenCalledWith(true);
+        expect(weeksEl.style.maxHeight).toBe(`${MIN_ROW_HEIGHT * WEEKS_SHOWN}px`);
+        // Every row is on screen, so nothing has to slide into view. Under the
+        // dropped-rows clamp this was -4 rows and weeks 5 and 6 were unreachable.
+        const innerEl = weeksEl.firstElementChild as HTMLElement;
+        expect(innerEl.style.transform).toBe('translateY(0px)');
+      });
+
+      describe('too short even for that', () => {
+        beforeEach(() => {
+          cb.getRowHeight.and.returnValue(MIN_ROW_HEIGHT);
+          cb.canExpand.and.returnValue(false);
+        });
+
+        it('should stay collapsed rather than report an expansion it cannot render', () => {
+          handler.snapTo(true);
+          jasmine.clock().tick(SNAP_DURATION + 20);
+
+          expect(cb.onExpandChanged).toHaveBeenCalledWith(false);
+          expect(cb.onExpandChanged).not.toHaveBeenCalledWith(true);
+          expect(weeksEl.style.maxHeight).toBe(MIN_ROW_HEIGHT + 'px');
+        });
+
+        // Asserting the exact offset, not merely the absence of 'NaN': the
+        // browser rejects translateY(NaNpx) outright, so code that produced one
+        // would leave the transform empty and a not-toContain check would pass.
+        it('should still write a usable transform while dragging', () => {
+          cb.getActiveWeekIndex.and.returnValue(2);
+
+          handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
+          handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 200));
+
+          // 100px of a 120px range leaves a sixth of the collapsed offset.
+          const innerEl = weeksEl.firstElementChild as HTMLElement;
+          expect(innerEl.style.transform).toBe('translateY(-8px)');
+          expect(weeksEl.style.maxHeight).toBe(`${MIN_ROW_HEIGHT + 100}px`);
+        });
       });
     });
 
-    // The component re-measures on every getExpandedHeight() call, so reading it
-    // per touchmove interleaves layout reads with the style writes below it.
-    it('should measure the expanded height once per drag, not per touchmove', () => {
+    // The component measures layout to answer this, so reading it per touchmove
+    // would interleave layout reads with the style writes below it.
+    it('should read the row height once per drag, not per touchmove', () => {
       handleEl.dispatchEvent(makeTouchEvent('touchstart', 100, 100));
-      cb.getExpandedHeight.calls.reset();
+      cb.getRowHeight.calls.reset();
 
       handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 120));
       handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 140));
       handleEl.dispatchEvent(makeTouchEvent('touchmove', 100, 160));
 
       // Once for _startDrag, on the first move that crosses the threshold.
-      expect(cb.getExpandedHeight).toHaveBeenCalledTimes(1);
+      expect(cb.getRowHeight).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.spec.ts
@@ -604,6 +604,30 @@ describe('CalendarGestureHandler', () => {
         );
       });
 
+      // The binding cannot be relied on to correct the inline value at the end
+      // of the animation. Collapsed at 29px rows Angular has written 40px
+      // (`displayRowHeight()` is ROW_HEIGHT while collapsed); if the box grows
+      // mid-animation so `rowHeight()` reaches ROW_HEIGHT, the bound value is
+      // 40px before the flip and 40px after it, so Angular skips both writes
+      // and the 29px this handler set inline would stand. That is a 240px grid
+      // over 174px of rows: a dead strip, and 25px tap targets.
+      it('should re-read the row height after the animation, not reuse it', () => {
+        cb.getExpandedHeight.and.returnValue(MIN_ROW_HEIGHT * WEEKS_SHOWN);
+        cb.getRowHeight.and.returnValue(MIN_ROW_HEIGHT);
+
+        handler.snapTo(true);
+        expect(weeksEl.style.getPropertyValue('--row-height')).toBe(
+          `${MIN_ROW_HEIGHT}px`,
+        );
+
+        // The box grows while the 200ms animation runs.
+        cb.getExpandedHeight.and.returnValue(ROW_HEIGHT * WEEKS_SHOWN);
+        cb.getRowHeight.and.returnValue(ROW_HEIGHT);
+        jasmine.clock().tick(SNAP_DURATION + 20);
+
+        expect(weeksEl.style.getPropertyValue('--row-height')).toBe(`${ROW_HEIGHT}px`);
+      });
+
       it('should collapse to a full-size row, never a shrunken one', () => {
         cb.getExpandedHeight.and.returnValue(MIN_ROW_HEIGHT * WEEKS_SHOWN);
 

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
@@ -38,6 +38,8 @@ export class CalendarGestureHandler {
   private _touchActive = false;
   private _dragStartHeight = 0;
   private _dragActiveIdx = 0;
+  /** Sampled once per drag: measuring per touchmove interleaves layout reads with writes. */
+  private _dragExpandedHeight = 0;
   private _prefersReducedMotion =
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -60,23 +62,34 @@ export class CalendarGestureHandler {
     this._el.removeEventListener('touchcancel', this._onTouchCancel);
   }
 
-  snapTo(expanded: boolean, activeIdx?: number): void {
+  snapTo(requestExpanded: boolean, activeIdx?: number): void {
     const weeksEl = this._getWeeksEl();
     if (!weeksEl) return;
     const innerEl = weeksEl.firstElementChild as HTMLElement;
     if (activeIdx !== undefined) this._dragActiveIdx = activeIdx;
 
+    // A viewport with room for only one row leaves nothing to expand into.
+    // Reporting expanded there would desync the flag from the geometry: the
+    // calendar still looks collapsed while horizontal swipes take the expanded
+    // branch and jump whole months.
+    const expandedHeight = this._cb.getExpandedHeight();
+    const expanded = requestExpanded && expandedHeight > MIN_HEIGHT;
+
     const snapDur = this._animDuration(SNAP_DURATION);
-    const targetHeight = expanded ? this._cb.getExpandedHeight() : MIN_HEIGHT;
+    const targetHeight = expanded ? expandedHeight : MIN_HEIGHT;
     const idx = this._dragActiveIdx;
     const targetOffset = this._cb.getWeekOffset(expanded, idx);
 
     if (snapDur === 0) {
+      // Apply the target rather than clearing, for the same reason the animated
+      // branch below keeps its inline styles: Angular skips the DOM write when
+      // the bound signal value has not changed, which would leave the element
+      // with no max-height at all and drop the responsive row clamp.
       weeksEl.style.transition = '';
-      weeksEl.style.maxHeight = '';
+      weeksEl.style.maxHeight = targetHeight + 'px';
       if (innerEl) {
         innerEl.style.transition = '';
-        innerEl.style.transform = '';
+        innerEl.style.transform = `translateY(${targetOffset}px)`;
       }
       this._cb.onExpandChanged(expanded);
       this._cb.detectChanges();
@@ -225,7 +238,7 @@ export class CalendarGestureHandler {
         const deltaY = touch.clientY - this._touchStartY;
         const elapsed = Date.now() - this._touchStartTime;
         const velocity = deltaY / Math.max(elapsed, 1);
-        const expandedHeight = this._cb.getExpandedHeight();
+        const expandedHeight = this._dragExpandedHeight;
         const currentHeight = Math.max(
           MIN_HEIGHT,
           Math.min(expandedHeight, this._dragStartHeight + deltaY),
@@ -276,13 +289,14 @@ export class CalendarGestureHandler {
   private _startDrag(): void {
     this._isDragging = true;
     this._dragActiveIdx = this._cb.getActiveWeekIndex();
+    this._dragExpandedHeight = this._cb.getExpandedHeight();
     this._dragStartHeight = this._cb.getIsExpanded()
-      ? this._cb.getExpandedHeight()
+      ? this._dragExpandedHeight
       : MIN_HEIGHT;
   }
 
   private _updateDrag(deltaY: number): void {
-    const expandedHeight = this._cb.getExpandedHeight();
+    const expandedHeight = this._dragExpandedHeight;
     const newHeight = Math.max(
       MIN_HEIGHT,
       Math.min(expandedHeight, this._dragStartHeight + deltaY),
@@ -291,7 +305,10 @@ export class CalendarGestureHandler {
     if (!weeksEl) return;
     weeksEl.style.maxHeight = newHeight + 'px';
 
-    const progress = (newHeight - MIN_HEIGHT) / (expandedHeight - MIN_HEIGHT);
+    // Guarded: with room for a single row the range is 0 and the ratio would be
+    // NaN, which renders as translateY(NaNpx).
+    const range = expandedHeight - MIN_HEIGHT;
+    const progress = range > 0 ? (newHeight - MIN_HEIGHT) / range : 0;
     const collapsedOffset = this._cb.getWeekOffset(false, this._dragActiveIdx);
     const expandedOffset = this._cb.getWeekOffset(true, this._dragActiveIdx);
     const travel = expandedOffset - collapsedOffset;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
@@ -1,5 +1,9 @@
 export const ROW_HEIGHT = 40;
-export const WEEKS_SHOWN = 5;
+// 6, not 5: the expanded grid anchors to the week containing the 1st, and a
+// month starting late in the week spans 6 rows (Aug 2026 starts on a Saturday).
+// At 5 the month's last day had no cell at all — no task dot, not tappable
+// (#9449).
+export const WEEKS_SHOWN = 6;
 export const DAYS_IN_VIEW = WEEKS_SHOWN * 7;
 export const MIN_HEIGHT = ROW_HEIGHT;
 export const MAX_HEIGHT = ROW_HEIGHT * WEEKS_SHOWN;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
@@ -8,7 +8,6 @@ export const DAYS_IN_VIEW = WEEKS_SHOWN * 7;
 export const MIN_HEIGHT = ROW_HEIGHT;
 export const MAX_HEIGHT = ROW_HEIGHT * WEEKS_SHOWN;
 
-const SNAP_MIDPOINT = (MIN_HEIGHT + MAX_HEIGHT) / 2;
 const SNAP_VELOCITY = 0.3;
 const SNAP_DURATION = 200;
 const SLIDE_DURATION = 150;
@@ -19,6 +18,9 @@ const DIRECTION_RATIO = 1.5;
 export interface CalendarGestureCallbacks {
   getActiveWeekIndex(): number;
   getIsExpanded(): boolean;
+  /** `MAX_HEIGHT`, or less where the viewport cannot fit every row. */
+  getExpandedHeight(): number;
+  getWeekOffset(expanded: boolean, activeIdx: number): number;
   onExpandChanged(expanded: boolean): void;
   onVerticalSwipe(isDown: boolean): void;
   onHorizontalSwipe(dir: 1 | -1): void;
@@ -65,9 +67,9 @@ export class CalendarGestureHandler {
     if (activeIdx !== undefined) this._dragActiveIdx = activeIdx;
 
     const snapDur = this._animDuration(SNAP_DURATION);
-    const targetHeight = expanded ? MAX_HEIGHT : MIN_HEIGHT;
+    const targetHeight = expanded ? this._cb.getExpandedHeight() : MIN_HEIGHT;
     const idx = this._dragActiveIdx;
-    const targetOffset = expanded ? 0 : -idx * ROW_HEIGHT;
+    const targetOffset = this._cb.getWeekOffset(expanded, idx);
 
     if (snapDur === 0) {
       weeksEl.style.transition = '';
@@ -223,16 +225,17 @@ export class CalendarGestureHandler {
         const deltaY = touch.clientY - this._touchStartY;
         const elapsed = Date.now() - this._touchStartTime;
         const velocity = deltaY / Math.max(elapsed, 1);
+        const expandedHeight = this._cb.getExpandedHeight();
         const currentHeight = Math.max(
           MIN_HEIGHT,
-          Math.min(MAX_HEIGHT, this._dragStartHeight + deltaY),
+          Math.min(expandedHeight, this._dragStartHeight + deltaY),
         );
 
         let snapExpanded: boolean;
         if (Math.abs(velocity) > SNAP_VELOCITY) {
           snapExpanded = velocity > 0;
         } else {
-          snapExpanded = currentHeight > SNAP_MIDPOINT;
+          snapExpanded = currentHeight > (MIN_HEIGHT + expandedHeight) / 2;
         }
         this.snapTo(snapExpanded);
       }
@@ -273,20 +276,27 @@ export class CalendarGestureHandler {
   private _startDrag(): void {
     this._isDragging = true;
     this._dragActiveIdx = this._cb.getActiveWeekIndex();
-    this._dragStartHeight = this._cb.getIsExpanded() ? MAX_HEIGHT : MIN_HEIGHT;
+    this._dragStartHeight = this._cb.getIsExpanded()
+      ? this._cb.getExpandedHeight()
+      : MIN_HEIGHT;
   }
 
   private _updateDrag(deltaY: number): void {
+    const expandedHeight = this._cb.getExpandedHeight();
     const newHeight = Math.max(
       MIN_HEIGHT,
-      Math.min(MAX_HEIGHT, this._dragStartHeight + deltaY),
+      Math.min(expandedHeight, this._dragStartHeight + deltaY),
     );
     const weeksEl = this._getWeeksEl();
     if (!weeksEl) return;
     weeksEl.style.maxHeight = newHeight + 'px';
 
-    const progress = (newHeight - MIN_HEIGHT) / (MAX_HEIGHT - MIN_HEIGHT);
-    const offset = -this._dragActiveIdx * ROW_HEIGHT * (1 - progress);
+    const progress = (newHeight - MIN_HEIGHT) / (expandedHeight - MIN_HEIGHT);
+    const collapsedOffset = this._cb.getWeekOffset(false, this._dragActiveIdx);
+    const expandedOffset = this._cb.getWeekOffset(true, this._dragActiveIdx);
+    const travel = expandedOffset - collapsedOffset;
+    const travelled = travel * progress;
+    const offset = collapsedOffset + travelled;
     const innerEl = weeksEl.firstElementChild as HTMLElement;
     if (innerEl) {
       innerEl.style.transform = `translateY(${offset}px)`;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
@@ -27,8 +27,12 @@ export interface CalendarGestureCallbacks {
    * geometry is refreshed once at the start of anything that acts on it.
    */
   measure(): void;
-  /** `ROW_HEIGHT`, or less where the viewport cannot fit six of them. */
-  getRowHeight(): number;
+  /**
+   * Height of the fully expanded grid, already clamped to the room available.
+   * The collapsed height is always `ROW_HEIGHT`: a collapsed strip is one row
+   * in a viewport that has room for one, so it never shrinks with the grid.
+   */
+  getExpandedHeight(): number;
   /** False where not even `MIN_ROW_HEIGHT` rows fit, leaving nothing to expand into. */
   canExpand(): boolean;
   onExpandChanged(expanded: boolean): void;
@@ -49,7 +53,7 @@ export class CalendarGestureHandler {
   private _dragStartHeight = 0;
   private _dragActiveIdx = 0;
   /** Sampled once per drag: reading it per touchmove interleaves layout reads with writes. */
-  private _dragRowHeight = ROW_HEIGHT;
+  private _dragExpandedHeight = ROW_HEIGHT * WEEKS_SHOWN;
   private _prefersReducedMotion =
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -83,13 +87,12 @@ export class CalendarGestureHandler {
     // calendar still looks collapsed while horizontal swipes take the expanded
     // branch and jump whole months.
     this._cb.measure();
-    const rowHeight = this._cb.getRowHeight();
     const expanded = requestExpanded && this._cb.canExpand();
 
     const snapDur = this._animDuration(SNAP_DURATION);
-    const targetHeight = expanded ? rowHeight * WEEKS_SHOWN : rowHeight;
+    const targetHeight = expanded ? this._cb.getExpandedHeight() : ROW_HEIGHT;
     const idx = this._dragActiveIdx;
-    const targetOffset = expanded ? 0 : -idx * rowHeight;
+    const targetOffset = expanded ? 0 : -idx * ROW_HEIGHT;
 
     if (snapDur === 0) {
       // Apply the target rather than clearing, for the same reason the animated
@@ -249,10 +252,9 @@ export class CalendarGestureHandler {
         const deltaY = touch.clientY - this._touchStartY;
         const elapsed = Date.now() - this._touchStartTime;
         const velocity = deltaY / Math.max(elapsed, 1);
-        const rowHeight = this._dragRowHeight;
-        const expandedHeight = rowHeight * WEEKS_SHOWN;
+        const expandedHeight = this._dragExpandedHeight;
         const currentHeight = Math.max(
-          rowHeight,
+          ROW_HEIGHT,
           Math.min(expandedHeight, this._dragStartHeight + deltaY),
         );
 
@@ -260,7 +262,7 @@ export class CalendarGestureHandler {
         if (Math.abs(velocity) > SNAP_VELOCITY) {
           snapExpanded = velocity > 0;
         } else {
-          snapExpanded = currentHeight > (rowHeight + expandedHeight) / 2;
+          snapExpanded = currentHeight > (ROW_HEIGHT + expandedHeight) / 2;
         }
         this.snapTo(snapExpanded);
       }
@@ -302,28 +304,30 @@ export class CalendarGestureHandler {
     this._isDragging = true;
     this._dragActiveIdx = this._cb.getActiveWeekIndex();
     this._cb.measure();
-    this._dragRowHeight = this._cb.getRowHeight();
+    // Clamped by the component, so a drag cannot open past the room available
+    // even while `isExpanded` is stale against a shrunken box.
+    this._dragExpandedHeight = this._cb.getExpandedHeight();
     this._dragStartHeight = this._cb.getIsExpanded()
-      ? this._dragRowHeight * WEEKS_SHOWN
-      : this._dragRowHeight;
+      ? this._dragExpandedHeight
+      : ROW_HEIGHT;
   }
 
   private _updateDrag(deltaY: number): void {
-    const rowHeight = this._dragRowHeight;
-    const expandedHeight = rowHeight * WEEKS_SHOWN;
+    const expandedHeight = this._dragExpandedHeight;
     const newHeight = Math.max(
-      rowHeight,
+      ROW_HEIGHT,
       Math.min(expandedHeight, this._dragStartHeight + deltaY),
     );
     const weeksEl = this._getWeeksEl();
     if (!weeksEl) return;
     weeksEl.style.maxHeight = newHeight + 'px';
 
-    // The range is (WEEKS_SHOWN - 1) rows, so it is only zero if a row itself
-    // is, which MIN_ROW_HEIGHT rules out. A zero range would make this NaN and
-    // translateY(NaNpx) is dropped silently by CSSOM.
-    const progress = (newHeight - rowHeight) / (expandedHeight - rowHeight);
-    const offset = -this._dragActiveIdx * rowHeight * (1 - progress);
+    // Guarded: where the room is too tight to expand, the clamped expanded
+    // height collapses onto ROW_HEIGHT and the range is 0, which would make
+    // this NaN. translateY(NaNpx) is dropped silently by CSSOM.
+    const range = expandedHeight - ROW_HEIGHT;
+    const progress = range > 0 ? (newHeight - ROW_HEIGHT) / range : 0;
+    const offset = -this._dragActiveIdx * ROW_HEIGHT * (1 - progress);
     const innerEl = weeksEl.firstElementChild as HTMLElement;
     if (innerEl) {
       innerEl.style.transform = `translateY(${offset}px)`;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
@@ -33,6 +33,8 @@ export interface CalendarGestureCallbacks {
    * in a viewport that has room for one, so it never shrinks with the grid.
    */
   getExpandedHeight(): number;
+  /** Row height the grid renders at once expanded; collapsed is always `ROW_HEIGHT`. */
+  getRowHeight(): number;
   /** False where not even `MIN_ROW_HEIGHT` rows fit, leaving nothing to expand into. */
   canExpand(): boolean;
   onExpandChanged(expanded: boolean): void;
@@ -93,6 +95,16 @@ export class CalendarGestureHandler {
     const targetHeight = expanded ? this._cb.getExpandedHeight() : ROW_HEIGHT;
     const idx = this._dragActiveIdx;
     const targetOffset = expanded ? 0 : -idx * ROW_HEIGHT;
+
+    // Rows take their post-snap height now, not when the flag flips at the end
+    // of the animation. `targetOffset` counts in whole rows, so animating to it
+    // while the rows on screen are still the other height points the window at
+    // the wrong week for the duration: collapsing from index 2 at 29px rows
+    // travelled to -80px and landed on week 3 before jumping back.
+    weeksEl.style.setProperty(
+      '--row-height',
+      `${expanded ? this._cb.getRowHeight() : ROW_HEIGHT}px`,
+    );
 
     if (snapDur === 0) {
       // Apply the target rather than clearing, for the same reason the animated

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
@@ -1,3 +1,4 @@
+/** Height of one week row where there is room for six of them. */
 export const ROW_HEIGHT = 40;
 // 6, not 5: the expanded grid anchors to the week containing the 1st, and a
 // month starting late in the week spans 6 rows (Aug 2026 starts on a Saturday).
@@ -5,8 +6,10 @@ export const ROW_HEIGHT = 40;
 // (#9449).
 export const WEEKS_SHOWN = 6;
 export const DAYS_IN_VIEW = WEEKS_SHOWN * 7;
-export const MIN_HEIGHT = ROW_HEIGHT;
-export const MAX_HEIGHT = ROW_HEIGHT * WEEKS_SHOWN;
+// Rows shrink rather than being dropped where six of them do not fit, so the
+// grid always spans the whole month. Below this a date is neither legible nor
+// reliably tappable, and the calendar stays collapsed instead (`canExpand`).
+export const MIN_ROW_HEIGHT = 24;
 
 const SNAP_VELOCITY = 0.3;
 const SNAP_DURATION = 200;
@@ -18,9 +21,16 @@ const DIRECTION_RATIO = 1.5;
 export interface CalendarGestureCallbacks {
   getActiveWeekIndex(): number;
   getIsExpanded(): boolean;
-  /** `MAX_HEIGHT`, or less where the viewport cannot fit every row. */
-  getExpandedHeight(): number;
-  getWeekOffset(expanded: boolean, activeIdx: number): number;
+  /**
+   * Re-read the layout. The component observes the box it measures against, but
+   * cannot see the rows' own top move (the month label wrapping, say), so the
+   * geometry is refreshed once at the start of anything that acts on it.
+   */
+  measure(): void;
+  /** `ROW_HEIGHT`, or less where the viewport cannot fit six of them. */
+  getRowHeight(): number;
+  /** False where not even `MIN_ROW_HEIGHT` rows fit, leaving nothing to expand into. */
+  canExpand(): boolean;
   onExpandChanged(expanded: boolean): void;
   onVerticalSwipe(isDown: boolean): void;
   onHorizontalSwipe(dir: 1 | -1): void;
@@ -38,8 +48,8 @@ export class CalendarGestureHandler {
   private _touchActive = false;
   private _dragStartHeight = 0;
   private _dragActiveIdx = 0;
-  /** Sampled once per drag: measuring per touchmove interleaves layout reads with writes. */
-  private _dragExpandedHeight = 0;
+  /** Sampled once per drag: reading it per touchmove interleaves layout reads with writes. */
+  private _dragRowHeight = ROW_HEIGHT;
   private _prefersReducedMotion =
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -68,17 +78,18 @@ export class CalendarGestureHandler {
     const innerEl = weeksEl.firstElementChild as HTMLElement;
     if (activeIdx !== undefined) this._dragActiveIdx = activeIdx;
 
-    // A viewport with room for only one row leaves nothing to expand into.
+    // A viewport too short for six legible rows leaves nothing to expand into.
     // Reporting expanded there would desync the flag from the geometry: the
     // calendar still looks collapsed while horizontal swipes take the expanded
     // branch and jump whole months.
-    const expandedHeight = this._cb.getExpandedHeight();
-    const expanded = requestExpanded && expandedHeight > MIN_HEIGHT;
+    this._cb.measure();
+    const rowHeight = this._cb.getRowHeight();
+    const expanded = requestExpanded && this._cb.canExpand();
 
     const snapDur = this._animDuration(SNAP_DURATION);
-    const targetHeight = expanded ? expandedHeight : MIN_HEIGHT;
+    const targetHeight = expanded ? rowHeight * WEEKS_SHOWN : rowHeight;
     const idx = this._dragActiveIdx;
-    const targetOffset = this._cb.getWeekOffset(expanded, idx);
+    const targetOffset = expanded ? 0 : -idx * rowHeight;
 
     if (snapDur === 0) {
       // Apply the target rather than clearing, for the same reason the animated
@@ -238,9 +249,10 @@ export class CalendarGestureHandler {
         const deltaY = touch.clientY - this._touchStartY;
         const elapsed = Date.now() - this._touchStartTime;
         const velocity = deltaY / Math.max(elapsed, 1);
-        const expandedHeight = this._dragExpandedHeight;
+        const rowHeight = this._dragRowHeight;
+        const expandedHeight = rowHeight * WEEKS_SHOWN;
         const currentHeight = Math.max(
-          MIN_HEIGHT,
+          rowHeight,
           Math.min(expandedHeight, this._dragStartHeight + deltaY),
         );
 
@@ -248,7 +260,7 @@ export class CalendarGestureHandler {
         if (Math.abs(velocity) > SNAP_VELOCITY) {
           snapExpanded = velocity > 0;
         } else {
-          snapExpanded = currentHeight > (MIN_HEIGHT + expandedHeight) / 2;
+          snapExpanded = currentHeight > (rowHeight + expandedHeight) / 2;
         }
         this.snapTo(snapExpanded);
       }
@@ -289,31 +301,29 @@ export class CalendarGestureHandler {
   private _startDrag(): void {
     this._isDragging = true;
     this._dragActiveIdx = this._cb.getActiveWeekIndex();
-    this._dragExpandedHeight = this._cb.getExpandedHeight();
+    this._cb.measure();
+    this._dragRowHeight = this._cb.getRowHeight();
     this._dragStartHeight = this._cb.getIsExpanded()
-      ? this._dragExpandedHeight
-      : MIN_HEIGHT;
+      ? this._dragRowHeight * WEEKS_SHOWN
+      : this._dragRowHeight;
   }
 
   private _updateDrag(deltaY: number): void {
-    const expandedHeight = this._dragExpandedHeight;
+    const rowHeight = this._dragRowHeight;
+    const expandedHeight = rowHeight * WEEKS_SHOWN;
     const newHeight = Math.max(
-      MIN_HEIGHT,
+      rowHeight,
       Math.min(expandedHeight, this._dragStartHeight + deltaY),
     );
     const weeksEl = this._getWeeksEl();
     if (!weeksEl) return;
     weeksEl.style.maxHeight = newHeight + 'px';
 
-    // Guarded: with room for a single row the range is 0 and the ratio would be
-    // NaN, which renders as translateY(NaNpx).
-    const range = expandedHeight - MIN_HEIGHT;
-    const progress = range > 0 ? (newHeight - MIN_HEIGHT) / range : 0;
-    const collapsedOffset = this._cb.getWeekOffset(false, this._dragActiveIdx);
-    const expandedOffset = this._cb.getWeekOffset(true, this._dragActiveIdx);
-    const travel = expandedOffset - collapsedOffset;
-    const travelled = travel * progress;
-    const offset = collapsedOffset + travelled;
+    // The range is (WEEKS_SHOWN - 1) rows, so it is only zero if a row itself
+    // is, which MIN_ROW_HEIGHT rules out. A zero range would make this NaN and
+    // translateY(NaNpx) is dropped silently by CSSOM.
+    const progress = (newHeight - rowHeight) / (expandedHeight - rowHeight);
+    const offset = -this._dragActiveIdx * rowHeight * (1 - progress);
     const innerEl = weeksEl.firstElementChild as HTMLElement;
     if (innerEl) {
       innerEl.style.transform = `translateY(${offset}px)`;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-gesture-handler.ts
@@ -141,6 +141,14 @@ export class CalendarGestureHandler {
         // leaving the element without maxHeight (visually stuck open).
         weeksEl.style.transition = '';
         weeksEl.style.maxHeight = targetHeight + 'px';
+        // Re-read rather than reuse the value written before the animation: if
+        // the box grew during it, `rowHeight()` can reach `ROW_HEIGHT` while
+        // still collapsed, so the binding's value never changes across the flip
+        // and Angular writes nothing, stranding the pre-growth inline height.
+        weeksEl.style.setProperty(
+          '--row-height',
+          `${expanded ? this._cb.getRowHeight() : ROW_HEIGHT}px`,
+        );
         if (innerEl) {
           innerEl.style.transition = '';
           innerEl.style.transform = `translateY(${targetOffset}px)`;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.html
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.html
@@ -18,7 +18,7 @@
   class="weeks"
   role="grid"
   #weeksContainer
-  [style.--row-height]="rowHeight() + 'px'"
+  [style.--row-height]="displayRowHeight() + 'px'"
   [style.max-height.px]="maxHeight()"
 >
   <div

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.html
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.html
@@ -18,6 +18,7 @@
   class="weeks"
   role="grid"
   #weeksContainer
+  [style.--row-height]="rowHeight() + 'px'"
   [style.max-height.px]="maxHeight()"
 >
   <div

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.scss
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.scss
@@ -28,6 +28,13 @@
 
 .weeks {
   overflow: hidden;
+  // Set from the component, so ROW_HEIGHT is not restated here. Six rows always
+  // render; where they do not fit at full size they shrink (#9449 review).
+  --row-height: 40px;
+}
+
+.week {
+  height: var(--row-height);
 }
 
 .week button {
@@ -37,9 +44,9 @@
   background: none;
   color: inherit;
   font-size: 14px;
-  width: 36px;
-  height: 36px;
-  margin: var(--s-quarter) auto;
+  width: min(36px, calc(var(--row-height) - 2 * var(--s-quarter)));
+  height: min(36px, calc(var(--row-height) - 2 * var(--s-quarter)));
+  margin: auto;
   border-radius: 50%;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
@@ -1,14 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
-import { PlannerCalendarNavComponent } from './planner-calendar-nav.component';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import {
+  DAYS_IN_VIEW,
   MIN_HEIGHT,
   MAX_HEIGHT,
   ROW_HEIGHT,
   WEEKS_SHOWN,
 } from './planner-calendar-gesture-handler';
+import { PlannerCalendarNavComponent } from './planner-calendar-nav.component';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
 import { getWeekRange } from '../../../util/get-week-range';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
@@ -18,6 +19,11 @@ import { DateTimeFormatService } from '../../../core/date-time-format/date-time-
 // "Juli 2026" in an English app. Asserting against a fixed locale here would
 // pass either way if it matched the runner's browser, so it must not.
 const MOCK_TEXT_LOCALE = 'fr-FR';
+
+/** Room below the first week row: exactly enough for all six. */
+const ROOM_FOR_ALL_ROWS = MAX_HEIGHT;
+/** Room for four rows, the XS case from the #9463 review. */
+const ROOM_FOR_FOUR_ROWS = 4 * ROW_HEIGHT;
 
 describe('PlannerCalendarNavComponent', () => {
   let fixture: ComponentFixture<PlannerCalendarNavComponent>;
@@ -248,21 +254,81 @@ describe('PlannerCalendarNavComponent', () => {
   });
 
   describe('maxHeight computed', () => {
+    // Stated explicitly rather than inherited from the Karma iframe: the
+    // expanded height is clamped by the room actually below the rows, so
+    // leaving it implicit would make these assertions depend on the runner.
+    const setRoom = (px: number): void => component['_availableForRows'].set(px);
+
     it('should return MIN_HEIGHT when collapsed', () => {
+      setRoom(ROOM_FOR_ALL_ROWS);
       component.isExpanded.set(false);
       expect(component.maxHeight()).toBe(MIN_HEIGHT);
     });
 
     it('should return MAX_HEIGHT when expanded', () => {
+      setRoom(ROOM_FOR_ALL_ROWS);
       component.isExpanded.set(true);
       expect(component.maxHeight()).toBe(MAX_HEIGHT);
+    });
+
+    // Review of #9463: six 40px rows overflowed the Planner at XS heights.
+    // planner-plan-view collapsed to 0px and the bottom nav covered all but
+    // 6px of the collapse handle.
+    it('should not expand past the room available below the rows', () => {
+      setRoom(ROOM_FOR_FOUR_ROWS);
+      component.isExpanded.set(true);
+
+      const expanded = component.maxHeight();
+      expect(expanded).toBe(4 * ROW_HEIGHT);
+      expect(expanded).toBeLessThan(MAX_HEIGHT);
+      expect(expanded).toBeLessThanOrEqual(ROOM_FOR_FOUR_ROWS);
+    });
+
+    it('should always keep at least one row when there is no room at all', () => {
+      setRoom(0);
+      component.isExpanded.set(true);
+
+      expect(component.maxHeight()).toBe(ROW_HEIGHT);
+    });
+
+    it('should still build all six weeks of days when the height is clamped', () => {
+      setRoom(ROOM_FOR_FOUR_ROWS);
+      component.isExpanded.set(true);
+
+      expect(component.weeks().length).toBe(WEEKS_SHOWN);
+      expect(component.weeks().flat().length).toBe(DAYS_IN_VIEW);
     });
   });
 
   describe('weekOffset computed', () => {
+    const setRoom = (px: number): void => component['_availableForRows'].set(px);
+
     it('should return 0 when expanded', () => {
+      setRoom(ROOM_FOR_ALL_ROWS);
       component.isExpanded.set(true);
       expect(component.weekOffset()).toBe(0);
+    });
+
+    // Dropping rows must not make a day unreachable — that is the bug #9449
+    // fixed, at a different viewport.
+    it('should keep the active week visible when the height is clamped', () => {
+      const weeks = component.weeks();
+      fixture.componentRef.setInput('visibleDayDate', weeks[WEEKS_SHOWN - 1][0].dateStr);
+      component.isExpanded.set(true);
+      fixture.detectChanges();
+      // After the last change detection: the component re-measures the real
+      // available room on every expand, which would overwrite this.
+      setRoom(ROOM_FOR_FOUR_ROWS);
+
+      const rows = component.maxHeight() / ROW_HEIGHT;
+      const firstVisibleRow = -component.weekOffset() / ROW_HEIGHT;
+
+      expect(component.activeWeekIndex()).toBe(WEEKS_SHOWN - 1);
+      expect(firstVisibleRow).toBeGreaterThan(0);
+      expect(component.activeWeekIndex()).toBeGreaterThanOrEqual(firstVisibleRow);
+      expect(component.activeWeekIndex()).toBeLessThan(firstVisibleRow + rows);
+      // Never scrolled past the last row.
+      expect(firstVisibleRow + rows).toBeLessThanOrEqual(WEEKS_SHOWN);
     });
 
     it('should return negative offset based on activeWeekIndex when collapsed', () => {

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
@@ -9,7 +9,10 @@ import {
   ROW_HEIGHT,
   WEEKS_SHOWN,
 } from './planner-calendar-gesture-handler';
-import { PlannerCalendarNavComponent } from './planner-calendar-nav.component';
+import {
+  HANDLE_HEIGHT,
+  PlannerCalendarNavComponent,
+} from './planner-calendar-nav.component';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
 import { getWeekRange } from '../../../util/get-week-range';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
@@ -253,6 +256,67 @@ describe('PlannerCalendarNavComponent', () => {
     });
   });
 
+  // The measurement itself, which nothing else exercises: both setRoom() helpers
+  // below write _availableForRows directly. Stubbing the two rects pins the
+  // arithmetic, HANDLE_HEIGHT against `.handle`'s own CSS, and the assumption
+  // that the nav's parentElement is the box the plan list shares.
+  describe('_measureAvailableForRows', () => {
+    const stubGeometry = (weeksTop: number, parentBottom: number): void => {
+      const weeksEl = component['_weeksEl']()!.nativeElement;
+      const parentEl = fixture.nativeElement.parentElement as HTMLElement;
+      spyOn(weeksEl, 'getBoundingClientRect').and.returnValue({
+        top: weeksTop,
+      } as DOMRect);
+      spyOn(parentEl, 'getBoundingClientRect').and.returnValue({
+        bottom: parentBottom,
+      } as DOMRect);
+    };
+
+    // Literals, not the constants: expressing the expectation in terms of
+    // HANDLE_HEIGHT/MIN_PLAN_VIEW_HEIGHT would just restate the implementation
+    // and hold for any value of them.
+    it('should reserve the handle and a row of plan list below the grid', () => {
+      stubGeometry(110, 356);
+      component['_measureAvailableForRows']();
+
+      expect(component['_availableForRows']()).toBe(178);
+    });
+
+    // HANDLE_HEIGHT restates `.handle`'s own CSS (padding 12px 0 + a 4px
+    // ::after). Nothing else notices if one side changes.
+    it('should keep HANDLE_HEIGHT in step with the rendered handle', () => {
+      const handle = fixture.nativeElement.querySelector('.handle') as HTMLElement;
+
+      expect(handle.getBoundingClientRect().height).toBe(HANDLE_HEIGHT);
+    });
+
+    // The XS case from the #9463 review: 400px viewport, route content ending
+    // at 356 because the bottom nav owns the rest.
+    it('should allow four rows at the reported XS geometry', () => {
+      stubGeometry(110, 356);
+      component['_measureAvailableForRows']();
+      component.isExpanded.set(true);
+
+      expect(component.maxHeight()).toBe(4 * ROW_HEIGHT);
+    });
+
+    it('should allow all six rows when the route content is tall', () => {
+      stubGeometry(110, 800);
+      component['_measureAvailableForRows']();
+      component.isExpanded.set(true);
+
+      expect(component.maxHeight()).toBe(MAX_HEIGHT);
+    });
+
+    it('should not expand when the route content leaves room for one row', () => {
+      stubGeometry(110, 220);
+      component['_measureAvailableForRows']();
+      component.isExpanded.set(true);
+
+      expect(component.maxHeight()).toBe(MIN_HEIGHT);
+    });
+  });
+
   describe('maxHeight computed', () => {
     // Stated explicitly rather than inherited from the Karma iframe: the
     // expanded height is clamped by the room actually below the rows, so
@@ -316,8 +380,8 @@ describe('PlannerCalendarNavComponent', () => {
       fixture.componentRef.setInput('visibleDayDate', weeks[WEEKS_SHOWN - 1][0].dateStr);
       component.isExpanded.set(true);
       fixture.detectChanges();
-      // After the last change detection: the component re-measures the real
-      // available room on every expand, which would overwrite this.
+      // Last, so the ResizeObserver's initial callback cannot land on top of it
+      // with the runner's real geometry.
       setRoom(ROOM_FOR_FOUR_ROWS);
 
       const rows = component.maxHeight() / ROW_HEIGHT;

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
@@ -69,13 +69,28 @@ describe('PlannerCalendarNavComponent', () => {
   });
 
   describe('weeks computed', () => {
-    it('should generate a 5-week calendar grid with 7 days per week', () => {
+    it('should generate a calendar grid of WEEKS_SHOWN weeks with 7 days per week', () => {
       const weeks = component.weeks();
 
       expect(weeks.length).toBe(WEEKS_SHOWN);
       for (const week of weeks) {
         expect(week.length).toBe(7);
       }
+    });
+
+    it('should still reach the last day of a month that spans six rows (#9449)', () => {
+      // August 2026 starts on a Saturday, so with Monday as the first day of
+      // week the grid is anchored at Mon 27 Jul and Mon 31 Aug lands in the
+      // sixth row. At five rows it had no cell at all: no task dot, no way to
+      // tap it.
+      mockTodayDateStr.set('2026-08-01');
+      fixture.componentRef.setInput('visibleDayDate', '2026-08-01');
+      fixture.detectChanges();
+
+      const allDays = component.weeks().flat();
+
+      expect(allDays[0].dateStr).toBe('2026-07-27');
+      expect(allDays.map((d) => d.dateStr)).toContain('2026-08-31');
     });
 
     it('should start the grid from the week containing today', () => {

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
@@ -415,6 +415,22 @@ describe('PlannerCalendarNavComponent', () => {
       expect(component.displayRowHeight()).toBeLessThan(ROW_HEIGHT);
     });
 
+    // `_availableForRows` has no floor: it is `clientHeight - top - HANDLE -
+    // MIN_PLAN_VIEW`, so an Electron minimum window (300x240, `minHeight: 240`
+    // in electron/main-window.ts) drives it under one row and it can go
+    // negative. A negative `max-height` is rejected by CSSOM outright, leaving
+    // the element on its last valid value rather than failing visibly.
+    it('should keep a collapsed row at full height when the room runs out', () => {
+      component.isExpanded.set(false);
+
+      setRoom(18);
+      expect(component.maxHeight()).toBe(ROW_HEIGHT);
+
+      setRoom(-32);
+      expect(component.maxHeight()).toBe(ROW_HEIGHT);
+      expect(component.maxHeight()).toBeGreaterThan(0);
+    });
+
     // `canExpand()` gates entering the expanded state and nothing leaves it, so
     // a height-only shrink (a banner above `.route-wrapper`, which fires no
     // resize event) leaves `isExpanded` true with the room gone. Without the

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
@@ -400,6 +400,40 @@ describe('PlannerCalendarNavComponent', () => {
       expect(component.maxHeight()).toBe(ROW_HEIGHT);
     });
 
+    // The collapsed strip is one row in a viewport with room for one, so it
+    // must not shrink with the expanded grid: `.week button` is
+    // `min(36px, var(--row-height) - 4px)`, so a 29px collapsed row hands every
+    // user 25px tap targets whether or not they ever expand (#9463 review).
+    it('should keep collapsed rows full size on a viewport that shrinks the grid', () => {
+      setRoom(ROOM_FOR_FOUR_ROWS);
+      component.isExpanded.set(false);
+
+      expect(component.displayRowHeight()).toBe(ROW_HEIGHT);
+      expect(component.maxHeight()).toBe(ROW_HEIGHT);
+      // The expanded grid still shrinks; only the collapsed strip is pinned.
+      component.isExpanded.set(true);
+      expect(component.displayRowHeight()).toBeLessThan(ROW_HEIGHT);
+    });
+
+    // `canExpand()` gates entering the expanded state and nothing leaves it, so
+    // a height-only shrink (a banner above `.route-wrapper`, which fires no
+    // resize event) leaves `isExpanded` true with the room gone. Without the
+    // clamp, `rowHeight()`'s MIN_ROW_HEIGHT floor put a fixed 144px grid into
+    // whatever was left and overflowed the plan-list reserve.
+    it('should not exceed the room available while stale-expanded', () => {
+      setRoom(ROOM_FOR_ALL_ROWS);
+      component.isExpanded.set(true);
+      expect(component.maxHeight()).toBe(EXPANDED_ALL_ROWS);
+
+      // The box shrinks under it; nothing collapses the flag.
+      setRoom(100);
+
+      expect(component.canExpand()).toBe(false);
+      expect(component.isExpanded()).toBe(true);
+      expect(component.maxHeight()).toBe(100);
+      expect(component.maxHeight()).toBeLessThan(MIN_ROW_HEIGHT * WEEKS_SHOWN);
+    });
+
     it('should return six full-size rows when expanded', () => {
       setRoom(ROOM_FOR_ALL_ROWS);
       component.isExpanded.set(true);
@@ -484,8 +518,9 @@ describe('PlannerCalendarNavComponent', () => {
       expect(component.weekOffset()).toBe(-2 * ROW_HEIGHT);
     });
 
-    // One row of a shrunken grid is one shrunken row high.
-    it('should scale the collapsed offset with the row height', () => {
+    // Collapsed rows are full size whatever the room, so the offset that slides
+    // the active week into the strip is too.
+    it('should keep the collapsed offset at full rows on a shrunken viewport', () => {
       const weeks = component.weeks();
       fixture.componentRef.setInput('visibleDayDate', weeks[2][0].dateStr);
       component.isExpanded.set(false);
@@ -493,7 +528,7 @@ describe('PlannerCalendarNavComponent', () => {
       setRoom(ROOM_FOR_FOUR_ROWS);
 
       expect(component.rowHeight()).toBeLessThan(ROW_HEIGHT);
-      expect(component.weekOffset()).toBe(-2 * component.rowHeight());
+      expect(component.weekOffset()).toBe(-2 * ROW_HEIGHT);
     });
 
     it('should return 0 when collapsed and activeWeekIndex is 0', () => {

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.spec.ts
@@ -4,8 +4,7 @@ import { GlobalConfigService } from '../../config/global-config.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import {
   DAYS_IN_VIEW,
-  MIN_HEIGHT,
-  MAX_HEIGHT,
+  MIN_ROW_HEIGHT,
   ROW_HEIGHT,
   WEEKS_SHOWN,
 } from './planner-calendar-gesture-handler';
@@ -23,10 +22,11 @@ import { DateTimeFormatService } from '../../../core/date-time-format/date-time-
 // pass either way if it matched the runner's browser, so it must not.
 const MOCK_TEXT_LOCALE = 'fr-FR';
 
-/** Room below the first week row: exactly enough for all six. */
-const ROOM_FOR_ALL_ROWS = MAX_HEIGHT;
-/** Room for four rows, the XS case from the #9463 review. */
+/** Room below the first week row: exactly enough for six full-size rows. */
+const ROOM_FOR_ALL_ROWS = ROW_HEIGHT * WEEKS_SHOWN;
+/** The XS case from the #9463 review, where six full-size rows do not fit. */
 const ROOM_FOR_FOUR_ROWS = 4 * ROW_HEIGHT;
+const EXPANDED_ALL_ROWS = ROW_HEIGHT * WEEKS_SHOWN;
 
 describe('PlannerCalendarNavComponent', () => {
   let fixture: ComponentFixture<PlannerCalendarNavComponent>;
@@ -40,6 +40,7 @@ describe('PlannerCalendarNavComponent', () => {
 
   let mockGlobalConfigService: jasmine.SpyObj<GlobalConfigService>;
   let mockGlobalTrackingIntervalService: jasmine.SpyObj<GlobalTrackingIntervalService>;
+  let plannerEl: HTMLElement;
 
   beforeEach(() => {
     mockTodayDateStr.set('2026-02-16');
@@ -74,6 +75,14 @@ describe('PlannerCalendarNavComponent', () => {
 
     fixture = TestBed.createComponent(PlannerCalendarNavComponent);
     component = fixture.componentInstance;
+    // The nav measures against the planner host, so the fixture has to have one:
+    // in the app it is `planner.component.html`'s own element.
+    plannerEl = document.createElement('planner');
+    // planner.component.scss gives the host `display: flex`; an unknown element
+    // is inline by default, where height and clientHeight do not apply.
+    plannerEl.style.display = 'block';
+    fixture.nativeElement.parentElement.insertBefore(plannerEl, fixture.nativeElement);
+    plannerEl.appendChild(fixture.nativeElement);
     fixture.detectChanges();
   });
 
@@ -259,17 +268,23 @@ describe('PlannerCalendarNavComponent', () => {
   // The measurement itself, which nothing else exercises: both setRoom() helpers
   // below write _availableForRows directly. Stubbing the two rects pins the
   // arithmetic, HANDLE_HEIGHT against `.handle`'s own CSS, and the assumption
-  // that the nav's parentElement is the box the plan list shares.
+  // that the planner host is the box the plan list shares.
   describe('_measureAvailableForRows', () => {
-    const stubGeometry = (weeksTop: number, parentBottom: number): void => {
+    // offsetTop/offsetParent/clientHeight, because that is what the measurement
+    // reads: layout coordinates, so an ancestor transform cannot scale them.
+    const define = (el: HTMLElement, props: Record<string, unknown>): void => {
+      for (const [k, value] of Object.entries(props)) {
+        Object.defineProperty(el, k, { value, configurable: true });
+      }
+    };
+    const stubGeometry = (weeksTop: number, containerHeight: number): void => {
       const weeksEl = component['_weeksEl']()!.nativeElement;
-      const parentEl = fixture.nativeElement.parentElement as HTMLElement;
-      spyOn(weeksEl, 'getBoundingClientRect').and.returnValue({
-        top: weeksTop,
-      } as DOMRect);
-      spyOn(parentEl, 'getBoundingClientRect').and.returnValue({
-        bottom: parentBottom,
-      } as DOMRect);
+      define(weeksEl, { offsetTop: weeksTop, offsetParent: plannerEl });
+      define(plannerEl, {
+        offsetTop: 0,
+        offsetParent: null,
+        clientHeight: containerHeight,
+      });
     };
 
     // Literals, not the constants: expressing the expectation in terms of
@@ -282,6 +297,53 @@ describe('PlannerCalendarNavComponent', () => {
       expect(component['_availableForRows']()).toBe(178);
     });
 
+    // Resolved by selector rather than parentElement, so wrapping the nav in
+    // planner.component.html cannot silently change what is measured.
+    it('should measure against the planner host through a wrapper', () => {
+      const wrapper = document.createElement('div');
+      plannerEl.insertBefore(wrapper, fixture.nativeElement);
+      wrapper.appendChild(fixture.nativeElement);
+      stubGeometry(110, 356);
+
+      component['_measureAvailableForRows']();
+
+      expect(component['_availableForRows']()).toBe(178);
+    });
+
+    // The route enter animation (warpRoute) starts the view at scale(1.2) and
+    // the first measurement lands while it is in flight. Read through
+    // getBoundingClientRect that reported 227px of room where there were 178 —
+    // a whole extra row, and the handle ended up below the route content.
+    it('should measure the same while an ancestor is being scaled', () => {
+      plannerEl.style.height = '300px';
+      plannerEl.style.overflow = 'hidden';
+
+      component['_measureAvailableForRows']();
+      const unscaled = component['_availableForRows']();
+
+      plannerEl.style.transform = 'scale(1.2)';
+      // The scale really is in effect, so this cannot pass by not applying it.
+      expect(plannerEl.getBoundingClientRect().height).toBeCloseTo(360, 0);
+
+      component['_measureAvailableForRows']();
+
+      expect(component['_availableForRows']()).toBe(unscaled);
+    });
+
+    // Guards the test above: it compares two readings, so a measurement wired to
+    // nothing at all would satisfy it.
+    it('should follow the height of the planner host', () => {
+      plannerEl.style.overflow = 'hidden';
+      plannerEl.style.height = '300px';
+      component['_measureAvailableForRows']();
+      const shorter = component['_availableForRows']();
+
+      plannerEl.style.height = '500px';
+      component['_measureAvailableForRows']();
+
+      expect(component['_availableForRows']() - shorter).toBe(200);
+    });
+
     // HANDLE_HEIGHT restates `.handle`'s own CSS (padding 12px 0 + a 4px
     // ::after). Nothing else notices if one side changes.
     it('should keep HANDLE_HEIGHT in step with the rendered handle', () => {
@@ -291,48 +353,57 @@ describe('PlannerCalendarNavComponent', () => {
     });
 
     // The XS case from the #9463 review: 400px viewport, route content ending
-    // at 356 because the bottom nav owns the rest.
-    it('should allow four rows at the reported XS geometry', () => {
+    // at 356 because the bottom nav owns the rest. 178px of room over six rows
+    // is 29px each, where dropping rows gave four full-size ones and hid the
+    // rest of the month.
+    it('should shrink the rows to fit at the reported XS geometry', () => {
       stubGeometry(110, 356);
       component['_measureAvailableForRows']();
       component.isExpanded.set(true);
 
-      expect(component.maxHeight()).toBe(4 * ROW_HEIGHT);
+      expect(component.rowHeight()).toBe(29);
+      expect(component.maxHeight()).toBe(29 * WEEKS_SHOWN);
+      expect(component.maxHeight()).toBeLessThanOrEqual(178);
     });
 
-    it('should allow all six rows when the route content is tall', () => {
+    it('should use full-size rows when the route content is tall', () => {
       stubGeometry(110, 800);
       component['_measureAvailableForRows']();
       component.isExpanded.set(true);
 
-      expect(component.maxHeight()).toBe(MAX_HEIGHT);
+      expect(component.rowHeight()).toBe(ROW_HEIGHT);
+      expect(component.maxHeight()).toBe(EXPANDED_ALL_ROWS);
     });
 
-    it('should not expand when the route content leaves room for one row', () => {
+    it('should refuse to expand when six legible rows do not fit', () => {
       stubGeometry(110, 220);
       component['_measureAvailableForRows']();
-      component.isExpanded.set(true);
 
-      expect(component.maxHeight()).toBe(MIN_HEIGHT);
+      expect(component.canExpand()).toBe(false);
     });
   });
 
   describe('maxHeight computed', () => {
-    // Stated explicitly rather than inherited from the Karma iframe: the
-    // expanded height is clamped by the room actually below the rows, so
-    // leaving it implicit would make these assertions depend on the runner.
-    const setRoom = (px: number): void => component['_availableForRows'].set(px);
+    // Stated explicitly rather than inherited from the Karma iframe: the row
+    // height is clamped by the room actually below the rows, so leaving it
+    // implicit would make these assertions depend on the runner. The observer
+    // goes first, so nothing can re-measure over the value afterwards and the
+    // test does not depend on when it would have fired.
+    const setRoom = (px: number): void => {
+      component['_resizeObserver']?.disconnect();
+      component['_availableForRows'].set(px);
+    };
 
-    it('should return MIN_HEIGHT when collapsed', () => {
+    it('should return one row when collapsed', () => {
       setRoom(ROOM_FOR_ALL_ROWS);
       component.isExpanded.set(false);
-      expect(component.maxHeight()).toBe(MIN_HEIGHT);
+      expect(component.maxHeight()).toBe(ROW_HEIGHT);
     });
 
-    it('should return MAX_HEIGHT when expanded', () => {
+    it('should return six full-size rows when expanded', () => {
       setRoom(ROOM_FOR_ALL_ROWS);
       component.isExpanded.set(true);
-      expect(component.maxHeight()).toBe(MAX_HEIGHT);
+      expect(component.maxHeight()).toBe(EXPANDED_ALL_ROWS);
     });
 
     // Review of #9463: six 40px rows overflowed the Planner at XS heights.
@@ -343,16 +414,25 @@ describe('PlannerCalendarNavComponent', () => {
       component.isExpanded.set(true);
 
       const expanded = component.maxHeight();
-      expect(expanded).toBe(4 * ROW_HEIGHT);
-      expect(expanded).toBeLessThan(MAX_HEIGHT);
+      expect(expanded).toBeLessThan(EXPANDED_ALL_ROWS);
       expect(expanded).toBeLessThanOrEqual(ROOM_FOR_FOUR_ROWS);
     });
 
-    it('should always keep at least one row when there is no room at all', () => {
-      setRoom(0);
+    // The whole point of shrinking rather than dropping rows: the grid still
+    // spans six rows, so no part of the month falls outside it.
+    it('should still show every row when the height is clamped', () => {
+      setRoom(ROOM_FOR_FOUR_ROWS);
       component.isExpanded.set(true);
 
-      expect(component.maxHeight()).toBe(ROW_HEIGHT);
+      expect(component.rowHeight()).toBeLessThan(ROW_HEIGHT);
+      expect(component.maxHeight()).toBe(component.rowHeight() * WEEKS_SHOWN);
+    });
+
+    it('should not shrink rows below MIN_ROW_HEIGHT when there is no room at all', () => {
+      setRoom(0);
+
+      expect(component.rowHeight()).toBe(MIN_ROW_HEIGHT);
+      expect(component.canExpand()).toBe(false);
     });
 
     it('should still build all six weeks of days when the height is clamped', () => {
@@ -365,7 +445,10 @@ describe('PlannerCalendarNavComponent', () => {
   });
 
   describe('weekOffset computed', () => {
-    const setRoom = (px: number): void => component['_availableForRows'].set(px);
+    const setRoom = (px: number): void => {
+      component['_resizeObserver']?.disconnect();
+      component['_availableForRows'].set(px);
+    };
 
     it('should return 0 when expanded', () => {
       setRoom(ROOM_FOR_ALL_ROWS);
@@ -373,26 +456,21 @@ describe('PlannerCalendarNavComponent', () => {
       expect(component.weekOffset()).toBe(0);
     });
 
-    // Dropping rows must not make a day unreachable — that is the bug #9449
-    // fixed, at a different viewport.
-    it('should keep the active week visible when the height is clamped', () => {
+    // #9463 review: clamping the row *count* pinned the window to rows 0..n-1
+    // when the active week was row 0, and the tail of the month rendered off
+    // screen with no gesture that scrolls within an expanded grid. Shrinking
+    // rows keeps the offset at 0, so every week stays on screen.
+    it('should stay at 0 when expanded on a viewport that clamps the rows', () => {
       const weeks = component.weeks();
-      fixture.componentRef.setInput('visibleDayDate', weeks[WEEKS_SHOWN - 1][0].dateStr);
+      fixture.componentRef.setInput('visibleDayDate', weeks[0][0].dateStr);
       component.isExpanded.set(true);
       fixture.detectChanges();
-      // Last, so the ResizeObserver's initial callback cannot land on top of it
-      // with the runner's real geometry.
       setRoom(ROOM_FOR_FOUR_ROWS);
 
-      const rows = component.maxHeight() / ROW_HEIGHT;
-      const firstVisibleRow = -component.weekOffset() / ROW_HEIGHT;
-
-      expect(component.activeWeekIndex()).toBe(WEEKS_SHOWN - 1);
-      expect(firstVisibleRow).toBeGreaterThan(0);
-      expect(component.activeWeekIndex()).toBeGreaterThanOrEqual(firstVisibleRow);
-      expect(component.activeWeekIndex()).toBeLessThan(firstVisibleRow + rows);
-      // Never scrolled past the last row.
-      expect(firstVisibleRow + rows).toBeLessThanOrEqual(WEEKS_SHOWN);
+      expect(component.activeWeekIndex()).toBe(0);
+      expect(component.weekOffset()).toBe(0);
+      // The last row's bottom edge is inside the grid, so its days are on screen.
+      expect(component.rowHeight() * WEEKS_SHOWN).toBe(component.maxHeight());
     });
 
     it('should return negative offset based on activeWeekIndex when collapsed', () => {
@@ -401,8 +479,21 @@ describe('PlannerCalendarNavComponent', () => {
       fixture.componentRef.setInput('visibleDayDate', targetDay);
       component.isExpanded.set(false);
       fixture.detectChanges();
+      setRoom(ROOM_FOR_ALL_ROWS);
 
       expect(component.weekOffset()).toBe(-2 * ROW_HEIGHT);
+    });
+
+    // One row of a shrunken grid is one shrunken row high.
+    it('should scale the collapsed offset with the row height', () => {
+      const weeks = component.weeks();
+      fixture.componentRef.setInput('visibleDayDate', weeks[2][0].dateStr);
+      component.isExpanded.set(false);
+      fixture.detectChanges();
+      setRoom(ROOM_FOR_FOUR_ROWS);
+
+      expect(component.rowHeight()).toBeLessThan(ROW_HEIGHT);
+      expect(component.weekOffset()).toBe(-2 * component.rowHeight());
     });
 
     it('should return 0 when collapsed and activeWeekIndex is 0', () => {

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
@@ -13,6 +13,9 @@ import {
   untracked,
   viewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { fromEvent } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 import { DEFAULT_FIRST_DAY_OF_WEEK } from '../../../core/locale.constants';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { GlobalConfigService } from '../../config/global-config.service';
@@ -24,11 +27,15 @@ import { parseDbDateStr } from '../../../util/parse-db-date-str';
 import {
   CalendarGestureHandler,
   DAYS_IN_VIEW,
-  MAX_HEIGHT,
   MIN_HEIGHT,
   ROW_HEIGHT,
   WEEKS_SHOWN,
 } from './planner-calendar-gesture-handler';
+
+/** The collapse handle, which sits below the week rows and must stay tappable. */
+export const HANDLE_HEIGHT = 28;
+/** One task row of the plan list must stay visible behind an expanded calendar. */
+export const MIN_PLAN_VIEW_HEIGHT = ROW_HEIGHT;
 
 interface CalendarDay {
   dateStr: string;
@@ -63,6 +70,14 @@ export class PlannerCalendarNavComponent {
   dayTapped = output<string>();
 
   isExpanded = signal(false);
+  /**
+   * Room below the first week row, measured rather than derived from
+   * `window.innerHeight`: everything above the rows (app header, the planner's
+   * own chrome, month label, day labels) varies by platform and route, and
+   * guessing it is what made the six-row grid overflow at XS heights.
+   * Infinity until first measured, so nothing is clamped before layout exists.
+   */
+  private _availableForRows = signal(Number.POSITIVE_INFINITY);
   private _anchorWeekStart = signal<string | null>(null);
   private _displayedRow = signal<number | null>(null);
   private _weeksEl = viewChild<ElementRef<HTMLElement>>('weeksContainer');
@@ -120,13 +135,50 @@ export class PlannerCalendarNavComponent {
     return 0;
   });
 
-  maxHeight = computed(() => {
-    return this.isExpanded() ? MAX_HEIGHT : MIN_HEIGHT;
+  /**
+   * Week rows the expanded grid may show. Six rows of *data* are always built
+   * (`DAYS_IN_VIEW`), so every day of the month exists, carries its task dot and
+   * stays tappable — but rendering all six needs 240px, which at XS heights
+   * pushed `planner-plan-view` to 0px and hid the collapse handle behind the
+   * bottom nav. When rows are dropped here the grid slides to keep the active
+   * week in view, so nothing becomes unreachable.
+   */
+  private _visibleWeekRows = computed(() => {
+    const fits = Math.floor(this._availableForRows() / ROW_HEIGHT);
+    return Math.min(WEEKS_SHOWN, Math.max(1, fits));
   });
 
-  weekOffset = computed(() => {
-    return this.isExpanded() ? 0 : -this.activeWeekIndex() * ROW_HEIGHT;
+  private _measureAvailableForRows(): void {
+    const el = this._weeksEl()?.nativeElement;
+    if (!el) return;
+    // Bounded by the route content, not the window: on XS the bottom nav takes
+    // the last ~44px, so measuring against window.innerHeight reserves space
+    // that the plan list never gets.
+    const container = this._elRef.nativeElement.parentElement as HTMLElement | null;
+    const bottom = container
+      ? container.getBoundingClientRect().bottom
+      : window.innerHeight;
+    this._availableForRows.set(
+      bottom - el.getBoundingClientRect().top - HANDLE_HEIGHT - MIN_PLAN_VIEW_HEIGHT,
+    );
+  }
+
+  maxHeight = computed(() => {
+    return this.isExpanded() ? this._visibleWeekRows() * ROW_HEIGHT : MIN_HEIGHT;
   });
+
+  weekOffset = computed(() =>
+    this._weekOffsetFor(this.isExpanded(), this.activeWeekIndex()),
+  );
+
+  // Active week at the top of the window, clamped so the last row can never sit
+  // below it. Collapsed (1 row) and unclamped expanded (6 rows) both fall out of
+  // this: -activeWeekIndex * ROW_HEIGHT and 0 respectively.
+  private _weekOffsetFor(expanded: boolean, activeIdx: number): number {
+    const rows = expanded ? this._visibleWeekRows() : 1;
+    const firstRow = Math.min(activeIdx, WEEKS_SHOWN - rows);
+    return -firstRow * ROW_HEIGHT;
+  }
 
   monthLabel = computed(() => {
     // The spelled-out month name follows textLocale(): passing no locale would
@@ -187,6 +239,11 @@ export class PlannerCalendarNavComponent {
       {
         getActiveWeekIndex: () => this.activeWeekIndex(),
         getIsExpanded: () => this.isExpanded(),
+        getExpandedHeight: () => {
+          this._measureAvailableForRows();
+          return this._visibleWeekRows() * ROW_HEIGHT;
+        },
+        getWeekOffset: (expanded, activeIdx) => this._weekOffsetFor(expanded, activeIdx),
         onExpandChanged: (expanded) => this.isExpanded.set(expanded),
         onVerticalSwipe: (isDown) => this._handleVerticalSwipe(isDown),
         onHorizontalSwipe: (dir) => this._handleHorizontalSwipe(dir),
@@ -194,6 +251,18 @@ export class PlannerCalendarNavComponent {
       },
     );
     this._destroyRef.onDestroy(() => this._gesture.destroy());
+
+    effect(() => {
+      // Re-measure once the rows exist, and again whenever the expanded state
+      // settles (the rows' offset can shift with the surrounding layout).
+      this._weeksEl();
+      this.isExpanded();
+      untracked(() => this._measureAvailableForRows());
+    });
+
+    fromEvent(window, 'resize')
+      .pipe(debounceTime(50), takeUntilDestroyed())
+      .subscribe(() => this._measureAvailableForRows());
   }
 
   private _handleVerticalSwipe(isDown: boolean): void {

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
@@ -13,9 +13,6 @@ import {
   untracked,
   viewChild,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { fromEvent } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
 import { DEFAULT_FIRST_DAY_OF_WEEK } from '../../../core/locale.constants';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { GlobalConfigService } from '../../config/global-config.service';
@@ -59,6 +56,7 @@ export class PlannerCalendarNavComponent {
   private _elRef = inject(ElementRef);
   private _destroyRef = inject(DestroyRef);
   private _gesture!: CalendarGestureHandler;
+  private _resizeObserver?: ResizeObserver;
 
   private _firstDayOfWeek = computed(() => {
     const cfg = this._globalConfigService.localization()?.firstDayOfWeek;
@@ -148,13 +146,17 @@ export class PlannerCalendarNavComponent {
     return Math.min(WEEKS_SHOWN, Math.max(1, fits));
   });
 
+  private _parentEl(): HTMLElement | null {
+    return this._elRef.nativeElement.parentElement as HTMLElement | null;
+  }
+
   private _measureAvailableForRows(): void {
     const el = this._weeksEl()?.nativeElement;
     if (!el) return;
     // Bounded by the route content, not the window: on XS the bottom nav takes
     // the last ~44px, so measuring against window.innerHeight reserves space
     // that the plan list never gets.
-    const container = this._elRef.nativeElement.parentElement as HTMLElement | null;
+    const container = this._parentEl();
     const bottom = container
       ? container.getBoundingClientRect().bottom
       : window.innerHeight;
@@ -253,16 +255,24 @@ export class PlannerCalendarNavComponent {
     this._destroyRef.onDestroy(() => this._gesture.destroy());
 
     effect(() => {
-      // Re-measure once the rows exist, and again whenever the expanded state
-      // settles (the rows' offset can shift with the surrounding layout).
-      this._weeksEl();
-      this.isExpanded();
-      untracked(() => this._measureAvailableForRows());
+      // Observe the box the measurement is taken against, rather than the
+      // window: the route content also shrinks when a banner appears above it
+      // (`<banner>` sits above `.route-wrapper`), which fires no resize event.
+      // Expanding moves neither input, so it is deliberately not a trigger.
+      const el = this._weeksEl()?.nativeElement;
+      if (!el) return;
+      untracked(() => this._observeAvailableForRows());
     });
+  }
 
-    fromEvent(window, 'resize')
-      .pipe(debounceTime(50), takeUntilDestroyed())
-      .subscribe(() => this._measureAvailableForRows());
+  private _observeAvailableForRows(): void {
+    const container = this._parentEl();
+    this._measureAvailableForRows();
+    if (!container || this._resizeObserver) return;
+
+    this._resizeObserver = new ResizeObserver(() => this._measureAvailableForRows());
+    this._resizeObserver.observe(container);
+    this._destroyRef.onDestroy(() => this._resizeObserver?.disconnect());
   }
 
   private _handleVerticalSwipe(isDown: boolean): void {

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
@@ -211,13 +211,14 @@ export class PlannerCalendarNavComponent {
    * put a fixed 144px grid into whatever space was left, overflowing into the
    * `MIN_PLAN_VIEW_HEIGHT` reserve the clamp exists to protect. A no-op
    * whenever `canExpand()` is true.
+   *
+   * The collapsed branch is deliberately not clamped. `_availableForRows` has
+   * no floor, so at an Electron minimum window it can fall under one row or go
+   * negative, and a negative `max-height` is rejected by CSSOM outright, which
+   * leaves the element on whatever value was last valid rather than failing
+   * visibly. One collapsed row is the floor.
    */
-  maxHeight = computed(() =>
-    Math.min(
-      this.isExpanded() ? this.rowHeight() * WEEKS_SHOWN : ROW_HEIGHT,
-      this._availableForRows(),
-    ),
-  );
+  maxHeight = computed(() => (this.isExpanded() ? this.maxExpandedHeight() : ROW_HEIGHT));
 
   /** What the grid opens to, clamped the same way `maxHeight` is. */
   maxExpandedHeight = computed(() =>
@@ -290,6 +291,7 @@ export class PlannerCalendarNavComponent {
         getIsExpanded: () => this.isExpanded(),
         measure: () => this._measureAvailableForRows(),
         getExpandedHeight: () => this.maxExpandedHeight(),
+        getRowHeight: () => this.rowHeight(),
         canExpand: () => this.canExpand(),
         onExpandChanged: (expanded) => this.isExpanded.set(expanded),
         onVerticalSwipe: (isDown) => this._handleVerticalSwipe(isDown),

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
@@ -1,4 +1,5 @@
 import {
+  afterNextRender,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -24,7 +25,7 @@ import { parseDbDateStr } from '../../../util/parse-db-date-str';
 import {
   CalendarGestureHandler,
   DAYS_IN_VIEW,
-  MIN_HEIGHT,
+  MIN_ROW_HEIGHT,
   ROW_HEIGHT,
   WEEKS_SHOWN,
 } from './planner-calendar-gesture-handler';
@@ -32,7 +33,7 @@ import {
 /** The collapse handle, which sits below the week rows and must stay tappable. */
 export const HANDLE_HEIGHT = 28;
 /** One task row of the plan list must stay visible behind an expanded calendar. */
-export const MIN_PLAN_VIEW_HEIGHT = ROW_HEIGHT;
+const MIN_PLAN_VIEW_HEIGHT = 40;
 
 interface CalendarDay {
   dateStr: string;
@@ -134,20 +135,39 @@ export class PlannerCalendarNavComponent {
   });
 
   /**
-   * Week rows the expanded grid may show. Six rows of *data* are always built
-   * (`DAYS_IN_VIEW`), so every day of the month exists, carries its task dot and
-   * stays tappable — but rendering all six needs 240px, which at XS heights
-   * pushed `planner-plan-view` to 0px and hid the collapse handle behind the
-   * bottom nav. When rows are dropped here the grid slides to keep the active
-   * week in view, so nothing becomes unreachable.
+   * Height of one week row. Six rows are always rendered, so the grid spans the
+   * whole month and every day stays tappable (#9449); where six 40px rows do
+   * not fit they shrink instead. Dropping rows would hide the tail of the month
+   * behind an edge no gesture scrolls past, which is the bug this PR is for.
    */
-  private _visibleWeekRows = computed(() => {
-    const fits = Math.floor(this._availableForRows() / ROW_HEIGHT);
-    return Math.min(WEEKS_SHOWN, Math.max(1, fits));
+  rowHeight = computed(() => {
+    const fits = Math.floor(this._availableForRows() / WEEKS_SHOWN);
+    return Math.min(ROW_HEIGHT, Math.max(MIN_ROW_HEIGHT, fits));
   });
 
+  /**
+   * Below six `MIN_ROW_HEIGHT` rows the grid no longer fits at a legible size,
+   * so it stays collapsed. Nothing is lost: the collapsed strip walks all six
+   * rows one at a time on a horizontal swipe.
+   */
+  canExpand = computed(() => this._availableForRows() >= WEEKS_SHOWN * MIN_ROW_HEIGHT);
+
+  // The planner host, not `parentElement`: it is the box whose bottom bounds
+  // the calendar, and resolving it by selector survives the nav being wrapped
+  // in planner.component.html.
   private _parentEl(): HTMLElement | null {
-    return this._elRef.nativeElement.parentElement as HTMLElement | null;
+    return this._elRef.nativeElement.closest('planner') as HTMLElement | null;
+  }
+
+  /** Distance from the top of the offset chain, which no ancestor transform scales. */
+  private _layoutTop(el: HTMLElement): number {
+    let top = 0;
+    let cur: HTMLElement | null = el;
+    while (cur) {
+      top += cur.offsetTop;
+      cur = cur.offsetParent as HTMLElement | null;
+    }
+    return top;
   }
 
   private _measureAvailableForRows(): void {
@@ -157,30 +177,27 @@ export class PlannerCalendarNavComponent {
     // the last ~44px, so measuring against window.innerHeight reserves space
     // that the plan list never gets.
     const container = this._parentEl();
-    const bottom = container
-      ? container.getBoundingClientRect().bottom
-      : window.innerHeight;
+    // Without the host there is nothing to measure against, so leave the room
+    // unbounded and render full-size rows rather than guess at a clamp.
+    if (!container) return;
+    // offsetTop/clientHeight rather than getBoundingClientRect: the route enter
+    // animation (warpRoute) starts this view at scale(1.2), and a rect read
+    // while that is in flight is 20% too generous. Measured 227px of room where
+    // there were 178, which is a whole extra row.
+    const topWithinContainer = this._layoutTop(el) - this._layoutTop(container);
     this._availableForRows.set(
-      bottom - el.getBoundingClientRect().top - HANDLE_HEIGHT - MIN_PLAN_VIEW_HEIGHT,
+      container.clientHeight - topWithinContainer - HANDLE_HEIGHT - MIN_PLAN_VIEW_HEIGHT,
     );
   }
 
-  maxHeight = computed(() => {
-    return this.isExpanded() ? this._visibleWeekRows() * ROW_HEIGHT : MIN_HEIGHT;
-  });
-
-  weekOffset = computed(() =>
-    this._weekOffsetFor(this.isExpanded(), this.activeWeekIndex()),
+  maxHeight = computed(() =>
+    this.isExpanded() ? this.rowHeight() * WEEKS_SHOWN : this.rowHeight(),
   );
 
-  // Active week at the top of the window, clamped so the last row can never sit
-  // below it. Collapsed (1 row) and unclamped expanded (6 rows) both fall out of
-  // this: -activeWeekIndex * ROW_HEIGHT and 0 respectively.
-  private _weekOffsetFor(expanded: boolean, activeIdx: number): number {
-    const rows = expanded ? this._visibleWeekRows() : 1;
-    const firstRow = Math.min(activeIdx, WEEKS_SHOWN - rows);
-    return -firstRow * ROW_HEIGHT;
-  }
+  // Expanded shows every row, so there is nothing to scroll to.
+  weekOffset = computed(() =>
+    this.isExpanded() ? 0 : -this.activeWeekIndex() * this.rowHeight(),
+  );
 
   monthLabel = computed(() => {
     // The spelled-out month name follows textLocale(): passing no locale would
@@ -241,11 +258,9 @@ export class PlannerCalendarNavComponent {
       {
         getActiveWeekIndex: () => this.activeWeekIndex(),
         getIsExpanded: () => this.isExpanded(),
-        getExpandedHeight: () => {
-          this._measureAvailableForRows();
-          return this._visibleWeekRows() * ROW_HEIGHT;
-        },
-        getWeekOffset: (expanded, activeIdx) => this._weekOffsetFor(expanded, activeIdx),
+        measure: () => this._measureAvailableForRows(),
+        getRowHeight: () => this.rowHeight(),
+        canExpand: () => this.canExpand(),
         onExpandChanged: (expanded) => this.isExpanded.set(expanded),
         onVerticalSwipe: (isDown) => this._handleVerticalSwipe(isDown),
         onHorizontalSwipe: (dir) => this._handleHorizontalSwipe(dir),
@@ -254,17 +269,16 @@ export class PlannerCalendarNavComponent {
     );
     this._destroyRef.onDestroy(() => this._gesture.destroy());
 
-    effect(() => {
-      // Observe the box the measurement is taken against, rather than the
-      // window: the route content also shrinks when a banner appears above it
-      // (`<banner>` sits above `.route-wrapper`), which fires no resize event.
-      // Expanding moves neither input, so it is deliberately not a trigger.
-      const el = this._weeksEl()?.nativeElement;
-      if (!el) return;
-      untracked(() => this._observeAvailableForRows());
-    });
+    // After the first render, not as soon as the rows exist: the month label and
+    // day labels are laid out in the same pass and push the rows down, so an
+    // earlier read measures from a top the grid no longer has.
+    afterNextRender(() => this._observeAvailableForRows());
   }
 
+  // Observes the box the measurement is taken against, rather than the window:
+  // the route content also shrinks when a banner appears above it (`<banner>`
+  // sits above `.route-wrapper`), which fires no resize event. It cannot see the
+  // rows' own top move, which is why the gesture handler re-measures too.
   private _observeAvailableForRows(): void {
     const container = this._parentEl();
     this._measureAvailableForRows();

--- a/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
+++ b/src/app/features/planner/planner-calendar-nav/planner-calendar-nav.component.ts
@@ -190,13 +190,43 @@ export class PlannerCalendarNavComponent {
     );
   }
 
+  /**
+   * The row height actually rendered. Collapsed rows stay full size even where
+   * an expanded grid would have to shrink: the collapsed strip is one row in a
+   * viewport with room for it, and `.week button` is
+   * `min(36px, var(--row-height) - 4px)`, so a shrunken collapsed row would
+   * hand every user 25px tap targets whether or not they ever expand. Rows
+   * resizing across the expand transition is the accepted trade.
+   */
+  displayRowHeight = computed(() => (this.isExpanded() ? this.rowHeight() : ROW_HEIGHT));
+
+  /**
+   * Clamped by the measured room, not only by `canExpand()`.
+   *
+   * `canExpand()` gates *entering* the expanded state and nothing leaves it:
+   * `isExpanded` is written only from `snapTo`, and `isXs` is a max-*width*
+   * query, so a height-only shrink (a `<banner>` appearing above
+   * `.route-wrapper`, which fires no resize event) leaves the flag true while
+   * the room is gone. Without this clamp `rowHeight()`'s `MIN_ROW_HEIGHT` floor
+   * put a fixed 144px grid into whatever space was left, overflowing into the
+   * `MIN_PLAN_VIEW_HEIGHT` reserve the clamp exists to protect. A no-op
+   * whenever `canExpand()` is true.
+   */
   maxHeight = computed(() =>
-    this.isExpanded() ? this.rowHeight() * WEEKS_SHOWN : this.rowHeight(),
+    Math.min(
+      this.isExpanded() ? this.rowHeight() * WEEKS_SHOWN : ROW_HEIGHT,
+      this._availableForRows(),
+    ),
+  );
+
+  /** What the grid opens to, clamped the same way `maxHeight` is. */
+  maxExpandedHeight = computed(() =>
+    Math.min(this.rowHeight() * WEEKS_SHOWN, this._availableForRows()),
   );
 
   // Expanded shows every row, so there is nothing to scroll to.
   weekOffset = computed(() =>
-    this.isExpanded() ? 0 : -this.activeWeekIndex() * this.rowHeight(),
+    this.isExpanded() ? 0 : -this.activeWeekIndex() * ROW_HEIGHT,
   );
 
   monthLabel = computed(() => {
@@ -259,7 +289,7 @@ export class PlannerCalendarNavComponent {
         getActiveWeekIndex: () => this.activeWeekIndex(),
         getIsExpanded: () => this.isExpanded(),
         measure: () => this._measureAvailableForRows(),
-        getRowHeight: () => this.rowHeight(),
+        getExpandedHeight: () => this.maxExpandedHeight(),
         canExpand: () => this.canExpand(),
         onExpandChanged: (expanded) => this.isExpanded.set(expanded),
         onVerticalSwipe: (isDown) => this._handleVerticalSwipe(isDown),

--- a/src/app/features/schedule/schedule.constants.ts
+++ b/src/app/features/schedule/schedule.constants.ts
@@ -30,16 +30,14 @@ export const SCHEDULE_CONSTANTS = {
    * Month view layout configuration.
    */
   MONTH_VIEW: {
-    /** Height offset for header/controls in month view calculation */
-    HEADER_OFFSET: 160,
-    /** Minimum height per week row on desktop */
-    MIN_HEIGHT_PER_WEEK_DESKTOP: 100,
-    /** Minimum height per week row on mobile */
-    MIN_HEIGHT_PER_WEEK_MOBILE: 60,
-    /** Minimum number of weeks to show */
-    MIN_WEEKS: 3,
-    /** Maximum number of weeks to show */
-    MAX_WEEKS: 6,
+    /**
+     * Number of week rows in the month grid. Fixed at 6 so the grid always
+     * spans the whole month: a month starting late in the week (Aug 2026 starts
+     * on a Saturday) needs 6 rows, and rows are `1fr` inside a fixed-height
+     * grid, so fewer rows only ever removes days — it never makes them taller.
+     * Must stay in sync with `--nr-of-weeks` in `schedule.component.scss`.
+     */
+    NR_OF_WEEKS: 6,
   },
 
   /**

--- a/src/app/features/schedule/schedule.constants.ts
+++ b/src/app/features/schedule/schedule.constants.ts
@@ -27,20 +27,6 @@ export const SCHEDULE_CONSTANTS = {
   },
 
   /**
-   * Month view layout configuration.
-   */
-  MONTH_VIEW: {
-    /**
-     * Number of week rows in the month grid. Fixed at 6 so the grid always
-     * spans the whole month: a month starting late in the week (Aug 2026 starts
-     * on a Saturday) needs 6 rows, and rows are `1fr` inside a fixed-height
-     * grid, so fewer rows only ever removes days — it never makes them taller.
-     * Must stay in sync with `--nr-of-weeks` in `schedule.component.scss`.
-     */
-    NR_OF_WEEKS: 6,
-  },
-
-  /**
    * Column widths for different screen sizes.
    * These values determine the width of day columns in the schedule view.
    */

--- a/src/app/features/schedule/schedule.service.spec.ts
+++ b/src/app/features/schedule/schedule.service.spec.ts
@@ -333,10 +333,10 @@ describe('ScheduleService', () => {
       });
 
       it('should span the whole month for every month/firstDayOfWeek combination', () => {
-        // 24 consecutive months covers every start-weekday and both a leap and
-        // a non-leap February.
+        // 24 consecutive months from Jan 2027 covers every start-weekday and
+        // both a non-leap February (2027) and a leap one (2028).
         for (let monthOffset = 0; monthOffset < 24; monthOffset++) {
-          const reference = new Date(2026, monthOffset, 15);
+          const reference = new Date(2027, monthOffset, 15);
           const year = reference.getFullYear();
           const month = reference.getMonth();
           const first = dayStr(new Date(year, month, 1));

--- a/src/app/features/schedule/schedule.service.spec.ts
+++ b/src/app/features/schedule/schedule.service.spec.ts
@@ -15,6 +15,7 @@ import { HiddenCalendarProvidersService } from '../calendar-integration/hidden-c
 import { TaskService } from '../tasks/task.service';
 import { ScheduleCalendarMapEntry, ScheduleEvent } from './schedule.model';
 import { SVEType } from './schedule.const';
+import { SCHEDULE_CONSTANTS } from './schedule.constants';
 
 describe('ScheduleService', () => {
   let service: ScheduleService;
@@ -303,6 +304,56 @@ describe('ScheduleService', () => {
       const lastDay = new Date(result[result.length - 1]);
       // With 5 weeks starting from late December, we should reach into February
       expect(lastDay.getMonth()).toBeGreaterThanOrEqual(0);
+    });
+
+    describe('full-month coverage (#9449)', () => {
+      const dayStr = (date: Date): string => dateService.todayStr(date.getTime());
+      const lastDayOfMonth = (year: number, month: number): Date =>
+        new Date(year, month + 1, 0);
+
+      it('should include Mon 31 Aug 2026 for every first day of week', () => {
+        const aug31 = dayStr(new Date(2026, 7, 31));
+
+        for (let firstDayOfWeek = 0; firstDayOfWeek < 7; firstDayOfWeek++) {
+          const result = service.getMonthDaysToShow(
+            SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS,
+            firstDayOfWeek,
+            new Date(2026, 7, 15),
+          );
+          expect(result).withContext(`firstDayOfWeek ${firstDayOfWeek}`).toContain(aug31);
+        }
+      });
+
+      it('should not reach 31 Aug 2026 with only 5 weeks — why NR_OF_WEEKS is 6', () => {
+        // August 2026 starts on a Saturday, so the padded grid needs 6 rows.
+        // This is the shape the reported bug had: a shorter window silently
+        // stopped before the end of the month.
+        const result = service.getMonthDaysToShow(5, 1, new Date(2026, 7, 15));
+        expect(result).not.toContain(dayStr(new Date(2026, 7, 31)));
+      });
+
+      it('should span the whole month for every month/firstDayOfWeek combination', () => {
+        // 24 consecutive months covers every start-weekday and both a leap and
+        // a non-leap February.
+        for (let monthOffset = 0; monthOffset < 24; monthOffset++) {
+          const reference = new Date(2026, monthOffset, 15);
+          const year = reference.getFullYear();
+          const month = reference.getMonth();
+          const first = dayStr(new Date(year, month, 1));
+          const last = dayStr(lastDayOfMonth(year, month));
+
+          for (let firstDayOfWeek = 0; firstDayOfWeek < 7; firstDayOfWeek++) {
+            const result = service.getMonthDaysToShow(
+              SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS,
+              firstDayOfWeek,
+              reference,
+            );
+            const context = `${year}-${month + 1}, firstDayOfWeek ${firstDayOfWeek}`;
+            expect(result).withContext(context).toContain(first);
+            expect(result).withContext(context).toContain(last);
+          }
+        }
+      });
     });
   });
 

--- a/src/app/features/schedule/schedule.service.spec.ts
+++ b/src/app/features/schedule/schedule.service.spec.ts
@@ -15,7 +15,6 @@ import { HiddenCalendarProvidersService } from '../calendar-integration/hidden-c
 import { TaskService } from '../tasks/task.service';
 import { ScheduleCalendarMapEntry, ScheduleEvent } from './schedule.model';
 import { SVEType } from './schedule.const';
-import { SCHEDULE_CONSTANTS } from './schedule.constants';
 
 describe('ScheduleService', () => {
   let service: ScheduleService;
@@ -311,20 +310,59 @@ describe('ScheduleService', () => {
       const lastDayOfMonth = (year: number, month: number): Date =>
         new Date(year, month + 1, 0);
 
+      // The derivation itself. Pinning at 6 spanned every month but left an
+      // empty row on most of them; deriving from available height is what
+      // #9449 was filed for. The month is the right input.
+      it('should derive 4 to 6 weeks, and never fewer than the month needs', () => {
+        // Feb 2027 is 28 days starting on a Monday, the only shape that fits
+        // in four rows under a Monday-first week.
+        expect(service.getMonthWeeksToShow(1, new Date(2027, 1, 15))).toBe(4);
+        // Aug 2026 starts on a Saturday: 5 leading days + 31 needs six rows.
+        expect(service.getMonthWeeksToShow(1, new Date(2026, 7, 15))).toBe(6);
+        // Sep 2026 is 30 days from a Tuesday: five rows is exact.
+        expect(service.getMonthWeeksToShow(1, new Date(2026, 8, 15))).toBe(5);
+      });
+
+      it('should never return a count that drops a day of the month', () => {
+        // The count and the grid it feeds have to agree for every pair, or a
+        // day gets no cell and therefore no events at all.
+        for (let monthOffset = 0; monthOffset < 24; monthOffset++) {
+          const reference = new Date(2027, monthOffset, 15);
+          const year = reference.getFullYear();
+          const month = reference.getMonth();
+          const last = dayStr(lastDayOfMonth(year, month));
+
+          for (let firstDayOfWeek = 0; firstDayOfWeek < 7; firstDayOfWeek++) {
+            const weeks = service.getMonthWeeksToShow(firstDayOfWeek, reference);
+            const context = `${year}-${month + 1}, firstDayOfWeek ${firstDayOfWeek}`;
+            expect(weeks).withContext(context).toBeGreaterThanOrEqual(4);
+            expect(weeks).withContext(context).toBeLessThanOrEqual(6);
+            expect(service.getMonthDaysToShow(weeks, firstDayOfWeek, reference))
+              .withContext(context)
+              .toContain(last);
+            // And not a row more than it needs.
+            expect(service.getMonthDaysToShow(weeks - 1, firstDayOfWeek, reference))
+              .withContext(context)
+              .not.toContain(last);
+          }
+        }
+      });
+
       it('should include Mon 31 Aug 2026 for every first day of week', () => {
         const aug31 = dayStr(new Date(2026, 7, 31));
 
         for (let firstDayOfWeek = 0; firstDayOfWeek < 7; firstDayOfWeek++) {
+          const reference = new Date(2026, 7, 15);
           const result = service.getMonthDaysToShow(
-            SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS,
+            service.getMonthWeeksToShow(firstDayOfWeek, reference),
             firstDayOfWeek,
-            new Date(2026, 7, 15),
+            reference,
           );
           expect(result).withContext(`firstDayOfWeek ${firstDayOfWeek}`).toContain(aug31);
         }
       });
 
-      it('should not reach 31 Aug 2026 with only 5 weeks — why NR_OF_WEEKS is 6', () => {
+      it('should not reach 31 Aug 2026 with only 5 weeks — why August derives 6', () => {
         // August 2026 starts on a Saturday, so the padded grid needs 6 rows.
         // This is the shape the reported bug had: a shorter window silently
         // stopped before the end of the month.
@@ -344,7 +382,7 @@ describe('ScheduleService', () => {
 
           for (let firstDayOfWeek = 0; firstDayOfWeek < 7; firstDayOfWeek++) {
             const result = service.getMonthDaysToShow(
-              SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS,
+              service.getMonthWeeksToShow(firstDayOfWeek, reference),
               firstDayOfWeek,
               reference,
             );

--- a/src/app/features/schedule/schedule.service.ts
+++ b/src/app/features/schedule/schedule.service.ts
@@ -177,6 +177,34 @@ export class ScheduleService {
     return daysToShow;
   }
 
+  /**
+   * Week rows the displayed month actually occupies, 4 to 6.
+   *
+   * A month needs `daysToGoBack` leading days from the previous month plus its
+   * own length, rounded up to whole weeks. `daysToGoBack` is 0-6 and a month is
+   * 28-31 days, so this is 4 (only a non-leap February starting exactly on the
+   * week's first day) to 6 (a 31-day month starting 5 or 6 days in, e.g. August
+   * 2026 under Monday-first). Most months are 5.
+   *
+   * Pinning it at 6 spans every month but leaves an empty row on most of them.
+   * Deriving it from *available height* is what #9449 was filed for: a day left
+   * out of `daysToShow` gets no events computed at all, so the task vanished
+   * rather than merely being clipped. The month is the right input; the viewport
+   * is not.
+   */
+  getMonthWeeksToShow(
+    firstDayOfWeek: number = 0,
+    referenceDate: Date | null = null,
+  ): number {
+    // Same logical-day anchoring as getMonthDaysToShow below.
+    const today = referenceDate || this._dateService.getLogicalTodayDate();
+    const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    const daysToGoBack = (firstDayOfMonth.getDay() - firstDayOfWeek + 7) % 7;
+    // Day 0 of the next month is the last day of this one.
+    const daysInMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
+    return Math.ceil((daysToGoBack + daysInMonth) / 7);
+  }
+
   getMonthDaysToShow(
     numberOfWeeks: number,
     firstDayOfWeek: number = 0,

--- a/src/app/features/schedule/schedule/schedule.component.html
+++ b/src/app/features/schedule/schedule/schedule.component.html
@@ -137,6 +137,7 @@
 </div>
 
 <div
+  #scrollWrapper
   class="scroll-wrapper"
   [attr.data-horizontal-scroll]="shouldEnableHorizontalScroll() || null"
   (scroll)="onScrollWrapperScroll($event)"

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1002,14 +1002,60 @@ describe('ScheduleComponent', () => {
       // and therefore no events computed at all). Height must not influence it.
       mockLayoutService.selectedTimeView.set('month');
 
-      component['_windowSize'] = signal({ width: 1280, height: 1400 });
+      // One signal, mutated with .set(): replacing the field instead would not
+      // invalidate the computed, so the second read would return the first
+      // read's cached value and the test could not fail.
+      const windowSize = signal({ width: 1280, height: 1400 });
+      component['_windowSize'] = windowSize;
       const onTallWindow = component['_daysToShowCount']();
 
-      component['_windowSize'] = signal({ width: 1280, height: 500 });
+      windowSize.set({ width: 1280, height: 500 });
       const onShortWindow = component['_daysToShowCount']();
 
       expect(onShortWindow).toBe(onTallWindow);
       expect(onShortWindow).toBe(SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS);
+    });
+  });
+
+  describe('scroll position on view change', () => {
+    // Six rows overflow the wrapper on a short window, so a scroll position
+    // carried over from week view clamped to the bottom and opened the month
+    // with its first row above the viewport (#9463 review).
+    const scrollWrapper = (): HTMLElement =>
+      fixture.nativeElement.querySelector('.scroll-wrapper');
+
+    beforeEach(() => jasmine.clock().install());
+    afterEach(() => jasmine.clock().uninstall());
+
+    it('should reset the wrapper to the top when entering month view', () => {
+      mockLayoutService.selectedTimeView.set('week');
+      fixture.detectChanges();
+
+      // Cast because Element.scrollTo is overloaded; we always call the
+      // options form.
+      const scrollToSpy = spyOn(scrollWrapper(), 'scrollTo') as jasmine.Spy;
+
+      mockLayoutService.selectedTimeView.set('month');
+      fixture.detectChanges();
+      jasmine.clock().tick(1);
+
+      expect(scrollToSpy).toHaveBeenCalled();
+      const [opts] = scrollToSpy.calls.mostRecent().args as [ScrollToOptions];
+      expect(opts.top).toBe(0);
+      expect(opts.left).toBe(0);
+    });
+
+    it('should not reset the wrapper while staying in month view', () => {
+      mockLayoutService.selectedTimeView.set('month');
+      fixture.detectChanges();
+      jasmine.clock().tick(1);
+
+      const scrollToSpy = spyOn(scrollWrapper(), 'scrollTo') as jasmine.Spy;
+
+      fixture.detectChanges();
+      jasmine.clock().tick(1);
+
+      expect(scrollToSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1045,6 +1045,30 @@ describe('ScheduleComponent', () => {
       expect(opts.left).toBe(0);
     });
 
+    // schedule-day-panel renders its own schedule-week, so a second
+    // `#work-start` can exist outside this component. Resolving it through the
+    // document would anchor on whichever came first.
+    it('should ignore a work-start element outside its own host', () => {
+      const stray = document.createElement('div');
+      stray.id = 'work-start';
+      document.body.insertBefore(stray, document.body.firstChild);
+      const scrollIntoViewSpy = spyOn(stray, 'scrollIntoView');
+
+      try {
+        // Month view, so the only #work-start in the document is the stray one:
+        // this component renders schedule-month, which has none.
+        mockLayoutService.selectedTimeView.set('month');
+        fixture.detectChanges();
+        jasmine.clock().tick(1);
+
+        component['_scrollAnchorToTop']('work-start');
+
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+      } finally {
+        stray.remove();
+      }
+    });
+
     it('should not reset the wrapper while staying in month view', () => {
       mockLayoutService.selectedTimeView.set('month');
       fixture.detectChanges();
@@ -1052,6 +1076,16 @@ describe('ScheduleComponent', () => {
 
       const scrollToSpy = spyOn(scrollWrapper(), 'scrollTo') as jasmine.Spy;
 
+      // A *different* array, not just a navigation: the mock returns one fixed
+      // reference, and a computed that yields the same reference is treated as
+      // unchanged, so dependents never re-run. Without this the test only rules
+      // out a reset wired to every change-detection pass.
+      mockScheduleService.getMonthDaysToShow.and.returnValue([
+        '2026-02-01',
+        '2026-02-02',
+        '2026-02-03',
+      ]);
+      component.goToNextPeriod();
       fixture.detectChanges();
       jasmine.clock().tick(1);
 

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -46,6 +46,7 @@ describe('ScheduleComponent', () => {
     mockScheduleService = jasmine.createSpyObj('ScheduleService', [
       'getDaysToShow',
       'getMonthDaysToShow',
+      'getMonthWeeksToShow',
       'buildScheduleDays',
       'scheduleRefreshTick',
       'getTodayStr',
@@ -64,6 +65,9 @@ describe('ScheduleComponent', () => {
       '2026-01-02',
       '2026-01-03',
     ]);
+    // The month view derives its row count from the displayed month; tests that
+    // care about the number override this.
+    mockScheduleService.getMonthWeeksToShow.and.returnValue(6);
     mockScheduleService.buildScheduleDays.and.returnValue([]);
     mockScheduleService.getTodayStr.and.callFake((timestamp?: number | Date) => {
       const date = timestamp ? new Date(timestamp) : new Date();
@@ -985,21 +989,30 @@ describe('ScheduleComponent', () => {
       expect(daysToShowCount).toBe(7);
     });
 
-    it('should return the full week count in month view', () => {
-      // Arrange
+    // The row count follows the displayed month, not a constant and not the
+    // window. `_daysToShowCount` deliberately does not answer for month view:
+    // it reads neither `selectedDate` nor `firstDayOfWeek`.
+    it("should ask the service for the displayed month's week count", () => {
+      mockScheduleService.getMonthWeeksToShow.and.returnValue(5);
       mockLayoutService.selectedTimeView.set('month');
+      fixture.detectChanges();
 
-      // Act
-      const daysToShowCount = component['_daysToShowCount']();
+      component.daysToShow();
 
-      // Assert
-      expect(daysToShowCount).toBe(SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS);
+      const [weeks, firstDayOfWeek] =
+        mockScheduleService.getMonthDaysToShow.calls.mostRecent().args;
+      expect(weeks).toBe(5);
+      expect(mockScheduleService.getMonthWeeksToShow).toHaveBeenCalledWith(
+        firstDayOfWeek,
+        null,
+      );
     });
 
     it('should not shrink the month grid on a short window (#9449)', () => {
       // The month grid used to be sized from the viewport, so a short window
       // dropped the tail of the month (a task on Mon 31 Aug 2026 had no cell
       // and therefore no events computed at all). Height must not influence it.
+      mockScheduleService.getMonthWeeksToShow.and.returnValue(6);
       mockLayoutService.selectedTimeView.set('month');
 
       // One signal, mutated with .set(): replacing the field instead would not
@@ -1007,13 +1020,19 @@ describe('ScheduleComponent', () => {
       // read's cached value and the test could not fail.
       const windowSize = signal({ width: 1280, height: 1400 });
       component['_windowSize'] = windowSize;
-      const onTallWindow = component['_daysToShowCount']();
+      fixture.detectChanges();
+      component.daysToShow();
+      const onTallWindow =
+        mockScheduleService.getMonthDaysToShow.calls.mostRecent().args[0];
 
       windowSize.set({ width: 1280, height: 500 });
-      const onShortWindow = component['_daysToShowCount']();
+      fixture.detectChanges();
+      component.daysToShow();
+      const onShortWindow =
+        mockScheduleService.getMonthDaysToShow.calls.mostRecent().args[0];
 
       expect(onShortWindow).toBe(onTallWindow);
-      expect(onShortWindow).toBe(SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS);
+      expect(onShortWindow).toBe(6);
     });
   });
 

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -985,35 +985,31 @@ describe('ScheduleComponent', () => {
       expect(daysToShowCount).toBe(7);
     });
 
-    it('should return a value between MIN_WEEKS and MAX_WEEKS in month view', () => {
+    it('should return the full week count in month view', () => {
       // Arrange
       mockLayoutService.selectedTimeView.set('month');
 
       // Act
       const daysToShowCount = component['_daysToShowCount']();
 
-      // Assert - should be bounded by constants
-      expect(daysToShowCount).toBeGreaterThanOrEqual(
-        SCHEDULE_CONSTANTS.MONTH_VIEW.MIN_WEEKS,
-      );
-      expect(daysToShowCount).toBeLessThanOrEqual(
-        SCHEDULE_CONSTANTS.MONTH_VIEW.MAX_WEEKS,
-      );
+      // Assert
+      expect(daysToShowCount).toBe(SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS);
     });
 
-    it('should use MONTH_VIEW constants for calculation', () => {
-      // This test verifies the constants are being used by checking
-      // that the result is consistent with the constant values
+    it('should not shrink the month grid on a short window (#9449)', () => {
+      // The month grid used to be sized from the viewport, so a short window
+      // dropped the tail of the month (a task on Mon 31 Aug 2026 had no cell
+      // and therefore no events computed at all). Height must not influence it.
       mockLayoutService.selectedTimeView.set('month');
 
-      const daysToShowCount = component['_daysToShowCount']();
+      component['_windowSize'] = signal({ width: 1280, height: 1400 });
+      const onTallWindow = component['_daysToShowCount']();
 
-      // The result must be an integer (whole number of weeks)
-      expect(Number.isInteger(daysToShowCount)).toBe(true);
+      component['_windowSize'] = signal({ width: 1280, height: 500 });
+      const onShortWindow = component['_daysToShowCount']();
 
-      // Must be within the defined bounds
-      expect(daysToShowCount).toBeGreaterThanOrEqual(3); // MIN_WEEKS
-      expect(daysToShowCount).toBeLessThanOrEqual(6); // MAX_WEEKS
+      expect(onShortWindow).toBe(onTallWindow);
+      expect(onShortWindow).toBe(SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS);
     });
   });
 

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -141,28 +141,19 @@ export class ScheduleComponent {
   });
 
   private _daysToShowCount = computed(() => {
-    const size = this._windowSize();
     const selectedView = this._currentTimeViewMode();
-    const width = size.width;
-    const height = size.height;
 
     if (selectedView === 'day') return 1;
 
+    // Month view: a fixed grid of weeks, never a function of the window height.
+    // Deriving the row count from available space used to drop the tail of the
+    // month whenever the window was short (#9449): a month whose 1st falls late
+    // in the week needs 6 rows (Aug 2026 starts on a Saturday), and a day left
+    // out of `daysToShow` gets no events computed at all, so the task vanished
+    // rather than merely being clipped. 6 rows covers every month/firstDayOfWeek
+    // combination and matches the 6 row tracks the grid already reserves.
     if (selectedView === 'month') {
-      const availableHeight = height - SCHEDULE_CONSTANTS.MONTH_VIEW.HEADER_OFFSET;
-      const minHeightPerWeek =
-        width < SCHEDULE_CONSTANTS.BREAKPOINTS.TABLET
-          ? SCHEDULE_CONSTANTS.MONTH_VIEW.MIN_HEIGHT_PER_WEEK_MOBILE
-          : SCHEDULE_CONSTANTS.MONTH_VIEW.MIN_HEIGHT_PER_WEEK_DESKTOP;
-      const maxWeeks = Math.floor(availableHeight / minHeightPerWeek);
-
-      if (maxWeeks < SCHEDULE_CONSTANTS.MONTH_VIEW.MIN_WEEKS) {
-        return SCHEDULE_CONSTANTS.MONTH_VIEW.MIN_WEEKS;
-      } else if (maxWeeks > SCHEDULE_CONSTANTS.MONTH_VIEW.MAX_WEEKS) {
-        return SCHEDULE_CONSTANTS.MONTH_VIEW.MAX_WEEKS;
-      } else {
-        return maxWeeks;
-      }
+      return SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS;
     }
 
     // Week view: always 7 days

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -148,16 +148,9 @@ export class ScheduleComponent {
 
     if (selectedView === 'day') return 1;
 
-    // Month view: a fixed grid of weeks, never a function of the window height.
-    // Deriving the row count from available space used to drop the tail of the
-    // month whenever the window was short (#9449): a month whose 1st falls late
-    // in the week needs 6 rows (Aug 2026 starts on a Saturday), and a day left
-    // out of `daysToShow` gets no events computed at all, so the task vanished
-    // rather than merely being clipped. 6 rows covers every month/firstDayOfWeek
-    // combination and matches the 6 row tracks the grid already reserves.
-    if (selectedView === 'month') {
-      return SCHEDULE_CONSTANTS.MONTH_VIEW.NR_OF_WEEKS;
-    }
+    // Month view derives its own count from the displayed month, in `daysToShow`
+    // below: it needs `selectedDate` and `firstDayOfWeek`, neither of which is
+    // read here.
 
     // Week view: always 7 days
     return 7;
@@ -171,9 +164,16 @@ export class ScheduleComponent {
     this._todayDateStr();
 
     if (selectedView === 'month') {
+      // Rows follow the month, never the window height. Deriving them from
+      // available space is what #9449 was filed for: a day left out of
+      // `daysToShow` gets no events computed at all, so a task on it vanished
+      // rather than merely being clipped. 4-6 rows spans every
+      // month/firstDayOfWeek pair, and `weeksToShow` carries the same number
+      // into the grid's `--nr-of-weeks`, so the tracks follow the days.
+      const firstDayOfWeek = this.firstDayOfWeek();
       return this.scheduleService.getMonthDaysToShow(
-        count,
-        this.firstDayOfWeek(),
+        this.scheduleService.getMonthWeeksToShow(firstDayOfWeek, selectedDate),
+        firstDayOfWeek,
         selectedDate,
       );
     }

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -7,6 +7,7 @@ import {
   ElementRef,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import { fromEvent } from 'rxjs';
 import { select, Store } from '@ngrx/store';
@@ -103,6 +104,8 @@ export class ScheduleComponent {
   toggleCalProvider(providerId: string): void {
     this._hiddenCalendarProviders.toggle(providerId);
   }
+
+  private _scrollWrapper = viewChild<ElementRef<HTMLElement>>('scrollWrapper');
 
   private _currentTimeViewMode = computed(() => this.layoutService.selectedTimeView());
   isMonthView = computed(() => this._currentTimeViewMode() === 'month');
@@ -392,6 +395,19 @@ export class ScheduleComponent {
     this.isHScrolled.set(el.scrollLeft > 0);
   }
 
+  // The month grid is taller than the wrapper on a short window, so a scroll
+  // position carried over from week view clamps to the bottom and opens the
+  // month with its first row above the viewport (#9463 review). scrollTo is
+  // safe here where _scrollAnchorToTop's measured offsets would not be, since
+  // a fixed origin is independent of the warpRoute scale.
+  private _resetScrollWrapper(): void {
+    this._scrollWrapper()?.nativeElement.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: 'instant',
+    });
+  }
+
   // Scroll one of the schedule's time anchors to the top of the scroll-wrapper.
   //
   // The framing (lead above the target, and clearance for the sticky time
@@ -441,6 +457,8 @@ export class ScheduleComponent {
             this.currentTimeRow() !== null ? 'current-time' : 'work-start',
           ),
         );
+      } else {
+        setTimeout(() => this._resetScrollWrapper());
       }
     });
   }


### PR DESCRIPTION
## Problem

Fixes #9449.

A task scheduled for Mon 31 Aug 2026 does not show up in the Schedule month view, and the day is not reachable in the Planner's calendar nav either.

August 2026 starts on a Saturday, so its padded grid needs six week rows. Two places assumed fewer:

**Schedule month view.** `_daysToShowCount` derived the number of week rows from the window height:

```ts
const availableHeight = height - MONTH_VIEW.HEADER_OFFSET;   // 160
const maxWeeks = Math.floor(availableHeight / minHeightPerWeek); // /100 on desktop
// clamped to MIN_WEEKS 3 .. MAX_WEEKS 6
```

That count went straight into `getMonthDaysToShow`, which emits exactly `numberOfWeeks * 7` days from the padded week start with no check that the month's last day is inside the window. Six rows needed a window at least 760px tall, so an ordinary desktop window produced five and the grid stopped at Aug 29/30. `daysToShow` is the only input to the event pipeline, so a day outside the window gets no events computed at all: the task is absent, not merely clipped.

The row tracks follow the rendered count on their own. Since #9623 `ScheduleMonthComponent` binds `[style.--nr-of-weeks]` to `weeksToShow()` on its own host, which shadows the static `6` on the schedule host, and `.month-grid-container` is `grid-template-rows: auto repeat(var(--nr-of-weeks), 1fr)` inside `height: calc(100vh - 120px)`. That is not the whole story, though, and an earlier revision of this description got it wrong. `1fr` is `minmax(auto, 1fr)` and `.month-day-cell` carries `min-height: 80px`, so once the rows stop fitting it is the track *minimum* that sets the grid height rather than the `fr` share, and the grid overflows. Measured at 1280x500: six rows overflow the wrapper by 121px, five by 40, four not at all, a step of exactly 81 (the cell minimum plus the 1px gap). What the old viewport-derived count did was not make cells shorter, it removed days outright.

**Planner calendar nav.** `WEEKS_SHOWN` was hard-coded to 5 while `_shiftToMonth` anchors to the week containing the 1st, so August's expanded grid ran Mon 27 Jul to Sun 30 Aug. Mon 31 Aug had no cell: no task dot, and no way to tap through to that day.

One correction to the report: the day *does* appear in the September grid on both surfaces, as a dimmed `other-month` padding cell, since September 2026 starts on a Tuesday and its grid begins Aug 30/31. So the "missing from September too" part is that dimmed cell not registering rather than a second defect.

## Solution

- Month view row count is derived from the displayed month (`ScheduleService.getMonthWeeksToShow`, `ceil((daysToGoBack + daysInMonth) / 7)`, so 4 to 6) instead of from the viewport. `SCHEDULE_CONSTANTS.MONTH_VIEW` is deleted with the old height math.

  **This is a layout change, and the trade-off is worth stating plainly.** Cells are `1fr` inside a fixed-height grid, so a month needing six rows gets shorter cells than one needing four, and on a short window the grid overflows and scrolls (which is what the scroll reset below is for). Measured at 1280x500 on September 2026, which derives five rows: 35 cells from `2026-08-31` to `2026-10-04`, `scrollHeight` 440 against `clientHeight` 400. What it buys is that no day of the month is ever left out of `daysToShow`, which is the bug: a day outside the window gets no events computed at all, so the task disappears rather than being clipped.
- Removed the now-unused `HEADER_OFFSET`, `MIN_HEIGHT_PER_WEEK_DESKTOP`, `MIN_HEIGHT_PER_WEEK_MOBILE`, `MIN_WEEKS` and `MAX_WEEKS` constants.
- `WEEKS_SHOWN` in the planner calendar nav goes from 5 to 6.

`getMonthDaysToShow` itself is unchanged: its `numberOfWeeks` parameter stays literal, and the caller owns the grid size.

An earlier revision of this PR pinned the count at six and recorded an objection to deriving it: that the row tracks were hard-coded and the `:host[style*='--nr-of-weeks: N']` density rules were dead. Both were true before #9623 and are not now. That commit binds the tracks to `weeksToShow()` and deletes the density rules, so the derived count needed no wiring up, and the pinned six is gone.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Verification

Checked against the running app (`ng serve`, 1280x700 viewport, which is short enough that the old code computed five rows), reading the `data-day` attributes off the rendered month grid:

| | cells | window | August days | has 2026-08-31 |
|---|---|---|---|---|
| before | 35 | 2026-07-27 to 2026-08-30 | 30 of 31 | no |
| after | 42 | 2026-07-27 to 2026-09-06 | 31 of 31 | yes |

I have before/after screenshots of the August 2026 grid (the before one shows the empty sixth row track under the 24-30 row). The template has no screenshot slot so I left them out; happy to post them in a comment.

New tests, each sabotage-verified:

- `schedule.service.spec.ts` — Mon 31 Aug 2026 is present for all seven first-day-of-week values; a 5-week window provably misses it; and every month/first-day-of-week combination across 24 consecutive months contains both the 1st and the last day. Pinning the derived count back to 6 fails 2 of 50.
- `schedule.service.spec.ts` — the derivation itself: 4 for a non-leap February starting on the week's first day, 6 for August 2026, 5 for September 2026; and across 24 months x 7 first-days, the count both reaches the last day of the month and would drop it with one row fewer, so it is pinned from both sides rather than restating the formula.
- `schedule.component.spec.ts` — the month row count is unchanged between a 1400px-tall and a 500px-tall window. Restoring the height-derived count fails it.
- `planner-calendar-nav.component.spec.ts` — August 2026's expanded grid is anchored at Mon 27 Jul and contains Mon 31 Aug; the collapsed strip keeps full-size rows on a viewport that shrinks the expanded grid; and an expanded grid whose box shrinks under it never exceeds the room left. Reverting the clamp fails 1 of 49; reverting the collapsed pin fails 2 of 49.
- `planner-calendar-gesture-handler.spec.ts` — with no room to expand, a drag does not open the grid at all and still writes a usable transform (the interpolation range is 0 there).
- `e2e/tests/schedule/schedule-month-scroll-reset.spec.ts` — entering month view at 1280x500 resets the wrapper. It asserts the grid really overflows first, so it cannot pass vacuously. Deleting the reset branch fails it with `Received: 40`.

One existing test needed repair rather than a behavior change: the expanded panel is taller now, so the snap midpoint moved, and `handle drag > should snap to expanded when dragging down past midpoint` used a literal 100px drag that landed exactly on the new midpoint (the comparison is strict `>`). It now derives its drag distance from the geometry; I confirmed it still fails when the drag is below the midpoint.

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki) — no user-facing behavior change beyond the bug itself
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass — full suite 14645 green, 0 failing (14631 on the `America/Los_Angeles` run); schedule e2e 8/8, planner e2e 24/24
- [x] My commit messages follow the Angular format (`type(scope): description`)


