### PR TITLE
fix(tasks): make Shift+T schedule for today without moving the task

### DIFF
--- a/e2e/pages/project.page.ts
+++ b/e2e/pages/project.page.ts
@@ -365,8 +365,15 @@ export class ProjectPage extends BasePage {
     let newProject;
     let projectFound = false;
 
-    // Check if .nav-children container exists after expansion
-    const navChildren = this.page.locator('.nav-children');
+    // Check if the Projects tree's .nav-children container exists after expansion.
+    // Scope it to that tree: every expanded tree (Tags, Notes, …) renders its own
+    // .nav-children, so an unscoped locator is a strict-mode violation as soon as
+    // a second one is open.
+    const navChildren = this.page
+      .locator('nav-list-tree')
+      .filter({ hasText: 'Projects' })
+      .first()
+      .locator('.nav-children');
     const navChildrenExists = await navChildren.count();
 
     if (navChildrenExists > 0) {
@@ -374,8 +381,8 @@ export class ProjectPage extends BasePage {
 
       try {
         // Primary approach: nav-child-item structure with nav-item button
-        newProject = this.page
-          .locator('.nav-children .nav-child-item nav-item button')
+        newProject = navChildren
+          .locator('.nav-child-item nav-item button')
           .filter({ hasText: projectName });
         await newProject.waitFor({ state: 'visible', timeout: 3000 });
         projectFound = true;

--- a/e2e/tests/work-view/add-to-today.spec.ts
+++ b/e2e/tests/work-view/add-to-today.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../fixtures/test.fixture';
 import { expectTaskVisible } from '../../utils/assertions';
+import { waitForStatePersistence } from '../../utils/waits';
 
 test.describe('Add to Today - Subtask Support', () => {
   test('should add subtask to Today when parent is NOT in Today', async ({
@@ -234,7 +235,15 @@ test.describe('Add to Today - keyboard shortcut', () => {
     // Assert real Today membership. Checking that the row is still visible in
     // the project — as the subtask tests above do — passes even when the
     // shortcut does nothing, which is how #9563 shipped unnoticed.
+    //
+    // Reload instead of navigating by hash: the soft navigation keeps the
+    // leaving project view in the DOM while it animates out, and that ghost row
+    // is a visible <task> with this title, so a plain visibility check passes
+    // even when nothing was scheduled (verified by dropping the keypress). The
+    // reload also proves the schedule survived persistence.
+    await waitForStatePersistence(page);
     await page.goto('/#/tag/TODAY/tasks');
+    await page.reload();
     await workViewPage.waitForTaskList();
     await expectTaskVisible(taskPage, 'Shortcut To Today');
   });

--- a/e2e/tests/work-view/add-to-today.spec.ts
+++ b/e2e/tests/work-view/add-to-today.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../fixtures/test.fixture';
+import { expectTaskVisible } from '../../utils/assertions';
 
 test.describe('Add to Today - Subtask Support', () => {
   test('should add subtask to Today when parent is NOT in Today', async ({
@@ -204,5 +205,37 @@ test.describe('Add to Today - Subtask Support', () => {
       .locator('task task-title')
       .filter({ hasText: 'Context Menu Subtask' });
     await expect(todaySubtask).toBeVisible();
+  });
+});
+
+test.describe('Add to Today - keyboard shortcut', () => {
+  test('Shift+T schedules a top-level project task for Today', async ({
+    page,
+    projectPage,
+    workViewPage,
+    taskPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await projectPage.createAndGoToTestProject();
+
+    await workViewPage.addTask('Shortcut To Today');
+    const task = await taskPage.waitForTaskWithText('Shortcut To Today');
+
+    // Precondition: the task is NOT on Today yet. The "Add to Today" button is
+    // rendered exactly when the task has no due day for today, so its presence
+    // keeps this test from passing vacuously.
+    await task.hover();
+    await expect(task.locator('button[title*="Add to Today"]')).toBeVisible();
+
+    await task.focus();
+    await expect(task).toBeFocused();
+    await page.keyboard.press('Shift+T');
+
+    // Assert real Today membership. Checking that the row is still visible in
+    // the project — as the subtask tests above do — passes even when the
+    // shortcut does nothing, which is how #9563 shipped unnoticed.
+    await page.goto('/#/tag/TODAY/tasks');
+    await workViewPage.waitForTaskList();
+    await expectTaskVisible(taskPage, 'Shortcut To Today');
   });
 });

--- a/e2e/tests/work-view/sections.spec.ts
+++ b/e2e/tests/work-view/sections.spec.ts
@@ -9,9 +9,9 @@ import { expect, test } from '../../fixtures/test.fixture';
  */
 test.describe('Sections', () => {
   /**
-   * Create a fresh project and navigate to it. Avoids
-   * `createAndGoToTestProject()` which hits a strict-mode `.nav-children`
-   * violation when both Projects and Tags trees are expanded.
+   * Create a fresh project and navigate to it. Takes a per-test project name,
+   * which `createAndGoToTestProject()` does not offer. (Its strict-mode
+   * `.nav-children` violation is fixed, so it is no longer a reason to avoid it.)
    */
   const setupTestProject = async (
     workViewPage: import('../../pages/work-view.page').WorkViewPage,

--- a/src/app/features/tasks/store/task.selectors.ts
+++ b/src/app/features/tasks/store/task.selectors.ts
@@ -418,8 +418,8 @@ export const selectAllTasksWithSubTasks = createSelector(
 
 // selectOverdueTasks (rebased): decision reads only dueDay/dueWithTime from the
 // snapshot; public re-maps ids to live Task refs. Shares the overdue comparison
-// with the isTaskOverdue util (Shift+T path) via isTaskOverdueByThreshold so the
-// two definitions cannot drift; the threshold is computed once per recompute.
+// with the isTaskOverdue util via isTaskOverdueByThreshold so the two definitions
+// cannot drift; the threshold is computed once per recompute.
 export const selectOverdueTaskIds = createSelector(
   selectTaskSchedulingSnapshot,
   selectTodayStr,

--- a/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
+++ b/src/app/features/tasks/task-context-menu/task-context-menu-inner/task-context-menu-inner.component.html
@@ -258,7 +258,9 @@
         <mat-icon>arrow_upward</mat-icon>
         {{ T.F.TASK.CMP.MOVE_TO_REGULAR | translate }}
       </span>
-      <span class="key-i">{{ kb.taskScheduleToday }}</span>
+      <!-- No shortcut hint: taskScheduleToday (Shift+T) schedules for today and
+      does NOT move between lists. Advertising it here is what made #8592's
+      reporter expect the two to be equivalent. -->
     </button>
   }
 

--- a/src/app/features/tasks/task-shortcut.service.spec.ts
+++ b/src/app/features/tasks/task-shortcut.service.spec.ts
@@ -711,7 +711,7 @@ describe('TaskShortcutService', () => {
     it('delegates to the focused <task> component (preserves overdue/backlog branching)', () => {
       const taskComponent = {
         task: () => ({ id: 'focused-task-1' }),
-        moveToTodayWithFocus: jasmine.createSpy('moveToTodayWithFocus'),
+        scheduleForTodayWithFocus: jasmine.createSpy('scheduleForTodayWithFocus'),
         taskContextMenu: () => undefined,
       };
       setFocusedTask('focused-task-1');
@@ -723,7 +723,7 @@ describe('TaskShortcutService', () => {
       const result = service.handleTaskShortcuts(event);
 
       expect(result).toBe(true);
-      expect(taskComponent.moveToTodayWithFocus).toHaveBeenCalled();
+      expect(taskComponent.scheduleForTodayWithFocus).toHaveBeenCalled();
       expect(mockTaskService.scheduleForTodayById).not.toHaveBeenCalled();
     });
 
@@ -772,7 +772,7 @@ describe('TaskShortcutService', () => {
 
       const staleComponent = {
         task: () => ({ id: 'stale-task-elsewhere' }),
-        moveToTodayWithFocus: jasmine.createSpy('moveToTodayWithFocus'),
+        scheduleForTodayWithFocus: jasmine.createSpy('scheduleForTodayWithFocus'),
         taskContextMenu: () => undefined,
       };
       mockTaskFocusService.focusedTaskId.set('stale-task-elsewhere');
@@ -785,7 +785,7 @@ describe('TaskShortcutService', () => {
         'overdue-planner-task',
       );
       expect(mockTaskService.scheduleForTodayById).toHaveBeenCalledTimes(1);
-      expect(staleComponent.moveToTodayWithFocus).not.toHaveBeenCalled();
+      expect(staleComponent.scheduleForTodayWithFocus).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -90,11 +90,13 @@ export class TaskShortcutService {
     // Schedule for today (Shift+T). This is the one task shortcut wired to work
     // without a live <task> component, so it also fires from views that render
     // <planner-task> (the Planner overdue list). When a real <task> is focused
-    // we still delegate, so the backlog→regular position-only move (#8592/#8603)
-    // and the overdue branch in moveToToday() are preserved. (#8851)
+    // we delegate instead, because that path also keeps keyboard focus sane when
+    // scheduling removes the row from the current list. (#8851)
+    // Neither path changes the task's list position — that stays the context
+    // menu's job, so #8592 keeps holding. (#9563)
     if (checkKeyCombo(ev, keys.taskScheduleToday)) {
       if (focusedTaskId) {
-        this._handleTaskShortcut(focusedTaskId, 'moveToTodayWithFocus');
+        this._handleTaskShortcut(focusedTaskId, 'scheduleForTodayWithFocus');
         ev.preventDefault();
         ev.stopPropagation();
         return true;

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -739,5 +739,37 @@ describe('TaskComponent shortcut handling', () => {
 
       expect(storeSpy.dispatch).not.toHaveBeenCalled();
     });
+
+    describe('scheduleForTodayWithFocus', () => {
+      it('keeps focus on the task instead of advancing to the next one', fakeAsync(() => {
+        // Both reports describe the caret moving on to the next task, because
+        // this used to call focusNext() unconditionally. Scheduling does not
+        // remove the row from a normal list, so focus must stay on the task;
+        // advancing is only the delayed fallback for a row that disappeared
+        // (the overdue panels).
+        // Asserted through the focus methods rather than document.activeElement:
+        // the TestBed host is a <div>, so focusSelfOrNextIfNotPossible's
+        // `tagName === 'task'` check can never pass here.
+        const focusSelfSpy = spyOn(component, 'focusSelf');
+        const focusNextSpy = spyOn(component, 'focusNext');
+        setTask({});
+
+        component.scheduleForTodayWithFocus();
+
+        expect(focusSelfSpy).toHaveBeenCalled();
+        expect(focusNextSpy).not.toHaveBeenCalled();
+        tick(200); // flush the fallback timer
+      }));
+
+      it('still schedules the task', fakeAsync(() => {
+        (fixture.nativeElement as HTMLElement).tabIndex = 0;
+        setTask({});
+
+        component.scheduleForTodayWithFocus();
+        tick(200);
+
+        expectScheduledForToday();
+      }));
+    });
   });
 });

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -635,74 +635,108 @@ describe('TaskComponent shortcut handling', () => {
     }));
   });
 
-  describe('moveToToday overdue branch (#8851)', () => {
+  describe('scheduleForToday — Shift+T (#9563)', () => {
+    // Must match the GlobalTrackingIntervalService.todayDateStr signal above,
+    // which is what isScheduledToday() reads.
+    const TODAY = '2026-05-05';
     let dateService: jasmine.SpyObj<DateService>;
     let projectService: jasmine.SpyObj<ProjectService>;
+
+    const setTask = (task: Partial<TaskWithSubTasks>): void => {
+      fixture.componentRef.setInput('task', {
+        ...createTopLevelTask('Task'),
+        dueDay: undefined,
+        dueWithTime: undefined,
+        ...task,
+      });
+      storeSpy.dispatch.calls.reset();
+      projectService.moveTaskToTodayList.calls.reset();
+    };
+
+    const expectScheduledForToday = (): void =>
+      expect(storeSpy.dispatch).toHaveBeenCalledOnceWith(
+        TaskSharedActions.planTasksForToday({
+          taskIds: ['top-1'],
+          today: TODAY,
+          startOfNextDayDiffMs: 0,
+          // computed key: a quoted 'top-1' trips the naming-convention rule
+          parentTaskMap: { ['top-1']: undefined },
+        }),
+      );
 
     beforeEach(() => {
       dateService = TestBed.inject(DateService) as jasmine.SpyObj<DateService>;
       projectService = TestBed.inject(ProjectService) as jasmine.SpyObj<ProjectService>;
       (dateService as any).todayStr = jasmine
         .createSpy('todayStr')
-        .and.returnValue('2026-06-01');
+        .and.returnValue(TODAY);
       (dateService as any).getStartOfNextDayDiffMs = jasmine
         .createSpy('getStartOfNextDayDiffMs')
         .and.returnValue(0);
     });
 
-    it('schedules an overdue task for today instead of a position-only move', () => {
-      fixture.componentRef.setInput('task', {
-        ...createTopLevelTask('Overdue'),
-        dueDay: '2026-05-30',
-      });
-      storeSpy.dispatch.calls.reset();
+    it('schedules an unscheduled task for today', () => {
+      // The #9563/#9567 regression: this did only a backlog→regular move, which
+      // the project reducer no-ops for a task already in the regular list — so
+      // the shortcut did nothing at all.
+      setTask({});
 
-      component.moveToToday();
+      component.scheduleForToday();
 
-      expect(storeSpy.dispatch).toHaveBeenCalledWith(
-        TaskSharedActions.planTasksForToday({
-          taskIds: ['top-1'],
-          today: '2026-06-01',
-          startOfNextDayDiffMs: 0,
-          parentTaskMap: { ['top-1']: undefined },
-        }),
-      );
-      expect(projectService.moveTaskToTodayList).not.toHaveBeenCalled();
+      expectScheduledForToday();
     });
 
-    it('keeps the position-only move for a non-overdue task (#8592)', () => {
-      fixture.componentRef.setInput('task', {
-        ...createTopLevelTask('Not overdue'),
-        dueDay: undefined,
-        dueWithTime: undefined,
-      });
-      storeSpy.dispatch.calls.reset();
+    it('schedules an overdue task for today (#8851)', () => {
+      setTask({ dueDay: '2026-04-30' });
 
-      component.moveToToday();
+      component.scheduleForToday();
 
-      expect(projectService.moveTaskToTodayList).toHaveBeenCalledWith(
-        'top-1',
-        'project-1',
-      );
+      expectScheduledForToday();
+    });
+
+    it('never moves the task between the backlog and the regular list (#8592)', () => {
+      // #8592 reported Shift+T (advertised in the "Move to regular list" menu
+      // entry) changing the schedule as a side effect of a list move. The two
+      // intents stay separate: this shortcut schedules and never repositions.
+      setTask({});
+
+      component.scheduleForToday();
+
+      expect(projectService.moveTaskToTodayList).not.toHaveBeenCalled();
+      expect(projectService.moveTaskToBacklog).not.toHaveBeenCalled();
+    });
+
+    it('leaves a task already scheduled for today untouched', () => {
+      setTask({ dueDay: TODAY });
+
+      component.scheduleForToday();
+
       expect(storeSpy.dispatch).not.toHaveBeenCalled();
     });
 
-    it('keeps the position-only move for a done task with a stale past dueDay', () => {
-      // A done task can sit in the backlog with an old dueDay; it must take the
-      // backlog→regular position-only move, not be re-added to Today.
-      fixture.componentRef.setInput('task', {
-        ...createTopLevelTask('Done + overdue'),
-        isDone: true,
-        dueDay: '2026-05-30',
+    it('keeps the reminder of a task due at a time today', () => {
+      // planTasksForToday clears remindAt unconditionally, so re-planning a task
+      // that is already on Today would silently drop its reminder.
+      // isToday is installed as a property on the DateService mock, so it has
+      // to be redefined rather than assigned.
+      Object.defineProperty(dateService, 'isToday', {
+        value: () => true,
+        configurable: true,
       });
-      storeSpy.dispatch.calls.reset();
+      setTask({ dueWithTime: 1746453600000, remindAt: 1746452000000 });
 
-      component.moveToToday();
+      component.scheduleForToday();
 
-      expect(projectService.moveTaskToTodayList).toHaveBeenCalledWith(
-        'top-1',
-        'project-1',
-      );
+      expect(storeSpy.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not put a done task on Today', () => {
+      // Completion never synthesizes a dueDay; done tasks reach Today's Done
+      // list via isDone. Dating one inflates the daily summary's done count.
+      setTask({ isDone: true, dueDay: '2026-04-30' });
+
+      component.scheduleForToday();
+
       expect(storeSpy.dispatch).not.toHaveBeenCalled();
     });
   });

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -85,7 +85,6 @@ import { PlannerActions } from '../../planner/store/planner.actions';
 import { PlannerService } from '../../planner/planner.service';
 import { DialogDeadlineComponent } from '../dialog-deadline/dialog-deadline.component';
 import { isDeadlineOverdue as isDeadlineOverdueFn } from '../util/is-deadline-overdue';
-import { isTaskOverdue } from '../util/is-task-overdue';
 import { isDeadlineApproaching as isDeadlineApproachingFn } from '../util/is-deadline-approaching';
 import { TaskContextMenuComponent } from '../task-context-menu/task-context-menu.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -818,14 +817,6 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
   }
 
-  moveToTodayWithFocus(): void {
-    const t = this.task();
-    if (t.projectId) {
-      this.focusNext(true, true);
-      this.moveToToday();
-    }
-  }
-
   openProjectMenu(): void {
     if (this.task().parentId) {
       return;
@@ -1386,34 +1377,42 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     }
   }
 
-  moveToToday(): void {
-    const t = this.task();
-    if (!t.projectId) {
+  /**
+   * `taskScheduleToday` (Shift+T, "Schedule task for today"). Schedules only —
+   * it must never change list position, because #8592 asked for the
+   * backlog→regular move to leave the schedule alone via BOTH the context menu
+   * and this shortcut. Keeping the two intents apart is what stops #8592 and
+   * #9563 from taking turns being broken; the context menu's own moveToToday()
+   * owns the position-only move.
+   *
+   * A backlog task does not need the move to land on Today: membership is
+   * computed from dueDay/dueWithTime alone (computeOrderedTaskIdsForToday),
+   * never from project.backlogTaskIds.
+   */
+  scheduleForToday(): void {
+    // Nothing to do, and doing it anyway is destructive: planTasksForToday
+    // clears remindAt unconditionally, so this would drop the reminder of a
+    // task due at a time today. The "Add to Today" button hides itself in this
+    // state for the same reason.
+    if (this.isScheduledToday()) {
       return;
     }
-    // An overdue task is never in the backlog, so the position-only move below
-    // early-returns for it (moveProjectTaskToRegularListAuto) and Shift+T would
-    // no-op. Schedule it for today instead — the same thing the "Add to My Day"
-    // button and Schedule → Today do (#8851). Overdue vs. backlog→regular are
-    // cleanly separated because overdue tasks are never in the backlog. Exclude
-    // done tasks: a done task with a stale past dueDay can still sit in the
-    // backlog, and it should take the position-only move, not be re-added to
-    // Today. (isTaskOverdue stays done-agnostic — selectOverdueTasks needs
-    // done tasks included.)
-    if (
-      !t.isDone &&
-      isTaskOverdue(
-        t,
-        this._dateService.todayStr(),
-        this._dateService.getStartOfNextDayDiffMs(),
-      )
-    ) {
-      this.addToMyDay();
+    // Completion never synthesizes a dueDay (see task-related-model.effects.ts):
+    // done tasks reach Today's Done list via isDone, and dating one instead
+    // inflates the daily summary's done count for today.
+    if (this.task().isDone) {
       return;
     }
-    // Moving to the regular list is a list-position change only; it must not
-    // schedule the task for today (#8592).
-    this._projectService.moveTaskToTodayList(t.id, t.projectId);
+    this.addToMyDay();
+  }
+
+  scheduleForTodayWithFocus(): void {
+    this._storeNextFocusEl();
+    this.scheduleForToday();
+    // Same focus handling as the sibling schedule shortcuts: keep focus on the
+    // task, and only advance if scheduling removed the row from this list (the
+    // Planner/work-view overdue panels).
+    this.focusSelfOrNextIfNotPossible();
   }
 
   trackByProjectId(i: number, project: Project): string {

--- a/src/app/features/tasks/util/is-task-overdue.ts
+++ b/src/app/features/tasks/util/is-task-overdue.ts
@@ -21,8 +21,10 @@ export const getLogicalTodayStartMs = (
  * Overdue comparison against a *precomputed* logical start-of-today threshold.
  * This is the single source of truth for "what counts as overdue"; both
  * `isTaskOverdue` and `selectOverdueTaskIds` route through it so the two overdue
- * definitions can never drift. Callers that iterate many tasks (the selector)
- * compute the threshold once and pass it in, instead of per task.
+ * definitions can never drift. (`isTaskOverdue` currently has no production
+ * caller — it is the tested, readable form of this pair and the entry point any
+ * new caller should use.) Callers that iterate many tasks (the selector) compute
+ * the threshold once and pass it in, instead of per task.
  *
  * Priority follows the dueWithTime/dueDay mutual-exclusivity pattern.
  */


### PR DESCRIPTION
## Problem

Fixes #9563, fixes #9567 — two independent reports, 13 hours apart, on v18.19.0 and v18.18.0:

> Pressed the keyboard shortcut to schedule task for today but it does not get scheduled. Instead, the selector moves to the next available task with no changes made. Using the keybind to schedule to any other time (such as "schedule task for tomorrow") works as intended. Pressing the button to schedule task for today works as intended.

`taskScheduleToday` (Shift+T, labelled "Schedule task for today") did a backlog→regular **list move** instead of scheduling. `moveProjectTaskToRegularListAuto`'s reducer early-returns for any task already in the regular list (`project.reducer.ts:526-531`), so the shortcut was a silent no-op for the common case — while `focusNext()` still advanced the caret, which is the second half of both reports. The reporter's console log shows exactly this: the action dispatches, is captured as an op and uploaded, and changes nothing.

Regressed in **v18.13.0** by 9e23832879 (#8603), which removed `addToMyDay()` from `TaskComponent.moveToToday()`. #8851 later patched only the overdue slice of the breakage.

## Solution

The obvious fix — restore the pre-#8603 "move + schedule" — **re-opens #8592**, whose reproduction names Shift+T explicitly:

> Right click the task and select 'Move to regular list' **OR select the task and press SHIFT+T (the shortcut indicated in the menu)** → The task moves up to the regular list AND is scheduled for today.

Both issues come from one mislabel: the context menu's "Move to regular list" entry advertised Shift+T as its keybinding, so a single keypress was expected to serve two contradictory intents. Patching either side just makes the other one break again — this is the second swing already.

So the intents are separated instead:

| | does | advertises a shortcut |
|---|---|---|
| **Shift+T** (`scheduleForToday`) | schedules for today, never repositions | — |
| **"Move to regular list"** (context menu) | position only | no longer |
| **Shift+B** / "Move to backlog" | position only | unchanged |

The list move is **deleted**, not gated. A backlog task does not need it to reach Today: membership is computed from `dueDay`/`dueWithTime` alone (`computeOrderedTaskIdsForToday`, `work-context.selectors.ts:42-121`) and never consults `project.backlogTaskIds`. Dropping it also removes a phantom sync op — capture is action-based with no state diffing, so the no-op move shipped a real op that could revert a peer's backlog move on replay.

Two guards come with it:

- **Already on Today** → skip. `handlePlanTasksForToday` clears `remindAt` unconditionally while `shouldClearDueTimeForToday` keeps a `dueWithTime` that is today, so re-planning would silently drop the reminder of a task due at a time today. The ☀️ button hides itself in this state for the same reason.
- **Done tasks** → skip. Completion never synthesizes a `dueDay` (`task-related-model.effects.ts:77-81`); done tasks reach Today's Done list via `isDone`. Dating one adds it to `daily-summary.component.ts:556`, which admits on `dueDay === dayStr` with no `isDone` guard, inflating today's done count.

Focus now follows the same pattern as the sibling schedule shortcuts (`_storeNextFocusEl()` + `focusSelfOrNextIfNotPossible()`), so the caret stays on the task unless scheduling actually removed the row — the shortcuts the reporter said "work as intended".

`moveToToday()` is renamed `scheduleForToday()`. The name collision with `TaskContextMenuInnerComponent.moveToToday()`, which has the opposite contract, is what caused this regression twice.

### Please sanity-check this call

**There is no longer any keyboard route out of the backlog.** Shift+T was doing double duty and its mirror Shift+B is position-only. If you want that back it needs its own keybinding — I did not add one, since a new shortcut is a permanent surface and the reported bug does not require it.

## Type of Change

- [x] Bug fix

## Testing

- Full unit suite: **14115 pass, 0 fail**
- New unit tests replace two that asserted the buggy behaviour while citing #8592 — including the missing **#8592 regression guard** (asserts no list-position dispatch), the reminder-preservation case, the done-task case, and the focus contract
- New e2e presses Shift+T on a top-level project task and asserts it appears in the Today view. The existing subtask tests assert the row is visible where it already was, which stays true when the shortcut does nothing — that is why e2e slept through the original regression
- `npm run checkFile` clean on all changed `.ts` files; prettier clean on the template

The e2e could not run locally (sandbox: `global-setup` shells out to `npm run plugins:build`, which needs network installs). It is running on CI via [E2E Tests (Scheduled) run 31797571227](https://github.com/super-productivity/super-productivity/actions/runs/31797571227) and this PR.

## Follow-ups (not in this PR)

- #9577 — Shift+T behaves differently on `<planner-task>` hosts than on `<task>` hosts; the fallback path lacks both guards above
- #9374 — the mirror bug: #8603 stripped `unschedule()` from `moveToBacklog()` the same way, also shortcut-only. [Root cause commented there](https://github.com/super-productivity/super-productivity/issues/9374#issuecomment-5292756313); it needs the same "don't overload one keypress" decision, so it is not a straight revert

## Checklist

- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format
- [ ] Documentation — no user-facing doc changes; the shortcut's existing label ("Schedule task for today") now matches what it does
