### PR TITLE
[DO NOT MERGE] fix(android): keep add-task bar above keyboard on old WebViews

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -25,6 +25,7 @@ import com.superproductivity.superproductivity.service.ForegroundServiceFailure
 import com.superproductivity.superproductivity.service.SyncReminderScheduler
 import com.superproductivity.superproductivity.service.TrackingForegroundService
 import com.superproductivity.superproductivity.util.printWebViewVersion
+import com.superproductivity.superproductivity.webview.ImeWebViewHeight
 import com.superproductivity.superproductivity.webview.JavaScriptInterface
 import com.superproductivity.superproductivity.webview.NativeInsetShimGate
 import com.superproductivity.superproductivity.webview.WebHelper
@@ -228,9 +229,11 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
-            logImeGeometryOnTransition(rect, isKeyboardOpen)
             adjustWebViewHeightForKeyboard(rect, isKeyboardOpen)
             pushStatusBarOverlap(rect)
+            // After the shim, so the log shows the height it applied. See
+            // logImeGeometryOnTransition.
+            logImeGeometryOnTransition(rect, isKeyboardOpen)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -509,6 +512,13 @@ class CapacitorMainActivity : BridgeActivity() {
      * prints the gate's inputs next to the geometry it decides from, so a test
      * build gives an unambiguous answer.
      *
+     * Must be called **after** the shim has had its pass, so `paramsHeight` is
+     * what the shim just applied rather than the value it replaced. `target` is
+     * recomputed here from the same input, so a pass where the shim bailed on a
+     * degenerate frame still reads unambiguously (`target` set, `paramsHeight`
+     * unchanged) instead of looking like the gate was off. `webViewHeight` is
+     * still the pre-layout measurement — it catches up on the next pass.
+     *
      * Silent unless explicitly enabled (`adb shell setprop log.tag.SUPKeyboard
      * DEBUG`), so release builds stay quiet; the transition check comes first to
      * keep the per-layout-pass listener cheap. Geometry and versions only — never
@@ -527,6 +537,9 @@ class CapacitorMainActivity : BridgeActivity() {
                 "wvMajor=${NativeInsetShimGate.activeProviderMajor(webViewCompatibility)} " +
                 "(raw=${webViewCompatibility?.majorVersion} src=${webViewCompatibility?.source}) " +
                 "rectBottom=${rect.bottom} webViewTop=${webViewLocationOnScreen[1]} " +
+                "target=${
+                    ImeWebViewHeight.targetHeight(rect.bottom, webViewLocationOnScreen[1])
+                } " +
                 "webViewHeight=${webView.height} paramsHeight=${webView.layoutParams?.height}"
         )
     }
@@ -573,12 +586,14 @@ class CapacitorMainActivity : BridgeActivity() {
         val targetHeight: Int
         if (isKeyboardOpen) {
             webView.getLocationOnScreen(webViewLocationOnScreen)
-            val heightToKeyboardTop = rect.bottom - webViewLocationOnScreen[1]
-            // Guard against a degenerate/transient measurement collapsing the
-            // WebView to 0 — the height==0 check above would then latch and stop
-            // recomputing. Keep the current height until a sane value appears.
-            if (heightToKeyboardTop <= 0) return
-            targetHeight = heightToKeyboardTop
+            // Absolute target, never a delta — see ImeWebViewHeight for why that is
+            // what keeps this from re-creating #8508. null = degenerate/transient
+            // frame; keep the current height until a sane value appears, or the
+            // height==0 check above would latch and stop recomputing.
+            targetHeight = ImeWebViewHeight.targetHeight(
+                rectBottom = rect.bottom,
+                webViewTop = webViewLocationOnScreen[1],
+            ) ?: return
         } else {
             targetHeight = webViewLayoutHeightDefault ?: ViewGroup.LayoutParams.MATCH_PARENT
         }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -63,6 +63,11 @@ class CapacitorMainActivity : BridgeActivity() {
     // See pushStatusBarOverlap.
     private var lastStatusBarOverlapCssPx: Int = -1
 
+    // Last IME state the geometry diagnostic logged, so the per-layout-pass
+    // listener logs once per transition instead of every pass. null = nothing yet.
+    // See logImeGeometryOnTransition.
+    private var lastLoggedKeyboardOpen: Boolean? = null
+
     private var isTimerCompleteReceiverRegistered = false
     private var isForegroundServiceFailureReceiverRegistered = false
     private var isWidgetDoneDrainReceiverRegistered = false
@@ -223,6 +228,7 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
+            logImeGeometryOnTransition(rect, isKeyboardOpen)
             adjustWebViewHeightForKeyboard(rect, isKeyboardOpen)
             pushStatusBarOverlap(rect)
         }
@@ -491,8 +497,39 @@ class CapacitorMainActivity : BridgeActivity() {
     private fun shouldRunNativeInsetShim(): Boolean =
         NativeInsetShimGate.shouldRunShim(
             sdkInt = android.os.Build.VERSION.SDK_INT,
-            webViewMajor = webViewCompatibility?.majorVersion,
+            webViewMajor = NativeInsetShimGate.activeProviderMajor(webViewCompatibility),
         )
+
+    /**
+     * One-line IME geometry diagnostic, logged once per keyboard transition.
+     *
+     * #9316 can only be settled on a reporter's device, and the shim is a strict
+     * no-op wherever the window already resizes for the IME — so "the bar looks
+     * fixed" cannot by itself tell a working shim from one that never ran. This
+     * prints the gate's inputs next to the geometry it decides from, so a test
+     * build gives an unambiguous answer.
+     *
+     * Silent unless explicitly enabled (`adb shell setprop log.tag.SUPKeyboard
+     * DEBUG`), so release builds stay quiet; the transition check comes first to
+     * keep the per-layout-pass listener cheap. Geometry and versions only — never
+     * user content.
+     */
+    private fun logImeGeometryOnTransition(rect: Rect, isKeyboardOpen: Boolean) {
+        if (lastLoggedKeyboardOpen == isKeyboardOpen) return
+        lastLoggedKeyboardOpen = isKeyboardOpen
+        if (!Log.isLoggable("SUPKeyboard", Log.DEBUG)) return
+        val webView = bridge?.webView ?: return
+        webView.getLocationOnScreen(webViewLocationOnScreen)
+        Log.d(
+            "SUPKeyboard",
+            "ime=$isKeyboardOpen shim=${shouldRunNativeInsetShim()} " +
+                "sdk=${android.os.Build.VERSION.SDK_INT} " +
+                "wvMajor=${NativeInsetShimGate.activeProviderMajor(webViewCompatibility)} " +
+                "(raw=${webViewCompatibility?.majorVersion} src=${webViewCompatibility?.source}) " +
+                "rectBottom=${rect.bottom} webViewTop=${webViewLocationOnScreen[1]} " +
+                "webViewHeight=${webView.height} paramsHeight=${webView.layoutParams?.height}"
+        )
+    }
 
     /**
      * Soft-keyboard fallback for the add-task bar sitting behind the keyboard

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -26,6 +26,7 @@ import com.superproductivity.superproductivity.service.SyncReminderScheduler
 import com.superproductivity.superproductivity.service.TrackingForegroundService
 import com.superproductivity.superproductivity.util.printWebViewVersion
 import com.superproductivity.superproductivity.webview.JavaScriptInterface
+import com.superproductivity.superproductivity.webview.NativeInsetShimGate
 import com.superproductivity.superproductivity.webview.WebHelper
 import com.superproductivity.superproductivity.webview.WebViewBlockActivity
 import com.superproductivity.superproductivity.webview.WebViewCompatibilityChecker
@@ -48,18 +49,18 @@ class CapacitorMainActivity : BridgeActivity() {
     private var isFrontendReady = false
     private var startupOverlayManager: StartupOverlayManager? = null
 
-    // SDK < 30 soft-keyboard workaround: the WebView's resting layout height
+    // Soft-keyboard workaround: the WebView's resting layout height
     // (e.g. MATCH_PARENT), captured so it can be restored when the keyboard hides.
-    // See adjustWebViewHeightForKeyboardBelowApi30.
+    // See adjustWebViewHeightForKeyboard.
     private var webViewLayoutHeightDefault: Int? = null
 
     // Reused scratch for getLocationOnScreen in the keyboard layout listener (hot
     // path) to avoid allocating an IntArray on every pass while the IME is up.
     private val webViewLocationOnScreen = IntArray(2)
 
-    // SDK < 30 status-bar overlap workaround: last value pushed to JS, to dedupe
-    // the per-layout-pass listener. -1 = nothing pushed yet.
-    // See pushStatusBarOverlapBelowApi30.
+    // Status-bar overlap workaround: last value pushed to JS, to dedupe the
+    // per-layout-pass listener. -1 = nothing pushed yet.
+    // See pushStatusBarOverlap.
     private var lastStatusBarOverlapCssPx: Int = -1
 
     private var isTimerCompleteReceiverRegistered = false
@@ -204,8 +205,8 @@ class CapacitorMainActivity : BridgeActivity() {
 
 
         // Remember the WebView's resting layout height (e.g. MATCH_PARENT) so the
-        // SDK < 30 keyboard workaround can restore it on hide. See
-        // adjustWebViewHeightForKeyboardBelowApi30.
+        // keyboard workaround can restore it on hide. See
+        // adjustWebViewHeightForKeyboard.
         webViewLayoutHeightDefault = bridge?.webView?.layoutParams?.height
 
         // Handle keyboard visibility changes
@@ -222,8 +223,8 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
-            adjustWebViewHeightForKeyboardBelowApi30(rect, isKeyboardOpen)
-            pushStatusBarOverlapBelowApi30(rect)
+            adjustWebViewHeightForKeyboard(rect, isKeyboardOpen)
+            pushStatusBarOverlap(rect)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -348,8 +349,8 @@ class CapacitorMainActivity : BridgeActivity() {
         // re-enters here, but it also wipes the inline --android-status-bar-overlap
         // off the fresh document. Re-arm the dedupe so the next layout pass
         // re-publishes it; otherwise the unchanged value is skipped and the
-        // header overlaps the status bar again on the WebView < 140 / API < 30
-        // tail. See pushStatusBarOverlapBelowApi30.
+        // header overlaps the status bar again on the WebView < 140 / API < 35
+        // tail. See pushStatusBarOverlap.
         lastStatusBarOverlapCssPx = -1
         pendingShareIntent?.let {
             Log.d("SP_SHARE", "Flushing pending share intent: $it")
@@ -484,17 +485,27 @@ class CapacitorMainActivity : BridgeActivity() {
     }
 
     /**
-     * SDK < 30 soft-keyboard fallback for the add-task bar sitting behind the
-     * keyboard (#8508 follow-up, Android 9 / API 28).
+     * Whether Capacitor's SystemBars leaves the insets unowned on this device, so
+     * our native shims below have to step in. See [NativeInsetShimGate].
+     */
+    private fun shouldRunNativeInsetShim(): Boolean =
+        NativeInsetShimGate.shouldRunShim(
+            sdkInt = android.os.Build.VERSION.SDK_INT,
+            webViewMajor = webViewCompatibility?.majorVersion,
+        )
+
+    /**
+     * Soft-keyboard fallback for the add-task bar sitting behind the keyboard
+     * (#8508 follow-up on Android 9 / API 28; #9316 on API 34 + WebView 124/126).
      *
      * Context: Android edge-to-edge inset handling is owned by Capacitor's
      * built-in SystemBars now (the `@capawesome` edge-to-edge plugin was removed).
      * SystemBars only pads the WebView for the IME on **WebView >= 140**
-     * (passthrough) or **API >= 35**; below that band it is a no-op, and under
-     * enforced edge-to-edge the window does NOT resize for the IME on API < 30,
-     * so the `position: fixed` add-task bar sits behind the keyboard. This shim
-     * covers exactly that WebView < 140 / API < 30 tail and is **gated to
-     * WebView < 140** so it never double-counts against SystemBars' own padding.
+     * (passthrough) or **API >= 35**; outside that it applies nothing, the window
+     * does NOT resize for the IME, and the `position: fixed` add-task bar sits
+     * behind the keyboard. This shim covers exactly that gap — see
+     * [NativeInsetShimGate] for why the gate is the complement of SystemBars'
+     * two ownership branches, so the two never double-count.
      *
      * We must NOT correct this via `bottomMargin` or `padding` (a margin writer
      * fights whatever owns the insets, and WebView padding does not move the web
@@ -504,20 +515,19 @@ class CapacitorMainActivity : BridgeActivity() {
      * the view shrinks the web layout viewport, so the existing CSS resolves the
      * bar above the keyboard with no web-side keyboard-height math (avoiding the
      * reverted #8295 fallback). The target (`rect.bottom − webViewTop`) is read
-     * from `getWindowVisibleDisplayFrame` (reliable on API 28) and does not
-     * depend on the WebView's own height, so it is stable across passes — no
-     * feedback loop. See docs/android-edge-to-edge-keyboard.md and
-     * docs/plans/2026-06-22-android-systembars-migration-corrected.md.
+     * from `getWindowVisibleDisplayFrame` and does not depend on the WebView's
+     * own height, so it is stable across passes — no feedback loop.
      *
-     * API >= 30 and WebView >= 140 are strict no-ops.
+     * That absolute target is also what makes this **resize-detecting**, the
+     * hard requirement #8508 left behind: on a device where the window already
+     * shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
+     * computed height equals the current one and nothing moves. It cannot
+     * re-create the squashed-WebView regression the way the reverted delta-based
+     * inset did. See docs/android-edge-to-edge-keyboard.md and
+     * docs/plans/2026-06-22-android-systembars-migration-corrected.md.
      */
-    private fun adjustWebViewHeightForKeyboardBelowApi30(rect: Rect, isKeyboardOpen: Boolean) {
-        if (android.os.Build.VERSION.SDK_INT >= 30) return
-        // Skip when SystemBars already handles the IME inset (WebView >= 140
-        // passthrough pads the WebView parent itself). Unknown version (null) ->
-        // run the shim, the safe default on API < 30.
-        val wvMajor = webViewCompatibility?.majorVersion
-        if (wvMajor != null && wvMajor >= 140) return
+    private fun adjustWebViewHeightForKeyboard(rect: Rect, isKeyboardOpen: Boolean) {
+        if (!shouldRunNativeInsetShim()) return
         val webView = bridge?.webView ?: return
         val params = webView.layoutParams ?: return
         // Ignore stale/pre-layout geometry so the height is not set from a bad frame.
@@ -549,7 +559,8 @@ class CapacitorMainActivity : BridgeActivity() {
 
     /**
      * Status-bar overlap workaround for the web header drawing BEHIND the status
-     * bar on the WebView < 140 tail (#8508 / #8283 follow-up, Android 9 / API 28).
+     * bar on the WebView < 140 tail (#8508 / #8283 follow-up, Android 9 / API 28;
+     * reads 0 and self-disables where the WebView is already inset).
      *
      * Edge-to-edge insets are owned by Capacitor's built-in SystemBars now. On
      * **API >= 35** it injects the real `--safe-area-inset-*` px, and on
@@ -571,19 +582,12 @@ class CapacitorMainActivity : BridgeActivity() {
      * once it is — `max()` never double-counts. Physical px → CSS px via display
      * density; deduped so the per-layout listener does not spam evaluateJavascript.
      *
-     * Gated to **SDK < 30 AND WebView < 140** (mirrors
-     * adjustWebViewHeightForKeyboardBelowApi30) so it never fights SystemBars; on
-     * API >= 35 the injected --safe-area-inset-top wins via var() precedence and
-     * the published var is ignored regardless. (Known small gap: an API 30–34
-     * device on an old WebView < 140 also has env()==0; rare, since WebView
-     * auto-updates above API 30 — broaden the gate if it ever surfaces.)
+     * Shares [NativeInsetShimGate] with the keyboard shim so it never fights
+     * SystemBars; on API >= 35 the injected --safe-area-inset-top wins via var()
+     * precedence and the published var is ignored regardless.
      */
-    private fun pushStatusBarOverlapBelowApi30(rect: Rect) {
-        if (android.os.Build.VERSION.SDK_INT >= 30) return
-        // Skip when SystemBars/env() already give the correct top inset (WebView
-        // >= 140 passthrough). Unknown version (null) -> run it, the safe default.
-        val wvMajor = webViewCompatibility?.majorVersion
-        if (wvMajor != null && wvMajor >= 140) return
+    private fun pushStatusBarOverlap(rect: Rect) {
+        if (!shouldRunNativeInsetShim()) return
         if (!::javaScriptInterface.isInitialized) return
         val webView = bridge?.webView ?: return
         webView.getLocationOnScreen(webViewLocationOnScreen)

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/ImeWebViewHeight.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/ImeWebViewHeight.kt
@@ -1,0 +1,28 @@
+package com.superproductivity.superproductivity.webview
+
+/**
+ * The WebView layout height that keeps the web content above the soft keyboard,
+ * for `CapacitorMainActivity.adjustWebViewHeightForKeyboard`.
+ *
+ * Split out from the activity for one reason: this arithmetic *is* the argument
+ * that widening [NativeInsetShimGate] cannot re-create #8508, and that argument
+ * deserves a test rather than a comment. The target is **absolute** — the visible
+ * frame's bottom minus where the WebView starts — never a delta applied to the
+ * current height. So on a device whose window already shrank for the IME, the
+ * WebView bottom is already at `rectBottom` and this returns the height already
+ * in effect: the caller compares, sees no change, and writes nothing. A
+ * delta-based inset is what squashed the WebView in #8508; do not reintroduce
+ * one here.
+ */
+object ImeWebViewHeight {
+    /**
+     * @param rectBottom bottom of `getWindowVisibleDisplayFrame` — the keyboard's
+     *   top edge while the IME is up, in physical px.
+     * @param webViewTop the WebView's top on screen (`getLocationOnScreen`).
+     * @return the height to apply, or `null` for a degenerate/transient frame
+     *   that would collapse the WebView — the caller must then leave the current
+     *   height alone rather than latch a bad value.
+     */
+    fun targetHeight(rectBottom: Int, webViewTop: Int): Int? =
+        (rectBottom - webViewTop).takeIf { it > 0 }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
@@ -16,6 +16,14 @@ package com.superproductivity.superproductivity.webview
  * are nobody's job. That intersection is what this gate names, so the shims run
  * exactly where `SystemBars` is absent and are a strict no-op everywhere it acts.
  *
+ * Why nothing else catches it: the app runs the WebView under
+ * `SYSTEM_UI_FLAG_LAYOUT_STABLE or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` (Capacitor's
+ * StatusBar plugin, `overlaysWebView: true` in `capacitor.config.ts`), and under
+ * layout-fullscreen the manifest's `adjustResize` does **not** shrink the window
+ * for the IME. So on API < 35 the framework never resizes anything either — which
+ * is why this is a WebView-version problem, not the SDK-version problem the
+ * original gate assumed.
+ *
  * Widened from the original `SDK_INT < 30` gate for #9316: two users on **API 34
  * with WebView 124 / 126** had the add-task bar sit behind the keyboard, and one
  * of them confirmed the fix by side-loading WebView 151 with no app change. The
@@ -23,9 +31,11 @@ package com.superproductivity.superproductivity.webview
  * false on a custom ROM that ships its own `com.android.webview` and disables the
  * Play-updated Google package.
  *
- * @param webViewMajor the **active** provider's major version
- *   (`WebView.getCurrentWebViewPackage()`, the same source `SystemBars` reads), or
- *   `null` when it could not be read.
+ * **Not quite the exact complement:** branch 1 also requires `viewport-fit=cover`,
+ * which `SystemBars` only learns at `onDOMReady`. `src/index.html` sets it (keep it
+ * there — dropping it strands WebView >= 140 / API < 35 devices with no inset
+ * owner), so the only residual gap is the window before the first DOM ready, where
+ * the IME cannot be up yet.
  */
 object NativeInsetShimGate {
     /** `SystemBars` passthrough threshold — `WEBVIEW_VERSION_WITH_SAFE_AREA_FIX`. */
@@ -33,6 +43,33 @@ object NativeInsetShimGate {
 
     /** `SystemBars` pads the WebView for the IME unconditionally from Android 15. */
     const val SDK_WITH_SYSTEM_BARS_IME_PADDING = 35
+
+    /**
+     * The version to gate on: the **active** provider's major version, or `null`
+     * when we do not know what is actually rendering.
+     *
+     * `SystemBars` reads only `WebView.getCurrentWebViewPackage()` and treats a
+     * failed read as `0`, so the gate must agree with *that* or the two can
+     * disagree about who owns the insets. [WebViewCompatibilityChecker] answers a
+     * different question (may we block the app?) and therefore falls back to
+     * scanning installed packages — which on a custom ROM can report an
+     * installed-but-**disabled** provider. That is exactly the #9316 layout, where
+     * the scan finds `com.google.android.webview` 150 while the active provider is
+     * `com.android.webview` 124: feeding the gate 150 would switch the shim off on
+     * the one device it exists for, with `SystemBars` (seeing 0) off as well.
+     *
+     * So only an authoritative reading counts — `getCurrentWebViewPackage()`
+     * ([WebViewCompatibilityChecker.Result.providerPackageIsCurrent]) or the
+     * user-agent string, both of which describe the provider actually in use.
+     * Anything else degrades to `null`, which runs the shim.
+     */
+    fun activeProviderMajor(result: WebViewCompatibilityChecker.Result?): Int? =
+        result
+            ?.takeIf {
+                it.providerPackageIsCurrent ||
+                    it.source == WebViewCompatibilityChecker.VersionSource.USER_AGENT
+            }
+            ?.majorVersion
 
     fun shouldRunShim(sdkInt: Int, webViewMajor: Int?): Boolean {
         if (sdkInt >= SDK_WITH_SYSTEM_BARS_IME_PADDING) return false

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
@@ -1,0 +1,45 @@
+package com.superproductivity.superproductivity.webview
+
+/**
+ * Decides whether our native inset shims in `CapacitorMainActivity` must run, or
+ * whether Capacitor's built-in `SystemBars` already owns the insets.
+ *
+ * `SystemBars` installs an `OnApplyWindowInsetsListener` on the WebView's parent
+ * (the activity content root) on **every** API level, so it — not the framework —
+ * is the inset owner. But it only ever applies IME padding / real safe-area px on
+ * two paths (`SystemBars.initWindowInsetsListener`):
+ *
+ * 1. the passthrough branch, gated `webViewMajor >= 140 && viewport-fit=cover`
+ * 2. an `SDK_INT >= 35` branch
+ *
+ * Outside those two, it applies nothing at all — the keyboard and the status bar
+ * are nobody's job. That intersection is what this gate names, so the shims run
+ * exactly where `SystemBars` is absent and are a strict no-op everywhere it acts.
+ *
+ * Widened from the original `SDK_INT < 30` gate for #9316: two users on **API 34
+ * with WebView 124 / 126** had the add-task bar sit behind the keyboard, and one
+ * of them confirmed the fix by side-loading WebView 151 with no app change. The
+ * old gate assumed API >= 30 implies a current WebView because it auto-updates —
+ * false on a custom ROM that ships its own `com.android.webview` and disables the
+ * Play-updated Google package.
+ *
+ * @param webViewMajor the **active** provider's major version
+ *   (`WebView.getCurrentWebViewPackage()`, the same source `SystemBars` reads), or
+ *   `null` when it could not be read.
+ */
+object NativeInsetShimGate {
+    /** `SystemBars` passthrough threshold — `WEBVIEW_VERSION_WITH_SAFE_AREA_FIX`. */
+    const val WEBVIEW_VERSION_WITH_INSET_SUPPORT = 140
+
+    /** `SystemBars` pads the WebView for the IME unconditionally from Android 15. */
+    const val SDK_WITH_SYSTEM_BARS_IME_PADDING = 35
+
+    fun shouldRunShim(sdkInt: Int, webViewMajor: Int?): Boolean {
+        if (sdkInt >= SDK_WITH_SYSTEM_BARS_IME_PADDING) return false
+        // Unknown version -> run the shim. SystemBars reads the same provider and
+        // treats an unreadable version as 0, so it skips its passthrough branch
+        // too; leaving both off would strand the device with no inset owner.
+        if (webViewMajor == null) return true
+        return webViewMajor < WEBVIEW_VERSION_WITH_INSET_SUPPORT
+    }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/ImeWebViewHeightTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/ImeWebViewHeightTest.kt
@@ -1,0 +1,53 @@
+package com.superproductivity.superproductivity.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ImeWebViewHeightTest {
+
+    @Test
+    fun `computes the height already in effect where the window resized itself`() {
+        // The #8508 invariant, and the reason widening the gate is safe: on a
+        // device that already shrank for the IME the WebView bottom is at
+        // rectBottom, so the target equals the current height. The caller's
+        // `params.height == targetHeight` check then writes nothing — no second
+        // inset stacked on the system's own, which is what squashed the WebView
+        // in #8508. A delta-based target would fail this test.
+        val webViewTop = 100
+        val rectBottom = 1800
+        val currentHeight = rectBottom - webViewTop
+
+        assertEquals(
+            currentHeight,
+            ImeWebViewHeight.targetHeight(rectBottom = rectBottom, webViewTop = webViewTop)
+        )
+    }
+
+    @Test
+    fun `shrinks to the keyboard top where the window did not resize`() {
+        // #9316: window stays full height (layout-fullscreen suppresses
+        // adjustResize), the visible frame stops at the keyboard, so the WebView
+        // must be pinned to that.
+        assertEquals(1100, ImeWebViewHeight.targetHeight(rectBottom = 1200, webViewTop = 100))
+    }
+
+    @Test
+    fun `stays idempotent when applied repeatedly`() {
+        // The listener fires on every layout pass; feeding the result back must
+        // not drift, or the shim would walk the WebView shut over a few passes.
+        val first = ImeWebViewHeight.targetHeight(rectBottom = 1200, webViewTop = 100)
+        val second = ImeWebViewHeight.targetHeight(rectBottom = 1200, webViewTop = 100)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `refuses a degenerate frame instead of collapsing the WebView`() {
+        // Transient/pre-layout geometry. Returning 0 or a negative height would
+        // latch (the caller stops recomputing once the WebView measures 0), so
+        // the current height must be kept instead.
+        assertNull(ImeWebViewHeight.targetHeight(rectBottom = 100, webViewTop = 100))
+        assertNull(ImeWebViewHeight.targetHeight(rectBottom = 50, webViewTop = 100))
+        assertNull(ImeWebViewHeight.targetHeight(rectBottom = 0, webViewTop = 0))
+    }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
@@ -1,6 +1,8 @@
 package com.superproductivity.superproductivity.webview
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -45,4 +47,75 @@ class NativeInsetShimGateTest {
         assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = null))
         assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = null))
     }
+
+    @Test
+    fun `ignores a version scanned from an installed-but-disabled provider`() {
+        // The crDroid layout in #9316: getCurrentWebViewPackage() failed, so the
+        // checker's PackageManager scan reported the *disabled* Google package
+        // (150) while the active provider is com.android.webview 124. SystemBars
+        // reads 0 there and does nothing, so trusting 150 would leave the device
+        // with no inset owner — the exact bug. Degrade to null and run the shim.
+        val scanned = result(
+            majorVersion = 150,
+            source = WebViewCompatibilityChecker.VersionSource.PACKAGE,
+            providerPackageIsCurrent = false,
+        )
+        assertNull(NativeInsetShimGate.activeProviderMajor(scanned))
+        assertTrue(
+            NativeInsetShimGate.shouldRunShim(
+                sdkInt = 34,
+                webViewMajor = NativeInsetShimGate.activeProviderMajor(scanned),
+            )
+        )
+    }
+
+    @Test
+    fun `trusts versions that describe the provider actually in use`() {
+        // getCurrentWebViewPackage() and the user-agent string both describe the
+        // active provider, which is what SystemBars branches on.
+        assertEquals(
+            124,
+            NativeInsetShimGate.activeProviderMajor(
+                result(
+                    majorVersion = 124,
+                    source = WebViewCompatibilityChecker.VersionSource.PACKAGE,
+                    providerPackageIsCurrent = true,
+                )
+            )
+        )
+        assertEquals(
+            126,
+            NativeInsetShimGate.activeProviderMajor(
+                result(
+                    majorVersion = 126,
+                    source = WebViewCompatibilityChecker.VersionSource.USER_AGENT,
+                    providerPackageIsCurrent = false,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `runs when the compatibility check produced no result at all`() {
+        assertNull(NativeInsetShimGate.activeProviderMajor(null))
+        assertTrue(
+            NativeInsetShimGate.shouldRunShim(
+                sdkInt = 34,
+                webViewMajor = NativeInsetShimGate.activeProviderMajor(null),
+            )
+        )
+    }
+
+    private fun result(
+        majorVersion: Int?,
+        source: WebViewCompatibilityChecker.VersionSource,
+        providerPackageIsCurrent: Boolean,
+    ) = WebViewCompatibilityChecker.Result(
+        status = WebViewCompatibilityChecker.Status.OK,
+        majorVersion = majorVersion,
+        providerPackage = null,
+        providerVersionName = null,
+        source = source,
+        providerPackageIsCurrent = providerPackageIsCurrent,
+    )
 }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
@@ -1,0 +1,48 @@
+package com.superproductivity.superproductivity.webview
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeInsetShimGateTest {
+
+    @Test
+    fun `runs on the API 34 old-WebView gap reported in 9316`() {
+        // OnePlus 7T Pro / crDroid (Android 14) with the ROM's own
+        // com.android.webview 124, and a bigme HiBreak Pro on WebView 126.
+        // SystemBars pads for neither (< 140 and < API 35), so the add-task bar
+        // sat behind the keyboard. This is the regression this gate fixes.
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = 124))
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = 126))
+    }
+
+    @Test
+    fun `still runs on the API 28 case it was originally written for`() {
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = 100))
+    }
+
+    @Test
+    fun `off once SystemBars passthrough owns the insets`() {
+        // WebView >= 140 pads the WebView parent itself; running as well would
+        // double-count and re-create the squashed WebView of #8508.
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = 140))
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = 151))
+    }
+
+    @Test
+    fun `off from API 35 regardless of WebView version`() {
+        // SystemBars' unconditional SDK >= 35 branch owns the IME padding there,
+        // so the shim must stay a strict no-op even on an ancient WebView.
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 35, webViewMajor = 124))
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 36, webViewMajor = null))
+    }
+
+    @Test
+    fun `runs when the WebView version cannot be read below API 35`() {
+        // SystemBars reads the same provider and treats an unreadable version as
+        // 0, so it skips its passthrough branch too. Both off would strand the
+        // device with no inset owner at all.
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = null))
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = null))
+    }
+}

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -8,8 +8,8 @@ area has regressed repeatedly (#8295, then #8508).**
 > Capacitor's built-in `SystemBars`** (`insetsHandling: 'css'`). Edge-to-edge
 > insets + IME padding are now handled by SystemBars on **WebView ≥ 140** (or
 > API ≥ 35); the **WebView < 140 / API < 35** tail is covered by env() + a native
-> keyboard shim (`adjustWebViewHeightForKeyboardBelowApi30`, now gated to
-> WebView < 140 so it never fights SystemBars). Bar backgrounds are no longer
+> keyboard shim (`adjustWebViewHeightForKeyboard`, gated by `NativeInsetShimGate`
+> to exactly that tail so it never fights SystemBars). Bar backgrounds are no longer
 > painted by a plugin (SystemBars has no color API) — the bars are transparent
 > and the theme color shows through via `NavigationBarPlugin.setWebViewBackgroundColor`
 > (window decor + WebView surface). The #8508 sections below describe the _former_
@@ -121,7 +121,7 @@ bar sits just above the keyboard (no behind-keyboard regression).**
 
 ## #8508 follow-up — SDK 28 (Android 9): add-task bar sits BEHIND the keyboard
 
-**Status: fix implemented (`CapacitorMainActivity.adjustWebViewForKeyboardBelowApi30`),
+**Status: fix implemented (`CapacitorMainActivity.adjustWebViewHeightForKeyboard`),
 PENDING ON-DEVICE VALIDATION across the matrix below.** After 18.12.0 (patch
 removed) a user on **Android 9 / API 28** reports the global add-task bar sits
 _below / behind_ the soft keyboard. This is the realization of open item #4
@@ -160,7 +160,7 @@ resize, that double-counts and floats the bar mid-screen. The web layer lacks
 the signal to disambiguate; native has it unambiguously.
 
 **Implemented fix (native, explicit WebView height while the IME is up, scoped to
-API < 30) — `CapacitorMainActivity.adjustWebViewHeightForKeyboardBelowApi30`.**
+API < 30) — `CapacitorMainActivity.adjustWebViewHeightForKeyboard`.**
 Driven from the existing keyboard `OnGlobalLayoutListener`:
 
 - while the keyboard is up: set an explicit WebView **layout height** to the
@@ -271,7 +271,7 @@ an iOS bottom gap appears, drop the term there too.
 
 ## #8508 follow-up — SDK 28 (Android 9): header draws BEHIND the status bar
 
-**Status: fix implemented (`CapacitorMainActivity.pushStatusBarOverlapBelowApi30`),
+**Status: fix implemented (`CapacitorMainActivity.pushStatusBarOverlap`),
 PENDING ON-DEVICE VALIDATION.** Separate from the keyboard — on API 28 the web
 header overlaps the **status bar** (no top gap), reported on #8508.
 
@@ -290,7 +290,7 @@ edge-to-edge under the status bar" from "WebView is already inset below it" —
 `env()` is 0 in both, and adding the status-bar height blindly would double-count
 in the inset case. Native has the geometry.
 
-**Fix (native overlap → SCSS fallback) — `pushStatusBarOverlapBelowApi30`.** From
+**Fix (native overlap → SCSS fallback) — `pushStatusBarOverlap`.** From
 the existing keyboard `OnGlobalLayoutListener`, measure the overlap
 `max(0, rect.top − webViewTopOnScreen)` — `rect.top` is the visible-frame top
 (= status-bar height, reliable on API 28; the same frame the keyboard path reads)
@@ -316,15 +316,67 @@ SystemBars on `--safe-area-inset-*`:
 - JS readers (`_patchCdkViewportForSafeArea`) still parse the `var(max(...))`
   token to 0, so overlay positioning is unchanged — preserving #8283 scoping
   (only the header padding is affected).
-- Known small gap: an **API 30–34** device on an **old WebView < 140** also has
+- ~~Known small gap: an **API 30–34** device on an **old WebView < 140** also has
   env()==0 but is excluded by the SDK < 30 gate; rare (WebView auto-updates above
-  API 30) — broaden the gate to WebView-only if it ever surfaces.
+  API 30) — broaden the gate to WebView-only if it ever surfaces.~~ **It surfaced
+  (#9316); the gate was broadened — see the section below.**
 - The var lives only as an inline style on the document, so a web-side reload
   (`window.location.reload()` — language change, PWA update, sync-conflict
   recovery) wipes it. The native dedupe (`lastStatusBarOverlapCssPx`) is reset in
   `flushPendingShareIntent()` (runs on every frontend (re)load) so the next layout
   pass re-publishes it; without the reset the unchanged value would be skipped and
   the overlap would regress after a reload.
+
+## #9316 — API 34 + old WebView: add-task bar behind the keyboard
+
+**Status: gate widened (`NativeInsetShimGate`), PENDING ON-DEVICE VALIDATION by
+the reporters.** Two users on **Android 14 (API 34)** report the add-task bar (and
+the task-detail notes field) sitting behind the keyboard. This is the "known small
+gap" above, realized.
+
+**Root cause — nobody owns the IME inset.** `SystemBars` installs its
+`OnApplyWindowInsetsListener` on the WebView's parent (the activity content root,
+`capacitor_bridge_layout_main.xml`) on **every** API level, so it — not the
+framework — is the inset owner. But it only applies IME padding on two paths
+(`SystemBars.initWindowInsetsListener`): the passthrough branch, gated
+`webViewMajor >= 140 && viewport-fit=cover`, and an `SDK_INT >= 35` branch. On
+**API < 35 AND WebView < 140** it applies nothing at all — and our shims were
+gated `SDK_INT < 30`, so they did not step in either. Nothing shrinks →
+`obscured = innerHeight − visualViewport.height` is 0 → `--keyboard-height: 0` →
+the `position: fixed` bar stays at the bottom of a viewport that extends behind
+the IME. The reporters' before/after screenshots are pixel-identical, which is
+exactly this signature.
+
+**Why the old gate's assumption failed.** `SDK_INT < 30` encoded "API >= 30
+implies a current WebView, because it auto-updates." Not on a custom ROM:
+crDroid ships its own `com.android.webview` (124) and the Play-updated
+`com.google.android.webview` (150) is *installed but disabled*. Settings shows
+150; `dumpsys webviewupdate` shows the **active** provider is 124. Always read
+the `Current WebView package` line, never the Settings screen.
+
+**Evidence.** Two independent reporters at API 34 / WebView 124 and 126. One of
+them side-loaded WebView 151 with no app change and the bug disappeared — a clean
+A/B isolating the WebView version, and a direct confirmation of the 140 boundary.
+
+**Fix — `NativeInsetShimGate.shouldRunShim(sdkInt, webViewMajor)`**, now shared by
+`adjustWebViewHeightForKeyboard` and `pushStatusBarOverlap` (both lost their
+`BelowApi30` suffix — the gate is no longer SDK 30). It is the exact complement of
+SystemBars' two ownership branches: run iff `sdkInt < 35 && (webViewMajor == null
+|| webViewMajor < 140)`. An unreadable version runs the shim, because SystemBars
+treats an unreadable version as `0` and skips its passthrough too — both off would
+strand the device with no inset owner. Unit-covered in `NativeInsetShimGateTest`.
+
+**Why this does not re-arm #8508.** The rule from that saga is that any inset must
+be *resize-detecting*. This shim already is, structurally: it sets the WebView's
+layout height to an **absolute** target read from the visible frame
+(`rect.bottom − webViewTop`), not a delta. On a device where the window already
+shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
+computed height equals the current one and nothing moves. That property is what
+makes broadening the gate safe; do not replace it with a delta-based inset.
+
+**Still REQUIRED before release:** the widened band (API 30–34) is not covered by
+any device on hand — validate via a test build with the #9316 reporters, plus the
+matrix below to confirm API >= 35 and WebView >= 140 are untouched.
 
 ## What NOT to do
 
@@ -346,6 +398,14 @@ typing a word fast right after tapping +, on:
 - Android 15 (API 35) — we opt out via `windowOptOutEdgeToEdgeEnforcement`
 - Android 16 (API 36) — our target; the system was observed to still resize for
   the IME on a real device
+
+**The WebView version is a second axis, not a detail (#9316).** SystemBars
+branches on it at 140, so an API 30–34 device on WebView < 140 behaves nothing
+like the same device on WebView >= 140 — that combination is what #9316 was, and
+it is the one the SDK-only matrix missed. Read the active provider with
+`adb shell dumpsys webviewupdate` (the `Current WebView package` line) — **not**
+the Settings screen, which can show an installed-but-disabled package. Custom
+ROMs are the realistic source of an old WebView above API 30.
 
 Both gesture-nav and 3-button-nav, light and dark. Confirm: no blank gap above
 the keyboard, bar visible just above the keyboard, and typed characters appear in

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -347,10 +347,21 @@ the `position: fixed` bar stays at the bottom of a viewport that extends behind
 the IME. The reporters' before/after screenshots are pixel-identical, which is
 exactly this signature.
 
+**Why `adjustResize` does not save us.** The manifest declares
+`windowSoftInputMode="adjustResize"`, so the obvious question is why the window
+does not simply shrink. Because Capacitor's StatusBar plugin runs with
+`overlaysWebView: true` (`capacitor.config.ts`), which applies
+`SYSTEM_UI_FLAG_LAYOUT_STABLE or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` to the decor
+view (`StatusBar.setOverlaysWebView`) — and under layout-fullscreen `adjustResize`
+stops resizing for the IME. That is the long-standing Android behaviour the
+`getWindowVisibleDisplayFrame` + explicit-height workaround exists for, and it is
+SDK-independent below 35, which is why the symptom never depended on the API
+level the original gate keyed off.
+
 **Why the old gate's assumption failed.** `SDK_INT < 30` encoded "API >= 30
 implies a current WebView, because it auto-updates." Not on a custom ROM:
 crDroid ships its own `com.android.webview` (124) and the Play-updated
-`com.google.android.webview` (150) is *installed but disabled*. Settings shows
+`com.google.android.webview` (150) is _installed but disabled_. Settings shows
 150; `dumpsys webviewupdate` shows the **active** provider is 124. Always read
 the `Current WebView package` line, never the Settings screen.
 
@@ -360,14 +371,29 @@ A/B isolating the WebView version, and a direct confirmation of the 140 boundary
 
 **Fix — `NativeInsetShimGate.shouldRunShim(sdkInt, webViewMajor)`**, now shared by
 `adjustWebViewHeightForKeyboard` and `pushStatusBarOverlap` (both lost their
-`BelowApi30` suffix — the gate is no longer SDK 30). It is the exact complement of
+`BelowApi30` suffix — the gate is no longer SDK 30). It is the complement of
 SystemBars' two ownership branches: run iff `sdkInt < 35 && (webViewMajor == null
 || webViewMajor < 140)`. An unreadable version runs the shim, because SystemBars
 treats an unreadable version as `0` and skips its passthrough too — both off would
 strand the device with no inset owner. Unit-covered in `NativeInsetShimGateTest`.
 
+Two caveats on "complement":
+
+- Branch 1 additionally requires **`viewport-fit=cover`**, which SystemBars only
+  learns at `onDOMReady`. `src/index.html` sets it (there is a comment there
+  saying so — keep it), leaving only the pre-DOM-ready window uncovered, where the
+  IME cannot be up yet.
+- The gate must read the **active** provider, the same thing SystemBars reads
+  (`WebView.getCurrentWebViewPackage()`, failure treated as `0`).
+  `WebViewCompatibilityChecker` answers a different question and can fall back to
+  scanning installed packages, which on the crDroid layout above reports the
+  disabled 150 rather than the active 124 — that number would switch the shim off
+  on exactly the devices it is for. `NativeInsetShimGate.activeProviderMajor()`
+  therefore accepts only `getCurrentWebViewPackage()` or user-agent readings and
+  degrades anything else to `null` (→ run the shim).
+
 **Why this does not re-arm #8508.** The rule from that saga is that any inset must
-be *resize-detecting*. This shim already is, structurally: it sets the WebView's
+be _resize-detecting_. This shim already is, structurally: it sets the WebView's
 layout height to an **absolute** target read from the visible frame
 (`rect.bottom − webViewTop`), not a delta. On a device where the window already
 shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
@@ -377,6 +403,24 @@ makes broadening the gate safe; do not replace it with a delta-based inset.
 **Still REQUIRED before release:** the widened band (API 30–34) is not covered by
 any device on hand — validate via a test build with the #9316 reporters, plus the
 matrix below to confirm API >= 35 and WebView >= 140 are untouched.
+
+**Validate the mechanism, not just the symptom.** The shim is a strict no-op
+wherever the window already resizes, so "the bar looks fixed" cannot distinguish a
+working shim from one that never ran — and a coincidental fix would send the next
+regression hunt down the wrong path. `logImeGeometryOnTransition` prints the gate
+inputs and geometry once per keyboard transition; it is off unless enabled, so ask
+the reporter for:
+
+```
+adb shell setprop log.tag.SUPKeyboard DEBUG   # then restart the app
+adb logcat -s SUPKeyboard
+adb shell dumpsys webviewupdate | grep -i 'Current WebView package'
+```
+
+A fixed device must show `shim=true` with `paramsHeight` dropping to roughly
+`rectBottom − webViewTop` while `ime=true`, and the provider version from
+`dumpsys` must match the `wvMajor=` the gate read. If `shim=false`, the version
+source is wrong, not the theory.
 
 ## What NOT to do
 

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -347,7 +347,11 @@ the `position: fixed` bar stays at the bottom of a viewport that extends behind
 the IME. The reporters' before/after screenshots are pixel-identical, which is
 exactly this signature.
 
-**Why `adjustResize` does not save us.** The manifest declares
+**Why `adjustResize` does not save us — INFERRED, not yet observed.** This is
+read off the sources below, not measured on a device in the affected band; treat
+it as the working explanation and confirm it before building on it (an API 30–34
+emulator settles it — the window configuration does not depend on the WebView
+version, so any device in the band answers the question). The manifest declares
 `windowSoftInputMode="adjustResize"`, so the obvious question is why the window
 does not simply shrink. Because Capacitor's StatusBar plugin runs with
 `overlaysWebView: true` (`capacitor.config.ts`), which applies
@@ -417,10 +421,19 @@ adb logcat -s SUPKeyboard
 adb shell dumpsys webviewupdate | grep -i 'Current WebView package'
 ```
 
-A fixed device must show `shim=true` with `paramsHeight` dropping to roughly
-`rectBottom − webViewTop` while `ime=true`, and the provider version from
-`dumpsys` must match the `wvMajor=` the gate read. If `shim=false`, the version
-source is wrong, not the theory.
+The line is printed **after** the shim's pass, so on a fixed device the
+`ime=true` line reads `shim=true` with `paramsHeight` equal to `target` (both
+`rectBottom − webViewTop`). Cases to distinguish:
+
+- `shim=false` → the gate is off: compare `wvMajor=` against the `dumpsys`
+  provider. The version source is wrong, not the theory.
+- `target` set but `paramsHeight` unchanged → the shim ran and bailed on a
+  degenerate frame, or the height was already correct (the device resized itself,
+  in which case the shim is a legitimate no-op — see `ImeWebViewHeight`).
+- no line at all → the listener never saw a transition; check the tag is enabled
+  and the app was restarted after `setprop`.
+
+`webViewHeight` lags by one layout pass — that is expected, not a failure.
 
 ## What NOT to do
 

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,12 @@
       the same way it does natively. Ignored where it doesn't apply: native
       WebViews (keyboard handled natively), iOS Safari (unsupported → falls back
       to the JS `--keyboard-height` visualViewport tracking), and desktop.
+
+      viewport-fit=cover is load-bearing on Android beyond the notch: Capacitor's
+      SystemBars only passes real insets through when it reads it back from this
+      tag (WebView >= 140). Dropping it strands WebView >= 140 / API < 35 devices
+      with no inset owner — see NativeInsetShimGate and
+      docs/android-edge-to-edge-keyboard.md.
     -->
     <meta
       content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE.** Opened as a draft to run CI and to build a test APK, not to
> land. The band this change touches (API 30-34 on WebView < 140) cannot be
> tested on any hardware available here, and merging to `master` auto-publishes
> to the Play internal track. It stays open until one of the #9316 reporters
> confirms a test build on their device.

## Problem

Fixes #9316. On Android the global add-task bar sits behind the soft keyboard,
as does the notes field in the task detail view. Reported by two users, still
present on 18.19.0.

Capacitor's `SystemBars` owns the WebView container's window insets on every API
level, but only applies IME padding on two paths: the passthrough branch
(WebView >= 140 with `viewport-fit=cover`) or `SDK_INT >= 35`. Our own native
keyboard shim was gated to `SDK_INT < 30`. **API 30-34 on a WebView below 140
falls between all three**, so nothing pads and nothing resizes: `obscured` stays
0, `--keyboard-height` stays 0, and the `position: fixed` bar sits behind the
IME. The reporters' with/without-keyboard screenshots are pixel-identical, which
is exactly that signature.

**Why `adjustResize` does not save us**, given the manifest declares it: the
StatusBar plugin runs with `overlaysWebView: true`, which puts the decor view in
`SYSTEM_UI_FLAG_LAYOUT_STABLE | SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` — and under
layout-fullscreen `adjustResize` stops resizing for the IME. That is the
long-standing Android behaviour this shim's `getWindowVisibleDisplayFrame` +
explicit-height approach exists for, and it is SDK-independent below 35. So the
symptom never depended on the API level the old gate keyed off.

The old gate encoded an assumption that holds on stock Android and fails on a
custom ROM: "API >= 30 implies a current WebView, because it auto-updates."
crDroid ships its own AOSP `com.android.webview` (124) and disables the
Play-updated Google package, which the Settings screen still lists as 150. The
active provider is only visible via `adb shell dumpsys webviewupdate`.

`docs/android-edge-to-edge-keyboard.md` already predicted this exact gap and
guessed wrong about its likelihood.

## Solution

Derive the gate from what `SystemBars` actually handles instead of a hardcoded
SDK level (`NativeInsetShimGate`): run iff `sdkInt < 35` **and** the active
provider is below 140, the complement of its two ownership branches, so the two
can never double-count. An unreadable version runs the shim, matching
`SystemBars`, which treats it as `0` and skips passthrough too; both off would
leave no inset owner at all. Both shims share the gate and lose their now-wrong
`BelowApi30` suffix.

**The gate reads the *active* provider only** (`activeProviderMajor`).
`WebViewCompatibilityChecker` answers a different question — may we block the
app? — so it falls back to scanning installed packages, which on the crDroid
layout above reports the disabled 150 rather than the active 124. Feeding the
gate that number would switch the shim off on precisely the devices it exists
for, while `SystemBars` (which reads `getCurrentWebViewPackage()` and sees 0) is
off as well. Only `getCurrentWebViewPackage()` or user-agent readings count;
anything else degrades to `null`, which runs the shim.

Two caveats on calling this the exact complement, both now documented: branch 1
additionally requires `viewport-fit=cover`, which `SystemBars` only learns at
`onDOMReady` (`src/index.html` sets it, and now says why it must stay), leaving
only the pre-DOM-ready window — where the IME cannot be up — uncovered.

**This does not re-arm #8508.** That saga's rule is that any inset must be
resize-detecting. This shim already is, structurally: it sets the WebView height
to an **absolute** target read from the visible frame, not a delta. On a device
that already shrank for the IME, the WebView bottom is already at `rect.bottom`,
so it computes the height already in effect and nothing moves. That property is
what makes widening the gate safe at all.

## Validation

Confirmed by the reporters, independent of this branch:

- Android 14 / WebView 124 and Android 14 / WebView 126: both broken.
- One reporter side-loaded WebView 151 with no app change and the symptom
  disappeared, isolating the version boundary the code branches at.

Done here:

- 88 JVM unit tests pass, 12 of them new, pinning both reported configurations,
  both no-op directions, the disabled-provider reading that must not be trusted,
  and the absolute-target invariant the "does not re-arm #8508" argument rests on
  (`ImeWebViewHeight` — on an already-resized window the target equals the height
  in effect, so nothing is written).

**Not done, and why this must not merge yet:** no device in the widened API
30-34 band exists here. Outside `API < 35 && WebView < 140` the gate is a pure
no-op, so most devices are untouched by construction. Inside the band, the one
new case is a device that *already* resizes correctly, where the shim would pin
an explicit pixel height instead of `MATCH_PARENT` while the IME is up. That is
visually a no-op and self-corrects on the next layout pass, but it is unverified,
and it is the same shape of assumption that produced #8508 twice.

**For whoever tests the APK — validate the mechanism, not just the symptom.**
The shim is a strict no-op wherever the window already resizes, so "the bar looks
fixed" cannot distinguish a working shim from one that never ran, and a
coincidental fix would send the next regression hunt down the wrong path.
`logImeGeometryOnTransition` prints the gate inputs and geometry once per
keyboard transition; it stays silent unless enabled:

```
adb shell setprop log.tag.SUPKeyboard DEBUG   # then restart the app
adb logcat -s SUPKeyboard
adb shell dumpsys webviewupdate | grep -i 'Current WebView package'
```

The line is printed after the shim's pass, so on a fixed device the `ime=true`
line reads `shim=true` with `paramsHeight` equal to `target`. If `shim=false`,
compare `wvMajor=` against the `dumpsys` provider — the version source is wrong,
not the theory. If `target` is set but `paramsHeight` did not change, the shim
either bailed on a degenerate frame or the height was already correct, i.e. the
device resizes itself and the shim is a legitimate no-op. `webViewHeight` lags one
layout pass by design. Geometry and versions only — the log carries no user
content.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files (none changed; this is Kotlin, Markdown and HTML — the latter two prettier-formatted)
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
