### PR TITLE
fix(android): decrypt E2EE op payloads in background reminder sync

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -46,7 +46,10 @@ jobs:
           echo "${CHANGED_FILES}"
 
           android=false
-          ANDROID_PATTERN='^(android/|capacitor\.config\.ts$|package(-lock)?\.json$|\.github/workflows/android-tests\.yml$)'
+          # packages/sync-core is included because the Kotlin op-payload
+          # decryptor must stay wire-compatible with its encrypt() — the live
+          # round-trip test below is what catches drift on sync-core PRs.
+          ANDROID_PATTERN='^(android/|packages/sync-core/|tools/generate-android-crypto-fixtures\.mjs$|capacitor\.config\.ts$|package(-lock)?\.json$|\.github/workflows/android-tests\.yml$)'
           if grep -Eq "${ANDROID_PATTERN}" <<< "${CHANGED_FILES}"; then android=true; fi
 
           echo "→ android=${android}"
@@ -93,9 +96,18 @@ jobs:
           mkdir -p android/app/src/main/assets/public
           npx cap update android
 
+      # Fresh ciphertexts from the real sync-core encrypt() (built by npm i),
+      # decrypted by LiveJsEncryptRoundTripTest — fails the PR that changes
+      # the KDF parameters or wire format.
+      - name: Generate live crypto fixtures from sync-core
+        if: steps.changes.outputs.android == 'true'
+        run: node tools/generate-android-crypto-fixtures.mjs
+
       - name: Run Android JVM tests
         if: steps.changes.outputs.android == 'true'
         working-directory: android
+        env:
+          LIVE_CRYPTO_FIXTURES: ${{ github.workspace }}/android/app/build/live-crypto-fixtures.tsv
         run: ./gradlew :app:testPlayDebugUnitTest :app:testFdroidDebugUnitTest
 
       - name: Enable KVM

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,4 +133,15 @@ dependencies {
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 }
 
+// The live crypto fixtures are generated outside Gradle
+// (tools/generate-android-crypto-fixtures.mjs), so declare them as a
+// unit-test input — otherwise a regenerated file leaves the test task
+// UP-TO-DATE/FROM-CACHE and LiveJsEncryptRoundTripTest silently reports
+// stale results (defeating its drift-detection purpose in CI).
+tasks.withType(Test).configureEach {
+    inputs.file(layout.buildDirectory.file('live-crypto-fixtures.tsv'))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+        .optional()
+}
+
 apply from: 'capacitor.build.gradle'

--- a/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Argon2.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Argon2.kt
@@ -358,14 +358,6 @@ object Argon2 {
         (value ushr 24).toByte(),
     )
 
-    private fun readLongLE(data: ByteArray, offset: Int): Long {
-        var result = 0L
-        for (i in 7 downTo 0) {
-            result = (result shl 8) or (data[offset + i].toLong() and 0xFF)
-        }
-        return result
-    }
-
     private fun longsToBytesLE(longs: LongArray): ByteArray {
         val out = ByteArray(longs.size * 8)
         for (i in longs.indices) {

--- a/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Argon2.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Argon2.kt
@@ -1,0 +1,379 @@
+package com.superproductivity.superproductivity.crypto
+
+/**
+ * Argon2id key derivation (RFC 9106, version 0x13), ported for decrypting
+ * E2EE SuperSync op payloads in the background sync worker.
+ *
+ * The JS side derives keys via hash-wasm's argon2id
+ * (packages/sync-core/src/encryption/argon2.ts); this implementation must
+ * produce identical output for identical inputs — locked by Argon2Test
+ * against the RFC 9106 test vector and hash-wasm generated vectors,
+ * including the production parameters (p=1, t=3, m=64 MiB).
+ *
+ * Lanes are computed sequentially: parallelism only permits concurrency, the
+ * result is identical. Fine here — production always uses parallelism=1.
+ *
+ * shortcut: pure-Kotlin block permutation via index tables — a derivation with
+ * production params takes seconds on a phone. Acceptable because results are
+ * cached per salt (see DerivedKeyCache); hand-inlined BlaMka rounds or JNI are
+ * the upgrade path if it ever matters.
+ */
+object Argon2 {
+
+    private const val VERSION = 0x13
+    private const val TYPE_ARGON2ID = 2
+    private const val BLOCK_LONGS = 128
+    private const val SYNC_POINTS = 4
+    private const val MASK_32 = 0xFFFFFFFFL
+
+    /** Row i of the 8x8 register matrix = 16 consecutive u64 words. */
+    private val ROW_INDICES = Array(8) { row -> IntArray(16) { row * 16 + it } }
+
+    /** Column i = register pairs (2i, 2i+1) of each row. */
+    private val COL_INDICES = Array(8) { col ->
+        IntArray(16) { k -> (k / 2) * 16 + 2 * col + (k % 2) }
+    }
+
+    fun argon2id(
+        password: ByteArray,
+        salt: ByteArray,
+        parallelism: Int,
+        memoryKiB: Int,
+        iterations: Int,
+        outputLength: Int,
+        secret: ByteArray = ByteArray(0),
+        associatedData: ByteArray = ByteArray(0),
+    ): ByteArray {
+        require(parallelism >= 1) { "parallelism must be >= 1" }
+        require(memoryKiB >= 8 * parallelism) { "memoryKiB must be >= 8 * parallelism" }
+        require(iterations >= 1) { "iterations must be >= 1" }
+        require(outputLength >= 4) { "outputLength must be >= 4" }
+
+        val lanes = parallelism
+        val blockCount = 4 * lanes * (memoryKiB / (4 * lanes))
+        val laneLength = blockCount / lanes
+        val segmentLength = laneLength / SYNC_POINTS
+
+        val memory = LongArray(blockCount * BLOCK_LONGS)
+        val h0 = initialHash(
+            password, salt, secret, associatedData,
+            lanes, memoryKiB, iterations, outputLength,
+        )
+
+        for (lane in 0 until lanes) {
+            fillFirstBlocks(memory, h0, lane, laneLength)
+        }
+        h0.fill(0)
+
+        for (pass in 0 until iterations) {
+            for (slice in 0 until SYNC_POINTS) {
+                for (lane in 0 until lanes) {
+                    fillSegment(
+                        memory, pass, lane, slice,
+                        lanes, laneLength, segmentLength, iterations, blockCount,
+                    )
+                }
+            }
+        }
+
+        // C = XOR of the last block of every lane; tag = H'(outputLength, C)
+        val finalBlock = LongArray(BLOCK_LONGS)
+        for (lane in 0 until lanes) {
+            val base = (lane * laneLength + laneLength - 1) * BLOCK_LONGS
+            for (i in 0 until BLOCK_LONGS) {
+                finalBlock[i] = finalBlock[i] xor memory[base + i]
+            }
+        }
+        memory.fill(0)
+        return variableLengthHash(outputLength, longsToBytesLE(finalBlock))
+    }
+
+    private fun initialHash(
+        password: ByteArray,
+        salt: ByteArray,
+        secret: ByteArray,
+        associatedData: ByteArray,
+        lanes: Int,
+        memoryKiB: Int,
+        iterations: Int,
+        outputLength: Int,
+    ): ByteArray =
+        Blake2b(64)
+            .update(le32(lanes))
+            .update(le32(outputLength))
+            .update(le32(memoryKiB))
+            .update(le32(iterations))
+            .update(le32(VERSION))
+            .update(le32(TYPE_ARGON2ID))
+            .update(le32(password.size)).update(password)
+            .update(le32(salt.size)).update(salt)
+            .update(le32(secret.size)).update(secret)
+            .update(le32(associatedData.size)).update(associatedData)
+            .digest()
+
+    private fun fillFirstBlocks(memory: LongArray, h0: ByteArray, lane: Int, laneLength: Int) {
+        for (blockIndex in 0..1) {
+            val blockBytes = variableLengthHash(
+                1024,
+                h0 + le32(blockIndex) + le32(lane),
+            )
+            val base = (lane * laneLength + blockIndex) * BLOCK_LONGS
+            for (i in 0 until BLOCK_LONGS) {
+                memory[base + i] = readLongLE(blockBytes, i * 8)
+            }
+        }
+    }
+
+    private fun fillSegment(
+        memory: LongArray,
+        pass: Int,
+        lane: Int,
+        slice: Int,
+        lanes: Int,
+        laneLength: Int,
+        segmentLength: Int,
+        iterations: Int,
+        blockCount: Int,
+    ) {
+        // Argon2id: data-independent addressing for the first two slices of the
+        // first pass, data-dependent afterwards.
+        val dataIndependent = pass == 0 && slice < 2
+        val addressBlock = LongArray(BLOCK_LONGS)
+        val inputBlock = LongArray(BLOCK_LONGS)
+        val work = LongArray(BLOCK_LONGS)
+        val workCopy = LongArray(BLOCK_LONGS)
+        val permuteBuf = LongArray(16)
+
+        if (dataIndependent) {
+            inputBlock[0] = pass.toLong()
+            inputBlock[1] = lane.toLong()
+            inputBlock[2] = slice.toLong()
+            inputBlock[3] = blockCount.toLong()
+            inputBlock[4] = iterations.toLong()
+            inputBlock[5] = TYPE_ARGON2ID.toLong()
+        }
+
+        var startingIndex = 0
+        if (pass == 0 && slice == 0) {
+            startingIndex = 2
+            if (dataIndependent) {
+                nextAddresses(addressBlock, inputBlock, work, workCopy, permuteBuf)
+            }
+        }
+
+        var currOffset = lane * laneLength + slice * segmentLength + startingIndex
+        var prevOffset =
+            if (currOffset % laneLength == 0) currOffset + laneLength - 1 else currOffset - 1
+
+        for (index in startingIndex until segmentLength) {
+            if (currOffset % laneLength == 1) {
+                prevOffset = currOffset - 1
+            }
+
+            val pseudoRand = if (dataIndependent) {
+                if (index % BLOCK_LONGS == 0) {
+                    nextAddresses(addressBlock, inputBlock, work, workCopy, permuteBuf)
+                }
+                addressBlock[index % BLOCK_LONGS]
+            } else {
+                memory[prevOffset * BLOCK_LONGS]
+            }
+
+            val refLane = if (pass == 0 && slice == 0) {
+                lane
+            } else {
+                ((pseudoRand ushr 32) % lanes).toInt()
+            }
+            val refIndex = indexAlpha(
+                pass, slice, index,
+                sameLane = refLane == lane,
+                laneLength = laneLength,
+                segmentLength = segmentLength,
+                j1 = pseudoRand and MASK_32,
+            )
+            val refOffset = refLane * laneLength + refIndex
+
+            fillBlock(
+                memory, prevOffset, refOffset, currOffset,
+                withXor = pass != 0,
+                work = work, workCopy = workCopy, permuteBuf = permuteBuf,
+            )
+            currOffset++
+            prevOffset++
+        }
+    }
+
+    /** RFC 9106 §3.4.1.3: map J1 onto the reference block index. */
+    private fun indexAlpha(
+        pass: Int,
+        slice: Int,
+        index: Int,
+        sameLane: Boolean,
+        laneLength: Int,
+        segmentLength: Int,
+        j1: Long,
+    ): Int {
+        val referenceAreaSize: Long = if (pass == 0) {
+            when {
+                slice == 0 -> (index - 1).toLong()
+                sameLane -> (slice * segmentLength + index - 1).toLong()
+                else -> (slice * segmentLength + (if (index == 0) -1 else 0)).toLong()
+            }
+        } else {
+            if (sameLane) {
+                (laneLength - segmentLength + index - 1).toLong()
+            } else {
+                (laneLength - segmentLength + (if (index == 0) -1 else 0)).toLong()
+            }
+        }
+        var relativePosition = (j1 * j1) ushr 32
+        relativePosition = referenceAreaSize - 1L - ((referenceAreaSize * relativePosition) ushr 32)
+        val startPosition = if (pass != 0 && slice != SYNC_POINTS - 1) {
+            ((slice + 1) * segmentLength).toLong()
+        } else {
+            0L
+        }
+        return ((startPosition + relativePosition) % laneLength).toInt()
+    }
+
+    /** addressBlock = G(0, G(0, ++inputBlock)) — RFC 9106 §3.4.1.2. */
+    private fun nextAddresses(
+        addressBlock: LongArray,
+        inputBlock: LongArray,
+        work: LongArray,
+        workCopy: LongArray,
+        permuteBuf: LongArray,
+    ) {
+        inputBlock[6]++
+        gBlock(inputBlock, addressBlock, work, workCopy, permuteBuf)
+        gBlock(addressBlock, addressBlock, work, workCopy, permuteBuf)
+    }
+
+    /** out = G(0, input) = P-permuted(input) XOR input, both standalone blocks. */
+    private fun gBlock(
+        input: LongArray,
+        out: LongArray,
+        work: LongArray,
+        workCopy: LongArray,
+        permuteBuf: LongArray,
+    ) {
+        input.copyInto(work)
+        input.copyInto(workCopy)
+        applyPermutations(work, permuteBuf)
+        for (i in 0 until BLOCK_LONGS) {
+            out[i] = work[i] xor workCopy[i]
+        }
+    }
+
+    /**
+     * memory[curr] = G(memory[prev], memory[ref]) — XORed with the old block
+     * content on later passes (version 0x13 behavior).
+     */
+    private fun fillBlock(
+        memory: LongArray,
+        prevOffset: Int,
+        refOffset: Int,
+        currOffset: Int,
+        withXor: Boolean,
+        work: LongArray,
+        workCopy: LongArray,
+        permuteBuf: LongArray,
+    ) {
+        val prevBase = prevOffset * BLOCK_LONGS
+        val refBase = refOffset * BLOCK_LONGS
+        val currBase = currOffset * BLOCK_LONGS
+        for (i in 0 until BLOCK_LONGS) {
+            val r = memory[prevBase + i] xor memory[refBase + i]
+            work[i] = r
+            workCopy[i] = if (withXor) r xor memory[currBase + i] else r
+        }
+        applyPermutations(work, permuteBuf)
+        for (i in 0 until BLOCK_LONGS) {
+            memory[currBase + i] = work[i] xor workCopy[i]
+        }
+    }
+
+    /** P applied to the 8 rows, then the 8 columns, of the 8x8 register matrix. */
+    private fun applyPermutations(v: LongArray, buf: LongArray) {
+        for (i in 0 until 8) {
+            permute(v, ROW_INDICES[i], buf)
+        }
+        for (i in 0 until 8) {
+            permute(v, COL_INDICES[i], buf)
+        }
+    }
+
+    private fun permute(v: LongArray, indices: IntArray, w: LongArray) {
+        for (k in 0 until 16) {
+            w[k] = v[indices[k]]
+        }
+        blamka(w, 0, 4, 8, 12)
+        blamka(w, 1, 5, 9, 13)
+        blamka(w, 2, 6, 10, 14)
+        blamka(w, 3, 7, 11, 15)
+        blamka(w, 0, 5, 10, 15)
+        blamka(w, 1, 6, 11, 12)
+        blamka(w, 2, 7, 8, 13)
+        blamka(w, 3, 4, 9, 14)
+        for (k in 0 until 16) {
+            v[indices[k]] = w[k]
+        }
+    }
+
+    /** BlaMka GB: BLAKE2b's G with a + b replaced by a + b + 2 * lo32(a) * lo32(b). */
+    private fun blamka(w: LongArray, a: Int, b: Int, c: Int, d: Int) {
+        w[a] = w[a] + w[b] + 2 * (w[a] and MASK_32) * (w[b] and MASK_32)
+        w[d] = (w[d] xor w[a]).rotateRight(32)
+        w[c] = w[c] + w[d] + 2 * (w[c] and MASK_32) * (w[d] and MASK_32)
+        w[b] = (w[b] xor w[c]).rotateRight(24)
+        w[a] = w[a] + w[b] + 2 * (w[a] and MASK_32) * (w[b] and MASK_32)
+        w[d] = (w[d] xor w[a]).rotateRight(16)
+        w[c] = w[c] + w[d] + 2 * (w[c] and MASK_32) * (w[d] and MASK_32)
+        w[b] = (w[b] xor w[c]).rotateRight(63)
+    }
+
+    /** H'(T, X) — RFC 9106 §3.3 variable-length hash on top of BLAKE2b. */
+    private fun variableLengthHash(outputLength: Int, input: ByteArray): ByteArray {
+        if (outputLength <= 64) {
+            return Blake2b(outputLength).update(le32(outputLength)).update(input).digest()
+        }
+        val fullBlocks = (outputLength + 31) / 32 - 2
+        val out = ByteArray(outputLength)
+        var v = Blake2b(64).update(le32(outputLength)).update(input).digest()
+        System.arraycopy(v, 0, out, 0, 32)
+        for (i in 1 until fullBlocks) {
+            v = Blake2b(64).update(v).digest()
+            System.arraycopy(v, 0, out, i * 32, 32)
+        }
+        val lastLength = outputLength - 32 * fullBlocks
+        v = Blake2b(lastLength).update(v).digest()
+        System.arraycopy(v, 0, out, 32 * fullBlocks, lastLength)
+        return out
+    }
+
+    private fun le32(value: Int): ByteArray = byteArrayOf(
+        value.toByte(),
+        (value ushr 8).toByte(),
+        (value ushr 16).toByte(),
+        (value ushr 24).toByte(),
+    )
+
+    private fun readLongLE(data: ByteArray, offset: Int): Long {
+        var result = 0L
+        for (i in 7 downTo 0) {
+            result = (result shl 8) or (data[offset + i].toLong() and 0xFF)
+        }
+        return result
+    }
+
+    private fun longsToBytesLE(longs: LongArray): ByteArray {
+        val out = ByteArray(longs.size * 8)
+        for (i in longs.indices) {
+            val value = longs[i]
+            for (j in 0 until 8) {
+                out[i * 8 + j] = (value ushr (8 * j)).toByte()
+            }
+        }
+        return out
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Blake2b.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Blake2b.kt
@@ -1,0 +1,124 @@
+package com.superproductivity.superproductivity.crypto
+
+/**
+ * Minimal unkeyed BLAKE2b (RFC 7693) with variable digest length (1..64 bytes).
+ *
+ * Exists only as a building block for [Argon2] (initial hash H0 and the
+ * variable-length hash H'): Android ships no BLAKE2b and the project rules
+ * forbid adding a crypto dependency. Verified against RFC 7693 and hash-wasm
+ * generated vectors in Blake2bTest.
+ */
+class Blake2b(private val digestSize: Int) {
+
+    companion object {
+        private val IV = longArrayOf(
+            0x6a09e667f3bcc908L, -0x4498517a7b3558c5L, 0x3c6ef372fe94f82bL, -0x5ab00ac5a0e2c90fL,
+            0x510e527fade682d1L, -0x64fa9773d4c193e1L, 0x1f83d9abfb41bd6bL, 0x5be0cd19137e2179L,
+        )
+
+        private val SIGMA = arrayOf(
+            intArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+            intArrayOf(14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3),
+            intArrayOf(11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4),
+            intArrayOf(7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8),
+            intArrayOf(9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13),
+            intArrayOf(2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9),
+            intArrayOf(12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11),
+            intArrayOf(13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10),
+            intArrayOf(6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5),
+            intArrayOf(10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0),
+        )
+
+        private fun readLongLE(data: ByteArray, offset: Int): Long {
+            var result = 0L
+            for (i in 7 downTo 0) {
+                result = (result shl 8) or (data[offset + i].toLong() and 0xFF)
+            }
+            return result
+        }
+    }
+
+    init {
+        require(digestSize in 1..64) { "digestSize must be 1..64" }
+    }
+
+    private val h = IV.copyOf().also {
+        it[0] = it[0] xor (0x01010000L or digestSize.toLong())
+    }
+    private val buffer = ByteArray(128)
+    private var bufferLength = 0
+
+    // Byte counter. RFC 7693 defines it as 128-bit; Argon2 inputs are far below
+    // 2^63 bytes so a single Long low word suffices (high word stays 0).
+    private var counter = 0L
+
+    fun update(data: ByteArray, offset: Int = 0, length: Int = data.size - offset): Blake2b {
+        var pos = offset
+        var remaining = length
+        while (remaining > 0) {
+            // Compress only when more input follows — the final block must stay
+            // buffered for the finalization-flagged compression in digest().
+            if (bufferLength == 128) {
+                counter += 128
+                compress(isFinal = false)
+                bufferLength = 0
+            }
+            val toCopy = minOf(128 - bufferLength, remaining)
+            System.arraycopy(data, pos, buffer, bufferLength, toCopy)
+            bufferLength += toCopy
+            pos += toCopy
+            remaining -= toCopy
+        }
+        return this
+    }
+
+    fun digest(): ByteArray {
+        counter += bufferLength
+        buffer.fill(0, bufferLength, 128)
+        compress(isFinal = true)
+        val out = ByteArray(digestSize)
+        for (i in 0 until digestSize) {
+            out[i] = (h[i / 8] ushr (8 * (i % 8))).toByte()
+        }
+        return out
+    }
+
+    private fun compress(isFinal: Boolean) {
+        val m = LongArray(16)
+        for (i in 0 until 16) {
+            m[i] = readLongLE(buffer, i * 8)
+        }
+        val v = LongArray(16)
+        h.copyInto(v)
+        IV.copyInto(v, 8)
+        v[12] = v[12] xor counter
+        if (isFinal) {
+            v[14] = v[14].inv()
+        }
+        for (round in 0 until 12) {
+            val s = SIGMA[round % 10]
+            g(v, 0, 4, 8, 12, m[s[0]], m[s[1]])
+            g(v, 1, 5, 9, 13, m[s[2]], m[s[3]])
+            g(v, 2, 6, 10, 14, m[s[4]], m[s[5]])
+            g(v, 3, 7, 11, 15, m[s[6]], m[s[7]])
+            g(v, 0, 5, 10, 15, m[s[8]], m[s[9]])
+            g(v, 1, 6, 11, 12, m[s[10]], m[s[11]])
+            g(v, 2, 7, 8, 13, m[s[12]], m[s[13]])
+            g(v, 3, 4, 9, 14, m[s[14]], m[s[15]])
+        }
+        for (i in 0 until 8) {
+            h[i] = h[i] xor v[i] xor v[i + 8]
+        }
+    }
+
+    private fun g(v: LongArray, a: Int, b: Int, c: Int, d: Int, x: Long, y: Long) {
+        v[a] = v[a] + v[b] + x
+        v[d] = (v[d] xor v[a]).rotateRight(32)
+        v[c] = v[c] + v[d]
+        v[b] = (v[b] xor v[c]).rotateRight(24)
+        v[a] = v[a] + v[b] + y
+        v[d] = (v[d] xor v[a]).rotateRight(16)
+        v[c] = v[c] + v[d]
+        v[b] = (v[b] xor v[c]).rotateRight(63)
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Blake2b.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/crypto/Blake2b.kt
@@ -28,14 +28,6 @@ class Blake2b(private val digestSize: Int) {
             intArrayOf(6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5),
             intArrayOf(10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0),
         )
-
-        private fun readLongLE(data: ByteArray, offset: Int): Long {
-            var result = 0L
-            for (i in 7 downTo 0) {
-                result = (result shl 8) or (data[offset + i].toLong() and 0xFF)
-            }
-            return result
-        }
     }
 
     init {
@@ -121,4 +113,12 @@ class Blake2b(private val digestSize: Int) {
         v[c] = v[c] + v[d]
         v[b] = (v[b] xor v[c]).rotateRight(63)
     }
+}
+
+internal fun readLongLE(data: ByteArray, offset: Int): Long {
+    var result = 0L
+    for (i in 7 downTo 0) {
+        result = (result shl 8) or (data[offset + i].toLong() and 0xFF)
+    }
+    return result
 }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptor.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptor.kt
@@ -33,8 +33,7 @@ interface DerivedKeyCache {
  * salt) is deliberately unsupported: the worker only fetches freshly written
  * ops, which are always in the current format; legacy input just fails GCM
  * authentication and is skipped.
- */
-/**
+ *
  * @param deriveOnMiss when false, only cached keys are used and unknown salts
  *   fail fast — for callers on a tight deadline (BroadcastReceiver goAsync
  *   ~10s window) where a seconds-long KDF could get the process killed. The
@@ -60,6 +59,14 @@ class OpPayloadDecryptor(
         private const val ARGON2_MEMORY_KIB = 65536
     }
 
+    // Per-instance memo in front of [keyCache]: the persistent cache may sit
+    // on EncryptedSharedPreferences, where every read costs a Keystore
+    // round-trip — per op that would dwarf the AES-GCM decrypt itself. It
+    // cannot go stale: a decryptor never outlives a password change (callers
+    // build one per run).
+    private val keyMemo = HashMap<String, SecretKeySpec>()
+    private var cipher: Cipher? = null
+
     /** Returns the decrypted payload JSON, or null if this op can't be read. */
     fun decrypt(ciphertextB64: String): String? {
         val bytes = try {
@@ -75,19 +82,17 @@ class OpPayloadDecryptor(
         val salt = bytes.copyOfRange(0, SALT_LENGTH)
         val iv = bytes.copyOfRange(SALT_LENGTH, SALT_LENGTH + IV_LENGTH)
 
-        // Cache before verifying the password: a wrong password would otherwise
-        // re-run the 64 MiB KDF for every op sharing the salt. Stale entries
-        // are cleared when the password changes.
         val saltB64 = Base64.encode(salt)
-        val key = keyCache.get(saltB64)
-            ?: deriveKey(salt)?.also { keyCache.put(saltB64, it) }
+        val key = keyMemo[saltB64]
+            ?: resolveKey(saltB64, salt)?.also { keyMemo[saltB64] = it }
             ?: return null
 
         return try {
-            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            val cipher = this.cipher
+                ?: Cipher.getInstance("AES/GCM/NoPadding").also { this.cipher = it }
             cipher.init(
                 Cipher.DECRYPT_MODE,
-                SecretKeySpec(key, "AES"),
+                key,
                 GCMParameterSpec(GCM_TAG_LENGTH_BYTES * 8, iv),
             )
             val offset = SALT_LENGTH + IV_LENGTH
@@ -97,6 +102,16 @@ class OpPayloadDecryptor(
             logWarn("OpPayloadDecryptor: decryption failed (${e.javaClass.simpleName}), skipping op")
             null
         }
+    }
+
+    private fun resolveKey(saltB64: String, salt: ByteArray): SecretKeySpec? {
+        // Cache before verifying the password: a wrong password would otherwise
+        // re-run the 64 MiB KDF for every op sharing the salt. Stale entries
+        // are cleared when the password changes.
+        val keyBytes = keyCache.get(saltB64)
+            ?: deriveKey(salt)?.also { keyCache.put(saltB64, it) }
+            ?: return null
+        return SecretKeySpec(keyBytes, "AES")
     }
 
     private fun deriveKey(salt: ByteArray): ByteArray? {

--- a/android/app/src/main/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptor.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptor.kt
@@ -1,0 +1,123 @@
+package com.superproductivity.superproductivity.crypto
+
+import java.security.GeneralSecurityException
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlin.io.encoding.Base64
+
+/**
+ * Cache for Argon2id-derived keys, keyed by the salt embedded in each
+ * ciphertext. The JS side derives one salt per (device, process session), so
+ * ops arrive with a small set of recurring salts — caching turns the
+ * seconds-per-derivation KDF into a one-time cost per remote session.
+ *
+ * Keys derive from the E2EE password, so any implementation must be cleared
+ * when the password changes (BackgroundSyncCredentialStore does this).
+ */
+interface DerivedKeyCache {
+    fun get(saltB64: String): ByteArray?
+
+    fun put(saltB64: String, key: ByteArray)
+}
+
+/**
+ * Decrypts E2EE SuperSync op payloads for the background reminder worker.
+ *
+ * Wire format (public contract, packages/sync-core/src/encryption.ts):
+ * base64( SALT(16) | IV(12) | AES-256-GCM ciphertext+tag(16) ), key =
+ * Argon2id(password, salt, p=1, t=3, m=64 MiB, len=32).
+ *
+ * Every failure returns null so callers degrade to today's behavior (skip the
+ * op for reminder extraction). The legacy PBKDF2 format (IV | ciphertext, no
+ * salt) is deliberately unsupported: the worker only fetches freshly written
+ * ops, which are always in the current format; legacy input just fails GCM
+ * authentication and is skipped.
+ */
+/**
+ * @param deriveOnMiss when false, only cached keys are used and unknown salts
+ *   fail fast — for callers on a tight deadline (BroadcastReceiver goAsync
+ *   ~10s window) where a seconds-long KDF could get the process killed. The
+ *   periodic worker derives and caches, so misses there are transient.
+ */
+class OpPayloadDecryptor(
+    private val password: String,
+    private val keyCache: DerivedKeyCache,
+    private val logWarn: (String) -> Unit = {},
+    private val deriveOnMiss: Boolean = true,
+) {
+
+    companion object {
+        private const val SALT_LENGTH = 16
+        private const val IV_LENGTH = 12
+        private const val GCM_TAG_LENGTH_BYTES = 16
+        private const val KEY_LENGTH = 32
+
+        // Must match packages/sync-core/src/encryption/argon2.ts exactly —
+        // pinned by Argon2Test's "production params" vector.
+        private const val ARGON2_PARALLELISM = 1
+        private const val ARGON2_ITERATIONS = 3
+        private const val ARGON2_MEMORY_KIB = 65536
+    }
+
+    /** Returns the decrypted payload JSON, or null if this op can't be read. */
+    fun decrypt(ciphertextB64: String): String? {
+        val bytes = try {
+            Base64.decode(ciphertextB64)
+        } catch (e: IllegalArgumentException) {
+            logWarn("OpPayloadDecryptor: payload is not valid base64, skipping op")
+            return null
+        }
+        if (bytes.size < SALT_LENGTH + IV_LENGTH + GCM_TAG_LENGTH_BYTES) {
+            logWarn("OpPayloadDecryptor: payload too short (${bytes.size} bytes), skipping op")
+            return null
+        }
+        val salt = bytes.copyOfRange(0, SALT_LENGTH)
+        val iv = bytes.copyOfRange(SALT_LENGTH, SALT_LENGTH + IV_LENGTH)
+
+        // Cache before verifying the password: a wrong password would otherwise
+        // re-run the 64 MiB KDF for every op sharing the salt. Stale entries
+        // are cleared when the password changes.
+        val saltB64 = Base64.encode(salt)
+        val key = keyCache.get(saltB64)
+            ?: deriveKey(salt)?.also { keyCache.put(saltB64, it) }
+            ?: return null
+
+        return try {
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(key, "AES"),
+                GCMParameterSpec(GCM_TAG_LENGTH_BYTES * 8, iv),
+            )
+            val offset = SALT_LENGTH + IV_LENGTH
+            String(cipher.doFinal(bytes, offset, bytes.size - offset), Charsets.UTF_8)
+        } catch (e: GeneralSecurityException) {
+            // Wrong password, corrupted data, or a legacy-format payload.
+            logWarn("OpPayloadDecryptor: decryption failed (${e.javaClass.simpleName}), skipping op")
+            null
+        }
+    }
+
+    private fun deriveKey(salt: ByteArray): ByteArray? {
+        if (!deriveOnMiss) {
+            logWarn("OpPayloadDecryptor: no cached key for salt, skipping op (cache-only mode)")
+            return null
+        }
+        return try {
+            Argon2.argon2id(
+                password = password.toByteArray(Charsets.UTF_8),
+                salt = salt,
+                parallelism = ARGON2_PARALLELISM,
+                memoryKiB = ARGON2_MEMORY_KIB,
+                iterations = ARGON2_ITERATIONS,
+                outputLength = KEY_LENGTH,
+            )
+        } catch (e: OutOfMemoryError) {
+            // The KDF needs 64 MiB of working memory; on a memory-constrained
+            // background worker we skip gracefully rather than crash the process.
+            logWarn("OpPayloadDecryptor: not enough memory for key derivation, skipping op")
+            null
+        }
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/receiver/ReminderAlarmReceiver.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/receiver/ReminderAlarmReceiver.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import com.superproductivity.superproductivity.service.BackgroundSyncCredentialStore
 import com.superproductivity.superproductivity.service.ReminderNotificationHelper
 import com.superproductivity.superproductivity.service.SuperSyncBackgroundProvider
+import com.superproductivity.superproductivity.service.buildPayloadDecryptor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -90,7 +91,11 @@ class ReminderAlarmReceiver : BroadcastReceiver() {
             context, credentials.baseUrl
         )
 
-        val result = SuperSyncBackgroundProvider().fetchQuick(
+        // Cache-only decryptor: a cold KDF takes seconds and would blow the
+        // goAsync() window. Ops with unknown salts degrade to envelope-only
+        // parsing, which fails open (notification shows).
+        val decryptor = buildPayloadDecryptor(context, TAG, deriveOnMiss = false)
+        val result = SuperSyncBackgroundProvider(decryptor).fetchQuick(
             credentials.baseUrl, credentials.accessToken, lastSeq
         ) ?: return false  // Error -> fail-open
 

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
@@ -5,6 +5,8 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import org.json.JSONArray
+import org.json.JSONException
 
 /**
  * EncryptedSharedPreferences-backed store for background sync credentials.
@@ -23,6 +25,14 @@ object BackgroundSyncCredentialStore {
     private const val KEY_BASE_URL = "BASE_URL"
     private const val KEY_ACCESS_TOKEN = "ACCESS_TOKEN"
     private const val KEY_SEQ_PREFIX = "LAST_SERVER_SEQ_"
+    private const val KEY_ENCRYPTION_PASSWORD = "ENCRYPTION_PASSWORD"
+    private const val KEY_DERIVED_KEY_CACHE = "DERIVED_KEY_CACHE"
+
+    /**
+     * Each remote (device, process session) contributes one salt; a handful of
+     * active devices is the realistic ceiling, so a small cap suffices.
+     */
+    private const val MAX_CACHED_KEYS = 12
 
     data class Credentials(
         val baseUrl: String,
@@ -76,7 +86,74 @@ object BackgroundSyncCredentialStore {
         getPrefs(context).edit()
             .remove(KEY_BASE_URL)
             .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_ENCRYPTION_PASSWORD)
+            .remove(KEY_DERIVED_KEY_CACHE)
             .commit()
+    }
+
+    /**
+     * Stores the E2EE password so the background worker can decrypt op
+     * payloads (SuperSync encrypts payloads end-to-end since #8670).
+     * Cached derived keys are password-dependent, so they are dropped on change.
+     */
+    @Synchronized
+    fun setEncryptionPassword(context: Context, password: String) {
+        val prefs = getPrefs(context)
+        if (prefs.getString(KEY_ENCRYPTION_PASSWORD, null) == password) return
+        prefs.edit()
+            .putString(KEY_ENCRYPTION_PASSWORD, password)
+            .remove(KEY_DERIVED_KEY_CACHE)
+            .commit()
+    }
+
+    @Synchronized
+    fun getEncryptionPassword(context: Context): String? {
+        return getPrefs(context).getString(KEY_ENCRYPTION_PASSWORD, null)
+    }
+
+    @Synchronized
+    fun clearEncryptionPassword(context: Context) {
+        getPrefs(context).edit()
+            .remove(KEY_ENCRYPTION_PASSWORD)
+            .remove(KEY_DERIVED_KEY_CACHE)
+            .commit()
+    }
+
+    /** @see SharedPrefsDerivedKeyCache */
+    @Synchronized
+    fun getCachedDerivedKey(context: Context, saltB64: String): String? {
+        val entries = readKeyCache(getPrefs(context))
+        for (i in 0 until entries.length()) {
+            val entry = entries.optJSONArray(i) ?: continue
+            if (entry.optString(0) == saltB64) return entry.optString(1)
+        }
+        return null
+    }
+
+    /** @see SharedPrefsDerivedKeyCache */
+    @Synchronized
+    fun putCachedDerivedKey(context: Context, saltB64: String, keyB64: String) {
+        val prefs = getPrefs(context)
+        val entries = readKeyCache(prefs)
+        val updated = JSONArray()
+        // Newest first; re-adding a salt moves it to the front, oldest fall off
+        updated.put(JSONArray().put(saltB64).put(keyB64))
+        for (i in 0 until entries.length()) {
+            if (updated.length() >= MAX_CACHED_KEYS) break
+            val entry = entries.optJSONArray(i) ?: continue
+            if (entry.optString(0) != saltB64) updated.put(entry)
+        }
+        prefs.edit().putString(KEY_DERIVED_KEY_CACHE, updated.toString()).commit()
+    }
+
+    private fun readKeyCache(prefs: SharedPreferences): JSONArray {
+        val raw = prefs.getString(KEY_DERIVED_KEY_CACHE, null) ?: return JSONArray()
+        return try {
+            JSONArray(raw)
+        } catch (e: JSONException) {
+            Log.w(TAG, "Corrupt derived-key cache, resetting")
+            JSONArray()
+        }
     }
 
     @Synchronized

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
@@ -5,8 +5,6 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
-import org.json.JSONArray
-import org.json.JSONException
 
 /**
  * EncryptedSharedPreferences-backed store for background sync credentials.
@@ -28,18 +26,23 @@ object BackgroundSyncCredentialStore {
     private const val KEY_ENCRYPTION_PASSWORD = "ENCRYPTION_PASSWORD"
     private const val KEY_DERIVED_KEY_CACHE = "DERIVED_KEY_CACHE"
 
-    /**
-     * Each remote (device, process session) contributes one salt; a handful of
-     * active devices is the realistic ceiling, so a small cap suffices.
-     */
-    private const val MAX_CACHED_KEYS = 12
-
     data class Credentials(
         val baseUrl: String,
         val accessToken: String
     )
 
+    // Created once per process: EncryptedSharedPreferences.create() does
+    // Keystore work on every call, which adds up now that the derived-key
+    // cache reads go through here. All access is via @Synchronized methods,
+    // so a plain field is safe.
+    private var prefs: SharedPreferences? = null
+
     private fun getPrefs(context: Context): SharedPreferences {
+        prefs?.let { return it }
+        return createPrefs(context).also { prefs = it }
+    }
+
+    private fun createPrefs(context: Context): SharedPreferences {
         return try {
             val masterKey = MasterKey.Builder(context.applicationContext)
                 .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -92,18 +95,23 @@ object BackgroundSyncCredentialStore {
     }
 
     /**
-     * Stores the E2EE password so the background worker can decrypt op
-     * payloads (SuperSync encrypts payloads end-to-end since #8670).
-     * Cached derived keys are password-dependent, so they are dropped on change.
+     * Mirrors the E2EE password so the background worker can decrypt op
+     * payloads (SuperSync encrypts payloads end-to-end since #8670); an empty
+     * password clears it. Cached derived keys are password-dependent, so any
+     * change also drops the key cache — this method is the single owner of
+     * that invariant.
      */
     @Synchronized
     fun setEncryptionPassword(context: Context, password: String) {
         val prefs = getPrefs(context)
-        if (prefs.getString(KEY_ENCRYPTION_PASSWORD, null) == password) return
-        prefs.edit()
-            .putString(KEY_ENCRYPTION_PASSWORD, password)
-            .remove(KEY_DERIVED_KEY_CACHE)
-            .commit()
+        if ((prefs.getString(KEY_ENCRYPTION_PASSWORD, null) ?: "") == password) return
+        val editor = prefs.edit().remove(KEY_DERIVED_KEY_CACHE)
+        if (password.isEmpty()) {
+            editor.remove(KEY_ENCRYPTION_PASSWORD)
+        } else {
+            editor.putString(KEY_ENCRYPTION_PASSWORD, password)
+        }
+        editor.commit()
     }
 
     @Synchronized
@@ -111,49 +119,15 @@ object BackgroundSyncCredentialStore {
         return getPrefs(context).getString(KEY_ENCRYPTION_PASSWORD, null)
     }
 
+    /** Raw persisted derived-key cache; the format is owned by [SharedPrefsDerivedKeyCache]. */
     @Synchronized
-    fun clearEncryptionPassword(context: Context) {
-        getPrefs(context).edit()
-            .remove(KEY_ENCRYPTION_PASSWORD)
-            .remove(KEY_DERIVED_KEY_CACHE)
-            .commit()
+    fun getDerivedKeyCacheRaw(context: Context): String? {
+        return getPrefs(context).getString(KEY_DERIVED_KEY_CACHE, null)
     }
 
-    /** @see SharedPrefsDerivedKeyCache */
     @Synchronized
-    fun getCachedDerivedKey(context: Context, saltB64: String): String? {
-        val entries = readKeyCache(getPrefs(context))
-        for (i in 0 until entries.length()) {
-            val entry = entries.optJSONArray(i) ?: continue
-            if (entry.optString(0) == saltB64) return entry.optString(1)
-        }
-        return null
-    }
-
-    /** @see SharedPrefsDerivedKeyCache */
-    @Synchronized
-    fun putCachedDerivedKey(context: Context, saltB64: String, keyB64: String) {
-        val prefs = getPrefs(context)
-        val entries = readKeyCache(prefs)
-        val updated = JSONArray()
-        // Newest first; re-adding a salt moves it to the front, oldest fall off
-        updated.put(JSONArray().put(saltB64).put(keyB64))
-        for (i in 0 until entries.length()) {
-            if (updated.length() >= MAX_CACHED_KEYS) break
-            val entry = entries.optJSONArray(i) ?: continue
-            if (entry.optString(0) != saltB64) updated.put(entry)
-        }
-        prefs.edit().putString(KEY_DERIVED_KEY_CACHE, updated.toString()).commit()
-    }
-
-    private fun readKeyCache(prefs: SharedPreferences): JSONArray {
-        val raw = prefs.getString(KEY_DERIVED_KEY_CACHE, null) ?: return JSONArray()
-        return try {
-            JSONArray(raw)
-        } catch (e: JSONException) {
-            Log.w(TAG, "Corrupt derived-key cache, resetting")
-            JSONArray()
-        }
+    fun setDerivedKeyCacheRaw(context: Context, value: String) {
+        getPrefs(context).edit().putString(KEY_DERIVED_KEY_CACHE, value).commit()
     }
 
     @Synchronized

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/SharedPrefsDerivedKeyCache.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/SharedPrefsDerivedKeyCache.kt
@@ -1,0 +1,56 @@
+package com.superproductivity.superproductivity.service
+
+import android.content.Context
+import android.util.Log
+import com.superproductivity.superproductivity.crypto.DerivedKeyCache
+import com.superproductivity.superproductivity.crypto.OpPayloadDecryptor
+import kotlin.io.encoding.Base64
+
+/**
+ * Builds the op-payload decryptor from the mirrored E2EE password, or null
+ * when none is stored (E2EE password not yet mirrored, e.g. old JS bundle) —
+ * callers then degrade to envelope-only parsing, i.e. pre-fix behavior.
+ *
+ * @param deriveOnMiss pass false from deadline-bound callers (BroadcastReceiver);
+ *   see [OpPayloadDecryptor].
+ */
+fun buildPayloadDecryptor(
+    context: Context,
+    logTag: String,
+    deriveOnMiss: Boolean = true,
+): OpPayloadDecryptor? {
+    val password = BackgroundSyncCredentialStore.getEncryptionPassword(context)
+        ?.takeIf { it.isNotEmpty() }
+        ?: return null
+    return OpPayloadDecryptor(
+        password = password,
+        keyCache = SharedPrefsDerivedKeyCache(context),
+        logWarn = { Log.w(logTag, it) },
+        deriveOnMiss = deriveOnMiss,
+    )
+}
+
+/**
+ * Persists Argon2id-derived keys in [BackgroundSyncCredentialStore]'s
+ * EncryptedSharedPreferences so the seconds-long KDF runs once per remote
+ * session salt instead of on every worker wake-up. The store clears the
+ * cache whenever the E2EE password changes.
+ */
+class SharedPrefsDerivedKeyCache(context: Context) : DerivedKeyCache {
+
+    private val appContext = context.applicationContext
+
+    override fun get(saltB64: String): ByteArray? {
+        val keyB64 = BackgroundSyncCredentialStore.getCachedDerivedKey(appContext, saltB64)
+            ?: return null
+        return try {
+            Base64.decode(keyB64)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
+
+    override fun put(saltB64: String, key: ByteArray) {
+        BackgroundSyncCredentialStore.putCachedDerivedKey(appContext, saltB64, Base64.encode(key))
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/SharedPrefsDerivedKeyCache.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/SharedPrefsDerivedKeyCache.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.util.Log
 import com.superproductivity.superproductivity.crypto.DerivedKeyCache
 import com.superproductivity.superproductivity.crypto.OpPayloadDecryptor
+import org.json.JSONArray
+import org.json.JSONException
 import kotlin.io.encoding.Base64
 
 /**
@@ -33,24 +35,62 @@ fun buildPayloadDecryptor(
 /**
  * Persists Argon2id-derived keys in [BackgroundSyncCredentialStore]'s
  * EncryptedSharedPreferences so the seconds-long KDF runs once per remote
- * session salt instead of on every worker wake-up. The store clears the
- * cache whenever the E2EE password changes.
+ * session salt instead of on every worker wake-up. Stored as a JSON list of
+ * [saltB64, keyB64] pairs under a single pref key; the store drops that key
+ * whenever the E2EE password changes.
  */
 class SharedPrefsDerivedKeyCache(context: Context) : DerivedKeyCache {
+
+    companion object {
+        private const val TAG = "DerivedKeyCache"
+
+        /**
+         * Each remote (device, process session) contributes one salt; a handful
+         * of active devices is the realistic ceiling, so a small cap suffices.
+         */
+        private const val MAX_CACHED_KEYS = 12
+    }
 
     private val appContext = context.applicationContext
 
     override fun get(saltB64: String): ByteArray? {
-        val keyB64 = BackgroundSyncCredentialStore.getCachedDerivedKey(appContext, saltB64)
-            ?: return null
-        return try {
-            Base64.decode(keyB64)
-        } catch (e: IllegalArgumentException) {
-            null
+        val entries = readEntries()
+        for (i in 0 until entries.length()) {
+            val entry = entries.optJSONArray(i) ?: continue
+            if (entry.optString(0) == saltB64) {
+                return try {
+                    Base64.decode(entry.optString(1))
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            }
         }
+        return null
     }
 
     override fun put(saltB64: String, key: ByteArray) {
-        BackgroundSyncCredentialStore.putCachedDerivedKey(appContext, saltB64, Base64.encode(key))
+        val entries = readEntries()
+        val updated = JSONArray()
+        // Newest first, truncated at the cap. put() only runs on a get() miss,
+        // so a duplicate salt can only race in from concurrent callers — the
+        // skip below keeps one copy.
+        updated.put(JSONArray().put(saltB64).put(Base64.encode(key)))
+        for (i in 0 until entries.length()) {
+            if (updated.length() >= MAX_CACHED_KEYS) break
+            val entry = entries.optJSONArray(i) ?: continue
+            if (entry.optString(0) != saltB64) updated.put(entry)
+        }
+        BackgroundSyncCredentialStore.setDerivedKeyCacheRaw(appContext, updated.toString())
+    }
+
+    private fun readEntries(): JSONArray {
+        val raw = BackgroundSyncCredentialStore.getDerivedKeyCacheRaw(appContext)
+            ?: return JSONArray()
+        return try {
+            JSONArray(raw)
+        } catch (e: JSONException) {
+            Log.w(TAG, "Corrupt derived-key cache, resetting")
+            JSONArray()
+        }
     }
 }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProvider.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProvider.kt
@@ -1,6 +1,7 @@
 package com.superproductivity.superproductivity.service
 
 import android.util.Log
+import com.superproductivity.superproductivity.crypto.OpPayloadDecryptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
@@ -16,8 +17,16 @@ import kotlin.math.abs
  * only TIME_TRACKING and CRT (addTask) ops populate it. For schedule/unschedule/
  * deadline actions, the actual data is in actionPayload. This provider uses
  * action-type matching to handle both paths.
+ *
+ * SuperSync encrypts op payloads end-to-end (mandatory since #8670), so the
+ * payload arrives as a base64 string, not JSON. [payloadDecryptor] makes those
+ * readable; without one (no E2EE password mirrored yet, e.g. old JS bundle)
+ * only the plaintext envelope fields (actionType/opType/entityId) are usable —
+ * cancels still work, schedules are skipped.
  */
-class SuperSyncBackgroundProvider : BackgroundSyncProvider {
+class SuperSyncBackgroundProvider(
+    private val payloadDecryptor: OpPayloadDecryptor? = null,
+) : BackgroundSyncProvider {
 
     companion object {
         private const val TAG = "SuperSyncBgProvider"
@@ -126,7 +135,7 @@ class SuperSyncBackgroundProvider : BackgroundSyncProvider {
         }
     }
 
-    private fun parseResponse(body: String): ReminderChangeResult {
+    internal fun parseResponse(body: String): ReminderChangeResult {
         val json = JSONObject(body)
         val ops = json.optJSONArray("ops")
             ?: return ReminderChangeResult(emptySet(), emptyList(), json.optLong("latestSeq", 0L), false)
@@ -144,17 +153,19 @@ class SuperSyncBackgroundProvider : BackgroundSyncProvider {
         for (i in 0 until ops.length()) {
             val serverOp = ops.getJSONObject(i)
             val op = serverOp.getJSONObject("op")
+            // Lazy so envelope-only ops (e.g. DEL) never pay for decryption
+            val payload = lazy(LazyThreadSafetyMode.NONE) { resolvePayload(op) }
 
             // Process schedules first so that within the same op, cancels take precedence
             val tempMap = mutableMapOf<Pair<String, Boolean>, ReminderToSchedule>()
-            extractRemindersToSchedule(op, tempMap, now)
+            extractRemindersToSchedule(op, payload, tempMap, now)
             for ((key, reminder) in tempMap) {
                 reminderMap[key] = reminder
                 taskLastAction[reminder.taskId] = "schedule"
             }
 
             val cancelIds = mutableSetOf<String>()
-            extractReminderRelevantTaskIds(op, cancelIds)
+            extractReminderRelevantTaskIds(op, payload, cancelIds)
             for (id in cancelIds) {
                 taskLastAction[id] = "cancel"
             }
@@ -175,14 +186,39 @@ class SuperSyncBackgroundProvider : BackgroundSyncProvider {
     }
 
     /**
+     * Resolves an op's payload to usable JSON: either the plaintext object
+     * directly, or — since payload E2EE became mandatory — the decrypted
+     * base64 string. Returns null when there is no payload or it can't be
+     * read (no decryptor, wrong password, corrupt data); callers then fall
+     * back to the plaintext envelope fields only.
+     */
+    private fun resolvePayload(op: JSONObject): JSONObject? {
+        op.optJSONObject("payload")?.let { return it }
+        val decryptor = payloadDecryptor ?: return null
+        val encrypted = op.opt("payload") as? String ?: return null
+        if (encrypted.isEmpty()) return null
+        val decrypted = decryptor.decrypt(encrypted) ?: return null
+        return try {
+            JSONObject(decrypted)
+        } catch (e: org.json.JSONException) {
+            Log.w(TAG, "Decrypted payload is not a JSON object, skipping op")
+            null
+        }
+    }
+
+    /**
      * Extracts task IDs from an operation if it represents a reminder-relevant change.
      * Server operation format:
      *   actionType = full NgRx action string, opType = "CRT"/"UPD"/"DEL",
      *   entityType = "TASK"/"PROJECT"/etc.,
      *   entityId = single ID, entityIds = batch IDs,
-     *   payload = { actionPayload: {...}, entityChanges: [...] }
+     *   payload = { actionPayload: {...}, entityChanges: [...] } (encrypted: base64 string)
      */
-    private fun extractReminderRelevantTaskIds(op: JSONObject, out: MutableSet<String>) {
+    private fun extractReminderRelevantTaskIds(
+        op: JSONObject,
+        payloadLazy: Lazy<JSONObject?>,
+        out: MutableSet<String>
+    ) {
         val entityType = op.optString("entityType", "")
         if (entityType != "TASK") return
 
@@ -215,7 +251,7 @@ class SuperSyncBackgroundProvider : BackgroundSyncProvider {
         // The payload structure is: payload.entityChanges[] with per-entity changes,
         // and payload.actionPayload with the original action payload.
         if (opType == "UPD") {
-            val payload = op.optJSONObject("payload") ?: return
+            val payload = payloadLazy.value ?: return
 
             // Primary: check entityChanges array (always present, consistent structure).
             // Each entry has: { entityType, entityId, opType, changes: { isDone, remindAt, ... } }
@@ -301,7 +337,12 @@ class SuperSyncBackgroundProvider : BackgroundSyncProvider {
      * 2. actionPayload — for schedule/reschedule/setDeadline actions where the op-log
      *    returns empty entityChanges and the reminder data is only in the action payload.
      */
-    private fun extractRemindersToSchedule(op: JSONObject, out: MutableMap<Pair<String, Boolean>, ReminderToSchedule>, now: Long) {
+    private fun extractRemindersToSchedule(
+        op: JSONObject,
+        payloadLazy: Lazy<JSONObject?>,
+        out: MutableMap<Pair<String, Boolean>, ReminderToSchedule>,
+        now: Long
+    ) {
         val entityType = op.optString("entityType", "")
         if (entityType != "TASK") return
 
@@ -309,7 +350,7 @@ class SuperSyncBackgroundProvider : BackgroundSyncProvider {
         // Only CRT and UPD operations can create/update reminders
         if (opType != "CRT" && opType != "UPD") return
 
-        val payload = op.optJSONObject("payload") ?: return
+        val payload = payloadLazy.value ?: return
         val actionType = op.optString("actionType", "")
 
         // Path 1: Check entityChanges (populated for CRT/addTask ops)

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProvider.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProvider.kt
@@ -22,10 +22,13 @@ import kotlin.math.abs
  * payload arrives as a base64 string, not JSON. [payloadDecryptor] makes those
  * readable; without one (no E2EE password mirrored yet, e.g. old JS bundle)
  * only the plaintext envelope fields (actionType/opType/entityId) are usable —
- * cancels still work, schedules are skipped.
+ * cancels still work, schedules are skipped. The parameter has no default on
+ * purpose: passing null silently degrades to that envelope-only mode, so every
+ * construction site must make it an explicit decision (use
+ * [buildPayloadDecryptor]).
  */
 class SuperSyncBackgroundProvider(
-    private val payloadDecryptor: OpPayloadDecryptor? = null,
+    private val payloadDecryptor: OpPayloadDecryptor?,
 ) : BackgroundSyncProvider {
 
     companion object {
@@ -193,10 +196,12 @@ class SuperSyncBackgroundProvider(
      * back to the plaintext envelope fields only.
      */
     private fun resolvePayload(op: JSONObject): JSONObject? {
+        // Discriminates by JSON type (object = plaintext, string = encrypted)
+        // rather than the op's isPayloadEncrypted flag — equivalent for every
+        // shipped format and robust when the optional flag is absent.
         op.optJSONObject("payload")?.let { return it }
         val decryptor = payloadDecryptor ?: return null
         val encrypted = op.opt("payload") as? String ?: return null
-        if (encrypted.isEmpty()) return null
         val decrypted = decryptor.decrypt(encrypted) ?: return null
         return try {
             JSONObject(decrypted)

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/SyncReminderWorker.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/SyncReminderWorker.kt
@@ -30,7 +30,9 @@ class SyncReminderWorker(
             return Result.success()
         }
 
-        val provider = SuperSyncBackgroundProvider()
+        val provider = SuperSyncBackgroundProvider(
+            buildPayloadDecryptor(applicationContext, TAG)
+        )
         var lastSeq = BackgroundSyncCredentialStore.getLastServerSeq(
             applicationContext, credentials.baseUrl
         )

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
@@ -500,6 +500,25 @@ class JavaScriptInterface(
         }
     }
 
+    /**
+     * Mirrors the SuperSync E2EE password so background reminder sync can
+     * decrypt op payloads (encrypted end-to-end since #8670). Separate method
+     * from [setSuperSyncCredentials] so an old JS bundle paired with a new APK
+     * (and vice versa) keeps working. Empty string clears the password.
+     * NEVER log the password.
+     */
+    @Suppress("unused")
+    @JavascriptInterface
+    fun setSuperSyncEncryptionPassword(password: String) {
+        safeCall("Failed to set SuperSync encryption password") {
+            if (password.isEmpty()) {
+                BackgroundSyncCredentialStore.clearEncryptionPassword(activity)
+            } else {
+                BackgroundSyncCredentialStore.setEncryptionPassword(activity, password)
+            }
+        }
+    }
+
     @Suppress("unused")
     @JavascriptInterface
     fun openAppNotificationSettings() {

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/JavaScriptInterface.kt
@@ -511,11 +511,7 @@ class JavaScriptInterface(
     @JavascriptInterface
     fun setSuperSyncEncryptionPassword(password: String) {
         safeCall("Failed to set SuperSync encryption password") {
-            if (password.isEmpty()) {
-                BackgroundSyncCredentialStore.clearEncryptionPassword(activity)
-            } else {
-                BackgroundSyncCredentialStore.setEncryptionPassword(activity, password)
-            }
+            BackgroundSyncCredentialStore.setEncryptionPassword(activity, password)
         }
     }
 

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Argon2Test.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Argon2Test.kt
@@ -1,0 +1,87 @@
+package com.superproductivity.superproductivity.crypto
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Vectors: RFC 9106 §5.3 (the official argon2id test vector, with secret and
+ * associated data) plus hash-wasm generated fixtures — hash-wasm is the exact
+ * library the JS side (packages/sync-core) uses for op-payload encryption, and
+ * the prod vector uses the production KDF parameters (p=1, t=3, m=64 MiB).
+ */
+class Argon2Test {
+
+    private val salt16 = hexToBytes("000102030405060708090a0b0c0d0e0f")
+
+    @Test
+    fun `matches RFC 9106 argon2id test vector`() {
+        val tag = Argon2.argon2id(
+            password = ByteArray(32) { 0x01 },
+            salt = ByteArray(16) { 0x02 },
+            parallelism = 4,
+            memoryKiB = 32,
+            iterations = 3,
+            outputLength = 32,
+            secret = ByteArray(8) { 0x03 },
+            associatedData = ByteArray(12) { 0x04 },
+        )
+        assertEquals(
+            "0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659",
+            tag.toHex(),
+        )
+    }
+
+    @Test
+    fun `matches hash-wasm with small single-lane params`() {
+        val tag = Argon2.argon2id(
+            password = "test-password".toByteArray(),
+            salt = salt16,
+            parallelism = 1,
+            memoryKiB = 64,
+            iterations = 3,
+            outputLength = 32,
+        )
+        assertEquals(
+            "0d786afcedf5887149009b3bf1ce23bef5769cb2dc10d058c8c40dd7f431f7f1",
+            tag.toHex(),
+        )
+    }
+
+    @Test
+    fun `matches hash-wasm with four lanes`() {
+        val tag = Argon2.argon2id(
+            password = "test-password".toByteArray(),
+            salt = salt16,
+            parallelism = 4,
+            memoryKiB = 64,
+            iterations = 3,
+            outputLength = 32,
+        )
+        assertEquals(
+            "395cb724885b0d8fe5a8ed5374cc22258ffef04b5225de589c6d24700e3fc6a0",
+            tag.toHex(),
+        )
+    }
+
+    @Test
+    fun `matches hash-wasm with production params`() {
+        // p=1, t=3, m=64 MiB — the exact parameters sync-core uses for op
+        // payload encryption. Slow (~seconds); this is the vector that proves
+        // real cross-device key derivation works.
+        val tag = Argon2.argon2id(
+            password = "test-encryption-password-123".toByteArray(),
+            salt = salt16,
+            parallelism = 1,
+            memoryKiB = 65536,
+            iterations = 3,
+            outputLength = 32,
+        )
+        assertEquals(
+            "d72cc3369f92963baa9bc9de03be105e6c663b67ed1f085623a8f736463c20c9",
+            tag.toHex(),
+        )
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Argon2Test.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Argon2Test.kt
@@ -11,7 +11,7 @@ import org.junit.Test
  */
 class Argon2Test {
 
-    private val salt16 = hexToBytes("000102030405060708090a0b0c0d0e0f")
+    private val salt16 = "000102030405060708090a0b0c0d0e0f".hexToByteArray()
 
     @Test
     fun `matches RFC 9106 argon2id test vector`() {
@@ -27,7 +27,7 @@ class Argon2Test {
         )
         assertEquals(
             "0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659",
-            tag.toHex(),
+            tag.toHexString(),
         )
     }
 
@@ -43,7 +43,7 @@ class Argon2Test {
         )
         assertEquals(
             "0d786afcedf5887149009b3bf1ce23bef5769cb2dc10d058c8c40dd7f431f7f1",
-            tag.toHex(),
+            tag.toHexString(),
         )
     }
 
@@ -59,7 +59,7 @@ class Argon2Test {
         )
         assertEquals(
             "395cb724885b0d8fe5a8ed5374cc22258ffef04b5225de589c6d24700e3fc6a0",
-            tag.toHex(),
+            tag.toHexString(),
         )
     }
 
@@ -78,10 +78,7 @@ class Argon2Test {
         )
         assertEquals(
             "d72cc3369f92963baa9bc9de03be105e6c663b67ed1f085623a8f736463c20c9",
-            tag.toHex(),
+            tag.toHexString(),
         )
     }
-
-    private fun hexToBytes(hex: String): ByteArray =
-        ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
 }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Blake2bTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Blake2bTest.kt
@@ -1,0 +1,64 @@
+package com.superproductivity.superproductivity.crypto
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Vectors: "abc" (RFC 7693 appendix A) plus hash-wasm generated fixtures —
+ * hash-wasm is the exact library the JS side (packages/sync-core) uses, so
+ * matching it is what guarantees cross-language key derivation.
+ */
+class Blake2bTest {
+
+    @Test
+    fun `abc with 64-byte digest matches RFC 7693`() {
+        assertEquals(
+            "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1" +
+                "7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923",
+            Blake2b(64).update("abc".toByteArray()).digest().toHex(),
+        )
+    }
+
+    @Test
+    fun `300-byte multi-block input matches hash-wasm`() {
+        val input = ByteArray(300) { it.toByte() }
+        assertEquals(
+            "d9cf5983dc6b34c0fa1f0226926855ad3eccd2bcdcd8f8053b9a80664d33b5af" +
+                "cc32fd21c70ea14f4ef50ca97c3203c4d1803159f0e01bb6cb1d1c83db52b63c",
+            Blake2b(64).update(input).digest().toHex(),
+        )
+    }
+
+    @Test
+    fun `incremental updates equal single update`() {
+        val input = ByteArray(300) { it.toByte() }
+        val single = Blake2b(64).update(input).digest()
+        val incremental = Blake2b(64)
+            .update(input, 0, 1)
+            .update(input, 1, 127)
+            .update(input, 128, 128)
+            .update(input, 256, 44)
+            .digest()
+        assertEquals(single.toHex(), incremental.toHex())
+    }
+
+    @Test
+    fun `abc with 28-byte digest matches hash-wasm`() {
+        assertEquals(
+            "9bd237b02a29e43bdd6738afa5b53ff0eee178d6210b618e4511aec8",
+            Blake2b(28).update("abc".toByteArray()).digest().toHex(),
+        )
+    }
+
+    @Test
+    fun `empty input with 64-byte digest matches RFC 7693 reference`() {
+        // From the BLAKE2 reference implementation's testvectors (blake2b, empty input)
+        assertEquals(
+            "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419" +
+                "d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce",
+            Blake2b(64).digest().toHex(),
+        )
+    }
+}
+
+internal fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Blake2bTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/Blake2bTest.kt
@@ -15,7 +15,7 @@ class Blake2bTest {
         assertEquals(
             "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1" +
                 "7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923",
-            Blake2b(64).update("abc".toByteArray()).digest().toHex(),
+            Blake2b(64).update("abc".toByteArray()).digest().toHexString(),
         )
     }
 
@@ -25,7 +25,7 @@ class Blake2bTest {
         assertEquals(
             "d9cf5983dc6b34c0fa1f0226926855ad3eccd2bcdcd8f8053b9a80664d33b5af" +
                 "cc32fd21c70ea14f4ef50ca97c3203c4d1803159f0e01bb6cb1d1c83db52b63c",
-            Blake2b(64).update(input).digest().toHex(),
+            Blake2b(64).update(input).digest().toHexString(),
         )
     }
 
@@ -39,14 +39,14 @@ class Blake2bTest {
             .update(input, 128, 128)
             .update(input, 256, 44)
             .digest()
-        assertEquals(single.toHex(), incremental.toHex())
+        assertEquals(single.toHexString(), incremental.toHexString())
     }
 
     @Test
     fun `abc with 28-byte digest matches hash-wasm`() {
         assertEquals(
             "9bd237b02a29e43bdd6738afa5b53ff0eee178d6210b618e4511aec8",
-            Blake2b(28).update("abc".toByteArray()).digest().toHex(),
+            Blake2b(28).update("abc".toByteArray()).digest().toHexString(),
         )
     }
 
@@ -56,9 +56,9 @@ class Blake2bTest {
         assertEquals(
             "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419" +
                 "d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce",
-            Blake2b(64).digest().toHex(),
+            Blake2b(64).digest().toHexString(),
         )
     }
 }
 
-internal fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+internal fun ByteArray.toHexString(): String = joinToString("") { "%02x".format(it) }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/EncryptedOpFixtures.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/EncryptedOpFixtures.kt
@@ -1,0 +1,53 @@
+package com.superproductivity.superproductivity.crypto
+
+/**
+ * Ciphertexts produced by the REAL JS encrypt() (packages/sync-core, Argon2id
+ * + AES-256-GCM) with [PASSWORD] and distinct session salts — the shared
+ * cross-language proof that the Kotlin side can read production op payloads.
+ *
+ * When the KDF parameters or wire format change, regenerate every constant
+ * here together (see the contract note in
+ * packages/sync-core/src/encryption/argon2.ts).
+ */
+object EncryptedOpFixtures {
+    const val PASSWORD = "test-encryption-password-123"
+
+    const val CRT_PLAINTEXT =
+        "{\"actionPayload\":{},\"entityChanges\":[{\"entityType\":\"TASK\"," +
+            "\"entityId\":\"task-crt-1\",\"opType\":\"CRT\",\"changes\":{" +
+            "\"id\":\"task-crt-1\",\"title\":\"Water plants\"," +
+            "\"remindAt\":4102444500000,\"deadlineRemindAt\":4102444700000}}]}"
+
+    const val CRT_CIPHERTEXT =
+        "yInMh3KUZFmkCS83epg2CtNuiIkgEa0YXB+kFt8WQ3sRR0a4Y4qJSLABI1u1vZ/7MMTjvm2lJRHP" +
+            "+tyojvcwQHLRi3/AJNjuW6f2RlmiWd3BvseQ+6yohZHO1nLR6oST8bG+Z+8919wcgrR//qUxTDVi" +
+            "v6LkuzfuPDTgxbReesJzu8H0KahiMK1iwHznRTB/FXHeBHh3agHu4B5i23VPRFLVHpFjyrbqRSje" +
+            "Afhx07467A6Z0j4PYAHssN7jOBkMJOh6qA4M8kyMkc53h7R2Y77efjR6tL30wTaurg9IB3gNrySO" +
+            "0rLBKV3dvRd9DjlQKIcNCDkFSaQJcu/tU7I="
+
+    const val SCHEDULE_PLAINTEXT =
+        "{\"actionPayload\":{\"task\":{\"id\":\"task-sched-1\",\"title\":\"Buy milk\"}," +
+            "\"dueWithTime\":4102444800000,\"remindAt\":4102444200000},\"entityChanges\":[]}"
+
+    const val SCHEDULE_CIPHERTEXT =
+        "NZGjL4VYD9CYLgZql5KbDLKGIgXfko/I2n2ydKIu8MS6xrPmesgUIS4Vm5aOzZFL9ubGAQ1lqolm" +
+            "D+WM/ORvX0SfQAHroLS9hovvqzh5mHFrrY75L/N//JWcLjPx1H+SY3gDTonXZD+fAxWVvmMUUOXt" +
+            "lriaR2bztfF9yw3JvnmJEtJ6f7QpZ334czpvY0hg1wNaNDMs1aRNoSTXQD9+6qbWh3faDBShq78p" +
+            "UHfyxJulwn+f5Nl2"
+
+    const val DISMISS_CIPHERTEXT =
+        "91DsnzZw6biDoWvY2a3R8WSZXwXu2+1jARKgfyA0PIlR3rN5cttbLFEFhf2ZX3vd5zc9kkJCnXyx" +
+            "q/CjBd2f/QR+pEpEncU4atId6zYLK+UodKS0jhF76543enULpD8cDiyGBWqhlck="
+}
+
+class InMemoryKeyCache : DerivedKeyCache {
+    val map = mutableMapOf<String, ByteArray>()
+    var putCount = 0
+
+    override fun get(saltB64: String): ByteArray? = map[saltB64]
+
+    override fun put(saltB64: String, key: ByteArray) {
+        putCount++
+        map[saltB64] = key
+    }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/LiveJsEncryptRoundTripTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/LiveJsEncryptRoundTripTest.kt
@@ -1,0 +1,60 @@
+package com.superproductivity.superproductivity.crypto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+import kotlin.io.encoding.Base64
+
+/**
+ * Round-trip against ciphertexts freshly produced by the REAL sync-core
+ * encrypt() — regenerated on every CI run by
+ * tools/generate-android-crypto-fixtures.mjs, so KDF-parameter or wire-format
+ * drift fails the PR that introduces it instead of silently degrading
+ * background reminders on Android.
+ *
+ * Skipped when the fixture file is absent (plain local runs); the frozen
+ * vectors in [EncryptedOpFixtures] still cover compatibility there. Local run:
+ *
+ *   node tools/generate-android-crypto-fixtures.mjs
+ *   cd android && ./gradlew :app:testFdroidDebugUnitTest
+ */
+class LiveJsEncryptRoundTripTest {
+
+    private data class Fixture(val name: String, val plaintext: String, val ciphertext: String)
+
+    @Test
+    fun `decrypts fixtures freshly encrypted by the real JS implementation`() {
+        val file = locateFixtures()
+        assumeTrue("live fixtures not generated - skipping", file != null)
+
+        var password: String? = null
+        val fixtures = mutableListOf<Fixture>()
+        file!!.readLines().forEach { line ->
+            val parts = line.split('\t')
+            when (parts.firstOrNull()) {
+                "password" -> password = decodeUtf8(parts[1])
+                "entry" -> fixtures.add(Fixture(parts[1], decodeUtf8(parts[2]), parts[3]))
+            }
+        }
+        assertTrue("fixture file has no entries", fixtures.size >= 2)
+
+        val decryptor = OpPayloadDecryptor(password!!, InMemoryKeyCache())
+        for ((name, plaintext, ciphertext) in fixtures) {
+            assertEquals("fixture '$name'", plaintext, decryptor.decrypt(ciphertext))
+        }
+
+        // The generator clears the JS session cache between entries, so the
+        // fixtures must span distinct salts (like ops from different devices).
+        val salts = fixtures.map { Base64.decode(it.ciphertext).copyOf(16).toHexString() }
+        assertTrue("expected distinct session salts", salts.toSet().size >= 2)
+    }
+
+    private fun decodeUtf8(b64: String): String = String(Base64.decode(b64), Charsets.UTF_8)
+
+    private fun locateFixtures(): File? =
+        listOfNotNull(System.getenv("LIVE_CRYPTO_FIXTURES"), "build/live-crypto-fixtures.tsv")
+            .map(::File)
+            .firstOrNull { it.isFile }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptorTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptorTest.kt
@@ -1,0 +1,121 @@
+package com.superproductivity.superproductivity.crypto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import kotlin.io.encoding.Base64
+
+/**
+ * The ciphertexts were produced by the REAL JS encrypt()
+ * (packages/sync-core, Argon2id + AES-256-GCM) with password
+ * "test-encryption-password-123" and distinct session salts — this is the
+ * cross-language proof that the Kotlin side can read production op payloads.
+ */
+class OpPayloadDecryptorTest {
+
+    private class InMemoryKeyCache : DerivedKeyCache {
+        val map = mutableMapOf<String, ByteArray>()
+        var putCount = 0
+
+        override fun get(saltB64: String): ByteArray? = map[saltB64]
+
+        override fun put(saltB64: String, key: ByteArray) {
+            putCount++
+            map[saltB64] = key
+        }
+    }
+
+    private fun newDecryptor(
+        cache: InMemoryKeyCache = InMemoryKeyCache(),
+        password: String = PASSWORD,
+    ): OpPayloadDecryptor = OpPayloadDecryptor(password, cache)
+
+    @Test
+    fun `decrypts real sync-core ciphertext for a CRT payload`() {
+        assertEquals(CRT_PLAINTEXT, newDecryptor().decrypt(CRT_CIPHERTEXT))
+    }
+
+    @Test
+    fun `decrypts real sync-core ciphertext with a different session salt`() {
+        assertEquals(SCHEDULE_PLAINTEXT, newDecryptor().decrypt(SCHEDULE_CIPHERTEXT))
+    }
+
+    @Test
+    fun `derives the key only once per salt`() {
+        val cache = InMemoryKeyCache()
+        val decryptor = newDecryptor(cache)
+        assertEquals(CRT_PLAINTEXT, decryptor.decrypt(CRT_CIPHERTEXT))
+        assertEquals(CRT_PLAINTEXT, decryptor.decrypt(CRT_CIPHERTEXT))
+        assertEquals(1, cache.putCount)
+    }
+
+    @Test
+    fun `reuses a pre-populated cache across decryptor instances`() {
+        val cache = InMemoryKeyCache()
+        newDecryptor(cache).decrypt(CRT_CIPHERTEXT)
+        assertEquals(CRT_PLAINTEXT, newDecryptor(cache).decrypt(CRT_CIPHERTEXT))
+        assertEquals(1, cache.putCount)
+    }
+
+    @Test
+    fun `cache-only mode returns null on a cold cache but decrypts once primed`() {
+        val cache = InMemoryKeyCache()
+        val cacheOnly = OpPayloadDecryptor(PASSWORD, cache, deriveOnMiss = false)
+        assertNull(cacheOnly.decrypt(CRT_CIPHERTEXT))
+        // The periodic worker primes the cache...
+        newDecryptor(cache).decrypt(CRT_CIPHERTEXT)
+        // ...after which the deadline-bound receiver can decrypt too
+        assertEquals(CRT_PLAINTEXT, cacheOnly.decrypt(CRT_CIPHERTEXT))
+    }
+
+    @Test
+    fun `wrong password returns null`() {
+        assertNull(newDecryptor(password = "wrong-password").decrypt(CRT_CIPHERTEXT))
+    }
+
+    @Test
+    fun `tampered ciphertext fails GCM authentication and returns null`() {
+        val bytes = Base64.decode(CRT_CIPHERTEXT)
+        bytes[bytes.size - 1] = (bytes[bytes.size - 1].toInt() xor 0x01).toByte()
+        assertNull(newDecryptor().decrypt(Base64.encode(bytes)))
+    }
+
+    @Test
+    fun `invalid base64 returns null`() {
+        assertNull(newDecryptor().decrypt("not-base64!!!"))
+    }
+
+    @Test
+    fun `too-short input returns null without deriving a key`() {
+        val cache = InMemoryKeyCache()
+        assertNull(newDecryptor(cache).decrypt(Base64.encode(ByteArray(20))))
+        assertEquals(0, cache.putCount)
+    }
+
+    companion object {
+        const val PASSWORD = "test-encryption-password-123"
+
+        const val CRT_PLAINTEXT =
+            "{\"actionPayload\":{},\"entityChanges\":[{\"entityType\":\"TASK\"," +
+                "\"entityId\":\"task-crt-1\",\"opType\":\"CRT\",\"changes\":{" +
+                "\"id\":\"task-crt-1\",\"title\":\"Water plants\"," +
+                "\"remindAt\":4102444500000,\"deadlineRemindAt\":4102444700000}}]}"
+
+        const val CRT_CIPHERTEXT =
+            "yInMh3KUZFmkCS83epg2CtNuiIkgEa0YXB+kFt8WQ3sRR0a4Y4qJSLABI1u1vZ/7MMTjvm2lJRHP" +
+                "+tyojvcwQHLRi3/AJNjuW6f2RlmiWd3BvseQ+6yohZHO1nLR6oST8bG+Z+8919wcgrR//qUxTDVi" +
+                "v6LkuzfuPDTgxbReesJzu8H0KahiMK1iwHznRTB/FXHeBHh3agHu4B5i23VPRFLVHpFjyrbqRSje" +
+                "Afhx07467A6Z0j4PYAHssN7jOBkMJOh6qA4M8kyMkc53h7R2Y77efjR6tL30wTaurg9IB3gNrySO" +
+                "0rLBKV3dvRd9DjlQKIcNCDkFSaQJcu/tU7I="
+
+        const val SCHEDULE_PLAINTEXT =
+            "{\"actionPayload\":{\"task\":{\"id\":\"task-sched-1\",\"title\":\"Buy milk\"}," +
+                "\"dueWithTime\":4102444800000,\"remindAt\":4102444200000},\"entityChanges\":[]}"
+
+        const val SCHEDULE_CIPHERTEXT =
+            "NZGjL4VYD9CYLgZql5KbDLKGIgXfko/I2n2ydKIu8MS6xrPmesgUIS4Vm5aOzZFL9ubGAQ1lqolm" +
+                "D+WM/ORvX0SfQAHroLS9hovvqzh5mHFrrY75L/N//JWcLjPx1H+SY3gDTonXZD+fAxWVvmMUUOXt" +
+                "lriaR2bztfF9yw3JvnmJEtJ6f7QpZ334czpvY0hg1wNaNDMs1aRNoSTXQD9+6qbWh3faDBShq78p" +
+                "UHfyxJulwn+f5Nl2"
+    }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptorTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/crypto/OpPayloadDecryptorTest.kt
@@ -1,29 +1,17 @@
 package com.superproductivity.superproductivity.crypto
 
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.CRT_CIPHERTEXT
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.CRT_PLAINTEXT
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.PASSWORD
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.SCHEDULE_CIPHERTEXT
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.SCHEDULE_PLAINTEXT
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import kotlin.io.encoding.Base64
 
-/**
- * The ciphertexts were produced by the REAL JS encrypt()
- * (packages/sync-core, Argon2id + AES-256-GCM) with password
- * "test-encryption-password-123" and distinct session salts — this is the
- * cross-language proof that the Kotlin side can read production op payloads.
- */
+/** See [EncryptedOpFixtures] for provenance of the real-JS ciphertexts. */
 class OpPayloadDecryptorTest {
-
-    private class InMemoryKeyCache : DerivedKeyCache {
-        val map = mutableMapOf<String, ByteArray>()
-        var putCount = 0
-
-        override fun get(saltB64: String): ByteArray? = map[saltB64]
-
-        override fun put(saltB64: String, key: ByteArray) {
-            putCount++
-            map[saltB64] = key
-        }
-    }
 
     private fun newDecryptor(
         cache: InMemoryKeyCache = InMemoryKeyCache(),
@@ -90,32 +78,5 @@ class OpPayloadDecryptorTest {
         val cache = InMemoryKeyCache()
         assertNull(newDecryptor(cache).decrypt(Base64.encode(ByteArray(20))))
         assertEquals(0, cache.putCount)
-    }
-
-    companion object {
-        const val PASSWORD = "test-encryption-password-123"
-
-        const val CRT_PLAINTEXT =
-            "{\"actionPayload\":{},\"entityChanges\":[{\"entityType\":\"TASK\"," +
-                "\"entityId\":\"task-crt-1\",\"opType\":\"CRT\",\"changes\":{" +
-                "\"id\":\"task-crt-1\",\"title\":\"Water plants\"," +
-                "\"remindAt\":4102444500000,\"deadlineRemindAt\":4102444700000}}]}"
-
-        const val CRT_CIPHERTEXT =
-            "yInMh3KUZFmkCS83epg2CtNuiIkgEa0YXB+kFt8WQ3sRR0a4Y4qJSLABI1u1vZ/7MMTjvm2lJRHP" +
-                "+tyojvcwQHLRi3/AJNjuW6f2RlmiWd3BvseQ+6yohZHO1nLR6oST8bG+Z+8919wcgrR//qUxTDVi" +
-                "v6LkuzfuPDTgxbReesJzu8H0KahiMK1iwHznRTB/FXHeBHh3agHu4B5i23VPRFLVHpFjyrbqRSje" +
-                "Afhx07467A6Z0j4PYAHssN7jOBkMJOh6qA4M8kyMkc53h7R2Y77efjR6tL30wTaurg9IB3gNrySO" +
-                "0rLBKV3dvRd9DjlQKIcNCDkFSaQJcu/tU7I="
-
-        const val SCHEDULE_PLAINTEXT =
-            "{\"actionPayload\":{\"task\":{\"id\":\"task-sched-1\",\"title\":\"Buy milk\"}," +
-                "\"dueWithTime\":4102444800000,\"remindAt\":4102444200000},\"entityChanges\":[]}"
-
-        const val SCHEDULE_CIPHERTEXT =
-            "NZGjL4VYD9CYLgZql5KbDLKGIgXfko/I2n2ydKIu8MS6xrPmesgUIS4Vm5aOzZFL9ubGAQ1lqolm" +
-                "D+WM/ORvX0SfQAHroLS9hovvqzh5mHFrrY75L/N//JWcLjPx1H+SY3gDTonXZD+fAxWVvmMUUOXt" +
-                "lriaR2bztfF9yw3JvnmJEtJ6f7QpZ334czpvY0hg1wNaNDMs1aRNoSTXQD9+6qbWh3faDBShq78p" +
-                "UHfyxJulwn+f5Nl2"
     }
 }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProviderTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProviderTest.kt
@@ -1,0 +1,201 @@
+package com.superproductivity.superproductivity.service
+
+import com.superproductivity.superproductivity.crypto.DerivedKeyCache
+import com.superproductivity.superproductivity.crypto.OpPayloadDecryptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reproduction of the "background reminders stopped working" bug: SuperSync
+ * encrypts op payloads end-to-end (mandatory since #8670), so `payload` is a
+ * base64 string and the plaintext-JSON parsing found no reminders to schedule.
+ *
+ * The download-response fixture mirrors GET /api/sync/ops exactly; the
+ * ciphertexts were produced by the real JS encrypt() (packages/sync-core)
+ * with distinct session salts, like ops from different devices.
+ */
+class SuperSyncBackgroundProviderTest {
+
+    private class InMemoryKeyCache : DerivedKeyCache {
+        private val map = mutableMapOf<String, ByteArray>()
+
+        override fun get(saltB64: String): ByteArray? = map[saltB64]
+
+        override fun put(saltB64: String, key: ByteArray) {
+            map[saltB64] = key
+        }
+    }
+
+    private fun providerWithDecryptor(): SuperSyncBackgroundProvider =
+        SuperSyncBackgroundProvider(OpPayloadDecryptor(PASSWORD, InMemoryKeyCache()))
+
+    @Test
+    fun `schedules reminders from encrypted ops when a decryptor is present`() {
+        val result = providerWithDecryptor().parseResponse(ENCRYPTED_DOWNLOAD_RESPONSE)
+
+        val byKey = result.remindersToSchedule.associateBy { Pair(it.taskId, it.isDueDate) }
+        assertEquals(3, byKey.size)
+
+        // op-1 (CRT, entityChanges path): remindAt + deadlineRemindAt
+        val crtReminder = byKey[Pair("task-crt-1", false)]!!
+        assertEquals("Water plants", crtReminder.title)
+        assertEquals(4102444500000L, crtReminder.remindAt)
+        val crtDeadline = byKey[Pair("task-crt-1", true)]!!
+        assertEquals(4102444700000L, crtDeadline.remindAt)
+
+        // op-2 (scheduleTaskWithTime, actionPayload path)
+        val schedReminder = byKey[Pair("task-sched-1", false)]!!
+        assertEquals("Buy milk", schedReminder.title)
+        assertEquals(4102444200000L, schedReminder.remindAt)
+
+        // op-3 (dismissReminderOnly) cancels via the plaintext envelope
+        assertEquals(setOf("task-dismiss-1"), result.taskIdsToCancel)
+        assertEquals(103L, result.latestSeq)
+        assertEquals(false, result.hasMore)
+    }
+
+    @Test
+    fun `without a decryptor encrypted ops degrade to envelope-only cancels`() {
+        val result = SuperSyncBackgroundProvider().parseResponse(ENCRYPTED_DOWNLOAD_RESPONSE)
+
+        assertTrue(result.remindersToSchedule.isEmpty())
+        assertEquals(setOf("task-dismiss-1"), result.taskIdsToCancel)
+        assertEquals(103L, result.latestSeq)
+    }
+
+    @Test
+    fun `wrong password degrades to envelope-only cancels`() {
+        val provider =
+            SuperSyncBackgroundProvider(OpPayloadDecryptor("wrong-password", InMemoryKeyCache()))
+        val result = provider.parseResponse(ENCRYPTED_DOWNLOAD_RESPONSE)
+
+        assertTrue(result.remindersToSchedule.isEmpty())
+        assertEquals(setOf("task-dismiss-1"), result.taskIdsToCancel)
+    }
+
+    @Test
+    fun `plaintext payloads keep working with and without a decryptor`() {
+        val plaintextResponse = """
+            {
+              "ops": [
+                {
+                  "serverSeq": 7,
+                  "receivedAt": 1755700001000,
+                  "op": {
+                    "id": "op-plain",
+                    "clientId": "client_desktop_1",
+                    "actionType": "[Task Shared] scheduleTaskWithTime",
+                    "opType": "UPD",
+                    "entityType": "TASK",
+                    "entityId": "task-plain-1",
+                    "payload": {
+                      "actionPayload": {
+                        "task": { "id": "task-plain-1", "title": "Plain task" },
+                        "dueWithTime": 4102444800000,
+                        "remindAt": 4102444200000
+                      },
+                      "entityChanges": []
+                    },
+                    "vectorClock": { "client_desktop_1": 1 },
+                    "timestamp": 1755700000000,
+                    "schemaVersion": 6
+                  }
+                }
+              ],
+              "hasMore": false,
+              "latestSeq": 7
+            }
+        """.trimIndent()
+
+        for (provider in listOf(SuperSyncBackgroundProvider(), providerWithDecryptor())) {
+            val result = provider.parseResponse(plaintextResponse)
+            assertEquals(1, result.remindersToSchedule.size)
+            val reminder = result.remindersToSchedule.single()
+            assertEquals("task-plain-1", reminder.taskId)
+            assertEquals("Plain task", reminder.title)
+            assertEquals(4102444200000L, reminder.remindAt)
+        }
+    }
+
+    companion object {
+        const val PASSWORD = "test-encryption-password-123"
+
+        private const val CRT_CIPHERTEXT =
+            "yInMh3KUZFmkCS83epg2CtNuiIkgEa0YXB+kFt8WQ3sRR0a4Y4qJSLABI1u1vZ/7MMTjvm2lJRHP" +
+                "+tyojvcwQHLRi3/AJNjuW6f2RlmiWd3BvseQ+6yohZHO1nLR6oST8bG+Z+8919wcgrR//qUxTDVi" +
+                "v6LkuzfuPDTgxbReesJzu8H0KahiMK1iwHznRTB/FXHeBHh3agHu4B5i23VPRFLVHpFjyrbqRSje" +
+                "Afhx07467A6Z0j4PYAHssN7jOBkMJOh6qA4M8kyMkc53h7R2Y77efjR6tL30wTaurg9IB3gNrySO" +
+                "0rLBKV3dvRd9DjlQKIcNCDkFSaQJcu/tU7I="
+
+        private const val SCHEDULE_CIPHERTEXT =
+            "NZGjL4VYD9CYLgZql5KbDLKGIgXfko/I2n2ydKIu8MS6xrPmesgUIS4Vm5aOzZFL9ubGAQ1lqolm" +
+                "D+WM/ORvX0SfQAHroLS9hovvqzh5mHFrrY75L/N//JWcLjPx1H+SY3gDTonXZD+fAxWVvmMUUOXt" +
+                "lriaR2bztfF9yw3JvnmJEtJ6f7QpZ334czpvY0hg1wNaNDMs1aRNoSTXQD9+6qbWh3faDBShq78p" +
+                "UHfyxJulwn+f5Nl2"
+
+        private const val DISMISS_CIPHERTEXT =
+            "91DsnzZw6biDoWvY2a3R8WSZXwXu2+1jARKgfyA0PIlR3rN5cttbLFEFhf2ZX3vd5zc9kkJCnXyx" +
+                "q/CjBd2f/QR+pEpEncU4atId6zYLK+UodKS0jhF76543enULpD8cDiyGBWqhlck="
+
+        private val ENCRYPTED_DOWNLOAD_RESPONSE = """
+            {
+              "ops": [
+                {
+                  "serverSeq": 101,
+                  "receivedAt": 1755700001000,
+                  "op": {
+                    "id": "op-1",
+                    "clientId": "client_desktop_1",
+                    "actionType": "[Task] Add task",
+                    "opType": "CRT",
+                    "entityType": "TASK",
+                    "entityId": "task-crt-1",
+                    "payload": "$CRT_CIPHERTEXT",
+                    "isPayloadEncrypted": true,
+                    "vectorClock": { "client_desktop_1": 7 },
+                    "timestamp": 1755700000000,
+                    "schemaVersion": 6
+                  }
+                },
+                {
+                  "serverSeq": 102,
+                  "receivedAt": 1755700002000,
+                  "op": {
+                    "id": "op-2",
+                    "clientId": "client_desktop_1",
+                    "actionType": "[Task Shared] scheduleTaskWithTime",
+                    "opType": "UPD",
+                    "entityType": "TASK",
+                    "entityId": "task-sched-1",
+                    "payload": "$SCHEDULE_CIPHERTEXT",
+                    "isPayloadEncrypted": true,
+                    "vectorClock": { "client_desktop_1": 7 },
+                    "timestamp": 1755700000000,
+                    "schemaVersion": 6
+                  }
+                },
+                {
+                  "serverSeq": 103,
+                  "receivedAt": 1755700003000,
+                  "op": {
+                    "id": "op-3",
+                    "clientId": "client_desktop_1",
+                    "actionType": "[Task Shared] dismissReminderOnly",
+                    "opType": "UPD",
+                    "entityType": "TASK",
+                    "entityId": "task-dismiss-1",
+                    "payload": "$DISMISS_CIPHERTEXT",
+                    "isPayloadEncrypted": true,
+                    "vectorClock": { "client_desktop_1": 7 },
+                    "timestamp": 1755700000000,
+                    "schemaVersion": 6
+                  }
+                }
+              ],
+              "hasMore": false,
+              "latestSeq": 103
+            }
+        """.trimIndent()
+    }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProviderTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/service/SuperSyncBackgroundProviderTest.kt
@@ -1,6 +1,10 @@
 package com.superproductivity.superproductivity.service
 
-import com.superproductivity.superproductivity.crypto.DerivedKeyCache
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.CRT_CIPHERTEXT
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.DISMISS_CIPHERTEXT
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.PASSWORD
+import com.superproductivity.superproductivity.crypto.EncryptedOpFixtures.SCHEDULE_CIPHERTEXT
+import com.superproductivity.superproductivity.crypto.InMemoryKeyCache
 import com.superproductivity.superproductivity.crypto.OpPayloadDecryptor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -12,20 +16,11 @@ import org.junit.Test
  * base64 string and the plaintext-JSON parsing found no reminders to schedule.
  *
  * The download-response fixture mirrors GET /api/sync/ops exactly; the
- * ciphertexts were produced by the real JS encrypt() (packages/sync-core)
- * with distinct session salts, like ops from different devices.
+ * ciphertexts (see [com.superproductivity.superproductivity.crypto.EncryptedOpFixtures])
+ * were produced by the real JS encrypt() (packages/sync-core) with distinct
+ * session salts, like ops from different devices.
  */
 class SuperSyncBackgroundProviderTest {
-
-    private class InMemoryKeyCache : DerivedKeyCache {
-        private val map = mutableMapOf<String, ByteArray>()
-
-        override fun get(saltB64: String): ByteArray? = map[saltB64]
-
-        override fun put(saltB64: String, key: ByteArray) {
-            map[saltB64] = key
-        }
-    }
 
     private fun providerWithDecryptor(): SuperSyncBackgroundProvider =
         SuperSyncBackgroundProvider(OpPayloadDecryptor(PASSWORD, InMemoryKeyCache()))
@@ -57,7 +52,7 @@ class SuperSyncBackgroundProviderTest {
 
     @Test
     fun `without a decryptor encrypted ops degrade to envelope-only cancels`() {
-        val result = SuperSyncBackgroundProvider().parseResponse(ENCRYPTED_DOWNLOAD_RESPONSE)
+        val result = SuperSyncBackgroundProvider(null).parseResponse(ENCRYPTED_DOWNLOAD_RESPONSE)
 
         assertTrue(result.remindersToSchedule.isEmpty())
         assertEquals(setOf("task-dismiss-1"), result.taskIdsToCancel)
@@ -108,7 +103,7 @@ class SuperSyncBackgroundProviderTest {
             }
         """.trimIndent()
 
-        for (provider in listOf(SuperSyncBackgroundProvider(), providerWithDecryptor())) {
+        for (provider in listOf(SuperSyncBackgroundProvider(null), providerWithDecryptor())) {
             val result = provider.parseResponse(plaintextResponse)
             assertEquals(1, result.remindersToSchedule.size)
             val reminder = result.remindersToSchedule.single()
@@ -119,25 +114,6 @@ class SuperSyncBackgroundProviderTest {
     }
 
     companion object {
-        const val PASSWORD = "test-encryption-password-123"
-
-        private const val CRT_CIPHERTEXT =
-            "yInMh3KUZFmkCS83epg2CtNuiIkgEa0YXB+kFt8WQ3sRR0a4Y4qJSLABI1u1vZ/7MMTjvm2lJRHP" +
-                "+tyojvcwQHLRi3/AJNjuW6f2RlmiWd3BvseQ+6yohZHO1nLR6oST8bG+Z+8919wcgrR//qUxTDVi" +
-                "v6LkuzfuPDTgxbReesJzu8H0KahiMK1iwHznRTB/FXHeBHh3agHu4B5i23VPRFLVHpFjyrbqRSje" +
-                "Afhx07467A6Z0j4PYAHssN7jOBkMJOh6qA4M8kyMkc53h7R2Y77efjR6tL30wTaurg9IB3gNrySO" +
-                "0rLBKV3dvRd9DjlQKIcNCDkFSaQJcu/tU7I="
-
-        private const val SCHEDULE_CIPHERTEXT =
-            "NZGjL4VYD9CYLgZql5KbDLKGIgXfko/I2n2ydKIu8MS6xrPmesgUIS4Vm5aOzZFL9ubGAQ1lqolm" +
-                "D+WM/ORvX0SfQAHroLS9hovvqzh5mHFrrY75L/N//JWcLjPx1H+SY3gDTonXZD+fAxWVvmMUUOXt" +
-                "lriaR2bztfF9yw3JvnmJEtJ6f7QpZ334czpvY0hg1wNaNDMs1aRNoSTXQD9+6qbWh3faDBShq78p" +
-                "UHfyxJulwn+f5Nl2"
-
-        private const val DISMISS_CIPHERTEXT =
-            "91DsnzZw6biDoWvY2a3R8WSZXwXu2+1jARKgfyA0PIlR3rN5cttbLFEFhf2ZX3vd5zc9kkJCnXyx" +
-                "q/CjBd2f/QR+pEpEncU4atId6zYLK+UodKS0jhF76543enULpD8cDiyGBWqhlck="
-
         private val ENCRYPTED_DOWNLOAD_RESPONSE = """
             {
               "ops": [

--- a/packages/shared-schema/src/supersync-http-contract.ts
+++ b/packages/shared-schema/src/supersync-http-contract.ts
@@ -76,6 +76,8 @@ export const SuperSyncOperationSchema = z.object({
   vectorClock: SuperSyncVectorClockSchema,
   timestamp: z.number(),
   schemaVersion: z.number().int().min(1).max(100),
+  /** Optional (absent on old clients) — readers must sniff the payload type
+   * instead of relying on it (android `SuperSyncBackgroundProvider` does). */
   isPayloadEncrypted: z.boolean().optional(),
   syncImportReason: z.enum(SUPER_SYNC_IMPORT_REASONS).optional(),
   /** Server cursor proven to be included in a causally accepted REPAIR snapshot. */

--- a/packages/sync-core/src/encryption.ts
+++ b/packages/sync-core/src/encryption.ts
@@ -18,6 +18,9 @@
  * Ciphertext is base64-encoded for transport. `detectFormat()` discriminates
  * by length: < 28 bytes is invalid, < 44 bytes is unambiguously legacy,
  * >= 44 bytes is treated as Argon2id with a legacy fallback on auth failure.
+ * The Android background sync reads the Argon2id format independently
+ * (android `crypto/OpPayloadDecryptor.kt`) — changes here must be mirrored
+ * there and its fixtures regenerated (see the note in encryption/argon2.ts).
  *
  * ## Salt and IV semantics
  *

--- a/packages/sync-core/src/encryption.ts
+++ b/packages/sync-core/src/encryption.ts
@@ -21,6 +21,8 @@
  * The Android background sync reads the Argon2id format independently
  * (android `crypto/OpPayloadDecryptor.kt`) — changes here must be mirrored
  * there and its fixtures regenerated (see the note in encryption/argon2.ts).
+ * CI verifies the round-trip live: tools/generate-android-crypto-fixtures.mjs
+ * feeds fresh encrypt() output to the Kotlin tests on every Android CI run.
  *
  * ## Salt and IV semantics
  *

--- a/packages/sync-core/src/encryption/argon2.ts
+++ b/packages/sync-core/src/encryption/argon2.ts
@@ -1,6 +1,11 @@
 import { argon2id } from 'hash-wasm';
 import { KEY_LENGTH, SALT_LENGTH, getRandomBytes } from './web-crypto';
 
+// These parameters (and the salt|iv|ciphertext wire format in encryption.ts)
+// are a cross-platform contract: the Android background reminder worker
+// re-implements this KDF in Kotlin and must derive identical keys.
+// If you change them, update android/.../crypto/OpPayloadDecryptor.kt and its
+// hash-wasm-generated test vectors (Argon2Test.kt) in the same PR.
 const DEFAULT_ARGON2_PARAMS = {
   parallelism: 1,
   iterations: 3,

--- a/src/app/features/android/android-interface.ts
+++ b/src/app/features/android/android-interface.ts
@@ -152,6 +152,9 @@ export interface AndroidInterface {
   // Background sync credential bridge (for WorkManager-based reminder cancellation)
   setSuperSyncCredentials?(baseUrl: string, accessToken: string): void;
   clearSuperSyncCredentials?(): void;
+  // Mirrors the E2EE password so the background worker can decrypt op payloads;
+  // '' clears it. Optional: older APKs don't have it.
+  setSuperSyncEncryptionPassword?(password: string): void;
 }
 
 export type ForegroundServiceStartFailure = {

--- a/src/app/features/android/store/android-sync-bridge.effects.spec.ts
+++ b/src/app/features/android/store/android-sync-bridge.effects.spec.ts
@@ -21,9 +21,10 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
   const superSyncCfg = (
     accessToken: string,
     baseUrl?: string,
+    encryptKey?: string,
   ): CurrentProviderPrivateCfg => ({
     providerId: SyncProviderId.SuperSync,
-    privateCfg: { accessToken, baseUrl } as SuperSyncPrivateCfg,
+    privateCfg: { accessToken, baseUrl, encryptKey } as SuperSyncPrivateCfg,
   });
 
   const dropboxCfg = (): CurrentProviderPrivateCfg => ({
@@ -68,6 +69,24 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
       ).toBe(true);
     });
 
+    it('should detect encryption key change within SuperSync', () => {
+      expect(
+        credentialConfigEqual(
+          superSyncCfg('token1', 'https://a.com', 'old-pass'),
+          superSyncCfg('token1', 'https://a.com', 'new-pass'),
+        ),
+      ).toBe(false);
+    });
+
+    it('should treat same encryption key as equal', () => {
+      expect(
+        credentialConfigEqual(
+          superSyncCfg('token1', 'https://a.com', 'pass'),
+          superSyncCfg('token1', 'https://a.com', 'pass'),
+        ),
+      ).toBe(true);
+    });
+
     it('should treat all non-SuperSync emissions as equal to prevent repeated clears', () => {
       expect(credentialConfigEqual(dropboxCfg(), dropboxCfg())).toBe(true);
     });
@@ -87,6 +106,20 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
         type: 'set',
         baseUrl: 'https://sync.example.com',
         accessToken: 'my-token',
+        encryptionPassword: '',
+      });
+    });
+
+    it('should include the encryption password when configured', () => {
+      expect(
+        getSuperSyncCredentialBridgeCommand(
+          superSyncCfg('my-token', 'https://sync.example.com', 'my-e2ee-pass'),
+        ),
+      ).toEqual({
+        type: 'set',
+        baseUrl: 'https://sync.example.com',
+        accessToken: 'my-token',
+        encryptionPassword: 'my-e2ee-pass',
       });
     });
 

--- a/src/app/features/android/store/android-sync-bridge.effects.spec.ts
+++ b/src/app/features/android/store/android-sync-bridge.effects.spec.ts
@@ -1,21 +1,22 @@
 import { BehaviorSubject } from 'rxjs';
-import { distinctUntilChanged, filter } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { SyncProviderId } from '../../../op-log/sync-providers/provider.const';
 import { CurrentProviderPrivateCfg } from '../../../op-log/core/types/sync.types';
 import type { SuperSyncPrivateCfg } from '@sp/sync-providers/super-sync';
 import type { DropboxPrivateCfg } from '@sp/sync-providers/dropbox';
 import type { WebdavPrivateCfg } from '@sp/sync-providers/webdav';
 import {
-  credentialConfigEqual,
+  bridgeCommandEqual,
   getSuperSyncCredentialBridgeCommand,
+  SuperSyncCredentialBridgeCommand,
 } from './android-sync-bridge.effects';
 
 /**
  * Tests for AndroidSyncBridgeEffects credential mirroring logic.
  *
  * Since the actual effect is gated by IS_ANDROID_WEB_VIEW (false in tests),
- * we test the core logic directly: distinctUntilChanged comparator behavior
- * and the credential set/clear decision logic.
+ * we test the core logic directly: the credential set/clear decision logic
+ * and the command-level dedup used by distinctUntilChanged.
  */
 describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
   const superSyncCfg = (
@@ -32,67 +33,82 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
     privateCfg: { accessToken: 'dropbox-token' } as DropboxPrivateCfg,
   });
 
-  describe('distinctUntilChanged comparator', () => {
+  const webdavCfg = (): CurrentProviderPrivateCfg => ({
+    providerId: SyncProviderId.WebDAV,
+    privateCfg: {} as WebdavPrivateCfg,
+  });
+
+  // Comparator input as the effect produces it: cfg mapped to a command
+  const cmd = (
+    cfg: CurrentProviderPrivateCfg | null,
+  ): SuperSyncCredentialBridgeCommand | null =>
+    cfg ? getSuperSyncCredentialBridgeCommand(cfg) : null;
+
+  describe('distinctUntilChanged comparator (bridgeCommandEqual)', () => {
     it('should detect provider change from null to SuperSync', () => {
-      expect(credentialConfigEqual(null, superSyncCfg('token1'))).toBe(false);
+      expect(bridgeCommandEqual(null, cmd(superSyncCfg('token1')))).toBe(false);
     });
 
     it('should detect provider change from SuperSync to Dropbox', () => {
-      expect(credentialConfigEqual(superSyncCfg('token1'), dropboxCfg())).toBe(false);
-    });
-
-    it('should detect provider change from Dropbox to SuperSync', () => {
-      expect(credentialConfigEqual(dropboxCfg(), superSyncCfg('token1'))).toBe(false);
-    });
-
-    it('should detect access token change within SuperSync', () => {
-      expect(credentialConfigEqual(superSyncCfg('token1'), superSyncCfg('token2'))).toBe(
+      expect(bridgeCommandEqual(cmd(superSyncCfg('token1')), cmd(dropboxCfg()))).toBe(
         false,
       );
     });
 
+    it('should detect access token change within SuperSync', () => {
+      expect(
+        bridgeCommandEqual(cmd(superSyncCfg('token1')), cmd(superSyncCfg('token2'))),
+      ).toBe(false);
+    });
+
     it('should detect baseUrl change within SuperSync', () => {
       expect(
-        credentialConfigEqual(
-          superSyncCfg('token1', 'https://a.com'),
-          superSyncCfg('token1', 'https://b.com'),
+        bridgeCommandEqual(
+          cmd(superSyncCfg('token1', 'https://a.com')),
+          cmd(superSyncCfg('token1', 'https://b.com')),
         ),
       ).toBe(false);
     });
 
     it('should treat same SuperSync credentials as equal', () => {
       expect(
-        credentialConfigEqual(
-          superSyncCfg('token1', 'https://a.com'),
-          superSyncCfg('token1', 'https://a.com'),
+        bridgeCommandEqual(
+          cmd(superSyncCfg('token1', 'https://a.com')),
+          cmd(superSyncCfg('token1', 'https://a.com')),
         ),
       ).toBe(true);
     });
 
     it('should detect encryption key change within SuperSync', () => {
       expect(
-        credentialConfigEqual(
-          superSyncCfg('token1', 'https://a.com', 'old-pass'),
-          superSyncCfg('token1', 'https://a.com', 'new-pass'),
+        bridgeCommandEqual(
+          cmd(superSyncCfg('token1', 'https://a.com', 'old-pass')),
+          cmd(superSyncCfg('token1', 'https://a.com', 'new-pass')),
         ),
       ).toBe(false);
     });
 
     it('should treat same encryption key as equal', () => {
       expect(
-        credentialConfigEqual(
-          superSyncCfg('token1', 'https://a.com', 'pass'),
-          superSyncCfg('token1', 'https://a.com', 'pass'),
+        bridgeCommandEqual(
+          cmd(superSyncCfg('token1', 'https://a.com', 'pass')),
+          cmd(superSyncCfg('token1', 'https://a.com', 'pass')),
         ),
       ).toBe(true);
     });
 
     it('should treat all non-SuperSync emissions as equal to prevent repeated clears', () => {
-      expect(credentialConfigEqual(dropboxCfg(), dropboxCfg())).toBe(true);
+      expect(bridgeCommandEqual(cmd(dropboxCfg()), cmd(dropboxCfg()))).toBe(true);
+      // Even across different non-SuperSync providers — same clear command
+      expect(bridgeCommandEqual(cmd(dropboxCfg()), cmd(webdavCfg()))).toBe(true);
+    });
+
+    it('should distinguish the two clear reasons', () => {
+      expect(bridgeCommandEqual(cmd(superSyncCfg('')), cmd(dropboxCfg()))).toBe(false);
     });
 
     it('should treat two nulls as equal', () => {
-      expect(credentialConfigEqual(null, null)).toBe(true);
+      expect(bridgeCommandEqual(null, null)).toBe(true);
     });
   });
 
@@ -138,11 +154,7 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
     });
 
     it('should clear when provider is WebDAV', () => {
-      const webdavCfg: CurrentProviderPrivateCfg = {
-        providerId: SyncProviderId.WebDAV,
-        privateCfg: {} as WebdavPrivateCfg,
-      };
-      expect(getSuperSyncCredentialBridgeCommand(webdavCfg)).toEqual({
+      expect(getSuperSyncCredentialBridgeCommand(webdavCfg())).toEqual({
         type: 'clear',
         reason: 'not-supersync',
       });
@@ -161,14 +173,15 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
   });
 
   describe('integration: observable filtering', () => {
-    it('should only emit on meaningful changes through distinctUntilChanged + filter', () => {
+    it('should only emit on meaningful changes through map + distinctUntilChanged + filter', () => {
       const source$ = new BehaviorSubject<CurrentProviderPrivateCfg | null>(null);
-      const emissions: (CurrentProviderPrivateCfg | null)[] = [];
+      const emissions: SuperSyncCredentialBridgeCommand[] = [];
 
       const sub = source$
         .pipe(
-          distinctUntilChanged(credentialConfigEqual),
-          filter((val): val is CurrentProviderPrivateCfg => val !== null),
+          map(cmd),
+          distinctUntilChanged(bridgeCommandEqual),
+          filter((val): val is SuperSyncCredentialBridgeCommand => val !== null),
         )
         .subscribe((val) => {
           emissions.push(val);
@@ -180,6 +193,7 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
       // Set SuperSync
       source$.next(superSyncCfg('token1'));
       expect(emissions.length).toBe(1);
+      expect(emissions[0].type).toBe('set');
 
       // Same SuperSync credentials — deduplicated
       source$.next(superSyncCfg('token1'));
@@ -189,12 +203,14 @@ describe('AndroidSyncBridgeEffects - credential mirroring logic', () => {
       source$.next(superSyncCfg('token2'));
       expect(emissions.length).toBe(2);
 
-      // Switch to Dropbox — emits once
+      // Switch to Dropbox — emits one clear
       source$.next(dropboxCfg());
       expect(emissions.length).toBe(3);
+      expect(emissions[2]).toEqual({ type: 'clear', reason: 'not-supersync' });
 
-      // Dropbox config changes — deduplicated (all non-SuperSync treated equal)
+      // Switching among non-SuperSync providers — deduplicated (same clear command)
       source$.next(dropboxCfg());
+      source$.next(webdavCfg());
       expect(emissions.length).toBe(3);
 
       // Switch back to SuperSync — emits

--- a/src/app/features/android/store/android-sync-bridge.effects.ts
+++ b/src/app/features/android/store/android-sync-bridge.effects.ts
@@ -19,7 +19,7 @@ import { CurrentProviderPrivateCfg } from '../../../op-log/core/types/sync.types
  * Returns true (equal) when emissions should be suppressed:
  * - Provider ID changed → false (always emit)
  * - Both non-SuperSync → true (suppress, prevents repeated clearSuperSyncCredentials calls)
- * - Both SuperSync → compare accessToken and baseUrl
+ * - Both SuperSync → compare accessToken, baseUrl and encryptKey
  */
 export const credentialConfigEqual = (
   a: CurrentProviderPrivateCfg | null,
@@ -29,7 +29,11 @@ export const credentialConfigEqual = (
   if (a?.providerId !== SyncProviderId.SuperSync) return true;
   const aCfg = a?.privateCfg as SuperSyncPrivateCfg | undefined;
   const bCfg = b?.privateCfg as SuperSyncPrivateCfg | undefined;
-  return aCfg?.accessToken === bCfg?.accessToken && aCfg?.baseUrl === bCfg?.baseUrl;
+  return (
+    aCfg?.accessToken === bCfg?.accessToken &&
+    aCfg?.baseUrl === bCfg?.baseUrl &&
+    aCfg?.encryptKey === bCfg?.encryptKey
+  );
 };
 
 const isNonNull = (
@@ -41,6 +45,8 @@ export type SuperSyncCredentialBridgeCommand =
       type: 'set';
       baseUrl: string;
       accessToken: string;
+      /** E2EE password for decrypting op payloads natively; '' clears it */
+      encryptionPassword: string;
     }
   | {
       type: 'clear';
@@ -57,6 +63,7 @@ export const getSuperSyncCredentialBridgeCommand = (
         type: 'set',
         baseUrl: privateCfg.baseUrl || SUPER_SYNC_DEFAULT_BASE_URL,
         accessToken: privateCfg.accessToken,
+        encryptionPassword: privateCfg.encryptKey || '',
       };
     }
     return { type: 'clear', reason: 'no-token' };
@@ -88,6 +95,11 @@ export class AndroidSyncBridgeEffects {
               androidInterface.setSuperSyncCredentials?.(
                 command.baseUrl,
                 command.accessToken,
+              );
+              // Optional chaining: old APKs don't have this method yet.
+              // The password itself must never be logged.
+              androidInterface.setSuperSyncEncryptionPassword?.(
+                command.encryptionPassword,
               );
             } else if (command.reason === 'no-token') {
               DroidLog.log(

--- a/src/app/features/android/store/android-sync-bridge.effects.ts
+++ b/src/app/features/android/store/android-sync-bridge.effects.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { createEffect } from '@ngrx/effects';
-import { distinctUntilChanged, filter, tap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
 import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
 import { androidInterface } from '../android-interface';
 import { SyncProviderManager } from '../../../op-log/sync-providers/provider-manager.service';
@@ -12,33 +12,9 @@ import {
 import { skipWhileApplyingRemoteOps } from '../../../util/skip-during-sync.operator';
 import { DroidLog } from '../../../core/log';
 import { CurrentProviderPrivateCfg } from '../../../op-log/core/types/sync.types';
+import { isShallowEqual } from '../../../util/is-shallow-equal';
 
-/**
- * Compares two provider configs for credential-relevant equality.
- *
- * Returns true (equal) when emissions should be suppressed:
- * - Provider ID changed → false (always emit)
- * - Both non-SuperSync → true (suppress, prevents repeated clearSuperSyncCredentials calls)
- * - Both SuperSync → compare accessToken, baseUrl and encryptKey
- */
-export const credentialConfigEqual = (
-  a: CurrentProviderPrivateCfg | null,
-  b: CurrentProviderPrivateCfg | null,
-): boolean => {
-  if (a?.providerId !== b?.providerId) return false;
-  if (a?.providerId !== SyncProviderId.SuperSync) return true;
-  const aCfg = a?.privateCfg as SuperSyncPrivateCfg | undefined;
-  const bCfg = b?.privateCfg as SuperSyncPrivateCfg | undefined;
-  return (
-    aCfg?.accessToken === bCfg?.accessToken &&
-    aCfg?.baseUrl === bCfg?.baseUrl &&
-    aCfg?.encryptKey === bCfg?.encryptKey
-  );
-};
-
-const isNonNull = (
-  cfg: CurrentProviderPrivateCfg | null,
-): cfg is CurrentProviderPrivateCfg => cfg !== null;
+const isNonNull = <T>(value: T | null): value is T => value !== null;
 
 export type SuperSyncCredentialBridgeCommand =
   | {
@@ -72,6 +48,16 @@ export const getSuperSyncCredentialBridgeCommand = (
 };
 
 /**
+ * Two commands are equal when replaying the second would be a no-op on the
+ * native side — comparing commands (not configs) means credential-irrelevant
+ * config changes and repeated clears are suppressed automatically.
+ */
+export const bridgeCommandEqual = (
+  a: SuperSyncCredentialBridgeCommand | null,
+  b: SuperSyncCredentialBridgeCommand | null,
+): boolean => (a === null || b === null ? a === b : isShallowEqual(a, b));
+
+/**
  * Mirrors SuperSync credentials to native SharedPreferences so the
  * background SyncReminderWorker can authenticate against the server
  * without needing the WebView.
@@ -86,10 +72,10 @@ export class AndroidSyncBridgeEffects {
       () =>
         this._providerManager.currentProviderPrivateCfg$.pipe(
           skipWhileApplyingRemoteOps(),
-          distinctUntilChanged(credentialConfigEqual),
+          map((cfg) => (cfg ? getSuperSyncCredentialBridgeCommand(cfg) : null)),
+          distinctUntilChanged(bridgeCommandEqual),
           filter(isNonNull),
-          tap((cfg) => {
-            const command = getSuperSyncCredentialBridgeCommand(cfg);
+          tap((command) => {
             if (command.type === 'set') {
               DroidLog.log('AndroidSyncBridgeEffects: Setting SuperSync credentials');
               androidInterface.setSuperSyncCredentials?.(

--- a/tools/generate-android-crypto-fixtures.mjs
+++ b/tools/generate-android-crypto-fixtures.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Generates live encryption fixtures for the Android crypto unit tests.
+ *
+ * The Android background sync re-implements Argon2id + AES-GCM op-payload
+ * decryption in Kotlin (android .../crypto/OpPayloadDecryptor.kt). Its tests
+ * pin frozen ciphertexts, which only prove compatibility with sync-core as of
+ * the day they were generated. This script encrypts fresh fixtures with the
+ * REAL sync-core encrypt() so CI fails on the PR that changes the KDF
+ * parameters or wire format, instead of background reminders silently
+ * degrading (consumed by LiveJsEncryptRoundTripTest.kt).
+ *
+ * Usage: node tools/generate-android-crypto-fixtures.mjs [outFile]
+ * Requires packages/sync-core to be built (happens on `npm i` via prepare).
+ *
+ * Output is TSV with base64-wrapped fields so the Kotlin side needs no JSON
+ * parser and no quoting rules:
+ *   password\t<base64 utf-8 password>
+ *   entry\t<name>\t<base64 utf-8 plaintext>\t<ciphertext, already base64>
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { clearSessionKeyCache, encrypt } from '../packages/sync-core/dist/index.mjs';
+
+// Non-ASCII on purpose: proves both sides encode the password as UTF-8
+const PASSWORD = 'live-fixture-pässword-🔑';
+
+const ENTRIES = [
+  [
+    'crt-op',
+    '{"actionPayload":{},"entityChanges":[{"entityType":"TASK",' +
+      '"entityId":"task-crt-1","opType":"CRT","changes":{' +
+      '"id":"task-crt-1","title":"Water plants",' +
+      '"remindAt":4102444500000,"deadlineRemindAt":4102444700000}}]}',
+  ],
+  [
+    'unicode-payload',
+    '{"actionPayload":{"task":{"id":"t1","title":"Müsli 🥣 買い物"},' +
+      '"remindAt":4102444200000},"entityChanges":[]}',
+  ],
+  [
+    'large-payload',
+    `{"actionPayload":{"task":{"id":"t2","notes":"${'lorem ipsum '.repeat(700)}"}},"entityChanges":[]}`,
+  ],
+];
+
+const outFile = resolve(process.argv[2] ?? 'android/app/build/live-crypto-fixtures.tsv');
+const b64 = (s) => Buffer.from(s, 'utf8').toString('base64');
+
+const lines = [`password\t${b64(PASSWORD)}`];
+for (const [name, plaintext] of ENTRIES) {
+  // Fresh session salt per entry — mirrors ops arriving from different devices
+  clearSessionKeyCache();
+  lines.push(`entry\t${name}\t${b64(plaintext)}\t${await encrypt(plaintext, PASSWORD)}`);
+}
+
+await mkdir(dirname(outFile), { recursive: true });
+await writeFile(outFile, lines.join('\n') + '\n');
+console.log(`Wrote ${ENTRIES.length} live crypto fixtures to ${outFile}`);


### PR DESCRIPTION
Fixes #9663

## Problem

Since E2EE became mandatory for SuperSync (#8670), op payloads arrive as encrypted base64 strings. The Android background sync worker still parsed them as plaintext JSON, found no reminders, and silently advanced its cursor — so reminders scheduled on another device within the background-poll window never fired (e.g. a task started two hours before its due date).

## Fix

- **In-repo pure-Kotlin crypto**: BLAKE2b (RFC 7693) + Argon2id (RFC 9106, matching hash-wasm's p=1/t=3/m=64MiB parameters) + AES-GCM `OpPayloadDecryptor`, reading the same `SALT(16)|IV(12)|GCM` wire format as `sync-core`'s `encrypt()`. No new dependencies.
- **Password mirroring**: the web app mirrors the E2EE password to native storage via a new JS bridge method (`''` clears; optional chaining for old-APK skew). Derived keys are cached per salt in `EncryptedSharedPreferences`; any password change drops the cache.
- **Graceful degradation**: without a password (or on wrong password / format drift) the worker falls back to envelope-only mode — cancels still work, nothing is misapplied, and the op-log itself is untouched (this path only schedules/cancels notifications; it never writes sync state).
- The boot receiver uses cache-only key resolution (no 64MiB KDF inside its ~10s `goAsync` window).

## Tests

- Reproduction test written first (failed against the old plaintext-only parser); fixtures are real ciphertexts produced by the actual JS `encrypt()` with distinct session salts.
- Argon2id verified against the official RFC 9106 vector plus hash-wasm vectors including the exact production parameters; BLAKE2b against RFC 7693 + hash-wasm.
- **Live drift detection in CI**: `tools/generate-android-crypto-fixtures.mjs` encrypts fresh fixtures with the real `sync-core` build on every Android CI run and `LiveJsEncryptRoundTripTest` decrypts them — a KDF/wire-format change now fails the PR that introduces it instead of silently degrading background reminders. The workflow also triggers on `packages/sync-core/` changes now (previously the drift scenario skipped Android tests entirely), and the fixture file is a declared test-task input so a warm Gradle cache can't skip the check (verified with a corrupted fixture).
- 103 Android JVM tests, 17 effects spec tests, full web suite green.

## Sync-risk notes

Read-only with respect to sync state: worst case on any failure is a missed background notification (the pre-fix status quo), not data loss. One intentional behavior delta from the simplify pass: switching between two non-SuperSync providers no longer re-sends an identical clear command to the native side.

Still outstanding: an on-device smoke test (Keystore/WorkManager/Doze are only covered via JVM-test seams).