### PR TITLE
fix(sync-server): split batch conflict lookups off the two-index OR (#9503)

### DIFF
--- a/.github/workflows/supersync-server-tests.yml
+++ b/.github/workflows/supersync-server-tests.yml
@@ -23,8 +23,12 @@ jobs:
     name: SuperSync Server Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      DATABASE_URL: postgresql://supersync:superpassword@localhost:5432/supersync_db
+    # DATABASE_URL is set PER STEP, not here. Job-level it also reached the unit step, and
+    # the unit suite is written for a machine with no database: monitoring-db.ts adds a
+    # `datasources` override only when DATABASE_URL is set, so monitoring-scripts.spec.ts's
+    # exact-match assertion passed locally and failed on every CI run. That failure then
+    # skipped the two steps below, so the PostgreSQL integration suite never ran here at
+    # all while the check still reported on it.
     services:
       postgres:
         image: postgres:16-alpine
@@ -75,7 +79,11 @@ jobs:
         run: cd packages/super-sync-server && npm test
       - name: Apply PostgreSQL Test Schema
         working-directory: packages/super-sync-server
+        env:
+          DATABASE_URL: postgresql://supersync:superpassword@localhost:5432/supersync_db
         run: npx prisma db push --skip-generate
       - name: Run SuperSync PostgreSQL Integration Tests
         working-directory: packages/super-sync-server
+        env:
+          DATABASE_URL: postgresql://supersync:superpassword@localhost:5432/supersync_db
         run: npm run test:integration:postgres

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -269,7 +269,18 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > `packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts` and the note
   > at `detectConflictForEntity` in `packages/super-sync-server/src/sync/conflict.ts`.
 
-- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL unnesting the **union** of both columns, `entity_ids || CASE WHEN entity_id IS NULL THEN '{}' ELSE ARRAY[entity_id] END`, deduped by `DISTINCT ON`, with an `entity_ids && ... OR entity_id = ANY(...)` prefilter so the `GIN(entity_ids)` index (migration `20260613000001`) and the existing `entity_id` btree stay usable.
+- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL covering the **union** of both columns: a scalar branch (a lateral top-1 per requested id on the `entity_id` btree) `UNION ALL` an array branch (per-id `@>` probes of the `GIN(entity_ids)` index, migration `20260613000001`), deduped by `DISTINCT ON`.
+
+  > ⚠️ The two branches must stay **separate**. They were one query with an
+  > `entity_ids && ... OR entity_id = ANY(...)` prefilter, and this section used to
+  > claim that prefilter kept both indexes usable. It does the opposite: the `OR` spans
+  > the GIN and the `(user_id, entity_type, entity_id, server_seq)` btree, so the planner
+  > abandons both and slice-scans the btree — a 100-id probe matching nothing read and
+  > discarded the user's whole slice, and production cancelled it by `statement_timeout`
+  > every 5–12 minutes (#9503). Same degeneracy as the 2026-07-20 outage. The array
+  > branch also tags each candidate with the id that matched rather than re-deriving it
+  > by unnesting, which otherwise fans out quadratically on wide `entity_ids`. Both
+  > properties are pinned by `tests/batch-conflict-plan.pglite.spec.ts`.
 
   > ⚠️ It must be a **union**, not the mutually exclusive
   > `CASE WHEN cardinality(entity_ids) > 0 THEN entity_ids ELSE ARRAY[entity_id] END`
@@ -281,7 +292,7 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > loss**. That was the #8334 bug; the divergent-scalar case is the decisive test in
   > `tests/integration/conflict-detection-sql.integration.spec.ts`.
 
-**Forward-only by design:** rows written before migration `20260613000000` have an empty `entity_ids` array, so they are reached only by their scalar `entity_id` (= first entity) — via the scalar arm of the batch union above, or the scalar branch of the single-entity lookup. (Not via the exclusive `CASE` form: that is the removed #8334 bug documented in the warning above, not the current shape.) There is no `UPDATE` backfill. Entities 2..n of already-stored multi-entity ops were never persisted and are unrecoverable, so they remain invisible to conflict detection until that entity gets a fresh write. This residual is bounded: client-side LWW is unaffected (the client persists the full op and `VectorClockService.getEntityFrontier()` fans each op out to **every** entity), and the server only builds an authoritative snapshot from non-encrypted ops (`replayOpsToState()` throws on encrypted ops), so the pre-fix gap could only surface a stale value to a fresh client on non-encrypted self-hosted servers.
+**Forward-only by design:** rows written before migration `20260613000000` have an empty `entity_ids` array, so they are reached only by their scalar `entity_id` (= first entity) — via the scalar branch of the batch union above, or the scalar branch of the single-entity lookup. (Not via the exclusive `CASE` form: that is the removed #8334 bug documented in the warning above, not the current shape.) There is no `UPDATE` backfill. Entities 2..n of already-stored multi-entity ops were never persisted and are unrecoverable, so they remain invisible to conflict detection until that entity gets a fresh write. This residual is bounded: client-side LWW is unaffected (the client persists the full op and `VectorClockService.getEntityFrontier()` fans each op out to **every** entity), and the server only builds an authoritative snapshot from non-encrypted ops (`replayOpsToState()` throws on encrypted ops), so the pre-fix gap could only surface a stale value to a fresh client on non-encrypted self-hosted servers.
 
 ### The `SyncImportFilterService` Algorithm
 

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -269,7 +269,7 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > `packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts` and the note
   > at `detectConflictForEntity` in `packages/super-sync-server/src/sync/conflict.ts`.
 
-- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL covering the **union** of both columns: a scalar branch (a lateral top-1 per requested id on the `entity_id` btree) `UNION ALL` an array branch (one `entity_ids && <all requested ids>` probe of the `GIN(entity_ids)` index, migration `20260613000001`), deduped by `DISTINCT ON`.
+- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL covering the **union** of both columns: a scalar branch (a lateral top-1 per requested id on the `entity_id` btree) `UNION ALL` an array branch (per-id `entity_ids @> ARRAY[id]` probes of the `GIN(entity_ids)` index, migration `20260613000001`), deduped by `DISTINCT ON`.
 
   > ⚠️ The two branches must stay **separate**. They were one query with an
   > `entity_ids && ... OR entity_id = ANY(...)` prefilter, and this section used to
@@ -282,15 +282,17 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > by unnesting, which otherwise fans out quadratically on wide `entity_ids`. Both
   > properties are pinned by `tests/batch-conflict-plan.pglite.spec.ts`.
 
-  > ⚠️ The array branch is **one** `&&` probe, not one `@>` per requested id — the
-  > opposite of the single-entity lookup above, which probes a single id and for which
-  > the two are identical. A generic plan cannot see the bound ids, and a GIN scan reads
-  > the whole `fastupdate` pending list, so per-id probes pay both costs once per id:
-  > measured on PG 16.14 at 1.5M rows, 12.4 ms / 700 blocks against 0.64 ms / 601 for
-  > `&&`, and with a dirty pending list 261 ms / 47,800 blocks against 170 ms / 1,072.
-  > Chunked at `CONFLICT_DETECTION_ENTITY_BATCH_SIZE`, a 1000-id op reaches 2.6 s inside
-  > the upload transaction — #9503's own failure mode. Measure with the ids bound
-  > individually as Prisma sends them; one array parameter understates it ~25×.
+  > ⚠️ The array branch probes **per id** (`@>`), not once per batch (`&&`), and neither
+  > form dominates — so do not "optimise" it from a single benchmark. `@>` costs
+  > `probe × (descent + matches)`; `&&` costs `descent + matches × stored width`, because
+  > it must unnest every matching op's array to learn which ids matched. Measured on
+  > PG 16.14: `&&` is 20× faster on an all-new 100-id probe (0.68 ms vs 13.5 ms at 1.5M
+  > rows) and **75× slower** on a 2-id probe against 1000 ops of width 1000 (106 ms vs
+  > 1.4 ms) — and a 2-id probe is the modal multi-entity op. `@>` is shipped because its
+  > terms are bounded (probe size is chunked, descent grows only with index size) while
+  > `matches × width` is bounded by nothing a tenant controls. Equivalence of the forms is
+  > pinned by `tests/array-branch-equivalence.pglite.spec.ts`; measure with the ids bound
+  > individually as Prisma sends them, since one array parameter understates `@>` ~25×.
 
   > ⚠️ It must be a **union**, not the mutually exclusive
   > `CASE WHEN cardinality(entity_ids) > 0 THEN entity_ids ELSE ARRAY[entity_id] END`

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -269,7 +269,7 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > `packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts` and the note
   > at `detectConflictForEntity` in `packages/super-sync-server/src/sync/conflict.ts`.
 
-- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL covering the **union** of both columns: a scalar branch (a lateral top-1 per requested id on the `entity_id` btree) `UNION ALL` an array branch (per-id `@>` probes of the `GIN(entity_ids)` index, migration `20260613000001`), deduped by `DISTINCT ON`.
+- `detectConflictForEntities` / `prefetchLatestEntityOpsForBatch` (batch) — raw SQL covering the **union** of both columns: a scalar branch (a lateral top-1 per requested id on the `entity_id` btree) `UNION ALL` an array branch (one `entity_ids && <all requested ids>` probe of the `GIN(entity_ids)` index, migration `20260613000001`), deduped by `DISTINCT ON`.
 
   > ⚠️ The two branches must stay **separate**. They were one query with an
   > `entity_ids && ... OR entity_id = ANY(...)` prefilter, and this section used to
@@ -281,6 +281,16 @@ The lookups in `conflict.ts` match a requested entity as the scalar `entity_id` 
   > branch also tags each candidate with the id that matched rather than re-deriving it
   > by unnesting, which otherwise fans out quadratically on wide `entity_ids`. Both
   > properties are pinned by `tests/batch-conflict-plan.pglite.spec.ts`.
+
+  > ⚠️ The array branch is **one** `&&` probe, not one `@>` per requested id — the
+  > opposite of the single-entity lookup above, which probes a single id and for which
+  > the two are identical. A generic plan cannot see the bound ids, and a GIN scan reads
+  > the whole `fastupdate` pending list, so per-id probes pay both costs once per id:
+  > measured on PG 16.14 at 1.5M rows, 12.4 ms / 700 blocks against 0.64 ms / 601 for
+  > `&&`, and with a dirty pending list 261 ms / 47,800 blocks against 170 ms / 1,072.
+  > Chunked at `CONFLICT_DETECTION_ENTITY_BATCH_SIZE`, a 1000-id op reaches 2.6 s inside
+  > the upload transaction — #9503's own failure mode. Measure with the ids bound
+  > individually as Prisma sends them; one array parameter understates it ~25×.
 
   > ⚠️ It must be a **union**, not the mutually exclusive
   > `CASE WHEN cardinality(entity_ids) > 0 THEN entity_ids ELSE ARRAY[entity_id] END`

--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
     "pretest": "prisma generate",
     "test": "vitest run",
-    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/repair-causality.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts tests/integration/migrate-deploy-lock-retry.integration.spec.ts",
+    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/batch-conflict-plan.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/repair-causality.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts tests/integration/migrate-deploy-lock-retry.integration.spec.ts",
     "docker:build": "./scripts/build-and-push.sh",
     "docker:deploy": "./scripts/deploy.sh",
     "docker:deploy:build": "./scripts/deploy.sh --build",

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -158,22 +158,36 @@ export const detectConflictForEntities = async (
     // PLUS the sort column are covered by the composite btree, so each probe is an
     // index seek that terminates on an empty range when the entity is new.
     //
-    // Array branch: per-id `@>` probes, NOT one `entity_ids && $arr`. With
-    // `fastupdate = off` (migration 20260720000000, what `prisma migrate deploy` gives
-    // production) both forms ride the GIN and `@>` costs modestly more — +99 blocks on
-    // an all-new probe, +495 on the wide-array one. It earns that back when the pending
-    // list is DIRTY, which every `prisma db push` database has (CI, the E2E stack, the
-    // manual setup in README.md) because `fastupdate = off` cannot be expressed in
-    // schema.prisma: there a single 100-key `&&` is costly enough that the planner
-    // abandons the index for a SEQ SCAN of the whole table.
+    // Scale trade, worth knowing before "optimising" this: the fix moved the array
+    // branch's cost from "the probing user's slice" to "the whole table". That is an
+    // enormous win for the large slice that caused #9503, but on PG 16.14 with a TYPICAL
+    // small slice it inverts as the table grows — measured ~1.6x SLOWER than the old OR
+    // form at 1.5M rows (18.0ms vs 11.2ms), having been ~6x faster at 400k. The gap
+    // widens with table size. Bounding it is #9510.
     //
-    // At the 40k-row seed scale that seq scan is actually FASTER (108ms vs 185ms), so
-    // the case does not rest on wall-clock — it rests on how the two grow. `@>` reads
-    // |probe| x pending-list pages, and the pending list is capped by
-    // `gin_pending_list_limit` (4MB default => ~512 pages, so ~51k blocks at |probe|=100)
-    // INDEPENDENTLY of table size; the seq scan reads the whole heap, which on production
-    // is 5.6GB (~700k blocks). That is a structural bound, not an extrapolation. `@>` is
-    // also the same probe detectConflictForEntity ships.
+    // Array branch: per-id `@>` probes rather than one `entity_ids && $arr`. This is the
+    // same probe detectConflictForEntity ships, and it is NOT the settled choice the rest
+    // of this note is — treat it as the open question here. #9510.
+    //
+    // What is measured: on PGlite/PG18 a single 100-key `&&` under a dirty GIN pending
+    // list is costly enough that the planner abandons the index for a SEQ SCAN, which the
+    // per-id form avoids. That matters because `fastupdate = off` (migration
+    // 20260720000000) cannot be expressed in schema.prisma, so every `prisma db push`
+    // database — CI, the E2E stack, the manual setup in README.md — has the pending list
+    // ON. With the reloption right, `@>` costs +99 blocks on an all-new probe and +495 on
+    // the wide one.
+    //
+    // What does NOT hold: an earlier revision argued this was a "structural bound" from
+    // `gin_pending_list_limit`. Review measured the opposite on PG 16.14, production's
+    // actual version — `&&` stays on the GIN at every pending-list depth tested (no seq
+    // scan reproducible at all) and reads 5-46x FEWER blocks, and isolated GIN cost grows
+    // with table size for `@>` (0.8ms at 400k rows -> 3.7ms at 1.5M) while `&&` stays
+    // flat. The seq-scan fallback this form defends against looks PGlite-specific, and
+    // even there the seq scan measured faster than the GIN plan `@>` gets.
+    //
+    // So the per-id form is currently justified only for db-push databases on PG18-ish
+    // planners. Re-measure `&&` on PG 16 before assuming either way; do not "simplify"
+    // this on the strength of the paragraph above alone.
     //
     // `probe` binds the 100 ids ONCE — they used to be interpolated three times, for
     // 300 of the statement's 302 parameters — and is then referenced twice, so Postgres
@@ -793,14 +807,15 @@ export const prefetchLatestEntityOpsForBatch = async (
     // `array_hits` re-checks the entity TYPE with a row-wise `IN`, not a `JOIN`: `cand`
     // is keyed by id alone (the probe source drops the type), so a stored op matched by
     // id still has to be confirmed against the requested (type, id) PAIR. A semi-join
-    // stops at the first match per candidate where the JOIN scanned on, which measured
-    // 99k comparisons against 198k on the wide-array seed — though that particular
-    // saving is an artefact of the seed's ordering and would shrink on adversarial
-    // input. Output is identical either way (the outer DISTINCT ON absorbs the JOIN's
-    // duplicates), so this is a cost choice, not a correctness one. Under
-    // `force_generic_plan` it stays a NESTED LOOP, not a hash: the residual is
-    // |cand| x |touched|, bounded by the batch size and independent of how wide the
-    // stored arrays are, which is what distinguishes it from a fan-out.
+    // stops at the first match per candidate where the JOIN scanned on. Output is
+    // identical either way (the outer DISTINCT ON absorbs the JOIN's duplicates), so this
+    // is a cost choice, not a correctness one — and a modest, planner-dependent one:
+    // PGlite plans it as a nested loop and the semi-join halves the comparisons
+    // (99k vs 198k on the wide seed, itself an artefact of that seed's ordering), while
+    // PG 16.14 plans BOTH forms as a hash join at identical cost. Kept because it reads
+    // more directly and is never worse. Either way the residual is |cand| x |touched|,
+    // bounded by the batch size and independent of how wide the stored arrays are, which
+    // is what distinguishes it from a fan-out.
     const latestOps = await tx.$queryRaw<LatestBatchEntityOperationRow[]>`
       WITH touched(entity_type, entity_id) AS (
         VALUES ${Prisma.join(touchedRows)}

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -20,105 +20,32 @@ const TASK_TIME_DELTA_ACTION_TYPE = '[TimeTracking] Sync time spent';
  * ARRAY-branch candidates for BOTH batch conflict lookups: every stored op whose
  * `entity_ids` contains a probed id, tagged with the id that matched. Shared rather than
  * hand-copied — the #8334 "keep these two in sync" hazard is exactly what let #9503 ship
- * the same mis-plan into both queries. `probeSource` is passed in (rather than the
- * fragment reaching for a `probe` CTE the caller must remember to define) so the contract
- * is explicit; both call sites were measured plan-identical either way.
+ * the same mis-plan into both queries.
  *
- * Carrying `p.eid` is load-bearing for COST, not correctness. Re-deriving the matched id
- * downstream with `unnest(entity_ids) JOIN probe` instead emits |probe ∩ entity_ids|²
- * rows per op, because `cand` already holds one copy of the op per matching probe id.
- * On batch-conflict-plan.pglite.spec.ts's wide seed that is 59.8M join-filtered rows /
- * 2211 temp blocks / ~23s, against zero and ~8ms for the form below; at the 1000-id wire
- * cap the gap was 36.8s vs 4.5ms. Callers probe an id set that OVERLAPS the stored
- * arrays heavily — detect probes the incoming op's own ids, prefetch the upload batch's
- * — so that is the normal shape, not an edge case. Not selecting `entity_ids` at all
- * also keeps the materialised tuplestore narrow. Both spec guards fail on the fan-out
- * form; keep it that way.
+ * Three properties are load-bearing. Each is a COST property, not a correctness one, so
+ * nothing here fails loudly; changing one needs the full measurements in
+ * docs/sync-and-op-log/vector-clocks.md, not a single benchmark.
  *
- * MATERIALIZED is load-bearing: it stops the outer user_id / entity_type predicates
- * being pushed down, which hands the composite btree back and restores the slice scan
- * this whole change exists to remove (measured: 1106 blocks and no GIN without it).
+ * - `p.eid` is CARRIED, never re-derived downstream by unnesting `entity_ids`: `cand`
+ *   already holds one copy of the op per matching probe id, so re-deriving fans out
+ *   quadratically on wide arrays, and callers normally probe ids that OVERLAP the stored
+ *   arrays heavily. Guarded by the "does not fan out" tests in
+ *   batch-conflict-plan.pglite.spec.ts, which carry the numbers.
+ * - `MATERIALIZED` stops the callers' outer user_id / entity_type predicates being pushed
+ *   down, which would hand the composite btree back and restore the slice scan this whole
+ *   change exists to remove.
+ * - ONE `@>` PROBE PER ID, not one `&&` for the batch. Both forms are correct and both fix
+ *   #9503. `@>` ships because its terms are bounded (probe size is chunked, descent grows
+ *   only with index size) while `&&`'s `matches x stored width` is bounded by nothing a
+ *   tenant controls — but `&&` IS ~20x faster on an all-new probe, so this is a real
+ *   trade and not a free win. Equivalence of the forms is pinned by
+ *   array-branch-equivalence.pglite.spec.ts: swap the form there when you swap it here.
  *
- * Isolation: like the single-entity path, this matches by entity id across ALL users and
- * the callers' outer WHERE enforces the user boundary. CORRECT — cross-tenant rows are
- * rejected before anything is returned, pinned by the ARRAY-branch isolation tests in
- * entity-ids-conflict.pglite.spec.ts — but NOT cost-bounded per user, and that part IS a
- * regression against master, which carried `user_id` inside the scanned relation. The
- * `MATERIALIZED` fence is precisely what forbids putting it back.
- *
- * The cost is linear in the number of rows ACROSS ALL TENANTS carrying a probed id, and
- * the batch paths multiply it by the batch size where the single-entity path probes one.
- * It only bites on ids that are byte-identical across tenants — the hard-coded
- * 'KANBAN_DEFAULT' / 'EISENHOWER_MATRIX' that `sortBoards` both stores and probes.
- *
- * Do NOT read that as "small". Measured on PG 16.14, `fastupdate = off`, a 70-op account
- * probing one shared id: 20k co-tenants => 17.6 ms / 1,072 blk; 80k co-tenants =>
- * 74.3 ms / 2,478 blk and 800 TEMP BLOCKS WRITTEN — the MATERIALIZED tuplestore spills
- * at the shipped `work_mem = 4MB`. Against master's 0.09 ms / 6 blk. Chunked at 100, an
- * op at the wire cap issues ten of those inside one upload transaction, which is the
- * same order as #9503's own failure mode rather than "far from" it.
- *
- * And the driving input is not organic growth — it is other tenants' writes, unmetered:
- * `computeOpStorageBytes` charges payload + vectorClock only, so `entity_ids` costs zero
- * quota while the schema permits 1000 ids x 255 chars per op. Bounding it is #9510; the
- * cheap half of that fix (bill `entity_ids` bytes) needs no SQL change at all.
- *
- * DELIBERATELY NOT COVERED by batch-conflict-plan.pglite.spec.ts: that seed gives every
- * user disjoint ids, so the co-tenant term never appears in it. "Bounded" there means
- * "bounded given disjoint ids", not bounded absolutely. The real fix is the
- * expression-GIN sketched at detectConflictForEntity; it needs its own measurements.
- *
- * ONE `@>` PROBE PER ID, NOT ONE `&&` FOR THE BATCH. Both forms are correct and both fix
- * #9503; this is purely a cost choice, and it is NOT the obvious one, so here is the
- * whole cost model rather than the half of it that fits a single benchmark.
- *
- *   `@>` per id  ~  P x (D + M)        P = probe size (<= 100, chunked)
- *   `&&` batch   ~  D + M x W + M x P  D = index descent + GIN pending-list read
- *                                      M = matching ops,  W = stored entity_ids width
- *
- * `@>` gets the matched id FROM THE INDEX, so it never reads `entity_ids` at all. `&&`
- * must detoast and unnest every element of every matching op to recover which ids
- * matched, and re-scans the probe per candidate. Measured on postgres:16-alpine 16.14
- * (production's version), `fastupdate = off`, `force_generic_plan`, real statements with
- * the ids bound INDIVIDUALLY as Prisma sends them, median of 9:
- *
- *   shape                                  `@>` per id        `&&` batch
- *   100 all-new ids @ 1.5M rows            13.5 ms /    700    0.68 ms /   601 blk
- *   2-id probe, 1000 ops of width 1000      1.4 ms /     28     106 ms / 3,359
- *   10-id probe, same                       7.3 ms /    140     146 ms / 3,453
- *   100-id probe, same                     91.4 ms /  1,490     268 ms / 4,505
- *   100 ids over 10,000 width-2 ops        17.3 ms / 10,600     202 ms /   675
- *
- * NEITHER FORM DOMINATES, and the first row is the honest cost of this choice: `&&` is
- * 20x faster on an all-new probe, and that floor is paid by every batch upload. `@>` is
- * chosen anyway because of WHICH TERM IS BOUNDED. `P` is capped at
- * CONFLICT_DETECTION_ENTITY_BATCH_SIZE and `D` grows only with index size, so `@>` has a
- * predictable ceiling that no tenant's data can move. `M x W` has none: `M` counts
- * matching ops ACROSS ALL TENANTS (this CTE is not user-scoped — see above and #9510),
- * `W` runs to SUPER_SYNC_MAX_ENTITY_IDS_PER_OP, and neither is metered — `entity_ids` is
- * billed at zero bytes by computeOpStorageBytes. On an upload-path statement running
- * inside a transaction, a bounded 13.5 ms beats an unbounded 0.68 ms.
- *
- * MEASURE BOTH REGIMES. `&&` was briefly shipped on the strength of the first row alone,
- * from a seed with ~20 matching ops where the `M x W` term is invisible. A third form
- * (`&&` plus a hashed `x.eid IN (...)` semi-join) removes the `M x P` term — 202 ms ->
- * 34.7 ms on the width-2 shape — but not `M x W`, so it is still 155 ms on the
- * 2-id/width-1000 shape. If you want to revisit this, that is the promising direction,
- * and the bar is the whole table above, not one row of it.
- *
- * All three forms are EQUIVALENT, and that is asserted rather than asserted-about:
- * array-branch-equivalence.pglite.spec.ts differential-tests them against each other over
- * randomised ops and probes plus the edge shapes operators actually disagree on
- * (duplicate and NULL array elements, NULL scalars, divergent scalars, cross-tenant and
- * cross-type id collisions), with mutants that must diverge or the file fails. Swap the
- * form there when you swap it here.
- *
- * WHAT `@>` COSTS IN EXCHANGE: a GIN scan reads the whole `fastupdate` pending list, and
- * P per-id probes read it P times. With a dirty list (471 pending pages) a 100-id probe
- * measured 261 ms / 47,800 blocks against `&&`'s 170 ms / 1,072. Production sets
- * `fastupdate = off` (migration 20260720000000) and is not exposed; `prisma db push`
- * databases are, and README.md documents the one-line `ALTER INDEX` remedy. That is an
- * ops-config problem with an ops-config fix, not a reason to pay `M x W` on every upload.
+ * NOT user-scoped: like the single-entity path this matches by entity id across ALL users,
+ * and the callers' outer WHERE enforces the boundary. Correct — pinned by the ARRAY-branch
+ * isolation tests in entity-ids-conflict.pglite.spec.ts — but the cost is not bounded per
+ * tenant, which IS a regression against master and is tracked as #9510. The `MATERIALIZED`
+ * fence is precisely what forbids putting `user_id` back inside.
  */
 const arrayBranchCandidatesCte = (probeSource: Prisma.Sql): Prisma.Sql => Prisma.sql`
   cand AS MATERIALIZED (
@@ -202,15 +129,14 @@ export const detectConflictForEntities = async (
     // prefetchLatestEntityOpsForBatch — keep them in sync. (#8334)
     //
     // PERF — this must stay TWO separately-indexed branches, for the reason
-    // detectConflictForEntity documents at length below. It was ONE query with a
-    // combined `(entity_ids && $arr OR entity_id = ANY($arr))`, and that OR spans the
-    // entity_ids GIN and the (user_id, entity_type, entity_id, server_seq) btree, so
-    // the planner abandoned both and slice-scanned the btree: measured on PG16.14 and
-    // PGlite, a 100-id probe matching NOTHING read and discarded the probed user's
-    // ENTIRE (user_id, entity_type) slice. On production that ran twice per upload
-    // inside the transaction and was cancelled by statement_timeout every 5-12
-    // minutes (#9503). The batch paths were previously argued to be safe because they
-    // have no LIMIT for the planner to bet on; that was the wrong property to check.
+    // detectConflictForEntity documents at length below. It was ONE query with a combined
+    // `(entity_ids && $arr OR entity_id = ANY($arr))`, and that OR spans the entity_ids
+    // GIN and the (user_id, entity_type, entity_id, server_seq) btree, so the planner
+    // abandoned both and slice-scanned the btree: a 100-id probe matching NOTHING read and
+    // discarded the probed user's ENTIRE (user_id, entity_type) slice, twice per upload
+    // inside the transaction, and production cancelled it by statement_timeout every 5-12
+    // minutes (#9503). Guarded by batch-conflict-plan.pglite.spec.ts, whose CANARY test
+    // still reproduces the mis-plan on the old form.
     //
     // Scalar branch: a lateral top-1 per requested id. All three equality columns
     // PLUS the sort column are covered by the composite btree, so each probe is an
@@ -219,27 +145,17 @@ export const detectConflictForEntities = async (
     // Array branch: per-id `@>` probes. See arrayBranchCandidatesCte for the full cost
     // model and why the one-`&&`-per-batch alternative was measured and rejected.
     //
-    // Scale trade, worth knowing before "optimising" this: the fix moved the array
-    // branch's cost from "the probing user's slice" to a FIXED whole-table GIN probe.
-    // Small accounts therefore pay MORE than they used to, large ones far less.
-    // Measured on PG 16.14 at 1.5M rows with a 100-id all-new probe, median of 9, this
-    // statement against the pre-#9503 one:
+    // Trade accepted knowingly: this moves the array branch's cost from "the probing
+    // user's slice" to a FIXED whole-table GIN probe, so SMALL accounts pay ~13 ms / 700
+    // blocks per call they did not pay before (and this path runs twice per upload) while
+    // large ones pay far less. Accepted because the term it replaces is unbounded in
+    // account history while this one cannot exceed |probe| index descents. Measurements:
+    // PR #9516; the unbounded co-tenant term stacked on top of it is #9510.
     //
-    //   70-op account (typical)             0.05 ms /    3 blk  ->  13.6 ms / 700 blk
-    //   100k-op account (the #9503 one)    37.92 ms / 3659 blk  ->  13.5 ms / 700 blk
-    //
-    // So a typical account pays ~13 ms and ~700 blocks it did not pay before, on every
-    // batch upload, and this path runs twice per upload. That is a real and unconditional
-    // regression, accepted because the term it replaces is unbounded in account history
-    // (production's incident account had a slice far larger than this seed's) while this
-    // one cannot exceed |probe| index descents. It is also why the co-tenant term stacked
-    // on top of it (#9510) matters more than its absolute size suggests.
-    //
-    // `probe` binds the 100 ids ONCE — they used to be interpolated three times, for
-    // 300 of the statement's 302 parameters — and is then referenced twice, so Postgres
-    // materialises the list once. Its DISTINCT is redundant here (detectConflict already
-    // dedupes) and kept only so this shape stays identical to the prefetch sibling,
-    // where the same id can legitimately appear under two entity types.
+    // `probe` binds the ids ONCE and is then referenced twice, so Postgres materialises
+    // the list once. Its DISTINCT is redundant here (detectConflict already dedupes) and
+    // kept only so this shape stays identical to the prefetch sibling, where the same id
+    // can legitimately appear under two entity types.
     const idArray = Prisma.sql`ARRAY[${Prisma.join(batchEntityIds)}]::text[]`;
     const latestOps = await tx.$queryRaw<LatestEntityOperationRow[]>`
       WITH probe(eid) AS (
@@ -828,41 +744,26 @@ export const prefetchLatestEntityOpsForBatch = async (
       start,
       start + CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
     );
-    // The ::text casts pin the VALUES list's column types. Not required — inference
-    // resolves both columns without them on PG 16.14, checked with an untyped PREPARE —
-    // and a future edit that made them load-bearing would fail loudly at PREPARE, not
-    // silently. Kept only because they cost nothing and state the intent.
+    // The ::text casts pin the VALUES list's column types.
     const touchedRows = batchPairs.map(
       ({ entityType, entityId }) => Prisma.sql`(${entityType}::text, ${entityId}::text)`,
     );
 
-    // Two separately-indexed branches, mirroring detectConflictForEntities — see the
-    // PERF note there for the measurements. The array branch itself is the shared
-    // arrayBranchCandidatesCte, so only the scalar branch and the keying differ. (#8334)
+    // Two separately-indexed branches, mirroring detectConflictForEntities — see the PERF
+    // note there. The array branch is the shared arrayBranchCandidatesCte, so only the
+    // scalar branch and the keying differ. (#8334) This was the WORSE of the two under the
+    // old OR form: it carries no `entity_type` predicate of its own, so the btree's usable
+    // prefix was just `user_id` and the degeneracy read the user's ENTIRE history across
+    // every entity type. Only `batchUpload` defaulting to false spared it production
+    // traffic (#9503).
     //
-    // This query was the WORSE of the two: it carries no `entity_type` predicate (the
-    // entity type only ever appeared in the join), so the composite btree's usable
-    // prefix was just `user_id` and the OR degeneracy read the user's ENTIRE history,
-    // every entity type — measured at 20020 rows discarded against detect's 2520 on
-    // batch-conflict-plan.pglite.spec.ts's seed (the whole own-user population, against
-    // just its TASK slice). It is only spared production traffic because `batchUpload`
-    // defaults to false (#9503).
-    //
-    // The requested ids now come from `touched` instead of a second bound array, so
-    // there is no separate id-array parameter at all.
-    //
-    // `array_hits` re-checks the entity TYPE with a row-wise `IN`, not a `JOIN`: `cand`
-    // is keyed by id alone (the probe source drops the type), so a stored op matched by
-    // id still has to be confirmed against the requested (type, id) PAIR. A semi-join
-    // stops at the first match per candidate where the JOIN scanned on. Output is
-    // identical either way (the outer DISTINCT ON absorbs the JOIN's duplicates), so this
-    // is a cost choice, not a correctness one — and a modest, planner-dependent one:
-    // PGlite plans it as a nested loop and the semi-join halves the comparisons
-    // (99k vs 198k on the wide seed, itself an artefact of that seed's ordering), while
-    // PG 16.14 plans BOTH forms as a hash join at identical cost. Kept because it reads
-    // more directly and is never worse. Either way the residual is |cand| x |touched|,
-    // bounded by the batch size and independent of how wide the stored arrays are, which
-    // is what distinguishes it from a fan-out.
+    // `array_hits` re-checks the entity TYPE with a row-wise `IN`, not a `JOIN`: `cand` is
+    // keyed by id alone (the probe source drops the type), so a stored op matched by id
+    // must still be confirmed against the requested (type, id) PAIR. Semi-join vs JOIN is
+    // a cost choice here, not a correctness one — the outer DISTINCT ON absorbs either.
+    // Either way the residual is |cand| x |touched|, bounded by the batch size and
+    // independent of how wide the stored arrays are, which is what distinguishes it from
+    // a fan-out.
     const latestOps = await tx.$queryRaw<LatestBatchEntityOperationRow[]>`
       WITH touched(entity_type, entity_id) AS (
         VALUES ${Prisma.join(touchedRows)}

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -83,29 +83,92 @@ export const detectConflictForEntities = async (
     // when entity_ids is empty) so an op whose entity_id is NOT a member of its
     // own entity_ids — possible when a multi-entity op dedups to a different
     // primary, see getStoredEntityIds — still exposes that scalar entity here.
-    // DISTINCT ON dedupes the harmless overlap when entity_id is already in the
-    // array (the common entity_id = entityIds[0] case). The `&&`/`= ANY`
-    // prefilter keeps the GIN(entity_ids) + entity_id indexes usable; `eid = ANY`
-    // keeps only the requested entities, then DISTINCT ON picks the latest op per
-    // entity. Kept inline (not a shared fragment) so the positional params stay
-    // stable for the conflict-detection.spec mock; the same shape is duplicated in
+    // DISTINCT ON then picks the latest op per entity across both branches, which
+    // also dedupes the harmless overlap when entity_id is already in the array (the
+    // common entity_id = entityIds[0] case). The same shape is duplicated in
     // prefetchLatestEntityOpsForBatch — keep them in sync. (#8334)
+    //
+    // PERF — this must stay TWO separately-indexed branches, for the reason
+    // detectConflictForEntity documents at length below. It was ONE query with a
+    // combined `(entity_ids && $arr OR entity_id = ANY($arr))`, and that OR spans the
+    // entity_ids GIN and the (user_id, entity_type, entity_id, server_seq) btree, so
+    // the planner abandoned both and slice-scanned the btree: measured on PG16.14 and
+    // PGlite, a 100-id probe matching NOTHING read and discarded the probed user's
+    // ENTIRE (user_id, entity_type) slice. On production that ran twice per upload
+    // inside the transaction and was cancelled by statement_timeout every 5-12
+    // minutes (#9503). The batch paths were previously argued to be safe because they
+    // have no LIMIT for the planner to bet on; that was the wrong property to check.
+    //
+    // Scalar branch: a lateral top-1 per requested id. All three equality columns
+    // PLUS the sort column are covered by the composite btree, so each probe is an
+    // index seek that terminates on an empty range when the entity is new.
+    //
+    // Array branch: per-id `@>` probes, NOT one `entity_ids && $arr`. This is
+    // deliberate and measured. A single 100-key `&&` costs enough under a DIRTY GIN
+    // pending list that the planner abandons the index for a SEQ SCAN of the whole
+    // table — and `fastupdate = off` (migration 20260720000000) cannot be expressed in
+    // schema.prisma, so every `prisma db push` database has the pending list ON. The
+    // 1-key `@>` form keeps the GIN chosen in BOTH states for ~100 extra blocks, and
+    // is the same probe detectConflictForEntity already ships. batch-conflict-plan
+    // .pglite.spec.ts pins both properties; do not "simplify" this back to `&&`.
+    //
+    // MATERIALIZED is load-bearing on `cand`, exactly as in the single-entity path:
+    // it stops the outer user_id / entity_type predicates being pushed down, which
+    // would hand the composite btree back and restore the slice scan (measured: 2500
+    // rows discarded with them pushed in, 0 with the fence).
+    //
+    // `probe` binds the 100 ids ONCE — they used to be interpolated three times, for
+    // 300 of the statement's 302 parameters — and is then referenced three times, so
+    // Postgres materialises the list once. DISTINCT mirrors the prefetch sibling,
+    // where the same id can legitimately appear under two entity types.
     const idArray = Prisma.sql`ARRAY[${Prisma.join(batchEntityIds)}]::text[]`;
     const latestOps = await tx.$queryRaw<LatestEntityOperationRow[]>`
+      WITH probe(eid) AS (
+        SELECT DISTINCT unnest(${idArray})
+      ),
+      scalar_hits AS (
+        SELECT p.eid AS eid, x.client_id, x.action_type, x.vector_clock, x.server_seq
+        FROM probe p
+        CROSS JOIN LATERAL (
+          SELECT o.client_id, o.action_type, o.vector_clock, o.server_seq
+          FROM operations o
+          WHERE o.user_id = ${userId}
+            AND o.entity_type = ${op.entityType}
+            AND o.entity_id = p.eid
+          ORDER BY o.server_seq DESC
+          LIMIT 1
+        ) x
+      ),
+      cand AS MATERIALIZED (
+        SELECT x.user_id, x.entity_type, x.entity_ids, x.client_id, x.action_type,
+               x.vector_clock, x.server_seq
+        FROM probe p
+        CROSS JOIN LATERAL (
+          SELECT o.user_id, o.entity_type, o.entity_ids, o.client_id, o.action_type,
+                 o.vector_clock, o.server_seq
+          FROM operations o
+          WHERE o.entity_ids @> ARRAY[p.eid]
+        ) x
+      ),
+      array_hits AS (
+        SELECT m.eid AS eid, c.client_id, c.action_type, c.vector_clock, c.server_seq
+        FROM cand c
+        CROSS JOIN LATERAL unnest(c.entity_ids) AS m(eid)
+        JOIN probe p2 ON p2.eid = m.eid
+        WHERE c.user_id = ${userId}
+          AND c.entity_type = ${op.entityType}
+      )
       SELECT DISTINCT ON (eid)
         eid AS "entityId",
-        o.client_id AS "clientId",
-        o.action_type AS "actionType",
-        o.vector_clock AS "vectorClock"
-      FROM operations o
-      CROSS JOIN LATERAL unnest(
-        o.entity_ids || CASE WHEN o.entity_id IS NULL THEN '{}'::text[] ELSE ARRAY[o.entity_id] END
-      ) AS eid
-      WHERE o.user_id = ${userId}
-        AND o.entity_type = ${op.entityType}
-        AND (o.entity_ids && ${idArray} OR o.entity_id = ANY(${idArray}))
-        AND eid = ANY(${idArray})
-      ORDER BY eid, o.server_seq DESC
+        client_id AS "clientId",
+        action_type AS "actionType",
+        vector_clock AS "vectorClock"
+      FROM (
+        SELECT * FROM scalar_hits
+        UNION ALL
+        SELECT * FROM array_hits
+      ) u
+      ORDER BY eid, server_seq DESC
     `;
 
     const latestOpByEntityId = new Map<string, LatestEntityOperationRow>();
@@ -230,11 +293,14 @@ export const detectConflictForEntity = async (
   // sorts it (or walks (user_id, server_seq) backwards, betting `LIMIT 1` resolves
   // early). For an entity with no matching rows — the first-ever op for a new task,
   // the single most common upload there is — nothing bounds that work and it reads
-  // the user's whole slice. The batch unnest paths (detectConflictForEntities /
-  // prefetchLatestEntityOpsForBatch) cannot make that EARLY-EXIT bet — no LIMIT, and
-  // DISTINCT ON forces full evaluation. They carry the same two-index OR, though, so
-  // the SLICE-SCAN degeneracy is not excluded for them, and nothing EXPLAINs either
-  // batch query today (#9205).
+  // the user's whole slice. The batch unnest paths carried the same two-index OR and
+  // WERE hit by it: this paragraph used to argue they were safe because they have no
+  // LIMIT for the planner to bet on and DISTINCT ON forces full evaluation. Both
+  // statements are true and the conclusion was still wrong — "no early-exit bet to
+  // lose" and "cheap" are different properties, and the SLICE SCAN does not need a
+  // LIMIT. Production cancelled detectConflictForEntities by statement_timeout every
+  // 5-12 minutes until it was split the same way (#9503). Both batch queries are now
+  // EXPLAINed by batch-conflict-plan.pglite.spec.ts (#9205).
   //
   // Scalar branch: the (user_id, entity_type, entity_id, server_seq) btree covers all
   // three equality columns PLUS the sort column, so this is a direct index seek and a
@@ -655,37 +721,80 @@ export const prefetchLatestEntityOpsForBatch = async (
       start,
       start + CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
     );
+    // The ::text casts let the VALUES list stand alone as a CTE: without them
+    // Postgres cannot infer a type for the bound parameters outside a comparison.
     const touchedRows = batchPairs.map(
-      ({ entityType, entityId }) => Prisma.sql`(${entityType}, ${entityId})`,
+      ({ entityType, entityId }) => Prisma.sql`(${entityType}::text, ${entityId}::text)`,
     );
-    // Prefilter array (all requested ids) so the JOIN below can match a requested
-    // id inside a stored op's entity_ids set, not just its scalar entity_id, while
-    // keeping the GIN(entity_ids) + entity_id indexes usable. The unnest folds the
-    // scalar entity_id into the entity_ids set (UNION, deduped by DISTINCT ON) so a
-    // divergent scalar is never missed — see the matching note in
-    // detectConflictForEntities; keep the two shapes in sync. (#8334)
-    const idArray = Prisma.sql`ARRAY[${Prisma.join(
-      batchPairs.map((pair) => pair.entityId),
-    )}]::text[]`;
 
+    // Two separately-indexed branches, mirroring detectConflictForEntities — see the
+    // PERF note there for the measurements and for why the array branch probes per id
+    // rather than with one `&&`. Keep the two shapes in sync. (#8334)
+    //
+    // This query was the WORSE of the two: it carries no `entity_type` predicate (the
+    // entity type only ever appeared in the join), so the composite btree's usable
+    // prefix was just `user_id` and the OR degeneracy read the user's ENTIRE history,
+    // every entity type — measured at 20007 rows discarded against detect's 2500 on
+    // the same seed. It is only spared production traffic because `batchUpload`
+    // defaults to false (#9503).
+    //
+    // The requested ids now come from `touched` instead of a second bound array, so
+    // there is no separate id-array parameter at all.
     const latestOps = await tx.$queryRaw<LatestBatchEntityOperationRow[]>`
-      SELECT DISTINCT ON (o.entity_type, eid)
-        o.entity_type AS "entityType",
+      WITH touched(entity_type, entity_id) AS (
+        VALUES ${Prisma.join(touchedRows)}
+      ),
+      probe(eid) AS (
+        SELECT DISTINCT entity_id FROM touched
+      ),
+      scalar_hits AS (
+        SELECT t.entity_type, t.entity_id AS eid, x.client_id, x.action_type,
+               x.vector_clock, x.server_seq
+        FROM touched t
+        CROSS JOIN LATERAL (
+          SELECT o.client_id, o.action_type, o.vector_clock, o.server_seq
+          FROM operations o
+          WHERE o.user_id = ${userId}
+            AND o.entity_type = t.entity_type
+            AND o.entity_id = t.entity_id
+          ORDER BY o.server_seq DESC
+          LIMIT 1
+        ) x
+      ),
+      cand AS MATERIALIZED (
+        SELECT x.user_id, x.entity_type, x.entity_ids, x.client_id, x.action_type,
+               x.vector_clock, x.server_seq
+        FROM probe p
+        CROSS JOIN LATERAL (
+          SELECT o.user_id, o.entity_type, o.entity_ids, o.client_id, o.action_type,
+                 o.vector_clock, o.server_seq
+          FROM operations o
+          WHERE o.entity_ids @> ARRAY[p.eid]
+        ) x
+      ),
+      array_hits AS (
+        SELECT c.entity_type, m.eid AS eid, c.client_id, c.action_type,
+               c.vector_clock, c.server_seq
+        FROM cand c
+        CROSS JOIN LATERAL unnest(c.entity_ids) AS m(eid)
+        JOIN touched t2
+          ON t2.entity_type = c.entity_type
+         AND t2.entity_id = m.eid
+        WHERE c.user_id = ${userId}
+      )
+      SELECT DISTINCT ON (entity_type, eid)
+        entity_type AS "entityType",
         eid AS "entityId",
-        o.client_id AS "clientId",
-        o.action_type AS "actionType",
-        o.vector_clock AS "vectorClock",
-        o.server_seq AS "serverSeq"
-      FROM operations o
-      CROSS JOIN LATERAL unnest(
-        o.entity_ids || CASE WHEN o.entity_id IS NULL THEN '{}'::text[] ELSE ARRAY[o.entity_id] END
-      ) AS eid
-      JOIN (VALUES ${Prisma.join(touchedRows)}) AS touched(entity_type, entity_id)
-        ON touched.entity_type = o.entity_type
-       AND touched.entity_id = eid
-      WHERE o.user_id = ${userId}
-        AND (o.entity_ids && ${idArray} OR o.entity_id = ANY(${idArray}))
-      ORDER BY o.entity_type, eid, o.server_seq DESC
+        client_id AS "clientId",
+        action_type AS "actionType",
+        vector_clock AS "vectorClock",
+        server_seq AS "serverSeq"
+      FROM (
+        SELECT * FROM scalar_hits
+        UNION ALL
+        SELECT * FROM array_hits
+      ) u
+      ORDER BY entity_type, eid, server_seq DESC
     `;
 
     for (const latestOp of latestOps) {

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -61,13 +61,63 @@ const TASK_TIME_DELTA_ACTION_TYPE = '[TimeTracking] Sync time spent';
  * seed violates by construction. So "bounded" there means "bounded given disjoint ids",
  * not bounded absolutely. The real fix is the expression-GIN sketched at
  * detectConflictForEntity; it needs its own issue and its own measurements.
+ *
+ * ONE `&&` PROBE, NOT ONE `@>` PER ID. This is the load-bearing cost decision, and it is
+ * the opposite of what the single-entity path does — deliberately, because that path
+ * probes one id and the two forms are then identical.
+ *
+ * Two independent reasons, and BOTH were measured by A/B-ing the real statement this
+ * file emits with only this CTE swapped — on postgres:16-alpine 16.14 (production's
+ * version), 1.5M rows, 100-id all-new probe, `force_generic_plan`:
+ *
+ *   fastupdate            `@>` per id            `&&`
+ *   off (production)       12.4 ms /    700 blk   0.64 ms /   601 blk
+ *   on  (prisma db push)    261 ms / 47,800 blk    170 ms / 1,072 blk
+ *
+ * 1. Under a generic plan Postgres cannot see the 100 bound ids, and re-probing the GIN
+ *    once per opaque parameter costs ~18x what one multi-key probe costs. Measure this
+ *    with the ids bound INDIVIDUALLY, as Prisma sends them (104 parameters); collapsing
+ *    them into one array parameter makes the per-id form look ~25x cheaper than it is,
+ *    which is how it got shipped.
+ * 2. A GIN scan must read the whole PENDING LIST, so N per-id probes read it N times
+ *    where one `&&` reads it once — I/O linear in CONFLICT_DETECTION_ENTITY_BATCH_SIZE.
+ *    The list is bounded only by `gin_pending_list_limit` (4MB / ~512 pages by default),
+ *    not by anything a tenant controls. Both callers CHUNK at 100 ids, so an op carrying
+ *    the 1000-id wire cap issues ten such statements in one upload transaction: 2.6 s of
+ *    `@>` against 1.7 s of `&&`, 478,000 blocks against 10,720. Multi-second statements
+ *    inside the upload transaction are #9503's own failure mode, re-created by its fix.
+ *    Production sets `fastupdate = off` (migration 20260720000000) so it is not exposed,
+ *    but that reloption cannot be expressed in schema.prisma, so every `prisma db push`
+ *    database — CI, the E2E stack, the manual setup in README.md — is.
+ *
+ * An earlier revision shipped the per-id form on the grounds that PGlite/PG18 abandons
+ * the GIN for a SEQ SCAN under a dirty pending list. The plan claim is true and the cost
+ * conclusion was backwards: that seq scan is 6.8x FASTER and reads 20x fewer blocks than
+ * the GIN plan `@>` gets (26 ms / 981 blk vs 175 ms / 19,600 blk on the batch spec's
+ * seed). Do not "restore" the per-id form on the strength of a plan shape; measure cost.
+ *
+ * The LATERAL recovers WHICH probed ids each candidate matched — `cand` must stay tagged
+ * with `eid`, see above. It is bounded by |matching ops| x |entity_ids|, NOT squared:
+ * one row per (op, matched id) pair, exactly as the `@>` form produced. Verified
+ * equivalent to that form by differential fuzzing (448 comparisons over randomised ops
+ * and probes, zero differences; controls that drop the INTERSECT or weaken `&&` to `@>`
+ * diverge in 220/224 and 173/224 rounds).
+ *
+ * The COALESCE is documentation, not defence: an empty probe makes `array_agg` NULL and
+ * `entity_ids && NULL` already excludes every row, which is the same nothing the `@>`
+ * form returned. Both callers chunk a non-empty batch, so it is unreachable either way.
  */
 const arrayBranchCandidatesCte = (probeSource: Prisma.Sql): Prisma.Sql => Prisma.sql`
   cand AS MATERIALIZED (
-    SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+    SELECT x.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
            o.vector_clock, o.server_seq
-    FROM (${probeSource}) p
-    JOIN operations o ON o.entity_ids @> ARRAY[p.eid]
+    FROM operations o
+    CROSS JOIN LATERAL (
+      SELECT unnest(o.entity_ids) AS eid
+      INTERSECT
+      SELECT eid FROM (${probeSource}) p
+    ) x
+    WHERE o.entity_ids && COALESCE((SELECT array_agg(eid) FROM (${probeSource}) q), '{}')
   )
 `;
 
@@ -158,36 +208,22 @@ export const detectConflictForEntities = async (
     // PLUS the sort column are covered by the composite btree, so each probe is an
     // index seek that terminates on an empty range when the entity is new.
     //
+    // Array branch: see arrayBranchCandidatesCte for why it is ONE `&&` and not one
+    // `@>` per id, with the measurements.
+    //
     // Scale trade, worth knowing before "optimising" this: the fix moved the array
-    // branch's cost from "the probing user's slice" to "the whole table". That is an
-    // enormous win for the large slice that caused #9503, but on PG 16.14 with a TYPICAL
-    // small slice it inverts as the table grows — measured ~1.6x SLOWER than the old OR
-    // form at 1.5M rows (18.0ms vs 11.2ms), having been ~6x faster at 400k. The gap
-    // widens with table size. Bounding it is #9510.
+    // branch's cost from "the probing user's slice" to a roughly FIXED whole-table GIN
+    // probe. Small accounts therefore pay MORE than they used to, large ones far less.
+    // Measured on PG 16.14 at 1.5M rows with a 100-id all-new probe, this statement
+    // against the pre-#9503 one:
     //
-    // Array branch: per-id `@>` probes rather than one `entity_ids && $arr`. This is the
-    // same probe detectConflictForEntity ships, and it is NOT the settled choice the rest
-    // of this note is — treat it as the open question here. #9510.
+    //   70-op account (typical)             0.05 ms /    3 blk  ->  0.59 ms / 601 blk
+    //   100k-op account (the #9503 one)    37.77 ms / 4048 blk  ->  0.69 ms / 601 blk
     //
-    // What is measured: on PGlite/PG18 a single 100-key `&&` under a dirty GIN pending
-    // list is costly enough that the planner abandons the index for a SEQ SCAN, which the
-    // per-id form avoids. That matters because `fastupdate = off` (migration
-    // 20260720000000) cannot be expressed in schema.prisma, so every `prisma db push`
-    // database — CI, the E2E stack, the manual setup in README.md — has the pending list
-    // ON. With the reloption right, `@>` costs +99 blocks on an all-new probe and +495 on
-    // the wide one.
-    //
-    // What does NOT hold: an earlier revision argued this was a "structural bound" from
-    // `gin_pending_list_limit`. Review measured the opposite on PG 16.14, production's
-    // actual version — `&&` stays on the GIN at every pending-list depth tested (no seq
-    // scan reproducible at all) and reads 5-46x FEWER blocks, and isolated GIN cost grows
-    // with table size for `@>` (0.8ms at 400k rows -> 3.7ms at 1.5M) while `&&` stays
-    // flat. The seq-scan fallback this form defends against looks PGlite-specific, and
-    // even there the seq scan measured faster than the GIN plan `@>` gets.
-    //
-    // So the per-id form is currently justified only for db-push databases on PG18-ish
-    // planners. Re-measure `&&` on PG 16 before assuming either way; do not "simplify"
-    // this on the strength of the paragraph above alone.
+    // A typical account pays ~0.5 ms and ~600 blocks it did not pay before. That is
+    // worth it because the term it replaces is unbounded in account history, while this
+    // one is flat — but it is a real regression for small accounts, not a free win, and
+    // it is the reason the co-tenant term on top of it (#9510) matters.
     //
     // `probe` binds the 100 ids ONCE — they used to be interpolated three times, for
     // 300 of the statement's 302 parameters — and is then referenced twice, so Postgres
@@ -782,17 +818,19 @@ export const prefetchLatestEntityOpsForBatch = async (
       start,
       start + CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
     );
-    // The ::text casts let the VALUES list stand alone as a CTE: without them
-    // Postgres cannot infer a type for the bound parameters outside a comparison.
+    // The ::text casts pin the VALUES list's column types explicitly. They are belt and
+    // braces, not a requirement: inference from the `o.entity_type = t.entity_type`
+    // comparisons resolves both columns to text without them on PG 16.14 (checked with
+    // an untyped PREPARE, which is what leaves inference to do the work). Kept because a
+    // future edit that drops the last comparison — the array branch already probes
+    // `touched` through `array_agg` alone — would silently make them load-bearing.
     const touchedRows = batchPairs.map(
       ({ entityType, entityId }) => Prisma.sql`(${entityType}::text, ${entityId}::text)`,
     );
 
     // Two separately-indexed branches, mirroring detectConflictForEntities — see the
-    // PERF note there for the measurements and for why the array branch probes per id
-    // rather than with one `&&`. The array branch itself is the shared
-    // ARRAY_BRANCH_CANDIDATES_CTE, so only the scalar branch and the keying differ.
-    // (#8334)
+    // PERF note there for the measurements. The array branch itself is the shared
+    // arrayBranchCandidatesCte, so only the scalar branch and the keying differ. (#8334)
     //
     // This query was the WORSE of the two: it carries no `entity_type` predicate (the
     // entity type only ever appeared in the join), so the composite btree's usable

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -47,77 +47,85 @@ const TASK_TIME_DELTA_ACTION_TYPE = '[TimeTracking] Sync time spent';
  * `MATERIALIZED` fence is precisely what forbids putting it back.
  *
  * The cost is linear in the number of rows ACROSS ALL TENANTS carrying a probed id, and
- * the batch paths multiply it by the batch size (up to 1000 ids/op) where the
- * single-entity path probes one. Measured: 4000 co-tenants sharing one id => 30ms here
- * vs 0.1ms on master; a 100-id wide probe with 40 co-tenants => 14401 blocks / 821 temp
- * blocks / 110ms vs master's 810 blocks / 33ms. It only bites on ids that are
- * byte-identical across tenants — the hard-coded 'KANBAN_DEFAULT' / 'EISENHOWER_MATRIX'
- * that `sortBoards` both stores and probes — so it is small today and far from the
- * multi-second statement_timeout #9503 was about, but it grows with server population
- * and nothing the tenant controls bounds it.
+ * the batch paths multiply it by the batch size where the single-entity path probes one.
+ * It only bites on ids that are byte-identical across tenants — the hard-coded
+ * 'KANBAN_DEFAULT' / 'EISENHOWER_MATRIX' that `sortBoards` both stores and probes.
+ *
+ * Do NOT read that as "small". Measured on PG 16.14, `fastupdate = off`, a 70-op account
+ * probing one shared id: 20k co-tenants => 17.6 ms / 1,072 blk; 80k co-tenants =>
+ * 74.3 ms / 2,478 blk and 800 TEMP BLOCKS WRITTEN — the MATERIALIZED tuplestore spills
+ * at the shipped `work_mem = 4MB`. Against master's 0.09 ms / 6 blk. Chunked at 100, an
+ * op at the wire cap issues ten of those inside one upload transaction, which is the
+ * same order as #9503's own failure mode rather than "far from" it.
+ *
+ * And the driving input is not organic growth — it is other tenants' writes, unmetered:
+ * `computeOpStorageBytes` charges payload + vectorClock only, so `entity_ids` costs zero
+ * quota while the schema permits 1000 ids x 255 chars per op. Bounding it is #9510; the
+ * cheap half of that fix (bill `entity_ids` bytes) needs no SQL change at all.
  *
  * DELIBERATELY NOT COVERED by batch-conflict-plan.pglite.spec.ts: that seed gives every
- * user disjoint ids, and `expectBounded` asserts `rowsFiltered === 0`, which a shared-id
- * seed violates by construction. So "bounded" there means "bounded given disjoint ids",
- * not bounded absolutely. The real fix is the expression-GIN sketched at
- * detectConflictForEntity; it needs its own issue and its own measurements.
+ * user disjoint ids, so the co-tenant term never appears in it. "Bounded" there means
+ * "bounded given disjoint ids", not bounded absolutely. The real fix is the
+ * expression-GIN sketched at detectConflictForEntity; it needs its own measurements.
  *
- * ONE `&&` PROBE, NOT ONE `@>` PER ID. This is the load-bearing cost decision, and it is
- * the opposite of what the single-entity path does — deliberately, because that path
- * probes one id and the two forms are then identical.
+ * ONE `@>` PROBE PER ID, NOT ONE `&&` FOR THE BATCH. Both forms are correct and both fix
+ * #9503; this is purely a cost choice, and it is NOT the obvious one, so here is the
+ * whole cost model rather than the half of it that fits a single benchmark.
  *
- * Two independent reasons, and BOTH were measured by A/B-ing the real statement this
- * file emits with only this CTE swapped — on postgres:16-alpine 16.14 (production's
- * version), 1.5M rows, 100-id all-new probe, `force_generic_plan`:
+ *   `@>` per id  ~  P x (D + M)        P = probe size (<= 100, chunked)
+ *   `&&` batch   ~  D + M x W + M x P  D = index descent + GIN pending-list read
+ *                                      M = matching ops,  W = stored entity_ids width
  *
- *   fastupdate            `@>` per id            `&&`
- *   off (production)       12.4 ms /    700 blk   0.64 ms /   601 blk
- *   on  (prisma db push)    261 ms / 47,800 blk    170 ms / 1,072 blk
+ * `@>` gets the matched id FROM THE INDEX, so it never reads `entity_ids` at all. `&&`
+ * must detoast and unnest every element of every matching op to recover which ids
+ * matched, and re-scans the probe per candidate. Measured on postgres:16-alpine 16.14
+ * (production's version), `fastupdate = off`, `force_generic_plan`, real statements with
+ * the ids bound INDIVIDUALLY as Prisma sends them, median of 9:
  *
- * 1. Under a generic plan Postgres cannot see the 100 bound ids, and re-probing the GIN
- *    once per opaque parameter costs ~18x what one multi-key probe costs. Measure this
- *    with the ids bound INDIVIDUALLY, as Prisma sends them (104 parameters); collapsing
- *    them into one array parameter makes the per-id form look ~25x cheaper than it is,
- *    which is how it got shipped.
- * 2. A GIN scan must read the whole PENDING LIST, so N per-id probes read it N times
- *    where one `&&` reads it once — I/O linear in CONFLICT_DETECTION_ENTITY_BATCH_SIZE.
- *    The list is bounded only by `gin_pending_list_limit` (4MB / ~512 pages by default),
- *    not by anything a tenant controls. Both callers CHUNK at 100 ids, so an op carrying
- *    the 1000-id wire cap issues ten such statements in one upload transaction: 2.6 s of
- *    `@>` against 1.7 s of `&&`, 478,000 blocks against 10,720. Multi-second statements
- *    inside the upload transaction are #9503's own failure mode, re-created by its fix.
- *    Production sets `fastupdate = off` (migration 20260720000000) so it is not exposed,
- *    but that reloption cannot be expressed in schema.prisma, so every `prisma db push`
- *    database — CI, the E2E stack, the manual setup in README.md — is.
+ *   shape                                  `@>` per id        `&&` batch
+ *   100 all-new ids @ 1.5M rows            13.5 ms /    700    0.68 ms /   601 blk
+ *   2-id probe, 1000 ops of width 1000      1.4 ms /     28     106 ms / 3,359
+ *   10-id probe, same                       7.3 ms /    140     146 ms / 3,453
+ *   100-id probe, same                     91.4 ms /  1,490     268 ms / 4,505
+ *   100 ids over 10,000 width-2 ops        17.3 ms / 10,600     202 ms /   675
  *
- * An earlier revision shipped the per-id form on the grounds that PGlite/PG18 abandons
- * the GIN for a SEQ SCAN under a dirty pending list. The plan claim is true and the cost
- * conclusion was backwards: that seq scan is 6.8x FASTER and reads 20x fewer blocks than
- * the GIN plan `@>` gets (26 ms / 981 blk vs 175 ms / 19,600 blk on the batch spec's
- * seed). Do not "restore" the per-id form on the strength of a plan shape; measure cost.
+ * NEITHER FORM DOMINATES, and the first row is the honest cost of this choice: `&&` is
+ * 20x faster on an all-new probe, and that floor is paid by every batch upload. `@>` is
+ * chosen anyway because of WHICH TERM IS BOUNDED. `P` is capped at
+ * CONFLICT_DETECTION_ENTITY_BATCH_SIZE and `D` grows only with index size, so `@>` has a
+ * predictable ceiling that no tenant's data can move. `M x W` has none: `M` counts
+ * matching ops ACROSS ALL TENANTS (this CTE is not user-scoped — see above and #9510),
+ * `W` runs to SUPER_SYNC_MAX_ENTITY_IDS_PER_OP, and neither is metered — `entity_ids` is
+ * billed at zero bytes by computeOpStorageBytes. On an upload-path statement running
+ * inside a transaction, a bounded 13.5 ms beats an unbounded 0.68 ms.
  *
- * The LATERAL recovers WHICH probed ids each candidate matched — `cand` must stay tagged
- * with `eid`, see above. It is bounded by |matching ops| x |entity_ids|, NOT squared:
- * one row per (op, matched id) pair, exactly as the `@>` form produced. Verified
- * equivalent to that form by differential fuzzing (448 comparisons over randomised ops
- * and probes, zero differences; controls that drop the INTERSECT or weaken `&&` to `@>`
- * diverge in 220/224 and 173/224 rounds).
+ * MEASURE BOTH REGIMES. `&&` was briefly shipped on the strength of the first row alone,
+ * from a seed with ~20 matching ops where the `M x W` term is invisible. A third form
+ * (`&&` plus a hashed `x.eid IN (...)` semi-join) removes the `M x P` term — 202 ms ->
+ * 34.7 ms on the width-2 shape — but not `M x W`, so it is still 155 ms on the
+ * 2-id/width-1000 shape. If you want to revisit this, that is the promising direction,
+ * and the bar is the whole table above, not one row of it.
  *
- * The COALESCE is documentation, not defence: an empty probe makes `array_agg` NULL and
- * `entity_ids && NULL` already excludes every row, which is the same nothing the `@>`
- * form returned. Both callers chunk a non-empty batch, so it is unreachable either way.
+ * All three forms are EQUIVALENT, and that is asserted rather than asserted-about:
+ * array-branch-equivalence.pglite.spec.ts differential-tests them against each other over
+ * randomised ops and probes plus the edge shapes operators actually disagree on
+ * (duplicate and NULL array elements, NULL scalars, divergent scalars, cross-tenant and
+ * cross-type id collisions), with mutants that must diverge or the file fails. Swap the
+ * form there when you swap it here.
+ *
+ * WHAT `@>` COSTS IN EXCHANGE: a GIN scan reads the whole `fastupdate` pending list, and
+ * P per-id probes read it P times. With a dirty list (471 pending pages) a 100-id probe
+ * measured 261 ms / 47,800 blocks against `&&`'s 170 ms / 1,072. Production sets
+ * `fastupdate = off` (migration 20260720000000) and is not exposed; `prisma db push`
+ * databases are, and README.md documents the one-line `ALTER INDEX` remedy. That is an
+ * ops-config problem with an ops-config fix, not a reason to pay `M x W` on every upload.
  */
 const arrayBranchCandidatesCte = (probeSource: Prisma.Sql): Prisma.Sql => Prisma.sql`
   cand AS MATERIALIZED (
-    SELECT x.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+    SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
            o.vector_clock, o.server_seq
-    FROM operations o
-    CROSS JOIN LATERAL (
-      SELECT unnest(o.entity_ids) AS eid
-      INTERSECT
-      SELECT eid FROM (${probeSource}) p
-    ) x
-    WHERE o.entity_ids && COALESCE((SELECT array_agg(eid) FROM (${probeSource}) q), '{}')
+    FROM (${probeSource}) p
+    JOIN operations o ON o.entity_ids @> ARRAY[p.eid]
   )
 `;
 
@@ -208,22 +216,24 @@ export const detectConflictForEntities = async (
     // PLUS the sort column are covered by the composite btree, so each probe is an
     // index seek that terminates on an empty range when the entity is new.
     //
-    // Array branch: see arrayBranchCandidatesCte for why it is ONE `&&` and not one
-    // `@>` per id, with the measurements.
+    // Array branch: per-id `@>` probes. See arrayBranchCandidatesCte for the full cost
+    // model and why the one-`&&`-per-batch alternative was measured and rejected.
     //
     // Scale trade, worth knowing before "optimising" this: the fix moved the array
-    // branch's cost from "the probing user's slice" to a roughly FIXED whole-table GIN
-    // probe. Small accounts therefore pay MORE than they used to, large ones far less.
-    // Measured on PG 16.14 at 1.5M rows with a 100-id all-new probe, this statement
-    // against the pre-#9503 one:
+    // branch's cost from "the probing user's slice" to a FIXED whole-table GIN probe.
+    // Small accounts therefore pay MORE than they used to, large ones far less.
+    // Measured on PG 16.14 at 1.5M rows with a 100-id all-new probe, median of 9, this
+    // statement against the pre-#9503 one:
     //
-    //   70-op account (typical)             0.05 ms /    3 blk  ->  0.59 ms / 601 blk
-    //   100k-op account (the #9503 one)    37.77 ms / 4048 blk  ->  0.69 ms / 601 blk
+    //   70-op account (typical)             0.05 ms /    3 blk  ->  13.6 ms / 700 blk
+    //   100k-op account (the #9503 one)    37.92 ms / 3659 blk  ->  13.5 ms / 700 blk
     //
-    // A typical account pays ~0.5 ms and ~600 blocks it did not pay before. That is
-    // worth it because the term it replaces is unbounded in account history, while this
-    // one is flat — but it is a real regression for small accounts, not a free win, and
-    // it is the reason the co-tenant term on top of it (#9510) matters.
+    // So a typical account pays ~13 ms and ~700 blocks it did not pay before, on every
+    // batch upload, and this path runs twice per upload. That is a real and unconditional
+    // regression, accepted because the term it replaces is unbounded in account history
+    // (production's incident account had a slice far larger than this seed's) while this
+    // one cannot exceed |probe| index descents. It is also why the co-tenant term stacked
+    // on top of it (#9510) matters more than its absolute size suggests.
     //
     // `probe` binds the 100 ids ONCE — they used to be interpolated three times, for
     // 300 of the statement's 302 parameters — and is then referenced twice, so Postgres
@@ -818,12 +828,10 @@ export const prefetchLatestEntityOpsForBatch = async (
       start,
       start + CONFLICT_DETECTION_ENTITY_BATCH_SIZE,
     );
-    // The ::text casts pin the VALUES list's column types explicitly. They are belt and
-    // braces, not a requirement: inference from the `o.entity_type = t.entity_type`
-    // comparisons resolves both columns to text without them on PG 16.14 (checked with
-    // an untyped PREPARE, which is what leaves inference to do the work). Kept because a
-    // future edit that drops the last comparison — the array branch already probes
-    // `touched` through `array_agg` alone — would silently make them load-bearing.
+    // The ::text casts pin the VALUES list's column types. Not required — inference
+    // resolves both columns without them on PG 16.14, checked with an untyped PREPARE —
+    // and a future edit that made them load-bearing would fail loudly at PREPARE, not
+    // silently. Kept only because they cost nothing and state the intent.
     const touchedRows = batchPairs.map(
       ({ entityType, entityId }) => Prisma.sql`(${entityType}::text, ${entityId}::text)`,
     );
@@ -835,8 +843,9 @@ export const prefetchLatestEntityOpsForBatch = async (
     // This query was the WORSE of the two: it carries no `entity_type` predicate (the
     // entity type only ever appeared in the join), so the composite btree's usable
     // prefix was just `user_id` and the OR degeneracy read the user's ENTIRE history,
-    // every entity type — measured at 20007 rows discarded against detect's 2500 on
-    // the same seed. It is only spared production traffic because `batchUpload`
+    // every entity type — measured at 20020 rows discarded against detect's 2520 on
+    // batch-conflict-plan.pglite.spec.ts's seed (the whole own-user population, against
+    // just its TASK slice). It is only spared production traffic because `batchUpload`
     // defaults to false (#9503).
     //
     // The requested ids now come from `touched` instead of a second bound array, so

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -18,37 +18,55 @@ const TASK_TIME_DELTA_ACTION_TYPE = '[TimeTracking] Sync time spent';
 
 /**
  * ARRAY-branch candidates for BOTH batch conflict lookups: every stored op whose
- * `entity_ids` contains a probed id, tagged with the id that matched. Expects a
- * `probe(eid)` CTE in scope and binds no parameters of its own, which is why it can be
- * shared verbatim instead of hand-copied — the #8334 "keep these two in sync" hazard is
- * exactly what let #9503 ship the same mis-plan into both queries.
+ * `entity_ids` contains a probed id, tagged with the id that matched. Shared rather than
+ * hand-copied — the #8334 "keep these two in sync" hazard is exactly what let #9503 ship
+ * the same mis-plan into both queries. `probeSource` is passed in (rather than the
+ * fragment reaching for a `probe` CTE the caller must remember to define) so the contract
+ * is explicit; both call sites were measured plan-identical either way.
  *
  * Carrying `p.eid` is load-bearing for COST, not correctness. Re-deriving the matched id
  * downstream with `unnest(entity_ids) JOIN probe` instead emits |probe ∩ entity_ids|²
  * rows per op, because `cand` already holds one copy of the op per matching probe id.
- * Measured on PGlite over a 40k-row seed, 20 stored ops of 100 ids against a 100-id
- * probe: 8645ms / 19.8M join-filtered rows / 1611 temp blocks, against 8ms and zero for
- * the form below. At the 1000-id wire cap it was 36.8s vs 4.5ms. The probe set here is
- * the incoming op's OWN id list, so that overlap is maximal by construction, not an edge
- * case. Not selecting `entity_ids` at all also keeps the materialised tuplestore narrow.
- * batch-conflict-plan.pglite.spec.ts pins this; both guards fail on the fan-out form.
+ * On batch-conflict-plan.pglite.spec.ts's wide seed that is 59.8M join-filtered rows /
+ * 2211 temp blocks / ~23s, against zero and ~8ms for the form below; at the 1000-id wire
+ * cap the gap was 36.8s vs 4.5ms. Callers probe an id set that OVERLAPS the stored
+ * arrays heavily — detect probes the incoming op's own ids, prefetch the upload batch's
+ * — so that is the normal shape, not an edge case. Not selecting `entity_ids` at all
+ * also keeps the materialised tuplestore narrow. Both spec guards fail on the fan-out
+ * form; keep it that way.
  *
  * MATERIALIZED is load-bearing: it stops the outer user_id / entity_type predicates
  * being pushed down, which hands the composite btree back and restores the slice scan
- * this whole change exists to remove (measured: 1106 blocks and no GIN without it — an
- * earlier revision of this comment cited 2500 discarded rows, which is the OR form's
- * number, not the fence's).
+ * this whole change exists to remove (measured: 1106 blocks and no GIN without it).
  *
  * Isolation: like the single-entity path, this matches by entity id across ALL users and
- * the callers' outer WHERE enforces the user boundary — correct, but NOT cost-bounded
- * per user. See the note at detectConflictForEntity for the shared-literal probe vectors
- * ('KANBAN_DEFAULT' &c.) and the expression-GIN fix that would bound it.
+ * the callers' outer WHERE enforces the user boundary. CORRECT — cross-tenant rows are
+ * rejected before anything is returned, pinned by the ARRAY-branch isolation tests in
+ * entity-ids-conflict.pglite.spec.ts — but NOT cost-bounded per user, and that part IS a
+ * regression against master, which carried `user_id` inside the scanned relation. The
+ * `MATERIALIZED` fence is precisely what forbids putting it back.
+ *
+ * The cost is linear in the number of rows ACROSS ALL TENANTS carrying a probed id, and
+ * the batch paths multiply it by the batch size (up to 1000 ids/op) where the
+ * single-entity path probes one. Measured: 4000 co-tenants sharing one id => 30ms here
+ * vs 0.1ms on master; a 100-id wide probe with 40 co-tenants => 14401 blocks / 821 temp
+ * blocks / 110ms vs master's 810 blocks / 33ms. It only bites on ids that are
+ * byte-identical across tenants — the hard-coded 'KANBAN_DEFAULT' / 'EISENHOWER_MATRIX'
+ * that `sortBoards` both stores and probes — so it is small today and far from the
+ * multi-second statement_timeout #9503 was about, but it grows with server population
+ * and nothing the tenant controls bounds it.
+ *
+ * DELIBERATELY NOT COVERED by batch-conflict-plan.pglite.spec.ts: that seed gives every
+ * user disjoint ids, and `expectBounded` asserts `rowsFiltered === 0`, which a shared-id
+ * seed violates by construction. So "bounded" there means "bounded given disjoint ids",
+ * not bounded absolutely. The real fix is the expression-GIN sketched at
+ * detectConflictForEntity; it needs its own issue and its own measurements.
  */
-const ARRAY_BRANCH_CANDIDATES_CTE = Prisma.sql`
+const arrayBranchCandidatesCte = (probeSource: Prisma.Sql): Prisma.Sql => Prisma.sql`
   cand AS MATERIALIZED (
     SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
            o.vector_clock, o.server_seq
-    FROM probe p
+    FROM (${probeSource}) p
     JOIN operations o ON o.entity_ids @> ARRAY[p.eid]
   )
 `;
@@ -140,18 +158,22 @@ export const detectConflictForEntities = async (
     // PLUS the sort column are covered by the composite btree, so each probe is an
     // index seek that terminates on an empty range when the entity is new.
     //
-    // Array branch: per-id `@>` probes, NOT one `entity_ids && $arr`, and the tradeoff
-    // is narrower than it looks — measure before changing it either way. With
+    // Array branch: per-id `@>` probes, NOT one `entity_ids && $arr`. With
     // `fastupdate = off` (migration 20260720000000, what `prisma migrate deploy` gives
-    // production) both forms ride the GIN and `@>` costs ~100 extra blocks. With the
-    // pending list DIRTY a single 100-key `&&` is expensive enough that the planner
-    // abandons the index for a SEQ SCAN, which `@>` avoids — but on a 40k-row seed that
-    // seq scan measured FASTER than the surviving GIN plan (78ms vs 116ms), so `@>` is
-    // not a free win there. It is defensible because `fastupdate = off` cannot be
-    // expressed in schema.prisma, so `prisma db push` databases (CI, the E2E stack, the
-    // manual setup in README.md) have the pending list ON, and because a seq scan at
-    // production's 6.97M rows / 5.6GB extrapolates far worse than at 40k — that last
-    // step is UNMEASURED. `@>` is also the same probe detectConflictForEntity ships.
+    // production) both forms ride the GIN and `@>` costs modestly more — +99 blocks on
+    // an all-new probe, +495 on the wide-array one. It earns that back when the pending
+    // list is DIRTY, which every `prisma db push` database has (CI, the E2E stack, the
+    // manual setup in README.md) because `fastupdate = off` cannot be expressed in
+    // schema.prisma: there a single 100-key `&&` is costly enough that the planner
+    // abandons the index for a SEQ SCAN of the whole table.
+    //
+    // At the 40k-row seed scale that seq scan is actually FASTER (108ms vs 185ms), so
+    // the case does not rest on wall-clock — it rests on how the two grow. `@>` reads
+    // |probe| x pending-list pages, and the pending list is capped by
+    // `gin_pending_list_limit` (4MB default => ~512 pages, so ~51k blocks at |probe|=100)
+    // INDEPENDENTLY of table size; the seq scan reads the whole heap, which on production
+    // is 5.6GB (~700k blocks). That is a structural bound, not an extrapolation. `@>` is
+    // also the same probe detectConflictForEntity ships.
     //
     // `probe` binds the 100 ids ONCE — they used to be interpolated three times, for
     // 300 of the statement's 302 parameters — and is then referenced twice, so Postgres
@@ -176,7 +198,7 @@ export const detectConflictForEntities = async (
           LIMIT 1
         ) x
       ),
-      ${ARRAY_BRANCH_CANDIDATES_CTE},
+      ${arrayBranchCandidatesCte(Prisma.sql`SELECT eid FROM probe`)},
       array_hits AS (
         SELECT c.eid AS eid, c.client_id, c.action_type, c.vector_clock, c.server_seq
         FROM cand c
@@ -769,18 +791,19 @@ export const prefetchLatestEntityOpsForBatch = async (
     // there is no separate id-array parameter at all.
     //
     // `array_hits` re-checks the entity TYPE with a row-wise `IN`, not a `JOIN`: `cand`
-    // is keyed by id alone (`probe` drops the type), so a stored op matched by id still
-    // has to be confirmed against the requested (type, id) PAIR. A semi-join lets the
-    // planner hash `touched` once — the inner JOIN this replaced was planned as a nested
-    // loop that re-compared every candidate against all 100 pairs (measured 198k
-    // join-filter comparisons on the wide-array seed). It also cannot duplicate a row
-    // when `entityPairs` carries the same pair twice, which the JOIN could.
+    // is keyed by id alone (the probe source drops the type), so a stored op matched by
+    // id still has to be confirmed against the requested (type, id) PAIR. A semi-join
+    // stops at the first match per candidate where the JOIN scanned on, which measured
+    // 99k comparisons against 198k on the wide-array seed — though that particular
+    // saving is an artefact of the seed's ordering and would shrink on adversarial
+    // input. Output is identical either way (the outer DISTINCT ON absorbs the JOIN's
+    // duplicates), so this is a cost choice, not a correctness one. Under
+    // `force_generic_plan` it stays a NESTED LOOP, not a hash: the residual is
+    // |cand| x |touched|, bounded by the batch size and independent of how wide the
+    // stored arrays are, which is what distinguishes it from a fan-out.
     const latestOps = await tx.$queryRaw<LatestBatchEntityOperationRow[]>`
       WITH touched(entity_type, entity_id) AS (
         VALUES ${Prisma.join(touchedRows)}
-      ),
-      probe(eid) AS (
-        SELECT DISTINCT entity_id FROM touched
       ),
       scalar_hits AS (
         SELECT t.entity_type, t.entity_id AS eid, x.client_id, x.action_type,
@@ -796,7 +819,9 @@ export const prefetchLatestEntityOpsForBatch = async (
           LIMIT 1
         ) x
       ),
-      ${ARRAY_BRANCH_CANDIDATES_CTE},
+      ${arrayBranchCandidatesCte(
+        Prisma.sql`SELECT DISTINCT entity_id AS eid FROM touched`,
+      )},
       array_hits AS (
         SELECT c.entity_type, c.eid AS eid, c.client_id, c.action_type,
                c.vector_clock, c.server_seq

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -17,6 +17,43 @@ import {
 const TASK_TIME_DELTA_ACTION_TYPE = '[TimeTracking] Sync time spent';
 
 /**
+ * ARRAY-branch candidates for BOTH batch conflict lookups: every stored op whose
+ * `entity_ids` contains a probed id, tagged with the id that matched. Expects a
+ * `probe(eid)` CTE in scope and binds no parameters of its own, which is why it can be
+ * shared verbatim instead of hand-copied — the #8334 "keep these two in sync" hazard is
+ * exactly what let #9503 ship the same mis-plan into both queries.
+ *
+ * Carrying `p.eid` is load-bearing for COST, not correctness. Re-deriving the matched id
+ * downstream with `unnest(entity_ids) JOIN probe` instead emits |probe ∩ entity_ids|²
+ * rows per op, because `cand` already holds one copy of the op per matching probe id.
+ * Measured on PGlite over a 40k-row seed, 20 stored ops of 100 ids against a 100-id
+ * probe: 8645ms / 19.8M join-filtered rows / 1611 temp blocks, against 8ms and zero for
+ * the form below. At the 1000-id wire cap it was 36.8s vs 4.5ms. The probe set here is
+ * the incoming op's OWN id list, so that overlap is maximal by construction, not an edge
+ * case. Not selecting `entity_ids` at all also keeps the materialised tuplestore narrow.
+ * batch-conflict-plan.pglite.spec.ts pins this; both guards fail on the fan-out form.
+ *
+ * MATERIALIZED is load-bearing: it stops the outer user_id / entity_type predicates
+ * being pushed down, which hands the composite btree back and restores the slice scan
+ * this whole change exists to remove (measured: 1106 blocks and no GIN without it — an
+ * earlier revision of this comment cited 2500 discarded rows, which is the OR form's
+ * number, not the fence's).
+ *
+ * Isolation: like the single-entity path, this matches by entity id across ALL users and
+ * the callers' outer WHERE enforces the user boundary — correct, but NOT cost-bounded
+ * per user. See the note at detectConflictForEntity for the shared-literal probe vectors
+ * ('KANBAN_DEFAULT' &c.) and the expression-GIN fix that would bound it.
+ */
+const ARRAY_BRANCH_CANDIDATES_CTE = Prisma.sql`
+  cand AS MATERIALIZED (
+    SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+           o.vector_clock, o.server_seq
+    FROM probe p
+    JOIN operations o ON o.entity_ids @> ARRAY[p.eid]
+  )
+`;
+
+/**
  * Check if an incoming operation conflicts with existing operations.
  * Returns conflict info if a concurrent modification is detected.
  */
@@ -103,28 +140,28 @@ export const detectConflictForEntities = async (
     // PLUS the sort column are covered by the composite btree, so each probe is an
     // index seek that terminates on an empty range when the entity is new.
     //
-    // Array branch: per-id `@>` probes, NOT one `entity_ids && $arr`. This is
-    // deliberate and measured. A single 100-key `&&` costs enough under a DIRTY GIN
-    // pending list that the planner abandons the index for a SEQ SCAN of the whole
-    // table — and `fastupdate = off` (migration 20260720000000) cannot be expressed in
-    // schema.prisma, so every `prisma db push` database has the pending list ON. The
-    // 1-key `@>` form keeps the GIN chosen in BOTH states for ~100 extra blocks, and
-    // is the same probe detectConflictForEntity already ships. batch-conflict-plan
-    // .pglite.spec.ts pins both properties; do not "simplify" this back to `&&`.
-    //
-    // MATERIALIZED is load-bearing on `cand`, exactly as in the single-entity path:
-    // it stops the outer user_id / entity_type predicates being pushed down, which
-    // would hand the composite btree back and restore the slice scan (measured: 2500
-    // rows discarded with them pushed in, 0 with the fence).
+    // Array branch: per-id `@>` probes, NOT one `entity_ids && $arr`, and the tradeoff
+    // is narrower than it looks — measure before changing it either way. With
+    // `fastupdate = off` (migration 20260720000000, what `prisma migrate deploy` gives
+    // production) both forms ride the GIN and `@>` costs ~100 extra blocks. With the
+    // pending list DIRTY a single 100-key `&&` is expensive enough that the planner
+    // abandons the index for a SEQ SCAN, which `@>` avoids — but on a 40k-row seed that
+    // seq scan measured FASTER than the surviving GIN plan (78ms vs 116ms), so `@>` is
+    // not a free win there. It is defensible because `fastupdate = off` cannot be
+    // expressed in schema.prisma, so `prisma db push` databases (CI, the E2E stack, the
+    // manual setup in README.md) have the pending list ON, and because a seq scan at
+    // production's 6.97M rows / 5.6GB extrapolates far worse than at 40k — that last
+    // step is UNMEASURED. `@>` is also the same probe detectConflictForEntity ships.
     //
     // `probe` binds the 100 ids ONCE — they used to be interpolated three times, for
-    // 300 of the statement's 302 parameters — and is then referenced three times, so
-    // Postgres materialises the list once. DISTINCT mirrors the prefetch sibling,
+    // 300 of the statement's 302 parameters — and is then referenced twice, so Postgres
+    // materialises the list once. Its DISTINCT is redundant here (detectConflict already
+    // dedupes) and kept only so this shape stays identical to the prefetch sibling,
     // where the same id can legitimately appear under two entity types.
     const idArray = Prisma.sql`ARRAY[${Prisma.join(batchEntityIds)}]::text[]`;
     const latestOps = await tx.$queryRaw<LatestEntityOperationRow[]>`
       WITH probe(eid) AS (
-        SELECT DISTINCT unnest(${idArray})
+        SELECT DISTINCT eid FROM unnest(${idArray}) AS eid
       ),
       scalar_hits AS (
         SELECT p.eid AS eid, x.client_id, x.action_type, x.vector_clock, x.server_seq
@@ -139,22 +176,10 @@ export const detectConflictForEntities = async (
           LIMIT 1
         ) x
       ),
-      cand AS MATERIALIZED (
-        SELECT x.user_id, x.entity_type, x.entity_ids, x.client_id, x.action_type,
-               x.vector_clock, x.server_seq
-        FROM probe p
-        CROSS JOIN LATERAL (
-          SELECT o.user_id, o.entity_type, o.entity_ids, o.client_id, o.action_type,
-                 o.vector_clock, o.server_seq
-          FROM operations o
-          WHERE o.entity_ids @> ARRAY[p.eid]
-        ) x
-      ),
+      ${ARRAY_BRANCH_CANDIDATES_CTE},
       array_hits AS (
-        SELECT m.eid AS eid, c.client_id, c.action_type, c.vector_clock, c.server_seq
+        SELECT c.eid AS eid, c.client_id, c.action_type, c.vector_clock, c.server_seq
         FROM cand c
-        CROSS JOIN LATERAL unnest(c.entity_ids) AS m(eid)
-        JOIN probe p2 ON p2.eid = m.eid
         WHERE c.user_id = ${userId}
           AND c.entity_type = ${op.entityType}
       )
@@ -164,9 +189,9 @@ export const detectConflictForEntities = async (
         action_type AS "actionType",
         vector_clock AS "vectorClock"
       FROM (
-        SELECT * FROM scalar_hits
+        SELECT eid, client_id, action_type, vector_clock, server_seq FROM scalar_hits
         UNION ALL
-        SELECT * FROM array_hits
+        SELECT eid, client_id, action_type, vector_clock, server_seq FROM array_hits
       ) u
       ORDER BY eid, server_seq DESC
     `;
@@ -729,7 +754,9 @@ export const prefetchLatestEntityOpsForBatch = async (
 
     // Two separately-indexed branches, mirroring detectConflictForEntities — see the
     // PERF note there for the measurements and for why the array branch probes per id
-    // rather than with one `&&`. Keep the two shapes in sync. (#8334)
+    // rather than with one `&&`. The array branch itself is the shared
+    // ARRAY_BRANCH_CANDIDATES_CTE, so only the scalar branch and the keying differ.
+    // (#8334)
     //
     // This query was the WORSE of the two: it carries no `entity_type` predicate (the
     // entity type only ever appeared in the join), so the composite btree's usable
@@ -740,6 +767,14 @@ export const prefetchLatestEntityOpsForBatch = async (
     //
     // The requested ids now come from `touched` instead of a second bound array, so
     // there is no separate id-array parameter at all.
+    //
+    // `array_hits` re-checks the entity TYPE with a row-wise `IN`, not a `JOIN`: `cand`
+    // is keyed by id alone (`probe` drops the type), so a stored op matched by id still
+    // has to be confirmed against the requested (type, id) PAIR. A semi-join lets the
+    // planner hash `touched` once — the inner JOIN this replaced was planned as a nested
+    // loop that re-compared every candidate against all 100 pairs (measured 198k
+    // join-filter comparisons on the wide-array seed). It also cannot duplicate a row
+    // when `entityPairs` carries the same pair twice, which the JOIN could.
     const latestOps = await tx.$queryRaw<LatestBatchEntityOperationRow[]>`
       WITH touched(entity_type, entity_id) AS (
         VALUES ${Prisma.join(touchedRows)}
@@ -761,26 +796,13 @@ export const prefetchLatestEntityOpsForBatch = async (
           LIMIT 1
         ) x
       ),
-      cand AS MATERIALIZED (
-        SELECT x.user_id, x.entity_type, x.entity_ids, x.client_id, x.action_type,
-               x.vector_clock, x.server_seq
-        FROM probe p
-        CROSS JOIN LATERAL (
-          SELECT o.user_id, o.entity_type, o.entity_ids, o.client_id, o.action_type,
-                 o.vector_clock, o.server_seq
-          FROM operations o
-          WHERE o.entity_ids @> ARRAY[p.eid]
-        ) x
-      ),
+      ${ARRAY_BRANCH_CANDIDATES_CTE},
       array_hits AS (
-        SELECT c.entity_type, m.eid AS eid, c.client_id, c.action_type,
+        SELECT c.entity_type, c.eid AS eid, c.client_id, c.action_type,
                c.vector_clock, c.server_seq
         FROM cand c
-        CROSS JOIN LATERAL unnest(c.entity_ids) AS m(eid)
-        JOIN touched t2
-          ON t2.entity_type = c.entity_type
-         AND t2.entity_id = m.eid
         WHERE c.user_id = ${userId}
+          AND (c.entity_type, c.eid) IN (SELECT entity_type, entity_id FROM touched)
       )
       SELECT DISTINCT ON (entity_type, eid)
         entity_type AS "entityType",
@@ -790,9 +812,11 @@ export const prefetchLatestEntityOpsForBatch = async (
         vector_clock AS "vectorClock",
         server_seq AS "serverSeq"
       FROM (
-        SELECT * FROM scalar_hits
+        SELECT entity_type, eid, client_id, action_type, vector_clock, server_seq
+        FROM scalar_hits
         UNION ALL
-        SELECT * FROM array_hits
+        SELECT entity_type, eid, client_id, action_type, vector_clock, server_seq
+        FROM array_hits
       ) u
       ORDER BY entity_type, eid, server_seq DESC
     `;

--- a/packages/super-sync-server/src/sync/conflict.ts
+++ b/packages/super-sync-server/src/sync/conflict.ts
@@ -39,15 +39,22 @@ const TASK_TIME_DELTA_ACTION_TYPE = '[TimeTracking] Sync time spent';
  *   only with index size) while `&&`'s `matches x stored width` is bounded by nothing a
  *   tenant controls — but `&&` IS ~20x faster on an all-new probe, so this is a real
  *   trade and not a free win. Equivalence of the forms is pinned by
- *   array-branch-equivalence.pglite.spec.ts: swap the form there when you swap it here.
+ *   array-branch-equivalence.pglite.spec.ts, which DERIVES the shipped form from this
+ *   fragment, so changing it here re-points that spec automatically.
  *
  * NOT user-scoped: like the single-entity path this matches by entity id across ALL users,
  * and the callers' outer WHERE enforces the boundary. Correct — pinned by the ARRAY-branch
  * isolation tests in entity-ids-conflict.pglite.spec.ts — but the cost is not bounded per
  * tenant, which IS a regression against master and is tracked as #9510. The `MATERIALIZED`
  * fence is precisely what forbids putting `user_id` back inside.
+ *
+ * Exported ONLY so the equivalence spec can splice the real text instead of a copy; it
+ * binds no values, and that is asserted there because a `$n` would renumber the callers'
+ * parameters.
  */
-const arrayBranchCandidatesCte = (probeSource: Prisma.Sql): Prisma.Sql => Prisma.sql`
+export const arrayBranchCandidatesCte = (
+  probeSource: Prisma.Sql,
+): Prisma.Sql => Prisma.sql`
   cand AS MATERIALIZED (
     SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
            o.vector_clock, o.server_seq

--- a/packages/super-sync-server/tests/array-branch-equivalence.pglite.spec.ts
+++ b/packages/super-sync-server/tests/array-branch-equivalence.pglite.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { PGlite } from '@electric-sql/pglite';
+import { Prisma } from '@prisma/client';
+import { arrayBranchCandidatesCte } from '../src/sync/conflict';
 
 /**
  * The array branch of the batch conflict lookups is a COST choice between forms that
@@ -44,13 +46,18 @@ const CREATE = `
   CREATE INDEX operations_entity_ids_gin ON operations USING GIN (entity_ids);
 `;
 
-/** SHIPPED: one `@>` GIN probe per requested id, tagged with the id from the index. */
-const SHIPPED = `cand AS MATERIALIZED (
-  SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
-         o.vector_clock, o.server_seq
-  FROM (SELECT eid FROM probe) p
-  JOIN operations o ON o.entity_ids @> ARRAY[p.eid]
-)`;
+/**
+ * SHIPPED: one `@>` GIN probe per requested id, tagged with the id from the index.
+ *
+ * DERIVED from the production fragment, never copied. A hand-written literal here passed
+ * whether or not it still matched conflict.ts, so a later cost change to the array branch
+ * would have been "proved" equivalent by a file that never saw it — the same
+ * keep-these-two-in-sync hazard (#8334) that let #9503 ship the same mis-plan into both
+ * batch queries. The fragment binds no values, so `.sql` is its literal text; the first
+ * test below pins that, because a `$n` appearing here would silently renumber the `$1/$2/$3`
+ * of every query in this file.
+ */
+const SHIPPED = arrayBranchCandidatesCte(Prisma.sql`SELECT eid FROM probe`).sql;
 
 /**
  * The alternatives, kept here so a future cost change can be re-checked for equivalence
@@ -155,6 +162,21 @@ describe('batch array branch: alternative forms are equivalent (PGlite)', () => 
 
   afterEach(async () => {
     await db.close();
+  });
+
+  it('splices the REAL production fragment, and it binds no parameters', () => {
+    const fragment = arrayBranchCandidatesCte(Prisma.sql`SELECT eid FROM probe`);
+    // If the fragment ever binds a value, its `$1` would collide with this file's own
+    // `$1/$2/$3` and every query here would silently probe the wrong thing. Fail here
+    // instead, where the message says what to do.
+    expect(
+      fragment.values,
+      'arrayBranchCandidatesCte now binds values; thread them through detectQuery',
+    ).toEqual([]);
+    expect(SHIPPED).not.toMatch(/\$\d/);
+    // Sanity that we spliced the array branch and not something else entirely.
+    expect(SHIPPED).toContain('cand AS MATERIALIZED');
+    expect(SHIPPED).toContain('@> ARRAY[p.eid]');
   });
 
   it('returns identical rows to every alternative form, and mutants diverge', async () => {

--- a/packages/super-sync-server/tests/array-branch-equivalence.pglite.spec.ts
+++ b/packages/super-sync-server/tests/array-branch-equivalence.pglite.spec.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+
+/**
+ * The array branch of the batch conflict lookups is a COST choice between forms that
+ * must return identical rows. This file is the equivalence evidence for that choice.
+ *
+ * It exists because #9503's branch twice changed the shape of `arrayBranchCandidatesCte`
+ * on cost grounds, and both times the equivalence argument lived in a throwaway script
+ * whose result was quoted in a comment. A number nobody can re-derive is exactly what
+ * this repo's rules call a defect, and this is a silent-data-loss path: the array branch
+ * is how a stored multi-entity op is found via its NON-FIRST entity (#8334). Getting it
+ * wrong does not error — it reports "no conflict" and a concurrent remote edit is
+ * overwritten.
+ *
+ * So: randomised differential testing of the SHIPPED form against the alternatives that
+ * have been proposed for it, over data shaped to hit the cases that actually differ —
+ * duplicate array elements, NULL elements, NULL scalar `entity_id`, divergent scalars
+ * (an op whose `entity_id` is not a member of its own `entity_ids`), empty arrays,
+ * cross-tenant and cross-entity-type id collisions.
+ *
+ * The MUTANTS are not decoration. A differential test that cannot fail proves nothing,
+ * so each round also runs forms that are deliberately wrong and asserts they diverge at
+ * least sometimes across the run. If a mutant ever stops diverging, this file has lost
+ * its power and the seed needs widening — that is a failure, not a pass.
+ */
+
+const CREATE = `
+  CREATE TABLE operations (
+    id             text PRIMARY KEY,
+    user_id        integer NOT NULL,
+    client_id      text NOT NULL,
+    server_seq     integer NOT NULL,
+    action_type    text NOT NULL,
+    entity_type    text NOT NULL,
+    entity_id      text,
+    entity_ids     text[] NOT NULL DEFAULT '{}',
+    schema_version integer NOT NULL DEFAULT 1,
+    vector_clock   jsonb NOT NULL
+  );
+  CREATE UNIQUE INDEX operations_user_id_server_seq_key ON operations (user_id, server_seq);
+  CREATE INDEX operations_user_id_entity_type_entity_id_server_seq_idx
+    ON operations (user_id, entity_type, entity_id, server_seq);
+  CREATE INDEX operations_entity_ids_gin ON operations USING GIN (entity_ids);
+`;
+
+/** SHIPPED: one `@>` GIN probe per requested id, tagged with the id from the index. */
+const SHIPPED = `cand AS MATERIALIZED (
+  SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+         o.vector_clock, o.server_seq
+  FROM (SELECT eid FROM probe) p
+  JOIN operations o ON o.entity_ids @> ARRAY[p.eid]
+)`;
+
+/**
+ * The alternatives, kept here so a future cost change can be re-checked for equivalence
+ * without rebuilding this harness. Both were measured and rejected on cost (see
+ * arrayBranchCandidatesCte); neither is wrong.
+ */
+const EQUIVALENT_FORMS: Record<string, string> = {
+  'one && per batch, tags via INTERSECT': `cand AS MATERIALIZED (
+    SELECT x.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+           o.vector_clock, o.server_seq
+    FROM operations o
+    CROSS JOIN LATERAL (
+      SELECT unnest(o.entity_ids) AS eid INTERSECT SELECT eid FROM (SELECT eid FROM probe) p
+    ) x
+    WHERE o.entity_ids && COALESCE((SELECT array_agg(eid) FROM (SELECT eid FROM probe) q), '{}')
+  )`,
+  'one && per batch, tags via hashed IN': `probe_ids(ids) AS MATERIALIZED (
+    SELECT array_agg(eid) FROM (SELECT eid FROM probe) p
+  ),
+  cand AS MATERIALIZED (
+    SELECT x.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+           o.vector_clock, o.server_seq
+    FROM operations o
+    CROSS JOIN LATERAL unnest(o.entity_ids) AS x(eid)
+    WHERE o.entity_ids && (SELECT ids FROM probe_ids)
+      AND x.eid IN (SELECT unnest(ids) FROM probe_ids)
+  )`,
+};
+
+/** Deliberately WRONG forms, to prove the harness can tell the difference. */
+const MUTANTS: Record<string, string> = {
+  'tags every id the op touched, not just probed ones': `cand AS MATERIALIZED (
+    SELECT x.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+           o.vector_clock, o.server_seq
+    FROM operations o
+    CROSS JOIN LATERAL (SELECT unnest(o.entity_ids) AS eid) x
+    WHERE o.entity_ids && COALESCE((SELECT array_agg(eid) FROM (SELECT eid FROM probe) q), '{}')
+  )`,
+  'requires ALL probed ids present (@> instead of &&)': `cand AS MATERIALIZED (
+    SELECT x.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+           o.vector_clock, o.server_seq
+    FROM operations o
+    CROSS JOIN LATERAL (
+      SELECT unnest(o.entity_ids) AS eid INTERSECT SELECT eid FROM (SELECT eid FROM probe) p
+    ) x
+    WHERE o.entity_ids @> COALESCE((SELECT array_agg(eid) FROM (SELECT eid FROM probe) q), '{}')
+  )`,
+  'drops the scalar branch (#8334 divergent scalar becomes invisible)': `cand AS MATERIALIZED (
+    SELECT p.eid AS eid, o.user_id, o.entity_type, o.client_id, o.action_type,
+           o.vector_clock, o.server_seq
+    FROM (SELECT eid FROM probe) p
+    JOIN operations o ON o.entity_ids @> ARRAY[p.eid] AND o.entity_id IS NOT NULL
+  )`,
+};
+
+/** The real detectConflictForEntities shape, with only the array branch swapped. */
+const detectQuery = (cand: string): string => `
+  WITH probe(eid) AS (SELECT DISTINCT eid FROM unnest($1::text[]) AS eid),
+  scalar_hits AS (
+    SELECT p.eid AS eid, x.client_id, x.action_type, x.vector_clock, x.server_seq
+    FROM probe p
+    CROSS JOIN LATERAL (
+      SELECT o.client_id, o.action_type, o.vector_clock, o.server_seq
+      FROM operations o
+      WHERE o.user_id = $2 AND o.entity_type = $3 AND o.entity_id = p.eid
+      ORDER BY o.server_seq DESC LIMIT 1
+    ) x
+  ),
+  ${cand},
+  array_hits AS (
+    SELECT c.eid AS eid, c.client_id, c.action_type, c.vector_clock, c.server_seq
+    FROM cand c WHERE c.user_id = $2 AND c.entity_type = $3
+  )
+  SELECT DISTINCT ON (eid) eid, client_id, action_type, vector_clock
+  FROM (
+    SELECT eid, client_id, action_type, vector_clock, server_seq FROM scalar_hits
+    UNION ALL
+    SELECT eid, client_id, action_type, vector_clock, server_seq FROM array_hits
+  ) u
+  ORDER BY eid, server_seq DESC`;
+
+/** Deterministic PRNG — a flaky equivalence test is worse than none. */
+const makeRandom = (seed: number): (() => number) => {
+  let s = seed;
+  return () => (s = (s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+};
+
+const USERS = [1, 2, 3];
+const TYPES = ['TASK', 'PROJECT', 'TAG'];
+/** Small id universe so collisions, overlaps and duplicates are COMMON, not rare. */
+const IDS = Array.from({ length: 12 }, (_, i) => `e${i}`);
+const ROUNDS = 120;
+
+describe('batch array branch: alternative forms are equivalent (PGlite)', () => {
+  let db: PGlite;
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await db.exec(CREATE);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it('returns identical rows to every alternative form, and mutants diverge', async () => {
+    const rnd = makeRandom(987654321);
+    const pick = <T>(a: readonly T[]): T => a[Math.floor(rnd() * a.length)];
+    const subset = (max: number): string[] =>
+      Array.from({ length: Math.floor(rnd() * (max + 1)) }, () => pick(IDS));
+
+    const seqByUser: Record<number, number> = {};
+    const divergences: Record<string, number> = {};
+    let comparisons = 0;
+
+    for (let round = 0; round < ROUNDS; round++) {
+      // Grow the table as we go, so probes see many different states.
+      for (let k = 0; k < 5; k++) {
+        const userId = pick(USERS);
+        seqByUser[userId] = (seqByUser[userId] ?? 0) + 1;
+        const ids = subset(4);
+        // ~8% of rows carry a NULL array element, which is where INTERSECT's
+        // NOT-DISTINCT-FROM semantics could differ from `@>` if a probe ever held one.
+        if (rnd() < 0.08) ids.push(null as unknown as string);
+        await db.query(`INSERT INTO operations VALUES ($1,$2,$3,$4,$5,$6,$7,$8,1,$9)`, [
+          `op-${round}-${k}`,
+          userId,
+          `c${Math.floor(rnd() * 3)}`,
+          seqByUser[userId],
+          pick(['[Task] Update', '[TimeTracking] Sync time spent']),
+          pick(TYPES),
+          // ~15% full-state ops (NULL scalar); the rest often DIVERGE from their own
+          // entity_ids, which is the #8334 shape.
+          rnd() < 0.15 ? null : pick(IDS),
+          ids,
+          JSON.stringify({ [`c${Math.floor(rnd() * 3)}`]: round }),
+        ]);
+      }
+
+      const probeIds = [...new Set(subset(6))].filter(Boolean);
+      if (probeIds.length === 0) continue;
+      const params = [probeIds, pick(USERS), pick(TYPES)];
+
+      const shipped = await db.query(detectQuery(SHIPPED), params);
+      comparisons++;
+
+      for (const [name, cand] of Object.entries(EQUIVALENT_FORMS)) {
+        const other = await db.query(detectQuery(cand), params);
+        expect(
+          JSON.stringify(other.rows),
+          `"${name}" diverged from the shipped form on probe ${JSON.stringify(probeIds)}`,
+        ).toBe(JSON.stringify(shipped.rows));
+      }
+
+      for (const [name, cand] of Object.entries(MUTANTS)) {
+        const mutant = await db.query(detectQuery(cand), params);
+        if (JSON.stringify(mutant.rows) !== JSON.stringify(shipped.rows)) {
+          divergences[name] = (divergences[name] ?? 0) + 1;
+        }
+      }
+    }
+
+    expect(comparisons).toBeGreaterThan(80);
+    // Every mutant must be caught SOMETIMES. A zero here means the seed stopped covering
+    // the case that mutant breaks, and the equivalence assertions above lost their power.
+    for (const name of Object.keys(MUTANTS)) {
+      expect(
+        divergences[name] ?? 0,
+        `mutant "${name}" was never detected`,
+      ).toBeGreaterThan(0);
+    }
+  }, 180_000);
+
+  it('agrees on the edge shapes that operators actually disagree about', async () => {
+    // One row per case that has previously been argued about, so a failure names the
+    // case instead of a random round number.
+    await db.query(
+      `INSERT INTO operations VALUES
+        ('dup',       1,'c',1,'[Task] Update','TASK','e0', ARRAY['e1','e1','e2'], 1,'{"c":1}'),
+        ('nullelem',  1,'c',2,'[Task] Update','TASK','e3', ARRAY['e4',NULL],      1,'{"c":2}'),
+        ('divergent', 1,'c',3,'[Task] Update','TASK','e5', ARRAY['e6','e7'],      1,'{"c":3}'),
+        ('nullscalar',1,'c',4,'[Task] Update','TASK',NULL, ARRAY['e8'],           1,'{"c":4}'),
+        ('emptyarr',  1,'c',5,'[Task] Update','TASK','e9', '{}',                  1,'{"c":5}'),
+        ('othertenant',2,'c',1,'[Task] Update','TASK','e0',ARRAY['e1'],           1,'{"c":6}'),
+        ('othertype', 1,'c',6,'[Task] Update','PROJECT','e1',ARRAY['e2'],         1,'{"c":7}')`,
+    );
+
+    const params = [IDS, 1, 'TASK'];
+    const shipped = await db.query(detectQuery(SHIPPED), params);
+    // Sanity: the fixture must actually produce rows, or "identical" is vacuous.
+    expect(shipped.rows.length).toBeGreaterThan(0);
+
+    for (const [name, cand] of Object.entries(EQUIVALENT_FORMS)) {
+      const other = await db.query(detectQuery(cand), params);
+      expect(JSON.stringify(other.rows), `"${name}" diverged`).toBe(
+        JSON.stringify(shipped.rows),
+      );
+    }
+  });
+});

--- a/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
@@ -46,19 +46,21 @@ import type { Operation } from '../src/sync/sync.types';
  *    majority. The first fix for #9503 regressed only on wide arrays, and a width-2
  *    seed cannot express that: see the two "does not fan out" tests.
  *  - Every user gets DISJOINT entity ids, so nothing here measures the array branch's
- *    cross-tenant cost. That exclusion is deliberate and load-bearing: `expectBounded`
- *    asserts `rowsFiltered === 0`, which a shared-id seed violates by construction (the
- *    `cand` CTE matches by id across all users and `array_hits` filters afterwards). So
- *    "bounded" in this file means "bounded given disjoint ids" — the shared-literal case
- *    ('KANBAN_DEFAULT' &c.) is documented, with numbers, at arrayBranchCandidatesCte in
- *    conflict.ts, and is not guarded anywhere. Do not read these tests as covering it.
+ *    cross-tenant cost, which is linear in rows across ALL tenants carrying a probed id.
+ *    So "bounded" in this file means "bounded given disjoint ids". The shared-literal
+ *    case ('KANBAN_DEFAULT' &c.) is documented with numbers at arrayBranchCandidatesCte
+ *    in conflict.ts and tracked in #9510; it is not guarded anywhere. Do not read these
+ *    tests as covering it.
  *
- * REMAINING FIDELITY LIMITS: PGlite is PG18 and reports every block as a cache hit, so
- * these counts cannot model production's cold-cache I/O. The plan SHAPE is what
- * transfers. The shipped-vs-regressed plan shapes were also cross-checked against
- * postgres:16-alpine (PG 16.14), production's major version, during review of #9503 —
- * that was a one-off manual check, not something this file re-runs, so treat it as a
- * dated observation (2026-08) rather than a maintained property.
+ * REMAINING FIDELITY LIMITS — PGlite is PG18, and the planner differences from
+ * production's PG 16.14 are real, not theoretical. Measured during review of #9503
+ * (2026-08, a one-off manual check against postgres:16-alpine, NOT re-run by this file):
+ * PG 16.14 plans the array-branch join as a HASH join where PGlite uses a nested loop,
+ * so `Rows Removed by Join Filter` reads 0 there for a plan that is still 80x too
+ * expensive. That is exactly why `rowsTouched` is the primary assertion — see walk().
+ * Blocks are also unmodellable here: PGlite reports every block as a cache hit, so these
+ * counts cannot stand in for production's cold-cache I/O. The plan SHAPE transfers; the
+ * absolute numbers below do not.
  */
 
 const OWN_OPS = 20_000;
@@ -108,6 +110,7 @@ const INSERT_COLS =
 type PlanNode = Record<string, unknown>;
 type Measured = {
   blocks: number;
+  rowsTouched: number;
   rowsFiltered: number;
   rowsJoinFiltered: number;
   tempBlocks: number;
@@ -115,19 +118,34 @@ type Measured = {
 };
 
 /**
- * `Rows Removed by Filter` alone is NOT enough, and assuming it was let a 1000x
- * regression through review: this rewrite moved the id match from a `WHERE ... = ANY`
- * into a JOIN, and Postgres reports work discarded there as `Rows Removed by JOIN
- * Filter` — a different key. A fan-out that read and threw away 59.8M join rows scored
- * `rowsFiltered: 0` and passed `expectBounded` untouched. Count both, plus temp blocks,
- * which is what an over-wide intermediate spills to.
+ * `rowsTouched` — Actual Rows x Actual Loops summed over the tree — is the PRIMARY
+ * signal, and it is the only one here that is planner-independent.
+ *
+ * Two rounds of review were defeated by picking a counter instead. Round 1 asserted
+ * `Rows Removed by Filter`, and the fan-out moved the work into a JOIN, where Postgres
+ * reports `Rows Removed by Join Filter` — a different key, so 59.8M discarded rows
+ * scored 0. Round 2 added that key, and it too fails on PG 16.14 (production's version),
+ * where the same fan-out is planned as a HASH join and attributes nothing to a join
+ * filter: both counters read 0 while the query touches 2.2M rows against the shipped
+ * form's 12.5k. `tempBlocks` catches it only at low `work_mem` — the shipped
+ * docker-compose sets 4MB, but at 64MB an 80x regression passes clean.
+ *
+ * Rows touched separates the two by ~177x on BOTH PG 16.14 and PGlite and assumes
+ * nothing about join strategy or `work_mem`. Keep the discarded-row counters as
+ * secondary signals for the OR mis-plan, but do not rely on them alone again.
+ *
+ * `Actual Loops` multiplication is not cosmetic: Postgres divides the discarded-row
+ * counters by loops (`explain.c:show_instrumentation_count`), so a filter inside a
+ * per-probe nested loop is reported at 1/100th of what it discarded.
  */
 const walk = (
   node: PlanNode,
-  acc: { filtered: number; joinFiltered: number; nodes: string[] },
+  acc: { touched: number; filtered: number; joinFiltered: number; nodes: string[] },
 ): void => {
-  acc.filtered += (node['Rows Removed by Filter'] as number) ?? 0;
-  acc.joinFiltered += (node['Rows Removed by Join Filter'] as number) ?? 0;
+  const loops = (node['Actual Loops'] as number) ?? 1;
+  acc.touched += ((node['Actual Rows'] as number) ?? 0) * loops;
+  acc.filtered += ((node['Rows Removed by Filter'] as number) ?? 0) * loops;
+  acc.joinFiltered += ((node['Rows Removed by Join Filter'] as number) ?? 0) * loops;
   acc.nodes.push(
     `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
       `${node['Index Name'] ? ' on ' + node['Index Name'] : ''}`,
@@ -157,12 +175,13 @@ const explainGeneric = async (
       `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
     );
     const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
-    const acc = { filtered: 0, joinFiltered: 0, nodes: [] as string[] };
+    const acc = { touched: 0, filtered: 0, joinFiltered: 0, nodes: [] as string[] };
     walk(plan, acc);
     return {
       blocks:
         ((plan['Shared Hit Blocks'] as number) ?? 0) +
         ((plan['Shared Read Blocks'] as number) ?? 0),
+      rowsTouched: acc.touched,
       rowsFiltered: acc.filtered,
       rowsJoinFiltered: acc.joinFiltered,
       tempBlocks: (plan['Temp Written Blocks'] as number) ?? 0,
@@ -319,9 +338,8 @@ const BTREE_INDEX = 'operations_user_id_entity_type_entity_id_server_seq_idx';
  * it compares |cand| x |touched| — bounded by the batch size and INDEPENDENT of how wide
  * the stored arrays are, which is exactly what separates it from a fan-out.
  */
-const expectBounded = (measured: Measured, maxJoinFiltered = 0): void => {
-  expect(measured.rowsFiltered).toBe(0);
-  expect(measured.rowsJoinFiltered).toBeLessThanOrEqual(maxJoinFiltered);
+const expectBounded = (measured: Measured, maxRowsTouched: number): void => {
+  expect(measured.rowsTouched).toBeLessThanOrEqual(maxRowsTouched);
   expect(measured.tempBlocks).toBe(0);
   expect(measured.nodes).not.toContain('Seq Scan');
   expect(measured.nodes).toContain(GIN_INDEX);
@@ -329,13 +347,25 @@ const expectBounded = (measured: Measured, maxJoinFiltered = 0): void => {
 };
 
 /**
- * Ceiling for prefetch's pair re-check. Pinned just above the measured 99_000 (=|cand| x
- * |touched|) rather than at the analytic worst case: the natural-looking
- * PROBE_SIZE * WIDE_OPS * PROBE_SIZE = 200_000 would also admit the inner JOIN this
- * replaced, which measures exactly 198_000 — a ceiling that passes the form you removed
- * for cost is not a guard.
+ * Row-touch ceilings, each ~2x the measured value so a planner shift does not flake
+ * while any fan-out still fails by orders of magnitude.
+ *
+ * All-new probe: nothing matches, so both queries only pay the per-probe index seeks.
+ * Wide probe: |cand| is |probe| x WIDE_OPS = 2000 and the branches feed DISTINCT ON, so
+ * ~12.5k rows move. The round-1 fan-out re-expanded each candidate by WIDE_WIDTH and
+ * touched 2.2M on PG 16.14 / 21M on PGlite — 177x and 1700x over these ceilings.
  */
-const MAX_PAIR_RECHECK_COMPARISONS = 110_000;
+const MAX_ROWS_TOUCHED_ALL_NEW = 3_000;
+const MAX_ROWS_TOUCHED_WIDE = 30_000;
+/**
+ * Prefetch's wide case is higher (measured 115_505) because its array branch must
+ * re-check each candidate against the requested (entity_type, entity_id) PAIR, and under
+ * `force_generic_plan` PGlite runs that semi-join as a nested loop over `touched`:
+ * |cand| x |touched| on top of the rows the branches actually produce. PG 16.14 plans it
+ * as a hash join and pays none of this, so the ceiling is sized for the pessimistic
+ * planner. Still ~400x below the round-1 fan-out on the same seed.
+ */
+const MAX_ROWS_TOUCHED_WIDE_PAIRS = 250_000;
 
 describe('batch conflict detection does not scan the history (PGlite)', () => {
   let db: PGlite;
@@ -361,7 +391,7 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 
     expect(result.hasConflict).toBe(false);
     expect(measured).toHaveLength(1);
-    expectBounded(measured[0]);
+    expectBounded(measured[0], MAX_ROWS_TOUCHED_ALL_NEW);
   });
 
   it('detectConflictForEntities does not fan out on wide entity_ids (#9503)', async () => {
@@ -383,7 +413,7 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 
     expect(result.hasConflict).toBe(true);
     expect(measured).toHaveLength(1);
-    expectBounded(measured[0]);
+    expectBounded(measured[0], MAX_ROWS_TOUCHED_WIDE);
   });
 
   it('prefetchLatestEntityOpsForBatch reads a bounded amount for an all-new batch (#9503)', async () => {
@@ -398,7 +428,7 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 
     expect(latest.size).toBe(0);
     expect(measured).toHaveLength(1);
-    expectBounded(measured[0]);
+    expectBounded(measured[0], MAX_ROWS_TOUCHED_ALL_NEW);
   });
 
   it('prefetchLatestEntityOpsForBatch does not fan out on wide entity_ids (#9503)', async () => {
@@ -413,7 +443,7 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 
     expect(latest.size).toBe(PROBE_SIZE);
     expect(measured).toHaveLength(1);
-    expectBounded(measured[0], MAX_PAIR_RECHECK_COMPARISONS);
+    expectBounded(measured[0], MAX_ROWS_TOUCHED_WIDE_PAIRS);
   });
 
   it('still finds the latest op per entity for a batch that DOES match', async () => {

--- a/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
@@ -6,6 +6,7 @@ import {
   getEntityConflictKey,
   prefetchLatestEntityOpsForBatch,
 } from '../src/sync/conflict';
+import { explainGeneric, type Measured } from './explain-plan.helper';
 import type { Operation } from '../src/sync/sync.types';
 
 /**
@@ -54,13 +55,16 @@ import type { Operation } from '../src/sync/sync.types';
  *
  * REMAINING FIDELITY LIMITS — PGlite is PG18, and the planner differences from
  * production's PG 16.14 are real, not theoretical. Measured during review of #9503
- * (2026-08, a one-off manual check against postgres:16-alpine, NOT re-run by this file):
+ * (2026-08, one-off manual checks against postgres:16-alpine, NOT re-run by this file):
  * PG 16.14 plans the array-branch join as a HASH join where PGlite uses a nested loop,
  * so `Rows Removed by Join Filter` reads 0 there for a plan that is still 80x too
- * expensive. That is exactly why `rowsTouched` is the primary assertion — see walk().
- * Blocks are also unmodellable here: PGlite reports every block as a cache hit, so these
- * counts cannot stand in for production's cold-cache I/O. The plan SHAPE transfers; the
- * absolute numbers below do not.
+ * expensive. That is exactly why `rowsTouched` is the primary assertion — see
+ * explain-plan.helper.ts. The two versions also disagree on plan SHAPE under a dirty
+ * pending list (PG 16.14 stays on the GIN where PG18 seq-scans), which is why the last
+ * describe asserts cost and not nodes. Blocks are unmodellable here in the other
+ * direction too: PGlite reports every block as a cache hit, so these counts cannot stand
+ * in for production's cold-cache I/O. The plan shape mostly transfers; the absolute
+ * numbers below do not.
  */
 
 const OWN_OPS = 20_000;
@@ -106,92 +110,6 @@ const createIndexes = (fastupdate: 'on' | 'off'): string => `
 const INSERT_COLS =
   'id,user_id,client_id,server_seq,action_type,entity_type,entity_id,entity_ids,' +
   'schema_version,vector_clock';
-
-type PlanNode = Record<string, unknown>;
-type Measured = {
-  blocks: number;
-  rowsTouched: number;
-  rowsFiltered: number;
-  rowsJoinFiltered: number;
-  tempBlocks: number;
-  nodes: string;
-};
-
-/**
- * `rowsTouched` — Actual Rows x Actual Loops summed over the tree — is the PRIMARY
- * signal, and it is the only one here that is planner-independent.
- *
- * Two rounds of review were defeated by picking a counter instead. Round 1 asserted
- * `Rows Removed by Filter`, and the fan-out moved the work into a JOIN, where Postgres
- * reports `Rows Removed by Join Filter` — a different key, so 59.8M discarded rows
- * scored 0. Round 2 added that key, and it too fails on PG 16.14 (production's version),
- * where the same fan-out is planned as a HASH join and attributes nothing to a join
- * filter: both counters read 0 while the query touches 2.2M rows against the shipped
- * form's 12.5k. `tempBlocks` catches it only at low `work_mem` — the shipped
- * docker-compose sets 4MB, but at 64MB an 80x regression passes clean.
- *
- * Rows touched separates the two by ~177x on BOTH PG 16.14 and PGlite and assumes
- * nothing about join strategy or `work_mem`. Keep the discarded-row counters as
- * secondary signals for the OR mis-plan, but do not rely on them alone again.
- *
- * `Actual Loops` multiplication is not cosmetic: Postgres divides the discarded-row
- * counters by loops (`explain.c:show_instrumentation_count`), so a filter inside a
- * per-probe nested loop is reported at 1/100th of what it discarded.
- */
-const walk = (
-  node: PlanNode,
-  acc: { touched: number; filtered: number; joinFiltered: number; nodes: string[] },
-): void => {
-  const loops = (node['Actual Loops'] as number) ?? 1;
-  acc.touched += ((node['Actual Rows'] as number) ?? 0) * loops;
-  acc.filtered += ((node['Rows Removed by Filter'] as number) ?? 0) * loops;
-  acc.joinFiltered += ((node['Rows Removed by Join Filter'] as number) ?? 0) * loops;
-  acc.nodes.push(
-    `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
-      `${node['Index Name'] ? ' on ' + node['Index Name'] : ''}`,
-  );
-  for (const child of (node.Plans as PlanNode[]) ?? []) walk(child, acc);
-};
-
-const toSqlLiteral = (value: unknown): string => {
-  if (value === null || value === undefined) return 'NULL';
-  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
-  if (Array.isArray(value)) return `ARRAY[${value.map(toSqlLiteral).join(',')}]::text[]`;
-  return `'${String(value).replace(/'/g, "''")}'`;
-};
-
-let preparedCounterId = 0;
-const explainGeneric = async (
-  db: PGlite,
-  sql: string,
-  params: readonly unknown[],
-): Promise<Measured> => {
-  const name = `batch_plan_probe_${preparedCounterId++}`;
-  const args = params.map(toSqlLiteral).join(', ');
-  await db.exec(`SET plan_cache_mode = force_generic_plan`);
-  await db.exec(`PREPARE ${name} AS ${sql}`);
-  try {
-    const res = await db.query<Record<string, unknown>>(
-      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
-    );
-    const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
-    const acc = { touched: 0, filtered: 0, joinFiltered: 0, nodes: [] as string[] };
-    walk(plan, acc);
-    return {
-      blocks:
-        ((plan['Shared Hit Blocks'] as number) ?? 0) +
-        ((plan['Shared Read Blocks'] as number) ?? 0),
-      rowsTouched: acc.touched,
-      rowsFiltered: acc.filtered,
-      rowsJoinFiltered: acc.joinFiltered,
-      tempBlocks: (plan['Temp Written Blocks'] as number) ?? 0,
-      nodes: acc.nodes.join(' -> '),
-    };
-  } finally {
-    await db.exec(`DEALLOCATE ${name}`);
-    await db.exec(`SET plan_cache_mode = auto`);
-  }
-};
 
 /**
  * Renders the PRODUCTION tagged template through the real `Prisma.sql` (so nested
@@ -318,25 +236,21 @@ const BTREE_INDEX = 'operations_user_id_entity_type_entity_id_server_seq_idx';
 
 /**
  * NO BLOCK BUDGET HERE, unlike the sibling spec — tried and rejected on evidence. On the
- * all-new probe the fix reads 600 blocks against the OR form's 810 (detect) and 438
+ * all-new probe the fix reads 501 blocks against the OR form's 810 (detect) and 438
  * (prefetch): the regression reads FEWER blocks than the fix in one of the two cases, so
  * no threshold can separate them, and any budget wide enough not to flake would pass the
  * very mis-plan this file exists to catch. (The sibling's budget works because its
  * regression is 816 against a fixed 143.) `Measured.blocks` is therefore reported for
- * debugging and deliberately never asserted.
+ * debugging and asserted only in the dirty-pending-list describe, where it is a RATIO
+ * between two probe sizes rather than an absolute.
  *
- * Discarded-row counts carry the signal instead. They are the regressions' actual
- * signatures — "read history and threw it away" for the OR form, "expanded every
- * candidate and threw it away" for the fan-out — and unlike blocks they are scale-free.
- * The index-name assertions pin the same property structurally: the OR mis-plan is
- * precisely the one that rides NEITHER index usefully.
- *
- * `maxJoinFiltered` is 0 for every query with no join left to mis-plan. The one exception
- * is prefetchLatestEntityOpsForBatch, whose array branch must still confirm a by-id GIN
- * match against the requested (entity_type, entity_id) PAIR. Under `force_generic_plan`
- * Postgres cannot see the parameter values and plans that semi-join as a nested loop, so
- * it compares |cand| x |touched| — bounded by the batch size and INDEPENDENT of how wide
- * the stored arrays are, which is exactly what separates it from a fan-out.
+ * `rowsTouched` carries the signal instead: it is scale-free, planner-independent, and
+ * it is the fan-out's actual signature — "expanded every candidate and threw it away".
+ * The index-name assertions pin the OTHER regression structurally: the OR mis-plan is
+ * precisely the one that rides NEITHER index usefully, so requiring both here fails it
+ * even if a future seed stops blowing the row ceiling. Those node assertions hold under
+ * production's `fastupdate = off`; do NOT copy them into the dirty describe, where the
+ * cheapest plan is a seq scan.
  */
 const expectBounded = (measured: Measured, maxRowsTouched: number): void => {
   expect(measured.rowsTouched).toBeLessThanOrEqual(maxRowsTouched);
@@ -347,23 +261,26 @@ const expectBounded = (measured: Measured, maxRowsTouched: number): void => {
 };
 
 /**
- * Row-touch ceilings, each ~2x the measured value so a planner shift does not flake
- * while any fan-out still fails by orders of magnitude.
+ * Row-touch ceilings. They are deliberately LOOSE — the point is to fail a fan-out by
+ * orders of magnitude, not to pin a number a planner change can move.
  *
- * All-new probe: nothing matches, so both queries only pay the per-probe index seeks.
- * Wide probe: |cand| is |probe| x WIDE_OPS = 2000 and the branches feed DISTINCT ON, so
- * ~12.5k rows move. The round-1 fan-out re-expanded each candidate by WIDE_WIDTH and
- * touched 2.2M on PG 16.14 / 21M on PGlite — 177x and 1700x over these ceilings.
+ * All-new probe: nothing matches, so both queries only pay the index seeks. Measured 401.
+ * Wide probe: |cand| is |probe| x WIDE_OPS = 2000 and the branches feed DISTINCT ON.
+ * Measured 11_047 (detect) and 13_347 (prefetch). The round-1 fan-out re-expanded each
+ * candidate by WIDE_WIDTH and touched 2.2M on PG 16.14 / 21M on PGlite, so it fails
+ * these by ~75x and ~700x.
  */
 const MAX_ROWS_TOUCHED_ALL_NEW = 3_000;
 const MAX_ROWS_TOUCHED_WIDE = 30_000;
 /**
- * Prefetch's wide case is higher (measured 115_505) because its array branch must
- * re-check each candidate against the requested (entity_type, entity_id) PAIR, and under
- * `force_generic_plan` PGlite runs that semi-join as a nested loop over `touched`:
- * |cand| x |touched| on top of the rows the branches actually produce. PG 16.14 plans it
- * as a hash join and pays none of this, so the ceiling is sized for the pessimistic
- * planner. Still ~400x below the round-1 fan-out on the same seed.
+ * Prefetch keeps its own, much looser ceiling because its array branch must re-check
+ * each candidate against the requested (entity_type, entity_id) PAIR, and the cost of
+ * that semi-join is PLANNER-DEPENDENT by an order of magnitude: a hash semi-join (what
+ * both PGlite and PG 16.14 currently choose) touches the 13_347 above, while a nested
+ * loop over `touched` — which PGlite chose for the pre-`&&` shape of this same query —
+ * costs |cand| x |touched| and touched 115_505. The ceiling sits above the pessimistic
+ * plan on purpose, so a planner shift is not a red build. Still ~180x below the round-1
+ * fan-out on this seed, which is the regression it exists to catch.
  */
 const MAX_ROWS_TOUCHED_WIDE_PAIRS = 250_000;
 
@@ -505,45 +422,102 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 });
 
 /**
- * The array branch must ride the GIN even when the pending list is DIRTY.
+ * The array branch must stay CHEAP when the GIN pending list is DIRTY — and the shape
+ * that achieves that is ONE `&&` probe, not one `@>` per requested id.
  *
  * `fastupdate = off` is set by raw migration 20260720000000 and CANNOT be expressed in
  * schema.prisma, so every `prisma db push` database — CI, the E2E stack, the documented
- * manual setup — has it ON. Measured on this seed: a single 100-key `entity_ids && $arr`
- * probe costs enough under a dirty pending list that the planner abandons the GIN for a
- * SEQ SCAN of the whole table (40000 rows discarded) — at production's 6.97M rows that
- * is far worse than the slice scan being fixed. Probing per id with a 1-key `@>` keeps
- * the GIN chosen in BOTH states; it costs ~100 extra blocks when the reloption is right,
- * and it is the same shape detectConflictForEntity already ships.
+ * manual setup in README.md — has it ON. Every GIN scan then reads the whole pending
+ * list, so N per-id probes read it N times where one `&&` reads it once: the per-id
+ * form's I/O is LINEAR IN THE BATCH SIZE. Measured, per statement:
  *
- * So this is not a micro-optimisation: it is why the array branch is written as a
- * per-id lateral rather than one `&&`. Do not "simplify" it back.
+ *              PGlite, this seed        PG 16.14, 1.5M rows, 471 pending pages
+ *   form       time / blocks            time / blocks
+ *   `@>`x100   175 ms / 19,600           261 ms / 47,800
+ *   `&&`        26 ms /    981           170 ms /  1,072
+ *
+ * Both callers chunk at CONFLICT_DETECTION_ENTITY_BATCH_SIZE, so an op at the 1000-id
+ * wire cap issues ten of these in one upload transaction: 2.5 s of `@>` against 1.6 s of
+ * `&&` on PG 16.14. Multi-second statements inside the upload transaction are #9503's
+ * own failure mode, so this describe is not a micro-optimisation guard — it is the one
+ * that stops the fix re-creating the incident on every db-push deployment.
+ *
+ * ON THE PLAN SHAPE: under a dirty pending list PGlite/PG18 abandons the GIN for a SEQ
+ * SCAN here. That is FINE and this file deliberately does NOT forbid it — the seq scan
+ * is 6.8x faster and reads 20x fewer blocks than the GIN plan the per-id form gets. A
+ * previous revision asserted `not.toContain('Seq Scan')` and so pinned the WORSE outcome
+ * as if it were the requirement, which is how the per-id form got shipped. Assert cost,
+ * never plan shape, in this state.
  */
 describe('batch conflict array branch survives a dirty GIN pending list (PGlite)', () => {
   let db: PGlite;
+  /** A FULL-batch probe and a tenth-size one, both against the dirty pending list. */
+  let dirty: Measured;
+  let dirtySmall: Measured;
+  /** The full-batch probe again, after VACUUM flushes the pending list. */
+  let flushed: Measured;
 
+  // Measured in beforeAll rather than per-test because the VACUUM below DESTROYS the
+  // state the other assertions need, and an ordering dependency between `it`s is exactly
+  // the kind of thing that silently stops holding.
   beforeAll(async () => {
     db = new PGlite();
     await db.waitReady;
     await seed(db, 'on');
+
+    const probe = async (ids: string[]): Promise<Measured> => {
+      const runs: Measured[] = [];
+      await detectConflictForEntities(
+        USER_ID,
+        incomingOp(),
+        ids,
+        makeExplainingTx(db, runs),
+      );
+      expect(runs).toHaveLength(1);
+      return runs[0];
+    };
+
+    dirtySmall = await probe(brandNewIds().slice(0, PROBE_SIZE / 10));
+    dirty = await probe(brandNewIds());
+
+    // PGlite ships no pgstattuple, so `pending_pages` cannot be read directly. VACUUM
+    // flushes the pending list into the main GIN entry tree, so re-measuring the SAME
+    // probe afterwards prices the same query against a clean index — the difference IS
+    // the pending list.
+    await db.exec('VACUUM operations');
+    flushed = await probe(brandNewIds());
   }, 180_000);
 
   afterAll(async () => {
     await db.close();
   });
 
-  it('does not fall back to a Seq Scan with fastupdate=on', async () => {
-    const measured: Measured[] = [];
-    await detectConflictForEntities(
-      USER_ID,
-      incomingOp(),
-      brandNewIds(),
-      makeExplainingTx(db, measured),
-    );
+  /**
+   * CANARY. Without this the describe can pass while measuring a CLEAN index — which is
+   * what a reviewer suspected was already happening, on the grounds that a bulk load
+   * flushes past `gin_pending_list_limit`. It does not flush ALL of it: the tail stays
+   * pending (confirmed directly on PG 16.14 via pgstatginindex — 58 pages / 4,544 tuples
+   * after the same bulk load), and that tail is what the reloption exposes.
+   */
+  it('CANARY: the fastupdate=on seed really does leave a dirty pending list', () => {
+    expect(dirty.blocks).toBeGreaterThan(flushed.blocks * 2);
+  });
 
-    expect(measured[0].rowsFiltered).toBe(0);
-    expect(measured[0].rowsJoinFiltered).toBe(0);
-    expect(measured[0].nodes).not.toContain('Seq Scan');
-    expect(measured[0].nodes).toContain('operations_entity_ids_gin');
+  it('does not re-read the pending list once per probed id', () => {
+    // THE property, stated scale-free: one `&&` reads the pending list once however many
+    // ids are asked for, so a 10x bigger batch must NOT cost 10x the blocks. Measured
+    // 1065 blocks at 100 ids against 1010 at 10 — essentially flat. The per-id form is
+    // 19,600 at 100 ids and scales linearly, so it fails this by ~10x however the seed
+    // is resized. An absolute budget could not do this: it would have to be re-derived
+    // for every seed change, and the numbers above are PGlite's, not production's.
+    //
+    // Blocks, not time: this is an I/O regression, and PGlite reports every block as a
+    // cache hit, so wall time understates it exactly where production would feel it most.
+    expect(dirty.blocks).toBeLessThan(dirtySmall.blocks * 3);
+    // Deliberately NOT rowsFiltered === 0, which the other describe does assert: the
+    // seq-scan plan PG18 picks here reads and filters all 40,020 rows by construction,
+    // so that assertion would once again be pinning a plan shape rather than a cost.
+    // rowsTouched counts rows EMITTED, so it still fails any fan-out regression.
+    expect(dirty.rowsTouched).toBeLessThanOrEqual(MAX_ROWS_TOUCHED_ALL_NEW);
   });
 });

--- a/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
@@ -42,11 +42,16 @@ import type { Operation } from '../src/sync/sync.types';
  *    20260720000000, #9213), rather than left at the default as the sibling does. It
  *    decides which plan the array branch gets, so leaving it implicit would measure a
  *    state production is not in. The last describe pins the opposite state on purpose.
+ *  - The seed carries a WIDE-array population (see WIDE_WIDTH) as well as the width-2
+ *    majority. The first fix for #9503 regressed only on wide arrays, and a width-2
+ *    seed cannot express that: see the two "does not fan out" tests.
  *
- * REMAINING FIDELITY LIMIT: PGlite is PG18 and reports every block as a cache hit, so
+ * REMAINING FIDELITY LIMITS: PGlite is PG18 and reports every block as a cache hit, so
  * these counts cannot model production's cold-cache I/O. The plan SHAPE is what
- * transfers — and it was cross-checked node-for-node against postgres:16-alpine
- * (PG 16.14), production's major version, on this same seed.
+ * transfers. The shipped-vs-regressed plan shapes were also cross-checked against
+ * postgres:16-alpine (PG 16.14), production's major version, during review of #9503 —
+ * that was a one-off manual check, not something this file re-runs, so treat it as a
+ * dated observation (2026-08) rather than a maintained property.
  */
 
 const OWN_OPS = 20_000;
@@ -94,10 +99,28 @@ const INSERT_COLS =
   'schema_version,vector_clock';
 
 type PlanNode = Record<string, unknown>;
-type Measured = { blocks: number; rowsFiltered: number; nodes: string };
+type Measured = {
+  blocks: number;
+  rowsFiltered: number;
+  rowsJoinFiltered: number;
+  tempBlocks: number;
+  nodes: string;
+};
 
-const walk = (node: PlanNode, acc: { filtered: number; nodes: string[] }): void => {
+/**
+ * `Rows Removed by Filter` alone is NOT enough, and assuming it was let a 1000x
+ * regression through review: this rewrite moved the id match from a `WHERE ... = ANY`
+ * into a JOIN, and Postgres reports work discarded there as `Rows Removed by JOIN
+ * Filter` — a different key. A fan-out that read and threw away 19.8M join rows scored
+ * `rowsFiltered: 0` and passed `expectBounded` untouched. Count both, plus temp blocks,
+ * which is what an over-wide intermediate spills to.
+ */
+const walk = (
+  node: PlanNode,
+  acc: { filtered: number; joinFiltered: number; nodes: string[] },
+): void => {
   acc.filtered += (node['Rows Removed by Filter'] as number) ?? 0;
+  acc.joinFiltered += (node['Rows Removed by Join Filter'] as number) ?? 0;
   acc.nodes.push(
     `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
       `${node['Index Name'] ? ' on ' + node['Index Name'] : ''}`,
@@ -127,13 +150,15 @@ const explainGeneric = async (
       `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
     );
     const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
-    const acc = { filtered: 0, nodes: [] as string[] };
+    const acc = { filtered: 0, joinFiltered: 0, nodes: [] as string[] };
     walk(plan, acc);
     return {
       blocks:
         ((plan['Shared Hit Blocks'] as number) ?? 0) +
         ((plan['Shared Read Blocks'] as number) ?? 0),
       rowsFiltered: acc.filtered,
+      rowsJoinFiltered: acc.joinFiltered,
+      tempBlocks: (plan['Temp Written Blocks'] as number) ?? 0,
       nodes: acc.nodes.join(' -> '),
     };
   } finally {
@@ -184,6 +209,27 @@ const incomingOp = (): Operation =>
 const brandNewIds = (): string[] =>
   Array.from({ length: PROBE_SIZE }, (_, i) => `task-brand-new-${i}`);
 
+/**
+ * The OTHER pathological input, and the one a width-2 seed cannot express: repeated bulk
+ * ops over the SAME wide id set. `planTasksForToday`, `updateTasks`, `moveToArchive` and
+ * the board/planner reorders all emit the full id list (`task-shared.actions.ts`), and
+ * `detectConflictForEntities` probes the incoming op's OWN ids — so probe and stored
+ * `entity_ids` overlap MAXIMALLY here, by construction. That overlap is the multiplier in
+ * any array-branch fan-out, so this is where such a regression shows up and nowhere else.
+ */
+const WIDE_OPS = 20;
+/**
+ * Deliberately WIDER than PROBE_SIZE, so the two cost models separate numerically and a
+ * fan-out cannot hide inside the fan-out-free ceiling: without fan-out the array branch
+ * handles |probe| x WIDE_OPS candidate rows regardless of how wide the stored arrays
+ * are; with it, every candidate is re-expanded by WIDE_WIDTH.
+ */
+const WIDE_WIDTH = 300;
+const wideIds = (): string[] =>
+  Array.from({ length: WIDE_WIDTH }, (_, i) => `wide-task-${i}`);
+/** Probe a strict subset, as a client re-uploading part of a bulk selection would. */
+const wideProbeIds = (): string[] => wideIds().slice(0, PROBE_SIZE);
+
 const seed = async (db: PGlite, fastupdate: 'on' | 'off'): Promise<void> => {
   await db.exec(CREATE_TABLE);
   // BEFORE the rows, as in production: rows arrive one op at a time against a
@@ -223,6 +269,19 @@ const seed = async (db: PGlite, fastupdate: 'on' | 'off'): Promise<void> => {
   }
   await flush();
 
+  // The wide-array population (see wideIds): WIDE_OPS ops all carrying the SAME
+  // WIDE_WIDTH ids, as a repeated bulk action produces.
+  const wide = wideIds()
+    .map((id) => `"${id}"`)
+    .join(',');
+  for (let k = 1; k <= WIDE_OPS; k++) {
+    rows.push(
+      `('op-wide-${k}', ${USER_ID}, 'seed-client', ${OWN_OPS + k}, '[Task] Update',` +
+        ` 'TASK', 'wide-task-0', '{${wide}}', 1, '{"seed-client":${OWN_OPS + k}}')`,
+    );
+  }
+  await flush();
+
   // ANALYZE so the planner works from real statistics. Deliberately NOT VACUUM: that
   // would flush the GIN pending list and measure the freshly-vacuumed best case.
   await db.exec('ANALYZE operations');
@@ -249,12 +308,26 @@ const BTREE_INDEX = 'operations_user_id_entity_type_entity_id_server_seq_idx';
  * property structurally: the mis-plan is precisely the one that rides NEITHER index
  * usefully.
  */
-const expectBounded = (measured: Measured): void => {
+/**
+ * `maxJoinFiltered` is 0 for every query that has no join left to mis-plan. The one
+ * exception is prefetchLatestEntityOpsForBatch, whose array branch must still confirm a
+ * by-id GIN match against the requested (entity_type, entity_id) PAIR. Under
+ * `force_generic_plan` Postgres cannot see the parameter values and plans that semi-join
+ * as a nested loop, so it compares |cand| x |touched|. That is bounded by the batch size
+ * and the number of matching ops, and is INDEPENDENT of how wide the stored arrays are —
+ * which is exactly what separates it from a fan-out. See WIDE_WIDTH.
+ */
+const expectBounded = (measured: Measured, maxJoinFiltered = 0): void => {
   expect(measured.rowsFiltered).toBe(0);
+  expect(measured.rowsJoinFiltered).toBeLessThanOrEqual(maxJoinFiltered);
+  expect(measured.tempBlocks).toBe(0);
   expect(measured.nodes).not.toContain('Seq Scan');
   expect(measured.nodes).toContain(GIN_INDEX);
   expect(measured.nodes).toContain(BTREE_INDEX);
 };
+
+/** The fan-out-free ceiling for the pair re-check: candidates x requested pairs. */
+const MAX_PAIR_RECHECK_COMPARISONS = PROBE_SIZE * WIDE_OPS * PROBE_SIZE;
 
 describe('batch conflict detection does not scan the history (PGlite)', () => {
   let db: PGlite;
@@ -280,7 +353,27 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 
     expect(result.hasConflict).toBe(false);
     expect(measured).toHaveLength(1);
-    console.log('DETECT', JSON.stringify(measured[0]));
+    expectBounded(measured[0]);
+  });
+
+  it('detectConflictForEntities does not fan out on wide entity_ids (#9503)', async () => {
+    // REGRESSION GUARD. The first fix for #9503 tagged nothing onto the array-branch
+    // candidates and re-derived the matched id with `unnest(entity_ids) JOIN probe`.
+    // Because `cand` already holds one copy of an op per matching probe id, that emitted
+    // |probe n entity_ids| squared rows per op: measured 8645ms / 19.8M join-filtered
+    // rows / 1611 temp blocks on exactly this seed, against 8ms and zero for the shipped
+    // form. It passed the all-new test above untouched, because a batch that matches
+    // NOTHING has no fan-out to multiply.
+    const measured: Measured[] = [];
+    const result = await detectConflictForEntities(
+      USER_ID,
+      incomingOp(),
+      wideProbeIds(),
+      makeExplainingTx(db, measured),
+    );
+
+    expect(result.hasConflict).toBe(true);
+    expect(measured).toHaveLength(1);
     expectBounded(measured[0]);
   });
 
@@ -296,8 +389,22 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 
     expect(latest.size).toBe(0);
     expect(measured).toHaveLength(1);
-    console.log('PREFETCH', JSON.stringify(measured[0]));
     expectBounded(measured[0]);
+  });
+
+  it('prefetchLatestEntityOpsForBatch does not fan out on wide entity_ids (#9503)', async () => {
+    // Same guard for the sibling shape, which fanned out harder still (it re-joined
+    // `touched` on two columns): 36.8s at the 1000-id wire cap before the fix.
+    const measured: Measured[] = [];
+    const latest = await prefetchLatestEntityOpsForBatch(
+      USER_ID,
+      wideProbeIds().map((entityId) => ({ entityType: 'TASK', entityId })),
+      makeExplainingTx(db, measured),
+    );
+
+    expect(latest.size).toBe(PROBE_SIZE);
+    expect(measured).toHaveLength(1);
+    expectBounded(measured[0], MAX_PAIR_RECHECK_COMPARISONS);
   });
 
   it('still finds the latest op per entity for a batch that DOES match', async () => {
@@ -347,8 +454,10 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
       [USER_ID, 'TASK', ids],
     );
 
-    // The whole probed (user_id, 'TASK') slice, read and discarded.
-    expect(regressed.rowsFiltered).toBe(OWN_OPS / ENTITY_TYPES.length);
+    // The whole probed (user_id, 'TASK') slice, read and discarded. A lower bound, not
+    // an equality: the exact count is a planner artefact that a PGlite bump can shift,
+    // while "it still reads the slice" is the property this canary exists to assert.
+    expect(regressed.rowsFiltered).toBeGreaterThanOrEqual(OWN_OPS / ENTITY_TYPES.length);
     // ...and the structural cause: the OR makes the GIN unusable, so the plan rides
     // only the btree and uses it as a filter rather than a seek.
     expect(regressed.nodes).not.toContain(GIN_INDEX);
@@ -393,8 +502,8 @@ describe('batch conflict array branch survives a dirty GIN pending list (PGlite)
       makeExplainingTx(db, measured),
     );
 
-    console.log('DIRTYGIN', JSON.stringify(measured[0]));
     expect(measured[0].rowsFiltered).toBe(0);
+    expect(measured[0].rowsJoinFiltered).toBe(0);
     expect(measured[0].nodes).not.toContain('Seq Scan');
     expect(measured[0].nodes).toContain('operations_entity_ids_gin');
   });

--- a/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { Prisma } from '@prisma/client';
+import {
+  detectConflictForEntities,
+  getEntityConflictKey,
+  prefetchLatestEntityOpsForBatch,
+} from '../src/sync/conflict';
+import type { Operation } from '../src/sync/sync.types';
+
+/**
+ * Production incident #9503: `detectConflictForEntities` was cancelled by
+ * `statement_timeout` (SQLSTATE 57014) every 5-12 minutes on the production instance,
+ * inside the upload transaction. The sibling spec covers the SINGLE-entity lookup;
+ * nothing measured the two BATCH queries until this file (#9192, #9205).
+ *
+ * WHAT THE PLAN ACTUALLY WAS — measured, not reasoned. #9503 hypothesised an unbounded
+ * `DISTINCT ON`. It is not that. The combined `(entity_ids && $arr OR entity_id = ANY($arr))`
+ * spans the entity_ids GIN and the (user_id, entity_type, entity_id, server_seq) btree, and
+ * the planner abandons both to slice-scan the btree: on the seed below, PG16.14 and PGlite
+ * both discard the probed user's WHOLE (user_id, entity_type) slice — 2500 rows — for a
+ * 100-id probe that matches nothing. `prefetchLatestEntityOpsForBatch` carries no
+ * `entity_type` predicate at all, so it discarded 20007: the user's ENTIRE history.
+ * That is the same OR-across-two-indexes degeneracy as the 2026-07-20 outage, which
+ * conflict.ts flagged as "not excluded" for these paths. `DISTINCT ON` is not what made
+ * it expensive; the OR is.
+ *
+ * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS — the reasoning is documented
+ * once, in the sibling conflict-entity-lookup-plan.pglite.spec.ts header. The production
+ * tagged templates are rendered through the real `Prisma.sql`, so the SQL under test is
+ * byte-for-byte what conflict.ts sends, including nested `Prisma.join` fragments.
+ *
+ * WHY THIS SEED DIFFERS FROM THE SIBLING SPEC — do not "align" them:
+ *
+ *  - The sibling keeps `entity_ids` empty on EVERY row because array-element statistics
+ *    disarm ITS regression. That does NOT apply here, and it was checked rather than
+ *    assumed: the batch mis-plan reproduces identically at 0% and at 10% multi-entity
+ *    rows (2500 filtered either way), because the OR never lets the planner consider the
+ *    GIN in the first place. So this seed DOES populate a minority of rows — otherwise
+ *    the array branch of the fix is never exercised at all.
+ *  - `fastupdate = off` is set explicitly, matching production (migration
+ *    20260720000000, #9213), rather than left at the default as the sibling does. It
+ *    decides which plan the array branch gets, so leaving it implicit would measure a
+ *    state production is not in. The last describe pins the opposite state on purpose.
+ *
+ * REMAINING FIDELITY LIMIT: PGlite is PG18 and reports every block as a cache hit, so
+ * these counts cannot model production's cold-cache I/O. The plan SHAPE is what
+ * transfers — and it was cross-checked node-for-node against postgres:16-alpine
+ * (PG 16.14), production's major version, on this same seed.
+ */
+
+const OWN_OPS = 20_000;
+const OTHER_OPS = 20_000;
+const USER_ID = 1;
+const PROBE_SIZE = 100;
+/** Entity types are spread across the seed so the btree slice is N/(users x types). */
+const ENTITY_TYPES = [
+  'TASK',
+  'PROJECT',
+  'TAG',
+  'NOTE',
+  'BOARD',
+  'GLOBAL_CONFIG',
+  'SIMPLE_COUNTER',
+  'TASK_REPEAT_CFG',
+];
+
+const CREATE_TABLE = `
+  CREATE TABLE operations (
+    id             text PRIMARY KEY,
+    user_id        integer NOT NULL,
+    client_id      text NOT NULL,
+    server_seq     integer NOT NULL,
+    action_type    text NOT NULL,
+    entity_type    text NOT NULL,
+    entity_id      text,
+    entity_ids     text[] NOT NULL DEFAULT '{}',
+    schema_version integer NOT NULL DEFAULT 1,
+    vector_clock   jsonb NOT NULL
+  );
+`;
+
+const createIndexes = (fastupdate: 'on' | 'off'): string => `
+  CREATE UNIQUE INDEX operations_user_id_server_seq_key
+    ON operations (user_id, server_seq);
+  CREATE INDEX operations_user_id_entity_type_entity_id_server_seq_idx
+    ON operations (user_id, entity_type, entity_id, server_seq);
+  CREATE INDEX operations_entity_ids_gin ON operations USING GIN (entity_ids)
+    WITH (fastupdate = ${fastupdate});
+`;
+
+const INSERT_COLS =
+  'id,user_id,client_id,server_seq,action_type,entity_type,entity_id,entity_ids,' +
+  'schema_version,vector_clock';
+
+type PlanNode = Record<string, unknown>;
+type Measured = { blocks: number; rowsFiltered: number; nodes: string };
+
+const walk = (node: PlanNode, acc: { filtered: number; nodes: string[] }): void => {
+  acc.filtered += (node['Rows Removed by Filter'] as number) ?? 0;
+  acc.nodes.push(
+    `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
+      `${node['Index Name'] ? ' on ' + node['Index Name'] : ''}`,
+  );
+  for (const child of (node.Plans as PlanNode[]) ?? []) walk(child, acc);
+};
+
+const toSqlLiteral = (value: unknown): string => {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  if (Array.isArray(value)) return `ARRAY[${value.map(toSqlLiteral).join(',')}]::text[]`;
+  return `'${String(value).replace(/'/g, "''")}'`;
+};
+
+let preparedCounterId = 0;
+const explainGeneric = async (
+  db: PGlite,
+  sql: string,
+  params: readonly unknown[],
+): Promise<Measured> => {
+  const name = `batch_plan_probe_${preparedCounterId++}`;
+  const args = params.map(toSqlLiteral).join(', ');
+  await db.exec(`SET plan_cache_mode = force_generic_plan`);
+  await db.exec(`PREPARE ${name} AS ${sql}`);
+  try {
+    const res = await db.query<Record<string, unknown>>(
+      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
+    );
+    const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
+    const acc = { filtered: 0, nodes: [] as string[] };
+    walk(plan, acc);
+    return {
+      blocks:
+        ((plan['Shared Hit Blocks'] as number) ?? 0) +
+        ((plan['Shared Read Blocks'] as number) ?? 0),
+      rowsFiltered: acc.filtered,
+      nodes: acc.nodes.join(' -> '),
+    };
+  } finally {
+    await db.exec(`DEALLOCATE ${name}`);
+    await db.exec(`SET plan_cache_mode = auto`);
+  }
+};
+
+/**
+ * Renders the PRODUCTION tagged template through the real `Prisma.sql` (so nested
+ * `Prisma.Sql` / `Prisma.join` fragments and their `$n` numbering are Prisma's own),
+ * EXPLAINs it, then executes it for real so the caller still gets its rows.
+ */
+const makeExplainingTx = (db: PGlite, measured: Measured[]): Prisma.TransactionClient => {
+  const adapter = {
+    $queryRaw: async <T>(
+      strings: TemplateStringsArray,
+      ...values: Array<Prisma.Sql | Prisma.Sql['values'][number]>
+    ): Promise<T> => {
+      const query = Prisma.sql(strings, ...values);
+      measured.push(await explainGeneric(db, query.text, query.values));
+      return (await db.query(query.text, query.values)).rows as T;
+    },
+    // prefetch only reaches this for a GLOBAL_CONFIG:tasks pair, which these probes
+    // never request. Present so a future probe fails loudly instead of silently.
+    operation: {
+      findFirst: async (): Promise<null> => {
+        throw new Error('unexpected legacy-misc findFirst in a plan probe');
+      },
+    },
+  };
+  return adapter as unknown as Prisma.TransactionClient;
+};
+
+const incomingOp = (): Operation =>
+  ({
+    id: 'op-incoming',
+    clientId: 'uploader',
+    actionType: '[Task] Update',
+    opType: 'UPD',
+    entityType: 'TASK',
+    vectorClock: { uploader: 1 },
+    timestamp: 1,
+    schemaVersion: 1,
+  }) as unknown as Operation;
+
+/** The pathological input: a full batch that matches nothing (all-new entities). */
+const brandNewIds = (): string[] =>
+  Array.from({ length: PROBE_SIZE }, (_, i) => `task-brand-new-${i}`);
+
+const seed = async (db: PGlite, fastupdate: 'on' | 'off'): Promise<void> => {
+  await db.exec(CREATE_TABLE);
+  // BEFORE the rows, as in production: rows arrive one op at a time against a
+  // pre-existing index, which is what puts entries in the GIN pending list.
+  await db.exec(createIndexes(fastupdate));
+
+  let rows: string[] = [];
+  const flush = async (): Promise<void> => {
+    if (rows.length === 0) return;
+    await db.exec(`INSERT INTO operations (${INSERT_COLS}) VALUES ${rows.join(',')}`);
+    rows = [];
+  };
+  const entityTypeFor = (n: number): string => ENTITY_TYPES[n % ENTITY_TYPES.length];
+  // Every 10th op is multi-entity, mirroring that batch ops are a real but minority
+  // shape in production (typical entity_ids length is 2, not the 1000 the wire cap
+  // allows). Without any, the fix's array branch would never be exercised.
+  const entityIdsFor = (n: number, id: string): string =>
+    n % 10 === 0 ? `'{"${id}","co-${n}"}'` : `'{}'`;
+
+  for (let seq = 1; seq <= OWN_OPS; seq++) {
+    rows.push(
+      `('op-${seq}', ${USER_ID}, 'seed-client', ${seq}, '[Task] Update',` +
+        ` '${entityTypeFor(seq)}', 'task-${seq}', ${entityIdsFor(seq, `task-${seq}`)},` +
+        ` 1, '{"seed-client":${seq}}')`,
+    );
+    if (rows.length === 1000) await flush();
+  }
+  // A second population of comparable size spread over ~20k OTHER users, so the
+  // per-user btree slice is a small fraction of the table the GIN estimate sees.
+  for (let i = 1; i <= OTHER_OPS; i++) {
+    rows.push(
+      `('other-${i}', ${1000 + i}, 'seed-other', ${i}, '[Task] Update',` +
+        ` '${entityTypeFor(i)}', 'otask-${i}', ${entityIdsFor(i, `otask-${i}`)},` +
+        ` 1, '{"seed-other":${i}}')`,
+    );
+    if (rows.length === 1000) await flush();
+  }
+  await flush();
+
+  // ANALYZE so the planner works from real statistics. Deliberately NOT VACUUM: that
+  // would flush the GIN pending list and measure the freshly-vacuumed best case.
+  await db.exec('ANALYZE operations');
+};
+
+const GIN_INDEX = 'operations_entity_ids_gin';
+const BTREE_INDEX = 'operations_user_id_entity_type_entity_id_server_seq_idx';
+
+/**
+ * Measured on this seed with fastupdate=off, the production reloption: post-fix both
+ * batch queries discard NOTHING and read 600 blocks, riding the GIN for the array
+ * branch and the composite btree for the scalar one. The shipped OR form reads 806
+ * while discarding 2500 (detect) / 20007 (prefetch).
+ *
+ * NO BLOCK BUDGET HERE, unlike the sibling spec — that was tried and rejected on
+ * evidence. Fixed reads 600 blocks and the regression 806: a 34% gap, so no threshold
+ * separates them, and any budget wide enough not to flake would pass the very mis-plan
+ * this file exists to catch. (The sibling's budget works because its regression is 816
+ * against a fixed 143.)
+ *
+ * `rowsFiltered` carries the signal instead. It is the regression's actual signature —
+ * "read the user's history and threw it away" — and unlike blocks it is scale-free, so
+ * it keeps its meaning if the seed changes. The index-name assertions pin the same
+ * property structurally: the mis-plan is precisely the one that rides NEITHER index
+ * usefully.
+ */
+const expectBounded = (measured: Measured): void => {
+  expect(measured.rowsFiltered).toBe(0);
+  expect(measured.nodes).not.toContain('Seq Scan');
+  expect(measured.nodes).toContain(GIN_INDEX);
+  expect(measured.nodes).toContain(BTREE_INDEX);
+};
+
+describe('batch conflict detection does not scan the history (PGlite)', () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await seed(db, 'off');
+  }, 180_000);
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it('detectConflictForEntities reads a bounded amount for an all-new batch (#9503)', async () => {
+    const measured: Measured[] = [];
+    const result = await detectConflictForEntities(
+      USER_ID,
+      incomingOp(),
+      brandNewIds(),
+      makeExplainingTx(db, measured),
+    );
+
+    expect(result.hasConflict).toBe(false);
+    expect(measured).toHaveLength(1);
+    console.log('DETECT', JSON.stringify(measured[0]));
+    expectBounded(measured[0]);
+  });
+
+  it('prefetchLatestEntityOpsForBatch reads a bounded amount for an all-new batch (#9503)', async () => {
+    const measured: Measured[] = [];
+    const pairs = brandNewIds().map((entityId) => ({ entityType: 'TASK', entityId }));
+
+    const latest = await prefetchLatestEntityOpsForBatch(
+      USER_ID,
+      pairs,
+      makeExplainingTx(db, measured),
+    );
+
+    expect(latest.size).toBe(0);
+    expect(measured).toHaveLength(1);
+    console.log('PREFETCH', JSON.stringify(measured[0]));
+    expectBounded(measured[0]);
+  });
+
+  it('still finds the latest op per entity for a batch that DOES match', async () => {
+    const measured: Measured[] = [];
+    // seq % 8 === 0 puts the op on the TASK slice and seq % 10 === 0 makes it
+    // multi-entity, so multiples of 40 are both and carry a 'co-<seq>' array member.
+    const taskSeqs = [40, 80, 120, 160];
+    const ids = taskSeqs.map((seq) => `task-${seq}`);
+
+    const latest = await prefetchLatestEntityOpsForBatch(
+      USER_ID,
+      ids.map((entityId) => ({ entityType: 'TASK', entityId })),
+      makeExplainingTx(db, measured),
+    );
+
+    for (const seq of taskSeqs) {
+      expect(latest.get(getEntityConflictKey('TASK', `task-${seq}`))?.serverSeq).toBe(
+        seq,
+      );
+    }
+    // 'co-N' is only ever a NON-first member of a multi-entity op's array, so this
+    // pins that the array branch is really consulted, not just the scalar one.
+    const viaArray = await prefetchLatestEntityOpsForBatch(
+      USER_ID,
+      [{ entityType: 'TASK', entityId: 'co-40' }],
+      makeExplainingTx(db, measured),
+    );
+    expect(viaArray.get(getEntityConflictKey('TASK', 'co-40'))?.serverSeq).toBe(40);
+  });
+
+  it('CANARY: the shipped OR form still reproduces the mis-plan on this seed', async () => {
+    // If this stops discarding the slice, the seed no longer models the incident and
+    // the assertions above prove nothing — fix the seed, not this test.
+    const ids = brandNewIds();
+    const regressed = await explainGeneric(
+      db,
+      `SELECT DISTINCT ON (eid)
+         eid AS "entityId", o.client_id, o.action_type, o.vector_clock
+       FROM operations o
+       CROSS JOIN LATERAL unnest(
+         o.entity_ids || CASE WHEN o.entity_id IS NULL THEN '{}'::text[] ELSE ARRAY[o.entity_id] END
+       ) AS eid
+       WHERE o.user_id = $1 AND o.entity_type = $2
+         AND (o.entity_ids && $3::text[] OR o.entity_id = ANY($3::text[]))
+         AND eid = ANY($3::text[])
+       ORDER BY eid, o.server_seq DESC`,
+      [USER_ID, 'TASK', ids],
+    );
+
+    // The whole probed (user_id, 'TASK') slice, read and discarded.
+    expect(regressed.rowsFiltered).toBe(OWN_OPS / ENTITY_TYPES.length);
+    // ...and the structural cause: the OR makes the GIN unusable, so the plan rides
+    // only the btree and uses it as a filter rather than a seek.
+    expect(regressed.nodes).not.toContain(GIN_INDEX);
+    expect(regressed.nodes).toContain(BTREE_INDEX);
+  });
+});
+
+/**
+ * The array branch must ride the GIN even when the pending list is DIRTY.
+ *
+ * `fastupdate = off` is set by raw migration 20260720000000 and CANNOT be expressed in
+ * schema.prisma, so every `prisma db push` database — CI, the E2E stack, the documented
+ * manual setup — has it ON. Measured on this seed: a single 100-key `entity_ids && $arr`
+ * probe costs enough under a dirty pending list that the planner abandons the GIN for a
+ * SEQ SCAN of the whole table (40000 rows discarded) — at production's 6.97M rows that
+ * is far worse than the slice scan being fixed. Probing per id with a 1-key `@>` keeps
+ * the GIN chosen in BOTH states; it costs ~100 extra blocks when the reloption is right,
+ * and it is the same shape detectConflictForEntity already ships.
+ *
+ * So this is not a micro-optimisation: it is why the array branch is written as a
+ * per-id lateral rather than one `&&`. Do not "simplify" it back.
+ */
+describe('batch conflict array branch survives a dirty GIN pending list (PGlite)', () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await seed(db, 'on');
+  }, 180_000);
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it('does not fall back to a Seq Scan with fastupdate=on', async () => {
+    const measured: Measured[] = [];
+    await detectConflictForEntities(
+      USER_ID,
+      incomingOp(),
+      brandNewIds(),
+      makeExplainingTx(db, measured),
+    );
+
+    console.log('DIRTYGIN', JSON.stringify(measured[0]));
+    expect(measured[0].rowsFiltered).toBe(0);
+    expect(measured[0].nodes).not.toContain('Seq Scan');
+    expect(measured[0].nodes).toContain('operations_entity_ids_gin');
+  });
+});

--- a/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
@@ -42,10 +42,14 @@ import type { Operation } from '../src/sync/sync.types';
  *  - `fastupdate = off` is set explicitly, matching production (migration
  *    20260720000000, #9213), rather than left at the default as the sibling does. It
  *    decides which plan the array branch gets, so leaving it implicit would measure a
- *    state production is not in. The last describe pins the opposite state on purpose.
+ *    state production is not in. `prisma db push` databases get the default `on`, where
+ *    per-id probing re-reads the pending list once per id; that is an ops-config problem
+ *    with an ops-config fix (README.md's `ALTER INDEX`), not something this file pins.
  *  - The seed carries a WIDE-array population (see WIDE_WIDTH) as well as the width-2
- *    majority. The first fix for #9503 regressed only on wide arrays, and a width-2
- *    seed cannot express that: see the two "does not fan out" tests.
+ *    majority, with DISTINCT id sets per op. The first fix for #9503 regressed only on
+ *    wide arrays, and a width-2 seed cannot express that: see the two "does not fan out"
+ *    tests. Identical id sets cannot express it either — Memoize collapses the per-op
+ *    work, which is why wideIds() shifts each op's set.
  *  - Every user gets DISJOINT entity ids, so nothing here measures the array branch's
  *    cross-tenant cost, which is linear in rows across ALL tenants carrying a probed id.
  *    So "bounded" in this file means "bounded given disjoint ids". The shared-literal
@@ -59,12 +63,11 @@ import type { Operation } from '../src/sync/sync.types';
  * PG 16.14 plans the array-branch join as a HASH join where PGlite uses a nested loop,
  * so `Rows Removed by Join Filter` reads 0 there for a plan that is still 80x too
  * expensive. That is exactly why `rowsTouched` is the primary assertion — see
- * explain-plan.helper.ts. The two versions also disagree on plan SHAPE under a dirty
- * pending list (PG 16.14 stays on the GIN where PG18 seq-scans), which is why the last
- * describe asserts cost and not nodes. Blocks are unmodellable here in the other
- * direction too: PGlite reports every block as a cache hit, so these counts cannot stand
- * in for production's cold-cache I/O. The plan shape mostly transfers; the absolute
- * numbers below do not.
+ * explain-plan.helper.ts. The two versions also disagree on plan SHAPE under a dirty GIN
+ * pending list (PG 16.14 stays on the GIN where PG18 seq-scans), so never assert node
+ * names for that state. Blocks are unmodellable here in the other direction too: PGlite
+ * reports every block as a cache hit, so these counts cannot stand in for production's
+ * cold-cache I/O. The plan shape mostly transfers; the absolute numbers below do not.
  */
 
 const OWN_OPS = 20_000;
@@ -164,15 +167,36 @@ const brandNewIds = (): string[] =>
 const WIDE_OPS = 20;
 /**
  * Deliberately WIDER than PROBE_SIZE, so the two cost models separate numerically and a
- * fan-out cannot hide inside the fan-out-free ceiling: without fan-out the array branch
- * handles |probe| x WIDE_OPS candidate rows regardless of how wide the stored arrays
- * are; with it, every candidate is re-expanded by WIDE_WIDTH.
+ * fan-out cannot hide inside the fan-out-free ceiling: the array branch handles
+ * |probe| x WIDE_OPS candidate rows, while a fan-out re-expands every candidate by
+ * WIDE_WIDTH.
  */
 const WIDE_WIDTH = 300;
-const wideIds = (): string[] =>
-  Array.from({ length: WIDE_WIDTH }, (_, i) => `wide-task-${i}`);
-/** Probe a strict subset, as a client re-uploading part of a bulk selection would. */
-const wideProbeIds = (): string[] => wideIds().slice(0, PROBE_SIZE);
+/**
+ * Each wide op gets a DISTINCT id set (same width, shifted by `op`). Do not "simplify"
+ * this back to one shared literal: with byte-identical arrays Postgres MEMOIZES the
+ * array branch's per-candidate work and evaluates it ONCE for all WIDE_OPS, which hides
+ * exactly the per-op cost these tests exist to measure. Measured on this seed: identical
+ * arrays report 11_047 rows touched where distinct arrays report 19_306.
+ */
+const wideIds = (op: number): string[] =>
+  Array.from({ length: WIDE_WIDTH }, (_, i) => `wide-task-${i + op}`);
+/**
+ * Probe a strict subset that every wide op contains, as a client re-uploading part of a
+ * bulk selection would. Offset by WIDE_OPS so it lies inside all of their shifted sets.
+ */
+const wideProbeIds = (): string[] =>
+  Array.from({ length: PROBE_SIZE }, (_, i) => `wide-task-${i + WIDE_OPS}`);
+/**
+ * The SMALL-probe counterpart. `detectConflictForEntities` is entered at >= 2 entity ids,
+ * so this — not the 100-id batch — is the modal multi-entity op, and it is the shape the
+ * one-`&&`-per-batch form regresses on (75x on PG 16.14): that form's cost is
+ * |matching ops| x |stored width| and so is nearly indifferent to how few ids you ask
+ * for, while the shipped per-id `@>` pays only 2 index descents. Nothing else here
+ * covers it — the wide tests probe 100 ids and the all-new tests match nothing.
+ */
+const SMALL_PROBE_SIZE = 2;
+const smallWideProbeIds = (): string[] => wideProbeIds().slice(0, SMALL_PROBE_SIZE);
 
 const seed = async (db: PGlite, fastupdate: 'on' | 'off'): Promise<void> => {
   await db.exec(CREATE_TABLE);
@@ -213,12 +237,13 @@ const seed = async (db: PGlite, fastupdate: 'on' | 'off'): Promise<void> => {
   }
   await flush();
 
-  // The wide-array population (see wideIds): WIDE_OPS ops all carrying the SAME
-  // WIDE_WIDTH ids, as a repeated bulk action produces.
-  const wide = wideIds()
-    .map((id) => `"${id}"`)
-    .join(',');
+  // The wide-array population (see wideIds): WIDE_OPS ops each carrying WIDE_WIDTH ids,
+  // as a repeated bulk action produces. The id sets OVERLAP but are not identical, so
+  // Memoize cannot collapse the per-candidate work.
   for (let k = 1; k <= WIDE_OPS; k++) {
+    const wide = wideIds(k)
+      .map((id) => `"${id}"`)
+      .join(',');
     rows.push(
       `('op-wide-${k}', ${USER_ID}, 'seed-client', ${OWN_OPS + k}, '[Task] Update',` +
         ` 'TASK', 'wide-task-0', '{${wide}}', 1, '{"seed-client":${OWN_OPS + k}}')`,
@@ -248,17 +273,46 @@ const BTREE_INDEX = 'operations_user_id_entity_type_entity_id_server_seq_idx';
  * it is the fan-out's actual signature — "expanded every candidate and threw it away".
  * The index-name assertions pin the OTHER regression structurally: the OR mis-plan is
  * precisely the one that rides NEITHER index usefully, so requiring both here fails it
- * even if a future seed stops blowing the row ceiling. Those node assertions hold under
- * production's `fastupdate = off`; do NOT copy them into the dirty describe, where the
- * cheapest plan is a seq scan.
+ * even if a future seed stops blowing the row ceiling.
+ *
+ * The discarded-row counters are asserted TOO, not instead. `rowsTouched` counts rows
+ * EMITTED by each node, so a plan that seeks the btree on the (user_id, entity_type)
+ * prefix, filters the whole slice on a non-indexable predicate and emits nothing scores
+ * zero on it while doing exactly the work #9503 was about — and the array branch would
+ * still supply the GIN node the assertions below look for. Neither signal covers the
+ * other; the ceiling catches fan-out, the counters catch slice scans.
+ *
+ * `maxJoinFiltered` defaults to 0 because no branch has a join left to mis-plan. The one
+ * exception is prefetchLatestEntityOpsForBatch, whose array branch must confirm each
+ * by-id GIN match against the requested (entity_type, entity_id) PAIR — `cand` is keyed
+ * by id alone. Under `force_generic_plan` PGlite runs that semi-join as a nested loop, so
+ * it compares |cand| x |touched|. That residual is bounded by the BATCH SIZE and is
+ * independent of how wide the stored arrays are, which is exactly what distinguishes it
+ * from a fan-out; PG 16.14 plans it as a hash join and pays none of it.
  */
-const expectBounded = (measured: Measured, maxRowsTouched: number): void => {
+const expectBounded = (
+  measured: Measured,
+  maxRowsTouched: number,
+  maxJoinFiltered = 0,
+): void => {
   expect(measured.rowsTouched).toBeLessThanOrEqual(maxRowsTouched);
+  expect(measured.rowsFiltered).toBe(0);
+  expect(measured.rowsJoinFiltered).toBeLessThanOrEqual(maxJoinFiltered);
   expect(measured.tempBlocks).toBe(0);
   expect(measured.nodes).not.toContain('Seq Scan');
   expect(measured.nodes).toContain(GIN_INDEX);
   expect(measured.nodes).toContain(BTREE_INDEX);
 };
+
+/**
+ * |cand| x |touched| = (PROBE_SIZE x WIDE_OPS) x PROBE_SIZE — the structural bound on
+ * prefetch's pair re-check when it is planned as a nested loop. Measured 99_000, i.e.
+ * half of it, because a semi-join stops at the first match per candidate. Stated as the
+ * derivation rather than the measurement so it stays meaningful if the seed is resized;
+ * a fan-out re-expands each candidate by WIDE_WIDTH and lands in the millions, so the
+ * separation is orders of magnitude either way.
+ */
+const MAX_PAIR_RECHECK_JOIN_FILTERED = PROBE_SIZE * WIDE_OPS * PROBE_SIZE;
 
 /**
  * Row-touch ceilings. They are deliberately LOOSE — the point is to fail a fan-out by
@@ -360,7 +414,11 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 
     expect(latest.size).toBe(PROBE_SIZE);
     expect(measured).toHaveLength(1);
-    expectBounded(measured[0], MAX_ROWS_TOUCHED_WIDE_PAIRS);
+    expectBounded(
+      measured[0],
+      MAX_ROWS_TOUCHED_WIDE_PAIRS,
+      MAX_PAIR_RECHECK_JOIN_FILTERED,
+    );
   });
 
   it('still finds the latest op per entity for a batch that DOES match', async () => {
@@ -422,102 +480,61 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
 });
 
 /**
- * The array branch must stay CHEAP when the GIN pending list is DIRTY — and the shape
- * that achieves that is ONE `&&` probe, not one `@>` per requested id.
+ * A SMALL probe against a WIDE matching history — the shape nothing else here covers,
+ * and the one that decided `@>`-per-id over one-`&&`-per-batch.
  *
- * `fastupdate = off` is set by raw migration 20260720000000 and CANNOT be expressed in
- * schema.prisma, so every `prisma db push` database — CI, the E2E stack, the documented
- * manual setup in README.md — has it ON. Every GIN scan then reads the whole pending
- * list, so N per-id probes read it N times where one `&&` reads it once: the per-id
- * form's I/O is LINEAR IN THE BATCH SIZE. Measured, per statement:
+ * `detectConflictForEntities` is entered at >= 2 entity ids, so a 2-id probe is the MODAL
+ * multi-entity op, not an edge case; and wide stored arrays are what repeated bulk
+ * actions accumulate, because op rows are never deleted. The `&&` form's cost is
+ * |matching ops| x |stored width| — it must detoast and unnest every element of every
+ * matching op just to learn which ids matched — so it barely benefits from being asked
+ * for fewer ids. `@>` gets the matched id from the index and pays 2 descents.
  *
- *              PGlite, this seed        PG 16.14, 1.5M rows, 471 pending pages
- *   form       time / blocks            time / blocks
- *   `@>`x100   175 ms / 19,600           261 ms / 47,800
- *   `&&`        26 ms /    981           170 ms /  1,072
+ * Measured on PG 16.14, 1000 ops of width 1000, `fastupdate = off`:
  *
- * Both callers chunk at CONFLICT_DETECTION_ENTITY_BATCH_SIZE, so an op at the 1000-id
- * wire cap issues ten of these in one upload transaction: 2.5 s of `@>` against 1.6 s of
- * `&&` on PG 16.14. Multi-second statements inside the upload transaction are #9503's
- * own failure mode, so this describe is not a micro-optimisation guard — it is the one
- * that stops the fix re-creating the incident on every db-push deployment.
+ *   probe ids   `@>` per id (shipped)   one `&&` per batch
+ *   2            1.4 ms /    28 blk      106 ms / 3,359 blk
+ *   10           7.3 ms /   140          146 ms / 3,453
+ *   100         91.4 ms / 1,490          268 ms / 4,505
  *
- * ON THE PLAN SHAPE: under a dirty pending list PGlite/PG18 abandons the GIN for a SEQ
- * SCAN here. That is FINE and this file deliberately does NOT forbid it — the seq scan
- * is 6.8x faster and reads 20x fewer blocks than the GIN plan the per-id form gets. A
- * previous revision asserted `not.toContain('Seq Scan')` and so pinned the WORSE outcome
- * as if it were the requirement, which is how the per-id form got shipped. Assert cost,
- * never plan shape, in this state.
+ * The other tests in this file cannot see that: `wide` probes 100 ids (where the gap
+ * narrows to 1.3x) and `allnew` matches nothing (where `&&` wins 20x). A form was
+ * briefly shipped on the strength of the all-new number alone. This test is what makes
+ * that mistake fail instead of pass.
  */
-describe('batch conflict array branch survives a dirty GIN pending list (PGlite)', () => {
+describe('batch conflict array branch stays cheap for a SMALL probe (PGlite)', () => {
   let db: PGlite;
-  /** A FULL-batch probe and a tenth-size one, both against the dirty pending list. */
-  let dirty: Measured;
-  let dirtySmall: Measured;
-  /** The full-batch probe again, after VACUUM flushes the pending list. */
-  let flushed: Measured;
 
-  // Measured in beforeAll rather than per-test because the VACUUM below DESTROYS the
-  // state the other assertions need, and an ordering dependency between `it`s is exactly
-  // the kind of thing that silently stops holding.
   beforeAll(async () => {
     db = new PGlite();
     await db.waitReady;
-    await seed(db, 'on');
-
-    const probe = async (ids: string[]): Promise<Measured> => {
-      const runs: Measured[] = [];
-      await detectConflictForEntities(
-        USER_ID,
-        incomingOp(),
-        ids,
-        makeExplainingTx(db, runs),
-      );
-      expect(runs).toHaveLength(1);
-      return runs[0];
-    };
-
-    dirtySmall = await probe(brandNewIds().slice(0, PROBE_SIZE / 10));
-    dirty = await probe(brandNewIds());
-
-    // PGlite ships no pgstattuple, so `pending_pages` cannot be read directly. VACUUM
-    // flushes the pending list into the main GIN entry tree, so re-measuring the SAME
-    // probe afterwards prices the same query against a clean index — the difference IS
-    // the pending list.
-    await db.exec('VACUUM operations');
-    flushed = await probe(brandNewIds());
+    await seed(db, 'off');
   }, 180_000);
 
   afterAll(async () => {
     await db.close();
   });
 
-  /**
-   * CANARY. Without this the describe can pass while measuring a CLEAN index — which is
-   * what a reviewer suspected was already happening, on the grounds that a bulk load
-   * flushes past `gin_pending_list_limit`. It does not flush ALL of it: the tail stays
-   * pending (confirmed directly on PG 16.14 via pgstatginindex — 58 pages / 4,544 tuples
-   * after the same bulk load), and that tail is what the reloption exposes.
-   */
-  it('CANARY: the fastupdate=on seed really does leave a dirty pending list', () => {
-    expect(dirty.blocks).toBeGreaterThan(flushed.blocks * 2);
-  });
+  it('does not pay the stored array width when only two ids are asked for', async () => {
+    const measured: Measured[] = [];
+    const result = await detectConflictForEntities(
+      USER_ID,
+      incomingOp(),
+      smallWideProbeIds(),
+      makeExplainingTx(db, measured),
+    );
 
-  it('does not re-read the pending list once per probed id', () => {
-    // THE property, stated scale-free: one `&&` reads the pending list once however many
-    // ids are asked for, so a 10x bigger batch must NOT cost 10x the blocks. Measured
-    // 1065 blocks at 100 ids against 1010 at 10 — essentially flat. The per-id form is
-    // 19,600 at 100 ids and scales linearly, so it fails this by ~10x however the seed
-    // is resized. An absolute budget could not do this: it would have to be re-derived
-    // for every seed change, and the numbers above are PGlite's, not production's.
-    //
-    // Blocks, not time: this is an I/O regression, and PGlite reports every block as a
-    // cache hit, so wall time understates it exactly where production would feel it most.
-    expect(dirty.blocks).toBeLessThan(dirtySmall.blocks * 3);
-    // Deliberately NOT rowsFiltered === 0, which the other describe does assert: the
-    // seq-scan plan PG18 picks here reads and filters all 40,020 rows by construction,
-    // so that assertion would once again be pinning a plan shape rather than a cost.
-    // rowsTouched counts rows EMITTED, so it still fails any fan-out regression.
-    expect(dirty.rowsTouched).toBeLessThanOrEqual(MAX_ROWS_TOUCHED_ALL_NEW);
+    expect(result.hasConflict).toBe(true);
+    expect(measured).toHaveLength(1);
+    // Scale-free and planner-independent: asking for 2 ids instead of 100 must cost
+    // proportionally less. The per-id form is linear in the probe, so it lands far under
+    // this; a width-driven form is nearly flat in the probe and blows straight through
+    // it. Deliberately NOT an absolute budget — that would need re-deriving per seed.
+    expect(measured[0].rowsTouched).toBeLessThanOrEqual(
+      (MAX_ROWS_TOUCHED_WIDE * SMALL_PROBE_SIZE) / PROBE_SIZE,
+    );
+    expect(measured[0].rowsFiltered).toBe(0);
+    expect(measured[0].rowsJoinFiltered).toBe(0);
+    expect(measured[0].nodes).toContain(GIN_INDEX);
   });
 });

--- a/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/batch-conflict-plan.pglite.spec.ts
@@ -18,9 +18,9 @@ import type { Operation } from '../src/sync/sync.types';
  * `DISTINCT ON`. It is not that. The combined `(entity_ids && $arr OR entity_id = ANY($arr))`
  * spans the entity_ids GIN and the (user_id, entity_type, entity_id, server_seq) btree, and
  * the planner abandons both to slice-scan the btree: on the seed below, PG16.14 and PGlite
- * both discard the probed user's WHOLE (user_id, entity_type) slice — 2500 rows — for a
+ * both discard the probed user's WHOLE (user_id, entity_type) slice — 2520 rows — for a
  * 100-id probe that matches nothing. `prefetchLatestEntityOpsForBatch` carries no
- * `entity_type` predicate at all, so it discarded 20007: the user's ENTIRE history.
+ * `entity_type` predicate at all, so it discarded 20020: the user's ENTIRE history.
  * That is the same OR-across-two-indexes degeneracy as the 2026-07-20 outage, which
  * conflict.ts flagged as "not excluded" for these paths. `DISTINCT ON` is not what made
  * it expensive; the OR is.
@@ -35,7 +35,7 @@ import type { Operation } from '../src/sync/sync.types';
  *  - The sibling keeps `entity_ids` empty on EVERY row because array-element statistics
  *    disarm ITS regression. That does NOT apply here, and it was checked rather than
  *    assumed: the batch mis-plan reproduces identically at 0% and at 10% multi-entity
- *    rows (2500 filtered either way), because the OR never lets the planner consider the
+ *    rows (the same slice either way), because the OR never lets the planner consider the
  *    GIN in the first place. So this seed DOES populate a minority of rows — otherwise
  *    the array branch of the fix is never exercised at all.
  *  - `fastupdate = off` is set explicitly, matching production (migration
@@ -45,6 +45,13 @@ import type { Operation } from '../src/sync/sync.types';
  *  - The seed carries a WIDE-array population (see WIDE_WIDTH) as well as the width-2
  *    majority. The first fix for #9503 regressed only on wide arrays, and a width-2
  *    seed cannot express that: see the two "does not fan out" tests.
+ *  - Every user gets DISJOINT entity ids, so nothing here measures the array branch's
+ *    cross-tenant cost. That exclusion is deliberate and load-bearing: `expectBounded`
+ *    asserts `rowsFiltered === 0`, which a shared-id seed violates by construction (the
+ *    `cand` CTE matches by id across all users and `array_hits` filters afterwards). So
+ *    "bounded" in this file means "bounded given disjoint ids" — the shared-literal case
+ *    ('KANBAN_DEFAULT' &c.) is documented, with numbers, at arrayBranchCandidatesCte in
+ *    conflict.ts, and is not guarded anywhere. Do not read these tests as covering it.
  *
  * REMAINING FIDELITY LIMITS: PGlite is PG18 and reports every block as a cache hit, so
  * these counts cannot model production's cold-cache I/O. The plan SHAPE is what
@@ -111,7 +118,7 @@ type Measured = {
  * `Rows Removed by Filter` alone is NOT enough, and assuming it was let a 1000x
  * regression through review: this rewrite moved the id match from a `WHERE ... = ANY`
  * into a JOIN, and Postgres reports work discarded there as `Rows Removed by JOIN
- * Filter` — a different key. A fan-out that read and threw away 19.8M join rows scored
+ * Filter` — a different key. A fan-out that read and threw away 59.8M join rows scored
  * `rowsFiltered: 0` and passed `expectBounded` untouched. Count both, plus temp blocks,
  * which is what an over-wide intermediate spills to.
  */
@@ -291,31 +298,26 @@ const GIN_INDEX = 'operations_entity_ids_gin';
 const BTREE_INDEX = 'operations_user_id_entity_type_entity_id_server_seq_idx';
 
 /**
- * Measured on this seed with fastupdate=off, the production reloption: post-fix both
- * batch queries discard NOTHING and read 600 blocks, riding the GIN for the array
- * branch and the composite btree for the scalar one. The shipped OR form reads 806
- * while discarding 2500 (detect) / 20007 (prefetch).
+ * NO BLOCK BUDGET HERE, unlike the sibling spec — tried and rejected on evidence. On the
+ * all-new probe the fix reads 600 blocks against the OR form's 810 (detect) and 438
+ * (prefetch): the regression reads FEWER blocks than the fix in one of the two cases, so
+ * no threshold can separate them, and any budget wide enough not to flake would pass the
+ * very mis-plan this file exists to catch. (The sibling's budget works because its
+ * regression is 816 against a fixed 143.) `Measured.blocks` is therefore reported for
+ * debugging and deliberately never asserted.
  *
- * NO BLOCK BUDGET HERE, unlike the sibling spec — that was tried and rejected on
- * evidence. Fixed reads 600 blocks and the regression 806: a 34% gap, so no threshold
- * separates them, and any budget wide enough not to flake would pass the very mis-plan
- * this file exists to catch. (The sibling's budget works because its regression is 816
- * against a fixed 143.)
+ * Discarded-row counts carry the signal instead. They are the regressions' actual
+ * signatures — "read history and threw it away" for the OR form, "expanded every
+ * candidate and threw it away" for the fan-out — and unlike blocks they are scale-free.
+ * The index-name assertions pin the same property structurally: the OR mis-plan is
+ * precisely the one that rides NEITHER index usefully.
  *
- * `rowsFiltered` carries the signal instead. It is the regression's actual signature —
- * "read the user's history and threw it away" — and unlike blocks it is scale-free, so
- * it keeps its meaning if the seed changes. The index-name assertions pin the same
- * property structurally: the mis-plan is precisely the one that rides NEITHER index
- * usefully.
- */
-/**
- * `maxJoinFiltered` is 0 for every query that has no join left to mis-plan. The one
- * exception is prefetchLatestEntityOpsForBatch, whose array branch must still confirm a
- * by-id GIN match against the requested (entity_type, entity_id) PAIR. Under
- * `force_generic_plan` Postgres cannot see the parameter values and plans that semi-join
- * as a nested loop, so it compares |cand| x |touched|. That is bounded by the batch size
- * and the number of matching ops, and is INDEPENDENT of how wide the stored arrays are —
- * which is exactly what separates it from a fan-out. See WIDE_WIDTH.
+ * `maxJoinFiltered` is 0 for every query with no join left to mis-plan. The one exception
+ * is prefetchLatestEntityOpsForBatch, whose array branch must still confirm a by-id GIN
+ * match against the requested (entity_type, entity_id) PAIR. Under `force_generic_plan`
+ * Postgres cannot see the parameter values and plans that semi-join as a nested loop, so
+ * it compares |cand| x |touched| — bounded by the batch size and INDEPENDENT of how wide
+ * the stored arrays are, which is exactly what separates it from a fan-out.
  */
 const expectBounded = (measured: Measured, maxJoinFiltered = 0): void => {
   expect(measured.rowsFiltered).toBe(0);
@@ -326,8 +328,14 @@ const expectBounded = (measured: Measured, maxJoinFiltered = 0): void => {
   expect(measured.nodes).toContain(BTREE_INDEX);
 };
 
-/** The fan-out-free ceiling for the pair re-check: candidates x requested pairs. */
-const MAX_PAIR_RECHECK_COMPARISONS = PROBE_SIZE * WIDE_OPS * PROBE_SIZE;
+/**
+ * Ceiling for prefetch's pair re-check. Pinned just above the measured 99_000 (=|cand| x
+ * |touched|) rather than at the analytic worst case: the natural-looking
+ * PROBE_SIZE * WIDE_OPS * PROBE_SIZE = 200_000 would also admit the inner JOIN this
+ * replaced, which measures exactly 198_000 — a ceiling that passes the form you removed
+ * for cost is not a guard.
+ */
+const MAX_PAIR_RECHECK_COMPARISONS = 110_000;
 
 describe('batch conflict detection does not scan the history (PGlite)', () => {
   let db: PGlite;
@@ -360,10 +368,11 @@ describe('batch conflict detection does not scan the history (PGlite)', () => {
     // REGRESSION GUARD. The first fix for #9503 tagged nothing onto the array-branch
     // candidates and re-derived the matched id with `unnest(entity_ids) JOIN probe`.
     // Because `cand` already holds one copy of an op per matching probe id, that emitted
-    // |probe n entity_ids| squared rows per op: measured 8645ms / 19.8M join-filtered
-    // rows / 1611 temp blocks on exactly this seed, against 8ms and zero for the shipped
-    // form. It passed the all-new test above untouched, because a batch that matches
-    // NOTHING has no fan-out to multiply.
+    // |probe n entity_ids| squared rows per op: on this seed 59.8M join-filtered rows
+    // (= |cand| 2000 x WIDE_WIDTH x PROBE_SIZE, less the 200k that match) / 2211 temp
+    // blocks / ~23s, against zero and ~8ms for the shipped form. It passed the all-new
+    // test above untouched, because a batch that matches NOTHING has no fan-out to
+    // multiply — which is exactly why this seed needs a wide, MATCHING population.
     const measured: Measured[] = [];
     const result = await detectConflictForEntities(
       USER_ID,

--- a/packages/super-sync-server/tests/conflict-detection.spec.ts
+++ b/packages/super-sync-server/tests/conflict-detection.spec.ts
@@ -221,9 +221,17 @@ vi.mock('../src/db', async () => {
       if (!sql.includes('DISTINCT ON')) {
         throw new Error(`Unmocked raw query in tx: ${sql}`);
       }
-      const [userId, entityType, entityIdsSql] = params as [number, string, Prisma.Sql];
+      // Located by shape, not by position: userId is the only number, entityType the
+      // only bare string, and the id array the only Sql fragment. #9503 reordered
+      // these (and repeated userId/entityType), so a positional destructure is wrong.
+      const userId = params.find((p): p is number => typeof p === 'number') as number;
+      const entityType = params.find((p): p is string => typeof p === 'string') as string;
+      const entityIdsSql = params.find(
+        (p): p is Prisma.Sql =>
+          !!p && typeof p === 'object' && Array.isArray((p as Prisma.Sql).values),
+      );
       state.batchConflictQueryCount++;
-      if (!Array.isArray(entityIdsSql.values)) {
+      if (!entityIdsSql || !Array.isArray(entityIdsSql.values)) {
         throw new Error(
           'Expected batched conflict query entity IDs to be passed via Prisma.join(...)',
         );

--- a/packages/super-sync-server/tests/conflict-detection.spec.ts
+++ b/packages/super-sync-server/tests/conflict-detection.spec.ts
@@ -218,14 +218,28 @@ vi.mock('../src/db', async () => {
       // Anything left must be the batched multi-entity conflict lookup. Assert that
       // rather than assuming it: falling through and reinterpreting an unrelated
       // query as this one is how a mock silently answers a call it never modelled.
-      if (!sql.includes('DISTINCT ON')) {
+      // `DISTINCT ON` alone stopped discriminating once #9503 gave BOTH batch queries
+      // that clause, so key on detect's own CTE and exclude prefetch's — otherwise a
+      // future batchUpload test lands here, finds no bare string to read entityType
+      // from, matches no ops and silently reports "no conflict".
+      if (!sql.includes('scalar_hits') || sql.includes('touched(entity_type')) {
         throw new Error(`Unmocked raw query in tx: ${sql}`);
       }
-      // Located by shape, not by position: userId is the only number, entityType the
-      // only bare string, and the id array the only Sql fragment. #9503 reordered
-      // these (and repeated userId/entityType), so a positional destructure is wrong.
-      const userId = params.find((p): p is number => typeof p === 'number') as number;
-      const entityType = params.find((p): p is string => typeof p === 'string') as string;
+      // Located by shape, not by position: #9503 reordered the params (and repeated
+      // userId/entityType), so a positional destructure is wrong. Shape lookup is
+      // type-ambiguous, though, so assert the shape instead of trusting it — a future
+      // numeric param (a LIMIT, a schema version) would otherwise silently rebind
+      // userId and quietly disable the tenant scoping this mock exists to model.
+      const numberParams = params.filter((p): p is number => typeof p === 'number');
+      const stringParams = params.filter((p): p is string => typeof p === 'string');
+      if (new Set(numberParams).size !== 1 || new Set(stringParams).size !== 1) {
+        throw new Error(
+          `Batched conflict query params no longer identify userId/entityType by shape: ` +
+            `${numberParams.length} numbers, ${stringParams.length} strings`,
+        );
+      }
+      const userId = numberParams[0];
+      const entityType = stringParams[0];
       const entityIdsSql = params.find(
         (p): p is Prisma.Sql =>
           !!p && typeof p === 'object' && Array.isArray((p as Prisma.Sql).values),
@@ -242,7 +256,7 @@ vi.mock('../src/db', async () => {
         ),
       );
       // An op covers every entity in its entity_ids set UNION its scalar
-      // entity_id — mirrors the `entity_ids || ARRAY[entity_id]` unnest. The
+      // entity_id — mirrors the array branch UNION ALL the scalar branch. The
       // scalar is always folded in (not just for empty/pre-migration rows) so a
       // divergent scalar entity_id is never missed; the Set below dedupes the
       // common entity_id = entityIds[0] overlap. (#8334)

--- a/packages/super-sync-server/tests/conflict-detection.spec.ts
+++ b/packages/super-sync-server/tests/conflict-detection.spec.ts
@@ -240,9 +240,16 @@ vi.mock('../src/db', async () => {
       }
       const userId = numberParams[0];
       const entityType = stringParams[0];
+      // `values.length > 0` is load-bearing: the shared array-branch CTE is also a
+      // Prisma.Sql, with an EMPTY values array, so a bare Array.isArray check would
+      // match it if fragment order ever changed — and an empty id set matches no op,
+      // i.e. a silent "no conflict" for every entity.
       const entityIdsSql = params.find(
         (p): p is Prisma.Sql =>
-          !!p && typeof p === 'object' && Array.isArray((p as Prisma.Sql).values),
+          !!p &&
+          typeof p === 'object' &&
+          Array.isArray((p as Prisma.Sql).values) &&
+          (p as Prisma.Sql).values.length > 0,
       );
       state.batchConflictQueryCount++;
       if (!entityIdsSql || !Array.isArray(entityIdsSql.values)) {

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { PGlite } from '@electric-sql/pglite';
 import { detectConflictForEntity } from '../src/sync/conflict';
 import { isEntityArrayBranchQuery } from './sync.service.test-state';
+import { explainGeneric } from './explain-plan.helper';
 import type { Operation } from '../src/sync/sync.types';
 
 /**
@@ -18,17 +19,11 @@ import type { Operation } from '../src/sync/sync.types';
  * to the aggregate (MAX -> MIN), the fence (dropping MATERIALIZED) or the CTE shape
  * fail here instead of passing against a stale copy.
  *
- * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS. Prisma sends parameterized
- * prepared statements; under the default `auto` Postgres plans the first ~5 executions as
- * CUSTOM, then compares the generic cost against the average custom cost and MAY switch to
- * a generic plan — a cost comparison, not an automatic switch, so a statement can stay on
- * custom plans indefinitely. THIS one was observed going generic on production, and a
- * generic plan cannot see parameter values, so that is the mode this file covers.
- * Production also serves custom plans and this file does NOT cover them (a
- * custom-plan-only regression is possible; see the rejected `server_seq >` narrowing in
- * conflict.ts). `EXPLAIN` with literal constants is a third thing again, and is the trap:
- * this file once tested that way and the blind spot passed two designs that were
- * catastrophic in production. EVERYTHING here — including the shim — goes through
+ * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS — the reasoning lives with the
+ * harness, in explain-plan.helper.ts. THIS lookup is the one that was observed going
+ * generic on production. Production also serves custom plans and this file does NOT cover
+ * them (a custom-plan-only regression is possible; see the rejected `server_seq >`
+ * narrowing in conflict.ts). EVERYTHING here — including the shim — goes through
  * explainGeneric. If you add a shape, use explainGeneric.
  *
  * WHY THE SEED SHAPE IS WHAT IT IS — do not "simplify" it:
@@ -126,89 +121,21 @@ const INSERT_COLS =
 type PlanStats = {
   blocks: number;
   rowsFiltered: number;
+  rowsJoinFiltered: number;
   sql: string[];
   rawSql: string[];
   /** Plan node types + index names, per measured query, parallel to `sql`. */
   nodes: string[];
 };
-type PlanNode = Record<string, unknown>;
-type Measured = { blocks: number; rowsFiltered: number; nodes: string };
 
 const newStats = (): PlanStats => ({
   blocks: 0,
   rowsFiltered: 0,
+  rowsJoinFiltered: 0,
   sql: [],
   rawSql: [],
   nodes: [],
 });
-
-/**
- * Walks the plan tree for node names and filtered-row counts.
- *
- * Blocks are deliberately NOT summed here: `Shared Hit/Read Blocks` are CUMULATIVE,
- * so a parent already includes everything its children read. Summing every node
- * double-counts the same buffers once per level of nesting, inflating deep plans
- * (the CTE form nests one level deeper than the flat one) and biasing the budgets
- * against the new code. The ROOT node's value is the true total.
- */
-const accumulatePlan = (node: PlanNode, stats: PlanStats, nodes: string[]): void => {
-  stats.rowsFiltered += (node['Rows Removed by Filter'] as number) ?? 0;
-  nodes.push(
-    `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
-      `${node['Index Name'] ? ' on ' + node['Index Name'] : ''}`,
-  );
-  for (const child of (node.Plans as PlanNode[]) ?? []) {
-    accumulatePlan(child, stats, nodes);
-  }
-};
-
-const rootBlocks = (node: PlanNode): number =>
-  ((node['Shared Hit Blocks'] as number) ?? 0) +
-  ((node['Shared Read Blocks'] as number) ?? 0);
-
-const toSqlLiteral = (value: unknown): string => {
-  if (value === null || value === undefined) return 'NULL';
-  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
-  if (Array.isArray(value)) {
-    return `ARRAY[${value.map(toSqlLiteral).join(',')}]::text[]`;
-  }
-  return `'${String(value).replace(/'/g, "''")}'`;
-};
-
-/**
- * EXPLAIN through PREPARE/EXECUTE under `force_generic_plan` — the ONLY faithful way
- * to see what production gets. The params are rendered as literals for EXECUTE, but
- * the PLAN is built at PREPARE time with the values invisible, which is exactly the
- * situation Prisma puts Postgres in.
- */
-let preparedCounterId = 0;
-const explainGeneric = async (
-  db: PGlite,
-  sql: string,
-  params: readonly unknown[],
-): Promise<Measured> => {
-  const name = `plan_probe_${preparedCounterId++}`;
-  const args = params.map(toSqlLiteral).join(', ');
-  await db.exec(`SET plan_cache_mode = force_generic_plan`);
-  await db.exec(`PREPARE ${name} AS ${sql}`);
-  try {
-    const res = await db.query<Record<string, unknown>>(
-      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
-    );
-    const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
-    const stats = newStats();
-    const nodes: string[] = [];
-    accumulatePlan(plan, stats, nodes);
-    return {
-      blocks: rootBlocks(plan),
-      rowsFiltered: stats.rowsFiltered,
-      nodes: nodes.join(' -> '),
-    };
-  } finally {
-    await db.exec(`DEALLOCATE ${name}`);
-    await db.exec(`SET plan_cache_mode = auto`);
-  }
-};
 
 const incomingOp = (
   entityId: string,
@@ -295,6 +222,7 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
     const measured = await explainGeneric(db, sql, params);
     stats.blocks += measured.blocks;
     stats.rowsFiltered += measured.rowsFiltered;
+    stats.rowsJoinFiltered += measured.rowsJoinFiltered;
     stats.sql.push(sql);
     stats.nodes.push(measured.nodes);
     return (await db.query<Record<string, unknown>>(sql, params)).rows;
@@ -372,9 +300,13 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
 // the seed ever stops reproducing the mis-plan at all.
 const MAX_BLOCKS = 300;
 
-const expectWithinBudget = (measured: { blocks: number; rowsFiltered: number }): void => {
-  expect(measured.rowsFiltered).toBe(0);
-  expect(measured.blocks).toBeLessThan(MAX_BLOCKS);
+const expectWithinBudget = (stats: PlanStats): void => {
+  expect(stats.rowsFiltered).toBe(0);
+  // A regression that moves the discarded work into a JOIN is reported under a
+  // DIFFERENT key, and this spec scored 59.8M such rows as 0 until the walker was
+  // shared with the batch spec. Assert both counters, never just one.
+  expect(stats.rowsJoinFiltered).toBe(0);
+  expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
 };
 
 describe('detectConflictForEntity does not scan the history (PGlite)', () => {

--- a/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
+++ b/packages/super-sync-server/tests/conflict-entity-lookup-plan.pglite.spec.ts
@@ -120,8 +120,10 @@ const INSERT_COLS =
 
 type PlanStats = {
   blocks: number;
+  rowsTouched: number;
   rowsFiltered: number;
   rowsJoinFiltered: number;
+  tempBlocks: number;
   sql: string[];
   rawSql: string[];
   /** Plan node types + index names, per measured query, parallel to `sql`. */
@@ -130,8 +132,10 @@ type PlanStats = {
 
 const newStats = (): PlanStats => ({
   blocks: 0,
+  rowsTouched: 0,
   rowsFiltered: 0,
   rowsJoinFiltered: 0,
+  tempBlocks: 0,
   sql: [],
   rawSql: [],
   nodes: [],
@@ -221,8 +225,10 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
   ): Promise<Record<string, unknown>[]> => {
     const measured = await explainGeneric(db, sql, params);
     stats.blocks += measured.blocks;
+    stats.rowsTouched += measured.rowsTouched;
     stats.rowsFiltered += measured.rowsFiltered;
     stats.rowsJoinFiltered += measured.rowsJoinFiltered;
+    stats.tempBlocks += measured.tempBlocks;
     stats.sql.push(sql);
     stats.nodes.push(measured.nodes);
     return (await db.query<Record<string, unknown>>(sql, params)).rows;
@@ -300,12 +306,23 @@ const makeMeasuringTx = (db: PGlite, stats: PlanStats): unknown => {
 // the seed ever stops reproducing the mis-plan at all.
 const MAX_BLOCKS = 300;
 
+/**
+ * Both lookups touch only what actually matches: the scalar top-1 plus, for a deep
+ * entity, the winning row's re-fetch. Measured 3 on this seed; the ceiling is loose
+ * because it is a fan-out guard, not a pin.
+ */
+const MAX_ROWS_TOUCHED = 100;
+
 const expectWithinBudget = (stats: PlanStats): void => {
   expect(stats.rowsFiltered).toBe(0);
   // A regression that moves the discarded work into a JOIN is reported under a
-  // DIFFERENT key, and this spec scored 59.8M such rows as 0 until the walker was
-  // shared with the batch spec. Assert both counters, never just one.
+  // DIFFERENT key, and this spec scored such rows as 0 until the walker was shared with
+  // the batch spec. Assert both counters, never just one.
   expect(stats.rowsJoinFiltered).toBe(0);
+  // ...and neither counter sees a node that EMITS its rows rather than discarding them,
+  // which is what a fan-out does. The batch spec learned this the expensive way.
+  expect(stats.rowsTouched).toBeLessThanOrEqual(MAX_ROWS_TOUCHED);
+  expect(stats.tempBlocks).toBe(0);
   expect(stats.blocks).toBeLessThan(MAX_BLOCKS);
 };
 

--- a/packages/super-sync-server/tests/conflict.spec.ts
+++ b/packages/super-sync-server/tests/conflict.spec.ts
@@ -413,7 +413,17 @@ describe('conflict helpers', () => {
         $queryRaw: vi
           .fn()
           .mockImplementation(async (_strings: unknown, ...params: unknown[]) => {
-            const queriedEntityIds = (params[2] as Prisma.Sql).values;
+            // Located by shape, not by position: the id array is the only Sql
+            // fragment among the params. #9503 reordered them and a positional
+            // index broke silently.
+            const idArrayParam = params.find(
+              (param): param is Prisma.Sql =>
+                !!param &&
+                typeof param === 'object' &&
+                Array.isArray((param as Prisma.Sql).values),
+            );
+            if (!idArrayParam) throw new Error('no entity-id array param in query');
+            const queriedEntityIds = idArrayParam.values;
             queriedBatchSizes.push(queriedEntityIds.length);
             if (!queriedEntityIds.includes(boundaryEntityId)) return [];
 

--- a/packages/super-sync-server/tests/conflict.spec.ts
+++ b/packages/super-sync-server/tests/conflict.spec.ts
@@ -413,14 +413,17 @@ describe('conflict helpers', () => {
         $queryRaw: vi
           .fn()
           .mockImplementation(async (_strings: unknown, ...params: unknown[]) => {
-            // Located by shape, not by position: the id array is the only Sql
-            // fragment among the params. #9503 reordered them and a positional
-            // index broke silently.
+            // Located by shape, not by position: #9503 reordered the params and a
+            // positional index broke silently. `values.length > 0` is load-bearing —
+            // the shared array-branch CTE is ALSO a Prisma.Sql, with an EMPTY values
+            // array, so a bare Array.isArray check would match it if fragment order
+            // ever changed and would then report "no conflict" for every entity.
             const idArrayParam = params.find(
               (param): param is Prisma.Sql =>
                 !!param &&
                 typeof param === 'object' &&
-                Array.isArray((param as Prisma.Sql).values),
+                Array.isArray((param as Prisma.Sql).values) &&
+                (param as Prisma.Sql).values.length > 0,
             );
             if (!idArrayParam) throw new Error('no entity-id array param in query');
             const queriedEntityIds = idArrayParam.values;

--- a/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
+++ b/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { PGlite } from '@electric-sql/pglite';
 import { Prisma } from '@prisma/client';
 import {
+  detectConflict,
   detectConflictForEntities,
   getEntityConflictKey,
   prefetchLatestEntityOpsForBatch,
 } from '../src/sync/conflict';
+import { isEntityArrayBranchQuery } from './sync.service.test-state';
 import type { Operation, VectorClock } from '../src/sync/sync.types';
 
 const USER_ID = 1;
@@ -17,9 +19,9 @@ const TASK_TIME_DELTA_ACTION = '[TimeTracking] Sync time spent';
  * Real-Postgres regression for #8334's multi-entity conflict-detection SQL.
  *
  * The mock-based specs (issue-8334-detect-conflict.spec.ts, conflict-detection.spec.ts)
- * reproduce the Prisma filter semantics by hand and can NOT catch a bug in the raw
- * `unnest(CASE ...)` SQL that detectConflictForEntities / prefetchLatestEntityOpsForBatch
- * actually send to Postgres. This spec runs that SQL against an in-process Postgres
+ * reproduce the Prisma filter semantics by hand and can NOT catch a bug in the raw SQL
+ * that detectConflictForEntities / prefetchLatestEntityOpsForBatch actually send to
+ * Postgres. This spec runs that SQL against an in-process Postgres
  * (PGlite — no Docker, no DATABASE_URL) so it runs in the normal `npm test` CI job.
  *
  * A small transaction adapter renders the production Prisma tagged template through
@@ -136,7 +138,7 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
     await createSchema();
   });
 
-  describe('detectConflictForEntities (batch unnest SQL)', () => {
+  describe('detectConflictForEntities (batch scalar + array branch SQL)', () => {
     it('finds a stored multi-entity op via its NON-FIRST entity (the #8334 bug)', async () => {
       // op A touches task-1 + task-2; scalar entity_id is task-1.
       await insertOp({
@@ -281,6 +283,42 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
       expect(result).toEqual({ hasConflict: false });
     });
 
+    it('isolates by user and entity type in the ARRAY branch too', async () => {
+      // The test above stores its foreign rows with entity_ids = '{}', so they are only
+      // ever reachable via the scalar branch and the array branch's WHERE never has to
+      // reject anything. Since #9503 the array branch matches by entity id across ALL
+      // users inside a MATERIALIZED CTE and re-applies user_id / entity_type afterwards,
+      // so it needs its own isolation case: without it, dropping either predicate leaks
+      // another tenant's vector clock and every spec still passes.
+      await insertOp({
+        id: 'other-user-array',
+        serverSeq: 20,
+        clientId: 'Z',
+        userId: OTHER_USER_ID,
+        entityId: 'other-primary',
+        entityIds: ['other-primary', 'shared-id'],
+        vectorClock: { Z: 1 },
+      });
+      await insertOp({
+        id: 'same-user-project-array',
+        serverSeq: 21,
+        clientId: 'Y',
+        entityType: 'PROJECT',
+        entityId: 'project-primary',
+        entityIds: ['project-primary', 'shared-id'],
+        vectorClock: { Y: 1 },
+      });
+
+      const result = await detectConflictForEntities(
+        USER_ID,
+        incomingOp(),
+        ['shared-id', 'task-unmatched'],
+        transaction,
+      );
+
+      expect(result).toEqual({ hasConflict: false });
+    });
+
     it('uses the selected actionType when resolving concurrent timer deltas', async () => {
       await insertOp({
         id: 'timer-delta',
@@ -302,7 +340,39 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
     });
   });
 
-  describe('prefetchLatestEntityOpsForBatch (JOIN-over-pairs unnest SQL)', () => {
+  describe('prefetchLatestEntityOpsForBatch (pair-keyed batch SQL)', () => {
+    it('isolates by user and entity type in the ARRAY branch', async () => {
+      // Companion to the detect-side case above: both foreign rows carry the requested
+      // id inside entity_ids, so the array branch's `user_id` filter and its
+      // (entity_type, entity_id) pair re-check each have to reject one of them.
+      await insertOp({
+        id: 'other-user-array',
+        serverSeq: 20,
+        clientId: 'Z',
+        userId: OTHER_USER_ID,
+        entityId: 'other-primary',
+        entityIds: ['other-primary', 'shared-id'],
+        vectorClock: { Z: 1 },
+      });
+      await insertOp({
+        id: 'same-user-project-array',
+        serverSeq: 21,
+        clientId: 'Y',
+        entityType: 'PROJECT',
+        entityId: 'project-primary',
+        entityIds: ['project-primary', 'shared-id'],
+        vectorClock: { Y: 1 },
+      });
+
+      const latest = await prefetchLatestEntityOpsForBatch(
+        USER_ID,
+        [{ entityType: 'TASK', entityId: 'shared-id' }],
+        transaction,
+      );
+
+      expect(latest.size).toBe(0);
+    });
+
     it('returns the latest same-user op for each (type,id) pair', async () => {
       await insertOp({
         id: 'opA-old',
@@ -399,5 +469,50 @@ describe('#8334 multi-entity conflict SQL (PGlite)', () => {
         serverSeq: 1,
       });
     });
+  });
+
+  // Three tx mocks (sync.service.test-state, conflict-detection.spec, sync.service.spec)
+  // route raw queries by sniffing the tagged template's LITERALS. Nothing but a comment
+  // kept those three predicates mutually exclusive, and #9503 already broke one of them:
+  // `DISTINCT ON` stopped separating the two batch queries once both had it. A mock that
+  // answers a query it never modelled returns "no conflict", which is silent data loss
+  // dressed as a passing suite — so pin the partition itself.
+  it('each raw conflict template matches exactly one tx-mock discriminator', async () => {
+    const seen: string[] = [];
+    const capturingTx = {
+      $queryRaw: async (strings: TemplateStringsArray): Promise<unknown[]> => {
+        seen.push(strings.join(''));
+        return [];
+      },
+      operation: {
+        findFirst: async (): Promise<null> => null,
+        findUnique: async (): Promise<null> => null,
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    // The single-entity array branch, then both batch templates.
+    await detectConflict(
+      USER_ID,
+      { ...incomingOp(), entityId: 'solo' } as Operation,
+      capturingTx,
+    );
+    await detectConflictForEntities(USER_ID, incomingOp(), ['a', 'b'], capturingTx);
+    await prefetchLatestEntityOpsForBatch(
+      USER_ID,
+      [{ entityType: 'TASK', entityId: 'a' }],
+      capturingTx,
+    );
+
+    const discriminators = [
+      isEntityArrayBranchQuery,
+      (sql: string): boolean =>
+        sql.includes('scalar_hits') && !sql.includes('touched(entity_type'),
+      (sql: string): boolean => sql.includes('touched(entity_type'),
+    ];
+
+    expect(seen).toHaveLength(3);
+    for (const sql of seen) {
+      expect(discriminators.filter((matches) => matches(sql))).toHaveLength(1);
+    }
   });
 });

--- a/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
+++ b/packages/super-sync-server/tests/entity-ids-conflict.pglite.spec.ts
@@ -26,9 +26,10 @@ const TASK_TIME_DELTA_ACTION = '[TimeTracking] Sync time spent';
  * Prisma.sql, including nested Prisma.Sql / Prisma.join fragments, then executes its
  * PostgreSQL text and bound values in PGlite. There is no second copy of the query.
  *
- * Load-bearing detail: the unnest folds the scalar `entity_id` INTO the `entity_ids`
- * set with a UNION (`o.entity_ids || ...ARRAY[entity_id]`), NOT a mutually-exclusive
- * `CASE WHEN cardinality(entity_ids) > 0 THEN entity_ids ELSE ARRAY[entity_id]`. The
+ * Load-bearing detail: the queries cover the scalar `entity_id` AND the `entity_ids` set
+ * as a UNION — since #9503 that is a scalar branch `UNION ALL` an array branch, before
+ * it a single `o.entity_ids || ...ARRAY[entity_id]` unnest. Either way it must NOT be a
+ * mutually-exclusive `CASE WHEN cardinality(entity_ids) > 0 THEN ... ELSE ...`. The
  * old CASE form dropped the scalar whenever entity_ids was non-empty, so an op whose
  * scalar entity_id is NOT a member of its own entity_ids (the dedup-off-scalar case)
  * was invisible — a later concurrent op touching that scalar was wrongly accepted

--- a/packages/super-sync-server/tests/explain-plan.helper.ts
+++ b/packages/super-sync-server/tests/explain-plan.helper.ts
@@ -11,7 +11,7 @@ import type { PGlite } from '@electric-sql/pglite';
  * same class of bug. One implementation, one place to fix.
  */
 
-export type PlanNode = Record<string, unknown>;
+type PlanNode = Record<string, unknown>;
 
 export type Measured = {
   /** ROOT-node buffers only — see rootBlocks. */
@@ -72,10 +72,25 @@ const rootBlocks = (node: PlanNode): number =>
   ((node['Shared Hit Blocks'] as number) ?? 0) +
   ((node['Shared Read Blocks'] as number) ?? 0);
 
-export const toSqlLiteral = (value: unknown): string => {
+/**
+ * Renders an EXECUTE argument. TEST-ONLY, and deliberately not exported: it builds SQL
+ * literals by escaping, which is safe here only because every value comes from a spec's
+ * own fixture and `standard_conforming_strings` is on. Arrays are hard-coded to
+ * `::text[]` — the only array parameter these statements bind — and a non-scalar would
+ * otherwise render as `[object Object]`, silently EXPLAINing a DIFFERENT query than
+ * production sends, which is the exact fidelity trap this harness exists to prevent. So
+ * it throws instead.
+ */
+const toSqlLiteral = (value: unknown): string => {
   if (value === null || value === undefined) return 'NULL';
   if (typeof value === 'number' || typeof value === 'bigint') return String(value);
   if (Array.isArray(value)) return `ARRAY[${value.map(toSqlLiteral).join(',')}]::text[]`;
+  if (typeof value === 'object') {
+    throw new Error(
+      `explainGeneric cannot render a non-scalar parameter (${JSON.stringify(value)}); ` +
+        'add an explicit cast rather than letting it stringify.',
+    );
+  }
   return `'${String(value).replace(/'/g, "''")}'`;
 };
 

--- a/packages/super-sync-server/tests/explain-plan.helper.ts
+++ b/packages/super-sync-server/tests/explain-plan.helper.ts
@@ -1,0 +1,129 @@
+import type { PGlite } from '@electric-sql/pglite';
+
+/**
+ * Shared EXPLAIN harness for the two conflict-lookup plan specs.
+ *
+ * Extracted because it was copied, and the copy rotted: the batch spec's walker was
+ * fixed to multiply the discarded-row counters by `Actual Loops` and to read
+ * `Rows Removed by Join Filter`, while the single-entity spec's copy kept
+ * under-reporting by up to the loop count and scored a join fan-out as zero. Both specs
+ * exist to catch cost regressions on the upload path, so a blind spot in either is the
+ * same class of bug. One implementation, one place to fix.
+ */
+
+export type PlanNode = Record<string, unknown>;
+
+export type Measured = {
+  /** ROOT-node buffers only — see rootBlocks. */
+  blocks: number;
+  /** Actual Rows x Actual Loops, summed over the tree. The primary signal. */
+  rowsTouched: number;
+  rowsFiltered: number;
+  rowsJoinFiltered: number;
+  tempBlocks: number;
+  /** Node types + index names, joined with ' -> '. */
+  nodes: string;
+};
+
+type Accumulator = {
+  touched: number;
+  filtered: number;
+  joinFiltered: number;
+  nodes: string[];
+};
+
+/**
+ * `rowsTouched` — Actual Rows x Actual Loops summed over the tree — is the PRIMARY
+ * signal, and the only one here that is planner-independent.
+ *
+ * Two rounds of review were defeated by picking a counter instead. Round 1 asserted
+ * `Rows Removed by Filter`, and a fan-out moved the work into a JOIN, where Postgres
+ * reports `Rows Removed by Join Filter` — a different key, so 59.8M discarded rows
+ * scored 0. Round 2 added that key, and it too fails on PG 16.14 (production's version),
+ * where the same fan-out is planned as a HASH join and attributes nothing to a join
+ * filter: both counters read 0 while the query touches 2.2M rows against the shipped
+ * form's 12.5k. `tempBlocks` catches it only at low `work_mem` — the shipped
+ * docker-compose sets 4MB, but at 64MB an 80x regression passes clean.
+ *
+ * `Actual Loops` multiplication is not cosmetic: Postgres divides the discarded-row
+ * counters by loops (`explain.c:show_instrumentation_count`), so a filter inside a
+ * per-probe nested loop is reported at 1/100th of what it discarded.
+ */
+const walk = (node: PlanNode, acc: Accumulator): void => {
+  const loops = (node['Actual Loops'] as number) ?? 1;
+  acc.touched += ((node['Actual Rows'] as number) ?? 0) * loops;
+  acc.filtered += ((node['Rows Removed by Filter'] as number) ?? 0) * loops;
+  acc.joinFiltered += ((node['Rows Removed by Join Filter'] as number) ?? 0) * loops;
+  acc.nodes.push(
+    `${node['Node Type']}${node['Scan Direction'] ? ' ' + node['Scan Direction'] : ''}` +
+      `${node['Index Name'] ? ' on ' + node['Index Name'] : ''}`,
+  );
+  for (const child of (node.Plans as PlanNode[]) ?? []) walk(child, acc);
+};
+
+/**
+ * Buffers are deliberately taken from the ROOT node only: `Shared Hit/Read Blocks` are
+ * CUMULATIVE, so a parent already includes everything its children read. Summing every
+ * node double-counts the same buffers once per level of nesting, inflating deep plans
+ * (a CTE form nests one level deeper than a flat one) and biasing budgets against the
+ * new code.
+ */
+const rootBlocks = (node: PlanNode): number =>
+  ((node['Shared Hit Blocks'] as number) ?? 0) +
+  ((node['Shared Read Blocks'] as number) ?? 0);
+
+export const toSqlLiteral = (value: unknown): string => {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  if (Array.isArray(value)) return `ARRAY[${value.map(toSqlLiteral).join(',')}]::text[]`;
+  return `'${String(value).replace(/'/g, "''")}'`;
+};
+
+let preparedCounterId = 0;
+
+/**
+ * EXPLAIN through PREPARE/EXECUTE under `force_generic_plan` — the ONLY faithful way to
+ * see what production gets. The params are rendered as literals for EXECUTE, but the
+ * PLAN is built at PREPARE time with the values invisible, which is exactly the
+ * situation Prisma puts Postgres in.
+ *
+ * MEASURE WITH `force_generic_plan`, NEVER WITH LITERALS. Prisma sends parameterized
+ * prepared statements; under the default `auto` Postgres plans the first ~5 executions
+ * as CUSTOM, then compares the generic cost against the average custom cost and MAY
+ * switch — a cost comparison, not an automatic switch, so a statement can stay on custom
+ * plans indefinitely. The single-entity lookup was observed going generic on production,
+ * and a generic plan cannot see parameter values, so that is the mode these specs cover.
+ * Production also serves custom plans and they are NOT covered here. `EXPLAIN` with
+ * literal constants is a third thing again, and is the trap: the single-entity spec once
+ * tested that way and the blind spot passed two designs that were catastrophic in
+ * production. If you add a shape, route it through this function.
+ */
+export const explainGeneric = async (
+  db: PGlite,
+  sql: string,
+  params: readonly unknown[],
+): Promise<Measured> => {
+  const name = `plan_probe_${preparedCounterId++}`;
+  const args = params.map(toSqlLiteral).join(', ');
+  await db.exec(`SET plan_cache_mode = force_generic_plan`);
+  await db.exec(`PREPARE ${name} AS ${sql}`);
+  try {
+    const res = await db.query<Record<string, unknown>>(
+      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
+    );
+    const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;
+    const acc: Accumulator = { touched: 0, filtered: 0, joinFiltered: 0, nodes: [] };
+    walk(plan, acc);
+    return {
+      blocks: rootBlocks(plan),
+      rowsTouched: acc.touched,
+      rowsFiltered: acc.filtered,
+      rowsJoinFiltered: acc.joinFiltered,
+      tempBlocks: (plan['Temp Written Blocks'] as number) ?? 0,
+      nodes: acc.nodes.join(' -> '),
+    };
+  } finally {
+    await db.exec(`DEALLOCATE ${name}`);
+    await db.exec(`SET plan_cache_mode = auto`);
+  }
+};

--- a/packages/super-sync-server/tests/explain-plan.helper.ts
+++ b/packages/super-sync-server/tests/explain-plan.helper.ts
@@ -1,7 +1,5 @@
-import type { PGlite } from '@electric-sql/pglite';
-
 /**
- * Shared EXPLAIN harness for the two conflict-lookup plan specs.
+ * Shared EXPLAIN harness for the conflict-lookup plan specs.
  *
  * Extracted because it was copied, and the copy rotted: the batch spec's walker was
  * fixed to multiply the discarded-row counters by `Actual Loops` and to read
@@ -9,7 +7,17 @@ import type { PGlite } from '@electric-sql/pglite';
  * under-reporting by up to the loop count and scored a join fan-out as zero. Both specs
  * exist to catch cost regressions on the upload path, so a blind spot in either is the
  * same class of bug. One implementation, one place to fix.
+ *
+ * The runner is structural rather than `PGlite` so the same walker also drives a REAL
+ * PostgreSQL connection (batch-conflict-plan.integration.spec.ts). PGlite is PG18 and
+ * production is PG 16.x; the two planners disagree about this exact query — see that
+ * spec's header — so the numbers have to be reproducible on both without a second
+ * implementation to keep in sync.
  */
+export type ExplainRunner = {
+  exec: (sql: string) => Promise<unknown>;
+  query: (sql: string) => Promise<{ rows: Array<Record<string, unknown>> }>;
+};
 
 type PlanNode = Record<string, unknown>;
 
@@ -114,7 +122,7 @@ let preparedCounterId = 0;
  * production. If you add a shape, route it through this function.
  */
 export const explainGeneric = async (
-  db: PGlite,
+  db: ExplainRunner,
   sql: string,
   params: readonly unknown[],
 ): Promise<Measured> => {
@@ -123,7 +131,7 @@ export const explainGeneric = async (
   await db.exec(`SET plan_cache_mode = force_generic_plan`);
   await db.exec(`PREPARE ${name} AS ${sql}`);
   try {
-    const res = await db.query<Record<string, unknown>>(
+    const res = await db.query(
       `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE ${name}${args ? `(${args})` : ''}`,
     );
     const plan = (res.rows[0]['QUERY PLAN'] as PlanNode[])[0].Plan as PlanNode;

--- a/packages/super-sync-server/tests/integration/batch-conflict-plan.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/batch-conflict-plan.integration.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Plan guard for the batch conflict lookups on a REAL PostgreSQL — production's major
+ * version, not PGlite's.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM batch-conflict-plan.pglite.spec.ts. That spec is the
+ * primary guard and covers far more shapes (fan-out, wide arrays, dirty pending list),
+ * but it runs on PGlite, which is PG18. Production is PG 16.x, and the two planners
+ * genuinely disagree about THIS query: the same array-branch join is a nested loop on
+ * PGlite and a hash join on PG 16.14, which is why `rowsTouched` rather than
+ * `Rows Removed by Join Filter` is the primary signal over there. So "the plan is fine"
+ * was, until this file, only ever asserted on a version nobody runs. CI already provides
+ * a `postgres:16-alpine` service for the integration suite; this spends it on the one
+ * assertion PGlite cannot make.
+ *
+ * WHAT #9503 ACTUALLY WAS. `(entity_ids && $arr OR entity_id = ANY($arr))` spans the
+ * entity_ids GIN and the (user_id, entity_type, entity_id, server_seq) btree. The planner
+ * abandons both and slice-scans the btree, discarding the probed user's whole
+ * (user_id, entity_type) slice for a batch that matches nothing. On production that ran
+ * twice per upload inside the transaction and was cancelled by `statement_timeout` every
+ * 5-12 minutes.
+ *
+ * THE SEED IS THE WHOLE TEST — do not shrink it. The degeneracy is a STATISTICS trap, not
+ * a row-count one, and it only appears when `n_distinct(user_id)` is large: under
+ * `force_generic_plan` the planner cannot see the bound user id, so it estimates
+ * `user_id = $n` at ntuples/n_distinct. With ~20k distinct users that estimate is ~2 rows
+ * while the real slice is OWN_OPS/8 = 2500, and the btree looks irresistible. Seeded with
+ * two or three users instead, the estimate is ACCURATE, PG 16.14 correctly picks a
+ * BitmapOr over both indexes, the old form runs in half a millisecond and this file
+ * proves nothing. That was measured, not reasoned: three smaller seeds all failed to
+ * reproduce before the user population was raised. Hence the CANARY test below — if the
+ * old form ever stops mis-planning here, the seed has stopped reproducing #9503 and the
+ * other assertions are vacuous, which is a FAILURE, not a pass.
+ *
+ * Prerequisites, as for the other *.integration.spec.ts files: a real PostgreSQL with the
+ * schema applied (`prisma db push`) and DATABASE_URL set; skipped entirely when unset.
+ *
+ *   DATABASE_URL=postgresql://... npx vitest run --config vitest.integration.config.ts \
+ *     tests/integration/batch-conflict-plan.integration.spec.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient, Prisma } from '@prisma/client';
+import {
+  detectConflictForEntities,
+  prefetchLatestEntityOpsForBatch,
+} from '../../src/sync/conflict';
+import {
+  explainGeneric,
+  type ExplainRunner,
+  type Measured,
+} from '../explain-plan.helper';
+import type { Operation } from '../../src/sync/sync.types';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+
+/** Reserved high range so this never collides with other specs' fixtures. */
+const USER_ID_BASE = 990_000;
+const OWN_USER_ID = USER_ID_BASE;
+const OTHER_USERS = 20_000;
+const OWN_OPS = 20_000;
+/** One full batch: CONFLICT_DETECTION_ENTITY_BATCH_SIZE, so exactly one statement runs. */
+const PROBE_SIZE = 100;
+/** Spread so the btree slice is OWN_OPS/8 — big enough to be obvious when scanned. */
+const ENTITY_TYPES = [
+  'TASK',
+  'PROJECT',
+  'TAG',
+  'NOTE',
+  'BOARD',
+  'GLOBAL_CONFIG',
+  'SIMPLE_COUNTER',
+  'TASK_REPEAT_CFG',
+];
+
+const GIN_INDEX = 'operations_entity_ids_gin';
+const BTREE_INDEX = 'operations_user_id_entity_type_entity_id_server_seq_idx';
+
+/** The pathological input from #9503: a full batch of entities that match nothing. */
+const brandNewIds = (): string[] =>
+  Array.from({ length: PROBE_SIZE }, (_, i) => `plan-brand-new-${i}`);
+
+const incomingOp = (): Operation =>
+  ({
+    id: 'op-incoming',
+    clientId: 'uploader',
+    actionType: '[Task] Update',
+    opType: 'UPD',
+    entityType: 'TASK',
+    vectorClock: { uploader: 1 },
+    timestamp: 1,
+    schemaVersion: 1,
+  }) as unknown as Operation;
+
+/**
+ * PREPARE/EXECUTE is SESSION state, and Prisma's pool hands out connections per query, so
+ * the EXPLAIN would land on a different backend than the PREPARE. Every probe therefore
+ * runs inside one interactive transaction, which pins a single connection.
+ */
+const runnerFor = (tx: Prisma.TransactionClient): ExplainRunner => ({
+  exec: (sql) => tx.$executeRawUnsafe(sql),
+  query: async (sql) => ({
+    rows: (await tx.$queryRawUnsafe(sql)) as Array<Record<string, unknown>>,
+  }),
+});
+
+/** Renders the PRODUCTION tagged template through the real `Prisma.sql`, EXPLAINs it, */
+/** then executes it so the caller still gets its rows. Mirrors the PGlite sibling. */
+const makeExplainingTx = (
+  tx: Prisma.TransactionClient,
+  measured: Measured[],
+): Prisma.TransactionClient => {
+  const runner = runnerFor(tx);
+  const adapter = {
+    $queryRaw: async <T>(
+      strings: TemplateStringsArray,
+      ...values: Array<Prisma.Sql | Prisma.Sql['values'][number]>
+    ): Promise<T> => {
+      const query = Prisma.sql(strings, ...values);
+      measured.push(await explainGeneric(runner, query.text, query.values));
+      return (await tx.$queryRawUnsafe(query.text, ...query.values)) as T;
+    },
+    operation: {
+      findFirst: async (): Promise<null> => {
+        throw new Error('unexpected legacy-misc findFirst in a plan probe');
+      },
+    },
+  };
+  return adapter as unknown as Prisma.TransactionClient;
+};
+
+describeWithDb('Batch conflict lookup plans (real PostgreSQL)', () => {
+  let prisma: PrismaClient;
+
+  const cleanup = async (): Promise<void> => {
+    // operations cascade from users (Operation.user has onDelete: Cascade).
+    await prisma.$executeRawUnsafe(`DELETE FROM users WHERE id >= ${USER_ID_BASE}`);
+  };
+
+  beforeAll(async () => {
+    prisma = new PrismaClient({ datasources: { db: { url: DATABASE_URL } } });
+    await prisma.$connect();
+    await cleanup();
+
+    // Production runs with fastupdate off (migration 20260720000000), but `prisma db push`
+    // — what CI and the documented manual setup use — never applies that raw migration, so
+    // the index would otherwise be left on the default `on`. Set it BEFORE the rows exist,
+    // as production did, so nothing lands in a pending list and the plan is the one
+    // production gets rather than a pending-list artefact.
+    await prisma.$executeRawUnsafe(`ALTER INDEX "${GIN_INDEX}" SET (fastupdate = off)`);
+
+    await prisma.$executeRawUnsafe(`
+      INSERT INTO users (id, email)
+      SELECT ${USER_ID_BASE} + g, 'plan-guard-' || g || '@test.local'
+      FROM generate_series(0, ${OTHER_USERS}) g
+    `);
+
+    const typeExpr = `(ARRAY[${ENTITY_TYPES.map((t) => `'${t}'`).join(',')}])[1 + (g % ${ENTITY_TYPES.length})]`;
+    const cols = `id, user_id, client_id, server_seq, action_type, op_type, entity_type,
+                  entity_id, entity_ids, payload, vector_clock, schema_version,
+                  client_timestamp, received_at`;
+
+    // The probed user's own history: one big per-user slice.
+    await prisma.$executeRawUnsafe(`
+      INSERT INTO operations (${cols})
+      SELECT 'plan-own-' || g, ${OWN_USER_ID}, 'seed-client', g, '[Task] Update', 'UPD',
+             ${typeExpr}, 'task-' || g,
+             CASE WHEN g % 10 = 0 THEN ARRAY['task-' || g, 'co-' || g] ELSE '{}'::text[] END,
+             '{}'::jsonb, ('{"seed-client":' || g || '}')::jsonb, 1, 0, 0
+      FROM generate_series(1, ${OWN_OPS}) g
+    `);
+
+    // A comparable population under ~20k DIFFERENT users. This is the load-bearing part:
+    // it is what makes n_distinct(user_id) large and the generic-plan estimate wrong.
+    await prisma.$executeRawUnsafe(`
+      INSERT INTO operations (${cols})
+      SELECT 'plan-other-' || g, ${USER_ID_BASE} + g, 'seed-other', g, '[Task] Update', 'UPD',
+             ${typeExpr}, 'otask-' || g,
+             CASE WHEN g % 10 = 0 THEN ARRAY['otask-' || g, 'oco-' || g] ELSE '{}'::text[] END,
+             '{}'::jsonb, ('{"seed-other":' || g || '}')::jsonb, 1, 0, 0
+      FROM generate_series(1, ${OTHER_USERS}) g
+    `);
+
+    // Statistics are the point of this fixture, so they must be real.
+    await prisma.$executeRawUnsafe('ANALYZE operations');
+  }, 300_000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await cleanup();
+    // Leave the index as `prisma db push` created it, so this file cannot change how any
+    // other spec plans.
+    await prisma.$executeRawUnsafe(`ALTER INDEX "${GIN_INDEX}" RESET (fastupdate)`);
+    await prisma.$disconnect();
+  }, 120_000);
+
+  /**
+   * A plan that rides NEITHER index usefully is exactly the #9503 mis-plan, so requiring
+   * both — plus zero rows discarded by a filter — fails it structurally, without pinning a
+   * number a planner change can move.
+   */
+  const expectNoSliceScan = (measured: Measured): void => {
+    expect(measured.rowsFiltered).toBe(0);
+    expect(measured.nodes).not.toContain('Seq Scan');
+    expect(measured.nodes).toContain(GIN_INDEX);
+    expect(measured.nodes).toContain(BTREE_INDEX);
+  };
+
+  it('CANARY: the pre-#9503 OR form still mis-plans on this seed', async () => {
+    // Without this, a planner or seed change could silently make every assertion below
+    // vacuous — they would pass on a query that was never expensive here in the first
+    // place. This is the shape conflict.ts USED to send.
+    const ids = brandNewIds();
+    const measured = await prisma.$transaction(async (tx) =>
+      explainGeneric(
+        runnerFor(tx),
+        `SELECT DISTINCT ON (eid) eid, o.client_id, o.action_type, o.vector_clock
+         FROM operations o
+         CROSS JOIN LATERAL unnest(
+           o.entity_ids || CASE WHEN o.entity_id IS NULL THEN '{}'::text[]
+                                ELSE ARRAY[o.entity_id] END) AS eid
+         WHERE o.user_id = $2 AND o.entity_type = $3
+           AND (o.entity_ids && $1 OR o.entity_id = ANY($1)) AND eid = ANY($1)
+         ORDER BY eid, o.server_seq DESC`,
+        [ids, OWN_USER_ID, 'TASK'],
+      ),
+    );
+
+    // The whole (user_id, entity_type) slice, read and thrown away for a probe that
+    // matches nothing. OWN_OPS/8 = 2500; asserted loosely so autovacuum timing cannot
+    // flake it.
+    expect(measured.rowsFiltered).toBeGreaterThan(1_000);
+  }, 120_000);
+
+  it('detectConflictForEntities does not scan the slice on an all-new batch', async () => {
+    const measured: Measured[] = [];
+    const result = await prisma.$transaction(async (tx) =>
+      detectConflictForEntities(
+        OWN_USER_ID,
+        incomingOp(),
+        brandNewIds(),
+        makeExplainingTx(tx, measured),
+      ),
+    );
+
+    expect(result.hasConflict).toBe(false);
+    expect(measured).toHaveLength(1);
+    expectNoSliceScan(measured[0]);
+  }, 120_000);
+
+  it('prefetchLatestEntityOpsForBatch does not scan the slice on an all-new batch', async () => {
+    const measured: Measured[] = [];
+    const pairs = brandNewIds().map((entityId) => ({ entityType: 'TASK', entityId }));
+    const latest = await prisma.$transaction(async (tx) =>
+      prefetchLatestEntityOpsForBatch(OWN_USER_ID, pairs, makeExplainingTx(tx, measured)),
+    );
+
+    expect(latest.size).toBe(0);
+    expect(measured).toHaveLength(1);
+    expectNoSliceScan(measured[0]);
+  }, 120_000);
+});

--- a/packages/super-sync-server/tests/integration/conflict-detection-sql.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/conflict-detection-sql.integration.spec.ts
@@ -4,9 +4,11 @@
  * Runs the ACTUAL `detectConflict` / `prefetchLatestEntityOpsForBatch` functions
  * (not a copy of the SQL, not a mock) against a REAL PostgreSQL database. Unit
  * tests mock `$queryRaw` and can only verify the JS transformation around the
- * query — this verifies the literal SQL: the `entity_ids || ARRAY[entity_id]`
- * unnest, the `&&` / `= ANY` prefilter, the `DISTINCT ON` latest-per-entity pick,
- * and the empty-array → scalar fallback for pre-migration rows.
+ * query — this verifies the literal SQL: the scalar branch `UNION ALL` the array
+ * branch (#9503 replaced the single `entity_ids || ARRAY[entity_id]` unnest and its
+ * `&&` / `= ANY` prefilter with these two separately-indexed branches), the
+ * `DISTINCT ON` latest-per-entity pick, and the empty-array → scalar fallback for
+ * pre-migration rows.
  *
  * The decisive #8334 case is "divergent scalar": a stored op whose scalar `entity_id`
  * is NOT a member of its own `entity_ids`. The previous mutually-exclusive

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -450,18 +450,24 @@ vi.mock('../src/db', async () => {
         return [{ lastSeq }];
       }
       if (sql.includes('touched(entity_type, entity_id)')) {
-        // Params are [touchedRows (the VALUES CTE), userId, userId]: userId is the
-        // only number; the touched rows are the only Sql fragment, whose .values hold
-        // the flattened (entity_type, entity_id) pairs. Matched on the CTE name rather
-        // than on `JOIN (VALUES` because #9503 lifted the VALUES list into a CTE and
-        // dropped the separate idArray params. Deliberately position-independent —
+        // Params are [touchedRows (the VALUES CTE), userId, arrayBranchCte, userId]:
+        // userId is the only number, and touchedRows is the only Sql fragment with a
+        // NON-EMPTY .values (the shared array-branch CTE binds nothing), whose values
+        // hold the flattened (entity_type, entity_id) pairs. Matched on the CTE name
+        // rather than on `JOIN (VALUES` because #9503 lifted the VALUES list into a CTE
+        // and dropped the separate idArray params. Deliberately position-independent —
         // three mocks broke on positional params during that change.
+        //
+        // This mock matches stored ops by scalar entityId only and ignores entityIds,
+        // so it does not model the array branch: a future batchUpload test whose prior
+        // op is multi-entity would get a false "no conflict" here.
         const txUserId = params.find((p: unknown) => typeof p === 'number') as number;
         const valuesParam = params.find(
           (p: unknown) =>
             !!p &&
             typeof p === 'object' &&
-            Array.isArray((p as { values?: unknown[] }).values),
+            Array.isArray((p as { values?: unknown[] }).values) &&
+            (p as { values: unknown[] }).values.length > 0,
         ) as { values: unknown[] } | undefined;
         const touchedParams = valuesParam?.values ?? [];
         const touchedPairs = new Set<string>();

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -449,12 +449,13 @@ vi.mock('../src/db', async () => {
         state.serverSeqCounter = Math.max(state.serverSeqCounter, lastSeq);
         return [{ lastSeq }];
       }
-      if (sql.includes('JOIN (VALUES')) {
-        // Params are [touchedRows (VALUES join), userId, idArray, idArray]: userId
-        // is the only number; the VALUES join is the first Sql fragment, whose
-        // .values hold the flattened (entity_type, entity_id) touched pairs. The
-        // idArray prefilter params (#8334) are not needed by the mock. (Previously
-        // userId was the last param and the join the only fragment.)
+      if (sql.includes('touched(entity_type, entity_id)')) {
+        // Params are [touchedRows (the VALUES CTE), userId, userId]: userId is the
+        // only number; the touched rows are the only Sql fragment, whose .values hold
+        // the flattened (entity_type, entity_id) pairs. Matched on the CTE name rather
+        // than on `JOIN (VALUES` because #9503 lifted the VALUES list into a CTE and
+        // dropped the separate idArray params. Deliberately position-independent —
+        // three mocks broke on positional params during that change.
         const txUserId = params.find((p: unknown) => typeof p === 'number') as number;
         const valuesParam = params.find(
           (p: unknown) =>

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -33,10 +33,15 @@ export function resetTestState(): void {
  * entity_ids GIN index — so every tx mock must answer it via $queryRaw rather than
  * the typed model API.
  *
- * `AS "maxSeq"` is the load-bearing half of the discriminator. `entity_ids @>` alone
- * is NOT enough any more: since #9503 split them the same way, both batch queries
- * probe the GIN with `@>` too. Only this one aggregates to a maxSeq, so keep both
- * conditions — dropping the alias check would silently route a batch query here.
+ * `AS "maxSeq"` is the load-bearing half of the discriminator: only this query
+ * aggregates to a maxSeq. Keep `entity_ids @>` as well, but do not rely on it —
+ * this inspects the template LITERALS, and both batch queries moved their `@>` into
+ * an interpolated `Prisma.sql` fragment, so it is a bound VALUE there and invisible
+ * here. Which is the general hazard worth remembering: every tx mock discriminates on
+ * template literals, so extracting SQL into a `Prisma.sql` fragment silently removes
+ * that text from all of their views. The dangerous direction is prefetch losing
+ * `touched(entity_type` from its literals while `scalar_hits` survives — it would then
+ * be answered by detect's branch. (Losing `scalar_hits` throws, which is loud.)
  */
 export function isEntityArrayBranchQuery(strings: unknown): boolean {
   const sql = Array.isArray(strings) ? strings.join('') : String(strings);

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -31,9 +31,12 @@ export function resetTestState(): void {
 /**
  * detectConflictForEntity's array branch is raw SQL — a MATERIALIZED CTE over the
  * entity_ids GIN index — so every tx mock must answer it via $queryRaw rather than
- * the typed model API. `AS "maxSeq"` is the discriminator: the only other raw query
- * against `operations` (prefetchLatestEntityOpsForBatch) is a DISTINCT ON with no
- * such alias, so the two never collide.
+ * the typed model API.
+ *
+ * `AS "maxSeq"` is the load-bearing half of the discriminator. `entity_ids @>` alone
+ * is NOT enough any more: since #9503 split them the same way, both batch queries
+ * probe the GIN with `@>` too. Only this one aggregates to a maxSeq, so keep both
+ * conditions — dropping the alias check would silently route a batch query here.
  */
 export function isEntityArrayBranchQuery(strings: unknown): boolean {
   const sql = Array.isArray(strings) ? strings.join('') : String(strings);

--- a/packages/super-sync-server/vitest.config.ts
+++ b/packages/super-sync-server/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'tests/integration/clean-slate-atomicity-sql.integration.spec.ts',
       'tests/integration/snapshot-vector-clock-sql.integration.spec.ts',
       'tests/integration/conflict-detection-sql.integration.spec.ts',
+      'tests/integration/batch-conflict-plan.integration.spec.ts',
       'tests/integration/repair-causality.integration.spec.ts',
       'tests/integration/health-alert-db-probe.integration.spec.ts',
       'tests/integration/migrate-deploy-db-timeout.integration.spec.ts',


### PR DESCRIPTION
## Problem

Fixes #9503. `detectConflictForEntities` was cancelled by `statement_timeout` (SQLSTATE 57014) every 5–12 minutes on the production SuperSync instance, **inside the upload transaction**.

The cause is not what the issue hypothesised (an unbounded `DISTINCT ON`). Both batch conflict queries ran a combined predicate:

```sql
(entity_ids && $arr OR entity_id = ANY($arr))
```

That `OR` spans two different indexes — the `entity_ids` GIN and the `(user_id, entity_type, entity_id, server_seq)` btree — so the planner abandons both and slice-scans the btree. Measured on PG 16.14 and PGlite: a 100-id probe matching **nothing** reads and discards the probing user's entire `(user_id, entity_type)` slice. `prefetchLatestEntityOpsForBatch` carries no `entity_type` predicate at all, so it discarded the user's *entire* history (20,020 rows against detect's 2,520 on the test seed).

Same OR-across-two-indexes degeneracy as the 2026-07-20 outage, which `conflict.ts` had already flagged as "not excluded" for these paths.

## Solution

Split each batch query into **two separately-indexed branches** — a scalar branch (lateral top-1 per requested id, rides the composite btree) `UNION ALL` an array branch (per-id `@>` probes, rides the GIN), deduped by `DISTINCT ON`. The array branch is shared between both callers, because #8334 established that hand-copying them is how they drift.

Measured on `postgres:16-alpine` **16.14** (production's version), 1.5M rows, `force_generic_plan`, 100-id all-new probe, median of 9:

| account | before (OR) | after |
| --- | --- | --- |
| 100k-op (the incident account) | 37.9 ms / 3,659 blk | 13.5 ms / 700 blk |
| 70-op (typical) | 0.05 ms / 3 blk | 13.6 ms / 700 blk |

Note the second row honestly: small accounts pay ~13 ms and ~700 blocks they did not pay before, on every batch upload, twice per upload. That is accepted because the term it replaces is unbounded in account history — production's incident account had a far larger slice than any test seed — while this one cannot exceed `|probe|` index descents.

### This branch reverts its own fifth commit — please read before re-litigating

Commit `56dda0e` switched the array branch to a single `entity_ids && $arr` probe, on measurements showing it 20× faster. A multi-agent review found that conclusion was drawn from a seed covering only one cost regime, and `0f487fd` reverts it. The full picture, same methodology:

| shape | `@>` per id (shipped) | one `&&` per batch |
| --- | --- | --- |
| 100 all-new ids @ 1.5M rows | 13.5 ms / 700 blk | **0.68 ms / 601** |
| 2-id probe, 1000 ops of width 1000 | **1.4 ms / 28** | 106 ms / 3,359 |
| 10-id probe, same | **7.3 ms / 140** | 146 ms / 3,453 |
| 100-id probe, same | **91.4 ms / 1,490** | 268 ms / 4,505 |
| 100 ids over 10,000 width-2 ops | **17.3 ms** / 10,600 | 202 ms / 675 |

`@>` takes the matched id from the index. `&&` must detoast and unnest every element of every matching op just to learn which ids matched, so its cost is `matches × width` and it barely benefits from being asked for fewer ids. A 2-id probe is the **modal** multi-entity op (this path is entered at ≥ 2 ids), and wide stored arrays are what repeated bulk actions accumulate, since op rows are never deleted.

Neither form dominates. `@>` is shipped because of **which term is bounded**: probe size is chunked at `CONFLICT_DETECTION_ENTITY_BATCH_SIZE` and descent grows only with index size, whereas `matches × width` is bounded by nothing a tenant controls — the CTE is not user-scoped (#9510) and `entity_ids` is billed at zero bytes by `computeOpStorageBytes`.

**If you want to revisit this, the bar is the whole table, not one row of it.** A third form (`&&` plus a hashed `IN` semi-join) fixes the width-2 regime but not the wide one; it is documented in `conflict.ts` as the promising direction.

## Testing

- Full `packages/super-sync-server` suite green — 54 files / 1143 tests. `npm run checkFile` clean on every changed `.ts`.
- **Equivalence is a committed spec**, not a quoted number: `tests/array-branch-equivalence.pglite.spec.ts` differential-tests all three array-branch forms over randomised ops and probes plus the edge shapes operators actually disagree on — duplicate and NULL array elements, NULL scalars, divergent scalars (the #8334 silent-data-loss class), cross-tenant and cross-type id collisions. It carries mutants that **must** diverge, so the file fails if it ever loses detection power.
- **Plan guards mutation-tested** against the shipped query: switching to `&&` → fails (6,313 rows touched vs a 600 ceiling); dropping `MATERIALIZED` → 5 failures; reintroducing the fan-out → 3 failures; dropping the outer `user_id` filter → fails.
- Tenant isolation verified with a mutation control that leaks a foreign tenant's clock when either outer predicate is neutralised, so the isolation tests are load-bearing rather than decorative.

Two test-harness defects were fixed along the way, both of which had been hiding real cost:

1. The wide seed gave all 20 ops one **identical** array, so Postgres memoized the per-candidate work and evaluated it once — 11,047 vs 19,306 rows touched with distinct sets.
2. `conflict-entity-lookup-plan.pglite.spec.ts` had its own copy of the plan walker which summed per-loop averages as totals and ignored `Rows Removed by Join Filter`, so a join fan-out scored zero. The harness is now shared (`tests/explain-plan.helper.ts`) with the fix in one place.

## Risks

Every change here is on the conflict-detection path, where a subtle bug silently loses user data across devices rather than erroring. Specifically checked:

- **Semantic equivalence** — the array branch is unchanged in output from what shipped before #9503; the union-not-`CASE` shape that #8334 established is preserved, including ops whose scalar `entity_id` is not a member of their own `entity_ids`.
- **Tenant isolation** — the CTE matches across all tenants by design (the `MATERIALIZED` fence forbids pushing `user_id` in without restoring the slice scan); the callers' outer `WHERE` is the boundary, and it is now covered by tests that fail when it is removed.
- **Not covered here:** custom-plan behaviour. All measurement is under `force_generic_plan`, which is the mode production was observed in, and the specs say so.

**Known and tracked, not introduced by this PR but made more visible by it:** the array branch is correct but not cost-bounded per user (#9510). Review measured 74 ms and 800 spilled temp blocks at 80k co-tenants sharing an id, and found the driving input is unmetered — `computeOpStorageBytes` charges `entity_ids` zero bytes. #9510 now carries those numbers and a cheap first half (bill `entity_ids` bytes) that needs no SQL change.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have included relevant changes to the documentation ([`docs/sync-and-op-log/vector-clocks.md`](docs/sync-and-op-log/vector-clocks.md))
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
