### PR TITLE
fix(mac): restore macOS release builds by verifying compiled icns directly

### DIFF
--- a/tools/generate-mac-icon.js
+++ b/tools/generate-mac-icon.js
@@ -23,7 +23,7 @@ const {
 } = require('node:fs');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
-const { compareIconsets, verifyIcns } = require('./verify-mac-icon');
+const { verifyIcns } = require('./verify-mac-icon');
 
 const BUILD_DIR = join(__dirname, '..', 'build');
 const SOURCE_SVG = join(BUILD_DIR, 'icon-mac.svg');
@@ -150,7 +150,6 @@ const generateIconset = async () => {
 const compileWithIconutil = () => {
   const temporaryDirectory = mkdtempSync(join(tmpdir(), 'sp-mac-icon-'));
   const temporaryIcon = join(temporaryDirectory, 'icon.icns');
-  const extractedIconset = join(temporaryDirectory, 'icon.iconset');
 
   try {
     execFileSync(
@@ -158,12 +157,11 @@ const compileWithIconutil = () => {
       ['--convert', 'icns', '--output', temporaryIcon, ICONSET_DIR],
       { stdio: 'inherit' },
     );
-    execFileSync(
-      '/usr/bin/iconutil',
-      ['--convert', 'iconset', '--output', extractedIconset, temporaryIcon],
-      { stdio: 'inherit' },
-    );
-    compareIconsets(ICONSET_DIR, extractedIconset);
+    // Verify the compiled artifact directly. `iconutil --convert iconset`
+    // must NOT be used as a round-trip oracle: it un-premultiplies the
+    // straight-alpha ARGB planes its own compile step wrote, clamping
+    // anti-aliased pixels into garbage (#9481).
+    verifyIcns(readFileSync(temporaryIcon), temporaryIcon, ICONSET_DIR);
     copyFileSync(temporaryIcon, OUTPUT_ICNS);
   } finally {
     rmSync(temporaryDirectory, { recursive: true, force: true });
@@ -175,7 +173,7 @@ const generateMacIcon = async () => {
 
   if (process.platform === 'darwin') {
     compileWithIconutil();
-    console.log(`Verified ${OUTPUT_ICNS} with an iconutil round trip`);
+    console.log(`Verified compiled ${OUTPUT_ICNS} against the source iconset`);
   } else {
     if (COMPILE_ONLY) {
       throw new Error('--compile-only requires macOS and /usr/bin/iconutil');

--- a/tools/verify-mac-icon.js
+++ b/tools/verify-mac-icon.js
@@ -192,13 +192,20 @@ const decodePng = (buffer, expectedPixels, source) => {
   return { width, height, pixels };
 };
 
+// The iconutil round trip re-encodes pixels through CoreGraphics, whose
+// premultiply rounding can land one level away from Math.round on
+// anti-aliased pixels — an exact compare failed every mac release build
+// since v18.17.0 (16x16 pixel 19). Real artwork regressions like #6323
+// move many pixels by many levels, so one level of noise is safe to absorb.
+const CODEC_ROUNDING_TOLERANCE = 1;
+const MAX_REPORTED_PIXEL_DIFFS = 8;
+
 const compareDecodedPng = (expected, actual, source) => {
+  const diffs = [];
   for (let offset = 0; offset < expected.pixels.length; offset += 4) {
     const expectedAlpha = expected.pixels[offset + 3];
     const actualAlpha = actual.pixels[offset + 3];
-    if (expectedAlpha !== actualAlpha) {
-      fail(source, `alpha differs at pixel ${offset / 4}`);
-    }
+    let delta = Math.abs(expectedAlpha - actualAlpha);
 
     for (let channel = 0; channel < 3; channel++) {
       const expectedPremultiplied = Math.round(
@@ -207,10 +214,27 @@ const compareDecodedPng = (expected, actual, source) => {
       const actualPremultiplied = Math.round(
         (actual.pixels[offset + channel] * actualAlpha) / 255,
       );
-      if (expectedPremultiplied !== actualPremultiplied) {
-        fail(source, `artwork differs at pixel ${offset / 4}`);
-      }
+      delta = Math.max(delta, Math.abs(expectedPremultiplied - actualPremultiplied));
     }
+
+    if (delta > CODEC_ROUNDING_TOLERANCE) {
+      diffs.push({ pixel: offset / 4, delta, offset });
+    }
+  }
+
+  if (diffs.length) {
+    const details = diffs
+      .slice(0, MAX_REPORTED_PIXEL_DIFFS)
+      .map(({ pixel, delta, offset }) => {
+        const expectedRgba = Array.from(expected.pixels.subarray(offset, offset + 4));
+        const actualRgba = Array.from(actual.pixels.subarray(offset, offset + 4));
+        return `pixel ${pixel} (delta ${delta}): expected rgba(${expectedRgba.join(',')}), got rgba(${actualRgba.join(',')})`;
+      })
+      .join('; ');
+    fail(
+      source,
+      `artwork differs at ${diffs.length} pixel(s) beyond rounding tolerance: ${details}`,
+    );
   }
 };
 

--- a/tools/verify-mac-icon.js
+++ b/tools/verify-mac-icon.js
@@ -192,11 +192,18 @@ const decodePng = (buffer, expectedPixels, source) => {
   return { width, height, pixels };
 };
 
-// The iconutil round trip re-encodes pixels through CoreGraphics, whose
-// premultiply rounding can land one level away from Math.round on
-// anti-aliased pixels — an exact compare failed every mac release build
-// since v18.17.0 (16x16 pixel 19). Real artwork regressions like #6323
-// move many pixels by many levels, so one level of noise is safe to absorb.
+// The iconutil round trip is lossy in two convention-dependent ways, and an
+// exact compare failed every mac release build since v18.17.0 (#9481):
+// - CoreGraphics premultiply rounding can land one level away from
+//   Math.round on anti-aliased pixels, and
+// - `iconutil --convert iconset` un-premultiplies small-size payloads even
+//   though its compile step stored our straight-alpha bytes verbatim, so
+//   partially transparent pixels come back as clamp(value * 255 / alpha) —
+//   artwork preserved, alpha convention reinterpreted (observed on macos-15:
+//   16x16 pixel 19 expected rgba(9,118,207,54) came back rgba(43,255,255,54)).
+// A pixel passes if the actual data matches the expected artwork under
+// either convention with one level of rounding noise; real artwork
+// regressions like #6323 match neither.
 const CODEC_ROUNDING_TOLERANCE = 1;
 const MAX_REPORTED_PIXEL_DIFFS = 8;
 
@@ -205,18 +212,30 @@ const compareDecodedPng = (expected, actual, source) => {
   for (let offset = 0; offset < expected.pixels.length; offset += 4) {
     const expectedAlpha = expected.pixels[offset + 3];
     const actualAlpha = actual.pixels[offset + 3];
-    let delta = Math.abs(expectedAlpha - actualAlpha);
+    const alphaDelta = Math.abs(expectedAlpha - actualAlpha);
+    let premultipliedDelta = alphaDelta;
+    let unpremultipliedDelta = alphaDelta;
 
     for (let channel = 0; channel < 3; channel++) {
-      const expectedPremultiplied = Math.round(
-        (expected.pixels[offset + channel] * expectedAlpha) / 255,
+      const expectedValue = expected.pixels[offset + channel];
+      const actualValue = actual.pixels[offset + channel];
+      const expectedPremultiplied = Math.round((expectedValue * expectedAlpha) / 255);
+      const actualPremultiplied = Math.round((actualValue * actualAlpha) / 255);
+      premultipliedDelta = Math.max(
+        premultipliedDelta,
+        Math.abs(expectedPremultiplied - actualPremultiplied),
       );
-      const actualPremultiplied = Math.round(
-        (actual.pixels[offset + channel] * actualAlpha) / 255,
+
+      const expectedUnpremultiplied = expectedAlpha
+        ? Math.min(255, Math.round((expectedValue * 255) / expectedAlpha))
+        : actualValue;
+      unpremultipliedDelta = Math.max(
+        unpremultipliedDelta,
+        Math.abs(expectedUnpremultiplied - actualValue),
       );
-      delta = Math.max(delta, Math.abs(expectedPremultiplied - actualPremultiplied));
     }
 
+    const delta = Math.min(premultipliedDelta, unpremultipliedDelta);
     if (delta > CODEC_ROUNDING_TOLERANCE) {
       diffs.push({ pixel: offset / 4, delta, offset });
     }

--- a/tools/verify-mac-icon.js
+++ b/tools/verify-mac-icon.js
@@ -192,18 +192,11 @@ const decodePng = (buffer, expectedPixels, source) => {
   return { width, height, pixels };
 };
 
-// The iconutil round trip is lossy in two convention-dependent ways, and an
-// exact compare failed every mac release build since v18.17.0 (#9481):
-// - CoreGraphics premultiply rounding can land one level away from
-//   Math.round on anti-aliased pixels, and
-// - `iconutil --convert iconset` un-premultiplies small-size payloads even
-//   though its compile step stored our straight-alpha bytes verbatim, so
-//   partially transparent pixels come back as clamp(value * 255 / alpha) —
-//   artwork preserved, alpha convention reinterpreted (observed on macos-15:
-//   16x16 pixel 19 expected rgba(9,118,207,54) came back rgba(43,255,255,54)).
-// A pixel passes if the actual data matches the expected artwork under
-// either convention with one level of rounding noise; real artwork
-// regressions like #6323 match neither.
+// CoreGraphics runs ARGB payloads through a premultiply round trip whose
+// rounding can land one level away from Math.round on anti-aliased pixels
+// (#9481 — an exact compare failed every mac release build since v18.17.0).
+// Real artwork regressions like #6323 move many pixels by many levels, so
+// one level of noise is safe to absorb.
 const CODEC_ROUNDING_TOLERANCE = 1;
 const MAX_REPORTED_PIXEL_DIFFS = 8;
 
@@ -212,30 +205,18 @@ const compareDecodedPng = (expected, actual, source) => {
   for (let offset = 0; offset < expected.pixels.length; offset += 4) {
     const expectedAlpha = expected.pixels[offset + 3];
     const actualAlpha = actual.pixels[offset + 3];
-    const alphaDelta = Math.abs(expectedAlpha - actualAlpha);
-    let premultipliedDelta = alphaDelta;
-    let unpremultipliedDelta = alphaDelta;
+    let delta = Math.abs(expectedAlpha - actualAlpha);
 
     for (let channel = 0; channel < 3; channel++) {
-      const expectedValue = expected.pixels[offset + channel];
-      const actualValue = actual.pixels[offset + channel];
-      const expectedPremultiplied = Math.round((expectedValue * expectedAlpha) / 255);
-      const actualPremultiplied = Math.round((actualValue * actualAlpha) / 255);
-      premultipliedDelta = Math.max(
-        premultipliedDelta,
-        Math.abs(expectedPremultiplied - actualPremultiplied),
+      const expectedPremultiplied = Math.round(
+        (expected.pixels[offset + channel] * expectedAlpha) / 255,
       );
-
-      const expectedUnpremultiplied = expectedAlpha
-        ? Math.min(255, Math.round((expectedValue * 255) / expectedAlpha))
-        : actualValue;
-      unpremultipliedDelta = Math.max(
-        unpremultipliedDelta,
-        Math.abs(expectedUnpremultiplied - actualValue),
+      const actualPremultiplied = Math.round(
+        (actual.pixels[offset + channel] * actualAlpha) / 255,
       );
+      delta = Math.max(delta, Math.abs(expectedPremultiplied - actualPremultiplied));
     }
 
-    const delta = Math.min(premultipliedDelta, unpremultipliedDelta);
     if (delta > CODEC_ROUNDING_TOLERANCE) {
       diffs.push({ pixel: offset / 4, delta, offset });
     }
@@ -255,6 +236,68 @@ const compareDecodedPng = (expected, actual, source) => {
       `artwork differs at ${diffs.length} pixel(s) beyond rounding tolerance: ${details}`,
     );
   }
+};
+
+const ARGB_MAGIC = Buffer.from('ARGB', 'ascii');
+
+// icns run-length encoding (not classic PackBits): a control byte below 0x80
+// starts a literal run of control+1 bytes; 0x80 and above repeats the next
+// byte control-0x80+3 times.
+const decodeIcnsRle = (data, expectedLength, source) => {
+  const plane = Buffer.alloc(expectedLength);
+  let inputOffset = 0;
+  let outputOffset = 0;
+  while (outputOffset < expectedLength) {
+    if (inputOffset >= data.length) {
+      fail(source, 'truncated RLE channel data');
+    }
+    const control = data[inputOffset++];
+    const count = control < 0x80 ? control + 1 : control - 0x80 + 3;
+    if (outputOffset + count > expectedLength) {
+      fail(
+        source,
+        `RLE run overflows channel by ${outputOffset + count - expectedLength} bytes`,
+      );
+    }
+    if (control < 0x80) {
+      if (inputOffset + count > data.length) {
+        fail(source, 'truncated RLE literal run');
+      }
+      data.copy(plane, outputOffset, inputOffset, inputOffset + count);
+      inputOffset += count;
+    } else {
+      if (inputOffset >= data.length) {
+        fail(source, 'truncated RLE repeat run');
+      }
+      plane.fill(data[inputOffset++], outputOffset, outputOffset + count);
+    }
+    outputOffset += count;
+  }
+  return { plane, bytesRead: inputOffset };
+};
+
+// iconutil stores small representations (icp4/icp5) as 'ARGB': four
+// icns-RLE-compressed planes in alpha, red, green, blue order holding
+// straight (non-premultiplied) channel values.
+const decodeArgbChunk = (buffer, expectedPixels, source) => {
+  const pixelCount = expectedPixels * expectedPixels;
+  const pixels = Buffer.alloc(pixelCount * 4);
+  let offset = ARGB_MAGIC.length;
+  for (const channel of [3, 0, 1, 2]) {
+    const { plane, bytesRead } = decodeIcnsRle(
+      buffer.subarray(offset),
+      pixelCount,
+      `${source}:plane${channel}`,
+    );
+    for (let i = 0; i < pixelCount; i++) {
+      pixels[i * 4 + channel] = plane[i];
+    }
+    offset += bytesRead;
+  }
+  if (offset !== buffer.length) {
+    fail(source, `unexpected ${buffer.length - offset} trailing bytes in ARGB data`);
+  }
+  return { width: expectedPixels, height: expectedPixels, pixels };
 };
 
 const parseIcns = (buffer, source) => {
@@ -339,11 +382,11 @@ const verifyIcns = (buffer, source = 'ICNS', expectedIconsetDirectory) => {
       continue;
     }
 
-    const decoded = decodePng(
-      chunks.get(representation.type),
-      representation.pixels,
-      `${source}:${representation.type}`,
-    );
+    const chunk = chunks.get(representation.type);
+    const chunkSource = `${source}:${representation.type}`;
+    const decoded = chunk.subarray(0, 4).equals(ARGB_MAGIC)
+      ? decodeArgbChunk(chunk, representation.pixels, chunkSource)
+      : decodePng(chunk, representation.pixels, chunkSource);
     if (expectedFiles) {
       compareDecodedPng(
         expectedFiles.get(representation.file),

--- a/tools/verify-mac-icon.js
+++ b/tools/verify-mac-icon.js
@@ -8,10 +8,12 @@ const { crc32, inflateSync } = require('node:zlib');
 const PNG_SIGNATURE = Buffer.from('89504e470d0a1a0a', 'hex');
 const MIN_TRANSPARENT_PIXEL_RATIO = 0.2;
 // Same-sized 1x and 2x images are separate semantic representations in ICNS.
+// iconutil stores the small sizes as ic04/ic05 (ARGB form) while the portable
+// generator writes icp4/icp5 (PNG form); either type satisfies the slot.
 const REPRESENTATIONS = [
-  { label: '16x16', type: 'icp4', file: 'icon_16x16.png', pixels: 16 },
+  { label: '16x16', type: 'icp4', argbType: 'ic04', file: 'icon_16x16.png', pixels: 16 },
   { label: '16x16@2x', type: 'ic11', file: 'icon_16x16@2x.png', pixels: 32 },
-  { label: '32x32', type: 'icp5', file: 'icon_32x32.png', pixels: 32 },
+  { label: '32x32', type: 'icp5', argbType: 'ic05', file: 'icon_32x32.png', pixels: 32 },
   { label: '32x32@2x', type: 'ic12', file: 'icon_32x32@2x.png', pixels: 64 },
   { label: '128x128', type: 'ic07', file: 'icon_128x128.png', pixels: 128 },
   { label: '128x128@2x', type: 'ic13', file: 'icon_128x128@2x.png', pixels: 256 },
@@ -20,7 +22,6 @@ const REPRESENTATIONS = [
   { label: '512x512', type: 'ic09', file: 'icon_512x512.png', pixels: 512 },
   { label: '512x512@2x', type: 'ic10', file: 'icon_512x512@2x.png', pixels: 1024 },
 ];
-const LEGACY_REPRESENTATION_TYPES = ['ic04', 'ic05'];
 const ICONSET_FILES = REPRESENTATIONS.map(({ file, pixels }) => [file, pixels]);
 
 const fail = (source, message) => {
@@ -361,38 +362,45 @@ const compareIconsets = (expectedDirectory, actualDirectory) => {
   }
 };
 
+const decodeRepresentationChunk = (chunk, expectedPixels, chunkSource) => {
+  if (chunk.subarray(0, 4).equals(ARGB_MAGIC)) {
+    return decodeArgbChunk(chunk, expectedPixels, chunkSource);
+  }
+  if (chunk.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return decodePng(chunk, expectedPixels, chunkSource);
+  }
+  fail(
+    chunkSource,
+    `unrecognized payload (starts with ${chunk.subarray(0, 8).toString('hex')})`,
+  );
+};
+
 const verifyIcns = (buffer, source = 'ICNS', expectedIconsetDirectory) => {
   const chunks = parseIcns(buffer, source);
-  const legacyType = LEGACY_REPRESENTATION_TYPES.find((type) => chunks.has(type));
-  if (legacyType) {
-    fail(
-      source,
-      `legacy ICNS representation ${legacyType} requires native iconutil verification`,
-    );
-  }
-
   const expectedFiles = expectedIconsetDirectory
     ? verifyIconset(expectedIconsetDirectory)
     : undefined;
   const missing = [];
 
   for (const representation of REPRESENTATIONS) {
-    if (!chunks.has(representation.type)) {
+    const presentTypes = [representation.type, representation.argbType].filter(
+      (type) => type && chunks.has(type),
+    );
+    if (!presentTypes.length) {
       missing.push(`${representation.label} (${representation.type})`);
       continue;
     }
 
-    const chunk = chunks.get(representation.type);
-    const chunkSource = `${source}:${representation.type}`;
-    const decoded = chunk.subarray(0, 4).equals(ARGB_MAGIC)
-      ? decodeArgbChunk(chunk, representation.pixels, chunkSource)
-      : decodePng(chunk, representation.pixels, chunkSource);
-    if (expectedFiles) {
-      compareDecodedPng(
-        expectedFiles.get(representation.file),
-        decoded,
-        `${source}:${representation.type}`,
+    for (const type of presentTypes) {
+      const chunkSource = `${source}:${type}`;
+      const decoded = decodeRepresentationChunk(
+        chunks.get(type),
+        representation.pixels,
+        chunkSource,
       );
+      if (expectedFiles) {
+        compareDecodedPng(expectedFiles.get(representation.file), decoded, chunkSource);
+      }
     }
   }
 

--- a/tools/verify-mac-icon.test.js
+++ b/tools/verify-mac-icon.test.js
@@ -148,6 +148,31 @@ test('macOS icon comparison tolerates one level of premultiplied rounding noise'
   assert.doesNotThrow(() => compareIconsets(ICONSET_PATH, actualIconset));
 });
 
+test('macOS icon comparison tolerates iconutil un-premultiplying straight-alpha data', (t) => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'sp-mac-iconset-test-'));
+  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  const actualIconset = join(temporaryDirectory, 'icon.iconset');
+  cpSync(ICONSET_PATH, actualIconset, { recursive: true });
+
+  // Reproduce what `iconutil --convert iconset` did on macos-15 (#9481): it
+  // treated the straight-alpha bytes stored at compile time as premultiplied
+  // and un-premultiplied them, clamping channels at 255.
+  const decoded = verifyIconset(ICONSET_PATH).get('icon_16x16.png');
+  const pixels = Buffer.from(decoded.pixels);
+  for (let offset = 0; offset < pixels.length; offset += 4) {
+    const alpha = pixels[offset + 3];
+    for (let channel = 0; channel < 3; channel++) {
+      pixels[offset + channel] = alpha
+        ? Math.min(255, Math.round((pixels[offset + channel] * 255) / alpha))
+        : 0;
+    }
+  }
+  writeFileSync(join(actualIconset, 'icon_16x16.png'), encodePng(16, pixels));
+
+  assert.doesNotThrow(() => compareIconsets(ICONSET_PATH, actualIconset));
+});
+
 test('macOS icon comparison rejects artwork drift beyond rounding noise', (t) => {
   const temporaryDirectory = mkdtempSync(join(tmpdir(), 'sp-mac-iconset-test-'));
   t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));

--- a/tools/verify-mac-icon.test.js
+++ b/tools/verify-mac-icon.test.js
@@ -44,15 +44,15 @@ test('checked-in macOS icon sources contain every standard representation', () =
   assert.doesNotThrow(() => verifyIcns(readFileSync(ICON_PATH), ICON_PATH, ICONSET_PATH));
 });
 
-test('macOS icon verification rejects unchecked legacy small-icon payloads', () => {
-  const legacyIcon = Buffer.from(readFileSync(ICON_PATH));
-  assert.equal(legacyIcon.toString('ascii', 8, 12), 'icp4');
-  legacyIcon.write('ic04', 8, 4, 'ascii');
-  legacyIcon.fill(0, 16, 24);
+test('macOS icon verification rejects unrecognized small-icon payloads', () => {
+  const mangledIcon = Buffer.from(readFileSync(ICON_PATH));
+  assert.equal(mangledIcon.toString('ascii', 8, 12), 'icp4');
+  mangledIcon.write('ic04', 8, 4, 'ascii');
+  mangledIcon.fill(0, 16, 24);
 
   assert.throws(
-    () => verifyIcns(legacyIcon, 'legacy.icns', ICONSET_PATH),
-    /legacy.*ic04|ic04.*legacy/i,
+    () => verifyIcns(mangledIcon, 'mangled.icns', ICONSET_PATH),
+    /unrecognized payload/,
   );
 });
 
@@ -176,10 +176,12 @@ const buildIcnsWithArgbSmallIcon = (pixels) => {
   while (offset < source.length) {
     const type = source.toString('ascii', offset, offset + 4);
     const length = source.readUInt32BE(offset + 4);
-    chunks.push({
-      type,
-      data: type === 'icp4' ? argbData : source.subarray(offset + 8, offset + length),
-    });
+    // iconutil emits the 16x16 slot as ic04 with ARGB data; mirror that shape.
+    chunks.push(
+      type === 'icp4'
+        ? { type: 'ic04', data: argbData }
+        : { type, data: source.subarray(offset + 8, offset + length) },
+    );
     offset += length;
   }
 

--- a/tools/verify-mac-icon.test.js
+++ b/tools/verify-mac-icon.test.js
@@ -148,29 +148,66 @@ test('macOS icon comparison tolerates one level of premultiplied rounding noise'
   assert.doesNotThrow(() => compareIconsets(ICONSET_PATH, actualIconset));
 });
 
-test('macOS icon comparison tolerates iconutil un-premultiplying straight-alpha data', (t) => {
-  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'sp-mac-iconset-test-'));
-  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
-
-  const actualIconset = join(temporaryDirectory, 'icon.iconset');
-  cpSync(ICONSET_PATH, actualIconset, { recursive: true });
-
-  // Reproduce what `iconutil --convert iconset` did on macos-15 (#9481): it
-  // treated the straight-alpha bytes stored at compile time as premultiplied
-  // and un-premultiplied them, clamping channels at 255.
-  const decoded = verifyIconset(ICONSET_PATH).get('icon_16x16.png');
-  const pixels = Buffer.from(decoded.pixels);
-  for (let offset = 0; offset < pixels.length; offset += 4) {
-    const alpha = pixels[offset + 3];
-    for (let channel = 0; channel < 3; channel++) {
-      pixels[offset + channel] = alpha
-        ? Math.min(255, Math.round((pixels[offset + channel] * 255) / alpha))
-        : 0;
-    }
+// iconutil compiles small representations as 'ARGB' chunks: four icns-RLE
+// planes in A,R,G,B order with straight-alpha values. Encode literal-only
+// runs, which the icns RLE decoder must accept.
+const encodeIcnsRlePlane = (plane) => {
+  const parts = [];
+  for (let offset = 0; offset < plane.length; offset += 128) {
+    const literals = plane.subarray(offset, Math.min(offset + 128, plane.length));
+    parts.push(Buffer.from([literals.length - 1]), literals);
   }
-  writeFileSync(join(actualIconset, 'icon_16x16.png'), encodePng(16, pixels));
+  return Buffer.concat(parts);
+};
 
-  assert.doesNotThrow(() => compareIconsets(ICONSET_PATH, actualIconset));
+const buildIcnsWithArgbSmallIcon = (pixels) => {
+  const planes = [3, 0, 1, 2].map((channel) => {
+    const plane = Buffer.alloc(pixels.length / 4);
+    for (let i = 0; i < plane.length; i++) {
+      plane[i] = pixels[i * 4 + channel];
+    }
+    return encodeIcnsRlePlane(plane);
+  });
+  const argbData = Buffer.concat([Buffer.from('ARGB', 'ascii'), ...planes]);
+
+  const source = readFileSync(ICON_PATH);
+  const chunks = [];
+  let offset = 8;
+  while (offset < source.length) {
+    const type = source.toString('ascii', offset, offset + 4);
+    const length = source.readUInt32BE(offset + 4);
+    chunks.push({
+      type,
+      data: type === 'icp4' ? argbData : source.subarray(offset + 8, offset + length),
+    });
+    offset += length;
+  }
+
+  const totalLength = chunks.reduce((sum, chunk) => sum + 8 + chunk.data.length, 8);
+  const icns = Buffer.alloc(totalLength);
+  icns.write('icns', 0, 4, 'ascii');
+  icns.writeUInt32BE(totalLength, 4);
+  let outputOffset = 8;
+  for (const { type, data } of chunks) {
+    icns.write(type, outputOffset, 4, 'ascii');
+    icns.writeUInt32BE(8 + data.length, outputOffset + 4);
+    data.copy(icns, outputOffset + 8);
+    outputOffset += 8 + data.length;
+  }
+  return icns;
+};
+
+test('macOS icns verification accepts iconutil-style ARGB small representations', () => {
+  const decoded = verifyIconset(ICONSET_PATH).get('icon_16x16.png');
+  const icns = buildIcnsWithArgbSmallIcon(decoded.pixels);
+  assert.doesNotThrow(() => verifyIcns(icns, 'argb.icns', ICONSET_PATH));
+});
+
+test('macOS icns verification rejects ARGB artwork drift', () => {
+  const decoded = verifyIconset(ICONSET_PATH).get('icon_16x16.png');
+  const pixels = shiftChannelByPremultipliedLevels(decoded, 8);
+  const icns = buildIcnsWithArgbSmallIcon(pixels);
+  assert.throws(() => verifyIcns(icns, 'argb.icns', ICONSET_PATH), /artwork differs/);
 });
 
 test('macOS icon comparison rejects artwork drift beyond rounding noise', (t) => {

--- a/tools/verify-mac-icon.test.js
+++ b/tools/verify-mac-icon.test.js
@@ -13,6 +13,7 @@ const {
 } = require('node:fs');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
+const { crc32, deflateSync } = require('node:zlib');
 const afterPack = require('./afterPack');
 const { resolveNpmInvocation } = require('./generate-mac-icon');
 const { compareIconsets, verifyIconset, verifyIcns } = require('./verify-mac-icon');
@@ -75,6 +76,84 @@ test('macOS icon verification rejects the full-bleed generic small artwork', (t)
     () => compareIconsets(ICONSET_PATH, actualIconset),
     /fully transparent pixels/,
   );
+});
+
+const pngChunk = (type, data) => {
+  const chunk = Buffer.alloc(data.length + 12);
+  chunk.writeUInt32BE(data.length, 0);
+  chunk.write(type, 4, 4, 'ascii');
+  data.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(chunk.subarray(4, 8 + data.length)), 8 + data.length);
+  return chunk;
+};
+
+const encodePng = (size, pixels) => {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(size, 0);
+  ihdr.writeUInt32BE(size, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // RGBA
+  const rowLength = size * 4;
+  const filtered = Buffer.alloc((rowLength + 1) * size);
+  for (let row = 0; row < size; row++) {
+    pixels.copy(
+      filtered,
+      row * (rowLength + 1) + 1,
+      row * rowLength,
+      (row + 1) * rowLength,
+    );
+  }
+  return Buffer.concat([
+    Buffer.from('89504e470d0a1a0a', 'hex'),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', deflateSync(filtered)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+};
+
+// Move one channel of one anti-aliased pixel by exactly `levels` steps in
+// premultiplied space — the same kind of drift the iconutil round trip
+// introduces (one level) and real artwork regressions exceed (many levels).
+const shiftChannelByPremultipliedLevels = (decoded, levels) => {
+  const pixels = Buffer.from(decoded.pixels);
+  for (let offset = 0; offset < pixels.length; offset += 4) {
+    const alpha = pixels[offset + 3];
+    if (alpha < 32 || alpha === 255) continue;
+    for (let channel = 0; channel < 3; channel++) {
+      const premultiplied = Math.round((pixels[offset + channel] * alpha) / 255);
+      if (premultiplied <= levels) continue;
+      const shifted = Math.round(((premultiplied - levels) * 255) / alpha);
+      if (Math.round((shifted * alpha) / 255) !== premultiplied - levels) continue;
+      pixels[offset + channel] = shifted;
+      return pixels;
+    }
+  }
+  throw new Error('no shiftable anti-aliased pixel found in iconset');
+};
+
+const writeShiftedSmallIcon = (directory, levels) => {
+  const actualIconset = join(directory, 'icon.iconset');
+  cpSync(ICONSET_PATH, actualIconset, { recursive: true });
+  const decoded = verifyIconset(ICONSET_PATH).get('icon_16x16.png');
+  const pixels = shiftChannelByPremultipliedLevels(decoded, levels);
+  writeFileSync(join(actualIconset, 'icon_16x16.png'), encodePng(16, pixels));
+  return actualIconset;
+};
+
+test('macOS icon comparison tolerates one level of premultiplied rounding noise', (t) => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'sp-mac-iconset-test-'));
+  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  const actualIconset = writeShiftedSmallIcon(temporaryDirectory, 1);
+  assert.doesNotThrow(() => compareIconsets(ICONSET_PATH, actualIconset));
+});
+
+test('macOS icon comparison rejects artwork drift beyond rounding noise', (t) => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'sp-mac-iconset-test-'));
+  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  const actualIconset = writeShiftedSmallIcon(temporaryDirectory, 8);
+  assert.throws(() => compareIconsets(ICONSET_PATH, actualIconset), /artwork differs/);
 });
 
 for (const electronPlatformName of ['darwin', 'mas']) {


### PR DESCRIPTION
## Problem

Every macOS release job since v18.17.0 fails at the icon verification step, so **v18.17.0 and v18.18.0 shipped with zero macOS artifacts** (both `mac-bin` in *Build All & Release* and the *Mac Store* workflow died in `beforePack`).

The verification added in #9335 uses `iconutil --convert iconset` to extract the compiled `.icns` back into PNGs and compares them against the source iconset. That extract direction is inherently lossy: iconutil compiles the 16/32px slots as `ic04`/`ic05` ARGB chunks with **straight** (non-premultiplied) alpha, but on extraction it treats the planes as premultiplied and un-premultiplies them again — `clamp(value * 255 / alpha)` — turning every anti-aliased pixel into garbage. The check could never pass on a tag build, and it only executes on tag builds (Electron smoke on PRs is Linux-only), so it shipped green and failed on its first two real runs.

## Fix

Stop round-tripping through `iconutil --convert iconset` and verify the compiled `.icns` directly:

- `tools/verify-mac-icon.js` gains an in-repo decoder for iconutil's native output: icns RLE decompression plus `ARGB` chunk parsing (four planes in A,R,G,B order, straight alpha).
- The 16px/32px representations now accept either the PNG form (`icp4`/`icp5`, what our portable Linux compiler writes) or the ARGB form (`ic04`/`ic05`, what modern iconutil emits). Both are decoded and compared pixel-for-pixel against the source iconset.
- Comparison happens in premultiplied space with a ±1 rounding tolerance, since iconutil's compile pass round-trips pixels through CoreGraphics premultiplication.
- `tools/generate-mac-icon.js` verifies the compiled artifact in-place; the lossy extract step is gone.
- Mismatches now report per-pixel expected/actual RGBA values, so a future failure is diagnosable from CI logs alone.

## Verification

- **Real macOS pipeline:** [`Test macOS DMG Build` run 31129176215](https://github.com/super-productivity/super-productivity/actions/runs/31129176215) is fully green on this branch — icon compile + verify, signing, notarization, and DMG codesign all pass on `macos-15`. (Rounds 1–3 of this branch failed that same workflow; the per-pixel diagnostics from those runs are what pinned the root cause.)
- **Unit tests:** `npm run test:mac-icon` — 12 tests, including new coverage for ARGB/icns-RLE decoding, ±1 premultiplied tolerance, drift rejection at 8 levels, and rejection of unrecognized payloads.

## Follow-up after merge

The failed tag runs are pinned to pre-fix SHAs and can never succeed on re-run. Shipping macOS artifacts requires cutting **v18.18.1** once this is on master.
