### PR TITLE
fix(gitlab): restore finish-day worklog dialog

### DIFF
--- a/src/app/features/issue/providers/gitlab/gitlab-issue.effects.spec.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-issue.effects.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
+import { BeforeFinishDayAction } from '../../../before-finish-day/before-finish-day.model';
+import { BeforeFinishDayService } from '../../../before-finish-day/before-finish-day.service';
+import { DateService } from '../../../../core/date/date.service';
+import { DEFAULT_TASK, Task } from '../../../tasks/task.model';
+import { selectAllTasksInActiveProjects } from '../../../tasks/store/task.selectors';
+import { IssueProviderService } from '../../issue-provider.service';
+import { GITLAB_TYPE } from '../../issue.const';
+import { DEFAULT_GITLAB_CFG } from './gitlab.const';
+import { GitlabIssueEffects } from './gitlab-issue.effects';
+
+const DAY = '2026-08-06';
+const PREVIOUS_DAY = '2026-08-05';
+
+describe('GitlabIssueEffects', () => {
+  let store: MockStore;
+  let beforeFinishDayAction: BeforeFinishDayAction;
+  let matDialog: jasmine.SpyObj<MatDialog>;
+  let dateService: jasmine.SpyObj<DateService>;
+
+  const createTask = (id: string, partial: Partial<Task> = {}): Task => ({
+    ...DEFAULT_TASK,
+    id,
+    title: `Task ${id}`,
+    projectId: 'project-1',
+    created: Date.now(),
+    ...partial,
+  });
+
+  beforeEach(() => {
+    matDialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+    matDialog.open.and.returnValue({
+      afterClosed: () => of(undefined),
+    } as ReturnType<MatDialog['open']>);
+    dateService = jasmine.createSpyObj<DateService>('DateService', ['todayStr']);
+    dateService.todayStr.and.returnValue(DAY);
+
+    const beforeFinishDayService = jasmine.createSpyObj<BeforeFinishDayService>(
+      'BeforeFinishDayService',
+      ['addAction'],
+    );
+    beforeFinishDayService.addAction.and.callFake((action) => {
+      beforeFinishDayAction = action;
+    });
+
+    const issueProviderService = jasmine.createSpyObj<IssueProviderService>(
+      'IssueProviderService',
+      ['getCfgOnce$'],
+    );
+    issueProviderService.getCfgOnce$.and.returnValue(
+      of({
+        ...DEFAULT_GITLAB_CFG,
+        id: 'gitlab-provider',
+        issueProviderKey: 'GITLAB',
+        isEnabled: true,
+        isEnableTimeTracking: true,
+      }),
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        GitlabIssueEffects,
+        provideMockStore({
+          selectors: [{ selector: selectAllTasksInActiveProjects, value: [] }],
+        }),
+        { provide: MatDialog, useValue: matDialog },
+        { provide: BeforeFinishDayService, useValue: beforeFinishDayService },
+        { provide: IssueProviderService, useValue: issueProviderService },
+        { provide: DateService, useValue: dateService },
+      ],
+    });
+
+    store = TestBed.inject(MockStore);
+    TestBed.inject(GitlabIssueEffects);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+  });
+
+  it('includes GitLab tasks outside the active context when finishing the day', async () => {
+    const gitlabTask = createTask('gitlab-task', {
+      issueType: GITLAB_TYPE,
+      issueId: '42',
+      issueProviderId: 'gitlab-provider',
+      timeSpentOnDay: { [DAY]: 60000 },
+    });
+    store.overrideSelector(selectAllTasksInActiveProjects, [gitlabTask]);
+    store.refreshState();
+
+    await beforeFinishDayAction();
+
+    expect(matDialog.open).toHaveBeenCalledWith(
+      jasmine.any(Function),
+      jasmine.objectContaining({
+        data: jasmine.objectContaining({
+          issueProviderId: 'gitlab-provider',
+          tasksForIssueProvider: [gitlabTask],
+        }),
+      }),
+    );
+  });
+
+  it('excludes GitLab tasks without time tracked today', async () => {
+    const oldGitlabTask = createTask('old-gitlab-task', {
+      issueType: GITLAB_TYPE,
+      issueId: '43',
+      issueProviderId: 'gitlab-provider',
+      timeSpentOnDay: { [PREVIOUS_DAY]: 60000 },
+    });
+    store.overrideSelector(selectAllTasksInActiveProjects, [oldGitlabTask]);
+    store.refreshState();
+
+    await beforeFinishDayAction();
+
+    expect(matDialog.open).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/features/issue/providers/gitlab/gitlab-issue.effects.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-issue.effects.ts
@@ -5,22 +5,30 @@ import { GITLAB_TYPE } from '../../issue.const';
 import { IssueProviderService } from '../../issue-provider.service';
 import { TaskCopy } from '../../../tasks/task.model';
 import { BeforeFinishDayService } from '../../../before-finish-day/before-finish-day.service';
-import { WorkContextService } from '../../../work-context/work-context.service';
+import { Store } from '@ngrx/store';
+import { selectAllTasksInActiveProjects } from '../../../tasks/store/task.selectors';
+import { DateService } from '../../../../core/date/date.service';
 
 @Injectable()
 export class GitlabIssueEffects {
   private readonly _matDialog = inject(MatDialog);
   private readonly _beforeFinishDayService = inject(BeforeFinishDayService);
-  private readonly _workContextService = inject(WorkContextService);
+  private readonly _store = inject(Store);
   private readonly _issueProviderService = inject(IssueProviderService);
+  private readonly _dateService = inject(DateService);
 
   constructor() {
     this._beforeFinishDayService.addAction(async () => {
-      const tasksForCurrentList =
-        await this._workContextService.allTasksForCurrentContext$
-          .pipe(first())
-          .toPromise();
-      const gitlabTasks = tasksForCurrentList.filter((t) => t.issueType === GITLAB_TYPE);
+      // The Today summary includes worked-on tasks from every context, including tasks
+      // that the user has configured not to auto-add to Today.
+      const todayStr = this._dateService.todayStr();
+      const tasks = await this._store
+        .select(selectAllTasksInActiveProjects)
+        .pipe(first())
+        .toPromise();
+      const gitlabTasks = tasks.filter(
+        (t) => t.issueType === GITLAB_TYPE && (t.timeSpentOnDay?.[todayStr] ?? 0) > 0,
+      );
       if (gitlabTasks.length > 0) {
         // sort gitlab tasks by issueProviderId
         const gitlabTasksByIssueProviderId: { [key: string]: TaskCopy[] } =


### PR DESCRIPTION
## Problem

Fixes #9466.

Since v18.16, worked-on tasks can correctly remain outside the Today list when automatic adding is disabled or they already have another due date. The GitLab Finish Day hook only inspected the active context list, so it missed those tasks even though the Today summary includes their tracked time. With no qualifying GitLab task found, the worklog dialog did not open.

## Solution

Read tasks across active projects, then limit the dialog input to GitLab tasks with positive tracked time on the app's logical current day. The date comes from `DateService.todayStr()`, so the configured start-of-next-day offset is respected. This restores tasks outside the active context without including archived-project tasks or old untouched worklogs.

Added positive coverage for a qualifying GitLab task outside the active context and negative coverage ensuring a task with only previous-day time does not open the dialog.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Verification

- `npm run checkFile` on both changed TypeScript files
- Focused effect suite: 2 tests passed
- Full default-timezone application suite: 14,062 tests passed, 2 skipped
- Full Los Angeles timezone suite: 14,048 tests passed, 16 skipped
- Package suites: 765 tests passed with type checks
- Repository lint and release-note/tooling tests passed
- Production frontend build and all 23 package builds passed during the initial verification

## Checklist

- [x] Documentation is not needed because this restores the existing Finish Day behavior
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes
- [x] Existing relevant tests pass
- [x] My commit messages follow the Angular format (`type(scope): description`)