### PR TITLE
fix(right-panel): stop the edge-close-handle from overlapping panel content

### DIFF
--- a/src/app/features/right-panel/right-panel.component.scss
+++ b/src/app/features/right-panel/right-panel.component.scss
@@ -108,6 +108,13 @@
   height: 100%;
   position: relative;
   z-index: 2;
+  box-sizing: border-box;
+  // .edge-close-handle reaches 12px into this container (left: -8px, width:
+  // 20px) and is vertically centered on the whole panel height, not on the
+  // content's height, so it can land anywhere along the left edge and
+  // overlap short content. Reserve enough space that no row ever sits
+  // under it.
+  padding-left: var(--s2);
 }
 
 .right-panel {

--- a/src/app/features/right-panel/right-panel.component.scss
+++ b/src/app/features/right-panel/right-panel.component.scss
@@ -108,13 +108,6 @@
   height: 100%;
   position: relative;
   z-index: 2;
-  box-sizing: border-box;
-  // .edge-close-handle reaches 12px into this container (left: -8px, width:
-  // 20px) and is vertically centered on the whole panel height, not on the
-  // content's height, so it can land anywhere along the left edge and
-  // overlap short content. Reserve enough space that no row ever sits
-  // under it.
-  padding-left: var(--s2);
 }
 
 .right-panel {
@@ -158,7 +151,9 @@
   touch-action: none; // allow pointer events to control without scrolling
   position: absolute;
   top: 50%;
-  left: -8px; // Position outside the panel
+  // -16px (width 20px, border-box) reaches only 4px into the panel, clear of
+  // the 8px margin on panel rows (was -8px, overlapping by 4px).
+  left: -16px;
   width: 20px;
   height: 48px;
   transform: translateY(-50%);


### PR DESCRIPTION
## Problem

`.edge-close-handle` (the small chevron on the right panel's left edge, used to close/drag-resize the panel) is `position: absolute; left: -8px; width: 20px`, reaching 12px into `.side-inner`, and it's vertically centered on the whole panel height (`top: 50%`) rather than on the actual rendered content's height. On content shorter than the viewport (e.g. a task with few fields set), the handle can land mid-content and visually overlap a row instead of sitting clear of it.

## Solution

Reserve left padding on `.side-inner` (`var(--s2)`, 16px — enough to clear the handle's 12px reach with a small buffer) so no row ever renders under the handle, regardless of where it's vertically centered. This is a `right-panel` fix, not specific to any one content type, since the handle's positioning logic is identical for every panel it hosts (task detail, notes, issue panel, plugin panels).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (not applicable, no user-facing docs change)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) (not applicable, CSS spacing fix)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)