### PR TITLE
chore(deps): upgrade electron from 41.4.0 to 43.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,10 +92,10 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
-          # Retry electron's flaky postinstall binary download. Drop
-          # node_modules/electron between tries so npm re-runs the postinstall
-          # (a plain re-`npm i` skips scripts for an already-present package).
-          command: npm i || { rm -rf node_modules/electron; exit 1; }
+          # Retry to ride out transient npm registry flakiness. (Since
+          # Electron 42 `npm i` no longer downloads the Electron binary;
+          # electron-builder fetches its own copy when packaging.)
+          command: npm i
 
       - name: Install Playwright Browsers
         run: |
@@ -219,10 +219,10 @@ jobs:
         uses: ./.github/actions/setup-electron-build
 
       # @nx/nx-darwin-arm64 + dmg-license aren't in package.json (npm's
-      # optional-dep bug skips them), so install them explicitly. That install
-      # and `npm i` both run electron's flaky postinstall binary download, so
-      # retry the whole thing — dropping node_modules/electron between tries
-      # forces the postinstall to re-run (npm skips it for a present package).
+      # optional-dep bug skips them), so install them explicitly, and retry to
+      # ride out transient npm registry flakiness. (Since Electron 42 `npm i`
+      # no longer downloads the Electron binary; electron-builder fetches its
+      # own copy when packaging.)
       - name: Install npm Packages
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
@@ -230,7 +230,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
-          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i || { rm -rf node_modules/electron; exit 1; }
+          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i
 
       - run: 'echo "$PROVISION_PROFILE" | base64 --decode > embedded.provisionprofile'
         shell: bash
@@ -309,10 +309,10 @@ jobs:
         uses: ./.github/actions/setup-electron-build
 
       # @nx/nx-win32-x64-msvc isn't in package.json (npm's optional-dep bug
-      # skips it), so install it explicitly. That install and `npm i` both run
-      # electron's flaky postinstall binary download, so retry the whole thing
-      # — dropping node_modules/electron between tries forces the postinstall
-      # to re-run (npm skips it for a present package).
+      # skips it), so install it explicitly, and retry to ride out transient
+      # npm registry flakiness. (Since Electron 42 `npm i` no longer downloads
+      # the Electron binary; electron-builder fetches its own copy when
+      # packaging.)
       - name: Install npm Packages
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
@@ -320,7 +320,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
-          command: npm install @nx/nx-win32-x64-msvc && npm i || { rm -rf node_modules/electron; exit 1; }
+          command: npm install @nx/nx-win32-x64-msvc && npm i
 
       - name: Setup Chrome
         id: setup-chrome

--- a/.github/workflows/electron-smoke.yml
+++ b/.github/workflows/electron-smoke.yml
@@ -62,10 +62,10 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
-          # Retry electron's flaky postinstall binary download. Drop
-          # node_modules/electron between tries so npm re-runs the postinstall
-          # (a plain re-`npm i` skips scripts for an already-present package).
-          command: npm i || { rm -rf node_modules/electron; exit 1; }
+          # Retry to ride out transient npm registry flakiness. (Since
+          # Electron 42 `npm i` no longer downloads the Electron binary;
+          # electron-builder fetches its own copy at packaging time below.)
+          command: npm i
 
       - run: npm run env
 
@@ -81,7 +81,16 @@ jobs:
         # --linux dir produces linux-unpacked/ with the real app.asar but
         # skips AppImage/deb/snap/rpm — cheap and enough to exercise the
         # same packaging pipeline release uses.
-        run: npx electron-builder --linux dir --publish never
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          # Retry electron-builder's Electron zip download from GitHub
+          # releases, which fails transiently now and then (e.g. EOF mid
+          # download).
+          command: npx electron-builder --linux dir --publish never
 
       - name: Verify require() targets in app.asar
         run: |

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -27,10 +27,10 @@ jobs:
         uses: ./.github/actions/setup-electron-build
 
       # @nx/nx-win32-x64-msvc isn't in package.json (npm's optional-dep bug
-      # skips it), so install it explicitly. That install and `npm i` both run
-      # electron's flaky postinstall binary download, so retry the whole thing
-      # — dropping node_modules/electron between tries forces the postinstall
-      # to re-run (npm skips it for a present package).
+      # skips it), so install it explicitly, and retry to ride out transient
+      # npm registry flakiness. (Since Electron 42 `npm i` no longer downloads
+      # the Electron binary; electron-builder fetches its own copy when
+      # packaging.)
       - name: Install npm Packages
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
@@ -38,7 +38,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
-          command: npm install @nx/nx-win32-x64-msvc && npm i || { rm -rf node_modules/electron; exit 1; }
+          command: npm install @nx/nx-win32-x64-msvc && npm i
 
       - name: Build Frontend & Electron TS
         run: npm run buildAllElectron:noTests:prod
@@ -77,10 +77,10 @@ jobs:
         uses: ./.github/actions/setup-electron-build
 
       # @nx/nx-darwin-arm64 + dmg-license aren't in package.json (npm's
-      # optional-dep bug skips them), so install them explicitly. That install
-      # and `npm i` both run electron's flaky postinstall binary download, so
-      # retry the whole thing — dropping node_modules/electron between tries
-      # forces the postinstall to re-run (npm skips it for a present package).
+      # optional-dep bug skips them), so install them explicitly, and retry to
+      # ride out transient npm registry flakiness. (Since Electron 42 `npm i`
+      # no longer downloads the Electron binary; electron-builder fetches its
+      # own copy when packaging.)
       - name: Install npm Packages
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
@@ -88,7 +88,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
-          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i || { rm -rf node_modules/electron; exit 1; }
+          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i
 
       - run: 'echo "$PROVISION_PROFILE" | base64 --decode > embedded.provisionprofile'
         shell: bash

--- a/.github/workflows/test-mac-dmg-build.yml
+++ b/.github/workflows/test-mac-dmg-build.yml
@@ -18,10 +18,10 @@ jobs:
         uses: ./.github/actions/setup-electron-build
 
       # @nx/nx-darwin-arm64 + dmg-license aren't in package.json (npm's
-      # optional-dep bug skips them), so install them explicitly. That install
-      # and `npm i` both run electron's flaky postinstall binary download, so
-      # retry the whole thing — dropping node_modules/electron between tries
-      # forces the postinstall to re-run (npm skips it for a present package).
+      # optional-dep bug skips them), so install them explicitly, and retry to
+      # ride out transient npm registry flakiness. (Since Electron 42 `npm i`
+      # no longer downloads the Electron binary; electron-builder fetches its
+      # own copy when packaging.)
       - name: Install npm packages
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
@@ -29,7 +29,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
-          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i || { rm -rf node_modules/electron; exit 1; }
+          command: npm install @nx/nx-darwin-arm64 dmg-license && npm i
 
       - name: Decode provisioning profile
         shell: bash

--- a/electron/jira.test.cjs
+++ b/electron/jira.test.cjs
@@ -4,6 +4,19 @@ const path = require('node:path');
 
 require('ts-node/register/transpile-only');
 
+// Electron >= 42 removed its postinstall step: `require('electron')` now
+// downloads the ~120MB binary on demand and throws when that fails. This suite
+// only reaches electron transitively (proxy-agent -> electron-log/main) and
+// never touches real electron APIs, so pre-seed the module cache with a stub
+// to keep the tests offline-safe and download-free.
+const electronId = require.resolve('electron');
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: {},
+};
+
 const {
   executeJiraRequest,
 } = require(

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "cross-env": "^10.1.0",
         "detect-it": "^4.0.1",
         "dotenv": "^17.4.2",
-        "electron": "41.4.0",
+        "electron": "43.4.0",
         "electron-builder": "^26.8.1",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -4407,6 +4407,16 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -4533,60 +4543,37 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
       }
     },
-    "node_modules/@electron/get/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@electron/get/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@electron/get/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@electron/notarize": {
@@ -10097,17 +10084,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.4",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
@@ -14126,22 +14102,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.4.0.tgz",
-      "integrity": "sha512-1afmxJGyrZ4bve+PDCs8YtNjjVu4cPwUtSjx36o6gyJWI0NvhebMKtIzzKNOScRyXntH2hX0i350Xgm3BKiEYQ==",
+      "version": "43.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
+      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -15802,27 +15778,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
     },
     "node_modules/extsprintf": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "cross-env": "^10.1.0",
     "detect-it": "^4.0.1",
     "dotenv": "^17.4.2",
-    "electron": "41.4.0",
+    "electron": "43.4.0",
     "electron-builder": "^26.8.1",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",

--- a/src/app/core-ui/main-header/main-header.component.scss
+++ b/src/app/core-ui/main-header/main-header.component.scss
@@ -28,12 +28,17 @@
 }
 
 :host-context(.isNoMac.isObsidianStyleHeader.isElectron) {
-  // Dynamic window controls width using Window Controls Overlay CSS env vars
-  // env(titlebar-area-width) = available width (viewport - controls)
-  // So: controls width = 100vw - titlebar-area-width
-  // Fallback calc ensures 140px when env vars unavailable
-  // Only on non-Mac: macOS window controls are on the left, no right padding needed
-  padding-right: calc(100vw - env(titlebar-area-width, calc(100vw - 140px)));
+  // Keep header content inside the Window Controls Overlay safe area:
+  // env(titlebar-area-x) = left inset, env(titlebar-area-width) = safe width.
+  // Since Electron 43, Linux WCO follows the native button layout, so controls
+  // can sit left, right, or on both sides — pad both edges instead of assuming
+  // right-side controls. Fallbacks (0 left / 140px right) preserve the old
+  // behavior when the env vars are unavailable.
+  // Only on non-Mac: macOS uses hiddenInset traffic lights, handled above.
+  padding-left: env(titlebar-area-x, 0px);
+  padding-right: calc(
+    100vw - env(titlebar-area-x, 0px) - env(titlebar-area-width, calc(100vw - 140px))
+  );
 
   // Prevent header content from overflowing into the window controls area
   // when the window is resized to a narrow width (fixes #6365).


### PR DESCRIPTION
Supersedes #9559 (Dependabot) — same dependency bump (lockfile verified line-identical), plus the changes the two-major jump actually requires.

## Changes

- **fix(header):** Electron 43 makes Linux Window-Controls-Overlay follow the native title-bar layout (buttons can sit left, right, or both sides — e.g. RTL systems, GNOME close-only). The header previously reserved space with right-only padding; it now derives both safe-area insets from `env(titlebar-area-x)` / `env(titlebar-area-width)`. Backward-compatible with Electron ≤42 (where `x` is always 0). This was the blocking finding on #9465.
- **test(electron):** since Electron 42, `require('electron')` downloads the ~120MB binary on demand (postinstall removed) — `jira.test.cjs` reaches it transitively via `electron-log/main` and started failing offline / downloading mid-test in CI. The suite now pre-seeds `require.cache` with a stub; 280/280 pass fully offline.
- **chore(deps):** the bump itself, identical to Dependabot's resolution (`electron@43.4.0`, `@electron/get@5.1.0`, `@electron-internal/extract-zip@1.0.5`; `extract-zip`/`@types/yauzl` dropped).
- **ci(build):** the `npm i || { rm -rf node_modules/electron; … }` retry hack in 7 places targeted the removed postinstall download; comments rewritten, retry kept for plain registry flakiness. The smoke workflow's electron-builder packaging step (which died with a download EOF on the Dependabot run) is now wrapped in the same 3-attempt retry.

## Breaking-changes audit (42 → 43)

Checked every documented change against the codebase: no call sites for removed/changed APIs (`clearStorageData` quotas, `showHiddenFiles`, `toBitmap`, `createFromNamedImage`, main-process `Notification`, `ELECTRON_SKIP_BINARY_DOWNLOAD`); Node 22.18 satisfies the new ≥22.12 requirement; no armv7l/ia32 targets affected by upcoming 44 removals. Behavior notes: dialogs without `defaultPath` now open Downloads (sync-folder + image pickers — cosmetic), and frameless Linux windows default to rounded corners.

## Verification

- 280/280 electron node tests (offline), main-process tsc clean, SCSS lint, YAML validated.
- The packaged-app boot on 43.4.0 is what the **Linux Packaged Electron App** job on this PR must prove — it passed on the byte-identical 43.3.0 bump (#9465) and only failed on #9559 due to a transient download EOF (now retried).
- Worth one manual glance: header layout on Linux with left-side window buttons (X11/KDE; GNOME-Wayland forces native decorations).