### PR TITLE
feat: add full worklog export

### DIFF
--- a/docs/wiki/4.21-Worklog.md
+++ b/docs/wiki/4.21-Worklog.md
@@ -44,7 +44,7 @@ So the worklog is a **reorganized view** of the same “time spent per day” da
 
 - **Inline time correction** — Leaf-task rows can be corrected inline. The app updates the task's “time spent per day” value for that date, so the corrected time is reflected in History, reports, and metrics.
 - **Parent rows** — Parent tasks show the sum of their subtasks and are not edited directly, which avoids double-counting.
-- **Export** — You can export the worklog (e.g. to CSV or for external time sheets). Export uses the same task–date–duration data and can be **filtered by project and date range**. An option lets you **exclude time that falls outside the chosen range**, so only time within the range is included in the export. CSV output uses semicolons and safely quotes fields that contain semicolons, quotation marks, or line breaks. You can choose the text used to separate multiple task values in one exported field. When export is grouped by individual worklog rows, each row represents a task, date, and duration; start and end times are day-level values rather than per-task session times. That way you get a clean slice of work for the period you care about.
+- **Export** — You can export the complete worklog from the total at the top of History, or export an individual month or week. Export uses the same task–date–duration data and can be **filtered by project and date range**. An option lets you **exclude time that falls outside the chosen range**, so only time within the range is included in the export. CSV output uses semicolons and safely quotes fields that contain semicolons, quotation marks, or line breaks. You can choose the text used to separate multiple task values in one exported field. When export is grouped by individual worklog rows, each row represents a task, date, and duration; start and end times are day-level values rather than per-task session times. That way you get a clean slice of work for the period you care about.
 
 ## Summary
 
@@ -53,7 +53,7 @@ So the worklog is a **reorganized view** of the same “time spent per day” da
 - **Totals** — Only **leaf tasks** contribute to day/month/year totals so there is no double-counting.
 - **Refresh** — Updates when you open History (or its legacy `worklog`/`quick-history` routes) or the daily summary, or when you refresh manually; not live as you track.
 - **Editing** — Leaf-task time can be corrected inline; parent-task totals are read-only.
-- **Export** — Filter by project and date range; optional exclusion of time outside the range.
+- **Export** — Export the complete history or a single month or week; filter by project and date range, with optional exclusion of time outside the range.
 
 ## Related
 

--- a/src/app/features/history/history.component.html
+++ b/src/app/features/history/history.component.html
@@ -5,6 +5,17 @@
         wData.totalTimeSpent | msToString
       }}</strong>
     </h1>
+    <button
+      (click)="exportAllData()"
+      [attr.aria-label]="T.F.WORKLOG.CMP.EXPORT_DATA | translate"
+      [disabled]="!wData.totalTimeSpent"
+      [matTooltip]="T.F.WORKLOG.CMP.EXPORT_DATA | translate"
+      class="mat-elevation-z1 export-all"
+      color="primary"
+      mat-mini-fab
+    >
+      <mat-icon>call_made</mat-icon>
+    </button>
     <div class="years">
       @for (year of wData.worklog | keyvalue: sortWorklogItems; track year.key) {
         <div class="year">

--- a/src/app/features/history/history.component.scss
+++ b/src/app/features/history/history.component.scss
@@ -6,6 +6,11 @@
 
 .total-time {
   margin-top: var(--s4);
+  margin-bottom: var(--s);
+}
+
+.export-all {
+  margin-bottom: var(--s3);
 }
 
 .year {

--- a/src/app/features/history/history.component.spec.ts
+++ b/src/app/features/history/history.component.spec.ts
@@ -28,6 +28,7 @@ import { selectAllProjectColorsAndTitles } from '../project/store/project.select
 import { mapArchiveToWorklog } from '../worklog/util/map-archive-to-worklog';
 import { DateService } from '../../core/date/date.service';
 import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
+import { DialogWorklogExportComponent } from '../worklog/dialog-worklog-export/dialog-worklog-export.component';
 
 describe('HistoryComponent', () => {
   let fixture: ComponentFixture<HistoryComponent>;
@@ -198,6 +199,44 @@ describe('HistoryComponent', () => {
       .map((de) => de.nativeElement.textContent.trim());
 
     expect(dayLabels).toEqual(['Wed 1.', 'Thu 2.', 'Fri 3.']);
+  });
+
+  it('exports the complete worklog date range', () => {
+    const tasks = [createTaskForDate('2024-03-02'), createTaskForDate('2026-08-14')];
+    worklogData$.next(
+      mapArchiveToWorklog(
+        {
+          ids: tasks.map((task) => task.id),
+          entities: tasks.reduce(
+            (entities, task) => ({ ...entities, [task.id]: task }),
+            {},
+          ),
+        },
+        [],
+        { workStart: {}, workEnd: {} },
+        1,
+        'en-US',
+      ),
+    );
+    fixture.detectChanges();
+
+    fixture.componentInstance.exportAllData();
+
+    expect(matDialogSpy.open).toHaveBeenCalledWith(
+      DialogWorklogExportComponent,
+      jasmine.objectContaining({
+        data: {
+          rangeStart: new Date(2024, 2, 2),
+          rangeEnd: new Date(2026, 7, 14),
+        },
+      }),
+    );
+  });
+
+  it('does not open an export for an empty worklog', () => {
+    fixture.componentInstance.exportAllData();
+
+    expect(matDialogSpy.open).not.toHaveBeenCalled();
   });
 
   it('explicitly restores the archived hierarchy to Today once', fakeAsync(() => {

--- a/src/app/features/history/history.component.ts
+++ b/src/app/features/history/history.component.ts
@@ -35,6 +35,8 @@ import { WorklogTaskRowComponent } from '../worklog/worklog-task-row/worklog-tas
 import { HistoryDayMetaComponent } from './history-day-meta/history-day-meta.component';
 import { DateService } from '../../core/date/date.service';
 import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
+import { parseDbDateStr } from '../../util/parse-db-date-str';
+import { WorklogDay, WorklogMonth, WorklogYear } from '../worklog/worklog.model';
 
 @Component({
   selector: 'history',
@@ -110,6 +112,31 @@ export class HistoryComponent {
         ? getDateRangeForWeek(+year, week, +month)
         : getDateRangeForMonth(+year, +month);
 
+    this._openExportDialog(rangeStart, rangeEnd);
+  }
+
+  exportAllData(): void {
+    const worklog = this.worklogData()?.worklog;
+    if (!worklog) {
+      return;
+    }
+
+    const dateStrings = (Object.values(worklog) as WorklogYear[])
+      .flatMap((year) => Object.values(year.ent) as WorklogMonth[])
+      .flatMap((month) => Object.values(month.ent) as WorklogDay[])
+      .map((day) => day.dateStr)
+      .sort();
+
+    const firstDate = dateStrings[0];
+    const lastDate = dateStrings[dateStrings.length - 1];
+    if (!firstDate || !lastDate) {
+      return;
+    }
+
+    this._openExportDialog(parseDbDateStr(firstDate), parseDbDateStr(lastDate));
+  }
+
+  private _openExportDialog(rangeStart: Date, rangeEnd: Date): void {
     this._matDialog.open(DialogWorklogExportComponent, {
       restoreFocus: true,
       panelClass: 'big',


### PR DESCRIPTION
Fixes #4393.

Adds an export action next to the total worklog time. It derives the first and last recorded worklog dates and reuses the existing export dialog, so users can export all available history without exporting each month separately. Empty worklogs leave the action disabled and do not open a dialog.

Also updates the Worklog wiki and adds regression coverage for the full date range and empty state.

Verification:
- `npm run checkFile src/app/features/history/history.component.ts`
- `npm run checkFile src/app/features/history/history.component.spec.ts`
- `npm run checkFile src/app/features/history/history.component.scss`
- `npm run test:file -- src/app/features/history/history.component.spec.ts` (6 tests passed)
- `git diff --check`