### PR TITLE
fix(android): stop logging task titles and shared content to logcat

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -352,7 +352,7 @@ class CapacitorMainActivity : BridgeActivity() {
         // tail. See pushStatusBarOverlapBelowApi30.
         lastStatusBarOverlapCssPx = -1
         pendingShareIntent?.let {
-            Log.d("SP_SHARE", "Flushing pending share intent: $it")
+            Log.d("SP_SHARE", "Flushing pending share intent")
             callJSInterfaceFunctionIfExists("next", "onShareWithAttachment$", it.toString())
             pendingShareIntent = null
             ShareIntentQueue.getAndClear(this)
@@ -426,9 +426,13 @@ class CapacitorMainActivity : BridgeActivity() {
                 // "Shared Content" here masks that derivation (issue: blank shared tasks).
                 val sharedTitle = intent.getStringExtra(Intent.EXTRA_TITLE) ?: ""
                 val sharedSubject = intent.getStringExtra(Intent.EXTRA_SUBJECT) ?: ""
-                Log.d("SP_SHARE", "Shared text: $sharedText")
-                Log.d("SP_SHARE", "Shared title: $sharedTitle")
-                Log.d("SP_SHARE", "Shared subject: $sharedSubject")
+                // Shape only, never the content: logcat is world-readable to adb and
+                // ends up in bug reports, and this carries whatever the user shared.
+                Log.d(
+                    "SP_SHARE",
+                    "Received share: textLen=${sharedText?.length ?: 0} " +
+                        "hasTitle=${sharedTitle.isNotEmpty()} hasSubject=${sharedSubject.isNotEmpty()}",
+                )
 
                 // Ignore empty/blank shares — they only produce useless blank tasks.
                 if (!sharedText.isNullOrBlank()) {
@@ -443,12 +447,12 @@ class CapacitorMainActivity : BridgeActivity() {
                     ShareIntentQueue.setPending(this, json.toString())
 
                     if (isFrontendReady) {
-                        Log.d("SP_SHARE", "Frontend ready, sending directly: $json")
+                        Log.d("SP_SHARE", "Frontend ready, sending directly (type=$type)")
                         callJSInterfaceFunctionIfExists("next", "onShareWithAttachment$", json.toString())
                         pendingShareIntent = null
                         ShareIntentQueue.getAndClear(this)
                     } else {
-                        Log.d("SP_SHARE", "Frontend NOT ready, queueing: $json")
+                        Log.d("SP_SHARE", "Frontend NOT ready, queueing (type=$type)")
                         pendingShareIntent = json
                         Toast.makeText(this, R.string.share_received, Toast.LENGTH_SHORT).show()
                     }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/receiver/BootReceiver.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/receiver/BootReceiver.kt
@@ -36,7 +36,7 @@ class BootReceiver : BroadcastReceiver() {
         }
 
         for (alarm in alarms) {
-            Log.d(TAG, "Re-scheduling alarm: id=${alarm.notificationId}, title=${alarm.title}")
+            Log.d(TAG, "Re-scheduling alarm: id=${alarm.notificationId}")
             ReminderNotificationHelper.scheduleReminder(
                 context,
                 alarm.notificationId,

--- a/android/app/src/main/java/com/superproductivity/superproductivity/receiver/ReminderActionReceiver.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/receiver/ReminderActionReceiver.kt
@@ -44,7 +44,7 @@ class ReminderActionReceiver : BroadcastReceiver() {
 
         when (intent.action) {
             ACTION_SNOOZE -> {
-                Log.d(TAG, "Snooze 10m: notificationId=$notificationId, title=$title")
+                Log.d(TAG, "Snooze 10m: notificationId=$notificationId")
 
                 // Dismiss the notification
                 if (notificationId != -1) {
@@ -57,7 +57,7 @@ class ReminderActionReceiver : BroadcastReceiver() {
             }
 
             ACTION_SNOOZE_1H -> {
-                Log.d(TAG, "Snooze 1h: notificationId=$notificationId, title=$title")
+                Log.d(TAG, "Snooze 1h: notificationId=$notificationId")
 
                 // Dismiss the notification
                 if (notificationId != -1) {

--- a/android/app/src/main/java/com/superproductivity/superproductivity/receiver/ReminderAlarmReceiver.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/receiver/ReminderAlarmReceiver.kt
@@ -44,7 +44,7 @@ class ReminderAlarmReceiver : BroadcastReceiver() {
         val isOngoing = intent.getBooleanExtra(EXTRA_IS_ONGOING, false)
         val triggerAtMs = intent.getLongExtra(EXTRA_TRIGGER_AT_MS, 0L)
 
-        Log.d(TAG, "Alarm triggered: id=$notificationId, title=$title, triggerAt=$triggerAtMs")
+        Log.d(TAG, "Alarm triggered: id=$notificationId, triggerAt=$triggerAtMs")
 
         val pendingResult = goAsync()
 

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/FocusModeForegroundService.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/FocusModeForegroundService.kt
@@ -251,7 +251,7 @@ class FocusModeForegroundService : Service() {
     }
 
     private fun startFocusMode(): Boolean {
-        Log.d(TAG, "Starting focus mode: title=$title, durationMs=$durationMs, remainingMs=$remainingMs, isBreak=$isBreak, isPaused=$isPaused")
+        Log.d(TAG, "Starting focus mode: durationMs=$durationMs, remainingMs=$remainingMs, isBreak=$isBreak, isPaused=$isPaused")
         FocusModeNotificationHelper.cancelCompletionNotification(this)
 
         isRunning = true
@@ -339,7 +339,7 @@ class FocusModeForegroundService : Service() {
     }
 
     private fun onTimerComplete() {
-        Log.d(TAG, "Timer completed! isBreak=$isBreak, title=$title")
+        Log.d(TAG, "Timer completed! isBreak=$isBreak")
         hasNotifiedCompletion = true
 
         // Show high-priority completion notification with sound.

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/FocusModeNotificationHelper.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/FocusModeNotificationHelper.kt
@@ -189,7 +189,7 @@ object FocusModeNotificationHelper {
         message: String,
         isBreak: Boolean
     ) {
-        Log.d(TAG, "Showing completion notification: title=$title, isBreak=$isBreak")
+        Log.d(TAG, "Showing completion notification: isBreak=$isBreak")
         createCompletionChannel(context)
 
         val contentIntent = Intent(context, CapacitorMainActivity::class.java).apply {

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/ReminderNotificationHelper.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/ReminderNotificationHelper.kt
@@ -88,7 +88,7 @@ object ReminderNotificationHelper {
         useAlarmStyle: Boolean = false,
         isOngoing: Boolean = false
     ) {
-        Log.d(TAG, "Scheduling reminder: id=$notificationId, title=$title, useAlarmStyle=$useAlarmStyle")
+        Log.d(TAG, "Scheduling reminder: id=$notificationId, useAlarmStyle=$useAlarmStyle")
 
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/TrackingForegroundService.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/TrackingForegroundService.kt
@@ -191,7 +191,7 @@ class TrackingForegroundService : Service() {
     }
 
     private fun startTracking(taskId: String, title: String, timeSpentMs: Long): Boolean {
-        Log.d(TAG, "Starting tracking: taskId=$taskId, title=$title, timeSpentMs=$timeSpentMs")
+        Log.d(TAG, "Starting tracking: taskId=$taskId, timeSpentMs=$timeSpentMs")
 
         currentTaskId = taskId
         taskTitle = title

--- a/android/app/src/main/java/com/superproductivity/superproductivity/widget/StartupOverlayManager.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/widget/StartupOverlayManager.kt
@@ -250,7 +250,7 @@ class StartupOverlayManager(private val activity: android.app.Activity) {
         editText?.text?.clear()
         updateFeedback()
 
-        Log.d(TAG, "Task queued from startup overlay: $title (total: $taskCount)")
+        Log.d(TAG, "Task queued from startup overlay (total: $taskCount)")
     }
 
     private fun updateFeedback() {


### PR DESCRIPTION
Found while working on #7229 (PR #9585), but unrelated to it — filed separately so each can be reviewed and reverted on its own.

## The problem

Twelve sites across the share, reminder, alarm, focus-mode, tracking and widget paths interpolated user content into `Log.d`, none of them gated on `BuildConfig.DEBUG`:

- **Task titles** — `ReminderAlarmReceiver`, `ReminderActionReceiver` (×2), `ReminderNotificationHelper`, `BootReceiver`, `FocusModeForegroundService` (×2), `FocusModeNotificationHelper`, `TrackingForegroundService`, `StartupOverlayManager`
- **Whole shared payloads** — `CapacitorMainActivity`: the shared text, title and subject, plus the assembled JSON at two more sites. That's arbitrary user content: URLs, note bodies, email subjects.

Logcat is readable over adb and is captured in bug reports and ADB dumps, so this puts task titles on any screen where a user is asked to collect logs — which we do ask for, including in #7229 itself.

This is the project's own rule, stated in `CLAUDE.md`:

> **Logging:** `Log.log({ id: task.id })`, never `Log.log(task)` or `Log.log(title)` — log history is exportable, never log user content.

## The change

Shape, not content. IDs, durations, counts and flags are kept — they're what the logs were actually useful for, and they match the pattern already used correctly elsewhere (`ReminderActionReceiver`'s sanitized `taskId` line). The share handler now logs `textLen=… hasTitle=… hasSubject=…`, and the two JSON dumps log the derived `type` (`LINK`/`NOTE`) instead of the payload.

No behaviour changes — every edit is inside a log string.

## Testing

`./gradlew :app:testPlayDebugUnitTest :app:testFdroidDebugUnitTest` — green, both flavors, no new compiler warnings (`it` and `type` remain in scope and used at every touched site).