### PR TITLE
fix(supersync-chart): mount tmp into the migrate-db init container

### DIFF
--- a/packages/super-sync-server/helm/supersync/templates/deployment.yaml
+++ b/packages/super-sync-server/helm/supersync/templates/deployment.yaml
@@ -70,6 +70,12 @@ spec:
               value: {{ .Values.externalDatabase.url | quote }}
               {{- end }}
             {{- end }}
+          volumeMounts:
+            # scripts/migrate-deploy.sh calls mktemp, and securityContext defaults to
+            # readOnlyRootFilesystem: true — without a writable /tmp the init container exits
+            # with "mktemp: Read-only file system" before any migration runs.
+            - name: tmp
+              mountPath: /tmp
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
         - name: copy-public

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -454,6 +454,42 @@ describe('performance migrations', () => {
     expect(composeFile).toContain('- db');
   });
 
+  it('mounts a writable /tmp into the migrate-db initContainer so migrate-deploy.sh runs under readOnlyRootFilesystem', () => {
+    const helmDeployment = readFileSync(
+      join(currentDir, '../helm/supersync/templates/deployment.yaml'),
+      'utf8',
+    );
+    const helmValues = readFileSync(
+      join(currentDir, '../helm/supersync/values.yaml'),
+      'utf8',
+    );
+
+    const migrateDbStart = helmDeployment.indexOf('- name: migrate-db');
+    expect(migrateDbStart).toBeGreaterThan(-1);
+    // The migrate-db initContainer block ends at the next list item at the
+    // same indent (the following initContainer).
+    const nextContainer = helmDeployment.indexOf(
+      '\n        - name: ',
+      migrateDbStart + 1,
+    );
+    expect(nextContainer).toBeGreaterThan(migrateDbStart);
+    const migrateDbBlock = helmDeployment.slice(migrateDbStart, nextContainer);
+
+    // migrate-deploy.sh writes a temp log via `mktemp` under /tmp and runs
+    // with `set -eu`, so a read-only /tmp aborts the install before any
+    // migration runs. /tmp must therefore be backed by a writable volume
+    // mounted into THIS initContainer.
+    expect(migrateDbBlock).toContain('sh scripts/migrate-deploy.sh');
+    expect(migrateDbBlock).toContain('volumeMounts:');
+    expect(migrateDbBlock).toMatch(/- name: tmp\s+mountPath: \/tmp/);
+    // ...and the mounted volume must actually be declared as a writable
+    // emptyDir at the pod level.
+    expect(helmDeployment).toMatch(/- name: tmp\s+emptyDir:/);
+    // The mount is required precisely because the shared securityContext
+    // applied to this initContainer sets a read-only root filesystem.
+    expect(helmValues).toContain('readOnlyRootFilesystem: true');
+  });
+
   it('backfills operation payload bytes with per-user batched updates', () => {
     const script = readFileSync(
       join(currentDir, '../scripts/migrate-payload-bytes.ts'),


### PR DESCRIPTION
Fixes #9523.

A default `helm install` of the SuperSync chart never becomes ready. The `migrate-db` init container exits immediately with:

```
mktemp: : Read-only file system
```

and crash-loops, so no migration runs and the deployment stays at `Init:Error`.

The cause is a missing mount rather than a missing volume. The pod already declares a `tmp` emptyDir, and the app container mounts it at `/tmp` — but `migrate-db` declares no `volumeMounts` at all, while `securityContext` defaults to `readOnlyRootFilesystem: true`. `scripts/migrate-deploy.sh` calls `mktemp`, which then has nowhere to write.

This mounts the volume that already exists. One hunk, no new values, no behaviour change for anyone who had already worked around it by relaxing `readOnlyRootFilesystem`.

Reproduced on k3s v1.36.1 with `postgresql.enabled=false` and an external CloudNativePG database; the same failure occurs with the bundled Postgres, since the init container is identical in both paths.

Verified with `helm template` that the rendered init container now carries the mount, and on the cluster that the migration proceeds and the release goes ready.

Heads-up given as the issue template asks — happy to adjust the shape if you would rather see `TMPDIR` pointed at an existing writable path instead.