### PR TITLE
style(tasks): tighten task-detail row spacing to match the task list rhythm

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.scss
+++ b/src/app/features/tasks/task-detail-panel/task-additional-info-item/task-detail-item.component.scss
@@ -53,7 +53,9 @@
 .input-item,
 .mat-expansion-panel {
   border: 1px solid var(--divider-color);
-  margin: var(--s);
+  // Match the main task list's inter-row rhythm rather than the roomier 8px,
+  // recovering density while keeping the 48px touch target (see #9266).
+  margin: var(--s-half);
   border-radius: var(--card-border-radius);
   background: var(--task-detail-bg);
   font-size: 14px;


### PR DESCRIPTION
## Problem

Part of the follow-up items from #9281. `.input-item` / `.mat-expansion-panel` used `margin: var(--s)` (8px) per row in the task detail panel, which the maintainer estimated as roughly 70px of chrome across the panel's ~530px height.

## Solution

Planner and boards already moved their inter-row gap from `var(--s)` to `var(--s-half)` for the same reason (#9266, "match the task list rhythm"). Apply the same token here, on the same rule, so the task detail panel's density matches the rest of the app. No change to card style (border/radius/background), and the 48px row touch target is untouched — only the outer margin changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Other (please describe): visual density/style tweak
- [ ] Documentation

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (not applicable, no user-facing docs change)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) (not applicable, single CSS token swap)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)