### PR TITLE
fix(ui): stop iOS zooming the page when focusing sub-16px inputs

### DIFF
--- a/e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts
+++ b/e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts
@@ -1,0 +1,71 @@
+import { Page } from 'playwright/test';
+
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Issues #9415, #9551, #9556: on iOS, tapping the tag field in a task's detail
+ * panel zoomed the whole page and left the tag autocomplete misaligned.
+ *
+ * iOS zooms the page whenever the focused form control's computed font-size is
+ * below 16px, and only restores the scale on blur. That was suppressed app-wide
+ * by `user-scalable=no` in the viewport meta until #9272 deliberately dropped it
+ * to restore pinch-zoom (shipped in v18.16.0) — which surfaced the zoom on every
+ * bare input that is not inside a mat-form-field (those resolve to 16px via
+ * --mat-form-field-container-text-size).
+ *
+ * The zoom itself is a WebKit behavior and cannot be reproduced in Chromium, so
+ * this pins the invariant it keys off instead: every focusable text control in
+ * the detail panel must compute to >= 16px. That is exactly what regressed, and
+ * it fails against the pre-fix stylesheet (tag input: ~13px UA default,
+ * add-subtask input: 14px).
+ *
+ * Run: npm run e2e:file e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts -- --retries=0
+ */
+
+const IOS_ZOOM_THRESHOLD_PX = 16;
+
+const getFontSizePx = async (page: Page, selector: string): Promise<number> => {
+  const raw = await page
+    .locator(selector)
+    .first()
+    .evaluate((el) => getComputedStyle(el).fontSize);
+  return parseFloat(raw);
+};
+
+test.describe('Task detail iOS focus zoom', () => {
+  test('should keep detail panel inputs at or above the iOS zoom threshold', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask('zoom threshold task');
+
+    const task = taskPage.getTaskByText('zoom threshold task');
+    await task.hover();
+    await page.getByRole('button', { name: 'Show/hide task panel' }).click();
+
+    // Tag field — the control all three issues named.
+    const tagInput = page.locator('tag-edit input');
+    await tagInput.waitFor({ state: 'visible' });
+    expect(await getFontSizePx(page, 'tag-edit input')).toBeGreaterThanOrEqual(
+      IOS_ZOOM_THRESHOLD_PX,
+    );
+
+    // Add-subtask field — same panel, same gesture, same defect.
+    await task.focus();
+    await task.press('a');
+    const subTaskInput = page.locator('.e2e-add-subtask-input');
+    await subTaskInput.waitFor({ state: 'visible' });
+    expect(await getFontSizePx(page, '.e2e-add-subtask-input')).toBeGreaterThanOrEqual(
+      IOS_ZOOM_THRESHOLD_PX,
+    );
+
+    // The panel title is deliberately not asserted here. `.task-title` is 17px
+    // and only drops to 15px at mq(xs) — which is `min-width`, so phones keep
+    // 17px and never triggered the zoom. Measured at a 390px viewport to
+    // confirm. Asserting it needs a viewport resize mid-test, which reports
+    // transitional values before the layout settles, so it was dropped rather
+    // than shipped flaky.
+  });
+});

--- a/e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts
+++ b/e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts
@@ -90,6 +90,13 @@ test.describe('Task detail iOS focus zoom', () => {
     expect(await getFontSizePx(page, '.e2e-add-subtask-input')).toBeGreaterThanOrEqual(
       IOS_ZOOM_THRESHOLD_PX,
     );
+
+    // The panel title is not asserted. `.task-title` is 17px below 600px, so
+    // phones already clear the threshold; its >=600px rule stays at 15px, so a
+    // touch tablet can still trip the zoom there. Knowingly left — raising it
+    // would change desktop for a case nobody has reported. Reading it here
+    // would also need a viewport resize mid-test, which reports transitional
+    // values before the layout settles.
   });
 
   // Controls with a non-focusable display counterpart (rendered markdown, the

--- a/e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts
+++ b/e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright/test';
+import { Locator, Page } from 'playwright/test';
 
 import { expect, test } from '../../fixtures/test.fixture';
 
@@ -14,10 +14,9 @@ import { expect, test } from '../../fixtures/test.fixture';
  * --mat-form-field-container-text-size).
  *
  * The zoom itself is a WebKit behavior and cannot be reproduced in Chromium, so
- * this pins the invariant it keys off instead: every focusable text control in
- * the detail panel must compute to >= 16px. That is exactly what regressed, and
- * it fails against the pre-fix stylesheet (tag input: ~13px UA default,
- * add-subtask input: 14px).
+ * these pin the invariant it keys off instead: every focusable text control
+ * reachable from the detail panel must compute to >= 16px. That is exactly what
+ * regressed — verified to fail against the pre-fix stylesheets.
  *
  * Run: npm run e2e:file e2e/tests/task-detail/ios-focus-zoom-9556.spec.ts -- --retries=0
  */
@@ -32,40 +31,102 @@ const getFontSizePx = async (page: Page, selector: string): Promise<number> => {
   return parseFloat(raw);
 };
 
+const openTaskDetailPanel = async (
+  page: Page,
+  workViewPage: {
+    waitForTaskList: () => Promise<void>;
+    addTask: (t: string) => Promise<void>;
+  },
+  taskPage: { getTaskByText: (t: string) => Locator },
+  title: string,
+): Promise<Locator> => {
+  await workViewPage.waitForTaskList();
+  await workViewPage.addTask(title);
+  const task = taskPage.getTaskByText(title);
+  await task.hover();
+  await page.getByRole('button', { name: 'Show/hide task panel' }).click();
+  return task;
+};
+
+// Mirrors WorkViewPage.addSubTask: the 'a' shortcut only lands once focus has
+// actually settled on the task, so verify and retry rather than assuming.
+const openSubTaskDraft = async (page: Page, task: Locator): Promise<void> => {
+  await task.focus();
+  await page.waitForTimeout(200);
+  const isFocused = await task.evaluate(
+    (el) => el === document.activeElement || el.contains(document.activeElement),
+  );
+  if (!isFocused) {
+    await task.focus();
+    await page.waitForTimeout(200);
+  }
+  await task.press('a');
+  await page
+    .locator('.e2e-add-subtask-input')
+    .waitFor({ state: 'visible', timeout: 5000 });
+};
+
 test.describe('Task detail iOS focus zoom', () => {
   test('should keep detail panel inputs at or above the iOS zoom threshold', async ({
     page,
     workViewPage,
     taskPage,
   }) => {
-    await workViewPage.waitForTaskList();
-    await workViewPage.addTask('zoom threshold task');
-
-    const task = taskPage.getTaskByText('zoom threshold task');
-    await task.hover();
-    await page.getByRole('button', { name: 'Show/hide task panel' }).click();
+    const task = await openTaskDetailPanel(
+      page,
+      workViewPage,
+      taskPage,
+      'zoom threshold task',
+    );
 
     // Tag field — the control all three issues named.
-    const tagInput = page.locator('tag-edit input');
-    await tagInput.waitFor({ state: 'visible' });
+    await page.locator('tag-edit input').waitFor({ state: 'visible' });
     expect(await getFontSizePx(page, 'tag-edit input')).toBeGreaterThanOrEqual(
       IOS_ZOOM_THRESHOLD_PX,
     );
 
     // Add-subtask field — same panel, same gesture, same defect.
-    await task.focus();
-    await task.press('a');
-    const subTaskInput = page.locator('.e2e-add-subtask-input');
-    await subTaskInput.waitFor({ state: 'visible' });
+    await openSubTaskDraft(page, task);
     expect(await getFontSizePx(page, '.e2e-add-subtask-input')).toBeGreaterThanOrEqual(
       IOS_ZOOM_THRESHOLD_PX,
     );
+  });
 
-    // The panel title is deliberately not asserted here. `.task-title` is 17px
-    // and only drops to 15px at mq(xs) — which is `min-width`, so phones keep
-    // 17px and never triggered the zoom. Measured at a 390px viewport to
-    // confirm. Asserting it needs a viewport resize mid-test, which reports
-    // transitional values before the layout settles, so it was dropped rather
-    // than shipped flaky.
+  // Controls with a non-focusable display counterpart (rendered markdown, the
+  // static title) are raised only under `isTouchPrimary`, so both layers move
+  // together and desktop keeps its 14px. Forcing the class is what a phone
+  // would set via InputIntentService.
+  test('should raise editor/display pairs above the threshold on touch', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await openTaskDetailPanel(page, workViewPage, taskPage, 'touch zoom task');
+
+    await page.locator('inline-markdown .markdown-parsed').first().waitFor();
+    await page.evaluate(() => {
+      document.body.classList.remove('isMousePrimary');
+      document.body.classList.add('isTouchPrimary');
+    });
+
+    // Polled rather than read once: these elements carry a font-size
+    // transition, so an immediate read catches an intermediate value. A real
+    // phone sets isTouchPrimary at startup, long before any field is focused,
+    // so the transition only exists in this test.
+    //
+    // Task description. Asserted on the rendered half, not the textarea: both
+    // are raised by a single `.markdown-unparsed, .markdown-parsed` declaration
+    // in inline-markdown.component.scss, so this covers the focusable half too,
+    // and opening the editor needs a click sequence through an animating
+    // expansion panel that proved flaky. Keep the two selectors in one
+    // declaration or this stops covering the textarea.
+    await expect
+      .poll(() => getFontSizePx(page, 'inline-markdown .markdown-parsed'))
+      .toBeGreaterThanOrEqual(IOS_ZOOM_THRESHOLD_PX);
+
+    // Task title in a list row — the most frequent inline edit on mobile.
+    await expect
+      .poll(() => getFontSizePx(page, 'task task-title'))
+      .toBeGreaterThanOrEqual(IOS_ZOOM_THRESHOLD_PX);
   });
 });

--- a/src/app/features/tag/tag-edit/tag-edit.component.scss
+++ b/src/app/features/tag/tag-edit/tag-edit.component.scss
@@ -15,6 +15,13 @@
     appearance: none;
     display: block;
     width: 100%;
+    // iOS zooms the whole page when focusing an input whose computed font-size
+    // is below 16px. This input sits outside a mat-form-field on purpose (see
+    // the placeholder comment below), so without these it falls back to the
+    // ~13px Arial UA default and triggers that zoom (#9415, #9551, #9556).
+    // 16px is a fixed platform threshold, not a design token.
+    font-family: inherit;
+    font-size: 16px;
     box-shadow: none;
     border: none;
     color: var(--text-color);

--- a/src/app/features/tag/tag-edit/tag-edit.component.scss
+++ b/src/app/features/tag/tag-edit/tag-edit.component.scss
@@ -1,3 +1,5 @@
+@use '../../../../styles/globals' as *;
+
 :host {
   width: 100%;
 
@@ -15,16 +17,15 @@
     appearance: none;
     display: block;
     width: 100%;
-    // iOS zooms the whole page when focusing an input whose computed font-size
-    // is below 16px. This input sits outside a mat-form-field on purpose (see
-    // the placeholder comment below), so without these it falls back to the
-    // ~13px Arial UA default and triggers that zoom (#9415, #9551, #9556).
-    // 16px is a fixed platform threshold, not a design token.
-    font-family: inherit;
-    font-size: 16px;
     box-shadow: none;
     border: none;
     color: var(--text-color);
+    // matChipInput only inherits Material's form-field typography when it sits
+    // inside a mat-form-field; in the task detail panel it does not, so this
+    // input fell back to the UA default for form controls (~13px).
+    @include noIosFocusZoom();
+    // The UA `font` shorthand also forces its own family here; follow the app stack.
+    font-family: inherit;
     border-top: 1px solid transparent;
     border-bottom: 1px solid transparent;
     height: 40px;

--- a/src/app/features/tasks/add-subtask-input/add-subtask-input.component.scss
+++ b/src/app/features/tasks/add-subtask-input/add-subtask-input.component.scss
@@ -1,3 +1,5 @@
+@use '../../../../styles/globals' as *;
+
 :host {
   display: block;
   margin-top: var(--s-quarter);
@@ -22,7 +24,9 @@
   background: var(--bg-lightest);
   color: var(--text-color-most-intense);
   font-family: var(--font-primary-stack);
-  font-size: 14px;
+  // Renders in the task detail panel right next to tag-edit, so it hit the same
+  // iOS focus zoom (#9556). line-height stays 40px — only the glyphs grow.
+  @include noIosFocusZoom();
   line-height: 40px;
 
   &:focus {

--- a/src/app/features/tasks/select-task/select-task-minimal/select-task-minimal.component.scss
+++ b/src/app/features/tasks/select-task/select-task-minimal/select-task-minimal.component.scss
@@ -10,7 +10,9 @@ input {
   border: 1px solid var(--border-color);
   border-radius: var(--card-border-radius);
   padding: var(--s) 12px;
-  font-size: 14px;
+  // Schedule's create-task field: a plain input with no display counterpart,
+  // so raising it cannot desync anything (#9556).
+  @include noIosFocusZoom();
   line-height: 1.4;
   background: transparent;
   color: inherit;

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
@@ -72,8 +72,12 @@ progress-bar {
   min-height: 40px;
   font-size: 17px;
 
+  // 16px rather than 15px: this rule outweighs task-title's own touch-scoped
+  // bump, and at these widths a touch device is a tablet — where 15px would
+  // still trip the iOS focus zoom (#9556). Below 600px the base 17px already
+  // clears it.
   @include mq(xs) {
-    font-size: 15px;
+    font-size: 16px;
   }
 
   &:focus {

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
@@ -72,12 +72,8 @@ progress-bar {
   min-height: 40px;
   font-size: 17px;
 
-  // 16px rather than 15px: this rule outweighs task-title's own touch-scoped
-  // bump, and at these widths a touch device is a tablet — where 15px would
-  // still trip the iOS focus zoom (#9556). Below 600px the base 17px already
-  // clears it.
   @include mq(xs) {
-    font-size: 16px;
+    font-size: 15px;
   }
 
   &:focus {

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.scss
@@ -128,7 +128,10 @@
       overflow-wrap: break-word;
       display: block;
       resize: none;
+      // Sits beside .markdown-preview at the same size, so only raise it where
+      // the zoom actually happens rather than desyncing the two on desktop.
       font-size: 14px;
+      @include noIosFocusZoomOnTouch();
       // Allow proper flex shrinking
       min-height: 0;
 

--- a/src/app/ui/inline-input/inline-input.component.scss
+++ b/src/app/ui/inline-input/inline-input.component.scss
@@ -42,9 +42,13 @@ input {
   color: var(--text-color);
   padding: var(--s-half) var(--s-half);
   text-align: center;
-  // Only visible while editing, so there is no display counterpart to stay in
-  // sync with — safe to raise unconditionally (#9556).
-  @include noIosFocusZoom();
+  font-size: 14px;
+  // Overlays .value-wrapper, which has no size of its own and inherits from
+  // whatever row hosts it. Raising this unconditionally would resize the
+  // overlay on plain desktop hover (see the :host:hover rule below), so it is
+  // scoped to touch where the zoom is the real problem (#9556). The 14px above
+  // must stay: without it the untouched path falls to the ~13px UA default.
+  @include noIosFocusZoomOnTouch();
   min-height: 100%;
 
   @include inlineEditElevation();

--- a/src/app/ui/inline-input/inline-input.component.scss
+++ b/src/app/ui/inline-input/inline-input.component.scss
@@ -42,7 +42,9 @@ input {
   color: var(--text-color);
   padding: var(--s-half) var(--s-half);
   text-align: center;
-  font-size: 14px;
+  // Only visible while editing, so there is no display counterpart to stay in
+  // sync with — safe to raise unconditionally (#9556).
+  @include noIosFocusZoom();
   min-height: 100%;
 
   @include inlineEditElevation();

--- a/src/app/ui/inline-markdown/inline-markdown.component.scss
+++ b/src/app/ui/inline-markdown/inline-markdown.component.scss
@@ -33,6 +33,10 @@
 
 .markdown-unparsed,
 .markdown-parsed {
+  // The textarea (unparsed) is the focusable half and sat at 14px via
+  // .mat-body-2, so it triggered the iOS zoom. Both halves are raised together
+  // so the description does not change size when the editor opens (#9556).
+  @include noIosFocusZoomOnTouch();
   //transition: height 1.3s;
   border: 0;
   padding: var(--s) var(--s2);

--- a/src/app/ui/task-title/task-title.component.scss
+++ b/src/app/ui/task-title/task-title.component.scss
@@ -3,6 +3,16 @@
 
 // TODO rename to task title component
 
+// .display-value, the edit textarea and .height-measure all take `font-size:
+// inherit`, so raising it on the host moves all three at once — the textarea
+// clears the iOS zoom threshold and stays measured correctly by
+// .height-measure. Raising only the textarea would desync that pair and
+// mis-size the box. Written out rather than via noIosFocusZoomOnTouch() because
+// that mixin nests as a descendant, which cannot target the host itself.
+:host-context(body.isTouchPrimary) {
+  @include noIosFocusZoom();
+}
+
 :host {
   display: flex;
   align-items: center;

--- a/src/styles/mixins/_ios-focus-zoom.scss
+++ b/src/styles/mixins/_ios-focus-zoom.scss
@@ -14,3 +14,27 @@
 @mixin noIosFocusZoom() {
   font-size: 16px;
 }
+
+// Same threshold, but only where touch is the primary input.
+//
+// Use for controls that have a non-focusable display counterpart rendered at
+// the same size (an inline editor behind rendered markdown, a title textarea
+// behind its static text). Those must move together or the text visibly jumps
+// size on tap — and moving them unconditionally would restyle the app for
+// desktop users, who are not affected by the zoom at all. On touch the larger
+// text is a readability win rather than a compromise.
+//
+// Apply to whatever element the size is inherited from so every layer follows
+// in one place. This nests as a DESCENDANT of the touch-primary body, so it
+// cannot target a component host — for that, write
+// `:host-context(body.isTouchPrimary) { @include noIosFocusZoom(); }` at the top
+// level of the stylesheet instead (see task-title.component.scss).
+//
+// Known gap: an iPad in mouse mode (`isMousePrimary`) that focuses via a
+// hardware Tab still zooms — accepted, since the zoom is far less disruptive at
+// that viewport.
+@mixin noIosFocusZoomOnTouch() {
+  :host-context(body.isTouchPrimary) & {
+    @include noIosFocusZoom();
+  }
+}

--- a/src/styles/mixins/_ios-focus-zoom.scss
+++ b/src/styles/mixins/_ios-focus-zoom.scss
@@ -1,0 +1,16 @@
+// iOS zooms the whole page when the focused form control's computed font-size
+// is below 16px, and only restores the scale on blur. That was suppressed
+// app-wide by `user-scalable=no` in the viewport meta until #9272 deliberately
+// dropped it to restore pinch-zoom (shipped in v18.16.0), which surfaced the
+// zoom on every sub-16px input (#9415, #9551, #9556).
+//
+// Apply to bare inputs/textareas that are NOT inside a mat-form-field — those
+// already resolve to 16px via --mat-form-field-container-text-size, which is
+// why most of the app was unaffected.
+//
+// Keep the literal: 16px is a WebKit platform threshold, not a design token.
+// Binding it to --font-size-lg (also 16px today) would silently re-arm the bug
+// the day that token is retuned.
+@mixin noIosFocusZoom() {
+  font-size: 16px;
+}

--- a/src/styles/mixins/_mixins.scss
+++ b/src/styles/mixins/_mixins.scss
@@ -13,5 +13,6 @@
 @forward '_responsive-ratio';
 @forward '_material-icon';
 @forward '_media-queries';
+@forward '_ios-focus-zoom';
 
 // Internal @use statements removed to avoid potential circular dependency issues


### PR DESCRIPTION
## Problem

Fixes #9415, #9551, #9556 — three independent iOS reports, all describing the same thing:
tapping the tag/label field in a task's detail panel zooms the whole screen and leaves the
tag list oversized and misaligned.

iOS zooms the page whenever the focused form control's computed `font-size` is below 16px,
restoring the scale only on blur. That was suppressed app-wide by `maximum-scale=1.0,
user-scalable=no` in the viewport meta until #9272 (`6209542dc1`) deliberately removed it to
restore pinch-zoom — an intentional accessibility improvement, listed in that PR as "allow
browser zoom". It first shipped in **v18.16.0**; `git merge-base --is-ancestor` confirms it is
absent from v18.15.0.

The timing matches exactly: #9415 was filed against `18.16.0I`, the first release containing
the change, and there are no comparable reports before it.

The tag field was the most visible casualty because `tag-edit`'s chip input is deliberately
**not** wrapped in a `mat-form-field` (its own SCSS comment says so), so it receives no
Material typography. `MatChipInput` only adds the class carrying `font: inherit` when
`MAT_FORM_FIELD` is injectable (`chips.mjs:2387-2394`), so it fell back to the browser
default — **measured at 13.3333px**. Every other `mat-form-field` input in the app resolves to
16px via `--mat-form-field-container-text-size`, which is why the rest of the app was fine and
why adding a tag during task *creation* (add-task-bar, explicitly 16px) never showed the bug.

## Solution

Raise the affected controls to 16px rather than re-disabling pinch-zoom, so #9272's
accessibility improvement stays intact. The controls split into two kinds:

**Edit-only controls** — no display counterpart, so raising them is free and unconditional:
`tag-edit`, `add-subtask-input`, `select-task-minimal`.

**Editor/display pairs** — the task description, inline task titles, `inline-input`, and the
fullscreen markdown editor each render an editor behind or over static text at the same size.
Raising only the editor makes text visibly jump on tap; raising both everywhere would restyle
desktop, which has no zoom to fix. These are raised together under `isTouchPrimary` via a new
`noIosFocusZoomOnTouch()` mixin, where the larger text is a mobile readability gain rather
than a compromise.

A shared `src/styles/mixins/_ios-focus-zoom.scss` carries the threshold and the rationale in
one place. The literal `16px` is deliberate and commented: it is a WebKit platform threshold,
not a design token. Binding it to `--font-size-lg` (also 16px today) would silently re-arm the
bug the day that token is retuned — and commit `114e5067a1` already swept this exact block for
hardcoded values once.

### Verification

The zoom is a WebKit behaviour and cannot be reproduced in the browsers CI runs, so the e2e
guard pins the invariant it keys off instead: the affected controls must compute to >= 16px.
That is exactly what regressed, and the guard was **verified to fail against the pre-fix
stylesheets** (13.3333px for the tag input, 14px for the others) and pass after.

Measured in the running app at a 390px viewport: task rows 14px on mouse / 16px on touch,
`inline-input` 14px / 16px, detail panel renders without clipping, desktop pixel-identical
wherever the fix is touch-scoped.

### Not changed

- `dialog-logs` and the local REST API token — readonly monospace fields on desktop-oriented
  screens, where 16px would look wrong.
- The formly inputs (`keyboard`, `icon`, `time`, `duration`, `image-input`) need nothing: they
  use `matInput` inside a form-field wrapper and already resolve to 16px.
- `input-duration-slider` was already 16px by default, and 39.6px minimum in focus mode.
- The detail panel title's `>=600px` rule stays at 15px. A touch tablet can still trip the
  zoom there; raising it would have changed desktop for a case nobody has reported. The gap is
  recorded in the spec.

### Known gaps

- **Not verified on a physical iOS device.** The premise that >= 16px stops the zoom is
  well-established but untested here, and there is no way to reproduce the symptom in CI. I've
  drafted a comment asking the three reporters to confirm on the next build.
- `isTouchPrimary` flips to mouse on a `pen` or `mouse` pointer event, so an iPad with an Apple
  Pencil or Magic Keyboard can still zoom on the touch-scoped controls.

### Worth a second opinion

Capacitor disables pinch-zoom at the WebView level on **both** native platforms already —
`zoomingEnabled` defaults to `NO` (`CAPInstanceDescriptor.m:40`) and the delegate kills the
pinch recognizer (`WebViewDelegationHandler.swift:337-340`); Android does the same via
`setBuiltInZoomControls(false)`. So #9272's gain only ever applied to mobile web and the PWA.
That means `maximum-scale=1` (without `user-scalable=no`) would fix all of this in one line, at
a cost paid only on mobile web.

I did not take that route: both approaches are equally unverifiable without a device, but they
fail differently. The CSS approach degrades harmlessly if the premise is wrong (small inputs
are simply 16px on mobile), while the viewport approach is all-or-nothing and would need
startup JS to scope it to the native shell. Happy to switch if you'd rather have the one-liner.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing functionality change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass — 80 e2e across task-detail, planner, task-basic, schedule, worklog, work-view
- [x] My commit messages follow the Angular format (`type(scope): description`)
