### PR TITLE
fix(calendar): prevent deleted events from reappearing

### DIFF
--- a/docs/wiki/3.07-Issue-Integration-Comparison.md
+++ b/docs/wiki/3.07-Issue-Integration-Comparison.md
@@ -101,7 +101,9 @@ Every issue provider supports the same basic operations: checking that the integ
 - **Issue import:** Calendar events (VEVENT) from iCal URLs. Events appear in the Schedule/Planner; event description becomes the task note. **Completion and time/date changes are not synced back**—the feed is read-only from the app’s perspective; if you change the task in the app, the external calendar is not updated.
 - **Status transitions / Worklog / Comments / Subtasks / Attachments:** Not supported.
 - **Filtering:** Text-based search in event titles. Calendar provider settings can also apply optional case-insensitive include and exclude regular expressions to event titles. The include filter acts as an allowlist; the exclude filter is applied afterward.
-- **Auto-import:** Current day events.
+- **Auto-import:** Current day events. Deleting an auto-imported event task keeps
+  that event from being imported again; using **Undo** restores both the task and
+  its auto-import eligibility.
 - **Time estimates:** Event duration used as task time estimate.
 - **Due dates:** Event start time (all-day or timed).
 - **Descriptions:** Event description as task notes.

--- a/e2e/tests/calendar/deleted-calendar-task-no-reimport.spec.ts
+++ b/e2e/tests/calendar/deleted-calendar-task-no-reimport.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Live repro for https://github.com/super-productivity/super-productivity/issues/5162
+ *
+ * Deleting a calendar event task that was auto-imported (`isAutoImportForCurrentDay`)
+ * must stick: the next auto-import pass (here: an app restart, which re-runs the
+ * poll effect immediately) must NOT re-create the task.
+ *
+ * The iCal feed is stubbed via page.route so the test is hermetic.
+ *
+ * Discriminating end state after delete + reload:
+ * - WITH the fix: the event is import-dismissed but still renders as a read-only
+ *   calendar chip in the Schedule (dismissal only gates auto-import, not the view),
+ *   and no task exists for it.
+ * - WITHOUT the fix: the event is re-imported as a task, so the chip is filtered
+ *   out (event id matches an existing task) and the task list contains it again —
+ *   both assertions fail.
+ */
+
+const ICAL_URL = 'https://example.com/sp-5162.ics';
+const EVENT_TITLE = 'E2E-5162 Sprint Planning';
+// Control event TOMORROW that is never imported (auto-import is today-only). It
+// always renders as a calendar chip, giving a positive "calendar finished
+// rendering" anchor that is independent of the event under test.
+const CONTROL_TITLE = 'E2E-5162 Control Tomorrow';
+
+const PANEL_BTN = '.e2e-toggle-issue-provider-panel';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const icalDate = (d: Date): string =>
+  `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(
+    d.getDate(),
+  ).padStart(2, '0')}`;
+
+const buildIcal = (): string => {
+  const now = new Date();
+  const today = icalDate(now);
+  const tomorrow = icalDate(new Date(now.getTime() + ONE_DAY_MS));
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//SP E2E//EN',
+    'BEGIN:VEVENT',
+    `DTSTART:${today}T120000Z`,
+    `DTEND:${today}T130000Z`,
+    `SUMMARY:${EVENT_TITLE}`,
+    'UID:e2e-5162-event',
+    'END:VEVENT',
+    'BEGIN:VEVENT',
+    `DTSTART:${tomorrow}T120000Z`,
+    `DTEND:${tomorrow}T130000Z`,
+    `SUMMARY:${CONTROL_TITLE}`,
+    'UID:e2e-5162-control',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+};
+
+test.describe('Calendar #5162', () => {
+  test('deleted auto-imported calendar task is not re-imported after restart', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await page.route(ICAL_URL, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/calendar',
+        body: buildIcal(),
+      }),
+    );
+
+    await workViewPage.waitForTaskList();
+
+    // --- Configure a calendar provider with auto-import enabled ---
+    await page.waitForSelector(PANEL_BTN, { state: 'visible' });
+    await page.click(PANEL_BTN);
+    await page.waitForSelector('mat-tab-group', { state: 'visible' });
+    await page.click('mat-tab-group .mat-mdc-tab:last-child');
+    await page.waitForSelector('issue-provider-setup-overview', { state: 'visible' });
+
+    await page.getByRole('button', { name: 'Other (iCal)' }).click();
+    const dialog = page.locator('mat-dialog-container');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    await dialog.locator('input[id*="icalUrl"]').fill(ICAL_URL);
+    await dialog.getByRole('checkbox', { name: /auto import events as tasks/i }).check();
+
+    await dialog.locator('button[type="submit"]').click();
+    await expect(dialog).toBeHidden({ timeout: 5000 });
+
+    await page.keyboard.press('Escape');
+
+    // --- The event auto-imports as a task ---
+    const importedTask = taskPage.getTaskByText(EVENT_TITLE);
+    await expect(importedTask).toBeVisible({ timeout: 15000 });
+
+    // --- Delete it (focus + Backspace avoids entering title edit mode) ---
+    await importedTask.focus();
+    await page.keyboard.press('Backspace');
+    const confirmBtn = page.locator('mat-dialog-actions button:has-text("Delete")');
+    const confirmAppeared = await confirmBtn
+      .waitFor({ state: 'visible', timeout: 3000 })
+      .then(() => true)
+      .catch(() => false);
+    if (confirmAppeared) {
+      await confirmBtn.click();
+    }
+    await expect(importedTask).not.toBeVisible({ timeout: 5000 });
+
+    // --- Restart the app: the poll effect re-runs its import pass immediately ---
+    // Importing an event also writes it to the per-day skip list, which filters the
+    // Schedule *view* (not the import). Clear it so the chip assertion below can
+    // discriminate: with the fix the event renders as a chip; without it, the
+    // re-imported task filters the chip out.
+    await page.evaluate(() => {
+      localStorage.removeItem('SUP_CALENDER_EVENTS_SKIPPED_TODAY');
+      localStorage.removeItem('SUP_CALENDER_EVENTS_LAST_SKIP_DAY');
+    });
+    await page.reload();
+    await workViewPage.waitForTaskList();
+
+    // --- The event renders as a calendar chip in the Schedule (NOT a task)… ---
+    await page.goto(page.url().replace(/#.*$/, '') + '#/schedule');
+    await page.waitForSelector('schedule', { state: 'visible', timeout: 10000 });
+    const schedule = page.locator('schedule');
+    await expect(schedule.getByText(CONTROL_TITLE).first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(schedule.getByText(EVENT_TITLE).first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    // --- …and stays out of the task list ---
+    await page.goto(page.url().replace(/#.*$/, '').replace(/\/$/, '') + '#/tag/TODAY');
+    await workViewPage.waitForTaskList();
+    await expect(taskPage.getTaskByText(EVENT_TITLE)).toHaveCount(0);
+  });
+});

--- a/e2e/tests/calendar/deleted-calendar-task-no-reimport.spec.ts
+++ b/e2e/tests/calendar/deleted-calendar-task-no-reimport.spec.ts
@@ -134,7 +134,12 @@ test.describe('Calendar #5162', () => {
     });
 
     // --- …and stays out of the task list ---
-    await page.goto(page.url().replace(/#.*$/, '').replace(/\/$/, '') + '#/tag/TODAY');
+    // Use the canonical work-view route: bare `#/tag/TODAY` matches the lazy
+    // `tag/:id` child routes, which have no empty-path route, and renders an
+    // empty outlet on CI (locally the `**` fallback happens to rescue it).
+    await page.goto(
+      page.url().replace(/#.*$/, '').replace(/\/$/, '') + '#/tag/TODAY/tasks',
+    );
     await workViewPage.waitForTaskList();
     await expect(taskPage.getTaskByText(EVENT_TITLE)).toHaveCount(0);
   });

--- a/src/app/features/calendar-integration/store/calendar-integration.effects.spec.ts
+++ b/src/app/features/calendar-integration/store/calendar-integration.effects.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { BehaviorSubject, of, Subscription } from 'rxjs';
 import { CalendarIntegrationEffects } from './calendar-integration.effects';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
@@ -156,6 +156,9 @@ describe('CalendarIntegrationEffects pollChanges$ startup guard', () => {
 
   afterEach(() => {
     sub?.unsubscribe();
+    // overrideSelector() mutates the globally memoized selector, so without this
+    // every later spec in the Karma run would read this empty task state.
+    TestBed.inject(MockStore).resetSelectors();
   });
 
   it('imports a today event when first sync is done and we are NOT in a sync window', fakeAsync(() => {

--- a/src/app/features/calendar-integration/store/calendar-integration.effects.spec.ts
+++ b/src/app/features/calendar-integration/store/calendar-integration.effects.spec.ts
@@ -16,6 +16,9 @@ import { HydrationStateService } from '../../../op-log/apply/hydration-state.ser
 import { selectCalendarProviders } from '../../issue/store/issue-provider.selectors';
 import { IssueProviderCalendar } from '../../issue/issue.model';
 import { CalendarIntegrationEvent } from '../calendar-integration.model';
+import { selectTaskFeatureState } from '../../tasks/store/task.selectors';
+import { initialTaskState } from '../../tasks/store/task.reducer';
+import { TaskState } from '../../tasks/task.model';
 
 describe('CalendarIntegrationEffects pollChanges$ startup guard', () => {
   let effects: CalendarIntegrationEffects;
@@ -27,6 +30,9 @@ describe('CalendarIntegrationEffects pollChanges$ startup guard', () => {
   let requestEvents$Spy: jasmine.Spy;
   let isInitialSyncDoneSyncSpy: jasmine.Spy;
   let isInSyncWindowSpy: jasmine.Spy;
+  let taskStateForSelector: TaskState & {
+    dismissedCalendarAutoImportEventIdsByProvider?: Record<string, string[]>;
+  };
 
   const PROVIDER_ID = 'ip-cal-1';
 
@@ -80,12 +86,16 @@ describe('CalendarIntegrationEffects pollChanges$ startup guard', () => {
     isInSyncWindowSpy = jasmine.createSpy('isInSyncWindow').and.returnValue(false);
 
     todayDateStr$ = new BehaviorSubject<string>('2026-05-20');
+    taskStateForSelector = { ...initialTaskState };
 
     TestBed.configureTestingModule({
       providers: [
         CalendarIntegrationEffects,
         provideMockStore({
-          selectors: [{ selector: selectCalendarProviders, value: [buildProvider()] }],
+          selectors: [
+            { selector: selectCalendarProviders, value: [buildProvider()] },
+            { selector: selectTaskFeatureState, value: taskStateForSelector },
+          ],
         }),
         {
           provide: GlobalTrackingIntervalService,
@@ -168,6 +178,33 @@ describe('CalendarIntegrationEffects pollChanges$ startup guard', () => {
     );
   }));
 
+  it('does NOT auto-import an event dismissed by deleting its task', fakeAsync(() => {
+    taskStateForSelector.dismissedCalendarAutoImportEventIdsByProvider = {
+      [PROVIDER_ID]: ['legacy-cal-evt-1'],
+    };
+    requestEvents$Spy.and.returnValue(
+      of([buildEvent('cal-evt-1', { legacyIds: ['legacy-cal-evt-1'] })]),
+    );
+
+    sub = effects.pollChanges$.subscribe();
+    tick(0);
+    flush();
+
+    expect(addTaskFromIssueSpy).not.toHaveBeenCalled();
+  }));
+
+  it('keeps calendar event dismissals scoped to their provider', fakeAsync(() => {
+    taskStateForSelector.dismissedCalendarAutoImportEventIdsByProvider = {
+      another_provider: ['cal-evt-1'],
+    };
+
+    sub = effects.pollChanges$.subscribe();
+    tick(0);
+    flush();
+
+    expect(addTaskFromIssueSpy).toHaveBeenCalledTimes(1);
+  }));
+
   it('does NOT import while the initial sync has not completed (cold-start race)', fakeAsync(() => {
     isInitialSyncDoneSyncSpy.and.returnValue(false);
     isInSyncWindowSpy.and.returnValue(false);
@@ -199,6 +236,21 @@ describe('CalendarIntegrationEffects pollChanges$ startup guard', () => {
     // the import loop runs. The second guard inside the tap must catch this.
     getAllIssueIdsSpy.and.callFake(async () => {
       isInSyncWindowSpy.and.returnValue(true);
+      return [];
+    });
+
+    sub = effects.pollChanges$.subscribe();
+    tick(0);
+    flush();
+
+    expect(addTaskFromIssueSpy).not.toHaveBeenCalled();
+  }));
+
+  it('does NOT import if the event is dismissed during the IDB-read await', fakeAsync(() => {
+    getAllIssueIdsSpy.and.callFake(async () => {
+      taskStateForSelector.dismissedCalendarAutoImportEventIdsByProvider = {
+        [PROVIDER_ID]: ['cal-evt-1'],
+      };
       return [];
     });
 

--- a/src/app/features/calendar-integration/store/calendar-integration.effects.ts
+++ b/src/app/features/calendar-integration/store/calendar-integration.effects.ts
@@ -10,7 +10,10 @@ import { CalendarIntegrationEvent } from '../calendar-integration.model';
 import { isCalenderEventDue } from '../is-calender-event-due';
 import { CalendarIntegrationService } from '../calendar-integration.service';
 import { BannerId } from '../../../core/banner/banner.model';
-import { selectTaskByIssueId } from '../../tasks/store/task.selectors';
+import {
+  selectTaskByIssueId,
+  selectTaskFeatureState,
+} from '../../tasks/store/task.selectors';
 import { NavigateToTaskService } from '../../../core-ui/navigate-to-task/navigate-to-task.service';
 import { T } from '../../../t.const';
 import { isValidUrl } from '../../../util/is-valid-url';
@@ -50,6 +53,7 @@ export class CalendarIntegrationEffects {
   private _translateStore = inject(TranslateStore);
   private _syncTriggerService = inject(SyncTriggerService);
   private _hydrationStateService = inject(HydrationStateService);
+  private _taskState = this._store.selectSignal(selectTaskFeatureState);
 
   /**
    * Poll external calendar providers for events and auto-import them as tasks.
@@ -122,6 +126,12 @@ export class CalendarIntegrationEffects {
                         // during the await (e.g. tab resume → openSyncWindow()),
                         // and importing now would still emit a duplicate CRT op.
                         if (!this._hydrationStateService.isInSyncWindow()) {
+                          const dismissedIdsByProvider =
+                            this._taskState()
+                              .dismissedCalendarAutoImportEventIdsByProvider;
+                          const dismissedEventIds = new Set(
+                            dismissedIdsByProvider?.[calProvider.id] ?? [],
+                          );
                           allEventsToday.forEach((calEv) => {
                             if (
                               passesCalendarEventRegexFilter(
@@ -130,7 +140,10 @@ export class CalendarIntegrationEffects {
                                 calProvider.filterExcludeRegex,
                               ) &&
                               this._dateService.isToday(calEv.start) &&
-                              !matchesAnyCalendarEventId(calEv, allIssueIds)
+                              !matchesAnyCalendarEventId(calEv, allIssueIds) &&
+                              !getCalendarEventIdCandidates(calEv).some((id) =>
+                                dismissedEventIds.has(id),
+                              )
                             ) {
                               this._issueService.addTaskFromIssue({
                                 issueProviderKey:

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1130,6 +1130,23 @@ describe('Task Reducer', () => {
   // -----------------------------------------------------------------------
 
   describe('loadAllData - timeSpentOnDay normalization', () => {
+    it('should default calendar event dismissals missing from older persisted state', () => {
+      const appDataComplete = {
+        task: {
+          ids: [],
+          entities: {},
+          currentTaskId: null,
+          selectedTaskId: null,
+          lastCurrentTaskId: null,
+          isDataLoaded: false,
+        },
+      } as any;
+
+      const result = taskReducer(initialTaskState, loadAllData({ appDataComplete }));
+
+      expect(result.dismissedCalendarAutoImportEventIdsByProvider).toEqual({});
+    });
+
     it('should normalize tasks with undefined timeSpentOnDay to {} on load', () => {
       const taskWithUndefined = createTask('t1', { timeSpentOnDay: undefined as any });
       const appDataComplete = {

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -171,6 +171,7 @@ export const initialTaskState: TaskState = taskAdapter.getInitialState({
   taskDetailTargetPanel: TaskDetailTargetPanel.Default,
   lastCurrentTaskId: null,
   isDataLoaded: false,
+  dismissedCalendarAutoImportEventIdsByProvider: {},
 }) as TaskState;
 
 export const taskReducer = createReducer<TaskState>(
@@ -197,6 +198,8 @@ export const taskReducer = createReducer<TaskState>(
         selectedTaskId: null,
         lastCurrentTaskId: task.currentTaskId,
         isDataLoaded: true,
+        dismissedCalendarAutoImportEventIdsByProvider:
+          sanitized.dismissedCalendarAutoImportEventIdsByProvider ?? {},
       } as TaskState),
     );
   }),

--- a/src/app/features/tasks/task.model.ts
+++ b/src/app/features/tasks/task.model.ts
@@ -224,6 +224,17 @@ export interface TaskState extends EntityState<Task> {
   taskDetailTargetPanel?: TaskDetailTargetPanel | null;
   lastCurrentTaskId: string | null;
   isDataLoaded: boolean;
+  /**
+   * iCal event IDs whose imported tasks were explicitly deleted, scoped by provider.
+   * Optional because persisted task state from older versions does not contain it.
+   * Provider deletion intentionally does not prune this commutative tombstone set:
+   * concurrent provider/task deletes must converge regardless of replay order.
+   * shortcut: grow-only — entries carry no timestamp, so nothing can age them out
+   * deterministically (deleting a daily recurring occurrence every day adds ~250
+   * entries/year; non-recurring dismissals stay relevant forever). If growth ever
+   * matters, record the dismissal day in the delete op payload and prune on replay.
+   */
+  dismissedCalendarAutoImportEventIdsByProvider?: Record<string, string[]>;
 }
 
 export interface WorklogTask extends Task {

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -466,6 +466,9 @@ describe('OperationLogUploadService', () => {
           actionPayload: {
             taskIds: ['task-1'],
             tasks: [{ id: 'task-1', title: 'local recovery snapshot' }],
+            calendarAutoImportDismissals: [
+              { issueProviderId: 'calendar-1', issueId: 'event-1' },
+            ],
           },
           entityChanges: [],
         };
@@ -480,13 +483,21 @@ describe('OperationLogUploadService', () => {
 
         const uploadedOps = mockApiProvider.uploadOps.calls.mostRecent().args[0];
         expect(uploadedOps[0].payload).toEqual({
-          actionPayload: { taskIds: ['task-1'] },
+          actionPayload: {
+            taskIds: ['task-1'],
+            calendarAutoImportDismissals: [
+              { issueProviderId: 'calendar-1', issueId: 'event-1' },
+            ],
+          },
           entityChanges: [],
         });
         expect(entry.op.payload).toEqual({
           actionPayload: {
             taskIds: ['task-1'],
             tasks: [{ id: 'task-1', title: 'local recovery snapshot' }],
+            calendarAutoImportDismissals: [
+              { issueProviderId: 'calendar-1', issueId: 'event-1' },
+            ],
           },
           entityChanges: [],
         });

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
@@ -1011,6 +1011,25 @@ describe('taskSharedCrudMetaReducer', () => {
       );
     });
 
+    it('should dismiss a deleted iCal event from future auto-imports', () => {
+      const testState = createStateWithExistingTasks(['task1'], [], [], []);
+      const action = createDeleteAction({
+        issueType: 'ICAL',
+        issueProviderId: 'calendar-provider',
+        issueId: 'calendar-event',
+      });
+
+      metaReducer(testState, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0];
+      const taskState = updatedState[TASK_FEATURE_NAME] as unknown as {
+        dismissedCalendarAutoImportEventIdsByProvider?: Record<string, string[]>;
+      };
+      expect(taskState.dismissedCalendarAutoImportEventIdsByProvider).toEqual({
+        'calendar-provider': ['calendar-event'],
+      });
+    });
+
     it('should handle task with subtasks removal from tags', () => {
       const testState = createStateWithExistingTasks(
         [],
@@ -1146,6 +1165,58 @@ describe('taskSharedCrudMetaReducer', () => {
         mockReducer,
         testState,
       );
+    });
+
+    it('should carry and apply iCal dismissals for deterministic remote replay', () => {
+      const calendarTask = createMockTask({
+        id: 'task1',
+        issueType: 'ICAL',
+        issueProviderId: 'calendar-provider',
+        issueId: 'calendar-event',
+      });
+      const action = TaskSharedActions.deleteTasks({
+        taskIds: ['task1'],
+        tasks: [calendarTask],
+      });
+
+      expect(
+        (
+          action as unknown as {
+            calendarAutoImportDismissals?: {
+              issueProviderId: string;
+              issueId: string;
+            }[];
+          }
+        ).calendarAutoImportDismissals,
+      ).toEqual([{ issueProviderId: 'calendar-provider', issueId: 'calendar-event' }]);
+
+      const remoteAction = {
+        type: action.type,
+        taskIds: action.taskIds,
+        calendarAutoImportDismissals: action.calendarAutoImportDismissals,
+        meta: action.meta,
+      };
+      metaReducer(createBaseState(), remoteAction);
+      const updatedState = mockReducer.calls.mostRecent().args[0];
+      const taskState = updatedState[TASK_FEATURE_NAME] as unknown as {
+        dismissedCalendarAutoImportEventIdsByProvider?: Record<string, string[]>;
+      };
+      expect(taskState.dismissedCalendarAutoImportEventIdsByProvider).toEqual({
+        'calendar-provider': ['calendar-event'],
+      });
+    });
+
+    it('should ignore malformed calendar dismissal markers during remote replay', () => {
+      const action = {
+        ...TaskSharedActions.deleteTasks({ taskIds: ['missing-task'] }),
+        calendarAutoImportDismissals: [
+          null,
+          { issueProviderId: 'calendar-provider' },
+          { issueProviderId: 123, issueId: 'calendar-event' },
+        ],
+      } as unknown as Action;
+
+      expect(() => metaReducer(createBaseState(), action)).not.toThrow();
     });
 
     it('should preserve currentTaskId when not in deleted tasks', () => {
@@ -2634,6 +2705,34 @@ describe('taskSharedCrudMetaReducer', () => {
       expect(restoredTask).toBeDefined();
       expect(restoredTask.modified).toBeGreaterThanOrEqual(beforeRestore);
       expect(restoredTask.modified).not.toEqual(oldTimestamp);
+    });
+
+    it('should undo the calendar event dismissal when restoring a deleted task', () => {
+      const testState = createBaseState();
+      testState[TASK_FEATURE_NAME] = {
+        ...testState[TASK_FEATURE_NAME],
+        dismissedCalendarAutoImportEventIdsByProvider: {
+          'calendar-provider': ['calendar-event'],
+        },
+      } as (typeof testState)[typeof TASK_FEATURE_NAME];
+      const calendarTask = createMockTask({
+        id: 'calendar-task',
+        issueType: 'ICAL',
+        issueProviderId: 'calendar-provider',
+        issueId: 'calendar-event',
+      });
+      const action = createRestoreAction({
+        taskOverrides: calendarTask,
+        deletedTaskEntities: { 'calendar-task': calendarTask },
+      });
+
+      metaReducer(testState, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0];
+      const taskState = updatedState[TASK_FEATURE_NAME] as unknown as {
+        dismissedCalendarAutoImportEventIdsByProvider?: Record<string, string[]>;
+      };
+      expect(taskState.dismissedCalendarAutoImportEventIdsByProvider).toEqual({});
     });
 
     it('should restore task to project taskIds', () => {

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -1,7 +1,11 @@
 import { Action, ActionReducer, MetaReducer } from '@ngrx/store';
 import { Update } from '@ngrx/entity';
 import { RootState } from '../../root-state';
-import { TaskSharedActions } from '../task-shared.actions';
+import {
+  CalendarAutoImportDismissal,
+  getCalendarAutoImportDismissals,
+  TaskSharedActions,
+} from '../task-shared.actions';
 import {
   PROJECT_FEATURE_NAME,
   projectAdapter,
@@ -21,7 +25,12 @@ import {
 } from '../../../features/tasks/store/task.reducer.util';
 import { Tag } from '../../../features/tag/tag.model';
 import { Project } from '../../../features/project/project.model';
-import { DEFAULT_TASK, Task, TaskWithSubTasks } from '../../../features/tasks/task.model';
+import {
+  DEFAULT_TASK,
+  Task,
+  TaskState,
+  TaskWithSubTasks,
+} from '../../../features/tasks/task.model';
 import { calcTotalTimeSpent } from '../../../features/tasks/util/calc-total-time-spent';
 import { IN_PROGRESS_TAG, TODAY_TAG } from '../../../features/tag/tag.const';
 import { unique } from '../../../util/unique';
@@ -323,24 +332,76 @@ const handleConvertToSubTask = (
   };
 };
 
-const handleDeleteTask = (
-  state: RootState,
-  task: {
-    id: string;
-    projectId?: string | null;
-    tagIds: string[];
-    subTasks?: Task[];
-    subTaskIds?: string[];
-  },
-): RootState => {
+const updateCalendarAutoImportDismissals = (
+  taskState: TaskState,
+  dismissals: unknown,
+  isDismissed: boolean,
+): TaskState => {
+  const validDismissals = Array.isArray(dismissals)
+    ? dismissals.filter(
+        (dismissal): dismissal is CalendarAutoImportDismissal =>
+          typeof dismissal === 'object' &&
+          dismissal !== null &&
+          typeof dismissal.issueProviderId === 'string' &&
+          dismissal.issueProviderId.length > 0 &&
+          typeof dismissal.issueId === 'string' &&
+          dismissal.issueId.length > 0,
+      )
+    : [];
+  if (validDismissals.length === 0) return taskState;
+
+  let dismissedByProvider = {
+    ...(taskState.dismissedCalendarAutoImportEventIdsByProvider ?? {}),
+  };
+  let hasChanged = false;
+
+  validDismissals.forEach(({ issueProviderId, issueId }) => {
+    const currentIds = Object.hasOwn(dismissedByProvider, issueProviderId)
+      ? (dismissedByProvider[issueProviderId] ?? [])
+      : [];
+    if (isDismissed) {
+      if (!currentIds.includes(issueId)) {
+        dismissedByProvider = {
+          ...dismissedByProvider,
+          [issueProviderId]: [...currentIds, issueId].sort(),
+        };
+        hasChanged = true;
+      }
+      return;
+    }
+
+    if (currentIds.includes(issueId)) {
+      const remainingIds = currentIds.filter((id) => id !== issueId);
+      if (remainingIds.length > 0) {
+        dismissedByProvider = {
+          ...dismissedByProvider,
+          [issueProviderId]: remainingIds,
+        };
+      } else {
+        Reflect.deleteProperty(dismissedByProvider, issueProviderId);
+      }
+      hasChanged = true;
+    }
+  });
+
+  return hasChanged
+    ? {
+        ...taskState,
+        dismissedCalendarAutoImportEventIdsByProvider: dismissedByProvider,
+      }
+    : taskState;
+};
+
+const handleDeleteTask = (state: RootState, task: TaskWithSubTasks): RootState => {
   let updatedState = state;
 
   // Delete task from task state using helper
   updatedState = {
     ...updatedState,
-    [TASK_FEATURE_NAME]: deleteTaskHelper(
-      updatedState[TASK_FEATURE_NAME],
-      task as TaskWithSubTasks,
+    [TASK_FEATURE_NAME]: updateCalendarAutoImportDismissals(
+      deleteTaskHelper(updatedState[TASK_FEATURE_NAME], task),
+      getCalendarAutoImportDismissals([task, ...(task.subTasks ?? [])]),
+      true,
     ),
   };
 
@@ -359,7 +420,11 @@ const handleDeleteTask = (
   return removeTasksFromAllTags(updatedState, [task.id, ...(task.subTaskIds || [])]);
 };
 
-const handleDeleteTasks = (state: RootState, taskIds: string[]): RootState => {
+const handleDeleteTasks = (
+  state: RootState,
+  taskIds: string[],
+  capturedCalendarAutoImportDismissals: unknown = [],
+): RootState => {
   let updatedState = state;
 
   // Get all task IDs including subtasks, and collect project associations
@@ -376,16 +441,36 @@ const handleDeleteTasks = (state: RootState, taskIds: string[]): RootState => {
   }, []);
 
   // Remove tasks from task state
-  const newTaskState = taskAdapter.removeMany(allIds, updatedState[TASK_FEATURE_NAME]);
+  let newTaskState = taskAdapter.removeMany(allIds, updatedState[TASK_FEATURE_NAME]);
+  newTaskState = {
+    ...newTaskState,
+    currentTaskId:
+      newTaskState.currentTaskId && taskIds.includes(newTaskState.currentTaskId)
+        ? null
+        : newTaskState.currentTaskId,
+  };
+  // Dismissals apply from two sources: the captured action payload (kept when the
+  // upload sanitizer strips the heavy `tasks` snapshots, so remote replay is
+  // deterministic) and a state-derived fallback that backfills ops from old
+  // clients and callers that pass no task snapshots.
+  newTaskState = updateCalendarAutoImportDismissals(
+    newTaskState,
+    capturedCalendarAutoImportDismissals,
+    true,
+  );
+  const stateCalendarAutoImportDismissals = getCalendarAutoImportDismissals(
+    allIds
+      .map((id) => state[TASK_FEATURE_NAME].entities[id])
+      .filter((task): task is Task => !!task),
+  );
+  newTaskState = updateCalendarAutoImportDismissals(
+    newTaskState,
+    stateCalendarAutoImportDismissals,
+    true,
+  );
   updatedState = {
     ...updatedState,
-    [TASK_FEATURE_NAME]: {
-      ...newTaskState,
-      currentTaskId:
-        newTaskState.currentTaskId && taskIds.includes(newTaskState.currentTaskId)
-          ? null
-          : newTaskState.currentTaskId,
-    },
+    [TASK_FEATURE_NAME]: newTaskState,
   };
 
   // Clean up projects - remove task IDs from all affected projects
@@ -485,6 +570,14 @@ const handleRestoreDeletedTask = (
     [TASK_FEATURE_NAME]: taskAdapter.addMany(
       tasksToRestore,
       updatedState[TASK_FEATURE_NAME],
+    ),
+  };
+  updatedState = {
+    ...updatedState,
+    [TASK_FEATURE_NAME]: updateCalendarAutoImportDismissals(
+      updatedState[TASK_FEATURE_NAME],
+      getCalendarAutoImportDismissals(tasksToRestore),
+      false,
     ),
   };
 
@@ -943,8 +1036,10 @@ const createActionHandlers = (state: RootState, action: Action): ActionHandlerMa
     return handleDeleteTask(state, task);
   },
   [TaskSharedActions.deleteTasks.type]: () => {
-    const { taskIds } = action as ReturnType<typeof TaskSharedActions.deleteTasks>;
-    return handleDeleteTasks(state, taskIds);
+    const { taskIds, calendarAutoImportDismissals } = action as ReturnType<
+      typeof TaskSharedActions.deleteTasks
+    >;
+    return handleDeleteTasks(state, taskIds, calendarAutoImportDismissals);
   },
   [TaskSharedActions.restoreDeletedTask.type]: () => {
     return handleRestoreDeletedTask(

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -17,6 +17,20 @@ import { shouldClearDueTimeForToday } from '../../util/is-today.util';
  */
 export const PROJECT_DELETE_WINS_MARKER = 'projectDeleteWins';
 
+export interface CalendarAutoImportDismissal {
+  issueProviderId: string;
+  issueId: string;
+}
+
+export const getCalendarAutoImportDismissals = (
+  tasks: readonly Task[],
+): CalendarAutoImportDismissal[] =>
+  tasks.flatMap((task) =>
+    task.issueType === 'ICAL' && task.issueProviderId && task.issueId
+      ? [{ issueProviderId: task.issueProviderId, issueId: task.issueId }]
+      : [],
+  );
+
 /**
  * Shared actions that affect multiple reducers (tasks, projects, tags)
  * These actions are handled by the task-shared meta-reducer
@@ -92,16 +106,24 @@ export const TaskSharedActions = createActionGroup({
     // Issue metadata for remote issue deletion still travels through
     // DeletedTaskIssueSidecarService. Task snapshots are persisted separately
     // so a concurrent winning update can recreate an entity after this delete.
-    deleteTasks: (taskProps: { taskIds: string[]; tasks?: Task[] }) => ({
-      ...taskProps,
-      meta: {
-        isPersistent: true,
-        entityType: 'TASK',
-        entityIds: taskProps.taskIds,
-        opType: OpType.Delete,
-        isBulk: true,
-      } satisfies PersistentActionMeta,
-    }),
+    deleteTasks: (taskProps: { taskIds: string[]; tasks?: Task[] }) => {
+      const calendarAutoImportDismissals = getCalendarAutoImportDismissals(
+        taskProps.tasks ?? [],
+      );
+      return {
+        ...taskProps,
+        ...(calendarAutoImportDismissals.length > 0 && {
+          calendarAutoImportDismissals,
+        }),
+        meta: {
+          isPersistent: true,
+          entityType: 'TASK',
+          entityIds: taskProps.taskIds,
+          opType: OpType.Delete,
+          isBulk: true,
+        } satisfies PersistentActionMeta,
+      };
+    },
 
     // TODO rename to `moveTaskToArchive__` to indicate it should not be called directly
     // Note: Full task payload is required for sync reliability.


### PR DESCRIPTION
## Problem

Deleting an auto-imported calendar event task only removes the task — the iCal auto-import poll re-creates it within a minute, because nothing records that the user dismissed the event.

Fixes #5162

## Approach

- Record a provider-scoped tombstone (`dismissedCalendarAutoImportEventIdsByProvider` on `TaskState`) when an iCal event task is deleted, via the existing `deleteTask`/`deleteTasks` meta-reducer path (one user intent = one op).
- The auto-import poll skips events whose ID candidates (incl. `legacyIds`) are dismissed for that provider — mirroring the existing duplicate-suppression semantics.
- **Undo** (`restoreDeletedTask`) clears the dismissal, restoring auto-import eligibility.
- For bulk deletes, the compact dismissal list is captured in the action payload and survives the upload sanitizer (which strips the heavy `tasks` snapshots), so remote replay is deterministic. A state-derived fallback backfills ops from old clients.

## Sync compatibility (no schema bump — rule 10)

- Old clients tolerate both new surfaces: typia `createValidate` accepts the extra state field, and `convertOpToAction` spreads payloads so old reducers ignore `calendarAutoImportDismissals` while still applying the delete. Degrades to status quo (old clients keep re-importing).
- Dismissal set is a commutative, sorted, grow-only set → concurrent deletes/restores converge regardless of replay order. Remote payloads are shape-validated and guarded against `__proto__`/`constructor` keys.

## Known limitations (deliberate)

- **Grow-only tombstone set**: entries carry no timestamp so nothing can prune them deterministically (~250 entries/year if a daily recurring occurrence is deleted every day). Ceiling + upgrade path documented on the model field.
- **Archive deletes bypass the fix**: deleting a same-day event task from the worklog/archive can still re-import it (archive reduction writes the dismissal into the archive slice, which the poll never reads). Rare timing; left out of scope.
- **One reappearance is still possible in a sync race**: a device polling before receiving the delete op re-imports; once the op (with dismissals) propagates, the next delete sticks.
- Project deletion intentionally does not record dismissals (deleting a project ≠ dismissing events); the Schedule-view calendar overlay and the due-banner are unchanged.

## Test plan

- Reducer specs: single delete records dismissal; bulk delete replays deterministically from captured payload; malformed remote markers are ignored; restore clears the dismissal.
- Effects specs: dismissed events are not imported; dismissals are provider-scoped; dismissal arriving during the IDB-read await is honored.
- Upload spec: `tasks` snapshots stripped, dismissal metadata preserved.
- `frozen-state.spec` green (old persisted state without the field hydrates with `{}` default).
- 291 tests across the 5 affected suites pass; `checkFile` clean on all modified files.