### PR TITLE
fix: correct Japanese Eisenhower board labels #9532

### DIFF
--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -122,12 +122,12 @@
         "EISENHAUER_MATRIX": "アイゼンハウアーマトリックス",
         "IN_PROGRESS": "進行中で",
         "KANBAN": "カンバン",
-        "NOT_URGENT_IMPORTANT": "緊急性がなく、重要ではありません",
-        "NOT_URGENT_NOT_IMPORTANT": "緊急ではない、重要ではない",
+        "NOT_URGENT_IMPORTANT": "緊急ではないが重要",
+        "NOT_URGENT_NOT_IMPORTANT": "緊急でも重要でもない",
         "TO_DO": "やるべきこと",
         "URGENT": "緊急",
         "URGENT_IMPORTANT": "緊急かつ重要",
-        "URGENT_NOT_IMPORTANT": "緊急 & 重要ではない"
+        "URGENT_NOT_IMPORTANT": "緊急だが重要ではない"
       },
       "FORM": {
         "ADD_NEW_PANEL": "新しいパネルを追加",


### PR DESCRIPTION
## Problem

The Japanese translation of the default Eisenhower Matrix board panel labels is incorrect: the Q2 panel ("Not urgent but important") is translated as "not urgent and **not** important", which duplicates the meaning of the Q4 panel. Issue  #9532.

As a result, two of the four quadrants read as the same category in Japanese, and the most important quadrant of the framework — the one for important, non-urgent work — is effectively missing from the UI.

Current state (see screenshot):

| Position | Intended meaning | Current `ja` string | Back-translation |
|---|---|---|---|
| Top-left (Q1) | Urgent & Important | 緊急かつ重要 | Urgent and important ✅ |
| Top-right (Q2) | Not Urgent & Important | 緊急性がなく、重要ではありません | Not urgent and **not important** ❌ |
| Bottom-left (Q3) | Urgent & Not Important | 緊急 & 重要ではない | Ambiguous — can be parsed as either "urgent & not important" or "not (urgent & important)" ⚠️ |
| Bottom-right (Q4) | Not Urgent & Not Important | 緊急ではない、重要ではない | Not urgent, not important ✅ |

<!-- Attach your screenshot here -->

## Solution

Corrected the affected strings in `src/assets/i18n/ja.json`:

| Position | Before | After | Back-translation |
|---|---|---|---|
| Q2 | 緊急性がなく、重要ではありません | 緊急ではないが重要 | Not urgent but important |
| Q3 | 緊急 & 重要ではない | 緊急だが重要ではない | Urgent but not important |
| Q4 | 緊急ではない、重要ではない | 緊急でも重要でもない | Neither urgent nor important |

- Q2 is the actual bug fix.
- Q3 is a clarity fix: the original relies on `&` plus a trailing negation, which is grammatically ambiguous in Japanese. Using the contrastive particle `が` ("but") makes the scope of the negation explicit and mirrors the Q2 wording.
- Q4 is a minor consistency fix so all four labels follow the same pattern.

Only values were changed; no keys were added, removed, or renamed. No other locale files were touched.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no documented behaviour changes
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files — n/a, only `.json` changed
- [ ] I have added tests for my changes (if applicable) — n/a, translation-only change
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
<img width="1115" height="798" alt="2026-08-10_11-19-41" src="https://github.com/user-attachments/assets/593442cb-d424-4318-8b3d-d680571fd038" />
