### PR TITLE
fix(add-task-bar): stop autosize placeholder measure resetting caret

### DIFF
--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.html
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.html
@@ -25,6 +25,18 @@
             <span [class.syntax-highlight]="!!seg.type">{{ seg.text }}</span>
           }
         </div>
+        <!-- The placeholder attribute is only attached while the field is
+             empty: cdkTextareaAutosize measures a present placeholder by
+             temporarily swapping it into textarea.value (on every window
+             resize — incl. the synthetic ones for mobile keyboard show/hide —
+             and on every placeholder change), and each swap resets the caret
+             to the end, mangling mid-text typing. Without the attribute the
+             directive skips that measurement entirely; the aria-label keeps
+             the accessible name stable while the placeholder is detached. -->
+        @let inputPlaceholder =
+          isSearchMode()
+            ? (T.F.TASK.ADD_TASK_BAR.PLACEHOLDER_SEARCH | translate)
+            : (T.F.TASK.ADD_TASK_BAR.PLACEHOLDER_CREATE | translate);
         <textarea
           #inputEl
           class="main-input"
@@ -35,11 +47,8 @@
           [mentionListTemplate]="mentionListTemplate"
           (listShownChange)="updateListShown($event)"
           [matAutocomplete]="taskAutoCompleteEl"
-          [placeholder]="
-            isSearchMode()
-              ? (T.F.TASK.ADD_TASK_BAR.PLACEHOLDER_SEARCH | translate)
-              : (T.F.TASK.ADD_TASK_BAR.PLACEHOLDER_CREATE | translate)
-          "
+          [placeholder]="stateService.inputTxt() ? '' : inputPlaceholder"
+          [attr.aria-label]="inputPlaceholder"
           cdkTextareaAutosize
           cdkAutosizeMinRows="1"
           cdkAutosizeMaxRows="4"
@@ -191,6 +200,9 @@
         class="note-input-section"
         @expandFade
       >
+        <!-- Placeholder only while empty — same caret-preserving reason as the
+             main input above. -->
+        @let notePlaceholder = T.F.TASK.ADD_TASK_BAR.NOTE_PLACEHOLDER | translate;
         <textarea
           #noteEl
           class="note-input"
@@ -198,7 +210,8 @@
           cdkAutosizeMinRows="3"
           cdkAutosizeMaxRows="8"
           [(ngModel)]="stateService.noteTxt"
-          [placeholder]="T.F.TASK.ADD_TASK_BAR.NOTE_PLACEHOLDER | translate"
+          [placeholder]="stateService.noteTxt() ? '' : notePlaceholder"
+          [attr.aria-label]="notePlaceholder"
           (keydown)="onNoteKeydown($event)"
         ></textarea>
       </div>

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -1379,4 +1379,54 @@ describe('AddTaskBarComponent', () => {
       expect(inputEl.value).toBe('first line second third');
     });
   });
+
+  // cdkTextareaAutosize measures a present placeholder by temporarily swapping
+  // it into textarea.value, and each swap resets the caret to the end — so the
+  // placeholder must be detached whenever the field has text (the only time a
+  // caret position exists worth preserving).
+  describe('caret preservation via detached placeholder', () => {
+    let inputEl: HTMLTextAreaElement;
+
+    const typeText = (text: string): void => {
+      inputEl.value = text;
+      inputEl.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+    };
+
+    beforeEach(() => {
+      fixture.detectChanges();
+      inputEl = fixture.debugElement.nativeElement.querySelector('.main-input');
+    });
+
+    it('shows the placeholder only while the field is empty', () => {
+      expect(inputEl.getAttribute('placeholder')).toBeTruthy();
+
+      typeText('water the plants');
+      expect(inputEl.hasAttribute('placeholder')).toBe(false);
+
+      typeText('');
+      expect(inputEl.getAttribute('placeholder')).toBeTruthy();
+    });
+
+    it('keeps a stable accessible name while the placeholder is detached', () => {
+      const emptyLabel = inputEl.getAttribute('aria-label');
+      expect(emptyLabel).toBeTruthy();
+
+      typeText('water the plants');
+      expect(inputEl.getAttribute('aria-label')).toBe(emptyLabel);
+    });
+
+    it('keeps a mid-text caret when the placeholder-affecting search mode toggles', () => {
+      typeText('water the plants');
+      inputEl.focus();
+      inputEl.setSelectionRange(9, 9);
+
+      component.toggleSearchMode();
+      fixture.detectChanges();
+
+      expect(inputEl.value).toBe('water the plants');
+      expect(inputEl.selectionStart).toBe(9);
+      expect(inputEl.selectionEnd).toBe(9);
+    });
+  });
 });

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -1428,5 +1428,22 @@ describe('AddTaskBarComponent', () => {
       expect(inputEl.selectionStart).toBe(9);
       expect(inputEl.selectionEnd).toBe(9);
     });
+
+    it('detaches the note placeholder while the note has text', () => {
+      component.stateService.isNoteExpanded.set(true);
+      fixture.detectChanges();
+      const noteEl: HTMLTextAreaElement =
+        fixture.debugElement.nativeElement.querySelector('.note-input');
+      expect(noteEl.getAttribute('placeholder')).toBeTruthy();
+      const emptyLabel = noteEl.getAttribute('aria-label');
+      expect(emptyLabel).toBeTruthy();
+
+      noteEl.value = 'a note';
+      noteEl.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(noteEl.hasAttribute('placeholder')).toBe(false);
+      expect(noteEl.getAttribute('aria-label')).toBe(emptyLabel);
+    });
   });
 });


### PR DESCRIPTION
## Problem

The cursor in the add task bar sometimes jumps to the end of the text mid-typing, so subsequent keystrokes land in the wrong place.

## Root cause

`CdkTextareaAutosize` measures how tall the placeholder would render (`_cacheTextareaPlaceholderHeight()`) by **temporarily writing the placeholder string into `textarea.value` and writing the original text back**. Both writes collapse the selection to the end of the field (the directive's follow-up rAF `_scrollToCaretPosition` re-applies the already-destroyed selection, so it doesn't rescue it).

That measurement re-runs on:

- **every `window` resize** — including the mobile soft-keyboard showing/hiding/changing height while typing, and the synthetic resize events the app dispatches for iOS viewport changes (`global-theme.service.ts`), plus any desktop window resize, and
- **every placeholder binding change** — the search-mode toggle (Ctrl+1) swaps the placeholder text, so it alone threw the caret to the end.

Confirmed empirically by instrumenting `HTMLTextAreaElement.prototype` value/selection writes in the running app: every jump traced to `_CdkTextareaAutosize._cacheTextareaPlaceholderHeight` with the caret mid-text before and at the end after.

## Fix

Template-only: attach the `placeholder` attribute **only while the field is empty** — `[placeholder]="stateService.inputTxt() ? '' : inputPlaceholder"`. With no placeholder attribute present, the CDK short-circuits the measurement entirely (`if (!this.placeholder) { cached = 0; return; }`), so nothing can touch the caret while composing. While the field is empty the placeholder behaves exactly as before, and the swaps that still occur there are harmless (no caret position worth preserving). A stable `[attr.aria-label]` keeps the accessible name while the placeholder is detached — previously the placeholder was the field's only name source, so this is also a small a11y improvement. Same pattern applied to the note textarea.

## Verification

- **Browser probe (Playwright, instrumented prototype):** pre-fix, search toggle / resize / typing-during-resize all produced caret-destroying value swaps; post-fix, zero programmatic value writes in those scenarios and characters typed during a resize storm land at the caret. Placeholder still shows when empty and reattaches after clearing.
- **4 regression tests** in `add-task-bar.component.spec.ts`: placeholder detaches with text and reattaches when cleared (main + note field), aria-label stays stable, and a mid-text caret survives the search-mode toggle. All 4 fail against the pre-fix template (caret 16 instead of 9 — the literal bug); suite green at 64/64.
- Independent adversarial review traced the CDK source and all state transitions (init with persisted sessionStorage draft, programmatic clears, chip-pick rewrites, `auditTime(16)` resize race) — verdict: ship as-is.

## Notes

- Minor behavior change: on viewports narrow enough for the placeholder to wrap, the empty bar no longer holds the placeholder's two-line height once typing starts (it sizes to content). Arguably more correct.
- The underlying issue is upstream CDK behavior (the measurement should preserve the selection); this fix removes our exposure without private-API patching.