### PR TITLE
fix(search): reveal tasks hidden inside collapsed containers (#8780)

### DIFF
--- a/e2e/tests/search/global-search-collapsed-section-8780.spec.ts
+++ b/e2e/tests/search/global-search-collapsed-section-8780.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import type { Page } from '@playwright/test';
+
+/**
+ * Companion to `global-search-collapsed-subtask-8780.spec.ts` for the OTHER
+ * container that removes a task from the DOM: a collapsed section.
+ *
+ * Sections render through the same `collapsible` (`@if (isExpanded)`), so a task
+ * inside a collapsed one has no `#t-<id>` node and the reveal can only expire —
+ * the reported symptom, in the default (non-customized) view.
+ *
+ * This one matters more than the parent case does: expanding a section is a
+ * PERSISTED, op-log-synced write (`updateSection`), so it must be proven against
+ * the real reducers and the real render path rather than a spy. Hence a live
+ * test even though the fixture needs store seeding.
+ *
+ * Section membership is seeded via dispatch because there is no UI path to it
+ * other than drag-and-drop — same reasoning, and same `__e2eTestHelpers.store`
+ * mechanism, as `global-search-orphan-8780.spec.ts`. Everything after the seed
+ * (collapsing, searching, clicking) is real UI.
+ *
+ * The seed actions carry no `meta`, so op-log capture skips them: the seed proves
+ * the reducer and the render path, not the sync path. That is fine here, because
+ * the write under test — `updateSection` from the reveal — is dispatched by the
+ * app itself and does carry real meta.
+ */
+const seedSectionContaining = async (
+  page: Page,
+  opts: { taskId: string; sectionId: string; title: string },
+): Promise<void> => {
+  await page.evaluate(({ taskId, sectionId, title }) => {
+    const store = (
+      window as unknown as {
+        __e2eTestHelpers: { store: { dispatch: (a: unknown) => void } };
+      }
+    ).__e2eTestHelpers.store;
+
+    // Sections are valid for projects and the singleton TODAY tag; the work
+    // view starts on TODAY, so that is the context this must belong to.
+    store.dispatch({
+      type: '[Section] Add Section',
+      section: {
+        id: sectionId,
+        contextId: 'TODAY',
+        contextType: 'TAG',
+        title,
+        taskIds: [],
+        isExpanded: true,
+      },
+    });
+    store.dispatch({
+      type: '[Section] Add Task to Section',
+      sectionId,
+      taskId,
+      afterTaskId: null,
+      sourceSectionId: null,
+    });
+  }, opts);
+};
+
+test.describe('Global Search — collapsed section (#8780)', () => {
+  test('reveals a task inside a collapsed section', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    const taskName = `${testPrefix}-TaskInSection`;
+    const sectionTitle = `${testPrefix}-Section`;
+    await workViewPage.addTask(taskName);
+
+    const taskEl = taskPage.getTaskByText(taskName);
+    await expect(taskEl).toBeVisible();
+    const taskId = await taskEl.evaluate((el: HTMLElement) => {
+      const host = el.closest('task') ?? el;
+      return (host as HTMLElement).dataset.taskId ?? '';
+    });
+    expect(taskId).toBeTruthy();
+
+    await seedSectionContaining(page, {
+      taskId,
+      sectionId: `${testPrefix}-section-id`,
+      title: sectionTitle,
+    });
+
+    const section = page.locator('collapsible').filter({ hasText: sectionTitle });
+    const taskRow = page.locator(`task[data-task-id="${taskId}"]`);
+    await expect(taskRow).toBeVisible();
+
+    // Collapse it through the real UI, then confirm the premise: the row is not
+    // merely hidden, it is gone from the DOM.
+    await section.locator('.collapsible-header').first().click();
+    await expect(taskRow).toHaveCount(0);
+
+    await page.keyboard.press('Shift+F');
+    await expect(page).toHaveURL(/\/#\/search$/);
+    await page.locator('search-page .search-field input').fill(taskName);
+    const result = page
+      .locator('search-page mat-list-item')
+      .filter({ hasText: taskName });
+    await expect(result).toHaveCount(1);
+    await result.click();
+
+    await expect(taskRow).toBeVisible();
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.id ?? ''))
+      .toBe(`t-${taskId}`);
+  });
+
+  /**
+   * The two reveals that write SYNCED ops live in different components and run at
+   * different times — `showSubTasks` in NavigateToTaskService before the route
+   * change, `updateSection` in WorkViewComponent on a retry tick afterwards. Each
+   * is covered alone; this is the only check that one navigation drives BOTH, and
+   * that neither undoes or blocks the other.
+   *
+   * Stacking them is not contrived: sections group top-level tasks, and a task
+   * with subtasks is exactly what ends up in one.
+   */
+  test('reveals a subtask whose parent is collapsed inside a collapsed section', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    const parentName = `${testPrefix}-SectionedParent`;
+    const subTaskName = `${testPrefix}-DoublyHidden`;
+    const sectionTitle = `${testPrefix}-OuterSection`;
+    await workViewPage.addTask(parentName);
+
+    const parentTask = taskPage.getTaskByText(parentName);
+    await expect(parentTask).toBeVisible();
+    const parentId = await parentTask.evaluate((el: HTMLElement) => {
+      const host = el.closest('task') ?? el;
+      return (host as HTMLElement).dataset.taskId ?? '';
+    });
+    expect(parentId).toBeTruthy();
+
+    await parentTask.focus();
+    await page.keyboard.press('a');
+    const draftInput = parentTask.locator('.e2e-add-subtask-input');
+    await expect(draftInput).toBeFocused();
+    await draftInput.fill(subTaskName);
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Escape');
+
+    const subTask = parentTask.locator('.sub-tasks task').first();
+    await expect(subTask).toBeVisible();
+    const subTaskId = await subTask.evaluate(
+      (el: HTMLElement) => el.dataset.taskId ?? '',
+    );
+    expect(subTaskId).toBeTruthy();
+    const subTaskRow = page.locator(`task[data-task-id="${subTaskId}"]`);
+
+    // Hide #1: collapse the parent.
+    await parentTask.locator('.toggle-sub-tasks-btn').click();
+    await expect(parentTask.locator('.sub-tasks task')).toHaveCount(0);
+
+    // Hide #2: put the parent in a section and collapse that too, so even the
+    // parent row is gone and expanding only the parent would not be enough.
+    await seedSectionContaining(page, {
+      taskId: parentId,
+      sectionId: `${testPrefix}-outer-section-id`,
+      title: sectionTitle,
+    });
+    const section = page.locator('collapsible').filter({ hasText: sectionTitle });
+    await section.locator('.collapsible-header').first().click();
+    await expect(page.locator(`task[data-task-id="${parentId}"]`)).toHaveCount(0);
+
+    await page.keyboard.press('Shift+F');
+    await expect(page).toHaveURL(/\/#\/search$/);
+    await page.locator('search-page .search-field input').fill(subTaskName);
+    const result = page
+      .locator('search-page mat-list-item')
+      .filter({ hasText: subTaskName });
+    await expect(result).toHaveCount(1);
+    await result.click();
+
+    await expect(subTaskRow).toBeVisible();
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.id ?? ''))
+      .toBe(`t-${subTaskId}`);
+  });
+});

--- a/src/app/core-ui/navigate-to-task/navigate-to-task.service.spec.ts
+++ b/src/app/core-ui/navigate-to-task/navigate-to-task.service.spec.ts
@@ -349,7 +349,11 @@ describe('NavigateToTaskService', () => {
     );
   });
 
-  it('opens the backlog when navigating to a subtask whose parent is there', async () => {
+  // Asserts the param only. It does NOT prove the task ends up focused: the
+  // backlog renders outside `#splitTopEl`, which both reveal loops require, so a
+  // backlog row is shown but never scrolled to. Pre-existing gap, see the note in
+  // `_focusTaskElement`. (#8780)
+  it('sends isInBacklog when navigating to a subtask whose parent is in the backlog', async () => {
     const parent = createTask({
       id: 'backlog-parent',
       projectId: 'p1',
@@ -496,6 +500,32 @@ describe('NavigateToTaskService', () => {
       await service.navigate(child.id);
 
       expect(taskService.showSubTasks).toHaveBeenCalledOnceWith('parent-1');
+    });
+
+    it('expands for an out-of-enum hide mode, which the template still hides', async () => {
+      // The template binds `isHideAll="!!t._hideSubTasksMode"`, so ANY truthy
+      // value hides the subtask. A strict `=== HideAll` check would miss legacy
+      // or corrupt values and leave the reveal failing exactly as it did before.
+      const child = setUpSubTask({
+        _hideSubTasksMode: 99 as unknown as HideSubTasksMode,
+      });
+
+      await service.navigate(child.id);
+
+      expect(taskService.showSubTasks).toHaveBeenCalledWith('parent-1');
+    });
+
+    it('expands in the same-context branch too, where no route change happens', async () => {
+      // The expansion runs before the same-context check, so it must apply on
+      // the branch that only polls the DOM instead of routing.
+      router.url = '/project/p1/tasks';
+      const child = setUpSubTask({ _hideSubTasksMode: HideSubTasksMode.HideAll });
+
+      await service.navigate(child.id);
+
+      expect(router.navigate).not.toHaveBeenCalled();
+      expect(taskService.showSubTasks).toHaveBeenCalledWith('parent-1');
+      expect(layoutService.focusTaskInViewWhenReady).toHaveBeenCalled();
     });
 
     it('leaves an already expanded parent alone', async () => {

--- a/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
+++ b/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
@@ -231,14 +231,22 @@ export class NavigateToTaskService {
     if (parent?.id !== task.parentId) {
       return;
     }
-    // `filterDoneTasks` exempts the currently TRACKED task from HideAll, so that
-    // one row renders even inside a collapsed parent. Without this check the
-    // tracked-task pill — which navigates to exactly that task — would expand
+    // Mirrors `filterDoneTasks` together with the bindings that feed it
+    // (`task.component.html`: isHideDone = mode === HideDone, isHideAll = !!mode,
+    // and isHideDone wins): HideDone drops only done subtasks, any OTHER truthy
+    // mode keeps just the currently TRACKED one. That exemption is why the
+    // tracked-task pill — which navigates to exactly that task — must not expand
     // the parent on every device to reveal a row already on screen.
+    //
+    // Reading `!!mode` rather than `=== HideAll` matters for legacy or
+    // out-of-enum values: the template hides those rows, but a strict enum check
+    // would decide nothing was wrong and the reveal would fail exactly as it did
+    // before this fix.
+    const mode = parent._hideSubTasksMode;
     const isHiddenByParent =
-      (parent._hideSubTasksMode === HideSubTasksMode.HideAll &&
-        this._currentTaskId() !== task.id) ||
-      (parent._hideSubTasksMode === HideSubTasksMode.HideDone && task.isDone);
+      mode === HideSubTasksMode.HideDone
+        ? task.isDone
+        : !!mode && this._currentTaskId() !== task.id;
     if (!isHiddenByParent) {
       return;
     }
@@ -296,6 +304,34 @@ export class NavigateToTaskService {
   }
 
   private _focusTaskElement(taskId: string): void {
+    // KNOWN GAP: this branch gets the collapsed-parent reveal above and nothing
+    // else. The other containers that can drop a row from the DOM — customizer
+    // group, section, and the done/overdue/later panels — are opened by
+    // WorkViewComponent off the `focusItem` query param, which only the
+    // route-change branch sets.
+    //
+    // (The backlog is a separate, pre-existing gap on BOTH branches: `isInBacklog`
+    // opens the split, but `#splitBottomEl` is a sibling of `#splitTopEl`, and both
+    // reveal loops require the row to live inside their container. A backlog task
+    // therefore becomes visible but is never scrolled to or focused.)
+    //
+    // This is NOT the reported bug: global search runs from `/search`, so it never
+    // matches the same-context check above and always routes. The cost lands on the
+    // in-app callers (tracked-task pill, notification actions, issue creation,
+    // calendar events), and it fails loudly through the snack below.
+    //
+    // Worst case there: a subtask whose parent is collapsed AND which sits inside
+    // a collapsed section. The parent reveal above has already written its synced
+    // op by then, so the user gets a cross-device write for a navigation that then
+    // visibly fails. Accepted rather than reordered, because running the parent
+    // reveal before the branch split is what makes it work on both paths.
+    //
+    // Re-routing here with `focusItem` is not the fix: the router default is
+    // `onSameUrlNavigation: 'ignore'` (see `provideRouter` in main.ts), so a second
+    // navigation to the same task would emit nothing at all. Closing this means one
+    // reveal path for both branches — consolidating the three retry loops that
+    // already compete here, rather than adding a fourth participant. (#8780)
+    //
     // Never swallow silently: if the task never becomes focusable in the current
     // context, surface the error instead of leaving the user on the wrong view.
     this._layoutService.focusTaskInViewWhenReady(taskId, undefined, () => {

--- a/src/app/features/work-view/work-view.component.html
+++ b/src/app/features/work-view/work-view.component.html
@@ -137,6 +137,10 @@
               }
             </div>
           }
+          <!-- Keep this @if chain and the panels below in lockstep with
+               _expandCollapsedContainerFor(): the search reveal has to open
+               whichever container holds the target, and it mirrors these
+               conditions to know which ones are on screen. (#8780) -->
           @if (customizedUndoneTasks(); as customized) {
             @if (customized.grouped) {
               @for (

--- a/src/app/features/work-view/work-view.component.spec.ts
+++ b/src/app/features/work-view/work-view.component.spec.ts
@@ -1,5 +1,11 @@
-import { TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import { ElementRef, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
@@ -33,6 +39,13 @@ import {
 } from '../../root-store/app-state/app-state.selectors';
 import { CalendarIntegrationService } from '../calendar-integration/calendar-integration.service';
 import { TODAY_TAG } from '../tag/tag.const';
+import { LS } from '../../core/persistence/storage-keys.const';
+
+/** Shape the customizer emits, narrowed to what these specs vary. */
+type CustomizedStub = {
+  list: TaskWithSubTasks[];
+  grouped?: Record<string, TaskWithSubTasks[]>;
+};
 
 /**
  * Tests for the constructor effect() in WorkViewComponent that deselects the
@@ -46,6 +59,138 @@ import { TODAY_TAG } from '../tag/tag.const';
 
 const buildTask = (id: string, subTasks: TaskWithSubTasks[] = []): TaskWithSubTasks =>
   ({ id, subTasks }) as unknown as TaskWithSubTasks;
+
+type ServiceStub = Record<string, unknown>;
+
+/**
+ * Mutable so a spec can switch work context after the TestBed is configured —
+ * the component reads `activeWorkContextId` as a plain property, and a spread
+ * would freeze the value at configuration time.
+ */
+const activeContext = { id: 'ctx' };
+
+/**
+ * One TestBed setup for the whole file: each block overrides only the stub
+ * members it exercises, and everything else stays the minimal surface the
+ * component touches while constructing.
+ */
+const configureWorkViewTestBed = (
+  overrides: {
+    taskService?: ServiceStub;
+    customizerService?: ServiceStub;
+    sectionService?: ServiceStub;
+    queryParams$?: Observable<Record<string, string>>;
+    /** Drives `isOnTodayList()`, which gates the Overdue/Later Today panels. */
+    isTodayList?: boolean;
+    /** Plugin id embedded in the work-view body; replaces the whole task list. */
+    embedPluginId?: string | null;
+  } = {},
+): void => {
+  const workContextService = {
+    get activeWorkContextId(): string {
+      return activeContext.id;
+    },
+    undoneTasks$: of([]),
+    todayRemainingInProject$: of(0),
+    estimateRemainingToday$: of(0),
+    workingToday$: of(0),
+    breakTimeToday$: of(0),
+    isTodayList$: of(overrides.isTodayList ?? false),
+    activeWorkContextId$: of('ctx'),
+    activeWorkContextTypeAndId$: of({ activeType: 'PROJECT', activeId: 'ctx' }),
+    activeWorkContext$: of({ id: 'ctx', type: 'PROJECT' }),
+    isActiveWorkContextProject$: of(true),
+    isContextChanging$: of(false),
+  };
+
+  // Reset the shared mutable context: a block that switched it to TODAY would
+  // otherwise decide the starting context of every later block, since Jasmine
+  // randomizes spec order.
+  activeContext.id = 'ctx';
+
+  TestBed.configureTestingModule({
+    imports: [WorkViewComponent, TranslateModule.forRoot()],
+    providers: [
+      provideNoopAnimations(),
+      provideMockStore({ initialState: {} }),
+      {
+        provide: TaskService,
+        useValue: {
+          selectedTaskId: signal<string | null>(null),
+          setSelectedId: () => {},
+          moveToArchive: () => Promise.resolve(),
+          ...overrides.taskService,
+        },
+      },
+      { provide: TakeABreakService, useValue: { resetTimer: () => {} } },
+      {
+        provide: LayoutService,
+        useValue: {
+          isXs: signal(false),
+          isWorkViewScrolled: { set: () => {} },
+          showAddTaskBar: () => {},
+        },
+      },
+      {
+        provide: TaskViewCustomizerService,
+        useValue: {
+          customizeUndoneTasks: () => of({ list: [] as TaskWithSubTasks[] }),
+          isCustomized: signal(false),
+          ...overrides.customizerService,
+        },
+      },
+      { provide: WorkContextService, useValue: workContextService },
+      {
+        provide: PluginBridgeService,
+        useValue: {
+          workContextEmbedPluginId: signal<string | null>(
+            overrides.embedPluginId ?? null,
+          ),
+        },
+      },
+      { provide: ProjectService, useValue: { onMoveToBacklog$: of() } },
+      {
+        provide: SectionService,
+        useValue: {
+          getSectionsByContextId$: () => of([] as readonly Section[]),
+          ...overrides.sectionService,
+        },
+      },
+      { provide: SnackService, useValue: { open: () => {} } },
+      {
+        provide: CalendarIntegrationService,
+        useValue: { calendarEvents$: of([]) },
+      },
+      {
+        provide: GlobalConfigService,
+        useValue: {
+          appFeatures: signal({ isFinishDayEnabled: false }),
+          cfg: () => ({}),
+        },
+      },
+      {
+        provide: ActivatedRoute,
+        useValue: { queryParams: overrides.queryParams$ ?? of({}) },
+      },
+    ],
+  });
+
+  // Stub the template and imports so children (task-list, backlog, …) don't have
+  // to be instantiated; everything under test runs without rendering.
+  TestBed.overrideComponent(WorkViewComponent, {
+    set: { template: '', imports: [], styles: [''] },
+  });
+};
+
+/** Selector defaults every block needs. */
+const overrideDefaultSelectors = (store: MockStore): void => {
+  store.overrideSelector(selectOverdueTasksWithSubTasks, []);
+  store.overrideSelector(selectLaterTodayTasksWithSubTasks, []);
+  store.overrideSelector(selectTaskRepeatCfgsByProjectId, []);
+  store.overrideSelector(selectTaskRepeatCfgsByTagId, []);
+  store.overrideSelector(selectTodayStr, '2026-06-23');
+  store.overrideSelector(selectStartOfNextDayDiffMs, 0);
+};
 
 describe('WorkViewComponent', () => {
   let store: MockStore;
@@ -67,7 +212,6 @@ describe('WorkViewComponent', () => {
     // (a plain Subject) to exercise the sentinel/readiness guard.
     let customizeSource: () => Observable<{ list: TaskWithSubTasks[] }>;
     let isCustomized: ReturnType<typeof signal<boolean>>;
-    let activeWorkContextId: string;
 
     const createComponent = async (
       inputs: {
@@ -91,100 +235,18 @@ describe('WorkViewComponent', () => {
       customized$ = new BehaviorSubject<{ list: TaskWithSubTasks[] }>({ list: [] });
       customizeSource = () => customized$.asObservable();
       isCustomized = signal(false);
-      activeWorkContextId = 'some-project-id';
+      activeContext.id = 'some-project-id';
 
-      TestBed.configureTestingModule({
-        imports: [WorkViewComponent, TranslateModule.forRoot()],
-        providers: [
-          provideNoopAnimations(),
-          provideMockStore({ initialState: {} }),
-          {
-            provide: TaskService,
-            useValue: {
-              selectedTaskId,
-              setSelectedId,
-              moveToArchive: () => Promise.resolve(),
-            },
-          },
-          { provide: TakeABreakService, useValue: { resetTimer: () => {} } },
-          {
-            provide: LayoutService,
-            useValue: {
-              isXs: signal(false),
-              isWorkViewScrolled: { set: () => {} },
-              showAddTaskBar: () => {},
-            },
-          },
-          {
-            provide: TaskViewCustomizerService,
-            useValue: {
-              customizeUndoneTasks: () => customizeSource(),
-              isCustomized,
-            },
-          },
-          {
-            provide: WorkContextService,
-            useValue: {
-              get activeWorkContextId() {
-                return activeWorkContextId;
-              },
-              undoneTasks$: of([]),
-              todayRemainingInProject$: of(0),
-              estimateRemainingToday$: of(0),
-              workingToday$: of(0),
-              breakTimeToday$: of(0),
-              isTodayList$: of(false),
-              activeWorkContextId$: of(null),
-              activeWorkContextTypeAndId$: of({
-                activeType: 'TAG',
-                activeId: 'TODAY',
-              }),
-              activeWorkContext$: of({ id: TODAY_TAG.id, type: 'TAG' }),
-              isActiveWorkContextProject$: of(false),
-              isContextChanging$: of(false),
-            },
-          },
-          {
-            provide: PluginBridgeService,
-            useValue: { workContextEmbedPluginId: signal(null) },
-          },
-          { provide: ProjectService, useValue: { onMoveToBacklog$: of() } },
-          {
-            provide: SectionService,
-            useValue: {
-              getSectionsByContextId$: () => of([] as readonly Section[]),
-            },
-          },
-          { provide: SnackService, useValue: { open: () => {} } },
-          {
-            provide: CalendarIntegrationService,
-            useValue: { calendarEvents$: of([]) },
-          },
-          {
-            provide: GlobalConfigService,
-            useValue: {
-              appFeatures: signal({ isFinishDayEnabled: false }),
-              cfg: () => ({}),
-            },
-          },
-          { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
-        ],
-      });
-
-      // Stub the template and imports so children (task-list, backlog, etc.)
-      // don't need to be instantiated. The constructor effect runs without
-      // rendering and this keeps the dependency surface small.
-      TestBed.overrideComponent(WorkViewComponent, {
-        set: { template: '', imports: [], styles: [''] },
+      configureWorkViewTestBed({
+        taskService: { selectedTaskId, setSelectedId },
+        customizerService: {
+          customizeUndoneTasks: () => customizeSource(),
+          isCustomized,
+        },
       });
 
       store = TestBed.inject(MockStore);
-      store.overrideSelector(selectOverdueTasksWithSubTasks, []);
-      store.overrideSelector(selectLaterTodayTasksWithSubTasks, []);
-      store.overrideSelector(selectTaskRepeatCfgsByProjectId, []);
-      store.overrideSelector(selectTaskRepeatCfgsByTagId, []);
-      store.overrideSelector(selectTodayStr, '2026-06-23');
-      store.overrideSelector(selectStartOfNextDayDiffMs, 0);
+      overrideDefaultSelectors(store);
     });
 
     it('deselects when the task is absent from every list', async () => {
@@ -266,7 +328,7 @@ describe('WorkViewComponent', () => {
     });
 
     it('keeps the selection when on TODAY_TAG and task is in overdueTasks', async () => {
-      activeWorkContextId = TODAY_TAG.id;
+      activeContext.id = TODAY_TAG.id;
       store.overrideSelector(selectOverdueTasksWithSubTasks, [buildTask('overdue-1')]);
       store.refreshState();
 
@@ -278,7 +340,7 @@ describe('WorkViewComponent', () => {
     });
 
     it('deselects when NOT on TODAY_TAG even if task is in overdueTasks', async () => {
-      activeWorkContextId = 'some-project-id';
+      activeContext.id = 'some-project-id';
       store.overrideSelector(selectOverdueTasksWithSubTasks, [buildTask('overdue-1')]);
       store.refreshState();
 
@@ -312,91 +374,13 @@ describe('WorkViewComponent', () => {
       sections: Section[],
       undone: TaskWithSubTasks[],
     ): Promise<WorkViewComponent> => {
-      TestBed.configureTestingModule({
-        imports: [WorkViewComponent, TranslateModule.forRoot()],
-        providers: [
-          provideNoopAnimations(),
-          provideMockStore({ initialState: {} }),
-          {
-            provide: TaskService,
-            useValue: {
-              selectedTaskId: signal<string | null>(null),
-              setSelectedId: () => {},
-              moveToArchive: () => Promise.resolve(),
-            },
-          },
-          { provide: TakeABreakService, useValue: { resetTimer: () => {} } },
-          {
-            provide: LayoutService,
-            useValue: {
-              isXs: signal(false),
-              isWorkViewScrolled: { set: () => {} },
-              showAddTaskBar: () => {},
-            },
-          },
-          {
-            provide: TaskViewCustomizerService,
-            useValue: {
-              customizeUndoneTasks: () => of({ list: [] as TaskWithSubTasks[] }),
-              isCustomized: signal(false),
-            },
-          },
-          {
-            provide: WorkContextService,
-            useValue: {
-              activeWorkContextId: 'ctx',
-              undoneTasks$: of([]),
-              todayRemainingInProject$: of(0),
-              estimateRemainingToday$: of(0),
-              workingToday$: of(0),
-              breakTimeToday$: of(0),
-              isTodayList$: of(false),
-              activeWorkContextId$: of('ctx'),
-              activeWorkContextTypeAndId$: of({
-                activeType: 'PROJECT',
-                activeId: 'ctx',
-              }),
-              activeWorkContext$: of({ id: 'ctx', type: 'PROJECT' }),
-              isActiveWorkContextProject$: of(true),
-              isContextChanging$: of(false),
-            },
-          },
-          {
-            provide: PluginBridgeService,
-            useValue: { workContextEmbedPluginId: signal(null) },
-          },
-          { provide: ProjectService, useValue: { onMoveToBacklog$: of() } },
-          {
-            provide: SectionService,
-            useValue: {
-              getSectionsByContextId$: () => of(sections as readonly Section[]),
-            },
-          },
-          { provide: SnackService, useValue: { open: () => {} } },
-          {
-            provide: CalendarIntegrationService,
-            useValue: { calendarEvents$: of([]) },
-          },
-          {
-            provide: GlobalConfigService,
-            useValue: {
-              appFeatures: signal({ isFinishDayEnabled: false }),
-              cfg: () => ({}),
-            },
-          },
-          { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
-        ],
-      });
-      TestBed.overrideComponent(WorkViewComponent, {
-        set: { template: '', imports: [], styles: [''] },
+      configureWorkViewTestBed({
+        sectionService: {
+          getSectionsByContextId$: () => of(sections as readonly Section[]),
+        },
       });
       store = TestBed.inject(MockStore);
-      store.overrideSelector(selectOverdueTasksWithSubTasks, []);
-      store.overrideSelector(selectLaterTodayTasksWithSubTasks, []);
-      store.overrideSelector(selectTaskRepeatCfgsByProjectId, []);
-      store.overrideSelector(selectTaskRepeatCfgsByTagId, []);
-      store.overrideSelector(selectTodayStr, '2026-06-23');
-      store.overrideSelector(selectStartOfNextDayDiffMs, 0);
+      overrideDefaultSelectors(store);
 
       await TestBed.compileComponents();
       const fixture = TestBed.createComponent(WorkViewComponent);
@@ -464,157 +448,421 @@ describe('WorkViewComponent', () => {
   });
 
   /**
-   * A collapsed customizer group unmounts its whole task-list (`collapsible`
-   * renders its panel behind `@if (isExpanded)`), so a `focusItem` target inside
-   * one has no row to focus and retrying alone can never succeed. The reveal
-   * loop must expand the holding group. (#8780)
+   * A `collapsible` renders its content behind `@if (isExpanded)`, so a task in a
+   * collapsed group or section has no DOM node at all and the `focusItem` retry
+   * loop can only expire silently. Driven through the real entry point (the
+   * `focusItem` query param) so the wiring is covered, not just the helper. (#8780)
    */
-  describe('collapsed group reveal (#8780)', () => {
-    let toggleGroupExpansion: jasmine.Spy;
+  describe('focusItem reveals collapsed containers (#8780)', () => {
+    const buildCollapsibleSection = (id: string, taskIds: string[]): Section =>
+      ({
+        id,
+        title: id,
+        contextId: 'ctx',
+        contextType: 'PROJECT',
+        taskIds,
+        isExpanded: false,
+      }) as unknown as Section;
 
-    const setup = async (
-      focusItem: string | undefined,
-      grouped: Record<string, TaskWithSubTasks[]> | undefined,
-      collapsedGroupIds: string[],
-    ): Promise<void> => {
-      toggleGroupExpansion = jasmine.createSpy('toggleGroupExpansion');
-      TestBed.configureTestingModule({
-        imports: [WorkViewComponent, TranslateModule.forRoot()],
-        providers: [
-          provideNoopAnimations(),
-          provideMockStore({ initialState: {} }),
-          {
-            provide: TaskService,
-            useValue: {
-              selectedTaskId: signal<string | null>(null),
-              setSelectedId: () => {},
-              moveToArchive: () => Promise.resolve(),
-            },
-          },
-          { provide: TakeABreakService, useValue: { resetTimer: () => {} } },
-          {
-            provide: LayoutService,
-            useValue: {
-              isXs: signal(false),
-              isWorkViewScrolled: { set: () => {} },
-              showAddTaskBar: () => {},
-            },
-          },
-          {
-            provide: TaskViewCustomizerService,
-            useValue: {
-              customizeUndoneTasks: () => of({ list: [], grouped }),
-              isCustomized: signal(true),
-              collapsedGroupIds: signal(collapsedGroupIds),
-              toggleGroupExpansion,
-            },
-          },
-          {
-            provide: WorkContextService,
-            useValue: {
-              activeWorkContextId: 'ctx',
-              undoneTasks$: of([]),
-              todayRemainingInProject$: of(0),
-              estimateRemainingToday$: of(0),
-              workingToday$: of(0),
-              breakTimeToday$: of(0),
-              isTodayList$: of(false),
-              activeWorkContextId$: of('ctx'),
-              activeWorkContextTypeAndId$: of({
-                activeType: 'PROJECT',
-                activeId: 'ctx',
-              }),
-              activeWorkContext$: of({ id: 'ctx', type: 'PROJECT' }),
-              isActiveWorkContextProject$: of(true),
-              isContextChanging$: of(false),
-            },
-          },
-          {
-            provide: PluginBridgeService,
-            useValue: { workContextEmbedPluginId: signal(null) },
-          },
-          { provide: ProjectService, useValue: { onMoveToBacklog$: of() } },
-          {
-            provide: SectionService,
-            useValue: {
-              getSectionsByContextId$: () => of([] as readonly Section[]),
-            },
-          },
-          { provide: SnackService, useValue: { open: () => {} } },
-          {
-            provide: CalendarIntegrationService,
-            useValue: { calendarEvents$: of([]) },
-          },
-          {
-            provide: GlobalConfigService,
-            useValue: {
-              appFeatures: signal({ isFinishDayEnabled: false }),
-              cfg: () => ({}),
-            },
-          },
-          // The reveal loop is kicked off by this query param in ngOnInit.
-          { provide: ActivatedRoute, useValue: { queryParams: of({ focusItem }) } },
-        ],
-      });
-      TestBed.overrideComponent(WorkViewComponent, {
-        set: { template: '', imports: [], styles: [''] },
+    // The focus retry loop keeps rescheduling for ~5s; without an explicit
+    // destroy those timers outlive the spec and run against a reset MockStore.
+    let fixture: ComponentFixture<WorkViewComponent> | undefined;
+    afterEach(() => {
+      fixture?.destroy();
+      fixture = undefined;
+      // The panel signals persist to localStorage, and the component seeds them
+      // from it at construction — a spec that left one collapsed would decide
+      // the starting state of every later one under randomized spec order.
+      localStorage.removeItem(LS.DONE_TASKS_HIDDEN);
+      localStorage.removeItem(LS.OVERDUE_TASKS_HIDDEN);
+      localStorage.removeItem(LS.LATER_TODAY_TASKS_HIDDEN);
+    });
+
+    const setup = (opts: {
+      focusItem?: string;
+      queryParams$?: Observable<Record<string, string>>;
+      doneTasks?: TaskWithSubTasks[];
+      overdueTasks?: TaskWithSubTasks[];
+      laterTodayTasks?: TaskWithSubTasks[];
+      undone?: TaskWithSubTasks[];
+      grouped?: Record<string, TaskWithSubTasks[]>;
+      /** Source for the customized list, for specs where it arrives late. */
+      customized$?: Observable<CustomizedStub>;
+      collapsedGroupIds?: string[];
+      sections?: Section[];
+      /** Source for the sections, for specs where they arrive late. */
+      sections$?: Observable<readonly Section[]>;
+      /** Defaults to "grouping is the only customization", as in the app. */
+      isCustomized?: boolean;
+      isTodayList?: boolean;
+      embedPluginId?: string | null;
+    }): {
+      cmp: WorkViewComponent;
+      toggleGroupExpansion: jasmine.Spy;
+      updateSection: jasmine.Spy;
+    } => {
+      const toggleGroupExpansion = jasmine.createSpy('toggleGroupExpansion');
+      const updateSection = jasmine.createSpy('updateSection');
+      const undone = opts.undone ?? [];
+
+      configureWorkViewTestBed({
+        customizerService: {
+          customizeUndoneTasks: () =>
+            opts.customized$ ?? of({ list: undone, grouped: opts.grouped }),
+          isCustomized: signal(opts.isCustomized ?? !!(opts.grouped || opts.customized$)),
+          collapsedGroupIds: signal(opts.collapsedGroupIds ?? []),
+          toggleGroupExpansion,
+          getOrderedGroupKeys: (grouped: Record<string, TaskWithSubTasks[]>) =>
+            Object.keys(grouped),
+        },
+        sectionService: {
+          getSectionsByContextId$: () =>
+            opts.sections$ ?? of((opts.sections ?? []) as readonly Section[]),
+          updateSection,
+        },
+        queryParams$:
+          opts.queryParams$ ??
+          (opts.focusItem ? of({ focusItem: opts.focusItem }) : undefined),
+        isTodayList: opts.isTodayList,
+        embedPluginId: opts.embedPluginId,
       });
       store = TestBed.inject(MockStore);
-      store.overrideSelector(selectOverdueTasksWithSubTasks, []);
-      store.overrideSelector(selectLaterTodayTasksWithSubTasks, []);
-      store.overrideSelector(selectTaskRepeatCfgsByProjectId, []);
-      store.overrideSelector(selectTaskRepeatCfgsByTagId, []);
-      store.overrideSelector(selectTodayStr, '2026-06-23');
-      store.overrideSelector(selectStartOfNextDayDiffMs, 0);
+      overrideDefaultSelectors(store);
+      if (opts.overdueTasks) {
+        store.overrideSelector(selectOverdueTasksWithSubTasks, opts.overdueTasks);
+      }
+      if (opts.laterTodayTasks) {
+        store.overrideSelector(selectLaterTodayTasksWithSubTasks, opts.laterTodayTasks);
+      }
 
-      await TestBed.compileComponents();
-      const fixture = TestBed.createComponent(WorkViewComponent);
-      fixture.componentRef.setInput('undoneTasks', []);
-      fixture.componentRef.setInput('doneTasks', []);
+      fixture = TestBed.createComponent(WorkViewComponent);
+      fixture.componentRef.setInput('undoneTasks', undone);
+      fixture.componentRef.setInput('doneTasks', opts.doneTasks ?? []);
       fixture.componentRef.setInput('backlogTasks', []);
-      // The stubbed template renders no rows, so the focus attempt always misses
-      // — exactly the state the reveal step exists to repair.
       fixture.detectChanges();
+      return {
+        cmp: fixture.componentInstance,
+        toggleGroupExpansion,
+        updateSection,
+      };
     };
 
-    it('expands the collapsed group holding the focus target', async () => {
-      await setup('t1', { Today: [buildTask('t1')], Tomorrow: [buildTask('t2')] }, [
-        'Today',
-      ]);
+    /** Re-runs a focus attempt the way a freshly rendered split pane does. */
+    const retriggerFocusAttempt = (cmp: WorkViewComponent): void => {
+      cmp.splitTopElRef = new ElementRef(document.createElement('div'));
+    };
 
-      expect(toggleGroupExpansion).toHaveBeenCalledOnceWith('Today');
+    it('expands the collapsed group holding the focused task', () => {
+      const { toggleGroupExpansion } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted'), buildTask('other')],
+        grouped: { groupA: [buildTask('other')], groupB: [buildTask('wanted')] },
+        collapsedGroupIds: ['groupA', 'groupB'],
+      });
+
+      expect(toggleGroupExpansion).toHaveBeenCalledOnceWith('groupB');
     });
 
-    it('expands the group holding the target as a SUBTASK', async () => {
-      await setup('sub-1', { Today: [buildTask('t1', [buildTask('sub-1')])] }, ['Today']);
+    it('expands the collapsed group when the focused task is a subtask inside it', () => {
+      // The reporter's case combined with grouping: search results point at
+      // subtasks, and the group lists only their parents.
+      const parent = buildTask('parent', [buildTask('wanted-sub')]);
+      const { toggleGroupExpansion } = setup({
+        focusItem: 'wanted-sub',
+        undone: [parent],
+        grouped: { groupA: [parent] },
+        collapsedGroupIds: ['groupA'],
+      });
 
-      expect(toggleGroupExpansion).toHaveBeenCalledOnceWith('Today');
+      expect(toggleGroupExpansion).toHaveBeenCalledOnceWith('groupA');
     });
 
-    it('leaves an already expanded group alone', async () => {
-      await setup('t1', { Today: [buildTask('t1')] }, []);
+    it('ignores a stale collapsed id that resolves off Object.prototype', () => {
+      // Group keys are user-authored project/tag titles and the collapsed ids are
+      // rehydrated from localStorage, so `constructor` is a reachable value.
+      // Indexing `grouped` by it would yield a function rather than a task list.
+      const { toggleGroupExpansion } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+        grouped: { groupA: [buildTask('wanted')] },
+        collapsedGroupIds: ['constructor', 'toString'],
+      });
 
       expect(toggleGroupExpansion).not.toHaveBeenCalled();
     });
 
-    it('does nothing when the target is in no group', async () => {
-      await setup('nope', { Today: [buildTask('t1')] }, ['Today']);
+    it('does nothing when the target is in no group', () => {
+      const { toggleGroupExpansion } = setup({
+        focusItem: 'nope',
+        undone: [buildTask('wanted')],
+        grouped: { groupA: [buildTask('wanted')] },
+        collapsedGroupIds: ['groupA'],
+      });
 
       expect(toggleGroupExpansion).not.toHaveBeenCalled();
     });
 
-    it('does nothing when grouping is off', async () => {
-      await setup('t1', undefined, ['Today']);
+    it('leaves already expanded groups alone', () => {
+      const { toggleGroupExpansion } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+        grouped: { groupA: [buildTask('wanted')] },
+        collapsedGroupIds: [],
+      });
 
       expect(toggleGroupExpansion).not.toHaveBeenCalled();
     });
 
-    it('ignores a stale collapsed id that resolves off Object.prototype', async () => {
-      // Group keys are user-authored project/tag titles, so `constructor` is a
-      // reachable value. Indexing `grouped` by it would yield a function.
-      await setup('t1', { Today: [buildTask('t1')] }, ['constructor', 'toString']);
+    it('expands the collapsed section holding the focused task', () => {
+      const { updateSection } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted'), buildTask('other')],
+        sections: [
+          buildCollapsibleSection('s1', ['other']),
+          buildCollapsibleSection('s2', ['wanted']),
+        ],
+      });
+
+      expect(updateSection).toHaveBeenCalledOnceWith('s2', { isExpanded: true });
+    });
+
+    it('never expands a section while the customizer is on, since none is rendered', () => {
+      // Sort-only/filter-only customization: `grouped` is undefined but the
+      // template renders the flat list, so no section collapsible exists.
+      // Expanding one would push a synced op to every device for nothing.
+      const { updateSection } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+        isCustomized: true,
+        sections: [buildCollapsibleSection('s1', ['wanted'])],
+      });
+
+      expect(updateSection).not.toHaveBeenCalled();
+    });
+
+    it('expands the collapsed Done panel for a done task', () => {
+      // The Done/Overdue/Later panels are siblings of the undone list, so they
+      // are checked whatever it renders — and a done task hidden behind one
+      // reproduces the reported symptom exactly. Search can return done tasks
+      // via its "include completed" option.
+      const { cmp } = setup({
+        focusItem: 'done-1',
+        doneTasks: [buildTask('done-1')],
+      });
+      cmp.isDoneHidden.set(true);
+
+      retriggerFocusAttempt(cmp);
+
+      expect(cmp.isDoneHidden()).toBe(false);
+    });
+
+    it('expands the collapsed Overdue panel for an overdue task', () => {
+      const { cmp } = setup({
+        focusItem: 'overdue-1',
+        overdueTasks: [buildTask('overdue-1')],
+        isTodayList: true,
+      });
+      cmp.isOverdueHidden.set(true);
+
+      retriggerFocusAttempt(cmp);
+
+      expect(cmp.isOverdueHidden()).toBe(false);
+    });
+
+    it('expands the collapsed Later Today panel for a later-today task', () => {
+      const { cmp } = setup({
+        focusItem: 'later-1',
+        laterTodayTasks: [buildTask('later-1')],
+        isTodayList: true,
+      });
+      cmp.isLaterTodayHidden.set(true);
+
+      retriggerFocusAttempt(cmp);
+
+      expect(cmp.isLaterTodayHidden()).toBe(false);
+    });
+
+    it('leaves the Today-only panels alone outside the Today list', () => {
+      // The overdue and later-today LISTS are global, but their panels only
+      // render on Today. Flipping them from a project page would silently drop a
+      // collapse preference for a panel that is not even on screen — and could
+      // never reveal anything, since the row is not rendered here either.
+      const { cmp } = setup({
+        focusItem: 'overdue-1',
+        overdueTasks: [buildTask('overdue-1')],
+        laterTodayTasks: [buildTask('overdue-1')],
+        isTodayList: false,
+      });
+      cmp.isOverdueHidden.set(true);
+      cmp.isLaterTodayHidden.set(true);
+
+      retriggerFocusAttempt(cmp);
+
+      expect(cmp.isOverdueHidden()).toBe(true);
+      expect(cmp.isLaterTodayHidden()).toBe(true);
+    });
+
+    it('opens only the first panel that holds the task, never all of them', () => {
+      // A reveal that expanded every panel would undo collapse state the user set
+      // deliberately. Here the three lists hold different tasks; the overlap case
+      // is covered below.
+      const { cmp } = setup({
+        focusItem: 'done-1',
+        doneTasks: [buildTask('done-1')],
+        overdueTasks: [buildTask('overdue-1')],
+        laterTodayTasks: [buildTask('later-1')],
+        isTodayList: true,
+      });
+      cmp.isDoneHidden.set(true);
+      cmp.isOverdueHidden.set(true);
+      cmp.isLaterTodayHidden.set(true);
+
+      retriggerFocusAttempt(cmp);
+
+      expect(cmp.isDoneHidden()).toBe(false);
+      expect(cmp.isOverdueHidden()).toBe(true);
+      expect(cmp.isLaterTodayHidden()).toBe(true);
+    });
+
+    it('opens one panel when the task is in two lists at once', () => {
+      // The panel lists genuinely overlap, because membership matches nested
+      // subtasks and the selectors attach the whole subtask family: an undone
+      // overdue subtask of a DONE parent is in doneTasks (nested) and in
+      // overdueTasks (top-level). Opening Done alone is correct — the row renders
+      // there under its parent — but it is a choice, so pin it.
+      const doneParent = buildTask('done-parent', [buildTask('overdue-sub')]);
+      const { cmp } = setup({
+        focusItem: 'overdue-sub',
+        doneTasks: [doneParent],
+        overdueTasks: [buildTask('overdue-sub')],
+        isTodayList: true,
+      });
+      cmp.isDoneHidden.set(true);
+      cmp.isOverdueHidden.set(true);
+
+      retriggerFocusAttempt(cmp);
+
+      expect(cmp.isDoneHidden()).toBe(false);
+      expect(cmp.isOverdueHidden()).toBe(true);
+    });
+
+    it('expands nothing while a plugin embed replaces the task list', () => {
+      // `#splitTopEl` is outside the plugin `@if`, so the loop keeps its
+      // container and runs its full budget with no rows to find. Expanding here
+      // would push a synced updateSection for a section nobody can see.
+      const { cmp, updateSection } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+        sections: [buildCollapsibleSection('s1', ['wanted'])],
+        doneTasks: [buildTask('done-1')],
+        embedPluginId: 'some-plugin',
+      });
+      cmp.isDoneHidden.set(true);
+
+      retriggerFocusAttempt(cmp);
+
+      expect(updateSection).not.toHaveBeenCalled();
+      expect(cmp.isDoneHidden()).toBe(true);
+    });
+
+    it('expands the group once the grouped list arrives on a later retry', fakeAsync(() => {
+      // The customized list is deferred by one animation frame, so the first
+      // attempt sees no groups at all. Retrying is the ONLY reason this case
+      // works — the reveal has to survive data that arrives after it starts.
+      const customized$ = new BehaviorSubject<CustomizedStub>({
+        list: [buildTask('wanted')],
+      });
+      const { toggleGroupExpansion } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+        customized$,
+        collapsedGroupIds: ['groupA'],
+      });
+      expect(toggleGroupExpansion).not.toHaveBeenCalled();
+
+      customized$.next({
+        list: [buildTask('wanted')],
+        grouped: { groupA: [buildTask('wanted')] },
+      });
+      tick(250);
+
+      expect(toggleGroupExpansion).toHaveBeenCalledWith('groupA');
+      discardPeriodicTasks();
+    }));
+
+    it('expands the section once the sections arrive on a later retry', fakeAsync(() => {
+      const sections$ = new BehaviorSubject<readonly Section[]>([]);
+      const { cmp, updateSection } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+        sections$,
+      });
+      // No panel may be opened on the way: while the sections are still missing
+      // the attempt falls through to the panel checks, and this task is in none
+      // of those lists.
+      cmp.isDoneHidden.set(true);
+      expect(updateSection).not.toHaveBeenCalled();
+
+      sections$.next([buildCollapsibleSection('s1', ['wanted'])]);
+      tick(250);
+
+      expect(updateSection).toHaveBeenCalledWith('s1', { isExpanded: true });
+      expect(cmp.isDoneHidden()).toBe(true);
+      discardPeriodicTasks();
+    }));
+
+    it('stops expanding once focusItem leaves the url', fakeAsync(() => {
+      // The spy leaves collapsedGroupIds untouched, so an uncancelled loop keeps
+      // re-expanding — which is what makes this observable at all.
+      const queryParams$ = new BehaviorSubject<Record<string, string>>({
+        focusItem: 'wanted',
+      });
+      const { toggleGroupExpansion } = setup({
+        queryParams$,
+        undone: [buildTask('wanted')],
+        grouped: { groupA: [buildTask('wanted')] },
+        collapsedGroupIds: ['groupA'],
+      });
+      tick(250);
+      const callsWhileFocused = toggleGroupExpansion.calls.count();
+      expect(callsWhileFocused).toBeGreaterThan(0);
+
+      queryParams$.next({});
+      tick(2000);
+
+      expect(toggleGroupExpansion.calls.count()).toBe(callsWhileFocused);
+      discardPeriodicTasks();
+    }));
+
+    it('does not replay the reveal on a later re-mount once it has given up', fakeAsync(() => {
+      const { cmp, toggleGroupExpansion } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+        grouped: { groupA: [buildTask('wanted')] },
+        collapsedGroupIds: ['groupA'],
+      });
+      // Burn the whole retry budget (21 attempts × 250ms).
+      tick(6000);
+      const callsAfterGivingUp = toggleGroupExpansion.calls.count();
+
+      // A context change re-creates splitTopEl, which restarts a pending reveal.
+      cmp.splitTopElRef = new ElementRef(document.createElement('div'));
+      tick(6000);
+
+      expect(toggleGroupExpansion.calls.count()).toBe(callsAfterGivingUp);
+      discardPeriodicTasks();
+    }));
+
+    it('does not touch any container without a focusItem', () => {
+      const { toggleGroupExpansion, updateSection } = setup({
+        undone: [buildTask('wanted')],
+        grouped: { groupA: [buildTask('wanted')] },
+        collapsedGroupIds: ['groupA'],
+        sections: [buildCollapsibleSection('s1', ['wanted'])],
+      });
 
       expect(toggleGroupExpansion).not.toHaveBeenCalled();
+      expect(updateSection).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/features/work-view/work-view.component.ts
+++ b/src/app/features/work-view/work-view.component.ts
@@ -491,6 +491,13 @@ export class WorkViewComponent implements OnInit, OnDestroy {
           this._pendingFocusItemTaskId = params.focusItem;
           this._focusItemInWorkViewWhenReady(params.focusItem);
         } else {
+          // Cancel the chain too, not just the marker: a still-running loop
+          // would keep expanding containers for a task the user has navigated
+          // away from (e.g. the backlog shortcut drops `focusItem`).
+          if (this._pendingFocusItemTimeout) {
+            window.clearTimeout(this._pendingFocusItemTimeout);
+            this._pendingFocusItemTimeout = undefined;
+          }
           this._pendingFocusItemTaskId = null;
         }
         // NOTE: otherwise this is not triggered right away
@@ -692,15 +699,19 @@ export class WorkViewComponent implements OnInit, OnDestroy {
     }
 
     if (retriesLeft <= 0) {
+      // Give up for good: leaving the id pending would let the `splitTopEl`
+      // setter replay the whole loop on every later context change, re-opening
+      // containers the user has since collapsed by hand.
+      this._pendingFocusItemTaskId = null;
       return;
     }
 
-    // A collapsed group unmounts its whole task-list, so retrying alone would
-    // poll for a row that can never appear. Below the give-up guard: on the
-    // final attempt there is no retry left to use the expansion, and expanding
-    // then would only persist a collapse change the user never sees resolved.
-    // Idempotent — once the key leaves collapsedGroupIds it no longer matches.
-    this._expandCollapsedGroupFor(taskId);
+    // A collapsed container unmounts its whole task-list, so retrying alone
+    // would poll for a row that can never appear. Below the give-up guard: on
+    // the final attempt there is no retry left to use the expansion, and
+    // expanding then would only persist a collapse change the user never sees
+    // resolved. Idempotent — an already-expanded container no longer matches.
+    this._expandCollapsedContainerFor(taskId);
 
     this._pendingFocusItemTimeout = window.setTimeout(() => {
       this._pendingFocusItemTimeout = undefined;
@@ -708,30 +719,112 @@ export class WorkViewComponent implements OnInit, OnDestroy {
     }, WorkViewComponent._FOCUS_ITEM_RETRY_DELAY);
   }
 
-  /** Reveals a task hidden inside a collapsed customizer group. (#8780) */
-  private _expandCollapsedGroupFor(taskId: string): void {
+  /**
+   * Opens whichever collapsed container holds the target task, if any.
+   *
+   * `collapsible` renders its content behind `@if (isExpanded)`, so a collapsed
+   * container leaves the task with no DOM node at all and the retry loop above
+   * can never succeed — it just expires silently. Runs on every failed attempt
+   * because the grouped/section data can arrive after the first one; it never
+   * re-opens a container it already opened, since only containers still listed
+   * as collapsed are candidates. (#8780)
+   */
+  private _expandCollapsedContainerFor(taskId: string): void {
+    // A plugin embed replaces the entire task list, but `#splitTopEl` sits
+    // OUTSIDE that `@if` — so the loop keeps its container, runs its full budget
+    // and would expand containers that are not rendered at all, including a
+    // synced `updateSection` for a section nobody can see.
+    if (this.pluginEmbedId()) {
+      return;
+    }
+
+    if (this._expandCollapsedUndoneContainerFor(taskId)) {
+      return;
+    }
+
+    // The done/overdue/later panels are siblings of the undone list, not
+    // alternatives to it, so they are checked whatever it renders. Nothing here
+    // is synced — but the collapse state is still a preference the user set, so
+    // each check mirrors the panel's own `@if`. That matters because the overdue
+    // and later-today lists are GLOBAL while their panels are Today-only: plain
+    // membership would flip a Today panel from a project page that never shows it.
+    //
+    // These lists DO overlap: `_hasTaskInList` matches nested subtasks too, and
+    // every selector attaches the full, unfiltered subtask family — so an undone
+    // overdue subtask of a done parent sits in `doneTasks` (nested under its
+    // parent) AND in `overdueTasks` (top-level). The `else if` therefore picks a
+    // winner rather than stating an impossibility, and opening only the first
+    // match is correct: the row is rendered in that panel too.
+    if (this.isDoneHidden() && this._hasTaskInList(this.doneTasks(), taskId)) {
+      this.isDoneHidden.set(false);
+    } else if (
+      this.isShowOverduePanel() &&
+      this.isOverdueHidden() &&
+      this._hasTaskInList(this.overdueTasks(), taskId)
+    ) {
+      this.isOverdueHidden.set(false);
+    } else if (
+      this.isOnTodayList() &&
+      this.isLaterTodayHidden() &&
+      this._hasTaskInList(this.laterTodayTasks(), taskId)
+    ) {
+      this.isLaterTodayHidden.set(false);
+    }
+  }
+
+  /**
+   * The undone list renders as EITHER groups, sections or a flat list, so this
+   * half must follow the template's `@if` chain: expanding a section is a synced
+   * write, and firing it for a section that is not on screen would push a
+   * pointless op to every device. Returns whether it opened something.
+   */
+  private _expandCollapsedUndoneContainerFor(taskId: string): boolean {
+    // Same order as the template's `@if` chain: `grouped` first, sections only
+    // when there is no grouping. Testing `isCustomized()` first would diverge
+    // while the customizer is switched off — that signal flips synchronously
+    // while the grouped list lags by an animation frame, so the view would still
+    // be showing groups when this decided to expand a section.
     const grouped = this.customizedUndoneTasks().grouped;
-    if (!grouped) {
-      return;
+    if (grouped) {
+      const collapsedGroupIds = this.customizerService.collapsedGroupIds();
+      // Iterate the record's OWN keys rather than indexing it by the collapsed
+      // ids: group keys are user-authored project/tag titles, so a stale id like
+      // `constructor` would otherwise resolve off Object.prototype.
+      const groupKey = Object.keys(grouped).find(
+        (key) =>
+          collapsedGroupIds.includes(key) && this._hasTaskInList(grouped[key], taskId),
+      );
+      if (!groupKey) {
+        return false;
+      }
+      // Never log groupKey: it is a project/tag TITLE, and log history is
+      // exportable. Its index is enough to read a reporter's trace. (rule 9)
+      recordSearchNavDebug('workView:expandCollapsedGroup', {
+        taskId,
+        groupIndex: Object.keys(grouped).indexOf(groupKey),
+      });
+      this.customizerService.toggleGroupExpansion(groupKey);
+      return true;
     }
-    const collapsedGroupIds = this.customizerService.collapsedGroupIds();
-    // Iterate the record's OWN keys rather than indexing it by the collapsed
-    // ids: group keys are user-authored project/tag titles, so a stale id like
-    // `constructor` would otherwise resolve off Object.prototype.
-    const groupKey = Object.keys(grouped).find(
-      (key) =>
-        collapsedGroupIds.includes(key) && this._hasTaskInList(grouped[key], taskId),
-    );
-    if (!groupKey) {
-      return;
+
+    // `grouped` is also undefined for a sort-only/filter-only customization, and
+    // on the first attempt of a grouped view (the list is deferred by a frame).
+    // Neither renders sections.
+    if (this.customizerService.isCustomized()) {
+      return false;
     }
-    // Never log groupKey: it is a project/tag TITLE, and log history is
-    // exportable. Its index is enough to read a reporter's trace. (rule 9)
-    recordSearchNavDebug('workView:expandCollapsedGroup', {
-      taskId,
-      groupIndex: Object.keys(grouped).indexOf(groupKey),
-    });
-    this.customizerService.toggleGroupExpansion(groupKey);
+
+    const bySection = this.undoneTasksBySection();
+    for (const section of this.sections()) {
+      if (section.isExpanded) {
+        continue;
+      }
+      if (this._hasTaskInList(bySection.dict[section.id], taskId)) {
+        this.sectionService.updateSection(section.id, { isExpanded: true });
+        return true;
+      }
+    }
+    return false;
   }
 
   private _getRelativeTopWithinContainer(
@@ -761,7 +854,10 @@ export class WorkViewComponent implements OnInit, OnDestroy {
     taskList: TaskWithSubTasks[] | null | undefined,
     taskId: string,
   ): boolean {
-    if (!taskList || !taskList.length) {
+    // Array check, not just truthiness: callers index plain object literals by
+    // a key that may be stale, and an inherited Object.prototype member would
+    // otherwise reach the `for…of` below and throw.
+    if (!Array.isArray(taskList) || !taskList.length) {
       return false;
     }
 


### PR DESCRIPTION
Builds on **#9590**, which fixed the collapsed parent and the collapsed customizer group. This
covers every *other* container that hides a task from search navigation.

## Problem

Search finds a task, you click the result, and nothing happens — no navigation, no error, no focus.

Reported in **#8780** (currently **closed** — needs reopening), and confirmed from the reporter's own
`SP_SEARCH_NAV_DEBUG` trace: navigation worked perfectly — correct location resolved, route changed,
work view mounted, container present — then 20 attempts of `hasDirectMatch: false`, and silence.

## Why it recurs beyond #9590

`collapsible` renders its content behind `@if (isExpanded)`, so a task inside *any* collapsed
container has **no `#t-<id>` node at all**. The reveal loop only polls the DOM for that id, so it
cannot succeed — it just expires. #9590 taught the reveal to open a collapsed parent and a collapsed
group; the same silent failure remains for every other container.

So instead of fixing the next one that came to mind, I enumerated every gate between "task is in the
store" and "row is in the DOM":

| Container | Status | Cost of expanding |
| --- | --- | --- |
| Collapsed parent (`_hideSubTasksMode`) | #9590, hardened here | synced `updateTaskUi` |
| Customizer group | #9590 | localStorage only |
| **Section** | **this PR** | synced `updateSection` |
| **Done / Overdue / Later Today panel** | **this PR** | local signal |
| **Plugin embed replaces the list** | **this PR** — bails out | — |
| Backlog split | **not fixed** — see below | — |

## Gated on rendered, not on membership

Each reveal checks that the container is actually **on screen**, not merely that the task is in some
list. Several of these lists are broader than their containers:

- the overdue and later-today lists are **global**, but their panels render on the **Today list
  only** — plain membership would flip a Today panel from a project page that never shows it, and
  persist that to localStorage;
- the section branch mirrors the template's `@if` chain **in the same order**, so it never writes a
  synced op for a section that is not rendered;
- a plugin embed replaces the whole task list, yet `#splitTopEl` sits *outside* that `@if` — so the
  loop kept its container and would have pushed `updateSection` for a section nobody could see.

## Also fixed, found by reviewing the reveal path as a whole

- The reveal expanded containers **after** its retry budget was exhausted.
- `_pendingFocusItemTaskId` was never cleared on giving up, so the `splitTopEl` setter replayed the
  whole loop on every later context change — re-opening containers the user had since collapsed by
  hand.
- A running reveal was not cancelled when `focusItem` left the URL.
- The parent guard read `=== HideAll`, but the template hides on `!!_hideSubTasksMode` — so a legacy
  or out-of-enum value hid the row while the reveal decided nothing was wrong. That is the original
  bug, for that data.

## Testing

- **34** unit tests in `work-view.component.spec.ts`, **22** in `navigate-to-task.service.spec.ts`
- **E2E**: collapsed section, plus one stacking a collapsed parent *inside* a collapsed section —
  the only check that one navigation drives **both** synced reveals without either blocking the
  other. Verified failing without the fix.
- **Full suite green: 14244 passing.**
- **Mutation-checked**: every branch disabled in turn to confirm a test actually fails. The one
  surviving mutant is discussed below.

The section E2E seeds membership by dispatch (there is no UI path to it but drag-and-drop, same
mechanism as the existing orphan spec); everything after the seed is real UI against real reducers.

`global-search-collapsed-parent-8780.spec.ts` from an earlier revision of this branch was deleted —
#9590's `global-search-collapsed-subtask-8780.spec.ts` covers the same scenario.

## Two claims I made and then disproved

Recording these so review starts from the right premises.

- **"A task is in at most one of the done/overdue/later lists."** False. `_hasTaskInList` matches
  nested subtasks and every selector attaches the full unfiltered subtask family, so an undone
  overdue subtask of a *done* parent is in `doneTasks` (nested) and `overdueTasks` (top-level). The
  `else if` chain picks a winner rather than stating an impossibility — that choice now has a test.
  This is also why the surviving mutant survived: no test constructed an overlap, not that none
  exists.
- **"The backlog is handled by the pre-existing `isInBacklog` param."** Overstated. The param opens
  the split, but `#splitBottomEl` is a *sibling* of `#splitTopEl` and both reveal loops require the
  row inside their container — so a backlog task is made visible but never scrolled to or focused.
  Pre-existing, on both branches, **not fixed here**; documented in `_focusTaskElement`, and the
  pre-existing test whose title implied otherwise now says what it actually asserts. Inferred from
  the DOM structure and the container check, not yet reproduced end-to-end.

## Known gap (documented in code, not fixed here)

The same-context branch of `NavigateToTaskService` skips the route change, so it never sets the
`focusItem` param the work-view reveal is driven by — it gets the parent reveal only.

**Not the reported bug**: global search runs from `/search`, so it never matches the same-context
check. It costs the in-app callers (tracked-task pill, notification actions, issue creation, calendar
events), and it fails *loudly* through the existing error snack.

Re-routing with `focusItem` is not the fix — the router default is `onSameUrlNavigation: 'ignore'`,
so a repeat navigation to the same task would emit nothing. Closing it properly means one reveal path
for both branches, consolidating the three retry loops that already compete here. That is a hot-path
refactor deserving its own PR.

## Risk

- Two synced ops (`updateTaskUi`, `updateSection`) can be written as part of a navigation. They
  target different entities through different reducers with no ordering dependency, and each is the
  same op the corresponding expand button already writes. Both are guarded to fire only when the
  container is rendered and hiding the task.
- No schema change, no new dependency, no new user-facing setting.
