### PR TITLE
fix(release): strip emoji from the App Store "What's New" text

### DIFF
--- a/tools/prepare-appstore-release-notes.js
+++ b/tools/prepare-appstore-release-notes.js
@@ -13,6 +13,9 @@
 // text to remove Android references"). Those changes also don't apply to the
 // macOS/iOS builds, so dropping them is correct on both counts.
 //
+// Emoji are stripped for the same reason: App Store Connect rejects some of them
+// outright in "What's New" (see EMOJI_PATTERN).
+//
 // Usage: node tools/prepare-appstore-release-notes.js [outFile] [locale]
 //   outFile  defaults to fastlane/appstore_metadata/<locale>/release_notes.txt
 //   locale   defaults to en-US
@@ -60,7 +63,45 @@ const OTHER_PLATFORM_PATTERNS = [
   /\baur\b/i,
 ];
 
+// App Store Connect rejects individual emoji in "What's New" and names the
+// offender in the error ("What's New in This Version can’t contain the following
+// character(s): 🚨. - /data/attributes/whatsNew"). Apple documents neither which
+// characters are blocked nor when the set changes, so strip pictographs
+// wholesale instead of chasing a blocklist. Emoji reach the notes without anyone
+// writing one deliberately: the bug-report issue template prefixes titles with
+// "🚨 ", and a squash merge carries that into the commit subject the changelog is
+// built from (this sank both Apple release lanes for 18.20.0, via #9530).
+// Deliberately aggressive, mirroring OTHER_PLATFORM_PATTERNS: a missed emoji
+// fails the release, while an over-eager match only costs decoration (©, ® and ™
+// are pictographs too and go with it — they have never appeared in a changelog
+// entry here, and Apple accepts the text either way).
+const EMOJI_PATTERN =
+  /[\p{Extended_Pictographic}\p{Emoji_Modifier}\p{Regional_Indicator}\u{FE0E}\u{FE0F}\u{20E3}\u{200D}]/gu;
+
+// Bullet/heading markers, i.e. everything that can legitimately precede the text
+// of a line. A line left with only these once its emoji are gone had no prose to
+// begin with.
+const LINE_MARKERS_ONLY = /^[\s*•\-#]*$/;
+
 const isMarkdownHeading = (line) => /^\s*#{1,6}\s/.test(line);
+
+// Remove emoji, then repair the line: close the gap the removed character left
+// ("- 🚨 Fix" -> "- Fix"), and blank out a line that was pure decoration ("- 🎉")
+// so it leaves neither a bare bullet nor content that keeps an otherwise empty
+// heading alive. Runs before stripOtherPlatformLines so dropEmptyHeadings sees
+// the blanked lines.
+const stripEmoji = (markdown) =>
+  markdown
+    .split('\n')
+    .map((line) => {
+      const stripped = line.replace(EMOJI_PATTERN, '');
+      if (stripped === line) {
+        return line;
+      }
+      const collapsed = stripped.replace(/[ \t]{2,}/g, ' ').trimEnd();
+      return LINE_MARKERS_ONLY.test(collapsed) ? '' : collapsed;
+    })
+    .join('\n');
 
 // Drop a section heading that has no content line after it (before the next
 // heading). Single backward pass: walking bottom-up, "did real content follow
@@ -143,7 +184,7 @@ const truncateToMaxChars = (text, maxChars = MAX_CHARS) => {
 };
 
 const buildAppStoreReleaseNotes = (markdown, onDrop) =>
-  truncateToMaxChars(toPlainText(stripOtherPlatformLines(markdown, onDrop)));
+  truncateToMaxChars(toPlainText(stripOtherPlatformLines(stripEmoji(markdown), onDrop)));
 
 const main = () => {
   const locale = process.argv[3] || 'en-US';
@@ -182,6 +223,7 @@ module.exports = {
   MAX_CHARS,
   OTHER_PLATFORM_PATTERNS,
   buildAppStoreReleaseNotes,
+  stripEmoji,
   stripOtherPlatformLines,
   toPlainText,
   truncateToMaxChars,

--- a/tools/prepare-appstore-release-notes.js
+++ b/tools/prepare-appstore-release-notes.js
@@ -74,14 +74,18 @@ const OTHER_PLATFORM_PATTERNS = [
 // Deliberately aggressive, mirroring OTHER_PLATFORM_PATTERNS: a missed emoji
 // fails the release, while an over-eager match only costs decoration (©, ® and ™
 // are pictographs too and go with it — they have never appeared in a changelog
-// entry here, and Apple accepts the text either way).
+// entry here, and Apple accepts the text either way). The trailing TAG block is
+// the tail of a tag sequence (e.g. the England flag): invisible on its own, so
+// leaving it behind would send Apple an unrenderable character and produce a CI
+// error naming nothing.
 const EMOJI_PATTERN =
-  /[\p{Extended_Pictographic}\p{Emoji_Modifier}\p{Regional_Indicator}\u{FE0E}\u{FE0F}\u{20E3}\u{200D}]/gu;
+  /[\p{Extended_Pictographic}\p{Emoji_Modifier}\p{Regional_Indicator}\u{FE0E}\u{FE0F}\u{20E3}\u{200D}\u{E0020}-\u{E007F}]/gu;
 
-// Bullet/heading markers, i.e. everything that can legitimately precede the text
-// of a line. A line left with only these once its emoji are gone had no prose to
-// begin with.
-const LINE_MARKERS_ONLY = /^[\s*•\-#]*$/;
+// Bullet/heading and emphasis markers, i.e. everything that can legitimately
+// precede the text of a line. A line left with only these once its emoji are
+// gone had no prose to begin with. Covers the markers the AI generation path can
+// emit ("+", "_", ">"), not just the "- " the deterministic generator produces.
+const LINE_MARKERS_ONLY = /^[\s*•\-#+_>]*$/;
 
 const isMarkdownHeading = (line) => /^\s*#{1,6}\s/.test(line);
 
@@ -220,6 +224,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  EMOJI_PATTERN,
   MAX_CHARS,
   OTHER_PLATFORM_PATTERNS,
   buildAppStoreReleaseNotes,

--- a/tools/prepare-appstore-release-notes.test.js
+++ b/tools/prepare-appstore-release-notes.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+  EMOJI_PATTERN,
   buildAppStoreReleaseNotes,
   stripEmoji,
   stripOtherPlatformLines,
@@ -9,10 +10,13 @@ const {
   truncateToMaxChars,
 } = require('./prepare-appstore-release-notes');
 
-// Matches how App Store Connect reports the rejection: any emoji left in the
-// text is a failed release lane.
+// Any emoji left in the text is a failed release lane, so assert against the
+// very pattern the code strips with: a hand-written subset here would silently
+// stop covering a member that a later edit drops from EMOJI_PATTERN. Rebuilt
+// without the /g flag, since a global regex reused across `test()` calls carries
+// lastIndex between them.
 const assertNoEmoji = (text) =>
-  assert.doesNotMatch(text, /\p{Extended_Pictographic}|\p{Regional_Indicator}/u);
+  assert.doesNotMatch(text, new RegExp(EMOJI_PATTERN.source, 'u'));
 
 test('strips bullets that name a non-Apple platform', () => {
   const markdown = [
@@ -174,6 +178,29 @@ test('strips emoji anywhere in the notes, keeping non-emoji symbols', () => {
   assert.match(text, /### Features/);
   assert.match(text, /Add focus mode 1 with a group view — see the guide → settings/);
   assert.match(text, /Fix the locale ✓/);
+});
+
+// Each of these is a separate member of EMOJI_PATTERN whose residue is invisible
+// in a diff, so without a case per member a later edit could drop one and leave
+// the suite green while shipping a character Apple rejects.
+test('strips the invisible emoji parts, leaving no residue', () => {
+  const cases = [
+    // Skin-tone modifier (\p{Emoji_Modifier}): the base is a pictograph, the
+    // modifier is not, so dropping either half leaves a stray character.
+    ['- Wave 👋🏽 goodbye to stale caches', /• Wave goodbye to stale caches/],
+    // Text-presentation selector (U+FE0E) trailing a dingbat.
+    ['- Mark done ✔︎ faster', /• Mark done faster/],
+    // Tag sequence (U+E0020-U+E007F): six invisible tag chars after the flag.
+    ['- Fix 🏴󠁧󠁢󠁥󠁮󠁧󠁿 English sorting', /• Fix English sorting/],
+  ];
+
+  for (const [markdown, expected] of cases) {
+    const text = buildAppStoreReleaseNotes(markdown);
+    assertNoEmoji(text);
+    assert.match(text, expected);
+    // Nothing invisible survives either: the line must be plain ASCII prose.
+    assert.doesNotMatch(text, /[^\x20-\x7E\n•]/);
+  }
 });
 
 test('drops a heading whose only bullet was pure emoji decoration', () => {

--- a/tools/prepare-appstore-release-notes.test.js
+++ b/tools/prepare-appstore-release-notes.test.js
@@ -3,10 +3,16 @@ const assert = require('node:assert/strict');
 
 const {
   buildAppStoreReleaseNotes,
+  stripEmoji,
   stripOtherPlatformLines,
   toPlainText,
   truncateToMaxChars,
 } = require('./prepare-appstore-release-notes');
+
+// Matches how App Store Connect reports the rejection: any emoji left in the
+// text is a failed release lane.
+const assertNoEmoji = (text) =>
+  assert.doesNotMatch(text, /\p{Extended_Pictographic}|\p{Regional_Indicator}/u);
 
 test('strips bullets that name a non-Apple platform', () => {
   const markdown = [
@@ -131,6 +137,65 @@ test('end-to-end: produces clean plain-text What’s New without platform names'
   // Apple-relevant content is kept and bulletized (scope prefix retained).
   assert.match(text, /• focus-mode: surface session-done/);
   assert.match(text, /• tasks: preserve manual order within a tag/);
+});
+
+test('strips the emoji App Store Connect rejected for 18.20.0', () => {
+  // Verbatim shape of the bullet that failed both Apple release lanes: the
+  // bug-report issue template prefixes titles with "🚨 " and the squash merge
+  // carried it into the commit subject.
+  const markdown = [
+    '### Other Changes',
+    '',
+    '- 🚨 Cannot connect to CalDAV Todo issue provider (#9530)',
+  ].join('\n');
+
+  const text = buildAppStoreReleaseNotes(markdown);
+
+  assertNoEmoji(text);
+  // The note itself survives, with the gap the emoji left closed up.
+  assert.match(text, /• Cannot connect to CalDAV Todo issue provider \(#9530\)/);
+});
+
+test('strips emoji anywhere in the notes, keeping non-emoji symbols', () => {
+  const markdown = [
+    '🎉 A big release!',
+    '',
+    '### ✨ Features',
+    '',
+    '- Add focus mode 1️⃣ with a 👨‍👩‍👧 group view — see the guide → settings',
+    '- Fix the 🇩🇪 locale ✓',
+  ].join('\n');
+
+  const text = stripEmoji(markdown);
+
+  assertNoEmoji(text);
+  // Punctuation and arrows are not pictographs and must survive untouched.
+  assert.match(text, /A big release!/);
+  assert.match(text, /### Features/);
+  assert.match(text, /Add focus mode 1 with a group view — see the guide → settings/);
+  assert.match(text, /Fix the locale ✓/);
+});
+
+test('drops a heading whose only bullet was pure emoji decoration', () => {
+  const markdown = ['### Features', '', '- 🎉', '', '### Fixes', '', '- Fix sync'].join(
+    '\n',
+  );
+
+  const text = buildAppStoreReleaseNotes(markdown);
+
+  // No bare "•" bullet and no heading left hanging over nothing.
+  assert.doesNotMatch(text, /^\s*[•\-]\s*$/m);
+  assert.doesNotMatch(text, /Features/);
+  assert.match(text, /Fixes/);
+  assert.match(text, /• Fix sync/);
+});
+
+test('leaves emoji-free notes byte-for-byte unchanged', () => {
+  const markdown = ['### Fixes', '', '- **tasks:** keep the list anchored (#8533)'].join(
+    '\n',
+  );
+
+  assert.equal(stripEmoji(markdown), markdown);
 });
 
 test('toPlainText converts markdown bullets/links/emphasis to plain text', () => {


### PR DESCRIPTION
Both Apple release lanes failed for 18.20.0 with

  An attribute value has invalid characters. - What's New in This Version
  can't contain the following character(s): 🚨. - /data/attributes/whatsNew

App Store Connect blocks some emoji in whatsNew, and no one wrote that one
by hand: the bug-report issue template prefixes titles with "🚨 ", the
squash merge for #9530 carried it into the commit subject, and the
changelog generator turned it into a release-note bullet.

Apple documents neither the blocked set nor when it changes, so the
App Store transform now strips pictographs wholesale rather than tracking a
blocklist -- the same deliberately aggressive bias already used for
non-Apple platform names, where a miss costs a failed release and an
over-eager match only costs decoration. Lines left as bare bullets or
headings are dropped so nothing dangles.

Only the App Store text is affected; the GitHub and Play Store changelogs
keep their emoji.

Verified end to end by regenerating the real 18.20.0 notes: the rejected
bullet now reads "• Cannot connect to CalDAV Todo issue provider (#9530)"
and the output is emoji-free.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vg413FSRvrm92TTe2x4UDv