### PR TITLE
fix(op-log): skip compaction while boot hydration replay is in progress (#9084)

### DIFF
--- a/src/app/op-log/apply/hydration-state.service.ts
+++ b/src/app/op-log/apply/hydration-state.service.ts
@@ -130,17 +130,10 @@ export class HydrationStateService implements RemoteApplyWindowPort {
 
   /**
    * #9084: true for the full duration of OperationLogHydratorService's
-   * hydrateStore() run, from before the snapshot's loadAllData dispatch until
-   * the tail ops it implies have actually been replayed into the store. A
-   * write landing in that window (e.g. TODAY_TAG repair reacting to
-   * loadAllData) is durable and unblocks the compaction counter before the
-   * tail ops are re-dispatched, so none of compact()'s other guards see it:
-   * getPendingRemoteOps is empty (the tail ops are local, already
-   * 'applied' from their original session) and nothing is pending or
-   * deferred. Without this flag compact() would cache a state missing the
-   * tail ops' effects under a lastAppliedOpSeq that covers them, and prune
-   * the very ops the next boot needs to recover them. Set/cleared by
-   * OperationLogHydratorService around each hydrateStore() run.
+   * hydrateStore() run, covering the gap between the snapshot's loadAllData
+   * dispatch and the tail-op replay on top of it. Compaction must not run in
+   * that gap — see the guard in OperationLogCompactionService._doCompact for
+   * the full reasoning. Set/cleared by the hydrator around each run.
    */
   isHydrationInProgress(): boolean {
     return this._isHydrationInProgress;

--- a/src/app/op-log/apply/hydration-state.service.ts
+++ b/src/app/op-log/apply/hydration-state.service.ts
@@ -64,6 +64,7 @@ const SYNC_WINDOW_FAILSAFE_MS = 2000;
 export class HydrationStateService implements RemoteApplyWindowPort {
   private _isApplyingRemoteOps = signal(false);
   private _isHydrationFallbackActive = false;
+  private _isHydrationInProgress = false;
   private _isDirectApplyActive = false;
   private _applyingRemoteOpsHoldCount = 0;
   private _isInPostSyncCooldown = signal(false);
@@ -125,6 +126,28 @@ export class HydrationStateService implements RemoteApplyWindowPort {
 
   setHydrationFallbackActive(isActive: boolean): void {
     this._isHydrationFallbackActive = isActive;
+  }
+
+  /**
+   * #9084: true for the full duration of OperationLogHydratorService's
+   * hydrateStore() run, from before the snapshot's loadAllData dispatch until
+   * the tail ops it implies have actually been replayed into the store. A
+   * write landing in that window (e.g. TODAY_TAG repair reacting to
+   * loadAllData) is durable and unblocks the compaction counter before the
+   * tail ops are re-dispatched, so none of compact()'s other guards see it:
+   * getPendingRemoteOps is empty (the tail ops are local, already
+   * 'applied' from their original session) and nothing is pending or
+   * deferred. Without this flag compact() would cache a state missing the
+   * tail ops' effects under a lastAppliedOpSeq that covers them, and prune
+   * the very ops the next boot needs to recover them. Set/cleared by
+   * OperationLogHydratorService around each hydrateStore() run.
+   */
+  isHydrationInProgress(): boolean {
+    return this._isHydrationInProgress;
+  }
+
+  setHydrationInProgress(isInProgress: boolean): void {
+    this._isHydrationInProgress = isInProgress;
   }
 
   /**

--- a/src/app/op-log/persistence/operation-log-compaction.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.spec.ts
@@ -154,6 +154,30 @@ describe('OperationLogCompactionService', () => {
       expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
     });
 
+    // #9084: boot hydration dispatches the snapshot's loadAllData, then
+    // replays tail ops on top of it with await boundaries (and no lock) in
+    // between. A write landing in that window can trigger compaction before
+    // the tail ops are re-dispatched, baking a state cache that is missing
+    // their effects under a lastAppliedOpSeq that already covers them.
+    it('should skip compaction while boot hydration replay is in progress (#9084)', async () => {
+      TestBed.inject(HydrationStateService).setHydrationInProgress(true);
+
+      const result = await service.compact();
+
+      expect(result).toBe(false);
+      expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
+      expect(mockOpLogStore.deleteOpsWhere).not.toHaveBeenCalled();
+    });
+
+    it('should also block emergency compaction while boot hydration replay is in progress', async () => {
+      TestBed.inject(HydrationStateService).setHydrationInProgress(true);
+
+      const result = await service.emergencyCompact();
+
+      expect(result).toBe(false);
+      expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
+    });
+
     it('should log metrics if compaction is slow', async () => {
       // Use jasmine.clock to control Date.now() without actual delays
       jasmine.clock().install();

--- a/src/app/op-log/persistence/operation-log-compaction.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.spec.ts
@@ -154,12 +154,9 @@ describe('OperationLogCompactionService', () => {
       expect(mockOpLogStore.saveStateCache).not.toHaveBeenCalled();
     });
 
-    // #9084: boot hydration dispatches the snapshot's loadAllData, then
-    // replays tail ops on top of it with await boundaries (and no lock) in
-    // between. A write landing in that window can trigger compaction before
-    // the tail ops are re-dispatched, baking a state cache that is missing
-    // their effects under a lastAppliedOpSeq that already covers them.
-    it('should skip compaction while boot hydration replay is in progress (#9084)', async () => {
+    // #9084: compaction must skip while hydration is between the snapshot's
+    // loadAllData dispatch and the tail-op replay — see the guard in _doCompact.
+    it('should skip compaction while hydration replay is in progress (#9084)', async () => {
       TestBed.inject(HydrationStateService).setHydrationInProgress(true);
 
       const result = await service.compact();
@@ -169,7 +166,7 @@ describe('OperationLogCompactionService', () => {
       expect(mockOpLogStore.deleteOpsWhere).not.toHaveBeenCalled();
     });
 
-    it('should also block emergency compaction while boot hydration replay is in progress', async () => {
+    it('should also block emergency compaction while hydration replay is in progress', async () => {
       TestBed.inject(HydrationStateService).setHydrationInProgress(true);
 
       const result = await service.emergencyCompact();

--- a/src/app/op-log/persistence/operation-log-compaction.service.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.ts
@@ -133,22 +133,23 @@ export class OperationLogCompactionService {
         return false;
       }
 
-      // GUARD (#9084): boot hydration dispatches the snapshot's loadAllData,
-      // then replays the tail ops on top of it — with await boundaries in
-      // between and no lock held across them. A write that lands in that
-      // window (e.g. TODAY_TAG repair) is durable and can push the
-      // compaction counter over threshold before the tail ops are
-      // re-dispatched. None of the guards above see it: the tail ops are
-      // local and already 'applied' from their original session (so
-      // getPendingRemoteOps is empty), and nothing is pending or deferred.
-      // Compacting then would cache a state missing the tail ops' effects
-      // under a lastAppliedOpSeq that covers them, and prune the very ops
-      // the next boot needs to recover them. Skipping is always safe: the
-      // op-log stays the source of truth and compaction re-runs once
-      // hydration completes.
+      // GUARD (#9084): hydration dispatches the snapshot's loadAllData and
+      // only later replays the tail ops on top of it (await boundaries, no
+      // lock in between). Compacting inside that gap would cache state
+      // missing the tail ops' effects under a lastAppliedOpSeq that covers
+      // them — and prune the very ops the next boot needs to recover them.
+      // The guards above don't see this: the tail ops are already terminal
+      // ('applied' in their original session), nothing pending or deferred.
+      // Reachable via re-entrant hydration (PluginAPI.reInitData()) in a
+      // session past the compaction threshold, or the legacy-snapshot
+      // compact() in RemoteOpsProcessingService; on a cold boot repair
+      // effects are held off by skipDuringSyncWindow() until after
+      // hydrateStore() resolves. Skipping is always safe: the op-log stays
+      // the source of truth and the next over-threshold write retriggers
+      // compaction once hydration completes.
       if (this.hydrationState.isHydrationInProgress()) {
         OpLog.warn(
-          `OperationLogCompactionService: Skipping ${label}compaction — boot hydration replay in progress (#9084)`,
+          `OperationLogCompactionService: Skipping ${label}compaction — hydration replay in progress (#9084)`,
         );
         return false;
       }

--- a/src/app/op-log/persistence/operation-log-compaction.service.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.ts
@@ -133,6 +133,26 @@ export class OperationLogCompactionService {
         return false;
       }
 
+      // GUARD (#9084): boot hydration dispatches the snapshot's loadAllData,
+      // then replays the tail ops on top of it — with await boundaries in
+      // between and no lock held across them. A write that lands in that
+      // window (e.g. TODAY_TAG repair) is durable and can push the
+      // compaction counter over threshold before the tail ops are
+      // re-dispatched. None of the guards above see it: the tail ops are
+      // local and already 'applied' from their original session (so
+      // getPendingRemoteOps is empty), and nothing is pending or deferred.
+      // Compacting then would cache a state missing the tail ops' effects
+      // under a lastAppliedOpSeq that covers them, and prune the very ops
+      // the next boot needs to recover them. Skipping is always safe: the
+      // op-log stays the source of truth and compaction re-runs once
+      // hydration completes.
+      if (this.hydrationState.isHydrationInProgress()) {
+        OpLog.warn(
+          `OperationLogCompactionService: Skipping ${label}compaction — boot hydration replay in progress (#9084)`,
+        );
+        return false;
+      }
+
       // 1. Get current state from NgRx store
       const currentState = this.stateSnapshot.getStateSnapshotForOperationLog();
       this.checkCompactionTimeout(startTime, `${label}state snapshot`);

--- a/src/app/op-log/persistence/operation-log-hydrator.retry.integration.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.retry.integration.spec.ts
@@ -131,6 +131,7 @@ describe('OperationLogHydratorService retryFailedRemoteOps (integration, real st
           useValue: {
             startApplyingRemoteOps: () => {},
             endApplyingRemoteOps: () => {},
+            setHydrationInProgress: () => {},
           },
         },
       ],

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -157,6 +157,7 @@ describe('OperationLogHydratorService', () => {
       'startApplyingRemoteOps',
       'endApplyingRemoteOps',
       'setHydrationFallbackActive',
+      'setHydrationInProgress',
     ]);
     mockSnapshotService = jasmine.createSpyObj('OperationLogSnapshotService', [
       'isValidSnapshot',
@@ -513,6 +514,39 @@ describe('OperationLogHydratorService', () => {
         // Hydration state is managed around the dispatch
         expect(mockHydrationStateService.startApplyingRemoteOps).toHaveBeenCalled();
         expect(mockHydrationStateService.endApplyingRemoteOps).toHaveBeenCalled();
+      });
+
+      // #9084: compaction can race the gap between the snapshot's loadAllData
+      // dispatch and the tail ops actually being replayed on top of it — a
+      // write landing there (e.g. TODAY_TAG repair) is durable and can trigger
+      // compaction while the tail ops' effects are still missing from state.
+      // isHydrationInProgress must stay set for the whole run so compaction's
+      // guard (#9084) covers that gap, not just the bulk-dispatch call itself
+      // (already covered by start/endApplyingRemoteOps above).
+      it('should hold hydration-in-progress across the full run, from before the snapshot dispatch until after the tail replay (#9084)', async () => {
+        const snapshot = createMockSnapshot({ lastAppliedOpSeq: 5 });
+        const tailOps = [createMockEntry(6, createMockOperation('op-6'))];
+        mockOpLogStore.loadStateCache.and.resolveTo(snapshot);
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo(tailOps);
+
+        const callOrder: string[] = [];
+        mockHydrationStateService.setHydrationInProgress.and.callFake(((
+          isInProgress: boolean,
+        ) => {
+          callOrder.push(isInProgress ? 'in-progress:true' : 'in-progress:false');
+        }) as never);
+        mockStore.dispatch.and.callFake(((action: { type: string }) => {
+          callOrder.push(`dispatch:${action.type}`);
+        }) as never);
+
+        await service.hydrateStore();
+
+        expect(callOrder).toEqual([
+          'in-progress:true',
+          `dispatch:${loadAllData.type}`,
+          `dispatch:${bulkApplyHydrationOperations.type}`,
+          'in-progress:false',
+        ]);
       });
 
       it('should replay a tail op with a malformed stored schemaVersion verbatim instead of failing into recovery', async () => {

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -516,13 +516,9 @@ describe('OperationLogHydratorService', () => {
         expect(mockHydrationStateService.endApplyingRemoteOps).toHaveBeenCalled();
       });
 
-      // #9084: compaction can race the gap between the snapshot's loadAllData
-      // dispatch and the tail ops actually being replayed on top of it — a
-      // write landing there (e.g. TODAY_TAG repair) is durable and can trigger
-      // compaction while the tail ops' effects are still missing from state.
-      // isHydrationInProgress must stay set for the whole run so compaction's
-      // guard (#9084) covers that gap, not just the bulk-dispatch call itself
-      // (already covered by start/endApplyingRemoteOps above).
+      // #9084: the flag must bracket the whole run — from before the snapshot
+      // dispatch until after the tail replay — so the compaction guard covers
+      // the gap between them, not just the bulk-dispatch call itself.
       it('should hold hydration-in-progress across the full run, from before the snapshot dispatch until after the tail replay (#9084)', async () => {
         const snapshot = createMockSnapshot({ lastAppliedOpSeq: 5 });
         const tailOps = [createMockEntry(6, createMockOperation('op-6'))];

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -121,6 +121,14 @@ export class OperationLogHydratorService {
     // version AFTER the migration chain has actually run, which is safe.
     let snapshotPersistedDuringHydration = false;
 
+    // #9084: held for the whole run, including the await boundaries between
+    // dispatching the snapshot's loadAllData and actually replaying the tail
+    // ops on top of it. A write landing in that window is durable and can
+    // trigger compaction before the tail ops are re-dispatched, which would
+    // cache state missing their effects — see the guard in
+    // OperationLogCompactionService._doCompact.
+    this.hydrationStateService.setHydrationInProgress(true);
+
     try {
       // PERF: Parallel startup operations - all access different IndexedDB stores
       // and don't depend on each other's results, so they can run concurrently.
@@ -412,6 +420,8 @@ export class OperationLogHydratorService {
         });
         throw recoveryErr;
       }
+    } finally {
+      this.hydrationStateService.setHydrationInProgress(false);
     }
   }
 

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -121,15 +121,14 @@ export class OperationLogHydratorService {
     // version AFTER the migration chain has actually run, which is safe.
     let snapshotPersistedDuringHydration = false;
 
-    // #9084: held for the whole run, including the await boundaries between
-    // dispatching the snapshot's loadAllData and actually replaying the tail
-    // ops on top of it. A write landing in that window is durable and can
-    // trigger compaction before the tail ops are re-dispatched, which would
-    // cache state missing their effects — see the guard in
-    // OperationLogCompactionService._doCompact.
-    this.hydrationStateService.setHydrationInProgress(true);
-
     try {
+      // #9084: held for the whole run so compaction cannot capture the gap
+      // between the loadAllData dispatch and the tail replay — see the guard
+      // in OperationLogCompactionService._doCompact. Inside the try so a
+      // throw still reaches the recovery path below; the finally always
+      // clears it.
+      this.hydrationStateService.setHydrationInProgress(true);
+
       // PERF: Parallel startup operations - all access different IndexedDB stores
       // and don't depend on each other's results, so they can run concurrently.
       const [pendingRemoteOps, , hasBackup] = await Promise.all([


### PR DESCRIPTION
This is a small, targeted change to src/app/op-log/apply/hydration-state.service.ts, .../operation-log-compaction.service.spec.ts, .../operation-log-compaction.service.ts, .../operation-log-hydrator.service.spec.ts and a few others that resolves the reported issue without touching anything unrelated. Fixes #9084.

I pushed this to my fork first and the project's own CI workflows pass on the commit.
