### PR TITLE
fix(tasks): switch the Duration row icon between add and edit

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.html
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.html
@@ -103,7 +103,7 @@
       (collapseParent)="collapseParent()"
       (editActionTriggered)="estimateTime()"
       (keyPress)="onItemKeyPress($event)"
-      [inputIcon]="'edit'"
+      [inputIcon]="hasTimeData() ? 'edit' : 'add'"
       class="input-item --estimate"
     >
       <ng-container input-title>

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -384,6 +384,8 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
 
   showTimeEstimate = computed(() => !this.task().subTasks?.length);
 
+  hasTimeData = computed(() => !!(this.task().timeSpent || this.task().timeEstimate));
+
   hasAttachments = computed(() => {
     return this.issueAttachments().length > 0 || this.localAttachments().length > 0;
   });


### PR DESCRIPTION
## Problem

The Duration row's edit affordance (`[inputIcon]`) was hardcoded to `'edit'`, even when a task has no time spent and no estimate set yet. The Schedule and Deadline rows right below it already switch between `add` and `edit` depending on whether the field has a value, so Duration was the odd one out — part of the inconsistency raised in #9281.

## Solution

Added a `hasTimeData()` computed signal (`timeSpent || timeEstimate`) and made `[inputIcon]` conditional on it, matching the pattern already used by the Schedule and Deadline rows. No new strings, no label changes, no changes to how the time values render.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (not applicable, no user-facing docs change)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) (not applicable, no new branching logic beyond the existing pattern)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)