### PR TITLE
ci(build): let a failed Windows release job be re-run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,7 @@ jobs:
           name: e2eResults
           path: .tmp/e2e-test-results/**/*.*
           retention-days: 14
+          overwrite: true # so a re-run of this job does not fail on the existing artifact
 
       - name: Build Frontend & Electron
         run: npm run build
@@ -359,6 +360,10 @@ jobs:
           path: .tmp/app-builds/*.exe
           if-no-files-found: error
           retention-days: 1
+          # Artifacts are scoped to the run, not the attempt, and uploading a
+          # name that already exists fails. Without this, re-running this job
+          # after a signing failure dies here instead of retrying the signing.
+          overwrite: true
 
       - name: Sign Windows executables with SignPath
         uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2

--- a/docs/release-and-publishing.md
+++ b/docs/release-and-publishing.md
@@ -165,3 +165,25 @@ for development-only labels, secrets, and personal data before upload.
   release.
 - Record the release URL and any intentionally skipped or manually completed
   channel in the release discussion.
+- A failing SignPath step prints only what the connector returns, which can be a
+  bare `Invalid request to SignPath API.` with no detail (v18.20.0, run
+  31883046355). The workflow log cannot say more: diagnose it in the SignPath
+  web UI, where the signing request record carries the real reason. Check, in
+  order, that `SIGNPATH_API_TOKEN` is still valid, that the `super-productivity`
+  project with the `release-signing` policy and `github-zip-pe` artifact
+  configuration still exist under those exact slugs, and that the GitHub trusted
+  build system is still authorized for the organization. The submitted artifact
+  size is a further suspect — it reached ~930 MB for v18.20.0 against ~900 MB
+  for the last accepted submission — and can be halved by submitting the
+  installers and the portables as two separate artifacts.
+- If the SignPath side checks out, treat it as a platform-side regression and
+  report it to SignPath support with the run URL and submission timestamp. Their
+  application and pipeline connector ship continuously, and releases here are
+  weeks apart, so a release can be the first build to meet a new version:
+  application 1.218.0 (2026-08-11) and pipeline connector 0.7.4 (2026-08-13)
+  both landed between the last accepted submission and the v18.20.0 failure.
+  Signing is also the one release step with no local reproduction — the log is
+  a relay, so their support seeing the server-side record beats guessing here.
+- Windows signing runs only on a `v*` tag, so a signing fix can only be
+  exercised by re-running `windows-bin` or by pushing a pre-release tag. Never
+  move a released tag to retest.


### PR DESCRIPTION
## Problem

The v18.20.0 Windows release job failed at SignPath signing ([run 31883046355](https://github.com/super-productivity/super-productivity/actions/runs/31883046355)). The obvious next step once signing is fixed is to re-run `windows-bin` — but that re-run would never reach the signing step.

`actions/upload-artifact` v4+ scopes artifacts to the **workflow run**, not the run attempt, and the pinned v7.0.1 documents its default plainly:

> If false, the action will fail if an artifact for the given name already exists.

So `unsigned-windows-executables` from the first attempt is still present, and a re-run dies at the upload step — before SignPath is ever contacted. The signing failure you were trying to retry never gets exercised.

## Fix

`overwrite: true` on the two `upload-artifact` steps in `build.yml` that can be re-run into an existing artifact:

- **`windows-bin` → "Upload unsigned executables for SignPath"** — the one that blocks release re-runs.
- **`linux-bin-and-snap-release` → "Upload E2E results on failure"** — same latent problem: the step is `if: ${{ failure() }}`, so a re-run after a second E2E failure collides identically.

Trade-off on the E2E one: the re-run's results replace the previous attempt's. That is the better of the two behaviours — the alternative is the upload failing outright, so you get *nothing* from the re-run plus a confusing second error. Download the first attempt's results before re-running if you need them side by side.

Also adds a SignPath troubleshooting entry to `docs/release-and-publishing.md`, since the workflow log is only a relay: for v18.20.0 it printed a bare `Invalid request to SignPath API.` with no connector logs and no `validationResult`, and the real reason exists only in SignPath's backend.

## Scope

Only `build.yml` is touched. Other workflows also use `upload-artifact` without `overwrite`, but none of them are on the release path, so they are left alone rather than swept.

Note that this helps **future** runs only. The stuck v18.20.0 run executes the workflow as it existed at the tag, so re-running it still requires deleting the existing artifact first (or waiting for it to expire at 2026-08-16 12:15 UTC).

## Verification

- `build.yml` parses; both `upload-artifact` steps in it now carry `overwrite: true`, and there are no others in the file.
- `overwrite` confirmed as a real input on the pinned `upload-artifact` SHA (v7.0.1).
- `prettier --check` clean on both changed files.
- Branch is exactly one commit on top of current `master`.
