### PR TITLE
fix(ui): preserve time input editing state

### DIFF
--- a/src/app/ui/input-time/input-time.directive.spec.ts
+++ b/src/app/ui/input-time/input-time.directive.spec.ts
@@ -35,6 +35,14 @@ describe('InputTimeDirective', () => {
       expect(nativeElement.value).toBe('17:00');
     });
 
+    it('does not rewrite an identical value', () => {
+      nativeElement.value = '17:00';
+
+      directive.writeValue('17:00');
+
+      expect(renderer.setProperty).not.toHaveBeenCalled();
+    });
+
     it('clears the display for an empty/invalid value', () => {
       directive.writeValue(null);
       expect(nativeElement.value).toBe('');

--- a/src/app/ui/input-time/input-time.directive.ts
+++ b/src/app/ui/input-time/input-time.directive.ts
@@ -53,11 +53,11 @@ export class InputTimeDirective implements ControlValueAccessor {
   }
 
   writeValue(value: string | null): void {
-    this._renderer.setProperty(
-      this._elementRef.nativeElement,
-      'value',
-      toPaddedClockStr(value),
-    );
+    const normalizedValue = toPaddedClockStr(value);
+    if (this._elementRef.nativeElement.value === normalizedValue) {
+      return;
+    }
+    this._renderer.setProperty(this._elementRef.nativeElement, 'value', normalizedValue);
   }
 
   registerOnChange(fn: (value: string) => void): void {


### PR DESCRIPTION
## Summary

- avoid rewriting a native time input when its normalized value is already displayed
- preserve Chrome's active hour/minute editing segment across Formly model feedback
- add a regression test for identical value writes

## Root cause

`InputTimeDirective` emits after every digit. Formly immediately writes the same value back through `writeValue()`. Assigning that identical value to the native input resets Chrome's active time segment, so typing `18` into the hour field produced `08`.

## Verification

- `npm run test:file -- src/app/ui/input-time/input-time.directive.spec.ts --include src/app/ui/input-time/input-time-formly/input-time-formly.component.spec.ts` — 13/13 passed
- `npm run checkFile src/app/ui/input-time/input-time.directive.ts` — passed
- `npm run checkFile src/app/ui/input-time/input-time.directive.spec.ts` — passed
- repository pre-commit lint — passed (existing warnings only)
- real Chrome reproduction: typing hour `18`, moving to minutes, then typing `30` now results in `18:30`
- independent code review — no findings

Full `npm test` note: all package suites passed (765 tests) and release-note tests passed (24 tests). The Angular suite later hit two unrelated SQLite 2-second timeouts and Chrome crashed/disconnected after 12,792/14,127 tests. The focused affected suites pass.

Closes #9548
