### PR TITLE
fix(tasks): keep the global add-task bar above the system navigation bar

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -41,9 +41,9 @@
 // the autocomplete panel rule further down.
 :host-context(.isTouchPrimary).global {
   top: auto;
-  // Keep the action buttons clear of both the keyboard and system navigation.
-  // Capacitor reports a zero bottom safe area while the keyboard is visible.
-  bottom: calc(var(--keyboard-height) + var(--safe-area-bottom) + var(--s2));
+  // Keep the action buttons clear of whichever occupies more space: the
+  // keyboard or system navigation. Mobile browsers may report both at once.
+  bottom: calc(max(var(--keyboard-height), var(--safe-area-bottom)) + var(--s2));
   transition: bottom var(--transition-duration-m) ease-out;
 }
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -41,8 +41,18 @@
 // the autocomplete panel rule further down.
 :host-context(.isTouchPrimary).global {
   top: auto;
-  // Keep the action buttons clear of whichever occupies more space: the
-  // keyboard or system navigation. Mobile browsers may report both at once.
+  // Clear whichever bottom obstruction is taller — the keyboard or the system
+  // navigation bar (#9462) — never their sum: where `--keyboard-height` is set
+  // it measures the obscured slice of the viewport, and the IME spans to the
+  // screen edge with the nav bar drawn over it, so the inset is already inside
+  // that number. In practice each platform reports only one of the two anyway
+  // (the Capacitor build zeroes the bottom inset while the IME is up — see
+  // SystemBars.calcSafeAreaInsets — and mobile web never writes
+  // `--keyboard-height` at all: its tracker is gated on IS_TOUCH_ONLY, which
+  // Android Chrome fails, and its keyboard shrinks the layout viewport instead,
+  // #9277), so max() just picks out whichever term is live on the platform at
+  // hand. `--s2` rather than `--s`, which leaves the buttons flush against the
+  // obstruction and awkward to tap.
   bottom: calc(max(var(--keyboard-height), var(--safe-area-bottom)) + var(--s2));
   transition: bottom var(--transition-duration-m) ease-out;
 }
@@ -50,6 +60,14 @@
 // Capacitor's native iOS mode shrinks the WebView around the keyboard. Only
 // apply an additional offset when the keyboard still overlays that viewport;
 // using its full height here would move the fixed bar twice (#8778).
+//
+// Deliberately no `--safe-area-bottom` here, unlike the rule above: on iOS the
+// inset comes from capacitor-plugin-safe-area, which reads the window insets and
+// re-reads them on orientation change only — so it keeps reporting the home
+// indicator while the keyboard is up. Folding it in (even via max()) would float
+// the bar an indicator's height above the keyboard in the common case. Clearing
+// the indicator while the bar is open *without* a keyboard therefore needs a
+// rule gated on `body.isKeyboardVisible`, not a wider max().
 :host-context(.isTouchPrimary.isIOS).global {
   bottom: calc(var(--keyboard-overlay-offset) + var(--s2));
 }

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -41,9 +41,9 @@
 // the autocomplete panel rule further down.
 :host-context(.isTouchPrimary).global {
   top: auto;
-  // Extra gap above the keyboard so the bottom action buttons stay easy to
-  // tap — `--s` alone leaves them flush against the IME's top edge.
-  bottom: calc(var(--keyboard-height) + var(--s2));
+  // Keep the action buttons clear of both the keyboard and system navigation.
+  // Capacitor reports a zero bottom safe area while the keyboard is visible.
+  bottom: calc(var(--keyboard-height) + var(--safe-area-bottom) + var(--s2));
   transition: bottom var(--transition-duration-m) ease-out;
 }
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -339,6 +339,8 @@ describe('AddTaskBarComponent', () => {
       document.body.classList.remove(BodyClass.isIOS);
       fixture.nativeElement.classList.add('global');
       fixture.nativeElement.style.setProperty('--keyboard-height', '336px');
+      // Non-zero for every case in this block, so the assertions below pin
+      // whether each offset stacks with the bottom inset or supersedes it.
       fixture.nativeElement.style.setProperty('--safe-area-bottom', '48px');
       fixture.nativeElement.style.setProperty('--keyboard-overlay-offset', '0px');
       fixture.nativeElement.style.setProperty('--s', '8px');
@@ -352,6 +354,9 @@ describe('AddTaskBarComponent', () => {
       document.body.classList.toggle(BodyClass.isIOS, hadIOSClass);
     });
 
+    // iOS keeps the overlay-offset-only rule on purpose — its inset source never
+    // zeroes out while the keyboard is up, so folding it in would lift the bar
+    // off the keyboard. See the iOS block in the component stylesheet.
     it('uses the overlay-only keyboard offset for the iOS global bar', () => {
       document.body.classList.add(BodyClass.isIOS);
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -339,6 +339,7 @@ describe('AddTaskBarComponent', () => {
       document.body.classList.remove(BodyClass.isIOS);
       fixture.nativeElement.classList.add('global');
       fixture.nativeElement.style.setProperty('--keyboard-height', '336px');
+      fixture.nativeElement.style.setProperty('--safe-area-bottom', '48px');
       fixture.nativeElement.style.setProperty('--keyboard-overlay-offset', '0px');
       fixture.nativeElement.style.setProperty('--s', '8px');
       fixture.nativeElement.style.setProperty('--s2', '16px');
@@ -364,7 +365,7 @@ describe('AddTaskBarComponent', () => {
       expect(getComputedStyle(fixture.nativeElement).bottom).toBe('56px');
     });
 
-    it('keeps the measured keyboard offset for non-iOS touch builds', () => {
+    it('does not add the safe area to the keyboard offset for non-iOS touch builds', () => {
       expect(getComputedStyle(fixture.nativeElement).bottom).toBe('352px');
     });
 

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -368,6 +368,13 @@ describe('AddTaskBarComponent', () => {
       expect(getComputedStyle(fixture.nativeElement).bottom).toBe('352px');
     });
 
+    it('keeps the global bar above the bottom safe area without a keyboard', () => {
+      fixture.nativeElement.style.setProperty('--keyboard-height', '0px');
+      fixture.nativeElement.style.setProperty('--safe-area-bottom', '48px');
+
+      expect(getComputedStyle(fixture.nativeElement).bottom).toBe('64px');
+    });
+
     it('keeps the top-positioned layout for mouse-primary iOS devices', () => {
       document.body.classList.remove(BodyClass.isTouchPrimary);
       const layoutBeforeIOSClass = fixture.nativeElement.getBoundingClientRect();


### PR DESCRIPTION
## Problem

Refs #9462 — on Android the floating global add-task bar renders *behind* the
system navigation bar. In the reporter's second screenshot the bar's action row
(search / note / Inbox / Today / Estimate) is half-hidden under the nav buttons.

The rule anchoring the bar offset the keyboard only:

```scss
bottom: calc(var(--keyboard-height) + var(--s2));
```

With no keyboard up that is `16px` — inside the ~48dp navigation strip. On the
reported device (Android 16 / WebView ≥ 140, `viewport-fit=cover`) Capacitor's
`SystemBars` takes its passthrough path: the WebView draws edge-to-edge and the
real inset is injected into `--safe-area-inset-bottom`. Every other
bottom-anchored element reads it — the mobile bottom nav via
`--bottom-nav-safe-area`, CDK overlays via `patchCdkViewportForSafeArea`, and
even the native pre-hydration overlay (`StartupOverlayManager.kt` lifts itself by
the system-bar inset, with a comment asserting the web bar already does the
same). The add-task bar was the one element ignoring it.

## Solution

```scss
bottom: calc(max(var(--keyboard-height), var(--safe-area-bottom)) + var(--s2));
```

`max()`, not a sum. Where `--keyboard-height` is set it measures the obscured
slice of the viewport, and the IME spans to the screen edge with the nav bar
drawn over it — so the inset is already inside that number and adding them would
push the bar a nav bar too far. In practice only one term is ever live per
platform anyway: the Capacitor build zeroes the bottom inset while the IME is up
(`SystemBars.calcSafeAreaInsets`), and mobile web never writes
`--keyboard-height` at all (its tracker is gated on `IS_TOUCH_ONLY`, which
Android Chrome fails; there the keyboard shrinks the layout viewport instead,
#9277).

Because `max(a, b) >= a`, the bar can only ever move *up* — no state that
currently clears an obstruction can start overlapping one.

### Not in this PR

- **iOS keeps the same class of bug** (bar open + keyboard dismissed sits in the
  home-indicator strip). Deliberately deferred and documented inline: on iOS the
  inset comes from `capacitor-plugin-safe-area`, which re-reads the window insets
  on orientation change only, so folding it into the iOS rule — even via `max()`
  — would float the bar a home indicator's height above the keyboard in the
  common case. Fixing it properly needs a rule gated on `body.isKeyboardVisible`,
  which wants device verification of its own.
- **The issue's first screenshot** is not the bottom nav (that clears the inset
  correctly) but the menu overlay opened from it, which is #8792/#9394 —
  shipped in v18.17.0, tagged about an hour after the issue was filed. Worth
  asking the reporter to retest that half on ≥ 18.17.0 before this is closed.

## Verification

- `add-task-bar.component.spec.ts` — 56/56. Exactly one spec fails against
  `master`: the new no-keyboard case. The renamed `352px` spec passes on master
  too and exists purely as the anti-sum guard (a sum computes `400px`).
- Measured in a real browser (412×915, 48px inset injected the way SystemBars
  does) to exercise the full cascade, which the unit test cannot: `bottom`
  resolves to **64px**, bar height 79px, bottom nav top edge at 92px.
- Snackbar clearance while the bar is open was checked: bar top 143px vs snack
  slot 140px, a 3px overlap — identical to the geometry every zero-inset touch
  platform (Android mobile web, desktop touch) has shipped all along. Tight
  constant, not a regression introduced here.
- `npm run checkFile` clean on both files.

### Known residual

On an installed Android PWA `--keyboard-height` is never written, so if Chrome
keeps reporting `env(safe-area-inset-bottom)` while the virtual keyboard is up,
the bar floats the inset height above the keyboard. Cosmetic, bounded by the
inset, never an overlap — and not decidable without a device.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have included relevant changes to the documentation/wiki — n/a, no
      user-facing behavior change beyond the fixed offset
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
