### PR TITLE
feat: add Auto-Fill Time Spent community plugin

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/MazenMohamed203/auto-fill-time-spent",
     "author": "MazenMohamed203",
     "authorUrl": "https://github.com/MazenMohamed203",
-    "stars": 2
+    "stars": 5
   },
   {
     "name": "Obsidian Integration",

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -40,12 +40,12 @@
     "stars": 0
   },
   {
-  "name": "Auto-Fill Time Spent",
-  "shortDescription": "Automatically sets Time Spent equal to Time Estimate when completing a task that has no tracked time. Perfect for off-computer activities.",
-  "url": "https://github.com/MazenMohamed203/auto-fill-time-spent",
-  "author": "MazenMohamed203",
-  "authorUrl": "https://github.com/MazenMohamed203",
-  "stars": 1
+    "name": "Auto-Fill Time Spent",
+    "shortDescription": "Automatically sets Time Spent equal to Time Estimate when completing a task that has no tracked time. Perfect for off-computer activities.",
+    "url": "https://github.com/MazenMohamed203/auto-fill-time-spent",
+    "author": "MazenMohamed203",
+    "authorUrl": "https://github.com/MazenMohamed203",
+    "stars": 2
   },
   {
     "name": "Obsidian Integration",

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -40,6 +40,14 @@
     "stars": 0
   },
   {
+  "name": "Auto-Fill Time Spent",
+  "shortDescription": "Automatically sets Time Spent equal to Time Estimate when completing a task that has no tracked time. Perfect for off-computer activities.",
+  "url": "https://github.com/MazenMohamed203/auto-fill-time-spent",
+  "author": "MazenMohamed203",
+  "authorUrl": "https://github.com/MazenMohamed203",
+  "stars": 1
+  },
+  {
     "name": "Obsidian Integration",
     "shortDescription": "Provides 2-way sync between SP tasks and Obsidian tasks.",
     "url": "https://codeberg.org/sinenomine/sp-obsidian/",

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/MazenMohamed203/auto-fill-time-spent",
     "author": "MazenMohamed203",
     "authorUrl": "https://github.com/MazenMohamed203",
-    "stars": 5
+    "stars": 6
   },
   {
     "name": "Obsidian Integration",


### PR DESCRIPTION
When a task with a Time Estimate is marked complete and Time Spent is zero,
the plugin automatically sets Time Spent equal to the estimate.

## Problem

Users who don't use the built-in timer (e.g. for off-computer activities like
running, workouts, or errands) are left with Time Spent = 0 even when they had
an estimate set. 

Requested in: https://github.com/super-productivity/super-productivity/issues/5501

## Solution

Added the **Auto-Fill Time Spent** community plugin to `community-plugins.json`.

The plugin registers a `taskComplete` hook and sets `timeSpent = timeEstimate`
only when both conditions are true:
- `timeEstimate > 0` (the task has an estimate)
- `timeSpent === 0` (no time was tracked)

Tasks where the timer was actually used are never modified.

Plugin repo: https://github.com/MazenMohamed203/auto-fill-time-spent

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (please describe) — adding a plugin to the community plugins list

## Checklist

- [x] I have included relevant changes to the documentation/wiki
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files *(no .ts/.scss files changed)*
- [ ] I have added tests for my changes *(not applicable — JSON list addition only)*
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`feat: add Auto-Fill Time Spent community plugin`)