### PR TITLE
fix(sync): apply LWW conflict winners for array entities (#9526)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # environment files
+# Anything named .env* holds real secrets (JWT_SECRET, POSTGRES_PASSWORD,
+# SMTP_PASS) — the only exception is the checked-in example. The previous
+# rules listed .local variants one by one, which let hand-made backups such as
+# .env.bak.<timestamp> sit untracked in a production checkout, one `git add -A`
+# away from being committed.
 .env
-.env.local
-.env.*.local
+.env.*
+!.env.example
 
 # auto-generated environment constants
 src/app/config/env.generated.ts

--- a/e2e/tests/plugins/plugin-iframe.spec.ts
+++ b/e2e/tests/plugins/plugin-iframe.spec.ts
@@ -78,6 +78,28 @@ test.describe.serial('Plugin Iframe', () => {
     await expect(iframe).toBeVisible();
   });
 
+  // #9526: the API bridge script must be injected in <head> so that classic
+  // (non-defer) plugin scripts see window.PluginAPI at parse time. The bundled
+  // API Test Plugin records `typeof window.PluginAPI` at the top of its inline
+  // body script; before the fix the bridge was appended before </body> and this
+  // read 'undefined', pushing plugins into local fallbacks that bypass sync.
+  test('PluginAPI is available to parse-time plugin scripts', async ({ page }) => {
+    await page.goto('/#/plugins/api-test-plugin/index');
+
+    const iframe = page.locator(PLUGIN_IFRAME);
+    await iframe.waitFor({ state: 'visible' });
+
+    const frameLocator = page.frameLocator(PLUGIN_IFRAME);
+    await frameLocator.locator('body').waitFor({ state: 'visible' });
+
+    const typeAtParseTime = await frameLocator
+      .locator('body')
+      .evaluate(
+        () => (window as unknown as Record<string, unknown>).__pluginApiTypeAtParseTime,
+      );
+    expect(typeAtParseTime).toBe('object');
+  });
+
   test('verify iframe loads with correct content', async ({ page }) => {
     // Navigate directly to plugin page
     await page.goto('/#/plugins/api-test-plugin/index');

--- a/e2e/tests/sync/supersync-plugin-user-data.spec.ts
+++ b/e2e/tests/sync/supersync-plugin-user-data.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from '../../fixtures/supersync.fixture';
+import {
+  createTestUser,
+  getSuperSyncConfig,
+  createSimulatedClient,
+  closeClient,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+import {
+  enablePluginWithVerification,
+  waitForPluginAssets,
+  waitForPluginManagementInit,
+} from '../../helpers/plugin-test.helpers';
+
+/**
+ * SuperSync Plugin User Data E2E Tests (#9526)
+ *
+ * Plugin data persisted via PluginAPI.persistDataSynced() syncs as
+ * PLUGIN_USER_DATA ops. Since v18.10.0 LWW conflict resolution emits synthetic
+ * `[PLUGIN_USER_DATA] LWW Update` ops for conflict winners — but until #9526
+ * the receiving client's lwwUpdateMetaReducer only supported singleton and
+ * adapter storage patterns, so array-entity winners were silently dropped
+ * ("Unsupported storage pattern") and clients diverged permanently.
+ *
+ * These tests drive the REAL pipeline end to end: plugin iframe → postMessage
+ * bridge → NgRx store → op-log → SuperSync server → other client.
+ */
+
+const PLUGIN_IFRAME = 'plugin-index iframe';
+const PLUGIN_NAME = 'API Test Plugin';
+const PLUGIN_URL = '/#/plugins/api-test-plugin/index';
+
+const enableApiTestPlugin = async (client: SimulatedE2EClient): Promise<void> => {
+  const assetsAvailable = await waitForPluginAssets(client.page);
+  if (!assetsAvailable) {
+    throw new Error(`[${client.clientName}] Plugin assets not available`);
+  }
+  const initSuccess = await waitForPluginManagementInit(client.page);
+  if (!initSuccess) {
+    throw new Error(`[${client.clientName}] Plugin management failed to initialize`);
+  }
+  // Idempotent: only toggles when the plugin is not already enabled (it may
+  // already be enabled via a synced PLUGIN_METADATA op from the other client).
+  const enabled = await enablePluginWithVerification(client.page, PLUGIN_NAME, 15000);
+  if (!enabled) {
+    throw new Error(`[${client.clientName}] Failed to enable ${PLUGIN_NAME}`);
+  }
+};
+
+/** Opens the plugin's iframe view and waits for the bridge to be usable. */
+const openPluginFrame = async (
+  client: SimulatedE2EClient,
+): Promise<ReturnType<SimulatedE2EClient['page']['frameLocator']>> => {
+  await client.page.goto(PLUGIN_URL);
+  const iframe = client.page.locator(PLUGIN_IFRAME);
+  await iframe.waitFor({ state: 'visible', timeout: 15000 });
+  const frame = client.page.frameLocator(PLUGIN_IFRAME);
+  await frame.locator('body').waitFor({ state: 'visible', timeout: 15000 });
+  await frame
+    .locator('body')
+    .evaluate((_el) =>
+      (window as unknown as Record<string, unknown>).PluginAPI ? true : false,
+    );
+  return frame;
+};
+
+const persistPluginData = async (
+  client: SimulatedE2EClient,
+  data: string,
+): Promise<void> => {
+  const frame = await openPluginFrame(client);
+  await frame.locator('body').evaluate(async (_el, dataToPersist) => {
+    const api = (
+      window as unknown as {
+        PluginAPI: { persistDataSynced: (d: string) => Promise<void> };
+      }
+    ).PluginAPI;
+    await api.persistDataSynced(dataToPersist);
+  }, data);
+};
+
+const loadPluginData = async (client: SimulatedE2EClient): Promise<string | null> => {
+  const frame = await openPluginFrame(client);
+  return frame.locator('body').evaluate(async () => {
+    const api = (
+      window as unknown as {
+        PluginAPI: { loadPersistedData: () => Promise<string | null> };
+      }
+    ).PluginAPI;
+    return api.loadPersistedData();
+  });
+};
+
+test.describe('@supersync SuperSync Plugin User Data', () => {
+  /**
+   * Scenario: plugin data syncs between clients (non-conflict baseline) and a
+   * concurrent-edit conflict propagates the LWW winner to the losing client.
+   *
+   * Actions:
+   * 1.  Client A enables the plugin, persists SEED, syncs
+   * 2.  Client B syncs (receives plugin metadata + data), verifies SEED
+   * 3.  Client B persists B-DATA (earlier timestamp)
+   * 4.  Client A persists A-DATA (later timestamp)
+   * 5.  Client B syncs first (uploads B-DATA)
+   * 6.  Client A syncs (conflict → LWW → A wins → uploads
+   *     [PLUGIN_USER_DATA] LWW Update carrying A-DATA)
+   * 7.  Client B syncs (receives the LWW Update op)
+   * 8.  KEY: B now reads A-DATA — without the #9526 array branch the op is
+   *     dropped ("Unsupported storage pattern") and B keeps B-DATA forever
+   */
+  test('plugin data conflict: LWW winner propagates to the losing client', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.setTimeout(240000);
+    const appUrl = baseURL || 'http://localhost:4242';
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    const seedData = JSON.stringify({ v: `seed-${testRunId}` });
+    const dataA = JSON.stringify({ v: `A-${testRunId}` });
+    const dataB = JSON.stringify({ v: `B-${testRunId}` });
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      clientA = await createSimulatedClient(browser, appUrl, 'A', testRunId);
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      clientB = await createSimulatedClient(browser, appUrl, 'B', testRunId);
+      await clientB.sync.setupSuperSync(syncConfig);
+
+      // 1. Client A enables the plugin and persists the seed value
+      await enableApiTestPlugin(clientA);
+      await persistPluginData(clientA, seedData);
+      await clientA.sync.syncAndWait();
+      console.log('[PluginData] Client A persisted seed and synced');
+
+      // 2. Client B syncs and must see A's data (plain upsert op — baseline)
+      await clientB.sync.syncAndWait();
+      await enableApiTestPlugin(clientB);
+      expect(await loadPluginData(clientB)).toBe(seedData);
+      console.log('[PluginData] ✓ Baseline: plugin data synced A → B');
+
+      // 3. Client B writes first (earlier timestamp)
+      await persistPluginData(clientB, dataB);
+
+      // 4. Timestamp gap, then Client A writes (later timestamp → LWW winner)
+      await clientA.page.waitForTimeout(1200);
+      await persistPluginData(clientA, dataA);
+
+      // 5. Client B uploads its change first
+      await clientB.sync.syncAndWait();
+
+      // 6. Client A syncs: server reports the conflict, LWW resolution picks
+      //    A's later write, and A uploads the synthetic LWW Update op
+      await clientA.sync.syncAndWait();
+
+      // 7. Client B receives the LWW Update op
+      await clientB.sync.syncAndWait();
+
+      // 8. KEY assertion: B applied the array-entity LWW winner
+      expect(await loadPluginData(clientB)).toBe(dataA);
+      console.log('[PluginData] ✓ LWW winner applied on losing client B');
+
+      // A keeps its winning value; extra round proves convergence is stable
+      await clientA.sync.syncAndWait();
+      expect(await loadPluginData(clientA)).toBe(dataA);
+      console.log('[PluginData] ✓ Clients converged on the LWW winner');
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+});

--- a/packages/plugin-dev/api-test-plugin/index.html
+++ b/packages/plugin-dev/api-test-plugin/index.html
@@ -233,6 +233,11 @@ console.log(tasks.length);</code></pre>
     <hr />
 
     <script>
+      // #9526: captured at parse time — the host injects the PluginAPI bridge
+      // in <head>, so it must already exist when this classic script executes.
+      // Asserted by e2e/tests/plugins/plugin-iframe.spec.ts.
+      window.__pluginApiTypeAtParseTime = typeof window.PluginAPI;
+
       let lastTaskId = null;
       let lastProjectId = null;
       let lastTagId = null;

--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -312,15 +312,15 @@ export const convertOpToAction = (op: Operation): PersistentAction => {
     delete actionPayload['id'];
   }
 
-  // Force `payload.id = op.entityId` for adapter-backed LWW Update ops. The
-  // op's `entityId` is the canonical identifier for adapters — producers also
-  // enforce this when creating ops, but a malformed/older remote op (or any
-  // path that ever drifts) could carry a payload.id that disagrees with
-  // op.entityId, in which case the consumer reducer at
-  // task-shared-meta-reducers/lww-update.meta-reducer.ts trusts payload.id and
-  // would update the WRONG entity. Singleton LWW actions target their feature
-  // state as a whole; their conflict-routing entityId may be composite and must
-  // not be injected into that state. Issues #7330, #9256.
+  // Force `payload.id = op.entityId` for adapter- and array-backed LWW Update
+  // ops (arrays since #9526). The op's `entityId` is the canonical identifier
+  // for both — producers also enforce this when creating ops, but a
+  // malformed/older remote op (or any path that ever drifts) could carry a
+  // payload.id that disagrees with op.entityId, in which case the consumer
+  // reducer at task-shared-meta-reducers/lww-update.meta-reducer.ts trusts
+  // payload.id and would update the WRONG entity. Singleton LWW actions target
+  // their feature state as a whole; their conflict-routing entityId may be
+  // composite and must not be injected into that state. Issues #7330, #9256.
   if (
     !isFullStateOp &&
     isLwwPayloadIdCanonical(lwwEntityType) &&

--- a/src/app/op-log/core/entity-registry.spec.ts
+++ b/src/app/op-log/core/entity-registry.spec.ts
@@ -68,8 +68,9 @@ describe('entity-registry', () => {
   ];
 
   describe('LWW payload id semantics', () => {
-    it('uses payload.id only for adapter-backed entities', () => {
+    it('uses payload.id for adapter- and array-backed entities', () => {
       expect(isLwwPayloadIdCanonical('TASK')).toBeTrue();
+      expect(isLwwPayloadIdCanonical('PLUGIN_USER_DATA')).toBeTrue();
       expect(isLwwPayloadIdCanonical('TIME_TRACKING')).toBeFalse();
       expect(isLwwPayloadIdCanonical('PLANNER')).toBeFalse();
       expect(isLwwPayloadIdCanonical('ALL')).toBeFalse();
@@ -81,21 +82,22 @@ describe('entity-registry', () => {
     // adapter). Pin the payload-id verdict for EVERY entity so a future
     // storagePattern change can't silently re-open the retarget gate for the
     // wrong entity or slam it shut on a legitimate one. Table is exhaustive over
-    // ENTITY_CONFIGS via the categorized lists above.
-    it('is canonical for exactly the adapter entities and no others', () => {
-      for (const entityType of ADAPTER_ENTITIES) {
+    // ENTITY_CONFIGS via the categorized lists above. Array entities became
+    // canonical with #9526 (the LWW reducer applies them by payload identity,
+    // so the integrity gate must cover them).
+    it('is canonical for exactly the adapter and array entities and no others', () => {
+      for (const entityType of [...ADAPTER_ENTITIES, ...ARRAY_ENTITIES]) {
         expect(isLwwPayloadIdCanonical(entityType))
-          .withContext(`adapter ${entityType} → canonical`)
+          .withContext(`id-addressed ${entityType} → canonical`)
           .toBeTrue();
       }
       for (const entityType of [
         ...SINGLETON_ENTITIES,
         ...MAP_ENTITIES,
-        ...ARRAY_ENTITIES,
         ...SPECIAL_OPERATION_TYPES,
       ]) {
         expect(isLwwPayloadIdCanonical(entityType))
-          .withContext(`non-adapter ${entityType} → not canonical`)
+          .withContext(`non-id-addressed ${entityType} → not canonical`)
           .toBeFalse();
       }
     });

--- a/src/app/op-log/core/entity-registry.ts
+++ b/src/app/op-log/core/entity-registry.ts
@@ -369,12 +369,22 @@ export const getPayloadKey = (entityType: EntityType): string | undefined =>
 
 /**
  * Whether an LWW action payload's top-level `id` selects the state that the
- * LWW meta-reducer applies. Only adapter-backed entities are addressed by that
- * field; singleton actions target their registered feature state as a whole.
+ * LWW meta-reducer applies. Adapter- and array-backed entities are addressed
+ * by that field (arrays since #9526: items are found by `id` in the feature
+ * array); singleton actions target their registered feature state as a whole.
+ *
+ * Lockstep contract: `assertDecryptedOpMetadataIntegrity` uses this to decide
+ * which encrypted LWW ops must carry an authenticated `payload.id` matching
+ * `op.entityId` (GHSA-8pxh-mgc7-gp3g) — widening the reducer's id-addressed
+ * patterns without widening this helper would reopen the retarget hole.
  */
-export const isLwwPayloadIdCanonical = (entityType: string | undefined): boolean =>
-  entityType !== undefined &&
-  ENTITY_CONFIGS[entityType as EntityType]?.storagePattern === 'adapter';
+export const isLwwPayloadIdCanonical = (entityType: string | undefined): boolean => {
+  const pattern =
+    entityType !== undefined
+      ? ENTITY_CONFIGS[entityType as EntityType]?.storagePattern
+      : undefined;
+  return pattern === 'adapter' || pattern === 'array';
+};
 
 /**
  * Sentinel `entityId` value denoting "the one and only" instance of an entity

--- a/src/app/op-log/sync/conflict-resolution.service.spec.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.spec.ts
@@ -8611,6 +8611,24 @@ describe('ConflictResolutionService', () => {
       expect(extractActionPayload(op.payload)['id']).toBe('task-canonical');
     });
 
+    it('should force payload.id to the canonical entityId for array entities (#9526 lockstep)', () => {
+      // Array LWW ops are applied by payload identity since #9526, so
+      // assertDecryptedOpMetadataIntegrity fails CLOSED when an encrypted
+      // array op's payload.id disagrees with op.entityId. This pins the
+      // producer side of that lockstep: a payload without a matching id would
+      // turn every legitimate array conflict winner into an integrity reject.
+      const op = service.createLWWUpdateOp(
+        'PLUGIN_USER_DATA',
+        'plugin-canonical',
+        { id: 'stale-id', data: '{"v":1}' },
+        TEST_CLIENT_ID,
+        { [TEST_CLIENT_ID]: 1 },
+        Date.now(),
+      );
+
+      expect(extractActionPayload(op.payload)['id']).toBe('plugin-canonical');
+    });
+
     it('should preserve and normalize an explicit operation footprint', () => {
       const op = service.createLWWUpdateOp(
         'TASK',

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.spec.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.spec.ts
@@ -71,6 +71,25 @@ describe('assertDecryptedOpMetadataIntegrity', () => {
         OperationIntegrityError,
       );
     });
+
+    it('throws for an array-entity LWW op whose entityId was retargeted (#9526 lockstep)', () => {
+      // Since the reducer applies array LWW updates by payload identity,
+      // array entities are retargetable and must be in scope of the gate.
+      const op = createOp({
+        actionType: toLwwUpdateActionType('PLUGIN_USER_DATA'),
+        entityType: 'PLUGIN_USER_DATA',
+        entityId: 'victim-plugin',
+      });
+      const authenticatedPayload = {
+        actionPayload: { id: 'real-plugin', data: '{}' },
+        entityChanges: [],
+        lwwUpdateMode: 'replace',
+      };
+
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, authenticatedPayload),
+      ).toThrowError(OperationIntegrityError);
+    });
   });
 
   describe('accepts legitimate ops (no false positives)', () => {
@@ -102,6 +121,23 @@ describe('assertDecryptedOpMetadataIntegrity', () => {
       const op = createOp({ entityId: undefined });
       expect(() =>
         assertDecryptedOpMetadataIntegrity(op, { id: 'task-123' }),
+      ).not.toThrow();
+    });
+
+    it('passes a genuine array-entity LWW op (payload.id matches entityId)', () => {
+      const op = createOp({
+        actionType: toLwwUpdateActionType('PLUGIN_USER_DATA'),
+        entityType: 'PLUGIN_USER_DATA',
+        entityId: 'sync-md',
+      });
+      const authenticatedPayload = {
+        actionPayload: { id: 'sync-md', data: '{}' },
+        entityChanges: [],
+        lwwUpdateMode: 'replace',
+      };
+
+      expect(() =>
+        assertDecryptedOpMetadataIntegrity(op, authenticatedPayload),
       ).not.toThrow();
     });
   });

--- a/src/app/op-log/sync/verify-decrypted-op-integrity.ts
+++ b/src/app/op-log/sync/verify-decrypted-op-integrity.ts
@@ -209,13 +209,14 @@ export const assertDecryptedOpMetadataIntegrity = (
   // Derive the target from actionType because it chooses the reducer branch;
   // op.entityType is unauthenticated metadata and must not grant an exemption.
   //
-  // Scope is adapter-only ON PURPOSE and stays tied to the reducer: only the
-  // adapter branch of lwwUpdateMetaReducer addresses an entity BY `payload.id`,
-  // so only adapters can be retargeted by a tampered id. Singleton LWW replaces a
-  // whole feature slice (id irrelevant) and map/array LWW ops are not applied by
-  // that reducer at all — none carry a canonical `payload.id` to protect. If the
-  // reducer ever learns to apply a map/array LWW update by payload identity, this
-  // gate must be widened in lockstep or the retarget defense would not cover it.
+  // Scope stays tied to the reducer: the adapter branch AND (since #9526) the
+  // array branch of lwwUpdateMetaReducer address an entity BY `payload.id`, so
+  // both can be retargeted by a tampered id and are in scope via
+  // isLwwPayloadIdCanonical. Singleton LWW replaces a whole feature slice (id
+  // irrelevant) and map LWW ops are not applied by that reducer at all — no
+  // canonical `payload.id` to protect. If the reducer ever learns to apply a
+  // map LWW update by payload identity, this gate must be widened in lockstep
+  // or the retarget defense would not cover it.
   if (!op.entityId || !isLwwPayloadIdCanonical(lwwEntityType)) {
     return;
   }

--- a/src/app/plugins/util/plugin-iframe.util.spec.ts
+++ b/src/app/plugins/util/plugin-iframe.util.spec.ts
@@ -456,15 +456,41 @@ describe('handlePluginMessage()', () => {
       expect(html).toContain('<div id="app"></div>');
     });
 
-    it('injects the API bridge script (with the bridge token) before </body>', () => {
+    it('injects the API bridge script (with the bridge token) into <head>', () => {
       const html = buildPluginIframeHtml({
         ...createConfig(pluginBridge),
         indexHtml: '<html><head></head><body></body></html>',
       });
       expect(html).toContain('const bridgeToken = "test-bridge-token"');
       expect(html).toContain('window.PluginAPI');
-      // script is injected inside the body, before its closing tag
-      expect(html.indexOf('window.PluginAPI')).toBeLessThan(html.indexOf('</body>'));
+      expect(html.indexOf('window.PluginAPI')).toBeLessThan(html.indexOf('</head>'));
+    });
+
+    // #9526: classic (non-defer) plugin scripts execute at parse time — the API
+    // must already exist by then, or plugins fall into local fallbacks that
+    // silently bypass sync.
+    it('defines window.PluginAPI before any plugin script runs', () => {
+      const html = buildPluginIframeHtml({
+        ...createConfig(pluginBridge),
+        indexHtml:
+          '<html><head><script>window.PluginAPI.getTasks();</script></head>' +
+          '<body><script>window.PluginAPI.showSnack({});</script></body></html>',
+      });
+      const apiDefinition = html.indexOf('window.PluginAPI = {');
+      expect(apiDefinition).toBeGreaterThan(-1);
+      expect(apiDefinition).toBeLessThan(html.indexOf('window.PluginAPI.getTasks()'));
+      expect(apiDefinition).toBeLessThan(html.indexOf('window.PluginAPI.showSnack({})'));
+    });
+
+    it('prepends the API script for fragment HTML without a <head>', () => {
+      const html = buildPluginIframeHtml({
+        ...createConfig(pluginBridge),
+        indexHtml: '<div id="app"></div><script>window.PluginAPI.getTasks();</script>',
+      });
+      expect(html).toContain('<div id="app"></div>');
+      expect(html.indexOf('window.PluginAPI = {')).toBeLessThan(
+        html.indexOf('window.PluginAPI.getTasks()'),
+      );
     });
   });
 

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -320,7 +320,9 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
                 try {
                   handler(data.payload);
                 } catch (error) {
-                  PluginLog.err('Hook handler error:', error);
+                  // console, not PluginLog: this runs inside the iframe, where
+                  // the host's PluginLog global does not exist.
+                  console.error('Plugin hook handler error:', error);
                 }
               });
             }
@@ -557,6 +559,15 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
  * Build the full HTML document for a plugin UI iframe: the plugin's index.html
  * with the host CSS and the postMessage API bridge injected.
  *
+ * The API script is injected at the START of <head>, before any plugin markup,
+ * so `window.PluginAPI` exists synchronously for every plugin script —
+ * including classic inline/blocking scripts that run at parse time. It was
+ * previously appended before </body>, which left parse-time plugin code
+ * without the API and pushed plugins into local-storage fallbacks that
+ * silently bypass sync (#9526). The script only touches `window` /
+ * `window.parent` (no DOM access), so running it before <body> exists is safe;
+ * the host's only reaction to the (now earlier) READY message is a log line.
+ *
  * Returned as a string for `iframe.srcdoc`, NOT a `blob:` URL: srcdoc is parsed
  * inline, so there is no blob URL lifecycle to track and revoke. The iframe is
  * same-origin with the host (see PLUGIN_IFRAME_SANDBOX — `allow-same-origin` is
@@ -568,28 +579,19 @@ export const buildPluginIframeHtml = (config: PluginIframeConfig): string => {
   const fullCssInjection =
     cssInjection + (config.manifest.uiKit !== false ? PLUGIN_UI_KIT_CSS : '');
 
-  // Inject CSS at start of head so plugin styles come later and win by source order
-  let html = config.indexHtml;
+  // CSS first (at start of head, so plugin styles come later and win by source
+  // order), then the API script — both before any plugin content.
+  const headInjection = fullCssInjection + apiScript;
+  const html = config.indexHtml;
   const headMatch = html.match(/<head[^>]*>/i);
 
   if (headMatch) {
     const insertPos = headMatch.index! + headMatch[0].length;
-    html = html.slice(0, insertPos) + fullCssInjection + html.slice(insertPos);
-  } else {
-    // If no head tag, inject at beginning
-    html = fullCssInjection + html;
+    return html.slice(0, insertPos) + headInjection + html.slice(insertPos);
   }
-
-  // Inject API script before closing body tag
-  const bodyEnd = html.toLowerCase().lastIndexOf('</body>');
-
-  if (bodyEnd !== -1) {
-    html = html.slice(0, bodyEnd) + apiScript + html.slice(bodyEnd);
-  } else {
-    html = html + apiScript;
-  }
-
-  return html;
+  // No head tag: prepend — srcdoc fragments execute scripts in document order,
+  // so the API script still runs before any plugin script.
+  return headInjection + html;
 };
 
 /**

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -25,6 +25,9 @@ import {
 } from '../../../features/simple-counter/simple-counter.model';
 import { convertOpToAction } from '../../../op-log/apply/operation-converter.util';
 import { ActionType, Operation, OpType } from '../../../op-log/core/operation.types';
+import { PLUGIN_USER_DATA_FEATURE_NAME } from '../../../plugins/store/plugin-user-data.reducer';
+import { BOARDS_FEATURE_NAME } from '../../../features/boards/store/boards.reducer';
+import { REMINDER_FEATURE_NAME } from '../../../features/reminder/store/reminder.reducer';
 
 describe('lwwUpdateMetaReducer', () => {
   const mockReducer = jasmine.createSpy('reducer');
@@ -4270,6 +4273,282 @@ describe('lwwUpdateMetaReducer', () => {
       const updatedState = mockReducer.calls.mostRecent().args[0] as Partial<RootState>;
       const updatedTask = updatedState[TASK_FEATURE_NAME]?.entities[TASK_ID] as Task;
       expect(updatedTask.dueDay).toBeNull();
+    });
+  });
+
+  // Regression #9526: conflict resolution produces `[PLUGIN_USER_DATA] LWW Update`
+  // (and BOARD/REMINDER/PLUGIN_METADATA) ops since v18.10.0, but the reducer only
+  // supported singleton + adapter patterns — array-entity winners were silently
+  // dropped on every receiving client ("Unsupported storage pattern").
+  describe('array entity LWW Updates (#9526)', () => {
+    const PLUGIN_ID = 'sync-md';
+    const BOARD_ID = 'board1';
+    const REMINDER_ID = 'reminder1';
+
+    const createMockStateWithArrayEntities = (): Partial<RootState> =>
+      ({
+        ...createMockState(),
+        [PLUGIN_USER_DATA_FEATURE_NAME]: [
+          { id: PLUGIN_ID, data: '{"v":1}' },
+          { id: 'other-plugin', data: 'untouched' },
+        ],
+        [BOARDS_FEATURE_NAME]: {
+          boardCfgs: [
+            { id: BOARD_ID, title: 'Old Board', cols: 2, panels: [] },
+            { id: 'board2', title: 'Other Board', cols: 1, panels: [] },
+          ],
+        },
+        [REMINDER_FEATURE_NAME]: [
+          { id: REMINDER_ID, type: 'TASK', relatedId: TASK_ID, remindAt: 1000 },
+        ],
+      }) as unknown as Partial<RootState>;
+
+    beforeEach(() => {
+      // Prevent devError from throwing (it calls alert + confirm -> throws if true)
+      if (!jasmine.isSpy(window.alert)) {
+        spyOn(window, 'alert');
+      }
+      if (!jasmine.isSpy(window.confirm)) {
+        spyOn(window, 'confirm').and.returnValue(false);
+      } else {
+        (window.confirm as jasmine.Spy).and.returnValue(false);
+      }
+    });
+
+    it('should replace an existing PLUGIN_USER_DATA item in place', () => {
+      const state = createMockStateWithArrayEntities();
+      const action = {
+        type: '[PLUGIN_USER_DATA] LWW Update',
+        id: PLUGIN_ID,
+        data: '{"v":2}',
+        meta: {
+          isPersistent: true,
+          entityType: 'PLUGIN_USER_DATA',
+          entityId: PLUGIN_ID,
+          isRemote: true,
+          lwwUpdateMode: 'replace',
+        },
+      };
+
+      reducer(state, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      const items = updatedState[PLUGIN_USER_DATA_FEATURE_NAME] as Array<
+        Record<string, unknown>
+      >;
+      expect(items).toEqual([
+        { id: PLUGIN_ID, data: '{"v":2}' },
+        { id: 'other-plugin', data: 'untouched' },
+      ]);
+    });
+
+    it('should append a missing item on replace (recreate after local delete)', () => {
+      const state = createMockStateWithArrayEntities();
+      const action = {
+        type: '[PLUGIN_USER_DATA] LWW Update',
+        id: 'new-plugin',
+        data: '{"fresh":true}',
+        meta: {
+          isPersistent: true,
+          entityType: 'PLUGIN_USER_DATA',
+          entityId: 'new-plugin',
+          isRemote: true,
+          lwwUpdateMode: 'replace',
+        },
+      };
+
+      reducer(state, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      const items = updatedState[PLUGIN_USER_DATA_FEATURE_NAME] as Array<
+        Record<string, unknown>
+      >;
+      expect(items.length).toBe(3);
+      expect(items[2]).toEqual({ id: 'new-plugin', data: '{"fresh":true}' });
+    });
+
+    it('should shallow-merge into an existing item in patch mode', () => {
+      const state = createMockStateWithArrayEntities();
+      const action = {
+        type: '[BOARD] LWW Update',
+        id: BOARD_ID,
+        title: 'Patched Board',
+        meta: {
+          isPersistent: true,
+          entityType: 'BOARD',
+          entityId: BOARD_ID,
+          isRemote: true,
+          lwwUpdateMode: 'patch',
+        },
+      };
+
+      reducer(state, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      const boards = updatedState[BOARDS_FEATURE_NAME] as {
+        boardCfgs: Array<Record<string, unknown>>;
+      };
+      expect(boards.boardCfgs[0]).toEqual({
+        id: BOARD_ID,
+        title: 'Patched Board',
+        cols: 2,
+        panels: [],
+      });
+      expect(boards.boardCfgs[1]).toEqual({
+        id: 'board2',
+        title: 'Other Board',
+        cols: 1,
+        panels: [],
+      });
+    });
+
+    it('should ignore a patch for an absent item instead of inserting a partial one', () => {
+      const state = createMockStateWithArrayEntities();
+      const action = {
+        type: '[BOARD] LWW Update',
+        id: 'gone-board',
+        title: 'Partial Delta',
+        meta: {
+          isPersistent: true,
+          entityType: 'BOARD',
+          entityId: 'gone-board',
+          isRemote: true,
+          lwwUpdateMode: 'patch',
+        },
+      };
+
+      reducer(state, action);
+
+      expect(mockReducer).toHaveBeenCalledWith(state, action);
+    });
+
+    it('should replace an item inside a keyed array feature state (BOARD.boardCfgs)', () => {
+      const state = createMockStateWithArrayEntities();
+      const action = {
+        type: '[BOARD] LWW Update',
+        id: BOARD_ID,
+        title: 'New Board',
+        cols: 3,
+        panels: [],
+        meta: {
+          isPersistent: true,
+          entityType: 'BOARD',
+          entityId: BOARD_ID,
+          isRemote: true,
+          lwwUpdateMode: 'replace',
+        },
+      };
+
+      reducer(state, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      const boards = updatedState[BOARDS_FEATURE_NAME] as {
+        boardCfgs: Array<Record<string, unknown>>;
+      };
+      expect(boards.boardCfgs[0]).toEqual({
+        id: BOARD_ID,
+        title: 'New Board',
+        cols: 3,
+        panels: [],
+      });
+      expect(boards.boardCfgs.length).toBe(2);
+    });
+
+    it('should replace an item when the feature state IS the array (REMINDER)', () => {
+      const state = createMockStateWithArrayEntities();
+      // NOTE: the wire payload carries Reminder.type, but the action
+      // representation shadows it with the action type — the reducer must
+      // preserve the existing item's `type` rather than dropping the field.
+      const action = {
+        type: '[REMINDER] LWW Update',
+        id: REMINDER_ID,
+        relatedId: TASK_ID,
+        remindAt: 2000,
+        meta: {
+          isPersistent: true,
+          entityType: 'REMINDER',
+          entityId: REMINDER_ID,
+          isRemote: true,
+          lwwUpdateMode: 'replace',
+        },
+      };
+
+      reducer(state, action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      const reminders = updatedState[REMINDER_FEATURE_NAME] as Array<
+        Record<string, unknown>
+      >;
+      expect(reminders.length).toBe(1);
+      expect(reminders[0]['remindAt']).toBe(2000);
+      expect(reminders[0]['id']).toBe(REMINDER_ID);
+      expect(reminders[0]['type']).toBe('TASK');
+    });
+
+    it('should pass through when the payload has no id', () => {
+      const state = createMockStateWithArrayEntities();
+      const action = {
+        type: '[PLUGIN_USER_DATA] LWW Update',
+        data: 'no id here',
+        meta: {
+          isPersistent: true,
+          entityType: 'PLUGIN_USER_DATA',
+          isRemote: true,
+          lwwUpdateMode: 'replace',
+        },
+      };
+
+      reducer(state, action);
+
+      expect(mockReducer).toHaveBeenCalledWith(state, action);
+    });
+
+    it('should apply a real PLUGIN_USER_DATA op end-to-end via convertOpToAction', () => {
+      const state = createMockStateWithArrayEntities();
+      // Exact op shape shipped producers emit (createLWWUpdateOp since v18.10.0)
+      const op: Operation = {
+        id: 'op-plugin-lww',
+        actionType: '[PLUGIN_USER_DATA] LWW Update' as ActionType,
+        opType: OpType.Update,
+        entityType: 'PLUGIN_USER_DATA',
+        entityId: PLUGIN_ID,
+        payload: {
+          actionPayload: { id: PLUGIN_ID, data: '{"v":9}' },
+          entityChanges: [],
+          lwwUpdateMode: 'replace',
+        },
+        clientId: 'clientB',
+        vectorClock: { clientB: 7 },
+        timestamp: 1700000000000,
+        schemaVersion: 1,
+      };
+
+      const action = convertOpToAction(op);
+      reducer(state, action as unknown as Action);
+
+      const updatedState = mockReducer.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      const items = updatedState[PLUGIN_USER_DATA_FEATURE_NAME] as Array<
+        Record<string, unknown>
+      >;
+      expect(items[0]).toEqual({ id: PLUGIN_ID, data: '{"v":9}' });
     });
   });
 });

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.spec.ts
@@ -4411,6 +4411,32 @@ describe('lwwUpdateMetaReducer', () => {
       });
     });
 
+    it('should skip a replace-mode REMINDER recreate for an absent item (required `type` cannot survive the action envelope)', () => {
+      const state = createMockStateWithArrayEntities();
+      // A full replace snapshot as produced by conflict resolution — but the
+      // flat action envelope shadows the entity's `type` field, so appending
+      // this would create a Reminder that fails typia validation on the next
+      // hydration. The item must stay deleted instead.
+      const action = {
+        type: '[REMINDER] LWW Update',
+        id: 'deleted-reminder',
+        relatedId: TASK_ID,
+        remindAt: 2000,
+        title: 'recreated',
+        meta: {
+          isPersistent: true,
+          entityType: 'REMINDER',
+          entityId: 'deleted-reminder',
+          isRemote: true,
+          lwwUpdateMode: 'replace',
+        },
+      };
+
+      reducer(state, action);
+
+      expect(mockReducer).toHaveBeenCalledWith(state, action);
+    });
+
     it('should ignore a patch for an absent item instead of inserting a partial one', () => {
       const state = createMockStateWithArrayEntities();
       const action = {

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.ts
@@ -445,13 +445,31 @@ const filterOrphanedTaskIdsFromEntityData = (
  *   payloads merge and replace produce the same result.
  * - A missing item is appended for `'replace'` snapshots (the delete-vs-update
  *   heal, mirroring the adapter recreate path) but skipped for `'patch'` deltas
- *   — a partial delta cannot recreate a schema-valid item.
+ *   — a partial delta cannot recreate a schema-valid item. Types listed in
+ *   ARRAY_RECREATE_UNSAFE_ENTITY_TYPES are skipped in BOTH modes: for them
+ *   even a full snapshot cannot recreate a schema-valid item.
  * - No `modified` stamping: these models have no such field and a stray key
  *   would fail typia validation on hydration.
  *
  * Returns undefined when the update cannot be applied (caller passes the state
  * through unchanged).
  */
+/**
+ * Array entities whose model has a schema-REQUIRED field named `type` or
+ * `meta`. The flat action envelope shadows those keys (see convertOpToAction),
+ * so a recreate-append could only ever produce an item that fails typia
+ * validation on the next hydration — the "Repair attempted but failed"
+ * dead-end that RECREATE_FALLBACK exists to prevent for adapter entities
+ * (SIMPLE_COUNTER precedent). Skipping the append instead is deterministic
+ * (pure reducer, every client skips identically) and safe: the item stays
+ * deleted on this client while the updating device keeps its copy — the same
+ * accepted divergence shape as SIMPLE_COUNTER's documented `type` limitation.
+ * A RECREATE_FALLBACK entry is deliberately NOT the fix: membership there
+ * also opts the type into SPAP-14 disjoint-merge, and inventing a Reminder
+ * `type` would misfire notifications rather than heal anything.
+ */
+const ARRAY_RECREATE_UNSAFE_ENTITY_TYPES: ReadonlySet<string> = new Set(['REMINDER']);
+
 const applyArrayEntityLwwUpdate = (options: {
   rootState: RootState;
   featureName: string;
@@ -479,6 +497,14 @@ const applyArrayEntityLwwUpdate = (options: {
   const index = items.findIndex((item) => (item as { id?: unknown })?.id === id);
   if (index === -1 && options.lwwUpdateMode === 'patch') {
     OpLog.log(`lwwUpdateMetaReducer: Ignoring ${entityType} patch for absent item ${id}`);
+    return undefined;
+  }
+  if (index === -1 && ARRAY_RECREATE_UNSAFE_ENTITY_TYPES.has(entityType)) {
+    OpLog.warn(
+      `lwwUpdateMetaReducer: Skipping ${entityType} recreate for absent item — ` +
+        'the action envelope cannot carry its required `type` field, so the ' +
+        'appended item would fail schema validation',
+    );
     return undefined;
   }
   const updatedItems =

--- a/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/lww-update.meta-reducer.ts
@@ -4,6 +4,7 @@ import { RootState } from '../../root-state';
 import {
   getEntityConfig,
   isAdapterEntity,
+  isArrayEntity,
   isSingletonEntity,
 } from '../../../op-log/core/entity-registry';
 import { getLwwEntityType } from '../../../op-log/core/lww-update-action-types';
@@ -429,6 +430,69 @@ const filterOrphanedTaskIdsFromEntityData = (
 };
 
 /**
+ * Applies an LWW Update to an array-pattern feature state (BOARD, REMINDER,
+ * PLUGIN_USER_DATA, PLUGIN_METADATA): items live in a plain array — the feature
+ * state itself for `arrayKey: null`, else under `arrayKey` — addressed by their
+ * `id` field. Before #9526 these ops fell into the "Unsupported storage
+ * pattern" bail and every conflict winner for these entities was silently
+ * dropped on receiving clients.
+ *
+ * Semantics vs the adapter branch:
+ * - An existing item is shallow-MERGED in both modes. Entity fields named
+ *   `type` or `meta` cannot survive the action representation (the action
+ *   envelope shadows them — e.g. `Reminder.type`), so a raw replace would
+ *   silently drop them; these models are fixed-shape, so for real full-snapshot
+ *   payloads merge and replace produce the same result.
+ * - A missing item is appended for `'replace'` snapshots (the delete-vs-update
+ *   heal, mirroring the adapter recreate path) but skipped for `'patch'` deltas
+ *   — a partial delta cannot recreate a schema-valid item.
+ * - No `modified` stamping: these models have no such field and a stray key
+ *   would fail typia validation on hydration.
+ *
+ * Returns undefined when the update cannot be applied (caller passes the state
+ * through unchanged).
+ */
+const applyArrayEntityLwwUpdate = (options: {
+  rootState: RootState;
+  featureName: string;
+  featureState: unknown;
+  arrayKey: string | null | undefined;
+  entityType: string;
+  entityData: Record<string, unknown>;
+  lwwUpdateMode?: LwwUpdateMode;
+}): RootState | undefined => {
+  const { rootState, featureName, featureState, arrayKey, entityType, entityData } =
+    options;
+  const id = entityData['id'];
+  if (typeof id !== 'string' || !id) {
+    OpLog.warn(`lwwUpdateMetaReducer: ${entityType} LWW Update payload has no id`);
+    return undefined;
+  }
+  const items =
+    arrayKey === null || arrayKey === undefined
+      ? featureState
+      : (featureState as Record<string, unknown>)[arrayKey];
+  if (!Array.isArray(items)) {
+    OpLog.warn(`lwwUpdateMetaReducer: ${entityType} feature state is not an array`);
+    return undefined;
+  }
+  const index = items.findIndex((item) => (item as { id?: unknown })?.id === id);
+  if (index === -1 && options.lwwUpdateMode === 'patch') {
+    OpLog.log(`lwwUpdateMetaReducer: Ignoring ${entityType} patch for absent item ${id}`);
+    return undefined;
+  }
+  const updatedItems =
+    index === -1
+      ? [...items, entityData]
+      : items.map((item, i) => (i === index ? { ...item, ...entityData } : item));
+  const updatedFeatureState =
+    arrayKey === null || arrayKey === undefined
+      ? updatedItems
+      : { ...(featureState as Record<string, unknown>), [arrayKey]: updatedItems };
+  return { ...rootState, [featureName]: updatedFeatureState };
+};
+
+/**
  * Meta-reducer that handles LWW (Last-Write-Wins) Update actions.
  *
  * When a LWW conflict is resolved and local state wins, a `[ENTITY_TYPE] LWW Update`
@@ -560,6 +624,24 @@ export const lwwUpdateMetaReducer: MetaReducer = (
       return reducer(updatedState, action);
     }
 
+    // Array entities (#9526): BOARD, REMINDER, PLUGIN_USER_DATA, PLUGIN_METADATA.
+    if (isArrayEntity(config)) {
+      const updatedState = applyArrayEntityLwwUpdate({
+        rootState,
+        featureName,
+        featureState,
+        arrayKey: config.arrayKey,
+        entityType,
+        entityData,
+        lwwUpdateMode: actionMeta?.lwwUpdateMode,
+      });
+      return reducer(updatedState ?? state, action);
+    }
+
+    // Only 'map' (PLANNER) remains unsupported: its LWW wire payload is a
+    // spread string[] day (numeric keys, no real `id` addressing), so applying
+    // it needs a producer-side payload redesign first — tracked separately
+    // from #9526.
     if (!isAdapterEntity(config)) {
       OpLog.warn(`lwwUpdateMetaReducer: Unsupported storage pattern for: ${entityType}`);
       devError(`lwwUpdateMetaReducer: Unsupported storage pattern for: ${entityType}`);


### PR DESCRIPTION
Closes #9526

## Root cause

Since v18.10.0 migrated `PLUGIN_USER_DATA` / `PLUGIN_METADATA` from the retired `'virtual'` storage pattern to `'array'`, conflict resolution has been producing `[ENTITY_TYPE] LWW Update` ops for array entities that **no receiver could apply**: `lwwUpdateMetaReducer` only had `singleton` and `adapter` branches, so every array-entity conflict winner (BOARD, REMINDER, PLUGIN_USER_DATA, PLUGIN_METADATA) hit the `Unsupported storage pattern` warning and was silently dropped — permanent cross-client divergence. The issue's own logs show these dead ops being replayed on every boot.

A second, independent bug hid the symptom further: the PluginAPI bridge script was injected before `</body>`, so plugin scripts reading `window.PluginAPI` at parse time saw `undefined`.

## Changes

- **`fix(sync)`: array-entity branch in `lwwUpdateMetaReducer`** — resolves the item list via the registry's `arrayKey` (`null` ⇒ the feature state *is* the array), addresses items by payload `id`, shallow-merges existing items in both modes (protects fields shadowed by the flat action envelope, e.g. `Reminder.type`), appends absent items for `replace` snapshots (delete-vs-update heal), skips `patch` deltas for absent items.
- **Integrity lockstep (GHSA-8pxh-mgc7-gp3g)** — `isLwwPayloadIdCanonical` widened to `adapter || array`, so the encrypted-op gate now fail-closed-verifies `payload.id === op.entityId` for array LWW ops, and the converter forces the id on the receiver. Producers already forced it (`!isSingletonEntityId` branch), so **nothing changes on the wire**.
- **`fix(sync)`: REMINDER recreate guard** — recreate-appends are skipped for REMINDER: the action envelope cannot carry its required `type` field, so an appended item could never be schema-valid (deterministic pure-reducer skip; same accepted-divergence shape as the documented SIMPLE_COUNTER limitation).
- **`fix(plugins)`: PluginAPI bridge injected at the start of `<head>`** (prepend fallback for headless fragments), so `window.PluginAPI` exists before any plugin script parses. Also fixes a latent `PluginLog.err` → `console.error` in the generated iframe script.
- **`test(e2e)`** — two-client SuperSync spec (seed → concurrent writes → LWW winner propagates → convergence) and an iframe spec pinning parse-time `PluginAPI` availability.

No schema bump (rule 10): receiver-side only. Old clients degrade exactly as before (warn + drop). PLANNER (`map`) remains intentionally unsupported — its LWW wire payload has no real id addressing.

## Risk call-outs

- **Fail-closed widening**: an encrypted array LWW op with a mismatched/missing `payload.id` now aborts the download batch instead of being silently dropped by the reducer. Three independent reviewers traced every shipped producer path: array payloads are sourced by `item.id === entityId` (even pre-id-forcing v18.10–v18.14), so no genuine op can trip it. Accepted deliberately — fail-closed is the correct posture for the tamper defense; if a support case ever shows this signature, the fix is server-side row cleanup, not loosening the gate.
- **actionType-swap vector** (pre-existing, documented OPEN pending AAD binding): its destination set grows with this PR — a compromised server could retag an authenticated LWW payload at an array entity. Payload content stays authenticated (only the user's own snapshots can be redirected). Follow-up: carry the entity type inside the authenticated envelope and verify when present.
- **Accepted divergence**: REMINDER recreate skip means a reminder deleted locally stays deleted while the updating device keeps its copy — deterministic and logged.

## Testing

- Unit tests written failing-first (6 failing before the meta-reducer fix); suites green: lww-update meta-reducer 144, integrity gate 33, entity registry 37, conflict resolution 240, iframe util 19.
- Iframe e2e verified failing-first against the pre-fix injection.
- SuperSync two-client spec dispatched on this branch: https://github.com/super-productivity/super-productivity/actions/runs/31818125855 (`E2E Tests (Scheduled)`, grep `SuperSync Plugin User Data`).
- A six-perspective multi-agent review (correctness, security, architecture, alternatives, performance, simplicity) found no critical issues; polish items (JSDoc placement, `<header>` regex false-positive, e2e helper no-op wait) are queued as a follow-up commit.

Note: `458dc040cb` (`chore(git)`: `.env` ignore hardening) rides on this branch as an isolated, unrelated commit.
