### PR TITLE
feat: show project and tags on recurring task previews

### DIFF
--- a/docs/wiki/4.03-Planner-View.md
+++ b/docs/wiki/4.03-Planner-View.md
@@ -42,7 +42,7 @@ When you plan a task for a day but don't complete it:
 
 The Planner shows:
 
-- **Recurring task projections** — Instances of repeating tasks on the days they'll occur
+- **Recurring task projections** — Instances of repeating tasks on the days they'll occur, including the project and tags the created instances will have
 - **Recurring tasks without times** — Shown as separate items in each day's column
 - **Recurring tasks with times** — Appear in the scheduled items timeline (Schedule view)
 - **Calendar events** — External calendar events merged into the same timeline view

--- a/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.html
+++ b/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.html
@@ -3,9 +3,15 @@
   [title]="T.F.PLANNER.EDIT_REPEATED_TASK | translate: { taskName: repeatCfg().title }"
 >
   <mat-icon>repeat</mat-icon>
-  <div class="title">
-    {{ repeatCfg().title }}
-    <!--   {{event.start|date:'HH:mm'}} – {{(event.start + event.duration)|date:'HH:mm'}}-->
+  <div class="wrap">
+    <div class="title">
+      {{ repeatCfg().title }}
+      <!--   {{event.start|date:'HH:mm'}} – {{(event.start + event.duration)|date:'HH:mm'}}-->
+    </div>
+    <tag-list
+      [isShowProjectTagAlways]="true"
+      [task]="repeatCfg()"
+    ></tag-list>
   </div>
   <div class="planner-time-remaining-shared">
     @if (overWriteTimeEstimate() > 0) {

--- a/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.html
+++ b/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.html
@@ -9,6 +9,7 @@
       <!--   {{event.start|date:'HH:mm'}} – {{(event.start + event.duration)|date:'HH:mm'}}-->
     </div>
     <tag-list
+      class="planner-tag-list-shared"
       [isShowProjectTagAlways]="true"
       [task]="repeatCfg()"
     ></tag-list>

--- a/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.scss
+++ b/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.scss
@@ -38,31 +38,16 @@
 
 .wrap {
   flex-grow: 1;
-  flex-shrink: 1;
   min-width: 0;
 }
 
 .title {
   font-size: var(--planner-font-size-mobile);
-  flex-shrink: 1;
-  min-width: 0;
   overflow: hidden;
   overflow-wrap: anywhere;
 
   @include mq(xs) {
     font-size: var(--planner-font-size);
-  }
-}
-
-// note: we use .tags-container, since we don't want margins for an empty list
-:host ::ng-deep .tags-container {
-  margin-top: var(--s-quarter);
-  margin-bottom: var(--s-quarter);
-}
-
-:host ::ng-deep .tag-title {
-  @include mq(xs) {
-    font-size: var(--planner-font-size-smaller) !important;
   }
 }
 

--- a/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.scss
+++ b/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.scss
@@ -36,6 +36,12 @@
   }
 }
 
+.wrap {
+  flex-grow: 1;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
 .title {
   font-size: var(--planner-font-size-mobile);
   flex-shrink: 1;
@@ -45,6 +51,18 @@
 
   @include mq(xs) {
     font-size: var(--planner-font-size);
+  }
+}
+
+// note: we use .tags-container, since we don't want margins for an empty list
+:host ::ng-deep .tags-container {
+  margin-top: var(--s-quarter);
+  margin-bottom: var(--s-quarter);
+}
+
+:host ::ng-deep .tag-title {
+  @include mq(xs) {
+    font-size: var(--planner-font-size-smaller) !important;
   }
 }
 

--- a/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.ts
+++ b/src/app/features/planner/planner-repeat-projection/planner-repeat-projection.component.ts
@@ -3,20 +3,20 @@ import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogEditTaskRepeatCfgComponent } from '../../task-repeat-cfg/dialog-edit-task-repeat-cfg/dialog-edit-task-repeat-cfg.component';
 import { T } from 'src/app/t.const';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { MatIcon } from '@angular/material/icon';
 import { MsToStringPipe } from '../../../ui/duration/ms-to-string.pipe';
+import { TagListComponent } from '../../tag/tag-list/tag-list.component';
 
 @Component({
   selector: 'planner-repeat-projection',
   templateUrl: './planner-repeat-projection.component.html',
   styleUrl: './planner-repeat-projection.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatIcon, MsToStringPipe, TranslatePipe],
+  imports: [MatIcon, MsToStringPipe, TranslatePipe, TagListComponent],
 })
 export class PlannerRepeatProjectionComponent {
   private _matDialog = inject(MatDialog);
-  private _translateService = inject(TranslateService);
 
   repeatCfg = input.required<TaskRepeatCfg>();
   overWriteTimeEstimate = input(0);

--- a/src/app/features/planner/planner-task/planner-task.component.html
+++ b/src/app/features/planner/planner-task/planner-task.component.html
@@ -33,6 +33,7 @@
         }
 
         <tag-list
+          class="planner-tag-list-shared"
           [isShowProjectTagAlways]="true"
           [tagsToHide]="tagsToHide()"
           [task]="task()"

--- a/src/app/features/planner/planner-task/planner-task.component.scss
+++ b/src/app/features/planner/planner-task/planner-task.component.scss
@@ -22,12 +22,10 @@
     }
   }
 
-  // note: we use .tags-container, since we don't want margins for an empty list
+  // v-margins come from the global .planner-tag-list-shared rules
   ::ng-deep .tags-container {
     // to match task title padding
     margin-left: 3px;
-    margin-bottom: var(--s-quarter);
-    margin-top: var(--s-quarter);
   }
 }
 
@@ -57,12 +55,6 @@
 
   @include mq(xs) {
     padding: var(--s-quarter) 0;
-  }
-}
-
-:host ::ng-deep .tag-title {
-  @include mq(xs) {
-    font-size: var(--planner-font-size-smaller) !important;
   }
 }
 

--- a/src/app/features/tag/tag-list/tag-list.component.ts
+++ b/src/app/features/tag/tag-list/tag-list.component.ts
@@ -31,6 +31,16 @@ import { getTaskRepeatInfoText } from '../../tasks/task-detail-panel/get-task-re
 import { TranslateService } from '@ngx-translate/core';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 
+/**
+ * Structural contract of what tag-list actually reads from its input. Both
+ * Task and TaskRepeatCfg satisfy it (repeat cfgs simply lack the optional
+ * issue/repeat fields, so those chips never render for them).
+ */
+export type TagListTask = Pick<
+  Task,
+  'tagIds' | 'issueId' | 'issueType' | 'issuePoints' | 'repeatCfgId'
+> & { projectId: string | null };
+
 @Component({
   selector: 'tag-list',
   templateUrl: './tag-list.component.html',
@@ -46,7 +56,7 @@ export class TagListComponent {
   private readonly _translateService = inject(TranslateService);
   private readonly _dateTimeFormatService = inject(DateTimeFormatService);
 
-  task = input.required<Task>();
+  task = input.required<TagListTask>();
 
   tagsToHide = input<string[]>();
 
@@ -106,7 +116,7 @@ export class TagListComponent {
       this.isShowProjectTagAlways() ||
       this.workContext()?.activeType === WorkContextType.TAG
     ) {
-      return this.task().projectId;
+      return this.task().projectId ?? undefined;
     }
     return undefined;
   });

--- a/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.html
+++ b/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.html
@@ -3,7 +3,10 @@
   [matTooltip]="nextDueTooltip()"
 >
   <mat-icon>repeat</mat-icon>
-  <div class="title">{{ repeatCfg().title }}</div>
+  <div class="wrap">
+    <div class="title">{{ repeatCfg().title }}</div>
+    <tag-list [task]="repeatCfg()"></tag-list>
+  </div>
   <div class="info">
     @if (repeatCfg().isPaused) {
       <mat-icon class="paused-icon">pause</mat-icon>

--- a/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.html
+++ b/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.html
@@ -5,7 +5,10 @@
   <mat-icon>repeat</mat-icon>
   <div class="wrap">
     <div class="title">{{ repeatCfg().title }}</div>
-    <tag-list [task]="repeatCfg()"></tag-list>
+    <tag-list
+      class="planner-tag-list-shared"
+      [task]="repeatCfg()"
+    ></tag-list>
   </div>
   <div class="info">
     @if (repeatCfg().isPaused) {

--- a/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.scss
+++ b/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.scss
@@ -27,10 +27,20 @@
   }
 }
 
-.title {
+.wrap {
   flex: 1;
   min-width: 0;
+}
+
+.title {
+  min-width: 0;
   @include truncateText();
+}
+
+// note: we use .tags-container, since we don't want margins for an empty list
+:host ::ng-deep .tags-container {
+  margin-top: var(--s-quarter);
+  margin-bottom: var(--s-quarter);
 }
 
 .info {

--- a/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.scss
+++ b/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.scss
@@ -33,14 +33,7 @@
 }
 
 .title {
-  min-width: 0;
   @include truncateText();
-}
-
-// note: we use .tags-container, since we don't want margins for an empty list
-:host ::ng-deep .tags-container {
-  margin-top: var(--s-quarter);
-  margin-bottom: var(--s-quarter);
 }
 
 .info {

--- a/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.ts
+++ b/src/app/features/task-repeat-cfg/repeat-cfg-preview/repeat-cfg-preview.component.ts
@@ -14,6 +14,7 @@ import { T } from '../../../t.const';
 import { TranslateService } from '@ngx-translate/core';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
+import { TagListComponent } from '../../tag/tag-list/tag-list.component';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { getNextRepeatOccurrence } from '../store/get-next-repeat-occurrence.util';
 import { formatMonthDay } from '../../../util/format-month-day.util';
@@ -24,7 +25,7 @@ import { Log } from '../../../core/log';
   templateUrl: './repeat-cfg-preview.component.html',
   styleUrl: './repeat-cfg-preview.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatIcon, MatTooltip],
+  imports: [MatIcon, MatTooltip, TagListComponent],
 })
 export class RepeatCfgPreviewComponent {
   private _matDialog = inject(MatDialog);

--- a/src/styles/components/planner-shared.scss
+++ b/src/styles/components/planner-shared.scss
@@ -30,6 +30,20 @@
   }
 }
 
+// tag chips on planner-style rows (planner-task, planner-repeat-projection,
+// repeat-cfg-preview); we target .tags-container, since we don't want margins
+// for an empty list
+tag-list.planner-tag-list-shared .tags-container {
+  margin-top: var(--s-quarter);
+  margin-bottom: var(--s-quarter);
+}
+
+tag-list.planner-tag-list-shared .tag-title {
+  @include media-queries.mq(xs) {
+    font-size: var(--planner-font-size-smaller) !important;
+  }
+}
+
 .planner-drag-place-holder-shared {
   min-height: var(--planner-item-height);
   margin-bottom: 4px;


### PR DESCRIPTION
## Summary

Fixes the confusion reported in #9626: recurring-task previews only showed the title, so users believed project/tag info does not carry over to future occurrences. The data was never lost — created instances inherit `projectId` and `tagIds` from the repeat config — but none of the previews showed it.

- **Planner repeat projections** (day columns and timed items) now render the project + tag chips via the shared `tag-list`, matching the real task rows next to them
- **Work-view "Recurring Tasks" section** rows show the chips too, following the same context rules as the task list above (project chip in tag contexts, tags elsewhere)
- Follow-up cleanup commit: consolidates the previously copy-pasted `::ng-deep` tag-chip styles (incl. the pre-existing `planner-task` copy) into a shared `.planner-tag-list-shared` class in `planner-shared.scss`, and types `tag-list`'s input as `TagListTask` — the structural contract both `Task` and `TaskRepeatCfg` satisfy (three call sites were relying on non-strict template checking)

Closes #9626

## Screenshots

Planner — future-day projections now show the same chips as the real instance:

(see issue #9626 for the before state)

## Verification

- `npm run checkFile` clean on all touched files; dev build compiles
- `tag-list` unit spec passes (15/15)
- Playwright run: created a tagged daily-repeat task, asserted chips render on the planner projection and the work-view Recurring Tasks row
- Existing projection-click e2e (`recurring-startdate-to-today-creates-real-instance-bug-7923`) still passes — chips are inert, projection click still opens the edit dialog