### PR TITLE
fix(config): commit time fields on blur so typing keeps both hour digits

### DIFF
--- a/e2e/tests/settings/work-start-time-input-9548.spec.ts
+++ b/e2e/tests/settings/work-start-time-input-9548.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import type { Page } from '@playwright/test';
+
+/**
+ * #9548: typing `18` into the "Work Day Start" hour segment produced `08`.
+ *
+ * The config form binds `[model]="cfg()"`, so a field that commits on every
+ * keystroke round-trips through the store and hands formly a fresh model
+ * object, which rebuilds the field mid-edit and drops the native time
+ * control's in-progress editing state — the first digit is lost. This drives
+ * the real settings UI because none of that path (store -> signal -> formly
+ * rebuild) exists in a component harness, and the native `<input type="time">`
+ * segment state only reacts to real key events, not `fill()`.
+ */
+
+const SECTION = '.section-schedule';
+const WORK_START_INPUT = `${SECTION} input[type=time]`;
+
+const openScheduleSection = async (page: Page): Promise<void> => {
+  await page.goto('/#/config?tab=2');
+  await page.waitForURL(/config/);
+
+  const collapsible = page.locator(`${SECTION} collapsible`);
+  await collapsible.waitFor({ state: 'visible', timeout: 20000 });
+  await collapsible.scrollIntoViewIfNeeded();
+
+  const isExpanded = await collapsible.evaluate((el: Element) =>
+    el.classList.contains('isExpanded'),
+  );
+  if (!isExpanded) {
+    await collapsible.locator('.collapsible-header').click();
+    await collapsible
+      .locator('.collapsible-panel')
+      .waitFor({ state: 'visible', timeout: 5000 });
+  }
+};
+
+/** The work start/end times are hidden behind their own toggle. */
+const enableWorkStartEnd = async (page: Page): Promise<void> => {
+  const toggle = page
+    .locator(`${SECTION} mat-slide-toggle, ${SECTION} mat-checkbox`)
+    .first();
+  await toggle.scrollIntoViewIfNeeded();
+  const classes = (await toggle.getAttribute('class')) ?? '';
+  if (!classes.includes('checked')) {
+    await toggle.click();
+  }
+  await page.locator(WORK_START_INPUT).first().waitFor({ state: 'visible' });
+};
+
+test.describe('Schedule: work day start time input (#9548)', () => {
+  test('should keep both hour digits while typing', async ({ page, workViewPage }) => {
+    await workViewPage.waitForTaskList();
+    await openScheduleSection(page);
+    await enableWorkStartEnd(page);
+
+    const input = page.locator(WORK_START_INPUT).first();
+    await input.click();
+
+    // Typed one key at a time on purpose: the bug only appears between
+    // keystrokes, so `fill('18:30')` would pass against the broken build.
+    await page.keyboard.press('1');
+    await page.keyboard.press('8');
+    // Chrome auto-advances to the minute segment after two hour digits.
+    await page.keyboard.press('3');
+    await page.keyboard.press('0');
+
+    await expect(input).toHaveValue('18:30');
+  });
+
+  test('should persist the typed time across a reload', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await openScheduleSection(page);
+    await enableWorkStartEnd(page);
+
+    const input = page.locator(WORK_START_INPUT).first();
+    await input.click();
+    for (const key of ['1', '8', '3', '0']) {
+      await page.keyboard.press(key);
+    }
+    // The field is `updateOn: 'blur'` — the value only reaches the form on blur.
+    await input.blur();
+    // The save snack confirms the store commit; the write to IndexedDB behind
+    // it is async, so the re-read below still retries.
+    await expect(page.locator('mat-snack-bar-container')).toBeVisible({
+      timeout: 10000,
+    });
+
+    await expect(async () => {
+      await page.reload();
+      await openScheduleSection(page);
+      await enableWorkStartEnd(page);
+      await expect(page.locator(WORK_START_INPUT).first()).toHaveValue('18:30');
+    }).toPass({ timeout: 45000 });
+  });
+});

--- a/src/app/util/adjust-to-live-formly-form.spec.ts
+++ b/src/app/util/adjust-to-live-formly-form.spec.ts
@@ -139,6 +139,16 @@ describe('adjustToLiveFormlyForm', () => {
 
       expect(result[0].modelOptions?.updateOn).toBe('blur');
     });
+
+    // #9548: committing per keystroke rebuilt the field mid-edit, so a native
+    // <input type="time"> lost the first digit of the hour ('18' became '08').
+    it('should add blur update behavior to time fields', () => {
+      const items: FormlyFieldConfig[] = [{ key: 'timeField', type: 'time' }];
+
+      const result = adjustToLiveFormlyForm(items);
+
+      expect(result[0].modelOptions?.updateOn).toBe('blur');
+    });
   });
 
   describe('fieldGroup processing', () => {

--- a/src/app/util/adjust-to-live-formly-form.ts
+++ b/src/app/util/adjust-to-live-formly-form.ts
@@ -15,12 +15,18 @@ export const adjustToLiveFormlyForm = (
         type: 'toggle',
       };
     }
+    // `updateOn: 'blur'` is load-bearing, not a nicety: the config form binds
+    // `[model]="cfg()"`, so committing per keystroke round-trips through the
+    // store and hands formly a fresh model object, which rebuilds the field
+    // mid-edit and discards the native control's in-progress editing state.
+    // For `time` that ate the first digit of every hour typed (#9548).
     if (
       item.type === 'input' ||
       item.type === 'textarea' ||
       item.type === 'duration' ||
       item.type === 'icon' ||
-      item.type === 'color'
+      item.type === 'color' ||
+      item.type === 'time'
     ) {
       return {
         ...item,


### PR DESCRIPTION
## Problem

Closes #9548.

Typing `18` into the hour segment of **Settings → Time & Tracking → Schedule → Work Day Start** produces `08` — the first digit is dropped. Continuing into the minute segment leaves the field empty, and the interaction persists `00:00` to the config, so this is a silent config-corruption path rather than only a display glitch.

Measured against the real settings UI, pressing `1`, `8`, `3`, `0` as individual key events:

| build | after `1` | after `8` | after `3`,`0` | after reload |
| --- | --- | --- | --- | --- |
| master | `01:00` | **`08:00`** | `""` | `00:00` |
| this PR | `01:00` | `18:00` | `18:30` | `18:30` |

Shipped since v18.10.0 (#8270), so it affects every released version that has the locale-aware time fields.

## Solution

The config form binds `[model]="cfg()"`. A field that commits on every keystroke therefore round-trips through the store and hands ngx-formly a fresh model object, which trips `changes.model && this._modelChangeValue !== changes.model.currentValue` in `FormlyForm.ngOnChanges` and calls `builder.build(this.field)` — rebuilding the field mid-edit and taking the native time control's in-progress editing state with it.

`adjustToLiveFormlyForm` already forces `modelOptions.updateOn = 'blur'` for `input`, `textarea`, `duration`, `icon` and `color` for exactly this reason. The `time` type added in #8270 was never added to that list. This adds it — one line, plus tests.

Side benefit: a time edit now costs one store dispatch instead of one per keystroke, so it no longer emits a burst of config ops (and no longer writes half-typed values into `startOfNextDayTime`, which feeds the logical-day calculation).

### Notes for review

- Blast radius is the five `type: 'time'` fields (four in `schedule-form.const.ts`, `startOfNextDayTime` in `misc-settings-form.const.ts`). No other test drives a time input, and the `startOfNextDayTime` specs are store-level so they don't go through the form.
- **Tradeoff, measured.** Committing on blur means an edit that never blurs is not saved. With focus still in the field:

  | path | result |
  | --- | --- |
  | click anywhere else in the app | saved (`mousedown` blurs first) |
  | back button / SPA route change | **edit lost** |
  | hard reload or app killed mid-edit | **edit lost** |

  Destroying a focused input does not fire `blur`, so nothing commits. This is the pre-existing behaviour of every other settings field (`input`, `textarea`, `duration`, `icon`, `color`), so this makes `time` consistent rather than introducing a new class of loss — and on master those same paths "save" a corrupted `00:00`/`08:00`, which is worse than not saving. Flagging it explicitly because it is a real behaviour change and the alternatives (commit on `change`, or commit in `ngOnDestroy`) are both worse: `change` fires per segment edit on a native time input and would reintroduce the original bug, and a destroy-hook would make `time` inconsistent with every other field. Happy to add one if you disagree.
- The existing Enter-to-commit `keydown` handler in that branch applies to `time` unmodified, since a native time input's `.value` is already canonical `HH:mm`.
- This supersedes #9554, which targeted the same issue by guarding `writeValue` against identical writes. I measured that patch against the reproduction above and it behaves identically to master at every step — re-writing an identical value doesn't reset the segment state, because Blink's `HTMLInputElement::SetValue` skips the view update when the sanitized value is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing behaviour change beyond the field working
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

### Verification

- New E2E `work-start-time-input-9548.spec.ts` fails on master (`""` and `00:00`) and passes with the fix; stable across `--repeat-each=3`.
- Full `e2e/tests/settings/` folder: 11/11.
- `adjust-to-live-formly-form.spec.ts` 19/19, `input-time.directive.spec.ts` 8/8.
- `npm run checkFile` clean on all three files.
