### PR TITLE
fix(task): unique icons for move-to-bottom and move-to-backlog

### DIFF
--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
@@ -237,7 +237,7 @@
       mat-menu-item
     >
       <span class="menuItemLeft">
-        <mat-icon>arrow_downward</mat-icon>
+        <mat-icon>list_alt</mat-icon>
         {{ T.F.TASK.CMP.MOVE_TO_BACKLOG | translate }}
       </span>
       <span class="key-i">{{ kb.moveToBacklog }}</span>

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
@@ -237,7 +237,7 @@
       mat-menu-item
     >
       <span class="menuItemLeft">
-        <mat-icon>list_alt</mat-icon>
+        <mat-icon>move_down</mat-icon>
         {{ T.F.TASK.CMP.MOVE_TO_BACKLOG | translate }}
       </span>
       <span class="key-i">{{ kb.moveToBacklog }}</span>
@@ -255,7 +255,7 @@
       mat-menu-item
     >
       <span class="menuItemLeft">
-        <mat-icon>arrow_upward</mat-icon>
+        <mat-icon>move_up</mat-icon>
         {{ T.F.TASK.CMP.MOVE_TO_REGULAR | translate }}
       </span>
       <!-- No shortcut hint: taskScheduleToday (Shift+T) schedules for today and


### PR DESCRIPTION
# Problem

The `MOVE_TO_BOTTOM` and `MOVE_TO_BACKLOG` icons are the same, creating visual confusion.

## Solution

- Let `MOVE_TO_BOTTOM` have the arrow_downward icon since it pairs with `MOVE_TO_TOP`
- Use a unique icon for `MOVE_TO_BACKLOG`

<img width="394" height="395" alt="image" src="https://github.com/user-attachments/assets/72564cc6-20e1-4167-bfd4-a4a8a50d080f" />


## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [X] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [X] I have added tests for my changes (if applicable)
- [X] Existing tests still pass
- [X] My commit messages follow the Angular format (`type(scope): description`)
