### PR TITLE
Fix schedule dialog layout on small phones (360–390px)

### DIFF
--- a/e2e/tests/planner/schedule-dialog-small-viewport.spec.ts
+++ b/e2e/tests/planner/schedule-dialog-small-viewport.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import { openTaskDetailPanel } from '../../utils/schedule-task-helper';
+
+// Regression test for the schedule dialog on small phones (e.g. 360–390px wide):
+// - mat-calendar's min-height used to transfer through its aspect-ratio into a
+//   ~400px intrinsic width, forcing horizontal scrolling inside the dialog.
+// - The Cancel/Unschedule/Schedule action row used to wrap onto a second row.
+test.use({ viewport: { width: 372, height: 800 } });
+
+const SCHEDULE_DIALOG = 'dialog-schedule-task';
+const DETAIL_PANEL_SCHEDULE_ITEM =
+  'task-detail-item:has(mat-icon:text("alarm")), ' +
+  'task-detail-item:has(mat-icon:text("today")), ' +
+  'task-detail-item:has(mat-icon:text("schedule"))';
+
+test.describe('schedule dialog on a small viewport', () => {
+  test('fits without horizontal scroll and keeps action buttons on one row', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const title = `${testPrefix}-small-screen`;
+    // Mobile layout: use the bottom-nav FAB to open the add task bar
+    await page.locator('mobile-bottom-nav .add-task-button').click();
+    const input = page.locator('add-task-bar .main-input').first();
+    await input.waitFor({ state: 'visible' });
+    await input.fill(title);
+    await input.press('Enter');
+    await page.keyboard.press('Escape');
+    const task = page.locator(`task:has-text("${title}")`).first();
+    await task.waitFor({ state: 'visible' });
+
+    // Schedule the task with a time so the dialog shows all three action
+    // buttons (Cancel / Unschedule / Schedule) when reopened.
+    await openTaskDetailPanel(page, task);
+    const scheduleItem = page.locator(DETAIL_PANEL_SCHEDULE_ITEM).first();
+    await scheduleItem.click();
+    const dialog = page.locator(SCHEDULE_DIALOG);
+    await dialog.waitFor({ state: 'visible' });
+    const timeInput = page.locator(`${SCHEDULE_DIALOG} input[type="time"]`);
+    await timeInput.fill('23:00');
+    await page.locator('[data-test-id="schedule-submit-btn"]').click();
+    await dialog.waitFor({ state: 'hidden' });
+
+    await page.locator(DETAIL_PANEL_SCHEDULE_ITEM).first().click();
+    await dialog.waitFor({ state: 'visible' });
+    // Let the dialog's open animation finish — getBoundingClientRect is scaled
+    // down while the MDC dialog scale-in transform is still running.
+    await page.waitForTimeout(500);
+
+    const metrics = await dialog.evaluate((dialogEl) => {
+      const content = dialogEl.querySelector('mat-dialog-content');
+      const cal = dialogEl.querySelector('mat-calendar');
+      const btns = Array.from(
+        dialogEl.querySelectorAll('mat-dialog-actions button'),
+      ) as HTMLElement[];
+      return {
+        contentClientW: content?.clientWidth ?? 0,
+        contentScrollW: content?.scrollWidth ?? 0,
+        calRight: cal?.getBoundingClientRect().right ?? 0,
+        calHeight: cal?.getBoundingClientRect().height ?? 0,
+        btnTops: btns.map((b) => b.getBoundingClientRect().top),
+        windowW: window.innerWidth,
+      };
+    });
+
+    // No horizontal overflow inside the dialog
+    expect(metrics.contentScrollW).toBeLessThanOrEqual(metrics.contentClientW + 1);
+    // Calendar (incl. the last weekday column) fits the viewport
+    expect(metrics.calRight).toBeLessThanOrEqual(metrics.windowW);
+    // The 6-row month height reservation is still in place (see #6556, #9452)
+    expect(metrics.calHeight).toBeGreaterThanOrEqual(416);
+    // All three action buttons stay on a single row
+    expect(metrics.btnTops.length).toBe(3);
+    expect(Math.max(...metrics.btnTops) - Math.min(...metrics.btnTops)).toBeLessThan(2);
+  });
+});

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.scss
@@ -38,6 +38,14 @@ mat-dialog-content {
 mat-dialog-actions {
   padding: 0 0 var(--s2) 0 !important;
   row-gap: calc(var(--s) + var(--s-half));
+
+  // On very narrow phones (≤398px) the three action buttons don't fit with
+  // their icons and wrap onto a second row — drop the icons, keep the labels.
+  @include mq(xxxs, max) {
+    button mat-icon {
+      display: none;
+    }
+  }
 }
 
 .dialog-actions-and-warnings {

--- a/src/app/features/tasks/dialog-deadline/dialog-deadline.component.scss
+++ b/src/app/features/tasks/dialog-deadline/dialog-deadline.component.scss
@@ -31,6 +31,14 @@ mat-dialog-content {
 mat-dialog-actions {
   padding: 0 0 var(--s2) 0 !important;
   row-gap: calc(var(--s) + var(--s-half));
+
+  // On very narrow phones (≤398px) the three action buttons don't fit with
+  // their icons and wrap onto a second row — drop the icons, keep the labels.
+  @include mq(xxxs, max) {
+    button mat-icon {
+      display: none;
+    }
+  }
 }
 
 .dialog-actions-and-warnings {

--- a/src/app/ui/datetime-picker/datetime-picker.component.scss
+++ b/src/app/ui/datetime-picker/datetime-picker.component.scss
@@ -58,6 +58,11 @@
       height: auto;
       min-height: 416px;
       aspect-ratio: 25 / 26;
+      // The min-height transfers through the aspect-ratio into a ~400px
+      // intrinsic width, which forces horizontal scrolling in dialogs narrower
+      // than that (360–390px phones). Cap the width; min-height still reserves
+      // the 6-row height on its own.
+      max-width: 100%;
     }
 
     .mat-calendar-header {


### PR DESCRIPTION
## Problem

The schedule dialog (and deadline dialog) had layout issues on very narrow phones (360–390px wide):
1. The `mat-calendar` component's `min-height` combined with `aspect-ratio` created an intrinsic width of ~400px, forcing horizontal scrolling inside the dialog
2. The Cancel/Unschedule/Schedule action buttons wrapped onto a second row due to space constraints

Fixes #6556 and #9452.

## Solution

**CSS changes:**
- Added `max-width: 100%` to `mat-calendar` in `datetime-picker.component.scss` to prevent the aspect-ratio from forcing an intrinsic width wider than the dialog, while preserving the 6-row month height via `min-height`
- Added a media query for `xxxs` (≤398px) viewports in both `dialog-schedule-task.component.scss` and `dialog-deadline.component.scss` to hide button icons on very narrow screens, allowing the three action buttons to fit on a single row with just their text labels

**Test coverage:**
- Added comprehensive E2E regression test (`schedule-dialog-small-viewport.spec.ts`) that verifies:
  - No horizontal overflow inside the dialog
  - Calendar fits within the viewport width
  - The 6-row month height is preserved
  - All three action buttons remain on a single row

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (E2E regression test added)
- [x] Existing tests still pass

https://claude.ai/code/session_01MB1MmwSsubgzpjJJmbawNc