### PR TITLE
feat(community-plugins): add JSON to Tasks plugin

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -142,7 +142,7 @@
     "author": "Fernando Pindado",
     "authorUrl": "https://codeberg.org/fpindado",
     "stars": 0
-  }
+  },
   {
     "name": "JSON to Tasks",
     "shortDescription": "Create tasks and subtasks from pasted JSON, with project/tag resolution and optional creation of missing projects and tags.",
@@ -150,5 +150,5 @@
     "author": "nekoritsme",
     "authorUrl": "https://github.com/nekoritsme",
     "stars": 0
-}
+  }
 ]

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -143,4 +143,12 @@
     "authorUrl": "https://codeberg.org/fpindado",
     "stars": 0
   }
+  {
+    "name": "JSON to Tasks",
+    "shortDescription": "Create tasks and subtasks from pasted JSON, with project/tag resolution and optional creation of missing projects and tags.",
+    "url": "https://github.com/nekoritsme/superproductivity-fromjson-totasks",
+    "author": "nekoritsme",
+    "authorUrl": "https://github.com/nekoritsme",
+    "stars": 0
+}
 ]


### PR DESCRIPTION
## Problem

Super Productivity currently has no simple way to create multiple tasks from structured JSON generated by external tools such as ChatGPT.

## Solution

Add the **JSON to Tasks** plugin to the community plugins list.

The plugin allows users to paste a single JSON task object or an array of tasks and create them in Super Productivity.

It supports:

* tasks and subtasks
* notes
* time estimates
* due dates
* projects and tags by name
* optional creation of missing projects and tags

Plugin repository:
https://github.com/nekoritsme/superproductivity-fromjson-totasks

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Refactoring
* [ ] Documentation
* [ ] Other (please describe)

## Checklist

* [ ] I have included relevant changes to the documentation/[[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki)](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
* [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
* [ ] I have added tests for my changes (if applicable)
* [x] Existing tests still pass
* [x] My commit messages follow the Angular format (`type(scope): description`)