### PR TITLE
fix(config): commit image-input fields on blur to stop per-keystroke ops

### DIFF
--- a/src/app/util/adjust-to-live-formly-form.spec.ts
+++ b/src/app/util/adjust-to-live-formly-form.spec.ts
@@ -151,6 +151,18 @@ describe('adjustToLiveFormlyForm', () => {
       // the same branch also opts `time` into Enter-to-commit
       expect(result[0].templateOptions?.keydown).toBeDefined();
     });
+
+    // #9591: the project/tag background image URL committed per keystroke, and
+    // `updateProject` is op-log captured, so a 60-character URL emitted ~60
+    // persisted and synced ops instead of one.
+    it('should add blur update behavior to image-input fields', () => {
+      const items: FormlyFieldConfig[] = [{ key: 'imageField', type: 'image-input' }];
+
+      const result = adjustToLiveFormlyForm(items);
+
+      expect(result[0].modelOptions?.updateOn).toBe('blur');
+      expect(result[0].templateOptions?.keydown).toBeDefined();
+    });
   });
 
   describe('fieldGroup processing', () => {

--- a/src/app/util/adjust-to-live-formly-form.ts
+++ b/src/app/util/adjust-to-live-formly-form.ts
@@ -24,13 +24,21 @@ export const adjustToLiveFormlyForm = (
     // itself. For `time` that ate the first digit of every hour typed (#9548).
     // The general fix is for the config form to ignore an incoming `cfg` that
     // deep-equals what it just emitted; until then, input-like types opt in here.
+    //
+    // The cost is not always visible state loss. `image-input` is a plain text
+    // input used for the project/tag background image, and the settings dialog
+    // assigns the emitted model straight back, so no field rebuild happens
+    // there — but every keystroke still reached `updateProject`, which is
+    // op-log captured, emitting one persisted and synced op per character
+    // typed (#9591).
     if (
       item.type === 'input' ||
       item.type === 'textarea' ||
       item.type === 'duration' ||
       item.type === 'icon' ||
       item.type === 'color' ||
-      item.type === 'time'
+      item.type === 'time' ||
+      item.type === 'image-input'
     ) {
       return {
         ...item,


### PR DESCRIPTION
## Problem

Fixes #9591

`image-input` is missing from the `updateOn: 'blur'` list in `src/app/util/adjust-to-live-formly-form.ts`, so the project/tag background image field commits on every keystroke. In the settings dialog that reaches `onModelChange` → `_applyChanges` → `ProjectService.update` / `TagService.updateTag`, both of which are op-log captured, so typing a 60-character URL emits roughly 60 persisted and synced ops instead of one, plus the matching IndexedDB writes.

As the issue notes, there is no visible symptom here. The dialog assigns the emitted model straight back (`this.entityData = next`), which satisfies formly's `_modelChangeValue` guard, so the field is not re-created mid-edit and no input state is lost. This is only the write-amplification half of #9548's root cause.

## Solution

Add `image-input` to the same branch `time` was added to in #9582. One line, plus a unit spec.

**Where the fix fires:** the project/tag settings dialog builds its fields with `adjustToLiveFormlyForm(buildWorkContextSettingsFormCfg(...))` (`dialog-work-context-settings.component.ts:104`), so it picks this up. The other `image-input` site, the wallpaper dialog, builds its fields with a bare `buildWallpaperFields()` and only writes in `save()`, so it never had the per-keystroke commit and is unaffected either way.

## Verification

The new spec fails against the unfixed file with `Expected undefined to be 'blur'` and passes with it, 20/20 in that file. `tsc --noEmit` clean, `npm run checkFile` clean on both changed files.

I did not add an e2e for this one. The observable is op count rather than rendered state, and #9582's e2e was justified by visible digit loss that has no analogue here. Happy to add one if you would rather have the coverage.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing setting or API change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
