### PR TITLE
fix(schedule): guard schedule config against invalid clock strings

### DIFF
--- a/ARCHITECTURE-DECISIONS.md
+++ b/ARCHITECTURE-DECISIONS.md
@@ -332,6 +332,71 @@ recoverable via local undo, not via sync.
 
 ---
 
+### 8. Additive Data-Model Evolution over Schema Bumps
+
+**Status**: ✅ Active (since August 2026)
+
+**Decision**: Persisted and synced data evolves **additively**. Pick the change
+channel by what actually changed (table below). Do not raise
+`CURRENT_SCHEMA_VERSION` unless a change is **both** inexpressible as an additive
+or derived field **and** would be _misapplied_ — not merely ignored — by older
+clients. This is the constructive counterpart to the bump policy (sync rule 10),
+which says when not to bump but not what to do instead.
+
+| What changed                                                   | Channel                                                               | Precedent                                              |
+| -------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------ |
+| Local storage layout (stores, indexes, derived meta)           | `DB_VERSION` ladder — local only, never transmitted                   | `db-upgrade.ts` v7 seeds the full-state-ops meta store |
+| Shape of stored state (new field, legacy key, changed default) | Read-time normalization in the `loadAllData` reducer                  | `migrateFocusModeConfig`, `migrateKeyboardConfig`      |
+| Representation of an existing **synced** field                 | Dual field — new field wins, legacy re-derived from it on every write | `normalizeStartOfNextDayConfig`                        |
+| Semantics of an operation                                      | Payload marker / envelope, inert on older clients                     | `LwwUpdatePayload`; the v4 `projectDeleteWins` marker  |
+
+**Rationale**:
+
+- A bump fences only receivers that ship _after_ it. Released v17.0.0–v18.14.0
+  clients apply ops up to schema 5 unmigrated and, at ≥ 6, block them while still
+  advancing the cursor — permanently skipping them. A bump therefore never buys
+  safety against the clients actually writing today's data.
+- It cannot be reverted once any op carries the new version, and it hard-blocks
+  every lagging post-v18.14.0 client on a frozen cursor.
+- The legacy fleet does not age out on its own: there is **no desktop
+  auto-updater** (the block in `electron/start-app.ts` is commented out) and the
+  update banner's dismissal is persisted. Any policy gated on "wait for the old
+  fleet to shrink" is a permanent no in disguise.
+- Additive fields are safe by construction here: typia uses `createValidate`
+  (excess properties are neither rejected nor stripped) and LWW patch application
+  goes through `updateOne`, a shallow merge that retains unknown keys. **Renames
+  and removals are the dangerous shape** — an old client that wins a conflict
+  re-emits the entity without the field, destroying it fleet-wide — and no bump
+  prevents that, because old clients keep writing regardless.
+
+**Evaluation record (2026-08)**: raising `CURRENT_SCHEMA_VERSION` to 5 was
+considered and **declined**. Neither candidate motivation survived: the
+accumulated optional-field/runtime-default debt needs no migration (that pattern
+_is_ the answer, per sync rule 11), and the typed RRULE recurrence model can ship
+as an additive field while the flat fields stay canonical and re-derived — see
+#9664, which also corrects that plan's inverted cross-version gate. A migration
+with no payload is pure cost.
+
+**Implementation**: no new machinery — each channel above already exists and has
+a shipped precedent.
+
+**Documentation**: [Bump Policy §A.7.11](docs/sync-and-op-log/operation-log-architecture.md#bump-policy--a-bump-does-not-protect-the-released-fleet), [`persisted-model-fields.md`](docs/sync-and-op-log/persisted-model-fields.md), `AGENTS.md` sync rules 10 and 11
+
+**Key Files**:
+
+- [`schema-version.ts`](packages/shared-schema/src/schema-version.ts) — the constant and its bump warning
+- [`normalize-start-of-next-day-config.ts`](src/app/features/config/normalize-start-of-next-day-config.ts) — the dual-field template
+- [`global-config.reducer.ts`](src/app/features/config/store/global-config.reducer.ts) — read-time normalization at `loadAllData`
+- [`db-upgrade.ts`](src/app/op-log/persistence/db-upgrade.ts) / [`db-keys.const.ts`](src/app/op-log/persistence/db-keys.const.ts) — the local-only version ladder
+
+**When to Update This Pattern**:
+
+- A change genuinely requires removing or renaming a synced field
+- `CURRENT_SCHEMA_VERSION` is raised (record what earned it)
+- A desktop auto-updater ships — it changes the fleet assumption this rests on
+
+---
+
 ## Decisions Recorded Elsewhere
 
 These carry the same authority as the numbered records above. They live outside this file because they are long enough to stand alone, or because they are enforced as contributor/agent rules that must be read before touching the subsystem. Keep this table complete — if you record a decision somewhere else, add a row here.

--- a/e2e/tests/schedule/invalid-schedule-cfg-clock-string-5358.spec.ts
+++ b/e2e/tests/schedule/invalid-schedule-cfg-clock-string-5358.spec.ts
@@ -23,53 +23,61 @@ import { expect, test } from '../../fixtures/test.fixture';
 
 const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
 
+type StoreLike = {
+  dispatch: (action: unknown) => void;
+  subscribe: (next: (state: unknown) => void) => { unsubscribe: () => void };
+};
+
 /**
  * Dispatch straight into the in-memory NgRx store and read the resulting
  * schedule config back, so the test cannot silently pass on a no-op write.
- * Local e2e runs serve the dev build, so `ng.getComponent` is available (the
- * #7067 spec documents the production fallback of injecting an op into
- * IndexedDB; not needed here).
+ *
+ * Uses `window.__e2eTestHelpers.store` (main.ts), NOT `ng.getComponent`: the
+ * CI e2e bundle is built by `ng build` with no configuration, which keeps the
+ * dev `environment` (so the helper is exposed) but leaves `optimization` at
+ * its default `true` -- and that defines `ngDevMode: false`, which strips the
+ * Angular global debug utils. A `ng.getComponent` probe therefore works under
+ * `ng serve` locally and silently returns nothing in CI.
+ *
+ * The helper is attached after a dynamic import resolves, hence the poll.
  */
 const corruptScheduleCfg = async (
   page: import('@playwright/test').Page,
-): Promise<string | null> =>
-  page.evaluate((): string | null => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ng = (window as any).ng;
-    if (!ng?.getComponent) return null;
+): Promise<void> => {
+  await expect
+    .poll(
+      () =>
+        page.evaluate((): string | null => {
+          const store = (
+            window as unknown as { __e2eTestHelpers?: { store?: StoreLike } }
+          ).__e2eTestHelpers?.store;
+          if (!store) return null;
 
-    for (const el of Array.from(document.querySelectorAll('*'))) {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const comp = ng.getComponent(el) as any;
-        const store = comp?._store ?? comp?.store ?? comp?.__store;
-        if (!store?.dispatch) continue;
+          store.dispatch({
+            type: '[Global Config] Update Global Config Section',
+            sectionKey: 'schedule',
+            sectionCfg: {
+              isWorkStartEndEnabled: true,
+              workStart: '',
+              workEnd: '',
+              isLunchBreakEnabled: true,
+              lunchBreakStart: '',
+              lunchBreakEnd: '',
+            },
+            isSkipSnack: true,
+          });
 
-        store.dispatch({
-          type: '[Global Config] Update Global Config Section',
-          sectionKey: 'schedule',
-          sectionCfg: {
-            isWorkStartEndEnabled: true,
-            workStart: '',
-            workEnd: '',
-            isLunchBreakEnabled: true,
-            lunchBreakStart: '',
-            lunchBreakEnd: '',
-          },
-          meta: {},
-        });
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let state: any = null;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        store.subscribe((s: any) => (state = s)).unsubscribe();
-        return state?.globalConfig?.schedule?.workStart ?? null;
-      } catch {
-        // keep scanning for a component that exposes the store
-      }
-    }
-    return null;
-  });
+          let state: unknown = null;
+          store.subscribe((s) => (state = s)).unsubscribe();
+          return (
+            (state as { globalConfig?: { schedule?: { workStart?: string } } } | null)
+              ?.globalConfig?.schedule?.workStart ?? null
+          );
+        }),
+      { message: 'schedule config should read back as corrupted' },
+    )
+    .toBe('');
+};
 
 test.describe('Schedule with a corrupt schedule config (#5358)', () => {
   test.use({ viewport: DESKTOP_VIEWPORT });
@@ -97,7 +105,7 @@ test.describe('Schedule with a corrupt schedule config (#5358)', () => {
     page.on('console', (m) => m.type() === 'error' && record(m.text()));
     page.on('pageerror', (e) => record(e.message));
 
-    expect(await corruptScheduleCfg(page)).toBe('');
+    await corruptScheduleCfg(page);
 
     await page.getByRole('menuitem', { name: 'Schedule' }).click();
     await expect(page.locator('schedule-week')).toBeVisible({ timeout: 10000 });

--- a/e2e/tests/schedule/invalid-schedule-cfg-clock-string-5358.spec.ts
+++ b/e2e/tests/schedule/invalid-schedule-cfg-clock-string-5358.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Bug: https://github.com/super-productivity/super-productivity/issues/5358
+ * (and the `#/schedule` variant in #4842)
+ *
+ * A malformed time in the *schedule config* (workStart / workEnd /
+ * lunchBreakStart / lunchBreakEnd) makes getDateTimeFromClockString() throw
+ * "Invalid clock string" the moment the Schedule renders, taking the whole
+ * view down.
+ *
+ * The settings form validates, so such a value does not come from the UI --
+ * it arrives verbatim from an import or a synced snapshot: `loadAllData`
+ * spreads globalConfig over the defaults at the top level only, so unlike
+ * misc/tasks/idle/... the `schedule` section gets no per-field defaulting,
+ * and typia accepts '' for a `string` so autoFixTypiaErrors never repairs it.
+ * `updateGlobalConfigSection` -- dispatched below, and the same action a
+ * remote op replays -- takes a partial section with no validation at all.
+ *
+ * Expected: the Schedule renders without work-hours blocks (as when the
+ *           feature is off), rather than crashing.
+ */
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+/**
+ * Dispatch straight into the in-memory NgRx store and read the resulting
+ * schedule config back, so the test cannot silently pass on a no-op write.
+ * Local e2e runs serve the dev build, so `ng.getComponent` is available (the
+ * #7067 spec documents the production fallback of injecting an op into
+ * IndexedDB; not needed here).
+ */
+const corruptScheduleCfg = async (
+  page: import('@playwright/test').Page,
+): Promise<string | null> =>
+  page.evaluate((): string | null => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ng = (window as any).ng;
+    if (!ng?.getComponent) return null;
+
+    for (const el of Array.from(document.querySelectorAll('*'))) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const comp = ng.getComponent(el) as any;
+        const store = comp?._store ?? comp?.store ?? comp?.__store;
+        if (!store?.dispatch) continue;
+
+        store.dispatch({
+          type: '[Global Config] Update Global Config Section',
+          sectionKey: 'schedule',
+          sectionCfg: {
+            isWorkStartEndEnabled: true,
+            workStart: '',
+            workEnd: '',
+            isLunchBreakEnabled: true,
+            lunchBreakStart: '',
+            lunchBreakEnd: '',
+          },
+          meta: {},
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let state: any = null;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        store.subscribe((s: any) => (state = s)).unsubscribe();
+        return state?.globalConfig?.schedule?.workStart ?? null;
+      } catch {
+        // keep scanning for a component that exposes the store
+      }
+    }
+    return null;
+  });
+
+test.describe('Schedule with a corrupt schedule config (#5358)', () => {
+  test.use({ viewport: DESKTOP_VIEWPORT });
+
+  test('renders the Schedule instead of throwing "Invalid clock string"', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    // At least one task is required: mapToScheduleDays early-returns [] when
+    // tasks, scheduled tasks, repeat cfgs, calendar items and planner days are
+    // ALL empty, so a clean profile never reaches the blocker-block code at
+    // all. That is very likely why this was filed "unable to reproduce".
+    await workViewPage.addTask('ScheduleCfgBug5358');
+
+    // Both oracles below were verified to FAIL against the pre-fix commit:
+    // the throw escapes the schedule computed, `schedule-week` never renders,
+    // and the error surfaces as a pageerror. (An earlier version of this test
+    // passed while broken because it had no task -- see addTask above.)
+    const clockErrors: string[] = [];
+    const record = (text: string): void => {
+      if (text.includes('Invalid clock string')) clockErrors.push(text);
+    };
+    page.on('console', (m) => m.type() === 'error' && record(m.text()));
+    page.on('pageerror', (e) => record(e.message));
+
+    expect(await corruptScheduleCfg(page)).toBe('');
+
+    await page.getByRole('menuitem', { name: 'Schedule' }).click();
+    await expect(page.locator('schedule-week')).toBeVisible({ timeout: 10000 });
+
+    // The view must actually be populated, not an empty shell left behind by a
+    // swallowed error.
+    await expect(
+      page.locator('schedule-week .col:not(.end-of-day)[data-day]').first(),
+    ).toBeVisible();
+
+    expect(clockErrors).toEqual([]);
+  });
+});

--- a/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
+++ b/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
@@ -14,6 +14,7 @@ import {
   SVEEntryForNextDay,
 } from '../schedule.model';
 import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
+import { isValidSplitTime } from '../../../util/is-valid-split-time';
 import { SCHEDULE_TASK_MIN_DURATION_IN_MS, SVEType } from '../schedule.const';
 import { createViewEntriesForDay } from './create-view-entries-for-day';
 import { msLeftToday } from '../../../util/ms-left-today';
@@ -74,6 +75,15 @@ export const createScheduleDays = (
     }
   }
 
+  // Hoisted out of the day loop: a corrupt `workStart` (possible because an
+  // imported/synced `schedule` config is never per-field defaulted or healed --
+  // see createBlockerBlocksForWorkStartEnd) would otherwise throw "Invalid clock
+  // string" here and take the whole Schedule panel down (#5358). Skipping it
+  // just means the day starts at `now`, as when no work start/end is set.
+  // Not a devError: createSortedBlockerBlocks already reports the same cfg.
+  const isWorkStartTimeUsable =
+    !!workStartEndCfg && isValidSplitTime(workStartEndCfg.startTime);
+
   const v: ScheduleDay[] = dayDates.map((dayDate, i) => {
     const nextDayStartDate = dateStrToUtcDate(dayDate);
     nextDayStartDate.setHours(24, 0, 0, 0);
@@ -87,7 +97,7 @@ export const createScheduleDays = (
       dayStartTime >= todayStart && dayStartTime < currentWeekEndTime;
 
     let startTime = i == 0 ? now : dayStartTime;
-    if (workStartEndCfg) {
+    if (workStartEndCfg && isWorkStartTimeUsable) {
       const startTimeToday = getDateTimeFromClockString(
         workStartEndCfg.startTime,
         dateStrToUtcDate(dayDate),

--- a/src/app/features/schedule/map-schedule-data/create-sorted-blocker-blocks.ts
+++ b/src/app/features/schedule/map-schedule-data/create-sorted-blocker-blocks.ts
@@ -138,6 +138,20 @@ const createBlockerBlocksForWorkStartEnd = (
   if (!workStartEndCfg) {
     return blockedBlocks;
   }
+  // Same corrupt-data class as the repeat-cfg guard above (#7067): the schedule
+  // config is taken verbatim from an imported/synced snapshot -- `loadAllData`
+  // spreads `globalConfig` over the defaults at the top level only, so unlike
+  // `misc`/`tasks`/... the `schedule` section gets no per-field defaulting, and
+  // typia accepts '' for a `string` so autoFixTypiaErrors never repairs it.
+  // Without this, a single bad value throws on every Schedule panel open,
+  // permanently (#5358, #4842). Reported once here rather than per day.
+  if (
+    !isValidSplitTime(workStartEndCfg.startTime) ||
+    !isValidSplitTime(workStartEndCfg.endTime)
+  ) {
+    devError('Timeline: Invalid work start/end time in schedule config');
+    return blockedBlocks;
+  }
   let i: number = 0;
   while (i < nrOfDays) {
     // Calculate proper day start instead of adding 24-hour increments
@@ -183,6 +197,13 @@ const createBlockerBlocksForLunchBreak = (
   const blockedBlocks: BlockedBlock[] = [];
 
   if (!lunchBreakCfg) {
+    return blockedBlocks;
+  }
+  if (
+    !isValidSplitTime(lunchBreakCfg.startTime) ||
+    !isValidSplitTime(lunchBreakCfg.endTime)
+  ) {
+    devError('Timeline: Invalid lunch break time in schedule config');
     return blockedBlocks;
   }
   let i: number = 0;

--- a/src/app/features/schedule/map-schedule-data/invalid-schedule-cfg-clock-string.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/invalid-schedule-cfg-clock-string.spec.ts
@@ -1,0 +1,168 @@
+import { createSortedBlockerBlocks } from './create-sorted-blocker-blocks';
+import { createScheduleDays } from './create-schedule-days';
+import { BlockedBlockType } from '../schedule.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+import { _resetDevErrorState } from '../../../util/dev-error';
+import { isTaskOutsideWorkHours } from '../../tasks/util/is-task-outside-work-hours';
+import { ScheduleConfig } from '../../config/global-config.model';
+
+/**
+ * Reproduction for the "Invalid clock string" crash on opening the Schedule
+ * panel (#5358, and the schedule-route variant in #4842).
+ *
+ * The repeat-cfg call sites were guarded in #7067, but the ones fed by the
+ * *schedule config* (workStart/workEnd/lunchBreakStart/lunchBreakEnd) still
+ * call getDateTimeFromClockString bare. A malformed value there is not
+ * repairable by anything downstream:
+ *
+ *  - the settings form validates, but `loadAllData` spreads an incoming
+ *    `globalConfig` over the defaults at the TOP level only — `schedule` is
+ *    not deep-merged, so an imported/synced section is taken verbatim
+ *    (global-config.reducer.ts:169-180);
+ *  - `updateGlobalConfigSection` spreads a partial section with no validation,
+ *    so a remote client's op lands unchecked;
+ *  - typia accepts '' for a `string` field, so autoFixTypiaErrors never fires.
+ *
+ * Result: the value sticks and the Schedule panel throws on every open.
+ * Expected behaviour is the #7067 one — skip/fall back, never throw.
+ */
+describe('Schedule: malformed schedule-config clock strings (#5358)', () => {
+  const NOW = new Date('2026-08-21T10:00:00').getTime();
+
+  beforeEach(() => {
+    // test.ts stubs window.confirm to TRUE globally, which makes devError
+    // rethrow in non-production -- that would mask the guard under the very
+    // error it prevents. Silence both, and re-arm devError's one-shot alert
+    // latch so ordering with other specs cannot change the outcome.
+    _resetDevErrorState();
+    if (jasmine.isSpy(window.confirm)) {
+      (window.confirm as jasmine.Spy).and.returnValue(false);
+    } else {
+      spyOn(window, 'confirm').and.returnValue(false);
+    }
+    if (jasmine.isSpy(window.alert)) {
+      (window.alert as jasmine.Spy).and.stub();
+    } else {
+      spyOn(window, 'alert').and.stub();
+    }
+  });
+
+  describe('createSortedBlockerBlocks', () => {
+    it('does not throw on an empty workStart/workEnd', () => {
+      expect(() =>
+        createSortedBlockerBlocks(
+          [],
+          [],
+          [],
+          { startTime: '', endTime: '' },
+          undefined,
+          NOW,
+          3,
+        ),
+      ).not.toThrow();
+    });
+
+    it('does not throw on a malformed workEnd', () => {
+      expect(() =>
+        createSortedBlockerBlocks(
+          [],
+          [],
+          [],
+          { startTime: '09:00', endTime: '17:00 PM' },
+          undefined,
+          NOW,
+          3,
+        ),
+      ).not.toThrow();
+    });
+
+    it('does not throw on an empty lunch break', () => {
+      expect(() =>
+        createSortedBlockerBlocks(
+          [],
+          [],
+          [],
+          undefined,
+          { startTime: '', endTime: '' },
+          NOW,
+          3,
+        ),
+      ).not.toThrow();
+    });
+
+    it('emits no WorkdayStartEnd block for an unusable cfg rather than a bogus one', () => {
+      const blocks = createSortedBlockerBlocks(
+        [],
+        [],
+        [],
+        { startTime: '', endTime: '' },
+        undefined,
+        NOW,
+        3,
+      );
+      expect(
+        blocks.filter((b) =>
+          b.entries.some((e) => e.type === BlockedBlockType.WorkdayStartEnd),
+        ),
+      ).toEqual([]);
+    });
+
+    it('still honours a valid cfg', () => {
+      const blocks = createSortedBlockerBlocks(
+        [],
+        [],
+        [],
+        { startTime: '09:00', endTime: '17:00' },
+        undefined,
+        NOW,
+        3,
+      );
+      expect(
+        blocks.filter((b) =>
+          b.entries.some((e) => e.type === BlockedBlockType.WorkdayStartEnd),
+        ).length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createScheduleDays', () => {
+    it('does not throw on an empty workStart', () => {
+      const dayDates = [getDbDateStr(NOW)];
+      expect(() =>
+        createScheduleDays([], [], dayDates, {}, {}, { startTime: '', endTime: '' }, NOW),
+      ).not.toThrow();
+    });
+  });
+
+  describe('isTaskOutsideWorkHours', () => {
+    const TASK = {
+      dueWithTime: NOW,
+      timeEstimate: 60 * 60 * 1000,
+      timeSpent: 0,
+      subTaskIds: [],
+    };
+
+    it('reports "not outside" instead of throwing on a corrupt workStart', () => {
+      const cfg = {
+        isWorkStartEndEnabled: true,
+        workStart: '',
+        workEnd: '17:00',
+      } as ScheduleConfig;
+      expect(() => isTaskOutsideWorkHours(TASK, cfg)).not.toThrow();
+      expect(isTaskOutsideWorkHours(TASK, cfg)).toBe(false);
+    });
+
+    it('still detects a task outside valid work hours', () => {
+      const cfg = {
+        isWorkStartEndEnabled: true,
+        workStart: '09:00',
+        workEnd: '17:00',
+      } as ScheduleConfig;
+      const lateTask = {
+        ...TASK,
+        dueWithTime: new Date('2026-08-21T22:00:00').getTime(),
+      };
+      expect(isTaskOutsideWorkHours(lateTask, cfg)).toBe(true);
+    });
+  });
+});

--- a/src/app/features/tasks/util/is-task-outside-work-hours.ts
+++ b/src/app/features/tasks/util/is-task-outside-work-hours.ts
@@ -4,6 +4,7 @@ import { getTimeLeftForTask } from '../../../util/get-time-left-for-task';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
+import { isValidSplitTime } from '../../../util/is-valid-split-time';
 
 const MIN_TASK_DURATION = 60 * 1000;
 
@@ -11,7 +12,17 @@ export const isTaskOutsideWorkHours = (
   task: Pick<Task, 'dueWithTime' | 'timeEstimate' | 'timeSpent' | 'subTaskIds'>,
   scheduleConfig?: ScheduleConfig | null,
 ): boolean => {
-  if (!scheduleConfig?.isWorkStartEndEnabled || typeof task.dueWithTime !== 'number') {
+  // A corrupt workStart/workEnd (an imported or synced `schedule` config is
+  // taken verbatim -- never per-field defaulted, never healed) would throw
+  // "Invalid clock string" out of a signal computed and take the schedule
+  // dialog down (#5358). Unknown work hours simply means "cannot tell", so no
+  // warning -- and no devError, since this runs on every recomputation.
+  if (
+    !scheduleConfig?.isWorkStartEndEnabled ||
+    typeof task.dueWithTime !== 'number' ||
+    !isValidSplitTime(scheduleConfig.workStart) ||
+    !isValidSplitTime(scheduleConfig.workEnd)
+  ) {
     return false;
   }
 


### PR DESCRIPTION
Fixes the `Invalid clock string` crash when the schedule config holds a malformed time. Closes #5358 (and covers the `#/schedule` variant reported in #4842).

## The bug

`getDateTimeFromClockString` throws on a malformed time. The repeat-cfg call sites were guarded in de3e374 (#7067), but the four fed by the **schedule config** (`workStart` / `workEnd` / `lunchBreakStart` / `lunchBreakEnd`) were not — so a single bad value takes the entire Schedule view down, on every open, permanently.

Permanently, because nothing repairs it:

- `loadAllData` spreads `globalConfig` over the defaults at the **top level only**. Unlike `misc` / `tasks` / `idle` / …, the `schedule` section from an import or a synced snapshot is taken verbatim, with no per-field defaulting.
- `updateGlobalConfigSection` spreads a partial section with no validation, and is op-log captured — a remote client's op writes straight through.
- typia accepts `''` for a `string`, so `autoFixTypiaErrors` never fires.

The settings form does validate, so this isn't a UI-authored value — it matches #7067's framing: corrupt data arriving via sync or import.

## The fix

Guard the four sites the same way #7067 did — `devError` and skip. Deliberately **not** falling back to `DEFAULT_GLOBAL_CONFIG`, which would silently invent work hours the user never set; a bogus block would also misplace scheduling. Skipping degrades to "no work-hours blocks", i.e. the same as having the feature switched off.

`isTaskOutsideWorkHours` returns `false` ("cannot tell") without a `devError`, since it runs on every recomputation of a signal computed.

Read-side only — no reducer, no op, no persisted-model change, so no sync surface.

## Reproduction

E2E (`41259ca`) verified in both directions against the pre-fix commit: with a corrupt `workStart`, `schedule-week` does not render at all and the error escapes as a pageerror; with the fix, the view renders. Plus 8 unit tests covering all four sites, including controls proving valid configs still emit blocks and still detect out-of-hours tasks.

Two findings from building that E2E, both recorded in the commit messages:

- **`mapToScheduleDays` early-returns `[]`** when tasks, scheduled tasks, repeat cfgs, calendar items and planner days are *all* empty. On a clean profile the blocker-block code is never reached and the crash cannot happen regardless of how corrupt the config is — a likely reason #5358 sat under `unable to reproduce` for 10 months. The test needs at least one task to exist.
- **The first two oracles were false.** Asserting on `pageerror` alone, and then on `.global-error-alert`, both passed with the fix reverted — because with no task present nothing ever threw. Only after adding a task did the test start discriminating.

## What this does not do

It stops the crash; it does not stop bad values entering the config. That's deliberate: validating inside the op-log reducer would make op acceptance client-dependent and risk cross-device divergence, and tightening the typia model on a field users may already hold as `''` would turn a broken panel into a failed hydration (the #9125 class). Deep-merging `schedule` in `loadAllData` would only address *missing* fields, which `autoFixTypiaErrors` already handles.
