### PR TITLE
task-repeat: fix monthly-anchor reschedule bug, reconcile plan doc with rrule epic

### DIFF
--- a/docs/research/recurring-events-implementation-plan.md
+++ b/docs/research/recurring-events-implementation-plan.md
@@ -5,9 +5,12 @@
 > what follows is already implemented on that branch (forward/inverse RRULE
 > converters, the old-client compatibility contract, an off-by-default per-device
 > engine flag), and the branch resolved several questions this document still
-> poses as open. Check there before planning or building anything here. Note the
-> branch's implementation uses a **raw `rrule` string**, not the typed union
-> sketched below — reconcile the two before treating either as decided.
+> poses as open. Check there before planning or building anything here.
+>
+> **Reconciled 2026-08-21: the branch's raw-`rrule`-string design stands; the
+> typed-union sketch below is superseded** (kept as rationale record). The
+> rejection reasoning below was checked against the branch and does not hold
+> against its actual design — see "Why the raw-string rejection was stale".
 
 > **Revision note (verified against code 2026-06-02).** Rewritten after two rounds
 > of multi-axis review against the actual codebase. The original draft was built on
@@ -33,42 +36,59 @@
 
 ---
 
-## Decision: a typed, RRULE-isomorphic recurrence model
+## Decision (superseded): a typed, RRULE-isomorphic recurrence model
 
-The recurrence **pattern** becomes a single typed, structured field — a
-discriminated union that maps **1:1 to RFC 5545** — replacing the ~14
-interdependent flat fields (`repeatCycle`, `repeatEvery`, the 7 weekday booleans,
-`monthlyWeekOfMonth`, `monthlyWeekday`, `monthlyLastDay`, `quickSetting`).
+> **Superseded 2026-08-21.** The standing decision is the epic branch's: a raw
+> `rrule?: string` added alongside the legacy flat fields, which stay
+> dual-written forever as the wire format. Everything from here down is the
+> superseded typed-model plan, kept because its correctness constraints
+> (DTSTART/noon anchoring, EXDATE day-string matching, `UNTIL` inclusivity,
+> WKST, monthly-anchor precedence, the parity gate, the wire-rename and
+> migration warnings) apply to the epic's serializer and engine just the same —
+> only the persisted shape differs.
+
+The superseded plan: the recurrence **pattern** becomes a single typed,
+structured field — a discriminated union that maps **1:1 to RFC 5545** —
+replacing the ~14 interdependent flat fields (`repeatCycle`, `repeatEvery`, the
+7 weekday booleans, `monthlyWeekOfMonth`, `monthlyWeekday`, `monthlyLastDay`,
+`quickSetting`).
 
 The RFC-5545 **RRULE string is produced/parsed only at the boundary** (`.ics`
-export, CalDAV). **The raw string is never the persisted/synced field.**
+export, CalDAV). **The raw string is never the persisted/synced field.** (This
+last line is precisely what the epic decided differently.)
 
-### Why typed-isomorphic instead of a raw RRULE string
+### Why the raw-string rejection was stale (reconciled 2026-08-21)
 
-A raw `rrule` string as the canonical field was considered and rejected. It is the
-worst fit for _this_ codebase:
+An earlier revision rejected a raw `rrule` string as the canonical field on
+three grounds. Checked against what `feat/rrule-epic` actually built, each
+objection is answered by a design decision the rejection did not anticipate:
 
-- **Un-queryable.** NgRx selectors (`task-repeat-cfg.selectors.ts`) read fields; a
-  string forces parsing on every projection.
-- **Un-diffable / un-repairable.** The op-log diffs fields and `data-repair.ts`
-  repairs typed shapes (`_fixTaskRepeatMissingWeekday`,
-  `_fixTaskRepeatCfgInvalidQuickSetting`); it cannot validate or repair the
-  _interior_ of an opaque string. A partially-corrupt string would sync silently.
-- **Hot-path performance.** The occurrence engine runs **synchronously**,
-  `days × configs` times, in selector projectors (`selectTaskRepeatCfgsForExactDay`,
-  `selectAllUnprocessedTaskRepeatCfgs`) consumed per displayed day by the schedule
-  (~up to a month grid) and the 14-day mobile-notification lookahead. Expanding a
-  raw string means ical.js iteration, which is **forward-only** and **async**
-  (the engine is lazy-loaded, ~76 KB) — it cannot run inside a sync selector and is
-  far heavier than today's bounded loops. To keep a raw string _and_ stay fast you
-  would maintain a parsed structured form alongside it — i.e. rebuild this typed
-  model anyway, plus a redundant string.
+- **"Un-queryable."** The branch adds `rrule?: string` _additively_ and
+  **dual-writes the legacy flat fields forever** — they are the wire format for
+  old clients (roadmap, "Dual-engine endgame" §4). Selectors and any field-level
+  consumer keep a structured representation; nothing is forced to parse the
+  string on projection.
+- **"Un-diffable / un-repairable."** Same dual-write: the op-log still diffs the
+  legacy fields, and `data-repair.ts` still repairs them. For the string itself
+  the branch has an explicit policy instead of silent corruption: the engine is
+  fail-soft (malformed `rrule` → log + `null`, never a throw), `isRRuleValid`
+  gates routing (invalid → legacy fallback), and the decided post-legacy-engine
+  behavior for an invalid string is **pause + repair prompt**, never silent
+  rescheduling.
+- **"Hot-path performance."** The objection assumed the expansion engine would
+  be ical.js (async, lazy-loaded, forward-only). The branch's engine is
+  **rrule.js (`rrule@2.8.1`, pinned exact) — synchronous** — in a dedicated
+  day-granular, UTC-based occurrence util (`store/rrule-occurrence.util.ts`)
+  with memoised validity probing. It runs inside the existing sync calculators;
+  no async dependency enters the selector path.
 
-A typed union maps onto the same `FREQ/INTERVAL/BYDAY/BYMONTHDAY/COUNT/UNTIL`
-concepts the existing engine already handles, so it stays queryable, validatable,
-diffable, and **fast** — while remaining losslessly serializable to the RRULE
-string for interop. It honors the "RRULE as the model" intent in substance (the
-model _is_ RRULE, structured) without the opaque-blob costs.
+The one cost the old reasoning weighed correctly: **`rrule` is a new root
+runtime dependency**, which the project rules normally forbid. The
+maintainer-owned epic accepted it deliberately and treats it like an engine —
+pinned to an exact version, with a differential spec battery as the upgrade
+tripwire (a parser-version drift between devices is a duplicate-task generator,
+see the roadmap's risk model). That trade is decided; do not relitigate it here,
+and do not un-pin the version.
 
 ### Honest caveats on the goals (design to them)
 
@@ -86,9 +106,14 @@ model _is_ RRULE, structured) without the opaque-blob costs.
 
 ---
 
-## The typed model
+## The typed model (superseded — kept as rationale record)
 
-Replace the flat pattern fields in `TaskRepeatCfgCopy`
+> Superseded by the epic's `rrule?: string` + legacy dual-write (see above).
+> Preserved because the invariant analysis below (what a discriminated union
+> makes unrepresentable) is the best record of the legacy fields' implicit
+> precedence rules.
+
+The sketch replaced the flat pattern fields in `TaskRepeatCfgCopy`
 (`task-repeat-cfg.model.ts` — edit `TaskRepeatCfgCopy`, not the `Readonly` alias)
 with one discriminated union plus an end condition. Sketch (final names TBD):
 
@@ -97,7 +122,7 @@ type Weekday = 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU';
 
 type RecurrencePattern =
   | { freq: 'DAILY'; interval: number }
-  | { freq: 'WEEKLY'; interval: number; byDay: Weekday[]; wkst?: Weekday }
+  | { freq: 'WEEKLY'; interval: number; byDay: Weekday[] } // WKST is derived (weekday of effective startDate), never persisted
   | { freq: 'MONTHLY'; interval: number; on: { monthDay: number } } // BYMONTHDAY=n
   | { freq: 'MONTHLY'; interval: number; on: { lastDay: true } } // BYMONTHDAY=-1
   | { freq: 'MONTHLY'; interval: number; on: { week: 1 | 2 | 3 | 4 | -1; day: Weekday } } // BYDAY=nDD
@@ -112,7 +137,7 @@ interface RecurrenceConfigPart {
   // canonical, RRULE-isomorphic, persisted/synced:
   recurrence: RecurrencePattern;
   end: RecurrenceEnd;
-  exDates: string[]; // = today's `deletedInstanceDates`, NOT renamed on the wire
+  deletedInstanceDates: string[]; // wire name kept verbatim — `exDates` would be exactly the forbidden rename
   // SP carve-out — not expressible in RFC 5545:
   repeatFromCompletionDate?: boolean;
 }
@@ -162,6 +187,13 @@ Phase-1 mapping table) needs it at the boundary; only general engine-side
 
 ## Engine decision: keep the synchronous bounded engine
 
+> _Reconciled:_ this holds for legacy/flag-off cfgs — the branch keeps the
+> bounded loops authoritative there. For cfgs carrying an `rrule` string with
+> the flag on, the branch routes to its **synchronous** rrule.js engine
+> (`store/rrule-occurrence.util.ts`); ical.js remains boundary-only either way.
+> The paragraph below records why ical.js must never become the occurrence
+> runtime, which still stands.
+
 **The occurrence runtime stays the existing synchronous bounded loops**
 (`get-next-repeat-occurrence.util.ts`, `get-newest-possible-due-date.util.ts`),
 re-pointed to read the new typed `recurrence` field instead of the flat fields.
@@ -201,18 +233,29 @@ A pure module (e.g. `task-repeat-cfg/rrule/`). `typed → RRULE` is simple strin
 assembly (or `ICAL.Recur.fromData({...}).toString()`); `RRULE → typed` (for `.ics`
 import) uses ical.js parsing. Field mapping — must cover everything:
 
-| Typed model                                                                         | RRULE                                                                                                                                                                                                               |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{freq, interval}`                                                                  | `FREQ=...;INTERVAL=...`                                                                                                                                                                                             |
-| WEEKLY `byDay`                                                                      | `BYDAY=MO,WE,...`; for `INTERVAL>1`, `WKST` = weekday of the effective startDate — **never** user `firstDayOfWeek` (display-only). The epic branch instead emits no `WKST` and re-anchors via `getAlignedStartDate` |
-| MONTHLY `on.monthDay`                                                               | `BYMONTHDAY=<n>` for n ≤ 28; for 29–31 SP clamps to month-end where plain `BYMONTHDAY` skips — emit the clamp idiom `BYMONTHDAY=<n>,-1;BYSETPOS=1`                                                                  |
-| MONTHLY `on.lastDay`                                                                | `BYMONTHDAY=-1`                                                                                                                                                                                                     |
-| MONTHLY `on.{week,day}`                                                             | `BYDAY=<week><DD>` (`-1`=last)                                                                                                                                                                                      |
-| YEARLY `{month, day}`                                                               | `BYMONTH=<m>;BYMONTHDAY=<d>`; SP clamps Feb-29 → Feb-28 in non-leap years, and the clamp **has** an RFC equivalent — the same idiom (`BYMONTH=2;BYMONTHDAY=29,-1;BYSETPOS=1`)                                       |
-| `end.count` / `end.until`                                                           | `COUNT=` / `UNTIL=` (end-of-day UTC)                                                                                                                                                                                |
-| `exDates`                                                                           | `EXDATE` (export only; do not rename the wire field)                                                                                                                                                                |
-| `repeatFromCompletionDate`                                                          | **Not expressible** — serializer refuses/flags; such configs are export-incompatible by nature                                                                                                                      |
-| `startTime`, `remindAt`, `waitForCompletion`, `skipOverdue`, subtask flags, `order` | SP extensions, out of band of RRULE — preserve                                                                                                                                                                      |
+| Typed model                                                                         | RRULE                                                                                                                                                                                                                             |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{freq, interval}`                                                                  | `FREQ=...;INTERVAL=...`                                                                                                                                                                                                           |
+| WEEKLY `byDay`                                                                      | `BYDAY=MO,WE,...`; for `INTERVAL>1`, `WKST` = weekday of the effective startDate — **never** user `firstDayOfWeek` (display-only). The epic branch instead emits no `WKST` and re-anchors via `getAlignedStartDate`               |
+| MONTHLY `on.monthDay`                                                               | `BYMONTHDAY=<n>` for n ≤ 28; for 29–31 SP clamps to month-end where plain `BYMONTHDAY` skips — emit the clamp idiom `BYMONTHDAY=<n>,-1;BYSETPOS=1`                                                                                |
+| MONTHLY `on.lastDay`                                                                | `BYMONTHDAY=-1`                                                                                                                                                                                                                   |
+| MONTHLY `on.{week,day}`                                                             | `BYDAY=<week><DD>` (`-1`=last)                                                                                                                                                                                                    |
+| YEARLY `{month, day}`                                                               | `BYMONTH=<m>;BYMONTHDAY=<d>`; SP clamps Feb-29 → Feb-28 in non-leap years, and the clamp **has** an RFC equivalent — the same idiom (`BYMONTH=2;BYMONTHDAY=29,-1;BYSETPOS=1`)                                                     |
+| `end.count` / `end.until`                                                           | `COUNT=` / `UNTIL=` (end-of-day UTC)                                                                                                                                                                                              |
+| `deletedInstanceDates`                                                              | `EXDATE` (export only; the wire field name stays verbatim)                                                                                                                                                                        |
+| `repeatFromCompletionDate`                                                          | **Not expressible** — serializer refuses/flags; such configs are export-incompatible by nature                                                                                                                                    |
+| `startTime`, `remindAt`, `waitForCompletion`, `skipOverdue`, subtask flags, `order` | SP extensions, out of band of RRULE — preserve                                                                                                                                                                                    |
+| `isPaused`                                                                          | No RRULE equivalent. A paused cfg must **not** be exported as a live RRULE (it promises occurrences SP will never create) — serializer skips or flags it (`store/task-repeat-cfg.selectors.ts:102,142` short-circuits generation) |
+| `lastTaskCreationDay` / `lastTaskCreation`                                          | Internal creation cursor, out of band of RRULE — never exported, never derived from an imported rule                                                                                                                              |
+
+The three MONTHLY rows are **not independent** — the engine resolves one anchor
+with fixed precedence: nth-weekday (`monthlyWeekOfMonth` + `monthlyWeekday`,
+checked first at `get-next-repeat-occurrence.util.ts:110`) → `monthlyLastDay` →
+startDate's day-of-month. A row-by-row serializer that emits parts for a cfg
+carrying several anchors produces `BYMONTHDAY=-1;BYDAY=2TU` — in RFC 5545 an
+**intersection**, usually the empty set. Serialize exactly one anchor, in that
+precedence order (the epic branch's `legacyTaskRepeatCfgToRRule` switch does
+exactly this).
 
 ### 1.3 DTSTART / date-basis correctness (the part that bites)
 

--- a/docs/research/recurring-events-implementation-plan.md
+++ b/docs/research/recurring-events-implementation-plan.md
@@ -1,5 +1,14 @@
 # Recurring Events Implementation Plan
 
+> **Read `rrule-epic-roadmap.md` on `feat/rrule-epic` first.** This plan is the
+> _design rationale_ companion to a live epic, not a greenfield proposal. Much of
+> what follows is already implemented on that branch (forward/inverse RRULE
+> converters, the old-client compatibility contract, an off-by-default per-device
+> engine flag), and the branch resolved several questions this document still
+> poses as open. Check there before planning or building anything here. Note the
+> branch's implementation uses a **raw `rrule` string**, not the typed union
+> sketched below — reconcile the two before treating either as decided.
+
 > **Revision note (verified against code 2026-06-02).** Rewritten after two rounds
 > of multi-axis review against the actual codebase. The original draft was built on
 > three false premises and several sync-unsafe steps; a later "raw RRULE string as
@@ -244,14 +253,44 @@ Migrate via the live op-log schema system:
   `remote-ops-processing.service.ts`. The conversion itself is pure O(1)
   string/struct assembly per config — cheap even for many configs; the migration
   must **not** expand occurrences per config.
-- **Cross-version story (resolve the old-client contradiction):** you cannot both
-  retire the flat fields _and_ have old clients keep computing from them. The
-  decision is to gate via **`MIN_SUPPORTED_SCHEMA_VERSION`**: pre-typed clients
-  fall below the minimum and get the existing "update required"
-  (`VERSION_UNSUPPORTED`) flow before they can apply typed-model ops. State this as
-  a deliberate, breaking, update-required step with its UX consequence — it is the
-  real safety mechanism, not "atomic flip" (op-log migration is per-op on receive,
-  not a single fleet-wide transaction).
+- **Cross-version story (resolve the old-client contradiction).** _Corrected
+  2026-08 — see #9664._ An earlier revision of this bullet named
+  **`MIN_SUPPORTED_SCHEMA_VERSION`** as a "force-update gate" that would push
+  pre-typed clients through the `VERSION_UNSUPPORTED` flow. That is backwards.
+  It is a lower bound applied to data _this_ client reads
+  (`remote-ops-processing.service.ts:177`, `operation-log-sync.service.ts:2318`,
+  `verify-decrypted-op-integrity.ts:139`, `migrate.ts:49,115`); senders stamp
+  `CURRENT_SCHEMA_VERSION` only, and no server-side client-version gate exists.
+  Raising it would wedge the **updated** client — the block halts the cycle
+  before upload (`sync-wrapper.service.ts:595-606`), the cursor is not advanced,
+  and the `VERSION_UNSUPPORTED` snack deliberately carries no remedy
+  (`remote-ops-processing.service.ts:540-546`, "updating THIS device cannot
+  help"). It never prompts the old device. **There is no version gate here.**
+
+  Nor does a `CURRENT_SCHEMA_VERSION` bump supply one for the _currently
+  released_ fleet: master is at 4, so a bump lands on 5 — inside the
+  v17.0.0–v18.14.0 tolerated band (`2 + 3`) — and those clients apply the ops
+  **unmigrated**; a bump to 6 blocks them but still advances their cursor,
+  permanently skipping the ops. (Post-v18.14.0 receivers _do_ block safely, so a
+  bump becomes a real fence once that cohort ages out.) See
+  `packages/shared-schema/src/schema-version.ts` and
+  `docs/sync-and-op-log/operation-log-architecture.md` §A.7.11.
+
+- **The mechanism that actually solves this is already built on
+  `feat/rrule-epic`** — do not re-derive it. The legacy schedule fields stay
+  populated alongside the new representation as the wire format for old clients
+  (`util/legacy-cfg-to-rrule.util.ts`), under an **exact-or-null contract**:
+  where the rule is within legacy expressiveness the legacy fields fire on the
+  same days; where it is not (`COUNT`/`UNTIL`, seasonal `BYMONTH`,
+  `BYWEEKNO`/`BYYEARDAY`, multi-day lists, out-of-union ordinals) the
+  `LEGACY_NEVER_FIRES_FALLBACK` sentinel is written instead — an all-false
+  `WEEKLY` cfg, which every released version deterministically never fires. Old
+  clients create **nothing** rather than tasks on wrong days that would sync
+  back. `getAlignedStartDate` handles `startDate`'s double duty as both the
+  monthly/yearly day encoding and the interval anchor. The off-by-default
+  per-device flag (`RRuleFeatureFlagService`, localStorage, never synced) keeps
+  the legacy engine authoritative while the epic is incomplete — that flag, not
+  a schema gate, is what makes half-built phases safe.
 - **Never rename `deletedInstanceDates` on the wire.** Keep the synced field name;
   `exDates` is the in-memory/typed name and `EXDATE` the export name. Under
   whole-entity LWW, an old client that wins a conflict re-emits the entity without
@@ -300,20 +339,20 @@ So the real risk is feeding a **wrong DTSTART/anchor**, not "wrong engine":
 
 ## Risk register
 
-| Risk                                                                    | Severity    | Mitigation                                                                     |
-| ----------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------ |
-| Occurrence dates shift on model swap → re-keyed instances               | **Blocker** | Keep the existing bounded engine; Phase-1 golden master gates migration        |
-| Cross-version sync: old client can't read typed model                   | **Blocker** | `MIN_SUPPORTED_SCHEMA_VERSION` force-update gate (not "compute from legacy")   |
-| Renaming the `deletedInstanceDates` wire key loses skip data            | High        | Do not rename the persisted key; `EXDATE` only at export                       |
-| `repeatFromCompletionDate` fed a fixed DTSTART → becomes fixed-calendar | High        | Route completion mode before any fixed-anchor path; re-anchor per cycle        |
-| Wrong migration subsystem (`pfapi-config.js`)                           | High        | Use `packages/shared-schema` migrations + `schema-migration.service.ts`        |
-| Hot-path regression from async/forward-only ical.js iteration           | High        | ical.js for string parse/serialize only; sync bounded engine stays the runtime |
-| DTSTART carries `startTime` → day rolls                                 | High        | DTSTART = local-noon of anchor day; `startTime` applied post-expansion         |
-| EXDATE never matches (instant vs noon)                                  | Medium      | Filter by `getDbDateStr` day-string                                            |
-| Bi-weekly shifts (WKST default)                                         | Medium      | Thread `firstDayOfWeek` → `WKST`                                               |
-| `UNTIL` drops final day                                                 | Medium      | Inclusive end-of-day                                                           |
-| ~~Production shadow mode cost~~                                         | n/a         | Not needed — engine unchanged; offline golden master covers parity             |
-| ~~Bundle size of new dep~~                                              | n/a         | No new dep — ical.js already present & lazy-loaded                             |
+| Risk                                                                    | Severity    | Mitigation                                                                                                                                                                                       |
+| ----------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Occurrence dates shift on model swap → re-keyed instances               | **Blocker** | Keep the existing bounded engine; Phase-1 golden master gates migration                                                                                                                          |
+| Cross-version sync: old client can't read typed model                   | **Blocker** | No version gate exists (#9664). Keep legacy fields populated on the wire under the exact-or-null contract; `LEGACY_NEVER_FIRES_FALLBACK` for inexpressible rules; per-device flag gates the epic |
+| Renaming the `deletedInstanceDates` wire key loses skip data            | High        | Do not rename the persisted key; `EXDATE` only at export                                                                                                                                         |
+| `repeatFromCompletionDate` fed a fixed DTSTART → becomes fixed-calendar | High        | Route completion mode before any fixed-anchor path; re-anchor per cycle                                                                                                                          |
+| Wrong migration subsystem (`pfapi-config.js`)                           | High        | Use `packages/shared-schema` migrations + `schema-migration.service.ts`                                                                                                                          |
+| Hot-path regression from async/forward-only ical.js iteration           | High        | ical.js for string parse/serialize only; sync bounded engine stays the runtime                                                                                                                   |
+| DTSTART carries `startTime` → day rolls                                 | High        | DTSTART = local-noon of anchor day; `startTime` applied post-expansion                                                                                                                           |
+| EXDATE never matches (instant vs noon)                                  | Medium      | Filter by `getDbDateStr` day-string                                                                                                                                                              |
+| Bi-weekly shifts (WKST default)                                         | Medium      | Thread `firstDayOfWeek` → `WKST`                                                                                                                                                                 |
+| `UNTIL` drops final day                                                 | Medium      | Inclusive end-of-day                                                                                                                                                                             |
+| ~~Production shadow mode cost~~                                         | n/a         | Not needed — engine unchanged; offline golden master covers parity                                                                                                                               |
+| ~~Bundle size of new dep~~                                              | n/a         | No new dep — ical.js already present & lazy-loaded                                                                                                                                               |
 
 ---
 
@@ -346,7 +385,8 @@ So the real risk is feeding a **wrong DTSTART/anchor**, not "wrong engine":
 | Quick settings / dialog UI                                           | `dialog-edit-task-repeat-cfg/` (form const, quick-setting updates, build options)                                                                                                                                                                                                      |
 | Human-readable text                                                  | `src/app/features/tasks/task-detail-panel/get-task-repeat-info-text.util.ts`                                                                                                                                                                                                           |
 | RRULE serialize/parse (boundary only)                                | `src/app/features/schedule/ical/ical-lazy-loader.ts` (reuse loader)                                                                                                                                                                                                                    |
-| Migration (corrected)                                                | `packages/shared-schema/src/migrations/` (+ `index.ts`), `packages/shared-schema/src/schema-version.ts` (`CURRENT_SCHEMA_VERSION`, `MIN_SUPPORTED_SCHEMA_VERSION`), `src/app/op-log/persistence/schema-migration.service.ts`                                                           |
+| Migration (corrected)                                                | `packages/shared-schema/src/migrations/` (+ `index.ts`), `packages/shared-schema/src/schema-version.ts` (`CURRENT_SCHEMA_VERSION` — note `MIN_SUPPORTED_SCHEMA_VERSION` is _not_ a cross-version gate, #9664), `src/app/op-log/persistence/schema-migration.service.ts`                |
+| Old-client wire compatibility (already built on `feat/rrule-epic`)   | `src/app/features/task-repeat-cfg/util/legacy-cfg-to-rrule.util.ts` (`legacyTaskRepeatCfgToRRule`, `rruleToLegacyTaskRepeatCfg`, `LEGACY_NEVER_FIRES_FALLBACK`, `getAlignedStartDate`), `src/app/features/config/rrule-feature-flag.service.ts`                                        |
 | Validation / repair                                                  | `src/app/op-log/validation/` (`createValidate`, `data-repair.ts`)                                                                                                                                                                                                                      |
 | Calendar roadmap (note: predates #6040/#7726/`deletedInstanceDates`) | `docs/long-term-plans/calendar-two-way-sync-technical-analysis.md` (CalDAV VEVENT expansion shipped as the `caldav-calendar-provider` plugin)                                                                                                                                          |
 

--- a/docs/research/recurring-events-implementation-plan.md
+++ b/docs/research/recurring-events-implementation-plan.md
@@ -15,8 +15,8 @@
 > the model" revision was then corrected again after review surfaced real costs in
 > this codebase. Net premises now driving the plan:
 >
-> 1. **The RRULE engine is already in the repo.** `ical.js@2.2.1` is a dependency,
->    lazy-loaded (`src/app/features/schedule/ical/ical-lazy-loader.ts`), and
+> 1. **The RRULE engine is already in the repo.** `ical.js@2.2.1` is already in
+>    `package.json` (a **devDependency**, not `dependencies`), lazy-loaded (`src/app/features/schedule/ical/ical-lazy-loader.ts`), and
 >    expands RRULEs in **two** places
 >    (`get-relevant-events-from-ical.ts`,
 >    `packages/plugin-dev/caldav-calendar-provider/src/plugin.ts`).
@@ -137,7 +137,7 @@ Verified in `src/app/features/task-repeat-cfg/`:
 | Daily / Weekly / Monthly / Yearly + `repeatEvery` interval | ✅             | `get-next-repeat-occurrence.util.ts`                                              |
 | Weekday selection (weekly)                                 | ✅             | 7 booleans, `task-repeat-cfg.model.ts`                                            |
 | **Nth weekday of month** ("2nd Tue", "last Fri")           | ✅ #6040       | `monthlyWeekOfMonth` + `monthlyWeekday`; `get-nth-weekday-of-month.util.ts`       |
-| **Last day of month**                                      | ✅ #7726       | `monthlyLastDay`; month-end clamp in `get-next-repeat-occurrence.util.ts:101-116` |
+| **Last day of month**                                      | ✅ #7726       | `monthlyLastDay`; month-end clamp in `get-next-repeat-occurrence.util.ts:125-140` |
 | First day of month                                         | ✅             | quick-setting `MONTHLY_FIRST_DAY`                                                 |
 | Skip occurrence (EXDATE)                                   | ✅             | `deletedInstanceDates: string[]`                                                  |
 | After-completion recurrence                                | ✅ (SP-unique) | `repeatFromCompletionDate` + `getEffectiveRepeatStartDate`                        |
@@ -152,8 +152,11 @@ Verified in `src/app/features/task-repeat-cfg/`:
 
 **Genuinely missing (delivered in Phase 3):** end conditions (`COUNT`/`UNTIL`),
 multiple days per month (`BYMONTHDAY=1,15`), `.ics`/CalDAV RRULE generation
-(Phase 1). Deferred / YAGNI: `RDATE`, `RECURRENCE-ID`, `BYSETPOS`, `BYWEEKNO`,
-`BYYEARDAY`, sub-daily, full two-way `.ics` import.
+(Phase 1). Deferred / YAGNI: `RDATE`, `RECURRENCE-ID`, `BYWEEKNO`, `BYYEARDAY`,
+sub-daily, full two-way `.ics` import. `BYSETPOS` is **not** wholly deferrable:
+the serializer's month-end clamp idiom `BYMONTHDAY=<d>,-1;BYSETPOS=1` (see the
+Phase-1 mapping table) needs it at the boundary; only general engine-side
+`BYSETPOS` expansion stays deferred.
 
 ---
 
@@ -173,7 +176,7 @@ Consequences:
   shape), so the deterministic-ID parity risk is small and an **offline
   golden-master test is sufficient — no production shadow mode required**.
 - New common patterns (multi-day-per-month, end conditions) are small extensions
-  to the bounded engine. Exotic RRULE parts (`BYSETPOS`, `BYWEEKNO`) are not free;
+  to the bounded engine. Exotic RRULE parts (general `BYSETPOS`, `BYWEEKNO`) are not free;
   defer them, and if ever needed, expand those rare configs via ical.js _off_ the
   hot path.
 
@@ -198,31 +201,40 @@ A pure module (e.g. `task-repeat-cfg/rrule/`). `typed → RRULE` is simple strin
 assembly (or `ICAL.Recur.fromData({...}).toString()`); `RRULE → typed` (for `.ics`
 import) uses ical.js parsing. Field mapping — must cover everything:
 
-| Typed model                                                                         | RRULE                                                                                          |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `{freq, interval}`                                                                  | `FREQ=...;INTERVAL=...`                                                                        |
-| WEEKLY `byDay`                                                                      | `BYDAY=MO,WE,...` (+ `WKST` from user `firstDayOfWeek`)                                        |
-| MONTHLY `on.monthDay`                                                               | `BYMONTHDAY=<n>`                                                                               |
-| MONTHLY `on.lastDay`                                                                | `BYMONTHDAY=-1`                                                                                |
-| MONTHLY `on.{week,day}`                                                             | `BYDAY=<week><DD>` (`-1`=last)                                                                 |
-| YEARLY `{month, day}`                                                               | `BYMONTH=<m>;BYMONTHDAY=<d>` (document Feb-29 → Feb-28; no RFC equivalent)                     |
-| `end.count` / `end.until`                                                           | `COUNT=` / `UNTIL=` (end-of-day UTC)                                                           |
-| `exDates`                                                                           | `EXDATE` (export only; do not rename the wire field)                                           |
-| `repeatFromCompletionDate`                                                          | **Not expressible** — serializer refuses/flags; such configs are export-incompatible by nature |
-| `startTime`, `remindAt`, `waitForCompletion`, `skipOverdue`, subtask flags, `order` | SP extensions, out of band of RRULE — preserve                                                 |
+| Typed model                                                                         | RRULE                                                                                                                                                                                                               |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{freq, interval}`                                                                  | `FREQ=...;INTERVAL=...`                                                                                                                                                                                             |
+| WEEKLY `byDay`                                                                      | `BYDAY=MO,WE,...`; for `INTERVAL>1`, `WKST` = weekday of the effective startDate — **never** user `firstDayOfWeek` (display-only). The epic branch instead emits no `WKST` and re-anchors via `getAlignedStartDate` |
+| MONTHLY `on.monthDay`                                                               | `BYMONTHDAY=<n>` for n ≤ 28; for 29–31 SP clamps to month-end where plain `BYMONTHDAY` skips — emit the clamp idiom `BYMONTHDAY=<n>,-1;BYSETPOS=1`                                                                  |
+| MONTHLY `on.lastDay`                                                                | `BYMONTHDAY=-1`                                                                                                                                                                                                     |
+| MONTHLY `on.{week,day}`                                                             | `BYDAY=<week><DD>` (`-1`=last)                                                                                                                                                                                      |
+| YEARLY `{month, day}`                                                               | `BYMONTH=<m>;BYMONTHDAY=<d>`; SP clamps Feb-29 → Feb-28 in non-leap years, and the clamp **has** an RFC equivalent — the same idiom (`BYMONTH=2;BYMONTHDAY=29,-1;BYSETPOS=1`)                                       |
+| `end.count` / `end.until`                                                           | `COUNT=` / `UNTIL=` (end-of-day UTC)                                                                                                                                                                                |
+| `exDates`                                                                           | `EXDATE` (export only; do not rename the wire field)                                                                                                                                                                |
+| `repeatFromCompletionDate`                                                          | **Not expressible** — serializer refuses/flags; such configs are export-incompatible by nature                                                                                                                      |
+| `startTime`, `remindAt`, `waitForCompletion`, `skipOverdue`, subtask flags, `order` | SP extensions, out of band of RRULE — preserve                                                                                                                                                                      |
 
 ### 1.3 DTSTART / date-basis correctness (the part that bites)
 
 - **DTSTART is local-noon of the anchor day, time component stripped.** The legacy
   engine never uses `startTime` for date math — it anchors at `setHours(12,…)`
-  (`get-next-repeat-occurrence.util.ts:36`). A non-noon DTSTART makes ical.js emit
+  (`get-next-repeat-occurrence.util.ts:43-45`). A non-noon DTSTART makes ical.js emit
   occurrences at a different instant that can roll to a different **calendar day**
   across a day/DST boundary → broken parity and shifted IDs. `startTime` stays a
   post-expansion task-template field, not part of DTSTART date math.
 - **EXDATE by day-string**, not instant equality: filter generated occurrences by
   `getDbDateStr(occurrence)` against `exDates`.
 - **`UNTIL` is inclusive end-of-day.**
-- **`WKST` from `firstDayOfWeek`**, or bi-weekly (`INTERVAL=2`) occurrences shift.
+- **`WKST` = weekday of the effective startDate** — or emit no `WKST` and
+  re-anchor DTSTART instead, as the epic branch does (`getAlignedStartDate`).
+  **Not** user `firstDayOfWeek`: that setting is display-only
+  (`src/app/core/date-time-format/custom-date-adapter.ts:19`). The engine counts
+  rolling 7-day blocks from the startDate's weekday
+  (`getDiffInWeeks(startDate, d) % repeatEvery`,
+  `get-next-repeat-occurrence.util.ts:88,95-96`), so a calendar-week `WKST`
+  shifts bi-weekly (`INTERVAL=2`) occurrences. Counterexample: startDate Wed
+  2026-01-07, `INTERVAL=2`, `BYDAY=MO,FR` — SP fires Mon 01-12; `WKST=MO` fires
+  Mon 01-19.
 
 ### 1.4 Occurrence-parity golden master (the gate)
 
@@ -349,7 +361,7 @@ So the real risk is feeding a **wrong DTSTART/anchor**, not "wrong engine":
 | Hot-path regression from async/forward-only ical.js iteration           | High        | ical.js for string parse/serialize only; sync bounded engine stays the runtime                                                                                                                   |
 | DTSTART carries `startTime` → day rolls                                 | High        | DTSTART = local-noon of anchor day; `startTime` applied post-expansion                                                                                                                           |
 | EXDATE never matches (instant vs noon)                                  | Medium      | Filter by `getDbDateStr` day-string                                                                                                                                                              |
-| Bi-weekly shifts (WKST default)                                         | Medium      | Thread `firstDayOfWeek` → `WKST`                                                                                                                                                                 |
+| Bi-weekly shifts (WKST default)                                         | Medium      | `WKST` = weekday of effective startDate (never display-only `firstDayOfWeek`), or omit `WKST` and re-anchor (`getAlignedStartDate`)                                                              |
 | `UNTIL` drops final day                                                 | Medium      | Inclusive end-of-day                                                                                                                                                                             |
 | ~~Production shadow mode cost~~                                         | n/a         | Not needed — engine unchanged; offline golden master covers parity                                                                                                                               |
 | ~~Bundle size of new dep~~                                              | n/a         | No new dep — ical.js already present & lazy-loaded                                                                                                                                               |

--- a/docs/research/recurring-events-implementation-plan.md
+++ b/docs/research/recurring-events-implementation-plan.md
@@ -22,7 +22,9 @@
 >    (`get-relevant-events-from-ical.ts`,
 >    `packages/plugin-dev/caldav-calendar-provider/src/plugin.ts`).
 >    `caldav-client.service.ts` uses ical.js only to parse VTODO — it does **not**
->    expand RRULEs. **Do not add `rrule` (rrule.js).**
+>    expand RRULEs. **Do not add `rrule` (rrule.js).** _(Superseded on this
+>    point: the epic added pinned `rrule@2.8.1` as its engine — see the
+>    Decision note.)_
 > 2. **The headline "critical gaps" already shipped.** Nth-weekday of month
 >    (#6040), last-day-of-month (#7726), EXDATE (`deletedInstanceDates`). Earlier
 >    gap-analysis/industry-standards research drafts marked these missing; that was
@@ -402,10 +404,10 @@ So the real risk is feeding a **wrong DTSTART/anchor**, not "wrong engine":
 | Hot-path regression from async/forward-only ical.js iteration           | High        | ical.js for string parse/serialize only; sync bounded engine stays the runtime                                                                                                                   |
 | DTSTART carries `startTime` → day rolls                                 | High        | DTSTART = local-noon of anchor day; `startTime` applied post-expansion                                                                                                                           |
 | EXDATE never matches (instant vs noon)                                  | Medium      | Filter by `getDbDateStr` day-string                                                                                                                                                              |
-| Bi-weekly shifts (WKST default)                                         | Medium      | Startdate-derived WKST, or omit + re-anchor — see 1.3                                                                                                                                            |
+| Bi-weekly shifts (WKST default)                                         | Medium      | startDate-derived WKST, or omit + re-anchor — see 1.3                                                                                                                                            |
 | `UNTIL` drops final day                                                 | Medium      | Inclusive end-of-day                                                                                                                                                                             |
 | ~~Production shadow mode cost~~                                         | n/a         | Not needed — engine unchanged; offline golden master covers parity                                                                                                                               |
-| ~~Bundle size of new dep~~                                              | n/a         | No new dep — ical.js already present & lazy-loaded                                                                                                                                               |
+| ~~Bundle size of new dep~~                                              | n/a         | No new dep in the typed-model plan (the epic did add pinned `rrule` — see the Decision note)                                                                                                     |
 
 ---
 
@@ -415,7 +417,8 @@ So the real risk is feeding a **wrong DTSTART/anchor**, not "wrong engine":
    config-shape corpus over a 5-year window, both CI timezones; harness green in CI.
 2. **Serializer round-trips** `typed → RRULE → typed` for every shape
    (property-tested), incl. monthly-nth-weekday and last-day.
-3. **No new runtime dependency** (ical.js only, boundary-only).
+3. **No new runtime dependency** (ical.js only, boundary-only). _(Superseded —
+   the epic deliberately added pinned `rrule`; see the Decision note.)_
 4. **No synced field key renamed** (`deletedInstanceDates` stays on the wire).
 5. **Forward-compat:** an old client reading the new fields neither errors nor
    strips them (regression spec).

--- a/docs/research/recurring-events-implementation-plan.md
+++ b/docs/research/recurring-events-implementation-plan.md
@@ -7,10 +7,8 @@
 > engine flag), and the branch resolved several questions this document still
 > poses as open. Check there before planning or building anything here.
 >
-> **Reconciled 2026-08-21: the branch's raw-`rrule`-string design stands; the
-> typed-union sketch below is superseded** (kept as rationale record). The
-> rejection reasoning below was checked against the branch and does not hold
-> against its actual design — see "Why the raw-string rejection was stale".
+> **Reconciled 2026-08-21: the branch's raw-`rrule`-string design stands** —
+> see the Decision note below for what is superseded and why it is kept.
 
 > **Revision note (verified against code 2026-06-02).** Rewritten after two rounds
 > of multi-axis review against the actual codebase. The original draft was built on
@@ -54,8 +52,7 @@ replacing the ~14 interdependent flat fields (`repeatCycle`, `repeatEvery`, the
 `quickSetting`).
 
 The RFC-5545 **RRULE string is produced/parsed only at the boundary** (`.ics`
-export, CalDAV). **The raw string is never the persisted/synced field.** (This
-last line is precisely what the epic decided differently.)
+export, CalDAV). **The raw string is never the persisted/synced field.**
 
 ### Why the raw-string rejection was stale (reconciled 2026-08-21)
 
@@ -78,9 +75,10 @@ objection is answered by a design decision the rejection did not anticipate:
 - **"Hot-path performance."** The objection assumed the expansion engine would
   be ical.js (async, lazy-loaded, forward-only). The branch's engine is
   **rrule.js (`rrule@2.8.1`, pinned exact) — synchronous** — in a dedicated
-  day-granular, UTC-based occurrence util (`store/rrule-occurrence.util.ts`)
-  with memoised validity probing. It runs inside the existing sync calculators;
-  no async dependency enters the selector path.
+  day-granular, UTC-based occurrence util (`store/rrule-occurrence.util.ts`).
+  It runs inside the existing sync calculators; no async dependency enters the
+  selector path. (Implementation specifics live on the branch — the roadmap is
+  the source of truth for current mechanics.)
 
 The one cost the old reasoning weighed correctly: **`rrule` is a new root
 runtime dependency**, which the project rules normally forbid. The
@@ -108,10 +106,9 @@ and do not un-pin the version.
 
 ## The typed model (superseded — kept as rationale record)
 
-> Superseded by the epic's `rrule?: string` + legacy dual-write (see above).
-> Preserved because the invariant analysis below (what a discriminated union
-> makes unrepresentable) is the best record of the legacy fields' implicit
-> precedence rules.
+> Superseded — see the Decision note above. Kept because the invariant
+> analysis below is the best record of the legacy fields' implicit precedence
+> rules.
 
 The sketch replaced the flat pattern fields in `TaskRepeatCfgCopy`
 (`task-repeat-cfg.model.ts` — edit `TaskRepeatCfgCopy`, not the `Readonly` alias)
@@ -122,7 +119,7 @@ type Weekday = 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU';
 
 type RecurrencePattern =
   | { freq: 'DAILY'; interval: number }
-  | { freq: 'WEEKLY'; interval: number; byDay: Weekday[] } // WKST is derived (weekday of effective startDate), never persisted
+  | { freq: 'WEEKLY'; interval: number; byDay: Weekday[] } // WKST derived, never persisted — see 1.3
   | { freq: 'MONTHLY'; interval: number; on: { monthDay: number } } // BYMONTHDAY=n
   | { freq: 'MONTHLY'; interval: number; on: { lastDay: true } } // BYMONTHDAY=-1
   | { freq: 'MONTHLY'; interval: number; on: { week: 1 | 2 | 3 | 4 | -1; day: Weekday } } // BYDAY=nDD
@@ -178,21 +175,18 @@ Verified in `src/app/features/task-repeat-cfg/`:
 **Genuinely missing (delivered in Phase 3):** end conditions (`COUNT`/`UNTIL`),
 multiple days per month (`BYMONTHDAY=1,15`), `.ics`/CalDAV RRULE generation
 (Phase 1). Deferred / YAGNI: `RDATE`, `RECURRENCE-ID`, `BYWEEKNO`, `BYYEARDAY`,
-sub-daily, full two-way `.ics` import. `BYSETPOS` is **not** wholly deferrable:
-the serializer's month-end clamp idiom `BYMONTHDAY=<d>,-1;BYSETPOS=1` (see the
-Phase-1 mapping table) needs it at the boundary; only general engine-side
-`BYSETPOS` expansion stays deferred.
+sub-daily, full two-way `.ics` import. `BYSETPOS`: needed only for the
+serializer's month-end clamp idiom (see the Phase-1 mapping table); general
+engine-side expansion stays deferred.
 
 ---
 
 ## Engine decision: keep the synchronous bounded engine
 
-> _Reconciled:_ this holds for legacy/flag-off cfgs — the branch keeps the
-> bounded loops authoritative there. For cfgs carrying an `rrule` string with
-> the flag on, the branch routes to its **synchronous** rrule.js engine
-> (`store/rrule-occurrence.util.ts`); ical.js remains boundary-only either way.
-> The paragraph below records why ical.js must never become the occurrence
-> runtime, which still stands.
+> _Reconciled:_ holds for legacy/flag-off cfgs; flag-on `rrule` cfgs route to
+> the branch's synchronous rrule.js engine (see "Why the raw-string rejection
+> was stale"). ical.js stays boundary-only either way — the paragraph below
+> records why, and still stands.
 
 **The occurrence runtime stays the existing synchronous bounded loops**
 (`get-next-repeat-occurrence.util.ts`, `get-newest-possible-due-date.util.ts`),
@@ -233,20 +227,24 @@ A pure module (e.g. `task-repeat-cfg/rrule/`). `typed → RRULE` is simple strin
 assembly (or `ICAL.Recur.fromData({...}).toString()`); `RRULE → typed` (for `.ics`
 import) uses ical.js parsing. Field mapping — must cover everything:
 
-| Typed model                                                                         | RRULE                                                                                                                                                                                                                             |
-| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{freq, interval}`                                                                  | `FREQ=...;INTERVAL=...`                                                                                                                                                                                                           |
-| WEEKLY `byDay`                                                                      | `BYDAY=MO,WE,...`; for `INTERVAL>1`, `WKST` = weekday of the effective startDate — **never** user `firstDayOfWeek` (display-only). The epic branch instead emits no `WKST` and re-anchors via `getAlignedStartDate`               |
-| MONTHLY `on.monthDay`                                                               | `BYMONTHDAY=<n>` for n ≤ 28; for 29–31 SP clamps to month-end where plain `BYMONTHDAY` skips — emit the clamp idiom `BYMONTHDAY=<n>,-1;BYSETPOS=1`                                                                                |
-| MONTHLY `on.lastDay`                                                                | `BYMONTHDAY=-1`                                                                                                                                                                                                                   |
-| MONTHLY `on.{week,day}`                                                             | `BYDAY=<week><DD>` (`-1`=last)                                                                                                                                                                                                    |
-| YEARLY `{month, day}`                                                               | `BYMONTH=<m>;BYMONTHDAY=<d>`; SP clamps Feb-29 → Feb-28 in non-leap years, and the clamp **has** an RFC equivalent — the same idiom (`BYMONTH=2;BYMONTHDAY=29,-1;BYSETPOS=1`)                                                     |
-| `end.count` / `end.until`                                                           | `COUNT=` / `UNTIL=` (end-of-day UTC)                                                                                                                                                                                              |
-| `deletedInstanceDates`                                                              | `EXDATE` (export only; the wire field name stays verbatim)                                                                                                                                                                        |
-| `repeatFromCompletionDate`                                                          | **Not expressible** — serializer refuses/flags; such configs are export-incompatible by nature                                                                                                                                    |
-| `startTime`, `remindAt`, `waitForCompletion`, `skipOverdue`, subtask flags, `order` | SP extensions, out of band of RRULE — preserve                                                                                                                                                                                    |
-| `isPaused`                                                                          | No RRULE equivalent. A paused cfg must **not** be exported as a live RRULE (it promises occurrences SP will never create) — serializer skips or flags it (`store/task-repeat-cfg.selectors.ts:102,142` short-circuits generation) |
-| `lastTaskCreationDay` / `lastTaskCreation`                                          | Internal creation cursor, out of band of RRULE — never exported, never derived from an imported rule                                                                                                                              |
+| Typed model                                                                         | RRULE                                                                                                                                 |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `{freq, interval}`                                                                  | `FREQ=...;INTERVAL=...`                                                                                                               |
+| WEEKLY `byDay`                                                                      | `BYDAY=MO,WE,...` (WKST: see 1.3)                                                                                                     |
+| MONTHLY `on.monthDay`                                                               | `BYMONTHDAY=<n>` (n ≤ 28); 29–31 → clamp idiom `BYMONTHDAY=<n>,-1;BYSETPOS=1` (SP clamps to month-end, plain `BYMONTHDAY` skips)      |
+| MONTHLY `on.lastDay`                                                                | `BYMONTHDAY=-1`                                                                                                                       |
+| MONTHLY `on.{week,day}`                                                             | `BYDAY=<week><DD>` (`-1`=last)                                                                                                        |
+| YEARLY `{month, day}`                                                               | `BYMONTH=<m>;BYMONTHDAY=<d>`; Feb-29 → same clamp idiom (`BYMONTH=2;BYMONTHDAY=29,-1;BYSETPOS=1`, clamps to Feb-28 in non-leap years) |
+| `end.count` / `end.until`                                                           | `COUNT=` / `UNTIL=` (end-of-day UTC)                                                                                                  |
+| `deletedInstanceDates`                                                              | `EXDATE` (export only; the wire field name stays verbatim)                                                                            |
+| `repeatFromCompletionDate`                                                          | **Not expressible** — serializer refuses/flags; such configs are export-incompatible by nature                                        |
+| `startTime`, `remindAt`, `waitForCompletion`, `skipOverdue`, subtask flags, `order` | SP extensions, out of band of RRULE — preserve                                                                                        |
+| `isPaused`                                                                          | No RRULE equivalent — serializer skips or flags a paused cfg (see below)                                                              |
+| `lastTaskCreationDay` / `lastTaskCreation`                                          | Internal creation cursor, out of band of RRULE — never exported, never derived from an imported rule                                  |
+
+`isPaused` short-circuits all occurrence generation
+(`store/task-repeat-cfg.selectors.ts:102,142`), so exporting a paused cfg as a
+live RRULE would promise occurrences SP never creates.
 
 The three MONTHLY rows are **not independent** — the engine resolves one anchor
 with fixed precedence: nth-weekday (`monthlyWeekOfMonth` + `monthlyWeekday`,
@@ -404,7 +402,7 @@ So the real risk is feeding a **wrong DTSTART/anchor**, not "wrong engine":
 | Hot-path regression from async/forward-only ical.js iteration           | High        | ical.js for string parse/serialize only; sync bounded engine stays the runtime                                                                                                                   |
 | DTSTART carries `startTime` → day rolls                                 | High        | DTSTART = local-noon of anchor day; `startTime` applied post-expansion                                                                                                                           |
 | EXDATE never matches (instant vs noon)                                  | Medium      | Filter by `getDbDateStr` day-string                                                                                                                                                              |
-| Bi-weekly shifts (WKST default)                                         | Medium      | `WKST` = weekday of effective startDate (never display-only `firstDayOfWeek`), or omit `WKST` and re-anchor (`getAlignedStartDate`)                                                              |
+| Bi-weekly shifts (WKST default)                                         | Medium      | Startdate-derived WKST, or omit + re-anchor — see 1.3                                                                                                                                            |
 | `UNTIL` drops final day                                                 | Medium      | Inclusive end-of-day                                                                                                                                                                             |
 | ~~Production shadow mode cost~~                                         | n/a         | Not needed — engine unchanged; offline golden master covers parity                                                                                                                               |
 | ~~Bundle size of new dep~~                                              | n/a         | No new dep — ical.js already present & lazy-loaded                                                                                                                                               |

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.spec.ts
@@ -2968,6 +2968,108 @@ describe('TaskRepeatCfgEffects - Repeatable Subtasks', () => {
         done();
       }, 0);
     });
+
+    // Editing a monthly anchor ("2nd Tuesday" -> "3rd Tuesday", or toggling
+    // last-day-of-month) changes which day the next occurrence lands on, just
+    // like editing the weekly weekday booleans does -- but the monthly anchor
+    // fields were missing from SCHEDULE_AFFECTING_FIELDS, so the live instance
+    // silently stayed on the old day.
+    it('reschedules the live instance when only the monthly nth-weekday anchor changes', () => {
+      const today = new Date();
+      const todayStr = getDbDateStr(today);
+
+      const liveTask: Task = {
+        ...mockTask,
+        isDone: false,
+        dueDay: todayStr,
+        created: today.getTime(),
+      };
+
+      const updatedCfg: TaskRepeatCfgCopy = {
+        ...mockRepeatCfg,
+        repeatCycle: 'MONTHLY',
+        repeatEvery: 1,
+        startDate: todayStr,
+        monthlyWeekOfMonth: 2,
+        monthlyWeekday: 2,
+      };
+      const expectedOccurrence = getNextRepeatOccurrence(updatedCfg as any, new Date(), {
+        inclusive: true,
+      })!;
+      const expectedDayStr = getDbDateStr(expectedOccurrence);
+
+      const action = updateTaskRepeatCfg({
+        taskRepeatCfg: {
+          id: 'repeat-cfg-id',
+          changes: { monthlyWeekOfMonth: 2, monthlyWeekday: 2 },
+        },
+      });
+
+      actions$ = of(action);
+      taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(of(updatedCfg));
+      taskService.getTasksByRepeatCfgId$.and.returnValue(of([liveTask]));
+
+      const emitted: Action[] = [];
+      effects.rescheduleTaskOnRepeatCfgUpdate$.subscribe((result) =>
+        emitted.push(result),
+      );
+
+      expect(emitted).toEqual([
+        PlannerActions.planTaskForDay({ task: liveTask as any, day: expectedDayStr }),
+      ]);
+      expect(taskRepeatCfgService.updateTaskRepeatCfg).toHaveBeenCalledWith(
+        'repeat-cfg-id',
+        jasmine.objectContaining({ lastTaskCreationDay: expectedDayStr }),
+      );
+    });
+
+    it('reschedules the live instance when only monthlyLastDay changes', () => {
+      const today = new Date();
+      const todayStr = getDbDateStr(today);
+
+      const liveTask: Task = {
+        ...mockTask,
+        isDone: false,
+        dueDay: todayStr,
+        created: today.getTime(),
+      };
+
+      const updatedCfg: TaskRepeatCfgCopy = {
+        ...mockRepeatCfg,
+        repeatCycle: 'MONTHLY',
+        repeatEvery: 1,
+        startDate: todayStr,
+        monthlyLastDay: true,
+      };
+      const expectedOccurrence = getNextRepeatOccurrence(updatedCfg as any, new Date(), {
+        inclusive: true,
+      })!;
+      const expectedDayStr = getDbDateStr(expectedOccurrence);
+
+      const action = updateTaskRepeatCfg({
+        taskRepeatCfg: {
+          id: 'repeat-cfg-id',
+          changes: { monthlyLastDay: true },
+        },
+      });
+
+      actions$ = of(action);
+      taskRepeatCfgService.getTaskRepeatCfgById$.and.returnValue(of(updatedCfg));
+      taskService.getTasksByRepeatCfgId$.and.returnValue(of([liveTask]));
+
+      const emitted: Action[] = [];
+      effects.rescheduleTaskOnRepeatCfgUpdate$.subscribe((result) =>
+        emitted.push(result),
+      );
+
+      expect(emitted).toEqual([
+        PlannerActions.planTaskForDay({ task: liveTask as any, day: expectedDayStr }),
+      ]);
+      expect(taskRepeatCfgService.updateTaskRepeatCfg).toHaveBeenCalledWith(
+        'repeat-cfg-id',
+        jasmine.objectContaining({ lastTaskCreationDay: expectedDayStr }),
+      );
+    });
   });
 });
 

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
@@ -57,6 +57,9 @@ const SCHEDULE_AFFECTING_FIELDS: (keyof TaskRepeatCfgCopy)[] = [
   'friday',
   'saturday',
   'sunday',
+  'monthlyWeekOfMonth',
+  'monthlyWeekday',
+  'monthlyLastDay',
   'isPaused',
 ];
 

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.effects.ts
@@ -46,22 +46,54 @@ import { getFirstRepeatOccurrence } from './get-first-repeat-occurrence.util';
 import { getNextRepeatOccurrence } from './get-next-repeat-occurrence.util';
 import { clampPastTimedOccurrence } from './clamp-past-timed-occurrence.util';
 
-const SCHEDULE_AFFECTING_FIELDS: (keyof TaskRepeatCfgCopy)[] = [
-  'startDate',
-  'repeatCycle',
-  'repeatEvery',
-  'monday',
-  'tuesday',
-  'wednesday',
-  'thursday',
-  'friday',
-  'saturday',
-  'sunday',
-  'monthlyWeekOfMonth',
-  'monthlyWeekday',
-  'monthlyLastDay',
-  'isPaused',
-];
+// Exhaustive classification: `true` = editing this field changes which day
+// occurrences land on, so rescheduleTaskOnRepeatCfgUpdate$ must relocate the
+// live instance. Exhaustiveness makes a new TaskRepeatCfgCopy field a compile
+// error here until classified — the open-ended list this replaces silently
+// missed the monthly anchor fields for years.
+// Load-bearing `false` entries: lastTaskCreation* (the effect re-dispatches
+// them; `true` would re-enter it), quickSetting (derived UI value — the mapped
+// pattern fields carry the actual change), deletedInstanceDates (written by
+// the delete-instance flow, which removes the live task itself).
+const SCHEDULE_AFFECTING_BY_FIELD: Record<keyof TaskRepeatCfgCopy, boolean> = {
+  id: false,
+  projectId: false,
+  lastTaskCreation: false,
+  lastTaskCreationDay: false,
+  title: false,
+  tagIds: false,
+  order: false,
+  defaultEstimate: false,
+  startTime: false,
+  remindAt: false,
+  isPaused: true,
+  quickSetting: false,
+  repeatCycle: true,
+  startDate: true,
+  repeatEvery: true,
+  monday: true,
+  tuesday: true,
+  wednesday: true,
+  thursday: true,
+  friday: true,
+  saturday: true,
+  sunday: true,
+  monthlyWeekOfMonth: true,
+  monthlyWeekday: true,
+  monthlyLastDay: true,
+  notes: false,
+  shouldInheritSubtasks: false,
+  repeatFromCompletionDate: false,
+  waitForCompletion: false,
+  disableAutoUpdateSubtasks: false,
+  subTaskTemplates: false,
+  deletedInstanceDates: false,
+  skipOverdue: false,
+};
+
+const SCHEDULE_AFFECTING_FIELDS = (
+  Object.keys(SCHEDULE_AFFECTING_BY_FIELD) as (keyof TaskRepeatCfgCopy)[]
+).filter((field) => SCHEDULE_AFFECTING_BY_FIELD[field]);
 
 @Injectable()
 export class TaskRepeatCfgEffects {


### PR DESCRIPTION
Closes #9664.

## App fix: editing a monthly anchor never rescheduled the live instance

`SCHEDULE_AFFECTING_FIELDS` omitted `monthlyWeekOfMonth`, `monthlyWeekday`, and `monthlyLastDay`, so editing e.g. "2nd Tuesday" → "3rd Tuesday" (or toggling last-day-of-month) left the existing undone instance on the old day — while the equivalent weekly-weekday edit rescheduled correctly. Reproduced test-first (two specs that fail without the fix), then fixed.

`deletedInstanceDates` was deliberately **not** added: its only writer is the delete-instance flow, which removes the live task in the same breath — widening to it could race that deletion while fixing no observed symptom.

Follow-up refactor: the open-ended field allowlist is now an exhaustive `Record<keyof TaskRepeatCfgCopy, boolean>` — a new model field fails compilation until classified, killing the drift class this bug came from (the epic's `rrule?` field would have been the next silent miss). Behavior-identical (derived list, full suite green); the deliberate exclusions (`lastTaskCreation*` re-entrancy, `quickSetting`, `deletedInstanceDates`) are now explicit `false` entries. This is an isolated commit (`23b510be`) — easy to drop if the leaner 3-line list is preferred.

## Doc: `recurring-events-implementation-plan.md` corrected and reconciled

- **#9664 proper** (`4bae0695`): the Phase-2 claim that `MIN_SUPPORTED_SCHEMA_VERSION` is a cross-version "force-update gate" was backwards — it is receive-side only; corrected with the verified mechanics.
- **Factual errors fixed against the engine** (`09459558`): the WKST prescription was wrong in all 3 places (`firstDayOfWeek` is display-only; the engine counts rolling 7-day blocks from startDate's weekday), `BYMONTHDAY` 29–31 needs the clamp idiom `BYMONTHDAY=<d>,-1;BYSETPOS=1` (Feb-29 **does** have an RFC equivalent), plus stale line-number citations and ical.js being a devDependency.
- **Design tension resolved** (`62ac408d`, `a0af609e`): the doc argued at length against exactly what `feat/rrule-epic` implements (raw `rrule` string). Checked against the branch, the rejection was stale — legacy fields stay dual-written forever as the wire format (queryable/diffable/repairable), and the flag-on engine is synchronous rrule.js, not async ical.js. The doc now records the branch's design as standing, marks the typed-union plan superseded (kept as rationale record), and names the one real accepted cost: the pinned `rrule@2.8.1` dependency. Also adds the monthly-anchor precedence rule, `isPaused`/`lastTaskCreation*` mapping rows, and fixes the sketch's `exDates` rename contradiction.

## Verification

- Full unit suite: 14277/14277 green
- Effect spec: 91/91, incl. the two new red-before-fix tests
- Every doc claim verified against master code or `origin/feat/rrule-epic` sources; doc re-read top-to-bottom after the reconciliation