### PR TITLE
fix(task): keep own tags when converting to/from sub task

### DIFF
--- a/ARCHITECTURE-DECISIONS.md
+++ b/ARCHITECTURE-DECISIONS.md
@@ -332,6 +332,71 @@ recoverable via local undo, not via sync.
 
 ---
 
+### 8. Additive Data-Model Evolution over Schema Bumps
+
+**Status**: ✅ Active (since August 2026)
+
+**Decision**: Persisted and synced data evolves **additively**. Pick the change
+channel by what actually changed (table below). Do not raise
+`CURRENT_SCHEMA_VERSION` unless a change is **both** inexpressible as an additive
+or derived field **and** would be _misapplied_ — not merely ignored — by older
+clients. This is the constructive counterpart to the bump policy (sync rule 10),
+which says when not to bump but not what to do instead.
+
+| What changed                                                   | Channel                                                               | Precedent                                              |
+| -------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------ |
+| Local storage layout (stores, indexes, derived meta)           | `DB_VERSION` ladder — local only, never transmitted                   | `db-upgrade.ts` v7 seeds the full-state-ops meta store |
+| Shape of stored state (new field, legacy key, changed default) | Read-time normalization in the `loadAllData` reducer                  | `migrateFocusModeConfig`, `migrateKeyboardConfig`      |
+| Representation of an existing **synced** field                 | Dual field — new field wins, legacy re-derived from it on every write | `normalizeStartOfNextDayConfig`                        |
+| Semantics of an operation                                      | Payload marker / envelope, inert on older clients                     | `LwwUpdatePayload`; the v4 `projectDeleteWins` marker  |
+
+**Rationale**:
+
+- A bump fences only receivers that ship _after_ it. Released v17.0.0–v18.14.0
+  clients apply ops up to schema 5 unmigrated and, at ≥ 6, block them while still
+  advancing the cursor — permanently skipping them. A bump therefore never buys
+  safety against the clients actually writing today's data.
+- It cannot be reverted once any op carries the new version, and it hard-blocks
+  every lagging post-v18.14.0 client on a frozen cursor.
+- The legacy fleet does not age out on its own: there is **no desktop
+  auto-updater** (the block in `electron/start-app.ts` is commented out) and the
+  update banner's dismissal is persisted. Any policy gated on "wait for the old
+  fleet to shrink" is a permanent no in disguise.
+- Additive fields are safe by construction here: typia uses `createValidate`
+  (excess properties are neither rejected nor stripped) and LWW patch application
+  goes through `updateOne`, a shallow merge that retains unknown keys. **Renames
+  and removals are the dangerous shape** — an old client that wins a conflict
+  re-emits the entity without the field, destroying it fleet-wide — and no bump
+  prevents that, because old clients keep writing regardless.
+
+**Evaluation record (2026-08)**: raising `CURRENT_SCHEMA_VERSION` to 5 was
+considered and **declined**. Neither candidate motivation survived: the
+accumulated optional-field/runtime-default debt needs no migration (that pattern
+_is_ the answer, per sync rule 11), and the typed RRULE recurrence model can ship
+as an additive field while the flat fields stay canonical and re-derived — see
+#9664, which also corrects that plan's inverted cross-version gate. A migration
+with no payload is pure cost.
+
+**Implementation**: no new machinery — each channel above already exists and has
+a shipped precedent.
+
+**Documentation**: [Bump Policy §A.7.11](docs/sync-and-op-log/operation-log-architecture.md#bump-policy--a-bump-does-not-protect-the-released-fleet), [`persisted-model-fields.md`](docs/sync-and-op-log/persisted-model-fields.md), `AGENTS.md` sync rules 10 and 11
+
+**Key Files**:
+
+- [`schema-version.ts`](packages/shared-schema/src/schema-version.ts) — the constant and its bump warning
+- [`normalize-start-of-next-day-config.ts`](src/app/features/config/normalize-start-of-next-day-config.ts) — the dual-field template
+- [`global-config.reducer.ts`](src/app/features/config/store/global-config.reducer.ts) — read-time normalization at `loadAllData`
+- [`db-upgrade.ts`](src/app/op-log/persistence/db-upgrade.ts) / [`db-keys.const.ts`](src/app/op-log/persistence/db-keys.const.ts) — the local-only version ladder
+
+**When to Update This Pattern**:
+
+- A change genuinely requires removing or renaming a synced field
+- `CURRENT_SCHEMA_VERSION` is raised (record what earned it)
+- A desktop auto-updater ships — it changes the fleet assumption this rests on
+
+---
+
 ## Decisions Recorded Elsewhere
 
 These carry the same authority as the numbered records above. They live outside this file because they are long enough to stand alone, or because they are enforced as contributor/agent rules that must be read before touching the subsystem. Keep this table complete — if you record a decision somewhere else, add a row here.

--- a/e2e/tests/task-list-basic/convert-task-keeps-tags.spec.ts
+++ b/e2e/tests/task-list-basic/convert-task-keeps-tags.spec.ts
@@ -110,10 +110,8 @@ test.describe('Convert task keeps own tags (#9651)', () => {
     await expect(menu).toBeVisible();
     await menu.getByRole('menuitem', { name: /convert to parent task/i }).click();
 
-    const moverTopLevel = page
-      .locator('task-list[data-level="root"] > .task-list-inner > task, task')
-      .filter({ hasText: 'DragMover' })
-      .first();
+    // Root-levelness is asserted via the sub-list toHaveCount(0) check below.
+    const moverTopLevel = page.locator('task').filter({ hasText: 'DragMover' }).first();
     await expect(moverTopLevel).toBeVisible({ timeout: 5000 });
     // Not a subtask anymore
     await expect(

--- a/e2e/tests/task-list-basic/convert-task-keeps-tags.spec.ts
+++ b/e2e/tests/task-list-basic/convert-task-keeps-tags.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import type { Locator, Page } from '@playwright/test';
+
+// E2E reproduction for #9651: a task must keep its OWN tags when it is
+// converted to a subtask (drag into a subtask list) and when it is converted
+// back to a top-level task (context menu). Before the fix, nesting wiped the
+// tags and promoting overwrote them with the previous parent's tags.
+test.describe('Convert task keeps own tags (#9651)', () => {
+  const stableBoundingBox = async (
+    locator: Locator,
+  ): Promise<{ x: number; y: number; width: number; height: number }> => {
+    await locator.waitFor({ state: 'visible' });
+    let box = await locator.boundingBox();
+    await expect
+      .poll(async () => {
+        box = await locator.boundingBox();
+        return !!box && box.height > 0;
+      })
+      .toBe(true);
+    if (!box) throw new Error('drag source/target has no bounding box');
+    return box;
+  };
+
+  // CDK drag-drop ignores Playwright's HTML5 dragTo — drive the gesture
+  // manually (same approach as drag-task-into-subtask.spec.ts).
+  const cdkDragTo = async (
+    page: Page,
+    source: Locator,
+    target: Locator,
+  ): Promise<void> => {
+    const s = await stableBoundingBox(source);
+    const t = await stableBoundingBox(target);
+    /* eslint-disable no-mixed-operators */
+    const sx = s.x + s.width / 2;
+    const sy = s.y + s.height / 2;
+    const tx = t.x + t.width / 2;
+    const ty = t.y + t.height / 2;
+    /* eslint-enable no-mixed-operators */
+    await page.mouse.move(sx, sy);
+    await page.mouse.down();
+    await page.mouse.move(sx + 10, sy + 10, { steps: 5 });
+    await page.mouse.move(tx, ty, { steps: 20 });
+    await page.mouse.up();
+  };
+
+  const disableAnimations = async (page: Page): Promise<void> => {
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const store = (
+            window as unknown as {
+              __e2eTestHelpers?: { store?: { dispatch: (a: unknown) => void } };
+            }
+          ).__e2eTestHelpers?.store;
+          if (!store) return false;
+          store.dispatch({
+            type: '[Global Config] Update Global Config Section',
+            sectionKey: 'misc',
+            sectionCfg: { isDisableAnimations: true },
+            isSkipSnack: true,
+          });
+          return true;
+        }),
+      )
+      .toBe(true);
+    await expect(page.locator('body.isDisableAnimations')).toBeVisible();
+  };
+
+  const tagTitlesOf = (task: Locator): Locator => task.locator('tag-list tag .tag-title');
+
+  test('keeps own tag when dragged into a subtask list and when converted back to parent task', async ({
+    page,
+    workViewPage,
+    tagPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    // Pre-create tags so #shortSyntax attaches them without a confirm dialog.
+    await tagPage.createTag('parTag');
+    await tagPage.createTag('ownTag');
+
+    // Parent with one existing subtask → its subtask drop list is rendered.
+    await workViewPage.addTask('DragParent #parTag');
+    const parent = page.locator('task').filter({ hasText: 'DragParent' }).first();
+    await workViewPage.addSubTask(parent, 'ExistingSub');
+    await parent.locator('.sub-tasks task').first().waitFor({ state: 'visible' });
+
+    // The task under test, carrying its own tag.
+    await workViewPage.addTask('DragMover #ownTag');
+    const mover = page.locator('task').filter({ hasText: 'DragMover' }).first();
+    await expect(tagTitlesOf(mover)).toContainText(['ownTag']);
+
+    await disableAnimations(page);
+
+    // --- Direction 1: top-level → subtask keeps the own tag ---
+    const dragHandle = mover.locator('done-toggle').first();
+    const subRow = parent
+      .locator('.sub-tasks task')
+      .filter({ hasText: 'ExistingSub' })
+      .first();
+    await cdkDragTo(page, dragHandle, subRow);
+
+    const moverAsSub = parent.locator('.sub-tasks task').filter({ hasText: 'DragMover' });
+    await expect(moverAsSub).toBeVisible({ timeout: 5000 });
+    await expect(tagTitlesOf(moverAsSub)).toContainText(['ownTag']);
+
+    // --- Direction 2: subtask → top-level keeps the own tag, not the parent's ---
+    await moverAsSub.locator('task-title').click({ button: 'right' });
+    const menu = page.locator('.mat-mdc-menu-panel');
+    await expect(menu).toBeVisible();
+    await menu.getByRole('menuitem', { name: /convert to parent task/i }).click();
+
+    const moverTopLevel = page
+      .locator('task-list[data-level="root"] > .task-list-inner > task, task')
+      .filter({ hasText: 'DragMover' })
+      .first();
+    await expect(moverTopLevel).toBeVisible({ timeout: 5000 });
+    // Not a subtask anymore
+    await expect(
+      parent.locator('.sub-tasks task').filter({ hasText: 'DragMover' }),
+    ).toHaveCount(0);
+    // Own tag kept, previous parent's tag NOT inherited
+    await expect(tagTitlesOf(moverTopLevel)).toContainText(['ownTag']);
+    await expect(tagTitlesOf(moverTopLevel).filter({ hasText: 'parTag' })).toHaveCount(0);
+  });
+});

--- a/src/app/features/tasks/store/task-internal.effects.spec.ts
+++ b/src/app/features/tasks/store/task-internal.effects.spec.ts
@@ -218,6 +218,48 @@ describe('TaskInternalEffects', () => {
       );
     });
 
+    it('should emit for convertToMainTask when the payload is a stub without tagIds (drag path)', (done) => {
+      const parentTask = createTask('parent', { tagIds: ['tag1'] });
+      const task = createTask('task1', { parentId: undefined, tagIds: ['tag2'] });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([parentTask, task]));
+      store.refreshState();
+
+      effects.reassertOwnTagsAfterConvert$.subscribe((action) => {
+        expect((action as any).task.changes.tagIds).toEqual(['tag2']);
+        done();
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToMainTask({
+          task: { id: 'task1', parentId: 'parent' } as Task,
+        }),
+      );
+    });
+
+    it('should NOT emit for convertToMainTask when own tags equal the parent tags', (done) => {
+      const parentTask = createTask('parent', { tagIds: ['tag1'] });
+      const task = createTask('task1', { parentId: undefined, tagIds: ['tag1'] });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([parentTask, task]));
+      store.refreshState();
+
+      let emitted = false;
+      effects.reassertOwnTagsAfterConvert$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToMainTask({
+          task: createTask('task1', { parentId: 'parent', tagIds: ['tag1'] }),
+          parentTagIds: ['tag1'],
+        }),
+      );
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 50);
+    });
+
     it('should NOT emit for convertToMainTask when the task had no own tags (inherit fallback)', (done) => {
       // Post-reducer state: promoted with inherited parent tags
       const task = createTask('task1', { parentId: undefined, tagIds: ['tag1'] });

--- a/src/app/features/tasks/store/task-internal.effects.spec.ts
+++ b/src/app/features/tasks/store/task-internal.effects.spec.ts
@@ -146,6 +146,54 @@ describe('TaskInternalEffects', () => {
       );
     });
 
+    it('should filter the virtual TODAY tag out of re-asserted tagIds (legacy-dirty data)', (done) => {
+      const parentTask = createTask('parent', { subTaskIds: ['task1'] });
+      const task = createTask('task1', {
+        parentId: 'parent',
+        tagIds: ['TODAY', 'tag1'],
+      });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([parentTask, task]));
+      store.refreshState();
+
+      effects.reassertOwnTagsAfterConvert$.subscribe((action) => {
+        expect((action as any).task.changes.tagIds).toEqual(['tag1']);
+        done();
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToSubTask({
+          taskId: 'task1',
+          targetParentId: 'parent',
+          afterTaskId: null,
+        }),
+      );
+    });
+
+    it('should NOT emit when tagIds contains only the virtual TODAY tag', (done) => {
+      const parentTask = createTask('parent', { subTaskIds: ['task1'] });
+      const task = createTask('task1', { parentId: 'parent', tagIds: ['TODAY'] });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([parentTask, task]));
+      store.refreshState();
+
+      let emitted = false;
+      effects.reassertOwnTagsAfterConvert$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToSubTask({
+          taskId: 'task1',
+          targetParentId: 'parent',
+          afterTaskId: null,
+        }),
+      );
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 50);
+    });
+
     it('should NOT emit for convertToSubTask when the task has no tags', (done) => {
       const parentTask = createTask('parent', { subTaskIds: ['task1'] });
       const task = createTask('task1', { parentId: 'parent', tagIds: [] });

--- a/src/app/features/tasks/store/task-internal.effects.spec.ts
+++ b/src/app/features/tasks/store/task-internal.effects.spec.ts
@@ -122,6 +122,127 @@ describe('TaskInternalEffects', () => {
     store.resetSelectors();
   });
 
+  describe('reassertOwnTagsAfterConvert$', () => {
+    it('should re-assert kept tags after convertToSubTask (#9651)', (done) => {
+      // State reflects the post-reducer result: task nested, own tags kept
+      const parentTask = createTask('parent', { subTaskIds: ['task1'] });
+      const task = createTask('task1', { parentId: 'parent', tagIds: ['tag1'] });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([parentTask, task]));
+      store.refreshState();
+
+      effects.reassertOwnTagsAfterConvert$.subscribe((action) => {
+        expect(action.type).toBe(TaskSharedActions.updateTask.type);
+        expect((action as any).task.id).toBe('task1');
+        expect((action as any).task.changes.tagIds).toEqual(['tag1']);
+        done();
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToSubTask({
+          taskId: 'task1',
+          targetParentId: 'parent',
+          afterTaskId: null,
+        }),
+      );
+    });
+
+    it('should NOT emit for convertToSubTask when the task has no tags', (done) => {
+      const parentTask = createTask('parent', { subTaskIds: ['task1'] });
+      const task = createTask('task1', { parentId: 'parent', tagIds: [] });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([parentTask, task]));
+      store.refreshState();
+
+      let emitted = false;
+      effects.reassertOwnTagsAfterConvert$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToSubTask({
+          taskId: 'task1',
+          targetParentId: 'parent',
+          afterTaskId: null,
+        }),
+      );
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 50);
+    });
+
+    it('should NOT emit when the convertToSubTask op was rejected by the guard', (done) => {
+      // Post-reducer state unchanged: task still top-level with tags
+      const task = createTask('task1', { tagIds: ['tag1'] });
+      const otherTask = createTask('other', {});
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task, otherTask]));
+      store.refreshState();
+
+      let emitted = false;
+      effects.reassertOwnTagsAfterConvert$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToSubTask({
+          taskId: 'task1',
+          targetParentId: 'other',
+          afterTaskId: null,
+        }),
+      );
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 50);
+    });
+
+    it('should re-assert own tags after convertToMainTask (#9651)', (done) => {
+      // Post-reducer state: promoted with own tags kept
+      const task = createTask('task1', { parentId: undefined, tagIds: ['tag2'] });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task]));
+      store.refreshState();
+
+      effects.reassertOwnTagsAfterConvert$.subscribe((action) => {
+        expect(action.type).toBe(TaskSharedActions.updateTask.type);
+        expect((action as any).task.id).toBe('task1');
+        expect((action as any).task.changes.tagIds).toEqual(['tag2']);
+        done();
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToMainTask({
+          task: createTask('task1', { parentId: 'parent', tagIds: ['tag2'] }),
+          parentTagIds: ['tag1'],
+        }),
+      );
+    });
+
+    it('should NOT emit for convertToMainTask when the task had no own tags (inherit fallback)', (done) => {
+      // Post-reducer state: promoted with inherited parent tags
+      const task = createTask('task1', { parentId: undefined, tagIds: ['tag1'] });
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task]));
+      store.refreshState();
+
+      let emitted = false;
+      effects.reassertOwnTagsAfterConvert$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(
+        TaskSharedActions.convertToMainTask({
+          task: createTask('task1', { parentId: 'parent', tagIds: [] }),
+          parentTagIds: ['tag1'],
+        }),
+      );
+
+      setTimeout(() => {
+        expect(emitted).toBe(false);
+        done();
+      }, 50);
+    });
+  });
+
   describe('onAllSubTasksDone$', () => {
     it('should mark parent as done when all subtasks are done and config enabled', (done) => {
       const parentTask = createTask('parent', {

--- a/src/app/features/tasks/store/task-internal.effects.ts
+++ b/src/app/features/tasks/store/task-internal.effects.ts
@@ -24,7 +24,8 @@ import {
   moveProjectTaskToBacklogListAuto,
 } from '../../project/store/project.actions';
 import { DateService } from '../../../core/date/date.service';
-import { TODAY_TAG } from '../../tag/tag.const';
+import { filterOutTodayTag } from '../../../root-store/meta/task-shared-meta-reducers/task-shared-helpers';
+import { fastArrayCompare } from '../../../util/fast-array-compare';
 
 @Injectable()
 export class TaskInternalEffects {
@@ -113,36 +114,47 @@ export class TaskInternalEffects {
         const isConvertToSub = action.type === TaskSharedActions.convertToSubTask.type;
         const taskId = isConvertToSub ? action.taskId : action.task.id;
         const task = state.entities[taskId];
-        if (!task || !task.tagIds?.length) {
+        if (!task) {
           return EMPTY;
         }
+        // TODAY is virtual (rule 5) and must never be re-asserted into synced
+        // tagIds — legacy-dirty data may still carry it on the to-sub path
+        // (to-main already filters in the reducer).
+        const ownTagIds = filterOutTodayTag(task.tagIds ?? []);
+        if (!ownTagIds.length) {
+          return EMPTY;
+        }
+        // NOTE: for a convert the reducer guard rejected (e.g. already nested
+        // under the target), this still reads as applied and emits a redundant
+        // but idempotent op — prior state isn't available here to tell apart.
         const isApplied = isConvertToSub
           ? task.parentId === action.targetParentId
           : !task.parentId;
         if (!isApplied) {
           return EMPTY;
         }
-        // What an old client's reducer leaves in tagIds after replaying this
-        // op: [] for to-sub, the parent's tags for to-main. Emit only when
-        // the kept tags differ — otherwise both fleets already agree.
-        const parent = isConvertToSub
-          ? undefined
-          : state.entities[action.task.parentId as string];
-        const oldClientTagIds = isConvertToSub
-          ? []
-          : (Array.isArray(parent?.tagIds)
-              ? parent.tagIds
-              : (action.parentTagIds ?? [])
-            ).filter((id) => id !== TODAY_TAG.id);
-        const isSameResult =
-          task.tagIds.length === oldClientTagIds.length &&
-          task.tagIds.every((id, i) => id === oldClientTagIds[i]);
-        if (isSameResult) {
+        if (isConvertToSub) {
+          // Old clients wipe tagIds on to-sub; ownTagIds is non-empty here,
+          // so the fleets always differ — re-assert unconditionally.
+          return of(
+            TaskSharedActions.updateTask({
+              task: { id: taskId, changes: { tagIds: ownTagIds } },
+            }),
+          );
+        }
+        // To-main: an old client's reducer overwrites tagIds with its parent's
+        // tags. Emit only when the kept tags differ — otherwise both fleets
+        // already agree.
+        const parent = state.entities[action.task.parentId as string];
+        const oldClientTagIds = filterOutTodayTag(
+          Array.isArray(parent?.tagIds) ? parent.tagIds : (action.parentTagIds ?? []),
+        );
+        if (fastArrayCompare(ownTagIds, oldClientTagIds)) {
           return EMPTY;
         }
         return of(
           TaskSharedActions.updateTask({
-            task: { id: taskId, changes: { tagIds: task.tagIds } },
+            task: { id: taskId, changes: { tagIds: ownTagIds } },
           }),
         );
       }),

--- a/src/app/features/tasks/store/task-internal.effects.ts
+++ b/src/app/features/tasks/store/task-internal.effects.ts
@@ -94,6 +94,46 @@ export class TaskInternalEffects {
     ),
   );
 
+  /**
+   * #9651 graceful degradation: this client keeps a task's own tags across
+   * convertToSubTask / convertToMainTask, but clients released before that
+   * change replay these ops by wiping (to-sub) or overwriting with the
+   * parent's (to-main) tagIds. Re-asserting the kept tags as a follow-up
+   * updateTask op makes those clients converge to the same state. Fires only
+   * on the originating client (LOCAL_ACTIONS), only when the convert actually
+   * applied and the task had own tags to preserve.
+   */
+  reassertOwnTagsAfterConvert$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(TaskSharedActions.convertToSubTask, TaskSharedActions.convertToMainTask),
+      withLatestFrom(this._store$.pipe(select(selectTaskFeatureState))),
+      mergeMap(([action, state]) => {
+        const isConvertToSub = action.type === TaskSharedActions.convertToSubTask.type;
+        const taskId = isConvertToSub ? action.taskId : action.task.id;
+        const task = state.entities[taskId];
+        if (!task || !task.tagIds?.length) {
+          return EMPTY;
+        }
+        const isApplied = isConvertToSub
+          ? task.parentId === action.targetParentId
+          : !task.parentId;
+        // For to-main, re-assert only tags the task owned BEFORE the convert
+        // (payload snapshot): the inherit-parent fallback yields the same
+        // result on old clients and needs no extra op. Drag-and-drop may pass
+        // a payload stub without tagIds — then we conservatively skip.
+        const hadOwnTags = isConvertToSub ? true : !!action.task.tagIds?.length;
+        if (!isApplied || !hadOwnTags) {
+          return EMPTY;
+        }
+        return of(
+          TaskSharedActions.updateTask({
+            task: { id: taskId, changes: { tagIds: task.tagIds } },
+          }),
+        );
+      }),
+    ),
+  );
+
   planStartedTaskForToday$ = createEffect(() =>
     this._actions$.pipe(
       ofType(setCurrentTask),

--- a/src/app/features/tasks/store/task-internal.effects.ts
+++ b/src/app/features/tasks/store/task-internal.effects.ts
@@ -24,6 +24,7 @@ import {
   moveProjectTaskToBacklogListAuto,
 } from '../../project/store/project.actions';
 import { DateService } from '../../../core/date/date.service';
+import { TODAY_TAG } from '../../tag/tag.const';
 
 @Injectable()
 export class TaskInternalEffects {
@@ -97,11 +98,12 @@ export class TaskInternalEffects {
   /**
    * #9651 graceful degradation: this client keeps a task's own tags across
    * convertToSubTask / convertToMainTask, but clients released before that
-   * change replay these ops by wiping (to-sub) or overwriting with the
-   * parent's (to-main) tagIds. Re-asserting the kept tags as a follow-up
-   * updateTask op makes those clients converge to the same state. Fires only
-   * on the originating client (LOCAL_ACTIONS), only when the convert actually
-   * applied and the task had own tags to preserve.
+   * change (<= v18.20.1) replay these ops by wiping (to-sub) or overwriting
+   * with the parent's (to-main) tagIds. Re-asserting the kept tags as a
+   * follow-up updateTask op makes those clients converge to the same state.
+   * Fires only on the originating client (LOCAL_ACTIONS), only when the
+   * convert actually applied and old clients would end up with different
+   * tags. Removable once pre-change clients are no longer a concern.
    */
   reassertOwnTagsAfterConvert$ = createEffect(() =>
     this._actions$.pipe(
@@ -117,12 +119,25 @@ export class TaskInternalEffects {
         const isApplied = isConvertToSub
           ? task.parentId === action.targetParentId
           : !task.parentId;
-        // For to-main, re-assert only tags the task owned BEFORE the convert
-        // (payload snapshot): the inherit-parent fallback yields the same
-        // result on old clients and needs no extra op. Drag-and-drop may pass
-        // a payload stub without tagIds — then we conservatively skip.
-        const hadOwnTags = isConvertToSub ? true : !!action.task.tagIds?.length;
-        if (!isApplied || !hadOwnTags) {
+        if (!isApplied) {
+          return EMPTY;
+        }
+        // What an old client's reducer leaves in tagIds after replaying this
+        // op: [] for to-sub, the parent's tags for to-main. Emit only when
+        // the kept tags differ — otherwise both fleets already agree.
+        const parent = isConvertToSub
+          ? undefined
+          : state.entities[action.task.parentId as string];
+        const oldClientTagIds = isConvertToSub
+          ? []
+          : (Array.isArray(parent?.tagIds)
+              ? parent.tagIds
+              : (action.parentTagIds ?? [])
+            ).filter((id) => id !== TODAY_TAG.id);
+        const isSameResult =
+          task.tagIds.length === oldClientTagIds.length &&
+          task.tagIds.every((id, i) => id === oldClientTagIds[i]);
+        if (isSameResult) {
           return EMPTY;
         }
         return of(

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.spec.ts
@@ -25,6 +25,7 @@ import {
   expectTaskEntityExists,
   expectTaskEntityNotExists,
   expectTaskUpdate,
+  expectTaskUpdates,
 } from './test-utils';
 
 describe('taskSharedCrudMetaReducer', () => {
@@ -409,6 +410,71 @@ describe('taskSharedCrudMetaReducer', () => {
       );
     });
 
+    it('should keep own tags instead of inheriting the parent tags (#9651)', () => {
+      const { action, testState: baseTestState } = createConvertAction({
+        tagIds: ['tag2'],
+      });
+      const testState = {
+        ...baseTestState,
+        [TASK_FEATURE_NAME]: {
+          ...baseTestState[TASK_FEATURE_NAME],
+          entities: {
+            ...baseTestState[TASK_FEATURE_NAME].entities,
+            task1: action.task,
+          },
+          ids: [...baseTestState[TASK_FEATURE_NAME].ids, 'task1'],
+        },
+        [TAG_FEATURE_NAME]: {
+          ...baseTestState[TAG_FEATURE_NAME],
+          ids: [...(baseTestState[TAG_FEATURE_NAME].ids as string[]), 'tag2'],
+          entities: {
+            ...baseTestState[TAG_FEATURE_NAME].entities,
+            tag2: createMockTag({ id: 'tag2', taskIds: ['task1'] }),
+          },
+        },
+      };
+
+      metaReducer(testState, action);
+      expectStateUpdate(
+        {
+          ...expectTaskUpdate('task1', { parentId: undefined, tagIds: ['tag2'] }),
+          ...expectTagUpdates({
+            tag1: { taskIds: [] },
+            tag2: { taskIds: ['task1'] },
+          }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('should inherit the parent tags when the task has no own tags', () => {
+      const { action, testState: baseTestState } = createConvertAction({ tagIds: [] });
+      const testState = {
+        ...baseTestState,
+        [TASK_FEATURE_NAME]: {
+          ...baseTestState[TASK_FEATURE_NAME],
+          entities: {
+            ...baseTestState[TASK_FEATURE_NAME].entities,
+            task1: action.task,
+          },
+          ids: [...baseTestState[TASK_FEATURE_NAME].ids, 'task1'],
+        },
+      };
+
+      metaReducer(testState, action);
+      expectStateUpdate(
+        {
+          ...expectTaskUpdate('task1', { parentId: undefined, tagIds: ['tag1'] }),
+          ...expectTagUpdate('tag1', { taskIds: ['task1'] }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
     it('should use captured dates when replaying on a different day', () => {
       const capturedToday = '2024-06-14';
       const capturedTimestamp = new Date(2024, 5, 14, 12, 0, 0, 0).getTime();
@@ -774,27 +840,27 @@ describe('taskSharedCrudMetaReducer', () => {
         afterTaskId,
       });
 
-    it('should move a main task under the target parent', () => {
+    it('should move a main task under the target parent and keep its own tags', () => {
       const testState = createConvertToSubTaskState();
       const action = createConvertToSubTaskAction();
 
       metaReducer(testState, action);
       expectStateUpdate(
-        {
-          ...expectTaskUpdate('task1', {
+        expectTaskUpdates({
+          task1: {
             parentId: 'parent-task',
             projectId: 'project1',
-            tagIds: [],
-          }),
-          ...expectTaskUpdate('parent-task', { subTaskIds: ['task1'] }),
-        },
+            tagIds: ['tag1'],
+          },
+          'parent-task': { subTaskIds: ['task1'] },
+        }),
         action,
         mockReducer,
         testState,
       );
     });
 
-    it('should remove converted task from project and tag top-level lists', () => {
+    it('should remove converted task from project lists and TODAY ordering but keep own tag membership', () => {
       const testState = createConvertToSubTaskState();
       const action = createConvertToSubTaskAction();
 
@@ -806,8 +872,44 @@ describe('taskSharedCrudMetaReducer', () => {
             backlogTaskIds: [],
           }),
           ...expectTagUpdates({
-            tag1: { taskIds: ['parent-task'] },
+            tag1: { taskIds: ['parent-task', 'task1'] },
             TODAY: { taskIds: [] },
+          }),
+        },
+        action,
+        mockReducer,
+        testState,
+      );
+    });
+
+    it('should keep a tag the target parent does not have (#9651)', () => {
+      const base = createConvertToSubTaskState({ tagIds: ['tag2'] });
+      const testState = {
+        ...base,
+        [TAG_FEATURE_NAME]: {
+          ...base[TAG_FEATURE_NAME],
+          ids: [...(base[TAG_FEATURE_NAME].ids as string[]), 'tag2'],
+          entities: {
+            ...base[TAG_FEATURE_NAME].entities,
+            tag1: {
+              ...base[TAG_FEATURE_NAME].entities.tag1,
+              taskIds: ['parent-task'],
+            } as Tag,
+            tag2: createMockTag({ id: 'tag2', taskIds: ['task1'] }),
+          },
+        },
+      };
+      const action = createConvertToSubTaskAction();
+
+      metaReducer(testState, action);
+      expectStateUpdate(
+        {
+          ...expectTaskUpdate('task1', {
+            parentId: 'parent-task',
+            tagIds: ['tag2'],
+          }),
+          ...expectTagUpdates({
+            tag2: { taskIds: ['task1'] },
           }),
         },
         action,
@@ -834,10 +936,10 @@ describe('taskSharedCrudMetaReducer', () => {
           ...expectTaskUpdate('task1', {
             parentId: 'parent-task',
             dueDay: undefined,
-            tagIds: [],
+            tagIds: ['tag1'],
           }),
           ...expectTagUpdates({
-            tag1: { taskIds: ['parent-task'] },
+            tag1: { taskIds: ['parent-task', 'task1'] },
             TODAY: { taskIds: [] },
           }),
           planner: jasmine.objectContaining({

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -185,17 +185,15 @@ const handleConvertToMainTask = (
   // The stored entity wins over the payload snapshot; TODAY is virtual and
   // never lives in tagIds.
   const storedTask = state[TASK_FEATURE_NAME].entities[task.id];
-  const ownTagIds = (
+  const ownTagIds = filterOutTodayTag(
     Array.isArray(storedTask?.tagIds)
       ? storedTask.tagIds
       : Array.isArray(task.tagIds)
         ? task.tagIds
-        : []
-  ).filter((id) => id !== TODAY_TAG.id);
+        : [],
+  );
   const keptTagIds =
-    ownTagIds.length > 0
-      ? ownTagIds
-      : resolvedParentTagIds.filter((id) => id !== TODAY_TAG.id);
+    ownTagIds.length > 0 ? ownTagIds : filterOutTodayTag(resolvedParentTagIds);
   const positionConvertedTask = (taskIds: string[]): string[] => {
     // Dropped at the start of DONE → append to the bottom of the done list.
     if (afterTaskId == null && isDone) {

--- a/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer.ts
@@ -179,6 +179,23 @@ const handleConvertToMainTask = (
     : Array.isArray(parentTask.tagIds)
       ? parentTask.tagIds
       : [];
+  // #9651: a tagged sub task keeps its own tags on promotion; the parent's
+  // tags are only inherited when the task has none (a top-level task without
+  // project or tag would fail validation and vanish from every context view).
+  // The stored entity wins over the payload snapshot; TODAY is virtual and
+  // never lives in tagIds.
+  const storedTask = state[TASK_FEATURE_NAME].entities[task.id];
+  const ownTagIds = (
+    Array.isArray(storedTask?.tagIds)
+      ? storedTask.tagIds
+      : Array.isArray(task.tagIds)
+        ? task.tagIds
+        : []
+  ).filter((id) => id !== TODAY_TAG.id);
+  const keptTagIds =
+    ownTagIds.length > 0
+      ? ownTagIds
+      : resolvedParentTagIds.filter((id) => id !== TODAY_TAG.id);
   const positionConvertedTask = (taskIds: string[]): string[] => {
     // Dropped at the start of DONE → append to the bottom of the done list.
     if (afterTaskId == null && isDone) {
@@ -200,11 +217,7 @@ const handleConvertToMainTask = (
       id: task.id,
       changes: {
         parentId: undefined,
-        // Filter out TODAY_TAG.id - it's a virtual tag where membership is
-        // determined by task.dueDay, not by being in tagIds
-        tagIds: (Array.isArray(parentTask.tagIds) ? parentTask.tagIds : []).filter(
-          (id) => id !== TODAY_TAG.id,
-        ),
+        tagIds: keptTagIds,
         modified: capturedModified ?? Date.now(),
         ...(isPlanForToday && !task.dueWithTime
           ? {
@@ -250,7 +263,7 @@ const handleConvertToMainTask = (
 
   // Update tags - only update tags that exist
   const tagIdsToUpdate = [
-    ...resolvedParentTagIds,
+    ...keptTagIds,
     ...(isPlanForToday ? [TODAY_TAG.id] : []),
   ].filter((tagId) => state[TAG_FEATURE_NAME].entities[tagId]);
 
@@ -295,7 +308,18 @@ const handleConvertToSubTask = (
     });
   }
 
-  updatedState = removeTasksFromAllTags(updatedState, [task.id]);
+  // #9651: the task keeps its own tags when nested — only the stale TODAY
+  // ordering entry is dropped (dueDay is cleared below and TODAY membership
+  // is virtual, derived from dueDay).
+  const todayTag = updatedState[TAG_FEATURE_NAME].entities[TODAY_TAG.id];
+  if (todayTag && todayTag.taskIds.includes(task.id)) {
+    updatedState = updateTags(updatedState, [
+      {
+        id: TODAY_TAG.id,
+        changes: { taskIds: removeTasksFromList(todayTag.taskIds, [task.id]) },
+      },
+    ]);
+  }
   updatedState = removeTaskFromPlannerDays(updatedState, task.id);
 
   let taskState = updatedState[TASK_FEATURE_NAME];
@@ -316,7 +340,6 @@ const handleConvertToSubTask = (
         changes: {
           parentId: targetParent.id,
           projectId: targetParent.projectId,
-          tagIds: [],
           dueDay: undefined,
           modified: Date.now(),
         },

--- a/src/app/root-store/meta/task-shared-meta-reducers/test-utils.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/test-utils.ts
@@ -194,6 +194,22 @@ export const expectTaskUpdate = (taskId: string, changes: Partial<Task>) => ({
   }),
 });
 
+// NOTE: spreading two expectTaskUpdate() results into one expectation object
+// silently drops the first (same TASK_FEATURE_NAME key) — use this for
+// asserting on more than one task.
+export const expectTaskUpdates = (updates: Record<string, Partial<Task>>) => ({
+  [TASK_FEATURE_NAME]: jasmine.objectContaining({
+    entities: jasmine.objectContaining(
+      Object.fromEntries(
+        Object.entries(updates).map(([taskId, changes]) => [
+          taskId,
+          jasmine.objectContaining(changes),
+        ]),
+      ),
+    ),
+  }),
+});
+
 export const expectTaskEntityExists = (taskId: string) => ({
   [TASK_FEATURE_NAME]: jasmine.objectContaining({
     entities: jasmine.objectContaining({

--- a/src/app/root-store/meta/task-shared-meta-reducers/test-utils.ts
+++ b/src/app/root-store/meta/task-shared-meta-reducers/test-utils.ts
@@ -186,13 +186,8 @@ export const expectTagUpdates = (updates: Record<string, Partial<Tag>>) => ({
   }),
 });
 
-export const expectTaskUpdate = (taskId: string, changes: Partial<Task>) => ({
-  [TASK_FEATURE_NAME]: jasmine.objectContaining({
-    entities: jasmine.objectContaining({
-      [taskId]: jasmine.objectContaining(changes),
-    }),
-  }),
-});
+export const expectTaskUpdate = (taskId: string, changes: Partial<Task>) =>
+  expectTaskUpdates({ [taskId]: changes });
 
 // NOTE: spreading two expectTaskUpdate() results into one expectation object
 // silently drops the first (same TASK_FEATURE_NAME key) — use this for


### PR DESCRIPTION
Closes #9651

## Problem

A task loses its own tags when its parent/child relationship changes:

- Dragging a top-level task into a subtask list (`convertToSubTask`) wiped its `tagIds` entirely.
- Converting a subtask back to a top-level task (`convertToMainTask`) overwrote its tags with the previous parent's tags.
- Moving a subtask between parents kept tags — the inconsistency users noticed.

Subtask tags are supported everywhere else (detail panel editing, rendering, tag views), so the wipe/inherit behavior was inconsistent data loss.

## Fix

- `convertToSubTask` keeps the task's own tags; only the stale TODAY *ordering* entry is removed (TODAY is virtual — membership derives from `dueDay`).
- `convertToMainTask` keeps the task's own tags; the parent's tags are inherited only when the task has none (a top-level task with no project and no tags fails validation and would vanish from every context view — the fallback is load-bearing).

## Cross-version sync convergence (no schema bump)

These are existing op types: released clients (≤ v18.20.1) replay them with the old wipe/inherit semantics. A new `LOCAL_ACTIONS` effect `reassertOwnTagsAfterConvert$` dispatches a follow-up `updateTask` op re-asserting the kept `tagIds` — only on the originating client, only when the convert actually applied, and only when an old client's replay result would differ. Old clients replay convert (wipe/inherit) then updateTask (restore) and converge. Per sync rule 10, no schema bump.

Accepted costs: +1 synced op per tagged convert; slightly widened LWW window on `tagIds`; the convert + re-assert pair is not atomic in the log (crash between them = pre-fix status quo on old clients).

## Testing

- Reducer + effect unit tests written first and confirmed failing without the fix (full suite: 14,287 green).
- New Playwright e2e (`convert-task-keeps-tags.spec.ts`) drag-nests a tagged task and converts it back via context menu; verified to fail on pre-fix code at the tag assertion.
- Multi-agent review pass (7 reviewers): one consensus finding — legacy-dirty `'TODAY'` entries in `tagIds` could have been re-broadcast by the convergence op — fixed with `filterOutTodayTag` at the emit point + tests.

## Known benign gap

`tag.taskIds` *ordering* may briefly differ across mixed-version fleets on to-sub (old clients re-add via front-insert); membership converges and ordering self-heals on the next reorder op.