### PR TITLE
fix(schedule): open schedule view scrolled to current time #9417

### DIFF
--- a/e2e/store-screenshots/helpers.ts
+++ b/e2e/store-screenshots/helpers.ts
@@ -51,9 +51,11 @@ export const openTaskDetailPanel = async (page: Page, taskId: string): Promise<v
 
 /**
  * Nudge the schedule's scroll container up by `pxUp` pixels so the
- * captured frame shows a bit of context before work-start (default
- * scroll lands flush at work-start, which crops anything earlier in the
- * day). Pass through to the schedule scroll-wrapper rather than the
+ * captured frame shows a bit of context before the current time. The
+ * default scroll now already leaves a lead above its target (see
+ * scroll-padding-top on .scroll-wrapper), so this over-corrects; shrink
+ * `pxUp` when the screenshots are next regenerated. Pass through to the
+ * schedule scroll-wrapper rather than the
  * page scroll so we don't disturb non-schedule layouts.
  */
 export const scrollScheduleUp = async (page: Page, pxUp = 80): Promise<void> => {

--- a/src/app/features/schedule/schedule-constants.scss
+++ b/src/app/features/schedule/schedule-constants.scss
@@ -16,6 +16,17 @@ $schedule-day-column-width-desktop: 180px;
 $schedule-day-column-width-tablet: 150px;
 $schedule-day-column-width-mobile: 120px;
 
+// Sticky week header. Used both for the header itself and for the
+// scroll-padding that keeps the scroll target from landing under it.
+$schedule-week-header-height: 32px;
+$schedule-week-header-height-mobile: 22px;
+
+// How much of the schedule stays visible above the scroll target, as a
+// fraction of the scroll viewport. A fixed number of minutes reads very
+// differently on a 950px desktop viewport and a 400px phone one; a fraction
+// is stable across breakpoints and zoom levels. ~1h on a desktop viewport.
+$schedule-scroll-lead: 12%;
+
 // Scrollbar dimensions
 $schedule-scrollbar-height: 8px;
 $schedule-scrollbar-width: 4px;

--- a/src/app/features/schedule/schedule-day-panel/schedule-day-panel.component.ts
+++ b/src/app/features/schedule/schedule-day-panel/schedule-day-panel.component.ts
@@ -457,6 +457,12 @@ export class ScheduleDayPanelComponent implements AfterViewInit, OnDestroy {
     return null;
   }
 
+  // TODO replace with the schedule view's approach (scrollIntoView plus
+  // scroll-padding on the scroll container, see ScheduleComponent) so there is
+  // one implementation of "scroll to now" instead of two that can drift. This
+  // one is rect-based like the old schedule code was, but its enter animation
+  // (slideInFromRightAni) is translateX only, so it does not hit the transform
+  // overshoot that fix had.
   private _scrollToCurrentTime(): void {
     if (!this.scheduleWeekRef?.nativeElement) {
       Log.warn('[ScheduleDayPanel] No scheduleWeekRef available');

--- a/src/app/features/schedule/schedule-week/schedule-week.component.scss
+++ b/src/app/features/schedule/schedule-week/schedule-week.component.scss
@@ -228,10 +228,12 @@
   grid-template-columns: var(--schedule-time-width) repeat(var(--nr-of-days), 1fr);
   width: 100%;
   box-sizing: border-box;
-  min-height: 32px;
+  // Kept in sync with the scroll-padding on .scroll-wrapper, which offsets the
+  // initial scroll target so it doesn't land under this sticky header.
+  min-height: $schedule-week-header-height;
 
   @include mq(xs, max) {
-    min-height: 22px;
+    min-height: $schedule-week-header-height-mobile;
   }
 }
 
@@ -398,7 +400,6 @@
 
 .work-end,
 .work-start {
-  scroll-margin-top: 80px;
   border-top: 2px dashed var(--separator-color);
   min-width: 100px;
   grid-column: 2 / -1;

--- a/src/app/features/schedule/schedule/schedule.component.scss
+++ b/src/app/features/schedule/schedule/schedule.component.scss
@@ -17,6 +17,19 @@
   overflow-x: hidden;
   box-sizing: border-box;
 
+  // Framing for the initial scroll to the current time (or work start):
+  // keep the target clear of the sticky week header and the sticky time
+  // column, and leave a slice of the preceding schedule visible above it so
+  // it reads as "now, in context" rather than the day being cut off.
+  scroll-padding-top: calc(#{$schedule-week-header-height} + #{$schedule-scroll-lead});
+  scroll-padding-left: calc(#{$schedule-time-column-width} + 12px);
+
+  @include mq(xs, max) {
+    scroll-padding-top: calc(
+      #{$schedule-week-header-height-mobile} + #{$schedule-scroll-lead}
+    );
+  }
+
   // Enable horizontal scroll when viewport is too small for 7 days
   &[data-horizontal-scroll] {
     overflow-x: scroll; // Show horizontal scrollbar when needed

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1180,4 +1180,62 @@ describe('ScheduleComponent', () => {
       expect(mockLayoutService.selectedTimeView()).toBe('day');
     });
   });
+
+  describe('scroll target measurement', () => {
+    const TARGET_TOP_PX = 250;
+    let host: HTMLElement;
+    let wrapper: HTMLElement;
+
+    const buildScrollableDom = (scale: string): void => {
+      host = document.createElement('div');
+      // The route enter animation (warpRoute) starts the view at scale(1.2),
+      // and the scroll runs while that is still in flight.
+      host.style.cssText = `position:relative;transform:${scale};transform-origin:top left;`;
+
+      wrapper = document.createElement('div');
+      wrapper.className = 'scroll-wrapper';
+      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
+
+      const spacer = document.createElement('div');
+      spacer.style.cssText = 'height:600px;width:400px;';
+
+      const target = document.createElement('div');
+      target.id = 'test-scroll-target';
+      target.style.cssText = `position:absolute;top:${TARGET_TOP_PX}px;left:0;height:2px;width:10px;`;
+
+      wrapper.append(spacer, target);
+      host.append(wrapper);
+      document.body.append(host);
+    };
+
+    afterEach(() => host?.remove());
+
+    it('scrolls to the layout position even while an ancestor is scaled', () => {
+      buildScrollableDom('scale(1.2)');
+      const scrollToSpy = spyOn(wrapper, 'scrollTo');
+
+      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
+
+      expect(scrollToSpy).toHaveBeenCalled();
+      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
+      // Rect-based math would return TARGET_TOP_PX * 1.2 here, scrolling the
+      // view roughly two hours past "now".
+      expect(options.top).toBe(TARGET_TOP_PX);
+    });
+
+    it('gives the same target with and without the scale', () => {
+      buildScrollableDom('scale(1.2)');
+      const scaledSpy = spyOn(wrapper, 'scrollTo');
+      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
+      const scaledTop = (scaledSpy.calls.mostRecent().args[0] as ScrollToOptions).top;
+      host.remove();
+
+      buildScrollableDom('none');
+      const plainSpy = spyOn(wrapper, 'scrollTo');
+      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
+      const plainTop = (plainSpy.calls.mostRecent().args[0] as ScrollToOptions).top;
+
+      expect(scaledTop).toBe(plainTop);
+    });
+  });
 });

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1257,6 +1257,51 @@ describe('ScheduleComponent', () => {
       expect(options.top).toBe(TARGET_TOP_PX - leadPx);
     });
 
+    it('keeps the full lead visible below the sticky week header', () => {
+      const HEADER_HEIGHT_PX = 33;
+
+      host = document.createElement('div');
+      host.style.cssText = 'position:relative;';
+
+      wrapper = document.createElement('div');
+      wrapper.className = 'scroll-wrapper';
+      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
+
+      const week = document.createElement('schedule-week');
+      week.style.cssText = 'display:block;';
+
+      // Sticky, so it stays over the top of the viewport once scrolled and
+      // covers the first HEADER_HEIGHT_PX of whatever sits below it.
+      const header = document.createElement('div');
+      header.className = 'week-header';
+      header.style.cssText = `position:sticky;top:0;height:${HEADER_HEIGHT_PX}px;width:400px;`;
+
+      const grid = document.createElement('div');
+      grid.className = 'grid-container';
+      grid.style.cssText = 'position:relative;height:2880px;width:400px;';
+
+      const target = document.createElement('div');
+      target.id = 'test-scroll-target';
+      target.style.cssText = `position:absolute;top:${TARGET_TOP_PX}px;left:0;height:2px;width:10px;`;
+
+      grid.append(target);
+      week.append(header, grid);
+      wrapper.append(week);
+      host.append(wrapper);
+      document.body.append(host);
+
+      const scrollToSpy = spyOn(wrapper, 'scrollTo');
+      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
+
+      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
+      const leadPx = SCROLL_LEAD_MINUTES * PX_PER_MINUTE;
+      // The target sits HEADER_HEIGHT_PX further down the flow, and the scroll
+      // pulls back by the same amount, so the lead below the header is the full
+      // 30 minutes. Without the compensation this lands HEADER_HEIGHT_PX lower
+      // and the header covers more than half of that lead.
+      expect(options.top).toBe(TARGET_TOP_PX - leadPx);
+    });
+
     it('clamps the lead at the top of the day', () => {
       host = document.createElement('div');
       host.style.cssText = 'position:relative;';

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ScheduleComponent } from './schedule.component';
 import { TaskService } from '../../tasks/task.service';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
@@ -1099,6 +1099,63 @@ describe('ScheduleComponent', () => {
       expect(component.isWeekView()).toBe(false);
       expect(component.isMonthView()).toBe(false);
     });
+  });
+
+  describe('initial scroll target on view switch', () => {
+    // The effect only re-runs when isMonthView() flips, so go through month first.
+    const switchToMonthThenWeek = (scrollSpy: jasmine.Spy): void => {
+      mockLayoutService.selectedTimeView.set('month');
+      fixture.detectChanges();
+      scrollSpy.calls.reset();
+      mockLayoutService.selectedTimeView.set('week');
+      fixture.detectChanges();
+    };
+
+    it('scrolls to current-time when the current-time indicator is rendered', fakeAsync(() => {
+      const scrollSpy = spyOn<any>(component, '_scrollIntoViewWithTimeColumnOffset');
+      // Viewing today (default: _selectedDate null) → #current-time renders.
+      expect(fixture.nativeElement.querySelector('#current-time')).toBeTruthy();
+
+      switchToMonthThenWeek(scrollSpy);
+      tick();
+
+      expect(scrollSpy).toHaveBeenCalledWith('current-time');
+    }));
+
+    it('falls back to work-start when the current-time indicator is absent', fakeAsync(() => {
+      const scrollSpy = spyOn<any>(component, '_scrollIntoViewWithTimeColumnOffset');
+      // Viewing a future range without today → currentTimeRow() is null.
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2027-06-14',
+        '2027-06-15',
+        '2027-06-16',
+      ]);
+      component['_selectedDate'].set(new Date(2027, 5, 15));
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('#current-time')).toBeFalsy();
+
+      switchToMonthThenWeek(scrollSpy);
+      tick();
+
+      expect(scrollSpy).toHaveBeenCalledWith('work-start');
+    }));
+
+    it('scrolls to current-time on initial load directly in week view', fakeAsync(() => {
+      // The issue's actual scenario: component created while already in week
+      // view. Spy on the prototype BEFORE creating the fixture so the
+      // constructor effect's initial run is captured.
+      const scrollSpy = spyOn<any>(
+        ScheduleComponent.prototype,
+        '_scrollIntoViewWithTimeColumnOffset',
+      );
+      const freshFixture = TestBed.createComponent(ScheduleComponent);
+      freshFixture.detectChanges();
+      tick();
+
+      // Viewing today (default: _selectedDate null) → currentTimeRow non-null.
+      expect(scrollSpy).toHaveBeenCalledWith('current-time');
+      freshFixture.destroy();
+    }));
   });
 
   describe('day view toggle rendering', () => {

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1112,7 +1112,7 @@ describe('ScheduleComponent', () => {
     };
 
     it('scrolls to current-time when the current-time indicator is rendered', fakeAsync(() => {
-      const scrollSpy = spyOn<any>(component, '_scrollIntoViewWithTimeColumnOffset');
+      const scrollSpy = spyOn<any>(component, '_scrollAnchorToTop');
       // Viewing today (default: _selectedDate null) → #current-time renders.
       expect(fixture.nativeElement.querySelector('#current-time')).toBeTruthy();
 
@@ -1123,7 +1123,7 @@ describe('ScheduleComponent', () => {
     }));
 
     it('falls back to work-start when the current-time indicator is absent', fakeAsync(() => {
-      const scrollSpy = spyOn<any>(component, '_scrollIntoViewWithTimeColumnOffset');
+      const scrollSpy = spyOn<any>(component, '_scrollAnchorToTop');
       // Viewing a future range without today → currentTimeRow() is null.
       mockScheduleService.getDaysToShow.and.returnValue([
         '2027-06-14',
@@ -1144,10 +1144,7 @@ describe('ScheduleComponent', () => {
       // The issue's actual scenario: component created while already in week
       // view. Spy on the prototype BEFORE creating the fixture so the
       // constructor effect's initial run is captured.
-      const scrollSpy = spyOn<any>(
-        ScheduleComponent.prototype,
-        '_scrollIntoViewWithTimeColumnOffset',
-      );
+      const scrollSpy = spyOn<any>(ScheduleComponent.prototype, '_scrollAnchorToTop');
       const freshFixture = TestBed.createComponent(ScheduleComponent);
       freshFixture.detectChanges();
       tick();
@@ -1181,169 +1178,61 @@ describe('ScheduleComponent', () => {
     });
   });
 
-  describe('scroll target measurement', () => {
-    const TARGET_TOP_PX = 250;
-    // The test grid below is 2880px tall for a 24h day.
-    const PX_PER_MINUTE = 2;
-    const SCROLL_LEAD_MINUTES = 30;
-    let host: HTMLElement;
-    let wrapper: HTMLElement;
+  describe('scroll framing', () => {
+    // Rendered against the real schedule-week DOM and the component's own
+    // styles, so a rename of .week-header or .scroll-wrapper fails here rather
+    // than only in production.
+    const LEAD_FRACTION = 0.12;
 
-    const buildScrollableDom = (scale: string): void => {
-      host = document.createElement('div');
-      // The route enter animation (warpRoute) starts the view at scale(1.2),
-      // and the scroll runs while that is still in flight.
-      host.style.cssText = `position:relative;transform:${scale};transform-origin:top left;`;
-
-      wrapper = document.createElement('div');
-      wrapper.className = 'scroll-wrapper';
-      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
-
-      const spacer = document.createElement('div');
-      spacer.style.cssText = 'height:600px;width:400px;';
-
-      const target = document.createElement('div');
-      target.id = 'test-scroll-target';
-      target.style.cssText = `position:absolute;top:${TARGET_TOP_PX}px;left:0;height:2px;width:10px;`;
-
-      wrapper.append(spacer, target);
-      host.append(wrapper);
-      document.body.append(host);
+    const renderScrollable = (transform: string): HTMLElement => {
+      const host = fixture.nativeElement as HTMLElement;
+      host.style.cssText = `display:block;height:400px;transform:${transform};transform-origin:top left;`;
+      fixture.detectChanges();
+      return host;
     };
 
-    afterEach(() => host?.remove());
+    afterEach(() => ((fixture.nativeElement as HTMLElement).style.cssText = ''));
 
-    it('scrolls to the layout position even while an ancestor is scaled', () => {
-      buildScrollableDom('scale(1.2)');
-      const scrollToSpy = spyOn(wrapper, 'scrollTo');
+    it('lands the current time below the sticky header with a lead above it', () => {
+      const host = renderScrollable('none');
+      const wrapper = host.querySelector('.scroll-wrapper') as HTMLElement;
+      const header = host.querySelector('.week-header') as HTMLElement;
+      const anchor = host.querySelector('#current-time') as HTMLElement;
+      expect(wrapper && header && anchor).toBeTruthy();
 
-      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
+      wrapper.scrollTop = 0;
+      const distanceFromContentTop =
+        anchor.getBoundingClientRect().top - wrapper.getBoundingClientRect().top;
 
-      expect(scrollToSpy).toHaveBeenCalled();
-      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
-      // Rect-based math would return TARGET_TOP_PX * 1.2 here, scrolling the
-      // view roughly two hours past "now".
-      expect(options.top).toBe(TARGET_TOP_PX);
+      component['_scrollAnchorToTop']('current-time');
+
+      const lead = LEAD_FRACTION * wrapper.clientHeight;
+      const maxScrollTop = wrapper.scrollHeight - wrapper.clientHeight;
+      // Within one viewport of the end of the day the browser clamps, and the
+      // lead cannot be honored — anchoring on "now" can't do better there.
+      const expected = Math.min(
+        Math.max(0, distanceFromContentTop - header.offsetHeight - lead),
+        maxScrollTop,
+      );
+      expect(Math.abs(wrapper.scrollTop - expected)).toBeLessThan(2);
     });
 
-    it('leaves 30 minutes of the schedule visible above the target', () => {
-      host = document.createElement('div');
-      host.style.cssText = 'position:relative;';
+    it('lands at the same place while the route enter animation is scaling the view', () => {
+      const plainHost = renderScrollable('none');
+      const plainWrapper = plainHost.querySelector('.scroll-wrapper') as HTMLElement;
+      component['_scrollAnchorToTop']('current-time');
+      const plainTop = plainWrapper.scrollTop;
 
-      wrapper = document.createElement('div');
-      wrapper.className = 'scroll-wrapper';
-      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
+      plainWrapper.scrollTop = 0;
+      // warpRoute starts the view at scale(1.2); the scroll runs on a
+      // setTimeout(0) while that is still in flight.
+      const scaledHost = renderScrollable('scale(1.2)');
+      const scaledWrapper = scaledHost.querySelector('.scroll-wrapper') as HTMLElement;
+      component['_scrollAnchorToTop']('current-time');
 
-      // The grid always spans a full 24h, so its height fixes the pixels-per-
-      // minute scale. 2880px / 1440min = 2px per minute.
-      const grid = document.createElement('div');
-      grid.className = 'grid-container';
-      grid.style.cssText = 'position:relative;height:2880px;width:400px;';
-
-      const target = document.createElement('div');
-      target.id = 'test-scroll-target';
-      target.style.cssText = `position:absolute;top:${TARGET_TOP_PX}px;left:0;height:2px;width:10px;`;
-
-      grid.append(target);
-      wrapper.append(grid);
-      host.append(wrapper);
-      document.body.append(host);
-
-      const scrollToSpy = spyOn(wrapper, 'scrollTo');
-      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
-
-      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
-      const leadPx = SCROLL_LEAD_MINUTES * PX_PER_MINUTE;
-      expect(options.top).toBe(TARGET_TOP_PX - leadPx);
-    });
-
-    it('keeps the full lead visible below the sticky week header', () => {
-      const HEADER_HEIGHT_PX = 33;
-
-      host = document.createElement('div');
-      host.style.cssText = 'position:relative;';
-
-      wrapper = document.createElement('div');
-      wrapper.className = 'scroll-wrapper';
-      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
-
-      const week = document.createElement('schedule-week');
-      week.style.cssText = 'display:block;';
-
-      // Sticky, so it stays over the top of the viewport once scrolled and
-      // covers the first HEADER_HEIGHT_PX of whatever sits below it.
-      const header = document.createElement('div');
-      header.className = 'week-header';
-      header.style.cssText = `position:sticky;top:0;height:${HEADER_HEIGHT_PX}px;width:400px;`;
-
-      const grid = document.createElement('div');
-      grid.className = 'grid-container';
-      grid.style.cssText = 'position:relative;height:2880px;width:400px;';
-
-      const target = document.createElement('div');
-      target.id = 'test-scroll-target';
-      target.style.cssText = `position:absolute;top:${TARGET_TOP_PX}px;left:0;height:2px;width:10px;`;
-
-      grid.append(target);
-      week.append(header, grid);
-      wrapper.append(week);
-      host.append(wrapper);
-      document.body.append(host);
-
-      const scrollToSpy = spyOn(wrapper, 'scrollTo');
-      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
-
-      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
-      const leadPx = SCROLL_LEAD_MINUTES * PX_PER_MINUTE;
-      // The target sits HEADER_HEIGHT_PX further down the flow, and the scroll
-      // pulls back by the same amount, so the lead below the header is the full
-      // 30 minutes. Without the compensation this lands HEADER_HEIGHT_PX lower
-      // and the header covers more than half of that lead.
-      expect(options.top).toBe(TARGET_TOP_PX - leadPx);
-    });
-
-    it('clamps the lead at the top of the day', () => {
-      host = document.createElement('div');
-      host.style.cssText = 'position:relative;';
-
-      wrapper = document.createElement('div');
-      wrapper.className = 'scroll-wrapper';
-      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
-
-      const grid = document.createElement('div');
-      grid.className = 'grid-container';
-      grid.style.cssText = 'position:relative;height:2880px;width:400px;';
-
-      const target = document.createElement('div');
-      target.id = 'test-scroll-target';
-      // 10px into the day, less than the 60px of lead.
-      target.style.cssText = 'position:absolute;top:10px;left:0;height:2px;width:10px;';
-
-      grid.append(target);
-      wrapper.append(grid);
-      host.append(wrapper);
-      document.body.append(host);
-
-      const scrollToSpy = spyOn(wrapper, 'scrollTo');
-      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
-
-      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
-      expect(options.top).toBe(0);
-    });
-
-    it('gives the same target with and without the scale', () => {
-      buildScrollableDom('scale(1.2)');
-      const scaledSpy = spyOn(wrapper, 'scrollTo');
-      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
-      const scaledTop = (scaledSpy.calls.mostRecent().args[0] as ScrollToOptions).top;
-      host.remove();
-
-      buildScrollableDom('none');
-      const plainSpy = spyOn(wrapper, 'scrollTo');
-      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
-      const plainTop = (plainSpy.calls.mostRecent().args[0] as ScrollToOptions).top;
-
-      expect(scaledTop).toBe(plainTop);
+      // Rect-based math landed 20% of the distance from midnight too far —
+      // hundreds of pixels. What is left here is sub-pixel rounding.
+      expect(Math.abs(scaledWrapper.scrollTop - plainTop)).toBeLessThan(2);
     });
   });
 });

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1183,6 +1183,9 @@ describe('ScheduleComponent', () => {
 
   describe('scroll target measurement', () => {
     const TARGET_TOP_PX = 250;
+    // The test grid below is 2880px tall for a 24h day.
+    const PX_PER_MINUTE = 2;
+    const SCROLL_LEAD_MINUTES = 30;
     let host: HTMLElement;
     let wrapper: HTMLElement;
 
@@ -1221,6 +1224,66 @@ describe('ScheduleComponent', () => {
       // Rect-based math would return TARGET_TOP_PX * 1.2 here, scrolling the
       // view roughly two hours past "now".
       expect(options.top).toBe(TARGET_TOP_PX);
+    });
+
+    it('leaves 30 minutes of the schedule visible above the target', () => {
+      host = document.createElement('div');
+      host.style.cssText = 'position:relative;';
+
+      wrapper = document.createElement('div');
+      wrapper.className = 'scroll-wrapper';
+      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
+
+      // The grid always spans a full 24h, so its height fixes the pixels-per-
+      // minute scale. 2880px / 1440min = 2px per minute.
+      const grid = document.createElement('div');
+      grid.className = 'grid-container';
+      grid.style.cssText = 'position:relative;height:2880px;width:400px;';
+
+      const target = document.createElement('div');
+      target.id = 'test-scroll-target';
+      target.style.cssText = `position:absolute;top:${TARGET_TOP_PX}px;left:0;height:2px;width:10px;`;
+
+      grid.append(target);
+      wrapper.append(grid);
+      host.append(wrapper);
+      document.body.append(host);
+
+      const scrollToSpy = spyOn(wrapper, 'scrollTo');
+      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
+
+      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
+      const leadPx = SCROLL_LEAD_MINUTES * PX_PER_MINUTE;
+      expect(options.top).toBe(TARGET_TOP_PX - leadPx);
+    });
+
+    it('clamps the lead at the top of the day', () => {
+      host = document.createElement('div');
+      host.style.cssText = 'position:relative;';
+
+      wrapper = document.createElement('div');
+      wrapper.className = 'scroll-wrapper';
+      wrapper.style.cssText = 'position:relative;overflow:auto;height:100px;width:200px;';
+
+      const grid = document.createElement('div');
+      grid.className = 'grid-container';
+      grid.style.cssText = 'position:relative;height:2880px;width:400px;';
+
+      const target = document.createElement('div');
+      target.id = 'test-scroll-target';
+      // 10px into the day, less than the 60px of lead.
+      target.style.cssText = 'position:absolute;top:10px;left:0;height:2px;width:10px;';
+
+      grid.append(target);
+      wrapper.append(grid);
+      host.append(wrapper);
+      document.body.append(host);
+
+      const scrollToSpy = spyOn(wrapper, 'scrollTo');
+      component['_scrollIntoViewWithTimeColumnOffset']('test-scroll-target');
+
+      const options = scrollToSpy.calls.mostRecent().args[0] as ScrollToOptions;
+      expect(options.top).toBe(0);
     });
 
     it('gives the same target with and without the scale', () => {

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -402,19 +402,25 @@ export class ScheduleComponent {
 
     const timeCol = scrollContainer.querySelector(
       'schedule-week .time-column-bg, schedule-week .filler',
-    );
+    ) as HTMLElement | null;
     // `.filler` is `display:none` in side-panel mode, so a 0-width hit
     // here means we matched the hidden one — fall back to the default.
-    const timeColWidth = timeCol?.getBoundingClientRect().width || 48;
+    const timeColWidth = timeCol?.offsetWidth || 48;
     const EXTRA_PX = 12;
 
-    const elRect = element.getBoundingClientRect();
-    const containerRect = scrollContainer.getBoundingClientRect();
-    const targetTop = scrollContainer.scrollTop + elRect.top - containerRect.top;
+    // Measured via offsetTop/offsetLeft rather than getBoundingClientRect().
+    // Rects are visual coordinates and include any ancestor CSS transform,
+    // while scrollTo() takes layout coordinates. The route enter animation
+    // starts this view at scale(1.2) and the scroll runs on a setTimeout(0),
+    // so rect-based math overshoots by whatever the animation's current scale
+    // happens to be.
+    const elPos = this._layoutOffset(element);
+    const containerPos = this._layoutOffset(scrollContainer);
+    const targetTop = elPos.top - containerPos.top - scrollContainer.clientTop;
     const targetLeft =
-      scrollContainer.scrollLeft +
-      elRect.left -
-      containerRect.left -
+      elPos.left -
+      containerPos.left -
+      scrollContainer.clientLeft -
       timeColWidth -
       EXTRA_PX;
 
@@ -423,6 +429,22 @@ export class ScheduleComponent {
       left: Math.max(0, targetLeft),
       behavior: 'instant',
     });
+  }
+
+  // Position within the offset-parent chain. Unlike getBoundingClientRect(),
+  // this is unaffected by CSS transforms on any ancestor.
+  private _layoutOffset(element: HTMLElement): { top: number; left: number } {
+    let top = 0;
+    let left = 0;
+    let node: HTMLElement | null = element;
+
+    while (node) {
+      top += node.offsetTop;
+      left += node.offsetLeft;
+      node = node.offsetParent as HTMLElement | null;
+    }
+
+    return { top, left };
   }
 
   selectTimeView(view: 'week' | 'month' | 'day'): void {

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   computed,
   effect,
+  ElementRef,
   inject,
   signal,
 } from '@angular/core';
@@ -44,10 +45,6 @@ import { DateTimeFormatService } from '../../../core/date-time-format/date-time-
 import { getWeekNumber } from '../../../util/get-week-number';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
 
-// How much of the schedule before the scroll target stays visible above it.
-const SCROLL_LEAD_MINUTES = 30;
-const MINUTES_PER_DAY = 24 * 60;
-
 @Component({
   selector: 'schedule',
   imports: [
@@ -82,6 +79,7 @@ export class ScheduleComponent {
   private _dateTimeFormatService = inject(DateTimeFormatService);
   private _translate = inject(TranslateService);
   private _hiddenCalendarProviders = inject(HiddenCalendarProvidersService);
+  private _elRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   readonly hiddenCalendarProviderIds = this._hiddenCalendarProviders.hiddenProviderIds;
   readonly enabledCalendarProviders = toSignal(
@@ -396,87 +394,26 @@ export class ScheduleComponent {
     this.isHScrolled.set(el.scrollLeft > 0);
   }
 
-  // Scroll a target element into view inside the scroll-wrapper, but pull
-  // horizontally back by the sticky time column's width (+ a bit extra) so
-  // the target doesn't end up sitting under the time column.
-  private _scrollIntoViewWithTimeColumnOffset(elementId: string): void {
-    const element = document.getElementById(elementId);
-    const scrollContainer = element?.closest('.scroll-wrapper') as HTMLElement | null;
-    if (!element || !scrollContainer) return;
-
-    const timeCol = scrollContainer.querySelector(
-      'schedule-week .time-column-bg, schedule-week .filler',
-    ) as HTMLElement | null;
-    // `.filler` is `display:none` in side-panel mode, so a 0-width hit
-    // here means we matched the hidden one — fall back to the default.
-    const timeColWidth = timeCol?.offsetWidth || 48;
-    const EXTRA_PX = 12;
-
-    // The week header is `position: sticky; top: 0` inside this same scroll
-    // container, so it sits opaque over the top of the viewport and covers
-    // that many pixels of the lead we leave below. Pull the scroll target up
-    // by its height, the vertical counterpart to the time column offset.
-    const stickyHeader = scrollContainer.querySelector(
-      'schedule-week .week-header',
-    ) as HTMLElement | null;
-    const stickyHeaderHeight = stickyHeader?.offsetHeight || 0;
-
-    // Measured via offsetTop/offsetLeft rather than getBoundingClientRect().
-    // Rects are visual coordinates and include any ancestor CSS transform,
-    // while scrollTo() takes layout coordinates. The route enter animation
-    // starts this view at scale(1.2) and the scroll runs on a setTimeout(0),
-    // so rect-based math overshoots by whatever the animation's current scale
-    // happens to be.
-    const elPos = this._layoutOffset(element);
-    const containerPos = this._layoutOffset(scrollContainer);
-    const targetTop =
-      elPos.top -
-      containerPos.top -
-      scrollContainer.clientTop -
-      this._leadPx(element) -
-      stickyHeaderHeight;
-    const targetLeft =
-      elPos.left -
-      containerPos.left -
-      scrollContainer.clientLeft -
-      timeColWidth -
-      EXTRA_PX;
-
-    scrollContainer.scrollTo({
-      top: Math.max(0, targetTop),
-      left: Math.max(0, targetLeft),
-      behavior: 'instant',
-    });
-  }
-
-  // Leave a bit of the preceding schedule visible above the target, so it reads
-  // as "now, in context" rather than the day being cut off at the top.
+  // Scroll one of the schedule's time anchors to the top of the scroll-wrapper.
   //
-  // Measured from the rendered grid, which always spans exactly 24h, rather
-  // than from the row height: rows are shorter on mobile, so a fixed pixel
-  // amount would mean a different number of minutes per breakpoint.
-  private _leadPx(element: HTMLElement): number {
-    const grid = element.closest('.grid-container') as HTMLElement | null;
-    const dayHeight = grid?.offsetHeight;
-    if (!dayHeight) return 0;
+  // The framing (lead above the target, and clearance for the sticky time
+  // column and week header) lives in CSS as scroll-padding on .scroll-wrapper,
+  // next to the row-height and column-width variables it is derived from.
+  //
+  // scrollIntoView is used rather than scrollTo with measured offsets because
+  // it resolves the target in layout coordinates: the route enter animation
+  // (warpRoute) starts this view at scale(1.2) and the scroll runs on a
+  // setTimeout(0), so anything measured from getBoundingClientRect() while that
+  // is in flight overshoots by the animation's current scale.
+  //
+  // The lookup is scoped to this component's own element: the right panel
+  // embeds a second schedule-week that renders its own #current-time.
+  private _scrollAnchorToTop(elementId: string): void {
+    const element = this._elRef.nativeElement.querySelector(
+      `#${elementId}`,
+    ) as HTMLElement | null;
 
-    return (dayHeight / MINUTES_PER_DAY) * SCROLL_LEAD_MINUTES;
-  }
-
-  // Position within the offset-parent chain. Unlike getBoundingClientRect(),
-  // this is unaffected by CSS transforms on any ancestor.
-  private _layoutOffset(element: HTMLElement): { top: number; left: number } {
-    let top = 0;
-    let left = 0;
-    let node: HTMLElement | null = element;
-
-    while (node) {
-      top += node.offsetTop;
-      left += node.offsetLeft;
-      node = node.offsetParent as HTMLElement | null;
-    }
-
-    return { top, left };
+    element?.scrollIntoView({ block: 'start', inline: 'start', behavior: 'instant' });
   }
 
   selectTimeView(view: 'week' | 'month' | 'day'): void {
@@ -502,7 +439,7 @@ export class ScheduleComponent {
         // 2-minute refresh tick would re-run this effect and yank the scroll
         // position while the user is reading the schedule.
         setTimeout(() =>
-          this._scrollIntoViewWithTimeColumnOffset(
+          this._scrollAnchorToTop(
             this.currentTimeRow() !== null ? 'current-time' : 'work-start',
           ),
         );

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -412,6 +412,15 @@ export class ScheduleComponent {
     const timeColWidth = timeCol?.offsetWidth || 48;
     const EXTRA_PX = 12;
 
+    // The week header is `position: sticky; top: 0` inside this same scroll
+    // container, so it sits opaque over the top of the viewport and covers
+    // that many pixels of the lead we leave below. Pull the scroll target up
+    // by its height, the vertical counterpart to the time column offset.
+    const stickyHeader = scrollContainer.querySelector(
+      'schedule-week .week-header',
+    ) as HTMLElement | null;
+    const stickyHeaderHeight = stickyHeader?.offsetHeight || 0;
+
     // Measured via offsetTop/offsetLeft rather than getBoundingClientRect().
     // Rects are visual coordinates and include any ancestor CSS transform,
     // while scrollTo() takes layout coordinates. The route enter animation
@@ -421,7 +430,11 @@ export class ScheduleComponent {
     const elPos = this._layoutOffset(element);
     const containerPos = this._layoutOffset(scrollContainer);
     const targetTop =
-      elPos.top - containerPos.top - scrollContainer.clientTop - this._leadPx(element);
+      elPos.top -
+      containerPos.top -
+      scrollContainer.clientTop -
+      this._leadPx(element) -
+      stickyHeaderHeight;
     const targetLeft =
       elPos.left -
       containerPos.left -

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -44,6 +44,10 @@ import { DateTimeFormatService } from '../../../core/date-time-format/date-time-
 import { getWeekNumber } from '../../../util/get-week-number';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
 
+// How much of the schedule before the scroll target stays visible above it.
+const SCROLL_LEAD_MINUTES = 30;
+const MINUTES_PER_DAY = 24 * 60;
+
 @Component({
   selector: 'schedule',
   imports: [
@@ -416,7 +420,8 @@ export class ScheduleComponent {
     // happens to be.
     const elPos = this._layoutOffset(element);
     const containerPos = this._layoutOffset(scrollContainer);
-    const targetTop = elPos.top - containerPos.top - scrollContainer.clientTop;
+    const targetTop =
+      elPos.top - containerPos.top - scrollContainer.clientTop - this._leadPx(element);
     const targetLeft =
       elPos.left -
       containerPos.left -
@@ -429,6 +434,20 @@ export class ScheduleComponent {
       left: Math.max(0, targetLeft),
       behavior: 'instant',
     });
+  }
+
+  // Leave a bit of the preceding schedule visible above the target, so it reads
+  // as "now, in context" rather than the day being cut off at the top.
+  //
+  // Measured from the rendered grid, which always spans exactly 24h, rather
+  // than from the row height: rows are shorter on mobile, so a fixed pixel
+  // amount would mean a different number of minutes per breakpoint.
+  private _leadPx(element: HTMLElement): number {
+    const grid = element.closest('.grid-container') as HTMLElement | null;
+    const dayHeight = grid?.offsetHeight;
+    if (!dayHeight) return 0;
+
+    return (dayHeight / MINUTES_PER_DAY) * SCROLL_LEAD_MINUTES;
   }
 
   // Position within the offset-parent chain. Unlike getBoundingClientRect(),

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -442,8 +442,16 @@ export class ScheduleComponent {
 
     effect(() => {
       if (this.isMonthView() === false) {
-        // scroll to work start whenever view is switched to work-week
-        setTimeout(() => this._scrollIntoViewWithTimeColumnOffset('work-start'));
+        // prefer the current time when it is visible (today is in range),
+        // otherwise fall back to work start. NOTE: the signal read must stay
+        // inside the setTimeout so it is untracked — otherwise currentTimeRow's
+        // 2-minute refresh tick would re-run this effect and yank the scroll
+        // position while the user is reading the schedule.
+        setTimeout(() =>
+          this._scrollIntoViewWithTimeColumnOffset(
+            this.currentTimeRow() !== null ? 'current-time' : 'work-start',
+          ),
+        );
       }
     });
   }


### PR DESCRIPTION
## Problem

Fixes #9417

Opening the schedule view lands at midnight (or at the work start time when that setting is enabled) instead of the current time. When "work start/end" isn't configured, the scroll-on-open silently no-ops because the `#work-start` anchor element is never rendered, so the view sits at 12am and the user has to scroll down to now every time.

## Solution

The scroll-on-open effect in `schedule.component.ts` now prefers the current time indicator whenever today is in the visible range, and only falls back to the work start anchor otherwise (for example after navigating to a week that doesn't include today).

The target choice derives from the component's own `currentTimeRow()` signal rather than a DOM query, which keeps the decision consistent with what `schedule-week` actually renders (the `#current-time` element is guarded by exactly `currentTimeRow() !== null`). The signal read stays inside the `setTimeout` so it remains untracked; otherwise the 2-minute refresh tick would re-run the effect and yank the scroll position while reading the schedule (noted in a comment). The lookup is scoped to the component's own host element, so the duplicate `#current-time` rendered by the right panel's embedded schedule is excluded by construction rather than by DOM order.

The scroll itself is `scrollIntoView({ block: 'start', inline: 'start' })`, and all of the framing lives in CSS as `scroll-padding` on `.scroll-wrapper`:

- **Transform immunity.** The `warpRoute` enter animation starts the view at `scale(1.2)` and the scroll runs on a `setTimeout(0)`, so anything measured from `getBoundingClientRect()` while that is in flight overshoots by the animation's current scale. `scrollIntoView` resolves the target in layout coordinates and is immune to this on its own, so no manual measurement is needed.
- **Lead above the target.** `scroll-padding-top` leaves a slice of the preceding schedule visible above the target, as a fraction of the scroll viewport rather than a fixed number of minutes. A constant reads very differently across breakpoints (30 minutes is ~5% of a desktop viewport but ~10% of a phone one); 12% is roughly an hour on desktop and stays proportional elsewhere. The sticky week header's height folds into the same value.
- **Time column clearance.** `scroll-padding-left` keeps the target clear of the sticky time column, replacing a DOM probe for its width.

Two specs run against the rendered `schedule-week`: one asserts the anchor lands below the sticky header with the lead above it, measured from the real DOM, and one asserts the landing position is unchanged under an ancestor `scale(1.2)`.

### Behavior notes

Within one viewport of the end of the day the browser clamps the scroll and the lead can't be honored — inherent to anchoring on "now", and accepted deliberately rather than papered over with a larger constant. Padding the grid to avoid it would make the scrollbar misrepresent how much day is left in every other interaction with the view. When today is visible but it's before work start, the view still anchors on now (fewer branches, and work start is in the viewport either way).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing setting or API change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
