### PR TITLE
feat(api): expose focus mode state

### DIFF
--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -355,29 +355,40 @@ curl -X POST http://127.0.0.1:3876/task-control/stop
 does not expose task content and does not add controls for starting, pausing,
 resuming, skipping, or cancelling a focus session.
 
+```bash
+curl --noproxy 127.0.0.1 -H "@$HOME/.sp-api-header" http://127.0.0.1:3876/focus
+```
+
 **Response data:**
 
 ```typescript
 {
   mode: 'Flowtime' | 'Pomodoro' | 'Countdown';
-  cycle: number; // non-negative
+  cycle: number;
+  isSessionDone: boolean;
   timer: null | {
     purpose: 'work' | 'break';
-    isRunning: boolean;
-    isPaused: boolean;
-    elapsedMs: number; // normalized non-negative
-    remainingMs: number; // normalized non-negative
-    durationMs: number; // normalized non-negative
+    status: 'running' | 'paused' | 'done';
+    isOvertime: boolean;
     isLongBreak: boolean;
+    elapsedMs: number;
+    remainingMs: number;
+    durationMs: number;
   };
 }
 ```
 
-`timer` is `null` when no work or break session exists. A paused work session or
-break still has a timer object with `isRunning: false` and `isPaused: true`.
-`elapsedMs`, `durationMs`, and `remainingMs` are normalized to non-negative values.
-`remainingMs` is derived from the same timer sample as `durationMs` and `elapsedMs`,
-so it is zero for Flowtime and after a countdown has reached its duration.
+`timer` is `null` when no work or break timer exists. A completed work session is
+represented by `timer: null` and `isSessionDone: true`; a completed break retains its
+break timer with `status: 'done'`. Other active timer states are `running` or `paused`.
+`isOvertime` is independent from `status`, so it remains true when an overtime work
+session is paused. Flowtime timers have no countdown duration, so their `remainingMs`
+is zero while their status remains `running` or `paused`.
+
+`cycle` is Pomodoro-only and 1-based. It advances when a Pomodoro work session
+completes, so it is already advanced during that session's following break. Flowtime
+and Countdown keep it at `1`. Focus Mode state is not persisted, so the cycle resets to
+`1` when the app restarts and when the user explicitly resets the Pomodoro cycle count.
 
 ---
 

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -385,10 +385,11 @@ break timer with `status: 'done'`. Other active timer states are `running` or `p
 session is paused. Flowtime timers have no countdown duration, so their `remainingMs`
 is zero while their status remains `running` or `paused`.
 
-`cycle` is Pomodoro-only and 1-based. It advances when a Pomodoro work session
-completes, so it is already advanced during that session's following break. Flowtime
-and Countdown keep it at `1`. Focus Mode state is not persisted, so the cycle resets to
-`1` when the app restarts and when the user explicitly resets the Pomodoro cycle count.
+`cycle` is the 1-based counter used by Pomodoro. Only completing a Pomodoro work
+session advances it, so it is already advanced during that session's following break.
+Switching to Flowtime or Countdown retains the current value, but those modes do not
+advance it. Focus Mode state is not persisted, so the cycle resets to `1` when the app
+restarts and when the user explicitly resets the Pomodoro cycle count.
 
 ---
 

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -356,7 +356,7 @@ does not expose task content and does not add controls for starting, pausing,
 resuming, skipping, or cancelling a focus session.
 
 ```bash
-curl --noproxy 127.0.0.1 -H "@$HOME/.sp-api-header" http://127.0.0.1:3876/focus
+curl http://127.0.0.1:3876/focus
 ```
 
 **Response data:**
@@ -381,6 +381,8 @@ curl --noproxy 127.0.0.1 -H "@$HOME/.sp-api-header" http://127.0.0.1:3876/focus
 `timer` is `null` when no work or break timer exists. A completed work session is
 represented by `timer: null` and `isSessionDone: true`; a completed break retains its
 break timer with `status: 'done'`. Other active timer states are `running` or `paused`.
+`isSessionDone` mirrors the current Focus Mode screen, so it can remain true after the
+overlay is dismissed until another focus action changes the screen.
 `isOvertime` is independent from `status`, so it remains true when an overtime work
 session is paused. Flowtime timers have no countdown duration, so their `remainingMs`
 is zero while their status remains `running` or `paused`.

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -365,9 +365,9 @@ resuming, skipping, or cancelling a focus session.
     purpose: 'work' | 'break';
     isRunning: boolean;
     isPaused: boolean;
-    elapsedMs: number;
-    remainingMs: number; // clamped to zero
-    durationMs: number;
+    elapsedMs: number; // normalized non-negative
+    remainingMs: number; // normalized non-negative
+    durationMs: number; // normalized non-negative
     isLongBreak: boolean;
   };
 }
@@ -375,7 +375,9 @@ resuming, skipping, or cancelling a focus session.
 
 `timer` is `null` when no work or break session exists. A paused work session or
 break still has a timer object with `isRunning: false` and `isPaused: true`.
-`remainingMs` is zero for Flowtime and after a countdown has reached its duration.
+`elapsedMs`, `durationMs`, and `remainingMs` are normalized to non-negative values.
+`remainingMs` is derived from the same timer sample as `durationMs` and `elapsedMs`,
+so it is zero for Flowtime and after a countdown has reached its duration.
 
 ---
 

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -345,6 +345,40 @@ curl -X POST http://127.0.0.1:3876/task-control/stop
 
 ---
 
+### Focus State Endpoint
+
+| Method | Path     | Description                                               |
+| ------ | -------- | --------------------------------------------------------- |
+| GET    | `/focus` | Get the current read-only Focus Mode timer state and mode |
+
+`GET /focus` reports the authoritative Focus Mode state used by the desktop app. It
+does not expose task content and does not add controls for starting, pausing,
+resuming, skipping, or cancelling a focus session.
+
+**Response data:**
+
+```typescript
+{
+  mode: 'Flowtime' | 'Pomodoro' | 'Countdown';
+  cycle: number; // non-negative
+  timer: null | {
+    purpose: 'work' | 'break';
+    isRunning: boolean;
+    isPaused: boolean;
+    elapsedMs: number;
+    remainingMs: number; // clamped to zero
+    durationMs: number;
+    isLongBreak: boolean;
+  };
+}
+```
+
+`timer` is `null` when no work or break session exists. A paused work session or
+break still has a timer object with `isRunning: false` and `isPaused: true`.
+`remainingMs` is zero for Flowtime and after a countdown has reached its duration.
+
+---
+
 ### Project Endpoints
 
 | Method | Path        | Description   |

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -14,8 +14,13 @@ import {
   LocalRestApiRequestPayload,
   LocalRestApiResponsePayload,
 } from '../../../../electron/shared-with-frontend/local-rest-api.model';
-import { FocusModeMode, TimerState } from '../../features/focus-mode/focus-mode.model';
-import * as focusSelectors from '../../features/focus-mode/store/focus-mode.selectors';
+import {
+  FocusModeMode,
+  FocusModeState,
+  FocusScreen,
+  TimerState,
+} from '../../features/focus-mode/focus-mode.model';
+import { initialState as initialFocusModeState } from '../../features/focus-mode/store/focus-mode.reducer';
 
 describe('LocalRestApiHandlerService', () => {
   let service: LocalRestApiHandlerService;
@@ -54,19 +59,19 @@ describe('LocalRestApiHandlerService', () => {
     subTasks,
   });
 
-  const setFocusState = ({
-    timer,
-    mode = FocusModeMode.Countdown,
-    cycle = 0,
-  }: {
-    timer: TimerState;
-    mode?: FocusModeMode;
-    cycle?: number;
-  }): void => {
-    store.overrideSelector(focusSelectors.selectTimer, timer);
-    store.overrideSelector(focusSelectors.selectMode, mode);
-    store.overrideSelector(focusSelectors.selectCurrentCycle, cycle);
-    store.refreshState();
+  const setFocusState = (
+    overrides: Partial<Omit<FocusModeState, 'timer'>> & {
+      timer?: Partial<TimerState>;
+    } = {},
+  ): void => {
+    const { timer: timerOverrides, ...stateOverrides } = overrides;
+    store.setState({
+      focusMode: {
+        ...initialFocusModeState,
+        ...stateOverrides,
+        timer: { ...initialFocusModeState.timer, ...timerOverrides },
+      },
+    });
   };
 
   const mockElectronApi = (): void => {
@@ -192,7 +197,7 @@ describe('LocalRestApiHandlerService', () => {
         { provide: ProjectService, useValue: projectServiceMock },
         { provide: TagService, useValue: tagServiceMock },
         { provide: DateService, useValue: dateServiceMock },
-        provideMockStore(),
+        provideMockStore({ initialState: { focusMode: initialFocusModeState } }),
       ],
     });
 
@@ -257,20 +262,12 @@ describe('LocalRestApiHandlerService', () => {
     };
 
     it('should return a null timer while focus mode is idle', async () => {
-      setFocusState({
-        timer: {
-          isRunning: false,
-          startedAt: null,
-          elapsed: 0,
-          duration: 0,
-          purpose: null,
-        },
-        mode: FocusModeMode.Countdown,
-      });
+      setFocusState({ mode: FocusModeMode.Countdown });
 
       expectFocusData(await requestFocus(), {
         mode: FocusModeMode.Countdown,
-        cycle: 0,
+        cycle: 1,
+        isSessionDone: false,
         timer: null,
       });
     });
@@ -285,16 +282,17 @@ describe('LocalRestApiHandlerService', () => {
           purpose: 'work',
         },
         mode: FocusModeMode.Pomodoro,
-        cycle: 2,
+        currentCycle: 2,
       });
 
       expectFocusData(await requestFocus(), {
         mode: FocusModeMode.Pomodoro,
         cycle: 2,
+        isSessionDone: false,
         timer: {
           purpose: 'work',
-          isRunning: true,
-          isPaused: false,
+          status: 'running',
+          isOvertime: false,
           elapsedMs: 120_000,
           remainingMs: 1_380_000,
           durationMs: 1_500_000,
@@ -313,16 +311,17 @@ describe('LocalRestApiHandlerService', () => {
           purpose: 'work',
         },
         mode: FocusModeMode.Countdown,
-        cycle: 1,
+        currentCycle: 1,
       });
 
       expectFocusData(await requestFocus(), {
         mode: FocusModeMode.Countdown,
         cycle: 1,
+        isSessionDone: false,
         timer: {
           purpose: 'work',
-          isRunning: false,
-          isPaused: true,
+          status: 'paused',
+          isOvertime: false,
           elapsedMs: 90_000,
           remainingMs: 210_000,
           durationMs: 300_000,
@@ -331,7 +330,49 @@ describe('LocalRestApiHandlerService', () => {
       });
     });
 
-    it('should return short and long Pomodoro breaks', async () => {
+    it('should return a running Countdown work timer', async () => {
+      setFocusState({
+        timer: {
+          isRunning: true,
+          startedAt: 1,
+          elapsed: 90_000,
+          duration: 300_000,
+          purpose: 'work',
+        },
+        mode: FocusModeMode.Countdown,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Countdown,
+        cycle: 1,
+        isSessionDone: false,
+        timer: {
+          purpose: 'work',
+          status: 'running',
+          isOvertime: false,
+          elapsedMs: 90_000,
+          remainingMs: 210_000,
+          durationMs: 300_000,
+          isLongBreak: false,
+        },
+      });
+    });
+
+    it('should return a completed work session separately from the timer', async () => {
+      setFocusState({
+        currentScreen: FocusScreen.SessionDone,
+        mode: FocusModeMode.Countdown,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Countdown,
+        cycle: 1,
+        isSessionDone: true,
+        timer: null,
+      });
+    });
+
+    it('should return running short and long Pomodoro breaks', async () => {
       const timer: TimerState = {
         isRunning: true,
         startedAt: 1,
@@ -340,14 +381,15 @@ describe('LocalRestApiHandlerService', () => {
         purpose: 'break',
       };
 
-      setFocusState({ timer, mode: FocusModeMode.Pomodoro, cycle: 2 });
+      setFocusState({ timer, mode: FocusModeMode.Pomodoro, currentCycle: 2 });
       expectFocusData(await requestFocus(), {
         mode: FocusModeMode.Pomodoro,
         cycle: 2,
+        isSessionDone: false,
         timer: {
           purpose: 'break',
-          isRunning: true,
-          isPaused: false,
+          status: 'running',
+          isOvertime: false,
           elapsedMs: 30_000,
           remainingMs: 270_000,
           durationMs: 300_000,
@@ -356,17 +398,18 @@ describe('LocalRestApiHandlerService', () => {
       });
 
       setFocusState({
-        timer: { ...timer, isRunning: false, isLongBreak: true },
+        timer: { ...timer, isLongBreak: true },
         mode: FocusModeMode.Pomodoro,
-        cycle: 4,
+        currentCycle: 5,
       });
       expectFocusData(await requestFocus(), {
         mode: FocusModeMode.Pomodoro,
-        cycle: 4,
+        cycle: 5,
+        isSessionDone: false,
         timer: {
           purpose: 'break',
-          isRunning: false,
-          isPaused: true,
+          status: 'running',
+          isOvertime: false,
           elapsedMs: 30_000,
           remainingMs: 270_000,
           durationMs: 300_000,
@@ -375,7 +418,37 @@ describe('LocalRestApiHandlerService', () => {
       });
     });
 
-    it('should return Flowtime state with no remaining countdown time', async () => {
+    it('should return a completed Pomodoro break as done', async () => {
+      setFocusState({
+        timer: {
+          isRunning: false,
+          startedAt: 1,
+          elapsed: 300_000,
+          duration: 300_000,
+          purpose: 'break',
+          isLongBreak: true,
+        },
+        mode: FocusModeMode.Pomodoro,
+        currentCycle: 5,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Pomodoro,
+        cycle: 5,
+        isSessionDone: false,
+        timer: {
+          purpose: 'break',
+          status: 'done',
+          isOvertime: false,
+          elapsedMs: 300_000,
+          remainingMs: 0,
+          durationMs: 300_000,
+          isLongBreak: true,
+        },
+      });
+    });
+
+    it('should return running and paused Flowtime work timers', async () => {
       setFocusState({
         timer: {
           isRunning: true,
@@ -385,16 +458,42 @@ describe('LocalRestApiHandlerService', () => {
           purpose: 'work',
         },
         mode: FocusModeMode.Flowtime,
-        cycle: -1,
       });
 
       expectFocusData(await requestFocus(), {
         mode: FocusModeMode.Flowtime,
-        cycle: 0,
+        cycle: 1,
+        isSessionDone: false,
         timer: {
           purpose: 'work',
-          isRunning: true,
-          isPaused: false,
+          status: 'running',
+          isOvertime: false,
+          elapsedMs: 600_000,
+          remainingMs: 0,
+          durationMs: 0,
+          isLongBreak: false,
+        },
+      });
+
+      setFocusState({
+        timer: {
+          isRunning: false,
+          startedAt: 1,
+          elapsed: 600_000,
+          duration: 0,
+          purpose: 'work',
+        },
+        mode: FocusModeMode.Flowtime,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Flowtime,
+        cycle: 1,
+        isSessionDone: false,
+        timer: {
+          purpose: 'work',
+          status: 'paused',
+          isOvertime: false,
           elapsedMs: 600_000,
           remainingMs: 0,
           durationMs: 0,
@@ -403,28 +502,30 @@ describe('LocalRestApiHandlerService', () => {
       });
     });
 
-    it('should normalize a work timer after a backward clock adjustment', async () => {
+    it('should preserve overtime while a work timer is paused', async () => {
       setFocusState({
         timer: {
-          isRunning: true,
+          isRunning: false,
           startedAt: 1,
-          elapsed: -1_000,
-          duration: 300_000,
+          elapsed: 1_600_000,
+          duration: 1_500_000,
           purpose: 'work',
         },
-        mode: FocusModeMode.Countdown,
+        mode: FocusModeMode.Pomodoro,
+        _isOvertimeEnabled: true,
       });
 
       expectFocusData(await requestFocus(), {
-        mode: FocusModeMode.Countdown,
-        cycle: 0,
+        mode: FocusModeMode.Pomodoro,
+        cycle: 1,
+        isSessionDone: false,
         timer: {
           purpose: 'work',
-          isRunning: true,
-          isPaused: false,
-          elapsedMs: 0,
-          remainingMs: 300_000,
-          durationMs: 300_000,
+          status: 'paused',
+          isOvertime: true,
+          elapsedMs: 1_600_000,
+          remainingMs: 0,
+          durationMs: 1_500_000,
           isLongBreak: false,
         },
       });

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { LocalRestApiHandlerService } from './local-rest-api-handler.service';
 import { TaskService } from '../../features/tasks/task.service';
@@ -13,6 +14,8 @@ import {
   LocalRestApiRequestPayload,
   LocalRestApiResponsePayload,
 } from '../../../../electron/shared-with-frontend/local-rest-api.model';
+import { FocusModeMode, TimerState } from '../../features/focus-mode/focus-mode.model';
+import * as focusSelectors from '../../features/focus-mode/store/focus-mode.selectors';
 
 describe('LocalRestApiHandlerService', () => {
   let service: LocalRestApiHandlerService;
@@ -21,6 +24,7 @@ describe('LocalRestApiHandlerService', () => {
   let projectServiceMock: jasmine.SpyObj<ProjectService>;
   let tagServiceMock: jasmine.SpyObj<TagService>;
   let dateServiceMock: jasmine.SpyObj<DateService>;
+  let store: MockStore;
   let activeProjects: Project[];
   let requestHandler: ((payload: LocalRestApiRequestPayload) => void) | null = null;
   let responsePromiseResolve: ((response: LocalRestApiResponsePayload) => void) | null =
@@ -49,6 +53,30 @@ describe('LocalRestApiHandlerService', () => {
     ...task,
     subTasks,
   });
+
+  const setFocusState = ({
+    timer,
+    mode = FocusModeMode.Countdown,
+    cycle = 0,
+    isPaused = false,
+    isLongBreak = false,
+    remainingMs = Math.max(0, timer.duration - timer.elapsed),
+  }: {
+    timer: TimerState;
+    mode?: FocusModeMode;
+    cycle?: number;
+    isPaused?: boolean;
+    isLongBreak?: boolean;
+    remainingMs?: number;
+  }): void => {
+    store.overrideSelector(focusSelectors.selectTimer, timer);
+    store.overrideSelector(focusSelectors.selectMode, mode);
+    store.overrideSelector(focusSelectors.selectCurrentCycle, cycle);
+    store.overrideSelector(focusSelectors.selectIsSessionPaused, isPaused);
+    store.overrideSelector(focusSelectors.selectIsLongBreak, isLongBreak);
+    store.overrideSelector(focusSelectors.selectTimeRemaining, remainingMs);
+    store.refreshState();
+  };
 
   const mockElectronApi = (): void => {
     (window as any).ea = {
@@ -173,10 +201,12 @@ describe('LocalRestApiHandlerService', () => {
         { provide: ProjectService, useValue: projectServiceMock },
         { provide: TagService, useValue: tagServiceMock },
         { provide: DateService, useValue: dateServiceMock },
+        provideMockStore(),
       ],
     });
 
     service = TestBed.inject(LocalRestApiHandlerService);
+    store = TestBed.inject(MockStore);
   });
 
   afterEach(() => {
@@ -212,6 +242,178 @@ describe('LocalRestApiHandlerService', () => {
 
       expect(response.body.ok).toBe(true);
       expect(response.status).toBe(200);
+    });
+  });
+
+  describe('GET /focus', () => {
+    beforeEach(() => {
+      service.init();
+    });
+
+    const requestFocus = async (): Promise<LocalRestApiResponsePayload> =>
+      sendRequestAndWait(createRequest('GET', '/focus'));
+
+    const expectFocusData = (
+      response: LocalRestApiResponsePayload,
+      expected: unknown,
+    ): void => {
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      if (!response.body.ok) {
+        throw new Error(`Expected success response, got ${response.body.error.code}`);
+      }
+      expect(response.body.data).toEqual(expected);
+    };
+
+    it('should return a null timer while focus mode is idle', async () => {
+      setFocusState({
+        timer: {
+          isRunning: false,
+          startedAt: null,
+          elapsed: 0,
+          duration: 0,
+          purpose: null,
+        },
+        mode: FocusModeMode.Countdown,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Countdown,
+        cycle: 0,
+        timer: null,
+      });
+    });
+
+    it('should return a running Pomodoro work timer', async () => {
+      setFocusState({
+        timer: {
+          isRunning: true,
+          startedAt: 1,
+          elapsed: 120_000,
+          duration: 1_500_000,
+          purpose: 'work',
+        },
+        mode: FocusModeMode.Pomodoro,
+        cycle: 2,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Pomodoro,
+        cycle: 2,
+        timer: {
+          purpose: 'work',
+          isRunning: true,
+          isPaused: false,
+          elapsedMs: 120_000,
+          remainingMs: 1_380_000,
+          durationMs: 1_500_000,
+          isLongBreak: false,
+        },
+      });
+    });
+
+    it('should return a paused Countdown work timer', async () => {
+      setFocusState({
+        timer: {
+          isRunning: false,
+          startedAt: 1,
+          elapsed: 90_000,
+          duration: 300_000,
+          purpose: 'work',
+        },
+        mode: FocusModeMode.Countdown,
+        cycle: 1,
+        isPaused: true,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Countdown,
+        cycle: 1,
+        timer: {
+          purpose: 'work',
+          isRunning: false,
+          isPaused: true,
+          elapsedMs: 90_000,
+          remainingMs: 210_000,
+          durationMs: 300_000,
+          isLongBreak: false,
+        },
+      });
+    });
+
+    it('should return short and long Pomodoro breaks', async () => {
+      const timer: TimerState = {
+        isRunning: true,
+        startedAt: 1,
+        elapsed: 30_000,
+        duration: 300_000,
+        purpose: 'break',
+      };
+
+      setFocusState({ timer, mode: FocusModeMode.Pomodoro, cycle: 2 });
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Pomodoro,
+        cycle: 2,
+        timer: {
+          purpose: 'break',
+          isRunning: true,
+          isPaused: false,
+          elapsedMs: 30_000,
+          remainingMs: 270_000,
+          durationMs: 300_000,
+          isLongBreak: false,
+        },
+      });
+
+      setFocusState({
+        timer: { ...timer, isRunning: false, isLongBreak: true },
+        mode: FocusModeMode.Pomodoro,
+        cycle: 4,
+        isPaused: true,
+        isLongBreak: true,
+      });
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Pomodoro,
+        cycle: 4,
+        timer: {
+          purpose: 'break',
+          isRunning: false,
+          isPaused: true,
+          elapsedMs: 30_000,
+          remainingMs: 270_000,
+          durationMs: 300_000,
+          isLongBreak: true,
+        },
+      });
+    });
+
+    it('should return Flowtime state and clamp negative remaining time', async () => {
+      setFocusState({
+        timer: {
+          isRunning: true,
+          startedAt: 1,
+          elapsed: 600_000,
+          duration: 0,
+          purpose: 'work',
+        },
+        mode: FocusModeMode.Flowtime,
+        cycle: -1,
+        remainingMs: -1,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Flowtime,
+        cycle: 0,
+        timer: {
+          purpose: 'work',
+          isRunning: true,
+          isPaused: false,
+          elapsedMs: 600_000,
+          remainingMs: 0,
+          durationMs: 0,
+          isLongBreak: false,
+        },
+      });
     });
   });
 

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -58,23 +58,14 @@ describe('LocalRestApiHandlerService', () => {
     timer,
     mode = FocusModeMode.Countdown,
     cycle = 0,
-    isPaused = false,
-    isLongBreak = false,
-    remainingMs = Math.max(0, timer.duration - timer.elapsed),
   }: {
     timer: TimerState;
     mode?: FocusModeMode;
     cycle?: number;
-    isPaused?: boolean;
-    isLongBreak?: boolean;
-    remainingMs?: number;
   }): void => {
     store.overrideSelector(focusSelectors.selectTimer, timer);
     store.overrideSelector(focusSelectors.selectMode, mode);
     store.overrideSelector(focusSelectors.selectCurrentCycle, cycle);
-    store.overrideSelector(focusSelectors.selectIsSessionPaused, isPaused);
-    store.overrideSelector(focusSelectors.selectIsLongBreak, isLongBreak);
-    store.overrideSelector(focusSelectors.selectTimeRemaining, remainingMs);
     store.refreshState();
   };
 
@@ -323,7 +314,6 @@ describe('LocalRestApiHandlerService', () => {
         },
         mode: FocusModeMode.Countdown,
         cycle: 1,
-        isPaused: true,
       });
 
       expectFocusData(await requestFocus(), {
@@ -369,8 +359,6 @@ describe('LocalRestApiHandlerService', () => {
         timer: { ...timer, isRunning: false, isLongBreak: true },
         mode: FocusModeMode.Pomodoro,
         cycle: 4,
-        isPaused: true,
-        isLongBreak: true,
       });
       expectFocusData(await requestFocus(), {
         mode: FocusModeMode.Pomodoro,
@@ -387,7 +375,7 @@ describe('LocalRestApiHandlerService', () => {
       });
     });
 
-    it('should return Flowtime state and clamp negative remaining time', async () => {
+    it('should return Flowtime state with no remaining countdown time', async () => {
       setFocusState({
         timer: {
           isRunning: true,
@@ -398,7 +386,6 @@ describe('LocalRestApiHandlerService', () => {
         },
         mode: FocusModeMode.Flowtime,
         cycle: -1,
-        remainingMs: -1,
       });
 
       expectFocusData(await requestFocus(), {
@@ -411,6 +398,33 @@ describe('LocalRestApiHandlerService', () => {
           elapsedMs: 600_000,
           remainingMs: 0,
           durationMs: 0,
+          isLongBreak: false,
+        },
+      });
+    });
+
+    it('should normalize a work timer after a backward clock adjustment', async () => {
+      setFocusState({
+        timer: {
+          isRunning: true,
+          startedAt: 1,
+          elapsed: -1_000,
+          duration: 300_000,
+          purpose: 'work',
+        },
+        mode: FocusModeMode.Countdown,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Countdown,
+        cycle: 0,
+        timer: {
+          purpose: 'work',
+          isRunning: true,
+          isPaused: false,
+          elapsedMs: 0,
+          remainingMs: 300_000,
+          durationMs: 300_000,
           isLongBreak: false,
         },
       });

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -20,7 +20,11 @@ import {
   FocusScreen,
   TimerState,
 } from '../../features/focus-mode/focus-mode.model';
-import { initialState as initialFocusModeState } from '../../features/focus-mode/store/focus-mode.reducer';
+import * as focusModeActions from '../../features/focus-mode/store/focus-mode.actions';
+import {
+  focusModeReducer,
+  initialState as initialFocusModeState,
+} from '../../features/focus-mode/store/focus-mode.reducer';
 
 describe('LocalRestApiHandlerService', () => {
   let service: LocalRestApiHandlerService;
@@ -523,6 +527,40 @@ describe('LocalRestApiHandlerService', () => {
         timer: {
           purpose: 'work',
           status: 'paused',
+          isOvertime: false,
+          elapsedMs: 600_000,
+          remainingMs: 0,
+          durationMs: 0,
+          isLongBreak: false,
+        },
+      });
+    });
+
+    it('should retain the Pomodoro cycle after switching to Flowtime', async () => {
+      const flowtimeState = focusModeReducer(
+        {
+          ...initialFocusModeState,
+          mode: FocusModeMode.Pomodoro,
+          currentCycle: 5,
+          timer: {
+            isRunning: true,
+            startedAt: 1,
+            elapsed: 600_000,
+            duration: 1_500_000,
+            purpose: 'work',
+          },
+        },
+        focusModeActions.setFocusModeMode({ mode: FocusModeMode.Flowtime }),
+      );
+      store.setState({ focusMode: flowtimeState });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Flowtime,
+        cycle: 5,
+        isSessionDone: false,
+        timer: {
+          purpose: 'work',
+          status: 'running',
           isOvertime: false,
           elapsedMs: 600_000,
           remainingMs: 0,

--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -448,6 +448,36 @@ describe('LocalRestApiHandlerService', () => {
       });
     });
 
+    it('should return a stopped Pomodoro break with time remaining as paused', async () => {
+      setFocusState({
+        timer: {
+          isRunning: false,
+          startedAt: 1,
+          elapsed: 30_000,
+          duration: 300_000,
+          purpose: 'break',
+          isLongBreak: true,
+        },
+        mode: FocusModeMode.Pomodoro,
+        currentCycle: 5,
+      });
+
+      expectFocusData(await requestFocus(), {
+        mode: FocusModeMode.Pomodoro,
+        cycle: 5,
+        isSessionDone: false,
+        timer: {
+          purpose: 'break',
+          status: 'paused',
+          isOvertime: false,
+          elapsedMs: 30_000,
+          remainingMs: 270_000,
+          durationMs: 300_000,
+          isLongBreak: true,
+        },
+      });
+    });
+
     it('should return running and paused Flowtime work timers', async () => {
       setFocusState({
         timer: {

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject } from '@angular/core';
+import { Store } from '@ngrx/store';
 import { firstValueFrom } from 'rxjs';
 import typia from 'typia';
 import { TaskService } from '../../features/tasks/task.service';
@@ -9,6 +10,14 @@ import { TagService } from '../../features/tag/tag.service';
 import { TODAY_TAG } from '../../features/tag/tag.const';
 import { DateService } from '../date/date.service';
 import { isTodayWithOffset } from '../../util/is-today.util';
+import {
+  selectCurrentCycle,
+  selectIsLongBreak,
+  selectIsSessionPaused,
+  selectMode,
+  selectTimeRemaining,
+  selectTimer,
+} from '../../features/focus-mode/store/focus-mode.selectors';
 import {
   LocalRestApiRequestPayload,
   LocalRestApiResponsePayload,
@@ -178,6 +187,7 @@ export class LocalRestApiHandlerService {
   private readonly _projectService = inject(ProjectService);
   private readonly _tagService = inject(TagService);
   private readonly _dateService = inject(DateService);
+  private readonly _store = inject(Store);
   private _isInitialized = false;
 
   init(): void {
@@ -216,6 +226,10 @@ export class LocalRestApiHandlerService {
 
     if (method === 'GET' && path === '/status') {
       return this._handleGetStatus(requestId);
+    }
+
+    if (method === 'GET' && path === '/focus') {
+      return this._handleGetFocus(requestId);
     }
 
     if (method === 'GET' && path === '/task-control/current') {
@@ -265,6 +279,34 @@ export class LocalRestApiHandlerService {
       currentTask,
       currentTaskId: currentTask?.id ?? null,
       taskCount: allTasks.length,
+    });
+  }
+
+  private async _handleGetFocus(requestId: string): Promise<LocalRestApiResponsePayload> {
+    const [timer, mode, cycle, isPaused, isLongBreak, remainingMs] = await Promise.all([
+      firstValueFrom(this._store.select(selectTimer)),
+      firstValueFrom(this._store.select(selectMode)),
+      firstValueFrom(this._store.select(selectCurrentCycle)),
+      firstValueFrom(this._store.select(selectIsSessionPaused)),
+      firstValueFrom(this._store.select(selectIsLongBreak)),
+      firstValueFrom(this._store.select(selectTimeRemaining)),
+    ]);
+
+    return createSuccessResponse(requestId, 200, {
+      mode,
+      cycle: Math.max(0, cycle),
+      timer:
+        timer.purpose === null
+          ? null
+          : {
+              purpose: timer.purpose,
+              isRunning: timer.isRunning,
+              isPaused,
+              elapsedMs: timer.elapsed,
+              remainingMs: Math.max(0, remainingMs),
+              durationMs: timer.duration,
+              isLongBreak,
+            },
     });
   }
 

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -12,10 +12,7 @@ import { DateService } from '../date/date.service';
 import { isTodayWithOffset } from '../../util/is-today.util';
 import {
   selectCurrentCycle,
-  selectIsLongBreak,
-  selectIsSessionPaused,
   selectMode,
-  selectTimeRemaining,
   selectTimer,
 } from '../../features/focus-mode/store/focus-mode.selectors';
 import {
@@ -283,14 +280,13 @@ export class LocalRestApiHandlerService {
   }
 
   private async _handleGetFocus(requestId: string): Promise<LocalRestApiResponsePayload> {
-    const [timer, mode, cycle, isPaused, isLongBreak, remainingMs] = await Promise.all([
+    const [timer, mode, cycle] = await Promise.all([
       firstValueFrom(this._store.select(selectTimer)),
       firstValueFrom(this._store.select(selectMode)),
       firstValueFrom(this._store.select(selectCurrentCycle)),
-      firstValueFrom(this._store.select(selectIsSessionPaused)),
-      firstValueFrom(this._store.select(selectIsLongBreak)),
-      firstValueFrom(this._store.select(selectTimeRemaining)),
     ]);
+    const durationMs = Math.max(0, timer.duration);
+    const elapsedMs = Math.max(0, timer.elapsed);
 
     return createSuccessResponse(requestId, 200, {
       mode,
@@ -301,11 +297,11 @@ export class LocalRestApiHandlerService {
           : {
               purpose: timer.purpose,
               isRunning: timer.isRunning,
-              isPaused,
-              elapsedMs: timer.elapsed,
-              remainingMs: Math.max(0, remainingMs),
-              durationMs: timer.duration,
-              isLongBreak,
+              isPaused: !timer.isRunning,
+              elapsedMs,
+              remainingMs: Math.max(0, durationMs - elapsedMs),
+              durationMs,
+              isLongBreak: timer.purpose === 'break' && timer.isLongBreak === true,
             },
     });
   }

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -12,11 +12,11 @@ import { DateService } from '../date/date.service';
 import { isTodayWithOffset } from '../../util/is-today.util';
 import {
   selectCurrentCycle,
+  selectIsBreakTimeUp,
   selectIsInOvertime,
   selectIsLongBreak,
   selectIsRunning,
   selectIsSessionCompleted,
-  selectIsSessionPaused,
   selectMode,
   selectTimeRemaining,
   selectTimer,
@@ -286,27 +286,16 @@ export class LocalRestApiHandlerService {
   }
 
   private async _handleGetFocus(requestId: string): Promise<LocalRestApiResponsePayload> {
-    const [
-      timer,
-      mode,
-      cycle,
-      isRunning,
-      isSessionPaused,
-      isLongBreak,
-      remainingMs,
-      isSessionDone,
-      isOvertime,
-    ] = await Promise.all([
-      firstValueFrom(this._store.select(selectTimer)),
-      firstValueFrom(this._store.select(selectMode)),
-      firstValueFrom(this._store.select(selectCurrentCycle)),
-      firstValueFrom(this._store.select(selectIsRunning)),
-      firstValueFrom(this._store.select(selectIsSessionPaused)),
-      firstValueFrom(this._store.select(selectIsLongBreak)),
-      firstValueFrom(this._store.select(selectTimeRemaining)),
-      firstValueFrom(this._store.select(selectIsSessionCompleted)),
-      firstValueFrom(this._store.select(selectIsInOvertime)),
-    ]);
+    const state = await firstValueFrom(this._store);
+    const timer = selectTimer(state);
+    const mode = selectMode(state);
+    const cycle = selectCurrentCycle(state);
+    const isRunning = selectIsRunning(state);
+    const isBreakTimeUp = selectIsBreakTimeUp(state);
+    const isLongBreak = selectIsLongBreak(state);
+    const remainingMs = selectTimeRemaining(state);
+    const isSessionDone = selectIsSessionCompleted(state);
+    const isOvertime = selectIsInOvertime(state);
 
     return createSuccessResponse(requestId, 200, {
       mode,
@@ -317,11 +306,7 @@ export class LocalRestApiHandlerService {
           ? null
           : {
               purpose: timer.purpose,
-              status: isRunning
-                ? 'running'
-                : isSessionPaused && timer.purpose === 'break' && remainingMs === 0
-                  ? 'done'
-                  : 'paused',
+              status: isRunning ? 'running' : isBreakTimeUp ? 'done' : 'paused',
               isOvertime,
               isLongBreak,
               elapsedMs: timer.elapsed,

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -12,7 +12,13 @@ import { DateService } from '../date/date.service';
 import { isTodayWithOffset } from '../../util/is-today.util';
 import {
   selectCurrentCycle,
+  selectIsInOvertime,
+  selectIsLongBreak,
+  selectIsRunning,
+  selectIsSessionCompleted,
+  selectIsSessionPaused,
   selectMode,
+  selectTimeRemaining,
   selectTimer,
 } from '../../features/focus-mode/store/focus-mode.selectors';
 import {
@@ -280,28 +286,47 @@ export class LocalRestApiHandlerService {
   }
 
   private async _handleGetFocus(requestId: string): Promise<LocalRestApiResponsePayload> {
-    const [timer, mode, cycle] = await Promise.all([
+    const [
+      timer,
+      mode,
+      cycle,
+      isRunning,
+      isSessionPaused,
+      isLongBreak,
+      remainingMs,
+      isSessionDone,
+      isOvertime,
+    ] = await Promise.all([
       firstValueFrom(this._store.select(selectTimer)),
       firstValueFrom(this._store.select(selectMode)),
       firstValueFrom(this._store.select(selectCurrentCycle)),
+      firstValueFrom(this._store.select(selectIsRunning)),
+      firstValueFrom(this._store.select(selectIsSessionPaused)),
+      firstValueFrom(this._store.select(selectIsLongBreak)),
+      firstValueFrom(this._store.select(selectTimeRemaining)),
+      firstValueFrom(this._store.select(selectIsSessionCompleted)),
+      firstValueFrom(this._store.select(selectIsInOvertime)),
     ]);
-    const durationMs = Math.max(0, timer.duration);
-    const elapsedMs = Math.max(0, timer.elapsed);
 
     return createSuccessResponse(requestId, 200, {
       mode,
-      cycle: Math.max(0, cycle),
+      cycle,
+      isSessionDone,
       timer:
         timer.purpose === null
           ? null
           : {
               purpose: timer.purpose,
-              isRunning: timer.isRunning,
-              isPaused: !timer.isRunning,
-              elapsedMs,
-              remainingMs: Math.max(0, durationMs - elapsedMs),
-              durationMs,
-              isLongBreak: timer.purpose === 'break' && timer.isLongBreak === true,
+              status: isRunning
+                ? 'running'
+                : isSessionPaused && timer.purpose === 'break' && remainingMs === 0
+                  ? 'done'
+                  : 'paused',
+              isOvertime,
+              isLongBreak,
+              elapsedMs: timer.elapsed,
+              remainingMs,
+              durationMs: timer.duration,
             },
     });
   }

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -35,12 +35,7 @@ import {
   selectPomodoroConfig,
 } from '../../config/store/global-config.reducer';
 import { updateGlobalConfigSection } from '../../config/store/global-config.actions';
-import {
-  FocusModeMode,
-  FocusScreen,
-  getBreakCycle,
-  TimerState,
-} from '../focus-mode.model';
+import { FocusModeMode, FocusScreen, getBreakCycle } from '../focus-mode.model';
 import { MetricService } from '../../metric/metric.service';
 import { FocusModeStorageService } from '../focus-mode-storage.service';
 import { TakeABreakService } from '../../take-a-break/take-a-break.service';
@@ -304,7 +299,7 @@ export class FocusModeEffects {
     () =>
       this.store.select(selectors.selectTimer).pipe(
         skipWhileApplyingRemoteOps(),
-        filter((timer) => this._isBreakTimeUp(timer)),
+        filter((timer) => selectors.selectIsBreakTimeUp.projector(timer)),
         distinctUntilChanged(
           (prev, curr) =>
             prev.elapsed === curr.elapsed && prev.startedAt === curr.startedAt,
@@ -331,7 +326,11 @@ export class FocusModeEffects {
     () =>
       this.store.select(selectors.selectTimer).pipe(
         skipWhileApplyingRemoteOps(),
-        map((timer) => this._isBreakTimeUp(timer) && this._isLoopBreakEndAlarmOn()),
+        map(
+          (timer) =>
+            selectors.selectIsBreakTimeUp.projector(timer) &&
+            this._isLoopBreakEndAlarmOn(),
+        ),
         distinctUntilChanged(),
         tap((shouldAlarm) => {
           if (shouldAlarm) {
@@ -956,15 +955,6 @@ export class FocusModeEffects {
       ),
     { dispatch: false },
   );
-
-  private _isBreakTimeUp(timer: TimerState): boolean {
-    return (
-      timer.purpose === 'break' &&
-      !timer.isRunning &&
-      timer.startedAt !== null &&
-      timer.elapsed >= timer.duration
-    );
-  }
 
   private _isLoopBreakEndAlarmOn(): boolean {
     return (

--- a/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
@@ -215,6 +215,44 @@ describe('FocusModeSelectors', () => {
     });
   });
 
+  describe('selectIsBreakTimeUp', () => {
+    it('should return true for a completed break', () => {
+      const timer = createMockTimer({
+        isRunning: false,
+        startedAt: 1,
+        elapsed: 300000,
+        duration: 300000,
+        purpose: 'break',
+      });
+
+      expect(selectors.selectIsBreakTimeUp.projector(timer)).toBe(true);
+    });
+
+    it('should return false for a running break', () => {
+      const timer = createMockTimer({
+        isRunning: true,
+        startedAt: 1,
+        elapsed: 300000,
+        duration: 300000,
+        purpose: 'break',
+      });
+
+      expect(selectors.selectIsBreakTimeUp.projector(timer)).toBe(false);
+    });
+
+    it('should return false for an unstarted zero-duration break offer', () => {
+      const timer = createMockTimer({
+        isRunning: false,
+        startedAt: null,
+        elapsed: 0,
+        duration: 0,
+        purpose: 'break',
+      });
+
+      expect(selectors.selectIsBreakTimeUp.projector(timer)).toBe(false);
+    });
+  });
+
   describe('selectTimeElapsed', () => {
     it('should select elapsed time', () => {
       const timer = createMockTimer({ elapsed: 300000 });

--- a/src/app/features/focus-mode/store/focus-mode.selectors.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.ts
@@ -58,6 +58,15 @@ export const selectIsLongBreak = createSelector(
   (timer) => timer.purpose === 'break' && timer.isLongBreak === true,
 );
 
+export const selectIsBreakTimeUp = createSelector(
+  selectTimer,
+  (timer) =>
+    timer.purpose === 'break' &&
+    !timer.isRunning &&
+    timer.startedAt !== null &&
+    timer.elapsed >= timer.duration,
+);
+
 // Timer selectors - much simpler!
 export const selectTimeElapsed = createSelector(selectTimer, (timer) => timer.elapsed);
 


### PR DESCRIPTION
## Problem

External desktop clients cannot read the authoritative Focus Mode timer state through the opt-in
Local REST API. This blocks a companion bar from showing the native timer without recreating timer
logic. Related: https://github.com/aaronedev/dotfiles/issues/247

## Solution

Add authenticated, read-only `GET /focus` to the existing renderer Local REST request pipeline.
Its data contract is:

```ts
{
  mode: "Flowtime" | "Pomodoro" | "Countdown";
  cycle: number;
  isSessionDone: boolean;
  timer: null | {
    purpose: "work" | "break";
    status: "running" | "paused" | "done";
    isOvertime: boolean;
    isLongBreak: boolean;
    elapsedMs: number;
    remainingMs: number;
    durationMs: number;
  };
}
```

The handler reads the existing Focus Mode selectors as one coherent store sample. Completed work
uses `isSessionDone` to distinguish its idle timer from an untouched session; a completed break
retains its timer with `status: "done"`. `isOvertime` is independent from status, including while
an overtime work timer is paused. The endpoint returns no task content or credentials and adds no
focus controls: start, pause, resume, skip, and cancel remain native-app behavior. It inherits the
established opt-in Local REST API and Bearer authentication; `GET /health` remains the only
unauthenticated exception.

Focused tests use real Focus Mode state and cover idle, running and paused work, completed work,
running, paused, and completed breaks, Flowtime, overtime, and realistic cycle values. The API
reference documents the authenticated curl usage, state semantics, and 1-based Pomodoro cycle.

## Type of Change

- [x] New feature

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing focused tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Validation

- `npm run checkFile src/app/core/electron/local-rest-api-handler.service.ts`
- `npm run checkFile src/app/core/electron/local-rest-api-handler.service.spec.ts`
- `npm run test:file src/app/core/electron/local-rest-api-handler.service.spec.ts` (80/80 passing)
- `npm run docs:check-links`
- `git diff --check`

## Remaining dependency

The companion integration in aaronedev/dotfiles will capability-detect this endpoint. It can use
native focus state after this PR is reviewed, merged, and released; this PR intentionally does not
add focus control endpoints.
