### PR TITLE
fix(sync): sweep old ops for users with snapshots older than retention

### DIFF
--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
     "pretest": "prisma generate",
     "test": "vitest run",
-    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/batch-conflict-plan.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/repair-causality.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts tests/integration/migrate-deploy-lock-retry.integration.spec.ts",
+    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/batch-conflict-plan.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/repair-causality.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts tests/integration/migrate-deploy-lock-retry.integration.spec.ts tests/integration/old-ops-sweep.integration.spec.ts",
     "docker:build": "./scripts/build-and-push.sh",
     "docker:deploy": "./scripts/deploy.sh",
     "docker:deploy:build": "./scripts/deploy.sh --build",
@@ -31,7 +31,9 @@
     "monitor:all:quick": "node dist/scripts/run-all-monitoring.js --quick",
     "monitor:all:save": "node dist/scripts/run-all-monitoring.js --save",
     "migrate-payload-bytes": "node dist/scripts/migrate-payload-bytes.js",
-    "migrate-payload-bytes:dev": "ts-node scripts/migrate-payload-bytes.ts"
+    "migrate-payload-bytes:dev": "ts-node scripts/migrate-payload-bytes.ts",
+    "dry-run-old-ops-sweep": "node dist/scripts/dry-run-old-ops-sweep.js",
+    "dry-run-old-ops-sweep:dev": "tsx scripts/dry-run-old-ops-sweep.ts"
   },
   "dependencies": {
     "@fastify/cors": "^11.1.0",

--- a/packages/super-sync-server/scripts/dry-run-old-ops-sweep.ts
+++ b/packages/super-sync-server/scripts/dry-run-old-ops-sweep.ts
@@ -1,0 +1,279 @@
+#!/usr/bin/env tsx
+/**
+ * Read-only dry run of the daily old-ops sweep
+ * (`StorageQuotaService.deleteOldSyncedOpsForAllUsers`).
+ *
+ * Mirrors the production deletion logic in set-based SQL and reports, without
+ * writing anything, exactly what the next sweep would delete on THIS database:
+ *   - per-user prune boundary (validated-causal marker, or causal fallback)
+ *   - would-delete counts and the retained base + tail
+ *   - safety checks that must come back clean before trusting the sweep
+ *   - the cohorts the sweep deliberately skips (no causal base, no snapshot)
+ *
+ * Run on the server host (uses DATABASE_URL like the monitoring scripts):
+ *   npm run dry-run-old-ops-sweep:dev
+ * Large tables may need a longer statement budget:
+ *   MONITOR_STATEMENT_TIMEOUT_MS=1800000 npm run dry-run-old-ops-sweep:dev
+ *
+ * Exits non-zero when a safety check fails — in that case do NOT trust the
+ * sweep on this database before understanding why.
+ */
+import { Prisma } from '@prisma/client';
+import { prisma, disconnectDb, reportMonitoringError } from './monitoring-db';
+import { RETENTION_MS } from '../src/sync/sync.types';
+
+const TOP_N = 25;
+const DEFAULT_DAILY_BUDGET = 25_000;
+const VERIFY_CHUNK = 1000;
+
+// Must stay in lockstep with CAUSAL_FULL_STATE_OPERATION_WHERE
+// (src/sync/sync.types.ts) — the predicate that authorizes deletion.
+const causalFullStateSql = (alias: string): Prisma.Sql =>
+  Prisma.raw(`(
+    ${alias}.op_type IN ('SYNC_IMPORT', 'BACKUP_IMPORT')
+    OR (${alias}.op_type = 'REPAIR' AND ${alias}.repair_base_server_seq IS NOT NULL)
+  )`);
+
+interface PerUserRow {
+  user_id: number;
+  last_snapshot_seq: number;
+  protected_from_seq: number | null;
+  used_fallback: boolean;
+  would_delete: bigint;
+  fresh_prefix: bigint;
+  retained_from_boundary: bigint;
+}
+
+interface CohortRow {
+  user_id: number;
+  op_count: bigint;
+}
+
+const n = (v: bigint | number): number => Number(v);
+
+/**
+ * Independent re-verification: for each (userId, boundarySeq) pair, the
+ * boundary must be a surviving causal full-state op. Deliberately NOT derived
+ * from the main CTE — a translation bug there cannot hide here.
+ */
+const findBadBoundaries = async (
+  pairs: { userId: number; seq: number }[],
+): Promise<number[]> => {
+  const bad: number[] = [];
+  for (let i = 0; i < pairs.length; i += VERIFY_CHUNK) {
+    const chunk = pairs.slice(i, i + VERIFY_CHUNK);
+    const values = Prisma.join(
+      chunk.map((p) => Prisma.sql`(${p.userId}::int, ${p.seq}::int)`),
+    );
+    const rows = await prisma.$queryRaw<{ user_id: number }[]>`
+      SELECT b.user_id
+      FROM (VALUES ${values}) AS b(user_id, seq)
+      WHERE NOT EXISTS (
+        SELECT 1 FROM operations o
+        WHERE o.user_id = b.user_id
+          AND o.server_seq = b.seq
+          AND ${causalFullStateSql('o')}
+      )
+    `;
+    bad.push(...rows.map((r) => r.user_id));
+  }
+  return bad;
+};
+
+const main = async (): Promise<void> => {
+  const cutoff = BigInt(Date.now() - RETENTION_MS);
+
+  // Per-user view of what the sweep would do. Boundary resolution mirrors
+  // production: the latestFullStateSeq marker counts only when it is <=
+  // lastSnapshotSeq AND its op row matches the causal predicate; otherwise
+  // fall back to the newest causal full-state op <= lastSnapshotSeq.
+  const perUser = await prisma.$queryRaw<PerUserRow[]>`
+    WITH eligible AS (
+      SELECT s.user_id, s.last_snapshot_seq, s.latest_full_state_seq
+      FROM user_sync_state s
+      WHERE s.last_snapshot_seq IS NOT NULL
+        AND s.last_snapshot_seq > 0
+        AND s.snapshot_at IS NOT NULL
+    ),
+    marked AS (
+      SELECT
+        e.user_id,
+        e.last_snapshot_seq,
+        CASE
+          WHEN e.latest_full_state_seq IS NOT NULL
+            AND e.latest_full_state_seq <= e.last_snapshot_seq
+            AND EXISTS (
+              SELECT 1 FROM operations o
+              WHERE o.user_id = e.user_id
+                AND o.server_seq = e.latest_full_state_seq
+                AND ${causalFullStateSql('o')}
+            )
+          THEN e.latest_full_state_seq
+        END AS marker_seq
+      FROM eligible e
+    ),
+    resolved AS (
+      SELECT
+        m.user_id,
+        m.last_snapshot_seq,
+        m.marker_seq IS NULL AS used_fallback,
+        COALESCE(
+          m.marker_seq,
+          (
+            SELECT max(o.server_seq) FROM operations o
+            WHERE o.user_id = m.user_id
+              AND o.server_seq <= m.last_snapshot_seq
+              AND ${causalFullStateSql('o')}
+          )
+        ) AS protected_from_seq
+      FROM marked m
+    )
+    SELECT
+      r.user_id,
+      r.last_snapshot_seq,
+      r.protected_from_seq,
+      r.used_fallback,
+      (
+        SELECT count(*) FROM operations o
+        WHERE o.user_id = r.user_id
+          AND o.server_seq < r.protected_from_seq
+          AND o.received_at < ${cutoff}
+      ) AS would_delete,
+      (
+        SELECT count(*) FROM operations o
+        WHERE o.user_id = r.user_id
+          AND o.server_seq < r.protected_from_seq
+          AND o.received_at >= ${cutoff}
+      ) AS fresh_prefix,
+      (
+        SELECT count(*) FROM operations o
+        WHERE o.user_id = r.user_id
+          AND o.server_seq >= r.protected_from_seq
+      ) AS retained_from_boundary
+    FROM resolved r
+  `;
+
+  const withBoundary = perUser.filter(
+    (r) => r.protected_from_seq !== null && r.protected_from_seq > 1,
+  );
+  const skippedNoBase = perUser.filter((r) => r.protected_from_seq === null);
+  const staleMarkers = perUser.filter(
+    (r) => r.used_fallback && r.protected_from_seq !== null,
+  );
+  const totalWouldDelete = withBoundary.reduce((sum, r) => sum + n(r.would_delete), 0);
+
+  // Safety check 1: boundary must be a surviving causal full-state op —
+  // re-verified independently for every user the sweep would actually touch.
+  const affected = withBoundary.filter((r) => n(r.would_delete) > 0);
+  const badBoundaryUsers = await findBadBoundaries(
+    affected.map((r) => ({
+      userId: r.user_id,
+      // non-null: withBoundary filtered on it
+      seq: r.protected_from_seq as number,
+    })),
+  );
+
+  // Safety check 2: the boundary may never exceed lastSnapshotSeq, or pruning
+  // would eat into the cached snapshot's replay tail (the restore path).
+  const tailViolations = withBoundary.filter(
+    (r) => (r.protected_from_seq as number) > r.last_snapshot_seq,
+  );
+
+  // Cohort: users the sweep never reaches because they hold no snapshot.
+  const snapshotless = await prisma.$queryRaw<CohortRow[]>`
+    SELECT o.user_id, count(*) AS op_count
+    FROM operations o
+    LEFT JOIN user_sync_state s ON s.user_id = o.user_id
+    WHERE s.user_id IS NULL
+       OR s.last_snapshot_seq IS NULL
+       OR s.last_snapshot_seq <= 0
+       OR s.snapshot_at IS NULL
+    GROUP BY o.user_id
+    ORDER BY count(*) DESC
+  `;
+  const snapshotlessOps = snapshotless.reduce((sum, r) => sum + n(r.op_count), 0);
+
+  const [{ total_ops }] = await prisma.$queryRaw<[{ total_ops: bigint }]>`
+    SELECT count(*) AS total_ops FROM operations
+  `;
+
+  console.log('=== Old-ops sweep dry run (read-only) ===');
+  console.log(`cutoff: received_at < ${new Date(Number(cutoff)).toISOString()}`);
+  console.log(`operations table total:        ${n(total_ops)}`);
+  console.log(`eligible users (snapshot > 0): ${perUser.length}`);
+  console.log(`  with a causal prune boundary: ${withBoundary.length}`);
+  console.log(`  via stale-marker fallback:    ${staleMarkers.length}`);
+  console.log(`  skipped (no causal base):     ${skippedNoBase.length}`);
+  console.log(`total rows the sweep would delete: ${totalWouldDelete}`);
+  console.log(
+    `  ≈ ${Math.ceil(totalWouldDelete / DEFAULT_DAILY_BUDGET)} daily runs at the ` +
+      `default ${DEFAULT_DAILY_BUDGET}/run budget (OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN)`,
+  );
+
+  const top = [...affected]
+    .sort((a, b) => n(b.would_delete) - n(a.would_delete))
+    .slice(0, TOP_N)
+    .map((r) => ({
+      user_id: r.user_id,
+      boundary_seq: r.protected_from_seq,
+      would_delete: n(r.would_delete),
+      fresh_prefix_kept: n(r.fresh_prefix),
+      base_plus_tail_kept: n(r.retained_from_boundary),
+      via: r.used_fallback ? 'fallback' : 'marker',
+    }));
+  console.log(`\nTop ${top.length} users by would-delete:`);
+  console.table(top);
+
+  if (skippedNoBase.length > 0) {
+    console.log(
+      `\nSkipped without causal base (histories left intact): ` +
+        skippedNoBase
+          .slice(0, TOP_N)
+          .map((r) => r.user_id)
+          .join(', ') +
+        (skippedNoBase.length > TOP_N ? ', …' : ''),
+    );
+  }
+
+  console.log(
+    `\nUnswept snapshotless cohort: ${snapshotless.length} users holding ` +
+      `${snapshotlessOps} ops (out of the sweep's scope entirely). Top ${TOP_N}:`,
+  );
+  console.table(
+    snapshotless.slice(0, TOP_N).map((r) => ({
+      user_id: r.user_id,
+      op_count: n(r.op_count),
+    })),
+  );
+
+  console.log('\n=== Safety checks ===');
+  console.log(
+    `boundary is a surviving causal full-state op: ` +
+      (badBoundaryUsers.length === 0
+        ? 'OK'
+        : `VIOLATED for users ${badBoundaryUsers.join(', ')}`),
+  );
+  console.log(
+    `boundary <= lastSnapshotSeq (cached-snapshot tail protected): ` +
+      (tailViolations.length === 0
+        ? 'OK'
+        : `VIOLATED for users ${tailViolations.map((r) => r.user_id).join(', ')}`),
+  );
+
+  if (badBoundaryUsers.length + tailViolations.length > 0) {
+    console.error(
+      `\nSafety check(s) failed — do not trust the sweep on this database ` +
+        `before understanding why.`,
+    );
+    process.exitCode = 1;
+  } else {
+    console.log('\nAll safety checks passed.');
+  }
+};
+
+main()
+  .catch((err) => {
+    reportMonitoringError('Dry run failed:', err);
+    process.exitCode = 1;
+  })
+  .finally(() => disconnectDb());

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -424,7 +424,6 @@ export class StorageQuotaService {
       select: {
         userId: true,
         lastSnapshotSeq: true,
-        snapshotAt: true,
         latestFullStateSeq: true,
       },
       orderBy: { snapshotAt: 'asc' },

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -439,14 +439,20 @@ export class StorageQuotaService {
     for (const state of states) {
       if (remainingDeleteBudget <= 0) break;
 
-      const snapshotAt = Number(state.snapshotAt);
       const lastSnapshotSeq = state.lastSnapshotSeq ?? 0;
 
       // The cached snapshot is only exposed by restore endpoints; normal sync
       // clients still bootstrap from the operation log. Therefore cleanup may
       // only remove the superseded prefix before the newest full-state op and
       // must keep that op plus its complete replay tail.
-      if (!(snapshotAt >= cutoffTime && lastSnapshotSeq > 0)) continue;
+      //
+      // Snapshot AGE is deliberately not a gate. An earlier `snapshotAt >=
+      // cutoffTime` check skipped exactly the long-lapsed cohort — inverted
+      // against deleteStaleDevices, which prunes those users' device rows
+      // unconditionally — so lapsed accounts accumulated operations forever.
+      // Safety comes from protectedFromSeq (validated causal full-state op,
+      // ≤ lastSnapshotSeq), not from snapshot recency.
+      if (lastSnapshotSeq <= 0) continue;
       let protectedFromSeq =
         typeof state.latestFullStateSeq === 'number' &&
         state.latestFullStateSeq <= lastSnapshotSeq

--- a/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * Real-PostgreSQL coverage for the daily old-ops sweep
+ * (`deleteOldSyncedOpsForAllUsers`).
+ *
+ * Unit tests exercise the sweep through an in-memory Prisma mock; this suite
+ * pins the actual SQL the sweep issues, on real rows:
+ *   - a lapsed user (snapshot older than the retention cutoff) gets the
+ *     superseded prefix pruned while the causal full-state base + replay tail
+ *     survive (regression for the inverted snapshotAt >= cutoff gate),
+ *   - a snapshotless user is never touched,
+ *   - a user whose only full-state op is a legacy REPAIR (no causal base
+ *     cursor) is skipped entirely.
+ *
+ * Run with:
+ *   DATABASE_URL=postgresql://supersync:superpassword@localhost:55432/supersync_db \
+ *     npx vitest run --config vitest.integration.config.ts \
+ *     tests/integration/old-ops-sweep.integration.spec.ts
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { prisma } from '../../src/db';
+import { SyncService } from '../../src/sync/sync.service';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const LAPSED_USER_ID = 99981;
+const SNAPSHOTLESS_USER_ID = 99982;
+const LEGACY_REPAIR_USER_ID = 99983;
+const ALL_USER_IDS = [LAPSED_USER_ID, SNAPSHOTLESS_USER_ID, LEGACY_REPAIR_USER_ID];
+
+describeWithDb('Old-ops sweep (PostgreSQL)', () => {
+  const now = Date.now();
+  const cutoffTime = now - 50 * DAY_MS;
+  const oldReceivedAt = BigInt(now - 60 * DAY_MS);
+
+  const seedOp = async (
+    userId: number,
+    serverSeq: number,
+    overrides: {
+      opType?: string;
+      actionType?: string;
+      entityType?: string;
+      entityId?: string | null;
+      payload?: object;
+      repairBaseServerSeq?: number | null;
+    } = {},
+  ): Promise<void> => {
+    await prisma.operation.create({
+      data: {
+        id: `sweep-op-${userId}-${serverSeq}`,
+        userId,
+        clientId: `sweep-client-${userId}`,
+        serverSeq,
+        actionType: overrides.actionType ?? '[Task] Add',
+        opType: overrides.opType ?? 'CRT',
+        entityType: overrides.entityType ?? 'TASK',
+        entityId:
+          overrides.entityId === undefined ? `task-${serverSeq}` : overrides.entityId,
+        payload: overrides.payload ?? { title: 'sweep fixture' },
+        vectorClock: { [`sweep-client-${userId}`]: serverSeq },
+        schemaVersion: 1,
+        clientTimestamp: oldReceivedAt,
+        receivedAt: oldReceivedAt,
+        repairBaseServerSeq: overrides.repairBaseServerSeq ?? null,
+      },
+    });
+  };
+
+  const survivingSeqs = async (userId: number): Promise<number[]> => {
+    const ops = await prisma.operation.findMany({
+      where: { userId },
+      orderBy: { serverSeq: 'asc' },
+      select: { serverSeq: true },
+    });
+    return ops.map((op) => op.serverSeq);
+  };
+
+  beforeAll(async () => {
+    await prisma.user.deleteMany({ where: { id: { in: ALL_USER_IDS } } });
+    for (const id of ALL_USER_IDS) {
+      await prisma.user.create({
+        data: { id, email: `sweep-test-${id}@test.local`, isVerified: 1 },
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({ where: { id: { in: ALL_USER_IDS } } });
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.operation.deleteMany({ where: { userId: { in: ALL_USER_IDS } } });
+    await prisma.userSyncState.deleteMany({
+      where: { userId: { in: ALL_USER_IDS } },
+    });
+  });
+
+  it('prunes a lapsed user to the causal base + tail, leaves the other cohorts intact', async () => {
+    // Lapsed user: snapshot taken 100 days ago (predates the cutoff — the
+    // cohort the removed snapshotAt >= cutoff gate used to skip forever).
+    // Ops 1-3 = superseded prefix, 4 = causal SYNC_IMPORT base, 5 = tail.
+    await seedOp(LAPSED_USER_ID, 1);
+    await seedOp(LAPSED_USER_ID, 2);
+    await seedOp(LAPSED_USER_ID, 3);
+    await seedOp(LAPSED_USER_ID, 4, {
+      opType: 'SYNC_IMPORT',
+      actionType: 'LOAD_ALL_DATA',
+      entityType: 'ALL',
+      entityId: null,
+      payload: { appDataComplete: { TASK: {} } },
+    });
+    await seedOp(LAPSED_USER_ID, 5);
+    await prisma.userSyncState.create({
+      data: {
+        userId: LAPSED_USER_ID,
+        lastSeq: 5,
+        lastSnapshotSeq: 4,
+        snapshotAt: BigInt(now - 100 * DAY_MS),
+        latestFullStateSeq: 4,
+      },
+    });
+
+    // Snapshotless user: outside the sweep's scope, must keep everything.
+    await seedOp(SNAPSHOTLESS_USER_ID, 1);
+    await prisma.userSyncState.create({
+      data: { userId: SNAPSHOTLESS_USER_ID, lastSeq: 1 },
+    });
+
+    // Legacy-REPAIR user: full-state op without a causal base cursor must
+    // never authorize pruning, even with a stale marker pointing at it.
+    await seedOp(LEGACY_REPAIR_USER_ID, 1);
+    await seedOp(LEGACY_REPAIR_USER_ID, 2);
+    await seedOp(LEGACY_REPAIR_USER_ID, 3, {
+      opType: 'REPAIR',
+      actionType: 'LOAD_ALL_DATA',
+      entityType: 'ALL',
+      entityId: null,
+      payload: { appDataComplete: { TASK: {} } },
+      repairBaseServerSeq: null,
+    });
+    await prisma.userSyncState.create({
+      data: {
+        userId: LEGACY_REPAIR_USER_ID,
+        lastSeq: 3,
+        lastSnapshotSeq: 3,
+        snapshotAt: BigInt(now - 100 * DAY_MS),
+        latestFullStateSeq: 3,
+      },
+    });
+
+    const service = new SyncService({});
+    // The sweep runs across ALL users in this database, so assert per-user
+    // outcomes rather than totals other suites' leftovers could inflate.
+    const { affectedUserIds } = await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+
+    expect(await survivingSeqs(LAPSED_USER_ID)).toEqual([4, 5]);
+    expect(affectedUserIds).toContain(LAPSED_USER_ID);
+
+    expect(await survivingSeqs(SNAPSHOTLESS_USER_ID)).toEqual([1]);
+    expect(affectedUserIds).not.toContain(SNAPSHOTLESS_USER_ID);
+
+    expect(await survivingSeqs(LEGACY_REPAIR_USER_ID)).toEqual([1, 2, 3]);
+    expect(affectedUserIds).not.toContain(LEGACY_REPAIR_USER_ID);
+  });
+
+  it('keeps a fresh prefix (inside retention) even below the causal base', async () => {
+    // Ops below the boundary but received inside the retention window must
+    // survive until they age out — deletion requires BOTH seq < boundary
+    // AND receivedAt < cutoff.
+    await seedOp(LAPSED_USER_ID, 1);
+    await prisma.operation.update({
+      where: { id: `sweep-op-${LAPSED_USER_ID}-1` },
+      data: { receivedAt: BigInt(now - 10 * DAY_MS) },
+    });
+    await seedOp(LAPSED_USER_ID, 2, {
+      opType: 'SYNC_IMPORT',
+      actionType: 'LOAD_ALL_DATA',
+      entityType: 'ALL',
+      entityId: null,
+      payload: { appDataComplete: { TASK: {} } },
+    });
+    await prisma.userSyncState.create({
+      data: {
+        userId: LAPSED_USER_ID,
+        lastSeq: 2,
+        lastSnapshotSeq: 2,
+        snapshotAt: BigInt(now - 100 * DAY_MS),
+        latestFullStateSeq: 2,
+      },
+    });
+
+    const service = new SyncService({});
+    await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+
+    expect(await survivingSeqs(LAPSED_USER_ID)).toEqual([1, 2]);
+  });
+});

--- a/packages/super-sync-server/tests/monitoring-sql.pglite.spec.ts
+++ b/packages/super-sync-server/tests/monitoring-sql.pglite.spec.ts
@@ -137,8 +137,9 @@ const LAPSED_LAST_OP_AGO = 40 * ONE_DAY;
 const NEVER_SYNCED_USER = 5; // no device, no ops, no sync state
 // The cohort daily cleanup actually produces: operations with NO sync_devices
 // row. `deleteStaleDevices` prunes every device unseen for RETENTION_DAYS, while
-// `deleteOldSyncedOpsForAllUsers` SKIPS users whose snapshot predates the same
-// cutoff -- so a long-lapsed user keeps its operations and loses its heartbeat.
+// `deleteOldSyncedOpsForAllUsers` keeps each user's newest full-state op plus
+// its replay tail forever -- so a long-lapsed user still holds operations after
+// losing its heartbeat.
 // A fixture without this user cannot detect a window widened past retention,
 // where the device-scoped driver silently stops seeing these accounts.
 const PRUNED_DEVICE_USER = 6;

--- a/packages/super-sync-server/tests/monitoring-sql.pglite.spec.ts
+++ b/packages/super-sync-server/tests/monitoring-sql.pglite.spec.ts
@@ -136,10 +136,11 @@ const LAPSED_LAST_SEEN_AGO = 10 * ONE_DAY;
 const LAPSED_LAST_OP_AGO = 40 * ONE_DAY;
 const NEVER_SYNCED_USER = 5; // no device, no ops, no sync state
 // The cohort daily cleanup actually produces: operations with NO sync_devices
-// row. `deleteStaleDevices` prunes every device unseen for RETENTION_DAYS, while
-// `deleteOldSyncedOpsForAllUsers` keeps each user's newest full-state op plus
-// its replay tail forever -- so a long-lapsed user still holds operations after
-// losing its heartbeat.
+// row. `deleteStaleDevices` prunes every device unseen for RETENTION_DAYS,
+// while the old-ops sweep never empties a user's history: snapshotless users
+// (like this fixture user, seeded with last_seq only) are excluded outright,
+// and swept users keep their newest full-state op plus replay tail -- so a
+// long-lapsed user still holds operations after losing its heartbeat.
 // A fixture without this user cannot detect a window widened past retention,
 // where the device-scoped driver silently stops seeing these accounts.
 const PRUNED_DEVICE_USER = 6;

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -3127,6 +3127,58 @@ describe('SyncService', () => {
       expect(freshClientOps.map((op) => op.serverSeq)).toEqual([4, 5]);
     });
 
+    it('prunes the superseded prefix for a lapsed user whose snapshot predates the cutoff', async () => {
+      // Regression for the inverted retention gate: the sweep used to skip any
+      // user whose snapshotAt was OLDER than the retention cutoff, so exactly
+      // the long-lapsed cohort kept its full operation history forever while
+      // deleteStaleDevices pruned the same users' device rows unconditionally.
+      // Snapshot age buys no safety here — pruning is bounded by the validated
+      // causal full-state op (protectedFromSeq ≤ lastSnapshotSeq), which keeps
+      // the replay base, its tail, and the cached snapshot's tail intact
+      // regardless of when the snapshot was taken.
+      const service = getSyncService();
+      const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
+
+      for (let i = 1; i <= 5; i++) {
+        const isFullState = i === 4;
+        testState.operations.set(`old-op-${i}`, {
+          id: `old-op-${i}`,
+          userId,
+          clientId,
+          serverSeq: i,
+          actionType: isFullState ? 'LOAD_ALL_DATA' : 'ADD',
+          opType: isFullState ? 'SYNC_IMPORT' : 'CRT',
+          entityType: isFullState ? 'ALL' : 'TASK',
+          entityId: isFullState ? null : `t${i}`,
+          entityIds: [],
+          payload: isFullState ? { appDataComplete: { TASK: {} } } : {},
+          vectorClock: {},
+          schemaVersion: 1,
+          clientTimestamp: BigInt(Date.now()),
+          receivedAt: BigInt(cutoffTime - 1),
+          isPayloadEncrypted: false,
+          syncImportReason: null,
+          repairBaseServerSeq: null,
+        });
+      }
+
+      // Snapshot taken 100 days ago — well before the cutoff (lapsed user).
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: 5,
+        lastSnapshotSeq: 4,
+        snapshotAt: BigInt(Date.now() - 100 * 24 * 60 * 60 * 1000),
+        latestFullStateSeq: 4,
+      });
+
+      const { totalDeleted, affectedUserIds } =
+        await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+
+      expect(totalDeleted).toBe(3);
+      expect(affectedUserIds).toContain(userId);
+      expect(Array.from(testState.operations.keys())).toEqual(['old-op-4', 'old-op-5']);
+    });
+
     it('does not prune history behind a stale latestFullStateSeq marker pointing at a legacy REPAIR (primary path)', async () => {
       // Regression for the primary-path gap: installs upgraded from before the
       // causal-marker migration can carry a `latestFullStateSeq` that points at a


### PR DESCRIPTION
## Problem

The daily old-ops sweep (`deleteOldSyncedOpsForAllUsers`) skipped any user whose `snapshotAt` predated the retention cutoff (45 days) — inverted against `deleteStaleDevices`, which prunes the same users' device rows unconditionally. The long-lapsed cohort therefore kept its entire operation history forever: on the hosted instance this produced users with 35k+ retained operations and an 8.44M-row `operations` table. The gap was documented as a side-finding in a47af8b0a7.

## Why removing the recency gate is safe

The gate dates from Dec 2025 (f68fac6b34), when deletion went up to and *including* `lastSnapshotSeq` and the cached snapshot blob was the only replay base — recency was load-bearing then. Since the causal-marker rework it is not: pruning is bounded by `protectedFromSeq`, a **validated causal full-state op** at or below `lastSnapshotSeq` (marker re-verified against `CAUSAL_FULL_STATE_OPERATION_WHERE`; legacy REPAIRs without a causal base can never authorize deletion). That keeps the replay base, its complete tail, and the cached snapshot's tail intact regardless of snapshot age. Returning devices with cursors inside the pruned range hit the existing gap-detection → re-bootstrap path already exercised for active users.

## Changes

- **Gate:** `snapshotAt >= cutoffTime && lastSnapshotSeq > 0` → `lastSnapshotSeq > 0`, with a comment pinning why snapshot age is deliberately not a gate.
- **Regression test (written first, failed pre-fix):** lapsed user with a 100-day-old snapshot gets ops 1–3 pruned, causal base + tail (4–5) kept.
- **Real-Postgres integration test** (`old-ops-sweep.integration.spec.ts`, wired into `test:integration:postgres`): pins the actual SQL — lapsed user pruned to base + tail, snapshotless user untouched, legacy-REPAIR user skipped, fresh prefix inside retention kept. Verified to fail against the pre-fix code.
- **Read-only production preflight** (`npm run dry-run-old-ops-sweep:dev`): mirrors the sweep in set-based SQL and reports per-user would-delete counts, skipped/snapshotless cohorts, and safety checks (boundary is a surviving causal full-state op; boundary ≤ `lastSnapshotSeq`); exits non-zero on violation.
- Review nits: dead `snapshotAt` select dropped; monitoring-fixture comment corrected.

## Review

Seven-way review (6 focused Claude reviewers + Codex): no critical findings. Main operational note: with stalest-first ordering, the lapsed backlog consumes the default 25k/day budget for months and starves active-user pruning meanwhile — raise `OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN` on the hosted instance for the drain period.

## Deploy notes (hosted instance)

1. Run the dry-run script against the production DB; both safety checks must print OK.
2. `pg_dump` before the first post-deploy cleanup run.
3. Raise `OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN` for the drain; reset once the daily budget-exhausted warning stops.

## Known remaining gap (out of scope)

Users with **no snapshot at all** are still excluded by the `findMany` filter and remain unswept; the dry-run script reports the size of that cohort.