### PR TITLE
fix(worklog): handle current week boundaries

### DIFF
--- a/src/app/features/worklog/worklog-week/worklog-week.component.spec.ts
+++ b/src/app/features/worklog/worklog-week/worklog-week.component.spec.ts
@@ -1,0 +1,30 @@
+import { KeyValue } from '@angular/common';
+import { WorklogDay } from '../worklog.model';
+import { sortWorklogDays } from './worklog-week.component';
+
+const toKeyValue = (dateStr: string): KeyValue<string, WorklogDay> => ({
+  key: String(Number(dateStr.slice(-2))),
+  value: {
+    dateStr,
+  } as WorklogDay,
+});
+
+describe('sortWorklogDays()', () => {
+  it('sorts single-digit and double-digit days chronologically', () => {
+    expect(
+      sortWorklogDays(toKeyValue('2026-08-09'), toKeyValue('2026-08-10')),
+    ).toBeLessThan(0);
+  });
+
+  it('sorts merged days chronologically across month boundaries', () => {
+    expect(
+      sortWorklogDays(toKeyValue('2026-07-31'), toKeyValue('2026-08-01')),
+    ).toBeLessThan(0);
+  });
+
+  it('sorts merged days chronologically across year boundaries', () => {
+    expect(
+      sortWorklogDays(toKeyValue('2026-12-31'), toKeyValue('2027-01-01')),
+    ).toBeLessThan(0);
+  });
+});

--- a/src/app/features/worklog/worklog-week/worklog-week.component.ts
+++ b/src/app/features/worklog/worklog-week/worklog-week.component.ts
@@ -21,6 +21,12 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { MetricService } from '../../metric/metric.service';
 import { DialogViewArchivedTaskComponent } from '../../tasks/dialog-view-archived-task/dialog-view-archived-task.component';
 import { WorklogTaskRowComponent } from '../worklog-task-row/worklog-task-row.component';
+import { WorklogDay } from '../worklog.model';
+
+export const sortWorklogDays = (
+  a: KeyValue<string, WorklogDay>,
+  b: KeyValue<string, WorklogDay>,
+): number => a.value.dateStr.localeCompare(b.value.dateStr);
 
 @Component({
   selector: 'worklog-week',
@@ -53,9 +59,7 @@ export class WorklogWeekComponent {
   T: typeof T = T;
   keys: (o: Record<string, unknown>) => string[] = Object.keys;
 
-  sortDays<T extends KeyValue<string, V>, V = unknown>(a: T, b: T): number {
-    return b.key < a.key ? 1 : -1;
-  }
+  sortDays = sortWorklogDays;
 
   async exportData(): Promise<void> {
     const now = new Date();

--- a/src/app/features/worklog/worklog.service.spec.ts
+++ b/src/app/features/worklog/worklog.service.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { NavigationEnd, Router } from '@angular/router';
-import { BehaviorSubject, of, Subject } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, of, Subject } from 'rxjs';
 import { DateAdapter } from '@angular/material/core';
-import { WorklogService } from './worklog.service';
+import { getWorklogWeekForDate, WorklogService } from './worklog.service';
 import { WorkContextService } from '../work-context/work-context.service';
 import { DataInitStateService } from '../../core/data-init/data-init-state.service';
 import { TaskService } from '../tasks/task.service';
@@ -10,6 +10,137 @@ import { TimeTrackingService } from '../time-tracking/time-tracking.service';
 import { TaskArchiveService } from '../archive/task-archive.service';
 import { DateTimeFormatService } from 'src/app/core/date-time-format/date-time-format.service';
 import { WorkContext, WorkContextType } from '../work-context/work-context.model';
+import { Worklog, WorklogDay } from './worklog.model';
+import { DateService } from '../../core/date/date.service';
+import { parseDbDateStr } from '../../util/parse-db-date-str';
+
+const MONDAY = 1;
+const TUESDAY = 2;
+
+const createWorklog = (dateStrs: string[]): Worklog => {
+  const worklog: Worklog = {};
+
+  dateStrs.forEach((dateStr, index) => {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const worklogDay: WorklogDay = {
+      dateStr,
+      dayStr: dateStr,
+      logEntries: [],
+      timeSpent: index + 1,
+      workStart: 0,
+      workEnd: 0,
+    };
+
+    worklog[year] ??= {
+      timeSpent: 0,
+      monthWorked: 0,
+      daysWorked: 0,
+      ent: {},
+    };
+    worklog[year].ent[month] ??= {
+      timeSpent: 0,
+      daysWorked: 0,
+      ent: {},
+      weeks: [],
+    };
+    worklog[year].ent[month].ent[day] = worklogDay;
+  });
+
+  return worklog;
+};
+
+const getDateStrs = (week: ReturnType<typeof getWorklogWeekForDate>): string[] =>
+  Object.values(week?.ent ?? {})
+    .map((day) => day.dateStr)
+    .sort();
+
+describe('getWorklogWeekForDate()', () => {
+  it('returns earlier days when the current month has no worklog bucket yet', () => {
+    const worklog = createWorklog([
+      '2026-07-27',
+      '2026-07-28',
+      '2026-07-29',
+      '2026-07-30',
+      '2026-07-31',
+    ]);
+
+    const result = getWorklogWeekForDate(worklog, parseDbDateStr('2026-08-01'), MONDAY);
+
+    expect(getDateStrs(result)).toEqual([
+      '2026-07-27',
+      '2026-07-28',
+      '2026-07-29',
+      '2026-07-30',
+      '2026-07-31',
+    ]);
+    expect(result?.daysWorked).toBe(5);
+  });
+
+  it('merges the current week across a month boundary up to the selected date', () => {
+    const worklog = createWorklog([
+      '2026-07-27',
+      '2026-07-28',
+      '2026-07-29',
+      '2026-07-30',
+      '2026-07-31',
+      '2026-08-01',
+      '2026-08-02',
+    ]);
+
+    const result = getWorklogWeekForDate(worklog, parseDbDateStr('2026-08-01'), MONDAY);
+
+    expect(getDateStrs(result)).toEqual([
+      '2026-07-27',
+      '2026-07-28',
+      '2026-07-29',
+      '2026-07-30',
+      '2026-07-31',
+      '2026-08-01',
+    ]);
+    expect(result?.daysWorked).toBe(6);
+    expect(result?.timeSpent).toBe(21);
+  });
+
+  it('merges the current week across a year boundary', () => {
+    const worklog = createWorklog([
+      '2026-12-28',
+      '2026-12-29',
+      '2026-12-30',
+      '2026-12-31',
+      '2027-01-01',
+      '2027-01-02',
+    ]);
+
+    const result = getWorklogWeekForDate(worklog, parseDbDateStr('2027-01-02'), MONDAY);
+
+    expect(getDateStrs(result)).toEqual([
+      '2026-12-28',
+      '2026-12-29',
+      '2026-12-30',
+      '2026-12-31',
+      '2027-01-01',
+      '2027-01-02',
+    ]);
+    expect(result?.daysWorked).toBe(6);
+  });
+
+  it('uses the configured first day of the week', () => {
+    const worklog = createWorklog(['2026-08-03', '2026-08-04', '2026-08-05']);
+
+    const result = getWorklogWeekForDate(worklog, parseDbDateStr('2026-08-05'), TUESDAY);
+
+    expect(getDateStrs(result)).toEqual(['2026-08-04', '2026-08-05']);
+    expect(result?.daysWorked).toBe(2);
+  });
+
+  it('returns null when the current week has no worklog data', () => {
+    const worklog = createWorklog(['2026-07-31']);
+
+    const result = getWorklogWeekForDate(worklog, parseDbDateStr('2026-08-08'), MONDAY);
+
+    expect(result).toBeNull();
+  });
+});
 
 describe('WorklogService moment replacement', () => {
   describe('date string parsing', () => {
@@ -45,11 +176,19 @@ describe('WorklogService context-aware loading', () => {
   let routerEvents$: Subject<NavigationEnd>;
   let service: WorklogService;
   let loadCalls: WorkContext[];
+  let worklogToLoad: Worklog;
+  let getFirstDayOfWeek: jasmine.Spy<() => number>;
+  let getLogicalTodayDate: jasmine.Spy<() => Date>;
 
   beforeEach(() => {
     activeWorkContext$ = new BehaviorSubject<WorkContext>(ctxA);
     routerEvents$ = new Subject<NavigationEnd>();
     loadCalls = [];
+    worklogToLoad = {};
+    getFirstDayOfWeek = jasmine.createSpy().and.returnValue(TUESDAY);
+    getLogicalTodayDate = jasmine
+      .createSpy()
+      .and.returnValue(parseDbDateStr('2026-08-05'));
 
     TestBed.configureTestingModule({
       providers: [
@@ -82,7 +221,11 @@ describe('WorklogService context-aware loading', () => {
         },
         {
           provide: DateAdapter,
-          useValue: { getFirstDayOfWeek: () => 0 },
+          useValue: { getFirstDayOfWeek },
+        },
+        {
+          provide: DateService,
+          useValue: { getLogicalTodayDate },
         },
         {
           provide: DateTimeFormatService,
@@ -94,8 +237,18 @@ describe('WorklogService context-aware loading', () => {
 
     spyOn<any>(service, '_loadWorklogForWorkContext').and.callFake((ctx: WorkContext) => {
       loadCalls.push(ctx);
-      return Promise.resolve({ worklog: {}, totalTimeSpent: 0 });
+      return Promise.resolve({ worklog: worklogToLoad, totalTimeSpent: 0 });
     });
+  });
+
+  it('uses the logical date and configured week start for currentWeek$', async () => {
+    worklogToLoad = createWorklog(['2026-08-03', '2026-08-04', '2026-08-05']);
+
+    const result = await firstValueFrom(service.currentWeek$);
+
+    expect(getLogicalTodayDate).toHaveBeenCalledOnceWith();
+    expect(getFirstDayOfWeek).toHaveBeenCalledOnceWith();
+    expect(getDateStrs(result)).toEqual(['2026-08-04', '2026-08-05']);
   });
 
   it('reloads the worklog when the active context changes', async () => {

--- a/src/app/features/worklog/worklog.service.ts
+++ b/src/app/features/worklog/worklog.service.ts
@@ -28,6 +28,55 @@ import { TaskArchiveService } from '../archive/task-archive.service';
 import { getDbDateStr } from '../../util/get-db-date-str';
 import { DateTimeFormatService } from 'src/app/core/date-time-format/date-time-format.service';
 import { Log } from '../../core/log';
+import { DateService } from '../../core/date/date.service';
+
+export const getWorklogWeekForDate = (
+  worklog: Worklog,
+  relativeDate: Date,
+  firstDayOfWeek: number,
+): WorklogWeek | null => {
+  const normalizedFirstDayOfWeek = ((firstDayOfWeek % 7) + 7) % 7;
+  const rangeEnd = new Date(
+    relativeDate.getFullYear(),
+    relativeDate.getMonth(),
+    relativeDate.getDate(),
+  );
+  const daysSinceStart = (rangeEnd.getDay() - normalizedFirstDayOfWeek + 7) % 7;
+  const rangeStart = new Date(rangeEnd);
+  rangeStart.setDate(rangeStart.getDate() - daysSinceStart);
+
+  const ent: WorklogWeek['ent'] = {};
+  let daysWorked = 0;
+  let timeSpent = 0;
+
+  for (
+    const date = new Date(rangeStart);
+    date <= rangeEnd;
+    date.setDate(date.getDate() + 1)
+  ) {
+    const day =
+      worklog[date.getFullYear()]?.ent[date.getMonth() + 1]?.ent[date.getDate()];
+
+    if (day) {
+      ent[date.getDate()] = day;
+      daysWorked += 1;
+      timeSpent += day.timeSpent;
+    }
+  }
+
+  if (daysWorked === 0) {
+    return null;
+  }
+
+  return {
+    start: rangeStart.getDate(),
+    end: rangeEnd.getDate(),
+    weekNr: getWeekNumber(relativeDate, normalizedFirstDayOfWeek),
+    timeSpent,
+    daysWorked,
+    ent,
+  };
+};
 
 @Injectable({ providedIn: 'root' })
 export class WorklogService {
@@ -37,6 +86,7 @@ export class WorklogService {
   private readonly _timeTrackingService = inject(TimeTrackingService);
   private readonly _router = inject(Router);
   private readonly _dateTimeFormatService = inject(DateTimeFormatService);
+  private readonly _dateService = inject(DateService);
   private _dateAdapter = inject(DateAdapter);
   private _taskArchiveService = inject(TaskArchiveService);
 
@@ -107,17 +157,8 @@ export class WorklogService {
   );
   currentWeek$: Observable<WorklogWeek | null> = this.worklog$.pipe(
     map((worklog) => {
-      const now = new Date();
-      const year = now.getFullYear();
-      const month = now.getMonth() + 1;
-      const weekNr = getWeekNumber(now);
-
-      if (worklog[year] && worklog[year].ent[month]) {
-        return (
-          worklog[year].ent[month].weeks.find((week) => week.weekNr === weekNr) || null
-        );
-      }
-      return null;
+      const today = this._dateService.getLogicalTodayDate();
+      return getWorklogWeekForDate(worklog, today, this._dateAdapter.getFirstDayOfWeek());
     }),
   );
 


### PR DESCRIPTION
## Problem

The current-week widget called `getWeekNumber(now)` without the configured `firstDayOfWeek` and only searched the current calendar month. This omitted days when a week crossed a month or year boundary and produced the wrong week for non-Monday starts.

The day comparator also compared day-of-month keys as strings, so values such as `"10"` and `"9"` could be ordered incorrectly.

This fix is extracted from #9550 following the maintainer feedback there.

## Solution

- Calculate the current-week range using `DateService.getLogicalTodayDate()` and the configured `DateAdapter.getFirstDayOfWeek()`.
- Collect worklog days from the configured week start through logical today across month and year boundaries.
- Sort displayed days by the complete `YYYY-MM-DD` value instead of the day-of-month key.
- Add regression coverage for custom week starts, month/year boundaries, empty weeks, logical-date wiring, and single/double-digit day ordering.

This PR only changes current-week widget data and ordering. The export dialog date-range behavior is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Testing

- `npm run checkFile` for every changed TypeScript file
- `npm run test:file -- src/app/features/worklog/worklog.service.spec.ts` — 10/10 passed
- `npm run test:file -- src/app/features/worklog/worklog-week/worklog-week.component.spec.ts` — 3/3 passed
- Full lint completed with no errors. The full unit run reached 14,270 passing tests and is currently blocked by the unrelated existing CalDAV `principal-collection-set` spec, which also fails when run alone.

## Checklist

- [x] No documentation update is needed for this focused bug fix
- [x] I have run `npm run checkFile` on changed TypeScript files
- [x] I have added tests for the changes
- [x] Relevant existing tests pass
- [x] My commit message follows the Angular format