### PR TITLE
fix(sync): guard snapshot/compaction anchors against concurrent-tab appends (#9438)

### DIFF
--- a/e2e/tests/multi-tab/second-tab-no-data-loss.spec.ts
+++ b/e2e/tests/multi-tab/second-tab-no-data-loss.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import { expectTaskCount } from '../../utils/assertions';
+
+/**
+ * Multi-tab smoke test for #9438: a second tab shares the origin's IndexedDB
+ * and — although the multi-instance blocker replaces its UI — still hydrates
+ * the op log in the background (hydration starts from an APP_INITIALIZER,
+ * before the single-instance probe resolves). Its post-replay checkpoint
+ * snapshot could historically anchor past ops the first tab appended
+ * concurrently, silently dropping them from the next boot's replay.
+ *
+ * This is a broad safety net, not a deterministic reproduction — the precise
+ * race is pinned by the Karma integration specs
+ * (multi-tab-frontier-guard.integration.spec.ts). Here: first tab works,
+ * a second tab opens mid-session, the first tab keeps working, and after a
+ * reload of the first tab every task must still be there.
+ */
+test.describe('Multi-tab', () => {
+  test('second tab must not cause task loss in the first tab after reload', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    const BEFORE_COUNT = 8;
+    for (let i = 1; i <= BEFORE_COUNT; i++) {
+      await workViewPage.addTask(`before-${i}`);
+    }
+    await expectTaskCount(taskPage, BEFORE_COUNT);
+
+    // The "second tab": same context = same IndexedDB + localStorage, exactly
+    // like a real second browser tab. No error collector on purpose — the
+    // blocked tab's torn-down UI may log teardown noise that is not under
+    // test here.
+    const page2 = await page.context().newPage();
+    await page2.goto('/', { waitUntil: 'domcontentloaded' });
+
+    // Keep appending in the first tab while the second tab hydrates — this is
+    // the overlap the #9438 guard protects.
+    await workViewPage.addTask('after-1');
+    await workViewPage.addTask('after-2');
+    await expectTaskCount(taskPage, BEFORE_COUNT + 2);
+
+    // The single-instance probe must have blocked the second tab's UI (the
+    // first tab responds to the BroadcastChannel probe).
+    await expect(page2.getByText('App is already open')).toBeVisible();
+
+    // Let persistence and the second tab's background hydration settle —
+    // NgRx effects write outside Angular's zone (same wait as the
+    // reload-persistence smoke test in work-view.spec.ts).
+    await page.waitForTimeout(1500);
+    await page2.close();
+
+    // The first tab's next boot replays snapshot + tail: nothing may be lost.
+    await page.reload();
+    await workViewPage.waitForTaskList();
+    await expectTaskCount(taskPage, BEFORE_COUNT + 2);
+    await expect(taskPage.getTaskByText('before-1')).toBeVisible();
+    await expect(taskPage.getTaskByText('after-2')).toBeVisible();
+  });
+});

--- a/src/app/op-log/persistence/operation-log-compaction.service.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.ts
@@ -73,6 +73,19 @@ export class OperationLogCompactionService {
       );
       return false;
     }
+    // Same fast-path rationale for the sticky #9438 divergence flag: it only
+    // clears on re-hydration/baseline install, compact() re-fires after every
+    // write once the counter sits at the threshold, and each attempt would
+    // otherwise pay the flush + cross-tab lock + state capture below before
+    // the in-lock guard skips anyway. The scalar frontier check stays in-lock
+    // (it needs getLastSeq()); only the sticky half can be hoisted. Emergency
+    // compaction is exempt from the #9438 guard, so it must not bail here.
+    if (!isEmergency && this.tabSeqFrontier.hasKnownForeignWrites()) {
+      OpLog.warn(
+        'OperationLogCompactionService: Skipping compaction — sticky concurrent-tab divergence (#9438)',
+      );
+      return false;
+    }
     const compactExclusively = async (): Promise<boolean> => {
       const startTime = Date.now();
       const label = isEmergency ? 'emergency ' : '';
@@ -171,14 +184,20 @@ export class OperationLogCompactionService {
       // concurrent tab's op is counted there while its effect is absent from
       // this tab's state. Anchoring the cache past it would make the next
       // boot's tail replay silently skip that op (and step 7 would prune ops
-      // behind the false anchor). Emergency compaction is exempt: it already
-      // accepts a residual re-replay window (see the lock note below) and
-      // must stay able to free space during quota recovery.
+      // behind the false anchor). Emergency compaction is exempt so quota
+      // recovery cannot wedge on a diverged tab — a real trade-off: a
+      // diverged emergency compact could still write the stale anchor this
+      // guard prevents (permanent op skip, NOT the bounded re-replay window
+      // the bare-lock note below accepts). Today that is unreachable in the
+      // quota path (the #8751 phantom guard skips deterministically there —
+      // see the reachability note in operation-log.effects.ts); re-evaluate
+      // this exemption if emergency compaction ever becomes completable.
       if (!isEmergency && !this.tabSeqFrontier.isSaveSafeAt(lastSeq)) {
         OpLog.warn(
           'OperationLogCompactionService: Skipping compaction — the op log ' +
             "contains writes from a concurrent tab that are not in this tab's " +
             'state (#9438)',
+          { lastSeq, frontier: this.tabSeqFrontier.frontierSeq },
         );
         return false;
       }

--- a/src/app/op-log/persistence/operation-log-compaction.service.ts
+++ b/src/app/op-log/persistence/operation-log-compaction.service.ts
@@ -18,6 +18,7 @@ import { OperationCaptureService } from '../capture/operation-capture.service';
 import { getPhantomChangeRisk } from '../capture/phantom-change-guard.util';
 import { OperationWriteFlushService } from '../sync/operation-write-flush.service';
 import { HydrationStateService } from '../apply/hydration-state.service';
+import { TabSeqFrontierService } from './tab-seq-frontier.service';
 
 /**
  * Manages the compaction (garbage collection) of the operation log.
@@ -36,6 +37,7 @@ export class OperationLogCompactionService {
   private operationCapture = inject(OperationCaptureService);
   private writeFlushService = inject(OperationWriteFlushService);
   private hydrationState = inject(HydrationStateService);
+  private tabSeqFrontier = inject(TabSeqFrontierService);
 
   async compact(): Promise<boolean> {
     return this._doCompact(COMPACTION_RETENTION_MS, false);
@@ -164,6 +166,22 @@ export class OperationLogCompactionService {
       // 3. Get lastSeq IMMEDIATELY before writing cache to minimize race window
       // This ensures new ops written after this point have seq > lastSeq
       const lastSeq = await this.opLogStore.getLastSeq();
+
+      // GUARD (#9438): lastSeq is the global max across the SHARED store — a
+      // concurrent tab's op is counted there while its effect is absent from
+      // this tab's state. Anchoring the cache past it would make the next
+      // boot's tail replay silently skip that op (and step 7 would prune ops
+      // behind the false anchor). Emergency compaction is exempt: it already
+      // accepts a residual re-replay window (see the lock note below) and
+      // must stay able to free space during quota recovery.
+      if (!isEmergency && !this.tabSeqFrontier.isSaveSafeAt(lastSeq)) {
+        OpLog.warn(
+          'OperationLogCompactionService: Skipping compaction — the op log ' +
+            "contains writes from a concurrent tab that are not in this tab's " +
+            'state (#9438)',
+        );
+        return false;
+      }
 
       // 4. Extract entity keys for conflict detection after compaction
       // This allows us to distinguish between entities that existed at snapshot time

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -17,6 +17,7 @@ import { OperationApplierService } from '../apply/operation-applier.service';
 import { HydrationStateService } from '../apply/hydration-state.service';
 import { OperationLogSnapshotService } from './operation-log-snapshot.service';
 import { OperationLogRecoveryService } from './operation-log-recovery.service';
+import { TabSeqFrontierService } from './tab-seq-frontier.service';
 import { SyncHydrationService } from './sync-hydration.service';
 import {
   ActionType,
@@ -370,6 +371,54 @@ describe('OperationLogHydratorService', () => {
         await service.hydrateStore();
 
         expect(mockOpLogStore.setVectorClock).toHaveBeenCalledWith(exactClock);
+      });
+    });
+
+    describe('tab applied-seq frontier establishment (#9438)', () => {
+      // The snapshot/compaction guard only arms once hydration establishes
+      // the frontier — these tests protect that wiring.
+      it('establishes the frontier at the snapshot anchor when there are no tail ops', async () => {
+        const snapshot = createMockSnapshot({ lastAppliedOpSeq: 5 });
+        mockOpLogStore.loadStateCache.and.resolveTo(snapshot);
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([]);
+
+        await service.hydrateStore();
+
+        const frontier = TestBed.inject(TabSeqFrontierService);
+        expect(frontier.isSaveSafeAt(5)).toBe(true);
+        expect(frontier.isSaveSafeAt(6)).toBe(false);
+      });
+
+      it('establishes the frontier at the last replayed tail seq', async () => {
+        const snapshot = createMockSnapshot({ lastAppliedOpSeq: 5 });
+        mockOpLogStore.loadStateCache.and.resolveTo(snapshot);
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          createMockEntry(6, createMockOperation('op-6')),
+          createMockEntry(7, createMockOperation('op-7')),
+        ]);
+
+        await service.hydrateStore();
+
+        const frontier = TestBed.inject(TabSeqFrontierService);
+        expect(frontier.isSaveSafeAt(7)).toBe(true);
+        expect(frontier.isSaveSafeAt(8)).toBe(false);
+      });
+
+      it('covers reducer-rejected tail entries with the frontier (replay skips them by design)', async () => {
+        const snapshot = createMockSnapshot({ lastAppliedOpSeq: 5 });
+        const rejectedEntry: OperationLogEntry = {
+          ...createMockEntry(6, createMockOperation('op-reducer-rejected')),
+          rejectedAt: Date.now(),
+          reducerRejectedAt: Date.now(),
+        };
+        mockOpLogStore.loadStateCache.and.resolveTo(snapshot);
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([rejectedEntry]);
+
+        await service.hydrateStore();
+
+        const frontier = TestBed.inject(TabSeqFrontierService);
+        expect(frontier.isSaveSafeAt(6)).toBe(true);
+        expect(frontier.isSaveSafeAt(5)).toBe(false);
       });
     });
 

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -10,6 +10,7 @@ import {
   SchemaMigrationService,
 } from './schema-migration.service';
 import { OperationLogSnapshotService } from './operation-log-snapshot.service';
+import { TabSeqFrontierService } from './tab-seq-frontier.service';
 import { OperationLogRecoveryService } from './operation-log-recovery.service';
 import { SyncHydrationService } from './sync-hydration.service';
 import { ArchiveMigrationService } from './archive-migration.service';
@@ -76,6 +77,7 @@ export class OperationLogHydratorService {
   private hydrationStateService = inject(HydrationStateService);
   private injector = inject(Injector);
   private clientIdProvider: ClientIdProvider = inject(CLIENT_ID_PROVIDER);
+  private tabSeqFrontier = inject(TabSeqFrontierService);
 
   // Extracted services
   private snapshotService = inject(OperationLogSnapshotService);
@@ -490,11 +492,22 @@ export class OperationLogHydratorService {
     lastAppliedOpSeq: number,
     pendingRemoteOps: OperationLogEntry[],
   ): Promise<boolean> {
-    const tailOps = (await this.opLogStore.getOpsAfterSeq(lastAppliedOpSeq)).filter(
+    const allTailEntries = await this.opLogStore.getOpsAfterSeq(lastAppliedOpSeq);
+    // #9438: every entry read here is covered by this hydration pass —
+    // including reducer-rejected ones, which replay deliberately skips
+    // forever. Ops a concurrent tab appends AFTER this read lie beyond this
+    // frontier, which is what arms the snapshot/compaction guard against
+    // anchoring past them.
+    const coveredSeq =
+      allTailEntries.length > 0
+        ? allTailEntries[allTailEntries.length - 1].seq
+        : lastAppliedOpSeq;
+    const tailOps = allTailEntries.filter(
       (entry) => entry.reducerRejectedAt === undefined,
     );
 
     if (tailOps.length === 0) {
+      this.tabSeqFrontier.establishFrontier(coveredSeq);
       return false;
     }
 
@@ -535,6 +548,7 @@ export class OperationLogHydratorService {
           appDataComplete: appData as unknown as AppDataComplete,
         }),
       );
+      this.tabSeqFrontier.establishFrontier(coveredSeq);
       // No snapshot save needed - full state ops already contain complete state
       // Snapshot will be saved after next batch of regular operations
       return false;
@@ -564,6 +578,10 @@ export class OperationLogHydratorService {
       localClientId,
       pendingRemoteOps.filter((entry) => tailOpIds.has(entry.op.id)),
     );
+
+    // #9438: establish BEFORE the async validation below so a concurrent
+    // tab's append during it cannot end up inside the save's anchor.
+    this.tabSeqFrontier.establishFrontier(coveredSeq);
 
     // CHECKPOINT C: Validate state after replaying tail operations.
     // If invalid, we keep the data on screen but skip the snapshot save so
@@ -614,9 +632,12 @@ export class OperationLogHydratorService {
     // legacy data. Replay ALL operations from the beginning of the log.
     // Status-blind except for durable reducer rejections — see the replay
     // policy note on _replayTailOps.
-    const allOps = (await this.opLogStore.getOpsAfterSeq(0)).filter(
-      (entry) => entry.reducerRejectedAt === undefined,
-    );
+    const allEntries = await this.opLogStore.getOpsAfterSeq(0);
+    // #9438: see _replayTailOps — the frontier covers everything read here,
+    // reducer-rejected entries included. Not established in fallback mode
+    // (partial state; the #9140 guards keep every save path skipped there).
+    const coveredSeq = allEntries.length > 0 ? allEntries[allEntries.length - 1].seq : 0;
+    const allOps = allEntries.filter((entry) => entry.reducerRejectedAt === undefined);
 
     if (allOps.length === 0) {
       if (fallbackCause !== undefined) {
@@ -629,6 +650,7 @@ export class OperationLogHydratorService {
       OpLog.normal(
         'OperationLogHydratorService: Fresh install detected. No data to load.',
       );
+      this.tabSeqFrontier.establishFrontier(coveredSeq);
       return false;
     }
 
@@ -659,6 +681,9 @@ export class OperationLogHydratorService {
           appDataComplete: appData as unknown as AppDataComplete,
         }),
       );
+      if (fallbackCause === undefined) {
+        this.tabSeqFrontier.establishFrontier(coveredSeq);
+      }
       // No snapshot save needed - full state ops already contain complete state
       OpLog.normal('OperationLogHydratorService: Full replay complete.');
       return false;
@@ -697,6 +722,10 @@ export class OperationLogHydratorService {
       );
       return false;
     }
+
+    // #9438: establish BEFORE the async validation below so a concurrent
+    // tab's append during it cannot end up inside the save's anchor.
+    this.tabSeqFrontier.establishFrontier(coveredSeq);
 
     // CHECKPOINT C: Validate state after replaying all operations.
     // If invalid, we still proceed but skip the snapshot save so we don't

--- a/src/app/op-log/persistence/operation-log-snapshot.service.ts
+++ b/src/app/op-log/persistence/operation-log-snapshot.service.ts
@@ -14,6 +14,7 @@ import { hasMeaningfulStateData } from '../validation/has-meaningful-state-data.
 import { OperationCaptureService } from '../capture/operation-capture.service';
 import { getPhantomChangeRisk } from '../capture/phantom-change-guard.util';
 import { OperationWriteFlushService } from '../sync/operation-write-flush.service';
+import { TabSeqFrontierService } from './tab-seq-frontier.service';
 
 type StateCache = MigratableStateCache;
 
@@ -37,6 +38,7 @@ export class OperationLogSnapshotService {
   private validateStateService = inject(ValidateStateService);
   private operationCapture = inject(OperationCaptureService);
   private writeFlushService = inject(OperationWriteFlushService);
+  private tabSeqFrontier = inject(TabSeqFrontierService);
 
   /**
    * Validates that a snapshot has the expected structure and data.
@@ -135,6 +137,21 @@ export class OperationLogSnapshotService {
         // and lastSeq after — see JSDoc above.
         const currentState = this.stateSnapshotService.getStateSnapshotForOperationLog();
         const lastSeq = await this.opLogStore.getLastSeq();
+
+        // GUARD (#9438): lastSeq is the global max across the SHARED store,
+        // but a concurrent tab's op is counted there while its effect is
+        // absent from this tab's captured state. Anchoring past it would make
+        // the next boot's tail replay silently skip that op. Persist only
+        // when the global max matches the frontier this tab has actually
+        // applied; skipping costs at most a slower next boot.
+        if (!this.tabSeqFrontier.isSaveSafeAt(lastSeq)) {
+          OpLog.warn(
+            'OperationLogSnapshotService: Skipping snapshot save — the op log ' +
+              'contains writes from a concurrent tab that are not in this ' +
+              "tab's state (#9438)",
+          );
+          return false;
+        }
 
         // GUARD (#7892): never cache an empty/degraded state over a good one.
         // The snapshot is only a load-time cache — the op-log is the source of

--- a/src/app/op-log/persistence/operation-log-snapshot.service.ts
+++ b/src/app/op-log/persistence/operation-log-snapshot.service.ts
@@ -149,6 +149,7 @@ export class OperationLogSnapshotService {
             'OperationLogSnapshotService: Skipping snapshot save — the op log ' +
               'contains writes from a concurrent tab that are not in this ' +
               "tab's state (#9438)",
+            { lastSeq, frontier: this.tabSeqFrontier.frontierSeq },
           );
           return false;
         }

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -51,6 +51,7 @@ import {
 import { IndexedDBOpenError } from '../core/errors/indexed-db-open.error';
 import { limitVectorClockSize, vectorClockToString } from '../../core/util/vector-clock';
 import { CLIENT_ID_PROVIDER, ClientIdProvider } from '../util/client-id.provider';
+import { TabSeqFrontierService } from './tab-seq-frontier.service';
 import { CompactOperation } from './compact/compact-operation.types';
 import {
   isCompactOperation,
@@ -397,6 +398,9 @@ const rebaseLocalClockOnDurable = (
 export class OperationLogStoreService implements RemoteOperationApplyStorePort<Operation> {
   private clientIdProvider: ClientIdProvider = inject(CLIENT_ID_PROVIDER);
   private readonly _lockService = inject(LockService);
+  // #9438: every seq this instance writes is reported so state-derived cache
+  // writers (snapshot save, compaction) can detect concurrent-tab appends.
+  private readonly _tabSeqFrontier = inject(TabSeqFrontierService);
   private _db?: IDBPDatabase<OpLogDB>;
   private _initPromise?: Promise<void>;
   // Phase A migration seam: methods migrated off direct `idb` route through
@@ -773,22 +777,23 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
   ): Promise<number> {
     await this._ensureInit();
     try {
-      if (isFullStateOpType(op.opType)) {
-        return await this._adapter.transaction(
-          [STORE_NAMES.OPS, STORE_NAMES.META],
-          'readwrite',
-          async (tx) => {
-            const entry = this._buildStoredEntry(op, source, options);
-            const seq = await tx.add(STORE_NAMES.OPS, entry);
-            await this._recordFullStateOpInTx(tx, entry.op, seq);
-            return seq;
-          },
-        );
-      }
-      return await this._adapter.add(
-        STORE_NAMES.OPS,
-        this._buildStoredEntry(op, source, options),
-      );
+      const seq = isFullStateOpType(op.opType)
+        ? await this._adapter.transaction(
+            [STORE_NAMES.OPS, STORE_NAMES.META],
+            'readwrite',
+            async (tx) => {
+              const entry = this._buildStoredEntry(op, source, options);
+              const writtenSeq = await tx.add(STORE_NAMES.OPS, entry);
+              await this._recordFullStateOpInTx(tx, entry.op, writtenSeq);
+              return writtenSeq;
+            },
+          )
+        : await this._adapter.add(
+            STORE_NAMES.OPS,
+            this._buildStoredEntry(op, source, options),
+          );
+      this._tabSeqFrontier.observeOwnWrite(seq);
+      return seq;
     } catch (e) {
       this._handleAppendError(e);
     }
@@ -887,6 +892,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       });
       this._vectorClockCache = { ...committedClock };
       this._invalidateUnsyncedCache();
+      // The cache installed above IS the state the caller hydrates from, so
+      // the tab's applied frontier is exactly this seq (#9438).
+      this._tabSeqFrontier.establishFrontier(seq);
       return seq;
     } catch (e) {
       this._handleAppendError(e);
@@ -923,16 +931,24 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       if (ops.some((op) => isFullStateOpType(op.opType))) {
         storeNames.push(STORE_NAMES.META);
       }
-      return await this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
-        const seqs: number[] = [];
-        for (const op of ops) {
-          const entry = this._buildStoredEntry(op, source, options);
-          const seq = await tx.add(STORE_NAMES.OPS, entry);
-          await this._recordFullStateOpInTx(tx, entry.op, seq);
-          seqs.push(seq);
-        }
-        return seqs;
-      });
+      const seqs = await this._adapter.transaction(
+        storeNames,
+        'readwrite',
+        async (tx) => {
+          const writtenSeqs: number[] = [];
+          for (const op of ops) {
+            const entry = this._buildStoredEntry(op, source, options);
+            const seq = await tx.add(STORE_NAMES.OPS, entry);
+            await this._recordFullStateOpInTx(tx, entry.op, seq);
+            writtenSeqs.push(seq);
+          }
+          return writtenSeqs;
+        },
+      );
+      for (const seq of seqs) {
+        this._tabSeqFrontier.observeOwnWrite(seq);
+      }
+      return seqs;
     } catch (e) {
       this._handleAppendError(e);
     }
@@ -1113,13 +1129,21 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
             } satisfies ArchiveStoreEntry);
           }
 
-          return { seqs, writtenOps, skippedCount };
+          return { seqs, writtenOps, skippedCount, snapshotFrontier };
         }),
       );
 
       this._vectorClockCache = { ...prunedVectorClock };
       this._invalidateAppliedAndUnsyncedCaches();
-      return result;
+      // The committed baseline replaces this tab's live state (dispatched by
+      // the caller inside the same locked section), so its frontier is the
+      // tab's applied frontier (#9438).
+      this._tabSeqFrontier.establishFrontier(result.snapshotFrontier);
+      return {
+        seqs: result.seqs,
+        writtenOps: result.writtenOps,
+        skippedCount: result.skippedCount,
+      };
     } catch (e) {
       this._handleAppendError(e);
     }
@@ -1220,6 +1244,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         );
       }
 
+      for (const seq of seqs) {
+        this._tabSeqFrontier.observeOwnWrite(seq);
+      }
       return { seqs, writtenOps, skippedCount };
     } catch (e) {
       if (e instanceof DOMException && e.name === 'QuotaExceededError') {
@@ -1364,6 +1391,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     }
     if (rejectOpIds.length > 0) {
       this._invalidateUnsyncedCache();
+    }
+    for (const writtenOp of written) {
+      this._tabSeqFrontier.observeOwnWrite(writtenOp.seq);
     }
     return { written, skippedCount };
   }
@@ -2301,6 +2331,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     });
     this._invalidateAppliedAndUnsyncedCaches();
     this._vectorClockCache = null;
+    this._tabSeqFrontier.resetToUnestablished();
   }
 
   // ============================================================
@@ -2413,6 +2444,8 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       },
     );
     this._invalidateAppliedAndUnsyncedCaches();
+    // Frontier seqs are meaningless after an ops wipe (#9438).
+    this._tabSeqFrontier.resetToUnestablished();
   }
 
   /**
@@ -2517,6 +2550,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
 
       this._invalidateAppliedAndUnsyncedCaches();
       this._vectorClockCache = { ...opts.vectorClock };
+      // Ops were wiped and the remote replay has not run yet — the frontier is
+      // unknown until the follow-up hydration/baseline commit (#9438).
+      this._tabSeqFrontier.resetToUnestablished();
     } catch (e) {
       if (e instanceof DOMException && e.name === 'QuotaExceededError') {
         throw new StorageQuotaExceededError();
@@ -2894,27 +2930,33 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       if (isFullStateOpType(op.opType)) {
         storeNames.push(STORE_NAMES.META);
       }
-      return await this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
-        // 1. Append operation to ops store (encoded to compact format)
-        const entry = this._buildStoredEntry(op, source, options);
-        const seq = await tx.add(STORE_NAMES.OPS, entry);
-        await this._recordFullStateOpInTx(tx, entry.op, seq);
+      const writtenSeq = await this._adapter.transaction(
+        storeNames,
+        'readwrite',
+        async (tx) => {
+          // 1. Append operation to ops store (encoded to compact format)
+          const entry = this._buildStoredEntry(op, source, options);
+          const seq = await tx.add(STORE_NAMES.OPS, entry);
+          await this._recordFullStateOpInTx(tx, entry.op, seq);
 
-        // 2. Update vector clock to match the operation's clock (only for
-        // local ops). The op.vectorClock already contains the incremented
-        // value from the caller; we store it as the current clock so
-        // subsequent operations can build on it.
-        if (source === 'local') {
-          await tx.put(
-            STORE_NAMES.VECTOR_CLOCK,
-            { clock: op.vectorClock, lastUpdate: Date.now() },
-            SINGLETON_KEY,
-          );
-          this._vectorClockCache = op.vectorClock;
-        }
+          // 2. Update vector clock to match the operation's clock (only for
+          // local ops). The op.vectorClock already contains the incremented
+          // value from the caller; we store it as the current clock so
+          // subsequent operations can build on it.
+          if (source === 'local') {
+            await tx.put(
+              STORE_NAMES.VECTOR_CLOCK,
+              { clock: op.vectorClock, lastUpdate: Date.now() },
+              SINGLETON_KEY,
+            );
+            this._vectorClockCache = op.vectorClock;
+          }
 
-        return seq;
-      });
+          return seq;
+        },
+      );
+      this._tabSeqFrontier.observeOwnWrite(writtenSeq);
+      return writtenSeq;
     } catch (e) {
       this._handleAppendError(e);
     }
@@ -2993,6 +3035,9 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
 
     this._vectorClockCache = committedClock ?? null;
     this._invalidateUnsyncedCache();
+    // The repaired state written above becomes this tab's live state, with
+    // the replacement op as its replay anchor (#9438).
+    this._tabSeqFrontier.establishFrontier(seq);
     return seq;
   }
 
@@ -3055,7 +3100,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
       // tests (#7709) spy on the shared connection's `transaction` and poison
       // `opsStore.add`; that still fires here because the adapter operates on
       // that same adopted connection.
-      await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, () =>
+      const committedSeq = await this._lockService.request(LOCK_NAMES.TASK_ARCHIVE, () =>
         this._adapter.transaction(storeNames, 'readwrite', async (tx) => {
           if (opts.requiredImportBackupId !== undefined) {
             const currentBackup = await tx.get<{ backupId?: string }>(
@@ -3127,12 +3172,17 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
               lastModified: compactedAt,
             });
           }
+
+          return seq;
         }),
       );
 
       // Reached only on a committed transaction.
       this._invalidateAppliedAndUnsyncedCaches();
       this._vectorClockCache = newVectorClock;
+      // The committed baseline becomes this tab's live state (the caller
+      // dispatches it), anchored at the SYNC_IMPORT op's seq (#9438).
+      this._tabSeqFrontier.establishFrontier(committedSeq);
       // The clientId rotated atomically with the stores above. Invalidate the
       // ClientIdService cache so the next read sees the rotated value. On
       // abort the transaction() above throws, so this is not reached and the

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -398,8 +398,13 @@ const rebaseLocalClockOnDurable = (
 export class OperationLogStoreService implements RemoteOperationApplyStorePort<Operation> {
   private clientIdProvider: ClientIdProvider = inject(CLIENT_ID_PROVIDER);
   private readonly _lockService = inject(LockService);
-  // #9438: every seq this instance writes is reported so state-derived cache
-  // writers (snapshot save, compaction) can detect concurrent-tab appends.
+  // #9438 INVARIANT: every method that adds rows to STORE_NAMES.OPS must
+  // report the committed seqs after its transaction commits — observeOwnWrite
+  // for plain appends, establishFrontier only when the method also installs
+  // the state cache the live store will match. A missed observe makes the
+  // next observed write look like a foreign gap and silently disables
+  // snapshot saves + compaction for the session (all platforms) — see the
+  // TabSeqFrontierService doc.
   private readonly _tabSeqFrontier = inject(TabSeqFrontierService);
   private _db?: IDBPDatabase<OpLogDB>;
   private _initPromise?: Promise<void>;

--- a/src/app/op-log/persistence/tab-seq-frontier.service.spec.ts
+++ b/src/app/op-log/persistence/tab-seq-frontier.service.spec.ts
@@ -73,4 +73,29 @@ describe('TabSeqFrontierService (#9438)', () => {
     service.establishFrontier(10);
     expect(service.isSaveSafeAt(12)).toBe(false);
   });
+
+  it('treats establishFrontier(0) as a reset — ops wipes keep the seq generator, so the next seq is unknowable', () => {
+    service.establishFrontier(0);
+    // Post-wipe first append continues from the preserved generator (e.g. 4);
+    // that must NOT read as a foreign gap.
+    service.observeOwnWrite(4);
+    expect(service.hasKnownForeignWrites()).toBe(false);
+    expect(service.isSaveSafeAt(4)).toBe(true);
+  });
+
+  it('establishFrontier(0) also clears an earlier sticky divergence back to default-open', () => {
+    service.establishFrontier(4);
+    service.observeOwnWrite(6);
+    expect(service.hasKnownForeignWrites()).toBe(true);
+    service.establishFrontier(0);
+    expect(service.hasKnownForeignWrites()).toBe(false);
+    expect(service.isSaveSafeAt(99)).toBe(true);
+  });
+
+  it('exposes sticky divergence for pre-lock fast-paths', () => {
+    service.establishFrontier(4);
+    expect(service.hasKnownForeignWrites()).toBe(false);
+    service.observeOwnWrite(6);
+    expect(service.hasKnownForeignWrites()).toBe(true);
+  });
 });

--- a/src/app/op-log/persistence/tab-seq-frontier.service.spec.ts
+++ b/src/app/op-log/persistence/tab-seq-frontier.service.spec.ts
@@ -1,0 +1,76 @@
+import { TabSeqFrontierService } from './tab-seq-frontier.service';
+
+describe('TabSeqFrontierService (#9438)', () => {
+  let service: TabSeqFrontierService;
+
+  beforeEach(() => {
+    service = new TabSeqFrontierService();
+  });
+
+  it('defaults open while no frontier is established (pre-#9438 behavior)', () => {
+    expect(service.isSaveSafeAt(0)).toBe(true);
+    expect(service.isSaveSafeAt(42)).toBe(true);
+  });
+
+  it('ignores own writes before a frontier is established', () => {
+    service.observeOwnWrite(7);
+    expect(service.isSaveSafeAt(7)).toBe(true);
+    expect(service.isSaveSafeAt(99)).toBe(true);
+  });
+
+  it('is safe exactly at the established frontier', () => {
+    service.establishFrontier(10);
+    expect(service.isSaveSafeAt(10)).toBe(true);
+    expect(service.isSaveSafeAt(11)).toBe(false);
+    expect(service.isSaveSafeAt(9)).toBe(false);
+  });
+
+  it('advances contiguously through own writes', () => {
+    service.establishFrontier(10);
+    service.observeOwnWrite(11);
+    service.observeOwnWrite(12);
+    expect(service.isSaveSafeAt(12)).toBe(true);
+  });
+
+  it('ignores re-observed (idempotent) seqs at or below the frontier', () => {
+    service.establishFrontier(10);
+    service.observeOwnWrite(10);
+    service.observeOwnWrite(5);
+    expect(service.isSaveSafeAt(10)).toBe(true);
+  });
+
+  it('detects a foreign interleave when an own write skips a seq — and stays diverged even though the scalars align again', () => {
+    service.establishFrontier(4);
+    // Another tab took seq 5; our own append returned 6.
+    service.observeOwnWrite(6);
+    // Global max now equals what we last wrote — the unsound scalar check
+    // would pass here and bake an anchor past the unapplied foreign op 5.
+    expect(service.isSaveSafeAt(6)).toBe(false);
+  });
+
+  it('stays diverged across further contiguous own writes', () => {
+    service.establishFrontier(4);
+    service.observeOwnWrite(6);
+    service.observeOwnWrite(7);
+    expect(service.isSaveSafeAt(7)).toBe(false);
+  });
+
+  it('clears divergence on the next establish (re-hydration / baseline install)', () => {
+    service.establishFrontier(4);
+    service.observeOwnWrite(6);
+    service.establishFrontier(6);
+    expect(service.isSaveSafeAt(6)).toBe(true);
+  });
+
+  it('falls back to default-open after a reset (ops wipe)', () => {
+    service.establishFrontier(4);
+    service.observeOwnWrite(6);
+    service.resetToUnestablished();
+    expect(service.isSaveSafeAt(0)).toBe(true);
+  });
+
+  it('is unsafe when the global max moved past the frontier without any own write (pure foreign append)', () => {
+    service.establishFrontier(10);
+    expect(service.isSaveSafeAt(12)).toBe(false);
+  });
+});

--- a/src/app/op-log/persistence/tab-seq-frontier.service.ts
+++ b/src/app/op-log/persistence/tab-seq-frontier.service.ts
@@ -18,6 +18,11 @@ import { OpLog } from '../../core/log';
  * - `establishFrontier(seq)` — the live state now reflects exactly the ops up
  *   to `seq`. Called when hydration finishes a replay and when the store
  *   atomically installs a new state-cache baseline. Clears any divergence.
+ *   `seq === 0` (empty ops store) resets to unestablished instead: ops wipes
+ *   preserve the auto-increment generator on BOTH backends, so the next
+ *   append's seq is unknowable and anchoring at 0 would fabricate a gap →
+ *   sticky false divergence (reachable via USE_REMOTE force-download and the
+ *   boot after an interrupted rebuild).
  * - `observeOwnWrite(seq)` — this tab appended an op whose reducer effect is
  *   in its state (capture persists after the reducer ran; remote applies hold
  *   the op-log lock across append+apply, so saves cannot observe the gap).
@@ -31,14 +36,25 @@ import { OpLog } from '../../core/log';
  *   anchor at `globalLastSeq`. While no frontier is established this returns
  *   true: hydration establishes before any save path runs in production, and
  *   defaulting open keeps the pre-#9438 behavior on any path that never
- *   establishes (a wiring gap then means "no new protection", never
- *   "snapshots permanently disabled").
+ *   establishes.
+ *
+ * ## Wiring invariant (asymmetric failure modes)
+ *
+ * Every `OperationLogStoreService` method that adds rows to the OPS store
+ * MUST report the committed seqs to this tracker. The two possible wiring
+ * gaps fail very differently: a missed `establishFrontier` merely leaves the
+ * tracker default-open ("no new protection"); a missed `observeOwnWrite`
+ * makes the next observed own write look like a foreign gap → sticky
+ * divergence → snapshot saves AND compaction silently disabled for the rest
+ * of the session, on ALL platforms including single-instance Electron. Keep
+ * that in mind when the divergence warning fires on a platform where no
+ * concurrent tab can exist — it then indicates a wiring gap, not multi-tab.
  *
  * Divergence only clears on the next `establishFrontier` (re-hydration or a
  * baseline install), matching the skip-on-risk shape of the #8751/#7892
  * guards: skipping a save costs at most a slower next boot; the op-log stays
- * the source of truth. Single-instance platforms (Electron/Android) can never
- * observe a gap, so the guard is inert there.
+ * the source of truth. Single-instance platforms can never see a genuine
+ * foreign gap, so with complete wiring the guard is inert there.
  */
 @Injectable({ providedIn: 'root' })
 export class TabSeqFrontierService {
@@ -46,6 +62,13 @@ export class TabSeqFrontierService {
   private _hasForeignWrites = false;
 
   establishFrontier(seq: number): void {
+    if (seq === 0) {
+      // Empty ops store: wipes keep the seq generator, so the next append's
+      // seq is unknowable — see the class doc. Default-open until a real
+      // baseline exists.
+      this.resetToUnestablished();
+      return;
+    }
     this._frontier = seq;
     this._hasForeignWrites = false;
   }
@@ -58,8 +81,9 @@ export class TabSeqFrontierService {
       this._hasForeignWrites = true;
       OpLog.warn(
         'TabSeqFrontierService: own append skipped past the applied frontier — ' +
-          'a concurrent tab is writing; state-derived cache writes are disabled ' +
-          'until the next hydration (#9438)',
+          'a concurrent tab is writing (or, on single-instance platforms, an ' +
+          'append path is missing its observe call); state-derived cache ' +
+          'writes are disabled until the next hydration (#9438)',
         { frontier: this._frontier, observedSeq: seq },
       );
     }
@@ -79,5 +103,21 @@ export class TabSeqFrontierService {
       return true;
     }
     return !this._hasForeignWrites && globalLastSeq === this._frontier;
+  }
+
+  /**
+   * Sticky-divergence probe for cheap pre-lock fast-paths (mirrors the #8751
+   * fast-path shape): once true, every save attempt would skip anyway, so
+   * callers can bail before paying the flush + cross-tab lock + state
+   * capture. The scalar `isSaveSafeAt` check cannot be hoisted the same way —
+   * it needs the in-lock `getLastSeq()`.
+   */
+  hasKnownForeignWrites(): boolean {
+    return this._hasForeignWrites;
+  }
+
+  /** Current frontier for diagnostics only; null while unestablished. */
+  get frontierSeq(): number | null {
+    return this._frontier;
   }
 }

--- a/src/app/op-log/persistence/tab-seq-frontier.service.ts
+++ b/src/app/op-log/persistence/tab-seq-frontier.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+import { OpLog } from '../../core/log';
+
+/**
+ * Tracks the highest op-log seq whose effect is known to be applied to THIS
+ * tab's live NgRx state (#9438).
+ *
+ * The shared OPS store is written by every tab of the same origin, but live
+ * tabs do not exchange operation payloads: an op appended by a concurrent tab
+ * is counted by `getLastSeq()` while its effect is absent from this tab's
+ * state. Persisting that global max as a snapshot's `lastAppliedOpSeq` makes
+ * the next boot's tail replay (`getOpsAfterSeq`) silently skip the op. The
+ * writers that derive a state cache from live state (snapshot save,
+ * compaction) therefore consult this tracker before trusting `getLastSeq()`.
+ *
+ * ## Semantics
+ *
+ * - `establishFrontier(seq)` — the live state now reflects exactly the ops up
+ *   to `seq`. Called when hydration finishes a replay and when the store
+ *   atomically installs a new state-cache baseline. Clears any divergence.
+ * - `observeOwnWrite(seq)` — this tab appended an op whose reducer effect is
+ *   in its state (capture persists after the reducer ran; remote applies hold
+ *   the op-log lock across append+apply, so saves cannot observe the gap).
+ *   Advances the frontier only contiguously: a skipped seq proves another
+ *   tab's op interleaved below our own write, which a scalar frontier cannot
+ *   represent — that sets a sticky divergence instead. The sticky flag is
+ *   required because after such an interleave the tab's own next append makes
+ *   the scalar values equal again (foreign seq 5, own append returns 6 →
+ *   frontier 6 == global max 6) while state still lacks seq 5.
+ * - `isSaveSafeAt(globalLastSeq)` — true when a state-derived cache write may
+ *   anchor at `globalLastSeq`. While no frontier is established this returns
+ *   true: hydration establishes before any save path runs in production, and
+ *   defaulting open keeps the pre-#9438 behavior on any path that never
+ *   establishes (a wiring gap then means "no new protection", never
+ *   "snapshots permanently disabled").
+ *
+ * Divergence only clears on the next `establishFrontier` (re-hydration or a
+ * baseline install), matching the skip-on-risk shape of the #8751/#7892
+ * guards: skipping a save costs at most a slower next boot; the op-log stays
+ * the source of truth. Single-instance platforms (Electron/Android) can never
+ * observe a gap, so the guard is inert there.
+ */
+@Injectable({ providedIn: 'root' })
+export class TabSeqFrontierService {
+  private _frontier: number | null = null;
+  private _hasForeignWrites = false;
+
+  establishFrontier(seq: number): void {
+    this._frontier = seq;
+    this._hasForeignWrites = false;
+  }
+
+  observeOwnWrite(seq: number): void {
+    if (this._frontier === null || seq <= this._frontier) {
+      return;
+    }
+    if (seq !== this._frontier + 1 && !this._hasForeignWrites) {
+      this._hasForeignWrites = true;
+      OpLog.warn(
+        'TabSeqFrontierService: own append skipped past the applied frontier — ' +
+          'a concurrent tab is writing; state-derived cache writes are disabled ' +
+          'until the next hydration (#9438)',
+        { frontier: this._frontier, observedSeq: seq },
+      );
+    }
+    // Keep advancing even when diverged so the log above stays meaningful;
+    // the sticky flag alone decides save safety from here on.
+    this._frontier = seq;
+  }
+
+  /** After an ops wipe the baseline is unknown — fall back to default-open. */
+  resetToUnestablished(): void {
+    this._frontier = null;
+    this._hasForeignWrites = false;
+  }
+
+  isSaveSafeAt(globalLastSeq: number): boolean {
+    if (this._frontier === null) {
+      return true;
+    }
+    return !this._hasForeignWrites && globalLastSeq === this._frontier;
+  }
+}

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { TabSeqFrontierService } from '../persistence/tab-seq-frontier.service';
 import { OperationLogSyncService } from './operation-log-sync.service';
 import { FILE_BASED_SYNC_CONSTANTS } from '../sync-providers/file-based/file-based-sync.types';
 import { SchemaMigrationService } from '../persistence/schema-migration.service';
@@ -142,6 +143,8 @@ describe('OperationLogSyncService', () => {
       'loadImportBackup',
     ]);
     opLogStoreSpy.hasSyncedOps.and.resolveTo(true);
+    // 0 = empty store; establishFrontier(0) resets to default-open (#9438).
+    opLogStoreSpy.getLastSeq.and.resolveTo(0);
     opLogStoreSpy.getUnsynced.and.resolveTo([]);
     opLogStoreSpy.getPendingRemoteOps.and.resolveTo([]);
     opLogStoreSpy.getFailedRemoteOps.and.resolveTo([]);
@@ -4604,6 +4607,35 @@ describe('OperationLogSyncService', () => {
       await service.forceDownloadRemoteState(mockProvider);
 
       expect(callOrder).toEqual(['downloadRemoteOps', 'runRemoteStateReplacement']);
+    });
+
+    it('re-establishes the tab seq frontier at the store tail after a completed rebuild (#9438)', async () => {
+      // The pre-rebuild ops wipe correctly leaves the tracker default-open;
+      // once the rebuild has applied everything it wrote (inside the
+      // exclusive section), _completeRawRebuild must re-arm the guard —
+      // including clearing a sticky divergence from before the rebuild.
+      const frontier = TestBed.inject(TabSeqFrontierService);
+      frontier.establishFrontier(4);
+      frontier.observeOwnWrite(6); // gap → sticky divergence
+      expect(frontier.hasKnownForeignWrites()).toBe(true);
+      opLogStoreSpy.getLastSeq.and.resolveTo(42);
+      downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+        newOps: [makeRemoteOp()],
+        needsFullStateUpload: false,
+        success: true,
+        providerMode: 'superSyncOps',
+        failedFileCount: 0,
+        latestServerSeq: 1,
+      });
+      const mockProvider = {
+        supportsOperationSync: true,
+        setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+      } as any;
+
+      await service.forceDownloadRemoteState(mockProvider);
+
+      expect(frontier.hasKnownForeignWrites()).toBe(false);
+      expect(frontier.isSaveSafeAt(42)).toBe(true);
     });
 
     it('should preserve device-local sync settings in the atomic rebuild baseline', async () => {

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -12,6 +12,7 @@ import {
   ImportBackupRef,
   OperationLogStoreService,
 } from '../persistence/operation-log-store.service';
+import { TabSeqFrontierService } from '../persistence/tab-seq-frontier.service';
 import { BackupService } from '../backup/backup.service';
 import { OpLog } from '../../core/log';
 import { OperationSyncCapable } from '../sync-providers/provider.interface';
@@ -166,6 +167,7 @@ export class OperationLogSyncService {
   private schemaMigrationService = inject(SchemaMigrationService);
   private validateStateService = inject(ValidateStateService);
   private repairSyncContext = inject(RepairSyncContextService);
+  private tabSeqFrontier = inject(TabSeqFrontierService);
 
   // Extracted services
   private remoteOpsProcessingService = inject(RemoteOpsProcessingService);
@@ -2234,6 +2236,13 @@ export class OperationLogSyncService {
 
   private async _completeRawRebuild(backupRef?: ImportBackupRef): Promise<boolean> {
     this._assertNoCaptureRacedWithRebuild();
+    // #9438: every op the rebuild wrote inside this exclusive section is
+    // applied to live state by now (processRemoteOps, the snapshot
+    // materialization, and _restorePreservedLocalOps all throw on partial
+    // apply), so the tab frontier equals the store tail again. Re-arm the
+    // snapshot/compaction guard that the pre-rebuild ops wipe correctly left
+    // default-open.
+    this.tabSeqFrontier.establishFrontier(await this.opLogStore.getLastSeq());
     const hasDurableRecovery = await this.opLogStore.completeRawRebuild(backupRef);
     // The conflict journal describes conflicts in the op history that was JUST
     // replaced (documented contract: cleared whenever the full dataset is

--- a/src/app/op-log/testing/integration/multi-tab-frontier-guard.integration.spec.ts
+++ b/src/app/op-log/testing/integration/multi-tab-frontier-guard.integration.spec.ts
@@ -1,0 +1,230 @@
+import { TestBed } from '@angular/core/testing';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { OperationLogSnapshotService } from '../../persistence/operation-log-snapshot.service';
+import { OperationLogCompactionService } from '../../persistence/operation-log-compaction.service';
+import { TabSeqFrontierService } from '../../persistence/tab-seq-frontier.service';
+import { VectorClockService } from '../../sync/vector-clock.service';
+import { StateSnapshotService } from '../../backup/state-snapshot.service';
+import { ValidateStateService } from '../../validation/validate-state.service';
+import { OpType } from '../../core/operation.types';
+import { TestClient, resetTestUuidCounter } from './helpers/test-client.helper';
+import { clearDeferredActions } from '../../capture/operation-capture.meta-reducer';
+import {
+  createMinimalTaskPayload,
+  createTaskOperation,
+} from './helpers/operation-factory.helper';
+
+/**
+ * Reproduction for #9438: a snapshot/compaction save reads this tab's live
+ * NgRx state but anchors `lastAppliedOpSeq` at the shared store's global max
+ * seq. An op appended by a CONCURRENT TAB before the save's lock was taken is
+ * then counted as applied while its effect is absent from the captured state,
+ * and the next boot's tail replay (`getOpsAfterSeq(anchor)`) silently skips
+ * it.
+ *
+ * The concurrent tab is simulated faithfully: a second OperationLogStoreService
+ * instance over the SAME database, whose writes do not tick this tab's
+ * frontier tracker — exactly like a real foreign tab (tabs share IndexedDB but
+ * not JS state).
+ */
+describe('Multi-tab frontier guard (#9438)', () => {
+  let storeService: OperationLogStoreService;
+  let foreignStore: OperationLogStoreService;
+  let snapshotService: OperationLogSnapshotService;
+  let compactionService: OperationLogCompactionService;
+  let frontier: TabSeqFrontierService;
+  let mockStateSnapshot: jasmine.SpyObj<StateSnapshotService>;
+  let client: TestClient;
+  let foreignClient: TestClient;
+
+  const TASK_ID = 'task-1';
+  const meaningfulState = {
+    task: {
+      ids: [TASK_ID],
+      entities: { [TASK_ID]: createMinimalTaskPayload(TASK_ID, { title: 'Task 1' }) },
+    },
+    project: { ids: [], entities: {} },
+    tag: { ids: [], entities: {} },
+    note: { ids: [], entities: {} },
+    globalConfig: {},
+  } as any;
+
+  beforeEach(async () => {
+    mockStateSnapshot = jasmine.createSpyObj('StateSnapshotService', [
+      'getStateSnapshot',
+      'getStateSnapshotForOperationLog',
+    ]);
+    mockStateSnapshot.getStateSnapshot.and.returnValue(meaningfulState);
+    mockStateSnapshot.getStateSnapshotForOperationLog.and.returnValue(meaningfulState);
+
+    TestBed.configureTestingModule({
+      providers: [
+        OperationLogStoreService,
+        OperationLogSnapshotService,
+        OperationLogCompactionService,
+        VectorClockService,
+        { provide: StateSnapshotService, useValue: mockStateSnapshot },
+        // Only used by the migrate path, never by the save path under test —
+        // mocked because the real one drags in the NgRx Store.
+        {
+          provide: ValidateStateService,
+          useValue: jasmine.createSpyObj('ValidateStateService', [
+            'validateState',
+            'validateAndRepair',
+          ]),
+        },
+      ],
+    });
+
+    storeService = TestBed.inject(OperationLogStoreService);
+    snapshotService = TestBed.inject(OperationLogSnapshotService);
+    compactionService = TestBed.inject(OperationLogCompactionService);
+    frontier = TestBed.inject(TabSeqFrontierService);
+
+    await storeService.init();
+    await storeService._clearAllDataForTesting();
+    resetTestUuidCounter();
+    clearDeferredActions();
+
+    // The foreign tab: same database, but its own (throwaway) frontier
+    // tracker so its appends stay invisible to this tab's tracking — as in
+    // a real separate tab.
+    const foreignInjector = Injector.create({
+      providers: [
+        { provide: TabSeqFrontierService, useValue: new TabSeqFrontierService() },
+      ],
+      parent: TestBed.inject(Injector),
+    });
+    foreignStore = runInInjectionContext(
+      foreignInjector,
+      () => new OperationLogStoreService(),
+    );
+    await foreignStore.init();
+
+    // Same clientId on both: real tabs share the on-disk client identity.
+    client = new TestClient('client-tab');
+    foreignClient = new TestClient('client-tab');
+  });
+
+  const appendOwnOps = async (count: number, idPrefix: string): Promise<number> => {
+    let lastSeq = 0;
+    for (let i = 1; i <= count; i++) {
+      lastSeq = await storeService.append(
+        createTaskOperation(client, `${idPrefix}-${i}`, OpType.Create, {
+          title: `${idPrefix} ${i}`,
+        }),
+        'local',
+      );
+    }
+    return lastSeq;
+  };
+
+  it('snapshot save must not anchor past an op appended by a concurrent tab', async () => {
+    const hydratedSeq = await appendOwnOps(3, 'own');
+    // What the hydrator does at the end of replay: this tab's state now
+    // reflects exactly seqs 1..3.
+    frontier.establishFrontier(hydratedSeq);
+
+    const foreignSeq = await foreignStore.append(
+      createTaskOperation(foreignClient, 'foreign-task', OpType.Create, {
+        title: 'written by another tab',
+      }),
+      'local',
+    );
+    expect(foreignSeq).toBe(hydratedSeq + 1);
+
+    const didSave = await snapshotService.saveCurrentStateAsSnapshot();
+
+    // The foreign op's effect is NOT in this tab's captured state, so it must
+    // remain beyond the persisted anchor (else the next boot's
+    // getOpsAfterSeq(anchor) silently skips it).
+    const cache = await storeService.loadStateCache();
+    const anchor = cache?.lastAppliedOpSeq ?? 0;
+    expect(anchor).toBeLessThan(foreignSeq);
+    expect(didSave).toBe(false);
+  });
+
+  it('snapshot save must skip after an interleave even when the scalars align again', async () => {
+    const hydratedSeq = await appendOwnOps(3, 'own');
+    frontier.establishFrontier(hydratedSeq);
+
+    // Foreign tab takes seq 4 …
+    const foreignSeq = await foreignStore.append(
+      createTaskOperation(foreignClient, 'foreign-task', OpType.Create, {
+        title: 'written by another tab',
+      }),
+      'local',
+    );
+    // … then this tab's own next append returns seq 5: the global max now
+    // equals this tab's latest own write, which is exactly the case a naive
+    // scalar comparison gets wrong.
+    const ownSeq = await storeService.append(
+      createTaskOperation(client, 'own-after-interleave', OpType.Create, {
+        title: 'own op after interleave',
+      }),
+      'local',
+    );
+    expect(ownSeq).toBe(foreignSeq + 1);
+
+    const didSave = await snapshotService.saveCurrentStateAsSnapshot();
+
+    const cache = await storeService.loadStateCache();
+    const anchor = cache?.lastAppliedOpSeq ?? 0;
+    expect(anchor).toBeLessThan(foreignSeq);
+    expect(didSave).toBe(false);
+  });
+
+  it('compaction must not anchor past an op appended by a concurrent tab', async () => {
+    const hydratedSeq = await appendOwnOps(3, 'own');
+    frontier.establishFrontier(hydratedSeq);
+
+    const foreignSeq = await foreignStore.append(
+      createTaskOperation(foreignClient, 'foreign-task', OpType.Create, {
+        title: 'written by another tab',
+      }),
+      'local',
+    );
+
+    const didCompact = await compactionService.compact();
+
+    const cache = await storeService.loadStateCache();
+    const anchor = cache?.lastAppliedOpSeq ?? 0;
+    expect(anchor).toBeLessThan(foreignSeq);
+    expect(didCompact).toBe(false);
+
+    // The foreign op must still be delivered by the next boot's tail replay.
+    const tail = await storeService.getOpsAfterSeq(anchor);
+    expect(tail.some((entry) => entry.seq === foreignSeq)).toBe(true);
+  });
+
+  it('saves normally when only this tab has written since hydration (no false positive)', async () => {
+    const hydratedSeq = await appendOwnOps(3, 'own');
+    frontier.establishFrontier(hydratedSeq);
+    const lastOwnSeq = await appendOwnOps(2, 'later');
+
+    const didSave = await snapshotService.saveCurrentStateAsSnapshot();
+
+    expect(didSave).toBe(true);
+    const cache = await storeService.loadStateCache();
+    expect(cache?.lastAppliedOpSeq).toBe(lastOwnSeq);
+  });
+
+  it('stays default-open while no frontier was established (pre-hydration behavior unchanged)', async () => {
+    await appendOwnOps(3, 'own');
+    const foreignSeq = await foreignStore.append(
+      createTaskOperation(foreignClient, 'foreign-task', OpType.Create, {
+        title: 'written by another tab',
+      }),
+      'local',
+    );
+
+    const didSave = await snapshotService.saveCurrentStateAsSnapshot();
+
+    // Deliberately unguarded: production establishes during hydration before
+    // any save path can run; unestablished callers keep pre-#9438 semantics.
+    expect(didSave).toBe(true);
+    const cache = await storeService.loadStateCache();
+    expect(cache?.lastAppliedOpSeq).toBe(foreignSeq);
+  });
+});

--- a/src/app/op-log/testing/integration/multi-tab-frontier-guard.integration.spec.ts
+++ b/src/app/op-log/testing/integration/multi-tab-frontier-guard.integration.spec.ts
@@ -210,6 +210,43 @@ describe('Multi-tab frontier guard (#9438)', () => {
     expect(cache?.lastAppliedOpSeq).toBe(lastOwnSeq);
   });
 
+  it('does not false-positive after an ops wipe whose baseline commit sees an empty store (seq generator survives clear)', async () => {
+    // Regression for the USE_REMOTE force-download shape: ops wiped (the
+    // auto-increment generator is NOT reset by clear() on either backend),
+    // then a baseline committed against the empty store, then appends resume
+    // at the preserved generator value. Establishing a frontier of 0 here
+    // would make that first append look like a foreign gap → sticky
+    // divergence on single-instance platforms.
+    const preWipeSeq = await appendOwnOps(3, 'own');
+    frontier.establishFrontier(preWipeSeq);
+    await storeService.clearAllOperations();
+
+    await storeService.commitFileSnapshotBaseline({
+      state: meaningfulState,
+      lastAppliedOpSeq: 0,
+      vectorClock: {},
+      compactedAt: Date.now(),
+      snapshotIncludedOps: [],
+    });
+
+    const postWipeSeq = await storeService.append(
+      createTaskOperation(client, 'post-wipe-task', OpType.Create, {
+        title: 'first op after wipe',
+      }),
+      'local',
+    );
+    // Documents the premise: clear() preserved the generator.
+    expect(postWipeSeq).toBe(preWipeSeq + 1);
+
+    const didSave = await snapshotService.saveCurrentStateAsSnapshot();
+
+    // Unestablished after the wipe → default-open (pre-#9438 semantics), not
+    // a sticky skip.
+    expect(didSave).toBe(true);
+    const cache = await storeService.loadStateCache();
+    expect(cache?.lastAppliedOpSeq).toBe(postWipeSeq);
+  });
+
   it('stays default-open while no frontier was established (pre-hydration behavior unchanged)', async () => {
     await appendOwnOps(3, 'own');
     const foreignSeq = await foreignStore.append(

--- a/src/app/op-log/testing/integration/multi-tab-frontier-guard.integration.spec.ts
+++ b/src/app/op-log/testing/integration/multi-tab-frontier-guard.integration.spec.ts
@@ -247,6 +247,86 @@ describe('Multi-tab frontier guard (#9438)', () => {
     expect(cache?.lastAppliedOpSeq).toBe(postWipeSeq);
   });
 
+  // WIRING LOCK: every mid-session append method of the store must keep the
+  // tracker in step — a method missing its observe/establish call makes the
+  // next observed write look like a foreign gap and silently disables
+  // snapshot saves + compaction for the session on ALL platforms (see the
+  // invariant note in TabSeqFrontierService). Each case fails if the wiring
+  // for that method is removed. New append methods must be added here.
+  describe('store wiring lock (#9438)', () => {
+    let baseSeq: number;
+
+    beforeEach(async () => {
+      baseSeq = await appendOwnOps(2, 'base');
+      frontier.establishFrontier(baseSeq);
+    });
+
+    const expectInStep = async (): Promise<void> => {
+      const lastSeq = await storeService.getLastSeq();
+      expect(frontier.hasKnownForeignWrites()).toBe(false);
+      expect(frontier.isSaveSafeAt(lastSeq)).toBe(true);
+    };
+
+    it('appendBatch advances the frontier', async () => {
+      await storeService.appendBatch(
+        [
+          createTaskOperation(client, 'wl-batch-1', OpType.Create, { title: 'b1' }),
+          createTaskOperation(client, 'wl-batch-2', OpType.Create, { title: 'b2' }),
+        ],
+        'local',
+      );
+      await expectInStep();
+    });
+
+    it('appendBatchSkipDuplicates advances the frontier', async () => {
+      await storeService.appendBatchSkipDuplicates(
+        [createTaskOperation(client, 'wl-skipdup-1', OpType.Create, { title: 's1' })],
+        'remote',
+        { pendingApply: true },
+      );
+      await expectInStep();
+    });
+
+    it('appendMixedSourceBatchSkipDuplicates advances the frontier', async () => {
+      await storeService.appendMixedSourceBatchSkipDuplicates([
+        {
+          source: 'remote',
+          ops: [
+            createTaskOperation(client, 'wl-mixed-1', OpType.Create, { title: 'm1' }),
+          ],
+        },
+      ]);
+      await expectInStep();
+    });
+
+    it('appendWithVectorClockOverwrite advances the frontier', async () => {
+      await storeService.appendWithVectorClockOverwrite(
+        createTaskOperation(client, 'wl-vclock-1', OpType.Create, { title: 'v1' }),
+        'local',
+      );
+      await expectInStep();
+    });
+
+    it('appendOperationAndSnapshot establishes at its written seq, clearing prior divergence', async () => {
+      // Put the tracker into the pure-foreign mismatch state first …
+      await foreignStore.append(
+        createTaskOperation(foreignClient, 'wl-foreign', OpType.Create, {
+          title: 'foreign',
+        }),
+        'local',
+      );
+      // … then install a full baseline: state cache and op are one atomic
+      // anchor, so the tracker must be re-established at exactly that seq.
+      const seq = await storeService.appendOperationAndSnapshot(
+        createTaskOperation(client, 'wl-anchor', OpType.Create, { title: 'anchor' }),
+        'local',
+        { state: meaningfulState, vectorClock: {}, compactedAt: Date.now() },
+      );
+      expect(frontier.isSaveSafeAt(seq)).toBe(true);
+      await expectInStep();
+    });
+  });
+
   it('stays default-open while no frontier was established (pre-hydration behavior unchanged)', async () => {
     await appendOwnOps(3, 'own');
     const foreignSeq = await foreignStore.append(

--- a/src/app/op-log/validation/repair-operation.service.spec.ts
+++ b/src/app/op-log/validation/repair-operation.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { TabSeqFrontierService } from '../persistence/tab-seq-frontier.service';
 import { RepairOperationService } from './repair-operation.service';
 import {
   MixedSourceOperationBatch,
@@ -281,6 +282,26 @@ describe('RepairOperationService', () => {
       );
 
       expect(seq).toBe(77);
+    });
+
+    it('should re-establish the tab seq frontier at the repair seq, clearing prior divergence (#9438)', async () => {
+      // A REPAIR is a full-state baseline: it supersedes earlier ops on
+      // replay and the caller dispatches the repaired state, so a prior
+      // sticky concurrent-tab divergence must not keep saves disabled.
+      const frontier = TestBed.inject(TabSeqFrontierService);
+      frontier.establishFrontier(4);
+      frontier.observeOwnWrite(6); // gap → sticky divergence
+      expect(frontier.hasKnownForeignWrites()).toBe(true);
+
+      mockBatchAppendWithSeq(77);
+      await service.createRepairOperation(
+        mockRepairedState,
+        createRepairSummary(),
+        'test-client',
+      );
+
+      expect(frontier.hasKnownForeignWrites()).toBe(false);
+      expect(frontier.isSaveSafeAt(77)).toBe(true);
     });
 
     it('should throw error if clientId is empty', async () => {

--- a/src/app/op-log/validation/repair-operation.service.ts
+++ b/src/app/op-log/validation/repair-operation.service.ts
@@ -21,6 +21,7 @@ import { alertDialog } from '../../util/native-dialogs';
 import { RepairSyncContextService } from './repair-sync-context.service';
 import { StateSnapshotService } from '../backup/state-snapshot.service';
 import { SnackService } from '../../core/snack/snack.service';
+import { TabSeqFrontierService } from '../persistence/tab-seq-frontier.service';
 
 export interface RebaseStaleRepairOptions {
   staleRepairOpId: string;
@@ -46,6 +47,7 @@ export class RepairOperationService {
   private repairSyncContext = inject(RepairSyncContextService);
   private stateSnapshotService = inject(StateSnapshotService);
   private snackService = inject(SnackService);
+  private tabSeqFrontier = inject(TabSeqFrontierService);
 
   // Once-per-session guard for the non-interactive "data repaired" snack, so a
   // repeat-repair loop can't spam it (mirrors the version-block snack latch).
@@ -106,6 +108,13 @@ export class RepairOperationService {
         compactedAt: Date.now(),
         schemaVersion: CURRENT_SCHEMA_VERSION,
       });
+
+      // #9438: this is a full-state baseline install — REPAIR supersedes all
+      // earlier ops on replay and the caller dispatches repairedState as the
+      // live state right after — so re-establish the tab frontier here (also
+      // clears any sticky concurrent-tab divergence, mirroring the store's
+      // other baseline installs).
+      this.tabSeqFrontier.establishFrontier(seq);
 
       OpLog.log('[RepairOperationService] Created REPAIR operation', {
         seq,


### PR DESCRIPTION
Closes #9438.

## Problem

`saveCurrentStateAsSnapshot()` and `compact()` capture this tab's live NgRx state but anchor `lastAppliedOpSeq` at the shared store's global max seq. On web, a concurrent tab's op appended before the save's lock acquisition is counted by `getLastSeq()` while its effect is absent from the captured state — the next boot's tail replay (`getOpsAfterSeq(anchor)`) silently skips it. Tabs share one client ID, so sync never re-delivers own ops: permanent, silent data loss on the device. Reachability is broader than the probe race: hydration starts from an `APP_INITIALIZER` and the multi-instance blocker only swaps the DOM, so every second tab hydrates and reaches the checkpoint saves. (Full analysis in #9438.)

## Fix

New in-memory, tab-local **`TabSeqFrontierService`** (no persisted-shape change): tracks the highest seq whose effect is in this tab's state.

- **Established** at the end of every hydration replay path and inside every store method that atomically installs a state-cache baseline; ops wipes reset it (`establishFrontier(0)` = reset, since wipes preserve the seq generator).
- **Advanced contiguously** on every own append (wired inside the store service — all 10 seq-producing sites). A skipped seq proves a foreign interleave and sets a **sticky** divergence flag — required because after an interleave the scalars re-align (foreign 5, own 6 → frontier 6 == global max 6) while state still lacks 5.
- **Checked** by both save paths: skip + warn when `getLastSeq()` ≠ frontier or divergence is sticky — same skip-on-risk shape as the #8751/#7892 guards (cost: slower next boot; op-log stays source of truth). Default-open while unestablished keeps pre-fix semantics on any path that never establishes. Emergency compaction is exempt (see in-code note).

Follow-ups from review: pre-lock sticky fast-path in `_doCompact` (mirrors #8751), and guard re-arm after the two mid-session baseline flows that previously left sessions default-open/diverged — `createRepairOperation` (caller dispatches the repaired state; REPAIR is a full-state baseline) and `_completeRawRebuild` (everything the rebuild writes is applied before it runs, inside the exclusive section).

## Reproduction-first + review

- Failing tests written first: 3 reproduction tests (snapshot, compaction, scalar-realignment interleave) against a real second `OperationLogStoreService` over the same IndexedDB failed pre-fix — the persisted anchor equaled the foreign op's seq.
- Multi-agent review (6 independent reviewers): no criticals; its one verified defect (`establishFrontier(0)` after a wipe → sticky false positive on single-instance platforms) is fixed and regression-pinned; convergent warnings (fast-path, emergency-exemption framing, wiring docs) all addressed.

## Tests

- `tab-seq-frontier.service.spec.ts` — 14 semantic edge cases incl. the interleave counterexample and establish(0)-reset.
- `multi-tab-frontier-guard.integration.spec.ts` — reproduction + no-false-positive + default-open + post-wipe generator-skew regression + a **wiring lock** (one case per store append method; removing any observe/establish call fails a named test).
- Hydrator establish wiring (3 cases), repair re-establish, rebuild re-arm specs.
- New E2E smoke `e2e/tests/multi-tab/second-tab-no-data-loss.spec.ts` (second page, real blocker, hydration overlap, reload) — passing.
- Full unit suite green (14k+); op-log tree green after every commit; `E2E Tests (Scheduled)` dispatched for this branch.

## Risk notes

Every wiring failure direction is "skip the save" (safe), never "write a bad anchor". Residuals, documented in code: emergency compaction keeps pre-fix behavior; a genuine dual-active-tab session disables snapshots/compaction in both tabs until reload (session-bounded, matches the multi-tab-unsupported posture); gap detection assumes gapless tail seq assignment (IDB spec reverts the generator on abort; SQLite sequence is transactional).
