### PR TITLE
fix(task-repeat-cfg): anchor the monthly day-of-month presets on the date they were set up for

### DIFF
--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -954,4 +954,51 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       expect(savedCfg().skipOverdue).toBe(true);
     });
   });
+
+  // save() re-derives the quick setting from the stored start date, so a preset
+  // that ignored that date rewrote it on every save — and a startDate in the
+  // change set reschedules the live instance (#7373).
+  describe('monthly anchors survive an unrelated save', () => {
+    const changes = (): Partial<TaskRepeatCfg> =>
+      mockTaskRepeatCfgService.updateTaskRepeatCfg.calls.mostRecent()
+        .args[1] as Partial<TaskRepeatCfg>;
+
+    it('keeps a future MONTHLY_LAST_DAY start date where the user put it', async () => {
+      const fixture = await setupTestBed({
+        repeatCfg: {
+          ...DEFAULT_TASK_REPEAT_CFG,
+          id: 'repeat-cfg-last-day',
+          title: 'Pay rent',
+          quickSetting: 'MONTHLY_LAST_DAY',
+          repeatCycle: 'MONTHLY',
+          monthlyLastDay: true,
+          startDate: '2099-09-30',
+        },
+      });
+
+      fixture.componentInstance.save();
+
+      expect(mockTaskRepeatCfgService.updateTaskRepeatCfg).toHaveBeenCalledTimes(1);
+      expect(changes().startDate).toBeUndefined();
+      expect('startDate' in changes()).toBe(false);
+    });
+
+    it('keeps a future MONTHLY_FIRST_DAY start date where the user put it', async () => {
+      const fixture = await setupTestBed({
+        repeatCfg: {
+          ...DEFAULT_TASK_REPEAT_CFG,
+          id: 'repeat-cfg-first-day',
+          title: 'Pay rent',
+          quickSetting: 'MONTHLY_FIRST_DAY',
+          repeatCycle: 'MONTHLY',
+          startDate: '2099-10-01',
+        },
+      });
+
+      fixture.componentInstance.save();
+
+      expect(changes().startDate).toBeUndefined();
+      expect('startDate' in changes()).toBe(false);
+    });
+  });
 });

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component.spec.ts
@@ -979,7 +979,8 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
       fixture.componentInstance.save();
 
       expect(mockTaskRepeatCfgService.updateTaskRepeatCfg).toHaveBeenCalledTimes(1);
-      expect(changes().startDate).toBeUndefined();
+      // `rescheduleTaskOnRepeatCfgUpdate$` filters on `field in changes`, so key
+      // absence is the assertion that matches the effect.
       expect('startDate' in changes()).toBe(false);
     });
 
@@ -997,7 +998,6 @@ describe('DialogEditTaskRepeatCfgComponent', () => {
 
       fixture.componentInstance.save();
 
-      expect(changes().startDate).toBeUndefined();
       expect('startDate' in changes()).toBe(false);
     });
   });

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates.spec.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates.spec.ts
@@ -206,6 +206,60 @@ describe('getQuickSettingUpdates', () => {
     });
   });
 
+  // Both callers pass a reference day — the picked date in the add bar, the
+  // config's own start date in the repeat dialog — and these two presets used
+  // to derive their anchor from `new Date()` regardless, so the saved
+  // recurrence started in a month the user never chose.
+  describe('monthly day-of-month presets honour the referenceDate', () => {
+    afterEach(() => jasmine.clock().uninstall());
+
+    const mockToday = (date: Date): void => {
+      jasmine.clock().install();
+      jasmine.clock().mockDate(date);
+    };
+
+    it('MONTHLY_FIRST_DAY anchors to the 1st after the reference date', () => {
+      mockToday(new Date(2026, 7, 8));
+      const result = getQuickSettingUpdates('MONTHLY_FIRST_DAY', new Date(2026, 11, 15));
+      expect(result!.startDate).toBe('2027-01-01');
+    });
+
+    it('MONTHLY_FIRST_DAY keeps a reference date that already is the 1st', () => {
+      mockToday(new Date(2026, 7, 8));
+      const result = getQuickSettingUpdates('MONTHLY_FIRST_DAY', new Date(2026, 11, 1));
+      expect(result!.startDate).toBe('2026-12-01');
+    });
+
+    it('MONTHLY_LAST_DAY anchors to the end of the reference month', () => {
+      mockToday(new Date(2026, 7, 8));
+      const result = getQuickSettingUpdates('MONTHLY_LAST_DAY', new Date(2026, 11, 15));
+      expect(result!.startDate).toBe('2026-12-31');
+    });
+
+    // Re-deriving the preset from the date it already produced must be a no-op:
+    // the dialog runs this on every save, and a changed startDate reschedules
+    // the live instance (#7373).
+    it('MONTHLY_LAST_DAY leaves an anchor it produced itself alone', () => {
+      mockToday(new Date(2026, 7, 8));
+      const result = getQuickSettingUpdates('MONTHLY_LAST_DAY', new Date(2026, 10, 30));
+      expect(result!.startDate).toBe('2026-11-30');
+    });
+
+    // #7726 still holds: a stale start date must not drag a fresh anchor into
+    // the past, so the reference day is floored at today.
+    it('MONTHLY_FIRST_DAY ignores a reference date that is in the past', () => {
+      mockToday(new Date(2026, 7, 8));
+      const result = getQuickSettingUpdates('MONTHLY_FIRST_DAY', new Date(2020, 0, 15));
+      expect(result!.startDate).toBe('2026-09-01');
+    });
+
+    it('MONTHLY_LAST_DAY ignores a reference date that is in the past', () => {
+      mockToday(new Date(2026, 7, 8));
+      const result = getQuickSettingUpdates('MONTHLY_LAST_DAY', new Date(2020, 0, 15));
+      expect(result!.startDate).toBe('2026-08-31');
+    });
+  });
+
   describe('YEARLY_CURRENT_DATE', () => {
     it('should return YEARLY cycle with repeatEvery 1', () => {
       const result = getQuickSettingUpdates('YEARLY_CURRENT_DATE');

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates.ts
@@ -32,6 +32,13 @@ export const MONTHLY_ANCHOR_RESET: Partial<TaskRepeatCfg> = {
   monthlyLastDay: undefined,
 };
 
+// The day a monthly day-of-month anchor is derived from: the date the
+// recurrence is being set up for — the picked date in the add bar, the config's
+// own start date in the dialog — floored at today so a stale start date cannot
+// drag a freshly chosen preset into the past (#7726).
+const anchorDayFor = (referenceDate: Date | undefined, today: Date): Date =>
+  referenceDate && referenceDate.getTime() > today.getTime() ? referenceDate : today;
+
 /**
  * Returns partial TaskRepeatCfg updates based on the quick setting.
  * @param quickSetting The quick setting to apply
@@ -80,13 +87,15 @@ export const getQuickSettingUpdates = (
     }
 
     case 'MONTHLY_FIRST_DAY': {
-      // Anchor to the next 1st-of-month that is today or later, so the first
-      // generated instance is never backdated (#7726). `month + 1` rolls the
-      // year over correctly in December.
+      // Anchor to the first 1st-of-month on or after the anchor day, so the
+      // first generated instance is never backdated (#7726) and lands in the
+      // month the recurrence was set up for rather than the month it happens to
+      // be saved in. `month + 1` rolls the year over correctly in December.
+      const anchor = anchorDayFor(referenceDate, today);
       const firstDay =
-        today.getDate() === 1
-          ? new Date(today.getFullYear(), today.getMonth(), 1)
-          : new Date(today.getFullYear(), today.getMonth() + 1, 1);
+        anchor.getDate() === 1
+          ? new Date(anchor.getFullYear(), anchor.getMonth(), 1)
+          : new Date(anchor.getFullYear(), anchor.getMonth() + 1, 1);
       return {
         repeatCycle: 'MONTHLY',
         repeatEvery: 1,
@@ -96,11 +105,12 @@ export const getQuickSettingUpdates = (
     }
 
     case 'MONTHLY_LAST_DAY': {
-      // First occurrence = the upcoming last day of the current month, which
-      // is always today or later. The `monthlyLastDay` flag tells the
+      // First occurrence = the last day of the anchor day's month, which is
+      // always that day or later. The `monthlyLastDay` flag tells the
       // occurrence engine to clamp to month-end every month, so `startDate`'s
       // day-of-month no longer needs to be a hardcoded 31 (#7726).
-      const lastDayThisMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+      const anchor = anchorDayFor(referenceDate, today);
+      const lastDayThisMonth = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0);
       return {
         repeatCycle: 'MONTHLY',
         repeatEvery: 1,

--- a/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates.ts
+++ b/src/app/features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-quick-setting-updates.ts
@@ -36,6 +36,12 @@ export const MONTHLY_ANCHOR_RESET: Partial<TaskRepeatCfg> = {
 // recurrence is being set up for — the picked date in the add bar, the config's
 // own start date in the dialog — floored at today so a stale start date cannot
 // drag a freshly chosen preset into the past (#7726).
+//
+// Both day-of-month presets below then take the first day matching their own
+// pattern that falls on or after that anchor, so a recurrence never starts
+// before the day it was set up for. That one rule puts them in different
+// months for the same anchor (2099-12-15 → 2100-01-01 for the 1st, 2099-12-31
+// for the last day), because the two patterns sit at opposite ends of a month.
 const anchorDayFor = (referenceDate: Date | undefined, today: Date): Date =>
   referenceDate && referenceDate.getTime() > today.getTime() ? referenceDate : today;
 
@@ -87,10 +93,9 @@ export const getQuickSettingUpdates = (
     }
 
     case 'MONTHLY_FIRST_DAY': {
-      // Anchor to the first 1st-of-month on or after the anchor day, so the
-      // first generated instance is never backdated (#7726) and lands in the
-      // month the recurrence was set up for rather than the month it happens to
-      // be saved in. `month + 1` rolls the year over correctly in December.
+      // The first 1st-of-month on or after the anchor day: the anchor's own
+      // month when the anchor already is the 1st, the next month otherwise.
+      // `month + 1` rolls the year over correctly in December.
       const anchor = anchorDayFor(referenceDate, today);
       const firstDay =
         anchor.getDate() === 1
@@ -105,8 +110,8 @@ export const getQuickSettingUpdates = (
     }
 
     case 'MONTHLY_LAST_DAY': {
-      // First occurrence = the last day of the anchor day's month, which is
-      // always that day or later. The `monthlyLastDay` flag tells the
+      // The last day of the anchor day's month, which is always that day or
+      // later — the same on-or-after rule. The `monthlyLastDay` flag tells the
       // occurrence engine to clamp to month-end every month, so `startDate`'s
       // day-of-month no longer needs to be a hardcoded 31 (#7726).
       const anchor = anchorDayFor(referenceDate, today);

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -653,6 +653,50 @@ describe('AddTaskBarComponent', () => {
       expect(addRepeatCfgSpy.calls.mostRecent().args[2].startDate).toBe('2024-05-20');
     });
 
+    // The contextual monthly presets read the picked date, so "the 1st of the
+    // month" has to mean the month the user picked into, not the month the bar
+    // happens to be open in. Dates far enough out to stay true whatever day the
+    // suite runs on.
+    it('should anchor a monthly-first-day repeat to the month of the picked date', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const addRepeatCfgSpy = spyOn(
+        TestBed.inject(TaskRepeatCfgService),
+        'addTaskRepeatCfgToTask',
+      );
+
+      component.stateService.updateInputTxt('Pay rent');
+      component.stateService.updateCleanText('Pay rent');
+      component.stateService.updateDate('2099-09-15');
+      component.stateService.updateRepeatSetting({
+        type: 'PRESET',
+        quickSetting: 'MONTHLY_FIRST_DAY',
+      });
+
+      await component.addTask();
+
+      expect(addRepeatCfgSpy.calls.mostRecent().args[2].startDate).toBe('2099-10-01');
+    });
+
+    it('should anchor a monthly-last-day repeat to the month of the picked date', async () => {
+      mockTaskService.add.and.returnValue('task-1');
+      const addRepeatCfgSpy = spyOn(
+        TestBed.inject(TaskRepeatCfgService),
+        'addTaskRepeatCfgToTask',
+      );
+
+      component.stateService.updateInputTxt('Pay rent');
+      component.stateService.updateCleanText('Pay rent');
+      component.stateService.updateDate('2099-09-15');
+      component.stateService.updateRepeatSetting({
+        type: 'PRESET',
+        quickSetting: 'MONTHLY_LAST_DAY',
+      });
+
+      await component.addTask();
+
+      expect(addRepeatCfgSpy.calls.mostRecent().args[2].startDate).toBe('2099-09-30');
+    });
+
     it('should copy entered notes to an inline repeat preset config (discussion #937)', async () => {
       mockTaskService.add.and.returnValue('task-1');
       const addRepeatCfgSpy = spyOn(


### PR DESCRIPTION
`MONTHLY_FIRST_DAY` and `MONTHLY_LAST_DAY` build their anchor from `new Date()` and drop the `referenceDate` both callers pass, so the saved recurrence starts in a month the user never chose. This is the divergence I flagged at the end of #9404 but deliberately left out of it — different cause from the workday roll, so it gets its own change.

Every branch of the bug is reachable today, and I reproduced each before touching the code.

## From the add task bar

Type `Pay rent`, pick **2026-11-15** in the date chip, then choose **Monthly on the last day** in the repeat menu (today being 2026-08-08).

The config is written with `startDate: 2026-08-31` — the last day of the month the bar happens to be open in. The task's own `dueDay` is the picked day, but both `addTaskRepeatCfgToTask` effects derive the first occurrence from the config, so the task itself lands on **Aug 31**, three months before the month that was picked into. There is no start-date field in the add bar, so nothing on screen explains it.

## From the repeat dialog, creating

Open the repeat dialog on a task due **2099-12-15** and pick a monthly day-of-month preset. `MONTHLY_LAST_DAY` writes `2026-08-31`, `MONTHLY_FIRST_DAY` writes `2026-09-01` — a config for a task three years out, anchored in the month the dialog was opened in. After the fix: `2099-12-31` and `2100-01-01`. (Credit to @johannesjo for measuring this branch out — the original description only claimed the two below.)

## From the repeat dialog, editing

A config anchored on **2026-12-31** with `MONTHLY_LAST_DAY`, deliberately set to start in December. Open the dialog, change the title or the reminder time, hit Save.

`save()` re-derives the quick setting from the stored start date on every save with a non-`CUSTOM` quick setting, and this preset ignores that date — so the save writes `startDate: 2026-08-31`. `getTaskRepeatCfgChanges` then puts `startDate` into the change set, `startDate` is a `SCHEDULE_AFFECTING_FIELDS` member, and `rescheduleTaskOnRepeatCfgUpdate$` relocates the live instance. Editing a title moves the recurrence four months earlier. That is the same class of spurious reschedule #7373 fixed for the other fields.

## The fix

One helper, used by both branches:

```ts
const anchorDayFor = (referenceDate: Date | undefined, today: Date): Date =>
  referenceDate && referenceDate.getTime() > today.getTime() ? referenceDate : today;
```

The floor at today is load-bearing rather than defensive, and it is what keeps #7726 intact. A long-running config carries an old start date, so a plain `referenceDate ?? today` would anchor a freshly chosen preset years in the past — the exact backdating #7726 removed. With no reference date, or one already behind us, the anchor is still derived from today and nothing about the current behavior changes.

From the anchor, each preset takes **the first day matching its own pattern that falls on or after that anchor** — one rule, both presets. It lands them in different months for the same anchor (`2099-12-15` → `2100-01-01` for the 1st, `2099-12-31` for the last day) because the two patterns sit at opposite ends of a month, not because they disagree.

That next-month result for `MONTHLY_FIRST_DAY` is deliberate, and it is the reason I did not take the symmetric-looking alternative ("the 1st of the anchor's own month, floored at today", which would give `2099-12-01`). In the add bar the reference date *is* the task's due day, and in the dialog it is a user-set, user-visible start date; either way, starting the recurrence **before** the day the user chose materializes an instance on a day they did not ask for, and in the dialog it drags a visible start date backwards. Too-late costs the user one skipped period and is visible in the start-date field; too-early creates something behind their back. Pinned by `MONTHLY_FIRST_DAY anchors to the 1st after the reference date`.

Left alone on purpose: `MONTHLY_CURRENT_DATE`, `MONTHLY_NTH_WEEKDAY` and `YEARLY_CURRENT_DATE` take the reference verbatim, past included — for those the reference *is* the chosen day, and flooring it would change a behavior nobody has complained about.

**Switching presets inside the dialog does not touch the start date at all.** The form's `change` handler calls `getQuickSettingUpdates()` with no reference, but it applies the result through `field.form.patchValue()`, and `startDate` / `monthlyLastDay` are not formly field keys (`task-repeat-cfg-form.const.ts` has `title`, `quickSetting`, `repeatEvery`, `repeatCycle`, the monthly-weekday pair, the seven weekday flags, and the trailing option toggles). `patchValue` drops keys with no matching control, so the visible start-date field keeps its value and `save()` re-derives from *that*, idempotently. An earlier version of this description claimed the switch re-anchored the visible field on today; that was wrong, and @johannesjo caught it.

**One boundary this does not cross:** the date chip keeps showing the picked day while the config anchors to the 1st or the last day of that month. Rolling the chip the way `MONDAY_TO_FRIDAY` does since #9404 would be a UX change beyond this bug — "monthly on the 1st, starting from the month I picked" is what the preset means, and the workday roll exists for an excluded-day rule these presets do not have.

**Scope, stated plainly:** this fixes configs whose start date is in the *future*. For an already-running monthly config the floor sends the anchor to today, so the first save in each new month still rewrites `startDate`, still puts it in the change set, and still fires `rescheduleTaskOnRepeatCfgUpdate$` — identical before and after this PR. So #7373's class of spurious reschedule is narrowed here, not closed; the common case stays open, and the root of it is that `save()` re-derives the preset unconditionally instead of leaving a stored anchor that already satisfies the preset alone. Happy to take that as a follow-up.

## Coverage

- `get-quick-setting-updates.spec.ts` — six specs: each preset honouring a future reference date, `MONTHLY_FIRST_DAY` on a reference that already is the 1st, `MONTHLY_LAST_DAY` re-deriving the anchor it produced itself (the dialog's every-save path), and both presets ignoring a reference date in the past. 39 total, from 33.
- `add-task-bar.component.spec.ts` — the two picked-date repros above, asserting the `startDate` handed to `addTaskRepeatCfgToTask`. 62, from 60.
- `dialog-edit-task-repeat-cfg.component.spec.ts` — an untouched save on a future-anchored config of each preset, asserting `startDate` is absent from the change set, since key presence is what `rescheduleTaskOnRepeatCfgUpdate$` filters on (`field in changes`). 42, from 40.

The component specs use 2099 dates so they assert the same thing whatever day the suite runs on.

**Verified by breaking each half of the fix first.** Never honouring the reference (the old behavior) → `4 FAILED / 35 SUCCESS` in the util spec, `2 FAILED / 60` in the add bar spec, `2 FAILED / 40` in the dialog spec. Dropping the floor (`referenceDate ?? today`) → `2 FAILED / 37`, `Expected '2020-01-31' to be '2026-08-31'` and `Expected '2020-02-01' to be '2026-09-01'`.

Full `npm test`: **14120 of 14136 passing, 16 skipped** in `Europe/Berlin` *and* `America/Los_Angeles`. `npm run lint`: 0 errors, only the pre-existing grandfathered `max-lines` warnings and two unused-disable directives, none in the touched files.
