### PR TITLE
fix(worklog): disambiguate duplicate Titles column in export

### DIFF
--- a/src/app/features/worklog/worklog-export/worklog-export.component.ts
+++ b/src/app/features/worklog/worklog-export/worklog-export.component.ts
@@ -25,7 +25,12 @@ import { WORKLOG_EXPORT_DEFAULTS } from '../../work-context/work-context.const';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { ProjectService } from '../../project/project.service';
 import { TagService } from '../../tag/tag.service';
-import { createRows, formatRows, formatText } from './worklog-export.util';
+import {
+  createRows,
+  formatRows,
+  formatText,
+  getHeadlineCol,
+} from './worklog-export.util';
 import { MatDialogActions, MatDialogContent } from '@angular/material/dialog';
 import { FormsModule } from '@angular/forms';
 import { MatAnchor, MatButton, MatMiniFabButton } from '@angular/material/button';
@@ -195,36 +200,7 @@ export class WorklogExportComponent implements OnInit, OnDestroy {
             this.formattedRows = formatRows(rows, this.options);
             // TODO format to csv
 
-            this.headlineCols = this.options.cols.map((col) => {
-              switch (col) {
-                case 'DATE':
-                  return 'Date';
-                case 'START':
-                  return 'Start';
-                case 'END':
-                  return 'End';
-                case 'TITLES':
-                  return 'Titles';
-                case 'TITLES_INCLUDING_SUB':
-                  return 'Titles';
-                case 'NOTES':
-                  return 'Descriptions';
-                case 'PROJECTS':
-                  return 'Projects';
-                case 'TAGS':
-                  return 'Tags';
-                case 'TIME_MS':
-                case 'TIME_STR':
-                case 'TIME_CLOCK':
-                  return 'Worked';
-                case 'ESTIMATE_MS':
-                case 'ESTIMATE_STR':
-                case 'ESTIMATE_CLOCK':
-                  return 'Estimate';
-                default:
-                  return 'INVALID COL';
-              }
-            });
+            this.headlineCols = this.options.cols.map(getHeadlineCol);
 
             this.txt = formatText(this.headlineCols, this.formattedRows);
             this._changeDetectorRef.detectChanges();

--- a/src/app/features/worklog/worklog-export/worklog-export.util.spec.ts
+++ b/src/app/features/worklog/worklog-export/worklog-export.util.spec.ts
@@ -1,6 +1,11 @@
 import { WorkStartEnd } from 'src/app/features/work-context/work-context.model';
 import { WorklogGrouping } from '../worklog.model';
-import { createRows, formatRows, formatText } from './worklog-export.util';
+import {
+  createRows,
+  formatRows,
+  formatText,
+  getHeadlineCol,
+} from './worklog-export.util';
 import { DEFAULT_TASK, WorklogTask } from '../../tasks/task.model';
 import { DEFAULT_PROJECT } from '../../project/project.const';
 import { DEFAULT_TAG } from '../../tag/tag.const';
@@ -471,6 +476,13 @@ describe('worklog-export.util moment replacement', () => {
         expect(rounded).toBe(expected);
       });
     });
+  });
+});
+
+describe('getHeadlineCol', () => {
+  it('gives the two title columns distinct headers', () => {
+    expect(getHeadlineCol('TITLES')).toBe('Parent Titles');
+    expect(getHeadlineCol('TITLES_INCLUDING_SUB')).toBe('Titles');
   });
 });
 

--- a/src/app/features/worklog/worklog-export/worklog-export.util.ts
+++ b/src/app/features/worklog/worklog-export/worklog-export.util.ts
@@ -8,7 +8,11 @@ import { ProjectCopy } from '../../project/project.model';
 import { TagCopy } from '../../tag/tag.model';
 import { WorklogTask } from '../../tasks/task.model';
 import { resolveDisplayTagIds } from '../../tasks/util/resolve-display-tag-ids.util';
-import { WorklogExportSettingsCopy, WorklogGrouping } from '../worklog.model';
+import {
+  WorklogColTypes,
+  WorklogExportSettingsCopy,
+  WorklogGrouping,
+} from '../worklog.model';
 import { Log } from '../../../core/log';
 import {
   ItemsByKey,
@@ -340,6 +344,43 @@ export const formatRows = (
       }
     });
   });
+};
+
+/**
+ * Deliberately untranslated: the headers are consumed by spreadsheets and
+ * scripts, so they must not vary with the UI language.
+ */
+export const getHeadlineCol = (col: WorklogColTypes): string => {
+  switch (col) {
+    case 'DATE':
+      return 'Date';
+    case 'START':
+      return 'Start';
+    case 'END':
+      return 'End';
+    case 'TITLES':
+      // must differ from TITLES_INCLUDING_SUB: both columns can be exported
+      // together to attribute a sub-task row to its parent task
+      return 'Parent Titles';
+    case 'TITLES_INCLUDING_SUB':
+      return 'Titles';
+    case 'NOTES':
+      return 'Descriptions';
+    case 'PROJECTS':
+      return 'Projects';
+    case 'TAGS':
+      return 'Tags';
+    case 'TIME_MS':
+    case 'TIME_STR':
+    case 'TIME_CLOCK':
+      return 'Worked';
+    case 'ESTIMATE_MS':
+    case 'ESTIMATE_STR':
+    case 'ESTIMATE_CLOCK':
+      return 'Estimate';
+    default:
+      return 'INVALID COL';
+  }
 };
 
 /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2282,7 +2282,7 @@
           "FULL_QUARTERS": "full quarters",
           "NOTES": "Task Notes",
           "PARENT_TASK": "Parent Task",
-          "PARENT_TASK_TITLES_ONLY": "Parent Task Titles only",
+          "PARENT_TASK_TITLES_ONLY": "Parent Task Titles",
           "PROJECTS": "Project Names",
           "STARTED_WORKING": "Started Working",
           "TAGS": "Tags",
@@ -2290,7 +2290,7 @@
           "TIME_AS_CLOCK": "Time as clock (e.g. 5:23)",
           "TIME_AS_MILLISECONDS": "Time as milliseconds",
           "TIME_AS_STRING": "Time as string (e.g. 5h 23m)",
-          "TITLES_AND_SUB_TASK_TITLES": "Titles and Subtask Titles",
+          "TITLES_AND_SUB_TASK_TITLES": "Task/Subtask Titles",
           "WORKLOG": "Worklog"
         },
         "OPTIONS": "Options",


### PR DESCRIPTION
## Problem

Adding both title columns to the Worklog CSV export produced two columns literally headed `Titles`, so a sub-task row could not be told apart from its parent task.

That pair — plus "Project Names" — is the way to attribute a sub-task's tracked time to its parent task and project. The columns exist and work correctly; the output was just unreadable.

Two dropdown labels also described behaviour the columns never had:

- **"Parent Task Titles only"** — the "only" reads as a row filter. The column actually falls back to the task's own title when there is no parent (`getTaskFields`).
- **"Titles and Subtask Titles"** — never emitted both. It emits `task.title`, i.e. the task actually worked on.

Came out of a user report where the conclusion was that the feature was missing altogether.

## Change

- `TITLES` now exports the header `Parent Titles`
- `TITLES_INCLUDING_SUB` keeps `Titles` — it is the column that emits the row's own task title, and it is the one in `WORKLOG_EXPORT_DEFAULTS`, so **the default export stays byte-identical**
- Both labels corrected in `en.json` only — no i18n key renamed, other locales untouched per project rule
- Header mapping moved out of the component into `getHeadlineCol()` in the util, so the pair is covered by a unit test. There is no component TestBed spec to hang the assertion on, and the mapping is pure — it never belonged inside an RxJS `subscribe` callback.

## Verification

- `worklog-export.util.spec.ts` — 24/24 pass (1 new)
- existing e2e `e2e/tests/worklog/worklog-basic.spec.ts:128` still asserts the unchanged default header row `Date;Start;End;Worked;Titles`
- `src/tsconfig.app.json` and `src/tsconfig.spec.json` both `--noEmit` clean; `npm run checkFile` clean on all changed `.ts`
- No persisted data touched: only `cols` (column ids) are stored, headers are computed at render time

## Notes

- Anyone who explicitly added the `TITLES` column **and** parses the CSV by header name will see `Titles` → `Parent Titles`. Narrow, but worth a release-note line.
- **Not addressed here:** the same duplicate-header issue is still live for `TIME_MS` / `TIME_STR` / `TIME_CLOCK` (all return `Worked`) and the three `ESTIMATE_*` (all return `Estimate`), reachable by combining e.g. "Time as milliseconds" with "Time as clock". Unreported and outside this symptom's scope — happy to file it separately.