### PR TITLE
fix(sync): resolve bulk archive conflicts via scoped replacement (#9537)

### DIFF
--- a/e2e/tests/sync/supersync-archive-conflict.spec.ts
+++ b/e2e/tests/sync/supersync-archive-conflict.spec.ts
@@ -165,6 +165,140 @@ test.describe('@supersync Archive Conflict Resolution', () => {
   });
 
   /**
+   * Test C: archive-vs-archive — both clients bulk-archive overlapping tasks
+   * ("Finish day" on two devices, #9537).
+   *
+   * Scenario:
+   * 1. Client A creates T1, T2, T3, syncs
+   * 2. Client B syncs (gets all three)
+   * 3. Client B marks T1 done, archives it, syncs (uploads its own archive op)
+   * 4. Client A — WS-blocked, unaware — marks ALL THREE done and archives them
+   *    in ONE atomic bulk moveToArchive
+   * 5. Client A syncs: its bulk archive loses T1 to B's remote archive. The
+   *    scoped replacement must re-upload T2+T3's archival instead of wedging
+   *    sync forever with SYNC_MULTI_ENTITY_UNSUPPORTED (#9537)
+   * 6. Client B syncs (downloads the replacement)
+   *
+   * Expected: no active tasks on either client; ALL THREE tasks in BOTH
+   * worklogs. T2/T3 in Client B's worklog is the load-bearing assertion —
+   * they can only arrive via the scoped replacement op.
+   */
+  test('bulk archive resolves when both clients archived an overlapping task @supersync', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    const uniqueId = Date.now();
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      // ============ PHASE 1: Client A creates three tasks and syncs ============
+      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      const task1Name = `ArchVsArch-T1-${uniqueId}`;
+      const task2Name = `ArchVsArch-T2-${uniqueId}`;
+      const task3Name = `ArchVsArch-T3-${uniqueId}`;
+
+      await clientA.workView.addTask(task1Name);
+      await clientA.workView.addTask(task2Name);
+      await clientA.workView.addTask(task3Name);
+      console.log(`[ArchVsArch] Client A created tasks T1, T2, T3`);
+
+      await clientA.sync.syncAndWait();
+      console.log('[ArchVsArch] Client A synced (uploaded tasks)');
+
+      // ============ PHASE 2: Client B downloads tasks ============
+      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
+      await clientB.sync.setupSuperSync(syncConfig);
+      await clientB.sync.syncAndWait();
+
+      await waitForTask(clientB.page, task1Name);
+      await waitForTask(clientB.page, task2Name);
+      await waitForTask(clientB.page, task3Name);
+      console.log('[ArchVsArch] Client B received all three tasks');
+
+      // Block WS-triggered downloads on Client A so it doesn't auto-receive
+      // B's archive before Phase 4 (we want a true concurrent archive race)
+      await clientA.page.evaluate(
+        () => ((globalThis as any).__SP_E2E_BLOCK_WS_DOWNLOAD = true),
+      );
+
+      // ============ PHASE 3: Client B archives the overlapping task ============
+      await markTaskDoneByKey(clientB, task1Name);
+      await archiveDoneTasks(clientB);
+      console.log('[ArchVsArch] Client B archived T1');
+
+      await clientB.sync.syncAndWait();
+      console.log('[ArchVsArch] Client B synced (uploaded its archive op)');
+
+      // ============ PHASE 4: Client A bulk-archives ALL THREE ============
+      // Client A never received B's archive: T1 is still active here, so the
+      // finish-day style bulk covers T1, T2 and T3 in one atomic op.
+      await markTaskDoneByKey(clientA, task1Name);
+      await markTaskDoneByKey(clientA, task2Name);
+      await markTaskDoneByKey(clientA, task3Name);
+      await archiveDoneTasks(clientA);
+      console.log('[ArchVsArch] Client A bulk-archived T1+T2+T3');
+
+      // ============ PHASE 5: Client A syncs (archive-vs-archive conflict) ====
+      await clientA.page.evaluate(
+        () => ((globalThis as any).__SP_E2E_BLOCK_WS_DOWNLOAD = false),
+      );
+      await clientA.sync.syncAndWait();
+      console.log('[ArchVsArch] Client A synced (conflict resolved, no wedge)');
+
+      // Second sync uploads the scoped replacement created by resolution
+      await clientA.sync.syncAndWait();
+      console.log('[ArchVsArch] Client A synced again (uploaded replacement)');
+
+      // ============ PHASE 6: Client B syncs to receive the replacement ======
+      await clientB.sync.syncAndWait();
+
+      // Extra sync round for convergence
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      console.log('[ArchVsArch] Extra sync round for convergence');
+
+      // ============ PHASE 7: Verify tasks NOT in active task list ============
+      await navigateToWorkView(clientA);
+      await navigateToWorkView(clientB);
+
+      await expectTaskNotVisible(clientA, task1Name);
+      await expectTaskNotVisible(clientA, task2Name);
+      await expectTaskNotVisible(clientA, task3Name);
+      console.log('[ArchVsArch] Client A: no tasks in active list');
+
+      await expectTaskNotVisible(clientB, task1Name);
+      await expectTaskNotVisible(clientB, task2Name);
+      await expectTaskNotVisible(clientB, task3Name);
+      console.log('[ArchVsArch] Client B: no tasks in active list');
+
+      // ============ PHASE 8: Verify ALL tasks IN worklog on BOTH clients =====
+      await expectTaskInWorklog(clientA, task1Name);
+      await expectTaskInWorklog(clientA, task2Name);
+      await expectTaskInWorklog(clientA, task3Name);
+      console.log('[ArchVsArch] Client A: all three tasks in worklog');
+
+      // T2/T3 here prove the scoped replacement arrived — without it Client B
+      // would keep them active forever (or, pre-fix, sync would wedge).
+      await expectTaskInWorklog(clientB, task1Name);
+      await expectTaskInWorklog(clientB, task2Name);
+      await expectTaskInWorklog(clientB, task3Name);
+      console.log('[ArchVsArch] Client B: all three tasks in worklog');
+
+      console.log('[ArchVsArch] ✓ Test C passed: overlapping bulk archives converged');
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+
+  /**
    * Test B: LWW Update does not resurrect archived tasks (Bug B)
    *
    * Scenario:

--- a/e2e/tests/sync/supersync-archive-conflict.spec.ts
+++ b/e2e/tests/sync/supersync-archive-conflict.spec.ts
@@ -246,6 +246,9 @@ test.describe('@supersync Archive Conflict Resolution', () => {
       console.log('[ArchVsArch] Client A bulk-archived T1+T2+T3');
 
       // ============ PHASE 5: Client A syncs (archive-vs-archive conflict) ====
+      // (The WS transport stays blocked by the harness either way — flipping
+      // the flag only mirrors sibling Test A's choreography; determinism comes
+      // from the harness's blocked immediate-upload/auto-sync + explicit syncs.)
       await clientA.page.evaluate(
         () => ((globalThis as any).__SP_E2E_BLOCK_WS_DOWNLOAD = false),
       );
@@ -273,9 +276,12 @@ test.describe('@supersync Archive Conflict Resolution', () => {
       await expectTaskNotVisible(clientA, task3Name);
       console.log('[ArchVsArch] Client A: no tasks in active list');
 
-      await expectTaskNotVisible(clientB, task1Name);
-      await expectTaskNotVisible(clientB, task2Name);
-      await expectTaskNotVisible(clientB, task3Name);
+      // Client B archives T2/T3 through the async remote-apply pipeline —
+      // give it the same extended window sibling Test B documents (15s).
+      const archivedAssertionTimeout = 15000;
+      await expectTaskNotVisible(clientB, task1Name, archivedAssertionTimeout);
+      await expectTaskNotVisible(clientB, task2Name, archivedAssertionTimeout);
+      await expectTaskNotVisible(clientB, task3Name, archivedAssertionTimeout);
       console.log('[ArchVsArch] Client B: no tasks in active list');
 
       // ============ PHASE 8: Verify ALL tasks IN worklog on BOTH clients =====

--- a/e2e/tests/sync/supersync-archive-conflict.spec.ts
+++ b/e2e/tests/sync/supersync-archive-conflict.spec.ts
@@ -246,9 +246,9 @@ test.describe('@supersync Archive Conflict Resolution', () => {
       console.log('[ArchVsArch] Client A bulk-archived T1+T2+T3');
 
       // ============ PHASE 5: Client A syncs (archive-vs-archive conflict) ====
-      // (The WS transport stays blocked by the harness either way — flipping
-      // the flag only mirrors sibling Test A's choreography; determinism comes
-      // from the harness's blocked immediate-upload/auto-sync + explicit syncs.)
+      // (Flipping the flag mirrors sibling Test A's choreography; the
+      // harness's WS route-block plus blocked immediate-upload/auto-sync and
+      // the explicit syncs are what keep this race deterministic.)
       await clientA.page.evaluate(
         () => ((globalThis as any).__SP_E2E_BLOCK_WS_DOWNLOAD = false),
       );

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -3481,6 +3481,159 @@ describe('ConflictResolutionService', () => {
         ).toBe(VectorClockComparison.GREATER_THAN);
       });
 
+      it('narrows payload tasks AND entityChanges when scoping a partially rejected bulk archive', async () => {
+        // Capture emits entityChanges: [] for moveToArchive today, but the
+        // scoping must narrow whatever a legacy/peer row carries — this pins
+        // the filter with a synthetic non-empty fixture (#9537).
+        const localBulkArchive: Operation = {
+          ...createOpWithTimestamp(
+            'local-archive-multiple',
+            'client-a',
+            1000,
+            OpType.Update,
+            'task-1',
+          ),
+          actionType: ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+          entityIds: ['task-1', 'task-2'],
+          payload: {
+            actionPayload: {
+              tasks: [
+                { id: 'task-1', title: 'Task one', subTasks: [] },
+                {
+                  id: 'task-2',
+                  title: 'Task two',
+                  subTasks: [{ id: 'task-2-child', parentId: 'task-2', title: 'Child' }],
+                },
+              ],
+            },
+            entityChanges: [
+              {
+                entityType: 'TASK',
+                entityId: 'task-1',
+                opType: OpType.Update,
+                changes: {},
+              },
+              {
+                entityType: 'TASK',
+                entityId: 'task-2',
+                opType: OpType.Update,
+                changes: {},
+              },
+            ],
+          },
+        };
+        const remoteArchive: Operation = {
+          ...createOpWithTimestamp(
+            'remote-archive-task-1',
+            'client-b',
+            2000,
+            OpType.Update,
+            'task-1',
+          ),
+          actionType: ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+          payload: {
+            actionPayload: {
+              tasks: [{ id: 'task-1', title: 'Remote snapshot', subTasks: [] }],
+            },
+            entityChanges: [],
+          },
+        };
+        mockOperationApplier.applyOperations.and.callFake(async (ops, options) => {
+          await options?.onReducersCommitted?.(ops);
+          return { appliedOps: ops };
+        });
+
+        const result = await service.autoResolveConflictsLWW([
+          createConflict('task-1', [localBulkArchive], [remoteArchive]),
+        ]);
+
+        const replacement = getFirstMixedLocalOp();
+        expect(result.localWinOpsCreated).toBe(1);
+        expect(replacement.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
+        expect(replacement.entityId).toBe('task-2');
+        expect(replacement.entityIds).toEqual(['task-2']);
+        expect(
+          (
+            extractActionPayload(replacement.payload)['tasks'] as Array<{
+              id: string;
+              subTasks?: Array<{ id: string }>;
+            }>
+          ).map(({ id }) => id),
+        ).toEqual(['task-2']);
+        // The retained parent keeps its nested subtasks.
+        expect(
+          (
+            extractActionPayload(replacement.payload)['tasks'] as Array<{
+              subTasks?: Array<{ id: string }>;
+            }>
+          )[0].subTasks?.map(({ id }) => id),
+        ).toEqual(['task-2-child']);
+        expect(
+          (
+            replacement.payload as { entityChanges?: Array<{ entityId: string }> }
+          ).entityChanges?.map(({ entityId }) => entityId),
+        ).toEqual(['task-2']);
+        expect(
+          compareVectorClocks(replacement.vectorClock, localBulkArchive.vectorClock),
+        ).toBe(VectorClockComparison.GREATER_THAN);
+        expect(
+          compareVectorClocks(replacement.vectorClock, remoteArchive.vectorClock),
+        ).toBe(VectorClockComparison.GREATER_THAN);
+      });
+
+      it('scopes a legacy flat-payload bulk archive without inventing a MultiEntityPayload wrapper', async () => {
+        const localBulkArchive: Operation = {
+          ...createOpWithTimestamp(
+            'local-archive-flat',
+            'client-a',
+            1000,
+            OpType.Update,
+            'task-1',
+          ),
+          actionType: ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+          entityIds: ['task-1', 'task-2'],
+          // Legacy flat shape: the action payload IS the op payload.
+          payload: {
+            tasks: [
+              { id: 'task-1', title: 'Task one', subTasks: [] },
+              { id: 'task-2', title: 'Task two', subTasks: [] },
+            ],
+          },
+        };
+        const remoteArchive: Operation = {
+          ...createOpWithTimestamp(
+            'remote-archive-task-1-flat',
+            'client-b',
+            2000,
+            OpType.Update,
+            'task-1',
+          ),
+          actionType: ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+          payload: {
+            actionPayload: {
+              tasks: [{ id: 'task-1', title: 'Remote snapshot', subTasks: [] }],
+            },
+            entityChanges: [],
+          },
+        };
+        mockOperationApplier.applyOperations.and.callFake(async (ops, options) => {
+          await options?.onReducersCommitted?.(ops);
+          return { appliedOps: ops };
+        });
+
+        await service.autoResolveConflictsLWW([
+          createConflict('task-1', [localBulkArchive], [remoteArchive]),
+        ]);
+
+        const replacement = getFirstMixedLocalOp();
+        expect(replacement.entityIds).toEqual(['task-2']);
+        const payload = replacement.payload as Record<string, unknown>;
+        expect('actionPayload' in payload).toBe(false);
+        expect((payload['tasks'] as Array<{ id: string }>).map(({ id }) => id)).toEqual([
+          'task-2',
+        ]);
+      });
+
       it('preserves unaffected siblings from non-task bulk deletes', async () => {
         const localBulkDelete: Operation = {
           ...createOpWithTimestamp(

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -3592,7 +3592,10 @@ describe('ConflictResolutionService', () => {
           ),
           actionType: ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
           entityIds: ['task-1', 'task-2'],
-          // Legacy flat shape: the action payload IS the op payload.
+          // Legacy flat shape: the action payload IS the op payload (still
+          // accepted by extractActionPayload / payload validation). NOTE: the
+          // flat-payload + populated-entityIds combination is a defensive
+          // hybrid — scoping requires entityIds regardless of payload era.
           payload: {
             tasks: [
               { id: 'task-1', title: 'Task one', subTasks: [] },

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -2428,7 +2428,10 @@ export class ConflictResolutionService {
       // overlapping a bulk delete, would make the per-op scoped replacements
       // re-assert contradictory or superseded intents with no cross-op
       // ordering — one op's uniquely-retained tasks could silently never
-      // upload. Keep the safe stop for those degenerate histories.
+      // upload. Keep the safe stop for those degenerate histories. (Scope
+      // caveat: this sees only ops sharing THIS row's conflicted task — an
+      // overlap confined to non-conflicted siblings passes and resolves
+      // per-op, which can re-assert the older op's stale sibling snapshot.)
       const localBulkArchiveOps = plan.conflict.localOps.filter(
         (op) =>
           isMultiEntityOperation(op) &&
@@ -3153,11 +3156,15 @@ export class ConflictResolutionService {
    * remote-archived tasks' stale local snapshots.
    *
    * Retained tasks that are back in the ACTIVE store (restored after the bulk
-   * archive was captured) are dropped from the replacement — their later
-   * pending ops are authoritative. Degenerate multi-bulk histories (two
-   * pending bulk archives sharing a task, bulk archive overlapping a bulk
-   * delete) never reach this method: `_assertMultiEntityPlansAreSafe` keeps
-   * the fail-closed stop for them.
+   * archive was captured) are dropped from the replacement; when such a task's
+   * own row won locally, a current-state compensation op re-asserts the
+   * restore (the row rejection discards the raw restoreTask op with the row).
+   * Degenerate multi-bulk histories (two pending bulk archives, or a bulk
+   * archive plus a bulk delete, sharing a CONFLICTED task) never reach this
+   * method: `_assertMultiEntityPlansAreSafe` keeps the fail-closed stop for
+   * them. Overlaps confined to non-conflicted siblings still flow through
+   * per-op and can re-assert a stale snapshot — a pre-existing hazard of the
+   * whole preserve/recreate family, shared with `_createArchiveWinOp`.
    */
   private async _preservePartiallyRejectedLocalBulkArchives(
     resolutions: LWWResolution[],
@@ -3217,29 +3224,40 @@ export class ConflictResolutionService {
       }
 
       // With nothing left to re-assert, the replacement is skipped entirely —
-      // but any archive-win row still holding the FULL-SET recreation must
-      // drop it too (winner stays local, remote loser rows stay rejected;
-      // same shape as archive-sibling rows with `localWinOp: undefined`).
+      // any archive-win row still holding the FULL-SET recreation is handled
+      // per-row below.
       const replacementOp =
         stillArchivedEntityIds.length > 0
           ? await this._createScopedBulkArchiveReplacement(group, stillArchivedEntityIds)
           : undefined;
+      const stillArchivedEntityIdSet = new Set(stillArchivedEntityIds);
       let assignedToLocalWinner = false;
       for (const resolution of group.resolutions) {
         if (
-          resolution.winner === 'local' &&
-          resolution.localWinOp?.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
+          resolution.winner !== 'local' ||
+          resolution.localWinOp?.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE ||
           // Provenance binding: only swap a recreation built from THIS
           // group's op (`_createArchiveWinOp` reuses the payload reference).
           // A recreation derived from a different pending archive op must
           // stay untouched, or its group's replacement would be lost.
-          resolution.localWinOp.payload === group.archiveOp.payload
+          resolution.localWinOp.payload !== group.archiveOp.payload
         ) {
-          resolution.localWinOp = replacementOp;
-          if (replacementOp) {
-            assignedToLocalWinner = true;
-          }
+          continue;
         }
+        if (replacementOp && stillArchivedEntityIdSet.has(resolution.conflict.entityId)) {
+          resolution.localWinOp = replacementOp;
+          assignedToLocalWinner = true;
+          continue;
+        }
+        // The row's own task was restored after the bulk archive: its archive
+        // intent is obsolete, but the row still resolves winner=local and ALL
+        // its raw local ops — including the pending restoreTask op — are
+        // rejected with it. A bare undefined localWinOp would lose the
+        // restore fleet-wide (nothing re-asserts the entity) and wedge the
+        // mixed-winner compensation when the row's remote loser is a
+        // multi-entity op, so re-assert the CURRENT active state — the
+        // restore's outcome — as the row's local-win op instead.
+        resolution.localWinOp = await this._createLocalWinUpdateOp(resolution.conflict);
       }
       if (replacementOp && !assignedToLocalWinner) {
         additionalOps.push(replacementOp);

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -948,6 +948,7 @@ export class ConflictResolutionService {
     const additionalLocalIntentOps = [
       ...(await this._preservePartiallyRejectedLocalBulkDeletes(resolutions)),
       ...(await this._preservePartiallyRejectedLocalBulkPlanOps(resolutions)),
+      ...(await this._preservePartiallyRejectedLocalBulkArchives(resolutions)),
     ];
 
     const allOpsToApply: Operation[] = [];
@@ -2371,9 +2372,12 @@ export class ConflictResolutionService {
 
   /**
    * Generic multi-entity operations cannot be partially compensated safely.
-   * Fail before op-log mutation unless the winner removes the whole remote set,
-   * a local archive is re-created as the same atomic action, or the local legacy
-   * rounding action has an explicit per-entity reconciliation path above.
+   * Fail before op-log mutation unless every multi-entity op in the plan has an
+   * explicit resolution path: bulk archives are re-created when they win
+   * (`_createArchiveWinOp`) or re-scoped to the tasks no remote archive covered
+   * when they lose (`_preservePartiallyRejectedLocalBulkArchives`, #9537),
+   * independent bulk deletes are re-scoped, and the local legacy rounding
+   * action has an explicit per-entity reconciliation path above.
    *
    * The Today-list ops that used to make this reachable from ordinary use —
    * `planTasksForToday` (dispatched with every due task id by the automatic
@@ -2402,21 +2406,14 @@ export class ConflictResolutionService {
         );
       }
 
-      const localMultiOps = plan.conflict.localOps.filter(isMultiEntityOperation);
-      const localArchiveIsRecreated =
-        plan.winner === 'local' &&
-        plan.localWinOperationKind === 'archive-win' &&
-        localMultiOps.every(
-          (op) => op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
-        );
-      const unsafeLocalOp = localArchiveIsRecreated
-        ? undefined
-        : localMultiOps.find(
-            (op) =>
-              !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType) &&
-              !DECOMPOSABLE_MULTI_ACTION_FIELDS.has(op.actionType) &&
-              !isResolvableTodayListAction(op.actionType),
-          );
+      const unsafeLocalOp = plan.conflict.localOps.find(
+        (op) =>
+          isMultiEntityOperation(op) &&
+          op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
+          !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType) &&
+          !DECOMPOSABLE_MULTI_ACTION_FIELDS.has(op.actionType) &&
+          !isResolvableTodayListAction(op.actionType),
+      );
       if (unsafeLocalOp) {
         throw new UnsupportedMultiEntityConflictError(
           'local',
@@ -3094,6 +3091,154 @@ export class ConflictResolutionService {
 
     return {
       ...group.deleteOp,
+      id: uuidv7(),
+      entityId: retainedEntityIds[0],
+      entityIds: retainedEntityIds,
+      payload: scopedPayload,
+      clientId,
+      vectorClock: this.mergeAndIncrementClocks(allClocks, clientId),
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+  }
+
+  /**
+   * #9537: preserves the surviving tasks of a bulk `moveToArchive` row that
+   * lost one or more of its entities to a concurrent REMOTE archive — the
+   * finish-day-on-two-devices race, where both clients archive overlapping
+   * done tasks in one atomic op each.
+   *
+   * The losing bulk row is rejected as a unit. Without a replacement its
+   * non-overlapping tasks would stay archived locally but never upload, so
+   * every other device would keep them active forever. Mirroring
+   * `_preservePartiallyRejectedLocalBulkDeletes`, this emits ONE scoped
+   * replacement per bulk row — narrowed to the tasks no remote archive in the
+   * batch covered, with a vector clock dominating every involved row. Tasks
+   * the remote archive DID cover stay with the remote winner: both sides
+   * agree those are archived, only the discarded local snapshot differs
+   * (standard remote-archive-wins precedence).
+   *
+   * Groups whose every row won locally are skipped: the pre-existing
+   * `_createArchiveWinOp` recreation already re-emits the full task set.
+   * When a group mixes winners (some tasks remote-archived, others winning
+   * against plain remote edits), the archive-win rows' full-set recreation is
+   * swapped for the scoped op so the replacement cannot re-assert the
+   * remote-archived tasks' stale local snapshots.
+   */
+  private async _preservePartiallyRejectedLocalBulkArchives(
+    resolutions: LWWResolution[],
+  ): Promise<Operation[]> {
+    interface BulkArchiveResolutionGroup {
+      archiveOp: Operation;
+      resolutions: LWWResolution[];
+      remoteWinnerIds: Set<string>;
+    }
+
+    const groups = new Map<string, BulkArchiveResolutionGroup>();
+    for (const resolution of resolutions) {
+      for (const localOp of resolution.conflict.localOps) {
+        if (
+          localOp.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE ||
+          getOpEntityIds(localOp).length <= 1
+        ) {
+          continue;
+        }
+        const group = groups.get(localOp.id) ?? {
+          archiveOp: localOp,
+          resolutions: [],
+          remoteWinnerIds: new Set<string>(),
+        };
+        group.resolutions.push(resolution);
+        if (resolution.winner === 'remote') {
+          group.remoteWinnerIds.add(resolution.conflict.entityId);
+        }
+        groups.set(localOp.id, group);
+      }
+    }
+
+    const additionalOps: Operation[] = [];
+    for (const group of groups.values()) {
+      if (group.remoteWinnerIds.size === 0) {
+        continue;
+      }
+      const retainedEntityIds = getOpEntityIds(group.archiveOp).filter(
+        (entityId) => !group.remoteWinnerIds.has(entityId),
+      );
+      if (retainedEntityIds.length === 0) {
+        continue;
+      }
+
+      const replacementOp = await this._createScopedBulkArchiveReplacement(
+        group,
+        retainedEntityIds,
+      );
+      let assignedToLocalWinner = false;
+      for (const resolution of group.resolutions) {
+        if (
+          resolution.winner === 'local' &&
+          resolution.localWinOp?.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE
+        ) {
+          resolution.localWinOp = replacementOp;
+          assignedToLocalWinner = true;
+        }
+      }
+      if (!assignedToLocalWinner) {
+        additionalOps.push(replacementOp);
+      }
+    }
+    return additionalOps;
+  }
+
+  private async _createScopedBulkArchiveReplacement(
+    group: {
+      archiveOp: Operation;
+      resolutions: LWWResolution[];
+    },
+    retainedEntityIds: string[],
+  ): Promise<Operation> {
+    const clientId = await this.clientIdProvider.loadClientId();
+    if (!clientId) {
+      throw new Error(
+        'ConflictResolutionService: Cannot preserve partial bulk archive - no client ID',
+      );
+    }
+
+    const allClocks = group.resolutions.flatMap(({ conflict }) => [
+      ...conflict.localOps.map((op) => op.vectorClock),
+      ...conflict.remoteOps.map((op) => op.vectorClock),
+    ]);
+    const retainedEntityIdSet = new Set(retainedEntityIds);
+    const originalPayload = group.archiveOp.payload;
+    const originalActionPayload = extractActionPayload(originalPayload);
+    const originalTasks = originalActionPayload['tasks'];
+    if (!Array.isArray(originalTasks)) {
+      throw new Error(
+        `ConflictResolutionService: Cannot scope bulk archive ${group.archiveOp.actionType} - unsupported payload`,
+      );
+    }
+    const scopedActionPayload: Record<string, unknown> = {
+      ...originalActionPayload,
+      tasks: originalTasks.filter((task) => {
+        if (typeof task !== 'object' || task === null) {
+          return false;
+        }
+        const snapshot = task as Record<string, unknown>;
+        return (
+          typeof snapshot['id'] === 'string' && retainedEntityIdSet.has(snapshot['id'])
+        );
+      }),
+    };
+    const scopedPayload = isMultiEntityPayload(originalPayload)
+      ? {
+          ...originalPayload,
+          actionPayload: scopedActionPayload,
+          entityChanges: originalPayload.entityChanges.filter((change) =>
+            retainedEntityIdSet.has(change.entityId),
+          ),
+        }
+      : scopedActionPayload;
+
+    return {
+      ...group.archiveOp,
       id: uuidv7(),
       entityId: retainedEntityIds[0],
       entityIds: retainedEntityIds,

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -2421,6 +2421,34 @@ export class ConflictResolutionService {
           getOpEntityIds(unsafeLocalOp).length,
         );
       }
+
+      // The bulk-archive excusal above assumes at most ONE whole-entity local
+      // intent per row. Two pending bulk archives sharing a task (archive →
+      // restore → re-archive with no sync between), or a bulk archive
+      // overlapping a bulk delete, would make the per-op scoped replacements
+      // re-assert contradictory or superseded intents with no cross-op
+      // ordering — one op's uniquely-retained tasks could silently never
+      // upload. Keep the safe stop for those degenerate histories.
+      const localBulkArchiveOps = plan.conflict.localOps.filter(
+        (op) =>
+          isMultiEntityOperation(op) &&
+          op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+      );
+      const distinctBulkArchiveOpIds = new Set(localBulkArchiveOps.map(({ id }) => id));
+      const hasBulkDeleteOverlap =
+        distinctBulkArchiveOpIds.size > 0 &&
+        plan.conflict.localOps.some(
+          (op) =>
+            isMultiEntityOperation(op) &&
+            INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType),
+        );
+      if (distinctBulkArchiveOpIds.size > 1 || hasBulkDeleteOverlap) {
+        throw new UnsupportedMultiEntityConflictError(
+          'local',
+          ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+          getOpEntityIds(localBulkArchiveOps[0]).length,
+        );
+      }
     }
   }
 
@@ -3123,6 +3151,13 @@ export class ConflictResolutionService {
    * against plain remote edits), the archive-win rows' full-set recreation is
    * swapped for the scoped op so the replacement cannot re-assert the
    * remote-archived tasks' stale local snapshots.
+   *
+   * Retained tasks that are back in the ACTIVE store (restored after the bulk
+   * archive was captured) are dropped from the replacement — their later
+   * pending ops are authoritative. Degenerate multi-bulk histories (two
+   * pending bulk archives sharing a task, bulk archive overlapping a bulk
+   * delete) never reach this method: `_assertMultiEntityPlansAreSafe` keeps
+   * the fail-closed stop for them.
    */
   private async _preservePartiallyRejectedLocalBulkArchives(
     resolutions: LWWResolution[],
@@ -3163,25 +3198,50 @@ export class ConflictResolutionService {
       const retainedEntityIds = getOpEntityIds(group.archiveOp).filter(
         (entityId) => !group.remoteWinnerIds.has(entityId),
       );
-      if (retainedEntityIds.length === 0) {
-        continue;
+
+      // A retained task that is back in the ACTIVE store was restored (or
+      // re-created) by a LATER local op — that op's own pending row is the
+      // authoritative representation. Re-asserting the stale archive snapshot
+      // with a dominating clock would silently override the restore on every
+      // other device (and on this one after a status-blind replay). Mirrors
+      // the later-local-delete guard in `_createLocalMultiReconciliationOps`.
+      const stillArchivedEntityIds: string[] = [];
+      for (const entityId of retainedEntityIds) {
+        const activeEntity = await this.getCurrentEntityState(
+          group.archiveOp.entityType,
+          entityId,
+        );
+        if (activeEntity === undefined || activeEntity === null) {
+          stillArchivedEntityIds.push(entityId);
+        }
       }
 
-      const replacementOp = await this._createScopedBulkArchiveReplacement(
-        group,
-        retainedEntityIds,
-      );
+      // With nothing left to re-assert, the replacement is skipped entirely —
+      // but any archive-win row still holding the FULL-SET recreation must
+      // drop it too (winner stays local, remote loser rows stay rejected;
+      // same shape as archive-sibling rows with `localWinOp: undefined`).
+      const replacementOp =
+        stillArchivedEntityIds.length > 0
+          ? await this._createScopedBulkArchiveReplacement(group, stillArchivedEntityIds)
+          : undefined;
       let assignedToLocalWinner = false;
       for (const resolution of group.resolutions) {
         if (
           resolution.winner === 'local' &&
-          resolution.localWinOp?.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE
+          resolution.localWinOp?.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
+          // Provenance binding: only swap a recreation built from THIS
+          // group's op (`_createArchiveWinOp` reuses the payload reference).
+          // A recreation derived from a different pending archive op must
+          // stay untouched, or its group's replacement would be lost.
+          resolution.localWinOp.payload === group.archiveOp.payload
         ) {
           resolution.localWinOp = replacementOp;
-          assignedToLocalWinner = true;
+          if (replacementOp) {
+            assignedToLocalWinner = true;
+          }
         }
       }
-      if (!assignedToLocalWinner) {
+      if (replacementOp && !assignedToLocalWinner) {
         additionalOps.push(replacementOp);
       }
     }
@@ -3208,7 +3268,12 @@ export class ConflictResolutionService {
     ]);
     const retainedEntityIdSet = new Set(retainedEntityIds);
     const originalPayload = group.archiveOp.payload;
-    const originalActionPayload = extractActionPayload(originalPayload);
+    // extractActionPayload passes a null/undefined payload through — guard so
+    // a malformed row hits the clean throw below, not a raw TypeError.
+    const originalActionPayload = (extractActionPayload(originalPayload) ?? {}) as Record<
+      string,
+      unknown
+    >;
     const originalTasks = originalActionPayload['tasks'];
     if (!Array.isArray(originalTasks)) {
       throw new Error(

--- a/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
@@ -480,6 +480,127 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
       (op) => op.actionType === ActionType.TASK_SHARED_RESTORE,
     );
     expect(restoreOp).toBeDefined();
+    // Exactly the replacement + the restore op — nothing else re-asserted.
+    expect(pending.length).toBe(2);
+  });
+
+  it('re-asserts a restored task via a current-state op when its own row is conflicted', async () => {
+    // The restored task B here has its OWN conflict row (a concurrent remote
+    // edit), so row rejection discards the pending restoreTask op along with
+    // the bulk archive. The resolution must emit a current-state compensation
+    // for B — with neither a replacement archive nor a compensation, the
+    // restore would silently never reach other devices.
+    const restoredB: Task = {
+      ...doneTask(TASK_B),
+      title: 'Restored B current title',
+      isDone: false,
+    };
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B)],
+      }) as PersistentAction,
+    );
+    store.dispatch(
+      TaskSharedActions.restoreTask({
+        task: restoredB,
+        subTasks: [],
+      }) as PersistentAction,
+    );
+    await writeFlush.flushPendingWrites();
+    taskStateById[TASK_B] = restoredB;
+
+    const client = remoteClient();
+    const remoteArchiveOp = buildRemoteArchiveOp(client, [TASK_A], bulkOp.timestamp + 1);
+    const remoteEditOp = buildRemoteTaskEdit(client, TASK_B, bulkOp.timestamp + 2);
+    const conflicts = [
+      ...(await detectConflictsFor(remoteArchiveOp)),
+      ...(await detectConflictsFor(remoteEditOp)),
+    ];
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    const pending = await unsyncedOps();
+    // No archive op survives (A remote-archived, B restored)...
+    expect(
+      pending.some((op) => op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE),
+    ).toBe(false);
+    // ...but B's restored state is re-asserted by a compensation op.
+    const compensation = pending.find((op) => op.entityId === TASK_B);
+    expect(compensation).toBeDefined();
+    const compensationPayload = compensation!.payload as {
+      actionPayload?: { title?: string };
+    };
+    expect(compensationPayload.actionPayload?.title).toBe('Restored B current title');
+    expectDominates(compensation!, remoteEditOp);
+    expectDominates(compensation!, bulkOp);
+
+    const appliedIds = appliedOps().map(({ id }) => id);
+    expect(appliedIds).toContain(remoteArchiveOp.id);
+    expect(appliedIds).not.toContain(remoteEditOp.id);
+  });
+
+  it('compensates a restored task instead of wedging when a remote BULK delete shares its row', async () => {
+    // Same restored-task shape, but the remote loser on B is a MULTI-entity
+    // deleteTasks op: with a bare undefined localWinOp the mixed-winner
+    // machinery would throw 'Cannot safely compensate mixed multi-entity
+    // winners' and wedge sync — the current-state compensation keeps the row
+    // coverable and the uncontested sibling delete applies.
+    const restoredB: Task = {
+      ...doneTask(TASK_B),
+      title: 'Restored B survives delete',
+      isDone: false,
+    };
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B)],
+      }) as PersistentAction,
+    );
+    store.dispatch(
+      TaskSharedActions.restoreTask({
+        task: restoredB,
+        subTasks: [],
+      }) as PersistentAction,
+    );
+    await writeFlush.flushPendingWrites();
+    taskStateById[TASK_B] = restoredB;
+
+    const client = remoteClient();
+    const remoteArchiveOp = buildRemoteArchiveOp(client, [TASK_A], bulkOp.timestamp + 1);
+    const remoteDeleteAction = TaskSharedActions.deleteTasks({
+      taskIds: [TASK_B, 'task-remote-only'],
+    }) as PersistentAction;
+    const { type, meta, ...actionPayload } = remoteDeleteAction;
+    const remoteDeleteOp: Operation = {
+      ...client.createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: TASK_B,
+        entityIds: [TASK_B, 'task-remote-only'],
+        payload: { actionPayload, entityChanges: [] },
+      }),
+      timestamp: bulkOp.timestamp + 2,
+    };
+    const conflicts = [
+      ...(await detectConflictsFor(remoteArchiveOp)),
+      ...(await detectConflictsFor(remoteDeleteOp)),
+    ];
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    const pending = await unsyncedOps();
+    expect(
+      pending.some((op) => op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE),
+    ).toBe(false);
+    const compensation = pending.find((op) => op.entityId === TASK_B);
+    expect(compensation).toBeDefined();
+    expectDominates(compensation!, remoteDeleteOp);
+
+    // The remote bulk delete applies (its uncontested sibling wins), followed
+    // by B's compensation in the same batch.
+    const appliedIds = appliedOps().map(({ id }) => id);
+    expect(appliedIds).toContain(remoteDeleteOp.id);
+    expect(appliedIds).toContain(compensation!.id);
   });
 
   it('accumulates remote-archived tasks across archive ops from several clients', async () => {
@@ -565,7 +686,7 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
       }) as PersistentAction,
     );
     await writeFlush.flushPendingWrites();
-    const [bulkOp1] = await unsyncedOps();
+    const [bulkOp1, bulkOp2] = await unsyncedOps();
 
     const remoteEditOp = buildRemoteTaskEdit(
       remoteClient(),
@@ -582,10 +703,14 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
     }
 
     expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
+    expect((thrown as Error).message).toBe(
+      'SYNC_MULTI_ENTITY_UNSUPPORTED side=local ' +
+        `actionType=${ActionType.TASK_SHARED_MOVE_TO_ARCHIVE} entityCount=3`,
+    );
     expect(operationApplier.applyOperations).not.toHaveBeenCalled();
     expect(await journal.list('history')).toEqual([]);
     // Fail-closed means pre-mutation: both bulk rows stay pending untouched.
-    expect((await unsyncedOps()).length).toBe(2);
+    expect((await unsyncedOps()).map(({ id }) => id)).toEqual([bulkOp1.id, bulkOp2.id]);
   });
 
   it('fails closed when a bulk archive overlaps a pending bulk delete', async () => {
@@ -603,7 +728,7 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
       }) as PersistentAction,
     );
     await writeFlush.flushPendingWrites();
-    const [bulkArchiveOp] = await unsyncedOps();
+    const [bulkArchiveOp, bulkDeleteOp] = await unsyncedOps();
 
     const remoteEditOp = buildRemoteTaskEdit(
       remoteClient(),
@@ -620,7 +745,16 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
     }
 
     expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
+    expect((thrown as Error).message).toBe(
+      'SYNC_MULTI_ENTITY_UNSUPPORTED side=local ' +
+        `actionType=${ActionType.TASK_SHARED_MOVE_TO_ARCHIVE} entityCount=2`,
+    );
     expect(operationApplier.applyOperations).not.toHaveBeenCalled();
     expect(await journal.list('history')).toEqual([]);
+    // Fail-closed means pre-mutation: both bulk rows stay pending untouched.
+    expect((await unsyncedOps()).map(({ id }) => id)).toEqual([
+      bulkArchiveOp.id,
+      bulkDeleteOp.id,
+    ]);
   });
 });

--- a/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
@@ -603,6 +603,65 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
     expect(appliedIds).toContain(compensation!.id);
   });
 
+  it('splits one group between a scoped replacement and a restore compensation', async () => {
+    // One group containing BOTH kinds of local-win rows: C stays archived
+    // (its row takes the scoped replacement), B was restored (its row takes
+    // the current-state compensation). Pins the branch condition itself — an
+    // inverted check would hand B's row the C-scoped replacement and leave
+    // C's row without any local-win op, silently losing the restore.
+    const restoredB: Task = {
+      ...doneTask(TASK_B),
+      title: 'Restored B stays',
+      isDone: false,
+    };
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B), doneTask(TASK_C)],
+      }) as PersistentAction,
+    );
+    store.dispatch(
+      TaskSharedActions.restoreTask({
+        task: restoredB,
+        subTasks: [],
+      }) as PersistentAction,
+    );
+    await writeFlush.flushPendingWrites();
+    taskStateById[TASK_B] = restoredB;
+
+    const client = remoteClient();
+    const remoteArchiveOp = buildRemoteArchiveOp(client, [TASK_A], bulkOp.timestamp + 1);
+    const remoteEditB = buildRemoteTaskEdit(client, TASK_B, bulkOp.timestamp + 2);
+    const remoteEditC = buildRemoteTaskEdit(client, TASK_C, bulkOp.timestamp + 3);
+    const conflicts = [
+      ...(await detectConflictsFor(remoteArchiveOp)),
+      ...(await detectConflictsFor(remoteEditB)),
+      ...(await detectConflictsFor(remoteEditC)),
+    ];
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    const pending = await unsyncedOps();
+    const replacement = pending.find(
+      (op) => op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+    );
+    expect(replacement).toBeDefined();
+    expect(replacement!.entityIds).toEqual([TASK_C]);
+    expect(payloadTaskIds(replacement!)).toEqual([TASK_C]);
+    const compensation = pending.find(
+      (op) =>
+        op.entityId === TASK_B &&
+        op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+    );
+    expect(compensation).toBeDefined();
+    expect(
+      (compensation!.payload as { actionPayload?: { title?: string } }).actionPayload
+        ?.title,
+    ).toBe('Restored B stays');
+    expect(pending.length).toBe(2);
+    expectDominates(replacement!, bulkOp);
+    expectDominates(compensation!, remoteEditB);
+  });
+
   it('accumulates remote-archived tasks across archive ops from several clients', async () => {
     // Three-device finish-day race: client B archived A, client C archived B,
     // the local bulk covered A, B and C — ONE replacement scoped to C, with a

--- a/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
@@ -12,6 +12,7 @@ import { OperationCaptureService } from '../../capture/operation-capture.service
 import { clearDeferredActions } from '../../capture/operation-capture.meta-reducer';
 import { OperationLogEffects } from '../../capture/operation-log.effects';
 import { buildEntityRegistry, ENTITY_REGISTRY } from '../../core/entity-registry';
+import { UnsupportedMultiEntityConflictError } from '../../core/errors/sync-errors';
 import { ActionType, EntityConflict, Operation } from '../../core/operation.types';
 import {
   isPersistentAction,
@@ -62,14 +63,15 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
   let effectSubscription: Subscription;
   let taskStateById: Record<string, Task | undefined>;
 
-  const doneTask = (id: string): TaskWithSubTasks => ({
+  const doneTask = (id: string, subTasks: Task[] = []): TaskWithSubTasks => ({
     ...DEFAULT_TASK,
     id,
     title: `Done ${id}`,
     projectId: 'project1',
     isDone: true,
     doneOn: 1_000,
-    subTasks: [],
+    subTaskIds: subTasks.map(({ id: subId }) => subId),
+    subTasks,
   });
 
   beforeEach(async () => {
@@ -200,7 +202,7 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
     timestamp: number,
   ): Operation => {
     const remoteAction = TaskSharedActions.moveToArchive({
-      tasks: taskIds.map(doneTask),
+      tasks: taskIds.map((id) => doneTask(id)),
     }) as PersistentAction;
     const { type, meta, ...actionPayload } = remoteAction;
     return {
@@ -272,9 +274,23 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
 
   it('re-scopes a losing bulk archive to the tasks the remote archive did not cover (finish-day race)', async () => {
     // LOCAL: the Mac's "Finish day" archives 4 done tasks in one atomic op.
+    // Task C carries a subtask to pin that nested subtasks survive scoping.
+    const subTaskC: Task = {
+      ...DEFAULT_TASK,
+      id: 'task-c-sub-1',
+      title: 'Subtask of C',
+      projectId: 'project1',
+      parentId: TASK_C,
+      isDone: true,
+    };
     const [bulkOp] = await dispatchAndFlush(
       TaskSharedActions.moveToArchive({
-        tasks: [doneTask(TASK_A), doneTask(TASK_B), doneTask(TASK_C), doneTask(TASK_D)],
+        tasks: [
+          doneTask(TASK_A),
+          doneTask(TASK_B),
+          doneTask(TASK_C, [subTaskC]),
+          doneTask(TASK_D),
+        ],
       }) as PersistentAction,
     );
     expect(bulkOp.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
@@ -296,13 +312,25 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
     expect(replacement.entityId).toBe(TASK_B);
     expect(replacement.entityIds).toEqual([TASK_B, TASK_C, TASK_D]);
     expect(payloadTaskIds(replacement)).toEqual([TASK_B, TASK_C, TASK_D]);
+    const retainedC = (
+      replacement.payload as { actionPayload: { tasks: TaskWithSubTasks[] } }
+    ).actionPayload.tasks.find(({ id }) => id === TASK_C);
+    expect(retainedC!.subTasks).toEqual([subTaskC]);
     expect(replacement.timestamp).toBe(bulkOp.timestamp);
     expectDominates(replacement, bulkOp);
     expectDominates(replacement, remoteOp);
+    // A plain clock merge would already dominate both concurrent originals —
+    // pin the increment, which is what protects against third parties.
+    expect(replacement.vectorClock[LOCAL_CLIENT_ID]).toBe(
+      (bulkOp.vectorClock[LOCAL_CLIENT_ID] ?? 0) + 1,
+    );
 
-    // The remote archive is applied (its snapshot wins for the shared task).
+    // The remote archive is applied (its snapshot wins for the shared task);
+    // the replacement is upload-only — local state already reflects it.
     expect(operationApplier.applyOperations).toHaveBeenCalled();
-    expect(appliedOps().map(({ id }) => id)).toContain(remoteOp.id);
+    const appliedIds = appliedOps().map(({ id }) => id);
+    expect(appliedIds).toContain(remoteOp.id);
+    expect(appliedIds).not.toContain(replacement.id);
   });
 
   it('rejects the bulk archive outright when the remote archive covers every task', async () => {
@@ -359,10 +387,12 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
     expectDominates(replacement, remoteArchiveOp);
     expectDominates(replacement, remoteEditOp);
 
-    // The remote archive is applied; the losing remote edit is not.
+    // The remote archive is applied; the losing remote edit and the
+    // upload-only replacement are not.
     const appliedIds = appliedOps().map(({ id }) => id);
     expect(appliedIds).toContain(remoteArchiveOp.id);
     expect(appliedIds).not.toContain(remoteEditOp.id);
+    expect(appliedIds).not.toContain(replacement.id);
   });
 
   it('resolves a winning bulk archive that shares an entity with a decomposable bulk op', async () => {
@@ -411,5 +441,186 @@ describe('bulk archive conflict resolution integration (#9537)', () => {
 
     // The losing remote edit is rejected, not applied.
     expect(appliedOps().map(({ id }) => id)).not.toContain(remoteEditOp.id);
+  });
+
+  it('drops a retained task from the replacement when it was restored from archive meanwhile', async () => {
+    // Between the bulk archive and the resolving sync, the user restored B —
+    // B is back in the ACTIVE store and a restoreTask op is pending. The
+    // replacement must not re-assert B's stale archival with a dominating
+    // clock, or the restore would be silently overridden fleet-wide.
+    const restoredB = doneTask(TASK_B);
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), restoredB, doneTask(TASK_C)],
+      }) as PersistentAction,
+    );
+    store.dispatch(
+      TaskSharedActions.restoreTask({
+        task: restoredB,
+        subTasks: [],
+      }) as PersistentAction,
+    );
+    await writeFlush.flushPendingWrites();
+    taskStateById[TASK_B] = restoredB;
+
+    const remoteOp = buildRemoteArchiveOp(remoteClient(), [TASK_A], bulkOp.timestamp + 1);
+    const conflicts = await detectConflictsFor(remoteOp);
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    const pending = await unsyncedOps();
+    const replacement = pending.find(
+      (op) => op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+    );
+    expect(replacement).toBeDefined();
+    expect(replacement!.entityIds).toEqual([TASK_C]);
+    expect(payloadTaskIds(replacement!)).toEqual([TASK_C]);
+    // The restore op itself stays pending and uploads normally.
+    const restoreOp = pending.find(
+      (op) => op.actionType === ActionType.TASK_SHARED_RESTORE,
+    );
+    expect(restoreOp).toBeDefined();
+  });
+
+  it('accumulates remote-archived tasks across archive ops from several clients', async () => {
+    // Three-device finish-day race: client B archived A, client C archived B,
+    // the local bulk covered A, B and C — ONE replacement scoped to C, with a
+    // clock dominating every involved row.
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B), doneTask(TASK_C)],
+      }) as PersistentAction,
+    );
+    const remoteArchiveA = buildRemoteArchiveOp(
+      new TestClient('remote-client-b'),
+      [TASK_A],
+      bulkOp.timestamp + 1,
+    );
+    const remoteArchiveB = buildRemoteArchiveOp(
+      new TestClient('remote-client-c'),
+      [TASK_B],
+      bulkOp.timestamp + 2,
+    );
+    const conflicts = [
+      ...(await detectConflictsFor(remoteArchiveA)),
+      ...(await detectConflictsFor(remoteArchiveB)),
+    ];
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    const pending = await unsyncedOps();
+    expect(pending.length).toBe(1);
+    const replacement = pending[0];
+    expect(replacement.entityIds).toEqual([TASK_C]);
+    expect(payloadTaskIds(replacement)).toEqual([TASK_C]);
+    expectDominates(replacement, bulkOp);
+    expectDominates(replacement, remoteArchiveA);
+    expectDominates(replacement, remoteArchiveB);
+    const appliedIds = appliedOps().map(({ id }) => id);
+    expect(appliedIds).toContain(remoteArchiveA.id);
+    expect(appliedIds).toContain(remoteArchiveB.id);
+  });
+
+  it('emits ONE replacement when several archive-win rows share the same bulk op', async () => {
+    // Remote archived A; two SEPARATE remote edits hit B and C — two
+    // archive-win rows for the same bulk op. Both rows must end up pointing at
+    // the SAME scoped replacement (deduped by id), never one op per row.
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B), doneTask(TASK_C)],
+      }) as PersistentAction,
+    );
+    const client = remoteClient();
+    const remoteArchiveOp = buildRemoteArchiveOp(client, [TASK_A], bulkOp.timestamp + 1);
+    const remoteEditB = buildRemoteTaskEdit(client, TASK_B, bulkOp.timestamp + 2);
+    const remoteEditC = buildRemoteTaskEdit(client, TASK_C, bulkOp.timestamp + 3);
+    const conflicts = [
+      ...(await detectConflictsFor(remoteArchiveOp)),
+      ...(await detectConflictsFor(remoteEditB)),
+      ...(await detectConflictsFor(remoteEditC)),
+    ];
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    const pending = await unsyncedOps();
+    expect(pending.length).toBe(1);
+    expect(pending[0].entityIds).toEqual([TASK_B, TASK_C]);
+    expect(payloadTaskIds(pending[0])).toEqual([TASK_B, TASK_C]);
+  });
+
+  it('fails closed when two pending bulk archives share a conflicted task', async () => {
+    // Archive → restore → re-archive without a sync in between leaves TWO
+    // pending bulk archives containing the same task. Per-op scoped
+    // replacement cannot express a coherent cross-op supersession order here,
+    // so the preflight must keep the safe stop instead of silently dropping
+    // one op's uniquely-retained tasks.
+    store.dispatch(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B), doneTask(TASK_D)],
+      }) as PersistentAction,
+    );
+    store.dispatch(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_C)],
+      }) as PersistentAction,
+    );
+    await writeFlush.flushPendingWrites();
+    const [bulkOp1] = await unsyncedOps();
+
+    const remoteEditOp = buildRemoteTaskEdit(
+      remoteClient(),
+      TASK_A,
+      bulkOp1.timestamp + 1,
+    );
+    const conflicts = await detectConflictsFor(remoteEditOp);
+
+    let thrown: unknown;
+    try {
+      await resolver.autoResolveConflictsLWW(conflicts);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
+    expect(operationApplier.applyOperations).not.toHaveBeenCalled();
+    expect(await journal.list('history')).toEqual([]);
+    // Fail-closed means pre-mutation: both bulk rows stay pending untouched.
+    expect((await unsyncedOps()).length).toBe(2);
+  });
+
+  it('fails closed when a bulk archive overlaps a pending bulk delete', async () => {
+    // A bulk archive and a bulk delete both covering task A re-assert
+    // contradictory whole-entity intents for A if scoped independently — keep
+    // the safe stop (pre-fix parity: this shape always wedged).
+    store.dispatch(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B)],
+      }) as PersistentAction,
+    );
+    store.dispatch(
+      TaskSharedActions.deleteTasks({
+        taskIds: [TASK_A, TASK_C],
+      }) as PersistentAction,
+    );
+    await writeFlush.flushPendingWrites();
+    const [bulkArchiveOp] = await unsyncedOps();
+
+    const remoteEditOp = buildRemoteTaskEdit(
+      remoteClient(),
+      TASK_A,
+      bulkArchiveOp.timestamp + 1,
+    );
+    const conflicts = await detectConflictsFor(remoteEditOp);
+
+    let thrown: unknown;
+    try {
+      await resolver.autoResolveConflictsLWW(conflicts);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
+    expect(operationApplier.applyOperations).not.toHaveBeenCalled();
+    expect(await journal.list('history')).toEqual([]);
   });
 });

--- a/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/archive-conflict-resolution.integration.spec.ts
@@ -1,0 +1,415 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action, Store } from '@ngrx/store';
+import { of, Subject, Subscription } from 'rxjs';
+import { SnackService } from '../../../core/snack/snack.service';
+import { ClientIdService } from '../../../core/util/client-id.service';
+import { DEFAULT_TASK, Task, TaskWithSubTasks } from '../../../features/tasks/task.model';
+import { roundTimeSpentForDay } from '../../../features/tasks/store/task.actions';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { OperationApplierService } from '../../apply/operation-applier.service';
+import { OperationCaptureService } from '../../capture/operation-capture.service';
+import { clearDeferredActions } from '../../capture/operation-capture.meta-reducer';
+import { OperationLogEffects } from '../../capture/operation-log.effects';
+import { buildEntityRegistry, ENTITY_REGISTRY } from '../../core/entity-registry';
+import { ActionType, EntityConflict, Operation } from '../../core/operation.types';
+import {
+  isPersistentAction,
+  PersistentAction,
+} from '../../core/persistent-action.interface';
+import { OperationLogCompactionService } from '../../persistence/operation-log-compaction.service';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { ConflictJournalService } from '../../sync/conflict-journal.service';
+import { ConflictResolutionService } from '../../sync/conflict-resolution.service';
+import { ImmediateUploadService } from '../../sync/immediate-upload.service';
+import { OperationWriteFlushService } from '../../sync/operation-write-flush.service';
+import { CLIENT_ID_PROVIDER } from '../../util/client-id.provider';
+import { ValidateStateService } from '../../validation/validate-state.service';
+import { compareVectorClocks, VectorClockComparison } from '@sp/sync-core';
+import {
+  ApplyOperationsOptions,
+  ApplyOperationsResult,
+} from '../../core/types/apply.types';
+import { resetTestUuidCounter, TestClient } from './helpers/test-client.helper';
+
+/**
+ * #9537 / #9405: both devices archiving overlapping done tasks concurrently
+ * (each side's "Finish day" emits ONE atomic multi-task `moveToArchive` op)
+ * used to fail the multi-entity preflight with
+ * `SYNC_MULTI_ENTITY_UNSUPPORTED side=local actionType=moveToArchive` and
+ * wedge sync on every retry. These specs pin the resolution behavior: the
+ * batch resolves, the losing bulk archive row is rejected, and a scoped
+ * replacement re-uploads the archive intent for the tasks no remote archive
+ * covered (mirroring the bulk-delete preserve mechanism).
+ */
+describe('bulk archive conflict resolution integration (#9537)', () => {
+  const LOCAL_CLIENT_ID = 'archive-client';
+  const REMOTE_CLIENT_ID = 'remote-client';
+  const TASK_A = 'task-a';
+  const TASK_B = 'task-b';
+  const TASK_C = 'task-c';
+  const TASK_D = 'task-d';
+  const SIBLING_X = 'task-sibling-x';
+
+  let opLogStore: OperationLogStoreService;
+  let capture: OperationCaptureService;
+  let writeFlush: OperationWriteFlushService;
+  let resolver: ConflictResolutionService;
+  let journal: ConflictJournalService;
+  let operationApplier: jasmine.SpyObj<OperationApplierService>;
+  let store: jasmine.SpyObj<Store>;
+  let actions$: Subject<Action>;
+  let effectSubscription: Subscription;
+  let taskStateById: Record<string, Task | undefined>;
+
+  const doneTask = (id: string): TaskWithSubTasks => ({
+    ...DEFAULT_TASK,
+    id,
+    title: `Done ${id}`,
+    projectId: 'project1',
+    isDone: true,
+    doneOn: 1_000,
+    subTasks: [],
+  });
+
+  beforeEach(async () => {
+    resetTestUuidCounter();
+    clearDeferredActions();
+    actions$ = new Subject<Action>();
+    store = jasmine.createSpyObj<Store>('Store', ['dispatch', 'select']);
+    taskStateById = {
+      [SIBLING_X]: {
+        ...DEFAULT_TASK,
+        id: SIBLING_X,
+        title: 'Sibling X',
+        projectId: 'project1',
+      },
+    };
+    // Serve current entity state for reconciliation snapshots from a plain map.
+    // The registry's TASK selectById is a props-based selector: (selector, {id}).
+    store.select.and.callFake(((_selector: unknown, props?: { id?: string }): unknown =>
+      of(props?.id ? taskStateById[props.id] : undefined)) as Store['select']);
+
+    operationApplier = jasmine.createSpyObj<OperationApplierService>(
+      'OperationApplierService',
+      ['applyOperations'],
+    );
+    // Mimic the real applier's contract: report every op as reducer-committed
+    // and applied, so the resolution's markApplied/checkpoint bookkeeping runs.
+    operationApplier.applyOperations.and.callFake((async (
+      ops: Operation[],
+      options: ApplyOperationsOptions = {},
+    ): Promise<ApplyOperationsResult> => {
+      await options.onReducersCommitted?.(ops, []);
+      return { appliedOps: ops };
+    }) as OperationApplierService['applyOperations']);
+    const validateState = jasmine.createSpyObj<ValidateStateService>(
+      'ValidateStateService',
+      ['validateAndRepairCurrentState'],
+    );
+    validateState.validateAndRepairCurrentState.and.resolveTo(true);
+    const compaction = jasmine.createSpyObj<OperationLogCompactionService>(
+      'OperationLogCompactionService',
+      ['compact', 'emergencyCompact'],
+    );
+    compaction.compact.and.resolveTo(true);
+    compaction.emergencyCompact.and.resolveTo(true);
+    const clientId = jasmine.createSpyObj<ClientIdService>('ClientIdService', [
+      'getOrGenerateClientId',
+    ]);
+    clientId.getOrGenerateClientId.and.resolveTo(LOCAL_CLIENT_ID);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ConflictResolutionService,
+        OperationLogEffects,
+        OperationLogStoreService,
+        OperationCaptureService,
+        provideMockActions(() => actions$),
+        { provide: Store, useValue: store },
+        { provide: OperationApplierService, useValue: operationApplier },
+        { provide: ValidateStateService, useValue: validateState },
+        { provide: OperationLogCompactionService, useValue: compaction },
+        {
+          provide: ImmediateUploadService,
+          useValue: jasmine.createSpyObj<ImmediateUploadService>(
+            'ImmediateUploadService',
+            ['trigger'],
+          ),
+        },
+        { provide: ClientIdService, useValue: clientId },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj<SnackService>('SnackService', ['open']),
+        },
+        {
+          provide: CLIENT_ID_PROVIDER,
+          useValue: {
+            loadClientId: () => Promise.resolve(LOCAL_CLIENT_ID),
+            getOrGenerateClientId: () => Promise.resolve(LOCAL_CLIENT_ID),
+            clearCache: () => {},
+          },
+        },
+        { provide: ENTITY_REGISTRY, useValue: buildEntityRegistry() },
+      ],
+    });
+
+    opLogStore = TestBed.inject(OperationLogStoreService);
+    capture = TestBed.inject(OperationCaptureService);
+    writeFlush = TestBed.inject(OperationWriteFlushService);
+    resolver = TestBed.inject(ConflictResolutionService);
+    journal = TestBed.inject(ConflictJournalService);
+    capture.clear();
+    store.dispatch.and.callFake(((action: Action): void => {
+      if (!isPersistentAction(action)) {
+        throw new Error('Expected a persistent action');
+      }
+      capture.incrementPending(action);
+      actions$.next(action);
+    }) as Store['dispatch']);
+
+    await opLogStore.init();
+    await opLogStore._clearAllDataForTesting();
+    await journal.clearAll();
+    effectSubscription =
+      TestBed.inject(OperationLogEffects).persistOperation$.subscribe();
+  });
+
+  afterEach(async () => {
+    await writeFlush.flushPendingWrites();
+    effectSubscription.unsubscribe();
+    actions$.complete();
+    capture.clear();
+    clearDeferredActions();
+    await opLogStore._clearAllDataForTesting();
+    await journal.clearAll();
+    TestBed.resetTestingModule();
+  });
+
+  const dispatchAndFlush = async (action: PersistentAction): Promise<Operation[]> => {
+    store.dispatch(action);
+    await writeFlush.flushPendingWrites();
+    return (await opLogStore.getUnsynced()).map(({ op }) => op);
+  };
+
+  const remoteClient = (): TestClient => new TestClient(REMOTE_CLIENT_ID);
+
+  const buildRemoteArchiveOp = (
+    client: TestClient,
+    taskIds: string[],
+    timestamp: number,
+  ): Operation => {
+    const remoteAction = TaskSharedActions.moveToArchive({
+      tasks: taskIds.map(doneTask),
+    }) as PersistentAction;
+    const { type, meta, ...actionPayload } = remoteAction;
+    return {
+      ...client.createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: taskIds[0],
+        entityIds: taskIds,
+        payload: { actionPayload, entityChanges: [] },
+      }),
+      timestamp,
+    };
+  };
+
+  const buildRemoteTaskEdit = (
+    client: TestClient,
+    targetTaskId: string,
+    timestamp: number,
+  ): Operation => {
+    const remoteAction = TaskSharedActions.updateTask({
+      task: { id: targetTaskId, changes: { title: 'Concurrent remote edit' } },
+    }) as PersistentAction;
+    const { type, meta, ...actionPayload } = remoteAction;
+    return {
+      ...client.createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: targetTaskId,
+        payload: { actionPayload, entityChanges: [] },
+      }),
+      timestamp,
+    };
+  };
+
+  const detectConflictsFor = async (
+    remoteOperation: Operation,
+  ): Promise<EntityConflict[]> => {
+    const detection = await resolver.checkOpForConflicts(remoteOperation, {
+      localPendingOpsByEntity: await opLogStore.getUnsyncedByEntity(),
+      appliedFrontierByEntity: new Map(),
+      retainedOpsByEntity: new Map(),
+      snapshotVectorClock: undefined,
+      snapshotEntityKeys: undefined,
+      hasNoSnapshotClock: true,
+    });
+    expect(detection.conflicts.length).toBeGreaterThan(0);
+    return detection.conflicts;
+  };
+
+  const unsyncedOps = async (): Promise<Operation[]> =>
+    (await opLogStore.getUnsynced()).map(({ op }) => op);
+
+  const appliedOps = (): Operation[] =>
+    operationApplier.applyOperations.calls.allArgs().flatMap(([ops]) => ops);
+
+  const expectDominates = (dominating: Operation, dominated: Operation): void => {
+    expect(compareVectorClocks(dominating.vectorClock, dominated.vectorClock)).toBe(
+      VectorClockComparison.GREATER_THAN,
+    );
+  };
+
+  const payloadTaskIds = (op: Operation): string[] => {
+    const actionPayload = (op.payload as { actionPayload: { tasks: Task[] } })
+      .actionPayload;
+    return actionPayload.tasks.map(({ id }) => id);
+  };
+
+  it('re-scopes a losing bulk archive to the tasks the remote archive did not cover (finish-day race)', async () => {
+    // LOCAL: the Mac's "Finish day" archives 4 done tasks in one atomic op.
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B), doneTask(TASK_C), doneTask(TASK_D)],
+      }) as PersistentAction,
+    );
+    expect(bulkOp.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
+    expect(bulkOp.entityIds).toEqual([TASK_A, TASK_B, TASK_C, TASK_D]);
+
+    // REMOTE: the other device archived one of the SAME tasks concurrently.
+    const remoteOp = buildRemoteArchiveOp(remoteClient(), [TASK_A], bulkOp.timestamp + 1);
+    const conflicts = await detectConflictsFor(remoteOp);
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    // The atomic bulk row is rejected; ONE scoped replacement re-uploads the
+    // archive intent for the tasks the remote archive did not cover.
+    const pending = await unsyncedOps();
+    expect(pending.length).toBe(1);
+    const replacement = pending[0];
+    expect(replacement.id).not.toBe(bulkOp.id);
+    expect(replacement.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
+    expect(replacement.entityId).toBe(TASK_B);
+    expect(replacement.entityIds).toEqual([TASK_B, TASK_C, TASK_D]);
+    expect(payloadTaskIds(replacement)).toEqual([TASK_B, TASK_C, TASK_D]);
+    expect(replacement.timestamp).toBe(bulkOp.timestamp);
+    expectDominates(replacement, bulkOp);
+    expectDominates(replacement, remoteOp);
+
+    // The remote archive is applied (its snapshot wins for the shared task).
+    expect(operationApplier.applyOperations).toHaveBeenCalled();
+    expect(appliedOps().map(({ id }) => id)).toContain(remoteOp.id);
+  });
+
+  it('rejects the bulk archive outright when the remote archive covers every task', async () => {
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B)],
+      }) as PersistentAction,
+    );
+
+    const remoteOp = buildRemoteArchiveOp(
+      remoteClient(),
+      [TASK_A, TASK_B],
+      bulkOp.timestamp + 1,
+    );
+    const conflicts = await detectConflictsFor(remoteOp);
+    expect(conflicts.length).toBe(2);
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    // Both sides archived both tasks — plain rejection converges with no
+    // replacement op left behind.
+    expect(await unsyncedOps()).toEqual([]);
+    expect(appliedOps().map(({ id }) => id)).toContain(remoteOp.id);
+  });
+
+  it('swaps the archive-win recreation for the scoped op when winners are mixed', async () => {
+    const [bulkOp] = await dispatchAndFlush(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B)],
+      }) as PersistentAction,
+    );
+
+    // Remote archived task A (remote archive wins A) AND edited task B (the
+    // local archive wins B via archive precedence).
+    const client = remoteClient();
+    const remoteArchiveOp = buildRemoteArchiveOp(client, [TASK_A], bulkOp.timestamp + 1);
+    const remoteEditOp = buildRemoteTaskEdit(client, TASK_B, bulkOp.timestamp + 2);
+    const conflicts = [
+      ...(await detectConflictsFor(remoteArchiveOp)),
+      ...(await detectConflictsFor(remoteEditOp)),
+    ];
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    // Exactly ONE replacement, scoped to task B: the archive-win recreation
+    // must not re-assert task A's stale local snapshot over the remote archive.
+    const pending = await unsyncedOps();
+    expect(pending.length).toBe(1);
+    const replacement = pending[0];
+    expect(replacement.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
+    expect(replacement.entityIds).toEqual([TASK_B]);
+    expect(payloadTaskIds(replacement)).toEqual([TASK_B]);
+    expectDominates(replacement, bulkOp);
+    expectDominates(replacement, remoteArchiveOp);
+    expectDominates(replacement, remoteEditOp);
+
+    // The remote archive is applied; the losing remote edit is not.
+    const appliedIds = appliedOps().map(({ id }) => id);
+    expect(appliedIds).toContain(remoteArchiveOp.id);
+    expect(appliedIds).not.toContain(remoteEditOp.id);
+  });
+
+  it('resolves a winning bulk archive that shares an entity with a decomposable bulk op', async () => {
+    // #9537 (second shape): "Finish day" rounds time spent (bulk) and then
+    // archives (bulk) — both ops touch task A. The old preflight required
+    // EVERY local multi-entity op to be a moveToArchive for the archive-win
+    // excusal, so the excused-but-present rounding op wedged sync anyway.
+    store.dispatch(
+      roundTimeSpentForDay({
+        day: '2026-08-13',
+        taskIds: [TASK_A, SIBLING_X],
+        roundTo: '5M',
+        isRoundUp: true,
+      }) as PersistentAction,
+    );
+    store.dispatch(
+      TaskSharedActions.moveToArchive({
+        tasks: [doneTask(TASK_A), doneTask(TASK_B)],
+      }) as PersistentAction,
+    );
+    await writeFlush.flushPendingWrites();
+    const [roundOp, bulkOp] = await unsyncedOps();
+    expect(roundOp.actionType).toBe(ActionType.TASK_ROUND_TIME_SPENT);
+    expect(bulkOp.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
+
+    const remoteEditOp = buildRemoteTaskEdit(
+      remoteClient(),
+      TASK_A,
+      bulkOp.timestamp + 1,
+    );
+    const conflicts = await detectConflictsFor(remoteEditOp);
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    // The archive wins task A (archive precedence) and is re-created for the
+    // full set; the rounding op's sibling is preserved as a field patch.
+    const pending = await unsyncedOps();
+    const recreation = pending.find(
+      (op) => op.actionType === ActionType.TASK_SHARED_MOVE_TO_ARCHIVE,
+    );
+    expect(recreation).toBeDefined();
+    expect(recreation!.id).not.toBe(bulkOp.id);
+    expect(recreation!.entityIds).toEqual([TASK_A, TASK_B]);
+    const siblingPatch = pending.find((op) => op.entityId === SIBLING_X);
+    expect(siblingPatch).toBeDefined();
+
+    // The losing remote edit is rejected, not applied.
+    expect(appliedOps().map(({ id }) => id)).not.toContain(remoteEditOp.id);
+  });
+});

--- a/src/app/op-log/testing/integration/unsupported-multi-entity-conflict.integration.spec.ts
+++ b/src/app/op-log/testing/integration/unsupported-multi-entity-conflict.integration.spec.ts
@@ -7,7 +7,7 @@ import { SnackService } from '../../../core/snack/snack.service';
 import { ClientIdService } from '../../../core/util/client-id.service';
 import { ArchiveModel } from '../../../features/archive/archive.model';
 import { TaskArchiveService } from '../../../features/archive/task-archive.service';
-import { DEFAULT_TASK, Task, TaskWithSubTasks } from '../../../features/tasks/task.model';
+import { DEFAULT_TASK, Task } from '../../../features/tasks/task.model';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { OperationApplierService } from '../../apply/operation-applier.service';
 import { OperationCaptureService } from '../../capture/operation-capture.service';
@@ -250,86 +250,18 @@ describe('unsupported archive multi-entity conflict integration (#9405)', () => 
     expect(await journal.list('history')).toEqual([]);
   });
 
-  it('wedges sync when both devices archive an overlapping done task (finish-day race)', async () => {
-    // Reachable from ordinary use on two devices: "Finish day" (daily summary /
-    // work view) archives ALL done tasks as ONE atomic moveToArchive op. When a
-    // second device archives any of the same tasks concurrently, the planner
-    // resolves the shared entity as remote-archive (winner=remote), so the
-    // local multi-entity archive op loses — and a losing moveToArchive has no
-    // scoped-replacement path (the archive-win recreation only runs when LOCAL
-    // wins). The preflight fails closed and sync stays wedged until one side's
-    // ops change. Pins the live defect observed 2026-08 (entityCount=4).
-    const doneTask = (id: string): TaskWithSubTasks => ({
-      ...DEFAULT_TASK,
-      id,
-      title: `Done ${id}`,
-      projectId: 'project1',
-      isDone: true,
-      doneOn: 1_000,
-      subTasks: [],
-    });
-    const localAction = TaskSharedActions.moveToArchive({
-      tasks: [doneTask('task-a'), doneTask('task-b')],
-    }) as PersistentAction;
-    store.dispatch(localAction);
-
-    const localOperation = await pendingLocalOperation();
-    expect(localOperation.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
-    expect(localOperation.entityIds).toEqual(['task-a', 'task-b']);
-
-    const remoteAction = TaskSharedActions.moveToArchive({
-      tasks: [doneTask('task-a')],
-    }) as PersistentAction;
-    const { type, meta, ...actionPayload } = remoteAction;
-    const remoteOperation = {
-      ...new TestClient(REMOTE_CLIENT_ID).createOperation({
-        actionType: type,
-        opType: meta.opType,
-        entityType: meta.entityType,
-        entityId: 'task-a',
-        entityIds: ['task-a'],
-        payload: {
-          actionPayload,
-          entityChanges: capture.extractEntityChanges(remoteAction),
-        },
-      }),
-      timestamp: localOperation.timestamp + 1,
-    };
-    const detection = await resolver.checkOpForConflicts(remoteOperation, {
-      localPendingOpsByEntity: await opLogStore.getUnsyncedByEntity(),
-      appliedFrontierByEntity: new Map(),
-      retainedOpsByEntity: new Map(),
-      snapshotVectorClock: undefined,
-      snapshotEntityKeys: undefined,
-      hasNoSnapshotClock: true,
-    });
-    expect(detection.conflicts.length).toBeGreaterThan(0);
-
-    let thrown: unknown;
-    try {
-      await resolver.autoResolveConflictsLWW(detection.conflicts);
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
-    expect((thrown as Error).message).toBe(
-      'SYNC_MULTI_ENTITY_UNSUPPORTED side=local ' +
-        `actionType=${ActionType.TASK_SHARED_MOVE_TO_ARCHIVE} entityCount=2`,
-    );
-    expect(operationApplier.applyOperations).not.toHaveBeenCalled();
-    expect(await journal.list('history')).toEqual([]);
-  });
-
   describe('reachability of the guard beyond bulk actions', () => {
     // The report reads as a recurring-task problem, but the guard is not
     // scoped to one. Every action below carries >1 entityId and is neither an
-    // independent multi-delete, decomposable, nor a resolvable Today-list op,
-    // so one pending local op plus one concurrent remote edit of the same task
-    // is enough to stop sync. This pins the REMAINING blocked surface; the
-    // formerly-pinned Today-list cases (moveTaskInTodayTagList,
+    // independent multi-delete, decomposable, a resolvable Today-list op, nor
+    // a bulk archive, so one pending local op plus one concurrent remote edit
+    // of the same task is enough to stop sync. This pins the REMAINING blocked
+    // surface; the formerly-pinned Today-list cases (moveTaskInTodayTagList,
     // planTasksForToday, removeTasksFromTodayTag) resolve since #9426 and are
-    // covered by today-plan-conflict-resolution.integration.spec.ts.
+    // covered by today-plan-conflict-resolution.integration.spec.ts, and the
+    // formerly-pinned finish-day archive-vs-archive race resolves via the
+    // scoped-replacement path (#9537) covered by
+    // archive-conflict-resolution.integration.spec.ts.
     //
     // Each case notes its production dispatcher, because "an action creator
     // exists" is not the same claim as "a user can trigger it".

--- a/src/app/op-log/testing/integration/unsupported-multi-entity-conflict.integration.spec.ts
+++ b/src/app/op-log/testing/integration/unsupported-multi-entity-conflict.integration.spec.ts
@@ -7,7 +7,7 @@ import { SnackService } from '../../../core/snack/snack.service';
 import { ClientIdService } from '../../../core/util/client-id.service';
 import { ArchiveModel } from '../../../features/archive/archive.model';
 import { TaskArchiveService } from '../../../features/archive/task-archive.service';
-import { DEFAULT_TASK, Task } from '../../../features/tasks/task.model';
+import { DEFAULT_TASK, Task, TaskWithSubTasks } from '../../../features/tasks/task.model';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { OperationApplierService } from '../../apply/operation-applier.service';
 import { OperationCaptureService } from '../../capture/operation-capture.service';
@@ -246,6 +246,77 @@ describe('unsupported archive multi-entity conflict integration (#9405)', () => 
     expect((await opLogStore.getUnsynced()).map(({ op }) => op.id)).toEqual([
       localOperation.id,
     ]);
+    expect(operationApplier.applyOperations).not.toHaveBeenCalled();
+    expect(await journal.list('history')).toEqual([]);
+  });
+
+  it('wedges sync when both devices archive an overlapping done task (finish-day race)', async () => {
+    // Reachable from ordinary use on two devices: "Finish day" (daily summary /
+    // work view) archives ALL done tasks as ONE atomic moveToArchive op. When a
+    // second device archives any of the same tasks concurrently, the planner
+    // resolves the shared entity as remote-archive (winner=remote), so the
+    // local multi-entity archive op loses — and a losing moveToArchive has no
+    // scoped-replacement path (the archive-win recreation only runs when LOCAL
+    // wins). The preflight fails closed and sync stays wedged until one side's
+    // ops change. Pins the live defect observed 2026-08 (entityCount=4).
+    const doneTask = (id: string): TaskWithSubTasks => ({
+      ...DEFAULT_TASK,
+      id,
+      title: `Done ${id}`,
+      projectId: 'project1',
+      isDone: true,
+      doneOn: 1_000,
+      subTasks: [],
+    });
+    const localAction = TaskSharedActions.moveToArchive({
+      tasks: [doneTask('task-a'), doneTask('task-b')],
+    }) as PersistentAction;
+    store.dispatch(localAction);
+
+    const localOperation = await pendingLocalOperation();
+    expect(localOperation.actionType).toBe(ActionType.TASK_SHARED_MOVE_TO_ARCHIVE);
+    expect(localOperation.entityIds).toEqual(['task-a', 'task-b']);
+
+    const remoteAction = TaskSharedActions.moveToArchive({
+      tasks: [doneTask('task-a')],
+    }) as PersistentAction;
+    const { type, meta, ...actionPayload } = remoteAction;
+    const remoteOperation = {
+      ...new TestClient(REMOTE_CLIENT_ID).createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: 'task-a',
+        entityIds: ['task-a'],
+        payload: {
+          actionPayload,
+          entityChanges: capture.extractEntityChanges(remoteAction),
+        },
+      }),
+      timestamp: localOperation.timestamp + 1,
+    };
+    const detection = await resolver.checkOpForConflicts(remoteOperation, {
+      localPendingOpsByEntity: await opLogStore.getUnsyncedByEntity(),
+      appliedFrontierByEntity: new Map(),
+      retainedOpsByEntity: new Map(),
+      snapshotVectorClock: undefined,
+      snapshotEntityKeys: undefined,
+      hasNoSnapshotClock: true,
+    });
+    expect(detection.conflicts.length).toBeGreaterThan(0);
+
+    let thrown: unknown;
+    try {
+      await resolver.autoResolveConflictsLWW(detection.conflicts);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
+    expect((thrown as Error).message).toBe(
+      'SYNC_MULTI_ENTITY_UNSUPPORTED side=local ' +
+        `actionType=${ActionType.TASK_SHARED_MOVE_TO_ARCHIVE} entityCount=2`,
+    );
     expect(operationApplier.applyOperations).not.toHaveBeenCalled();
     expect(await journal.list('history')).toEqual([]);
   });


### PR DESCRIPTION
## Problem

When two devices concurrently archive overlapping done tasks (e.g., both running "Finish day"), the local bulk `moveToArchive` operation conflicts with the remote archive. Previously, this would fail the multi-entity preflight check with `SYNC_MULTI_ENTITY_UNSUPPORTED` and wedge sync on every retry (#9537, #9405).

The issue occurs because:

1. Device A archives tasks [A, B, C, D] in one atomic bulk op
2. Device B concurrently archives task A
3. When A syncs, its bulk op conflicts with B's remote archive on task A
4. The system had no resolution path for partially-rejected bulk archives

The only escape was a destructive force-overwrite (see the reporter's workaround in #9537).

## Solution

Implement scoped replacement logic for losing bulk archive operations, mirroring the existing `_preservePartiallyRejectedLocalBulkDeletes` mechanism (#9426 pattern):

1. **Scoped replacement**: When a bulk `moveToArchive` loses one or more entities to concurrent remote archives, emit ONE replacement op narrowed to the tasks the remote archive did not cover (e.g., [B, C, D] instead of [A, B, C, D]). A full overlap degrades to plain rejection.

2. **Vector clock dominance**: The replacement carries a merged-and-incremented vector clock that dominates every involved row and preserves the original timestamp, ensuring convergence without re-asserting remote-archived tasks' stale local snapshots.

3. **Restored task handling**: Tasks that were restored (back in the ACTIVE store) after the bulk archive are dropped from the replacement. If such a task's own row won locally, a current-state compensation op re-asserts the restore (the row rejection discards the raw `restoreTask` op).

4. **Mixed-winner groups**: When a group mixes winners (some tasks remote-archived, others winning against plain edits), the archive-win rows' full-set recreation is swapped for the scoped op so it cannot re-assert remote-archived tasks' stale snapshots.

5. **Safety guards**: Degenerate multi-bulk histories (two pending bulk archives, or a bulk archive plus a bulk delete, sharing a conflicted task) keep the fail-closed stop — adversarial review confirmed no production flow reaches these shapes, and they either wedged or silently misresolved in every shipped release.

The preflight excusal is per-op now, which also fixes a second wedge shape: a *winning* bulk archive sharing an entity with an excused decomposable op (e.g. `roundTimeSpentForDay`) no longer throws. The genuinely unsafe remainder (`updateTasks`, legacy `addTagToTask`) still fails closed. No schema bump — the replacement is an ordinary `moveToArchive` op that old clients apply natively.

### Changes

- **`conflict-resolution.service.ts`**:
  - Added `_preservePartiallyRejectedLocalBulkArchives()` to create scoped replacements for losing bulk archives
  - Added `_createScopedBulkArchiveReplacement()` to narrow payload tasks and entityChanges
  - Relaxed `_assertMultiEntityPlansAreSafe()` to excuse bulk archives per-op, with new fail-closed checks for degenerate multi-bulk overlaps
  - Wired the new preserve step into `autoResolveConflictsLWW()`

- **`archive-conflict-resolution.integration.spec.ts`** (new, 12 tests): scoped replacement, full-overlap rejection, mixed winners, decomposable-sibling coexistence, restored-task drop/compensation/split-group shapes, multi-client races, one-replacement-per-group dedupe, and the two fail-closed shapes

- **`conflict-resolution.service.spec.ts`**: unit tests for entityChanges narrowing and legacy flat-payload scoping

- **`supersync-archive-conflict.spec.ts`** (e2e): two-client finish-day race against a live SuperSync server — verified to fail with the exact production wedge error on pre-fix code and pass with the fix

- **`unsupported-multi-entity-conflict.integration.spec.ts`**: archive pin relocated to the new spec; remaining blocked surface unchanged

Every behavior change was reproduced as a failing test before its fix. The branch went through three multi-agent review rounds; all confirmed findings are fixed on the branch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmn4zoaEt6CKthHfn3DToW