### PR TITLE
fix(electron): Update StartupWMClass for electron-builder

### DIFF
--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -87,7 +87,7 @@ linux:
     - x-scheme-handler/superproductivity
   desktop:
     entry:
-      StartupWMClass: superproductivity
+      StartupWMClass: superproductivity-bin
   target:
     - AppImage
     - deb


### PR DESCRIPTION
## Problem

A generic (gear) icon from the desktop environment shown in the task bar.

## Solution

'StartupWMClass: superproductivity' being replaced by 'StartupWMClass: superproductivity-bin' in electron-builder.yaml

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [X] I have added tests for my changes (if applicable)
- [X] Existing tests still pass
- [X] My commit messages follow the Angular format (`type(scope): description`)
