### PR TITLE
 fix(issue-provider): include error detail in "Connection failed" message (#9635)

### DIFF
--- a/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
+++ b/src/app/features/issue/dialog-edit-issue-provider/dialog-edit-issue-provider.component.ts
@@ -72,6 +72,7 @@ import { ISSUE_PROVIDER_COMMON_FORM_FIELDS } from '../common-issue-form-stuff.co
 import { TagService } from '../../tag/tag.service';
 import { ChipListInputComponent } from '../../../ui/chip-list-input/chip-list-input.component';
 import { unique } from '../../../util/unique';
+import { getErrorTxt } from '../../../util/get-error-text';
 import { mergeIssueProviderModelUpdates } from './issue-provider-model-merge.util';
 
 type OptionsLoadState = 'idle' | 'loading' | 'loaded' | 'empty' | 'failed';
@@ -300,6 +301,7 @@ export class DialogEditIssueProviderComponent {
         this._snackService.open({
           type: 'ERROR',
           msg: T.F.ISSUE.S.CONNECTION_FAILED,
+          translateParams: { errorMsg: 'Unknown error' },
         });
       }
     } catch (error) {
@@ -307,6 +309,7 @@ export class DialogEditIssueProviderComponent {
       this._snackService.open({
         type: 'ERROR',
         msg: T.F.ISSUE.S.CONNECTION_FAILED,
+        translateParams: { errorMsg: getErrorTxt(error) },
       });
     }
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -516,7 +516,7 @@
       },
       "S": {
         "AUTO_CREATE_FAILED": "Auto-create issue failed: {{errorMsg}}",
-        "CONNECTION_FAILED": "Connection failed",
+        "CONNECTION_FAILED": "Connection failed: {{errorMsg}}",
         "CONNECTION_SUCCESS": "Connection works!",
         "ERR_GENERIC": "{{issueProviderName}} Error: {{errTxt}}",
         "ERR_NETWORK": "{{issueProviderName}}: Request failed because of a client side network error",


### PR DESCRIPTION
## Problem

Vague error message when testing connection to an issue provider.

## Solution

Added status code response when an error occurs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
