### PR TITLE
fix(schedule): drive the month grid from the real week count

### DIFF
--- a/src/app/features/schedule/schedule-month/schedule-month.component.scss
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.scss
@@ -69,40 +69,8 @@
   max-width: 100%;
   overflow: hidden;
 
-  :host[style*='--nr-of-weeks: 3'] & {
-    min-height: 120px;
-  }
-
-  :host[style*='--nr-of-weeks: 4'] & {
-    min-height: 100px;
-  }
-
-  :host[style*='--nr-of-weeks: 5'] & {
-    min-height: 85px;
-  }
-
-  :host[style*='--nr-of-weeks: 6'] & {
-    min-height: 70px;
-  }
-
   @include mq(xs, max) {
     min-height: 50px;
-
-    :host[style*='--nr-of-weeks: 3'] & {
-      min-height: 80px;
-    }
-
-    :host[style*='--nr-of-weeks: 4'] & {
-      min-height: 65px;
-    }
-
-    :host[style*='--nr-of-weeks: 5'] & {
-      min-height: 55px;
-    }
-
-    :host[style*='--nr-of-weeks: 6'] & {
-      min-height: 50px;
-    }
   }
 
   &.other-month {
@@ -173,40 +141,6 @@
   @include mq(xs, max) {
     padding: var(--s-quarter);
     max-height: calc(100% - 25px);
-  }
-
-  :host[style*='--nr-of-weeks: 3'] & .month-event:nth-child(n + 8) {
-    display: none;
-  }
-
-  :host[style*='--nr-of-weeks: 4'] & .month-event:nth-child(n + 6) {
-    display: none;
-  }
-
-  :host[style*='--nr-of-weeks: 5'] & .month-event:nth-child(n + 4) {
-    display: none;
-  }
-
-  :host[style*='--nr-of-weeks: 6'] & .month-event:nth-child(n + 3) {
-    display: none;
-  }
-
-  @include mq(xs, max) {
-    :host[style*='--nr-of-weeks: 3'] & .month-event:nth-child(n + 4) {
-      display: none;
-    }
-
-    :host[style*='--nr-of-weeks: 4'] & .month-event:nth-child(n + 3) {
-      display: none;
-    }
-
-    :host[style*='--nr-of-weeks: 5'] & .month-event:nth-child(n + 2) {
-      display: none;
-    }
-
-    :host[style*='--nr-of-weeks: 6'] & .month-event:nth-child(n + 2) {
-      display: none;
-    }
   }
 
   .month-event:nth-child(n + 4) {

--- a/src/app/features/schedule/schedule-month/schedule-month.component.spec.ts
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.spec.ts
@@ -307,6 +307,44 @@ describe('ScheduleMonthComponent', () => {
     });
   });
 
+  describe('week-count custom property', () => {
+    // `--nr-of-weeks` was only ever declared as a static 6 on `schedule`, so
+    // `grid-template-rows` always repeated six rows. At 5 weeks that rendered a
+    // sixth, empty row and sized every row 1/6 instead of 1/5 (#9584).
+    it('should expose the rendered week count on the host', () => {
+      const host = fixture.nativeElement as HTMLElement;
+
+      fixture.componentRef.setInput('weeksToShow', 5);
+      fixture.detectChanges();
+
+      expect(host.style.getPropertyValue('--nr-of-weeks')).toBe('5');
+    });
+
+    it('should give the grid one row per rendered week', () => {
+      const host = fixture.nativeElement as HTMLElement;
+      const grid = host.querySelector('.month-grid-container') as HTMLElement;
+
+      fixture.componentRef.setInput('weeksToShow', 5);
+      fixture.detectChanges();
+
+      // `auto` for the weekday headers, then one row per week.
+      const rows = getComputedStyle(grid).gridTemplateRows.split(' ').length;
+      expect(rows).toBe(6);
+    });
+
+    it('should track the week count when it changes', () => {
+      const host = fixture.nativeElement as HTMLElement;
+
+      fixture.componentRef.setInput('weeksToShow', 3);
+      fixture.detectChanges();
+      expect(host.style.getPropertyValue('--nr-of-weeks')).toBe('3');
+
+      fixture.componentRef.setInput('weeksToShow', 6);
+      fixture.detectChanges();
+      expect(host.style.getPropertyValue('--nr-of-weeks')).toBe('6');
+    });
+  });
+
   describe('getDayClass', () => {
     it('should pass referenceMonth to service.getDayClass', () => {
       // Arrange

--- a/src/app/features/schedule/schedule-month/schedule-month.component.ts
+++ b/src/app/features/schedule/schedule-month/schedule-month.component.ts
@@ -14,6 +14,15 @@ import { parseDbDateStr } from 'src/app/util/parse-db-date-str';
 import { TranslatePipe, TranslateService, TranslateStore } from '@ngx-translate/core';
 import { getPluralKey } from '../../../util/get-plural-key';
 
+// `grid-template-rows` repeats `var(--nr-of-weeks)`, which otherwise resolves to
+// the static 6 declared on `schedule`. At 5 weeks that leaves a sixth, empty row
+// and sizes every row 1/6 instead of 1/5 (#9584).
+const HOST_WEEKS_VAR = '[style.--nr-of-weeks]' as const;
+
+const HOST_BINDINGS = {
+  [HOST_WEEKS_VAR]: 'weeksToShow()',
+} as const;
+
 @Component({
   selector: 'schedule-month',
   imports: [ScheduleEventComponent, TranslatePipe],
@@ -21,6 +30,7 @@ import { getPluralKey } from '../../../util/get-plural-key';
   styleUrl: './schedule-month.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
+  host: HOST_BINDINGS,
 })
 export class ScheduleMonthComponent {
   private _scheduleService = inject(ScheduleService);


### PR DESCRIPTION
Fixes #9584

Both halves in one commit, so the binding never activates the dead rules.

Thanks for the runtime measurements — and for the correction. You're right that `weeksToShow` is derived from `window.innerHeight`, so 3 weeks is the *shortest* window, not the most crowded month. I had that backwards, and it does make the delete case stronger.

## 1. Delete the 16 dead selectors

`--nr-of-weeks` was only ever declared inside a stylesheet, so it never reached the host's `style` attribute and none of the selectors matched. The adaptive cell heights and per-week-count event caps they describe have never shipped.

Not revived, per your measurements: every one of them outranks the single `@media (min-height: 800px)` rule that lifts the generic cap, so turning them on can only subtract — 8 events down to 2 at 6 weeks on a tall screen. The generic height-driven cap stays as the one capping system.

## 2. Bind the property to the rendered week count

This is the half that fixes something users actually see. `grid-template-rows: auto repeat(var(--nr-of-weeks), 1fr)` did resolve, but always to the static 6 inherited from `schedule`, while the template only renders cells for `weekIndex < weeksToShow()`. At 5 weeks that declared six rows for five weeks of cells, sized every row 1/6, and left a blank strip at the bottom — and 1366x768 lands squarely in the 5-week bucket.

Bound on `ScheduleMonthComponent` rather than `ScheduleComponent`, since `:host` in that stylesheet is `<schedule-month>`.

One wrinkle worth flagging: written through the `HOST_BINDINGS` const pattern from `progress-circle.component.ts`, because a literal `'[style.--nr-of-weeks]'` key trips `@typescript-eslint/naming-convention`. `ScheduleComponent`'s existing `--nr-of-days` binding only gets away with the literal because that file is `/* eslint-disable */`. Happy to switch to an inline disable comment if you'd prefer the shape to match `ScheduleComponent` exactly.

## Verification

Three specs cover the binding, and all three fail without it (`Expected '' to be '5'`, `Expected '' to be '3'`/`'6'` for the change-tracking case, and the grid row count). 36/36 in the month spec, 64/64 in the schedule spec, `npm run checkFile` clean on all three changed files.

I left `--nr-of-weeks: 6` on `schedule` in place as a fallback rather than widening the diff. Say the word if you'd rather it go.

**Not in scope, per your comment:** the "+N more" badge, which stays a separate PR.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing setting or API change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
