### PR TITLE
fix(tasks): reveal the add/edit affordance on touch devices

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.html
+++ b/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.html
@@ -22,6 +22,8 @@
         class="input-item__edit-btn"
         color="accent"
         mat-icon-button
+        tabindex="-1"
+        aria-hidden="true"
       >
         <mat-icon>{{ inputIcon }}</mat-icon>
       </button>

--- a/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.scss
+++ b/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.scss
@@ -252,4 +252,8 @@
   .input-item:hover & {
     display: block !important;
   }
+
+  @media (hover: none) {
+    display: block !important;
+  }
 }


### PR DESCRIPTION
## Problem

Part of the follow-up items from #9281. `.input-item__edit-btn` was `display: none !important` except under `.input-item:hover`, so the add-vs-edit icon distinction the code already computes for the Duration/Schedule/Deadline rows never rendered on a touch device — hover never resolves before a tap, so there was no visual signal for what tapping a row would do.

## Solution

Reveal the button under `@media (hover: none)` as well as on hover, so touch devices see the same add/edit affordance desktop users see on hover. The button has no click handler of its own (taps fall through to the row's own click handler), so it's marked `tabindex="-1"` `aria-hidden="true"` now that it's visible, keeping it out of the tab order and off assistive tech.

Verified in Chrome DevTools with touch emulation enabled (`matchMedia('(hover: none)').matches === true`): the icon is now visible without hovering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (not applicable, no user-facing docs change)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) (not applicable, CSS media query + a11y attributes)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)