### PR TITLE
fix(electron): pin the Linux desktop name, revert StartupWMClass to it

### DIFF
--- a/build/linux/snap-wrapper.sh
+++ b/build/linux/snap-wrapper.sh
@@ -13,10 +13,13 @@
 # Same mechanism used by Signal Desktop and Mattermost Desktop snaps
 # (snapcrafters/signal-desktop, snapcrafters/mattermost-desktop).
 #
-# All Linux launches pass through this wrapper so the app can set a stable
-# WM_CLASS for desktop-file matching. Only our Snap on Wayland receives the
-# extra ozone flag. The SNAP_NAME gate protects .deb/.rpm installs invoked via
-# xdg-open from *another* snap (where $SNAP leaks into the child env).
+# All Linux launches pass through this wrapper, but only our Snap on Wayland
+# receives the extra ozone flag; every other launch is a plain exec. The
+# SNAP_NAME gate protects .deb/.rpm installs invoked via xdg-open from *another*
+# snap (where $SNAP leaks into the child env).
+#
+# This wrapper deliberately does NOT pass --class: Electron ignores that switch.
+# See tools/verify-linux-wm-class.test.js and #9674.
 #
 # See docs/research/snap-wayland-gpu-fix-research.md §18.
 
@@ -33,24 +36,16 @@ else
   BIN_DIR=$(dirname "$SELF")
 fi
 BIN="$BIN_DIR/superproductivity-bin"
-# Must match linux.desktop.entry.StartupWMClass in electron-builder.yaml.
-APP_CLASS="superproductivity"
 
-# If the user already supplied --ozone-platform or --class on argv, don't
-# override. Stop scanning at -- so positional args aren't misread as flags.
+# If the user already supplied --ozone-platform on argv, don't override. Stop
+# scanning at -- so positional args aren't misread as flags.
 HAS_OZONE_PLATFORM=
-HAS_APP_CLASS=
 for arg in "$@"; do
   case "$arg" in
     --) break ;;
     --ozone-platform=* | --ozone-platform) HAS_OZONE_PLATFORM=1 ;;
-    --class=* | --class) HAS_APP_CLASS=1 ;;
   esac
 done
-
-if [ -z "$HAS_APP_CLASS" ]; then
-  set -- "--class=$APP_CLASS" "$@"
-fi
 
 if [ -n "$IS_OUR_SNAP" ] && [ -z "$HAS_OZONE_PLATFORM" ] && { [ "$XDG_SESSION_TYPE" = "wayland" ] || [ -n "$WAYLAND_DISPLAY" ]; }; then
   exec "$BIN" --ozone-platform=x11 "$@"

--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -87,7 +87,14 @@ linux:
     - x-scheme-handler/superproductivity
   desktop:
     entry:
-      StartupWMClass: superproductivity-bin
+      # Must equal LINUX_DESKTOP_NAME in electron/start-app.ts, which pins the
+      # XDG app id that Electron 42+ uses for both the X11 WM_CLASS and the
+      # Wayland app_id. Enforced by tools/verify-linux-wm-class.test.js.
+      # Reverts #9634: `superproductivity-bin` matched the Wayland app_id only on
+      # Electron <= 41, where it came from the renamed binary's basename (#9450).
+      # The Electron 43 bump (#9571, v18.20.0) moved it to the XDG app id, so the
+      # `-bin` value now matches nothing on either session type.
+      StartupWMClass: superproductivity
   target:
     - AppImage
     - deb

--- a/electron/start-app.ts
+++ b/electron/start-app.ts
@@ -27,6 +27,13 @@ import * as fs from 'fs';
 
 const ICONS_FOLDER = __dirname + '/assets/icons/';
 const APP_DISPLAY_NAME = 'Super Productivity';
+// Filename of the .desktop entry electron-builder installs, i.e.
+// `${linux.executableName}.desktop`. The `.desktop` suffix is required and is
+// what Electron's own default uses: `Browser::SetAsDefaultProtocolClient` hands
+// this value straight to `g_desktop_app_info_new()`, which wants a desktop-file
+// id, while the window identity strips the suffix itself. Coupled to the
+// desktop entry by `tools/verify-linux-wm-class.test.js`.
+const LINUX_DESKTOP_NAME = 'superproductivity.desktop';
 const IS_MAC = process.platform === 'darwin';
 // const DESKTOP_ENV = process.env.DESKTOP_SESSION;
 // const IS_GNOME = DESKTOP_ENV === 'gnome' || DESKTOP_ENV === 'gnome-xorg';
@@ -154,8 +161,21 @@ export const startApp = (): void => {
   }
 
   if (process.platform === 'linux') {
+    // Pin the .desktop filename rather than letting Electron infer it. Since
+    // Electron 42 the XDG app id derived from this value sets BOTH the X11
+    // WM_CLASS and the Wayland app_id — `native_window_views.cc` uses
+    // `GetXdgAppId().value_or(Browser::GetName())`, so the app id wins and
+    // `setName` below no longer reaches the window identity. Electron's own
+    // inference (`lib/browser/init.ts`) slugifies the app name, which happens to
+    // produce the same value today but would become `super-productivity` the
+    // moment a `productName` is added to package.json, detaching every window
+    // from `superproductivity.desktop`. Must run before the first window is
+    // created. #9674, #9450.
+    app.setDesktopName(LINUX_DESKTOP_NAME);
+
     // Preserve the historical userData path based on package.json `name`, while
-    // exposing a human-readable app name to Linux desktop environments.
+    // exposing a human-readable app name to Linux desktop environments (#8640).
+    // Safe for the window identity because of the pin above.
     const userDataPath = app.getPath('userData');
     app.setPath('userData', userDataPath);
     app.setName(APP_DISPLAY_NAME);

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "int:watch": "node ./tools/extract-i18n-watch.js",
     "lint": "npm run lint:ts && npm run lint:scss && npm run lint:css-vars && npm run test:lint-rules && npm run test:tools && npm run test:mac-icon",
     "test:lint-rules": "node eslint-local-rules/run-specs.js",
-    "test:tools": "node --test tools/theme-assets.test.js tools/check-css-vars.test.js",
+    "test:tools": "node --test tools/theme-assets.test.js tools/check-css-vars.test.js tools/verify-linux-wm-class.test.js",
     "test:mac-icon": "node --test tools/verify-mac-icon.test.js",
     "lint:ts": "ng lint",
     "lint:scss": "stylelint \"**/*.scss\" \"src/assets/themes/*.css\" -- --custom-formatter @csstools/stylelint-formatter-github",

--- a/tools/afterPack.js
+++ b/tools/afterPack.js
@@ -3,11 +3,17 @@
 // macOS: verifies the actual icon copied into every packaged .app.
 //
 // Linux: renames the main Electron binary to `superproductivity-bin` and installs
-// a shell wrapper at the original name. The wrapper forces
-// --class=superproductivity for stable desktop-file matching and forces
-// --ozone-platform=x11 when running in our Snap sandbox on a Wayland session.
-// Non-Snap launches (AppImage, .deb, .rpm) and X11 sessions only receive the
-// stable class flag.
+// a shell wrapper at the original name. The wrapper's only job is forcing
+// --ozone-platform=x11 when running in our Snap sandbox on a Wayland session;
+// non-Snap launches (AppImage, .deb, .rpm) and X11 sessions pass straight
+// through.
+//
+// The rename used to leak into the window identity: through Electron 41 a
+// native-Wayland session took its `app_id` from this binary's basename, which is
+// what #9450 reported. Electron 42+ derives both the Wayland `app_id` and the X11
+// WM_CLASS from the XDG app id instead, which electron/start-app.ts pins
+// explicitly, so the rename is now invisible to the shell. See
+// tools/verify-linux-wm-class.test.js.
 //
 // Context: field reports on issue #7270 (v18.2.4/v18.2.5) show that
 // app.commandLine.appendSwitch('ozone-platform','x11') from inside the
@@ -150,3 +156,7 @@ async function afterPack(context) {
 }
 
 module.exports = afterPack;
+// Exposed for tools/verify-linux-wm-class.test.js. electron-builder resolves the
+// hook via the default function export, so extra properties on it are inert.
+module.exports.BIN_NAME = BIN_NAME;
+module.exports.RENAMED = RENAMED;

--- a/tools/verify-linux-wm-class.test.js
+++ b/tools/verify-linux-wm-class.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// Couples the Linux window identity to the desktop entry and to the packaged
+// binary names. Nothing coupled them before, which is how #9674 drifted: the app
+// reported a WM_CLASS no `StartupWMClass` matched for seven releases, so shells
+// showed a second, generic launcher entry.
+//
+// How the identity is derived, on the Electron this repo pins (43.x):
+// `native_window_views.cc` sets both WM_CLASS fields and the Wayland `app_id`
+// from `GetXdgAppId().value_or(Browser::GetName())` — i.e. `CHROME_DESKTOP`
+// minus `.desktop`, falling back to the app name only when unset. Electron's own
+// bootstrap always sets it, to a slug of the app name, so the fallback is dead
+// and `app.setName()` cannot reach the window identity. `electron/start-app.ts`
+// pins the value explicitly instead of trusting that slug.
+//
+// Measured against a real Electron 43.4.0 binary on X11 (2026-08): with this
+// repo's `name: superProductivity` and no `productName`, WM_CLASS comes out as
+// "superproductivity", "superproductivity" whether or not `app.setName()` runs.
+// Adding a `productName` without the pin moves it to "super-productivity".
+//
+// Blind spot: this asserts the inputs, not a packaged binary's actual WM_CLASS.
+// Electron 42 changed this derivation (through 41 it came from `app.getName()`),
+// so re-measure on an Electron major bump rather than trusting this file.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const { BIN_NAME, RENAMED } = require('./afterPack');
+
+const ROOT = join(__dirname, '..');
+const readRoot = (...p) => readFileSync(join(ROOT, ...p), 'utf8');
+
+const BUILDER_YAML = readRoot('electron-builder.yaml');
+
+/**
+ * Reads a scalar from the flat `key: value` lines of electron-builder.yaml. Not
+ * YAML-aware — it takes the first match anywhere in the file and cannot read a
+ * quoted or space-containing value. Both keys used here are unique and bare; no
+ * YAML parser is declared as a dependency, and the project forbids adding one.
+ */
+const builderValue = (key) => {
+  const match = BUILDER_YAML.match(new RegExp(`^\\s*${key}:\\s*(\\S+)\\s*$`, 'm'));
+  assert.ok(match, `${key} not found as a bare scalar in electron-builder.yaml`);
+  return match[1];
+};
+
+test('the pinned desktop name matches the desktop entry StartupWMClass', () => {
+  const startApp = readRoot('electron', 'start-app.ts');
+  const pinned = startApp.match(/const LINUX_DESKTOP_NAME = '([^']+)'/);
+  assert.ok(pinned, 'LINUX_DESKTOP_NAME not found in electron/start-app.ts');
+  // Keep the `.desktop` suffix: Electron hands this value verbatim to
+  // `g_desktop_app_info_new()` when registering the protocol handler, which
+  // needs a desktop-file id, and strips the suffix itself for the window id.
+  assert.match(pinned[1], /\.desktop$/, 'the pinned name must be a .desktop id');
+  assert.equal(
+    pinned[1].replace(/\.desktop$/, ''),
+    builderValue('StartupWMClass'),
+    'app.setDesktopName() sets the X11 WM_CLASS and the Wayland app_id; it must match StartupWMClass (#9674)',
+  );
+});
+
+test('the desktop entry filename matches StartupWMClass', () => {
+  // electron-builder installs the entry as `${executableName}.desktop`, and the
+  // pinned desktop name is that filename — so the two have to agree.
+  assert.equal(builderValue('StartupWMClass'), builderValue('executableName'));
+});
+
+test('the packaged wrapper is installed under the name the desktop entry execs', () => {
+  assert.equal(BIN_NAME, builderValue('executableName'));
+});
+
+test('the argv wrapper execs the binary afterPack actually renames', () => {
+  // Drift here ships a launcher that execs a nonexistent path — the app simply
+  // does not start.
+  const wrapper = readRoot('build', 'linux', 'snap-wrapper.sh');
+  assert.match(wrapper, new RegExp(`/${RENAMED}"`));
+});


### PR DESCRIPTION
## Problem

Two things, one root cause.

**1. The reported bug (#9674, #9450).** On Linux the shell matches a running window to its launcher by `WM_CLASS` (X11) / `app_id` (Wayland) against `StartupWMClass` in the `.desktop` entry. Ours has not matched for some time, so GNOME/KDE show a generic gear icon and a duplicate dock entry.

**2. A regression that landed while #9674 was open.** #9634 set `StartupWMClass: superproductivity-bin`. That value was correct against the Electron **41** behaviour @trekirk measured on v18.16.0, where a native-Wayland session took its `app_id` from the renamed binary's basename. But the Electron **43** bump (#9571, v18.20.0) moved the app id, and #9634 merged after it. At HEAD, `-bin` matches nothing on **either** session type — so it turns a Wayland-only symptom into an everyone symptom.

### What actually derives the window identity

Since Electron 42, `native_window_views.cc` sets both `WM_CLASS` fields *and* the Wayland `app_id` from the XDG app id:

```cc
const auto app_id = platform_util::GetXdgAppId();          // CHROME_DESKTOP minus ".desktop"
const std::string name = app_id.value_or(Browser::Get()->GetName());
params.wm_class_name  = base::ToLowerASCII(name);
params.wm_class_class = name;
if (app_id) params.wayland_app_id = *app_id;
```

Electron's bootstrap always sets it — `lib/browser/init.ts` calls `setDesktopName(packageJson.desktopName || defaultDesktopName(app.name))` — so the `Browser::GetName()` fallback is dead code and **`app.setName()` can no longer reach the window identity**. Through Electron 41 it could, which is what #8640 tripped over.

### Measured on a real Electron 43.4.0 binary (X11, 2026-08)

| Probe | `CHROME_DESKTOP` | `WM_CLASS` |
| --- | --- | --- |
| baseline, no `setName` | `superproductivity.desktop` | `"superproductivity", "superproductivity"` |
| `setName('Super Productivity')` — master today | `superproductivity.desktop` | `"superproductivity", "superproductivity"` |
| this PR (pin + `setName`) | `superproductivity.desktop` | `"superproductivity", "superproductivity"` |
| a `productName` added, no pin | `super-productivity.desktop` | `"super-productivity", "super-productivity"` |
| a `productName` added, with pin | `superproductivity.desktop` | `"superproductivity", "superproductivity"` |

Row 2 is why `app.setName` stays: on Electron 43 it no longer affects the window, so #8640's readable notification name costs nothing. Row 4 is why the pin exists.

## Solution

1. **`electron-builder.yaml`** — revert `StartupWMClass` to `superproductivity`. This is the part that fixes the live symptom.
2. **`electron/start-app.ts`** — `app.setDesktopName('superproductivity.desktop')` before the first window, instead of relying on Electron slugifying the app name into the same string by luck. Electron's own docs warn the inferred name "may not match the packaged app's actual `.desktop` file"; note `electron-builder.yaml` already carries `productName: Super Productivity` — it just does not reach the asar's `package.json` today. The `.desktop` suffix is deliberate: `Browser::SetAsDefaultProtocolClient` hands this value straight to `g_desktop_app_info_new()`, which needs a desktop-file id (verified: bare `"Alacritty"` returns NULL, `"Alacritty.desktop"` resolves), while the window identity strips the suffix itself.
3. **`build/linux/snap-wrapper.sh`** — drop the `--class` prepend and its argv scan. Electron reads that switch on neither version, so it never reached the window the shell matches; the comments claiming it kept desktop-file matching stable were wrong. The `--ozone-platform=x11` forcing for #7270 is untouched, including the `--` break and the `IS_OUR_SNAP` gate.
4. **`tools/afterPack.js`** — correct the same false `--class` claim in the header, and record that the binary rename no longer leaks into the window identity.
5. **`tools/verify-linux-wm-class.test.js`** (new) — couples the four names that have to agree: the pin, `StartupWMClass`, `linux.executableName`, and the binary the wrapper execs. Nothing coupled them before, which is how this drifted for seven releases and how #9634 landed. Runs in `test:tools`, which `npm run lint` runs in CI.

### Notes for review

- **This reverts #9634**, merged the same day #9674 was filed. Not a criticism of the analysis there — it was right for the Electron version it was measured on, and the ordering against #9571 is easy to miss. Happy to drop the revert if you would rather handle it separately.
- The guard test caught #9634 on its first run, which is the argument for it existing.
- **Not measured on Wayland.** The `app_id` path is source-verified — same `app_id` local as `WM_CLASS`, quoted above — but I only had an X11 session.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing behaviour change beyond the icon fix
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Fixes #9674
Refs #9450, #9634
