### PR TITLE
fix(error-handler): keep raw stacktrace when the throttle swallows the resolve

### DIFF
--- a/src/app/core/error-handler/global-error-handler.util.spec.ts
+++ b/src/app/core/error-handler/global-error-handler.util.spec.ts
@@ -1,4 +1,8 @@
-import { getGithubErrorUrl, getSimpleMeta } from './global-error-handler.util';
+import {
+  getGithubErrorUrl,
+  getSimpleMeta,
+  logAdvancedStacktrace,
+} from './global-error-handler.util';
 import { getErrorTxt } from '../../util/get-error-text';
 
 describe('global-error-handler.util', () => {
@@ -31,6 +35,62 @@ describe('global-error-handler.util', () => {
       const meta = getSimpleMeta();
       expect(meta).toContain('META:');
       expect(meta).toContain('SP');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // #9647 / #7079: crash reports arriving with no "### Stacktrace" section.
+  //
+  // logAdvancedStacktrace() runs for EVERY error, while the error dialog is
+  // built only for the first one. A throw that repeats (a selector crashing on
+  // every store emission) trips the 2-per-5s throttle within milliseconds, and
+  // the throttled call resolves ''. Writing that '' back into the dialog and the
+  // pre-filled GitHub link stripped the raw err.stack the dialog already had,
+  // leaving the user with nothing to report.
+  // -----------------------------------------------------------------------
+  describe('logAdvancedStacktrace', () => {
+    const RAW_STACK = 'at doThing (chunk-ABC.js:1:1)';
+    const PREFILLED_HREF = 'https://github.com/prefilled-with-raw-stack';
+
+    let spinnerEl: HTMLElement;
+    let stacktraceEl: HTMLElement;
+    let linkEl: HTMLElement;
+
+    beforeEach(() => {
+      spinnerEl = document.createElement('div');
+      spinnerEl.id = 'error-fetching-info-wrapper';
+      stacktraceEl = document.createElement('pre');
+      stacktraceEl.id = 'stack-trace';
+      stacktraceEl.textContent = RAW_STACK;
+      linkEl = document.createElement('a');
+      linkEl.className = 'github-issue-urlX';
+      linkEl.setAttribute('href', PREFILLED_HREF);
+      document.body.append(spinnerEl, stacktraceEl, linkEl);
+    });
+
+    afterEach(() => {
+      spinnerEl.remove();
+      stacktraceEl.remove();
+      linkEl.remove();
+    });
+
+    it('should keep the raw stacktrace when no better one can be resolved', async () => {
+      // HTTP-shaped errors deterministically resolve to '' — same empty result
+      // the throttle produces for a repeating error.
+      await logAdvancedStacktrace({
+        url: 'https://example.com/api',
+        message: 'Boom',
+        stack: RAW_STACK,
+      });
+
+      expect(stacktraceEl.textContent).toBe(RAW_STACK);
+      expect(linkEl.getAttribute('href')).toBe(PREFILLED_HREF);
+    });
+
+    it('should still remove the loading spinner when no stack could be resolved', async () => {
+      await logAdvancedStacktrace({ url: 'https://example.com/api', message: 'Boom' });
+
+      expect(document.getElementById('error-fetching-info-wrapper')).toBeNull();
     });
   });
 

--- a/src/app/core/error-handler/global-error-handler.util.ts
+++ b/src/app/core/error-handler/global-error-handler.util.ts
@@ -68,6 +68,18 @@ export const logAdvancedStacktrace = (
     .then((stack) => {
       document.getElementById('error-fetching-info-wrapper')?.remove();
 
+      // An empty resolve means we have nothing BETTER than the raw `err.stack`
+      // that createErrorAlert() already put into the dialog and the pre-filled
+      // GitHub report — the throttle (2 per 5s) swallowed this call, or the error
+      // carried no stack at all. Since this runs for EVERY error while the dialog
+      // is only built for the first one, a repeating throw (e.g. a selector that
+      // crashes on every store emission) reaches the throttle within milliseconds
+      // and would otherwise wipe the stacktrace out of the bug report the user
+      // then files — which is how #9647 and #7079 arrived with no stacktrace at all.
+      if (!stack) {
+        return;
+      }
+
       if (additionalLogFn) {
         additionalLogFn(stack);
       }


### PR DESCRIPTION
## Problem

Crash reports for repeating errors arrive with no `### Stacktrace` section at all, which makes them unactionable — see #9647 and #7079.

`logAdvancedStacktrace()` runs for **every** error (`global-error-handler.class.ts:72`, outside the `isErrorAlertShown` guard), while the error dialog is built only for the first one. A throw that repeats — e.g. an NgRx selector that crashes on every store emission — trips the 2-per-5s stacktrace throttle within milliseconds. The throttled call resolves `''`, and that `''` was written straight back into `#stack-trace` and into the pre-filled GitHub report link:

```ts
stacktraceEl.innerText = stack;                                  // wipes the shown stack
el.setAttribute('href', getGithubErrorUrl(errEscaped, stack, origErr));  // wipes it from the report
```

That erases the raw `err.stack` `createErrorAlert()` had already put there, and `getGithubIssueErrorMarkdown` guards on `if (stacktrace)`, so the whole section vanishes from the issue the user then files.

## Fix

Skip the DOM/href update when nothing better than the raw stack was resolved. The spinner removal stays *before* the guard, so the dialog does not hang on "Trying to load more info…".

## Behavior change worth noting

`additionalLogFn(stack)` is no longer called with `''` — on Electron that drops a `Frontend Error Stack: ''` line for throttled/stackless errors. Strictly less noise; the raw stack is already logged one line earlier by `error('Frontend Error:', err, simpleStack)`.

## Tests

Two specs in `global-error-handler.util.spec.ts`. Verified they gate the fix — with the guard neutered, `should keep the raw stacktrace when no better one can be resolved` fails (`Expected '' to be 'at doThing (chunk-ABC.js:1:1)'`, plus the href rewritten to a stackless report URL). 10/10 pass with it; `checkFile` clean on both files.

## Scope

- Does **not** fix the underlying #9647 crash — that still needs the reporter's data export. I asked for it on the issue.
- A *different* second error still overwrites the first error's stack in the dialog. Pre-existing, unchanged, and no observed report of it — fixing it means threading "which error owns the dialog" through, which isn't warranted without evidence.
