### PR TITLE
fix(tasks): render Later Today subtasks in subTaskIds order (#9614)

### DIFF
--- a/e2e/tests/work-view/later-today-subtask-order-9614.spec.ts
+++ b/e2e/tests/work-view/later-today-subtask-order-9614.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Issue #9614: Sorting sub-tasks of a repeating task does not apply on Today.
+ *
+ * A repeating task with a time (e.g. "Every day, 22:00") creates a daily
+ * instance scheduled for later today, which is rendered in the "Later Today"
+ * panel of the Today view. Reordering its subtasks updates parent.subTaskIds
+ * (visible in the task detail panel), but the "Later Today" panel kept
+ * rendering the subtasks in store insertion order because
+ * selectLaterTodayStructure derived the subtask order from snapshot iteration
+ * order instead of parent.subTaskIds.
+ *
+ * This test schedules a parent for later today (same selector path as a
+ * repeating instance), reorders its subtasks via the keyboard shortcut
+ * (Ctrl+Shift+ArrowUp, same store action as drag & drop) and asserts the
+ * panel reflects the new order.
+ */
+
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+
+const getFutureTimeToday = (): string => {
+  const now = new Date();
+  const future = new Date(now.getTime() + TWO_HOURS_MS);
+  if (future.getDate() !== now.getDate()) {
+    // Close to midnight: clamp to the last minutes of today.
+    return '23:59';
+  }
+  const hh = String(future.getHours()).padStart(2, '0');
+  const mm = String(future.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+};
+
+test.describe('Later Today: subtask order (#9614)', () => {
+  test('reordering subtasks is reflected in the Later Today panel', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    const parentName = `${testPrefix}-EndOfDay`;
+    await workViewPage.addTask(parentName);
+    const parent = taskPage.getTaskByText(parentName).first();
+    await expect(parent).toBeVisible();
+
+    await workViewPage.addSubTask(parent, `${testPrefix}-Sub1`);
+    await workViewPage.addSubTask(parent, `${testPrefix}-Sub2`);
+    await workViewPage.addSubTask(parent, `${testPrefix}-Sub3`);
+    await expect(taskPage.getSubTasks(parent)).toHaveCount(3);
+
+    // Schedule the parent for later today via the schedule dialog ('s').
+    await parent.focus();
+    await expect(parent).toBeFocused();
+    await page.keyboard.press('s');
+
+    const scheduleDialog = page.locator('dialog-schedule-task');
+    await expect(scheduleDialog).toBeVisible({ timeout: 10000 });
+
+    const todayCell = scheduleDialog.locator('.mat-calendar-body-today').first();
+    await expect(todayCell).toBeVisible();
+    await todayCell.click();
+
+    const timeInput = scheduleDialog.locator('input[type="time"]');
+    await timeInput.waitFor({ state: 'visible', timeout: 10000 });
+    await timeInput.fill(getFutureTimeToday());
+
+    await scheduleDialog.locator('[data-test-id="schedule-submit-btn"]').click();
+    await scheduleDialog.waitFor({ state: 'hidden', timeout: 10000 });
+
+    // The parent now lives in the "Later Today" panel.
+    const laterTodayList = page.locator('task-list[listModelId="LATER_TODAY"]');
+    await expect(laterTodayList).toBeVisible({ timeout: 10000 });
+    const parentInPanel = laterTodayList
+      .locator('task')
+      .filter({ hasText: parentName })
+      .first();
+    await expect(parentInPanel).toBeVisible();
+
+    const subTaskTitles = parentInPanel.locator('.sub-tasks task task-title');
+    await expect(subTaskTitles).toHaveText(
+      [`${testPrefix}-Sub1`, `${testPrefix}-Sub2`, `${testPrefix}-Sub3`],
+      { timeout: 10000 },
+    );
+
+    // Move Sub3 to the top (2x Ctrl+Shift+ArrowUp) - dispatches moveSubTaskUp,
+    // which mutates parent.subTaskIds exactly like drag & drop does.
+    const sub3 = taskPage
+      .getSubTasks(parentInPanel)
+      .filter({ hasText: `${testPrefix}-Sub3` })
+      .first();
+    await sub3.focus();
+    await expect(sub3).toBeFocused();
+    await page.keyboard.press('Control+Shift+ArrowUp');
+    await page.waitForTimeout(300);
+    await page.keyboard.press('Control+Shift+ArrowUp');
+
+    // The panel must reflect the new order. Before the fix it kept showing
+    // the original creation order even though subTaskIds had changed.
+    await expect(subTaskTitles).toHaveText(
+      [`${testPrefix}-Sub3`, `${testPrefix}-Sub1`, `${testPrefix}-Sub2`],
+      { timeout: 10000 },
+    );
+  });
+});

--- a/src/app/features/tasks/store/task-later-today.selectors.spec.ts
+++ b/src/app/features/tasks/store/task-later-today.selectors.spec.ts
@@ -618,6 +618,39 @@ describe('selectLaterTodayTasksWithSubTasks', () => {
     expect(subTaskIds).toContain('SUB_UNSCHEDULED_M');
   });
 
+  it('should order subtasks by parent subTaskIds, not by store insertion order (#9614)', () => {
+    // Reordering subtasks (drag & drop / move up / down) only updates
+    // parent.subTaskIds - the entity insertion order in the store never changes.
+    // The Later Today panel must follow subTaskIds like every other list.
+    const parentTask = createMockTask({
+      id: 'PARENT_REORDERED',
+      title: 'Parent with reordered subtasks',
+      dueWithTime: todayAt(22, 0),
+      dueDay: todayStr,
+      subTaskIds: ['SUB_R2', 'SUB_R1'], // user moved SUB_R2 to the top
+    });
+
+    const subR1 = createMockTask({
+      id: 'SUB_R1',
+      title: 'Subtask created first',
+      parentId: 'PARENT_REORDERED',
+      dueDay: todayStr,
+    });
+
+    const subR2 = createMockTask({
+      id: 'SUB_R2',
+      title: 'Subtask created second',
+      parentId: 'PARENT_REORDERED',
+      dueDay: todayStr,
+    });
+
+    // Store insertion order (creation order): SUB_R1 before SUB_R2
+    const result = runLaterToday([parentTask, subR1, subR2], todayStr, 0);
+
+    expect(result.length).toBe(1);
+    expect(result[0].subTasks?.map((st) => st.id)).toEqual(['SUB_R2', 'SUB_R1']);
+  });
+
   it('should expose scheduled nested subtasks as top-level when their direct parent is not included', () => {
     const grandparent = createMockTask({
       id: 'GRANDPARENT',

--- a/src/app/features/tasks/store/task.selectors.ts
+++ b/src/app/features/tasks/store/task.selectors.ts
@@ -630,17 +630,10 @@ export const selectLaterTodayStructure = createSelector(
     const scheduledParentTasks: SchedulingSnapshot[] = [];
     const scheduledSubtasks: SchedulingSnapshot[] = [];
     const unscheduledParentsInToday: SchedulingSnapshot[] = [];
-    const subtaskIdsByParentId: Record<string, string[]> = {};
     const dueWithTimeById = new Map<string, number | null>();
 
     for (const snap of snapshot) {
       dueWithTimeById.set(snap.id, snap.dueWithTime);
-      if (snap.parentId) {
-        if (!subtaskIdsByParentId.hasOwnProperty(snap.parentId)) {
-          subtaskIdsByParentId[snap.parentId] = [];
-        }
-        subtaskIdsByParentId[snap.parentId].push(snap.id);
-      }
 
       if (snap.isDone || !isInToday(snap)) continue;
 
@@ -685,8 +678,12 @@ export const selectLaterTodayStructure = createSelector(
 
     // Sort by earliest scheduled time (parent's own dueWithTime or its subtasks').
     // PERF: Pre-compute earliest times to avoid recalculating in sort comparator.
+    // NOTE: subtask order MUST come from the parent's subTaskIds (the single
+    // source of truth for manual ordering, like selectAllTasksWithSubTasksStructure)
+    // and NOT from snapshot iteration order - the entity insertion order never
+    // changes on reorder, so the panel would ignore drag & drop (#9614).
     const withTimes = allTopLevel.map((snap) => {
-      const childIds = subtaskIdsByParentId[snap.id] ?? [];
+      const childIds = snap.subTaskIds;
       const earliestTime = Math.min(
         snap.dueWithTime || Infinity,
         ...childIds.map((cid) => dueWithTimeById.get(cid) || Infinity),


### PR DESCRIPTION
Fixes #9614

## Problem

Reordering the sub-tasks of a task that is scheduled for later today (most prominently the daily instance of a repeating task with a time, e.g. "Every day, 22:00") updates the store and the task detail panel, but the "Later Today" panel in the Today view keeps rendering the sub-tasks in their creation order.

Cause: `selectLaterTodayStructure` derived each parent's sub-task order from the iteration order of the scheduling snapshot (entity insertion order, which never changes on reorder) instead of from `parent.subTaskIds`, the single source of truth for manual ordering. For repeating tasks this is especially visible because the sub-task instances are recreated from templates every day, so any reordering done during the day never shows up in the panel.

## Fix

Use the parent's `subTaskIds` from the scheduling snapshot, exactly like `selectAllTasksWithSubTasksStructure` already does. The obsolete `subtaskIdsByParentId` map (built from iteration order) is removed. Downstream behavior is unchanged: the stable with-sub-tasks mapper already drops missing entities, and the earliest-time sort reads times per id, so orphaned/scheduled-sub-task handling and sorting are unaffected (all 29 existing later-today specs still pass).

## Reproduction / Tests

- New unit test in `task-later-today.selectors.spec.ts` that fails without the fix (sub-tasks came back in insertion order instead of `subTaskIds` order).
- New E2E test `e2e/tests/work-view/later-today-subtask-order-9614.spec.ts`: schedules a parent for later today, reorders its sub-tasks, and asserts the panel reflects the new order. Fails on master, passes with the fix (verified both ways locally).
- `npm run test:file` for `task-later-today.selectors.spec.ts` (29 ✓) and `task.selectors.spec.ts` (77 ✓), `checkFile` clean on all touched files.

Note: sync-wise this is a pure read-path/selector change; no actions, reducers, or op-log behavior are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)