### PR TITLE
fix(tasks): show 'Set deadline' instead of 'Deadline' on an empty deadline row

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -416,7 +416,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
         ? this.T.F.TASK.ADDITIONAL_INFO.DEADLINE_OVERDUE
         : this.T.F.TASK.ADDITIONAL_INFO.DEADLINE_DUE_BY;
     }
-    return this.T.F.TASK.ADDITIONAL_INFO.DEADLINE;
+    return this.T.F.TASK.CMP.SET_DEADLINE;
   });
 
   // EFFECTS


### PR DESCRIPTION
## Problem

Part of the follow-up items from #9281. When a task has no deadline set, the Deadline row's title read "Deadline" — a noun that doesn't communicate what tapping the row does. The Schedule row right above it already follows an action-oriented empty-state convention ("Schedule task"), so Deadline was inconsistent with it.

## Solution

`deadlineLabelKey()` now falls back to the existing `T.F.TASK.CMP.SET_DEADLINE` key ("Set deadline") instead of `T.F.TASK.ADDITIONAL_INFO.DEADLINE`, when no deadline is set. No new translation key needed. The overdue/due-by labels for tasks that already have a deadline are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (not applicable, no user-facing docs change)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) (not applicable, single-line label swap using an existing key)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)