### PR TITLE
fix(sync): resolve remote RoundTimeSpentForDay multi-entity conflicts (#9601)

### DIFF
--- a/e2e/tests/sync/supersync-round-time-conflict.spec.ts
+++ b/e2e/tests/sync/supersync-round-time-conflict.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test } from '../../fixtures/supersync.fixture';
+import {
+  createTestUser,
+  getSuperSyncConfig,
+  createSimulatedClient,
+  closeClient,
+  waitForTask,
+  renameTask,
+  recordTaskTimeDelta,
+  getTaskTimeSpentFromState,
+  navigateToWorkView,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+import { expectTaskVisible } from '../../utils/supersync-assertions';
+
+/**
+ * SuperSync Round-Time-Spent Conflict E2E Test (#9601)
+ *
+ * Device A's "Finish day" rounds time spent across all of today's tasks in ONE
+ * atomic multi-task `roundTimeSpentForDay` op. When device B holds a concurrent
+ * pending edit on any of those tasks, downloading the rounding op used to stop
+ * B's sync forever with
+ * `SYNC_MULTI_ENTITY_UNSUPPORTED side=remote actionType=[Task] RoundTimeSpentForDay`.
+ *
+ * This test pins the resolved behavior: the rounding op replays atomically on B
+ * (uncontested siblings converge to the rounded value), B's newer edit wins its
+ * task via a compensation snapshot that re-uploads B's state, and both clients
+ * converge on the mixed result.
+ *
+ * Prerequisites:
+ * - super-sync-server running on localhost:1901 with TEST_MODE=true
+ * - Frontend running on localhost:4242
+ */
+
+/** Local YYYY-MM-DD — must match the browser's `todayStr` (same machine TZ). */
+const localDateStr = (): string => {
+  const d = new Date();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+};
+
+const expectExactTaskTime = async (
+  client: SimulatedE2EClient,
+  taskName: string,
+  expectedTimeSpent: number,
+): Promise<void> => {
+  await expect
+    .poll(() => getTaskTimeSpentFromState(client, taskName), {
+      timeout: 30000,
+      intervals: [250, 500, 1000],
+    })
+    .toBe(expectedTimeSpent);
+};
+
+test.describe('@supersync Round Time Spent Conflict Resolution', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  /**
+   * Scenario (mirrors the #9601 report):
+   * 1. Client A creates T1–T3 with odd tracked times, syncs
+   * 2. Client B syncs (receives tasks + times), then gets WS-blocked
+   * 3. Client A rounds UP to 5m via the daily-summary UI (ONE multi-task op), syncs
+   * 4. Client B renames T1 — a NEWER concurrent edit on a rounded task
+   * 5. Client B syncs: downloads the multi-task rounding op → conflict on T1.
+   *    Pre-fix this wedged sync forever; post-fix it resolves as mixed winners.
+   *
+   * Expected convergence on BOTH clients:
+   * - T2/T3 (uncontested): exactly the rounded 5m (300000ms)
+   * - T1 (B's edit won): renamed AND unrounded (130000ms) — B's compensation
+   *   snapshot re-uploaded its full state over A's rounding
+   */
+  test('remote multi-task rounding resolves against a concurrent edit @supersync', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    const uniqueId = Date.now();
+    const taskDate = localDateStr();
+    const time1 = 130_000; // 2m10s — stays unrounded on the conflicted task
+    const time2 = 70_000; // 1m10s → rounds UP to 5m
+    const time3 = 110_000; // 1m50s → rounds UP to 5m
+    const roundedTime = 300_000; // 5m
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      // ============ PHASE 1: Client A creates tasks with tracked time ========
+      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      const task1Name = `RoundConflict-T1-${uniqueId}`;
+      const task2Name = `RoundConflict-T2-${uniqueId}`;
+      const task3Name = `RoundConflict-T3-${uniqueId}`;
+
+      await clientA.workView.addTask(task1Name);
+      await clientA.workView.addTask(task2Name);
+      await clientA.workView.addTask(task3Name);
+      await recordTaskTimeDelta(clientA, task1Name, taskDate, time1);
+      await recordTaskTimeDelta(clientA, task2Name, taskDate, time2);
+      await recordTaskTimeDelta(clientA, task3Name, taskDate, time3);
+      await expectExactTaskTime(clientA, task1Name, time1);
+      console.log('[RoundConflict] Client A created T1–T3 with tracked time');
+
+      await clientA.sync.syncAndWait();
+      console.log('[RoundConflict] Client A synced (uploaded tasks + time)');
+
+      // ============ PHASE 2: Client B downloads tasks ========================
+      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
+      await clientB.sync.setupSuperSync(syncConfig);
+      await clientB.sync.syncAndWait();
+
+      await waitForTask(clientB.page, task1Name);
+      await waitForTask(clientB.page, task2Name);
+      await waitForTask(clientB.page, task3Name);
+      await expectExactTaskTime(clientB, task1Name, time1);
+      console.log('[RoundConflict] Client B received all tasks with time');
+
+      // Block WS-triggered downloads on Client B so it does not auto-receive
+      // A's rounding op before making its own concurrent edit (true race).
+      await clientB.page.evaluate(
+        () => ((globalThis as any).__SP_E2E_BLOCK_WS_DOWNLOAD = true),
+      );
+
+      // ============ PHASE 3: Client A rounds time via the daily summary ======
+      // Drives the real finish-day UI: ONE atomic roundTimeSpentForDay op
+      // covering all three tasks.
+      await clientA.page.goto('/#/tag/TODAY/daily-summary');
+      const roundMenuBtn = clientA.page
+        .locator('task-summary-tables button', { hasText: 'Round Time Spent' })
+        .first();
+      await roundMenuBtn.waitFor({ state: 'visible' });
+      await roundMenuBtn.click();
+      await clientA.page
+        .locator('button', { hasText: 'Round UP all tasks to 5 minutes' })
+        .click();
+      await expectExactTaskTime(clientA, task2Name, roundedTime);
+      await expectExactTaskTime(clientA, task3Name, roundedTime);
+      console.log('[RoundConflict] Client A rounded all tasks UP to 5m');
+
+      await navigateToWorkView(clientA);
+      await clientA.sync.syncAndWait();
+      console.log('[RoundConflict] Client A synced (uploaded multi-task rounding op)');
+
+      // ============ PHASE 4: Client B makes a NEWER concurrent edit ==========
+      // The rename's timestamp is newer than A's rounding, so T1 must resolve
+      // as a LOCAL win on B while T2/T3 stay uncontested remote rounding.
+      const task1Renamed = `RoundConflict-T1-edited-${uniqueId}`;
+      await renameTask(clientB, task1Name, task1Renamed);
+      console.log(`[RoundConflict] Client B renamed ${task1Name} → ${task1Renamed}`);
+
+      // ============ PHASE 5: Client B syncs (the #9601 moment) ===============
+      // Pre-fix: conflict resolution throws SYNC_MULTI_ENTITY_UNSUPPORTED
+      // side=remote and the sync spinner never completes — syncAndWait fails.
+      await clientB.page.evaluate(
+        () => ((globalThis as any).__SP_E2E_BLOCK_WS_DOWNLOAD = false),
+      );
+      await clientB.sync.syncAndWait();
+      console.log('[RoundConflict] Client B synced (conflict resolved, no wedge)');
+
+      // Convergence rounds: B uploads its compensation, A downloads it.
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
+      console.log('[RoundConflict] Extra sync rounds for convergence');
+
+      // ============ PHASE 6: Verify the mixed result on BOTH clients =========
+      await navigateToWorkView(clientA);
+      await navigateToWorkView(clientB);
+
+      // Uncontested siblings: rounded everywhere.
+      await expectExactTaskTime(clientA, task2Name, roundedTime);
+      await expectExactTaskTime(clientA, task3Name, roundedTime);
+      await expectExactTaskTime(clientB, task2Name, roundedTime);
+      await expectExactTaskTime(clientB, task3Name, roundedTime);
+      console.log('[RoundConflict] T2/T3 rounded to 5m on both clients');
+
+      // Conflicted task: B's newer edit won — renamed and unrounded on BOTH
+      // clients. The rename reaching A proves the compensation op uploaded;
+      // the unrounded time on A proves it replaced A's rounded state.
+      await waitForTask(clientB.page, task1Renamed);
+      await expectTaskVisible(clientA, task1Renamed);
+      await expectExactTaskTime(clientA, task1Renamed, time1);
+      await expectExactTaskTime(clientB, task1Renamed, time1);
+      console.log('[RoundConflict] T1 kept rename + unrounded time on both clients');
+
+      console.log(
+        '[RoundConflict] ✓ Test passed: remote multi-task rounding conflict converged',
+      );
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+});

--- a/e2e/tests/sync/supersync-round-time-conflict.spec.ts
+++ b/e2e/tests/sync/supersync-round-time-conflict.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../../fixtures/supersync.fixture';
+import { test } from '../../fixtures/supersync.fixture';
 import {
   createTestUser,
   getSuperSyncConfig,
@@ -7,7 +7,7 @@ import {
   waitForTask,
   renameTask,
   recordTaskTimeDelta,
-  getTaskTimeSpentFromState,
+  expectExactTaskTime,
   navigateToWorkView,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
@@ -38,19 +38,6 @@ const localDateStr = (): string => {
   const month = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${d.getFullYear()}-${month}-${day}`;
-};
-
-const expectExactTaskTime = async (
-  client: SimulatedE2EClient,
-  taskName: string,
-  expectedTimeSpent: number,
-): Promise<void> => {
-  await expect
-    .poll(() => getTaskTimeSpentFromState(client, taskName), {
-      timeout: 30000,
-      intervals: [250, 500, 1000],
-    })
-    .toBe(expectedTimeSpent);
 };
 
 test.describe('@supersync Round Time Spent Conflict Resolution', () => {
@@ -132,11 +119,14 @@ test.describe('@supersync Round Time Spent Conflict Resolution', () => {
       const roundMenuBtn = clientA.page
         .locator('task-summary-tables button', { hasText: 'Round Time Spent' })
         .first();
-      await roundMenuBtn.waitFor({ state: 'visible' });
       await roundMenuBtn.click();
       await clientA.page
-        .locator('button', { hasText: 'Round UP all tasks to 5 minutes' })
+        .getByRole('menuitem', { name: 'Round UP all tasks to 5 minutes' })
         .click();
+      // T1 rounding on A is the PREMISE of the conflict below: without it, B's
+      // rename would not race a rounded task and every later assertion would
+      // pass in a conflict-free run too.
+      await expectExactTaskTime(clientA, task1Name, roundedTime);
       await expectExactTaskTime(clientA, task2Name, roundedTime);
       await expectExactTaskTime(clientA, task3Name, roundedTime);
       console.log('[RoundConflict] Client A rounded all tasks UP to 5m');

--- a/e2e/tests/sync/supersync-time-tracking-advanced.spec.ts
+++ b/e2e/tests/sync/supersync-time-tracking-advanced.spec.ts
@@ -10,6 +10,7 @@ import {
   waitForTaskTimeSpent,
   getTaskTimeSpentFromState,
   markTaskDone,
+  recordTaskTimeDelta,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
 import { expectTaskVisible } from '../../utils/supersync-assertions';
@@ -17,98 +18,6 @@ import { waitForAppReady } from '../../utils/waits';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
-
-/**
- * Record an exact local time delta through the same two actions used by the
- * production timer: one updates local state, the other writes the replayable op.
- */
-const recordTaskTimeDelta = async (
-  client: SimulatedE2EClient,
-  taskName: string,
-  date: string,
-  duration: number,
-): Promise<void> => {
-  await client.page.evaluate(
-    async ({ name, taskDate, delta }) => {
-      const isRecordInPage = (value: unknown): value is Record<string, unknown> =>
-        typeof value === 'object' && value !== null;
-
-      type StoreSubscription = { unsubscribe: () => void };
-      type StoreLike = {
-        subscribe: (next: (state: unknown) => void) => StoreSubscription;
-        dispatch: (action: unknown) => void;
-      };
-
-      const store = (
-        window as unknown as {
-          __e2eTestHelpers?: { store?: StoreLike };
-        }
-      ).__e2eTestHelpers?.store;
-
-      if (!store) {
-        throw new Error('E2E store helper is unavailable');
-      }
-
-      const rootState = await new Promise<Record<string, unknown>>((resolve, reject) => {
-        const subscriptionRef: { current?: StoreSubscription } = {};
-        let isDone = false;
-        const timeoutId = window.setTimeout(() => {
-          if (!isDone) {
-            isDone = true;
-            subscriptionRef.current?.unsubscribe();
-            reject(new Error('Timed out reading the NgRx state'));
-          }
-        }, 1000);
-
-        subscriptionRef.current = store.subscribe((state) => {
-          if (isDone || !isRecordInPage(state)) {
-            return;
-          }
-          isDone = true;
-          window.clearTimeout(timeoutId);
-          window.setTimeout(() => subscriptionRef.current?.unsubscribe());
-          resolve(state);
-        });
-      });
-
-      const taskState = rootState.tasks ?? rootState.task;
-      if (!isRecordInPage(taskState) || !isRecordInPage(taskState.entities)) {
-        throw new Error('Task state is unavailable');
-      }
-
-      const task = Object.values(taskState.entities).find(
-        (value) =>
-          isRecordInPage(value) &&
-          typeof value.title === 'string' &&
-          value.title.includes(name),
-      );
-      if (!isRecordInPage(task) || typeof task.id !== 'string') {
-        throw new Error(`Task not found: ${name}`);
-      }
-
-      store.dispatch({
-        type: '[TimeTracking] Add time spent',
-        task,
-        date: taskDate,
-        duration: delta,
-        isFromTrackingReminder: false,
-      });
-      store.dispatch({
-        type: '[TimeTracking] Sync time spent',
-        taskId: task.id,
-        date: taskDate,
-        duration: delta,
-        meta: {
-          isPersistent: true,
-          entityType: 'TASK',
-          entityId: task.id,
-          opType: 'UPD',
-        },
-      });
-    },
-    { name: taskName, taskDate: date, delta: duration },
-  );
-};
 
 const expectExactTaskTime = async (
   client: SimulatedE2EClient,

--- a/e2e/tests/sync/supersync-time-tracking-advanced.spec.ts
+++ b/e2e/tests/sync/supersync-time-tracking-advanced.spec.ts
@@ -8,9 +8,9 @@ import {
   startTimeTracking,
   stopTimeTracking,
   waitForTaskTimeSpent,
-  getTaskTimeSpentFromState,
   markTaskDone,
   recordTaskTimeDelta,
+  expectExactTaskTime,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
 import { expectTaskVisible } from '../../utils/supersync-assertions';
@@ -18,19 +18,6 @@ import { waitForAppReady } from '../../utils/waits';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
-
-const expectExactTaskTime = async (
-  client: SimulatedE2EClient,
-  taskName: string,
-  expectedTimeSpent: number,
-): Promise<void> => {
-  await expect
-    .poll(() => getTaskTimeSpentFromState(client, taskName), {
-      timeout: 30000,
-      intervals: [250, 500, 1000],
-    })
-    .toBe(expectedTimeSpent);
-};
 
 /**
  * SuperSync Time Tracking Advanced E2E Tests

--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -1070,6 +1070,26 @@ export const waitForTaskTimeSpent = async (
 };
 
 /**
+ * Poll until a task's persisted timeSpent equals the exact expected value.
+ *
+ * @param client - The simulated E2E client
+ * @param taskName - The task name
+ * @param expectedTimeSpent - The expected timeSpent in milliseconds
+ */
+export const expectExactTaskTime = async (
+  client: SimulatedE2EClient,
+  taskName: string,
+  expectedTimeSpent: number,
+): Promise<void> => {
+  await expect
+    .poll(() => getTaskTimeSpentFromState(client, taskName), {
+      timeout: 30000,
+      intervals: [250, 500, 1000],
+    })
+    .toBe(expectedTimeSpent);
+};
+
+/**
  * Record an exact local time delta through the same two actions used by the
  * production timer: one updates local state, the other writes the replayable op.
  *

--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -1070,6 +1070,103 @@ export const waitForTaskTimeSpent = async (
 };
 
 /**
+ * Record an exact local time delta through the same two actions used by the
+ * production timer: one updates local state, the other writes the replayable op.
+ *
+ * @param client - The simulated E2E client
+ * @param taskName - The task name to record time on
+ * @param date - The worklog day string (YYYY-MM-DD) to book the time on
+ * @param duration - The time delta in milliseconds
+ */
+export const recordTaskTimeDelta = async (
+  client: SimulatedE2EClient,
+  taskName: string,
+  date: string,
+  duration: number,
+): Promise<void> => {
+  await client.page.evaluate(
+    async ({ name, taskDate, delta }) => {
+      const isRecordInPage = (value: unknown): value is Record<string, unknown> =>
+        typeof value === 'object' && value !== null;
+
+      type StoreSubscription = { unsubscribe: () => void };
+      type StoreLike = {
+        subscribe: (next: (state: unknown) => void) => StoreSubscription;
+        dispatch: (action: unknown) => void;
+      };
+
+      const store = (
+        window as unknown as {
+          __e2eTestHelpers?: { store?: StoreLike };
+        }
+      ).__e2eTestHelpers?.store;
+
+      if (!store) {
+        throw new Error('E2E store helper is unavailable');
+      }
+
+      const rootState = await new Promise<Record<string, unknown>>((resolve, reject) => {
+        const subscriptionRef: { current?: StoreSubscription } = {};
+        let isDone = false;
+        const timeoutId = window.setTimeout(() => {
+          if (!isDone) {
+            isDone = true;
+            subscriptionRef.current?.unsubscribe();
+            reject(new Error('Timed out reading the NgRx state'));
+          }
+        }, 1000);
+
+        subscriptionRef.current = store.subscribe((state) => {
+          if (isDone || !isRecordInPage(state)) {
+            return;
+          }
+          isDone = true;
+          window.clearTimeout(timeoutId);
+          window.setTimeout(() => subscriptionRef.current?.unsubscribe());
+          resolve(state);
+        });
+      });
+
+      const taskState = rootState.tasks ?? rootState.task;
+      if (!isRecordInPage(taskState) || !isRecordInPage(taskState.entities)) {
+        throw new Error('Task state is unavailable');
+      }
+
+      const task = Object.values(taskState.entities).find(
+        (value) =>
+          isRecordInPage(value) &&
+          typeof value.title === 'string' &&
+          value.title.includes(name),
+      );
+      if (!isRecordInPage(task) || typeof task.id !== 'string') {
+        throw new Error(`Task not found: ${name}`);
+      }
+
+      store.dispatch({
+        type: '[TimeTracking] Add time spent',
+        task,
+        date: taskDate,
+        duration: delta,
+        isFromTrackingReminder: false,
+      });
+      store.dispatch({
+        type: '[TimeTracking] Sync time spent',
+        taskId: task.id,
+        date: taskDate,
+        duration: delta,
+        meta: {
+          isPersistent: true,
+          entityType: 'TASK',
+          entityId: task.id,
+          opType: 'UPD',
+        },
+      });
+    },
+    { name: taskName, taskDate: date, delta: duration },
+  );
+};
+
+/**
  * Check if a task has the given text (exists on client).
  *
  * @param client - The simulated E2E client

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1280,6 +1280,35 @@ describe('Task Reducer', () => {
     });
   });
 
+  describe('roundTimeSpentForDay - unknown task ids (remote replay, #9601)', () => {
+    // A remote/replayed rounding op may list tasks this client has archived or
+    // deleted meanwhile. The whole op must not abort — remaining tasks round.
+    it('should skip unknown task ids and round the remaining ones', () => {
+      const state: TaskState = {
+        ...initialTaskState,
+        ids: ['t1'],
+        entities: {
+          t1: createTask('t1', {
+            subTaskIds: [],
+            timeSpentOnDay: { '2026-04-02': 70000 },
+          }),
+        },
+      };
+      const action = fromActions.roundTimeSpentForDay({
+        day: '2026-04-02',
+        taskIds: ['archived-elsewhere', 't1'],
+        isRoundUp: true,
+        roundTo: '5M',
+        projectId: undefined,
+      });
+
+      expect(() => taskReducer(state, action)).not.toThrow();
+      const result = taskReducer(state, action);
+      expect(result.entities['t1']!.timeSpentOnDay['2026-04-02']).toBe(300000);
+      expect(result.ids).toEqual(['t1']);
+    });
+  });
+
   // Regression: subtask collapse state (_hideSubTasksMode) must survive a restart.
   // It only persists if the action that writes it is captured to the op-log,
   // which requires isPersistent metadata. `updateTaskUi` carries an absolute

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -544,7 +544,12 @@ export const taskReducer = createReducer<TaskState>(
     const isLimitToProject: boolean = !!projectId || projectId === null;
 
     const idsToUpdateDirectly: string[] = taskIds.filter((id) => {
-      const task: Task = getTaskById(id, state);
+      // A remote/replayed op may list tasks this client archived or deleted
+      // meanwhile — skip them instead of aborting the whole rounding (#9601).
+      const task: Task | undefined = state.entities[id];
+      if (!task) {
+        return false;
+      }
       return (
         (task.subTaskIds.length === 0 || !!task.parentId) &&
         (!isLimitToProject || task.projectId === projectId)

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -2379,6 +2379,17 @@ export class ConflictResolutionService {
    * independent bulk deletes are re-scoped, and the local legacy rounding
    * action has an explicit per-entity reconciliation path above.
    *
+   * A REMOTE `roundTimeSpentForDay` (#9601 — "Finish day" on device A races
+   * next-morning edits on device B) resolves via the generic mixed-winner
+   * machinery: the atomic row replays once, then local-win compensation
+   * snapshots re-assert and re-upload each local winner after it. Uncontested
+   * siblings converge exactly (no concurrent ops means their values equal the
+   * sender's pre-rounding input); a remote-win target keeps rounded(local
+   * value) — a bounded divergence in the two time fields, accepted over the
+   * permanent sync wedge. Gated on the static-payload check so `entityIds`
+   * faithfully declare the replay write set: an id in `taskIds` but not
+   * `entityIds` was never conflict-checked, so that shape stays blocked.
+   *
    * The Today-list ops that used to make this reachable from ordinary use —
    * `planTasksForToday` (dispatched with every due task id by the automatic
    * day-rollover) and the ordering-only Today ops — now resolve via
@@ -2396,7 +2407,8 @@ export class ConflictResolutionService {
           isMultiEntityOperation(op) &&
           op.actionType !== ActionType.TASK_SHARED_MOVE_TO_ARCHIVE &&
           !INDEPENDENT_MULTI_DELETE_ACTIONS.has(op.actionType) &&
-          !isResolvableTodayListAction(op.actionType),
+          !isResolvableTodayListAction(op.actionType) &&
+          !isRoundTimePayloadValidForStaticFields(op),
       );
       if (unsafeRemoteOp) {
         throw new UnsupportedMultiEntityConflictError(

--- a/src/app/op-log/sync/conflict-resolution.service.ts
+++ b/src/app/op-log/sync/conflict-resolution.service.ts
@@ -339,6 +339,12 @@ const isRoundTimePayloadValidForStaticFields = (op: Operation): boolean => {
     return false;
   }
   const actionPayload = extractActionPayload(op.payload);
+  // The gate runs on remote (attacker-influenceable) input and the download
+  // path never re-validates payload shape — stay total instead of throwing a
+  // raw TypeError out of the preflight on a null/missing actionPayload.
+  if (typeof actionPayload !== 'object' || actionPayload === null) {
+    return false;
+  }
   const taskIds = actionPayload['taskIds'];
   if (
     !Array.isArray(taskIds) ||
@@ -369,6 +375,27 @@ const isRoundTimePayloadValidForStaticFields = (op: Operation): boolean => {
     declaredIds.size === operationIds.length &&
     operationIds.every((id) => declaredIds.has(id))
   );
+};
+
+/**
+ * Mirror of the rounding reducer's write filter (`roundTimeSpentForDay` in
+ * task.reducer.ts): the op declares every task id of the day, but the reducer
+ * skips parents-with-subtasks and — when the payload carries a project limit
+ * (a string id or the explicit `null` no-project bucket) — tasks of other
+ * projects. Used to spot conflict targets the replay cannot write on this
+ * client. Keep in sync with the reducer's filter.
+ */
+const doesRoundTimeOpWriteTask = (
+  op: Operation,
+  task: Record<string, unknown>,
+): boolean => {
+  const actionPayload = extractActionPayload(op.payload);
+  const projectId = actionPayload['projectId'];
+  const isLimitToProject = !!projectId || projectId === null;
+  const subTaskIds = task['subTaskIds'];
+  const isDirectlyRoundable =
+    (Array.isArray(subTaskIds) ? subTaskIds.length === 0 : true) || !!task['parentId'];
+  return isDirectlyRoundable && (!isLimitToProject || task['projectId'] === projectId);
 };
 
 const INDEPENDENT_MULTI_DELETE_ACTIONS = new Set<ActionType>([
@@ -2033,6 +2060,7 @@ export class ConflictResolutionService {
         toEntityKey(entityType as EntityType, entityId),
     });
     this._assertMultiEntityPlansAreSafe(plans);
+    await this._forceLocalWinForUnwritableRoundTimeTargets(plans);
 
     // A rejected local bulk op was already applied optimistically. If the
     // remote winner changes only part of one entity, rejecting the whole row
@@ -2371,6 +2399,54 @@ export class ConflictResolutionService {
   }
 
   /**
+   * A rounding op declares EVERY task id of the day, but its reducer writes
+   * only tasks passing the payload's project limit that are not
+   * parents-with-subtasks (`doesRoundTimeOpWriteTask`). Letting such a row
+   * resolve as a remote win would reject the local pending ops while the
+   * replay writes nothing to the entity — the local edit would stay visible
+   * on this client but silently never upload. Force those rows to LOCAL wins:
+   * the compensation snapshot re-asserts and re-uploads the local state, and
+   * the mixed-winner machinery still applies the atomic row once for its
+   * writable targets. This is not a compromise — the sender's own dispatch
+   * filtered the same ids, so the entity was never rounded anywhere.
+   *
+   * Rows whose entity is absent from the live store are left untouched:
+   * delete/archive precedence already classifies them, and no snapshot could
+   * be built for an entity that is gone.
+   */
+  private async _forceLocalWinForUnwritableRoundTimeTargets(
+    plans: LwwConflictResolutionPlan<EntityConflict>[],
+  ): Promise<void> {
+    for (const plan of plans) {
+      if (plan.winner !== 'remote' || plan.conflict.entityType !== 'TASK') {
+        continue;
+      }
+      const isRoundTimeOnlyRow =
+        plan.conflict.remoteOps.length > 0 &&
+        plan.conflict.remoteOps.every(
+          (op) =>
+            isMultiEntityOperation(op) && isRoundTimePayloadValidForStaticFields(op),
+        );
+      if (!isRoundTimeOnlyRow) {
+        continue;
+      }
+      const task = await this.getCurrentEntityState('TASK', plan.conflict.entityId);
+      if (task === null || typeof task !== 'object') {
+        continue;
+      }
+      const taskRecord = task as Record<string, unknown>;
+      if (
+        plan.conflict.remoteOps.some((op) => doesRoundTimeOpWriteTask(op, taskRecord))
+      ) {
+        continue;
+      }
+      plan.winner = 'local';
+      plan.reason = 'local-timestamp';
+      plan.localWinOperationKind = 'update';
+    }
+  }
+
+  /**
    * Generic multi-entity operations cannot be partially compensated safely.
    * Fail before op-log mutation unless every multi-entity op in the plan has an
    * explicit resolution path: bulk archives are re-created when they win
@@ -2382,13 +2458,23 @@ export class ConflictResolutionService {
    * A REMOTE `roundTimeSpentForDay` (#9601 — "Finish day" on device A races
    * next-morning edits on device B) resolves via the generic mixed-winner
    * machinery: the atomic row replays once, then local-win compensation
-   * snapshots re-assert and re-upload each local winner after it. Uncontested
-   * siblings converge exactly (no concurrent ops means their values equal the
-   * sender's pre-rounding input); a remote-win target keeps rounded(local
-   * value) — a bounded divergence in the two time fields, accepted over the
-   * permanent sync wedge. Gated on the static-payload check so `entityIds`
-   * faithfully declare the replay write set: an id in `taskIds` but not
-   * `entityIds` was never conflict-checked, so that shape stays blocked.
+   * snapshots re-assert and re-upload each local winner after it. Targets the
+   * replay cannot write on this client are forced to local wins first
+   * (`_forceLocalWinForUnwritableRoundTimeTargets`). The gate's set-equality
+   * check guarantees every DIRECT write target is conflict-checked (an id in
+   * `taskIds` but not `entityIds` would be an unchecked write, so that shape
+   * stays blocked); the reducer additionally recalculates parents of listed
+   * subtasks — undeclared, but derived-fields-only.
+   *
+   * Accepted bounded divergence, both confined to `timeSpent`/
+   * `timeSpentOnDay[day]` and chosen over the permanent sync wedge: a
+   * remote-win target keeps rounded(local value) rather than the sender's
+   * rounded value, and pre-rounding time deltas piggybacking in the SAME
+   * download batch replay after the rounding (resolution rows are appended
+   * before non-conflicting ops), yielding round(base)+delta vs the sender's
+   * round(base+delta). Degenerate histories where a local winner has no
+   * creatable compensation snapshot still fail closed via the mixed-winner
+   * "Cannot safely compensate" throw.
    *
    * The Today-list ops that used to make this reachable from ordinary use —
    * `planTasksForToday` (dispatched with every due task id by the automatic

--- a/src/app/op-log/testing/integration/round-time-conflict-convergence.integration.spec.ts
+++ b/src/app/op-log/testing/integration/round-time-conflict-convergence.integration.spec.ts
@@ -375,4 +375,117 @@ describe('round-time conflict convergence integration (#8944)', () => {
       taskSyncProjection(localState, TASK_Y),
     );
   });
+
+  it('resolves a remote rounding op overlapping a pending local archive (#9601 both-finish-day)', async () => {
+    // Both devices ran "Finish day": the remote client rounded X, Y and Z in
+    // one atomic op; this client archived X before syncing. The rounding op
+    // replays against a store where X is gone — the reducer must skip the
+    // missing id (uncontested siblings still round) instead of throwing, which
+    // the conflict path would escalate into IncompleteRemoteOperationsError
+    // and a permanently re-wedged sync.
+    const TASK_Z = 'task-z';
+    initialState = createStateWithExistingTasks([TASK_X, TASK_Y, TASK_Z]);
+    initialState = updateTaskEntity(initialState, TASK_X, {
+      title: 'Task X',
+      isDone: true,
+      timeSpent: 10 * MINUTE,
+      timeSpentOnDay: { [DAY]: 10 * MINUTE },
+    });
+    initialState = updateTaskEntity(initialState, TASK_Y, {
+      title: 'Task Y',
+      timeSpent: 20 * MINUTE,
+      timeSpentOnDay: { [DAY]: 20 * MINUTE },
+    });
+    initialState = updateTaskEntity(initialState, TASK_Z, {
+      title: 'Task Z',
+      timeSpent: 7 * MINUTE,
+      timeSpentOnDay: { [DAY]: 7 * MINUTE },
+    });
+    reducer = createReducer(initialState);
+    localState = initialState;
+
+    const capture = TestBed.inject(OperationCaptureService);
+    const resolver = TestBed.inject(ConflictResolutionService);
+    const server = new MockSyncServer();
+    const clientA = new TestClient(CLIENT_A);
+    const clientB = new TestClient(CLIENT_B);
+
+    // Remote finish day: X 10m → 15m, Y 20m → 30m, Z 7m → 15m.
+    const roundAction = roundTimeSpentForDay({
+      day: DAY,
+      taskIds: [TASK_X, TASK_Y, TASK_Z],
+      roundTo: 'QUARTER',
+      isRoundUp: true,
+    }) as PersistentAction;
+    let remoteState = reducer(initialState, roundAction);
+    const remoteRoundOp = captureOperation(roundAction, clientB, capture, 1_000);
+    server.uploadOps([remoteRoundOp], CLIENT_B);
+
+    // Local finish day (NEWER): X is done and gets bulk-archived.
+    const archiveAction = TaskSharedActions.moveToArchive({
+      tasks: [{ ...getTask(localState, TASK_X), subTasks: [] }],
+    }) as PersistentAction;
+    localState = reducer(localState, archiveAction);
+    expect(localState[TASK_FEATURE_NAME].entities[TASK_X]).toBeUndefined();
+    const localArchiveOp = captureOperation(archiveAction, clientA, capture, 2_000);
+    await opLogStore.append(localArchiveOp, 'local');
+
+    const detection = await resolver.checkOpForConflicts(remoteRoundOp, {
+      localPendingOpsByEntity: await opLogStore.getUnsyncedByEntity(),
+      appliedFrontierByEntity: new Map(),
+      retainedOpsByEntity: new Map(),
+      snapshotVectorClock: undefined,
+      snapshotEntityKeys: undefined,
+      hasNoSnapshotClock: true,
+    });
+    expect(detection.conflicts.length).toBe(1);
+    expect(detection.conflicts[0]?.entityId).toBe(TASK_X);
+
+    // The load-bearing claim: this resolves instead of wedging.
+    await resolver.autoResolveConflictsLWW(detection.conflicts);
+
+    // X stays archived (archive precedence); the atomic replay skipped the
+    // missing id and still rounded the uncontested siblings.
+    expect(localState[TASK_FEATURE_NAME].entities[TASK_X]).toBeUndefined();
+    expect(getTask(localState, TASK_Y).timeSpent).toBe(30 * MINUTE);
+    expect(getTask(localState, TASK_Z).timeSpent).toBe(15 * MINUTE);
+
+    // The archive intent survives as an uploadable op for X.
+    const pendingEntries = await opLogStore.getUnsynced();
+    expect(pendingEntries.length).toBeGreaterThan(0);
+    const pendingOps = pendingEntries.map((entry) => entry.op);
+    expect(
+      pendingOps.every((op) => op.actionType === TaskSharedActions.moveToArchive.type),
+    ).toBe(true);
+
+    // Remote client downloads the archive ops and converges.
+    server.uploadOps(pendingOps, CLIENT_A);
+    const downloadedByB = server
+      .downloadOps(1, CLIENT_B)
+      .ops.map((entry) => entry.op as Operation);
+    for (const op of downloadedByB) {
+      remoteState = reducer(remoteState, convertOpToAction(op));
+    }
+    expect(remoteState[TASK_FEATURE_NAME].entities[TASK_X]).toBeUndefined();
+    expect(taskSyncProjection(remoteState, TASK_Y)).toEqual(
+      taskSyncProjection(localState, TASK_Y),
+    );
+    expect(taskSyncProjection(remoteState, TASK_Z)).toEqual(
+      taskSyncProjection(localState, TASK_Z),
+    );
+
+    // Status-blind restart replay reproduces the live result.
+    let restartedState = initialState;
+    const durableEntries = await opLogStore.getOpsAfterSeq(0);
+    for (const entry of durableEntries) {
+      restartedState = reducer(restartedState, convertOpToAction(entry.op));
+    }
+    expect(restartedState[TASK_FEATURE_NAME].entities[TASK_X]).toBeUndefined();
+    expect(taskSyncProjection(restartedState, TASK_Y)).toEqual(
+      taskSyncProjection(localState, TASK_Y),
+    );
+    expect(taskSyncProjection(restartedState, TASK_Z)).toEqual(
+      taskSyncProjection(localState, TASK_Z),
+    );
+  });
 });

--- a/src/app/op-log/testing/integration/round-time-conflict-convergence.integration.spec.ts
+++ b/src/app/op-log/testing/integration/round-time-conflict-convergence.integration.spec.ts
@@ -287,4 +287,92 @@ describe('round-time conflict convergence integration (#8944)', () => {
       taskSyncProjection(localState, TASK_Y),
     );
   });
+
+  it('resolves a REMOTE bulk rounding op against a newer local edit and converges (#9601)', async () => {
+    const capture = TestBed.inject(OperationCaptureService);
+    const resolver = TestBed.inject(ConflictResolutionService);
+    const server = new MockSyncServer();
+    const clientA = new TestClient(CLIENT_A);
+    const clientB = new TestClient(CLIENT_B);
+
+    // Device B ("finish day"): rounds BOTH tasks up to the quarter hour in one
+    // atomic op and uploads it. X: 10m → 15m, Y: 20m → 30m on device B.
+    const roundAction = roundTimeSpentForDay({
+      day: DAY,
+      taskIds: [TASK_X, TASK_Y],
+      roundTo: 'QUARTER',
+      isRoundUp: true,
+    }) as PersistentAction;
+    let remoteState = reducer(initialState, roundAction);
+    const remoteRoundOp = captureOperation(roundAction, clientB, capture, 1_000);
+    server.uploadOps([remoteRoundOp], CLIENT_B);
+
+    // This device (A, next morning): a NEWER pending edit on task Y.
+    const localEditAction = TaskSharedActions.updateTask({
+      task: { id: TASK_Y, changes: { title: 'Local title for Y' } },
+    }) as PersistentAction;
+    localState = reducer(localState, localEditAction);
+    const localEditOp = captureOperation(localEditAction, clientA, capture, 2_000);
+    await opLogStore.append(localEditOp, 'local');
+
+    const detection = await resolver.checkOpForConflicts(remoteRoundOp, {
+      localPendingOpsByEntity: await opLogStore.getUnsyncedByEntity(),
+      appliedFrontierByEntity: new Map(),
+      retainedOpsByEntity: new Map(),
+      snapshotVectorClock: undefined,
+      snapshotEntityKeys: undefined,
+      hasNoSnapshotClock: true,
+    });
+    expect(detection.conflicts.length).toBe(1);
+    expect(detection.conflicts[0]?.entityId).toBe(TASK_Y);
+
+    const resolution = await resolver.autoResolveConflictsLWW(detection.conflicts);
+    expect(resolution.localWinOpsCreated).toBe(1);
+
+    // The original edit is superseded by the compensation snapshot.
+    const rejectedEdit = await opLogStore.getOpById(localEditOp.id);
+    expect(rejectedEdit?.rejectedAt).toBeDefined();
+    const pendingEntries = await opLogStore.getUnsynced();
+    expect(pendingEntries.length).toBe(1);
+    const compensationOp = pendingEntries[0].op;
+    expect(compensationOp.entityId).toBe(TASK_Y);
+
+    // Through the REAL reducer: the uncontested sibling X converges to the
+    // sender's rounded value; the local winner Y keeps its title AND its
+    // unrounded time (the atomic replay's transient rounding of Y is undone by
+    // the compensation snapshot applied after it).
+    expect(getTask(localState, TASK_X).timeSpent).toBe(15 * MINUTE);
+    expect(getTask(localState, TASK_Y).title).toBe('Local title for Y');
+    expect(getTask(localState, TASK_Y).timeSpent).toBe(20 * MINUTE);
+
+    // Device B downloads the compensation and converges on both tasks.
+    server.uploadOps([compensationOp], CLIENT_A);
+    const downloadedByB = server
+      .downloadOps(1, CLIENT_B)
+      .ops.map((entry) => entry.op as Operation);
+    expect(downloadedByB.map(({ id }) => id)).toEqual([compensationOp.id]);
+    for (const op of downloadedByB) {
+      remoteState = reducer(remoteState, convertOpToAction(op));
+    }
+    expect(taskSyncProjection(remoteState, TASK_X)).toEqual(
+      taskSyncProjection(localState, TASK_X),
+    );
+    expect(taskSyncProjection(remoteState, TASK_Y)).toEqual(
+      taskSyncProjection(localState, TASK_Y),
+    );
+
+    // Status-blind restart: replaying the durable log by seq (rejected edit,
+    // remote rounding row, compensation) reproduces the live-apply result.
+    let restartedState = initialState;
+    const durableEntries = await opLogStore.getOpsAfterSeq(0);
+    for (const entry of durableEntries) {
+      restartedState = reducer(restartedState, convertOpToAction(entry.op));
+    }
+    expect(taskSyncProjection(restartedState, TASK_X)).toEqual(
+      taskSyncProjection(localState, TASK_X),
+    );
+    expect(taskSyncProjection(restartedState, TASK_Y)).toEqual(
+      taskSyncProjection(localState, TASK_Y),
+    );
+  });
 });

--- a/src/app/op-log/testing/integration/round-time-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/round-time-conflict-resolution.integration.spec.ts
@@ -1,0 +1,344 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action, Store } from '@ngrx/store';
+import { of, Subject, Subscription } from 'rxjs';
+import { SnackService } from '../../../core/snack/snack.service';
+import { ClientIdService } from '../../../core/util/client-id.service';
+import { DEFAULT_TASK, Task } from '../../../features/tasks/task.model';
+import { roundTimeSpentForDay } from '../../../features/tasks/store/task.actions';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { OperationApplierService } from '../../apply/operation-applier.service';
+import { OperationCaptureService } from '../../capture/operation-capture.service';
+import { clearDeferredActions } from '../../capture/operation-capture.meta-reducer';
+import { OperationLogEffects } from '../../capture/operation-log.effects';
+import { buildEntityRegistry, ENTITY_REGISTRY } from '../../core/entity-registry';
+import { UnsupportedMultiEntityConflictError } from '../../core/errors/sync-errors';
+import { ActionType, EntityConflict, Operation } from '../../core/operation.types';
+import {
+  isPersistentAction,
+  PersistentAction,
+} from '../../core/persistent-action.interface';
+import { OperationLogCompactionService } from '../../persistence/operation-log-compaction.service';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { ConflictJournalService } from '../../sync/conflict-journal.service';
+import { ConflictResolutionService } from '../../sync/conflict-resolution.service';
+import { ImmediateUploadService } from '../../sync/immediate-upload.service';
+import { OperationWriteFlushService } from '../../sync/operation-write-flush.service';
+import { CLIENT_ID_PROVIDER } from '../../util/client-id.provider';
+import { ValidateStateService } from '../../validation/validate-state.service';
+import { compareVectorClocks, VectorClockComparison } from '@sp/sync-core';
+import {
+  ApplyOperationsOptions,
+  ApplyOperationsResult,
+} from '../../core/types/apply.types';
+import { resetTestUuidCounter, TestClient } from './helpers/test-client.helper';
+
+/**
+ * #9601: device A's "Finish day" rounds time spent across many tasks in ONE
+ * atomic multi-task `roundTimeSpentForDay` op. When device B has concurrent
+ * pending edits on any of those tasks, the downloaded rounding op used to fail
+ * the multi-entity preflight with
+ * `SYNC_MULTI_ENTITY_UNSUPPORTED side=remote actionType=[Task] RoundTimeSpentForDay`
+ * and wedge sync on every retry — the same action type already had a local-side
+ * decomposable path (#9561), but no remote-side exemption. These specs pin the
+ * resolution behavior: the rounding op replays atomically (uncontested siblings
+ * converge exactly — no concurrent ops means their values equal the sender's
+ * pre-rounding values), local winners are re-asserted by compensation snapshots
+ * applied after it, and a malformed payload whose declared entity ids disagree
+ * with its replay write set keeps the fail-closed stop.
+ */
+describe('remote round-time-spent conflict resolution integration (#9601)', () => {
+  const LOCAL_CLIENT_ID = 'round-client';
+  const REMOTE_CLIENT_ID = 'remote-client';
+  const TASK_A = 'task-a';
+  const TASK_B = 'task-b';
+  const TASK_C = 'task-c';
+  const ROUND_DAY = '2026-08-14';
+
+  let opLogStore: OperationLogStoreService;
+  let capture: OperationCaptureService;
+  let writeFlush: OperationWriteFlushService;
+  let resolver: ConflictResolutionService;
+  let journal: ConflictJournalService;
+  let operationApplier: jasmine.SpyObj<OperationApplierService>;
+  let store: jasmine.SpyObj<Store>;
+  let actions$: Subject<Action>;
+  let effectSubscription: Subscription;
+  let taskStateById: Record<string, Task | undefined>;
+
+  beforeEach(async () => {
+    resetTestUuidCounter();
+    clearDeferredActions();
+    actions$ = new Subject<Action>();
+    store = jasmine.createSpyObj<Store>('Store', ['dispatch', 'select']);
+    taskStateById = {};
+    // Serve current entity state for compensation snapshots from a plain map.
+    // The registry's TASK selectById is a props-based selector: (selector, {id}).
+    store.select.and.callFake(((_selector: unknown, props?: { id?: string }): unknown =>
+      of(props?.id ? taskStateById[props.id] : undefined)) as Store['select']);
+
+    operationApplier = jasmine.createSpyObj<OperationApplierService>(
+      'OperationApplierService',
+      ['applyOperations'],
+    );
+    // Mimic the real applier's contract: report every op as reducer-committed
+    // and applied, so the resolution's markApplied/checkpoint bookkeeping runs.
+    operationApplier.applyOperations.and.callFake((async (
+      ops: Operation[],
+      options: ApplyOperationsOptions = {},
+    ): Promise<ApplyOperationsResult> => {
+      await options.onReducersCommitted?.(ops, []);
+      return { appliedOps: ops };
+    }) as OperationApplierService['applyOperations']);
+    const validateState = jasmine.createSpyObj<ValidateStateService>(
+      'ValidateStateService',
+      ['validateAndRepairCurrentState'],
+    );
+    validateState.validateAndRepairCurrentState.and.resolveTo(true);
+    const compaction = jasmine.createSpyObj<OperationLogCompactionService>(
+      'OperationLogCompactionService',
+      ['compact', 'emergencyCompact'],
+    );
+    compaction.compact.and.resolveTo(true);
+    compaction.emergencyCompact.and.resolveTo(true);
+    const clientId = jasmine.createSpyObj<ClientIdService>('ClientIdService', [
+      'getOrGenerateClientId',
+    ]);
+    clientId.getOrGenerateClientId.and.resolveTo(LOCAL_CLIENT_ID);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ConflictResolutionService,
+        OperationLogEffects,
+        OperationLogStoreService,
+        OperationCaptureService,
+        provideMockActions(() => actions$),
+        { provide: Store, useValue: store },
+        { provide: OperationApplierService, useValue: operationApplier },
+        { provide: ValidateStateService, useValue: validateState },
+        { provide: OperationLogCompactionService, useValue: compaction },
+        {
+          provide: ImmediateUploadService,
+          useValue: jasmine.createSpyObj<ImmediateUploadService>(
+            'ImmediateUploadService',
+            ['trigger'],
+          ),
+        },
+        { provide: ClientIdService, useValue: clientId },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj<SnackService>('SnackService', ['open']),
+        },
+        {
+          provide: CLIENT_ID_PROVIDER,
+          useValue: {
+            loadClientId: () => Promise.resolve(LOCAL_CLIENT_ID),
+            getOrGenerateClientId: () => Promise.resolve(LOCAL_CLIENT_ID),
+            clearCache: () => {},
+          },
+        },
+        { provide: ENTITY_REGISTRY, useValue: buildEntityRegistry() },
+      ],
+    });
+
+    opLogStore = TestBed.inject(OperationLogStoreService);
+    capture = TestBed.inject(OperationCaptureService);
+    writeFlush = TestBed.inject(OperationWriteFlushService);
+    resolver = TestBed.inject(ConflictResolutionService);
+    journal = TestBed.inject(ConflictJournalService);
+    capture.clear();
+    store.dispatch.and.callFake(((action: Action): void => {
+      if (!isPersistentAction(action)) {
+        throw new Error('Expected a persistent action');
+      }
+      capture.incrementPending(action);
+      actions$.next(action);
+    }) as Store['dispatch']);
+
+    await opLogStore.init();
+    await opLogStore._clearAllDataForTesting();
+    await journal.clearAll();
+    effectSubscription =
+      TestBed.inject(OperationLogEffects).persistOperation$.subscribe();
+  });
+
+  afterEach(async () => {
+    await writeFlush.flushPendingWrites();
+    effectSubscription.unsubscribe();
+    actions$.complete();
+    capture.clear();
+    clearDeferredActions();
+    await opLogStore._clearAllDataForTesting();
+    await journal.clearAll();
+    TestBed.resetTestingModule();
+  });
+
+  const dispatchAndFlush = async (action: PersistentAction): Promise<Operation[]> => {
+    store.dispatch(action);
+    await writeFlush.flushPendingWrites();
+    return (await opLogStore.getUnsynced()).map(({ op }) => op);
+  };
+
+  const remoteClient = (): TestClient => new TestClient(REMOTE_CLIENT_ID);
+
+  const buildRemoteRoundTimeOp = (
+    client: TestClient,
+    taskIds: string[],
+    timestamp: number,
+    entityIds: string[] = taskIds,
+  ): Operation => {
+    const remoteAction = roundTimeSpentForDay({
+      day: ROUND_DAY,
+      taskIds,
+      roundTo: '5M',
+      isRoundUp: true,
+    }) as PersistentAction;
+    const { type, meta, ...actionPayload } = remoteAction;
+    return {
+      ...client.createOperation({
+        actionType: type,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: entityIds[0],
+        entityIds,
+        payload: { actionPayload, entityChanges: [] },
+      }),
+      timestamp,
+    };
+  };
+
+  const detectConflictsFor = async (
+    remoteOperation: Operation,
+  ): Promise<EntityConflict[]> => {
+    const detection = await resolver.checkOpForConflicts(remoteOperation, {
+      localPendingOpsByEntity: await opLogStore.getUnsyncedByEntity(),
+      appliedFrontierByEntity: new Map(),
+      retainedOpsByEntity: new Map(),
+      snapshotVectorClock: undefined,
+      snapshotEntityKeys: undefined,
+      hasNoSnapshotClock: true,
+    });
+    expect(detection.conflicts.length).toBeGreaterThan(0);
+    return detection.conflicts;
+  };
+
+  const unsyncedOps = async (): Promise<Operation[]> =>
+    (await opLogStore.getUnsynced()).map(({ op }) => op);
+
+  const appliedOps = (): Operation[] =>
+    operationApplier.applyOperations.calls.allArgs().flatMap(([ops]) => ops);
+
+  const expectDominates = (dominating: Operation, dominated: Operation): void => {
+    expect(compareVectorClocks(dominating.vectorClock, dominated.vectorClock)).toBe(
+      VectorClockComparison.GREATER_THAN,
+    );
+  };
+
+  it('resolves a remote finish-day rounding op racing a newer local edit (mixed winners)', async () => {
+    // LOCAL (device B, next morning): a pending edit on one of the tasks the
+    // remote rounding covers — the newer timestamp makes it the local winner.
+    const [localEditOp] = await dispatchAndFlush(
+      TaskSharedActions.updateTask({
+        task: { id: TASK_A, changes: { title: 'Local morning edit' } },
+      }) as PersistentAction,
+    );
+    taskStateById[TASK_A] = {
+      ...DEFAULT_TASK,
+      id: TASK_A,
+      title: 'Local morning edit',
+      projectId: 'project1',
+    };
+
+    // REMOTE (device A, previous evening): "Finish day" rounded 3 tasks at once.
+    const remoteRoundOp = buildRemoteRoundTimeOp(
+      remoteClient(),
+      [TASK_A, TASK_B, TASK_C],
+      localEditOp.timestamp - 1,
+    );
+    const conflicts = await detectConflictsFor(remoteRoundOp);
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    // The original local edit is rejected; ONLY the compensation snapshot
+    // stays pending for upload, dominating both concurrent originals and
+    // keeping the local winner's timestamp.
+    const pending = await unsyncedOps();
+    expect(pending.length).toBe(1);
+    const compensation = pending[0];
+    expect(compensation.id).not.toBe(localEditOp.id);
+    expect(compensation.entityId).toBe(TASK_A);
+    expect(
+      (compensation.payload as { actionPayload?: { title?: string } }).actionPayload
+        ?.title,
+    ).toBe('Local morning edit');
+    expect(compensation.timestamp).toBe(localEditOp.timestamp);
+    expectDominates(compensation, localEditOp);
+    expectDominates(compensation, remoteRoundOp);
+
+    // The atomic rounding op is applied once (uncontested siblings B and C get
+    // their rounding), then task A's local-win compensation replays after it.
+    const appliedIds = appliedOps().map(({ id }) => id);
+    expect(appliedIds).toContain(remoteRoundOp.id);
+    expect(appliedIds).toContain(compensation.id);
+    expect(appliedIds.indexOf(remoteRoundOp.id)).toBeLessThan(
+      appliedIds.indexOf(compensation.id),
+    );
+  });
+
+  it('applies the rounding atomically when the remote side wins the shared task', async () => {
+    const [localEditOp] = await dispatchAndFlush(
+      TaskSharedActions.updateTask({
+        task: { id: TASK_A, changes: { title: 'Older local edit' } },
+      }) as PersistentAction,
+    );
+
+    const remoteRoundOp = buildRemoteRoundTimeOp(
+      remoteClient(),
+      [TASK_A, TASK_B, TASK_C],
+      localEditOp.timestamp + 1,
+    );
+    const conflicts = await detectConflictsFor(remoteRoundOp);
+
+    await resolver.autoResolveConflictsLWW(conflicts);
+
+    // Remote wins outright: the rounding applies once, the stale local edit is
+    // rejected, and nothing is left pending — no compensation is needed.
+    expect(appliedOps().map(({ id }) => id)).toContain(remoteRoundOp.id);
+    expect(await unsyncedOps()).toEqual([]);
+  });
+
+  it('fails closed when the declared entity ids disagree with the replay write set', async () => {
+    // A payload whose `taskIds` exceed `entityIds` would round a task that
+    // conflict detection never checked — that shape must keep the safe stop.
+    const [localEditOp] = await dispatchAndFlush(
+      TaskSharedActions.updateTask({
+        task: { id: TASK_A, changes: { title: 'Local edit' } },
+      }) as PersistentAction,
+    );
+
+    const malformedRemoteOp = buildRemoteRoundTimeOp(
+      remoteClient(),
+      [TASK_A, TASK_B, TASK_C],
+      localEditOp.timestamp - 1,
+      [TASK_A, TASK_B],
+    );
+    const conflicts = await detectConflictsFor(malformedRemoteOp);
+
+    let thrown: unknown;
+    try {
+      await resolver.autoResolveConflictsLWW(conflicts);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
+    expect((thrown as Error).message).toBe(
+      'SYNC_MULTI_ENTITY_UNSUPPORTED side=remote ' +
+        `actionType=${ActionType.TASK_ROUND_TIME_SPENT} entityCount=2`,
+    );
+    expect(operationApplier.applyOperations).not.toHaveBeenCalled();
+    expect(await journal.list('history')).toEqual([]);
+    // Fail-closed means pre-mutation: the local edit stays pending untouched.
+    expect((await unsyncedOps()).map(({ id }) => id)).toEqual([localEditOp.id]);
+  });
+});

--- a/src/app/op-log/testing/integration/round-time-conflict-resolution.integration.spec.ts
+++ b/src/app/op-log/testing/integration/round-time-conflict-resolution.integration.spec.ts
@@ -13,7 +13,12 @@ import { clearDeferredActions } from '../../capture/operation-capture.meta-reduc
 import { OperationLogEffects } from '../../capture/operation-log.effects';
 import { buildEntityRegistry, ENTITY_REGISTRY } from '../../core/entity-registry';
 import { UnsupportedMultiEntityConflictError } from '../../core/errors/sync-errors';
-import { ActionType, EntityConflict, Operation } from '../../core/operation.types';
+import {
+  ActionType,
+  EntityConflict,
+  Operation,
+  OpType,
+} from '../../core/operation.types';
 import {
   isPersistentAction,
   PersistentAction,
@@ -186,12 +191,14 @@ describe('remote round-time-spent conflict resolution integration (#9601)', () =
     taskIds: string[],
     timestamp: number,
     entityIds: string[] = taskIds,
+    projectId?: string | null,
   ): Operation => {
     const remoteAction = roundTimeSpentForDay({
       day: ROUND_DAY,
       taskIds,
       roundTo: '5M',
       isRoundUp: true,
+      projectId,
     }) as PersistentAction;
     const { type, meta, ...actionPayload } = remoteAction;
     return {
@@ -291,6 +298,15 @@ describe('remote round-time-spent conflict resolution integration (#9601)', () =
         task: { id: TASK_A, changes: { title: 'Older local edit' } },
       }) as PersistentAction,
     );
+    // The conflicted task IS writable by the rounding op (no project limit, no
+    // subtasks) — pins that the unwritable-target local-win override below
+    // does NOT fire for genuinely rounded targets.
+    taskStateById[TASK_A] = {
+      ...DEFAULT_TASK,
+      id: TASK_A,
+      title: 'Older local edit',
+      projectId: 'project1',
+    };
 
     const remoteRoundOp = buildRemoteRoundTimeOp(
       remoteClient(),
@@ -305,6 +321,96 @@ describe('remote round-time-spent conflict resolution integration (#9601)', () =
     // rejected, and nothing is left pending — no compensation is needed.
     expect(appliedOps().map(({ id }) => id)).toContain(remoteRoundOp.id);
     expect(await unsyncedOps()).toEqual([]);
+  });
+
+  /**
+   * A production rounding op declares EVERY task id of the day, but its
+   * reducer writes only tasks matching the payload's project limit that are
+   * not parents-with-subtasks. A remote win on a declared-but-unwritten
+   * target would reject the local pending edit while the replay writes
+   * nothing to that entity — the edit would stay visible locally but never
+   * upload. Such rows must resolve as LOCAL wins instead, re-asserting and
+   * re-uploading the local state via a compensation snapshot.
+   */
+  describe('declared-but-unwritten targets resolve as local wins', () => {
+    const expectLocalStatePreserved = async (
+      localEditOp: Operation,
+      remoteRoundOp: Operation,
+      expectedTitle: string,
+    ): Promise<void> => {
+      const pending = await unsyncedOps();
+      expect(pending.length).toBe(1);
+      const compensation = pending[0];
+      expect(compensation.id).not.toBe(localEditOp.id);
+      expect(compensation.entityId).toBe(TASK_A);
+      expect(
+        (compensation.payload as { actionPayload?: { title?: string } }).actionPayload
+          ?.title,
+      ).toBe(expectedTitle);
+      expectDominates(compensation, localEditOp);
+      expectDominates(compensation, remoteRoundOp);
+
+      // The rounding op still applies atomically for its writable targets.
+      const appliedIds = appliedOps().map(({ id }) => id);
+      expect(appliedIds).toContain(remoteRoundOp.id);
+      expect(appliedIds).toContain(compensation.id);
+    };
+
+    it('keeps an OLDER local edit when the op is limited to another project', async () => {
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: TASK_A, changes: { title: 'Cross-project edit' } },
+        }) as PersistentAction,
+      );
+      taskStateById[TASK_A] = {
+        ...DEFAULT_TASK,
+        id: TASK_A,
+        title: 'Cross-project edit',
+        projectId: 'project1',
+      };
+
+      // The remote per-project rounding covers only 'other-project' tasks but
+      // declares task A anyway; its timestamp is NEWER, so plain LWW would
+      // pick remote and silently drop the local edit from the upload stream.
+      const remoteRoundOp = buildRemoteRoundTimeOp(
+        remoteClient(),
+        [TASK_A, TASK_B, TASK_C],
+        localEditOp.timestamp + 1,
+        [TASK_A, TASK_B, TASK_C],
+        'other-project',
+      );
+      const conflicts = await detectConflictsFor(remoteRoundOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      await expectLocalStatePreserved(localEditOp, remoteRoundOp, 'Cross-project edit');
+    });
+
+    it('keeps an OLDER local edit when the conflicted task is a parent with subtasks', async () => {
+      const [localEditOp] = await dispatchAndFlush(
+        TaskSharedActions.updateTask({
+          task: { id: TASK_A, changes: { title: 'Parent edit' } },
+        }) as PersistentAction,
+      );
+      taskStateById[TASK_A] = {
+        ...DEFAULT_TASK,
+        id: TASK_A,
+        title: 'Parent edit',
+        projectId: 'project1',
+        subTaskIds: ['task-a-sub-1'],
+      };
+
+      const remoteRoundOp = buildRemoteRoundTimeOp(
+        remoteClient(),
+        [TASK_A, TASK_B, TASK_C],
+        localEditOp.timestamp + 1,
+      );
+      const conflicts = await detectConflictsFor(remoteRoundOp);
+
+      await resolver.autoResolveConflictsLWW(conflicts);
+
+      await expectLocalStatePreserved(localEditOp, remoteRoundOp, 'Parent edit');
+    });
   });
 
   it('fails closed when the declared entity ids disagree with the replay write set', async () => {
@@ -339,6 +445,41 @@ describe('remote round-time-spent conflict resolution integration (#9601)', () =
     expect(operationApplier.applyOperations).not.toHaveBeenCalled();
     expect(await journal.list('history')).toEqual([]);
     // Fail-closed means pre-mutation: the local edit stays pending untouched.
+    expect((await unsyncedOps()).map(({ id }) => id)).toEqual([localEditOp.id]);
+  });
+
+  it('fails closed with the TYPED error on a rounding op without an action payload', async () => {
+    // The gate runs on attacker-influenceable remote input: a payload shaped
+    // `{entityChanges: []}` (no actionPayload) must yield the typed
+    // fail-closed error, not a TypeError thrown from inside the validator.
+    const [localEditOp] = await dispatchAndFlush(
+      TaskSharedActions.updateTask({
+        task: { id: TASK_A, changes: { title: 'Local edit' } },
+      }) as PersistentAction,
+    );
+
+    const malformedRemoteOp: Operation = {
+      ...remoteClient().createOperation({
+        actionType: ActionType.TASK_ROUND_TIME_SPENT,
+        opType: OpType.Update,
+        entityType: 'TASK',
+        entityId: TASK_A,
+        entityIds: [TASK_A, TASK_B],
+        payload: { entityChanges: [] },
+      }),
+      timestamp: localEditOp.timestamp - 1,
+    };
+    const conflicts = await detectConflictsFor(malformedRemoteOp);
+
+    let thrown: unknown;
+    try {
+      await resolver.autoResolveConflictsLWW(conflicts);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UnsupportedMultiEntityConflictError);
+    expect(operationApplier.applyOperations).not.toHaveBeenCalled();
     expect((await unsyncedOps()).map(({ id }) => id)).toEqual([localEditOp.id]);
   });
 });


### PR DESCRIPTION
## Problem

Fixes #9601. A remote multi-task `RoundTimeSpentForDay` op ("Finish day" rounding on device A) racing any concurrent pending edit on device B failed the multi-entity conflict preflight with `SYNC_MULTI_ENTITY_UNSUPPORTED side=remote` and wedged sync permanently — the batch aborted before resolution, the server cursor never advanced, and every retry re-downloaded the same ops. The action type had a local-side decomposable path since #9561 but no remote-side exemption, which is exactly the asymmetry the issue reports. Reliably reproduced by the reporter on three platforms.

## Solution

**Core fix** (`conflict-resolution.service.ts`): allow validated remote rounding ops through `_assertMultiEntityPlansAreSafe` and let the existing mixed-winner machinery resolve them — the atomic row replays once (uncontested siblings converge exactly), local winners are re-asserted by compensation snapshots applied after it and re-uploaded. The exemption is gated on the existing static-payload validator, so a row whose `taskIds` disagree with its declared `entityIds` keeps the fail-closed stop.

**Review hardening** (six-perspective multi-agent review on the first commit; every verified finding fixed test-first):

- The rounding reducer now **skips task ids missing from the store** instead of throwing, so a replayed op listing tasks this client archived/deleted meanwhile no longer aborts — on the conflict path that throw escalated to `IncompleteRemoteOperationsError` and re-wedged sync (both-devices-finish-day shape).
- **Declared-but-unwritten conflict targets are forced to local wins** (`_forceLocalWinForUnwritableRoundTimeTargets`): production ops declare every task id of the day but the reducer writes only tasks passing the payload's project limit that aren't parents-with-subtasks. A remote win on such a row rejected the local pending edit while the replay wrote nothing — silently dropping the edit from the upload stream. The sender's own dispatch filtered the same ids, so nothing was rounded anywhere; forcing local win is correct, not a compromise.
- The payload **validator is total**: null/missing `actionPayload` yields the typed fail-closed error, not a raw `TypeError` from inside the preflight.
- The guard's doc comment states the accepted bounded divergences explicitly (remote-win targets keep `rounded(local value)`; same-batch pre-rounding deltas replay after the rounding) — both confined to the two time fields, self-healing, and chosen over the permanent wedge.

**Tests** (each production change was proven by a test that failed before it):

- `round-time-conflict-resolution.integration.spec.ts` (new): reproduces the reported wedge, pins mixed-winner resolution, remote-win, forced-local-win (project-limit + parent shapes), and both fail-closed gates.
- `round-time-conflict-convergence.integration.spec.ts`: two real-reducer scenarios — the #9601 remote-row mixed-winner flow and the both-finish-day archive overlap — asserting exact converged values on both simulated clients plus status-blind restart-replay determinism.
- `task.reducer.spec.ts`: unknown-id skip behavior.
- `supersync-round-time-conflict.spec.ts` (new E2E): two real clients drive the daily-summary rounding UI end to end, with a premise assertion guaranteeing the conflict actually forms.
- E2E helper dedup: `recordTaskTimeDelta` / `expectExactTaskTime` moved to `supersync-helpers.ts`.

Verified locally: all op-log specs (3864), all tasks specs (1478), checkFile clean. SuperSync E2E dispatched on this branch: https://github.com/super-productivity/super-productivity/actions/runs/31880692683

Follow-ups filed separately: #9605 (test-harness extraction), #9606 (unify local/remote exemption lists so a future decomposable action can't recreate this asymmetry).

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)