### PR TITLE
fix(task): keep selected task box within the list container #9540

### DIFF
--- a/src/app/features/tasks/task/_task-base.scss
+++ b/src/app/features/tasks/task/_task-base.scss
@@ -128,12 +128,6 @@
   :host.isSelected.isSelected .inner-wrapper > &,
   :host.isSelected.isCurrent.isCurrent.isCurrent.isCurrent & {
     @include mq(xs) {
-      right: -34px;
-    }
-    @include mq(md) {
-      right: -234px;
-    }
-    @include mq(xl) {
       right: calc(-1 * var(--task-border-radius));
     }
   }


### PR DESCRIPTION
## Problem

Fixes #9540

When a task is selected and the right detail panel is open, the selected task's box extends far past the right edge of the task list. At common desktop widths (600px to 2000px viewport) the box is widened by fixed offsets (`right: -34px` / `right: -234px`) that date back to 2020, when the detail panel was an overlay and the extended box "tucked under" it to look connected.

The panel has since become a resizable flex sibling that squeezes the content area, so no fixed offset can line up with it anymore. The result is the selected task jutting ~230px past every other row. In the Today view the parent has `overflow-x: hidden`, so it presents as the box running off the list edge (or under the panel) rather than a scrollbar.

The "exceeds its time estimate" step in the issue repro is incidental. The trigger is simply a selected task with the panel open at these widths.

## Solution

Remove the stale magic offsets and use the same `right: calc(-1 * var(--task-border-radius))` the rule already applied at very large screens (and which the `isCurrent` rule uses for both edges). The selected rule already sets `left: calc(-1 * var(--task-border-radius))`, so this also makes the selected box symmetric instead of asymmetric.

Net 6-line deletion, no TS/template changes. Note `mq(xs)` is min-width 600px, so sub-600px mobile layouts never hit the removed rules and are unaffected.

Verified locally (ng serve, dark theme, Today view, 1500px window): before, the selected box ran ~90px under the open panel; after, it ends flush with the list container. Grepped the codebase for anything referencing the removed offsets: no other rule depends on them.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing behaviour or API change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) — n/a, SCSS-only change with no unit-testable surface
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

