### PR TITLE
fix(work-context): reset the active context when its project is deleted

### DIFF
--- a/src/app/features/work-context/store/work-context.effects.spec.ts
+++ b/src/app/features/work-context/store/work-context.effects.spec.ts
@@ -15,6 +15,7 @@ import { WorkContextService } from '../work-context.service';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { TODAY_TAG } from '../../tag/tag.const';
 import { loadAllData } from '../../../root-store/meta/load-all-data.action';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { selectActiveContextTypeAndId } from './work-context.selectors';
 
 describe('WorkContextEffects', () => {
@@ -245,6 +246,68 @@ describe('WorkContextEffects', () => {
 
       setTimeout(() => {
         expect(emitted).toBe(false);
+        done();
+      }, 50);
+    });
+  });
+
+  describe('resetContextOnDeletedProject$', () => {
+    const deleteProject = (projectId: string): unknown =>
+      TaskSharedActions.deleteProject({ projectId, noteIds: [], allTaskIds: [] });
+
+    it('should switch to TODAY when the deleted project is the active context', (done) => {
+      store.overrideSelector(selectActiveContextTypeAndId, {
+        activeId: 'project-123',
+        activeType: WorkContextType.PROJECT,
+      });
+
+      effects.resetContextOnDeletedProject$.subscribe((action) => {
+        expect(action).toEqual(
+          setActiveWorkContext({
+            activeId: TODAY_TAG.id,
+            activeType: WorkContextType.TAG,
+          }),
+        );
+        done();
+      });
+
+      actions$.next(deleteProject('project-123'));
+    });
+
+    it('should not dispatch when another project is deleted', (done) => {
+      store.overrideSelector(selectActiveContextTypeAndId, {
+        activeId: 'project-123',
+        activeType: WorkContextType.PROJECT,
+      });
+
+      let actionDispatched = false;
+      effects.resetContextOnDeletedProject$.subscribe(() => {
+        actionDispatched = true;
+      });
+
+      actions$.next(deleteProject('some-other-project'));
+
+      setTimeout(() => {
+        expect(actionDispatched).toBe(false);
+        done();
+      }, 50);
+    });
+
+    it('should not dispatch when the active context is a tag', (done) => {
+      store.overrideSelector(selectActiveContextTypeAndId, {
+        activeId: TODAY_TAG.id,
+        activeType: WorkContextType.TAG,
+      });
+
+      let actionDispatched = false;
+      effects.resetContextOnDeletedProject$.subscribe(() => {
+        actionDispatched = true;
+      });
+
+      actions$.next(deleteProject(TODAY_TAG.id));
+
+      setTimeout(() => {
+        expect(actionDispatched).toBe(false);
         done();
       }, 50);
     });

--- a/src/app/features/work-context/store/work-context.effects.ts
+++ b/src/app/features/work-context/store/work-context.effects.ts
@@ -14,6 +14,7 @@ import { TODAY_TAG } from '../../tag/tag.const';
 import { WorkContextType } from '../work-context.model';
 import { WorkContextService } from '../work-context.service';
 import { loadAllData } from '../../../root-store/meta/load-all-data.action';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { Store } from '@ngrx/store';
 import { selectActiveContextTypeAndId } from './work-context.selectors';
 import { Log } from '../../../core/log';
@@ -65,6 +66,37 @@ export class WorkContextEffects {
       filter(
         ([, currentContext]) =>
           !currentContext || currentContext.activeId !== TODAY_TAG.id,
+      ),
+      map(() =>
+        setActiveWorkContext({
+          activeId: TODAY_TAG.id,
+          activeType: WorkContextType.TAG,
+        }),
+      ),
+    ),
+  );
+
+  /**
+   * Resets the active context when the project it points at is deleted locally.
+   *
+   * Nothing else does this: `validateContextAfterDataLoad$` below only covers
+   * `loadAllData` (sync/import), and the delete effects do config cleanup but
+   * never touch the context. Left as is, `activeWorkContextType` stays PROJECT
+   * with a dead id, so `TaskService.add()` stamps new tasks with a projectId
+   * that no longer exists and they end up in no list at all.
+   *
+   * The UI's "Delete project" navigates away before removing, so this is
+   * normally a no-op for it — except when `misc.defaultStartPage` points at the
+   * project being deleted, where its `navigateByUrl('/')` resolves right back
+   * to it and `WorkContextService` early-returns on the unchanged id.
+   */
+  resetContextOnDeletedProject$: Observable<unknown> = createEffect(() =>
+    this._actions$.pipe(
+      ofType(TaskSharedActions.deleteProject),
+      withLatestFrom(this._store$.select(selectActiveContextTypeAndId)),
+      filter(
+        ([{ projectId }, { activeType, activeId }]) =>
+          activeType === WorkContextType.PROJECT && activeId === projectId,
       ),
       map(() =>
         setActiveWorkContext({


### PR DESCRIPTION
## Problem

Deleting the project you are currently viewing can leave the app with `activeWorkContextType === PROJECT` and an id that no longer resolves. New tasks created in that state are stamped with the dead `projectId`, and `task-shared-crud.reducer.ts` skips the project-list update because the entity is gone — the task exists in task state, belongs to no project and no tag, is invisible in every list, and syncs that way.

The menu item normally dodges this by navigating to `/` before removing (`work-context-menu.component.ts:152-158`). It does not when `misc.defaultStartPage` names the project being deleted: that navigation resolves **before** the delete, so `DefaultStartPageGuard` still finds the project and routes straight back to it — its missing-project fallback to Today cannot fire yet — and `WorkContextService` then early-returns because the URL id equals the active id (`work-context.service.ts:535`).

Nothing afterwards repairs it: the reducer ignores `deleteProject`, `validateContextAfterDataLoad$` only covers `loadAllData` (sync/import, #5859), and the delete effects clean config, not the context. `ValidProjectIdGuard` is `canActivate` only, so it never re-runs on the already-active route; on the next reload it returns `false` rather than a `UrlTree` and navigation is simply cancelled, leaving a blank content area.

Split out of #9525 at the maintainer's suggestion — it is a bug on the existing UI path and does not depend on that PR's outcome.

## Solution

An effect on `TaskSharedActions.deleteProject` that switches the context to Today when the deleted project is the active one. It mirrors `validateContextAfterDataLoad$` right below it, and it covers every route into the cascade rather than only the menu item — including any future caller that deletes without navigating first.

For the ordinary menu-item path it is a no-op: the navigation has already changed the context by the time the action lands.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — no user-facing surface changes, so nothing to document
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

Three cases in `work-context.effects.spec.ts`: the active project is deleted (resets to Today), another project is deleted (no dispatch), the active context is a tag (no dispatch).

The reset test fails without the fix — with the effect's guard forced to `false` it times out waiting for the action, and passes again once restored:

```console
$ npm run test:file src/app/features/work-context/store/work-context.effects.spec.ts
# effect disabled:
Executed 17 of 17 (1 FAILED) — Error: Timeout - Async function did not complete within 2000ms
# effect restored:
Executed 17 of 17 SUCCESS
```

Full unit suite on this branch: `TOTAL: 14261 SUCCESS`.

Claude Code was used to prepare this PR; I reviewed and tested the result.
