### PR TITLE
fix(mobile): reserve the full bottom safe area and dock the add-task FAB

### DIFF
--- a/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
+++ b/src/app/core-ui/mobile-bottom-nav/mobile-bottom-nav.component.scss
@@ -81,9 +81,16 @@
     flex: 0 0 var(--s7);
     width: var(--s7);
     height: var(--s7);
-    margin-left: var(--s);
-    margin-right: var(--s);
-    margin-bottom: var(--s3);
+    // A full nav-button width of gutter on each side. At var(--s) the 56px FAB
+    // came within 7px of the neighbouring buttons' active pill on a 390px
+    // viewport, so it read as sitting on top of the row rather than beside it.
+    margin-left: var(--s2);
+    margin-right: var(--s2);
+    // Dock the FAB centred on the bar's top edge instead of sinking it into the
+    // icon row. With `align-items: center` the margin box is centred in the
+    // --bottom-nav-height content box, so a bottom margin of exactly that
+    // height puts the FAB's centre on the bar's top border — for any FAB size.
+    margin-bottom: var(--bottom-nav-height);
     box-shadow: var(--whiteframe-shadow-4dp);
     transition: var(--transition-standard);
 

--- a/src/app/features/onboarding/onboarding-hint.component.scss
+++ b/src/app/features/onboarding/onboarding-hint.component.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/globals' as *;
+
 :host {
   pointer-events: none;
 }
@@ -8,16 +10,32 @@
   pointer-events: auto;
   animation: hint-appear var(--transition-duration-l) var(--ani-enter-timing);
 
+  // The un-anchored variant (the closing "explore" hint has no target element).
+  // It used to sit dead centre of the viewport, where it reads as a modal with
+  // no backdrop and covers whatever is underneath — settings rows, the task
+  // list. Park it in the bottom-end corner like a toast instead: out of the
+  // centred content column, clear of the side nav and the header.
   &.floating {
-    top: 50%;
-    left: 50%;
-    bottom: auto;
-    transform: translate(-50%, -50%);
-    animation-name: hint-appear-floating;
+    top: auto;
+    left: auto;
+    inset-inline-end: var(--s2);
+    inset-block-end: calc(var(--s2) + var(--safe-area-bottom));
+    transform: none;
 
     .hint-chip {
-      max-width: 340px;
+      max-width: min(340px, calc(100vw - var(--s4)));
     }
+  }
+}
+
+// Clear the mobile bottom nav, the same way snack bars do
+// (see src/styles/components/_overwrite-material.scss).
+@include mq(xs, max) {
+  :host-context(body.hasMobileBottomNav) .hint-container.floating {
+    inset-block-end: calc(
+      var(--s2) + var(--bottom-nav-height) + var(--bottom-nav-safe-area) +
+        var(--bottom-nav-extra-offset)
+    );
   }
 }
 
@@ -155,18 +173,6 @@
   to {
     opacity: 1;
     transform: translateY(0);
-  }
-}
-
-@keyframes hint-appear-floating {
-  from {
-    opacity: 0;
-    transform: translate(-50%, calc(-50% + 4px));
-  }
-
-  to {
-    opacity: 1;
-    transform: translate(-50%, -50%);
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,12 +56,6 @@ body.isNativeMobile {
   }
 }
 
-// Native Android's opaque system bars need the full inset, not the iOS half
-// default — see --bottom-nav-safe-area in _css-variables.scss (#8792).
-body.isNativeMobile:not(.isIOS) {
-  --bottom-nav-safe-area: var(--safe-area-bottom);
-}
-
 // iOS-specific adjustments
 body.isIOS {
   // Prevent overscroll bounce effect

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -65,18 +65,25 @@
   --safe-area-right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));
 
   // Bottom clearance reserved by the mobile bottom nav and everything stacked
-  // above it (scroll content, snackbars). Half the inset by default: iOS's home
-  // indicator is thin and translucent, so a full inset reads as an oversized gap.
-  // Native Android's system bars (3-button / gesture) are opaque and must be
-  // cleared in full or the nav buttons draw under them (#8792) — overridden to
-  // the full inset for native Android in styles.scss. Reads through the shared
-  // --safe-area-bottom (not raw env()) so this tracks the same source as the
-  // header/side-nav/body insets and all bottom-inset UI behaves uniformly across
-  // SystemBars WebView bands. Caveat: on the narrow API >= 35 / WebView < 140
-  // band the shared source can double-count vs SystemBars' native padding (a
-  // cosmetic gap, not an overlap — see the device-matrix risks in
+  // above it (scroll content, snackbars). The FULL inset, on every platform.
+  //
+  // This used to be half the inset on iOS on the theory that the home indicator
+  // is thin and translucent, so a full inset would read as an oversized gap.
+  // It doesn't: the nav's background fills the reserved band (see
+  // mobile-bottom-nav.component.scss), so there is no gap to see — only the
+  // 44px button row moves up out of the band. At half of a 34pt iOS inset the
+  // icons and the active-item pill still land inside the home-indicator band
+  // (#5563), which is also why native Android already needed the full inset
+  // (#8792). One rule for both is simpler and correct in both places.
+  //
+  // Reads through the shared --safe-area-bottom (not raw env()) so this tracks
+  // the same source as the header/side-nav/body insets and all bottom-inset UI
+  // behaves uniformly across SystemBars WebView bands. Caveat: on the narrow
+  // API >= 35 / WebView < 140 band the shared source can double-count vs
+  // SystemBars' native padding (a cosmetic gap, not an overlap — see the
+  // device-matrix risks in
   // docs/plans/2026-06-22-android-systembars-migration-corrected.md).
-  --bottom-nav-safe-area: calc(var(--safe-area-bottom) / 2);
+  --bottom-nav-safe-area: var(--safe-area-bottom);
 
   // Keyboard height (set dynamically via JS)
   --keyboard-height: 0px;


### PR DESCRIPTION
Split out of #9304, which carried these two alongside a CSS-token sweep. They are
the part of that branch CI cannot speak to — both need a look on a real device —
so they get their own PR rather than blocking a lint gate behind a layout change.

## Reserve the full bottom safe area

Fixes #5563.

`--bottom-nav-safe-area` was half the inset on iOS, on the theory that the home
indicator is thin and translucent so a full inset would read as an oversized gap.
It doesn't: the nav's background fills the reserved band
(`mobile-bottom-nav.component.scss` sets `height: calc(--bottom-nav-height +
--bottom-nav-safe-area)` with a matching `padding-bottom`), so there is no gap to
see — only the 44px button row moves up out of the band.

At half of a 34pt iOS inset the icons and the active-item pill still land inside
the home-indicator band, which is what #5563 reports on an iPhone PWA. Native
Android already needed the full inset for the same reason (#8792) and was getting
it via a `body.isNativeMobile:not(.isIOS)` override in `styles.scss`. One rule for
both is simpler and correct in both places, so the override is gone.

`viewport-fit=cover` is set in `index.html`, so `env(safe-area-inset-bottom)`
resolves in the iOS PWA. Everything stacked on the bar — content padding, snack
bars, and the hint below — reads through the same token and moves with it.

## Dock the add-task FAB

The FAB sat *in* the icon row with a `var(--s)` gutter, which put the 56px button
within 7px of the neighbouring buttons' active pill on a 390px viewport — it read
as sitting on top of the row rather than beside it. Gutter goes to `var(--s2)`, a
full nav-button width each side.

`margin-bottom: var(--bottom-nav-height)` docks it centred on the bar's top edge:
with `align-items: center` the margin box is centred in the `--bottom-nav-height`
content box, so a bottom margin of exactly that height puts the FAB's centre on
the border — for any FAB size. The `.smaller` variant resets it.

## Anchor the floating onboarding hint like a toast

The un-anchored variant (the closing "explore" hint has no target element) sat
dead centre of the viewport, where it reads as a modal with no backdrop and covers
whatever is underneath. It moves to the bottom-end corner, clear of the side nav,
the header and the mobile bottom nav — the last of those the same way snack bars
do it in `_overwrite-material.scss`.

## What to look at

Neither change is visible to CI, so the useful review is a screenshot:

- **A notched iPhone.** The bar grows from 44+17px to 44+34px. Check the icons and
  the active pill clear the home indicator, and that the extra 17px doesn't read as
  dead weight.
- **Android, 3-button and gesture.** Should be unchanged — it already had the full
  inset — but the override moved, so it is worth confirming.
- **The FAB overhang.** It now stands 28px proud of the bar, over scrollable
  content, at the bar's z-index. That strip will intercept taps on whatever is
  beneath it. Inherent to a docked FAB and presumably what we want, but it is the
  judgement call the diff cannot make.

`ng build` passes. There is no automated coverage for any of the above.
