### PR TITLE
fix(ios): request local network permission for LAN sync servers

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -49,6 +49,8 @@
 	<true/>
 	<key>NSUserNotificationsUsageDescription</key>
 	<string>Super Productivity uses notifications to remind you about tasks and scheduled events.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Super Productivity uses your local network to sync with sync servers you host yourself, such as a WebDAV or Super Sync server on your network.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>


### PR DESCRIPTION
## Problem

The iOS app never asks for local network permission, so syncing with a sync server on the local network fails with no actionable error.

In the app the failure surfaces only as:

> SuperSync native request failed: Error

The iOS app logs show the request failing in the native networking layer, without usable detail:

```json
{
  "timestamp": "2026-08-10T21:52:27.594Z",
  "level": "WARN",
  "context": "ol",
  "message": "SuperSyncProvider transient network error, retrying in 3000ms (attempt 2/2)",
  "args": [
    {
      "url": "<URL_OF_SELF-HOSTED_SUPERSYNC>",
      "attempt": 2,
      "maxRetries": 2,
      "delayMs": 3000,
      "errorName": "Error",
      "errorCode": "NSURLErrorDomain"
    }
  ]
}
```

`NSURLErrorDomain` places the failure in native `URLSession` rather than in the web view, and no local network prompt was ever shown for the app.

iOS 14+ only presents that prompt if the app declares `NSLocalNetworkUsageDescription` in `Info.plist`. That key was missing, so the system never asked, and requests to a self-hosted WebDAV/Nextcloud or SuperSync server on the LAN failed the way shown above.

Both native HTTP paths are affected: `WebDavHttpPlugin` for WebDAV, and `CapacitorHttp` (`enabled: true` in `capacitor.config.ts`), which routes `fetch`/`XHR` through native `URLSession`. Because that traffic originates in the app process, it is subject to local network privacy — so the missing key is what suppressed the prompt.

Found while testing on a device; there is no existing issue for it.

## Solution

Add `NSLocalNetworkUsageDescription` to `ios/App/App/Info.plist`, next to the existing `NSUserNotificationsUsageDescription` and worded in the same style.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no wiki page documents the iOS permission prompts
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files — n/a, no `.ts`/`.scss` files changed
- [ ] I have added tests for my changes (if applicable) — n/a, `Info.plist` is not unit-testable
- [x] Existing tests still pass — unchanged by this PR: no `.ts`/`.scss`/test input is touched, so lint and the unit suite cannot be affected. Left to CI to confirm.
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- Not verified locally: the prompt itself. Confirming that requires an iOS build on a device/simulator.